### PR TITLE
feat: pipeline loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "fastrlp"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +754,15 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1260,6 +1278,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "reth"
 version = "0.1.0"
 
@@ -1323,7 +1350,9 @@ dependencies = [
  "async-trait",
  "reth-db",
  "reth-primitives",
+ "tempfile",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -1609,6 +1638,20 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
 
 [[package]]
 name = "thiserror"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,6 +1353,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-futures",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1321,6 +1321,7 @@ name = "reth-stages"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "reth-db",
  "reth-primitives",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,6 +1353,8 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tracing",
+ "tracing-futures",
 ]
 
 [[package]]

--- a/crates/stages/Cargo.toml
+++ b/crates/stages/Cargo.toml
@@ -12,6 +12,8 @@ reth-primitives = { path = "../primitives" }
 reth-db = { path = "../db" }
 async-trait = "0.1.57"
 thiserror = "1.0.37"
+tracing = "0.1.36"
+tracing-futures = "0.2.5"
 
 [dev-dependencies]
 tokio = { version = "1.21.2", features = ["rt", "macros"] }

--- a/crates/stages/Cargo.toml
+++ b/crates/stages/Cargo.toml
@@ -12,3 +12,7 @@ reth-primitives = { path = "../primitives" }
 reth-db = { path = "../db" }
 async-trait = "0.1.57"
 thiserror = "1.0.37"
+
+[dev-dependencies]
+tokio = { version = "1.21.2", features = ["rt", "macros"] }
+tempfile = "3.3.0"

--- a/crates/stages/Cargo.toml
+++ b/crates/stages/Cargo.toml
@@ -14,7 +14,9 @@ async-trait = "0.1.57"
 thiserror = "1.0.37"
 tracing = "0.1.36"
 tracing-futures = "0.2.5"
+tokio = { version = "1.21.2", features = ["sync"] }
 
 [dev-dependencies]
-tokio = { version = "1.21.2", features = ["rt", "macros"] }
+tokio = { version = "*", features = ["rt", "sync", "macros"] }
+tokio-stream = "0.1.10"
 tempfile = "3.3.0"

--- a/crates/stages/Cargo.toml
+++ b/crates/stages/Cargo.toml
@@ -9,5 +9,6 @@ description = "Staged syncing primitives used in reth."
 
 [dependencies]
 reth-primitives = { path = "../primitives" }
+reth-db = { path = "../db" }
 async-trait = "0.1.57"
 thiserror = "1.0.37"

--- a/crates/stages/src/lib.rs
+++ b/crates/stages/src/lib.rs
@@ -60,7 +60,10 @@ pub enum StageError {
     ///
     /// TODO: This depends on the consensus engine and should include the validation failure reason
     #[error("Stage encountered a validation error.")]
-    Validation { block: U64 },
+    Validation {
+        /// The block that failed validation.
+        block: U64,
+    },
     /// The stage encountered an internal error.
     #[error(transparent)]
     Internal(Box<dyn std::error::Error + Send + Sync>),

--- a/crates/stages/src/lib.rs
+++ b/crates/stages/src/lib.rs
@@ -11,6 +11,7 @@
 use async_trait::async_trait;
 use reth_db::mdbx;
 use reth_primitives::U64;
+use std::fmt::Display;
 use thiserror::Error;
 
 mod pipeline;
@@ -75,6 +76,12 @@ pub enum StageError {
 /// Each stage ID must be unique.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct StageId(pub &'static str);
+
+impl Display for StageId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 impl StageId {
     /// Get the last committed progress of this stage.

--- a/crates/stages/src/lib.rs
+++ b/crates/stages/src/lib.rs
@@ -60,7 +60,7 @@ pub enum StageError {
     ///
     /// TODO: This depends on the consensus engine and should include the validation failure reason
     #[error("Stage encountered a validation error.")]
-    Validation,
+    Validation { block: U64 },
     /// The stage encountered an internal error.
     #[error(transparent)]
     Internal(Box<dyn std::error::Error + Send + Sync>),

--- a/crates/stages/src/lib.rs
+++ b/crates/stages/src/lib.rs
@@ -18,7 +18,7 @@ mod pipeline;
 pub use pipeline::*;
 
 /// Stage execution input, see [Stage::execute].
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct ExecInput {
     /// The stage that was run before the current stage and the block number it reached.
     pub previous_stage: Option<(StageId, U64)>,
@@ -27,7 +27,7 @@ pub struct ExecInput {
 }
 
 /// Stage unwind input, see [Stage::unwind].
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct UnwindInput {
     /// The current highest block of the stage.
     pub stage_progress: U64,
@@ -38,7 +38,7 @@ pub struct UnwindInput {
 }
 
 /// The output of a stage execution.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ExecOutput {
     /// How far the stage got.
     pub stage_progress: U64,
@@ -49,7 +49,7 @@ pub struct ExecOutput {
 }
 
 /// The output of a stage unwinding.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct UnwindOutput {
     /// The block at which the stage has unwound to.
     pub stage_progress: U64,
@@ -128,7 +128,7 @@ impl StageId {
 ///
 /// Stages are executed as part of a pipeline where they are executed serially.
 #[async_trait]
-pub trait Stage<'db, E>
+pub trait Stage<'db, E>: Send + Sync
 where
     E: mdbx::EnvironmentKind,
 {

--- a/crates/stages/src/lib.rs
+++ b/crates/stages/src/lib.rs
@@ -61,7 +61,7 @@ pub enum StageError {
     /// The stage encountered a state validation error.
     ///
     /// TODO: This depends on the consensus engine and should include the validation failure reason
-    #[error("Stage encountered a validation error.")]
+    #[error("Stage encountered a validation error in block {block}.")]
     Validation {
         /// The block that failed validation.
         block: U64,

--- a/crates/stages/src/pipeline.rs
+++ b/crates/stages/src/pipeline.rs
@@ -1,9 +1,6 @@
 use crate::{DbTransaction, ExecInput, ExecOutput, Stage, StageError, StageId, UnwindInput};
 use reth_primitives::U64;
-use std::{
-    cmp::max,
-    fmt::{Debug, Formatter},
-};
+use std::fmt::{Debug, Formatter};
 
 struct QueuedStage {
     /// The actual stage to execute.

--- a/crates/stages/src/pipeline.rs
+++ b/crates/stages/src/pipeline.rs
@@ -268,7 +268,7 @@ where
         to: U64,
         bad_block: Option<U64>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let mut tx = db.begin_rw_txn()?;
+        // Sort stages by unwind priority
         let mut unwind_pipeline = {
             let mut stages: Vec<_> = self.stages.iter_mut().enumerate().collect();
             stages.sort_by_key(|(id, stage)| {
@@ -282,6 +282,8 @@ where
             stages
         };
 
+        // Unwind stages in reverse order of priority (i.e. higher priority = first)
+        let mut tx = db.begin_rw_txn()?;
         for (_, QueuedStage { stage, .. }) in unwind_pipeline.iter_mut() {
             let stage_id = stage.id();
             let mut stage_progress = stage_id.get_progress(&tx)?.unwrap_or_default();


### PR DESCRIPTION
Implements the execution and unwinding loops of the pipeline. The saving/loading of stage progress is also implemented, although it's not nice to look at w/o db abstractions