### PR TITLE
feat(p2p): add anchor file for discovery state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+
+[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,9 +346,30 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "pkcs8",
  "rand_core",
  "sec1",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "enr"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26fa0a0be8915790626d5759eb51fe47435a8eac92c2f212bd2da9aa7f30ea56"
+dependencies = [
+ "base64",
+ "bs58",
+ "bytes",
+ "hex",
+ "k256",
+ "log",
+ "rand",
+ "rlp",
+ "secp256k1",
+ "serde",
+ "sha3",
  "zeroize",
 ]
 
@@ -1427,6 +1454,13 @@ dependencies = [
 [[package]]
 name = "reth-p2p"
 version = "0.1.0"
+dependencies = [
+ "enr",
+ "serde",
+ "serde_derive",
+ "thiserror",
+ "toml",
+]
 
 [[package]]
 name = "reth-primitives"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,6 +1461,7 @@ dependencies = [
  "serde_derive",
  "thiserror",
  "toml",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1458,6 +1458,7 @@ dependencies = [
  "secp256k1",
  "serde",
  "serde_derive",
+ "tempfile",
  "thiserror",
  "toml",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,8 +356,7 @@ dependencies = [
 [[package]]
 name = "enr"
 version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fa0a0be8915790626d5759eb51fe47435a8eac92c2f212bd2da9aa7f30ea56"
+source = "git+https://github.com/sigp/enr#125f8a5f2deede3e47e852ea70fc9b6e1e9c6e50"
 dependencies = [
  "base64",
  "bs58",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,6 +1456,7 @@ name = "reth-p2p"
 version = "0.1.0"
 dependencies = [
  "enr",
+ "secp256k1",
  "serde",
  "serde_derive",
  "thiserror",
@@ -1662,6 +1663,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7649a0b3ffb32636e60c7ce0d70511eda9c52c658cd0634e194d5a19943aeff"
 dependencies = [
+ "rand",
  "secp256k1-sys",
 ]
 

--- a/crates/net/p2p/Cargo.toml
+++ b/crates/net/p2p/Cargo.toml
@@ -8,3 +8,8 @@ readme = "README.md"
 description = "Utilities for interacting with ethereum's peer to peer network."
 
 [dependencies]
+enr = { version = "0.6.2", features = ["serde", "rust-secp256k1"] }
+serde = "1.0.145"
+serde_derive = "1.0.145"
+thiserror = "1.0.37"
+toml = "0.5.9"

--- a/crates/net/p2p/Cargo.toml
+++ b/crates/net/p2p/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 description = "Utilities for interacting with ethereum's peer to peer network."
 
 [dependencies]
-enr = { version = "0.6.2", features = ["serde", "rust-secp256k1"] }
+enr = { git = "https://github.com/sigp/enr", features = ["serde", "rust-secp256k1"] }
 serde = "1.0.145"
 serde_derive = "1.0.145"
 thiserror = "1.0.37"

--- a/crates/net/p2p/Cargo.toml
+++ b/crates/net/p2p/Cargo.toml
@@ -15,6 +15,9 @@ thiserror = "1.0.37"
 toml = "0.5.9"
 tracing = "0.1.36"
 
+[dev-dependencies]
+tempfile = "3.3.0"
+
 [dev-dependencies.secp256k1]
 version = "0.24"
 features = ["rand-std"]

--- a/crates/net/p2p/Cargo.toml
+++ b/crates/net/p2p/Cargo.toml
@@ -13,6 +13,7 @@ serde = "1.0.145"
 serde_derive = "1.0.145"
 thiserror = "1.0.37"
 toml = "0.5.9"
+tracing = "0.1.36"
 
 [dev-dependencies.secp256k1]
 version = "0.24"

--- a/crates/net/p2p/Cargo.toml
+++ b/crates/net/p2p/Cargo.toml
@@ -13,3 +13,7 @@ serde = "1.0.145"
 serde_derive = "1.0.145"
 thiserror = "1.0.37"
 toml = "0.5.9"
+
+[dev-dependencies.secp256k1]
+version = "0.24"
+features = ["rand-std"]

--- a/crates/net/p2p/src/anchor.rs
+++ b/crates/net/p2p/src/anchor.rs
@@ -2,7 +2,8 @@
 
 use std::{
     fs::{File, OpenOptions},
-    io::{Read, Write}, path::Path,
+    io::{Read, Write},
+    path::Path,
 };
 
 use enr::{secp256k1::SecretKey, Enr};

--- a/crates/net/p2p/src/anchor.rs
+++ b/crates/net/p2p/src/anchor.rs
@@ -3,7 +3,7 @@
 use std::{
     fs::{File, OpenOptions},
     io::{Read, Write},
-    path::Path,
+    path::Path, collections::HashSet,
 };
 
 use enr::{secp256k1::SecretKey, Enr};
@@ -11,7 +11,6 @@ use serde_derive::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::error;
 
-// TODO: impl Hash for Enr<K> upstream and change to HashSet to prevent duplicates
 // TODO: enforce one-to-one mapping between IP and key
 
 /// Contains a list of peers to persist across node restarts.
@@ -31,10 +30,10 @@ use tracing::error;
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Anchor {
     /// Peers that have been obtained discovery sources when the node is running
-    pub discovered_peers: Vec<Enr<SecretKey>>,
+    pub discovered_peers: HashSet<Enr<SecretKey>>,
 
     /// Pre-determined peers to reach out to
-    pub static_peers: Vec<Enr<SecretKey>>,
+    pub static_peers: HashSet<Enr<SecretKey>>,
 }
 
 impl Anchor {

--- a/crates/net/p2p/src/anchor.rs
+++ b/crates/net/p2p/src/anchor.rs
@@ -55,19 +55,19 @@ impl Anchor {
     }
 }
 
-#[derive(Debug, Error)]
 /// An error that can occur while parsing a peer list from a file
+#[derive(Debug, Error)]
 pub enum AnchorError {
     /// Error opening the anchor file
-    #[error("error opening or writing the anchor file")]
+    #[error("Could not open or write to the anchor file.")]
     IoError(#[from] std::io::Error),
 
     /// Error occurred when loading the anchor file from TOML
-    #[error("error deserializing the peer list from TOML")]
+    #[error("Could not deserialize the peer list from TOML.")]
     LoadError(#[from] toml::de::Error),
 
     /// Error occurred when saving the anchor file to TOML
-    #[error("error serializing the peer list as TOML")]
+    #[error("Could not serialize the peer list as TOML.")]
     SaveError(#[from] toml::ser::Error),
 }
 

--- a/crates/net/p2p/src/anchor.rs
+++ b/crates/net/p2p/src/anchor.rs
@@ -6,6 +6,7 @@ use std::{
     path::Path,
 };
 
+use tracing::error;
 use enr::{secp256k1::SecretKey, Enr};
 use serde_derive::{Deserialize, Serialize};
 use thiserror::Error;
@@ -134,7 +135,7 @@ impl PersistentAnchor {
 impl Drop for PersistentAnchor {
     fn drop(&mut self) {
         if let Err(save_error) = self.save_toml() {
-            println!("Could not save anchor to file: {}", save_error)
+            error!("Could not save anchor to file: {}", save_error)
         }
     }
 }

--- a/crates/net/p2p/src/anchor.rs
+++ b/crates/net/p2p/src/anchor.rs
@@ -60,15 +60,15 @@ impl Anchor {
 #[derive(Debug, Error)]
 pub enum AnchorError {
     /// Error opening the anchor file
-    #[error("Could not open or write to the anchor file.")]
+    #[error("Could not open or write to the anchor file: {0}")]
     IoError(#[from] std::io::Error),
 
     /// Error occurred when loading the anchor file from TOML
-    #[error("Could not deserialize the peer list from TOML.")]
+    #[error("Could not deserialize the peer list from TOML: {0}")]
     LoadError(#[from] toml::de::Error),
 
     /// Error occurred when saving the anchor file to TOML
-    #[error("Could not serialize the peer list as TOML.")]
+    #[error("Could not serialize the peer list as TOML: {0}")]
     SaveError(#[from] toml::ser::Error),
 }
 

--- a/crates/net/p2p/src/anchor.rs
+++ b/crates/net/p2p/src/anchor.rs
@@ -142,6 +142,7 @@ mod tests {
         fs::{remove_file, OpenOptions},
         net::Ipv4Addr,
     };
+    use tempfile::tempdir;
 
     use super::{Anchor, PersistentAnchor};
 
@@ -162,7 +163,7 @@ mod tests {
     #[test]
     fn create_empty_anchor() {
         let file_name = "temp_anchor.toml";
-        let temp_file_path = std::env::temp_dir().with_file_name(file_name);
+        let temp_file_path = tempdir().unwrap().path().with_file_name(file_name);
 
         // this test's purpose is to make sure new_from_file works if the file doesn't exist
         assert!(!temp_file_path.exists());
@@ -176,7 +177,7 @@ mod tests {
     #[test]
     fn save_temp_anchor() {
         let file_name = "temp_anchor_two.toml";
-        let temp_file_path = std::env::temp_dir().with_file_name(file_name);
+        let temp_file_path = tempdir().unwrap().path().with_file_name(file_name);
         let temp_file =
             OpenOptions::new().read(true).write(true).create(true).open(&temp_file_path).unwrap();
 

--- a/crates/net/p2p/src/anchor.rs
+++ b/crates/net/p2p/src/anchor.rs
@@ -1,9 +1,10 @@
 //! Peer persistence utilities
 
 use std::{
+    collections::HashSet,
     fs::{File, OpenOptions},
     io::{Read, Write},
-    path::Path, collections::HashSet,
+    path::Path,
 };
 
 use enr::{secp256k1::SecretKey, Enr};

--- a/crates/net/p2p/src/anchor.rs
+++ b/crates/net/p2p/src/anchor.rs
@@ -2,8 +2,7 @@
 
 use std::{
     fs::{File, OpenOptions},
-    io::{Read, Write},
-    path::Path,
+    io::{Read, Write}, path::Path,
 };
 
 use enr::{secp256k1::SecretKey, Enr};
@@ -86,7 +85,7 @@ pub struct PersistentAnchor {
 impl PersistentAnchor {
     /// This will attempt to load the [`Anchor`] from a file, and if the file doesn't exist it will
     /// attempt to initialize it with an empty peer list.
-    pub fn new_from_file<P: AsRef<Path>>(path: P) -> Result<Self, AnchorError> {
+    pub fn new_from_file(path: &Path) -> Result<Self, AnchorError> {
         let file = OpenOptions::new().read(true).write(true).create(true).open(path)?;
 
         // if the file does not exist then we should create it

--- a/crates/net/p2p/src/anchor.rs
+++ b/crates/net/p2p/src/anchor.rs
@@ -1,0 +1,134 @@
+//! Peer persistence utilities
+
+use std::{
+    fs::{File, OpenOptions},
+    io::{BufReader, Read, Write},
+    path::Path,
+};
+
+use enr::{secp256k1::SecretKey, Enr};
+use serde_derive::{Deserialize, Serialize};
+use thiserror::Error;
+
+// TODO: impl Hash for Enr<K> upstream and change to HashSet to prevent duplicates
+// TODO: enforce one-to-one mapping between IP and key
+
+/// Contains a list of peers to persist across node restarts.
+///
+/// Addresses in this list can come from:
+///  * Discovery methods (discv4, discv5, dnsdisc)
+///  * Known static peers
+///
+/// Updates to this list can come from:
+///  * Discovery methods (discv4, discv5, dnsdisc)
+///    * All peers we connect to from discovery methods are outbound peers.
+///  * Inbound connections
+///    * Updates for inbound connections must be based on the address advertised in the node record
+///      for that peer, if a node record exists.
+///    * Updates for inbound connections must NOT be based on the peer's remote address, since its
+///      port may be ephemeral.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Anchor {
+    /// Peers that have been obtained discovery sources when the node is running
+    pub discovered_peers: Vec<Enr<SecretKey>>,
+
+    /// Pre-determined peers to reach out to
+    pub static_peers: Vec<Enr<SecretKey>>,
+}
+
+impl Anchor {
+    /// Creates an empty [`Anchor`]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds peers to the discovered peer list
+    pub fn add_discovered(&mut self, new_peers: Vec<Enr<SecretKey>>) {
+        self.discovered_peers.extend(new_peers);
+        self.discovered_peers.dedup();
+    }
+
+    /// Adds peers to the static peer list.
+    pub fn add_static(&mut self, new_peers: Vec<Enr<SecretKey>>) {
+        self.static_peers.extend(new_peers);
+        self.static_peers.dedup();
+    }
+}
+
+#[derive(Debug, Error)]
+/// An error that can occur while parsing a peer list from a file
+pub enum AnchorError {
+    /// Error opening the anchor file
+    #[error("error opening or writing the anchor file")]
+    IoError(#[from] std::io::Error),
+
+    /// Error occurred when loading the anchor file from TOML
+    #[error("error deserializing the peer list from TOML")]
+    LoadError(#[from] toml::de::Error),
+
+    /// Error occurred when saving the anchor file to TOML
+    #[error("error serializing the peer list as TOML")]
+    SaveError(#[from] toml::ser::Error),
+}
+
+/// A version of [`Anchor`] that is loaded from a TOML file and saves its contents when it is
+/// dropped.
+#[derive(Debug)]
+pub struct PersistentAnchor {
+    /// The list of addresses to persist
+    anchor: Anchor,
+
+    /// The File handle for the anchor
+    file: File,
+}
+
+impl PersistentAnchor {
+    /// This will attempt to load the [`Anchor`] from a file, and if the file doesn't exist it will
+    /// attempt to initialize it with an empty peer list.
+    pub fn new_from_file<P: AsRef<Path>>(path: P) -> Result<Self, AnchorError> {
+        let file = OpenOptions::new().write(true).create(true).open(path)?;
+        Self::from_toml(file)
+    }
+
+    /// Load the [`Anchor`] from the given TOML file.
+    pub fn from_toml(file: File) -> Result<Self, AnchorError> {
+        let mut reader = BufReader::new(&file);
+        let mut contents = String::new();
+        reader.read_to_string(&mut contents)?;
+
+        let anchor: Anchor = toml::from_str(&contents)?;
+        Ok(Self { anchor, file })
+    }
+
+    /// Save the contents of the [`Anchor`] into the associated file as TOML.
+    pub fn save_toml(&mut self) -> Result<(), AnchorError> {
+        let anchor_contents = toml::to_vec(&self.anchor)?;
+        self.file.write_all(anchor_contents.as_ref())?;
+        Ok(())
+    }
+}
+
+impl Drop for PersistentAnchor {
+    fn drop(&mut self) {
+        self.save_toml().unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Anchor;
+
+    #[test]
+    fn serde_read_toml() {
+        let _: Anchor = toml::from_str(r#"
+            discovered_peers = [
+                "enr:-Iu4QGuiaVXBEoi4kcLbsoPYX7GTK9ExOODTuqYBp9CyHN_PSDtnLMCIL91ydxUDRPZ-jem-o0WotK6JoZjPQWhTfEsTgmlkgnY0gmlwhDbOLfeJc2VjcDI1NmsxoQLVqNEoCVTC74VmUx25USyFe7lL0TgpXHaCX9CDy9H6boN0Y3CCIyiDdWRwgiMo",
+                "enr:-Iu4QLNTiVhgyDyvCBnewNcn9Wb7fjPoKYD2NPe-jDZ3_TqaGFK8CcWr7ai7w9X8Im_ZjQYyeoBP_luLLBB4wy39gQ4JgmlkgnY0gmlwhCOhiGqJc2VjcDI1NmsxoQMrmBYg_yR_ZKZKoLiChvlpNqdwXwodXmgw_TRow7RVwYN0Y3CCIyiDdWRwgiMo",
+            ]
+            static_peers = [
+                "enr:-Iu4QLpJhdfRFsuMrAsFQOSZTIW1PAf7Ndg0GB0tMByt2-n1bwVgLsnHOuujMg-YLns9g1Rw8rfcw1KCZjQrnUcUdekNgmlkgnY0gmlwhA01ZgSJc2VjcDI1NmsxoQPk2OMW7stSjbdcMgrKEdFOLsRkIuxgBFryA3tIJM0YxYN0Y3CCIyiDdWRwgiMo",
+                "enr:-Iu4QBHuAmMN5ogZP_Mwh_bADnIOS2xqj8yyJI3EbxW66WKtO_JorshNQJ1NY8zo-u3G7HQvGW3zkV6_kRx5d0R19bETgmlkgnY0gmlwhDRCMUyJc2VjcDI1NmsxoQJZ8jY1HYauxirnJkVI32FoN7_7KrE05asCkZb7nj_b-YN0Y3CCIyiDdWRwgiMo",
+            ]
+        "#).expect("Parsing valid TOML into an Anchor should not fail");
+    }
+}

--- a/crates/net/p2p/src/anchor.rs
+++ b/crates/net/p2p/src/anchor.rs
@@ -37,11 +37,6 @@ pub struct Anchor {
 }
 
 impl Anchor {
-    /// Creates an empty [`Anchor`]
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     /// Adds peers to the discovered peer list
     pub fn add_discovered(&mut self, new_peers: Vec<Enr<SecretKey>>) {
         self.discovered_peers.extend(new_peers);

--- a/crates/net/p2p/src/anchor.rs
+++ b/crates/net/p2p/src/anchor.rs
@@ -40,13 +40,11 @@ impl Anchor {
     /// Adds peers to the discovered peer list
     pub fn add_discovered(&mut self, new_peers: Vec<Enr<SecretKey>>) {
         self.discovered_peers.extend(new_peers);
-        self.discovered_peers.dedup();
     }
 
     /// Adds peers to the static peer list.
     pub fn add_static(&mut self, new_peers: Vec<Enr<SecretKey>>) {
         self.static_peers.extend(new_peers);
-        self.static_peers.dedup();
     }
 
     /// Returns true if both peer lists are empty

--- a/crates/net/p2p/src/lib.rs
+++ b/crates/net/p2p/src/lib.rs
@@ -6,3 +6,5 @@
 ))]
 
 //! Utilities for interacting with ethereum's peer to peer network.
+
+pub mod anchor;


### PR DESCRIPTION
Adds a struct called `Anchor` which represents two types of peers that the node might want to persist:
 - A "static" peer list, which are user specified. This list shouldn't be overwritten by the node.
 - A "discovered" peer list, which would be modified by the node and populated with active peers.

Also introduces `PersistentAnchor` which can load from a TOML file, saving to a file on `drop`

This will be used in case the node restarts, so discovery can start off with peers that are likely to be active.

todo:
- [x] change static peer type to include IPs instead of, or in addition to ENRs?
  - Going to keep them as ENRs for now unless there is an explicit reason to allow IPs in the static peer list
- [ ] enforce one-to-one mapping between IP and key
- [x] temp toml file tests