### PR TITLE
feat(db): mdbx integration & table skeletons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,6 +1297,7 @@ version = "0.1.0"
 name = "reth-db"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "eyre",
  "libmdbx",
  "page_size",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,16 +417,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "eyre"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
-dependencies = [
- "indenter",
- "once_cell",
-]
-
-[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,12 +776,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "indenter"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
@@ -1437,11 +1421,11 @@ name = "reth-db"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "eyre",
  "libmdbx",
  "page_size",
  "reth-primitives",
  "tempfile",
+ "thiserror",
 ]
 
 [[package]]
@@ -2005,9 +1989,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -2017,9 +2001,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2028,9 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,6 +410,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "fastrlp"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,6 +770,15 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1286,6 +1304,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "reth"
 version = "0.1.0"
 
@@ -1301,6 +1328,8 @@ dependencies = [
  "eyre",
  "libmdbx",
  "page_size",
+ "reth-primitives",
+ "tempfile",
 ]
 
 [[package]]
@@ -1637,6 +1666,20 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
 
 [[package]]
 name = "thiserror"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fastrlp"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +748,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1029,6 +1045,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "page_size"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,7 +1297,9 @@ version = "0.1.0"
 name = "reth-db"
 version = "0.1.0"
 dependencies = [
+ "eyre",
  "libmdbx",
+ "page_size",
 ]
 
 [[package]]

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -8,7 +8,15 @@ readme = "README.md"
 description = "Staged syncing primitives used in reth."
 
 [dependencies]
+
+# reth
+reth-primitives = { path = "../primitives" }
+
+# misc
 bytes = "1.2.1"
 eyre = "0.6.8"
 libmdbx = "0.1.8"
 page_size = "0.4.2"
+
+[dev-dependencies]
+tempfile = "3.3.0"

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -8,7 +8,6 @@ readme = "README.md"
 description = "Staged syncing primitives used in reth."
 
 [dependencies]
-
 # reth
 reth-primitives = { path = "../primitives" }
 

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 description = "Staged syncing primitives used in reth."
 
 [dependencies]
+bytes = "1.2.1"
 eyre = "0.6.8"
 libmdbx = "0.1.8"
 page_size = "0.4.2"

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -8,4 +8,6 @@ readme = "README.md"
 description = "Staged syncing primitives used in reth."
 
 [dependencies]
+eyre = "0.6.8"
 libmdbx = "0.1.8"
+page_size = "0.4.2"

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -13,9 +13,9 @@ reth-primitives = { path = "../primitives" }
 
 # misc
 bytes = "1.2.1"
-eyre = "0.6.8"
 libmdbx = "0.1.8"
 page_size = "0.4.2"
+thiserror = "1.0.37"
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/crates/db/src/kv/cursor.rs
+++ b/crates/db/src/kv/cursor.rs
@@ -12,7 +12,7 @@ pub struct Cursor<'tx, K: TransactionKind, T: Table> {
     /// Inner `libmdbx` cursor.
     pub inner: libmdbx::Cursor<'tx, K>,
     /// Table name as is inside the database.
-    pub table: String, // TODO
+    pub table: &'static str,
     /// Phantom data to enforce encoding/decoding.
     pub _dbi: std::marker::PhantomData<T>,
 }

--- a/crates/db/src/kv/cursor.rs
+++ b/crates/db/src/kv/cursor.rs
@@ -1,18 +1,23 @@
+//! Cursor wrapper for libmdbx-sys.
+
 use crate::{
     kv::{Decode, DupSort, Encode, Table},
     utils::*,
 };
 use libmdbx::{self, TransactionKind};
 
-// Cursor wrapper to access KV items.
+/// Cursor wrapper to access KV items.
+#[derive(Debug)]
 pub struct Cursor<'tx, K: TransactionKind, T: Table> {
     /// Inner `libmdbx` cursor.
     pub inner: libmdbx::Cursor<'tx, K>,
-    /// Table name.
+    /// Table name as is inside the database.
     pub table: String, // TODO
+    /// Phantom data to enforce encoding/decoding.
     pub _dbi: std::marker::PhantomData<T>,
 }
 
+/// Takes `(key, value)` from the database and decodes it appropriately.
 #[macro_export]
 macro_rules! decode {
     ($v:expr) => {
@@ -134,8 +139,11 @@ where
 }
 
 /// Provides an iterator to `Cursor` when handling `Table`.
+#[derive(Debug)]
 pub struct Walker<'a, K: TransactionKind, T: Table> {
+    /// Cursor to be used to walk through the table.
     pub cursor: Cursor<'a, K, T>,
+    /// `(key, value)` where to start the walk.
     pub start: Option<eyre::Result<(T::Key, T::Value)>>,
 }
 
@@ -155,8 +163,11 @@ where
 }
 
 /// Provides an iterator to `Cursor` when handling a `DupSort` table.
+#[derive(Debug)]
 pub struct DupWalker<'a, K: TransactionKind, T: DupSort> {
+    /// Cursor to be used to walk through the table.
     pub cursor: Cursor<'a, K, T>,
+    /// Value where to start the walk.
     pub start: Option<eyre::Result<T::Value>>,
 }
 

--- a/crates/db/src/kv/cursor.rs
+++ b/crates/db/src/kv/cursor.rs
@@ -1,0 +1,175 @@
+use crate::kv::{Decode, DupSort, Encode, Table};
+use libmdbx::{self, TransactionKind};
+use std::borrow::Cow;
+
+pub struct Cursor<'tx, K: TransactionKind, T: Table> {
+    pub inner: libmdbx::Cursor<'tx, K>,
+    pub table: String, // todo
+    pub _dbi: std::marker::PhantomData<T>,
+}
+
+#[macro_export]
+macro_rules! decode {
+    ($v:expr) => {
+        $v?.map(decoder::<T>).transpose()
+    };
+}
+
+impl<'tx, K: TransactionKind, T: Table> Cursor<'tx, K, T> {
+    pub fn first(&mut self) -> eyre::Result<Option<(T::Key, T::Value)>>
+    where
+        T::Key: Decode,
+    {
+        decode!(self.inner.first())
+    }
+
+    pub fn seek(&mut self, key: T::SeekKey) -> eyre::Result<Option<(T::Key, T::Value)>>
+    where
+        T::Key: Decode,
+    {
+        decode!(self.inner.set_range(key.encode().as_ref()))
+    }
+
+    pub fn seek_exact(&mut self, key: T::Key) -> eyre::Result<Option<(T::Key, T::Value)>>
+    where
+        T::Key: Decode,
+    {
+        decode!(self.inner.set_key(key.encode().as_ref()))
+    }
+
+    #[allow(clippy::should_implement_trait)]
+    pub fn next(&mut self) -> eyre::Result<Option<(T::Key, T::Value)>>
+    where
+        T::Key: Decode,
+    {
+        decode!(self.inner.next())
+    }
+
+    pub fn prev(&mut self) -> eyre::Result<Option<(T::Key, T::Value)>>
+    where
+        T::Key: Decode,
+    {
+        decode!(self.inner.prev())
+    }
+
+    pub fn last(&mut self) -> eyre::Result<Option<(T::Key, T::Value)>>
+    where
+        T::Key: Decode,
+    {
+        decode!(self.inner.last())
+    }
+
+    pub fn current(&mut self) -> eyre::Result<Option<(T::Key, T::Value)>>
+    where
+        T::Key: Decode,
+    {
+        decode!(self.inner.get_current())
+    }
+
+    pub fn walk(
+        mut self,
+        start_key: T::Key,
+    ) -> eyre::Result<impl Iterator<Item = eyre::Result<(<T as Table>::Key, <T as Table>::Value)>>>
+    where
+        T::Key: Decode,
+    {
+        let start = self.inner.set_range(start_key.encode().as_ref())?.map(decoder::<T>);
+
+        Ok(Walker { cursor: self, start })
+    }
+}
+
+impl<'txn, K, T> Cursor<'txn, K, T>
+where
+    K: TransactionKind,
+    T: DupSort,
+{
+    pub fn next_dup(&mut self) -> eyre::Result<Option<(T::Key, T::Value)>>
+    where
+        T::Key: Decode,
+    {
+        decode!(self.inner.next_dup())
+    }
+
+    pub fn next_no_dup(&mut self) -> eyre::Result<Option<(T::Key, T::Value)>>
+    where
+        T::Key: Decode,
+    {
+        decode!(self.inner.next_nodup())
+    }
+
+    pub fn next_dup_val(&mut self) -> eyre::Result<Option<T::Value>> {
+        self.inner.next_dup()?.map(decode_value::<T>).transpose()
+    }
+
+    pub fn walk_dup(
+        mut self,
+        key: T::Key,
+        subkey: T::SubKey,
+    ) -> eyre::Result<impl Iterator<Item = eyre::Result<<T as Table>::Value>>> {
+        let start = self
+            .inner
+            .get_both_range(key.encode().as_ref(), subkey.encode().as_ref())?
+            .map(decode_one::<T>);
+
+        Ok(DupWalker { cursor: self, start })
+    }
+}
+
+pub fn decoder<'a, T>(kv: (Cow<'a, [u8]>, Cow<'a, [u8]>)) -> eyre::Result<(T::Key, T::Value)>
+where
+    T: Table,
+    T::Key: Decode,
+{
+    Ok((Decode::decode(&kv.0)?, Decode::decode(&kv.1)?))
+}
+
+pub fn decode_value<'a, T>(kv: (Cow<'a, [u8]>, Cow<'a, [u8]>)) -> eyre::Result<T::Value>
+where
+    T: Table,
+{
+    Decode::decode(&kv.1)
+}
+
+pub fn decode_one<'a, T>(value: Cow<'a, [u8]>) -> eyre::Result<T::Value>
+where
+    T: Table,
+{
+    Decode::decode(&value)
+}
+
+pub struct Walker<'a, K: TransactionKind, T: Table> {
+    pub cursor: Cursor<'a, K, T>,
+    pub start: Option<eyre::Result<(T::Key, T::Value)>>,
+}
+
+impl<'tx, K: TransactionKind, T: Table> std::iter::Iterator for Walker<'tx, K, T>
+where
+    T::Key: Decode,
+{
+    type Item = eyre::Result<(T::Key, T::Value)>;
+    fn next(&mut self) -> Option<Self::Item> {
+        let start = self.start.take();
+        if start.is_some() {
+            return start
+        }
+
+        self.cursor.next().transpose()
+    }
+}
+
+pub struct DupWalker<'a, K: TransactionKind, T: DupSort> {
+    pub cursor: Cursor<'a, K, T>,
+    pub start: Option<eyre::Result<T::Value>>,
+}
+
+impl<'tx, K: TransactionKind, T: DupSort> std::iter::Iterator for DupWalker<'tx, K, T> {
+    type Item = eyre::Result<T::Value>;
+    fn next(&mut self) -> Option<Self::Item> {
+        let start = self.start.take();
+        if start.is_some() {
+            return start
+        }
+        self.cursor.next_dup_val().transpose()
+    }
+}

--- a/crates/db/src/kv/cursor.rs
+++ b/crates/db/src/kv/cursor.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 pub struct Cursor<'tx, K: TransactionKind, T: Table> {
     pub inner: libmdbx::Cursor<'tx, K>,
-    pub table: String, // todo
+    pub table: String, // TODO
     pub _dbi: std::marker::PhantomData<T>,
 }
 

--- a/crates/db/src/kv/error.rs
+++ b/crates/db/src/kv/error.rs
@@ -1,0 +1,36 @@
+//! KVError declaration.
+
+use libmdbx::Error;
+use thiserror::Error;
+
+/// KV error type.
+#[derive(Debug, Error)]
+pub enum KVError {
+    /// Generic MDBX error.
+    #[error("MDBX error: {0:?}")]
+    MDBX(#[from] Error),
+    /// Failed to open MDBX file.
+    #[error("{0:?}")]
+    DatabaseLocation(Error),
+    /// Failed to create a table in database.
+    #[error("{0:?}")]
+    TableCreation(Error),
+    /// Failed to insert a value into a table.
+    #[error("{0:?}")]
+    Put(Error),
+    /// Failed to get a value into a table.
+    #[error("{0:?}")]
+    Get(Error),
+    /// Failed to delete a `(key, vakue)` pair into a table.
+    #[error("{0:?}")]
+    Delete(Error),
+    /// Failed to commit transaction changes into the database.
+    #[error("{0:?}")]
+    Commit(Error),
+    /// Failed to initiate a MDBX transaction.
+    #[error("{0:?}")]
+    InitTransaction(Error),
+    /// Failed to decode or encode a key or value coming from a table..
+    #[error("{0:?}")]
+    InvalidValue(Option<String>),
+}

--- a/crates/db/src/kv/mod.rs
+++ b/crates/db/src/kv/mod.rs
@@ -51,14 +51,14 @@ impl<E: EnvironmentKind> Env<E> {
             inner: Environment::new()
                 .set_max_dbs(TABLES.len())
                 .set_geometry(Geometry {
-                    size: Some(0..0x100000),     // TODO
-                    growth_step: Some(0x100000), // TODO
+                    size: Some(0..0x100000),     // TODO: reevaluate
+                    growth_step: Some(0x100000), // TODO: reevaluate
                     shrink_threshold: None,
                     page_size: Some(PageSize::Set(default_page_size())),
                 })
                 .set_flags(EnvironmentFlags {
                     mode,
-                    no_rdahead: true,
+                    no_rdahead: true, // TODO: reevaluate
                     coalesce: true,
                     ..Default::default()
                 })

--- a/crates/db/src/kv/mod.rs
+++ b/crates/db/src/kv/mod.rs
@@ -1,3 +1,5 @@
+//! Module that interacts with MDBX.
+
 use crate::utils::{default_page_size, TableType};
 use libmdbx::{
     DatabaseFlags, Environment, EnvironmentFlags, EnvironmentKind, Error, Geometry, Mode, PageSize,
@@ -16,13 +18,19 @@ pub mod cursor;
 pub mod tx;
 use tx::Tx;
 
+/// Environment used when opening a MDBX environment. RO/RW.
+#[derive(Debug)]
 pub enum EnvKind {
+    /// Read-only MDBX environment.
     RO,
+    /// Read-write MDBX environment.
     RW,
 }
 
 /// Wrapper for the libmdbx environment.
+#[derive(Debug)]
 pub struct Env<E: EnvironmentKind> {
+    /// Libmdbx-sys environment.
     pub inner: Environment<E>,
 }
 

--- a/crates/db/src/kv/mod.rs
+++ b/crates/db/src/kv/mod.rs
@@ -1,0 +1,81 @@
+use crate::utils::{default_page_size, TEMP_PLACEHOLDER_NUM_TABLES};
+use libmdbx::{
+    Environment, EnvironmentFlags, EnvironmentKind, Error, Geometry, Mode, PageSize, SyncMode,
+    WriteMap, RO, RW,
+};
+use std::{ops::Deref, path::Path};
+
+pub mod table;
+use table::{Decode, DupSort, Encode, Table};
+
+pub mod cursor;
+
+pub mod tx;
+use tx::Tx;
+
+pub enum EnvKind {
+    RO,
+    RW,
+}
+
+pub struct Env<E: EnvironmentKind> {
+    pub inner: Environment<E>,
+}
+
+impl<E: EnvironmentKind> Env<E> {
+    pub fn open(path: &Path, kind: EnvKind) -> Result<Env<WriteMap>, Error> {
+        let mode = match kind {
+            EnvKind::RO => Mode::ReadOnly,
+            EnvKind::RW => Mode::ReadWrite { sync_mode: SyncMode::Durable },
+        };
+
+        let env = Env {
+            inner: Environment::new()
+                .set_max_dbs(TEMP_PLACEHOLDER_NUM_TABLES)
+                .set_geometry(Geometry {
+                    size: Some(0..usize::MAX),
+                    growth_step: Some(isize::MAX),
+                    shrink_threshold: None,
+                    page_size: Some(PageSize::Set(default_page_size())),
+                })
+                .set_flags(EnvironmentFlags {
+                    mode,
+                    no_rdahead: true,
+                    coalesce: true,
+                    ..Default::default()
+                })
+                .open(path)?,
+        };
+
+        if let EnvKind::RW = kind {
+            env.maybe_create_tables()?;
+        }
+
+        Ok(env)
+    }
+
+    fn maybe_create_tables(&self) -> Result<(), Error> {
+        let tx = self.inner.begin_rw_txn()?;
+        // loop & create
+        tx.commit()?;
+        Ok(())
+    }
+}
+
+impl<E: EnvironmentKind> Env<E> {
+    pub fn begin_tx(&self) -> eyre::Result<Tx<'_, RO, E>> {
+        Ok(Tx { inner: self.inner.begin_ro_txn()? })
+    }
+
+    pub fn begin_mut_tx(&self) -> eyre::Result<Tx<'_, RW, E>> {
+        Ok(Tx { inner: self.inner.begin_rw_txn()? })
+    }
+}
+
+impl<E: EnvironmentKind> Deref for Env<E> {
+    type Target = libmdbx::Environment<E>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}

--- a/crates/db/src/kv/mod.rs
+++ b/crates/db/src/kv/mod.rs
@@ -1,13 +1,15 @@
 use crate::utils::{default_page_size, TEMP_PLACEHOLDER_NUM_TABLES};
 use libmdbx::{
-    Environment, EnvironmentFlags, EnvironmentKind, Error, Geometry, Mode, PageSize, SyncMode,
-    WriteMap, RO, RW,
+    DatabaseFlags, Environment, EnvironmentFlags, EnvironmentKind, Error, Geometry, Mode, PageSize,
+    SyncMode, RO, RW,
 };
 use std::{ops::Deref, path::Path};
 
 pub mod table;
-pub mod tables;
 use table::{Decode, DupSort, Encode, Table};
+
+pub mod tables;
+use tables::Account;
 
 pub mod cursor;
 
@@ -24,7 +26,7 @@ pub struct Env<E: EnvironmentKind> {
 }
 
 impl<E: EnvironmentKind> Env<E> {
-    pub fn open(path: &Path, kind: EnvKind) -> Result<Env<WriteMap>, Error> {
+    pub fn open(path: &Path, kind: EnvKind) -> Result<Env<E>, Error> {
         let mode = match kind {
             EnvKind::RO => Mode::ReadOnly,
             EnvKind::RW => Mode::ReadWrite { sync_mode: SyncMode::Durable },
@@ -34,8 +36,8 @@ impl<E: EnvironmentKind> Env<E> {
             inner: Environment::new()
                 .set_max_dbs(TEMP_PLACEHOLDER_NUM_TABLES)
                 .set_geometry(Geometry {
-                    size: Some(0..usize::MAX),
-                    growth_step: Some(isize::MAX),
+                    size: Some(0..0x100000),     // TODO
+                    growth_step: Some(0x100000), // TODO
                     shrink_threshold: None,
                     page_size: Some(PageSize::Set(default_page_size())),
                 })
@@ -57,8 +59,24 @@ impl<E: EnvironmentKind> Env<E> {
 
     fn maybe_create_tables(&self) -> Result<(), Error> {
         let tx = self.inner.begin_rw_txn()?;
-        // loop & create
+        // TODO: loop & create dup_sort flag
+        tx.create_db(Some(Account::name()), DatabaseFlags::default())?;
+        // tx.create_db(Some(Storage::name()), DatabaseFlags::default())?;
+
         tx.commit()?;
+
+        //         let tx = s.inner.begin_rw_txn()?;
+        // for (table, info) in chart {
+        //     tx.create_db(
+        //         Some(table),
+        //         if info.dup_sort {
+        //             DatabaseFlags::DUP_SORT
+        //         } else {
+        //             DatabaseFlags::default()
+        //         },
+        //     )?;
+        // }
+        // tx.commit()?;
         Ok(())
     }
 }
@@ -78,5 +96,38 @@ impl<E: EnvironmentKind> Deref for Env<E> {
 
     fn deref(&self) -> &Self::Target {
         &self.inner
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{tables::Account, Env, EnvKind};
+    use libmdbx::NoWriteMap;
+    use reth_primitives::Address;
+    use std::str::FromStr;
+    use tempfile::TempDir;
+
+    #[test]
+    fn db_creation() {
+        Env::<NoWriteMap>::open(&TempDir::new().unwrap().into_path(), EnvKind::RW).unwrap();
+    }
+
+    #[test]
+    fn db_put_get() {
+        let env =
+            Env::<NoWriteMap>::open(&TempDir::new().unwrap().into_path(), EnvKind::RW).unwrap();
+
+        let key = Address::from_str("0xa2c122be93b0074270ebee7f6b7292c7deb45047").unwrap();
+        let value = vec![1, 3, 3, 7];
+
+        let tx = env.begin_mut_tx().unwrap();
+        tx.put(Account, key, value.clone()).unwrap();
+        tx.commit().unwrap();
+
+        let tx = env.begin_tx().unwrap();
+        let result = tx.get(Account, key).unwrap();
+        tx.commit().unwrap();
+
+        assert!(result == Some(value))
     }
 }

--- a/crates/db/src/kv/mod.rs
+++ b/crates/db/src/kv/mod.rs
@@ -6,6 +6,7 @@ use libmdbx::{
 use std::{ops::Deref, path::Path};
 
 pub mod table;
+pub mod tables;
 use table::{Decode, DupSort, Encode, Table};
 
 pub mod cursor;

--- a/crates/db/src/kv/table.rs
+++ b/crates/db/src/kv/table.rs
@@ -1,0 +1,27 @@
+use std::fmt::Debug;
+
+pub trait Encode: Send + Sync + Sized {
+    type Encoded: AsRef<[u8]> + Send + Sync;
+
+    fn encode(self) -> Self::Encoded;
+}
+
+pub trait Decode: Send + Sync + Sized {
+    fn decode(b: &[u8]) -> eyre::Result<Self>;
+}
+
+pub trait Object: Encode + Decode {}
+
+impl<T> Object for T where T: Encode + Decode {}
+
+pub trait Table: Send + Sync + Debug + 'static {
+    type Key: Encode;
+    type Value: Object;
+    type SeekKey: Encode;
+
+    fn db_name(&self) -> &str; //string::String<Bytes>; todo
+}
+
+pub trait DupSort: Table {
+    type SubKey: Object;
+}

--- a/crates/db/src/kv/table.rs
+++ b/crates/db/src/kv/table.rs
@@ -1,20 +1,21 @@
 //! Table traits.
 #![allow(missing_docs)]
 
+use super::KVError;
 use bytes::Bytes;
 use reth_primitives::{Address, U256};
 use std::fmt::Debug;
 
 /// Trait that will transform the data to be saved in the DB.
-pub trait Encode: Send + Sync + Sized {
+pub trait Encode: Send + Sync + Sized + Debug {
     type Encoded: AsRef<[u8]> + Send + Sync;
 
     fn encode(self) -> Self::Encoded;
 }
 
 /// Trait that will transform the data to be read from the DB.
-pub trait Decode: Send + Sync + Sized {
-    fn decode(value: &[u8]) -> eyre::Result<Self>;
+pub trait Decode: Send + Sync + Sized + Debug {
+    fn decode(value: &[u8]) -> Result<Self, KVError>;
 }
 
 /// Generic trait that enforces the database value to implement [`Encode`] and [`Decode`].
@@ -50,7 +51,7 @@ impl Encode for Vec<u8> {
 }
 
 impl Decode for Vec<u8> {
-    fn decode(value: &[u8]) -> eyre::Result<Self> {
+    fn decode(value: &[u8]) -> Result<Self, KVError> {
         Ok(value.to_vec())
     }
 }
@@ -64,7 +65,7 @@ impl Encode for Bytes {
 }
 
 impl Decode for Bytes {
-    fn decode(value: &[u8]) -> eyre::Result<Self> {
+    fn decode(value: &[u8]) -> Result<Self, KVError> {
         Ok(value.to_vec().into())
     }
 }
@@ -78,7 +79,7 @@ impl Encode for Address {
 }
 
 impl Decode for Address {
-    fn decode(value: &[u8]) -> eyre::Result<Self> {
+    fn decode(value: &[u8]) -> Result<Self, KVError> {
         Ok(Address::from_slice(value))
     }
 }
@@ -92,7 +93,7 @@ impl Encode for u16 {
 }
 
 impl Decode for u16 {
-    fn decode(value: &[u8]) -> eyre::Result<Self> {
+    fn decode(value: &[u8]) -> Result<Self, KVError> {
         unsafe { Ok(u16::from_be_bytes(*(value.as_ptr() as *const [_; 2]))) }
     }
 }
@@ -106,7 +107,7 @@ impl Encode for u64 {
 }
 
 impl Decode for u64 {
-    fn decode(value: &[u8]) -> eyre::Result<Self> {
+    fn decode(value: &[u8]) -> Result<Self, KVError> {
         unsafe { Ok(u64::from_be_bytes(*(value.as_ptr() as *const [_; 8]))) }
     }
 }
@@ -122,7 +123,7 @@ impl Encode for U256 {
 }
 
 impl Decode for U256 {
-    fn decode(value: &[u8]) -> eyre::Result<Self> {
+    fn decode(value: &[u8]) -> Result<Self, KVError> {
         let mut result = [0; 32];
         result.copy_from_slice(value);
         Ok(Self::from_big_endian(&result))

--- a/crates/db/src/kv/table.rs
+++ b/crates/db/src/kv/table.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use std::fmt::Debug;
 
 pub trait Encode: Send + Sync + Sized {
@@ -19,9 +20,37 @@ pub trait Table: Send + Sync + Debug + 'static {
     type Value: Object;
     type SeekKey: Encode;
 
-    fn db_name(&self) -> &str; //string::String<Bytes>; todo
+    fn db_name(&self) -> &'static str; //string::String<Bytes>; todo
 }
 
 pub trait DupSort: Table {
     type SubKey: Object;
+}
+
+impl Encode for Vec<u8> {
+    type Encoded = Self;
+
+    fn encode(self) -> Self::Encoded {
+        self
+    }
+}
+
+impl Decode for Vec<u8> {
+    fn decode(b: &[u8]) -> eyre::Result<Self> {
+        Ok(b.to_vec())
+    }
+}
+
+impl Encode for Bytes {
+    type Encoded = Self;
+
+    fn encode(self) -> Self::Encoded {
+        self
+    }
+}
+
+impl Decode for Bytes {
+    fn decode(b: &[u8]) -> eyre::Result<Self> {
+        Ok(b.to_vec().into())
+    }
 }

--- a/crates/db/src/kv/table.rs
+++ b/crates/db/src/kv/table.rs
@@ -1,3 +1,6 @@
+//! Table traits.
+#![allow(missing_docs)]
+
 use bytes::Bytes;
 use reth_primitives::{Address, U256};
 use std::fmt::Debug;
@@ -21,11 +24,15 @@ impl<T> Object for T where T: Encode + Decode {}
 
 /// Generic trait that a database table should follow.
 pub trait Table: Send + Sync + Debug + 'static {
+    /// Key element of `Table`.
     type Key: Encode;
+    /// Value element of `Table`.
     type Value: Object;
+    /// Seek Key element of `Table`.
     type SeekKey: Encode;
 
-    fn db_name(&self) -> &'static str; //string::String<Bytes>; TODO
+    /// Return name as it is present inside the MDBX.
+    fn name(&self) -> &'static str;
 }
 
 /// DupSort allows for keys not to be repeated in the database,

--- a/crates/db/src/kv/table.rs
+++ b/crates/db/src/kv/table.rs
@@ -1,4 +1,5 @@
 use bytes::Bytes;
+use reth_primitives::Address;
 use std::fmt::Debug;
 
 pub trait Encode: Send + Sync + Sized {
@@ -20,7 +21,7 @@ pub trait Table: Send + Sync + Debug + 'static {
     type Value: Object;
     type SeekKey: Encode;
 
-    fn db_name(&self) -> &'static str; //string::String<Bytes>; todo
+    fn db_name(&self) -> &'static str; //string::String<Bytes>; TODO
 }
 
 pub trait DupSort: Table {
@@ -52,5 +53,19 @@ impl Encode for Bytes {
 impl Decode for Bytes {
     fn decode(b: &[u8]) -> eyre::Result<Self> {
         Ok(b.to_vec().into())
+    }
+}
+
+impl Encode for Address {
+    type Encoded = [u8; 20];
+
+    fn encode(self) -> Self::Encoded {
+        self.0
+    }
+}
+
+impl Decode for Address {
+    fn decode(b: &[u8]) -> eyre::Result<Self> {
+        Ok(Address::from_slice(b))
     }
 }

--- a/crates/db/src/kv/table.rs
+++ b/crates/db/src/kv/table.rs
@@ -1,5 +1,4 @@
 //! Table traits.
-#![allow(missing_docs)]
 
 use super::KVError;
 use bytes::Bytes;
@@ -8,13 +7,16 @@ use std::fmt::Debug;
 
 /// Trait that will transform the data to be saved in the DB.
 pub trait Encode: Send + Sync + Sized + Debug {
+    /// Encoded type.
     type Encoded: AsRef<[u8]> + Send + Sync;
 
+    /// Decodes data going into the database.
     fn encode(self) -> Self::Encoded;
 }
 
 /// Trait that will transform the data to be read from the DB.
 pub trait Decode: Send + Sync + Sized + Debug {
+    /// Decodes data coming from the database.
     fn decode(value: &[u8]) -> Result<Self, KVError>;
 }
 
@@ -39,6 +41,7 @@ pub trait Table: Send + Sync + Debug + 'static {
 /// DupSort allows for keys not to be repeated in the database,
 /// for more check: https://libmdbx.dqdkfa.ru/usage.html#autotoc_md48
 pub trait DupSort: Table {
+    /// Subkey type. For more check https://libmdbx.dqdkfa.ru/usage.html#autotoc_md48
     type SubKey: Object;
 }
 

--- a/crates/db/src/kv/tables.rs
+++ b/crates/db/src/kv/tables.rs
@@ -1,4 +1,26 @@
-use reth_primitives::Address;
+use crate::utils::TableType;
+use reth_primitives::{Address, U256};
+
+/// Default tables that should be present inside database.
+pub const TABLES: [(TableType, &str); 17] = [
+    (TableType::Table, CanonicalHeaders::name()),
+    (TableType::Table, HeaderTD::name()),
+    (TableType::Table, HeaderNumbers::name()),
+    (TableType::Table, Headers::name()),
+    (TableType::Table, BlockBodies::name()),
+    (TableType::Table, CumulativeTxCount::name()),
+    (TableType::Table, NonCanonicalTransactions::name()),
+    (TableType::Table, Transactions::name()),
+    (TableType::Table, Receipts::name()),
+    (TableType::Table, Logs::name()),
+    (TableType::Table, PlainState::name()),
+    (TableType::Table, AccountHistory::name()),
+    (TableType::Table, StorageHistory::name()),
+    (TableType::DupSort, AccountChangeSet::name()),
+    (TableType::DupSort, StorageChangeSet::name()),
+    (TableType::Table, TxSenders::name()),
+    (TableType::Table, Config::name()),
+];
 
 #[macro_export]
 macro_rules! table {
@@ -17,7 +39,7 @@ macro_rules! table {
         }
 
         impl $name {
-            pub fn name() -> &'static str {
+            pub const  fn name() -> &'static str {
                 stringify!($name)
             }
         }
@@ -33,5 +55,56 @@ macro_rules! table {
     };
 }
 
-table!(Account => Address => Vec<u8>);
-table!(Storage => Address => Vec<u8>);
+//
+//  TABLE DEFINITIONS
+//
+
+table!(CanonicalHeaders => BNum => HeaderHash);
+table!(HeaderTD => BNum_BHash => RlpTotalDifficulty);
+table!(HeaderNumbers => BNum_BHash => BNum);
+table!(Headers => BNum_BHash => RlpHeader);
+
+table!(BlockBodies => BNum_BHash => NumTxesInBlock);
+table!(CumulativeTxCount => BNum_BHash => u64); // TODO U256?
+
+table!(NonCanonicalTransactions => BNum_BHash_TxId => RlpTxBody);
+table!(Transactions => TxId => RlpTxBody); // Canonical only
+table!(Receipts => TxId => Receipt); // Canonical only
+table!(Logs => TxId => Receipt); // Canonical only
+
+table!(PlainState => Address => Vec<u8>);
+
+table!(AccountHistory => Address => TxIdList);
+table!(StorageHistory => Address_StorageKey => TxIdList);
+
+table!(AccountChangeSet => TxId => AccountBeforeTx);
+table!(StorageChangeSet => TxId => StorageKeyBeforeTx);
+
+table!(TxSenders => TxId => Address); // Is it necessary?
+table!(Config => ConfigKey => ConfigValue);
+
+//
+// TODO: Temporary types, until they're properly defined alongside with the Encode and Decode Trait
+//
+
+type ConfigKey = Vec<u8>;
+type ConfigValue = Vec<u8>;
+#[allow(non_camel_case_types)]
+type BNum_BHash = Vec<u8>;
+#[allow(non_camel_case_types)]
+type BNum_BHash_TxId = Vec<u8>;
+type RlpHeader = Vec<u8>;
+type RlpTotalDifficulty = Vec<u8>;
+type RlpTxBody = Vec<u8>;
+type Receipt = Vec<u8>;
+type NumTxesInBlock = u16; // TODO can it be u16
+type BNum = u64; // TODO check size
+type TxId = u64; // TODO check size
+type HeaderHash = U256;
+type PlainStateKey = Address; // TODO new type will have to account for address_incarna_skey as well
+type AccountHistoryValue = Vec<u8>;
+type TxIdList = Vec<u8>;
+#[allow(non_camel_case_types)]
+type Address_StorageKey = Vec<u8>;
+type AccountBeforeTx = Vec<u8>;
+type StorageKeyBeforeTx = Vec<u8>;

--- a/crates/db/src/kv/tables.rs
+++ b/crates/db/src/kv/tables.rs
@@ -1,0 +1,28 @@
+#[macro_export]
+macro_rules! table {
+    ($name:ident => $key:ty => $value:ty => $seek:ty) => {
+        #[derive(Clone, Copy, Debug, Default)]
+        pub struct $name;
+
+        impl $crate::kv::table::Table for $name {
+            type Key = $key;
+            type Value = $value;
+            type SeekKey = $seek;
+
+            fn db_name(&self) -> &'static str  {
+               stringify!($name)
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", stringify!($name))
+            }
+        }
+    };
+    ($name:ident => $key:ty => $value:ty) => {
+        table!($name => $key => $value => $key);
+    };
+}
+
+table!(Account => Vec<u8> => Vec<u8> => Vec<u8>);

--- a/crates/db/src/kv/tables.rs
+++ b/crates/db/src/kv/tables.rs
@@ -1,30 +1,34 @@
+//! Declaration of all MDBX tables.
+
 use crate::utils::TableType;
 use reth_primitives::{Address, U256};
 
 /// Default tables that should be present inside database.
 pub const TABLES: [(TableType, &str); 17] = [
-    (TableType::Table, CanonicalHeaders::name()),
-    (TableType::Table, HeaderTD::name()),
-    (TableType::Table, HeaderNumbers::name()),
-    (TableType::Table, Headers::name()),
-    (TableType::Table, BlockBodies::name()),
-    (TableType::Table, CumulativeTxCount::name()),
-    (TableType::Table, NonCanonicalTransactions::name()),
-    (TableType::Table, Transactions::name()),
-    (TableType::Table, Receipts::name()),
-    (TableType::Table, Logs::name()),
-    (TableType::Table, PlainState::name()),
-    (TableType::Table, AccountHistory::name()),
-    (TableType::Table, StorageHistory::name()),
-    (TableType::DupSort, AccountChangeSet::name()),
-    (TableType::DupSort, StorageChangeSet::name()),
-    (TableType::Table, TxSenders::name()),
-    (TableType::Table, Config::name()),
+    (TableType::Table, CanonicalHeaders::const_name()),
+    (TableType::Table, HeaderTD::const_name()),
+    (TableType::Table, HeaderNumbers::const_name()),
+    (TableType::Table, Headers::const_name()),
+    (TableType::Table, BlockBodies::const_name()),
+    (TableType::Table, CumulativeTxCount::const_name()),
+    (TableType::Table, NonCanonicalTransactions::const_name()),
+    (TableType::Table, Transactions::const_name()),
+    (TableType::Table, Receipts::const_name()),
+    (TableType::Table, Logs::const_name()),
+    (TableType::Table, PlainState::const_name()),
+    (TableType::Table, AccountHistory::const_name()),
+    (TableType::Table, StorageHistory::const_name()),
+    (TableType::DupSort, AccountChangeSet::const_name()),
+    (TableType::DupSort, StorageChangeSet::const_name()),
+    (TableType::Table, TxSenders::const_name()),
+    (TableType::Table, Config::const_name()),
 ];
 
 #[macro_export]
+/// Macro to declare all necessary tables.
 macro_rules! table {
     ($name:ident => $key:ty => $value:ty => $seek:ty) => {
+        /// $name MDBX table.
         #[derive(Clone, Copy, Debug, Default)]
         pub struct $name;
 
@@ -33,13 +37,15 @@ macro_rules! table {
             type Value = $value;
             type SeekKey = $seek;
 
-            fn db_name(&self) -> &'static str  {
-               stringify!($name)
+            /// Return $name as it is present inside the database.
+            fn name(&self) -> &'static str {
+                $name::const_name()
             }
         }
 
         impl $name {
-            pub const  fn name() -> &'static str {
+            /// Return $name as it is present inside the database.
+            pub const fn const_name() -> &'static str {
                 stringify!($name)
             }
         }
@@ -72,7 +78,7 @@ table!(Transactions => TxId => RlpTxBody); // Canonical only
 table!(Receipts => TxId => Receipt); // Canonical only
 table!(Logs => TxId => Receipt); // Canonical only
 
-table!(PlainState => Address => Vec<u8>);
+table!(PlainState => PlainStateKey => Vec<u8>);
 
 table!(AccountHistory => Address => TxIdList);
 table!(StorageHistory => Address_StorageKey => TxIdList);
@@ -102,7 +108,6 @@ type BNum = u64; // TODO check size
 type TxId = u64; // TODO check size
 type HeaderHash = U256;
 type PlainStateKey = Address; // TODO new type will have to account for address_incarna_skey as well
-type AccountHistoryValue = Vec<u8>;
 type TxIdList = Vec<u8>;
 #[allow(non_camel_case_types)]
 type Address_StorageKey = Vec<u8>;

--- a/crates/db/src/kv/tables.rs
+++ b/crates/db/src/kv/tables.rs
@@ -1,3 +1,5 @@
+use reth_primitives::Address;
+
 #[macro_export]
 macro_rules! table {
     ($name:ident => $key:ty => $value:ty => $seek:ty) => {
@@ -14,6 +16,12 @@ macro_rules! table {
             }
         }
 
+        impl $name {
+            pub fn name() -> &'static str {
+                stringify!($name)
+            }
+        }
+
         impl std::fmt::Display for $name {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 write!(f, "{}", stringify!($name))
@@ -25,4 +33,5 @@ macro_rules! table {
     };
 }
 
-table!(Account => Vec<u8> => Vec<u8> => Vec<u8>);
+table!(Account => Address => Vec<u8>);
+table!(Storage => Address => Vec<u8>);

--- a/crates/db/src/kv/tx.rs
+++ b/crates/db/src/kv/tx.rs
@@ -30,7 +30,7 @@ impl<'env, K: TransactionKind, E: EnvironmentKind> Tx<'env, K, E> {
 
         Ok(Cursor {
             inner: self.inner.cursor(&self.inner.open_db(Some(table_name))?)?,
-            table: table_name.to_string(), // todo
+            table: table_name.to_string(), // TODO
             _dbi: PhantomData,
         })
     }
@@ -40,6 +40,10 @@ impl<'env, K: TransactionKind, E: EnvironmentKind> Tx<'env, K, E> {
             .get(&self.inner.open_db(Some(table.db_name()))?, key.encode().as_ref())?
             .map(decode_one::<T>)
             .transpose()
+    }
+
+    pub fn commit(self) -> eyre::Result<bool> {
+        self.inner.commit().map_err(From::from)
     }
 }
 
@@ -77,9 +81,5 @@ impl<'a, E: EnvironmentKind> Tx<'a, RW, E> {
         self.inner.clear_db(&self.inner.open_db(Some(table.db_name()))?)?;
 
         Ok(())
-    }
-
-    pub fn commit(self) -> eyre::Result<bool> {
-        self.inner.commit().map_err(From::from)
     }
 }

--- a/crates/db/src/kv/tx.rs
+++ b/crates/db/src/kv/tx.rs
@@ -41,7 +41,7 @@ impl<'env, K: TransactionKind, E: EnvironmentKind> Tx<'env, K, E> {
 
         Ok(Cursor {
             inner: self.inner.cursor(&self.inner.open_db(Some(table_name))?)?,
-            table: table_name.to_string(), // TODO
+            table: table_name,
             _dbi: PhantomData,
         })
     }

--- a/crates/db/src/kv/tx.rs
+++ b/crates/db/src/kv/tx.rs
@@ -1,6 +1,9 @@
-use crate::kv::{
-    cursor::{decode_one, Cursor},
-    table::{Encode, Table},
+use crate::{
+    kv::{
+        cursor::Cursor,
+        table::{Encode, Table},
+    },
+    utils::decode_one,
 };
 use libmdbx::{EnvironmentKind, Transaction, TransactionKind, WriteFlags, RW};
 use std::marker::PhantomData;

--- a/crates/db/src/kv/tx.rs
+++ b/crates/db/src/kv/tx.rs
@@ -79,7 +79,8 @@ impl<'a, E: EnvironmentKind> Tx<'a, RW, E> {
             .map_err(KVError::Put)
     }
 
-    /// Deletes the `(key, value)` entry on `table`.
+    /// Deletes the `(key, value)` entry on `table`. When `value` is `None`, all entries with `key`
+    /// are to be deleted. Otherwise, only the item matching that data shall be.
     pub fn delete<T>(&self, table: T, key: T::Key, value: Option<T::Value>) -> Result<bool, KVError>
     where
         T: Table,

--- a/crates/db/src/kv/tx.rs
+++ b/crates/db/src/kv/tx.rs
@@ -1,0 +1,85 @@
+use crate::kv::{
+    cursor::{decode_one, Cursor},
+    table::{Encode, Table},
+};
+use libmdbx::{EnvironmentKind, Transaction, TransactionKind, WriteFlags, RW};
+use std::marker::PhantomData;
+
+pub struct Tx<'a, K: TransactionKind, E: EnvironmentKind> {
+    pub inner: Transaction<'a, K, E>,
+}
+
+impl<'env, K: TransactionKind, E: EnvironmentKind> Tx<'env, K, E> {
+    pub fn new<'a>(inner: Transaction<'a, K, E>) -> Self
+    where
+        'a: 'env,
+    {
+        Self { inner }
+    }
+
+    pub fn id(&self) -> u64 {
+        self.inner.id()
+    }
+
+    pub fn cursor<'a, T: Table>(&'a self, table: T) -> eyre::Result<Cursor<'a, K, T>>
+    where
+        'env: 'a,
+        T: Table,
+    {
+        let table_name = table.db_name();
+
+        Ok(Cursor {
+            inner: self.inner.cursor(&self.inner.open_db(Some(table_name))?)?,
+            table: table_name.to_string(), // todo
+            _dbi: PhantomData,
+        })
+    }
+
+    pub fn get<T: Table>(&self, table: T, key: T::Key) -> eyre::Result<Option<T::Value>> {
+        self.inner
+            .get(&self.inner.open_db(Some(table.db_name()))?, key.encode().as_ref())?
+            .map(decode_one::<T>)
+            .transpose()
+    }
+}
+
+impl<'a, E: EnvironmentKind> Tx<'a, RW, E> {
+    pub fn put<T>(&self, table: T, k: T::Key, v: T::Value) -> eyre::Result<()>
+    where
+        T: Table,
+    {
+        Ok(self.inner.put(
+            &self.inner.open_db(Some(table.db_name()))?,
+            &k.encode(),
+            &v.encode(),
+            WriteFlags::UPSERT,
+        )?)
+    }
+
+    pub fn delete<T>(&self, table: T, key: T::Key, value: Option<T::Value>) -> eyre::Result<bool>
+    where
+        T: Table,
+    {
+        let mut data = None;
+
+        let value = value.map(Encode::encode);
+        if let Some(value) = &value {
+            data = Some(value.as_ref());
+        };
+
+        Ok(self.inner.del(&self.inner.open_db(Some(table.db_name()))?, key.encode(), data)?)
+    }
+
+    pub fn clear<T>(&self, table: T) -> eyre::Result<()>
+    where
+        T: Table,
+    {
+        self.inner.clear_db(&self.inner.open_db(Some(table.db_name()))?)?;
+
+        Ok(())
+    }
+
+    pub fn commit(self) -> eyre::Result<bool> {
+        self.inner.commit().map_err(From::from)
+    }
+}

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -6,7 +6,6 @@
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
 ))]
-//! DB primitives for reth.
 
 /// Rust bindings for [MDBX](https://libmdbx.dqdkfa.ru/).
 pub mod mdbx {

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -12,3 +12,6 @@
 pub mod mdbx {
     pub use libmdbx::*;
 }
+
+mod kv;
+mod utils;

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -1,17 +1,12 @@
+//! Module that interacts with MDBX.
+
 #![warn(missing_debug_implementations, missing_docs, unreachable_pub)]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![doc(test(
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
 ))]
+//! DB primitives for reth.
 
-//! Database bindings for reth.
-// TODO: Actually provide database bindings. For now, this is just a re-export of MDBX.
-
-/// Rust bindings for [MDBX](https://libmdbx.dqdkfa.ru/).
-pub mod mdbx {
-    pub use libmdbx::*;
-}
-
-mod kv;
+pub mod kv;
 mod utils;

--- a/crates/db/src/utils.rs
+++ b/crates/db/src/utils.rs
@@ -1,4 +1,4 @@
-pub const TEMP_PLACEHOLDER_NUM_TABLES: usize = 10;
+pub const TEMP_PLACEHOLDER_NUM_TABLES: usize = 2;
 
 /// Returns the default page size that can be used in this OS.
 pub fn default_page_size() -> usize {

--- a/crates/db/src/utils.rs
+++ b/crates/db/src/utils.rs
@@ -1,4 +1,5 @@
-pub const TEMP_PLACEHOLDER_NUM_TABLES: usize = 2;
+use crate::kv::table::{Decode, Table};
+use std::borrow::Cow;
 
 /// Returns the default page size that can be used in this OS.
 pub fn default_page_size() -> usize {
@@ -13,4 +14,29 @@ pub fn default_page_size() -> usize {
     } else {
         os_page_size
     }
+}
+
+/// Helper function to decode a `(key, value)` pair.
+pub fn decoder<'a, T>(kv: (Cow<'a, [u8]>, Cow<'a, [u8]>)) -> eyre::Result<(T::Key, T::Value)>
+where
+    T: Table,
+    T::Key: Decode,
+{
+    Ok((Decode::decode(&kv.0)?, Decode::decode(&kv.1)?))
+}
+
+/// Helper function to decode only a value from a `(key, value)` pair.
+pub fn decode_value<'a, T>(kv: (Cow<'a, [u8]>, Cow<'a, [u8]>)) -> eyre::Result<T::Value>
+where
+    T: Table,
+{
+    Decode::decode(&kv.1)
+}
+
+/// Helper function to decode a value. It can be a key or subkey.
+pub fn decode_one<'a, T>(value: Cow<'a, [u8]>) -> eyre::Result<T::Value>
+where
+    T: Table,
+{
+    Decode::decode(&value)
 }

--- a/crates/db/src/utils.rs
+++ b/crates/db/src/utils.rs
@@ -1,13 +1,19 @@
 use crate::kv::table::{Decode, Table};
 use std::borrow::Cow;
 
+/// Enum for the type of table present in libmdbx.
+pub enum TableType {
+    Table,
+    DupSort,
+}
+
 /// Returns the default page size that can be used in this OS.
 pub fn default_page_size() -> usize {
     let os_page_size = page_size::get();
     let libmdbx_max_page_size = 0x10000;
 
     if os_page_size < 4096 {
-        // may lead to errors if it's reduced further because of the potential size of the data
+        // May lead to errors if it's reduced further because of the potential size of the data.
         4096
     } else if os_page_size > libmdbx_max_page_size {
         libmdbx_max_page_size

--- a/crates/db/src/utils.rs
+++ b/crates/db/src/utils.rs
@@ -1,0 +1,16 @@
+pub const TEMP_PLACEHOLDER_NUM_TABLES: usize = 10;
+
+/// Returns the default page size that can be used in this OS.
+pub fn default_page_size() -> usize {
+    let os_page_size = page_size::get();
+    let libmdbx_max_page_size = 0x10000;
+
+    if os_page_size < 4096 {
+        // may lead to errors if it's reduced further because of the potential size of the data
+        4096
+    } else if os_page_size > libmdbx_max_page_size {
+        libmdbx_max_page_size
+    } else {
+        os_page_size
+    }
+}

--- a/crates/db/src/utils.rs
+++ b/crates/db/src/utils.rs
@@ -1,6 +1,9 @@
 //! Utils crate for `db`.
 
-use crate::kv::table::{Decode, Table};
+use crate::kv::{
+    table::{Decode, Table},
+    KVError,
+};
 use std::borrow::Cow;
 
 /// Enum for the type of table present in libmdbx.
@@ -26,7 +29,9 @@ pub(crate) fn default_page_size() -> usize {
 }
 
 /// Helper function to decode a `(key, value)` pair.
-pub(crate) fn decoder<'a, T>(kv: (Cow<'a, [u8]>, Cow<'a, [u8]>)) -> eyre::Result<(T::Key, T::Value)>
+pub(crate) fn decoder<'a, T>(
+    kv: (Cow<'a, [u8]>, Cow<'a, [u8]>),
+) -> Result<(T::Key, T::Value), KVError>
 where
     T: Table,
     T::Key: Decode,
@@ -35,7 +40,7 @@ where
 }
 
 /// Helper function to decode only a value from a `(key, value)` pair.
-pub(crate) fn decode_value<'a, T>(kv: (Cow<'a, [u8]>, Cow<'a, [u8]>)) -> eyre::Result<T::Value>
+pub(crate) fn decode_value<'a, T>(kv: (Cow<'a, [u8]>, Cow<'a, [u8]>)) -> Result<T::Value, KVError>
 where
     T: Table,
 {
@@ -43,7 +48,7 @@ where
 }
 
 /// Helper function to decode a value. It can be a key or subkey.
-pub(crate) fn decode_one<T>(value: Cow<'_, [u8]>) -> eyre::Result<T::Value>
+pub(crate) fn decode_one<T>(value: Cow<'_, [u8]>) -> Result<T::Value, KVError>
 where
     T: Table,
 {

--- a/crates/db/src/utils.rs
+++ b/crates/db/src/utils.rs
@@ -16,6 +16,8 @@ pub enum TableType {
 /// Returns the default page size that can be used in this OS.
 pub(crate) fn default_page_size() -> usize {
     let os_page_size = page_size::get();
+
+    // source: https://gitflic.ru/project/erthink/libmdbx/blob?file=mdbx.h#line-num-821
     let libmdbx_max_page_size = 0x10000;
 
     // May lead to errors if it's reduced further because of the potential size of the

--- a/crates/db/src/utils.rs
+++ b/crates/db/src/utils.rs
@@ -18,14 +18,11 @@ pub(crate) fn default_page_size() -> usize {
     let os_page_size = page_size::get();
     let libmdbx_max_page_size = 0x10000;
 
-    if os_page_size < 4096 {
-        // May lead to errors if it's reduced further because of the potential size of the data.
-        4096
-    } else if os_page_size > libmdbx_max_page_size {
-        libmdbx_max_page_size
-    } else {
-        os_page_size
-    }
+    // May lead to errors if it's reduced further because of the potential size of the
+    // data.
+    let min_page_size = 4096;
+
+    os_page_size.clamp(min_page_size, libmdbx_max_page_size)
 }
 
 /// Helper function to decode a `(key, value)` pair.

--- a/crates/db/src/utils.rs
+++ b/crates/db/src/utils.rs
@@ -1,14 +1,17 @@
+//! Utils crate for `db`.
+
 use crate::kv::table::{Decode, Table};
 use std::borrow::Cow;
 
 /// Enum for the type of table present in libmdbx.
+#[derive(Debug)]
 pub enum TableType {
     Table,
     DupSort,
 }
 
 /// Returns the default page size that can be used in this OS.
-pub fn default_page_size() -> usize {
+pub(crate) fn default_page_size() -> usize {
     let os_page_size = page_size::get();
     let libmdbx_max_page_size = 0x10000;
 
@@ -23,7 +26,7 @@ pub fn default_page_size() -> usize {
 }
 
 /// Helper function to decode a `(key, value)` pair.
-pub fn decoder<'a, T>(kv: (Cow<'a, [u8]>, Cow<'a, [u8]>)) -> eyre::Result<(T::Key, T::Value)>
+pub(crate) fn decoder<'a, T>(kv: (Cow<'a, [u8]>, Cow<'a, [u8]>)) -> eyre::Result<(T::Key, T::Value)>
 where
     T: Table,
     T::Key: Decode,
@@ -32,7 +35,7 @@ where
 }
 
 /// Helper function to decode only a value from a `(key, value)` pair.
-pub fn decode_value<'a, T>(kv: (Cow<'a, [u8]>, Cow<'a, [u8]>)) -> eyre::Result<T::Value>
+pub(crate) fn decode_value<'a, T>(kv: (Cow<'a, [u8]>, Cow<'a, [u8]>)) -> eyre::Result<T::Value>
 where
     T: Table,
 {
@@ -40,7 +43,7 @@ where
 }
 
 /// Helper function to decode a value. It can be a key or subkey.
-pub fn decode_one<'a, T>(value: Cow<'a, [u8]>) -> eyre::Result<T::Value>
+pub(crate) fn decode_one<T>(value: Cow<'_, [u8]>) -> eyre::Result<T::Value>
 where
     T: Table,
 {


### PR DESCRIPTION
I think it's a good first step. 

Next follow-ups:
* Start implementing the actual model types alongside their encoders/decoders.
* Improve/add functions to access/manage libmdbx cursor as it is needed.
* page_size/sizes/ open params

Theoretically, you insert stuff already, as long as it is a `Vec<u8>`.  Check tests at `crates/db/src/kv/mod.rs`  and some table declarations at `crates/db/src/kv/tables.rs`   