### PR TITLE
feat(primitives): add Chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
  "chrono",
  "elliptic-curve",
  "ethabi",
- "fastrlp",
+ "fastrlp 0.1.3",
  "generic-array",
  "hex",
  "k256",
@@ -436,6 +436,17 @@ dependencies = [
  "bytes",
  "ethereum-types",
  "fastrlp-derive",
+]
+
+[[package]]
+name = "fastrlp"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9244dd9f0a2b54815814926640439146f469837ec4141e33354b6b258a0493"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
 ]
 
 [[package]]
@@ -1434,6 +1445,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "ethers-core",
+ "fastrlp 0.2.0",
 ]
 
 [[package]]
@@ -1461,7 +1473,7 @@ dependencies = [
 name = "reth-rpc-types"
 version = "0.1.0"
 dependencies = [
- "fastrlp",
+ "fastrlp 0.1.3",
  "reth-primitives",
  "serde",
  "serde_json",

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -8,5 +8,6 @@ readme = "README.md"
 description = "Commonly used types in reth."
 
 [dependencies]
+fastrlp = { version = "0.2.0" }
 ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 bytes = "1.2"

--- a/crates/primitives/src/chain.rs
+++ b/crates/primitives/src/chain.rs
@@ -1,0 +1,138 @@
+use crate::U256;
+use ethers_core::types::{ParseChainError, U64};
+use fastrlp::{Decodable, Encodable};
+use std::{fmt, str::FromStr};
+
+/// Either a named or chain id or the actual id value
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Chain {
+    /// Contains a known chain
+    Named(ethers_core::types::Chain),
+    /// Contains the id of a chain
+    Id(u64),
+}
+
+impl Chain {
+    /// The id of the chain
+    pub fn id(&self) -> u64 {
+        match self {
+            Chain::Named(chain) => *chain as u64,
+            Chain::Id(id) => *id,
+        }
+    }
+
+    /// Helper function for checking if a chainid corresponds to a legacy chainid
+    /// without eip1559
+    pub fn is_legacy(&self) -> bool {
+        match self {
+            Chain::Named(c) => c.is_legacy(),
+            Chain::Id(_) => false,
+        }
+    }
+}
+
+impl fmt::Display for Chain {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Chain::Named(chain) => chain.fmt(f),
+            Chain::Id(id) => {
+                if let Ok(chain) = ethers_core::types::Chain::try_from(*id) {
+                    chain.fmt(f)
+                } else {
+                    id.fmt(f)
+                }
+            }
+        }
+    }
+}
+
+impl From<ethers_core::types::Chain> for Chain {
+    fn from(id: ethers_core::types::Chain) -> Self {
+        Chain::Named(id)
+    }
+}
+
+impl From<u64> for Chain {
+    fn from(id: u64) -> Self {
+        ethers_core::types::Chain::try_from(id).map(Chain::Named).unwrap_or_else(|_| Chain::Id(id))
+    }
+}
+
+impl From<U256> for Chain {
+    fn from(id: U256) -> Self {
+        id.as_u64().into()
+    }
+}
+
+impl From<Chain> for u64 {
+    fn from(c: Chain) -> Self {
+        match c {
+            Chain::Named(c) => c as u64,
+            Chain::Id(id) => id,
+        }
+    }
+}
+
+impl From<Chain> for U64 {
+    fn from(c: Chain) -> Self {
+        u64::from(c).into()
+    }
+}
+
+impl From<Chain> for U256 {
+    fn from(c: Chain) -> Self {
+        u64::from(c).into()
+    }
+}
+
+impl TryFrom<Chain> for ethers_core::types::Chain {
+    type Error = ParseChainError;
+
+    fn try_from(chain: Chain) -> Result<Self, Self::Error> {
+        match chain {
+            Chain::Named(chain) => Ok(chain),
+            Chain::Id(id) => id.try_into(),
+        }
+    }
+}
+
+impl FromStr for Chain {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(chain) = ethers_core::types::Chain::from_str(s) {
+            Ok(Chain::Named(chain))
+        } else {
+            s.parse::<u64>()
+                .map(Chain::Id)
+                .map_err(|_| format!("Expected known chain or integer, found: {s}"))
+        }
+    }
+}
+
+impl Encodable for Chain {
+    fn length(&self) -> usize {
+        match self {
+            Self::Named(chain) => u64::from(*chain).length(),
+            Self::Id(id) => id.length(),
+        }
+    }
+    fn encode(&self, out: &mut dyn fastrlp::BufMut) {
+        match self {
+            Self::Named(chain) => u64::from(*chain).encode(out),
+            Self::Id(id) => id.encode(out),
+        }
+    }
+}
+
+impl Decodable for Chain {
+    fn decode(buf: &mut &[u8]) -> Result<Self, fastrlp::DecodeError> {
+        Ok(u64::decode(buf)?.into())
+    }
+}
+
+impl Default for Chain {
+    fn default() -> Self {
+        ethers_core::types::Chain::Mainnet.into()
+    }
+}

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -8,6 +8,7 @@
 //! Commonly used types in reth.
 
 mod block;
+mod chain;
 mod header;
 mod log;
 mod receipt;


### PR DESCRIPTION
Adds a `Chain` type, copypasta'd from `foundry_config::Chain`. This is necessary for the `Status` type used in p2p.
Also adds `fastrlp` to deps.