### PR TITLE
feat: add eth-wire

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,33 +421,6 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ebdd63c828f58aa067f40f9adcbea5e114fb1f90144b3a1e2858e0c9b1ff4e8"
-dependencies = [
- "arrayvec",
- "bytes",
- "chrono",
- "elliptic-curve",
- "ethabi",
- "fastrlp 0.1.3",
- "generic-array",
- "hex",
- "k256",
- "rand",
- "rlp",
- "rlp-derive",
- "rust_decimal",
- "serde",
- "serde_json",
- "strum",
- "thiserror",
- "tiny-keccak",
- "unicode-xid",
-]
-
-[[package]]
-name = "ethers-core"
-version = "0.17.0"
 source = "git+https://github.com/gakonst/ethers-rs#f3a5a7aef06db391f8d2c4370bbc2a1b6ae4ea0f"
 dependencies = [
  "arrayvec",
@@ -1524,7 +1497,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "ethereum-forkid",
- "ethers-core 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-core",
  "fastrlp 0.2.0",
  "hex",
  "hex-literal",
@@ -1564,7 +1537,7 @@ name = "reth-primitives"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "ethers-core 0.17.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core",
  "fastrlp 0.2.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "build_const"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
+
+[[package]]
 name = "byte-slice-cast"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +248,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
+dependencies = [
+ "build_const",
 ]
 
 [[package]]
@@ -370,10 +385,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11da94e443c60508eb62cf256243a64da87304c2802ac2528847f79d750007ef"
 dependencies = [
  "crunchy",
- "fixed-hash",
+ "fixed-hash 0.7.0",
  "impl-rlp",
  "impl-serde",
  "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum-forkid"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e61cdc29def2ba89221f2e72c8a31c6413655122d29a8dd69749b8492c80c5"
+dependencies = [
+ "crc",
+ "fastrlp 0.2.0",
+ "maplit",
+ "primitive-types 0.12.0",
+ "thiserror",
 ]
 
 [[package]]
@@ -383,10 +411,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2827b94c556145446fcce834ca86b7abf0c39a805883fe20e72c5bfdb5a0dc6"
 dependencies = [
  "ethbloom",
- "fixed-hash",
+ "fixed-hash 0.7.0",
  "impl-rlp",
  "impl-serde",
- "primitive-types",
+ "primitive-types 0.11.1",
  "uint",
 ]
 
@@ -447,6 +475,7 @@ dependencies = [
  "arrayvec",
  "auto_impl",
  "bytes",
+ "fastrlp-derive",
 ]
 
 [[package]]
@@ -480,6 +509,15 @@ dependencies = [
  "byteorder",
  "rand",
  "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
  "static_assertions",
 ]
 
@@ -683,6 +721,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-literal"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "hmac"
@@ -1013,6 +1057,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "mdbx-sys"
 version = "0.12.1-0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1285,10 +1335,20 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e28720988bff275df1f51b171e1b2a18c30d194c4d2b61defdacecd625a5d94a"
 dependencies = [
- "fixed-hash",
+ "fixed-hash 0.7.0",
  "impl-codec",
  "impl-rlp",
  "impl-serde",
+ "uint",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cfd65aea0c5fa0bfcc7c9e7ca828c921ef778f43d325325ec84bda371bfa75a"
+dependencies = [
+ "fixed-hash 0.8.0",
  "uint",
 ]
 
@@ -1432,6 +1492,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-eth-wire"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "ethereum-forkid",
+ "fastrlp 0.2.0",
+ "hex",
+ "hex-literal",
+ "reth-primitives",
+ "ruint",
+ "thiserror",
+]
+
+[[package]]
 name = "reth-executor"
 version = "0.1.0"
 dependencies = [
@@ -1538,7 +1612,7 @@ dependencies = [
  "bytes",
  "hashbrown",
  "num_enum",
- "primitive-types",
+ "primitive-types 0.11.1",
  "revm_precompiles",
  "rlp",
  "sha3",
@@ -1554,7 +1628,7 @@ dependencies = [
  "hashbrown",
  "num",
  "once_cell",
- "primitive-types",
+ "primitive-types 0.11.1",
  "ripemd",
  "secp256k1",
  "sha2",
@@ -1602,6 +1676,25 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "ruint"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea68c70fa2b6ce8f8b656e9d3d64776b7ced5b235bb93bb9fee560bf2381196"
+dependencies = [
+ "fastrlp 0.2.0",
+ "ruint-macro",
+ "rustc_version",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4bb0fa2c9df745e5ebf08fb033655b5fba6511a3e6e82b68f5053963e267755"
 
 [[package]]
 name = "rust_decimal"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,7 +385,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11da94e443c60508eb62cf256243a64da87304c2802ac2528847f79d750007ef"
 dependencies = [
  "crunchy",
- "fixed-hash 0.7.0",
+ "fixed-hash",
  "impl-rlp",
  "impl-serde",
  "tiny-keccak",
@@ -393,14 +393,14 @@ dependencies = [
 
 [[package]]
 name = "ethereum-forkid"
-version = "0.11.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e61cdc29def2ba89221f2e72c8a31c6413655122d29a8dd69749b8492c80c5"
+checksum = "70b823f6b913b97e58a2bd67a7beeb48b0338d4aa8e3cc21d9cdab457716e4d4"
 dependencies = [
  "crc",
- "fastrlp 0.2.0",
+ "fastrlp",
  "maplit",
- "primitive-types 0.12.0",
+ "primitive-types",
  "thiserror",
 ]
 
@@ -411,10 +411,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2827b94c556145446fcce834ca86b7abf0c39a805883fe20e72c5bfdb5a0dc6"
 dependencies = [
  "ethbloom",
- "fixed-hash 0.7.0",
+ "fixed-hash",
  "impl-rlp",
  "impl-serde",
- "primitive-types 0.11.1",
+ "primitive-types",
  "uint",
 ]
 
@@ -428,7 +428,7 @@ dependencies = [
  "chrono",
  "elliptic-curve",
  "ethabi",
- "fastrlp 0.1.3",
+ "fastrlp",
  "generic-array",
  "hex",
  "k256",
@@ -467,18 +467,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrlp"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9244dd9f0a2b54815814926640439146f469837ec4141e33354b6b258a0493"
-dependencies = [
- "arrayvec",
- "auto_impl",
- "bytes",
- "fastrlp-derive",
-]
-
-[[package]]
 name = "fastrlp-derive"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,15 +497,6 @@ dependencies = [
  "byteorder",
  "rand",
  "rustc-hex",
- "static_assertions",
-]
-
-[[package]]
-name = "fixed-hash"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
-dependencies = [
  "static_assertions",
 ]
 
@@ -1335,20 +1314,10 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e28720988bff275df1f51b171e1b2a18c30d194c4d2b61defdacecd625a5d94a"
 dependencies = [
- "fixed-hash 0.7.0",
+ "fixed-hash",
  "impl-codec",
  "impl-rlp",
  "impl-serde",
- "uint",
-]
-
-[[package]]
-name = "primitive-types"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cfd65aea0c5fa0bfcc7c9e7ca828c921ef778f43d325325ec84bda371bfa75a"
-dependencies = [
- "fixed-hash 0.8.0",
  "uint",
 ]
 
@@ -1498,7 +1467,7 @@ dependencies = [
  "bytes",
  "ethereum-forkid",
  "ethers-core",
- "fastrlp 0.2.0",
+ "fastrlp",
  "hex",
  "hex-literal",
  "reth-primitives",
@@ -1537,7 +1506,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "ethers-core",
- "fastrlp 0.2.0",
+ "fastrlp",
 ]
 
 [[package]]
@@ -1565,7 +1534,7 @@ dependencies = [
 name = "reth-rpc-types"
 version = "0.1.0"
 dependencies = [
- "fastrlp 0.1.3",
+ "fastrlp",
  "reth-primitives",
  "serde",
  "serde_json",
@@ -1612,7 +1581,7 @@ dependencies = [
  "bytes",
  "hashbrown",
  "num_enum",
- "primitive-types 0.11.1",
+ "primitive-types",
  "revm_precompiles",
  "rlp",
  "sha3",
@@ -1628,7 +1597,7 @@ dependencies = [
  "hashbrown",
  "num",
  "once_cell",
- "primitive-types 0.11.1",
+ "primitive-types",
  "ripemd",
  "secp256k1",
  "sha2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,7 +1502,6 @@ dependencies = [
  "hex",
  "hex-literal",
  "reth-primitives",
- "ruint",
  "thiserror",
 ]
 
@@ -1677,25 +1676,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "ruint"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea68c70fa2b6ce8f8b656e9d3d64776b7ced5b235bb93bb9fee560bf2381196"
-dependencies = [
- "fastrlp 0.2.0",
- "ruint-macro",
- "rustc_version",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "ruint-macro"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4bb0fa2c9df745e5ebf08fb033655b5fba6511a3e6e82b68f5053963e267755"
 
 [[package]]
 name = "rust_decimal"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,6 +421,33 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ebdd63c828f58aa067f40f9adcbea5e114fb1f90144b3a1e2858e0c9b1ff4e8"
+dependencies = [
+ "arrayvec",
+ "bytes",
+ "chrono",
+ "elliptic-curve",
+ "ethabi",
+ "fastrlp 0.1.3",
+ "generic-array",
+ "hex",
+ "k256",
+ "rand",
+ "rlp",
+ "rlp-derive",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "strum",
+ "thiserror",
+ "tiny-keccak",
+ "unicode-xid",
+]
+
+[[package]]
+name = "ethers-core"
+version = "0.17.0"
 source = "git+https://github.com/gakonst/ethers-rs#f3a5a7aef06db391f8d2c4370bbc2a1b6ae4ea0f"
 dependencies = [
  "arrayvec",
@@ -1497,6 +1524,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "ethereum-forkid",
+ "ethers-core 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fastrlp 0.2.0",
  "hex",
  "hex-literal",
@@ -1536,7 +1564,7 @@ name = "reth-primitives"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "ethers-core",
+ "ethers-core 0.17.0 (git+https://github.com/gakonst/ethers-rs)",
  "fastrlp 0.2.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/executor",
     "crates/interfaces",
     "crates/net/p2p",
+    "crates/net/eth-wire",
     "crates/net/rpc",
     "crates/net/rpc-api",
     "crates/net/rpc-types",

--- a/crates/net/eth-wire/Cargo.toml
+++ b/crates/net/eth-wire/Cargo.toml
@@ -19,3 +19,4 @@ reth-primitives = { path = "../../primitives" }
 
 [dev-dependencies]
 hex-literal = "0.3"
+ethers-core = "0.17.0"

--- a/crates/net/eth-wire/Cargo.toml
+++ b/crates/net/eth-wire/Cargo.toml
@@ -8,8 +8,10 @@ readme = "README.md"
 
 [dependencies]
 bytes = { version = "1.1" }
-fastrlp = { version = "0.2", features = ["alloc", "derive", "std"] }
-ethereum-forkid = "0.11"
+
+# can remove these restrictions once ethereum-types is bumped across the board
+fastrlp = { version = "0.1.3", features = ["alloc", "derive", "std", "ethereum-types"] }
+ethereum-forkid = "=0.10"
 hex = "0.4"
 thiserror = "1"
 

--- a/crates/net/eth-wire/Cargo.toml
+++ b/crates/net/eth-wire/Cargo.toml
@@ -19,4 +19,4 @@ reth-primitives = { path = "../../primitives" }
 
 [dev-dependencies]
 hex-literal = "0.3"
-ethers-core = "0.17.0"
+ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }

--- a/crates/net/eth-wire/Cargo.toml
+++ b/crates/net/eth-wire/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "reth-eth-wire"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/foundry-rs/reth"
+readme = "README.md"
+
+[dependencies]
+bytes = { version = "1.1" }
+fastrlp = { version = "0.2", features = ["alloc", "derive", "std"] }
+ruint = { version = "1.3", features = ["fastrlp", "serde"] }
+ethereum-forkid = "0.11"
+hex = "0.4"
+thiserror = "1"
+
+# reth
+reth-primitives = { path = "../../primitives" }
+
+[dev-dependencies]
+hex-literal = "0.3"

--- a/crates/net/eth-wire/Cargo.toml
+++ b/crates/net/eth-wire/Cargo.toml
@@ -9,7 +9,6 @@ readme = "README.md"
 [dependencies]
 bytes = { version = "1.1" }
 fastrlp = { version = "0.2", features = ["alloc", "derive", "std"] }
-ruint = { version = "1.3", features = ["fastrlp", "serde"] }
 ethereum-forkid = "0.11"
 hex = "0.4"
 thiserror = "1"

--- a/crates/net/eth-wire/src/lib.rs
+++ b/crates/net/eth-wire/src/lib.rs
@@ -9,3 +9,6 @@
 
 mod status;
 pub use status::Status;
+
+mod version;
+pub use version::EthVersion;

--- a/crates/net/eth-wire/src/lib.rs
+++ b/crates/net/eth-wire/src/lib.rs
@@ -1,0 +1,11 @@
+#![warn(missing_docs, unreachable_pub)]
+#![deny(unused_must_use, rust_2018_idioms)]
+#![doc(test(
+    no_crate_inject,
+    attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
+))]
+
+//! Types for the eth wire protocol.
+
+mod status;
+pub use status::Status;

--- a/crates/net/eth-wire/src/status.rs
+++ b/crates/net/eth-wire/src/status.rs
@@ -1,6 +1,6 @@
 use ethereum_forkid::ForkId;
 use fastrlp::{RlpDecodable, RlpEncodable};
-use reth_primitives::{U256, Chain, H256};
+use reth_primitives::{Chain, H256, U256};
 use std::fmt::{Debug, Display};
 
 /// The status message is used in the eth protocol handshake to ensure that peers are on the same
@@ -92,7 +92,7 @@ mod tests {
     use ethers_core::types::Chain as NamedChain;
     use fastrlp::{Decodable, Encodable};
     use hex_literal::hex;
-    use reth_primitives::{Chain, U256, H256};
+    use reth_primitives::{Chain, H256, U256};
 
     use crate::{EthVersion, Status};
 
@@ -103,8 +103,14 @@ mod tests {
             version: EthVersion::Eth67 as u8,
             chain: Chain::Named(NamedChain::Mainnet),
             total_difficulty: U256::from(36206751599115524359527u128),
-            blockhash: H256::from_str("feb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13d").unwrap(),
-            genesis: H256::from_str("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3").unwrap(),
+            blockhash: H256::from_str(
+                "feb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13d",
+            )
+            .unwrap(),
+            genesis: H256::from_str(
+                "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3",
+            )
+            .unwrap(),
             forkid: ForkId { hash: ForkHash([0xb7, 0x15, 0x07, 0x7d]), next: 0 },
         };
 
@@ -120,8 +126,14 @@ mod tests {
             version: EthVersion::Eth67 as u8,
             chain: Chain::Named(NamedChain::Mainnet),
             total_difficulty: U256::from(36206751599115524359527u128),
-            blockhash: H256::from_str("feb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13d").unwrap(),
-            genesis: H256::from_str("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3").unwrap(),
+            blockhash: H256::from_str(
+                "feb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13d",
+            )
+            .unwrap(),
+            genesis: H256::from_str(
+                "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3",
+            )
+            .unwrap(),
             forkid: ForkId { hash: ForkHash([0xb7, 0x15, 0x07, 0x7d]), next: 0 },
         };
         let status = Status::decode(&mut &data[..]).unwrap();
@@ -135,8 +147,14 @@ mod tests {
             version: EthVersion::Eth66 as u8,
             chain: Chain::Named(NamedChain::BinanceSmartChain),
             total_difficulty: U256::from(37851386u64),
-            blockhash: H256::from_str("f8514c4680ef27700751b08f37645309ce65a449616a3ea966bf39dd935bb27b").unwrap(),
-            genesis: H256::from_str("0d21840abff46b96c84b2ac9e10e4f5cdaeb5693cb665db62a2f3b02d2d57b5b").unwrap(),
+            blockhash: H256::from_str(
+                "f8514c4680ef27700751b08f37645309ce65a449616a3ea966bf39dd935bb27b",
+            )
+            .unwrap(),
+            genesis: H256::from_str(
+                "0d21840abff46b96c84b2ac9e10e4f5cdaeb5693cb665db62a2f3b02d2d57b5b",
+            )
+            .unwrap(),
             forkid: ForkId { hash: ForkHash([0x5d, 0x43, 0xd2, 0xfd]), next: 0 },
         };
 
@@ -152,8 +170,14 @@ mod tests {
             version: EthVersion::Eth66 as u8,
             chain: Chain::Named(NamedChain::BinanceSmartChain),
             total_difficulty: U256::from(37851386u64),
-            blockhash: H256::from_str("f8514c4680ef27700751b08f37645309ce65a449616a3ea966bf39dd935bb27b").unwrap(),
-            genesis: H256::from_str("0d21840abff46b96c84b2ac9e10e4f5cdaeb5693cb665db62a2f3b02d2d57b5b").unwrap(),
+            blockhash: H256::from_str(
+                "f8514c4680ef27700751b08f37645309ce65a449616a3ea966bf39dd935bb27b",
+            )
+            .unwrap(),
+            genesis: H256::from_str(
+                "0d21840abff46b96c84b2ac9e10e4f5cdaeb5693cb665db62a2f3b02d2d57b5b",
+            )
+            .unwrap(),
             forkid: ForkId { hash: ForkHash([0x5d, 0x43, 0xd2, 0xfd]), next: 0 },
         };
         let status = Status::decode(&mut &data[..]).unwrap();
@@ -170,8 +194,14 @@ mod tests {
                 "0x000000000000000000000000006d68fcffffffffffffffffffffffffdeab81b8",
             )
             .unwrap(),
-            blockhash: H256::from_str("523e8163a6d620a4cc152c547a05f28a03fec91a2a615194cb86df9731372c0c").unwrap(),
-            genesis: H256::from_str("6499dccdc7c7def3ebb1ce4c6ee27ec6bd02aee570625ca391919faf77ef27bd").unwrap(),
+            blockhash: H256::from_str(
+                "523e8163a6d620a4cc152c547a05f28a03fec91a2a615194cb86df9731372c0c",
+            )
+            .unwrap(),
+            genesis: H256::from_str(
+                "6499dccdc7c7def3ebb1ce4c6ee27ec6bd02aee570625ca391919faf77ef27bd",
+            )
+            .unwrap(),
             forkid: ForkId { hash: ForkHash([0x1a, 0x67, 0xcc, 0xd8]), next: 0 },
         };
         let status = Status::decode(&mut &data[..]).unwrap();

--- a/crates/net/eth-wire/src/status.rs
+++ b/crates/net/eth-wire/src/status.rs
@@ -1,7 +1,6 @@
 use ethereum_forkid::ForkId;
 use fastrlp::{RlpDecodable, RlpEncodable};
-use reth_primitives::Chain;
-use ruint::Uint;
+use reth_primitives::{U256, Chain, H256};
 use std::fmt::{Debug, Display};
 
 /// The status message is used in the eth protocol handshake to ensure that peers are on the same
@@ -22,13 +21,13 @@ pub struct Status {
     pub chain: Chain,
 
     /// Total difficulty of the best chain.
-    pub total_difficulty: Uint<256, 4>,
+    pub total_difficulty: U256,
 
     /// The highest difficulty block hash the peer has seen
-    pub blockhash: [u8; 32],
+    pub blockhash: H256,
 
     /// The genesis hash of the peer's chain.
-    pub genesis: [u8; 32],
+    pub genesis: H256,
 
     /// The fork identifier, a [CRC32
     /// checksum](https://en.wikipedia.org/wiki/Cyclic_redundancy_check#CRC-32_algorithm) for
@@ -38,8 +37,6 @@ pub struct Status {
     pub forkid: ForkId,
 }
 
-// TODO: Determine if it's worth wrapping or aliasing [u8; 32] across these types, to help derive
-// traits like this rather than having to manually implement them.
 impl Display for Status {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let hexed_blockhash = hex::encode(self.blockhash);
@@ -95,8 +92,7 @@ mod tests {
     use ethers_core::types::Chain as NamedChain;
     use fastrlp::{Decodable, Encodable};
     use hex_literal::hex;
-    use reth_primitives::Chain;
-    use ruint::Uint;
+    use reth_primitives::{Chain, U256, H256};
 
     use crate::{EthVersion, Status};
 
@@ -106,9 +102,9 @@ mod tests {
         let status = Status {
             version: EthVersion::Eth67 as u8,
             chain: Chain::Named(NamedChain::Mainnet),
-            total_difficulty: Uint::from(36206751599115524359527u128),
-            blockhash: hex!("feb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13d"),
-            genesis: hex!("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"),
+            total_difficulty: U256::from(36206751599115524359527u128),
+            blockhash: H256::from_str("feb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13d").unwrap(),
+            genesis: H256::from_str("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3").unwrap(),
             forkid: ForkId { hash: ForkHash([0xb7, 0x15, 0x07, 0x7d]), next: 0 },
         };
 
@@ -123,9 +119,9 @@ mod tests {
         let expected = Status {
             version: EthVersion::Eth67 as u8,
             chain: Chain::Named(NamedChain::Mainnet),
-            total_difficulty: Uint::from(36206751599115524359527u128),
-            blockhash: hex!("feb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13d"),
-            genesis: hex!("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"),
+            total_difficulty: U256::from(36206751599115524359527u128),
+            blockhash: H256::from_str("feb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13d").unwrap(),
+            genesis: H256::from_str("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3").unwrap(),
             forkid: ForkId { hash: ForkHash([0xb7, 0x15, 0x07, 0x7d]), next: 0 },
         };
         let status = Status::decode(&mut &data[..]).unwrap();
@@ -138,9 +134,9 @@ mod tests {
         let status = Status {
             version: EthVersion::Eth66 as u8,
             chain: Chain::Named(NamedChain::BinanceSmartChain),
-            total_difficulty: Uint::from(37851386u64),
-            blockhash: hex!("f8514c4680ef27700751b08f37645309ce65a449616a3ea966bf39dd935bb27b"),
-            genesis: hex!("0d21840abff46b96c84b2ac9e10e4f5cdaeb5693cb665db62a2f3b02d2d57b5b"),
+            total_difficulty: U256::from(37851386u64),
+            blockhash: H256::from_str("f8514c4680ef27700751b08f37645309ce65a449616a3ea966bf39dd935bb27b").unwrap(),
+            genesis: H256::from_str("0d21840abff46b96c84b2ac9e10e4f5cdaeb5693cb665db62a2f3b02d2d57b5b").unwrap(),
             forkid: ForkId { hash: ForkHash([0x5d, 0x43, 0xd2, 0xfd]), next: 0 },
         };
 
@@ -155,9 +151,9 @@ mod tests {
         let expected = Status {
             version: EthVersion::Eth66 as u8,
             chain: Chain::Named(NamedChain::BinanceSmartChain),
-            total_difficulty: Uint::from(37851386u64),
-            blockhash: hex!("f8514c4680ef27700751b08f37645309ce65a449616a3ea966bf39dd935bb27b"),
-            genesis: hex!("0d21840abff46b96c84b2ac9e10e4f5cdaeb5693cb665db62a2f3b02d2d57b5b"),
+            total_difficulty: U256::from(37851386u64),
+            blockhash: H256::from_str("f8514c4680ef27700751b08f37645309ce65a449616a3ea966bf39dd935bb27b").unwrap(),
+            genesis: H256::from_str("0d21840abff46b96c84b2ac9e10e4f5cdaeb5693cb665db62a2f3b02d2d57b5b").unwrap(),
             forkid: ForkId { hash: ForkHash([0x5d, 0x43, 0xd2, 0xfd]), next: 0 },
         };
         let status = Status::decode(&mut &data[..]).unwrap();
@@ -170,12 +166,12 @@ mod tests {
         let expected = Status {
             version: EthVersion::Eth66 as u8,
             chain: Chain::Id(2100),
-            total_difficulty: Uint::from_str(
+            total_difficulty: U256::from_str(
                 "0x000000000000000000000000006d68fcffffffffffffffffffffffffdeab81b8",
             )
             .unwrap(),
-            blockhash: hex!("523e8163a6d620a4cc152c547a05f28a03fec91a2a615194cb86df9731372c0c"),
-            genesis: hex!("6499dccdc7c7def3ebb1ce4c6ee27ec6bd02aee570625ca391919faf77ef27bd"),
+            blockhash: H256::from_str("523e8163a6d620a4cc152c547a05f28a03fec91a2a615194cb86df9731372c0c").unwrap(),
+            genesis: H256::from_str("6499dccdc7c7def3ebb1ce4c6ee27ec6bd02aee570625ca391919faf77ef27bd").unwrap(),
             forkid: ForkId { hash: ForkHash([0x1a, 0x67, 0xcc, 0xd8]), next: 0 },
         };
         let status = Status::decode(&mut &data[..]).unwrap();

--- a/crates/net/eth-wire/src/status.rs
+++ b/crates/net/eth-wire/src/status.rs
@@ -110,10 +110,7 @@ mod tests {
             total_difficulty: Uint::from(36206751599115524359527u128),
             blockhash: hex!("feb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13d"),
             genesis: hex!("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"),
-            forkid: ForkId {
-                hash: ForkHash([0xb7, 0x15, 0x07, 0x7d]),
-                next: 0,
-            },
+            forkid: ForkId { hash: ForkHash([0xb7, 0x15, 0x07, 0x7d]), next: 0 },
         };
 
         let mut rlp_status = vec![];
@@ -131,10 +128,7 @@ mod tests {
             total_difficulty: Uint::from(36206751599115524359527u128),
             blockhash: hex!("feb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13d"),
             genesis: hex!("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"),
-            forkid: ForkId {
-                hash: ForkHash([0xb7, 0x15, 0x07, 0x7d]),
-                next: 0,
-            },
+            forkid: ForkId { hash: ForkHash([0xb7, 0x15, 0x07, 0x7d]), next: 0 },
         };
         let status = Status::decode(&mut &data[..]).unwrap();
         assert_eq!(status, expected);
@@ -149,10 +143,7 @@ mod tests {
             total_difficulty: Uint::from(37851386u64),
             blockhash: hex!("f8514c4680ef27700751b08f37645309ce65a449616a3ea966bf39dd935bb27b"),
             genesis: hex!("0d21840abff46b96c84b2ac9e10e4f5cdaeb5693cb665db62a2f3b02d2d57b5b"),
-            forkid: ForkId {
-                hash: ForkHash([0x5d, 0x43, 0xd2, 0xfd]),
-                next: 0,
-            },
+            forkid: ForkId { hash: ForkHash([0x5d, 0x43, 0xd2, 0xfd]), next: 0 },
         };
 
         let mut rlp_status = vec![];
@@ -169,10 +160,7 @@ mod tests {
             total_difficulty: Uint::from(37851386u64),
             blockhash: hex!("f8514c4680ef27700751b08f37645309ce65a449616a3ea966bf39dd935bb27b"),
             genesis: hex!("0d21840abff46b96c84b2ac9e10e4f5cdaeb5693cb665db62a2f3b02d2d57b5b"),
-            forkid: ForkId {
-                hash: ForkHash([0x5d, 0x43, 0xd2, 0xfd]),
-                next: 0,
-            },
+            forkid: ForkId { hash: ForkHash([0x5d, 0x43, 0xd2, 0xfd]), next: 0 },
         };
         let status = Status::decode(&mut &data[..]).unwrap();
         assert_eq!(status, expected);
@@ -190,10 +178,7 @@ mod tests {
             .unwrap(),
             blockhash: hex!("523e8163a6d620a4cc152c547a05f28a03fec91a2a615194cb86df9731372c0c"),
             genesis: hex!("6499dccdc7c7def3ebb1ce4c6ee27ec6bd02aee570625ca391919faf77ef27bd"),
-            forkid: ForkId {
-                hash: ForkHash([0x1a, 0x67, 0xcc, 0xd8]),
-                next: 0,
-            },
+            forkid: ForkId { hash: ForkHash([0x1a, 0x67, 0xcc, 0xd8]), next: 0 },
         };
         let status = Status::decode(&mut &data[..]).unwrap();
         assert_eq!(status, expected);

--- a/crates/net/eth-wire/src/status.rs
+++ b/crates/net/eth-wire/src/status.rs
@@ -1,0 +1,201 @@
+use ethereum_forkid::ForkId;
+use fastrlp::{RlpDecodable, RlpEncodable};
+use reth_primitives::chain::Chain;
+use ruint::Uint;
+use std::fmt::{Debug, Display};
+
+/// The status message is used in the eth protocol handshake to ensure that peers are on the same
+/// network and are following the same fork.
+/// The total difficulty and best block hash are used to identify whether or not the requesting
+/// client should be sent historical blocks for a full blockchain sync.
+///
+/// When performing a handshake, the total difficulty is not guaranteed to correspond to the block
+/// hash. This information should be treated as untrusted.
+#[derive(Copy, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+pub struct Status {
+    /// The current protocol version. For example, peers running `eth/66` would have a version of
+    /// 66.
+    pub version: u8,
+
+    /// The chain id, as introduced in
+    /// [EIP155](https://eips.ethereum.org/EIPS/eip-155#list-of-chain-ids).
+    pub chain: Chain,
+
+    /// Total difficulty of the best chain.
+    pub total_difficulty: Uint<256, 4>,
+
+    /// The highest difficulty block hash the peer has seen
+    pub blockhash: [u8; 32],
+
+    /// The genesis hash of the peer's chain.
+    pub genesis: [u8; 32],
+
+    /// The fork identifier, a [CRC32
+    /// checksum](https://en.wikipedia.org/wiki/Cyclic_redundancy_check#CRC-32_algorithm) for
+    /// identifying the peer's fork as defined by
+    /// [EIP-2124](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2124.md).
+    /// This was added in [`eth/64`](https://eips.ethereum.org/EIPS/eip-2364)
+    pub forkid: ForkId,
+}
+
+// TODO: Determine if it's worth wrapping or aliasing [u8; 32] across these types, to help derive
+// traits like this rather than having to manually implement them.
+impl Display for Status {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let hexed_blockhash = hex::encode(self.blockhash);
+        let hexed_genesis = hex::encode(self.genesis);
+        write!(
+            f,
+            "Status {{ version: {}, chain: {}, total_difficulty: {}, blockhash: {}, genesis: {}, forkid: {:X?} }}",
+            self.version,
+            self.chain,
+            self.total_difficulty,
+            hexed_blockhash,
+            hexed_genesis,
+            self.forkid
+        )
+    }
+}
+
+impl Debug for Status {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let hexed_blockhash = hex::encode(self.blockhash);
+        let hexed_genesis = hex::encode(self.genesis);
+        if f.alternate() {
+            write!(
+                f,
+                "Status {{\n\tversion: {:?},\n\tchain: {:?},\n\ttotal_difficulty: {:?},\n\tblockhash: {},\n\tgenesis: {},\n\tforkid: {:X?}\n}}",
+                self.version,
+                self.chain,
+                self.total_difficulty,
+                hexed_blockhash,
+                hexed_genesis,
+                self.forkid
+            )
+        } else {
+            write!(
+                f,
+                "Status {{ version: {:?}, chain: {:?}, total_difficulty: {:?}, blockhash: {}, genesis: {}, forkid: {:X?} }}",
+                self.version,
+                self.chain,
+                self.total_difficulty,
+                hexed_blockhash,
+                hexed_genesis,
+                self.forkid
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use ethereum_forkid::{ForkHash, ForkId};
+    use ethers::prelude::Chain as NamedChain;
+    use fastrlp::{Decodable, Encodable};
+    use foundry_config::Chain;
+    use hex_literal::hex;
+    use ruint::Uint;
+
+    use crate::{EthVersion, Status};
+
+    #[test]
+    fn encode_eth_status_message() {
+        let expected = hex!("f85643018a07aac59dabcdd74bc567a0feb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13da0d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3c684b715077d80");
+        let status = Status {
+            version: EthVersion::Eth67 as u8,
+            // ethers versions arent the same due to patches, so using Id here
+            chain: Chain::Named(NamedChain::Mainnet),
+            total_difficulty: Uint::from(36206751599115524359527u128),
+            blockhash: hex!("feb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13d"),
+            genesis: hex!("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"),
+            forkid: ForkId {
+                hash: ForkHash([0xb7, 0x15, 0x07, 0x7d]),
+                next: 0,
+            },
+        };
+
+        let mut rlp_status = vec![];
+        status.encode(&mut rlp_status);
+        assert_eq!(rlp_status, expected);
+    }
+
+    #[test]
+    fn decode_eth_status_message() {
+        let data = hex!("f85643018a07aac59dabcdd74bc567a0feb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13da0d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3c684b715077d80");
+        let expected = Status {
+            version: EthVersion::Eth67 as u8,
+            // ethers versions arent the same due to patches, so using Id here
+            chain: Chain::Named(NamedChain::Mainnet),
+            total_difficulty: Uint::from(36206751599115524359527u128),
+            blockhash: hex!("feb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13d"),
+            genesis: hex!("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"),
+            forkid: ForkId {
+                hash: ForkHash([0xb7, 0x15, 0x07, 0x7d]),
+                next: 0,
+            },
+        };
+        let status = Status::decode(&mut &data[..]).unwrap();
+        assert_eq!(status, expected);
+    }
+
+    #[test]
+    fn encode_network_status_message() {
+        let expected = hex!("f850423884024190faa0f8514c4680ef27700751b08f37645309ce65a449616a3ea966bf39dd935bb27ba00d21840abff46b96c84b2ac9e10e4f5cdaeb5693cb665db62a2f3b02d2d57b5bc6845d43d2fd80");
+        let status = Status {
+            version: EthVersion::Eth66 as u8,
+            chain: Chain::Named(NamedChain::BinanceSmartChain),
+            total_difficulty: Uint::from(37851386u64),
+            blockhash: hex!("f8514c4680ef27700751b08f37645309ce65a449616a3ea966bf39dd935bb27b"),
+            genesis: hex!("0d21840abff46b96c84b2ac9e10e4f5cdaeb5693cb665db62a2f3b02d2d57b5b"),
+            forkid: ForkId {
+                hash: ForkHash([0x5d, 0x43, 0xd2, 0xfd]),
+                next: 0,
+            },
+        };
+
+        let mut rlp_status = vec![];
+        status.encode(&mut rlp_status);
+        assert_eq!(rlp_status, expected);
+    }
+
+    #[test]
+    fn decode_network_status_message() {
+        let data = hex!("f850423884024190faa0f8514c4680ef27700751b08f37645309ce65a449616a3ea966bf39dd935bb27ba00d21840abff46b96c84b2ac9e10e4f5cdaeb5693cb665db62a2f3b02d2d57b5bc6845d43d2fd80");
+        let expected = Status {
+            version: EthVersion::Eth66 as u8,
+            chain: Chain::Named(NamedChain::BinanceSmartChain),
+            total_difficulty: Uint::from(37851386u64),
+            blockhash: hex!("f8514c4680ef27700751b08f37645309ce65a449616a3ea966bf39dd935bb27b"),
+            genesis: hex!("0d21840abff46b96c84b2ac9e10e4f5cdaeb5693cb665db62a2f3b02d2d57b5b"),
+            forkid: ForkId {
+                hash: ForkHash([0x5d, 0x43, 0xd2, 0xfd]),
+                next: 0,
+            },
+        };
+        let status = Status::decode(&mut &data[..]).unwrap();
+        assert_eq!(status, expected);
+    }
+
+    #[test]
+    fn decode_another_network_status_message() {
+        let data = hex!("f86142820834936d68fcffffffffffffffffffffffffdeab81b8a0523e8163a6d620a4cc152c547a05f28a03fec91a2a615194cb86df9731372c0ca06499dccdc7c7def3ebb1ce4c6ee27ec6bd02aee570625ca391919faf77ef27bdc6841a67ccd880");
+        let expected = Status {
+            version: EthVersion::Eth66 as u8,
+            chain: Chain::Id(2100),
+            total_difficulty: Uint::from_str(
+                "0x000000000000000000000000006d68fcffffffffffffffffffffffffdeab81b8",
+            )
+            .unwrap(),
+            blockhash: hex!("523e8163a6d620a4cc152c547a05f28a03fec91a2a615194cb86df9731372c0c"),
+            genesis: hex!("6499dccdc7c7def3ebb1ce4c6ee27ec6bd02aee570625ca391919faf77ef27bd"),
+            forkid: ForkId {
+                hash: ForkHash([0x1a, 0x67, 0xcc, 0xd8]),
+                next: 0,
+            },
+        };
+        let status = Status::decode(&mut &data[..]).unwrap();
+        assert_eq!(status, expected);
+    }
+}

--- a/crates/net/eth-wire/src/status.rs
+++ b/crates/net/eth-wire/src/status.rs
@@ -105,7 +105,6 @@ mod tests {
         let expected = hex!("f85643018a07aac59dabcdd74bc567a0feb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13da0d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3c684b715077d80");
         let status = Status {
             version: EthVersion::Eth67 as u8,
-            // ethers versions arent the same due to patches, so using Id here
             chain: Chain::Named(NamedChain::Mainnet),
             total_difficulty: Uint::from(36206751599115524359527u128),
             blockhash: hex!("feb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13d"),
@@ -123,7 +122,6 @@ mod tests {
         let data = hex!("f85643018a07aac59dabcdd74bc567a0feb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13da0d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3c684b715077d80");
         let expected = Status {
             version: EthVersion::Eth67 as u8,
-            // ethers versions arent the same due to patches, so using Id here
             chain: Chain::Named(NamedChain::Mainnet),
             total_difficulty: Uint::from(36206751599115524359527u128),
             blockhash: hex!("feb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13d"),

--- a/crates/net/eth-wire/src/status.rs
+++ b/crates/net/eth-wire/src/status.rs
@@ -1,6 +1,6 @@
 use ethereum_forkid::ForkId;
 use fastrlp::{RlpDecodable, RlpEncodable};
-use reth_primitives::chain::Chain;
+use reth_primitives::Chain;
 use ruint::Uint;
 use std::fmt::{Debug, Display};
 
@@ -92,10 +92,10 @@ mod tests {
     use std::str::FromStr;
 
     use ethereum_forkid::{ForkHash, ForkId};
-    use ethers::prelude::Chain as NamedChain;
+    use ethers_core::types::Chain as NamedChain;
     use fastrlp::{Decodable, Encodable};
-    use foundry_config::Chain;
     use hex_literal::hex;
+    use reth_primitives::Chain;
     use ruint::Uint;
 
     use crate::{EthVersion, Status};

--- a/crates/net/eth-wire/src/version.rs
+++ b/crates/net/eth-wire/src/version.rs
@@ -1,0 +1,109 @@
+use std::str::FromStr;
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("Unknown eth protocol version: {0}")]
+pub struct ParseVersionError(String);
+
+/// The `eth` protocol version.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub enum EthVersion {
+    /// The `eth` protocol version 66.
+    Eth66 = 66,
+
+    /// The `eth` protocol version 67.
+    Eth67 = 67,
+}
+
+/// Allow for converting from a `&str` to an `EthVersion`.
+///
+/// # Example
+/// ```
+/// use ethp2p::EthVersion;
+/// use std::convert::TryFrom;
+///
+/// let version = EthVersion::try_from("67").unwrap();
+/// assert_eq!(version, EthVersion::Eth67);
+/// ```
+impl TryFrom<&str> for EthVersion {
+    type Error = ParseVersionError;
+
+    #[inline]
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "66" => Ok(EthVersion::Eth66),
+            "67" => Ok(EthVersion::Eth67),
+            _ => Err(ParseVersionError(s.to_string())),
+        }
+    }
+}
+
+/// Allow for converting from a u8 to an `EthVersion`.
+///
+/// # Example
+/// ```
+/// use ethp2p::EthVersion;
+/// use std::convert::TryFrom;
+///
+/// let version = EthVersion::try_from(67).unwrap();
+/// assert_eq!(version, EthVersion::Eth67);
+/// ```
+impl TryFrom<u8> for EthVersion {
+    type Error = ParseVersionError;
+
+    #[inline]
+    fn try_from(u: u8) -> Result<Self, Self::Error> {
+        match u {
+            66 => Ok(EthVersion::Eth66),
+            67 => Ok(EthVersion::Eth67),
+            _ => Err(ParseVersionError(u.to_string())),
+        }
+    }
+}
+
+impl FromStr for EthVersion {
+    type Err = ParseVersionError;
+
+    #[inline]
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        EthVersion::try_from(s)
+    }
+}
+
+impl From<EthVersion> for u8 {
+    #[inline]
+    fn from(v: EthVersion) -> u8 {
+        v as u8
+    }
+}
+
+impl From<EthVersion> for &'static str {
+    #[inline]
+    fn from(v: EthVersion) -> &'static str {
+        match v {
+            EthVersion::Eth66 => "66",
+            EthVersion::Eth67 => "67",
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{EthVersion, ParseVersionError};
+    use std::{convert::TryFrom, string::ToString};
+
+    #[test]
+    fn test_eth_version_try_from_str() {
+        assert_eq!(EthVersion::Eth66, EthVersion::try_from("66").unwrap());
+        assert_eq!(EthVersion::Eth67, EthVersion::try_from("67").unwrap());
+        assert_eq!(Err(ParseVersionError("68".to_string())), EthVersion::try_from("68"));
+    }
+
+    #[test]
+    fn test_eth_version_from_str() {
+        assert_eq!(EthVersion::Eth66, "66".parse().unwrap());
+        assert_eq!(EthVersion::Eth67, "67".parse().unwrap());
+        assert_eq!(Err(ParseVersionError("68".to_string())), "68".parse::<EthVersion>());
+    }
+}

--- a/crates/net/eth-wire/src/version.rs
+++ b/crates/net/eth-wire/src/version.rs
@@ -20,8 +20,7 @@ pub enum EthVersion {
 ///
 /// # Example
 /// ```
-/// use ethp2p::EthVersion;
-/// use std::convert::TryFrom;
+/// use reth_eth_wire::EthVersion;
 ///
 /// let version = EthVersion::try_from("67").unwrap();
 /// assert_eq!(version, EthVersion::Eth67);
@@ -43,8 +42,7 @@ impl TryFrom<&str> for EthVersion {
 ///
 /// # Example
 /// ```
-/// use ethp2p::EthVersion;
-/// use std::convert::TryFrom;
+/// use reth_eth_wire::EthVersion;
 ///
 /// let version = EthVersion::try_from(67).unwrap();
 /// assert_eq!(version, EthVersion::Eth67);

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -8,6 +8,6 @@ readme = "README.md"
 description = "Commonly used types in reth."
 
 [dependencies]
-fastrlp = { version = "0.2.0" }
+fastrlp = { version = "0.1.3" }
 ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 bytes = "1.2"

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -17,6 +17,7 @@ mod transaction;
 
 pub use account::Account;
 pub use block::{Block, BlockLocked};
+pub use chain::Chain;
 pub use header::{Header, HeaderLocked};
 pub use log::Log;
 pub use receipt::Receipt;


### PR DESCRIPTION
This adds some code from ethp2p, just `Status` and `EthVersion` for now. For the rest of the wire protocol, most types in `primitives` need to be complete and they need to implement `fastrlp::{Encodable, Decodable}`. The `Status` is specifically important for the initial `eth` handshake implementation.