### PR TITLE
wip:  `DataApi` trait for querying/inserting data

### DIFF
--- a/crates/db/src/api.rs
+++ b/crates/db/src/api.rs
@@ -1,0 +1,63 @@
+#![allow(missing_docs)]
+
+//! Module with the API traits that memdb, libmdbx and static have to provide.
+use reth_primitives::{
+    Account, Address, Block, BlockHash, BlockNumber, Bytes, Header, Receipt, Transaction, TxHash,
+    TxNumber, H256, U256,
+};
+
+/// Enum for API Errors.
+#[derive(Debug)]
+pub enum ApiError {}
+
+/// Common API for querying and writing data.
+#[rustfmt::skip]
+pub trait DataApi {
+    /// Returns the lowest and highest block number the data structure contains.
+    fn read_block_number_range(&self) -> Result<(BlockNumber, BlockNumber), ApiError>;
+    fn read_block_latest(&self) -> Result<Block, ApiError>;
+    fn read_block(&self, number: Option<BlockNumber>, hash: Option<BlockHash>) -> Result<Block, ApiError>;
+    fn write_block(&self, block: Block) -> Result<(), ApiError>;
+    fn delete_blocks(&self, number: Option<Vec<BlockNumber>>, hash: Option<Vec<BlockHash>>) -> Result<(), ApiError>;
+    fn truncate_blocks(&self, from: BlockNumber) -> Result<(), ApiError>;
+    fn has_block(&self, hash: BlockHash) -> Result<bool, ApiError>;
+
+    fn read_header_latest(&self) -> Result<Header, ApiError>;
+    fn read_header(&self, number: Option<u64>, hash: H256) -> Result<Header, ApiError>;
+    fn read_header_number(&self, hash: H256) -> Result<u64, ApiError>;
+    fn write_header(&self, header: Header) -> Result<(), ApiError>;
+    fn write_header_number(&self, hash: H256) -> Result<(), ApiError>;
+    fn delete_headers(&self, header: Vec<Header>) -> Result<(), ApiError>;
+
+    fn read_tx( &self, number: Option<TxNumber>, hash: Option<TxHash>) -> Result<Transaction, ApiError>;
+    fn write_tx(&self, transaction: Transaction) -> Result<(), ApiError>;
+    fn delete_txes(&self, number: Option<Vec<TxNumber>>, hash: Option<Vec<TxHash>>) -> Result<(), ApiError>;
+    fn write_tx_senders(&self, senders: Vec<(TxHash, Address)>) -> Result<(), ApiError>;
+    fn move_to_canonical_txes(&self) -> Result<(), ApiError>;
+    fn move_to_non_canonical_txes(&self) -> Result<(), ApiError>;
+
+    fn read_canonical_hash(&self, number: u64) -> Result<H256, ApiError>;
+    fn write_total_difficulty(&self, difficulty: U256) -> Result<(), ApiError>;
+    fn truncate_total_difficulty(&self, from: BlockNumber) -> Result<(), ApiError>;
+
+    fn read_receipt(&self, number: Option<TxNumber>) -> Result<Receipt, ApiError>;
+    fn write_receipts(&self, tx: Vec<TxNumber>, receipt: Vec<Receipt>) -> Result<(), ApiError>;
+    fn delete_receipts(&self, tx: Vec<TxNumber>) -> Result<(), ApiError>;
+
+    fn read_account(&self, address: Address, tx_number: Option<TxNumber>) -> Result<Account, ApiError>;
+    fn read_account_code(&self, address: Address, tx_number: Option<TxNumber>) -> Result<Bytes, ApiError>;
+    fn read_account_code_size(&self, address: Address, tx_number: Option<TxNumber>) -> Result<u64, ApiError>;
+    fn read_account_storage(&self, address: Address, tx_number: Option<TxNumber>, key: H256) -> Result<Bytes, ApiError>;
+    fn read_account_incarnation(&self, address: Address, tx_number: Option<TxNumber>) -> Result<u64, ApiError>;
+    fn update_account_code(&self, address: Address, code: Bytes) -> Result<(), ApiError>;
+    fn write_account_storage(&self, address: Address, key: H256, value: H256) -> Result<(), ApiError>;
+    fn delete_account(&self, account: Address) -> Result<(), ApiError>;
+    fn create_contract(&self, account: Address) -> Result<(), ApiError>;
+
+    fn read_change_set_account(&self) -> Result<(), ApiError>;
+    fn write_change_set_storage(&self) -> Result<(), ApiError>;
+
+    fn read_history_account(&self) -> Result<(), ApiError>;
+    fn write_history_storage(&self) -> Result<(), ApiError>;
+
+}

--- a/crates/db/src/kv/table.rs
+++ b/crates/db/src/kv/table.rs
@@ -148,3 +148,17 @@ impl Decode for H256 {
         Ok(Self::from_slice(&result))
     }
 }
+
+impl Encode for Vec<U256> {
+    type Encoded = Vec<u8>;
+
+    fn encode(self) -> Self::Encoded {
+        todo!();
+    }
+}
+
+impl Decode for Vec<U256> {
+    fn decode(_value: &[u8]) -> Result<Self, KVError> {
+        todo!();
+    }
+}

--- a/crates/db/src/kv/tables.rs
+++ b/crates/db/src/kv/tables.rs
@@ -4,7 +4,7 @@ use crate::{
     kv::blocks::{BlockNumber_BlockHash, HeaderHash, NumTransactions, NumTxesInBlock},
     utils::TableType,
 };
-use reth_primitives::{Address, BlockNumber};
+use reth_primitives::{Address, BlockNumber, TxNumber};
 
 /// Default tables that should be present inside database.
 pub const TABLES: [(TableType, &str); 17] = [
@@ -76,20 +76,20 @@ table!(Headers => BlockNumber_BlockHash => RlpHeader);
 table!(BlockBodies => BlockNumber_BlockHash => NumTxesInBlock);
 table!(CumulativeTxCount => BlockNumber_BlockHash => NumTransactions); // TODO U256?
 
-table!(NonCanonicalTransactions => BlockNumber_BlockHash_TxId => RlpTxBody);
-table!(Transactions => TxId => RlpTxBody); // Canonical only
-table!(Receipts => TxId => Receipt); // Canonical only
-table!(Logs => TxId => Receipt); // Canonical only
+table!(NonCanonicalTransactions => BlockNumber_BlockHash_TxNumber => RlpTxBody);
+table!(Transactions => TxNumber => RlpTxBody); // Canonical only
+table!(Receipts => TxNumber => Receipt); // Canonical only
+table!(Logs => TxNumber => Receipt); // Canonical only
 
 table!(PlainState => PlainStateKey => Vec<u8>);
 
-table!(AccountHistory => Address => TxIdList);
-table!(StorageHistory => Address_StorageKey => TxIdList);
+table!(AccountHistory => Address => TxNumberList);
+table!(StorageHistory => Address_StorageKey => TxNumberList);
 
-table!(AccountChangeSet => TxId => AccountBeforeTx);
-table!(StorageChangeSet => TxId => StorageKeyBeforeTx);
+table!(AccountChangeSet => TxNumber => AccountBeforeTx);
+table!(StorageChangeSet => TxNumber => StorageKeyBeforeTx);
 
-table!(TxSenders => TxId => Address); // Is it necessary?
+table!(TxSenders => TxNumber => Address); // Is it necessary?
 table!(Config => ConfigKey => ConfigValue);
 
 //
@@ -99,14 +99,13 @@ table!(Config => ConfigKey => ConfigValue);
 type ConfigKey = Vec<u8>;
 type ConfigValue = Vec<u8>;
 #[allow(non_camel_case_types)]
-type BlockNumber_BlockHash_TxId = Vec<u8>;
+type BlockNumber_BlockHash_TxNumber = Vec<u8>;
 type RlpHeader = Vec<u8>;
 type RlpTotalDifficulty = Vec<u8>;
 type RlpTxBody = Vec<u8>;
 type Receipt = Vec<u8>;
-type TxId = u64; // TODO check size
 type PlainStateKey = Address; // TODO new type will have to account for address_incarna_skey as well
-type TxIdList = Vec<u8>;
+type TxNumberList = Vec<TxNumber>;
 #[allow(non_camel_case_types)]
 type Address_StorageKey = Vec<u8>;
 type AccountBeforeTx = Vec<u8>;

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -12,5 +12,6 @@ pub mod mdbx {
     pub use libmdbx::*;
 }
 
+pub mod api;
 pub mod kv;
 mod utils;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -32,6 +32,8 @@ pub type Address = H160;
 pub type BlockID = H256;
 /// TxHash is Kecack hash of rlp encoded signed transaction
 pub type TxHash = H256;
+/// TxNumber is the transaction sequence number of all transactions in chain
+pub type TxNumber = U256;
 
 /// Storage Key
 pub type StorageKey = H256;


### PR DESCRIPTION
WIP 

Ideally, `mdbx`, `memory_db` and `static` have a common well-defined API to query for data. Is it a too naive of an approach?
All 3 elements would implement the same `DataApi` trait.

Other crates (RPC,pool, executor etc) request the data through an `ApiManager` (which implements the same trait) without knowing where the data is. `ApiManager` will accordingly to the parameters choose the best course of action. (eg. if no block is passed, then its the tip and will query mdbx.)

---

If we all agree this is the way to go, then I'd ask that you'd also add whatever API you need here. 

This also helps out with the schema design, to know what's really needed in the DB/Index... or how we can merge/structure data
