### PR TITLE
refactor(stages): split `Pipeline::run`

### DIFF
--- a/crates/stages/src/pipeline/ctrl.rs
+++ b/crates/stages/src/pipeline/ctrl.rs
@@ -1,0 +1,14 @@
+use reth_primitives::BlockNumber;
+
+/// Determines the control flow during pipeline execution.
+pub(crate) enum ControlFlow {
+    /// An unwind was requested and must be performed before continuing.
+    Unwind {
+        /// The block to unwind to.
+        target: BlockNumber,
+        /// The block that caused the unwind.
+        bad_block: Option<BlockNumber>,
+    },
+    /// The pipeline is allowed to continue executing stages.
+    Continue,
+}

--- a/crates/stages/src/pipeline/state.rs
+++ b/crates/stages/src/pipeline/state.rs
@@ -1,0 +1,43 @@
+use crate::{
+    pipeline::event::PipelineEvent,
+    util::{opt, opt::MaybeSender},
+};
+use reth_primitives::BlockNumber;
+
+/// The state of the pipeline during execution.
+pub(crate) struct PipelineState {
+    pub(crate) events_sender: MaybeSender<PipelineEvent>,
+    pub(crate) max_block: Option<BlockNumber>,
+    /// The maximum progress achieved by any stage during the execution of the pipeline.
+    pub(crate) maximum_progress: Option<BlockNumber>,
+    /// The minimum progress achieved by any stage during the execution of the pipeline.
+    pub(crate) minimum_progress: Option<BlockNumber>,
+    /// Whether or not the previous stage reached the tip of the chain.
+    ///
+    /// **Do not use this** under normal circumstances. Instead, opt for
+    /// [PipelineState::reached_tip] and [PipelineState::set_reached_tip].
+    pub(crate) reached_tip: bool,
+}
+
+impl PipelineState {
+    /// Record the progress of a stage, setting the maximum and minimum progress achieved by any
+    /// stage during the execution of the pipeline.
+    pub(crate) fn record_progress_outliers(&mut self, stage_progress: BlockNumber) {
+        // Update our minimum and maximum stage progress
+        self.minimum_progress = opt::min(self.minimum_progress, stage_progress);
+        self.maximum_progress = opt::max(self.maximum_progress, stage_progress);
+    }
+
+    /// Whether or not the pipeline reached the tip of the chain.
+    pub(crate) fn reached_tip(&self) -> bool {
+        self.reached_tip ||
+            self.max_block
+                .zip(self.minimum_progress)
+                .map_or(false, |(target, progress)| progress >= target)
+    }
+
+    /// Set whether or not the pipeline has reached the tip of the chain.
+    pub(crate) fn set_reached_tip(&mut self, flag: bool) {
+        self.reached_tip = flag;
+    }
+}

--- a/crates/stages/src/util.rs
+++ b/crates/stages/src/util.rs
@@ -16,7 +16,7 @@ pub(crate) mod opt {
     }
 
     /// The producing side of a [tokio::mpsc] channel that may or may not be set.
-    #[derive(Default)]
+    #[derive(Default, Clone)]
     pub(crate) struct MaybeSender<T> {
         inner: Option<Sender<T>>,
     }
@@ -58,6 +58,84 @@ pub(crate) mod opt {
             assert_eq!(min(None, 5), Some(5));
             assert_eq!(min(Some(1), 5), Some(1));
             assert_eq!(min(Some(10), 5), Some(5));
+        }
+    }
+}
+
+pub(crate) mod db {
+    use reth_db::mdbx;
+
+    /// A container for a MDBX transaction that will open a new inner transaction when the current
+    /// one is committed.
+    // NOTE: This container is needed since `Transaction::commit` takes `mut self`, so methods in
+    // the pipeline that just take a reference will not be able to commit their transaction and let
+    // the pipeline continue. Is there a better way to do this?
+    pub(crate) struct TxContainer<'db, 'tx, E>
+    where
+        'db: 'tx,
+        E: mdbx::EnvironmentKind,
+    {
+        /// A handle to the MDBX database.
+        pub(crate) db: &'db mdbx::Environment<E>,
+        tx: Option<mdbx::Transaction<'tx, mdbx::RW, E>>,
+    }
+
+    impl<'db, 'tx, E> TxContainer<'db, 'tx, E>
+    where
+        'db: 'tx,
+        E: mdbx::EnvironmentKind,
+    {
+        /// Create a new container with the given database handle.
+        ///
+        /// A new inner transaction will be opened.
+        pub(crate) fn new(db: &'db mdbx::Environment<E>) -> Result<Self, mdbx::Error> {
+            Ok(Self { db, tx: Some(db.begin_rw_txn()?) })
+        }
+
+        /// Commit the current inner transaction and open a new one.
+        ///
+        /// # Panics
+        ///
+        /// Panics if an inner transaction does not exist. This should never be the case unless
+        /// [TxContainer::close] was called without following up with a call to [TxContainer::open].
+        pub(crate) fn commit(&mut self) -> Result<bool, mdbx::Error> {
+            let success =
+                self.tx.take().expect("Tried committing a non-existent transaction").commit()?;
+            self.tx = Some(self.db.begin_rw_txn()?);
+            Ok(success)
+        }
+
+        /// Get the inner transaction.
+        ///
+        /// # Panics
+        ///
+        /// Panics if an inner transaction does not exist. This should never be the case unless
+        /// [TxContainer::close] was called without following up with a call to [TxContainer::open].
+        pub(crate) fn get(&self) -> &mdbx::Transaction<'tx, mdbx::RW, E> {
+            self.tx.as_ref().expect("Tried getting a reference to a non-existent transaction")
+        }
+
+        /// Get a mutable reference to the inner transaction.
+        ///
+        /// # Panics
+        ///
+        /// Panics if an inner transaction does not exist. This should never be the case unless
+        /// [TxContainer::close] was called without following up with a call to [TxContainer::open].
+        pub(crate) fn get_mut(&mut self) -> &mut mdbx::Transaction<'tx, mdbx::RW, E> {
+            self.tx
+                .as_mut()
+                .expect("Tried getting a mutable reference to a non-existent transaction")
+        }
+
+        /// Open a new inner transaction.
+        pub(crate) fn open(&mut self) -> Result<(), mdbx::Error> {
+            self.tx = Some(self.db.begin_rw_txn()?);
+            Ok(())
+        }
+
+        /// Close the current inner transaction.
+        pub(crate) fn close(&mut self) {
+            self.tx.take();
         }
     }
 }


### PR DESCRIPTION
An attempt to split `Pipeline::run` into smaller functions.

- `Pipeline::run` is just a loop that calls another function and controls whether or not to stop execution of the pipeline
- `Pipeline::run_loop` attempts to run every stage in sequence. If a stage requests an unwind, `Pipeline::unwind` is called and the control is given back to `Pipeline::run` that calls `Pipeline::run_loop` once again, which ensures each stage is executed in the correct order after an unwind
- `QueuedStage` now has an `execute` method that executes the inner stage and does the appropriate business logic around firing pipeline events for stages and error handling
- The state of the pipeline during execution is in a new struct `PipelineState` instead of in a bunch of variables in `Pipeline::run`
- Each of `run`, `run_loop` and `QueuedStage::execute` return a `Result<ControlFlow, PipelineError>`. The `ControlFlow` enum is used to bubble control flow decisions up from stages into the appropriate parts of each of the functions. For example, `ControlFlow::Unwind` calls `Pipeline::unwind` in `run_loop`

There are a couple of places where we commit our MDBX transaction:

- When a stage returns, progress is committed. In the future, we will have some logic around how often to commit. The reason for the commit here is that a stage realistically might operate on huge batches of blocks, so just committing once after the stage is completely done is infeasible.
- When a loop completes, we also commit for good sanity.

Some of the places were we commit are OK since a new transaction is immediately opened at the start of the loop in `Pipeline::run`. However, in other places we commit "mid-logic". An issue arises here: committing consumes the transaction itself, which moves the object, but since we only pass `&mut mdbx::Transaction` around this is not possible. To solve this problem, I had to create a wrapper type that commits the inner transaction and opens a new one immediately after: `TxContainer`.

I'm not sure if there is a nicer way to solve that