### PR TITLE
chore: nuke src

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,0 @@
-#![warn(missing_debug_implementations, missing_docs, unreachable_pub)]
-#![deny(unused_must_use, rust_2018_idioms)]
-#![doc(test(
-    no_crate_inject,
-    attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
-))]
-
-//! <reth crate template>


### PR DESCRIPTION
Given binaries are in `bin/` and all relevant types and components are in their own crates, there isn't really a reason for `src/` to exist