### PR TITLE
db: supply table as Type not as fn param

### DIFF
--- a/crates/db/src/kv/mod.rs
+++ b/crates/db/src/kv/mod.rs
@@ -175,12 +175,12 @@ mod tests {
 
         // PUT
         let tx = env.begin_mut_tx().expect(ERROR_INIT_TX);
-        tx.put(PlainState, key, value.clone()).expect(ERROR_PUT);
+        tx.put::<PlainState>(key, value.clone()).expect(ERROR_PUT);
         tx.commit().expect(ERROR_COMMIT);
 
         // GET
         let tx = env.begin_tx().expect(ERROR_INIT_TX);
-        let result = tx.get(PlainState, key).expect(ERROR_GET);
+        let result = tx.get::<PlainState>(key).expect(ERROR_GET);
         assert!(result.expect(ERROR_RETURN_VALUE) == value);
         tx.commit().expect(ERROR_COMMIT);
     }
@@ -199,7 +199,7 @@ mod tests {
 
             // PUT
             let result = env.update(|tx| {
-                tx.put(PlainState, key, value.clone()).expect(ERROR_PUT);
+                tx.put::<PlainState>(key, value.clone()).expect(ERROR_PUT);
                 200
             });
             assert!(result.expect(ERROR_RETURN_VALUE) == 200);
@@ -208,7 +208,7 @@ mod tests {
         let env = Env::<WriteMap>::open(&path, EnvKind::RO).expect(ERROR_DB_CREATION);
 
         // GET
-        let result = env.view(|tx| tx.get(PlainState, key).expect(ERROR_GET)).expect(ERROR_GET);
+        let result = env.view(|tx| tx.get::<PlainState>(key).expect(ERROR_GET)).expect(ERROR_GET);
 
         assert!(result == Some(value))
     }

--- a/crates/db/src/kv/table.rs
+++ b/crates/db/src/kv/table.rs
@@ -27,15 +27,14 @@ impl<T> Object for T where T: Encode + Decode {}
 
 /// Generic trait that a database table should follow.
 pub trait Table: Send + Sync + Debug + 'static {
+    /// Return table name as it is present inside the MDBX.
+    const NAME: &'static str;
     /// Key element of `Table`.
     type Key: Encode;
     /// Value element of `Table`.
     type Value: Object;
     /// Seek Key element of `Table`.
     type SeekKey: Encode;
-
-    /// Return name as it is present inside the MDBX.
-    fn name(&self) -> &'static str;
 }
 
 /// DupSort allows for keys not to be repeated in the database,

--- a/crates/db/src/kv/tables.rs
+++ b/crates/db/src/kv/tables.rs
@@ -33,14 +33,11 @@ macro_rules! table {
         pub struct $name;
 
         impl $crate::kv::table::Table for $name {
+            const NAME: &'static str = $name::const_name();
             type Key = $key;
             type Value = $value;
             type SeekKey = $seek;
 
-            /// Return $name as it is present inside the database.
-            fn name(&self) -> &'static str {
-                $name::const_name()
-            }
         }
 
         impl $name {


### PR DESCRIPTION
Simplifies function signatures of transaction-related actions.

Follow-up from https://github.com/foundry-rs/reth/pull/15.