### PR TITLE
feat(rpc): add rpc-api client feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
+name = "async-lock"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +182,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
 
 [[package]]
+name = "bumpalo"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+
+[[package]]
 name = "byte-slice-cast"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,6 +261,22 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
@@ -471,6 +502,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,6 +647,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+dependencies = [
+ "gloo-timers",
+ "send_wrapper",
+]
+
+[[package]]
 name = "futures-util"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,6 +712,51 @@ dependencies = [
  "fnv",
  "log",
  "regex",
+]
+
+[[package]]
+name = "gloo-net"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec897194fb9ac576c708f63d35604bc58f2a262b8cec0fabfed26f3991255f21"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-sink",
+ "gloo-utils",
+ "js-sys",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fb7d06c1c8cc2a29bee7ec961009a0b2caa0793ee4900c2ffb348734ba1c8f9"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-utils"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40913a05c8297adca04392f707b1e73b12ba7b8eab7244a4961580b1fd34063c"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -801,6 +893,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
+dependencies = [
+ "http",
+ "hyper",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "webpki-roots",
+]
+
+[[package]]
 name = "impl-codec"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,17 +972,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
+name = "js-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "jsonrpsee"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bd0d559d5e679b1ab2f869b486a11182923863b1b3ee8b421763cdd707b783a"
 dependencies = [
  "jsonrpsee-core",
+ "jsonrpsee-http-client",
  "jsonrpsee-http-server",
  "jsonrpsee-proc-macros",
  "jsonrpsee-types",
+ "jsonrpsee-wasm-client",
+ "jsonrpsee-ws-client",
  "jsonrpsee-ws-server",
  "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-client-transport"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8752740ecd374bcbf8b69f3e80b0327942df76f793f8d4e60d3355650c31fb74"
+dependencies = [
+ "anyhow",
+ "futures-channel",
+ "futures-timer",
+ "futures-util",
+ "gloo-net",
+ "http",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "pin-project",
+ "rustls-native-certs",
+ "soketto",
+ "thiserror",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tracing",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -885,9 +1030,11 @@ checksum = "f3dc3e9cf2ba50b7b1d7d76a667619f82846caa39e8e8daa8a4962d74acaddca"
 dependencies = [
  "anyhow",
  "arrayvec",
+ "async-lock",
  "async-trait",
  "beef",
  "futures-channel",
+ "futures-timer",
  "futures-util",
  "globset",
  "http",
@@ -903,7 +1050,29 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "tracing-futures",
  "unicase",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "jsonrpsee-http-client"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f7c0e2333ab2115c302eeb4f137c8a4af5ab609762df68bbda8f06496677c9"
+dependencies = [
+ "async-trait",
+ "hyper",
+ "hyper-rustls",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -948,6 +1117,29 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-wasm-client"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597b4eb94730e7695d0a2a429bc37a12e6e84d12680fdafb9b8f5f53652aab57"
+dependencies = [
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+]
+
+[[package]]
+name = "jsonrpsee-ws-client"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ee5feddd5188e62ac08fcf0e56478138e581509d4730f3f7be9b57dd402a4ff"
+dependencies = [
+ "http",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
 ]
 
 [[package]]
@@ -1230,6 +1422,12 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "page_size"
@@ -1670,6 +1868,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "ripemd"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,6 +1945,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.20.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+dependencies = [
+ "base64",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1744,10 +1990,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
+name = "schannel"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+dependencies = [
+ "lazy_static",
+ "windows-sys",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "sec1"
@@ -1783,10 +2049,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "security-framework"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+
+[[package]]
+name = "send_wrapper"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
@@ -2062,6 +2357,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2190,6 +2496,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2210,6 +2522,103 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+dependencies = [
+ "cfg-if",
+ "serde",
+ "serde_json",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+
+[[package]]
+name = "web-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
+dependencies = [
+ "webpki",
+]
 
 [[package]]
 name = "winapi"

--- a/crates/net/rpc-api/Cargo.toml
+++ b/crates/net/rpc-api/Cargo.toml
@@ -16,3 +16,6 @@ reth-rpc-types = { path = "../rpc-types" }
 
 # misc
 jsonrpsee = { version = "0.15", features = ["server", "macros"] }
+
+[features]
+client = ["jsonrpsee/client", "jsonrpsee/async-client"]

--- a/crates/net/rpc-api/src/debug.rs
+++ b/crates/net/rpc-api/src/debug.rs
@@ -6,8 +6,8 @@ use reth_primitives::{
 use reth_rpc_types::RichBlock;
 
 /// Debug rpc interface.
-#[rpc(server)]
-#[cfg_attr(feature = "client", rpc(client,))]
+#[cfg_attr(not(feature = "client"), rpc(server))]
+#[cfg_attr(feature = "client", rpc(server, client))]
 pub trait DebugApi {
     /// Returns an RLP-encoded header.
     #[method(name = "debug_getRawHeader")]

--- a/crates/net/rpc-api/src/debug.rs
+++ b/crates/net/rpc-api/src/debug.rs
@@ -7,6 +7,7 @@ use reth_rpc_types::RichBlock;
 
 /// Debug rpc interface.
 #[rpc(server)]
+#[cfg_attr(feature = "client", rpc(client,))]
 pub trait DebugApi {
     /// Returns an RLP-encoded header.
     #[method(name = "debug_getRawHeader")]

--- a/crates/net/rpc-api/src/engine.rs
+++ b/crates/net/rpc-api/src/engine.rs
@@ -6,6 +6,7 @@ use reth_rpc_types::engine::{
 };
 
 #[rpc(server)]
+#[cfg_attr(feature = "client", rpc(client,))]
 pub trait EngineApi {
     /// See also <https://github.com/ethereum/execution-apis/blob/8db51dcd2f4bdfbd9ad6e4a7560aac97010ad063/src/engine/specification.md#engine_newpayloadv1>
     #[method(name = "engine_newPayloadV1")]

--- a/crates/net/rpc-api/src/engine.rs
+++ b/crates/net/rpc-api/src/engine.rs
@@ -5,8 +5,8 @@ use reth_rpc_types::engine::{
     TransitionConfiguration,
 };
 
-#[rpc(server)]
-#[cfg_attr(feature = "client", rpc(client,))]
+#[cfg_attr(not(feature = "client"), rpc(server))]
+#[cfg_attr(feature = "client", rpc(server, client))]
 pub trait EngineApi {
     /// See also <https://github.com/ethereum/execution-apis/blob/8db51dcd2f4bdfbd9ad6e4a7560aac97010ad063/src/engine/specification.md#engine_newpayloadv1>
     #[method(name = "engine_newPayloadV1")]

--- a/crates/net/rpc-api/src/eth.rs
+++ b/crates/net/rpc-api/src/eth.rs
@@ -12,8 +12,8 @@ use reth_rpc_types::{
 };
 
 /// Eth rpc interface.
-#[rpc(server)]
-#[cfg_attr(feature = "client", rpc(client,))]
+#[cfg_attr(not(feature = "client"), rpc(server))]
+#[cfg_attr(feature = "client", rpc(server, client))]
 #[async_trait]
 pub trait EthApi {
     /// Returns protocol version encoded as a string (quotes are necessary).

--- a/crates/net/rpc-api/src/eth.rs
+++ b/crates/net/rpc-api/src/eth.rs
@@ -20,7 +20,7 @@ pub trait EthApi {
     #[method(name = "eth_protocolVersion")]
     fn protocol_version(&self) -> Result<u64>;
 
-    /// Returns an object with data about the sync status or false. (wtf?)
+    /// Returns an object with data about the sync status or false.
     #[method(name = "eth_syncing")]
     fn syncing(&self) -> Result<SyncStatus>;
 

--- a/crates/net/rpc-api/src/eth.rs
+++ b/crates/net/rpc-api/src/eth.rs
@@ -13,6 +13,7 @@ use reth_rpc_types::{
 
 /// Eth rpc interface.
 #[rpc(server)]
+#[cfg_attr(feature = "client", rpc(client,))]
 #[async_trait]
 pub trait EthApi {
     /// Returns protocol version encoded as a string (quotes are necessary).

--- a/crates/net/rpc-api/src/eth_filter.rs
+++ b/crates/net/rpc-api/src/eth_filter.rs
@@ -3,8 +3,8 @@ use reth_primitives::{rpc::Filter, U256};
 use reth_rpc_types::{FilterChanges, Index, Log};
 
 /// Rpc Interface for poll-based ethereum filter API.
-#[rpc(server)]
-#[cfg_attr(feature = "client", rpc(client,))]
+#[cfg_attr(not(feature = "client"), rpc(server))]
+#[cfg_attr(feature = "client", rpc(server, client))]
 pub trait EthFilterApi {
     /// Creates anew filter and returns its id.
     #[method(name = "eth_newFilter")]

--- a/crates/net/rpc-api/src/eth_filter.rs
+++ b/crates/net/rpc-api/src/eth_filter.rs
@@ -4,6 +4,7 @@ use reth_rpc_types::{FilterChanges, Index, Log};
 
 /// Rpc Interface for poll-based ethereum filter API.
 #[rpc(server)]
+#[cfg_attr(feature = "client", rpc(client,))]
 pub trait EthFilterApi {
     /// Creates anew filter and returns its id.
     #[method(name = "eth_newFilter")]

--- a/crates/net/rpc-api/src/eth_pubsub.rs
+++ b/crates/net/rpc-api/src/eth_pubsub.rs
@@ -3,6 +3,7 @@ use reth_rpc_types::pubsub::{Kind, Params};
 
 /// Ethereum pub-sub rpc interface.
 #[rpc(server)]
+#[cfg_attr(feature = "client", rpc(client,))]
 pub trait EthPubSubApi {
     /// Create an ethereum subscription.
     #[subscription(

--- a/crates/net/rpc-api/src/eth_pubsub.rs
+++ b/crates/net/rpc-api/src/eth_pubsub.rs
@@ -1,15 +1,15 @@
-use jsonrpsee::proc_macros::rpc;
+use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
 use reth_rpc_types::pubsub::{Kind, Params};
 
 /// Ethereum pub-sub rpc interface.
-#[rpc(server)]
-#[cfg_attr(feature = "client", rpc(client,))]
+#[cfg_attr(not(feature = "client"), rpc(server))]
+#[cfg_attr(feature = "client", rpc(server, client))]
 pub trait EthPubSubApi {
     /// Create an ethereum subscription.
     #[subscription(
         name = "eth_subscribe" => "eth_subscription",
         unsubscribe = "eth_unsubscribe",
-        item = pubsub::Result
+        item = Result
     )]
     fn subscribe(&self, kind: Kind, params: Option<Params>);
 }

--- a/crates/net/rpc-api/src/eth_pubsub.rs
+++ b/crates/net/rpc-api/src/eth_pubsub.rs
@@ -1,4 +1,4 @@
-use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
+use jsonrpsee::proc_macros::rpc;
 use reth_rpc_types::pubsub::{Kind, Params};
 
 /// Ethereum pub-sub rpc interface.
@@ -9,7 +9,7 @@ pub trait EthPubSubApi {
     #[subscription(
         name = "eth_subscribe" => "eth_subscription",
         unsubscribe = "eth_unsubscribe",
-        item = Result
+        item = reth_rpc_types::pubsub::SubscriptionResult
     )]
-    fn subscribe(&self, kind: Kind, params: Option<Params>);
+    fn eth_subscribe(&self, kind: Kind, params: Option<Params>);
 }

--- a/crates/net/rpc-api/src/net.rs
+++ b/crates/net/rpc-api/src/net.rs
@@ -3,6 +3,7 @@ use reth_rpc_types::PeerCount;
 
 /// Net rpc interface.
 #[rpc(server)]
+#[cfg_attr(feature = "client", rpc(client,))]
 pub trait NetApi {
     /// Returns protocol version.
     #[method(name = "net_version")]

--- a/crates/net/rpc-api/src/net.rs
+++ b/crates/net/rpc-api/src/net.rs
@@ -2,8 +2,8 @@ use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
 use reth_rpc_types::PeerCount;
 
 /// Net rpc interface.
-#[rpc(server)]
-#[cfg_attr(feature = "client", rpc(client,))]
+#[cfg_attr(not(feature = "client"), rpc(server))]
+#[cfg_attr(feature = "client", rpc(server, client))]
 pub trait NetApi {
     /// Returns protocol version.
     #[method(name = "net_version")]

--- a/crates/net/rpc-api/src/trace.rs
+++ b/crates/net/rpc-api/src/trace.rs
@@ -8,6 +8,7 @@ use std::collections::HashSet;
 
 /// Ethereum trace API
 #[rpc(server)]
+#[cfg_attr(feature = "client", rpc(client,))]
 pub trait TraceApi {
     /// Executes the given call and returns a number of possible traces for it.
     #[method(name = "trace_call")]

--- a/crates/net/rpc-api/src/trace.rs
+++ b/crates/net/rpc-api/src/trace.rs
@@ -7,8 +7,8 @@ use reth_rpc_types::{
 use std::collections::HashSet;
 
 /// Ethereum trace API
-#[rpc(server)]
-#[cfg_attr(feature = "client", rpc(client,))]
+#[cfg_attr(not(feature = "client"), rpc(server))]
+#[cfg_attr(feature = "client", rpc(server, client))]
 pub trait TraceApi {
     /// Executes the given call and returns a number of possible traces for it.
     #[method(name = "trace_call")]

--- a/crates/net/rpc-api/src/web3.rs
+++ b/crates/net/rpc-api/src/web3.rs
@@ -2,8 +2,8 @@ use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
 use reth_primitives::{Bytes, H256};
 
 /// Web3 rpc interface.
-#[rpc(server)]
-#[cfg_attr(feature = "client", rpc(client,))]
+#[cfg_attr(not(feature = "client"), rpc(server))]
+#[cfg_attr(feature = "client", rpc(server, client))]
 pub trait Web3Api {
     /// Returns current client version.
     #[method(name = "web3_clientVersion")]

--- a/crates/net/rpc-api/src/web3.rs
+++ b/crates/net/rpc-api/src/web3.rs
@@ -3,6 +3,7 @@ use reth_primitives::{Bytes, H256};
 
 /// Web3 rpc interface.
 #[rpc(server)]
+#[cfg_attr(feature = "client", rpc(client,))]
 pub trait Web3Api {
     /// Returns current client version.
     #[method(name = "web3_clientVersion")]

--- a/crates/net/rpc-types/src/eth/account.rs
+++ b/crates/net/rpc-types/src/eth/account.rs
@@ -1,16 +1,16 @@
 #![allow(missing_docs)]
 use reth_primitives::{Address, Bytes, H256, H512, U256, U64};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// Account information.
-#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct AccountInfo {
     /// Account name
     pub name: String,
 }
 
 /// Data structure with proof for one single storage-entry
-#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StorageProof {
     /// Storage key.
@@ -22,7 +22,7 @@ pub struct StorageProof {
 }
 
 /// Response for EIP-1186 account proof `eth_getProof`
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EIP1186AccountProofResponse {
     pub address: Address,
@@ -35,7 +35,7 @@ pub struct EIP1186AccountProofResponse {
 }
 
 /// Extended account information (used by `parity_allAccountInfo`).
-#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ExtAccountInfo {
     /// Account name
     pub name: String,
@@ -49,7 +49,7 @@ pub struct ExtAccountInfo {
 /// account derived from a signature
 /// as well as information that tells if it is valid for
 /// the current chain
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RecoveredAccount {
     /// address of the recovered account

--- a/crates/net/rpc-types/src/eth/block.rs
+++ b/crates/net/rpc-types/src/eth/block.rs
@@ -1,10 +1,10 @@
 use crate::Transaction;
 use reth_primitives::{rpc::H64, Address, Bloom, Bytes, H256, U256};
-use serde::{ser::Error, Serialize, Serializer};
+use serde::{ser::Error, Deserialize, Serialize, Serializer};
 use std::{collections::BTreeMap, ops::Deref};
 
 /// Block Transactions depending on the boolean attribute of `eth_getBlockBy*`
-#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum BlockTransactions {
     /// Only hashes
@@ -14,7 +14,7 @@ pub enum BlockTransactions {
 }
 
 /// Block representation
-#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Block {
     /// Header of the block
@@ -34,7 +34,7 @@ pub struct Block {
 }
 
 /// Block header representation.
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Header {
     /// Hash of the block
@@ -81,11 +81,12 @@ pub type RichBlock = Rich<Block>;
 pub type RichHeader = Rich<Header>;
 
 /// Value representation with additional info
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct Rich<T> {
     /// Standard value.
     pub inner: T,
     /// Additional fields that should be serialized into the `Block` object
+    #[serde(flatten)]
     pub extra_info: BTreeMap<String, serde_json::Value>,
 }
 

--- a/crates/net/rpc-types/src/eth/call.rs
+++ b/crates/net/rpc-types/src/eth/call.rs
@@ -1,8 +1,8 @@
 use reth_primitives::{rpc::transaction::eip2930::AccessListItem, Address, Bytes, U256};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Call request
-#[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize)]
+#[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(default, rename_all = "camelCase", deny_unknown_fields)]
 pub struct CallRequest {
     /// From

--- a/crates/net/rpc-types/src/eth/filter.rs
+++ b/crates/net/rpc-types/src/eth/filter.rs
@@ -1,6 +1,6 @@
 use crate::Log;
 use reth_primitives::H256;
-use serde::{Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Response of the `eth_getFilterChanges` RPC.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -23,5 +23,38 @@ impl Serialize for FilterChanges {
             FilterChanges::Hashes(hashes) => hashes.serialize(s),
             FilterChanges::Empty => (&[] as &[serde_json::Value]).serialize(s),
         }
+    }
+}
+
+impl<'de> Deserialize<'de> for FilterChanges {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Changes {
+            Logs(Vec<Log>),
+            Hashes(Vec<H256>),
+        }
+
+        let changes = Changes::deserialize(deserializer)?;
+        let changes = match changes {
+            Changes::Logs(vals) => {
+                if vals.is_empty() {
+                    FilterChanges::Empty
+                } else {
+                    FilterChanges::Logs(vals)
+                }
+            }
+            Changes::Hashes(vals) => {
+                if vals.is_empty() {
+                    FilterChanges::Empty
+                } else {
+                    FilterChanges::Hashes(vals)
+                }
+            }
+        };
+        Ok(changes)
     }
 }

--- a/crates/net/rpc-types/src/eth/index.rs
+++ b/crates/net/rpc-types/src/eth/index.rs
@@ -1,6 +1,6 @@
 use serde::{
     de::{Error, Visitor},
-    Deserialize, Deserializer,
+    Deserialize, Deserializer, Serialize, Serializer,
 };
 use std::fmt;
 
@@ -11,6 +11,15 @@ pub struct Index(usize);
 impl From<Index> for usize {
     fn from(idx: Index) -> Self {
         idx.0
+    }
+}
+
+impl Serialize for Index {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&format!("{:x}", self.0))
     }
 }
 

--- a/crates/net/rpc-types/src/eth/pubsub.rs
+++ b/crates/net/rpc-types/src/eth/pubsub.rs
@@ -18,7 +18,7 @@ pub enum SubscriptionResult {
 }
 
 /// Response type for a SyncStatus subscription
-#[derive(Debug, Serialize, Eq, PartialEq, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum PubSubSyncStatus {
     /// If not currently syncing, this should always be `false`
@@ -28,7 +28,7 @@ pub enum PubSubSyncStatus {
 }
 
 /// Sync status infos
-#[derive(Debug, Serialize, Eq, PartialEq, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[allow(missing_docs)]
 pub struct SyncStatusMetadata {
@@ -54,7 +54,7 @@ impl Serialize for SubscriptionResult {
 }
 
 /// Subscription kind.
-#[derive(Debug, Deserialize, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 pub enum Kind {
@@ -76,6 +76,18 @@ pub enum Params {
     None,
     /// Log parameters.
     Logs(Box<Filter>),
+}
+
+impl Serialize for Params {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Params::None => (&[] as &[serde_json::Value]).serialize(serializer),
+            Params::Logs(logs) => logs.serialize(serializer),
+        }
+    }
 }
 
 impl<'a> Deserialize<'a> for Params {

--- a/crates/net/rpc-types/src/eth/pubsub.rs
+++ b/crates/net/rpc-types/src/eth/pubsub.rs
@@ -5,7 +5,8 @@ use reth_primitives::{rpc::Filter, H256};
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 
 /// Subscription result.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(untagged)]
 pub enum SubscriptionResult {
     /// New block header.
     Header(Box<RichHeader>),

--- a/crates/net/rpc-types/src/eth/trace/filter.rs
+++ b/crates/net/rpc-types/src/eth/trace/filter.rs
@@ -1,9 +1,9 @@
 //! `trace_filter` types and support
 use reth_primitives::{Address, BlockNumber};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Trace filter.
-#[derive(Debug, PartialEq, Eq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 pub struct TraceFilter {

--- a/crates/net/rpc-types/src/eth/transaction/mod.rs
+++ b/crates/net/rpc-types/src/eth/transaction/mod.rs
@@ -9,10 +9,10 @@ pub use typed::*;
 use reth_primitives::{
     rpc::transaction::eip2930::AccessListItem, Address, Bytes, H256, H512, U256, U64,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// Transaction object
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Transaction {
     /// Hash

--- a/crates/net/rpc-types/src/eth/transaction/receipt.rs
+++ b/crates/net/rpc-types/src/eth/transaction/receipt.rs
@@ -1,8 +1,8 @@
 use reth_primitives::{rpc::Log, Address, Bloom, H256, U256, U64};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// Transaction receipt
-#[derive(Clone, Debug, Serialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TransactionReceipt {
     /// Transaction Hash.

--- a/crates/net/rpc-types/src/eth/work.rs
+++ b/crates/net/rpc-types/src/eth/work.rs
@@ -1,5 +1,9 @@
 use reth_primitives::{H256, U256};
-use serde::{Serialize, Serializer};
+use serde::{
+    de::{Error, SeqAccess, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+use std::fmt;
 
 /// The result of an `eth_getWork` request
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
@@ -25,5 +29,41 @@ impl Serialize for Work {
             }
             None => (&self.pow_hash, &self.seed_hash, &self.target).serialize(s),
         }
+    }
+}
+
+impl<'a> Deserialize<'a> for Work {
+    fn deserialize<D>(deserializer: D) -> Result<Work, D::Error>
+    where
+        D: Deserializer<'a>,
+    {
+        struct WorkVisitor;
+
+        impl<'a> Visitor<'a> for WorkVisitor {
+            type Value = Work;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(formatter, "Work object")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'a>,
+            {
+                let pow_hash = seq
+                    .next_element::<H256>()?
+                    .ok_or_else(|| A::Error::custom("missing pow hash"))?;
+                let seed_hash = seq
+                    .next_element::<H256>()?
+                    .ok_or_else(|| A::Error::custom("missing seed hash"))?;
+                let target = seq
+                    .next_element::<H256>()?
+                    .ok_or_else(|| A::Error::custom("missing target"))?;
+                let number = seq.next_element::<u64>()?;
+                Ok(Work { pow_hash, seed_hash, target, number })
+            }
+        }
+
+        deserializer.deserialize_any(WorkVisitor)
     }
 }


### PR DESCRIPTION
add optional client feature to generate RPC client API.

this will generate a client trait that is automatically implemented for jsonrpsee Client types and can be used to send request to a server.

also adds missing Deserialize impls, required by the Client trait.

prep for #35 