### PR TITLE
docs: add contributor docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,26 +2,6 @@
 
 *Blazing-fast implementation of the Ethereum protocol*
 
-![Github Actions](https://github.com/foundry-rs/reth/workflows/ci/badge.svg)
+## Docs
 
-## Directory Structure
-
-This repository contains several Rust crates that implement the different building blocks of an Ethereum node. The high-level structure of the repository is as follows:
-
-- `crates/`
-    - [`db/`](crates/db): Strongly typed database bindings to [LibMDBX](https://github.com/vorot93/libmdbx-rs/) containing read/write access to Ethereum state and historical data (transactions, blocks etc.)
-    - [`executor/`](crates/executor): Blazing-fast instrumented EVM using [`revm`](https://github.com/bluealloy/revm/). Used during consensus, syncing & during transaction simulation / gas estimation.
-    - [`interfaces/`](crates/interfaces): Traits containing common abstractions across the components used in the system. For ease of unit testing, each crate importing the interface is recommended to create mock/in-memory implementations of each trait.
-    - `net/`
-        - [`p2p`](crates/net/p2p): Implements the Ethereum P2P protocol.
-        - [`rpc-api`](crates/net/rpc-api): Traits 
-            - Supported transports: HTTP, WS, IPC
-            - Supported namespaces: `eth_`, `engine_`, `debug_`
-        - [`rpc`](crates/net/rpc): Implementation of all ETH JSON RPC traits defined in `rpc-api`.
-        - [`rpc-types`](crates/net/rpc-types): Types relevant for the RPC endpoints above, grouped by namespace
-    - [`primitives/`](crates/stages): Commonly used types in Reth.
-    - [`stages/`](crates/stages): The staged sync pipeline, including implementations of each stage.
-    - [`transaction-pool/`](crates/transaction-pool): An in-memory pending transactions pool.
-- [`crate-template`](crate-template): Template crate to use when instantiating new crates under `crates/`.
-- [`bin/`](bin): Where all binaries are stored.
-- [`examples/`](examples): Example usage of the reth stack as a library.
+Contributor docs can be found [here](./docs).

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 *Blazing-fast implementation of the Ethereum protocol*
 
+![Github Actions](https://github.com/foundry-rs/reth/workflows/ci/badge.svg)
+
 ## Docs
 
 Contributor docs can be found [here](./docs).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,6 @@
 ## reth Contributor Documentation
 
-This directory contains documentation for contributors on how the [repository](./repo) is structured, as well as high level [design documents](./design).
+This directory contains documentation for contributors.
+
+- [Repository and project structure](./repo)
+- [Design documents](./design)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+## reth Contributor Documentation
+
+This directory contains documentation for contributors on how the [repository](./repo) is structured, as well as high level [design documents](./design).

--- a/docs/repo/labels.md
+++ b/docs/repo/labels.md
@@ -1,0 +1,13 @@
+## Labels
+
+Each label in the repository has a description attached that describes what the label means.
+
+There are 7 label categories in the repository:
+
+- **Area labels**: These labels denote the general area of the project an issue or PR affects. These start with `A-`.
+- **Category labels**: These labels denote the type of issue or change being made, for example https://github.com/foundry-rs/reth/labels/C-bug or https://github.com/foundry-rs/reth/labels/C-enhancement. These start with `C-`.
+- **Difficulty labels**: These are reserved for the very easy or very hard issues. Any issue without one of these labels can be considered to be of "average difficulty". They start with `D-`.
+- **Meta labels**: These start with `M-` and convey meaning to the core contributors, usually about the release process.
+- **Platform labels**: These describe the platform an issue is present on. They start with `O-`.
+- **Priority labels**: These are reserved for issues that require more immediate attention (high priority and critical priority) and they start with `P-`.
+- **Status labels**: These labels convey meaning to contributors about an issue or PR's status, e.g. whether they are blocked or need triage.

--- a/docs/repo/labels.md
+++ b/docs/repo/labels.md
@@ -10,4 +10,4 @@ There are 7 label categories in the repository:
 - **Meta labels**: These start with `M-` and convey meaning to the core contributors, usually about the release process.
 - **Platform labels**: These describe the platform an issue is present on. They start with `O-`.
 - **Priority labels**: These are reserved for issues that require more immediate attention (high priority and critical priority) and they start with `P-`.
-- **Status labels**: These labels convey meaning to contributors about an issue or PR's status, e.g. whether they are blocked or need triage.
+- **Status labels**: These labels convey meaning to contributors about an issue or PR's status, e.g. whether they are blocked or need triage. They start with `S-`.

--- a/docs/repo/layout.md
+++ b/docs/repo/layout.md
@@ -1,0 +1,21 @@
+## Project Layout
+
+This repository contains several Rust crates that implement the different building blocks of an Ethereum node. The high-level structure of the repository is as follows:
+
+- `crates/`
+    - [`db/`](../../crates/db): Strongly typed database bindings to [LibMDBX](https://github.com/vorot93/libmdbx-rs/) containing read/write access to Ethereum state and historical data (transactions, blocks etc.)
+    - [`executor/`](../../crates/executor): Blazing-fast instrumented EVM using [`revm`](https://github.com/bluealloy/revm/). Used during consensus, syncing & during transaction simulation / gas estimation.
+    - [`interfaces/`](../../crates/interfaces): Traits containing common abstractions across the components used in the system. For ease of unit testing, each crate importing the interface is recommended to create mock/in-memory implementations of each trait.
+    - `net/`
+        - [`p2p`](../../crates/net/p2p): Implements the Ethereum P2P protocol.
+        - [`rpc-api`](../../crates/net/rpc-api): Traits
+            - Supported transports: HTTP, WS, IPC
+            - Supported namespaces: `eth_`, `engine_`, `debug_`
+        - [`rpc`](../../crates/net/rpc): Implementation of all ETH JSON RPC traits defined in `rpc-api`.
+        - [`rpc-types`](../../crates/net/rpc-types): Types relevant for the RPC endpoints above, grouped by namespace
+    - [`primitives/`](../../crates/stages): Commonly used types in Reth.
+    - [`stages/`](../../crates/stages): The staged sync pipeline, including implementations of each stage.
+    - [`transaction-pool/`](../../crates/transaction-pool): An in-memory pending transactions pool.
+- [`crate-template`](../../crate-template): Template crate to use when instantiating new crates under `crates/`.
+- [`bin/`](../../bin): Where all binaries are stored.
+- [`examples/`](../../examples): Example usage of the reth stack as a library.

--- a/docs/repo/layout.md
+++ b/docs/repo/layout.md
@@ -3,19 +3,18 @@
 This repository contains several Rust crates that implement the different building blocks of an Ethereum node. The high-level structure of the repository is as follows:
 
 - `crates/`
-    - [`db/`](../../crates/db): Strongly typed database bindings to [LibMDBX](https://github.com/vorot93/libmdbx-rs/) containing read/write access to Ethereum state and historical data (transactions, blocks etc.)
-    - [`executor/`](../../crates/executor): Blazing-fast instrumented EVM using [`revm`](https://github.com/bluealloy/revm/). Used during consensus, syncing & during transaction simulation / gas estimation.
-    - [`interfaces/`](../../crates/interfaces): Traits containing common abstractions across the components used in the system. For ease of unit testing, each crate importing the interface is recommended to create mock/in-memory implementations of each trait.
-    - `net/`
-        - [`p2p`](../../crates/net/p2p): Implements the Ethereum P2P protocol.
-        - [`rpc-api`](../../crates/net/rpc-api): Traits
-            - Supported transports: HTTP, WS, IPC
-            - Supported namespaces: `eth_`, `engine_`, `debug_`
-        - [`rpc`](../../crates/net/rpc): Implementation of all ETH JSON RPC traits defined in `rpc-api`.
-        - [`rpc-types`](../../crates/net/rpc-types): Types relevant for the RPC endpoints above, grouped by namespace
-    - [`primitives/`](../../crates/stages): Commonly used types in Reth.
-    - [`stages/`](../../crates/stages): The staged sync pipeline, including implementations of each stage.
-    - [`transaction-pool/`](../../crates/transaction-pool): An in-memory pending transactions pool.
+    - [`db`](../../crates/db): Strongly typed database bindings to [LibMDBX](https://github.com/vorot93/libmdbx-rs/) containing read/write access to Ethereum state and historical data (transactions, blocks etc.)
+    - [`executor`](../../crates/executor): Blazing-fast instrumented EVM using [`revm`](https://github.com/bluealloy/revm/). Used during consensus, syncing & during transaction simulation / gas estimation.
+    - [`interfaces`](../../crates/interfaces): Traits containing common abstractions across the components used in the system. For ease of unit testing, each crate importing the interface is recommended to create mock/in-memory implementations of each trait.
+    - [`net/p2p`](../../crates/net/p2p): Implements the Ethereum P2P protocol.
+    - [`net/rpc-api`](../../crates/net/rpc-api): Traits
+        - Supported transports: HTTP, WS, IPC
+        - Supported namespaces: `eth_`, `engine_`, `debug_`
+    - [`net/rpc`](../../crates/net/rpc): Implementation of all ETH JSON RPC traits defined in `rpc-api`.
+    - [`net/rpc-types`](../../crates/net/rpc-types): Types relevant for the RPC endpoints above, grouped by namespace
+    - [`primitives`](../../crates/stages): Commonly used types in Reth.
+    - [`stages`](../../crates/stages): The staged sync pipeline, including implementations of each stage.
+    - [`transaction-pool`](../../crates/transaction-pool): An in-memory pending transactions pool.
 - [`crate-template`](../../crate-template): Template crate to use when instantiating new crates under `crates/`.
-- [`bin/`](../../bin): Where all binaries are stored.
-- [`examples/`](../../examples): Example usage of the reth stack as a library.
+- [`bin`](../../bin): Where all binaries are stored.
+- [`examples`](../../examples): Example usage of the reth stack as a library.


### PR DESCRIPTION
I created a bunch of labels so we can start tracking progress etc. using issues and I thought it would make sense to document how they work in a contributor docs folder.

Longer term I envision us having small "guides" for debugging/profiling etc. in this directory, as well as design documents for the various components.