### PR TITLE
chore: migrate stages to new db abstractions

### DIFF
--- a/crates/db/src/kv/tables.rs
+++ b/crates/db/src/kv/tables.rs
@@ -1,7 +1,7 @@
 //! Declaration of all MDBX tables.
 
 use crate::utils::TableType;
-use reth_primitives::{Address, U256};
+use reth_primitives::{Address, BlockNumber, U256};
 
 /// Default tables that should be present inside database.
 pub const TABLES: [(TableType, &str); 18] = [
@@ -87,7 +87,7 @@ table!(StorageChangeSet => TxId => StorageKeyBeforeTx);
 table!(TxSenders => TxId => Address); // Is it necessary?
 table!(Config => ConfigKey => ConfigValue);
 
-table!(SyncStage => Vec<u8> => BNum);
+table!(SyncStage => Vec<u8> => BlockNumber);
 
 //
 // TODO: Temporary types, until they're properly defined alongside with the Encode and Decode Trait

--- a/crates/db/src/kv/tables.rs
+++ b/crates/db/src/kv/tables.rs
@@ -87,7 +87,7 @@ table!(StorageChangeSet => TxId => StorageKeyBeforeTx);
 table!(TxSenders => TxId => Address); // Is it necessary?
 table!(Config => ConfigKey => ConfigValue);
 
-table!(SyncStage => Vec<u8> => BlockNumber);
+table!(SyncStage => StageId => BlockNumber);
 
 //
 // TODO: Temporary types, until they're properly defined alongside with the Encode and Decode Trait
@@ -113,3 +113,4 @@ type TxIdList = Vec<u8>;
 type Address_StorageKey = Vec<u8>;
 type AccountBeforeTx = Vec<u8>;
 type StorageKeyBeforeTx = Vec<u8>;
+type StageId = Vec<u8>;

--- a/crates/db/src/kv/tables.rs
+++ b/crates/db/src/kv/tables.rs
@@ -4,7 +4,7 @@ use crate::utils::TableType;
 use reth_primitives::{Address, U256};
 
 /// Default tables that should be present inside database.
-pub const TABLES: [(TableType, &str); 17] = [
+pub const TABLES: [(TableType, &str); 18] = [
     (TableType::Table, CanonicalHeaders::const_name()),
     (TableType::Table, HeaderTD::const_name()),
     (TableType::Table, HeaderNumbers::const_name()),
@@ -22,6 +22,7 @@ pub const TABLES: [(TableType, &str); 17] = [
     (TableType::DupSort, StorageChangeSet::const_name()),
     (TableType::Table, TxSenders::const_name()),
     (TableType::Table, Config::const_name()),
+    (TableType::Table, SyncStage::const_name()),
 ];
 
 #[macro_export]
@@ -85,6 +86,8 @@ table!(StorageChangeSet => TxId => StorageKeyBeforeTx);
 
 table!(TxSenders => TxId => Address); // Is it necessary?
 table!(Config => ConfigKey => ConfigValue);
+
+table!(SyncStage => Vec<u8> => BNum_BHash);
 
 //
 // TODO: Temporary types, until they're properly defined alongside with the Encode and Decode Trait

--- a/crates/db/src/kv/tables.rs
+++ b/crates/db/src/kv/tables.rs
@@ -87,7 +87,7 @@ table!(StorageChangeSet => TxId => StorageKeyBeforeTx);
 table!(TxSenders => TxId => Address); // Is it necessary?
 table!(Config => ConfigKey => ConfigValue);
 
-table!(SyncStage => Vec<u8> => BNum_BHash);
+table!(SyncStage => Vec<u8> => BNum);
 
 //
 // TODO: Temporary types, until they're properly defined alongside with the Encode and Decode Trait

--- a/crates/stages/src/error.rs
+++ b/crates/stages/src/error.rs
@@ -1,5 +1,5 @@
 use crate::pipeline::PipelineEvent;
-use reth_db::mdbx;
+use reth_db::kv::KVError;
 use reth_primitives::BlockNumber;
 use thiserror::Error;
 use tokio::sync::mpsc::error::SendError;
@@ -17,7 +17,7 @@ pub enum StageError {
     },
     /// The stage encountered a database error.
     #[error("A database error occurred.")]
-    Database(#[from] mdbx::Error),
+    Database(#[from] KVError),
     /// The stage encountered an internal error.
     #[error(transparent)]
     Internal(Box<dyn std::error::Error + Send + Sync>),
@@ -31,7 +31,7 @@ pub enum PipelineError {
     Stage(#[from] StageError),
     /// The pipeline encountered a database error.
     #[error("A database error occurred.")]
-    Database(#[from] mdbx::Error),
+    Database(#[from] KVError),
     /// The pipeline encountered an error while trying to send an event.
     #[error("The pipeline encountered an error while trying to send an event.")]
     Channel(#[from] SendError<PipelineEvent>),

--- a/crates/stages/src/id.rs
+++ b/crates/stages/src/id.rs
@@ -1,4 +1,7 @@
-use reth_db::mdbx;
+use reth_db::{
+    kv::{tables::SyncStage, tx::Tx, KVError},
+    mdbx,
+};
 use reth_primitives::BlockNumber;
 use std::fmt::Display;
 
@@ -18,33 +21,25 @@ impl StageId {
     /// Get the last committed progress of this stage.
     pub fn get_progress<'db, K, E>(
         &self,
-        tx: &mdbx::Transaction<'db, K, E>,
-    ) -> Result<Option<BlockNumber>, mdbx::Error>
+        tx: &Tx<'db, K, E>,
+    ) -> Result<Option<BlockNumber>, KVError>
     where
         K: mdbx::TransactionKind,
         E: mdbx::EnvironmentKind,
     {
-        // TODO: Clean up when we get better database abstractions
-        let bytes: Option<Vec<u8>> = tx.get(&tx.open_db(Some("SyncStage"))?, self.0.as_ref())?;
-
+        let bytes = tx.get::<SyncStage>(self.0.as_bytes().to_vec())?;
         Ok(bytes.map(|b| BlockNumber::from_be_bytes(b.try_into().expect("Database corrupt"))))
     }
 
     /// Save the progress of this stage.
     pub fn save_progress<'db, E>(
         &self,
-        tx: &mdbx::Transaction<'db, mdbx::RW, E>,
+        tx: &Tx<'db, mdbx::RW, E>,
         block: BlockNumber,
-    ) -> Result<(), mdbx::Error>
+    ) -> Result<(), KVError>
     where
         E: mdbx::EnvironmentKind,
     {
-        // TODO: Clean up when we get better database abstractions
-        tx.put(
-            &tx.open_db(Some("SyncStage"))?,
-            self.0,
-            block.to_be_bytes(),
-            mdbx::WriteFlags::UPSERT,
-        )
+        tx.put::<SyncStage>(self.0.as_bytes().to_vec(), block.to_be_bytes().to_vec())
     }
 }

--- a/crates/stages/src/id.rs
+++ b/crates/stages/src/id.rs
@@ -27,7 +27,7 @@ impl StageId {
         K: mdbx::TransactionKind,
         E: mdbx::EnvironmentKind,
     {
-        Ok(tx.get::<SyncStage>(self.0.as_bytes().to_vec())?)
+        tx.get::<SyncStage>(self.0.as_bytes().to_vec())
     }
 
     /// Save the progress of this stage.

--- a/crates/stages/src/id.rs
+++ b/crates/stages/src/id.rs
@@ -27,8 +27,7 @@ impl StageId {
         K: mdbx::TransactionKind,
         E: mdbx::EnvironmentKind,
     {
-        let bytes = tx.get::<SyncStage>(self.0.as_bytes().to_vec())?;
-        Ok(bytes.map(|b| BlockNumber::from_be_bytes(b.try_into().expect("Database corrupt"))))
+        Ok(tx.get::<SyncStage>(self.0.as_bytes().to_vec())?)
     }
 
     /// Save the progress of this stage.
@@ -40,6 +39,6 @@ impl StageId {
     where
         E: mdbx::EnvironmentKind,
     {
-        tx.put::<SyncStage>(self.0.as_bytes().to_vec(), block.to_be_bytes().to_vec())
+        tx.put::<SyncStage>(self.0.as_bytes().to_vec(), block)
     }
 }

--- a/crates/stages/src/pipeline.rs
+++ b/crates/stages/src/pipeline.rs
@@ -3,7 +3,7 @@ use crate::{
     util::{db::TxContainer, opt::MaybeSender},
     ExecInput, ExecOutput, Stage, StageError, StageId, UnwindInput, UnwindOutput,
 };
-use reth_db::mdbx;
+use reth_db::{kv::Env, mdbx};
 use reth_primitives::BlockNumber;
 use std::fmt::{Debug, Formatter};
 use tokio::sync::mpsc::Sender;
@@ -118,7 +118,7 @@ where
 
     /// Run the pipeline in an infinite loop. Will terminate early if the user has specified
     /// a `max_block` in the pipeline.
-    pub async fn run(&mut self, db: &'db mdbx::Environment<E>) -> Result<(), PipelineError> {
+    pub async fn run(&mut self, db: &'db Env<E>) -> Result<(), PipelineError> {
         let mut state = PipelineState {
             events_sender: self.events_sender.clone(),
             max_block: self.max_block,
@@ -189,7 +189,7 @@ where
     /// If the unwind is due to a bad block the number of that block should be specified.
     pub async fn unwind(
         &mut self,
-        db: &'db mdbx::Environment<E>,
+        db: &'db Env<E>,
         to: BlockNumber,
         bad_block: Option<BlockNumber>,
     ) -> Result<(), PipelineError> {
@@ -208,7 +208,7 @@ where
         };
 
         // Unwind stages in reverse order of priority (i.e. higher priority = first)
-        let mut tx = db.begin_rw_txn()?;
+        let mut tx = db.begin_mut_tx()?;
         for (_, QueuedStage { stage, .. }) in unwind_pipeline.iter_mut() {
             let stage_id = stage.id();
             let span = info_span!("Unwinding", stage = %stage_id);
@@ -361,8 +361,11 @@ where
 mod tests {
     use super::*;
     use crate::{StageId, UnwindOutput};
-    use reth_db::mdbx;
-    use tempfile::tempdir;
+    use reth_db::{
+        kv::{tx::Tx, EnvKind},
+        mdbx,
+    };
+    use tempfile::TempDir;
     use tokio::sync::mpsc::channel;
     use tokio_stream::{wrappers::ReceiverStream, StreamExt};
     use utils::TestStage;
@@ -566,34 +569,15 @@ mod tests {
     mod utils {
         use super::*;
         use async_trait::async_trait;
+        use reth_db::kv::KVError;
         use std::{collections::VecDeque, error::Error};
 
-        // TODO: This is... not great.
-        pub(crate) fn test_db() -> Result<mdbx::Environment<mdbx::WriteMap>, mdbx::Error> {
-            const DB_TABLES: usize = 10;
-
-            // Build environment
-            let mut builder = mdbx::Environment::<mdbx::WriteMap>::new();
-            builder.set_max_dbs(DB_TABLES);
-            builder.set_geometry(mdbx::Geometry {
-                size: Some(0..usize::MAX),
-                growth_step: None,
-                shrink_threshold: None,
-                page_size: None,
-            });
-            builder.set_rp_augment_limit(16 * 256 * 1024);
-
-            // Open
-            let tempdir = tempdir().unwrap();
-            let path = tempdir.path();
-            std::fs::DirBuilder::new().recursive(true).create(path).unwrap();
-            let db = builder.open(path)?;
-
-            // Create tables
-            let tx = db.begin_rw_txn()?;
-            tx.create_db(Some("SyncStage"), mdbx::DatabaseFlags::default())?;
-            tx.commit()?;
-
+        pub(crate) fn test_db() -> Result<Env<mdbx::WriteMap>, KVError> {
+            let path =
+                TempDir::new().expect("Not able to create a temporary directory.").into_path();
+            let db = Env::<mdbx::WriteMap>::open(&path, EnvKind::RW)
+                .expect("Not able to open existing mdbx file.");
+            db.create_tables()?;
             Ok(db)
         }
 
@@ -633,7 +617,7 @@ mod tests {
 
             async fn execute<'tx>(
                 &mut self,
-                _: &mut mdbx::Transaction<'tx, mdbx::RW, E>,
+                _: &mut Tx<'tx, mdbx::RW, E>,
                 _: ExecInput,
             ) -> Result<ExecOutput, StageError>
             where
@@ -646,7 +630,7 @@ mod tests {
 
             async fn unwind<'tx>(
                 &mut self,
-                _: &mut mdbx::Transaction<'tx, mdbx::RW, E>,
+                _: &mut Tx<'tx, mdbx::RW, E>,
                 _: UnwindInput,
             ) -> Result<UnwindOutput, Box<dyn Error + Send + Sync>>
             where

--- a/crates/stages/src/stage.rs
+++ b/crates/stages/src/stage.rs
@@ -1,6 +1,6 @@
 use crate::{error::StageError, id::StageId};
 use async_trait::async_trait;
-use reth_db::mdbx;
+use reth_db::{kv::tx::Tx, mdbx};
 use reth_primitives::BlockNumber;
 
 /// Stage execution input, see [Stage::execute].
@@ -63,7 +63,7 @@ where
     /// Execute the stage.
     async fn execute<'tx>(
         &mut self,
-        tx: &mut mdbx::Transaction<'tx, mdbx::RW, E>,
+        tx: &mut Tx<'tx, mdbx::RW, E>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError>
     where
@@ -72,7 +72,7 @@ where
     /// Unwind the stage.
     async fn unwind<'tx>(
         &mut self,
-        tx: &mut mdbx::Transaction<'tx, mdbx::RW, E>,
+        tx: &mut Tx<'tx, mdbx::RW, E>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, Box<dyn std::error::Error + Send + Sync>>
     where


### PR DESCRIPTION
Migrate stages to use new db abstractions instead of built-in `mdbx::*` types