### PR TITLE
refactor(txpool): get rid of block number requirement

### DIFF
--- a/crates/transaction-pool/src/client.rs
+++ b/crates/transaction-pool/src/client.rs
@@ -1,24 +1,10 @@
 //! Provides access to the chain's storage
 
-use crate::{
-    error::{PoolError, PoolResult},
-    validate::TransactionValidator,
-};
-use reth_primitives::{BlockID, U64};
+use crate::{error::PoolError, validate::TransactionValidator};
 
 /// The interface used to interact with the blockchain and access storage.
 #[async_trait::async_trait]
 pub trait PoolClient: Send + Sync + TransactionValidator {
     /// Error type that can be converted to the crate's internal Error.
     type Error: Into<PoolError>;
-
-    /// Returns the block number for the given block identifier.
-    fn convert_block_id(&self, block_id: &BlockID) -> PoolResult<Option<U64>>;
-
-    /// Same as [`PoolClient::convert_block_id()`] but returns an error if no matching block number
-    /// was found
-    fn ensure_block_number(&self, block_id: &BlockID) -> PoolResult<U64> {
-        self.convert_block_id(block_id)
-            .and_then(|number| number.ok_or_else(|| PoolError::BlockNumberNotFound(*block_id)))
-    }
 }

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -23,11 +23,7 @@ pub trait TransactionPool: Send + Sync {
     /// Adds an _unvalidated_ transaction into the pool.
     ///
     /// Consumer: RPC
-    async fn add_transaction(
-        &self,
-        block_id: BlockID,
-        transaction: Self::Transaction,
-    ) -> PoolResult<TxHash>;
+    async fn add_transaction(&self, transaction: Self::Transaction) -> PoolResult<TxHash>;
 
     /// Adds the given _unvalidated_ transaction into the pool.
     ///
@@ -36,7 +32,6 @@ pub trait TransactionPool: Send + Sync {
     /// Consumer: RPC
     async fn add_transactions(
         &self,
-        block_id: BlockID,
         transactions: Vec<Self::Transaction>,
     ) -> PoolResult<Vec<PoolResult<TxHash>>>;
 

--- a/crates/transaction-pool/src/validate.rs
+++ b/crates/transaction-pool/src/validate.rs
@@ -38,7 +38,6 @@ pub trait TransactionValidator: Send + Sync {
     /// transactions for the sender.
     async fn validate_transaction(
         &self,
-        _block_id: &BlockID,
         _transaction: Self::Transaction,
     ) -> TransactionValidationOutcome<Self::Transaction> {
         unimplemented!()


### PR DESCRIPTION
As discussed here

https://github.com/foundry-rs/reth/pull/52#discussion_r993622222

> The newest known block (as in base fee, and forks) should already be known to txpool

this gets rid of the BlockId argument.

once merged, the `PoolClient` and `TransactionValidator` can be merged in a followup