### PR TITLE
feat(txpool): add listeners for all transactions

### DIFF
--- a/crates/transaction-pool/src/pool/state.rs
+++ b/crates/transaction-pool/src/pool/state.rs
@@ -32,7 +32,7 @@ bitflags::bitflags! {
 /// Identifier for the used Sub-pool
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
 #[repr(u8)]
-pub(crate) enum SubPool {
+pub enum SubPool {
     Queued = 0,
     Pending,
     BaseFee,
@@ -42,12 +42,12 @@ pub(crate) enum SubPool {
 
 impl SubPool {
     /// Whether this transaction is to be moved to the pending sub-pool.
-    pub(crate) fn is_pending(&self) -> bool {
+    pub fn is_pending(&self) -> bool {
         matches!(self, SubPool::Pending)
     }
 
     /// Returns whether this is a promotion depending on the current sub-pool location.
-    pub(crate) fn is_promoted(&self, other: SubPool) -> bool {
+    pub fn is_promoted(&self, other: SubPool) -> bool {
         self > &other
     }
 }

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -150,19 +150,19 @@ impl<T: TransactionOrdering> TxPool<T> {
 
         match self.all_transactions.insert_tx(tx, on_chain_balance, on_chain_nonce) {
             InsertResult::Inserted { transaction, move_to, replaced_tx, updates, .. } => {
-                self.add_new_transaction(transaction, replaced_tx, move_to);
+                self.add_new_transaction(transaction.clone(), replaced_tx, move_to);
                 let UpdateOutcome { promoted, discarded, removed } = self.process_updates(updates);
 
                 // This transaction was moved to the pending pool.
                 let res = if move_to.is_pending() {
                     AddedTransaction::Pending(AddedPendingTransaction {
-                        hash,
+                        transaction,
                         promoted,
                         discarded,
                         removed,
                     })
                 } else {
-                    AddedTransaction::Parked { hash }
+                    AddedTransaction::Parked { transaction, subpool: move_to }
                 };
 
                 Ok(res)


### PR DESCRIPTION
Allow registering listeners for _all_ added transaction objects

This adds a new listener set that sends newly added transactions over a set of `Sender` channels.