### PR TITLE
feat: skip/error pipeline events

### DIFF
--- a/crates/stages/src/pipeline/ctrl.rs
+++ b/crates/stages/src/pipeline/ctrl.rs
@@ -1,6 +1,7 @@
 use reth_primitives::BlockNumber;
 
 /// Determines the control flow during pipeline execution.
+#[derive(Debug)]
 pub(crate) enum ControlFlow {
     /// An unwind was requested and must be performed before continuing.
     Unwind {


### PR DESCRIPTION
Adds `PipelineEvent::Skipped` and `PipelineEvent::Error` events, adds a test that ensures the `require_tip` behavior works and includes a fix for pipeline state that was uncovered using the test (we need to reset `minimum_progress`/`maximum_progress` for each loop otherwise we get stuck)