### PR TITLE
refactor(txpool): consider below proto fee cap an error

### DIFF
--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -1,6 +1,6 @@
 //! Transaction pool errors
 
-use reth_primitives::BlockID;
+use reth_primitives::{BlockID, TxHash, U256};
 
 /// Transaction pool result type.
 pub type PoolResult<T> = Result<T, PoolError>;
@@ -9,15 +9,9 @@ pub type PoolResult<T> = Result<T, PoolError>;
 #[derive(Debug, thiserror::Error)]
 pub enum PoolError {
     /// Thrown if a replacement transaction's gas price is below the already imported transaction
-    #[error("Tx: insufficient gas price to replace existing transaction")]
-    ReplacementUnderpriced,
+    #[error("[{0:?}]: insufficient gas price to replace existing transaction.")]
+    ReplacementUnderpriced(TxHash),
     /// Encountered a transaction that was already added into the poll
-    #[error("[{0:?}] Already added")]
-    AlreadyAdded(Box<dyn std::any::Any + Send + Sync>),
-    /// Encountered a cycle in the graph pool
-    #[error("Transaction with cyclic dependent transactions")]
-    CyclicTransaction,
-    /// Thrown if no number was found for the given block id
-    #[error("Invalid block id: {0:?}")]
-    BlockNumberNotFound(BlockID),
+    #[error("[{0:?}] Transaction feeCap {1} below chain minimum.")]
+    ProtocolFeeCapTooLow(TxHash, U256),
 }

--- a/crates/transaction-pool/src/pool/state.rs
+++ b/crates/transaction-pool/src/pool/state.rs
@@ -4,10 +4,6 @@ bitflags::bitflags! {
     /// This mirrors [erigon's ephemeral state field](https://github.com/ledgerwatch/erigon/wiki/Transaction-Pool-Design#ordering-function).
     #[derive(Default)]
     pub(crate) struct TxState: u8 {
-        /// Set to `1` if the `feeCap` of the transaction meets the chain's minimum `feeCap` requirement.
-        ///
-        /// This is different from `ENOUGH_FEE_CAP_BLOCK` which tracks on a per-block basis.
-        const ENOUGH_FEE_CAP_PROTOCOL = 0b100000;
         /// Set to `1` of the transaction is either the next transaction of the sender (on chain nonce == tx.nonce) or all prior transactions are also present in the pool.
         const NO_NONCE_GAPS = 0b010000;
         /// Bit derived from the sender's balance.
@@ -23,9 +19,9 @@ bitflags::bitflags! {
         const ENOUGH_FEE_CAP_BLOCK = 0b000010;
         const IS_LOCAL = 0b000001;
 
-        const BASE_FEE_POOL_BITS = Self::ENOUGH_FEE_CAP_PROTOCOL.bits | Self::NO_NONCE_GAPS.bits | Self::ENOUGH_BALANCE.bits | Self::NOT_TOO_MUCH_GAS.bits;
+        const BASE_FEE_POOL_BITS = Self::NO_NONCE_GAPS.bits | Self::ENOUGH_BALANCE.bits | Self::NOT_TOO_MUCH_GAS.bits;
 
-        const QUEUED_POOL_BITS  = Self::ENOUGH_FEE_CAP_PROTOCOL.bits;
+        const QUEUED_POOL_BITS  = 0b100000;
     }
 }
 
@@ -73,5 +69,11 @@ mod tests {
         let mut state = TxState::default();
         state |= TxState::NO_NONCE_GAPS;
         assert!(state.intersects(TxState::NO_NONCE_GAPS))
+    }
+
+    #[test]
+    fn test_tx_queud() {
+        let mut state = TxState::default();
+        assert_eq!(SubPool::Queued, state.into());
     }
 }

--- a/crates/transaction-pool/src/test_util/mock.rs
+++ b/crates/transaction-pool/src/test_util/mock.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     identifier::{SenderIdentifiers, TransactionId},
-    pool::txpool::TxPool,
+    pool::txpool::{TxPool, MIN_PROTOCOL_BASE_FEE},
     PoolTransaction, TransactionOrdering, ValidPoolTransaction,
 };
 use paste::paste;
@@ -123,8 +123,8 @@ impl MockTransaction {
             hash: H256::random(),
             sender: Address::random(),
             nonce: 0,
-            max_fee_per_gas: U256::zero(),
-            max_priority_fee_per_gas: U256::zero(),
+            max_fee_per_gas: MIN_PROTOCOL_BASE_FEE,
+            max_priority_fee_per_gas: MIN_PROTOCOL_BASE_FEE,
             gas_limit: 0,
             value: Default::default(),
         }


### PR DESCRIPTION
instead of tracking the `feeCap_tx > proto_feecap` requirement as part of the state, treat it as an error.

This is sound, since a tx that can't satisfy this condition will never become valid, since the lower bound of the protocol feecap is constant (7 WEI).