### PR TITLE
chore(txpool): require public traits to have 'static lifetime

### DIFF
--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -9,7 +9,7 @@ use std::{fmt, sync::Arc};
 /// unverified transactions. And by block production that needs to get transactions to execute in a
 /// new block.
 #[async_trait::async_trait]
-pub trait TransactionPool: Send + Sync {
+pub trait TransactionPool: Send + Sync + 'static {
     /// The transaction type of the pool
     type Transaction: PoolTransaction;
 

--- a/crates/transaction-pool/src/validate.rs
+++ b/crates/transaction-pool/src/validate.rs
@@ -25,7 +25,7 @@ pub enum TransactionValidationOutcome<T: PoolTransaction> {
 
 /// Provides support for validating transaction at any given state of the chain
 #[async_trait::async_trait]
-pub trait TransactionValidator: Send + Sync {
+pub trait TransactionValidator: Send + Sync + 'static {
     /// The transaction type to validate.
     type Transaction: PoolTransaction;
 


### PR DESCRIPTION
expect types to be valid for `'static` this will make it easier to use as a field of that type.