### PR TITLE
refactor(txpool): simplify is local

### DIFF
--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -179,7 +179,6 @@ where
                     transaction,
                     transaction_id,
                     propagate: false,
-                    is_local: false,
                     timestamp: Instant::now(),
                     origin,
                 };

--- a/crates/transaction-pool/src/pool/state.rs
+++ b/crates/transaction-pool/src/pool/state.rs
@@ -19,7 +19,6 @@ bitflags::bitflags! {
         ///
         /// Set to 1 if `feeCap` of the transaction meets the requirement of the pending block.
         const ENOUGH_FEE_CAP_BLOCK = 0b000010;
-        const IS_LOCAL = 0b000001;
 
         const PENDING_POOL_BITS = Self::NO_PARKED_ANCESTORS.bits | Self::NO_NONCE_GAPS.bits | Self::ENOUGH_BALANCE.bits | Self::NOT_TOO_MUCH_GAS.bits |  Self::ENOUGH_FEE_CAP_BLOCK.bits;
 
@@ -112,7 +111,7 @@ mod tests {
         assert_eq!(SubPool::Pending, state.into());
         assert!(state.is_pending());
 
-        let bits = 0b111111;
+        let bits = 0b111110;
         let state = TxState::from_bits(bits).unwrap();
         assert_eq!(SubPool::Pending, state.into());
         assert!(state.is_pending());

--- a/crates/transaction-pool/src/test_util/mock.rs
+++ b/crates/transaction-pool/src/test_util/mock.rs
@@ -347,7 +347,6 @@ impl MockTransactionFactory {
         let transaction_id = self.tx_id(&transaction);
         MockValidTx {
             propagate: false,
-            is_local: false,
             transaction_id,
             cost: transaction.cost(),
             transaction,

--- a/crates/transaction-pool/src/validate.rs
+++ b/crates/transaction-pool/src/validate.rs
@@ -51,8 +51,6 @@ pub struct ValidPoolTransaction<T: PoolTransaction> {
     pub transaction_id: TransactionId,
     /// Whether to propagate the transaction.
     pub propagate: bool,
-    /// Whether the tx is from a local source.
-    pub is_local: bool,
     /// Total cost of the transaction: `feeCap x gasLimit + transferred_value`.
     pub cost: U256,
     /// Timestamp when this was added to the pool.
@@ -103,6 +101,11 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
     pub(crate) fn is_underpriced(&self, other: &Self) -> bool {
         self.transaction.effective_gas_price() <= other.transaction.effective_gas_price()
     }
+
+    /// Whether the transaction originated locally.
+    pub(crate) fn is_local(&self) -> bool {
+        self.origin.is_local()
+    }
 }
 
 #[cfg(test)]
@@ -112,7 +115,6 @@ impl<T: PoolTransaction + Clone> Clone for ValidPoolTransaction<T> {
             transaction: self.transaction.clone(),
             transaction_id: self.transaction_id,
             propagate: self.propagate,
-            is_local: self.is_local,
             cost: self.cost,
             timestamp: self.timestamp,
             origin: self.origin,


### PR DESCRIPTION
get rid of `IS_LOCAL` state bit and boolean `is_local` flag in favor of new `TransactionOrigin`