### PR TITLE
feat(txpool): enforce account tx capacity

### DIFF
--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -1,6 +1,6 @@
 //! Transaction pool errors
 
-use reth_primitives::{BlockID, TxHash, U256};
+use reth_primitives::{Address, BlockID, TxHash, U256};
 
 /// Transaction pool result type.
 pub type PoolResult<T> = Result<T, PoolError>;
@@ -14,4 +14,7 @@ pub enum PoolError {
     /// Encountered a transaction that was already added into the poll
     #[error("[{0:?}] Transaction feeCap {1} below chain minimum.")]
     ProtocolFeeCapTooLow(TxHash, U256),
+    /// Thrown when the number of unique transactions of a sender exceeded the slot capacity.
+    #[error("{0:?} identified as spammer. Transaction {1:?} rejected.")]
+    SpammerExceededCapacity(Address, TxHash),
 }

--- a/crates/transaction-pool/src/test_util/mock.rs
+++ b/crates/transaction-pool/src/test_util/mock.rs
@@ -331,7 +331,7 @@ impl PoolTransaction for MockTransaction {
 
 #[derive(Default)]
 pub struct MockTransactionFactory {
-    ids: SenderIdentifiers,
+    pub ids: SenderIdentifiers,
 }
 
 // === impl MockTransactionFactory ===
@@ -342,8 +342,16 @@ impl MockTransactionFactory {
         TransactionId::new(sender, tx.get_nonce())
     }
 
-    /// Converts the transaction into a validated transaction
     pub fn validated(&mut self, transaction: MockTransaction) -> MockValidTx {
+        self.validated_with_origin(TransactionOrigin::External, transaction)
+    }
+
+    /// Converts the transaction into a validated transaction
+    pub fn validated_with_origin(
+        &mut self,
+        origin: TransactionOrigin,
+        transaction: MockTransaction,
+    ) -> MockValidTx {
         let transaction_id = self.tx_id(&transaction);
         MockValidTx {
             propagate: false,
@@ -352,7 +360,7 @@ impl MockTransactionFactory {
             cost: transaction.cost(),
             transaction,
             timestamp: Instant::now(),
-            origin: TransactionOrigin::External,
+            origin,
         }
     }
 


### PR DESCRIPTION
detect spammers by enforcing the configured `max_account_slots` for external transactions.