### PR TITLE
feat(api): add StorageProvider trait

### DIFF
--- a/crates/interfaces/src/provider/mod.rs
+++ b/crates/interfaces/src/provider/mod.rs
@@ -1,3 +1,5 @@
 mod block;
+mod storage;
 
 pub use block::BlockProvider;
+pub use storage::StorageProvider;

--- a/crates/interfaces/src/provider/storage.rs
+++ b/crates/interfaces/src/provider/storage.rs
@@ -1,0 +1,8 @@
+use crate::Result;
+use reth_primitives::{rpc::BlockId, Address, H256, U256};
+
+/// Provides access to storage data
+pub trait StorageProvider {
+    /// Returns the value from a storage position at a given address and `BlockId`
+    fn storage_at(&self, address: Address, index: U256, at: BlockId) -> Result<Option<H256>>;
+}


### PR DESCRIPTION
add API trait, intended to be used for things like `eth_getStorageAt `