### PR TITLE
feat(txpool): enforce size limits

### DIFF
--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -5,11 +5,11 @@ pub(crate) const MAX_ACCOUNT_SLOTS_PER_SENDER: usize = 16;
 #[derive(Debug, Clone)]
 pub struct PoolConfig {
     /// Max number of transaction in the pending sub-pool
-    pub pending_limit: usize,
+    pub pending_limit: SubPoolLimit,
     /// Max number of transaction in the basefee sub-pool
-    pub basefee_limit: usize,
+    pub basefee_limit: SubPoolLimit,
     /// Max number of transaction in the queued sub-pool
-    pub queued_limit: usize,
+    pub queued_limit: SubPoolLimit,
     /// Max number of executable transaction slots guaranteed per account
     pub max_account_slots: usize,
 }
@@ -17,10 +17,34 @@ pub struct PoolConfig {
 impl Default for PoolConfig {
     fn default() -> Self {
         Self {
-            pending_limit: 10_000,
-            basefee_limit: 10_000,
-            queued_limit: 10_000,
+            pending_limit: Default::default(),
+            basefee_limit: Default::default(),
+            queued_limit: Default::default(),
             max_account_slots: MAX_ACCOUNT_SLOTS_PER_SENDER,
         }
+    }
+}
+
+/// Size limits for a sub-pool.
+#[derive(Debug, Clone)]
+pub struct SubPoolLimit {
+    /// Max. amount of transaction in the pool.
+    pub max_txs: usize,
+    /// Max. combined size of transactions in the pool.
+    pub max_size: usize,
+}
+
+impl SubPoolLimit {
+    /// Returns whether the size or amount constraint is violated.
+    #[inline]
+    pub fn is_exceeded(&self, txs: usize, size: usize) -> bool {
+        self.max_txs < txs || self.max_size < size
+    }
+}
+
+impl Default for SubPoolLimit {
+    fn default() -> Self {
+        // either 10k transactions or 20MB
+        Self { max_txs: 10_000, max_size: 20 * 1024 * 1024 }
     }
 }

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -17,4 +17,8 @@ pub enum PoolError {
     /// Thrown when the number of unique transactions of a sender exceeded the slot capacity.
     #[error("{0:?} identified as spammer. Transaction {1:?} rejected.")]
     SpammerExceededCapacity(Address, TxHash),
+    /// Thrown when a new transaction is added to the pool, but then immediately discarded to
+    /// respect the size limits of the pool.
+    #[error("[{0:?}] Transaction discarded outright due to pool size constraints.")]
+    DiscardedOnInsert(TxHash),
 }

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -64,7 +64,7 @@
 //!    category (2.) and become pending.
 
 use crate::{
-    error::PoolResult,
+    error::{PoolError, PoolResult},
     identifier::{SenderId, SenderIdentifiers, TransactionId},
     pool::{listener::PoolEventListener, state::SubPool, txpool::TxPool},
     traits::{NewTransactionEvent, PoolStatus, PoolTransaction, TransactionOrigin},
@@ -76,7 +76,11 @@ pub use events::TransactionEvent;
 use futures::channel::mpsc::{channel, Receiver, Sender};
 use parking_lot::{Mutex, RwLock};
 use reth_primitives::{Address, TxHash};
-use std::{collections::HashMap, sync::Arc, time::Instant};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::Instant,
+};
 use tracing::warn;
 
 mod best;
@@ -170,6 +174,9 @@ where
     }
 
     /// Add a single validated transaction into the pool.
+    ///
+    /// Note: this is only used internally by [`Self::add_transactions()`], all new transaction(s)
+    /// come in through that function, either as a batch or `std::iter::once`.
     fn add_transaction(
         &self,
         origin: TransactionOrigin,
@@ -218,9 +225,28 @@ where
         origin: TransactionOrigin,
         transactions: impl IntoIterator<Item = TransactionValidationOutcome<T::Transaction>>,
     ) -> Vec<PoolResult<TxHash>> {
-        // TODO check pool limits
+        let added =
+            transactions.into_iter().map(|tx| self.add_transaction(origin, tx)).collect::<Vec<_>>();
 
-        transactions.into_iter().map(|tx| self.add_transaction(origin, tx)).collect::<Vec<_>>()
+        // If at least one transaction was added successfully, then we enforce the pool size limits.
+        let discarded =
+            if added.iter().any(Result::is_ok) { self.discard_worst() } else { Default::default() };
+
+        if discarded.is_empty() {
+            return added
+        }
+
+        // It may happen that a newly added transaction is immediately discarded, so we need to
+        // adjust the result here
+        added
+            .into_iter()
+            .map(|res| match res {
+                Ok(ref hash) if discarded.contains(hash) => {
+                    Err(PoolError::DiscardedOnInsert(*hash))
+                }
+                other => other,
+            })
+            .collect()
     }
 
     /// Notify all listeners about a new pending transaction.
@@ -309,6 +335,11 @@ where
     /// Whether the pool is empty
     pub(crate) fn is_empty(&self) -> bool {
         self.pool.read().is_empty()
+    }
+
+    /// Enforces the size limits of pool and returns the discarded transactions if violated.
+    pub(crate) fn discard_worst(&self) -> HashSet<TxHash> {
+       self.pool.write().discard_worst().into_iter().map(|tx|*tx.hash()).collect()
     }
 }
 

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -339,7 +339,7 @@ where
 
     /// Enforces the size limits of pool and returns the discarded transactions if violated.
     pub(crate) fn discard_worst(&self) -> HashSet<TxHash> {
-       self.pool.write().discard_worst().into_iter().map(|tx|*tx.hash()).collect()
+        self.pool.write().discard_worst().into_iter().map(|tx| *tx.hash()).collect()
     }
 }
 

--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -15,7 +15,7 @@ pub(crate) struct ParkedPool<T: ParkedOrd> {
     submission_id: u64,
     /// _All_ Transactions that are currently inside the pool grouped by their identifier.
     by_id: FnvHashMap<TransactionId, ParkedPoolTransaction<T>>,
-    /// All transactions sorted by their priority function.
+    /// All transactions sorted by their order function.
     best: BTreeSet<ParkedPoolTransaction<T>>,
     /// Keeps track of the size of this pool.
     ///
@@ -58,6 +58,12 @@ impl<T: ParkedOrd> ParkedPool<T> {
         self.size_of -= tx.transaction.size();
 
         Some(tx.transaction.into())
+    }
+
+    /// Removes the worst transaction from this pool.
+    pub(crate) fn pop_worst(&mut self) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let worst = self.best.iter().next_back().map(|tx| *tx.transaction.id())?;
+        self.remove_transaction(&worst)
     }
 
     fn next_id(&mut self) -> u64 {


### PR DESCRIPTION
adds support for enforcing size limits.

we check limits after insert and discard transactions as long as limits are exceeded.

this needs additional tests, but first needs better testing support to make it easier to test.

will do that in a followup together with tests for #69 