### PR TITLE
feat(primitives): transaction encoding tests

### DIFF
--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -413,9 +413,7 @@ impl Encodable for TransactionKind {
 
 impl Decodable for TransactionKind {
     fn decode(buf: &mut &[u8]) -> Result<Self, DecodeError> {
-        println!("buf: {:x?}", buf);
         if let Some(&first) = buf.first() {
-            println!("first: {:x?}", first);
             if first == EMPTY_STRING_CODE {
                 buf.advance(1);
                 Ok(TransactionKind::Create)
@@ -503,17 +501,13 @@ impl Decodable for TransactionSigned {
         // keep this around so we can use it to calculate the hash
         let original_encoding = *buf;
 
-        println!("!encoding: {:x?}", buf);
         let header = Header::decode(buf)?;
-        println!("header: {:?}", header);
         // if the transaction is encoded as a string then it is a typed transaction
         if !header.list {
-            println!("typed tx");
             let tx_type = *buf
                 .first()
                 .ok_or(DecodeError::Custom("typed tx cannot be decoded from an empty slice"))?;
             buf.advance(1);
-            println!("tx_type: {:x?}", tx_type);
             // decode the list header for the rest of the transaction
             let header = Header::decode(buf)?;
             if !header.list {
@@ -569,7 +563,6 @@ impl Decodable for TransactionSigned {
             }
 
             let hash = keccak256(original_encoding).into();
-            println!("hash: {:x?}", hash);
             Ok(TransactionSigned { transaction, hash, signature })
         }
     }
@@ -592,8 +585,6 @@ impl TransactionSigned {
         let mut initial_tx = Self { transaction, hash: Default::default(), signature };
         let mut buf = Vec::new();
         initial_tx.encode(&mut buf);
-        println!("tx: {:x?}", initial_tx);
-        println!("?encoding: {:x?}", buf);
         initial_tx.hash = keccak256(&buf).into();
         initial_tx
     }
@@ -811,7 +802,6 @@ mod tests {
         let expected =
             TransactionSigned::from_transaction_and_signature(expected, expected_signature);
         assert_eq!(expected, TransactionSigned::decode(bytes_fourth).unwrap());
-        println!("{:?}", expected.hash);
 
         let bytes_fifth = &mut &hex::decode("f8650f84832156008287fb94cf7f9e66af820a19257a2108375b180b0ec491678204d2802ca035b7bfeb9ad9ece2cbafaaf8e202e706b4cfaeb233f46198f00b44d4a566a981a0612638fb29427ca33b9a3be2a0a561beecfe0269655be160d35e72d366a6a860").unwrap()[..];
         let expected = Transaction::Legacy {
@@ -835,6 +825,5 @@ mod tests {
 
         let expected = TransactionSigned::from_transaction_and_signature(expected, signature);
         assert_eq!(expected, TransactionSigned::decode(bytes_fifth).unwrap());
-        println!("{:?}", expected.hash);
     }
 }

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -532,3 +532,228 @@ impl TransactionSigned {
         initial_tx
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use crate::{
+        transaction::{signature::Signature, TransactionKind},
+        Address, Transaction, TransactionSigned, H256, U256,
+    };
+    use bytes::BytesMut;
+    use ethers_core::{types::Bytes, utils::hex};
+    use reth_rlp::{Decodable, Encodable};
+
+    #[test]
+    fn test_decode_create() {
+        panic!("not implemented");
+        // tests that a contract creation tx encodes and decodes properly
+        let tx = TransactionSigned {
+            transaction: Transaction::Eip2930 {
+                chain_id: 1u64,
+                nonce: 0,
+                gas_price: 1,
+                gas_limit: 2,
+                to: TransactionKind::Create,
+                value: U256::from(3),
+                input: Bytes::from(vec![1, 2]),
+                access_list: Default::default(),
+            },
+            hash: H256::default(),
+            signature: Signature { y_parity: 1, r: U256::default(), s: U256::default() },
+        };
+
+        let mut encoded = BytesMut::new();
+        tx.encode(&mut encoded);
+
+        let decoded = TransactionSigned::decode(&mut &*encoded).unwrap();
+        assert_eq!(decoded, tx);
+    }
+
+    #[test]
+    fn test_decode_create_goerli() {
+        panic!("not implemented");
+        // test that an example create tx from goerli decodes properly
+        let tx_bytes =
+              hex::decode("02f901ee05228459682f008459682f11830209bf8080b90195608060405234801561001057600080fd5b50610175806100206000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c80630c49c36c14610030575b600080fd5b61003861004e565b604051610045919061011d565b60405180910390f35b60606020600052600f6020527f68656c6c6f2073746174656d696e64000000000000000000000000000000000060405260406000f35b600081519050919050565b600082825260208201905092915050565b60005b838110156100be5780820151818401526020810190506100a3565b838111156100cd576000848401525b50505050565b6000601f19601f8301169050919050565b60006100ef82610084565b6100f9818561008f565b93506101098185602086016100a0565b610112816100d3565b840191505092915050565b6000602082019050818103600083015261013781846100e4565b90509291505056fea264697066735822122051449585839a4ea5ac23cae4552ef8a96b64ff59d0668f76bfac3796b2bdbb3664736f6c63430008090033c080a0136ebffaa8fc8b9fda9124de9ccb0b1f64e90fbd44251b4c4ac2501e60b104f9a07eb2999eec6d185ef57e91ed099afb0a926c5b536f0155dd67e537c7476e1471")
+                  .unwrap();
+        let _decoded = TransactionSigned::decode(&mut &tx_bytes[..]).unwrap();
+    }
+
+    #[test]
+    fn test_decode_call() {
+        let request = Transaction::Eip2930 {
+            chain_id: 1u64,
+            nonce: 0,
+            gas_price: 1,
+            gas_limit: 2,
+            to: TransactionKind::Call(Address::default()),
+            value: U256::from(3),
+            input: Bytes::from(vec![1, 2]),
+            access_list: Default::default(),
+        };
+
+        let signature = Signature { y_parity: 1, r: U256::default(), s: U256::default() };
+
+        let tx = TransactionSigned::from_transaction_and_signature(request, signature);
+
+        let mut encoded = BytesMut::new();
+        tx.encode(&mut encoded);
+
+        let decoded = TransactionSigned::decode(&mut &*encoded).unwrap();
+        assert_eq!(decoded, tx);
+    }
+
+    #[test]
+    fn decode_transaction_consumes_buffer() {
+        panic!("not implemented");
+        let bytes = &mut &hex::decode("b87502f872041a8459682f008459682f0d8252089461815774383099e24810ab832a5b2a5425c154d58829a2241af62c000080c001a059e6b67f48fb32e7e570dfb11e042b5ad2e55e3ce3ce9cd989c7e06e07feeafda0016b83f4f980694ed2eee4d10667242b1f40dc406901b34125b008d334d47469").unwrap()[..];
+        let _transaction_res = TransactionSigned::decode(bytes).unwrap();
+        assert_eq!(
+            bytes.len(),
+            0,
+            "did not consume all bytes in the buffer, {:?} remaining",
+            bytes.len()
+        );
+    }
+
+    #[test]
+    fn decode_multiple_network_txs() {
+        panic!("not implemented");
+        let bytes_first = &mut &hex::decode("f86b02843b9aca00830186a094d3e8763675e4c425df46cc3b5c0f6cbdac39604687038d7ea4c68000802ba00eb96ca19e8a77102767a41fc85a36afd5c61ccb09911cec5d3e86e193d9c5aea03a456401896b1b6055311536bf00a718568c744d8c1f9df59879e8350220ca18").unwrap()[..];
+        let expected_request = Transaction::Eip1559 {
+            chain_id: 1u64,
+            nonce: 2,
+            max_priority_fee_per_gas: 1000000000,
+            max_fee_per_gas: 10000000000,
+            gas_limit: 21000,
+            to: TransactionKind::Call(
+                Address::from_str("d3e8763675e4c425df46cc3b5c0f6cbdac396046").unwrap(),
+            ),
+            value: U256::from(1000000000000000000u64),
+            input: Bytes::default(),
+            access_list: Default::default(),
+        };
+        let expected_signature = Signature {
+            y_parity: 0,
+            r: U256::from_str("0eb96ca19e8a77102767a41fc85a36afd5c61ccb09911cec5d3e86e193d9c5ae")
+                .unwrap(),
+            s: U256::from_str("3a456401896b1b6055311536bf00a718568c744d8c1f9df59879e8350220ca18")
+                .unwrap(),
+        };
+        let expected =
+            TransactionSigned::from_transaction_and_signature(expected_request, expected_signature);
+        assert_eq!(expected, TransactionSigned::decode(bytes_first).unwrap());
+
+        let bytes_second = &mut &hex::decode("f86b01843b9aca00830186a094d3e8763675e4c425df46cc3b5c0f6cbdac3960468702769bb01b2a00802ba0e24d8bd32ad906d6f8b8d7741e08d1959df021698b19ee232feba15361587d0aa05406ad177223213df262cb66ccbb2f46bfdccfdfbbb5ffdda9e2c02d977631da").unwrap()[..];
+        let expected_request = Transaction::Legacy {
+            chain_id: Some(4),
+            nonce: 1u64,
+            gas_price: 1000000000u64,
+            gas_limit: 100000u64,
+            to: TransactionKind::Call(Address::from_slice(
+                &hex::decode("d3e8763675e4c425df46cc3b5c0f6cbdac396046").unwrap()[..],
+            )),
+            value: 693361000000000u64.into(),
+            input: Default::default(),
+        };
+        let expected_signature = Signature {
+            y_parity: 0,
+            r: U256::from_str("e24d8bd32ad906d6f8b8d7741e08d1959df021698b19ee232feba15361587d0a")
+                .unwrap(),
+            s: U256::from_str("5406ad177223213df262cb66ccbb2f46bfdccfdfbbb5ffdda9e2c02d977631da")
+                .unwrap(),
+        };
+
+        let expected =
+            TransactionSigned::from_transaction_and_signature(expected_request, expected_signature);
+        assert_eq!(expected, TransactionSigned::decode(bytes_second).unwrap());
+
+        let bytes_third = &mut &hex::decode("f86b0384773594008398968094d3e8763675e4c425df46cc3b5c0f6cbdac39604687038d7ea4c68000802ba0ce6834447c0a4193c40382e6c57ae33b241379c5418caac9cdc18d786fd12071a03ca3ae86580e94550d7c071e3a02eadb5a77830947c9225165cf9100901bee88").unwrap()[..];
+        let expected_request = Transaction::Legacy {
+            chain_id: Some(4),
+            nonce: 3u64.into(),
+            gas_price: 2000000000u64.into(),
+            gas_limit: 10000000u64.into(),
+            to: TransactionKind::Call(Address::from_slice(
+                &hex::decode("d3e8763675e4c425df46cc3b5c0f6cbdac396046").unwrap()[..],
+            )),
+            value: 1000000000000000u64.into(),
+            input: Bytes::default(),
+        };
+
+        let expected_signature = Signature {
+            y_parity: 0,
+            r: U256::from_str("ce6834447c0a4193c40382e6c57ae33b241379c5418caac9cdc18d786fd12071")
+                .unwrap(),
+            s: U256::from_str("3ca3ae86580e94550d7c071e3a02eadb5a77830947c9225165cf9100901bee88")
+                .unwrap(),
+        };
+
+        let expected =
+            TransactionSigned::from_transaction_and_signature(expected_request, expected_signature);
+        assert_eq!(expected, TransactionSigned::decode(bytes_third).unwrap());
+
+        let bytes_fourth = &mut &hex::decode("b87502f872041a8459682f008459682f0d8252089461815774383099e24810ab832a5b2a5425c154d58829a2241af62c000080c001a059e6b67f48fb32e7e570dfb11e042b5ad2e55e3ce3ce9cd989c7e06e07feeafda0016b83f4f980694ed2eee4d10667242b1f40dc406901b34125b008d334d47469").unwrap()[..];
+        let expected = Transaction::Eip1559 {
+            chain_id: 4,
+            nonce: 26u64.into(),
+            max_priority_fee_per_gas: 1500000000u64.into(),
+            max_fee_per_gas: 1500000013u64.into(),
+            gas_limit: 21000u64.into(),
+            to: TransactionKind::Call(Address::from_slice(
+                &hex::decode("61815774383099e24810ab832a5b2a5425c154d5").unwrap()[..],
+            )),
+            value: 3000000000000000000u64.into(),
+            input: Default::default(),
+            access_list: Default::default(),
+        };
+
+        let expected_signature = Signature {
+            y_parity: 1,
+            r: U256::from_str("59e6b67f48fb32e7e570dfb11e042b5ad2e55e3ce3ce9cd989c7e06e07feeafd")
+                .unwrap(),
+            s: U256::from_str("016b83f4f980694ed2eee4d10667242b1f40dc406901b34125b008d334d47469")
+                .unwrap(),
+        };
+
+        let expected =
+            TransactionSigned::from_transaction_and_signature(expected, expected_signature);
+        assert_eq!(expected, TransactionSigned::decode(bytes_fourth).unwrap());
+
+        let bytes_fifth = &mut &hex::decode("f8650f84832156008287fb94cf7f9e66af820a19257a2108375b180b0ec491678204d2802ca035b7bfeb9ad9ece2cbafaaf8e202e706b4cfaeb233f46198f00b44d4a566a981a0612638fb29427ca33b9a3be2a0a561beecfe0269655be160d35e72d366a6a860").unwrap()[..];
+        let expected = Transaction::Legacy {
+            chain_id: Some(4),
+            nonce: 15u64.into(),
+            gas_price: 2200000000u64.into(),
+            gas_limit: 34811u64.into(),
+            to: TransactionKind::Call(Address::from_slice(
+                &hex::decode("cf7f9e66af820a19257a2108375b180b0ec49167").unwrap()[..],
+            )),
+            value: 1234u64.into(),
+            input: Bytes::default(),
+        };
+        let signature = Signature {
+            y_parity: 1,
+            r: U256::from_str("35b7bfeb9ad9ece2cbafaaf8e202e706b4cfaeb233f46198f00b44d4a566a981")
+                .unwrap(),
+            s: U256::from_str("612638fb29427ca33b9a3be2a0a561beecfe0269655be160d35e72d366a6a860")
+                .unwrap(),
+        };
+
+        let expected = TransactionSigned::from_transaction_and_signature(expected, signature);
+        assert_eq!(expected, TransactionSigned::decode(bytes_fifth).unwrap());
+    }
+
+    // <https://github.com/gakonst/ethers-rs/issues/1732>
+    #[test]
+    fn test_recover_legacy_tx() {
+        let raw_tx = "f9015482078b8505d21dba0083022ef1947a250d5630b4cf539739df2c5dacb4c659f2488d880c46549a521b13d8b8e47ff36ab50000000000000000000000000000000000000000000066ab5a608bd00a23f2fe000000000000000000000000000000000000000000000000000000000000008000000000000000000000000048c04ed5691981c42154c6167398f95e8f38a7ff00000000000000000000000000000000000000000000000000000000632ceac70000000000000000000000000000000000000000000000000000000000000002000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000006c6ee5e31d828de241282b9606c8e98ea48526e225a0c9077369501641a92ef7399ff81c21639ed4fd8fc69cb793cfa1dbfab342e10aa0615facb2f1bcf3274a354cfe384a38d0cc008a11c2dd23a69111bc6930ba27a8";
+
+        let tx = TransactionSigned::decode(&mut &hex::decode(raw_tx).unwrap()[..]).unwrap();
+        // let recovered = tx.recover().unwrap();
+        // let expected: Address = "0xa12e1462d0ced572f396f58b6e2d03894cd7c8a4".parse().unwrap();
+        // assert_eq!(expected, recovered);
+    }
+}

--- a/crates/primitives/src/transaction/signature.rs
+++ b/crates/primitives/src/transaction/signature.rs
@@ -12,21 +12,22 @@ pub struct Signature {
     /// The S field of the signature; the point on the curve.
     pub s: U256,
     /// yParity: Signature Y parity; formally Ty
-    pub y_parity: u8,
+    pub odd_y_parity: bool,
 }
 
 impl Signature {
     /// Encode the `v`, `r`, `s` values without a RLP header.
-    /// Encodes the `v` value without EIP-155.
-    pub(crate) fn encode_inner(&self, out: &mut dyn reth_rlp::BufMut) {
-        (self.y_parity + 27).encode(out);
+    /// Encodes the `v` value using the legacy scheme without EIP-155.
+    pub(crate) fn encode_inner_legacy(&self, out: &mut dyn reth_rlp::BufMut) {
+        (self.odd_y_parity as u8 + 27).encode(out);
         self.r.encode(out);
         self.s.encode(out);
     }
 
-    /// Output the length of the signature without the length of the RLP header, without EIP-155.
-    pub(crate) fn payload_len(&self) -> usize {
-        (self.y_parity + 27).length() + self.r.length() + self.s.length()
+    /// Output the length of the signature without the length of the RLP header, using the legacy
+    /// scheme without EIP-155.
+    pub(crate) fn payload_len_legacy(&self) -> usize {
+        (self.odd_y_parity as u8 + 27).length() + self.r.length() + self.s.length()
     }
 
     /// Encode the `v`, `r`, `s` values without a RLP header.
@@ -34,7 +35,7 @@ impl Signature {
     pub(crate) fn encode_eip155_inner(&self, out: &mut dyn reth_rlp::BufMut, chain_id: u64) {
         // EIP-155: v = {0, 1} + CHAIN_ID * 2 + 35
         // assumes y_parity is 0 or 1
-        let v = chain_id * 2 + 35 + self.y_parity as u64;
+        let v = chain_id * 2 + 35 + self.odd_y_parity as u64;
         v.encode(out);
         self.r.encode(out);
         self.s.encode(out);
@@ -45,7 +46,7 @@ impl Signature {
     pub(crate) fn eip155_payload_len(&self, chain_id: u64) -> usize {
         // EIP-155: v = {0, 1} + CHAIN_ID * 2 + 35
         // assumes y_parity is 0 or 1
-        let v = chain_id * 2 + 35 + self.y_parity as u64;
+        let v = chain_id * 2 + 35 + self.odd_y_parity as u64;
         v.length() + self.r.length() + self.s.length()
     }
 
@@ -57,11 +58,13 @@ impl Signature {
         let s = Decodable::decode(buf)?;
         if v >= 35 {
             // EIP-155: v = {0, 1} + CHAIN_ID * 2 + 35
-            let y_parity = ((v - 35) % 2) as u8;
+            let y_parity = ((v - 35) % 2) != 0;
             let chain_id = (v - 35) >> 1;
-            Ok((Signature { r, s, y_parity }, Some(chain_id)))
+            Ok((Signature { r, s, odd_y_parity: y_parity }, Some(chain_id)))
         } else {
-            Ok((Signature { r, s, y_parity: (v % 2) as u8 }, None))
+            // non-EIP-155 legacy scheme
+            let y_parity = (v - 27) != 0;
+            Ok((Signature { r, s, odd_y_parity: y_parity }, None))
         }
     }
 }

--- a/crates/primitives/src/transaction/signature.rs
+++ b/crates/primitives/src/transaction/signature.rs
@@ -34,7 +34,6 @@ impl Signature {
     /// Encodes the `v` value with EIP-155 support, using the specified chain ID.
     pub(crate) fn encode_eip155_inner(&self, out: &mut dyn reth_rlp::BufMut, chain_id: u64) {
         // EIP-155: v = {0, 1} + CHAIN_ID * 2 + 35
-        // assumes y_parity is 0 or 1
         let v = chain_id * 2 + 35 + self.odd_y_parity as u64;
         v.encode(out);
         self.r.encode(out);
@@ -45,7 +44,6 @@ impl Signature {
     /// support.
     pub(crate) fn eip155_payload_len(&self, chain_id: u64) -> usize {
         // EIP-155: v = {0, 1} + CHAIN_ID * 2 + 35
-        // assumes y_parity is 0 or 1
         let v = chain_id * 2 + 35 + self.odd_y_parity as u64;
         v.length() + self.r.length() + self.s.length()
     }

--- a/crates/primitives/src/transaction/signature.rs
+++ b/crates/primitives/src/transaction/signature.rs
@@ -56,13 +56,13 @@ impl Signature {
         let s = Decodable::decode(buf)?;
         if v >= 35 {
             // EIP-155: v = {0, 1} + CHAIN_ID * 2 + 35
-            let y_parity = ((v - 35) % 2) != 0;
+            let odd_y_parity = ((v - 35) % 2) != 0;
             let chain_id = (v - 35) >> 1;
-            Ok((Signature { r, s, odd_y_parity: y_parity }, Some(chain_id)))
+            Ok((Signature { r, s, odd_y_parity }, Some(chain_id)))
         } else {
             // non-EIP-155 legacy scheme
-            let y_parity = (v - 27) != 0;
-            Ok((Signature { r, s, odd_y_parity: y_parity }, None))
+            let odd_y_parity = (v - 27) != 0;
+            Ok((Signature { r, s, odd_y_parity }, None))
         }
     }
 }


### PR DESCRIPTION
Adds tests on top of #102 for signed transaction encoding and decoding

Changes `Signature` to use `odd_y_parity: bool` instead of a `u8`