### PR TITLE
chore: reexport sha3 from primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,7 +895,7 @@ dependencies = [
  "impl-rlp",
  "impl-serde",
  "scale-info",
- "tiny-keccak",
+ "tiny-keccak 2.0.2",
 ]
 
 [[package]]
@@ -936,7 +936,7 @@ dependencies = [
  "serde_json",
  "strum",
  "thiserror",
- "tiny-keccak",
+ "tiny-keccak 2.0.2",
  "unicode-xid",
 ]
 
@@ -2535,8 +2535,8 @@ dependencies = [
  "reth-rlp",
  "serde",
  "serde_json",
- "sha3",
  "thiserror",
+ "tiny-keccak 0.3.0",
 ]
 
 [[package]]
@@ -3366,6 +3366,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tiny-keccak"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cd8183d45872feda10001dfacfebf7e163e159922582cd919bed08732447c4"
 
 [[package]]
 name = "tiny-keccak"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2535,6 +2535,7 @@ dependencies = [
  "reth-rlp",
  "serde",
  "serde_json",
+ "sha3",
  "thiserror",
 ]
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -8,18 +8,23 @@ readme = "README.md"
 description = "Commonly used types in reth."
 
 [dependencies]
-ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-bytes = "1.2"
-
-serde = "1.0"
-thiserror = "1"
+# reth
 reth-rlp = { path = "../common/rlp", features = ["std", "derive", "ethereum-types"]}
-parity-scale-codec = { version = "3.2.1", features = ["derive", "bytes"] }
 reth-codecs = { version = "0.1.0", path = "../codecs" }
+
+# ethereum
+ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+parity-scale-codec = { version = "3.2.1", features = ["derive", "bytes"] }
+sha3 = "0.10"
 
 #used for forkid
 crc = "1"
 maplit = "1"
+
+# misc
+bytes = "1.2"
+serde = "1.0"
+thiserror = "1"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -15,7 +15,7 @@ reth-codecs = { version = "0.1.0", path = "../codecs" }
 # ethereum
 ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 parity-scale-codec = { version = "3.2.1", features = ["derive", "bytes"] }
-sha3 = "0.10"
+tiny-keccak = "0.3"
 
 #used for forkid
 crc = "1"

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -49,3 +49,11 @@ pub use ethers_core::{
     types as rpc,
     types::{Bloom, Bytes, H128, H160, H256, H512, H64, U128, U256, U64},
 };
+
+#[doc(hidden)]
+mod __reexport {
+    pub use sha3;
+}
+
+// Useful reexports
+pub use __reexport::*;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -52,7 +52,7 @@ pub use ethers_core::{
 
 #[doc(hidden)]
 mod __reexport {
-    pub use sha3;
+    pub use tiny_keccak;
 }
 
 // Useful reexports
@@ -60,6 +60,7 @@ pub use __reexport::*;
 
 /// Returns the keccak256 hash for the given data.
 pub fn keccak256(data: impl AsRef<[u8]>) -> H256 {
-    use sha3::Digest;
-    H256::from_slice(sha3::Keccak256::digest(data.as_ref()).as_slice())
+    let mut res: [u8; 32] = [0; 32];
+    tiny_keccak::keccak_256(data.as_ref(), &mut res);
+    res.into()
 }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -57,3 +57,9 @@ mod __reexport {
 
 // Useful reexports
 pub use __reexport::*;
+
+/// Returns the keccak256 hash for the given data.
+pub fn keccak256(data: impl AsRef<[u8]>) -> H256 {
+    use sha3::Digest;
+    H256::from_slice(sha3::Keccak256::digest(data.as_ref()).as_slice())
+}


### PR DESCRIPTION
adds and reexports `sha3` from primitives.

and adds `keccak256` function