### PR TITLE
feat: add cargo deny

### DIFF
--- a/crates/codecs/Cargo.toml
+++ b/crates/codecs/Cargo.toml
@@ -2,6 +2,9 @@
 name = "reth-codecs"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/foundry-rs/reth"
+readme = "README.md"
 
 [features]
 default = ["scale"]

--- a/crates/codecs/derive/Cargo.toml
+++ b/crates/codecs/derive/Cargo.toml
@@ -2,6 +2,9 @@
 name = "codecs-derive"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/foundry-rs/reth"
+readme = "../README.md"
 
 [lib]
 proc-macro = true

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,97 @@
+# This section is considered when running `cargo deny check advisories`
+# More documentation for the advisories section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+vulnerability = "deny"
+unmaintained = "warn"
+yanked = "warn"
+notice = "warn"
+
+# This section is considered when running `cargo deny check bans`.
+# More documentation about the 'bans' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+# Lint level for when multiple versions of the same crate are detected
+multiple-versions = "warn"
+# Lint level for when a crate version requirement is `*`
+wildcards = "allow"
+highlight = "all"
+# List of crates to deny
+deny = [
+    # Each entry the name of a crate and a version range. If version is
+    # not specified, all versions will be matched.
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+# Similarly to `skip` allows you to skip certain crates during duplicate
+# detection. Unlike skip, it also includes the entire tree of transitive
+# dependencies starting at the specified crate, up to a certain depth, which is
+# by default infinite
+skip-tree = [
+    # we don't really care if our example brings in some duplicate dependencies, for now
+    { name = "example-runner-ash", version = "0.0.0", depth = 20 },
+    { name = "example-runner-cpu", version = "0.0.0", depth = 20 },
+    { name = "example-runner-wgpu", version = "0.0.0", depth = 20 },
+    { name = "compiletests", version = "0.0.0", depth = 20 },
+    { name = "compiletests-deps-helper", version = "0.0.0", depth = 20 },
+]
+
+
+
+
+[licenses]
+unlicensed = "deny"
+# List of explictly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.7 short identifier (+ optional exception)].
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-DFS-2016"
+]
+# Allow 1 or more licenses on a per-crate basis, so that particular licenses
+# aren't accepted for every possible crate as with the normal allow list
+exceptions = [
+    # CC0 is a permissive license but somewhat unclear status for source code
+    # so we prefer to not have dependencies using it
+    # https://tldrlegal.com/license/creative-commons-cc0-1.0-universal
+    { allow = ["CC0-1.0"], name = "secp256k1" },
+    { allow = ["CC0-1.0"], name = "secp256k1-sys" },
+    { allow = ["CC0-1.0"], name = "tiny-keccak" },
+
+    # TODO: temporarily allow libmdx
+    { allow = ["GPL-3.0"], name = "libmdbx" },
+    { allow = ["GPL-3.0"], name = "mdbx-sys" },
+
+    # TODO: ethers transitive deps
+    { allow = ["GPL-3.0"], name = "fastrlp" },
+    { allow = ["GPL-3.0"], name = "fastrlp-derive" },
+]
+#copyleft = "deny"
+
+# See note in unicode-ident's readme!
+[[licenses.clarify]]
+name = "unicode-ident"
+version = "*"
+expression = "(MIT OR Apache-2.0) AND Unicode-DFS-2016"
+license-files = [
+    { path = "LICENSE-UNICODE", hash = 0x3fb01745 }
+]
+
+# This section is considered when running `cargo deny check sources`.
+# More documentation about the 'sources' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+# Lint level for what to happen when a crate from a crate registry that is not
+# in the allow list is encountered
+unknown-registry = "warn"
+# Lint level for what to happen when a crate from a git repository that is not
+# in the allow list is encountered
+unknown-git = "allow"

--- a/deny.toml
+++ b/deny.toml
@@ -23,24 +23,12 @@ deny = [
     #{ name = "ansi_term", version = "=0.11.0" },
 ]
 # Certain crates/versions that will be skipped when doing duplicate detection.
-skip = [
-    #{ name = "ansi_term", version = "=0.11.0" },
-]
+skip = []
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite
-skip-tree = [
-    # we don't really care if our example brings in some duplicate dependencies, for now
-    { name = "example-runner-ash", version = "0.0.0", depth = 20 },
-    { name = "example-runner-cpu", version = "0.0.0", depth = 20 },
-    { name = "example-runner-wgpu", version = "0.0.0", depth = 20 },
-    { name = "compiletests", version = "0.0.0", depth = 20 },
-    { name = "compiletests-deps-helper", version = "0.0.0", depth = 20 },
-]
-
-
-
+skip-tree = []
 
 [licenses]
 unlicensed = "deny"


### PR DESCRIPTION
add cargo deny https://github.com/EmbarkStudios/cargo-deny `deny.toml`

currently allows some GPL dependencies:
 `fastrlp` (pulled in by ethers)
`libmdbx`