### PR TITLE
headers(part1) feat(interfaces): introduce implicit trait bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2413,6 +2413,7 @@ version = "0.1.0"
 name = "reth-db"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "bytes",
  "criterion",
  "eyre",
@@ -2427,6 +2428,7 @@ dependencies = [
  "tempfile",
  "test-fuzz",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -30,8 +30,10 @@ tempfile = "3.3.0"
 test-fuzz = "3.0.4"
 criterion = "0.4.0"
 iai = "0.1.1"
+tokio = { version = "1.21.2", features = ["full"] }
 
 reth-interfaces = { path = "../interfaces",features=["bench"] }
+async-trait = "0.1.58"
 
 [features]
 test-utils = ["tempfile"]

--- a/crates/db/src/kv/mod.rs
+++ b/crates/db/src/kv/mod.rs
@@ -223,7 +223,7 @@ mod gat_tests {
     #[async_trait::async_trait]
     impl<'c, DB: Database> Stage<DB> for MyStage<'c, DB> {
         async fn run(&mut self, db: &mut DBContainer<'_, DB>) -> () {
-            let _tx = db.open().unwrap();
+            let _tx = db.commit().unwrap();
             ()
         }
     }

--- a/crates/db/src/kv/mod.rs
+++ b/crates/db/src/kv/mod.rs
@@ -211,20 +211,19 @@ mod tests {
 // This ensures that we can use the GATs in the downstream staged exec pipeline.
 mod gat_tests {
     use super::*;
-    use reth_interfaces::db::{mock::DatabaseMock, DBContainer, DbTx};
-    use std::{future::Future, pin::Pin};
+    use reth_interfaces::db::{mock::DatabaseMock, DBContainer};
 
     #[async_trait::async_trait]
     trait Stage<DB: Database> {
-        async fn run(&mut self, db: &<DB as DatabaseGAT<'_>>::TXMut) -> ();
+        async fn run(&mut self, db: &mut DBContainer<'_, DB>) -> ();
     }
 
     struct MyStage<'a, DB>(&'a DB);
 
     #[async_trait::async_trait]
     impl<'c, DB: Database> Stage<DB> for MyStage<'c, DB> {
-        async fn run(&mut self, db: &<DB as DatabaseGAT<'_>>::TXMut) -> () {
-            db.commit().unwrap();
+        async fn run(&mut self, db: &mut DBContainer<'_, DB>) -> () {
+            let _tx = db.open().unwrap();
             ()
         }
     }
@@ -234,8 +233,9 @@ mod gat_tests {
     fn can_spawn() {
         let db = DatabaseMock::default();
         tokio::spawn(async move {
+            let mut container = DBContainer::new(&db).unwrap();
             let mut stage = MyStage(&db);
-            let _ = stage.run(&db.tx_mut().unwrap());
+            let _ = stage.run(&mut container);
         });
     }
 }

--- a/crates/db/src/kv/mod.rs
+++ b/crates/db/src/kv/mod.rs
@@ -7,7 +7,7 @@ use libmdbx::{
 };
 use reth_interfaces::db::{
     tables::{TableType, TABLES},
-    Database, Error,
+    Database, DatabaseGAT, Error,
 };
 use std::{ops::Deref, path::Path};
 
@@ -32,15 +32,17 @@ pub struct Env<E: EnvironmentKind> {
     pub inner: Environment<E>,
 }
 
-impl<E: EnvironmentKind> Database for Env<E> {
-    type TX<'a> = tx::Tx<'a, RO, E>;
-    type TXMut<'a> = tx::Tx<'a, RW, E>;
+impl<'a, E: EnvironmentKind> DatabaseGAT<'a> for Env<E> {
+    type TX = tx::Tx<'a, RO, E>;
+    type TXMut = tx::Tx<'a, RW, E>;
+}
 
-    fn tx(&self) -> Result<Self::TX<'_>, Error> {
+impl<E: EnvironmentKind> Database for Env<E> {
+    fn tx(&self) -> Result<<Self as DatabaseGAT<'_>>::TX, Error> {
         Ok(Tx::new(self.inner.begin_ro_txn().map_err(|e| Error::Internal(e.into()))?))
     }
 
-    fn tx_mut(&self) -> Result<Self::TXMut<'_>, Error> {
+    fn tx_mut(&self) -> Result<<Self as DatabaseGAT<'_>>::TXMut, Error> {
         Ok(Tx::new(self.inner.begin_rw_txn().map_err(|e| Error::Internal(e.into()))?))
     }
 }

--- a/crates/interfaces/Cargo.toml
+++ b/crates/interfaces/Cargo.toml
@@ -24,6 +24,7 @@ parity-scale-codec = { version = "3.2.1", features = ["bytes"] }
 
 [dev-dependencies]
 test-fuzz = "3.0.4"
+tokio = { version = "1.21.2", features = ["full"] }
 
 [features]
 bench = []

--- a/crates/interfaces/src/db/container.rs
+++ b/crates/interfaces/src/db/container.rs
@@ -1,0 +1,96 @@
+use crate::db::{Database, DatabaseGAT, DbTx, Error};
+
+/// A container for any DB transaction that will open a new inner transaction when the current
+/// one is committed.
+// NOTE: This container is needed since `Transaction::commit` takes `mut self`, so methods in
+// the pipeline that just take a reference will not be able to commit their transaction and let
+// the pipeline continue. Is there a better way to do this?
+pub(crate) struct DBContainer<'this, DB: Database> {
+    /// A handle to the DB.
+    pub(crate) db: &'this DB,
+    tx: Option<<DB as DatabaseGAT<'this>>::TXMut>,
+}
+
+impl<'this, DB> DBContainer<'this, DB>
+where
+    DB: Database,
+{
+    /// Create a new container with the given database handle.
+    ///
+    /// A new inner transaction will be opened.
+    pub(crate) fn new(db: &'this DB) -> Result<Self, Error> {
+        Ok(Self { db, tx: Some(db.tx_mut()?) })
+    }
+
+    /// Commit the current inner transaction and open a new one.
+    ///
+    /// # Panics
+    ///
+    /// Panics if an inner transaction does not exist. This should never be the case unless
+    /// [DBContainer::close] was called without following up with a call to [DBContainer::open].
+    pub(crate) fn commit(&mut self) -> Result<bool, Error> {
+        let success =
+            self.tx.take().expect("Tried committing a non-existent transaction").commit()?;
+        self.tx = Some(self.db.tx_mut()?);
+        Ok(success)
+    }
+
+    /// Get the inner transaction.
+    ///
+    /// # Panics
+    ///
+    /// Panics if an inner transaction does not exist. This should never be the case unless
+    /// [DBContainer::close] was called without following up with a call to [DBContainer::open].
+    pub(crate) fn get(&self) -> &<DB as DatabaseGAT<'this>>::TXMut {
+        self.tx.as_ref().expect("Tried getting a reference to a non-existent transaction")
+    }
+
+    /// Get a mutable reference to the inner transaction.
+    ///
+    /// # Panics
+    ///
+    /// Panics if an inner transaction does not exist. This should never be the case unless
+    /// [DBContainer::close] was called without following up with a call to [DBContainer::open].
+    pub(crate) fn get_mut(&mut self) -> &mut <DB as DatabaseGAT<'this>>::TXMut {
+        self.tx.as_mut().expect("Tried getting a mutable reference to a non-existent transaction")
+    }
+
+    /// Open a new inner transaction.
+    pub(crate) fn open(&mut self) -> Result<(), Error> {
+        self.tx = Some(self.db.tx_mut()?);
+        Ok(())
+    }
+
+    /// Close the current inner transaction.
+    pub(crate) fn close(&mut self) {
+        self.tx.take();
+    }
+}
+
+#[cfg(test)]
+// This ensures that we can use the GATs in the downstream staged exec pipeline.
+mod tests {
+    use super::*;
+    use crate::db::mock::DatabaseMock;
+    use std::{future::Future, pin::Pin};
+
+    trait Stage<DB: Database> {
+        fn run<'a>(
+            &'a mut self,
+            db: &mut DBContainer<'_, DB>,
+        ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
+    }
+
+    struct MyStage<DB>(DB);
+    impl<DB: Database> Stage<DB> for MyStage<DB> {
+        fn run<'a>(
+            &'a mut self,
+            db: &mut DBContainer<'_, DB>,
+        ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+            Box::pin(async move {
+                let tx = db.open().unwrap();
+                ()
+            })
+        }
+    }
+}

--- a/crates/interfaces/src/db/container.rs
+++ b/crates/interfaces/src/db/container.rs
@@ -75,17 +75,17 @@ mod tests {
     use std::{future::Future, pin::Pin};
 
     trait Stage<DB: Database> {
-        fn run<'a>(
+        fn run<'a, 'b: 'a>(
             &'a mut self,
-            db: &mut DBContainer<'_, DB>,
+            db: &'b mut DBContainer<'b, DB>,
         ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
     }
 
     struct MyStage<DB>(DB);
     impl<DB: Database> Stage<DB> for MyStage<DB> {
-        fn run<'a>(
+        fn run<'a, 'b: 'a>(
             &'a mut self,
-            db: &mut DBContainer<'_, DB>,
+            db: &'b mut DBContainer<'b, DB>,
         ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
             Box::pin(async move {
                 let tx = db.open().unwrap();

--- a/crates/interfaces/src/db/container.rs
+++ b/crates/interfaces/src/db/container.rs
@@ -72,7 +72,6 @@ where
 mod tests {
     use super::*;
     use crate::db::mock::DatabaseMock;
-    use std::{future::Future, pin::Pin};
 
     #[async_trait::async_trait]
     trait Stage<DB: Database> {

--- a/crates/interfaces/src/db/container.rs
+++ b/crates/interfaces/src/db/container.rs
@@ -97,11 +97,38 @@ mod tests {
     #[test]
     #[should_panic] // no tokio runtime configured
     fn can_spawn() {
+        let db = DatabaseMock::default();
         tokio::spawn(async move {
-            let db = DatabaseMock::default();
             let mut container = DBContainer::new(&db).unwrap();
             let mut stage = MyStage(&db);
             stage.run(&mut container);
         });
     }
+
+    // REVIEW PLS:  Is this supposed to compile in any way? Or not because
+    // the tokio::spawn
+    // error[E0597]: `container` does not live long enough
+    //    --> crates/interfaces/src/db/container.rs:104:23
+    //     |
+    // 101 |         let mut container = DBContainer::new(&db).unwrap();
+    //     |             ------------- lifetime `'1` appears in the type of `container`
+    // ...
+    // 104 |             stage.run(&mut container);
+    //     |             ----------^^^^^^^^^^^^^^-
+    //     |             |         |
+    //     |             |         borrowed value does not live long enough
+    //     |             argument requires that `container` is borrowed for `'1`
+    // 105 |         });
+    //     |         - `container` dropped here while still borrowed
+    //
+    // #[test]
+    // #[should_panic] // no tokio runtime configured
+    // fn can_spawn() {
+    //     let db = DatabaseMock::default();
+    //     let mut container = DBContainer::new(&db).unwrap();
+    //     tokio::spawn(async move {
+    //         let mut stage = MyStage(&db);
+    //         stage.run(&mut container);
+    //     });
+    // }
 }

--- a/crates/interfaces/src/db/mock.rs
+++ b/crates/interfaces/src/db/mock.rs
@@ -2,7 +2,8 @@
 use std::collections::BTreeMap;
 
 use super::{
-    Database, DbCursorRO, DbCursorRW, DbDupCursorRO, DbDupCursorRW, DbTx, DbTxMut, DupSort, Table,
+    Database, DatabaseGAT, DbCursorRO, DbCursorRW, DbDupCursorRO, DbDupCursorRW, DbTx, DbTxMut,
+    DupSort, Table,
 };
 
 /// Mock database used for testing with inner BTreeMap structure
@@ -14,17 +15,19 @@ pub struct DatabaseMock {
 }
 
 impl Database for DatabaseMock {
-    type TX<'a> = TxMock;
-
-    type TXMut<'a> = TxMock;
-
-    fn tx(&self) -> Result<Self::TX<'_>, super::Error> {
+    fn tx(&self) -> Result<<Self as DatabaseGAT<'_>>::TX, super::Error> {
         Ok(TxMock::default())
     }
 
-    fn tx_mut(&self) -> Result<Self::TXMut<'_>, super::Error> {
+    fn tx_mut(&self) -> Result<<Self as DatabaseGAT<'_>>::TXMut, super::Error> {
         Ok(TxMock::default())
     }
+}
+
+impl<'a> DatabaseGAT<'a> for DatabaseMock {
+    type TX = TxMock;
+
+    type TXMut = TxMock;
 }
 
 /// Mock read only tx

--- a/crates/interfaces/src/db/mod.rs
+++ b/crates/interfaces/src/db/mod.rs
@@ -1,4 +1,5 @@
 pub mod codecs;
+mod container;
 mod error;
 pub mod mock;
 pub mod models;

--- a/crates/interfaces/src/db/mod.rs
+++ b/crates/interfaces/src/db/mod.rs
@@ -9,6 +9,8 @@ pub mod tables;
 pub use error::Error;
 pub use table::*;
 
+pub use container::DBContainer;
+
 // Sealed trait helper to prevent misuse of the API.
 mod sealed {
     pub trait Sealed: Sized {}

--- a/crates/interfaces/src/db/mod.rs
+++ b/crates/interfaces/src/db/mod.rs
@@ -8,26 +8,38 @@ pub mod tables;
 pub use error::Error;
 pub use table::*;
 
-/// Main Database trait that spawns transactions to be executed.
-pub trait Database {
+// Sealed trait helper to prevent misuse of the API.
+mod sealed {
+    pub trait Sealed: Sized {}
+    pub struct Bounds<T>(T);
+    impl<T> Sealed for Bounds<T> {}
+}
+use sealed::{Bounds, Sealed};
+
+/// Implements the GAT method from:
+/// https://sabrinajewson.org/blog/the-better-alternative-to-lifetime-gats#the-better-gats.
+///
+/// Sealed trait which cannot be implemented by 3rd parties, exposed only for implementers
+pub trait DatabaseGAT<'a, __ImplicitBounds: Sealed = Bounds<&'a Self>>: Send + Sync {
     /// RO database transaction
-    type TX<'a>: DbTx<'a> + Send + Sync
-    where
-        Self: 'a;
+    type TX: DbTx<'a> + Send + Sync;
     /// RW database transaction
-    type TXMut<'a>: DbTxMut<'a> + DbTx<'a> + Send + Sync
-    where
-        Self: 'a;
+    type TXMut: DbTxMut<'a> + DbTx<'a> + Send + Sync;
+}
+
+/// Main Database trait that spawns transactions to be executed.
+pub trait Database: for<'a> DatabaseGAT<'a> {
     /// Create read only transaction.
-    fn tx(&self) -> Result<Self::TX<'_>, Error>;
+    fn tx(&self) -> Result<<Self as DatabaseGAT<'_>>::TX, Error>;
+
     /// Create read write transaction only possible if database is open with write access.
-    fn tx_mut(&self) -> Result<Self::TXMut<'_>, Error>;
+    fn tx_mut(&self) -> Result<<Self as DatabaseGAT<'_>>::TXMut, Error>;
 
     /// Takes a function and passes a read-only transaction into it, making sure it's closed in the
     /// end of the execution.
     fn view<T, F>(&self, f: F) -> Result<T, Error>
     where
-        F: Fn(&Self::TX<'_>) -> T,
+        F: Fn(&<Self as DatabaseGAT<'_>>::TX) -> T,
     {
         let tx = self.tx()?;
 
@@ -41,7 +53,7 @@ pub trait Database {
     /// the end of the execution.
     fn update<T, F>(&self, f: F) -> Result<T, Error>
     where
-        F: Fn(&Self::TXMut<'_>) -> T,
+        F: Fn(&<Self as DatabaseGAT<'_>>::TXMut) -> T,
     {
         let tx = self.tx_mut()?;
 


### PR DESCRIPTION
So we've run in the issue where Async Trait doesn't cover GATs. And we need to manually desugar it. But we also want the futures to be `Send`, but also not require `DB: 'static`. So we need to rethink about our trait design.

Implements Approach 3 from https://sabrinajewson.org/blog/the-better-alternative-to-lifetime-gats/. My understanding of the solution tl;dr is: 
1. instead of using GATs you pull the lifetime up to a `HelperTrait<'a>` where the associated types get the lifetime from the trait instead of the associated type.
2. You introduce an additional bound `trait HelperTrait<'a, _Bound = (&'a Self,)>`
3. You make your `Trait: for<'a> HelperTrait`
4. This solves the lifetime issue, at the cost of some verbosity in downstream code because you need to do `<T as HelperTrait>::MyType` explicitly

@rakita @rkrasiuk @mattsse does the above sound rihgt?

--

Status:
- [x] Introduce the new traits in `interfaces/` + modify the mocks
- [x] Modify the MDBX implementation's traits
- [x] Modify the Pipeline to use the new DB traits -> this is done via the `DBContainer` which prevents all the GAT trait context leaking to the Stages, which is nice. 