### PR TITLE
ci: make codecov informational for now

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true


### PR DESCRIPTION
Prevents Codecov from posting failing status checks for now