### PR TITLE
ci: add cargo deny action

### DIFF
--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -1,8 +1,12 @@
 on:
   push:
-    branches:
-      - main
+    branches: [main]
+    paths:
+      - 'Cargo.lock'
   pull_request:
+    branches: [main]
+    paths:
+      - 'Cargo.lock'
 
 env:
   RUSTFLAGS: -D warnings

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -1,0 +1,24 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  RUSTFLAGS: -D warnings
+  NEXTEST_EXPERIMENTAL_FILTER_EXPR: 1
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+name: deny
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Check
+        uses: EmbarkStudios/cargo-deny-action@v1

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -17,8 +17,18 @@ name: deny
 jobs:
   check:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
       - name: Check
         uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          command: check ${{ matrix.checks }}

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 ![cargo-deny status](https://github.com/foundry-rs/reth/workflows/deny/badge.svg)
 [![Codecov](https://img.shields.io/codecov/c/github/foundry-rs/reth?token=c24SDcMImE)][codecov]
 
-# Build
+## Build
 
-To build this project we are currently using rust nightly for GAT support, that is planed to release in rust 1.65 (4.nov.2022). GAT's are used for Database trait in reth-interface. 
+To build this project we are currently using Rust nightly for GAT support, that is planed to release in rust 1.65 (4th Nov 2022). GAT's are used for the `Database` trait in `reth-interface`. 
 
 ## Docs
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 *Blazing-fast implementation of the Ethereum protocol*
 
-![Github Actions](https://github.com/foundry-rs/reth/workflows/ci/badge.svg)
+![CI status](https://github.com/foundry-rs/reth/workflows/ci/badge.svg)
+![cargo-deny status](https://github.com/foundry-rs/reth/workflows/deny/badge.svg)
 [![Codecov](https://img.shields.io/codecov/c/github/foundry-rs/reth?token=c24SDcMImE)][codecov]
 
 # Build


### PR DESCRIPTION
Adds an action that runs `cargo-deny` and a badge for it as well.

The workflow runs a matrix to allow advisory failures which is recommended by Embark: https://github.com/EmbarkStudios/cargo-deny-action#recommended-pipeline-to-avoid-sudden-breakages