### PR TITLE
chore: bump tiny-keccak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,7 +934,7 @@ dependencies = [
  "impl-rlp",
  "impl-serde",
  "scale-info",
- "tiny-keccak 2.0.2",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -975,7 +975,7 @@ dependencies = [
  "serde_json",
  "strum",
  "thiserror",
- "tiny-keccak 2.0.2",
+ "tiny-keccak",
  "unicode-xid",
 ]
 
@@ -2634,7 +2634,7 @@ dependencies = [
  "serde_json",
  "sucds",
  "thiserror",
- "tiny-keccak 0.3.0",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -3501,12 +3501,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "tiny-keccak"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cd8183d45872feda10001dfacfebf7e163e159922582cd919bed08732447c4"
 
 [[package]]
 name = "tiny-keccak"

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -15,7 +15,7 @@ reth-codecs = { version = "0.1.0", path = "../codecs" }
 # ethereum
 ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 parity-scale-codec = { version = "3.2.1", features = ["derive", "bytes"] }
-tiny-keccak = "0.3"
+tiny-keccak = { version = "2.0", features = ["sha3"] }
 
 #used for forkid
 crc = "1"

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -65,7 +65,10 @@ pub use __reexport::*;
 
 /// Returns the keccak256 hash for the given data.
 pub fn keccak256(data: impl AsRef<[u8]>) -> H256 {
-    let mut res: [u8; 32] = [0; 32];
-    tiny_keccak::keccak_256(data.as_ref(), &mut res);
-    res.into()
+    use tiny_keccak::{Hasher, Sha3};
+    let mut sha3 = Sha3::v256();
+    let mut output = [0; 32];
+    sha3.update(data.as_ref());
+    sha3.finalize(&mut output);
+    output.into()
 }


### PR DESCRIPTION
previously added a very outdated version of `tiny-keccak`

this migrates to the latest version