### PR TITLE
chore: reexport hex from primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2625,6 +2625,7 @@ dependencies = [
  "bytes",
  "crc",
  "ethers-core",
+ "hex",
  "hex-literal",
  "maplit",
  "parity-scale-codec",

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -27,6 +27,7 @@ serde = "1.0"
 thiserror = "1"
 sucds = "0.5.0"
 arbitrary = { version = "1.1.7", features = ["derive"], optional = true}
+hex = "0.4"
 
 [dev-dependencies]
 arbitrary = { version = "1.1.7", features = ["derive"]}

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -57,6 +57,7 @@ pub use ethers_core::{
 
 #[doc(hidden)]
 mod __reexport {
+    pub use hex;
     pub use tiny_keccak;
 }
 


### PR DESCRIPTION
`hex` is so commonly used that it's worth reexporting from primitives directly