### PR TITLE
chore: clarify ring license

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -42,8 +42,10 @@ allow = [
     "BSD-2-Clause",
     "BSD-3-Clause",
     "ISC",
-    "Unicode-DFS-2016"
+    "Unicode-DFS-2016",
+    "OpenSSL"
 ]
+
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
 exceptions = [
@@ -53,6 +55,7 @@ exceptions = [
     { allow = ["CC0-1.0"], name = "secp256k1" },
     { allow = ["CC0-1.0"], name = "secp256k1-sys" },
     { allow = ["CC0-1.0"], name = "tiny-keccak" },
+    { allow = ["CC0-1.0"], name = "more-asserts" },
 
     # TODO: temporarily allow libmdx
     { allow = ["GPL-3.0"], name = "libmdbx" },
@@ -71,6 +74,13 @@ version = "*"
 expression = "(MIT OR Apache-2.0) AND Unicode-DFS-2016"
 license-files = [
     { path = "LICENSE-UNICODE", hash = 0x3fb01745 }
+]
+[[licenses.clarify]]
+name = "ring"
+version = "*"
+expression = "OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 }
 ]
 
 # This section is considered when running `cargo deny check sources`.


### PR DESCRIPTION
add clarify entry for ring to make cargo deny happy.

ring has `OpenSSL` license which is ISC-style: https://github.com/briansmith/ring/blob/main/LICENSE