### PR TITLE
chore(db): comment for cursor, cleanup unneeded fn

### DIFF
--- a/crates/db/src/kv/cursor.rs
+++ b/crates/db/src/kv/cursor.rs
@@ -126,6 +126,7 @@ impl<'tx, T: Table> DbCursorRW<'tx, T> for Cursor<'tx, RW, T> {
     /// Database operation that will update an existing row if a specified value already
     /// exists in a table, and insert a new row if the specified value doesn't already exist
     fn upsert(&mut self, key: T::Key, value: T::Value) -> Result<(), Error> {
+        // Default `WriteFlags` is UPSERT
         self.inner
             .put(key.encode().as_ref(), value.encode().as_ref(), WriteFlags::UPSERT)
             .map_err(|e| Error::Internal(e.into()))


### PR DESCRIPTION
Added a few comments, and removed the' inner' function left behind when experimenting with `Walker`.

`Sized` is removed from `Walker`  as that same restriction is specified in `walk` function of `DbCursorRO`