### PR TITLE
feat(interfaces): add `ShardedKey`

### DIFF
--- a/crates/interfaces/src/db/models/mod.rs
+++ b/crates/interfaces/src/db/models/mod.rs
@@ -3,6 +3,8 @@
 pub mod accounts;
 pub mod blocks;
 pub mod integer_list;
+pub mod sharded_key;
 
 pub use accounts::*;
 pub use blocks::*;
+pub use sharded_key::ShardedKey;

--- a/crates/interfaces/src/db/models/sharded_key.rs
+++ b/crates/interfaces/src/db/models/sharded_key.rs
@@ -1,0 +1,63 @@
+//! Sharded key
+
+use crate::db::{
+    table::{Decode, Encode},
+    Error,
+};
+use eyre::eyre;
+use reth_primitives::TxNumber;
+
+/// Sometimes data can be too big to be saved for a single key. This helps out by dividing the data
+/// into different shards. Example:
+///
+/// `Address | 200` -> data is from transaction 0 to 200.
+///
+/// `Address | 300` -> data is from transaction 201 to 300.
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct ShardedKey<T> {
+    /// The key for this type.
+    pub key: T,
+    /// Highest tx number to which `value` is related to.
+    pub highest_tx_number: TxNumber,
+}
+
+impl<T> ShardedKey<T> {
+    /// Creates a new `ShardedKey<T>`.
+    pub fn new(key: T, highest_tx_number: TxNumber) -> Self {
+        ShardedKey { key, highest_tx_number }
+    }
+}
+
+impl<T> Encode for ShardedKey<T>
+where
+    T: Encode,
+    Vec<u8>: From<<T as Encode>::Encoded>,
+{
+    type Encoded = Vec<u8>;
+
+    fn encode(self) -> Self::Encoded {
+        let mut buf: Vec<u8> = Encode::encode(self.key).into();
+        buf.extend_from_slice(&self.highest_tx_number.to_be_bytes());
+        buf
+    }
+}
+
+impl<T> Decode for ShardedKey<T>
+where
+    T: Decode,
+{
+    fn decode<B: Into<bytes::Bytes>>(value: B) -> Result<Self, Error> {
+        let value: bytes::Bytes = value.into();
+        let tx_num_index = value.len() - 8;
+
+        let highest_tx_number = u64::from_be_bytes(
+            value.as_ref()[tx_num_index..]
+                .try_into()
+                .map_err(|_| Error::Decode(eyre!("Into bytes error.")))?,
+        );
+        let key = T::decode(value.slice(..tx_num_index))?;
+
+        Ok(ShardedKey::new(key, highest_tx_number))
+    }
+}

--- a/crates/interfaces/src/db/models/sharded_key.rs
+++ b/crates/interfaces/src/db/models/sharded_key.rs
@@ -13,7 +13,6 @@ use reth_primitives::TxNumber;
 /// `Address | 200` -> data is from transaction 0 to 200.
 ///
 /// `Address | 300` -> data is from transaction 201 to 300.
-
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct ShardedKey<T> {
     /// The key for this type.

--- a/crates/interfaces/src/db/tables.rs
+++ b/crates/interfaces/src/db/tables.rs
@@ -4,6 +4,7 @@ use crate::db::{
     models::{
         accounts::{AccountBeforeTx, TxNumberAddress},
         blocks::{BlockNumHash, HeaderHash, NumTransactions, NumTxesInBlock},
+        ShardedKey,
     },
     DupSort,
 };
@@ -105,7 +106,7 @@ table!(Logs => TxNumber => Receipt); // Canonical only
 table!(PlainAccountState => Address => Account);
 dupsort!(PlainStorageState => Address => [H256] StorageEntry);
 
-table!(AccountHistory => Address => TxNumberList);
+table!(AccountHistory => ShardedKey<Address> => TxNumberList);
 table!(StorageHistory => Address_StorageKey => TxNumberList);
 
 dupsort!(AccountChangeSet => TxNumber => [Address] AccountBeforeTx);


### PR DESCRIPTION
Adds `ShardedKey` for values that might be too big for a single key. Used it on `AccountHistory`. Follow-up will add to `StorageHistory`.

```
/// Sometimes data can be too big to be saved for a single key. This helps out by dividing the data
/// into different shards. Example:
///
/// `Address | 200` -> data is from transaction 0 to 200.
///
/// `Address | 300` -> data is from transaction 201 to 300.
```

More: [erigon](https://github.com/ledgerwatch/erigon-lib/blob/4f5232504fdfca6c2374f4377282a75f7f05eb6d/kv/tables.go#L121-L160)

Take a notice to the test as well. 