### PR TITLE
feat(rlp): add smol-str feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3221,6 +3221,7 @@ dependencies = [
  "hex-literal",
  "reth-rlp",
  "reth-rlp-derive",
+ "smol_str",
 ]
 
 [[package]]
@@ -3845,6 +3846,12 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "smol_str"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7475118a28b7e3a2e157ce0131ba8c5526ea96e90ee601d9f6bb2e286a35ab44"
 
 [[package]]
 name = "socket2"

--- a/crates/common/rlp/Cargo.toml
+++ b/crates/common/rlp/Cargo.toml
@@ -11,6 +11,7 @@ arrayvec = { version = "0.7", default-features = false }
 auto_impl = "1"
 bytes = { version = "1", default-features = false }
 ethnum = { version = "1", default-features = false, optional = true }
+smol_str = { version = "0.1", default-features = false, optional = true }
 ethereum-types = { version = "0.13", features = ["codec"], optional = true }
 reth-rlp-derive = { version = "0.1", path = "../rlp-derive", optional = true }
 
@@ -20,6 +21,7 @@ reth-rlp-test = { path = ".", package = "reth-rlp", features = [
     "std",
     "ethnum",
     "ethereum-types",
+    "smol_str"
 ] }
 criterion = "0.4.0"
 hex-literal = "0.3"

--- a/crates/common/rlp/src/encode.rs
+++ b/crates/common/rlp/src/encode.rs
@@ -175,6 +175,16 @@ impl Encodable for bool {
 
 impl_max_encoded_len!(bool, { <u8 as MaxEncodedLenAssoc>::LEN });
 
+#[cfg(feature = "smol_str")]
+impl Encodable for smol_str::SmolStr {
+    fn encode(&self, out: &mut dyn BufMut) {
+        self.as_bytes().encode(out);
+    }
+    fn length(&self) -> usize {
+        self.as_bytes().length()
+    }
+}
+
 #[cfg(feature = "ethnum")]
 mod ethnum_support {
     use super::*;
@@ -505,5 +515,18 @@ mod tests {
     fn rlp_list() {
         assert_eq!(encoded_list::<u64>(&[]), &hex!("c0")[..]);
         assert_eq!(encoded_list(&[0xFFCCB5_u64, 0xFFC0B5_u64]), &hex!("c883ffccb583ffc0b5")[..]);
+    }
+
+    #[cfg(feature = "smol_str")]
+    #[test]
+    fn rlp_smol_str() {
+        use smol_str::SmolStr;
+        assert_eq!(encoded(SmolStr::new(""))[..], hex!("80")[..]);
+        let mut b = BytesMut::new();
+        "test smol str".to_string().encode(&mut b);
+        assert_eq!(&encoded(SmolStr::new("test smol str"))[..], b.as_ref());
+        let mut b = BytesMut::new();
+        "abcdefgh".to_string().encode(&mut b);
+        assert_eq!(&encoded(SmolStr::new("abcdefgh"))[..], b.as_ref());
     }
 }


### PR DESCRIPTION
Add rlp support for [SmolStr](https://github.com/rust-analyzer/smol_str), useful for smol, stack allocated strings