### PR TITLE
fix(db): add traits `Encode/Decode` for keys and `Compress/Uncompress` for values

### DIFF
--- a/crates/consensus/src/verification.rs
+++ b/crates/consensus/src/verification.rs
@@ -304,7 +304,7 @@ mod tests {
         parent.gas_used = 17763076;
         parent.gas_limit = 30000000;
         parent.base_fee_per_gas = Some(0x28041f7f5);
-        parent.number = parent.number - 1;
+        parent.number -= 1;
 
         let ommers = Vec::new();
         let receipts = Vec::new();

--- a/crates/db/src/kv/cursor.rs
+++ b/crates/db/src/kv/cursor.rs
@@ -4,8 +4,8 @@ use std::marker::PhantomData;
 
 use crate::utils::*;
 use reth_interfaces::db::{
-    DbCursorRO, DbCursorRW, DbDupCursorRO, DbDupCursorRW, DupSort, DupWalker, Encode, Error, Table,
-    Walker,
+    Compress, DbCursorRO, DbCursorRW, DbDupCursorRO, DbDupCursorRW, DupSort, DupWalker, Encode,
+    Error, Table, Walker,
 };
 use reth_libmdbx::{self, TransactionKind, WriteFlags, RO, RW};
 
@@ -128,13 +128,13 @@ impl<'tx, T: Table> DbCursorRW<'tx, T> for Cursor<'tx, RW, T> {
     fn upsert(&mut self, key: T::Key, value: T::Value) -> Result<(), Error> {
         // Default `WriteFlags` is UPSERT
         self.inner
-            .put(key.encode().as_ref(), value.encode().as_ref(), WriteFlags::UPSERT)
+            .put(key.encode().as_ref(), value.compress().as_ref(), WriteFlags::UPSERT)
             .map_err(|e| Error::Internal(e.into()))
     }
 
     fn append(&mut self, key: T::Key, value: T::Value) -> Result<(), Error> {
         self.inner
-            .put(key.encode().as_ref(), value.encode().as_ref(), WriteFlags::APPEND)
+            .put(key.encode().as_ref(), value.compress().as_ref(), WriteFlags::APPEND)
             .map_err(|e| Error::Internal(e.into()))
     }
 
@@ -150,7 +150,7 @@ impl<'tx, T: DupSort> DbDupCursorRW<'tx, T> for Cursor<'tx, RW, T> {
 
     fn append_dup(&mut self, key: T::Key, value: T::Value) -> Result<(), Error> {
         self.inner
-            .put(key.encode().as_ref(), value.encode().as_ref(), WriteFlags::APPEND_DUP)
+            .put(key.encode().as_ref(), value.compress().as_ref(), WriteFlags::APPEND_DUP)
             .map_err(|e| Error::Internal(e.into()))
     }
 }

--- a/crates/db/src/kv/mod.rs
+++ b/crates/db/src/kv/mod.rs
@@ -269,7 +269,7 @@ mod tests {
         {
             let tx = env.tx().expect(ERROR_INIT_TX);
             let mut cursor = tx.cursor_dup::<PlainStorageState>().unwrap();
-            let mut walker = cursor.walk_dup(key.into(), H256::from_low_u64_be(1)).unwrap();
+            let mut walker = cursor.walk_dup(key, H256::from_low_u64_be(1)).unwrap();
             assert_eq!(
                 value11,
                 walker

--- a/crates/db/src/utils.rs
+++ b/crates/db/src/utils.rs
@@ -2,7 +2,7 @@
 
 //suse crate::kv::Error;
 use bytes::Bytes;
-use reth_interfaces::db::{Decode, Error, Table, Uncompress};
+use reth_interfaces::db::{Decode, Decompress, Error, Table};
 use std::borrow::Cow;
 
 /// Returns the default page size that can be used in this OS.
@@ -26,11 +26,11 @@ pub(crate) fn decoder<'a, T>(
 where
     T: Table,
     T::Key: Decode,
-    T::Value: Uncompress,
+    T::Value: Decompress,
 {
     Ok((
         Decode::decode(Bytes::from(kv.0.into_owned()))?,
-        Uncompress::uncompress(Bytes::from(kv.1.into_owned()))?,
+        Decompress::decompress(Bytes::from(kv.1.into_owned()))?,
     ))
 }
 
@@ -39,7 +39,7 @@ pub(crate) fn decode_value<'a, T>(kv: (Cow<'a, [u8]>, Cow<'a, [u8]>)) -> Result<
 where
     T: Table,
 {
-    Uncompress::uncompress(Bytes::from(kv.1.into_owned()))
+    Decompress::decompress(Bytes::from(kv.1.into_owned()))
 }
 
 /// Helper function to decode a value. It can be a key or subkey.
@@ -47,5 +47,5 @@ pub(crate) fn decode_one<T>(value: Cow<'_, [u8]>) -> Result<T::Value, Error>
 where
     T: Table,
 {
-    Uncompress::uncompress(Bytes::from(value.into_owned()))
+    Decompress::decompress(Bytes::from(value.into_owned()))
 }

--- a/crates/db/src/utils.rs
+++ b/crates/db/src/utils.rs
@@ -2,7 +2,7 @@
 
 //suse crate::kv::Error;
 use bytes::Bytes;
-use reth_interfaces::db::{Decode, Error, Table};
+use reth_interfaces::db::{Decode, Error, Table, Uncompress};
 use std::borrow::Cow;
 
 /// Returns the default page size that can be used in this OS.
@@ -26,10 +26,11 @@ pub(crate) fn decoder<'a, T>(
 where
     T: Table,
     T::Key: Decode,
+    T::Value: Uncompress,
 {
     Ok((
         Decode::decode(Bytes::from(kv.0.into_owned()))?,
-        Decode::decode(Bytes::from(kv.1.into_owned()))?,
+        Uncompress::uncompress(Bytes::from(kv.1.into_owned()))?,
     ))
 }
 
@@ -38,7 +39,7 @@ pub(crate) fn decode_value<'a, T>(kv: (Cow<'a, [u8]>, Cow<'a, [u8]>)) -> Result<
 where
     T: Table,
 {
-    Decode::decode(Bytes::from(kv.1.into_owned()))
+    Uncompress::uncompress(Bytes::from(kv.1.into_owned()))
 }
 
 /// Helper function to decode a value. It can be a key or subkey.
@@ -46,5 +47,5 @@ pub(crate) fn decode_one<T>(value: Cow<'_, [u8]>) -> Result<T::Value, Error>
 where
     T: Table,
 {
-    Decode::decode(Bytes::from(value.into_owned()))
+    Uncompress::uncompress(Bytes::from(value.into_owned()))
 }

--- a/crates/interfaces/src/db/codecs/fuzz/mod.rs
+++ b/crates/interfaces/src/db/codecs/fuzz/mod.rs
@@ -8,7 +8,7 @@ mod inputs;
 /// Some types like [`IntegerList`] might have some restrictons on how they're fuzzed. For example,
 /// the list is assumed to be sorted before creating the object.
 macro_rules! impl_fuzzer_with_input {
-    ($(($name:tt, $input_type:tt)),+) => {
+    ($(($name:tt, $input_type:tt, $encode:tt, $encode_method:tt, $decode:tt, $decode_method:tt)),+) => {
         $(
             /// Macro generated module to be used by test-fuzz and `bench` if it applies.
             #[allow(non_snake_case)]
@@ -29,11 +29,11 @@ macro_rules! impl_fuzzer_with_input {
                 /// This method is used for benchmarking, so its parameter should be the actual type that is being tested.
                 pub fn encode_and_decode(obj: $name) -> (usize, $name)
                 {
-                    let data = table::Encode::encode(obj);
+                    let data = table::$encode::$encode_method(obj);
                     let size = data.len();
 
                     // Some `data` might be a fixed array.
-                    (size, table::Decode::decode(data.to_vec()).expect("failed to decode"))
+                    (size, table::$decode::$decode_method(data.to_vec()).expect("failed to decode"))
                 }
 
                 #[cfg(test)]
@@ -56,14 +56,36 @@ macro_rules! impl_fuzzer_with_input {
 
 /// Fuzzer generates a random instance of the object and proceeds to encode and decode it. It then
 /// makes sure that it matches the original object.
-macro_rules! impl_fuzzer {
+macro_rules! impl_fuzzer_key {
     ($($name:tt),+) => {
         $(
-            impl_fuzzer_with_input!(($name, $name));
+            impl_fuzzer_with_input!(($name, $name, Encode, encode, Decode, decode));
         )+
     };
 }
 
-impl_fuzzer!(Header, Account, BlockNumHash, TxNumberAddress);
+/// Fuzzer generates a random instance of the object and proceeds to compress and uncompress it. It
+/// then makes sure that it matches the original object.
+macro_rules! impl_fuzzer_value {
+    ($($name:tt),+) => {
+        $(
+            impl_fuzzer_with_input!(($name, $name, Compress, compress, Uncompress, uncompress));
+        )+
+    };
+}
 
-impl_fuzzer_with_input!((IntegerList, IntegerListInput));
+/// Fuzzer generates a random instance of the object and proceeds to compress and uncompress it. It
+/// then makes sure that it matches the original object. It supports being fed a different kind of
+/// input, as long as it supports Into<T>.
+macro_rules! impl_fuzzer_value_with_input {
+    ($(($name:tt, $input:tt)),+) => {
+        $(
+            impl_fuzzer_with_input!(($name, $input, Compress, compress, Uncompress, uncompress));
+        )+
+    };
+}
+
+impl_fuzzer_value!(Header, Account);
+
+impl_fuzzer_key!(BlockNumHash, TxNumberAddress);
+impl_fuzzer_value_with_input!((IntegerList, IntegerListInput));

--- a/crates/interfaces/src/db/codecs/fuzz/mod.rs
+++ b/crates/interfaces/src/db/codecs/fuzz/mod.rs
@@ -64,23 +64,23 @@ macro_rules! impl_fuzzer_key {
     };
 }
 
-/// Fuzzer generates a random instance of the object and proceeds to compress and uncompress it. It
+/// Fuzzer generates a random instance of the object and proceeds to compress and decompress it. It
 /// then makes sure that it matches the original object.
 macro_rules! impl_fuzzer_value {
     ($($name:tt),+) => {
         $(
-            impl_fuzzer_with_input!(($name, $name, Compress, compress, Uncompress, uncompress));
+            impl_fuzzer_with_input!(($name, $name, Compress, compress, Decompress, decompress));
         )+
     };
 }
 
-/// Fuzzer generates a random instance of the object and proceeds to compress and uncompress it. It
+/// Fuzzer generates a random instance of the object and proceeds to compress and decompress it. It
 /// then makes sure that it matches the original object. It supports being fed a different kind of
 /// input, as long as it supports Into<T>.
 macro_rules! impl_fuzzer_value_with_input {
     ($(($name:tt, $input:tt)),+) => {
         $(
-            impl_fuzzer_with_input!(($name, $input, Compress, compress, Uncompress, uncompress));
+            impl_fuzzer_with_input!(($name, $input, Compress, compress, Decompress, decompress));
         )+
     };
 }

--- a/crates/interfaces/src/db/codecs/postcard.rs
+++ b/crates/interfaces/src/db/codecs/postcard.rs
@@ -14,7 +14,6 @@ use reth_primitives::*;
 // }
 //
 // impl_heapless_postcard!(T, MaxSize(T))
-
 macro_rules! impl_postcard {
     ($($name:tt),+) => {
         $(

--- a/crates/interfaces/src/db/codecs/scale.rs
+++ b/crates/interfaces/src/db/codecs/scale.rs
@@ -1,4 +1,4 @@
-use crate::db::{models::accounts::AccountBeforeTx, Compress, Error, Uncompress};
+use crate::db::{models::accounts::AccountBeforeTx, Compress, Decompress, Error};
 use parity_scale_codec::decode_from_bytes;
 use reth_primitives::*;
 
@@ -6,7 +6,7 @@ mod sealed {
     pub trait Sealed {}
 }
 
-/// Marker trait type to restrict the [`Compress`] and [`Uncompress`] with scale to chosen types.
+/// Marker trait type to restrict the [`Compress`] and [`Decompress`] with scale to chosen types.
 pub trait ScaleValue: sealed::Sealed {}
 
 impl<T> Compress for T
@@ -20,11 +20,11 @@ where
     }
 }
 
-impl<T> Uncompress for T
+impl<T> Decompress for T
 where
     T: ScaleValue + parity_scale_codec::Decode + Sync + Send + std::fmt::Debug,
 {
-    fn uncompress<B: Into<bytes::Bytes>>(value: B) -> Result<T, Error> {
+    fn decompress<B: Into<bytes::Bytes>>(value: B) -> Result<T, Error> {
         decode_from_bytes(value.into()).map_err(|e| Error::Decode(e.into()))
     }
 }

--- a/crates/interfaces/src/db/codecs/scale.rs
+++ b/crates/interfaces/src/db/codecs/scale.rs
@@ -1,4 +1,4 @@
-use crate::db::{models::accounts::AccountBeforeTx, Compress, Decode, Encode, Error, Uncompress};
+use crate::db::{models::accounts::AccountBeforeTx, Compress, Error, Uncompress};
 use parity_scale_codec::decode_from_bytes;
 use reth_primitives::*;
 
@@ -20,9 +20,6 @@ where
     }
 }
 
-/// Marker trait type to restrict the [`Encode`] and [`Decode`] with scale to chosen types.
-pub trait ScaleKey: sealed::Sealed {}
-
 impl<T> Uncompress for T
 where
     T: ScaleValue + parity_scale_codec::Decode + Sync + Send + std::fmt::Debug,
@@ -32,32 +29,11 @@ where
     }
 }
 
-impl<T> Encode for T
-where
-    T: ScaleKey + parity_scale_codec::Encode + Sync + Send + std::fmt::Debug,
-{
-    type Encoded = Vec<u8>;
-
-    fn encode(self) -> Self::Encoded {
-        parity_scale_codec::Encode::encode(&self)
-    }
-}
-
-impl<T> Decode for T
-where
-    T: ScaleKey + parity_scale_codec::Decode + Sync + Send + std::fmt::Debug,
-{
-    fn decode<B: Into<bytes::Bytes>>(value: B) -> Result<T, Error> {
-        decode_from_bytes(value.into()).map_err(|e| Error::Decode(e.into()))
-    }
-}
-
 /// Implements SCALE both for value and key types.
 macro_rules! impl_scale {
     ($($name:tt),+) => {
         $(
             impl ScaleValue for $name {}
-            impl ScaleKey for $name {}
             impl sealed::Sealed for $name {}
         )+
     };
@@ -74,7 +50,6 @@ macro_rules! impl_scale_value {
 }
 
 impl ScaleValue for Vec<u8> {}
-impl ScaleKey for Vec<u8> {}
 impl sealed::Sealed for Vec<u8> {}
 
 impl_scale!(U256, H256, H160);

--- a/crates/interfaces/src/db/codecs/scale.rs
+++ b/crates/interfaces/src/db/codecs/scale.rs
@@ -1,16 +1,40 @@
-use crate::db::{models::accounts::AccountBeforeTx, Decode, Encode, Error};
+use crate::db::{models::accounts::AccountBeforeTx, Compress, Decode, Encode, Error, Uncompress};
 use parity_scale_codec::decode_from_bytes;
 use reth_primitives::*;
 
 mod sealed {
     pub trait Sealed {}
 }
-/// Marker trait type to restrict the TableEncode and TableDecode with scale to chosen types.
-pub trait ScaleOnly: sealed::Sealed {}
+
+/// Marker trait type to restrict the [`Compress`] and [`Uncompress`] with scale to chosen types.
+pub trait ScaleValue: sealed::Sealed {}
+
+impl<T> Compress for T
+where
+    T: ScaleValue + parity_scale_codec::Encode + Sync + Send + std::fmt::Debug,
+{
+    type Compressed = Vec<u8>;
+
+    fn compress(self) -> Self::Compressed {
+        parity_scale_codec::Encode::encode(&self)
+    }
+}
+
+/// Marker trait type to restrict the [`Encode`] and [`Decode`] with scale to chosen types.
+pub trait ScaleKey: sealed::Sealed {}
+
+impl<T> Uncompress for T
+where
+    T: ScaleValue + parity_scale_codec::Decode + Sync + Send + std::fmt::Debug,
+{
+    fn uncompress<B: Into<bytes::Bytes>>(value: B) -> Result<T, Error> {
+        decode_from_bytes(value.into()).map_err(|e| Error::Decode(e.into()))
+    }
+}
 
 impl<T> Encode for T
 where
-    T: ScaleOnly + parity_scale_codec::Encode + Sync + Send + std::fmt::Debug,
+    T: ScaleKey + parity_scale_codec::Encode + Sync + Send + std::fmt::Debug,
 {
     type Encoded = Vec<u8>;
 
@@ -21,27 +45,40 @@ where
 
 impl<T> Decode for T
 where
-    T: ScaleOnly + parity_scale_codec::Decode + Sync + Send + std::fmt::Debug,
+    T: ScaleKey + parity_scale_codec::Decode + Sync + Send + std::fmt::Debug,
 {
     fn decode<B: Into<bytes::Bytes>>(value: B) -> Result<T, Error> {
         decode_from_bytes(value.into()).map_err(|e| Error::Decode(e.into()))
     }
 }
 
+/// Implements SCALE both for value and key types.
 macro_rules! impl_scale {
     ($($name:tt),+) => {
         $(
-            impl ScaleOnly for $name {}
+            impl ScaleValue for $name {}
+            impl ScaleKey for $name {}
             impl sealed::Sealed for $name {}
         )+
     };
 }
 
-impl ScaleOnly for Vec<u8> {}
+/// Implements SCALE only for value types.
+macro_rules! impl_scale_value {
+    ($($name:tt),+) => {
+        $(
+            impl ScaleValue for $name {}
+            impl sealed::Sealed for $name {}
+        )+
+    };
+}
+
+impl ScaleValue for Vec<u8> {}
+impl ScaleKey for Vec<u8> {}
 impl sealed::Sealed for Vec<u8> {}
 
-impl_scale!(u8, u32, u16, u64, U256, H256, H160);
-
+impl_scale!(U256, H256, H160);
 impl_scale!(Header, Account, Log, Receipt, TxType, StorageEntry);
-
 impl_scale!(AccountBeforeTx);
+
+impl_scale_value!(u8, u32, u16, u64);

--- a/crates/interfaces/src/db/models/accounts.rs
+++ b/crates/interfaces/src/db/models/accounts.rs
@@ -66,7 +66,7 @@ impl Decode for TxNumberAddress {
                 .try_into()
                 .map_err(|_| Error::Decode(eyre!("Into bytes error.")))?,
         );
-        let hash = Address::decode(value.slice(8..))?;
+        let hash = Address::from_slice(&value.slice(8..));
 
         Ok(TxNumberAddress((num, hash)))
     }

--- a/crates/interfaces/src/db/models/blocks.rs
+++ b/crates/interfaces/src/db/models/blocks.rs
@@ -88,7 +88,7 @@ mod test {
         bytes[..8].copy_from_slice(&num.to_be_bytes());
         bytes[8..].copy_from_slice(&hash.0);
 
-        let encoded = Encode::encode(key.clone());
+        let encoded = Encode::encode(key);
         assert_eq!(encoded, bytes);
 
         let decoded: BlockNumHash = Decode::decode(encoded.to_vec()).unwrap();

--- a/crates/interfaces/src/db/models/blocks.rs
+++ b/crates/interfaces/src/db/models/blocks.rs
@@ -65,7 +65,7 @@ impl Decode for BlockNumHash {
                 .try_into()
                 .map_err(|_| Error::Decode(eyre!("Into bytes error.")))?,
         );
-        let hash = H256::decode(value.slice(8..))?;
+        let hash = H256::from_slice(&value.slice(8..));
 
         Ok(BlockNumHash((num, hash)))
     }

--- a/crates/interfaces/src/db/models/integer_list.rs
+++ b/crates/interfaces/src/db/models/integer_list.rs
@@ -1,8 +1,8 @@
-//! Implements [`Compress`] and [`Uncompress`] for [`IntegerList`]
+//! Implements [`Compress`] and [`Decompress`] for [`IntegerList`]
 
 use crate::db::{
     error::Error,
-    table::{Compress, Uncompress},
+    table::{Compress, Decompress},
 };
 use bytes::Bytes;
 use reth_primitives::IntegerList;
@@ -15,8 +15,8 @@ impl Compress for IntegerList {
     }
 }
 
-impl Uncompress for IntegerList {
-    fn uncompress<B: Into<Bytes>>(value: B) -> Result<Self, Error> {
+impl Decompress for IntegerList {
+    fn decompress<B: Into<Bytes>>(value: B) -> Result<Self, Error> {
         IntegerList::from_bytes(&value.into()).map_err(|e| Error::Decode(eyre::eyre!("{e}")))
     }
 }

--- a/crates/interfaces/src/db/models/integer_list.rs
+++ b/crates/interfaces/src/db/models/integer_list.rs
@@ -1,22 +1,22 @@
-//! Implements [`Encode`] and [`Decode`] for [`IntegerList`]
+//! Implements [`Compress`] and [`Uncompress`] for [`IntegerList`]
 
 use crate::db::{
     error::Error,
-    table::{Decode, Encode},
+    table::{Compress, Uncompress},
 };
 use bytes::Bytes;
 use reth_primitives::IntegerList;
 
-impl Encode for IntegerList {
-    type Encoded = Vec<u8>;
+impl Compress for IntegerList {
+    type Compressed = Vec<u8>;
 
-    fn encode(self) -> Self::Encoded {
+    fn compress(self) -> Self::Compressed {
         self.to_bytes()
     }
 }
 
-impl Decode for IntegerList {
-    fn decode<B: Into<Bytes>>(value: B) -> Result<Self, Error> {
+impl Uncompress for IntegerList {
+    fn uncompress<B: Into<Bytes>>(value: B) -> Result<Self, Error> {
         IntegerList::from_bytes(&value.into()).map_err(|e| Error::Decode(eyre::eyre!("{e}")))
     }
 }

--- a/crates/interfaces/src/db/models/mod.rs
+++ b/crates/interfaces/src/db/models/mod.rs
@@ -15,45 +15,28 @@ use crate::db::{
 };
 use eyre::eyre;
 
-/// Helper type to ensure that `uint` keys are saved in raw and big-endian format.
-#[derive(Debug)]
-pub struct UncompressedUint<T> {
-    /// Inner value
-    pub inner: T,
-}
-
-/// Macro to ensure that UncompressedUint<uintN> keys are saved in raw and big-endian format.
+/// Macro that implements [`Encode`] and [`Decode`] for uint types.
 macro_rules! impl_uints {
     ($(($name:tt, $size:tt)),+) => {
         $(
-            impl Encode for UncompressedUint<$name>
+            impl Encode for $name
             {
                 type Encoded = [u8; $size];
 
                 fn encode(self) -> Self::Encoded {
-                    $name::to_be_bytes(self.inner)
+                    self.to_be_bytes()
                 }
             }
 
-            impl Decode for UncompressedUint<$name>
+            impl Decode for $name
             {
                 fn decode<B: Into<bytes::Bytes>>(value: B) -> Result<Self, Error> {
                     let value: bytes::Bytes = value.into();
-                    Ok(UncompressedUint { inner: $name::from_be_bytes(
-                         value.as_ref().try_into().map_err(|_| Error::Decode(eyre!("Into bytes error.")))?
-                    ) })
-                }
-            }
-
-            impl From<$name> for UncompressedUint<$name> {
-                fn from(num: $name) -> Self {
-                    UncompressedUint {inner: num}
-                }
-            }
-
-            impl From<UncompressedUint<$name>> for $name {
-                fn from(num: UncompressedUint<$name>) -> Self {
-                    num.inner
+                    Ok(
+                        $name::from_be_bytes(
+                            value.as_ref().try_into().map_err(|_| Error::Decode(eyre!("Into bytes error.")))?
+                        )
+                    )
                 }
             }
         )+

--- a/crates/interfaces/src/db/models/mod.rs
+++ b/crates/interfaces/src/db/models/mod.rs
@@ -7,6 +7,7 @@ pub mod sharded_key;
 
 pub use accounts::*;
 pub use blocks::*;
+use reth_primitives::{Address, H256};
 pub use sharded_key::ShardedKey;
 
 use crate::db::{
@@ -44,3 +45,41 @@ macro_rules! impl_uints {
 }
 
 impl_uints!((u64, 8), (u32, 4), (u16, 2), (u8, 1));
+
+impl Encode for Vec<u8> {
+    type Encoded = Vec<u8>;
+    fn encode(self) -> Self::Encoded {
+        self
+    }
+}
+
+impl Decode for Vec<u8> {
+    fn decode<B: Into<bytes::Bytes>>(value: B) -> Result<Self, Error> {
+        Ok(value.into().to_vec())
+    }
+}
+
+impl Encode for Address {
+    type Encoded = [u8; 20];
+    fn encode(self) -> Self::Encoded {
+        self.to_fixed_bytes()
+    }
+}
+
+impl Decode for Address {
+    fn decode<B: Into<bytes::Bytes>>(value: B) -> Result<Self, Error> {
+        Ok(Address::from_slice(&value.into()[..]))
+    }
+}
+impl Encode for H256 {
+    type Encoded = [u8; 32];
+    fn encode(self) -> Self::Encoded {
+        self.to_fixed_bytes()
+    }
+}
+
+impl Decode for H256 {
+    fn decode<B: Into<bytes::Bytes>>(value: B) -> Result<Self, Error> {
+        Ok(H256::from_slice(&value.into()[..]))
+    }
+}

--- a/crates/interfaces/src/db/models/mod.rs
+++ b/crates/interfaces/src/db/models/mod.rs
@@ -22,6 +22,7 @@ pub struct UncompressedUint<T> {
     pub inner: T,
 }
 
+/// Macro to ensure that UncompressedUint<uintN> keys are saved in raw and big-endian format.
 macro_rules! impl_uints {
     ($(($name:tt, $size:tt)),+) => {
         $(

--- a/crates/interfaces/src/db/models/mod.rs
+++ b/crates/interfaces/src/db/models/mod.rs
@@ -8,3 +8,55 @@ pub mod sharded_key;
 pub use accounts::*;
 pub use blocks::*;
 pub use sharded_key::ShardedKey;
+
+use crate::db::{
+    table::{Decode, Encode},
+    Error,
+};
+use eyre::eyre;
+
+/// Helper type to ensure that `uint` keys are saved in raw and big-endian format.
+#[derive(Debug)]
+pub struct UncompressedUint<T> {
+    /// Inner value
+    pub inner: T,
+}
+
+macro_rules! impl_uints {
+    ($(($name:tt, $size:tt)),+) => {
+        $(
+            impl Encode for UncompressedUint<$name>
+            {
+                type Encoded = [u8; $size];
+
+                fn encode(self) -> Self::Encoded {
+                    $name::to_be_bytes(self.inner)
+                }
+            }
+
+            impl Decode for UncompressedUint<$name>
+            {
+                fn decode<B: Into<bytes::Bytes>>(value: B) -> Result<Self, Error> {
+                    let value: bytes::Bytes = value.into();
+                    Ok(UncompressedUint { inner: $name::from_be_bytes(
+                         value.as_ref().try_into().map_err(|_| Error::Decode(eyre!("Into bytes error.")))?
+                    ) })
+                }
+            }
+
+            impl From<$name> for UncompressedUint<$name> {
+                fn from(num: $name) -> Self {
+                    UncompressedUint {inner: num}
+                }
+            }
+
+            impl From<UncompressedUint<$name>> for $name {
+                fn from(num: UncompressedUint<$name>) -> Self {
+                    num.inner
+                }
+            }
+        )+
+    };
+}
+
+impl_uints!((u64, 8), (u32, 4), (u16, 2), (u8, 1));

--- a/crates/interfaces/src/db/table.rs
+++ b/crates/interfaces/src/db/table.rs
@@ -5,12 +5,27 @@ use std::{
     marker::{Send, Sync},
 };
 
+/// Trait that will transform the data to be saved in the DB in a (ideally) compressed format
+pub trait Compress: Send + Sync + Sized + Debug {
+    /// Compressed type.
+    type Compressed: AsRef<[u8]> + Send + Sync;
+
+    /// Compresses data going into the database.
+    fn compress(self) -> Self::Compressed;
+}
+
+/// Trait that will transform the data to be read from the DB.
+pub trait Uncompress: Send + Sync + Sized + Debug {
+    /// Uncompresses data coming from the database.
+    fn uncompress<B: Into<Bytes>>(value: B) -> Result<Self, Error>;
+}
+
 /// Trait that will transform the data to be saved in the DB.
 pub trait Encode: Send + Sync + Sized + Debug {
     /// Encoded type.
     type Encoded: AsRef<[u8]> + Send + Sync;
 
-    /// Decodes data going into the database.
+    /// Encodes data going into the database.
     fn encode(self) -> Self::Encoded;
 }
 
@@ -20,10 +35,15 @@ pub trait Decode: Send + Sync + Sized + Debug {
     fn decode<B: Into<Bytes>>(value: B) -> Result<Self, Error>;
 }
 
-/// Generic trait that enforces the database value to implement [`Encode`] and [`Decode`].
-pub trait Object: Encode + Decode {}
+/// Generic trait that enforces the database key to implement [`Encode`] and [`Decode`].
+pub trait Key: Encode + Decode {}
 
-impl<T> Object for T where T: Encode + Decode {}
+impl<T> Key for T where T: Encode + Decode {}
+
+/// Generic trait that enforces the database value to implement [`Compress`] and [`Uncompress`].
+pub trait Value: Compress + Uncompress {}
+
+impl<T> Value for T where T: Compress + Uncompress {}
 
 /// Generic trait that a database table should follow.
 ///
@@ -39,11 +59,11 @@ pub trait Table: Send + Sync + Debug + 'static {
     /// Key element of `Table`.
     ///
     /// Sorting should be taken into account when encoding this.
-    type Key: Object;
+    type Key: Key;
     /// Value element of `Table`.
-    type Value: Object;
+    type Value: Value;
     /// Seek Key element of `Table`.
-    type SeekKey: Object;
+    type SeekKey: Key;
 }
 
 /// DupSort allows for keys not to be repeated in the database,
@@ -52,5 +72,5 @@ pub trait DupSort: Table {
     /// Subkey type. For more check https://libmdbx.dqdkfa.ru/usage.html#autotoc_md48
     ///
     /// Sorting should be taken into account when encoding this.
-    type SubKey: Object;
+    type SubKey: Key;
 }

--- a/crates/interfaces/src/db/table.rs
+++ b/crates/interfaces/src/db/table.rs
@@ -15,9 +15,9 @@ pub trait Compress: Send + Sync + Sized + Debug {
 }
 
 /// Trait that will transform the data to be read from the DB.
-pub trait Uncompress: Send + Sync + Sized + Debug {
-    /// Uncompresses data coming from the database.
-    fn uncompress<B: Into<Bytes>>(value: B) -> Result<Self, Error>;
+pub trait Decompress: Send + Sync + Sized + Debug {
+    /// Decompresses data coming from the database.
+    fn decompress<B: Into<Bytes>>(value: B) -> Result<Self, Error>;
 }
 
 /// Trait that will transform the data to be saved in the DB.
@@ -40,10 +40,10 @@ pub trait Key: Encode + Decode {}
 
 impl<T> Key for T where T: Encode + Decode {}
 
-/// Generic trait that enforces the database value to implement [`Compress`] and [`Uncompress`].
-pub trait Value: Compress + Uncompress {}
+/// Generic trait that enforces the database value to implement [`Compress`] and [`Decompress`].
+pub trait Value: Compress + Decompress {}
 
-impl<T> Value for T where T: Compress + Uncompress {}
+impl<T> Value for T where T: Compress + Decompress {}
 
 /// Generic trait that a database table should follow.
 ///

--- a/crates/interfaces/src/db/tables.rs
+++ b/crates/interfaces/src/db/tables.rs
@@ -131,15 +131,15 @@ table!(
 
 table!(
     /// Stores the transaction body from canonical transactions. Canonical only
-    Transactions => TxNumber => RlpTxBody);
+    Transactions =>  UncompressedUint<TxNumber> => RlpTxBody);
 
 table!(
     /// Stores transaction receipts. Canonical only
-    Receipts => TxNumber => Receipt);
+    Receipts =>  UncompressedUint<TxNumber> => Receipt);
 
 table!(
     /// Stores transaction logs. Canonical only
-    Logs => TxNumber => Receipt);
+    Logs =>  UncompressedUint<TxNumber> => Receipt);
 
 table!(
     /// Stores the current state of an Account.
@@ -200,7 +200,7 @@ table!(
 
 dupsort!(
     /// Stores state of an account before a certain transaction changed it.
-    AccountChangeSet => TxNumber => [Address] AccountBeforeTx);
+    AccountChangeSet =>  UncompressedUint<TxNumber> => [Address] AccountBeforeTx);
 
 dupsort!(
     /// Stores state of a storage key before a certain transaction changed it.
@@ -208,7 +208,7 @@ dupsort!(
 
 table!(
     /// Stores the transaction sender from each transaction.
-    TxSenders => TxNumber => Address); // Is it necessary? if so, inverted index index so we dont repeat addresses?
+    TxSenders =>  UncompressedUint<TxNumber> => Address); // Is it necessary? if so, inverted index index so we dont repeat addresses?
 
 table!(
     /// Config.

--- a/crates/interfaces/src/db/tables.rs
+++ b/crates/interfaces/src/db/tables.rs
@@ -131,15 +131,15 @@ table!(
 
 table!(
     /// Stores the transaction body from canonical transactions. Canonical only
-    Transactions =>  TxNumber => RlpTxBody);
+    Transactions => TxNumber => RlpTxBody);
 
 table!(
     /// Stores transaction receipts. Canonical only
-    Receipts =>  TxNumber => Receipt);
+    Receipts => TxNumber => Receipt);
 
 table!(
     /// Stores transaction logs. Canonical only
-    Logs =>  TxNumber => Receipt);
+    Logs => TxNumber => Receipt);
 
 table!(
     /// Stores the current state of an Account.
@@ -200,7 +200,7 @@ table!(
 
 dupsort!(
     /// Stores state of an account before a certain transaction changed it.
-    AccountChangeSet =>  TxNumber => [Address] AccountBeforeTx);
+    AccountChangeSet => TxNumber => [Address] AccountBeforeTx);
 
 dupsort!(
     /// Stores state of a storage key before a certain transaction changed it.
@@ -208,7 +208,7 @@ dupsort!(
 
 table!(
     /// Stores the transaction sender from each transaction.
-    TxSenders =>  TxNumber => Address); // Is it necessary? if so, inverted index index so we dont repeat addresses?
+    TxSenders => TxNumber => Address); // Is it necessary? if so, inverted index index so we dont repeat addresses?
 
 table!(
     /// Config.

--- a/crates/interfaces/src/db/tables.rs
+++ b/crates/interfaces/src/db/tables.rs
@@ -4,7 +4,7 @@ use crate::db::{
     models::{
         accounts::{AccountBeforeTx, TxNumberAddress},
         blocks::{BlockNumHash, HeaderHash, NumTransactions, NumTxesInBlock},
-        ShardedKey,
+        ShardedKey, UncompressedUint,
     },
     DupSort,
 };
@@ -90,7 +90,7 @@ macro_rules! dupsort {
 //  TABLE DEFINITIONS
 //
 
-table!(CanonicalHeaders => BlockNumber => HeaderHash);
+table!(CanonicalHeaders => UncompressedUint<BlockNumber> => HeaderHash);
 table!(HeaderTD => BlockNumHash => RlpTotalDifficulty);
 table!(HeaderNumbers => BlockNumHash => BlockNumber);
 table!(Headers => BlockNumHash => Header);

--- a/crates/interfaces/src/db/tables.rs
+++ b/crates/interfaces/src/db/tables.rs
@@ -4,7 +4,7 @@ use crate::db::{
     models::{
         accounts::{AccountBeforeTx, TxNumberAddress},
         blocks::{BlockNumHash, HeaderHash, NumTransactions, NumTxesInBlock},
-        ShardedKey, UncompressedUint,
+        ShardedKey,
     },
     DupSort,
 };
@@ -103,7 +103,7 @@ macro_rules! dupsort {
 
 table!(
     /// Stores the header hashes belonging to the canonical chain.
-    CanonicalHeaders => UncompressedUint<BlockNumber> => HeaderHash);
+    CanonicalHeaders => BlockNumber => HeaderHash);
 
 table!(
     /// Stores the total difficulty from a block header.
@@ -131,15 +131,15 @@ table!(
 
 table!(
     /// Stores the transaction body from canonical transactions. Canonical only
-    Transactions =>  UncompressedUint<TxNumber> => RlpTxBody);
+    Transactions =>  TxNumber => RlpTxBody);
 
 table!(
     /// Stores transaction receipts. Canonical only
-    Receipts =>  UncompressedUint<TxNumber> => Receipt);
+    Receipts =>  TxNumber => Receipt);
 
 table!(
     /// Stores transaction logs. Canonical only
-    Logs =>  UncompressedUint<TxNumber> => Receipt);
+    Logs =>  TxNumber => Receipt);
 
 table!(
     /// Stores the current state of an Account.
@@ -200,7 +200,7 @@ table!(
 
 dupsort!(
     /// Stores state of an account before a certain transaction changed it.
-    AccountChangeSet =>  UncompressedUint<TxNumber> => [Address] AccountBeforeTx);
+    AccountChangeSet =>  TxNumber => [Address] AccountBeforeTx);
 
 dupsort!(
     /// Stores state of a storage key before a certain transaction changed it.
@@ -208,7 +208,7 @@ dupsort!(
 
 table!(
     /// Stores the transaction sender from each transaction.
-    TxSenders =>  UncompressedUint<TxNumber> => Address); // Is it necessary? if so, inverted index index so we dont repeat addresses?
+    TxSenders =>  TxNumber => Address); // Is it necessary? if so, inverted index index so we dont repeat addresses?
 
 table!(
     /// Config.

--- a/crates/libmdbx-rs/benches/utils.rs
+++ b/crates/libmdbx-rs/benches/utils.rs
@@ -17,7 +17,7 @@ pub fn setup_bench_db(num_rows: u32) -> (TempDir, Environment<NoWriteMap>) {
         let txn = env.begin_rw_txn().unwrap();
         let db = txn.open_db(None).unwrap();
         for i in 0..num_rows {
-            txn.put(&db, &get_key(i), &get_data(i), WriteFlags::empty()).unwrap();
+            txn.put(&db, get_key(i), get_data(i), WriteFlags::empty()).unwrap();
         }
         txn.commit().unwrap();
     }

--- a/crates/libmdbx-rs/src/lib.rs
+++ b/crates/libmdbx-rs/src/lib.rs
@@ -52,7 +52,7 @@ mod test_utils {
             LittleEndian::write_u64(&mut value, height);
             let tx = env.begin_rw_txn().expect("begin_rw_txn");
             let index = tx.create_db(None, DatabaseFlags::DUP_SORT).expect("open index db");
-            tx.put(&index, &HEIGHT_KEY, &value, WriteFlags::empty()).expect("tx.put");
+            tx.put(&index, HEIGHT_KEY, value, WriteFlags::empty()).expect("tx.put");
             tx.commit().expect("tx.commit");
         }
     }

--- a/crates/libmdbx-rs/tests/environment.rs
+++ b/crates/libmdbx-rs/tests/environment.rs
@@ -101,7 +101,7 @@ fn test_stat() {
         let mut value = [0u8; 8];
         LittleEndian::write_u64(&mut value, i);
         let tx = env.begin_rw_txn().expect("begin_rw_txn");
-        tx.put(&tx.open_db(None).unwrap(), &value, &value, WriteFlags::default()).expect("tx.put");
+        tx.put(&tx.open_db(None).unwrap(), value, value, WriteFlags::default()).expect("tx.put");
         tx.commit().expect("tx.commit");
     }
 
@@ -143,7 +143,7 @@ fn test_freelist() {
         let mut value = [0u8; 8];
         LittleEndian::write_u64(&mut value, i);
         let tx = env.begin_rw_txn().expect("begin_rw_txn");
-        tx.put(&tx.open_db(None).unwrap(), &value, &value, WriteFlags::default()).expect("tx.put");
+        tx.put(&tx.open_db(None).unwrap(), value, value, WriteFlags::default()).expect("tx.put");
         tx.commit().expect("tx.commit");
     }
     let tx = env.begin_rw_txn().expect("begin_rw_txn");

--- a/crates/libmdbx-rs/tests/transaction.rs
+++ b/crates/libmdbx-rs/tests/transaction.rs
@@ -261,7 +261,7 @@ fn test_concurrent_writers() {
         threads.push(thread::spawn(move || {
             let txn = writer_env.begin_rw_txn().unwrap();
             let db = txn.open_db(None).unwrap();
-            txn.put(&db, &format!("{}{}", key, i), &format!("{}{}", val, i), WriteFlags::empty())
+            txn.put(&db, format!("{}{}", key, i), format!("{}{}", val, i), WriteFlags::empty())
                 .unwrap();
             txn.commit().is_ok()
         }));

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -407,8 +407,7 @@ pub mod tests {
         let consensus = Arc::new(TestConsensus::default());
         let downloader = test_utils::TestDownloader::new(download_result);
 
-        let mut stage =
-            HeaderStage { consensus: consensus.clone(), client: client.clone(), downloader };
+        let mut stage = HeaderStage { consensus: consensus.clone(), client, downloader };
         tokio::spawn(async move {
             let mut db = DBContainer::<Env<WriteMap>>::new(db.borrow()).unwrap();
             let result = stage.execute(&mut db, input).await;

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -295,7 +295,6 @@ pub(crate) mod tests {
     // Validate that all necessary tables are updated after the
     // header download with some previous progress.
     async fn headers_stage_prev_progress() {
-        // TODO: set bigger range once `MDBX_EKEYMISMATCH` issue is resolved
         let (start, end) = (10000, 10241);
         let head = gen_random_header(start, None);
         let headers = gen_random_header_range(start + 1..end, head.hash());


### PR DESCRIPTION
closes #141

One of the reasons for this error is:
```
MDBX_APPEND Append the given key/data pair to the end of the database. 
This option allows fast bulk loading when keys are already known to be in the correct order. 
Loading unsorted keys with this flag will cause a MDBX_EKEYMISMATCH error.
```

And so it happens that we're saving keys as little endian (`scale` does mean `Simple Concatenated Aggregate **Little-Endian**` .. ), and in this particular case:
```
10239 -> [255, ...]
10240 -> [0, ...] <--- error
```

~~Added a wrapper type `UncompressedUint` so we can make sure that the key is saved as raw an big endian while keeping uint `Values` encoded with scale.~~
~~Is this approach ok? Seems a bit ugly having to use `.into()` everywhere.~~
~~If it's okay, i'll spread it to other keys~~

As suggested by rakita: `Encode/Decode` for key types and `Compress/Uncompress` for value types.

Note that SCALE also implements `Encode/Decode` for certain key types (eg. Address), but not the `uint` types.
