### PR TITLE
chore: remove mdbx c files from github lang stat

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+crates/libmdbx-rs/mdbx-sys/* linguist-vendored


### PR DESCRIPTION
This should remove mdbx C files from github stat. Now it is predominantly C because of included lib but this is rust project.

Link:
https://proandroiddev.com/removing-noise-from-your-github-language-stats-e96113f8183d