### PR TITLE
feat(eth-wire): use UnauthedEthStream to create EthStream

### DIFF
--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -44,7 +44,6 @@ where
         status: Status,
         fork_filter: ForkFilter,
     ) -> Result<(EthStream<S>, Status), EthStreamError> {
-
         tracing::trace!("sending eth status ...");
 
         // we need to encode and decode here on our own because we don't have an `EthStream` yet
@@ -54,7 +53,8 @@ where
         self.inner.send(our_status_bytes).await?;
 
         tracing::trace!("waiting for eth status from peer ...");
-        let their_msg = self.inner
+        let their_msg = self
+            .inner
             .next()
             .await
             .ok_or(EthStreamError::HandshakeError(HandshakeError::NoResponse))??;

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -60,7 +60,7 @@ pub struct UnauthedP2PStream<S> {
 }
 
 impl<S> UnauthedP2PStream<S> {
-    /// Create a new `UnauthedP2PStream` from a `Stream` of bytes.
+    /// Create a new `UnauthedP2PStream` from a type `S` which implements `Stream` and `Sink`.
     pub fn new(inner: S) -> Self {
         Self { inner }
     }


### PR DESCRIPTION
This introduces a new type, `UnauthedEthStream`, which represents an unauthenticated `eth` connection with a peer. Given a `Stream + Sink` connection with a peer, this can be used to perform a handshake and create an `EthStream`:
```rust
let (eth_stream, their_status) = UnauthedEthStream::new(stream)
    .handshake(status, fork_filter)
    .await
    .unwrap();
```

The `authed` flag is removed from `EthStream` and the `UnauthedEthStream::handshake` method now returns both the authenticated `EthStream` and the incoming `Status` message from the peer.

Tests are updated to assert that the `Status` message is sent and returned from the `handshake` method properly.

Fixes #160 