### PR TITLE
refactor(txpool): use tx hash for on new block update

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -78,12 +78,12 @@
 pub use crate::{
     config::PoolConfig,
     ordering::TransactionOrdering,
-    traits::{BestTransactions, NewBlockEvent, PoolTransaction, TransactionPool},
+    traits::{BestTransactions, OnNewBlockEvent, PoolTransaction, TransactionPool},
     validate::{TransactionValidationOutcome, TransactionValidator},
 };
 use crate::{
     error::PoolResult,
-    pool::PoolInner,
+    pool::{OnNewBlockOutcome, PoolInner},
     traits::{NewTransactionEvent, PoolStatus, TransactionOrigin},
     validate::ValidPoolTransaction,
 };
@@ -178,9 +178,8 @@ where
         self.pool.status()
     }
 
-    fn on_new_block(&self, _event: NewBlockEvent<Self::Transaction>) {
-        // TODO perform maintenance: update pool accordingly
-        todo!()
+    fn on_new_block(&self, event: OnNewBlockEvent) {
+        self.pool.on_new_block(event);
     }
 
     async fn add_transaction(

--- a/crates/transaction-pool/src/pool/events.rs
+++ b/crates/transaction-pool/src/pool/events.rs
@@ -11,14 +11,13 @@ pub enum TransactionEvent<Hash> {
     /// Transaction has been added to the queued pool.
     Queued,
     /// Transaction has been included in the block belonging to this hash.
-    Included(H256),
+    Mined(H256),
     /// Transaction has been replaced by the transaction belonging to the hash.
     ///
     /// E.g. same (sender + nonce) pair
     Replaced(Hash),
     /// Transaction was dropped due to configured limits.
-    Dropped,
+    Discarded,
     /// Transaction became invalid indefinitely.
     Invalid,
-    // TODO Timedout?, broadcasted(peers)
 }

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -69,13 +69,13 @@ use crate::{
     pool::{listener::PoolEventListener, state::SubPool, txpool::TxPool},
     traits::{NewTransactionEvent, PoolStatus, PoolTransaction, TransactionOrigin},
     validate::{TransactionValidationOutcome, ValidPoolTransaction},
-    PoolConfig, TransactionOrdering, TransactionValidator, U256,
+    OnNewBlockEvent, PoolConfig, TransactionOrdering, TransactionValidator, U256,
 };
 use best::BestTransactions;
 pub use events::TransactionEvent;
 use futures::channel::mpsc::{channel, Receiver, Sender};
 use parking_lot::{Mutex, RwLock};
-use reth_primitives::{Address, TxHash};
+use reth_primitives::{Address, TxHash, H256};
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
@@ -162,6 +162,12 @@ where
         let (tx, rx) = channel(TX_LISTENER_BUFFER_SIZE);
         self.transaction_listener.lock().push(tx);
         rx
+    }
+
+    /// Updates the entire pool after a new block was mined.
+    pub(crate) fn on_new_block(&self, block: OnNewBlockEvent) {
+        let outcome = self.pool.write().on_new_block(block);
+        self.notify_on_new_block(outcome);
     }
 
     /// Resubmits transactions back into the pool.
@@ -285,14 +291,28 @@ where
         });
     }
 
+    /// Notifies transaction listeners about changes after a block was processed.
+    fn notify_on_new_block(&self, outcome: OnNewBlockOutcome) {
+        let OnNewBlockOutcome { mined, promoted, discarded, block_hash } = outcome;
+
+        let mut listener = self.event_listener.write();
+
+        mined.iter().for_each(|tx| listener.mined(tx, block_hash));
+        promoted.iter().for_each(|tx| listener.ready(tx, None));
+        discarded.iter().for_each(|tx| listener.discarded(tx));
+    }
+
     /// Fire events for the newly added transaction.
     fn notify_event_listeners(&self, tx: &AddedTransaction<T::Transaction>) {
         let mut listener = self.event_listener.write();
 
         match tx {
             AddedTransaction::Pending(tx) => {
-                listener.ready(tx.transaction.hash(), None);
-                // TODO  more listeners for discarded, removed etc...
+                let AddedPendingTransaction { transaction, promoted, discarded,.. } = tx;
+
+                listener.ready(transaction.hash(), None);
+                promoted.iter().for_each(|tx| listener.ready(tx, None));
+                discarded.iter().for_each(|tx| listener.discarded(tx));
             }
             AddedTransaction::Parked { transaction, .. } => {
                 listener.queued(transaction.hash());
@@ -408,4 +428,17 @@ impl<T: PoolTransaction> AddedTransaction<T> {
             }
         }
     }
+}
+
+/// Contains all state changes after a [`NewBlockEvent`] was processed
+#[derive(Debug)]
+pub(crate) struct OnNewBlockOutcome {
+    /// Hash of the block.
+    pub(crate) block_hash: H256,
+    /// All mined transactions.
+    pub(crate) mined: Vec<TxHash>,
+    /// Transactions promoted to the ready queue.
+    pub(crate) promoted: Vec<TxHash>,
+    /// transaction that were discarded during the update
+    pub(crate) discarded: Vec<TxHash>,
 }

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -308,7 +308,7 @@ where
 
         match tx {
             AddedTransaction::Pending(tx) => {
-                let AddedPendingTransaction { transaction, promoted, discarded,.. } = tx;
+                let AddedPendingTransaction { transaction, promoted, discarded, .. } = tx;
 
                 listener.ready(transaction.hash(), None);
                 promoted.iter().for_each(|tx| listener.ready(tx, None));

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -21,7 +21,7 @@ pub trait TransactionPool: Send + Sync + 'static {
     /// Implementers need to update the pool accordingly.
     /// For example the base fee of the pending block is determined after a block is mined which
     /// affects the dynamic fee requirement of pending transactions in the pool.
-    fn on_new_block(&self, event: NewBlockEvent<Self::Transaction>);
+    fn on_new_block(&self, event: OnNewBlockEvent);
 
     /// Adds an _unvalidated_ transaction into the pool.
     ///
@@ -128,7 +128,7 @@ impl TransactionOrigin {
 
 /// Event fired when a new block was mined
 #[derive(Debug, Clone)]
-pub struct NewBlockEvent<T: PoolTransaction> {
+pub struct OnNewBlockEvent {
     /// Hash of the added block.
     pub hash: H256,
     /// EIP-1559 Base fee of the _next_ (pending) block
@@ -138,7 +138,7 @@ pub struct NewBlockEvent<T: PoolTransaction> {
     /// Provides a set of state changes that affected the accounts.
     pub state_changes: StateDiff,
     /// All mined transactions in the block
-    pub mined_transactions: Vec<Arc<ValidPoolTransaction<T>>>,
+    pub mined_transactions: Vec<H256>,
 }
 
 /// Contains a list of changed state


### PR DESCRIPTION
Instead of expecting the entire transaction object, only expect the transaction hash when a block was mined, since the block can include transactions unknown to the pool.

Remove the transaction by hash from the pool