### PR TITLE
meta(dep): ignore c files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-crates/libmdbx-rs/mdbx-sys/* linguist-vendored
+crates/libmdbx-rs/mdbx-sys/** linguist-vendored


### PR DESCRIPTION
follow up on #153 

ignore mdbx-sys subfolders according to [linguist docs](https://github.com/github/linguist/blob/master/docs/overrides.md#vendored-code)