### PR TITLE
refactor: rename HeaderLocked to SealedHeader

### DIFF
--- a/crates/consensus/src/consensus.rs
+++ b/crates/consensus/src/consensus.rs
@@ -2,7 +2,7 @@
 
 use crate::{verification, Config};
 use reth_interfaces::consensus::{Consensus, Error, ForkchoiceState};
-use reth_primitives::{HeaderLocked, H256};
+use reth_primitives::{SealedHeader, H256};
 use tokio::sync::watch;
 
 /// Ethereum consensus
@@ -32,7 +32,7 @@ impl Consensus for EthConsensus {
         self.channel.1.clone()
     }
 
-    fn validate_header(&self, header: &HeaderLocked, parent: &HeaderLocked) -> Result<(), Error> {
+    fn validate_header(&self, header: &SealedHeader, parent: &SealedHeader) -> Result<(), Error> {
         verification::validate_header_standalone(header, &self.config)?;
         verification::validate_header_regarding_parent(parent, header, &self.config)
 

--- a/crates/consensus/src/verification.rs
+++ b/crates/consensus/src/verification.rs
@@ -1,12 +1,12 @@
 //! ALl functions for verification of block
 use crate::{config, Config};
 use reth_interfaces::{consensus::Error, provider::HeaderProvider, Result as RethResult};
-use reth_primitives::{BlockLocked, HeaderLocked, TransactionSigned};
+use reth_primitives::{BlockLocked, SealedHeader, TransactionSigned};
 use std::time::SystemTime;
 
 /// Validate header standalone
 pub fn validate_header_standalone(
-    header: &HeaderLocked,
+    header: &SealedHeader,
     config: &config::Config,
 ) -> Result<(), Error> {
     // Gas used needs to be less then gas limit. Gas used is going to be check after execution.
@@ -106,8 +106,8 @@ pub fn calculate_next_block_base_fee(gas_used: u64, gas_limit: u64, base_fee: u6
 
 /// Validate block in regards to parent
 pub fn validate_header_regarding_parent(
-    parent: &HeaderLocked,
-    child: &HeaderLocked,
+    parent: &SealedHeader,
+    child: &SealedHeader,
     config: &config::Config,
 ) -> Result<(), Error> {
     // Parent number is consistent.
@@ -186,7 +186,7 @@ pub fn validate_header_regarding_parent(
 pub fn validate_block_regarding_chain<PROV: HeaderProvider>(
     block: &BlockLocked,
     provider: &PROV,
-) -> RethResult<HeaderLocked> {
+) -> RethResult<SealedHeader> {
     let hash = block.header.hash();
 
     // Check if block is known.
@@ -200,7 +200,7 @@ pub fn validate_block_regarding_chain<PROV: HeaderProvider>(
         .ok_or(Error::ParentUnknown { hash: block.parent_hash })?;
 
     // Return parent header.
-    Ok(parent.lock())
+    Ok(parent.seal())
 }
 
 /// Full validation of block before execution.
@@ -310,7 +310,7 @@ mod tests {
         let receipts = Vec::new();
         let body = Vec::new();
 
-        (BlockLocked { header: header.lock(), body, receipts, ommers }, parent)
+        (BlockLocked { header: header.seal(), body, receipts, ommers }, parent)
     }
 
     #[test]

--- a/crates/interfaces/src/consensus.rs
+++ b/crates/interfaces/src/consensus.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use reth_primitives::{BlockHash, BlockNumber, HeaderLocked, H256};
+use reth_primitives::{BlockHash, BlockNumber, SealedHeader, H256};
 use tokio::sync::watch::Receiver;
 
 /// Re-export forkchoice state
@@ -14,7 +14,7 @@ pub trait Consensus: Send + Sync {
     fn fork_choice_state(&self) -> Receiver<ForkchoiceState>;
 
     /// Validate if header is correct and follows consensus specification
-    fn validate_header(&self, header: &HeaderLocked, parent: &HeaderLocked) -> Result<(), Error>;
+    fn validate_header(&self, header: &SealedHeader, parent: &SealedHeader) -> Result<(), Error>;
 }
 
 /// Consensus Errors

--- a/crates/interfaces/src/p2p/headers/downloader.rs
+++ b/crates/interfaces/src/p2p/headers/downloader.rs
@@ -4,7 +4,7 @@ use crate::consensus::Consensus;
 use async_trait::async_trait;
 use reth_primitives::{
     rpc::{BlockId, BlockNumber},
-    Header, HeaderLocked, H256,
+    Header, SealedHeader, H256,
 };
 use reth_rpc_types::engine::ForkchoiceState;
 use std::{fmt::Debug, time::Duration};
@@ -74,9 +74,9 @@ pub trait Downloader: Sync + Send {
     /// Download the headers
     async fn download(
         &self,
-        head: &HeaderLocked,
+        head: &SealedHeader,
         forkchoice: &ForkchoiceState,
-    ) -> Result<Vec<HeaderLocked>, DownloadError>;
+    ) -> Result<Vec<SealedHeader>, DownloadError>;
 
     /// Perform a header request and returns the headers.
     // TODO: Isn't this effectively blocking per request per downloader?
@@ -108,7 +108,7 @@ pub trait Downloader: Sync + Send {
     /// Validate whether the header is valid in relation to it's parent
     ///
     /// Returns Ok(false) if the
-    fn validate(&self, header: &HeaderLocked, parent: &HeaderLocked) -> Result<(), DownloadError> {
+    fn validate(&self, header: &SealedHeader, parent: &SealedHeader) -> Result<(), DownloadError> {
         if !(parent.hash() == header.parent_hash && parent.number + 1 == header.number) {
             return Err(DownloadError::MismatchedHeaders {
                 header_number: header.number.into(),

--- a/crates/interfaces/src/test_utils.rs
+++ b/crates/interfaces/src/test_utils.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use std::{collections::HashSet, sync::Arc, time::Duration};
 
-use reth_primitives::{Header, HeaderLocked, H256, H512, U256};
+use reth_primitives::{Header, SealedHeader, H256, H512, U256};
 use reth_rpc_types::engine::ForkchoiceState;
 
 use tokio::sync::{broadcast, mpsc, watch};
@@ -16,12 +16,12 @@ use tokio_stream::{wrappers::BroadcastStream, StreamExt};
 #[derive(Debug)]
 /// A test downloader which just returns the values that have been pushed to it.
 pub struct TestDownloader {
-    result: Result<Vec<HeaderLocked>, DownloadError>,
+    result: Result<Vec<SealedHeader>, DownloadError>,
 }
 
 impl TestDownloader {
     /// Instantiates the downloader with the mock responses
-    pub fn new(result: Result<Vec<HeaderLocked>, DownloadError>) -> Self {
+    pub fn new(result: Result<Vec<SealedHeader>, DownloadError>) -> Self {
         Self { result }
     }
 }
@@ -45,9 +45,9 @@ impl Downloader for TestDownloader {
 
     async fn download(
         &self,
-        _: &HeaderLocked,
+        _: &SealedHeader,
         _: &ForkchoiceState,
-    ) -> Result<Vec<HeaderLocked>, DownloadError> {
+    ) -> Result<Vec<SealedHeader>, DownloadError> {
         self.result.clone()
     }
 }
@@ -157,8 +157,8 @@ impl Consensus for TestConsensus {
 
     fn validate_header(
         &self,
-        _header: &HeaderLocked,
-        _parent: &HeaderLocked,
+        _header: &SealedHeader,
+        _parent: &SealedHeader,
     ) -> Result<(), consensus::Error> {
         if self.fail_validation {
             Err(consensus::Error::BaseFeeMissing)
@@ -170,19 +170,19 @@ impl Consensus for TestConsensus {
 
 /// Generate a range of random header. The parent hash of the first header
 /// in the result will be equal to head
-pub fn gen_random_header_range(rng: std::ops::Range<u64>, head: H256) -> Vec<HeaderLocked> {
+pub fn gen_random_header_range(rng: std::ops::Range<u64>, head: H256) -> Vec<SealedHeader> {
     let mut headers = Vec::with_capacity(rng.end.saturating_sub(rng.start) as usize);
     for idx in rng {
         headers.push(gen_random_header(
             idx,
-            Some(headers.last().map(|h: &HeaderLocked| h.hash()).unwrap_or(head)),
+            Some(headers.last().map(|h: &SealedHeader| h.hash()).unwrap_or(head)),
         ));
     }
     headers
 }
 
 /// Generate a random header
-pub fn gen_random_header(number: u64, parent: Option<H256>) -> HeaderLocked {
+pub fn gen_random_header(number: u64, parent: Option<H256>) -> SealedHeader {
     let header = reth_primitives::Header {
         number,
         nonce: rand::random(),
@@ -190,5 +190,5 @@ pub fn gen_random_header(number: u64, parent: Option<H256>) -> HeaderLocked {
         parent_hash: parent.unwrap_or_default(),
         ..Default::default()
     };
-    header.lock()
+    header.seal()
 }

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -1,4 +1,4 @@
-use crate::{Header, HeaderLocked, Receipt, Transaction, TransactionSigned, H256};
+use crate::{Header, Receipt, SealedHeader, Transaction, TransactionSigned, H256};
 use std::ops::Deref;
 
 /// Ethereum full block.
@@ -11,7 +11,7 @@ pub struct Block {
     /// Block receipts.
     pub receipts: Vec<Receipt>,
     /// Ommers/uncles header
-    pub ommers: Vec<HeaderLocked>,
+    pub ommers: Vec<SealedHeader>,
 }
 
 impl Deref for Block {
@@ -25,13 +25,13 @@ impl Deref for Block {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct BlockLocked {
     /// Locked block header.
-    pub header: HeaderLocked,
+    pub header: SealedHeader,
     /// Transactions with signatures.
     pub body: Vec<TransactionSigned>,
     /// Block receipts.
     pub receipts: Vec<Receipt>,
     /// Omners/uncles header
-    pub ommers: Vec<HeaderLocked>,
+    pub ommers: Vec<SealedHeader>,
 }
 
 impl BlockLocked {

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -66,17 +66,17 @@ pub struct Header {
 
 impl Header {
     /// Heavy function that will calculate hash of data and will *not* save the change to metadata.
-    /// Use lock, HeaderLocked and unlock if you need hash to be persistent.
+    /// Use [`Header::seal`], [`SealedHeader`] and unlock if you need hash to be persistent.
     pub fn hash_slow(&self) -> H256 {
         let mut out = BytesMut::new();
         self.encode(&mut out);
         H256::from_slice(keccak256(&out).as_slice())
     }
 
-    /// Calculate hash and lock the Header so that it can't be changed.
-    pub fn lock(self) -> HeaderLocked {
+    /// Calculate hash and seal the Header so that it can't be changed.
+    pub fn seal(self) -> SealedHeader {
         let hash = self.hash_slow();
-        HeaderLocked { header: self, hash }
+        SealedHeader { header: self, hash }
     }
 
     fn header_payload_length(&self) -> usize {
@@ -174,22 +174,23 @@ impl Decodable for Header {
     }
 }
 
+/// A [`Header`] that is sealed at a precalculated hash, use [`SealedHeader::unseal()`] if you want
+/// to modify header.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Hash)]
-/// HeaderLocked that has precalculated hash, use unlock if you want to modify header.
-pub struct HeaderLocked {
+pub struct SealedHeader {
     /// Locked Header fields.
     header: Header,
     /// Locked Header hash.
     hash: BlockHash,
 }
 
-impl AsRef<Header> for HeaderLocked {
+impl AsRef<Header> for SealedHeader {
     fn as_ref(&self) -> &Header {
         &self.header
     }
 }
 
-impl Deref for HeaderLocked {
+impl Deref for SealedHeader {
     type Target = Header;
 
     fn deref(&self) -> &Self::Target {
@@ -197,16 +198,16 @@ impl Deref for HeaderLocked {
     }
 }
 
-impl HeaderLocked {
-    /// Construct a new locked header.
-    /// Applicable when hash is known from
-    /// the database provided it's not corrupted.
+impl SealedHeader {
+    /// Construct a new sealed header.
+    ///
+    /// Applicable when hash is known from the database provided it's not corrupted.
     pub fn new(header: Header, hash: H256) -> Self {
         Self { header, hash }
     }
 
     /// Extract raw header that can be modified.
-    pub fn unlock(self) -> Header {
+    pub fn unseal(self) -> Header {
         self.header
     }
 

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -23,7 +23,7 @@ mod transaction;
 pub use account::Account;
 pub use block::{Block, BlockLocked};
 pub use chain::Chain;
-pub use header::{Header, HeaderLocked};
+pub use header::{Header, SealedHeader};
 pub use hex_bytes::Bytes;
 pub use integer_list::IntegerList;
 pub use jsonu256::JsonU256;


### PR DESCRIPTION
rename `HeaderLocked` to `SealedHeader` and `(un)lock` to `un(seal)`