### PR TITLE
feat(test): add TestApi type

### DIFF
--- a/crates/interfaces/src/provider/block.rs
+++ b/crates/interfaces/src/provider/block.rs
@@ -17,7 +17,7 @@ pub trait HeaderProvider: Send + Sync {
     fn header(&self, block_hash: &BlockHash) -> Result<Option<Header>>;
 }
 
-/// Client trait for fetching `Block` related data.
+/// Api trait for fetching `Block` related data.
 pub trait BlockProvider: Send + Sync {
     /// Returns the current info for the chain.
     fn chain_info(&self) -> Result<ChainInfo>;

--- a/crates/interfaces/src/provider/mod.rs
+++ b/crates/interfaces/src/provider/mod.rs
@@ -3,7 +3,7 @@ pub mod db_provider;
 mod error;
 mod storage;
 
-pub use block::{BlockProvider, HeaderProvider};
+pub use block::{BlockProvider, ChainInfo, HeaderProvider};
 pub use db_provider::{self as db, ProviderImpl};
 pub use error::Error;
 pub use storage::{StateProvider, StateProviderFactory, StorageProvider};

--- a/crates/interfaces/src/test_utils/api.rs
+++ b/crates/interfaces/src/test_utils/api.rs
@@ -1,0 +1,31 @@
+use crate::{provider, provider::BlockProvider};
+use reth_primitives::{rpc::BlockId, Block, BlockNumber, H256, U256};
+
+/// Supports various api interfaces for testing purposes.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct TestApi;
+
+/// Noop implementation for testing purposes
+impl BlockProvider for TestApi {
+    fn chain_info(&self) -> crate::Result<provider::ChainInfo> {
+        Ok(provider::ChainInfo {
+            best_hash: Default::default(),
+            best_number: 0,
+            last_finalized: None,
+            safe_finalized: None,
+        })
+    }
+
+    fn block(&self, _id: BlockId) -> crate::Result<Option<Block>> {
+        Ok(None)
+    }
+
+    fn block_number(&self, _hash: H256) -> crate::Result<Option<BlockNumber>> {
+        Ok(None)
+    }
+
+    fn block_hash(&self, _number: U256) -> crate::Result<Option<H256>> {
+        Ok(None)
+    }
+}

--- a/crates/interfaces/src/test_utils/headers.rs
+++ b/crates/interfaces/src/test_utils/headers.rs
@@ -1,3 +1,4 @@
+//! Testing support for headers related interfaces.
 use crate::{
     consensus::{self, Consensus},
     p2p::headers::{
@@ -5,11 +6,9 @@ use crate::{
         downloader::{DownloadError, Downloader},
     },
 };
-use std::{collections::HashSet, sync::Arc, time::Duration};
-
 use reth_primitives::{Header, SealedHeader, H256, H512, U256};
 use reth_rpc_types::engine::ForkchoiceState;
-
+use std::{collections::HashSet, sync::Arc, time::Duration};
 use tokio::sync::{broadcast, mpsc, watch};
 use tokio_stream::{wrappers::BroadcastStream, StreamExt};
 

--- a/crates/interfaces/src/test_utils/mod.rs
+++ b/crates/interfaces/src/test_utils/mod.rs
@@ -1,0 +1,5 @@
+mod api;
+mod headers;
+
+pub use api::TestApi;
+pub use headers::*;


### PR DESCRIPTION
Closes #182

add `TestApi` type and add noop `BlockProvider` impl, intended to be used for tests that need an impl of API traits but don't use them.