### PR TITLE
ci: remove NEXTEST_EXPERIMENTAL_FILTER_EXPR env var

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
 
 env:
   RUSTFLAGS: -D warnings
-  NEXTEST_EXPERIMENTAL_FILTER_EXPR: 1
   CARGO_TERM_COLOR: always
 
 concurrency:

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -10,7 +10,6 @@ on:
 
 env:
   RUSTFLAGS: -D warnings
-  NEXTEST_EXPERIMENTAL_FILTER_EXPR: 1
   CARGO_TERM_COLOR: always
 
 concurrency:


### PR DESCRIPTION
from CI logs:

> warning: filter expressions are no longer experimental: NEXTEST_EXPERIMENTAL_FILTER_EXPR does not need to be set