### PR TITLE
fix: remove broken client feature for pubsub

### DIFF
--- a/crates/net/rpc-api/src/eth_pubsub.rs
+++ b/crates/net/rpc-api/src/eth_pubsub.rs
@@ -2,8 +2,7 @@ use jsonrpsee::proc_macros::rpc;
 use reth_rpc_types::pubsub::{Kind, Params};
 
 /// Ethereum pub-sub rpc interface.
-#[cfg_attr(not(feature = "client"), rpc(server))]
-#[cfg_attr(feature = "client", rpc(server, client))]
+#[rpc(server)]
 pub trait EthPubSubApi {
     /// Create an ethereum subscription.
     #[subscription(


### PR DESCRIPTION
the client feature for pubsub appears to be currently broken in jsonrpsee.

client is not needed for pubsub atm, so can remove for now.