### PR TITLE
ci: make codecov less noisy

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,4 +2,9 @@ coverage:
   status:
     project:
       default:
+        threshold: null
         informational: true
+github_checks:
+  annotations: false
+comment:
+  require_changes: true


### PR DESCRIPTION
- Sets `threshold` to `null` which should disable the failing check for good
- Removes in-line annotations so the review view is less cluttered
- Require changes in coverage for the comment to be posted by the bot