### PR TITLE
chore(txpool): add PoolError::hash function

### DIFF
--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -22,3 +22,17 @@ pub enum PoolError {
     #[error("[{0:?}] Transaction discarded outright due to pool size constraints.")]
     DiscardedOnInsert(TxHash),
 }
+
+// === impl PoolError ===
+
+impl PoolError {
+    /// Returns the hash of the transaction that resulted in this error.
+    pub fn hash(&self) -> &TxHash {
+        match self {
+            PoolError::ReplacementUnderpriced(hash) => hash,
+            PoolError::ProtocolFeeCapTooLow(hash, _) => hash,
+            PoolError::SpammerExceededCapacity(_, hash) => hash,
+            PoolError::DiscardedOnInsert(hash) => hash,
+        }
+    }
+}


### PR DESCRIPTION
Add function to access the hash of the function that resulted in an error.

This will be useful for tracking bad transactions in the network impl