### PR TITLE
feat: add block propagation handlers

### DIFF
--- a/crates/net/eth-wire/src/types/broadcast.rs
+++ b/crates/net/eth-wire/src/types/broadcast.rs
@@ -10,6 +10,20 @@ pub struct NewBlockHashes(
     pub Vec<BlockHashNumber>,
 );
 
+// === impl NewBlockHashes ===
+
+impl NewBlockHashes {
+    /// Returns the latest block in the list of blocks.
+    pub fn latest(&self) -> Option<&BlockHashNumber> {
+        self.0.iter().fold(None, |latest, block| {
+            if let Some(latest) = latest {
+                return if latest.number > block.number { Some(latest) } else { Some(block) }
+            }
+            Some(block)
+        })
+    }
+}
+
 /// A block hash _and_ a block number.
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable)]
 pub struct BlockHashNumber {
@@ -85,5 +99,22 @@ pub struct NewPooledTransactionHashes(
 impl From<Vec<H256>> for NewPooledTransactionHashes {
     fn from(v: Vec<H256>) -> Self {
         NewPooledTransactionHashes(v)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_return_latest_block() {
+        let mut blocks = NewBlockHashes(vec![BlockHashNumber { hash: H256::random(), number: 0 }]);
+        let latest = blocks.latest().unwrap();
+        assert_eq!(latest.number, 0);
+
+        blocks.0.push(BlockHashNumber { hash: H256::random(), number: 100 });
+        blocks.0.push(BlockHashNumber { hash: H256::random(), number: 2 });
+        let latest = blocks.latest().unwrap();
+        assert_eq!(latest.number, 100);
     }
 }

--- a/crates/net/network/src/import.rs
+++ b/crates/net/network/src/import.rs
@@ -22,11 +22,33 @@ pub struct BlockImportOutcome {
     /// Sender of the `NewBlock` message.
     pub peer: PeerId,
     /// The result after validating the block
-    pub result: Result<NewBlockMessage, BlockImportError>,
+    pub result: Result<BlockValidation, BlockImportError>,
+}
+
+/// Represents the successful validation of a received `NewBlock` message.
+#[derive(Debug)]
+pub enum BlockValidation {
+    /// Basic Header validity check, after which the block should be relayed to peers via a
+    /// `NewBlock` message
+    ValidHeader {
+        /// received block
+        block: NewBlockMessage,
+    },
+    /// Successfully imported: state-root matches after execution. The block should be relayed via
+    /// `NewBlockHashes`
+    ValidBlock {
+        /// validated block.
+        block: NewBlockMessage,
+    },
 }
 
 /// Represents the error case of a failed block import
-pub enum BlockImportError {}
+#[derive(Debug, thiserror::Error)]
+pub enum BlockImportError {
+    /// Consensus error
+    #[error(transparent)]
+    Consensus(#[from] reth_interfaces::consensus::Error),
+}
 
 /// An implementation of `BlockImport` that does nothing
 #[derive(Debug, Default)]

--- a/crates/net/network/src/message.rs
+++ b/crates/net/network/src/message.rs
@@ -26,11 +26,20 @@ pub struct NewBlockMessage {
     pub block: Arc<NewBlock>,
 }
 
+// === impl NewBlockMessage ===
+
+impl NewBlockMessage {
+    /// Returns the block number of the block
+    pub fn number(&self) -> u64 {
+        self.block.block.header.number
+    }
+}
+
 /// Represents all messages that can be sent to a peer session
 #[derive(Debug)]
 pub enum PeerMessage {
     /// Announce new block hashes
-    NewBlockHashes(NewBlockHashes),
+    NewBlockHashes(Arc<NewBlockHashes>),
     /// Broadcast new block.
     NewBlock(NewBlockMessage),
     /// Broadcast transactions.

--- a/crates/net/network/src/swarm.rs
+++ b/crates/net/network/src/swarm.rs
@@ -153,6 +153,10 @@ where
                 let msg = PeerMessage::NewBlock(msg);
                 self.sessions.send_message(&peer_id, msg);
             }
+            StateAction::NewBlockHashes { peer_id, hashes } => {
+                let msg = PeerMessage::NewBlockHashes(hashes);
+                self.sessions.send_message(&peer_id, msg);
+            }
         }
         None
     }


### PR DESCRIPTION
Adds missing block propagation handlers for `NewBlock` and `NewBlogHashes`.

While they're part of devp2 v67 they should be switched off for POS network: https://eips.ethereum.org/EIPS/eip-3675#devp2p

Since this is determined by the forkId we should add this as part of the `is_valid_message`, 

