### PR TITLE
feat: add FromRecoveredTransaction conversion trait

### DIFF
--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -42,8 +42,8 @@ pub use log::Log;
 pub use receipt::Receipt;
 pub use storage::StorageEntry;
 pub use transaction::{
-    AccessList, AccessListItem, Signature, Transaction, TransactionKind, TransactionSigned,
-    TransactionSignedEcRecovered, TxType,
+    AccessList, AccessListItem, FromRecoveredTransaction, Signature, Transaction, TransactionKind,
+    TransactionSigned, TransactionSignedEcRecovered, TxType,
 };
 
 /// A block hash.

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1,8 +1,3 @@
-mod access_list;
-mod signature;
-mod tx_type;
-mod util;
-
 use crate::{Address, Bytes, ChainId, TxHash, H256, U256};
 pub use access_list::{AccessList, AccessListItem};
 use bytes::{Buf, BytesMut};
@@ -13,13 +8,18 @@ use reth_rlp::{length_of_length, Decodable, DecodeError, Encodable, Header, EMPT
 pub use signature::Signature;
 pub use tx_type::TxType;
 
+mod access_list;
+mod signature;
+mod tx_type;
+mod util;
+
 /// A raw transaction.
 ///
 /// Transaction types were introduced in [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718).
 #[main_codec]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Transaction {
-    /// Legacy transaciton.
+    /// Legacy transaction.
     Legacy {
         /// Added as EIP-155: Simple replay attack protection
         chain_id: Option<ChainId>,
@@ -707,10 +707,25 @@ impl TransactionSignedEcRecovered {
     }
 }
 
+/// A transaction type that can be created from a [`TransactionSignedEcRecovered`] transaction.
+///
+/// This is a conversion trait that'll ensure transactions received via P2P can be converted to the
+/// transaction type that the transaction pool uses.
+pub trait FromRecoveredTransaction {
+    /// Converts to this type from the given [`TransactionSignedEcRecovered`].
+    fn from_recovered_transaction(tx: TransactionSignedEcRecovered) -> Self;
+}
+
+// Noop conversion
+impl FromRecoveredTransaction for TransactionSignedEcRecovered {
+    #[inline]
+    fn from_recovered_transaction(tx: TransactionSignedEcRecovered) -> Self {
+        tx
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
     use crate::{
         transaction::{signature::Signature, TransactionKind},
         AccessList, Address, Bytes, Transaction, TransactionSigned, H256, U256,
@@ -718,6 +733,7 @@ mod tests {
     use bytes::BytesMut;
     use ethers_core::utils::hex;
     use reth_rlp::{Decodable, Encodable};
+    use std::str::FromStr;
 
     #[test]
     fn test_decode_create() {

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1,6 +1,6 @@
 use crate::{error::PoolResult, pool::state::SubPool, validate::ValidPoolTransaction, BlockID};
 use futures::{channel::mpsc::Receiver, future::Shared};
-use reth_primitives::{Address, TxHash, H256, U256};
+use reth_primitives::{Address, FromRecoveredTransaction, TxHash, H256, U256};
 use std::{fmt, sync::Arc};
 
 /// General purpose abstraction fo a transaction-pool.
@@ -174,7 +174,7 @@ impl<T> BestTransactions for std::iter::Empty<T> {
 }
 
 /// Trait for transaction types used inside the pool
-pub trait PoolTransaction: fmt::Debug + Send + Sync + 'static {
+pub trait PoolTransaction: fmt::Debug + Send + Sync + FromRecoveredTransaction {
     /// Hash of the transaction.
     fn hash(&self) -> &TxHash;
 


### PR DESCRIPTION
adds a `FromRecoveredTransaction` conversion trait.

we receive `SignedTransaction` over the network which are then injected into the txpool. the pool is generic over `PoolTransaction`.

By binding `PoolTransaction: FromRecoveredTransaction` we ensure that we can always inject transactions received via P2P