### PR TITLE
chore(txpool): remove hash generics

### DIFF
--- a/crates/transaction-pool/src/pool/events.rs
+++ b/crates/transaction-pool/src/pool/events.rs
@@ -1,9 +1,9 @@
-use reth_primitives::H256;
+use reth_primitives::{TxHash, H256};
 use serde::{Deserialize, Serialize};
 
 /// Various events that describe status changes of a transaction.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub enum TransactionEvent<Hash> {
+pub enum TransactionEvent {
     /// Transaction has been added to the ready queue.
     Ready,
     /// Transaction has been added to the pending pool.
@@ -15,7 +15,7 @@ pub enum TransactionEvent<Hash> {
     /// Transaction has been replaced by the transaction belonging to the hash.
     ///
     /// E.g. same (sender + nonce) pair
-    Replaced(Hash),
+    Replaced(TxHash),
     /// Transaction was dropped due to configured limits.
     Discarded,
     /// Transaction became invalid indefinitely.

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -105,7 +105,7 @@ pub struct PoolInner<V: TransactionValidator, T: TransactionOrdering> {
     /// Pool settings.
     config: PoolConfig,
     /// Manages listeners for transaction state change events.
-    event_listener: RwLock<PoolEventListener<TxHash>>,
+    event_listener: RwLock<PoolEventListener>,
     /// Listeners for new ready transactions.
     pending_transaction_listener: Mutex<Vec<mpsc::Sender<TxHash>>>,
     /// Listeners for new transactions added to the pool.


### PR DESCRIPTION
get rid of unnecessary hash generics and use `TxHash` instead.