### PR TITLE
chore(txpool): use stabilized pop_last

### DIFF
--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -49,8 +49,7 @@ impl<T: TransactionOrdering> Iterator for BestTransactions<T> {
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             // Remove the next independent tx with the highest priority
-            let best = self.independent.iter().next_back()?.clone();
-            let best = self.independent.take(&best)?;
+            let best = self.independent.pop_last()?;
             let hash = best.transaction.hash();
 
             // skip transactions that were marked as invalid


### PR DESCRIPTION
Ref #212

use stabilized `BTreeMap::pop_last` over `next_back + remove`