### PR TITLE
refactor(net): separate Sink and Stream

### DIFF
--- a/crates/net/eth-wire/src/error.rs
+++ b/crates/net/eth-wire/src/error.rs
@@ -59,8 +59,8 @@ pub enum P2PStreamError {
     EmptyProtocolMessage,
     #[error(transparent)]
     PingerError(#[from] PingerError),
-    #[error("ping timed out with {0} retries")]
-    PingTimeout(u8),
+    #[error("ping timed out with")]
+    PingTimeout,
     #[error(transparent)]
     ParseVersionError(#[from] SharedCapabilityError),
     #[error("mismatched protocol version in Hello message. expected: {expected:?}, got: {got:?}")]


### PR DESCRIPTION
The previous implementation did mix Sink and Stream.

This moves all Sink related polling into the `Sink` impl.

`poll_ready` does the actual work by advancing the underlying stream via `poll_flush` and also respecting the buffer capacity.

ping related disconnects will clear the message buffer and send queue in the Disconnect message and terminate the stream. Perhaps this should just bubble up the error but handling ping issues automatically should be fine I think. Have to keep in mind that a terminated stream still needs to send the actual disconnect message. We'll figure this out once we implement the `ActiveSession`