### PR TITLE
feat(db): Add `Compact` derive for enums + refactor

### DIFF
--- a/crates/codecs/derive/src/compact/enums.rs
+++ b/crates/codecs/derive/src/compact/enums.rs
@@ -1,81 +1,120 @@
 use super::*;
 
-/// Generates `from_compact` code for an enum variant.
-///
-/// `fields_iterator` might look something like \[VariantUnit, VariantUnamedField, Field,
-/// VariantUnit...\].
-pub(crate) fn handle_enum_variant_from(
-    variant_name: &str,
-    fields_iterator: &mut std::iter::Peekable<std::iter::Enumerate<std::slice::Iter<FieldTypes>>>,
-    enum_lines: &mut Vec<TokenStream2>,
-    variant_index: &mut u8,
-    ident: &Ident,
-) {
-    let variant_name = format_ident!("{variant_name}");
-    if let Some((_, next_field)) = fields_iterator.peek() {
-        match next_field {
-            FieldTypes::EnumUnnamedField(next_ftype) => {
-                // This variant is of the type `EnumVariant(UnnamedField)`
-                let field_type = format_ident!("{next_ftype}");
-
-                // Unamed type
-                enum_lines.push(quote! {
-                    #variant_index => {
-                        let mut inner = #field_type::default();
-                        (inner, buf) = #field_type::from_compact(buf, buf.len());
-                        #ident::#variant_name(inner)
-                    }
-                });
-                fields_iterator.next();
-            }
-            FieldTypes::EnumVariant(_) => enum_lines.push(quote! {
-                #variant_index => #ident::#variant_name,
-            }),
-            FieldTypes::StructField(_) => unreachable!(),
-        };
-    } else {
-        // This variant has no fields: Unit type
-        enum_lines.push(quote! {
-            #variant_index => #ident::#variant_name,
-        });
-    }
-    *variant_index += 1;
+#[derive(Debug)]
+pub struct EnumHandler<'a> {
+    current_variant_index: u8,
+    fields_iterator: std::iter::Peekable<std::slice::Iter<'a, FieldTypes>>,
+    enum_lines: Vec<TokenStream2>,
 }
 
-/// Generates `to_compact` code for an enum variant.
-///
-/// `fields_iterator` might look something like [VariantUnit, VariantUnamedField, Field,
-/// VariantUnit...].
-pub(crate) fn handle_enum_variant_to(
-    variant_name: &str,
-    variant_index: &mut u8,
-    fields_iterator: &mut std::iter::Peekable<std::slice::Iter<FieldTypes>>,
-    enum_lines: &mut Vec<TokenStream2>,
-    ident: &Ident,
-) {
-    let variant_name = format_ident!("{variant_name}");
-    if let Some(next_field) = fields_iterator.peek() {
-        match next_field {
-            FieldTypes::EnumUnnamedField(_) => {
-                // Unamed type
-                enum_lines.push(quote! {
-                    #ident::#variant_name(field) => {
-                        field.to_compact(&mut buffer);
-                        #variant_index
-                    },
-                });
-                fields_iterator.next();
-            }
-            FieldTypes::EnumVariant(_) => enum_lines.push(quote! {
-                #ident::#variant_name => #variant_index,
-            }),
-            FieldTypes::StructField(_) => unreachable!(),
-        };
-    } else {
-        // This variant has no fields: Unit type
-        enum_lines.push(quote! {
-            #ident::#variant_name => #variant_index,
-        });
+impl<'a> EnumHandler<'a> {
+    pub fn new(fields: &'a FieldList) -> Self {
+        EnumHandler {
+            current_variant_index: 0u8,
+            enum_lines: vec![],
+            fields_iterator: fields.iter().peekable(),
+        }
     }
-    *variant_index += 1;
+
+    pub fn next_field(&mut self) -> Option<&'a FieldTypes> {
+        self.fields_iterator.next()
+    }
+
+    pub fn generate_to(mut self, ident: &Ident) -> Vec<TokenStream2> {
+        while let Some(field) = self.next_field() {
+            match field {
+                //  The following method will advance the
+                // `fields_iterator` by itself and stop right before the next variant.
+                FieldTypes::EnumVariant(name) => self.to(name, ident),
+                FieldTypes::EnumUnnamedField(_) => unreachable!(),
+                FieldTypes::StructField(_) => unreachable!(),
+            }
+        }
+        self.enum_lines
+    }
+
+    pub fn generate_from(mut self, ident: &Ident) -> Vec<TokenStream2> {
+        while let Some(field) = self.next_field() {
+            match field {
+                //  The following method will advance the
+                // `fields_iterator` by itself and stop right before the next variant.
+                FieldTypes::EnumVariant(name) => self.from(name, ident),
+                FieldTypes::EnumUnnamedField(_) => unreachable!(),
+                FieldTypes::StructField(_) => unreachable!(),
+            }
+        }
+        self.enum_lines
+    }
+
+    /// Generates `from_compact` code for an enum variant.
+    ///
+    /// `fields_iterator` might look something like \[VariantUnit, VariantUnamedField, Field,
+    /// VariantUnit...\].
+    pub fn from(&mut self, variant_name: &str, ident: &Ident) {
+        let variant_name = format_ident!("{variant_name}");
+        let current_variant_index = self.current_variant_index;
+
+        if let Some(next_field) = self.fields_iterator.peek() {
+            match next_field {
+                FieldTypes::EnumUnnamedField(next_ftype) => {
+                    // This variant is of the type `EnumVariant(UnnamedField)`
+                    let field_type = format_ident!("{next_ftype}");
+
+                    // Unamed type
+                    self.enum_lines.push(quote! {
+                        #current_variant_index => {
+                            let mut inner = #field_type::default();
+                            (inner, buf) = #field_type::from_compact(buf, buf.len());
+                            #ident::#variant_name(inner)
+                        }
+                    });
+                    self.fields_iterator.next();
+                }
+                FieldTypes::EnumVariant(_) => self.enum_lines.push(quote! {
+                    #current_variant_index => #ident::#variant_name,
+                }),
+                FieldTypes::StructField(_) => unreachable!(),
+            };
+        } else {
+            // This variant has no fields: Unit type
+            self.enum_lines.push(quote! {
+                #current_variant_index => #ident::#variant_name,
+            });
+        }
+        self.current_variant_index += 1;
+    }
+
+    /// Generates `to_compact` code for an enum variant.
+    ///
+    /// `fields_iterator` might look something like [VariantUnit, VariantUnamedField, Field,
+    /// VariantUnit...].
+    pub fn to(&mut self, variant_name: &str, ident: &Ident) {
+        let variant_name = format_ident!("{variant_name}");
+        let current_variant_index = self.current_variant_index;
+
+        if let Some(next_field) = self.fields_iterator.peek() {
+            match next_field {
+                FieldTypes::EnumUnnamedField(_) => {
+                    // Unamed type
+                    self.enum_lines.push(quote! {
+                        #ident::#variant_name(field) => {
+                            field.to_compact(&mut buffer);
+                            #current_variant_index
+                        },
+                    });
+                    self.fields_iterator.next();
+                }
+                FieldTypes::EnumVariant(_) => self.enum_lines.push(quote! {
+                    #ident::#variant_name => #current_variant_index,
+                }),
+                FieldTypes::StructField(_) => unreachable!(),
+            };
+        } else {
+            // This variant has no fields: Unit type
+            self.enum_lines.push(quote! {
+                #ident::#variant_name => #current_variant_index,
+            });
+        }
+        self.current_variant_index += 1;
+    }
 }

--- a/crates/codecs/derive/src/compact/enums.rs
+++ b/crates/codecs/derive/src/compact/enums.rs
@@ -1,0 +1,81 @@
+use super::*;
+
+/// Generates `from_compact` code for an enum variant.
+///
+/// `fields_iterator` might look something like \[VariantUnit, VariantUnamedField, Field,
+/// VariantUnit...\].
+pub(crate) fn handle_enum_variant_from(
+    variant_name: &str,
+    fields_iterator: &mut std::iter::Peekable<std::iter::Enumerate<std::slice::Iter<FieldTypes>>>,
+    enum_lines: &mut Vec<TokenStream2>,
+    variant_index: &mut u8,
+    ident: &Ident,
+) {
+    let variant_name = format_ident!("{variant_name}");
+    if let Some((_, next_field)) = fields_iterator.peek() {
+        match next_field {
+            FieldTypes::EnumUnnamedField(next_ftype) => {
+                // This variant is of the type `EnumVariant(UnnamedField)`
+                let field_type = format_ident!("{next_ftype}");
+
+                // Unamed type
+                enum_lines.push(quote! {
+                    #variant_index => {
+                        let mut inner = #field_type::default();
+                        (inner, buf) = #field_type::from_compact(buf, buf.len());
+                        #ident::#variant_name(inner)
+                    }
+                });
+                fields_iterator.next();
+            }
+            FieldTypes::EnumVariant(_) => enum_lines.push(quote! {
+                #variant_index => #ident::#variant_name,
+            }),
+            FieldTypes::StructField(_) => unreachable!(),
+        };
+    } else {
+        // This variant has no fields: Unit type
+        enum_lines.push(quote! {
+            #variant_index => #ident::#variant_name,
+        });
+    }
+    *variant_index += 1;
+}
+
+/// Generates `to_compact` code for an enum variant.
+///
+/// `fields_iterator` might look something like [VariantUnit, VariantUnamedField, Field,
+/// VariantUnit...].
+pub(crate) fn handle_enum_variant_to(
+    variant_name: &str,
+    variant_index: &mut u8,
+    fields_iterator: &mut std::iter::Peekable<std::slice::Iter<FieldTypes>>,
+    enum_lines: &mut Vec<TokenStream2>,
+    ident: &Ident,
+) {
+    let variant_name = format_ident!("{variant_name}");
+    if let Some(next_field) = fields_iterator.peek() {
+        match next_field {
+            FieldTypes::EnumUnnamedField(_) => {
+                // Unamed type
+                enum_lines.push(quote! {
+                    #ident::#variant_name(field) => {
+                        field.to_compact(&mut buffer);
+                        #variant_index
+                    },
+                });
+                fields_iterator.next();
+            }
+            FieldTypes::EnumVariant(_) => enum_lines.push(quote! {
+                #ident::#variant_name => #variant_index,
+            }),
+            FieldTypes::StructField(_) => unreachable!(),
+        };
+    } else {
+        // This variant has no fields: Unit type
+        enum_lines.push(quote! {
+            #ident::#variant_name => #variant_index,
+        });
+    }
+    *variant_index += 1;
+}

--- a/crates/codecs/derive/src/compact/flags.rs
+++ b/crates/codecs/derive/src/compact/flags.rs
@@ -1,0 +1,133 @@
+use super::*;
+
+/// Generates the flag fieldset struct that is going to be used to store the length of fields and
+/// their potential presence.
+pub(crate) fn generate_flag_struct(ident: &Ident, fields: &FieldList) -> TokenStream2 {
+    let is_enum = fields.iter().any(|field| matches!(field, FieldTypes::EnumVariant(_)));
+
+    let flags_ident = format_ident!("{ident}Flags");
+    let mut field_flags = vec![];
+
+    let total_bits = if is_enum {
+        field_flags.push(quote! {
+            variant: B8,
+        });
+        8
+    } else {
+        build_struct_field_flags(
+            fields
+                .iter()
+                .filter_map(|f| {
+                    if let FieldTypes::StructField(f) = f {
+                        return Some(f)
+                    }
+                    None
+                })
+                .collect::<Vec<_>>(),
+            &mut field_flags,
+        )
+    };
+
+    if total_bits == 0 {
+        return placeholder_flag_struct(&flags_ident)
+    }
+
+    let total_bytes = pad_flag_struct(total_bits, &mut field_flags);
+
+    // Provides the number of bytes used to represent the flag struct.
+    let readable_bytes = vec![
+        quote! {
+            buf.get_u8(),
+        };
+        total_bytes.into()
+    ];
+
+    // Generate the flag struct.
+    quote! {
+        #[bitfield]
+        #[derive(Clone, Copy, Debug, Default)]
+        struct #flags_ident {
+            #(#field_flags)*
+        }
+
+        impl #flags_ident {
+            fn from(mut buf: &[u8]) -> (Self, &[u8]) {
+                (#flags_ident::from_bytes([
+                    #(#readable_bytes)*
+                ]), buf)
+            }
+        }
+    }
+}
+
+/// Builds the flag struct for the user struct fields.
+///
+/// Returns the total number of bits necessary.
+fn build_struct_field_flags(
+    fields: Vec<&StructFieldDescriptor>,
+    field_flags: &mut Vec<TokenStream2>,
+) -> u8 {
+    let mut total_bits = 0;
+
+    // Find out the adequate bit size for the length of each field, if applicable.
+    for (name, ftype, is_compact) in fields {
+        if *is_compact {
+            if is_flag_type(ftype) {
+                let name = format_ident!("{name}_len");
+                let bitsize = get_bit_size(ftype);
+                let bsize = format_ident!("B{bitsize}");
+                total_bits += bitsize;
+
+                field_flags.push(quote! {
+                    #name: #bsize ,
+                });
+            } else {
+                let name = format_ident!("{name}");
+
+                field_flags.push(quote! {
+                    #name: bool ,
+                });
+
+                total_bits += 1;
+            }
+        }
+    }
+    total_bits
+}
+
+/// Total number of bits should be divisible by 8, so we might need to pad the struct with an unused
+/// skipped field.
+///
+/// Returns the total number of bytes used by the flags struct.
+fn pad_flag_struct(total_bits: u8, field_flags: &mut Vec<TokenStream2>) -> u8 {
+    let remaining = 8 - total_bits % 8;
+    let total_bytes = if remaining != 8 {
+        let bsize = format_ident!("B{remaining}");
+        field_flags.push(quote! {
+            #[skip]
+            unused: #bsize ,
+        });
+        (total_bits + remaining) / 8
+    } else {
+        total_bits / 8
+    };
+    total_bytes
+}
+
+/// Placeholder struct for when there are no bitfields to be added.
+fn placeholder_flag_struct(flags: &Ident) -> TokenStream2 {
+    quote! {
+        #[derive(Debug, Default)]
+        struct #flags {
+        }
+
+        impl #flags {
+            fn from(mut buf: &[u8]) -> (Self, &[u8]) {
+                (#flags::default(), buf)
+            }
+            fn into_bytes(self) -> [u8; 0] {
+                []
+            }
+        }
+    }
+}

--- a/crates/codecs/derive/src/compact/mod.rs
+++ b/crates/codecs/derive/src/compact/mod.rs
@@ -142,15 +142,6 @@ pub fn is_flag_type(ftype: &str) -> bool {
     get_bit_size(ftype) > 0
 }
 
-/// Given the field name in a string format, returns various [`Ident`] necessary to generate code
-/// with [`quote`].
-pub fn get_field_idents(name: &str) -> (Ident, Ident, Ident) {
-    let name = format_ident!("{name}");
-    let set_len_method = format_ident!("set_{name}_len");
-    let len = format_ident!("{name}_len");
-    (name, set_len_method, len)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/codecs/derive/src/compact/mod.rs
+++ b/crates/codecs/derive/src/compact/mod.rs
@@ -7,6 +7,15 @@ use syn::{parse_macro_input, Data, DeriveInput};
 mod generator;
 use generator::*;
 
+mod enums;
+use enums::*;
+
+mod flags;
+use flags::*;
+
+mod structs;
+use structs::*;
+
 // Helper Alias type
 type IsCompact = bool;
 // Helper Alias type
@@ -14,7 +23,16 @@ type FieldName = String;
 // Helper Alias type
 type FieldType = String;
 // Helper Alias type
-type FieldList = Vec<(FieldName, FieldType, IsCompact)>;
+type StructFieldDescriptor = (FieldName, FieldType, IsCompact);
+// Helper Alias type
+type FieldList = Vec<FieldTypes>;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum FieldTypes {
+    StructField(StructFieldDescriptor),
+    EnumVariant(String),
+    EnumUnnamedField(FieldType),
+}
 
 /// Derives the [`Compact`] trait and its from/to implementations.
 pub fn derive(input: TokenStream) -> TokenStream {
@@ -22,7 +40,6 @@ pub fn derive(input: TokenStream) -> TokenStream {
 
     let DeriveInput { ident, data, .. } = parse_macro_input!(input);
     let fields = get_fields(&data);
-
     output.extend(generate_flag_struct(&ident, &fields));
     output.extend(generate_from_to(&ident, &fields));
     output.into()
@@ -30,43 +47,84 @@ pub fn derive(input: TokenStream) -> TokenStream {
 
 /// Given a list of fields on a struct, extract their fields and types.
 pub fn get_fields(data: &Data) -> FieldList {
-    let mut named_fields = vec![];
-    if let syn::Data::Struct(data) = data {
-        if let syn::Fields::Named(ref fields) = data.fields {
-            for field in &fields.named {
-                if let syn::Type::Path(ref path) = field.ty {
-                    let segments = &path.path.segments;
-                    if !segments.is_empty() {
-                        let mut ftype = String::new();
-                        for (index, segment) in segments.iter().enumerate() {
-                            ftype.push_str(&segment.ident.to_string());
-                            if index < segments.len() - 1 {
-                                ftype.push_str("::");
-                            }
-                        }
-                        let should_compact = is_flag_type(&ftype) ||
-                            field.attrs.iter().any(|attr| {
-                                attr.path.segments.iter().any(|path| path.ident == "maybe_zero")
-                            });
+    let mut fields = vec![];
 
-                        named_fields.push((
-                            field.ident.as_ref().expect("qed").to_string(),
-                            ftype,
-                            should_compact,
-                        ));
+    match data {
+        Data::Struct(data) => match data.fields {
+            syn::Fields::Named(ref data_fields) => {
+                for field in &data_fields.named {
+                    load_field(field, &mut fields, false);
+                }
+                assert_eq!(fields.len(), data_fields.named.len());
+            }
+            syn::Fields::Unnamed(ref data_fields) => {
+                assert!(
+                    data_fields.unnamed.len() == 1,
+                    "Compact only allows one unnamed field. Consider making it a struct."
+                );
+                load_field(&data_fields.unnamed[0], &mut fields, false);
+            }
+            syn::Fields::Unit => todo!(),
+        },
+        Data::Enum(data) => {
+            for variant in &data.variants {
+                fields.push(FieldTypes::EnumVariant(variant.ident.to_string()));
+
+                match &variant.fields {
+                    syn::Fields::Named(_) => {
+                        panic!("Not allowed to have Enum Variants with multiple named fields. Make it a struct instead.")
                     }
+                    syn::Fields::Unnamed(data_fields) => {
+                        assert!(
+                            data_fields.unnamed.len() == 1,
+                            "Compact only allows one unnamed field. Consider making it a struct."
+                        );
+                        load_field(&data_fields.unnamed[0], &mut fields, true);
+                    }
+                    syn::Fields::Unit => (),
                 }
             }
-            assert_eq!(named_fields.len(), fields.named.len());
+        }
+        Data::Union(_) => todo!(),
+    }
+
+    fields
+}
+
+fn load_field(field: &syn::Field, fields: &mut FieldList, is_enum: bool) {
+    if let syn::Type::Path(ref path) = field.ty {
+        let segments = &path.path.segments;
+        if !segments.is_empty() {
+            let mut ftype = String::new();
+            for (index, segment) in segments.iter().enumerate() {
+                ftype.push_str(&segment.ident.to_string());
+                if index < segments.len() - 1 {
+                    ftype.push_str("::");
+                }
+            }
+
+            if is_enum {
+                fields.push(FieldTypes::EnumUnnamedField(ftype.to_string()));
+            } else {
+                let should_compact = is_flag_type(&ftype) ||
+                    field.attrs.iter().any(|attr| {
+                        attr.path.segments.iter().any(|path| path.ident == "maybe_zero")
+                    });
+
+                fields.push(FieldTypes::StructField((
+                    field.ident.as_ref().map(|i| i.to_string()).unwrap_or_default(),
+                    ftype,
+                    should_compact,
+                )));
+            }
         }
     }
-    named_fields
 }
 
 /// Given the field type in a string format, return the amount of bits necessary to save its maximum
 /// length.
 pub fn get_bit_size(ftype: &str) -> u8 {
-    if ftype == "u64" || ftype == "BlockNumber" || ftype == "TxNumber" {
+    if ftype == "u64" || ftype == "BlockNumber" || ftype == "TxNumber" || ftype == "ChainId" {
         return 4
     } else if ftype == "TxType" {
         return 2

--- a/crates/codecs/derive/src/compact/structs.rs
+++ b/crates/codecs/derive/src/compact/structs.rs
@@ -1,0 +1,72 @@
+use super::*;
+
+/// Generates `from_compact` code for a struct field.
+pub(crate) fn handle_struct_field_from(
+    name: &str,
+    known_types: [&str; 5],
+    field_num: usize,
+    fields: &Vec<FieldTypes>,
+    ftype: &str,
+    lines: &mut Vec<TokenStream2>,
+    is_compact: &bool,
+) {
+    let (name, _, len) = get_field_idents(name);
+    assert!(
+        known_types.contains(&ftype) || is_flag_type(ftype) || field_num == fields.len() - 1,
+        "{ftype} field should be placed as the last one since it's not known. "
+    );
+    if ftype == "bytes::Bytes" {
+        lines.push(quote! {
+            let mut #name = bytes::Bytes::new();
+            (#name, buf) = bytes::Bytes::from_compact(buf, buf.len() as usize);
+        })
+    } else {
+        let ident_type = format_ident!("{ftype}");
+        lines.push(quote! {
+            let mut #name = #ident_type::default();
+        });
+        if !is_flag_type(ftype) {
+            // It's a type that handles its own length requirements. (h256, Custom, ...)
+            lines.push(quote! {
+                (#name, buf) = #ident_type::from_compact(buf, buf.len());
+            })
+        } else if *is_compact {
+            lines.push(quote! {
+                (#name, buf) = #ident_type::from_compact(buf, flags.#len() as usize);
+            });
+        } else {
+            todo!()
+        }
+    }
+}
+
+/// Generates `from_compact` code for a struct field.
+pub(crate) fn handle_struct_field_to(
+    is_compact: &bool,
+    ftype: &str,
+    lines: &mut Vec<TokenStream2>,
+    name: Ident,
+    len: Ident,
+    set_len_method: Ident,
+) {
+    // H256 with #[maybe_zero] attribute for example
+    if *is_compact && !is_flag_type(ftype) {
+        let itype = format_ident!("{ftype}");
+        let set_bool_method = format_ident!("set_{name}");
+        lines.push(quote! {
+            if self.#name != #itype::zero() {
+                flags.#set_bool_method(true);
+                self.#name.to_compact(&mut buffer);
+            };
+        });
+    } else {
+        lines.push(quote! {
+            let #len = self.#name.to_compact(&mut buffer);
+        });
+    }
+    if is_flag_type(ftype) {
+        lines.push(quote! {
+            flags.#set_len_method(#len as u8);
+        })
+    }
+}

--- a/crates/codecs/derive/src/compact/structs.rs
+++ b/crates/codecs/derive/src/compact/structs.rs
@@ -1,72 +1,114 @@
 use super::*;
 
-/// Generates `from_compact` code for a struct field.
-pub(crate) fn handle_struct_field_from(
-    name: &str,
-    known_types: [&str; 5],
-    field_num: usize,
-    fields: &Vec<FieldTypes>,
-    ftype: &str,
-    lines: &mut Vec<TokenStream2>,
-    is_compact: &bool,
-) {
-    let (name, _, len) = get_field_idents(name);
-    assert!(
-        known_types.contains(&ftype) || is_flag_type(ftype) || field_num == fields.len() - 1,
-        "{ftype} field should be placed as the last one since it's not known. "
-    );
-    if ftype == "bytes::Bytes" {
-        lines.push(quote! {
-            let mut #name = bytes::Bytes::new();
-            (#name, buf) = bytes::Bytes::from_compact(buf, buf.len() as usize);
-        })
-    } else {
-        let ident_type = format_ident!("{ftype}");
-        lines.push(quote! {
-            let mut #name = #ident_type::default();
-        });
-        if !is_flag_type(ftype) {
-            // It's a type that handles its own length requirements. (h256, Custom, ...)
-            lines.push(quote! {
-                (#name, buf) = #ident_type::from_compact(buf, buf.len());
-            })
-        } else if *is_compact {
-            lines.push(quote! {
-                (#name, buf) = #ident_type::from_compact(buf, flags.#len() as usize);
-            });
-        } else {
-            todo!()
-        }
-    }
+#[derive(Debug)]
+pub struct StructHandler<'a> {
+    fields_iterator: std::iter::Peekable<std::slice::Iter<'a, FieldTypes>>,
+    lines: Vec<TokenStream2>,
 }
 
-/// Generates `from_compact` code for a struct field.
-pub(crate) fn handle_struct_field_to(
-    is_compact: &bool,
-    ftype: &str,
-    lines: &mut Vec<TokenStream2>,
-    name: Ident,
-    len: Ident,
-    set_len_method: Ident,
-) {
-    // H256 with #[maybe_zero] attribute for example
-    if *is_compact && !is_flag_type(ftype) {
-        let itype = format_ident!("{ftype}");
-        let set_bool_method = format_ident!("set_{name}");
-        lines.push(quote! {
-            if self.#name != #itype::zero() {
-                flags.#set_bool_method(true);
-                self.#name.to_compact(&mut buffer);
-            };
-        });
-    } else {
-        lines.push(quote! {
-            let #len = self.#name.to_compact(&mut buffer);
-        });
+impl<'a> StructHandler<'a> {
+    pub fn new(fields: &'a FieldList) -> Self {
+        StructHandler { lines: vec![], fields_iterator: fields.iter().peekable() }
     }
-    if is_flag_type(ftype) {
-        lines.push(quote! {
-            flags.#set_len_method(#len as u8);
-        })
+
+    pub fn next_field(&mut self) -> Option<&'a FieldTypes> {
+        self.fields_iterator.next()
+    }
+
+    pub fn generate_to(mut self) -> Vec<TokenStream2> {
+        while let Some(field) = self.next_field() {
+            match field {
+                //  The following method will advance the
+                // `fields_iterator` by itself and stop right before the next variant.
+                FieldTypes::EnumVariant(_) => unreachable!(),
+                FieldTypes::EnumUnnamedField(_) => unreachable!(),
+                FieldTypes::StructField(field_descriptor) => self.to(field_descriptor),
+            }
+        }
+        self.lines
+    }
+
+    pub fn generate_from(mut self, known_types: &[&str]) -> Vec<TokenStream2> {
+        while let Some(field) = self.next_field() {
+            match field {
+                //  The following method will advance the
+                // `fields_iterator` by itself and stop right before the next variant.
+                FieldTypes::EnumVariant(_) => unreachable!(),
+                FieldTypes::EnumUnnamedField(_) => unreachable!(),
+                FieldTypes::StructField(field_descriptor) => {
+                    self.from(field_descriptor, known_types)
+                }
+            }
+        }
+        self.lines
+    }
+
+    /// Generates `to_compact` code for a struct field.
+    fn to(&mut self, field_descriptor: &StructFieldDescriptor) {
+        let (name, ftype, is_compact) = field_descriptor;
+
+        let name = format_ident!("{name}");
+        let set_len_method = format_ident!("set_{name}_len");
+        let len = format_ident!("{name}_len");
+
+        // H256 with #[maybe_zero] attribute for example
+        if *is_compact && !is_flag_type(ftype) {
+            let itype = format_ident!("{ftype}");
+            let set_bool_method = format_ident!("set_{name}");
+            self.lines.push(quote! {
+                if self.#name != #itype::zero() {
+                    flags.#set_bool_method(true);
+                    self.#name.to_compact(&mut buffer);
+                };
+            });
+        } else {
+            self.lines.push(quote! {
+                let #len = self.#name.to_compact(&mut buffer);
+            });
+        }
+        if is_flag_type(ftype) {
+            self.lines.push(quote! {
+                flags.#set_len_method(#len as u8);
+            })
+        }
+    }
+
+    /// Generates `from_compact` code for a struct field.
+    fn from(&mut self, field_descriptor: &StructFieldDescriptor, known_types: &[&str]) {
+        let (name, ftype, is_compact) = field_descriptor;
+
+        let name = format_ident!("{name}");
+        let len = format_ident!("{name}_len");
+
+        assert!(
+            known_types.contains(&ftype.as_str()) ||
+                is_flag_type(ftype) ||
+                self.fields_iterator.peek().is_none(),
+            "{ftype} field should be placed as the last one since it's not known. "
+        );
+
+        if ftype == "bytes::Bytes" {
+            self.lines.push(quote! {
+                let mut #name = bytes::Bytes::new();
+                (#name, buf) = bytes::Bytes::from_compact(buf, buf.len() as usize);
+            })
+        } else {
+            let ident_type = format_ident!("{ftype}");
+            self.lines.push(quote! {
+                let mut #name = #ident_type::default();
+            });
+            if !is_flag_type(ftype) {
+                // It's a type that handles its own length requirements. (h256, Custom, ...)
+                self.lines.push(quote! {
+                    (#name, buf) = #ident_type::from_compact(buf, buf.len());
+                })
+            } else if *is_compact {
+                self.lines.push(quote! {
+                    (#name, buf) = #ident_type::from_compact(buf, flags.#len() as usize);
+                });
+            } else {
+                todo!()
+            }
+        }
     }
 }

--- a/crates/codecs/src/lib.rs
+++ b/crates/codecs/src/lib.rs
@@ -387,4 +387,39 @@ mod tests {
             (TestStruct::default(), vec![].as_slice())
         );
     }
+
+    #[use_compact]
+    #[derive(Debug, PartialEq, Clone, Default)]
+    pub enum TestEnum {
+        #[default]
+        Var0,
+        Var1(TestStruct),
+        Var2(u64),
+    }
+
+    #[cfg(test)]
+    #[allow(dead_code)]
+    #[test_fuzz::test_fuzz]
+    fn compact_test_enum_all_variants(var0: TestEnum, var1: TestEnum, var2: TestEnum) {
+        let mut buf = vec![];
+        var0.clone().to_compact(&mut buf);
+        assert_eq!(TestEnum::from_compact(&buf, buf.len()).0, var0);
+
+        let mut buf = vec![];
+        var1.clone().to_compact(&mut buf);
+        assert_eq!(TestEnum::from_compact(&buf, buf.len()).0, var1);
+
+        let mut buf = vec![];
+        var2.clone().to_compact(&mut buf);
+        assert_eq!(TestEnum::from_compact(&buf, buf.len()).0, var2);
+    }
+
+    #[test]
+    fn compact_test_enum() {
+        let var0 = TestEnum::Var0;
+        let var1 = TestEnum::Var1(TestStruct::default());
+        let var2 = TestEnum::Var2(1u64);
+
+        compact_test_enum_all_variants(var0, var1, var2);
+    }
 }

--- a/crates/codecs/src/lib.rs
+++ b/crates/codecs/src/lib.rs
@@ -1,5 +1,6 @@
 use bytes::{Buf, Bytes};
 pub use codecs_derive::*;
+use ethers_core::types::{Bloom, H160, H256, U256};
 
 /// Trait that implements the `Compact` codec.
 ///
@@ -20,6 +21,8 @@ pub trait Compact {
     /// advanced (eg.`.advance(len)`).
     ///
     /// `len` can either be the `buf` remaining length, or the length of the compacted type.
+    ///
+    /// It will panic, if `len` is smaller than `buf.len()`.
     fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8])
     where
         Self: Sized;
@@ -44,8 +47,6 @@ impl Compact for u64 {
         (0, buf)
     }
 }
-
-use ethers_core::types::{Bloom, H160, H256, U256};
 
 impl<T> Compact for Vec<T>
 where

--- a/crates/primitives/src/transaction/tx_type.rs
+++ b/crates/primitives/src/transaction/tx_type.rs
@@ -22,9 +22,9 @@ impl Compact for TxType {
         }
     }
 
-    fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
+    fn from_compact(buf: &[u8], identifier: usize) -> (Self, &[u8]) {
         (
-            match len {
+            match identifier {
                 0 => TxType::Legacy,
                 1 => TxType::EIP2930,
                 _ => TxType::EIP1559,


### PR DESCRIPTION
Adds `Compact` derive for enums with one caveat:
* Enum can only be of an `Unit` variant or with a single unnamed field (which has to implement `Compact`)

Otherwise, complexity would increase too much, and I think that's a fair trade-off. 
```
Enum::Var({ field1, field2} )
```
vs
```
struct Fields { field1, field2}  ; 
Enum::Var(Fields )
```

Is there a performance hit? I'm assuming the rust optimizer will take care of it.

Still want to add:
- test for enum code gen (similar to the struct one)
- some remaining docs

---

It also went through a refactor and makes things more readable than on the original PR which hasn't been merged. 

That's why I'm setting the original derive branch as the merge target. It can help @mattsse with reviewing  it (or others).