### PR TITLE
chore(txpool): clarify ready terminology

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -59,7 +59,7 @@
 //!
 //! The `TransactionPool` trait exposes all externally used functionality of the pool, such as
 //! inserting, querying specific transactions by hash or retrieving the best transactions.
-//! Additionally, it allows to register event listeners for new ready transactions or state changes.
+//! In addition, it enables the registration of event listeners that are notified of state changes.
 //! Events are communicated via channels.
 //!
 //! ### Architecture
@@ -217,7 +217,7 @@ where
     fn best_transactions(
         &self,
     ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<Self::Transaction>>>> {
-        Box::new(self.pool.ready_transactions())
+        Box::new(self.pool.best_transactions())
     }
 
     fn remove_invalid(

--- a/crates/transaction-pool/src/pool/events.rs
+++ b/crates/transaction-pool/src/pool/events.rs
@@ -4,8 +4,6 @@ use serde::{Deserialize, Serialize};
 /// Various events that describe status changes of a transaction.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum TransactionEvent {
-    /// Transaction has been added to the ready queue.
-    Ready,
     /// Transaction has been added to the pending pool.
     Pending,
     /// Transaction has been added to the queued pool.

--- a/crates/transaction-pool/src/pool/listener.rs
+++ b/crates/transaction-pool/src/pool/listener.rs
@@ -32,9 +32,9 @@ impl PoolEventListener {
         }
     }
 
-    /// Notify listeners about a transaction that was added to the ready queue.
-    pub(crate) fn ready(&mut self, tx: &TxHash, replaced: Option<&TxHash>) {
-        self.notify_with(tx, |notifier| notifier.ready());
+    /// Notify listeners about a transaction that was added to the pending queue.
+    pub(crate) fn pending(&mut self, tx: &TxHash, replaced: Option<&TxHash>) {
+        self.notify_with(tx, |notifier| notifier.pending());
 
         if let Some(replaced) = replaced {
             // notify listeners that this transaction was replaced
@@ -77,8 +77,8 @@ impl PoolEventNotifier {
         self.senders.is_empty() || self.is_done
     }
 
-    /// Transaction became ready.
-    fn ready(&mut self) {
+    /// Transaction was moved to the pending queue.
+    fn pending(&mut self) {
         self.notify(TransactionEvent::Pending)
     }
 

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -188,7 +188,10 @@ impl<T: TransactionOrdering> TxPool<T> {
     ///
     /// The `Pending` pool contains all transactions that have no nonce gaps, and can be afforded by
     /// the sender. It only contains transactions that are ready to be included in the pending
-    /// block.
+    /// block. In the pending pool are all transactions that could be listed currently, but not
+    /// necessarily independently. However, this pool never contains transactions with nonce gaps. A
+    /// transaction is considered `ready` when it has the lowest nonce of all transactions from the
+    /// same sender. Which is equals to the chain nonce of the sender in the pending pool.
     ///
     /// The `BaseFee` pool contains transaction that currently can't satisfy the dynamic fee
     /// requirement. With EIP-1559, transactions can become executable or not without any changes to


### PR DESCRIPTION
Closes #62 

Clarify and cleanup `ready`,`pending` terminology.