### PR TITLE
feat: add tracing crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3460,6 +3460,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-tracing"
+version = "0.1.0"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "reth-transaction-pool"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,10 @@ members = [
     "crates/net/bodies-downloaders",
     "crates/primitives",
     "crates/stages",
+    "crates/tracing",
     "crates/transaction-pool",
     "crates/db",
     "crates/libmdbx-rs",
-    "crates/libmdbx-rs/mdbx-sys"
+    "crates/libmdbx-rs/mdbx-sys",
 ]
 default-members = ["bin/reth"]

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "reth-tracing"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/foundry-rs/reth"
+readme = "README.md"
+description = "tracing helpers"
+
+[dependencies]
+tracing = { version = "0.1", default-features = false }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -1,0 +1,22 @@
+#![warn(missing_docs, unreachable_pub)]
+#![deny(unused_must_use, rust_2018_idioms)]
+#![doc(test(
+    no_crate_inject,
+    attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
+))]
+
+//! reth-tracing
+
+// re-export tracing crates.
+pub use tracing;
+pub use tracing_subscriber;
+
+/// Initialises a tracing subscriber via `RUST_LOG` environment variable filter.
+///
+/// Note: This ignores any error and should be used for testing.
+pub fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_writer(std::io::stderr)
+        .try_init();
+}


### PR DESCRIPTION
Closes #235

Adds `reth-tracing` crate that at this point only provides a way to initialize a tracing subscriber via `RUST_LOG`.

This should make it easier tot debug tests by installing a tracing subscriber in one step.