### PR TITLE
feat(net): reputation system and peer reporting

### DIFF
--- a/crates/interfaces/src/p2p/error.rs
+++ b/crates/interfaces/src/p2p/error.rs
@@ -17,6 +17,8 @@ pub enum RequestError {
     UnsupportedCapability,
     #[error("Request timed out while awaiting response.")]
     Timeout,
+    #[error("Received bad response.")]
+    BadResponse,
 }
 
 impl<T> From<mpsc::error::SendError<T>> for RequestError {

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -1,4 +1,9 @@
-use crate::{config::NetworkMode, manager::NetworkEvent, message::PeerRequest, peers::PeersHandle};
+use crate::{
+    config::NetworkMode,
+    manager::NetworkEvent,
+    message::PeerRequest,
+    peers::{PeersHandle, ReputationChangeKind},
+};
 use parking_lot::Mutex;
 use reth_eth_wire::{NewBlock, NewPooledTransactionHashes, Transactions};
 use reth_primitives::{PeerId, H256};
@@ -88,7 +93,12 @@ impl NetworkHandle {
     /// Sends a message to the [`NetworkManager`] to disconnect an existing connection to the given
     /// peer.
     pub fn disconnect_peer(&self, peer: PeerId) {
-        let _ = self.inner.to_manager_tx.send(NetworkHandleMessage::DisconnectPeer(peer));
+        self.send_message(NetworkHandleMessage::DisconnectPeer(peer))
+    }
+
+    /// Send a reputation change for the given peer.
+    pub fn reputation_change(&self, peer_id: PeerId, kind: ReputationChangeKind) {
+        self.send_message(NetworkHandleMessage::ReputationChange(peer_id, kind));
     }
 
     /// Sends a [`PeerRequest`] to the given peer's session.
@@ -134,4 +144,6 @@ pub(crate) enum NetworkHandleMessage {
         /// The request to send to the peer's sessions.
         request: PeerRequest,
     },
+    /// Apply a reputation change to the given peer.
+    ReputationChange(PeerId, ReputationChangeKind),
 }

--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -105,7 +105,7 @@ impl PeersManager {
     pub(crate) fn apply_reputation_change(&mut self, peer_id: &PeerId, rep: ReputationChangeKind) {
         let reputation_change = self.reputation_weights.change(rep);
         let should_disconnect = if let Some(mut peer) = self.peers.get_mut(peer_id) {
-            peer.reputation -= reputation_change.as_i32();
+            peer.reputation = peer.reputation.saturating_sub(reputation_change.as_i32());
             let should_disconnect = peer.state.is_connected() && peer.is_banned();
 
             if should_disconnect {
@@ -138,7 +138,7 @@ impl PeersManager {
         if let Some(mut peer) = self.peers.get_mut(peer_id) {
             self.connection_info.decr_state(peer.state);
             peer.state = PeerConnectionState::Idle;
-            peer.reputation -= reputation_change.as_i32();
+            peer.reputation = peer.reputation.saturating_sub(reputation_change.as_i32());
         }
     }
 

--- a/crates/net/network/src/peers/mod.rs
+++ b/crates/net/network/src/peers/mod.rs
@@ -1,0 +1,8 @@
+//! Peer related implementations
+
+mod manager;
+mod reputation;
+
+pub(crate) use manager::{PeerAction, PeersManager};
+pub use manager::{PeersConfig, PeersHandle};
+pub(crate) use reputation::ReputationChange;

--- a/crates/net/network/src/peers/mod.rs
+++ b/crates/net/network/src/peers/mod.rs
@@ -6,3 +6,4 @@ mod reputation;
 pub(crate) use manager::{PeerAction, PeersManager};
 pub use manager::{PeersConfig, PeersHandle};
 pub(crate) use reputation::ReputationChange;
+pub use reputation::{ReputationChangeKind, ReputationChangeWeights};

--- a/crates/net/network/src/peers/reputation.rs
+++ b/crates/net/network/src/peers/reputation.rs
@@ -1,0 +1,40 @@
+//! Peer reputation management
+
+/// The type that tracks the reputation score.
+type Reputation = i32;
+
+/// The reputation value below which new connection from/to peers are rejected.
+pub const BANNED_REPUTATION: i32 = 0;
+
+/// The reputation change to apply to a node that dropped the connection.
+const REMOTE_DISCONNECT_REPUTATION_CHANGE: i32 = -100;
+
+/// Represents a change in a peer's reputation.
+#[derive(Debug, Copy, Clone, Default)]
+pub(crate) struct ReputationChange(Reputation);
+
+// === impl ReputationChange ===
+
+impl ReputationChange {
+    /// Apply no reputation change.
+    pub(crate) const fn none() -> Self {
+        Self(0)
+    }
+
+    /// Reputation change for a peer that dropped the connection.
+    pub(crate) const fn dropped() -> Self {
+        Self(REMOTE_DISCONNECT_REPUTATION_CHANGE)
+    }
+
+    /// Helper type for easier conversion
+    #[inline]
+    pub(crate) fn as_i32(self) -> Reputation {
+        self.0
+    }
+}
+
+impl From<ReputationChange> for Reputation {
+    fn from(value: ReputationChange) -> Self {
+        value.0
+    }
+}

--- a/crates/net/network/src/peers/reputation.rs
+++ b/crates/net/network/src/peers/reputation.rs
@@ -1,13 +1,103 @@
 //! Peer reputation management
 
 /// The type that tracks the reputation score.
-type Reputation = i32;
+pub(crate) type Reputation = i32;
+
+/// The minimal unit we're measuring reputation
+const REPUTATION_UNIT: i32 = -1024;
 
 /// The reputation value below which new connection from/to peers are rejected.
-pub const BANNED_REPUTATION: i32 = 0;
+pub(crate) const BANNED_REPUTATION: i32 = 100 * REPUTATION_UNIT;
 
-/// The reputation change to apply to a node that dropped the connection.
-const REMOTE_DISCONNECT_REPUTATION_CHANGE: i32 = -100;
+/// The reputation change to apply to a peer that dropped the connection.
+const REMOTE_DISCONNECT_REPUTATION_CHANGE: i32 = 4 * REPUTATION_UNIT;
+
+/// The reputation change to apply to a peer that we failed to connect to.
+const FAILED_TO_CONNECT_REPUTATION_CHANGE: i32 = 24 * REPUTATION_UNIT;
+
+/// The reputation change to apply to a peer that failed to respond in time.
+const TIMEOUT_REPUTATION_CHANGE: i32 = REPUTATION_UNIT;
+
+/// The reputation change to apply to a peer that sent a bad message.
+const BAD_MESSAGE_REPUTATION_CHANGE: i32 = 8 * REPUTATION_UNIT;
+
+/// The reputation change to apply to a peer which violates protocol rules: minimal reputation
+const BAD_PROTOCOL_REPUTATION_CHANGE: i32 = i32::MIN;
+
+/// Various kinds of reputation changes.
+#[derive(Debug, Copy, Clone)]
+pub enum ReputationChangeKind {
+    /// Received an unspecific bad message from the peer
+    BadMessage,
+    /// Peer sent a bad block.
+    ///
+    /// Note: this will we only used in pre-merge, pow consensus, since after no more block announcements are sent via devp2p: [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#devp2p)
+    BadBlock,
+    /// Peer sent a bad transaction messages. E.g. Transactions which weren't recoverable.
+    BadTransactions,
+    /// Peer failed to respond in time.
+    Timeout,
+    /// Peer does not adhere to network protocol rules.
+    BadProtocol,
+    /// Failed to establish a connection to the peer.
+    FailedToConnect,
+    /// Connection dropped by peer.
+    Dropped,
+    /// Apply a reputation change by value
+    Other(Reputation),
+}
+
+/// How the [`ReputationChangeKind`] are weighted.
+#[derive(Debug, Clone)]
+pub struct ReputationChangeWeights {
+    /// Weight for [`ReputationChangeKind::BadMessage`]
+    pub bad_message: Reputation,
+    /// Weight for [`ReputationChangeKind::BadBlock`]
+    pub bad_block: Reputation,
+    /// Weight for [`ReputationChangeKind::BadTransactions`]
+    pub bad_transactions: Reputation,
+    /// Weight for [`ReputationChangeKind::Timeout`]
+    pub timeout: Reputation,
+    /// Weight for [`ReputationChangeKind::BadProtocol`]
+    pub bad_protocol: Reputation,
+    /// Weight for [`ReputationChangeKind::FailedToConnect`]
+    pub failed_to_connect: Reputation,
+    /// Weight for [`ReputationChangeKind::Dropped`]
+    pub dropped: Reputation,
+}
+
+// === impl ReputationChangeWeights ===
+
+impl ReputationChangeWeights {
+    /// Returns the quantifiable [`ReputationChange`] for the given [`ReputationChangeKind`] using
+    /// the configured weights
+    pub(crate) fn change(&self, kind: ReputationChangeKind) -> ReputationChange {
+        match kind {
+            ReputationChangeKind::BadMessage => self.bad_message.into(),
+            ReputationChangeKind::BadBlock => self.bad_block.into(),
+            ReputationChangeKind::BadTransactions => self.bad_transactions.into(),
+            ReputationChangeKind::Timeout => self.timeout.into(),
+            ReputationChangeKind::BadProtocol => self.bad_protocol.into(),
+            ReputationChangeKind::FailedToConnect => self.failed_to_connect.into(),
+            ReputationChangeKind::Dropped => self.dropped.into(),
+            ReputationChangeKind::Other(val) => val.into(),
+        }
+    }
+}
+
+impl Default for ReputationChangeWeights {
+    fn default() -> Self {
+        Self {
+            bad_block: BAD_MESSAGE_REPUTATION_CHANGE,
+            bad_transactions: BAD_MESSAGE_REPUTATION_CHANGE,
+            bad_message: BAD_MESSAGE_REPUTATION_CHANGE,
+            timeout: TIMEOUT_REPUTATION_CHANGE,
+            bad_protocol: BAD_PROTOCOL_REPUTATION_CHANGE,
+            failed_to_connect: FAILED_TO_CONNECT_REPUTATION_CHANGE,
+            dropped: REMOTE_DISCONNECT_REPUTATION_CHANGE,
+        }
+    }
+}
 
 /// Represents a change in a peer's reputation.
 #[derive(Debug, Copy, Clone, Default)]
@@ -36,5 +126,11 @@ impl ReputationChange {
 impl From<ReputationChange> for Reputation {
     fn from(value: ReputationChange) -> Self {
         value.0
+    }
+}
+
+impl From<Reputation> for ReputationChange {
+    fn from(value: Reputation) -> Self {
+        ReputationChange(value)
     }
 }

--- a/crates/net/network/src/session/handle.rs
+++ b/crates/net/network/src/session/handle.rs
@@ -72,6 +72,7 @@ pub(crate) enum PendingSessionEvent {
         capabilities: Arc<Capabilities>,
         status: Status,
         conn: EthStream<P2PStream<ECIESStream<TcpStream>>>,
+        direction: Direction,
     },
     /// Handshake unsuccessful, session was disconnected.
     Disconnected {
@@ -88,7 +89,12 @@ pub(crate) enum PendingSessionEvent {
         error: io::Error,
     },
     /// Thrown when authentication via Ecies failed.
-    EciesAuthError { remote_addr: SocketAddr, session_id: SessionId, error: ECIESError },
+    EciesAuthError {
+        remote_addr: SocketAddr,
+        session_id: SessionId,
+        error: ECIESError,
+        direction: Direction,
+    },
 }
 
 /// Commands that can be sent to the spawned session.
@@ -131,5 +137,10 @@ pub(crate) enum ActiveSessionMessage {
         capabilities: Arc<Capabilities>,
         /// Message received from the peer.
         message: CapabilityMessage,
+    },
+    /// Received a bad message from the peer.
+    BadMessage {
+        /// Identifier of the remote peer.
+        peer_id: PeerId,
     },
 }

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -80,6 +80,11 @@ where
         }
     }
 
+    /// Returns mutable access to the [`PeersManager`]
+    pub(crate) fn peers_mut(&mut self) -> &mut PeersManager {
+        &mut self.peers_manager
+    }
+
     /// How many peers we're currently connected to.
     pub fn num_connected_peers(&self) -> usize {
         self.connected_peers.len()

--- a/crates/net/network/src/swarm.rs
+++ b/crates/net/network/src/swarm.rs
@@ -1,7 +1,7 @@
 use crate::{
     listener::{ConnectionListener, ListenerEvent},
     message::{PeerMessage, PeerRequestSender},
-    session::{SessionEvent, SessionId, SessionManager},
+    session::{Direction, SessionEvent, SessionId, SessionManager},
     state::{AddSessionError, NetworkState, StateAction},
 };
 use futures::Stream;
@@ -29,7 +29,7 @@ use tracing::warn;
 /// [`SessionsManager`]. Outgoing connections are either initiated on demand or triggered by the
 /// [`NetworkState`] and also delegated to the [`NetworkState`].
 #[must_use = "Swarm does nothing unless polled"]
-pub struct Swarm<C> {
+pub(crate) struct Swarm<C> {
     /// Listens for new incoming connections.
     incoming: ConnectionListener,
     /// All sessions.
@@ -86,6 +86,7 @@ where
                 capabilities,
                 status,
                 messages,
+                direction,
             } => match self.state.on_session_activated(
                 peer_id,
                 capabilities.clone(),
@@ -97,13 +98,15 @@ where
                     remote_addr,
                     capabilities,
                     messages,
+                    direction,
                 }),
                 Err(err) => {
                     match err {
                         AddSessionError::AtCapacity { peer } => {
-                            self.sessions.disconnect(peer, Some(DisconnectReason::TooManyPeers))
+                            self.sessions.disconnect(peer, Some(DisconnectReason::TooManyPeers));
                         }
                     };
+                    self.state.peers_mut().on_disconnected(&peer_id);
                     None
                 }
             },
@@ -125,14 +128,12 @@ where
             }
             SessionEvent::SessionClosedOnConnectionError { peer_id, remote_addr, error } => {
                 self.state.on_session_closed(peer_id);
-
-                // TODO(mattsse): reputation change on error
-
                 Some(SwarmEvent::SessionClosed { peer_id, remote_addr, error: Some(error) })
             }
             SessionEvent::OutgoingConnectionError { remote_addr, peer_id, error } => {
                 Some(SwarmEvent::OutgoingConnectionError { peer_id, remote_addr, error })
             }
+            SessionEvent::BadMessage { peer_id } => Some(SwarmEvent::BadMessage { peer_id }),
         }
     }
 
@@ -232,7 +233,7 @@ where
 
 /// All events created or delegated by the [`Swarm`] that represents changes to the state of the
 /// network.
-pub enum SwarmEvent {
+pub(crate) enum SwarmEvent {
     /// Events related to the actual network protocol.
     ValidMessage {
         /// The peer that sent the message
@@ -247,6 +248,11 @@ pub enum SwarmEvent {
         capabilities: Arc<Capabilities>,
         /// Message received from the peer.
         message: CapabilityMessage,
+    },
+    /// Received a bad message from the peer.
+    BadMessage {
+        /// Identifier of the remote peer.
+        peer_id: PeerId,
     },
     /// The underlying tcp listener closed.
     TcpListenerClosed {
@@ -275,6 +281,7 @@ pub enum SwarmEvent {
         remote_addr: SocketAddr,
         capabilities: Arc<Capabilities>,
         messages: PeerRequestSender,
+        direction: Direction,
     },
     SessionClosed {
         peer_id: PeerId,

--- a/crates/net/network/tests/it/connect.rs
+++ b/crates/net/network/tests/it/connect.rs
@@ -42,7 +42,7 @@ async fn test_establish_connections() {
 
     let net = handle.terminate().await;
 
-    net.for_each(|peer| {
-        assert!(peer.num_peers() >= 1);
-    });
+    assert_eq!(net.peers()[0].num_peers(), 2);
+    assert_eq!(net.peers()[1].num_peers(), 1);
+    assert_eq!(net.peers()[2].num_peers(), 1);
 }


### PR DESCRIPTION
Closes #196 

Adds reputation variants that result in a peer's reputation change.

Weights for the variants are configurable.

If a connected peer drops below the banned threshold, a disconnect is triggered.