### PR TITLE
ci: fix fuzz tests

### DIFF
--- a/.github/scripts/fuzz.sh
+++ b/.github/scripts/fuzz.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 
-# Runs fuzz tests using `cargo test-fuzz`. These should only be run after a `cargo test` has been executed once: https://github.com/trailofbits/test-fuzz#usage
+# Runs fuzz tests using `cargo test-fuzz`.
+# These should only be run after a `cargo test` has been executed once: https://github.com/trailofbits/test-fuzz#usage
 
 PACKAGE=$1
 TEST_TIME=${2:-5}
+
+echo "::group::$PACKAGE"
 
 # Gets the list of tests present in the package.
 TESTS=$(cargo test-fuzz --list -p $PACKAGE | head -n -3 | tail -n+9 | cat - <(echo \"--list\"]) | cat - | jq -r ".[]")
@@ -14,3 +17,5 @@ do
     cargo test-fuzz --no-ui  -p "$PACKAGE" $test  -- -V $TEST_TIME
     set +x
 done;
+
+echo "::endgroup::"

--- a/.github/scripts/fuzz.sh
+++ b/.github/scripts/fuzz.sh
@@ -1,18 +1,20 @@
 #!/bin/bash
-
 # Runs fuzz tests using `cargo test-fuzz`.
-# These should only be run after a `cargo test` has been executed once: https://github.com/trailofbits/test-fuzz#usage
 
 PACKAGE=$1
 TEST_TIME=${2:-5}
 
 echo "::group::$PACKAGE"
 
+echo Building corpus.
+cargo test -p $PACKAGE --no-run --all-features
+
 # Gets the list of tests present in the package.
 TESTS=$(cargo test-fuzz --list -p $PACKAGE | head -n -3 | tail -n+9 | cat - <(echo \"--list\"]) | cat - | jq -r ".[]")
 
 for test in $TESTS
 do
+    echo Running test: $test
     set -x
     cargo test-fuzz --no-ui  -p "$PACKAGE" $test  -- -V $TEST_TIME
     set +x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
           command: nextest
           args: run --locked --workspace --all-features
 
+      - name: Install fuzzer
+        run: cargo install cargo-test-fuzz afl
+
       - name: Run fuzz tests
         run: | 
           ./.github/scripts/fuzz.sh reth-primitives

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,23 @@ jobs:
       - name: Install fuzzer
         run: cargo install cargo-test-fuzz afl
 
+  fuzz:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Install fuzzer
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-test-fuzz afl
+
       - name: Run fuzz tests
         run: | 
           ./.github/scripts/fuzz.sh reth-primitives


### PR DESCRIPTION
Fuzz tests are not currently running:

```
error: no such command: `test-fuzz`

	View all installed commands with `cargo --list`
jq: error (at <stdin>:1): Cannot iterate over string ("--list")
parse error: Unmatched ']' at line 1, column 9
error: no such command: `test-fuzz`

	View all installed commands with `cargo --list`
jq: error (at <stdin>:1): Cannot iterate over string ("--list")
parse error: Unmatched ']' at line 1, column 9
error: no such command: `test-fuzz`

	View all installed commands with `cargo --list`
jq: error (at <stdin>:1): Cannot iterate over string ("--list")
parse error: Unmatched ']' at line 1, column 9
error: no such command: `test-fuzz`

	View all installed commands with `cargo --list`
jq: error (at <stdin>:1): Cannot iterate over string ("--list")
parse error: Unmatched ']' at line 1, column 9
```