### PR TITLE
fix(sync): headers test client & stage tests

### DIFF
--- a/crates/interfaces/src/p2p/headers/error.rs
+++ b/crates/interfaces/src/p2p/headers/error.rs
@@ -15,11 +15,8 @@ pub enum DownloadError {
         error: consensus::Error,
     },
     /// Timed out while waiting for request id response.
-    #[error("Timed out while getting headers for request {request_id}.")]
-    Timeout {
-        /// The request id that timed out
-        request_id: u64,
-    },
+    #[error("Timed out while getting headers for request.")]
+    Timeout,
     /// Error when checking that the current [`Header`] has the parent's hash as the parent_hash
     /// field, and that they have sequential block numbers.
     #[error("Headers did not match, current number: {header_number} / current hash: {header_hash}, parent number: {parent_number} / parent_hash: {parent_hash}")]

--- a/crates/interfaces/src/test_utils/headers.rs
+++ b/crates/interfaces/src/test_utils/headers.rs
@@ -5,9 +5,10 @@ use crate::{
         error::{RequestError, RequestResult},
         headers::{
             client::{HeadersClient, HeadersRequest},
-            downloader::{BatchDownload, HeaderBatchDownload, HeaderDownloader},
+            downloader::{HeaderBatchDownload, HeaderDownloader},
             error::DownloadError,
         },
+        traits::BatchDownload,
     },
 };
 use futures::{Future, FutureExt, Stream};


### PR DESCRIPTION
Fixes tests and test utils for the refactored headers client introduced in #249 