### PR TITLE
feat(net): propagate new transactions

### DIFF
--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -105,6 +105,11 @@ impl NetworkHandle {
     pub fn send_request(&self, peer_id: PeerId, request: PeerRequest) {
         self.send_message(NetworkHandleMessage::EthRequest { peer_id, request })
     }
+
+    /// Send full transactions to the peer
+    pub fn send_transactions(&self, peer_id: PeerId, msg: Arc<Transactions>) {
+        self.send_message(NetworkHandleMessage::SendTransaction { peer_id, msg })
+    }
 }
 
 struct NetworkInner {

--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -16,7 +16,9 @@ use reth_interfaces::p2p::error::RequestResult;
 use reth_primitives::{
     FromRecoveredTransaction, IntoRecoveredTransaction, PeerId, TransactionSigned, TxHash, H256,
 };
-use reth_transaction_pool::{error::PoolResult, TransactionPool};
+use reth_transaction_pool::{
+    error::PoolResult, PropagateKind, PropagatedTransactions, TransactionPool,
+};
 use std::{
     collections::{hash_map::Entry, HashMap},
     future::Future,
@@ -27,6 +29,7 @@ use std::{
 };
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::wrappers::{ReceiverStream, UnboundedReceiverStream};
+use tracing::trace;
 
 /// Cache limit of transactions to keep track of for a single peer.
 const PEER_TRANSACTION_CACHE_LIMIT: usize = 1024 * 10;
@@ -149,6 +152,55 @@ where
             let resp = PooledTransactions(transactions);
             let _ = response.send(Ok(resp));
         }
+    }
+
+    /// Invoked when a new transaction is pending.
+    ///
+    /// When new transactions appear in the pool, we propagate them to the network using the
+    /// `Transactions` and `NewPooledTransactionHashes` messages. The Transactions message relays
+    /// complete transaction objects and is typically sent to a small, random fraction of connected
+    /// peers.
+    ///
+    /// All other peers receive a notification of the transaction hash and can request the
+    /// complete transaction object if it is unknown to them. The dissemination of complete
+    /// transactions to a fraction of peers usually ensures that all nodes receive the transaction
+    /// and won't need to request it.
+    fn on_new_transactions(&mut self, hashes: impl IntoIterator<Item = TxHash>) {
+        trace!(target: "net::tx", "Start propagating transactions");
+
+        let propagated = self.propagate_transactions(
+            self.pool
+                .get_all(hashes)
+                .into_iter()
+                .map(|tx| (*tx.hash(), tx.transaction.to_recovered_transaction().into_signed()))
+                .collect(),
+        );
+
+        // notify pool so events get fired
+        self.pool.on_propagated(propagated);
+    }
+
+    fn propagate_transactions(
+        &mut self,
+        txs: Vec<(TxHash, TransactionSigned)>,
+    ) -> PropagatedTransactions {
+        let mut propagated = PropagatedTransactions::default();
+
+        for (peer_id, peer) in self.peers.iter_mut() {
+            let (hashes, full): (Vec<_>, Vec<_>) =
+                txs.iter().filter(|(hash, _)| peer.transactions.insert(*hash)).cloned().unzip();
+
+            if !full.is_empty() {
+                // TODO select peer for full or hash
+                self.network.send_transactions(*peer_id, Arc::new(Transactions(full)));
+
+                for hash in hashes {
+                    propagated.0.entry(hash).or_default().push(PropagateKind::Full(*peer_id));
+                }
+            }
+        }
+
+        propagated
     }
 
     /// Request handler for an incoming `NewPooledTransactionHashes`
@@ -323,8 +375,12 @@ where
         }
 
         // handle new transactions
-        while let Poll::Ready(Some(_hash)) = this.pending_transactions.poll_next_unpin(cx) {
-            // TODO(mattsse): propagate new transactions
+        let mut new_txs = Vec::new();
+        while let Poll::Ready(Some(hash)) = this.pending_transactions.poll_next_unpin(cx) {
+            new_txs.push(hash);
+        }
+        if !new_txs.is_empty() {
+            this.on_new_transactions(new_txs);
         }
 
         // Advance all requests.

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -78,7 +78,10 @@
 pub use crate::{
     config::PoolConfig,
     ordering::TransactionOrdering,
-    traits::{BestTransactions, OnNewBlockEvent, PoolTransaction, TransactionPool},
+    traits::{
+        BestTransactions, OnNewBlockEvent, PoolTransaction, PropagateKind, PropagatedTransactions,
+        TransactionPool,
+    },
     validate::{TransactionValidationOutcome, TransactionValidator},
 };
 use crate::{
@@ -240,6 +243,10 @@ where
         txs: impl IntoIterator<Item = TxHash>,
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         self.inner().get_all(txs)
+    }
+
+    fn on_propagated(&self, txs: PropagatedTransactions) {
+        self.inner().on_propagated(txs)
     }
 }
 

--- a/crates/transaction-pool/src/pool/events.rs
+++ b/crates/transaction-pool/src/pool/events.rs
@@ -1,3 +1,4 @@
+use crate::traits::PropagateKind;
 use reth_primitives::{TxHash, H256};
 use serde::{Deserialize, Serialize};
 
@@ -18,4 +19,6 @@ pub enum TransactionEvent {
     Discarded,
     /// Transaction became invalid indefinitely.
     Invalid,
+    /// Transaction was propagated to peers.
+    Propagated(Vec<PropagateKind>),
 }

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -69,7 +69,9 @@ use crate::{
     error::{PoolError, PoolResult},
     identifier::{SenderId, SenderIdentifiers, TransactionId},
     pool::{listener::PoolEventListener, state::SubPool, txpool::TxPool},
-    traits::{NewTransactionEvent, PoolStatus, PoolTransaction, TransactionOrigin},
+    traits::{
+        NewTransactionEvent, PoolStatus, PoolTransaction, PropagatedTransactions, TransactionOrigin,
+    },
     validate::{TransactionValidationOutcome, ValidPoolTransaction},
     OnNewBlockEvent, PoolConfig, TransactionOrdering, TransactionValidator, U256,
 };
@@ -355,6 +357,13 @@ where
         txs: impl IntoIterator<Item = TxHash>,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         self.pool.read().get_all(txs).collect()
+    }
+
+    /// Notify about propagated transactions.
+    pub(crate) fn on_propagated(&self, txs: PropagatedTransactions) {
+        let mut listener = self.event_listener.write();
+
+        txs.0.into_iter().for_each(|(hash, peers)| listener.propagated(&hash, peers))
     }
 
     /// Number of transactions in the entire pool


### PR DESCRIPTION
Closes #254


propagate new transactions promoted by the pool to peers who haven't seen it yet.


# TODO
* decide when to send full, when to send pooled transactions