### PR TITLE
fix(net): substract from correct var

### DIFF
--- a/crates/net/network/src/session/config.rs
+++ b/crates/net/network/src/session/config.rs
@@ -112,7 +112,7 @@ impl SessionCounter {
     }
 
     pub(crate) fn inc_pending_outbound(&mut self) {
-        self.pending_inbound += 1;
+        self.pending_outbound += 1;
     }
 
     pub(crate) fn dec_pending(&mut self, direction: &Direction) {


### PR DESCRIPTION
https://github.com/foundry-rs/reth/pull/253 merged w/o checking CI success, and we missed the error