### PR TITLE
chore(eth-wire): remove TODO about capability Ord

### DIFF
--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -418,12 +418,17 @@ pub fn set_capability_offsets(
     // map of capability name to version
     let mut shared_capabilities = HashMap::new();
 
-    // sorted list of capability names
-    // TODO: the Ord implementation for strings says the following:
-    // > Strings are ordered lexicographically by their byte values. This orders Unicode code
-    // points based on their positions in the code charts. This is not necessarily the same as
-    // “alphabetical” order.
-    // We need to implement a case-sensitive alphabetical sort
+    // The `Ord` implementation for capability names should be equivalent to geth (and every other
+    // client), since geth uses golang's default string comparison, which orders strings
+    // lexicographically. https://golang.org/pkg/strings/#Compare
+    //
+    // This is important because the capability name is used to determine the message id offset, so
+    // if the sorting is not identical, offsets for connected peers could be inconsistent.
+    // This would cause the peers to send messages with the wrong message id, which is usually a
+    // protocol violation.
+    //
+    // The `Ord` implementation for `SmolStr` (used here) currently delegates to rust's `Ord`
+    // implementation for `str`, which also orders strings lexicographically.
     let mut shared_capability_names = BTreeSet::new();
 
     // find highest shared version of each shared capability

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -420,7 +420,8 @@ pub fn set_capability_offsets(
 
     // The `Ord` implementation for capability names should be equivalent to geth (and every other
     // client), since geth uses golang's default string comparison, which orders strings
-    // lexicographically. https://golang.org/pkg/strings/#Compare
+    // lexicographically.
+    // https://golang.org/pkg/strings/#Compare
     //
     // This is important because the capability name is used to determine the message id offset, so
     // if the sorting is not identical, offsets for connected peers could be inconsistent.


### PR DESCRIPTION
Relevant context [from #159](https://github.com/foundry-rs/reth/issues/159):
> Ok so the sorting in geth [happens here](https://github.com/ethereum/go-ethereum/blob/08fb1aade6f8053f7b929d154db2a3c824779ac5/p2p/peer.go#L378), and [geth implements ordering based on the default golang `string` comparison](https://github.com/ethereum/go-ethereum/blob/08fb1aade6f8053f7b929d154db2a3c824779ac5/p2p/protocol.go#L84). Go compares strings lexicographically, so we should actually be fine here. Also I guess case-sensitive alphabetical sort can mean lexicographic sort.

See the updated comment for why the TODO is not applicable.

Fixes #159