### PR TITLE
refactor(net): use shared objects on a per peer basis

### DIFF
--- a/crates/net/eth-wire/src/types/broadcast.rs
+++ b/crates/net/eth-wire/src/types/broadcast.rs
@@ -1,6 +1,7 @@
 //! Types for broadcasting new data.
 use reth_primitives::{Header, TransactionSigned, H256, U128};
 use reth_rlp::{RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper};
+use std::sync::Arc;
 
 /// This informs peers of new blocks that have appeared on the network.
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper)]
@@ -85,6 +86,16 @@ impl From<Transactions> for Vec<TransactionSigned> {
         txs.0
     }
 }
+
+/// Same as [`Transactions`] but this is intended as egress message send from local to _many_ peers.
+///
+/// The list of transactions is constructed on per-peers basis, but the underlying transaction
+/// objects are shared.
+#[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper)]
+pub struct SharedTransactions(
+    /// New transactions for the peer to include in its mempool.
+    pub Vec<Arc<TransactionSigned>>,
+);
 
 /// This informs peers of transaction hashes for transactions that have appeared on the network,
 /// but have not been included in a block.

--- a/crates/net/network/src/message.rs
+++ b/crates/net/network/src/message.rs
@@ -8,7 +8,7 @@ use reth_eth_wire::{
     capability::CapabilityMessage, message::RequestPair, BlockBodies, BlockBody, BlockHeaders,
     EthMessage, GetBlockBodies, GetBlockHeaders, GetNodeData, GetPooledTransactions, GetReceipts,
     NewBlock, NewBlockHashes, NewPooledTransactionHashes, NodeData, PooledTransactions, Receipts,
-    Transactions,
+    SharedTransactions, Transactions,
 };
 use reth_interfaces::p2p::error::{RequestError, RequestResult};
 use reth_primitives::{Header, PeerId, Receipt, TransactionSigned, H256};
@@ -36,17 +36,20 @@ impl NewBlockMessage {
     }
 }
 
-/// Represents all messages that can be sent to a peer session
+/// All Bi-directional eth-message variants that can be sent to a session or received from a
+/// session.
 #[derive(Debug)]
 pub enum PeerMessage {
     /// Announce new block hashes
-    NewBlockHashes(Arc<NewBlockHashes>),
+    NewBlockHashes(NewBlockHashes),
     /// Broadcast new block.
     NewBlock(NewBlockMessage),
-    /// Broadcast transactions.
-    Transactions(Arc<Transactions>),
+    /// Received transactions _from_ the peer
+    ReceivedTransaction(Transactions),
+    /// Broadcast transactions _from_ local _to_ a peer.
+    SendTransactions(SharedTransactions),
     /// Send new pooled transactions
-    PooledTransactions(Arc<NewPooledTransactionHashes>),
+    PooledTransactions(NewPooledTransactionHashes),
     /// All `eth` request variants.
     EthRequest(PeerRequest),
     /// Other than eth namespace message

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -173,7 +173,7 @@ where
     /// but sending `NewBlockHash` broadcast to all peers that haven't seen it yet.
     pub(crate) fn announce_new_block_hash(&mut self, msg: NewBlockMessage) {
         let number = msg.block.block.header.number;
-        let hashes = Arc::new(NewBlockHashes(vec![BlockHashNumber { hash: msg.hash, number }]));
+        let hashes = NewBlockHashes(vec![BlockHashNumber { hash: msg.hash, number }]);
         for (peer_id, peer) in self.connected_peers.iter_mut() {
             if peer.blocks.contains(&msg.hash) {
                 // skip peers which already reported the block
@@ -186,7 +186,7 @@ where
 
             self.queued_messages.push_back(StateAction::NewBlockHashes {
                 peer_id: *peer_id,
-                hashes: Arc::clone(&hashes),
+                hashes: hashes.clone(),
             });
         }
     }
@@ -410,7 +410,7 @@ pub(crate) enum StateAction {
         /// Target of the message
         peer_id: PeerId,
         /// `NewBlockHashes` message to send to the peer.
-        hashes: Arc<NewBlockHashes>,
+        hashes: NewBlockHashes,
     },
     /// Create a new connection to the given node.
     Connect { remote_addr: SocketAddr, peer_id: PeerId },


### PR DESCRIPTION
Closes #265

The previous broadcast variants were `Arc<Vec<_>>`, however since the items in the vec depend on the peer (don't send object to a peer it has already seen), it should rather be `Vec<Arc<_>>`, and therefor only really relevant for `Transaction` and `Block`, no need to Arc H256
