### PR TITLE
feat(rpc): add new engine V2 types and routes

### DIFF
--- a/crates/net/rpc-api/src/engine.rs
+++ b/crates/net/rpc-api/src/engine.rs
@@ -9,20 +9,41 @@ use reth_rpc_types::engine::{
 #[cfg_attr(feature = "client", rpc(server, client))]
 pub trait EngineApi {
     /// See also <https://github.com/ethereum/execution-apis/blob/8db51dcd2f4bdfbd9ad6e4a7560aac97010ad063/src/engine/specification.md#engine_newpayloadv1>
+    /// Caution: This should not accept the `withdrawals` field
     #[method(name = "engine_newPayloadV1")]
-    async fn new_payload(&self, payload: ExecutionPayload) -> Result<PayloadStatus>;
+    async fn new_payload_v1(&self, payload: ExecutionPayload) -> Result<PayloadStatus>;
+
+    /// See also <https://github.com/ethereum/execution-apis/blob/8db51dcd2f4bdfbd9ad6e4a7560aac97010ad063/src/engine/specification.md#engine_newpayloadv1>
+    #[method(name = "engine_newPayloadV2")]
+    async fn new_payload_v2(&self, payload: ExecutionPayload) -> Result<PayloadStatus>;
 
     /// See also <https://github.com/ethereum/execution-apis/blob/8db51dcd2f4bdfbd9ad6e4a7560aac97010ad063/src/engine/specification.md#engine_forkchoiceUpdatedV1>
+    ///
+    /// Caution: This should not accept the `withdrawals` field
     #[method(name = "engine_forkchoiceUpdatedV1")]
-    async fn fork_choice_updated(
+    async fn fork_choice_updated_v1(
+        &self,
+        fork_choice_state: ForkchoiceState,
+        payload_attributes: Option<PayloadAttributes>,
+    ) -> Result<ForkchoiceUpdated>;
+
+    /// See also <https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#engine_forkchoiceupdatedv2>
+    #[method(name = "engine_forkchoiceUpdatedV2")]
+    async fn fork_choice_updated_v2(
         &self,
         fork_choice_state: ForkchoiceState,
         payload_attributes: Option<PayloadAttributes>,
     ) -> Result<ForkchoiceUpdated>;
 
     /// See also <https://github.com/ethereum/execution-apis/blob/8db51dcd2f4bdfbd9ad6e4a7560aac97010ad063/src/engine/specification.md#engine_getPayloadV1>
+    ///
+    /// Caution: This should not return the `withdrawals` field
     #[method(name = "engine_getPayloadV1")]
-    async fn get_payload(&self, payload_id: H64) -> Result<ExecutionPayload>;
+    async fn get_payload_v1(&self, payload_id: H64) -> Result<ExecutionPayload>;
+
+    /// See also <https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#engine_getpayloadv2>
+    #[method(name = "engine_getPayloadV2")]
+    async fn get_payload_v2(&self, payload_id: H64) -> Result<ExecutionPayload>;
 
     /// See also <https://github.com/ethereum/execution-apis/blob/8db51dcd2f4bdfbd9ad6e4a7560aac97010ad063/src/engine/specification.md#engine_exchangeTransitionConfigurationV1>
     #[method(name = "engine_exchangeTransitionConfigurationV1")]

--- a/crates/net/rpc-types/src/eth/engine.rs
+++ b/crates/net/rpc-types/src/eth/engine.rs
@@ -1,10 +1,13 @@
+//! Engine API types: <https://github.com/ethereum/execution-apis/blob/main/src/engine/authentication.md> and <https://eips.ethereum.org/EIPS/eip-3675> following the execution spec <https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md>
+
 #![allow(missing_docs)]
-//! Engine API types: <https://github.com/ethereum/execution-apis/blob/main/src/engine/authentication.md>
 
 use reth_primitives::{Address, BlockNumber, Bloom, Bytes, H256, H64, U256, U64};
 use serde::{Deserialize, Serialize};
 
 /// This structure maps on the ExecutionPayload structure of the beacon chain spec.
+///
+/// See also: <https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#executionpayloadv1>
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExecutionPayload {
@@ -22,6 +25,25 @@ pub struct ExecutionPayload {
     pub base_fee_per_gas: U256,
     pub block_hash: H256,
     pub transactions: Vec<Bytes>,
+    /// Array of [`Withdrawal`] enabled with V2
+    /// See <https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#executionpayloadv2>
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub withdrawal: Option<Withdrawal>,
+}
+
+/// This structure maps onto the validator withdrawal object from the beacon chain spec.
+///
+/// See also: <https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#withdrawalv1>
+#[derive(Default, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Withdrawal {
+    pub index: U64,
+    pub validator_index: U64,
+    pub address: Address,
+    /// Note: the amount value is represented on the beacon chain as a little-endian value in units
+    /// of Gwei, whereas the amount in this structure MUST be converted to a big-endian value in
+    /// units of Wei.
+    pub amount: U256,
 }
 
 /// This structure encapsulates the fork choice state
@@ -41,6 +63,10 @@ pub struct PayloadAttributes {
     pub timestamp: U64,
     pub prev_randao: H256,
     pub suggested_fee_recipient: Address,
+    /// Array of [`Withdrawal`] enabled with V2
+    /// See <https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#executionpayloadv2>
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub withdrawal: Option<Withdrawal>,
 }
 
 /// This structure contains the result of processing a payload
@@ -73,11 +99,11 @@ pub enum PayloadStatusEnum {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TransitionConfiguration {
-    /// maps on the TERMINAL_TOTAL_DIFFICULTY parameter of EIP-3675
+    /// Maps on the TERMINAL_TOTAL_DIFFICULTY parameter of EIP-3675
     pub terminal_total_difficulty: U256,
-    /// maps on TERMINAL_BLOCK_HASH parameter of EIP-3675
+    /// Maps on TERMINAL_BLOCK_HASH parameter of EIP-3675
     pub terminal_block_hash: H256,
-    /// maps on TERMINAL_BLOCK_NUMBER parameter of EIP-3675
+    /// Maps on TERMINAL_BLOCK_NUMBER parameter of EIP-3675
     pub terminal_block_number: BlockNumber,
 }
 


### PR DESCRIPTION
Add new engine V2 types and endpoints:

https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md

difference is additional `Withdrawal` type and fields