### PR TITLE
perf(txpool): Arc alloc transaction event

### DIFF
--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -24,7 +24,7 @@ tokio = { version = "1", default-features = false, features = ["sync"] }
 aquamarine = "0.1" # docs
 thiserror = "1.0"
 tracing = "0.1"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
 linked-hash-map = "0.5"
 fnv = "1.0.7"
 bitflags = "1.3"

--- a/crates/transaction-pool/src/pool/events.rs
+++ b/crates/transaction-pool/src/pool/events.rs
@@ -1,6 +1,7 @@
 use crate::traits::PropagateKind;
 use reth_primitives::{TxHash, H256};
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 /// Various events that describe status changes of a transaction.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -20,5 +21,5 @@ pub enum TransactionEvent {
     /// Transaction became invalid indefinitely.
     Invalid,
     /// Transaction was propagated to peers.
-    Propagated(Vec<PropagateKind>),
+    Propagated(Arc<Vec<PropagateKind>>),
 }

--- a/crates/transaction-pool/src/pool/listener.rs
+++ b/crates/transaction-pool/src/pool/listener.rs
@@ -2,7 +2,7 @@
 
 use crate::{pool::events::TransactionEvent, traits::PropagateKind};
 use reth_primitives::{rpc::TxHash, H256};
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 use tokio::sync::mpsc::UnboundedSender;
 
 type EventBroadcast = UnboundedSender<TransactionEvent>;
@@ -111,7 +111,7 @@ impl PoolEventBroadcaster {
 
     /// Transaction was propagated.
     fn propagated(&mut self, peers: Vec<PropagateKind>) {
-        self.broadcast(TransactionEvent::Propagated(peers));
+        self.broadcast(TransactionEvent::Propagated(Arc::new(peers)));
     }
 
     /// Transaction was replaced with the given transaction


### PR DESCRIPTION
tx events are multi consumer, wrapping `Vec<Propagate>` into arc makes it cheaper to send to multiple receivers.