### PR TITLE
feat: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,64 @@
+name: Bug Report
+description: Create a bug report
+labels: ["C-bug", "S-needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! Please provide as much detail as possible.
+        
+        If you believe you have found a vulnerability, please provide details [here](mailto:georgios@paradigm.xyz) instead.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: Describe the bug
+      description: |
+        A clear and concise description of what the bug is.
+        
+        If the bug is in a crate you are using (i.e. you are not running the standard `reth` binary) please mention that as well.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Steps to reproduce
+      description: Please provide any steps you think might be relevant to reproduce the bug.
+      placeholder: |
+        Steps to reproduce:
+        
+        1. Start '...'
+        2. Then '...'
+        3. Check '...'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Node logs
+      description: If applicable, please provide the node logs leading up to the bug.
+      render: text
+    validations:
+      required: false
+  - type: checkboxes
+    id: platform
+    attributes:
+      label: Platform(s)
+      description: What platform(s) did this occur on?
+      options:
+        - Linux (x86)
+        - Linux (ARM)
+        - Mac (Intel)
+        - Mac (Apple Silicon)
+        - Windows (x86)
+        - Windows (ARM)
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/foundry-rs/reth/blob/main/CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow the Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: GitHub Discussions
+    url: https://github.com/foundry-rs/reth/discussions
+    about: Please ask and answer questions here to keep the issue tracker clean.
+  - name: Security
+    url: mailto:georgios@paradigm.xyz
+    about: Please report security vulnerabilities here.

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,19 @@
+name: Documentation
+description: Suggest a change to our documentation
+labels: ["C-docs", "S-needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        If you are unsure if the docs are relevant or needed, please open up a discussion first.
+  - type: textarea
+    attributes:
+      label: Describe the change
+      description: |
+        Please describe the documentation you want to change or add, and if it is for end-users or contributors.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context to the feature (like screenshots, resources)

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,21 @@
+name: Feature request
+description: Suggest a feature
+labels: ["C-enhancement", "S-needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please ensure that the feature has not already been requested in the issue tracker.
+  - type: textarea
+    attributes:
+      label: Describe the feature
+      description: |
+        Please describe the feature and what it is aiming to solve, if relevant.
+        
+        If the feature is for a crate, please include a proposed API surface.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context to the feature (like screenshots, resources)


### PR DESCRIPTION
Adds the following templates:

- Bug report
- Feature request
- Documentation change

Each issue has the https://github.com/foundry-rs/reth/labels/S-needs-triage label so we can easily filter new issues that need labels applied etc.

Circumventing the templates is not allowed (should work for maintainers still) to try and keep the issue tracker tidy.

Discussions are redirected to the Discussions tab of the repository; maintainers will be in charge of creating tracking issues.

If we want other people to create tracking issues, they can be given the triage role on the repository.