### PR TITLE
docs: expand on status labels

### DIFF
--- a/docs/repo/labels.md
+++ b/docs/repo/labels.md
@@ -4,10 +4,40 @@ Each label in the repository has a description attached that describes what the 
 
 There are 7 label categories in the repository:
 
-- **Area labels**: These labels denote the general area of the project an issue or PR affects. These start with `A-`.
-- **Category labels**: These labels denote the type of issue or change being made, for example https://github.com/foundry-rs/reth/labels/C-bug or https://github.com/foundry-rs/reth/labels/C-enhancement. These start with `C-`.
-- **Difficulty labels**: These are reserved for the very easy or very hard issues. Any issue without one of these labels can be considered to be of "average difficulty". They start with `D-`.
-- **Meta labels**: These start with `M-` and convey meaning to the core contributors, usually about the release process.
-- **Platform labels**: These describe the platform an issue is present on. They start with `O-`.
-- **Priority labels**: These are reserved for issues that require more immediate attention (high priority and critical priority) and they start with `P-`.
-- **Status labels**: These labels convey meaning to contributors about an issue or PR's status, e.g. whether they are blocked or need triage. They start with `S-`.
+- **Area labels**: These labels denote the general area of the project an issue or PR affects. These start with [`A-`][area].
+- **Category labels**: These labels denote the type of issue or change being made, for example https://github.com/foundry-rs/reth/labels/C-bug or https://github.com/foundry-rs/reth/labels/C-enhancement. These start with [`C-`][category].
+- **Difficulty labels**: These are reserved for the very easy or very hard issues. Any issue without one of these labels can be considered to be of "average difficulty". They start with [`D-`][difficulty].
+- **Meta labels**: These start with [`M-`][meta] and convey meaning to the core contributors, usually about the release process.
+- **Platform labels**: These describe the platform an issue is present on. They start with [`O-`][platform].
+- **Priority labels**: These are reserved for issues that require more immediate attention (high priority and critical priority) and they start with [`P-`][priority].
+- **Status labels**: These labels convey meaning to contributors about an issue or PR's status, e.g. whether they are blocked or need triage. They start with [`S-`][status].
+
+### Status labels
+
+For easier at-a-glance communication of the status of issues and PRs the following labels are available:
+
+**Needs work**
+
+- https://github.com/foundry-rs/reth/labels/S-blocked
+- https://github.com/foundry-rs/reth/labels/S-needs-benchmark
+- https://github.com/foundry-rs/reth/labels/S-needs-design
+- https://github.com/foundry-rs/reth/labels/S-needs-investigation
+- https://github.com/foundry-rs/reth/labels/S-needs-rebase
+
+**Closure reasons**
+
+- https://github.com/foundry-rs/reth/labels/S-duplicate
+- https://github.com/foundry-rs/reth/labels/S-wontfix
+
+**Misc.**
+
+- https://github.com/foundry-rs/reth/labels/S-needs-triage
+- https://github.com/foundry-rs/reth/labels/S-controversial
+
+[area]: https://github.com/foundry-rs/reth/labels?q=a-
+[category]: https://github.com/foundry-rs/reth/labels?q=c-
+[difficulty]: https://github.com/foundry-rs/reth/labels?q=d-
+[meta]: https://github.com/foundry-rs/reth/labels?q=m-
+[platform]: https://github.com/foundry-rs/reth/labels?q=o-
+[priority]: https://github.com/foundry-rs/reth/labels?q=p-
+[status]: https://github.com/foundry-rs/reth/labels?q=s-


### PR DESCRIPTION
Adds links in the labels doc and expands a bit on the different status labels we have.