### PR TITLE
docs: crude release workflow doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!-- next-header -->
+
+## [Unreleased]
+
+Initial release.
+
+<!-- next-url !-->
+[Unreleased]: https://github.com/foundry-rs/reth/compare/978527367f159ff3d9f90723e73cf2560c8f54b8...HEAD

--- a/docs/repo/README.md
+++ b/docs/repo/README.md
@@ -5,6 +5,7 @@
 Documents on planning and process in the repository: what the labels mean, how issues are triaged, how a new release is cut and so on.
 
 - [Labels](./labels.md): Describes the labels in the repository.
+- [Release workflow](./release.md): Describes the release workflow for maintainers.
 
 ### Structure
 

--- a/docs/repo/release.md
+++ b/docs/repo/release.md
@@ -1,0 +1,14 @@
+## Release Workflow
+
+1. Update the version in `Cargo.toml`
+2. Update the changelog[^1]
+    - Check that all issues marked https://github.com/foundry-rs/reth/labels/M-changelog have been added to the changelog
+    - Move the "Unreleased" section in the changelog under a new header with the new version, and fix up the links in the bottom of the file
+3. Ensure tests and lints pass
+4. Commit the new changelog and version bump
+5. Tag the new version (no `v` prefix)
+6. Push the new commit and tag
+7. (Run release command)[^2]
+
+[^1]: This can be automated somewhat.
+[^2]: TBD.


### PR DESCRIPTION
Adds some basic release workflow instructions and a changelog following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).

I already use this in `ethers-flashbots` and some of the more tedious steps can be somewhat automated (e.g. shuffling items around in the changelog).

Notable PRs etc. should be tagged with `M-changelog` in case we need to write stuff in more detail (blog posts or whatever), makes them easier to refer to. I'm not sure I like an automated changelog for a node like we have for Foundry, but we can discuss