### PR TITLE
chore(net): deny unused and cleanup

### DIFF
--- a/crates/net/network/src/discovery.rs
+++ b/crates/net/network/src/discovery.rs
@@ -24,11 +24,11 @@ pub struct Discovery {
     /// Local ENR of the discovery service.
     local_enr: NodeRecord,
     /// Handler to interact with the Discovery v4 service
-    discv4: Discv4,
+    _discv4: Discv4,
     /// All KAD table updates from the discv4 service.
     discv4_updates: ReceiverStream<TableUpdate>,
     /// The initial config for the discv4 service
-    dsicv4_config: Discv4Config,
+    _dsicv4_config: Discv4Config,
     /// Events buffered until polled.
     queued_events: VecDeque<DiscoveryEvent>,
     /// The handle to the spawned discv4 service
@@ -57,9 +57,9 @@ impl Discovery {
 
         Ok(Self {
             local_enr,
-            discv4,
+            _discv4: discv4,
             discv4_updates,
-            dsicv4_config,
+            _dsicv4_config: dsicv4_config,
             _discv4_service,
             discovered_nodes: Default::default(),
             queued_events: Default::default(),
@@ -69,23 +69,6 @@ impl Discovery {
     /// Returns the id with which the local identifies itself in the network
     pub(crate) fn local_id(&self) -> PeerId {
         self.local_enr.id
-    }
-
-    /// Manually adds an address to the set.
-    ///
-    /// This has the same effect as adding node discovered via network gossip.
-    pub(crate) fn add_node_address(&mut self, peer_id: PeerId, addr: SocketAddr) {
-        self.on_discv4_update(TableUpdate::Added(NodeRecord {
-            address: addr.ip(),
-            tcp_port: addr.port(),
-            udp_port: addr.port(),
-            id: peer_id,
-        }))
-    }
-
-    /// Returns all nodes we know exist in the network.
-    pub fn nodes(&mut self) -> &HashMap<PeerId, SocketAddr> {
-        &self.discovered_nodes
     }
 
     fn on_discv4_update(&mut self, update: TableUpdate) {

--- a/crates/net/network/src/lib.rs
+++ b/crates/net/network/src/lib.rs
@@ -4,8 +4,6 @@
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
 ))]
-// TODO remove later
-#![allow(dead_code, clippy::too_many_arguments)]
 
 //! reth P2P networking.
 //!
@@ -25,11 +23,11 @@ mod listener;
 mod manager;
 mod message;
 mod network;
-mod peers;
+pub mod peers;
 mod session;
 mod state;
 mod swarm;
-mod transactions;
+pub mod transactions;
 
 pub use config::NetworkConfig;
 pub use fetch::FetchClient;

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -23,11 +23,12 @@ use crate::{
     listener::ConnectionListener,
     message::{NewBlockMessage, PeerMessage, PeerRequest, PeerRequestSender},
     network::{NetworkHandle, NetworkHandleMessage},
-    peers::{PeersManager, ReputationChangeKind},
+    peers::{PeersHandle, PeersManager, ReputationChangeKind},
     session::SessionManager,
     state::NetworkState,
     swarm::{Swarm, SwarmEvent},
     transactions::NetworkTransactionEvent,
+    FetchClient,
 };
 use futures::{Future, StreamExt};
 use parking_lot::Mutex;
@@ -36,7 +37,7 @@ use reth_eth_wire::{
     DisconnectReason,
 };
 use reth_interfaces::provider::BlockProvider;
-use reth_primitives::PeerId;
+use reth_primitives::{PeerId, H256};
 use std::{
     net::SocketAddr,
     pin::Pin,
@@ -48,7 +49,7 @@ use std::{
 };
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
-use tracing::{error, trace};
+use tracing::{error, trace, warn};
 
 /// Manages the _entire_ state of the network.
 ///
@@ -82,8 +83,6 @@ pub struct NetworkManager<C> {
     from_handle_rx: UnboundedReceiverStream<NetworkHandleMessage>,
     /// Handles block imports according to the `eth` protocol.
     block_import: Box<dyn BlockImport>,
-    /// The address of this node that listens for incoming connections.
-    listener_address: Arc<Mutex<SocketAddr>>,
     /// All listeners for [`Network`] events.
     event_listeners: NetworkEventListeners,
     /// Sender half to send events to the [`TransactionsManager`] task, if configured.
@@ -140,7 +139,7 @@ where
         let num_active_peers = Arc::new(AtomicUsize::new(0));
         let handle = NetworkHandle::new(
             Arc::clone(&num_active_peers),
-            Arc::clone(&listener_address),
+            listener_address,
             to_manager_tx,
             local_peer_id,
             peers_handle,
@@ -152,7 +151,6 @@ where
             handle,
             from_handle_rx: UnboundedReceiverStream::new(from_handle_rx),
             block_import,
-            listener_address,
             event_listeners: Default::default(),
             to_transactions: None,
             num_active_peers,
@@ -167,6 +165,11 @@ where
     /// Returns the [`SocketAddr`] that listens for incoming connections.
     pub fn local_addr(&self) -> SocketAddr {
         self.swarm.listener().local_address()
+    }
+
+    /// Returns the configured genesis hash
+    pub fn genesis_hash(&self) -> H256 {
+        self.swarm.state().genesis_hash()
     }
 
     /// How many peers we're currently connected to.
@@ -184,6 +187,20 @@ where
     /// The [`NetworkHandle`] can be used to interact with this [`NetworkManager`]
     pub fn handle(&self) -> &NetworkHandle {
         &self.handle
+    }
+
+    /// Returns a new [`PeersHandle`] that can be cloned and shared.
+    ///
+    /// The [`PeersHandle`] can be used to interact with the network's peer set.
+    pub fn peers_handle(&self) -> PeersHandle {
+        self.swarm.state().peers().handle()
+    }
+
+    /// Returns a new [`FetchClient`] that can be cloned and shared.
+    ///
+    /// The [`FetchClient`] is the entrypoint for sending requests to the network.
+    pub fn fetch_client(&self) -> FetchClient {
+        self.swarm.state().fetch_client()
     }
 
     /// Event hook for an unexpected message from the peer.
@@ -300,7 +317,9 @@ where
             PeerMessage::SendTransactions(_) => {
                 unreachable!("Not emitted by session")
             }
-            PeerMessage::Other(_) => {}
+            PeerMessage::Other(other) => {
+                error!(target : "net", message_id=%other.id, "Ignoring unsupported message");
+            }
         }
     }
 
@@ -336,6 +355,9 @@ where
             }
             NetworkHandleMessage::ReputationChange(peer_id, kind) => {
                 self.swarm.state_mut().peers_mut().apply_reputation_change(&peer_id, kind);
+            }
+            NetworkHandleMessage::FetchClient(tx) => {
+                let _ = tx.send(self.fetch_client());
             }
         }
     }
@@ -385,11 +407,11 @@ where
                 SwarmEvent::TcpListenerError(err) => {
                     trace!(target : "net", ?err, "TCP connection error.");
                 }
-                SwarmEvent::IncomingTcpConnection { remote_addr, .. } => {
-                    trace!(target : "net",?remote_addr, "Incoming connection");
+                SwarmEvent::IncomingTcpConnection { remote_addr, session_id } => {
+                    trace!(target : "net", ?session_id, ?remote_addr, "Incoming connection");
                 }
-                SwarmEvent::OutgoingTcpConnection { remote_addr } => {
-                    trace!(target : "net", ?remote_addr,"Starting outbound connection.");
+                SwarmEvent::OutgoingTcpConnection { remote_addr, peer_id } => {
+                    trace!(target : "net", ?remote_addr, ?peer_id, "Starting outbound connection.");
                 }
                 SwarmEvent::SessionEstablished {
                     peer_id,
@@ -408,7 +430,10 @@ where
                     );
 
                     if direction.is_incoming() {
-                        this.swarm.state_mut().peers_mut().on_active_session(peer_id, remote_addr);
+                        this.swarm
+                            .state_mut()
+                            .peers_mut()
+                            .on_active_inbound_session(peer_id, remote_addr);
                     }
 
                     this.event_listeners.send(NetworkEvent::SessionEstablished {
@@ -438,14 +463,36 @@ where
 
                     this.event_listeners.send(NetworkEvent::SessionClosed { peer_id });
                 }
-                SwarmEvent::IncomingPendingSessionClosed { .. } => {}
-                SwarmEvent::OutgoingPendingSessionClosed { peer_id, .. } => {
+                SwarmEvent::IncomingPendingSessionClosed { remote_addr, error } => {
+                    warn!(
+                        target : "net",
+                        ?remote_addr,
+                        ?error,
+                        "Incoming pending session failed"
+                    );
+                    this.swarm.state_mut().peers_mut().on_closed_incoming_pending_session()
+                }
+                SwarmEvent::OutgoingPendingSessionClosed { remote_addr, peer_id, error } => {
+                    warn!(
+                        target : "net",
+                        ?remote_addr,
+                        ?peer_id,
+                        ?error,
+                        "Outgoing pending session failed"
+                    );
                     this.swarm
                         .state_mut()
                         .peers_mut()
                         .apply_reputation_change(&peer_id, ReputationChangeKind::FailedToConnect);
                 }
-                SwarmEvent::OutgoingConnectionError { peer_id, .. } => {
+                SwarmEvent::OutgoingConnectionError { remote_addr, peer_id, error } => {
+                    warn!(
+                        target : "net",
+                        ?remote_addr,
+                        ?peer_id,
+                        ?error,
+                        "Outgoing connection error"
+                    );
                     this.swarm
                         .state_mut()
                         .peers_mut()

--- a/crates/net/network/src/message.rs
+++ b/crates/net/network/src/message.rs
@@ -5,7 +5,7 @@
 
 use futures::FutureExt;
 use reth_eth_wire::{
-    capability::CapabilityMessage, message::RequestPair, BlockBodies, BlockBody, BlockHeaders,
+    capability::RawCapabilityMessage, message::RequestPair, BlockBodies, BlockBody, BlockHeaders,
     EthMessage, GetBlockBodies, GetBlockHeaders, GetNodeData, GetPooledTransactions, GetReceipts,
     NewBlock, NewBlockHashes, NewPooledTransactionHashes, NodeData, PooledTransactions, Receipts,
     SharedTransactions, Transactions,
@@ -53,7 +53,8 @@ pub enum PeerMessage {
     /// All `eth` request variants.
     EthRequest(PeerRequest),
     /// Other than eth namespace message
-    Other(CapabilityMessage),
+    #[allow(unused)]
+    Other(RawCapabilityMessage),
 }
 
 /// Request Variants that only target block related data.
@@ -63,32 +64,6 @@ pub enum PeerMessage {
 pub enum BlockRequest {
     GetBlockHeaders(GetBlockHeaders),
     GetBlockBodies(GetBlockBodies),
-}
-
-/// All Request variants of an [`EthMessage`]
-///
-/// Note: These variants come without a request ID, as it's expected that the peer session will
-/// manage those
-#[derive(Debug, Clone)]
-#[allow(missing_docs)]
-#[allow(clippy::enum_variant_names)]
-pub enum EthRequest {
-    GetBlockHeaders(GetBlockHeaders),
-    GetBlockBodies(GetBlockBodies),
-    GetPooledTransactions(GetPooledTransactions),
-    GetNodeData(GetNodeData),
-    GetReceipts(GetReceipts),
-}
-
-/// Corresponding Response variants for [`EthRequest`]
-#[derive(Debug, Clone)]
-#[allow(missing_docs)]
-pub enum EthResponse {
-    BlockHeaders(BlockHeaders),
-    BlockBodies(BlockBodies),
-    PooledTransactions(PooledTransactions),
-    NodeData(NodeData),
-    Receipts(Receipts),
 }
 
 /// Protocol related request messages that expect a response
@@ -265,6 +240,7 @@ impl PeerResponseResult {
     }
 
     /// Returns whether this result is an error.
+    #[allow(unused)]
     pub fn is_err(&self) -> bool {
         match self {
             PeerResponseResult::BlockHeaders(res) => res.is_err(),
@@ -291,5 +267,10 @@ impl PeerRequestSender {
     /// Attempts to immediately send a message on this Sender
     pub fn try_send(&self, req: PeerRequest) -> Result<(), TrySendError<PeerRequest>> {
         self.to_session_tx.try_send(req)
+    }
+
+    /// Returns the peer id of the remote peer.
+    pub fn peer_id(&self) -> &PeerId {
+        &self.peer_id
     }
 }

--- a/crates/net/network/src/peers/reputation.rs
+++ b/crates/net/network/src/peers/reputation.rs
@@ -106,16 +106,6 @@ pub(crate) struct ReputationChange(Reputation);
 // === impl ReputationChange ===
 
 impl ReputationChange {
-    /// Apply no reputation change.
-    pub(crate) const fn none() -> Self {
-        Self(0)
-    }
-
-    /// Reputation change for a peer that dropped the connection.
-    pub(crate) const fn dropped() -> Self {
-        Self(REMOTE_DISCONNECT_REPUTATION_CHANGE)
-    }
-
     /// Helper type for easier conversion
     #[inline]
     pub(crate) fn as_i32(self) -> Reputation {

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -42,6 +42,7 @@ use tracing::{error, warn};
 ///    - incoming commands from the [`SessionsManager`]
 ///    - incoming requests via the request channel
 ///    - responses for handled ETH requests received from the remote peer.
+#[allow(unused)]
 pub(crate) struct ActiveSession {
     /// Keeps track of request ids.
     pub(crate) next_id: u64,
@@ -216,7 +217,9 @@ impl ActiveSession {
             PeerMessage::ReceivedTransaction(_) => {
                 unreachable!("Not emitted by network")
             }
-            PeerMessage::Other(_) => {}
+            PeerMessage::Other(other) => {
+                error!(target : "net::session", message_id=%other.id, "Ignoring unsupported message");
+            }
         }
     }
 
@@ -432,6 +435,7 @@ pub(crate) struct ReceivedRequest {
     /// Receiver half of the channel that's supposed to receive the proper response.
     rx: PeerResponse,
     /// Timestamp when we read this msg from the wire.
+    #[allow(unused)]
     received: Instant,
 }
 
@@ -463,6 +467,7 @@ impl From<EthBroadcastMessage> for OutgoingMessage {
 
 #[cfg(test)]
 mod tests {
+    #![allow(dead_code)]
     use super::*;
     use crate::session::{
         config::REQUEST_TIMEOUT, handle::PendingSessionEvent, start_pending_incoming_session,

--- a/crates/net/network/src/session/config.rs
+++ b/crates/net/network/src/session/config.rs
@@ -155,6 +155,7 @@ impl SessionCounter {
         }
     }
 
+    #[allow(unused)]
     pub(crate) fn ensure_pending_outbound(&self) -> Result<(), ExceedsSessionLimit> {
         Self::ensure(self.pending_outbound, self.limits.max_pending_outbound)
     }

--- a/crates/net/network/src/session/handle.rs
+++ b/crates/net/network/src/session/handle.rs
@@ -23,7 +23,7 @@ use tokio::{
 #[derive(Debug)]
 pub(crate) struct PendingSessionHandle {
     /// Can be used to tell the session to disconnect the connection/abort the handshake process.
-    pub(crate) disconnect_tx: oneshot::Sender<()>,
+    pub(crate) _disconnect_tx: oneshot::Sender<()>,
     /// The direction of the session
     pub(crate) direction: Direction,
 }
@@ -33,6 +33,7 @@ pub(crate) struct PendingSessionHandle {
 /// Within an active session that supports the `Ethereum Wire Protocol `, three high-level tasks can
 /// be performed: chain synchronization, block propagation and transaction exchange.
 #[derive(Debug)]
+#[allow(unused)]
 pub(crate) struct ActiveSessionHandle {
     /// The direction of the session
     pub(crate) direction: Direction,
@@ -65,8 +66,6 @@ impl ActiveSessionHandle {
 /// A session starts with a `Handshake`, followed by a `Hello` message which
 #[derive(Debug)]
 pub(crate) enum PendingSessionEvent {
-    /// Initial handshake step was successful <https://github.com/ethereum/devp2p/blob/6b0abc3d956a626c28dce1307ee9f546db17b6bd/rlpx.md#initial-handshake>
-    SuccessfulHandshake { remote_addr: SocketAddr, session_id: SessionId },
     /// Represents a successful `Hello` and `Status` exchange: <https://github.com/ethereum/devp2p/blob/6b0abc3d956a626c28dce1307ee9f546db17b6bd/rlpx.md#hello-0x00>
     Established {
         session_id: SessionId,
@@ -134,6 +133,7 @@ pub(crate) enum ActiveSessionMessage {
         message: PeerMessage,
     },
     /// Received a message that does not match the announced capabilities of the peer.
+    #[allow(unused)]
     InvalidMessage {
         /// Identifier of the remote peer.
         peer_id: PeerId,

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -9,6 +9,7 @@ use crate::{
         PeerResponseResult,
     },
     peers::{PeerAction, PeersManager},
+    FetchClient,
 };
 use reth_eth_wire::{
     capability::Capabilities, BlockHashNumber, DisconnectReason, NewBlockHashes, Status,
@@ -83,6 +84,21 @@ where
     /// Returns mutable access to the [`PeersManager`]
     pub(crate) fn peers_mut(&mut self) -> &mut PeersManager {
         &mut self.peers_manager
+    }
+
+    /// Returns access to the [`PeersManager`]
+    pub(crate) fn peers(&self) -> &PeersManager {
+        &self.peers_manager
+    }
+
+    /// Returns a new [`FetchClient`]
+    pub(crate) fn fetch_client(&self) -> FetchClient {
+        self.state_fetcher.client()
+    }
+
+    /// How many peers we're currently connected to.
+    pub fn genesis_hash(&self) -> H256 {
+        self.genesis_hash
     }
 
     /// How many peers we're currently connected to.
@@ -381,10 +397,11 @@ where
 /// Tracks the state of a Peer.
 ///
 /// For example known blocks,so we can decide what to announce.
-pub struct ConnectedPeer {
+pub(crate) struct ConnectedPeer {
     /// Best block of the peer.
     pub(crate) best_hash: H256,
     /// The capabilities of the connected peer.
+    #[allow(unused)]
     pub(crate) capabilities: Arc<Capabilities>,
     /// A communication channel directly to the session task.
     pub(crate) request_tx: PeerRequestSender,

--- a/crates/net/network/src/swarm.rs
+++ b/crates/net/network/src/swarm.rs
@@ -19,7 +19,7 @@ use std::{
     sync::Arc,
     task::{Context, Poll},
 };
-use tracing::warn;
+use tracing::{trace, warn};
 
 /// Contains the connectivity related state of the network.
 ///
@@ -67,6 +67,7 @@ where
     pub(crate) fn listener(&self) -> &ConnectionListener {
         &self.incoming
     }
+
     /// Mutable access to the [`SessionManager`].
     pub(crate) fn sessions_mut(&mut self) -> &mut SessionManager {
         &mut self.sessions
@@ -139,12 +140,19 @@ where
                 return Some(SwarmEvent::TcpListenerClosed { remote_addr: address })
             }
             ListenerEvent::Incoming { stream, remote_addr } => {
+                if let Err(limit) = self.state_mut().peers_mut().on_inbound_pending_session() {
+                    // We currently don't have additional capacity to establish a session from an
+                    // incoming connection, so we drop the connection.
+                    trace!(target: "net", %limit, ?remote_addr, "Exceeded incoming connection limit; dropping connection");
+                    return None
+                }
+
                 match self.sessions.on_incoming(stream, remote_addr) {
                     Ok(session_id) => {
                         return Some(SwarmEvent::IncomingTcpConnection { session_id, remote_addr })
                     }
                     Err(err) => {
-                        warn!(?err, "Incoming connection rejected");
+                        warn!(target: "net", ?err, "Incoming connection rejected");
                     }
                 }
             }
@@ -156,7 +164,8 @@ where
     fn on_state_action(&mut self, event: StateAction) -> Option<SwarmEvent> {
         match event {
             StateAction::Connect { remote_addr, peer_id } => {
-                self.sessions.dial_outbound(remote_addr, peer_id);
+                self.dial_outbound(remote_addr, peer_id);
+                return Some(SwarmEvent::OutgoingTcpConnection { remote_addr, peer_id })
             }
             StateAction::Disconnect { peer_id, reason } => {
                 self.sessions.disconnect(peer_id, reason);
@@ -269,6 +278,7 @@ pub(crate) enum SwarmEvent {
     /// An outbound connection is initiated.
     OutgoingTcpConnection {
         /// Address of the remote peer.
+        peer_id: PeerId,
         remote_addr: SocketAddr,
     },
     SessionEstablished {


### PR DESCRIPTION
remove `#[allow(unused)]` and fix all warnings, get rid of unused code or allow where likely useful in the future