### PR TITLE
codecs: "type specialization" for `Compact` on `Vec<T>` & `Option<T>`

### DIFF
--- a/crates/codecs/derive/src/compact/enums.rs
+++ b/crates/codecs/derive/src/compact/enums.rs
@@ -62,7 +62,7 @@ impl<'a> EnumHandler<'a> {
                     let from_compact_ident = if !use_alt_impl {
                         format_ident!("from_compact")
                     } else {
-                        format_ident!("alternative_from_compact")
+                        format_ident!("specialized_from_compact")
                     };
 
                     // Unamed type
@@ -103,7 +103,7 @@ impl<'a> EnumHandler<'a> {
                     let to_compact_ident = if !use_alt_impl {
                         format_ident!("to_compact")
                     } else {
-                        format_ident!("alternative_to_compact")
+                        format_ident!("specialized_to_compact")
                     };
 
                     // Unamed type

--- a/crates/codecs/derive/src/compact/enums.rs
+++ b/crates/codecs/derive/src/compact/enums.rs
@@ -56,15 +56,20 @@ impl<'a> EnumHandler<'a> {
 
         if let Some(next_field) = self.fields_iterator.peek() {
             match next_field {
-                FieldTypes::EnumUnnamedField(next_ftype) => {
+                FieldTypes::EnumUnnamedField((next_ftype, use_alt_impl)) => {
                     // This variant is of the type `EnumVariant(UnnamedField)`
                     let field_type = format_ident!("{next_ftype}");
+                    let from_compact_ident = if !use_alt_impl {
+                        format_ident!("from_compact")
+                    } else {
+                        format_ident!("alternative_from_compact")
+                    };
 
                     // Unamed type
                     self.enum_lines.push(quote! {
                         #current_variant_index => {
                             let mut inner = #field_type::default();
-                            (inner, buf) = #field_type::from_compact(buf, buf.len());
+                            (inner, buf) = #field_type::#from_compact_ident(buf, buf.len());
                             #ident::#variant_name(inner)
                         }
                     });
@@ -94,11 +99,17 @@ impl<'a> EnumHandler<'a> {
 
         if let Some(next_field) = self.fields_iterator.peek() {
             match next_field {
-                FieldTypes::EnumUnnamedField(_) => {
+                FieldTypes::EnumUnnamedField((_, use_alt_impl)) => {
+                    let to_compact_ident = if !use_alt_impl {
+                        format_ident!("to_compact")
+                    } else {
+                        format_ident!("alternative_to_compact")
+                    };
+
                     // Unamed type
                     self.enum_lines.push(quote! {
                         #ident::#variant_name(field) => {
-                            field.to_compact(&mut buffer);
+                            field.#to_compact_ident(&mut buffer);
                             #current_variant_index
                         },
                     });

--- a/crates/codecs/derive/src/compact/flags.rs
+++ b/crates/codecs/derive/src/compact/flags.rs
@@ -70,7 +70,7 @@ fn build_struct_field_flags(
     let mut total_bits = 0;
 
     // Find out the adequate bit size for the length of each field, if applicable.
-    for (name, ftype, is_compact) in fields {
+    for (name, ftype, is_compact, _) in fields {
         // This happens when dealing with a wrapper struct eg. Struct(pub U256).
         let name = if name.is_empty() { "placeholder" } else { name };
 

--- a/crates/codecs/derive/src/compact/generator.rs
+++ b/crates/codecs/derive/src/compact/generator.rs
@@ -43,14 +43,6 @@ pub fn generate_from_to(ident: &Ident, fields: &FieldList) -> TokenStream2 {
                 #(#from_compact)*
                 (obj, buf)
             }
-
-            fn alternative_to_compact(self, buf: &mut impl bytes::BufMut) -> usize {
-                self.to_compact(buf)
-            }
-
-            fn alternative_from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
-                Self::from_compact(buf, len)
-            }
         }
     }
 }

--- a/crates/codecs/derive/src/compact/generator.rs
+++ b/crates/codecs/derive/src/compact/generator.rs
@@ -43,6 +43,14 @@ pub fn generate_from_to(ident: &Ident, fields: &FieldList) -> TokenStream2 {
                 #(#from_compact)*
                 (obj, buf)
             }
+
+            fn alternative_to_compact(self, buf: &mut impl bytes::BufMut) -> usize {
+                self.to_compact(buf)
+            }
+
+            fn alternative_from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
+                Self::from_compact(buf, len)
+            }
         }
     }
 }
@@ -82,7 +90,7 @@ fn generate_from_compact(fields: &FieldList, ident: &Ident) -> Vec<TokenStream2>
             });
         } else {
             let fields = fields.iter().filter_map(|field| {
-                if let FieldTypes::StructField((name, _, _)) = field {
+                if let FieldTypes::StructField((name, _, _, _)) = field {
                     let ident = format_ident!("{name}");
                     return Some(quote! {
                         #ident: #ident,

--- a/crates/codecs/derive/src/compact/mod.rs
+++ b/crates/codecs/derive/src/compact/mod.rs
@@ -300,12 +300,6 @@ mod tests {
                     };
                     (obj, buf)
                 }
-                fn alternative_to_compact(self, buf: &mut impl bytes :: BufMut) -> usize {
-                    self.to_compact(buf)
-                }
-                fn alternative_from_compact(buf: &[u8], len : usize) -> (Self , & [u8]) {
-                    Self::from_compact(buf, len)
-                }
             }
         };
 

--- a/crates/codecs/derive/src/compact/mod.rs
+++ b/crates/codecs/derive/src/compact/mod.rs
@@ -254,12 +254,12 @@ mod tests {
                     flags.set_f_bool_f_len(f_bool_f_len as u8);
                     let f_option_none_len = self.f_option_none.to_compact(&mut buffer);
                     flags.set_f_option_none_len(f_option_none_len as u8);
-                    let f_option_some_len = self.f_option_some.alternative_to_compact(&mut buffer);
+                    let f_option_some_len = self.f_option_some.specialized_to_compact(&mut buffer);
                     flags.set_f_option_some_len(f_option_some_len as u8);
                     let f_option_some_u64_len = self.f_option_some_u64.to_compact(&mut buffer);
                     flags.set_f_option_some_u64_len(f_option_some_u64_len as u8);
                     let f_vec_empty_len = self.f_vec_empty.to_compact(&mut buffer);
-                    let f_vec_some_len = self.f_vec_some.alternative_to_compact(&mut buffer);
+                    let f_vec_some_len = self.f_vec_some.specialized_to_compact(&mut buffer);
                     let flags = flags.into_bytes();
                     total_len += flags.len() + buffer.len();
                     buf.put_slice(&flags);
@@ -279,14 +279,14 @@ mod tests {
                     let mut f_option_none = Option::default();
                     (f_option_none, buf) = Option::from_compact(buf, flags.f_option_none_len() as usize);
                     let mut f_option_some = Option::default();
-                    (f_option_some, buf) = Option::alternative_from_compact(buf, flags.f_option_some_len() as usize);
+                    (f_option_some, buf) = Option::specialized_from_compact(buf, flags.f_option_some_len() as usize);
                     let mut f_option_some_u64 = Option::default();
                     (f_option_some_u64, buf) =
                         Option::from_compact(buf, flags.f_option_some_u64_len() as usize);
                     let mut f_vec_empty = Vec::default();
                     (f_vec_empty, buf) = Vec::from_compact(buf, buf.len());
                     let mut f_vec_some = Vec::default();
-                    (f_vec_some, buf) = Vec::alternative_from_compact(buf, buf.len());
+                    (f_vec_some, buf) = Vec::specialized_from_compact(buf, buf.len());
                     let obj = TestStruct {
                         f_u64: f_u64,
                         f_u256: f_u256,

--- a/crates/codecs/derive/src/compact/mod.rs
+++ b/crates/codecs/derive/src/compact/mod.rs
@@ -22,8 +22,14 @@ type IsCompact = bool;
 type FieldName = String;
 // Helper Alias type
 type FieldType = String;
+/// `Compact` has alternative functions that can be used as a workaround for type
+/// specialization of fixed sized types.
+///
+/// Example: `Vec<H256>` vs `Vec<U256>`. The first does not
+/// require the len of the element, while the latter one does.
+type UseAlternative = bool;
 // Helper Alias type
-type StructFieldDescriptor = (FieldName, FieldType, IsCompact);
+type StructFieldDescriptor = (FieldName, FieldType, IsCompact, UseAlternative);
 // Helper Alias type
 type FieldList = Vec<FieldTypes>;
 
@@ -31,7 +37,7 @@ type FieldList = Vec<FieldTypes>;
 pub enum FieldTypes {
     StructField(StructFieldDescriptor),
     EnumVariant(String),
-    EnumUnnamedField(FieldType),
+    EnumUnnamedField((FieldType, UseAlternative)),
 }
 
 /// Derives the [`Compact`] trait and its from/to implementations.
@@ -96,15 +102,39 @@ fn load_field(field: &syn::Field, fields: &mut FieldList, is_enum: bool) {
         let segments = &path.path.segments;
         if !segments.is_empty() {
             let mut ftype = String::new();
+
+            let mut use_alt_impl: UseAlternative = false;
+
             for (index, segment) in segments.iter().enumerate() {
                 ftype.push_str(&segment.ident.to_string());
                 if index < segments.len() - 1 {
                     ftype.push_str("::");
                 }
+
+                // Since there's no impl specialization in rust stable atm, once we find we have a
+                // Vec/Option we try to find out if it's a Vec/Option of a fixed size data type.
+                // eg, Vec<H256>. If so, we use another impl to code/decode its data.
+                if ftype == "Vec" || ftype == "Option" {
+                    if let syn::PathArguments::AngleBracketed(ref args) = segment.arguments {
+                        if let Some(syn::GenericArgument::Type(syn::Type::Path(arg_path))) =
+                            args.args.last()
+                        {
+                            if let (Some(path), 1) =
+                                (arg_path.path.segments.first(), arg_path.path.segments.len())
+                            {
+                                if ["H256", "H160", "Address", "Bloom"]
+                                    .contains(&path.ident.to_string().as_str())
+                                {
+                                    use_alt_impl = true;
+                                }
+                            }
+                        }
+                    }
+                }
             }
 
             if is_enum {
-                fields.push(FieldTypes::EnumUnnamedField(ftype.to_string()));
+                fields.push(FieldTypes::EnumUnnamedField((ftype.to_string(), use_alt_impl)));
             } else {
                 let should_compact = is_flag_type(&ftype) ||
                     field.attrs.iter().any(|attr| {
@@ -115,6 +145,7 @@ fn load_field(field: &syn::Field, fields: &mut FieldList, is_enum: bool) {
                     field.ident.as_ref().map(|i| i.to_string()).unwrap_or_default(),
                     ftype,
                     should_compact,
+                    use_alt_impl,
                 )));
             }
         }
@@ -218,14 +249,14 @@ mod tests {
                     flags.set_f_bool_t_len(f_bool_t_len as u8);
                     let f_bool_f_len = self.f_bool_f.to_compact(&mut buffer);
                     flags.set_f_bool_f_len(f_bool_f_len as u8);
-                    let f_option_none_len = self.f_option_none.to_compact(&mut buffer);
+                    let f_option_none_len = self.f_option_none.alternative_to_compact(&mut buffer);
                     flags.set_f_option_none_len(f_option_none_len as u8);
-                    let f_option_some_len = self.f_option_some.to_compact(&mut buffer);
+                    let f_option_some_len = self.f_option_some.alternative_to_compact(&mut buffer);
                     flags.set_f_option_some_len(f_option_some_len as u8);
                     let f_option_some_u64_len = self.f_option_some_u64.to_compact(&mut buffer);
                     flags.set_f_option_some_u64_len(f_option_some_u64_len as u8);
-                    let f_vec_empty_len = self.f_vec_empty.to_compact(&mut buffer);
-                    let f_vec_some_len = self.f_vec_some.to_compact(&mut buffer);
+                    let f_vec_empty_len = self.f_vec_empty.alternative_to_compact(&mut buffer);
+                    let f_vec_some_len = self.f_vec_some.alternative_to_compact(&mut buffer);
                     let flags = flags.into_bytes();
                     total_len += flags.len() + buffer.len();
                     buf.put_slice(&flags);
@@ -243,16 +274,16 @@ mod tests {
                     let mut f_bool_f = bool::default();
                     (f_bool_f, buf) = bool::from_compact(buf, flags.f_bool_f_len() as usize);
                     let mut f_option_none = Option::default();
-                    (f_option_none, buf) = Option::from_compact(buf, flags.f_option_none_len() as usize);
+                    (f_option_none, buf) = Option::alternative_from_compact(buf, flags.f_option_none_len() as usize);
                     let mut f_option_some = Option::default();
-                    (f_option_some, buf) = Option::from_compact(buf, flags.f_option_some_len() as usize);
+                    (f_option_some, buf) = Option::alternative_from_compact(buf, flags.f_option_some_len() as usize);
                     let mut f_option_some_u64 = Option::default();
                     (f_option_some_u64, buf) =
                         Option::from_compact(buf, flags.f_option_some_u64_len() as usize);
                     let mut f_vec_empty = Vec::default();
-                    (f_vec_empty, buf) = Vec::from_compact(buf, buf.len());
+                    (f_vec_empty, buf) = Vec::alternative_from_compact(buf, buf.len());
                     let mut f_vec_some = Vec::default();
-                    (f_vec_some, buf) = Vec::from_compact(buf, buf.len());
+                    (f_vec_some, buf) = Vec::alternative_from_compact(buf, buf.len());
                     let obj = TestStruct {
                         f_u64: f_u64,
                         f_u256: f_u256,
@@ -265,6 +296,12 @@ mod tests {
                         f_vec_some: f_vec_some,
                     };
                     (obj, buf)
+                }
+                fn alternative_to_compact(self, buf: &mut impl bytes :: BufMut) -> usize {
+                    self.to_compact(buf)
+                }
+                fn alternative_from_compact(buf: &[u8], len : usize) -> (Self , & [u8]) {
+                    Self::from_compact(buf, len)
                 }
             }
         };

--- a/crates/codecs/derive/src/compact/structs.rs
+++ b/crates/codecs/derive/src/compact/structs.rs
@@ -46,14 +46,20 @@ impl<'a> StructHandler<'a> {
 
     /// Generates `to_compact` code for a struct field.
     fn to(&mut self, field_descriptor: &StructFieldDescriptor) {
-        let (name, ftype, is_compact) = field_descriptor;
+        let (name, ftype, is_compact, use_alt_impl) = field_descriptor;
+
+        let to_compact_ident = if !use_alt_impl {
+            format_ident!("to_compact")
+        } else {
+            format_ident!("alternative_to_compact")
+        };
 
         // Should only happen on wrapper structs like `Struct(pub Field)`
         if name.is_empty() {
             self.is_wrapper = true;
 
             self.lines.push(quote! {
-                let _len = self.0.to_compact(&mut buffer);
+                let _len = self.0.#to_compact_ident(&mut buffer);
             });
 
             if is_flag_type(ftype) {
@@ -76,12 +82,12 @@ impl<'a> StructHandler<'a> {
             self.lines.push(quote! {
                 if self.#name != #itype::zero() {
                     flags.#set_bool_method(true);
-                    self.#name.to_compact(&mut buffer);
+                    self.#name.#to_compact_ident(&mut buffer);
                 };
             });
         } else {
             self.lines.push(quote! {
-                let #len = self.#name.to_compact(&mut buffer);
+                let #len = self.#name.#to_compact_ident(&mut buffer);
             });
         }
         if is_flag_type(ftype) {
@@ -93,7 +99,7 @@ impl<'a> StructHandler<'a> {
 
     /// Generates `from_compact` code for a struct field.
     fn from(&mut self, field_descriptor: &StructFieldDescriptor, known_types: &[&str]) {
-        let (name, ftype, is_compact) = field_descriptor;
+        let (name, ftype, is_compact, use_alt_impl) = field_descriptor;
 
         let (name, len) = if name.is_empty() {
             self.is_wrapper = true;
@@ -102,6 +108,12 @@ impl<'a> StructHandler<'a> {
             (format_ident!("placeholder"), format_ident!("placeholder_len"))
         } else {
             (format_ident!("{name}"), format_ident!("{name}_len"))
+        };
+
+        let from_compact_ident = if !use_alt_impl {
+            format_ident!("from_compact")
+        } else {
+            format_ident!("alternative_from_compact")
         };
 
         assert!(
@@ -124,11 +136,11 @@ impl<'a> StructHandler<'a> {
             if !is_flag_type(ftype) {
                 // It's a type that handles its own length requirements. (h256, Custom, ...)
                 self.lines.push(quote! {
-                    (#name, buf) = #ident_type::from_compact(buf, buf.len());
+                    (#name, buf) = #ident_type::#from_compact_ident(buf, buf.len());
                 })
             } else if *is_compact {
                 self.lines.push(quote! {
-                    (#name, buf) = #ident_type::from_compact(buf, flags.#len() as usize);
+                    (#name, buf) = #ident_type::#from_compact_ident(buf, flags.#len() as usize);
                 });
             } else {
                 todo!()

--- a/crates/codecs/derive/src/compact/structs.rs
+++ b/crates/codecs/derive/src/compact/structs.rs
@@ -51,7 +51,7 @@ impl<'a> StructHandler<'a> {
         let to_compact_ident = if !use_alt_impl {
             format_ident!("to_compact")
         } else {
-            format_ident!("alternative_to_compact")
+            format_ident!("specialized_to_compact")
         };
 
         // Should only happen on wrapper structs like `Struct(pub Field)`
@@ -113,7 +113,7 @@ impl<'a> StructHandler<'a> {
         let from_compact_ident = if !use_alt_impl {
             format_ident!("from_compact")
         } else {
-            format_ident!("alternative_from_compact")
+            format_ident!("specialized_from_compact")
         };
 
         assert!(

--- a/crates/codecs/src/lib.rs
+++ b/crates/codecs/src/lib.rs
@@ -9,11 +9,16 @@ use ethers_core::types::{Bloom, H160, H256, U256};
 /// * Fixed array types (H256, Address, Bloom) are not compacted.
 /// * Max size of `T` in `Option<T>` or `Vec<T>` shouldn't exceed `0xffff`.
 /// * Any `bytes::Bytes` field **should be placed last**.
-/// * Any other type which is not known to the derive module **should be placed last**.
+/// * Any other type which is not known to the derive module **should be placed last** in they
+///   contain a `bytes::Bytes` field.
 ///
 /// The last two points make it easier to decode the data without saving the length on the
 /// `StructFlags`. It will fail compilation if it's not respected. If they're alias to known types,
 /// add their definitions to `get_bit_size()` or `known_types` in `generator.rs`.
+///
+/// Regarding the `alternative_*` methods: Mainly used as a workaround for not being able to
+/// specialize an impl over certain types like Vec<T>/Option<T> where T is a fixed size array like
+/// Vec<H256>.
 pub trait Compact {
     /// Takes a buffer which can be written to. *Ideally*, it returns the length written to.
     fn to_compact(self, buf: &mut impl bytes::BufMut) -> usize;
@@ -27,8 +32,10 @@ pub trait Compact {
     where
         Self: Sized;
 
+    /// "Optional": If there's no good reason to use it, just call `to_compact`
     fn alternative_to_compact(self, buf: &mut impl bytes::BufMut) -> usize;
 
+    /// "Optional": If there's no good reason to use it, just call `from_compact`
     fn alternative_from_compact(buf: &[u8], len: usize) -> (Self, &[u8])
     where
         Self: Sized;

--- a/crates/primitives/src/account.rs
+++ b/crates/primitives/src/account.rs
@@ -11,7 +11,6 @@ pub struct Account {
     pub nonce: u64,
     /// Account balance.
     pub balance: U256,
-    #[maybe_zero]
     /// Hash of the bytecode.
     pub bytecode_hash: Option<H256>,
 }

--- a/crates/primitives/src/transaction/tx_type.rs
+++ b/crates/primitives/src/transaction/tx_type.rs
@@ -32,4 +32,12 @@ impl Compact for TxType {
             buf,
         )
     }
+
+    fn alternative_to_compact(self, buf: &mut impl bytes::BufMut) -> usize {
+        self.to_compact(buf)
+    }
+
+    fn alternative_from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
+        Self::from_compact(buf, len)
+    }
 }

--- a/crates/primitives/src/transaction/tx_type.rs
+++ b/crates/primitives/src/transaction/tx_type.rs
@@ -32,12 +32,4 @@ impl Compact for TxType {
             buf,
         )
     }
-
-    fn alternative_to_compact(self, buf: &mut impl bytes::BufMut) -> usize {
-        self.to_compact(buf)
-    }
-
-    fn alternative_from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
-        Self::from_compact(buf, len)
-    }
 }


### PR DESCRIPTION
### Motivation
When handling `Vec<T>` and `Option<T>` we were encoding the length of each element. However, for types like `Address` and `H256`, it shouldn't be necessary since they're always constant in length.

However:
1. `impl specialization` is not stable.
2. macros + declaring all types is not possible because of circular dependencies . Example: `Vec<AccessListItem>`: importing  `Compact` from `codecs` to `primitives`, and importing `primitives` into `codecs`

So I guess the only other alternative is to have alternative implementations for `from_compact` and `to_compact`. Normally they will just call the default ones (since there are no optional methods on traits...),, but it allows us to specify different ones for `Vec<T>` and `Option<T>`. 

And then, all it remains is to make sure that the code generator chooses the alternative implementations when necessary:

```
Vec<H256> -> alternative_from_compact(..)
Vec<U256>  -> from_compact(..)
```
