### PR TITLE
refactor: replace reverse with HeadersDirection

### DIFF
--- a/crates/interfaces/src/p2p/headers/client.rs
+++ b/crates/interfaces/src/p2p/headers/client.rs
@@ -1,7 +1,7 @@
 use crate::p2p::error::RequestResult;
 use async_trait::async_trait;
 pub use reth_eth_wire::BlockHeaders;
-use reth_primitives::{BlockHashOrNumber, H256, U256};
+use reth_primitives::{BlockHashOrNumber, HeadersDirection, H256, U256};
 use std::fmt::Debug;
 
 /// The header request struct to be sent to connected peers, which
@@ -12,9 +12,8 @@ pub struct HeadersRequest {
     pub start: BlockHashOrNumber,
     /// The response max size
     pub limit: u64,
-    /// Flag indicating whether the blocks should
-    /// arrive in reverse
-    pub reverse: bool,
+    /// The direction in which headers should be returned.
+    pub direction: HeadersDirection,
 }
 
 /// The block headers downloader client

--- a/crates/interfaces/src/test_utils/headers.rs
+++ b/crates/interfaces/src/test_utils/headers.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use futures::{Future, FutureExt, Stream};
 use reth_eth_wire::BlockHeaders;
-use reth_primitives::{BlockLocked, Header, SealedHeader, H256, U256};
+use reth_primitives::{BlockLocked, Header, HeadersDirection, SealedHeader, H256, U256};
 use reth_rpc_types::engine::ForkchoiceState;
 use std::{
     pin::Pin,
@@ -88,7 +88,7 @@ impl Future for TestDownload {
 
         let request = HeadersRequest {
             limit: self.limit,
-            reverse: true,
+            direction: HeadersDirection::Rising,
             start: reth_primitives::BlockHashOrNumber::Number(0), // ignored
         };
         match ready!(self.client.get_headers(request).poll_unpin(cx)) {

--- a/crates/net/eth-wire/src/types/blocks.rs
+++ b/crates/net/eth-wire/src/types/blocks.rs
@@ -1,7 +1,7 @@
 //! Implements the `GetBlockHeaders`, `GetBlockBodies`, `BlockHeaders`, and `BlockBodies` message
 //! types.
 use super::RawBlockBody;
-use reth_primitives::{BlockHashOrNumber, Header, TransactionSigned, H256};
+use reth_primitives::{BlockHashOrNumber, Header, HeadersDirection, TransactionSigned, H256};
 use reth_rlp::{RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper};
 
 /// A request for a peer to return block headers starting at the requested block.
@@ -27,8 +27,8 @@ pub struct GetBlockHeaders {
     /// [`limit`](#structfield.limit) headers.
     pub skip: u32,
 
-    /// Whether or not the headers should be returned in reverse order.
-    pub reverse: bool,
+    /// The direction in which the headers should be returned in.
+    pub direction: HeadersDirection,
 }
 
 /// The response to [`GetBlockHeaders`], containing headers if any headers were found.
@@ -172,7 +172,7 @@ mod test {
                 ),
                 limit: 5,
                 skip: 5,
-                reverse: false,
+                direction: Default::default(),
             },
         }
         .encode(&mut data);
@@ -193,7 +193,7 @@ mod test {
                 ),
                 limit: 5,
                 skip: 5,
-                reverse: false,
+                direction: Default::default(),
             },
         };
         let result = RequestPair::decode(&mut &data[..]);
@@ -211,7 +211,7 @@ mod test {
                 start_block: BlockHashOrNumber::Number(9999),
                 limit: 5,
                 skip: 5,
-                reverse: false,
+                direction: Default::default(),
             },
         }
         .encode(&mut data);
@@ -228,7 +228,7 @@ mod test {
                 start_block: BlockHashOrNumber::Number(9999),
                 limit: 5,
                 skip: 5,
-                reverse: false,
+                direction: Default::default(),
             },
         };
         let result = RequestPair::decode(&mut &data[..]);

--- a/crates/net/headers-downloaders/src/linear.rs
+++ b/crates/net/headers-downloaders/src/linear.rs
@@ -11,7 +11,7 @@ use reth_interfaces::{
         traits::BatchDownload,
     },
 };
-use reth_primitives::{SealedHeader, H256};
+use reth_primitives::{HeadersDirection, SealedHeader, H256};
 use reth_rpc_types::engine::ForkchoiceState;
 use std::{
     borrow::Borrow,
@@ -148,7 +148,11 @@ where
     }
 
     fn headers_request(&self) -> HeadersRequest {
-        HeadersRequest { start: self.request_start().into(), limit: self.batch_size, reverse: true }
+        HeadersRequest {
+            start: self.request_start().into(),
+            limit: self.batch_size,
+            direction: HeadersDirection::Rising,
+        }
     }
 
     /// Tries to fuse the future with a new request

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -10,7 +10,7 @@ use reth_interfaces::{
     p2p::error::RequestResult,
     provider::{BlockProvider, HeaderProvider},
 };
-use reth_primitives::{BlockHashOrNumber, Header, PeerId};
+use reth_primitives::{BlockHashOrNumber, Header, HeadersDirection, PeerId};
 use std::{
     borrow::Borrow,
     future::Future,
@@ -77,9 +77,8 @@ where
 
     /// Returns the list of requested heders
     fn get_headers_response(&self, request: GetBlockHeaders) -> Vec<Header> {
-        let GetBlockHeaders { start_block, limit, skip, reverse } = request;
+        let GetBlockHeaders { start_block, limit, skip, direction } = request;
 
-        let direction = HeadersDirection::new(reverse);
         let mut headers = Vec::new();
 
         let mut block: BlockHashOrNumber = match start_block {
@@ -213,30 +212,6 @@ where
                     IncomingEthRequest::GetReceipts { .. } => {}
                 },
             }
-        }
-    }
-}
-
-/// Represents the direction for a headers request depending on the `reverse` field of the request.
-///
-/// [`HeadersDirection::Rising`] block numbers for `reverse == true`
-/// [`HeadersDirection::Falling`] block numbers for `reverse == false`
-///
-/// See also <https://github.com/ethereum/devp2p/blob/master/caps/eth.md#getblockheaders-0x03>
-#[derive(Copy, Clone)]
-pub enum HeadersDirection {
-    /// Rising block number.
-    Rising,
-    /// Falling block number.
-    Falling,
-}
-
-impl HeadersDirection {
-    fn new(reverse: bool) -> Self {
-        if reverse {
-            HeadersDirection::Rising
-        } else {
-            HeadersDirection::Falling
         }
     }
 }

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -152,12 +152,12 @@ impl StateFetcher {
             DownloadRequest::GetBlockHeaders { request, response } => {
                 let inflight = Request { request: request.clone(), response };
                 self.inflight_headers_requests.insert(peer_id, inflight);
-                let HeadersRequest { start, limit, reverse } = request;
+                let HeadersRequest { start, limit, direction } = request;
                 BlockRequest::GetBlockHeaders(GetBlockHeaders {
                     start_block: start,
                     limit,
                     skip: 0,
-                    reverse,
+                    direction,
                 })
             }
             DownloadRequest::GetBlockBodies { request, response } => {

--- a/crates/net/network/tests/it/requests.rs
+++ b/crates/net/network/tests/it/requests.rs
@@ -9,8 +9,8 @@ use reth_interfaces::p2p::{
     headers::client::{HeadersClient, HeadersRequest},
 };
 use reth_primitives::{
-    Block, Bytes, Header, Signature, Transaction, TransactionKind, TransactionSigned, TxEip2930,
-    H256, U256,
+    Block, Bytes, Header, HeadersDirection, Signature, Transaction, TransactionKind,
+    TransactionSigned, TxEip2930, H256, U256,
 };
 use std::sync::Arc;
 
@@ -108,7 +108,8 @@ async fn test_get_header() {
 
         mock_provider.add_header(hash, header.clone());
 
-        let req = HeadersRequest { start: hash.into(), limit: 1, reverse: false };
+        let req =
+            HeadersRequest { start: hash.into(), limit: 1, direction: HeadersDirection::Rising };
 
         let res = fetch0.get_headers(req).await;
         assert!(res.is_ok());

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -269,6 +269,79 @@ impl SealedHeader {
     }
 }
 
+/// Represents the direction for a headers request depending on the `reverse` field of the request.
+///
+/// [`HeadersDirection::Rising`] block numbers for `reverse == true`
+/// [`HeadersDirection::Falling`] block numbers for `reverse == false`
+///
+/// See also <https://github.com/ethereum/devp2p/blob/master/caps/eth.md#getblockheaders-0x03>
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Default)]
+pub enum HeadersDirection {
+    /// Falling block number.
+    #[default]
+    Falling,
+    /// Rising block number.
+    Rising,
+}
+
+impl HeadersDirection {
+    /// Returns true for rising block numbers
+    pub fn is_rising(&self) -> bool {
+        matches!(self, HeadersDirection::Rising)
+    }
+
+    /// Returns true for falling block numbers
+    pub fn is_falling(&self) -> bool {
+        matches!(self, HeadersDirection::Falling)
+    }
+
+    /// Converts the bool into a direction.
+    ///
+    /// Returns:
+    ///
+    /// [`HeadersDirection::Rising`] block numbers for `reverse == true`
+    /// [`HeadersDirection::Falling`] block numbers for `reverse == false`
+    pub fn new(reverse: bool) -> Self {
+        if reverse {
+            HeadersDirection::Rising
+        } else {
+            HeadersDirection::Falling
+        }
+    }
+}
+
+impl Encodable for HeadersDirection {
+    fn encode(&self, out: &mut dyn BufMut) {
+        bool::from(*self).encode(out)
+    }
+
+    fn length(&self) -> usize {
+        bool::from(*self).length()
+    }
+}
+
+impl Decodable for HeadersDirection {
+    fn decode(buf: &mut &[u8]) -> Result<Self, reth_rlp::DecodeError> {
+        let value: bool = Decodable::decode(buf)?;
+        Ok(value.into())
+    }
+}
+
+impl From<bool> for HeadersDirection {
+    fn from(reverse: bool) -> Self {
+        Self::new(reverse)
+    }
+}
+
+impl From<HeadersDirection> for bool {
+    fn from(value: HeadersDirection) -> Self {
+        match value {
+            HeadersDirection::Rising => true,
+            HeadersDirection::Falling => false,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{Decodable, Encodable, Header, H256};

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -36,7 +36,7 @@ pub use constants::{EMPTY_OMMER_ROOT, KECCAK_EMPTY, MAINNET_GENESIS};
 pub use ethbloom::Bloom;
 pub use forkid::{ForkFilter, ForkHash, ForkId, ValidationError};
 pub use hardfork::Hardfork;
-pub use header::{Header, SealedHeader};
+pub use header::{Header, HeadersDirection, SealedHeader};
 pub use hex_bytes::Bytes;
 pub use integer_list::IntegerList;
 pub use jsonu256::JsonU256;


### PR DESCRIPTION
This replaces `reverse: bool`, with `direction: HeadersDirection{Falling, Rising}`

`reverse` can be confusing, because you need to know what's normal.
