### PR TITLE
test: add mainnet connection test

### DIFF
--- a/crates/net/eth-wire/src/error.rs
+++ b/crates/net/eth-wire/src/error.rs
@@ -112,6 +112,8 @@ pub enum P2PHandshakeError {
     NoResponse,
     #[error("handshake timed out")]
     Timeout,
+    #[error("Disconnected by peer: {0}")]
+    Disconnected(DisconnectReason),
 }
 
 /// An error that can occur when interacting with a [`Pinger`].

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -147,6 +147,12 @@ impl<C> NetworkConfigBuilder<C> {
         self
     }
 
+    /// Sets the discv4 config to use.
+    pub fn discovery(mut self, builder: Discv4ConfigBuilder) -> Self {
+        self.discovery_v4_builder = builder;
+        self
+    }
+
     /// Consumes the type and creates the actual [`NetworkConfig`]
     pub fn build(self) -> NetworkConfig<C> {
         let Self {


### PR DESCRIPTION
try connecting to live net via mainnet bootnodes

handshake is directly disconnected by remote.
This adds support for handling the disconnect message during handshake

Perhaps this is a config/status/protocol issue, mind taking a closer look @Rjected ?

I also noticed unknown message ids of 128

```
RUST_LOG=net,reth_eth_wire cargo t test_connect_with_boot_nodes -- --nocapture // rm ignore annotation first
```