### PR TITLE
feat(db): cursor `insert`

### DIFF
--- a/crates/db/src/kv/cursor.rs
+++ b/crates/db/src/kv/cursor.rs
@@ -128,6 +128,12 @@ impl<'tx, T: Table> DbCursorRW<'tx, T> for Cursor<'tx, RW, T> {
             .map_err(|e| Error::Write(e.into()))
     }
 
+    fn insert(&mut self, key: T::Key, value: T::Value) -> Result<(), Error> {
+        self.inner
+            .put(key.encode().as_ref(), value.compress().as_ref(), WriteFlags::NO_OVERWRITE)
+            .map_err(|e| Error::Write(e.into()))
+    }
+
     /// Appends the data to the end of the table. Consequently, the append operation
     /// will fail if the inserted key is less than the last table key
     fn append(&mut self, key: T::Key, value: T::Value) -> Result<(), Error> {

--- a/crates/interfaces/src/db/mock.rs
+++ b/crates/interfaces/src/db/mock.rs
@@ -176,6 +176,14 @@ impl<'tx, T: Table> DbCursorRW<'tx, T> for CursorMock {
         todo!()
     }
 
+    fn insert(
+        &mut self,
+        _key: <T as Table>::Key,
+        _value: <T as Table>::Value,
+    ) -> Result<(), super::Error> {
+        todo!()
+    }
+
     fn append(
         &mut self,
         _key: <T as Table>::Key,

--- a/crates/interfaces/src/db/mod.rs
+++ b/crates/interfaces/src/db/mod.rs
@@ -190,6 +190,10 @@ pub trait DbCursorRW<'tx, T: Table> {
     /// exists in a table, and insert a new row if the specified value doesn't already exist
     fn upsert(&mut self, key: T::Key, value: T::Value) -> Result<(), Error>;
 
+    /// Database operation that will insert a row at a given key. If the key is already
+    /// present, the operation will result in an error.
+    fn insert(&mut self, key: T::Key, value: T::Value) -> Result<(), Error>;
+
     /// Append value to next cursor item.
     ///
     /// This is efficient for pre-sorted data. If the data is not pre-sorted, use [`insert`].


### PR DESCRIPTION
Expose the mdbx cursor insert functionality through `WriteFlags::NO_OVERWRITE` flag