### PR TITLE
chore(rlp): add comment on `0x80` decoding

### DIFF
--- a/crates/common/rlp/src/decode.rs
+++ b/crates/common/rlp/src/decode.rs
@@ -185,6 +185,12 @@ macro_rules! decode_integer {
                 if buf.remaining() < h.payload_length {
                     return Err(DecodeError::InputTooShort)
                 }
+                // In the case of 0x80, the Header will be decoded, leaving h.payload_length to be
+                // zero.
+                // 0x80 is the canonical encoding of 0, so we return 0 here.
+                if h.payload_length == 0 {
+                    return Ok(<$t>::from(0u8))
+                }
                 let v = <$t>::from_be_bytes(
                     static_left_pad(&buf[..h.payload_length]).ok_or(DecodeError::LeadingZero)?,
                 );

--- a/crates/common/rlp/src/decode.rs
+++ b/crates/common/rlp/src/decode.rs
@@ -258,6 +258,12 @@ mod ethereum_types_support {
                     if buf.remaining() < h.payload_length {
                         return Err(DecodeError::InputTooShort)
                     }
+                    // In the case of 0x80, the Header will be decoded, leaving h.payload_length to
+                    // be zero.
+                    // 0x80 is the canonical encoding of 0, so we return 0 here.
+                    if h.payload_length == 0 {
+                        return Ok(<$t>::from(0u8))
+                    }
                     let n = <$t>::from_big_endian(
                         &static_left_pad::<$n_bytes>(&buf[..h.payload_length])
                             .ok_or(DecodeError::LeadingZero)?,


### PR DESCRIPTION
The previous method correctly decodes `0x80`, but this makes it an explicit case and adds a comment about what happens when `0x80` is decoded as an integer.