### PR TITLE
fix(eth-wire): handle `0x80` for DisconnectReason and P2PMessageID

### DIFF
--- a/crates/common/rlp/src/encode.rs
+++ b/crates/common/rlp/src/encode.rs
@@ -552,6 +552,7 @@ mod tests {
     #[test]
     fn rlp_list() {
         assert_eq!(encoded_list::<u64>(&[]), &hex!("c0")[..]);
+        assert_eq!(encoded_list::<u8>(&[0x00u8]), &hex!("c180")[..]);
         assert_eq!(encoded_list(&[0xFFCCB5_u64, 0xFFC0B5_u64]), &hex!("c883ffccb583ffc0b5")[..]);
     }
 

--- a/crates/net/eth-wire/src/disconnect.rs
+++ b/crates/net/eth-wire/src/disconnect.rs
@@ -1,0 +1,207 @@
+use std::fmt::Display;
+
+use bytes::Buf;
+use reth_rlp::{Decodable, DecodeError, Encodable};
+
+/// RLPx disconnect reason.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DisconnectReason {
+    /// Disconnect requested by the local node or remote peer.
+    DisconnectRequested = 0x00,
+    /// TCP related error
+    TcpSubsystemError = 0x01,
+    /// Breach of protocol at the transport or p2p level
+    ProtocolBreach = 0x02,
+    /// Node has no matching protocols.
+    UselessPeer = 0x03,
+    /// Either the remote or local node has too many peers.
+    TooManyPeers = 0x04,
+    /// Already connected to the peer.
+    AlreadyConnected = 0x05,
+    /// `p2p` protocol version is incompatible
+    IncompatibleP2PProtocolVersion = 0x06,
+    NullNodeIdentity = 0x07,
+    ClientQuitting = 0x08,
+    UnexpectedHandshakeIdentity = 0x09,
+    /// The node is connected to itself
+    ConnectedToSelf = 0x0a,
+    /// Peer or local node did not respond to a ping in time.
+    PingTimeout = 0x0b,
+    /// Peer or local node violated a subprotocol-specific rule.
+    SubprotocolSpecific = 0x10,
+}
+
+impl Display for DisconnectReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let message = match self {
+            DisconnectReason::DisconnectRequested => "Disconnect requested",
+            DisconnectReason::TcpSubsystemError => "TCP sub-system error",
+            DisconnectReason::ProtocolBreach => {
+                "Breach of protocol, e.g. a malformed message, bad RLP, ..."
+            }
+            DisconnectReason::UselessPeer => "Useless peer",
+            DisconnectReason::TooManyPeers => "Too many peers",
+            DisconnectReason::AlreadyConnected => "Already connected",
+            DisconnectReason::IncompatibleP2PProtocolVersion => "Incompatible P2P protocol version",
+            DisconnectReason::NullNodeIdentity => {
+                "Null node identity received - this is automatically invalid"
+            }
+            DisconnectReason::ClientQuitting => "Client quitting",
+            DisconnectReason::UnexpectedHandshakeIdentity => "Unexpected identity in handshake",
+            DisconnectReason::ConnectedToSelf => {
+                "Identity is the same as this node (i.e. connected to itself)"
+            }
+            DisconnectReason::PingTimeout => "Ping timeout",
+            DisconnectReason::SubprotocolSpecific => "Some other reason specific to a subprotocol",
+        };
+
+        write!(f, "{message}")
+    }
+}
+
+/// This represents an unknown disconnect reason with the given code.
+#[derive(Debug, Clone)]
+pub struct UnknownDisconnectReason(u8);
+
+impl TryFrom<u8> for DisconnectReason {
+    // This error type should not be used to crash the node, but rather to log the error and
+    // disconnect the peer.
+    type Error = UnknownDisconnectReason;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0x00 => Ok(DisconnectReason::DisconnectRequested),
+            0x01 => Ok(DisconnectReason::TcpSubsystemError),
+            0x02 => Ok(DisconnectReason::ProtocolBreach),
+            0x03 => Ok(DisconnectReason::UselessPeer),
+            0x04 => Ok(DisconnectReason::TooManyPeers),
+            0x05 => Ok(DisconnectReason::AlreadyConnected),
+            0x06 => Ok(DisconnectReason::IncompatibleP2PProtocolVersion),
+            0x07 => Ok(DisconnectReason::NullNodeIdentity),
+            0x08 => Ok(DisconnectReason::ClientQuitting),
+            0x09 => Ok(DisconnectReason::UnexpectedHandshakeIdentity),
+            0x0a => Ok(DisconnectReason::ConnectedToSelf),
+            0x0b => Ok(DisconnectReason::PingTimeout),
+            0x10 => Ok(DisconnectReason::SubprotocolSpecific),
+            _ => Err(UnknownDisconnectReason(value)),
+        }
+    }
+}
+
+impl Encodable for DisconnectReason {
+    fn encode(&self, out: &mut dyn bytes::BufMut) {
+        // disconnect reasons are snappy encoded as follows:
+        // [0x02, 0x04, 0xc1, reason as u8]
+        // this is 3 bytes
+        out.put_u8(0x02);
+        out.put_u8(0x04);
+        out.put_u8(0xc1);
+        out.put_u8(*self as u8);
+    }
+    fn length(&self) -> usize {
+        // disconnect reasons are snappy encoded as follows:
+        // [0x02, 0x04, 0xc1, reason as u8]
+        // this is 4 bytes
+        4
+    }
+}
+
+impl Decodable for DisconnectReason {
+    fn decode(buf: &mut &[u8]) -> Result<Self, DecodeError> {
+        if buf.len() < 4 {
+            return Err(DecodeError::Custom("disconnect reason should have 4 bytes"))
+        }
+        println!("{:x?}", buf);
+
+        let first = buf[0];
+        if first != 0x02 {
+            return Err(DecodeError::Custom("invalid disconnect reason - invalid snappy header"))
+        }
+
+        let second = buf[1];
+        if second != 0x04 {
+            // TODO: make sure this error message is correct
+            return Err(DecodeError::Custom("invalid disconnect reason - invalid snappy header"))
+        }
+
+        let third = buf[2];
+        if third != 0xc1 {
+            return Err(DecodeError::Custom("invalid disconnect reason - invalid rlp header"))
+        }
+
+        let reason = buf[3];
+        let reason = DisconnectReason::try_from(reason)
+            .map_err(|_| DecodeError::Custom("unknown disconnect reason"))?;
+        buf.advance(4);
+        Ok(reason)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{p2pstream::P2PMessage, DisconnectReason};
+    use reth_rlp::{Decodable, Encodable};
+
+    #[test]
+    fn disconnect_round_trip() {
+        let all_reasons = vec![
+            DisconnectReason::DisconnectRequested,
+            DisconnectReason::TcpSubsystemError,
+            DisconnectReason::ProtocolBreach,
+            DisconnectReason::UselessPeer,
+            DisconnectReason::TooManyPeers,
+            DisconnectReason::AlreadyConnected,
+            DisconnectReason::IncompatibleP2PProtocolVersion,
+            DisconnectReason::NullNodeIdentity,
+            DisconnectReason::ClientQuitting,
+            DisconnectReason::UnexpectedHandshakeIdentity,
+            DisconnectReason::ConnectedToSelf,
+            DisconnectReason::PingTimeout,
+            DisconnectReason::SubprotocolSpecific,
+        ];
+
+        for reason in all_reasons {
+            let disconnect = P2PMessage::Disconnect(reason);
+
+            let mut disconnect_encoded = Vec::new();
+            disconnect.encode(&mut disconnect_encoded);
+
+            let disconnect_decoded = P2PMessage::decode(&mut &disconnect_encoded[..]).unwrap();
+
+            assert_eq!(disconnect, disconnect_decoded);
+        }
+    }
+
+    #[test]
+    fn test_reason_too_short() {
+        assert!(DisconnectReason::decode(&mut &[0u8][..]).is_err())
+    }
+
+    #[test]
+    fn disconnect_encoding_length() {
+        let all_reasons = vec![
+            DisconnectReason::DisconnectRequested,
+            DisconnectReason::TcpSubsystemError,
+            DisconnectReason::ProtocolBreach,
+            DisconnectReason::UselessPeer,
+            DisconnectReason::TooManyPeers,
+            DisconnectReason::AlreadyConnected,
+            DisconnectReason::IncompatibleP2PProtocolVersion,
+            DisconnectReason::NullNodeIdentity,
+            DisconnectReason::ClientQuitting,
+            DisconnectReason::UnexpectedHandshakeIdentity,
+            DisconnectReason::ConnectedToSelf,
+            DisconnectReason::PingTimeout,
+            DisconnectReason::SubprotocolSpecific,
+        ];
+
+        for reason in all_reasons {
+            let disconnect = P2PMessage::Disconnect(reason);
+
+            let mut disconnect_encoded = Vec::new();
+            disconnect.encode(&mut disconnect_encoded);
+
+            assert_eq!(disconnect_encoded.len(), disconnect.length());
+        }
+    }
+}

--- a/crates/net/eth-wire/src/disconnect.rs
+++ b/crates/net/eth-wire/src/disconnect.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use bytes::Buf;
-use reth_rlp::{Decodable, DecodeError, Encodable};
+use reth_rlp::{Decodable, DecodeError, Encodable, EMPTY_LIST_CODE};
 use thiserror::Error;
 
 /// RLPx disconnect reason.
@@ -129,7 +129,7 @@ impl Decodable for DisconnectReason {
         }
 
         let third = buf[2];
-        if third != 0xc1 {
+        if third != EMPTY_LIST_CODE + 1 {
             return Err(DecodeError::Custom("invalid disconnect reason - invalid rlp header"))
         }
 

--- a/crates/net/eth-wire/src/disconnect.rs
+++ b/crates/net/eth-wire/src/disconnect.rs
@@ -143,7 +143,10 @@ impl Decodable for DisconnectReason {
 
 #[cfg(test)]
 mod tests {
-    use crate::{p2pstream::{P2PMessage, P2PMessageID}, DisconnectReason};
+    use crate::{
+        p2pstream::{P2PMessage, P2PMessageID},
+        DisconnectReason,
+    };
     use reth_rlp::{Decodable, Encodable};
 
     #[test]

--- a/crates/net/eth-wire/src/error.rs
+++ b/crates/net/eth-wire/src/error.rs
@@ -3,7 +3,9 @@ use std::io;
 
 use reth_primitives::{Chain, ValidationError, H256};
 
-use crate::{capability::SharedCapabilityError, DisconnectReason, disconnect::UnknownDisconnectReason};
+use crate::{
+    capability::SharedCapabilityError, disconnect::UnknownDisconnectReason, DisconnectReason,
+};
 
 /// Errors when sending/receiving messages
 #[derive(thiserror::Error, Debug)]

--- a/crates/net/eth-wire/src/error.rs
+++ b/crates/net/eth-wire/src/error.rs
@@ -3,7 +3,7 @@ use std::io;
 
 use reth_primitives::{Chain, ValidationError, H256};
 
-use crate::{capability::SharedCapabilityError, DisconnectReason};
+use crate::{capability::SharedCapabilityError, DisconnectReason, disconnect::UnknownDisconnectReason};
 
 /// Errors when sending/receiving messages
 #[derive(thiserror::Error, Debug)]
@@ -84,6 +84,8 @@ pub enum P2PStreamError {
     SendBufferFull,
     #[error("disconnected")]
     Disconnected(DisconnectReason),
+    #[error("unknown disconnect reason: {0}")]
+    UnknownDisconnectReason(#[from] UnknownDisconnectReason),
 }
 
 // === impl P2PStreamError ===

--- a/crates/net/eth-wire/src/lib.rs
+++ b/crates/net/eth-wire/src/lib.rs
@@ -13,6 +13,7 @@ pub use tokio_util::codec::{
 };
 pub mod builder;
 pub mod capability;
+mod disconnect;
 pub mod error;
 mod ethstream;
 mod p2pstream;
@@ -22,6 +23,7 @@ pub mod types;
 pub use types::*;
 
 pub use crate::{
+    disconnect::DisconnectReason,
     ethstream::{EthStream, UnauthedEthStream, MAX_MESSAGE_SIZE},
-    p2pstream::{DisconnectReason, HelloMessage, P2PStream, ProtocolVersion, UnauthedP2PStream},
+    p2pstream::{HelloMessage, P2PStream, ProtocolVersion, UnauthedP2PStream},
 };

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -116,7 +116,7 @@ where
                 // DisconnectReason::DisconnectRequested, and the TryFrom implementation ensures
                 // that the disconnect reason is known.
                 let disconnect_id = u8::decode(&mut &first_message_bytes[1..])?;
-                let reason =  DisconnectReason::try_from(disconnect_id)?;
+                let reason = DisconnectReason::try_from(disconnect_id)?;
 
                 tracing::error!("Disconnected by peer during handshake: {}", reason);
                 return Err(P2PStreamError::HandshakeError(P2PHandshakeError::Disconnected(reason)))

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -3,6 +3,7 @@ use crate::{
     capability::{Capability, SharedCapability},
     error::{P2PHandshakeError, P2PStreamError},
     pinger::{Pinger, PingerEvent},
+    DisconnectReason,
 };
 use bytes::{Buf, Bytes, BytesMut};
 use futures::{Sink, SinkExt, StreamExt};
@@ -11,7 +12,6 @@ use reth_primitives::H512 as PeerId;
 use reth_rlp::{Decodable, DecodeError, Encodable, RlpDecodable, RlpEncodable};
 use std::{
     collections::{BTreeSet, HashMap, VecDeque},
-    fmt::Display,
     io,
     pin::Pin,
     task::{ready, Context, Poll},
@@ -680,144 +680,10 @@ impl Decodable for ProtocolVersion {
     }
 }
 
-/// RLPx disconnect reason.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum DisconnectReason {
-    /// Disconnect requested by the local node or remote peer.
-    DisconnectRequested = 0x00,
-    /// TCP related error
-    TcpSubsystemError = 0x01,
-    /// Breach of protocol at the transport or p2p level
-    ProtocolBreach = 0x02,
-    /// Node has no matching protocols.
-    UselessPeer = 0x03,
-    /// Either the remote or local node has too many peers.
-    TooManyPeers = 0x04,
-    /// Already connected to the peer.
-    AlreadyConnected = 0x05,
-    /// `p2p` protocol version is incompatible
-    IncompatibleP2PProtocolVersion = 0x06,
-    NullNodeIdentity = 0x07,
-    ClientQuitting = 0x08,
-    UnexpectedHandshakeIdentity = 0x09,
-    /// The node is connected to itself
-    ConnectedToSelf = 0x0a,
-    /// Peer or local node did not respond to a ping in time.
-    PingTimeout = 0x0b,
-    /// Peer or local node violated a subprotocol-specific rule.
-    SubprotocolSpecific = 0x10,
-}
-
-impl Display for DisconnectReason {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let message = match self {
-            DisconnectReason::DisconnectRequested => "Disconnect requested",
-            DisconnectReason::TcpSubsystemError => "TCP sub-system error",
-            DisconnectReason::ProtocolBreach => {
-                "Breach of protocol, e.g. a malformed message, bad RLP, ..."
-            }
-            DisconnectReason::UselessPeer => "Useless peer",
-            DisconnectReason::TooManyPeers => "Too many peers",
-            DisconnectReason::AlreadyConnected => "Already connected",
-            DisconnectReason::IncompatibleP2PProtocolVersion => "Incompatible P2P protocol version",
-            DisconnectReason::NullNodeIdentity => {
-                "Null node identity received - this is automatically invalid"
-            }
-            DisconnectReason::ClientQuitting => "Client quitting",
-            DisconnectReason::UnexpectedHandshakeIdentity => "Unexpected identity in handshake",
-            DisconnectReason::ConnectedToSelf => {
-                "Identity is the same as this node (i.e. connected to itself)"
-            }
-            DisconnectReason::PingTimeout => "Ping timeout",
-            DisconnectReason::SubprotocolSpecific => "Some other reason specific to a subprotocol",
-        };
-
-        write!(f, "{message}")
-    }
-}
-
-/// This represents an unknown disconnect reason with the given code.
-#[derive(Debug, Clone)]
-pub struct UnknownDisconnectReason(u8);
-
-impl TryFrom<u8> for DisconnectReason {
-    // This error type should not be used to crash the node, but rather to log the error and
-    // disconnect the peer.
-    type Error = UnknownDisconnectReason;
-
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value {
-            0x00 => Ok(DisconnectReason::DisconnectRequested),
-            0x01 => Ok(DisconnectReason::TcpSubsystemError),
-            0x02 => Ok(DisconnectReason::ProtocolBreach),
-            0x03 => Ok(DisconnectReason::UselessPeer),
-            0x04 => Ok(DisconnectReason::TooManyPeers),
-            0x05 => Ok(DisconnectReason::AlreadyConnected),
-            0x06 => Ok(DisconnectReason::IncompatibleP2PProtocolVersion),
-            0x07 => Ok(DisconnectReason::NullNodeIdentity),
-            0x08 => Ok(DisconnectReason::ClientQuitting),
-            0x09 => Ok(DisconnectReason::UnexpectedHandshakeIdentity),
-            0x0a => Ok(DisconnectReason::ConnectedToSelf),
-            0x0b => Ok(DisconnectReason::PingTimeout),
-            0x10 => Ok(DisconnectReason::SubprotocolSpecific),
-            _ => Err(UnknownDisconnectReason(value)),
-        }
-    }
-}
-
-impl Encodable for DisconnectReason {
-    fn encode(&self, out: &mut dyn bytes::BufMut) {
-        // disconnect reasons are snappy encoded as follows:
-        // [0x02, 0x04, 0xc1, reason as u8]
-        // this is 3 bytes
-        out.put_u8(0x02);
-        out.put_u8(0x04);
-        out.put_u8(0xc1);
-        out.put_u8(*self as u8);
-    }
-    fn length(&self) -> usize {
-        // disconnect reasons are snappy encoded as follows:
-        // [0x02, 0x04, 0xc1, reason as u8]
-        // this is 4 bytes
-        4
-    }
-}
-
-impl Decodable for DisconnectReason {
-    fn decode(buf: &mut &[u8]) -> Result<Self, DecodeError> {
-        if buf.len() < 4 {
-            return Err(DecodeError::Custom("disconnect reason should have 4 bytes"))
-        }
-        println!("{:x?}", buf);
-
-        let first = buf[0];
-        if first != 0x02 {
-            return Err(DecodeError::Custom("invalid disconnect reason - invalid snappy header"))
-        }
-
-        let second = buf[1];
-        if second != 0x04 {
-            // TODO: make sure this error message is correct
-            return Err(DecodeError::Custom("invalid disconnect reason - invalid snappy header"))
-        }
-
-        let third = buf[2];
-        if third != 0xc1 {
-            return Err(DecodeError::Custom("invalid disconnect reason - invalid rlp header"))
-        }
-
-        let reason = buf[3];
-        let reason = DisconnectReason::try_from(reason)
-            .map_err(|_| DecodeError::Custom("unknown disconnect reason"))?;
-        buf.advance(4);
-        Ok(reason)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::EthVersion;
+    use crate::{DisconnectReason, EthVersion};
     use reth_ecies::util::pk2id;
     use reth_rlp::EMPTY_STRING_CODE;
     use secp256k1::{SecretKey, SECP256K1};
@@ -1089,68 +955,5 @@ mod tests {
         hello.encode(&mut hello_encoded);
 
         assert_eq!(hello_encoded[0], P2PMessageID::Hello as u8);
-    }
-
-    #[test]
-    fn disconnect_round_trip() {
-        let all_reasons = vec![
-            DisconnectReason::DisconnectRequested,
-            DisconnectReason::TcpSubsystemError,
-            DisconnectReason::ProtocolBreach,
-            DisconnectReason::UselessPeer,
-            DisconnectReason::TooManyPeers,
-            DisconnectReason::AlreadyConnected,
-            DisconnectReason::IncompatibleP2PProtocolVersion,
-            DisconnectReason::NullNodeIdentity,
-            DisconnectReason::ClientQuitting,
-            DisconnectReason::UnexpectedHandshakeIdentity,
-            DisconnectReason::ConnectedToSelf,
-            DisconnectReason::PingTimeout,
-            DisconnectReason::SubprotocolSpecific,
-        ];
-
-        for reason in all_reasons {
-            let disconnect = P2PMessage::Disconnect(reason);
-
-            let mut disconnect_encoded = Vec::new();
-            disconnect.encode(&mut disconnect_encoded);
-
-            let disconnect_decoded = P2PMessage::decode(&mut &disconnect_encoded[..]).unwrap();
-
-            assert_eq!(disconnect, disconnect_decoded);
-        }
-    }
-
-    #[test]
-    fn test_reason_too_short() {
-        assert!(DisconnectReason::decode(&mut &[0u8][..]).is_err())
-    }
-
-    #[test]
-    fn disconnect_encoding_length() {
-        let all_reasons = vec![
-            DisconnectReason::DisconnectRequested,
-            DisconnectReason::TcpSubsystemError,
-            DisconnectReason::ProtocolBreach,
-            DisconnectReason::UselessPeer,
-            DisconnectReason::TooManyPeers,
-            DisconnectReason::AlreadyConnected,
-            DisconnectReason::IncompatibleP2PProtocolVersion,
-            DisconnectReason::NullNodeIdentity,
-            DisconnectReason::ClientQuitting,
-            DisconnectReason::UnexpectedHandshakeIdentity,
-            DisconnectReason::ConnectedToSelf,
-            DisconnectReason::PingTimeout,
-            DisconnectReason::SubprotocolSpecific,
-        ];
-
-        for reason in all_reasons {
-            let disconnect = P2PMessage::Disconnect(reason);
-
-            let mut disconnect_encoded = Vec::new();
-            disconnect.encode(&mut disconnect_encoded);
-
-            assert_eq!(disconnect_encoded.len(), disconnect.length());
-        }
     }
 }


### PR DESCRIPTION
This includes three main fixes:
 - Decode `0x80` into `0x00` for disconnect reasons and p2p message IDs. fixes #311
 - Decode disconnect reasons pre-p2p-handshake from the uncompressed format. fixes #308
 - Correct manual snappy encoding / decoding for `Disconnect`

The `Encodable` and `Decodable` implementation for `P2PMessage` is documented with our assumptions about whether or not a message is snappy encoded.
`DisconnectReason` is moved to a separate file.

Two tests are added to check the correctness of the manual snappy encoding. One checks that the `Disconnect` encoding matches the snappy encoding, and the other checks that the `Disconnect` encoding can be snappy decompressed to the correct value.

This documents that the first message must be either a `Hello` or `Disconnect` message.

An extra test case is added for rlp-encoding `[0u8]`, showing that it is indeed encoded as `c180`.
