### PR TITLE
perf(disc): instantly lookup self in DHT

### DIFF
--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -321,10 +321,7 @@ impl Discv4Service {
 
         // delay the first lookup for a bit to give the bootstrap process a chance to resolve
         // entries first
-        let self_lookup_interval = tokio::time::interval_at(
-            tokio::time::Instant::now() + config.ping_timeout / 2,
-            config.lookup_interval,
-        );
+        let self_lookup_interval = tokio::time::interval(config.lookup_interval);
 
         let ping_interval = tokio::time::interval(config.ping_interval);
 

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -319,8 +319,6 @@ impl Discv4Service {
             None,
         );
 
-        // delay the first lookup for a bit to give the bootstrap process a chance to resolve
-        // entries first
         let self_lookup_interval = tokio::time::interval(config.lookup_interval);
 
         let ping_interval = tokio::time::interval(config.ping_interval);


### PR DESCRIPTION
This sets the interval for looking up own node in DHT to `now` and removes delays, this will trigger a lookup instantly