### PR TITLE
perf(net): exclude bootnodes from update stream

### DIFF
--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -113,7 +113,7 @@ where
         let NetworkConfig {
             client,
             secret_key,
-            discovery_v4_config,
+            mut discovery_v4_config,
             discovery_addr,
             listener_addr,
             peers_config,
@@ -121,6 +121,7 @@ where
             genesis_hash,
             block_import,
             network_mode,
+            boot_nodes,
             ..
         } = config;
 
@@ -130,6 +131,8 @@ where
         let incoming = ConnectionListener::bind(listener_addr).await?;
         let listener_address = Arc::new(Mutex::new(incoming.local_address()));
 
+        // merge configured boot nodes
+        discovery_v4_config.bootstrap_nodes.extend(boot_nodes.clone());
         let discovery = Discovery::new(discovery_addr, secret_key, discovery_v4_config).await?;
         // need to retrieve the addr here since provided port could be `0`
         let local_peer_id = discovery.local_id();

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -359,6 +359,7 @@ impl SessionManager {
                     target : "net::session",
                     ?session_id,
                     ?remote_addr,
+                    ?error,
                     "disconnected pending session"
                 );
                 self.remove_pending_session(&session_id);


### PR DESCRIPTION
Closes #307 

We don't won't to connect to configured bootnodes, since they don't accept connections.

This modifies the `Disc::bootstrap` routine so that bootnodes are excluded from the `TableUpdate` stream and are therefore excluded from the network's peerset and not used to establish a connection.

There is a use case where connections should be established with bootnodes, which should be a separate setting, like `preferred_nodes` or something