### PR TITLE
fix(eth-wire): encode p2p message id as valid rlp

### DIFF
--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -926,6 +926,7 @@ mod tests {
         let mut hello_encoded = Vec::new();
         hello.encode(&mut hello_encoded);
 
-        assert_eq!(hello_encoded[0], P2PMessageID::Hello as u8);
+        // zero is encoded as 0x80, the empty string code in RLP
+        assert_eq!(hello_encoded[0], EMPTY_STRING_CODE);
     }
 }

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -549,7 +549,7 @@ impl P2PMessage {
 /// compressed in the `p2p` subprotocol.
 impl Encodable for P2PMessage {
     fn encode(&self, out: &mut dyn bytes::BufMut) {
-        out.put_u8(self.message_id() as u8);
+        (self.message_id() as u8).encode(out);
         match self {
             P2PMessage::Hello(msg) => msg.encode(out),
             P2PMessage::Disconnect(msg) => msg.encode(out),

--- a/crates/primitives/src/hex_bytes.rs
+++ b/crates/primitives/src/hex_bytes.rs
@@ -169,7 +169,7 @@ impl FromStr for Bytes {
             hex::decode(value)
         }
         .map(Into::into)
-        .map_err(|e| ParseBytesError(format!("Invalid hex: {}", e)))
+        .map_err(|e| ParseBytesError(format!("Invalid hex: {e}")))
     }
 }
 


### PR DESCRIPTION
In network connection tests, we would incorrectly encode `Hello` messages, encoding the message id as `0x00` instead of `0x80`. Decoding was fixed in #311.

Using `BufMut` put_u8 does not encode zero as `0x80`, but its `Encodable` trait does.

`hello_message_id_prefix` was also incorrect, and was corrected