### PR TITLE
chore(ecies): remove body size check

### DIFF
--- a/crates/net/ecies/src/algorithm.rs
+++ b/crates/net/ecies/src/algorithm.rs
@@ -19,11 +19,9 @@ use secp256k1::{
 };
 use sha2::Sha256;
 use sha3::Keccak256;
-use std::{convert::TryFrom, io};
+use std::convert::TryFrom;
 
 const PROTOCOL_VERSION: usize = 4;
-
-pub(crate) const MAX_BODY_SIZE: usize = 19_573_451;
 
 fn ecdh_x(public_key: &PublicKey, secret_key: &SecretKey) -> H256 {
     H256::from_slice(&secp256k1::ecdh::shared_secret_point(public_key, secret_key)[..32])
@@ -484,14 +482,8 @@ impl ECIES {
         if header.as_slice().len() < 3 {
             return Err(ECIESError::InvalidHeader)
         }
-        let body_size = usize::try_from(header.as_slice().read_uint::<BigEndian>(3)?)?;
 
-        if body_size > MAX_BODY_SIZE {
-            return Err(ECIESError::IO(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("body size ({body_size}) exceeds limit ({MAX_BODY_SIZE} bytes)"),
-            )))
-        }
+        let body_size = usize::try_from(header.as_slice().read_uint::<BigEndian>(3)?)?;
 
         self.body_size = Some(body_size);
 

--- a/crates/net/ecies/src/codec.rs
+++ b/crates/net/ecies/src/codec.rs
@@ -1,7 +1,4 @@
-use crate::{
-    algorithm::ECIES,
-    ECIESError, EgressECIESValue, IngressECIESValue,
-};
+use crate::{algorithm::ECIES, ECIESError, EgressECIESValue, IngressECIESValue};
 use bytes::BytesMut;
 use reth_primitives::H512 as PeerId;
 use secp256k1::SecretKey;

--- a/crates/net/ecies/src/codec.rs
+++ b/crates/net/ecies/src/codec.rs
@@ -1,5 +1,5 @@
 use crate::{
-    algorithm::{ECIES, MAX_BODY_SIZE},
+    algorithm::ECIES,
     ECIESError, EgressECIESValue, IngressECIESValue,
 };
 use bytes::BytesMut;
@@ -133,17 +133,6 @@ impl Encoder<EgressECIESValue> for ECIESCodec {
                 Ok(())
             }
             EgressECIESValue::Message(data) => {
-                if data.len() > MAX_BODY_SIZE {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        format!(
-                            "body size ({}) exceeds limit ({} bytes)",
-                            data.len(),
-                            MAX_BODY_SIZE
-                        ),
-                    ))
-                }
-
                 self.ecies.write_header(buf, data.len());
                 self.ecies.write_body(buf, &data);
                 Ok(())


### PR DESCRIPTION
This removes ECIES body size checks, to revise the max body size at a later point