### PR TITLE
chore(codecs): contain `[Struct]Flags` in a mod and import what's necessary

### DIFF
--- a/crates/codecs/derive/src/compact/mod.rs
+++ b/crates/codecs/derive/src/compact/mod.rs
@@ -205,25 +205,33 @@ mod tests {
 
         // Expected output in a TokenStream format. Commas matter!
         let should_output = quote! {
-            #[bitfield]
-            #[derive(Clone, Copy, Debug, Default)]
-            struct TestStructFlags {
-                f_u64_len: B4,
-                f_u256_len: B6,
-                f_bool_t_len: B1,
-                f_bool_f_len: B1,
-                f_option_none_len: B1,
-                f_option_some_len: B1,
-                f_option_some_u64_len: B1,
-                #[skip]
-                unused: B1,
-            }
-            impl TestStructFlags {
-                fn from(mut buf: &[u8]) -> (Self, &[u8]) {
-                    (
-                        TestStructFlags::from_bytes([buf.get_u8(), buf.get_u8(),]),
-                        buf
-                    )
+            pub use TestStruct_flags::TestStructFlags;
+            mod TestStruct_flags {
+                use bytes::Buf;
+                use modular_bitfield::prelude::*;
+
+                #[doc=r" Fieldset that facilitates compacting the parent type."]
+                #[bitfield]
+                #[derive(Clone, Copy, Debug, Default)]
+                pub struct TestStructFlags {
+                    pub f_u64_len: B4,
+                    pub f_u256_len: B6,
+                    pub f_bool_t_len: B1,
+                    pub f_bool_f_len: B1,
+                    pub f_option_none_len: B1,
+                    pub f_option_some_len: B1,
+                    pub f_option_some_u64_len: B1,
+                    #[skip]
+                    unused: B1,
+                }
+                impl TestStructFlags {
+                    #[doc=r" Deserializes this fieldset and returns it, alongside the original slice in an advanced position."]
+                    pub fn from(mut buf: &[u8]) -> (Self, &[u8]) {
+                        (
+                            TestStructFlags::from_bytes([buf.get_u8(), buf.get_u8(),]),
+                            buf
+                        )
+                    }
                 }
             }
             #[cfg(test)]

--- a/crates/codecs/src/lib.rs
+++ b/crates/codecs/src/lib.rs
@@ -282,7 +282,6 @@ impl Compact for bool {
 mod tests {
     use super::*;
     use ethers_core::types::Address;
-    use modular_bitfield::prelude::*;
 
     #[test]
     fn compact_bytes() {

--- a/crates/interfaces/src/db/codecs/compact.rs
+++ b/crates/interfaces/src/db/codecs/compact.rs
@@ -2,8 +2,6 @@ use crate::db::{
     models::{accounts::AccountBeforeTx, StoredBlockBody},
     Compress, Decompress, Error,
 };
-use bytes::Buf;
-use modular_bitfield::prelude::*;
 use reth_codecs::{main_codec, Compact};
 use reth_primitives::*;
 

--- a/crates/interfaces/src/db/models/blocks.rs
+++ b/crates/interfaces/src/db/models/blocks.rs
@@ -7,8 +7,7 @@ use crate::{
     },
     impl_fixed_arbitrary,
 };
-use bytes::{Buf, Bytes};
-use modular_bitfield::prelude::*;
+use bytes::Bytes;
 use reth_codecs::{main_codec, Compact};
 use reth_primitives::{BlockHash, BlockNumber, Header, TxNumber, H256};
 use serde::{Deserialize, Serialize};

--- a/crates/primitives/src/account.rs
+++ b/crates/primitives/src/account.rs
@@ -1,6 +1,4 @@
 use crate::{H256, U256};
-use bytes::Buf;
-use modular_bitfield::prelude::*;
 use reth_codecs::{main_codec, Compact};
 
 /// Account saved in database

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -2,9 +2,8 @@ use crate::{
     proofs::{EMPTY_LIST_HASH, EMPTY_ROOT},
     BlockHash, BlockNumber, Bloom, H160, H256, U256,
 };
-use bytes::{Buf, BufMut, BytesMut};
+use bytes::{BufMut, BytesMut};
 use ethers_core::{types::H64, utils::keccak256};
-use modular_bitfield::prelude::*;
 use reth_codecs::{main_codec, Compact};
 use reth_rlp::{length_of_length, Decodable, Encodable};
 use std::ops::Deref;

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -1,6 +1,5 @@
 use crate::{Bloom, Log, TxType};
 use bytes::{Buf, BufMut, BytesMut};
-use modular_bitfield::prelude::*;
 use reth_codecs::{main_codec, Compact};
 use reth_rlp::{length_of_length, Decodable, Encodable};
 use std::cmp::Ordering;

--- a/crates/primitives/src/storage.rs
+++ b/crates/primitives/src/storage.rs
@@ -1,6 +1,4 @@
 use super::{H256, U256};
-use bytes::Buf;
-use modular_bitfield::prelude::*;
 use reth_codecs::{main_codec, Compact};
 
 /// Account storage entry.

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -3,7 +3,6 @@ pub use access_list::{AccessList, AccessListItem};
 use bytes::{Buf, BytesMut};
 use derive_more::{AsRef, Deref};
 use ethers_core::utils::keccak256;
-use modular_bitfield::prelude::*;
 use reth_codecs::{main_codec, Compact};
 use reth_rlp::{length_of_length, Decodable, DecodeError, Encodable, Header, EMPTY_STRING_CODE};
 pub use signature::Signature;

--- a/crates/primitives/src/transaction/signature.rs
+++ b/crates/primitives/src/transaction/signature.rs
@@ -1,6 +1,4 @@
 use crate::{transaction::util::secp256k1, Address, H256, U256};
-use bytes::Buf;
-use modular_bitfield::prelude::*;
 use reth_codecs::{main_codec, Compact};
 use reth_rlp::{Decodable, DecodeError, Encodable};
 


### PR DESCRIPTION
`StructFlags` requires two imports to be in scope. When they're not, there are some long hard to read error messages.

```
use modular_bitfield::prelude::*; // eg. for `field: B2`
use bytes::Buf; // for `.get_u8(&mut self)`
```

Just wrap `StructFlags` in a `mod` and add the imports inside, during the code generation stage.
