### PR TITLE
refactor(net): box ecies error

### DIFF
--- a/crates/net/ecies/src/error.rs
+++ b/crates/net/ecies/src/error.rs
@@ -1,12 +1,45 @@
 use crate::IngressECIESValue;
+use std::fmt;
 use thiserror::Error;
 
 /// An error that occurs while reading or writing to an ECIES stream.
+pub struct ECIESError {
+    inner: Box<ECIESErrorImpl>,
+}
+
+// === impl ===
+
+impl ECIESError {
+    /// Consumes the type and returns the error enum
+    pub fn into_inner(self) -> ECIESErrorImpl {
+        *self.inner
+    }
+}
+
+impl fmt::Debug for ECIESError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&*self.inner, f)
+    }
+}
+
+impl fmt::Display for ECIESError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&*self.inner, f)
+    }
+}
+
+impl std::error::Error for ECIESError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.inner.source()
+    }
+}
+
+/// An error that occurs while reading or writing to an ECIES stream.
 #[derive(Debug, Error)]
-pub enum ECIESError {
+pub enum ECIESErrorImpl {
     /// Error during IO
     #[error("IO error")]
-    IO(#[from] std::io::Error),
+    IO(std::io::Error),
     /// Error when checking the HMAC tag against the tag on the data
     #[error("tag check failure")]
     TagCheckFailed,
@@ -21,13 +54,13 @@ pub enum ECIESError {
     InvalidHeader,
     /// Error when interacting with secp256k1
     #[error(transparent)]
-    Secp256k1(#[from] secp256k1::Error),
+    Secp256k1(secp256k1::Error),
     /// Error when decoding RLP data
     #[error(transparent)]
-    RLPDecoding(#[from] reth_rlp::DecodeError),
+    RLPDecoding(reth_rlp::DecodeError),
     /// Error when convering to integer
     #[error(transparent)]
-    FromInt(#[from] std::num::TryFromIntError),
+    FromInt(std::num::TryFromIntError),
     /// Error when trying to split an array beyond its length
     #[error("requested {idx} but array len is {len}")]
     OutOfBounds {
@@ -44,4 +77,34 @@ pub enum ECIESError {
         /// The actual value returned from the peer
         msg: Option<IngressECIESValue>,
     },
+}
+
+impl From<ECIESErrorImpl> for ECIESError {
+    fn from(source: ECIESErrorImpl) -> Self {
+        ECIESError { inner: Box::new(source) }
+    }
+}
+
+impl From<std::io::Error> for ECIESError {
+    fn from(source: std::io::Error) -> Self {
+        ECIESErrorImpl::IO(source).into()
+    }
+}
+
+impl From<secp256k1::Error> for ECIESError {
+    fn from(source: secp256k1::Error) -> Self {
+        ECIESErrorImpl::Secp256k1(source).into()
+    }
+}
+
+impl From<reth_rlp::DecodeError> for ECIESError {
+    fn from(source: reth_rlp::DecodeError) -> Self {
+        ECIESErrorImpl::RLPDecoding(source).into()
+    }
+}
+
+impl From<std::num::TryFromIntError> for ECIESError {
+    fn from(source: std::num::TryFromIntError) -> Self {
+        ECIESErrorImpl::FromInt(source).into()
+    }
 }

--- a/crates/net/ecies/src/lib.rs
+++ b/crates/net/ecies/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::result_large_err)]
 #![warn(missing_docs, unreachable_pub)]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![doc(test(
@@ -20,8 +19,8 @@ mod codec;
 
 use reth_primitives::H512 as PeerId;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
 /// Raw egress values for an ECIES protocol
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum EgressECIESValue {
     /// The AUTH message being sent out
     Auth,
@@ -31,8 +30,8 @@ pub enum EgressECIESValue {
     Message(bytes::Bytes),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
 /// Raw ingress values for an ECIES protocol
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum IngressECIESValue {
     /// Receiving a message from a [`PeerId`]
     AuthReceive(PeerId),

--- a/crates/net/ecies/src/stream.rs
+++ b/crates/net/ecies/src/stream.rs
@@ -1,5 +1,7 @@
 //! The ECIES Stream implementation which wraps over [`AsyncRead`] and [`AsyncWrite`].
-use crate::{codec::ECIESCodec, ECIESError, EgressECIESValue, IngressECIESValue};
+use crate::{
+    codec::ECIESCodec, error::ECIESErrorImpl, ECIESError, EgressECIESValue, IngressECIESValue,
+};
 use bytes::Bytes;
 use futures::{ready, Sink, SinkExt};
 use reth_primitives::H512 as PeerId;
@@ -64,7 +66,7 @@ where
         if matches!(msg, Some(IngressECIESValue::Ack)) {
             Ok(Self { stream: transport, remote_id })
         } else {
-            Err(ECIESError::InvalidHandshake { expected: IngressECIESValue::Ack, msg })
+            Err(ECIESErrorImpl::InvalidHandshake { expected: IngressECIESValue::Ack, msg }.into())
         }
     }
 
@@ -81,10 +83,11 @@ where
         let remote_id = match &msg {
             Some(IngressECIESValue::AuthReceive(remote_id)) => *remote_id,
             _ => {
-                return Err(ECIESError::InvalidHandshake {
+                return Err(ECIESErrorImpl::InvalidHandshake {
                     expected: IngressECIESValue::AuthReceive(Default::default()),
                     msg,
-                })
+                }
+                .into())
             }
         };
 


### PR DESCRIPTION
all Ok variants of an `Ecies` Result are small, like `()` or `usize`.

To keep the result type small, box the `EciesError`