### PR TITLE
deps(net): move `tokio-util` to dev deps

### DIFF
--- a/crates/net/eth-wire/Cargo.toml
+++ b/crates/net/eth-wire/Cargo.toml
@@ -22,7 +22,6 @@ ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features =
 tokio = { version = "1.21.2", features = ["full"] }
 futures = "0.3.24"
 tokio-stream = "0.1.11"
-tokio-util = { version = "0.7.4", features = ["io"] }
 pin-project = "1.0"
 tracing = "0.1.37"
 snap = "1.0.5"
@@ -32,6 +31,7 @@ smol_str = { version = "0.1", default-features = false }
 reth-ecies = { path = "../ecies" }
 ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 
+tokio-util = { version = "0.7.4", features = ["io", "codec"] }
 hex-literal = "0.3"
 rand = "0.8"
 secp256k1 = { version = "0.24.0", features = ["global-context", "rand-std", "recovery"] }

--- a/crates/net/eth-wire/src/lib.rs
+++ b/crates/net/eth-wire/src/lib.rs
@@ -6,9 +6,6 @@
 ))]
 //! Implementation of the `eth` wire protocol.
 
-pub use tokio_util::codec::{
-    LengthDelimitedCodec as PassthroughCodec, LengthDelimitedCodecError as PassthroughCodecError,
-};
 pub mod builder;
 pub mod capability;
 mod disconnect;
@@ -19,6 +16,11 @@ mod pinger;
 pub use builder::*;
 pub mod types;
 pub use types::*;
+
+#[cfg(test)]
+pub use tokio_util::codec::{
+    LengthDelimitedCodec as PassthroughCodec, LengthDelimitedCodecError as PassthroughCodecError,
+};
 
 pub use crate::{
     disconnect::DisconnectReason,


### PR DESCRIPTION
## Motivation
Currently stage testing fails on `main`. Steps to repro:
1. Checkout `main`
2. `cargo test --package reth-stages`

## Solution
Moved `tokio-util` to dev dep and enabled the `codec` feature