### PR TITLE
feat(eth-wire): derive serde traits for eth-wire types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,8 +1234,8 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "1.0.0"
-source = "git+https://github.com/gakonst/ethers-rs#c17c0c3c956f12d205a5ede3176599d8a30ca739"
+version = "1.0.2"
+source = "git+https://github.com/gakonst/ethers-rs#a88d2d03e3340a4f9dd39fae9dfe094750db13d5"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -3193,6 +3193,7 @@ dependencies = [
  "reth-primitives",
  "reth-rlp",
  "secp256k1",
+ "serde",
  "smol_str",
  "snap",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4035,6 +4035,9 @@ name = "smol_str"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7475118a28b7e3a2e157ce0131ba8c5526ea96e90ee601d9f6bb2e286a35ab44"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "snap"

--- a/crates/net/eth-wire/Cargo.toml
+++ b/crates/net/eth-wire/Cargo.toml
@@ -26,7 +26,7 @@ tokio-stream = "0.1.11"
 pin-project = "1.0"
 tracing = "0.1.37"
 snap = "1.0.5"
-smol_str = { version = "0.1", default-features = false }
+smol_str = { version = "0.1", features = ["serde"] }
 
 [dev-dependencies]
 reth-ecies = { path = "../ecies" }

--- a/crates/net/eth-wire/Cargo.toml
+++ b/crates/net/eth-wire/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 bytes = { version = "1.1" }
 hex = "0.4"
 thiserror = "1"
+serde = "1"
 
 # reth
 reth-primitives = { path = "../../primitives" }

--- a/crates/net/eth-wire/src/capability.rs
+++ b/crates/net/eth-wire/src/capability.rs
@@ -3,10 +3,11 @@
 use crate::{version::ParseVersionError, EthMessage, EthVersion};
 use bytes::{BufMut, Bytes};
 use reth_rlp::{Decodable, DecodeError, Encodable, RlpDecodable, RlpEncodable};
+use serde::{Serialize, Deserialize};
 use smol_str::SmolStr;
 
 /// A Capability message consisting of the message-id and the payload
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct RawCapabilityMessage {
     /// Identifier of the message.
     pub id: usize,
@@ -16,7 +17,7 @@ pub struct RawCapabilityMessage {
 
 /// Various protocol related event types bubbled up from a session that need to be handled by the
 /// network.
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum CapabilityMessage {
     /// Eth sub-protocol message.
     Eth(EthMessage),
@@ -25,7 +26,7 @@ pub enum CapabilityMessage {
 }
 
 /// A message indicating a supported capability and capability version.
-#[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable, Serialize, Deserialize)]
 pub struct Capability {
     /// The name of the subprotocol
     pub name: SmolStr,

--- a/crates/net/eth-wire/src/capability.rs
+++ b/crates/net/eth-wire/src/capability.rs
@@ -3,7 +3,7 @@
 use crate::{version::ParseVersionError, EthMessage, EthVersion};
 use bytes::{BufMut, Bytes};
 use reth_rlp::{Decodable, DecodeError, Encodable, RlpDecodable, RlpEncodable};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 
 /// A Capability message consisting of the message-id and the payload

--- a/crates/net/eth-wire/src/disconnect.rs
+++ b/crates/net/eth-wire/src/disconnect.rs
@@ -2,7 +2,7 @@
 
 use bytes::Buf;
 use reth_rlp::{Decodable, DecodeError, Encodable, EMPTY_LIST_CODE};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use thiserror::Error;
 

--- a/crates/net/eth-wire/src/disconnect.rs
+++ b/crates/net/eth-wire/src/disconnect.rs
@@ -2,11 +2,12 @@
 
 use bytes::Buf;
 use reth_rlp::{Decodable, DecodeError, Encodable, EMPTY_LIST_CODE};
+use serde::{Serialize, Deserialize};
 use std::fmt::Display;
 use thiserror::Error;
 
 /// RLPx disconnect reason.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DisconnectReason {
     /// Disconnect requested by the local node or remote peer.
     DisconnectRequested = 0x00,

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -10,6 +10,7 @@ use futures::{Sink, SinkExt, StreamExt};
 use pin_project::pin_project;
 use reth_primitives::H512 as PeerId;
 use reth_rlp::{Decodable, DecodeError, Encodable, RlpDecodable, RlpEncodable, EMPTY_STRING_CODE};
+use serde::{Serialize, Deserialize};
 use std::{
     collections::{BTreeSet, HashMap, VecDeque},
     io,
@@ -523,7 +524,7 @@ pub fn set_capability_offsets(
 }
 
 /// This represents only the reserved `p2p` subprotocol messages.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum P2PMessage {
     /// The first packet sent over the connection, and sent once by both sides.
     Hello(HelloMessage),
@@ -655,7 +656,7 @@ impl TryFrom<u8> for P2PMessageID {
 // TODO: determine if we should allow for the extra fields at the end like EIP-706 suggests
 /// Message used in the `p2p` handshake, containing information about the supported RLPx protocol
 /// version and capabilities.
-#[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable, Serialize, Deserialize)]
 pub struct HelloMessage {
     /// The version of the `p2p` protocol.
     pub protocol_version: ProtocolVersion,
@@ -671,7 +672,7 @@ pub struct HelloMessage {
 }
 
 /// RLPx `p2p` protocol version
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ProtocolVersion {
     /// `p2p` version 4
     V4 = 4,

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -10,7 +10,7 @@ use futures::{Sink, SinkExt, StreamExt};
 use pin_project::pin_project;
 use reth_primitives::H512 as PeerId;
 use reth_rlp::{Decodable, DecodeError, Encodable, RlpDecodable, RlpEncodable, EMPTY_STRING_CODE};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeSet, HashMap, VecDeque},
     io,

--- a/crates/net/eth-wire/src/types/blocks.rs
+++ b/crates/net/eth-wire/src/types/blocks.rs
@@ -3,6 +3,7 @@
 use super::RawBlockBody;
 use reth_primitives::{BlockHashOrNumber, Header, HeadersDirection, TransactionSigned, H256};
 use reth_rlp::{RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper};
+use serde::{Deserialize, Serialize};
 
 /// A request for a peer to return block headers starting at the requested block.
 /// The peer must return at most [`limit`](#structfield.limit) headers.
@@ -13,7 +14,9 @@ use reth_rlp::{RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrap
 ///
 /// If the [`skip`](#structfield.skip) field is non-zero, the peer must skip that amount of headers
 /// in the direction specified by [`reverse`](#structfield.reverse).
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable)]
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable, Serialize, Deserialize,
+)]
 pub struct GetBlockHeaders {
     /// The block number or hash that the peer should start returning headers from.
     pub start_block: BlockHashOrNumber,
@@ -32,7 +35,9 @@ pub struct GetBlockHeaders {
 }
 
 /// The response to [`GetBlockHeaders`], containing headers if any headers were found.
-#[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Serialize, Deserialize,
+)]
 pub struct BlockHeaders(
     /// The requested headers.
     pub Vec<Header>,
@@ -45,7 +50,9 @@ impl From<Vec<Header>> for BlockHeaders {
 }
 
 /// A request for a peer to return block bodies for the given block hashes.
-#[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Serialize, Deserialize,
+)]
 pub struct GetBlockBodies(
     /// The block hashes to request bodies for.
     pub Vec<H256>,
@@ -59,7 +66,7 @@ impl From<Vec<H256>> for GetBlockBodies {
 
 // TODO(onbjerg): We should have this type in primitives
 /// A response to [`GetBlockBodies`], containing bodies if any bodies were found.
-#[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable, Serialize, Deserialize)]
 pub struct BlockBody {
     /// Transactions in the block
     pub transactions: Vec<TransactionSigned>,
@@ -80,7 +87,9 @@ impl BlockBody {
 
 /// The response to [`GetBlockBodies`], containing the block bodies that the peer knows about if
 /// any were found.
-#[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Serialize, Deserialize,
+)]
 pub struct BlockBodies(
     /// The requested block bodies, each of which should correspond to a hash in the request.
     pub Vec<BlockBody>,

--- a/crates/net/eth-wire/src/types/broadcast.rs
+++ b/crates/net/eth-wire/src/types/broadcast.rs
@@ -1,10 +1,11 @@
 //! Types for broadcasting new data.
 use reth_primitives::{Header, TransactionSigned, H256, U128};
 use reth_rlp::{RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper};
+use serde::{Serialize, Deserialize};
 use std::sync::Arc;
 
 /// This informs peers of new blocks that have appeared on the network.
-#[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper)]
+#[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Serialize, Deserialize)]
 pub struct NewBlockHashes(
     /// New block hashes and the block number for each blockhash.
     /// Clients should request blocks using a [`GetBlockBodies`](crate::GetBlockBodies) message.
@@ -26,7 +27,7 @@ impl NewBlockHashes {
 }
 
 /// A block hash _and_ a block number.
-#[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable, Serialize, Deserialize)]
 pub struct BlockHashNumber {
     /// The block hash
     pub hash: H256,

--- a/crates/net/eth-wire/src/types/broadcast.rs
+++ b/crates/net/eth-wire/src/types/broadcast.rs
@@ -1,11 +1,13 @@
 //! Types for broadcasting new data.
 use reth_primitives::{Header, TransactionSigned, H256, U128};
 use reth_rlp::{RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 /// This informs peers of new blocks that have appeared on the network.
-#[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Serialize, Deserialize,
+)]
 pub struct NewBlockHashes(
     /// New block hashes and the block number for each blockhash.
     /// Clients should request blocks using a [`GetBlockBodies`](crate::GetBlockBodies) message.
@@ -48,7 +50,9 @@ impl From<NewBlockHashes> for Vec<BlockHashNumber> {
 }
 
 /// A block body, including transactions and uncle headers.
-#[derive(Debug, Clone, PartialEq, Eq, Default, RlpEncodable, RlpDecodable)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, Default, RlpEncodable, RlpDecodable, Serialize, Deserialize,
+)]
 pub struct RawBlockBody {
     /// This block's header
     pub header: Header,
@@ -60,7 +64,7 @@ pub struct RawBlockBody {
 
 /// A new block with the current total difficulty, which includes the difficulty of the returned
 /// block.
-#[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable, Serialize, Deserialize)]
 pub struct NewBlock {
     /// A new block.
     pub block: RawBlockBody,
@@ -70,7 +74,9 @@ pub struct NewBlock {
 
 /// This informs peers of transactions that have appeared on the network and are not yet included
 /// in a block.
-#[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Serialize, Deserialize,
+)]
 pub struct Transactions(
     /// New transactions for the peer to include in its mempool.
     pub Vec<TransactionSigned>,
@@ -100,7 +106,9 @@ pub struct SharedTransactions(
 
 /// This informs peers of transaction hashes for transactions that have appeared on the network,
 /// but have not been included in a block.
-#[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Serialize, Deserialize,
+)]
 pub struct NewPooledTransactionHashes(
     /// Transaction hashes for new transactions that have appeared on the network.
     /// Clients should request the transactions with the given hashes using a

--- a/crates/net/eth-wire/src/types/message.rs
+++ b/crates/net/eth-wire/src/types/message.rs
@@ -7,6 +7,7 @@ use super::{
 use crate::SharedTransactions;
 use bytes::{Buf, BufMut};
 use reth_rlp::{length_of_length, Decodable, Encodable, Header};
+use serde::{Deserialize, Serialize};
 use std::{fmt::Debug, sync::Arc};
 
 /// An `eth` protocol message, containing a message ID and payload.
@@ -139,7 +140,7 @@ impl From<EthBroadcastMessage> for ProtocolBroadcastMessage {
 ///
 ///  The newer `eth/66` is an efficiency upgrade on top of `eth/65`, introducing a request id to
 ///  correlate request-response message pairs. This allows for request multiplexing.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EthMessage {
     /// Status is required for the protocol handshake
     Status(Status),

--- a/crates/net/eth-wire/src/types/message.rs
+++ b/crates/net/eth-wire/src/types/message.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::{fmt::Debug, sync::Arc};
 
 /// An `eth` protocol message, containing a message ID and payload.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProtocolMessage {
     pub message_type: EthMessageID,
     pub message: EthMessage,
@@ -270,7 +270,7 @@ impl Encodable for EthBroadcastMessage {
 
 /// Represents message IDs for eth protocol messages.
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EthMessageID {
     Status = 0x00,
     NewBlockHashes = 0x01,
@@ -352,7 +352,7 @@ impl TryFrom<usize> for EthMessageID {
 /// This is used for all request-response style `eth` protocol messages.
 /// This can represent either a request or a response, since both include a message payload and
 /// request id.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RequestPair<T> {
     /// id for the contained request or response message
     pub request_id: u64,

--- a/crates/net/eth-wire/src/types/receipts.rs
+++ b/crates/net/eth-wire/src/types/receipts.rs
@@ -1,9 +1,12 @@
 //! Implements the `GetReceipts` and `Receipts` message types.
 use reth_primitives::{Receipt, H256};
 use reth_rlp::{RlpDecodableWrapper, RlpEncodableWrapper};
+use serde::{Deserialize, Serialize};
 
 /// A request for transaction receipts from the given block hashes.
-#[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Serialize, Deserialize,
+)]
 pub struct GetReceipts(
     /// The block hashes to request receipts for.
     pub Vec<H256>,
@@ -11,7 +14,9 @@ pub struct GetReceipts(
 
 /// The response to [`GetReceipts`], containing receipt lists that correspond to each block
 /// requested.
-#[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Serialize, Deserialize,
+)]
 pub struct Receipts(
     /// Each receipt hash should correspond to a block hash in the request.
     pub Vec<Vec<Receipt>>,

--- a/crates/net/eth-wire/src/types/state.rs
+++ b/crates/net/eth-wire/src/types/state.rs
@@ -1,11 +1,14 @@
 //! Implements the `GetNodeData` and `NodeData` message types.
 use reth_primitives::H256;
 use reth_rlp::{RlpDecodableWrapper, RlpEncodableWrapper};
+use serde::{Deserialize, Serialize};
 
 /// A request for state tree nodes corresponding to the given hashes.
 /// This message was removed in `eth/67`, only clients running `eth/66` or earlier will respond to
 /// this message.
-#[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Serialize, Deserialize,
+)]
 pub struct GetNodeData(pub Vec<H256>);
 
 /// The response to [`GetNodeData`], containing the state tree nodes or contract bytecode
@@ -13,7 +16,9 @@ pub struct GetNodeData(pub Vec<H256>);
 ///
 /// Not all nodes are guaranteed to be returned by the peer.
 /// This message was removed in `eth/67`.
-#[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Serialize, Deserialize,
+)]
 pub struct NodeData(pub Vec<bytes::Bytes>);
 
 #[cfg(test)]

--- a/crates/net/eth-wire/src/types/status.rs
+++ b/crates/net/eth-wire/src/types/status.rs
@@ -2,7 +2,7 @@ use crate::{EthVersion, StatusBuilder};
 
 use reth_primitives::{Chain, ForkId, Hardfork, H256, MAINNET_GENESIS, U256};
 use reth_rlp::{RlpDecodable, RlpEncodable};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display};
 
 /// The status message is used in the eth protocol handshake to ensure that peers are on the same

--- a/crates/net/eth-wire/src/types/status.rs
+++ b/crates/net/eth-wire/src/types/status.rs
@@ -2,6 +2,7 @@ use crate::{EthVersion, StatusBuilder};
 
 use reth_primitives::{Chain, ForkId, Hardfork, H256, MAINNET_GENESIS, U256};
 use reth_rlp::{RlpDecodable, RlpEncodable};
+use serde::{Serialize, Deserialize};
 use std::fmt::{Debug, Display};
 
 /// The status message is used in the eth protocol handshake to ensure that peers are on the same
@@ -11,7 +12,7 @@ use std::fmt::{Debug, Display};
 ///
 /// When performing a handshake, the total difficulty is not guaranteed to correspond to the block
 /// hash. This information should be treated as untrusted.
-#[derive(Copy, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[derive(Copy, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable, Serialize, Deserialize)]
 pub struct Status {
     /// The current protocol version. For example, peers running `eth/66` would have a version of
     /// 66.

--- a/crates/net/eth-wire/src/types/transactions.rs
+++ b/crates/net/eth-wire/src/types/transactions.rs
@@ -1,9 +1,12 @@
 //! Implements the `GetPooledTransactions` and `PooledTransactions` message types.
 use reth_primitives::{TransactionSigned, H256};
 use reth_rlp::{RlpDecodableWrapper, RlpEncodableWrapper};
+use serde::{Deserialize, Serialize};
 
 /// A list of transaction hashes that the peer would like transaction bodies for.
-#[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Serialize, Deserialize,
+)]
 pub struct GetPooledTransactions(
     /// The transaction hashes to request transaction bodies for.
     pub Vec<H256>,
@@ -25,7 +28,9 @@ where
 /// as the request's hashes. Hashes may be skipped, and the client should ensure that each body
 /// corresponds to a requested hash. Hashes may need to be re-requested if the bodies are not
 /// included in the response.
-#[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Serialize, Deserialize,
+)]
 pub struct PooledTransactions(
     /// The transaction bodies, each of which should correspond to a requested hash.
     pub Vec<TransactionSigned>,

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -1,5 +1,6 @@
 use crate::{Header, SealedHeader, TransactionSigned, H256};
 use reth_rlp::{Decodable, DecodeError, Encodable, RlpDecodable, RlpEncodable};
+use serde::{Deserialize, Serialize};
 use std::ops::Deref;
 
 /// Ethereum full block.
@@ -46,7 +47,7 @@ impl Deref for BlockLocked {
 }
 
 /// Either a block hash _or_ a block number
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum BlockHashOrNumber {
     /// A block hash
     Hash(H256),

--- a/crates/primitives/src/chain.rs
+++ b/crates/primitives/src/chain.rs
@@ -1,10 +1,11 @@
 use crate::U256;
 use ethers_core::types::{ParseChainError, U64};
 use reth_rlp::{Decodable, Encodable};
+use serde::{Serialize, Deserialize};
 use std::{fmt, str::FromStr};
 
 /// Either a named or chain id or the actual id value
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Chain {
     /// Contains a known chain
     Named(ethers_core::types::Chain),

--- a/crates/primitives/src/chain.rs
+++ b/crates/primitives/src/chain.rs
@@ -1,7 +1,7 @@
 use crate::U256;
 use ethers_core::types::{ParseChainError, U64};
 use reth_rlp::{Decodable, Encodable};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use std::{fmt, str::FromStr};
 
 /// Either a named or chain id or the actual id value

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -6,6 +6,7 @@ use bytes::{BufMut, BytesMut};
 use ethers_core::{types::H64, utils::keccak256};
 use reth_codecs::{main_codec, Compact};
 use reth_rlp::{length_of_length, Decodable, Encodable};
+use serde::{Deserialize, Serialize};
 use std::ops::Deref;
 
 /// Block header
@@ -279,7 +280,7 @@ impl SealedHeader {
 /// [`HeadersDirection::Falling`] block numbers for `reverse == false`
 ///
 /// See also <https://github.com/ethereum/devp2p/blob/master/caps/eth.md#getblockheaders-0x03>
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Default)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Default, Serialize, Deserialize)]
 pub enum HeadersDirection {
     /// Falling block number.
     #[default]


### PR DESCRIPTION
`test-fuzz` requires that types implement `Serialize`, so this derives `Serialize` and `Deserialize` for message types that we will be fuzzing the encoding for.