### PR TITLE
chore(sync): remove timeout from downloader

### DIFF
--- a/crates/interfaces/src/p2p/headers/downloader.rs
+++ b/crates/interfaces/src/p2p/headers/downloader.rs
@@ -7,7 +7,7 @@ use crate::{
 use futures::Stream;
 use reth_primitives::SealedHeader;
 use reth_rpc_types::engine::ForkchoiceState;
-use std::{pin::Pin, time::Duration};
+use std::pin::Pin;
 
 /// A Future for downloading a batch of headers.
 pub type HeaderBatchDownload<'a> = Pin<
@@ -37,9 +37,6 @@ pub trait HeaderDownloader: Sync + Send + Unpin {
 
     /// The Client used to download the headers
     type Client: HeadersClient;
-
-    /// The request timeout duration
-    fn timeout(&self) -> Duration;
 
     /// The consensus engine
     fn consensus(&self) -> &Self::Consensus;

--- a/crates/interfaces/src/test_utils/headers.rs
+++ b/crates/interfaces/src/test_utils/headers.rs
@@ -24,7 +24,6 @@ use std::{
         Arc,
     },
     task::{ready, Context, Poll},
-    time::Duration,
 };
 use tokio::sync::{watch, Mutex};
 
@@ -58,10 +57,6 @@ impl TestHeaderDownloader {
 impl HeaderDownloader for TestHeaderDownloader {
     type Consensus = TestConsensus;
     type Client = TestHeadersClient;
-
-    fn timeout(&self) -> Duration {
-        Duration::from_millis(1000)
-    }
 
     fn consensus(&self) -> &Self::Consensus {
         &self.consensus

--- a/crates/net/headers-downloaders/src/linear.rs
+++ b/crates/net/headers-downloaders/src/linear.rs
@@ -35,8 +35,6 @@ pub struct LinearDownloader<C, H> {
     client: Arc<H>,
     /// The batch size per one request
     pub batch_size: u64,
-    /// A single request timeout
-    pub request_timeout: Duration,
     /// The number of retries for downloading
     pub request_retries: usize,
 }
@@ -48,11 +46,6 @@ where
 {
     type Consensus = C;
     type Client = H;
-
-    /// The request timeout
-    fn timeout(&self) -> Duration {
-        self.request_timeout
-    }
 
     fn consensus(&self) -> &Self::Consensus {
         self.consensus.borrow()
@@ -77,7 +70,6 @@ impl<C: Consensus, H: HeadersClient> Clone for LinearDownloader<C, H> {
             consensus: Arc::clone(&self.consensus),
             client: Arc::clone(&self.client),
             batch_size: self.batch_size,
-            request_timeout: self.request_timeout,
             request_retries: self.request_retries,
         }
     }
@@ -422,7 +414,6 @@ impl LinearDownloadBuilder {
             consensus,
             client,
             batch_size: self.batch_size,
-            request_timeout: self.request_timeout,
             request_retries: self.request_retries,
         }
     }


### PR DESCRIPTION
Removes timeout from the `HeadersDownloader`.
closes #298 