### PR TITLE
add github link for book

### DIFF
--- a/book/README.md
+++ b/book/README.md
@@ -7,7 +7,7 @@
 
 > 📖 **Contributing**
 >
-> You can contribute to this book on [GitHub]().
+> You can contribute to this book on [GitHub][gh-book].
 
 ### Sections
 
@@ -17,3 +17,5 @@ To get started with Reth, install, configure and sync your node.
 **[A Tour Of Reth]()**
 
 This section will take a deep dive into the inner workings of Reth. 
+
+[gh-book]: https://github.com/paradigmxyz/reth/tree/main/book


### PR DESCRIPTION
fixing missing github link for book at: https://paradigmxyz.github.io/reth/