### PR TITLE
fix(interfaces/db): remove unused `$seek:ty` token in table! macro

### DIFF
--- a/crates/interfaces/src/db/tables.rs
+++ b/crates/interfaces/src/db/tables.rs
@@ -50,8 +50,7 @@ pub const TABLES: [(TableType, &str); 20] = [
 #[macro_export]
 /// Macro to declare all necessary tables.
 macro_rules! table {
-    (
-    $(#[$docs:meta])+ ( $table_name:ident ) $key:ty | $value:ty | $seek:ty) => {
+    ($(#[$docs:meta])+ ( $table_name:ident ) $key:ty | $value:ty) => {
         $(#[$docs])+
         ///
         #[doc = concat!("Takes [`", stringify!($key), "`] as a key and returns [`", stringify!($value), "`]")]
@@ -75,12 +74,6 @@ macro_rules! table {
                 write!(f, "{}", stringify!($table_name)) }
         }
     };
-    ($(#[$docs:meta])+ ( $table_name:ident ) $key:ty | $value:ty) => {
-        table!(
-            $(#[$docs])+
-            ( $table_name ) $key | $value | $key
-        );
-    };
 }
 
 macro_rules! dupsort {
@@ -89,7 +82,7 @@ macro_rules! dupsort {
             $(#[$docs])+
             ///
             #[doc = concat!("`DUPSORT` table with subkey being: [`", stringify!($subkey), "`].")]
-            ( $table_name ) $key | $value | $subkey
+            ( $table_name ) $key | $value
         );
         impl DupSort for $table_name {
             type SubKey = $subkey;


### PR DESCRIPTION
## Motivation

closes #248

## Check
check that with changes in `table!` and `dupsort!` macros, the same code is still generated

install [`cargo-expand`](https://github.com/dtolnay/cargo-expand) and create `check-macro-expansion.sh`:
```bash
#!/usr/bin/env bash

mkdir check-table-macro
cd check-table-macro

gh repo clone paradigmxyz/reth main
cd main/crates/interfaces
cargo expand >../../../main.rs
cd ../../..

gh repo clone 0xyyy/reth pr
cd pr/crates/interfaces
git checkout yyy/table-macro
cargo expand >../../../pr.rs
cd ../../..

diff main.rs pr.rs && echo "🎉 macro expansion results are identical!"
```
then run `bash check-macro-expansion.sh`