### PR TITLE
feat(ci): add geth bin to GITHUB_PATH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
             mv geth-linux-amd64-$GETH_BUILD/geth $HOME/bin/geth
             chmod u+x "$HOME/bin/geth"
             export PATH=$HOME/bin:$PATH
+            echo $HOME/bin >> $GITHUB_PATH
             geth version
 
       - name: Install latest nextest release


### PR DESCRIPTION
`PATH` is not updated between action steps, so `GITHUB_PATH` needs to be prepended with the directory the geth binary is in for the binary to be visible in other steps. This allows geth to be used in tests.