### PR TITLE
ci: install geth in coverage jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,17 @@ jobs:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
 
+      - name: Install geth
+        run: |
+          mkdir -p "$HOME/bin"
+          wget -q https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-$GETH_BUILD.tar.gz
+          tar -xvf geth-linux-amd64-$GETH_BUILD.tar.gz
+          mv geth-linux-amd64-$GETH_BUILD/geth $HOME/bin/geth
+          chmod u+x "$HOME/bin/geth"
+          export PATH=$HOME/bin:$PATH
+          echo $HOME/bin >> $GITHUB_PATH
+          geth version
+
       - name: Install latest nextest release
         uses: taiki-e/install-action@nextest
       - name: Install cargo-llvm-cov


### PR DESCRIPTION
install geth for coverage jobs which also runs tests