### PR TITLE
fix(net): outgoing requsts

### DIFF
--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -532,10 +532,9 @@ where
                         ?error,
                         "Outgoing pending session failed"
                     );
-                    this.swarm
-                        .state_mut()
-                        .peers_mut()
-                        .apply_reputation_change(&peer_id, ReputationChangeKind::FailedToConnect);
+                    let swarm = this.swarm.state_mut().peers_mut();
+                    swarm.on_closed_outgoing_pending_session();
+                    swarm.apply_reputation_change(&peer_id, ReputationChangeKind::FailedToConnect);
                 }
                 SwarmEvent::OutgoingConnectionError { remote_addr, peer_id, error } => {
                     warn!(

--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -121,6 +121,10 @@ impl PeersManager {
     pub(crate) fn on_closed_incoming_pending_session(&mut self) {
         self.connection_info.decr_in()
     }
+    /// Invoked when a pending session was closed.
+    pub(crate) fn on_closed_outgoing_pending_session(&mut self) {
+        self.connection_info.decr_out()
+    }
 
     /// Called when a new _incoming_ active session was established to the given peer.
     ///

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -194,7 +194,7 @@ where
     ) -> PoolResult<TxHash> {
         match tx {
             TransactionValidationOutcome::Valid { balance, state_nonce, transaction } => {
-                let sender_id = self.get_sender_id(*transaction.sender());
+                let sender_id = self.get_sender_id(transaction.sender());
                 let transaction_id = TransactionId::new(sender_id, transaction.nonce());
 
                 let tx = ValidPoolTransaction {

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -238,7 +238,7 @@ impl<T: TransactionOrdering> TxPool<T> {
                 Err(PoolError::ProtocolFeeCapTooLow(*transaction.hash(), fee_cap))
             }
             Err(InsertErr::ExceededSenderTransactionsCapacity { transaction }) => {
-                Err(PoolError::SpammerExceededCapacity(*transaction.sender(), *transaction.hash()))
+                Err(PoolError::SpammerExceededCapacity(transaction.sender(), *transaction.hash()))
             }
         }
     }

--- a/crates/transaction-pool/src/test_util/mock.rs
+++ b/crates/transaction-pool/src/test_util/mock.rs
@@ -282,10 +282,10 @@ impl PoolTransaction for MockTransaction {
         }
     }
 
-    fn sender(&self) -> &Address {
+    fn sender(&self) -> Address {
         match self {
-            MockTransaction::Legacy { sender, .. } => sender,
-            MockTransaction::Eip1559 { sender, .. } => sender,
+            MockTransaction::Legacy { sender, .. } => *sender,
+            MockTransaction::Eip1559 { sender, .. } => *sender,
         }
     }
 

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -240,7 +240,7 @@ pub trait PoolTransaction: fmt::Debug + Send + Sync + FromRecoveredTransaction {
     fn hash(&self) -> &TxHash;
 
     /// The Sender of the transaction.
-    fn sender(&self) -> &Address;
+    fn sender(&self) -> Address;
 
     /// Returns the nonce for this transaction.
     fn nonce(&self) -> u64;

--- a/crates/transaction-pool/src/validate.rs
+++ b/crates/transaction-pool/src/validate.rs
@@ -69,7 +69,7 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
     }
 
     /// Returns the address of the sender
-    pub fn sender(&self) -> &Address {
+    pub fn sender(&self) -> Address {
         self.transaction.sender()
     }
 


### PR DESCRIPTION
the issue related to https://github.com/Will-Smith11/reconnaissance networking issue was caused because when we go to `fill_outbound_slots` we increase our out connections. however if the connection fails we never decrease this amount so the node stops making requests because it thinks its hit max connections