### PR TITLE
meta(contrib): bug issue template platform type

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -40,11 +40,12 @@ body:
       render: text
     validations:
       required: false
-  - type: checkboxes
+  - type: dropdown
     id: platform
     attributes:
       label: Platform(s)
       description: What platform(s) did this occur on?
+      multiple: true
       options:
         - Linux (x86)
         - Linux (ARM)


### PR DESCRIPTION
The bug issue template is currently not rendered with `body[4]: options values must be of type Hash.` error