### PR TITLE
fix(net): improve dropped connection handling

### DIFF
--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -505,9 +505,9 @@ where
                         "Session disconnected"
                     );
 
-                    if error.is_some() {
+                    if let Some(ref err) = error {
                         // If the connection was closed due to an error, we report the peer
-                        this.swarm.state_mut().peers_mut().on_connection_dropped(&peer_id);
+                        this.swarm.state_mut().peers_mut().on_connection_dropped(&peer_id, err);
                     } else {
                         // Gracefully disconnected
                         this.swarm.state_mut().peers_mut().on_disconnected(&peer_id);

--- a/crates/net/network/src/message.rs
+++ b/crates/net/network/src/message.rs
@@ -13,6 +13,7 @@ use reth_eth_wire::{
 use reth_interfaces::p2p::error::{RequestError, RequestResult};
 use reth_primitives::{Header, PeerId, Receipt, TransactionSigned, H256};
 use std::{
+    fmt,
     sync::Arc,
     task::{ready, Context, Poll},
 };
@@ -253,7 +254,7 @@ impl PeerResponseResult {
 }
 
 /// A Cloneable connection for sending _requests_ directly to the session of a peer.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct PeerRequestSender {
     /// id of the remote node.
     pub(crate) peer_id: PeerId,
@@ -272,5 +273,11 @@ impl PeerRequestSender {
     /// Returns the peer id of the remote peer.
     pub fn peer_id(&self) -> &PeerId {
         &self.peer_id
+    }
+}
+
+impl fmt::Debug for PeerRequestSender {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PeerRequestSender").field("peer_id", &self.peer_id).finish_non_exhaustive()
     }
 }


### PR DESCRIPTION
Improves dropped connection handling.

If the error indicates that we'll never be able to establish a session, then we'll remove the peer from the peerset.