### PR TITLE
fix(sync): test db size map

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -62,7 +62,7 @@ impl<E: EnvironmentKind> Env<E> {
             inner: Environment::new()
                 .set_max_dbs(TABLES.len())
                 .set_geometry(Geometry {
-                    size: Some(0..0x1000000),    // TODO: reevaluate
+                    size: Some(0..0x10000000),   // TODO: reevaluate
                     growth_step: Some(0x100000), // TODO: reevaluate
                     shrink_threshold: None,
                     page_size: Some(PageSize::Set(default_page_size())),


### PR DESCRIPTION
This fixes the flaky `bodies::tests::unwind` test with errors out with `MDBX_MAP_FULL `