### PR TITLE
refactor(disc): use discv4 as log target

### DIFF
--- a/crates/net/discv4/src/mock.rs
+++ b/crates/net/discv4/src/mock.rs
@@ -149,7 +149,7 @@ impl Stream for MockDiscovery {
             match event {
                 IngressEvent::RecvError(_) => {}
                 IngressEvent::BadPacket(from, err, data) => {
-                    error!( target : "net::disc", ?from, ?err, packet=?hex::encode(&data), "bad packet");
+                    error!( target : "discv4", ?from, ?err, packet=?hex::encode(&data), "bad packet");
                 }
                 IngressEvent::Packet(remote_addr, Packet { msg, node_id, hash }) => match msg {
                     Message::Ping(ping) => {


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/419

this makes it easier to configure the log targets so `net` doesn't get polluted