### PR TITLE
feat(net): draft for sending status updates through `NetworkHandle`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3626,6 +3626,7 @@ dependencies = [
  "reth-eth-wire",
  "reth-executor",
  "reth-interfaces",
+ "reth-network",
  "reth-primitives",
  "reth-provider",
  "reth-rlp",

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -63,6 +63,7 @@ impl Command {
                         .build(consensus.clone(), fetch_client.clone()),
                     consensus: consensus.clone(),
                     client: fetch_client.clone(),
+                    network_handle: network.clone(),
                     commit_threshold: 100,
                 },
                 false,

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -20,11 +20,7 @@ use reth_network::{
 use reth_primitives::{hex_literal::hex, Bytes, Header, H256, U256};
 use reth_provider::{db_provider::ProviderImpl, BlockProvider, HeaderProvider};
 use reth_stages::stages::{bodies::BodyStage, headers::HeaderStage, senders::SendersStage};
-use std::{
-    path::Path,
-    str::FromStr,
-    sync::Arc,
-};
+use std::{path::Path, str::FromStr, sync::Arc};
 use tracing::{debug, info};
 
 /// Start the client

--- a/crates/interfaces/src/p2p/headers/client.rs
+++ b/crates/interfaces/src/p2p/headers/client.rs
@@ -1,7 +1,7 @@
 use crate::p2p::error::PeerRequestResult;
 use async_trait::async_trait;
 pub use reth_eth_wire::BlockHeaders;
-use reth_primitives::{BlockHashOrNumber, HeadersDirection};
+use reth_primitives::{BlockHashOrNumber, HeadersDirection, H256, U256};
 use std::fmt::Debug;
 
 /// The header request struct to be sent to connected peers, which
@@ -23,4 +23,10 @@ pub trait HeadersClient: Send + Sync + Debug {
     /// Sends the header request to the p2p network and returns the header response received from a
     /// peer.
     async fn get_headers(&self, request: HeadersRequest) -> PeerRequestResult<BlockHeaders>;
+}
+
+/// The status updater for updating the status of the p2p node
+pub trait StatusUpdater: Send + Sync {
+    /// Updates the status of the p2p node
+    fn update_status(&self, height: u64, hash: H256, total_difficulty: U256);
 }

--- a/crates/interfaces/src/p2p/headers/client.rs
+++ b/crates/interfaces/src/p2p/headers/client.rs
@@ -1,7 +1,7 @@
 use crate::p2p::error::PeerRequestResult;
 use async_trait::async_trait;
 pub use reth_eth_wire::BlockHeaders;
-use reth_primitives::{BlockHashOrNumber, HeadersDirection, H256, U256};
+use reth_primitives::{BlockHashOrNumber, HeadersDirection};
 use std::fmt::Debug;
 
 /// The header request struct to be sent to connected peers, which
@@ -20,11 +20,6 @@ pub struct HeadersRequest {
 #[async_trait]
 #[auto_impl::auto_impl(&, Arc, Box)]
 pub trait HeadersClient: Send + Sync + Debug {
-    /// Update the node's Status message.
-    ///
-    /// The updated Status message will be used during any new eth/65 handshakes.
-    fn update_status(&self, height: u64, hash: H256, td: U256);
-
     /// Sends the header request to the p2p network and returns the header response received from a
     /// peer.
     async fn get_headers(&self, request: HeadersRequest) -> PeerRequestResult<BlockHeaders>;

--- a/crates/interfaces/src/test_utils/headers.rs
+++ b/crates/interfaces/src/test_utils/headers.rs
@@ -227,14 +227,8 @@ impl TestConsensus {
 }
 
 /// Nil status updater for testing
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct TestStatusUpdater;
-
-impl Default for TestStatusUpdater {
-    fn default() -> Self {
-        Self
-    }
-}
 
 impl StatusUpdater for TestStatusUpdater {
     fn update_status(&self, _height: u64, _hash: H256, _total_difficulty: reth_primitives::U256) {}

--- a/crates/interfaces/src/test_utils/headers.rs
+++ b/crates/interfaces/src/test_utils/headers.rs
@@ -5,7 +5,7 @@ use crate::{
         downloader::{DownloadStream, Downloader},
         error::{PeerRequestResult, RequestError},
         headers::{
-            client::{HeadersClient, HeadersRequest},
+            client::{HeadersClient, HeadersRequest, StatusUpdater},
             downloader::HeaderDownloader,
             error::DownloadError,
         },
@@ -224,6 +224,20 @@ impl TestConsensus {
     pub fn set_fail_validation(&self, val: bool) {
         self.fail_validation.store(val, Ordering::SeqCst)
     }
+}
+
+/// Nil status updater for testing
+#[derive(Debug, Clone)]
+pub struct TestStatusUpdater;
+
+impl Default for TestStatusUpdater {
+    fn default() -> Self {
+        Self
+    }
+}
+
+impl StatusUpdater for TestStatusUpdater {
+    fn update_status(&self, _height: u64, _hash: H256, _total_difficulty: reth_primitives::U256) {}
 }
 
 #[async_trait::async_trait]

--- a/crates/interfaces/src/test_utils/headers.rs
+++ b/crates/interfaces/src/test_utils/headers.rs
@@ -14,7 +14,7 @@ use crate::{
 use futures::{Future, FutureExt, Stream};
 use reth_eth_wire::BlockHeaders;
 use reth_primitives::{
-    BlockLocked, BlockNumber, Header, HeadersDirection, PeerId, SealedHeader, H256, U256,
+    BlockLocked, BlockNumber, Header, HeadersDirection, PeerId, SealedHeader, H256,
 };
 use reth_rpc_types::engine::ForkchoiceState;
 use std::{
@@ -170,8 +170,6 @@ impl TestHeadersClient {
 
 #[async_trait::async_trait]
 impl HeadersClient for TestHeadersClient {
-    fn update_status(&self, _height: u64, _hash: H256, _td: U256) {}
-
     async fn get_headers(&self, request: HeadersRequest) -> PeerRequestResult<BlockHeaders> {
         if let Some(err) = &mut *self.error.lock().await {
             return Err(err.clone())

--- a/crates/net/network/src/fetch/client.rs
+++ b/crates/net/network/src/fetch/client.rs
@@ -1,13 +1,13 @@
 //! A client implementation that can interact with the network and download data.
 
-use crate::fetch::{DownloadRequest, StatusUpdate};
+use crate::fetch::DownloadRequest;
 use reth_eth_wire::{BlockBody, BlockHeaders};
 use reth_interfaces::p2p::{
     bodies::client::BodiesClient,
     error::PeerRequestResult,
     headers::client::{HeadersClient, HeadersRequest},
 };
-use reth_primitives::{WithPeerId, H256, U256};
+use reth_primitives::{WithPeerId, H256};
 use tokio::sync::{mpsc::UnboundedSender, oneshot};
 
 /// Front-end API for fetching data from the network.
@@ -15,16 +15,10 @@ use tokio::sync::{mpsc::UnboundedSender, oneshot};
 pub struct FetchClient {
     /// Sender half of the request channel.
     pub(crate) request_tx: UnboundedSender<DownloadRequest>,
-    /// Sender for sending Status updates
-    pub(crate) status_tx: UnboundedSender<StatusUpdate>,
 }
 
 #[async_trait::async_trait]
 impl HeadersClient for FetchClient {
-    fn update_status(&self, height: u64, hash: H256, total_difficulty: U256) {
-        let _ = self.status_tx.send(StatusUpdate { height, hash, total_difficulty });
-    }
-
     /// Sends a `GetBlockHeaders` request to an available peer.
     async fn get_headers(&self, request: HeadersRequest) -> PeerRequestResult<BlockHeaders> {
         let (response, rx) = oneshot::channel();

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -235,6 +235,7 @@ impl StateFetcher {
         }
     }
 
+    /// Returns sender half of the [`StatusUpdate`] channel.
     pub(crate) fn update_status_tx(&self) -> UnboundedSender<StatusUpdate> {
         self.status_tx.clone()
     }

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -7,7 +7,7 @@ use reth_interfaces::p2p::{
     error::{PeerRequestResult, RequestError, RequestResult},
     headers::client::HeadersRequest,
 };
-use reth_primitives::{Header, PeerId, H256, U256};
+use reth_primitives::{Header, PeerId, H256};
 use std::{
     collections::{HashMap, VecDeque},
     task::{Context, Poll},
@@ -38,10 +38,6 @@ pub struct StateFetcher {
     download_requests_rx: UnboundedReceiverStream<DownloadRequest>,
     /// Sender for download requests, used to detach a [`FetchClient`]
     download_requests_tx: UnboundedSender<DownloadRequest>,
-    /// Receiver for new incoming [`StatusUpdate`] requests.
-    status_rx: UnboundedReceiverStream<StatusUpdate>,
-    /// Sender for updating the status, used to detach a [`FetchClient`]
-    status_tx: UnboundedSender<StatusUpdate>,
 }
 
 // === impl StateSyncer ===
@@ -119,10 +115,6 @@ impl StateFetcher {
                 PollAction::NoRequests => false,
                 PollAction::NoPeersAvailable => true,
             };
-
-            if let Poll::Ready(Some(status)) = self.status_rx.poll_next_unpin(cx) {
-                return Poll::Ready(FetchAction::StatusUpdate(status))
-            }
 
             loop {
                 // poll incoming requests
@@ -229,22 +221,13 @@ impl StateFetcher {
 
     /// Returns a new [`FetchClient`] that can send requests to this type.
     pub(crate) fn client(&self) -> FetchClient {
-        FetchClient {
-            request_tx: self.download_requests_tx.clone(),
-            status_tx: self.status_tx.clone(),
-        }
-    }
-
-    /// Returns sender half of the [`StatusUpdate`] channel.
-    pub(crate) fn update_status_tx(&self) -> UnboundedSender<StatusUpdate> {
-        self.status_tx.clone()
+        FetchClient { request_tx: self.download_requests_tx.clone() }
     }
 }
 
 impl Default for StateFetcher {
     fn default() -> Self {
         let (download_requests_tx, download_requests_rx) = mpsc::unbounded_channel();
-        let (status_tx, status_rx) = mpsc::unbounded_channel();
         Self {
             inflight_headers_requests: Default::default(),
             inflight_bodies_requests: Default::default(),
@@ -252,8 +235,6 @@ impl Default for StateFetcher {
             queued_requests: Default::default(),
             download_requests_rx: UnboundedReceiverStream::new(download_requests_rx),
             download_requests_tx,
-            status_rx: UnboundedReceiverStream::new(status_rx),
-            status_tx,
         }
     }
 }
@@ -319,14 +300,6 @@ struct Request<Req, Resp> {
     response: oneshot::Sender<Resp>,
 }
 
-/// A message to update the status.
-#[derive(Debug, Clone)]
-pub(crate) struct StatusUpdate {
-    pub(crate) height: u64,
-    pub(crate) hash: H256,
-    pub(crate) total_difficulty: U256,
-}
-
 /// Requests that can be sent to the Syncer from a [`FetchClient`]
 pub(crate) enum DownloadRequest {
     /// Download the requested headers and send response through channel
@@ -362,8 +335,6 @@ pub(crate) enum FetchAction {
         /// The request to send
         request: BlockRequest,
     },
-    /// Propagate a received status update for the node
-    StatusUpdate(StatusUpdate),
 }
 
 /// Outcome of a processed response.

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -73,7 +73,7 @@ impl StateFetcher {
             if number > peer.best_number {
                 peer.best_hash = hash;
                 peer.best_number = number;
-                return true
+                return true;
             }
         }
         false
@@ -95,13 +95,13 @@ impl StateFetcher {
     fn poll_action(&mut self) -> PollAction {
         // we only check and not pop here since we don't know yet whether a peer is available.
         if self.queued_requests.is_empty() {
-            return PollAction::NoRequests
+            return PollAction::NoRequests;
         }
 
         let peer_id = if let Some(peer) = self.next_peer() {
             *peer.0
         } else {
-            return PollAction::NoPeersAvailable
+            return PollAction::NoPeersAvailable;
         };
 
         let request = self.queued_requests.pop_front().expect("not empty; qed");
@@ -121,7 +121,7 @@ impl StateFetcher {
             };
 
             if let Poll::Ready(Some(status)) = self.status_rx.poll_next_unpin(cx) {
-                return Poll::Ready(FetchAction::StatusUpdate(status))
+                return Poll::Ready(FetchAction::StatusUpdate(status));
             }
 
             loop {
@@ -138,7 +138,7 @@ impl StateFetcher {
             }
 
             if self.queued_requests.is_empty() || no_peers_available {
-                return Poll::Pending
+                return Poll::Pending;
             }
         }
     }
@@ -197,14 +197,14 @@ impl StateFetcher {
             return Some(BlockResponseOutcome::BadResponse(
                 peer_id,
                 ReputationChangeKind::BadMessage,
-            ))
+            ));
         }
 
         if let Some(peer) = self.peers.get_mut(&peer_id) {
             // If the peer is still ready to be accept new requests, we try to send a followup
             // request immediately.
             if peer.state.on_request_finished() {
-                return self.followup_request(peer_id)
+                return self.followup_request(peer_id);
             }
         }
         None
@@ -221,7 +221,7 @@ impl StateFetcher {
         }
         if let Some(peer) = self.peers.get_mut(&peer_id) {
             if peer.state.on_request_finished() {
-                return self.followup_request(peer_id)
+                return self.followup_request(peer_id);
             }
         }
         None
@@ -233,6 +233,10 @@ impl StateFetcher {
             request_tx: self.download_requests_tx.clone(),
             status_tx: self.status_tx.clone(),
         }
+    }
+
+    pub(crate) fn update_status_tx(&self) -> UnboundedSender<StatusUpdate> {
+        self.status_tx.clone()
     }
 }
 
@@ -298,7 +302,7 @@ impl PeerState {
     fn on_request_finished(&mut self) -> bool {
         if !matches!(self, PeerState::Closing) {
             *self = PeerState::Idle;
-            return true
+            return true;
         }
         false
     }

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -73,7 +73,7 @@ impl StateFetcher {
             if number > peer.best_number {
                 peer.best_hash = hash;
                 peer.best_number = number;
-                return true;
+                return true
             }
         }
         false
@@ -95,13 +95,13 @@ impl StateFetcher {
     fn poll_action(&mut self) -> PollAction {
         // we only check and not pop here since we don't know yet whether a peer is available.
         if self.queued_requests.is_empty() {
-            return PollAction::NoRequests;
+            return PollAction::NoRequests
         }
 
         let peer_id = if let Some(peer) = self.next_peer() {
             *peer.0
         } else {
-            return PollAction::NoPeersAvailable;
+            return PollAction::NoPeersAvailable
         };
 
         let request = self.queued_requests.pop_front().expect("not empty; qed");
@@ -121,7 +121,7 @@ impl StateFetcher {
             };
 
             if let Poll::Ready(Some(status)) = self.status_rx.poll_next_unpin(cx) {
-                return Poll::Ready(FetchAction::StatusUpdate(status));
+                return Poll::Ready(FetchAction::StatusUpdate(status))
             }
 
             loop {
@@ -138,7 +138,7 @@ impl StateFetcher {
             }
 
             if self.queued_requests.is_empty() || no_peers_available {
-                return Poll::Pending;
+                return Poll::Pending
             }
         }
     }
@@ -197,14 +197,14 @@ impl StateFetcher {
             return Some(BlockResponseOutcome::BadResponse(
                 peer_id,
                 ReputationChangeKind::BadMessage,
-            ));
+            ))
         }
 
         if let Some(peer) = self.peers.get_mut(&peer_id) {
             // If the peer is still ready to be accept new requests, we try to send a followup
             // request immediately.
             if peer.state.on_request_finished() {
-                return self.followup_request(peer_id);
+                return self.followup_request(peer_id)
             }
         }
         None
@@ -221,7 +221,7 @@ impl StateFetcher {
         }
         if let Some(peer) = self.peers.get_mut(&peer_id) {
             if peer.state.on_request_finished() {
-                return self.followup_request(peer_id);
+                return self.followup_request(peer_id)
             }
         }
         None
@@ -303,7 +303,7 @@ impl PeerState {
     fn on_request_finished(&mut self) -> bool {
         if !matches!(self, PeerState::Closing) {
             *self = PeerState::Idle;
-            return true;
+            return true
         }
         false
     }

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -166,6 +166,9 @@ where
             SessionManager::new(secret_key, sessions_config, executor, status, hello_message);
         let state = NetworkState::new(client, discovery, peers_manger, genesis_hash);
 
+        // Clone the status updater sender to be able to update status from the network handler
+        let status_tx = state.fetch_client().status_tx.clone();
+
         let swarm = Swarm::new(incoming, sessions, state);
 
         let (to_manager_tx, from_handle_rx) = mpsc::unbounded_channel();
@@ -178,6 +181,7 @@ where
             local_peer_id,
             peers_handle,
             network_mode,
+            status_tx,
         );
 
         Ok(Self {
@@ -429,7 +433,7 @@ where
             NetworkHandleMessage::AnnounceBlock(block, hash) => {
                 if self.handle.mode().is_stake() {
                     error!(target : "net", "Block propagation is not supported in POS - [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#devp2p)");
-                    return
+                    return;
                 }
                 let msg = NewBlockMessage { hash, block: Arc::new(block) };
                 self.swarm.state_mut().announce_new_block(msg);
@@ -482,7 +486,7 @@ where
                     // This is only possible if the channel was deliberately closed since we always
                     // have an instance of `NetworkHandle`
                     error!("network message channel closed.");
-                    return Poll::Ready(())
+                    return Poll::Ready(());
                 }
                 Poll::Ready(Some(msg)) => this.on_handle_message(msg),
             };

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -167,7 +167,7 @@ where
         let state = NetworkState::new(client, discovery, peers_manger, genesis_hash);
 
         // Clone the status updater sender to be able to update status from the network handler
-        let status_tx = state.fetch_client().status_tx.clone();
+        let status_tx = state.update_status_tx();
 
         let swarm = Swarm::new(incoming, sessions, state);
 

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -456,8 +456,8 @@ where
             NetworkHandleMessage::FetchClient(tx) => {
                 let _ = tx.send(self.fetch_client());
             }
-            NetworkHandleMessage::StatusUpdate(update) => {
-                self.swarm.sessions_mut().on_status_update(update);
+            NetworkHandleMessage::StatusUpdate { height, hash, total_difficulty } => {
+                self.swarm.sessions_mut().on_status_update(height, hash, total_difficulty);
             }
         }
     }

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -433,7 +433,7 @@ where
             NetworkHandleMessage::AnnounceBlock(block, hash) => {
                 if self.handle.mode().is_stake() {
                     error!(target : "net", "Block propagation is not supported in POS - [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#devp2p)");
-                    return;
+                    return
                 }
                 let msg = NewBlockMessage { hash, block: Arc::new(block) };
                 self.swarm.state_mut().announce_new_block(msg);
@@ -486,7 +486,7 @@ where
                     // This is only possible if the channel was deliberately closed since we always
                     // have an instance of `NetworkHandle`
                     error!("network message channel closed.");
-                    return Poll::Ready(());
+                    return Poll::Ready(())
                 }
                 Poll::Ready(Some(msg)) => this.on_handle_message(msg),
             };

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -7,7 +7,7 @@ use crate::{
     FetchClient,
 };
 use parking_lot::Mutex;
-use reth_eth_wire::{NewBlock, NewPooledTransactionHashes, SharedTransactions, Status};
+use reth_eth_wire::{NewBlock, NewPooledTransactionHashes, SharedTransactions};
 use reth_primitives::{PeerId, TransactionSigned, TxHash, H256, U256};
 use std::{
     net::SocketAddr,

--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -21,7 +21,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::trace;
 
 /// A communication channel to the [`PeersManager`] to apply manual changes to the peer set.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PeersHandle {
     /// Sender half of command channel back to the [`PeersManager`]
     manager_tx: mpsc::UnboundedSender<PeerCommand>,

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -147,10 +147,10 @@ impl SessionManager {
     }
 
     /// Invoked on a received status update
-    pub(crate) fn on_status_update(&mut self, status: StatusUpdate) {
-        self.status.blockhash = status.hash;
-        self.status.total_difficulty = status.total_difficulty;
-        self.fork_filter.set_head(status.height);
+    pub(crate) fn on_status_update(&mut self, height: u64, hash: H256, total_difficulty: U256) {
+        self.status.blockhash = hash;
+        self.status.total_difficulty = total_difficulty;
+        self.fork_filter.set_head(height);
     }
 
     /// An incoming TCP connection was received. This starts the authentication process to turn this
@@ -424,14 +424,6 @@ impl SessionManager {
             }
         }
     }
-}
-
-/// A message to update the status.
-#[derive(Debug, Clone)]
-pub(crate) struct StatusUpdate {
-    pub(crate) height: u64,
-    pub(crate) hash: H256,
-    pub(crate) total_difficulty: U256,
 }
 
 /// Events produced by the [`SessionManager`]

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -1,7 +1,6 @@
 //! Support for handling peer sessions.
 pub use crate::message::PeerRequestSender;
 use crate::{
-    fetch::StatusUpdate,
     message::PeerMessage,
     session::{
         active::ActiveSession,
@@ -20,7 +19,7 @@ use reth_eth_wire::{
     error::EthStreamError,
     DisconnectReason, HelloMessage, Status, UnauthedEthStream, UnauthedP2PStream,
 };
-use reth_primitives::{ForkFilter, Hardfork, PeerId};
+use reth_primitives::{ForkFilter, Hardfork, PeerId, H256, U256};
 use secp256k1::SecretKey;
 use std::{
     collections::HashMap,
@@ -425,6 +424,14 @@ impl SessionManager {
             }
         }
     }
+}
+
+/// A message to update the status.
+#[derive(Debug, Clone)]
+pub(crate) struct StatusUpdate {
+    pub(crate) height: u64,
+    pub(crate) hash: H256,
+    pub(crate) total_difficulty: U256,
 }
 
 /// Events produced by the [`SessionManager`]

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -23,7 +23,7 @@ use std::{
     sync::Arc,
     task::{Context, Poll},
 };
-use tokio::sync::oneshot;
+use tokio::sync::{mpsc::UnboundedSender, oneshot};
 use tracing::error;
 
 /// Cache limit of blocks to keep track of for a single peer.
@@ -96,6 +96,10 @@ where
         self.state_fetcher.client()
     }
 
+    pub(crate) fn update_status_tx(&self) -> UnboundedSender<StatusUpdate> {
+        self.state_fetcher.update_status_tx()
+    }
+
     /// Configured genesis hash.
     pub fn genesis_hash(&self) -> H256 {
         self.genesis_hash
@@ -160,7 +164,7 @@ where
         for (peer_id, peer) in self.active_peers.iter_mut() {
             if peer.blocks.contains(&msg.hash) {
                 // skip peers which already reported the block
-                continue
+                continue;
             }
 
             // Queue a `NewBlock` message for the peer
@@ -180,7 +184,7 @@ where
             }
 
             if count >= num_propagate {
-                break
+                break;
             }
         }
     }
@@ -193,7 +197,7 @@ where
         for (peer_id, peer) in self.active_peers.iter_mut() {
             if peer.blocks.contains(&msg.hash) {
                 // skip peers which already reported the block
-                continue
+                continue;
             }
 
             if self.state_fetcher.update_peer_block(peer_id, msg.hash, number) {
@@ -328,7 +332,7 @@ where
         loop {
             // drain buffered messages
             if let Some(message) = self.queued_messages.pop_front() {
-                return Poll::Ready(message)
+                return Poll::Ready(message);
             }
 
             while let Poll::Ready(discovery) = self.discovery.poll(cx) {
@@ -342,7 +346,7 @@ where
                     }
                     FetchAction::StatusUpdate(status) => {
                         // we want to return this directly
-                        return Poll::Ready(StateAction::StatusUpdate(status))
+                        return Poll::Ready(StateAction::StatusUpdate(status));
                     }
                 }
             }
@@ -389,7 +393,7 @@ where
             }
 
             if self.queued_messages.is_empty() {
-                return Poll::Pending
+                return Poll::Pending;
             }
         }
     }

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -96,6 +96,7 @@ where
         self.state_fetcher.client()
     }
 
+    /// Returns sender half of the [`StatusUpdate`] channel.
     pub(crate) fn update_status_tx(&self) -> UnboundedSender<StatusUpdate> {
         self.state_fetcher.update_status_tx()
     }

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -165,7 +165,7 @@ where
         for (peer_id, peer) in self.active_peers.iter_mut() {
             if peer.blocks.contains(&msg.hash) {
                 // skip peers which already reported the block
-                continue;
+                continue
             }
 
             // Queue a `NewBlock` message for the peer
@@ -185,7 +185,7 @@ where
             }
 
             if count >= num_propagate {
-                break;
+                break
             }
         }
     }
@@ -198,7 +198,7 @@ where
         for (peer_id, peer) in self.active_peers.iter_mut() {
             if peer.blocks.contains(&msg.hash) {
                 // skip peers which already reported the block
-                continue;
+                continue
             }
 
             if self.state_fetcher.update_peer_block(peer_id, msg.hash, number) {
@@ -333,7 +333,7 @@ where
         loop {
             // drain buffered messages
             if let Some(message) = self.queued_messages.pop_front() {
-                return Poll::Ready(message);
+                return Poll::Ready(message)
             }
 
             while let Poll::Ready(discovery) = self.discovery.poll(cx) {
@@ -347,7 +347,7 @@ where
                     }
                     FetchAction::StatusUpdate(status) => {
                         // we want to return this directly
-                        return Poll::Ready(StateAction::StatusUpdate(status));
+                        return Poll::Ready(StateAction::StatusUpdate(status))
                     }
                 }
             }
@@ -394,7 +394,7 @@ where
             }
 
             if self.queued_messages.is_empty() {
-                return Poll::Pending;
+                return Poll::Pending
             }
         }
     }

--- a/crates/net/network/src/swarm.rs
+++ b/crates/net/network/src/swarm.rs
@@ -1,5 +1,4 @@
 use crate::{
-    fetch::StatusUpdate,
     listener::{ConnectionListener, ListenerEvent},
     message::{PeerMessage, PeerRequestSender},
     peers::InboundConnectionError,
@@ -221,7 +220,6 @@ where
                 let msg = PeerMessage::NewBlockHashes(hashes);
                 self.sessions.send_message(&peer_id, msg);
             }
-            StateAction::StatusUpdate(status) => return Some(SwarmEvent::StatusUpdate(status)),
         }
         None
     }
@@ -279,8 +277,6 @@ where
 /// All events created or delegated by the [`Swarm`] that represents changes to the state of the
 /// network.
 pub(crate) enum SwarmEvent {
-    /// Received a node status update.
-    StatusUpdate(StatusUpdate),
     /// Events related to the actual network protocol.
     ValidMessage {
         /// The peer that sent the message

--- a/crates/stages/Cargo.toml
+++ b/crates/stages/Cargo.toml
@@ -14,7 +14,8 @@ reth-interfaces = { path = "../interfaces" }
 reth-executor = { path = "../executor" }
 reth-rlp = { path = "../common/rlp" }
 reth-db = { path = "../storage/db" }
-reth-provider = { path = "../storage/provider"}
+reth-provider = { path = "../storage/provider" }
+reth-network = { path = "../net/network" }
 
 #async
 tokio = { version = "1.21.2", features = ["sync"] }
@@ -34,7 +35,7 @@ rayon = "1.6.0"
 reth-db = { path = "../storage/db", features = ["test-utils", "mdbx"] }
 reth-interfaces = { path = "../interfaces", features = ["test-utils"] }
 reth-downloaders = { path = "../net/downloaders" }
-reth-eth-wire = { path = "../net/eth-wire" } # TODO(onbjerg): We only need this for [BlockBody]
+reth-eth-wire = { path = "../net/eth-wire" }                            # TODO(onbjerg): We only need this for [BlockBody]
 tokio = { version = "*", features = ["rt", "sync", "macros"] }
 tokio-stream = "0.1.10"
 tempfile = "3.3.0"


### PR DESCRIPTION
Draft for #407 

Currently only exposes an `update_status` method on `NetworkHandle`. Still have to move out of `HeadersClient`, waiting for feedback.