### PR TITLE
feat(net): integrate discovery banlist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3266,6 +3266,7 @@ dependencies = [
  "hex",
  "public-ip",
  "rand 0.8.5",
+ "reth-net-common",
  "reth-primitives",
  "reth-rlp",
  "reth-rlp-derive",
@@ -3451,6 +3452,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-net-common"
+version = "0.1.0"
+dependencies = [
+ "reth-primitives",
+]
+
+[[package]]
 name = "reth-network"
 version = "0.1.0"
 dependencies = [
@@ -3472,6 +3480,7 @@ dependencies = [
  "reth-ecies",
  "reth-eth-wire",
  "reth-interfaces",
+ "reth-net-common",
  "reth-primitives",
  "reth-provider",
  "reth-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/consensus",
     "crates/executor",
     "crates/interfaces",
+    "crates/net/common",
     "crates/net/ecies",
     "crates/net/eth-wire",
     "crates/net/discv4",

--- a/crates/net/common/Cargo.toml
+++ b/crates/net/common/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "reth-net-common"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+repository = "https://github.com/paradigmxyz/reth"
+description = """
+Types shared accross network code
+"""
+
+[dependencies]
+# reth
+reth-primitives = { path = "../../primitives" }

--- a/crates/net/common/src/ban_list.rs
+++ b/crates/net/common/src/ban_list.rs
@@ -1,0 +1,134 @@
+//! Support for banning peers.
+use reth_primitives::PeerId;
+use std::{collections::HashMap, net::IpAddr, time::Instant};
+
+/// Stores peers that should be taken out of circulation either indefinitely or until a certain
+/// timestamp
+#[derive(Debug, Clone, Default)]
+pub struct BanList {
+    /// A set of IPs whose packets get dropped instantly.
+    banned_ips: HashMap<IpAddr, Option<Instant>>,
+    /// A set of [`PeerId`] whose packets get dropped instantly.
+    banned_peers: HashMap<PeerId, Option<Instant>>,
+}
+
+impl BanList {
+    /// Creates a new ban list that bans the given peers and ips indefinitely.
+    pub fn new(
+        banned_peers: impl IntoIterator<Item = PeerId>,
+        banned_ips: impl IntoIterator<Item = IpAddr>,
+    ) -> Self {
+        Self {
+            banned_ips: banned_ips.into_iter().map(|ip| (ip, None)).collect(),
+            banned_peers: banned_peers.into_iter().map(|peer| (peer, None)).collect(),
+        }
+    }
+
+    /// Creates a new ban list that bans the given peers and ips with an optional timeout.
+    pub fn new_with_timeout(
+        banned_peers: HashMap<PeerId, Option<Instant>>,
+        banned_ips: HashMap<IpAddr, Option<Instant>>,
+    ) -> Self {
+        Self { banned_ips, banned_peers }
+    }
+
+    /// Removes all entries that should no longer be banned.
+    pub fn evict(&mut self, now: Instant) {
+        self.banned_ips.retain(|_, until| {
+            if let Some(until) = until {
+                return *until > now
+            }
+            true
+        });
+
+        self.banned_peers.retain(|_, until| {
+            if let Some(until) = until {
+                return *until > now
+            }
+            true
+        });
+    }
+
+    /// Returns true if either the given peer id _or_ ip address is banned.
+    #[inline]
+    pub fn is_banned(&self, peer_id: &PeerId, ip: &IpAddr) -> bool {
+        self.is_banned_peer(peer_id) || self.is_banned_ip(ip)
+    }
+
+    /// checks the ban list to see if it contains the given ip
+    #[inline]
+    pub fn is_banned_ip(&self, ip: &IpAddr) -> bool {
+        self.banned_ips.contains_key(ip)
+    }
+
+    /// checks the ban list to see if it contains the given ip
+    #[inline]
+    pub fn is_banned_peer(&self, peer_id: &PeerId) -> bool {
+        self.banned_peers.contains_key(peer_id)
+    }
+
+    /// Unbans the ip address
+    pub fn unban_ip(&mut self, ip: &IpAddr) {
+        self.banned_ips.remove(ip);
+    }
+
+    /// Unbans the ip address
+    pub fn unban_peer(&mut self, peer_id: &PeerId) {
+        self.banned_peers.remove(peer_id);
+    }
+
+    /// Bans the IP until the timestamp.
+    pub fn ban_ip_until(&mut self, ip: IpAddr, until: Instant) {
+        self.ban_ip_with(ip, Some(until));
+    }
+
+    /// Bans the peer until the timestamp
+    pub fn ban_peer_until(&mut self, node_id: PeerId, until: Instant) {
+        self.ban_peer_with(node_id, Some(until));
+    }
+
+    /// Bans the IP indefinitely.
+    pub fn ban_ip(&mut self, ip: IpAddr) {
+        self.ban_ip_with(ip, None);
+    }
+
+    /// Bans the peer indefinitely,
+    pub fn ban_peer(&mut self, node_id: PeerId) {
+        self.ban_peer_with(node_id, None);
+    }
+
+    /// Bans the peer indefinitely or until the given timeout.
+    pub fn ban_peer_with(&mut self, node_id: PeerId, until: Option<Instant>) {
+        self.banned_peers.insert(node_id, until);
+    }
+
+    /// Bans the ip indefinitely or until the given timeout.
+    pub fn ban_ip_with(&mut self, ip: IpAddr, until: Option<Instant>) {
+        self.banned_ips.insert(ip, until);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_ban_unban_peer() {
+        let peer = PeerId::random();
+        let mut banlist = BanList::default();
+        banlist.ban_peer(peer);
+        assert!(banlist.is_banned_peer(&peer));
+        banlist.unban_peer(&peer);
+        assert!(!banlist.is_banned_peer(&peer));
+    }
+
+    #[test]
+    fn can_ban_unban_ip() {
+        let ip = IpAddr::from([0, 0, 0, 0]);
+        let mut banlist = BanList::default();
+        banlist.ban_ip(ip);
+        assert!(banlist.is_banned_ip(&ip));
+        banlist.unban_ip(&ip);
+        assert!(!banlist.is_banned_ip(&ip));
+    }
+}

--- a/crates/net/common/src/lib.rs
+++ b/crates/net/common/src/lib.rs
@@ -1,0 +1,10 @@
+#![warn(missing_docs, unused_crate_dependencies)]
+#![deny(unused_must_use, rust_2018_idioms)]
+#![doc(test(
+    no_crate_inject,
+    attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
+))]
+
+//! Shared types across reth-net
+
+pub mod ban_list;

--- a/crates/net/discv4/Cargo.toml
+++ b/crates/net/discv4/Cargo.toml
@@ -14,6 +14,7 @@ Ethereum network support
 reth-primitives = { path = "../../primitives" }
 reth-rlp = { path = "../../common/rlp" }
 reth-rlp-derive = { path = "../../common/rlp-derive" }
+reth-net-common = { path = "../common" }
 
 # ethereum
 discv5 = { git = "https://github.com/sigp/discv5" }

--- a/crates/net/discv4/src/config.rs
+++ b/crates/net/discv4/src/config.rs
@@ -1,5 +1,5 @@
 use crate::node::NodeRecord;
-use discv5::PermitBanList;
+use reth_net_common::ban_list::BanList;
 ///! A set of configuration parameters to tune the discovery protocol.
 // This basis of this file has been taken from the discv5 codebase:
 // https://github.com/sigp/discv5
@@ -24,9 +24,8 @@ pub struct Discv4Config {
     pub find_node_timeout: Duration,
     /// The duration we set for neighbours responses
     pub neighbours_timeout: Duration,
-    /// A set of lists that permit or ban IP's or PeerIds from the server. See
-    /// `crate::PermitBanList`.
-    pub permit_ban_list: PermitBanList,
+    /// Provides a way to ban peers and ips.
+    pub ban_list: BanList,
     /// Set the default duration for which nodes are banned for. This timeouts are checked every 5
     /// minutes, so the precision will be to the nearest 5 minutes. If set to `None`, bans from
     /// the filter will last indefinitely. Default is 1 hour.
@@ -58,7 +57,7 @@ impl Default for Discv4Config {
             find_node_timeout: Duration::from_secs(2),
             neighbours_timeout: Duration::from_secs(30),
             lookup_interval: Duration::from_secs(20),
-            permit_ban_list: PermitBanList::default(),
+            ban_list: Default::default(),
             ban_duration: Some(Duration::from_secs(3600)), // 1 hour
             bootstrap_nodes: Default::default(),
             enable_dht_random_walk: true,
@@ -110,10 +109,10 @@ impl Discv4ConfigBuilder {
         self
     }
 
-    /// A set of lists that permit or ban IP's or PeerIds from the server. See
-    /// `crate::PermitBanList`.
-    pub fn permit_ban_list(&mut self, list: PermitBanList) -> &mut Self {
-        self.config.permit_ban_list = list;
+    /// A set of lists that can ban IP's or PeerIds from the server. See
+    /// [`BanList`].
+    pub fn ban_list(&mut self, ban_list: BanList) -> &mut Self {
+        self.config.ban_list = ban_list;
         self
     }
 

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -36,7 +36,7 @@ use std::{
     cell::RefCell,
     collections::{btree_map, hash_map::Entry, BTreeMap, HashMap, VecDeque},
     io,
-    net::SocketAddr,
+    net::{IpAddr, SocketAddr},
     pin::Pin,
     rc::Rc,
     sync::Arc,
@@ -224,7 +224,50 @@ impl Discv4 {
     /// Triggers a new self lookup without expecting a response
     pub fn send_lookup_self(&self) {
         let cmd = Discv4Command::Lookup { node_id: None, tx: None };
-        let _ = self.to_service.try_send(cmd);
+        self.send_to_service(cmd);
+    }
+
+    /// Removes the peer from the table, if it exists.
+    pub fn remove_peer(&self, node_id: PeerId) {
+        let cmd = Discv4Command::Remove(node_id);
+        // we want this message to arrive, so we clone the sender
+        let _ = self.to_service.clone().try_send(cmd);
+    }
+
+    /// Adds the peer and id to the ban list.
+    ///
+    /// This will prevent any future inclusion in the table
+    pub fn ban(&self, node_id: PeerId, ip: IpAddr) {
+        let cmd = Discv4Command::Ban(node_id, ip);
+        // we want this message to arrive, so we clone the sender
+        let _ = self.to_service.clone().try_send(cmd);
+    }
+    /// Adds the ip to the ban list.
+    ///
+    /// This will prevent any future inclusion in the table
+    pub fn ban_ip(&self, ip: IpAddr) {
+        let cmd = Discv4Command::BanIp(ip);
+        // we want this message to arrive, so we clone the sender
+        let _ = self.to_service.clone().try_send(cmd);
+    }
+
+    /// Adds the peer to the ban list.
+    ///
+    /// This will prevent any future inclusion in the table
+    pub fn ban_node(&self, node_id: PeerId) {
+        let cmd = Discv4Command::BanPeer(node_id);
+        // we want this message to arrive, so we clone the sender
+        let _ = self.to_service.clone().try_send(cmd);
+    }
+
+    fn send_to_service(&self, cmd: Discv4Command) {
+        let _ = self.to_service.try_send(cmd).map_err(|err| {
+            warn!(
+                target : "discv4",
+                %err,
+                "dropping command",
+            )
+        });
     }
 
     /// Returns the receiver half of new listener channel that streams [`DiscoveryUpdate`]s.
@@ -505,6 +548,28 @@ impl Discv4Service {
         });
     }
 
+    /// Adds the ip to the ban list indefinitely
+    pub fn ban_ip(&mut self, ip: IpAddr) {
+        self.config.ban_list.ban_ip(ip);
+    }
+
+    /// Adds the peer to the ban list indefinitely.
+    pub fn ban_node(&mut self, node_id: PeerId) {
+        self.remove_node(node_id);
+        self.config.ban_list.ban_peer(node_id);
+    }
+
+    /// Adds the ip to the ban list until the given timestamp.
+    pub fn ban_ip_util(&mut self, ip: IpAddr, until: Instant) {
+        self.config.ban_list.ban_ip_until(ip, until);
+    }
+
+    /// Adds the peer to the ban list and bans it until the given timestamp
+    pub fn ban_node_util(&mut self, node_id: PeerId, until: Instant) {
+        self.remove_node(node_id);
+        self.config.ban_list.ban_peer_until(node_id, until);
+    }
+
     /// Removes a `node_id` from the routing table.
     ///
     /// This allows applications, for whatever reason, to remove nodes from the local routing
@@ -740,6 +805,12 @@ impl Discv4Service {
         // This is the recursive lookup step where we initiate new FindNode requests for new nodes
         // that where discovered.
         for node in msg.nodes {
+            // prevent banned peers from being added to the context
+            if self.config.ban_list.is_banned(&node.id, &node.address) {
+                trace!(target: "discv4", peer_id=?node.id, ip=?node.address, "ignoring banned record");
+                continue
+            }
+
             let key = kad_key(node.id);
             let distance = our_key.distance(&key);
             ctx.add_node(distance, node);
@@ -915,6 +986,17 @@ impl Discv4Service {
                             let rx = self.update_stream();
                             let _ = tx.send(rx);
                         }
+                        Discv4Command::BanPeer(node_id) => self.ban_node(node_id),
+                        Discv4Command::Remove(node_id) => {
+                            self.remove_node(node_id);
+                        }
+                        Discv4Command::Ban(node_id, ip) => {
+                            self.ban_node(node_id);
+                            self.ban_ip(ip);
+                        }
+                        Discv4Command::BanIp(ip) => {
+                            self.ban_ip(ip);
+                        }
                     }
                 } else {
                     is_done = true;
@@ -1046,6 +1128,10 @@ pub(crate) async fn receive_loop(udp: Arc<UdpSocket>, tx: IngressSender, local_i
 
 /// The commands sent from the frontend to the service
 enum Discv4Command {
+    Ban(PeerId, IpAddr),
+    BanPeer(PeerId),
+    BanIp(IpAddr),
+    Remove(PeerId),
     Lookup { node_id: Option<PeerId>, tx: Option<NodeRecordSender> },
     Updates(OneshotSender<ReceiverStream<DiscoveryUpdate>>),
 }

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -560,12 +560,12 @@ impl Discv4Service {
     }
 
     /// Adds the ip to the ban list until the given timestamp.
-    pub fn ban_ip_util(&mut self, ip: IpAddr, until: Instant) {
+    pub fn ban_ip_until(&mut self, ip: IpAddr, until: Instant) {
         self.config.ban_list.ban_ip_until(ip, until);
     }
 
     /// Adds the peer to the ban list and bans it until the given timestamp
-    pub fn ban_node_util(&mut self, node_id: PeerId, until: Instant) {
+    pub fn ban_node_until(&mut self, node_id: PeerId, until: Instant) {
         self.remove_node(node_id);
         self.config.ban_list.ban_peer_until(node_id, until);
     }

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -13,6 +13,7 @@ Ethereum network support
 # reth
 reth-interfaces = { path = "../../interfaces" }
 reth-primitives = { path = "../../primitives" }
+reth-net-common = { path = "../common" }
 reth-discv4 = { path = "../discv4" }
 reth-eth-wire = { path = "../eth-wire" }
 reth-ecies = { path = "../ecies" }

--- a/crates/net/network/src/discovery.rs
+++ b/crates/net/network/src/discovery.rs
@@ -7,7 +7,7 @@ use reth_primitives::PeerId;
 use secp256k1::SecretKey;
 use std::{
     collections::{hash_map::Entry, HashMap, VecDeque},
-    net::SocketAddr,
+    net::{IpAddr, SocketAddr},
     task::{Context, Poll},
 };
 use tokio::task::JoinHandle;
@@ -24,7 +24,7 @@ pub struct Discovery {
     /// Local ENR of the discovery service.
     local_enr: NodeRecord,
     /// Handler to interact with the Discovery v4 service
-    _discv4: Discv4,
+    discv4: Discv4,
     /// All KAD table updates from the discv4 service.
     discv4_updates: ReceiverStream<DiscoveryUpdate>,
     /// The initial config for the discv4 service
@@ -57,13 +57,23 @@ impl Discovery {
 
         Ok(Self {
             local_enr,
-            _discv4: discv4,
+            discv4,
             discv4_updates,
             _dsicv4_config: dsicv4_config,
             _discv4_service,
             discovered_nodes: Default::default(),
             queued_events: Default::default(),
         })
+    }
+
+    /// Bans the [`IpAddr`] in the discovery service.
+    pub(crate) fn ban_ip(&self, ip: IpAddr) {
+        self.discv4.ban_ip(ip)
+    }
+
+    /// Bans the [`PeerId`] and [`IpAddr`] in the discovery service.
+    pub(crate) fn ban(&self, peer_id: PeerId, ip: IpAddr) {
+        self.discv4.ban(peer_id, ip)
     }
 
     /// Returns the id with which the local identifies itself in the network

--- a/crates/net/network/src/error.rs
+++ b/crates/net/network/src/error.rs
@@ -1,5 +1,10 @@
 //! Possible errors when interacting with the network.
 
+use reth_eth_wire::{
+    error::{EthStreamError, HandshakeError, P2PHandshakeError, P2PStreamError},
+    DisconnectReason,
+};
+
 /// All error variants for the network
 #[derive(Debug, thiserror::Error)]
 pub enum NetworkError {
@@ -9,4 +14,39 @@ pub enum NetworkError {
     /// IO error when creating the discovery service
     #[error("Failed to launch discovery service: {0}")]
     Discovery(std::io::Error),
+}
+
+/// Returns true if the error indicates that the corresponding peer should be removed from peer
+/// discover
+pub(crate) fn error_merits_discovery_ban(err: &EthStreamError) -> bool {
+    match err {
+        EthStreamError::P2PStreamError(P2PStreamError::HandshakeError(
+            P2PHandshakeError::HelloNotInHandshake,
+        )) |
+        EthStreamError::P2PStreamError(P2PStreamError::HandshakeError(
+            P2PHandshakeError::NonHelloMessageInHandshake,
+        )) => true,
+        EthStreamError::HandshakeError(err) => !matches!(err, HandshakeError::NoResponse),
+        _ => false,
+    }
+}
+
+/// Returns true if the error indicates that we'll never be able to establish a connection to that
+/// peer. For example, not matching capabilities or a mismatch in protocols.
+pub(crate) fn is_fatal_protocol_error(err: &EthStreamError) -> bool {
+    match err {
+        EthStreamError::P2PStreamError(err) => {
+            matches!(
+                err,
+                P2PStreamError::HandshakeError(P2PHandshakeError::NoSharedCapabilities) |
+                    P2PStreamError::UnknownReservedMessageId(_) |
+                    P2PStreamError::EmptyProtocolMessage |
+                    P2PStreamError::ParseVersionError(_) |
+                    P2PStreamError::Disconnected(DisconnectReason::UselessPeer) |
+                    P2PStreamError::MismatchedProtocolVersion { .. }
+            )
+        }
+        EthStreamError::HandshakeError(err) => !matches!(err, HandshakeError::NoResponse),
+        _ => false,
+    }
 }

--- a/crates/net/network/src/lib.rs
+++ b/crates/net/network/src/lib.rs
@@ -102,4 +102,4 @@ pub use fetch::FetchClient;
 pub use manager::{NetworkEvent, NetworkManager};
 pub use message::PeerRequest;
 pub use network::NetworkHandle;
-pub use peers::{BanList, PeersConfig};
+pub use peers::PeersConfig;

--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -1,12 +1,13 @@
-use crate::peers::{reputation::BANNED_REPUTATION, ReputationChangeKind, ReputationChangeWeights};
-use futures::StreamExt;
-use reth_eth_wire::{
-    error::{EthStreamError, HandshakeError, P2PHandshakeError, P2PStreamError},
-    DisconnectReason,
+use crate::{
+    error::{error_merits_discovery_ban, is_fatal_protocol_error},
+    peers::{reputation::BANNED_REPUTATION, ReputationChangeKind, ReputationChangeWeights},
 };
+use futures::StreamExt;
+use reth_eth_wire::{error::EthStreamError, DisconnectReason};
+use reth_net_common::ban_list::BanList;
 use reth_primitives::PeerId;
 use std::{
-    collections::{hash_map::Entry, HashMap, HashSet, VecDeque},
+    collections::{hash_map::Entry, HashMap, VecDeque},
     fmt::Display,
     net::{IpAddr, SocketAddr},
     task::{Context, Poll},
@@ -109,7 +110,7 @@ impl PeersManager {
         &mut self,
         addr: IpAddr,
     ) -> Result<(), InboundConnectionError> {
-        if self.ban_list.banned_ip(&addr) {
+        if self.ban_list.is_banned_ip(&addr) {
             return Err(InboundConnectionError::IpBanned)
         }
         if !self.connection_info.has_in_capacity() {
@@ -140,7 +141,7 @@ impl PeersManager {
     pub(crate) fn on_active_inbound_session(&mut self, peer_id: PeerId, addr: SocketAddr) {
         // we only need to check the peer id here as the ip address will have been checked at
         // on_inbound_pending_session
-        if self.ban_list.banned_peer(&peer_id) {
+        if self.ban_list.is_banned_peer(&peer_id) {
             self.queued_actions.push_back(PeerAction::DisconnectBannedIncoming { peer_id });
             return
         }
@@ -197,12 +198,25 @@ impl PeersManager {
     ///
     /// Depending on whether the error is fatal, the peer will be removed from the peer set
     /// otherwise its reputation is slashed.
-    pub(crate) fn on_connection_dropped(&mut self, peer_id: &PeerId, err: &EthStreamError) {
+    pub(crate) fn on_connection_dropped(
+        &mut self,
+        remote_addr: &SocketAddr,
+        peer_id: &PeerId,
+        err: &EthStreamError,
+    ) {
         if is_fatal_protocol_error(err) {
             // remove the peer to which we can't establish a connection due to protocol related
             // issues.
             if let Some(peer) = self.peers.remove(peer_id) {
                 self.connection_info.decr_state(peer.state);
+            }
+
+            // If the error is caused by a peer that should be banned
+            if error_merits_discovery_ban(err) {
+                self.queued_actions.push_back(PeerAction::DiscoveryBan {
+                    peer_id: *peer_id,
+                    ip_addr: remote_addr.ip(),
+                })
             }
         } else if let Some(mut peer) = self.peers.get_mut(peer_id) {
             self.connection_info.decr_state(peer.state);
@@ -219,7 +233,7 @@ impl PeersManager {
     /// If the peer already exists, then the address will be updated. If the addresses differ, the
     /// old address is returned
     pub(crate) fn add_discovered_node(&mut self, peer_id: PeerId, addr: SocketAddr) {
-        if self.ban_list.is_banned(&addr.ip(), &peer_id) {
+        if self.ban_list.is_banned(&peer_id, &addr.ip()) {
             return
         }
 
@@ -488,6 +502,8 @@ pub enum PeerAction {
         /// Peer id of the established connection.
         peer_id: PeerId,
     },
+    /// Ban the peer in discovery.
+    DiscoveryBan { peer_id: PeerId, ip_addr: IpAddr },
 }
 
 /// Config type for initiating a [`PeersManager`] instance
@@ -550,40 +566,6 @@ impl PeersConfig {
     }
 }
 
-/// Configuration for the automatic removal of unwanted peers
-#[derive(Debug, Default)]
-pub struct BanList {
-    /// banned peer ids
-    banned_peers: HashSet<PeerId>,
-    /// banned ips
-    banned_ips: HashSet<IpAddr>,
-}
-
-impl BanList {
-    /// creates a new instance from existing values
-    pub fn new(banned_peers: HashSet<PeerId>, banned_ips: HashSet<IpAddr>) -> Self {
-        Self { banned_ips, banned_peers }
-    }
-
-    /// checks the ban list to see if it contains the given ip
-    #[inline]
-    pub(self) fn banned_ip(&self, ip: &IpAddr) -> bool {
-        self.banned_ips.contains(ip)
-    }
-
-    /// checks the banned list to see if it contains the given peer id
-    #[inline]
-    pub(self) fn banned_peer(&self, peer_id: &PeerId) -> bool {
-        self.banned_peers.contains(peer_id)
-    }
-    /// checks the ban list for the given ip address and peer_id and returns true
-    /// if the address is in the ban list
-    #[inline]
-    pub(self) fn is_banned(&self, ip: &IpAddr, peer_id: &PeerId) -> bool {
-        self.banned_ip(ip) || self.banned_peer(peer_id)
-    }
-}
-
 #[derive(Debug, Error)]
 pub enum InboundConnectionError {
     ExceedsLimit(usize),
@@ -596,50 +578,28 @@ impl Display for InboundConnectionError {
     }
 }
 
-/// Returns true if the error indicates that we'll never be able to establish a connection to that
-/// peer. For example, not matching capabilities or a mismatch in protocols.
-fn is_fatal_protocol_error(err: &EthStreamError) -> bool {
-    match err {
-        EthStreamError::P2PStreamError(err) => {
-            matches!(
-                err,
-                P2PStreamError::HandshakeError(P2PHandshakeError::NoSharedCapabilities) |
-                    P2PStreamError::UnknownReservedMessageId(_) |
-                    P2PStreamError::EmptyProtocolMessage |
-                    P2PStreamError::ParseVersionError(_) |
-                    P2PStreamError::Disconnected(DisconnectReason::UselessPeer) |
-                    P2PStreamError::MismatchedProtocolVersion { .. }
-            )
-        }
-        EthStreamError::HandshakeError(err) => !matches!(err, HandshakeError::NoResponse),
-        _ => false,
-    }
-}
-
 #[cfg(test)]
 mod test {
-    use std::{
-        collections::HashSet,
-        net::{IpAddr, Ipv4Addr, SocketAddr},
-    };
-
-    use reth_primitives::{PeerId, H512};
-
+    use super::PeersManager;
     use crate::{
         peers::{
             manager::{ConnectionInfo, PeerConnectionState},
             PeerAction,
         },
-        BanList, PeersConfig,
+        PeersConfig,
     };
-
-    use super::PeersManager;
+    use reth_net_common::ban_list::BanList;
+    use reth_primitives::{PeerId, H512};
+    use std::{
+        collections::HashSet,
+        net::{IpAddr, Ipv4Addr, SocketAddr},
+    };
 
     #[tokio::test]
     async fn test_discovery_ban_list() {
         let ip = IpAddr::V4(Ipv4Addr::new(127, 0, 1, 2));
         let socket_addr = SocketAddr::new(ip, 8008);
-        let ban_list = BanList::new(HashSet::default(), HashSet::from_iter(vec![ip]));
+        let ban_list = BanList::new(HashSet::new(), vec![ip]);
         let config = PeersConfig::default().with_ban_list(ban_list);
         let mut peer_manager = PeersManager::new(config);
         peer_manager.add_discovered_node(H512::default(), socket_addr);
@@ -651,7 +611,7 @@ mod test {
     async fn test_on_pending_ban_list() {
         let ip = IpAddr::V4(Ipv4Addr::new(127, 0, 1, 2));
         let socket_addr = SocketAddr::new(ip, 8008);
-        let ban_list = BanList::new(HashSet::default(), HashSet::from_iter(vec![ip]));
+        let ban_list = BanList::new(HashSet::new(), vec![ip]);
         let config = PeersConfig::default().with_ban_list(ban_list);
         let mut peer_manager = PeersManager::new(config);
         let a = peer_manager.on_inbound_pending_session(socket_addr.ip());
@@ -672,7 +632,7 @@ mod test {
         let ip = IpAddr::V4(Ipv4Addr::new(127, 0, 1, 2));
         let socket_addr = SocketAddr::new(ip, 8008);
         let given_peer_id: PeerId = H512::from_low_u64_ne(123403423412);
-        let ban_list = BanList::new(HashSet::from_iter(vec![given_peer_id]), HashSet::default());
+        let ban_list = BanList::new(vec![given_peer_id], HashSet::new());
         let config = PeersConfig::default().with_ban_list(ban_list);
         let mut peer_manager = PeersManager::new(config);
         peer_manager.on_active_inbound_session(given_peer_id, socket_addr);

--- a/crates/net/network/src/peers/mod.rs
+++ b/crates/net/network/src/peers/mod.rs
@@ -3,6 +3,6 @@
 mod manager;
 mod reputation;
 
-pub use manager::{BanList, PeersConfig, PeersHandle};
 pub(crate) use manager::{InboundConnectionError, PeerAction, PeersManager};
+pub use manager::{PeersConfig, PeersHandle};
 pub use reputation::{ReputationChangeKind, ReputationChangeWeights};

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -41,7 +41,9 @@ mod active;
 mod config;
 mod handle;
 pub use config::SessionsConfig;
+use reth_ecies::ECIESError;
 
+use crate::error::error_merits_discovery_ban;
 use reth_tasks::TaskExecutor;
 
 /// Internal identifier for active sessions.
@@ -368,14 +370,14 @@ impl SessionManager {
                     Direction::Incoming => {
                         Poll::Ready(SessionEvent::IncomingPendingSessionClosed {
                             remote_addr,
-                            error,
+                            error: error.map(PendingSessionHandshakeError::Eth),
                         })
                     }
                     Direction::Outgoing(peer_id) => {
                         Poll::Ready(SessionEvent::OutgoingPendingSessionClosed {
                             remote_addr,
                             peer_id,
-                            error,
+                            error: error.map(PendingSessionHandshakeError::Eth),
                         })
                     }
                 }
@@ -411,14 +413,14 @@ impl SessionManager {
                     Direction::Incoming => {
                         Poll::Ready(SessionEvent::IncomingPendingSessionClosed {
                             remote_addr,
-                            error: None,
+                            error: Some(PendingSessionHandshakeError::Ecies(error)),
                         })
                     }
                     Direction::Outgoing(peer_id) => {
                         Poll::Ready(SessionEvent::OutgoingPendingSessionClosed {
                             remote_addr,
                             peer_id,
-                            error: None,
+                            error: Some(PendingSessionHandshakeError::Ecies(error)),
                         })
                     }
                 }
@@ -459,13 +461,16 @@ pub(crate) enum SessionEvent {
         /// Identifier of the remote peer.
         peer_id: PeerId,
     },
-    /// Closed an incoming pending session during authentication.
-    IncomingPendingSessionClosed { remote_addr: SocketAddr, error: Option<EthStreamError> },
-    /// Closed an outgoing pending session during authentication.
+    /// Closed an incoming pending session during handshaking.
+    IncomingPendingSessionClosed {
+        remote_addr: SocketAddr,
+        error: Option<PendingSessionHandshakeError>,
+    },
+    /// Closed an outgoing pending session during handshaking.
     OutgoingPendingSessionClosed {
         remote_addr: SocketAddr,
         peer_id: PeerId,
-        error: Option<EthStreamError>,
+        error: Option<PendingSessionHandshakeError>,
     },
     /// Failed to establish a tcp stream
     OutgoingConnectionError { remote_addr: SocketAddr, peer_id: PeerId, error: io::Error },
@@ -480,6 +485,26 @@ pub(crate) enum SessionEvent {
     },
     /// Active session was gracefully disconnected.
     Disconnected { peer_id: PeerId, remote_addr: SocketAddr },
+}
+
+/// Errors that can occur during handshaking/authenticating the underlying streams.
+#[derive(Debug)]
+pub(crate) enum PendingSessionHandshakeError {
+    Eth(EthStreamError),
+    Ecies(ECIESError),
+}
+
+// === impl PendingSessionHandshakeError ===
+
+impl PendingSessionHandshakeError {
+    /// Returns true if the error indicates that the corresponding peer should be removed from peer
+    /// discover
+    pub(crate) fn merits_discovery_ban(&self) -> bool {
+        match self {
+            PendingSessionHandshakeError::Eth(eth) => error_merits_discovery_ban(eth),
+            PendingSessionHandshakeError::Ecies(_) => true,
+        }
+    }
 }
 
 /// The direction of the connection.

--- a/crates/net/network/src/swarm.rs
+++ b/crates/net/network/src/swarm.rs
@@ -3,7 +3,7 @@ use crate::{
     listener::{ConnectionListener, ListenerEvent},
     message::{PeerMessage, PeerRequestSender},
     peers::InboundConnectionError,
-    session::{Direction, SessionEvent, SessionId, SessionManager},
+    session::{Direction, PendingSessionHandshakeError, SessionEvent, SessionId, SessionManager},
     state::{NetworkState, StateAction},
 };
 use futures::Stream;
@@ -338,12 +338,15 @@ pub(crate) enum SwarmEvent {
         error: Option<EthStreamError>,
     },
     /// Closed an incoming pending session during authentication.
-    IncomingPendingSessionClosed { remote_addr: SocketAddr, error: Option<EthStreamError> },
+    IncomingPendingSessionClosed {
+        remote_addr: SocketAddr,
+        error: Option<PendingSessionHandshakeError>,
+    },
     /// Closed an outgoing pending session during authentication.
     OutgoingPendingSessionClosed {
         remote_addr: SocketAddr,
         peer_id: PeerId,
-        error: Option<EthStreamError>,
+        error: Option<PendingSessionHandshakeError>,
     },
     /// Failed to establish a tcp stream to the given address/node
     OutgoingConnectionError { remote_addr: SocketAddr, peer_id: PeerId, error: io::Error },

--- a/crates/net/network/tests/it/connect.rs
+++ b/crates/net/network/tests/it/connect.rs
@@ -8,7 +8,8 @@ use ethers_core::utils::Geth;
 use ethers_providers::{Http, Middleware, Provider};
 use futures::StreamExt;
 use reth_discv4::{bootnodes::mainnet_nodes, Discv4Config};
-use reth_network::{BanList, NetworkConfig, NetworkEvent, NetworkManager, PeersConfig};
+use reth_net_common::ban_list::BanList;
+use reth_network::{NetworkConfig, NetworkEvent, NetworkManager, PeersConfig};
 use reth_primitives::PeerId;
 use reth_provider::test_utils::TestApi;
 use secp256k1::SecretKey;
@@ -130,7 +131,7 @@ async fn test_incoming_node_id_blacklist() {
     let geth_peer_id: PeerId =
         provider.node_info().await.unwrap().enr.public_key().encode_uncompressed().into();
 
-    let ban_list = BanList::new(HashSet::from_iter(vec![geth_peer_id]), HashSet::default());
+    let ban_list = BanList::new(vec![geth_peer_id], HashSet::new());
     let peer_config = PeersConfig::default().with_ban_list(ban_list);
 
     let reth_p2p_socket = SocketAddr::new([127, 0, 0, 1].into(), 30303);


### PR DESCRIPTION
* extract and extend banlist, move to `common` crate, used in network and discovery
* match errors and decide to ban irrecoverable errors like bad handshake or wrong network (genesis mismatch), these nodes are taken out of circulation in the DHT