### PR TITLE
fix(net): ban useless peers

### DIFF
--- a/crates/net/network/src/error.rs
+++ b/crates/net/network/src/error.rs
@@ -25,6 +25,9 @@ pub(crate) fn error_merits_discovery_ban(err: &EthStreamError) -> bool {
         )) |
         EthStreamError::P2PStreamError(P2PStreamError::HandshakeError(
             P2PHandshakeError::NonHelloMessageInHandshake,
+        )) |
+        EthStreamError::P2PStreamError(P2PStreamError::Disconnected(
+            DisconnectReason::UselessPeer,
         )) => true,
         EthStreamError::HandshakeError(err) => !matches!(err, HandshakeError::NoResponse),
         _ => false,


### PR DESCRIPTION
if a node responds with UselessPeer (no matching protocols) we ban it from our discovery