### PR TITLE
meta(sync): tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,7 +1003,7 @@ dependencies = [
 [[package]]
 name = "discv5"
 version = "0.1.0"
-source = "git+https://github.com/mattsse/discv5?branch=matt/add-mut-value#3fcc98dd2dd86d56d8b43f3556f5171abed02f6d"
+source = "git+https://github.com/mattsse/discv5?branch=matt/add-mut-value#0a70cf9190aad45adebf6fb68a9d6573ce8a3be7"
 dependencies = [
  "aes 0.7.5",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,6 +1218,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1857,6 +1870,12 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -3778,6 +3797,7 @@ dependencies = [
  "aquamarine",
  "assert_matches",
  "async-trait",
+ "env_logger",
  "futures-util",
  "itertools 0.10.5",
  "metrics",
@@ -3793,6 +3813,7 @@ dependencies = [
  "reth-provider",
  "reth-rlp",
  "tempfile",
+ "test-log",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -4610,6 +4631,17 @@ dependencies = [
  "serde",
  "sha-1 0.10.1",
  "test-fuzz-internal",
+]
+
+[[package]]
+name = "test-log"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f0c854faeb68a048f0f2dc410c5ddae3bf83854ef0e4977d58306a5edef50e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,19 +1218,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,12 +1857,6 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -3797,7 +3778,6 @@ dependencies = [
  "aquamarine",
  "assert_matches",
  "async-trait",
- "env_logger",
  "futures-util",
  "itertools 0.10.5",
  "metrics",
@@ -3813,7 +3793,6 @@ dependencies = [
  "reth-provider",
  "reth-rlp",
  "tempfile",
- "test-log",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -4631,17 +4610,6 @@ dependencies = [
  "serde",
  "sha-1 0.10.1",
  "test-fuzz-internal",
-]
-
-[[package]]
-name = "test-log"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f0c854faeb68a048f0f2dc410c5ddae3bf83854ef0e4977d58306a5edef50e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/crates/stages/Cargo.toml
+++ b/crates/stages/Cargo.toml
@@ -41,3 +41,6 @@ tokio-stream = "0.1.10"
 tempfile = "3.3.0"
 assert_matches = "1.5.0"
 rand = "0.8.5"
+# TODO:
+env_logger = "*"
+test-log = "*"

--- a/crates/stages/Cargo.toml
+++ b/crates/stages/Cargo.toml
@@ -41,6 +41,3 @@ tokio-stream = "0.1.10"
 tempfile = "3.3.0"
 assert_matches = "1.5.0"
 rand = "0.8.5"
-# TODO:
-env_logger = "*"
-test-log = "*"

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -6,7 +6,7 @@ use futures_util::StreamExt;
 use reth_db::{
     cursor::{DbCursorRO, DbCursorRW},
     database::{Database, DatabaseGAT},
-    models::{StoredBlockBody, StoredBlockOmmers},
+    models::{BlockNumHash, StoredBlockBody, StoredBlockOmmers},
     tables,
     transaction::{DbTx, DbTxMut},
 };
@@ -16,7 +16,7 @@ use reth_interfaces::{
 };
 use reth_primitives::{BlockNumber, SealedHeader};
 use std::{fmt::Debug, sync::Arc};
-use tracing::{error, warn};
+use tracing::*;
 
 const BODIES: StageId = StageId("Bodies");
 
@@ -80,7 +80,7 @@ impl<DB: Database, D: BodyDownloader, C: Consensus> Stage<DB> for BodyStage<D, C
     ) -> Result<ExecOutput, StageError> {
         let previous_stage_progress = input.previous_stage_progress();
         if previous_stage_progress == 0 {
-            warn!("The body stage seems to be running first, no work can be completed.");
+            error!(target: "sync::stages::bodies", "The body stage is running first, no work can be done");
             return Err(StageError::DatabaseIntegrity(DatabaseIntegrityError::BlockBody {
                 number: 0,
             }))
@@ -93,6 +93,7 @@ impl<DB: Database, D: BodyDownloader, C: Consensus> Stage<DB> for BodyStage<D, C
         // Short circuit in case we already reached the target block
         let target = previous_stage_progress.min(starting_block + self.commit_threshold);
         if target <= stage_progress {
+            info!(target: "sync::stages::bodies", stage_progress, target, "Target block already reached");
             return Ok(ExecOutput { stage_progress, done: true })
         }
 
@@ -107,20 +108,17 @@ impl<DB: Database, D: BodyDownloader, C: Consensus> Stage<DB> for BodyStage<D, C
         let mut block_transition_cursor = tx.cursor_mut::<tables::BlockTransitionIndex>()?;
         let mut tx_transition_cursor = tx.cursor_mut::<tables::TxTransitionIndex>()?;
 
-        // Get id for the first transaction in the block
+        // Get id for the first transaction and first transition in the block
         let (mut current_tx_id, mut transition_id) = tx.get_next_block_ids(starting_block)?;
 
         // NOTE(onbjerg): The stream needs to live here otherwise it will just create a new iterator
         // on every iteration of the while loop -_-
         let mut bodies_stream = self.downloader.bodies_stream(bodies_to_download.iter());
         let mut highest_block = stage_progress;
+        trace!(target: "sync::stages::bodies", highest_block, tx_id = current_tx_id, transition_id, "Commencing sync");
         while let Some(result) = bodies_stream.next().await {
             let Ok(response) = result else {
-                error!(
-                    "Encountered an error downloading block {}: {:?}",
-                    highest_block + 1,
-                    result.unwrap_err()
-                );
+                error!(target: "sync::stages::bodies", block = highest_block + 1, error = ?result.unwrap_err(), "Error downloading block");
                 return Ok(ExecOutput {
                     stage_progress: highest_block,
                     done: false,
@@ -129,20 +127,21 @@ impl<DB: Database, D: BodyDownloader, C: Consensus> Stage<DB> for BodyStage<D, C
 
             // Write block
             let block_header = response.header();
-            let block_number = block_header.number;
-            let block_key = block_header.num_hash().into();
+            let numhash: BlockNumHash = block_header.num_hash().into();
 
             match response {
                 BlockResponse::Full(block) => {
+                    trace!(target: "sync::stages::bodies", ommers = block.ommers.len(), txs = block.body.len(), ?numhash, "Writing full block");
+
                     body_cursor.append(
-                        block_key,
+                        numhash,
                         StoredBlockBody {
                             start_tx_id: current_tx_id,
                             tx_count: block.body.len() as u64,
                         },
                     )?;
                     ommers_cursor.append(
-                        block_key,
+                        numhash,
                         StoredBlockOmmers {
                             ommers: block
                                 .ommers
@@ -164,8 +163,9 @@ impl<DB: Database, D: BodyDownloader, C: Consensus> Stage<DB> for BodyStage<D, C
                     }
                 }
                 BlockResponse::Empty(_) => {
+                    trace!(target: "sync::stages::bodies", ?numhash, "Writing empty block");
                     body_cursor.append(
-                        block_key,
+                        numhash,
                         StoredBlockBody { start_tx_id: current_tx_id, tx_count: 0 },
                     )?;
                 }
@@ -175,12 +175,14 @@ impl<DB: Database, D: BodyDownloader, C: Consensus> Stage<DB> for BodyStage<D, C
             // Increment the transition if the block contains an addition block reward.
             // If the block does not have a reward, the transition will be the same as the
             // transition at the last transaction of this block.
-            if self.consensus.has_block_reward(block_number) {
+            let has_reward = self.consensus.has_block_reward(numhash.number());
+            debug!(target: "sync::stages::bodies", has_reward, ?numhash, "Block reward");
+            if has_reward {
                 transition_id += 1;
             }
-            block_transition_cursor.append(block_key, transition_id)?;
+            block_transition_cursor.append(numhash, transition_id)?;
 
-            highest_block = block_number;
+            highest_block = numhash.number();
         }
 
         // The stage is "done" if:
@@ -188,6 +190,7 @@ impl<DB: Database, D: BodyDownloader, C: Consensus> Stage<DB> for BodyStage<D, C
         // - We reached our target and the target was not limited by the batch size of the stage
         let capped = target < previous_stage_progress;
         let done = highest_block < target || !capped;
+        info!(target: "sync::stages::bodies", stage_progress = highest_block, done, "Sync iteration finished");
 
         Ok(ExecOutput { stage_progress: highest_block, done })
     }
@@ -352,7 +355,7 @@ mod tests {
     }
 
     /// Same as [full_body_download] except we have made progress before
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn sync_from_previous_progress() {
         let (stage_progress, previous_stage) = (1, 21);
 

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -115,7 +115,7 @@ impl<DB: Database, D: BodyDownloader, C: Consensus> Stage<DB> for BodyStage<D, C
         // on every iteration of the while loop -_-
         let mut bodies_stream = self.downloader.bodies_stream(bodies_to_download.iter());
         let mut highest_block = stage_progress;
-        trace!(target: "sync::stages::bodies", highest_block, tx_id = current_tx_id, transition_id, "Commencing sync");
+        trace!(target: "sync::stages::bodies", stage_progress, target, start_tx_id = current_tx_id, transition_id, "Commencing sync");
         while let Some(result) = bodies_stream.next().await {
             let Ok(response) = result else {
                 error!(target: "sync::stages::bodies", block = highest_block + 1, error = ?result.unwrap_err(), "Error downloading block");
@@ -176,7 +176,7 @@ impl<DB: Database, D: BodyDownloader, C: Consensus> Stage<DB> for BodyStage<D, C
             // If the block does not have a reward, the transition will be the same as the
             // transition at the last transaction of this block.
             let has_reward = self.consensus.has_block_reward(numhash.number());
-            debug!(target: "sync::stages::bodies", has_reward, ?numhash, "Block reward");
+            trace!(target: "sync::stages::bodies", has_reward, ?numhash, "Block reward");
             if has_reward {
                 transition_id += 1;
             }
@@ -190,7 +190,7 @@ impl<DB: Database, D: BodyDownloader, C: Consensus> Stage<DB> for BodyStage<D, C
         // - We reached our target and the target was not limited by the batch size of the stage
         let capped = target < previous_stage_progress;
         let done = highest_block < target || !capped;
-        info!(target: "sync::stages::bodies", stage_progress = highest_block, done, "Sync iteration finished");
+        info!(target: "sync::stages::bodies", stage_progress = highest_block, target, done, "Sync iteration finished");
 
         Ok(ExecOutput { stage_progress: highest_block, done })
     }

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -355,7 +355,7 @@ mod tests {
     }
 
     /// Same as [full_body_download] except we have made progress before
-    #[test_log::test(tokio::test)]
+    #[tokio::test]
     async fn sync_from_previous_progress() {
         let (stage_progress, previous_stage) = (1, 21);
 

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -76,12 +76,7 @@ impl<DB: Database, D: HeaderDownloader, C: Consensus, H: HeadersClient, S: Statu
 
         // Lookup the head and tip of the sync range
         let (head, tip) = self.get_head_and_tip(tx, stage_progress).await?;
-        debug!(
-            target: "sync::stages::headers",
-            "Syncing from tip {:?} to head {:?}",
-            tip,
-            head.hash()
-        );
+        debug!(target: "sync::stages::headers", ?tip, head = ?head.hash(), "Commencing sync");
 
         let mut current_progress = stage_progress;
         let mut stream =
@@ -93,11 +88,7 @@ impl<DB: Database, D: HeaderDownloader, C: Consensus, H: HeadersClient, S: Statu
         while let Some(headers) = stream.next().await {
             match headers.into_iter().collect::<Result<Vec<_>, _>>() {
                 Ok(res) => {
-                    info!(
-                        target: "sync::stages::headers",
-                        len = res.len(),
-                        "Received headers"
-                    );
+                    info!(target: "sync::stages::headers", len = res.len(), "Received headers");
 
                     // Perform basic response validation
                     self.validate_header_response(&res)?;
@@ -107,25 +98,15 @@ impl<DB: Database, D: HeaderDownloader, C: Consensus, H: HeadersClient, S: Statu
                 }
                 Err(e) => match e {
                     DownloadError::Timeout => {
-                        warn!(
-                            target: "sync::stages::headers",
-                            "No response for header request"
-                        );
+                        warn!(target: "sync::stages::headers", "No response for header request");
                         return Err(StageError::Recoverable(DownloadError::Timeout.into()))
                     }
                     DownloadError::HeaderValidation { hash, error } => {
-                        error!(
-                            target: "sync::stages::headers",
-                            "Validation error for header {hash}: {error}"
-                        );
+                        error!( target: "sync::stages::headers", ?error, ?hash, "Validation error");
                         return Err(StageError::Validation { block: stage_progress, error })
                     }
                     error => {
-                        error!(
-                            target: "sync::stages::headers",
-                            ?error,
-                            "An unexpected error occurred"
-                        );
+                        error!(target: "sync::stages::headers", ?error, "Unexpected error");
                         return Err(StageError::Recoverable(error.into()))
                     }
                 },
@@ -133,6 +114,7 @@ impl<DB: Database, D: HeaderDownloader, C: Consensus, H: HeadersClient, S: Statu
         }
 
         // Write total difficulty values after all headers have been inserted
+        info!(target: "sync::stages::headers", head = ?head.hash(), "Writing total difficulty");
         self.write_td::<DB>(tx, &head)?;
 
         let stage_progress = current_progress.max(

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -102,7 +102,7 @@ impl<DB: Database, D: HeaderDownloader, C: Consensus, H: HeadersClient, S: Statu
                         return Err(StageError::Recoverable(DownloadError::Timeout.into()))
                     }
                     DownloadError::HeaderValidation { hash, error } => {
-                        error!( target: "sync::stages::headers", ?error, ?hash, "Validation error");
+                        error!(target: "sync::stages::headers", ?error, ?hash, "Validation error");
                         return Err(StageError::Validation { block: stage_progress, error })
                     }
                     error => {
@@ -114,7 +114,7 @@ impl<DB: Database, D: HeaderDownloader, C: Consensus, H: HeadersClient, S: Statu
         }
 
         // Write total difficulty values after all headers have been inserted
-        info!(target: "sync::stages::headers", head = ?head.hash(), "Writing total difficulty");
+        debug!(target: "sync::stages::headers", head = ?head.hash(), "Writing total difficulty");
         self.write_td::<DB>(tx, &head)?;
 
         let stage_progress = current_progress.max(

--- a/crates/stages/src/stages/senders.rs
+++ b/crates/stages/src/stages/senders.rs
@@ -13,6 +13,7 @@ use reth_db::{
 use reth_primitives::TxNumber;
 use std::fmt::Debug;
 use thiserror::Error;
+use tracing::*;
 
 const SENDERS: StageId = StageId("Senders");
 
@@ -63,6 +64,7 @@ impl<DB: Database> Stage<DB> for SendersStage {
         let max_block_num = previous_stage_progress.min(stage_progress + self.commit_threshold);
 
         if max_block_num <= stage_progress {
+            info!(target: "sync::stages::senders", max_block_num, stage_progress, "Target block already reached");
             return Ok(ExecOutput { stage_progress, done: true })
         }
 
@@ -74,6 +76,7 @@ impl<DB: Database> Stage<DB> for SendersStage {
 
         // No transactions to walk over
         if start_tx_index > end_tx_index {
+            info!(target: "sync::stages::senders", start_tx_index, end_tx_index, "Target transaction already reached");
             return Ok(ExecOutput { stage_progress: max_block_num, done: true })
         }
 
@@ -88,17 +91,19 @@ impl<DB: Database> Stage<DB> for SendersStage {
             .take_while(|res| res.as_ref().map(|(k, _)| *k <= end_tx_index).unwrap_or_default());
 
         // Iterate over transactions in chunks
+        info!(target: "sync::stages::senders", start_tx_index, end_tx_index, batch_size = self.batch_size, "Recovering senders");
         for chunk in &entries.chunks(self.batch_size) {
             let transactions = chunk.collect::<Result<Vec<_>, DbError>>()?;
             // Recover signers for the chunk in parallel
             let recovered = transactions
                 .into_par_iter()
-                .map(|(id, transaction)| {
+                .map(|(tx_id, transaction)| {
+                    trace!(target: "sync::stages::senders", tx_id, hash = ?transaction.hash(), "Recovering sender");
                     let signer =
                         transaction.recover_signer().ok_or_else::<StageError, _>(|| {
-                            SendersStageError::SenderRecovery { tx: id }.into()
+                            SendersStageError::SenderRecovery { tx: tx_id }.into()
                         })?;
-                    Ok((id, signer))
+                    Ok((tx_id, signer))
                 })
                 .collect::<Result<Vec<_>, StageError>>()?;
             // Append the signers to the table
@@ -106,6 +111,7 @@ impl<DB: Database> Stage<DB> for SendersStage {
         }
 
         let done = max_block_num >= previous_stage_progress;
+        info!(target: "sync::stages::senders", stage_progress = max_block_num, done, "Sync iteration finished");
         Ok(ExecOutput { stage_progress: max_block_num, done })
     }
 

--- a/crates/stages/src/stages/senders.rs
+++ b/crates/stages/src/stages/senders.rs
@@ -91,7 +91,7 @@ impl<DB: Database> Stage<DB> for SendersStage {
             .take_while(|res| res.as_ref().map(|(k, _)| *k <= end_tx_index).unwrap_or_default());
 
         // Iterate over transactions in chunks
-        info!(target: "sync::stages::senders", start_tx_index, end_tx_index, batch_size = self.batch_size, "Recovering senders");
+        info!(target: "sync::stages::senders", start_tx_index, end_tx_index, "Recovering senders");
         for chunk in &entries.chunks(self.batch_size) {
             let transactions = chunk.collect::<Result<Vec<_>, DbError>>()?;
             // Recover signers for the chunk in parallel

--- a/crates/stages/src/stages/senders.rs
+++ b/crates/stages/src/stages/senders.rs
@@ -64,7 +64,7 @@ impl<DB: Database> Stage<DB> for SendersStage {
         let max_block_num = previous_stage_progress.min(stage_progress + self.commit_threshold);
 
         if max_block_num <= stage_progress {
-            info!(target: "sync::stages::senders", max_block_num, stage_progress, "Target block already reached");
+            info!(target: "sync::stages::senders", target = max_block_num, stage_progress, "Target block already reached");
             return Ok(ExecOutput { stage_progress, done: true })
         }
 

--- a/crates/storage/db/src/tables/models/blocks.rs
+++ b/crates/storage/db/src/tables/models/blocks.rs
@@ -65,8 +65,14 @@ pub type HeaderHash = H256;
 /// element as BlockNumber, helps out with querying/sorting.
 ///
 /// Since it's used as a key, the `BlockNumber` is not compressed when encoding it.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct BlockNumHash(pub (BlockNumber, BlockHash));
+
+impl std::fmt::Debug for BlockNumHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("").field(&self.0 .0).field(&self.0 .1).finish()
+    }
+}
 
 impl BlockNumHash {
     /// Consumes `Self` and returns [`BlockNumber`], [`BlockHash`]


### PR DESCRIPTION
This PR adds tracing to sync stages. The target for the traces/logs is written in a format `sync::stages::<stage_name>`. The pipeline progress logic is written at the `info` level and per data block logs are written at the `trace` level