### PR TITLE
refactor(headers): introduce safe abstractions

### DIFF
--- a/crates/storage/db/src/abstraction/database.rs
+++ b/crates/storage/db/src/abstraction/database.rs
@@ -41,7 +41,8 @@ pub trait Database: for<'a> DatabaseGAT<'a> {
     /// the end of the execution.
     fn update<T, F>(&self, f: F) -> Result<T, Error>
     where
-        F: Fn(&<Self as DatabaseGAT<'_>>::TXMut) -> T,
+        // Any variables used inside update are moved and can only be used once.
+        F: FnOnce(&<Self as DatabaseGAT<'_>>::TXMut) -> T,
     {
         let tx = self.tx_mut()?;
 


### PR DESCRIPTION
Context:
* We were using `StageDB`, which is a wrapper over a mutable transaction, i.e. not really a DB, and has footguns (e.g. derefing to a tx makes it less clear to understand what is going on - my bad here when I introdcued this). This results into long-lived write transactions which we should think of as long-Mutexes, obviously bad.

Solution:
* We refactor each Stage to instead take a `DB: Database` and instantiate safe wrappers over it which proceed to give us methods for each action we want. For Headers, there is for example `HeadersReader` and `HeadersWriter`. These abstractions are going to be consumed by anyone that wants to use the DB, whether it's a stage, or a DB client.


TODO:
1. Refactor these safe abstractions in `storage/reth-providers`