### PR TITLE
fix(sync): headers stage progress

### DIFF
--- a/crates/interfaces/src/p2p/headers/downloader.rs
+++ b/crates/interfaces/src/p2p/headers/downloader.rs
@@ -6,8 +6,7 @@ use crate::{
     },
 };
 
-use reth_primitives::SealedHeader;
-use reth_rpc_types::engine::ForkchoiceState;
+use reth_primitives::{SealedHeader, H256};
 
 /// A downloader capable of fetching block headers.
 ///
@@ -17,11 +16,7 @@ use reth_rpc_types::engine::ForkchoiceState;
 #[auto_impl::auto_impl(&, Arc, Box)]
 pub trait HeaderDownloader: Downloader {
     /// Stream the headers
-    fn stream(
-        &self,
-        head: SealedHeader,
-        forkchoice: ForkchoiceState,
-    ) -> DownloadStream<'_, SealedHeader>;
+    fn stream(&self, head: SealedHeader, tip: H256) -> DownloadStream<'_, SealedHeader>;
 
     /// Validate whether the header is valid in relation to it's parent
     fn validate(&self, header: &SealedHeader, parent: &SealedHeader) -> DownloadResult<()> {

--- a/crates/interfaces/src/test_utils/headers.rs
+++ b/crates/interfaces/src/test_utils/headers.rs
@@ -67,11 +67,7 @@ impl Downloader for TestHeaderDownloader {
 
 #[async_trait::async_trait]
 impl HeaderDownloader for TestHeaderDownloader {
-    fn stream(
-        &self,
-        _head: SealedHeader,
-        _forkchoice: ForkchoiceState,
-    ) -> DownloadStream<'_, SealedHeader> {
+    fn stream(&self, _head: SealedHeader, _tip: H256) -> DownloadStream<'_, SealedHeader> {
         Box::pin(self.create_download())
     }
 }

--- a/crates/stages/src/error.rs
+++ b/crates/stages/src/error.rs
@@ -56,7 +56,10 @@ impl StageError {
     pub fn is_fatal(&self) -> bool {
         matches!(
             self,
-            StageError::Database(_) | StageError::DatabaseIntegrity(_) | StageError::Fatal(_)
+            StageError::Database(_) |
+                StageError::DatabaseIntegrity(_) |
+                StageError::Checkpoint(_) |
+                StageError::Fatal(_)
         )
     }
 }

--- a/crates/stages/src/error.rs
+++ b/crates/stages/src/error.rs
@@ -36,6 +36,9 @@ pub enum StageError {
     /// rely on external downloaders
     #[error("Invalid download response: {0}")]
     Download(String),
+    /// Invalid checkpoint passed to the stage
+    #[error("Invalid checkpoint: {0}")]
+    Checkpoint(u64),
     /// The stage encountered a recoverable error.
     ///
     /// These types of errors are caught by the [Pipeline] and trigger a restart of the stage.

--- a/crates/stages/src/error.rs
+++ b/crates/stages/src/error.rs
@@ -37,8 +37,8 @@ pub enum StageError {
     #[error("Invalid download response: {0}")]
     Download(String),
     /// Invalid checkpoint passed to the stage
-    #[error("Invalid checkpoint: {0}")]
-    Checkpoint(u64),
+    #[error("Invalid stage progress: {0}")]
+    StageProgress(u64),
     /// The stage encountered a recoverable error.
     ///
     /// These types of errors are caught by the [Pipeline] and trigger a restart of the stage.
@@ -58,7 +58,7 @@ impl StageError {
             self,
             StageError::Database(_) |
                 StageError::DatabaseIntegrity(_) |
-                StageError::Checkpoint(_) |
+                StageError::StageProgress(_) |
                 StageError::Fatal(_)
         )
     }

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -247,7 +247,7 @@ impl<D: BodyDownloader, C: Consensus> BodyStage<D, C> {
 mod tests {
     use super::*;
     use crate::test_utils::{
-        stage_test_suite, ExecuteStageTestRunner, StageTestRunner, UnwindStageTestRunner,
+        stage_test_suite_ext, ExecuteStageTestRunner, StageTestRunner, UnwindStageTestRunner,
         PREV_STAGE_ID,
     };
     use assert_matches::assert_matches;
@@ -258,7 +258,7 @@ mod tests {
     use std::collections::HashMap;
     use test_utils::*;
 
-    stage_test_suite!(BodyTestRunner);
+    stage_test_suite_ext!(BodyTestRunner);
 
     /// Checks that the stage downloads at most `batch_size` blocks.
     #[tokio::test]

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -204,7 +204,7 @@ impl<D: HeaderDownloader, C: Consensus, H: HeadersClient, S: StatusUpdater>
         let tip = match next_header {
             Some(header) if stage_progress + 1 != header.number => header.parent_hash,
             None => self.next_fork_choice_state(&head.hash()).await.head_block_hash,
-            _ => return Err(StageError::Checkpoint(stage_progress)),
+            _ => return Err(StageError::StageProgress(stage_progress)),
         };
         Ok((head, tip))
     }
@@ -446,7 +446,7 @@ mod tests {
             .expect("failed to write header");
         assert_matches!(
             stage.get_head_and_tip(&db, stage_progress).await,
-            Err(StageError::Checkpoint(progress)) if progress == stage_progress
+            Err(StageError::StageProgress(progress)) if progress == stage_progress
         );
     }
 

--- a/crates/stages/src/stages/senders.rs
+++ b/crates/stages/src/stages/senders.rs
@@ -131,11 +131,11 @@ mod tests {
 
     use super::*;
     use crate::test_utils::{
-        stage_test_suite, ExecuteStageTestRunner, StageTestRunner, TestRunnerError,
+        stage_test_suite_ext, ExecuteStageTestRunner, StageTestRunner, TestRunnerError,
         TestTransaction, UnwindStageTestRunner, PREV_STAGE_ID,
     };
 
-    stage_test_suite!(SendersTestRunner);
+    stage_test_suite_ext!(SendersTestRunner);
 
     #[tokio::test]
     async fn execute_intermediate_commit() {

--- a/crates/stages/src/stages/senders.rs
+++ b/crates/stages/src/stages/senders.rs
@@ -131,11 +131,11 @@ mod tests {
 
     use super::*;
     use crate::test_utils::{
-        stage_test_suite, ExecuteStageTestRunner, StageTestRunner, TestRunnerError, TestStageDB,
-        UnwindStageTestRunner, PREV_STAGE_ID,
+        stage_test_suite_ext, ExecuteStageTestRunner, StageTestRunner, TestRunnerError,
+        TestStageDB, UnwindStageTestRunner, PREV_STAGE_ID,
     };
 
-    stage_test_suite!(SendersTestRunner);
+    stage_test_suite_ext!(SendersTestRunner);
 
     #[tokio::test]
     async fn execute_intermediate_commit() {

--- a/crates/stages/src/test_utils/macros.rs
+++ b/crates/stages/src/test_utils/macros.rs
@@ -20,37 +20,6 @@ macro_rules! stage_test_suite {
             assert!(runner.validate_execution(input, result.ok()).is_ok(), "execution validation");
         }
 
-        /// Check that the execution is short-circuited if the target was already reached.
-        #[tokio::test]
-        async fn execute_already_reached_target() {
-            let stage_progress = 1000;
-
-            // Set up the runner
-            let mut runner = $runner::default();
-            let input = crate::stage::ExecInput {
-                previous_stage: Some((crate::test_utils::PREV_STAGE_ID, stage_progress)),
-                stage_progress: Some(stage_progress),
-            };
-            let seed = runner.seed_execution(input).expect("failed to seed");
-
-            // Run stage execution
-            let rx = runner.execute(input);
-
-            // Run `after_execution` hook
-            runner.after_execution(seed).await.expect("failed to run after execution hook");
-
-            // Assert the successful result
-            let result = rx.await.unwrap();
-            assert_matches::assert_matches!(
-                result,
-                Ok(ExecOutput { done, reached_tip, stage_progress })
-                    if done && reached_tip && stage_progress == stage_progress
-            );
-
-            // Validate the stage execution
-            assert!(runner.validate_execution(input, result.ok()).is_ok(), "execution validation");
-        }
-
         // Run the complete stage execution flow.
         #[tokio::test]
         async fn execute() {
@@ -142,4 +111,42 @@ macro_rules! stage_test_suite {
     };
 }
 
+macro_rules! stage_test_suite_ext {
+    ($runner:ident) => {
+        crate::test_utils::stage_test_suite!($runner);
+
+        /// Check that the execution is short-circuited if the target was already reached.
+        #[tokio::test]
+        async fn execute_already_reached_target() {
+            let stage_progress = 1000;
+
+            // Set up the runner
+            let mut runner = $runner::default();
+            let input = crate::stage::ExecInput {
+                previous_stage: Some((crate::test_utils::PREV_STAGE_ID, stage_progress)),
+                stage_progress: Some(stage_progress),
+            };
+            let seed = runner.seed_execution(input).expect("failed to seed");
+
+            // Run stage execution
+            let rx = runner.execute(input);
+
+            // Run `after_execution` hook
+            runner.after_execution(seed).await.expect("failed to run after execution hook");
+
+            // Assert the successful result
+            let result = rx.await.unwrap();
+            assert_matches::assert_matches!(
+                result,
+                Ok(ExecOutput { done, reached_tip, stage_progress })
+                    if done && reached_tip && stage_progress == stage_progress
+            );
+
+            // Validate the stage execution
+            assert!(runner.validate_execution(input, result.ok()).is_ok(), "execution validation");
+        }
+    };
+}
+
 pub(crate) use stage_test_suite;
+pub(crate) use stage_test_suite_ext;

--- a/crates/stages/src/test_utils/macros.rs
+++ b/crates/stages/src/test_utils/macros.rs
@@ -111,6 +111,8 @@ macro_rules! stage_test_suite {
     };
 }
 
+// `execute_already_reached_target` is not suitable for the headers stage thus
+// included in the test suite extension
 macro_rules! stage_test_suite_ext {
     ($runner:ident) => {
         crate::test_utils::stage_test_suite!($runner);


### PR DESCRIPTION
The previous behavior of the `HeaderStage` in case of an error would be propagating it to the pipeline. The stage might have already committed headers before encountering the error. Upon the next invocation of `HeaderStage::execute`, the stage would attempt to write headers from the consensus tip (without closing the db gap) resulting in overwrite and further failure.

This PR changes how the `HeaderStage` looks up the range of headers to download. The algorithm is the following:
- look up the `stage_progress` in the database
- look at the next item
  * if there is no next header, there is no gap in the database and we should download `[local head, consensus tip]` range
  * if the next header exists and isn't sequential, that header's parent hash will be the tip to download from
  * if the next header is congruent, the stage progress is invalid