### PR TITLE
feat(net): add `Status` to session established event

### DIFF
--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -35,7 +35,7 @@ use futures::{Future, StreamExt};
 use parking_lot::Mutex;
 use reth_eth_wire::{
     capability::{Capabilities, CapabilityMessage},
-    DisconnectReason,
+    DisconnectReason, Status,
 };
 use reth_primitives::{PeerId, H256};
 use reth_provider::BlockProvider;
@@ -522,6 +522,7 @@ where
                     remote_addr,
                     capabilities,
                     messages,
+                    status,
                     direction,
                 } => {
                     let total_active = this.num_active_peers.fetch_add(1, Ordering::Relaxed) + 1;
@@ -543,6 +544,7 @@ where
                     this.event_listeners.send(NetworkEvent::SessionEstablished {
                         peer_id,
                         capabilities,
+                        status,
                         messages,
                     });
                 }
@@ -645,6 +647,8 @@ pub enum NetworkEvent {
         capabilities: Arc<Capabilities>,
         /// A request channel to the session task.
         messages: PeerRequestSender,
+        /// The status of the peer to which a session was established.
+        status: Status,
     },
 }
 

--- a/crates/net/network/src/swarm.rs
+++ b/crates/net/network/src/swarm.rs
@@ -9,6 +9,7 @@ use futures::Stream;
 use reth_eth_wire::{
     capability::{Capabilities, CapabilityMessage},
     error::EthStreamError,
+    Status,
 };
 use reth_primitives::PeerId;
 use reth_provider::BlockProvider;
@@ -132,6 +133,7 @@ where
                     remote_addr,
                     capabilities,
                     messages,
+                    status,
                     direction,
                 })
             }
@@ -325,6 +327,7 @@ pub(crate) enum SwarmEvent {
         remote_addr: SocketAddr,
         capabilities: Arc<Capabilities>,
         messages: PeerRequestSender,
+        status: Status,
         direction: Direction,
     },
     SessionClosed {


### PR DESCRIPTION
Propagates the remote peer's `Status` up the event chain, so that it can be listened to through the network event listener. Useful for determining wether we want to stay connected to a given peer given the parameters in their status message.

Closes #466