### PR TITLE
fix(sync): remove redundant error

### DIFF
--- a/crates/stages/src/db.rs
+++ b/crates/stages/src/db.rs
@@ -106,7 +106,7 @@ where
     pub(crate) fn get_block_hash(&self, number: BlockNumber) -> Result<BlockHash, StageError> {
         let hash = self
             .get::<tables::CanonicalHeaders>(number)?
-            .ok_or(DatabaseIntegrityError::CanonicalHash { number })?;
+            .ok_or(DatabaseIntegrityError::CanonicalHeader { number })?;
         Ok(hash)
     }
 

--- a/crates/stages/src/error.rs
+++ b/crates/stages/src/error.rs
@@ -69,13 +69,6 @@ impl StageError {
 #[derive(Error, Debug)]
 #[allow(missing_docs)]
 pub enum DatabaseIntegrityError {
-    // TODO(onbjerg): What's the difference between this and the one below?
-    /// The canonical hash for a block is missing from the database.
-    #[error("No canonical hash for block #{number}")]
-    CanonicalHash {
-        /// The block number key
-        number: BlockNumber,
-    },
     /// The canonical header for a block is missing from the database.
     #[error("No canonical header for block #{number}")]
     CanonicalHeader {

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -178,7 +178,7 @@ impl<D: HeaderDownloader, C: Consensus, H: HeadersClient, S: StatusUpdater>
         // Get head hash and reposition the cursor
         let (head_num, head_hash) = cursor
             .seek_exact(stage_progress)?
-            .ok_or(DatabaseIntegrityError::CanonicalHash { number: stage_progress })?;
+            .ok_or(DatabaseIntegrityError::CanonicalHeader { number: stage_progress })?;
 
         // Construct head
         let (_, head) = header_cursor
@@ -415,7 +415,7 @@ mod tests {
         // Empty database
         assert_matches!(
             stage.get_head_and_tip(&db, stage_progress).await,
-            Err(StageError::DatabaseIntegrity(DatabaseIntegrityError::CanonicalHash { number }))
+            Err(StageError::DatabaseIntegrity(DatabaseIntegrityError::CanonicalHeader { number }))
                 if number == stage_progress
         );
 


### PR DESCRIPTION
The `CanonicalHash` error variant was unused