### PR TITLE
temp: header stage backoff stand-in

### DIFF
--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -105,30 +105,34 @@ impl<DB: Database, D: HeaderDownloader, C: Consensus, H: HeadersClient, S: Statu
                     db.commit()?;
                     current_progress = current_progress.max(write_progress);
                 }
-                Err(e) => match e {
-                    DownloadError::Timeout => {
-                        warn!(
-                            target: "sync::stages::headers",
-                            "No response for header request"
-                        );
-                        return Err(StageError::Recoverable(DownloadError::Timeout.into()))
+                Err(e) => {
+                    // TEMP: "Backoff"
+                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                    match e {
+                        DownloadError::Timeout => {
+                            warn!(
+                                target: "sync::stages::headers",
+                                "No response for header request"
+                            );
+                            return Err(StageError::Recoverable(DownloadError::Timeout.into()))
+                        }
+                        DownloadError::HeaderValidation { hash, error } => {
+                            error!(
+                                target: "sync::stages::headers",
+                                "Validation error for header {hash}: {error}"
+                            );
+                            return Err(StageError::Validation { block: stage_progress, error })
+                        }
+                        error => {
+                            error!(
+                                target: "sync::stages::headers",
+                                ?error,
+                                "An unexpected error occurred"
+                            );
+                            return Err(StageError::Recoverable(error.into()))
+                        }
                     }
-                    DownloadError::HeaderValidation { hash, error } => {
-                        error!(
-                            target: "sync::stages::headers",
-                            "Validation error for header {hash}: {error}"
-                        );
-                        return Err(StageError::Validation { block: stage_progress, error })
-                    }
-                    error => {
-                        error!(
-                            target: "sync::stages::headers",
-                            ?error,
-                            "An unexpected error occurred"
-                        );
-                        return Err(StageError::Recoverable(error.into()))
-                    }
-                },
+                }
             }
         }
 


### PR DESCRIPTION
In order to not spam peers we are connected to we should wait a bit when requests fail. This is a small temporary fix that introduces a 1 second delay, but it is obviously not ideal. We should implement a real backoff like we have in the bodies downloader.