### PR TITLE
feat: `reth stage` command

### DIFF
--- a/bin/reth/src/cli.rs
+++ b/bin/reth/src/cli.rs
@@ -1,12 +1,11 @@
 //! CLI definition and entrypoint to executable
 
-use clap::{ArgAction, Parser, Subcommand};
-use tracing_subscriber::util::SubscriberInitExt;
-
 use crate::{
-    db, node, test_eth_chain,
+    db, node, stage, test_eth_chain,
     util::reth_tracing::{self, TracingMode},
 };
+use clap::{ArgAction, Parser, Subcommand};
+use tracing_subscriber::util::SubscriberInitExt;
 
 /// main function that parses cli and runs command
 pub async fn run() -> eyre::Result<()> {
@@ -20,21 +19,25 @@ pub async fn run() -> eyre::Result<()> {
         Commands::Node(command) => command.execute().await,
         Commands::TestEthChain(command) => command.execute().await,
         Commands::Db(command) => command.execute().await,
+        Commands::Stage(command) => command.execute().await,
     }
 }
 
 /// Commands to be executed
 #[derive(Subcommand)]
 pub enum Commands {
-    /// Main node command
+    /// Start the node
     #[command(name = "node")]
     Node(node::Command),
-    /// Runs Ethereum blockchain tests
+    /// Run Ethereum blockchain tests
     #[command(name = "test-chain")]
     TestEthChain(test_eth_chain::Command),
-    /// DB Debugging utilities
+    /// Database debugging utilities
     #[command(name = "db")]
     Db(db::Command),
+    /// Run a single stage
+    #[command(name = "stage")]
+    Stage(stage::Command),
 }
 
 #[derive(Parser)]

--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -9,5 +9,6 @@
 pub mod cli;
 pub mod db;
 pub mod node;
+pub mod stage;
 pub mod test_eth_chain;
 pub mod util;

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -1,0 +1,33 @@
+//! Main db command
+//!
+//! Database debugging tool
+
+use clap::Parser;
+use std::path::Path;
+
+/// `reth stage` command
+#[derive(Debug, Parser)]
+pub struct Command {
+    /// Path to database folder
+    #[arg(long, default_value = "~/.reth/db")]
+    db: String,
+
+    /// The name of the stage to run
+    stage: String,
+}
+
+impl Command {
+    /// Execute `stage` command
+    pub async fn execute(&self) -> eyre::Result<()> {
+        let path = shellexpand::full(&self.db)?.into_owned();
+        let expanded_db_path = Path::new(&path);
+        std::fs::create_dir_all(expanded_db_path)?;
+
+        let _db = reth_db::mdbx::Env::<reth_db::mdbx::WriteMap>::open(
+            expanded_db_path,
+            reth_db::mdbx::EnvKind::RW,
+        )?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Adds a `reth stage` command to run stages in isolation.

Stages will read the database at the specified path. Some stages may require pre-existing data, which is out of scope for this tool: it has to be acquired elsewhere.

The command uses the minimum number of flags possible to keep the maintenance burden low - specialized config for some stages will not be possible. At some point when we have node config, we should revisit and possibly load the config for stage-specific config as well.