### PR TITLE
RLP decoding error tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3577,6 +3577,7 @@ dependencies = [
  "rlp",
  "secp256k1",
  "smol_str",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/common/rlp/Cargo.toml
+++ b/crates/common/rlp/Cargo.toml
@@ -16,6 +16,7 @@ enr = { version = "0.7", default-features = false, optional = true }
 rlp = { version = "0.5.2", default-features = false, optional = true }
 ethereum-types = { version = "0.14", features = ["codec"], optional = true }
 reth-rlp-derive = { version = "0.1", path = "../rlp-derive", optional = true }
+tracing = "0.1.37"
 
 [dev-dependencies]
 reth-rlp = { path = ".", package = "reth-rlp", features = [

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -74,7 +74,7 @@ where
         let msg = match ProtocolMessage::decode(&mut their_msg.as_ref()) {
             Ok(m) => m,
             Err(err) => {
-                tracing::warn!("rlp decode error in handshake: msg={their_msg:x}");
+                tracing::warn!("rlp decode error in eth handshake: msg={their_msg:x}");
                 return Err(err.into())
             }
         };

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -73,7 +73,10 @@ where
 
         let msg = match ProtocolMessage::decode(&mut their_msg.as_ref()) {
             Ok(m) => m,
-            Err(err) => return Err(err.into()),
+            Err(err) => {
+                tracing::trace!("rlp decode error {their_msg:?}");
+                return Err(err.into())
+            }
         };
 
         // TODO: Add any missing checks
@@ -191,7 +194,10 @@ where
 
         let msg = match ProtocolMessage::decode(&mut bytes.as_ref()) {
             Ok(m) => m,
-            Err(err) => return Poll::Ready(Some(Err(err.into()))),
+            Err(err) => {
+                tracing::trace!("rlp decode error {bytes:?}");
+                return Poll::Ready(Some(Err(err.into())))
+            }
         };
 
         if matches!(msg.message, EthMessage::Status(_)) {

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -74,7 +74,7 @@ where
         let msg = match ProtocolMessage::decode(&mut their_msg.as_ref()) {
             Ok(m) => m,
             Err(err) => {
-                tracing::warn!("rlp decode error in handshake {their_msg:x}");
+                tracing::warn!("rlp decode error in handshake: msg={their_msg:x}");
                 return Err(err.into())
             }
         };
@@ -195,7 +195,7 @@ where
         let msg = match ProtocolMessage::decode(&mut bytes.as_ref()) {
             Ok(m) => m,
             Err(err) => {
-                tracing::warn!("rlp decode error {bytes:x}");
+                tracing::warn!("rlp decode error: msg={bytes:x}");
                 return Poll::Ready(Some(Err(err.into())))
             }
         };

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -74,7 +74,7 @@ where
         let msg = match ProtocolMessage::decode(&mut their_msg.as_ref()) {
             Ok(m) => m,
             Err(err) => {
-                tracing::trace!("rlp decode error {their_msg:?}");
+                tracing::warn!("rlp decode error in handshake {their_msg:x}");
                 return Err(err.into())
             }
         };
@@ -195,7 +195,7 @@ where
         let msg = match ProtocolMessage::decode(&mut bytes.as_ref()) {
             Ok(m) => m,
             Err(err) => {
-                tracing::trace!("rlp decode error {bytes:?}");
+                tracing::warn!("rlp decode error {bytes:x}");
                 return Poll::Ready(Some(Err(err.into())))
             }
         };


### PR DESCRIPTION
Linked to https://github.com/paradigmxyz/reth/issues/325

This PR adds tracing to RLP decoding errors.

It adds two **WARN** level traces: one inside `UnauthedEthStream::handshake` and another one inside `EthStream::poll_next`.