### PR TITLE
fix(eth-wire): fix disconnect reason rlp decoding

### DIFF
--- a/crates/net/eth-wire/src/disconnect.rs
+++ b/crates/net/eth-wire/src/disconnect.rs
@@ -142,10 +142,12 @@ impl Decodable for DisconnectReason {
         } else if buf.len() == 4 {
             // snappy encoded as a rlp list containing a single byte
             // [2, 4, list header, rlp(reason)]
-            buf.advance(2); // safe, we have three bytes left
+            //  ^
 
             // advance the buffer to the end, one byte left
-            buf.advance(1);
+            // [2, 4, list header, rlp(reason)]
+            //                     ^
+            buf.advance(3); // safe, we have three bytes left
 
             // the reason is encoded at the end of the snappy encoded bytes
             u8::decode(buf)?

--- a/crates/net/eth-wire/src/disconnect.rs
+++ b/crates/net/eth-wire/src/disconnect.rs
@@ -157,7 +157,7 @@ impl Decodable for DisconnectReason {
             // the reason is encoded at the end of the snappy encoded bytes
             u8::decode(buf)?
         } else {
-            return Err(DecodeError::Custom("disconnect reason too long"))
+            return Err(DecodeError::Custom("invalid disconnect reason length"))
         };
 
         let reason = DisconnectReason::try_from(reason_byte)
@@ -285,34 +285,6 @@ mod tests {
     #[test]
     fn test_decode_known_reasons() {
         let all_reasons = vec![
-            // snappy, compressing a single byte
-            "010080",
-            "010001",
-            "010002",
-            "010003",
-            "010004",
-            "010005",
-            "010006",
-            "010007",
-            "010008",
-            "010009",
-            "01000a",
-            "01000b",
-            "010010",
-            // snappy, encoded the disconnect reason as a list
-            "010204c180",
-            "010204c101",
-            "010204c102",
-            "010204c103",
-            "010204c104",
-            "010204c105",
-            "010204c106",
-            "010204c107",
-            "010204c108",
-            "010204c109",
-            "010204c10a",
-            "010204c10b",
-            "010204c110",
             // non-snappy, encoding the disconnect reason as a single byte
             "0180",
             "0101",
@@ -341,6 +313,34 @@ mod tests {
             "01c10a",
             "01c10b",
             "01c110",
+            // snappy, compressing a single byte
+            "010080",
+            "010001",
+            "010002",
+            "010003",
+            "010004",
+            "010005",
+            "010006",
+            "010007",
+            "010008",
+            "010009",
+            "01000a",
+            "01000b",
+            "010010",
+            // snappy, encoded the disconnect reason as a list
+            "010204c180",
+            "010204c101",
+            "010204c102",
+            "010204c103",
+            "010204c104",
+            "010204c105",
+            "010204c106",
+            "010204c107",
+            "010204c108",
+            "010204c109",
+            "010204c10a",
+            "010204c10b",
+            "010204c110",
         ];
 
         for reason in all_reasons {

--- a/crates/net/eth-wire/src/disconnect.rs
+++ b/crates/net/eth-wire/src/disconnect.rs
@@ -274,6 +274,8 @@ mod tests {
             // snappy, compressing a single byte
             "010003",
             "010004",
+            "010008",
+            "010010",
             // snappy, encoded the disconnect reason as a list
             "010204c180",
             "010204c101",

--- a/crates/net/eth-wire/src/disconnect.rs
+++ b/crates/net/eth-wire/src/disconnect.rs
@@ -124,6 +124,7 @@ impl Encodable for DisconnectReason {
 /// input is snappy compressed.
 impl Decodable for DisconnectReason {
     fn decode(buf: &mut &[u8]) -> Result<Self, DecodeError> {
+        tracing::trace!("Decoding disconnect reason: {}", hex::encode(&buf));
         if buf.len() < 4 {
             return Err(DecodeError::Custom("disconnect reason should have 4 bytes"))
         }

--- a/crates/net/eth-wire/src/disconnect.rs
+++ b/crates/net/eth-wire/src/disconnect.rs
@@ -311,6 +311,7 @@ mod tests {
             "010010",
             // TODO: just saw this format once, not really sure what this format even is
             "01010003",
+            "01010000",
             // snappy, encoded the disconnect reason as a list
             "010204c180",
             "010204c101",

--- a/crates/net/eth-wire/src/disconnect.rs
+++ b/crates/net/eth-wire/src/disconnect.rs
@@ -124,22 +124,17 @@ impl Encodable for DisconnectReason {
 /// input is snappy compressed.
 impl Decodable for DisconnectReason {
     fn decode(buf: &mut &[u8]) -> Result<Self, DecodeError> {
-        println!("buf: {:x?}", buf);
         let first = *buf.first().ok_or(DecodeError::InputTooShort)?;
 
         // encoded as a single byte
         let reason_byte = if buf.len() == 1 {
-            println!("single byte: {:x?}", buf);
             u8::decode(buf)?
         } else if buf.len() == 2 {
             if first == 0x00 {
                 // snappy encoded containing single byte
-                println!("snappy single byte: {:x?}", buf);
                 buf.advance(1);
-                println!("snappy last byte: {:x?}", buf);
                 u8::decode(&mut &buf[..])?
             } else {
-                println!("rlp single byte: {:x?}", buf);
                 // rlp encoded as a list containing a single byte
                 let _header = Header::decode(buf)?;
                 u8::decode(buf)?
@@ -148,11 +143,9 @@ impl Decodable for DisconnectReason {
             // snappy encoded as a rlp list containing a single byte
             // [2, 4, list header, rlp(reason)]
             buf.advance(2); // safe, we have three bytes left
-            println!("snappy rlp first: {:x?}", buf);
 
             // advance the buffer to the end, one byte left
             buf.advance(1);
-            println!("snappy rlp second: {:x?}", buf);
 
             // the reason is encoded at the end of the snappy encoded bytes
             u8::decode(buf)?

--- a/crates/net/eth-wire/src/disconnect.rs
+++ b/crates/net/eth-wire/src/disconnect.rs
@@ -268,4 +268,16 @@ mod tests {
 
         assert_eq!(decompressed, disconnect_raw);
     }
+
+    #[test]
+    fn test_decode_known_reasons() {
+        let all_reasons = vec![
+            b"010003",
+        ];
+
+        for reason in all_reasons {
+            let reason = hex::decode(reason).unwrap();
+            _ = DisconnectReason::decode(&mut &reason[..]).unwrap();
+        }
+    }
 }

--- a/crates/net/eth-wire/src/disconnect.rs
+++ b/crates/net/eth-wire/src/disconnect.rs
@@ -124,7 +124,6 @@ impl Encodable for DisconnectReason {
 /// input is snappy compressed.
 impl Decodable for DisconnectReason {
     fn decode(buf: &mut &[u8]) -> Result<Self, DecodeError> {
-        tracing::trace!("Decoding disconnect reason: {}", hex::encode(&buf));
         if buf.len() < 4 {
             return Err(DecodeError::Custom("disconnect reason should have 4 bytes"))
         }
@@ -272,7 +271,27 @@ mod tests {
     #[test]
     fn test_decode_known_reasons() {
         let all_reasons = vec![
-            b"010003",
+            // snappy, compressing a single byte
+            "010003",
+            "010004",
+            // snappy, encoded the disconnect reason as a list
+            "010204c180",
+            "010204c101",
+            "010204c102",
+            "010204c103",
+            "010204c104",
+            "010204c105",
+            "010204c106",
+            "010204c107",
+            "010204c108",
+            "010204c109",
+            "010204c10a",
+            "010204c10b",
+            "010204c110",
+            // non-snappy, encoding the disconnect reason as a single byte
+            "0104",
+            // non-snappy, encoding the disconnect reason in a list
+            "01c104",
         ];
 
         for reason in all_reasons {

--- a/crates/net/eth-wire/src/disconnect.rs
+++ b/crates/net/eth-wire/src/disconnect.rs
@@ -272,9 +272,18 @@ mod tests {
     fn test_decode_known_reasons() {
         let all_reasons = vec![
             // snappy, compressing a single byte
+            "010080",
+            "010001",
+            "010002",
             "010003",
             "010004",
+            "010005",
+            "010006",
+            "010007",
             "010008",
+            "010009",
+            "01000a",
+            "01000b",
             "010010",
             // snappy, encoded the disconnect reason as a list
             "010204c180",
@@ -291,9 +300,33 @@ mod tests {
             "010204c10b",
             "010204c110",
             // non-snappy, encoding the disconnect reason as a single byte
+            "0180",
+            "0101",
+            "0102",
+            "0103",
             "0104",
+            "0105",
+            "0106",
+            "0107",
+            "0108",
+            "0109",
+            "010a",
+            "010b",
+            "0110",
             // non-snappy, encoding the disconnect reason in a list
+            "01c180",
+            "01c101",
+            "01c102",
+            "01c103",
             "01c104",
+            "01c105",
+            "01c106",
+            "01c107",
+            "01c108",
+            "01c109",
+            "01c10a",
+            "01c10b",
+            "01c110",
         ];
 
         for reason in all_reasons {

--- a/crates/net/eth-wire/src/error.rs
+++ b/crates/net/eth-wire/src/error.rs
@@ -120,6 +120,8 @@ pub enum P2PHandshakeError {
     Timeout,
     #[error("Disconnected by peer: {0}")]
     Disconnected(DisconnectReason),
+    #[error("error decoding a message during handshake: {0}")]
+    DecodeError(#[from] reth_rlp::DecodeError),
 }
 
 /// An error that can occur when interacting with a [`Pinger`].

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -71,6 +71,8 @@ where
             return Err(EthStreamError::MessageTooBig(their_msg.len()))
         }
 
+        tracing::trace!("Decoding first eth message from peer: {}", hex::encode(&their_msg));
+
         let msg = match ProtocolMessage::decode(&mut their_msg.as_ref()) {
             Ok(m) => m,
             Err(err) => {
@@ -83,6 +85,7 @@ where
         // https://github.com/ethereum/go-ethereum/blob/9244d5cd61f3ea5a7645fdf2a1a96d53421e412f/eth/protocols/eth/handshake.go#L87-L89
         match msg.message {
             EthMessage::Status(resp) => {
+                tracing::trace!("Got correctly encoded status message: {:?}", resp);
                 if status.genesis != resp.genesis {
                     return Err(HandshakeError::MismatchedGenesis {
                         expected: status.genesis,

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -71,8 +71,6 @@ where
             return Err(EthStreamError::MessageTooBig(their_msg.len()))
         }
 
-        tracing::trace!("Decoding first eth message from peer: {}", hex::encode(&their_msg));
-
         let msg = match ProtocolMessage::decode(&mut their_msg.as_ref()) {
             Ok(m) => m,
             Err(err) => {
@@ -85,7 +83,6 @@ where
         // https://github.com/ethereum/go-ethereum/blob/9244d5cd61f3ea5a7645fdf2a1a96d53421e412f/eth/protocols/eth/handshake.go#L87-L89
         match msg.message {
             EthMessage::Status(resp) => {
-                tracing::trace!("Got correctly encoded status message: {:?}", resp);
                 if status.genesis != resp.genesis {
                     return Err(HandshakeError::MismatchedGenesis {
                         expected: status.genesis,

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -290,10 +290,11 @@ where
                     this.outgoing_messages.push_back(pong_bytes.into());
                 }
                 _ if id == P2PMessageID::Disconnect as u8 => {
-
                     let reason = DisconnectReason::decode(&mut &bytes[1..]).map_err(|e| {
                         let hex_msg = hex::encode(&bytes[1..]);
-                        tracing::warn!("Failed to decode disconnect message from peer ({hex_msg}): {e}");
+                        tracing::warn!(
+                            "Failed to decode disconnect message from peer ({hex_msg}): {e}"
+                        );
                         e
                     })?;
                     return Poll::Ready(Some(Err(P2PStreamError::Disconnected(reason))))

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -114,7 +114,7 @@ where
             }
             Err(e) => {
                 let hex_msg = hex::encode(&first_message_bytes);
-                tracing::error!("Failed to decode Hello message from peer ({hex_msg}): {e}");
+                tracing::error!("Failed to decode first message from peer ({hex_msg}): {e}");
                 Err(P2PStreamError::HandshakeError(e.into()))
             }
             Ok(msg) => {

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -291,7 +291,7 @@ where
                 }
                 _ if id == P2PMessageID::Disconnect as u8 => {
                     let reason = DisconnectReason::decode(&mut &bytes[1..]).map_err(|e| {
-                        let hex_msg = hex::encode(&bytes[1..]);
+                        let hex_msg = hex::encode(&bytes[..]);
                         tracing::warn!(
                             "Failed to decode disconnect message from peer ({hex_msg}): {e}"
                         );

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -291,7 +291,7 @@ where
                 _ if id == P2PMessageID::Disconnect as u8 => {
                     let reason = DisconnectReason::decode(&mut &bytes[1..]).map_err(|err| {
                         tracing::warn!(
-                            ?err, msg=%hex::encode(&bytes[..]), "Failed to decode disconnect message from peer"
+                            ?err, msg=%hex::encode(&bytes[1..]), "Failed to decode disconnect message from peer"
                         );
                         err
                     })?;

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -99,7 +99,7 @@ where
             })
         }
 
-        tracing::trace!("Decoding Hello message from peer: {}", hex::encode(&first_message_bytes));
+        tracing::trace!("Decoding first message from peer: {}", hex::encode(&first_message_bytes));
 
         // the u8::decode implementation handles the 0x80 case for P2PMessageID::Hello, and the
         // TryFrom implementation ensures that the message id is known.
@@ -133,6 +133,8 @@ where
             }
         }
 
+        tracing::trace!("Decoding Hello message from peer: {}", hex::encode(&first_message_bytes));
+
         let their_hello = match P2PMessage::decode(&mut &first_message_bytes[..])? {
             P2PMessage::Hello(hello) => Ok(hello),
             msg => {
@@ -141,6 +143,8 @@ where
                 Err(P2PStreamError::HandshakeError(P2PHandshakeError::NonHelloMessageInHandshake))
             }
         }?;
+
+        tracing::trace!("Received a valid Hello: {:?}", their_hello);
 
         // TODO: explicitly document that we only support v5.
         if their_hello.protocol_version != ProtocolVersion::V5 {

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -99,6 +99,8 @@ where
             })
         }
 
+        tracing::trace!("Decoding Hello message from peer: {}", hex::encode(&first_message_bytes));
+
         // the u8::decode implementation handles the 0x80 case for P2PMessageID::Hello, and the
         // TryFrom implementation ensures that the message id is known.
         let message_id = u8::decode(&mut &first_message_bytes[..])?;

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -114,7 +114,7 @@ where
             }
             Err(e) => {
                 let hex_msg = hex::encode(&first_message_bytes);
-                tracing::error!("Failed to decode first message from peer ({hex_msg}): {e}");
+                tracing::warn!("Failed to decode first message from peer ({hex_msg}): {e}");
                 Err(P2PStreamError::HandshakeError(e.into()))
             }
             Ok(msg) => {

--- a/crates/net/network/tests/it/connect.rs
+++ b/crates/net/network/tests/it/connect.rs
@@ -298,6 +298,9 @@ async fn test_geth_disconnect() {
         panic!("Expected a session established event");
     }
 
+    // remove geth as a peer deliberately
+    handle.disconnect_peer(geth_peer_id);
+
     // wait for a disconnect from geth
     if let Some(NetworkEvent::SessionClosed { peer_id }) = events.next().await {
         assert_eq!(peer_id, geth_peer_id);

--- a/crates/net/network/tests/it/connect.rs
+++ b/crates/net/network/tests/it/connect.rs
@@ -255,3 +255,53 @@ async fn test_outgoing_connect_with_single_geth() {
     let incoming_peer_id = event_stream.next_session_established().await.unwrap();
     assert_eq!(incoming_peer_id, geth_peer_id);
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_geth_disconnect() {
+    reth_tracing::init_tracing();
+    let secret_key = SecretKey::new(&mut rand::thread_rng());
+
+    let reth_p2p_socket = SocketAddr::new([127, 0, 0, 1].into(), 30309);
+    let reth_disc_socket = SocketAddr::new([127, 0, 0, 1].into(), 30310);
+    let config = NetworkConfig::builder(Arc::new(TestApi::default()), secret_key)
+        .listener_addr(reth_p2p_socket)
+        .discovery_addr(reth_disc_socket)
+        .build();
+    let network = NetworkManager::new(config).await.unwrap();
+
+    let handle = network.handle().clone();
+    tokio::task::spawn(network);
+
+    // instantiate geth and add ourselves as a peer
+    let temp_dir = tempfile::tempdir().unwrap().into_path();
+    let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
+
+    let geth_p2p_port = geth.p2p_port().unwrap();
+    let geth_socket = SocketAddr::new([127, 0, 0, 1].into(), geth_p2p_port);
+    let geth_endpoint = SocketAddr::new([127, 0, 0, 1].into(), geth.port()).to_string();
+
+    let provider = Provider::<Http>::try_from(format!("http://{geth_endpoint}")).unwrap();
+
+    // get the peer id we should be expecting
+    let geth_peer_id: PeerId =
+        provider.node_info().await.unwrap().enr.public_key().encode_uncompressed().into();
+
+    // add geth as a peer then wait for a `SessionEstablished` event
+    handle.add_peer(geth_peer_id, geth_socket);
+
+    // create networkeventstream to get the next session established event easily
+    let mut events = handle.event_listener();
+
+    if let Some(NetworkEvent::SessionEstablished { peer_id, .. }) = events.next().await {
+        assert_eq!(peer_id, geth_peer_id);
+    } else {
+        panic!("Expected a session established event");
+    }
+
+    // wait for a disconnect from geth
+    if let Some(NetworkEvent::SessionClosed { peer_id }) = events.next().await {
+        assert_eq!(peer_id, geth_peer_id);
+    } else {
+        panic!("Expected a session closed event");
+    }
+}


### PR DESCRIPTION
This currently tests decoding a set of known disconnect reason encodings, and checks that we can decode a disconnect reason from geth.

Traces for more decoding errors are also added.

Fixes #501 

TODO:
 - [x] fix disconnect reason decoding