### PR TITLE
chore: add codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
+bin/                        @onbjerg
 crates/net/                 @mattsse @Rjected
 crates/net/downloaders/     @onbjerg @rkrasiuk
 crates/executor/            @rakita

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+crates/net/                 @mattsse @Rjected
+crates/net/downloaders/     @onbjerg @rkrasiuk
+crates/executor/            @rakita
+crates/stages/              @onbjerg @rkrasiuk
+crates/storage/             @rakita @joshieDo
+crates/transaction-pool/    @mattsse


### PR DESCRIPTION
Adds a `CODEOWNERS` file that (at a minimum) automatically assigns reviewers to PRs based on the files changed. There are some paths I am not sure who to assign to:

- `bin` (just added myself here for now)
- `book`
- `docs`
- `crates/common`
- `crates/interfaces`
- `crates/primitives`
- `crates/tasks`

Also the paths/owners I've added here might be wrong

More about the `CODEOWNERS` file [here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)