### PR TITLE
refactor: move metrics endpoint to node cmd

### DIFF
--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -1,5 +1,6 @@
 //! Database debugging tool
 
+use crate::util::parse_path;
 use clap::{Parser, Subcommand};
 use eyre::{Result, WrapErr};
 use reth_db::{
@@ -11,15 +12,16 @@ use reth_db::{
 };
 use reth_interfaces::test_utils::generators::random_block_range;
 use reth_provider::insert_canonical_block;
-use std::path::Path;
+use std::path::PathBuf;
 use tracing::info;
 
 /// `reth db` command
 #[derive(Debug, Parser)]
 pub struct Command {
-    /// Path to database folder
-    #[arg(long, value_name = "PATH", default_value = "~/.reth/db")]
-    db: String,
+    /// The path to the database folder.
+    // TODO: This should use dirs-next
+    #[arg(long, value_name = "PATH", default_value = "~/.reth/db", value_parser = parse_path)]
+    db: PathBuf,
 
     #[clap(subcommand)]
     command: Subcommands,
@@ -58,13 +60,11 @@ pub struct ListArgs {
 impl Command {
     /// Execute `db` command
     pub async fn execute(&self) -> eyre::Result<()> {
-        let path = shellexpand::full(&self.db)?.into_owned();
-        let expanded_db_path = Path::new(&path);
-        std::fs::create_dir_all(expanded_db_path)?;
+        std::fs::create_dir_all(&self.db)?;
 
         // TODO: Auto-impl for Database trait
         let db = reth_db::mdbx::Env::<reth_db::mdbx::WriteMap>::open(
-            expanded_db_path,
+            &self.db,
             reth_db::mdbx::EnvKind::RW,
         )?;
 

--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -18,7 +18,7 @@ use tracing::info;
 #[derive(Debug, Parser)]
 pub struct Command {
     /// Path to database folder
-    #[arg(long, default_value = "~/.reth/db")]
+    #[arg(long, value_name = "PATH", default_value = "~/.reth/db")]
     db: String,
 
     #[clap(subcommand)]

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -39,11 +39,13 @@ const MAINNET_GENESIS: &str = include_str!("../../res/chainspec/mainnet.json");
 pub struct Command {
     /// The path to the database folder.
     // TODO: This should use dirs-next
-    #[arg(long, default_value = "~/.reth/db")]
+    #[arg(long, value_name = "PATH", default_value = "~/.reth/db")]
     db: String,
 
-    /// Enable Prometheus metrics. The metrics will be served at the given interface and port.
-    #[clap(long)]
+    /// Enable Prometheus metrics.
+    ///
+    /// The metrics will be served at the given interface and port.
+    #[clap(long, value_name = "SOCKET")]
     metrics: Option<SocketAddr>,
 }
 

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -3,6 +3,9 @@
 //! Starts the client
 use crate::util::chainspec::Genesis;
 use clap::{crate_version, Parser};
+use eyre::WrapErr;
+use metrics_exporter_prometheus::PrometheusBuilder;
+use metrics_util::layers::{PrefixLayer, Stack};
 use reth_consensus::EthConsensus;
 use reth_db::{
     cursor::DbCursorRO,
@@ -22,6 +25,7 @@ use reth_primitives::{hex_literal::hex, Account, Header, H256};
 use reth_provider::{db_provider::ProviderImpl, BlockProvider, HeaderProvider};
 use reth_stages::stages::{bodies::BodyStage, headers::HeaderStage, senders::SendersStage};
 use std::{
+    net::SocketAddr,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -37,6 +41,10 @@ pub struct Command {
     // TODO: This should use dirs-next
     #[arg(long, default_value = "~/.reth/db")]
     db: String,
+
+    /// Enable Prometheus metrics. The metrics will be served at the given interface and port.
+    #[clap(long)]
+    metrics: Option<SocketAddr>,
 }
 
 impl Command {
@@ -49,6 +57,19 @@ impl Command {
         info!("Opening database at {}", db_path.display());
         let db = Arc::new(init_db(db_path)?);
         info!("Database open");
+
+        if let Some(listen_addr) = self.metrics {
+            info!("Starting metrics endpoint at {}", listen_addr);
+            let (recorder, exporter) = PrometheusBuilder::new()
+                .with_http_listener(listen_addr)
+                .build()
+                .wrap_err("Could not build Prometheus endpoint.")?;
+            tokio::task::spawn(exporter);
+            Stack::new(recorder)
+                .push(PrefixLayer::new("reth"))
+                .install()
+                .wrap_err("Couldn't set metrics recorder.")?;
+        }
 
         // TODO: More info from chainspec (chain ID etc.)
         let consensus = Arc::new(EthConsensus::new(consensus_config()));

--- a/bin/reth/src/util/mod.rs
+++ b/bin/reth/src/util/mod.rs
@@ -1,11 +1,14 @@
 //! Utility functions.
-
-use std::path::{Path, PathBuf};
+use std::{
+    env::VarError,
+    path::{Path, PathBuf},
+};
 use walkdir::{DirEntry, WalkDir};
 
 /// Utilities for parsing chainspecs
 pub mod chainspec;
 
+/// Finds all files in a directory with a given postfix.
 pub(crate) fn find_all_files_with_postfix(path: &Path, postfix: &str) -> Vec<PathBuf> {
     WalkDir::new(path)
         .into_iter()
@@ -13,6 +16,12 @@ pub(crate) fn find_all_files_with_postfix(path: &Path, postfix: &str) -> Vec<Pat
         .filter(|e| e.file_name().to_string_lossy().ends_with(postfix))
         .map(DirEntry::into_path)
         .collect::<Vec<PathBuf>>()
+}
+
+/// Parses a user-specified path with support for environment variables and common shorthands (e.g.
+/// ~ for the user's home directory).
+pub(crate) fn parse_path(value: &str) -> Result<PathBuf, shellexpand::LookupError<VarError>> {
+    shellexpand::full(value).map(|path| PathBuf::from(path.into_owned()))
 }
 
 /// Tracing utility


### PR DESCRIPTION
Moves the `--metrics` flag to the `reth node` command (doesn't make sense that it is global) and also changes it from a flag to an option that takes an address to serve the metrics on, e.g. `reth node --metrics 127.0.0.1:9999`