### PR TITLE
perf(net): increase udp channel buffers

### DIFF
--- a/crates/net/discv4/src/config.rs
+++ b/crates/net/discv4/src/config.rs
@@ -134,7 +134,7 @@ impl Discv4ConfigBuilder {
         self
     }
 
-    /// Sets the channel size for incoming messages
+    /// Sets the channel size for outgoing messages
     pub fn udp_egress_message_buffer(&mut self, udp_egress_message_buffer: usize) -> &mut Self {
         self.config.udp_egress_message_buffer = udp_egress_message_buffer;
         self

--- a/crates/net/discv4/src/config.rs
+++ b/crates/net/discv4/src/config.rs
@@ -17,6 +17,10 @@ use std::{
 pub struct Discv4Config {
     /// Whether to enable the incoming packet filter. Default: false.
     pub enable_packet_filter: bool,
+    /// Size of the channel buffer for outgoing messages.
+    pub udp_egress_message_buffer: usize,
+    /// Size of the channel buffer for incoming messages.
+    pub udp_ingress_message_buffer: usize,
     /// The number of retries for each UDP request. Default: 1.
     pub request_retries: u8,
     /// The time between pings to ensure connectivity amongst connected nodes. Default: 300
@@ -87,6 +91,12 @@ impl Default for Discv4Config {
     fn default() -> Self {
         Self {
             enable_packet_filter: false,
+            /// This should be high enough to cover an entire recursive FindNode lookup which is
+            /// includes sending FindNode to nodes it discovered in the rounds using the
+            /// concurrency factor ALPHA
+            udp_egress_message_buffer: 1024,
+            /// Every outgoing request will eventually lead to an incoming response
+            udp_ingress_message_buffer: 1024,
             request_retries: 1,
             ping_interval: Duration::from_secs(300),
             ping_timeout: Duration::from_secs(5),
@@ -115,6 +125,18 @@ impl Discv4ConfigBuilder {
     /// Whether to enable the incoming packet filter.
     pub fn enable_packet_filter(&mut self) -> &mut Self {
         self.config.enable_packet_filter = true;
+        self
+    }
+
+    /// Sets the channel size for incoming messages
+    pub fn udp_ingress_message_buffer(&mut self, udp_ingress_message_buffer: usize) -> &mut Self {
+        self.config.udp_ingress_message_buffer = udp_ingress_message_buffer;
+        self
+    }
+
+    /// Sets the channel size for incoming messages
+    pub fn udp_egress_message_buffer(&mut self, udp_egress_message_buffer: usize) -> &mut Self {
+        self.config.udp_egress_message_buffer = udp_egress_message_buffer;
         self
     }
 

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -373,13 +373,9 @@ impl Discv4Service {
         config: Discv4Config,
         commands_rx: Option<mpsc::Receiver<Discv4Command>>,
     ) -> Self {
-        // Heuristic limit for channel buffer size, which is correlated with the number of
-        // concurrent requests and bucket size. This should be large enough to cover multiple
-        // lookups while also anticipating incoming requests.
-        const UDP_CHANNEL_BUFFER: usize = MAX_NODES_PER_BUCKET * ALPHA * (ALPHA * 2);
         let socket = Arc::new(socket);
-        let (ingress_tx, ingress_rx) = mpsc::channel(UDP_CHANNEL_BUFFER);
-        let (egress_tx, egress_rx) = mpsc::channel(UDP_CHANNEL_BUFFER);
+        let (ingress_tx, ingress_rx) = mpsc::channel(config.udp_ingress_message_buffer);
+        let (egress_tx, egress_rx) = mpsc::channel(config.udp_egress_message_buffer);
         let mut tasks = JoinSet::<()>::new();
 
         let udp = Arc::clone(&socket);


### PR DESCRIPTION
Increase channel buffers to a more appropriate default.

previously we had a heuristic based on ALPHA which was too low for heavy load, leading to dropped packets.

This bumps the buffer from 288 -> 1024.
A single buffered message is smaller than the max datagram size of 1280bytes, which includes rlp overhead, so the max memory increase should be less than 700kb.