### PR TITLE
meta(license): add years and authors

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-The MIT License (MIT)
+Copyright (c) 2022 Reth Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I've found myself reading and referencing some Reth code in Lighthouse (see https://github.com/sigp/lighthouse/pull/3794) and noticed that the license files are lacking copyright years and authors.

This PR adds what I guessed might be sensible values. Of course I'm happy to modify them as you see fit.