### PR TITLE
chore(net): improve ecies error for unreadable stream

### DIFF
--- a/crates/net/ecies/src/error.rs
+++ b/crates/net/ecies/src/error.rs
@@ -83,6 +83,14 @@ pub enum ECIESErrorImpl {
         /// The actual value returned from the peer
         msg: Option<IngressECIESValue>,
     },
+    /// Error when the stream was closed by the peer for being unreadable.
+    ///
+    /// This exact error case happens when the wrapped stream in
+    /// [`Framed`](tokio_util::codec::Framed) is closed by the peer, See
+    /// [ConnectionReset](std::io::ErrorKind::ConnectionReset) and the ecies codec fails to decode
+    /// a message from the (partially filled) buffer.
+    #[error("Stream closed due to no further readable.")]
+    UnreadableStream,
 }
 
 impl From<ECIESErrorImpl> for ECIESError {

--- a/crates/net/ecies/src/error.rs
+++ b/crates/net/ecies/src/error.rs
@@ -89,7 +89,7 @@ pub enum ECIESErrorImpl {
     /// [`Framed`](tokio_util::codec::Framed) is closed by the peer, See
     /// [ConnectionReset](std::io::ErrorKind::ConnectionReset) and the ecies codec fails to decode
     /// a message from the (partially filled) buffer.
-    #[error("Stream closed due to no further readable.")]
+    #[error("Stream closed due to not being readable.")]
     UnreadableStream,
 }
 

--- a/crates/net/ecies/src/stream.rs
+++ b/crates/net/ecies/src/stream.rs
@@ -62,13 +62,23 @@ where
         transport.send(EgressECIESValue::Auth).await?;
 
         trace!("waiting for ecies ack ...");
+
         let msg = transport.try_next().await?;
 
+        // `Framed` returns `None` if the underlying stream is no longer readable, and the codec is
+        // unable to decode another message from the (partially filled) buffer. This usually happens
+        // if the remote drops the TcpStream.
+        let msg = msg.ok_or_else(|| ECIESErrorImpl::UnreadableStream)?;
+
         trace!("parsing ecies ack ...");
-        if matches!(msg, Some(IngressECIESValue::Ack)) {
+        if matches!(msg, IngressECIESValue::Ack) {
             Ok(Self { stream: transport, remote_id })
         } else {
-            Err(ECIESErrorImpl::InvalidHandshake { expected: IngressECIESValue::Ack, msg }.into())
+            Err(ECIESErrorImpl::InvalidHandshake {
+                expected: IngressECIESValue::Ack,
+                msg: Some(msg),
+            }
+            .into())
         }
     }
 


### PR DESCRIPTION
Closes #511

the `Framed` stream will return `None`:

https://github.com/tokio-rs/tokio/blob/3886a3eaf4f513cc3522597a6fdd990e4f68b922/tokio-util/src/codec/framed_impl.rs#L173-L197

if the stream is no longer readable.