### PR TITLE
chore(db): modify state transition docs

### DIFF
--- a/crates/storage/db/src/tables/mod.rs
+++ b/crates/storage/db/src/tables/mod.rs
@@ -232,12 +232,12 @@ table!(
     /// }
     /// ```
     ///
-    ( AccountHistory ) ShardedKey<Address> | TxNumberList
+    ( AccountHistory ) ShardedKey<Address> | TransitionList
 );
 
 table!(
     /// Stores pointers to transactions that changed each storage key.
-    ( StorageHistory ) AddressStorageKey | TxNumberList
+    ( StorageHistory ) AddressStorageKey | TransitionList
 );
 
 dupsort!(
@@ -275,7 +275,7 @@ table!(
 /// Alias Types
 
 /// List with transaction numbers.
-pub type TxNumberList = IntegerList;
+pub type TransitionList = IntegerList;
 /// Encoded stage id.
 pub type StageId = Vec<u8>;
 

--- a/docs/design/database.md
+++ b/docs/design/database.md
@@ -59,7 +59,7 @@ AccountHistory {
 StorageHistory {
     H256 Account "PK"
     H256 StorageKey "PK"
-    TransitionList TransitionIdList "u64 list of transitions where account storage entry was changed"
+    TransitionList TransitionIdList "List of transitions where account storage entry was changed"
 }
 AccountChangeSet {
     u64 TransitionId "PK"

--- a/docs/design/database.md
+++ b/docs/design/database.md
@@ -25,18 +25,17 @@
 
 # Table design
 
-We do Transaction-granularity indexing. This means that we store the state for every account after every transaction that touched it, and we provide indexes for accessing that quickly.
-While this may make the database size bigger (and we need to benchmark this once we're closer to prod) it also enables blazing-fast historical tracing and simulations because we
-don't need to re-execute all transactions inside a block.
+Historical state changes are indexed by autoincrementing enumeration called `TransitionId`. This means that `reth` stores the state for every account after every transaction that touched it, and it provides indexes for accessing that data quickly. While this may make the database size bigger (needs benchmark once `reth` is closer to prod), it also enables blazing-fast historical tracing and simulations because there is no need to re-execute all transactions inside a block.
+
+State transitions differ from transaction level enumeration in order to account for block rewards.
+e.g. If block #1 contains transactions from id 0 to 5 (inclusive) and has a reward, the reward will be assigned transition id 6 and transition ids in block #2 will start block index 7.
+
+Two additional tables `TxTransitionIdIndex` and `BlockTransitionIdIndex` are introduced to enable reverse lookup of transition by transaction id and block number respectively. The transition id at block number denotes the final state transition of the block. If block has a reward, the state transition at block number `x` points at data about the state transition for the reward distribution. Otherwise, it points to the state transition at the last transaction in block number `x`.
 
 Below, you can see the table design that implements this scheme:
 
 ```mermaid
 erDiagram
-TransactionHash ||--o{ TxChangeIdIndex : index
-BlockChangeIdIndex ||--o{ ChangeSet : "unique index"
-History ||--o{ ChangeSet : index
-TxChangeIdIndex ||--o{ ChangeSet : "unique index"
 Transactions {
     u64 TxNumber "PK"
     Transaction Data
@@ -45,24 +44,38 @@ TransactionHash {
     H256 TxHash "PK"
     u64 TxNumber
 }
-TxChangeIdIndex {
+TxTransitionIdIndex {
     u64 TxNumber "PK"
-    u64 ChangeId 
+    u64 TransitionId 
 }
-BlockChangeIdIndex {
+BlockTransitionIdIndex {
     u64 BlockNumber "PK"
-    u64 ChangeId
-}
-ChangeSet {
-    u64 ChangeId "PK"
-    ChangeSet PreviousValues "[Acc1[Balance,Nonce),Acc2(Balance,Nonce)] Previous values"
+    u64 TransitionId
 }
 History {
     H256 Account "PK"
-    u64 ChangeIdList "[ChangeId,ChangeId,...] Points where account changed"
+    u64 TransitionIdList "TransitionId[] (transitions where account changed)"
 }
-EVM ||--o{ History: "Load Account by finding first bigger ChangeId in List, and index it in ChangeSet table"
-BlockChangeIdIndex ||--o{ EVM : "Use state (by block Changeid)"
-TxChangeIdIndex ||--o{ EVM : "Use state (by tx ChangeId)"
+AccountChangeSet {
+    u64 TransitionId "PK"
+    address Address "PK"
+    ChangeSet AccountChangeSet "Account before transition"
+}
+StorageChangeSet {
+    u64 TransitionId "PK"
+    address Address "PK"
+    H256 StorageEntry "PK"
+    ChangeSet StorageChangeSet "Storage entry before transition"
+}
+EVM ||--o{ History: "Load Account by finding first bigger TransitionId in List, and index it in ChangeSet table"
+BlockTransitionIdIndex ||--o{ EVM : "Use state (by block TransitionId)"
+TxTransitionIdIndex ||--o{ EVM : "Use state (by tx TransitionId)"
 TransactionHash ||--o{ Transactions : index
+TransactionHash ||--o{ TxTransitionIdIndex : index
+History ||--o{ AccountChangeSet : index
+BlockTransitionIdIndex ||--o{ AccountChangeSet : "unique index"
+TxTransitionIdIndex ||--o{ AccountChangeSet : "unique index"
+History ||--o{ StorageChangeSet : index
+BlockTransitionIdIndex ||--o{ StorageChangeSet : "unique index"
+TxTransitionIdIndex ||--o{ StorageChangeSet : "unique index"
 ```

--- a/docs/design/database.md
+++ b/docs/design/database.md
@@ -52,30 +52,35 @@ BlockTransitionIdIndex {
     u64 BlockNumber "PK"
     u64 TransitionId
 }
-History {
+AccountHistory {
     H256 Account "PK"
-    u64 TransitionIdList "TransitionId[] (transitions where account changed)"
+    u64[] TransitionIdList "List of transitions where account was changed"
+}
+StorageHistory {
+    H256 Account "PK"
+    H256 StorageKey "PK"
+    u64[] TransitionIdList "List of transitions where account storage entry was changed"
 }
 AccountChangeSet {
     u64 TransitionId "PK"
-    address Address "PK"
+    H256 Account "PK"
     ChangeSet AccountChangeSet "Account before transition"
 }
 StorageChangeSet {
     u64 TransitionId "PK"
-    address Address "PK"
-    H256 StorageEntry "PK"
+    H256 Account "PK"
+    H256 StorageKey "PK"
     ChangeSet StorageChangeSet "Storage entry before transition"
 }
-EVM ||--o{ History: "Load Account by finding first bigger TransitionId in List, and index it in ChangeSet table"
-BlockTransitionIdIndex ||--o{ EVM : "Use state (by block TransitionId)"
-TxTransitionIdIndex ||--o{ EVM : "Use state (by tx TransitionId)"
+EVM ||--o{ AccountHistory: "Load Account by first greater TransitionId"
+EVM ||--o{ StorageHistory: "Load Storage Entry by first greater TransitionId"
 TransactionHash ||--o{ Transactions : index
-TransactionHash ||--o{ TxTransitionIdIndex : index
-History ||--o{ AccountChangeSet : index
+Transactions ||--o{ TxTransitionIdIndex : index
+AccountHistory ||--o{ AccountChangeSet : index
 BlockTransitionIdIndex ||--o{ AccountChangeSet : "unique index"
 TxTransitionIdIndex ||--o{ AccountChangeSet : "unique index"
-History ||--o{ StorageChangeSet : index
+StorageHistory ||--o{ StorageChangeSet : index
 BlockTransitionIdIndex ||--o{ StorageChangeSet : "unique index"
 TxTransitionIdIndex ||--o{ StorageChangeSet : "unique index"
+
 ```

--- a/docs/design/database.md
+++ b/docs/design/database.md
@@ -54,12 +54,12 @@ BlockTransitionIdIndex {
 }
 AccountHistory {
     H256 Account "PK"
-    u64[] TransitionIdList "List of transitions where account was changed"
+    TransitionList TransitionIdList "List of transitions where account was changed"
 }
 StorageHistory {
     H256 Account "PK"
     H256 StorageKey "PK"
-    u64[] TransitionIdList "List of transitions where account storage entry was changed"
+    TransitionList TransitionIdList "u64 list of transitions where account storage entry was changed"
 }
 AccountChangeSet {
     u64 TransitionId "PK"
@@ -82,5 +82,4 @@ TxTransitionIdIndex ||--o{ AccountChangeSet : "unique index"
 StorageHistory ||--o{ StorageChangeSet : index
 BlockTransitionIdIndex ||--o{ StorageChangeSet : "unique index"
 TxTransitionIdIndex ||--o{ StorageChangeSet : "unique index"
-
 ```


### PR DESCRIPTION
Modify the description and semantics of state transition table docs introduced in #430 and implemented in #449. Provide more examples for transition lookups.