### PR TITLE
fix(net): set disconnect status

### DIFF
--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -224,6 +224,7 @@ impl<S> P2PStream<S> {
         let mut buf = BytesMut::with_capacity(disconnect.length());
         disconnect.encode(&mut buf);
         self.outgoing_messages.push_back(buf.freeze());
+        self.disconnecting = true;
     }
 }
 


### PR DESCRIPTION
Discovered here: https://github.com/paradigmxyz/reth/pull/502#issuecomment-1356480185

This properly sets the `disconnect` state when queuing in the disconnect message 