### PR TITLE
fix(net): add already connected check

### DIFF
--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -137,7 +137,7 @@ where
         );
     }
 
-    /// Event hook for a disconnected session for the peer.
+    /// Event hook for a disconnected session for the given peer.
     pub(crate) fn on_session_closed(&mut self, peer: PeerId) {
         self.active_peers.remove(&peer);
         self.state_fetcher.on_session_closed(&peer);

--- a/crates/net/network/src/swarm.rs
+++ b/crates/net/network/src/swarm.rs
@@ -137,6 +137,11 @@ where
                     direction,
                 })
             }
+            SessionEvent::AlreadyConnected { peer_id, remote_addr, direction } => {
+                trace!( target: "net", ?peer_id, ?remote_addr, ?direction, "already connected");
+                self.state.peers_mut().on_already_connected(direction);
+                None
+            }
             SessionEvent::ValidMessage { peer_id, message } => {
                 Some(SwarmEvent::ValidMessage { peer_id, message })
             }

--- a/crates/net/network/tests/it/connect.rs
+++ b/crates/net/network/tests/it/connect.rs
@@ -168,6 +168,9 @@ async fn test_incoming_node_id_blacklist() {
     // check for session to be opened
     let incoming_peer_id = event_stream.next_session_established().await.unwrap();
     assert_eq!(incoming_peer_id, geth_peer_id);
+
+    handle.disconnect_peer(incoming_peer_id);
+
     // check to see that the session was closed
     let incoming_peer_id = event_stream.next_session_closed().await.unwrap();
     assert_eq!(incoming_peer_id, geth_peer_id);

--- a/crates/net/network/tests/it/connect.rs
+++ b/crates/net/network/tests/it/connect.rs
@@ -154,6 +154,8 @@ async fn test_incoming_node_id_blacklist() {
     let network = NetworkManager::new(config).await.unwrap();
 
     let handle = network.handle().clone();
+    let events = handle.event_listener();
+
     tokio::task::spawn(network);
 
     // make geth connect to us
@@ -162,14 +164,11 @@ async fn test_incoming_node_id_blacklist() {
 
     provider.add_peer(our_enode).await.unwrap();
 
-    let events = handle.event_listener();
     let mut event_stream = NetworkEventStream::new(events);
 
     // check for session to be opened
     let incoming_peer_id = event_stream.next_session_established().await.unwrap();
     assert_eq!(incoming_peer_id, geth_peer_id);
-
-    handle.disconnect_peer(incoming_peer_id);
 
     // check to see that the session was closed
     let incoming_peer_id = event_stream.next_session_closed().await.unwrap();


### PR DESCRIPTION
Add missing `AlreadyConnected` check.

Previously we didn't check if there is an existing session to the peer.
This adds the check and disconnects the session if there's already one.

This can happen when:
* remote _and_ local initiate a connction
* remote initiates multiple connections

Fixes an issue discovered on main.