### PR TITLE
chore: remove unnecessary step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,6 @@ jobs:
           command: nextest
           args: run --locked --workspace --all-features
 
-      - name: Install fuzzer
-        run: cargo install cargo-test-fuzz afl
-
   fuzz:
     # Pin to `20.04` instead of `ubuntu-latest`, until ubuntu-latest migration is complete
     # See also <https://github.com/foundry-rs/foundry/issues/3827>


### PR DESCRIPTION
No reason to install the fuzzer after the tests are run in the non-fuzz test job