### PR TITLE
refactor(sync): remove `require_tip`

### DIFF
--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -114,42 +114,33 @@ impl Command {
         // TODO: Remove magic numbers
         let fetch_client = Arc::new(network.fetch_client().await?);
         let mut pipeline = reth_stages::Pipeline::new()
-            .push(
-                HeaderStage {
-                    downloader: headers::linear::LinearDownloadBuilder::default()
-                        .batch_size(config.stages.headers.downloader_batch_size)
-                        .retries(config.stages.headers.downloader_retries)
-                        .build(consensus.clone(), fetch_client.clone()),
-                    consensus: consensus.clone(),
-                    client: fetch_client.clone(),
-                    network_handle: network.clone(),
-                    commit_threshold: config.stages.headers.commit_threshold,
-                },
-                false,
-            )
-            .push(
-                BodyStage {
-                    downloader: Arc::new(
-                        bodies::concurrent::ConcurrentDownloader::new(
-                            fetch_client.clone(),
-                            consensus.clone(),
-                        )
-                        .with_batch_size(config.stages.bodies.downloader_batch_size)
-                        .with_retries(config.stages.bodies.downloader_retries)
-                        .with_concurrency(config.stages.bodies.downloader_concurrency),
-                    ),
-                    consensus: consensus.clone(),
-                    commit_threshold: config.stages.bodies.commit_threshold,
-                },
-                false,
-            )
-            .push(
-                SendersStage {
-                    batch_size: config.stages.senders.batch_size,
-                    commit_threshold: config.stages.senders.commit_threshold,
-                },
-                false,
-            );
+            .push(HeaderStage {
+                downloader: headers::linear::LinearDownloadBuilder::default()
+                    .batch_size(config.stages.headers.downloader_batch_size)
+                    .retries(config.stages.headers.downloader_retries)
+                    .build(consensus.clone(), fetch_client.clone()),
+                consensus: consensus.clone(),
+                client: fetch_client.clone(),
+                network_handle: network.clone(),
+                commit_threshold: config.stages.headers.commit_threshold,
+            })
+            .push(BodyStage {
+                downloader: Arc::new(
+                    bodies::concurrent::ConcurrentDownloader::new(
+                        fetch_client.clone(),
+                        consensus.clone(),
+                    )
+                    .with_batch_size(config.stages.bodies.downloader_batch_size)
+                    .with_retries(config.stages.bodies.downloader_retries)
+                    .with_concurrency(config.stages.bodies.downloader_concurrency),
+                ),
+                consensus: consensus.clone(),
+                commit_threshold: config.stages.bodies.commit_threshold,
+            })
+            .push(SendersStage {
+                batch_size: config.stages.senders.batch_size,
+                commit_threshold: config.stages.senders.commit_threshold,
+            });
 
         if let Some(tip) = self.tip {
             debug!("Tip manually set: {}", tip);

--- a/crates/stages/src/pipeline/state.rs
+++ b/crates/stages/src/pipeline/state.rs
@@ -12,11 +12,6 @@ pub(crate) struct PipelineState {
     pub(crate) maximum_progress: Option<BlockNumber>,
     /// The minimum progress achieved by any stage during the execution of the pipeline.
     pub(crate) minimum_progress: Option<BlockNumber>,
-    /// Whether or not the previous stage reached the tip of the chain.
-    ///
-    /// **Do not use this** under normal circumstances. Instead, opt for
-    /// [PipelineState::reached_tip] and [PipelineState::set_reached_tip].
-    pub(crate) reached_tip: bool,
 }
 
 impl PipelineState {
@@ -27,48 +22,11 @@ impl PipelineState {
         self.minimum_progress = opt::min(self.minimum_progress, stage_progress);
         self.maximum_progress = opt::max(self.maximum_progress, stage_progress);
     }
-
-    /// Whether or not the pipeline reached the tip of the chain.
-    pub(crate) fn reached_tip(&self) -> bool {
-        self.reached_tip ||
-            self.max_block
-                .zip(self.minimum_progress)
-                .map_or(false, |(target, progress)| progress >= target)
-    }
-
-    /// Set whether or not the pipeline has reached the tip of the chain.
-    pub(crate) fn set_reached_tip(&mut self, flag: bool) {
-        self.reached_tip = flag;
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn reached_tip() {
-        let mut state = PipelineState {
-            events_sender: MaybeSender::new(None),
-            max_block: None,
-            maximum_progress: None,
-            minimum_progress: None,
-            reached_tip: false,
-        };
-
-        // default
-        assert!(!state.reached_tip());
-
-        // reached tip
-        state.set_reached_tip(true);
-        assert!(state.reached_tip());
-
-        // reached max block
-        state.set_reached_tip(false);
-        state.max_block = Some(1);
-        state.minimum_progress = Some(1);
-        assert!(state.reached_tip());
-    }
 
     #[test]
     fn record_progress_outliers() {
@@ -77,7 +35,6 @@ mod tests {
             max_block: None,
             maximum_progress: None,
             minimum_progress: None,
-            reached_tip: false,
         };
 
         state.record_progress_outliers(10);

--- a/crates/stages/src/stage.rs
+++ b/crates/stages/src/stage.rs
@@ -37,8 +37,6 @@ pub struct ExecOutput {
     pub stage_progress: BlockNumber,
     /// Whether or not the stage is done.
     pub done: bool,
-    /// Whether or not the stage reached the tip of the chain.
-    pub reached_tip: bool,
 }
 
 /// The output of a stage unwinding.

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -108,7 +108,7 @@ impl<DB: Database> Stage<DB> for ExecutionStage {
 
         // no more canonical blocks, we are done with execution.
         if canonical_batch.is_empty() {
-            return Ok(ExecOutput { stage_progress: last_block, done: true, reached_tip: true })
+            return Ok(ExecOutput { stage_progress: last_block, done: true })
         }
 
         // Get block headers and bodies from canonical hashes
@@ -262,7 +262,7 @@ impl<DB: Database> Stage<DB> for ExecutionStage {
 
         let last_block = last_block + canonical_batch.len() as u64;
         let is_done = canonical_batch.len() < BATCH_SIZE as usize;
-        Ok(ExecOutput { done: is_done, reached_tip: true, stage_progress: last_block })
+        Ok(ExecOutput { done: is_done, stage_progress: last_block })
     }
 
     /// Unwind the stage.
@@ -414,7 +414,7 @@ mod tests {
         execution_stage.config.spec_upgrades = SpecUpgrades::new_berlin_activated();
         let output = execution_stage.execute(&mut tx, input).await.unwrap();
         tx.commit().unwrap();
-        assert_eq!(output, ExecOutput { stage_progress: 1, done: true, reached_tip: true });
+        assert_eq!(output, ExecOutput { stage_progress: 1, done: true });
         let tx = tx.deref_mut();
         // check post state
         let account1 = H160(hex!("1000000000000000000000000000000000000000"));

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -142,7 +142,7 @@ impl<DB: Database, D: HeaderDownloader, C: Consensus, H: HeadersClient, S: Statu
                 .unwrap_or_default(),
         );
 
-        Ok(ExecOutput { stage_progress, reached_tip: true, done: true })
+        Ok(ExecOutput { stage_progress, done: true })
     }
 
     /// Unwind the stage.
@@ -403,7 +403,7 @@ mod tests {
         let result = rx.await.unwrap();
         assert_matches!(
             result,
-            Ok(ExecOutput { done: true, reached_tip: true, stage_progress })
+            Ok(ExecOutput { done: true, stage_progress })
                 if stage_progress == tip.number
         );
         assert!(runner.validate_execution(input, result.ok()).is_ok(), "validation failed");

--- a/crates/stages/src/test_utils/macros.rs
+++ b/crates/stages/src/test_utils/macros.rs
@@ -40,8 +40,8 @@ macro_rules! stage_test_suite {
             let result = rx.await.unwrap();
             assert_matches::assert_matches!(
                 result,
-                Ok(ExecOutput { done, reached_tip, stage_progress })
-                    if done && reached_tip && stage_progress == previous_stage
+                Ok(ExecOutput { done, stage_progress })
+                    if done && stage_progress == previous_stage
             );
 
             // Validate the stage execution
@@ -90,8 +90,8 @@ macro_rules! stage_test_suite {
             let result = rx.await.unwrap();
             assert_matches::assert_matches!(
                 result,
-                Ok(ExecOutput { done, reached_tip, stage_progress })
-                    if done && reached_tip && stage_progress == previous_stage
+                Ok(ExecOutput { done, stage_progress })
+                    if done && stage_progress == previous_stage
             );
             assert!(runner.validate_execution(execute_input, result.ok()).is_ok(), "execution validation");
 
@@ -142,8 +142,8 @@ macro_rules! stage_test_suite_ext {
             let result = rx.await.unwrap();
             assert_matches::assert_matches!(
                 result,
-                Ok(ExecOutput { done, reached_tip, stage_progress })
-                    if done && reached_tip && stage_progress == stage_progress
+                Ok(ExecOutput { done, stage_progress })
+                    if done && stage_progress == stage_progress
             );
 
             // Validate the stage execution


### PR DESCRIPTION
`require_tip` is a flag that signals that we can skip certain expensive stages if we have not fully synced until the tip of the chain yet.

`require_tip` could only be determined by the headers stage, and it signalled that we have all of the headers to sync all the way to the chain tip

 Some stages may wait to execute until the tip is reached, e.g. the stage that checks the stage root, but there are a few problems:

- On initial sync, `reached_tip` would be `true` when we leave the headers stage, but by the time we reach the hashing stage, this would actually no longer be the case: the other stages have spent enough time for us to be "out of sync". This means that the optimization here is lost, and the additional logic is added for nothing.
- When we are not doing our initial sync, `reached_tip` would always be `true` for each subsequent block we sync. The same logic applies as above, i.e. the extra logic is there for nothing.

In other words, `reached_tip` would *always* be `true` once we leave the header stage, making the extra logic entirely redundant.