### PR TITLE
test: fix `emits_bodies_in_order` test

### DIFF
--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -131,7 +131,7 @@ impl<'a, DB: Database> DbTool<'a, DB> {
     /// Seeds the database with some random data, only used for testing
     fn seed(&mut self, len: u64) -> Result<()> {
         info!("Generating random block range from 0 to {len}");
-        let chain = random_block_range(0..len, Default::default());
+        let chain = random_block_range(0..len, Default::default(), 0..64);
 
         self.db.update(|tx| {
             chain.iter().try_for_each(|block| {

--- a/crates/interfaces/src/test_utils/generators.rs
+++ b/crates/interfaces/src/test_utils/generators.rs
@@ -1,4 +1,4 @@
-use rand::{thread_rng, Rng};
+use rand::{distributions::uniform::SampleRange, thread_rng, Rng};
 use reth_primitives::{
     proofs, Address, BlockLocked, Bytes, Header, SealedHeader, Signature, Transaction,
     TransactionKind, TransactionSigned, TxLegacy, H256, U256,
@@ -141,13 +141,19 @@ pub fn random_block(number: u64, parent: Option<H256>, tx_count: Option<u8>) -> 
 /// in the result will be equal to `head`.
 ///
 /// See [random_block] for considerations when validating the generated blocks.
-pub fn random_block_range(rng: std::ops::Range<u64>, head: H256) -> Vec<BlockLocked> {
-    let mut blocks = Vec::with_capacity(rng.end.saturating_sub(rng.start) as usize);
-    for idx in rng {
+pub fn random_block_range(
+    block_numbers: std::ops::Range<u64>,
+    head: H256,
+    tx_count: std::ops::Range<u8>,
+) -> Vec<BlockLocked> {
+    let mut rng = rand::thread_rng();
+    let mut blocks =
+        Vec::with_capacity(block_numbers.end.saturating_sub(block_numbers.start) as usize);
+    for idx in block_numbers {
         blocks.push(random_block(
             idx,
             Some(blocks.last().map(|block: &BlockLocked| block.header.hash()).unwrap_or(head)),
-            None,
+            Some(tx_count.clone().sample_single(&mut rng)),
         ));
     }
     blocks

--- a/crates/net/downloaders/src/bodies/concurrent.rs
+++ b/crates/net/downloaders/src/bodies/concurrent.rs
@@ -244,11 +244,15 @@ mod tests {
                         .into_iter()
                         .map(| header | {
                             let body = bodies .remove(&header.hash()).unwrap();
-                            BlockResponse::Full(BlockLocked {
-                                header,
-                                body: body.transactions,
-                                ommers: body.ommers.into_iter().map(|o| o.seal()).collect(),
-                            })
+                            if header.is_empty() {
+                                BlockResponse::Empty(header)
+                            } else {
+                                BlockResponse::Full(BlockLocked {
+                                    header,
+                                    body: body.transactions,
+                                    ommers: body.ommers.into_iter().map(|o| o.seal()).collect(),
+                                })
+                            }
                         })
                         .collect::<Vec<BlockResponse>>()
                 );

--- a/crates/net/downloaders/src/test_utils.rs
+++ b/crates/net/downloaders/src/test_utils.rs
@@ -19,7 +19,7 @@ use tokio::sync::Mutex;
 pub(crate) fn generate_bodies(
     rng: std::ops::Range<u64>,
 ) -> (Vec<SealedHeader>, HashMap<H256, BlockBody>) {
-    let blocks = random_block_range(rng, H256::zero());
+    let blocks = random_block_range(rng, H256::zero(), 0..2);
 
     let headers = blocks.iter().map(|block| block.header.clone()).collect();
     let bodies = blocks

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -626,7 +626,7 @@ mod tests {
             fn seed_execution(&mut self, input: ExecInput) -> Result<Self::Seed, TestRunnerError> {
                 let start = input.stage_progress.unwrap_or_default();
                 let end = input.previous_stage_progress() + 1;
-                let blocks = random_block_range(start..end, GENESIS_HASH);
+                let blocks = random_block_range(start..end, GENESIS_HASH, 0..2);
                 self.tx.insert_headers(blocks.iter().map(|block| &block.header))?;
                 if let Some(progress) = blocks.first() {
                     // Insert last progress data

--- a/crates/stages/src/stages/senders.rs
+++ b/crates/stages/src/stages/senders.rs
@@ -251,7 +251,7 @@ mod tests {
             let stage_progress = input.stage_progress.unwrap_or_default();
             let end = input.previous_stage_progress() + 1;
 
-            let blocks = random_block_range(stage_progress..end, H256::zero());
+            let blocks = random_block_range(stage_progress..end, H256::zero(), 0..2);
 
             let mut current_tx_id = 0;
             blocks.iter().try_for_each(|b| -> Result<(), TestRunnerError> {


### PR DESCRIPTION
I wanted to make the amount of transactions in randomly generated blocks configurable so we can speed up body and sender recovery tests, and I noticed that empty blocks was the cause for the flakiness described in #531.

This PR adds the tx count configuration and fixes the test

Closes #531 