### PR TITLE
feat(eth-wire): RLP encode then compress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3487,6 +3487,7 @@ dependencies = [
  "reth-ecies",
  "reth-primitives",
  "reth-rlp",
+ "reth-tracing",
  "secp256k1",
  "serde",
  "smol_str",

--- a/crates/net/eth-wire/Cargo.toml
+++ b/crates/net/eth-wire/Cargo.toml
@@ -30,10 +30,11 @@ smol_str = { version = "0.1", features = ["serde"] }
 metrics = "0.20.1"
 
 [dev-dependencies]
-test-fuzz = "3.0.4"
 reth-ecies = { path = "../ecies" }
+reth-tracing = { path = "../../tracing" }
 ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 
+test-fuzz = "3.0.4"
 tokio-util = { version = "0.7.4", features = ["io", "codec"] }
 hex-literal = "0.3"
 rand = "0.8"

--- a/crates/net/eth-wire/src/disconnect.rs
+++ b/crates/net/eth-wire/src/disconnect.rs
@@ -212,12 +212,33 @@ mod tests {
             // encoding the disconnect reason as a single byte
             "0100", // 0x00 case
             "0180", // second 0x00 case
-            "0101", "0102", "0103", "0104", "0105", "0106", "0107", "0108", "0109", "010a", "010b",
-            "0110",   // encoding the disconnect reason in a list
+            "0101",
+            "0102",
+            "0103",
+            "0104",
+            "0105",
+            "0106",
+            "0107",
+            "0108",
+            "0109",
+            "010a",
+            "010b",
+            "0110",
+            // encoding the disconnect reason in a list
             "01c100", // 0x00 case
             "01c180", // second 0x00 case
-            "01c101", "01c102", "01c103", "01c104", "01c105", "01c106", "01c107", "01c108",
-            "01c109", "01c10a", "01c10b", "01c110",
+            "01c101",
+            "01c102",
+            "01c103",
+            "01c104",
+            "01c105",
+            "01c106",
+            "01c107",
+            "01c108",
+            "01c109",
+            "01c10a",
+            "01c10b",
+            "01c110",
         ];
 
         for reason in all_reasons {

--- a/crates/net/eth-wire/src/disconnect.rs
+++ b/crates/net/eth-wire/src/disconnect.rs
@@ -212,33 +212,12 @@ mod tests {
             // encoding the disconnect reason as a single byte
             "0100", // 0x00 case
             "0180", // second 0x00 case
-            "0101",
-            "0102",
-            "0103",
-            "0104",
-            "0105",
-            "0106",
-            "0107",
-            "0108",
-            "0109",
-            "010a",
-            "010b",
-            "0110",
-            // encoding the disconnect reason in a list
+            "0101", "0102", "0103", "0104", "0105", "0106", "0107", "0108", "0109", "010a", "010b",
+            "0110",   // encoding the disconnect reason in a list
             "01c100", // 0x00 case
             "01c180", // second 0x00 case
-            "01c101",
-            "01c102",
-            "01c103",
-            "01c104",
-            "01c105",
-            "01c106",
-            "01c107",
-            "01c108",
-            "01c109",
-            "01c10a",
-            "01c10b",
-            "01c110",
+            "01c101", "01c102", "01c103", "01c104", "01c105", "01c106", "01c107", "01c108",
+            "01c109", "01c10a", "01c10b", "01c110",
         ];
 
         for reason in all_reasons {

--- a/crates/net/eth-wire/src/hello.rs
+++ b/crates/net/eth-wire/src/hello.rs
@@ -108,46 +108,8 @@ mod tests {
     use secp256k1::{SecretKey, SECP256K1};
 
     use crate::{
-        capability::Capability,
-        p2pstream::{P2PMessage, P2PMessageID},
-        EthVersion, HelloMessage, ProtocolVersion,
+        capability::Capability, p2pstream::P2PMessage, EthVersion, HelloMessage, ProtocolVersion,
     };
-
-    #[test]
-    fn test_pong_snappy_encoding_parity() {
-        // encode pong using our `Encodable` implementation
-        let pong = P2PMessage::Pong;
-        let mut pong_encoded = Vec::new();
-        pong.encode(&mut pong_encoded);
-
-        // the definition of pong is 0x80 (an empty rlp string)
-        let pong_raw = vec![EMPTY_STRING_CODE];
-        let mut snappy_encoder = snap::raw::Encoder::new();
-        let pong_compressed = snappy_encoder.compress_vec(&pong_raw).unwrap();
-        let mut pong_expected = vec![P2PMessageID::Pong as u8];
-        pong_expected.extend(&pong_compressed);
-
-        // ensure that the two encodings are equal
-        assert_eq!(
-            pong_expected, pong_encoded,
-            "left: {pong_expected:#x?}, right: {pong_encoded:#x?}"
-        );
-
-        // also ensure that the length is correct
-        assert_eq!(pong_expected.len(), P2PMessage::Pong.length());
-
-        // try to decode using Decodable
-        let p2p_message = P2PMessage::decode(&mut &pong_expected[..]).unwrap();
-        assert_eq!(p2p_message, P2PMessage::Pong);
-
-        // finally decode the encoded message with snappy
-        let mut snappy_decoder = snap::raw::Decoder::new();
-
-        // the message id is not compressed, only compress the latest bits
-        let decompressed = snappy_decoder.decompress_vec(&pong_encoded[1..]).unwrap();
-
-        assert_eq!(decompressed, pong_raw);
-    }
 
     #[test]
     fn test_hello_encoding_round_trip() {

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -199,14 +199,43 @@ impl<S> P2PStream<S> {
     /// reading new messages.
     ///
     /// Once disconnect process has started, the [`Stream`] will terminate immediately.
-    pub fn start_disconnect(&mut self, reason: DisconnectReason) {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error only if the message fails to compress.
+    pub fn start_disconnect(&mut self, reason: DisconnectReason) -> Result<(), snap::Error> {
         // clear any buffered messages and queue in
         self.outgoing_messages.clear();
         let disconnect = P2PMessage::Disconnect(reason);
         let mut buf = BytesMut::with_capacity(disconnect.length());
         disconnect.encode(&mut buf);
-        self.outgoing_messages.push_back(buf.freeze());
+
+        tracing::trace!(
+            fromlen=%buf.len(),
+            msg=%hex::encode(&buf),
+            "Compressing disconnect message",
+        );
+
+        let mut compressed = BytesMut::zeroed(1 + snap::raw::max_compress_len(buf.len() - 1));
+        let compressed_size = self.encoder.compress(&buf[1..], &mut compressed[1..])?;
+
+        // truncate the compressed buffer to the actual compressed size (plus one for the message
+        // id)
+        compressed.truncate(compressed_size + 1);
+
+        // we do not add the capability offset because the disconnect message is a `p2p` reserved
+        // message
+        compressed[0] = buf[0];
+
+        tracing::trace!(
+            tolen=%compressed.len(),
+            compressed=%hex::encode(&compressed),
+            "Compressed disconnect message",
+        );
+
+        self.outgoing_messages.push_back(compressed.freeze());
         self.disconnecting = true;
+        Ok(())
     }
 }
 
@@ -216,9 +245,10 @@ where
 {
     /// Disconnects the connection by sending a disconnect message.
     ///
-    /// This future resolves once the disconnect message has been sent.
+    /// This future resolves once the disconnect message has been sent and the stream has been
+    /// closed.
     pub async fn disconnect(mut self, reason: DisconnectReason) -> Result<(), P2PStreamError> {
-        self.start_disconnect(reason);
+        self.start_disconnect(reason)?;
         self.close().await
     }
 }
@@ -257,7 +287,7 @@ where
             }
             _ => {
                 // encode the disconnect message
-                this.start_disconnect(DisconnectReason::PingTimeout);
+                this.start_disconnect(DisconnectReason::PingTimeout)?;
 
                 // End the stream after ping related error
                 return Poll::Ready(None)
@@ -273,6 +303,12 @@ where
                 None => return Poll::Ready(None),
             };
 
+            tracing::trace!(
+                fromlen=%bytes.len(),
+                msg=%hex::encode(&bytes),
+                "Determining decompressed message length",
+            );
+
             // first check that the compressed message length does not exceed the max
             // payload size
             let decompressed_len = snap::raw::decompress_len(&bytes[1..])?;
@@ -286,6 +322,13 @@ where
             // create a buffer to hold the decompressed message, adding a byte to the length for
             // the message ID byte, which is the first byte in this buffer
             let mut decompress_buf = BytesMut::zeroed(decompressed_len + 1);
+
+            tracing::trace!(
+                fromlen=%bytes.len(),
+                tolen=%decompress_buf.len(),
+                msg=%hex::encode(&bytes),
+                "Decompressing message",
+            );
 
             // each message following a successful handshake is compressed with snappy, so we need
             // to decompress the message before we can decode it.
@@ -307,9 +350,9 @@ where
                     this.outgoing_messages.push_back(pong_bytes.into());
                 }
                 _ if id == P2PMessageID::Disconnect as u8 => {
-                    let reason = DisconnectReason::decode(&mut &bytes[1..]).map_err(|err| {
+                    let reason = DisconnectReason::decode(&mut &decompress_buf[1..]).map_err(|err| {
                         tracing::warn!(
-                            ?err, msg=%hex::encode(&bytes[1..]), "Failed to decode disconnect message from peer"
+                            ?err, msg=%hex::encode(&decompress_buf[1..]), "Failed to decode disconnect message from peer"
                         );
                         err
                     })?;
@@ -402,17 +445,22 @@ where
             return Err(P2PStreamError::SendBufferFull)
         }
 
-        let mut compressed = BytesMut::zeroed(1 + snap::raw::max_compress_len(item.len() - 1));
+        tracing::trace!(
+            fromlen=%item.len(),
+            msg=%hex::encode(&item),
+            "Compressing message",
+        );
 
-        // all messages sent in this stream are subprotocol messages, so we need to switch the
-        // message id based on the offset
-        compressed[0] = item[0] + this.shared_capability.offset();
+        let mut compressed = BytesMut::zeroed(1 + snap::raw::max_compress_len(item.len() - 1));
         let compressed_size = this.encoder.compress(&item[1..], &mut compressed[1..])?;
 
         // truncate the compressed buffer to the actual compressed size (plus one for the message
         // id)
         compressed.truncate(compressed_size + 1);
 
+        // all messages sent in this stream are subprotocol messages, so we need to switch the
+        // message id based on the offset
+        compressed[0] = item[0] + this.shared_capability.offset();
         this.outgoing_messages.push_back(compressed.freeze());
 
         Ok(())
@@ -574,13 +622,9 @@ impl Encodable for P2PMessage {
             P2PMessage::Hello(msg) => msg.encode(out),
             P2PMessage::Disconnect(msg) => msg.encode(out),
             P2PMessage::Ping => {
-                out.put_u8(0x01);
-                out.put_u8(0x00);
                 out.put_u8(EMPTY_STRING_CODE);
             }
             P2PMessage::Pong => {
-                out.put_u8(0x01);
-                out.put_u8(0x00);
                 out.put_u8(EMPTY_STRING_CODE);
             }
         }
@@ -590,8 +634,8 @@ impl Encodable for P2PMessage {
         let payload_len = match self {
             P2PMessage::Hello(msg) => msg.length(),
             P2PMessage::Disconnect(msg) => msg.length(),
-            P2PMessage::Ping => 3, // len([0x01, 0x00, 0x80]) = 3
-            P2PMessage::Pong => 3, // len([0x01, 0x00, 0x80]) = 3
+            P2PMessage::Ping => 1,
+            P2PMessage::Pong => 1,
         };
         payload_len + 1 // (1 for length of p2p message id)
     }
@@ -610,13 +654,11 @@ impl Decodable for P2PMessage {
             P2PMessageID::Hello => Ok(P2PMessage::Hello(HelloMessage::decode(buf)?)),
             P2PMessageID::Disconnect => Ok(P2PMessage::Disconnect(DisconnectReason::decode(buf)?)),
             P2PMessageID::Ping => {
-                // len([0x01, 0x00, 0x80]) = 3
-                buf.advance(3);
+                buf.advance(1);
                 Ok(P2PMessage::Ping)
             }
             P2PMessageID::Pong => {
-                // len([0x01, 0x00, 0x80]) = 3
-                buf.advance(3);
+                buf.advance(1);
                 Ok(P2PMessage::Pong)
             }
         }
@@ -705,7 +747,6 @@ mod tests {
     use super::*;
     use crate::{DisconnectReason, EthVersion};
     use reth_ecies::util::pk2id;
-    use reth_rlp::EMPTY_STRING_CODE;
     use secp256k1::{SecretKey, SECP256K1};
     use tokio::net::{TcpListener, TcpStream};
     use tokio_util::codec::Decoder;
@@ -725,6 +766,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_can_disconnect() {
+        reth_tracing::init_tracing();
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let local_addr = listener.local_addr().unwrap();
 
@@ -754,7 +796,7 @@ mod tests {
         let err = p2p_stream.next().await.unwrap().unwrap_err();
         match err {
             P2PStreamError::Disconnected(reason) => assert_eq!(reason, expected_disconnect),
-            _ => panic!("unexpected err"),
+            e => panic!("unexpected err: {e}"),
         }
     }
 
@@ -804,41 +846,5 @@ mod tests {
 
         // make sure the server receives the message and asserts before ending the test
         handle.await.unwrap();
-    }
-
-    #[test]
-    fn test_ping_snappy_encoding_parity() {
-        // encode ping using our `Encodable` implementation
-        let ping = P2PMessage::Ping;
-        let mut ping_encoded = Vec::new();
-        ping.encode(&mut ping_encoded);
-
-        // the definition of ping is 0x80 (an empty rlp string)
-        let ping_raw = vec![EMPTY_STRING_CODE];
-        let mut snappy_encoder = snap::raw::Encoder::new();
-        let ping_compressed = snappy_encoder.compress_vec(&ping_raw).unwrap();
-        let mut ping_expected = vec![P2PMessageID::Ping as u8];
-        ping_expected.extend(&ping_compressed);
-
-        // ensure that the two encodings are equal
-        assert_eq!(
-            ping_expected, ping_encoded,
-            "left: {ping_expected:#x?}, right: {ping_encoded:#x?}"
-        );
-
-        // also ensure that the length is correct
-        assert_eq!(ping_expected.len(), P2PMessage::Ping.length());
-
-        // try to decode using Decodable
-        let p2p_message = P2PMessage::decode(&mut &ping_expected[..]).unwrap();
-        assert_eq!(p2p_message, P2PMessage::Ping);
-
-        // finally decode the encoded message with snappy
-        let mut snappy_decoder = snap::raw::Decoder::new();
-
-        // the message id is not compressed, only compress the latest bits
-        let decompressed = snappy_decoder.decompress_vec(&ping_encoded[1..]).unwrap();
-
-        assert_eq!(decompressed, ping_raw);
     }
 }

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -303,12 +303,6 @@ where
                 None => return Poll::Ready(None),
             };
 
-            tracing::trace!(
-                fromlen=%bytes.len(),
-                msg=%hex::encode(&bytes),
-                "Determining decompressed message length",
-            );
-
             // first check that the compressed message length does not exceed the max
             // payload size
             let decompressed_len = snap::raw::decompress_len(&bytes[1..])?;


### PR DESCRIPTION
Previously the `Encodable` and `Decodable` implementations for `p2p` messages like `Disconnect` were brittle and included logic related to snappy compression. This is incorrect, because the `Encodable` and `Decodable` implementations should only define what is necessary to encode and decode the RLP representation of the data type, and should not include logic related to protocol details like snappy.

Now, we assume the input to the `Decodable` implementations are not compressed, and we do not encode compressed messages with `Encodable` implementations.

This effects serialization for:
 - `DisconnectReason`
 - `P2PMessage::Ping`
 - `P2PMessage::Pong`
 
 `start_disconnect` is refactored to return a `Result<(), snap::Error>`, and it now compresses the disconnect message explicitly.

Tests are removed which ensure `Encodable` implementations are snappy decodable.
Tests are removed which ensure `Decodable` implementations work correctly with snappy-compressed input.

Documentation is added which explains the need for capability offsets, how they are calculated, and how they are used to determine subprotocol message IDs.