### PR TITLE
perf(net): put timeout check behind interval

### DIFF
--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -438,8 +438,11 @@ impl Future for ActiveSession {
             }
 
             if !progress {
-                // check for timed out requests
-                this.evict_timed_out_requests(Instant::now());
+
+                if this.timeout_interval.poll_tick(cx).is_ready() {
+                    // check for timed out requests
+                    this.evict_timed_out_requests(Instant::now());
+                }
 
                 return Poll::Pending
             }

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -438,7 +438,6 @@ impl Future for ActiveSession {
             }
 
             if !progress {
-
                 if this.timeout_interval.poll_tick(cx).is_ready() {
                     // check for timed out requests
                     this.evict_timed_out_requests(Instant::now());


### PR DESCRIPTION
put the `evict_timed_out_requests` that removes all timed out requests behind the interval so it's not always called