### PR TITLE
test(net): add e2e test for already connected

### DIFF
--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -568,6 +568,7 @@ where
                         "Session disconnected"
                     );
 
+                    let mut reason = None;
                     if let Some(ref err) = error {
                         // If the connection was closed due to an error, we report the peer
                         this.swarm.state_mut().peers_mut().on_connection_dropped(
@@ -575,12 +576,13 @@ where
                             &peer_id,
                             err,
                         );
+                        reason = err.as_disconnected();
                     } else {
                         // Gracefully disconnected
                         this.swarm.state_mut().peers_mut().on_disconnected(peer_id);
                     }
 
-                    this.event_listeners.send(NetworkEvent::SessionClosed { peer_id });
+                    this.event_listeners.send(NetworkEvent::SessionClosed { peer_id, reason });
                 }
                 SwarmEvent::IncomingPendingSessionClosed { remote_addr, error } => {
                     warn!(
@@ -647,6 +649,8 @@ pub enum NetworkEvent {
     SessionClosed {
         /// The identifier of the peer to which a session was closed.
         peer_id: PeerId,
+        /// Why the disconnect was triggered
+        reason: Option<DisconnectReason>,
     },
     /// Established a new session with the given peer.
     SessionEstablished {

--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -288,7 +288,7 @@ where
     /// Handles a received event related to common network events.
     fn on_network_event(&mut self, event: NetworkEvent) {
         match event {
-            NetworkEvent::SessionClosed { peer_id } => {
+            NetworkEvent::SessionClosed { peer_id, .. } => {
                 // remove the peer
                 self.peers.remove(&peer_id);
             }


### PR DESCRIPTION
tests that additional connections from the same peer (PeerId) are properly disconnected with `AlreadyConnected` reason