### PR TITLE
feat(cli): add implementation for verbose flag

### DIFF
--- a/bin/reth/src/cli.rs
+++ b/bin/reth/src/cli.rs
@@ -11,8 +11,12 @@ use crate::{
 /// main function that parses cli and runs command
 pub async fn run() -> eyre::Result<()> {
     let opt = Cli::parse();
-    reth_tracing::build_subscriber(if opt.silent { TracingMode::Silent } else { TracingMode::All })
-        .init();
+    reth_tracing::build_subscriber(if opt.silent {
+        TracingMode::Silent
+    } else {
+        TracingMode::from(opt.verbose)
+    })
+    .init();
 
     match opt.command {
         Commands::Node(command) => command.execute().await,

--- a/bin/reth/src/util/mod.rs
+++ b/bin/reth/src/util/mod.rs
@@ -31,17 +31,41 @@ pub mod reth_tracing {
 
     /// Tracing modes
     pub enum TracingMode {
-        /// Enable all info traces.
+        /// Enable all traces.
         All,
-        /// Disable tracing
+        /// Enable debug traces.
+        Debug,
+        /// Enable info traces.
+        Info,
+        /// Enable warn traces.
+        Warn,
+        /// Enable error traces.
+        Error,
+        /// Disable tracing.
         Silent,
     }
 
     impl TracingMode {
         fn into_env_filter(self) -> EnvFilter {
             match self {
-                Self::All => EnvFilter::new("reth=info"),
+                Self::All => EnvFilter::new("reth=trace"),
+                Self::Debug => EnvFilter::new("reth=debug"),
+                Self::Info => EnvFilter::new("reth=info"),
+                Self::Warn => EnvFilter::new("reth=warn"),
+                Self::Error => EnvFilter::new("reth=error"),
                 Self::Silent => EnvFilter::new(""),
+            }
+        }
+    }
+
+    impl From<u8> for TracingMode {
+        fn from(value: u8) -> Self {
+            match value {
+                0 => Self::Error,
+                1 => Self::Warn,
+                2 => Self::Info,
+                3 => Self::Debug,
+                _ => Self::All,
             }
         }
     }


### PR DESCRIPTION
Previously the `--verbose` flag wasn't really doing anything. This PR adds the functionality needed for it to work.

Brief explanation: without specifying the flag, the default is `error` level tracing, and for each one specified thereafter, the level increases, up to `trace` level at a count of 4.