### PR TITLE
feat(net): add ForkTransition type

### DIFF
--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -470,7 +470,11 @@ where
                 let _ = tx.send(self.fetch_client());
             }
             NetworkHandleMessage::StatusUpdate { height, hash, total_difficulty } => {
-                self.swarm.sessions_mut().on_status_update(height, hash, total_difficulty);
+                if let Some(transition) =
+                    self.swarm.sessions_mut().on_status_update(height, hash, total_difficulty)
+                {
+                    self.swarm.state_mut().update_fork_id(transition.current);
+                }
             }
         }
     }

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -19,7 +19,7 @@ use reth_eth_wire::{
     error::EthStreamError,
     DisconnectReason, HelloMessage, Status, UnauthedEthStream, UnauthedP2PStream,
 };
-use reth_primitives::{ForkFilter, PeerId, H256, U256};
+use reth_primitives::{ForkFilter, ForkTransition, PeerId, H256, U256};
 use secp256k1::SecretKey;
 use std::{
     collections::HashMap,
@@ -146,11 +146,19 @@ impl SessionManager {
         }
     }
 
-    /// Invoked on a received status update
-    pub(crate) fn on_status_update(&mut self, height: u64, hash: H256, total_difficulty: U256) {
+    /// Invoked on a received status update.
+    ///
+    /// If the updated activated another fork, this will return a [`ForkTransition`] and updates the
+    /// active [`ForkId`](reth_primitives::ForkId). See also [`ForkFilter::set_head`].
+    pub(crate) fn on_status_update(
+        &mut self,
+        height: u64,
+        hash: H256,
+        total_difficulty: U256,
+    ) -> Option<ForkTransition> {
         self.status.blockhash = hash;
         self.status.total_difficulty = total_difficulty;
-        self.fork_filter.set_head(height);
+        self.fork_filter.set_head(height)
     }
 
     /// An incoming TCP connection was received. This starts the authentication process to turn this

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -216,10 +216,9 @@ where
         self.state_fetcher.update_peer_block(peer_id, hash, number);
     }
 
-    /// Invoked on a [`ForkId`] update
-    #[allow(unused)]
-    pub(crate) fn update_fork_id(&mut self, _fork_id: ForkId) {
-        todo!()
+    /// Invoked when a new [`ForkId`] is activated.
+    pub(crate) fn update_fork_id(&mut self, fork_id: ForkId) {
+        self.discovery.update_fork_id(fork_id)
     }
 
     /// Invoked after a `NewBlock` message was received by the peer.

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -35,7 +35,7 @@ pub use block::{Block, BlockHashOrNumber, BlockLocked};
 pub use chain::Chain;
 pub use constants::{EMPTY_OMMER_ROOT, KECCAK_EMPTY, MAINNET_GENESIS};
 pub use ethbloom::Bloom;
-pub use forkid::{ForkFilter, ForkHash, ForkId, ValidationError};
+pub use forkid::{ForkFilter, ForkHash, ForkId, ForkTransition, ValidationError};
 pub use hardfork::Hardfork;
 pub use header::{Header, HeadersDirection, SealedHeader};
 pub use hex_bytes::Bytes;


### PR DESCRIPTION
Closes #477

The `ForkFilter` type already updates the currently active ForkId, this adds a `ForkTransition` type and update new forkId in discovery.