### PR TITLE
ci: speed up fuzz tests

### DIFF
--- a/.github/scripts/fuzz.sh
+++ b/.github/scripts/fuzz.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 # Runs fuzz tests using `cargo test-fuzz`.
 
 PACKAGE=$1

--- a/.github/scripts/fuzz.sh
+++ b/.github/scripts/fuzz.sh
@@ -5,12 +5,14 @@ set -e
 PACKAGE=$1
 TEST_TIME=${2:-5}
 
+echo Building corpus.
+cargo test -p $PACKAGE
+
+# We configure coverage after building a corpus to only include
+# fuzz tests in the coverage report.
 echo Configuring coverage.
 source <(cargo llvm-cov show-env --export-prefix)
 cargo llvm-cov clean --workspace
-
-echo Building corpus.
-cargo test -p $PACKAGE
 
 # Gets the list of tests present in the package.
 TESTS=$(cargo test-fuzz --list -p $PACKAGE | head -n -3 | tail -n+9 | cat - <(echo \"--list\"]) | cat - | jq -r ".[]")
@@ -22,3 +24,6 @@ do
     cargo test-fuzz --no-ui --exact -p "$PACKAGE" $test -- -V $TEST_TIME
     set +x
 done;
+
+echo Building coverage report.
+cargo llvm-cov report --lcov --output-path lcov.info

--- a/.github/scripts/fuzz.sh
+++ b/.github/scripts/fuzz.sh
@@ -5,6 +5,9 @@ set -e
 PACKAGE=$1
 TEST_TIME=${2:-5}
 
+echo Building corpus.
+cargo test -p $PACKAGE
+
 # Gets the list of tests present in the package.
 TESTS=$(cargo test-fuzz --list -p $PACKAGE | head -n -3 | tail -n+9 | cat - <(echo \"--list\"]) | cat - | jq -r ".[]")
 

--- a/.github/scripts/fuzz.sh
+++ b/.github/scripts/fuzz.sh
@@ -4,8 +4,6 @@
 PACKAGE=$1
 TEST_TIME=${2:-5}
 
-echo "::group::$PACKAGE"
-
 echo Building corpus.
 cargo test -p $PACKAGE --no-run --all-features
 
@@ -19,5 +17,3 @@ do
     cargo test-fuzz --no-ui  -p "$PACKAGE" $test  -- -V $TEST_TIME
     set +x
 done;
-
-echo "::endgroup::"

--- a/.github/scripts/fuzz.sh
+++ b/.github/scripts/fuzz.sh
@@ -5,9 +5,6 @@ set -e
 PACKAGE=$1
 TEST_TIME=${2:-5}
 
-echo Building corpus.
-cargo test -p $PACKAGE --no-run --all-features
-
 # Gets the list of tests present in the package.
 TESTS=$(cargo test-fuzz --list -p $PACKAGE | head -n -3 | tail -n+9 | cat - <(echo \"--list\"]) | cat - | jq -r ".[]")
 
@@ -15,6 +12,6 @@ for test in $TESTS
 do
     echo Running test: $test
     set -x
-    cargo test-fuzz --no-ui  -p "$PACKAGE" $test  -- -V $TEST_TIME
+    cargo test-fuzz --no-ui --exact -p "$PACKAGE" $test -- -V $TEST_TIME
     set +x
 done;

--- a/.github/scripts/fuzz.sh
+++ b/.github/scripts/fuzz.sh
@@ -5,6 +5,10 @@ set -e
 PACKAGE=$1
 TEST_TIME=${2:-5}
 
+echo Configuring coverage.
+source <(cargo llvm-cov show-env --export-prefix)
+cargo llvm-cov clean --workspace
+
 echo Building corpus.
 cargo test -p $PACKAGE
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,8 @@ jobs:
         target:
           - reth-primitives
           - reth-db
-          - reth-eth-wire
+          # TODO(onbjerg): Re-enable once the tests are fixed
+          # - reth-eth-wire
           - reth-codecs
     steps:
       - name: Checkout sources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ env:
   RUSTFLAGS: -D warnings
   CARGO_TERM_COLOR: always
   GETH_BUILD: 1.10.26-e5eb32ac
-  AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES: 1
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           command: install
           args: cargo-test-fuzz afl
 
-      - name: check for cargo afl
+      - name: Force install cargo-afl
         run: |
           cargo install --force afl
           cargo afl --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
+          flags: unit-tests
 
   fuzz:
     # Pin to `20.04` instead of `ubuntu-latest`, until ubuntu-latest migration is complete
@@ -72,6 +73,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -81,17 +84,24 @@ jobs:
         with:
           command: install
           args: cargo-test-fuzz afl
-
       - name: Force install cargo-afl
         run: |
           cargo install --force afl
           cargo afl --version
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Run fuzz tests
         run: |
           ./.github/scripts/fuzz.sh ${{ matrix.target }}
         env:
           AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES: 1
+      - name: Upload coverage data to codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: fuzz-tests
 
   lint:
     # Pin to `20.04` instead of `ubuntu-latest`, until ubuntu-latest migration is complete

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -41,12 +43,17 @@ jobs:
 
       - name: Install latest nextest release
         uses: taiki-e/install-action@nextest
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
 
-      - name: Test with latest nextest release
-        uses: actions-rs/cargo@v1
+      - name: Run tests
+        run: cargo llvm-cov nextest --lcov --output-path lcov.info --locked --workspace --all-features
+
+      - name: Upload coverage data to codecov
+        uses: codecov/codecov-action@v3
         with:
-          command: nextest
-          args: run --locked --workspace --all-features
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
 
   fuzz:
     # Pin to `20.04` instead of `ubuntu-latest`, until ubuntu-latest migration is complete
@@ -111,39 +118,3 @@ jobs:
         with:
           args: --all --all-features
           token: ${{ secrets.GITHUB_TOKEN }}
-
-  coverage:
-    # Pin to `20.04` instead of `ubuntu-latest`, until ubuntu-latest migration is complete
-    # See also <https://github.com/foundry-rs/foundry/issues/3827>
-    runs-on: ubuntu-20.04
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Install latest nextest release
-        uses: taiki-e/install-action@nextest
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
-
-      - name: Install geth
-        run: |
-            mkdir -p "$HOME/bin"
-            wget -q https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-$GETH_BUILD.tar.gz
-            tar -xvf geth-linux-amd64-$GETH_BUILD.tar.gz
-            mv geth-linux-amd64-$GETH_BUILD/geth $HOME/bin/geth
-            chmod u+x "$HOME/bin/geth"
-            export PATH=$HOME/bin:$PATH
-            echo $HOME/bin >> $GITHUB_PATH
-            geth version
-
-      - name: Collect coverage data
-        run: cargo llvm-cov nextest --lcov --output-path lcov.info --locked --workspace --all-features
-      - name: Upload coverage data to codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,7 @@ jobs:
         target:
           - reth-primitives
           - reth-db
-          # TODO(onbjerg): Re-enable once the tests are fixed
-          # - reth-eth-wire
+          - reth-eth-wire
           - reth-codecs
     steps:
       - name: Checkout sources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,13 @@ jobs:
     # Pin to `20.04` instead of `ubuntu-latest`, until ubuntu-latest migration is complete
     # See also <https://github.com/foundry-rs/foundry/issues/3827>
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        target:
+          - reth-primitives
+          - reth-db
+          - reth-eth-wire
+          - reth-codecs
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -75,10 +82,9 @@ jobs:
 
       - name: Run fuzz tests
         run: |
-          ./.github/scripts/fuzz.sh reth-primitives
-          ./.github/scripts/fuzz.sh reth-db
-          ./.github/scripts/fuzz.sh reth-eth-wire
-          ./.github/scripts/fuzz.sh reth-codecs
+          ./.github/scripts/fuzz.sh ${{ matrix.target }}
+        env:
+          AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES: 1
 
   lint:
     # Pin to `20.04` instead of `ubuntu-latest`, until ubuntu-latest migration is complete


### PR DESCRIPTION
Speed up fuzz tests by running them in a matrix

To do:

- [x]  Collect fuzz test coverage data
- [x]  Probably move coverage collection into the test job itself, no reason to run the same tests 2 times