### PR TITLE
feat(rpc): basic engine api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3725,6 +3725,7 @@ dependencies = [
  "reth-network",
  "reth-primitives",
  "reth-provider",
+ "reth-rlp",
  "reth-rpc-api",
  "reth-rpc-types",
  "reth-transaction-pool",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3336,13 +3336,16 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "eyre",
+ "futures",
  "reth-interfaces",
  "reth-primitives",
  "reth-provider",
  "reth-rlp",
+ "reth-rpc-types",
  "serde",
  "thiserror",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -3725,13 +3728,13 @@ dependencies = [
  "reth-network",
  "reth-primitives",
  "reth-provider",
- "reth-rlp",
  "reth-rpc-api",
  "reth-rpc-types",
  "reth-transaction-pool",
  "serde",
  "serde_json",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3720,6 +3720,7 @@ dependencies = [
  "async-trait",
  "hex",
  "jsonrpsee",
+ "reth-consensus",
  "reth-interfaces",
  "reth-network",
  "reth-primitives",

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -11,14 +11,19 @@ readme = "README.md"
 reth-primitives = { path = "../primitives" }
 reth-interfaces = { path = "../interfaces" }
 reth-provider = { path = "../storage/provider" }
-reth-rlp = {path = "../common/rlp"}
+reth-rlp = { path = "../common/rlp" }
+reth-rpc-types = { path = "../net/rpc-types" }
+
+# async
+futures = "0.3"
+async-trait = "0.1.57"
+tokio = { version = "1.21.2", features = ["sync"] }
+tokio-stream = "0.1"
 
 # common
-async-trait = "0.1.57"
 thiserror = "1.0.37"
 eyre = "0.6.8"
 auto_impl = "1.0"
-tokio = { version = "1.21.2", features = ["sync"] }
 
 # io
 serde = { version = "1.0", optional = true }

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -17,7 +17,7 @@ reth-rpc-types = { path = "../net/rpc-types" }
 # async
 futures = "0.3"
 async-trait = "0.1.57"
-tokio = { version = "1.21.2", features = ["sync"] }
+tokio = { version = "1", features = ["sync"] }
 tokio-stream = "0.1"
 
 # common

--- a/crates/consensus/src/engine/error.rs
+++ b/crates/consensus/src/engine/error.rs
@@ -1,6 +1,9 @@
 use reth_primitives::{Bytes, H256, U256};
 use thiserror::Error;
 
+/// The Engine API result type
+pub type EngineApiResult<Ok> = Result<Ok, EngineApiError>;
+
 /// Error returned by [`EngineApi`][crate::engine::EngineApi]
 #[derive(Error, Debug)]
 pub enum EngineApiError {

--- a/crates/consensus/src/engine/mod.rs
+++ b/crates/consensus/src/engine/mod.rs
@@ -77,9 +77,9 @@ pub struct EthConsensusEngine<Client> {
     /// Consensus configuration
     config: Config,
     client: Client,
-    /// Placeholder for storing future built blocks
+    /// Placeholder for storing future blocks
     local_store: HashMap<H64, ExecutionPayload>, // TODO: bound
-    remote_store: HashMap<H64, ExecutionPayload>,
+    // remote_store: HashMap<H64, ExecutionPayload>,
     rx: UnboundedReceiverStream<EngineMessage>,
 }
 

--- a/crates/consensus/src/engine/mod.rs
+++ b/crates/consensus/src/engine/mod.rs
@@ -245,8 +245,7 @@ impl<Client: HeaderProvider + BlockProvider> ConsensusEngine for EthConsensusEng
             return Err(EngineApiError::TerminalTD {
                 execution: merge_terminal_td,
                 consensus: terminal_total_difficulty,
-            }
-            .into())
+            })
         }
 
         // Short circuit if communicated block hash is zero
@@ -270,8 +269,7 @@ impl<Client: HeaderProvider + BlockProvider> ConsensusEngine for EthConsensusEng
             _ => Err(EngineApiError::TerminalBlockHash {
                 execution: local_hash,
                 consensus: terminal_block_hash,
-            }
-            .into()),
+            }),
         }
     }
 }

--- a/crates/consensus/src/engine/mod.rs
+++ b/crates/consensus/src/engine/mod.rs
@@ -23,10 +23,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 
 mod error;
 use crate::Config;
-pub use error::EngineApiError;
-
-/// The Engine API result type
-pub type EngineApiResult<Ok> = Result<Ok, EngineApiError>;
+pub use error::{EngineApiError, EngineApiResult};
 
 /// The Engine API response sender
 pub type EngineApiSender<Ok> = oneshot::Sender<EngineApiResult<Ok>>;

--- a/crates/consensus/src/engine/mod.rs
+++ b/crates/consensus/src/engine/mod.rs
@@ -15,14 +15,15 @@ use std::{
     collections::HashMap,
     future::Future,
     pin::Pin,
+    sync::Arc,
     task::{ready, Context, Poll},
 };
 use tokio::sync::oneshot;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 mod error;
-pub use error::EngineApiError;
 use crate::Config;
+pub use error::EngineApiError;
 
 /// The Engine API result type
 pub type EngineApiResult<Ok> = Result<Ok, EngineApiError>;

--- a/crates/consensus/src/engine/mod.rs
+++ b/crates/consensus/src/engine/mod.rs
@@ -198,7 +198,7 @@ impl<Client: HeaderProvider + BlockProvider> ConsensusEngine for EthConsensusEng
 
         // TODO: execute block
 
-        return Ok(PayloadStatus::new(PayloadStatusEnum::Valid, block.hash()))
+        Ok(PayloadStatus::new(PayloadStatusEnum::Valid, block.hash()))
     }
 
     fn fork_choice_updated(

--- a/crates/consensus/src/engine/mod.rs
+++ b/crates/consensus/src/engine/mod.rs
@@ -22,7 +22,6 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 
 mod error;
 pub use error::EngineApiError;
-
 use crate::Config;
 
 /// The Engine API result type
@@ -73,10 +72,11 @@ pub enum EngineMessage {
 }
 
 /// The consensus engine API implementation
+#[must_use = "EthConsensusEngine does nothing unless polled."]
 pub struct EthConsensusEngine<Client> {
     /// Consensus configuration
     config: Config,
-    client: Client,
+    client: Arc<Client>,
     /// Placeholder for storing future blocks
     local_store: HashMap<H64, ExecutionPayload>, // TODO: bound
     // remote_store: HashMap<H64, ExecutionPayload>,

--- a/crates/consensus/src/engine/mod.rs
+++ b/crates/consensus/src/engine/mod.rs
@@ -1,0 +1,297 @@
+use futures::StreamExt;
+use reth_interfaces::consensus::ForkchoiceState;
+use reth_primitives::{
+    proofs::{self, EMPTY_LIST_HASH},
+    rpc::BlockId,
+    BlockLocked, Header, TransactionSigned, H64,
+};
+use reth_provider::{BlockProvider, HeaderProvider};
+use reth_rlp::Decodable;
+use reth_rpc_types::engine::{
+    ExecutionPayload, ForkchoiceUpdated, PayloadAttributes, PayloadStatus, PayloadStatusEnum,
+    TransitionConfiguration,
+};
+use std::{
+    collections::HashMap,
+    future::Future,
+    pin::Pin,
+    task::{ready, Context, Poll},
+};
+use tokio::sync::oneshot;
+use tokio_stream::wrappers::UnboundedReceiverStream;
+
+mod error;
+pub use error::EngineApiError;
+
+use crate::Config;
+
+/// The Engine API result type
+pub type EngineApiResult<Ok> = Result<Ok, EngineApiError>;
+
+/// The Engine API response sender
+pub type EngineApiSender<Ok> = oneshot::Sender<EngineApiResult<Ok>>;
+
+/// Consensus engine API trait.
+pub trait ConsensusEngine {
+    /// Retrieves payload from local cache.
+    fn get_payload(&self, payload_id: H64) -> Option<ExecutionPayload>;
+
+    /// Receives a payload to validate and execute.
+    fn new_payload(&mut self, payload: ExecutionPayload) -> EngineApiResult<PayloadStatus>;
+
+    /// Updates the fork choice state
+    fn fork_choice_updated(
+        &self,
+        fork_choice_state: ForkchoiceState,
+        payload_attributes: Option<PayloadAttributes>,
+    ) -> EngineApiResult<ForkchoiceUpdated>;
+
+    /// Verifies the transition configuration between execution and consensus clients.
+    fn exchange_transition_configuration(
+        &self,
+        config: TransitionConfiguration,
+    ) -> EngineApiResult<TransitionConfiguration>;
+}
+
+/// Message type for communicating with [EthConsensusEngine]
+pub enum EngineMessage {
+    /// New payload message
+    NewPayload(ExecutionPayload, EngineApiSender<PayloadStatus>),
+    /// Get payload message
+    GetPayload(H64, EngineApiSender<ExecutionPayload>),
+    /// Forkchoice updated message
+    ForkchoiceUpdated(
+        ForkchoiceState,
+        Option<PayloadAttributes>,
+        EngineApiSender<ForkchoiceUpdated>,
+    ),
+    /// Exchange transition configuration message
+    ExchangeTransitionConfiguration(
+        TransitionConfiguration,
+        EngineApiSender<TransitionConfiguration>,
+    ),
+}
+
+/// The consensus engine API implementation
+pub struct EthConsensusEngine<Client> {
+    /// Consensus configuration
+    config: Config,
+    client: Client,
+    /// Placeholder for storing future built blocks
+    local_store: HashMap<H64, ExecutionPayload>, // TODO: bound
+    remote_store: HashMap<H64, ExecutionPayload>,
+    rx: UnboundedReceiverStream<EngineMessage>,
+}
+
+impl<Client: HeaderProvider + BlockProvider> EthConsensusEngine<Client> {
+    fn on_message(&mut self, msg: EngineMessage) {
+        match msg {
+            EngineMessage::GetPayload(payload_id, tx) => {
+                // NOTE: Will always result in `PayloadUnknown` since we don't support block
+                // building for now.
+                let _ = tx.send(self.get_payload(payload_id).ok_or(EngineApiError::PayloadUnknown));
+            }
+            EngineMessage::NewPayload(payload, tx) => {
+                let _ = tx.send(self.new_payload(payload));
+            }
+            EngineMessage::ForkchoiceUpdated(state, attrs, tx) => {
+                let _ = tx.send(self.fork_choice_updated(state, attrs));
+            }
+            EngineMessage::ExchangeTransitionConfiguration(config, tx) => {
+                let _ = tx.send(self.exchange_transition_configuration(config));
+            }
+        }
+    }
+
+    /// Try to construct a block from given payload. Perform addition validation of `extra_data` and
+    /// `base_fee_per_gas` fields.
+    ///
+    /// NOTE: The log bloom is assumed to be validated during serialization.
+    /// NOTE: Ommers hash is validated upon computing block hash and comparing the value with
+    /// `payload.block_hash`.
+    /// Ref: https://github.com/ethereum/go-ethereum/blob/79a478bb6176425c2400e949890e668a3d9a3d05/core/beacon/types.go#L145
+    fn try_construct_block(&self, payload: ExecutionPayload) -> EngineApiResult<BlockLocked> {
+        if payload.extra_data.len() > 32 {
+            return Err(EngineApiError::PayloadExtraData(payload.extra_data))
+        }
+
+        if payload.base_fee_per_gas.is_zero() {
+            return Err(EngineApiError::PayloadBaseFee(payload.base_fee_per_gas))
+        }
+
+        let transactions = payload
+            .transactions
+            .iter()
+            .map(|tx| TransactionSigned::decode(&mut tx.as_ref()))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        let transactions_root = proofs::calculate_transaction_root(transactions.iter());
+        let header = Header {
+            parent_hash: payload.parent_hash,
+            beneficiary: payload.fee_recipient,
+            state_root: payload.state_root,
+            transactions_root,
+            receipts_root: payload.receipts_root,
+            logs_bloom: payload.logs_bloom,
+            number: payload.block_number.as_u64(),
+            gas_limit: payload.gas_limit.as_u64(),
+            gas_used: payload.gas_used.as_u64(),
+            timestamp: payload.timestamp.as_u64(),
+            mix_hash: payload.prev_randao,
+            base_fee_per_gas: Some(payload.base_fee_per_gas.as_u64()),
+            extra_data: payload.extra_data.0,
+            // Defaults
+            ommers_hash: EMPTY_LIST_HASH,
+            difficulty: Default::default(),
+            nonce: Default::default(),
+        };
+        let header = header.seal();
+
+        if payload.block_hash != header.hash() {
+            return Err(EngineApiError::PayloadBlockHash {
+                execution: header.hash(),
+                consensus: payload.block_hash,
+            })
+        }
+
+        Ok(BlockLocked { header, body: transactions, ommers: Default::default() })
+    }
+}
+
+impl<Client: HeaderProvider + BlockProvider> ConsensusEngine for EthConsensusEngine<Client> {
+    fn get_payload(&self, payload_id: H64) -> Option<ExecutionPayload> {
+        self.local_store.get(&payload_id).cloned()
+    }
+
+    fn new_payload(&mut self, payload: ExecutionPayload) -> EngineApiResult<PayloadStatus> {
+        let block = match self.try_construct_block(payload) {
+            Ok(b) => b,
+            Err(err) => {
+                return Ok(PayloadStatus::from_status(PayloadStatusEnum::InvalidBlockHash {
+                    validation_error: err.to_string(),
+                }))
+            }
+        };
+
+        // The block already exists in our database
+        if self.client.is_known(&block.hash())? {
+            return Ok(PayloadStatus::new(PayloadStatusEnum::Valid, block.hash()))
+        }
+
+        let Some(parent) = self.client.block(BlockId::Hash(block.parent_hash))? else {
+             // TODO: cache block for storing later
+             return Ok(PayloadStatus::from_status(PayloadStatusEnum::Syncing))
+        };
+
+        let parent_td = self.client.header_td(&block.parent_hash)?;
+        if parent_td.unwrap_or_default() <= self.config.merge_terminal_total_difficulty.into() {
+            return Ok(PayloadStatus::from_status(PayloadStatusEnum::Invalid {
+                validation_error: EngineApiError::PayloadPreMerge.to_string(),
+            }))
+        }
+
+        if block.timestamp <= parent.timestamp {
+            return Err(EngineApiError::PayloadTimestamp {
+                invalid: block.timestamp,
+                latest: parent.timestamp,
+            })
+        }
+
+        // TODO: execute block
+
+        return Ok(PayloadStatus::new(PayloadStatusEnum::Valid, block.hash()))
+    }
+
+    fn fork_choice_updated(
+        &self,
+        fork_choice_state: ForkchoiceState,
+        _payload_attributes: Option<PayloadAttributes>,
+    ) -> EngineApiResult<ForkchoiceUpdated> {
+        let ForkchoiceState { head_block_hash, finalized_block_hash, .. } = fork_choice_state;
+
+        if head_block_hash.is_zero() {
+            return Ok(ForkchoiceUpdated::from_status(PayloadStatusEnum::Invalid {
+                validation_error: EngineApiError::ForkchoiceEmptyHead.to_string(),
+            }))
+        }
+
+        // Block is not known, nothing to do.
+        if !self.client.is_known(&head_block_hash)? {
+            return Ok(ForkchoiceUpdated::from_status(PayloadStatusEnum::Syncing))
+        }
+
+        // The finalized block hash is not known, we are still syncing
+        if !finalized_block_hash.is_zero() && !self.client.is_known(&finalized_block_hash)? {
+            return Ok(ForkchoiceUpdated::from_status(PayloadStatusEnum::Syncing))
+        }
+
+        let chain_info = self.client.chain_info()?;
+        Ok(ForkchoiceUpdated::from_status(PayloadStatusEnum::Valid)
+            .with_latest_valid_hash(chain_info.best_hash))
+    }
+
+    fn exchange_transition_configuration(
+        &self,
+        config: TransitionConfiguration,
+    ) -> EngineApiResult<TransitionConfiguration> {
+        let TransitionConfiguration {
+            terminal_total_difficulty,
+            terminal_block_hash,
+            terminal_block_number,
+        } = config;
+
+        // Compare total difficulty values
+        let merge_terminal_td = self.config.merge_terminal_total_difficulty.into();
+        if merge_terminal_td != terminal_total_difficulty {
+            return Err(EngineApiError::TerminalTD {
+                execution: merge_terminal_td,
+                consensus: terminal_total_difficulty,
+            }
+            .into())
+        }
+
+        // Short circuit if communicated block hash is zero
+        if terminal_block_hash.is_zero() {
+            return Ok(TransitionConfiguration {
+                terminal_total_difficulty: merge_terminal_td,
+                ..Default::default()
+            })
+        }
+
+        // Attempt to look up terminal block hash
+        let local_hash = self.client.block_hash(terminal_block_number.into())?;
+
+        // Transition configuration exchange is successful if block hashes match
+        match local_hash {
+            Some(hash) if hash == terminal_block_hash => Ok(TransitionConfiguration {
+                terminal_total_difficulty: merge_terminal_td,
+                terminal_block_hash,
+                terminal_block_number,
+            }),
+            _ => Err(EngineApiError::TerminalBlockHash {
+                execution: local_hash,
+                consensus: terminal_block_hash,
+            }
+            .into()),
+        }
+    }
+}
+
+impl<Client> Future for EthConsensusEngine<Client>
+where
+    Client: HeaderProvider + BlockProvider + Unpin,
+{
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        loop {
+            match ready!(this.rx.poll_next_unpin(cx)) {
+                Some(msg) => this.on_message(msg),
+                None => {
+                    // channel closed
+                    return Poll::Ready(())
+                }
+            }
+        }
+    }
+}

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -11,8 +11,10 @@
 //! - `serde`: Enable serde support for configuration types.
 pub mod config;
 pub mod consensus;
-pub mod engine;
 pub mod verification;
+
+/// Engine API module.
+pub mod engine;
 
 pub use config::Config;
 pub use consensus::EthConsensus;

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -11,6 +11,7 @@
 //! - `serde`: Enable serde support for configuration types.
 pub mod config;
 pub mod consensus;
+pub mod engine;
 pub mod verification;
 
 pub use config::Config;

--- a/crates/consensus/src/verification.rs
+++ b/crates/consensus/src/verification.rs
@@ -431,6 +431,10 @@ mod tests {
         fn header_by_number(&self, _num: u64) -> Result<Option<Header>> {
             Ok(self.parent.clone())
         }
+
+        fn header_td(&self, _hash: &BlockHash) -> Result<Option<U256>> {
+            Ok(None)
+        }
     }
 
     fn mock_tx(nonce: u64) -> TransactionSignedEcRecovered {

--- a/crates/net/network/tests/it/testnet.rs
+++ b/crates/net/network/tests/it/testnet.rs
@@ -349,6 +349,10 @@ impl HeaderProvider for MockEthProvider {
         let lock = self.headers.lock();
         Ok(lock.values().find(|h| h.number == num).cloned())
     }
+
+    fn header_td(&self, hash: &BlockHash) -> reth_interfaces::Result<Option<U256>> {
+        todo!()
+    }
 }
 
 impl BlockProvider for MockEthProvider {

--- a/crates/net/network/tests/it/testnet.rs
+++ b/crates/net/network/tests/it/testnet.rs
@@ -350,7 +350,7 @@ impl HeaderProvider for MockEthProvider {
         Ok(lock.values().find(|h| h.number == num).cloned())
     }
 
-    fn header_td(&self, hash: &BlockHash) -> reth_interfaces::Result<Option<U256>> {
+    fn header_td(&self, _hash: &BlockHash) -> reth_interfaces::Result<Option<U256>> {
         todo!()
     }
 }

--- a/crates/net/rpc-types/Cargo.toml
+++ b/crates/net/rpc-types/Cargo.toml
@@ -11,7 +11,7 @@ Reth RPC types
 [dependencies]
 # reth
 reth-primitives = { path = "../../primitives" }
-reth-rlp = {path = "../../common/rlp"}
+reth-rlp = { path = "../../common/rlp" }
 
 # misc
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/net/rpc-types/src/eth/engine.rs
+++ b/crates/net/rpc-types/src/eth/engine.rs
@@ -96,7 +96,7 @@ pub enum PayloadStatusEnum {
 }
 
 /// This structure contains configurable settings of the transition process.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TransitionConfiguration {
     /// Maps on the TERMINAL_TOTAL_DIFFICULTY parameter of EIP-3675

--- a/crates/net/rpc-types/src/eth/engine.rs
+++ b/crates/net/rpc-types/src/eth/engine.rs
@@ -66,7 +66,7 @@ pub struct PayloadAttributes {
     /// Array of [`Withdrawal`] enabled with V2
     /// See <https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#executionpayloadv2>
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub withdrawal: Option<Withdrawal>,
+    pub withdrawal: Option<Withdrawal>, // TODO: should be a vec
 }
 
 /// This structure contains the result of processing a payload

--- a/crates/net/rpc-types/src/eth/engine.rs
+++ b/crates/net/rpc-types/src/eth/engine.rs
@@ -79,6 +79,16 @@ pub struct PayloadStatus {
     pub latest_valid_hash: Option<H256>,
 }
 
+impl PayloadStatus {
+    pub fn new(status: PayloadStatusEnum, latest_valid_hash: H256) -> Self {
+        Self { status, latest_valid_hash: Some(latest_valid_hash) }
+    }
+
+    pub fn from_status(status: PayloadStatusEnum) -> Self {
+        Self { status, latest_valid_hash: None }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "status", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum PayloadStatusEnum {
@@ -115,8 +125,12 @@ pub struct ForkchoiceUpdated {
 }
 
 impl ForkchoiceUpdated {
-    pub fn new(status: PayloadStatusEnum) -> Self {
-        Self { payload_status: PayloadStatus { status, latest_valid_hash: None }, payload_id: None }
+    pub fn new(payload_status: PayloadStatus) -> Self {
+        Self { payload_status, payload_id: None }
+    }
+
+    pub fn from_status(status: PayloadStatusEnum) -> Self {
+        Self { payload_status: PayloadStatus::from_status(status), payload_id: None }
     }
 
     pub fn with_latest_valid_hash(mut self, hash: H256) -> Self {

--- a/crates/net/rpc-types/src/eth/engine.rs
+++ b/crates/net/rpc-types/src/eth/engine.rs
@@ -113,3 +113,19 @@ pub struct ForkchoiceUpdated {
     pub payload_status: PayloadStatus,
     pub payload_id: Option<H64>,
 }
+
+impl ForkchoiceUpdated {
+    pub fn new(status: PayloadStatusEnum) -> Self {
+        Self { payload_status: PayloadStatus { status, latest_valid_hash: None }, payload_id: None }
+    }
+
+    pub fn with_latest_valid_hash(mut self, hash: H256) -> Self {
+        self.payload_status.latest_valid_hash = Some(hash);
+        self
+    }
+
+    pub fn with_payload_id(mut self, id: H64) -> Self {
+        self.payload_id = Some(id);
+        self
+    }
+}

--- a/crates/net/rpc/Cargo.toml
+++ b/crates/net/rpc/Cargo.toml
@@ -18,13 +18,15 @@ reth-provider = { path = "../../storage/provider" }
 reth-transaction-pool = { path = "../../transaction-pool" }
 reth-network = { path = "../network" }
 reth-consensus = { path = "../../consensus", features = ["serde"] }
-reth-rlp = { path = "../../common/rlp" }
 
 # rpc
 jsonrpsee = { version = "0.16" }
 
-# misc
+# async
 async-trait = "0.1"
+tokio = { version = "1.21.2", features = ["sync"] }
+
+# misc
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"

--- a/crates/net/rpc/Cargo.toml
+++ b/crates/net/rpc/Cargo.toml
@@ -17,6 +17,7 @@ reth-rpc-types = { path = "../rpc-types" }
 reth-provider = { path = "../../storage/provider"}
 reth-transaction-pool = { path = "../../transaction-pool" }
 reth-network = { path = "../network" }
+reth-consensus = { path = "../../consensus", features = ["serde"] }
 
 # rpc
 jsonrpsee = { version = "0.16" }

--- a/crates/net/rpc/Cargo.toml
+++ b/crates/net/rpc/Cargo.toml
@@ -24,7 +24,7 @@ jsonrpsee = { version = "0.16" }
 
 # async
 async-trait = "0.1"
-tokio = { version = "1.21.2", features = ["sync"] }
+tokio = { version = "1", features = ["sync"] }
 
 # misc
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/net/rpc/Cargo.toml
+++ b/crates/net/rpc/Cargo.toml
@@ -14,10 +14,11 @@ reth-interfaces = { path = "../../interfaces" }
 reth-primitives = { path = "../../primitives" }
 reth-rpc-api = { path = "../rpc-api" }
 reth-rpc-types = { path = "../rpc-types" }
-reth-provider = { path = "../../storage/provider"}
+reth-provider = { path = "../../storage/provider" }
 reth-transaction-pool = { path = "../../transaction-pool" }
 reth-network = { path = "../network" }
 reth-consensus = { path = "../../consensus", features = ["serde"] }
+reth-rlp = { path = "../../common/rlp" }
 
 # rpc
 jsonrpsee = { version = "0.16" }

--- a/crates/net/rpc/src/engine/error.rs
+++ b/crates/net/rpc/src/engine/error.rs
@@ -1,0 +1,47 @@
+use jsonrpsee::core::Error as RpcError;
+use reth_primitives::{BlockNumber, H256, U256};
+use thiserror::Error;
+
+use crate::result::rpc_err;
+
+/// Error returned by [`EngineApi`][crate::engine::EngineApi]
+#[derive(Error, Debug)]
+pub enum EngineApiError {
+    #[error(
+        "Invalid transition terminal total difficulty. Expected: {expected}. Received: {received}"
+    )]
+    TerminalTD { expected: U256, received: U256 },
+    #[error("Invalid transition terminal block hash. Expected: {expected}. Received: {received}")]
+    TerminalBlockHash { expected: H256, received: H256 },
+    #[error(
+        "Invalid transition terminal block number. Expected: {expected}. Received: {received}"
+    )]
+    TerminalBlockNumber { expected: BlockNumber, received: BlockNumber },
+    #[error("Unknown payload")]
+    UnknownPayload,
+    /// API encountered an internal error.
+    #[error(transparent)]
+    Internal(reth_interfaces::Error),
+}
+
+impl EngineApiError {
+    fn code(&self) -> i32 {
+        match self {
+            Self::UnknownPayload => -38001,
+            // Any other server error: https://github.com/ethereum/go-ethereum/blob/79a478bb6176425c2400e949890e668a3d9a3d05/core/beacon/errors.go#L79
+            _ => -32000,
+        }
+    }
+}
+
+// impl Into<RpcError> for EngineApiError {
+//     fn into(self) -> jsonrpsee::core::Error {
+//         rpc_err(self.code(), self.to_string(), None)
+//     }
+// }
+
+impl From<EngineApiError> for RpcError {
+    fn from(value: EngineApiError) -> Self {
+        rpc_err(value.code(), value.to_string(), None)
+    }
+}

--- a/crates/net/rpc/src/engine/error.rs
+++ b/crates/net/rpc/src/engine/error.rs
@@ -1,5 +1,5 @@
 use jsonrpsee::core::Error as RpcError;
-use reth_primitives::{H256, U256};
+use reth_primitives::{Bytes, H256, U256};
 use thiserror::Error;
 
 use crate::result::rpc_err;
@@ -7,36 +7,58 @@ use crate::result::rpc_err;
 /// Error returned by [`EngineApi`][crate::engine::EngineApi]
 #[derive(Error, Debug)]
 pub enum EngineApiError {
+    #[error("Invalid payload extra data: {0}")]
+    PayloadExtraData(Bytes),
+    #[error("Invalid payload base fee: {0}")]
+    PayloadBaseFee(U256),
+    /// Invalid payload block hash.
+    #[error("Invalid payload block hash. Execution: {execution}. Consensus: {consensus}")]
+    PayloadBlockHash {
+        /// The block hash computed from the payload.
+        execution: H256,
+        /// The block hash provided with the payload.
+        consensus: H256,
+    },
+    /// Unknown payload requested.
+    #[error("Unknown payload")]
+    PayloadUnknown,
+    /// Terminal total difficulty mismatch during transition configuration exchange.
     #[error(
         "Invalid transition terminal total difficulty. Execution: {execution}. Consensus: {consensus}"
     )]
-    TerminalTD { execution: U256, consensus: U256 },
+    TerminalTD {
+        /// Execution terminal total difficulty value.
+        execution: U256,
+        /// Consensus terminal total difficulty value.
+        consensus: U256,
+    },
+    /// Terminal block hash mismatch during transition configuration exchange.
     #[error(
         "Invalid transition terminal block hash. Execution: {execution:?}. Consensus: {consensus}"
     )]
-    TerminalBlockHash { execution: Option<H256>, consensus: H256 },
-    #[error("Unknown payload")]
-    UnknownPayload,
+    TerminalBlockHash {
+        /// Execution terminal block hash. `None` if block number is not found in the database.
+        execution: Option<H256>,
+        /// Consensus terminal block hash.
+        consensus: H256,
+    },
+    /// Encountered decoding error.
+    #[error(transparent)]
+    Decode(#[from] reth_rlp::DecodeError),
     /// API encountered an internal error.
     #[error(transparent)]
-    Internal(reth_interfaces::Error),
+    Internal(#[from] reth_interfaces::Error),
 }
 
 impl EngineApiError {
     fn code(&self) -> i32 {
         match self {
-            Self::UnknownPayload => -38001,
-            // Any other server error: https://github.com/ethereum/go-ethereum/blob/79a478bb6176425c2400e949890e668a3d9a3d05/core/beacon/errors.go#L79
-            _ => -32000,
+            Self::PayloadUnknown => -38001,
+            // Any other server error
+            _ => jsonrpsee::types::error::INTERNAL_ERROR_CODE,
         }
     }
 }
-
-// impl Into<RpcError> for EngineApiError {
-//     fn into(self) -> jsonrpsee::core::Error {
-//         rpc_err(self.code(), self.to_string(), None)
-//     }
-// }
 
 impl From<EngineApiError> for RpcError {
     fn from(value: EngineApiError) -> Self {

--- a/crates/net/rpc/src/engine/error.rs
+++ b/crates/net/rpc/src/engine/error.rs
@@ -1,5 +1,5 @@
 use jsonrpsee::core::Error as RpcError;
-use reth_primitives::{BlockNumber, H256, U256};
+use reth_primitives::{H256, U256};
 use thiserror::Error;
 
 use crate::result::rpc_err;
@@ -8,15 +8,13 @@ use crate::result::rpc_err;
 #[derive(Error, Debug)]
 pub enum EngineApiError {
     #[error(
-        "Invalid transition terminal total difficulty. Expected: {expected}. Received: {received}"
+        "Invalid transition terminal total difficulty. Execution: {execution}. Consensus: {consensus}"
     )]
-    TerminalTD { expected: U256, received: U256 },
-    #[error("Invalid transition terminal block hash. Expected: {expected}. Received: {received}")]
-    TerminalBlockHash { expected: H256, received: H256 },
+    TerminalTD { execution: U256, consensus: U256 },
     #[error(
-        "Invalid transition terminal block number. Expected: {expected}. Received: {received}"
+        "Invalid transition terminal block hash. Execution: {execution:?}. Consensus: {consensus}"
     )]
-    TerminalBlockNumber { expected: BlockNumber, received: BlockNumber },
+    TerminalBlockHash { execution: Option<H256>, consensus: H256 },
     #[error("Unknown payload")]
     UnknownPayload,
     /// API encountered an internal error.

--- a/crates/net/rpc/src/engine/mod.rs
+++ b/crates/net/rpc/src/engine/mod.rs
@@ -1,138 +1,55 @@
-use crate::{result::ToRpcResult, EthApiSpec};
+use crate::result::rpc_err;
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult as Result;
-use reth_consensus::Config;
+use reth_consensus::engine::{EngineApiError, EngineApiResult, EngineMessage};
 use reth_interfaces::consensus::ForkchoiceState;
-use reth_primitives::{
-    proofs::{self, EMPTY_LIST_HASH},
-    Block, BlockLocked, Header, TransactionSigned, H256, H64,
-};
-use reth_rlp::Decodable;
+use reth_primitives::H64;
 use reth_rpc_api::EngineApiServer;
 use reth_rpc_types::engine::{
-    ExecutionPayload, ForkchoiceUpdated, PayloadAttributes, PayloadStatus, PayloadStatusEnum,
-    TransitionConfiguration,
+    ExecutionPayload, ForkchoiceUpdated, PayloadAttributes, PayloadStatus, TransitionConfiguration,
+};
+use tokio::sync::{
+    mpsc::UnboundedSender,
+    oneshot::{self, Receiver},
 };
 
-mod error;
-pub use error::EngineApiError;
-
-/// The Engine API result type
-pub type EngineApiResult<Ok> = std::result::Result<Ok, EngineApiError>;
-
 /// The server implementation of Engine API
-pub struct EngineApi<Eth> {
-    /// The implementation of `eth` API
-    eth: Eth,
-    /// Consensus configuration
-    config: Config,
+pub struct EngineApi {
+    /// Handle to the consensus engine
+    engine_tx: UnboundedSender<EngineMessage>,
 }
 
-impl<Eth> std::fmt::Debug for EngineApi<Eth> {
+impl std::fmt::Debug for EngineApi {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("EngineApi").field("config", &self.config).finish_non_exhaustive()
+        f.debug_struct("EngineApi").finish_non_exhaustive()
     }
 }
 
-impl<Eth> EngineApi<Eth>
-where
-    Eth: EthApiSpec + 'static,
-{
-    fn block_by_hash(&self, hash: H256) -> EngineApiResult<Option<Block>> {
-        Ok(self.eth.block_by_hash(hash)?)
-    }
-
-    /// Try to construct a block from given payload. Perform addition validation of `extra_data` and
-    /// `base_fee_per_gas` fields.
-    ///
-    /// NOTE: The log bloom is assumed to be validated during serialization.
-    /// NOTE: Ommers hash is validated upon computing block hash and comparing the value with
-    /// `payload.block_hash`.
-    /// Ref: https://github.com/ethereum/go-ethereum/blob/79a478bb6176425c2400e949890e668a3d9a3d05/core/beacon/types.go#L145
-    fn try_construct_block(&self, payload: ExecutionPayload) -> EngineApiResult<BlockLocked> {
-        if payload.extra_data.len() > 32 {
-            return Err(EngineApiError::PayloadExtraData(payload.extra_data))
-        }
-
-        if payload.base_fee_per_gas.is_zero() {
-            return Err(EngineApiError::PayloadBaseFee(payload.base_fee_per_gas))
-        }
-
-        let transactions = payload
-            .transactions
-            .iter()
-            .map(|tx| TransactionSigned::decode(&mut tx.as_ref()))
-            .collect::<std::result::Result<Vec<_>, _>>()?;
-        let transactions_root = proofs::calculate_transaction_root(transactions.iter());
-        let header = Header {
-            parent_hash: payload.parent_hash,
-            beneficiary: payload.fee_recipient,
-            state_root: payload.state_root,
-            transactions_root,
-            receipts_root: payload.receipts_root,
-            logs_bloom: payload.logs_bloom,
-            number: payload.block_number.as_u64(),
-            gas_limit: payload.gas_limit.as_u64(),
-            gas_used: payload.gas_used.as_u64(),
-            timestamp: payload.timestamp.as_u64(),
-            mix_hash: payload.prev_randao,
-            base_fee_per_gas: Some(payload.base_fee_per_gas.as_u64()),
-            extra_data: payload.extra_data.0,
-            // Defaults
-            ommers_hash: EMPTY_LIST_HASH,
-            difficulty: Default::default(),
-            nonce: Default::default(),
-        };
-        let header = header.seal();
-
-        if payload.block_hash != header.hash() {
-            return Err(EngineApiError::PayloadBlockHash {
-                execution: header.hash(),
-                consensus: payload.block_hash,
-            })
-        }
-
-        Ok(BlockLocked { header, body: transactions, ommers: Default::default() })
+impl EngineApi {
+    async fn delegate_request<T>(
+        &self,
+        msg: EngineMessage,
+        rx: Receiver<EngineApiResult<T>>,
+    ) -> Result<T> {
+        let _ = self.engine_tx.send(msg);
+        rx.await.expect("channel is open").map_err(|err| {
+            let code = match err {
+                EngineApiError::PayloadUnknown => -38001,
+                // Any other server error
+                _ => jsonrpsee::types::error::INTERNAL_ERROR_CODE,
+            };
+            rpc_err(code, err.to_string(), None)
+        })
     }
 }
 
 #[async_trait]
-impl<Eth> EngineApiServer for EngineApi<Eth>
-where
-    Eth: EthApiSpec + 'static,
-{
+impl EngineApiServer for EngineApi {
     /// See also <https://github.com/ethereum/execution-apis/blob/8db51dcd2f4bdfbd9ad6e4a7560aac97010ad063/src/engine/specification.md#engine_newpayloadv1>
     /// Caution: This should not accept the `withdrawals` field
     async fn new_payload_v1(&self, payload: ExecutionPayload) -> Result<PayloadStatus> {
-        let block: BlockLocked = match self.try_construct_block(payload) {
-            Ok(b) => b,
-            Err(err) => {
-                return Ok(PayloadStatus::from_status(PayloadStatusEnum::InvalidBlockHash {
-                    validation_error: err.to_string(),
-                }))
-            }
-        };
-
-        // The block already exists in our database
-        if let Some(existing) = self.block_by_hash(block.hash())? {
-            return Ok(PayloadStatus::new(PayloadStatusEnum::Valid, block.hash()))
-        }
-
-        let Some(parent) = self.block_by_hash(block.parent_hash)? else {
-             // TODO: cache block for storing later
-             return Ok(PayloadStatus::from_status(PayloadStatusEnum::Syncing))
-        };
-
-        if parent.number + 1 != block.number {
-            // Our database is incongruent, potential reorg
-            // TODO: handle
-            todo!()
-        }
-
-        // TODO: sanity checks on td & timestamp
-        // https://github.com/ethereum/go-ethereum/blob/79a478bb6176425c2400e949890e668a3d9a3d05/eth/catalyst/api.go#L403-L414
-
-        return Ok(PayloadStatus::new(PayloadStatusEnum::Valid, block.hash()))
+        let (tx, rx) = oneshot::channel();
+        self.delegate_request(EngineMessage::NewPayload(payload, tx), rx).await
     }
 
     /// See also <https://github.com/ethereum/execution-apis/blob/8db51dcd2f4bdfbd9ad6e4a7560aac97010ad063/src/engine/specification.md#engine_newpayloadv1>
@@ -148,24 +65,12 @@ where
         fork_choice_state: ForkchoiceState,
         payload_attributes: Option<PayloadAttributes>,
     ) -> Result<ForkchoiceUpdated> {
-        let ForkchoiceState { head_block_hash, finalized_block_hash, .. } = fork_choice_state;
-
-        if head_block_hash.is_zero() {
-            return Ok(ForkchoiceUpdated::from_status(PayloadStatusEnum::Invalid {
-                validation_error: "Empty head".to_owned(),
-            }))
-        }
-
-        // The finalized block hash is not known, we are still syncing
-        if !finalized_block_hash.is_zero() && self.block_by_hash(finalized_block_hash)?.is_none() {
-            return Ok(ForkchoiceUpdated::from_status(PayloadStatusEnum::Syncing))
-        }
-
-        // TODO: record head
-
-        let chain_info = self.eth.chain_info().with_message("Failed to read chain info")?;
-        Ok(ForkchoiceUpdated::from_status(PayloadStatusEnum::Valid)
-            .with_latest_valid_hash(chain_info.best_hash))
+        let (tx, rx) = oneshot::channel();
+        self.delegate_request(
+            EngineMessage::ForkchoiceUpdated(fork_choice_state, payload_attributes, tx),
+            rx,
+        )
+        .await
     }
 
     /// See also <https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#engine_forkchoiceupdatedv2>
@@ -180,64 +85,22 @@ where
     /// See also <https://github.com/ethereum/execution-apis/blob/8db51dcd2f4bdfbd9ad6e4a7560aac97010ad063/src/engine/specification.md#engine_getPayloadV1>
     ///
     /// Caution: This should not return the `withdrawals` field
-    async fn get_payload_v1(&self, _payload_id: H64) -> Result<ExecutionPayload> {
-        // NOTE: Currently, we are not a builder
-        Err(EngineApiError::PayloadUnknown.into())
+    async fn get_payload_v1(&self, payload_id: H64) -> Result<ExecutionPayload> {
+        let (tx, rx) = oneshot::channel();
+        self.delegate_request(EngineMessage::GetPayload(payload_id, tx), rx).await
     }
 
     /// See also <https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#engine_getpayloadv2>
     async fn get_payload_v2(&self, _payload_id: H64) -> Result<ExecutionPayload> {
-        // NOTE: Currently, we are not a builder
-        Err(EngineApiError::PayloadUnknown.into())
+        todo!()
     }
 
     /// See also <https://github.com/ethereum/execution-apis/blob/8db51dcd2f4bdfbd9ad6e4a7560aac97010ad063/src/engine/specification.md#engine_exchangeTransitionConfigurationV1>
     async fn exchange_transition_configuration(
         &self,
-        transition_configuration: TransitionConfiguration,
+        config: TransitionConfiguration,
     ) -> Result<TransitionConfiguration> {
-        let TransitionConfiguration {
-            terminal_total_difficulty,
-            terminal_block_hash,
-            terminal_block_number,
-        } = transition_configuration;
-
-        // Compare total difficulty values
-        let merge_terminal_td = self.config.merge_terminal_total_difficulty.into();
-        if merge_terminal_td != terminal_total_difficulty {
-            return Err(EngineApiError::TerminalTD {
-                execution: merge_terminal_td,
-                consensus: terminal_total_difficulty,
-            }
-            .into())
-        }
-
-        // Short circuit if communicated block hash is zero
-        if terminal_block_hash.is_zero() {
-            return Ok(TransitionConfiguration {
-                terminal_total_difficulty: merge_terminal_td,
-                ..Default::default()
-            })
-        }
-
-        // Attempt to look up terminal block hash
-        let local_hash = self
-            .eth
-            .block_hash(terminal_block_number)
-            .with_message("Failed to get block by hash")?;
-
-        // Transition configuration exchange is successful if block hashes match
-        match local_hash {
-            Some(hash) if hash == terminal_block_hash => Ok(TransitionConfiguration {
-                terminal_total_difficulty: merge_terminal_td,
-                terminal_block_hash,
-                terminal_block_number,
-            }),
-            _ => Err(EngineApiError::TerminalBlockHash {
-                execution: local_hash,
-                consensus: terminal_block_hash,
-            }
-            .into()),
-        }
+        let (tx, rx) = oneshot::channel();
+        self.delegate_request(EngineMessage::ExchangeTransitionConfiguration(config, tx), rx).await
     }
 }

--- a/crates/net/rpc/src/engine/mod.rs
+++ b/crates/net/rpc/src/engine/mod.rs
@@ -1,0 +1,143 @@
+use crate::{
+    result::{rpc_err, ToRpcResult},
+    EthApiSpec,
+};
+use async_trait::async_trait;
+use jsonrpsee::core::RpcResult as Result;
+use reth_consensus::Config;
+use reth_interfaces::consensus::ForkchoiceState;
+use reth_primitives::{H256, H64};
+use reth_rpc_api::EngineApiServer;
+use reth_rpc_types::engine::{
+    ExecutionPayload, ForkchoiceUpdated, PayloadAttributes, PayloadStatus, PayloadStatusEnum,
+    TransitionConfiguration,
+};
+
+mod error;
+pub use error::EngineApiError;
+
+/// TODO:
+pub struct EngineApi {
+    /// The implementation of `eth` API
+    eth: Box<dyn EthApiSpec>,
+    /// Consensus configuration
+    config: Config,
+}
+
+impl std::fmt::Debug for EngineApi {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EngineApi").finish_non_exhaustive()
+    }
+}
+
+impl EngineApi {
+    fn get_local_transition_configuration(&self) -> TransitionConfiguration {
+        return TransitionConfiguration {
+            terminal_total_difficulty: self.config.merge_terminal_total_difficulty.into(),
+            terminal_block_hash: H256::zero(),
+            terminal_block_number: 0,
+        }
+    }
+}
+
+#[async_trait]
+impl EngineApiServer for EngineApi {
+    /// See also <https://github.com/ethereum/execution-apis/blob/8db51dcd2f4bdfbd9ad6e4a7560aac97010ad063/src/engine/specification.md#engine_newpayloadv1>
+    /// Caution: This should not accept the `withdrawals` field
+    async fn new_payload_v1(&self, _payload: ExecutionPayload) -> Result<PayloadStatus> {
+        todo!()
+    }
+
+    /// See also <https://github.com/ethereum/execution-apis/blob/8db51dcd2f4bdfbd9ad6e4a7560aac97010ad063/src/engine/specification.md#engine_newpayloadv1>
+    async fn new_payload_v2(&self, _payload: ExecutionPayload) -> Result<PayloadStatus> {
+        todo!()
+    }
+
+    /// See also <https://github.com/ethereum/execution-apis/blob/8db51dcd2f4bdfbd9ad6e4a7560aac97010ad063/src/engine/specification.md#engine_forkchoiceUpdatedV1>
+    ///
+    /// Caution: This should not accept the `withdrawals` field
+    async fn fork_choice_updated_v1(
+        &self,
+        fork_choice_state: ForkchoiceState,
+        payload_attributes: Option<PayloadAttributes>,
+    ) -> Result<ForkchoiceUpdated> {
+        let ForkchoiceState { head_block_hash, finalized_block_hash, .. } = fork_choice_state;
+
+        if head_block_hash.is_zero() {
+            return Ok(ForkchoiceUpdated::new(PayloadStatusEnum::InvalidBlockHash {
+                validation_error: "Empty head".to_owned(),
+            }))
+        }
+
+        if !finalized_block_hash.is_zero() &&
+            self.eth
+                .block_by_hash(finalized_block_hash)
+                .with_message("failed to get block by hash")? // TODO: extract
+                .is_none()
+        {
+            return Ok(ForkchoiceUpdated::new(PayloadStatusEnum::Syncing))
+        }
+
+        // TODO: record head
+
+        let chain_info = self.eth.chain_info().with_message("failed to read chain info")?;
+        Ok(ForkchoiceUpdated::new(PayloadStatusEnum::Valid)
+            .with_latest_valid_hash(chain_info.best_hash))
+    }
+
+    /// See also <https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#engine_forkchoiceupdatedv2>
+    async fn fork_choice_updated_v2(
+        &self,
+        _fork_choice_state: ForkchoiceState,
+        _payload_attributes: Option<PayloadAttributes>,
+    ) -> Result<ForkchoiceUpdated> {
+        todo!()
+    }
+
+    /// See also <https://github.com/ethereum/execution-apis/blob/8db51dcd2f4bdfbd9ad6e4a7560aac97010ad063/src/engine/specification.md#engine_getPayloadV1>
+    ///
+    /// Caution: This should not return the `withdrawals` field
+    async fn get_payload_v1(&self, _payload_id: H64) -> Result<ExecutionPayload> {
+        // NOTE: Currently we are not a builder
+        Err(EngineApiError::UnknownPayload.into())
+    }
+
+    /// See also <https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#engine_getpayloadv2>
+    async fn get_payload_v2(&self, _payload_id: H64) -> Result<ExecutionPayload> {
+        // NOTE: Currently we are not a builder
+        Err(EngineApiError::UnknownPayload.into())
+    }
+
+    /// See also <https://github.com/ethereum/execution-apis/blob/8db51dcd2f4bdfbd9ad6e4a7560aac97010ad063/src/engine/specification.md#engine_exchangeTransitionConfigurationV1>
+    async fn exchange_transition_configuration(
+        &self,
+        transition_configuration: TransitionConfiguration,
+    ) -> Result<TransitionConfiguration> {
+        let local = self.get_local_transition_configuration();
+        if local.terminal_total_difficulty != transition_configuration.terminal_total_difficulty {
+            return Err(EngineApiError::TerminalTD {
+                expected: local.terminal_total_difficulty,
+                received: transition_configuration.terminal_total_difficulty,
+            }
+            .into())
+        }
+
+        if local.terminal_block_hash != transition_configuration.terminal_block_hash {
+            return Err(EngineApiError::TerminalBlockHash {
+                expected: local.terminal_block_hash,
+                received: transition_configuration.terminal_block_hash,
+            }
+            .into())
+        }
+
+        if local.terminal_block_number != transition_configuration.terminal_block_number {
+            return Err(EngineApiError::TerminalBlockNumber {
+                expected: local.terminal_block_number,
+                received: transition_configuration.terminal_block_number,
+            }
+            .into())
+        }
+
+        Ok(local)
+    }
+}

--- a/crates/net/rpc/src/engine/mod.rs
+++ b/crates/net/rpc/src/engine/mod.rs
@@ -1,6 +1,6 @@
 use crate::result::rpc_err;
 use async_trait::async_trait;
-use jsonrpsee::core::RpcResult as Result;
+use jsonrpsee::core::{Error, RpcResult as Result};
 use reth_consensus::engine::{EngineApiError, EngineApiResult, EngineMessage};
 use reth_interfaces::consensus::ForkchoiceState;
 use reth_primitives::H64;
@@ -32,7 +32,7 @@ impl EngineApi {
         rx: Receiver<EngineApiResult<T>>,
     ) -> Result<T> {
         let _ = self.engine_tx.send(msg);
-        rx.await.expect("channel is open").map_err(|err| {
+        rx.await.map_err(|err| Error::Custom(err.to_string()))?.map_err(|err| {
             let code = match err {
                 EngineApiError::PayloadUnknown => -38001,
                 // Any other server error

--- a/crates/net/rpc/src/engine/mod.rs
+++ b/crates/net/rpc/src/engine/mod.rs
@@ -1,12 +1,13 @@
-use crate::{
-    result::{rpc_err, ToRpcResult},
-    EthApiSpec,
-};
+use crate::{result::ToRpcResult, EthApiSpec};
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult as Result;
 use reth_consensus::Config;
 use reth_interfaces::consensus::ForkchoiceState;
-use reth_primitives::{H256, H64};
+use reth_primitives::{
+    proofs::{self, EMPTY_LIST_HASH},
+    Block, BlockLocked, Header, TransactionSigned, H256, H64,
+};
+use reth_rlp::Decodable;
 use reth_rpc_api::EngineApiServer;
 use reth_rpc_types::engine::{
     ExecutionPayload, ForkchoiceUpdated, PayloadAttributes, PayloadStatus, PayloadStatusEnum,
@@ -16,28 +17,122 @@ use reth_rpc_types::engine::{
 mod error;
 pub use error::EngineApiError;
 
-/// TODO:
-pub struct EngineApi {
+/// The Engine API result type
+pub type EngineApiResult<Ok> = std::result::Result<Ok, EngineApiError>;
+
+/// The server implementation of Engine API
+pub struct EngineApi<Eth> {
     /// The implementation of `eth` API
-    eth: Box<dyn EthApiSpec>,
+    eth: Eth,
     /// Consensus configuration
     config: Config,
 }
 
-impl std::fmt::Debug for EngineApi {
+impl<Eth> std::fmt::Debug for EngineApi<Eth> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("EngineApi").finish_non_exhaustive()
+        f.debug_struct("EngineApi").field("config", &self.config).finish_non_exhaustive()
+    }
+}
+
+impl<Eth> EngineApi<Eth>
+where
+    Eth: EthApiSpec + 'static,
+{
+    fn block_by_hash(&self, hash: H256) -> EngineApiResult<Option<Block>> {
+        Ok(self.eth.block_by_hash(hash)?)
+    }
+
+    /// Try to construct a block from given payload. Perform addition validation of `extra_data` and
+    /// `base_fee_per_gas` fields.
+    ///
+    /// NOTE: The log bloom is assumed to be validated during serialization.
+    /// NOTE: Ommers hash is validated upon computing block hash and comparing the value with
+    /// `payload.block_hash`.
+    /// Ref: https://github.com/ethereum/go-ethereum/blob/79a478bb6176425c2400e949890e668a3d9a3d05/core/beacon/types.go#L145
+    fn try_construct_block(&self, payload: ExecutionPayload) -> EngineApiResult<BlockLocked> {
+        if payload.extra_data.len() > 32 {
+            return Err(EngineApiError::PayloadExtraData(payload.extra_data))
+        }
+
+        if payload.base_fee_per_gas.is_zero() {
+            return Err(EngineApiError::PayloadBaseFee(payload.base_fee_per_gas))
+        }
+
+        let transactions = payload
+            .transactions
+            .iter()
+            .map(|tx| TransactionSigned::decode(&mut tx.as_ref()))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        let transactions_root = proofs::calculate_transaction_root(transactions.iter());
+        let header = Header {
+            parent_hash: payload.parent_hash,
+            beneficiary: payload.fee_recipient,
+            state_root: payload.state_root,
+            transactions_root,
+            receipts_root: payload.receipts_root,
+            logs_bloom: payload.logs_bloom,
+            number: payload.block_number.as_u64(),
+            gas_limit: payload.gas_limit.as_u64(),
+            gas_used: payload.gas_used.as_u64(),
+            timestamp: payload.timestamp.as_u64(),
+            mix_hash: payload.prev_randao,
+            base_fee_per_gas: Some(payload.base_fee_per_gas.as_u64()),
+            extra_data: payload.extra_data.0,
+            // Defaults
+            ommers_hash: EMPTY_LIST_HASH,
+            difficulty: Default::default(),
+            nonce: Default::default(),
+        };
+        let header = header.seal();
+
+        if payload.block_hash != header.hash() {
+            return Err(EngineApiError::PayloadBlockHash {
+                execution: header.hash(),
+                consensus: payload.block_hash,
+            })
+        }
+
+        Ok(BlockLocked { header, body: transactions, ommers: Default::default() })
     }
 }
 
 #[async_trait]
-impl EngineApiServer for EngineApi {
+impl<Eth> EngineApiServer for EngineApi<Eth>
+where
+    Eth: EthApiSpec + 'static,
+{
     /// See also <https://github.com/ethereum/execution-apis/blob/8db51dcd2f4bdfbd9ad6e4a7560aac97010ad063/src/engine/specification.md#engine_newpayloadv1>
     /// Caution: This should not accept the `withdrawals` field
-    async fn new_payload_v1(&self, _payload: ExecutionPayload) -> Result<PayloadStatus> {
-        // TODO: execute payload first
+    async fn new_payload_v1(&self, payload: ExecutionPayload) -> Result<PayloadStatus> {
+        let block: BlockLocked = match self.try_construct_block(payload) {
+            Ok(b) => b,
+            Err(err) => {
+                return Ok(PayloadStatus::from_status(PayloadStatusEnum::InvalidBlockHash {
+                    validation_error: err.to_string(),
+                }))
+            }
+        };
 
-        todo!()
+        // The block already exists in our database
+        if let Some(existing) = self.block_by_hash(block.hash())? {
+            return Ok(PayloadStatus::new(PayloadStatusEnum::Valid, block.hash()))
+        }
+
+        let Some(parent) = self.block_by_hash(block.parent_hash)? else {
+             // TODO: cache block for storing later
+             return Ok(PayloadStatus::from_status(PayloadStatusEnum::Syncing))
+        };
+
+        if parent.number + 1 != block.number {
+            // Our database is incongruent, potential reorg
+            // TODO: handle
+            todo!()
+        }
+
+        // TODO: sanity checks on td & timestamp
+        // https://github.com/ethereum/go-ethereum/blob/79a478bb6176425c2400e949890e668a3d9a3d05/eth/catalyst/api.go#L403-L414
+
+        return Ok(PayloadStatus::new(PayloadStatusEnum::Valid, block.hash()))
     }
 
     /// See also <https://github.com/ethereum/execution-apis/blob/8db51dcd2f4bdfbd9ad6e4a7560aac97010ad063/src/engine/specification.md#engine_newpayloadv1>
@@ -56,24 +151,20 @@ impl EngineApiServer for EngineApi {
         let ForkchoiceState { head_block_hash, finalized_block_hash, .. } = fork_choice_state;
 
         if head_block_hash.is_zero() {
-            return Ok(ForkchoiceUpdated::new(PayloadStatusEnum::Invalid {
+            return Ok(ForkchoiceUpdated::from_status(PayloadStatusEnum::Invalid {
                 validation_error: "Empty head".to_owned(),
             }))
         }
 
-        if !finalized_block_hash.is_zero() &&
-            self.eth
-                .block_by_hash(finalized_block_hash)
-                .with_message("Failed to get block by hash")? // TODO: extract
-                .is_none()
-        {
-            return Ok(ForkchoiceUpdated::new(PayloadStatusEnum::Syncing))
+        // The finalized block hash is not known, we are still syncing
+        if !finalized_block_hash.is_zero() && self.block_by_hash(finalized_block_hash)?.is_none() {
+            return Ok(ForkchoiceUpdated::from_status(PayloadStatusEnum::Syncing))
         }
 
         // TODO: record head
 
         let chain_info = self.eth.chain_info().with_message("Failed to read chain info")?;
-        Ok(ForkchoiceUpdated::new(PayloadStatusEnum::Valid)
+        Ok(ForkchoiceUpdated::from_status(PayloadStatusEnum::Valid)
             .with_latest_valid_hash(chain_info.best_hash))
     }
 
@@ -91,13 +182,13 @@ impl EngineApiServer for EngineApi {
     /// Caution: This should not return the `withdrawals` field
     async fn get_payload_v1(&self, _payload_id: H64) -> Result<ExecutionPayload> {
         // NOTE: Currently, we are not a builder
-        Err(EngineApiError::UnknownPayload.into())
+        Err(EngineApiError::PayloadUnknown.into())
     }
 
     /// See also <https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#engine_getpayloadv2>
     async fn get_payload_v2(&self, _payload_id: H64) -> Result<ExecutionPayload> {
         // NOTE: Currently, we are not a builder
-        Err(EngineApiError::UnknownPayload.into())
+        Err(EngineApiError::PayloadUnknown.into())
     }
 
     /// See also <https://github.com/ethereum/execution-apis/blob/8db51dcd2f4bdfbd9ad6e4a7560aac97010ad063/src/engine/specification.md#engine_exchangeTransitionConfigurationV1>

--- a/crates/net/rpc/src/eth/api/mod.rs
+++ b/crates/net/rpc/src/eth/api/mod.rs
@@ -1,8 +1,8 @@
 //! Provides everything related to `eth_` namespace
 
 use reth_interfaces::Result;
-use reth_primitives::{U256, U64};
-use reth_provider::{BlockProvider, StateProviderFactory};
+use reth_primitives::{rpc::BlockId, Block, BlockHash, U64};
+use reth_provider::{BlockProvider, ChainInfo, StateProviderFactory};
 use reth_rpc_types::Transaction;
 use reth_transaction_pool::TransactionPool;
 use std::sync::Arc;
@@ -16,11 +16,14 @@ pub trait EthApiSpec: Send + Sync {
     /// Returns the current ethereum protocol version.
     fn protocol_version(&self) -> U64;
 
-    /// Returns the best block number
-    fn block_number(&self) -> Result<U256>;
-
     /// Returns the chain id
     fn chain_id(&self) -> U64;
+
+    /// Returns client chain info
+    fn chain_info(&self) -> Result<ChainInfo>;
+
+    /// Get block by hash
+    fn block_by_hash(&self, hash: BlockHash) -> Result<Option<Block>>;
 }
 
 /// `Eth` API implementation.
@@ -66,14 +69,19 @@ where
         1u64.into()
     }
 
-    /// Returns the best block number
-    fn block_number(&self) -> Result<U256> {
-        Ok(self.client().chain_info()?.best_number.into())
-    }
-
     /// Returns the chain id
     fn chain_id(&self) -> U64 {
         todo!()
+    }
+
+    /// Returns the current info for the chain
+    fn chain_info(&self) -> Result<ChainInfo> {
+        self.client().chain_info()
+    }
+
+    /// Get block by hash
+    fn block_by_hash(&self, hash: BlockHash) -> Result<Option<Block>> {
+        self.client().block(BlockId::Hash(hash))
     }
 }
 

--- a/crates/net/rpc/src/eth/api/mod.rs
+++ b/crates/net/rpc/src/eth/api/mod.rs
@@ -1,7 +1,7 @@
 //! Provides everything related to `eth_` namespace
 
 use reth_interfaces::Result;
-use reth_primitives::{rpc::BlockId, Block, BlockHash, BlockNumber, U64};
+use reth_primitives::U64;
 use reth_provider::{BlockProvider, ChainInfo, StateProviderFactory};
 use reth_rpc_types::Transaction;
 use reth_transaction_pool::TransactionPool;
@@ -21,12 +21,6 @@ pub trait EthApiSpec: Send + Sync {
 
     /// Returns client chain info
     fn chain_info(&self) -> Result<ChainInfo>;
-
-    /// Get block by hash
-    fn block_by_hash(&self, hash: BlockHash) -> Result<Option<Block>>;
-
-    /// Get block hash by number
-    fn block_hash(&self, number: BlockNumber) -> Result<Option<BlockHash>>;
 }
 
 /// `Eth` API implementation.
@@ -80,16 +74,6 @@ where
     /// Returns the current info for the chain
     fn chain_info(&self) -> Result<ChainInfo> {
         self.client().chain_info()
-    }
-
-    /// Get block by hash
-    fn block_by_hash(&self, hash: BlockHash) -> Result<Option<Block>> {
-        self.client().block(BlockId::Hash(hash))
-    }
-
-    /// Get block hash by number
-    fn block_hash(&self, number: BlockNumber) -> Result<Option<BlockHash>> {
-        self.client().block_hash(number.into())
     }
 }
 

--- a/crates/net/rpc/src/eth/api/mod.rs
+++ b/crates/net/rpc/src/eth/api/mod.rs
@@ -1,7 +1,7 @@
 //! Provides everything related to `eth_` namespace
 
 use reth_interfaces::Result;
-use reth_primitives::{rpc::BlockId, Block, BlockHash, U64};
+use reth_primitives::{rpc::BlockId, Block, BlockHash, BlockNumber, U256, U64};
 use reth_provider::{BlockProvider, ChainInfo, StateProviderFactory};
 use reth_rpc_types::Transaction;
 use reth_transaction_pool::TransactionPool;
@@ -24,6 +24,9 @@ pub trait EthApiSpec: Send + Sync {
 
     /// Get block by hash
     fn block_by_hash(&self, hash: BlockHash) -> Result<Option<Block>>;
+
+    /// Get block hash by number
+    fn block_hash(&self, number: BlockNumber) -> Result<Option<BlockHash>>;
 }
 
 /// `Eth` API implementation.
@@ -82,6 +85,11 @@ where
     /// Get block by hash
     fn block_by_hash(&self, hash: BlockHash) -> Result<Option<Block>> {
         self.client().block(BlockId::Hash(hash))
+    }
+
+    /// Get block hash by number
+    fn block_hash(&self, number: BlockNumber) -> Result<Option<BlockHash>> {
+        self.client().block_hash(number.into())
     }
 }
 

--- a/crates/net/rpc/src/eth/api/mod.rs
+++ b/crates/net/rpc/src/eth/api/mod.rs
@@ -1,7 +1,7 @@
 //! Provides everything related to `eth_` namespace
 
 use reth_interfaces::Result;
-use reth_primitives::{rpc::BlockId, Block, BlockHash, BlockNumber, U256, U64};
+use reth_primitives::{rpc::BlockId, Block, BlockHash, BlockNumber, U64};
 use reth_provider::{BlockProvider, ChainInfo, StateProviderFactory};
 use reth_rpc_types::Transaction;
 use reth_transaction_pool::TransactionPool;

--- a/crates/net/rpc/src/eth/api/server.rs
+++ b/crates/net/rpc/src/eth/api/server.rs
@@ -42,11 +42,14 @@ where
     }
 
     fn block_number(&self) -> Result<U256> {
-        EthApiSpec::block_number(self).with_message("Failed to read block number")
+        Ok(EthApiSpec::chain_info(self)
+            .with_message("failed to read chain info")?
+            .best_number
+            .into())
     }
 
     async fn chain_id(&self) -> Result<Option<U64>> {
-        todo!()
+        Ok(Some(EthApiSpec::chain_id(self)))
     }
 
     async fn block_by_hash(&self, _hash: H256, _full: bool) -> Result<Option<RichBlock>> {

--- a/crates/net/rpc/src/lib.rs
+++ b/crates/net/rpc/src/lib.rs
@@ -15,7 +15,7 @@ mod engine;
 mod eth;
 mod net;
 
-pub use engine::{EngineApi, EngineApiError};
+pub use engine::EngineApi;
 pub use eth::{EthApi, EthApiSpec, EthPubSub};
 pub use net::NetApi;
 

--- a/crates/net/rpc/src/lib.rs
+++ b/crates/net/rpc/src/lib.rs
@@ -11,9 +11,11 @@
 //!
 //! Provides the implementation of all RPC interfaces.
 
+mod engine;
 mod eth;
 mod net;
 
+pub use engine::{EngineApi, EngineApiError};
 pub use eth::{EthApi, EthApiSpec, EthPubSub};
 pub use net::NetApi;
 

--- a/crates/storage/provider/src/block.rs
+++ b/crates/storage/provider/src/block.rs
@@ -31,6 +31,9 @@ pub trait HeaderProvider: Send + Sync {
             BlockHashOrNumber::Number(num) => self.header_by_number(num),
         }
     }
+
+    /// Get total difficulty by block hash.
+    fn header_td(&self, hash: &BlockHash) -> Result<Option<U256>>;
 }
 
 /// Api trait for fetching `Block` related data.

--- a/crates/storage/provider/src/test_utils/api.rs
+++ b/crates/storage/provider/src/test_utils/api.rs
@@ -40,7 +40,7 @@ impl HeaderProvider for TestApi {
         Ok(None)
     }
 
-    fn header_td(&self, hash: &BlockHash) -> Result<Option<U256>> {
+    fn header_td(&self, _hash: &BlockHash) -> Result<Option<U256>> {
         Ok(None)
     }
 }

--- a/crates/storage/provider/src/test_utils/api.rs
+++ b/crates/storage/provider/src/test_utils/api.rs
@@ -39,4 +39,8 @@ impl HeaderProvider for TestApi {
     fn header_by_number(&self, _num: u64) -> Result<Option<Header>> {
         Ok(None)
     }
+
+    fn header_td(&self, hash: &BlockHash) -> Result<Option<U256>> {
+        Ok(None)
+    }
 }


### PR DESCRIPTION
This PR introduces the skeleton for implementation of [Paris specs for engine API](https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md)

This PR does:
- basic validation for new payload received
- basic forkchoice update handling

This PR does not:
- execute new payloads
- cache unknown payloads or delegate them to block builders