### PR TITLE
chore(deps): bump rustversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3981,9 +3981,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4378ea89513870b6e2303ec50618e97da0fa43cdd9ded83ad3b6bad2693c08c6"
+checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "ryu"


### PR DESCRIPTION
This bumps rustversion that includes a fix for recompiles:
https://github.com/dtolnay/rustversion/commit/78d6d4b654a780b8074b0792eb45540044136f1d