### PR TITLE
chore(sync): rename senders stage

### DIFF
--- a/bin/reth/src/config.rs
+++ b/bin/reth/src/config.rs
@@ -17,7 +17,7 @@ pub struct StageConfig {
     /// Body stage configuration.
     pub bodies: BodiesConfig,
     /// Sender recovery stage configuration.
-    pub senders: SendersConfig,
+    pub sender_recovery: SenderRecoveryConfig,
 }
 
 /// Header stage configuration.
@@ -66,14 +66,14 @@ impl Default for BodiesConfig {
 
 /// Sender recovery stage configuration.
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct SendersConfig {
+pub struct SenderRecoveryConfig {
     /// The maximum number of blocks to process before committing progress to the database.
     pub commit_threshold: u64,
     /// The maximum number of transactions to recover senders for concurrently.
     pub batch_size: usize,
 }
 
-impl Default for SendersConfig {
+impl Default for SenderRecoveryConfig {
     fn default() -> Self {
         Self { commit_threshold: 5_000, batch_size: 1000 }
     }

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -27,7 +27,9 @@ use reth_network::{
 };
 use reth_primitives::{Account, Header, H256};
 use reth_provider::{db_provider::ProviderImpl, BlockProvider, HeaderProvider};
-use reth_stages::stages::{bodies::BodyStage, headers::HeaderStage, senders::SendersStage};
+use reth_stages::stages::{
+    bodies::BodyStage, headers::HeaderStage, sender_recovery::SenderRecoveryStage,
+};
 use std::{net::SocketAddr, path::Path, sync::Arc};
 use tracing::{debug, info};
 
@@ -137,9 +139,9 @@ impl Command {
                 consensus: consensus.clone(),
                 commit_threshold: config.stages.bodies.commit_threshold,
             })
-            .push(SendersStage {
-                batch_size: config.stages.senders.batch_size,
-                commit_threshold: config.stages.senders.commit_threshold,
+            .push(SenderRecoveryStage {
+                batch_size: config.stages.sender_recovery.batch_size,
+                commit_threshold: config.stages.sender_recovery.commit_threshold,
             });
 
         if let Some(tip) = self.tip {

--- a/book/stages/README.md
+++ b/book/stages/README.md
@@ -1,6 +1,6 @@
 # Stages
 
-The `stages` lib plays a central role in syncing the node, maintaining state, updating the database and more. The stages involved in the Reth pipeline are the `HeaderStage`, `BodyStage`, `SendersStage`, and `ExecutionStage` (note that this list is non-exhaustive, and more pipeline stages will be added in the near future). Each of these stages are queued up and stored within the Reth pipeline.
+The `stages` lib plays a central role in syncing the node, maintaining state, updating the database and more. The stages involved in the Reth pipeline are the `HeaderStage`, `BodyStage`, `SenderRecoveryStage`, and `ExecutionStage` (note that this list is non-exhaustive, and more pipeline stages will be added in the near future). Each of these stages are queued up and stored within the Reth pipeline.
 
 {{#template ../templates/source_and_github.md path_to_root=../../ path=crates/stages/src/pipeline.rs anchor=struct-Pipeline}}
 
@@ -51,9 +51,9 @@ The new block is then pre-validated, checking that the ommers hash and transacti
 
 <br>
 
-## SendersStage
+## SenderRecoveryStage
 
-Following a successful `BodyStage`, the `SenderStage` starts to execute. The `SenderStage` is responsible for recovering the transaction sender for each of the newly added transactions to the database. At the beginning of the execution function, all of the transactions are first retrieved from the database. Then the `SenderStage` goes through each transaction and recovers the signer from the transaction signature and hash. The transaction hash is derived by taking the Keccak 256-bit hash of the RLP encoded transaction bytes. This hash is then passed into the `recover_signer` function.
+Following a successful `BodyStage`, the `SenderRecoveryStage` starts to execute. The `SenderRecoveryStage` is responsible for recovering the transaction sender for each of the newly added transactions to the database. At the beginning of the execution function, all of the transactions are first retrieved from the database. Then the `SenderRecoveryStage` goes through each transaction and recovers the signer from the transaction signature and hash. The transaction hash is derived by taking the Keccak 256-bit hash of the RLP encoded transaction bytes. This hash is then passed into the `recover_signer` function.
 
 {{#template ../templates/source_and_github.md path_to_root=../../ path=crates/primitives/src/transaction/signature.rs anchor=fn-recover_signer}}
 

--- a/crates/stages/src/stages/mod.rs
+++ b/crates/stages/src/stages/mod.rs
@@ -5,4 +5,4 @@ pub mod execution;
 /// The headers stage.
 pub mod headers;
 /// The sender recovery stage.
-pub mod senders;
+pub mod sender_recovery;


### PR DESCRIPTION
Rename `SendersStage` to `SenderRecoveryStage` to provide more clarity about its scope