### PR TITLE
fix(consensus): block reward check

### DIFF
--- a/crates/consensus/src/consensus.rs
+++ b/crates/consensus/src/consensus.rs
@@ -57,6 +57,6 @@ impl Consensus for EthConsensus {
     }
 
     fn has_block_reward(&self, block_num: BlockNumber) -> bool {
-        block_num <= self.config.paris_block
+        block_num < self.config.paris_block
     }
 }


### PR DESCRIPTION
From [EIP3675 Test Cases](https://eips.ethereum.org/EIPS/eip-3675#test-cases) section:
> Beginning with `TRANSITION_BLOCK`, block rewards aren’t added to beneficiary account