### PR TITLE
ci: disable fuzzing jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,10 @@ jobs:
           flags: unit-tests
 
   fuzz:
+    # Skip the Fuzzing Jobs until we make them run fast and reliably. Currently they will
+    # always recompile the codebase for each test and that takes way too long.
+    if: false
+
     # Pin to `20.04` instead of `ubuntu-latest`, until ubuntu-latest migration is complete
     # See also <https://github.com/foundry-rs/foundry/issues/3827>
     runs-on: ubuntu-20.04


### PR DESCRIPTION
**TEMPORARY**

Fixes 2 problems:
* UX Issues: CI is taking way too long
* False sense of security: Test Fuzz is seemingly not generating as many random cases as we'd like (or at all) and it's giving us a false sense of security that our structs are fuzzed.

The UX issue might be a simple config bug. The security issue I'm less concerned about as all structs are unit tested and integration tested as part of the syncing process. Intend to debug this so that we can have bigger corpuses etc.



