### PR TITLE
feat: Add PeerEvent to NetworkEvent enum

### DIFF
--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -51,7 +51,6 @@ use std::{
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{error, info, trace, warn};
-
 /// Manages the _entire_ state of the network.
 ///
 /// This is an endless [`Future`] that consistently drives the state of the entire network forward.
@@ -667,6 +666,10 @@ pub enum NetworkEvent {
         /// The status of the peer to which a session was established.
         status: Status,
     },
+    /// Event emitted when a new peer is added
+    PeerAdded(PeerId),
+    /// Event emitted when a new peer is removed
+    PeerRemoved(PeerId),
 }
 
 /// Bundles all listeners for [`NetworkEvent`]s.

--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -312,6 +312,12 @@ where
                     msg,
                 })
             }
+            NetworkEvent::PeerAdded(_) => {
+                todo!()
+            }
+            NetworkEvent::PeerRemoved(_) => {
+                todo!()
+            }
         }
     }
 

--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -312,12 +312,8 @@ where
                     msg,
                 })
             }
-            NetworkEvent::PeerAdded(_) => {
-                todo!()
-            }
-            NetworkEvent::PeerRemoved(_) => {
-                todo!()
-            }
+            // TODO Add remaining events
+            _ => {}
         }
     }
 

--- a/crates/net/network/tests/it/connect.rs
+++ b/crates/net/network/tests/it/connect.rs
@@ -65,6 +65,12 @@ async fn test_establish_connections() {
                 NetworkEvent::SessionEstablished { peer_id, .. } => {
                     assert!(expected_connections.remove(&peer_id))
                 }
+                NetworkEvent::PeerAdded(peer_id) => {
+                    assert!(!expected_connections.contains(&peer_id))
+                }
+                NetworkEvent::PeerRemoved(_) => {
+                    panic!("unexpected event")
+                }
             }
         }
         assert!(expected_connections.is_empty());

--- a/crates/net/network/tests/it/testnet.rs
+++ b/crates/net/network/tests/it/testnet.rs
@@ -309,6 +309,7 @@ impl NetworkEventStream {
             match ev {
                 NetworkEvent::SessionClosed { peer_id, reason } => return Some((peer_id, reason)),
                 NetworkEvent::SessionEstablished { .. } => continue,
+                _ => todo!(),
             }
         }
         None
@@ -319,6 +320,7 @@ impl NetworkEventStream {
             match ev {
                 NetworkEvent::SessionClosed { .. } => continue,
                 NetworkEvent::SessionEstablished { peer_id, .. } => return Some(peer_id),
+                _ => todo!(),
             }
         }
         None

--- a/crates/net/network/tests/it/testnet.rs
+++ b/crates/net/network/tests/it/testnet.rs
@@ -308,8 +308,7 @@ impl NetworkEventStream {
         while let Some(ev) = self.inner.next().await {
             match ev {
                 NetworkEvent::SessionClosed { peer_id, reason } => return Some((peer_id, reason)),
-                NetworkEvent::SessionEstablished { .. } => continue,
-                _ => todo!(),
+                _ => continue,
             }
         }
         None
@@ -318,9 +317,8 @@ impl NetworkEventStream {
     pub async fn next_session_established(&mut self) -> Option<PeerId> {
         while let Some(ev) = self.inner.next().await {
             match ev {
-                NetworkEvent::SessionClosed { .. } => continue,
                 NetworkEvent::SessionEstablished { peer_id, .. } => return Some(peer_id),
-                _ => todo!(),
+                _ => continue,
             }
         }
         None


### PR DESCRIPTION
Closes #562

The peerEvent is based on this geth implementation:
https://github.com/ethereum/go-ethereum/blob/53d1ae096ac0515173e17f0f81a553e5f39027f7/p2p/peer.go#L94