### PR TITLE
feat(net): validate discovered enr forkid

### DIFF
--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -19,7 +19,7 @@ use reth_eth_wire::{
     error::EthStreamError,
     DisconnectReason, HelloMessage, Status, UnauthedEthStream, UnauthedP2PStream,
 };
-use reth_primitives::{ForkFilter, ForkTransition, PeerId, H256, U256};
+use reth_primitives::{ForkFilter, ForkId, ForkTransition, PeerId, H256, U256};
 use secp256k1::SecretKey;
 use std::{
     collections::HashMap,
@@ -125,6 +125,12 @@ impl SessionManager {
             active_session_tx,
             active_session_rx: ReceiverStream::new(active_session_rx),
         }
+    }
+
+    /// Check whether the provided [`ForkId`] is compatible based on the validation rules in
+    /// `EIP-2124`.
+    pub(crate) fn is_valid_fork_id(&self, fork_id: ForkId) -> bool {
+        self.fork_filter.validate(fork_id).is_ok()
     }
 
     /// Returns the next unique [`SessionId`].

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -262,8 +262,9 @@ where
             DiscoveryEvent::Discovered(peer, addr) => {
                 self.peers_manager.add_discovered_node(peer, addr);
             }
-            DiscoveryEvent::EnrForkId(peer, fork_id) => {
-                self.peers_manager.set_discovered_fork_id(peer, fork_id);
+            DiscoveryEvent::EnrForkId(peer_id, fork_id) => {
+                self.queued_messages
+                    .push_back(StateAction::DiscoveredEnrForkId { peer_id, fork_id });
             }
         }
     }
@@ -454,5 +455,11 @@ pub(crate) enum StateAction {
         peer_id: PeerId,
         /// Why the disconnect was initiated
         reason: Option<DisconnectReason>,
+    },
+    /// Retrieved a [`ForkId`] from the peer via ENR request, See <https://eips.ethereum.org/EIPS/eip-868>
+    DiscoveredEnrForkId {
+        peer_id: PeerId,
+        /// The reported [`ForkId`] by this peer.
+        fork_id: ForkId,
     },
 }

--- a/crates/net/network/src/swarm.rs
+++ b/crates/net/network/src/swarm.rs
@@ -227,6 +227,13 @@ where
                 let msg = PeerMessage::NewBlockHashes(hashes);
                 self.sessions.send_message(&peer_id, msg);
             }
+            StateAction::DiscoveredEnrForkId { peer_id, fork_id } => {
+                if self.sessions.is_valid_fork_id(fork_id) {
+                    self.state_mut().peers_mut().set_discovered_fork_id(peer_id, fork_id);
+                } else {
+                    self.state_mut().peers_mut().remove_discovered_node(peer_id);
+                }
+            }
         }
         None
     }


### PR DESCRIPTION
Closes #580

when we retrieve the forkid of a peer via discovery we can validate it against the current forkid, if it is invalid, we remove the peer.