### PR TITLE
fix: set stage progress metric to absolute value

### DIFF
--- a/crates/stages/src/id.rs
+++ b/crates/stages/src/id.rs
@@ -1,4 +1,4 @@
-use metrics::counter;
+use metrics::absolute_counter;
 use reth_db::{
     tables::SyncStage,
     transaction::{DbTx, DbTxMut},
@@ -31,7 +31,7 @@ impl StageId {
         tx: &impl DbTxMut<'db>,
         block: BlockNumber,
     ) -> Result<(), DbError> {
-        counter!("stage.progress", block, "stage" => self.0);
+        absolute_counter!("stage.progress", block, "stage" => self.0);
         tx.put::<SyncStage>(self.0.as_bytes().to_vec(), block)
     }
 }


### PR DESCRIPTION
`counter!` increments the counter, so you get weird behavior like this:

![image](https://user-images.githubusercontent.com/8862627/209374641-3403c7c5-7675-4dcc-8018-ac502cb3f82d.png)

(The checkpoint is at 200k)

Instead we should use `absolute_counter!` here