### PR TITLE
fix(db): Dont compress DupSort SubKey

### DIFF
--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -84,7 +84,7 @@ impl Command {
     /// Execute `node` command
     // TODO: RPC
     pub async fn execute(&self) -> eyre::Result<()> {
-        let config: Config = confy::load_path(&self.config)?;
+        let config: Config = confy::load_path(&self.config).unwrap_or_default();
         info!("reth {} starting", crate_version!());
 
         info!("Opening database at {}", &self.db);

--- a/crates/primitives/src/storage.rs
+++ b/crates/primitives/src/storage.rs
@@ -10,6 +10,10 @@ pub struct StorageEntry {
     pub value: U256,
 }
 
+
+// NOTE: Removing main_codec and manually encode subkey
+// and compress second part of the value. If we have compression
+// over whole value (Even SubKey) that would mess up fetching of values with seek_by_key_subkey
 impl Compact for StorageEntry {
     fn to_compact(self, buf: &mut impl bytes::BufMut) -> usize {
         // for now put full bytes and later compress it.

--- a/crates/primitives/src/storage.rs
+++ b/crates/primitives/src/storage.rs
@@ -10,7 +10,6 @@ pub struct StorageEntry {
     pub value: U256,
 }
 
-
 // NOTE: Removing main_codec and manually encode subkey
 // and compress second part of the value. If we have compression
 // over whole value (Even SubKey) that would mess up fetching of values with seek_by_key_subkey

--- a/crates/primitives/src/storage.rs
+++ b/crates/primitives/src/storage.rs
@@ -1,12 +1,28 @@
 use super::{H256, U256};
-use reth_codecs::{main_codec, Compact};
+use reth_codecs::Compact;
 
 /// Account storage entry.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-#[main_codec]
 pub struct StorageEntry {
     /// Storage key.
     pub key: H256,
     /// Value on storage key.
     pub value: U256,
+}
+
+impl Compact for StorageEntry {
+    fn to_compact(self, buf: &mut impl bytes::BufMut) -> usize {
+        // for now put full bytes and later compress it.
+        buf.put_slice(&self.key.to_fixed_bytes()[..]);
+        self.value.to_compact(buf) + 32
+    }
+
+    fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8])
+    where
+        Self: Sized,
+    {
+        let key = H256::from_slice(&buf[..32]);
+        let (value, out) = U256::from_compact(&buf[32..], len - 32);
+        (Self { key, value }, out)
+    }
 }

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -177,6 +177,12 @@ impl<DB: Database> Stage<DB> for ExecutionStage {
             let state_provider = SubState::new(State::new(StateProviderImplRefLatest::new(&**tx)));
 
             trace!(target: "sync::stages::execution", number = header.number, txs = recovered_transactions.len(), "Executing block");
+
+            // For ethereum tests that has MAX gas that calls contract until max depth (1024 calls)
+            // revm can take more then default allocated stack space. For this case we are using
+            // local thread with increased stack size. After this task is done https://github.com/bluealloy/revm/issues/305
+            // we can see to set more accurate stack size or even optimize revm to move more data to
+            // heap.
             let changeset = std::thread::scope(|scope| {
                 let handle = std::thread::Builder::new()
                     .stack_size(50 * 1024 * 1024)

--- a/crates/storage/db/src/tables/models/accounts.rs
+++ b/crates/storage/db/src/tables/models/accounts.rs
@@ -19,7 +19,6 @@ pub struct AccountBeforeTx {
     pub info: Option<Account>,
 }
 
-
 // NOTE: Removing main_codec and manually encode subkey
 // and compress second part of the value. If we have compression
 // over whole value (Even SubKey) that would mess up fetching of values with seek_by_key_subkey

--- a/crates/storage/db/src/tables/models/accounts.rs
+++ b/crates/storage/db/src/tables/models/accounts.rs
@@ -19,6 +19,10 @@ pub struct AccountBeforeTx {
     pub info: Option<Account>,
 }
 
+
+// NOTE: Removing main_codec and manually encode subkey
+// and compress second part of the value. If we have compression
+// over whole value (Even SubKey) that would mess up fetching of values with seek_by_key_subkey
 impl Compact for AccountBeforeTx {
     fn to_compact(self, buf: &mut impl bytes::BufMut) -> usize {
         // for now put full bytes and later compress it.

--- a/crates/storage/db/src/tables/models/accounts.rs
+++ b/crates/storage/db/src/tables/models/accounts.rs
@@ -6,20 +6,34 @@ use crate::{
     Error,
 };
 use bytes::Bytes;
-use reth_codecs::{main_codec, Compact};
+use reth_codecs::Compact;
 use reth_primitives::{Account, Address, TransitionId};
 use serde::{Deserialize, Serialize};
 
 /// Account as it is saved inside [`AccountChangeSet`]. [`Address`] is the subkey.
-/// TODO there should be `not_existing` boolean or Account be made as `Option` to
-/// handle scenario where account was not present before transaction.
-#[main_codec]
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct AccountBeforeTx {
     /// Address for the account. Acts as `DupSort::SubKey`.
     pub address: Address,
     /// Account state before the transaction.
     pub info: Option<Account>,
+}
+
+impl Compact for AccountBeforeTx {
+    fn to_compact(self, buf: &mut impl bytes::BufMut) -> usize {
+        // for now put full bytes and later compress it.
+        buf.put_slice(&self.address.to_fixed_bytes()[..]);
+        self.info.to_compact(buf) + 32
+    }
+
+    fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8])
+    where
+        Self: Sized,
+    {
+        let address = Address::from_slice(&buf[..20]);
+        let (info, out) = <Option<Account>>::from_compact(&buf[20..], len - 20);
+        (Self { address, info }, out)
+    }
 }
 
 /// [`TxNumber`] concatenated with [`Address`]. Used as a key for [`StorageChangeSet`]


### PR DESCRIPTION
Removing `main_codec` and manually encode subkey and compress second part of the value.

If we have compression over whole `value` (Even `SubKey`) that would mess up fetching of values with `seek_by_key_subkey` 
