### PR TITLE
refactor(net): unify dropped session handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3585,6 +3585,7 @@ version = "0.1.0"
 dependencies = [
  "aquamarine",
  "async-trait",
+ "auto_impl",
  "bytes",
  "enr 0.7.0",
  "ethers-core",

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -36,6 +36,7 @@ tokio = { version = "1", features = ["io-util", "net", "macros", "rt-multi-threa
 tokio-stream = "0.1"
 
 # misc
+auto_impl = "1"
 aquamarine = "0.1" # docs
 tracing = "0.1"
 fnv = "1.0"

--- a/crates/net/network/src/error.rs
+++ b/crates/net/network/src/error.rs
@@ -1,5 +1,6 @@
 //! Possible errors when interacting with the network.
 
+use crate::session::PendingSessionHandshakeError;
 use reth_eth_wire::{
     error::{EthStreamError, HandshakeError, P2PHandshakeError, P2PStreamError},
     DisconnectReason,
@@ -16,47 +17,90 @@ pub enum NetworkError {
     Discovery(std::io::Error),
 }
 
-/// Returns true if the error indicates that the corresponding peer should be removed from peer
-/// discovery, for example if it's using a different genesis hash.
-pub(crate) fn error_merits_discovery_ban(err: &EthStreamError) -> bool {
-    match err {
-        EthStreamError::P2PStreamError(P2PStreamError::HandshakeError(
-            P2PHandshakeError::HelloNotInHandshake,
-        )) |
-        EthStreamError::P2PStreamError(P2PStreamError::HandshakeError(
-            P2PHandshakeError::NonHelloMessageInHandshake,
-        )) => true,
-        EthStreamError::HandshakeError(err) => !matches!(err, HandshakeError::NoResponse),
-        _ => false,
+/// Abstraction over errors that can lead to a failed session
+#[auto_impl::auto_impl(&)]
+pub(crate) trait SessionError {
+    /// Returns true if the error indicates that the corresponding peer should be removed from peer
+    /// discovery, for example if it's using a different genesis hash.
+    fn merits_discovery_ban(&self) -> bool;
+
+    /// Returns true if the error indicates that we'll never be able to establish a connection to
+    /// that peer. For example, not matching capabilities or a mismatch in protocols.
+    ///
+    /// Note: This does not necessarily mean that either of the peers are in violation of the
+    /// protocol but rather that they'll never be able to connect with each other. This check is
+    /// a superset of [`error_merits_discovery_ban`] which checks if the peer should not be part
+    /// of the gossip network.
+    fn is_fatal_protocol_error(&self) -> bool;
+
+    /// Returns true if the error should lead to backoff, temporarily preventing additional
+    /// connection attempts
+    fn should_backoff(&self) -> bool;
+}
+
+impl SessionError for EthStreamError {
+    fn merits_discovery_ban(&self) -> bool {
+        match self {
+            EthStreamError::P2PStreamError(P2PStreamError::HandshakeError(
+                P2PHandshakeError::HelloNotInHandshake,
+            )) |
+            EthStreamError::P2PStreamError(P2PStreamError::HandshakeError(
+                P2PHandshakeError::NonHelloMessageInHandshake,
+            )) => true,
+            EthStreamError::HandshakeError(err) => !matches!(err, HandshakeError::NoResponse),
+            _ => false,
+        }
+    }
+
+    fn is_fatal_protocol_error(&self) -> bool {
+        match self {
+            EthStreamError::P2PStreamError(err) => {
+                matches!(
+                    err,
+                    P2PStreamError::HandshakeError(P2PHandshakeError::NoSharedCapabilities) |
+                        P2PStreamError::HandshakeError(P2PHandshakeError::HelloNotInHandshake) |
+                        P2PStreamError::HandshakeError(
+                            P2PHandshakeError::NonHelloMessageInHandshake
+                        ) |
+                        P2PStreamError::UnknownReservedMessageId(_) |
+                        P2PStreamError::EmptyProtocolMessage |
+                        P2PStreamError::ParseVersionError(_) |
+                        P2PStreamError::Disconnected(DisconnectReason::UselessPeer) |
+                        P2PStreamError::Disconnected(
+                            DisconnectReason::IncompatibleP2PProtocolVersion
+                        ) |
+                        P2PStreamError::MismatchedProtocolVersion { .. }
+                )
+            }
+            EthStreamError::HandshakeError(err) => !matches!(err, HandshakeError::NoResponse),
+            _ => false,
+        }
+    }
+
+    fn should_backoff(&self) -> bool {
+        Some(DisconnectReason::TooManyPeers) == self.as_disconnected()
     }
 }
 
-/// Returns true if the error indicates that we'll never be able to establish a connection to that
-/// peer. For example, not matching capabilities or a mismatch in protocols.
-///
-/// Note: This does not necessarily mean that either of the peers are in violation of the protocol
-/// but rather that they'll never be able to connect with each other. This check is a superset of
-/// [`error_merits_discovery_ban`] which checks if the peer should not be part of the gossip
-/// network.
-pub(crate) fn is_fatal_protocol_error(err: &EthStreamError) -> bool {
-    match err {
-        EthStreamError::P2PStreamError(err) => {
-            matches!(
-                err,
-                P2PStreamError::HandshakeError(P2PHandshakeError::NoSharedCapabilities) |
-                    P2PStreamError::HandshakeError(P2PHandshakeError::HelloNotInHandshake) |
-                    P2PStreamError::HandshakeError(P2PHandshakeError::NonHelloMessageInHandshake) |
-                    P2PStreamError::UnknownReservedMessageId(_) |
-                    P2PStreamError::EmptyProtocolMessage |
-                    P2PStreamError::ParseVersionError(_) |
-                    P2PStreamError::Disconnected(DisconnectReason::UselessPeer) |
-                    P2PStreamError::Disconnected(
-                        DisconnectReason::IncompatibleP2PProtocolVersion
-                    ) |
-                    P2PStreamError::MismatchedProtocolVersion { .. }
-            )
+impl SessionError for PendingSessionHandshakeError {
+    fn merits_discovery_ban(&self) -> bool {
+        match self {
+            PendingSessionHandshakeError::Eth(eth) => eth.merits_discovery_ban(),
+            PendingSessionHandshakeError::Ecies(_) => true,
         }
-        EthStreamError::HandshakeError(err) => !matches!(err, HandshakeError::NoResponse),
-        _ => false,
+    }
+
+    fn is_fatal_protocol_error(&self) -> bool {
+        match self {
+            PendingSessionHandshakeError::Eth(eth) => eth.is_fatal_protocol_error(),
+            PendingSessionHandshakeError::Ecies(_) => true,
+        }
+    }
+
+    fn should_backoff(&self) -> bool {
+        match self {
+            PendingSessionHandshakeError::Eth(eth) => eth.should_backoff(),
+            PendingSessionHandshakeError::Ecies(_) => true,
+        }
     }
 }

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -13,13 +13,14 @@ use crate::{
 };
 use fnv::FnvHashMap;
 use futures::{future::Either, io, FutureExt, StreamExt};
-use reth_ecies::stream::ECIESStream;
+use reth_ecies::{stream::ECIESStream, ECIESError};
 use reth_eth_wire::{
     capability::{Capabilities, CapabilityMessage},
     error::EthStreamError,
     DisconnectReason, HelloMessage, Status, UnauthedEthStream, UnauthedP2PStream,
 };
 use reth_primitives::{ForkFilter, ForkId, ForkTransition, PeerId, H256, U256};
+use reth_tasks::TaskExecutor;
 use secp256k1::SecretKey;
 use std::{
     collections::HashMap,
@@ -40,10 +41,6 @@ mod active;
 mod config;
 mod handle;
 pub use config::SessionsConfig;
-use reth_ecies::ECIESError;
-
-use crate::error::error_merits_discovery_ban;
-use reth_tasks::TaskExecutor;
 
 /// Internal identifier for active sessions.
 #[derive(Debug, Clone, Copy, PartialOrd, PartialEq, Eq, Hash)]
@@ -548,19 +545,6 @@ pub(crate) enum SessionEvent {
 pub(crate) enum PendingSessionHandshakeError {
     Eth(EthStreamError),
     Ecies(ECIESError),
-}
-
-// === impl PendingSessionHandshakeError ===
-
-impl PendingSessionHandshakeError {
-    /// Returns true if the error indicates that the corresponding peer should be removed from peer
-    /// discover
-    pub(crate) fn merits_discovery_ban(&self) -> bool {
-        match self {
-            PendingSessionHandshakeError::Eth(eth) => error_merits_discovery_ban(eth),
-            PendingSessionHandshakeError::Ecies(_) => true,
-        }
-    }
 }
 
 /// The direction of the connection.


### PR DESCRIPTION
Unifies how active|pending dropped sessions are handled

* gracefully: no error
* dropped: with error


Introduces a `SessionError` trait to make it easier to work with the different error types. The pending session has an error variant because it can fail on the ecies level.