### PR TITLE
fix(net): check for handshake disconnect

### DIFF
--- a/crates/net/eth-wire/src/error.rs
+++ b/crates/net/eth-wire/src/error.rs
@@ -96,11 +96,13 @@ pub enum P2PStreamError {
 impl P2PStreamError {
     /// Returns the [`DisconnectReason`] if it is the `Disconnected` variant.
     pub fn as_disconnected(&self) -> Option<DisconnectReason> {
-        if let P2PStreamError::Disconnected(reason) = self {
-            Some(*reason)
-        } else {
-            None
-        }
+        let reason = match self {
+            P2PStreamError::HandshakeError(P2PHandshakeError::Disconnected(reason)) => reason,
+            P2PStreamError::Disconnected(reason) => reason,
+            _ => return None,
+        };
+
+        Some(*reason)
     }
 }
 

--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -197,6 +197,7 @@ impl PeersManager {
 
     /// Temporarily puts the peer in timeout
     fn backoff_peer(&mut self, peer_id: PeerId) {
+        trace!(target: "net::peers", ?peer_id, "backing off");
         self.ban_list.ban_peer_until(peer_id, std::time::Instant::now() + self.backoff_duration);
     }
 
@@ -291,7 +292,10 @@ impl PeersManager {
         err: impl SessionError,
         reputation_change: ReputationChangeKind,
     ) {
+        trace!(target: "net::peers", ?remote_addr, ?peer_id, ?err, "handling failed connection");
+
         if err.is_fatal_protocol_error() {
+            trace!(target: "net::peers", ?remote_addr, ?peer_id, ?err, "fatal connection error");
             // remove the peer to which we can't establish a connection due to protocol related
             // issues.
             if let Some(peer) = self.peers.remove(peer_id) {


### PR DESCRIPTION
`P2PStreamError::as_disconnect` did not consider the `P2PHandshakeError::Disconnected`

also adds some additional traces