### PR TITLE
feat(cli): add `--disable-discovery`

### DIFF
--- a/bin/reth/src/config.rs
+++ b/bin/reth/src/config.rs
@@ -27,6 +27,7 @@ impl Config {
         db: Arc<DB>,
         chain_id: u64,
         genesis_hash: H256,
+        disable_discovery: bool,
     ) -> NetworkConfig<ProviderImpl<DB>> {
         let peer_config = reth_network::PeersConfig::default()
             .with_trusted_nodes(self.peers.trusted_nodes.clone())
@@ -36,6 +37,7 @@ impl Config {
             .peer_config(peer_config)
             .genesis_hash(genesis_hash)
             .chain_id(chain_id)
+            .set_discovery(disable_discovery)
             .build()
     }
 }

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -102,13 +102,10 @@ impl Command {
         let consensus = Arc::new(BeaconConsensus::new(self.chain.consensus.clone()));
         let genesis_hash = init_genesis(db.clone(), self.chain.genesis.clone())?;
 
-        let network =
-            config.network_config(
-                db.clone(), 
-                chain_id, 
-                genesis_hash,
-                self.disable_discovery,
-            ).start_network().await?;
+        let network = config
+            .network_config(db.clone(), chain_id, genesis_hash, self.disable_discovery)
+            .start_network()
+            .await?;
 
         info!(peer_id = ?network.peer_id(), local_addr = %network.local_addr(), "Started p2p networking");
 

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -75,6 +75,10 @@ pub struct Command {
     /// NOTE: This is a temporary flag
     #[arg(long = "debug.tip")]
     tip: Option<H256>,
+
+    /// Disable the discovery service.
+    #[arg(short, long)]
+    disable_discovery: bool,
 }
 
 impl Command {
@@ -100,7 +104,12 @@ impl Command {
 
         info!("Connecting to p2p");
         let network =
-            config.network_config(db.clone(), chain_id, genesis_hash).start_network().await?;
+            config.network_config(
+                db.clone(), 
+                chain_id, 
+                genesis_hash,
+                self.disable_discovery,
+            ).start_network().await?;
 
         // TODO: Are most of these Arcs unnecessary? For example, fetch client is completely
         // cloneable on its own

--- a/crates/net/network/src/discovery.rs
+++ b/crates/net/network/src/discovery.rs
@@ -24,15 +24,13 @@ pub struct Discovery {
     /// Local ENR of the discovery service.
     local_enr: NodeRecord,
     /// Handler to interact with the Discovery v4 service
-    discv4: Discv4,
+    discv4: Option<Discv4>,
     /// All KAD table updates from the discv4 service.
-    discv4_updates: ReceiverStream<DiscoveryUpdate>,
-    /// The initial config for the discv4 service
-    _dsicv4_config: Discv4Config,
+    discv4_updates: Option<ReceiverStream<DiscoveryUpdate>>,
     /// Events buffered until polled.
     queued_events: VecDeque<DiscoveryEvent>,
     /// The handle to the spawned discv4 service
-    _discv4_service: JoinHandle<()>,
+    _discv4_service: Option<JoinHandle<()>>,
 }
 
 impl Discovery {
@@ -43,23 +41,29 @@ impl Discovery {
     pub async fn new(
         discovery_addr: SocketAddr,
         sk: SecretKey,
-        dsicv4_config: Discv4Config,
+        discv4_config: Option<Discv4Config>,
     ) -> Result<Self, NetworkError> {
         let local_enr = NodeRecord::from_secret_key(discovery_addr, &sk);
-        let (discv4, mut discv4_service) =
-            Discv4::bind(discovery_addr, local_enr, sk, dsicv4_config.clone())
+        let (discv4, 
+            discv4_updates, 
+            _discv4_service
+        ) = if let Some(disc_config) = discv4_config {
+            let (discv4, mut discv4_service) =
+                Discv4::bind(discovery_addr, local_enr, sk, disc_config)
                 .await
                 .map_err(NetworkError::Discovery)?;
-        let discv4_updates = discv4_service.update_stream();
-
-        // spawn the service
-        let _discv4_service = discv4_service.spawn();
+            let discv4_updates = discv4_service.update_stream();
+            // spawn the service
+            let _discv4_service = discv4_service.spawn();
+            (Some(discv4), Some(discv4_updates), Some(_discv4_service))
+        } else {
+            (None, None, None)
+        };
 
         Ok(Self {
             local_enr,
             discv4,
             discv4_updates,
-            _dsicv4_config: dsicv4_config,
             _discv4_service,
             discovered_nodes: Default::default(),
             queued_events: Default::default(),
@@ -69,17 +73,23 @@ impl Discovery {
     /// Updates the `eth:ForkId` field in discv4.
     #[allow(unused)]
     pub(crate) fn update_fork_id(&self, fork_id: ForkId) {
-        self.discv4.set_eip868_rlp("eth".as_bytes().to_vec(), fork_id)
+        if let Some(discv4) = &self.discv4 {
+            discv4.set_eip868_rlp("eth".as_bytes().to_vec(), fork_id)
+        }
     }
 
     /// Bans the [`IpAddr`] in the discovery service.
     pub(crate) fn ban_ip(&self, ip: IpAddr) {
-        self.discv4.ban_ip(ip)
+        if let Some(discv4) = &self.discv4 {
+            discv4.ban_ip(ip)
+        }
     }
 
     /// Bans the [`PeerId`] and [`IpAddr`] in the discovery service.
     pub(crate) fn ban(&self, peer_id: PeerId, ip: IpAddr) {
-        self.discv4.ban(peer_id, ip)
+        if let Some(discv4) = &self.discv4 {
+            discv4.ban(peer_id, ip)
+        }
     }
 
     /// Returns the id with which the local identifies itself in the network
@@ -122,7 +132,9 @@ impl Discovery {
             }
 
             // drain the update stream
-            while let Poll::Ready(Some(update)) = self.discv4_updates.poll_next_unpin(cx) {
+            while let Some(Poll::Ready(Some(update))) = self.discv4_updates.as_mut().map(
+                |disc_updates|
+                disc_updates.poll_next_unpin(cx)) {
                 self.on_discv4_update(update)
             }
 

--- a/crates/net/network/src/discovery.rs
+++ b/crates/net/network/src/discovery.rs
@@ -44,14 +44,11 @@ impl Discovery {
         discv4_config: Option<Discv4Config>,
     ) -> Result<Self, NetworkError> {
         let local_enr = NodeRecord::from_secret_key(discovery_addr, &sk);
-        let (discv4, 
-            discv4_updates, 
-            _discv4_service
-        ) = if let Some(disc_config) = discv4_config {
+        let (discv4, discv4_updates, _discv4_service) = if let Some(disc_config) = discv4_config {
             let (discv4, mut discv4_service) =
                 Discv4::bind(discovery_addr, local_enr, sk, disc_config)
-                .await
-                .map_err(NetworkError::Discovery)?;
+                    .await
+                    .map_err(NetworkError::Discovery)?;
             let discv4_updates = discv4_service.update_stream();
             // spawn the service
             let _discv4_service = discv4_service.spawn();
@@ -132,9 +129,9 @@ impl Discovery {
             }
 
             // drain the update stream
-            while let Some(Poll::Ready(Some(update))) = self.discv4_updates.as_mut().map(
-                |disc_updates|
-                disc_updates.poll_next_unpin(cx)) {
+            while let Some(Poll::Ready(Some(update))) =
+                self.discv4_updates.as_mut().map(|disc_updates| disc_updates.poll_next_unpin(cx))
+            {
                 self.on_discv4_update(update)
             }
 
@@ -151,7 +148,6 @@ impl Discovery {
     ///
     /// NOTE: This instance does nothing
     pub(crate) fn noop() -> Self {
-        let (_tx, rx) = tokio::sync::mpsc::channel(1);
         Self {
             discovered_nodes: Default::default(),
             local_enr: NodeRecord {
@@ -160,10 +156,10 @@ impl Discovery {
                 udp_port: 0,
                 id: PeerId::random(),
             },
-            discv4: Some(Discv4::noop()),
-            discv4_updates: Some(ReceiverStream::new(rx)),
+            discv4: Default::default(),
+            discv4_updates: Default::default(),
             queued_events: Default::default(),
-            _discv4_service: Some(tokio::task::spawn(async move {})),
+            _discv4_service: Default::default(),
         }
     }
 }

--- a/crates/net/network/src/discovery.rs
+++ b/crates/net/network/src/discovery.rs
@@ -160,11 +160,10 @@ impl Discovery {
                 udp_port: 0,
                 id: PeerId::random(),
             },
-            discv4: Discv4::noop(),
-            discv4_updates: ReceiverStream::new(rx),
-            _dsicv4_config: Default::default(),
+            discv4: Some(Discv4::noop()),
+            discv4_updates: Some(ReceiverStream::new(rx)),
             queued_events: Default::default(),
-            _discv4_service: tokio::task::spawn(async move {}),
+            _discv4_service: Some(tokio::task::spawn(async move {})),
         }
     }
 }

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -166,7 +166,7 @@ where
             disc_config.add_eip868_pair("eth", status.forkid);
             disc_config
         });
-        
+
         let discovery = Discovery::new(discovery_addr, secret_key, discovery_v4_config).await?;
         // need to retrieve the addr here since provided port could be `0`
         let local_peer_id = discovery.local_id();

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -160,10 +160,13 @@ where
         let incoming = ConnectionListener::bind(listener_addr).await?;
         let listener_address = Arc::new(Mutex::new(incoming.local_address()));
 
-        // merge configured boot nodes
-        discovery_v4_config.bootstrap_nodes.extend(boot_nodes.clone());
-        discovery_v4_config.add_eip868_pair("eth", status.forkid);
-
+        discovery_v4_config = discovery_v4_config.map(|mut disc_config| {
+            // merge configured boot nodes
+            disc_config.bootstrap_nodes.extend(boot_nodes.clone());
+            disc_config.add_eip868_pair("eth", status.forkid);
+            disc_config
+        });
+        
         let discovery = Discovery::new(discovery_addr, secret_key, discovery_v4_config).await?;
         // need to retrieve the addr here since provided port could be `0`
         let local_peer_id = discovery.local_id();


### PR DESCRIPTION
Fixed typo: _dsicv4_config to _discv4_service. Added cli flag `disable_discovery` to not spawn the discv4 service when running node. Changed _discv4_service to Option<JoinHandle<()>> to allow for optional discovery. Let me know know if this is what you had in mind. 