### PR TITLE
refactor(net): unify closed incoming session handling

### DIFF
--- a/crates/net/common/src/ban_list.rs
+++ b/crates/net/common/src/ban_list.rs
@@ -47,21 +47,28 @@ impl BanList {
         evicted
     }
 
-    /// Removes all entries that should no longer be banned.
-    pub fn evict(&mut self, now: Instant) {
-        self.banned_ips.retain(|_, until| {
+    /// Removes all ip addresses that are no longer banned.
+    pub fn evict_ips(&mut self, now: Instant) -> Vec<IpAddr> {
+        let mut evicted = Vec::new();
+        self.banned_ips.retain(|peer, until| {
             if let Some(until) = until {
-                return *until > now
+                if now > *until {
+                    evicted.push(*peer);
+                    return false
+                }
             }
             true
         });
+        evicted
+    }
 
-        self.banned_peers.retain(|_, until| {
-            if let Some(until) = until {
-                return *until > now
-            }
-            true
-        });
+    /// Removes all entries that should no longer be banned.
+    ///
+    /// Returns the evicted entries.
+    pub fn evict(&mut self, now: Instant) -> (Vec<IpAddr>, Vec<PeerId>) {
+        let ips = self.evict_ips(now);
+        let peers = self.evict_peers(now);
+        (ips, peers)
     }
 
     /// Returns true if either the given peer id _or_ ip address is banned.

--- a/crates/net/network/src/error.rs
+++ b/crates/net/network/src/error.rs
@@ -63,6 +63,15 @@ impl SessionError for EthStreamError {
                         P2PStreamError::HandshakeError(
                             P2PHandshakeError::NonHelloMessageInHandshake
                         ) |
+                        P2PStreamError::HandshakeError(P2PHandshakeError::Disconnected(
+                            DisconnectReason::UselessPeer
+                        )) |
+                        P2PStreamError::HandshakeError(P2PHandshakeError::Disconnected(
+                            DisconnectReason::IncompatibleP2PProtocolVersion
+                        )) |
+                        P2PStreamError::HandshakeError(P2PHandshakeError::Disconnected(
+                            DisconnectReason::ProtocolBreach
+                        )) |
                         P2PStreamError::UnknownReservedMessageId(_) |
                         P2PStreamError::EmptyProtocolMessage |
                         P2PStreamError::ParseVersionError(_) |
@@ -70,6 +79,7 @@ impl SessionError for EthStreamError {
                         P2PStreamError::Disconnected(
                             DisconnectReason::IncompatibleP2PProtocolVersion
                         ) |
+                        P2PStreamError::Disconnected(DisconnectReason::ProtocolBreach) |
                         P2PStreamError::MismatchedProtocolVersion { .. }
                 )
             }
@@ -116,6 +126,17 @@ impl SessionError for PendingSessionHandshakeError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_is_fatal_disconnect() {
+        let err = PendingSessionHandshakeError::Eth(EthStreamError::P2PStreamError(
+            P2PStreamError::HandshakeError(P2PHandshakeError::Disconnected(
+                DisconnectReason::UselessPeer,
+            )),
+        ));
+
+        assert!(err.is_fatal_protocol_error());
+    }
 
     #[test]
     fn test_should_backoff() {

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -280,11 +280,13 @@ where
                 self.queued_messages.push_back(StateAction::Disconnect { peer_id, reason });
             }
             PeerAction::DisconnectBannedIncoming { peer_id } => {
-                // TODO: can IP ban
                 self.state_fetcher.on_pending_disconnect(&peer_id);
                 self.queued_messages.push_back(StateAction::Disconnect { peer_id, reason: None });
             }
-            PeerAction::DiscoveryBan { peer_id, ip_addr } => self.ban_discovery(peer_id, ip_addr),
+            PeerAction::DiscoveryBanPeerId { peer_id, ip_addr } => {
+                self.ban_discovery(peer_id, ip_addr)
+            }
+            PeerAction::DiscoveryBanIp { ip_addr } => self.ban_ip_discovery(ip_addr),
             PeerAction::BanPeer { .. } => {}
             PeerAction::UnBanPeer { .. } => {}
         }

--- a/crates/net/network/src/swarm.rs
+++ b/crates/net/network/src/swarm.rs
@@ -179,8 +179,9 @@ where
                 return Some(SwarmEvent::TcpListenerClosed { remote_addr: address })
             }
             ListenerEvent::Incoming { stream, remote_addr } => {
+                // ensure we can handle an incoming connection from this address
                 if let Err(err) =
-                    self.state_mut().peers_mut().on_inbound_pending_session(remote_addr.ip())
+                    self.state_mut().peers_mut().on_incoming_pending_session(remote_addr.ip())
                 {
                     match err {
                         InboundConnectionError::IpBanned => {
@@ -202,6 +203,9 @@ where
                     }
                     Err(err) => {
                         warn!(target: "net", ?err, "Incoming connection rejected");
+                        self.state_mut()
+                            .peers_mut()
+                            .on_incoming_pending_session_rejected_internally();
                     }
                 }
             }


### PR DESCRIPTION
followup for https://github.com/paradigmxyz/reth/pull/595

unifies how closed incoming sessions are handled, including IP ban if closed due to fatal protocol error