### PR TITLE
fix: do not lowercase table arg in `db list`

### DIFF
--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -160,7 +160,7 @@ impl<'a, DB: Database> DbTool<'a, DB> {
             };
         }
 
-        list_tables!(args.table.to_lowercase().as_str(), args.start, args.len => [
+        list_tables!(args.table.as_str(), args.start, args.len => [
             CanonicalHeaders,
             HeaderTD,
             HeaderNumbers,


### PR DESCRIPTION
We were lowercasing the table argument in `reth db list` but matching it to the actual names of the tables (all of which are pascal case)