### PR TITLE
perf: allocate responses capacity

### DIFF
--- a/crates/net/downloaders/src/bodies/concurrent.rs
+++ b/crates/net/downloaders/src/bodies/concurrent.rs
@@ -135,7 +135,7 @@ where
 
         let mut bodies = bodies.into_iter();
 
-        let mut responses = vec![];
+        let mut responses = Vec::with_capacity(headers.len());
         for header in headers.into_iter().cloned() {
             // If the header has no txs / ommers, just push it and continue
             if header.is_empty() {


### PR DESCRIPTION
Given we may download a lot of headers, it makes more sense to pre-allocate the vec length instead of re-allocating on each push