### PR TITLE
perf(net): backoff on IO error

### DIFF
--- a/crates/net/eth-wire/src/errors/eth.rs
+++ b/crates/net/eth-wire/src/errors/eth.rs
@@ -26,6 +26,14 @@ impl EthStreamError {
             None
         }
     }
+
+    /// Returns the [io::Error] if it was caused by IO
+    pub fn as_io(&self) -> Option<&io::Error> {
+        if let EthStreamError::P2PStreamError(P2PStreamError::Io(io)) = self {
+            return Some(io)
+        }
+        None
+    }
 }
 
 impl From<io::Error> for EthStreamError {

--- a/crates/net/network/src/error.rs
+++ b/crates/net/network/src/error.rs
@@ -95,15 +95,15 @@ impl SessionError for EthStreamError {
                 EthStreamError::P2PStreamError(P2PStreamError::HandshakeError(
                     P2PHandshakeError::NoResponse
                 ))
-        ) || self
-            .as_disconnected()
-            .map(|reason| {
-                matches!(
-                    reason,
-                    DisconnectReason::TooManyPeers | DisconnectReason::AlreadyConnected
-                )
-            })
-            .unwrap_or_default()
+        ) || self.as_io().is_some() ||
+            self.as_disconnected()
+                .map(|reason| {
+                    matches!(
+                        reason,
+                        DisconnectReason::TooManyPeers | DisconnectReason::AlreadyConnected
+                    )
+                })
+                .unwrap_or_default()
     }
 }
 


### PR DESCRIPTION
A failed outgoing session attempt can be caused by several IO error kinds, commonly:

* Connection Refused
* Unreachable
* TimedOut

This checks fo `io` error in `should_backoff` check so followup requests to the same peer are prevented.