### PR TITLE
meta: patch toolchain to `nightly-2022-12-27`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,9 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: nightly-2022-12-27
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
         with:
@@ -104,8 +105,9 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: nightly-2022-12-27
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
         with:
@@ -143,8 +145,9 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: nightly-2022-12-27
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -23,8 +23,9 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: nightly-2022-12-27
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
         with:
@@ -68,7 +69,9 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2022-12-27
 
       - name: Install cargo-udeps
         run: cargo install cargo-udeps --locked


### PR DESCRIPTION
Failing CI: https://github.com/paradigmxyz/reth/actions/runs/3799409484/jobs/6461910377
Tracking: https://github.com/rust-lang/rust/pull/106248