### PR TITLE
chore: rm rpc type imports

### DIFF
--- a/crates/net/rpc-api/src/debug.rs
+++ b/crates/net/rpc-api/src/debug.rs
@@ -1,8 +1,5 @@
 use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
-use reth_primitives::{
-    rpc::{BlockId, Bytes},
-    H256,
-};
+use reth_primitives::{rpc::BlockId, Bytes, H256};
 use reth_rpc_types::RichBlock;
 
 /// Debug rpc interface.

--- a/crates/net/rpc-types/src/eth/block.rs
+++ b/crates/net/rpc-types/src/eth/block.rs
@@ -1,5 +1,5 @@
 use crate::Transaction;
-use reth_primitives::{rpc::H64, Address, Bloom, Bytes, H256, U256};
+use reth_primitives::{Address, Bloom, Bytes, H256, H64, U256};
 use serde::{ser::Error, Deserialize, Serialize, Serializer};
 use std::{collections::BTreeMap, ops::Deref};
 

--- a/crates/transaction-pool/src/pool/listener.rs
+++ b/crates/transaction-pool/src/pool/listener.rs
@@ -1,7 +1,7 @@
 //! Listeners for the transaction-pool
 
 use crate::{pool::events::TransactionEvent, traits::PropagateKind};
-use reth_primitives::{rpc::TxHash, H256};
+use reth_primitives::{TxHash, H256};
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::mpsc::UnboundedSender;
 

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -3,7 +3,7 @@ use crate::{
     pool::{best::BestTransactions, size::SizeTracker},
     TransactionOrdering, ValidPoolTransaction,
 };
-use reth_primitives::rpc::TxHash;
+use reth_primitives::TxHash;
 use std::{
     cmp::Ordering,
     collections::{BTreeMap, BTreeSet},

--- a/crates/transaction-pool/src/validate.rs
+++ b/crates/transaction-pool/src/validate.rs
@@ -5,7 +5,7 @@ use crate::{
     identifier::{SenderId, TransactionId},
     traits::{PoolTransaction, TransactionOrigin},
 };
-use reth_primitives::{rpc::Address, TxHash, U256};
+use reth_primitives::{Address, TxHash, U256};
 use std::{fmt, time::Instant};
 
 /// A Result type returned after checking a transaction's validity.


### PR DESCRIPTION
closes #643 use primitive types directly