### PR TITLE
fix: advance buffer after enr decode

### DIFF
--- a/crates/common/rlp/src/decode.rs
+++ b/crates/common/rlp/src/decode.rs
@@ -391,7 +391,7 @@ where
 {
     fn decode(buf: &mut &[u8]) -> Result<Self, DecodeError> {
         // currently the only way to build an enr is to decode it using the rlp::Decodable trait
-        <Self as rlp::Decodable>::decode(&rlp::Rlp::new(buf)).map_err(|e| match e {
+        let enr = <Self as rlp::Decodable>::decode(&rlp::Rlp::new(buf)).map_err(|e| match e {
             rlp::DecoderError::RlpIsTooShort => DecodeError::InputTooShort,
             rlp::DecoderError::RlpInvalidLength => DecodeError::Overflow,
             rlp::DecoderError::RlpExpectedToBeList => DecodeError::UnexpectedString,
@@ -407,7 +407,13 @@ where
                 DecodeError::Custom("inconsistent length and data when decoding rlp")
             }
             rlp::DecoderError::Custom(s) => DecodeError::Custom(s),
-        })
+        });
+        if enr.is_ok() {
+            // Decode was successful, advance buffer
+            let header = Header::decode(buf)?;
+            buf.advance(header.payload_length);
+        }
+        enr
     }
 }
 
@@ -638,13 +644,16 @@ mod tests {
         use enr::{secp256k1::SecretKey, Enr, EnrPublicKey};
         use std::net::Ipv4Addr;
 
-        let valid_record = hex!("f884b8407098ad865b00a582051940cb9cf36836572411a47278783077011599ed5cd16b76f2635f4e234738f30813a89eb9137e3e3df5266e3a1f11df72ecf1145ccb9c01826964827634826970847f00000189736563703235366b31a103ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd31388375647082765f");
+        let mut valid_record = &hex!("f884b8407098ad865b00a582051940cb9cf36836572411a47278783077011599ed5cd16b76f2635f4e234738f30813a89eb9137e3e3df5266e3a1f11df72ecf1145ccb9c01826964827634826970847f00000189736563703235366b31a103ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd31388375647082765f")[..];
         let signature = hex!("7098ad865b00a582051940cb9cf36836572411a47278783077011599ed5cd16b76f2635f4e234738f30813a89eb9137e3e3df5266e3a1f11df72ecf1145ccb9c");
         let expected_pubkey =
             hex!("03ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd3138");
 
-        let enr = Enr::<SecretKey>::decode(&mut &valid_record[..]).unwrap();
+        let enr = Enr::<SecretKey>::decode(&mut valid_record).unwrap();
         let pubkey = enr.public_key().encode();
+
+        // Byte array must be consumed after enr has finished decoding
+        assert!(valid_record.is_empty());
 
         assert_eq!(enr.ip4(), Some(Ipv4Addr::new(127, 0, 0, 1)));
         assert_eq!(enr.id(), Some(String::from("v4")));
@@ -676,11 +685,13 @@ mod tests {
 
         let mut encoded = BytesMut::new();
         enr.encode(&mut encoded);
+        let mut encoded_bytes = &encoded[..];
+        let decoded_enr = Enr::<SecretKey>::decode(&mut encoded_bytes).unwrap();
 
-        let decoded_enr = Enr::<SecretKey>::decode(&mut &encoded[..]).unwrap();
+        // Byte array must be consumed after enr has finished decoding
+        assert!(encoded_bytes.is_empty());
 
         assert_eq!(decoded_enr, enr);
-
         assert_eq!(decoded_enr.id(), Some("v4".into()));
         assert_eq!(decoded_enr.ip4(), Some(ip));
         assert_eq!(decoded_enr.tcp4(), Some(tcp));

--- a/crates/common/rlp/src/decode.rs
+++ b/crates/common/rlp/src/decode.rs
@@ -644,16 +644,17 @@ mod tests {
         use enr::{secp256k1::SecretKey, Enr, EnrPublicKey};
         use std::net::Ipv4Addr;
 
-        let mut valid_record = &hex!("f884b8407098ad865b00a582051940cb9cf36836572411a47278783077011599ed5cd16b76f2635f4e234738f30813a89eb9137e3e3df5266e3a1f11df72ecf1145ccb9c01826964827634826970847f00000189736563703235366b31a103ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd31388375647082765f")[..];
+        let valid_record = hex!("f884b8407098ad865b00a582051940cb9cf36836572411a47278783077011599ed5cd16b76f2635f4e234738f30813a89eb9137e3e3df5266e3a1f11df72ecf1145ccb9c01826964827634826970847f00000189736563703235366b31a103ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd31388375647082765f");
         let signature = hex!("7098ad865b00a582051940cb9cf36836572411a47278783077011599ed5cd16b76f2635f4e234738f30813a89eb9137e3e3df5266e3a1f11df72ecf1145ccb9c");
         let expected_pubkey =
             hex!("03ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd3138");
 
-        let enr = Enr::<SecretKey>::decode(&mut valid_record).unwrap();
+        let mut valid_record_buf = valid_record.as_slice();
+        let enr = Enr::<SecretKey>::decode(&mut valid_record_buf).unwrap();
         let pubkey = enr.public_key().encode();
 
         // Byte array must be consumed after enr has finished decoding
-        assert!(valid_record.is_empty());
+        assert!(valid_record_buf.is_empty());
 
         assert_eq!(enr.ip4(), Some(Ipv4Addr::new(127, 0, 0, 1)));
         assert_eq!(enr.id(), Some(String::from("v4")));


### PR DESCRIPTION
After ENR has been decoded, advance the buffer.
Fixes #482 