### PR TITLE
bug(consensus): Remove mixHash zero check after merge

### DIFF
--- a/crates/consensus/src/verification.rs
+++ b/crates/consensus/src/verification.rs
@@ -3,7 +3,7 @@ use crate::{config, Config};
 use reth_interfaces::{consensus::Error, Result as RethResult};
 use reth_primitives::{
     BlockNumber, Header, SealedBlock, SealedHeader, Transaction, TransactionSignedEcRecovered,
-    TxEip1559, TxEip2930, TxLegacy, EMPTY_OMMER_ROOT, H256, U256,
+    TxEip1559, TxEip2930, TxLegacy, EMPTY_OMMER_ROOT, U256,
 };
 use reth_provider::{AccountProvider, HeaderProvider};
 use std::{

--- a/crates/consensus/src/verification.rs
+++ b/crates/consensus/src/verification.rs
@@ -57,9 +57,8 @@ pub fn validate_header_standalone(
             return Err(Error::TheMergeOmmerRootIsNotEmpty)
         }
 
-        if header.mix_hash != H256::zero() {
-            return Err(Error::TheMergeMixHashIsNotZero)
-        }
+        // mixHash is used instead of difficulty inside EVM
+        // https://eips.ethereum.org/EIPS/eip-4399#using-mixhash-field-instead-of-difficulty
     }
 
     Ok(())


### PR DESCRIPTION
Followed this EIP where `mixHash` should be zero: https://eips.ethereum.org/EIPS/eip-3675#block-structure 

but in follow-up EIP  mixHash after Paris is set from CL to `prevrandao` and is replacing difficulty opcode value: https://eips.ethereum.org/EIPS/eip-4399#using-mixhash-field-instead-of-difficulty  

so this check should be removed.