### PR TITLE
chore: add serde feature to network crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3765,6 +3765,7 @@ dependencies = [
  "reth-tracing",
  "reth-transaction-pool",
  "secp256k1 0.24.2",
+ "serde",
  "serial_test",
  "tempfile",
  "thiserror",

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -19,7 +19,7 @@ reth-consensus = { path = "../../crates/consensus", features = ["serde"] }
 reth-executor = { path = "../../crates/executor" }
 # reth-rpc = {path = "../../crates/net/rpc"}
 reth-rlp = { path = "../../crates/common/rlp" }
-reth-network = {path = "../../crates/net/network" }
+reth-network = {path = "../../crates/net/network", features = ["serde"] }
 reth-downloaders = {path = "../../crates/net/downloaders" }
 
 # tracing

--- a/bin/reth/src/config.rs
+++ b/bin/reth/src/config.rs
@@ -1,12 +1,12 @@
 //! Configuration files.
-use std::{collections::HashSet, sync::Arc};
+use std::sync::Arc;
 
 use reth_db::database::Database;
 use reth_network::{
     config::{mainnet_nodes, rng_secret_key},
-    NetworkConfig,
+    NetworkConfig, PeersConfig,
 };
-use reth_primitives::{NodeRecord, H256};
+use reth_primitives::H256;
 use reth_provider::ProviderImpl;
 use serde::{Deserialize, Serialize};
 
@@ -108,13 +108,4 @@ impl Default for SenderRecoveryConfig {
     fn default() -> Self {
         Self { commit_threshold: 5_000, batch_size: 1000 }
     }
-}
-
-/// Configuration for peer managing.
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
-pub struct PeersConfig {
-    /// Trusted nodes to connect to.
-    pub trusted_nodes: HashSet<NodeRecord>,
-    /// Connect to trusted nodes only?
-    pub connect_trusted_nodes_only: bool,
 }

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -35,6 +35,9 @@ pin-project = "1.0"
 tokio = { version = "1", features = ["io-util", "net", "macros", "rt-multi-thread", "time"] }
 tokio-stream = "0.1"
 
+# io
+serde = { version = "1.0", optional = true }
+
 # misc
 auto_impl = "1"
 aquamarine = "0.1" # docs
@@ -68,3 +71,5 @@ hex = "0.4"
 tempfile = "3.3"
 serial_test = "0.10"
 
+[features]
+serde = ["dep:serde"]

--- a/crates/net/network/src/lib.rs
+++ b/crates/net/network/src/lib.rs
@@ -108,6 +108,10 @@
 //!         .split_with_handle();
 //! }
 //! ```
+//!
+//! # Features
+//!
+//! - `serde`: Enable serde support for configuration types.
 
 mod builder;
 mod cache;

--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -25,6 +25,9 @@ use tokio::{
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, trace};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// A communication channel to the [`PeersManager`] to apply manual changes to the peer set.
 #[derive(Clone, Debug)]
 pub struct PeersHandle {
@@ -561,7 +564,7 @@ impl Default for PeersManager {
 }
 
 /// Tracks stats about connected nodes
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ConnectionInfo {
     /// Counter for currently occupied slots for active outbound connections.
     num_outbound: usize,
@@ -787,20 +790,28 @@ pub enum PeerAction {
 }
 
 /// Config type for initiating a [`PeersManager`] instance
-#[derive(Debug)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct PeersConfig {
     /// How often to recheck free slots for outbound connections.
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub refill_slots_interval: Duration,
     /// Restrictions on connections.
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub connection_info: ConnectionInfo,
     /// How to weigh reputation changes.
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub reputation_weights: ReputationChangeWeights,
     /// Restrictions on PeerIds and Ips.
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub ban_list: BanList,
     /// How long to ban bad peers.
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub ban_duration: Duration,
     /// How long to backoff peers that are we failed to connect to for non-fatal reasons, such as
     /// [`DisconnectReason::TooManyPeers`].
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub backoff_duration: Duration,
     /// Trusted nodes to connect to.
     pub trusted_nodes: HashSet<NodeRecord>,

--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -25,9 +25,6 @@ use tokio::{
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, trace};
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
 /// A communication channel to the [`PeersManager`] to apply manual changes to the peer set.
 #[derive(Clone, Debug)]
 pub struct PeersHandle {
@@ -565,6 +562,8 @@ impl Default for PeersManager {
 
 /// Tracks stats about connected nodes
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct ConnectionInfo {
     /// Counter for currently occupied slots for active outbound connections.
     num_outbound: usize,
@@ -791,14 +790,13 @@ pub enum PeerAction {
 
 /// Config type for initiating a [`PeersManager`] instance
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct PeersConfig {
     /// How often to recheck free slots for outbound connections.
     // #[cfg_attr(feature = "serde", serde(flatten))]
     pub refill_slots_interval: Duration,
     /// Restrictions on connections.
-    #[cfg_attr(feature = "serde", serde(skip))]
     pub connection_info: ConnectionInfo,
     /// How to weigh reputation changes.
     pub reputation_weights: ReputationChangeWeights,

--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -795,23 +795,20 @@ pub enum PeerAction {
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct PeersConfig {
     /// How often to recheck free slots for outbound connections.
-    #[cfg_attr(feature = "serde", serde(skip))]
+    // #[cfg_attr(feature = "serde", serde(flatten))]
     pub refill_slots_interval: Duration,
     /// Restrictions on connections.
     #[cfg_attr(feature = "serde", serde(skip))]
     pub connection_info: ConnectionInfo,
     /// How to weigh reputation changes.
-    #[cfg_attr(feature = "serde", serde(skip))]
     pub reputation_weights: ReputationChangeWeights,
     /// Restrictions on PeerIds and Ips.
     #[cfg_attr(feature = "serde", serde(skip))]
     pub ban_list: BanList,
     /// How long to ban bad peers.
-    #[cfg_attr(feature = "serde", serde(skip))]
     pub ban_duration: Duration,
     /// How long to backoff peers that are we failed to connect to for non-fatal reasons, such as
     /// [`DisconnectReason::TooManyPeers`].
-    #[cfg_attr(feature = "serde", serde(skip))]
     pub backoff_duration: Duration,
     /// Trusted nodes to connect to.
     pub trusted_nodes: HashSet<NodeRecord>,

--- a/crates/net/network/src/peers/reputation.rs
+++ b/crates/net/network/src/peers/reputation.rs
@@ -62,6 +62,8 @@ pub enum ReputationChangeKind {
 
 /// How the [`ReputationChangeKind`] are weighted.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct ReputationChangeWeights {
     /// Weight for [`ReputationChangeKind::BadMessage`]
     pub bad_message: Reputation,


### PR DESCRIPTION
This PR adds a `serde` feature to the network crate, along with _serde_ support for `PeersConfig`, as mentioned in https://github.com/paradigmxyz/reth/pull/569. It also replaces the `PeersConfig` in `bin/reth` to avoid duping.