### PR TITLE
chore: add RLP encoding support for IpAddr

### DIFF
--- a/crates/common/rlp/src/decode.rs
+++ b/crates/common/rlp/src/decode.rs
@@ -218,6 +218,32 @@ impl Decodable for bool {
     }
 }
 
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+impl Decodable for std::net::IpAddr {
+    fn decode(buf: &mut &[u8]) -> Result<Self, DecodeError> {
+        let h = Header::decode(buf)?;
+        if h.list {
+            return Err(DecodeError::UnexpectedList)
+        }
+        let o = match h.payload_length {
+            4 => {
+                let mut to = [0_u8; 4];
+                to.copy_from_slice(&buf[..4]);
+                IpAddr::V4(Ipv4Addr::from(to))
+            }
+            16 => {
+                let mut to = [0u8; 16];
+                to.copy_from_slice(&buf[..16]);
+                IpAddr::V6(Ipv6Addr::from(to))
+            }
+            _ => return Err(DecodeError::UnexpectedLength),
+        };
+        buf.advance(h.payload_length);
+        Ok(o)
+    }
+}
+
 #[cfg(feature = "ethnum")]
 decode_integer!(ethnum::U256);
 

--- a/crates/common/rlp/src/decode.rs
+++ b/crates/common/rlp/src/decode.rs
@@ -218,10 +218,11 @@ impl Decodable for bool {
     }
 }
 
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-
+#[cfg(feature = "std")]
 impl Decodable for std::net::IpAddr {
     fn decode(buf: &mut &[u8]) -> Result<Self, DecodeError> {
+        use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
         let h = Header::decode(buf)?;
         if h.list {
             return Err(DecodeError::UnexpectedList)

--- a/crates/common/rlp/src/encode.rs
+++ b/crates/common/rlp/src/encode.rs
@@ -217,13 +217,12 @@ where
     }
 }
 
-use std::net::IpAddr;
-
-impl Encodable for IpAddr {
+#[cfg(feature = "std")]
+impl Encodable for std::net::IpAddr {
     fn encode(&self, out: &mut dyn BufMut) {
         match self {
-            IpAddr::V4(ref o) => (&o.octets()[..]).encode(out),
-            IpAddr::V6(ref o) => (&o.octets()[..]).encode(out),
+            std::net::IpAddr::V4(ref o) => (&o.octets()[..]).encode(out),
+            std::net::IpAddr::V6(ref o) => (&o.octets()[..]).encode(out),
         }
     }
 }

--- a/crates/common/rlp/src/encode.rs
+++ b/crates/common/rlp/src/encode.rs
@@ -217,6 +217,17 @@ where
     }
 }
 
+use std::net::IpAddr;
+
+impl Encodable for IpAddr {
+    fn encode(&self, out: &mut dyn BufMut) {
+        match self {
+            IpAddr::V4(ref o) => (&o.octets()[..]).encode(out),
+            IpAddr::V6(ref o) => (&o.octets()[..]).encode(out),
+        }
+    }
+}
+
 #[cfg(feature = "ethnum")]
 mod ethnum_support {
     use super::*;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -43,7 +43,7 @@ pub use hex_bytes::Bytes;
 pub use integer_list::IntegerList;
 pub use jsonu256::JsonU256;
 pub use log::Log;
-pub use net::{NodeRecord, Octets};
+pub use net::NodeRecord;
 pub use peer::{PeerId, WithPeerId};
 pub use receipt::Receipt;
 pub use storage::StorageEntry;


### PR DESCRIPTION
Solves: https://github.com/paradigmxyz/reth/issues/628

This PR adds RLP encoding support for _std_'s `IpAddr`, to replace `Octets` (recently moved to primitives). This is enabled only with the _std_ feature.