### PR TITLE
feat(net): enforce trusted_nodes_only setting

### DIFF
--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -761,9 +761,9 @@ impl PeerConnectionState {
 /// Represents the kind of peer
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
 enum PeerKind {
-    /// Non-trusted peer.
+    /// Basic peer kind.
     #[default]
-    NonTrusted,
+    Basic,
     /// Trusted peer.
     Trusted,
 }

--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -300,7 +300,7 @@ impl PeersManager {
             Entry::Occupied(mut entry) => {
                 self.connection_info.decr_state(entry.get().state);
 
-                if entry.get().remove_after_disconnect {
+                if entry.get().remove_after_disconnect && !entry.get().kind.is_trusted() {
                     // this peer should be removed from the set
                     entry.remove();
                     self.queued_actions.push_back(PeerAction::PeerRemoved(peer_id));


### PR DESCRIPTION
Solves: https://github.com/paradigmxyz/reth/issues/637

This PR enforces the `connect_trusted_nodes_only` setting, added in https://github.com/paradigmxyz/reth/pull/569