### PR TITLE
refactor: rename StateProvider structs

### DIFF
--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -16,7 +16,7 @@ use reth_executor::{
     Config,
 };
 use reth_primitives::{Address, Header, StorageEntry, TransactionSignedEcRecovered, H256, U256};
-use reth_provider::StateProviderImplRefLatest;
+use reth_provider::LatestStateProviderRef;
 use std::fmt::Debug;
 use tracing::*;
 
@@ -181,7 +181,7 @@ impl<DB: Database> Stage<DB> for ExecutionStage {
                 .collect();
 
             // for now use default eth config
-            let state_provider = SubState::new(State::new(StateProviderImplRefLatest::new(&**tx)));
+            let state_provider = SubState::new(State::new(LatestStateProviderRef::new(&**tx)));
 
             trace!(target: "sync::stages::execution", number = header.number, txs = recovered_transactions.len(), "Executing block");
 

--- a/crates/storage/provider/src/db_provider.rs
+++ b/crates/storage/provider/src/db_provider.rs
@@ -6,8 +6,8 @@ mod storage;
 use std::sync::Arc;
 
 pub use storage::{
-    StateProviderImplHistory, StateProviderImplLatest, StateProviderImplRefHistory,
-    StateProviderImplRefLatest,
+    HistoricalStateProvider, HistoricalStateProviderRef, LatestStateProvider,
+    LatestStateProviderRef,
 };
 
 use reth_db::database::Database;

--- a/crates/storage/provider/src/db_provider/storage.rs
+++ b/crates/storage/provider/src/db_provider/storage.rs
@@ -17,11 +17,11 @@ use reth_primitives::{
 use std::marker::PhantomData;
 
 impl<DB: Database> StateProviderFactory for ProviderImpl<DB> {
-    type HistorySP<'a> = StateProviderImplHistory<'a,<DB as DatabaseGAT<'a>>::TX> where Self: 'a;
-    type LatestSP<'a> = StateProviderImplLatest<'a,<DB as DatabaseGAT<'a>>::TX> where Self: 'a;
+    type HistorySP<'a> = HistoricalStateProvider<'a,<DB as DatabaseGAT<'a>>::TX> where Self: 'a;
+    type LatestSP<'a> = LatestStateProvider<'a,<DB as DatabaseGAT<'a>>::TX> where Self: 'a;
     /// Storage provider for latest block
     fn latest(&self) -> Result<Self::LatestSP<'_>> {
-        Ok(StateProviderImplLatest::new(self.db.tx()?))
+        Ok(LatestStateProvider::new(self.db.tx()?))
     }
 
     fn history_by_block_number(&self, block_number: BlockNumber) -> Result<Self::HistorySP<'_>> {
@@ -37,7 +37,7 @@ impl<DB: Database> StateProviderFactory for ProviderImpl<DB> {
             .get::<tables::BlockTransitionIndex>(block_num_hash.into())?
             .ok_or(Error::BlockTransition { block_number, block_hash })?;
 
-        Ok(StateProviderImplHistory::new(tx, transition))
+        Ok(HistoricalStateProvider::new(tx, transition))
     }
 
     fn history_by_block_hash(&self, block_hash: BlockHash) -> Result<Self::HistorySP<'_>> {
@@ -52,12 +52,12 @@ impl<DB: Database> StateProviderFactory for ProviderImpl<DB> {
             .get::<tables::BlockTransitionIndex>(block_num_hash.into())?
             .ok_or(Error::BlockTransition { block_number, block_hash })?;
 
-        Ok(StateProviderImplHistory::new(tx, transition))
+        Ok(HistoricalStateProvider::new(tx, transition))
     }
 }
 
 /// State provider for a given transition
-pub struct StateProviderImplHistory<'a, TX: DbTx<'a>> {
+pub struct HistoricalStateProvider<'a, TX: DbTx<'a>> {
     /// Database transaction
     tx: TX,
     /// Transition is main indexer of account and storage changes
@@ -66,36 +66,36 @@ pub struct StateProviderImplHistory<'a, TX: DbTx<'a>> {
     _phantom: PhantomData<&'a TX>,
 }
 
-impl<'a, TX: DbTx<'a>> StateProviderImplHistory<'a, TX> {
+impl<'a, TX: DbTx<'a>> HistoricalStateProvider<'a, TX> {
     /// Create new StateProvider from history transaction number
     pub fn new(tx: TX, transition: TransitionId) -> Self {
         Self { tx, transition, _phantom: PhantomData {} }
     }
 }
 
-impl<'a, TX: DbTx<'a>> AccountProvider for StateProviderImplHistory<'a, TX> {
+impl<'a, TX: DbTx<'a>> AccountProvider for HistoricalStateProvider<'a, TX> {
     /// Get basic account information.
     fn basic_account(&self, address: Address) -> Result<Option<Account>> {
-        StateProviderImplRefHistory::new(&self.tx, self.transition).basic_account(address)
+        HistoricalStateProviderRef::new(&self.tx, self.transition).basic_account(address)
     }
 }
 
-impl<'a, TX: DbTx<'a>> BlockHashProvider for StateProviderImplHistory<'a, TX> {
+impl<'a, TX: DbTx<'a>> BlockHashProvider for HistoricalStateProvider<'a, TX> {
     fn block_hash(&self, number: U256) -> Result<Option<H256>> {
-        StateProviderImplRefHistory::new(&self.tx, self.transition).block_hash(number)
+        HistoricalStateProviderRef::new(&self.tx, self.transition).block_hash(number)
     }
 }
 
-impl<'a, TX: DbTx<'a>> StateProvider for StateProviderImplHistory<'a, TX> {
+impl<'a, TX: DbTx<'a>> StateProvider for HistoricalStateProvider<'a, TX> {
     fn storage(&self, account: Address, storage_key: StorageKey) -> Result<Option<StorageValue>> {
-        StateProviderImplRefHistory::new(&self.tx, self.transition).storage(account, storage_key)
+        HistoricalStateProviderRef::new(&self.tx, self.transition).storage(account, storage_key)
     }
 
     fn bytecode_by_hash(&self, code_hash: H256) -> Result<Option<Bytes>> {
-        StateProviderImplRefHistory::new(&self.tx, self.transition).bytecode_by_hash(code_hash)
+        HistoricalStateProviderRef::new(&self.tx, self.transition).bytecode_by_hash(code_hash)
     }
 }
-/// State provider with given hash
+/// State provider for a given transition id which takes a tx reference.
 ///
 /// It will access:
 /// [tables::AccountHistory]
@@ -103,7 +103,7 @@ impl<'a, TX: DbTx<'a>> StateProvider for StateProviderImplHistory<'a, TX> {
 /// [tables::StorageHistory]
 /// [tables::AccountChangeSet]
 /// [tables::StorageChangeSet]
-pub struct StateProviderImplRefHistory<'a, 'b, TX: DbTx<'a>> {
+pub struct HistoricalStateProviderRef<'a, 'b, TX: DbTx<'a>> {
     /// Transaction
     tx: &'b TX,
     /// Transition is main indexer of account and storage changes
@@ -112,14 +112,14 @@ pub struct StateProviderImplRefHistory<'a, 'b, TX: DbTx<'a>> {
     _phantom: PhantomData<&'a TX>,
 }
 
-impl<'a, 'b, TX: DbTx<'a>> StateProviderImplRefHistory<'a, 'b, TX> {
+impl<'a, 'b, TX: DbTx<'a>> HistoricalStateProviderRef<'a, 'b, TX> {
     /// Create new StateProvider from history transaction number
     pub fn new(tx: &'b TX, transition: TransitionId) -> Self {
         Self { tx, transition, _phantom: PhantomData {} }
     }
 }
 
-impl<'a, 'b, TX: DbTx<'a>> AccountProvider for StateProviderImplRefHistory<'a, 'b, TX> {
+impl<'a, 'b, TX: DbTx<'a>> AccountProvider for HistoricalStateProviderRef<'a, 'b, TX> {
     /// Get basic account information.
     fn basic_account(&self, _address: Address) -> Result<Option<Account>> {
         // TODO add when AccountHistory is defined
@@ -127,14 +127,14 @@ impl<'a, 'b, TX: DbTx<'a>> AccountProvider for StateProviderImplRefHistory<'a, '
     }
 }
 
-impl<'a, 'b, TX: DbTx<'a>> BlockHashProvider for StateProviderImplRefHistory<'a, 'b, TX> {
+impl<'a, 'b, TX: DbTx<'a>> BlockHashProvider for HistoricalStateProviderRef<'a, 'b, TX> {
     /// Get block hash by number.
     fn block_hash(&self, number: U256) -> Result<Option<H256>> {
         self.tx.get::<tables::CanonicalHeaders>(number.as_u64()).map_err(Into::into)
     }
 }
 
-impl<'a, 'b, TX: DbTx<'a>> StateProvider for StateProviderImplRefHistory<'a, 'b, TX> {
+impl<'a, 'b, TX: DbTx<'a>> StateProvider for HistoricalStateProviderRef<'a, 'b, TX> {
     /// Get storage.
     fn storage(&self, account: Address, storage_key: StorageKey) -> Result<Option<StorageValue>> {
         // TODO when StorageHistory is defined
@@ -169,74 +169,74 @@ impl<'a, 'b, TX: DbTx<'a>> StateProvider for StateProviderImplRefHistory<'a, 'b,
     }
 }
 
-/// State provider for latests state
-pub struct StateProviderImplLatest<'a, TX: DbTx<'a>> {
+/// State provider for latest state
+pub struct LatestStateProvider<'a, TX: DbTx<'a>> {
     /// database transaction
     db: TX,
     /// Phantom lifetime `'a`
     _phantom: PhantomData<&'a TX>,
 }
 
-impl<'a, TX: DbTx<'a>> StateProviderImplLatest<'a, TX> {
+impl<'a, TX: DbTx<'a>> LatestStateProvider<'a, TX> {
     /// Create new state provider
     pub fn new(db: TX) -> Self {
         Self { db, _phantom: PhantomData {} }
     }
 }
 
-impl<'a, TX: DbTx<'a>> AccountProvider for StateProviderImplLatest<'a, TX> {
+impl<'a, TX: DbTx<'a>> AccountProvider for LatestStateProvider<'a, TX> {
     /// Get basic account information.
     fn basic_account(&self, address: Address) -> Result<Option<Account>> {
-        StateProviderImplRefLatest::new(&self.db).basic_account(address)
+        LatestStateProviderRef::new(&self.db).basic_account(address)
     }
 }
 
-impl<'a, TX: DbTx<'a>> BlockHashProvider for StateProviderImplLatest<'a, TX> {
+impl<'a, TX: DbTx<'a>> BlockHashProvider for LatestStateProvider<'a, TX> {
     fn block_hash(&self, number: U256) -> Result<Option<H256>> {
-        StateProviderImplRefLatest::new(&self.db).block_hash(number)
+        LatestStateProviderRef::new(&self.db).block_hash(number)
     }
 }
 
-impl<'a, TX: DbTx<'a>> StateProvider for StateProviderImplLatest<'a, TX> {
+impl<'a, TX: DbTx<'a>> StateProvider for LatestStateProvider<'a, TX> {
     fn storage(&self, account: Address, storage_key: StorageKey) -> Result<Option<StorageValue>> {
-        StateProviderImplRefLatest::new(&self.db).storage(account, storage_key)
+        LatestStateProviderRef::new(&self.db).storage(account, storage_key)
     }
 
     fn bytecode_by_hash(&self, code_hash: H256) -> Result<Option<Bytes>> {
-        StateProviderImplRefLatest::new(&self.db).bytecode_by_hash(code_hash)
+        LatestStateProviderRef::new(&self.db).bytecode_by_hash(code_hash)
     }
 }
 
 /// State Provider over latest state that takes tx reference
-pub struct StateProviderImplRefLatest<'a, 'b, TX: DbTx<'a>> {
+pub struct LatestStateProviderRef<'a, 'b, TX: DbTx<'a>> {
     /// database transaction
     db: &'b TX,
     /// Phantom data over lifetime
     phantom: PhantomData<&'a TX>,
 }
 
-impl<'a, 'b, TX: DbTx<'a>> StateProviderImplRefLatest<'a, 'b, TX> {
+impl<'a, 'b, TX: DbTx<'a>> LatestStateProviderRef<'a, 'b, TX> {
     /// Create new state provider
     pub fn new(db: &'b TX) -> Self {
         Self { db, phantom: PhantomData {} }
     }
 }
 
-impl<'a, 'b, TX: DbTx<'a>> AccountProvider for StateProviderImplRefLatest<'a, 'b, TX> {
+impl<'a, 'b, TX: DbTx<'a>> AccountProvider for LatestStateProviderRef<'a, 'b, TX> {
     /// Get basic account information.
     fn basic_account(&self, address: Address) -> Result<Option<Account>> {
         self.db.get::<tables::PlainAccountState>(address).map_err(Into::into)
     }
 }
 
-impl<'a, 'b, TX: DbTx<'a>> BlockHashProvider for StateProviderImplRefLatest<'a, 'b, TX> {
+impl<'a, 'b, TX: DbTx<'a>> BlockHashProvider for LatestStateProviderRef<'a, 'b, TX> {
     /// Get block hash by number.
     fn block_hash(&self, number: U256) -> Result<Option<H256>> {
         self.db.get::<tables::CanonicalHeaders>(number.as_u64()).map_err(Into::into)
     }
 }
 
-impl<'a, 'b, TX: DbTx<'a>> StateProvider for StateProviderImplRefLatest<'a, 'b, TX> {
+impl<'a, 'b, TX: DbTx<'a>> StateProvider for LatestStateProviderRef<'a, 'b, TX> {
     /// Get storage.
     fn storage(&self, account: Address, storage_key: StorageKey) -> Result<Option<StorageValue>> {
         let mut cursor = self.db.cursor_dup::<tables::PlainStorageState>()?;

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -20,8 +20,8 @@ pub use block::{
     insert_canonical_block, BlockHashProvider, BlockProvider, ChainInfo, HeaderProvider,
 };
 pub use db_provider::{
-    self as db, ProviderImpl, StateProviderImplHistory, StateProviderImplLatest,
-    StateProviderImplRefHistory, StateProviderImplRefLatest,
+    self as db, HistoricalStateProvider, HistoricalStateProviderRef, LatestStateProvider,
+    LatestStateProviderRef, ProviderImpl,
 };
 pub use reth_interfaces::provider::Error;
 pub use state::{AccountProvider, StateProvider, StateProviderFactory};


### PR DESCRIPTION
Made all StateProvider Impls have a consistent name.
`StateProviderImplHistory` -> `HistoricalStateProvider`
`StateProviderImplLatest` -> `LatestStateProvider`

`StateProviderImplRefHistory` -> `HistoricalStateProviderRef`
`StateProviderImplRefLatest` -> `LatestStateProviderRef`

Closes #639 