### PR TITLE
fix(discv4): ignore self-entry on neighbours response

### DIFF
--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -1116,6 +1116,9 @@ impl Discv4Service {
                     );
                     self.try_ping(closest, PingReason::Lookup(closest, ctx.clone()))
                 }
+                BucketEntry::SelfEntry => {
+                    // we received our own node entry
+                }
                 _ => self.find_node(&closest, ctx.clone()),
             }
         }


### PR DESCRIPTION
Closes #636

ignore the `SelfEntry` variant when handling node records received from other nodes. this will prevent us from sending packets to our own node.