### PR TITLE
meta: latest nightly for lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,9 +143,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2022-12-27
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
Closes #646. Issue was addressed in https://github.com/rust-lang/rust/pull/106248
Partial revert of #642 (except for CI checks which were migrated to stable in #640)