### PR TITLE
build: Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Use latest rust image as the builder base
+FROM rust:1.66.0-bullseye AS builder
+
+# Set the build profile to be release
+ARG BUILD_PROFILE=release
+ENV BUILD_PROFILE $BUILD_PROFILE
+
+# Update and install dependencies
+RUN apt-get update && apt-get -y upgrade && apt-get install -y libclang-dev pkg-config
+
+# Copy base folder into docker context
+COPY . reth
+
+# Build reth
+RUN cd reth && cargo build --all --profile release
+
+# Use ubuntu as the release image
+FROM ubuntu:22.04
+
+# Update dependencies and add ethereum ppa
+RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
+  libssl-dev \
+  ca-certificates \
+  gnupg2 \
+  software-properties-common && apt-key update \
+  && add-apt-repository -y ppa:ethereum/ethereum
+
+# Install Geth as it's a dependency for reth
+RUN apt-get update && apt-get install -y ethereum \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+# Copy the built reth binary from the previous stage
+COPY --from=builder /reth/target/release/reth /usr/local/bin/reth
+
+CMD ["/usr/local/bin/reth"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Use latest rust image as the builder base
+# Use rust image as the builder base
 FROM rust:1.66.0-bullseye AS builder
 
 # Set the build profile to be release

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,21 +14,10 @@ COPY . reth
 # Build reth
 RUN cd reth && cargo build --all --profile release
 
-# Use ubuntu as the release image
-FROM ubuntu:22.04
+# Use alpine as the release image
+FROM frolvlad/alpine-glibc
 
-# Update dependencies and add ethereum ppa
-RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
-  libssl-dev \
-  ca-certificates \
-  gnupg2 \
-  software-properties-common && apt-key update \
-  && add-apt-repository -y ppa:ethereum/ethereum
-
-# Install Geth as it's a dependency for reth
-RUN apt-get update && apt-get install -y ethereum \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache linux-headers
 
 # Copy the built reth binary from the previous stage
 COPY --from=builder /reth/target/release/reth /usr/local/bin/reth


### PR DESCRIPTION
# Describe the feature
This PR adds a dockerfile, allowing the user to build and use `reth` as a docker image. The dockerfile is accepts a `BUILD_PROFILE` as an argument, so passing `-e BUILD_PROFILE=release` or `-e BUILD_PROFILE=debug` during the `docker build` stage will allow the user to build with a different profile. The dockerfile is split into two steps, to allow for smaller release images. 

# Additional context
Docker images help users more easily try out `reth`. Its additionally easier to integrate into widespread deployment systems. 
