### PR TITLE
fix: bump request timeout

### DIFF
--- a/crates/net/network/src/session/config.rs
+++ b/crates/net/network/src/session/config.rs
@@ -3,8 +3,10 @@
 use crate::session::{Direction, ExceedsSessionLimit};
 use std::time::Duration;
 
-/// Default request timeout.
-pub const REQUEST_TIMEOUT: Duration = Duration::from_millis(500u64);
+/// Default request timeout for a single request.
+///
+/// This represents the time we wait for a response until we consider it timed out.
+pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// Configuration options when creating a [SessionManager](crate::session::SessionManager).
 pub struct SessionsConfig {


### PR DESCRIPTION
This increases the default request timeout to 20s, mirroring geth's rtt estimate:

https://github.com/ethereum/go-ethereum/blob/1c737e8b6da2b14111f8224ef3f385b1fe0cd8b9/p2p/msgrate/msgrate.go#L52

ref #689