### PR TITLE
feat: Stage tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3494,6 +3494,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shellexpand",
+ "strum",
  "thiserror",
  "tokio",
  "tracing",

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -47,3 +47,4 @@ clap = { version = "4.0", features = ["derive", "cargo"] }
 thiserror = "1.0"
 tokio = { version = "1.21", features = ["sync", "macros", "rt-multi-thread"] }
 futures = "0.3.25"
+strum = "0.24.1"

--- a/bin/reth/src/cli.rs
+++ b/bin/reth/src/cli.rs
@@ -1,12 +1,11 @@
 //! CLI definition and entrypoint to executable
 
-use clap::{ArgAction, Parser, Subcommand};
-use tracing_subscriber::util::SubscriberInitExt;
-
 use crate::{
-    db, node, test_eth_chain,
+    db, node, stage, test_eth_chain,
     util::reth_tracing::{self, TracingMode},
 };
+use clap::{ArgAction, Parser, Subcommand};
+use tracing_subscriber::util::SubscriberInitExt;
 
 /// main function that parses cli and runs command
 pub async fn run() -> eyre::Result<()> {
@@ -22,6 +21,7 @@ pub async fn run() -> eyre::Result<()> {
         Commands::Node(command) => command.execute().await,
         Commands::TestEthChain(command) => command.execute().await,
         Commands::Db(command) => command.execute().await,
+        Commands::Stage(command) => command.execute().await,
     }
 }
 
@@ -31,12 +31,15 @@ pub enum Commands {
     /// Start the node
     #[command(name = "node")]
     Node(node::Command),
-    /// Runs Ethereum blockchain tests
+    /// Run Ethereum blockchain tests
     #[command(name = "test-chain")]
     TestEthChain(test_eth_chain::Command),
-    /// DB Debugging utilities
+    /// Database debugging utilities
     #[command(name = "db")]
     Db(db::Command),
+    /// Run a single stage
+    #[command(name = "stage")]
+    Stage(stage::Command),
 }
 
 #[derive(Parser)]

--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -12,5 +12,6 @@ pub mod db;
 pub mod dirs;
 pub mod node;
 pub mod prometheus_exporter;
+pub mod stage;
 pub mod test_eth_chain;
 pub mod util;

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -5,22 +5,18 @@ use crate::{
     config::Config,
     dirs::{ConfigPath, DbPath},
     prometheus_exporter,
-    util::chainspec::{chain_spec_value_parser, ChainSpecification, Genesis},
+    util::{
+        chainspec::{chain_spec_value_parser, ChainSpecification},
+        init::{init_db, init_genesis},
+    },
 };
 use clap::{crate_version, Parser};
 use fdlimit::raise_fd_limit;
 use reth_consensus::BeaconConsensus;
-use reth_db::{
-    cursor::DbCursorRO,
-    database::Database,
-    mdbx::{Env, WriteMap},
-    tables,
-    transaction::{DbTx, DbTxMut},
-};
 use reth_downloaders::{bodies, headers};
 use reth_executor::Config as ExecutorConfig;
 use reth_interfaces::consensus::ForkchoiceState;
-use reth_primitives::{Account, Header, H256};
+use reth_primitives::H256;
 use reth_stages::{
     metrics::HeaderMetrics,
     stages::{
@@ -28,7 +24,7 @@ use reth_stages::{
         sender_recovery::SenderRecoveryStage, total_difficulty::TotalDifficultyStage,
     },
 };
-use std::{net::SocketAddr, path::Path, sync::Arc};
+use std::{net::SocketAddr, sync::Arc};
 use tracing::{debug, info};
 
 /// Start the client
@@ -169,52 +165,4 @@ impl Command {
         info!("Finishing up");
         Ok(())
     }
-}
-
-/// Opens up an existing database or creates a new one at the specified path.
-fn init_db<P: AsRef<Path>>(path: P) -> eyre::Result<Env<WriteMap>> {
-    std::fs::create_dir_all(path.as_ref())?;
-    let db = reth_db::mdbx::Env::<reth_db::mdbx::WriteMap>::open(
-        path.as_ref(),
-        reth_db::mdbx::EnvKind::RW,
-    )?;
-    db.create_tables()?;
-
-    Ok(db)
-}
-
-/// Write the genesis block if it has not already been written
-#[allow(clippy::field_reassign_with_default)]
-fn init_genesis<DB: Database>(db: Arc<DB>, genesis: Genesis) -> Result<H256, reth_db::Error> {
-    let tx = db.tx_mut()?;
-    if let Some((_, hash)) = tx.cursor::<tables::CanonicalHeaders>()?.first()? {
-        debug!("Genesis already written, skipping.");
-        return Ok(hash)
-    }
-    debug!("Writing genesis block.");
-
-    // Insert account state
-    for (address, account) in &genesis.alloc {
-        tx.put::<tables::PlainAccountState>(
-            *address,
-            Account {
-                nonce: account.nonce.unwrap_or_default(),
-                balance: account.balance,
-                bytecode_hash: None,
-            },
-        )?;
-    }
-
-    // Insert header
-    let header: Header = genesis.into();
-    let hash = header.hash_slow();
-    tx.put::<tables::CanonicalHeaders>(0, hash)?;
-    tx.put::<tables::HeaderNumbers>(hash, 0)?;
-    tx.put::<tables::BlockBodies>((0, hash).into(), Default::default())?;
-    tx.put::<tables::BlockTransitionIndex>((0, hash).into(), 0)?;
-    tx.put::<tables::HeaderTD>((0, hash).into(), header.difficulty.into())?;
-    tx.put::<tables::Headers>((0, hash).into(), header)?;
-
-    tx.commit()?;
-    Ok(hash)
 }

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -127,7 +127,7 @@ impl Command {
 
                 let mut stage = SenderRecoveryStage {
                     batch_size: config.stages.sender_recovery.batch_size,
-                    commit_threshold: config.stages.sender_recovery.commit_threshold,
+                    commit_threshold: self.to - self.from + 1,
                 };
 
                 // Unwind first

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -1,32 +1,138 @@
-//! Main db command
+//! Main `stage` command
 //!
-//! Database debugging tool
+//! Stage debugging tool
+use crate::{
+    config::Config,
+    dirs::{ConfigPath, DbPath},
+    prometheus_exporter,
+    util::{
+        chainspec::{chain_spec_value_parser, ChainSpecification, Genesis},
+        init::init_db,
+    },
+};
+use reth_db::{
+    database::Database,
+    mdbx::{Env, WriteMap},
+    transaction::{DbTx, DbTxMut},
+};
+use reth_executor::Config as ExecutorConfig;
+use reth_stages::{
+    metrics::HeaderMetrics, stages::sender_recovery::SenderRecoveryStage, ExecInput, Stage,
+    Transaction,
+};
 
 use clap::Parser;
-use std::path::Path;
+use serde::Deserialize;
+use std::net::SocketAddr;
+use strum::{AsRefStr, EnumString, EnumVariantNames};
+use tracing::*;
 
 /// `reth stage` command
 #[derive(Debug, Parser)]
 pub struct Command {
-    /// Path to database folder
-    #[arg(long, default_value = "~/.reth/db")]
-    db: String,
+    /// The path to the database folder.
+    ///
+    /// Defaults to the OS-specific data directory:
+    ///
+    /// - Linux: `$XDG_DATA_HOME/reth/db` or `$HOME/.local/share/reth/db`
+    /// - Windows: `{FOLDERID_RoamingAppData}/reth/db`
+    /// - macOS: `$HOME/Library/Application Support/reth/db`
+    #[arg(long, value_name = "PATH", verbatim_doc_comment, default_value_t)]
+    db: DbPath,
+
+    /// The path to the configuration file to use.
+    #[arg(long, value_name = "FILE", verbatim_doc_comment, default_value_t)]
+    config: ConfigPath,
+
+    /// The chain this node is running.
+    ///
+    /// Possible values are either a built-in chain or the path to a chain specification file.
+    ///
+    /// Built-in chains:
+    /// - mainnet
+    /// - goerli
+    /// - sepolia
+    #[arg(
+        long,
+        value_name = "CHAIN_OR_PATH",
+        verbatim_doc_comment,
+        default_value = "mainnet",
+        value_parser = chain_spec_value_parser
+    )]
+    chain: ChainSpecification,
+
+    /// Enable Prometheus metrics.
+    ///
+    /// The metrics will be served at the given interface and port.
+    #[clap(long, value_name = "SOCKET")]
+    metrics: Option<SocketAddr>,
 
     /// The name of the stage to run
-    stage: String,
+    #[arg(long, short)]
+    stage: StageEnum,
+
+    /// The height to start at
+    #[arg(long)]
+    from: u64,
+
+    /// The end of the stage
+    #[arg(long, short)]
+    to: u64,
+
+    /// Whether to unwind or run the stage forward
+    #[arg(long, short)]
+    unwind: bool,
+}
+
+#[derive(
+    Debug, Clone, Copy, Eq, PartialEq, AsRefStr, EnumVariantNames, EnumString, Deserialize,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "kebab-case")]
+enum StageEnum {
+    Headers,
+    Bodies,
+    Senders,
+    Execution,
 }
 
 impl Command {
     /// Execute `stage` command
     pub async fn execute(&self) -> eyre::Result<()> {
-        let path = shellexpand::full(&self.db)?.into_owned();
-        let expanded_db_path = Path::new(&path);
-        std::fs::create_dir_all(expanded_db_path)?;
+        // Raise the fd limit of the process.
+        // Does not do anything on windows.
+        fdlimit::raise_fd_limit();
 
-        let _db = reth_db::mdbx::Env::<reth_db::mdbx::WriteMap>::open(
-            expanded_db_path,
-            reth_db::mdbx::EnvKind::RW,
-        )?;
+        if let Some(listen_addr) = self.metrics {
+            info!("Starting metrics endpoint at {}", listen_addr);
+            prometheus_exporter::initialize(listen_addr)?;
+            HeaderMetrics::describe();
+        }
+
+        let config: Config = confy::load_path(&self.config).unwrap_or_default();
+        info!("reth {} starting stage {:?}", clap::crate_version!(), self.stage);
+
+        match self.stage {
+            StageEnum::Senders => {
+                let mut stage = SenderRecoveryStage {
+                    batch_size: config.stages.sender_recovery.batch_size,
+                    commit_threshold: config.stages.sender_recovery.commit_threshold,
+                };
+                let db = init_db(&self.db)?;
+                let id = Stage::<Env<WriteMap>>::id(&stage);
+                let progress = db.view(|tx| id.get_progress(tx))??.unwrap_or_default();
+
+                // TODO: Figure out how to set start/end block range to run
+                let input = ExecInput { previous_stage: None, stage_progress: None };
+
+                let mut tx = Transaction::new(&db)?;
+                stage.execute(&mut tx, input).await?;
+            }
+            StageEnum::Execution => {
+                // let stage = ExecutionStage { config: ExecutorConfig::new_ethereum() };
+            }
+            _ => {}
+        }
 
         Ok(())
     }

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -6,16 +6,10 @@ use crate::{
     dirs::{ConfigPath, DbPath},
     prometheus_exporter,
     util::{
-        chainspec::{chain_spec_value_parser, ChainSpecification, Genesis},
+        chainspec::{chain_spec_value_parser, ChainSpecification},
         init::init_db,
     },
 };
-use reth_db::{
-    database::Database,
-    mdbx::{Env, WriteMap},
-    transaction::{DbTx, DbTxMut},
-};
-use reth_executor::Config as ExecutorConfig;
 use reth_stages::{
     metrics::HeaderMetrics, stages::sender_recovery::SenderRecoveryStage, ExecInput, Stage,
     StageId, Transaction, UnwindInput,

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -1,0 +1,33 @@
+//! Main db command
+//!
+//! Database debugging tool
+
+use clap::Parser;
+use std::path::Path;
+
+/// `reth stage` command
+#[derive(Debug, Parser)]
+pub struct Command {
+    /// Path to database folder
+    #[arg(long, default_value = "~/.reth/db")]
+    db: String,
+
+    /// The name of the stage to run
+    stage: String,
+}
+
+impl Command {
+    /// Execute `stage` command
+    pub async fn execute(&self) -> eyre::Result<()> {
+        let path = shellexpand::full(&self.db)?.into_owned();
+        let expanded_db_path = Path::new(&path);
+        std::fs::create_dir_all(expanded_db_path)?;
+
+        let _db = reth_db::mdbx::Env::<reth_db::mdbx::WriteMap>::open(
+            expanded_db_path,
+            reth_db::mdbx::EnvKind::RW,
+        )?;
+
+        Ok(())
+    }
+}

--- a/bin/reth/src/util/init.rs
+++ b/bin/reth/src/util/init.rs
@@ -25,12 +25,14 @@ pub fn init_db<P: AsRef<Path>>(path: P) -> eyre::Result<Env<WriteMap>> {
 /// Write the genesis block if it has not already been written
 #[allow(clippy::field_reassign_with_default)]
 pub fn init_genesis<DB: Database>(db: Arc<DB>, genesis: Genesis) -> Result<H256, reth_db::Error> {
-    let tx = db.tx_mut()?;
+    let tx = db.tx()?;
     if let Some((_, hash)) = tx.cursor::<tables::CanonicalHeaders>()?.first()? {
         debug!("Genesis already written, skipping.");
         return Ok(hash)
     }
+    drop(tx);
     debug!("Writing genesis block.");
+    let tx = db.tx_mut()?;
 
     // Insert account state
     for (address, account) in &genesis.alloc {

--- a/bin/reth/src/util/init.rs
+++ b/bin/reth/src/util/init.rs
@@ -1,0 +1,59 @@
+use crate::util::chainspec::Genesis;
+use reth_db::{
+    cursor::DbCursorRO,
+    database::Database,
+    mdbx::{Env, WriteMap},
+    tables,
+    transaction::{DbTx, DbTxMut},
+};
+use reth_primitives::{Account, Header, H256};
+use std::{path::Path, sync::Arc};
+use tracing::debug;
+
+/// Opens up an existing database or creates a new one at the specified path.
+pub fn init_db<P: AsRef<Path>>(path: P) -> eyre::Result<Env<WriteMap>> {
+    std::fs::create_dir_all(path.as_ref())?;
+    let db = reth_db::mdbx::Env::<reth_db::mdbx::WriteMap>::open(
+        path.as_ref(),
+        reth_db::mdbx::EnvKind::RW,
+    )?;
+    db.create_tables()?;
+
+    Ok(db)
+}
+
+/// Write the genesis block if it has not already been written
+#[allow(clippy::field_reassign_with_default)]
+pub fn init_genesis<DB: Database>(db: Arc<DB>, genesis: Genesis) -> Result<H256, reth_db::Error> {
+    let tx = db.tx_mut()?;
+    if let Some((_, hash)) = tx.cursor::<tables::CanonicalHeaders>()?.first()? {
+        debug!("Genesis already written, skipping.");
+        return Ok(hash)
+    }
+    debug!("Writing genesis block.");
+
+    // Insert account state
+    for (address, account) in &genesis.alloc {
+        tx.put::<tables::PlainAccountState>(
+            *address,
+            Account {
+                nonce: account.nonce.unwrap_or_default(),
+                balance: account.balance,
+                bytecode_hash: None,
+            },
+        )?;
+    }
+
+    // Insert header
+    let header: Header = genesis.into();
+    let hash = header.hash_slow();
+    tx.put::<tables::CanonicalHeaders>(0, hash)?;
+    tx.put::<tables::HeaderNumbers>(hash, 0)?;
+    tx.put::<tables::BlockBodies>((0, hash).into(), Default::default())?;
+    tx.put::<tables::BlockTransitionIndex>((0, hash).into(), 0)?;
+    tx.put::<tables::HeaderTD>((0, hash).into(), header.difficulty.into())?;
+    tx.put::<tables::Headers>((0, hash).into(), header)?;
+
+    tx.commit()?;
+    Ok(hash)
+}

--- a/bin/reth/src/util/mod.rs
+++ b/bin/reth/src/util/mod.rs
@@ -8,6 +8,9 @@ use walkdir::{DirEntry, WalkDir};
 /// Utilities for parsing chainspecs
 pub mod chainspec;
 
+/// Utilities for initializing parts of the chain
+pub mod init;
+
 /// Finds all files in a directory with a given postfix.
 pub(crate) fn find_all_files_with_postfix(path: &Path, postfix: &str) -> Vec<PathBuf> {
     WalkDir::new(path)


### PR DESCRIPTION
Adds a `reth stage` command to run stages in isolation.

Stages will read the database at the specified path. Some stages may require pre-existing data, which is out of scope for this tool: it has to be acquired elsewhere.

The command uses the minimum number of flags possible to keep the maintenance burden low - specialized config for some stages will not be possible. At some point when we have node config, we should revisit and possibly load the config for stage-specific config as well.

