### PR TITLE
feat(download): dynamically adjust body request

### DIFF
--- a/crates/net/downloaders/src/bodies/concurrent.rs
+++ b/crates/net/downloaders/src/bodies/concurrent.rs
@@ -161,7 +161,7 @@ where
             if header.is_empty() {
                 results.push(BlockResponse::Empty(header));
             } else {
-                // The body must be preset since we requested headers for all non-empty
+                // The body must be present since we requested headers for all non-empty
                 // bodies at this point
                 let (peer_id, body) = bodies.next().expect("download logic failed");
 

--- a/crates/net/downloaders/src/bodies/concurrent.rs
+++ b/crates/net/downloaders/src/bodies/concurrent.rs
@@ -131,6 +131,8 @@ where
             return Ok(headers.into_iter().cloned().map(BlockResponse::Empty).collect())
         }
 
+        // The bodies size might exceed a max response size limit set by peer. We need to keep
+        // retrying until we finish downloading all of the requested bodies
         let mut responses = Vec::with_capacity(headers_with_txs_and_ommers.len());
         while responses.len() != headers_with_txs_and_ommers.len() {
             let request: Vec<_> =


### PR DESCRIPTION
When the bodies response exceeds a peer response limit size, we need to retry a current request with the remaining bodies to download. This PR allows dynamically adjusting the request to finish the download

close #717 