### PR TITLE
chore: fix typo in book

### DIFF
--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -11,6 +11,6 @@
 - [Logs](./fundamentals/logs.md)
 
 ## Monitoring
-- [Matrics](./monitoring/matrics.md)
+- [Metrics](./monitoring/metrics.md)
 
 ## [FAQ](./faq/README.md)

--- a/book/fundamentals/command-line_options.md
+++ b/book/fundamentals/command-line_options.md
@@ -2,8 +2,8 @@
 
 ## Command
 - **node:** Start Reth node
-- **test-chain:** Runs Ethereum blockchain tests
-- **db:** database Debugging utilities for troubleshoot and fix issues with database systems.
+- **test-chain:** Run Ethereum blockchain tests
+- **db:** Debugging utilities to troubleshoot and fix issues with database systems.
 
 ## Options
 - **-v, --verbose:** Use verbose output

--- a/book/monitoring/metrics.md
+++ b/book/monitoring/metrics.md
@@ -1,4 +1,4 @@
-# Matrics
+# Metrics
 Reth integrated with Prometheus allows users to measure various metrics to gain insight into the status and performance of a Reth node. For example, users can track the network status, transaction pool status, and other metrics to understand how the node is functioning.
 
 ## Stage Header


### PR DESCRIPTION
This PR renames _Matrics_ to _Metrics_, and rephrases some of the command line option descriptions.