### PR TITLE
ci: add project workflow

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -1,0 +1,19 @@
+name: project
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  add:
+    name: add issue/pr
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.4.0
+        with:
+          project-url: https://github.com/orgs/paradigmxyz/projects/1
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/paradigmxyz/projects/1
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_PROJECT_TOKEN }}


### PR DESCRIPTION
A workflow to add issues/PRs to the project automatically.

Requires that the `GITHUB_TOKEN` also has the `project` scope on top of whatever was needed for the CI workflow