### PR TITLE
fix(codec): fix `from_compact` for vector of types with `Bytes`

### DIFF
--- a/crates/storage/codecs/src/lib.rs
+++ b/crates/storage/codecs/src/lib.rs
@@ -104,7 +104,9 @@ where
             let mut element = T::default();
 
             let len = buf.get_u16();
-            (element, buf) = T::from_compact(buf, len as usize);
+
+            (element, _) = T::from_compact(&buf[..(len as usize)], len as usize);
+            buf.advance(len as usize);
 
             list.push(element);
         }
@@ -161,7 +163,9 @@ where
         }
 
         let len = buf.get_u16();
-        let (element, buf) = T::from_compact(buf, len as usize);
+
+        let (element, _) = T::from_compact(&buf[..(len as usize)], len as usize);
+        buf.advance(len as usize);
 
         (Some(element), buf)
     }

--- a/crates/storage/db/src/tables/models/blocks.rs
+++ b/crates/storage/db/src/tables/models/blocks.rs
@@ -128,6 +128,8 @@ impl_fixed_arbitrary!(BlockNumHash, 40);
 
 #[cfg(test)]
 mod test {
+    use crate::table::{Compress, Decompress};
+
     use super::*;
     use rand::{thread_rng, Rng};
 
@@ -154,5 +156,16 @@ mod test {
         thread_rng().fill(bytes.as_mut_slice());
         let key = BlockNumHash::arbitrary(&mut Unstructured::new(&bytes)).unwrap();
         assert_eq!(bytes, Encode::encode(key));
+    }
+
+    #[test]
+    fn test_ommer() {
+        let mut ommer = StoredBlockOmmers::default();
+        ommer.ommers.push(Header::default());
+        ommer.ommers.push(Header::default());
+        assert!(
+            ommer.clone() ==
+                StoredBlockOmmers::decompress::<Vec<_>>(ommer.compress().into()).unwrap()
+        );
     }
 }


### PR DESCRIPTION
should close #722

When we call `from_compact` for types which have `bytes::Bytes` as their [final field](https://github.com/paradigmxyz/reth/blob/e069248e781b6fb42fc2ec9746e90fe2e5cf50fe/crates/storage/codecs/src/lib.rs#L12-L18) (eg. `Headers`), we exhaust the given buffer on that field. Which is problematic if we're handling a `Vec` of them.


### solution
Since we know the total type length when using `Vec` or `Option`, just give out a `buf[..len]` and advance the `buf` after

The added test reproduces the same kind of issue, but since I'm having troubles getting blocks/headers, can't really try it out

It's my expectation that issues like this should be easily caught once `proptest` is in. 
