### PR TITLE
feat(node): allow config'ing trusted nodes from cli

### DIFF
--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -16,3 +16,23 @@ pub mod prometheus_exporter;
 pub mod stage;
 pub mod test_eth_chain;
 pub mod util;
+
+use clap::Parser;
+use reth_primitives::NodeRecord;
+
+#[derive(Debug, Parser)]
+/// Parameters for configuring the network more granularly via CLI
+struct NetworkOpts {
+    /// Disable the discovery service.
+    #[arg(short, long)]
+    disable_discovery: bool,
+
+    /// Target trusted peer enodes
+    /// --trusted-peers enode://abcd@192.168.0.1:30303
+    #[arg(long)]
+    trusted_peers: Vec<NodeRecord>,
+
+    /// Connect only to trusted peers
+    #[arg(long)]
+    trusted_only: bool,
+}

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -9,11 +9,11 @@ use crate::{
         chainspec::{chain_spec_value_parser, ChainSpecification},
         init::{init_db, init_genesis},
     },
+    NetworkOpts,
 };
 use reth_consensus::BeaconConsensus;
 use reth_downloaders::bodies::concurrent::ConcurrentDownloader;
 use reth_executor::Config as ExecutorConfig;
-use reth_primitives::NodeRecord;
 use reth_stages::{
     metrics::HeaderMetrics,
     stages::{bodies::BodyStage, execution::ExecutionStage, sender_recovery::SenderRecoveryStage},
@@ -99,22 +99,6 @@ enum StageEnum {
     Bodies,
     Senders,
     Execution,
-}
-
-#[derive(Debug, Parser)]
-struct NetworkOpts {
-    /// Disable the discovery service.
-    #[arg(short, long)]
-    disable_discovery: bool,
-
-    /// Target trusted peer enodes
-    /// --trusted-peers enode://abcd@192.168.0.1:30303
-    #[arg(long)]
-    trusted_peers: Vec<NodeRecord>,
-
-    /// Connect only to trusted peers
-    #[arg(long)]
-    trusted_only: bool,
 }
 
 impl Command {


### PR DESCRIPTION
As title, the `reth stage` command already did that, exposes it now in the `reth node` for adding reliable connections.