### PR TITLE
ci: don't add PRs to project

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -4,9 +4,6 @@ on:
   issues:
     types:
       - opened
-  pull_request:
-    types:
-      - opened
 
 jobs:
   add:


### PR DESCRIPTION
Adding PRs to the project for external contributors fail because of secret sandboxing. It is possible to work around it, but at the risk of leaking the secret, which is not desireable.

Instead, we should just not add PRs to the project board - if contributors use the GitHub keywords such as closes/close/fixes etc. the PR will be linked to the issue, which will show up on the project board.