### PR TITLE
refactor: clean up `StateFetcher::next_peer`

### DIFF
--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -104,7 +104,7 @@ impl StateFetcher {
 
     /// Returns the _next_ idle peer that's ready to accept a request.
     fn next_peer(&self) -> Option<&PeerId> {
-        self.peers.iter().find(|(_, peer)| peer.state.is_idle()).map(|(key, _)| key)
+        self.peers.iter().find_map(|(peer_id, peer)| peer.state.is_idle().then_some(peer_id))
     }
 
     /// Returns the next action to return

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -103,8 +103,8 @@ impl StateFetcher {
     }
 
     /// Returns the _next_ idle peer that's ready to accept a request.
-    fn next_peer(&mut self) -> Option<(&PeerId, &mut Peer)> {
-        self.peers.iter_mut().find(|(_, peer)| peer.state.is_idle())
+    fn next_peer(&self) -> Option<&PeerId> {
+        self.peers.iter().find(|(_, peer)| peer.state.is_idle()).map(|(key, _)| key)
     }
 
     /// Returns the next action to return
@@ -114,8 +114,8 @@ impl StateFetcher {
             return PollAction::NoRequests
         }
 
-        let peer_id = if let Some(peer) = self.next_peer() {
-            *peer.0
+        let peer_id = if let Some(peer_id) = self.next_peer() {
+            *peer_id
         } else {
             return PollAction::NoPeersAvailable
         };


### PR DESCRIPTION
The `&mut Peer` is unused, so we do not need to return it