### PR TITLE
fix: apply correct reputation dmg on bad msg

### DIFF
--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -703,7 +703,7 @@ where
                     this.swarm
                         .state_mut()
                         .peers_mut()
-                        .apply_reputation_change(&peer_id, ReputationChangeKind::FailedToConnect);
+                        .apply_reputation_change(&peer_id, ReputationChangeKind::BadMessage);
                     this.metrics.invalid_messages_received.increment(1);
                 }
             }


### PR DESCRIPTION
We were applying `ReputationChangeKind::FailedToConnect` to peers on bad messages - this reputation change is by default 3 times worse than the correct change of `ReputationChangeKind::BadMessage`