### PR TITLE
feat: rotate peers when fetching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3815,6 +3815,7 @@ dependencies = [
  "fnv",
  "futures",
  "hex",
+ "linked-hash-map",
  "linked_hash_set",
  "metrics",
  "parking_lot 0.12.1",

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -52,6 +52,7 @@ parking_lot = "0.12"
 async-trait = "0.1"
 bytes = "1.2"
 linked_hash_set = "0.1"
+linked-hash-map = "0.5.6"
 rand = "0.8"
 secp256k1 = { version = "0.24", features = [
     "global-context",


### PR DESCRIPTION
Uses a LinkedHashMap to maintain insertion order.
When a peer is fetched, it is moved to end of the map.
Closes #740 