### PR TITLE
fix(disc): use remote addr for NodeRecord on ping

### DIFF
--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -834,9 +834,9 @@ impl Discv4Service {
     fn on_ping(&mut self, ping: Ping, remote_addr: SocketAddr, remote_id: PeerId, hash: H256) {
         // update the record
         let record = NodeRecord {
-            address: ping.from.address,
+            address: remote_addr.ip(),
+            udp_port: remote_addr.port(),
             tcp_port: ping.from.tcp_port,
-            udp_port: ping.from.udp_port,
             id: remote_id,
         };
 


### PR DESCRIPTION
Fixes "Received own packet." issue that was caused because we relied on the ping's from field instead of using the SocketAddr we received the message from. the `from` info could be our own local address

see also https://github.com/ethereum/go-ethereum/blob/master/p2p/discover/v4_udp.go#L657-L666