### PR TITLE
feat(cli): add more convenient SocketAddr argument parsing

### DIFF
--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -8,6 +8,7 @@ use crate::{
     util::{
         chainspec::{chain_spec_value_parser, ChainSpecification},
         init::{init_db, init_genesis},
+        socketaddr_value_parser,
     },
     NetworkOpts,
 };
@@ -65,7 +66,7 @@ pub struct Command {
     /// Enable Prometheus metrics.
     ///
     /// The metrics will be served at the given interface and port.
-    #[clap(long, value_name = "SOCKET")]
+    #[arg(long, value_name = "SOCKET", value_parser = socketaddr_value_parser)]
     metrics: Option<SocketAddr>,
 
     /// Set the chain tip manually for testing purposes.


### PR DESCRIPTION
Closes: https://github.com/paradigmxyz/reth/issues/730
This PR adds custom parsing for the `metrics` CLI option. This enables domain name resolving, with a default of "localhost" in case of specifying only the port (both `:8080` and `8080` are translated to `localhost:8080`).