### PR TITLE
docs: add release checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,14 +172,6 @@ If a pull request appears to be abandoned or stalled, it is polite to first chec
 
 _Adapted from the [Foundry contributing guide][foundry-contributing]_.
 
-### Releasing
-
-Releases are automatically done by the release workflow when a tag is pushed, however, these steps still need to be taken:
-
-1. Ensure that the versions in the relevant `Cargo.toml` files are up-to-date.
-2. Update documentation links.
-3. Perform a final audit for breaking changes.
-
 [rust-coc]: https://github.com/rust-lang/rust/blob/master/CODE_OF_CONDUCT.md
 [coc-header]: #code-of-conduct
 [dev-tg]: https://t.me/paradigm_reth

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,3 +4,7 @@ This directory contains documentation for contributors.
 
 - [Repository and Project Structure](./repo)
 - [Design](./design)
+
+### Meta
+
+- [Releasing](./release.md)

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,35 @@
+## Releasing
+
+This document outlines how to cut a new release.
+
+### Checklist
+
+It is assumed that the commit that is being considered for release has been marked as stable, i.e. that there is an expectation of no major bugs.
+
+- [ ] Ensure *all* tests and lints pass
+- [ ] Changelog
+  - [ ] Ensure the changelog is up to date by going over https://github.com/paradigmxyz/reth/labels/M-changelog
+  - [ ] Move the "Unreleased" section in [CHANGELOG.md](./CHANGELOG.md) into a header with the new version, and add a link at the bottom of the changelog to compare the new version to HEAD.
+- [ ] Version bump
+  - [ ] Update the version in `Cargo.toml`
+- [ ] Commit the changes
+  - The message format should be `release: x.y.z`, substituting `x.y.z` for the semver.
+- [ ] Tag the new commit with `x.y.z`
+- [ ] Push the changes, including the tag
+
+After pushing the tag, CI will start building the release, bundling it, and publishing it to package managers and crates.io. (TBD)
+
+> **Note**
+> This is a work in progress. There are still some unknowns:
+>
+> - Should we require that the commit is signed?
+> - Should we publish crates to crates.io? Should each crate use the same version?
+>
+> Additionally, a workflow needs to be added that:
+>
+> - Builds the release (cross-platform)
+> - Runs *all* tests once more, even the long ones
+> - Bundles the release with any aux files (license, config, ...)
+> - Publishes the release to GitHub, brew, Dockerhub, Arch, ...
+> - Publishes crates to crates.io
+> - Creates a GitHub release, copying over the relevant section of the changelog


### PR DESCRIPTION
Adds a basic release checklist based on [the one I already use](https://github.com/onbjerg/ethers-flashbots/blob/master/RELEASE.md). There are still a number of unknowns, but I have chosen to defer that to later when we are a bit closer and have the bandwidth to set up infra etc.