### PR TITLE
eth/api: fix typo "the"

### DIFF
--- a/crates/net/rpc/src/eth/api/server.rs
+++ b/crates/net/rpc/src/eth/api/server.rs
@@ -1,5 +1,5 @@
 //! Implementation of the [`jsonrpsee`] generated [`reth_rpc_api::EthApiServer`] trait
-//! Handles RPC requests for he `eth_` namespace.
+//! Handles RPC requests for the `eth_` namespace.
 
 use crate::{eth::api::EthApi, result::ToRpcResult};
 use jsonrpsee::core::RpcResult as Result;


### PR DESCRIPTION
Signed-off-by: Gyuho Lee <gyuho.lee@avalabs.org>