### PR TITLE
refactor: move `HasRemoteAddr` trait to net-common

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3631,6 +3631,7 @@ dependencies = [
  "hmac",
  "pin-project",
  "rand 0.8.5",
+ "reth-net-common",
  "reth-primitives",
  "reth-rlp",
  "secp256k1 0.24.2",
@@ -3786,7 +3787,6 @@ name = "reth-net-common"
 version = "0.1.0"
 dependencies = [
  "pin-project",
- "reth-ecies",
  "reth-primitives",
  "tokio",
 ]

--- a/crates/net/common/Cargo.toml
+++ b/crates/net/common/Cargo.toml
@@ -11,7 +11,6 @@ Types shared across network code
 [dependencies]
 # reth
 reth-primitives = { path = "../../primitives" }
-reth-ecies = { path = "../ecies" }
 
 # async
 pin-project = "1.0"

--- a/crates/net/common/src/bandwidth_meter.rs
+++ b/crates/net/common/src/bandwidth_meter.rs
@@ -20,7 +20,6 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use reth_ecies::stream::HasRemoteAddr;
 use std::{
     convert::TryFrom as _,
     io,
@@ -36,6 +35,8 @@ use tokio::{
     io::{AsyncRead, AsyncWrite, ReadBuf},
     net::TcpStream,
 };
+
+use crate::stream::HasRemoteAddr;
 
 /// Meters bandwidth usage of streams
 #[derive(Debug)]

--- a/crates/net/common/src/lib.rs
+++ b/crates/net/common/src/lib.rs
@@ -9,3 +9,5 @@
 
 pub mod ban_list;
 pub mod bandwidth_meter;
+/// Traits related to tokio streams
+pub mod stream;

--- a/crates/net/common/src/stream.rs
+++ b/crates/net/common/src/stream.rs
@@ -1,0 +1,13 @@
+use std::net::SocketAddr;
+use tokio::net::TcpStream;
+/// This trait is for instrumenting a TCPStream with a socket addr
+pub trait HasRemoteAddr {
+    /// Maybe returns a [`SocketAddr`]
+    fn remote_addr(&self) -> Option<SocketAddr>;
+}
+
+impl HasRemoteAddr for TcpStream {
+    fn remote_addr(&self) -> Option<SocketAddr> {
+        self.peer_addr().ok()
+    }
+}

--- a/crates/net/ecies/Cargo.toml
+++ b/crates/net/ecies/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 [dependencies]
 reth-rlp = { path = "../../common/rlp", features = ["derive", "ethereum-types", "std"] }
 reth-primitives = { path = "../../primitives" }
+reth-net-common = { path = "../common" }
 
 futures = "0.3.24"
 thiserror = "1.0.37"


### PR DESCRIPTION
closes #762 