### PR TITLE
chore(deps): bump tokio 1.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5046,9 +5046,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.23.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
+checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
 dependencies = [
  "autocfg",
  "bytes",


### PR DESCRIPTION
bump tokio 

fixes new Advisory

https://github.com/tokio-rs/tokio/security/advisories/GHSA-7rrj-xr53-82p7