### PR TITLE
feat(cli): more reasonable log output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3560,6 +3560,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-appender",
  "tracing-futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3561,6 +3561,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-futures",
  "tracing-subscriber",
  "walkdir",
@@ -3578,6 +3579,8 @@ dependencies = [
  "serde_json",
  "shellexpand",
  "tracing",
+ "tracing-appender",
+ "tracing-journald",
  "tracing-subscriber",
  "walkdir",
 ]
@@ -5281,6 +5284,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
+dependencies = [
+ "crossbeam-channel",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5311,6 +5325,17 @@ dependencies = [
  "futures-task",
  "pin-project",
  "tracing",
+]
+
+[[package]]
+name = "tracing-journald"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba316a74e8fc3c3896a850dba2375928a9fa171b085ecddfc7c054d39970f3fd"
+dependencies = [
+ "libc",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -27,6 +27,7 @@ reth-cli-utils = { path = "../../crates/cli/utils" }
 tracing = "0.1"
 tracing-futures = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-appender = "0.2"
 
 # io
 fdlimit = "0.2.1"

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -48,6 +48,7 @@ eyre = "0.6.8"
 clap = { version = "4.0", features = ["derive", "cargo"] }
 thiserror = "1.0"
 tokio = { version = "1.21", features = ["sync", "macros", "rt-multi-thread"] }
+tokio-stream = "0.1"
 futures = "0.3.25"
 strum = "0.24.1"
 tempfile = { version = "3.3.0" }

--- a/bin/reth/src/cli.rs
+++ b/bin/reth/src/cli.rs
@@ -139,7 +139,7 @@ impl Verbosity {
                 _ => Level::TRACE,
             };
 
-            format!("reth={level}").parse().unwrap()
+            format!("reth::cli={level}").parse().unwrap()
         }
     }
 }

--- a/bin/reth/src/cli.rs
+++ b/bin/reth/src/cli.rs
@@ -14,7 +14,7 @@ use tracing_subscriber::{filter::Directive, registry::LookupSpan};
 pub async fn run() -> eyre::Result<()> {
     let opt = Cli::parse();
 
-    let (layer, guard) = opt.logs.layer();
+    let (layer, _guard) = opt.logs.layer();
     reth_tracing::init(vec![layer, reth_tracing::stdout(opt.verbosity.directive())]);
 
     match opt.command {
@@ -67,7 +67,7 @@ struct Cli {
 
 #[derive(Args)]
 #[command(next_help_heading = "Logging")]
-pub struct Logs {
+struct Logs {
     /// The path to put log files in.
     #[arg(
         long = "log.directory",

--- a/bin/reth/src/cli.rs
+++ b/bin/reth/src/cli.rs
@@ -51,7 +51,7 @@ pub enum Commands {
 }
 
 #[derive(Parser)]
-#[command(author, version="0.1", about="Reth binary", long_about = None)]
+#[command(author, version = "0.1", about = "Reth", long_about = None)]
 struct Cli {
     /// The command to run
     #[clap(subcommand)]
@@ -64,10 +64,10 @@ struct Cli {
     /// -vvv    Info
     /// -vvvv   Debug
     /// -vvvvv  Traces (warning: very verbose!)
-    #[clap(short, long, action = ArgAction::Count, global = true, default_value_t = 2, verbatim_doc_comment)]
+    #[clap(short, long, action = ArgAction::Count, global = true, default_value_t = 2, verbatim_doc_comment, help_heading = "Display")]
     verbosity: u8,
 
     /// Silence all log output.
-    #[clap(long, global = true)]
+    #[clap(long, global = true, help_heading = "Display")]
     silent: bool,
 }

--- a/bin/reth/src/cli.rs
+++ b/bin/reth/src/cli.rs
@@ -89,8 +89,6 @@ struct Logs {
 
 impl Logs {
     /// Builds a tracing layer from the current log options.
-    ///
-    /// TODO: journald vs log file
     fn layer<S>(&self) -> (BoxedLayer<S>, Option<tracing_appender::non_blocking::WorkerGuard>)
     where
         S: Subscriber,

--- a/bin/reth/src/cli.rs
+++ b/bin/reth/src/cli.rs
@@ -1,7 +1,7 @@
 //! CLI definition and entrypoint to executable
 use crate::{
     db,
-    dirs::{LogsDir, StandardPath},
+    dirs::{LogsDir, PlatformPath},
     node, p2p, stage, test_eth_chain,
     utils::{reth_tracing, reth_tracing::BoxedLayer},
 };
@@ -76,7 +76,7 @@ struct Logs {
         default_value_t,
         conflicts_with = "journald"
     )]
-    log_directory: StandardPath<LogsDir>,
+    log_directory: PlatformPath<LogsDir>,
 
     /// Log events to journald.
     #[arg(long = "log.journald", global = true, conflicts_with = "log_directory")]

--- a/bin/reth/src/cli.rs
+++ b/bin/reth/src/cli.rs
@@ -139,7 +139,7 @@ impl Verbosity {
                 _ => Level::TRACE,
             };
 
-            format!("reth={}", level).parse().unwrap()
+            format!("reth={level}").parse().unwrap()
         }
     }
 }

--- a/bin/reth/src/cli.rs
+++ b/bin/reth/src/cli.rs
@@ -12,7 +12,7 @@ pub async fn run() -> eyre::Result<()> {
     reth_tracing::build_subscriber(if opt.silent {
         TracingMode::Silent
     } else {
-        TracingMode::from(opt.verbose)
+        TracingMode::from(opt.verbosity)
     })
     .init();
 
@@ -57,11 +57,17 @@ struct Cli {
     #[clap(subcommand)]
     command: Commands,
 
-    /// Use verbose output
-    #[clap(short, long, action = ArgAction::Count, global = true)]
-    verbose: u8,
+    /// Set the minimum log level for stdout.
+    ///
+    /// -v      Errors
+    /// -vv     Warnings
+    /// -vvv    Info
+    /// -vvvv   Debug
+    /// -vvvvv  Traces (warning: very verbose!)
+    #[clap(short, long, action = ArgAction::Count, global = true, default_value_t = 2, verbatim_doc_comment)]
+    verbosity: u8,
 
-    /// Silence all output
+    /// Silence all log output.
     #[clap(long, global = true)]
     silent: bool,
 }

--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -96,6 +96,7 @@ impl Command {
                         let num_pages = leaf_pages + branch_pages + overflow_pages;
                         let table_size = page_size * num_pages;
                         info!(
+                            target: "reth::cli",
                             "Table {} has {} entries (total size: {} KB)",
                             table,
                             stats.entries(),
@@ -130,7 +131,7 @@ impl<'a, DB: Database> DbTool<'a, DB> {
 
     /// Seeds the database with some random data, only used for testing
     fn seed(&mut self, len: u64) -> Result<()> {
-        info!("Generating random block range from 0 to {len}");
+        info!(target: "reth::cli", "Generating random block range from 0 to {len}");
         let chain = random_block_range(0..len, Default::default(), 0..64);
 
         self.db.update(|tx| {
@@ -140,7 +141,7 @@ impl<'a, DB: Database> DbTool<'a, DB> {
             })
         })??;
 
-        info!("Database seeded with {len} blocks");
+        info!(target: "reth::cli", "Database seeded with {len} blocks");
         Ok(())
     }
 
@@ -153,7 +154,7 @@ impl<'a, DB: Database> DbTool<'a, DB> {
                         self.list_table::<tables::$table>($start, $len)?
                     },)*
                     _ => {
-                        tracing::error!("Unknown table.");
+                        tracing::error!(target: "reth::cli", "Unknown table.");
                         return Ok(())
                     }
                 }

--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -1,5 +1,5 @@
 //! Database debugging tool
-use crate::dirs::{DbPath, StandardPath};
+use crate::dirs::{DbPath, PlatformPath};
 use clap::{Parser, Subcommand};
 use eyre::{Result, WrapErr};
 use reth_db::{
@@ -24,7 +24,7 @@ pub struct Command {
     /// - Windows: `{FOLDERID_RoamingAppData}/reth/db`
     /// - macOS: `$HOME/Library/Application Support/reth/db`
     #[arg(long, value_name = "PATH", verbatim_doc_comment, default_value_t)]
-    db: StandardPath<DbPath>,
+    db: PlatformPath<DbPath>,
 
     #[clap(subcommand)]
     command: Subcommands,

--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -1,5 +1,5 @@
 //! Database debugging tool
-use crate::dirs::DbPath;
+use crate::dirs::{DbPath, StandardPath};
 use clap::{Parser, Subcommand};
 use eyre::{Result, WrapErr};
 use reth_db::{
@@ -24,7 +24,7 @@ pub struct Command {
     /// - Windows: `{FOLDERID_RoamingAppData}/reth/db`
     /// - macOS: `$HOME/Library/Application Support/reth/db`
     #[arg(long, value_name = "PATH", verbatim_doc_comment, default_value_t)]
-    db: DbPath,
+    db: StandardPath<DbPath>,
 
     #[clap(subcommand)]
     command: Subcommands,

--- a/bin/reth/src/dirs.rs
+++ b/bin/reth/src/dirs.rs
@@ -95,11 +95,16 @@ trait XdgPath {
 ///
 /// # Example
 ///
-/// ```rs
-/// let default: StandardPath<DbPath> = StandardPath::default();
-/// let custom = StandardPath::from_str("my/path/to/db").unwrap();
+/// ```
+/// use reth::dirs::{StandardPath, DbPath};
+/// use std::str::FromStr;
 ///
-/// println!("Default db path: {default}, custom db path: {custom}");
+/// // Resolves to the platform-specific database path
+/// let default: StandardPath<DbPath> = StandardPath::default();
+/// // Resolves to `$(pwd)/my/path/to/db`
+/// let custom: StandardPath<DbPath> = StandardPath::from_str("my/path/to/db").unwrap();
+///
+/// assert_ne!(default.as_ref(), custom.as_ref());
 /// ```
 #[derive(Clone, Debug)]
 pub struct StandardPath<D>(PathBuf, std::marker::PhantomData<D>);

--- a/bin/reth/src/dirs.rs
+++ b/bin/reth/src/dirs.rs
@@ -96,26 +96,26 @@ trait XdgPath {
 /// # Example
 ///
 /// ```
-/// use reth::dirs::{StandardPath, DbPath};
+/// use reth::dirs::{PlatformPath, DbPath};
 /// use std::str::FromStr;
 ///
 /// // Resolves to the platform-specific database path
-/// let default: StandardPath<DbPath> = StandardPath::default();
+/// let default: PlatformPath<DbPath> = PlatformPath::default();
 /// // Resolves to `$(pwd)/my/path/to/db`
-/// let custom: StandardPath<DbPath> = StandardPath::from_str("my/path/to/db").unwrap();
+/// let custom: PlatformPath<DbPath> = PlatformPath::from_str("my/path/to/db").unwrap();
 ///
 /// assert_ne!(default.as_ref(), custom.as_ref());
 /// ```
 #[derive(Clone, Debug)]
-pub struct StandardPath<D>(PathBuf, std::marker::PhantomData<D>);
+pub struct PlatformPath<D>(PathBuf, std::marker::PhantomData<D>);
 
-impl<D> Display for StandardPath<D> {
+impl<D> Display for PlatformPath<D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0.display())
     }
 }
 
-impl<D: XdgPath> Default for StandardPath<D> {
+impl<D: XdgPath> Default for PlatformPath<D> {
     fn default() -> Self {
         Self(
             D::resolve().expect("Could not resolve default path. Set one manually."),
@@ -124,7 +124,7 @@ impl<D: XdgPath> Default for StandardPath<D> {
     }
 }
 
-impl<D> FromStr for StandardPath<D> {
+impl<D> FromStr for PlatformPath<D> {
     type Err = shellexpand::LookupError<VarError>;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -132,7 +132,7 @@ impl<D> FromStr for StandardPath<D> {
     }
 }
 
-impl<D> AsRef<Path> for StandardPath<D> {
+impl<D> AsRef<Path> for PlatformPath<D> {
     fn as_ref(&self) -> &Path {
         self.0.as_path()
     }

--- a/bin/reth/src/dirs.rs
+++ b/bin/reth/src/dirs.rs
@@ -28,67 +28,103 @@ pub fn config_dir() -> Option<PathBuf> {
     dirs_next::config_dir().map(|root| root.join("reth"))
 }
 
-/// A wrapper type that either parses a user-given path for the reth database or defaults to an
-/// OS-specific path.
-#[derive(Clone, Debug)]
-pub struct DbPath(PathBuf);
+/// Returns the path to the reth cache directory.
+///
+/// Refer to [dirs_next::cache_dir] for cross-platform behavior.
+pub fn cache_dir() -> Option<PathBuf> {
+    dirs_next::cache_dir().map(|root| root.join("reth"))
+}
 
-impl Display for DbPath {
+/// Returns the path to the reth logs directory.
+///
+/// Refer to [dirs_next::cache_dir] for cross-platform behavior.
+pub fn logs_dir() -> Option<PathBuf> {
+    cache_dir().map(|root| root.join("logs"))
+}
+
+/// Returns the path to the reth database.
+///
+/// Refer to [dirs_next::data_dir] for cross-platform behavior.
+#[derive(Default, Debug, Clone)]
+pub struct DbPath;
+
+impl XdgPath for DbPath {
+    fn resolve() -> Option<PathBuf> {
+        database_path()
+    }
+}
+
+/// Returns the path to the default reth configuration file.
+///
+/// Refer to [dirs_next::config_dir] for cross-platform behavior.
+#[derive(Default, Debug, Clone)]
+pub struct ConfigPath;
+
+impl XdgPath for ConfigPath {
+    fn resolve() -> Option<PathBuf> {
+        config_dir().map(|p| p.join("reth.toml"))
+    }
+}
+
+/// Returns the path to the reth logs directory.
+///
+/// Refer to [dirs_next::cache_dir] for cross-platform behavior.
+#[derive(Default, Debug, Clone)]
+pub struct LogsDir;
+
+impl XdgPath for LogsDir {
+    fn resolve() -> Option<PathBuf> {
+        logs_dir()
+    }
+}
+
+/// A small helper trait for unit structs that represent a standard path following the XDG
+/// path specification.
+trait XdgPath {
+    fn resolve() -> Option<PathBuf>;
+}
+
+/// A wrapper type that either parses a user-given path or defaults to an
+/// OS-specific path.
+///
+/// The [FromStr] implementation supports shell expansions and common patterns such as `~` for the
+/// home directory.
+///
+/// # Example
+///
+/// ```rs
+/// let default: StandardPath<DbPath> = StandardPath::default();
+/// let custom = StandardPath::from_str("my/path/to/db").unwrap();
+///
+/// println!("Default db path: {default}, custom db path: {custom}");
+/// ```
+#[derive(Clone, Debug)]
+pub struct StandardPath<D>(PathBuf, std::marker::PhantomData<D>);
+
+impl<D> Display for StandardPath<D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0.display())
     }
 }
 
-impl Default for DbPath {
-    fn default() -> Self {
-        Self(database_path().expect("Could not determine default database path. Set one manually."))
-    }
-}
-
-impl FromStr for DbPath {
-    type Err = shellexpand::LookupError<VarError>;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self(parse_path(s)?))
-    }
-}
-
-impl AsRef<Path> for DbPath {
-    fn as_ref(&self) -> &Path {
-        self.0.as_path()
-    }
-}
-
-/// A wrapper type that either parses a user-given path for the reth config or defaults to an
-/// OS-specific path.
-#[derive(Clone, Debug)]
-pub struct ConfigPath(PathBuf);
-
-impl Display for ConfigPath {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0.display())
-    }
-}
-
-impl Default for ConfigPath {
+impl<D: XdgPath> Default for StandardPath<D> {
     fn default() -> Self {
         Self(
-            config_dir()
-                .expect("Could not determine default database path. Set one manually.")
-                .join("reth.toml"),
+            D::resolve().expect("Could not resolve default path. Set one manually."),
+            std::marker::PhantomData,
         )
     }
 }
 
-impl FromStr for ConfigPath {
+impl<D> FromStr for StandardPath<D> {
     type Err = shellexpand::LookupError<VarError>;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self(parse_path(s)?))
+        Ok(Self(parse_path(s)?, std::marker::PhantomData))
     }
 }
 
-impl AsRef<Path> for ConfigPath {
+impl<D> AsRef<Path> for StandardPath<D> {
     fn as_ref(&self) -> &Path {
         self.0.as_path()
     }

--- a/bin/reth/src/dirs.rs
+++ b/bin/reth/src/dirs.rs
@@ -46,6 +46,7 @@ pub fn logs_dir() -> Option<PathBuf> {
 ///
 /// Refer to [dirs_next::data_dir] for cross-platform behavior.
 #[derive(Default, Debug, Clone)]
+#[non_exhaustive]
 pub struct DbPath;
 
 impl XdgPath for DbPath {
@@ -58,6 +59,7 @@ impl XdgPath for DbPath {
 ///
 /// Refer to [dirs_next::config_dir] for cross-platform behavior.
 #[derive(Default, Debug, Clone)]
+#[non_exhaustive]
 pub struct ConfigPath;
 
 impl XdgPath for ConfigPath {
@@ -70,6 +72,7 @@ impl XdgPath for ConfigPath {
 ///
 /// Refer to [dirs_next::cache_dir] for cross-platform behavior.
 #[derive(Default, Debug, Clone)]
+#[non_exhaustive]
 pub struct LogsDir;
 
 impl XdgPath for LogsDir {

--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -15,13 +15,14 @@ pub mod p2p;
 pub mod prometheus_exporter;
 pub mod stage;
 pub mod test_eth_chain;
-
-use clap::Parser;
 pub use reth_cli_utils as utils;
+
+use clap::Args;
 use reth_primitives::NodeRecord;
 
-#[derive(Debug, Parser)]
 /// Parameters for configuring the network more granularly via CLI
+#[derive(Debug, Args)]
+#[command(next_help_heading = "Networking")]
 struct NetworkOpts {
     /// Disable the discovery service.
     #[arg(short, long)]

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -14,20 +14,25 @@ use crate::{
 };
 use clap::{crate_version, Parser};
 use fdlimit::raise_fd_limit;
+use futures::{stream::select as stream_select, Stream, StreamExt};
 use reth_consensus::BeaconConsensus;
 use reth_downloaders::{bodies, headers};
 use reth_executor::Config as ExecutorConfig;
 use reth_interfaces::consensus::ForkchoiceState;
-use reth_primitives::H256;
+use reth_network::NetworkEvent;
+use reth_primitives::{BlockNumber, H256};
 use reth_stages::{
     metrics::HeaderMetrics,
     stages::{
         bodies::BodyStage, execution::ExecutionStage, headers::HeaderStage,
         sender_recovery::SenderRecoveryStage, total_difficulty::TotalDifficultyStage,
     },
+    PipelineEvent, StageId,
 };
-use std::{net::SocketAddr, sync::Arc};
-use tracing::{debug, info};
+use std::{net::SocketAddr, sync::Arc, time::Duration};
+use tokio::select;
+use tokio_stream::wrappers::ReceiverStream;
+use tracing::{debug, info, warn};
 
 /// Start the node
 #[derive(Debug, Parser)]
@@ -95,14 +100,14 @@ impl Command {
             });
         }
 
-        info!("reth {} starting", crate_version!());
+        info!(target: "reth::cli", "reth {} starting", crate_version!());
 
-        info!("Opening database at {}", &self.db);
+        info!(target: "reth::cli", path = %self.db, "Opening database");
         let db = Arc::new(init_db(&self.db)?);
-        info!("Database open");
+        info!(target: "reth::cli", "Database opened");
 
         if let Some(listen_addr) = self.metrics {
-            info!("Starting metrics endpoint at {}", listen_addr);
+            info!(target: "reth::cli", addr = %listen_addr, "Starting metrics endpoint");
             prometheus_exporter::initialize(listen_addr)?;
             HeaderMetrics::describe();
         }
@@ -116,14 +121,18 @@ impl Command {
             .start_network()
             .await?;
 
-        info!(peer_id = ?network.peer_id(), local_addr = %network.local_addr(), "Started p2p networking");
+        let (sender, receiver) = tokio::sync::mpsc::channel(64);
+        tokio::spawn(handle_events(stream_select(
+            network.event_listener().map(Into::into),
+            ReceiverStream::new(receiver).map(Into::into),
+        )));
 
-        // TODO: Are most of these Arcs unnecessary? For example, fetch client is completely
-        // cloneable on its own
-        // TODO: Remove magic numbers
+        info!(target: "reth::cli", peer_id = %network.peer_id(), local_addr = %network.local_addr(), "Connected to P2P network");
+
         let fetch_client = Arc::new(network.fetch_client().await?);
         let mut pipeline = reth_stages::Pipeline::default()
             .with_sync_state_updater(network.clone())
+            .with_channel(sender)
             .push(HeaderStage {
                 downloader: headers::linear::LinearDownloadBuilder::default()
                     .batch_size(config.stages.headers.downloader_batch_size)
@@ -161,19 +170,102 @@ impl Command {
             });
 
         if let Some(tip) = self.tip {
-            debug!("Tip manually set: {}", tip);
+            debug!(target: "reth::cli", %tip, "Tip manually set");
             consensus.notify_fork_choice_state(ForkchoiceState {
                 head_block_hash: tip,
                 safe_block_hash: tip,
                 finalized_block_hash: tip,
             })?;
+        } else {
+            warn!(target: "reth::cli", "No tip specified. reth cannot communicate with consensus clients, so a tip must manually be provided for the online stages with --debug.tip <HASH>.");
         }
 
         // Run pipeline
-        info!("Starting pipeline");
+        info!(target: "reth::cli", "Starting sync pipeline");
         pipeline.run(db.clone()).await?;
 
-        info!("Finishing up");
+        info!(target: "reth::cli", "Finishing up");
         Ok(())
+    }
+}
+
+/// The current high-level state of the node.
+#[derive(Default)]
+struct NodeState {
+    /// The number of connected peers.
+    connected_peers: usize,
+    /// The stage currently being executed.
+    current_stage: Option<StageId>,
+    /// The current checkpoint of the executing stage.
+    current_checkpoint: BlockNumber,
+}
+
+/// A node event.
+enum NodeEvent {
+    /// A network event.
+    Network(NetworkEvent),
+    /// A sync pipeline event.
+    Pipeline(PipelineEvent),
+}
+
+impl From<NetworkEvent> for NodeEvent {
+    fn from(evt: NetworkEvent) -> NodeEvent {
+        NodeEvent::Network(evt)
+    }
+}
+
+impl From<PipelineEvent> for NodeEvent {
+    fn from(evt: PipelineEvent) -> NodeEvent {
+        NodeEvent::Pipeline(evt)
+    }
+}
+
+/// Displays relevant information to the user from components of the node, and periodically
+/// displays the high-level status of the node.
+async fn handle_events(mut events: impl Stream<Item = NodeEvent> + Unpin) {
+    let mut state = NodeState::default();
+
+    let mut interval = tokio::time::interval(Duration::from_secs(30));
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        select! {
+            Some(event) = events.next() => {
+                match event {
+                    NodeEvent::Network(NetworkEvent::SessionEstablished { peer_id, status, .. }) => {
+                        state.connected_peers += 1;
+                        info!(target: "reth::cli", connected_peers = state.connected_peers, peer_id = %peer_id, best_block = %status.blockhash, "Peer connected");
+                    },
+                    NodeEvent::Network(NetworkEvent::SessionClosed { peer_id, reason }) => {
+                        state.connected_peers -= 1;
+                        let reason = reason.map(|s| s.to_string()).unwrap_or("None".to_string());
+                        warn!(target: "reth::cli", connected_peers = state.connected_peers, peer_id = %peer_id, %reason, "Peer disconnected.");
+                    },
+                    NodeEvent::Pipeline(PipelineEvent::Running { stage_id, stage_progress }) => {
+                        let notable = state.current_stage.is_none();
+                        state.current_stage = Some(stage_id);
+                        state.current_checkpoint = stage_progress.unwrap_or_default();
+
+                        if notable {
+                            info!(target: "reth::cli", stage = %stage_id, from = stage_progress, "Executing stage");
+                        }
+                    },
+                    NodeEvent::Pipeline(PipelineEvent::Ran { stage_id, result }) => {
+                        let notable = result.stage_progress > state.current_checkpoint;
+                        state.current_checkpoint = result.stage_progress;
+                        if result.done {
+                            state.current_stage = None;
+                            info!(target: "reth::cli", stage = %stage_id, checkpoint = result.stage_progress, "Stage finished executing");
+                        } else if notable {
+                            info!(target: "reth::cli", stage = %stage_id, checkpoint = result.stage_progress, "Stage committed progress");
+                        }
+                    }
+                    _ => (),
+                }
+            },
+            _ = interval.tick() => {
+                let stage = state.current_stage.map(|id| id.to_string()).unwrap_or("None".to_string());
+                info!(target: "reth::cli", connected_peers = state.connected_peers, %stage, checkpoint = state.current_checkpoint, "Status");
+            }
+        }
     }
 }

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -3,7 +3,7 @@
 //! Starts the client
 use crate::{
     config::Config,
-    dirs::{ConfigPath, DbPath, StandardPath},
+    dirs::{ConfigPath, DbPath, PlatformPath},
     prometheus_exporter,
     utils::{
         chainspec::{chain_spec_value_parser, ChainSpecification},
@@ -34,7 +34,7 @@ use tracing::{debug, info};
 pub struct Command {
     /// The path to the configuration file to use.
     #[arg(long, value_name = "FILE", verbatim_doc_comment, default_value_t)]
-    config: StandardPath<ConfigPath>,
+    config: PlatformPath<ConfigPath>,
 
     /// The path to the database folder.
     ///
@@ -44,7 +44,7 @@ pub struct Command {
     /// - Windows: `{FOLDERID_RoamingAppData}/reth/db`
     /// - macOS: `$HOME/Library/Application Support/reth/db`
     #[arg(long, value_name = "PATH", verbatim_doc_comment, default_value_t)]
-    db: StandardPath<DbPath>,
+    db: PlatformPath<DbPath>,
 
     /// The chain this node is running.
     ///

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -28,9 +28,13 @@ use reth_stages::{
 use std::{net::SocketAddr, sync::Arc};
 use tracing::{debug, info};
 
-/// Start the client
+/// Start the node
 #[derive(Debug, Parser)]
 pub struct Command {
+    /// The path to the configuration file to use.
+    #[arg(long, value_name = "FILE", verbatim_doc_comment, default_value_t)]
+    config: ConfigPath,
+
     /// The path to the database folder.
     ///
     /// Defaults to the OS-specific data directory:
@@ -40,10 +44,6 @@ pub struct Command {
     /// - macOS: `$HOME/Library/Application Support/reth/db`
     #[arg(long, value_name = "PATH", verbatim_doc_comment, default_value_t)]
     db: DbPath,
-
-    /// The path to the configuration file to use.
-    #[arg(long, value_name = "FILE", verbatim_doc_comment, default_value_t)]
-    config: ConfigPath,
 
     /// The chain this node is running.
     ///
@@ -65,13 +65,13 @@ pub struct Command {
     /// Enable Prometheus metrics.
     ///
     /// The metrics will be served at the given interface and port.
-    #[arg(long, value_name = "SOCKET", value_parser = parse_socket_address)]
+    #[arg(long, value_name = "SOCKET", value_parser = parse_socket_address, help_heading = "Metrics")]
     metrics: Option<SocketAddr>,
 
     /// Set the chain tip manually for testing purposes.
     ///
     /// NOTE: This is a temporary flag
-    #[arg(long = "debug.tip")]
+    #[arg(long = "debug.tip", help_heading = "Debug")]
     tip: Option<H256>,
 
     #[clap(flatten)]

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -3,16 +3,17 @@
 //! Starts the client
 use crate::{
     config::Config,
-    dirs::{ConfigPath, DbPath},
-    prometheus_exporter, NetworkOpts,
+    dirs::{ConfigPath, DbPath, StandardPath},
+    prometheus_exporter,
+    utils::{
+        chainspec::{chain_spec_value_parser, ChainSpecification},
+        init::{init_db, init_genesis},
+        parse_socket_address,
+    },
+    NetworkOpts,
 };
 use clap::{crate_version, Parser};
 use fdlimit::raise_fd_limit;
-use reth_cli_utils::{
-    chainspec::{chain_spec_value_parser, ChainSpecification},
-    init::{init_db, init_genesis},
-    parse_socket_address,
-};
 use reth_consensus::BeaconConsensus;
 use reth_downloaders::{bodies, headers};
 use reth_executor::Config as ExecutorConfig;
@@ -33,7 +34,7 @@ use tracing::{debug, info};
 pub struct Command {
     /// The path to the configuration file to use.
     #[arg(long, value_name = "FILE", verbatim_doc_comment, default_value_t)]
-    config: ConfigPath,
+    config: StandardPath<ConfigPath>,
 
     /// The path to the database folder.
     ///
@@ -43,7 +44,7 @@ pub struct Command {
     /// - Windows: `{FOLDERID_RoamingAppData}/reth/db`
     /// - macOS: `$HOME/Library/Application Support/reth/db`
     #[arg(long, value_name = "PATH", verbatim_doc_comment, default_value_t)]
-    db: DbPath,
+    db: StandardPath<DbPath>,
 
     /// The chain this node is running.
     ///

--- a/bin/reth/src/p2p/mod.rs
+++ b/bin/reth/src/p2p/mod.rs
@@ -1,7 +1,7 @@
 //! P2P Debugging tool
 use crate::{
     config::Config,
-    dirs::{ConfigPath, StandardPath},
+    dirs::{ConfigPath, PlatformPath},
     utils::{
         chainspec::{chain_spec_value_parser, ChainSpecification},
         hash_or_num_value_parser,
@@ -23,7 +23,7 @@ use std::sync::Arc;
 pub struct Command {
     /// The path to the configuration file to use.
     #[arg(long, value_name = "FILE", verbatim_doc_comment, default_value_t)]
-    config: StandardPath<ConfigPath>,
+    config: PlatformPath<ConfigPath>,
 
     /// The chain this node is running.
     ///

--- a/bin/reth/src/p2p/mod.rs
+++ b/bin/reth/src/p2p/mod.rs
@@ -1,10 +1,14 @@
 //! P2P Debugging tool
+use crate::{
+    config::Config,
+    dirs::{ConfigPath, StandardPath},
+    utils::{
+        chainspec::{chain_spec_value_parser, ChainSpecification},
+        hash_or_num_value_parser,
+    },
+};
 use backon::{ConstantBackoff, Retryable};
 use clap::{Parser, Subcommand};
-use reth_cli_utils::{
-    chainspec::{chain_spec_value_parser, ChainSpecification},
-    hash_or_num_value_parser,
-};
 use reth_db::mdbx::{Env, EnvKind, WriteMap};
 use reth_interfaces::p2p::{
     bodies::client::BodiesClient,
@@ -14,14 +18,12 @@ use reth_network::FetchClient;
 use reth_primitives::{BlockHashOrNumber, Header, NodeRecord, SealedHeader};
 use std::sync::Arc;
 
-use crate::{config::Config, dirs::ConfigPath};
-
 /// `reth p2p` command
 #[derive(Debug, Parser)]
 pub struct Command {
     /// The path to the configuration file to use.
     #[arg(long, value_name = "FILE", verbatim_doc_comment, default_value_t)]
-    config: ConfigPath,
+    config: StandardPath<ConfigPath>,
 
     /// The chain this node is running.
     ///

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -3,12 +3,13 @@
 //! Stage debugging tool
 use crate::{
     config::Config,
-    dirs::{ConfigPath, DbPath},
-    prometheus_exporter, NetworkOpts,
-};
-use reth_cli_utils::{
-    chainspec::{chain_spec_value_parser, ChainSpecification},
-    init::{init_db, init_genesis},
+    dirs::{ConfigPath, DbPath, StandardPath},
+    prometheus_exporter,
+    utils::{
+        chainspec::{chain_spec_value_parser, ChainSpecification},
+        init::{init_db, init_genesis},
+    },
+    NetworkOpts,
 };
 use reth_consensus::BeaconConsensus;
 use reth_downloaders::bodies::concurrent::ConcurrentDownloader;
@@ -36,11 +37,11 @@ pub struct Command {
     /// - Windows: `{FOLDERID_RoamingAppData}/reth/db`
     /// - macOS: `$HOME/Library/Application Support/reth/db`
     #[arg(long, value_name = "PATH", verbatim_doc_comment, default_value_t)]
-    db: DbPath,
+    db: StandardPath<DbPath>,
 
     /// The path to the configuration file to use.
     #[arg(long, value_name = "FILE", verbatim_doc_comment, default_value_t)]
-    config: ConfigPath,
+    config: StandardPath<ConfigPath>,
 
     /// The chain this node is running.
     ///

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -3,7 +3,7 @@
 //! Stage debugging tool
 use crate::{
     config::Config,
-    dirs::{ConfigPath, DbPath, StandardPath},
+    dirs::{ConfigPath, DbPath, PlatformPath},
     prometheus_exporter,
     utils::{
         chainspec::{chain_spec_value_parser, ChainSpecification},
@@ -37,11 +37,11 @@ pub struct Command {
     /// - Windows: `{FOLDERID_RoamingAppData}/reth/db`
     /// - macOS: `$HOME/Library/Application Support/reth/db`
     #[arg(long, value_name = "PATH", verbatim_doc_comment, default_value_t)]
-    db: StandardPath<DbPath>,
+    db: PlatformPath<DbPath>,
 
     /// The path to the configuration file to use.
     #[arg(long, value_name = "FILE", verbatim_doc_comment, default_value_t)]
-    config: StandardPath<ConfigPath>,
+    config: PlatformPath<ConfigPath>,
 
     /// The chain this node is running.
     ///

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -109,13 +109,13 @@ impl Command {
         fdlimit::raise_fd_limit();
 
         if let Some(listen_addr) = self.metrics {
-            info!("Starting metrics endpoint at {}", listen_addr);
+            info!(target: "reth::cli", "Starting metrics endpoint at {}", listen_addr);
             prometheus_exporter::initialize(listen_addr)?;
             HeaderMetrics::describe();
         }
 
         let config: Config = confy::load_path(&self.config).unwrap_or_default();
-        info!("reth {} starting stage {:?}", clap::crate_version!(), self.stage);
+        info!(target: "reth::cli", "reth {} starting stage {:?}", clap::crate_version!(), self.stage);
 
         let input = ExecInput {
             previous_stage: Some((StageId("No Previous Stage"), self.to)),

--- a/bin/reth/src/test_eth_chain/mod.rs
+++ b/bin/reth/src/test_eth_chain/mod.rs
@@ -38,12 +38,12 @@ impl Command {
                 }
                 Err(error) => {
                     num_of_failed += 1;
-                    error!("Test {file:?} failed:\n {error}\n");
+                    error!(target: "reth::cli", "Test {file:?} failed:\n{error}");
                 }
             }
         }
 
-        info!("\nPASSED {num_of_passed}/{} tests\n", num_of_passed + num_of_failed);
+        info!(target: "reth::cli", "{num_of_passed}/{} tests passed\n", num_of_passed + num_of_failed);
 
         if num_of_failed != 0 {
             Err(eyre!("Failed {num_of_failed} tests"))

--- a/bin/reth/src/test_eth_chain/runner.rs
+++ b/bin/reth/src/test_eth_chain/runner.rs
@@ -21,7 +21,7 @@ use std::{
     ffi::OsStr,
     path::{Path, PathBuf},
 };
-use tracing::{debug, info};
+use tracing::{debug, info, trace};
 
 /// Tests are test edge cases that are not possible to happen on mainnet, so we are skipping them.
 pub fn should_skip(path: &Path) -> bool {
@@ -80,7 +80,7 @@ pub async fn run_test(path: PathBuf) -> eyre::Result<()> {
     if should_skip(path) {
         return Ok(())
     }
-    info!("Executing test from path: {path:?}");
+    info!(target: "reth::cli", ?path, "Running test suite");
 
     for (name, suite) in suites.0 {
         if matches!(
@@ -101,7 +101,7 @@ pub async fn run_test(path: PathBuf) -> eyre::Result<()> {
 
         let pre_state = suite.pre.0;
 
-        debug!("Executing {:?} spec: {:?}", name, suite.network);
+        debug!(target: "reth::cli", name, network = ?suite.network, "Running test");
 
         let spec_upgrades: SpecUpgrades = suite.network.into();
         // if paris aka merge is not activated we dont have block rewards;
@@ -139,7 +139,7 @@ pub async fn run_test(path: PathBuf) -> eyre::Result<()> {
                 tx.put::<tables::Bytecodes>(code_hash, account.code.to_vec())?;
             }
             account.storage.iter().try_for_each(|(k, v)| {
-                tracing::trace!("Update storage: {address} key:{:?} val:{:?}", k.0, v.0);
+                trace!(target: "reth::cli", ?address, key = ?k.0, value = ?v.0, "Update storage");
                 tx.put::<tables::PlainStorageState>(
                     address,
                     StorageEntry { key: H256::from_slice(&k.0.to_be_bytes::<32>()), value: v.0 },
@@ -164,7 +164,7 @@ pub async fn run_test(path: PathBuf) -> eyre::Result<()> {
                 map
             }))
         })??;
-        tracing::trace!("Pre state :{:?}", storage);
+        trace!(target: "reth::cli", ?storage, "Pre-state");
 
         // Initialize the execution stage
         // Hardcode the chain_id to Ethereum 1.
@@ -189,7 +189,7 @@ pub async fn run_test(path: PathBuf) -> eyre::Result<()> {
         // Validate post state
         match suite.post_state {
             Some(RootOrState::Root(root)) => {
-                info!("Post state is root: #{root:?}")
+                info!(target: "reth::cli", "Post-state root: #{root:?}")
             }
             Some(RootOrState::State(state)) => db.view(|tx| -> eyre::Result<()> {
                 let mut cursor = tx.cursor_dup::<tables::PlainStorageState>()?;
@@ -269,7 +269,7 @@ pub async fn run_test(path: PathBuf) -> eyre::Result<()> {
                 }
                 Ok(())
             })??,
-            None => info!("Post state is none"),
+            None => info!(target: "reth::cli", "No post-state"),
         }
     }
     Ok(())

--- a/crates/cli/utils/Cargo.toml
+++ b/crates/cli/utils/Cargo.toml
@@ -2,23 +2,25 @@
 name = "reth-cli-utils"
 version = "0.1.0"
 edition = "2021"
-license = "MIT"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/paradigmxyz/reth"
 readme = "README.md"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
+# Internal
 reth-primitives = { path = "../../primitives" }
 reth-consensus = { path = "../../consensus", features = ["serde"] }
 reth-db = {path = "../../storage/db", features = ["mdbx", "test-utils"] }
 
-
+# Serialiation
 serde = "1.0"
 serde_json = "1.0"
 eyre = "0.6.8"
 shellexpand = "2.1"
 walkdir = "2.3"
 
+# Tracing
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-appender = "0.2"
+tracing-journald = "0.3"

--- a/crates/cli/utils/src/lib.rs
+++ b/crates/cli/utils/src/lib.rs
@@ -74,65 +74,20 @@ pub fn parse_socket_address(value: &str) -> Result<SocketAddr, eyre::Error> {
 /// Tracing utility
 pub mod reth_tracing {
     use tracing::Subscriber;
-    use tracing_subscriber::{prelude::*, EnvFilter};
-
-    /// Tracing modes
-    pub enum TracingMode {
-        /// Enable all traces.
-        All,
-        /// Enable debug traces.
-        Debug,
-        /// Enable info traces.
-        Info,
-        /// Enable warn traces.
-        Warn,
-        /// Enable error traces.
-        Error,
-        /// Disable tracing.
-        Silent,
-    }
-
-    impl TracingMode {
-        fn into_env_filter(self) -> EnvFilter {
-            match self {
-                Self::All => EnvFilter::new("reth=trace"),
-                Self::Debug => EnvFilter::new("reth=debug"),
-                Self::Info => EnvFilter::new("reth=info"),
-                Self::Warn => EnvFilter::new("reth=warn"),
-                Self::Error => EnvFilter::new("reth=error"),
-                Self::Silent => EnvFilter::new(""),
-            }
-        }
-    }
-
-    impl From<u8> for TracingMode {
-        fn from(value: u8) -> Self {
-            match value {
-                0 => Self::Error,
-                1 => Self::Warn,
-                2 => Self::Info,
-                3 => Self::Debug,
-                _ => Self::All,
-            }
-        }
-    }
+    use tracing_subscriber::{filter::Directive, prelude::*, EnvFilter};
 
     /// Build subscriber
     // TODO: JSON/systemd support
-    pub fn build_subscriber(mods: TracingMode) -> impl Subscriber {
+    pub fn build_subscriber<T: Into<Directive>>(default_directive: T) -> impl Subscriber {
         // TODO: Auto-detect
-        let no_color = std::env::var("RUST_LOG_STYLE").map(|val| val == "never").unwrap_or(false);
+        let with_ansi = std::env::var("RUST_LOG_STYLE").map(|val| val != "never").unwrap_or(true);
         let with_target = std::env::var("RUST_LOG_TARGET").map(|val| val != "0").unwrap_or(false);
 
-        // Take env over config
-        let filter = if std::env::var(EnvFilter::DEFAULT_ENV).unwrap_or_default().is_empty() {
-            mods.into_env_filter()
-        } else {
-            EnvFilter::from_default_env()
-        };
+        let filter =
+            EnvFilter::builder().with_default_directive(default_directive.into()).from_env_lossy();
 
         tracing_subscriber::registry()
-            .with(tracing_subscriber::fmt::layer().with_ansi(!no_color).with_target(with_target))
+            .with(tracing_subscriber::fmt::layer().with_ansi(with_ansi).with_target(with_target))
             .with(filter)
     }
 }

--- a/crates/cli/utils/src/lib.rs
+++ b/crates/cli/utils/src/lib.rs
@@ -135,6 +135,9 @@ pub mod reth_tracing {
         (layer, guard)
     }
 
+    /// Builds a new tracing layer that writes events to journald.
+    ///
+    /// The events are filtered by `directive`.
     pub fn journald<S>(directive: impl Into<Directive>) -> std::io::Result<BoxedLayer<S>>
     where
         S: Subscriber,

--- a/crates/cli/utils/src/lib.rs
+++ b/crates/cli/utils/src/lib.rs
@@ -115,6 +115,9 @@ pub mod reth_tracing {
     /// Builds a new tracing layer that appends to a log file.
     ///
     /// The events are filtered by `directive`.
+    ///
+    /// The boxed layer and a guard is returned. When the guard is dropped the buffer for the log
+    /// file is immediately flushed to disk. Any events after the guard is dropped may be missed.
     pub fn file<S>(
         directive: impl Into<Directive>,
         dir: impl AsRef<Path>,
@@ -138,6 +141,8 @@ pub mod reth_tracing {
     /// Builds a new tracing layer that writes events to journald.
     ///
     /// The events are filtered by `directive`.
+    ///
+    /// If the layer cannot connect to journald for any reason this function will return an error.
     pub fn journald<S>(directive: impl Into<Directive>) -> std::io::Result<BoxedLayer<S>>
     where
         S: Subscriber,

--- a/crates/cli/utils/src/lib.rs
+++ b/crates/cli/utils/src/lib.rs
@@ -73,12 +73,31 @@ pub fn parse_socket_address(value: &str) -> Result<SocketAddr, eyre::Error> {
 
 /// Tracing utility
 pub mod reth_tracing {
+    use std::path::Path;
     use tracing::Subscriber;
-    use tracing_subscriber::{filter::Directive, prelude::*, EnvFilter};
+    use tracing_subscriber::{
+        filter::Directive, prelude::*, registry::LookupSpan, EnvFilter, Layer, Registry,
+    };
 
-    /// Build subscriber
-    // TODO: JSON/systemd support
-    pub fn build_subscriber<T: Into<Directive>>(default_directive: T) -> impl Subscriber {
+    /// A boxed tracing [Layer].
+    pub type BoxedLayer<S> = Box<dyn Layer<S> + Send + Sync>;
+
+    /// Initializes a new [Subscriber] based on the given layers.
+    pub fn init(layers: Vec<BoxedLayer<Registry>>) {
+        tracing_subscriber::registry().with(layers).init();
+    }
+
+    /// Builds a new tracing layer that writes to stdout.
+    ///
+    /// The events are filtered by `default_directive`, unless overriden by `RUST_LOG`.
+    ///
+    /// Colors can be disabled with `RUST_LOG_STYLE=never`, and event targets can be displayed with
+    /// `RUST_LOG_TARGET=1`.
+    pub fn stdout<S>(default_directive: impl Into<Directive>) -> BoxedLayer<S>
+    where
+        S: Subscriber,
+        for<'a> S: LookupSpan<'a>,
+    {
         // TODO: Auto-detect
         let with_ansi = std::env::var("RUST_LOG_STYLE").map(|val| val != "never").unwrap_or(true);
         let with_target = std::env::var("RUST_LOG_TARGET").map(|val| val != "0").unwrap_or(false);
@@ -86,9 +105,44 @@ pub mod reth_tracing {
         let filter =
             EnvFilter::builder().with_default_directive(default_directive.into()).from_env_lossy();
 
-        tracing_subscriber::registry()
-            .with(tracing_subscriber::fmt::layer().with_ansi(with_ansi).with_target(with_target))
-            .with(filter)
+        tracing_subscriber::fmt::layer()
+            .with_ansi(with_ansi)
+            .with_target(with_target)
+            .with_filter(filter)
+            .boxed()
+    }
+
+    /// Builds a new tracing layer that appends to a log file.
+    ///
+    /// The events are filtered by `directive`.
+    pub fn file<S>(
+        directive: impl Into<Directive>,
+        dir: impl AsRef<Path>,
+        file_name: impl AsRef<Path>,
+    ) -> (BoxedLayer<S>, tracing_appender::non_blocking::WorkerGuard)
+    where
+        S: Subscriber,
+        for<'a> S: LookupSpan<'a>,
+    {
+        let (writer, guard) =
+            tracing_appender::non_blocking(tracing_appender::rolling::never(dir, file_name));
+        let layer = tracing_subscriber::fmt::layer()
+            .with_ansi(false)
+            .with_writer(writer)
+            .with_filter(EnvFilter::default().add_directive(directive.into()))
+            .boxed();
+
+        (layer, guard)
+    }
+
+    pub fn journald<S>(directive: impl Into<Directive>) -> std::io::Result<BoxedLayer<S>>
+    where
+        S: Subscriber,
+        for<'a> S: LookupSpan<'a>,
+    {
+        Ok(tracing_journald::layer()?
+            .with_filter(EnvFilter::default().add_directive(directive.into()))
+            .boxed())
     }
 }
 


### PR DESCRIPTION
This PR does some refactoring of various things related to the CLI output, and adds some new features related to logs.

## Added

- [x] Adds help headings to `reth node` and `reth`
- [x] Added journald and file log support: simplified logs are outputted to stdout by default, while more verbose logs are outputted to a log file or journald.

## Changed

- [x] Renamed `--silent` to `--quiet` (while still aliasing `--silent`), and adds a `-q` short option.
- [x] Moves CLI-specific logs to a new target `reth::cli` to allow for more granular filtering. This target should be very high level as it is the primary target that will be displayed to the user.

## Refactored

- [x] Simplifies the verbosity to `EnvFilter` translation by providing better types for `-v` and `--silent`.

## Next up

In a series of follow up PRs I will consolidate the tracing/logging things in the CLI with our tracing crate. I will also think about some way for stages to report their status as they are running, e.g. `status.waiting("Waiting for headers")` or `status.progress(last_processed_block, target_block)` so we can give more info to the user in a standardized way.

Closes #424 