### PR TITLE
refactor: rename cursor functions

### DIFF
--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -180,7 +180,7 @@ impl<'a, DB: Database> DbTool<'a, DB> {
 
     fn list_table<T: Table>(&mut self, start: usize, len: usize) -> Result<()> {
         let data = self.db.view(|tx| {
-            let mut cursor = tx.cursor::<T>().expect("Was not able to obtain a cursor.");
+            let mut cursor = tx.cursor_read::<T>().expect("Was not able to obtain a cursor.");
 
             // TODO: Upstream this in the DB trait.
             let start_walker = cursor.current().transpose();

--- a/bin/reth/src/test_eth_chain/runner.rs
+++ b/bin/reth/src/test_eth_chain/runner.rs
@@ -153,7 +153,7 @@ pub async fn run_test(path: PathBuf) -> eyre::Result<()> {
         tx.commit()?;
 
         let storage = db.view(|tx| -> Result<_, DbError> {
-            let mut cursor = tx.cursor_dup::<tables::PlainStorageState>()?;
+            let mut cursor = tx.cursor_dup_read::<tables::PlainStorageState>()?;
             let walker = cursor.first()?.map(|first| cursor.walk(first.0)).transpose()?;
             Ok(walker.map(|mut walker| {
                 let mut map: HashMap<Address, HashMap<U256, U256>> = HashMap::new();
@@ -192,7 +192,7 @@ pub async fn run_test(path: PathBuf) -> eyre::Result<()> {
                 info!("Post state is root: #{root:?}")
             }
             Some(RootOrState::State(state)) => db.view(|tx| -> eyre::Result<()> {
-                let mut cursor = tx.cursor_dup::<tables::PlainStorageState>()?;
+                let mut cursor = tx.cursor_dup_read::<tables::PlainStorageState>()?;
                 let walker = cursor.first()?.map(|first| cursor.walk(first.0)).transpose()?;
                 let storage = walker.map(|mut walker| {
                     let mut map: HashMap<Address, HashMap<U256, U256>> = HashMap::new();

--- a/crates/cli/utils/src/init.rs
+++ b/crates/cli/utils/src/init.rs
@@ -26,7 +26,7 @@ pub fn init_db<P: AsRef<Path>>(path: P) -> eyre::Result<Env<WriteMap>> {
 #[allow(clippy::field_reassign_with_default)]
 pub fn init_genesis<DB: Database>(db: Arc<DB>, genesis: Genesis) -> Result<H256, reth_db::Error> {
     let tx = db.tx()?;
-    if let Some((_, hash)) = tx.cursor::<tables::CanonicalHeaders>()?.first()? {
+    if let Some((_, hash)) = tx.cursor_read::<tables::CanonicalHeaders>()?.first()? {
         debug!("Genesis already written, skipping.");
         return Ok(hash)
     }

--- a/crates/stages/src/db.rs
+++ b/crates/stages/src/db.rs
@@ -207,7 +207,7 @@ where
         T: Table,
         F: FnMut(T::Key) -> BlockNumber,
     {
-        let mut cursor = self.cursor_mut::<T>()?;
+        let mut cursor = self.cursor_write::<T>()?;
         let mut entry = cursor.last()?;
         while let Some((key, _)) = entry {
             if selector(key) <= block {
@@ -226,7 +226,7 @@ where
         T1: Table,
         T2: Table<Key = T1::Value>,
     {
-        let mut cursor = self.cursor_mut::<T1>()?;
+        let mut cursor = self.cursor_write::<T1>()?;
         let mut walker = cursor.walk(start_at)?;
         while let Some((_, value)) = walker.next().transpose()? {
             self.delete::<T2>(value, None)?;

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -91,17 +91,17 @@ impl<DB: Database> Stage<DB> for ExecutionStage {
         let last_block = input.stage_progress.unwrap_or_default();
 
         // Get next canonical block hashes to execute.
-        let mut canonicals = tx.cursor::<tables::CanonicalHeaders>()?;
+        let mut canonicals = tx.cursor_read::<tables::CanonicalHeaders>()?;
         // Get header with canonical hashes.
-        let mut headers = tx.cursor::<tables::Headers>()?;
+        let mut headers = tx.cursor_read::<tables::Headers>()?;
         // Get bodies with canonical hashes.
-        let mut bodies_cursor = tx.cursor::<tables::BlockBodies>()?;
+        let mut bodies_cursor = tx.cursor_read::<tables::BlockBodies>()?;
         // Get ommers with canonical hashes.
-        let mut ommers_cursor = tx.cursor::<tables::BlockOmmers>()?;
+        let mut ommers_cursor = tx.cursor_read::<tables::BlockOmmers>()?;
         // Get transaction of the block that we are executing.
-        let mut tx_cursor = tx.cursor::<tables::Transactions>()?;
+        let mut tx_cursor = tx.cursor_read::<tables::Transactions>()?;
         // Skip sender recovery and load signer from database.
-        let mut tx_sender = tx.cursor::<tables::TxSenders>()?;
+        let mut tx_sender = tx.cursor_read::<tables::TxSenders>()?;
 
         // get canonical blocks (num,hash)
         let canonical_batch = canonicals
@@ -294,8 +294,8 @@ impl<DB: Database> Stage<DB> for ExecutionStage {
         info!(target: "sync::stages::execution", to_block = input.unwind_to, "Unwinding");
 
         // Acquire changeset cursors
-        let mut account_changeset = tx.cursor_dup_mut::<tables::AccountChangeSet>()?;
-        let mut storage_changeset = tx.cursor_dup_mut::<tables::StorageChangeSet>()?;
+        let mut account_changeset = tx.cursor_dup_write::<tables::AccountChangeSet>()?;
+        let mut storage_changeset = tx.cursor_dup_write::<tables::StorageChangeSet>()?;
 
         let from_transition_rev = tx.get_block_transition_by_num(input.unwind_to)? + 1;
         let to_transition_rev = tx.get_block_transition_by_num(input.stage_progress)? + 1;

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -76,10 +76,10 @@ impl<DB: Database> Stage<DB> for SenderRecoveryStage {
         }
 
         // Acquire the cursor for inserting elements
-        let mut senders_cursor = tx.cursor_mut::<tables::TxSenders>()?;
+        let mut senders_cursor = tx.cursor_write::<tables::TxSenders>()?;
 
         // Acquire the cursor over the transactions
-        let mut tx_cursor = tx.cursor::<tables::Transactions>()?;
+        let mut tx_cursor = tx.cursor_read::<tables::Transactions>()?;
         // Walk the transactions from start to end index (inclusive)
         let entries = tx_cursor
             .walk(start_tx_index)?
@@ -278,7 +278,7 @@ mod tests {
                     }
 
                     let start_hash = tx.get::<tables::CanonicalHeaders>(start_block)?.unwrap();
-                    let mut body_cursor = tx.cursor::<tables::BlockBodies>()?;
+                    let mut body_cursor = tx.cursor_read::<tables::BlockBodies>()?;
                     body_cursor.seek_exact((start_block, start_hash).into())?;
 
                     while let Some((_, body)) = body_cursor.next()? {

--- a/crates/stages/src/test_utils/test_db.rs
+++ b/crates/stages/src/test_utils/test_db.rs
@@ -63,7 +63,7 @@ impl TestTransaction {
     /// Check if the table is empty
     pub(crate) fn table_is_empty<T: Table>(&self) -> Result<bool, DbError> {
         self.query(|tx| {
-            let last = tx.cursor::<T>()?.last()?;
+            let last = tx.cursor_read::<T>()?.last()?;
             Ok(last.is_none())
         })
     }
@@ -112,7 +112,7 @@ impl TestTransaction {
         F: FnMut(&Option<<T as Table>::Value>, &S) -> (T::Key, T::Value),
     {
         self.commit(|tx| {
-            let mut cursor = tx.cursor_mut::<T>()?;
+            let mut cursor = tx.cursor_write::<T>()?;
             let mut last = cursor.last()?.map(|(_, v)| v);
             values.iter().try_for_each(|src| {
                 let (k, v) = transform(&last, src);
@@ -134,7 +134,7 @@ impl TestTransaction {
         F: FnMut(T::Key) -> BlockNumber,
     {
         self.query(|tx| {
-            let mut cursor = tx.cursor::<T>()?;
+            let mut cursor = tx.cursor_read::<T>()?;
             if let Some((key, _)) = cursor.last()? {
                 assert!(selector(key) <= num);
             }
@@ -154,7 +154,7 @@ impl TestTransaction {
         F: FnMut(T::Value) -> BlockNumber,
     {
         self.query(|tx| {
-            let mut cursor = tx.cursor::<T>()?;
+            let mut cursor = tx.cursor_read::<T>()?;
             let mut entry = cursor.last()?;
             while let Some((_, value)) = entry {
                 assert!(selector(value) <= num);

--- a/crates/storage/db/src/abstraction/mock.rs
+++ b/crates/storage/db/src/abstraction/mock.rs
@@ -60,11 +60,11 @@ impl<'a> DbTx<'a> for TxMock {
         todo!()
     }
 
-    fn cursor<T: Table>(&self) -> Result<<Self as DbTxGAT<'_>>::Cursor<T>, Error> {
+    fn cursor_read<T: Table>(&self) -> Result<<Self as DbTxGAT<'_>>::Cursor<T>, Error> {
         todo!()
     }
 
-    fn cursor_dup<T: DupSort>(&self) -> Result<<Self as DbTxGAT<'_>>::DupCursor<T>, Error> {
+    fn cursor_dup_read<T: DupSort>(&self) -> Result<<Self as DbTxGAT<'_>>::DupCursor<T>, Error> {
         todo!()
     }
 }
@@ -78,11 +78,11 @@ impl<'a> DbTxMut<'a> for TxMock {
         todo!()
     }
 
-    fn cursor_mut<T: Table>(&self) -> Result<<Self as DbTxMutGAT<'_>>::CursorMut<T>, Error> {
+    fn cursor_write<T: Table>(&self) -> Result<<Self as DbTxMutGAT<'_>>::CursorMut<T>, Error> {
         todo!()
     }
 
-    fn cursor_dup_mut<T: DupSort>(
+    fn cursor_dup_write<T: DupSort>(
         &self,
     ) -> Result<<Self as DbTxMutGAT<'_>>::DupCursorMut<T>, Error> {
         todo!()

--- a/crates/storage/db/src/abstraction/transaction.rs
+++ b/crates/storage/db/src/abstraction/transaction.rs
@@ -40,9 +40,9 @@ pub trait DbTx<'tx>: for<'a> DbTxGAT<'a> {
     /// freeing of memory pages
     fn commit(self) -> Result<bool, Error>;
     /// Iterate over read only values in table.
-    fn cursor<T: Table>(&self) -> Result<<Self as DbTxGAT<'_>>::Cursor<T>, Error>;
+    fn cursor_read<T: Table>(&self) -> Result<<Self as DbTxGAT<'_>>::Cursor<T>, Error>;
     /// Iterate over read only values in dup sorted table.
-    fn cursor_dup<T: DupSort>(&self) -> Result<<Self as DbTxGAT<'_>>::DupCursor<T>, Error>;
+    fn cursor_dup_read<T: DupSort>(&self) -> Result<<Self as DbTxGAT<'_>>::DupCursor<T>, Error>;
 }
 
 /// Read write transaction that allows writing to database
@@ -54,9 +54,9 @@ pub trait DbTxMut<'tx>: for<'a> DbTxMutGAT<'a> {
     /// Clears database.
     fn clear<T: Table>(&self) -> Result<(), Error>;
     /// Cursor mut
-    fn cursor_mut<T: Table>(&self) -> Result<<Self as DbTxMutGAT<'_>>::CursorMut<T>, Error>;
+    fn cursor_write<T: Table>(&self) -> Result<<Self as DbTxMutGAT<'_>>::CursorMut<T>, Error>;
     /// DupCursor mut.
-    fn cursor_dup_mut<T: DupSort>(
+    fn cursor_dup_write<T: DupSort>(
         &self,
     ) -> Result<<Self as DbTxMutGAT<'_>>::DupCursorMut<T>, Error>;
 }

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -202,7 +202,7 @@ mod tests {
 
         // Cursor
         let tx = env.tx().expect(ERROR_INIT_TX);
-        let mut cursor = tx.cursor::<Headers>().unwrap();
+        let mut cursor = tx.cursor_read::<Headers>().unwrap();
 
         let first = cursor.first().unwrap();
         assert!(first.is_some(), "First should be our put");
@@ -228,7 +228,7 @@ mod tests {
         // Cursor
         let missing_key = 2;
         let tx = db.tx().expect(ERROR_INIT_TX);
-        let mut cursor = tx.cursor::<CanonicalHeaders>().unwrap();
+        let mut cursor = tx.cursor_read::<CanonicalHeaders>().unwrap();
         assert_eq!(cursor.current(), Ok(None));
 
         // Seek exact
@@ -255,7 +255,7 @@ mod tests {
 
         let key_to_insert = 2;
         let tx = db.tx_mut().expect(ERROR_INIT_TX);
-        let mut cursor = tx.cursor_mut::<CanonicalHeaders>().unwrap();
+        let mut cursor = tx.cursor_write::<CanonicalHeaders>().unwrap();
 
         // INSERT
         cursor.seek_exact(1).unwrap();
@@ -282,7 +282,7 @@ mod tests {
         // APPEND
         let key_to_append = 2;
         let tx = db.tx_mut().expect(ERROR_INIT_TX);
-        let mut cursor = tx.cursor_mut::<CanonicalHeaders>().unwrap();
+        let mut cursor = tx.cursor_write::<CanonicalHeaders>().unwrap();
         cursor.seek_exact(1).unwrap();
         assert_eq!(cursor.append(key_to_append, H256::zero()), Err(Error::Write(4294936878)));
         assert_eq!(cursor.current(), Ok(Some((5, H256::zero())))); // the end of table
@@ -344,7 +344,7 @@ mod tests {
         // Iterate with cursor
         {
             let tx = env.tx().expect(ERROR_INIT_TX);
-            let mut cursor = tx.cursor_dup::<PlainStorageState>().unwrap();
+            let mut cursor = tx.cursor_dup_read::<PlainStorageState>().unwrap();
 
             // Notice that value11 and value22 have been ordered in the DB.
             assert!(Some(value00) == cursor.next_dup_val().unwrap());
@@ -355,7 +355,7 @@ mod tests {
         // Seek value with exact subkey
         {
             let tx = env.tx().expect(ERROR_INIT_TX);
-            let mut cursor = tx.cursor_dup::<PlainStorageState>().unwrap();
+            let mut cursor = tx.cursor_dup_read::<PlainStorageState>().unwrap();
             let mut walker = cursor.walk_dup(key, H256::from_low_u64_be(1)).unwrap();
             assert_eq!(
                 (key, value11),
@@ -393,7 +393,7 @@ mod tests {
         // Iterate with walk_dup
         {
             let tx = env.tx().expect(ERROR_INIT_TX);
-            let mut cursor = tx.cursor_dup::<PlainStorageState>().unwrap();
+            let mut cursor = tx.cursor_dup_read::<PlainStorageState>().unwrap();
             let first = cursor.first().unwrap().unwrap();
             let mut walker = cursor.walk_dup(first.0, first.1.key).unwrap();
 
@@ -408,7 +408,7 @@ mod tests {
         // Iterate by using `walk`
         {
             let tx = env.tx().expect(ERROR_INIT_TX);
-            let mut cursor = tx.cursor_dup::<PlainStorageState>().unwrap();
+            let mut cursor = tx.cursor_dup_read::<PlainStorageState>().unwrap();
             let first = cursor.first().unwrap().unwrap();
             let mut walker = cursor.walk(first.0).unwrap();
             assert_eq!(Some(Ok((key1, value00))), walker.next());
@@ -436,7 +436,7 @@ mod tests {
         // Iterate with walk
         {
             let tx = env.tx().expect(ERROR_INIT_TX);
-            let mut cursor = tx.cursor_dup::<PlainStorageState>().unwrap();
+            let mut cursor = tx.cursor_dup_read::<PlainStorageState>().unwrap();
             let first = cursor.first().unwrap().unwrap();
             let mut walker = cursor.walk(first.0).unwrap();
 
@@ -449,7 +449,7 @@ mod tests {
         // seek_by_key_subkey
         {
             let tx = env.tx().expect(ERROR_INIT_TX);
-            let mut cursor = tx.cursor_dup::<PlainStorageState>().unwrap();
+            let mut cursor = tx.cursor_dup_read::<PlainStorageState>().unwrap();
 
             // NOTE: There are two values with same SubKey but only first one is shown
             assert_eq!(Ok(Some(value00.clone())), cursor.seek_by_key_subkey(key1, value00.key));
@@ -471,7 +471,7 @@ mod tests {
         // Seek value with non existing key.
         {
             let tx = db.tx().expect(ERROR_INIT_TX);
-            let mut cursor = tx.cursor::<AccountHistory>().unwrap();
+            let mut cursor = tx.cursor_read::<AccountHistory>().unwrap();
 
             // It will seek the one greater or equal to the query. Since we have `Address | 100`,
             // `Address | 200` in the database and we're querying `Address | 150` it will return us

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -58,12 +58,12 @@ impl<'a, K: TransactionKind, E: EnvironmentKind> DbTxMutGAT<'a> for Tx<'_, K, E>
 
 impl<'tx, K: TransactionKind, E: EnvironmentKind> DbTx<'tx> for Tx<'tx, K, E> {
     // Iterate over read only values in database.
-    fn cursor<T: Table>(&self) -> Result<<Self as DbTxGAT<'_>>::Cursor<T>, Error> {
+    fn cursor_read<T: Table>(&self) -> Result<<Self as DbTxGAT<'_>>::Cursor<T>, Error> {
         self.new_cursor()
     }
 
     /// Iterate over read only values in database.
-    fn cursor_dup<T: DupSort>(&self) -> Result<<Self as DbTxGAT<'_>>::DupCursor<T>, Error> {
+    fn cursor_dup_read<T: DupSort>(&self) -> Result<<Self as DbTxGAT<'_>>::DupCursor<T>, Error> {
         self.new_cursor()
     }
 
@@ -120,11 +120,11 @@ impl<E: EnvironmentKind> DbTxMut<'_> for Tx<'_, RW, E> {
         Ok(())
     }
 
-    fn cursor_mut<T: Table>(&self) -> Result<<Self as DbTxMutGAT<'_>>::CursorMut<T>, Error> {
+    fn cursor_write<T: Table>(&self) -> Result<<Self as DbTxMutGAT<'_>>::CursorMut<T>, Error> {
         self.new_cursor()
     }
 
-    fn cursor_dup_mut<T: DupSort>(
+    fn cursor_dup_write<T: DupSort>(
         &self,
     ) -> Result<<Self as DbTxMutGAT<'_>>::DupCursorMut<T>, Error> {
         self.new_cursor()

--- a/crates/storage/db/src/tables/mod.rs
+++ b/crates/storage/db/src/tables/mod.rs
@@ -213,7 +213,7 @@ table!(
     ///     // Is there any transaction after number 150 that changed this account?
     ///     {
     ///         let tx = db.tx().expect("");
-    ///         let mut cursor = tx.cursor::<AccountHistory>().unwrap();
+    ///         let mut cursor = tx.cursor_read::<AccountHistory>().unwrap();
 
     ///         // It will seek the one greater or equal to the query. Since we have `Address | 100`,
     ///         // `Address | 200` in the database and we're querying `Address | 150` it will return us

--- a/crates/storage/provider/src/db_provider/storage.rs
+++ b/crates/storage/provider/src/db_provider/storage.rs
@@ -147,7 +147,7 @@ impl<'a, 'b, TX: DbTx<'a>> StateProvider for HistoricalStateProviderRef<'a, 'b, 
             return Ok(None)
         }
         let num = transaction_number.unwrap();
-        let mut cursor = self.tx.cursor_dup::<tables::StorageChangeSet>()?;
+        let mut cursor = self.tx.cursor_dup_read::<tables::StorageChangeSet>()?;
 
         if let Some((_, entry)) = cursor.seek_exact((num, account).into())? {
             if entry.key == storage_key {
@@ -239,7 +239,7 @@ impl<'a, 'b, TX: DbTx<'a>> BlockHashProvider for LatestStateProviderRef<'a, 'b, 
 impl<'a, 'b, TX: DbTx<'a>> StateProvider for LatestStateProviderRef<'a, 'b, TX> {
     /// Get storage.
     fn storage(&self, account: Address, storage_key: StorageKey) -> Result<Option<StorageValue>> {
-        let mut cursor = self.db.cursor_dup::<tables::PlainStorageState>()?;
+        let mut cursor = self.db.cursor_dup_read::<tables::PlainStorageState>()?;
         if let Some(entry) = cursor.seek_by_key_subkey(account, storage_key)? {
             if entry.key == storage_key {
                 return Ok(Some(entry.value))


### PR DESCRIPTION
Ref #755 

Renames cursor functions:
* cursor -> cursor_read
* cursor_dup -> cursor_dup_read
* cursor_mut -> cursor_write
* cursor_dup_mut -> cursor_dup_write