### PR TITLE
fix: make config serialize as toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1975,6 +1975,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3954,6 +3970,7 @@ dependencies = [
  "fnv",
  "futures",
  "hex",
+ "humantime-serde",
  "linked-hash-map",
  "linked_hash_set",
  "metrics",

--- a/bin/reth/src/config.rs
+++ b/bin/reth/src/config.rs
@@ -142,3 +142,12 @@ impl Default for ExecutionConfig {
         Self { commit_threshold: 5_000 }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Config;
+    #[test]
+    fn can_serde_config() {
+        let _: Config = confy::load("test", None).unwrap();
+    }
+}

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -13,6 +13,7 @@ use crate::{
     NetworkOpts,
 };
 use clap::{crate_version, Parser};
+use eyre::Context;
 use fdlimit::raise_fd_limit;
 use futures::{stream::select as stream_select, Stream, StreamExt};
 use reth_consensus::BeaconConsensus;
@@ -92,7 +93,8 @@ impl Command {
         // Does not do anything on windows.
         raise_fd_limit();
 
-        let mut config: Config = confy::load_path(&self.config).unwrap_or_default();
+        let mut config: Config =
+            confy::load_path(&self.config).wrap_err("Could not load config")?;
         config.peers.connect_trusted_nodes_only = self.network.trusted_only;
         if !self.network.trusted_peers.is_empty() {
             self.network.trusted_peers.iter().for_each(|peer| {

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -37,6 +37,7 @@ tokio-stream = "0.1"
 
 # io
 serde = { version = "1.0", optional = true }
+humantime-serde = { version = "1.1", optional = true }
 
 # metrics
 metrics = "0.20.1"
@@ -79,4 +80,4 @@ tempfile = "3.3"
 serial_test = "0.10"
 
 [features]
-serde = ["dep:serde"]
+serde = ["dep:serde", "dep:humantime-serde"]

--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -632,11 +632,12 @@ impl Default for PeersManager {
 /// Tracks stats about connected nodes
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct ConnectionInfo {
     /// Counter for currently occupied slots for active outbound connections.
+    #[cfg_attr(feature = "serde", serde(skip))]
     num_outbound: usize,
     /// Counter for currently occupied slots for active inbound connections.
+    #[cfg_attr(feature = "serde", serde(skip))]
     num_inbound: usize,
     /// Maximum allowed outbound connections.
     max_outbound: usize,
@@ -887,27 +888,27 @@ pub enum PeerAction {
 /// Config type for initiating a [`PeersManager`] instance
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct PeersConfig {
     /// How often to recheck free slots for outbound connections.
-    // #[cfg_attr(feature = "serde", serde(flatten))]
+    #[cfg_attr(feature = "serde", serde(with = "humantime_serde"))]
     pub refill_slots_interval: Duration,
-    /// Restrictions on connections.
-    pub connection_info: ConnectionInfo,
-    /// How to weigh reputation changes.
-    pub reputation_weights: ReputationChangeWeights,
-    /// Restrictions on PeerIds and Ips.
-    #[cfg_attr(feature = "serde", serde(skip))]
-    pub ban_list: BanList,
-    /// How long to ban bad peers.
-    pub ban_duration: Duration,
-    /// How long to backoff peers that are we failed to connect to for non-fatal reasons, such as
-    /// [`DisconnectReason::TooManyPeers`].
-    pub backoff_durations: PeerBackoffDurations,
     /// Trusted nodes to connect to.
     pub trusted_nodes: HashSet<NodeRecord>,
     /// Connect to trusted nodes only?
     pub connect_trusted_nodes_only: bool,
+    /// How long to ban bad peers.
+    #[cfg_attr(feature = "serde", serde(with = "humantime_serde"))]
+    pub ban_duration: Duration,
+    /// Restrictions on PeerIds and Ips.
+    #[cfg_attr(feature = "serde", serde(skip))]
+    pub ban_list: BanList,
+    /// Restrictions on connections.
+    pub connection_info: ConnectionInfo,
+    /// How to weigh reputation changes.
+    pub reputation_weights: ReputationChangeWeights,
+    /// How long to backoff peers that are we failed to connect to for non-fatal reasons, such as
+    /// [`DisconnectReason::TooManyPeers`].
+    pub backoff_durations: PeerBackoffDurations,
 }
 
 impl Default for PeersConfig {
@@ -973,15 +974,17 @@ impl PeersConfig {
 /// See also [`BackoffKind`](BackoffKind).
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct PeerBackoffDurations {
     /// Applies to connection problems where there is a chance that they will be resolved after the
     /// short duration.
+    #[cfg_attr(feature = "serde", serde(with = "humantime_serde"))]
     pub low: Duration,
     /// Applies to more severe connection problems where there is a lower chance that they will be
     /// resolved.
+    #[cfg_attr(feature = "serde", serde(with = "humantime_serde"))]
     pub medium: Duration,
     /// Intended for spammers, or bad peers in general.
+    #[cfg_attr(feature = "serde", serde(with = "humantime_serde"))]
     pub high: Duration,
 }
 

--- a/crates/net/network/src/peers/reputation.rs
+++ b/crates/net/network/src/peers/reputation.rs
@@ -63,7 +63,6 @@ pub enum ReputationChangeKind {
 /// How the [`ReputationChangeKind`] are weighted.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct ReputationChangeWeights {
     /// Weight for [`ReputationChangeKind::BadMessage`]
     pub bad_message: Reputation,


### PR DESCRIPTION
- Reorders some fields such that fields that would result in nested tables are last.
- Makes the config keys consistent by not camel-casing half of the config
- Ser/des durations as not tables
- Adds a simple sanity check test to ensure the config doesn't break

We should consider maybe moving away from TOML given this hard requirement of field ordering

Closes #805 