### PR TITLE
chore: double default session event buffer to 128

### DIFF
--- a/crates/net/network/src/session/config.rs
+++ b/crates/net/network/src/session/config.rs
@@ -32,7 +32,7 @@ impl Default for SessionsConfig {
             // `buffer + num sessions`. Each session can therefore fit at least 1 message in the
             // channel. The buffer size is additional capacity. The channel is always drained on
             // `poll`.
-            session_event_buffer: 64,
+            session_event_buffer: 128,
             limits: Default::default(),
             request_timeout: REQUEST_TIMEOUT,
         }


### PR DESCRIPTION
Closes #703.

Doubles the default session event buffer as asked in the linked issue. 