### PR TITLE
Downloaders: remove backoff logic

### DIFF
--- a/crates/net/downloaders/src/bodies/concurrent.rs
+++ b/crates/net/downloaders/src/bodies/concurrent.rs
@@ -65,7 +65,7 @@ where
                 .map(move |headers| {
                     (move || self.fetch_bodies(headers.clone()))
                         // We should not backoff from requests since the downloader does
-                        //not know what peer the request is being delivered to.
+                        // not know what peer the request is being delivered to.
                         // See: https://github.com/paradigmxyz/reth/issues/809
                         .retry(ConstantBackoff::default().with_delay(Duration::from_secs(0)))
                 })

--- a/crates/net/downloaders/src/bodies/concurrent.rs
+++ b/crates/net/downloaders/src/bodies/concurrent.rs
@@ -64,6 +64,9 @@ where
                 .chunks(self.batch_size)
                 .map(move |headers| {
                     (move || self.fetch_bodies(headers.clone()))
+                        // We should not backoff from requests since the downloader does 
+                        //not know what peer the request is being delivered to.
+                        // See: https://github.com/paradigmxyz/reth/issues/809
                         .retry(ConstantBackoff::default().with_delay(Duration::from_secs(0)))
                 })
                 .buffered(self.concurrency)

--- a/crates/net/downloaders/src/bodies/concurrent.rs
+++ b/crates/net/downloaders/src/bodies/concurrent.rs
@@ -67,7 +67,11 @@ where
                         // We should not backoff from requests since the downloader does
                         // not know what peer the request is being delivered to.
                         // See: https://github.com/paradigmxyz/reth/issues/809
-                        .retry(ConstantBackoff::default().with_delay(Duration::from_secs(0)))
+                        .retry(
+                            ConstantBackoff::default()
+                                .with_delay(Duration::from_secs(0))
+                                .with_max_times(self.retries),
+                        )
                 })
                 .buffered(self.concurrency)
                 .map_ok(|blocks| stream::iter(blocks.into_iter()).map(Ok))

--- a/crates/net/downloaders/src/bodies/concurrent.rs
+++ b/crates/net/downloaders/src/bodies/concurrent.rs
@@ -1,4 +1,4 @@
-use backon::{ExponentialBackoff, Retryable};
+use backon::{ConstantBackoff, Retryable};
 use futures_util::{stream, StreamExt, TryStreamExt};
 use reth_interfaces::{
     consensus::Consensus as ConsensusTrait,
@@ -12,7 +12,7 @@ use reth_interfaces::{
     },
 };
 use reth_primitives::{SealedBlock, SealedHeader};
-use std::{borrow::Borrow, sync::Arc};
+use std::{borrow::Borrow, sync::Arc, time::Duration};
 
 /// Downloads bodies in batches.
 ///
@@ -64,7 +64,7 @@ where
                 .chunks(self.batch_size)
                 .map(move |headers| {
                     (move || self.fetch_bodies(headers.clone()))
-                        .retry(ExponentialBackoff::default().with_max_times(self.retries))
+                        .retry(ConstantBackoff::default().with_delay(Duration::from_secs(0)))
                 })
                 .buffered(self.concurrency)
                 .map_ok(|blocks| stream::iter(blocks.into_iter()).map(Ok))

--- a/crates/net/downloaders/src/bodies/concurrent.rs
+++ b/crates/net/downloaders/src/bodies/concurrent.rs
@@ -64,7 +64,7 @@ where
                 .chunks(self.batch_size)
                 .map(move |headers| {
                     (move || self.fetch_bodies(headers.clone()))
-                        // We should not backoff from requests since the downloader does 
+                        // We should not backoff from requests since the downloader does
                         //not know what peer the request is being delivered to.
                         // See: https://github.com/paradigmxyz/reth/issues/809
                         .retry(ConstantBackoff::default().with_delay(Duration::from_secs(0)))


### PR DESCRIPTION
Closes #809.

Removes the backoff logic from the concurrent body downloader, along with a note as to why. reason (see linked issue): 
> "We should not backoff from download requests since the downloader does not know what peer the request is being delivered to."


