### PR TITLE
mx - readme.md fix - fix broken image with reth repo official banner 

### DIFF
--- a/book/README.md
+++ b/book/README.md
@@ -1,6 +1,6 @@
 # reth Book
 
-<img src="images/" style="border-radius: 20px">
+<img src="https://raw.githubusercontent.com/m0ham3dx/reth/main/assets/reth.jpg" style="border-radius: 20px">
 
 <!-- Add a quick description about Reth, what it is, the goals of the build, and any other quick overview information   -->
 

--- a/book/README.md
+++ b/book/README.md
@@ -1,6 +1,6 @@
 # reth Book
 
-<img src="https://raw.githubusercontent.com/m0ham3dx/reth/main/assets/reth.jpg" style="border-radius: 20px">
+<img src="../assets/reth.jpg" style="border-radius: 20px">
 
 <!-- Add a quick description about Reth, what it is, the goals of the build, and any other quick overview information   -->
 


### PR DESCRIPTION
# PR Description 

- Main index.html page page has a broken image link 
- This was fixed with [`reth official repo banner`](https://raw.githubusercontent.com/m0ham3dx/reth/main/assets/reth.jpg)

# Impact 

- No broken image in the cover page of the reth official book