### PR TITLE
chore: docker improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+/target
+/book
+/assets
+/.github

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get -y upgrade && apt-get install -y libclang-dev pkg-
 COPY . reth
 
 # Build reth
-RUN cd reth && cargo build --all --profile release
+RUN cd reth && cargo build --all --locked --profile $BUILD_PROFILE
 
 # Use alpine as the release image
 FROM frolvlad/alpine-glibc


### PR DESCRIPTION
- Ensures we don't send `./target` to the Docker daemon when building
- Builds from lockfile
- Uses the build profile arg