### PR TITLE
chore: Enable arbitrary in db tests

### DIFF
--- a/crates/storage/codecs/Cargo.toml
+++ b/crates/storage/codecs/Cargo.toml
@@ -12,11 +12,20 @@ compact = ["codecs-derive/compact"]
 scale = ["codecs-derive/scale"]
 postcard = ["codecs-derive/postcard"]
 no_codec = ["codecs-derive/no_codec"]
+arbitrary = [
+    "revm-interpreter/arbitrary",
+    "dep:arbitrary",
+    "dep:proptest",
+    "dep:proptest-derive",
+]
+
 
 [dependencies]
 bytes = "1.2.1"
 codecs-derive = { version = "0.1.0", path = "./derive", default-features = false }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "a05fb262d87c78ee52d400e6c0f4708d4c527f32", features = ["serde"] }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "a05fb262d87c78ee52d400e6c0f4708d4c527f32", features = [
+    "serde",
+] }
 
 # arbitrary utils
 arbitrary = { version = "1.1.7", features = ["derive"], optional = true }
@@ -24,6 +33,11 @@ proptest = { version = "1.0", optional = true }
 proptest-derive = { version = "0.3", optional = true }
 
 [dev-dependencies]
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "a05fb262d87c78ee52d400e6c0f4708d4c527f32", features = [
+    "serde",
+    "arbitrary",
+] }
+
 serde = "1.0"
 modular-bitfield = "0.11.2"
 test-fuzz = "3.0.4"

--- a/crates/storage/db/Cargo.toml
+++ b/crates/storage/db/Cargo.toml
@@ -22,7 +22,11 @@ parity-scale-codec = { version = "3.2.1", features = ["bytes"] }
 futures = "0.3.25"
 tokio-stream = "0.1.11"
 rand = "0.8.5"
-secp256k1 = { version = "0.24.2", default-features = false, features = ["alloc", "recovery", "rand"], optional = true }
+secp256k1 = { version = "0.24.2", default-features = false, features = [
+    "alloc",
+    "recovery",
+    "rand",
+], optional = true }
 modular-bitfield = "0.11.2"
 
 # misc
@@ -37,18 +41,22 @@ proptest = { version = "1.0", optional = true }
 proptest-derive = { version = "0.3", optional = true }
 
 [dev-dependencies]
+# reth libs with arbitrary
+reth-primitives = { path = "../../primitives", features = ["arbitrary"]}
+reth-codecs = { path = "../codecs",features = ["arbitrary"] }
+reth-interfaces = { path = "../../interfaces", features = ["bench"] }
+
 tempfile = "3.3.0"
 test-fuzz = "3.0.4"
 
 criterion = "0.4.0"
 iai = "0.1.1"
 tokio = { version = "1.21.2", features = ["full"] }
-reth-db = { path = ".", features = ["test-utils","bench"]}
+reth-db = { path = ".", features = ["test-utils", "bench"] }
 
 # needed for test-fuzz to work properly, see https://github.com/paradigmxyz/reth/pull/177#discussion_r1021172198
 secp256k1 = "0.24.2"
 
-reth-interfaces = { path = "../../interfaces", features=["bench"] }
 async-trait = "0.1.58"
 
 arbitrary = { version = "1.1.7", features = ["derive"] }
@@ -62,6 +70,13 @@ test-utils = ["tempfile"]
 bench-postcard = ["bench"]
 mdbx = ["reth-libmdbx"]
 bench = []
+arbitrary = [
+    "reth-primitives/arbitrary",
+    "reth-codecs/arbitrary",
+    "dep:arbitrary",
+    "dep:proptest",
+    "dep:proptest-derive",
+]
 
 [[bench]]
 name = "encoding_crit"


### PR DESCRIPTION
Fixes the bug where Header didnt implement arbitrary if called from db crate