### PR TITLE
feat(net): prioritize requesting peers with low latency

### DIFF
--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -114,7 +114,8 @@ impl StateFetcher {
         }
     }
 
-    /// Returns the _next_ idle peer that's ready to accept a request.
+    /// Returns the _next_ idle peer that's ready to accept a request,
+    /// prioritizing those with the lowest timeout/latency.
     /// Once a peer has been yielded, it will be moved to the end of the map
     fn next_peer(&mut self) -> Option<PeerId> {
         let peer = self

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -122,7 +122,7 @@ impl StateFetcher {
             .peers
             .iter()
             .filter(|(_, peer)| peer.state.is_idle())
-            .min_by_key(|(_, peer)| peer.timeout.load(Ordering::Relaxed).to_owned())
+            .min_by_key(|(_, peer)| peer.timeout())
             .map(|(id, _)| id.to_owned());
 
         if let Some(peer_id) = peer {
@@ -290,6 +290,12 @@ struct Peer {
     best_number: u64,
     /// Tracks the current timeout value we use for the peer.
     timeout: Arc<AtomicU64>,
+}
+
+impl Peer {
+    fn timeout(&self) -> u64 {
+        self.timeout.load(Ordering::Relaxed)
+    }
 }
 
 /// Tracks the state of an individual peer

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -123,7 +123,7 @@ impl StateFetcher {
             .iter()
             .filter(|(_, peer)| peer.state.is_idle())
             .min_by_key(|(_, peer)| peer.timeout())
-            .map(|(id, _)| id.to_owned());
+            .map(|(id, _)| *id);
 
         if let Some(peer_id) = peer {
             // Move to end of the map

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -121,7 +121,7 @@ impl StateFetcher {
             .peers
             .iter()
             .filter(|(_, peer)| peer.state.is_idle())
-            .min_by_key(|(_, peer)| peer.timeout.load(Ordering::SeqCst).to_owned())
+            .min_by_key(|(_, peer)| peer.timeout.load(Ordering::Relaxed).to_owned())
             .map(|(id, _)| id.to_owned());
 
         if let Some(peer_id) = peer {

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -8,6 +8,7 @@ use crate::{
         SessionId,
     },
 };
+use core::sync::atomic::Ordering;
 use fnv::FnvHashMap;
 use futures::{stream::Fuse, SinkExt, StreamExt};
 use reth_ecies::stream::ECIESStream;
@@ -25,7 +26,7 @@ use std::{
     future::Future,
     net::SocketAddr,
     pin::Pin,
-    sync::Arc,
+    sync::{atomic::AtomicU64, Arc},
     task::{ready, Context, Poll},
     time::{Duration, Instant},
 };
@@ -71,7 +72,7 @@ pub(crate) struct ActiveSession {
     /// Buffered messages that should be handled and sent to the peer.
     pub(crate) queued_outgoing: VecDeque<OutgoingMessage>,
     /// The maximum time we wait for a response from a peer.
-    pub(crate) request_timeout: Duration,
+    pub(crate) request_timeout: Arc<AtomicU64>,
     /// Interval when to check for timed out requests.
     pub(crate) timeout_interval: Interval,
 }
@@ -242,7 +243,7 @@ impl ActiveSession {
 
     /// Returns the deadline timestamp at which the request times out
     fn request_deadline(&self) -> Instant {
-        Instant::now() + self.request_timeout
+        Instant::now() + Duration::from_millis(self.request_timeout.load(Ordering::SeqCst))
     }
 
     /// Handle a Response to the peer
@@ -356,8 +357,10 @@ impl ActiveSession {
     fn update_request_timeout(&mut self, sent: Instant, received: Instant) {
         let elapsed = received.saturating_duration_since(sent);
 
-        self.request_timeout = calculate_new_timeout(self.request_timeout, elapsed);
-        self.timeout_interval = tokio::time::interval(self.request_timeout);
+        let current = Duration::from_millis(self.request_timeout.load(Ordering::SeqCst));
+        let request_timeout = calculate_new_timeout(current, elapsed);
+        self.request_timeout.store(request_timeout.as_millis() as u64, Ordering::SeqCst);
+        self.timeout_interval = tokio::time::interval(request_timeout);
     }
 }
 
@@ -682,7 +685,9 @@ mod tests {
                         queued_outgoing: Default::default(),
                         received_requests: Default::default(),
                         timeout_interval: tokio::time::interval(INITIAL_REQUEST_TIMEOUT),
-                        request_timeout: INITIAL_REQUEST_TIMEOUT,
+                        request_timeout: Arc::new(AtomicU64::new(
+                            INITIAL_REQUEST_TIMEOUT.as_millis() as u64,
+                        )),
                     }
                 }
                 _ => {

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -243,7 +243,7 @@ impl ActiveSession {
 
     /// Returns the deadline timestamp at which the request times out
     fn request_deadline(&self) -> Instant {
-        Instant::now() + Duration::from_millis(self.request_timeout.load(Ordering::SeqCst))
+        Instant::now() + Duration::from_millis(self.request_timeout.load(Ordering::Relaxed))
     }
 
     /// Handle a Response to the peer
@@ -357,9 +357,9 @@ impl ActiveSession {
     fn update_request_timeout(&mut self, sent: Instant, received: Instant) {
         let elapsed = received.saturating_duration_since(sent);
 
-        let current = Duration::from_millis(self.request_timeout.load(Ordering::SeqCst));
+        let current = Duration::from_millis(self.request_timeout.load(Ordering::Relaxed));
         let request_timeout = calculate_new_timeout(current, elapsed);
-        self.request_timeout.store(request_timeout.as_millis() as u64, Ordering::SeqCst);
+        self.request_timeout.store(request_timeout.as_millis() as u64, Ordering::Relaxed);
         self.timeout_interval = tokio::time::interval(request_timeout);
     }
 }

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -27,7 +27,7 @@ use std::{
     collections::HashMap,
     future::Future,
     net::SocketAddr,
-    sync::Arc,
+    sync::{atomic::AtomicU64, Arc},
     task::{Context, Poll},
     time::{Duration, Instant},
 };
@@ -379,7 +379,9 @@ impl SessionManager {
                     queued_outgoing: Default::default(),
                     received_requests: Default::default(),
                     timeout_interval: tokio::time::interval(self.request_timeout),
-                    request_timeout: self.request_timeout,
+                    request_timeout: Arc::new(AtomicU64::new(
+                        self.request_timeout.as_millis() as u64
+                    )),
                 };
 
                 self.spawn(session);

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -365,6 +365,8 @@ impl SessionManager {
 
                 let messages = PeerRequestSender::new(peer_id, to_session_tx);
 
+                let timeout = Arc::new(AtomicU64::new(self.request_timeout.as_millis() as u64));
+
                 let session = ActiveSession {
                     next_id: 0,
                     remote_peer_id: peer_id,
@@ -379,9 +381,7 @@ impl SessionManager {
                     queued_outgoing: Default::default(),
                     received_requests: Default::default(),
                     timeout_interval: tokio::time::interval(self.request_timeout),
-                    request_timeout: Arc::new(AtomicU64::new(
-                        self.request_timeout.as_millis() as u64
-                    )),
+                    request_timeout: Arc::clone(&timeout),
                 };
 
                 self.spawn(session);
@@ -407,6 +407,7 @@ impl SessionManager {
                     status,
                     messages,
                     direction,
+                    timeout,
                 })
             }
             PendingSessionEvent::Disconnected { remote_addr, session_id, direction, error } => {
@@ -521,6 +522,7 @@ pub(crate) enum SessionEvent {
         status: Status,
         messages: PeerRequestSender,
         direction: Direction,
+        timeout: Arc<AtomicU64>,
     },
     AlreadyConnected {
         peer_id: PeerId,

--- a/crates/net/network/src/swarm.rs
+++ b/crates/net/network/src/swarm.rs
@@ -121,12 +121,14 @@ where
                 status,
                 messages,
                 direction,
+                timeout,
             } => {
                 self.state.on_session_activated(
                     peer_id,
                     capabilities.clone(),
                     status,
                     messages.clone(),
+                    timeout,
                 );
                 Some(SwarmEvent::SessionEstablished {
                     peer_id,


### PR DESCRIPTION
Closes: https://github.com/paradigmxyz/reth/issues/826

This PR adds peer prioritization via latency when selecting peers to fetch data from. This info is passed thread-safely from the estimated RTT introduced in https://github.com/paradigmxyz/reth/pull/789.