### PR TITLE
refactor: add network-api crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3607,6 +3607,7 @@ dependencies = [
  "reth-executor",
  "reth-interfaces",
  "reth-network",
+ "reth-network-api",
  "reth-primitives",
  "reth-provider",
  "reth-rlp",
@@ -3993,6 +3994,7 @@ dependencies = [
  "reth-interfaces",
  "reth-metrics-derive",
  "reth-net-common",
+ "reth-network-api",
  "reth-primitives",
  "reth-provider",
  "reth-rlp",
@@ -4009,6 +4011,10 @@ dependencies = [
  "tokio-stream",
  "tracing",
 ]
+
+[[package]]
+name = "reth-network-api"
+version = "0.1.0"
 
 [[package]]
 name = "reth-primitives"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/net/discv4",
     "crates/net/dns",
     "crates/net/nat",
+    "crates/net/network-api",
     "crates/net/network",
     "crates/net/ipc",
     "crates/net/rpc",

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -20,6 +20,7 @@ reth-executor = { path = "../../crates/executor" }
 # reth-rpc = {path = "../../crates/net/rpc"}
 reth-rlp = { path = "../../crates/common/rlp" }
 reth-network = {path = "../../crates/net/network", features = ["serde"] }
+reth-network-api = {path = "../../crates/net/network-api" }
 reth-downloaders = {path = "../../crates/net/downloaders" }
 reth-cli-utils = { path = "../../crates/cli/utils" }
 reth-tracing = { path = "../../crates/tracing" }

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -21,6 +21,7 @@ use reth_downloaders::{bodies, headers};
 use reth_executor::Config as ExecutorConfig;
 use reth_interfaces::consensus::ForkchoiceState;
 use reth_network::NetworkEvent;
+use reth_network_api::NetworkInfo;
 use reth_primitives::{BlockNumber, H256};
 use reth_stages::{
     metrics::HeaderMetrics,

--- a/crates/net/network-api/Cargo.toml
+++ b/crates/net/network-api/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "reth-network-api"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/paradigmxyz/reth"
+readme = "README.md"
+description = "Network interfaces"
+
+[dependencies]

--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -1,0 +1,18 @@
+#![warn(missing_docs, unreachable_pub)]
+#![deny(unused_must_use, rust_2018_idioms)]
+#![doc(test(
+    no_crate_inject,
+    attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
+))]
+
+//! Reth network interface definitions.
+//!
+//! Provides abstractions for the reth-network crate.
+
+use std::net::SocketAddr;
+
+/// Provides general purpose information about the network
+pub trait NetworkInfo: Send + Sync {
+    /// Returns the [`SocketAddr`] that listens for incoming connections.
+    fn local_addr(&self) -> SocketAddr;
+}

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -20,6 +20,7 @@ normal = [
 reth-interfaces = { path = "../../interfaces" }
 reth-primitives = { path = "../../primitives" }
 reth-net-common = { path = "../common" }
+reth-network-api = { path = "../network-api" }
 reth-discv4 = { path = "../discv4" }
 reth-eth-wire = { path = "../eth-wire" }
 reth-ecies = { path = "../ecies" }

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -17,6 +17,7 @@ use std::{
     sync::Arc,
     task::{Context, Poll},
 };
+
 use tokio::sync::{mpsc::UnboundedReceiver, oneshot};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -13,6 +13,7 @@ use reth_interfaces::{
     sync::{SyncState, SyncStateProvider, SyncStateUpdater},
 };
 use reth_net_common::bandwidth_meter::BandwidthMeter;
+use reth_network_api::NetworkInfo;
 use reth_primitives::{PeerId, TransactionSigned, TxHash, H256, U256};
 use std::{
     net::SocketAddr,
@@ -62,11 +63,6 @@ impl NetworkHandle {
     /// How many peers we're currently connected to.
     pub fn num_connected_peers(&self) -> usize {
         self.inner.num_active_peers.load(Ordering::Relaxed)
-    }
-
-    /// Returns the [`SocketAddr`] that listens for incoming connections.
-    pub fn local_addr(&self) -> SocketAddr {
-        *self.inner.listener_address.lock()
     }
 
     /// Returns the [`PeerId`] used in the network.
@@ -207,6 +203,14 @@ impl NetworkHandle {
     /// Provides a shareable reference to the [`BandwidthMeter`] stored on the [`NetworkInner`]
     pub fn bandwidth_meter(&self) -> &BandwidthMeter {
         &self.inner.bandwidth_meter
+    }
+}
+
+// === API Implementations ===
+
+impl NetworkInfo for NetworkHandle {
+    fn local_addr(&self) -> SocketAddr {
+        *self.inner.listener_address.lock()
     }
 }
 

--- a/crates/net/network/tests/it/connect.rs
+++ b/crates/net/network/tests/it/connect.rs
@@ -14,6 +14,7 @@ use reth_interfaces::{
 };
 use reth_net_common::ban_list::BanList;
 use reth_network::{NetworkConfig, NetworkEvent, NetworkManager, PeersConfig};
+use reth_network_api::NetworkInfo;
 use reth_primitives::{HeadersDirection, NodeRecord, PeerId};
 use reth_provider::test_utils::NoopProvider;
 use reth_transaction_pool::test_utils::testing_pool;

--- a/crates/net/network/tests/it/requests.rs
+++ b/crates/net/network/tests/it/requests.rs
@@ -8,6 +8,7 @@ use reth_interfaces::p2p::{
     bodies::client::BodiesClient,
     headers::client::{HeadersClient, HeadersRequest},
 };
+use reth_network_api::NetworkInfo;
 use reth_primitives::{
     Block, Bytes, Header, HeadersDirection, Signature, Transaction, TransactionKind,
     TransactionSigned, TxEip2930, H256, U256,


### PR DESCRIPTION
This is the first step to address #683 and split `Networkhandle` impls into traits

This has the benefit that we can abstract over those traits (mainly in RPC) without running a network instance, which is useful for testing.

I'll create follow-up good-first-issues for other things we want to have as trait, like info about peers, etc...

