### PR TITLE
docs: use nightly clippy in vscode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,16 @@ If you are working in VSCode, we recommend you install the [rust-analyzer](https
 ```json
 "editor.formatOnSave": true,
 "rust-analyzer.rustfmt.extraArgs": ["+nightly"],
+"rust-analyzer.checkOnSave.overrideCommand": [
+  "cargo",
+  "+nightly",
+  "clippy",
+  "--all",
+  "--all-features",
+  "--",
+  "-D",
+  "warnings"
+],
 "[rust]": {
   "editor.defaultFormatter": "rust-lang.rust-analyzer"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,9 +96,7 @@ If you are working in VSCode, we recommend you install the [rust-analyzer](https
   "clippy",
   "--all",
   "--all-features",
-  "--message-format=json",
-  "--",
-  "-D warnings"
+  "--message-format=json"
 ],
 "[rust]": {
   "editor.defaultFormatter": "rust-lang.rust-analyzer"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,7 @@ If you are working in VSCode, we recommend you install the [rust-analyzer](https
   "clippy",
   "--all",
   "--all-features",
+  "--message-format=json",
   "--",
   "-D",
   "warnings"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,8 +98,7 @@ If you are working in VSCode, we recommend you install the [rust-analyzer](https
   "--all-features",
   "--message-format=json",
   "--",
-  "-D",
-  "warnings"
+  "-D warnings"
 ],
 "[rust]": {
   "editor.defaultFormatter": "rust-lang.rust-analyzer"


### PR DESCRIPTION
Before this small fix, I had a bunch of Clippy warnings/errors on VS Code.