### PR TITLE
test: add test for header stage two step download

### DIFF
--- a/crates/interfaces/src/test_utils/headers.rs
+++ b/crates/interfaces/src/test_utils/headers.rs
@@ -162,6 +162,12 @@ impl TestHeadersClient {
         lock.extend(headers);
     }
 
+    /// Clears the set.
+    pub async fn clear(&self) {
+        let mut lock = self.responses.lock().await;
+        lock.clear();
+    }
+
     /// Set response error
     pub async fn set_error(&self, err: RequestError) {
         let mut lock = self.error.lock().await;


### PR DESCRIPTION
Linked: https://github.com/paradigmxyz/reth/issues/418

This PR adds a test for `HeaderStage` where more than `commit_threshold` headers are downloaded, requiring a second call to `HeaderStage::execute`.