### PR TITLE
chore(primitives): derive default for Hardfork

### DIFF
--- a/crates/primitives/src/hardfork.rs
+++ b/crates/primitives/src/hardfork.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 /// Ethereum mainnet hardforks
 #[allow(missing_docs)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
 pub enum Hardfork {
     Frontier,
     Homestead,
@@ -19,6 +19,7 @@ pub enum Hardfork {
     London,
     ArrowGlacier,
     GrayGlacier,
+    #[default]
     Latest,
 }
 
@@ -152,12 +153,6 @@ impl FromStr for Hardfork {
             _ => return Err(format!("Unknown hardfork {s}")),
         };
         Ok(hardfork)
-    }
-}
-
-impl Default for Hardfork {
-    fn default() -> Self {
-        Hardfork::Latest
     }
 }
 


### PR DESCRIPTION
`Default` can be implemented on enums if the default member is tagged with `#[default]`, so we do that for `Hardfork` instead of manually implementing `Default`.