### PR TITLE
chore: convert warn,err to debug

### DIFF
--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -74,7 +74,7 @@ where
         let msg = match ProtocolMessage::decode(&mut their_msg.as_ref()) {
             Ok(m) => m,
             Err(err) => {
-                tracing::warn!("rlp decode error in eth handshake: msg={their_msg:x}");
+                tracing::debug!("rlp decode error in eth handshake: msg={their_msg:x}");
                 return Err(err.into())
             }
         };
@@ -197,7 +197,7 @@ where
         let msg = match ProtocolMessage::decode(&mut bytes.as_ref()) {
             Ok(m) => m,
             Err(err) => {
-                tracing::warn!("rlp decode error: msg={bytes:x}");
+                tracing::debug!("rlp decode error: msg={bytes:x}");
                 return Poll::Ready(Some(Err(err.into())))
             }
         };

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -108,16 +108,16 @@ where
         let their_hello = match P2PMessage::decode(&mut &first_message_bytes[..]) {
             Ok(P2PMessage::Hello(hello)) => Ok(hello),
             Ok(P2PMessage::Disconnect(reason)) => {
-                tracing::error!("Disconnected by peer during handshake: {}", reason);
+                tracing::debug!("Disconnected by peer during handshake: {}", reason);
                 counter!("p2pstream.disconnected_errors", 1);
                 Err(P2PStreamError::HandshakeError(P2PHandshakeError::Disconnected(reason)))
             }
             Err(err) => {
-                tracing::warn!(?err, msg=%hex::encode(&first_message_bytes), "Failed to decode first message from peer");
+                tracing::debug!(?err, msg=%hex::encode(&first_message_bytes), "Failed to decode first message from peer");
                 Err(P2PStreamError::HandshakeError(err.into()))
             }
             Ok(msg) => {
-                tracing::error!("expected hello message but received: {:?}", msg);
+                tracing::debug!("expected hello message but received: {:?}", msg);
                 Err(P2PStreamError::HandshakeError(P2PHandshakeError::NonHelloMessageInHandshake))
             }
         }?;
@@ -348,7 +348,7 @@ where
                 }
                 _ if id == P2PMessageID::Disconnect as u8 => {
                     let reason = DisconnectReason::decode(&mut &decompress_buf[1..]).map_err(|err| {
-                        tracing::warn!(
+                        tracing::debug!(
                             ?err, msg=%hex::encode(&decompress_buf[1..]), "Failed to decode disconnect message from peer"
                         );
                         err
@@ -559,7 +559,7 @@ pub fn set_capability_offsets(
         match shared_capability {
             SharedCapability::UnknownCapability { .. } => {
                 // Capabilities which are not shared are ignored
-                tracing::warn!("unknown capability: name={:?}, version={}", name, version,);
+                tracing::debug!("unknown capability: name={:?}, version={}", name, version,);
             }
             SharedCapability::Eth { .. } => {
                 // increment the offset if the capability is known


### PR DESCRIPTION
converts the warn and err level of eth-wire to debug.

all of these errors are logged in the network as well.