### PR TITLE
test: rm multi_thread flavor for tests

### DIFF
--- a/crates/net/discv4/Cargo.toml
+++ b/crates/net/discv4/Cargo.toml
@@ -40,7 +40,7 @@ generic-array = "0.14"
 
 [dev-dependencies]
 rand = "0.8"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["macros"] }
 reth-tracing = { path = "../../tracing" }
 
 [features]

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -1885,7 +1885,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     #[ignore]
     async fn test_lookup() {
         reth_tracing::init_test_tracing();
@@ -1921,7 +1921,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn test_mapped_ipv4() {
         reth_tracing::init_test_tracing();
         let mut rng = thread_rng();
@@ -1953,7 +1953,7 @@ mod tests {
         };
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn test_single_lookups() {
         reth_tracing::init_test_tracing();
 
@@ -1987,7 +1987,7 @@ mod tests {
         .await
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn test_no_local_in_closest() {
         reth_tracing::init_test_tracing();
 
@@ -2020,7 +2020,7 @@ mod tests {
         assert!(!closest.iter().any(|r| r.id == *service.local_peer_id()));
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn test_random_lookup() {
         reth_tracing::init_test_tracing();
 
@@ -2054,7 +2054,7 @@ mod tests {
         assert_eq!(ctx.inner.closest_nodes.borrow().len(), 1);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn test_service_commands() {
         reth_tracing::init_test_tracing();
 

--- a/crates/net/discv4/src/test_utils.rs
+++ b/crates/net/discv4/src/test_utils.rs
@@ -289,7 +289,7 @@ mod tests {
 
     /// This test creates two local UDP sockets. The mocked discovery service responds to specific
     /// messages and we check the actual service receives answers
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn can_mock_discovery() {
         reth_tracing::init_test_tracing();
 


### PR DESCRIPTION
async discovery tests use several tasks, but none of them are dependent on each other, so multithreaded flavor is unnecessary.

this should speed up the tests in CI