### PR TITLE
fix: use correct boolean conversion for direction

### DIFF
--- a/crates/net/downloaders/src/headers/linear.rs
+++ b/crates/net/downloaders/src/headers/linear.rs
@@ -173,7 +173,7 @@ where
         HeadersRequest {
             start: self.request_start().into(),
             limit: self.batch_size,
-            direction: HeadersDirection::Rising,
+            direction: HeadersDirection::Falling,
         }
     }
 

--- a/crates/net/eth-wire/src/types/blocks.rs
+++ b/crates/net/eth-wire/src/types/blocks.rs
@@ -134,8 +134,8 @@ mod test {
     };
     use hex_literal::hex;
     use reth_primitives::{
-        BlockHashOrNumber, Header, Signature, Transaction, TransactionKind, TransactionSigned,
-        TxLegacy, U256,
+        BlockHashOrNumber, Header, HeadersDirection, Signature, Transaction, TransactionKind,
+        TransactionSigned, TxLegacy, U256,
     };
     use reth_rlp::{Decodable, Encodable};
     use std::str::FromStr;
@@ -207,7 +207,7 @@ mod test {
                 ),
                 limit: 5,
                 skip: 5,
-                direction: Default::default(),
+                direction: HeadersDirection::Rising,
             },
         }
         .encode(&mut data);
@@ -228,7 +228,7 @@ mod test {
                 ),
                 limit: 5,
                 skip: 5,
-                direction: Default::default(),
+                direction: HeadersDirection::Rising,
             },
         };
         let result = RequestPair::decode(&mut &data[..]);
@@ -246,7 +246,7 @@ mod test {
                 start_block: BlockHashOrNumber::Number(9999),
                 limit: 5,
                 skip: 5,
-                direction: Default::default(),
+                direction: HeadersDirection::Rising,
             },
         }
         .encode(&mut data);
@@ -263,7 +263,7 @@ mod test {
                 start_block: BlockHashOrNumber::Number(9999),
                 limit: 5,
                 skip: 5,
-                direction: Default::default(),
+                direction: HeadersDirection::Rising,
             },
         };
         let result = RequestPair::decode(&mut &data[..]);

--- a/crates/net/eth-wire/src/types/message.rs
+++ b/crates/net/eth-wire/src/types/message.rs
@@ -366,14 +366,6 @@ impl<T> Encodable for RequestPair<T>
 where
     T: Encodable,
 {
-    fn length(&self) -> usize {
-        let mut length = 0;
-        length += self.request_id.length();
-        length += self.message.length();
-        length += length_of_length(length);
-        length
-    }
-
     fn encode(&self, out: &mut dyn reth_rlp::BufMut) {
         let header =
             Header { list: true, payload_length: self.request_id.length() + self.message.length() };
@@ -381,6 +373,14 @@ where
         header.encode(out);
         self.request_id.encode(out);
         self.message.encode(out);
+    }
+
+    fn length(&self) -> usize {
+        let mut length = 0;
+        length += self.request_id.length();
+        length += self.message.length();
+        length += length_of_length(length);
+        length
     }
 }
 

--- a/crates/net/network/tests/it/connect.rs
+++ b/crates/net/network/tests/it/connect.rs
@@ -308,7 +308,7 @@ async fn test_connect_to_trusted_peer() {
         .get_headers(HeadersRequest {
             start: 73174u64.into(),
             limit: 10,
-            direction: HeadersDirection::Rising,
+            direction: HeadersDirection::Falling,
         })
         .await;
 

--- a/crates/net/network/tests/it/requests.rs
+++ b/crates/net/network/tests/it/requests.rs
@@ -111,7 +111,7 @@ async fn test_get_header() {
         mock_provider.add_header(hash, header.clone());
 
         let req =
-            HeadersRequest { start: hash.into(), limit: 1, direction: HeadersDirection::Rising };
+            HeadersRequest { start: hash.into(), limit: 1, direction: HeadersDirection::Falling };
 
         let res = fetch0.get_headers(req).await;
         assert!(res.is_ok());

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -293,9 +293,9 @@ impl SealedHeader {
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Default, Serialize, Deserialize)]
 pub enum HeadersDirection {
     /// Falling block number.
-    #[default]
     Falling,
     /// Rising block number.
+    #[default]
     Rising,
 }
 
@@ -439,8 +439,20 @@ mod tests {
     fn sanity_direction() {
         let reverse = true;
         assert_eq!(HeadersDirection::Falling, reverse.into());
+        assert_eq!(reverse, bool::from(HeadersDirection::Falling));
 
         let reverse = false;
         assert_eq!(HeadersDirection::Rising, reverse.into());
+        assert_eq!(reverse, bool::from(HeadersDirection::Rising));
+
+        let mut buf = Vec::new();
+        let direction = HeadersDirection::Falling;
+        direction.encode(&mut buf);
+        assert_eq!(direction, HeadersDirection::decode(&mut buf.as_slice()).unwrap());
+
+        let mut buf = Vec::new();
+        let direction = HeadersDirection::Rising;
+        direction.encode(&mut buf);
+        assert_eq!(direction, HeadersDirection::decode(&mut buf.as_slice()).unwrap());
     }
 }

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -281,9 +281,13 @@ impl SealedHeader {
 }
 
 /// Represents the direction for a headers request depending on the `reverse` field of the request.
+/// > The response must contain a number of block headers, of rising number when reverse is 0,
+/// > falling when 1
 ///
-/// [`HeadersDirection::Rising`] block numbers for `reverse == true`
-/// [`HeadersDirection::Falling`] block numbers for `reverse == false`
+/// Ref: <https://github.com/ethereum/devp2p/blob/master/caps/eth.md#getblockheaders-0x03>
+///
+/// [`HeadersDirection::Rising`] block numbers for `reverse == 0 == false`
+/// [`HeadersDirection::Falling`] block numbers for `reverse == 1 == true`
 ///
 /// See also <https://github.com/ethereum/devp2p/blob/master/caps/eth.md#getblockheaders-0x03>
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Default, Serialize, Deserialize)]
@@ -310,13 +314,13 @@ impl HeadersDirection {
     ///
     /// Returns:
     ///
-    /// [`HeadersDirection::Rising`] block numbers for `reverse == true`
-    /// [`HeadersDirection::Falling`] block numbers for `reverse == false`
+    /// [`HeadersDirection::Rising`] block numbers for `reverse == 0 == false`
+    /// [`HeadersDirection::Falling`] block numbers for `reverse == 1 == true`
     pub fn new(reverse: bool) -> Self {
         if reverse {
-            HeadersDirection::Rising
-        } else {
             HeadersDirection::Falling
+        } else {
+            HeadersDirection::Rising
         }
     }
 }
@@ -347,8 +351,8 @@ impl From<bool> for HeadersDirection {
 impl From<HeadersDirection> for bool {
     fn from(value: HeadersDirection) -> Self {
         match value {
-            HeadersDirection::Rising => true,
-            HeadersDirection::Falling => false,
+            HeadersDirection::Rising => false,
+            HeadersDirection::Falling => true,
         }
     }
 }
@@ -356,9 +360,8 @@ impl From<HeadersDirection> for bool {
 #[cfg(test)]
 mod tests {
     use super::{Bytes, Decodable, Encodable, Header, H256};
-    use crate::{Address, U256};
+    use crate::{Address, HeadersDirection, U256};
     use ethers_core::utils::hex::{self, FromHex};
-
     use std::str::FromStr;
 
     #[test]
@@ -430,5 +433,14 @@ mod tests {
         };
         let header = <Header as Decodable>::decode(&mut data.as_slice()).unwrap();
         assert_eq!(header, expected);
+    }
+
+    #[test]
+    fn sanity_direction() {
+        let reverse = true;
+        assert_eq!(HeadersDirection::Falling, reverse.into());
+
+        let reverse = false;
+        assert_eq!(HeadersDirection::Rising, reverse.into());
     }
 }


### PR DESCRIPTION
Closes #869

this flips the wrong bool conversion for Direction and updates the request direction that we're sending from `Rising` to `Falling`