### PR TITLE
feat: show possible values for `reth stage`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3617,7 +3617,6 @@ dependencies = [
  "serde",
  "serde_json",
  "shellexpand",
- "strum",
  "tempfile",
  "thiserror",
  "tokio",

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -49,6 +49,5 @@ thiserror = "1.0"
 tokio = { version = "1.21", features = ["sync", "macros", "rt-multi-thread"] }
 tokio-stream = "0.1"
 futures = "0.3.25"
-strum = "0.24.1"
 tempfile = { version = "3.3.0" }
 backon = "0.2.0"

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -20,10 +20,8 @@ use reth_stages::{
     ExecInput, Stage, StageId, Transaction, UnwindInput,
 };
 
-use clap::Parser;
-use serde::Deserialize;
+use clap::{Parser, ValueEnum};
 use std::{net::SocketAddr, sync::Arc};
-use strum::{AsRefStr, EnumString, EnumVariantNames};
 use tracing::*;
 
 /// `reth stage` command
@@ -67,6 +65,7 @@ pub struct Command {
     metrics: Option<SocketAddr>,
 
     /// The name of the stage to run
+    #[arg(value_enum)]
     stage: StageEnum,
 
     /// The height to start at
@@ -89,11 +88,7 @@ pub struct Command {
     network: NetworkOpts,
 }
 
-#[derive(
-    Debug, Clone, Copy, Eq, PartialEq, AsRefStr, EnumVariantNames, EnumString, Deserialize,
-)]
-#[serde(rename_all = "snake_case")]
-#[strum(serialize_all = "kebab-case")]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, ValueEnum)]
 enum StageEnum {
     Headers,
     Bodies,


### PR DESCRIPTION
Removes `strum` and uses Clap's value enum construct to parse the possible values for `reth stage`, which also gives us the added benefit of `reth stage --help` showing the possible values.

```console
$ cargo r -q -- stage foo
error: 'foo' isn't a valid value for '<STAGE>'
  [possible values: headers, bodies, senders, execution]

For more information try '--help'
```

```console
$ cargo r -q -- stage --help
Run a single stage.

[...]

Usage: reth stage [OPTIONS] --from <FROM> --to <TO> <STAGE>

Arguments:
  <STAGE>
          The name of the stage to run

          [possible values: headers, bodies, senders, execution]
```

Closes #842 