### PR TITLE
`net`: Add way to get the `NodeRecord` of the local node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4017,6 +4017,9 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "0.1.0"
+dependencies = [
+ "reth-primitives",
+]
 
 [[package]]
 name = "reth-primitives"

--- a/crates/net/network-api/Cargo.toml
+++ b/crates/net/network-api/Cargo.toml
@@ -8,3 +8,4 @@ readme = "README.md"
 description = "Network interfaces"
 
 [dependencies]
+reth-primitives = { path = "../../primitives" }

--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -10,6 +10,7 @@
 //! Provides abstractions for the reth-network crate.
 
 use std::net::SocketAddr;
+use reth_primitives::NodeRecord;
 
 /// Provides general purpose information about the network.
 pub trait NetworkInfo: Send + Sync {
@@ -23,4 +24,7 @@ pub trait PeersInfo: Send + Sync {
     ///
     /// Note: this should only include established connections and _not_ ongoing attempts.
     fn num_connected_peers(&self) -> usize;
+
+    /// Returns the Ethereum Node Record of the node.
+    fn node_record(&self) -> NodeRecord;
 }

--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -26,5 +26,5 @@ pub trait PeersInfo: Send + Sync {
     fn num_connected_peers(&self) -> usize;
 
     /// Returns the Ethereum Node Record of the node.
-    fn node_record(&self) -> NodeRecord;
+    fn local_node_record(&self) -> NodeRecord;
 }

--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -9,8 +9,8 @@
 //!
 //! Provides abstractions for the reth-network crate.
 
-use std::net::SocketAddr;
 use reth_primitives::NodeRecord;
+use std::net::SocketAddr;
 
 /// Provides general purpose information about the network.
 pub trait NetworkInfo: Send + Sync {

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -208,7 +208,7 @@ impl PeersInfo for NetworkHandle {
         self.inner.num_active_peers.load(Ordering::Relaxed)
     }
 
-    fn node_record(&self) -> NodeRecord {
+    fn local_node_record(&self) -> NodeRecord {
         let id = *self.peer_id();
         let socket_addr = *self.inner.listener_address.lock();
         NodeRecord::new(socket_addr, id)

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -14,7 +14,7 @@ use reth_interfaces::{
 };
 use reth_net_common::bandwidth_meter::BandwidthMeter;
 use reth_network_api::{NetworkInfo, PeersInfo};
-use reth_primitives::{PeerId, TransactionSigned, TxHash, H256, U256};
+use reth_primitives::{NodeRecord, PeerId, TransactionSigned, TxHash, H256, U256};
 use std::{
     net::SocketAddr,
     sync::{
@@ -206,6 +206,12 @@ impl NetworkHandle {
 impl PeersInfo for NetworkHandle {
     fn num_connected_peers(&self) -> usize {
         self.inner.num_active_peers.load(Ordering::Relaxed)
+    }
+
+    fn node_record(&self) -> NodeRecord {
+        let id = *self.peer_id();
+        let socket_addr = *self.inner.listener_address.lock();
+        NodeRecord::new(socket_addr, id)
     }
 }
 


### PR DESCRIPTION
Closes #849 .

Adds a way of getting the `NodeRecord` of the local node thru `NetworkHandle::node_record`. This function has been defined in the `PeersInfo` trait (see #860).