### PR TITLE
feat: add a --nat flag to reth node

### DIFF
--- a/bin/reth/src/config.rs
+++ b/bin/reth/src/config.rs
@@ -29,6 +29,7 @@ impl Config {
         chain_id: u64,
         genesis_hash: H256,
         disable_discovery: bool,
+        nat_resolution_method: NatResolver,
     ) -> NetworkConfig<ProviderImpl<DB>> {
         let peer_config = reth_network::PeersConfig::default()
             .with_trusted_nodes(self.peers.trusted_nodes.clone())
@@ -39,6 +40,7 @@ impl Config {
             .genesis_hash(genesis_hash)
             .chain_id(chain_id)
             .set_discovery(disable_discovery)
+            .discovery(Discv4Config::builder().external_ip_resolver(Some(nat_resolution_method)))
             .build()
     }
 }

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -84,6 +84,9 @@ pub struct Command {
 
     #[clap(flatten)]
     network: NetworkOpts,
+
+    #[arg(long, default_value = "any")]
+    nat: NatResolver,
 }
 
 impl Command {
@@ -120,7 +123,13 @@ impl Command {
         let genesis_hash = init_genesis(db.clone(), self.chain.genesis.clone())?;
 
         let network = config
-            .network_config(db.clone(), chain_id, genesis_hash, self.network.disable_discovery)
+            .network_config(
+                db.clone(),
+                chain_id,
+                genesis_hash,
+                self.network.disable_discovery,
+                self.nat,
+            )
             .start_network()
             .await?;
 

--- a/crates/net/nat/src/lib.rs
+++ b/crates/net/nat/src/lib.rs
@@ -22,7 +22,7 @@ use tracing::warn;
 
 /// All builtin resolvers.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default, Hash)]
-pub enum NatResolver {
+pub(crate) enum NatResolver {
     /// Resolve with any available resolver.
     #[default]
     Any,

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -287,8 +287,20 @@ impl<C> NetworkConfigBuilder<C> {
     }
 
     /// Sets the boot nodes.
-    pub fn boot_nodes(mut self, nodes: impl IntoIterator<Item = NodeRecord>) -> Self {
-        self.boot_nodes = nodes.into_iter().collect();
+    // pub fn boot_nodes(mut self, nodes: impl IntoIterator<Item = NodeRecord>) -> Self {
+    //     self.boot_nodes = nodes.into_iter().collect();
+    //     self
+    // }
+
+    /// Sets the boot nodes
+    pub fn set_bootnodes(&mut self, envs: &Option<Vec<NodeRecord>>) -> &mut Self {
+        if let Some(bootnodes) = envs {
+            bootnodes.iter().for_each(|node| {
+                self.boot_nodes.insert(*node);
+            })
+        } else {
+            self.boot_nodes = mainnet_nodes().into_iter().collect();
+        }
         self
     }
 


### PR DESCRIPTION
Fixes: #854 

Draft
1. Regarding reusing enum NatResover, I made it pub(crate).  It raised a privateType error so probably not best way to do that.
2. For the nat resolution method, I passed it as a parameter to the function below but it breaks the function in other areas.
https://github.com/paradigmxyz/reth/blob/e3dbaf686e7aada22e1a91a02678971a2876b55b/bin/reth/src/node/mod.rs#L122-L125 
