### PR TITLE
feat(rpc): Add `admin_nodeInfo` to get the local node record

### DIFF
--- a/crates/net/rpc-api/src/admin.rs
+++ b/crates/net/rpc-api/src/admin.rs
@@ -1,5 +1,6 @@
 use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
 use reth_primitives::NodeRecord;
+use reth_rpc_types::NodeInfo;
 
 /// Admin namespace rpc interface that gives access to several non-standard RPC methods.
 #[rpc(server)]
@@ -36,5 +37,5 @@ pub trait AdminApi {
 
     /// Returns the ENR of the node.
     #[method(name = "admin_nodeInfo")]
-    fn node_info(&self) -> Result<NodeRecord>;
+    fn node_info(&self) -> Result<NodeInfo>;
 }

--- a/crates/net/rpc-api/src/admin.rs
+++ b/crates/net/rpc-api/src/admin.rs
@@ -33,4 +33,8 @@ pub trait AdminApi {
         item = String
     )]
     fn subscribe(&self);
+
+    /// Returns the ENR of the node.
+    #[method(name = "admin_nodeInfo")]
+    fn node_info(&self) -> Result<NodeRecord>;
 }

--- a/crates/net/rpc-types/src/admin.rs
+++ b/crates/net/rpc-types/src/admin.rs
@@ -1,0 +1,72 @@
+use reth_primitives::{NodeRecord, U256};
+use serde::{Deserialize, Serialize};
+
+/// Represents the `admin_nodeInfo` response, which can be queried for all the information
+/// known about the running node at the networking granularity.
+///
+/// Note: this format is not standardized.  Reth follows geth's format,
+/// see: https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-admin
+#[derive(Serialize, Deserialize, Debug)]
+pub struct NodeInfo {
+    /// Enode in URL format.
+    pub enode: String,
+    /// ID of the local node.
+    pub id: String,
+    /// IP of the local node.
+    pub ip: String,
+    /// Address exposed for listening for the local node.
+    #[serde(rename = "listenAddr")]
+    pub listen_addr: String,
+    /// Local node client name.
+    pub name: String,
+    /// Ports exposed by the node for discovery and listening.
+    pub ports: Ports,
+    /// Networking protocols being run by the local node.
+    pub protocols: Protocols,
+}
+
+impl NodeInfo {
+    /// Creates a new instance of `NodeInfo`.
+    pub fn new(enr: NodeRecord) -> NodeInfo {
+        NodeInfo {
+            enode: enr.to_string(),
+            id: enr.id.to_string(),
+            ip: enr.address.to_string(),
+            listen_addr: enr.tcp_addr().to_string(),
+            name: "Reth".to_owned(),
+            ports: Ports { discovery: enr.tcp_port.into(), listener: enr.tcp_port.into() },
+            protocols: Protocols {
+                eth: Eth { difficulty: todo!(), genesis: todo!(), head: todo!(), network: todo!() },
+            },
+        }
+    }
+}
+
+/// Ports exposed by the node for discovery and listening.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Ports {
+    /// Port exposed for node discovery.
+    pub discovery: u16,
+    /// Port exposed for listening.
+    pub listener: u16,
+}
+
+/// Networking protocols being run by the node.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Protocols {
+    /// Information about the Ethereum Wire Protocol (ETH)
+    pub eth: Eth,
+}
+
+/// Information about the Ethereum Wire Protocol (ETH)
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Eth {
+    /// Total difficulty of the best chain.
+    pub difficulty: U256,
+    /// The hash of the genesis block.
+    pub genesis: String,
+    /// Hash of the latest block of the best chain.
+    pub head: String,
+    /// Network ID in base 10.
+    pub network: u64,
+}

--- a/crates/net/rpc-types/src/admin.rs
+++ b/crates/net/rpc-types/src/admin.rs
@@ -1,6 +1,6 @@
-use std::net::{IpAddr, SocketAddr};
-use reth_primitives::{NodeRecord, U256, H512, rpc::H256};
+use reth_primitives::{rpc::H256, NodeRecord, H512, U256};
 use serde::{Deserialize, Serialize};
+use std::net::{IpAddr, SocketAddr};
 
 /// Represents the `admin_nodeInfo` response, which can be queried for all the information
 /// known about the running node at the networking granularity.

--- a/crates/net/rpc-types/src/admin.rs
+++ b/crates/net/rpc-types/src/admin.rs
@@ -1,5 +1,4 @@
-use crate::EthProtocolInfo;
-use reth_primitives::{NodeRecord, PeerId, H256};
+use reth_primitives::{NodeRecord, PeerId, H256, U256};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeMap,
@@ -35,13 +34,10 @@ impl NodeInfo {
     pub fn new(enr: NodeRecord) -> NodeInfo {
         let mut protocol_info = BTreeMap::from([(
             "eth".into(),
-            ProtocolInfo::Eth(EthInfo {
-                eth_protocol_info: EthProtocolInfo {
-                    version: todo!(),
-                    difficulty: todo!(),
-                    head: todo!(),
-                },
-                network: todo!(),
+            ProtocolInfo::Eth(EthProtocolInfo {
+                difficulty: todo!(),
+                head: todo!(),
+                network: 0,
                 genesis: todo!(),
             }),
         )]);
@@ -71,14 +67,15 @@ pub struct Ports {
 #[derive(Serialize, Deserialize, Debug)]
 pub enum ProtocolInfo {
     /// Information about the Ethereum Wire Protocol.
-    Eth(EthInfo),
+    Eth(EthProtocolInfo),
 }
 /// Information about the Ethereum Wire Protocol (ETH)
 #[derive(Serialize, Deserialize, Debug)]
-pub struct EthInfo {
-    /// Base information about the Ethereum Wire Protocol.
-    #[serde(flatten)]
-    pub eth_protocol_info: EthProtocolInfo,
+pub struct EthProtocolInfo {
+    /// The current difficulty at the head of the chain.
+    pub difficulty: U256,
+    /// The block hash of the head of the chain.
+    pub head: H256,
     /// Network ID in base 10.
     pub network: u64,
     /// Genesis block of the current chain.

--- a/crates/net/rpc-types/src/admin.rs
+++ b/crates/net/rpc-types/src/admin.rs
@@ -32,15 +32,8 @@ pub struct NodeInfo {
 impl NodeInfo {
     /// Creates a new instance of `NodeInfo`.
     pub fn new(enr: NodeRecord) -> NodeInfo {
-        let mut protocol_info = BTreeMap::from([(
-            "eth".into(),
-            ProtocolInfo::Eth(EthProtocolInfo {
-                difficulty: todo!(),
-                head: todo!(),
-                network: 0,
-                genesis: todo!(),
-            }),
-        )]);
+        let protocol_info =
+            BTreeMap::from([("eth".into(), ProtocolInfo::Eth(EthProtocolInfo::default()))]);
 
         NodeInfo {
             enode: enr,
@@ -70,7 +63,7 @@ pub enum ProtocolInfo {
     Eth(EthProtocolInfo),
 }
 /// Information about the Ethereum Wire Protocol (ETH)
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 pub struct EthProtocolInfo {
     /// The current difficulty at the head of the chain.
     pub difficulty: U256,

--- a/crates/net/rpc-types/src/admin.rs
+++ b/crates/net/rpc-types/src/admin.rs
@@ -1,4 +1,5 @@
-use reth_primitives::{NodeRecord, U256};
+use std::net::{IpAddr, SocketAddr};
+use reth_primitives::{NodeRecord, U256, H512, rpc::H256};
 use serde::{Deserialize, Serialize};
 
 /// Represents the `admin_nodeInfo` response, which can be queried for all the information
@@ -11,12 +12,12 @@ pub struct NodeInfo {
     /// Enode in URL format.
     pub enode: String,
     /// ID of the local node.
-    pub id: String,
+    pub id: H512,
     /// IP of the local node.
-    pub ip: String,
+    pub ip: IpAddr,
     /// Address exposed for listening for the local node.
     #[serde(rename = "listenAddr")]
-    pub listen_addr: String,
+    pub listen_addr: SocketAddr,
     /// Local node client name.
     pub name: String,
     /// Ports exposed by the node for discovery and listening.
@@ -30,9 +31,9 @@ impl NodeInfo {
     pub fn new(enr: NodeRecord) -> NodeInfo {
         NodeInfo {
             enode: enr.to_string(),
-            id: enr.id.to_string(),
-            ip: enr.address.to_string(),
-            listen_addr: enr.tcp_addr().to_string(),
+            id: enr.id,
+            ip: enr.address,
+            listen_addr: enr.tcp_addr(),
             name: "Reth".to_owned(),
             ports: Ports { discovery: enr.tcp_port.into(), listener: enr.tcp_port.into() },
             protocols: Protocols {
@@ -64,9 +65,9 @@ pub struct Eth {
     /// Total difficulty of the best chain.
     pub difficulty: U256,
     /// The hash of the genesis block.
-    pub genesis: String,
+    pub genesis: H256,
     /// Hash of the latest block of the best chain.
-    pub head: String,
+    pub head: H256,
     /// Network ID in base 10.
     pub network: u64,
 }

--- a/crates/net/rpc-types/src/admin.rs
+++ b/crates/net/rpc-types/src/admin.rs
@@ -51,7 +51,7 @@ impl NodeInfo {
             ip: enr.address,
             listen_addr: enr.tcp_addr(),
             name: "Reth".to_owned(),
-            ports: Ports { discovery: enr.udp_port.into(), listener: enr.tcp_port.into() },
+            ports: Ports { discovery: enr.udp_port, listener: enr.tcp_port },
             protocols: protocol_info,
         }
     }
@@ -69,6 +69,7 @@ pub struct Ports {
 /// Information about the different protocols that can be run by the node (ETH, )
 #[derive(Serialize, Deserialize, Debug)]
 pub enum ProtocolInfo {
+    // Information about the Ethereum Wire Protocol.
     Eth(EthInfo),
 }
 /// Information about the Ethereum Wire Protocol (ETH)

--- a/crates/net/rpc-types/src/admin.rs
+++ b/crates/net/rpc-types/src/admin.rs
@@ -1,5 +1,5 @@
 use crate::EthProtocolInfo;
-use reth_primitives::{NodeRecord, PeerId};
+use reth_primitives::{NodeRecord, PeerId, H256};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeMap,
@@ -42,6 +42,7 @@ impl NodeInfo {
                     head: todo!(),
                 },
                 network: todo!(),
+                genesis: todo!(),
             }),
         )]);
 
@@ -69,7 +70,7 @@ pub struct Ports {
 /// Information about the different protocols that can be run by the node (ETH, )
 #[derive(Serialize, Deserialize, Debug)]
 pub enum ProtocolInfo {
-    // Information about the Ethereum Wire Protocol.
+    /// Information about the Ethereum Wire Protocol.
     Eth(EthInfo),
 }
 /// Information about the Ethereum Wire Protocol (ETH)
@@ -80,4 +81,6 @@ pub struct EthInfo {
     pub eth_protocol_info: EthProtocolInfo,
     /// Network ID in base 10.
     pub network: u64,
+    /// Genesis block of the current chain.
+    pub genesis: H256,
 }

--- a/crates/net/rpc-types/src/eth/syncing.rs
+++ b/crates/net/rpc-types/src/eth/syncing.rs
@@ -76,7 +76,7 @@ pub struct PeerProtocolsInfo {
 }
 
 /// Peer Ethereum protocol information
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct EthProtocolInfo {
     /// Negotiated ethereum protocol version
     pub version: u32,

--- a/crates/net/rpc-types/src/lib.rs
+++ b/crates/net/rpc-types/src/lib.rs
@@ -9,6 +9,8 @@
 //!
 //! Provides all relevant types for the various RPC endpoints, grouped by namespace.
 
+mod admin;
 mod eth;
 
+pub use admin::*;
 pub use eth::*;

--- a/crates/net/rpc/src/admin.rs
+++ b/crates/net/rpc/src/admin.rs
@@ -13,6 +13,13 @@ pub struct AdminApi {
     network: NetworkHandle,
 }
 
+impl AdminApi {
+    /// Creates a new instance of `AdminApi`.
+    pub fn new(network: NetworkHandle) -> AdminApi {
+        AdminApi { network }
+    }
+}
+
 impl AdminApiServer for AdminApi {
     fn add_peer(&self, record: NodeRecord) -> RpcResult<bool> {
         self.network.add_peer(record.id, record.tcp_addr());

--- a/crates/net/rpc/src/admin.rs
+++ b/crates/net/rpc/src/admin.rs
@@ -3,6 +3,7 @@ use reth_network::{peers::PeerKind, NetworkHandle};
 use reth_network_api::PeersInfo;
 use reth_primitives::NodeRecord;
 use reth_rpc_api::AdminApiServer;
+use reth_rpc_types::NodeInfo;
 
 /// `admin` API implementation.
 ///
@@ -40,8 +41,10 @@ impl AdminApiServer for AdminApi {
         todo!()
     }
 
-    fn node_info(&self) -> RpcResult<NodeRecord> {
-        Ok(self.network.local_node_record())
+    fn node_info(&self) -> RpcResult<NodeInfo> {
+        let enr = self.network.local_node_record();
+
+        Ok(NodeInfo::new(enr))
     }
 }
 

--- a/crates/net/rpc/src/admin.rs
+++ b/crates/net/rpc/src/admin.rs
@@ -40,7 +40,7 @@ impl AdminApiServer for AdminApi {
         todo!()
     }
 
-    fn node_info(&self) -> RpcResult<NodeRecord>  {
+    fn node_info(&self) -> RpcResult<NodeRecord> {
         Ok(self.network.local_node_record())
     }
 }

--- a/crates/net/rpc/src/admin.rs
+++ b/crates/net/rpc/src/admin.rs
@@ -1,5 +1,6 @@
 use jsonrpsee::core::RpcResult;
 use reth_network::{peers::PeerKind, NetworkHandle};
+use reth_network_api::PeersInfo;
 use reth_primitives::NodeRecord;
 use reth_rpc_api::AdminApiServer;
 
@@ -37,6 +38,10 @@ impl AdminApiServer for AdminApi {
         _subscription_sink: jsonrpsee::SubscriptionSink,
     ) -> jsonrpsee::types::SubscriptionResult {
         todo!()
+    }
+
+    fn node_info(&self) -> RpcResult<NodeRecord>  {
+        Ok(self.network.local_node_record())
     }
 }
 


### PR DESCRIPTION
Closes #850.

Adds the rpc method `admin_nodeInfo`, which returns the local node's ENR.

I'd like to ask about this part of the issue:

> Additionally, AdminApi in the reth-rpc crate should be exported and constructable: currently it is private and impossible to construct.

AdminApi seems to have been exported with #866 : https://github.com/paradigmxyz/reth/blob/main/crates/net/rpc/src/lib.rs#L19 but what does constructable mean? just providing a `new` method?
