### PR TITLE
Added bench for recovering a transaction's signature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4027,6 +4027,7 @@ dependencies = [
  "arbitrary",
  "bytes",
  "crc",
+ "criterion",
  "derive_more",
  "ethers-core",
  "fixed-hash",

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -77,7 +77,12 @@ proptest-derive = "0.3"
 # necessary so we don't hit a "undeclared 'std'": 
 # https://github.com/paradigmxyz/reth/pull/177#discussion_r1021172198 
 secp256k1 = "0.24.2"
+criterion = "0.4.0"
 
 [features]
 default = []
 arbitrary = ["revm-interpreter/arbitrary", "dep:arbitrary", "dep:proptest", "dep:proptest-derive"]
+
+[[bench]]
+name = "recover_ecdsa_crit"
+harness = false

--- a/crates/primitives/benches/recover_ecdsa_crit.rs
+++ b/crates/primitives/benches/recover_ecdsa_crit.rs
@@ -1,0 +1,20 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use hex_literal::hex;
+use reth_primitives::TransactionSigned;
+use reth_rlp::Decodable;
+
+/// Benchmarks the recovery of the public key from the ECDSA message using criterion.
+pub fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("recover ECDSA", |b| {
+        b.iter(|| {
+            let raw =hex!("f88b8212b085028fa6ae00830f424094aad593da0c8116ef7d2d594dd6a63241bccfc26c80a48318b64b000000000000000000000000641c5d790f862a58ec7abcfd644c0442e9c201b32aa0a6ef9e170bca5ffb7ac05433b13b7043de667fbb0b4a5e45d3b54fb2d6efcc63a0037ec2c05c3d60c5f5f78244ce0a3859e3a18a36c61efb061b383507d3ce19d2");
+            let mut pointer = raw.as_ref();
+            let tx = TransactionSigned::decode(&mut pointer).unwrap();
+            tx.recover_signer();
+            }
+        )
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
- The SendersRecovery stage is almost entirely spent recovering transaction signatures, so let's benchmark this to see if we can improve it or at least not regress