### PR TITLE
fix(book): incorrect paths for book pages

### DIFF
--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -2,9 +2,9 @@
 
 ## Getting Started
 - [Introduction](./README.md)
-- [System requirements](./getting_started/system_requirement.md)
-- [Installation Reth](./getting_started/installation.md)
-- [Running Reth](./getting_started//running.md)
+- [System requirements](./getting_started/system_requirements.md)
+- [Installation](./getting_started/installation.md)
+- [Running Reth](./getting_started/running.md)
 
 ## Fundamentals
 - [Node](./fundamentals/node.md)


### PR DESCRIPTION
- Use correct file name `system_requirements.md`. This was causing an empty page because the referenced file didn't exist.
- Fix routing/rendering of the `running.md` page. Extra `/` was causing built site to request assets from incorrect home path.
- Change `installation.md` page title for improved grammar.