### PR TITLE
feat(net): integrate num active peers in downloader

### DIFF
--- a/crates/interfaces/src/p2p/downloader.rs
+++ b/crates/interfaces/src/p2p/downloader.rs
@@ -13,6 +13,9 @@ pub trait DownloadClient: Send + Sync + Debug {
     /// Penalize the peer for responding with a message
     /// that violates validation rules
     fn report_bad_message(&self, peer_id: PeerId);
+
+    /// Returns how many peers the network is currently connected to.
+    fn num_connected_peers(&self) -> usize;
 }
 
 /// The generic trait for requesting and verifying data

--- a/crates/interfaces/src/test_utils/bodies.rs
+++ b/crates/interfaces/src/test_utils/bodies.rs
@@ -22,6 +22,10 @@ impl<F: Sync + Send> DownloadClient for TestBodiesClient<F> {
     fn report_bad_message(&self, _peer_id: reth_primitives::PeerId) {
         // noop
     }
+
+    fn num_connected_peers(&self) -> usize {
+        0
+    }
 }
 
 #[async_trait]

--- a/crates/interfaces/src/test_utils/headers.rs
+++ b/crates/interfaces/src/test_utils/headers.rs
@@ -179,6 +179,10 @@ impl DownloadClient for TestHeadersClient {
     fn report_bad_message(&self, _peer_id: PeerId) {
         // noop
     }
+
+    fn num_connected_peers(&self) -> usize {
+        0
+    }
 }
 
 #[async_trait::async_trait]

--- a/crates/net/downloaders/src/test_utils.rs
+++ b/crates/net/downloaders/src/test_utils.rs
@@ -57,6 +57,10 @@ impl<F: Send + Sync> DownloadClient for TestBodiesClient<F> {
     fn report_bad_message(&self, _peer_id: PeerId) {
         // noop
     }
+
+    fn num_connected_peers(&self) -> usize {
+        0
+    }
 }
 
 #[async_trait]

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -184,6 +184,7 @@ where
         // need to retrieve the addr here since provided port could be `0`
         let local_peer_id = discovery.local_id();
 
+        let num_active_peers = Arc::new(AtomicUsize::new(0));
         let bandwidth_meter: BandwidthMeter = BandwidthMeter::default();
 
         let sessions = SessionManager::new(
@@ -195,13 +196,18 @@ where
             fork_filter,
             bandwidth_meter.clone(),
         );
-        let state = NetworkState::new(client, discovery, peers_manager, genesis_hash);
+        let state = NetworkState::new(
+            client,
+            discovery,
+            peers_manager,
+            genesis_hash,
+            Arc::clone(&num_active_peers),
+        );
 
         let swarm = Swarm::new(incoming, sessions, state);
 
         let (to_manager_tx, from_handle_rx) = mpsc::unbounded_channel();
 
-        let num_active_peers = Arc::new(AtomicUsize::new(0));
         let handle = NetworkHandle::new(
             Arc::clone(&num_active_peers),
             listener_address,

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -20,7 +20,10 @@ use std::{
     collections::{HashMap, VecDeque},
     net::{IpAddr, SocketAddr},
     num::NonZeroUsize,
-    sync::{atomic::AtomicU64, Arc},
+    sync::{
+        atomic::{AtomicU64, AtomicUsize},
+        Arc,
+    },
     task::{Context, Poll},
 };
 use tokio::sync::oneshot;
@@ -69,8 +72,9 @@ where
         discovery: Discovery,
         peers_manager: PeersManager,
         genesis_hash: H256,
+        num_active_peers: Arc<AtomicUsize>,
     ) -> Self {
-        let state_fetcher = StateFetcher::new(peers_manager.handle());
+        let state_fetcher = StateFetcher::new(peers_manager.handle(), num_active_peers);
         Self {
             active_peers: Default::default(),
             peers_manager,
@@ -525,7 +529,7 @@ mod tests {
             client: Arc::new(NoopProvider::default()),
             discovery: Discovery::noop(),
             genesis_hash: Default::default(),
-            state_fetcher: StateFetcher::new(handle),
+            state_fetcher: StateFetcher::new(handle, Default::default()),
         }
     }
 

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -775,6 +775,10 @@ mod tests {
             fn report_bad_message(&self, _: reth_primitives::PeerId) {
                 panic!("Noop client should not be called")
             }
+
+            fn num_connected_peers(&self) -> usize {
+                panic!("Noop client should not be called")
+            }
         }
 
         #[async_trait::async_trait]


### PR DESCRIPTION
adds `num_active_peers` to `Downloader`, this way we can adjust concurrent requests based on the number of active peers.