### PR TITLE
fix(net): reset backoff counter on graceful disconnect

### DIFF
--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -317,6 +317,10 @@ impl PeersManager {
                     entry.remove();
                     self.queued_actions.push_back(PeerAction::PeerRemoved(peer_id));
                 } else {
+                    // reset the peer's state
+                    // we reset the backoff counter since we're able to establish a succesful
+                    // session to that peer
+                    entry.get_mut().backoff_counter = 0;
                     entry.get_mut().state = PeerConnectionState::Idle;
                     return
                 }


### PR DESCRIPTION
if we were able to successfully establish an active session and disconnected it gracefully, we should reset the backoff counter