### PR TITLE
build: bump the CRC crate from 1.x to 3.x

### DIFF
--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -39,7 +39,7 @@ secp256k1 = { version = "0.24.2", default-features = false, features = [
 ] }
 
 # used for forkid
-crc = "1"
+crc = "3"
 
 # misc
 bytes = "1.2"

--- a/crates/primitives/src/forkid.rs
+++ b/crates/primitives/src/forkid.rs
@@ -48,6 +48,7 @@ impl From<H256> for ForkHash {
 impl AddAssign<BlockNumber> for ForkHash {
     fn add_assign(&mut self, block: BlockNumber) {
         let blob = block.to_be_bytes();
+        #[allow(clippy::suspicious_op_assign_impl)]
         let initial = (u32::from_be_bytes(self.0) ^ CRC_32_IEEE.algorithm.xorout).reverse_bits();
         let mut digest = CRC_32_IEEE.digest_with_initial(initial);
         digest.update(&blob);

--- a/crates/primitives/src/forkid.rs
+++ b/crates/primitives/src/forkid.rs
@@ -4,7 +4,7 @@
 #![deny(missing_docs)]
 
 use crate::{BlockNumber, H256};
-use crc::crc32;
+use crc::*;
 use reth_codecs::derive_arbitrary;
 use reth_rlp::*;
 use serde::{Deserialize, Serialize};
@@ -14,6 +14,8 @@ use std::{
     ops::{Add, AddAssign},
 };
 use thiserror::Error;
+
+const CRC_32_IEEE: Crc<u32> = Crc::<u32>::new(&CRC_32_ISO_HDLC);
 
 /// `CRC32` hash of all previous forks starting from genesis block.
 #[derive_arbitrary(rlp)]
@@ -39,14 +41,17 @@ impl fmt::Debug for ForkHash {
 
 impl From<H256> for ForkHash {
     fn from(genesis: H256) -> Self {
-        Self(crc32::checksum_ieee(&genesis[..]).to_be_bytes())
+        Self(CRC_32_IEEE.checksum(&genesis[..]).to_be_bytes())
     }
 }
 
 impl AddAssign<BlockNumber> for ForkHash {
     fn add_assign(&mut self, block: BlockNumber) {
         let blob = block.to_be_bytes();
-        self.0 = crc32::update(u32::from_be_bytes(self.0), &crc32::IEEE_TABLE, &blob).to_be_bytes();
+        let initial = (u32::from_be_bytes(self.0) ^ CRC_32_IEEE.algorithm.xorout).reverse_bits();
+        let mut digest = CRC_32_IEEE.digest_with_initial(initial);
+        digest.update(&blob);
+        self.0 = digest.finalize().to_be_bytes();
     }
 }
 

--- a/crates/primitives/src/forkid.rs
+++ b/crates/primitives/src/forkid.rs
@@ -48,9 +48,9 @@ impl From<H256> for ForkHash {
 impl AddAssign<BlockNumber> for ForkHash {
     fn add_assign(&mut self, block: BlockNumber) {
         let blob = block.to_be_bytes();
-        #[allow(clippy::suspicious_op_assign_impl)]
-        let initial = (u32::from_be_bytes(self.0) ^ CRC_32_IEEE.algorithm.xorout).reverse_bits();
-        let mut digest = CRC_32_IEEE.digest_with_initial(initial);
+        let digest = CRC_32_IEEE.digest_with_initial(u32::from_be_bytes(self.0));
+        let value = digest.finalize();
+        let mut digest = CRC_32_IEEE.digest_with_initial(value);
         digest.update(&blob);
         self.0 = digest.finalize().to_be_bytes();
     }


### PR DESCRIPTION
[CRC 1.x](https://crates.io/crates/crc/versions) has not been updated for over 4 years, this PR upgraded it to 3.x.