### PR TITLE
fix(net): set status, forkfilter from chainspec

### DIFF
--- a/crates/net/eth-wire/src/types/status.rs
+++ b/crates/net/eth-wire/src/types/status.rs
@@ -1,4 +1,4 @@
-use crate::{EthVersion, StatusBuilder};
+use crate::{BlockHashNumber, EthVersion, StatusBuilder};
 
 use ethers_core::utils::Genesis;
 use reth_codecs::derive_arbitrary;
@@ -81,6 +81,23 @@ impl Status {
     /// Helper for returning a builder for the status message.
     pub fn builder() -> StatusBuilder {
         Default::default()
+    }
+
+    /// Create a [`StatusBuilder`] from the given [`ChainSpec`](reth_primitives::ChainSpec) and
+    /// head block number.
+    ///
+    /// Sets the `chain` and `genesis`, `blockhash`, and `forkid` fields based on the [`ChainSpec`]
+    /// and head.
+    ///
+    /// The user should set the `total_difficulty` field if desired. Otherwise, the total
+    /// difficulty will be set to the [`Default`](std::default::Default) implementation for
+    /// [`Status`].
+    pub fn spec_builder(spec: &ChainSpec, head: &BlockHashNumber) -> StatusBuilder {
+        Self::builder()
+            .chain(spec.chain)
+            .genesis(spec.genesis_hash())
+            .blockhash(head.hash)
+            .forkid(spec.fork_id(head.number))
     }
 }
 

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -94,5 +94,6 @@ tempfile = "3.3"
 serial_test = "0.10"
 
 [features]
+default = ["serde"]
 serde = ["dep:serde", "dep:humantime-serde"]
 test-utils = ["reth-provider/test-utils", "dep:enr", "dep:ethers-core", "dep:tempfile"]


### PR DESCRIPTION
Previously, if unset, the `fork_filter` for the `NetworkConfig` would be set using the `chain_spec` and `head` fields. The `status` would be its default value, but the `fork_filter` being generated from the chainspec. As a result, the fork filter would not match the status. This would lead to unintentional disconnects by us on custom networks.

This removes the `status` and `fork_filter` fields from the network config builder, and changes the `head` field type to `BlockHashNumber`. If unset, the head hash is set to the genesis hash, and the head number set to zero. The `Status` and `ForkFilter` are then set based on this head and existing chainspec.

This adds a test checking that the forkid `hash` and `next` are set to the correct values, based on the chainspec.

Sets `serde` as a default feature for `reth-network`.