### PR TITLE
chore(net): reduce log level for outgoing conn errors

### DIFF
--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -689,7 +689,7 @@ where
                         .set(this.swarm.state().peers().num_inbound_connections() as f64);
                 }
                 SwarmEvent::OutgoingPendingSessionClosed { remote_addr, peer_id, error } => {
-                    warn!(
+                    trace!(
                         target : "net",
                         ?remote_addr,
                         ?peer_id,
@@ -716,7 +716,7 @@ where
                         .set(this.swarm.state().peers().num_outbound_connections() as f64);
                 }
                 SwarmEvent::OutgoingConnectionError { remote_addr, peer_id, error } => {
-                    warn!(
+                    trace!(
                         target : "net",
                         ?remote_addr,
                         ?peer_id,

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -36,7 +36,7 @@ use tokio::{
     sync::{mpsc, oneshot},
 };
 use tokio_stream::wrappers::ReceiverStream;
-use tracing::{instrument, trace, warn};
+use tracing::{instrument, trace};
 
 mod active;
 mod config;
@@ -460,7 +460,7 @@ impl SessionManager {
             }
             PendingSessionEvent::EciesAuthError { remote_addr, session_id, error, direction } => {
                 self.remove_pending_session(&session_id);
-                warn!(
+                trace!(
                     target : "net::session",
                     ?error,
                     ?session_id,


### PR DESCRIPTION
now that outgoing connection errors are no longer an issue, we should lower the log target.
especially since there are a lot of those cases