### PR TITLE
refactor: remove legacy headermetrics describe

### DIFF
--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -117,7 +117,6 @@ impl Command {
         if let Some(listen_addr) = self.metrics {
             info!(target: "reth::cli", addr = %listen_addr, "Starting metrics endpoint");
             prometheus_exporter::initialize(listen_addr)?;
-            HeaderMetrics::describe();
         }
 
         let genesis = init_genesis(db.clone(), self.chain.genesis().clone())?;

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -21,7 +21,6 @@ use reth_network::NetworkEvent;
 use reth_network_api::NetworkInfo;
 use reth_primitives::{BlockNumber, ChainSpec, NodeRecord, H256};
 use reth_stages::{
-    metrics::HeaderMetrics,
     stages::{
         bodies::BodyStage, execution::ExecutionStage, hashing_account::AccountHashingStage,
         hashing_storage::StorageHashingStage, headers::HeaderStage, merkle::MerkleStage,

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -21,6 +21,7 @@ use reth_network::NetworkEvent;
 use reth_network_api::NetworkInfo;
 use reth_primitives::{BlockNumber, ChainSpec, NodeRecord, H256};
 use reth_stages::{
+    metrics::HeaderMetrics,
     stages::{
         bodies::BodyStage, execution::ExecutionStage, hashing_account::AccountHashingStage,
         hashing_storage::StorageHashingStage, headers::HeaderStage, merkle::MerkleStage,

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -14,7 +14,6 @@ use reth_downloaders::bodies::concurrent::ConcurrentDownloader;
 use reth_net_nat::NatResolver;
 use reth_primitives::ChainSpec;
 use reth_stages::{
-    metrics::HeaderMetrics,
     stages::{bodies::BodyStage, execution::ExecutionStage, sender_recovery::SenderRecoveryStage},
     ExecInput, Stage, StageId, Transaction, UnwindInput,
 };

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -108,7 +108,6 @@ impl Command {
         if let Some(listen_addr) = self.metrics {
             info!(target: "reth::cli", "Starting metrics endpoint at {}", listen_addr);
             prometheus_exporter::initialize(listen_addr)?;
-            HeaderMetrics::describe();
         }
 
         let config: Config = confy::load_path(&self.config).unwrap_or_default();


### PR DESCRIPTION
Skimming through the code realized there were two legacy `HeaderMetrics::describe()` calls. This is now handled with the metrics macros.