### PR TITLE
chore: prevent redundant hash initialization

### DIFF
--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -685,9 +685,9 @@ impl Decodable for TransactionSigned {
                 transaction.set_chain_id(id);
             }
 
-            let mut signed = TransactionSigned { transaction, hash: Default::default(), signature };
             let tx_length = first_header.payload_length + first_header.length();
-            signed.hash = keccak256(&original_encoding[..tx_length]);
+            let hash = keccak256(&original_encoding[..tx_length]);
+            let signed = TransactionSigned { transaction, hash, signature };
             Ok(signed)
         }
     }


### PR DESCRIPTION
get rid of redundant `hash: Default::default`