### PR TITLE
docs: document rlp derive macros

### DIFF
--- a/crates/common/rlp-derive/src/de.rs
+++ b/crates/common/rlp-derive/src/de.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-pub fn impl_decodable(ast: &syn::DeriveInput) -> TokenStream {
+pub(crate) fn impl_decodable(ast: &syn::DeriveInput) -> TokenStream {
     let body = if let syn::Data::Struct(s) = &ast.data {
         s
     } else {
@@ -51,7 +51,7 @@ pub fn impl_decodable(ast: &syn::DeriveInput) -> TokenStream {
     }
 }
 
-pub fn impl_decodable_wrapper(ast: &syn::DeriveInput) -> TokenStream {
+pub(crate) fn impl_decodable_wrapper(ast: &syn::DeriveInput) -> TokenStream {
     let body = if let syn::Data::Struct(s) = &ast.data {
         s
     } else {

--- a/crates/common/rlp-derive/src/en.rs
+++ b/crates/common/rlp-derive/src/en.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-pub fn impl_encodable(ast: &syn::DeriveInput) -> TokenStream {
+pub(crate) fn impl_encodable(ast: &syn::DeriveInput) -> TokenStream {
     let body = if let syn::Data::Struct(s) = &ast.data {
         s
     } else {
@@ -49,7 +49,7 @@ pub fn impl_encodable(ast: &syn::DeriveInput) -> TokenStream {
     }
 }
 
-pub fn impl_encodable_wrapper(ast: &syn::DeriveInput) -> TokenStream {
+pub(crate) fn impl_encodable_wrapper(ast: &syn::DeriveInput) -> TokenStream {
     let body = if let syn::Data::Struct(s) = &ast.data {
         s
     } else {
@@ -88,7 +88,7 @@ pub fn impl_encodable_wrapper(ast: &syn::DeriveInput) -> TokenStream {
     }
 }
 
-pub fn impl_max_encoded_len(ast: &syn::DeriveInput) -> TokenStream {
+pub(crate) fn impl_max_encoded_len(ast: &syn::DeriveInput) -> TokenStream {
     let body = if let syn::Data::Struct(s) = &ast.data {
         s
     } else {

--- a/crates/common/rlp-derive/src/lib.rs
+++ b/crates/common/rlp-derive/src/lib.rs
@@ -1,3 +1,10 @@
+#![warn(missing_docs, unreachable_pub)]
+#![deny(unused_must_use)]
+#![doc(test(
+    no_crate_inject,
+    attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
+))]
+
 //! Derive macro for `#[derive(RlpEncodable, RlpDecodable)]`.
 //!
 //! For example of usage see `./tests/rlp.rs`.
@@ -17,34 +24,55 @@ use de::*;
 use en::*;
 use proc_macro::TokenStream;
 
+/// Derives `Encodable` for the type which encodes the all fields as list: `<rlp-header, fields...>`
 #[proc_macro_derive(RlpEncodable, attributes(rlp))]
 pub fn encodable(input: TokenStream) -> TokenStream {
-    let ast = syn::parse(input).unwrap();
+    let ast = match syn::parse(input) {
+        Ok(ast) => ast,
+        Err(err) => return err.to_compile_error().into()
+    };
     let gen = impl_encodable(&ast);
     gen.into()
 }
 
+/// Derives `Encodable` for the type which encodes the fields as-is, without a header: `<fields...>`
 #[proc_macro_derive(RlpEncodableWrapper, attributes(rlp))]
 pub fn encodable_wrapper(input: TokenStream) -> TokenStream {
-    let ast = syn::parse(input).unwrap();
+    let ast = match syn::parse(input) {
+        Ok(ast) => ast,
+        Err(err) => return err.to_compile_error().into()
+    };
     let gen = impl_encodable_wrapper(&ast);
     gen.into()
 }
 
+/// Derives `MaxEncodedLen` for types of constant size.
 #[proc_macro_derive(RlpMaxEncodedLen, attributes(rlp))]
 pub fn max_encoded_len(input: TokenStream) -> TokenStream {
-    let ast = syn::parse(input).unwrap();
+    let ast = match syn::parse(input) {
+        Ok(ast) => ast,
+        Err(err) => return err.to_compile_error().into()
+    };
     let gen = impl_max_encoded_len(&ast);
     gen.into()
 }
 
+/// Derives `Decodable` for the type whose implementation expects an rlp-list input: `<rlp-header, fields...>`
+///
+/// This is the inverse of `RlpEncodable`.
 #[proc_macro_derive(RlpDecodable, attributes(rlp))]
 pub fn decodable(input: TokenStream) -> TokenStream {
-    let ast = syn::parse(input).unwrap();
+    let ast = match syn::parse(input) {
+        Ok(ast) => ast,
+        Err(err) => return err.to_compile_error().into()
+    };
     let gen = impl_decodable(&ast);
     gen.into()
 }
 
+/// Derives `Decodable` for the type whose implementation expects only the individual fields encoded: `<fields...>`
+///
+/// This is the inverse of `RlpEncodableWrapper`.
 #[proc_macro_derive(RlpDecodableWrapper, attributes(rlp))]
 pub fn decodable_wrapper(input: TokenStream) -> TokenStream {
     let ast = syn::parse(input).unwrap();

--- a/crates/common/rlp-derive/src/lib.rs
+++ b/crates/common/rlp-derive/src/lib.rs
@@ -29,7 +29,7 @@ use proc_macro::TokenStream;
 pub fn encodable(input: TokenStream) -> TokenStream {
     let ast = match syn::parse(input) {
         Ok(ast) => ast,
-        Err(err) => return err.to_compile_error().into()
+        Err(err) => return err.to_compile_error().into(),
     };
     let gen = impl_encodable(&ast);
     gen.into()
@@ -40,7 +40,7 @@ pub fn encodable(input: TokenStream) -> TokenStream {
 pub fn encodable_wrapper(input: TokenStream) -> TokenStream {
     let ast = match syn::parse(input) {
         Ok(ast) => ast,
-        Err(err) => return err.to_compile_error().into()
+        Err(err) => return err.to_compile_error().into(),
     };
     let gen = impl_encodable_wrapper(&ast);
     gen.into()
@@ -51,26 +51,28 @@ pub fn encodable_wrapper(input: TokenStream) -> TokenStream {
 pub fn max_encoded_len(input: TokenStream) -> TokenStream {
     let ast = match syn::parse(input) {
         Ok(ast) => ast,
-        Err(err) => return err.to_compile_error().into()
+        Err(err) => return err.to_compile_error().into(),
     };
     let gen = impl_max_encoded_len(&ast);
     gen.into()
 }
 
-/// Derives `Decodable` for the type whose implementation expects an rlp-list input: `<rlp-header, fields...>`
+/// Derives `Decodable` for the type whose implementation expects an rlp-list input: `<rlp-header,
+/// fields...>`
 ///
 /// This is the inverse of `RlpEncodable`.
 #[proc_macro_derive(RlpDecodable, attributes(rlp))]
 pub fn decodable(input: TokenStream) -> TokenStream {
     let ast = match syn::parse(input) {
         Ok(ast) => ast,
-        Err(err) => return err.to_compile_error().into()
+        Err(err) => return err.to_compile_error().into(),
     };
     let gen = impl_decodable(&ast);
     gen.into()
 }
 
-/// Derives `Decodable` for the type whose implementation expects only the individual fields encoded: `<fields...>`
+/// Derives `Decodable` for the type whose implementation expects only the individual fields
+/// encoded: `<fields...>`
 ///
 /// This is the inverse of `RlpEncodableWrapper`.
 #[proc_macro_derive(RlpDecodableWrapper, attributes(rlp))]


### PR DESCRIPTION
document rlp derive macros and highlight difference between Wrapper and normal derive macro