### PR TITLE
chore: add help text for `--bootnodes`

### DIFF
--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -36,4 +36,10 @@ struct NetworkOpts {
     /// Connect only to trusted peers
     #[arg(long)]
     trusted_only: bool,
+
+    /// Bootnodes to connect to initially.
+    ///
+    /// Will fall back to a network-specific default if not specified.
+    #[arg(long, value_delimiter = ',')]
+    bootnodes: Option<Vec<NodeRecord>>,
 }

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -19,7 +19,7 @@ use reth_interfaces::consensus::ForkchoiceState;
 use reth_net_nat::NatResolver;
 use reth_network::NetworkEvent;
 use reth_network_api::NetworkInfo;
-use reth_primitives::{BlockNumber, ChainSpec, NodeRecord, H256};
+use reth_primitives::{BlockNumber, ChainSpec, H256};
 use reth_stages::{
     metrics::HeaderMetrics,
     stages::{

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -83,9 +83,6 @@ pub struct Command {
     #[clap(flatten)]
     network: NetworkOpts,
 
-    #[arg(long, value_delimiter = ',')]
-    bootnodes: Option<Vec<NodeRecord>>,
-
     #[arg(long, default_value = "any")]
     nat: NatResolver,
 }
@@ -129,7 +126,7 @@ impl Command {
                 db.clone(),
                 self.chain.clone(),
                 self.network.disable_discovery,
-                self.bootnodes.clone(),
+                self.network.bootnodes.clone(),
                 self.nat,
             )
             .start_network()


### PR DESCRIPTION
- Moves the `bootnodes` flag to `NetworkOpts`
- Adds help text