### PR TITLE
fix(staged-sync): write genesis EIP1559 base fee

### DIFF
--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -115,7 +115,7 @@ impl Command {
             prometheus_exporter::initialize(listen_addr)?;
         }
 
-        let genesis = init_genesis(db.clone(), self.chain.genesis().clone())?;
+        let genesis = init_genesis(db.clone(), self.chain.clone())?;
         info!(target: "reth::cli", ?genesis, "Inserted genesis");
 
         let consensus: Arc<BeaconConsensus> = Arc::new(BeaconConsensus::new(self.chain.clone()));

--- a/crates/staged-sync/src/utils/init.rs
+++ b/crates/staged-sync/src/utils/init.rs
@@ -26,7 +26,7 @@ pub fn init_db<P: AsRef<Path>>(path: P) -> eyre::Result<Env<WriteMap>> {
 /// Write the genesis block if it has not already been written
 #[allow(clippy::field_reassign_with_default)]
 pub fn init_genesis<DB: Database>(db: Arc<DB>, chain: ChainSpec) -> Result<H256, reth_db::Error> {
-    let genesis = chain.genesis;
+    let genesis = chain.genesis();
     let tx = db.tx()?;
     if let Some((_, hash)) = tx.cursor_read::<tables::CanonicalHeaders>()?.first()? {
         debug!("Genesis already written, skipping.");
@@ -50,10 +50,10 @@ pub fn init_genesis<DB: Database>(db: Arc<DB>, chain: ChainSpec) -> Result<H256,
     }
 
     // Insert header
-    let mut header: Header = genesis.into();
+    let mut header: Header = genesis.clone().into();
 
     // set base fee if EIP-1559 is enabled
-    if let Some(0) = chain.hardforks.get(&Hardfork::London) {
+    if chain.fork_active(Hardfork::London, 0) {
         header.base_fee_per_gas = Some(EIP1559_INITIAL_BASE_FEE);
     }
 

--- a/crates/staged-sync/src/utils/init.rs
+++ b/crates/staged-sync/src/utils/init.rs
@@ -5,7 +5,9 @@ use reth_db::{
     tables,
     transaction::{DbTx, DbTxMut},
 };
-use reth_primitives::{Account, Genesis, Header, H256};
+use reth_primitives::{
+    constants::EIP1559_INITIAL_BASE_FEE, Account, ChainSpec, Hardfork, Header, H256,
+};
 use std::{path::Path, sync::Arc};
 use tracing::debug;
 
@@ -23,12 +25,14 @@ pub fn init_db<P: AsRef<Path>>(path: P) -> eyre::Result<Env<WriteMap>> {
 
 /// Write the genesis block if it has not already been written
 #[allow(clippy::field_reassign_with_default)]
-pub fn init_genesis<DB: Database>(db: Arc<DB>, genesis: Genesis) -> Result<H256, reth_db::Error> {
+pub fn init_genesis<DB: Database>(db: Arc<DB>, chain: ChainSpec) -> Result<H256, reth_db::Error> {
+    let genesis = chain.genesis;
     let tx = db.tx()?;
     if let Some((_, hash)) = tx.cursor_read::<tables::CanonicalHeaders>()?.first()? {
         debug!("Genesis already written, skipping.");
         return Ok(hash)
     }
+
     drop(tx);
     debug!("Writing genesis block.");
     let tx = db.tx_mut()?;
@@ -46,7 +50,13 @@ pub fn init_genesis<DB: Database>(db: Arc<DB>, genesis: Genesis) -> Result<H256,
     }
 
     // Insert header
-    let header: Header = genesis.into();
+    let mut header: Header = genesis.into();
+
+    // set base fee if EIP-1559 is enabled
+    if let Some(0) = chain.hardforks.get(&Hardfork::London) {
+        header.base_fee_per_gas = Some(EIP1559_INITIAL_BASE_FEE);
+    }
+
     let hash = header.hash_slow();
     tx.put::<tables::CanonicalHeaders>(0, hash)?;
     tx.put::<tables::HeaderNumbers>(hash, 0)?;


### PR DESCRIPTION
If London is activated at genesis, then the `EIP1559_INITIAL_BASE_FEE` should be included in the genesis header written to the db during initialization.

Changes `init_genesis` to accept a `ChainSpec` instead of a `Genesis`.