### PR TITLE
fix: mark response correctly

### DIFF
--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -4,7 +4,7 @@ use crate::{message::BlockRequest, peers::PeersHandle};
 use futures::StreamExt;
 use reth_eth_wire::{BlockBody, GetBlockBodies, GetBlockHeaders};
 use reth_interfaces::p2p::{
-    error::{PeerRequestResult, RequestError, RequestResult, RequestValidation},
+    error::{EthResponseValidator, PeerRequestResult, RequestError, RequestResult},
     headers::client::HeadersRequest,
     priority::Priority,
 };
@@ -226,9 +226,12 @@ impl StateFetcher {
         res: RequestResult<Vec<Header>>,
     ) -> Option<BlockResponseOutcome> {
         let is_error = res.is_err();
+
         let resp = self.inflight_headers_requests.remove(&peer_id);
-        let is_likely_a_bad_message =
-            resp.as_ref().map(|r| res.is_likely_a_bad_message(&r.request)).unwrap_or_default();
+        let is_likely_bad_response = resp
+            .as_ref()
+            .map(|r| res.is_likely_bad_headers_response(&r.request))
+            .unwrap_or_default();
 
         if let Some(resp) = resp {
             let _ = resp.response.send(res.map(|h| (peer_id, h).into()));
@@ -242,13 +245,11 @@ impl StateFetcher {
             ))
         }
 
-        if !is_likely_a_bad_message {
-            if let Some(peer) = self.peers.get_mut(&peer_id) {
-                // If the peer is still ready to be accept new requests, we try to send a followup
-                // request immediately.
-                if peer.state.on_request_finished() {
-                    return self.followup_request(peer_id)
-                }
+        if let Some(peer) = self.peers.get_mut(&peer_id) {
+            // If the peer is still ready to be accept new requests, we try to send a followup
+            // request immediately.
+            if peer.state.on_request_finished() && !is_likely_bad_response {
+                return self.followup_request(peer_id)
             }
         }
 


### PR DESCRIPTION
Fixes a bug introduced in #946

that did not mark peers as idle once they sent a likely bad response.

Fix: moves the if check after the update.