### PR TITLE
chore: rm unused HeaderClient in Header Stage

### DIFF
--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -156,8 +156,7 @@ impl Command {
                         Default::default(),
                     ),
                 consensus: consensus.clone(),
-                client: fetch_client.clone(),
-                network_handle: network.clone(),
+                sync_status_updates: network.clone(),
                 metrics: HeaderMetrics::default(),
             })
             .push(TotalDifficultyStage {


### PR DESCRIPTION
no longer used in HeaderStage

also renames `network_handle` to `sync_status_updates`