### PR TITLE
chore: make FetchClient Cloneable

### DIFF
--- a/bin/reth/src/p2p/mod.rs
+++ b/bin/reth/src/p2p/mod.rs
@@ -102,7 +102,7 @@ impl Command {
             .start_network()
             .await?;
 
-        let fetch_client = Arc::new(network.fetch_client().await?);
+        let fetch_client = network.fetch_client().await?;
         let retries = self.retries.max(1);
         let backoff = ConstantBackoff::default().with_max_times(retries);
 
@@ -157,7 +157,7 @@ impl Command {
     /// Get a single header from network
     pub async fn get_single_header(
         &self,
-        client: Arc<FetchClient>,
+        client: FetchClient,
         id: BlockHashOrNumber,
     ) -> eyre::Result<SealedHeader> {
         let request = HeadersRequest {

--- a/crates/net/network/src/fetch/client.rs
+++ b/crates/net/network/src/fetch/client.rs
@@ -57,7 +57,7 @@ use tokio::sync::{mpsc::UnboundedSender, oneshot};
 //         end
 //     end
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FetchClient {
     /// Sender half of the request channel.
     pub(crate) request_tx: UnboundedSender<DownloadRequest>,


### PR DESCRIPTION
FetchClient can be Clone since it's just `Senders`