### PR TITLE
feat(sync): `TxLookup` stage

### DIFF
--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -649,20 +649,22 @@ mod tests {
 
         impl UnwindStageTestRunner for BodyTestRunner {
             fn validate_unwind(&self, input: UnwindInput) -> Result<(), TestRunnerError> {
-                self.tx.check_no_entry_above::<tables::BlockBodies, _>(input.unwind_to, |key| {
-                    key.number()
-                })?;
-                self.tx.check_no_entry_above::<tables::BlockOmmers, _>(input.unwind_to, |key| {
-                    key.number()
-                })?;
-                self.tx.check_no_entry_above::<tables::BlockTransitionIndex, _>(
+                self.tx
+                    .ensure_no_entry_above::<tables::BlockBodies, _>(input.unwind_to, |key| {
+                        key.number()
+                    })?;
+                self.tx
+                    .ensure_no_entry_above::<tables::BlockOmmers, _>(input.unwind_to, |key| {
+                        key.number()
+                    })?;
+                self.tx.ensure_no_entry_above::<tables::BlockTransitionIndex, _>(
                     input.unwind_to,
                     |key| key,
                 )?;
                 if let Some(last_tx_id) = self.get_last_tx_id()? {
                     self.tx
-                        .check_no_entry_above::<tables::Transactions, _>(last_tx_id, |key| key)?;
-                    self.tx.check_no_entry_above::<tables::TxTransitionIndex, _>(
+                        .ensure_no_entry_above::<tables::Transactions, _>(last_tx_id, |key| key)?;
+                    self.tx.ensure_no_entry_above::<tables::TxTransitionIndex, _>(
                         last_tx_id,
                         |key| key,
                     )?;

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -445,7 +445,7 @@ mod tests {
             .tx()
             .commit(|tx| {
                 let mut tx_cursor = tx.cursor_write::<tables::Transactions>()?;
-                let (_, transaction) = tx_cursor.last()?.expect("Could not read last transaction");
+                tx_cursor.last()?.expect("Could not read last transaction");
                 tx_cursor.delete_current()?;
                 Ok(())
             })

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -463,9 +463,9 @@ mod tests {
                 block: BlockNumber,
             ) -> Result<(), TestRunnerError> {
                 self.tx
-                    .check_no_entry_above_by_value::<tables::HeaderNumbers, _>(block, |val| val)?;
-                self.tx.check_no_entry_above::<tables::CanonicalHeaders, _>(block, |key| key)?;
-                self.tx.check_no_entry_above::<tables::Headers, _>(block, |key| key.number())?;
+                    .ensure_no_entry_above_by_value::<tables::HeaderNumbers, _>(block, |val| val)?;
+                self.tx.ensure_no_entry_above::<tables::CanonicalHeaders, _>(block, |key| key)?;
+                self.tx.ensure_no_entry_above::<tables::Headers, _>(block, |key| key.number())?;
                 Ok(())
             }
         }

--- a/crates/stages/src/stages/mod.rs
+++ b/crates/stages/src/stages/mod.rs
@@ -14,3 +14,5 @@ pub mod merkle;
 pub mod sender_recovery;
 /// The total difficulty stage
 pub mod total_difficulty;
+/// The transaction lookup stage
+pub mod tx_lookup;

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -228,6 +228,11 @@ mod tests {
             self.threshold = threshold;
         }
 
+        /// # Panics
+        /// 1. If there are any entries in the [tables::TxSenders] table above
+        /// a given block number.
+        /// 2. If the is no requested block entry in the bodies table,
+        /// but [tables::TxSenders] is not empty.
         fn ensure_no_senders_by_block(&self, block: BlockNumber) -> Result<(), TestRunnerError> {
             let body_result = self.tx.inner().get_block_body_by_num(block);
             match body_result {

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -229,16 +229,18 @@ mod tests {
         }
 
         /// # Panics
+        ///
         /// 1. If there are any entries in the [tables::TxSenders] table above
-        /// a given block number.
+        ///    a given block number.
+        ///
         /// 2. If the is no requested block entry in the bodies table,
-        /// but [tables::TxSenders] is not empty.
+        ///    but [tables::TxSenders] is not empty.
         fn ensure_no_senders_by_block(&self, block: BlockNumber) -> Result<(), TestRunnerError> {
             let body_result = self.tx.inner().get_block_body_by_num(block);
             match body_result {
                 Ok(body) => self
                     .tx
-                    .check_no_entry_above::<tables::TxSenders, _>(body.last_tx_index(), |key| {
+                    .ensure_no_entry_above::<tables::TxSenders, _>(body.last_tx_index(), |key| {
                         key
                     })?,
                 Err(_) => {

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -151,9 +151,10 @@ mod tests {
         };
 
         // Insert blocks with a single transaction at block `stage_progress + 10`
+        let non_empty_block_number = stage_progress + 10;
         let blocks = (stage_progress..input.previous_stage_progress() + 1)
             .map(|number| {
-                random_block(number, None, Some((number == stage_progress + 10) as u8), None)
+                random_block(number, None, Some((number == non_empty_block_number) as u8), None)
             })
             .collect::<Vec<_>>();
         runner.tx.insert_blocks(blocks.iter(), None).expect("failed to insert blocks");

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -228,7 +228,7 @@ mod tests {
             self.threshold = threshold;
         }
 
-        fn check_no_senders_by_block(&self, block: BlockNumber) -> Result<(), TestRunnerError> {
+        fn ensure_no_senders_by_block(&self, block: BlockNumber) -> Result<(), TestRunnerError> {
             let body_result = self.tx.inner().get_block_body_by_num(block);
             match body_result {
                 Ok(body) => self
@@ -300,7 +300,9 @@ mod tests {
 
                     Ok(())
                 })?,
-                None => self.check_no_senders_by_block(input.stage_progress.unwrap_or_default())?,
+                None => {
+                    self.ensure_no_senders_by_block(input.stage_progress.unwrap_or_default())?
+                }
             };
 
             Ok(())
@@ -309,7 +311,7 @@ mod tests {
 
     impl UnwindStageTestRunner for SenderRecoveryTestRunner {
         fn validate_unwind(&self, input: UnwindInput) -> Result<(), TestRunnerError> {
-            self.check_no_senders_by_block(input.unwind_to)
+            self.ensure_no_senders_by_block(input.unwind_to)
         }
     }
 }

--- a/crates/stages/src/stages/total_difficulty.rs
+++ b/crates/stages/src/stages/total_difficulty.rs
@@ -237,7 +237,7 @@ mod tests {
 
     impl TotalDifficultyTestRunner {
         fn check_no_td_above(&self, block: BlockNumber) -> Result<(), TestRunnerError> {
-            self.tx.check_no_entry_above::<tables::HeaderTD, _>(block, |key| key.number())?;
+            self.tx.ensure_no_entry_above::<tables::HeaderTD, _>(block, |key| key.number())?;
             Ok(())
         }
 

--- a/crates/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/src/stages/tx_lookup.rs
@@ -15,7 +15,7 @@ const TRANSACTION_LOOKUP: StageId = StageId("TransactionLookup");
 /// The transaction lookup stage.
 ///
 /// This stage walks over the bodies table, and sets the transaction hash of each transaction in a
-/// block to the correesponding `TransitionId` at each block. This is written to the
+/// block to the corresponding `TransitionId` at each block. This is written to the
 /// [`tables::TxHashNumber`] This is used for looking up changesets via the transaction hash.
 #[derive(Debug)]
 pub struct TransactionLookupStage {
@@ -45,6 +45,7 @@ impl<DB: Database> Stage<DB> for TransactionLookupStage {
         let mut tx_cursor = tx.cursor_write::<tables::Transactions>()?;
         let start_key = tx.get_block_numhash(start_block)?;
 
+        // Walk over block bodies within a specified range.
         let bodies = cursor_bodies
             .walk(start_key)?
             .take_while(|entry| {
@@ -55,6 +56,7 @@ impl<DB: Database> Stage<DB> for TransactionLookupStage {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
+        // Collect tranasctions for each body and insert the reverse lookup for hash -> tx_id.
         for (_, body) in bodies {
             let transactions = tx_cursor
                 .walk(body.start_tx_id)?

--- a/crates/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/src/stages/tx_lookup.rs
@@ -20,7 +20,14 @@ const TRANSACTION_LOOKUP: StageId = StageId("TransactionLookup");
 #[derive(Debug)]
 pub struct TransactionLookupStage {
     /// The number of table entries to commit at once
-    pub commit_threshold: u64,
+    commit_threshold: u64,
+}
+
+impl TransactionLookupStage {
+    /// Create new instance of [TransactionLookupStage].
+    pub fn new(commit_threshold: u64) -> Self {
+        Self { commit_threshold }
+    }
 }
 
 #[async_trait::async_trait]

--- a/crates/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/src/stages/tx_lookup.rs
@@ -1,6 +1,6 @@
 use crate::{
-    db::Transaction, exec_or_return, DatabaseIntegrityError, ExecAction, ExecInput, ExecOutput,
-    Stage, StageError, StageId, UnwindInput, UnwindOutput,
+    db::Transaction, exec_or_return, ExecAction, ExecInput, ExecOutput, Stage, StageError, StageId,
+    UnwindInput, UnwindOutput,
 };
 use reth_db::{
     cursor::{DbCursorRO, DbCursorRW},
@@ -14,9 +14,9 @@ const TRANSACTION_LOOKUP: StageId = StageId("TransactionLookup");
 
 /// The transaction lookup stage.
 ///
-/// This stage walks over the bodies table, and sets the transaction hash of each transaction in a block
-/// to the correesponding `TransitionId` at each block. This is written to the [`tables::TxHashNumber`]
-/// This is used for looking up changesets via the transaction hash.
+/// This stage walks over the bodies table, and sets the transaction hash of each transaction in a
+/// block to the correesponding `TransitionId` at each block. This is written to the
+/// [`tables::TxHashNumber`] This is used for looking up changesets via the transaction hash.
 #[derive(Debug)]
 pub struct TransactionLookupStage {
     /// The number of table entries to commit at once
@@ -43,7 +43,6 @@ impl<DB: Database> Stage<DB> for TransactionLookupStage {
 
         let mut cursor_bodies = tx.cursor_read::<tables::BlockBodies>()?;
         let mut tx_cursor = tx.cursor_write::<tables::Transactions>()?;
-        let (mut current_tx_id, _) = tx.get_next_block_ids(start_block)?;
         let start_key = tx.get_block_numhash(start_block)?;
 
         let bodies = cursor_bodies
@@ -54,18 +53,16 @@ impl<DB: Database> Stage<DB> for TransactionLookupStage {
                     .map(|(block_num_hash, _)| block_num_hash.number() <= end_block)
                     .unwrap_or_default()
             })
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>, _>>()?;
 
-        for body in bodies {
-            let (_, body) = body?;
-            let mut tx_walker = tx_cursor.walk(body.start_tx_id)?;
+        for (_, body) in bodies {
+            let transactions = tx_cursor
+                .walk(body.start_tx_id)?
+                .take(body.tx_count as usize)
+                .collect::<Result<Vec<_>, _>>()?;
 
-            // get next N transactions.
-            for _ in body.tx_id_range() {
-                let (_, transaction) =
-                    tx_walker.next().ok_or(DatabaseIntegrityError::EndOfTransactionTable)??;
-                tx.put::<tables::TxHashNumber>(transaction.hash(), current_tx_id)?;
-                current_tx_id += 1;
+            for (id, transaction) in transactions {
+                tx.put::<tables::TxHashNumber>(transaction.hash(), id)?;
             }
         }
 
@@ -88,7 +85,7 @@ impl<DB: Database> Stage<DB> for TransactionLookupStage {
         let mut rev_walker = body_cursor.walk_back(None)?;
         while let Some((key, body)) = rev_walker.next().transpose()? {
             if key.number() <= input.unwind_to {
-                break;
+                break
             }
 
             // Delete all transactions that belong to this block

--- a/crates/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/src/stages/tx_lookup.rs
@@ -208,7 +208,7 @@ mod tests {
             self.threshold = threshold;
         }
 
-        fn check_no_hash_by_block(&self, block: BlockNumber) -> Result<(), TestRunnerError> {
+        fn ensure_no_hash_by_block(&self, block: BlockNumber) -> Result<(), TestRunnerError> {
             let body_result = self.tx.inner().get_block_body_by_num(block);
             match body_result {
                 Ok(body) => self
@@ -281,7 +281,7 @@ mod tests {
 
                     Ok(())
                 })?,
-                None => self.check_no_hash_by_block(input.stage_progress.unwrap_or_default())?,
+                None => self.ensure_no_hash_by_block(input.stage_progress.unwrap_or_default())?,
             };
             Ok(())
         }
@@ -289,7 +289,7 @@ mod tests {
 
     impl UnwindStageTestRunner for TransactionLookupTestRunner {
         fn validate_unwind(&self, input: UnwindInput) -> Result<(), TestRunnerError> {
-            self.check_no_hash_by_block(input.unwind_to)
+            self.ensure_no_hash_by_block(input.unwind_to)
         }
     }
 }

--- a/crates/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/src/stages/tx_lookup.rs
@@ -131,9 +131,10 @@ mod tests {
         };
 
         // Insert blocks with a single transaction at block `stage_progress + 10`
+        let non_empty_block_number = stage_progress + 10;
         let blocks = (stage_progress..input.previous_stage_progress() + 1)
             .map(|number| {
-                random_block(number, None, Some((number == stage_progress + 10) as u8), None)
+                random_block(number, None, Some((number == non_empty_block_number) as u8), None)
             })
             .collect::<Vec<_>>();
         runner.tx.insert_blocks(blocks.iter(), None).expect("failed to insert blocks");

--- a/crates/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/src/stages/tx_lookup.rs
@@ -211,16 +211,22 @@ mod tests {
             self.threshold = threshold;
         }
 
+        /// # Panics
+        ///
+        /// 1. If there are any entries in the [tables::TxHashNumber] table above
+        ///    a given block number.
+        ///
+        /// 2. If the is no requested block entry in the bodies table,
+        ///    but [tables::TxHashNumber] is not empty.
         fn ensure_no_hash_by_block(&self, block: BlockNumber) -> Result<(), TestRunnerError> {
             let body_result = self.tx.inner().get_block_body_by_num(block);
             match body_result {
-                Ok(body) => self
-                    .tx
-                    .check_no_entry_above::<tables::TxSenders, _>(body.last_tx_index(), |key| {
-                        key
-                    })?,
+                Ok(body) => self.tx.ensure_no_entry_above_by_value::<tables::TxHashNumber, _>(
+                    body.last_tx_index(),
+                    |key| key,
+                )?,
                 Err(_) => {
-                    assert!(self.tx.table_is_empty::<tables::TxSenders>()?);
+                    assert!(self.tx.table_is_empty::<tables::TxHashNumber>()?);
                 }
             };
 

--- a/crates/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/src/stages/tx_lookup.rs
@@ -1,0 +1,107 @@
+use crate::{
+    db::Transaction, exec_or_return, DatabaseIntegrityError, ExecAction, ExecInput, ExecOutput,
+    Stage, StageError, StageId, UnwindInput, UnwindOutput,
+};
+use reth_db::{
+    cursor::{DbCursorRO, DbCursorRW},
+    database::Database,
+    tables,
+    transaction::{DbTx, DbTxMut},
+};
+use tracing::*;
+
+const TRANSACTION_LOOKUP: StageId = StageId("TransactionLookup");
+
+/// The transaction lookup stage.
+///
+/// This stage walks over the bodies table, and sets the transaction hash of each transaction in a block
+/// to the correesponding `TransitionId` at each block. This is written to the [`tables::TxHashNumber`]
+/// This is used for looking up changesets via the transaction hash.
+#[derive(Debug)]
+pub struct TransactionLookupStage {
+    /// The number of table entries to commit at once
+    pub commit_threshold: u64,
+}
+
+#[async_trait::async_trait]
+impl<DB: Database> Stage<DB> for TransactionLookupStage {
+    /// Return the id of the stage
+    fn id(&self) -> StageId {
+        TRANSACTION_LOOKUP
+    }
+
+    /// Write total difficulty entries
+    async fn execute(
+        &mut self,
+        tx: &mut Transaction<'_, DB>,
+        input: ExecInput,
+    ) -> Result<ExecOutput, StageError> {
+        let ((start_block, end_block), capped) =
+            exec_or_return!(input, self.commit_threshold, "sync::stages::transaction_lookup");
+
+        debug!(target: "sync::stages::transaction_lookup", start_block, end_block, "Commencing sync");
+
+        let mut cursor_bodies = tx.cursor_read::<tables::BlockBodies>()?;
+        let mut tx_cursor = tx.cursor_write::<tables::Transactions>()?;
+        let (mut current_tx_id, _) = tx.get_next_block_ids(start_block)?;
+        let start_key = tx.get_block_numhash(start_block)?;
+
+        let bodies = cursor_bodies
+            .walk(start_key)?
+            .take_while(|entry| {
+                entry
+                    .as_ref()
+                    .map(|(block_num_hash, _)| block_num_hash.number() <= end_block)
+                    .unwrap_or_default()
+            })
+            .collect::<Vec<_>>();
+
+        for body in bodies {
+            let (_, body) = body?;
+            let mut tx_walker = tx_cursor.walk(body.start_tx_id)?;
+
+            // get next N transactions.
+            for _ in body.tx_id_range() {
+                let (_, transaction) =
+                    tx_walker.next().ok_or(DatabaseIntegrityError::EndOfTransactionTable)??;
+                tx.put::<tables::TxHashNumber>(transaction.hash(), current_tx_id)?;
+                current_tx_id += 1;
+            }
+        }
+
+        let done = !capped;
+        info!(target: "sync::stages::transaction_lookup", stage_progress = end_block, done, "Sync iteration finished");
+        Ok(ExecOutput { done, stage_progress: end_block })
+    }
+
+    /// Unwind the stage.
+    async fn unwind(
+        &mut self,
+        tx: &mut Transaction<'_, DB>,
+        input: UnwindInput,
+    ) -> Result<UnwindOutput, StageError> {
+        info!(target: "sync::stages::transaction_lookup", to_block = input.unwind_to, "Unwinding");
+        // Cursors to unwind tx hash to number
+        let mut body_cursor = tx.cursor_write::<tables::BlockBodies>()?;
+        let mut tx_hash_number_cursor = tx.cursor_write::<tables::TxHashNumber>()?;
+        let mut transaction_cursor = tx.cursor_write::<tables::Transactions>()?;
+        let mut rev_walker = body_cursor.walk_back(None)?;
+        while let Some((key, body)) = rev_walker.next().transpose()? {
+            if key.number() <= input.unwind_to {
+                break;
+            }
+
+            // Delete all transactions that belong to this block
+            for tx_id in body.tx_id_range() {
+                // First delete the transaction and hash to id mapping
+                if let Some((_, transaction)) = transaction_cursor.seek_exact(tx_id)? {
+                    if tx_hash_number_cursor.seek_exact(transaction.hash)?.is_some() {
+                        tx_hash_number_cursor.delete_current()?;
+                    }
+                }
+            }
+        }
+
+        Ok(UnwindOutput { stage_progress: input.unwind_to })
+    }
+}

--- a/crates/stages/src/test_utils/test_db.rs
+++ b/crates/stages/src/test_utils/test_db.rs
@@ -196,7 +196,6 @@ impl TestTransaction {
     {
         self.commit(|tx| {
             let mut current_tx_id = tx_offset.unwrap_or_default();
-            let blocks = blocks.collect::<Vec<_>>();
 
             for block in blocks {
                 let key: BlockNumHash = block.num_hash().into();

--- a/crates/stages/src/test_utils/test_db.rs
+++ b/crates/stages/src/test_utils/test_db.rs
@@ -124,7 +124,7 @@ impl TestTransaction {
 
     /// Check that there is no table entry above a given
     /// number by [Table::Key]
-    pub(crate) fn check_no_entry_above<T, F>(
+    pub(crate) fn ensure_no_entry_above<T, F>(
         &self,
         num: u64,
         mut selector: F,
@@ -144,7 +144,7 @@ impl TestTransaction {
 
     /// Check that there is no table entry above a given
     /// number by [Table::Value]
-    pub(crate) fn check_no_entry_above_by_value<T, F>(
+    pub(crate) fn ensure_no_entry_above_by_value<T, F>(
         &self,
         num: u64,
         mut selector: F,


### PR DESCRIPTION
Closes #969 

This PR introduces a new `TransactionLookup` stage for staged sync.

Previously, `TxHashNumber` table for storing the mapping of transaction hash to transaction id was populated during the `Bodies` stage. Since the writes to this table are unsorted, they cannot be optimized neither with appends nor with cursor inserts. This introduced a major delay to a body download.

The delay is mitigated by extracting the writes to a separate stage.