### PR TITLE
fix(net): export `PeerInfo` struct

### DIFF
--- a/crates/net/network/src/lib.rs
+++ b/crates/net/network/src/lib.rs
@@ -143,5 +143,6 @@ pub use manager::{NetworkEvent, NetworkManager};
 pub use message::PeerRequest;
 pub use network::NetworkHandle;
 pub use peers::PeersConfig;
+pub use session::PeerInfo;
 
 pub use reth_eth_wire::DisconnectReason;

--- a/crates/net/network/src/session/handle.rs
+++ b/crates/net/network/src/session/handle.rs
@@ -64,6 +64,7 @@ impl ActiveSessionHandle {
     }
 }
 
+/// Info about an active peer session.
 #[derive(Debug)]
 #[allow(unused)]
 pub struct PeerInfo {


### PR DESCRIPTION
`NetworkHandle` contains methods for requesting info about a peer, but corresponding `PeerInfo` struct is not exported. This PR exports it.