### PR TITLE
test: add missing fork_id tests for the Görli and Sepolia nets

### DIFF
--- a/crates/primitives/src/chain_spec.rs
+++ b/crates/primitives/src/chain_spec.rs
@@ -423,7 +423,7 @@ impl ParisStatus {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Chain, ChainSpec, ForkHash, Genesis, Hardfork, Header, MAINNET};
+    use crate::{Chain, ChainSpec, ForkHash, Genesis, Hardfork, Header, MAINNET, GOERLI, SEPOLIA};
 
     #[test]
     fn test_empty_forkid() {

--- a/crates/primitives/src/chain_spec.rs
+++ b/crates/primitives/src/chain_spec.rs
@@ -484,7 +484,6 @@ mod tests {
     }
 
     // these tests check that the forkid computation is accurate
-    
     #[test]
     fn test_mainnet_forkids() {
         let frontier_forkid = MAINNET.fork_id(0);
@@ -567,6 +566,5 @@ mod tests {
         let mergenetsplit_forkid = SEPOLIA.fork_id(1735371);
         assert_eq!([0xb9, 0x6c, 0xbd, 0x13], mergenetsplit_forkid.hash.0);
         assert_eq!(0, mergenetsplit_forkid.next);
-
     }
 }

--- a/crates/primitives/src/chain_spec.rs
+++ b/crates/primitives/src/chain_spec.rs
@@ -483,8 +483,9 @@ mod tests {
         assert_eq!(unique_spec.fork_id(2), duplicate_spec.fork_id(2));
     }
 
+    // these tests check that the forkid computation is accurate
+    
     #[test]
-    // this test checks that the forkid computation is accurate
     fn test_mainnet_forkids() {
         let frontier_forkid = MAINNET.fork_id(0);
         assert_eq!([0xfc, 0x64, 0xec, 0x04], frontier_forkid.hash.0);
@@ -540,5 +541,32 @@ mod tests {
 
         let latest_forkid = MAINNET.fork_id(15050000);
         assert_eq!(0, latest_forkid.next);
+    }
+
+    #[test]
+    fn test_goerli_forkids() {
+        let frontier_forkid = GOERLI.fork_id(0);
+        assert_eq!([0xa3, 0xf5, 0xab, 0x08], frontier_forkid.hash.0);
+        assert_eq!(1561651, frontier_forkid.next);
+
+        let istanbul_forkid = GOERLI.fork_id(1561651);
+        assert_eq!([0xc2, 0x5e, 0xfa, 0x5c], istanbul_forkid.hash.0);
+        assert_eq!(4460644, istanbul_forkid.next);
+
+        let berlin_forkid = GOERLI.fork_id(4460644);
+        assert_eq!([0x75, 0x7a, 0x1c, 0x47], berlin_forkid.hash.0);
+        assert_eq!(5062605, berlin_forkid.next);
+
+        let london_forkid = GOERLI.fork_id(12965000);
+        assert_eq!([0xb8, 0xc6, 0x29, 0x9d], london_forkid.hash.0);
+        assert_eq!(0, london_forkid.next);
+    }
+
+    #[test]
+    fn test_sepolia_forkids() {
+        let mergenetsplit_forkid = SEPOLIA.fork_id(1735371);
+        assert_eq!([0xb9, 0x6c, 0xbd, 0x13], mergenetsplit_forkid.hash.0);
+        assert_eq!(0, mergenetsplit_forkid.next);
+
     }
 }

--- a/crates/primitives/src/chain_spec.rs
+++ b/crates/primitives/src/chain_spec.rs
@@ -423,7 +423,7 @@ impl ParisStatus {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Chain, ChainSpec, ForkHash, Genesis, Hardfork, Header, MAINNET, GOERLI, SEPOLIA};
+    use crate::{Chain, ChainSpec, ForkHash, Genesis, Hardfork, Header, GOERLI, MAINNET, SEPOLIA};
 
     #[test]
     fn test_empty_forkid() {


### PR DESCRIPTION
Added two fork id computation tests for the Görli and Sepolia nets.