### PR TITLE
Fixed dead link in Book -> Installing Geth

### DIFF
--- a/book/getting_started/installation.md
+++ b/book/getting_started/installation.md
@@ -1,6 +1,6 @@
 ## Installation
 
-To use Reth, you must first install Geth. You can find instructions for installing Geth at the following link: https://geth.ethereum.org/docs/install-and-build/installing-geth.
+To use Reth, you must first install Geth. You can find instructions for installing Geth at the following link: [https://geth.ethereum.org/docs/install-and-build/installing-geth](https://geth.ethereum.org/docs/getting-started/installing-geth).
 
 ### Ubuntu
 Building the source


### PR DESCRIPTION
https://geth.ethereum.org/docs/install-and-build/installing-geth which is in the book is a dead link 

however :  https://geth.ethereum.org/docs/getting-started/installing-geth is the new one that works