### PR TITLE
feat: in-process throughput measurement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4190,6 +4190,7 @@ dependencies = [
  "rand 0.8.5",
  "reth-codecs",
  "reth-ecies",
+ "reth-net-common",
  "reth-primitives",
  "reth-rlp",
  "reth-tracing",

--- a/crates/net/common/src/bandwidth_meter.rs
+++ b/crates/net/common/src/bandwidth_meter.rs
@@ -22,6 +22,7 @@
 
 use std::{
     convert::TryFrom as _,
+    future::Future,
     io,
     net::SocketAddr,
     pin::Pin,
@@ -30,10 +31,12 @@ use std::{
         Arc,
     },
     task::{ready, Context, Poll},
+    time::Duration,
 };
 use tokio::{
     io::{AsyncRead, AsyncWrite, ReadBuf},
     net::TcpStream,
+    time::{interval, Interval},
 };
 
 use crate::stream::HasRemoteAddr;
@@ -43,8 +46,20 @@ use crate::stream::HasRemoteAddr;
 struct BandwidthMeterInner {
     /// Measures the number of inbound packets
     inbound: AtomicU64,
+    /// Number of bytes received during throughput recording period
+    ingress_delta: AtomicU64,
+    /// Last measured throughput of bytes received in terms of bytes/s.
+    /// Stored as an [`AtomicU64`] but interpreted as an [`f64`] using `f64::from_bits`
+    ingress_throughput: AtomicU64,
     /// Measures the number of outbound packets
     outbound: AtomicU64,
+    /// Number of bytes sent during throughput recording period
+    egress_delta: AtomicU64,
+    /// Last measured throughput of bytes sent in terms of bytes/s.
+    /// Stored as an [`AtomicU64`] but interpreted as an [`f64`] using `f64::from_bits`
+    egress_throughput: AtomicU64,
+    /// Duration of interval over which throughput is evaluated
+    throughput_period: Duration,
 }
 
 /// Public shareable struct used for getting bandwidth metering info
@@ -69,16 +84,74 @@ impl BandwidthMeter {
     pub fn total_outbound(&self) -> u64 {
         self.inner.outbound.load(Ordering::Relaxed)
     }
+
+    pub fn ingress_throughput(&self) -> f64 {
+        f64::from_bits(self.inner.ingress_throughput.load(Ordering::Relaxed))
+    }
+
+    pub fn egress_throughput(&self) -> f64 {
+        f64::from_bits(self.inner.egress_throughput.load(Ordering::Relaxed))
+    }
 }
 
 impl Default for BandwidthMeter {
     fn default() -> Self {
-        Self {
+        let bandwidth_meter = Self {
             inner: Arc::new(BandwidthMeterInner {
                 inbound: AtomicU64::new(0),
+                ingress_delta: AtomicU64::new(0),
+                ingress_throughput: AtomicU64::new(0),
                 outbound: AtomicU64::new(0),
+                egress_delta: AtomicU64::new(0),
+                egress_throughput: AtomicU64::new(0),
+                throughput_period: Duration::from_secs(1),
             }),
+        };
+
+        tokio::spawn(ThroughputTask::new(
+            bandwidth_meter.inner.throughput_period,
+            bandwidth_meter.clone(),
+        ));
+
+        bandwidth_meter
+    }
+}
+
+/// An endless Future used to calculate ingress & egress throughputs
+/// for the given [`BandiwdthMeter`] on the given [`Interval`].
+struct ThroughputTask {
+    interval: Interval,
+    meter: BandwidthMeter,
+}
+
+impl ThroughputTask {
+    fn new(period: Duration, meter: BandwidthMeter) -> Self {
+        Self { interval: interval(period), meter }
+    }
+}
+
+impl Future for ThroughputTask {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+
+        if this.interval.poll_tick(cx).is_ready() {
+            let ingress_delta = this.meter.inner.ingress_delta.swap(0, Ordering::Relaxed);
+            let egress_delta = this.meter.inner.egress_delta.swap(0, Ordering::Relaxed);
+
+            this.meter.inner.ingress_throughput.store(
+                f64::to_bits((ingress_delta as f64) / this.interval.period().as_secs_f64()),
+                Ordering::Relaxed,
+            );
+
+            this.meter.inner.egress_throughput.store(
+                f64::to_bits((egress_delta as f64) / this.interval.period().as_secs_f64()),
+                Ordering::Relaxed,
+            );
         }
+
+        Poll::Pending
     }
 }
 
@@ -120,15 +193,16 @@ impl<Stream: AsyncRead> AsyncRead for MeteredStream<Stream> {
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
         let this = self.project();
-        let num_bytes = {
+        let num_bytes_u64 = {
             let init_num_bytes = buf.filled().len();
             ready!(this.inner.poll_read(cx, buf))?;
-            buf.filled().len() - init_num_bytes
+            u64::try_from(buf.filled().len() - init_num_bytes).unwrap_or(u64::max_value())
         };
         this.meter
             .inner
             .inbound
-            .fetch_add(u64::try_from(num_bytes).unwrap_or(u64::max_value()), Ordering::Relaxed);
+            .fetch_add(num_bytes_u64, Ordering::Relaxed);
+        this.meter.inner.ingress_delta.fetch_add(num_bytes_u64, Ordering::Relaxed);
         Poll::Ready(Ok(()))
     }
 }
@@ -141,10 +215,12 @@ impl<Stream: AsyncWrite> AsyncWrite for MeteredStream<Stream> {
     ) -> Poll<io::Result<usize>> {
         let this = self.project();
         let num_bytes = ready!(this.inner.poll_write(cx, buf))?;
+        let num_bytes_u64 = { u64::try_from(num_bytes).unwrap_or(u64::max_value()) };
         this.meter
             .inner
             .outbound
-            .fetch_add(u64::try_from(num_bytes).unwrap_or(u64::max_value()), Ordering::Relaxed);
+            .fetch_add(num_bytes_u64, Ordering::Relaxed);
+        this.meter.inner.egress_delta.fetch_add(num_bytes_u64, Ordering::Relaxed);
         Poll::Ready(Ok(num_bytes))
     }
 
@@ -267,5 +343,75 @@ mod tests {
 
         assert_bandwidth_counts(&shared_client_bandwidth_meter, 8, 8);
         assert_bandwidth_counts(&shared_server_bandwidth_meter, 8, 8);
+    }
+
+    struct ThroughputStatsTask<'a> {
+        interval: Interval,
+        meter: &'a BandwidthMeter,
+        max_throughputs: (f64, f64),
+    }
+
+    impl<'a> ThroughputStatsTask<'a> {
+        pub fn new(
+            interval: Interval,
+            meter: &'a BandwidthMeter,
+        ) -> Self {
+            Self {
+                interval,
+                meter,
+                max_throughputs: (0.0, 0.0)
+            }
+        }
+    }
+
+    impl<'a> Future for ThroughputStatsTask<'a> {
+        type Output = (f64, f64);
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let this = self.get_mut();
+
+            let ingress_throughput = this.meter.ingress_throughput();
+            let egress_throughput = this.meter.egress_throughput();
+
+            this.max_throughputs = (
+                if ingress_throughput > this.max_throughputs.0 { ingress_throughput } else { this.max_throughputs.0 },
+                if egress_throughput > this.max_throughputs.1 { egress_throughput } else { this.max_throughputs.1 },
+            );
+
+            if this.interval.poll_tick(cx).is_ready() {
+                return Poll::Ready(this.max_throughputs)
+            }
+
+            Poll::Pending
+        }
+    }
+
+    #[tokio::test]
+    async fn test_throughput_basic() {
+        let (client, server) = duplex(64);
+        let (mut metered_client, mut _metered_server) =
+            (MeteredStream::new(client), MeteredStream::new(server));
+
+        let network_io_meter = metered_client.get_bandwidth_meter().clone();
+
+        // Concurrently collect throughput stats & write out from stream.
+        // Want to be sure that stats task starts first, but can't use `spawn` due to `'static` lifetime constraint...
+        let ((_, max_egress_throughput), _) = tokio::join!(
+            async {
+                let mut one_s_interval = interval(Duration::from_secs(1));
+                // Resolves immediately, want this to actually poll for 1s
+                one_s_interval.tick().await;
+
+                ThroughputStatsTask::new(
+                    one_s_interval,
+                    &network_io_meter,
+                ).await
+            },
+            async {
+                metered_client.write_all(b"ping").await.unwrap()
+            }
+        );
+
+        assert_eq!(max_egress_throughput, 4.0);
     }
 }

--- a/crates/net/common/src/bandwidth_meter.rs
+++ b/crates/net/common/src/bandwidth_meter.rs
@@ -125,10 +125,7 @@ impl<Stream: AsyncRead> AsyncRead for MeteredStream<Stream> {
             ready!(this.inner.poll_read(cx, buf))?;
             u64::try_from(buf.filled().len() - init_num_bytes).unwrap_or(u64::max_value())
         };
-        this.meter
-            .inner
-            .inbound
-            .fetch_add(num_bytes_u64, Ordering::Relaxed);
+        this.meter.inner.inbound.fetch_add(num_bytes_u64, Ordering::Relaxed);
         Poll::Ready(Ok(()))
     }
 }
@@ -142,10 +139,7 @@ impl<Stream: AsyncWrite> AsyncWrite for MeteredStream<Stream> {
         let this = self.project();
         let num_bytes = ready!(this.inner.poll_write(cx, buf))?;
         let num_bytes_u64 = { u64::try_from(num_bytes).unwrap_or(u64::max_value()) };
-        this.meter
-            .inner
-            .outbound
-            .fetch_add(num_bytes_u64, Ordering::Relaxed);
+        this.meter.inner.outbound.fetch_add(num_bytes_u64, Ordering::Relaxed);
         Poll::Ready(Ok(num_bytes))
     }
 

--- a/crates/net/ecies/src/stream.rs
+++ b/crates/net/ecies/src/stream.rs
@@ -4,7 +4,10 @@ use crate::{
 };
 use bytes::Bytes;
 use futures::{ready, Sink, SinkExt};
-use reth_net_common::stream::HasRemoteAddr;
+use reth_net_common::{
+    stream::HasRemoteAddr,
+    bandwidth_meter::MeteredStream,
+};
 use reth_primitives::H512 as PeerId;
 use secp256k1::SecretKey;
 use std::{
@@ -139,6 +142,13 @@ where
 
     fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.project().stream.poll_close(cx)
+    }
+}
+
+impl<S, M> AsRef<MeteredStream<M>> for ECIESStream<S>
+where S: AsRef<MeteredStream<M>> {
+    fn as_ref(&self) -> &MeteredStream<M> {
+        self.stream.get_ref().as_ref()
     }
 }
 

--- a/crates/net/ecies/src/stream.rs
+++ b/crates/net/ecies/src/stream.rs
@@ -4,10 +4,7 @@ use crate::{
 };
 use bytes::Bytes;
 use futures::{ready, Sink, SinkExt};
-use reth_net_common::{
-    stream::HasRemoteAddr,
-    bandwidth_meter::MeteredStream,
-};
+use reth_net_common::{bandwidth_meter::MeteredStream, stream::HasRemoteAddr};
 use reth_primitives::H512 as PeerId;
 use secp256k1::SecretKey;
 use std::{
@@ -146,7 +143,9 @@ where
 }
 
 impl<S, M> AsRef<MeteredStream<M>> for ECIESStream<S>
-where S: AsRef<MeteredStream<M>> {
+where
+    S: AsRef<MeteredStream<M>>,
+{
     fn as_ref(&self) -> &MeteredStream<M> {
         self.stream.get_ref().as_ref()
     }

--- a/crates/net/eth-wire/Cargo.toml
+++ b/crates/net/eth-wire/Cargo.toml
@@ -17,6 +17,7 @@ serde = "1"
 reth-codecs = { path = "../../storage/codecs" }
 reth-primitives = { path = "../../primitives" }
 reth-rlp = { path = "../../common/rlp", features = ["alloc", "derive", "std", "ethereum-types", "smol_str"] }
+reth-net-common = { path = "../common" }
 
 # used for Chain and builders
 ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -8,6 +8,7 @@ use futures::{ready, Sink, SinkExt, StreamExt};
 use pin_project::pin_project;
 use reth_primitives::ForkFilter;
 use reth_rlp::{Decodable, Encodable};
+use reth_net_common::bandwidth_meter::MeteredStream;
 use std::{
     pin::Pin,
     task::{Context, Poll},
@@ -250,6 +251,13 @@ where
 
     fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.project().inner.poll_close(cx).map_err(Into::into)
+    }
+}
+
+impl<S, M> AsRef<MeteredStream<M>> for EthStream<S>
+where S: AsRef<MeteredStream<M>> {
+    fn as_ref(&self) -> &MeteredStream<M> {
+        self.inner().as_ref()
     }
 }
 

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -6,9 +6,9 @@ use crate::{
 use bytes::{Bytes, BytesMut};
 use futures::{ready, Sink, SinkExt, StreamExt};
 use pin_project::pin_project;
+use reth_net_common::bandwidth_meter::MeteredStream;
 use reth_primitives::ForkFilter;
 use reth_rlp::{Decodable, Encodable};
-use reth_net_common::bandwidth_meter::MeteredStream;
 use std::{
     pin::Pin,
     task::{Context, Poll},
@@ -255,7 +255,9 @@ where
 }
 
 impl<S, M> AsRef<MeteredStream<M>> for EthStream<S>
-where S: AsRef<MeteredStream<M>> {
+where
+    S: AsRef<MeteredStream<M>>,
+{
     fn as_ref(&self) -> &MeteredStream<M> {
         self.inner().as_ref()
     }

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -495,7 +495,9 @@ where
 }
 
 impl<S, M> AsRef<MeteredStream<M>> for P2PStream<S>
-where S: AsRef<MeteredStream<M>> {
+where
+    S: AsRef<MeteredStream<M>>,
+{
     fn as_ref(&self) -> &MeteredStream<M> {
         self.inner.as_ref()
     }

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -10,6 +10,7 @@ use futures::{Sink, SinkExt, StreamExt};
 use metrics::counter;
 use pin_project::pin_project;
 use reth_codecs::derive_arbitrary;
+use reth_net_common::bandwidth_meter::MeteredStream;
 use reth_rlp::{Decodable, DecodeError, Encodable, EMPTY_LIST_CODE};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -490,6 +491,13 @@ where
         ready!(self.as_mut().poll_flush(cx))?;
 
         Poll::Ready(Ok(()))
+    }
+}
+
+impl<S, M> AsRef<MeteredStream<M>> for P2PStream<S>
+where S: AsRef<MeteredStream<M>> {
+    fn as_ref(&self) -> &MeteredStream<M> {
+        self.inner.as_ref()
     }
 }
 

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -43,6 +43,8 @@ mod config;
 mod handle;
 pub use config::SessionsConfig;
 
+use self::active::SessionThroughputMeter;
+
 /// Internal identifier for active sessions.
 #[derive(Debug, Clone, Copy, PartialOrd, PartialEq, Eq, Hash)]
 pub struct SessionId(usize);
@@ -388,6 +390,7 @@ impl SessionManager {
                     received_requests: Default::default(),
                     timeout_interval: tokio::time::interval(self.request_timeout),
                     request_timeout: Arc::clone(&timeout),
+                    throughput_meter: SessionThroughputMeter::new(Duration::from_secs(1)),
                 };
 
                 self.spawn(session);


### PR DESCRIPTION
Resolves #992.

Excuse some of the inconsistent naming, this adopts naming conventions from #844.

Current approach is to store ingress/egress throughput as `AtomicU64`s on the given `BandwidthMeter` (read as `f64`s using `f64::from_bits`). When instantiating a `BandwidthMeter`, an endless background task is spawned which, on the given interval, calculates throughput values and writes them to the meter.

The idea is to read throughput values off of the `BandwidthMeter` in another background task to calculate whatever aggregate measurements of throughput (e.g. moving average of throughput) downstream of the meter. See my initial test for an example of this. It's not the most ergonomic, so I'm open to other designs!