### PR TITLE
refactor: Make Transaction fee and price field types consistent

### DIFF
--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -1,6 +1,6 @@
 //! Transaction pool errors
 
-use reth_primitives::{Address, TxHash, U256};
+use reth_primitives::{Address, TxHash};
 
 /// Transaction pool result type.
 pub type PoolResult<T> = Result<T, PoolError>;
@@ -13,7 +13,7 @@ pub enum PoolError {
     ReplacementUnderpriced(TxHash),
     /// Encountered a transaction that was already added into the poll
     #[error("[{0:?}] Transaction feeCap {1} below chain minimum.")]
-    ProtocolFeeCapTooLow(TxHash, U256),
+    ProtocolFeeCapTooLow(TxHash, u128),
     /// Thrown when the number of unique transactions of a sender exceeded the slot capacity.
     #[error("{0:?} identified as spammer. Transaction {1:?} rejected.")]
     SpammerExceededCapacity(Address, TxHash),

--- a/crates/transaction-pool/src/test_utils/pool.rs
+++ b/crates/transaction-pool/src/test_utils/pool.rs
@@ -9,7 +9,7 @@ use crate::{
     TransactionOrdering,
 };
 use rand::Rng;
-use reth_primitives::{Address, U256};
+use reth_primitives::{Address, U128, U256};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
@@ -62,7 +62,7 @@ impl<T: TransactionOrdering> DerefMut for MockPool<T> {
 /// Simulates transaction execution.
 pub struct MockTransactionSimulator<R: Rng> {
     /// The pending base fee
-    base_fee: U256,
+    base_fee: u128,
     /// Generator for transactions
     tx_generator: MockTransactionDistribution,
     /// represents the on chain balance of a sender.
@@ -160,7 +160,7 @@ pub struct MockSimulatorConfig {
     /// Scenarios to test
     pub scenarios: Vec<ScenarioType>,
     /// The start base fee
-    pub base_fee: U256,
+    pub base_fee: u128,
     /// generator for transactions
     pub tx_generator: MockTransactionDistribution,
 }
@@ -220,7 +220,7 @@ fn test_on_chain_nonce_scenario() {
         num_senders: 10,
         balance: U256::from(200_000u64),
         scenarios: vec![ScenarioType::OnchainNonce],
-        base_fee: U256::from(10u64),
+        base_fee: 10,
         tx_generator: MockTransactionDistribution::new(30, 10..100),
     };
     let mut simulator = MockTransactionSimulator::new(rand::thread_rng(), config);

--- a/crates/transaction-pool/src/validate.rs
+++ b/crates/transaction-pool/src/validate.rs
@@ -101,7 +101,7 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
     }
 
     /// Returns the EIP-1559 Max base fee the caller is willing to pay.
-    pub fn max_fee_per_gas(&self) -> Option<U256> {
+    pub fn max_fee_per_gas(&self) -> Option<u128> {
         self.transaction.max_fee_per_gas()
     }
 


### PR DESCRIPTION
Closes #976 

Updated these fields to U128 across the board:
`gas_price`
`effective_gas_price`
`pending_basefee`
`minimal_protocol_basefee`
`max_fee_per_gas`
`max_priority_fee_per_gas`

BTW, Im not sure if I should be updating this as well: 
https://github.com/paradigmxyz/reth/blob/167aa60ed20ec25645722f624ea5151e6acd0ca3/bin/reth/src/test_eth_chain/models.rs#L73
