### PR TITLE
meta: add field for version/commit

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -55,6 +55,9 @@ body:
         - Windows (ARM)
     validations:
       required: false
+  - type: input
+    attributes:
+      label: What version/commit are you on?
   - type: checkboxes
     id: terms
     attributes:


### PR DESCRIPTION
Closes #547

Adds an input field for `What version/commit are you on?` to bug template