### PR TITLE
refactor: use `dyn Consensus`

### DIFF
--- a/crates/consensus/src/consensus.rs
+++ b/crates/consensus/src/consensus.rs
@@ -27,19 +27,18 @@ impl BeaconConsensus {
             chain_spec,
         }
     }
-
-    /// Notifies all listeners of the latest [ForkchoiceState].
-    pub fn notify_fork_choice_state(
-        &self,
-        state: ForkchoiceState,
-    ) -> Result<(), SendError<ForkchoiceState>> {
-        self.channel.0.send(state)
-    }
 }
 
 impl Consensus for BeaconConsensus {
     fn fork_choice_state(&self) -> watch::Receiver<ForkchoiceState> {
         self.channel.1.clone()
+    }
+
+    fn notify_fork_choice_state(
+        &self,
+        state: ForkchoiceState,
+    ) -> Result<(), SendError<ForkchoiceState>> {
+        self.channel.0.send(state)
     }
 
     fn validate_header(&self, header: &SealedHeader, parent: &SealedHeader) -> Result<(), Error> {

--- a/crates/consensus/src/consensus.rs
+++ b/crates/consensus/src/consensus.rs
@@ -8,6 +8,7 @@ use tokio::sync::{watch, watch::error::SendError};
 ///
 /// This consensus engine does basic checks as outlined in the execution specs,
 /// but otherwise defers consensus on what the current chain is to a consensus client.
+#[derive(Debug)]
 pub struct BeaconConsensus {
     /// Watcher over the forkchoice state
     channel: (watch::Sender<ForkchoiceState>, watch::Receiver<ForkchoiceState>),

--- a/crates/interfaces/src/consensus.rs
+++ b/crates/interfaces/src/consensus.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use reth_primitives::{BlockHash, BlockNumber, SealedBlock, SealedHeader, H256};
-use tokio::sync::watch::Receiver;
+use tokio::sync::watch::{error::SendError, Receiver};
 
 /// Re-export forkchoice state
 pub use reth_rpc_types::engine::ForkchoiceState;
@@ -11,6 +11,12 @@ pub use reth_rpc_types::engine::ForkchoiceState;
 pub trait Consensus: Send + Sync {
     /// Get a receiver for the fork choice state
     fn fork_choice_state(&self) -> Receiver<ForkchoiceState>;
+
+    /// Notifies all listeners of the latest [ForkchoiceState].
+    fn notify_fork_choice_state(
+        &self,
+        state: ForkchoiceState,
+    ) -> Result<(), SendError<ForkchoiceState>>;
 
     /// Validate if header is correct and follows consensus specification.
     ///

--- a/crates/interfaces/src/consensus.rs
+++ b/crates/interfaces/src/consensus.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use reth_primitives::{BlockHash, BlockNumber, SealedBlock, SealedHeader, H256};
+use std::fmt::Debug;
 use tokio::sync::watch::{error::SendError, Receiver};
 
 /// Re-export forkchoice state
@@ -8,7 +9,7 @@ pub use reth_rpc_types::engine::ForkchoiceState;
 /// Consensus is a protocol that chooses canonical chain.
 #[async_trait]
 #[auto_impl::auto_impl(&, Arc)]
-pub trait Consensus: Send + Sync {
+pub trait Consensus: Debug + Send + Sync {
     /// Get a receiver for the fork choice state
     fn fork_choice_state(&self) -> Receiver<ForkchoiceState>;
 

--- a/crates/interfaces/src/p2p/headers/downloader.rs
+++ b/crates/interfaces/src/p2p/headers/downloader.rs
@@ -70,8 +70,8 @@ impl SyncTarget {
 /// Validate whether the header is valid in relation to it's parent
 ///
 /// Returns Ok(false) if the
-pub fn validate_header_download<C: Consensus>(
-    consensus: &C,
+pub fn validate_header_download(
+    consensus: &dyn Consensus,
     header: &SealedHeader,
     parent: &SealedHeader,
 ) -> DownloadResult<()> {

--- a/crates/interfaces/src/test_utils/headers.rs
+++ b/crates/interfaces/src/test_utils/headers.rs
@@ -26,7 +26,7 @@ use std::{
     },
     task::{ready, Context, Poll},
 };
-use tokio::sync::{watch, Mutex};
+use tokio::sync::{watch, watch::error::SendError, Mutex};
 
 /// A test downloader which just returns the values that have been pushed to it.
 #[derive(Debug)]
@@ -268,16 +268,6 @@ impl Default for TestConsensus {
 }
 
 impl TestConsensus {
-    /// Update the fork choice state
-    pub fn update_tip(&self, tip: H256) {
-        let state = ForkchoiceState {
-            head_block_hash: tip,
-            finalized_block_hash: H256::zero(),
-            safe_block_hash: H256::zero(),
-        };
-        self.channel.0.send(state).expect("updating fork choice state failed");
-    }
-
     /// Get the failed validation flag
     pub fn fail_validation(&self) -> bool {
         self.fail_validation.load(Ordering::SeqCst)
@@ -301,6 +291,13 @@ impl StatusUpdater for TestStatusUpdater {
 impl Consensus for TestConsensus {
     fn fork_choice_state(&self) -> watch::Receiver<ForkchoiceState> {
         self.channel.1.clone()
+    }
+
+    fn notify_fork_choice_state(
+        &self,
+        state: ForkchoiceState,
+    ) -> Result<(), SendError<ForkchoiceState>> {
+        self.channel.0.send(state)
     }
 
     fn validate_header(

--- a/crates/net/downloaders/src/bodies/concurrent.rs
+++ b/crates/net/downloaders/src/bodies/concurrent.rs
@@ -11,7 +11,6 @@ use reth_primitives::{BlockNumber, SealedHeader};
 use std::{
     cmp::Ordering,
     collections::BinaryHeap,
-    fmt::{Debug, Formatter},
     ops::{Range, RangeInclusive},
     pin::Pin,
     sync::Arc,
@@ -30,6 +29,7 @@ const CONCURRENCY_PEER_MULTIPLIER: usize = 4;
 /// Downloads bodies in batches.
 ///
 /// All blocks in a batch are fetched at the same time.
+#[derive(Debug)]
 pub struct ConcurrentDownloader<B, DB> {
     /// The bodies client
     client: Arc<B>,
@@ -56,19 +56,6 @@ pub struct ConcurrentDownloader<B, DB> {
     buffered_responses: BinaryHeap<OrderedBodiesResponse>,
     /// Queued body responses
     queued_bodies: Vec<BlockResponse>,
-}
-
-impl<B, DB> Debug for ConcurrentDownloader<B, DB> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ConcurrentDownloader")
-            .field("request_limit", &self.request_limit)
-            .field("stream_batch_size", &self.stream_batch_size)
-            .field("concurrent_requests_range", &self.concurrent_requests_range)
-            .field("max_buffered_responses", &self.max_buffered_responses)
-            .field("download_range", &self.download_range)
-            .field("latest_queued_block_number", &self.latest_queued_block_number)
-            .finish()
-    }
 }
 
 impl<B, DB> ConcurrentDownloader<B, DB>

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -14,10 +14,7 @@ use reth_interfaces::{
     consensus::Consensus,
     p2p::bodies::{downloader::BodyDownloader, response::BlockResponse},
 };
-use std::{
-    fmt::{Debug, Formatter},
-    sync::Arc,
-};
+use std::sync::Arc;
 use tracing::*;
 
 pub(crate) const BODIES: StageId = StageId("Bodies");
@@ -53,17 +50,12 @@ pub(crate) const BODIES: StageId = StageId("Bodies");
 /// - The [`CumulativeTxCount`][reth_interfaces::db::tables::CumulativeTxCount] table
 /// - The [`Transactions`][reth_interfaces::db::tables::Transactions] table
 /// - The [`TransactionHashNumber`][reth_interfaces::db::tables::TransactionHashNumber] table
+#[derive(Debug)]
 pub struct BodyStage<D: BodyDownloader> {
     /// The body downloader.
     pub downloader: D,
     /// The consensus engine.
     pub consensus: Arc<dyn Consensus>,
-}
-
-impl<D: BodyDownloader + Debug> Debug for BodyStage<D> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("BodyStage").field("downloader", &self.downloader).finish()
-    }
 }
 
 #[async_trait::async_trait]

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -18,7 +18,10 @@ use reth_interfaces::{
     },
 };
 use reth_primitives::{BlockNumber, Header, SealedHeader, U256};
-use std::{fmt::Debug, sync::Arc};
+use std::{
+    fmt::{Debug, Formatter},
+    sync::Arc,
+};
 use tracing::*;
 
 pub(crate) const HEADERS: StageId = StageId("Headers");
@@ -36,24 +39,28 @@ pub(crate) const HEADERS: StageId = StageId("Headers");
 ///
 /// NOTE: This stage downloads headers in reverse. Upon returning the control flow to the pipeline,
 /// the stage progress is not updated unless this stage is done.
-#[derive(Debug)]
-pub struct HeaderStage<D: HeaderDownloader, C: Consensus, S: StatusUpdater> {
+pub struct HeaderStage<D: HeaderDownloader, S: StatusUpdater> {
     /// Strategy for downloading the headers
     pub downloader: D,
     /// Consensus client implementation
-    pub consensus: Arc<C>,
+    pub consensus: Arc<dyn Consensus>,
     /// Emits updates about the sync status
     pub sync_status_updates: S,
     /// Header metrics
     pub metrics: HeaderMetrics,
 }
 
+impl<D: HeaderDownloader, S: StatusUpdater> Debug for HeaderStage<D, S> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HeaderStage").finish()
+    }
+}
+
 // === impl HeaderStage ===
 
-impl<D, C, S> HeaderStage<D, C, S>
+impl<D, S> HeaderStage<D, S>
 where
     D: HeaderDownloader,
-    C: Consensus,
     S: StatusUpdater,
 {
     fn update_head<DB: Database>(
@@ -178,11 +185,10 @@ where
 }
 
 #[async_trait::async_trait]
-impl<DB, D, C, S> Stage<DB> for HeaderStage<D, C, S>
+impl<DB, D, S> Stage<DB> for HeaderStage<D, S>
 where
     DB: Database,
     D: HeaderDownloader,
-    C: Consensus,
     S: StatusUpdater,
 {
     /// Return the id of the stage
@@ -307,6 +313,7 @@ mod tests {
         };
         use reth_downloaders::headers::linear::{LinearDownloadBuilder, LinearDownloader};
         use reth_interfaces::{
+            consensus::{Consensus, ForkchoiceState},
             p2p::headers::downloader::HeaderDownloader,
             test_utils::{
                 generators::{random_header, random_header_range},
@@ -341,7 +348,7 @@ mod tests {
         }
 
         impl<D: HeaderDownloader + 'static> StageTestRunner for HeadersTestRunner<D> {
-            type S = HeaderStage<D, TestConsensus, TestStatusUpdater>;
+            type S = HeaderStage<D, TestStatusUpdater>;
 
             fn tx(&self) -> &TestTransaction {
                 &self.tx
@@ -425,7 +432,12 @@ mod tests {
                     self.tx.insert_headers(std::iter::once(&tip))?;
                     tip.hash()
                 };
-                self.consensus.update_tip(tip);
+                self.consensus
+                    .notify_fork_choice_state(ForkchoiceState {
+                        head_block_hash: tip,
+                        ..Default::default()
+                    })
+                    .expect("Setting tip failed");
                 Ok(())
             }
         }
@@ -436,7 +448,7 @@ mod tests {
             }
         }
 
-        impl HeadersTestRunner<LinearDownloader<TestConsensus, TestHeadersClient>> {
+        impl HeadersTestRunner<LinearDownloader<TestHeadersClient>> {
             pub(crate) fn with_linear_downloader() -> Self {
                 let client = Arc::new(TestHeadersClient::default());
                 let consensus = Arc::new(TestConsensus::default());
@@ -489,7 +501,13 @@ mod tests {
 
         // skip `after_execution` hook for linear downloader
         let tip = headers.last().unwrap();
-        runner.consensus.update_tip(tip.hash());
+        runner
+            .consensus
+            .notify_fork_choice_state(ForkchoiceState {
+                head_block_hash: tip.hash(),
+                ..Default::default()
+            })
+            .expect("Setting tip failed");
 
         let result = rx.await.unwrap();
         assert_matches!(result, Ok(ExecOutput { done: true, stage_progress }) if stage_progress == tip.number);
@@ -504,7 +522,13 @@ mod tests {
         let stage = runner.stage();
 
         let consensus_tip = H256::random();
-        stage.consensus.update_tip(consensus_tip);
+        stage
+            .consensus
+            .notify_fork_choice_state(ForkchoiceState {
+                head_block_hash: consensus_tip,
+                ..Default::default()
+            })
+            .expect("Setting tip failed");
 
         // Genesis
         let stage_progress = 0;
@@ -568,7 +592,13 @@ mod tests {
 
         // skip `after_execution` hook for linear downloader
         let tip = headers.last().unwrap();
-        runner.consensus.update_tip(tip.hash());
+        runner
+            .consensus
+            .notify_fork_choice_state(ForkchoiceState {
+                head_block_hash: tip.hash(),
+                ..Default::default()
+            })
+            .expect("Setting tip failed");
 
         let result = rx.await.unwrap();
         assert_matches!(result, Ok(ExecOutput { done: false, stage_progress: progress }) if progress == stage_progress);

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -18,10 +18,7 @@ use reth_interfaces::{
     },
 };
 use reth_primitives::{BlockNumber, Header, SealedHeader, U256};
-use std::{
-    fmt::{Debug, Formatter},
-    sync::Arc,
-};
+use std::sync::Arc;
 use tracing::*;
 
 pub(crate) const HEADERS: StageId = StageId("Headers");
@@ -39,6 +36,7 @@ pub(crate) const HEADERS: StageId = StageId("Headers");
 ///
 /// NOTE: This stage downloads headers in reverse. Upon returning the control flow to the pipeline,
 /// the stage progress is not updated unless this stage is done.
+#[derive(Debug)]
 pub struct HeaderStage<D: HeaderDownloader, S: StatusUpdater> {
     /// Strategy for downloading the headers
     pub downloader: D,
@@ -48,12 +46,6 @@ pub struct HeaderStage<D: HeaderDownloader, S: StatusUpdater> {
     pub sync_status_updates: S,
     /// Header metrics
     pub metrics: HeaderMetrics,
-}
-
-impl<D: HeaderDownloader, S: StatusUpdater> Debug for HeaderStage<D, S> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("HeaderStage").finish()
-    }
 }
 
 // === impl HeaderStage ===


### PR DESCRIPTION
Replaces type parameters with `dyn Consensus` since we will need to instantiate different consensus engines at run time depending on the chain

Also adds a `notify_fork_choice_state` on the `Consensus` trait which can be used for debugging/testing