### PR TITLE
chore(download): propagate fatal bodies db error

### DIFF
--- a/crates/interfaces/src/p2p/bodies/downloader.rs
+++ b/crates/interfaces/src/p2p/bodies/downloader.rs
@@ -1,5 +1,5 @@
 use super::response::BlockResponse;
-use crate::{db, p2p::error::DownloadResult};
+use crate::db;
 use futures::Stream;
 use reth_primitives::BlockNumber;
 use std::ops::Range;
@@ -9,7 +9,7 @@ use std::ops::Range;
 /// A downloader represents a distinct strategy for submitting requests to download block bodies,
 /// while a [BodiesClient] represents a client capable of fulfilling these requests.
 pub trait BodyDownloader:
-    Send + Sync + Stream<Item = DownloadResult<Vec<BlockResponse>>> + Unpin
+    Send + Sync + Stream<Item = Result<Vec<BlockResponse>, db::Error>> + Unpin
 {
     /// Method for setting the download range.
     fn set_download_range(&mut self, range: Range<BlockNumber>) -> Result<(), db::Error>;

--- a/crates/interfaces/src/p2p/bodies/downloader.rs
+++ b/crates/interfaces/src/p2p/bodies/downloader.rs
@@ -1,5 +1,5 @@
 use super::response::BlockResponse;
-use crate::db;
+use crate::{db, p2p::error::DownloadResult};
 use futures::Stream;
 use reth_primitives::BlockNumber;
 use std::ops::Range;
@@ -8,7 +8,9 @@ use std::ops::Range;
 ///
 /// A downloader represents a distinct strategy for submitting requests to download block bodies,
 /// while a [BodiesClient] represents a client capable of fulfilling these requests.
-pub trait BodyDownloader: Send + Sync + Stream<Item = Vec<BlockResponse>> + Unpin {
+pub trait BodyDownloader:
+    Send + Sync + Stream<Item = DownloadResult<Vec<BlockResponse>>> + Unpin
+{
     /// Method for setting the download range.
     fn set_download_range(&mut self, range: Range<BlockNumber>) -> Result<(), db::Error>;
 }

--- a/crates/interfaces/src/p2p/error.rs
+++ b/crates/interfaces/src/p2p/error.rs
@@ -1,4 +1,4 @@
-use crate::{consensus, db};
+use crate::consensus;
 use reth_primitives::{rpc::BlockNumber, BlockHashOrNumber, Header, WithPeerId, H256};
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
@@ -151,9 +151,6 @@ pub enum DownloadError {
         /// How many headers we expected.
         expected: u64,
     },
-    /// Error while querying the database.
-    #[error(transparent)]
-    DatabaseError(#[from] db::Error),
     /// Error while executing the request.
     #[error(transparent)]
     RequestError(#[from] RequestError),

--- a/crates/interfaces/src/p2p/error.rs
+++ b/crates/interfaces/src/p2p/error.rs
@@ -1,4 +1,4 @@
-use crate::consensus;
+use crate::{consensus, db};
 use reth_primitives::{rpc::BlockNumber, BlockHashOrNumber, Header, WithPeerId, H256};
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
@@ -151,6 +151,9 @@ pub enum DownloadError {
         /// How many headers we expected.
         expected: u64,
     },
+    /// Error while querying the database.
+    #[error(transparent)]
+    DatabaseError(#[from] db::Error),
     /// Error while executing the request.
     #[error(transparent)]
     RequestError(#[from] RequestError),

--- a/crates/net/downloaders/src/bodies/concurrent.rs
+++ b/crates/net/downloaders/src/bodies/concurrent.rs
@@ -5,10 +5,7 @@ use reth_db::{cursor::DbCursorRO, database::Database, tables, transaction::DbTx}
 use reth_interfaces::{
     consensus::Consensus as ConsensusTrait,
     db,
-    p2p::{
-        bodies::{client::BodiesClient, downloader::BodyDownloader, response::BlockResponse},
-        error::DownloadResult,
-    },
+    p2p::bodies::{client::BodiesClient, downloader::BodyDownloader, response::BlockResponse},
 };
 use reth_primitives::{BlockNumber, SealedHeader};
 use std::{
@@ -324,7 +321,7 @@ where
     C: ConsensusTrait + 'static,
     DB: Database,
 {
-    type Item = DownloadResult<Vec<BlockResponse>>;
+    type Item = Result<Vec<BlockResponse>, db::Error>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
@@ -361,7 +358,7 @@ where
                     Err(error) => {
                         tracing::error!(target: "downloaders::bodies", ?error, "Failed to form next request");
                         this.clear();
-                        return Poll::Ready(Some(Err(error.into())))
+                        return Poll::Ready(Some(Err(error)))
                     }
                 };
             }

--- a/crates/net/downloaders/src/bodies/concurrent.rs
+++ b/crates/net/downloaders/src/bodies/concurrent.rs
@@ -5,7 +5,10 @@ use reth_db::{cursor::DbCursorRO, database::Database, tables, transaction::DbTx}
 use reth_interfaces::{
     consensus::Consensus as ConsensusTrait,
     db,
-    p2p::bodies::{client::BodiesClient, downloader::BodyDownloader, response::BlockResponse},
+    p2p::{
+        bodies::{client::BodiesClient, downloader::BodyDownloader, response::BlockResponse},
+        error::DownloadResult,
+    },
 };
 use reth_primitives::{BlockNumber, SealedHeader};
 use std::{
@@ -178,14 +181,31 @@ where
         max_dynamic.min(*self.concurrent_requests_range.end())
     }
 
+    // Check if the stream is terminated
     fn is_terminated(&self) -> bool {
-        self.in_progress_queue
-            .last_requested_block_number
-            .map(|last| last + 1 == self.download_range.end)
-            .unwrap_or_default() &&
+        // There is nothing to request if the range is empty
+        let nothing_to_request = self.download_range.is_empty() ||
+            // or all blocks have already been requested. 
+            self.in_progress_queue
+                .last_requested_block_number
+                .map(|last| last + 1 == self.download_range.end)
+                .unwrap_or_default();
+
+        nothing_to_request &&
             self.in_progress_queue.is_empty() &&
             self.buffered_responses.is_empty() &&
             self.queued_bodies.is_empty()
+    }
+
+    /// Clear all download related data.
+    ///
+    /// Should be invoked upon encountering fatal error.
+    fn clear(&mut self) {
+        self.download_range = Range::default();
+        self.latest_queued_block_number.take();
+        self.in_progress_queue.clear();
+        self.buffered_responses.clear();
+        self.queued_bodies.clear();
     }
 
     /// Queues bodies and sets the latest queued block number
@@ -304,7 +324,7 @@ where
     C: ConsensusTrait + 'static,
     DB: Database,
 {
-    type Item = Vec<BlockResponse>;
+    type Item = DownloadResult<Vec<BlockResponse>>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
@@ -340,6 +360,8 @@ where
                     Ok(None) => break 'inner,
                     Err(error) => {
                         tracing::error!(target: "downloaders::bodies", ?error, "Failed to form next request");
+                        this.clear();
+                        return Poll::Ready(Some(Err(error.into())))
                     }
                 };
             }
@@ -351,7 +373,7 @@ where
             // Yield next batch
             if this.queued_bodies.len() >= this.stream_batch_size {
                 let next_batch = this.queued_bodies.drain(..this.stream_batch_size);
-                return Poll::Ready(Some(next_batch.collect()))
+                return Poll::Ready(Some(Ok(next_batch.collect())))
             }
 
             if !new_request_submitted {
@@ -367,7 +389,7 @@ where
 
             let batch_size = this.stream_batch_size.min(this.queued_bodies.len());
             let next_batch = this.queued_bodies.drain(..batch_size);
-            return Poll::Ready(Some(next_batch.collect()))
+            return Poll::Ready(Some(Ok(next_batch.collect())))
         }
 
         Poll::Pending
@@ -555,7 +577,7 @@ mod tests {
 
         assert_matches!(
             downloader.next().await,
-            Some(res) => assert_eq!(res, zip_blocks(headers.iter(), &mut bodies))
+            Some(Ok(res)) => assert_eq!(res, zip_blocks(headers.iter(), &mut bodies))
         );
         assert_eq!(client.times_requested(), 1);
     }
@@ -587,7 +609,7 @@ mod tests {
 
             assert_matches!(
                 downloader.next().await,
-                Some(res) => assert_eq!(res, zip_blocks(headers.iter().skip(range_start as usize).take(stream_batch_size), &mut bodies))
+                Some(Ok(res)) => assert_eq!(res, zip_blocks(headers.iter().skip(range_start as usize).take(stream_batch_size), &mut bodies))
             );
             assert!(downloader.latest_queued_block_number >= Some(range_start));
             range_start += stream_batch_size as u64;
@@ -619,17 +641,17 @@ mod tests {
         downloader.set_download_range(0..100).expect("failed to set header range");
         assert_matches!(
             downloader.next().await,
-            Some(res) => assert_eq!(res, zip_blocks(headers.iter().take(100), &mut bodies))
+            Some(Ok(res)) => assert_eq!(res, zip_blocks(headers.iter().take(100), &mut bodies))
         );
 
         // Check that the stream is terminated
-        assert_eq!(downloader.next().await, None);
+        assert!(downloader.next().await.is_none());
 
         // Set and download the second range
         downloader.set_download_range(100..200).expect("failed to set header range");
         assert_matches!(
             downloader.next().await,
-            Some(res) => assert_eq!(res, zip_blocks(headers.iter().skip(100), &mut bodies))
+            Some(Ok(res)) => assert_eq!(res, zip_blocks(headers.iter().skip(100), &mut bodies))
         );
     }
 }

--- a/crates/net/downloaders/src/bodies/queue.rs
+++ b/crates/net/downloaders/src/bodies/queue.rs
@@ -40,12 +40,21 @@ where
     B: BodiesClient + 'static,
     C: ConsensusTrait + 'static,
 {
+    /// Returns `true` if the queue is empty.
     pub(crate) fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
 
+    /// Returns the number of queued requests.
     pub(crate) fn len(&self) -> usize {
         self.inner.len()
+    }
+
+    /// Clears the inner queue and related data.
+    pub(crate) fn clear(&mut self) {
+        self.inner.clear();
+        self.block_numbers.clear();
+        self.last_requested_block_number.take();
     }
 
     /// Add new request to the queue.

--- a/crates/stages/src/error.rs
+++ b/crates/stages/src/error.rs
@@ -1,5 +1,5 @@
 use crate::pipeline::PipelineEvent;
-use reth_interfaces::{consensus, db::Error as DbError, executor};
+use reth_interfaces::{consensus, db::Error as DbError, executor, p2p::error::DownloadError};
 use reth_primitives::{BlockNumber, TxNumber, H256};
 use thiserror::Error;
 use tokio::sync::mpsc::error::SendError;
@@ -35,7 +35,7 @@ pub enum StageError {
     /// Invalid download response. Applicable for stages which
     /// rely on external downloaders
     #[error("Invalid download response: {0}")]
-    Download(String),
+    Download(#[from] DownloadError),
     /// Invalid checkpoint passed to the stage
     #[error("Invalid stage progress: {0}")]
     StageProgress(u64),

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -414,7 +414,7 @@ mod tests {
                     client::BodiesClient, downloader::BodyDownloader, response::BlockResponse,
                 },
                 download::DownloadClient,
-                error::{DownloadResult, PeerRequestResult},
+                error::PeerRequestResult,
                 priority::Priority,
             },
             test_utils::{
@@ -741,7 +741,7 @@ mod tests {
         }
 
         impl Stream for TestBodyDownloader {
-            type Item = DownloadResult<Vec<BlockResponse>>;
+            type Item = Result<Vec<BlockResponse>, db::Error>;
             fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
                 let this = self.get_mut();
 

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -2,7 +2,7 @@ use crate::{
     db::Transaction, exec_or_return, ExecAction, ExecInput, ExecOutput, Stage, StageError, StageId,
     UnwindInput, UnwindOutput,
 };
-use futures_util::StreamExt;
+use futures_util::TryStreamExt;
 use reth_db::{
     cursor::{DbCursorRO, DbCursorRW},
     database::Database,
@@ -92,7 +92,7 @@ impl<DB: Database, D: BodyDownloader, C: Consensus> Stage<DB> for BodyStage<D, C
         let mut highest_block = input.stage_progress.unwrap_or_default();
         debug!(target: "sync::stages::bodies", stage_progress = highest_block, target = end_block, start_tx_id = current_tx_id, transition_id, "Commencing sync");
 
-        let downloaded_bodies = match self.downloader.next().await {
+        let downloaded_bodies = match self.downloader.try_next().await? {
             Some(downloaded_bodies) => downloaded_bodies,
             None => {
                 info!(target: "sync::stages::bodies", stage_progress = highest_block, "Download stream exhausted");
@@ -414,7 +414,7 @@ mod tests {
                     client::BodiesClient, downloader::BodyDownloader, response::BlockResponse,
                 },
                 download::DownloadClient,
-                error::PeerRequestResult,
+                error::{DownloadResult, PeerRequestResult},
                 priority::Priority,
             },
             test_utils::{
@@ -741,7 +741,7 @@ mod tests {
         }
 
         impl Stream for TestBodyDownloader {
-            type Item = Vec<BlockResponse>;
+            type Item = DownloadResult<Vec<BlockResponse>>;
             fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
                 let this = self.get_mut();
 
@@ -769,7 +769,7 @@ mod tests {
                 }
 
                 if !response.is_empty() {
-                    return Poll::Ready(Some(response))
+                    return Poll::Ready(Some(Ok(response)))
                 }
 
                 panic!("requested bodies without setting headers")


### PR DESCRIPTION
The database error from the bodies downloader is now considered fatal and propagated to the stage.
The downloader is cleared upon encountering a fatal error.