### PR TITLE
chore(metrics): allow dot in the scope value

### DIFF
--- a/crates/metrics/metrics-derive/src/expand.rs
+++ b/crates/metrics/metrics-derive/src/expand.rs
@@ -11,7 +11,7 @@ use crate::{metric::Metric, with_attrs::WithAttrs};
 /// Metric name regex according to Prometheus data model
 /// https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
 static METRIC_NAME_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^[a-zA-Z_:][a-zA-Z0-9_:]*$").unwrap());
+    Lazy::new(|| Regex::new(r"^[a-zA-Z_:.][a-zA-Z0-9_:.]*$").unwrap());
 
 /// Supported metrics separators
 const SUPPORTED_SEPARATORS: &[&str] = &[".", "_", ":"];

--- a/crates/metrics/metrics-derive/tests/compile-fail/metrics_attr.rs
+++ b/crates/metrics/metrics-derive/tests/compile-fail/metrics_attr.rs
@@ -24,7 +24,7 @@ struct CustomMetrics4;
 struct CustomMetrics5;
 
 #[derive(Metrics)]
-#[metrics(scope = "some.scope")]
+#[metrics(scope = "some-scope")]
 struct CustomMetrics6;
 
 #[derive(Metrics)]

--- a/crates/metrics/metrics-derive/tests/compile-fail/metrics_attr.stderr
+++ b/crates/metrics/metrics-derive/tests/compile-fail/metrics_attr.stderr
@@ -29,12 +29,6 @@ error: Value **must** be a string literal.
 23 | #[metrics(scope = 123)]
    |                   ^^^
 
-error: Value must match regex ^[a-zA-Z_:][a-zA-Z0-9_:]*$
-  --> tests/compile-fail/metrics_attr.rs:27:19
-   |
-27 | #[metrics(scope = "some.scope")]
-   |                   ^^^^^^^^^^^^
-
 error: Duplicate `scope` value provided.
   --> tests/compile-fail/metrics_attr.rs:31:33
    |

--- a/crates/metrics/metrics-derive/tests/compile-fail/metrics_attr.stderr
+++ b/crates/metrics/metrics-derive/tests/compile-fail/metrics_attr.stderr
@@ -29,6 +29,12 @@ error: Value **must** be a string literal.
 23 | #[metrics(scope = 123)]
    |                   ^^^
 
+error: Value must match regex ^[a-zA-Z_:.][a-zA-Z0-9_:.]*$
+  --> tests/compile-fail/metrics_attr.rs:27:19
+   |
+27 | #[metrics(scope = "some-scope")]
+   |                   ^^^^^^^^^^^^
+
 error: Duplicate `scope` value provided.
   --> tests/compile-fail/metrics_attr.rs:31:33
    |


### PR DESCRIPTION
Allow for `.` in the `scope = "<value>"` attribute