### PR TITLE
feat: compute genesis root

### DIFF
--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -1,6 +1,6 @@
 use crate::{
-    BlockNumber, Chain, ForkFilter, ForkHash, ForkId, Genesis,
-    GenesisAccount, Hardfork, Header, H160, H256, U256,
+    BlockNumber, Chain, ForkFilter, ForkHash, ForkId, Genesis, GenesisAccount, Hardfork, Header,
+    H160, H256, U256,
 };
 use ethers_core::utils::Genesis as EthersGenesis;
 use hex_literal::hex;

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -1,5 +1,5 @@
 use crate::{
-    proofs::genesis_state_root, BlockNumber, Chain, ForkFilter, ForkHash, ForkId, Genesis,
+    BlockNumber, Chain, ForkFilter, ForkHash, ForkId, Genesis,
     GenesisAccount, Hardfork, Header, H160, H256, U256,
 };
 use ethers_core::utils::Genesis as EthersGenesis;
@@ -195,8 +195,6 @@ impl From<EthersGenesis> for ChainSpec {
             .map(|(addr, account)| (addr.0.into(), account.clone().into()))
             .collect::<HashMap<H160, GenesisAccount>>();
 
-        let state_root = genesis_state_root(alloc.clone());
-
         let genesis_block = Genesis {
             nonce: genesis.nonce.as_u64(),
             timestamp: genesis.timestamp.as_u64(),
@@ -206,7 +204,6 @@ impl From<EthersGenesis> for ChainSpec {
             coinbase: genesis.coinbase.0.into(),
             extra_data: genesis.extra_data.0.into(),
             alloc,
-            state_root,
         };
 
         let genesis_hash = Header::from(genesis_block.clone()).seal().hash();

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -16,6 +16,14 @@ pub const EIP1559_ELASTICITY_MULTIPLIER: u64 = 2;
 pub const MAINNET_GENESIS: H256 =
     H256(hex!("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"));
 
+/// Goerli genesis hash.
+pub const GOERLI_GENESIS: H256 =
+    H256(hex!("bf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a"));
+
+/// Sepolia genesis hash.
+pub const SEPOLIA_GENESIS: H256 =
+    H256(hex!("25a5cc106eea7138acab33231d7160d69cb777ee0c2c553fcddf5138993e6dd9"));
+
 /// Keccak256 over empty array.
 pub const KECCAK_EMPTY: H256 =
     H256(hex!("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"));

--- a/crates/primitives/src/genesis.rs
+++ b/crates/primitives/src/genesis.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::{
     keccak256,
-    proofs::{KeccakHasher, EMPTY_ROOT},
+    proofs::{KeccakHasher, EMPTY_ROOT, genesis_state_root},
     utils::serde_helpers::deserialize_stringified_u64,
     Address, Bytes, Header, H256, KECCAK_EMPTY, U256,
 };
@@ -33,8 +33,6 @@ pub struct Genesis {
     pub mix_hash: H256,
     /// The genesis header coinbase address.
     pub coinbase: Address,
-    /// The genesis state root.
-    pub state_root: H256,
     /// The initial state of accounts in the genesis block.
     pub alloc: HashMap<Address, GenesisAccount>,
 }
@@ -46,7 +44,7 @@ impl From<Genesis> for Header {
             difficulty: genesis.difficulty,
             nonce: genesis.nonce,
             extra_data: genesis.extra_data,
-            state_root: genesis.state_root,
+            state_root: genesis_state_root(genesis.alloc),
             timestamp: genesis.timestamp,
             mix_hash: genesis.mix_hash,
             beneficiary: genesis.coinbase,

--- a/crates/primitives/src/genesis.rs
+++ b/crates/primitives/src/genesis.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::{
     keccak256,
-    proofs::{KeccakHasher, EMPTY_ROOT, genesis_state_root},
+    proofs::{genesis_state_root, KeccakHasher, EMPTY_ROOT},
     utils::serde_helpers::deserialize_stringified_u64,
     Address, Bytes, Header, H256, KECCAK_EMPTY, U256,
 };

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -40,7 +40,9 @@ pub use bloom::Bloom;
 pub use chain::{
     Chain, ChainInfo, ChainSpec, ChainSpecBuilder, ParisStatus, GOERLI, MAINNET, SEPOLIA,
 };
-pub use constants::{EMPTY_OMMER_ROOT, KECCAK_EMPTY, MAINNET_GENESIS};
+pub use constants::{
+    EMPTY_OMMER_ROOT, GOERLI_GENESIS, KECCAK_EMPTY, MAINNET_GENESIS, SEPOLIA_GENESIS,
+};
 pub use forkid::{ForkFilter, ForkHash, ForkId, ForkTransition, ValidationError};
 pub use genesis::{Genesis, GenesisAccount};
 pub use hardfork::Hardfork;

--- a/crates/staged-sync/src/utils/init.rs
+++ b/crates/staged-sync/src/utils/init.rs
@@ -68,3 +68,50 @@ pub fn init_genesis<DB: Database>(db: Arc<DB>, chain: ChainSpec) -> Result<H256,
     tx.commit()?;
     Ok(hash)
 }
+
+#[cfg(test)]
+mod tests {
+
+    use super::init_genesis;
+    use crate::utils::init::WriteMap;
+    use reth_db::mdbx::test_utils::create_test_rw_db;
+    use reth_primitives::{
+        Header, GOERLI, GOERLI_GENESIS, MAINNET, MAINNET_GENESIS, SEPOLIA, SEPOLIA_GENESIS,
+    };
+
+    #[test]
+    fn success_init_genesis_mainnet() {
+        let db = create_test_rw_db::<WriteMap>();
+
+        let mut chain_spec = MAINNET.clone();
+        chain_spec.genesis_hash = Header::default().hash_slow();
+
+        let genesis_hash = init_genesis(db.clone(), chain_spec).unwrap();
+        // actual, expected
+        assert_eq!(genesis_hash, MAINNET_GENESIS);
+    }
+
+    #[test]
+    fn success_init_genesis_goerli() {
+        let db = create_test_rw_db::<WriteMap>();
+
+        let mut chain_spec = GOERLI.clone();
+        chain_spec.genesis_hash = Header::default().hash_slow();
+
+        let genesis_hash = init_genesis(db.clone(), chain_spec).unwrap();
+        // actual, expected
+        assert_eq!(genesis_hash, GOERLI_GENESIS);
+    }
+
+    #[test]
+    fn success_init_genesis_sepolia() {
+        let db = create_test_rw_db::<WriteMap>();
+
+        let mut chain_spec = SEPOLIA.clone();
+        chain_spec.genesis_hash = Header::default().hash_slow();
+
+        let genesis_hash = init_genesis(db.clone(), chain_spec).unwrap();
+        // actual, expected
+        assert_eq!(genesis_hash, SEPOLIA_GENESIS);
+    }
+}

--- a/crates/staged-sync/src/utils/init.rs
+++ b/crates/staged-sync/src/utils/init.rs
@@ -76,17 +76,14 @@ mod tests {
     use crate::utils::init::WriteMap;
     use reth_db::mdbx::test_utils::create_test_rw_db;
     use reth_primitives::{
-        Header, GOERLI, GOERLI_GENESIS, MAINNET, MAINNET_GENESIS, SEPOLIA, SEPOLIA_GENESIS,
+        GOERLI, GOERLI_GENESIS, MAINNET, MAINNET_GENESIS, SEPOLIA, SEPOLIA_GENESIS,
     };
 
     #[test]
     fn success_init_genesis_mainnet() {
         let db = create_test_rw_db::<WriteMap>();
-
-        let mut chain_spec = MAINNET.clone();
-        chain_spec.genesis_hash = Header::default().hash_slow();
-
-        let genesis_hash = init_genesis(db.clone(), chain_spec).unwrap();
+        let genesis_hash = init_genesis(db.clone(), MAINNET.clone()).unwrap();
+        
         // actual, expected
         assert_eq!(genesis_hash, MAINNET_GENESIS);
     }
@@ -94,11 +91,8 @@ mod tests {
     #[test]
     fn success_init_genesis_goerli() {
         let db = create_test_rw_db::<WriteMap>();
-
-        let mut chain_spec = GOERLI.clone();
-        chain_spec.genesis_hash = Header::default().hash_slow();
-
-        let genesis_hash = init_genesis(db.clone(), chain_spec).unwrap();
+        let genesis_hash = init_genesis(db.clone(), GOERLI.clone()).unwrap();
+        
         // actual, expected
         assert_eq!(genesis_hash, GOERLI_GENESIS);
     }
@@ -106,11 +100,8 @@ mod tests {
     #[test]
     fn success_init_genesis_sepolia() {
         let db = create_test_rw_db::<WriteMap>();
-
-        let mut chain_spec = SEPOLIA.clone();
-        chain_spec.genesis_hash = Header::default().hash_slow();
-
-        let genesis_hash = init_genesis(db.clone(), chain_spec).unwrap();
+        let genesis_hash = init_genesis(db.clone(), SEPOLIA.clone()).unwrap();
+        
         // actual, expected
         assert_eq!(genesis_hash, SEPOLIA_GENESIS);
     }

--- a/crates/staged-sync/src/utils/init.rs
+++ b/crates/staged-sync/src/utils/init.rs
@@ -83,7 +83,7 @@ mod tests {
     fn success_init_genesis_mainnet() {
         let db = create_test_rw_db::<WriteMap>();
         let genesis_hash = init_genesis(db.clone(), MAINNET.clone()).unwrap();
-        
+
         // actual, expected
         assert_eq!(genesis_hash, MAINNET_GENESIS);
     }
@@ -92,7 +92,7 @@ mod tests {
     fn success_init_genesis_goerli() {
         let db = create_test_rw_db::<WriteMap>();
         let genesis_hash = init_genesis(db.clone(), GOERLI.clone()).unwrap();
-        
+
         // actual, expected
         assert_eq!(genesis_hash, GOERLI_GENESIS);
     }
@@ -101,7 +101,7 @@ mod tests {
     fn success_init_genesis_sepolia() {
         let db = create_test_rw_db::<WriteMap>();
         let genesis_hash = init_genesis(db.clone(), SEPOLIA.clone()).unwrap();
-        
+
         // actual, expected
         assert_eq!(genesis_hash, SEPOLIA_GENESIS);
     }


### PR DESCRIPTION
### Describe the feature
Genesis state root is not computed, but is a mandatory field inside `Genesis` struct.
This should be computed rather then be required, using `genesis_state_root` fn, to be in line with Geth behaviour.
It also includes tests for `init_genesis`.

### Additional context
Fixes #896 