### PR TITLE
fix(primitives): ensure sepolia activates london at genesis

### DIFF
--- a/crates/primitives/src/chain_spec.rs
+++ b/crates/primitives/src/chain_spec.rs
@@ -59,7 +59,21 @@ pub static SEPOLIA: Lazy<ChainSpec> = Lazy::new(|| ChainSpec {
     genesis: serde_json::from_str(include_str!("../res/genesis/sepolia.json"))
         .expect("Can't deserialize Sepolia genesis json"),
     genesis_hash: H256(hex!("25a5cc106eea7138acab33231d7160d69cb777ee0c2c553fcddf5138993e6dd9")),
-    hardforks: BTreeMap::from([(Hardfork::MergeNetsplit, 1735371)]),
+    hardforks: BTreeMap::from([
+        (Hardfork::Frontier, 0),
+        (Hardfork::Homestead, 0),
+        (Hardfork::Dao, 0),
+        (Hardfork::Tangerine, 0),
+        (Hardfork::SpuriousDragon, 0),
+        (Hardfork::Byzantium, 0),
+        (Hardfork::Constantinople, 0),
+        (Hardfork::Petersburg, 0),
+        (Hardfork::Istanbul, 0),
+        (Hardfork::Muirglacier, 0),
+        (Hardfork::Berlin, 0),
+        (Hardfork::London, 0),
+        (Hardfork::MergeNetsplit, 1735371),
+    ]),
     dao_fork_support: true,
     paris_block: Some(1450408),
     paris_ttd: Some(U256::from(17000000000000000_u64)),
@@ -563,6 +577,7 @@ mod tests {
 
     #[test]
     fn test_sepolia_forkids() {
+        // Test vector is from <https://github.com/ethereum/go-ethereum/blob/59a48e0289b1a7470a8285e665cab12b29117a70/core/forkid/forkid_test.go#L146-L151>
         let mergenetsplit_forkid = SEPOLIA.fork_id(1735371);
         assert_eq!([0xb9, 0x6c, 0xbd, 0x13], mergenetsplit_forkid.hash.0);
         assert_eq!(0, mergenetsplit_forkid.next);


### PR DESCRIPTION
Previously, we did not activate London or any previous forks for sepolia at genesis. This is done in geth here:
https://github.com/ethereum/go-ethereum/blob/59a48e0289b1a7470a8285e665cab12b29117a70/params/config.go#L148-L166

This ensures that the base fee per gas is written to the sepolia genesis block.