### PR TITLE
chore(stages): Helper for walking over table range

### DIFF
--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -711,7 +711,7 @@ mod tests {
                         let mut header_cursor = tx.cursor_read::<tables::Headers>()?;
 
                         let mut canonical_cursor = tx.cursor_read::<tables::CanonicalHeaders>()?;
-                        let walker = canonical_cursor.walk_range(range.start, range.end)?;
+                        let walker = canonical_cursor.walk_range(range.start..range.end)?;
 
                         let mut headers = Vec::default();
                         for entry in walker {

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -711,9 +711,7 @@ mod tests {
                         let mut header_cursor = tx.cursor_read::<tables::Headers>()?;
 
                         let mut canonical_cursor = tx.cursor_read::<tables::CanonicalHeaders>()?;
-                        let walker = canonical_cursor.walk(range.start)?.take_while(|entry| {
-                            entry.as_ref().map(|(num, _)| *num < range.end).unwrap_or_default()
-                        });
+                        let walker = canonical_cursor.walk_range(range.start, range.end)?;
 
                         let mut headers = Vec::default();
                         for entry in walker {

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -103,7 +103,7 @@ impl<DB: Database> Stage<DB> for ExecutionStage {
 
         // get canonical blocks (num,hash)
         let canonical_batch = canonicals
-            .walk_range(start_block, end_block + 1)?
+            .walk_range(start_block..end_block + 1)?
             .map(|i| i.map(BlockNumHash))
             .collect::<Result<Vec<_>, _>>()?;
 
@@ -332,7 +332,7 @@ impl<DB: Database> Stage<DB> for ExecutionStage {
         // get all batches for account change
         // Check if walk and walk_dup would do the same thing
         let account_changeset_batch = account_changeset
-            .walk_range(from_transition_rev, to_transition_rev)?
+            .walk_range(from_transition_rev..to_transition_rev)?
             .collect::<Result<Vec<_>, _>>()?;
 
         // revert all changes to PlainState
@@ -348,8 +348,8 @@ impl<DB: Database> Stage<DB> for ExecutionStage {
         // get all batches for storage change
         let storage_changeset_batch = storage_changeset
             .walk_range(
-                (from_transition_rev, Address::zero()).into(),
-                (to_transition_rev, Address::zero()).into(),
+                (from_transition_rev, Address::zero()).into()..
+                    (to_transition_rev, Address::zero()).into(),
             )?
             .collect::<Result<Vec<_>, _>>()?;
 

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -103,8 +103,7 @@ impl<DB: Database> Stage<DB> for ExecutionStage {
 
         // get canonical blocks (num,hash)
         let canonical_batch = canonicals
-            .walk(start_block)?
-            .take_while(|entry| entry.as_ref().map(|e| e.0 <= end_block).unwrap_or_default())
+            .walk_range(start_block, end_block + 1)?
             .map(|i| i.map(BlockNumHash))
             .collect::<Result<Vec<_>, _>>()?;
 
@@ -333,10 +332,7 @@ impl<DB: Database> Stage<DB> for ExecutionStage {
         // get all batches for account change
         // Check if walk and walk_dup would do the same thing
         let account_changeset_batch = account_changeset
-            .walk(from_transition_rev)?
-            .take_while(|item| {
-                item.as_ref().map(|(num, _)| *num < to_transition_rev).unwrap_or_default()
-            })
+            .walk_range(from_transition_rev, to_transition_rev)?
             .collect::<Result<Vec<_>, _>>()?;
 
         // revert all changes to PlainState
@@ -351,12 +347,10 @@ impl<DB: Database> Stage<DB> for ExecutionStage {
 
         // get all batches for storage change
         let storage_changeset_batch = storage_changeset
-            .walk((from_transition_rev, Address::zero()).into())?
-            .take_while(|item| {
-                item.as_ref()
-                    .map(|(key, _)| key.transition_id() < to_transition_rev)
-                    .unwrap_or_default()
-            })
+            .walk_range(
+                (from_transition_rev, Address::zero()).into(),
+                (to_transition_rev, Address::zero()).into(),
+            )?
             .collect::<Result<Vec<_>, _>>()?;
 
         // revert all changes to PlainStorage

--- a/crates/stages/src/stages/hashing_account.rs
+++ b/crates/stages/src/stages/hashing_account.rs
@@ -92,8 +92,7 @@ impl<DB: Database> Stage<DB> for AccountHashingStage {
             // Aggregate all transition changesets and and make list of account that have been
             // changed.
             tx.cursor_read::<tables::AccountChangeSet>()?
-                .walk(from_transition)?
-                .take_while(|res| res.as_ref().map(|(k, _)| *k < to_transition).unwrap_or_default())
+                .walk_range(from_transition, to_transition)?
                 .collect::<Result<Vec<_>, _>>()?
                 .into_iter()
                 // fold all account to one set of changed accounts
@@ -136,8 +135,7 @@ impl<DB: Database> Stage<DB> for AccountHashingStage {
 
         // Aggregate all transition changesets and and make list of account that have been changed.
         tx.cursor_read::<tables::AccountChangeSet>()?
-            .walk(from_transition_rev)?
-            .take_while(|res| res.as_ref().map(|(k, _)| *k < to_transition_rev).unwrap_or_default())
+            .walk_range(from_transition_rev, to_transition_rev)?
             .collect::<Result<Vec<_>, _>>()?
             .into_iter()
             .rev()

--- a/crates/stages/src/stages/hashing_account.rs
+++ b/crates/stages/src/stages/hashing_account.rs
@@ -92,7 +92,7 @@ impl<DB: Database> Stage<DB> for AccountHashingStage {
             // Aggregate all transition changesets and and make list of account that have been
             // changed.
             tx.cursor_read::<tables::AccountChangeSet>()?
-                .walk_range(from_transition, to_transition)?
+                .walk_range(from_transition..to_transition)?
                 .collect::<Result<Vec<_>, _>>()?
                 .into_iter()
                 // fold all account to one set of changed accounts
@@ -135,7 +135,7 @@ impl<DB: Database> Stage<DB> for AccountHashingStage {
 
         // Aggregate all transition changesets and and make list of account that have been changed.
         tx.cursor_read::<tables::AccountChangeSet>()?
-            .walk_range(from_transition_rev, to_transition_rev)?
+            .walk_range(from_transition_rev..to_transition_rev)?
             .collect::<Result<Vec<_>, _>>()?
             .into_iter()
             .rev()

--- a/crates/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/src/stages/hashing_storage.rs
@@ -99,8 +99,8 @@ impl<DB: Database> Stage<DB> for StorageHashingStage {
             // changed.
             tx.cursor_read::<tables::StorageChangeSet>()?
                 .walk_range(
-                    (from_transition, Address::zero()).into(),
-                    (to_transition, Address::zero()).into(),
+                    (from_transition, Address::zero()).into()..
+                        (to_transition, Address::zero()).into(),
                 )?
                 .collect::<Result<Vec<_>, _>>()?
                 .into_iter()
@@ -173,8 +173,8 @@ impl<DB: Database> Stage<DB> for StorageHashingStage {
         // Aggregate all transition changesets and make list of accounts that have been changed.
         tx.cursor_read::<tables::StorageChangeSet>()?
             .walk_range(
-                (from_transition_rev, Address::zero()).into(),
-                (to_transition_rev, Address::zero()).into(),
+                (from_transition_rev, Address::zero()).into()..
+                    (to_transition_rev, Address::zero()).into(),
             )?
             .collect::<Result<Vec<_>, _>>()?
             .into_iter()

--- a/crates/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/src/stages/hashing_storage.rs
@@ -98,10 +98,10 @@ impl<DB: Database> Stage<DB> for StorageHashingStage {
             // Aggregate all transition changesets and and make list of storages that have been
             // changed.
             tx.cursor_read::<tables::StorageChangeSet>()?
-                .walk((from_transition, H160::zero()).into())?
-                .take_while(|res| {
-                    res.as_ref().map(|(k, _)| k.0 .0 < to_transition).unwrap_or_default()
-                })
+                .walk_range(
+                    (from_transition, Address::zero()).into(),
+                    (to_transition, Address::zero()).into(),
+                )?
                 .collect::<Result<Vec<_>, _>>()?
                 .into_iter()
                 // fold all storages and save its old state so we can remove it from HashedStorage
@@ -172,12 +172,10 @@ impl<DB: Database> Stage<DB> for StorageHashingStage {
 
         // Aggregate all transition changesets and make list of accounts that have been changed.
         tx.cursor_read::<tables::StorageChangeSet>()?
-            .walk((from_transition_rev, H160::zero()).into())?
-            .take_while(|res| {
-                res.as_ref()
-                    .map(|(TransitionIdAddress((k, _)), _)| *k < to_transition_rev)
-                    .unwrap_or_default()
-            })
+            .walk_range(
+                (from_transition_rev, Address::zero()).into(),
+                (to_transition_rev, Address::zero()).into(),
+            )?
             .collect::<Result<Vec<_>, _>>()?
             .into_iter()
             .rev()

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -87,9 +87,7 @@ impl<DB: Database> Stage<DB> for SenderRecoveryStage {
         // Acquire the cursor over the transactions
         let mut tx_cursor = tx.cursor_read::<tables::Transactions>()?;
         // Walk the transactions from start to end index (inclusive)
-        let entries = tx_cursor
-            .walk(start_tx_index)?
-            .take_while(|res| res.as_ref().map(|(k, _)| *k <= end_tx_index).unwrap_or_default());
+        let entries = tx_cursor.walk_range(start_tx_index, end_tx_index + 1)?;
 
         // Iterate over transactions in chunks
         info!(target: "sync::stages::sender_recovery", start_tx_index, end_tx_index, "Recovering senders");

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -87,7 +87,7 @@ impl<DB: Database> Stage<DB> for SenderRecoveryStage {
         // Acquire the cursor over the transactions
         let mut tx_cursor = tx.cursor_read::<tables::Transactions>()?;
         // Walk the transactions from start to end index (inclusive)
-        let entries = tx_cursor.walk_range(start_tx_index, end_tx_index + 1)?;
+        let entries = tx_cursor.walk_range(start_tx_index..end_tx_index + 1)?;
 
         // Iterate over transactions in chunks
         info!(target: "sync::stages::sender_recovery", start_tx_index, end_tx_index, "Recovering senders");

--- a/crates/storage/db/src/abstraction/cursor.rs
+++ b/crates/storage/db/src/abstraction/cursor.rs
@@ -204,7 +204,7 @@ pub struct RangeWalker<'cursor, 'tx, T: Table, CURSOR: DbCursorRO<'tx, T>> {
     /// exclusive `key` where to stop the walk.
     end_key: T::Key,
     /// flag whether is ended
-    is_ended: bool,
+    is_done: bool,
     /// Phantom data for 'tx. As it is only used for `DbCursorRO`.
     _tx_phantom: PhantomData<&'tx T>,
 }

--- a/crates/storage/db/src/abstraction/cursor.rs
+++ b/crates/storage/db/src/abstraction/cursor.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use std::{marker::PhantomData, ops::Range};
 
 use crate::{
     common::{IterPairResult, PairResult, ValueOnlyResult},
@@ -42,8 +42,7 @@ pub trait DbCursorRO<'tx, T: Table> {
     /// less than `end_key`
     fn walk_range<'cursor>(
         &'cursor mut self,
-        start_key: T::Key,
-        end_key: T::Key,
+        range: Range<T::Key>,
     ) -> Result<RangeWalker<'cursor, 'tx, T, Self>, Error>
     where
         Self: Sized;

--- a/crates/storage/db/src/abstraction/cursor.rs
+++ b/crates/storage/db/src/abstraction/cursor.rs
@@ -214,7 +214,7 @@ impl<'cursor, 'tx, T: Table, CURSOR: DbCursorRO<'tx, T>> std::iter::Iterator
 {
     type Item = Result<(T::Key, T::Value), Error>;
     fn next(&mut self) -> Option<Self::Item> {
-        if self.is_ended {
+        if self.is_done {
             return None
         }
 
@@ -228,7 +228,7 @@ impl<'cursor, 'tx, T: Table, CURSOR: DbCursorRO<'tx, T>> std::iter::Iterator
             if key < self.end_key {
                 Some(Ok((key, value)))
             } else {
-                self.is_ended = true;
+                self.is_done = true;
                 None
             }
         } else {
@@ -240,7 +240,7 @@ impl<'cursor, 'tx, T: Table, CURSOR: DbCursorRO<'tx, T>> std::iter::Iterator
 impl<'cursor, 'tx, T: Table, CURSOR: DbCursorRO<'tx, T>> RangeWalker<'cursor, 'tx, T, CURSOR> {
     /// construct RangeWalker
     pub fn new(cursor: &'cursor mut CURSOR, start: IterPairResult<T>, end_key: T::Key) -> Self {
-        Self { cursor, start, end_key, is_ended: false, _tx_phantom: std::marker::PhantomData }
+        Self { cursor, start, end_key, is_done: false, _tx_phantom: std::marker::PhantomData }
     }
 }
 

--- a/crates/storage/db/src/abstraction/cursor.rs
+++ b/crates/storage/db/src/abstraction/cursor.rs
@@ -194,11 +194,14 @@ impl<'cursor, 'tx, T: Table, CURSOR: DbCursorRO<'tx, T>> std::iter::Iterator
     }
 }
 
+/// Provides a range iterator to `Cursor` when handling `Table`.
+/// Also check [`Walker`]
 pub struct RangeWalker<'cursor, 'tx, T: Table, CURSOR: DbCursorRO<'tx, T>> {
     /// Cursor to be used to walk through the table.
     cursor: &'cursor mut CURSOR,
     /// `(key, value)` where to start the walk.
     start: IterPairResult<T>,
+    // exclusive `key` where to stop the walk.
     end_key: T::Key,
     /// Phantom data for 'tx. As it is only used for `DbCursorRO`.
     _tx_phantom: PhantomData<&'tx T>,
@@ -228,7 +231,7 @@ impl<'cursor, 'tx, T: Table, CURSOR: DbCursorRO<'tx, T>> std::iter::Iterator
 }
 
 impl<'cursor, 'tx, T: Table, CURSOR: DbCursorRO<'tx, T>> RangeWalker<'cursor, 'tx, T, CURSOR> {
-    /// construct Walker
+    /// construct RangeWalker
     pub fn new(cursor: &'cursor mut CURSOR, start: IterPairResult<T>, end_key: T::Key) -> Self {
         Self { cursor, start, end_key, _tx_phantom: std::marker::PhantomData }
     }

--- a/crates/storage/db/src/abstraction/mock.rs
+++ b/crates/storage/db/src/abstraction/mock.rs
@@ -1,5 +1,5 @@
 //! Mock database
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, ops::Range};
 
 use crate::{
     common::{PairResult, ValueOnlyResult},
@@ -142,8 +142,7 @@ impl<'tx, T: Table> DbCursorRO<'tx, T> for CursorMock {
 
     fn walk_range<'cursor>(
         &'cursor mut self,
-        _start_key: <T as Table>::Key,
-        _end_key: <T as Table>::Key,
+        _range: Range<T::Key>,
     ) -> Result<RangeWalker<'cursor, 'tx, T, Self>, Error>
     where
         Self: Sized,

--- a/crates/storage/db/src/abstraction/mock.rs
+++ b/crates/storage/db/src/abstraction/mock.rs
@@ -142,8 +142,8 @@ impl<'tx, T: Table> DbCursorRO<'tx, T> for CursorMock {
 
     fn walk_range<'cursor>(
         &'cursor mut self,
-        start_key: <T as Table>::Key,
-        end_key: <T as Table>::Key,
+        _start_key: <T as Table>::Key,
+        _end_key: <T as Table>::Key,
     ) -> Result<RangeWalker<'cursor, 'tx, T, Self>, Error>
     where
         Self: Sized,

--- a/crates/storage/db/src/abstraction/mock.rs
+++ b/crates/storage/db/src/abstraction/mock.rs
@@ -4,7 +4,8 @@ use std::collections::BTreeMap;
 use crate::{
     common::{PairResult, ValueOnlyResult},
     cursor::{
-        DbCursorRO, DbCursorRW, DbDupCursorRO, DbDupCursorRW, DupWalker, ReverseWalker, Walker,
+        DbCursorRO, DbCursorRW, DbDupCursorRO, DbDupCursorRW, DupWalker, RangeWalker,
+        ReverseWalker, Walker,
     },
     database::{Database, DatabaseGAT},
     table::{DupSort, Table},
@@ -133,6 +134,17 @@ impl<'tx, T: Table> DbCursorRO<'tx, T> for CursorMock {
         &'cursor mut self,
         _start_key: T::Key,
     ) -> Result<Walker<'cursor, 'tx, T, Self>, Error>
+    where
+        Self: Sized,
+    {
+        todo!()
+    }
+
+    fn walk_range<'cursor>(
+        &'cursor mut self,
+        start_key: <T as Table>::Key,
+        end_key: <T as Table>::Key,
+    ) -> Result<RangeWalker<'cursor, 'tx, T, Self>, Error>
     where
         Self: Sized,
     {

--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -1,6 +1,6 @@
 //! Cursor wrapper for libmdbx-sys.
 
-use std::{borrow::Cow, marker::PhantomData};
+use std::{borrow::Cow, marker::PhantomData, ops::Range};
 
 use crate::{
     cursor::{
@@ -91,19 +91,18 @@ impl<'tx, K: TransactionKind, T: Table> DbCursorRO<'tx, T> for Cursor<'tx, K, T>
 
     fn walk_range<'cursor>(
         &'cursor mut self,
-        start_key: T::Key,
-        end_key: T::Key,
+        range: Range<T::Key>,
     ) -> Result<RangeWalker<'cursor, 'tx, T, Self>, Error>
     where
         Self: Sized,
     {
         let start = self
             .inner
-            .set_range(start_key.encode().as_ref())
+            .set_range(range.start.encode().as_ref())
             .map_err(|e| Error::Read(e.into()))?
             .map(decoder::<T>);
 
-        Ok(RangeWalker::new(self, start, end_key))
+        Ok(RangeWalker::new(self, start, range.end))
     }
 
     fn walk_back<'cursor>(


### PR DESCRIPTION
Closes #912 and closes #702 and replaces #942

## Motivation
* Revise and clean up repetitive pattern, `cursor -> walk -> take_while`.

## Note
* This PR is intended to replace #942. It's another approach to clean up repetitive pattern by adding `Cursor.walk_range()`.
* Please note that perf is not considered in this PR but it's better for future work than #942.