### PR TITLE
feat(download): bodies downloader metrics

### DIFF
--- a/crates/interfaces/src/p2p/error.rs
+++ b/crates/interfaces/src/p2p/error.rs
@@ -1,9 +1,8 @@
+use super::headers::client::HeadersRequest;
 use crate::consensus;
 use reth_primitives::{rpc::BlockNumber, BlockHashOrNumber, Header, WithPeerId, H256};
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
-
-use super::headers::client::HeadersRequest;
 
 /// Result alias for result of a request.
 pub type RequestResult<T> = Result<T, RequestError>;

--- a/crates/net/downloaders/src/bodies/concurrent.rs
+++ b/crates/net/downloaders/src/bodies/concurrent.rs
@@ -497,6 +497,8 @@ impl ConcurrentDownloaderBuilder {
             concurrent_requests_range,
             max_buffered_responses,
         } = self;
+        let metrics = DownloaderMetrics::new(BODIES_DOWNLOADER_SCOPE);
+        let in_progress_queue = BodiesRequestQueue::new(metrics.clone());
         ConcurrentDownloader {
             client,
             consensus,
@@ -505,12 +507,12 @@ impl ConcurrentDownloaderBuilder {
             stream_batch_size,
             max_buffered_responses,
             concurrent_requests_range,
+            in_progress_queue,
+            metrics,
             download_range: Default::default(),
             latest_queued_block_number: None,
-            in_progress_queue: Default::default(),
             buffered_responses: Default::default(),
             queued_bodies: Default::default(),
-            metrics: DownloaderMetrics::new(BODIES_DOWNLOADER_SCOPE),
         }
     }
 }

--- a/crates/net/downloaders/src/bodies/concurrent.rs
+++ b/crates/net/downloaders/src/bodies/concurrent.rs
@@ -1,3 +1,5 @@
+use crate::metrics::DownloaderMetrics;
+
 use super::queue::BodiesRequestQueue;
 use futures::Stream;
 use futures_util::StreamExt;
@@ -25,6 +27,9 @@ use std::{
 /// of concurrent requests, since we are expecting to connect to more peers
 /// in the near future.
 const CONCURRENCY_PEER_MULTIPLIER: usize = 4;
+
+/// The scope for headers downloader metrics.
+pub const BODIES_DOWNLOADER_SCOPE: &str = "downloaders.bodies";
 
 /// Downloads bodies in batches.
 ///
@@ -57,6 +62,8 @@ pub struct ConcurrentDownloader<B, DB> {
     buffered_responses: BinaryHeap<OrderedBodiesResponse>,
     /// Queued body responses
     queued_bodies: Vec<BlockResponse>,
+    /// The bodies downloader metrics.
+    metrics: DownloaderMetrics,
 }
 
 impl<B, DB> ConcurrentDownloader<B, DB>
@@ -64,31 +71,6 @@ where
     B: BodiesClient + 'static,
     DB: Database,
 {
-    fn new(
-        client: Arc<B>,
-        consensus: Arc<dyn Consensus>,
-        db: Arc<DB>,
-        request_limit: u64,
-        stream_batch_size: usize,
-        max_buffered_responses: usize,
-        concurrent_requests_range: RangeInclusive<usize>,
-    ) -> Self {
-        Self {
-            client,
-            consensus,
-            db,
-            request_limit,
-            stream_batch_size,
-            max_buffered_responses,
-            concurrent_requests_range,
-            download_range: Default::default(),
-            latest_queued_block_number: None,
-            in_progress_queue: Default::default(),
-            buffered_responses: Default::default(),
-            queued_bodies: Default::default(),
-        }
-    }
-
     /// Returns the next contiguous request.
     fn next_headers_request(&mut self) -> Result<Option<Vec<SealedHeader>>, db::Error> {
         let start_at = match self.in_progress_queue.last_requested_block_number {
@@ -368,6 +350,7 @@ where
             // Yield next batch
             if this.queued_bodies.len() >= this.stream_batch_size {
                 let next_batch = this.queued_bodies.drain(..this.stream_batch_size);
+                this.metrics.total_flushed.increment(next_batch.len() as u64);
                 return Poll::Ready(Some(Ok(next_batch.collect())))
             }
 
@@ -384,6 +367,7 @@ where
 
             let batch_size = this.stream_batch_size.min(this.queued_bodies.len());
             let next_batch = this.queued_bodies.drain(..batch_size);
+            this.metrics.total_flushed.increment(next_batch.len() as u64);
             return Poll::Ready(Some(Ok(next_batch.collect())))
         }
 
@@ -507,15 +491,27 @@ impl ConcurrentDownloaderBuilder {
         B: BodiesClient + 'static,
         DB: Database,
     {
-        ConcurrentDownloader::new(
+        let Self {
+            request_limit,
+            stream_batch_size,
+            concurrent_requests_range,
+            max_buffered_responses,
+        } = self;
+        ConcurrentDownloader {
             client,
             consensus,
             db,
-            self.request_limit,
-            self.stream_batch_size,
-            self.max_buffered_responses,
-            self.concurrent_requests_range,
-        )
+            request_limit,
+            stream_batch_size,
+            max_buffered_responses,
+            concurrent_requests_range,
+            download_range: Default::default(),
+            latest_queued_block_number: None,
+            in_progress_queue: Default::default(),
+            buffered_responses: Default::default(),
+            queued_bodies: Default::default(),
+            metrics: DownloaderMetrics::new(BODIES_DOWNLOADER_SCOPE),
+        }
     }
 }
 

--- a/crates/net/downloaders/src/bodies/queue.rs
+++ b/crates/net/downloaders/src/bodies/queue.rs
@@ -1,3 +1,5 @@
+use crate::metrics::DownloaderMetrics;
+
 use super::request::BodiesRequestFuture;
 use futures::{stream::FuturesUnordered, Stream};
 use futures_util::StreamExt;
@@ -21,24 +23,26 @@ pub(crate) struct BodiesRequestQueue<B> {
     inner: FuturesUnordered<BodiesRequestFuture<B>>,
     /// The block numbers being requested.
     block_numbers: HashSet<BlockNumber>,
+    /// The downloader metrics.
+    metrics: DownloaderMetrics,
     /// Last requested block number.
     pub(crate) last_requested_block_number: Option<BlockNumber>,
-}
-
-impl<B> Default for BodiesRequestQueue<B> {
-    fn default() -> Self {
-        Self {
-            inner: Default::default(),
-            block_numbers: Default::default(),
-            last_requested_block_number: None,
-        }
-    }
 }
 
 impl<B> BodiesRequestQueue<B>
 where
     B: BodiesClient + 'static,
 {
+    /// Create new instance of request queue.
+    pub(crate) fn new(metrics: DownloaderMetrics) -> Self {
+        Self {
+            metrics,
+            inner: Default::default(),
+            block_numbers: Default::default(),
+            last_requested_block_number: None,
+        }
+    }
+
     /// Returns `true` if the queue is empty.
     pub(crate) fn is_empty(&self) -> bool {
         self.inner.is_empty()
@@ -77,7 +81,9 @@ where
         self.block_numbers.extend(request.iter().map(|h| h.number));
 
         // Create request and push into the queue.
-        self.inner.push(BodiesRequestFuture::new(client, consensus).with_headers(request))
+        self.inner.push(
+            BodiesRequestFuture::new(client, consensus, self.metrics.clone()).with_headers(request),
+        )
     }
 
     /// Check if the block number is currently in progress

--- a/crates/net/downloaders/src/bodies/queue.rs
+++ b/crates/net/downloaders/src/bodies/queue.rs
@@ -1,6 +1,5 @@
-use crate::metrics::DownloaderMetrics;
-
 use super::request::BodiesRequestFuture;
+use crate::metrics::DownloaderMetrics;
 use futures::{stream::FuturesUnordered, Stream};
 use futures_util::StreamExt;
 use reth_interfaces::{

--- a/crates/net/downloaders/src/bodies/request.rs
+++ b/crates/net/downloaders/src/bodies/request.rs
@@ -1,3 +1,4 @@
+use crate::metrics::DownloaderMetrics;
 use futures::{Future, FutureExt};
 use reth_eth_wire::BlockBody;
 use reth_interfaces::{
@@ -13,8 +14,6 @@ use std::{
     sync::Arc,
     task::{ready, Context, Poll},
 };
-
-use crate::metrics::DownloaderMetrics;
 
 type BodiesFut = Pin<Box<dyn Future<Output = PeerRequestResult<Vec<BlockBody>>> + Send>>;
 

--- a/crates/net/downloaders/src/bodies/request.rs
+++ b/crates/net/downloaders/src/bodies/request.rs
@@ -82,8 +82,7 @@ where
     }
 
     fn on_error(&mut self, error: DownloadError, peer_id: Option<PeerId>) {
-        // TODO: reenable when BodyRequestError is removed in favor of DownloadError
-        // self.metrics.increment_errors(error);
+        self.metrics.increment_errors(&error);
         tracing::error!(target: "downloaders::bodies", ?peer_id, %error, "Error requesting bodies");
         if let Some(peer_id) = peer_id {
             self.client.report_bad_message(peer_id);

--- a/crates/net/downloaders/src/headers/mod.rs
+++ b/crates/net/downloaders/src/headers/mod.rs
@@ -1,5 +1,2 @@
 /// A Linear downloader implementation.
 pub mod linear;
-
-/// Metrics for linear downloader
-pub mod metrics;

--- a/crates/net/downloaders/src/lib.rs
+++ b/crates/net/downloaders/src/lib.rs
@@ -13,5 +13,8 @@ pub mod bodies;
 /// The collection of algorithms for downloading block headers.
 pub mod headers;
 
+/// Common downloader metrics.
+mod metrics;
+
 #[cfg(test)]
 mod test_utils;

--- a/crates/net/downloaders/src/lib.rs
+++ b/crates/net/downloaders/src/lib.rs
@@ -14,7 +14,7 @@ pub mod bodies;
 pub mod headers;
 
 /// Common downloader metrics.
-mod metrics;
+pub mod metrics;
 
 #[cfg(test)]
 mod test_utils;

--- a/crates/net/downloaders/src/metrics.rs
+++ b/crates/net/downloaders/src/metrics.rs
@@ -4,21 +4,21 @@ use reth_metrics_derive::Metrics;
 
 /// The header downloader metrics.
 #[derive(Metrics)]
-#[metrics(scope = "downloaders.headers")]
-pub struct HeaderDownloaderMetrics {
-    /// The number of headers that were successfully sent to the poller (stage)
+#[metrics(dynamic = true)]
+pub struct DownloaderMetrics {
+    /// The number of items that were successfully sent to the poller (stage)
     pub(crate) total_flushed: Counter,
-    /// Number of headers that were successfully downloaded
+    /// Number of items that were successfully downloaded
     pub(crate) total_downloaded: Counter,
-    /// Number of timeout errors while requesting headers
+    /// Number of timeout errors while requesting items
     pub(crate) timeout_errors: Counter,
-    /// Number of validation errors while requesting headers
+    /// Number of validation errors while requesting items
     pub(crate) validation_errors: Counter,
-    /// Number of unexpected errors while requesting headers
+    /// Number of unexpected errors while requesting items
     pub(crate) unexpected_errors: Counter,
 }
 
-impl HeaderDownloaderMetrics {
+impl DownloaderMetrics {
     /// Increment errors counter.
     pub(crate) fn increment_errors(&self, error: &DownloadError) {
         match error {

--- a/crates/net/downloaders/src/metrics.rs
+++ b/crates/net/downloaders/src/metrics.rs
@@ -10,7 +10,7 @@ use reth_metrics_derive::Metrics;
 /// use reth_downloaders::metrics::DownloaderMetrics;
 /// use reth_interfaces::p2p::error::DownloadError;
 ///
-/// // Initialized metrics.
+/// // Initialize metrics.
 /// let metrics = DownloaderMetrics::new("downloaders.headers");
 /// // Increment `downloaders.headers.timeout_errors` counter by 1.
 /// metrics.increment_errors(&DownloadError::Timeout);

--- a/crates/net/downloaders/src/metrics.rs
+++ b/crates/net/downloaders/src/metrics.rs
@@ -2,25 +2,37 @@ use metrics::Counter;
 use reth_interfaces::p2p::error::DownloadError;
 use reth_metrics_derive::Metrics;
 
-/// The header downloader metrics.
+/// Common downloader metrics.
+///
+/// These metrics will be dynamically initialized with the provided scope
+/// by corresponding downloaders.
+/// ```
+/// use reth_downloaders::metrics::DownloaderMetrics;
+/// use reth_interfaces::p2p::error::DownloadError;
+///
+/// // Initialized metrics.
+/// let metrics = DownloaderMetrics::new("downloaders.headers");
+/// // Increment `downloaders.headers.timeout_errors` counter by 1.
+/// metrics.increment_errors(&DownloadError::Timeout);
+/// ```
 #[derive(Clone, Metrics)]
 #[metrics(dynamic = true)]
 pub struct DownloaderMetrics {
     /// The number of items that were successfully sent to the poller (stage)
-    pub(crate) total_flushed: Counter,
+    pub total_flushed: Counter,
     /// Number of items that were successfully downloaded
-    pub(crate) total_downloaded: Counter,
+    pub total_downloaded: Counter,
     /// Number of timeout errors while requesting items
-    pub(crate) timeout_errors: Counter,
+    pub timeout_errors: Counter,
     /// Number of validation errors while requesting items
-    pub(crate) validation_errors: Counter,
+    pub validation_errors: Counter,
     /// Number of unexpected errors while requesting items
-    pub(crate) unexpected_errors: Counter,
+    pub unexpected_errors: Counter,
 }
 
 impl DownloaderMetrics {
     /// Increment errors counter.
-    pub(crate) fn increment_errors(&self, error: &DownloadError) {
+    pub fn increment_errors(&self, error: &DownloadError) {
         match error {
             DownloadError::Timeout => self.timeout_errors.increment(1),
             DownloadError::HeaderValidation { .. } | DownloadError::BodyValidation { .. } => {

--- a/crates/net/downloaders/src/metrics.rs
+++ b/crates/net/downloaders/src/metrics.rs
@@ -23,7 +23,9 @@ impl DownloaderMetrics {
     pub(crate) fn increment_errors(&self, error: &DownloadError) {
         match error {
             DownloadError::Timeout => self.timeout_errors.increment(1),
-            DownloadError::HeaderValidation { .. } => self.validation_errors.increment(1),
+            DownloadError::HeaderValidation { .. } | DownloadError::BodyValidation { .. } => {
+                self.validation_errors.increment(1)
+            }
             _error => self.unexpected_errors.increment(1),
         }
     }

--- a/crates/net/downloaders/src/metrics.rs
+++ b/crates/net/downloaders/src/metrics.rs
@@ -3,7 +3,7 @@ use reth_interfaces::p2p::error::DownloadError;
 use reth_metrics_derive::Metrics;
 
 /// The header downloader metrics.
-#[derive(Metrics)]
+#[derive(Clone, Metrics)]
 #[metrics(dynamic = true)]
 pub struct DownloaderMetrics {
     /// The number of items that were successfully sent to the poller (stage)

--- a/crates/net/downloaders/src/test_utils.rs
+++ b/crates/net/downloaders/src/test_utils.rs
@@ -18,6 +18,9 @@ use std::{
 };
 use tokio::sync::Mutex;
 
+/// Metrics scope used for testing.
+pub(crate) const TEST_SCOPE: &str = "downloaders.test";
+
 /// Generate a set of bodies and their corresponding block hashes
 pub(crate) fn generate_bodies(
     rng: std::ops::Range<u64>,

--- a/crates/net/downloaders/src/test_utils.rs
+++ b/crates/net/downloaders/src/test_utils.rs
@@ -96,7 +96,6 @@ impl BodiesClient for TestBodiesClient {
         }
         self.times_requested.fetch_add(1, Ordering::Relaxed);
         let bodies = &mut *self.bodies.lock().await;
-        println!("HASHES {}", hashes.len());
         Ok((
             PeerId::default(),
             hashes


### PR DESCRIPTION
Generalize current `HeaderDownloaderMetrics` to `DownloaderMetrics` and use it with dynamic scope.

Mirror the recorded headers metrics in the bodies downloader.

~~Blocked by #1026~~