### PR TITLE
test: print request error

### DIFF
--- a/crates/net/network/tests/it/requests.rs
+++ b/crates/net/network/tests/it/requests.rs
@@ -66,7 +66,7 @@ async fn test_get_body() {
         mock_provider.add_block(block_hash, block.clone());
 
         let res = fetch0.get_block_bodies(vec![block_hash]).await;
-        assert!(res.is_ok());
+        assert!(res.is_ok(), "{res:?}");
 
         let blocks = res.unwrap().1;
         assert_eq!(blocks.len(), 1);


### PR DESCRIPTION
ref #911

add the error to the failing assert in the flaky `test_get_body` test, this should help us track it down when it happens again