### PR TITLE
refactor(rpc): standardize type for  gas price/fees as U128

### DIFF
--- a/crates/net/rpc-types/src/eth/call.rs
+++ b/crates/net/rpc-types/src/eth/call.rs
@@ -1,4 +1,4 @@
-use reth_primitives::{rpc::transaction::eip2930::AccessListItem, Address, Bytes, U256};
+use reth_primitives::{rpc::transaction::eip2930::AccessListItem, Address, Bytes, U128, U256};
 use serde::{Deserialize, Serialize};
 
 /// Call request
@@ -10,11 +10,11 @@ pub struct CallRequest {
     /// To
     pub to: Option<Address>,
     /// Gas Price
-    pub gas_price: Option<U256>,
+    pub gas_price: Option<U128>,
     /// EIP-1559 Max base fee the caller is willing to pay
-    pub max_fee_per_gas: Option<U256>,
+    pub max_fee_per_gas: Option<U128>,
     /// EIP-1559 Priority fee the caller is paying to the block author
-    pub max_priority_fee_per_gas: Option<U256>,
+    pub max_priority_fee_per_gas: Option<U128>,
     /// Gas
     pub gas: Option<U256>,
     /// Value

--- a/crates/net/rpc-types/src/eth/transaction/mod.rs
+++ b/crates/net/rpc-types/src/eth/transaction/mod.rs
@@ -7,7 +7,7 @@ pub use request::TransactionRequest;
 pub use typed::*;
 
 use reth_primitives::{
-    rpc::transaction::eip2930::AccessListItem, Address, Bytes, H256, H512, U256, U64,
+    rpc::transaction::eip2930::AccessListItem, Address, Bytes, H256, H512, U128, U256, U64,
 };
 use serde::{Deserialize, Serialize};
 
@@ -33,13 +33,13 @@ pub struct Transaction {
     pub value: U256,
     /// Gas Price
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub gas_price: Option<U256>,
+    pub gas_price: Option<U128>,
     /// Max BaseFeePerGas the user is willing to pay.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_fee_per_gas: Option<U256>,
+    pub max_fee_per_gas: Option<U128>,
     /// The miner's tip.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_priority_fee_per_gas: Option<U256>,
+    pub max_priority_fee_per_gas: Option<U128>,
     /// Gas
     pub gas: U256,
     /// Data

--- a/crates/net/rpc-types/src/eth/transaction/receipt.rs
+++ b/crates/net/rpc-types/src/eth/transaction/receipt.rs
@@ -1,4 +1,4 @@
-use reth_primitives::{rpc::Log, Address, Bloom, H256, U256, U64};
+use reth_primitives::{rpc::Log, Address, Bloom, H256, U128, U256, U64};
 use serde::{Deserialize, Serialize};
 
 /// Transaction receipt
@@ -38,7 +38,7 @@ pub struct TransactionReceipt {
     /// The price paid post-execution by the transaction (i.e. base fee + priority fee). Both
     /// fields in 1559-style transactions are maximums (max fee + max priority fee), the amount
     /// that's actually paid by users can only be determined post-execution
-    pub effective_gas_price: U256,
+    pub effective_gas_price: U128,
     /// EIP-2718 Transaction type, Some(1) for AccessList transaction, None for Legacy
     #[serde(rename = "type")]
     pub transaction_type: U256,

--- a/crates/net/rpc-types/src/eth/transaction/request.rs
+++ b/crates/net/rpc-types/src/eth/transaction/request.rs
@@ -2,7 +2,7 @@ use crate::eth::transaction::typed::{
     EIP1559TransactionRequest, EIP2930TransactionRequest, LegacyTransactionRequest,
     TransactionKind, TypedTransactionRequest,
 };
-use reth_primitives::{AccessList, Address, Bytes, U256};
+use reth_primitives::{AccessList, Address, Bytes, U128, U256};
 use serde::{Deserialize, Serialize};
 
 /// Represents _all_ transaction requests received from RPC
@@ -16,13 +16,13 @@ pub struct TransactionRequest {
     pub to: Option<Address>,
     /// legacy, gas Price
     #[serde(default)]
-    pub gas_price: Option<U256>,
+    pub gas_price: Option<U128>,
     /// max base fee per gas sender is willing to pay
     #[serde(default)]
-    pub max_fee_per_gas: Option<U256>,
+    pub max_fee_per_gas: Option<U128>,
     /// miner tip
     #[serde(default)]
-    pub max_priority_fee_per_gas: Option<U256>,
+    pub max_priority_fee_per_gas: Option<U128>,
     /// gas
     pub gas: Option<U256>,
     /// value of th tx in wei
@@ -97,7 +97,7 @@ impl TransactionRequest {
                 Some(TypedTransactionRequest::EIP1559(EIP1559TransactionRequest {
                     nonce: nonce.unwrap_or(U256::ZERO),
                     max_fee_per_gas: max_fee_per_gas.unwrap_or_default(),
-                    max_priority_fee_per_gas: max_priority_fee_per_gas.unwrap_or(U256::ZERO),
+                    max_priority_fee_per_gas: max_priority_fee_per_gas.unwrap_or(U128::ZERO),
                     gas_limit: gas.unwrap_or_default(),
                     value: value.unwrap_or(U256::ZERO),
                     input: data.unwrap_or_default(),

--- a/crates/net/rpc-types/src/eth/transaction/typed.rs
+++ b/crates/net/rpc-types/src/eth/transaction/typed.rs
@@ -3,7 +3,7 @@
 //! json input of an RPC call. Depending on what fields are set, it can be converted into the
 //! container type [`TypedTransactionRequest`].
 
-use reth_primitives::{AccessList, Address, Bytes, U256};
+use reth_primitives::{AccessList, Address, Bytes, U128, U256};
 use reth_rlp::{BufMut, Decodable, DecodeError, Encodable, RlpDecodable, RlpEncodable};
 use serde::{Deserialize, Serialize};
 
@@ -24,7 +24,7 @@ pub enum TypedTransactionRequest {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LegacyTransactionRequest {
     pub nonce: U256,
-    pub gas_price: U256,
+    pub gas_price: U128,
     pub gas_limit: U256,
     pub kind: TransactionKind,
     pub value: U256,
@@ -37,7 +37,7 @@ pub struct LegacyTransactionRequest {
 pub struct EIP2930TransactionRequest {
     pub chain_id: u64,
     pub nonce: U256,
-    pub gas_price: U256,
+    pub gas_price: U128,
     pub gas_limit: U256,
     pub kind: TransactionKind,
     pub value: U256,
@@ -50,8 +50,8 @@ pub struct EIP2930TransactionRequest {
 pub struct EIP1559TransactionRequest {
     pub chain_id: u64,
     pub nonce: U256,
-    pub max_priority_fee_per_gas: U256,
-    pub max_fee_per_gas: U256,
+    pub max_priority_fee_per_gas: U128,
+    pub max_fee_per_gas: U128,
     pub gas_limit: U256,
     pub kind: TransactionKind,
     pub value: U256,


### PR DESCRIPTION
This PR is a request from this comment https://github.com/paradigmxyz/reth/pull/1005#discussion_r1085305081

Inside transaction pool, fees and prices have been set to `u128`, see: https://github.com/paradigmxyz/reth/pull/1005