### PR TITLE
fix(eth-wire): send p2p handshake disconnects

### DIFF
--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -78,6 +78,10 @@ where
     ) -> Result<(), P2PStreamError> {
         let mut buf = BytesMut::new();
         P2PMessage::Disconnect(reason).encode(&mut buf);
+        tracing::trace!(
+            %reason,
+            "Sending disconnect message during the handshake",
+        );
         self.inner.send(buf.freeze()).await.map_err(P2PStreamError::Io)
     }
 }


### PR DESCRIPTION
This sends disconnect messages during the `p2p` handshake, when either:
 * We do not share capabilities, or there is an error when determining shared capabilities (we send `UselessPeer` here)
 * We do not share the same protocol version (we send `IncompatibleP2PProtocolVersion` here)
 
Adds a test making sure we return the right error with mismatched protocol versions.

Fixes #657