### PR TITLE
fix(dns): ensure branch children are valid hashes

### DIFF
--- a/crates/net/dns/src/error.rs
+++ b/crates/net/dns/src/error.rs
@@ -19,6 +19,8 @@ pub enum ParseDnsEntryError {
     Base32DecodeError(String),
     #[error("{0}")]
     RlpDecodeError(String),
+    #[error("Invalid child hash in branch: {0}")]
+    InvalidChildHash(String),
     #[error("{0}")]
     Other(String),
 }


### PR DESCRIPTION
Closes #1050

ensures all children in a branch are valid (base32) hashes.

see also https://github.com/ethereum/go-ethereum/blob/df52967ff6080a27243569020ff64cd956fb8362/p2p/dnsdisc/tree.go#L395