### PR TITLE
fix: majority of docs warnings and errors

### DIFF
--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -214,7 +214,7 @@ impl<'a, DB: Database> DbTool<'a, DB> {
     }
 
     /// Grabs the contents of the table within a certain index range and places the
-    /// entries into a [HashMap].
+    /// entries into a [HashMap](std::collections::HashMap).
     fn list<T: Table>(&mut self, start: usize, len: usize) -> Result<BTreeMap<T::Key, T::Value>> {
         let data = self.db.view(|tx| {
             let mut cursor = tx.cursor_read::<T>().expect("Was not able to obtain a cursor.");

--- a/crates/consensus/src/engine/error.rs
+++ b/crates/consensus/src/engine/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 /// The Engine API result type
 pub type EngineApiResult<Ok> = Result<Ok, EngineApiError>;
 
-/// Error returned by [`EngineApi`][crate::engine::EngineApi]
+/// Error returned by Engine API
 #[derive(Error, Debug)]
 pub enum EngineApiError {
     /// Invalid payload extra data.

--- a/crates/consensus/src/engine/mod.rs
+++ b/crates/consensus/src/engine/mod.rs
@@ -112,7 +112,7 @@ impl<Client: HeaderProvider + BlockProvider + StateProvider> EthConsensusEngine<
     /// NOTE: The log bloom is assumed to be validated during serialization.
     /// NOTE: Empty ommers, nonce and difficulty values are validated upon computing block hash and
     /// comparing the value with `payload.block_hash`.
-    /// Ref: https://github.com/ethereum/go-ethereum/blob/79a478bb6176425c2400e949890e668a3d9a3d05/core/beacon/types.go#L145
+    /// Ref: <https://github.com/ethereum/go-ethereum/blob/79a478bb6176425c2400e949890e668a3d9a3d05/core/beacon/types.go#L145>
     fn try_construct_block(&self, payload: ExecutionPayload) -> EngineApiResult<SealedBlock> {
         if payload.extra_data.len() > 32 {
             return Err(EngineApiError::PayloadExtraData(payload.extra_data))

--- a/crates/executor/src/eth_dao_fork.rs
+++ b/crates/executor/src/eth_dao_fork.rs
@@ -1,4 +1,4 @@
-//! DAO FOrk related constants https://eips.ethereum.org/EIPS/eip-779
+//! DAO FOrk related constants <https://eips.ethereum.org/EIPS/eip-779>
 //! It happened on Ethereum block 1_920_000
 use reth_primitives::{hex_literal::hex, H160};
 

--- a/crates/interfaces/src/consensus.rs
+++ b/crates/interfaces/src/consensus.rs
@@ -36,7 +36,7 @@ pub trait Consensus: Debug + Send + Sync {
     /// After the Merge (aka Paris) block rewards became obsolete.
     /// This flag is needed as reth change set is indexed of transaction granularity
     /// (change set is indexed per transaction) we are introducing one additional index for block
-    /// reward This in essence would introduce gaps in [Transaction] table
+    /// reward This in essence would introduce gaps in Transaction table
     /// More on it [here](https://github.com/paradigmxyz/reth/issues/237)
     fn has_block_reward(&self, block_num: BlockNumber) -> bool;
 }

--- a/crates/interfaces/src/p2p/bodies/downloader.rs
+++ b/crates/interfaces/src/p2p/bodies/downloader.rs
@@ -10,7 +10,7 @@ pub type BodyDownloaderResult = DownloadResult<Vec<BlockResponse>>;
 /// A downloader capable of fetching and yielding block bodies from block headers.
 ///
 /// A downloader represents a distinct strategy for submitting requests to download block bodies,
-/// while a [BodiesClient] represents a client capable of fulfilling these requests.
+/// while a [BodiesClient](super::client::BodiesClient) represents a client capable of fulfilling these requests.
 pub trait BodyDownloader: Send + Sync + Stream<Item = BodyDownloaderResult> + Unpin {
     /// Method for setting the download range.
     fn set_download_range(&mut self, range: Range<BlockNumber>) -> DownloadResult<()>;

--- a/crates/interfaces/src/p2p/error.rs
+++ b/crates/interfaces/src/p2p/error.rs
@@ -7,7 +7,7 @@ use tokio::sync::{mpsc, oneshot};
 /// Result alias for result of a request.
 pub type RequestResult<T> = Result<T, RequestError>;
 
-/// Result with [PeerId]
+/// Result with [PeerId](reth_primitives::PeerId)
 pub type PeerRequestResult<T> = RequestResult<WithPeerId<T>>;
 
 /// Helper trait used to validate responses.

--- a/crates/interfaces/src/p2p/headers/downloader.rs
+++ b/crates/interfaces/src/p2p/headers/downloader.rs
@@ -8,7 +8,7 @@ use reth_primitives::{SealedHeader, H256};
 /// A downloader capable of fetching and yielding block headers.
 ///
 /// A downloader represents a distinct strategy for submitting requests to download block headers,
-/// while a [HeadersClient] represents a client capable of fulfilling these requests.
+/// while a [super::client::HeadersClient] represents a client capable of fulfilling these requests.
 ///
 /// A [HeaderDownloader] is a [Stream] that returns batches for headers.
 pub trait HeaderDownloader: Send + Sync + Stream<Item = Vec<SealedHeader>> + Unpin {

--- a/crates/interfaces/src/p2p/mod.rs
+++ b/crates/interfaces/src/p2p/mod.rs
@@ -9,7 +9,7 @@ pub mod bodies;
 /// [`HeadersClient`].
 ///
 /// [`Consensus`]: crate::consensus::Consensus
-/// [`HeadersClient`]: crate::p2p::headers::HeadersClient
+/// [`HeadersClient`]: super::headers::client::HeadersClient
 pub mod headers;
 
 /// Error types broadly used by p2p interfaces for any operation which may produce an error when

--- a/crates/interfaces/src/test_utils/generators.rs
+++ b/crates/interfaces/src/test_utils/generators.rs
@@ -59,7 +59,7 @@ pub fn random_tx() -> Transaction {
 
 /// Generates a random legacy [Transaction] that is signed.
 ///
-/// On top of the considerations of [gen_random_tx], these apply as well:
+/// On top of the considerations of gen_random_tx, these apply as well:
 ///
 /// - There is no guarantee that the nonce is not used twice for the same account
 pub fn random_signed_tx() -> TransactionSigned {

--- a/crates/metrics/metrics-derive/src/expand.rs
+++ b/crates/metrics/metrics-derive/src/expand.rs
@@ -9,7 +9,7 @@ use syn::{
 use crate::{metric::Metric, with_attrs::WithAttrs};
 
 /// Metric name regex according to Prometheus data model
-/// https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
+/// <https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels>
 static METRIC_NAME_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"^[a-zA-Z_:.][a-zA-Z0-9_:.]*$").unwrap());
 

--- a/crates/net/common/src/bandwidth_meter.rs
+++ b/crates/net/common/src/bandwidth_meter.rs
@@ -1,4 +1,4 @@
-//! Support for metering bandwidth. Takes heavy inspiration from https://github.com/libp2p/rust-libp2p/blob/master/src/bandwidth.rs
+//! Support for metering bandwidth. Takes heavy inspiration from <https://github.com/libp2p/rust-libp2p/blob/master/src/bandwidth.rs>
 
 // Copyright 2019 Parity Technologies (UK) Ltd.
 //

--- a/crates/net/discv4/src/config.rs
+++ b/crates/net/discv4/src/config.rs
@@ -1,7 +1,7 @@
 //! A set of configuration parameters to tune the discovery protocol.
 //!
 //! This basis of this file has been taken from the discv5 codebase:
-//! https://github.com/sigp/discv5
+//! <https://github.com/sigp/discv5>
 
 use bytes::{Bytes, BytesMut};
 use reth_net_common::ban_list::BanList;

--- a/crates/net/dns/src/error.rs
+++ b/crates/net/dns/src/error.rs
@@ -5,7 +5,7 @@ pub(crate) type ParseEntryResult<T> = Result<T, ParseDnsEntryError>;
 
 pub(crate) type LookupResult<T> = Result<T, LookupError>;
 
-/// Error while parsing a [DnsEntry]
+/// Error while parsing a [DnsEntry](crate::tree::DnsEntry)
 #[derive(thiserror::Error, Debug)]
 #[allow(missing_docs)]
 pub enum ParseDnsEntryError {

--- a/crates/net/downloaders/src/bodies/concurrent.rs
+++ b/crates/net/downloaders/src/bodies/concurrent.rs
@@ -410,7 +410,7 @@ where
 }
 
 /// SAFETY: we need to ensure `ConcurrentDownloader` is `Sync` because the of the [Downloader]
-/// trait. While [HeadersClient] is also `Sync`, the [HeadersClient::get_block_bodies] future does
+/// trait. While [HeadersClient](reth_interfaces::p2p::headers::client::HeadersClient) is also `Sync`, the [HeadersClient::get_block_bodies](reth_interfaces::p2p::headers::client::HeadersClient::get_block_bodies) future does
 /// not enforce `Sync` (async_trait). The future itself does not use any interior mutability
 /// whatsoever: All the mutations are performed through an exclusive reference on
 /// `ConcurrentDownloader` when the Stream is polled. This means it suffices that

--- a/crates/net/downloaders/src/bodies/request.rs
+++ b/crates/net/downloaders/src/bodies/request.rs
@@ -26,7 +26,7 @@ type BodiesFut = Pin<Box<dyn Future<Output = PeerRequestResult<Vec<BlockBody>>> 
 /// It then proceeds to verify the downloaded bodies. In case of an validation error,
 /// the future will start over.
 ///
-/// The future will filter out any empty headers (see [SealedHeader::is_empty]) from the request.
+/// The future will filter out any empty headers (see [reth_primitives::Header::is_empty]) from the request.
 /// If [BodiesRequestFuture] was initialized with all empty headers, no request will be dispatched
 /// and they will be immediately returned upon polling.
 ///

--- a/crates/net/eth-wire/src/builder.rs
+++ b/crates/net/eth-wire/src/builder.rs
@@ -1,4 +1,4 @@
-//! Builder structs for [`Status`](crate::types::Status) and [`Hello`](crate::types::Hello)
+//! Builder structs for [`Status`](crate::types::Status) and [`HelloMessage`]
 //! messages.
 
 use crate::{
@@ -84,13 +84,13 @@ impl StatusBuilder {
     }
 }
 
-/// Builder for [`Hello`](crate::types::Hello) messages.
+/// Builder for [`HelloMessage`].
 pub struct HelloBuilder {
     hello: HelloMessage,
 }
 
 impl HelloBuilder {
-    /// Creates a new [`HelloBuilder`](crate::builder::HelloBuilder) with default [`Hello`] values,
+    /// Creates a new [`HelloBuilder`](crate::builder::HelloBuilder) with default [`HelloMessage`] values,
     /// and a `PeerId` corresponding to the given pubkey.
     pub fn new(pubkey: PeerId) -> Self {
         Self {
@@ -106,7 +106,7 @@ impl HelloBuilder {
         }
     }
 
-    /// Consumes the type and creates the actual [`Hello`](crate::types::Hello) message.
+    /// Consumes the type and creates the actual [`HelloMessage`] message.
     pub fn build(self) -> HelloMessage {
         self.hello
     }

--- a/crates/net/eth-wire/src/errors/p2p.rs
+++ b/crates/net/eth-wire/src/errors/p2p.rs
@@ -76,7 +76,7 @@ pub enum P2PHandshakeError {
     DecodeError(#[from] reth_rlp::DecodeError),
 }
 
-/// An error that can occur when interacting with a [`Pinger`].
+/// An error that can occur when interacting with a [`Pinger`](crate::pinger::Pinger).
 #[derive(Debug, thiserror::Error)]
 pub enum PingerError {
     /// An unexpected pong was received while the pinger was in the `Ready` state.

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -624,10 +624,10 @@ pub enum P2PMessage {
     /// immediately.
     Disconnect(DisconnectReason),
 
-    /// Requests an immediate reply of [`Pong`] from the peer.
+    /// Requests an immediate reply of Pong from the peer.
     Ping,
 
-    /// Reply to the peer's [`Ping`] packet.
+    /// Reply to the peer's Ping packet.
     Pong,
 }
 

--- a/crates/net/eth-wire/src/pinger.rs
+++ b/crates/net/eth-wire/src/pinger.rs
@@ -112,11 +112,12 @@ pub(crate) enum PingState {
     TimedOut,
 }
 
-/// The element type produced by a [`IntervalPingerStream`], representing either a new [`Ping`]
+/// The element type produced by a [`IntervalPingerStream`], representing either a new
+/// [`Ping`](super::P2PMessage::Ping)
 /// message to send, or an indication that the peer should be timed out.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum PingerEvent {
-    /// A new [`Ping`] message should be sent.
+    /// A new [`Ping`](super::P2PMessage::Ping) message should be sent.
     Ping,
 
     /// The peer should be timed out.

--- a/crates/net/eth-wire/src/pinger.rs
+++ b/crates/net/eth-wire/src/pinger.rs
@@ -112,7 +112,7 @@ pub(crate) enum PingState {
     TimedOut,
 }
 
-/// The element type produced by a [`IntervalPingerStream`], representing either a new
+/// The element type produced by a IntervalPingerStream, representing either a new
 /// [`Ping`](super::P2PMessage::Ping)
 /// message to send, or an indication that the peer should be timed out.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/net/eth-wire/src/types/blocks.rs
+++ b/crates/net/eth-wire/src/types/blocks.rs
@@ -98,7 +98,7 @@ pub struct BlockBody {
 }
 
 impl BlockBody {
-    /// Create a [`Block`] from the body and its header.
+    /// Create a [`RawBlockBody`] from the body and its header.
     pub fn create_block(&self, header: &Header) -> RawBlockBody {
         RawBlockBody {
             header: header.clone(),

--- a/crates/net/ipc/src/server/mod.rs
+++ b/crates/net/ipc/src/server/mod.rs
@@ -430,8 +430,7 @@ impl<B, L> Builder<B, L> {
     /// registered resources on this server instance would exceed 8.
     ///
     /// See the module documentation for
-    /// [`resurce_limiting`](../jsonrpsee_utils/server/resource_limiting/index.html#
-    /// resource-limiting) for details.
+    /// [`resurce_limiting`](../jsonrpsee_utils/server/resource_limiting/index.html#resource-limiting) for details.
     pub fn register_resource(
         mut self,
         label: &'static str,

--- a/crates/net/network/src/lib.rs
+++ b/crates/net/network/src/lib.rs
@@ -21,7 +21,7 @@
 //! The `Network` is made up of several, separate tasks:
 //!
 //!    - `Transactions Task`: is a spawned
-//!      [`TransactionManager`](crate::transactions::TransactionsManager) future that:
+//!      [`TransactionsManager`](crate::transactions::TransactionsManager) future that:
 //!
 //!        * Responds to incoming transaction related requests
 //!        * Requests missing transactions from the `Network`

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -130,7 +130,7 @@ impl<C> NetworkManager<C> {
         &self.handle
     }
 
-    /// Returns a shareable reference to the [`BandwidthMeter`] stored on the [`NetworkInner`]
+    /// Returns a shareable reference to the [`BandwidthMeter`] stored on the [`NetworkInner`](reth_network::network::NetworkInner)
     /// inside of the [`NetworkHandle`]
     pub fn bandwidth_meter(&self) -> &BandwidthMeter {
         self.handle.bandwidth_meter()

--- a/crates/net/network/src/metrics.rs
+++ b/crates/net/network/src/metrics.rs
@@ -33,7 +33,7 @@ pub struct NetworkMetrics {
     pub(crate) invalid_messages_received: Counter,
 }
 
-/// Metrics for the TransactionManager
+/// Metrics for the TransactionsManager
 #[derive(Metrics)]
 #[metrics(scope = "network")]
 pub struct TransactionsManagerMetrics {

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -260,7 +260,7 @@ impl SyncStateUpdater for NetworkHandle {
 struct NetworkInner {
     /// Number of active peer sessions the node's currently handling.
     num_active_peers: Arc<AtomicUsize>,
-    /// Sender half of the message channel to the [`NetworkManager`].
+    /// Sender half of the message channel to the [`crate::NetworkManager`].
     to_manager_tx: UnboundedSender<NetworkHandleMessage>,
     /// The local address that accepts incoming connections.
     listener_address: Arc<Mutex<SocketAddr>>,

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -39,10 +39,10 @@ use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, error, info, trace, warn};
 
 /// The type that advances an established session by listening for incoming messages (from local
-/// node or read from connection) and emitting events back to the [`SessionsManager`].
+/// node or read from connection) and emitting events back to the [`SessionManager`](super::SessionManager).
 ///
 /// It listens for
-///    - incoming commands from the [`SessionsManager`]
+///    - incoming commands from the [`SessionManager`](super::SessionManager)
 ///    - incoming requests via the request channel
 ///    - responses for handled ETH requests received from the remote peer.
 #[allow(unused)]
@@ -61,7 +61,7 @@ pub(crate) struct ActiveSession {
     pub(crate) session_id: SessionId,
     /// Incoming commands from the manager
     pub(crate) commands_rx: ReceiverStream<SessionCommand>,
-    /// Sink to send messages to the [`SessionManager`].
+    /// Sink to send messages to the [`SessionManager`](super::SessionManager).
     pub(crate) to_session: mpsc::Sender<ActiveSessionMessage>,
     /// Incoming request to send to delegate to the remote peer.
     pub(crate) request_tx: Fuse<ReceiverStream<PeerRequest>>,
@@ -258,7 +258,7 @@ impl ActiveSession {
         }
     }
 
-    /// Send a message back to the [`SessionsManager`]
+    /// Send a message back to the [`SessionManager`](super::SessionManager)
     fn emit_message(&self, message: PeerMessage) {
         let _ = self.try_emit_message(message).map_err(|err| {
             warn!(
@@ -269,7 +269,7 @@ impl ActiveSession {
         });
     }
 
-    /// Send a message back to the [`SessionsManager`]
+    /// Send a message back to the [`SessionManager`](super::SessionManager)
     /// covering both broadcasts and incoming requests
     fn safe_emit_message(
         &self,
@@ -281,7 +281,7 @@ impl ActiveSession {
             .try_send(ActiveSessionMessage::ValidMessage { peer_id: self.remote_peer_id, message })
     }
 
-    /// Send a message back to the [`SessionsManager`]
+    /// Send a message back to the [`SessionManager`](super::SessionManager)
     fn try_emit_message(
         &self,
         message: PeerMessage,

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -153,7 +153,8 @@ impl SessionManager {
         self.hello_message.clone()
     }
 
-    /// Spawns the given future onto a new task that is tracked in the `spawned_tasks` [`JoinSet`].
+    /// Spawns the given future onto a new task that is tracked in the `spawned_tasks`
+    /// [`JoinSet`](tokio::task::JoinSet).
     fn spawn<F>(&self, f: F)
     where
         F: Future<Output = ()> + Send + 'static,

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -83,12 +83,12 @@ pub(crate) struct SessionManager {
     pending_sessions_tx: mpsc::Sender<PendingSessionEvent>,
     /// Receiver half that listens for [`PendingSessionEvent`] produced by pending sessions.
     pending_session_rx: ReceiverStream<PendingSessionEvent>,
-    /// The original Sender half of the [`ActiveSessionEvent`] channel.
+    /// The original Sender half of the ActiveSessionEvent channel.
     ///
     /// When active session state is reached, the corresponding [`ActiveSessionHandle`] will get a
     /// clone of this sender half.
     active_session_tx: mpsc::Sender<ActiveSessionMessage>,
-    /// Receiver half that listens for [`ActiveSessionEvent`] produced by pending sessions.
+    /// Receiver half that listens for ActiveSessionEvent produced by pending sessions.
     active_session_rx: ReceiverStream<ActiveSessionMessage>,
     /// Used to measure inbound & outbound bandwidth across all managed streams
     bandwidth_meter: BandwidthMeter,

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -465,7 +465,7 @@ pub(crate) struct ActivePeer {
     pub(crate) blocks: LruCache<H256>,
 }
 
-/// Message variants triggered by the [`State`]
+/// Message variants triggered by the [`NetworkState`]
 pub(crate) enum StateAction {
     /// Dispatch a `NewBlock` message to the peer
     NewBlock {

--- a/crates/net/network/src/swarm.rs
+++ b/crates/net/network/src/swarm.rs
@@ -266,7 +266,7 @@ where
 
     /// This advances all components.
     ///
-    /// Processes, delegates (internal) commands received from the [`NetworkManager`], then polls
+    /// Processes, delegates (internal) commands received from the [`NetworkManager`](crate::NetworkManager), then polls
     /// the [`SessionManager`] which yields messages produced by individual peer sessions that are
     /// then handled. Least priority are incoming connections that are handled and delegated to
     /// the [`SessionManager`] to turn them into a session.

--- a/crates/net/network/src/test_utils/testnet.rs
+++ b/crates/net/network/src/test_utils/testnet.rs
@@ -338,7 +338,7 @@ impl NetworkEventStream {
         None
     }
 
-    /// Ensures that the first two events are a [`PeerAdded`] and [`SessionEstablished`],
+    /// Ensures that the first two events are a [`PeerAdded`](NetworkEvent::PeerAdded) and [`SessionEstablished`](NetworkEvent::SessionEstablished),
     /// returning the [`PeerId`] of the established session.
     pub async fn peer_added_and_established(&mut self) -> Option<PeerId> {
         let peer_id = match self.inner.next().await {

--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -534,7 +534,7 @@ struct Peer {
     request_tx: PeerRequestSender,
 }
 
-/// Commands to send to the [`TransactionManager`]
+/// Commands to send to the [`TransactionsManager`](crate::transactions::TransactionsManager)
 enum TransactionsCommand {
     PropagateHash(H256),
 }

--- a/crates/net/rpc-types/src/admin.rs
+++ b/crates/net/rpc-types/src/admin.rs
@@ -7,7 +7,7 @@ use std::net::{IpAddr, SocketAddr};
 /// known about the running node at the networking granularity.
 ///
 /// Note: this format is not standardized.  Reth follows geth's format,
-/// see: https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-admin
+/// see: <https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-admin>
 #[derive(Serialize, Deserialize, Debug)]
 pub struct NodeInfo {
     /// Enode in URL format.

--- a/crates/net/rpc-types/src/eth/trace/parity.rs
+++ b/crates/net/rpc-types/src/eth/trace/parity.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-//! Types for trace module: Ref https://openethereum.github.io/JSONRPC-trace-module
+//! Types for trace module: Ref <https://openethereum.github.io/JSONRPC-trace-module>
 
 use reth_primitives::{Address, Bytes, H256, U256, U64};
 use serde::{Deserialize, Serialize};

--- a/crates/net/rpc-types/src/eth/transaction/typed.rs
+++ b/crates/net/rpc-types/src/eth/transaction/typed.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-//! The [`TransactionRequest`] is a universal representation for a transaction deserialized from the
+//! The [`TransactionRequest`](crate::TransactionRequest) is a universal representation for a transaction deserialized from the
 //! json input of an RPC call. Depending on what fields are set, it can be converted into the
 //! container type [`TypedTransactionRequest`].
 

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -3,13 +3,13 @@
 use crate::H256;
 use hex_literal::hex;
 
-/// Initial base fee as defined in: https://eips.ethereum.org/EIPS/eip-1559
+/// Initial base fee as defined in: <https://eips.ethereum.org/EIPS/eip-1559>
 pub const EIP1559_INITIAL_BASE_FEE: u64 = 1_000_000_000;
 
-/// Base fee max change denominator as defined in: https://eips.ethereum.org/EIPS/eip-1559
+/// Base fee max change denominator as defined in: <https://eips.ethereum.org/EIPS/eip-1559>
 pub const EIP1559_BASE_FEE_MAX_CHANGE_DENOMINATOR: u64 = 8;
 
-/// Elasticity multiplier as defined in: https://eips.ethereum.org/EIPS/eip-1559
+/// Elasticity multiplier as defined in: <https://eips.ethereum.org/EIPS/eip-1559>
 pub const EIP1559_ELASTICITY_MULTIPLIER: u64 = 2;
 
 /// The Ethereum mainnet genesis hash.

--- a/crates/primitives/src/forkid.rs
+++ b/crates/primitives/src/forkid.rs
@@ -1,5 +1,5 @@
 //! EIP-2124 implementation based on <https://eips.ethereum.org/EIPS/eip-2124>.
-//! Previously version of apache licenced: https://crates.io/crates/ethereum-forkid
+//! Previously version of apache licenced: <https://crates.io/crates/ethereum-forkid>
 
 #![deny(missing_docs)]
 

--- a/crates/stages/src/db.rs
+++ b/crates/stages/src/db.rs
@@ -207,7 +207,7 @@ where
         Ok(())
     }
 
-    /// Unwind a table forward by a [Walker] on another table
+    /// Unwind a table forward by a [Walker](reth_db::cursor::Walker) on another table
     pub(crate) fn unwind_table_by_walker<T1, T2>(&self, start_at: T1::Key) -> Result<(), Error>
     where
         DB: Database,

--- a/crates/stages/src/error.rs
+++ b/crates/stages/src/error.rs
@@ -41,7 +41,7 @@ pub enum StageError {
     StageProgress(u64),
     /// The stage encountered a recoverable error.
     ///
-    /// These types of errors are caught by the [Pipeline] and trigger a restart of the stage.
+    /// These types of errors are caught by the pipeline and trigger a restart of the stage.
     #[error(transparent)]
     Recoverable(Box<dyn std::error::Error + Send + Sync>),
     /// The stage encountered a fatal error.

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -37,17 +37,17 @@ pub(crate) const BODIES: StageId = StageId("Bodies");
 ///
 /// The bodies are processed and data is inserted into these tables:
 ///
-/// - [`BlockOmmers`][reth_interfaces::db::tables::BlockOmmers]
-/// - [`Transactions`][reth_interfaces::db::tables::Transactions]
+/// - [`BlockOmmers`][reth_db::tables::BlockOmmers]
+/// - [`Transactions`][reth_db::tables::Transactions]
 ///
 /// # Genesis
 ///
 /// This stage expects that the genesis has been inserted into the appropriate tables:
 ///
 /// - The header tables (see [`HeaderStage`][crate::stages::headers::HeaderStage])
-/// - The [`BlockOmmers`][reth_interfaces::db::tables::BlockOmmers] table
+/// - The [`BlockOmmers`][reth_db::tables::BlockOmmers] table
 /// - The [`CumulativeTxCount`][reth_interfaces::db::tables::CumulativeTxCount] table
-/// - The [`Transactions`][reth_interfaces::db::tables::Transactions] table
+/// - The [`Transactions`][reth_db::tables::Transactions] table
 #[derive(Debug)]
 pub struct BodyStage<D: BodyDownloader> {
     /// The body downloader.

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -31,8 +31,8 @@ const EXECUTION: StageId = StageId("Execution");
 /// [tables::CumulativeTxCount] to get tx number
 /// [tables::Transactions] to execute
 ///
-/// For state access [StateProvider] provides us latest state and history state
-/// For latest most recent state [StateProvider] would need (Used for execution Stage):
+/// For state access [StateProvider](reth_provider::StateProvider) provides us latest state and history state
+/// For latest most recent state [StateProvider](reth_provider::StateProvider) would need (Used for execution Stage):
 /// [tables::PlainAccountState]
 /// [tables::Bytecodes]
 /// [tables::PlainStorageState]

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -30,9 +30,9 @@ pub(crate) const HEADERS: StageId = StageId("Headers");
 ///
 /// The headers are processed and data is inserted into these tables:
 ///
-/// - [`HeaderNumbers`][reth_interfaces::db::tables::HeaderNumbers]
-/// - [`Headers`][reth_interfaces::db::tables::Headers]
-/// - [`CanonicalHeaders`][reth_interfaces::db::tables::CanonicalHeaders]
+/// - [`HeaderNumbers`][reth_db::tables::HeaderNumbers]
+/// - [`Headers`][reth_db::tables::Headers]
+/// - [`CanonicalHeaders`][reth_db::tables::CanonicalHeaders]
 ///
 /// NOTE: This stage downloads headers in reverse. Upon returning the control flow to the pipeline,
 /// the stage progress is not updated unless this stage is done.

--- a/crates/stages/src/stages/merkle.rs
+++ b/crates/stages/src/stages/merkle.rs
@@ -8,7 +8,7 @@ use tracing::*;
 const MERKLE_EXECUTION: StageId = StageId("MerkleExecuteStage");
 const MERKLE_UNWIND: StageId = StageId("MerkleUnwindStage");
 
-/// Merkle stage uses input from [AccountHashingStage] and [StorageHashingStage] stages
+/// Merkle stage uses input from [AccountHashingStage](super::hashing_account::AccountHashingStage) and [StorageHashingStage](super::hashing_storage::StorageHashingStage) stages
 /// and calculated intermediate hashed and state root.
 /// This stage depends on the Account and Storage stages. It will be executed after them during
 /// execution, and before them during unwinding.

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -20,7 +20,7 @@ const SENDER_RECOVERY: StageId = StageId("SenderRecovery");
 
 /// The sender recovery stage iterates over existing transactions,
 /// recovers the transaction signer and stores them
-/// in [`TxSenders`][reth_interfaces::db::tables::TxSenders] table.
+/// in [`TxSenders`][reth_db::tables::TxSenders] table.
 #[derive(Debug)]
 pub struct SenderRecoveryStage {
     /// The size of the chunk for parallel sender recovery
@@ -54,7 +54,7 @@ impl<DB: Database> Stage<DB> for SenderRecoveryStage {
     /// [`CumulativeTxCount`][reth_interfaces::db::tables::CumulativeTxCount],
     /// collect transactions within that range,
     /// recover signer for each transaction and store entries in
-    /// the [`TxSenders`][reth_interfaces::db::tables::TxSenders] table.
+    /// the [`TxSenders`][reth_db::tables::TxSenders] table.
     async fn execute(
         &mut self,
         tx: &mut Transaction<'_, DB>,

--- a/crates/stages/src/stages/total_difficulty.rs
+++ b/crates/stages/src/stages/total_difficulty.rs
@@ -16,7 +16,7 @@ const TOTAL_DIFFICULTY: StageId = StageId("TotalDifficulty");
 /// The total difficulty stage.
 ///
 /// This stage walks over inserted headers and computes total difficulty
-/// at each block. The entries are inserted into [`HeaderTD`][reth_interfaces::db::tables::HeaderTD]
+/// at each block. The entries are inserted into [`HeaderTD`][reth_db::tables::HeaderTD]
 /// table.
 #[derive(Debug)]
 pub struct TotalDifficultyStage {

--- a/crates/stages/src/util.rs
+++ b/crates/stages/src/util.rs
@@ -15,7 +15,7 @@ pub(crate) mod opt {
         a.map_or(Some(b), |v| Some(std::cmp::min(v, b)))
     }
 
-    /// The producing side of a [tokio::mpsc] channel that may or may not be set.
+    /// The producing side of a [tokio::sync::mpsc] channel that may or may not be set.
     #[derive(Default, Clone)]
     pub(crate) struct MaybeSender<T> {
         inner: Option<Sender<T>>,

--- a/crates/storage/codecs/derive/src/compact/generator.rs
+++ b/crates/storage/codecs/derive/src/compact/generator.rs
@@ -1,8 +1,8 @@
-//! Code generator for the [`Compact`] trait.
+//! Code generator for the [`Compact`](reth_codecs::Compact) trait.
 
 use super::*;
 
-/// Generates code to implement the [`Compact`] trait for a data type.
+/// Generates code to implement the [`Compact`](reth_codecs::Compact) trait for a data type.
 pub fn generate_from_to(ident: &Ident, fields: &FieldList) -> TokenStream2 {
     let flags = format_ident!("{ident}Flags");
 
@@ -47,7 +47,7 @@ pub fn generate_from_to(ident: &Ident, fields: &FieldList) -> TokenStream2 {
     }
 }
 
-/// Generates code to implement the [`Compact`] trait method `to_compact`.
+/// Generates code to implement the [`Compact`](reth_codecs::Compact) trait method `to_compact`.
 fn generate_from_compact(fields: &FieldList, ident: &Ident) -> Vec<TokenStream2> {
     let mut lines = vec![];
     let mut known_types = vec!["H256", "H160", "Address", "Bloom", "Vec"];
@@ -102,7 +102,7 @@ fn generate_from_compact(fields: &FieldList, ident: &Ident) -> Vec<TokenStream2>
     lines
 }
 
-/// Generates code to implement the [`Compact`] trait method `from_compact`.
+/// Generates code to implement the [`Compact`](reth_codecs::Compact) trait method `from_compact`.
 fn generate_to_compact(fields: &FieldList, ident: &Ident) -> Vec<TokenStream2> {
     let mut lines = vec![quote! {
         let mut buffer = bytes::BytesMut::new();

--- a/crates/storage/codecs/derive/src/compact/mod.rs
+++ b/crates/storage/codecs/derive/src/compact/mod.rs
@@ -40,7 +40,7 @@ pub enum FieldTypes {
     EnumUnnamedField((FieldType, UseAlternative)),
 }
 
-/// Derives the [`Compact`] trait and its from/to implementations.
+/// Derives the [`Compact`](super::Compact) trait and its from/to implementations.
 pub fn derive(input: TokenStream) -> TokenStream {
     let mut output = quote! {};
 

--- a/crates/storage/codecs/derive/src/lib.rs
+++ b/crates/storage/codecs/derive/src/lib.rs
@@ -134,7 +134,7 @@ pub fn derive_arbitrary(args: TokenStream, input: TokenStream) -> TokenStream {
     .into()
 }
 
-/// To be used for types that implement `Arbitrary` manually. See [`derive_arbitrary`] for more.
+/// To be used for types that implement `Arbitrary` manually. See [`macro@derive_arbitrary`] for more.
 #[proc_macro_attribute]
 pub fn add_arbitrary_tests(args: TokenStream, input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);

--- a/crates/storage/db/src/abstraction/cursor.rs
+++ b/crates/storage/db/src/abstraction/cursor.rs
@@ -100,7 +100,8 @@ pub trait DbDupCursorRW<'tx, T: DupSort> {
 
     /// Append duplicate value.
     ///
-    /// This is efficient for pre-sorted data. If the data is not pre-sorted, use [`insert`].
+    /// This is efficient for pre-sorted data. If the data is not pre-sorted, use
+    /// [`insert`](DbCursorRW::insert).
     fn append_dup(&mut self, key: T::Key, value: T::Value) -> Result<(), Error>;
 }
 

--- a/crates/storage/db/src/abstraction/cursor.rs
+++ b/crates/storage/db/src/abstraction/cursor.rs
@@ -86,7 +86,7 @@ pub trait DbCursorRW<'tx, T: Table> {
 
     /// Append value to next cursor item.
     ///
-    /// This is efficient for pre-sorted data. If the data is not pre-sorted, use [`insert`].
+    /// This is efficient for pre-sorted data. If the data is not pre-sorted, use [`insert`](DbCursorRW::insert).
     fn append(&mut self, key: T::Key, value: T::Value) -> Result<(), Error>;
 
     /// Delete current value that cursor points to

--- a/crates/storage/db/src/abstraction/database.rs
+++ b/crates/storage/db/src/abstraction/database.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 /// Implements the GAT method from:
-/// https://sabrinajewson.org/blog/the-better-alternative-to-lifetime-gats#the-better-gats.
+/// <https://sabrinajewson.org/blog/the-better-alternative-to-lifetime-gats#the-better-gats>.
 ///
 /// Sealed trait which cannot be implemented by 3rd parties, exposed only for implementers
 pub trait DatabaseGAT<'a, __ImplicitBounds: Sealed = Bounds<&'a Self>>: Send + Sync {

--- a/crates/storage/db/src/abstraction/table.rs
+++ b/crates/storage/db/src/abstraction/table.rs
@@ -66,9 +66,9 @@ pub trait Table: Send + Sync + Debug + 'static {
 }
 
 /// DupSort allows for keys not to be repeated in the database,
-/// for more check: https://libmdbx.dqdkfa.ru/usage.html#autotoc_md48
+/// for more check: <https://libmdbx.dqdkfa.ru/usage.html#autotoc_md48>
 pub trait DupSort: Table {
-    /// Subkey type. For more check https://libmdbx.dqdkfa.ru/usage.html#autotoc_md48
+    /// Subkey type. For more check <https://libmdbx.dqdkfa.ru/usage.html#autotoc_md48>
     ///
     /// Sorting should be taken into account when encoding this.
     type SubKey: Key;

--- a/crates/storage/db/src/abstraction/table.rs
+++ b/crates/storage/db/src/abstraction/table.rs
@@ -48,12 +48,12 @@ impl<T> Value for T where T: Compress + Decompress + Serialize {}
 
 /// Generic trait that a database table should follow.
 ///
-/// [`Table::Key`], [`Table::Value`], [`Table::SeekKey`] types should implement [`Encode`] and
+/// [`Table::Key`], [`Table::Value`] types should implement [`Encode`] and
 /// [`Decode`] when appropriate. These traits define how the data is stored and read from the
 /// database.
 ///
-/// It allows for the use of codecs. See [`crate::kv::models::blocks::BlockNumHash`] for a custom
-/// implementation, and [`crate::kv::codecs::scale`] for the use of an external codec.
+/// It allows for the use of codecs. See [`crate::tables::models::BlockNumHash`] for a custom
+/// implementation, and [`crate::tables::codecs::scale`] for the use of an external codec.
 pub trait Table: Send + Sync + Debug + 'static {
     /// Return table name as it is present inside the MDBX.
     const NAME: &'static str;

--- a/crates/storage/db/src/abstraction/transaction.rs
+++ b/crates/storage/db/src/abstraction/transaction.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 /// Implements the GAT method from:
-/// https://sabrinajewson.org/blog/the-better-alternative-to-lifetime-gats#the-better-gats.
+/// <https://sabrinajewson.org/blog/the-better-alternative-to-lifetime-gats#the-better-gats>.
 ///
 /// Sealed trait which cannot be implemented by 3rd parties, exposed only for implementers
 pub trait DbTxGAT<'a, __ImplicitBounds: Sealed = Bounds<&'a Self>>: Send + Sync {
@@ -17,7 +17,7 @@ pub trait DbTxGAT<'a, __ImplicitBounds: Sealed = Bounds<&'a Self>>: Send + Sync 
 }
 
 /// Implements the GAT method from:
-/// https://sabrinajewson.org/blog/the-better-alternative-to-lifetime-gats#the-better-gats.
+/// <https://sabrinajewson.org/blog/the-better-alternative-to-lifetime-gats#the-better-gats>.
 ///
 /// Sealed trait which cannot be implemented by 3rd parties, exposed only for implementers
 pub trait DbTxMutGAT<'a, __ImplicitBounds: Sealed = Bounds<&'a Self>>: Send + Sync {

--- a/crates/storage/db/src/tables/models/accounts.rs
+++ b/crates/storage/db/src/tables/models/accounts.rs
@@ -10,7 +10,7 @@ use reth_codecs::Compact;
 use reth_primitives::{Account, Address, TransitionId};
 use serde::{Deserialize, Serialize};
 
-/// Account as it is saved inside [`AccountChangeSet`]. [`Address`] is the subkey.
+/// Account as it is saved inside [`AccountChangeSet`](crate::tables::AccountChangeSet). [`Address`] is the subkey.
 #[derive(Debug, Default, Clone, Eq, PartialEq, Serialize)]
 pub struct AccountBeforeTx {
     /// Address for the account. Acts as `DupSort::SubKey`.
@@ -39,7 +39,7 @@ impl Compact for AccountBeforeTx {
     }
 }
 
-/// [`TxNumber`] concatenated with [`Address`]. Used as a key for [`StorageChangeSet`]
+/// [`TxNumber`](reth_primitives::TxNumber) concatenated with [`Address`](reth_primitives::Address). Used as a key for [`StorageChangeSet`]
 ///
 /// Since it's used as a key, it isn't compressed when encoding it.
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Ord, PartialOrd)]
@@ -56,7 +56,8 @@ impl TransitionIdAddress {
         self.0 .1
     }
 
-    /// Consumes `Self` and returns [`TxNumber`], [`Address`]
+    /// Consumes `Self` and returns [`TxNumber`](reth_primitives::TxNumber),
+    /// [`Address`](reth_primitives::Address)
     pub fn take(self) -> (TransitionId, Address) {
         (self.0 .0, self.0 .1)
     }

--- a/crates/storage/db/src/tables/models/blocks.rs
+++ b/crates/storage/db/src/tables/models/blocks.rs
@@ -58,7 +58,7 @@ pub struct StoredBlockOmmers {
     pub ommers: Vec<Header>,
 }
 
-/// Hash of the block header. Value for [`CanonicalHeaders`](reth_db::tables::CanonicalHeaders)
+/// Hash of the block header. Value for [`CanonicalHeaders`](crate::CanonicalHeaders)
 pub type HeaderHash = H256;
 
 /// BlockNumber concatenated with BlockHash. Used as a key for multiple tables. Having the first

--- a/crates/storage/db/src/tables/models/blocks.rs
+++ b/crates/storage/db/src/tables/models/blocks.rs
@@ -58,7 +58,7 @@ pub struct StoredBlockOmmers {
     pub ommers: Vec<Header>,
 }
 
-/// Hash of the block header. Value for [`CanonicalHeaders`]
+/// Hash of the block header. Value for [`CanonicalHeaders`](reth_db::tables::CanonicalHeaders)
 pub type HeaderHash = H256;
 
 /// BlockNumber concatenated with BlockHash. Used as a key for multiple tables. Having the first

--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -13,7 +13,7 @@ use tracing::debug;
 /// An iterator that returns transactions that can be executed on the current state (*best*
 /// transactions).
 ///
-/// The [`PendingPool`] contains transactions that *could* all be executed on the current state, but
+/// The [`PendingPool`](crate::pool::PendingPool) contains transactions that *could* all be executed on the current state, but
 /// only yields transactions that are ready to be executed now.
 /// While it contains all gapless transactions of a sender, it _always_ only returns the transaction
 /// with the current on chain nonce.

--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -13,7 +13,7 @@ use tracing::debug;
 /// An iterator that returns transactions that can be executed on the current state (*best*
 /// transactions).
 ///
-/// The [`PendingPool`](crate::pool::PendingPool) contains transactions that *could* all be executed on the current state, but
+/// The [`PendingPool`](crate::pool::pending::PendingPool) contains transactions that *could* all be executed on the current state, but
 /// only yields transactions that are ready to be executed now.
 /// While it contains all gapless transactions of a sender, it _always_ only returns the transaction
 /// with the current on chain nonce.

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -472,7 +472,7 @@ impl<T: PoolTransaction> AddedTransaction<T> {
     }
 }
 
-/// Contains all state changes after a [`NewBlockEvent`] was processed
+/// Contains all state changes after a [`OnNewBlockEvent`] was processed
 #[derive(Debug)]
 pub(crate) struct OnNewBlockOutcome {
     /// Hash of the block.

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -38,7 +38,7 @@ pub(crate) struct PendingPool<T: TransactionOrdering> {
     independent_transactions: BTreeSet<PendingTransactionRef<T>>,
     /// Keeps track of the size of this pool.
     ///
-    /// See also [`PoolTransaction::size`].
+    /// See also [`PoolTransaction::size`](crate::traits::PoolTransaction::size).
     size_of: SizeTracker,
 }
 

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -28,7 +28,7 @@ use std::{
 
 /// The minimal value the basefee can decrease to
 ///
-/// The `BASE_FEE_MAX_CHANGE_DENOMINATOR` (https://eips.ethereum.org/EIPS/eip-1559) is `8`, or 12.5%, once the base fee has dropped to `7` WEI it cannot decrease further because 12.5% of 7 is less than 1.
+/// The `BASE_FEE_MAX_CHANGE_DENOMINATOR` <https://eips.ethereum.org/EIPS/eip-1559> is `8`, or 12.5%, once the base fee has dropped to `7` WEI it cannot decrease further because 12.5% of 7 is less than 1.
 pub(crate) const MIN_PROTOCOL_BASE_FEE: u128 = 7;
 
 /// A pool that manages transactions.


### PR DESCRIPTION
This PR solves the majority of the doc warnings and errors from issue #1044. The remaining warns/errs I wasn't sure how to solve, like broken links to missing (probabily removed or renamed) features which require more investigation in the repo's commit history.

Also some more warns/errs appeared when pulling today, I suggest making these kind of doctests part of the CI so they don't get accumulated again.