### PR TITLE
fix: increase minimum request timeout

### DIFF
--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -81,7 +81,7 @@ pub(crate) struct ActiveSession {
 /// Constants for timeout updating
 
 /// Minimum timeout value
-const MINIMUM_TIMEOUT: Duration = Duration::from_millis(1);
+const MINIMUM_TIMEOUT: Duration = Duration::from_secs(2);
 /// Maximum timeout value
 const MAXIMUM_TIMEOUT: Duration = INITIAL_REQUEST_TIMEOUT;
 /// How much the new measurements affect the current timeout (X percent)
@@ -204,7 +204,7 @@ impl ActiveSession {
         None
     }
 
-    /// Handle an incoming peer request.
+    /// Handle an internal peer request that will be sent to the remote.
     fn on_peer_request(&mut self, request: PeerRequest, deadline: Instant) {
         let request_id = self.next_id();
         let msg = request.create_request_message(request_id);

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -839,7 +839,7 @@ mod tests {
 
     #[test]
     fn timeout_calculation_sanity_tests() {
-        let rtt = Duration::from_millis(200);
+        let rtt = Duration::from_secs(5);
         // timeout for an RTT of `rtt`
         let timeout = rtt * TIMEOUT_SCALING;
 

--- a/crates/net/network/tests/it/requests.rs
+++ b/crates/net/network/tests/it/requests.rs
@@ -113,7 +113,7 @@ async fn test_get_header() {
             HeadersRequest { start: hash.into(), limit: 1, direction: HeadersDirection::Falling };
 
         let res = fetch0.get_headers(req).await;
-        assert!(res.is_ok());
+        assert!(res.is_ok(), "{res:?}");
 
         let headers = res.unwrap().1 .0;
         assert_eq!(headers.len(), 1);


### PR DESCRIPTION
Closes #1071
Closes #911

the previous minimum timeout of 1ms was too low even for local networks.

so what ended up happening int the test was, the timeout was adapted:

```
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 18004
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 16204
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 14588
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 13130
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 11817
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 10638
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 9575
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 8617
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 7759
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 6983
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 6285
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 5657
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 5091
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 4585
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 4127
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 3714
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 3343
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 3011
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 2710
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 2439
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 2195
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 1980
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 1782
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 1604
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 1444
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 1300
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 1173
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 1056
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 950
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 855
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 770
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 693
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 626
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 563
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 507
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 456
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 410
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 369
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 332
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 299
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 269
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 242
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 222
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 200
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 181
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 166
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 149
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 134
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 121
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 112
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 101
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 91
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 82
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 74
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 69
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 62
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 56
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 50
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 45
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 41
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 37
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 33
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 32
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 32
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 30
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 27
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 27
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 24
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 22
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 20
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 18
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 19
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 17
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 15
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 13
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 12
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 14
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 13
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 12
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 11
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 10
[crates/net/network/src/session/active.rs:365] request_timeout.as_millis() = 9
```

but eventually the margin was so small that requests were evicted:

```
[crates/net/network/src/session/active.rs:345] "timedout" = "timedout"
[crates/net/network/src/session/active.rs:346] now - req.deadline = 49.787µs

```


this uses the same minimum timeout geth uses 2s

https://github.com/ethereum/go-ethereum/blob/2c6dda5ad7a720cccd957230f7978de0082ec8c7/p2p/msgrate/msgrate.go#L45