### PR TITLE
chore(sync): consistent stage ids

### DIFF
--- a/crates/stages/src/stages/hashing_account.rs
+++ b/crates/stages/src/stages/hashing_account.rs
@@ -15,7 +15,7 @@ use std::{
 use tracing::*;
 
 /// The [`StageId`] of the account hashing stage.
-pub const ACCOUNT_HASHING: StageId = StageId("AccountHashingStage");
+pub const ACCOUNT_HASHING: StageId = StageId("AccountHashing");
 
 /// Account hashing stage hashes plain account.
 /// This is preparation before generating intermediate hashes and calculating Merkle tree root.

--- a/crates/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/src/stages/hashing_storage.rs
@@ -13,7 +13,7 @@ use std::{collections::BTreeMap, fmt::Debug};
 use tracing::*;
 
 /// The [`StageId`] of the storage hashing stage.
-pub const STORAGE_HASHING: StageId = StageId("StorageHashingStage");
+pub const STORAGE_HASHING: StageId = StageId("StorageHashing");
 
 /// Storage hashing stage hashes plain storage.
 /// This is preparation before generating intermediate hashes and calculating Merkle tree root.

--- a/crates/stages/src/stages/index_account_history.rs
+++ b/crates/stages/src/stages/index_account_history.rs
@@ -14,7 +14,7 @@ use reth_primitives::{Address, TransitionId};
 use std::{collections::BTreeMap, fmt::Debug};
 use tracing::*;
 
-const INDEX_ACCOUNT_HISTORY: StageId = StageId("IndexAccountHistoryStage");
+const INDEX_ACCOUNT_HISTORY: StageId = StageId("IndexAccountHistory");
 
 /// Stage is indexing history the account changesets generated in
 /// [`ExecutionStage`][crate::stages::ExecutionStage]. For more information

--- a/crates/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/src/stages/index_storage_history.rs
@@ -14,7 +14,7 @@ use reth_primitives::{Address, TransitionId, H256};
 use std::{collections::BTreeMap, fmt::Debug};
 use tracing::*;
 
-const INDEX_STORAGE_HISTORY: StageId = StageId("IndexStorageHistoryStage");
+const INDEX_STORAGE_HISTORY: StageId = StageId("IndexStorageHistory");
 
 /// Stage is indexing history the account changesets generated in
 /// [`ExecutionStage`][crate::stages::ExecutionStage]. For more information

--- a/crates/stages/src/stages/merkle.rs
+++ b/crates/stages/src/stages/merkle.rs
@@ -6,10 +6,10 @@ use std::fmt::Debug;
 use tracing::*;
 
 /// The [`StageId`] of the merkle hashing execution stage.
-pub const MERKLE_EXECUTION: StageId = StageId("MerkleExecuteStage");
+pub const MERKLE_EXECUTION: StageId = StageId("MerkleExecute");
 
 /// The [`StageId`] of the merkle hashing unwind stage.
-pub const MERKLE_UNWIND: StageId = StageId("MerkleUnwindStage");
+pub const MERKLE_UNWIND: StageId = StageId("MerkleUnwind");
 
 /// The merkle hashing stage uses input from
 /// [`AccountHashingStage`][crate::stages::AccountHashingStage] and


### PR DESCRIPTION
Make all stage ids consistent by removing `...Stage` suffix.

This is a breaking database change for any synced nodes that ran these stages. 