### PR TITLE
fix: dont insert empty accounts after spurious dragon

### DIFF
--- a/crates/primitives/src/account.rs
+++ b/crates/primitives/src/account.rs
@@ -1,4 +1,4 @@
-use crate::{H256, U256};
+use crate::{H256, KECCAK_EMPTY, U256};
 use reth_codecs::{main_codec, Compact};
 
 /// An Ethereum account.
@@ -17,6 +17,17 @@ impl Account {
     /// Whether the account has bytecode.
     pub fn has_bytecode(&self) -> bool {
         self.bytecode_hash.is_some()
+    }
+
+    /// After SpuriousDragon empty account is defined as account with nonce == 0 && balance == 0 &&
+    /// bytecode = None.
+    pub fn is_empty(&self) -> bool {
+        let is_bytecode_empty = match self.bytecode_hash {
+            None => true,
+            Some(hash) => hash == KECCAK_EMPTY,
+        };
+
+        self.nonce == 0 && self.balance == U256::ZERO && is_bytecode_empty
     }
 }
 


### PR DESCRIPTION
closes #975

An additional bug is found in unwind as the working pattern for update->insert is different for dup table.