### PR TITLE
chore: run txlookup stage after exec

### DIFF
--- a/crates/stages/src/sets.rs
+++ b/crates/stages/src/sets.rs
@@ -107,7 +107,6 @@ where
             .add_stage(HeaderStage::new(self.header_downloader, self.consensus.clone()))
             .add_stage(TotalDifficultyStage::default())
             .add_stage(BodyStage { downloader: self.body_downloader, consensus: self.consensus })
-            .add_stage(TransactionLookupStage::default())
     }
 }
 
@@ -180,6 +179,7 @@ pub struct HistoryIndexingStages;
 impl<DB: Database> StageSet<DB> for HistoryIndexingStages {
     fn builder(self) -> StageSetBuilder<DB> {
         StageSetBuilder::default()
+            .add_stage(TransactionLookupStage::default())
             .add_stage(IndexStorageHistoryStage::default())
             .add_stage(IndexAccountHistoryStage::default())
     }


### PR DESCRIPTION
As discussed, `TransactionLookup` is really slow, and it prevents us from testing Execution at the moment. This PR moves TransactoinLookup to be part of the indexing stages.

We should separately track how to improve its performance.