### PR TITLE
perf(net): add protocol breach request timeout

### DIFF
--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -756,6 +756,12 @@ where
                         .apply_reputation_change(&peer_id, ReputationChangeKind::BadMessage);
                     this.metrics.invalid_messages_received.increment(1);
                 }
+                SwarmEvent::ProtocolBreach { peer_id } => {
+                    this.swarm
+                        .state_mut()
+                        .peers_mut()
+                        .apply_reputation_change(&peer_id, ReputationChangeKind::BadProtocol);
+                }
             }
         }
 

--- a/crates/net/network/src/session/config.rs
+++ b/crates/net/network/src/session/config.rs
@@ -5,8 +5,13 @@ use std::time::Duration;
 
 /// Default request timeout for a single request.
 ///
-/// This represents the time we wait for a response until we consider it timed out.
+/// This represents the amount of time we wait for a response until we consider it timed out.
 pub const INITIAL_REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Default timeout after which we'll consider the peer to be in violation of the protocol.
+///
+/// This is the time a peer has to answer a response.
+pub const PROTOCOL_BREACH_REQUEST_TIMEOUT: Duration = Duration::from_secs(2 * 60);
 
 /// Configuration options when creating a [SessionManager](crate::session::SessionManager).
 #[derive(Debug)]
@@ -20,8 +25,15 @@ pub struct SessionsConfig {
     ///
     /// By default, no limits will be enforced.
     pub limits: SessionLimits,
-    /// The maximum time we wait for a response from a peer.
-    pub request_timeout: Duration,
+    /// The maximum initial time we wait for a response from the peer before we timeout a request
+    /// _internally_.
+    pub initial_internal_request_timeout: Duration,
+    /// The amount of time we continue to wait for a response from the peer, even if we timed it
+    /// out internally (`initial_internal_request_timeout`). Timeouts are not penalized but the
+    /// session directly, however if a peer fails to respond at all (within
+    /// `PROTOCOL_BREACH_REQUEST_TIMEOUT`) this is considered a protocol violation and results in a
+    /// dropped session.
+    pub protocol_breach_request_timeout: Duration,
 }
 
 impl Default for SessionsConfig {
@@ -36,7 +48,8 @@ impl Default for SessionsConfig {
             // `poll`.
             session_event_buffer: 128,
             limits: Default::default(),
-            request_timeout: INITIAL_REQUEST_TIMEOUT,
+            initial_internal_request_timeout: INITIAL_REQUEST_TIMEOUT,
+            protocol_breach_request_timeout: PROTOCOL_BREACH_REQUEST_TIMEOUT,
         }
     }
 }

--- a/crates/net/network/src/session/handle.rs
+++ b/crates/net/network/src/session/handle.rs
@@ -169,4 +169,9 @@ pub(crate) enum ActiveSessionMessage {
         /// Identifier of the remote peer.
         peer_id: PeerId,
     },
+    /// Remote peer is considered in protocol violation
+    ProtocolBreach {
+        /// Identifier of the remote peer.
+        peer_id: PeerId,
+    },
 }

--- a/crates/net/network/src/swarm.rs
+++ b/crates/net/network/src/swarm.rs
@@ -173,6 +173,9 @@ where
                 Some(SwarmEvent::OutgoingConnectionError { peer_id, remote_addr, error })
             }
             SessionEvent::BadMessage { peer_id } => Some(SwarmEvent::BadMessage { peer_id }),
+            SessionEvent::ProtocolBreach { peer_id } => {
+                Some(SwarmEvent::ProtocolBreach { peer_id })
+            }
         }
     }
 
@@ -328,6 +331,11 @@ pub(crate) enum SwarmEvent {
     },
     /// Received a bad message from the peer.
     BadMessage {
+        /// Identifier of the remote peer.
+        peer_id: PeerId,
+    },
+    /// Remote peer is considered in protocol violation
+    ProtocolBreach {
         /// Identifier of the remote peer.
         peer_id: PeerId,
     },


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/1067

this introduces an additional `protocol_breach_request_timeout` parameter for active sessions.
This is the maximum time we wait for a response, if no response arrives in time, we consider this a protocol breach and will trigger a disconnect.

cc @jonasbostoen 

## Changes
keep the `InflightRequest` object until a response arrives, but time out request internally. This allows us to treat sync requests as timed out while we continue to wait for a response. A peer may just be under a heavy load and can't keep up with requests for a short period of time.