### PR TITLE
refactor: add Peers trait und decouple rpc from NetworkHandle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4428,6 +4428,7 @@ name = "reth-network-api"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "reth-eth-wire",
  "reth-primitives",
  "serde",
  "thiserror",
@@ -4541,7 +4542,6 @@ dependencies = [
  "jsonrpsee",
  "reth-consensus",
  "reth-interfaces",
- "reth-network",
  "reth-network-api",
  "reth-primitives",
  "reth-provider",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4611,6 +4611,7 @@ dependencies = [
  "reth-interfaces",
  "reth-net-nat",
  "reth-network",
+ "reth-network-api",
  "reth-primitives",
  "reth-provider",
  "reth-staged-sync",

--- a/crates/net/network-api/Cargo.toml
+++ b/crates/net/network-api/Cargo.toml
@@ -10,7 +10,7 @@ description = "Network interfaces"
 [dependencies]
 # reth
 reth-primitives = { path = "../../primitives" }
-
+reth-eth-wire = { path = "../eth-wire" }
 
 # io
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -17,7 +17,6 @@ use std::{
     sync::Arc,
     task::{Context, Poll},
 };
-
 use tokio::sync::{mpsc::UnboundedReceiver, oneshot};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 

--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -9,7 +9,7 @@ use crate::{
 use futures::StreamExt;
 use reth_eth_wire::{errors::EthStreamError, DisconnectReason};
 use reth_net_common::ban_list::BanList;
-use reth_network_api::ReputationChangeKind;
+use reth_network_api::{PeerKind, ReputationChangeKind};
 use reth_primitives::{ForkId, NodeRecord, PeerId};
 use std::{
     collections::{hash_map::Entry, HashMap, HashSet, VecDeque},
@@ -858,16 +858,6 @@ impl PeerConnectionState {
     fn is_unconnected(&self) -> bool {
         matches!(self, PeerConnectionState::Idle)
     }
-}
-
-/// Represents the kind of peer
-#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
-pub enum PeerKind {
-    /// Basic peer kind.
-    #[default]
-    Basic,
-    /// Trusted peer.
-    Trusted,
 }
 
 /// Commands the [`PeersManager`] listens for.

--- a/crates/net/network/src/peers/mod.rs
+++ b/crates/net/network/src/peers/mod.rs
@@ -4,5 +4,6 @@ mod manager;
 mod reputation;
 
 pub(crate) use manager::{InboundConnectionError, PeerAction, PeersManager};
-pub use manager::{PeerKind, PeersConfig, PeersHandle};
+pub use manager::{PeersConfig, PeersHandle};
 pub use reputation::ReputationChangeWeights;
+pub use reth_network_api::PeerKind;

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -8,12 +8,13 @@ use crate::{
         BlockRequest, NewBlockMessage, PeerRequest, PeerRequestSender, PeerResponse,
         PeerResponseResult,
     },
-    peers::{PeerAction, PeerKind, PeersManager},
+    peers::{PeerAction, PeersManager},
     FetchClient,
 };
 use reth_eth_wire::{
     capability::Capabilities, BlockHashNumber, DisconnectReason, NewBlockHashes, Status,
 };
+use reth_network_api::PeerKind;
 use reth_primitives::{ForkId, PeerId, H256};
 use reth_provider::BlockProvider;
 use std::{

--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -13,7 +13,7 @@ use reth_eth_wire::{
     GetPooledTransactions, NewPooledTransactionHashes, PooledTransactions, Transactions,
 };
 use reth_interfaces::{p2p::error::RequestResult, sync::SyncStateProvider};
-use reth_network_api::ReputationChangeKind;
+use reth_network_api::{Peers, ReputationChangeKind};
 use reth_primitives::{
     FromRecoveredTransaction, IntoRecoveredTransaction, PeerId, TransactionSigned, TxHash, H256,
 };

--- a/crates/net/network/tests/it/connect.rs
+++ b/crates/net/network/tests/it/connect.rs
@@ -1,9 +1,7 @@
 //! Connection tests
 
 use ethers_core::utils::Geth;
-
 use ethers_providers::{Http, Middleware, Provider};
-
 use futures::StreamExt;
 use reth_discv4::{bootnodes::mainnet_nodes, Discv4Config};
 use reth_eth_wire::DisconnectReason;
@@ -18,7 +16,7 @@ use reth_network::{
     },
     NetworkConfigBuilder, NetworkEvent, NetworkManager, PeersConfig,
 };
-use reth_network_api::{NetworkInfo, PeersInfo};
+use reth_network_api::{NetworkInfo, Peers, PeersInfo};
 use reth_primitives::{HeadersDirection, NodeRecord, PeerId};
 use reth_provider::test_utils::NoopProvider;
 use reth_transaction_pool::test_utils::testing_pool;

--- a/crates/net/network/tests/it/requests.rs
+++ b/crates/net/network/tests/it/requests.rs
@@ -7,7 +7,7 @@ use reth_interfaces::p2p::{
     headers::client::{HeadersClient, HeadersRequest},
 };
 use reth_network::test_utils::{NetworkEventStream, Testnet};
-use reth_network_api::NetworkInfo;
+use reth_network_api::{NetworkInfo, Peers};
 use reth_primitives::{
     Block, Bytes, Header, HeadersDirection, Signature, Transaction, TransactionKind,
     TransactionSigned, TxEip2930, H256, U256,

--- a/crates/net/rpc/Cargo.toml
+++ b/crates/net/rpc/Cargo.toml
@@ -16,7 +16,6 @@ reth-rpc-api = { path = "../rpc-api" }
 reth-rpc-types = { path = "../rpc-types" }
 reth-provider = { path = "../../storage/provider" }
 reth-transaction-pool = { path = "../../transaction-pool" }
-reth-network = { path = "../network" }
 reth-network-api = { path = "../network-api" }
 reth-consensus = { path = "../../consensus", features = ["serde"] }
 

--- a/crates/net/rpc/src/admin.rs
+++ b/crates/net/rpc/src/admin.rs
@@ -1,31 +1,31 @@
+use crate::result::ToRpcResult;
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
-
-use reth_network::{peers::PeerKind, NetworkHandle};
-use reth_network_api::{NetworkInfo, PeersInfo};
+use reth_network_api::{NetworkInfo, PeerKind, Peers};
 use reth_primitives::NodeRecord;
 use reth_rpc_api::AdminApiServer;
 use reth_rpc_types::NodeInfo;
 
-use crate::result::ToRpcResult;
-
 /// `admin` API implementation.
 ///
 /// This type provides the functionality for handling `admin` related requests.
-pub struct AdminApi {
+pub struct AdminApi<N> {
     /// An interface to interact with the network
-    network: NetworkHandle,
+    network: N,
 }
 
-impl AdminApi {
+impl<N> AdminApi<N> {
     /// Creates a new instance of `AdminApi`.
-    pub fn new(network: NetworkHandle) -> AdminApi {
+    pub fn new(network: N) -> Self {
         AdminApi { network }
     }
 }
 
 #[async_trait]
-impl AdminApiServer for AdminApi {
+impl<N> AdminApiServer for AdminApi<N>
+where
+    N: NetworkInfo + Peers + 'static,
+{
     fn add_peer(&self, record: NodeRecord) -> RpcResult<bool> {
         self.network.add_peer(record.id, record.tcp_addr());
         Ok(true)
@@ -61,7 +61,7 @@ impl AdminApiServer for AdminApi {
     }
 }
 
-impl std::fmt::Debug for AdminApi {
+impl<N> std::fmt::Debug for AdminApi<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AdminApi").finish_non_exhaustive()
     }

--- a/crates/net/rpc/src/web3.rs
+++ b/crates/net/rpc/src/web3.rs
@@ -1,7 +1,6 @@
 use crate::result::ToRpcResult;
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
-use reth_network::NetworkHandle;
 use reth_network_api::NetworkInfo;
 use reth_primitives::{keccak256, Bytes, H256};
 use reth_rpc_api::Web3ApiServer;
@@ -9,20 +8,23 @@ use reth_rpc_api::Web3ApiServer;
 /// `web3` API implementation.
 ///
 /// This type provides the functionality for handling `web3` related requests.
-pub struct Web3Api {
+pub struct Web3Api<N> {
     /// An interface to interact with the network
-    network: NetworkHandle,
+    network: N,
 }
 
-impl Web3Api {
+impl<N> Web3Api<N> {
     /// Creates a new instance of `Web3Api`.
-    pub fn new(network: NetworkHandle) -> Web3Api {
+    pub fn new(network: N) -> Self {
         Web3Api { network }
     }
 }
 
 #[async_trait]
-impl Web3ApiServer for Web3Api {
+impl<N> Web3ApiServer for Web3Api<N>
+where
+    N: NetworkInfo + 'static,
+{
     async fn client_version(&self) -> RpcResult<String> {
         let status = self.network.network_status().await.to_rpc_result()?;
         Ok(status.client_version)
@@ -33,7 +35,7 @@ impl Web3ApiServer for Web3Api {
     }
 }
 
-impl std::fmt::Debug for Web3Api {
+impl<N> std::fmt::Debug for Web3Api<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Web3Api").finish_non_exhaustive()
     }

--- a/crates/staged-sync/Cargo.toml
+++ b/crates/staged-sync/Cargo.toml
@@ -17,7 +17,8 @@ normal = [
 # reth
 reth-db = {path = "../../crates/storage/db", features = ["mdbx", "test-utils"] }
 reth-discv4 = { path = "../../crates/net/discv4" }
-reth-network = {path = "../../crates/net/network", features = ["serde"] }
+reth-network-api = { path = "../../crates/net/network-api" }
+reth-network = { path = "../../crates/net/network", features = ["serde"] }
 reth-primitives = { path = "../../crates/primitives" }
 reth-provider = { path = "../../crates/storage/provider", features = ["test-utils"] }
 reth-net-nat = { path = "../../crates/net/nat" }

--- a/crates/staged-sync/tests/sync.rs
+++ b/crates/staged-sync/tests/sync.rs
@@ -7,6 +7,7 @@ use reth_network::{
     test_utils::{unused_port, unused_tcp_udp, NetworkEventStream},
     NetworkConfig, NetworkManager,
 };
+use reth_network_api::Peers;
 use reth_primitives::{
     constants::EIP1559_INITIAL_BASE_FEE, ChainSpec, Hardfork, Header, PeerId, SealedHeader,
 };


### PR DESCRIPTION
Closes #857 

replace `NetworkHandle` with network-api traits in rpc crate

## Changes
* introduce `Peers` trait for managing peers of the network.