### PR TITLE
chore(rpc): replace all todo! macros in rpc crate with rpc error responses

### DIFF
--- a/crates/net/rpc/src/debug.rs
+++ b/crates/net/rpc/src/debug.rs
@@ -1,3 +1,4 @@
+use crate::result::internal_rpc_err;
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult as Result;
 use reth_primitives::{rpc::BlockId, Bytes, H256};
@@ -14,23 +15,23 @@ pub struct DebugApi {
 #[async_trait]
 impl DebugApiServer for DebugApi {
     async fn raw_header(&self, _block_id: BlockId) -> Result<Bytes> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn raw_block(&self, _block_id: BlockId) -> Result<Bytes> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn raw_transaction(&self, _hash: H256) -> Result<Bytes> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn raw_receipts(&self, _block_id: BlockId) -> Result<Vec<Bytes>> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn bad_blocks(&self) -> Result<Vec<RichBlock>> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 }
 

--- a/crates/net/rpc/src/engine/mod.rs
+++ b/crates/net/rpc/src/engine/mod.rs
@@ -1,4 +1,4 @@
-use crate::result::rpc_err;
+use crate::result::{internal_rpc_err, rpc_err};
 use async_trait::async_trait;
 use jsonrpsee::core::{Error, RpcResult as Result};
 use reth_interfaces::consensus::ForkchoiceState;
@@ -54,7 +54,7 @@ impl EngineApiServer for EngineApi {
 
     /// See also <https://github.com/ethereum/execution-apis/blob/8db51dcd2f4bdfbd9ad6e4a7560aac97010ad063/src/engine/specification.md#engine_newpayloadv1>
     async fn new_payload_v2(&self, _payload: ExecutionPayload) -> Result<PayloadStatus> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     /// See also <https://github.com/ethereum/execution-apis/blob/8db51dcd2f4bdfbd9ad6e4a7560aac97010ad063/src/engine/specification.md#engine_forkchoiceUpdatedV1>
@@ -79,7 +79,7 @@ impl EngineApiServer for EngineApi {
         _fork_choice_state: ForkchoiceState,
         _payload_attributes: Option<PayloadAttributes>,
     ) -> Result<ForkchoiceUpdated> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     /// See also <https://github.com/ethereum/execution-apis/blob/8db51dcd2f4bdfbd9ad6e4a7560aac97010ad063/src/engine/specification.md#engine_getPayloadV1>
@@ -92,7 +92,7 @@ impl EngineApiServer for EngineApi {
 
     /// See also <https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#engine_getpayloadv2>
     async fn get_payload_v2(&self, _payload_id: H64) -> Result<ExecutionPayload> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     /// See also <https://github.com/ethereum/execution-apis/blob/8db51dcd2f4bdfbd9ad6e4a7560aac97010ad063/src/engine/specification.md#engine_exchangeTransitionConfigurationV1>

--- a/crates/net/rpc/src/eth/api/server.rs
+++ b/crates/net/rpc/src/eth/api/server.rs
@@ -1,7 +1,10 @@
 //! Implementation of the [`jsonrpsee`] generated [`reth_rpc_api::EthApiServer`] trait
 //! Handles RPC requests for the `eth_` namespace.
 
-use crate::{eth::api::EthApi, result::ToRpcResult};
+use crate::{
+    eth::api::EthApi,
+    result::{internal_rpc_err, ToRpcResult},
+};
 use jsonrpsee::core::RpcResult as Result;
 use reth_primitives::{
     rpc::{transaction::eip2930::AccessListWithGasUsed, BlockId},
@@ -31,15 +34,15 @@ where
     }
 
     fn syncing(&self) -> Result<SyncStatus> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn author(&self) -> Result<Address> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn accounts(&self) -> Result<Vec<Address>> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     fn block_number(&self) -> Result<U256> {
@@ -53,7 +56,7 @@ where
     }
 
     async fn block_by_hash(&self, _hash: H256, _full: bool) -> Result<Option<RichBlock>> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn block_by_number(
@@ -61,26 +64,26 @@ where
         _number: BlockNumber,
         _full: bool,
     ) -> Result<Option<RichBlock>> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn block_transaction_count_by_hash(&self, _hash: H256) -> Result<Option<U256>> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn block_transaction_count_by_number(
         &self,
         _number: BlockNumber,
     ) -> Result<Option<U256>> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn block_uncles_count_by_hash(&self, _hash: H256) -> Result<U256> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn block_uncles_count_by_number(&self, _number: BlockNumber) -> Result<U256> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn uncle_by_block_hash_and_index(
@@ -88,7 +91,7 @@ where
         _hash: H256,
         _index: Index,
     ) -> Result<Option<RichBlock>> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn uncle_by_block_number_and_index(
@@ -96,14 +99,14 @@ where
         _number: BlockNumber,
         _index: Index,
     ) -> Result<Option<RichBlock>> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn transaction_by_hash(
         &self,
         _hash: H256,
     ) -> Result<Option<reth_rpc_types::Transaction>> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn transaction_by_block_hash_and_index(
@@ -111,7 +114,7 @@ where
         _hash: H256,
         _index: Index,
     ) -> Result<Option<reth_rpc_types::Transaction>> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn transaction_by_block_number_and_index(
@@ -119,15 +122,15 @@ where
         _number: BlockNumber,
         _index: Index,
     ) -> Result<Option<reth_rpc_types::Transaction>> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn transaction_receipt(&self, _hash: H256) -> Result<Option<TransactionReceipt>> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn balance(&self, _address: Address, _block_number: Option<BlockId>) -> Result<U256> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn storage_at(
@@ -136,7 +139,7 @@ where
         _index: U256,
         _block_number: Option<BlockId>,
     ) -> Result<H256> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn transaction_count(
@@ -144,15 +147,15 @@ where
         _address: Address,
         _block_number: Option<BlockId>,
     ) -> Result<U256> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn get_code(&self, _address: Address, _block_number: Option<BlockId>) -> Result<Bytes> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn call(&self, _request: CallRequest, _block_number: Option<BlockId>) -> Result<Bytes> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn create_access_list(
@@ -160,7 +163,7 @@ where
         _request: CallRequest,
         _block_number: Option<BlockId>,
     ) -> Result<AccessListWithGasUsed> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn estimate_gas(
@@ -168,11 +171,11 @@ where
         _request: CallRequest,
         _block_number: Option<BlockId>,
     ) -> Result<U256> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn gas_price(&self) -> Result<U256> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn fee_history(
@@ -181,51 +184,51 @@ where
         _newest_block: BlockNumber,
         _reward_percentiles: Option<Vec<f64>>,
     ) -> Result<FeeHistory> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn max_priority_fee_per_gas(&self) -> Result<U256> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn is_mining(&self) -> Result<bool> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn hashrate(&self) -> Result<U256> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn get_work(&self) -> Result<Work> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn submit_hashrate(&self, _hashrate: U256, _id: H256) -> Result<bool> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn submit_work(&self, _nonce: H64, _pow_hash: H256, _mix_digest: H256) -> Result<bool> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn send_transaction(&self, _request: TransactionRequest) -> Result<H256> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn send_raw_transaction(&self, _bytes: Bytes) -> Result<H256> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn sign(&self, _address: Address, _message: Bytes) -> Result<Bytes> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn sign_transaction(&self, _transaction: CallRequest) -> Result<Bytes> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn sign_typed_data(&self, _address: Address, _data: Value) -> Result<Bytes> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn get_proof(
@@ -234,6 +237,6 @@ where
         _keys: Vec<H256>,
         _block_number: Option<BlockId>,
     ) -> Result<EIP1186AccountProofResponse> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 }

--- a/crates/net/rpc/src/trace.rs
+++ b/crates/net/rpc/src/trace.rs
@@ -1,3 +1,4 @@
+use crate::result::internal_rpc_err;
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult as Result;
 use reth_primitives::{rpc::BlockId, Bytes, H256};
@@ -22,7 +23,7 @@ impl TraceApiServer for TraceApi {
         _trace_types: HashSet<TraceType>,
         _block_id: Option<BlockId>,
     ) -> Result<TraceResults> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn call_many(
@@ -30,7 +31,7 @@ impl TraceApiServer for TraceApi {
         _calls: Vec<(CallRequest, HashSet<TraceType>)>,
         _block_id: Option<BlockId>,
     ) -> Result<Vec<TraceResults>> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn raw_transaction(
@@ -39,7 +40,7 @@ impl TraceApiServer for TraceApi {
         _trace_types: HashSet<TraceType>,
         _block_id: Option<BlockId>,
     ) -> Result<TraceResults> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn replay_block_transactions(
@@ -47,7 +48,7 @@ impl TraceApiServer for TraceApi {
         _block_id: BlockId,
         _trace_types: HashSet<TraceType>,
     ) -> Result<Option<Vec<TraceResultsWithTransactionHash>>> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn replay_transaction(
@@ -55,15 +56,15 @@ impl TraceApiServer for TraceApi {
         _transaction: H256,
         _trace_types: HashSet<TraceType>,
     ) -> Result<TraceResults> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn block(&self, _block_id: BlockId) -> Result<Option<Vec<LocalizedTransactionTrace>>> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn filter(&self, _filter: TraceFilter) -> Result<Vec<LocalizedTransactionTrace>> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     fn trace(
@@ -71,11 +72,11 @@ impl TraceApiServer for TraceApi {
         _hash: H256,
         _indices: Vec<Index>,
     ) -> Result<Option<LocalizedTransactionTrace>> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     fn transaction_traces(&self, _hash: H256) -> Result<Option<Vec<LocalizedTransactionTrace>>> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 }
 


### PR DESCRIPTION
Closes #1106

### Motivation
> don't want the node to panic if an umimplemented handler is called