### PR TITLE
feat: implement headers for FileClient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4142,6 +4142,7 @@ name = "reth-downloaders"
 version = "0.1.0"
 dependencies = [
  "assert_matches",
+ "bytes",
  "futures",
  "futures-util",
  "metrics",
@@ -4157,6 +4158,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tokio-util 0.7.4",
  "tracing",
 ]
 

--- a/crates/net/downloaders/Cargo.toml
+++ b/crates/net/downloaders/Cargo.toml
@@ -30,6 +30,7 @@ thiserror = { version = "1", optional = true }
 reth-rlp = { path = "../../rlp", optional = true }
 tokio-util = { version = "0.7", features = ["codec"], optional = true }
 bytes = { version = "1", optional = true }
+tempfile = { version = "3.3", optional = true }
 
 [dev-dependencies]
 reth-db = { path = "../../storage/db", features = ["test-utils"] }
@@ -46,4 +47,4 @@ thiserror = "1"
 tempfile = "3.3"
 
 [features]
-test-utils = ["dep:reth-rlp", "dep:thiserror", "dep:tokio-util"]
+test-utils = ["dep:reth-rlp", "dep:thiserror", "dep:tokio-util", "dep:tempfile"]

--- a/crates/net/downloaders/Cargo.toml
+++ b/crates/net/downloaders/Cargo.toml
@@ -28,6 +28,8 @@ metrics = "0.20.1"
 
 thiserror = { version = "1", optional = true }
 reth-rlp = { path = "../../rlp", optional = true }
+tokio-util = { version = "0.7", features = ["codec"], optional = true }
+bytes = { version = "1", optional = true }
 
 [dev-dependencies]
 reth-db = { path = "../../storage/db", features = ["test-utils"] }
@@ -36,10 +38,12 @@ reth-tracing = { path = "../../tracing" }
 
 assert_matches = "1.5.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio-util = { version = "0.7", features = ["codec"] }
 reth-rlp = { path = "../../rlp" }
+bytes = "1"
 
 thiserror = "1"
 tempfile = "3.3"
 
 [features]
-test-utils = ["dep:reth-rlp", "dep:thiserror"]
+test-utils = ["dep:reth-rlp", "dep:thiserror", "dep:tokio-util"]

--- a/crates/net/downloaders/src/bodies/mod.rs
+++ b/crates/net/downloaders/src/bodies/mod.rs
@@ -8,5 +8,5 @@ pub mod task;
 mod queue;
 mod request;
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;

--- a/crates/net/downloaders/src/bodies/test_utils.rs
+++ b/crates/net/downloaders/src/bodies/test_utils.rs
@@ -1,3 +1,5 @@
+#![allow(unused)]
+//! Test helper impls for generating bodies
 use reth_db::{
     database::Database,
     mdbx::{Env, WriteMap},

--- a/crates/net/downloaders/src/bodies/test_utils.rs
+++ b/crates/net/downloaders/src/bodies/test_utils.rs
@@ -4,7 +4,7 @@ use reth_db::{
     tables,
     transaction::DbTxMut,
 };
-use reth_eth_wire::BlockBody;
+use reth_eth_wire::{BlockBody, RawBlockBody};
 use reth_interfaces::{db, p2p::bodies::response::BlockResponse};
 use reth_primitives::{SealedBlock, SealedHeader, H256};
 use std::collections::HashMap;
@@ -26,6 +26,19 @@ pub(crate) fn zip_blocks<'a>(
                     ommers: body.ommers.into_iter().map(|o| o.seal()).collect(),
                 })
             }
+        })
+        .collect()
+}
+
+pub(crate) fn create_raw_bodies<'a>(
+    headers: impl Iterator<Item = &'a SealedHeader>,
+    bodies: &mut HashMap<H256, BlockBody>,
+) -> Vec<RawBlockBody> {
+    headers
+        .into_iter()
+        .map(|header| {
+            let body = bodies.remove(&header.hash()).expect("body exists");
+            body.create_block(header)
         })
         .collect()
 }

--- a/crates/net/downloaders/src/headers/mod.rs
+++ b/crates/net/downloaders/src/headers/mod.rs
@@ -4,5 +4,5 @@ pub mod reverse_headers;
 /// A downloader implementation that spawns a downloader to a task
 pub mod task;
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;

--- a/crates/net/downloaders/src/headers/mod.rs
+++ b/crates/net/downloaders/src/headers/mod.rs
@@ -5,4 +5,4 @@ pub mod reverse_headers;
 pub mod task;
 
 #[cfg(test)]
-mod test_utils;
+pub mod test_utils;

--- a/crates/net/downloaders/src/headers/test_utils.rs
+++ b/crates/net/downloaders/src/headers/test_utils.rs
@@ -1,3 +1,5 @@
+#![allow(unused)]
+//! Test helper impls for generating bodies
 use reth_primitives::SealedHeader;
 
 /// Returns a new [SealedHeader] that's the child header of the given `parent`.

--- a/crates/net/downloaders/src/test_utils/file_client.rs
+++ b/crates/net/downloaders/src/test_utils/file_client.rs
@@ -41,6 +41,8 @@ use tracing::warn;
 ///
 /// Blocks are assumed to have populated transactions, so reading headers will also buffer
 /// transactions in memory for use in the bodies stage.
+///
+/// This reads the entire file into memory, so it is not suitable for large files.
 #[derive(Debug)]
 pub struct FileClient {
     /// The buffered headers retrieved when fetching new bodies.
@@ -89,7 +91,7 @@ impl FileClient {
         let mut hash_to_number = HashMap::new();
         let mut bodies = HashMap::new();
 
-        // use with_capacity to make sure the buffer contains the entire file
+        // use with_capacity to make sure the internal buffer contains the entire file
         let mut stream = FramedRead::with_capacity(&reader[..], BlockFileCodec, file_len as usize);
 
         let mut block_num = 0;

--- a/crates/net/downloaders/src/test_utils/file_client.rs
+++ b/crates/net/downloaders/src/test_utils/file_client.rs
@@ -30,6 +30,7 @@ use tokio::{
 };
 use tokio_stream::StreamExt;
 use tokio_util::codec::FramedRead;
+use tracing::warn;
 
 use super::file_codec::BlockFileCodec;
 
@@ -187,7 +188,7 @@ impl BodiesClient for FileClient {
 
 impl DownloadClient for FileClient {
     fn report_bad_message(&self, _peer_id: PeerId) {
-        panic!("Reported a bad message on a file client, the file may be corrupted or invalid");
+        warn!("Reported a bad message on a file client, the file may be corrupted or invalid");
         // noop
     }
 

--- a/crates/net/downloaders/src/test_utils/file_client.rs
+++ b/crates/net/downloaders/src/test_utils/file_client.rs
@@ -158,7 +158,7 @@ impl HeadersClient for FileClient {
             }
         }
 
-        Box::pin(async move { Ok((PeerId::default(), headers.into()).into()) })
+        Box::pin(async move { Ok((PeerId::default(), headers).into()) })
     }
 }
 

--- a/crates/net/downloaders/src/test_utils/file_codec.rs
+++ b/crates/net/downloaders/src/test_utils/file_codec.rs
@@ -6,6 +6,18 @@ use reth_rlp::{Decodable, Encodable};
 use tokio_util::codec::{Decoder, Encoder};
 
 /// Codec for reading raw block bodies from a file.
+///
+/// If using with [`FramedRead`](tokio_util::codec::FramedRead), the user should make sure the
+/// framed reader has capacity for the entire block file. Otherwise, the decoder will return
+/// [`InputTooShort`](reth_rlp::DecodeError::InputTooShort), because RLP headers can only be
+/// decoded if the internal buffer is large enough to contain the entire block body.
+///
+/// Without ensuring the framed reader has capacity for the entire file, a block body is likely to
+/// fall across two read buffers, the decoder will not be able to decode the header, which will
+/// cause it to fail.
+///
+/// It's recommended to use [`with_capacity`](tokio_util::codec::FramedRead::with_capacity) to set
+/// the capacity of the framed reader to the size of the file.
 pub(crate) struct BlockFileCodec;
 
 impl Decoder for BlockFileCodec {

--- a/crates/net/downloaders/src/test_utils/file_codec.rs
+++ b/crates/net/downloaders/src/test_utils/file_codec.rs
@@ -1,10 +1,9 @@
 //! Codec for reading raw block bodies from a file.
+use super::FileClientError;
 use bytes::{Buf, BytesMut};
 use reth_eth_wire::RawBlockBody;
 use reth_rlp::{Decodable, Encodable};
 use tokio_util::codec::{Decoder, Encoder};
-
-use super::FileClientError;
 
 /// Codec for reading raw block bodies from a file.
 pub(crate) struct BlockFileCodec;

--- a/crates/net/downloaders/src/test_utils/file_codec.rs
+++ b/crates/net/downloaders/src/test_utils/file_codec.rs
@@ -1,0 +1,34 @@
+//! Codec for reading raw block bodies from a file.
+use bytes::{Buf, BytesMut};
+use reth_eth_wire::RawBlockBody;
+use reth_rlp::{Decodable, Encodable};
+use tokio_util::codec::{Decoder, Encoder};
+
+use super::FileClientError;
+
+/// Codec for reading raw block bodies from a file.
+pub(crate) struct BlockFileCodec;
+
+impl Decoder for BlockFileCodec {
+    type Item = RawBlockBody;
+    type Error = FileClientError;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        if src.is_empty() {
+            return Ok(None)
+        }
+        let mut buf_slice = &mut src.as_ref();
+        let body = RawBlockBody::decode(buf_slice)?;
+        src.advance(src.len() - buf_slice.len());
+        Ok(Some(body))
+    }
+}
+
+impl Encoder<RawBlockBody> for BlockFileCodec {
+    type Error = FileClientError;
+
+    fn encode(&mut self, item: RawBlockBody, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        item.encode(dst);
+        Ok(())
+    }
+}

--- a/crates/net/downloaders/src/test_utils/mod.rs
+++ b/crates/net/downloaders/src/test_utils/mod.rs
@@ -1,9 +1,16 @@
 #![allow(unused)]
 //! Test helper impls
+use crate::bodies::test_utils::create_raw_bodies;
+use futures::SinkExt;
 use reth_eth_wire::BlockBody;
 use reth_interfaces::test_utils::generators::random_block_range;
 use reth_primitives::{SealedHeader, H256};
-use std::collections::HashMap;
+use std::{collections::HashMap, io::SeekFrom};
+use tokio::{
+    fs::File,
+    io::{AsyncSeekExt, AsyncWriteExt, BufWriter},
+};
+use tokio_util::codec::FramedWrite;
 
 /// Metrics scope used for testing.
 pub(crate) const TEST_SCOPE: &str = "downloaders.test";
@@ -31,9 +38,32 @@ pub(crate) fn generate_bodies(
     (headers, bodies)
 }
 
+/// Generate a set of bodies, write them to a temporary file, and return the file along with the
+/// bodies and corresponding block hashes
+pub(crate) async fn generate_bodies_file(
+    rng: std::ops::Range<u64>,
+) -> (tokio::fs::File, Vec<SealedHeader>, HashMap<H256, BlockBody>) {
+    let (headers, mut bodies) = generate_bodies(0..20);
+    let raw_block_bodies = create_raw_bodies(headers.clone().iter(), &mut bodies.clone());
+
+    let mut file: File = tempfile::tempfile().unwrap().into();
+    let mut writer = FramedWrite::new(file, BlockFileCodec);
+
+    // rlp encode one after the other
+    for block in raw_block_bodies {
+        writer.send(block).await.unwrap();
+    }
+
+    // get the file back
+    let mut file: File = writer.into_inner();
+    file.seek(SeekFrom::Start(0)).await.unwrap();
+    (file, headers, bodies)
+}
+
 mod file_client;
 mod file_codec;
 mod test_client;
 
 pub use file_client::{FileClient, FileClientError};
+pub(crate) use file_codec::BlockFileCodec;
 pub use test_client::TestBodiesClient;

--- a/crates/net/downloaders/src/test_utils/mod.rs
+++ b/crates/net/downloaders/src/test_utils/mod.rs
@@ -32,6 +32,7 @@ pub(crate) fn generate_bodies(
 }
 
 mod file_client;
+mod file_codec;
 mod test_client;
 
 pub use file_client::{FileClient, FileClientError};


### PR DESCRIPTION
builds on #1111

Fairly rough draft for the rest of `FileClient`, which:
 * loads blocks from a file
 * implements `BodiesClient`
 * implements `HeadersClient`

This also adds tests that write to a temp file, passing it to the `FileClient` to initialize. These tests then spin up headers and bodies clients, making sure the returned values match the headers and bodies generated.

Would appreciate review on loading from a file - RLP header decoding expects that we have a buffer containing the entire rlp object. When loading from a file, we currently get around this with an `unsafe` workaround, so we can obtain the payload length and read the rest of the rlp object from the file. It would be nice to get rid of unsafe here and generally find a cleaner way to do this.