### PR TITLE
perf(net): use qualified types for headers client future

### DIFF
--- a/bin/reth/src/p2p/mod.rs
+++ b/bin/reth/src/p2p/mod.rs
@@ -168,14 +168,14 @@ impl Command {
 
         let (_, response) = client.get_headers(request).await?.split();
 
-        if response.0.len() != 1 {
+        if response.len() != 1 {
             eyre::bail!(
                 "Invalid number of headers received. Expected: 1. Received: {}",
-                response.0.len()
+                response.len()
             )
         }
 
-        let header = response.0.into_iter().next().unwrap().seal();
+        let header = response.into_iter().next().unwrap().seal();
 
         let valid = match id {
             BlockHashOrNumber::Hash(hash) => header.hash() == hash,

--- a/crates/interfaces/src/p2p/headers/client.rs
+++ b/crates/interfaces/src/p2p/headers/client.rs
@@ -1,7 +1,7 @@
 use crate::p2p::{download::DownloadClient, error::PeerRequestResult, priority::Priority};
 use futures::Future;
 pub use reth_eth_wire::BlockHeaders;
-use reth_primitives::{BlockHashOrNumber, HeadersDirection, H256, U256};
+use reth_primitives::{BlockHashOrNumber, Header, HeadersDirection, H256, U256};
 use std::{fmt::Debug, pin::Pin};
 
 /// The header request struct to be sent to connected peers, which
@@ -17,13 +17,13 @@ pub struct HeadersRequest {
 }
 
 /// The headers future type
-pub type HeadersFut = Pin<Box<dyn Future<Output = PeerRequestResult<BlockHeaders>> + Send + Sync>>;
+pub type HeadersFut = Pin<Box<dyn Future<Output = PeerRequestResult<Vec<Header>>> + Send + Sync>>;
 
 /// The block headers downloader client
 #[auto_impl::auto_impl(&, Arc, Box)]
 pub trait HeadersClient: DownloadClient {
     /// The headers type
-    type Output: Future<Output = PeerRequestResult<BlockHeaders>> + Sync + Send + Unpin;
+    type Output: Future<Output = PeerRequestResult<Vec<Header>>> + Sync + Send + Unpin;
 
     /// Sends the header request to the p2p network and returns the header response received from a
     /// peer.
@@ -31,7 +31,7 @@ pub trait HeadersClient: DownloadClient {
         self.get_headers_with_priority(request, Priority::Normal)
     }
 
-    /// Sends the header request to the p2p network with priroity set and returns the header
+    /// Sends the header request to the p2p network with priority set and returns the header
     /// response received from a peer.
     fn get_headers_with_priority(
         &self,

--- a/crates/net/downloaders/src/headers/reverse_headers.rs
+++ b/crates/net/downloaders/src/headers/reverse_headers.rs
@@ -8,7 +8,7 @@ use reth_interfaces::{
     p2p::{
         error::{DownloadError, DownloadResult, PeerRequestResult},
         headers::{
-            client::{BlockHeaders, HeadersClient, HeadersRequest},
+            client::{HeadersClient, HeadersRequest},
             downloader::{validate_header_download, HeaderDownloader, SyncTarget},
         },
         priority::Priority,
@@ -279,8 +279,7 @@ where
         let HeadersRequestOutcome { request, outcome } = response;
         match outcome {
             Ok(res) => {
-                let (peer_id, headers) = res.split();
-                let mut headers = headers.0;
+                let (peer_id, mut headers) = res.split();
 
                 // update total downloaded metric
                 self.metrics.total_downloaded.increment(headers.len() as u64);
@@ -337,8 +336,7 @@ where
 
         match outcome {
             Ok(res) => {
-                let (peer_id, headers) = res.split();
-                let mut headers = headers.0;
+                let (peer_id, mut headers) = res.split();
 
                 // update total downloaded metric
                 self.metrics.total_downloaded.increment(headers.len() as u64);
@@ -693,7 +691,7 @@ where
     }
 }
 
-/// A future that returns a list of [`BlockHeaders`] on success.
+/// A future that returns a list of [`Header`] on success.
 struct HeadersRequestFuture<F> {
     request: Option<HeadersRequest>,
     fut: F,
@@ -701,7 +699,7 @@ struct HeadersRequestFuture<F> {
 
 impl<F> Future for HeadersRequestFuture<F>
 where
-    F: Future<Output = PeerRequestResult<BlockHeaders>> + Sync + Send + Unpin,
+    F: Future<Output = PeerRequestResult<Vec<Header>>> + Sync + Send + Unpin,
 {
     type Output = HeadersRequestOutcome;
 
@@ -717,7 +715,7 @@ where
 /// The outcome of the [HeadersRequestFuture]
 struct HeadersRequestOutcome {
     request: HeadersRequest,
-    outcome: PeerRequestResult<BlockHeaders>,
+    outcome: PeerRequestResult<Vec<Header>>,
 }
 
 // === impl OrderedHeadersResponse ===

--- a/crates/net/network/tests/it/requests.rs
+++ b/crates/net/network/tests/it/requests.rs
@@ -115,7 +115,7 @@ async fn test_get_header() {
         let res = fetch0.get_headers(req).await;
         assert!(res.is_ok(), "{res:?}");
 
-        let headers = res.unwrap().1 .0;
+        let headers = res.unwrap().1;
         assert_eq!(headers.len(), 1);
         assert_eq!(headers[0], header);
     }


### PR DESCRIPTION
replaces `Pin<Box<Future` with `Either`.

also replaces response type `BlockHeaders` with `Vec<Header>` cc @Rjected 