### PR TITLE
feat(rpc): add EthSigner trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4551,6 +4551,7 @@ dependencies = [
  "reth-rpc-engine-api",
  "reth-rpc-types",
  "reth-transaction-pool",
+ "secp256k1 0.24.3",
  "serde",
  "serde_json",
  "thiserror",

--- a/crates/net/rpc/Cargo.toml
+++ b/crates/net/rpc/Cargo.toml
@@ -27,6 +27,11 @@ async-trait = "0.1"
 tokio = { version = "1", features = ["sync"] }
 
 # misc
+secp256k1 = { version = "0.24", features = [
+    "global-context",
+    "rand-std",
+    "recovery",
+] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"

--- a/crates/net/rpc/src/eth/api/mod.rs
+++ b/crates/net/rpc/src/eth/api/mod.rs
@@ -1,5 +1,6 @@
 //! Provides everything related to `eth_` namespace
 
+use crate::eth::signer::EthSigner;
 use async_trait::async_trait;
 use reth_interfaces::Result;
 use reth_network_api::NetworkInfo;
@@ -34,7 +35,8 @@ pub trait EthApiSpec: Send + Sync {
 /// are implemented separately in submodules. The rpc handler implementation can then delegate to
 /// the main impls. This way [`EthApi`] is not limited to [`jsonrpsee`] and can be used standalone
 /// or in other network handlers (for example ipc).
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[allow(missing_debug_implementations)]
 pub struct EthApi<Pool, Client, Network> {
     /// All nested fields bundled together.
     inner: Arc<EthApiInner<Pool, Client, Network>>,
@@ -48,7 +50,7 @@ where
 {
     /// Creates a new, shareable instance.
     pub fn new(client: Arc<Client>, pool: Pool, network: Network) -> Self {
-        let inner = EthApiInner { client, pool, network };
+        let inner = EthApiInner { client, pool, network, signers: vec![] };
         Self { inner: Arc::new(inner) }
     }
 
@@ -90,7 +92,6 @@ where
 }
 
 /// Container type `EthApi`
-#[derive(Debug)]
 struct EthApiInner<Pool, Client, Network> {
     /// The transaction pool.
     pool: Pool,
@@ -98,4 +99,6 @@ struct EthApiInner<Pool, Client, Network> {
     client: Arc<Client>,
     /// An interface to interact with the network
     network: Network,
+    /// All configured Signers
+    signers: Vec<Box<dyn EthSigner>>,
 }

--- a/crates/net/rpc/src/eth/api/mod.rs
+++ b/crates/net/rpc/src/eth/api/mod.rs
@@ -50,7 +50,7 @@ where
 {
     /// Creates a new, shareable instance.
     pub fn new(client: Arc<Client>, pool: Pool, network: Network) -> Self {
-        let inner = EthApiInner { client, pool, network, signers: vec![] };
+        let inner = EthApiInner { client, pool, network, signers: Default::default() };
         Self { inner: Arc::new(inner) }
     }
 

--- a/crates/net/rpc/src/eth/mod.rs
+++ b/crates/net/rpc/src/eth/mod.rs
@@ -2,6 +2,7 @@
 
 mod api;
 mod pubsub;
+mod signer;
 
 pub use api::{EthApi, EthApiSpec};
 pub use pubsub::EthPubSub;

--- a/crates/net/rpc/src/eth/signer.rs
+++ b/crates/net/rpc/src/eth/signer.rs
@@ -1,0 +1,58 @@
+//! An abstraction over ethereum signers.
+
+use jsonrpsee::core::RpcResult as Result;
+use reth_primitives::{Address, Signature, TransactionSigned};
+use reth_rpc_types::TypedTransactionRequest;
+use secp256k1::SecretKey;
+use std::collections::HashMap;
+
+/// An Ethereum Signer used via RPC.
+#[async_trait::async_trait]
+pub(crate) trait EthSigner: Send + Sync {
+    /// Returns the available accounts for this signer.
+    fn accounts(&self) -> Vec<Address>;
+
+    /// Returns `true` whether this signer can sign for this address
+    fn is_signer_for(&self, addr: Address) -> bool {
+        self.accounts().contains(&addr)
+    }
+
+    /// Returns the signature
+    async fn sign(&self, address: Address, message: &[u8]) -> Result<Signature>;
+
+    /// signs a transaction request using the given account in request
+    fn sign_transaction(
+        &self,
+        request: TypedTransactionRequest,
+        address: &Address,
+    ) -> Result<TransactionSigned>;
+}
+
+/// Holds developer keys
+pub(crate) struct DevSigner {
+    addresses: Vec<Address>,
+    accounts: HashMap<Address, SecretKey>,
+}
+
+#[async_trait::async_trait]
+impl EthSigner for DevSigner {
+    fn accounts(&self) -> Vec<Address> {
+        self.addresses.clone()
+    }
+
+    fn is_signer_for(&self, addr: Address) -> bool {
+        self.accounts.contains_key(&addr)
+    }
+
+    async fn sign(&self, _address: Address, _message: &[u8]) -> Result<Signature> {
+        todo!()
+    }
+
+    fn sign_transaction(
+        &self,
+        _request: TypedTransactionRequest,
+        _address: &Address,
+    ) -> Result<TransactionSigned> {
+        todo!()
+    }
+}

--- a/crates/net/rpc/src/eth/signer.rs
+++ b/crates/net/rpc/src/eth/signer.rs
@@ -13,8 +13,8 @@ pub(crate) trait EthSigner: Send + Sync {
     fn accounts(&self) -> Vec<Address>;
 
     /// Returns `true` whether this signer can sign for this address
-    fn is_signer_for(&self, addr: Address) -> bool {
-        self.accounts().contains(&addr)
+    fn is_signer_for(&self, addr: &Address) -> bool {
+        self.accounts().contains(addr)
     }
 
     /// Returns the signature
@@ -40,8 +40,8 @@ impl EthSigner for DevSigner {
         self.addresses.clone()
     }
 
-    fn is_signer_for(&self, addr: Address) -> bool {
-        self.accounts.contains_key(&addr)
+    fn is_signer_for(&self, addr: &Address) -> bool {
+        self.accounts.contains_key(addr)
     }
 
     async fn sign(&self, _address: Address, _message: &[u8]) -> Result<Signature> {


### PR DESCRIPTION
Adds `EthSigner` abstraction. 

This will be used for all sign related RPC calls and for signing `eth_sendTransaction` requests.