### PR TITLE
feat(rpc): impl send_raw_transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4547,6 +4547,7 @@ dependencies = [
  "reth-network-api",
  "reth-primitives",
  "reth-provider",
+ "reth-rlp",
  "reth-rpc-api",
  "reth-rpc-engine-api",
  "reth-rpc-types",

--- a/crates/net/rpc/Cargo.toml
+++ b/crates/net/rpc/Cargo.toml
@@ -13,6 +13,7 @@ Reth RPC implementation
 reth-interfaces = { path = "../../interfaces" }
 reth-primitives = { path = "../../primitives" }
 reth-rpc-api = { path = "../rpc-api" }
+reth-rlp = { path = "../../common/rlp" }
 reth-rpc-types = { path = "../rpc-types" }
 reth-provider = { path = "../../storage/provider" }
 reth-transaction-pool = { path = "../../transaction-pool" }

--- a/crates/net/rpc/src/eth/api/mod.rs
+++ b/crates/net/rpc/src/eth/api/mod.rs
@@ -1,4 +1,7 @@
 //! Provides everything related to `eth_` namespace
+//!
+//! The entire implementation of the namespace is quite large, hence it is divided across several
+//! files.
 
 use async_trait::async_trait;
 use reth_interfaces::Result;
@@ -10,6 +13,7 @@ use reth_transaction_pool::TransactionPool;
 use std::sync::Arc;
 
 mod server;
+mod transactions;
 
 /// `Eth` API trait.
 ///
@@ -40,12 +44,7 @@ pub struct EthApi<Pool, Client, Network> {
     inner: Arc<EthApiInner<Pool, Client, Network>>,
 }
 
-impl<Pool, Client, Network> EthApi<Pool, Client, Network>
-where
-    Pool: TransactionPool + 'static,
-    Client: BlockProvider + StateProviderFactory + 'static,
-    Network: NetworkInfo,
-{
+impl<Pool, Client, Network> EthApi<Pool, Client, Network> {
     /// Creates a new, shareable instance.
     pub fn new(client: Arc<Client>, pool: Pool, network: Network) -> Self {
         let inner = EthApiInner { client, pool, network };
@@ -53,13 +52,18 @@ where
     }
 
     /// Returns the inner `Client`
-    fn client(&self) -> &Arc<Client> {
+    pub(crate) fn client(&self) -> &Arc<Client> {
         &self.inner.client
     }
 
     /// Returns the inner `Network`
-    fn network(&self) -> &Network {
+    pub(crate) fn network(&self) -> &Network {
         &self.inner.network
+    }
+
+    /// Returns the inner `Pool`
+    pub(crate) fn pool(&self) -> &Pool {
+        &self.inner.pool
     }
 }
 

--- a/crates/net/rpc/src/eth/api/server.rs
+++ b/crates/net/rpc/src/eth/api/server.rs
@@ -215,8 +215,8 @@ where
         Err(internal_rpc_err("unimplemented"))
     }
 
-    async fn send_raw_transaction(&self, _bytes: Bytes) -> Result<H256> {
-        Err(internal_rpc_err("unimplemented"))
+    async fn send_raw_transaction(&self, tx: Bytes) -> Result<H256> {
+        EthApi::send_raw_transaction(self, tx).await.to_rpc_result()
     }
 
     async fn sign(&self, _address: Address, _message: Bytes) -> Result<Bytes> {

--- a/crates/net/rpc/src/eth/api/transactions.rs
+++ b/crates/net/rpc/src/eth/api/transactions.rs
@@ -1,0 +1,45 @@
+//! Contains RPC handler implementations specific to transactions
+
+use crate::{
+    eth::error::{EthApiError, EthResult},
+    EthApi,
+};
+use reth_primitives::{Bytes, FromRecoveredTransaction, TransactionSigned, H256};
+use reth_provider::{BlockProvider, StateProviderFactory};
+use reth_rlp::Decodable;
+use reth_rpc_types::TransactionRequest;
+use reth_transaction_pool::{TransactionOrigin, TransactionPool};
+
+impl<Pool, Client, Network> EthApi<Pool, Client, Network>
+where
+    Pool: TransactionPool + 'static,
+    Client: BlockProvider + StateProviderFactory + 'static,
+    Network: 'static,
+{
+    pub(crate) async fn send_transaction(&self, _request: TransactionRequest) -> EthResult<H256> {
+        unimplemented!()
+    }
+
+    /// Decodes and recovers the transaction and submits it to the pool.
+    ///
+    /// Returns the hash of the transaction.
+    pub(crate) async fn send_raw_transaction(&self, tx: Bytes) -> EthResult<H256> {
+        let mut data = tx.as_ref();
+        if data.is_empty() {
+            return Err(EthApiError::EmptyRawTransactionData)
+        }
+
+        let transaction = TransactionSigned::decode(&mut data)
+            .map_err(|_| EthApiError::FailedToDecodeSignedTransaction)?;
+
+        let recovered =
+            transaction.into_ecrecovered().ok_or(EthApiError::InvalidTransactionSignature)?;
+
+        let pool_transaction = <Pool::Transaction>::from_recovered_transaction(recovered);
+
+        // submit the transaction to the pool with a `Local` origin
+        let hash = self.pool().add_transaction(TransactionOrigin::Local, pool_transaction).await?;
+
+        Ok(hash)
+    }
+}

--- a/crates/net/rpc/src/eth/error.rs
+++ b/crates/net/rpc/src/eth/error.rs
@@ -1,0 +1,36 @@
+//! Error variants for the `eth_` namespace.
+
+use crate::{impl_to_rpc_result, result::ToRpcResult};
+use reth_transaction_pool::error::PoolError;
+
+/// Result alias
+pub(crate) type EthResult<T> = Result<T, EthApiError>;
+
+/// Errors that can occur when interacting with the `eth_` namespace
+#[derive(Debug, thiserror::Error)]
+#[allow(missing_docs)]
+pub(crate) enum EthApiError {
+    /// When a raw transaction is empty
+    #[error("Empty transaction data")]
+    EmptyRawTransactionData,
+    #[error("Failed to decode signed transaction")]
+    FailedToDecodeSignedTransaction,
+    #[error("Invalid transaction signature")]
+    InvalidTransactionSignature,
+    #[error(transparent)]
+    PoolError(GethCompatPoolError),
+}
+
+impl_to_rpc_result!(EthApiError);
+
+/// A helper error type that ensures error messages are compatible with `geth`
+// TODO: replace thiserror with custom convert
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub(crate) struct GethCompatPoolError(PoolError);
+
+impl From<PoolError> for EthApiError {
+    fn from(err: PoolError) -> Self {
+        EthApiError::PoolError(GethCompatPoolError(err))
+    }
+}

--- a/crates/net/rpc/src/eth/mod.rs
+++ b/crates/net/rpc/src/eth/mod.rs
@@ -1,6 +1,7 @@
 //! `eth` namespace handler implementation.
 
 mod api;
+pub(crate) mod error;
 mod pubsub;
 
 pub use api::{EthApi, EthApiSpec};

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -678,6 +678,8 @@ impl TransactionSigned {
     }
 
     /// Devour Self, recover signer and return [`TransactionSignedEcRecovered`]
+    ///
+    /// Returns `None` if the transaction's signature is invalid.
     pub fn into_ecrecovered(self) -> Option<TransactionSignedEcRecovered> {
         let signer = self.recover_signer()?;
         Some(TransactionSignedEcRecovered { signed_transaction: self, signer })


### PR DESCRIPTION
Implements `eth_sendRawTransaction` handler

1. decode transaction
2. recover
3. submit to pool

This adds internal error types that are used as a more meaningful representation before they are converted into an RPC error.