### PR TITLE
fix: missing hashed storage entries

### DIFF
--- a/crates/interfaces/src/test_utils/generators.rs
+++ b/crates/interfaces/src/test_utils/generators.rs
@@ -182,6 +182,19 @@ pub fn random_eoa_account_range(acc_range: &mut std::ops::Range<u64>) -> Vec<(Ad
     accounts
 }
 
+/// Generate random Contract Accounts
+pub fn random_contract_account_range(
+    acc_range: &mut std::ops::Range<u64>,
+) -> Vec<(Address, Account)> {
+    let mut accounts = Vec::with_capacity(acc_range.end.saturating_sub(acc_range.start) as usize);
+    for _ in acc_range {
+        let (address, eoa_account) = random_eoa_account();
+        let account = Account { bytecode_hash: Some(H256::random()), ..eoa_account };
+        accounts.push((address, account))
+    }
+    accounts
+}
+
 #[cfg(test)]
 mod test {
     use std::str::FromStr;

--- a/crates/stages/src/stages/hashing_account.rs
+++ b/crates/stages/src/stages/hashing_account.rs
@@ -183,7 +183,7 @@ mod tests {
     stage_test_suite_ext!(AccountHashingTestRunner, account_hashing);
 
     #[tokio::test]
-    async fn execute_below_clean_threshold() {
+    async fn execute_clean_account_hashing() {
         let (previous_stage, stage_progress) = (20, 10);
         // Set up the runner
         let mut runner = AccountHashingTestRunner::default();


### PR DESCRIPTION
Found it while working on https://github.com/paradigmxyz/reth/pull/994

Some entries were missing from `HashedStorage`. Turns out we were inserting them into a `BTreeMap`, while using the `Account`'s `Address` as key. As the same `Address` can have multiple `StorageEntry`s, these were treated as duplicates, leaving Accounts with missing storage entries.