### PR TITLE
fix: add bytes to downloader test_utils deps

### DIFF
--- a/crates/net/downloaders/Cargo.toml
+++ b/crates/net/downloaders/Cargo.toml
@@ -26,6 +26,7 @@ tokio-stream = "0.1"
 tracing = "0.1.37"
 metrics = "0.20.1"
 
+# optional deps for the test-utils feature
 thiserror = { version = "1", optional = true }
 reth-rlp = { path = "../../rlp", optional = true }
 tokio-util = { version = "0.7", features = ["codec"], optional = true }
@@ -47,4 +48,4 @@ thiserror = "1"
 tempfile = "3.3"
 
 [features]
-test-utils = ["dep:reth-rlp", "dep:thiserror", "dep:tokio-util", "dep:tempfile"]
+test-utils = ["dep:reth-rlp", "dep:thiserror", "dep:tokio-util", "dep:tempfile", "dep:bytes"]


### PR DESCRIPTION
Importing `reth-downloaders` and using the `test-utils` features previously would not compile because `bytes` was not added as a feature dependency. This adds `bytes` to the `test-utils` dep, allowing the feature to be used elsewhere.

To reproduce: `cargo check --features test-utils -p reth-downloaders`