### PR TITLE
chore(net): support multiple eth protocol versions.

### DIFF
--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -817,6 +817,9 @@ async fn authenticate_stream(
     };
 
     // if the hello handshake was successful we can try status handshake
+    //
+    // Before trying status handshake, set up the version to shared_capability
+    let status = Status { version: p2p_stream.shared_capability().version(), ..status };
     let eth_unauthed = UnauthedEthStream::new(p2p_stream);
     let (eth_stream, their_status) = match eth_unauthed.handshake(status, fork_filter).await {
         Ok(stream_res) => stream_res,

--- a/crates/net/network/tests/it/main.rs
+++ b/crates/net/network/tests/it/main.rs
@@ -1,4 +1,5 @@
 mod connect;
 mod requests;
+mod session;
 
 fn main() {}

--- a/crates/net/network/tests/it/session.rs
+++ b/crates/net/network/tests/it/session.rs
@@ -1,0 +1,87 @@
+//! Session tests
+
+use futures::StreamExt;
+use reth_eth_wire::{capability::Capability, EthVersion};
+use reth_network::{
+    test_utils::{PeerConfig, Testnet},
+    NetworkEvent,
+};
+use reth_network_api::{NetworkInfo, Peers};
+use reth_provider::test_utils::NoopProvider;
+use std::sync::Arc;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_session_established_with_highest_version() {
+    reth_tracing::init_test_tracing();
+
+    let net = Testnet::create(2).await;
+
+    net.for_each(|peer| assert_eq!(0, peer.num_peers()));
+
+    let mut handles = net.handles();
+    let handle0 = handles.next().unwrap();
+    let handle1 = handles.next().unwrap();
+    drop(handles);
+
+    let handle = net.spawn();
+
+    handle0.add_peer(*handle1.peer_id(), handle1.local_addr());
+
+    let mut events = handle0.event_listener().take(2);
+    while let Some(event) = events.next().await {
+        match event {
+            NetworkEvent::PeerAdded(peer_id) => {
+                assert_eq!(handle1.peer_id(), &peer_id);
+            }
+            NetworkEvent::SessionEstablished { peer_id, status, .. } => {
+                assert_eq!(handle1.peer_id(), &peer_id);
+                assert_eq!(status.version, EthVersion::Eth67 as u8);
+            }
+            _ => {
+                panic!("unexpected event")
+            }
+        }
+    }
+
+    handle.terminate().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_session_established_with_different_capability() {
+    reth_tracing::init_test_tracing();
+
+    let mut net = Testnet::create(1).await;
+
+    let capabilities = vec![Capability::new("eth".into(), EthVersion::Eth66 as usize)];
+    let p1 = PeerConfig::with_capabilities(Arc::new(NoopProvider::default()), capabilities);
+    net.add_peer_with_config(p1).await.unwrap();
+
+    net.for_each(|peer| assert_eq!(0, peer.num_peers()));
+
+    let mut handles = net.handles();
+    let handle0 = handles.next().unwrap();
+    let handle1 = handles.next().unwrap();
+    drop(handles);
+
+    let handle = net.spawn();
+
+    handle0.add_peer(*handle1.peer_id(), handle1.local_addr());
+
+    let mut events = handle0.event_listener().take(2);
+    while let Some(event) = events.next().await {
+        match event {
+            NetworkEvent::PeerAdded(peer_id) => {
+                assert_eq!(handle1.peer_id(), &peer_id);
+            }
+            NetworkEvent::SessionEstablished { peer_id, status, .. } => {
+                assert_eq!(handle1.peer_id(), &peer_id);
+                assert_eq!(status.version, EthVersion::Eth66 as u8);
+            }
+            _ => {
+                panic!("unexpected event")
+            }
+        }
+    }
+
+    handle.terminate().await;
+}


### PR DESCRIPTION
Closes #1101 

### Motivation
> we're announcing support for eth66/67 by default in Hello but only check for a single version in the eth Status handshake

### Direction
> we add a list of versions as a separate parameter to the handshake function

### Alternative idea to direction
* overwrite SharedCapability::Eth.version to Status.version

### Note
* `geth` negotiates `eth` protocol and it selects `highest` version.
https://github.com/ethereum/go-ethereum/blob/d0a4989a8def7e6bad182d1513e8d4a093c1672d/cmd/devp2p/internal/ethtest/helpers.go#L130-L132
* We also already have the same logic at
https://github.com/paradigmxyz/reth/blob/a55e7fd9b5b40acce3030a9366285947455138be/crates/net/eth-wire/src/p2pstream.rs#L562-L567
* With this simple change, I'm success to handshake w/ Eth66.
* I expect it might mitigate the `MismatchedProtocolVersion` issue before #791 is completed.