### PR TITLE
perf(net): increase default capacity for incoming messages

### DIFF
--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -2,7 +2,7 @@ use crate::{
     error::{BackoffKind, SessionError},
     peers::{
         reputation::{is_banned_reputation, BACKOFF_REPUTATION_CHANGE, DEFAULT_REPUTATION},
-        ReputationChangeWeights,
+        ReputationChangeWeights, DEFAULT_MAX_PEERS_INBOUND, DEFAULT_MAX_PEERS_OUTBOUND,
     },
     session::{Direction, PendingSessionHandshakeError},
 };
@@ -713,7 +713,12 @@ impl ConnectionInfo {
 
 impl Default for ConnectionInfo {
     fn default() -> Self {
-        ConnectionInfo { num_outbound: 0, num_inbound: 0, max_outbound: 100, max_inbound: 30 }
+        ConnectionInfo {
+            num_outbound: 0,
+            num_inbound: 0,
+            max_outbound: DEFAULT_MAX_PEERS_OUTBOUND,
+            max_inbound: DEFAULT_MAX_PEERS_INBOUND,
+        }
     }
 }
 

--- a/crates/net/network/src/peers/mod.rs
+++ b/crates/net/network/src/peers/mod.rs
@@ -7,3 +7,9 @@ pub(crate) use manager::{InboundConnectionError, PeerAction, PeersManager};
 pub use manager::{PeersConfig, PeersHandle};
 pub use reputation::ReputationChangeWeights;
 pub use reth_network_api::PeerKind;
+
+/// Maximum number of available slots for outbound sessions.
+pub(crate) const DEFAULT_MAX_PEERS_OUTBOUND: usize = 100;
+
+/// Maximum number of available slots for inbound sessions.
+pub(crate) const DEFAULT_MAX_PEERS_INBOUND: usize = 30;

--- a/crates/net/network/src/session/config.rs
+++ b/crates/net/network/src/session/config.rs
@@ -1,6 +1,9 @@
 //! Configuration types for [SessionManager](crate::session::SessionManager).
 
-use crate::session::{Direction, ExceedsSessionLimit};
+use crate::{
+    peers::{DEFAULT_MAX_PEERS_INBOUND, DEFAULT_MAX_PEERS_OUTBOUND},
+    session::{Direction, ExceedsSessionLimit},
+};
 use std::time::Duration;
 
 /// Default request timeout for a single request.
@@ -46,7 +49,9 @@ impl Default for SessionsConfig {
             // `buffer + num sessions`. Each session can therefore fit at least 1 message in the
             // channel. The buffer size is additional capacity. The channel is always drained on
             // `poll`.
-            session_event_buffer: 128,
+            // The default is twice the maximum number of available slots, if all slots are occupied
+            // the buffer will have capacity for 3 messages per session (average).
+            session_event_buffer: (DEFAULT_MAX_PEERS_OUTBOUND + DEFAULT_MAX_PEERS_INBOUND) * 2,
             limits: Default::default(),
             initial_internal_request_timeout: INITIAL_REQUEST_TIMEOUT,
             protocol_breach_request_timeout: PROTOCOL_BREACH_REQUEST_TIMEOUT,


### PR DESCRIPTION
some testing indicated that at around 60 peers 5% of messages can no longer be delivered.

most of these as tx hash broadcasts and only contain 1-3 hashes each, so bumping the default buffer size to 2*max slots is reasonable imo.

cc @jonasbostoen 