### PR TITLE
fix: don't check postmerge rules when paris isn't activated

### DIFF
--- a/crates/consensus/src/validation.rs
+++ b/crates/consensus/src/validation.rs
@@ -46,24 +46,22 @@ pub fn validate_header_standalone(
 
     // EIP-3675: Upgrade consensus to Proof-of-Stake:
     // https://eips.ethereum.org/EIPS/eip-3675#replacing-difficulty-with-0
-    if let ParisStatus::Supported { block, .. } = chain_spec.paris_status() {
-        if let Some(block) = block {
-            if header.number >= block {
-                if header.difficulty != U256::ZERO {
-                    return Err(Error::TheMergeDifficultyIsNotZero)
-                }
-
-                if header.nonce != 0 {
-                    return Err(Error::TheMergeNonceIsNotZero)
-                }
-
-                if header.ommers_hash != EMPTY_OMMER_ROOT {
-                    return Err(Error::TheMergeOmmerRootIsNotEmpty)
-                }
-
-                // mixHash is used instead of difficulty inside EVM
-                // https://eips.ethereum.org/EIPS/eip-4399#using-mixhash-field-instead-of-difficulty
+    if let ParisStatus::Supported { block: Some(block), .. } = chain_spec.paris_status() {
+        if header.number >= block {
+            if header.difficulty != U256::ZERO {
+                return Err(Error::TheMergeDifficultyIsNotZero)
             }
+
+            if header.nonce != 0 {
+                return Err(Error::TheMergeNonceIsNotZero)
+            }
+
+            if header.ommers_hash != EMPTY_OMMER_ROOT {
+                return Err(Error::TheMergeOmmerRootIsNotEmpty)
+            }
+
+            // mixHash is used instead of difficulty inside EVM
+            // https://eips.ethereum.org/EIPS/eip-4399#using-mixhash-field-instead-of-difficulty
         }
     }
 

--- a/crates/consensus/src/validation.rs
+++ b/crates/consensus/src/validation.rs
@@ -585,4 +585,25 @@ mod tests {
         // perform block validation with paris not activated
         validate_header_standalone(&header.seal(), &chain_spec).unwrap();
     }
+
+    #[test]
+    fn paris_activated_nonzero_difficulty_fails() {
+        let (_, mut header) = mock_block();
+        let mut chain_spec = MAINNET.clone();
+
+        // set paris at genesis and ensure it is supported
+        chain_spec.paris_ttd = Some(U256::ZERO);
+        chain_spec.paris_block = Some(0);
+        assert_eq!(
+            chain_spec.paris_status(),
+            ParisStatus::Supported { terminal_total_difficulty: U256::ZERO, block: Some(0) }
+        );
+
+        // ensure the difficulty is not zero
+        header.difficulty = U256::from(1);
+
+        // ensure we fail because difficulty increased post merge
+        let validation_res = validate_header_standalone(&header.seal(), &chain_spec);
+        assert_eq!(validation_res, Err(Error::TheMergeDifficultyIsNotZero));
+    }
 }

--- a/crates/consensus/src/validation.rs
+++ b/crates/consensus/src/validation.rs
@@ -314,7 +314,7 @@ pub fn validate_header_regarding_parent(
 ///  If we already know the block.
 ///  If parent is known
 ///
-/// Returns parent block header  
+/// Returns parent block header
 pub fn validate_block_regarding_chain<PROV: HeaderProvider>(
     block: &SealedBlock,
     provider: &PROV,
@@ -366,8 +366,8 @@ pub fn full_validation<Provider: HeaderProvider + AccountProvider>(
 mod tests {
     use reth_interfaces::Result;
     use reth_primitives::{
-        hex_literal::hex, Account, Address, BlockHash, Bytes, Header, Signature, TransactionKind,
-        TransactionSigned, MAINNET,
+        hex_literal::hex, Account, Address, BlockHash, Bytes, Header, ParisStatus, Signature,
+        TransactionKind, TransactionSigned, MAINNET,
     };
 
     use super::*;
@@ -567,5 +567,22 @@ mod tests {
             ),
             Err(Error::TransactionNonceNotConsistent.into())
         );
+    }
+
+    #[test]
+    fn paris_not_activated_nonzero_difficulty() {
+        let (_, mut header) = mock_block();
+        let mut chain_spec = MAINNET.clone();
+
+        // un-set paris
+        chain_spec.paris_ttd = None;
+        chain_spec.paris_block = None;
+        assert_eq!(chain_spec.paris_status(), ParisStatus::NotSupported);
+
+        // ensure the difficulty is not zero
+        header.difficulty = U256::from(1);
+
+        // perform block validation with paris not activated
+        validate_header_standalone(&header.seal(), &chain_spec).unwrap();
     }
 }

--- a/crates/consensus/src/validation.rs
+++ b/crates/consensus/src/validation.rs
@@ -1,7 +1,7 @@
 //! Collection of methods for block validation.
 use reth_interfaces::{consensus::Error, Result as RethResult};
 use reth_primitives::{
-    BlockNumber, ChainSpec, Hardfork, Header, SealedBlock, SealedHeader, Transaction,
+    BlockNumber, ChainSpec, Hardfork, Header, ParisStatus, SealedBlock, SealedHeader, Transaction,
     TransactionSignedEcRecovered, TxEip1559, TxEip2930, TxLegacy, EMPTY_OMMER_ROOT, U256,
 };
 use reth_provider::{AccountProvider, HeaderProvider};
@@ -46,21 +46,25 @@ pub fn validate_header_standalone(
 
     // EIP-3675: Upgrade consensus to Proof-of-Stake:
     // https://eips.ethereum.org/EIPS/eip-3675#replacing-difficulty-with-0
-    if Some(header.number) >= chain_spec.paris_status().block_number() {
-        if header.difficulty != U256::ZERO {
-            return Err(Error::TheMergeDifficultyIsNotZero)
-        }
+    if let ParisStatus::Supported { block, .. } = chain_spec.paris_status() {
+        if let Some(block) = block {
+            if header.number >= block {
+                if header.difficulty != U256::ZERO {
+                    return Err(Error::TheMergeDifficultyIsNotZero)
+                }
 
-        if header.nonce != 0 {
-            return Err(Error::TheMergeNonceIsNotZero)
-        }
+                if header.nonce != 0 {
+                    return Err(Error::TheMergeNonceIsNotZero)
+                }
 
-        if header.ommers_hash != EMPTY_OMMER_ROOT {
-            return Err(Error::TheMergeOmmerRootIsNotEmpty)
-        }
+                if header.ommers_hash != EMPTY_OMMER_ROOT {
+                    return Err(Error::TheMergeOmmerRootIsNotEmpty)
+                }
 
-        // mixHash is used instead of difficulty inside EVM
-        // https://eips.ethereum.org/EIPS/eip-4399#using-mixhash-field-instead-of-difficulty
+                // mixHash is used instead of difficulty inside EVM
+                // https://eips.ethereum.org/EIPS/eip-4399#using-mixhash-field-instead-of-difficulty
+            }
+        }
     }
 
     Ok(())

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -397,7 +397,7 @@ impl From<&ChainSpec> for ChainSpecBuilder {
 }
 
 /// Merge Status
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ParisStatus {
     /// Paris is not supported
     NotSupported,


### PR DESCRIPTION
Previously, if the `ChainSpec` was initialized without paris support, `validate_header_standalone` would perform post-merge header validation checks because of the following condition:
```rust
if Some(header.number) >= chain_spec.paris_status().block_number() {
```

If `block_number()` returns `None`, then the inequality would always return true. This causes post-merge checks to be run for networks that do not support the post-merge transition. For example, when testing #877, importing hive blocks with a non-paris hive `genesis.json` would result in `TheMergeDifficultyIsNotZero`.

 * Adds a test making sure we perform this check and return the proper error when paris is activated.
 * Adds a test ensuring headers with non-zero difficulty pass validation when paris is not activated.