### PR TITLE
fix: use correct config for sender recovery stage

### DIFF
--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -212,7 +212,7 @@ impl Command {
                 OfflineStages::default()
                     .set(SenderRecoveryStage {
                         batch_size: stage_conf.sender_recovery.batch_size,
-                        commit_threshold: stage_conf.execution.commit_threshold,
+                        commit_threshold: stage_conf.sender_recovery.commit_threshold,
                     })
                     .set(ExecutionStage {
                         chain_spec: self.chain.clone(),


### PR DESCRIPTION
as title, we were using the execution stage's commit threshold instead of the sender recovery

discovered while benchmarking the senders recovery stage