### PR TITLE
feat(cli): allow running pipeline up to --debug.max-block

### DIFF
--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -80,6 +80,10 @@ pub struct Command {
 
     #[arg(long, default_value = "any")]
     nat: NatResolver,
+
+    /// Runs the sync only up to the specified block
+    #[arg(long = "debug.max-block", help_heading = "Debug")]
+    max_block: u64,
 }
 
 impl Command {
@@ -200,6 +204,7 @@ impl Command {
         let stage_conf = &config.stages;
 
         let pipeline = Pipeline::builder()
+            .with_max_block(self.max_block)
             .with_sync_state_updater(network.clone())
             .add_stages(
                 OnlineStages::new(consensus.clone(), header_downloader, body_downloader).set(


### PR DESCRIPTION
Exposes the `max_block` param of the pipeline builder to the CLI. 

This allows running the pipeline up and syncing each stage to a given block N, even if some of the stages are ahead of block N.