### PR TITLE
chore(rpc): update forkchoice state in `fork_choice_updated` handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4629,6 +4629,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/rpc/rpc-engine-api/Cargo.toml
+++ b/crates/rpc/rpc-engine-api/Cargo.toml
@@ -20,6 +20,9 @@ futures = "0.3"
 tokio = { version = "1", features = ["sync"] }
 tokio-stream = "0.1"
 
+# tracing
+tracing = "0.1"
+
 # misc
 thiserror = "1.0.37"
 

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -603,7 +603,7 @@ mod tests {
         #[tokio::test]
         async fn empty_head() {
             let (msg_tx, msg_rx) = unbounded_channel();
-            let (tip_tx, _tip_rx) = watch::channel(ForkchoiceState::default());
+            let (tip_tx, tip_rx) = watch::channel(ForkchoiceState::default());
             let engine = EngineApi {
                 client: Arc::new(MockEthProvider::default()),
                 chain_spec: MAINNET.clone(),
@@ -631,12 +631,13 @@ mod tests {
                     validation_error: EngineApiError::ForkchoiceEmptyHead.to_string(),
                 })
             );
+            assert!(!tip_rx.has_changed().unwrap());
         }
 
         #[tokio::test]
         async fn unknown_head_hash() {
             let (msg_tx, msg_rx) = unbounded_channel();
-            let (tip_tx, _tip_rx) = watch::channel(ForkchoiceState::default());
+            let (tip_tx, tip_rx) = watch::channel(ForkchoiceState::default());
             let engine = EngineApi {
                 client: Arc::new(MockEthProvider::default()),
                 chain_spec: MAINNET.clone(),
@@ -660,12 +661,13 @@ mod tests {
                 result.unwrap().unwrap(),
                 ForkchoiceUpdated::from_status(PayloadStatusEnum::Syncing)
             );
+            assert!(!tip_rx.has_changed().unwrap());
         }
 
         #[tokio::test]
         async fn unknown_finalized_hash() {
             let (msg_tx, msg_rx) = unbounded_channel();
-            let (tip_tx, _tip_rx) = watch::channel(ForkchoiceState::default());
+            let (tip_tx, tip_rx) = watch::channel(ForkchoiceState::default());
             let client = Arc::new(MockEthProvider::default());
             let engine = EngineApi {
                 client: client.clone(),
@@ -697,6 +699,7 @@ mod tests {
                 result.unwrap().unwrap(),
                 ForkchoiceUpdated::from_status(PayloadStatusEnum::Syncing)
             );
+            assert!(!tip_rx.has_changed().unwrap());
         }
 
         #[tokio::test]

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -128,7 +128,17 @@ impl BlockHashProvider for MockEthProvider {
 
 impl BlockProvider for MockEthProvider {
     fn chain_info(&self) -> Result<ChainInfo> {
-        todo!()
+        let lock = self.headers.lock();
+        Ok(lock
+            .iter()
+            .max_by_key(|h| h.1.number)
+            .map(|(hash, header)| ChainInfo {
+                best_hash: *hash,
+                best_number: header.number,
+                last_finalized: None,
+                safe_finalized: None,
+            })
+            .expect("provider is empty"))
     }
 
     fn block(&self, id: BlockId) -> Result<Option<Block>> {


### PR DESCRIPTION
Initialize engine api with a sender to update the `ForkChoiceState`. The forkchoice state is updated after validating the `fork_choice_updated` payload.