### PR TITLE
chore(download): lower the buffer limit for bodies downloader

### DIFF
--- a/crates/staged-sync/src/config.rs
+++ b/crates/staged-sync/src/config.rs
@@ -113,7 +113,7 @@ impl Default for BodiesConfig {
         Self {
             downloader_request_limit: 200,
             downloader_stream_batch_size: 10000,
-            downloader_max_buffered_responses: 30000,
+            downloader_max_buffered_responses: 1000,
             downloader_min_concurrent_requests: 5,
             downloader_max_concurrent_requests: 100,
         }

--- a/crates/staged-sync/src/config.rs
+++ b/crates/staged-sync/src/config.rs
@@ -101,6 +101,7 @@ pub struct BodiesConfig {
     /// The maximum number of block bodies returned at once from the stream
     pub downloader_stream_batch_size: usize,
     /// Maximum amount of received bodies to buffer internally.
+    /// The response contains multiple bodies.
     pub downloader_max_buffered_responses: usize,
     /// The minimum number of requests to send concurrently.
     pub downloader_min_concurrent_requests: usize,


### PR DESCRIPTION
Caps maximum buffered items at `limit * response size` = 200k **non-empty** bodies