### PR TITLE
fix(download): body download range reset limit

### DIFF
--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -306,8 +306,9 @@ where
                 }
 
                 for range in requests {
+                    let request_len = range.end.saturating_sub(range.end) as u64;
                     let headers = self
-                        .query_headers(range.start..range.end, range.clone().count() as u64)?
+                        .query_headers(range.start..range.end, request_len)?
                         .ok_or(DownloadError::MissingHeader { block_number: range.start })?;
 
                     // Dispatch contiguous request.

--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -291,17 +291,19 @@ where
                         continue
                     }
 
+                    // Extend the last range if it remains contiguous and request size
+                    // is under limit.
+                    // The ranges are inclusive to simplify calculation of request length.
+                    let new_range_end = num + 1;
                     if let Some(range) = requests.last_mut() {
-                        // Extend the last range if it remains contiguous and request size is under
-                        // limit
                         let range_len = range.end.saturating_sub(range.start);
                         if range.end == num && range_len < max_request_len {
-                            *range = range.start..num + 1;
+                            *range = range.start..new_range_end;
                         } else {
-                            requests.push(num..num + 1);
+                            requests.push(num..new_range_end);
                         }
                     } else {
-                        requests.push(num..num + 1);
+                        requests.push(num..new_range_end);
                     }
                 }
 

--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -291,18 +291,18 @@ where
                         continue
                     }
 
-                    match requests.last_mut() {
+                    if let Some(range) = requests.last_mut() {
                         // Extend the last range if it remains contiguous and request size is under
                         // limit
-                        Some(range)
-                            if range.end == num &&
-                                range.end.saturating_sub(range.start) < max_request_len =>
-                        {
-                            *range = range.start..num + 1; // exclusive range
+                        let range_len = range.end.saturating_sub(range.start);
+                        if range.end == num && range_len < max_request_len {
+                            *range = range.start..num + 1;
+                        } else {
+                            requests.push(num..num + 1);
                         }
-                        // Push the new request range
-                        _ => requests.push(num..num + 1), // exclusive range
-                    };
+                    } else {
+                        requests.push(num..num + 1);
+                    }
                 }
 
                 for range in requests {

--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -306,7 +306,7 @@ where
                 }
 
                 for range in requests {
-                    let request_len = range.end.saturating_sub(range.end) as u64;
+                    let request_len = range.end.saturating_sub(range.end);
                     let headers = self
                         .query_headers(range.start..range.end, request_len)?
                         .ok_or(DownloadError::MissingHeader { block_number: range.start })?;

--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -306,7 +306,7 @@ where
                 }
 
                 for range in requests {
-                    let request_len = range.end.saturating_sub(range.end);
+                    let request_len = range.end.saturating_sub(range.start);
                     let headers = self
                         .query_headers(range.start..range.end, request_len)?
                         .ok_or(DownloadError::MissingHeader { block_number: range.start })?;

--- a/crates/net/downloaders/src/bodies/request.rs
+++ b/crates/net/downloaders/src/bodies/request.rs
@@ -263,7 +263,7 @@ mod tests {
     #[tokio::test]
     async fn request_submits_until_fullfilled() {
         // Generate some random blocks
-        let (headers, mut bodies) = generate_bodies(0..20);
+        let (headers, bodies) = generate_bodies(0..20);
 
         let batch_size = 2;
         let client = Arc::new(
@@ -277,7 +277,7 @@ mod tests {
         )
         .with_headers(headers.clone());
 
-        assert_eq!(fut.await, zip_blocks(headers.iter(), &mut bodies));
+        assert_eq!(fut.await, zip_blocks(headers.iter(), &bodies));
         assert_eq!(
             client.times_requested(),
             // div_ceild

--- a/crates/net/downloaders/src/bodies/task.rs
+++ b/crates/net/downloaders/src/bodies/task.rs
@@ -148,7 +148,7 @@ mod tests {
         reth_tracing::init_test_tracing();
 
         let db = create_test_db::<WriteMap>(EnvKind::RW);
-        let (headers, mut bodies) = generate_bodies(0..20);
+        let (headers, bodies) = generate_bodies(0..20);
 
         insert_headers(&db, &headers);
 
@@ -166,7 +166,7 @@ mod tests {
 
         assert_matches!(
             downloader.next().await,
-            Some(Ok(res)) => assert_eq!(res, zip_blocks(headers.iter(), &mut bodies))
+            Some(Ok(res)) => assert_eq!(res, zip_blocks(headers.iter(), &bodies))
         );
         assert_eq!(client.times_requested(), 1);
     }
@@ -176,7 +176,7 @@ mod tests {
         reth_tracing::init_test_tracing();
 
         let db = create_test_db::<WriteMap>(EnvKind::RW);
-        let (headers, mut bodies) = generate_bodies(0..20);
+        let (headers, bodies) = generate_bodies(0..20);
 
         // Insert a subset of headers to the database
         insert_headers(&db, &headers[10..]);
@@ -194,7 +194,7 @@ mod tests {
         downloader.set_download_range(10..20).expect("failed to set download range");
         assert_matches!(
             downloader.next().await,
-            Some(Ok(res)) => assert_eq!(res, zip_blocks(headers.iter().skip(10), &mut bodies))
+            Some(Ok(res)) => assert_eq!(res, zip_blocks(headers.iter().skip(10), &bodies))
         );
 
         downloader.set_download_range(0..20).expect("failed to set download range");

--- a/crates/net/downloaders/src/bodies/test_utils.rs
+++ b/crates/net/downloaders/src/bodies/test_utils.rs
@@ -13,12 +13,12 @@ use std::collections::HashMap;
 
 pub(crate) fn zip_blocks<'a>(
     headers: impl Iterator<Item = &'a SealedHeader>,
-    bodies: &mut HashMap<H256, BlockBody>,
+    bodies: &HashMap<H256, BlockBody>,
 ) -> Vec<BlockResponse> {
     headers
         .into_iter()
         .map(|header| {
-            let body = bodies.remove(&header.hash()).expect("body exists");
+            let body = bodies.get(&header.hash()).expect("body exists").clone();
             if header.is_empty() {
                 BlockResponse::Empty(header.clone())
             } else {

--- a/crates/net/downloaders/src/test_utils/file_client.rs
+++ b/crates/net/downloaders/src/test_utils/file_client.rs
@@ -267,7 +267,7 @@ mod tests {
 
         assert_matches!(
             downloader.next().await,
-            Some(Ok(res)) => assert_eq!(res, zip_blocks(headers.iter(), &mut bodies))
+            Some(Ok(res)) => assert_eq!(res, zip_blocks(headers.iter(), &bodies))
         );
     }
 
@@ -349,7 +349,7 @@ mod tests {
 
         assert_matches!(
             downloader.next().await,
-            Some(Ok(res)) => assert_eq!(res, zip_blocks(headers.iter(), &mut bodies))
+            Some(Ok(res)) => assert_eq!(res, zip_blocks(headers.iter(), &bodies))
         );
     }
 }

--- a/crates/net/downloaders/src/test_utils/mod.rs
+++ b/crates/net/downloaders/src/test_utils/mod.rs
@@ -38,6 +38,29 @@ pub(crate) fn generate_bodies(
     (headers, bodies)
 }
 
+/// Generate a set of non-empty bodies
+pub(crate) fn generate_non_empty_bodies(
+    rng: std::ops::Range<u64>,
+) -> (Vec<SealedHeader>, HashMap<H256, BlockBody>) {
+    let blocks = random_block_range(rng, H256::zero(), 1..3);
+
+    let headers = blocks.iter().map(|block| block.header.clone()).collect();
+    let bodies = blocks
+        .into_iter()
+        .map(|block| {
+            (
+                block.hash(),
+                BlockBody {
+                    transactions: block.body,
+                    ommers: block.ommers.into_iter().map(|header| header.unseal()).collect(),
+                },
+            )
+        })
+        .collect();
+
+    (headers, bodies)
+}
+
 /// Generate a set of bodies, write them to a temporary file, and return the file along with the
 /// bodies and corresponding block hashes
 pub(crate) async fn generate_bodies_file(

--- a/crates/net/downloaders/src/test_utils/test_client.rs
+++ b/crates/net/downloaders/src/test_utils/test_client.rs
@@ -83,8 +83,9 @@ impl BodiesClient for TestBodiesClient {
                     .take(max_batch_size.unwrap_or(usize::MAX))
                     .map(|hash| {
                         bodies
-                            .remove(&hash)
+                            .get(&hash)
                             .expect("Downloader asked for a block it should not ask for")
+                            .clone()
                     })
                     .collect(),
             )


### PR DESCRIPTION
Limit the request size during download range reset in the body downloader.