### PR TITLE
feat: more downloader metrics

### DIFF
--- a/crates/net/downloaders/src/metrics.rs
+++ b/crates/net/downloaders/src/metrics.rs
@@ -22,9 +22,10 @@ pub struct DownloaderMetrics {
     pub total_flushed: Counter,
     /// Number of items that were successfully downloaded
     pub total_downloaded: Counter,
-    /// The number of requests currently in-flight.
+    /// The number of requests (can contain more than 1 item) currently in-flight.
     pub in_flight_requests: Gauge,
-    /// The number of responses in the internal buffer of the downloader.
+    /// The number of responses (can contain more than 1 item) in the internal buffer of the
+    /// downloader.
     pub buffered_responses: Gauge,
     /// The number of out-of-order requests sent by the downloader.
     /// The consumer of the download stream is able to re-request data (headers or bodies) in case

--- a/crates/net/downloaders/src/metrics.rs
+++ b/crates/net/downloaders/src/metrics.rs
@@ -1,4 +1,4 @@
-use metrics::Counter;
+use metrics::{Counter, Gauge};
 use reth_interfaces::p2p::error::DownloadError;
 use reth_metrics_derive::Metrics;
 
@@ -22,6 +22,10 @@ pub struct DownloaderMetrics {
     pub total_flushed: Counter,
     /// Number of items that were successfully downloaded
     pub total_downloaded: Counter,
+    /// The number of requests currently in-flight.
+    pub in_flight_requests: Gauge,
+    /// The number of responses in the internal buffer of the downloader.
+    pub buffered_responses: Gauge,
     /// The number of out-of-order requests sent by the downloader.
     /// The consumer of the download stream is able to re-request data (headers or bodies) in case
     /// it encountered a recoverable error (e.g. during insertion).


### PR DESCRIPTION
Adds a metric for the number of in-flight requests as well as a metric for the number of buffered responses

Draft because I need to 1) finish integrating this with the headers downloader and 2) remove the unrelated change I made to the error metric