### PR TITLE
feat(net): add test-utils and NoopNetwork

### DIFF
--- a/crates/net/network-api/Cargo.toml
+++ b/crates/net/network-api/Cargo.toml
@@ -19,3 +19,6 @@ serde = { version = "1.0", features = ["derive"] }
 async-trait = "0.1"
 thiserror = "1.0.37"
 tokio = { version = "1.21.2", features = ["sync"] }
+
+[features]
+test-utils = []

--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -10,18 +10,22 @@
 //! Provides abstractions for the reth-network crate.
 
 use async_trait::async_trait;
+use reth_eth_wire::DisconnectReason;
 use reth_primitives::{NodeRecord, PeerId, H256, U256};
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
+
+pub use error::NetworkError;
+pub use reputation::{Reputation, ReputationChangeKind};
 
 /// Network Error
 pub mod error;
 /// Reputation score
 pub mod reputation;
 
-pub use error::NetworkError;
-pub use reputation::{Reputation, ReputationChangeKind};
-use reth_eth_wire::DisconnectReason;
+#[cfg(feature = "test-utils")]
+/// Implementation of network traits for testing purposes.
+pub mod test_utils;
 
 /// Provides general purpose information about the network.
 #[async_trait]

--- a/crates/net/network-api/src/test_utils.rs
+++ b/crates/net/network-api/src/test_utils.rs
@@ -1,0 +1,60 @@
+use crate::{
+    EthProtocolInfo, NetworkError, NetworkInfo, NetworkStatus, PeerKind, Peers, PeersInfo,
+    ReputationChangeKind,
+};
+use async_trait::async_trait;
+use reth_eth_wire::{DisconnectReason, ProtocolVersion};
+use reth_primitives::{rpc::Chain::Mainnet, NodeRecord, PeerId};
+use std::net::{IpAddr, SocketAddr};
+
+/// A type that implements all network trait that does nothing.
+///
+/// Intended for testing purposes where network is not used.
+#[derive(Debug, Clone, Default)]
+pub struct NoopNetwork;
+
+#[async_trait]
+impl NetworkInfo for NoopNetwork {
+    fn local_addr(&self) -> SocketAddr {
+        (IpAddr::from(std::net::Ipv4Addr::UNSPECIFIED), 30303).into()
+    }
+
+    async fn network_status(&self) -> Result<NetworkStatus, NetworkError> {
+        Ok(NetworkStatus {
+            client_version: "reth-test".to_string(),
+            protocol_version: ProtocolVersion::V5 as u64,
+            eth_protocol_info: EthProtocolInfo {
+                difficulty: Default::default(),
+                head: Default::default(),
+                network: 1,
+                genesis: Default::default(),
+            },
+        })
+    }
+
+    fn chain_id(&self) -> u64 {
+        Mainnet.into()
+    }
+}
+
+impl PeersInfo for NoopNetwork {
+    fn num_connected_peers(&self) -> usize {
+        0
+    }
+
+    fn local_node_record(&self) -> NodeRecord {
+        NodeRecord::new(self.local_addr(), PeerId::random())
+    }
+}
+
+impl Peers for NoopNetwork {
+    fn add_peer_kind(&self, _peer: PeerId, _kind: PeerKind, _addr: SocketAddr) {}
+
+    fn remove_peer(&self, _peer: PeerId, _kind: PeerKind) {}
+
+    fn disconnect_peer(&self, _peer: PeerId) {}
+
+    fn disconnect_peer_with_reason(&self, _peer: PeerId, _reason: DisconnectReason) {}
+
+    fn reputation_change(&self, _peer_id: PeerId, _kind: ReputationChangeKind) {}
+}


### PR DESCRIPTION
Closes #1202

Adds a network type intended for testing.

ref https://github.com/paradigmxyz/reth/pull/1203