### PR TITLE
fix: add serde feature to secp256k1 dep in discv4

### DIFF
--- a/crates/net/discv4/Cargo.toml
+++ b/crates/net/discv4/Cargo.toml
@@ -23,6 +23,7 @@ secp256k1 = { version = "0.24", features = [
     "global-context",
     "rand-std",
     "recovery",
+    "serde",
 ] }
 enr = { version = "0.7.0", default-features = false, features = [
     "rust-secp256k1",


### PR DESCRIPTION
A missing _serde_ feature in the _secp256k1_ dependency of the _discv4_ crate was causing it to fail standalone compilation with:
```
error[E0432]: unresolved import `secp256k1::serde`
  --> crates/net/discv4/src/config.rs:11:16
   |
11 | use secp256k1::serde::{Deserialize, Serialize};
   |                ^^^^^ could not find `serde` in `secp256k1`
```