### PR TITLE
feat: JWT secret lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4071,6 +4071,7 @@ dependencies = [
  "reth-primitives",
  "reth-provider",
  "reth-rlp",
+ "reth-rpc",
  "reth-rpc-builder",
  "reth-staged-sync",
  "reth-stages",

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -20,7 +20,7 @@ reth-consensus = { path = "../../crates/consensus" }
 reth-executor = { path = "../../crates/executor" }
 reth-eth-wire = { path = "../../crates/net/eth-wire" }
 reth-rpc-builder = { path = "../../crates/rpc/rpc-builder" }
-# reth-rpc = {path = "../../crates/rpc/rpc"}
+reth-rpc = { path = "../../crates/rpc/rpc" }
 reth-rlp = { path = "../../crates/rlp" }
 reth-network = {path = "../../crates/net/network", features = ["serde"] }
 reth-network-api = {path = "../../crates/net/network-api" }

--- a/bin/reth/src/cli.rs
+++ b/bin/reth/src/cli.rs
@@ -1,4 +1,6 @@
 //! CLI definition and entrypoint to executable
+use std::str::FromStr;
+
 use crate::{
     chain, db,
     dirs::{LogsDir, PlatformPath},
@@ -10,7 +12,6 @@ use reth_tracing::{
     tracing_subscriber::{filter::Directive, registry::LookupSpan},
     BoxedLayer, FileWorkerGuard,
 };
-use std::str::FromStr;
 
 /// Parse CLI options, set up logging and run the chosen command.
 pub async fn run() -> eyre::Result<()> {

--- a/bin/reth/src/dirs.rs
+++ b/bin/reth/src/dirs.rs
@@ -42,6 +42,13 @@ pub fn logs_dir() -> Option<PathBuf> {
     cache_dir().map(|root| root.join("logs"))
 }
 
+/// Returns the path to the reth jwtsecret directory.
+///
+/// Refer to [dirs_next::cache_dir] for cross-platform behavior.
+pub fn jwt_secret_dir() -> Option<PathBuf> {
+    data_dir().map(|root| root.join("jwtsecret"))
+}
+
 /// Returns the path to the reth database.
 ///
 /// Refer to [dirs_next::data_dir] for cross-platform behavior.
@@ -52,6 +59,19 @@ pub struct DbPath;
 impl XdgPath for DbPath {
     fn resolve() -> Option<PathBuf> {
         database_path()
+    }
+}
+
+/// Returns the path to the default JWT secret hex file.
+///
+/// Refer to [dirs_next::data_dir] for cross-platform behavior.
+#[derive(Default, Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct JwtSecretPath;
+
+impl XdgPath for JwtSecretPath {
+    fn resolve() -> Option<PathBuf> {
+        jwt_secret_dir().map(|p| p.join("jwt.hex"))
     }
 }
 
@@ -119,7 +139,7 @@ trait XdgPath {
 ///
 /// assert_ne!(default.as_ref(), custom.as_ref());
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct PlatformPath<D>(PathBuf, std::marker::PhantomData<D>);
 
 impl<D> Display for PlatformPath<D> {

--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -4,6 +4,7 @@
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
 ))]
+
 //! Rust Ethereum (reth) binary executable.
 
 pub mod args;

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -135,6 +135,10 @@ impl Command {
 
         info!(target: "reth::cli", peer_id = %network.peer_id(), local_addr = %network.local_addr(), "Connected to P2P network");
 
+        // TODO: Use the resolved secret to spawn the Engine API server
+        // Look at `reth_rpc::AuthLayer` for integration hints
+        let _secret = self.rpc.jwt_secret();
+
         // TODO(mattsse): cleanup, add cli args
         let _rpc_server = reth_rpc_builder::launch(
             ShareableDatabase::new(db.clone()),


### PR DESCRIPTION
Closes #1199

I followed the Geth approach,  so I'd expect the CLI section growing this way:
```bash
API AND CONSOLE OPTIONS:
  --http                              Enable the HTTP-RPC server
  --http.addr value                   HTTP-RPC server listening interface (default: "localhost")
  --http.port value                   HTTP-RPC server listening port (default: 8545)
  --http.api value                    API's offered over the HTTP-RPC interface
  --http.rpcprefix value              HTTP path path prefix on which JSON-RPC is served. Use '/' to serve on all paths.
  --authrpc.jwtsecret value           Path to a JWT secret to use for authenticated RPC endpoints
  ...
```

As a node user I'd love to find Reth to adhere the same usage patterns as Geth, at least for common features.
Let me know if it works for you.
