### PR TITLE
feat: optional serde features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4331,7 +4331,6 @@ dependencies = [
  "reth-primitives",
  "reth-rpc-types",
  "secp256k1 0.24.3",
- "serde",
  "thiserror",
  "tokio",
  "tokio-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4552,7 +4552,6 @@ dependencies = [
  "reth-primitives",
  "reth-rpc-types",
  "secp256k1 0.24.3",
- "serde",
  "test-fuzz",
  "thiserror",
  "tokio",

--- a/crates/interfaces/Cargo.toml
+++ b/crates/interfaces/Cargo.toml
@@ -21,7 +21,6 @@ bytes = "1.2"
 reth-eth-wire = { path = "../net/eth-wire" }
 
 # codecs
-serde = { version = "1.0.*", default-features = false }
 parity-scale-codec = { version = "3.2.1", features = ["bytes"] }
 futures = "0.3.25"
 tokio-stream = "0.1.11"

--- a/crates/net/discv4/Cargo.toml
+++ b/crates/net/discv4/Cargo.toml
@@ -49,4 +49,4 @@ reth-tracing = { path = "../../tracing" }
 [features]
 default = ["serde"]
 test-utils = ["dep:rand"]
-serde = ["dep:serde", "secp256k1/serde"]
+serde = ["dep:serde"]

--- a/crates/net/discv4/Cargo.toml
+++ b/crates/net/discv4/Cargo.toml
@@ -23,7 +23,6 @@ secp256k1 = { version = "0.24", features = [
     "global-context",
     "rand-std",
     "recovery",
-    "serde",
 ] }
 enr = { version = "0.7.0", default-features = false, features = [
     "rust-secp256k1",
@@ -40,7 +39,7 @@ thiserror = "1.0"
 hex = "0.4"
 rand = { version = "0.8", optional = true }
 generic-array = "0.14"
-serde = "1.0"
+serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
 rand = "0.8"
@@ -48,4 +47,6 @@ tokio = { version = "1", features = ["macros"] }
 reth-tracing = { path = "../../tracing" }
 
 [features]
-test-utils = ["rand"]
+default = ["serde"]
+test-utils = ["dep:rand"]
+serde = ["dep:serde", "secp256k1/serde"]

--- a/crates/net/discv4/src/config.rs
+++ b/crates/net/discv4/src/config.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 #[cfg(feature = "serde")]
-use secp256k1::serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 /// Configuration parameters that define the performance of the discovery network.
 #[derive(Clone, Debug)]

--- a/crates/net/discv4/src/config.rs
+++ b/crates/net/discv4/src/config.rs
@@ -8,14 +8,17 @@ use reth_net_common::ban_list::BanList;
 use reth_net_nat::{NatResolver, ResolveNatInterval};
 use reth_primitives::NodeRecord;
 use reth_rlp::Encodable;
-use secp256k1::serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
     time::Duration,
 };
 
+#[cfg(feature = "serde")]
+use secp256k1::serde::{Deserialize, Serialize};
+
 /// Configuration parameters that define the performance of the discovery network.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Discv4Config {
     /// Whether to enable the incoming packet filter. Default: false.
     pub enable_packet_filter: bool,
@@ -39,7 +42,7 @@ pub struct Discv4Config {
     /// The duration we set for neighbours responses
     pub neighbours_expiration: Duration,
     /// Provides a way to ban peers and ips.
-    #[serde(skip)]
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub ban_list: BanList,
     /// Set the default duration for which nodes are banned for. This timeouts are checked every 5
     /// minutes, so the precision will be to the nearest 5 minutes. If set to `None`, bans from
@@ -137,7 +140,8 @@ impl Default for Discv4Config {
 }
 
 /// Builder type for [`Discv4Config`]
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Discv4ConfigBuilder {
     config: Discv4Config,
 }

--- a/crates/net/dns/Cargo.toml
+++ b/crates/net/dns/Cargo.toml
@@ -37,9 +37,13 @@ lru = "0.9"
 thiserror = "1.0"
 tracing = "0.1"
 parking_lot = "0.12"
-serde = "1.0"
-serde_with = "2.1.0"
+serde = { version = "1.0", optional = true }
+serde_with = { version = "2.1.0", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["sync", "rt", "rt-multi-thread"] }
 reth-tracing = { path = "../../tracing" }
+
+[features]
+default = ["serde"]
+serde = ["dep:serde", "dep:serde_with"]

--- a/crates/net/dns/src/config.rs
+++ b/crates/net/dns/src/config.rs
@@ -1,10 +1,12 @@
-use serde::{Deserialize, Serialize};
-
 use crate::tree::LinkEntry;
 use std::{collections::HashSet, num::NonZeroUsize, time::Duration};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Settings for the [DnsDiscoveryService](crate::DnsDiscoveryService).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DnsDiscoveryConfig {
     /// Timeout for DNS lookups.
     ///

--- a/crates/net/dns/src/tree.rs
+++ b/crates/net/dns/src/tree.rs
@@ -28,8 +28,10 @@ use data_encoding::{BASE32_NOPAD, BASE64URL_NOPAD};
 use enr::{Enr, EnrError, EnrKey, EnrKeyUnambiguous, EnrPublicKey};
 use reth_primitives::hex;
 use secp256k1::SecretKey;
-use serde_with::{DeserializeFromStr, SerializeDisplay};
 use std::{fmt, str::FromStr};
+
+#[cfg(feature = "serde")]
+use serde_with::{DeserializeFromStr, SerializeDisplay};
 
 const ROOT_V1_PREFIX: &str = "enrtree-root:v1";
 const LINK_PREFIX: &str = "enrtree://";
@@ -221,7 +223,8 @@ impl fmt::Display for BranchEntry {
 }
 
 /// A link entry
-#[derive(Debug, Clone, Hash, Eq, PartialEq, SerializeDisplay, DeserializeFromStr)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(SerializeDisplay, DeserializeFromStr))]
 pub struct LinkEntry<K: EnrKeyUnambiguous = SecretKey> {
     pub domain: String,
     pub pubkey: K::PublicKey,

--- a/crates/net/eth-wire/Cargo.toml
+++ b/crates/net/eth-wire/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 bytes = { version = "1.1" }
 hex = "0.4"
 thiserror = "1"
-serde = "1"
+serde = { version = "1", optional = true }
 
 # reth
 reth-codecs = { path = "../../storage/codecs" }
@@ -27,7 +27,7 @@ tokio-stream = "0.1.11"
 pin-project = "1.0"
 tracing = "0.1.37"
 snap = "1.0.5"
-smol_str = { version = "0.1", features = ["serde"] }
+smol_str = "0.1"
 metrics = "0.20.1"
 
 # arbitrary utils
@@ -52,10 +52,11 @@ proptest = { version = "1.0" }
 proptest-derive = "0.3"
 
 [features]
-default = []
+default = ["serde"]
+serde = ["dep:serde", "smol_str/serde"]
 arbitrary = ["reth-primitives/arbitrary", "dep:arbitrary", "dep:proptest", "dep:proptest-derive"]
 
 [[test]]
 name = "fuzz_roundtrip"
 path = "tests/fuzz_roundtrip.rs"
-required-features = ["arbitrary"]
+required-features = ["arbitrary", "serde"]

--- a/crates/net/eth-wire/src/capability.rs
+++ b/crates/net/eth-wire/src/capability.rs
@@ -4,8 +4,10 @@ use crate::{version::ParseVersionError, EthMessage, EthVersion};
 use bytes::{BufMut, Bytes};
 use reth_codecs::add_arbitrary_tests;
 use reth_rlp::{Decodable, DecodeError, Encodable, RlpDecodable, RlpEncodable};
-use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 #[cfg(any(test, feature = "arbitrary"))]
 use proptest::{
@@ -14,7 +16,8 @@ use proptest::{
 };
 
 /// A Capability message consisting of the message-id and the payload
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct RawCapabilityMessage {
     /// Identifier of the message.
     pub id: usize,
@@ -24,7 +27,8 @@ pub struct RawCapabilityMessage {
 
 /// Various protocol related event types bubbled up from a session that need to be handled by the
 /// network.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum CapabilityMessage {
     /// Eth sub-protocol message.
     Eth(EthMessage),
@@ -34,9 +38,8 @@ pub enum CapabilityMessage {
 
 /// A message indicating a supported capability and capability version.
 #[add_arbitrary_tests(rlp)]
-#[derive(
-    Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable, Serialize, Deserialize, Default, Hash,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable, Default, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Capability {
     /// The name of the subprotocol
     pub name: SmolStr,

--- a/crates/net/eth-wire/src/disconnect.rs
+++ b/crates/net/eth-wire/src/disconnect.rs
@@ -3,13 +3,16 @@
 use bytes::Buf;
 use reth_codecs::derive_arbitrary;
 use reth_rlp::{Decodable, DecodeError, Encodable, Header};
-use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use thiserror::Error;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// RLPx disconnect reason.
 #[derive_arbitrary(rlp)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum DisconnectReason {
     /// Disconnect requested by the local node or remote peer.
     #[default]

--- a/crates/net/eth-wire/src/hello.rs
+++ b/crates/net/eth-wire/src/hello.rs
@@ -2,6 +2,8 @@ use crate::{capability::Capability, EthVersion, ProtocolVersion};
 use reth_codecs::derive_arbitrary;
 use reth_primitives::PeerId;
 use reth_rlp::{RlpDecodable, RlpEncodable};
+
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// The client version: `reth/v{major}.{minor}.{patch}`
@@ -11,7 +13,8 @@ pub(crate) const DEFAULT_CLIENT_VERSION: &str = concat!("reth/v", env!("CARGO_PK
 /// Message used in the `p2p` handshake, containing information about the supported RLPx protocol
 /// version and capabilities.
 #[derive_arbitrary(rlp)]
-#[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct HelloMessage {
     /// The version of the `p2p` protocol.
     pub protocol_version: ProtocolVersion,

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -11,7 +11,6 @@ use metrics::counter;
 use pin_project::pin_project;
 use reth_codecs::derive_arbitrary;
 use reth_rlp::{Decodable, DecodeError, Encodable, EMPTY_LIST_CODE};
-use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeSet, HashMap, HashSet, VecDeque},
     io,
@@ -20,6 +19,9 @@ use std::{
     time::Duration,
 };
 use tokio_stream::Stream;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// [`MAX_PAYLOAD_SIZE`] is the maximum size of an uncompressed message payload.
 /// This is defined in [EIP-706](https://eips.ethereum.org/EIPS/eip-706).
@@ -615,7 +617,8 @@ pub fn set_capability_offsets(
 
 /// This represents only the reserved `p2p` subprotocol messages.
 #[derive_arbitrary(rlp)]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum P2PMessage {
     /// The first packet sent over the connection, and sent once by both sides.
     Hello(HelloMessage),
@@ -747,7 +750,8 @@ impl TryFrom<u8> for P2PMessageID {
 
 /// RLPx `p2p` protocol version
 #[derive_arbitrary(rlp)]
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ProtocolVersion {
     /// `p2p` version 4
     V4 = 4,

--- a/crates/net/eth-wire/src/types/blocks.rs
+++ b/crates/net/eth-wire/src/types/blocks.rs
@@ -4,6 +4,8 @@ use super::RawBlockBody;
 use reth_codecs::derive_arbitrary;
 use reth_primitives::{BlockHashOrNumber, Header, HeadersDirection, TransactionSigned, H256};
 use reth_rlp::{RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper};
+
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// A request for a peer to return block headers starting at the requested block.
@@ -16,9 +18,8 @@ use serde::{Deserialize, Serialize};
 /// If the [`skip`](#structfield.skip) field is non-zero, the peer must skip that amount of headers
 /// in the direction specified by [`reverse`](#structfield.reverse).
 #[derive_arbitrary(rlp)]
-#[derive(
-    Copy, Clone, Debug, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable, Serialize, Deserialize,
-)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GetBlockHeaders {
     /// The block number or hash that the peer should start returning headers from.
     pub start_block: BlockHashOrNumber,
@@ -38,17 +39,8 @@ pub struct GetBlockHeaders {
 
 /// The response to [`GetBlockHeaders`], containing headers if any headers were found.
 #[derive_arbitrary(rlp)]
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    RlpEncodableWrapper,
-    RlpDecodableWrapper,
-    Serialize,
-    Deserialize,
-    Default,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BlockHeaders(
     /// The requested headers.
     pub Vec<Header>,
@@ -62,17 +54,8 @@ impl From<Vec<Header>> for BlockHeaders {
 
 /// A request for a peer to return block bodies for the given block hashes.
 #[derive_arbitrary(rlp)]
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    RlpEncodableWrapper,
-    RlpDecodableWrapper,
-    Serialize,
-    Deserialize,
-    Default,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GetBlockBodies(
     /// The block hashes to request bodies for.
     pub Vec<H256>,
@@ -87,9 +70,8 @@ impl From<Vec<H256>> for GetBlockBodies {
 // TODO(onbjerg): We should have this type in primitives
 /// A response to [`GetBlockBodies`], containing bodies if any bodies were found.
 #[derive_arbitrary(rlp, 10)]
-#[derive(
-    Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable, Serialize, Deserialize, Default,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BlockBody {
     /// Transactions in the block
     pub transactions: Vec<TransactionSigned>,
@@ -111,17 +93,8 @@ impl BlockBody {
 /// The response to [`GetBlockBodies`], containing the block bodies that the peer knows about if
 /// any were found.
 #[derive_arbitrary(rlp, 1)]
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    RlpEncodableWrapper,
-    RlpDecodableWrapper,
-    Serialize,
-    Deserialize,
-    Default,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BlockBodies(
     /// The requested block bodies, each of which should correspond to a hash in the request.
     pub Vec<BlockBody>,

--- a/crates/net/eth-wire/src/types/broadcast.rs
+++ b/crates/net/eth-wire/src/types/broadcast.rs
@@ -2,22 +2,15 @@
 use reth_codecs::derive_arbitrary;
 use reth_primitives::{Header, TransactionSigned, H256, U128};
 use reth_rlp::{RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper};
-use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// This informs peers of new blocks that have appeared on the network.
 #[derive_arbitrary(rlp)]
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    RlpEncodableWrapper,
-    RlpDecodableWrapper,
-    Serialize,
-    Deserialize,
-    Default,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct NewBlockHashes(
     /// New block hashes and the block number for each blockhash.
     /// Clients should request blocks using a [`GetBlockBodies`](crate::GetBlockBodies) message.
@@ -40,9 +33,8 @@ impl NewBlockHashes {
 
 /// A block hash _and_ a block number.
 #[derive_arbitrary(rlp)]
-#[derive(
-    Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable, Serialize, Deserialize, Default,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BlockHashNumber {
     /// The block hash
     pub hash: H256,
@@ -64,9 +56,8 @@ impl From<NewBlockHashes> for Vec<BlockHashNumber> {
 
 /// A block body, including transactions and uncle headers.
 #[derive_arbitrary(rlp, 25)]
-#[derive(
-    Debug, Clone, PartialEq, Eq, Default, RlpEncodable, RlpDecodable, Serialize, Deserialize,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, RlpEncodable, RlpDecodable)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct RawBlockBody {
     /// This block's header
     pub header: Header,
@@ -79,9 +70,8 @@ pub struct RawBlockBody {
 /// A new block with the current total difficulty, which includes the difficulty of the returned
 /// block.
 #[derive_arbitrary(rlp, 25)]
-#[derive(
-    Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable, Serialize, Deserialize, Default,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct NewBlock {
     /// A new block.
     pub block: RawBlockBody,
@@ -92,17 +82,8 @@ pub struct NewBlock {
 /// This informs peers of transactions that have appeared on the network and are not yet included
 /// in a block.
 #[derive_arbitrary(rlp, 10)]
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    RlpEncodableWrapper,
-    RlpDecodableWrapper,
-    Serialize,
-    Deserialize,
-    Default,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Transactions(
     /// New transactions for the peer to include in its mempool.
     pub Vec<TransactionSigned>,
@@ -134,17 +115,8 @@ pub struct SharedTransactions(
 /// This informs peers of transaction hashes for transactions that have appeared on the network,
 /// but have not been included in a block.
 #[derive_arbitrary(rlp)]
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    RlpEncodableWrapper,
-    RlpDecodableWrapper,
-    Serialize,
-    Deserialize,
-    Default,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct NewPooledTransactionHashes(
     /// Transaction hashes for new transactions that have appeared on the network.
     /// Clients should request the transactions with the given hashes using a

--- a/crates/net/eth-wire/src/types/message.rs
+++ b/crates/net/eth-wire/src/types/message.rs
@@ -7,11 +7,14 @@ use super::{
 use crate::SharedTransactions;
 use bytes::{Buf, BufMut};
 use reth_rlp::{length_of_length, Decodable, Encodable, Header};
-use serde::{Deserialize, Serialize};
 use std::{fmt::Debug, sync::Arc};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// An `eth` protocol message, containing a message ID and payload.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ProtocolMessage {
     pub message_type: EthMessageID,
     pub message: EthMessage,
@@ -140,7 +143,8 @@ impl From<EthBroadcastMessage> for ProtocolBroadcastMessage {
 ///
 ///  The newer `eth/66` is an efficiency upgrade on top of `eth/65`, introducing a request id to
 ///  correlate request-response message pairs. This allows for request multiplexing.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum EthMessage {
     /// Status is required for the protocol handshake
     Status(Status),
@@ -270,7 +274,8 @@ impl Encodable for EthBroadcastMessage {
 
 /// Represents message IDs for eth protocol messages.
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum EthMessageID {
     Status = 0x00,
     NewBlockHashes = 0x01,
@@ -352,7 +357,8 @@ impl TryFrom<usize> for EthMessageID {
 /// This is used for all request-response style `eth` protocol messages.
 /// This can represent either a request or a response, since both include a message payload and
 /// request id.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct RequestPair<T> {
     /// id for the contained request or response message
     pub request_id: u64,

--- a/crates/net/eth-wire/src/types/receipts.rs
+++ b/crates/net/eth-wire/src/types/receipts.rs
@@ -2,21 +2,14 @@
 use reth_codecs::derive_arbitrary;
 use reth_primitives::{Receipt, H256};
 use reth_rlp::{RlpDecodableWrapper, RlpEncodableWrapper};
+
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// A request for transaction receipts from the given block hashes.
 #[derive_arbitrary(rlp)]
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    RlpEncodableWrapper,
-    RlpDecodableWrapper,
-    Serialize,
-    Deserialize,
-    Default,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GetReceipts(
     /// The block hashes to request receipts for.
     pub Vec<H256>,
@@ -25,17 +18,8 @@ pub struct GetReceipts(
 /// The response to [`GetReceipts`], containing receipt lists that correspond to each block
 /// requested.
 #[derive_arbitrary(rlp, 1)]
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    RlpEncodableWrapper,
-    RlpDecodableWrapper,
-    Serialize,
-    Deserialize,
-    Default,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Receipts(
     /// Each receipt hash should correspond to a block hash in the request.
     pub Vec<Vec<Receipt>>,

--- a/crates/net/eth-wire/src/types/state.rs
+++ b/crates/net/eth-wire/src/types/state.rs
@@ -2,23 +2,16 @@
 use reth_codecs::derive_arbitrary;
 use reth_primitives::{Bytes, H256};
 use reth_rlp::{RlpDecodableWrapper, RlpEncodableWrapper};
+
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// A request for state tree nodes corresponding to the given hashes.
 /// This message was removed in `eth/67`, only clients running `eth/66` or earlier will respond to
 /// this message.
 #[derive_arbitrary(rlp)]
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    RlpEncodableWrapper,
-    RlpDecodableWrapper,
-    Serialize,
-    Deserialize,
-    Default,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GetNodeData(pub Vec<H256>);
 
 /// The response to [`GetNodeData`], containing the state tree nodes or contract bytecode
@@ -27,17 +20,8 @@ pub struct GetNodeData(pub Vec<H256>);
 /// Not all nodes are guaranteed to be returned by the peer.
 /// This message was removed in `eth/67`.
 #[derive_arbitrary(rlp)]
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    RlpEncodableWrapper,
-    RlpDecodableWrapper,
-    Serialize,
-    Deserialize,
-    Default,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct NodeData(pub Vec<Bytes>);
 
 #[cfg(test)]

--- a/crates/net/eth-wire/src/types/status.rs
+++ b/crates/net/eth-wire/src/types/status.rs
@@ -4,8 +4,10 @@ use ethers_core::utils::Genesis;
 use reth_codecs::derive_arbitrary;
 use reth_primitives::{Chain, ChainSpec, ForkId, Hardfork, Head, H256, MAINNET, U256};
 use reth_rlp::{RlpDecodable, RlpEncodable};
-use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display};
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// The status message is used in the eth protocol handshake to ensure that peers are on the same
 /// network and are following the same fork.
@@ -13,7 +15,8 @@ use std::fmt::{Debug, Display};
 /// When performing a handshake, the total difficulty is not guaranteed to correspond to the block
 /// hash. This information should be treated as untrusted.
 #[derive_arbitrary(rlp)]
-#[derive(Copy, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable, Serialize, Deserialize)]
+#[derive(Copy, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Status {
     /// The current protocol version. For example, peers running `eth/66` would have a version of
     /// 66.

--- a/crates/net/eth-wire/src/types/transactions.rs
+++ b/crates/net/eth-wire/src/types/transactions.rs
@@ -2,21 +2,14 @@
 use reth_codecs::derive_arbitrary;
 use reth_primitives::{TransactionSigned, H256};
 use reth_rlp::{RlpDecodableWrapper, RlpEncodableWrapper};
+
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// A list of transaction hashes that the peer would like transaction bodies for.
 #[derive_arbitrary(rlp)]
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    RlpEncodableWrapper,
-    RlpDecodableWrapper,
-    Serialize,
-    Deserialize,
-    Default,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GetPooledTransactions(
     /// The transaction hashes to request transaction bodies for.
     pub Vec<H256>,
@@ -39,17 +32,8 @@ where
 /// corresponds to a requested hash. Hashes may need to be re-requested if the bodies are not
 /// included in the response.
 #[derive_arbitrary(rlp, 10)]
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    RlpEncodableWrapper,
-    RlpDecodableWrapper,
-    Serialize,
-    Deserialize,
-    Default,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PooledTransactions(
     /// The transaction bodies, each of which should correspond to a requested hash.
     pub Vec<TransactionSigned>,

--- a/crates/net/nat/Cargo.toml
+++ b/crates/net/nat/Cargo.toml
@@ -23,8 +23,12 @@ tracing = "0.1"
 pin-project-lite = "0.2.9"
 tokio = { version = "1", features = ["time"] }
 thiserror = "1.0"
-serde_with = "2.1.0"
+serde_with = { version = "2.1.0", optional = true }
 
 [dev-dependencies]
 reth-tracing = { path = "../../tracing" }
 tokio = { version = "1", features = ["macros"] }
+
+[features]
+default = ["serde"]
+serde = ["dep:serde_with"]

--- a/crates/net/nat/src/lib.rs
+++ b/crates/net/nat/src/lib.rs
@@ -9,7 +9,6 @@
 
 use igd::aio::search_gateway;
 use pin_project_lite::pin_project;
-use serde_with::{DeserializeFromStr, SerializeDisplay};
 use std::{
     fmt,
     future::{poll_fn, Future},
@@ -21,10 +20,12 @@ use std::{
 };
 use tracing::warn;
 
+#[cfg(feature = "serde")]
+use serde_with::{DeserializeFromStr, SerializeDisplay};
+
 /// All builtin resolvers.
-#[derive(
-    Debug, Clone, Copy, Eq, PartialEq, Default, Hash, SerializeDisplay, DeserializeFromStr,
-)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default, Hash)]
+#[cfg_attr(feature = "serde", derive(SerializeDisplay, DeserializeFromStr))]
 pub enum NatResolver {
     /// Resolve with any available resolver.
     #[default]

--- a/crates/net/network-api/Cargo.toml
+++ b/crates/net/network-api/Cargo.toml
@@ -13,7 +13,7 @@ reth-primitives = { path = "../../primitives" }
 reth-eth-wire = { path = "../eth-wire" }
 
 # io
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 # misc
 async-trait = "0.1"
@@ -21,4 +21,6 @@ thiserror = "1.0.37"
 tokio = { version = "1.21.2", features = ["sync"] }
 
 [features]
+default = ["serde"]
+serde = ["dep:serde"]
 test-utils = []

--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -12,8 +12,10 @@
 use async_trait::async_trait;
 use reth_eth_wire::DisconnectReason;
 use reth_primitives::{NodeRecord, PeerId, H256, U256};
-use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 pub use error::NetworkError;
 pub use reputation::{Reputation, ReputationChangeKind};
@@ -90,7 +92,8 @@ pub enum PeerKind {
 }
 
 /// The status of the network being ran by the local node.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct NetworkStatus {
     /// The local node client version.
     pub client_version: String,
@@ -100,10 +103,14 @@ pub struct NetworkStatus {
     pub eth_protocol_info: EthProtocolInfo,
 }
 /// Information about the Ethereum Wire Protocol (ETH)
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct EthProtocolInfo {
     /// The current difficulty at the head of the chain.
-    #[serde(deserialize_with = "reth_primitives::serde_helper::deserialize_json_u256")]
+    #[cfg_attr(
+        feature = "serde",
+        serde(deserialize_with = "reth_primitives::serde_helper::deserialize_json_u256")
+    )]
     pub difficulty: U256,
     /// The block hash of the head of the chain.
     pub head: H256,

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -62,10 +62,9 @@ secp256k1 = { version = "0.24", features = [
     "global-context",
     "rand-std",
     "recovery",
-    "serde",
 ] }
 
-enr = { version = "0.7.0", features = ["serde", "rust-secp256k1"], optional = true }
+enr = { version = "0.7.0", features = ["rust-secp256k1"], optional = true }
 ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false, optional = true }
 tempfile = { version = "3.3", optional = true }
 
@@ -96,5 +95,5 @@ serial_test = "0.10"
 
 [features]
 default = ["serde"]
-serde = ["dep:serde", "dep:humantime-serde"]
+serde = ["dep:serde", "dep:humantime-serde", "secp256k1/serde", "enr?/serde"]
 test-utils = ["reth-provider/test-utils", "dep:enr", "dep:ethers-core", "dep:tempfile"]

--- a/crates/rlp/Cargo.toml
+++ b/crates/rlp/Cargo.toml
@@ -16,7 +16,7 @@ enr = { version = "0.7", default-features = false, optional = true }
 rlp = { version = "0.5.2", default-features = false, optional = true }
 ethereum-types = { version = "0.14", features = ["codec"], optional = true }
 reth-rlp-derive = { version = "0.1", path = "./rlp-derive", optional = true }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "a05fb262d87c78ee52d400e6c0f4708d4c527f32", features = ["serde"] }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "a05fb262d87c78ee52d400e6c0f4708d4c527f32", features = [] }
 
 [dev-dependencies]
 reth-rlp = { path = ".", package = "reth-rlp", features = [

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -16,7 +16,6 @@ reth-rpc-types = { path = "../../rpc/rpc-types" }
 reth-db = { path = "../db" }
 
 # codecs
-serde = { version = "1.0.*", default-features = false }
 postcard = { version = "1.0.2", features = ["alloc"] }
 parity-scale-codec = { version = "3.2.1", features = ["bytes"] }
 

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -34,7 +34,7 @@ reth-metrics-derive = { path = "../metrics/metrics-derive" }
 aquamarine = "0.2.1" # docs
 thiserror = "1.0"
 tracing = "0.1"
-serde = { version = "1.0", features = ["derive", "rc"] }
+serde = { version = "1.0", features = ["derive", "rc"], optional = true }
 fnv = "1.0.7"
 bitflags = "1.3"
 
@@ -52,4 +52,5 @@ rand = "0.8"
 
 
 [features]
-test-utils = ["rand", "paste"]
+serde = ["dep:serde"]
+test-utils = ["rand", "paste", "serde"]

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -52,5 +52,6 @@ rand = "0.8"
 
 
 [features]
+default = ["serde"]
 serde = ["dep:serde"]
 test-utils = ["rand", "paste", "serde"]

--- a/crates/transaction-pool/src/pool/events.rs
+++ b/crates/transaction-pool/src/pool/events.rs
@@ -1,10 +1,13 @@
 use crate::traits::PropagateKind;
 use reth_primitives::{TxHash, H256};
-use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Various events that describe status changes of a transaction.
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum TransactionEvent {
     /// Transaction has been added to the pending pool.
     Pending,


### PR DESCRIPTION
Closes: https://github.com/paradigmxyz/reth/issues/1207

This PR makes _serde_ dependencies optional for crates using it, except for those using (de)serialization for some of their main functionality (namely _codecs_, _primitives_, _rpc_ and _db_ related crates).