### PR TITLE
feat: add total difficulty to ChainInfo

### DIFF
--- a/crates/primitives/src/chain/info.rs
+++ b/crates/primitives/src/chain/info.rs
@@ -1,8 +1,10 @@
-use crate::{BlockNumber, H256};
+use crate::{BlockNumber, H256, U256};
 
 /// Current status of the blockchain's head.
 #[derive(Debug, Eq, PartialEq)]
 pub struct ChainInfo {
+    /// Current total difficulty.
+    pub total_difficulty: Option<U256>,
     /// Best block hash.
     pub best_hash: H256,
     /// Best block number.

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -63,7 +63,10 @@ impl<DB: Database> BlockHashProvider for ShareableDatabase<DB> {
 
 impl<DB: Database> BlockProvider for ShareableDatabase<DB> {
     fn chain_info(&self) -> Result<ChainInfo> {
+        // TODO
+        let total_difficulty = None;
         Ok(ChainInfo {
+            total_difficulty,
             best_hash: Default::default(),
             best_number: 0,
             last_finalized: None,

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -129,10 +129,15 @@ impl BlockHashProvider for MockEthProvider {
 impl BlockProvider for MockEthProvider {
     fn chain_info(&self) -> Result<ChainInfo> {
         let lock = self.headers.lock();
+        let total_difficulty = match lock.values().fold(U256::ZERO, |td, h| td + h.difficulty) {
+            U256::ZERO => None,
+            td => Some(td),
+        };
         Ok(lock
             .iter()
             .max_by_key(|h| h.1.number)
             .map(|(hash, header)| ChainInfo {
+                total_difficulty,
                 best_hash: *hash,
                 best_number: header.number,
                 last_finalized: None,

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -23,6 +23,7 @@ impl BlockHashProvider for NoopProvider {
 impl BlockProvider for NoopProvider {
     fn chain_info(&self) -> Result<ChainInfo> {
         Ok(ChainInfo {
+            total_difficulty: None,
             best_hash: Default::default(),
             best_number: 0,
             last_finalized: None,


### PR DESCRIPTION
This introduces a `total_difficulty` field to `ChainInfo`, so the field can be used in RPCs such as `eth_getBlockByNumber` and `eth_getBlockByHash`.

We still need to implement the `BlockProvider` methods on the `ShareableDatabase` for the output to work on the RPCs, but these methods are not yet implemented so it should be fine for now.