### PR TITLE
test: basic rpc testing support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4639,6 +4639,7 @@ dependencies = [
  "jsonrpsee",
  "reth-ipc",
  "reth-network-api",
+ "reth-primitives",
  "reth-provider",
  "reth-rpc",
  "reth-rpc-api",

--- a/crates/rpc/rpc-api/src/admin.rs
+++ b/crates/rpc/rpc-api/src/admin.rs
@@ -1,31 +1,32 @@
-use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_primitives::NodeRecord;
 use reth_rpc_types::NodeInfo;
 
 /// Admin namespace rpc interface that gives access to several non-standard RPC methods.
-#[rpc(server)]
+#[cfg_attr(not(feature = "client"), rpc(server))]
+#[cfg_attr(feature = "client", rpc(server, client))]
 #[async_trait::async_trait]
 pub trait AdminApi {
     /// Adds the given node record to the peerset.
     #[method(name = "admin_addPeer")]
-    fn add_peer(&self, record: NodeRecord) -> Result<bool>;
+    fn add_peer(&self, record: NodeRecord) -> RpcResult<bool>;
 
     /// Disconnects from a remote node if the connection exists.
     ///
     /// Returns true if the peer was successfully removed.
     #[method(name = "admin_removePeer")]
-    fn remove_peer(&self, record: NodeRecord) -> Result<bool>;
+    fn remove_peer(&self, record: NodeRecord) -> RpcResult<bool>;
 
     /// Adds the given node record to the trusted peerset.
     #[method(name = "admin_addTrustedPeer")]
-    fn add_trusted_peer(&self, record: NodeRecord) -> Result<bool>;
+    fn add_trusted_peer(&self, record: NodeRecord) -> RpcResult<bool>;
 
     /// Removes a remote node from the trusted peer set, but it does not disconnect it
     /// automatically.
     ///
     /// Returns true if the peer was successfully removed.
     #[method(name = "admin_removeTrustedPeer")]
-    fn remove_trusted_peer(&self, record: NodeRecord) -> Result<bool>;
+    fn remove_trusted_peer(&self, record: NodeRecord) -> RpcResult<bool>;
 
     /// Creates an RPC subscription which serves events received from the network.
     #[subscription(
@@ -33,9 +34,9 @@ pub trait AdminApi {
         unsubscribe = "admin_peerEvents_unsubscribe",
         item = String
     )]
-    fn subscribe(&self);
+    fn subscribe_peer_events(&self);
 
     /// Returns the ENR of the node.
     #[method(name = "admin_nodeInfo")]
-    async fn node_info(&self) -> Result<NodeInfo>;
+    async fn node_info(&self) -> RpcResult<NodeInfo>;
 }

--- a/crates/rpc/rpc-api/src/lib.rs
+++ b/crates/rpc/rpc-api/src/lib.rs
@@ -30,3 +30,16 @@ pub mod servers {
         trace::TraceApiServer, web3::Web3ApiServer,
     };
 }
+
+/// re-export of all client traits
+#[cfg(feature = "client")]
+pub use clients::*;
+
+/// Aggregates all client traits.
+#[cfg(feature = "client")]
+pub mod clients {
+    pub use crate::{
+        admin::AdminApiClient, debug::DebugApiClient, engine::EngineApiClient, eth::EthApiClient,
+        net::NetApiClient, trace::TraceApiClient, web3::Web3ApiClient,
+    };
+}

--- a/crates/rpc/rpc-builder/Cargo.toml
+++ b/crates/rpc/rpc-builder/Cargo.toml
@@ -22,8 +22,10 @@ serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 reth-tracing = { path = "../../tracing" }
+reth-primitives = { path = "../../primitives" }
 reth-rpc-api = { path = "../rpc-api", features = ["client"] }
 reth-transaction-pool = { path = "../../transaction-pool", features = ["test-utils"] }
 reth-provider = { path = "../../storage/provider", features = ["test-utils"] }
+reth-network-api = { path = "../../net/network-api", features = ["test-utils"] }
 
 tokio = { version = "1", features = ["rt", "rt-multi-thread"] }

--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -1,8 +1,48 @@
 //! Standalone http tests
 
-use crate::utils::test_rpc_builder;
+use crate::utils::{launch_http, launch_http_ws, launch_ws};
+use jsonrpsee::core::client::{ClientT, SubscriptionClientT};
+use reth_primitives::NodeRecord;
+use reth_rpc_api::clients::AdminApiClient;
+use reth_rpc_builder::RethRpcModule;
+
+async fn test_basic_admin_calls<C>(client: &C)
+where
+    C: ClientT + SubscriptionClientT + Sync,
+{
+    let url = "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@10.3.58.6:30303?discport=30301";
+    let node: NodeRecord = url.parse().unwrap();
+
+    AdminApiClient::add_peer(client, node).await.unwrap();
+    AdminApiClient::remove_peer(client, node).await.unwrap();
+    AdminApiClient::add_trusted_peer(client, node).await.unwrap();
+    AdminApiClient::remove_trusted_peer(client, node).await.unwrap();
+    AdminApiClient::node_info(client).await.unwrap();
+}
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_launch_http() {
-    let _builder = test_rpc_builder();
+async fn test_call_admin_functions_http() {
+    reth_tracing::init_test_tracing();
+
+    let handle = launch_http(vec![RethRpcModule::Admin]).await;
+    let client = handle.http_client().unwrap();
+    test_basic_admin_calls(&client).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_call_admin_functions_ws() {
+    reth_tracing::init_test_tracing();
+
+    let handle = launch_ws(vec![RethRpcModule::Admin]).await;
+    let client = handle.ws_client().await.unwrap();
+    test_basic_admin_calls(&client).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_call_admin_functions_http_and_ws() {
+    reth_tracing::init_test_tracing();
+
+    let handle = launch_http_ws(vec![RethRpcModule::Admin]).await;
+    let client = handle.http_client().unwrap();
+    test_basic_admin_calls(&client).await;
 }

--- a/crates/rpc/rpc-builder/tests/it/utils.rs
+++ b/crates/rpc/rpc-builder/tests/it/utils.rs
@@ -1,8 +1,55 @@
+use reth_network_api::test_utils::NoopNetwork;
 use reth_provider::test_utils::NoopProvider;
-use reth_rpc_builder::RpcModuleBuilder;
+use reth_rpc_builder::{
+    RpcModuleBuilder, RpcModuleConfig, RpcServerConfig, RpcServerHandle, TransportRpcModuleConfig,
+};
 use reth_transaction_pool::test_utils::{testing_pool, TestPool};
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+
+/// Localhost with port 0 so a free port is used.
+pub fn test_address() -> SocketAddr {
+    SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0))
+}
+
+/// Launches a new server with http only with the given modules
+pub async fn launch_http(modules: impl Into<RpcModuleConfig>) -> RpcServerHandle {
+    let builder = test_rpc_builder();
+    let server = builder.build(TransportRpcModuleConfig::http(modules));
+    server
+        .start_server(RpcServerConfig::http(Default::default()).with_address(test_address()))
+        .await
+        .unwrap()
+}
+
+/// Launches a new server with ws only with the given modules
+pub async fn launch_ws(modules: impl Into<RpcModuleConfig>) -> RpcServerHandle {
+    let builder = test_rpc_builder();
+    let server = builder.build(TransportRpcModuleConfig::ws(modules));
+    server
+        .start_server(RpcServerConfig::ws(Default::default()).with_address(test_address()))
+        .await
+        .unwrap()
+}
+
+/// Launches a new server with http and ws and with the given modules
+pub async fn launch_http_ws(modules: impl Into<RpcModuleConfig>) -> RpcServerHandle {
+    let builder = test_rpc_builder();
+    let modules = modules.into();
+    let server = builder.build(TransportRpcModuleConfig::ws(modules.clone()).with_http(modules));
+    server
+        .start_server(
+            RpcServerConfig::ws(Default::default())
+                .with_http(Default::default())
+                .with_address(test_address()),
+        )
+        .await
+        .unwrap()
+}
 
 /// Returns an [RpcModuleBuilder] with testing components.
-pub fn test_rpc_builder() -> RpcModuleBuilder<NoopProvider, TestPool, ()> {
-    RpcModuleBuilder::default().with_client(NoopProvider::default()).with_pool(testing_pool())
+pub fn test_rpc_builder() -> RpcModuleBuilder<NoopProvider, TestPool, NoopNetwork> {
+    RpcModuleBuilder::default()
+        .with_client(NoopProvider::default())
+        .with_pool(testing_pool())
+        .with_network(NoopNetwork::default())
 }

--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -46,7 +46,7 @@ where
         Ok(true)
     }
 
-    fn subscribe(
+    fn subscribe_peer_events(
         &self,
         _subscription_sink: jsonrpsee::SubscriptionSink,
     ) -> jsonrpsee::types::SubscriptionResult {


### PR DESCRIPTION
adds mostly util code for testing RPC namespaces.

will create followups/good first issues to test each namespace.