### PR TITLE
feat: create primitive to rpc conversions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4680,6 +4680,7 @@ dependencies = [
  "reth-rlp",
  "serde",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -86,6 +86,7 @@ pub type TransitionId = u64;
 pub use ethers_core::{
     types as rpc,
     types::{BigEndianHash, H128, H64, U64},
+    utils as rpc_utils,
 };
 pub use revm_interpreter::{ruint::aliases::U128, B160 as H160, B256 as H256, U256};
 

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -182,11 +182,11 @@ impl Transaction {
     }
 
     /// Get chain_id.
-    pub fn chain_id(&self) -> Option<&u64> {
+    pub fn chain_id(&self) -> Option<u64> {
         match self {
-            Transaction::Legacy(TxLegacy { chain_id, .. }) => chain_id.as_ref(),
-            Transaction::Eip2930(TxEip2930 { chain_id, .. }) => Some(chain_id),
-            Transaction::Eip1559(TxEip1559 { chain_id, .. }) => Some(chain_id),
+            Transaction::Legacy(TxLegacy { chain_id, .. }) => *chain_id,
+            Transaction::Eip2930(TxEip2930 { chain_id, .. }) => Some(*chain_id),
+            Transaction::Eip1559(TxEip1559 { chain_id, .. }) => Some(*chain_id),
         }
     }
 
@@ -735,7 +735,7 @@ impl proptest::arbitrary::Arbitrary for TransactionSigned {
 
         any::<(Transaction, Signature)>()
             .prop_map(move |(mut transaction, sig)| {
-                if let Some(chain_id) = transaction.chain_id().cloned() {
+                if let Some(chain_id) = transaction.chain_id() {
                     // Otherwise we might overflow when calculating `v` on `recalculate_hash`
                     transaction.set_chain_id(chain_id % (u64::MAX / 2 - 36));
                 }
@@ -752,7 +752,7 @@ impl proptest::arbitrary::Arbitrary for TransactionSigned {
 impl<'a> arbitrary::Arbitrary<'a> for TransactionSigned {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let mut transaction = Transaction::arbitrary(u)?;
-        if let Some(chain_id) = transaction.chain_id().cloned() {
+        if let Some(chain_id) = transaction.chain_id() {
             // Otherwise we might overflow when calculating `v` on `recalculate_hash`
             transaction.set_chain_id(chain_id % (u64::MAX / 2 - 36));
         }

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -254,6 +254,18 @@ impl Transaction {
         }
     }
 
+    /// Max priority fee per gas for eip1559 transaction, for legacy and eip2930 transactions this
+    /// is `None`
+    pub fn max_priority_fee_per_gas(&self) -> Option<u128> {
+        match self {
+            Transaction::Legacy(_) => None,
+            Transaction::Eip2930(_) => None,
+            Transaction::Eip1559(TxEip1559 { max_priority_fee_per_gas, .. }) => {
+                Some(*max_priority_fee_per_gas)
+            }
+        }
+    }
+
     /// Get the transaction's input field.
     pub fn input(&self) -> &Bytes {
         match self {

--- a/crates/primitives/src/transaction/signature.rs
+++ b/crates/primitives/src/transaction/signature.rs
@@ -37,7 +37,7 @@ impl Signature {
 
     /// Output the `v` of the signature depends on chain_id
     #[inline]
-    fn v(&self, chain_id: Option<u64>) -> u64 {
+    pub fn v(&self, chain_id: Option<u64>) -> u64 {
         if let Some(chain_id) = chain_id {
             // EIP-155: v = {0, 1} + CHAIN_ID * 2 + 35
             self.odd_y_parity as u64 + chain_id * 2 + 35

--- a/crates/rpc/rpc-types/Cargo.toml
+++ b/crates/rpc/rpc-types/Cargo.toml
@@ -14,6 +14,9 @@ reth-primitives = { path = "../../primitives" }
 reth-rlp = { path = "../../rlp" }
 reth-network-api = { path = "../../net/network-api"}
 
+# errors
+thiserror = "1.0"
+
 # misc
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/rpc/rpc-types/src/eth/block.rs
+++ b/crates/rpc/rpc-types/src/eth/block.rs
@@ -1,7 +1,7 @@
 //! Contains types that represent ethereum types in [reth_primitives] when used in RPC
 use crate::Transaction;
 use reth_primitives::{
-    Address, Block as RethBlock, Bloom, Bytes, Header as RethHeader, H256, H64, U256,
+    Address, Block as PrimitiveBlock, Bloom, Bytes, Header as RethHeader, H256, H64, U256,
 };
 use reth_rlp::Encodable;
 use serde::{ser::Error, Deserialize, Serialize, Serializer};
@@ -46,9 +46,12 @@ pub struct Block {
 }
 
 impl Block {
-    /// Create a new block response from a reth block, using the total difficulty to populate its
-    /// field in the rpc response.
-    pub fn from_block_full(block: RethBlock, total_difficulty: U256) -> Result<Self, BlockError> {
+    /// Create a new block response from a [primitive block](reth_primitives::Block), using the
+    /// total difficulty to populate its field in the rpc response.
+    pub fn from_block_full(
+        block: PrimitiveBlock,
+        total_difficulty: U256,
+    ) -> Result<Self, BlockError> {
         let block_hash = block.header.hash_slow();
         let header_length = block.header.length();
         let block_length = block.length();

--- a/crates/rpc/rpc-types/src/eth/block.rs
+++ b/crates/rpc/rpc-types/src/eth/block.rs
@@ -1,5 +1,8 @@
 use crate::Transaction;
-use reth_primitives::{Address, Bloom, Bytes, H256, H64, U256};
+use reth_primitives::{
+    Address, Block as RethBlock, Bloom, Bytes, Header as RethHeader, H256, H64, U256,
+};
+use reth_rlp::Encodable;
 use serde::{ser::Error, Deserialize, Serialize, Serializer};
 use std::{collections::BTreeMap, ops::Deref};
 
@@ -11,6 +14,14 @@ pub enum BlockTransactions {
     Hashes(Vec<H256>),
     /// Full transactions
     Full(Vec<Transaction>),
+}
+
+/// Error that can occur when converting other types to blocks
+#[derive(Debug, thiserror::Error)]
+pub enum BlockError {
+    /// A transaction failed sender recovery
+    #[error("transaction failed sender recovery")]
+    InvalidSignature,
 }
 
 /// Block representation
@@ -31,6 +42,80 @@ pub struct Block {
     /// Base Fee for post-EIP1559 blocks.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub base_fee_per_gas: Option<U256>,
+}
+
+impl Block {
+    /// Create a new block response from a reth block, using the total difficulty to populate its
+    /// field in the rpc response.
+    pub(crate) fn from_block_full(
+        block: RethBlock,
+        total_difficulty: U256,
+    ) -> Result<Self, BlockError> {
+        let block_hash = block.header.hash_slow();
+        let header_length = block.header.length();
+        let block_length = block.length();
+        let uncles = block.ommers.into_iter().map(|h| h.hash_slow()).collect();
+
+        let RethHeader {
+            parent_hash,
+            ommers_hash,
+            beneficiary,
+            state_root,
+            transactions_root,
+            receipts_root,
+            logs_bloom,
+            difficulty,
+            number,
+            gas_limit,
+            gas_used,
+            timestamp,
+            mix_hash,
+            nonce,
+            base_fee_per_gas,
+            extra_data,
+        } = block.header;
+
+        let header = Header {
+            hash: Some(block_hash),
+            parent_hash,
+            uncles_hash: ommers_hash,
+            author: beneficiary,
+            miner: beneficiary,
+            state_root,
+            transactions_root,
+            receipts_root,
+            number: Some(U256::from(number)),
+            gas_used: U256::from(gas_used),
+            gas_limit: U256::from(gas_limit),
+            extra_data,
+            logs_bloom,
+            timestamp: U256::from(timestamp),
+            difficulty,
+            mix_hash,
+            nonce: Some(nonce.to_be_bytes().into()),
+            size: Some(U256::from(header_length)),
+        };
+
+        let mut transactions = Vec::new();
+        for (idx, tx) in block.body.iter().enumerate() {
+            let signed_tx = tx.clone().into_ecrecovered().ok_or(BlockError::InvalidSignature)?;
+            transactions.push(Transaction::from_recovered_with_block_context(
+                signed_tx,
+                block_hash,
+                number,
+                U256::from(idx),
+            ))
+        }
+
+        Ok(Self {
+            header,
+            uncles,
+            transactions: BlockTransactions::Full(transactions),
+            base_fee_per_gas: base_fee_per_gas.map(U256::from),
+            total_difficulty,
+            size: Some(U256::from(block_length)),
+        })
+    }
 }
 
 /// Block header representation.

--- a/crates/rpc/rpc-types/src/eth/block.rs
+++ b/crates/rpc/rpc-types/src/eth/block.rs
@@ -93,7 +93,7 @@ impl Block {
             size: Some(U256::from(header_length)),
         };
 
-        let mut transactions = Vec::new();
+        let mut transactions = Vec::with_capacity(block.body.len());
         for (idx, tx) in block.body.iter().enumerate() {
             let signed_tx = tx.clone().into_ecrecovered().ok_or(BlockError::InvalidSignature)?;
             transactions.push(Transaction::from_recovered_with_block_context(

--- a/crates/rpc/rpc-types/src/eth/block.rs
+++ b/crates/rpc/rpc-types/src/eth/block.rs
@@ -47,10 +47,7 @@ pub struct Block {
 impl Block {
     /// Create a new block response from a reth block, using the total difficulty to populate its
     /// field in the rpc response.
-    pub(crate) fn from_block_full(
-        block: RethBlock,
-        total_difficulty: U256,
-    ) -> Result<Self, BlockError> {
+    pub fn from_block_full(block: RethBlock, total_difficulty: U256) -> Result<Self, BlockError> {
         let block_hash = block.header.hash_slow();
         let header_length = block.header.length();
         let block_length = block.length();

--- a/crates/rpc/rpc-types/src/eth/block.rs
+++ b/crates/rpc/rpc-types/src/eth/block.rs
@@ -1,3 +1,4 @@
+//! Contains types that represent ethereum types in [reth_primitives] when used in RPC
 use crate::Transaction;
 use reth_primitives::{
     Address, Block as RethBlock, Bloom, Bytes, Header as RethHeader, H256, H64, U256,

--- a/crates/rpc/rpc-types/src/eth/transaction/mod.rs
+++ b/crates/rpc/rpc-types/src/eth/transaction/mod.rs
@@ -103,7 +103,7 @@ impl Transaction {
             TxType::EIP1559 => (None, Some(U128::from(signed_tx.max_fee_per_gas()))),
         };
 
-        let chain_id = signed_tx.chain_id().map(|id| U64::from(id));
+        let chain_id = signed_tx.chain_id().map(U64::from);
         let access_list = match &signed_tx.transaction {
             RethTransaction::Legacy(_) => None,
             RethTransaction::Eip2930(tx) => Some(

--- a/crates/rpc/rpc-types/src/eth/transaction/signature.rs
+++ b/crates/rpc/rpc-types/src/eth/transaction/signature.rs
@@ -1,5 +1,5 @@
 //! Signature related RPC values
-use reth_primitives::{Signature as CoreSignature, U256};
+use reth_primitives::{Signature as PrimitiveSignature, U256};
 use serde::{Deserialize, Serialize};
 
 /// Container type for all signature fields in RPC
@@ -19,7 +19,7 @@ impl Signature {
     /// the give chain id to compute the signature's recovery id.
     ///
     /// If the chain id is `Some`, the recovery id is computed according to [EIP-155](https://eips.ethereum.org/EIPS/eip-155).
-    pub fn from_primitive_signature(signature: CoreSignature, chain_id: Option<u64>) -> Self {
+    pub fn from_primitive_signature(signature: PrimitiveSignature, chain_id: Option<u64>) -> Self {
         Self { r: signature.r, s: signature.s, v: U256::from(signature.v(chain_id)) }
     }
 }

--- a/crates/rpc/rpc-types/src/eth/transaction/signature.rs
+++ b/crates/rpc/rpc-types/src/eth/transaction/signature.rs
@@ -1,5 +1,5 @@
 //! Signature related RPC values
-use reth_primitives::U256;
+use reth_primitives::{Signature as CoreSignature, U256};
 use serde::{Deserialize, Serialize};
 
 /// Container type for all signature fields in RPC
@@ -9,6 +9,17 @@ pub struct Signature {
     pub r: U256,
     /// The S field of the signature; the point on the curve.
     pub s: U256,
-    /// The standardised V field of the signature (0 or 1).
+    // todo: not just 0 or 1, due to eip155
+    /// The standardised recovery id of the signature (0 or 1).
     pub v: U256,
+}
+
+impl Signature {
+    /// Creates a new rpc signature from a [primitive signature](reth_primitives::Signature), using
+    /// the give chain id to compute the signature's recovery id.
+    ///
+    /// If the chain id is `Some`, the recovery id is computed according to [EIP-155](https://eips.ethereum.org/EIPS/eip-155).
+    pub fn from_primitive_signature(signature: CoreSignature, chain_id: Option<u64>) -> Self {
+        Self { r: signature.r, s: signature.s, v: U256::from(signature.v(chain_id)) }
+    }
 }

--- a/crates/rpc/rpc/src/eth/api/block.rs
+++ b/crates/rpc/rpc/src/eth/api/block.rs
@@ -15,8 +15,14 @@ where
         _full: bool,
     ) -> EthResult<Option<RichBlock>> {
         let block = self.client().block(BlockId::Hash(hash.0.into()))?;
-        // TODO: chain info total difficulty
-        todo!()
+        if let Some(_block) = block {
+            // TODO: GET TD FOR BLOCK - needs block provider? or header provider?
+            // let total_difficulty = todo!();
+            // let rich_block = Block::from_block_full(block, total_difficulty);
+            todo!()
+        } else {
+            Ok(None)
+        }
     }
 
     pub(crate) async fn block_by_number(
@@ -25,7 +31,13 @@ where
         _full: bool,
     ) -> EthResult<Option<RichBlock>> {
         let block = self.client().block(BlockId::Number(number.into()))?;
-        // TODO: chain info total difficulty
-        todo!()
+        if let Some(_block) = block {
+            // TODO: GET TD FOR BLOCK - needs block provider? or header provider?
+            // let total_difficulty = todo!();
+            // let rich_block = Block::from_block_full(block, total_difficulty);
+            todo!()
+        } else {
+            Ok(None)
+        }
     }
 }

--- a/crates/rpc/rpc/src/eth/api/block.rs
+++ b/crates/rpc/rpc/src/eth/api/block.rs
@@ -15,6 +15,7 @@ where
         _full: bool,
     ) -> EthResult<Option<RichBlock>> {
         let block = self.client().block(BlockId::Hash(hash.0.into()))?;
+        // TODO: chain info total difficulty
         todo!()
     }
 
@@ -24,6 +25,7 @@ where
         _full: bool,
     ) -> EthResult<Option<RichBlock>> {
         let block = self.client().block(BlockId::Number(number.into()))?;
+        // TODO: chain info total difficulty
         todo!()
     }
 }

--- a/crates/rpc/rpc/src/eth/api/block.rs
+++ b/crates/rpc/rpc/src/eth/api/block.rs
@@ -1,7 +1,7 @@
 //! Contains RPC handler implementations specific to blocks.
 
 use crate::{eth::error::EthResult, EthApi};
-use reth_primitives::H256;
+use reth_primitives::{rpc::BlockId, BlockNumber, H256};
 use reth_provider::{BlockProvider, StateProviderFactory};
 use reth_rpc_types::RichBlock;
 
@@ -11,9 +11,19 @@ where
 {
     pub(crate) async fn block_by_hash(
         &self,
-        _hash: H256,
+        hash: H256,
         _full: bool,
     ) -> EthResult<Option<RichBlock>> {
+        let block = self.client().block(BlockId::Hash(hash.0.into()))?;
+        todo!()
+    }
+
+    pub(crate) async fn block_by_number(
+        &self,
+        number: BlockNumber,
+        _full: bool,
+    ) -> EthResult<Option<RichBlock>> {
+        let block = self.client().block(BlockId::Number(number.into()))?;
         todo!()
     }
 }


### PR DESCRIPTION
The provider traits work with types from `reth_primitives`, but RPC uses separate types from `reth_rpc_types`, so we need to create conversions between these types to return the right information over RPC.

Block conversions:
```rust
/// Create a new block response from a reth block, using the total difficulty to populate its
/// field in the rpc response.
pub fn from_block_full(block: PrimitiveBlock, total_difficulty: U256) -> Result<Self, BlockError>
```

Transaction conversions:
```rust
/// Create a new rpc transction result, using the given block hash, number, and tx index fields
/// to populate the corresponing fields in the rpc result.
pub(crate) fn from_recovered_with_block_context(
    tx: TransactionSignedEcRecovered,
    block_hash: H256,
    block_number: BlockNumber,
    tx_index: U256,
) -> Self

/// Create a new rpc transaction result from a signed and recovered transaction, setting
/// environment related fields to `None`.
///
/// Sets the sender public key to `None` as well.
pub(crate) fn from_recovered(tx: TransactionSignedEcRecovered) -> Self
```

Signature conversions:
```rust
/// Creates a new rpc signature from a [primitive signature](reth_primitives::Signature), using
/// the give chain id to compute the signature's recovery id.
///
/// If the chain id is `Some`, the recovery id is computed according to [EIP-155](https://eips.ethereum.org/EIPS/eip-155).
pub fn from_primitive_signature(signature: PrimitiveSignature, chain_id: Option<u64>) -> Self {
    Self { r: signature.r, s: signature.s, v: U256::from(signature.v(chain_id)) }
}
```