### PR TITLE
fix(consensus): has_block_reward() should return `true` before `Paris`

### DIFF
--- a/crates/consensus/src/beacon/beacon_consensus.rs
+++ b/crates/consensus/src/beacon/beacon_consensus.rs
@@ -81,6 +81,21 @@ impl Consensus for BeaconConsensus {
     }
 
     fn has_block_reward(&self, total_difficulty: U256) -> bool {
-        self.chain_spec.fork(Hardfork::Paris).active_at_ttd(total_difficulty)
+        !self.chain_spec.fork(Hardfork::Paris).active_at_ttd(total_difficulty)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use reth_interfaces::consensus::Consensus;
+    use reth_primitives::{ChainSpecBuilder, U256};
+
+    use super::BeaconConsensus;
+
+    #[test]
+    fn test_has_block_reward_before_paris() {
+        let chain_spec = ChainSpecBuilder::mainnet().build();
+        let (consensus, _) = BeaconConsensus::builder().build(chain_spec);
+        assert!(consensus.has_block_reward(U256::ZERO));
     }
 }


### PR DESCRIPTION
Closes #1218 

### Describe the bug

When I run `cargo run --release -- node --debug.tip 0x8e38b4dbf6b11fcc3b9dee84fb7986e29ca0a02cecd8977c161ff7333329681e`, I met an error, `A stage encountered an irrecoverable error.`

```
Error: A stage encountered an irrecoverable error.

Caused by:
   0: An internal database error occurred: Database write error code: 4294936878
   1: Database write error code: 4294936878
```

### Description to fix
* The error is occurred when appending data with `transition_id` to `StorageChangeSet` table.
* After investigating and learning from code, I've found that `transition_id` is not increased because `has_block_reward()` returns `false`.

### Personal Note
* I had to use much time to catch it but I think it's really fun and meaningful time for me to understand Ethereum itself and also reth codebase.
* I think it's really good activity to fix a bug for a newbie in order to understand codebase.