### PR TITLE
fix: remove ctrl handling

### DIFF
--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -142,10 +142,9 @@ impl Command {
 
         // Run pipeline
         info!(target: "reth::cli", "Starting sync pipeline");
-        tokio::select! {
-            res = pipeline.run(db.clone()) => res?,
-            _ = tokio::signal::ctrl_c() => {},
-        };
+        pipeline.run(db.clone()).await?;
+
+        // TODO: this is where we'd handle graceful shutdown by listening to ctrl-c
 
         if !self.network.no_persist_peers {
             dump_peers(self.network.peers_file.as_ref(), network).await?;


### PR DESCRIPTION
this removes the concurrent ctrl-c listener that's combined with the pipeline.

Some stages are currently blocking the task so the ctrl-c isn't caught if we're listening for it concurrently with pipeline.

short term fix:
* remove ctrl listener: this PR
* long term: #1036 