### PR TITLE
chore: document parts of ECIES and MAC

### DIFF
--- a/crates/net/ecies/src/algorithm.rs
+++ b/crates/net/ecies/src/algorithm.rs
@@ -362,7 +362,6 @@ impl ECIES {
         buf
     }
 
-    // TODO: document more
     /// Write an `ack` message to the given buffer.
     pub fn write_ack(&mut self, out: &mut BytesMut) {
         let unencrypted = self.create_ack_unencrypted();
@@ -415,7 +414,6 @@ impl ECIES {
         Ok(())
     }
 
-    // TODO: document
     fn setup_frame(&mut self, incoming: bool) {
         let mut hasher = Keccak256::new();
         for el in &if incoming {
@@ -470,7 +468,6 @@ impl ECIES {
         out
     }
 
-    // TODO: document
     pub fn write_header(&mut self, out: &mut BytesMut, size: usize) {
         let mut buf = [0u8; 8];
         BigEndian::write_uint(&mut buf, size as u64, 3);

--- a/crates/net/ecies/src/mac.rs
+++ b/crates/net/ecies/src/mac.rs
@@ -10,6 +10,15 @@ use typenum::U16;
 
 pub type HeaderBytes = GenericArray<u8, U16>;
 
+// TODO: documentation / better specification
+// TODO: prove or disprove unforgeability
+/// [`Ethereum MAC`](https://github.com/ethereum/devp2p/blob/master/rlpx.md#mac) state.
+///
+/// The ethereum MAC is a cursed MAC construction.
+///
+/// The ethereum MAC is a nonstandard MAC construction that uses AES-256 (without a mode, as a
+/// block cipher) and Keccak-256. However, it only ever encrypts messages that are 128 bits long,
+/// and is not defined as a general MAC.
 #[derive(Debug)]
 pub struct MAC {
     secret: H256,
@@ -17,17 +26,21 @@ pub struct MAC {
 }
 
 impl MAC {
+    /// Initialize the MAC with the given secret
     pub fn new(secret: H256) -> Self {
         Self { secret, hasher: Keccak256::new() }
     }
 
+    /// Update the internal keccak256 hasher with the given data
     pub fn update(&mut self, data: &[u8]) {
         self.hasher.update(data)
     }
 
+    /// Accumulate the given [`HeaderBytes`] into the MAC's internal state.
     pub fn update_header(&mut self, data: &HeaderBytes) {
         let aes = Aes256Enc::new_from_slice(self.secret.as_ref()).unwrap();
         let mut encrypted = self.digest().to_fixed_bytes();
+
         aes.encrypt_padded::<NoPadding>(&mut encrypted, H128::len_bytes()).unwrap();
         for i in 0..data.len() {
             encrypted[i] ^= data[i];
@@ -35,11 +48,13 @@ impl MAC {
         self.hasher.update(encrypted);
     }
 
+    /// Accumulate the given message body into the MAC's internal state.
     pub fn update_body(&mut self, data: &[u8]) {
         self.hasher.update(data);
         let prev = self.digest();
         let aes = Aes256Enc::new_from_slice(self.secret.as_ref()).unwrap();
         let mut encrypted = self.digest().to_fixed_bytes();
+
         aes.encrypt_padded::<NoPadding>(&mut encrypted, H128::len_bytes()).unwrap();
         for i in 0..16 {
             encrypted[i] ^= prev[i];
@@ -47,6 +62,8 @@ impl MAC {
         self.hasher.update(encrypted);
     }
 
+    /// Produce a digest by finalizing the internal keccak256 hasher and returning the first 128
+    /// bits.
     pub fn digest(&self) -> H128 {
         H128::from_slice(&self.hasher.clone().finalize()[..16])
     }

--- a/crates/net/ecies/src/mac.rs
+++ b/crates/net/ecies/src/mac.rs
@@ -10,8 +10,6 @@ use typenum::U16;
 
 pub type HeaderBytes = GenericArray<u8, U16>;
 
-// TODO: documentation / better specification
-// TODO: prove or disprove unforgeability
 /// [`Ethereum MAC`](https://github.com/ethereum/devp2p/blob/master/rlpx.md#mac) state.
 ///
 /// The ethereum MAC is a cursed MAC construction.


### PR DESCRIPTION
These methods should eventually be more well documented and specified. This makes progress on documenting the RLPx MAC and ECIES implementations

_priority for review: not urgent_