### PR TITLE
chore: make clippy happy

### DIFF
--- a/bin/reth/src/chain/import.rs
+++ b/bin/reth/src/chain/import.rs
@@ -146,7 +146,6 @@ impl ImportCommand {
             .add_stages(
                 OfflineStages::default()
                     .set(SenderRecoveryStage {
-                        batch_size: config.stages.sender_recovery.batch_size,
                         commit_threshold: config.stages.sender_recovery.commit_threshold,
                     })
                     .set(ExecutionStage {


### PR DESCRIPTION
Sender recovery stage and config no longer include the `batch_size` field, so it is removed from the import config