### PR TITLE
feat(primitives): rm RawBlockBody, use Block

### DIFF
--- a/crates/net/downloaders/src/bodies/test_utils.rs
+++ b/crates/net/downloaders/src/bodies/test_utils.rs
@@ -6,9 +6,9 @@ use reth_db::{
     tables,
     transaction::DbTxMut,
 };
-use reth_eth_wire::{BlockBody, RawBlockBody};
+use reth_eth_wire::BlockBody;
 use reth_interfaces::{db, p2p::bodies::response::BlockResponse};
-use reth_primitives::{SealedBlock, SealedHeader, H256};
+use reth_primitives::{SealedBlock, SealedHeader, H256, Block};
 use std::collections::HashMap;
 
 pub(crate) fn zip_blocks<'a>(
@@ -35,7 +35,7 @@ pub(crate) fn zip_blocks<'a>(
 pub(crate) fn create_raw_bodies<'a>(
     headers: impl Iterator<Item = &'a SealedHeader>,
     bodies: &mut HashMap<H256, BlockBody>,
-) -> Vec<RawBlockBody> {
+) -> Vec<Block> {
     headers
         .into_iter()
         .map(|header| {

--- a/crates/net/downloaders/src/bodies/test_utils.rs
+++ b/crates/net/downloaders/src/bodies/test_utils.rs
@@ -8,7 +8,7 @@ use reth_db::{
 };
 use reth_eth_wire::BlockBody;
 use reth_interfaces::{db, p2p::bodies::response::BlockResponse};
-use reth_primitives::{SealedBlock, SealedHeader, H256, Block};
+use reth_primitives::{Block, SealedBlock, SealedHeader, H256};
 use std::collections::HashMap;
 
 pub(crate) fn zip_blocks<'a>(

--- a/crates/net/downloaders/src/test_utils/file_client.rs
+++ b/crates/net/downloaders/src/test_utils/file_client.rs
@@ -1,6 +1,6 @@
 use super::file_codec::BlockFileCodec;
 use itertools::Either;
-use reth_eth_wire::{BlockBody, RawBlockBody};
+use reth_eth_wire::BlockBody;
 use reth_interfaces::{
     p2p::{
         bodies::client::{BodiesClient, BodiesFut},
@@ -104,7 +104,7 @@ impl FileClient {
             hash_to_number.insert(block_hash, block.header.number);
             bodies.insert(
                 block_hash,
-                BlockBody { transactions: block.transactions, ommers: block.ommers },
+                BlockBody { transactions: block.body, ommers: block.ommers },
             );
         }
 

--- a/crates/net/downloaders/src/test_utils/file_client.rs
+++ b/crates/net/downloaders/src/test_utils/file_client.rs
@@ -102,10 +102,7 @@ impl FileClient {
             // add to the internal maps
             headers.insert(block.header.number, block.header.clone());
             hash_to_number.insert(block_hash, block.header.number);
-            bodies.insert(
-                block_hash,
-                BlockBody { transactions: block.body, ommers: block.ommers },
-            );
+            bodies.insert(block_hash, BlockBody { transactions: block.body, ommers: block.ommers });
         }
 
         trace!(blocks = headers.len(), "Initialized file client");

--- a/crates/net/downloaders/src/test_utils/file_codec.rs
+++ b/crates/net/downloaders/src/test_utils/file_codec.rs
@@ -1,7 +1,7 @@
 //! Codec for reading raw block bodies from a file.
 use super::FileClientError;
 use bytes::{Buf, BytesMut};
-use reth_eth_wire::RawBlockBody;
+use reth_primitives::Block;
 use reth_rlp::{Decodable, Encodable};
 use tokio_util::codec::{Decoder, Encoder};
 
@@ -21,7 +21,7 @@ use tokio_util::codec::{Decoder, Encoder};
 pub(crate) struct BlockFileCodec;
 
 impl Decoder for BlockFileCodec {
-    type Item = RawBlockBody;
+    type Item = Block;
     type Error = FileClientError;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
@@ -29,16 +29,16 @@ impl Decoder for BlockFileCodec {
             return Ok(None)
         }
         let mut buf_slice = &mut src.as_ref();
-        let body = RawBlockBody::decode(buf_slice)?;
+        let body = Block::decode(buf_slice)?;
         src.advance(src.len() - buf_slice.len());
         Ok(Some(body))
     }
 }
 
-impl Encoder<RawBlockBody> for BlockFileCodec {
+impl Encoder<Block> for BlockFileCodec {
     type Error = FileClientError;
 
-    fn encode(&mut self, item: RawBlockBody, dst: &mut BytesMut) -> Result<(), Self::Error> {
+    fn encode(&mut self, item: Block, dst: &mut BytesMut) -> Result<(), Self::Error> {
         item.encode(dst);
         Ok(())
     }

--- a/crates/net/eth-wire/src/types/blocks.rs
+++ b/crates/net/eth-wire/src/types/blocks.rs
@@ -1,8 +1,7 @@
 //! Implements the `GetBlockHeaders`, `GetBlockBodies`, `BlockHeaders`, and `BlockBodies` message
 //! types.
-use super::RawBlockBody;
 use reth_codecs::derive_arbitrary;
-use reth_primitives::{BlockHashOrNumber, Header, HeadersDirection, TransactionSigned, H256};
+use reth_primitives::{BlockHashOrNumber, Header, HeadersDirection, TransactionSigned, H256, Block};
 use reth_rlp::{RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper};
 
 #[cfg(feature = "serde")]
@@ -80,11 +79,11 @@ pub struct BlockBody {
 }
 
 impl BlockBody {
-    /// Create a [`RawBlockBody`] from the body and its header.
-    pub fn create_block(&self, header: &Header) -> RawBlockBody {
-        RawBlockBody {
+    /// Create a [`Block`](reth_primitives::Block) from the body and its header.
+    pub fn create_block(&self, header: &Header) -> Block {
+        Block {
             header: header.clone(),
-            transactions: self.transactions.clone(),
+            body: self.transactions.clone(),
             ommers: self.ommers.clone(),
         }
     }

--- a/crates/net/eth-wire/src/types/blocks.rs
+++ b/crates/net/eth-wire/src/types/blocks.rs
@@ -1,7 +1,9 @@
 //! Implements the `GetBlockHeaders`, `GetBlockBodies`, `BlockHeaders`, and `BlockBodies` message
 //! types.
 use reth_codecs::derive_arbitrary;
-use reth_primitives::{BlockHashOrNumber, Header, HeadersDirection, TransactionSigned, H256, Block};
+use reth_primitives::{
+    Block, BlockHashOrNumber, Header, HeadersDirection, TransactionSigned, H256,
+};
 use reth_rlp::{RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper};
 
 #[cfg(feature = "serde")]

--- a/crates/net/eth-wire/src/types/broadcast.rs
+++ b/crates/net/eth-wire/src/types/broadcast.rs
@@ -1,6 +1,6 @@
 //! Types for broadcasting new data.
 use reth_codecs::derive_arbitrary;
-use reth_primitives::{TransactionSigned, H256, U128, Block};
+use reth_primitives::{Block, TransactionSigned, H256, U128};
 use reth_rlp::{RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper};
 use std::sync::Arc;
 

--- a/crates/net/eth-wire/src/types/broadcast.rs
+++ b/crates/net/eth-wire/src/types/broadcast.rs
@@ -1,6 +1,6 @@
 //! Types for broadcasting new data.
 use reth_codecs::derive_arbitrary;
-use reth_primitives::{Header, TransactionSigned, H256, U128};
+use reth_primitives::{TransactionSigned, H256, U128, Block};
 use reth_rlp::{RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper};
 use std::sync::Arc;
 
@@ -54,19 +54,6 @@ impl From<NewBlockHashes> for Vec<BlockHashNumber> {
     }
 }
 
-/// A block body, including transactions and uncle headers.
-#[derive_arbitrary(rlp, 25)]
-#[derive(Debug, Clone, PartialEq, Eq, Default, RlpEncodable, RlpDecodable)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct RawBlockBody {
-    /// This block's header
-    pub header: Header,
-    /// Transactions in this block.
-    pub transactions: Vec<TransactionSigned>,
-    /// Uncle block headers.
-    pub ommers: Vec<Header>,
-}
-
 /// A new block with the current total difficulty, which includes the difficulty of the returned
 /// block.
 #[derive_arbitrary(rlp, 25)]
@@ -74,7 +61,7 @@ pub struct RawBlockBody {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct NewBlock {
     /// A new block.
-    pub block: RawBlockBody,
+    pub block: Block,
     /// The current total difficulty.
     pub td: U128,
 }

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -6,7 +6,9 @@ use std::ops::Deref;
 
 /// Ethereum full block.
 #[derive_arbitrary(rlp, 25)]
-#[derive(Debug, Clone, PartialEq, Eq, Default, RlpEncodable, RlpDecodable, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, Default, RlpEncodable, RlpDecodable, Serialize, Deserialize,
+)]
 pub struct Block {
     /// Block header.
     pub header: Header,

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -5,7 +5,8 @@ use serde::{Deserialize, Serialize};
 use std::ops::Deref;
 
 /// Ethereum full block.
-#[derive(Debug, Clone, PartialEq, Eq, Default, RlpEncodable, RlpDecodable)]
+#[derive_arbitrary(rlp, 25)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, RlpEncodable, RlpDecodable, Serialize, Deserialize)]
 pub struct Block {
     /// Block header.
     pub header: Header,


### PR DESCRIPTION
`reth_eth_wire::RawBlockBody` is the same as `reth_primitives::Block`, so let's just remove `RawBlockBody`, and use the primitive type for everything