### PR TITLE
ci: decrease proptest cases for `trie::arbitrary`

### DIFF
--- a/crates/stages/src/trie/mod.rs
+++ b/crates/stages/src/trie/mod.rs
@@ -366,6 +366,7 @@ impl DBTrieLoader {
 mod tests {
     use super::*;
     use assert_matches::assert_matches;
+    use proptest::{prelude::ProptestConfig, proptest};
     use reth_db::{mdbx::test_utils::create_test_rw_db, tables, transaction::DbTxMut};
     use reth_primitives::{
         hex_literal::hex,
@@ -623,7 +624,7 @@ mod tests {
 
     #[test]
     fn arbitrary() {
-        proptest::proptest!(|(accounts: BTreeMap<Address, (Account, BTreeSet<StorageEntry>)>)| {
+        proptest!(ProptestConfig::with_cases(10), |(accounts: BTreeMap<Address, (Account, BTreeSet<StorageEntry>)>)| {
             test_with_accounts(accounts);
         });
     }


### PR DESCRIPTION
CI is taking too long here. So it just decreases the number of proptest cases from default (256) to 10. 