### PR TITLE
chore: unify provider delegate macro

### DIFF
--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -146,6 +146,9 @@ delegate_provider_impls!(HistoricalStateProvider<'a, TX>);
 
 #[cfg(test)]
 mod tests {
+    use crate::{
+        AccountProvider, HistoricalStateProvider, HistoricalStateProviderRef, StateProvider,
+    };
     use reth_db::{
         database::Database,
         mdbx::test_utils::create_test_rw_db,
@@ -156,11 +159,15 @@ mod tests {
     };
     use reth_primitives::{hex_literal::hex, Account, StorageEntry, H160, H256, U256};
 
-    use crate::{AccountProvider, HistoricalStateProviderRef, StateProvider};
-
     const ADDRESS: H160 = H160(hex!("0000000000000000000000000000000000000001"));
     const STORAGE: H256 =
         H256(hex!("0000000000000000000000000000000000000000000000000000000000000001"));
+
+    fn assert_state_provider<T: StateProvider>() {}
+    #[allow(unused)]
+    fn assert_historical_state_provider<'txn, T: DbTx<'txn> + 'txn>() {
+        assert_state_provider::<HistoricalStateProvider<'txn, T>>();
+    }
 
     #[test]
     fn history_provider_get_account() {

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -77,3 +77,14 @@ impl<'a, TX: DbTx<'a>> LatestStateProvider<'a, TX> {
 
 // Delegates all provider impls to [LatestStateProviderRef]
 delegate_provider_impls!(LatestStateProvider<'a, TX>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_state_provider<T: StateProvider>() {}
+    #[allow(unused)]
+    fn assert_latest_state_provider<'txn, T: DbTx<'txn> + 'txn>() {
+        assert_state_provider::<LatestStateProvider<'txn, T>>();
+    }
+}

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -1,4 +1,7 @@
-use crate::{AccountProvider, BlockHashProvider, StateProvider};
+use crate::{
+    providers::state::macros::delegate_provider_impls, AccountProvider, BlockHashProvider,
+    StateProvider,
+};
 use reth_db::{cursor::DbDupCursorRO, tables, transaction::DbTx};
 use reth_interfaces::Result;
 use reth_primitives::{Account, Address, Bytes, StorageKey, StorageValue, H256, U256};
@@ -64,26 +67,13 @@ impl<'a, TX: DbTx<'a>> LatestStateProvider<'a, TX> {
     pub fn new(db: TX) -> Self {
         Self { db, _phantom: PhantomData {} }
     }
+
+    /// Returns a new provider that takes the `TX` as reference
+    #[inline(always)]
+    fn as_ref<'b>(&'b self) -> LatestStateProviderRef<'a, 'b, TX> {
+        LatestStateProviderRef::new(&self.db)
+    }
 }
 
-/// Derive trait implementation for [LatestStateProvider]
-/// from [LatestStateProviderRef] type.
-///
-/// Used to implement provider traits.
-macro_rules! derive_from_ref {
-    ($trait:ident, $(fn $func:ident(&self$(, )?$($arg_name:ident: $arg:ty),*) -> $ret:ty),*) => {
-        impl<'a, TX: DbTx<'a>> $trait for LatestStateProvider<'a, TX> {
-            $(fn $func(&self, $($arg_name: $arg),*) -> $ret {
-                LatestStateProviderRef::new(&self.db).$func($($arg_name),*)
-            })*
-        }
-    };
-}
-
-derive_from_ref!(AccountProvider, fn basic_account(&self, address: Address) -> Result<Option<Account>>);
-derive_from_ref!(BlockHashProvider, fn block_hash(&self, number: U256) -> Result<Option<H256>>);
-derive_from_ref!(
-    StateProvider,
-    fn storage(&self, account: Address, storage_key: StorageKey) -> Result<Option<StorageValue>>,
-    fn bytecode_by_hash(&self, code_hash: H256) -> Result<Option<Bytes>>
-);
+// Delegates all provider impls to [LatestStateProviderRef]
+delegate_provider_impls!(LatestStateProvider<'a, TX>);

--- a/crates/storage/provider/src/providers/state/macros.rs
+++ b/crates/storage/provider/src/providers/state/macros.rs
@@ -1,0 +1,47 @@
+//! Helper macros for implementing traits for various [StateProvider](crate::StateProvider)
+//! implementations
+
+/// A macro that delegates trait implementations to the `as_ref` function of the type.
+///
+/// Used to implement provider traits.
+macro_rules! delegate_impls_to_as_ref {
+    ( for $target:ty => $($trait:ident {  $(fn $func:ident(&self, $($arg:ident: $argty:ty),*) -> $ret:ty;)* })* ) => {
+
+        $(
+          impl<'a, TX: DbTx<'a>> $trait for $target {
+              $(
+                  fn $func(&self, $($arg: $argty),*) -> $ret {
+                    self.as_ref().$func($($arg),*)
+                  }
+              )*
+          }
+        )*
+    };
+}
+
+pub(crate) use delegate_impls_to_as_ref;
+
+/// Delegates the provider trait implementations to the `as_ref` function of the type:
+///
+/// [AccountProvider](crate::AccountProvider)
+/// [BlockHashProvider](crate::BlockHashProvider)
+/// [StateProvider](crate::StateProvider)
+macro_rules! delegate_provider_impls {
+    ($target:ty) => {
+        $crate::providers::state::macros::delegate_impls_to_as_ref!(
+            for $target =>
+            AccountProvider {
+                fn basic_account(&self, address: Address) -> Result<Option<Account>>;
+            }
+            BlockHashProvider {
+                fn block_hash(&self, number: U256) -> Result<Option<H256>>;
+            }
+            StateProvider {
+                fn storage(&self, account: Address, storage_key: StorageKey) -> Result<Option<StorageValue>>;
+                fn bytecode_by_hash(&self, code_hash: H256) -> Result<Option<Bytes>>;
+            }
+        );
+    }
+}
+
+pub(crate) use delegate_provider_impls;

--- a/crates/storage/provider/src/providers/state/mod.rs
+++ b/crates/storage/provider/src/providers/state/mod.rs
@@ -2,3 +2,4 @@
 pub(crate) mod chain;
 pub(crate) mod historical;
 pub(crate) mod latest;
+pub(crate) mod macros;


### PR DESCRIPTION
unifies both `derive_from_ref` macros into a single macro.

This makes it easier to add additional provider + delegate impls.