### PR TITLE
refactor: make SharableDatabase more relax

### DIFF
--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -239,7 +239,7 @@ impl Command {
         &self,
         config: &Config,
         db: &Arc<Env<WriteMap>>,
-    ) -> NetworkConfig<ShareableDatabase<Env<WriteMap>>> {
+    ) -> NetworkConfig<ShareableDatabase<Arc<Env<WriteMap>>>> {
         let peers_file = (!self.network.no_persist_peers).then_some(&self.network.peers_file);
         config.network_config(
             db.clone(),

--- a/crates/staged-sync/src/config.rs
+++ b/crates/staged-sync/src/config.rs
@@ -30,7 +30,7 @@ impl Config {
     /// Initializes network config from read data
     pub fn network_config<DB: Database>(
         &self,
-        db: Arc<DB>,
+        db: DB,
         chain_spec: ChainSpec,
         disable_discovery: bool,
         bootnodes: Option<Vec<NodeRecord>>,

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -6,7 +6,6 @@ use reth_db::{
 };
 use reth_interfaces::Result;
 use reth_primitives::{rpc::BlockId, Block, BlockHash, BlockNumber, ChainInfo, Header, H256, U256};
-use std::sync::Arc;
 
 mod state;
 pub use state::{
@@ -20,19 +19,19 @@ pub use state::{
 /// This provider implements most provider or provider factory traits.
 pub struct ShareableDatabase<DB> {
     /// Database
-    db: Arc<DB>,
+    db: DB,
 }
 
 impl<DB> ShareableDatabase<DB> {
     /// create new database provider
-    pub fn new(db: Arc<DB>) -> Self {
+    pub fn new(db: DB) -> Self {
         Self { db }
     }
 }
 
-impl<DB> Clone for ShareableDatabase<DB> {
+impl<DB: Clone> Clone for ShareableDatabase<DB> {
     fn clone(&self) -> Self {
-        Self { db: Arc::clone(&self.db) }
+        Self { db: self.db.clone() }
     }
 }
 


### PR DESCRIPTION
This would allows us to use `ShareableDatabase` as both with `Arc` and with ref.