### PR TITLE
feat: impl Provider for ChainState type

### DIFF
--- a/crates/storage/provider/src/providers/state/chain.rs
+++ b/crates/storage/provider/src/providers/state/chain.rs
@@ -38,7 +38,6 @@ impl<'a> ChainState<'a> {
 // Delegates all provider impls to the boxed [StateProvider]
 delegate_provider_impls!(ChainState<'a>);
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/storage/provider/src/providers/state/chain.rs
+++ b/crates/storage/provider/src/providers/state/chain.rs
@@ -1,4 +1,7 @@
-use crate::StateProvider;
+use crate::{
+    providers::state::macros::delegate_provider_impls, AccountProvider, BlockHashProvider,
+    StateProvider,
+};
 use std::marker::PhantomData;
 
 /// A type that can access the state at a specific access point (block number or tag)
@@ -13,6 +16,36 @@ use std::marker::PhantomData;
 ///
 /// Note: The lifetime of this type is limited by the type that created it.
 pub struct ChainState<'a> {
-    _inner: Box<dyn StateProvider>,
+    inner: Box<dyn StateProvider>,
     _phantom: PhantomData<&'a ()>,
+}
+
+// == impl ChainState ===
+
+impl<'a> ChainState<'a> {
+    /// Wraps the given [StateProvider]
+    pub fn new(inner: Box<dyn StateProvider>) -> Self {
+        Self { inner, _phantom: Default::default() }
+    }
+
+    /// Returns a new provider that takes the `TX` as reference
+    #[inline(always)]
+    fn as_ref(&self) -> impl StateProvider + '_ {
+        &*self.inner
+    }
+}
+
+// Delegates all provider impls to the boxed [StateProvider]
+delegate_provider_impls!(ChainState<'a>);
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_state_provider<T: StateProvider>() {}
+    #[allow(unused)]
+    fn assert_chain_state_provider<'txn>() {
+        assert_state_provider::<ChainState<'txn>>();
+    }
 }

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -142,7 +142,7 @@ impl<'a, TX: DbTx<'a>> HistoricalStateProvider<'a, TX> {
 }
 
 // Delegates all provider impls to [HistoricalStateProviderRef]
-delegate_provider_impls!(HistoricalStateProvider<'a, TX>);
+delegate_provider_impls!(HistoricalStateProvider<'a, TX> where [TX: DbTx<'a>]);
 
 #[cfg(test)]
 mod tests {

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -76,7 +76,7 @@ impl<'a, TX: DbTx<'a>> LatestStateProvider<'a, TX> {
 }
 
 // Delegates all provider impls to [LatestStateProviderRef]
-delegate_provider_impls!(LatestStateProvider<'a, TX>);
+delegate_provider_impls!(LatestStateProvider<'a, TX> where [TX: DbTx<'a>]);
 
 #[cfg(test)]
 mod tests {

--- a/crates/storage/provider/src/providers/state/macros.rs
+++ b/crates/storage/provider/src/providers/state/macros.rs
@@ -5,10 +5,10 @@
 ///
 /// Used to implement provider traits.
 macro_rules! delegate_impls_to_as_ref {
-    ( for $target:ty => $($trait:ident {  $(fn $func:ident(&self, $($arg:ident: $argty:ty),*) -> $ret:ty;)* })* ) => {
+    (for $target:ty => $($trait:ident $(where [$($generics:tt)*])? {  $(fn $func:ident(&self, $($arg:ident: $argty:path),*) -> $ret:path;)* })* ) => {
 
         $(
-          impl<'a, TX: DbTx<'a>> $trait for $target {
+          impl<'a, $($($generics)*)?> $trait for $target {
               $(
                   fn $func(&self, $($arg: $argty),*) -> $ret {
                     self.as_ref().$func($($arg),*)
@@ -27,18 +27,18 @@ pub(crate) use delegate_impls_to_as_ref;
 /// [BlockHashProvider](crate::BlockHashProvider)
 /// [StateProvider](crate::StateProvider)
 macro_rules! delegate_provider_impls {
-    ($target:ty) => {
+    ($target:ty $(where [$($generics:tt)*])?) => {
         $crate::providers::state::macros::delegate_impls_to_as_ref!(
             for $target =>
-            AccountProvider {
-                fn basic_account(&self, address: Address) -> Result<Option<Account>>;
+            AccountProvider $(where [$($generics)*])? {
+                fn basic_account(&self, address: reth_primitives::Address) -> reth_interfaces::Result<Option<reth_primitives::Account>>;
             }
-            BlockHashProvider {
-                fn block_hash(&self, number: U256) -> Result<Option<H256>>;
+            BlockHashProvider $(where [$($generics)*])? {
+                fn block_hash(&self, number: reth_primitives::U256) -> reth_interfaces::Result<Option<reth_primitives::H256>>;
             }
-            StateProvider {
-                fn storage(&self, account: Address, storage_key: StorageKey) -> Result<Option<StorageValue>>;
-                fn bytecode_by_hash(&self, code_hash: H256) -> Result<Option<Bytes>>;
+            StateProvider $(where [$($generics)*])?{
+                fn storage(&self, account: reth_primitives::Address, storage_key: reth_primitives::StorageKey) -> reth_interfaces::Result<Option<reth_primitives::StorageValue>>;
+                fn bytecode_by_hash(&self, code_hash: reth_primitives::H256) -> reth_interfaces::Result<Option<reth_primitives::Bytes>>;
             }
         );
     }


### PR DESCRIPTION
implements all Providers for the new `ChainState` provider type.

Modifies the macro so trait bounds are optional