### PR TITLE
feat: extend task executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4773,6 +4773,7 @@ name = "reth-tasks"
 version = "0.1.0"
 dependencies = [
  "futures-util",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-futures",

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -170,7 +170,7 @@ impl SessionManager {
         F: Future<Output = ()> + Send + 'static,
     {
         if let Some(ref executor) = self.executor {
-            executor.spawn(async move { f.await })
+            executor.spawn(async move { f.await });
         } else {
             tokio::task::spawn(async move { f.await });
         }

--- a/crates/tasks/Cargo.toml
+++ b/crates/tasks/Cargo.toml
@@ -12,6 +12,7 @@ tokio = { version = "1", features = ["sync", "rt"] }
 tracing-futures = "0.2"
 tracing = { version = "0.1", default-features = false }
 futures-util = "0.3"
+thiserror = "1.0"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["sync", "rt", "rt-multi-thread", "time", "macros"] }


### PR DESCRIPTION
add additional functions to `TaskExecutor` for
* `spawn_blocking`
* `with_signal` to get access to the shutdown signal