### PR TITLE
perf: use constant genesis hash if known chain

### DIFF
--- a/crates/net/eth-wire/src/builder.rs
+++ b/crates/net/eth-wire/src/builder.rs
@@ -42,6 +42,11 @@ pub struct StatusBuilder {
 }
 
 impl StatusBuilder {
+    /// Creates a new status builder
+    pub fn new(status: Status) -> StatusBuilder {
+        StatusBuilder { status }
+    }
+
     /// Consumes the type and creates the actual [`Status`](crate::types::Status) message.
     pub fn build(self) -> Status {
         self.status


### PR DESCRIPTION
Resolves: #1272 

Draft.

Can further optimise spec_builder() by doing
```rust
let gensis_hash = match spec.chain {
    Chain::Named(chain) => const,
    Chain::Id(id) => spec.genesis_hash(),
};
```