### PR TITLE
test(net): disable discv4 discovery in tests by default

### DIFF
--- a/crates/net/network/src/test_utils/testnet.rs
+++ b/crates/net/network/src/test_utils/testnet.rs
@@ -319,6 +319,7 @@ where
             .listener_addr(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)))
             .discovery_addr(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)))
             .no_dns_discovery()
+            .no_discv4_discovery()
     }
 }
 


### PR DESCRIPTION
disable discovery,
prevets flaky tests caused by discovered peers, likely related to #1304