### PR TITLE
perf(sync): do not store empty ommers entries

### DIFF
--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -125,7 +125,17 @@ impl Header {
 
     /// Checks if the header is empty - has no transactions and no ommers
     pub fn is_empty(&self) -> bool {
-        self.ommers_hash == EMPTY_LIST_HASH && self.transactions_root == EMPTY_ROOT
+        self.transaction_root_is_empty() && self.ommers_hash_is_empty()
+    }
+
+    /// Check if the ommers hash equals to empty hash list.
+    pub fn ommers_hash_is_empty(&self) -> bool {
+        self.ommers_hash == EMPTY_LIST_HASH
+    }
+
+    /// Check if the transaction root equals to empty root.
+    pub fn transaction_root_is_empty(&self) -> bool {
+        self.transactions_root == EMPTY_ROOT
     }
 
     /// Calculate hash and seal the Header so that it can't be changed.

--- a/crates/storage/provider/src/utils.rs
+++ b/crates/storage/provider/src/utils.rs
@@ -34,10 +34,12 @@ pub fn insert_block<'a, TX: DbTxMut<'a> + DbTx<'a>>(
     )?;
 
     // insert body ommers data
-    tx.put::<tables::BlockOmmers>(
-        block.number,
-        StoredBlockOmmers { ommers: block.ommers.iter().map(|h| h.as_ref().clone()).collect() },
-    )?;
+    if !block.ommers.is_empty() {
+        tx.put::<tables::BlockOmmers>(
+            block.number,
+            StoredBlockOmmers { ommers: block.ommers.iter().map(|h| h.as_ref().clone()).collect() },
+        )?;
+    }
 
     let (mut current_tx_id, mut transition_id) =
         if let Some(parent_tx_num_transition_id) = parent_tx_num_transition_id {


### PR DESCRIPTION
The header is considered _empty_ if it has no ommers **and** no transactions. 

Previously, we stored empty entries for blocks that have no ommers, but have at least one transaction. This PR introduces a check which skips storing empty ommers entries altogether.