### PR TITLE
Revert "cli: integrate TaskExecutor"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4715,7 +4715,6 @@ dependencies = [
  "reth-provider",
  "reth-staged-sync",
  "reth-stages",
- "reth-tasks",
  "reth-tracing",
  "secp256k1 0.24.3",
  "serde",

--- a/bin/reth/src/args/network_args.rs
+++ b/bin/reth/src/args/network_args.rs
@@ -3,7 +3,6 @@
 use crate::dirs::{KnownPeersPath, PlatformPath};
 use clap::Args;
 use reth_primitives::NodeRecord;
-use std::path::PathBuf;
 
 /// Parameters for configuring the network more granularity via CLI
 #[derive(Debug, Args)]
@@ -37,16 +36,4 @@ pub struct NetworkArgs {
     /// Do not persist peers. Cannot be used with --peers-file
     #[arg(long, verbatim_doc_comment, conflicts_with = "peers_file")]
     pub no_persist_peers: bool,
-}
-
-// === impl NetworkArgs ===
-
-impl NetworkArgs {
-    /// If `no_persist_peers` is true then this returns the path to the persistent peers file
-    pub fn persistent_peers_file(&self) -> Option<PathBuf> {
-        if self.no_persist_peers {
-            return None
-        }
-        Some(self.peers_file.clone().into())
-    }
 }

--- a/bin/reth/src/dirs.rs
+++ b/bin/reth/src/dirs.rs
@@ -170,9 +170,3 @@ impl<D> AsRef<Path> for PlatformPath<D> {
         self.0.as_path()
     }
 }
-
-impl<D> From<PlatformPath<D>> for PathBuf {
-    fn from(value: PlatformPath<D>) -> Self {
-        value.0
-    }
-}

--- a/bin/reth/src/p2p/mod.rs
+++ b/bin/reth/src/p2p/mod.rs
@@ -105,7 +105,6 @@ impl Command {
                 None,
                 self.nat,
                 None,
-                None,
             )
             .start_network()
             .await?;

--- a/bin/reth/src/runner.rs
+++ b/bin/reth/src/runner.rs
@@ -24,15 +24,12 @@ impl CliRunner {
     ) -> Result<(), E>
     where
         F: Future<Output = Result<(), E>>,
-        E: Send + Sync + From<std::io::Error> + From<reth_tasks::PanickedTaskError> + 'static,
+        E: Send + Sync + From<std::io::Error> + 'static,
     {
         let AsyncCliRunner { context, task_manager, tokio_runtime } = AsyncCliRunner::new()?;
 
         // Executes the command until it finished or ctrl-c was fired
-        let task_manager = tokio_runtime.block_on(run_to_completion_or_panic(
-            task_manager,
-            run_until_ctrl_c(command(context)),
-        ))?;
+        tokio_runtime.block_on(run_until_ctrl_c(command(context)))?;
         // after the command has finished or exit signal was received we drop the task manager which
         // fires the shutdown signal to all tasks spawned via the task executor
         drop(task_manager);
@@ -88,25 +85,7 @@ pub fn tokio_runtime() -> Result<tokio::runtime::Runtime, std::io::Error> {
     tokio::runtime::Builder::new_multi_thread().enable_all().build()
 }
 
-/// Runs the given future to completion or until a critical task panicked
-async fn run_to_completion_or_panic<F, E>(mut tasks: TaskManager, fut: F) -> Result<TaskManager, E>
-where
-    F: Future<Output = Result<(), E>>,
-    E: Send + Sync + From<reth_tasks::PanickedTaskError> + 'static,
-{
-    {
-        pin_mut!(fut);
-        tokio::select! {
-            err = &mut tasks => {
-                return Err(err.into())
-            },
-            res = fut => res?,
-        }
-    }
-    Ok(tasks)
-}
-
-/// Runs the future to completion or until a `ctrl-c` is received.
+/// Runs the future to completion or until a `ctrl-c` was received.
 async fn run_until_ctrl_c<F, E>(fut: F) -> Result<(), E>
 where
     F: Future<Output = Result<(), E>>,

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -145,7 +145,6 @@ impl Command {
                         None,
                         self.nat,
                         None,
-                        None,
                     )
                     .start_network()
                     .await?;

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -209,10 +209,8 @@ impl NetworkConfigBuilder {
     }
 
     /// Sets the executor to use for spawning tasks.
-    ///
-    /// If `None`, then [tokio::spawn] is used for spawning tasks.
-    pub fn executor(mut self, executor: Option<TaskExecutor>) -> Self {
-        self.executor = executor;
+    pub fn executor(mut self, executor: TaskExecutor) -> Self {
+        self.executor = Some(executor);
         self
     }
 

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -40,7 +40,7 @@ use reth_eth_wire::{
 };
 use reth_net_common::bandwidth_meter::BandwidthMeter;
 use reth_network_api::{EthProtocolInfo, NetworkStatus, ReputationChangeKind};
-use reth_primitives::{NodeRecord, PeerId, H256};
+use reth_primitives::{PeerId, H256};
 use reth_provider::BlockProvider;
 use std::{
     net::SocketAddr,
@@ -293,11 +293,6 @@ where
     /// Returns the [`PeerId`] used in the network.
     pub fn peer_id(&self) -> &PeerId {
         self.handle.peer_id()
-    }
-
-    /// Returns an iterator over all peers in the peer set.
-    pub fn all_peers(&self) -> impl Iterator<Item = NodeRecord> + '_ {
-        self.swarm.state().peers().iter_peers()
     }
 
     /// Returns a new [`PeersHandle`] that can be cloned and shared.

--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -163,11 +163,6 @@ impl PeersManager {
         PeersHandle { manager_tx: self.manager_tx.clone() }
     }
 
-    /// Returns an iterator over all peers
-    pub(crate) fn iter_peers(&self) -> impl Iterator<Item = NodeRecord> + '_ {
-        self.peers.iter().map(|(peer_id, v)| NodeRecord::new(v.addr, *peer_id))
-    }
-
     /// Invoked when a new _incoming_ tcp connection is accepted.
     ///
     /// returns an error if the inbound ip address is on the ban list or
@@ -643,7 +638,9 @@ impl PeersManager {
                         let _ = tx.send(self.peers.get(&peer).cloned());
                     }
                     PeerCommand::GetPeers(tx) => {
-                        let _ = tx.send(self.iter_peers().collect());
+                        let _ = tx.send(
+                            self.peers.iter().map(|(k, v)| NodeRecord::new(v.addr, *k)).collect(),
+                        );
                     }
                 }
             }

--- a/crates/staged-sync/Cargo.toml
+++ b/crates/staged-sync/Cargo.toml
@@ -24,7 +24,6 @@ reth-primitives = { path = "../../crates/primitives" }
 reth-provider = { path = "../../crates/storage/provider", features = ["test-utils"] }
 reth-net-nat = { path = "../../crates/net/nat" }
 reth-interfaces = { path = "../interfaces", optional = true }
-reth-tasks= { path = "../../crates/tasks" }
 
 # io
 serde = "1.0"

--- a/crates/staged-sync/src/config.rs
+++ b/crates/staged-sync/src/config.rs
@@ -13,7 +13,6 @@ use reth_network::{
 };
 use reth_primitives::{ChainSpec, NodeRecord};
 use reth_provider::ShareableDatabase;
-use reth_tasks::TaskExecutor;
 use serde::{Deserialize, Serialize};
 
 /// Configuration for the reth node.
@@ -29,7 +28,6 @@ pub struct Config {
 
 impl Config {
     /// Initializes network config from read data
-    #[allow(clippy::too_many_arguments)]
     pub fn network_config<DB: Database>(
         &self,
         db: DB,
@@ -38,7 +36,6 @@ impl Config {
         bootnodes: Option<Vec<NodeRecord>>,
         nat_resolution_method: reth_net_nat::NatResolver,
         peers_file: Option<PathBuf>,
-        executor: Option<TaskExecutor>,
     ) -> NetworkConfig<ShareableDatabase<DB>> {
         let peer_config = self
             .peers
@@ -52,7 +49,6 @@ impl Config {
             .peer_config(peer_config)
             .discovery(discv4)
             .chain_spec(chain_spec)
-            .executor(executor)
             .set_discovery(disable_discovery)
             .build(Arc::new(ShareableDatabase::new(db)))
     }


### PR DESCRIPTION
Reverts paradigmxyz/reth#1314

Reverting this PR because it caused the following tokio issues when running in debug & release mode.

```
2023-02-14T03:26:16.328377Z TRACE processed event=Pong
2023-02-14T03:26:16.328433Z TRACE processed event=Ping
2023-02-14T03:26:16.328410Z TRACE schedule outbound connection peer_id=0xba63e5f1331809d651ab33e58fe5b014ea02aaf643484cf70ef744c10b591ca8513adbbf9a10048baa144e191f25d4e901c6470886b1856a990356c26c175615 addr=15.204.197.7:30303
2023-02-14T03:26:16.328614Z TRACE sent payload to=15.204.197.7:30303 size=104
2023-02-14T03:26:16.329387Z TRACE sent payload to=15.204.197.7:30303 size=150
2023-02-14T03:26:16.328754Z TRACE Peer added peer_id=0xba63e5f1331809d651ab33e58fe5b014ea02aaf643484cf70ef744c10b591ca8513adbbf9a10048baa144e191f25d4e901c6470886b1856a990356c26c175615

thread 'tokio-runtime-worker' has overflowed its stack
fatal runtime error: stack overflow
[1]    58021 abort      RUST_LOG=trace cargo r --bin reth -- node --debug.tip  --db ../testdb
```

```
...
2023-02-14T02:55:14.444506Z  INFO Stage finished executing stage=IndexAccountHistory checkpoint=49924
Error: Critical task panicked pipeline task

```

cc @joshieDo @mattsse 