### PR TITLE
ci: add sync ci job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,51 @@ jobs:
       - name: Run Ethereum tests
         run: cargo run --release -- test-chain ethtests/BlockchainTests/GeneralStateTests/
 
+  eth-sync-release:
+    name: ethereum blockchain sync (release; 100k blocks)
+    runs-on: ubuntu-latest
+    env:
+      RUST_LOG: info,sync=error 
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+
+      - uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: true
+
+      - name: Run Sync (debug)
+        run: cargo run --bin reth -- node --debug.tip 0x91c90676cab257a59cd956d7cb0bceb9b1a71d79755c23c7277a0697ccfaf8c4 --debug.max-block 100000
+
+  eth-sync-debug:
+    name: ethereum blockchain sync (debug; 100k blocks)
+    runs-on: ubuntu-latest
+    env:
+      RUST_LOG: info,sync=error 
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+
+      - uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: true
+
+      - name: Run Sync
+        run: cargo run --release --bin reth -- node --debug.tip 0x91c90676cab257a59cd956d7cb0bceb9b1a71d79755c23c7277a0697ccfaf8c4 --debug.max-block 100000
+
+
   fuzz:
     # Skip the Fuzzing Jobs until we make them run fast and reliably. Currently they will
     # always recompile the codebase for each test and that takes way too long.


### PR DESCRIPTION
## Motivation

Had a couple issues recently and these jobs would have surfaced them straight-away. 

```
syncing from scratch on main in --debug mode results in the error below. Right away in the header stages (while or after making connections):
thread 'tokio-runtime-worker' has overflowed its stack
fatal runtime error: stack overflow
```

```
running release with debug.tip ... and debug.max-block 49924 results in the thing below 
...
2023-02-14T02:55:14.444506Z  INFO Stage finished executing stage=IndexAccountHistory checkpoint=49924
Error: Critical task panicked pipeline task
```

## Solution

Run sync on 2 different jobs (release & debug). If it takes too long, we can add hardcoded peers as github secrets, or reduce the max block