### PR TITLE
feat(storage): make `Database::view` accept `FnOnce` instead of `FnMut`

### DIFF
--- a/crates/storage/db/src/abstraction/database.rs
+++ b/crates/storage/db/src/abstraction/database.rs
@@ -26,9 +26,9 @@ pub trait Database: for<'a> DatabaseGAT<'a> {
 
     /// Takes a function and passes a read-only transaction into it, making sure it's closed in the
     /// end of the execution.
-    fn view<T, F>(&self, mut f: F) -> Result<T, Error>
+    fn view<T, F>(&self, f: F) -> Result<T, Error>
     where
-        F: FnMut(&<Self as DatabaseGAT<'_>>::TX) -> T,
+        F: FnOnce(&<Self as DatabaseGAT<'_>>::TX) -> T,
     {
         let tx = self.tx()?;
 


### PR DESCRIPTION
That way, we'll be able to move outer variables inside the closure. Especially useful for ranges passed to `walk_range`, e.g. https://github.com/paradigmxyz/reth/pull/1275/commits/f87bb18973f43917f7c0ef08315dbc54c56b423d