### PR TITLE
feat: add ChainEventSubscriptions trait

### DIFF
--- a/crates/interfaces/src/events.rs
+++ b/crates/interfaces/src/events.rs
@@ -1,0 +1,21 @@
+use reth_primitives::{Header, H256};
+use std::sync::Arc;
+use tokio::sync::mpsc::UnboundedReceiver;
+
+/// Type alias for a receiver that receives [NewBlockNotification]
+pub type NewBlockNotifications = UnboundedReceiver<NewBlockNotification>;
+
+/// A type that allows to register chain related event subscriptions.
+pub trait ChainEventSubscriptions {
+    /// Get notified when a new block was imported.
+    fn subscribe_new_blocks(&self) -> NewBlockNotifications;
+}
+
+/// A notification that's emitted when a new block was imported.
+#[derive(Clone, Debug)]
+pub struct NewBlockNotification {
+    /// Hash of the block that was imported
+    pub hash: H256,
+    /// The block header of the new block
+    pub header: Arc<Header>,
+}

--- a/crates/interfaces/src/lib.rs
+++ b/crates/interfaces/src/lib.rs
@@ -7,28 +7,30 @@
 
 //! Reth interface bindings
 
-/// Block Execution traits.
-pub mod executor;
-
 /// Consensus traits.
 pub mod consensus;
-
-/// Provider error
-pub mod provider;
 
 /// Database error
 pub mod db;
 
-/// P2P traits.
-pub mod p2p;
-
-/// Syncing related traits.
-pub mod sync;
+/// Block Execution traits.
+pub mod executor;
 
 /// Possible errors when interacting with the chain.
 mod error;
-
 pub use error::{Error, Result};
+
+/// Traits for subscribing to events.
+pub mod events;
+
+/// P2P traits.
+pub mod p2p;
+
+/// Provider error
+pub mod provider;
+
+/// Syncing related traits.
+pub mod sync;
 
 #[cfg(any(test, feature = "test-utils"))]
 /// Common test helpers for mocking out Consensus, Downloaders and Header Clients.


### PR DESCRIPTION
ref #1317

Adds a trait that provides a way to create subscriptions for chain related events, most importantly new blocks which is required for #1290 #1320

not exactly sure where this will be implemented because this is basically only relevant when the chain is fully synced.
But since we definitely need this, it would unblock work on RPC