### PR TITLE
chore: only log chain id and genesis

### DIFF
--- a/bin/reth/src/chain/import.rs
+++ b/bin/reth/src/chain/import.rs
@@ -84,7 +84,8 @@ impl ImportCommand {
         let db = Arc::new(init_db(&self.db)?);
         info!(target: "reth::cli", "Database opened");
 
-        debug!(target: "reth::cli", chainspec=?self.chain, "Initializing genesis");
+        debug!(target: "reth::cli", chain=%self.chain.chain, genesis=?self.chain.genesis_hash(), "Initializing genesis");
+
         init_genesis(db.clone(), self.chain.clone())?;
 
         // create a new FileClient

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -122,7 +122,8 @@ impl Command {
 
         self.start_metrics_endpoint()?;
 
-        debug!(target: "reth::cli", chainspec=?self.chain, "Initializing genesis");
+        debug!(target: "reth::cli", chain=%self.chain.chain, genesis=?self.chain.genesis_hash(), "Initializing genesis");
+
         init_genesis(db.clone(), self.chain.clone())?;
 
         let consensus = self.init_consensus()?;


### PR DESCRIPTION
the previous trace dumped the entire chainspec object which is quite huge.

this only logs chain id and genesis.

NOTE: genesis hash is still super slow in debug ref #1272 