### PR TITLE
fix(net): handle closed channel in Spawned downloader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4220,6 +4220,7 @@ dependencies = [
  "reth-metrics-derive",
  "reth-primitives",
  "reth-rlp",
+ "reth-tasks",
  "reth-tracing",
  "tempfile",
  "thiserror",

--- a/bin/reth/src/chain/import.rs
+++ b/bin/reth/src/chain/import.rs
@@ -133,11 +133,11 @@ impl ImportCommand {
     {
         let header_downloader = ReverseHeadersDownloaderBuilder::from(config.stages.headers)
             .build(file_client.clone(), consensus.clone())
-            .as_task();
+            .into_task();
 
         let body_downloader = BodiesDownloaderBuilder::from(config.stages.bodies)
             .build(file_client.clone(), consensus.clone(), db)
-            .as_task();
+            .into_task();
 
         let mut pipeline = Pipeline::builder()
             .with_sync_state_updater(file_client)

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -156,7 +156,13 @@ impl Command {
         info!(target: "reth::cli", "Started RPC server");
 
         let (mut pipeline, events) = self
-            .build_networked_pipeline(&mut config, network.clone(), &consensus, db.clone())
+            .build_networked_pipeline(
+                &mut config,
+                network.clone(),
+                &consensus,
+                db.clone(),
+                &ctx.task_executor,
+            )
             .await?;
 
         ctx.task_executor.spawn(handle_events(events));
@@ -181,6 +187,7 @@ impl Command {
         network: NetworkHandle,
         consensus: &Arc<dyn Consensus>,
         db: Arc<Env<WriteMap>>,
+        task_executor: &TaskExecutor,
     ) -> eyre::Result<(Pipeline<Env<WriteMap>, impl SyncStateUpdater>, impl Stream<Item = NodeEvent>)>
     {
         // building network downloaders using the fetch client
@@ -188,11 +195,11 @@ impl Command {
 
         let header_downloader = ReverseHeadersDownloaderBuilder::from(config.stages.headers)
             .build(fetch_client.clone(), consensus.clone())
-            .as_task();
+            .into_task_with(task_executor);
 
         let body_downloader = BodiesDownloaderBuilder::from(config.stages.bodies)
             .build(fetch_client.clone(), consensus.clone(), db.clone())
-            .as_task();
+            .into_task_with(task_executor);
 
         let mut pipeline = self
             .build_pipeline(config, header_downloader, body_downloader, network.clone(), consensus)

--- a/crates/net/downloaders/Cargo.toml
+++ b/crates/net/downloaders/Cargo.toml
@@ -13,6 +13,7 @@ reth-interfaces = { path = "../../interfaces" }
 reth-primitives = { path = "../../primitives" }
 reth-eth-wire = { path = "../eth-wire" }
 reth-db = { path = "../../storage/db" }
+reth-tasks = { path = "../../tasks" }
 reth-metrics-derive = { path = "../../metrics/metrics-derive" }
 
 # async

--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -16,6 +16,7 @@ use reth_interfaces::{
     },
 };
 use reth_primitives::{BlockNumber, SealedHeader};
+use reth_tasks::{TaskSpawner, TokioTaskExecutor};
 use std::{
     cmp::Ordering,
     collections::BinaryHeap,
@@ -246,10 +247,18 @@ where
     DB: Database,
     Self: BodyDownloader + 'static,
 {
+    /// Spawns the downloader task via [tokio::task::spawn]
+    pub fn into_task(self) -> TaskDownloader {
+        self.into_task_with(&TokioTaskExecutor::default())
+    }
+
     /// Convert the downloader into a [`TaskDownloader`](super::task::TaskDownloader) by spawning
-    /// it.
-    pub fn as_task(self) -> TaskDownloader {
-        TaskDownloader::spawn(self)
+    /// it via the given spawner.
+    pub fn into_task_with<S>(self, spawner: &S) -> TaskDownloader
+    where
+        S: TaskSpawner,
+    {
+        TaskDownloader::spawn_with(self, spawner)
     }
 }
 

--- a/crates/net/downloaders/src/headers/reverse_headers.rs
+++ b/crates/net/downloaders/src/headers/reverse_headers.rs
@@ -16,6 +16,7 @@ use reth_interfaces::{
     },
 };
 use reth_primitives::{BlockNumber, Header, HeadersDirection, PeerId, SealedHeader, H256};
+use reth_tasks::{TaskSpawner, TokioTaskExecutor};
 use std::{
     cmp::{Ordering, Reverse},
     collections::{binary_heap::PeekMut, BinaryHeap},
@@ -508,10 +509,18 @@ where
     H: HeadersClient,
     Self: HeaderDownloader + 'static,
 {
+    /// Spawns the downloader task via [tokio::task::spawn]
+    pub fn into_task(self) -> TaskDownloader {
+        self.into_task_with(&TokioTaskExecutor::default())
+    }
+
     /// Convert the downloader into a [`TaskDownloader`](super::task::TaskDownloader) by spawning
-    /// it.
-    pub fn as_task(self) -> TaskDownloader {
-        TaskDownloader::spawn(self)
+    /// it via the given `spawner`.
+    pub fn into_task_with<S>(self, spawner: &S) -> TaskDownloader
+    where
+        S: TaskSpawner,
+    {
+        TaskDownloader::spawn_with(self, spawner)
     }
 }
 

--- a/crates/net/downloaders/src/headers/task.rs
+++ b/crates/net/downloaders/src/headers/task.rs
@@ -1,17 +1,15 @@
-use futures::Stream;
+use futures::{FutureExt, Stream};
 use futures_util::StreamExt;
 use pin_project::pin_project;
 use reth_interfaces::p2p::headers::downloader::{HeaderDownloader, SyncTarget};
 use reth_primitives::SealedHeader;
+use reth_tasks::{TaskSpawner, TokioTaskExecutor};
 use std::{
     future::Future,
     pin::Pin,
     task::{ready, Context, Poll},
 };
-use tokio::{
-    sync::{mpsc, mpsc::UnboundedSender},
-    task::JoinSet,
-};
+use tokio::sync::{mpsc, mpsc::UnboundedSender};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 /// A [HeaderDownloader] that drives a spawned [HeaderDownloader] on a spawned task.
@@ -21,16 +19,13 @@ pub struct TaskDownloader {
     #[pin]
     from_downloader: UnboundedReceiverStream<Vec<SealedHeader>>,
     to_downloader: UnboundedSender<DownloaderUpdates>,
-    /// The spawned downloader tasks.
-    ///
-    /// Note: If this type is dropped, the downloader task gets dropped as well.
-    _task: JoinSet<()>,
 }
 
 // === impl TaskDownloader ===
 
 impl TaskDownloader {
-    /// Spawns the given `downloader` and returns a [TaskDownloader] that's connected to that task.
+    /// Spawns the given `downloader` via [tokio::task::spawn] and returns a [TaskDownloader] that's
+    /// connected to that task.
     ///
     /// # Panics
     ///
@@ -55,6 +50,16 @@ impl TaskDownloader {
     where
         T: HeaderDownloader + 'static,
     {
+        Self::spawn_with(downloader, &TokioTaskExecutor::default())
+    }
+
+    /// Spawns the given `downloader` via the given [TaskSpawner] returns a [TaskDownloader] that's
+    /// connected to that task.
+    pub fn spawn_with<T, S>(downloader: T, spawner: &S) -> Self
+    where
+        T: HeaderDownloader + 'static,
+        S: TaskSpawner,
+    {
         let (headers_tx, headers_rx) = mpsc::unbounded_channel();
         let (to_downloader, updates_rx) = mpsc::unbounded_channel();
 
@@ -63,15 +68,9 @@ impl TaskDownloader {
             updates: UnboundedReceiverStream::new(updates_rx),
             downloader,
         };
+        spawner.spawn(async move { downloader.await }.boxed());
 
-        let mut task = JoinSet::<()>::new();
-        task.spawn(downloader);
-
-        Self {
-            from_downloader: UnboundedReceiverStream::new(headers_rx),
-            to_downloader,
-            _task: task,
-        }
+        Self { from_downloader: UnboundedReceiverStream::new(headers_rx), to_downloader }
     }
 }
 


### PR DESCRIPTION
This (partially) fixes an issue surfaced by the `TaskExecutor`, which resulted in "hung" program after ctrl-c was pressed.

the spawned downloader task didn't have an exit condition. so if the pipeline was dropped they continued to operate.

## Changes
* add exit condition (channel to stage closed)
* spawn downloader task with custom spawner