### PR TITLE
chore: make TaskSpawner dyncloneable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,6 +1379,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
+
+[[package]]
 name = "ecdsa"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4774,6 +4780,7 @@ dependencies = [
 name = "reth-tasks"
 version = "0.1.0"
 dependencies = [
+ "dyn-clone",
  "futures-util",
  "thiserror",
  "tokio",

--- a/crates/tasks/Cargo.toml
+++ b/crates/tasks/Cargo.toml
@@ -8,11 +8,16 @@ readme = "README.md"
 description = "Task management"
 
 [dependencies]
+
+## async
 tokio = { version = "1", features = ["sync", "rt"] }
 tracing-futures = "0.2"
-tracing = { version = "0.1", default-features = false }
 futures-util = "0.3"
+
+## misc
+tracing = { version = "0.1", default-features = false }
 thiserror = "1.0"
+dyn-clone = "1.0"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["sync", "rt", "rt-multi-thread", "time", "macros"] }


### PR DESCRIPTION
add support for cloning `Box<dyn TaskSpawner>` via https://crates.io/crates/dyn-clone