### PR TITLE
ci: use sccache

### DIFF
--- a/.github/actions/rust-bootstrap/action.yml
+++ b/.github/actions/rust-bootstrap/action.yml
@@ -44,16 +44,22 @@ runs:
       if: runner.os == 'Linux'
       shell: bash
       run: |
+        # Install sccache
         curl -L -o sccache.tar.gz https://github.com/mozilla/sccache/releases/download/${{ inputs.sccache_version }}/sccache-${{ inputs.sccache_version }}-x86_64-unknown-linux-musl.tar.gz 
         tar -xvzf sccache.tar.gz
         mv sccache-${{ inputs.sccache_version }}-x86_64-unknown-linux-musl/sccache /home/runner/.cargo/bin/sccache
         rm -rf sccache*
         chmod +x /home/runner/.cargo/bin/sccache
 
+        # Install and set up mold
+        curl -L --retry 10 --silent --show-error https://github.com/rui314/mold/releases/download/v1.10.1/mold-1.10.1-$(uname -m)-linux.tar.gz | sudo tar -C /usr/local --strip-components=1 -xzf -
+        sudo ln -sf /usr/local/bin/mold "$(realpath /usr/bin/ld)"
+
     - name: Bootstrap Environment (macOS)
       if: runner.os == 'macOS'
       shell: bash
       run: |
+        # Install sccache
         curl -L -o sccache.tar.gz https://github.com/mozilla/sccache/releases/download/${{ inputs.sccache_version }}/sccache-${{ inputs.sccache_version }}-x86_64-apple-darwin.tar.gz
         tar -xvzf sccache.tar.gz
         mv sccache-${{ inputs.sccache_version }}-x86_64-apple-darwin/sccache /Users/runner/.cargo/bin/sccache
@@ -64,6 +70,7 @@ runs:
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
+        # Install sccache
         curl -L -o sccache.tar.gz https://github.com/mozilla/sccache/releases/download/${{ inputs.sccache_version }}/sccache-${{ inputs.sccache_version }}-x86_64-pc-windows-msvc.tar.gz 
         tar -xvzf sccache.tar.gz
         mv sccache-${{ inputs.sccache_version }}-x86_64-pc-windows-msvc/sccache.exe C:/Users/runneradmin/.cargo/bin/sccache.exe

--- a/.github/actions/rust-bootstrap/action.yml
+++ b/.github/actions/rust-bootstrap/action.yml
@@ -8,6 +8,10 @@ inputs:
   rust_target:
     description: rust target triple to install
     required: true
+  mold_version:
+    description: mold version to install (linux)
+    default: 1.10.1
+    required: true
   sccache_version:
     description: version of sccache to install
     default: v0.4.0-pre.7
@@ -17,14 +21,18 @@ inputs:
     default: auto
     required: true
   sccache_bucket:
+    description: sccache s3 bucket name
     default: reth-sccache
     required: true
   sccache_endpoint:
+    description: sccache s3 endpoint
     default: https://nyc3.digitaloceanspaces.com
     required: true
   sccache_key_id:
+    description: sccache s3 key id
     required: true
   sccache_secret:
+    description: sccache s3 key secret
     required: true
 runs:
   using: composite
@@ -45,14 +53,14 @@ runs:
       shell: bash
       run: |
         # Install sccache
-        curl -L -o sccache.tar.gz https://github.com/mozilla/sccache/releases/download/${{ inputs.sccache_version }}/sccache-${{ inputs.sccache_version }}-x86_64-unknown-linux-musl.tar.gz 
+        curl -L -o sccache.tar.gz https://github.com/mozilla/sccache/releases/download/${{ inputs.sccache_version }}/sccache-${{ inputs.sccache_version }}-$(uname -m)-unknown-linux-musl.tar.gz 
         tar -xvzf sccache.tar.gz
-        mv sccache-${{ inputs.sccache_version }}-x86_64-unknown-linux-musl/sccache /home/runner/.cargo/bin/sccache
+        mv sccache-${{ inputs.sccache_version }}-$(uname -m)-unknown-linux-musl/sccache /home/runner/.cargo/bin/sccache
         rm -rf sccache*
         chmod +x /home/runner/.cargo/bin/sccache
 
         # Install and set up mold
-        curl -L --retry 10 --silent --show-error https://github.com/rui314/mold/releases/download/v1.10.1/mold-1.10.1-$(uname -m)-linux.tar.gz | sudo tar -C /usr/local --strip-components=1 -xzf -
+        curl -L --retry 10 --silent --show-error https://github.com/rui314/mold/releases/download/v${{ inputs.mold_version }}/mold-${{ inputs.mold_version }}-$(uname -m)-linux.tar.gz | sudo tar -C /usr/local --strip-components=1 -xzf -
         sudo ln -sf /usr/local/bin/mold "$(realpath /usr/bin/ld)"
 
     - name: Bootstrap Environment (macOS)

--- a/.github/actions/rust-bootstrap/action.yml
+++ b/.github/actions/rust-bootstrap/action.yml
@@ -19,7 +19,7 @@ runs:
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ inputs.rust_toolchain }}
-        targets: ${{ input.rust_target }}
+        targets: ${{ inputs.rust_target }}
         components: clippy,llvm-tools-preview,rustfmt
 
     - uses: taiki-e/install-action@v1

--- a/.github/actions/rust-bootstrap/action.yml
+++ b/.github/actions/rust-bootstrap/action.yml
@@ -1,0 +1,78 @@
+name: Bootstrap Rust
+description: Configures the system environment for building Rust
+inputs:
+  rust_toolchain:
+    description: rust toolchain to install
+    default: stable
+    required: false
+  rust_target:
+    description: rust target triple to install
+    required: true
+  sccache_version:
+    description: version of sccache to install
+    default: v0.4.0-pre.7
+    required: false
+runs:
+  using: composite
+  steps:
+    - name: Install toolchain
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ inputs.rust_toolchain }}
+        targets: ${{ input.rust_target }}
+        components: clippy,llvm-tools-preview,rustfmt
+
+    - uses: taiki-e/install-action@v1
+      with:
+        tool: nextest,cargo-llvm-cov
+
+    - name: Bootstrap Environment (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        curl -o sccache.tar.gz https://github.com/mozilla/sccache/releases/download/${{ inputs.sccache_version }}/sccache-${{ inputs.sccache_version }}-x86_64-unknown-linux-musl.tar.gz 
+        tar -xvzf sccache.tar.gz
+        mv sccache-${{ inputs.sccache_version }}-x86_64-unknown-linux-musl/sccache /home/runner/.cargo/bin/sccache
+        rm -rf sccache*
+        chmod +x /home/runner/.cargo/bin/sccache
+
+    - name: Bootstrap Environment (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        curl -o sccache.tar.gz https://github.com/mozilla/sccache/releases/download/${{ inputs.sccache_version }}/sccache-${{ inputs.sccache_version }}-x86_64-apple-darwin.tar.gz
+        tar -xvzf sccache.tar.gz
+        mv sccache-${{ inputs.sccache_version }}-x86_64-apple-darwin/sccache /Users/runner/.cargo/bin/sccache
+        rm -rf sccache*
+        chmod +x /Users/runner/.cargo/bin/sccache
+
+    - name: Bootstrap Environment (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        curl -o sccache.tar.gz https://github.com/mozilla/sccache/releases/download/${{ inputs.sccache_version }}/sccache-${{ inputs.sccache_version }}-x86_64-pc-windows-msvc.tar.gz 
+        tar -xvzf sccache.tar.gz
+        mv sccache-${{ inputs.sccache_version }}-x86_64-pc-windows-msvc/sccache.exe C:/Users/runneradmin/.cargo/bin/sccache.exe
+
+    - name: Set environment
+      shell: bash
+      run: |
+        # Prevent the sccache server from terminating due to inactivity
+        echo "SCCACHE_IDLE_TIMEOUT=0" >> $GITHUB_ENV
+        echo "SCCACHE_GHA_VERSION=sccache" >> $GITHUB_ENV
+        echo "SCCACHE_BYPASS_CHECK=on" >> $GITHUB_ENV
+        # Disable incremental builds (they can't be cached)
+        echo "CARGO_INCREMENTAL=0" >> $GITHUB_ENV
+        echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+
+    - name: Configure sccache environment
+      uses: actions/github-script@v6
+      with:
+        script: |
+          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '')
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '')
+
+    - name: Start sccache
+      shell: bash
+      run: |
+        sccache --start-server

--- a/.github/actions/rust-bootstrap/action.yml
+++ b/.github/actions/rust-bootstrap/action.yml
@@ -12,6 +12,20 @@ inputs:
     description: version of sccache to install
     default: v0.4.0-pre.7
     required: false
+  sccache_region:
+    description: region of sccache s3 bucket
+    default: auto
+    required: true
+  sccache_bucket:
+    default: reth-sccache
+    required: true
+  sccache_endpoint:
+    default: https://nyc3.digitaloceanspaces.com
+    required: true
+  sccache_key_id:
+    required: true
+  sccache_secret:
+    required: true
 runs:
   using: composite
   steps:
@@ -59,20 +73,18 @@ runs:
       run: |
         # Prevent the sccache server from terminating due to inactivity
         echo "SCCACHE_IDLE_TIMEOUT=0" >> $GITHUB_ENV
-        # Change this to purge the cache
-        echo "SCCACHE_GHA_VERSION=sccache" >> $GITHUB_ENV
+        echo "SCCACHE_S3_USE_SSL=true" >> $GITHUB_ENV
         # Disable incremental builds (they can't be cached)
         echo "CARGO_INCREMENTAL=0" >> $GITHUB_ENV
         echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-
-    - name: Configure sccache environment
-      uses: actions/github-script@v6
-      with:
-        script: |
-          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '')
-          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '')
 
     - name: Start sccache
       shell: bash
       run: |
         sccache --start-server
+      env:
+        AWS_ACCESS_KEY_ID: ${{ inputs.sccache_key_id }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.sccache_secret }}
+        SCCACHE_BUCKET: ${{ inputs.sccache_bucket }}
+        SCCACHE_ENDPOINT: ${{ inputs.sccache_endpoint }}
+        SCCACHE_REGION: ${{ inputs.sccache_region }}

--- a/.github/actions/rust-bootstrap/action.yml
+++ b/.github/actions/rust-bootstrap/action.yml
@@ -61,8 +61,6 @@ runs:
         echo "SCCACHE_IDLE_TIMEOUT=0" >> $GITHUB_ENV
         # Change this to purge the cache
         echo "SCCACHE_GHA_VERSION=sccache" >> $GITHUB_ENV
-        # If a cache request fails, treat it as a cache miss
-        echo "SCCACHE_BYPASS_CHECK=on" >> $GITHUB_ENV
         # Disable incremental builds (they can't be cached)
         echo "CARGO_INCREMENTAL=0" >> $GITHUB_ENV
         echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV

--- a/.github/actions/rust-bootstrap/action.yml
+++ b/.github/actions/rust-bootstrap/action.yml
@@ -30,7 +30,7 @@ runs:
       if: runner.os == 'Linux'
       shell: bash
       run: |
-        curl -o sccache.tar.gz https://github.com/mozilla/sccache/releases/download/${{ inputs.sccache_version }}/sccache-${{ inputs.sccache_version }}-x86_64-unknown-linux-musl.tar.gz 
+        curl -L -o sccache.tar.gz https://github.com/mozilla/sccache/releases/download/${{ inputs.sccache_version }}/sccache-${{ inputs.sccache_version }}-x86_64-unknown-linux-musl.tar.gz 
         tar -xvzf sccache.tar.gz
         mv sccache-${{ inputs.sccache_version }}-x86_64-unknown-linux-musl/sccache /home/runner/.cargo/bin/sccache
         rm -rf sccache*
@@ -40,7 +40,7 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        curl -o sccache.tar.gz https://github.com/mozilla/sccache/releases/download/${{ inputs.sccache_version }}/sccache-${{ inputs.sccache_version }}-x86_64-apple-darwin.tar.gz
+        curl -L -o sccache.tar.gz https://github.com/mozilla/sccache/releases/download/${{ inputs.sccache_version }}/sccache-${{ inputs.sccache_version }}-x86_64-apple-darwin.tar.gz
         tar -xvzf sccache.tar.gz
         mv sccache-${{ inputs.sccache_version }}-x86_64-apple-darwin/sccache /Users/runner/.cargo/bin/sccache
         rm -rf sccache*
@@ -50,7 +50,7 @@ runs:
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        curl -o sccache.tar.gz https://github.com/mozilla/sccache/releases/download/${{ inputs.sccache_version }}/sccache-${{ inputs.sccache_version }}-x86_64-pc-windows-msvc.tar.gz 
+        curl -L -o sccache.tar.gz https://github.com/mozilla/sccache/releases/download/${{ inputs.sccache_version }}/sccache-${{ inputs.sccache_version }}-x86_64-pc-windows-msvc.tar.gz 
         tar -xvzf sccache.tar.gz
         mv sccache-${{ inputs.sccache_version }}-x86_64-pc-windows-msvc/sccache.exe C:/Users/runneradmin/.cargo/bin/sccache.exe
 

--- a/.github/actions/rust-bootstrap/action.yml
+++ b/.github/actions/rust-bootstrap/action.yml
@@ -59,7 +59,9 @@ runs:
       run: |
         # Prevent the sccache server from terminating due to inactivity
         echo "SCCACHE_IDLE_TIMEOUT=0" >> $GITHUB_ENV
+        # Change this to purge the cache
         echo "SCCACHE_GHA_VERSION=sccache" >> $GITHUB_ENV
+        # If a cache request fails, treat it as a cache miss
         echo "SCCACHE_BYPASS_CHECK=on" >> $GITHUB_ENV
         # Disable incremental builds (they can't be cached)
         echo "CARGO_INCREMENTAL=0" >> $GITHUB_ENV

--- a/.github/actions/sccache-finish/action.yml
+++ b/.github/actions/sccache-finish/action.yml
@@ -1,0 +1,13 @@
+name: sccache finish
+description: Stops the sccache server and prints stats
+runs:
+  using: composite
+  steps:
+    - name: Print sccache stats
+      shell: bash
+      run: sccache --show-stats
+
+    - name: Stop sccache
+      shell: bash
+      run: |
+        sccache --stop-server

--- a/.github/actions/sccache-finish/action.yml
+++ b/.github/actions/sccache-finish/action.yml
@@ -3,10 +3,6 @@ description: Stops the sccache server and prints stats
 runs:
   using: composite
   steps:
-    - name: Print sccache stats
-      shell: bash
-      run: sccache --show-stats
-
     - name: Stop sccache
       shell: bash
       run: |

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           rust_toolchain: stable
           rust_target: x86_64-unknown-linux-musl
+          sccache_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          sccache_secret: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Install valgrind
         uses: taiki-e/install-action@valgrind

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -19,10 +19,12 @@ jobs:
     # See also <https://github.com/foundry-rs/foundry/issues/3827>
     runs-on: ubuntu-20.04
     steps:
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/rust-bootstrap
         with:
           rust_toolchain: stable
           rust_target: x86_64-unknown-linux-musl
+
       - name: Install valgrind
         uses: taiki-e/install-action@valgrind
 
@@ -30,6 +32,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: main
+          clean: true
 
       - name: Generate test vectors
         uses: actions-rs/cargo@v1

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -19,9 +19,8 @@ jobs:
     # See also <https://github.com/foundry-rs/foundry/issues/3827>
     runs-on: ubuntu-20.04
     steps:
-      - name: Install Valgrind
-        run: |
-          sudo apt install valgrind
+      - name: Install valgrind
+        uses: taiki-e/install-action@valgrind
 
       - name: Checkout PR sources
         uses: actions/checkout@v3

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -19,17 +19,17 @@ jobs:
     # See also <https://github.com/foundry-rs/foundry/issues/3827>
     runs-on: ubuntu-20.04
     steps:
+      - uses: ./.github/actions/rust-bootstrap
+        with:
+          rust_toolchain: stable
+          rust_target: x86_64-unknown-linux-musl
       - name: Install valgrind
         uses: taiki-e/install-action@valgrind
 
-      - name: Checkout PR sources
+      - name: Checkout sources (main)
         uses: actions/checkout@v3
         with:
           ref: main
-
-      - uses: Swatinem/rust-cache@v1
-        with:
-          cache-on-failure: true
 
       - name: Generate test vectors
         uses: actions-rs/cargo@v1
@@ -43,7 +43,7 @@ jobs:
           command: bench
           args: --package reth-db --bench iai
 
-      - name: Checkout main sources
+      - name: Checkout PR sources
         uses: actions/checkout@v3
         with:
           clean: false
@@ -52,3 +52,5 @@ jobs:
         shell: 'script -q -e -c "bash {0}"' # required to workaround /dev/tty not being available
         run: |
           ./.github/scripts/compare_iai.sh
+
+      - uses: ./.github/actions/sccache-finish

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -20,10 +20,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install mdbook
-        run: |
-          mkdir mdbook
-          curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.14/mdbook-v0.4.14-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
-          echo `pwd`/mdbook >> $GITHUB_PATH
+        uses: taiki-e/install-action@mdbook
 
       - name: Install mdbook-template
         run: |
@@ -42,10 +39,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install mdbook
-        run: |
-          mkdir mdbook
-          curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.14/mdbook-v0.4.14-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
-          echo `pwd`/mdbook >> $GITHUB_PATH
+        uses: taiki-e/install-action@mdbook
 
       - name: Install mdbook-template
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,10 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@nightly
+      - uses: ./.github/actions/rust-bootstrap
         with:
-          components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
+          rust_toolchain: nightly
+          rust_target: x86_64-unknown-linux-musl
 
       - name: cargo fmt
         uses: actions-rs/cargo@v1
@@ -41,14 +38,17 @@ jobs:
         with:
           args: --all --all-features
           token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/sccache-finish
 
   doc-lint:
     name: doc lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: ./.github/actions/rust-bootstrap
+        with:
+          rust_toolchain: stable
+          rust_target: x86_64-unknown-linux-musl
       - name: Check if documentation builds
         run: RUSTDOCFLAGS="-D warnings" cargo doc --all --no-deps --all-features --document-private-items
+      - uses: ./.github/actions/sccache-finish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           rust_toolchain: nightly
           rust_target: x86_64-unknown-linux-musl
+          sccache_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          sccache_secret: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: cargo fmt
         uses: actions-rs/cargo@v1
@@ -49,6 +51,8 @@ jobs:
         with:
           rust_toolchain: stable
           rust_target: x86_64-unknown-linux-musl
+          sccache_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          sccache_secret: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: Check if documentation builds
         run: RUSTDOCFLAGS="-D warnings" cargo doc --all --no-deps --all-features --document-private-items
       - uses: ./.github/actions/sccache-finish

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -35,6 +35,8 @@ jobs:
         with:
           rust_toolchain: stable
           rust_target: x86_64-unknown-linux-musl
+          sccache_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          sccache_secret: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Install fuzzer
         uses: actions-rs/cargo@v1

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,7 +11,6 @@ env:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
-
 name: fuzz
 jobs:
   all:
@@ -32,13 +31,10 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/rust-bootstrap
         with:
-          components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
+          rust_toolchain: stable
+          rust_target: x86_64-unknown-linux-musl
 
       - name: Install fuzzer
         uses: actions-rs/cargo@v1
@@ -49,17 +45,16 @@ jobs:
         run: |
           cargo install --force afl
           cargo afl --version
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
-
       - name: Run fuzz tests
         run: |
           ./.github/scripts/fuzz.sh ${{ matrix.target }}
         env:
           AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES: 1
+
       - name: Upload coverage data to codecov
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           flags: fuzz-tests
+      - uses: ./.github/actions/sccache-finish

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,6 +30,8 @@ jobs:
         with:
           rust_toolchain: stable
           rust_target: x86_64-unknown-linux-musl
+          sccache_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          sccache_secret: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Install geth
         run: |
@@ -72,6 +74,8 @@ jobs:
         with:
           rust_toolchain: stable
           rust_target: x86_64-unknown-linux-musl
+          sccache_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          sccache_secret: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Sync
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,13 +26,10 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/rust-bootstrap
         with:
-          components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
+          rust_toolchain: stable
+          rust_target: x86_64-unknown-linux-musl
 
       - name: Install geth
         run: |
@@ -45,11 +42,6 @@ jobs:
           echo $HOME/bin >> $GITHUB_PATH
           geth version
 
-      - name: Install latest nextest release
-        uses: taiki-e/install-action@nextest
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
-
       - name: Run tests
         run: |
           cargo llvm-cov nextest --lcov --output-path lcov.info \
@@ -57,6 +49,7 @@ jobs:
             --partition hash:${{ matrix.partition }}/${{ strategy.job-total }} \
             -E 'kind(test)'
 
+      - uses: ./.github/actions/sccache-finish
       - name: Upload coverage data to codecov
         uses: codecov/codecov-action@v3
         with:
@@ -75,20 +68,16 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: ./.github/actions/rust-bootstrap
         with:
-          toolchain: stable
-          profile: minimal
+          rust_toolchain: stable
+          rust_target: x86_64-unknown-linux-musl
 
-      - uses: Swatinem/rust-cache@v1
-        with:
-          cache-on-failure: true
-
-      - name: Run Sync (debug)
+      - name: Sync
         run: |
           cargo run --profile ${{ matrix.profile }} \
             --bin reth -- node \
             --debug.tip 0x91c90676cab257a59cd956d7cb0bceb9b1a71d79755c23c7277a0697ccfaf8c4 \
             --debug.max-block 100000
+
+      - uses: ./.github/actions/sccache-finish

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -22,14 +22,10 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@nightly
+      - uses: ./.github/actions/rust-bootstrap
         with:
-          toolchain: nightly-2022-12-27
-          components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
+          rust_toolchain: stable
+          rust_target: x86_64-unknown-linux-musl
 
       - name: Install geth
         run: |
@@ -51,6 +47,7 @@ jobs:
       - name: Run tests
         run: cargo nextest run --locked --workspace --all-features
 
+      - uses: ./.github/actions/sccache-finish
       - uses: JasonEtco/create-an-issue@v2
         if: ${{ failure() }}
         env:
@@ -68,11 +65,13 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@nightly
-
-      - name: Install cargo-udeps
-        run: cargo install cargo-udeps --locked
+      - uses: ./.github/actions/rust-bootstrap
+        with:
+          rust_toolchain: stable
+          rust_target: x86_64-unknown-linux-musl
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-udeps
 
       - name: Check for unused dependencies
         run: cargo +nightly udeps --all-features --all-targets
@@ -85,4 +84,4 @@ jobs:
         with:
           update_existing: true
           filename: .github/SANITY_UNUSED_DEPS_ISSUE_TEMPLATE.md
-
+      - uses: ./.github/actions/sccache-finish

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           rust_toolchain: stable
           rust_target: x86_64-unknown-linux-musl
+          sccache_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          sccache_secret: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Install geth
         run: |
@@ -69,6 +71,9 @@ jobs:
         with:
           rust_toolchain: stable
           rust_target: x86_64-unknown-linux-musl
+          sccache_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          sccache_secret: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-udeps

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -23,20 +23,11 @@ jobs:
       matrix:
         partition: [1, 2, 3]
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/rust-bootstrap
         with:
-          components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-
-      - name: Install latest nextest release
-        uses: taiki-e/install-action@nextest
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+          rust_toolchain: stable
+          rust_target: x86_64-unknown-linux-musl
 
       - name: Run tests
         run: |
@@ -45,6 +36,7 @@ jobs:
             --partition hash:${{ matrix.partition }}/${{ strategy.job-total }} \
             -E 'kind(lib)' -E 'kind(bin)' -E 'kind(proc-macro)'
 
+      - uses: ./.github/actions/sccache-finish
       - name: Upload coverage data to codecov
         uses: codecov/codecov-action@v3
         with:
@@ -58,37 +50,32 @@ jobs:
     env:
       RUST_LOG: info,sync=error
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/rust-bootstrap
+        with:
+          rust_toolchain: stable
+          rust_target: x86_64-unknown-linux-musl
 
       - name: Checkout ethereum/tests
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ethereum/tests
           path: ethtests
           submodules: recursive
-
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-
-      - uses: Swatinem/rust-cache@v1
-        with:
-          cache-on-failure: true
-
       - name: Run Ethereum tests
         run: cargo run --release -- test-chain ethtests/BlockchainTests/GeneralStateTests/
+
+      - uses: ./.github/actions/sccache-finish
 
   doc-test:
     name: rustdoc
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: ./.github/actions/rust-bootstrap
+        with:
+          rust_toolchain: stable
+          rust_target: x86_64-unknown-linux-musl
       - name: Run doctests
         run: cargo test --doc --all --all-features
+      - uses: ./.github/actions/sccache-finish

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -28,6 +28,8 @@ jobs:
         with:
           rust_toolchain: stable
           rust_target: x86_64-unknown-linux-musl
+          sccache_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          sccache_secret: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Run tests
         run: |
@@ -55,6 +57,8 @@ jobs:
         with:
           rust_toolchain: stable
           rust_target: x86_64-unknown-linux-musl
+          sccache_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          sccache_secret: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Checkout ethereum/tests
         uses: actions/checkout@v3
@@ -76,6 +80,9 @@ jobs:
         with:
           rust_toolchain: stable
           rust_target: x86_64-unknown-linux-musl
+          sccache_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          sccache_secret: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
       - name: Run doctests
         run: cargo test --doc --all --all-features
       - uses: ./.github/actions/sccache-finish


### PR DESCRIPTION
Replaces our current cache with sccache. See the issue for the benefits.

Currently, this is slower than expected. It is not entirely clear to me why that is - the number of entries in the cache is considerably smaller here than locally

Closes #1350 