### PR TITLE
fix(hive+docker): use ubuntu image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 /book
 /assets
 /.github
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,8 @@ COPY . reth
 # Build reth
 RUN cd reth && cargo build --all --locked --profile $BUILD_PROFILE
 
-# Use alpine as the release image
-FROM frolvlad/alpine-glibc
-
-RUN apk add --no-cache linux-headers
+# Use Ubuntu as the release image
+FROM ubuntu
 
 # Copy the built reth binary from the previous stage
 COPY --from=builder /reth/target/release/reth /usr/local/bin/reth


### PR DESCRIPTION
Running the Hive tests on M1 using Alpine seems to fail, see #15e4215f3dcc827608a861c333027583fe2f38ca for more context. Instead, we choose to use Ubuntu, at the cost of a slightly larger image. Should be fine.


@onbjerg @Rjected if we go with this, we'll need to update the Hive dockerfile to 

```
-RUN apk add --update bash curl jq
+RUN apt-get update -y
+RUN apt-get install -y bash curl jq
```