### PR TITLE
fix: use `walk_range` on `import_table_with_range`

### DIFF
--- a/crates/storage/db/src/abstraction/table.rs
+++ b/crates/storage/db/src/abstraction/table.rs
@@ -108,8 +108,11 @@ pub trait TableImporter<'tx>: for<'a> DbTxMut<'a> {
         let mut destination_cursor = self.cursor_write::<T>()?;
         let mut source_cursor = source_tx.cursor_read::<T>()?;
 
-        let from = from.unwrap_or_default();
-        for row in source_cursor.walk_range(from..=to)? {
+        let source_range = match from {
+            Some(from) => source_cursor.walk_range(from..=to),
+            None => source_cursor.walk_range(..=to),
+        };
+        for row in source_range? {
             let (key, value) = row?;
             destination_cursor.append(key, value)?;
         }

--- a/crates/storage/db/src/abstraction/table.rs
+++ b/crates/storage/db/src/abstraction/table.rs
@@ -109,7 +109,7 @@ pub trait TableImporter<'tx>: for<'a> DbTxMut<'a> {
         let mut source_cursor = source_tx.cursor_read::<T>()?;
 
         let from = from.unwrap_or_default();
-        for row in source_cursor.walk_range(from..to)? {
+        for row in source_cursor.walk_range(from..=to)? {
             let (key, value) = row?;
             destination_cursor.append(key, value)?;
         }

--- a/crates/storage/db/src/abstraction/table.rs
+++ b/crates/storage/db/src/abstraction/table.rs
@@ -101,19 +101,17 @@ pub trait TableImporter<'tx>: for<'a> DbTxMut<'a> {
         source_tx: &R,
         from: Option<<T as Table>::Key>,
         to: <T as Table>::Key,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+    where
+        T::Key: Default,
+    {
         let mut destination_cursor = self.cursor_write::<T>()?;
         let mut source_cursor = source_tx.cursor_read::<T>()?;
 
-        for row in source_cursor.walk(from)? {
+        let from = from.unwrap_or_default();
+        for row in source_cursor.walk_range(from..to)? {
             let (key, value) = row?;
-            let finished = key == to;
-
             destination_cursor.append(key, value)?;
-
-            if finished {
-                break
-            }
         }
 
         Ok(())


### PR DESCRIPTION
There was some weird behaviour when importing `BlockOmmers`when using `reth dump-stage` (could not reproduce it myself).

In any case, this should be the proper way to do it.