### PR TITLE
fix(rlp): encode `None` optional fields as empty if any values left

### DIFF
--- a/crates/rlp/rlp-derive/src/lib.rs
+++ b/crates/rlp/rlp-derive/src/lib.rs
@@ -25,6 +25,8 @@ use de::*;
 use en::*;
 use proc_macro::TokenStream;
 
+
+
 /// Derives `Encodable` for the type which encodes the all fields as list: `<rlp-header, fields...>`
 #[proc_macro_derive(RlpEncodable, attributes(rlp))]
 pub fn encodable(input: TokenStream) -> TokenStream {

--- a/crates/rlp/rlp-derive/src/lib.rs
+++ b/crates/rlp/rlp-derive/src/lib.rs
@@ -25,8 +25,6 @@ use de::*;
 use en::*;
 use proc_macro::TokenStream;
 
-
-
 /// Derives `Encodable` for the type which encodes the all fields as list: `<rlp-header, fields...>`
 #[proc_macro_derive(RlpEncodable, attributes(rlp))]
 pub fn encodable(input: TokenStream) -> TokenStream {

--- a/crates/rlp/rlp-derive/src/utils.rs
+++ b/crates/rlp/rlp-derive/src/utils.rs
@@ -2,6 +2,8 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Attribute, DataStruct, Error, Field, Meta, NestedMeta, Result, Type, TypePath};
 
+pub(crate) const EMPTY_STRING_CODE: u8 = 0x80;
+
 pub(crate) fn parse_struct<'a>(
     ast: &'a syn::DeriveInput,
     derive_attr: &str,

--- a/crates/rlp/tests/rlp.rs
+++ b/crates/rlp/tests/rlp.rs
@@ -127,4 +127,9 @@ fn test_opt_fields_roundtrip() {
     let item = TestOpt { a: 1, b: 2, c: Some(3), d: Some(4) };
     assert_eq!(&*encoded(&item), expected);
     assert_eq!(TestOpt::decode(&mut &expected[..]).unwrap(), item);
+
+    let expected = hex!("c401028004");
+    let item = TestOpt { a: 1, b: 2, c: None, d: Some(4) };
+    assert_eq!(&*encoded(&item), expected);
+    assert_eq!(TestOpt::decode(&mut &expected[..]).unwrap(), item);
 }


### PR DESCRIPTION
Encode `None` optional fields as empty if there are any `Some` values left. 

This bug was discovered in fuzz tests for #1322 