### PR TITLE
fix(rpc): use rpc::BlockNumber type not u64

### DIFF
--- a/crates/rpc/rpc-api/src/eth.rs
+++ b/crates/rpc/rpc-api/src/eth.rs
@@ -1,7 +1,7 @@
 use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
 use reth_primitives::{
-    rpc::{transaction::eip2930::AccessListWithGasUsed, BlockId},
-    Address, BlockNumber, Bytes, H256, H64, U256, U64,
+    rpc::{transaction::eip2930::AccessListWithGasUsed, BlockId, BlockNumber},
+    Address, Bytes, H256, H64, U256, U64,
 };
 use reth_rpc_types::{
     CallRequest, EIP1186AccountProofResponse, FeeHistory, Index, RichBlock, SyncStatus,

--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -1,7 +1,5 @@
 //! Standalone http tests
 
-use std::collections::HashSet;
-
 use crate::utils::{launch_http, launch_http_ws, launch_ws};
 use jsonrpsee::{
     core::{
@@ -12,8 +10,8 @@ use jsonrpsee::{
 };
 use reth_primitives::{
     hex_literal::hex,
-    rpc::{BlockId, BlockNumber as RpcBlockNumber},
-    Address, BlockNumber, Bytes, NodeRecord, H256, H64, U256,
+    rpc::{BlockId, BlockNumber},
+    Address, Bytes, NodeRecord, H256, H64, U256,
 };
 use reth_rpc_api::{
     clients::{AdminApiClient, EthApiClient},
@@ -21,6 +19,7 @@ use reth_rpc_api::{
 };
 use reth_rpc_builder::RethRpcModule;
 use reth_rpc_types::{trace::filter::TraceFilter, CallRequest, Index, TransactionRequest};
+use std::collections::HashSet;
 
 fn is_unimplemented(err: Error) -> bool {
     match err {
@@ -169,7 +168,7 @@ async fn test_basic_debug_calls<C>(client: &C)
 where
     C: ClientT + SubscriptionClientT + Sync,
 {
-    let block_id = BlockId::Number(RpcBlockNumber::default());
+    let block_id = BlockId::Number(BlockNumber::default());
 
     assert!(is_unimplemented(DebugApiClient::raw_header(client, block_id).await.err().unwrap()));
     assert!(is_unimplemented(DebugApiClient::raw_block(client, block_id).await.err().unwrap()));
@@ -193,7 +192,7 @@ async fn test_basic_trace_calls<C>(client: &C)
 where
     C: ClientT + SubscriptionClientT + Sync,
 {
-    let block_id = BlockId::Number(RpcBlockNumber::default());
+    let block_id = BlockId::Number(BlockNumber::default());
     let trace_filter = TraceFilter {
         from_block: None,
         to_block: None,

--- a/crates/rpc/rpc/src/eth/api/block.rs
+++ b/crates/rpc/rpc/src/eth/api/block.rs
@@ -1,7 +1,7 @@
 //! Contains RPC handler implementations specific to blocks.
 
 use crate::{eth::error::EthResult, EthApi};
-use reth_primitives::{rpc::BlockId, BlockNumber, H256};
+use reth_primitives::{rpc::BlockId, H256};
 use reth_provider::{BlockProvider, StateProviderFactory};
 use reth_rpc_types::RichBlock;
 
@@ -27,7 +27,7 @@ where
 
     pub(crate) async fn block_by_number(
         &self,
-        number: BlockNumber,
+        number: u64,
         _full: bool,
     ) -> EthResult<Option<RichBlock>> {
         let block = self.client().block(BlockId::Number(number.into()))?;

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -7,8 +7,8 @@ use crate::{
 };
 use jsonrpsee::core::RpcResult as Result;
 use reth_primitives::{
-    rpc::{transaction::eip2930::AccessListWithGasUsed, BlockId},
-    Address, BlockNumber, Bytes, H256, H64, U256, U64,
+    rpc::{transaction::eip2930::AccessListWithGasUsed, BlockId, BlockNumber},
+    Address, Bytes, H256, H64, U256, U64,
 };
 use reth_provider::{BlockProvider, StateProviderFactory};
 use reth_rpc_api::EthApiServer;


### PR DESCRIPTION
use the correct `BlockNumber` enum and not the u64 alias in rpc
