### PR TITLE
fix: return correct file client tip

### DIFF
--- a/crates/net/downloaders/src/test_utils/file_client.rs
+++ b/crates/net/downloaders/src/test_utils/file_client.rs
@@ -112,7 +112,7 @@ impl FileClient {
 
     /// Get the tip hash of the chain.
     pub fn tip(&self) -> Option<H256> {
-        self.headers.get(&(self.headers.len() as u64 - 1)).map(|h| h.hash_slow())
+        self.headers.get(&(self.headers.len() as u64)).map(|h| h.hash_slow())
     }
 
     /// Use the provided bodies as the file client's block body buffer.


### PR DESCRIPTION
Previously we returned the second to last hash from the `tip` method, this causes our hive tests to fail with `wrong head block in status, want:  0x0e70e01064023f70f047dbf0b97e7109e4aa5df3d643d45f8e91e47d3d67a424 (block 999) have 0xdf776b8a853e11f0eb3ef5e26027821892935fd19f0ac762e69c6f6c7ede627b` in the devp2p test suite.