### PR TITLE
fix: use td from current head for status

### DIFF
--- a/crates/net/eth-wire/src/types/status.rs
+++ b/crates/net/eth-wire/src/types/status.rs
@@ -76,6 +76,7 @@ impl Status {
             .chain(spec.chain)
             .genesis(spec.genesis_hash())
             .blockhash(head.hash)
+            .total_difficulty(head.total_difficulty)
             .forkid(spec.fork_id(head))
     }
 }


### PR DESCRIPTION
Previously, the network config was not using the total difficulty passed in the `Head`, causing hive tests to fail:
```
peering failed: status exchange failed: wrong TD in status: have 17179869184 want 131072000
```

This uses the total difficulty from the head to initialize the status.