### PR TITLE
fix: convert fuzz test names to snake case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,6 +724,7 @@ checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 name = "codecs-derive"
 version = "0.1.0"
 dependencies = [
+ "convert_case 0.6.0",
  "parity-scale-codec",
  "proc-macro2 1.0.50",
  "quote 1.0.23",

--- a/crates/storage/codecs/derive/Cargo.toml
+++ b/crates/storage/codecs/derive/Cargo.toml
@@ -21,6 +21,7 @@ proc-macro = true
 proc-macro2 = "1.0.47"
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }
+convert_case = "0.6.0"
 
 # codecs
 serde = { version = "1.0.*", default-features = false }

--- a/crates/storage/codecs/derive/src/compact/generator.rs
+++ b/crates/storage/codecs/derive/src/compact/generator.rs
@@ -1,6 +1,7 @@
 //! Code generator for the `Compact` trait.
 
 use super::*;
+use convert_case::{Case, Casing};
 
 /// Generates code to implement the `Compact` trait for a data type.
 pub fn generate_from_to(ident: &Ident, fields: &FieldList) -> TokenStream2 {
@@ -9,8 +10,10 @@ pub fn generate_from_to(ident: &Ident, fields: &FieldList) -> TokenStream2 {
     let to_compact = generate_to_compact(fields, ident);
     let from_compact = generate_from_compact(fields, ident);
 
-    let fuzz = format_ident!("fuzz_test_{ident}");
-    let test = format_ident!("fuzz_{ident}");
+    let snake_case_ident = ident.to_string().to_case(Case::Snake);
+
+    let fuzz = format_ident!("fuzz_test_{snake_case_ident}");
+    let test = format_ident!("fuzz_{snake_case_ident}");
 
     // Build function
     quote! {

--- a/crates/storage/codecs/derive/src/compact/mod.rs
+++ b/crates/storage/codecs/derive/src/compact/mod.rs
@@ -238,15 +238,15 @@ mod tests {
             #[cfg(test)]
             #[allow(dead_code)]
             #[test_fuzz::test_fuzz]
-            fn fuzz_test_TestStruct(obj: TestStruct) {
+            fn fuzz_test_test_struct(obj: TestStruct) {
                 let mut buf = vec![];
                 let len = obj.clone().to_compact(&mut buf);
                 let (same_obj, buf) = TestStruct::from_compact(buf.as_ref(), len);
                 assert_eq!(obj, same_obj);
             }
             #[test]
-            pub fn fuzz_TestStruct() {
-                fuzz_test_TestStruct(TestStruct::default())
+            pub fn fuzz_test_struct() {
+                fuzz_test_test_struct(TestStruct::default())
             }
             impl Compact for TestStruct {
                 fn to_compact(self, buf: &mut impl bytes::BufMut) -> usize {


### PR DESCRIPTION
Convert idents in the fuzz test generation to snake case