### PR TITLE
test: `walk_back` and `walk_range`

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -102,6 +102,7 @@ impl<'tx, K: TransactionKind, T: Table> DbCursorRO<'tx, T> for Cursor<'tx, K, T>
         let start = match range.start_bound().cloned() {
             Bound::Included(key) => self.inner.set_range(key.encode().as_ref()),
             Bound::Excluded(key) => {
+                // unreachable!("Rust doesn't allow for Bound::Excluded in starting bounds");
                 self.inner
                     .set_range(key.encode().as_ref())
                     .map_err(|e| Error::Read(e.into()))?

--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -100,7 +100,12 @@ impl<'tx, K: TransactionKind, T: Table> DbCursorRO<'tx, T> for Cursor<'tx, K, T>
         Self: Sized,
     {
         let start = match range.start_bound().cloned() {
-            Bound::Included(key) => self.inner.set_range(key.encode().as_ref()),
+            Bound::Included(key) => {
+                if matches!(range.end_bound().cloned(), Bound::Included(end_key) | Bound::Excluded(end_key) if end_key < key) {
+                    return Err(Error::Read(2))
+                }
+                self.inner.set_range(key.encode().as_ref())
+            }
             Bound::Excluded(_key) => {
                 unreachable!("Rust doesn't allow for Bound::Excluded in starting bounds");
             }

--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -125,13 +125,11 @@ impl<'tx, K: TransactionKind, T: Table> DbCursorRO<'tx, T> for Cursor<'tx, K, T>
         Self: Sized,
     {
         let start = if let Some(start_key) = start_key {
-            self.inner
-                .set_range(start_key.encode().as_ref())
-                .map_err(|e| Error::Read(e.into()))?
-                .map(decoder::<T>)
+            decode!(self.inner.set_range(start_key.encode().as_ref()))
         } else {
-            self.last().transpose()
-        };
+            self.last()
+        }
+        .transpose();
 
         Ok(ReverseWalker::new(self, start))
     }

--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -101,13 +101,8 @@ impl<'tx, K: TransactionKind, T: Table> DbCursorRO<'tx, T> for Cursor<'tx, K, T>
     {
         let start = match range.start_bound().cloned() {
             Bound::Included(key) => self.inner.set_range(key.encode().as_ref()),
-            Bound::Excluded(key) => {
-                // unreachable!("Rust doesn't allow for Bound::Excluded in starting bounds");
-                self.inner
-                    .set_range(key.encode().as_ref())
-                    .map_err(|e| Error::Read(e.into()))?
-                    .map(decoder::<T>);
-                self.inner.next()
+            Bound::Excluded(_key) => {
+                unreachable!("Rust doesn't allow for Bound::Excluded in starting bounds");
             }
             Bound::Unbounded => self.inner.first(),
         }

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -341,6 +341,45 @@ mod tests {
     }
 
     #[test]
+    fn db_walk_back() {
+        let db: Arc<Env<WriteMap>> = test_utils::create_test_db(EnvKind::RW);
+
+        // PUT (0, 0), (1, 0), (3, 0)
+        let tx = db.tx_mut().expect(ERROR_INIT_TX);
+        vec![0, 1, 3]
+            .into_iter()
+            .try_for_each(|key| tx.put::<CanonicalHeaders>(key, H256::zero()))
+            .expect(ERROR_PUT);
+        tx.commit().expect(ERROR_COMMIT);
+
+        let tx = db.tx().expect(ERROR_INIT_TX);
+        let mut cursor = tx.cursor_read::<CanonicalHeaders>().unwrap();
+
+        let mut reverse_walker = cursor.walk_back(Some(1)).unwrap();
+        assert_eq!(reverse_walker.next(), Some(Ok((1, H256::zero()))));
+        assert_eq!(reverse_walker.next(), Some(Ok((0, H256::zero()))));
+        assert_eq!(reverse_walker.next(), None);
+
+        let mut reverse_walker = cursor.walk_back(Some(2)).unwrap();
+        assert_eq!(reverse_walker.next(), Some(Ok((3, H256::zero()))));
+        assert_eq!(reverse_walker.next(), Some(Ok((1, H256::zero()))));
+        assert_eq!(reverse_walker.next(), Some(Ok((0, H256::zero()))));
+        assert_eq!(reverse_walker.next(), None);
+
+        let mut reverse_walker = cursor.walk_back(Some(4)).unwrap();
+        assert_eq!(reverse_walker.next(), Some(Ok((3, H256::zero()))));
+        assert_eq!(reverse_walker.next(), Some(Ok((1, H256::zero()))));
+        assert_eq!(reverse_walker.next(), Some(Ok((0, H256::zero()))));
+        assert_eq!(reverse_walker.next(), None);
+
+        let mut reverse_walker = cursor.walk_back(None).unwrap();
+        assert_eq!(reverse_walker.next(), Some(Ok((3, H256::zero()))));
+        assert_eq!(reverse_walker.next(), Some(Ok((1, H256::zero()))));
+        assert_eq!(reverse_walker.next(), Some(Ok((0, H256::zero()))));
+        assert_eq!(reverse_walker.next(), None);
+    }
+
+    #[test]
     fn db_cursor_seek_exact_or_previous_key() {
         let db: Arc<Env<WriteMap>> = test_utils::create_test_db(EnvKind::RW);
 

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -269,6 +269,15 @@ mod tests {
         assert_eq!(walker.next(), Some(Ok((2, H256::zero()))));
         // next() returns None after walker is done
         assert_eq!(walker.next(), None);
+
+        // (∞, ∞)
+        let mut walker = cursor.walk_range(..).unwrap();
+        assert_eq!(walker.next(), Some(Ok((0, H256::zero()))));
+        assert_eq!(walker.next(), Some(Ok((1, H256::zero()))));
+        assert_eq!(walker.next(), Some(Ok((2, H256::zero()))));
+        assert_eq!(walker.next(), Some(Ok((3, H256::zero()))));
+        // next() returns None after walker is done
+        assert_eq!(walker.next(), None);
     }
 
     #[test]


### PR DESCRIPTION
This PR adds a test for the `ReverseWalker` created using `walk_back`. This also adds a missing case in the `walk_range` tests.