### PR TITLE
perf(disc): allow more FindNode failures

### DIFF
--- a/crates/net/discv4/src/config.rs
+++ b/crates/net/discv4/src/config.rs
@@ -26,7 +26,7 @@ pub struct Discv4Config {
     pub udp_egress_message_buffer: usize,
     /// Size of the channel buffer for incoming messages.
     pub udp_ingress_message_buffer: usize,
-    /// The number of allowed failures for `FindNode` requests. Default: 1.
+    /// The number of allowed failures for `FindNode` requests. Default: 5.
     pub max_find_node_failures: u8,
     /// The interval to use when checking for expired nodes that need to be re-pinged. Default:
     /// 300sec, 5min.
@@ -116,7 +116,7 @@ impl Default for Discv4Config {
             udp_egress_message_buffer: 1024,
             /// Every outgoing request will eventually lead to an incoming response
             udp_ingress_message_buffer: 1024,
-            max_find_node_failures: 2,
+            max_find_node_failures: 5,
             ping_interval: Duration::from_secs(300),
             /// unified expiration and timeout durations, mirrors geth's `expiration` duration
             ping_expiration: Duration::from_secs(20),

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -1232,6 +1232,8 @@ impl Discv4Service {
         self.pending_find_nodes.retain(|node_id, find_node_request| {
             if now.duration_since(find_node_request.sent_at) > self.config.request_timeout {
                 if !find_node_request.answered {
+                    // node actually responded but with fewer entries than expected, but we don't
+                    // treat this as an hard error since it responded.
                     failed_neighbours.push(*node_id);
                 }
                 return false


### PR DESCRIPTION
allow more failed FindNode requests before dropping the node.

mirroring geth: 
https://github.com/ethereum/go-ethereum/blob/241cf62b5c8b70b1a4206587fa42606ad5de024a/p2p/discover/v4_udp.go#L55-L55