### PR TITLE
perf(disc): only remove node from table if its bucket is half full

### DIFF
--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -1255,7 +1255,9 @@ impl Discv4Service {
                 _ => continue,
             };
 
-            // if the node failed to respond anything useful multiple times, remove the node from the table, but only if there are enough other nodes in the bucket (bucket must be at least half full)
+            // if the node failed to respond anything useful multiple times, remove the node from
+            // the table, but only if there are enough other nodes in the bucket (bucket must be at
+            // least half full)
             if failures > (self.config.max_find_node_failures as usize) {
                 if let Some(bucket) = self.kbuckets.get_bucket(&key) {
                     if bucket.num_entries() < MAX_NODES_PER_BUCKET / 2 {

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -1255,7 +1255,14 @@ impl Discv4Service {
                 _ => continue,
             };
 
+            // if the node failed to respond anything useful multiple times, remove the node from the table, but only if there are enough other nodes in the bucket (bucket must be at least half full)
             if failures > (self.config.max_find_node_failures as usize) {
+                if let Some(bucket) = self.kbuckets.get_bucket(&key) {
+                    if bucket.num_entries() < MAX_NODES_PER_BUCKET / 2 {
+                        // skip half empty bucket
+                        continue
+                    }
+                }
                 self.remove_node(node_id);
             }
         }


### PR DESCRIPTION
mirrors:

https://github.com/ethereum/go-ethereum/blob/241cf62b5c8b70b1a4206587fa42606ad5de024a/p2p/discover/lookup.go#L152-L155

only remove node if bucket is at least half full