### PR TITLE
chore: disable runtime shutdown for now

### DIFF
--- a/bin/reth/src/runner.rs
+++ b/bin/reth/src/runner.rs
@@ -2,8 +2,8 @@
 
 use futures::pin_mut;
 use reth_tasks::{TaskExecutor, TaskManager};
-use std::{future::Future, time::Duration};
-use tracing::{trace, warn};
+use std::future::Future;
+use tracing::trace;
 
 /// Used to execute cli commands
 #[derive(Default, Debug)]
@@ -39,8 +39,9 @@ impl CliRunner {
 
         // give all tasks that are now being shut down some time to finish before tokio leaks them
         // see [Runtime::shutdown_timeout](tokio::runtime::Runtime::shutdown_timeout)
-        warn!(target: "reth::cli", "Received shutdown signal, waiting up to 30 seconds for tasks.");
-        tokio_runtime.shutdown_timeout(Duration::from_secs(30));
+        // TODO: enable this again, when pipeline/stages are not longer blocking tasks
+        // warn!(target: "reth::cli", "Received shutdown signal, waiting up to 30 seconds for
+        // tasks."); tokio_runtime.shutdown_timeout(Duration::from_secs(30));
 
         Ok(())
     }


### PR DESCRIPTION
removes the runtime shutdown period for now because some tasks are blocking.