### PR TITLE
fix(net): set tracked peers metric by value

### DIFF
--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -664,12 +664,16 @@ where
                         SwarmEvent::PeerAdded(peer_id) => {
                             trace!(target: "net", ?peer_id, "Peer added");
                             this.event_listeners.send(NetworkEvent::PeerAdded(peer_id));
-                            this.metrics.tracked_peers.increment(1f64);
+                            this.metrics
+                                .tracked_peers
+                                .set(this.swarm.state().peers().num_known_peers() as f64);
                         }
                         SwarmEvent::PeerRemoved(peer_id) => {
                             trace!(target: "net", ?peer_id, "Peer dropped");
                             this.event_listeners.send(NetworkEvent::PeerRemoved(peer_id));
-                            this.metrics.tracked_peers.decrement(1f64);
+                            this.metrics
+                                .tracked_peers
+                                .set(this.swarm.state().peers().num_known_peers() as f64);
                         }
                         SwarmEvent::SessionClosed { peer_id, remote_addr, error } => {
                             let total_active =

--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -163,6 +163,12 @@ impl PeersManager {
         PeersHandle { manager_tx: self.manager_tx.clone() }
     }
 
+    /// Returns the number of peers in the peer set
+    #[inline]
+    pub(crate) fn num_known_peers(&self) -> usize {
+        self.peers.len()
+    }
+
     /// Returns an iterator over all peers
     pub(crate) fn iter_peers(&self) -> impl Iterator<Item = NodeRecord> + '_ {
         self.peers.iter().map(|(peer_id, v)| NodeRecord::new(v.addr, *peer_id))
@@ -199,11 +205,13 @@ impl PeersManager {
     }
 
     /// Returns the number of currently active inbound connections.
+    #[inline]
     pub(crate) fn num_inbound_connections(&self) -> usize {
         self.connection_info.num_inbound
     }
 
     /// Returns the number of currently active outbound connections.
+    #[inline]
     pub(crate) fn num_outbound_connections(&self) -> usize {
         self.connection_info.num_outbound
     }


### PR DESCRIPTION
this fixes a bug where the `tracked_peers` metrics was no longer accurate because it uses increment and decrement.

now that we can initialize nodes from file etc. it should use `set(value)` instead.