### PR TITLE
fix: actually exit

### DIFF
--- a/bin/reth/src/runner.rs
+++ b/bin/reth/src/runner.rs
@@ -40,10 +40,9 @@ impl CliRunner {
         // give all tasks that are now being shut down some time to finish before tokio leaks them
         // see [Runtime::shutdown_timeout](tokio::runtime::Runtime::shutdown_timeout)
         // TODO: enable this again, when pipeline/stages are not longer blocking tasks
+        std::process::exit(0);
         // warn!(target: "reth::cli", "Received shutdown signal, waiting up to 30 seconds for
         // tasks."); tokio_runtime.shutdown_timeout(Duration::from_secs(30));
-
-        Ok(())
     }
 
     /// Executes a regular future until completion or until external signal received.


### PR DESCRIPTION
we need to actually exit because by default drop(Runtime) tries to shutdown the runtime.