### PR TITLE
fix: set shanghai time in From<EthersGenesis>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ checksum = "1d7cba9b073f771a6f76683be98624dd68e867ff9e6adcad3afbb3d2044c3afa"
 dependencies = [
  "itertools 0.9.0",
  "proc-macro-error",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -161,7 +161,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -172,7 +172,7 @@ version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -227,7 +227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7862e21c893d65a1650125d157eaeec691439379a1cee17ee49031b79236ada4"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -239,7 +239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a8c1df849285fbacd587de7818cc7d13be6cd2cbcd47a04fb1801b0e2706e33"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -353,7 +353,7 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "regex",
  "rustc-hash",
@@ -691,7 +691,7 @@ checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -726,7 +726,7 @@ version = "0.1.0"
 dependencies = [
  "convert_case 0.6.0",
  "parity-scale-codec",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "serde",
  "syn 1.0.107",
@@ -1075,7 +1075,7 @@ dependencies = [
  "cc",
  "codespan-reporting",
  "once_cell",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "scratch",
  "syn 1.0.107",
@@ -1093,7 +1093,7 @@ version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357f40d1f06a24b60ae1fe122542c1fb05d28d32acb2aed064e84bc2ad1e252e"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -1126,7 +1126,7 @@ checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "strsim 0.9.3",
  "syn 1.0.107",
@@ -1140,7 +1140,7 @@ checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "strsim 0.10.0",
  "syn 1.0.107",
@@ -1213,7 +1213,7 @@ version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8beee4701e2e229e8098bbdecdca12449bc3e322f137d269182fa1291e20bd00"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -1226,7 +1226,7 @@ checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
 dependencies = [
  "darling 0.10.2",
  "derive_builder_core",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -1238,7 +1238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
 dependencies = [
  "darling 0.10.2",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -1250,7 +1250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case 0.4.0",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "rustc_version",
  "syn 1.0.107",
@@ -1427,7 +1427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0188e3c3ba8df5753894d54461f0e39bc91741dc5b22e1c46999ec2c71f4e4"
 dependencies = [
  "enum-ordinalize",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -1520,7 +1520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "570d109b813e904becc80d8d5da38376818a143348413f7149f1340fe04754d4"
 dependencies = [
  "heck",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -1532,7 +1532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
 dependencies = [
  "heck",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -1545,7 +1545,7 @@ checksum = "a62bb1df8b45ecb7ffa78dca1c17a438fb193eb083db0b1b494d2a61bcb5096a"
 dependencies = [
  "num-bigint",
  "num-traits",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "rustc_version",
  "syn 1.0.107",
@@ -1557,7 +1557,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88bcb3a067a6555d577aba299e75eff9942da276e6506fc6274327daa026132"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -1656,7 +1656,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#91d88288a652119c40dc4698a04feef8943ea3f1"
+source = "git+https://github.com/gakonst/ethers-rs#69edf3b49e98ff70b7e73bf65510a75fc77baace"
 dependencies = [
  "ethers-core",
  "ethers-providers",
@@ -1672,7 +1672,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#91d88288a652119c40dc4698a04feef8943ea3f1"
+source = "git+https://github.com/gakonst/ethers-rs#69edf3b49e98ff70b7e73bf65510a75fc77baace"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1686,7 +1686,7 @@ dependencies = [
  "k256",
  "num_enum",
  "open-fastrlp",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "rand 0.8.5",
  "rlp",
  "rlp-derive",
@@ -1703,7 +1703,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#91d88288a652119c40dc4698a04feef8943ea3f1"
+source = "git+https://github.com/gakonst/ethers-rs#69edf3b49e98ff70b7e73bf65510a75fc77baace"
 dependencies = [
  "ethers-core",
  "getrandom 0.2.8",
@@ -1719,7 +1719,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#91d88288a652119c40dc4698a04feef8943ea3f1"
+source = "git+https://github.com/gakonst/ethers-rs#69edf3b49e98ff70b7e73bf65510a75fc77baace"
 dependencies = [
  "async-trait",
  "auto_impl 0.5.0",
@@ -1744,7 +1744,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#91d88288a652119c40dc4698a04feef8943ea3f1"
+source = "git+https://github.com/gakonst/ethers-rs#69edf3b49e98ff70b7e73bf65510a75fc77baace"
 dependencies = [
  "async-trait",
  "auto_impl 1.0.1",
@@ -1781,7 +1781,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#91d88288a652119c40dc4698a04feef8943ea3f1"
+source = "git+https://github.com/gakonst/ethers-rs#69edf3b49e98ff70b7e73bf65510a75fc77baace"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1963,7 +1963,7 @@ version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -2548,7 +2548,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -2763,7 +2763,7 @@ checksum = "baa6da1e4199c10d7b1d0a6e5e8bd8e55f351163b6f4b3cbb044672a69bd4c1c"
 dependencies = [
  "heck",
  "proc-macro-crate",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -3060,7 +3060,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "731f8ecebd9f3a4aa847dfe75455e4757a45da40a7793d2f0b1f9b6ed18b23f3"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -3126,7 +3126,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -3277,16 +3277,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2be1598bf1c313dcdd12092e3f1920f463462525a21b7b4e11b4168353d0123e"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "oorandom"
@@ -3326,7 +3326,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "003b2be5c6c53c1cfeb0a238b8a1c3915cd410feb684457a36c10038f764bb1c"
 dependencies = [
  "bytes",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -3390,7 +3390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86b26a931f824dd4eca30b3e43bb4f31cd5f0d3a403c5f5ff27106b805bfde7b"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -3548,7 +3548,7 @@ version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -3678,7 +3678,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
  "version_check",
@@ -3690,7 +3690,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "version_check",
 ]
@@ -3706,9 +3706,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -3808,7 +3808,7 @@ version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
 ]
 
 [[package]]
@@ -4407,7 +4407,7 @@ version = "0.1.0"
 dependencies = [
  "metrics",
  "once_cell",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "regex",
  "serial_test",
@@ -4593,7 +4593,7 @@ dependencies = [
 name = "reth-rlp-derive"
 version = "0.1.1"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -4931,7 +4931,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -5088,7 +5088,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "303959cf613a6f6efd19ed4b4ad5bf79966a13352716299ad532cfb115f4205c"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -5276,7 +5276,7 @@ version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -5327,7 +5327,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1966009f3c05f095697c537312f5415d1e3ed31ce0a56942bac4c771c5c335e"
 dependencies = [
  "darling 0.14.2",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -5352,7 +5352,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b64f9e531ce97c88b4778aad0ceee079216071cffec6ac9b904277f8f92e7fe3"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -5641,7 +5641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "rustversion",
  "syn 1.0.107",
@@ -5702,7 +5702,7 @@ version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "unicode-ident",
 ]
@@ -5713,7 +5713,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
  "unicode-xid 0.2.4",
@@ -5767,7 +5767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9186daca5c58cb307d09731e0ba06b13fd6c036c90672b9bfc31cecf76cf689"
 dependencies = [
  "cargo_metadata",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "serde",
  "strum_macros",
@@ -5782,7 +5782,7 @@ dependencies = [
  "darling 0.14.2",
  "if_chain",
  "lazy_static",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "subprocess",
  "syn 1.0.107",
@@ -5826,7 +5826,7 @@ version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -5927,7 +5927,7 @@ version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -6102,7 +6102,7 @@ version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -6436,7 +6436,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2e7e85a0596447f0f2ac090e16bc4c516c6fe91771fb0c0ccf7fa3dae896b9c"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -6553,7 +6553,7 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
  "wasm-bindgen-shared",
@@ -6587,7 +6587,7 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
  "wasm-bindgen-backend",
@@ -6811,7 +6811,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
  "synstructure",

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -278,6 +278,17 @@ impl From<EthersGenesis> for ChainSpec {
             );
         }
 
+        // Time-based hardforks
+        let time_hardfork_opts = vec![
+            (Hardfork::Shanghai, genesis.config.shanghai_time),
+        ];
+        let time_hardforks = time_hardfork_opts
+            .iter()
+            .filter_map(|(hardfork, opt)| opt.map(|time| (*hardfork, ForkCondition::Timestamp(time))))
+            .collect::<BTreeMap<_, _>>();
+
+        hardforks.extend(time_hardforks);
+
         Self {
             chain: genesis.config.chain_id.into(),
             genesis: genesis_block,
@@ -900,5 +911,92 @@ mod tests {
         assert!(chainspec
             .fork(Hardfork::Paris)
             .active_at_ttd(first_pos_block_ttd, first_pos_difficulty));
+    }
+
+    #[test]
+    fn geth_genesis_with_shanghai() {
+        let geth_genesis = r#"
+        {
+          "config": {
+            "chainId": 1337,
+            "homesteadBlock": 0,
+            "eip150Block": 0,
+            "eip150Hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "eip155Block": 0,
+            "eip158Block": 0,
+            "byzantiumBlock": 0,
+            "constantinopleBlock": 0,
+            "petersburgBlock": 0,
+            "istanbulBlock": 0,
+            "muirGlacierBlock": 0,
+            "berlinBlock": 0,
+            "londonBlock": 0,
+            "arrowGlacierBlock": 0,
+            "grayGlacierBlock": 0,
+            "shanghaiTime": 0,
+            "terminalTotalDifficulty": 0,
+            "terminalTotalDifficultyPassed": true,
+            "ethash": {}
+          },
+          "nonce": "0x0",
+          "timestamp": "0x0",
+          "extraData": "0x",
+          "gasLimit": "0x4c4b40",
+          "difficulty": "0x1",
+          "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "coinbase": "0x0000000000000000000000000000000000000000",
+          "alloc": {
+            "658bdf435d810c91414ec09147daa6db62406379": {
+              "balance": "0x487a9a304539440000"
+            },
+            "aa00000000000000000000000000000000000000": {
+              "code": "0x6042",
+              "storage": {
+                "0x0000000000000000000000000000000000000000000000000000000000000000": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "0x0100000000000000000000000000000000000000000000000000000000000000": "0x0100000000000000000000000000000000000000000000000000000000000000",
+                "0x0200000000000000000000000000000000000000000000000000000000000000": "0x0200000000000000000000000000000000000000000000000000000000000000",
+                "0x0300000000000000000000000000000000000000000000000000000000000000": "0x0000000000000000000000000000000000000000000000000000000000000303"
+              },
+              "balance": "0x1",
+              "nonce": "0x1"
+            },
+            "bb00000000000000000000000000000000000000": {
+              "code": "0x600154600354",
+              "storage": {
+                "0x0000000000000000000000000000000000000000000000000000000000000000": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "0x0100000000000000000000000000000000000000000000000000000000000000": "0x0100000000000000000000000000000000000000000000000000000000000000",
+                "0x0200000000000000000000000000000000000000000000000000000000000000": "0x0200000000000000000000000000000000000000000000000000000000000000",
+                "0x0300000000000000000000000000000000000000000000000000000000000000": "0x0000000000000000000000000000000000000000000000000000000000000303"
+              },
+              "balance": "0x2",
+              "nonce": "0x1"
+            }
+          },
+          "number": "0x0",
+          "gasUsed": "0x0",
+          "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "baseFeePerGas": "0x3b9aca00"
+        }
+        "#;
+
+        let genesis: ethers_core::utils::Genesis = serde_json::from_str(geth_genesis).unwrap();
+        let chainspec = ChainSpec::from(genesis);
+
+        // assert a bunch of hardforks that should be set
+        assert_eq!(chainspec.hardforks.get(&Hardfork::Homestead).unwrap(), &ForkCondition::Block(0));
+        assert_eq!(chainspec.hardforks.get(&Hardfork::Tangerine).unwrap(), &ForkCondition::Block(0));
+        assert_eq!(chainspec.hardforks.get(&Hardfork::SpuriousDragon).unwrap(), &ForkCondition::Block(0));
+        assert_eq!(chainspec.hardforks.get(&Hardfork::Byzantium).unwrap(), &ForkCondition::Block(0));
+        assert_eq!(chainspec.hardforks.get(&Hardfork::Constantinople).unwrap(), &ForkCondition::Block(0));
+        assert_eq!(chainspec.hardforks.get(&Hardfork::Petersburg).unwrap(), &ForkCondition::Block(0));
+        assert_eq!(chainspec.hardforks.get(&Hardfork::Istanbul).unwrap(), &ForkCondition::Block(0));
+        assert_eq!(chainspec.hardforks.get(&Hardfork::MuirGlacier).unwrap(), &ForkCondition::Block(0));
+        assert_eq!(chainspec.hardforks.get(&Hardfork::Berlin).unwrap(), &ForkCondition::Block(0));
+        assert_eq!(chainspec.hardforks.get(&Hardfork::London).unwrap(), &ForkCondition::Block(0));
+        assert_eq!(chainspec.hardforks.get(&Hardfork::ArrowGlacier).unwrap(), &ForkCondition::Block(0));
+        assert_eq!(chainspec.hardforks.get(&Hardfork::GrayGlacier).unwrap(), &ForkCondition::Block(0));
+
+        // including time based hardforks
+        assert_eq!(chainspec.hardforks.get(&Hardfork::Shanghai).unwrap(), &ForkCondition::Timestamp(0));
     }
 }

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -279,12 +279,12 @@ impl From<EthersGenesis> for ChainSpec {
         }
 
         // Time-based hardforks
-        let time_hardfork_opts = vec![
-            (Hardfork::Shanghai, genesis.config.shanghai_time),
-        ];
+        let time_hardfork_opts = vec![(Hardfork::Shanghai, genesis.config.shanghai_time)];
         let time_hardforks = time_hardfork_opts
             .iter()
-            .filter_map(|(hardfork, opt)| opt.map(|time| (*hardfork, ForkCondition::Timestamp(time))))
+            .filter_map(|(hardfork, opt)| {
+                opt.map(|time| (*hardfork, ForkCondition::Timestamp(time)))
+            })
             .collect::<BTreeMap<_, _>>();
 
         hardforks.extend(time_hardforks);
@@ -983,20 +983,50 @@ mod tests {
         let chainspec = ChainSpec::from(genesis);
 
         // assert a bunch of hardforks that should be set
-        assert_eq!(chainspec.hardforks.get(&Hardfork::Homestead).unwrap(), &ForkCondition::Block(0));
-        assert_eq!(chainspec.hardforks.get(&Hardfork::Tangerine).unwrap(), &ForkCondition::Block(0));
-        assert_eq!(chainspec.hardforks.get(&Hardfork::SpuriousDragon).unwrap(), &ForkCondition::Block(0));
-        assert_eq!(chainspec.hardforks.get(&Hardfork::Byzantium).unwrap(), &ForkCondition::Block(0));
-        assert_eq!(chainspec.hardforks.get(&Hardfork::Constantinople).unwrap(), &ForkCondition::Block(0));
-        assert_eq!(chainspec.hardforks.get(&Hardfork::Petersburg).unwrap(), &ForkCondition::Block(0));
+        assert_eq!(
+            chainspec.hardforks.get(&Hardfork::Homestead).unwrap(),
+            &ForkCondition::Block(0)
+        );
+        assert_eq!(
+            chainspec.hardforks.get(&Hardfork::Tangerine).unwrap(),
+            &ForkCondition::Block(0)
+        );
+        assert_eq!(
+            chainspec.hardforks.get(&Hardfork::SpuriousDragon).unwrap(),
+            &ForkCondition::Block(0)
+        );
+        assert_eq!(
+            chainspec.hardforks.get(&Hardfork::Byzantium).unwrap(),
+            &ForkCondition::Block(0)
+        );
+        assert_eq!(
+            chainspec.hardforks.get(&Hardfork::Constantinople).unwrap(),
+            &ForkCondition::Block(0)
+        );
+        assert_eq!(
+            chainspec.hardforks.get(&Hardfork::Petersburg).unwrap(),
+            &ForkCondition::Block(0)
+        );
         assert_eq!(chainspec.hardforks.get(&Hardfork::Istanbul).unwrap(), &ForkCondition::Block(0));
-        assert_eq!(chainspec.hardforks.get(&Hardfork::MuirGlacier).unwrap(), &ForkCondition::Block(0));
+        assert_eq!(
+            chainspec.hardforks.get(&Hardfork::MuirGlacier).unwrap(),
+            &ForkCondition::Block(0)
+        );
         assert_eq!(chainspec.hardforks.get(&Hardfork::Berlin).unwrap(), &ForkCondition::Block(0));
         assert_eq!(chainspec.hardforks.get(&Hardfork::London).unwrap(), &ForkCondition::Block(0));
-        assert_eq!(chainspec.hardforks.get(&Hardfork::ArrowGlacier).unwrap(), &ForkCondition::Block(0));
-        assert_eq!(chainspec.hardforks.get(&Hardfork::GrayGlacier).unwrap(), &ForkCondition::Block(0));
+        assert_eq!(
+            chainspec.hardforks.get(&Hardfork::ArrowGlacier).unwrap(),
+            &ForkCondition::Block(0)
+        );
+        assert_eq!(
+            chainspec.hardforks.get(&Hardfork::GrayGlacier).unwrap(),
+            &ForkCondition::Block(0)
+        );
 
         // including time based hardforks
-        assert_eq!(chainspec.hardforks.get(&Hardfork::Shanghai).unwrap(), &ForkCondition::Timestamp(0));
+        assert_eq!(
+            chainspec.hardforks.get(&Hardfork::Shanghai).unwrap(),
+            &ForkCondition::Timestamp(0)
+        );
     }
 }

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -279,12 +279,11 @@ impl From<EthersGenesis> for ChainSpec {
         }
 
         // Time-based hardforks
-        let time_hardfork_opts = vec![(Hardfork::Shanghai, genesis.config.shanghai_time)];
-        let time_hardforks = time_hardfork_opts
-            .iter()
-            .filter_map(|(hardfork, opt)| {
-                opt.map(|time| (*hardfork, ForkCondition::Timestamp(time)))
-            })
+        let time_hardforks = genesis
+            .config
+            .shanghai_time
+            .map(|time| (Hardfork::Shanghai, ForkCondition::Timestamp(time)))
+            .into_iter()
             .collect::<BTreeMap<_, _>>();
 
         hardforks.extend(time_hardforks);


### PR DESCRIPTION
Previously, we were not setting the shanghai timestamp fork when using a geth genesis file. In the `rpc-compat` hive tests, this would cause header validation errors due to the fork not being configured:
```  
HeaderValidation { hash: 0x21c246c7052a09711c48e91d1b4673e203310a4c8f8f97525996efc544eea25a, error: WithdrawalsRootUnexpected }
```

Summary of changes:
 * extend hardforks with `Hardfork::Shanghai` as the first timestamp based fork
 * add a test making sure forks are set properly in `From<EthersGenesis> for ChainSpec`
 * update the ethers commit in `Cargo.lock` to use the new serde parsing