### PR TITLE
fix: make execution errors fatal

### DIFF
--- a/crates/stages/src/error.rs
+++ b/crates/stages/src/error.rs
@@ -71,6 +71,7 @@ impl StageError {
                 StageError::Download(_) |
                 StageError::DatabaseIntegrity(_) |
                 StageError::StageProgress(_) |
+                StageError::ExecutionError { .. } |
                 StageError::ChannelClosed |
                 StageError::Fatal(_)
         )


### PR DESCRIPTION
It does not make sense to retry the stage over and over if we encounter an execution error.