### PR TITLE
fix(disc): only start pinging new node if insert succesful

### DIFF
--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -809,13 +809,18 @@ impl Discv4Service {
         match self.kbuckets.entry(&key) {
             kbucket::Entry::Absent(entry) => {
                 let node = NodeEntry::new(record);
-                let _ = entry.insert(
+                match entry.insert(
                     node,
                     NodeStatus {
                         direction: ConnectionDirection::Outgoing,
                         state: ConnectionState::Disconnected,
                     },
-                );
+                ) {
+                    BucketInsertResult::Inserted | BucketInsertResult::Pending { .. } => {
+                        debug!(target : "discv4",  ?record, "inserted new record");
+                    }
+                    _ => return,
+                }
             }
             _ => return,
         }


### PR DESCRIPTION
inserting into the table can fail if the table is full.

Fix: ping only if the new node was added successfully