### PR TITLE
chore(rpc): return input related errors as invalid params

### DIFF
--- a/crates/rpc/rpc/src/eth/error.rs
+++ b/crates/rpc/rpc/src/eth/error.rs
@@ -33,9 +33,11 @@ pub(crate) enum EthApiError {
 impl From<EthApiError> for RpcError {
     fn from(value: EthApiError) -> Self {
         match value {
-            EthApiError::UnknownBlockNumber | EthApiError::InvalidBlockRange => {
-                rpc_err(INVALID_PARAMS_CODE, value.to_string(), None)
-            }
+            EthApiError::FailedToDecodeSignedTransaction |
+            EthApiError::InvalidTransactionSignature |
+            EthApiError::EmptyRawTransactionData |
+            EthApiError::UnknownBlockNumber |
+            EthApiError::InvalidBlockRange => rpc_err(INVALID_PARAMS_CODE, value.to_string(), None),
             err => internal_rpc_err(err.to_string()),
         }
     }


### PR DESCRIPTION
return errors related to call input with `INVALID_PARAMS_CODE`