### PR TITLE
chore: phase out ethers rpc block types

### DIFF
--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -7,7 +7,7 @@ use reth_eth_wire::{
     GetReceipts, NodeData, Receipts,
 };
 use reth_interfaces::p2p::error::RequestResult;
-use reth_primitives::{rpc, BlockHashOrNumber, Header, HeadersDirection, PeerId, U256};
+use reth_primitives::{BlockHashOrNumber, Header, HeadersDirection, PeerId, U256};
 use reth_provider::{BlockProvider, HeaderProvider};
 use std::{
     borrow::Borrow,
@@ -160,9 +160,7 @@ where
         let mut total_bytes = APPROX_BODY_SIZE;
 
         for hash in request.0 {
-            if let Some(block) =
-                self.client.block(rpc::BlockId::Hash(rpc::H256(hash.0))).unwrap_or_default()
-            {
+            if let Some(block) = self.client.block_by_hash(hash).unwrap_or_default() {
                 let body = BlockBody {
                     transactions: block.body,
                     ommers: block.ommers,

--- a/crates/primitives/src/chain/info.rs
+++ b/crates/primitives/src/chain/info.rs
@@ -1,4 +1,4 @@
-use crate::{rpc::BlockNumber as RpcBlockNumber, BlockNumber, H256};
+use crate::{BlockNumber, BlockNumberOrTag, H256};
 
 /// Current status of the blockchain's head.
 #[derive(Default, Debug, Eq, PartialEq)]
@@ -15,14 +15,14 @@ pub struct ChainInfo {
 
 impl ChainInfo {
     /// Attempts to convert a [BlockNumber](crate::rpc::BlockNumber) enum to a numeric value
-    pub fn convert_block_number(&self, number: RpcBlockNumber) -> Option<u64> {
+    pub fn convert_block_number(&self, number: BlockNumberOrTag) -> Option<u64> {
         match number {
-            RpcBlockNumber::Finalized => self.last_finalized,
-            RpcBlockNumber::Safe => self.safe_finalized,
-            RpcBlockNumber::Earliest => Some(0),
-            RpcBlockNumber::Number(num) => Some(num.as_u64()),
-            RpcBlockNumber::Pending => None,
-            RpcBlockNumber::Latest => Some(self.best_number),
+            BlockNumberOrTag::Finalized => self.last_finalized,
+            BlockNumberOrTag::Safe => self.safe_finalized,
+            BlockNumberOrTag::Earliest => Some(0),
+            BlockNumberOrTag::Number(num) => Some(num),
+            BlockNumberOrTag::Pending => None,
+            BlockNumberOrTag::Latest => Some(self.best_number),
         }
     }
 }

--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -1,5 +1,5 @@
 use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
-use reth_primitives::{rpc::BlockId, Bytes, H256};
+use reth_primitives::{BlockId, Bytes, H256};
 use reth_rpc_types::RichBlock;
 
 /// Debug rpc interface.

--- a/crates/rpc/rpc-api/src/eth.rs
+++ b/crates/rpc/rpc-api/src/eth.rs
@@ -30,7 +30,7 @@ pub trait EthApi {
     async fn accounts(&self) -> Result<Vec<Address>>;
 
     /// Returns the number of most recent block.
-    #[method(name = "eth_BlockNumberOrTag")]
+    #[method(name = "eth_blockNumber")]
     fn block_number(&self) -> Result<U256>;
 
     /// Returns the chain ID of the current network.
@@ -65,7 +65,7 @@ pub trait EthApi {
     async fn block_uncles_count_by_hash(&self, hash: H256) -> Result<U256>;
 
     /// Returns the number of uncles in a block with given block number.
-    #[method(name = "eth_getUncleCountByBlockNumberOrTag")]
+    #[method(name = "eth_getUncleCountByBlockNumber")]
     async fn block_uncles_count_by_number(&self, number: BlockNumberOrTag) -> Result<U256>;
 
     /// Returns an uncle block of the given block and index.
@@ -77,7 +77,7 @@ pub trait EthApi {
     ) -> Result<Option<RichBlock>>;
 
     /// Returns an uncle block of the given block and index.
-    #[method(name = "eth_getUncleByBlockNumberOrTagAndIndex")]
+    #[method(name = "eth_getUncleByBlockNumberAndIndex")]
     async fn uncle_by_block_number_and_index(
         &self,
         number: BlockNumberOrTag,
@@ -97,7 +97,7 @@ pub trait EthApi {
     ) -> Result<Option<Transaction>>;
 
     /// Returns information about a transaction by block number and transaction index position.
-    #[method(name = "eth_getTransactionByBlockNumberOrTagAndIndex")]
+    #[method(name = "eth_getTransactionByBlockNumberAndIndex")]
     async fn transaction_by_block_number_and_index(
         &self,
         number: BlockNumberOrTag,

--- a/crates/rpc/rpc-api/src/eth.rs
+++ b/crates/rpc/rpc-api/src/eth.rs
@@ -1,7 +1,7 @@
 use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
 use reth_primitives::{
-    rpc::{transaction::eip2930::AccessListWithGasUsed, BlockId, BlockNumber},
-    Address, Bytes, H256, H64, U256, U64,
+    rpc::transaction::eip2930::AccessListWithGasUsed, Address, BlockId, BlockNumberOrTag, Bytes,
+    H256, H64, U256, U64,
 };
 use reth_rpc_types::{
     CallRequest, EIP1186AccountProofResponse, FeeHistory, Index, RichBlock, SyncStatus,
@@ -30,7 +30,7 @@ pub trait EthApi {
     async fn accounts(&self) -> Result<Vec<Address>>;
 
     /// Returns the number of most recent block.
-    #[method(name = "eth_blockNumber")]
+    #[method(name = "eth_BlockNumberOrTag")]
     fn block_number(&self) -> Result<U256>;
 
     /// Returns the chain ID of the current network.
@@ -43,7 +43,11 @@ pub trait EthApi {
 
     /// Returns information about a block by number.
     #[method(name = "eth_getBlockByNumber")]
-    async fn block_by_number(&self, number: BlockNumber, full: bool) -> Result<Option<RichBlock>>;
+    async fn block_by_number(
+        &self,
+        number: BlockNumberOrTag,
+        full: bool,
+    ) -> Result<Option<RichBlock>>;
 
     /// Returns the number of transactions in a block from a block matching the given block hash.
     #[method(name = "eth_getBlockTransactionCountByHash")]
@@ -51,15 +55,18 @@ pub trait EthApi {
 
     /// Returns the number of transactions in a block matching the given block number.
     #[method(name = "eth_getBlockTransactionCountByNumber")]
-    async fn block_transaction_count_by_number(&self, number: BlockNumber) -> Result<Option<U256>>;
+    async fn block_transaction_count_by_number(
+        &self,
+        number: BlockNumberOrTag,
+    ) -> Result<Option<U256>>;
 
     /// Returns the number of uncles in a block from a block matching the given block hash.
     #[method(name = "eth_getUncleCountByBlockHash")]
     async fn block_uncles_count_by_hash(&self, hash: H256) -> Result<U256>;
 
     /// Returns the number of uncles in a block with given block number.
-    #[method(name = "eth_getUncleCountByBlockNumber")]
-    async fn block_uncles_count_by_number(&self, number: BlockNumber) -> Result<U256>;
+    #[method(name = "eth_getUncleCountByBlockNumberOrTag")]
+    async fn block_uncles_count_by_number(&self, number: BlockNumberOrTag) -> Result<U256>;
 
     /// Returns an uncle block of the given block and index.
     #[method(name = "eth_getUncleByBlockHashAndIndex")]
@@ -70,10 +77,10 @@ pub trait EthApi {
     ) -> Result<Option<RichBlock>>;
 
     /// Returns an uncle block of the given block and index.
-    #[method(name = "eth_getUncleByBlockNumberAndIndex")]
+    #[method(name = "eth_getUncleByBlockNumberOrTagAndIndex")]
     async fn uncle_by_block_number_and_index(
         &self,
-        number: BlockNumber,
+        number: BlockNumberOrTag,
         index: Index,
     ) -> Result<Option<RichBlock>>;
 
@@ -90,10 +97,10 @@ pub trait EthApi {
     ) -> Result<Option<Transaction>>;
 
     /// Returns information about a transaction by block number and transaction index position.
-    #[method(name = "eth_getTransactionByBlockNumberAndIndex")]
+    #[method(name = "eth_getTransactionByBlockNumberOrTagAndIndex")]
     async fn transaction_by_block_number_and_index(
         &self,
-        number: BlockNumber,
+        number: BlockNumberOrTag,
         index: Index,
     ) -> Result<Option<Transaction>>;
 

--- a/crates/rpc/rpc-api/src/trace.rs
+++ b/crates/rpc/rpc-api/src/trace.rs
@@ -1,5 +1,5 @@
 use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
-use reth_primitives::{rpc::BlockId, Bytes, H256};
+use reth_primitives::{BlockId, Bytes, H256};
 use reth_rpc_types::{
     trace::{filter::TraceFilter, parity::*},
     CallRequest, Index,

--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -9,9 +9,7 @@ use jsonrpsee::{
     types::error::{CallError, ErrorCode},
 };
 use reth_primitives::{
-    hex_literal::hex,
-    rpc::{BlockId, BlockNumber},
-    Address, Bytes, NodeRecord, H256, H64, U256,
+    hex_literal::hex, Address, BlockId, BlockNumberOrTag, Bytes, NodeRecord, H256, H64, U256,
 };
 use reth_rpc_api::{
     clients::{AdminApiClient, EthApiClient},
@@ -52,7 +50,7 @@ where
     let address = Address::default();
     let index = Index::default();
     let hash = H256::default();
-    let block_number = BlockNumber::default();
+    let block_number = BlockNumberOrTag::default();
     let call_request = CallRequest::default();
     let transaction_request = TransactionRequest::default();
     let bytes = Bytes::default();
@@ -161,7 +159,7 @@ async fn test_basic_debug_calls<C>(client: &C)
 where
     C: ClientT + SubscriptionClientT + Sync,
 {
-    let block_id = BlockId::Number(BlockNumber::default());
+    let block_id = BlockId::Number(BlockNumberOrTag::default());
 
     assert!(is_unimplemented(DebugApiClient::raw_header(client, block_id).await.err().unwrap()));
     assert!(is_unimplemented(DebugApiClient::raw_block(client, block_id).await.err().unwrap()));
@@ -185,7 +183,7 @@ async fn test_basic_trace_calls<C>(client: &C)
 where
     C: ClientT + SubscriptionClientT + Sync,
 {
-    let block_id = BlockId::Number(BlockNumber::default());
+    let block_id = BlockId::Number(BlockNumberOrTag::default());
     let trace_filter = TraceFilter {
         from_block: None,
         to_block: None,

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -7,7 +7,6 @@ use reth_executor::{
 use reth_interfaces::consensus::ForkchoiceState;
 use reth_primitives::{
     proofs::{self, EMPTY_LIST_HASH},
-    rpc::{BlockId, H256 as EthersH256},
     ChainSpec, Hardfork, Header, SealedBlock, TransactionSigned, H64, U256,
 };
 use reth_provider::{BlockProvider, HeaderProvider, StateProvider};
@@ -158,7 +157,7 @@ impl<Client: HeaderProvider + BlockProvider + StateProvider> EngineApi<Client> {
             return Ok(PayloadStatus::new(PayloadStatusEnum::Valid, block_hash))
         }
 
-        let Some(parent) = self.client.block(BlockId::Hash(EthersH256(parent_hash.0)))? else {
+        let Some(parent) = self.client.block_by_hash(parent_hash)? else {
              // TODO: cache block for storing later
              return Ok(PayloadStatus::from_status(PayloadStatusEnum::Syncing))
         };

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -1,7 +1,7 @@
 use crate::{result::internal_rpc_err, EthApiSpec};
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult as Result;
-use reth_primitives::{rpc::BlockId, Bytes, H256};
+use reth_primitives::{BlockId, Bytes, H256};
 use reth_rpc_api::DebugApiServer;
 use reth_rpc_types::RichBlock;
 

--- a/crates/rpc/rpc/src/eth/api/block.rs
+++ b/crates/rpc/rpc/src/eth/api/block.rs
@@ -1,7 +1,7 @@
 //! Contains RPC handler implementations specific to blocks.
 
 use crate::{eth::error::EthResult, EthApi};
-use reth_primitives::{rpc::BlockId, H256};
+use reth_primitives::{BlockId, H256};
 use reth_provider::{BlockProvider, StateProviderFactory};
 use reth_rpc_types::RichBlock;
 
@@ -14,7 +14,7 @@ where
         hash: H256,
         _full: bool,
     ) -> EthResult<Option<RichBlock>> {
-        let block = self.client().block(BlockId::Hash(hash.0.into()))?;
+        let block = self.client().block(hash.into())?;
         if let Some(_block) = block {
             // TODO: GET TD FOR BLOCK - needs block provider? or header provider?
             // let total_difficulty = todo!();

--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -8,8 +8,7 @@ use async_trait::async_trait;
 use reth_interfaces::Result;
 use reth_network_api::NetworkInfo;
 use reth_primitives::{
-    rpc::{BlockId, BlockNumber},
-    Address, ChainInfo, TransactionSigned, H256, U64,
+    Address, BlockId, BlockNumberOrTag, ChainInfo, TransactionSigned, H256, U64,
 };
 use reth_provider::{BlockProvider, StateProviderFactory};
 use std::num::NonZeroUsize;
@@ -97,7 +96,7 @@ impl<Client, Pool, Network> EthApi<Client, Pool, Network>
 where
     Client: BlockProvider + StateProviderFactory + 'static,
 {
-    fn convert_block_number(&self, num: BlockNumber) -> Result<Option<u64>> {
+    fn convert_block_number(&self, num: BlockNumberOrTag) -> Result<Option<u64>> {
         self.client().convert_block_number(num)
     }
 
@@ -119,7 +118,7 @@ where
         block_id: BlockId,
     ) -> Result<Option<<Client as StateProviderFactory>::HistorySP<'_>>> {
         match block_id {
-            BlockId::Hash(hash) => self.state_at_hash(H256(hash.0)).map(Some),
+            BlockId::Hash(hash) => self.state_at_hash(hash.into()).map(Some),
             BlockId::Number(num) => self.state_at_block_number(num),
         }
     }
@@ -129,7 +128,7 @@ where
     /// Returns `None` if no state available.
     pub(crate) fn state_at_block_number(
         &self,
-        num: BlockNumber,
+        num: BlockNumberOrTag,
     ) -> Result<Option<<Client as StateProviderFactory>::HistorySP<'_>>> {
         if let Some(number) = self.convert_block_number(num)? {
             self.state_at_number(number).map(Some)
@@ -158,7 +157,7 @@ where
     pub(crate) fn latest_state(
         &self,
     ) -> Result<Option<<Client as StateProviderFactory>::HistorySP<'_>>> {
-        self.state_at_block_number(BlockNumber::Latest)
+        self.state_at_block_number(BlockNumberOrTag::Latest)
     }
 }
 

--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -123,7 +123,7 @@ where
         }
     }
 
-    /// Returns the state at the given [BlockNumber] enum
+    /// Returns the state at the given [BlockNumberOrTag] enum
     ///
     /// Returns `None` if no state available.
     pub(crate) fn state_at_block_number(

--- a/crates/rpc/rpc/src/eth/api/state.rs
+++ b/crates/rpc/rpc/src/eth/api/state.rs
@@ -4,7 +4,7 @@ use crate::{
     eth::error::{EthApiError, EthResult},
     EthApi,
 };
-use reth_primitives::{rpc::BlockId, Address, Bytes, H256, U256};
+use reth_primitives::{Address, BlockId, Bytes, H256, U256};
 use reth_provider::{BlockProvider, StateProvider, StateProviderFactory};
 
 impl<Client, Pool, Network> EthApi<Client, Pool, Network>

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -108,14 +108,14 @@ where
                     FilterBlockOption::Range { from_block, to_block } => {
                         // from block is maximum of block from last poll or `from_block` of filter
                         if let Some(filter_from_block) =
-                            from_block.and_then(|num| info.convert_block_number(num))
+                            from_block.and_then(|num| info.convert_block_number(num.into()))
                         {
                             from_block_number = start_block.max(filter_from_block)
                         }
 
                         // to block is max the best number
                         if let Some(filter_to_block) =
-                            to_block.and_then(|num| info.convert_block_number(num))
+                            to_block.and_then(|num| info.convert_block_number(num.into()))
                         {
                             to_block_number = filter_to_block;
                             if to_block_number > best_number {
@@ -220,7 +220,7 @@ where
         // while block_number <= to_block {
         //     let _block = self
         //         .client
-        //         .block_by_number(BlockNumber::Number(block_number.into()))
+        //         .block_by_number(BlockNumberOrTag::Number(block_number.into()))
         //         .to_rpc_result()?
         //         .ok_or(EthApiError::UnknownBlockNumber)?;
         //

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -1,7 +1,7 @@
 use crate::result::internal_rpc_err;
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult as Result;
-use reth_primitives::{rpc::BlockId, Bytes, H256};
+use reth_primitives::{BlockId, Bytes, H256};
 use reth_rpc_api::TraceApiServer;
 use reth_rpc_types::{
     trace::{filter::TraceFilter, parity::*},

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -10,7 +10,7 @@ use reth_db::{
 };
 use reth_interfaces::Result;
 use reth_primitives::{
-    rpc::BlockId, Block, BlockHash, BlockNumber, ChainInfo, ChainSpec, Hardfork, Header,
+    Block, BlockHash, BlockId, BlockNumber, ChainInfo, ChainSpec, Hardfork, Header,
     TransactionSigned, TxHash, TxNumber, Withdrawal, H256, U256,
 };
 use std::{ops::RangeBounds, sync::Arc};

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -5,10 +5,8 @@ use crate::{
 use parking_lot::Mutex;
 use reth_interfaces::Result;
 use reth_primitives::{
-    keccak256,
-    rpc::{BlockId, BlockNumber},
-    Account, Address, Block, BlockHash, Bytes, ChainInfo, Header, StorageKey, StorageValue,
-    TransactionSigned, TxHash, H256, U256,
+    keccak256, Account, Address, Block, BlockHash, BlockId, BlockNumberOrTag, Bytes, ChainInfo,
+    Header, StorageKey, StorageValue, TransactionSigned, TxHash, H256, U256,
 };
 use std::{collections::HashMap, ops::RangeBounds, sync::Arc};
 
@@ -191,9 +189,9 @@ impl BlockProvider for MockEthProvider {
     fn block(&self, id: BlockId) -> Result<Option<Block>> {
         let lock = self.blocks.lock();
         match id {
-            BlockId::Hash(hash) => Ok(lock.get(&H256(hash.0)).cloned()),
-            BlockId::Number(BlockNumber::Number(num)) => {
-                Ok(lock.values().find(|b| b.number == num.as_u64()).cloned())
+            BlockId::Hash(hash) => Ok(lock.get(hash.as_ref()).cloned()),
+            BlockId::Number(BlockNumberOrTag::Number(num)) => {
+                Ok(lock.values().find(|b| b.number == num).cloned())
             }
             _ => {
                 unreachable!("unused in network tests")

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -4,8 +4,8 @@ use crate::{
 };
 use reth_interfaces::Result;
 use reth_primitives::{
-    rpc::BlockId, Account, Address, Block, BlockHash, BlockNumber, Bytes, ChainInfo, Header,
-    StorageKey, StorageValue, TransactionSigned, TxHash, TxNumber, H256, U256,
+    Account, Address, Block, BlockHash, BlockId, BlockNumber, Bytes, ChainInfo, Header, StorageKey,
+    StorageValue, TransactionSigned, TxHash, TxNumber, H256, U256,
 };
 use std::ops::RangeBounds;
 

--- a/crates/storage/provider/src/traits/block.rs
+++ b/crates/storage/provider/src/traits/block.rs
@@ -1,9 +1,6 @@
 use crate::{BlockIdProvider, HeaderProvider, TransactionsProvider};
 use reth_interfaces::Result;
-use reth_primitives::{
-    rpc::{BlockId, BlockNumber},
-    Block, H256,
-};
+use reth_primitives::{Block, BlockId, BlockNumberOrTag, H256};
 
 /// Api trait for fetching `Block` related data.
 #[auto_impl::auto_impl(&, Arc)]
@@ -15,17 +12,16 @@ pub trait BlockProvider:
 
     /// Returns the block. Returns `None` if block is not found.
     fn block_by_hash(&self, hash: H256) -> Result<Option<Block>> {
-        // TODO: replace with ruint
-        self.block(BlockId::Hash(reth_primitives::rpc::H256::from(hash.0)))
+        self.block(hash.into())
     }
 
     /// Returns the block. Returns `None` if block is not found.
-    fn block_by_number_or_tag(&self, num: BlockNumber) -> Result<Option<Block>> {
-        self.block(BlockId::Number(num))
+    fn block_by_number_or_tag(&self, num: BlockNumberOrTag) -> Result<Option<Block>> {
+        self.block(num.into())
     }
 
     /// Returns the block. Returns `None` if block is not found.
     fn block_by_number(&self, num: u64) -> Result<Option<Block>> {
-        self.block(BlockId::Number(BlockNumber::Number(num.into())))
+        self.block(num.into())
     }
 }

--- a/crates/storage/provider/src/traits/transactions.rs
+++ b/crates/storage/provider/src/traits/transactions.rs
@@ -1,6 +1,6 @@
 use crate::BlockIdProvider;
 use reth_interfaces::Result;
-use reth_primitives::{rpc::BlockId, BlockNumber, TransactionSigned, TxHash, TxNumber};
+use reth_primitives::{BlockId, BlockNumber, TransactionSigned, TxHash, TxNumber};
 use std::ops::RangeBounds;
 
 ///  Client trait for fetching [TransactionSigned] related data.

--- a/crates/storage/provider/src/traits/withdrawals.rs
+++ b/crates/storage/provider/src/traits/withdrawals.rs
@@ -1,5 +1,5 @@
 use reth_interfaces::Result;
-use reth_primitives::{rpc::BlockId, Withdrawal};
+use reth_primitives::{BlockId, Withdrawal};
 
 ///  Client trait for fetching [Withdrawal] related data.
 pub trait WithdrawalsProvider: Send + Sync {


### PR DESCRIPTION
closes https://github.com/paradigmxyz/reth/issues/1439
supersedes https://github.com/paradigmxyz/reth/pull/1441

replace 
* `ethers::rpc::BlockId` with `reth::BlockId`
* `ethers::rpc::BlockNumber` with `reth::BlockNumberOrTag` 