### PR TITLE
feat(engine-api): exchange capabilities

### DIFF
--- a/crates/rpc/rpc-api/src/engine.rs
+++ b/crates/rpc/rpc-api/src/engine.rs
@@ -66,4 +66,8 @@ pub trait EngineApi {
         &self,
         transition_configuration: TransitionConfiguration,
     ) -> Result<TransitionConfiguration>;
+
+    /// See also <https://github.com/ethereum/execution-apis/blob/6452a6b194d7db269bf1dbd087a267251d3cc7f8/src/engine/common.md#capabilities>
+    #[method(name = "engine_exchangeCapabilities")]
+    async fn exchange_capabilities(&self, capabilities: Vec<String>) -> Result<Vec<String>>;
 }

--- a/crates/rpc/rpc-types/src/eth/engine.rs
+++ b/crates/rpc/rpc-types/src/eth/engine.rs
@@ -8,6 +8,19 @@ use reth_primitives::{
 use reth_rlp::Encodable;
 use serde::{Deserialize, Serialize};
 
+/// The list of supported Engine capabilities
+pub const CAPABILITIES: [&str; 9] = [
+    "engine_forkchoiceUpdatedV1",
+    "engine_forkchoiceUpdatedV2",
+    "engine_exchangeTransitionConfigurationV1",
+    "engine_getPayloadV1",
+    "engine_getPayloadV2",
+    "engine_newPayloadV1",
+    "engine_newPayloadV2",
+    "engine_getPayloadBodiesByHashV1",
+    "engine_getPayloadBodiesByRangeV1",
+];
+
 /// This structure maps on the ExecutionPayload structure of the beacon chain spec.
 ///
 /// See also: <https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/paris.md#executionpayloadv1>

--- a/crates/rpc/rpc/src/engine/mod.rs
+++ b/crates/rpc/rpc/src/engine/mod.rs
@@ -13,7 +13,7 @@ use reth_rpc_engine_api::{
 };
 use reth_rpc_types::engine::{
     ExecutionPayload, ExecutionPayloadBodies, ForkchoiceUpdated, PayloadAttributes, PayloadStatus,
-    TransitionConfiguration, CAPABILITIES
+    TransitionConfiguration, CAPABILITIES,
 };
 use tokio::sync::{
     mpsc::UnboundedSender,

--- a/crates/rpc/rpc/src/engine/mod.rs
+++ b/crates/rpc/rpc/src/engine/mod.rs
@@ -7,7 +7,7 @@ use reth_rpc_api::EngineApiServer;
 use reth_rpc_engine_api::{EngineApiError, EngineApiMessage, EngineApiResult};
 use reth_rpc_types::engine::{
     ExecutionPayload, ExecutionPayloadBody, ForkchoiceUpdated, PayloadAttributes, PayloadStatus,
-    TransitionConfiguration,
+    TransitionConfiguration, CAPABILITIES,
 };
 use tokio::sync::{
     mpsc::UnboundedSender,
@@ -126,5 +126,10 @@ impl EngineApiServer for EngineApi {
         let (tx, rx) = oneshot::channel();
         self.delegate_request(EngineApiMessage::ExchangeTransitionConfiguration(config, tx), rx)
             .await
+    }
+
+    /// See also <https://github.com/ethereum/execution-apis/blob/6452a6b194d7db269bf1dbd087a267251d3cc7f8/src/engine/common.md#capabilities>
+    async fn exchange_capabilities(&self, _capabilities: Vec<String>) -> Result<Vec<String>> {
+        Ok(CAPABILITIES.into_iter().map(str::to_owned).collect())
     }
 }


### PR DESCRIPTION
Add support for [`engine_exchangeCapabilities`](https://github.com/ethereum/execution-apis/blob/main/src/engine/common.md#capabilities) method

Technically, this is blocked by #1445 which introduces the support for Shanghai methods.