### PR TITLE
docs: replace deprecated setting in rust-analyzer's snippet

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ If you are working in VSCode, we recommend you install the [rust-analyzer](https
 ```json
 "editor.formatOnSave": true,
 "rust-analyzer.rustfmt.extraArgs": ["+nightly"],
-"rust-analyzer.checkOnSave.overrideCommand": [
+"rust-analyzer.check.overrideCommand": [
   "cargo",
   "+nightly",
   "clippy",


### PR DESCRIPTION
The settings snippet for the [rust-analyzer](https://rust-analyzer.github.io/)  VSCode extension in `CONTRIBUTING.md` use a deprecated style for overriding the check command, I just replaced it with the new one.

See https://github.com/rust-lang/rust-analyzer/pull/12010