### PR TITLE
feat(net): support eth68 transactions

### DIFF
--- a/crates/net/network/src/message.rs
+++ b/crates/net/network/src/message.rs
@@ -7,7 +7,7 @@ use futures::FutureExt;
 use reth_eth_wire::{
     capability::RawCapabilityMessage, message::RequestPair, BlockBodies, BlockBody, BlockHeaders,
     EthMessage, GetBlockBodies, GetBlockHeaders, GetNodeData, GetPooledTransactions, GetReceipts,
-    NewBlock, NewBlockHashes, NewPooledTransactionHashes66, NodeData, PooledTransactions, Receipts,
+    NewBlock, NewBlockHashes, NewPooledTransactionHashes, NodeData, PooledTransactions, Receipts,
     SharedTransactions, Transactions,
 };
 use reth_interfaces::p2p::error::{RequestError, RequestResult};
@@ -50,7 +50,7 @@ pub enum PeerMessage {
     /// Broadcast transactions _from_ local _to_ a peer.
     SendTransactions(SharedTransactions),
     /// Send new pooled transactions
-    PooledTransactions(NewPooledTransactionHashes66),
+    PooledTransactions(NewPooledTransactionHashes),
     /// All `eth` request variants.
     EthRequest(PeerRequest),
     /// Other than eth namespace message

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use parking_lot::Mutex;
-use reth_eth_wire::{DisconnectReason, NewBlock, NewPooledTransactionHashes66, SharedTransactions};
+use reth_eth_wire::{DisconnectReason, NewBlock, NewPooledTransactionHashes, SharedTransactions};
 use reth_interfaces::{
     p2p::headers::client::StatusUpdater,
     sync::{SyncState, SyncStateProvider, SyncStateUpdater},
@@ -13,7 +13,7 @@ use reth_net_common::bandwidth_meter::BandwidthMeter;
 use reth_network_api::{
     NetworkError, NetworkInfo, NetworkStatus, PeerKind, Peers, PeersInfo, ReputationChangeKind,
 };
-use reth_primitives::{Head, NodeRecord, PeerId, TransactionSigned, TxHash, H256};
+use reth_primitives::{Head, NodeRecord, PeerId, TransactionSigned, H256};
 use std::{
     net::SocketAddr,
     sync::{
@@ -141,11 +141,8 @@ impl NetworkHandle {
     }
 
     /// Send transactions hashes to the peer.
-    pub fn send_transactions_hashes(&self, peer_id: PeerId, msg: Vec<TxHash>) {
-        self.send_message(NetworkHandleMessage::SendPooledTransactionHashes {
-            peer_id,
-            msg: NewPooledTransactionHashes66(msg),
-        })
+    pub fn send_transactions_hashes(&self, peer_id: PeerId, msg: NewPooledTransactionHashes) {
+        self.send_message(NetworkHandleMessage::SendPooledTransactionHashes { peer_id, msg })
     }
 
     /// Send full transactions to the peer
@@ -292,7 +289,7 @@ pub(crate) enum NetworkHandleMessage {
     /// Sends the list of transactions to the given peer.
     SendTransaction { peer_id: PeerId, msg: SharedTransactions },
     /// Sends the list of transactions hashes to the given peer.
-    SendPooledTransactionHashes { peer_id: PeerId, msg: NewPooledTransactionHashes66 },
+    SendPooledTransactionHashes { peer_id: PeerId, msg: NewPooledTransactionHashes },
     /// Send an `eth` protocol request to the peer.
     EthRequest {
         /// The peer to send the request to.

--- a/crates/primitives/src/transaction/tx_type.rs
+++ b/crates/primitives/src/transaction/tx_type.rs
@@ -14,12 +14,22 @@ pub enum TxType {
     EIP1559 = 2_isize,
 }
 
+impl From<TxType> for u8 {
+    fn from(value: TxType) -> Self {
+        match value {
+            TxType::Legacy => 0,
+            TxType::EIP2930 => 1,
+            TxType::EIP1559 => 2,
+        }
+    }
+}
+
 impl Compact for TxType {
     fn to_compact(self, _: &mut impl bytes::BufMut) -> usize {
         match self {
             TxType::Legacy => 0,
             TxType::EIP2930 => 1,
-            _ => 2,
+            TxType::EIP1559 => 2,
         }
     }
 


### PR DESCRIPTION
Closes #1477

Adds support for handling eth68 and eth66 transaction types depending on the negotiated version of the stream.

* adds various helper enums
* transaction task sends eth66 or eth depending on the negotiated version of the stream.


needs smol followup that makes changes to the txpool so the full transaction objects can be returned (required for eth68)
After that we could make additional optimizations to store the length of the encoded transaction. in the pool object.

~~failing clippy: #1480~~