### PR TITLE
chore(txpool): add pooled transaction function to get full tx object

### DIFF
--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -338,7 +338,7 @@ where
                 // Send a `NewPooledTransactionHashes` to the peer with _all_ transactions in the
                 // pool
                 if !self.network.is_syncing() {
-                    let msg = NewPooledTransactionHashes66(self.pool.pooled_transactions());
+                    let msg = NewPooledTransactionHashes66(self.pool.pooled_transaction_hashes());
                     self.network.send_message(NetworkHandleMessage::SendPooledTransactionHashes {
                         peer_id,
                         msg,

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -225,7 +225,11 @@ where
         self.pool.add_transaction_listener()
     }
 
-    fn pooled_transactions(&self) -> Vec<TxHash> {
+    fn pooled_transaction_hashes(&self) -> Vec<TxHash> {
+        self.pool.pooled_transactions_hashes()
+    }
+
+    fn pooled_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         self.pool.pooled_transactions()
     }
 

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -172,9 +172,15 @@ where
     }
 
     /// Returns hashes of _all_ transactions in the pool.
-    pub(crate) fn pooled_transactions(&self) -> Vec<TxHash> {
+    pub(crate) fn pooled_transactions_hashes(&self) -> Vec<TxHash> {
         let pool = self.pool.read();
         pool.all().hashes_iter().collect()
+    }
+
+    /// Returns _all_ transactions in the pool.
+    pub(crate) fn pooled_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let pool = self.pool.read();
+        pool.all().transactions_iter().collect()
     }
 
     /// Updates the entire pool after a new block was executed.

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -512,6 +512,13 @@ impl<T: PoolTransaction> AllTransactions<T> {
         self.by_hash.keys().copied()
     }
 
+    /// Returns an iterator over all _unique_ hashes in the pool
+    pub(crate) fn transactions_iter(
+        &self,
+    ) -> impl Iterator<Item = Arc<ValidPoolTransaction<T>>> + '_ {
+        self.by_hash.values().cloned()
+    }
+
     /// Returns if the transaction for the given hash is already included in this pool
     pub(crate) fn contains(&self, tx_hash: &TxHash) -> bool {
         self.by_hash.contains_key(tx_hash)

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -70,12 +70,19 @@ pub trait TransactionPool: Send + Sync + Clone {
     /// Returns a new stream that yields new valid transactions added to the pool.
     fn transactions_listener(&self) -> Receiver<NewTransactionEvent<Self::Transaction>>;
 
-    /// Returns hashes of all transactions in the pool.
+    /// Returns the _hashes_ of all transactions in the pool.
     ///
     /// Note: This returns a `Vec` but should guarantee that all hashes are unique.
     ///
     /// Consumer: P2P
-    fn pooled_transactions(&self) -> Vec<TxHash>;
+    fn pooled_transaction_hashes(&self) -> Vec<TxHash>;
+
+    /// Returns the _full_ transaction objects all transactions in the pool.
+    ///
+    /// Note: This returns a `Vec` but should guarantee that all transactions are unique.
+    ///
+    /// Consumer: P2P
+    fn pooled_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
 
     /// Returns an iterator that yields transactions that are ready for block production.
     ///


### PR DESCRIPTION
ref #1482

with eth68, tx hashes are no longer sufficient.
we need a function to get all transactions objects instead.