### PR TITLE
feat(eth-wire): add td bitlen check in handshake

### DIFF
--- a/crates/net/eth-wire/src/errors/eth.rs
+++ b/crates/net/eth-wire/src/errors/eth.rs
@@ -74,4 +74,6 @@ pub enum EthHandshakeError {
     MismatchedProtocolVersion { expected: u8, got: u8 },
     #[error("mismatched chain in Status message. expected: {expected:?}, got: {got:?}")]
     MismatchedChain { expected: Chain, got: Chain },
+    #[error("total difficulty bitlen is too large. maximum: {maximum:?}, got: {got:?}")]
+    TotalDifficultyBitLenTooLarge { maximum: usize, got: usize },
 }


### PR DESCRIPTION
Adds a check in the `eth` handshake ensuring the total difficulty bitlen does not exceed 100 bits. Also adds tests ensuring status handshakes with total difficulty over 100 bits fail, and under 100 bits do not.

Introduces an error variant for this type of handshake failure.

Fixes #1476