### PR TITLE
feat: implement eth handshake disconnects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4557,6 +4557,7 @@ name = "reth-eth-wire"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
+ "async-trait",
  "bytes",
  "ethers-core",
  "futures",

--- a/crates/net/eth-wire/Cargo.toml
+++ b/crates/net/eth-wire/Cargo.toml
@@ -15,12 +15,14 @@ serde = { version = "1", optional = true }
 # reth
 reth-codecs = { path = "../../storage/codecs" }
 reth-primitives = { path = "../../primitives" }
+reth-ecies = { path = "../ecies" }
 reth-rlp = { path = "../../rlp", features = ["alloc", "derive", "std", "ethereum-types", "smol_str"] }
 
 # used for Chain and builders
 ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 
 tokio = { version = "1.21.2", features = ["full"] }
+tokio-util = { version = "0.7.4", features = ["io", "codec"] }
 futures = "0.3.24"
 tokio-stream = "0.1.11"
 pin-project = "1.0"
@@ -28,6 +30,7 @@ tracing = "0.1.37"
 snap = "1.0.5"
 smol_str = "0.1"
 metrics = "0.20.1"
+async-trait = "0.1"
 
 # arbitrary utils
 arbitrary = { version = "1.1.7", features = ["derive"], optional = true }
@@ -36,7 +39,6 @@ proptest-derive = { version = "0.3", optional = true }
 
 [dev-dependencies]
 reth-primitives = { path = "../../primitives", features = ["arbitrary"] }
-reth-ecies = { path = "../ecies" }
 reth-tracing = { path = "../../tracing" }
 ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 

--- a/crates/net/eth-wire/src/disconnect.rs
+++ b/crates/net/eth-wire/src/disconnect.rs
@@ -1,7 +1,7 @@
 //! Disconnect
 
 use bytes::Bytes;
-use futures::SinkExt;
+use futures::{SinkExt, Sink};
 use reth_codecs::derive_arbitrary;
 use reth_ecies::stream::ECIESStream;
 use reth_primitives::bytes::{Buf, BufMut};
@@ -152,7 +152,7 @@ impl Decodable for DisconnectReason {
 /// lower-level disconnect functions (such as those that exist in the `p2p` protocol) if the
 /// underlying stream supports it.
 #[async_trait::async_trait]
-pub trait CanDisconnect<T>: SinkExt<T, Error = Self::E> + Unpin + Sized {
+pub trait CanDisconnect<T>: Sink<T, Error = Self::E> + Unpin + Sized {
     /// The error type that can be returned by [`disconnect`].
     type E: From<std::io::Error>;
 

--- a/crates/net/eth-wire/src/disconnect.rs
+++ b/crates/net/eth-wire/src/disconnect.rs
@@ -1,10 +1,15 @@
 //! Disconnect
 
+use bytes::Bytes;
+use futures::SinkExt;
 use reth_codecs::derive_arbitrary;
+use reth_ecies::stream::ECIESStream;
 use reth_primitives::bytes::{Buf, BufMut};
 use reth_rlp::{Decodable, DecodeError, Encodable, Header};
 use std::fmt::Display;
 use thiserror::Error;
+use tokio::io::AsyncWrite;
+use tokio_util::codec::{Encoder, Framed};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -140,6 +145,47 @@ impl Decodable for DisconnectReason {
             DisconnectReason::try_from(u8::decode(buf)?)
                 .map_err(|_| DecodeError::Custom("unknown disconnect reason"))
         }
+    }
+}
+
+/// This trait is meant to allow higher level protocols like `eth` to disconnect from a peer, using
+/// lower-level disconnect functions (such as those that exist in the `p2p` protocol) if the
+/// underlying stream supports it.
+#[async_trait::async_trait]
+pub trait CanDisconnect<T>: SinkExt<T, Error = Self::E> + Unpin + Sized + Send {
+    /// The error type that can be returned by [`disconnect`].
+    type E: From<std::io::Error>;
+
+    /// Disconnects from the underlying stream, using a [`DisconnectReason`] as disconnect
+    /// information if the stream implements a protocol that can carry the additional disconnect
+    /// metadata.
+    async fn disconnect(&mut self, reason: DisconnectReason) -> Result<(), Self::E>;
+}
+
+// basic impls for things like Framed<TcpStream, etc>
+#[async_trait::async_trait]
+impl<T, I, U> CanDisconnect<I> for Framed<T, U>
+where
+    T: AsyncWrite + Unpin + Send,
+    U: Encoder<I> + Send,
+    U::Error: From<std::io::Error>,
+{
+    type E = U::Error;
+
+    async fn disconnect(&mut self, _reason: DisconnectReason) -> Result<(), Self::E> {
+        self.close().await
+    }
+}
+
+#[async_trait::async_trait]
+impl<S> CanDisconnect<Bytes> for ECIESStream<S>
+where
+    S: AsyncWrite + Unpin + Send,
+{
+    type E = std::io::Error;
+
+    async fn disconnect(&mut self, _reason: DisconnectReason) -> Result<(), Self::E> {
+        self.close().await
     }
 }
 

--- a/crates/net/eth-wire/src/disconnect.rs
+++ b/crates/net/eth-wire/src/disconnect.rs
@@ -152,7 +152,7 @@ impl Decodable for DisconnectReason {
 /// lower-level disconnect functions (such as those that exist in the `p2p` protocol) if the
 /// underlying stream supports it.
 #[async_trait::async_trait]
-pub trait CanDisconnect<T>: SinkExt<T, Error = Self::E> + Unpin + Sized + Send {
+pub trait CanDisconnect<T>: SinkExt<T, Error = Self::E> + Unpin + Sized {
     /// The error type that can be returned by [`disconnect`].
     type E: From<std::io::Error>;
 

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -270,8 +270,15 @@ where
 
     fn start_send(self: Pin<&mut Self>, item: EthMessage) -> Result<(), Self::Error> {
         if matches!(item, EthMessage::Status(_)) {
-            // TODO: figure out how to disconnect here - do we need to send a message?
-            // self.project().inner.disconnect(DisconnectReason::ProtocolBreach);
+            // TODO: to disconnect here we would need to do something similar to P2PStream's
+            // start_disconnect, which would ideally be a part of the CanDisconnect trait, or at
+            // least similar.
+            //
+            // Other parts of reth do not need traits like CanDisconnect because they work
+            // exclusively with EthStream<P2PStream<S>>, where the inner P2PStream is accessible,
+            // allowing for its start_disconnect method to be called.
+            //
+            // self.project().inner.start_disconnect(DisconnectReason::ProtocolBreach);
             return Err(EthStreamError::EthHandshakeError(EthHandshakeError::StatusNotInHandshake))
         }
 

--- a/crates/net/eth-wire/src/lib.rs
+++ b/crates/net/eth-wire/src/lib.rs
@@ -24,7 +24,7 @@ pub use tokio_util::codec::{
 };
 
 pub use crate::{
-    disconnect::DisconnectReason,
+    disconnect::{CanDisconnect, DisconnectReason},
     ethstream::{EthStream, UnauthedEthStream, MAX_MESSAGE_SIZE},
     hello::HelloMessage,
     p2pstream::{P2PMessage, P2PMessageID, P2PStream, ProtocolVersion, UnauthedP2PStream},

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code, unreachable_pub, missing_docs, unused_variables)]
 use crate::{
     capability::{Capability, SharedCapability},
+    disconnect::CanDisconnect,
     errors::{P2PHandshakeError, P2PStreamError},
     pinger::{Pinger, PingerEvent},
     DisconnectReason, HelloMessage,
@@ -69,25 +70,6 @@ impl<S> UnauthedP2PStream<S> {
     /// Create a new `UnauthedP2PStream` from a type `S` which implements `Stream` and `Sink`.
     pub fn new(inner: S) -> Self {
         Self { inner }
-    }
-}
-
-impl<S> UnauthedP2PStream<S>
-where
-    S: Sink<Bytes, Error = io::Error> + Unpin,
-{
-    /// Send a disconnect message during the handshake. This is sent without snappy compression.
-    pub async fn send_disconnect(
-        &mut self,
-        reason: DisconnectReason,
-    ) -> Result<(), P2PStreamError> {
-        let mut buf = BytesMut::new();
-        P2PMessage::Disconnect(reason).encode(&mut buf);
-        tracing::trace!(
-            %reason,
-            "Sending disconnect message during the handshake",
-        );
-        self.inner.send(buf.freeze()).await.map_err(P2PStreamError::Io)
     }
 }
 
@@ -177,6 +159,37 @@ where
         let stream = P2PStream::new(self.inner, shared_capability);
 
         Ok((stream, their_hello))
+    }
+}
+
+impl<S> UnauthedP2PStream<S>
+where
+    S: Sink<Bytes, Error = io::Error> + Unpin,
+{
+    /// Send a disconnect message during the handshake. This is sent without snappy compression.
+    pub async fn send_disconnect(
+        &mut self,
+        reason: DisconnectReason,
+    ) -> Result<(), P2PStreamError> {
+        let mut buf = BytesMut::new();
+        P2PMessage::Disconnect(reason).encode(&mut buf);
+        tracing::trace!(
+            %reason,
+            "Sending disconnect message during the handshake",
+        );
+        self.inner.send(buf.freeze()).await.map_err(P2PStreamError::Io)
+    }
+}
+
+#[async_trait::async_trait]
+impl<S> CanDisconnect<Bytes> for P2PStream<S>
+where
+    S: Sink<Bytes, Error = io::Error> + Unpin + Send,
+{
+    type E = P2PStreamError;
+
+    async fn disconnect(&mut self, reason: DisconnectReason) -> Result<(), P2PStreamError> {
+        self.disconnect(reason).await
     }
 }
 
@@ -284,13 +297,13 @@ impl<S> P2PStream<S> {
 
 impl<S> P2PStream<S>
 where
-    S: Sink<Bytes, Error = io::Error> + Unpin,
+    S: Sink<Bytes, Error = io::Error> + Unpin + Send,
 {
     /// Disconnects the connection by sending a disconnect message.
     ///
     /// This future resolves once the disconnect message has been sent and the stream has been
     /// closed.
-    pub async fn disconnect(mut self, reason: DisconnectReason) -> Result<(), P2PStreamError> {
+    pub async fn disconnect(&mut self, reason: DisconnectReason) -> Result<(), P2PStreamError> {
         self.start_disconnect(reason)?;
         self.close().await
     }
@@ -821,7 +834,7 @@ mod tests {
 
             let (server_hello, _) = eth_hello();
 
-            let (p2p_stream, _) =
+            let (mut p2p_stream, _) =
                 UnauthedP2PStream::new(stream).handshake(server_hello).await.unwrap();
 
             p2p_stream.disconnect(expected_disconnect).await.unwrap();

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -186,8 +186,6 @@ impl<S> CanDisconnect<Bytes> for P2PStream<S>
 where
     S: Sink<Bytes, Error = io::Error> + Unpin + Send,
 {
-    type E = P2PStreamError;
-
     async fn disconnect(&mut self, reason: DisconnectReason) -> Result<(), P2PStreamError> {
         self.disconnect(reason).await
     }

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -184,7 +184,7 @@ where
 #[async_trait::async_trait]
 impl<S> CanDisconnect<Bytes> for P2PStream<S>
 where
-    S: Sink<Bytes, Error = io::Error> + Unpin + Send,
+    S: Sink<Bytes, Error = io::Error> + Unpin + Send + Sync,
 {
     async fn disconnect(&mut self, reason: DisconnectReason) -> Result<(), P2PStreamError> {
         self.disconnect(reason).await

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -753,9 +753,9 @@ mod tests {
             &self,
             local_addr: SocketAddr,
             f: F,
-        ) -> Pin<Box<dyn Future<Output = ()> + Send + Sync>>
+        ) -> Pin<Box<dyn Future<Output = ()> + Send>>
         where
-            F: FnOnce(EthStream<P2PStream<ECIESStream<TcpStream>>>) -> O + Send + Sync + 'static,
+            F: FnOnce(EthStream<P2PStream<ECIESStream<TcpStream>>>) -> O + Send + 'static,
             O: Future<Output = ()> + Send + Sync,
         {
             let status = self.status;


### PR DESCRIPTION
This implements disconnects in the eth handshake by introducing the `CanDisconnect` trait, following the design in #1492

The trait extends `Sink<T>`, with Default implementations for `ECIESStream` and all `Framed<T, U>` that implement `Sink`. These implementations just close the sink using `SinkExt::close`.