### PR TITLE
fix(docs): fix install command

### DIFF
--- a/book/getting_started/installation.md
+++ b/book/getting_started/installation.md
@@ -15,7 +15,7 @@ Then clone the repository and build the binary:
 ```console
 git clone https://github.com/paradigmxyz/reth
 cd reth
-cargo install --release --locked --path . --bin reth
+cargo install --locked --path bin/reth --bin reth
 ```
 
 The binary will now be in a platform specific folder, and should be accessible as `reth` via the command line.


### PR DESCRIPTION
cargo install uses release profile by default and --path --bin does not work in workspaces

ref https://github.com/rust-lang/cargo/issues/7124

Closes #1501