### PR TITLE
feat: add BlockProvider::ommers

### DIFF
--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -139,6 +139,7 @@ impl<DB: Database> BlockProvider for ShareableDatabase<DB> {
     fn ommers(&self, id: BlockId) -> Result<Option<Vec<Header>>> {
         if let Some(number) = self.block_number_for_id(id)? {
             let tx = self.db.tx()?;
+            // TODO: this can be optimized to return empty Vec post-merge
             let ommers =
                 tx.get::<tables::BlockOmmers>(number)?.map(|o| o.ommers).unwrap_or_default();
             return Ok(Some(ommers))

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -135,6 +135,17 @@ impl<DB: Database> BlockProvider for ShareableDatabase<DB> {
 
         Ok(None)
     }
+
+    fn ommers(&self, id: BlockId) -> Result<Option<Vec<Header>>> {
+        if let Some(number) = self.block_number_for_id(id)? {
+            let tx = self.db.tx()?;
+            let ommers =
+                tx.get::<tables::BlockOmmers>(number)?.map(|o| o.ommers).unwrap_or_default();
+            return Ok(Some(ommers))
+        }
+
+        Ok(None)
+    }
 }
 
 impl<DB: Database> TransactionsProvider for ShareableDatabase<DB> {

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -198,6 +198,10 @@ impl BlockProvider for MockEthProvider {
             }
         }
     }
+
+    fn ommers(&self, _id: BlockId) -> Result<Option<Vec<Header>>> {
+        Ok(None)
+    }
 }
 
 impl AccountProvider for MockEthProvider {

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -35,14 +35,18 @@ impl BlockProvider for NoopProvider {
     fn block(&self, _id: BlockId) -> Result<Option<Block>> {
         Ok(None)
     }
+
+    fn ommers(&self, _id: BlockId) -> Result<Option<Vec<Header>>> {
+        Ok(None)
+    }
 }
 
 impl TransactionsProvider for NoopProvider {
-    fn transaction_by_hash(&self, _hash: TxHash) -> Result<Option<TransactionSigned>> {
+    fn transaction_by_id(&self, _id: TxNumber) -> Result<Option<TransactionSigned>> {
         Ok(None)
     }
 
-    fn transaction_by_id(&self, _id: TxNumber) -> Result<Option<TransactionSigned>> {
+    fn transaction_by_hash(&self, _hash: TxHash) -> Result<Option<TransactionSigned>> {
         Ok(None)
     }
 

--- a/crates/storage/provider/src/traits/block.rs
+++ b/crates/storage/provider/src/traits/block.rs
@@ -1,14 +1,21 @@
 use crate::{BlockIdProvider, HeaderProvider, TransactionsProvider};
 use reth_interfaces::Result;
-use reth_primitives::{Block, BlockId, BlockNumberOrTag, H256};
+use reth_primitives::{Block, BlockId, BlockNumberOrTag, Header, H256};
 
 /// Api trait for fetching `Block` related data.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait BlockProvider:
     BlockIdProvider + HeaderProvider + TransactionsProvider + Send + Sync
 {
-    /// Returns the block. Returns `None` if block is not found.
+    /// Returns the block.
+    ///
+    /// Returns `None` if block is not found.
     fn block(&self, id: BlockId) -> Result<Option<Block>>;
+
+    /// Returns the ommers/uncle headers of the given block.
+    ///
+    /// Returns `None` if block is not found.
+    fn ommers(&self, id: BlockId) -> Result<Option<Vec<Header>>>;
 
     /// Returns the block. Returns `None` if block is not found.
     fn block_by_hash(&self, hash: H256) -> Result<Option<Block>> {


### PR DESCRIPTION
add a new provider function to fetch ommers headers of a block (required by rpc)