### PR TITLE
feat: add encoded_length to ValidPoolTransaction

### DIFF
--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -202,6 +202,7 @@ where
             TransactionValidationOutcome::Valid { balance, state_nonce, transaction } => {
                 let sender_id = self.get_sender_id(transaction.sender());
                 let transaction_id = TransactionId::new(sender_id, transaction.nonce());
+                let encoded_length = transaction.encoded_length();
 
                 let tx = ValidPoolTransaction {
                     cost: transaction.cost(),
@@ -210,6 +211,7 @@ where
                     propagate: false,
                     timestamp: Instant::now(),
                     origin,
+                    encoded_length,
                 };
 
                 let added = self.pool.write().add_transaction(tx, balance, state_nonce)?;

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -438,6 +438,7 @@ impl MockTransactionFactory {
         transaction: MockTransaction,
     ) -> MockValidTx {
         let transaction_id = self.tx_id(&transaction);
+        let encoded_length = transaction.encoded_length();
         MockValidTx {
             propagate: false,
             transaction_id,
@@ -445,6 +446,7 @@ impl MockTransactionFactory {
             transaction,
             timestamp: Instant::now(),
             origin,
+            encoded_length,
         }
     }
 

--- a/crates/transaction-pool/src/validate.rs
+++ b/crates/transaction-pool/src/validate.rs
@@ -94,6 +94,8 @@ pub struct ValidPoolTransaction<T: PoolTransaction> {
     pub timestamp: Instant,
     /// Where this transaction originated from.
     pub origin: TransactionOrigin,
+    /// The length of the rlp encoded transaction (cached)
+    pub encoded_length: usize,
 }
 
 // === impl ValidPoolTransaction ===
@@ -160,6 +162,7 @@ impl<T: PoolTransaction + Clone> Clone for ValidPoolTransaction<T> {
             cost: self.cost,
             timestamp: self.timestamp,
             origin: self.origin,
+            encoded_length: self.encoded_length,
         }
     }
 }


### PR DESCRIPTION
#1500 followup.

@mattsse any hint on where this new `encoded_length` should be used?