### PR TITLE
fix: patch ruint with quantity fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5244,8 +5244,7 @@ dependencies = [
 [[package]]
 name = "ruint"
 version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad3a104dc8c3867f653b0fec89c65e00b0ceb752718ad282177a7e0f33257ac"
+source = "git+https://github.com/mattsse/uint?branch=matt/skip-leading-zeros#7aa078a0d3ea5a05c09e7a2b42c06921d55e7c67"
 dependencies = [
  "arbitrary",
  "derive_more",
@@ -5261,8 +5260,7 @@ dependencies = [
 [[package]]
 name = "ruint-macro"
 version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62cc5760263ea229d367e7dff3c0cbf09e4797a125bd87059a6c095804f3b2d1"
+source = "git+https://github.com/mattsse/uint?branch=matt/skip-leading-zeros#7aa078a0d3ea5a05c09e7a2b42c06921d55e7c67"
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,5 @@ default-members = ["bin/reth"]
 [patch.crates-io]
 revm = { git = "https://github.com/bluealloy/revm" }
 revm-primitives = { git = "https://github.com/bluealloy/revm" }
+# patched for quantity U256 responses <https://github.com/recmo/uint/issues/224>
+ruint = { git = "https://github.com/mattsse/uint", branch = "matt/skip-leading-zeros" }

--- a/crates/primitives/src/jsonu256.rs
+++ b/crates/primitives/src/jsonu256.rs
@@ -111,9 +111,6 @@ mod test {
         let data = JsonU256(U256::from(16));
         let serialized = serde_json::to_string(&data).unwrap();
 
-        assert_eq!(
-            serialized,
-            r#""0x0000000000000000000000000000000000000000000000000000000000000010""#
-        );
+        assert_eq!(serialized, r#""0x10""#);
     }
 }


### PR DESCRIPTION
Closes #1465 #1486 by patching ruint with https://github.com/recmo/uint/pull/225

can be removed once merged into ruint or a decision is made that default serialize impl should include leading zeros in which case we need to replace U256 with a wrapper type..

```
 cast block-number
0
```

```
TRACE connection{remote_addr=127.0.0.1:51676 conn_id=0}:method_call{method="eth_blockNumber"}: send="{\"jsonrpc\":\"2.0\",\"result\":\"0x0\",\"id\":1}"
```