### PR TITLE
test: fix hive tests re: genesis smoke test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -208,7 +208,7 @@ checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -219,7 +219,7 @@ checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -267,18 +267,6 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7862e21c893d65a1650125d157eaeec691439379a1cee17ee49031b79236ada4"
-dependencies = [
- "proc-macro-error",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
- "syn 1.0.107",
-]
-
-[[package]]
-name = "auto_impl"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a8c1df849285fbacd587de7818cc7d13be6cd2cbcd47a04fb1801b0e2706e33"
@@ -286,7 +274,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -418,7 +406,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -780,7 +768,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -816,7 +804,7 @@ dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
  "serde",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1183,7 +1171,7 @@ dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
  "scratch",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1200,7 +1188,7 @@ checksum = "357f40d1f06a24b60ae1fe122542c1fb05d28d32acb2aed064e84bc2ad1e252e"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1234,7 +1222,7 @@ dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
  "strsim 0.9.3",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1248,7 +1236,7 @@ dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
  "strsim 0.10.0",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1259,7 +1247,7 @@ checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core 0.10.2",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1270,7 +1258,7 @@ checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
  "darling_core 0.14.2",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1329,7 +1317,7 @@ checksum = "8beee4701e2e229e8098bbdecdca12449bc3e322f137d269182fa1291e20bd00"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1342,7 +1330,7 @@ dependencies = [
  "derive_builder_core",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1354,7 +1342,7 @@ dependencies = [
  "darling 0.10.2",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1367,7 +1355,7 @@ dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
  "rustc_version",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1543,7 +1531,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1636,7 +1624,7 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1648,7 +1636,7 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1662,7 +1650,7 @@ dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
  "rustc_version",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1673,7 +1661,7 @@ checksum = "e88bcb3a067a6555d577aba299e75eff9942da276e6506fc6274327daa026132"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1770,7 +1758,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#228f9447269e61ca7d7f868edd58c08772e38650"
+source = "git+https://github.com/gakonst/ethers-rs#537d0a9deb8b1fc549bf21b48684e9155f12707b"
 dependencies = [
  "ethers-core",
  "ethers-providers",
@@ -1786,7 +1774,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#228f9447269e61ca7d7f868edd58c08772e38650"
+source = "git+https://github.com/gakonst/ethers-rs#537d0a9deb8b1fc549bf21b48684e9155f12707b"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1807,7 +1795,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "syn 1.0.107",
+ "syn 1.0.109",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -1817,7 +1805,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#228f9447269e61ca7d7f868edd58c08772e38650"
+source = "git+https://github.com/gakonst/ethers-rs#537d0a9deb8b1fc549bf21b48684e9155f12707b"
 dependencies = [
  "ethers-core",
  "getrandom 0.2.8",
@@ -1833,10 +1821,10 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#228f9447269e61ca7d7f868edd58c08772e38650"
+source = "git+https://github.com/gakonst/ethers-rs#537d0a9deb8b1fc549bf21b48684e9155f12707b"
 dependencies = [
  "async-trait",
- "auto_impl 0.5.0",
+ "auto_impl",
  "ethers-contract",
  "ethers-core",
  "ethers-etherscan",
@@ -1858,10 +1846,10 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#228f9447269e61ca7d7f868edd58c08772e38650"
+source = "git+https://github.com/gakonst/ethers-rs#537d0a9deb8b1fc549bf21b48684e9155f12707b"
 dependencies = [
  "async-trait",
- "auto_impl 1.0.1",
+ "auto_impl",
  "base64 0.21.0",
  "enr 0.7.0",
  "ethers-core",
@@ -1895,7 +1883,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#228f9447269e61ca7d7f868edd58c08772e38650"
+source = "git+https://github.com/gakonst/ethers-rs#537d0a9deb8b1fc549bf21b48684e9155f12707b"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1907,6 +1895,7 @@ dependencies = [
  "rand 0.8.5",
  "sha2 0.10.6",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -2101,7 +2090,7 @@ checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2720,7 +2709,7 @@ checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2962,7 +2951,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3274,7 +3263,7 @@ checksum = "731f8ecebd9f3a4aa847dfe75455e4757a45da40a7793d2f0b1f9b6ed18b23f3"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3359,7 +3348,7 @@ checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3516,23 +3505,23 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d829733185c1ca374f17e52b762f24f535ec625d2cc1f070e34c8a9068f341b"
+checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2be1598bf1c313dcdd12092e3f1920f463462525a21b7b4e11b4168353d0123e"
+checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3575,7 +3564,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "786393f80485445794f6043fd3138854dd109cc6c4bd1a6383db304c9ce9b9ce"
 dependencies = [
  "arrayvec",
- "auto_impl 1.0.1",
+ "auto_impl",
  "bytes",
  "ethereum-types",
  "open-fastrlp-derive",
@@ -3590,7 +3579,7 @@ dependencies = [
  "bytes",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3654,7 +3643,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3812,7 +3801,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3964,7 +3953,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -4285,15 +4274,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4592,7 +4572,7 @@ name = "reth-executor"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "auto_impl 1.0.1",
+ "auto_impl",
  "hash-db",
  "hashbrown 0.13.2",
  "plain_hasher",
@@ -4618,7 +4598,7 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "async-trait",
- "auto_impl 1.0.1",
+ "auto_impl",
  "futures",
  "hex-literal",
  "modular-bitfield",
@@ -4704,7 +4684,7 @@ dependencies = [
  "quote 1.0.23",
  "regex",
  "serial_test",
- "syn 1.0.107",
+ "syn 1.0.109",
  "trybuild",
 ]
 
@@ -4737,7 +4717,7 @@ version = "0.1.0"
 dependencies = [
  "aquamarine",
  "async-trait",
- "auto_impl 1.0.1",
+ "auto_impl",
  "enr 0.7.0",
  "ethers-core",
  "ethers-middleware",
@@ -4839,7 +4819,15 @@ dependencies = [
 name = "reth-provider"
 version = "0.1.0"
 dependencies = [
+ "arbitrary",
+ "async-trait",
  "auto_impl 1.0.1",
+ "bytes",
+ "futures",
+ "heapless",
+ "hex-literal",
+ "modular-bitfield",
+ "parity-scale-codec",
  "parking_lot 0.12.1",
  "reth-db",
  "reth-interfaces",
@@ -4882,7 +4870,7 @@ name = "reth-rlp"
 version = "0.1.2"
 dependencies = [
  "arrayvec",
- "auto_impl 1.0.1",
+ "auto_impl",
  "bytes",
  "criterion",
  "enr 0.7.0",
@@ -4905,7 +4893,7 @@ version = "0.1.1"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5146,7 +5134,7 @@ name = "revm"
 version = "3.0.0"
 source = "git+https://github.com/bluealloy/revm#4d2f0741c5f9daec0ceb7cc7733d65ea4c496170"
 dependencies = [
- "auto_impl 1.0.1",
+ "auto_impl",
  "revm-interpreter",
  "revm-precompile",
 ]
@@ -5184,7 +5172,7 @@ version = "1.0.0"
 source = "git+https://github.com/bluealloy/revm#4d2f0741c5f9daec0ceb7cc7733d65ea4c496170"
 dependencies = [
  "arbitrary",
- "auto_impl 1.0.1",
+ "auto_impl",
  "bytes",
  "derive_more",
  "enumn",
@@ -5263,7 +5251,7 @@ checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5424,7 +5412,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5612,7 +5600,7 @@ checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5663,7 +5651,7 @@ dependencies = [
  "darling 0.14.2",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5688,7 +5676,7 @@ checksum = "b64f9e531ce97c88b4778aad0ceee079216071cffec6ac9b904277f8f92e7fe3"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5984,7 +5972,7 @@ dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
  "rustversion",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6061,9 +6049,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
@@ -6078,7 +6066,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
  "unicode-xid 0.2.4",
 ]
 
@@ -6090,16 +6078,15 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
  "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "rustix",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -6148,7 +6135,7 @@ dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
  "subprocess",
- "syn 1.0.107",
+ "syn 1.0.109",
  "test-fuzz-internal",
  "toolchain_find",
  "unzip-n",
@@ -6191,7 +6178,7 @@ checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6292,7 +6279,7 @@ checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6507,7 +6494,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6592,7 +6579,7 @@ checksum = "744324b12d69a9fc1edea4b38b7b1311295b662d161ad5deac17bb1358224a08"
 dependencies = [
  "lazy_static",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6856,7 +6843,7 @@ checksum = "c2e7e85a0596447f0f2ac090e16bc4c516c6fe91771fb0c0ccf7fa3dae896b9c"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6982,7 +6969,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
@@ -7016,7 +7003,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7264,6 +7251,6 @@ checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
  "synstructure",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4819,15 +4819,7 @@ dependencies = [
 name = "reth-provider"
 version = "0.1.0"
 dependencies = [
- "arbitrary",
- "async-trait",
- "auto_impl 1.0.1",
- "bytes",
- "futures",
- "heapless",
- "hex-literal",
- "modular-bitfield",
- "parity-scale-codec",
+ "auto_impl",
  "parking_lot 0.12.1",
  "reth-db",
  "reth-interfaces",
@@ -5111,7 +5103,7 @@ version = "0.1.0"
 dependencies = [
  "aquamarine",
  "async-trait",
- "auto_impl 1.0.1",
+ "auto_impl",
  "bitflags",
  "fnv",
  "futures-util",

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -1126,7 +1126,7 @@ mod tests {
         "#;
         let genesis = serde_json::from_str::<AllGenesisFormats>(&hive_json).unwrap();
         let chainspec: ChainSpec = genesis.into();
-        assert_eq!(chainspec.genesis_hash, None)
+        assert_eq!(chainspec.genesis_hash, None);
         assert_eq!(Chain::Named(EtherType::Chain::Optimism), chainspec.chain);
         assert_eq!(
             chainspec.hardforks.get(&Hardfork::Homestead).unwrap(),

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -1128,10 +1128,15 @@ mod tests {
         let chainspec: ChainSpec = genesis.into();
         assert_eq!(chainspec.genesis_hash, None);
         assert_eq!(Chain::Named(EtherType::Chain::Optimism), chainspec.chain);
-        assert_eq!(
-            chainspec.hardforks.get(&Hardfork::Homestead).unwrap(),
-            &ForkCondition::Block(0)
-        );
-        assert_eq!(chainspec.hardforks.get(&Hardfork::Byzantium).unwrap(), &ForkCondition::Block(0));
+        let hard_forks = vec![
+            Hardfork::Byzantium,
+            Hardfork::Homestead,
+            Hardfork::Istanbul,
+            Hardfork::Petersburg,
+            Hardfork::Constantinople
+        ];
+        for ref fork in hard_forks {
+            assert_eq!(chainspec.hardforks.get(fork).unwrap(), &ForkCondition::Block(0));
+        }
     }
 }

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -1126,6 +1126,7 @@ mod tests {
         "#;
         let genesis = serde_json::from_str::<AllGenesisFormats>(&hive_json).unwrap();
         let chainspec: ChainSpec = genesis.into();
+        assert_eq!(chainspec.genesis_hash, None)
         assert_eq!(Chain::Named(EtherType::Chain::Optimism), chainspec.chain);
         assert_eq!(
             chainspec.hardforks.get(&Hardfork::Homestead).unwrap(),

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -145,7 +145,7 @@ impl ChainSpec {
             None
         };
 
-        let header = Header {
+        Header {
             gas_limit: self.genesis.gas_limit,
             difficulty: self.genesis.difficulty,
             nonce: self.genesis.nonce,
@@ -155,12 +155,8 @@ impl ChainSpec {
             mix_hash: self.genesis.mix_hash,
             beneficiary: self.genesis.coinbase,
             base_fee_per_gas,
-            transactions_root: EMPTY_ROOT,
-            receipts_root: EMPTY_ROOT,
-            ommers_hash: EMPTY_OMMER_ROOT,
             ..Default::default()
-        };
-        header
+        }
     }
 
     /// Get the hash of the genesis block.

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -583,12 +583,12 @@ impl ForkCondition {
 
 #[cfg(test)]
 mod tests {
-    use revm_primitives::U256;
     use crate::{
         AllGenesisFormats, Chain, ChainSpec, ChainSpecBuilder, ForkCondition, ForkHash, ForkId,
-        Genesis, Hardfork, Head, GOERLI, MAINNET, SEPOLIA,
+        Genesis, Hardfork, Head, GOERLI, H256, MAINNET, SEPOLIA,
     };
     use ethers_core::types as EtherType;
+    use revm_primitives::U256;
     fn test_fork_ids(spec: &ChainSpec, cases: &[(Head, ForkId)]) {
         for (block, expected_id) in cases {
             let computed_id = spec.fork_id(block);
@@ -1032,96 +1032,57 @@ mod tests {
     fn hive_geth_json() {
         let hive_json = r#"
         {
-        "nonce": "0x0000000000000042",
-
-        "difficulty": "0x2123456",
-
-        "mixHash": "0x123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234",
-
-        "coinbase": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-
-        "timestamp": "0x123456",
-
-        "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-
-        "extraData": "0xfafbfcfd",
-
-        "gasLimit": "0x2fefd8",
-
-        "alloc": {
-
-            "dbdbdb2cbd23b783741e8d7fcf51e459b497e4a6": {
-
-            "balance": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-
+            "nonce": "0x0000000000000042",
+            "difficulty": "0x2123456",
+            "mixHash": "0x123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234",
+            "coinbase": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "timestamp": "0x123456",
+            "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "extraData": "0xfafbfcfd",
+            "gasLimit": "0x2fefd8",
+            "alloc": {
+                "dbdbdb2cbd23b783741e8d7fcf51e459b497e4a6": {
+                    "balance": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                },
+                "e6716f9544a56c530d868e4bfbacb172315bdead": {
+                    "balance": "0x11",
+                    "code": "0x12"
+                },
+                "b9c015918bdaba24b4ff057a92a3873d6eb201be": {
+                    "balance": "0x21",
+                    "storage": {
+                        "0x0000000000000000000000000000000000000000000000000000000000000001": "0x22"
+                    }
+                },
+                "1a26338f0d905e295fccb71fa9ea849ffa12aaf4": {
+                    "balance": "0x31",
+                    "nonce": "0x32"
+                },
+                "0000000000000000000000000000000000000001": {
+                    "balance": "0x41"
+                },
+                "0000000000000000000000000000000000000002": {
+                    "balance": "0x51"
+                },
+                "0000000000000000000000000000000000000003": {
+                    "balance": "0x61"
+                },
+                "0000000000000000000000000000000000000004": {
+                    "balance": "0x71"
+                }
             },
-
-            "e6716f9544a56c530d868e4bfbacb172315bdead": {
-
-            "balance": "0x11",
-
-            "code": "0x12"
-
-            },
-
-            "b9c015918bdaba24b4ff057a92a3873d6eb201be": {
-
-            "balance": "0x21",
-
-            "storage": {
-
-                "0x0000000000000000000000000000000000000000000000000000000000000001": "0x22"
-
+            "config": {
+                "ethash": {},
+                "chainId": 10,
+                "homesteadBlock": 0,
+                "eip150Block": 0,
+                "eip155Block": 0,
+                "eip158Block": 0,
+                "byzantiumBlock": 0,
+                "constantinopleBlock": 0,
+                "petersburgBlock": 0,
+                "istanbulBlock": 0
             }
-
-            },
-
-            "1a26338f0d905e295fccb71fa9ea849ffa12aaf4": {
-
-            "balance": "0x31",
-
-            "nonce": "0x32"
-
-            },
-
-            "0000000000000000000000000000000000000001": {
-
-            "balance": "0x41"
-
-            },
-
-            "0000000000000000000000000000000000000002": {
-
-            "balance": "0x51"
-
-            },
-
-            "0000000000000000000000000000000000000003": {
-
-            "balance": "0x61"
-
-            },
-
-            "0000000000000000000000000000000000000004": {
-
-            "balance": "0x71"
-
-            }
-
-        },
-
-        "config": {
-            "ethash": {},
-            "chainId": 10,
-            "homesteadBlock": 0,
-            "eip150Block": 0,
-            "eip155Block": 0,
-            "eip158Block": 0,
-            "byzantiumBlock": 0,
-            "constantinopleBlock": 0,
-            "petersburgBlock": 0,
-            "istanbulBlock": 0
-        }
         }
         "#;
         let genesis = serde_json::from_str::<AllGenesisFormats>(&hive_json).unwrap();
@@ -1133,10 +1094,16 @@ mod tests {
             Hardfork::Homestead,
             Hardfork::Istanbul,
             Hardfork::Petersburg,
-            Hardfork::Constantinople
+            Hardfork::Constantinople,
         ];
         for ref fork in hard_forks {
             assert_eq!(chainspec.hardforks.get(fork).unwrap(), &ForkCondition::Block(0));
         }
+
+        let expected_hash: H256 =
+            hex_literal::hex!("5ae31c6522bd5856129f66be3d582b842e4e9faaa87f21cce547128339a9db3c")
+                .into();
+        let hash = chainspec.genesis_header().hash_slow();
+        assert_eq!(hash, expected_hash);
     }
 }

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -2,9 +2,9 @@ use crate::{
     constants::EIP1559_INITIAL_BASE_FEE,
     forkid::ForkFilterKey,
     header::Head,
-    proofs::{genesis_state_root, EMPTY_ROOT},
+    proofs::genesis_state_root,
     BlockNumber, Chain, ForkFilter, ForkHash, ForkId, Genesis, GenesisAccount, Hardfork, Header,
-    EMPTY_OMMER_ROOT, H160, H256, U256,
+    H160, H256, U256,
 };
 use ethers_core::utils::Genesis as EthersGenesis;
 use hex_literal::hex;

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -1,10 +1,7 @@
 use crate::{
-    constants::EIP1559_INITIAL_BASE_FEE,
-    forkid::ForkFilterKey,
-    header::Head,
-    proofs::genesis_state_root,
-    BlockNumber, Chain, ForkFilter, ForkHash, ForkId, Genesis, GenesisAccount, Hardfork, Header,
-    H160, H256, U256,
+    constants::EIP1559_INITIAL_BASE_FEE, forkid::ForkFilterKey, header::Head,
+    proofs::genesis_state_root, BlockNumber, Chain, ForkFilter, ForkHash, ForkId, Genesis,
+    GenesisAccount, Hardfork, Header, H160, H256, U256,
 };
 use ethers_core::utils::Genesis as EthersGenesis;
 use hex_literal::hex;

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -1092,6 +1092,7 @@ mod tests {
         "#;
         let genesis = serde_json::from_str::<AllGenesisFormats>(&hive_json).unwrap();
         let chainspec: ChainSpec = genesis.into();
+        println!("{chainspec:#?}");
         assert_eq!(chainspec.genesis_hash, None);
         assert_eq!(Chain::Named(EtherType::Chain::Optimism), chainspec.chain);
         let expected_state_root: H256 = hex_literal::hex!("9a6049ac535e3dc7436c189eaa81c73f35abd7f282ab67c32944ff0301d63360").into();

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -1,7 +1,10 @@
 use crate::{
-    constants::EIP1559_INITIAL_BASE_FEE, forkid::ForkFilterKey, header::Head,
-    proofs::{genesis_state_root, EMPTY_ROOT}, BlockNumber, Chain, ForkFilter, ForkHash, ForkId, Genesis,
-    GenesisAccount, Hardfork, Header, H160, H256, U256, EMPTY_OMMER_ROOT,
+    constants::EIP1559_INITIAL_BASE_FEE,
+    forkid::ForkFilterKey,
+    header::Head,
+    proofs::{genesis_state_root, EMPTY_ROOT},
+    BlockNumber, Chain, ForkFilter, ForkHash, ForkId, Genesis, GenesisAccount, Hardfork, Header,
+    EMPTY_OMMER_ROOT, H160, H256, U256,
 };
 use ethers_core::utils::Genesis as EthersGenesis;
 use hex_literal::hex;
@@ -157,7 +160,6 @@ impl ChainSpec {
             ommers_hash: EMPTY_OMMER_ROOT,
             ..Default::default()
         };
-        println!("genesis header: {:?}", header);
         header
     }
 
@@ -1090,12 +1092,13 @@ mod tests {
             }
         }
         "#;
-        let genesis = serde_json::from_str::<AllGenesisFormats>(&hive_json).unwrap();
+        let genesis = serde_json::from_str::<AllGenesisFormats>(hive_json).unwrap();
         let chainspec: ChainSpec = genesis.into();
-        println!("{chainspec:#?}");
         assert_eq!(chainspec.genesis_hash, None);
         assert_eq!(Chain::Named(EtherType::Chain::Optimism), chainspec.chain);
-        let expected_state_root: H256 = hex_literal::hex!("9a6049ac535e3dc7436c189eaa81c73f35abd7f282ab67c32944ff0301d63360").into();
+        let expected_state_root: H256 =
+            hex_literal::hex!("9a6049ac535e3dc7436c189eaa81c73f35abd7f282ab67c32944ff0301d63360")
+                .into();
         assert_eq!(chainspec.genesis_header().state_root, expected_state_root);
         let hard_forks = vec![
             Hardfork::Byzantium,

--- a/crates/primitives/src/genesis.rs
+++ b/crates/primitives/src/genesis.rs
@@ -84,10 +84,9 @@ impl Encodable for GenesisAccount {
             .as_ref()
             .map_or(EMPTY_ROOT, |storage| {
                 let storage_values =
-                    storage.iter().filter(|(_k, &v)| v != KECCAK_EMPTY).map(|(&k, v)| {
-                        let mut value_rlp = BytesMut::new();
-                        v.encode(&mut value_rlp);
-                        (k, value_rlp.freeze())
+                    storage.iter().filter(|(_k, &v)| v != H256::zero()).map(|(&k, v)| {
+                        let v256 = reth_rlp::encode_fixed_size(&(U256::from_be_bytes(*v.as_fixed_bytes())));
+                        (k, v256)
                     });
 
                 sec_trie_root::<KeccakHasher, _, _, _>(storage_values)

--- a/crates/primitives/src/genesis.rs
+++ b/crates/primitives/src/genesis.rs
@@ -87,23 +87,17 @@ impl Encodable for GenesisAccount {
                 if storage.is_empty() {
                     return EMPTY_ROOT;
                 }
+                println!("{storage:#?}");
                 let storage_values =
                     storage.iter().filter(|(_k, &v)| v != KECCAK_EMPTY).map(|(&k, v)| {
                         let mut value_rlp = BytesMut::new();
                         v.encode(&mut value_rlp);
-                        (k, value_rlp.freeze())
+                        (k, v)
                     });
                 sec_trie_root::<KeccakHasher, _, _, _>(storage_values)
             })
             .encode(out);
-        match self.code {
-            Some(ref code) => {
-                let mut code_rlp = BytesMut::new();
-                code.encode(&mut code_rlp);
-                keccak256(&code_rlp).encode(out);
-            }
-            None => KECCAK_EMPTY.encode(out),
-        }
+        self.code.as_ref().map_or(KECCAK_EMPTY, keccak256).encode(out);
     }
 }
 

--- a/crates/primitives/src/genesis.rs
+++ b/crates/primitives/src/genesis.rs
@@ -84,11 +84,11 @@ impl Encodable for GenesisAccount {
             .as_ref()
             .map_or(EMPTY_ROOT, |storage| {
                 let storage_values =
-                    storage.iter().filter(|(_k, &v)| v != H256::zero()).map(|(&k, v)| {
-                        let v256 = reth_rlp::encode_fixed_size(&(U256::from_be_bytes(*v.as_fixed_bytes())));
-                        (k, v256)
+                    storage.iter().filter(|(_k, &v)| v != KECCAK_EMPTY).map(|(&k, v)| {
+                        let mut value_rlp = BytesMut::new();
+                        v.encode(&mut value_rlp);
+                        (k, value_rlp.freeze())
                     });
-
                 sec_trie_root::<KeccakHasher, _, _, _>(storage_values)
             })
             .encode(out);

--- a/crates/primitives/src/genesis.rs
+++ b/crates/primitives/src/genesis.rs
@@ -6,9 +6,8 @@ use crate::{
     utils::serde_helpers::deserialize_stringified_u64,
     Address, Bytes, H256, KECCAK_EMPTY, U256,
 };
-use bytes::BytesMut;
 use ethers_core::utils::GenesisAccount as EthersGenesisAccount;
-use reth_rlp::{length_of_length, Encodable, Header as RlpHeader, encode_fixed_size};
+use reth_rlp::{encode_fixed_size, length_of_length, Encodable, Header as RlpHeader};
 use serde::{Deserialize, Serialize};
 use triehash::sec_trie_root;
 
@@ -85,12 +84,11 @@ impl Encodable for GenesisAccount {
             .as_ref()
             .map_or(EMPTY_ROOT, |storage| {
                 if storage.is_empty() {
-                    return EMPTY_ROOT;
+                    return EMPTY_ROOT
                 }
-                println!("{storage:#?}");
                 let storage_values =
                     storage.iter().filter(|(_k, &v)| v != KECCAK_EMPTY).map(|(&k, v)| {
-                        let value = U256::from_be_bytes(*v);
+                        let value = U256::from_be_bytes(**v);
                         (k, encode_fixed_size(&value))
                     });
                 sec_trie_root::<KeccakHasher, _, _, _>(storage_values)

--- a/crates/primitives/src/genesis.rs
+++ b/crates/primitives/src/genesis.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use bytes::BytesMut;
 use ethers_core::utils::GenesisAccount as EthersGenesisAccount;
-use reth_rlp::{length_of_length, Encodable, Header as RlpHeader};
+use reth_rlp::{length_of_length, Encodable, Header as RlpHeader, encode_fixed_size};
 use serde::{Deserialize, Serialize};
 use triehash::sec_trie_root;
 
@@ -90,9 +90,8 @@ impl Encodable for GenesisAccount {
                 println!("{storage:#?}");
                 let storage_values =
                     storage.iter().filter(|(_k, &v)| v != KECCAK_EMPTY).map(|(&k, v)| {
-                        let mut value_rlp = BytesMut::new();
-                        v.encode(&mut value_rlp);
-                        (k, v)
+                        let value = U256::from_be_bytes(*v);
+                        (k, encode_fixed_size(&value))
                     });
                 sec_trie_root::<KeccakHasher, _, _, _>(storage_values)
             })


### PR DESCRIPTION
Fixes #1489

Modifies the storage encoding to exit early on an empty storage map, and use `U256` instead of `H256` for encoding individual values.