### PR TITLE
fix(cli): block node command from exiting

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -92,3 +92,4 @@ jobs:
             --bin reth -- node \
             --debug.tip 0x91c90676cab257a59cd956d7cb0bceb9b1a71d79755c23c7277a0697ccfaf8c4 \
             --debug.max-block 100000
+            --debug.terminate

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -91,5 +91,5 @@ jobs:
           cargo run --profile ${{ matrix.profile }} \
             --bin reth -- node \
             --debug.tip 0x91c90676cab257a59cd956d7cb0bceb9b1a71d79755c23c7277a0697ccfaf8c4 \
-            --debug.max-block 100000
+            --debug.max-block 100000 \
             --debug.terminate

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -193,8 +193,8 @@ impl Command {
 
         tx.await??;
 
-        info!(target: "reth::cli", "Finishing up");
-        Ok(())
+        info!(target: "reth::cli", "Pipeline has finished.");
+        futures::future::pending().await
     }
 
     async fn build_networked_pipeline(

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -194,6 +194,9 @@ impl Command {
         tx.await??;
 
         info!(target: "reth::cli", "Pipeline has finished.");
+
+        // The pipeline has finished downloading blocks up to `--debug.tip` or `--debug.max-block`.
+        // Keep other node components alive for further usage.
         futures::future::pending().await
     }
 

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -108,6 +108,10 @@ pub struct Command {
     #[arg(long = "debug.max-block", help_heading = "Debug")]
     max_block: Option<u64>,
 
+    /// Flag indicating whether the node should be terminated after the pipeline sync.
+    #[arg(long = "debug.terminate", help_heading = "Debug")]
+    terminate: bool,
+
     #[clap(flatten)]
     rpc: RpcServerArgs,
 }
@@ -195,9 +199,13 @@ impl Command {
 
         info!(target: "reth::cli", "Pipeline has finished.");
 
-        // The pipeline has finished downloading blocks up to `--debug.tip` or `--debug.max-block`.
-        // Keep other node components alive for further usage.
-        futures::future::pending().await
+        if self.terminate {
+            Ok(())
+        } else {
+            // The pipeline has finished downloading blocks up to `--debug.tip` or
+            // `--debug.max-block`. Keep other node components alive for further usage.
+            futures::future::pending().await
+        }
     }
 
     async fn build_networked_pipeline(


### PR DESCRIPTION
Block the pipeline task after finishing.

Closes #1510 

This behavior will be changed with #1528 