### PR TITLE
feat: format table sizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2530,6 +2530,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
+name = "human_bytes"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39b528196c838e8b3da8b665e08c30958a6f2ede91d79f2ffcd0d4664b9c64eb"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4349,6 +4355,7 @@ dependencies = [
  "eyre",
  "fdlimit",
  "futures",
+ "human_bytes",
  "jsonrpsee",
  "metrics",
  "metrics-exporter-prometheus",

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -64,3 +64,4 @@ comfy-table = "6.1.4"
 crossterm = "0.25.0"
 tui = "0.19.0"
 jsonrpsee = { version = "0.16", features = ["server"] }
+human_bytes = "0.4.1"

--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -3,6 +3,7 @@ use crate::dirs::{DbPath, PlatformPath};
 use clap::{Parser, Subcommand};
 use comfy_table::{Cell, Row, Table as ComfyTable};
 use eyre::{Result, WrapErr};
+use human_bytes::human_bytes;
 use reth_db::{
     cursor::{DbCursorRO, Walker},
     database::Database,
@@ -91,7 +92,7 @@ impl Command {
                     "Branch Pages",
                     "Leaf Pages",
                     "Overflow Pages",
-                    "Total Size (KB)",
+                    "Total Size",
                 ]);
 
                 tool.db.view(|tx| {
@@ -120,7 +121,7 @@ impl Command {
                             .add_cell(Cell::new(branch_pages))
                             .add_cell(Cell::new(leaf_pages))
                             .add_cell(Cell::new(overflow_pages))
-                            .add_cell(Cell::new(table_size / 1024));
+                            .add_cell(Cell::new(human_bytes(table_size as f64)));
                         stats_table.add_row(row);
                     }
                     Ok::<(), eyre::Report>(())


### PR DESCRIPTION
Formats table sizes with more units in `reth db stats` for an easier overview of what is heavy

Block 6585000 for me rn:

```
| Table Name           | # Entries  | Branch Pages | Leaf Pages | Overflow Pages | Tree Depth | Total Size |
|----------------------|------------|--------------|------------|----------------|------------|------------|
| CanonicalHeaders     | 10000001   | 2017         | 242763     | 0              | 4          | 956.2 MiB  |
| HeaderTD             | 10000001   | 319          | 71092      | 0              | 4          | 278.9 MiB  |
| HeaderNumbers        | 10000001   | 2373         | 179417     | 0              | 4          | 710.1 MiB  |
| Headers              | 10000001   | 22153        | 2497858    | 0              | 4          | 9.6 GiB    |
| BlockBodies          | 10000001   | 264          | 58547      | 0              | 4          | 229.7 MiB  |
| BlockOmmers          | 927001     | 656          | 146665     | 0              | 4          | 575.5 MiB  |
| BlockWithdrawals     | 0          | 0            | 0          | 0              | 0          | 0 B        |
| Transactions         | 697373173  | 171360       | 38383925   | 4418410        | 5          | 163.9 GiB  |
| TxHashNumber         | 504708     | 146          | 9225       | 0              | 4          | 36.6 MiB   |
| Receipts             | 0          | 0            | 0          | 0              | 0          | 0 B        |
| Logs                 | 0          | 0            | 0          | 0              | 0          | 0 B        |
| PlainAccountState    | 65786718   | 9372         | 931814     | 0              | 4          | 3.6 GiB    |
| PlainStorageState    | 138153934  | 65530        | 2787861    | 0              | 4          | 10.9 GiB   |
| Bytecodes            | 161352     | 294          | 19853      | 182030         | 4          | 789.8 MiB  |
| BlockTransitionIndex | 10000001   | 288          | 64103      | 0              | 4          | 251.5 MiB  |
| TxTransitionIndex    | 697373173  | 19959        | 4470341    | 0              | 4          | 17.1 GiB   |
| AccountHistory       | 41456      | 54           | 3607       | 0              | 3          | 14.3 MiB   |
| StorageHistory       | 40711      | 90           | 3337       | 0              | 4          | 13.4 MiB   |
| AccountChangeSet     | 891635513  | 100615       | 13242191   | 0              | 5          | 50.9 GiB   |
| StorageChangeSet     | 1001425675 | 696696       | 16455389   | 0              | 5          | 65.4 GiB   |
| HashedAccount        | 30329      | 6            | 406        | 0              | 3          | 1.6 MiB    |
| HashedStorage        | 28258      | 37           | 472        | 0              | 3          | 2 MiB      |
| AccountsTrie         | 40302      | 34           | 2451       | 0              | 3          | 9.7 MiB    |
| StoragesTrie         | 68680      | 122          | 2124       | 0              | 3          | 8.8 MiB    |
| TxSenders            | 697373173  | 29097        | 6517507    | 0              | 4          | 25 GiB     |
| Config               | 0          | 0            | 0          | 0              | 0          | 0 B        |
| SyncStage            | 13         | 0            | 1          | 0              | 1          | 4 KiB      |
```