### PR TITLE
chore: check genesis mismatch in `init_genesis`

### DIFF
--- a/bin/reth/src/chain/init.rs
+++ b/bin/reth/src/chain/init.rs
@@ -49,16 +49,7 @@ impl InitCommand {
         info!(target: "reth::cli", "Database opened");
 
         info!(target: "reth::cli", "Writing genesis block");
-        let genesis_hash = init_genesis(db, self.chain.clone())?;
-
-        if genesis_hash != self.chain.genesis_hash() {
-            // TODO: better error text
-            return Err(eyre::eyre!(
-                "Genesis hash mismatch: expected {}, got {}",
-                self.chain.genesis_hash(),
-                genesis_hash
-            ))
-        }
+        init_genesis(db, self.chain.clone())?;
 
         Ok(())
     }

--- a/crates/staged-sync/Cargo.toml
+++ b/crates/staged-sync/Cargo.toml
@@ -41,7 +41,7 @@ tracing = "0.1.37"
 rand = { version = "0.8", optional = true }
 
 # errors
-thiserror = { version = "1", optional = true }
+thiserror = "1"
 
 # enr
 enr = { version = "0.7.0", features = ["serde", "rust-secp256k1"], optional = true }
@@ -89,7 +89,6 @@ test-utils = [
     "dep:enr",
     "dep:ethers-core",
     "dep:tempfile",
-    "dep:thiserror",
     "dep:hex",
     "dep:rand",
     "dep:tokio",

--- a/crates/staged-sync/src/utils/init.rs
+++ b/crates/staged-sync/src/utils/init.rs
@@ -28,7 +28,7 @@ pub enum InitDatabaseError {
     #[error("Genesis hash mismatch: expected {expected}, got {actual}")]
     GenesisHashMismatch { expected: H256, actual: H256 },
 
-    // Low-level database error.
+    /// Low-level database error.
     #[error(transparent)]
     DBError(#[from] reth_db::Error),
 }

--- a/crates/staged-sync/src/utils/init.rs
+++ b/crates/staged-sync/src/utils/init.rs
@@ -41,12 +41,10 @@ pub fn init_genesis<DB: Database>(db: Arc<DB>, chain: ChainSpec) -> eyre::Result
     if let Some((_, db_hash)) = tx.cursor_read::<tables::CanonicalHeaders>()?.first()? {
         if db_hash == hash {
             debug!("Genesis already written, skipping.");
-            return Ok(hash);
+            return Ok(hash)
         }
 
-        return Err(
-            InitDatabaseError::GenesisHashMismatch { expected: hash, actual: db_hash }.into()
-        );
+        return Err(InitDatabaseError::GenesisHashMismatch { expected: hash, actual: db_hash }.into())
     }
 
     drop(tx);


### PR DESCRIPTION
Resolves #1256

I've erred on the side of panicking rather than adding a new error type to `reth_db::Error` as that enum seems generally a bit more low-level than what we're erroring on here.

Happy to change `init_genesis` to return an `eyre::Result<H256>` as an alternative.