### PR TITLE
chore: silence unwanted clippy warning in test

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -279,6 +279,7 @@ mod tests {
         assert_eq!(walker.next(), None);
     }
 
+    #[allow(clippy::reversed_empty_ranges)]
     #[test]
     fn db_cursor_walk_range_invalid() {
         let db: Arc<Env<WriteMap>> = test_utils::create_test_db(EnvKind::RW);


### PR DESCRIPTION
We're passing in incorrect ranges on purpose in this test so this clippy rule doesn't help us. I'm getting errors showing up in vscode for it however.