### PR TITLE
refactor: Execution Stage owns Executor

### DIFF
--- a/bin/reth/src/chain/import.rs
+++ b/bin/reth/src/chain/import.rs
@@ -27,6 +27,7 @@ use reth_staged_sync::{
 use reth_stages::{
     prelude::*,
     stages::{ExecutionStage, SenderRecoveryStage, TotalDifficultyStage},
+    DefaultDB,
 };
 use std::sync::Arc;
 use tracing::{debug, info};
@@ -156,9 +157,11 @@ impl ImportCommand {
                 .set(SenderRecoveryStage {
                     commit_threshold: config.stages.sender_recovery.commit_threshold,
                 })
-                .set(ExecutionStage {
-                    chain_spec: self.chain.clone(),
-                    commit_threshold: config.stages.execution.commit_threshold,
+                .set({
+                    let mut stage: ExecutionStage<'_, DefaultDB<'_>> =
+                        ExecutionStage::from(self.chain.clone());
+                    stage.commit_threshold = config.stages.execution.commit_threshold;
+                    stage
                 }),
             )
             .with_max_block(0)

--- a/bin/reth/src/dump_stage/execution.rs
+++ b/bin/reth/src/dump_stage/execution.rs
@@ -7,8 +7,9 @@ use eyre::Result;
 use reth_db::{
     cursor::DbCursorRO, database::Database, table::TableImporter, tables, transaction::DbTx,
 };
+use reth_primitives::MAINNET;
 use reth_provider::Transaction;
-use reth_stages::{stages::ExecutionStage, Stage, StageId, UnwindInput};
+use reth_stages::{stages::ExecutionStage, DefaultDB, Stage, StageId, UnwindInput};
 use std::ops::DerefMut;
 use tracing::info;
 
@@ -96,7 +97,7 @@ async fn unwind_and_copy<DB: Database>(
     output_db: &reth_db::mdbx::Env<reth_db::mdbx::WriteMap>,
 ) -> eyre::Result<()> {
     let mut unwind_tx = Transaction::new(db_tool.db)?;
-    let mut exec_stage = ExecutionStage::default();
+    let mut exec_stage: ExecutionStage<'_, DefaultDB<'_>> = ExecutionStage::from(MAINNET.clone());
 
     exec_stage
         .unwind(
@@ -125,7 +126,7 @@ async fn dry_run(
     info!(target: "reth::cli", "Executing stage. [dry-run]");
 
     let mut tx = Transaction::new(&output_db)?;
-    let mut exec_stage = ExecutionStage::default();
+    let mut exec_stage: ExecutionStage<'_, DefaultDB<'_>> = ExecutionStage::from(MAINNET.clone());
 
     exec_stage
         .execute(

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -50,6 +50,7 @@ use reth_staged_sync::{
 use reth_stages::{
     prelude::*,
     stages::{ExecutionStage, SenderRecoveryStage, TotalDifficultyStage, FINISH},
+    DefaultDB,
 };
 use reth_tasks::TaskExecutor;
 use std::{net::SocketAddr, path::PathBuf, sync::Arc};
@@ -448,9 +449,11 @@ impl Command {
                     .set(SenderRecoveryStage {
                         commit_threshold: stage_conf.sender_recovery.commit_threshold,
                     })
-                    .set(ExecutionStage {
-                        chain_spec: self.chain.clone(),
-                        commit_threshold: stage_conf.execution.commit_threshold,
+                    .set({
+                        let mut stage: ExecutionStage<'_, DefaultDB<'_>> =
+                            ExecutionStage::from(self.chain.clone());
+                        stage.commit_threshold = stage_conf.execution.commit_threshold;
+                        stage
                     }),
             )
             .build();

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -17,7 +17,7 @@ use reth_staged_sync::{
 };
 use reth_stages::{
     stages::{BodyStage, ExecutionStage, SenderRecoveryStage},
-    ExecInput, Stage, StageId, UnwindInput,
+    DefaultDB, ExecInput, Stage, StageId, UnwindInput,
 };
 use std::{net::SocketAddr, sync::Arc};
 use tracing::*;
@@ -171,8 +171,8 @@ impl Command {
                 stage.execute(&mut tx, input).await?;
             }
             StageEnum::Execution => {
-                let mut stage =
-                    ExecutionStage { chain_spec: self.chain.clone(), commit_threshold: num_blocks };
+                let mut stage = ExecutionStage::<DefaultDB<'_>>::from(self.chain.clone());
+                stage.commit_threshold = num_blocks;
                 if !self.skip_unwind {
                     stage.unwind(&mut tx, unwind).await?;
                 }

--- a/bin/reth/src/test_eth_chain/runner.rs
+++ b/bin/reth/src/test_eth_chain/runner.rs
@@ -15,7 +15,7 @@ use reth_primitives::{
 };
 use reth_provider::Transaction;
 use reth_rlp::Decodable;
-use reth_stages::{stages::ExecutionStage, ExecInput, Stage, StageId};
+use reth_stages::{stages::ExecutionStage, DefaultDB, ExecInput, Stage, StageId};
 use std::{
     collections::HashMap,
     ffi::OsStr,
@@ -193,7 +193,7 @@ pub async fn run_test(path: PathBuf) -> eyre::Result<TestOutcome> {
 
         // Initialize the execution stage
         // Hardcode the chain_id to Ethereum 1.
-        let mut stage = ExecutionStage::new(chain_spec, 1000);
+        let mut stage = ExecutionStage::<DefaultDB<'_>>::from(chain_spec);
 
         // Call execution stage
         let input = ExecInput {

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -78,12 +78,12 @@ where
 
     /// Overrides the database
     pub fn with_db<OtherDB: StateProvider>(
-        self,
+        &self,
         db: &'a mut SubState<OtherDB>,
     ) -> Executor<'a, OtherDB> {
         let mut evm = EVM::new();
         evm.database(db);
-        Executor { chain_spec: self.chain_spec.clone(), evm, stack: self.stack }
+        Executor { chain_spec: self.chain_spec.clone(), evm, stack: self.stack.clone() }
     }
 
     fn recover_senders(
@@ -661,7 +661,7 @@ mod tests {
         let mut db = SubState::new(State::new(db));
 
         // execute chain and verify receipts
-        let mut executor = Executor::new(Arc::new(chain_spec), &mut db);
+        let mut executor = Executor::new(chain_spec, &mut db);
         let out = executor.execute_and_verify_receipt(&block, U256::ZERO, None).unwrap();
 
         assert_eq!(out.tx_changesets.len(), 1, "Should executed one transaction");
@@ -790,7 +790,7 @@ mod tests {
 
         let mut db = SubState::new(State::new(db));
         // execute chain and verify receipts
-        let mut executor = Executor::new(Arc::new(chain_spec), &mut db);
+        let mut executor = Executor::new(chain_spec, &mut db);
         let out = executor
             .execute_and_verify_receipt(
                 &Block { header, body: vec![], ommers: vec![], withdrawals: None },
@@ -881,7 +881,7 @@ mod tests {
         let mut db = SubState::new(State::new(db));
 
         // execute chain and verify receipts
-        let mut executor = Executor::new(Arc::new(chain_spec), &mut db);
+        let mut executor = Executor::new(chain_spec, &mut db);
         let out = executor.execute_and_verify_receipt(&block, U256::ZERO, None).unwrap();
 
         assert_eq!(out.tx_changesets.len(), 1, "Should executed one transaction");
@@ -930,7 +930,7 @@ mod tests {
         let mut db = SubState::new(State::new(StateProviderTest::default()));
 
         // execute chain and verify receipts
-        let mut executor = Executor::new(Arc::new(chain_spec), &mut db);
+        let mut executor = Executor::new(chain_spec, &mut db);
         let out = executor.execute_and_verify_receipt(&block, U256::ZERO, None).unwrap();
         assert_eq!(out.tx_changesets.len(), 0, "No tx");
 

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -656,7 +656,7 @@ mod tests {
         );
 
         // spec at berlin fork
-        let chain_spec = ChainSpecBuilder::mainnet().berlin_activated().build();
+        let chain_spec = Arc::new(ChainSpecBuilder::mainnet().berlin_activated().build());
 
         let mut db = SubState::new(State::new(db));
 
@@ -781,10 +781,12 @@ mod tests {
             beneficiary_balance += i;
         }
 
-        let chain_spec = ChainSpecBuilder::from(&*MAINNET)
-            .homestead_activated()
-            .with_fork(Hardfork::Dao, ForkCondition::Block(1))
-            .build();
+        let chain_spec = Arc::new(
+            ChainSpecBuilder::from(&*MAINNET)
+                .homestead_activated()
+                .with_fork(Hardfork::Dao, ForkCondition::Block(1))
+                .build(),
+        );
 
         let mut db = SubState::new(State::new(db));
         // execute chain and verify receipts
@@ -874,7 +876,7 @@ mod tests {
         );
 
         // spec at berlin fork
-        let chain_spec = ChainSpecBuilder::mainnet().berlin_activated().build();
+        let chain_spec = Arc::new(ChainSpecBuilder::mainnet().berlin_activated().build());
 
         let mut db = SubState::new(State::new(db));
 
@@ -923,7 +925,7 @@ mod tests {
             Address::from_str("c94f5374fce5edbc8e2a8697c15331677e6ebf0b").unwrap();
 
         // spec at shanghai fork
-        let chain_spec = ChainSpecBuilder::mainnet().shanghai_activated().build();
+        let chain_spec = Arc::new(ChainSpecBuilder::mainnet().shanghai_activated().build());
 
         let mut db = SubState::new(State::new(StateProviderTest::default()));
 

--- a/crates/revm/revm-inspectors/src/stack.rs
+++ b/crates/revm/revm-inspectors/src/stack.rs
@@ -10,7 +10,7 @@ use revm::{
 /// - Block: Hook on block execution
 /// - BlockWithIndex: Hook on block execution transaction index
 /// - Transaction: Hook on a specific transaction hash
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub enum Hook {
     #[default]
     /// No hook.
@@ -23,7 +23,7 @@ pub enum Hook {
     All,
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 /// An inspector that calls multiple inspectors in sequence.
 ///
 /// If a call to an inspector returns a value other than [InstructionResult::Continue] (or

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -12,3 +12,6 @@ pub mod database;
 
 /// reexport for convenience
 pub use reth_revm_primitives::*;
+
+/// Re-export everything
+pub use revm;

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -440,7 +440,7 @@ mod tests {
     };
 
     fn setup_engine_api() -> (EngineApiTestHandle, EngineApi<Arc<MockEthProvider>>) {
-        let chain_spec = MAINNET.clone();
+        let chain_spec = Arc::new(MAINNET.clone());
         let client = Arc::new(MockEthProvider::default());
         let (msg_tx, msg_rx) = unbounded_channel();
         let (forkchoice_state_tx, forkchoice_state_rx) = watch::channel(ForkchoiceState::default());
@@ -455,7 +455,7 @@ mod tests {
     }
 
     struct EngineApiTestHandle {
-        chain_spec: ChainSpec,
+        chain_spec: Arc<ChainSpec>,
         client: Arc<MockEthProvider>,
         msg_tx: UnboundedSender<EngineApiMessage>,
         forkchoice_state_rx: WatchReceiver<ForkchoiceState>,

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -305,7 +305,8 @@ impl<Client: HeaderProvider + BlockProvider + StateProviderFactory + EvmEnvProvi
         let total_difficulty = parent_td + block.header.difficulty;
 
         let mut db = SubState::new(State::new(&state_provider));
-        let mut executor = reth_executor::executor::Executor::new(&self.chain_spec, &mut db);
+        // TODO: Replace with ARC
+        let mut executor = reth_executor::executor::Executor::new(self.chain_spec.clone(), &mut db);
         match executor.execute_and_verify_receipt(&block.unseal(), total_difficulty, None) {
             Ok(_) => Ok(PayloadStatus::new(PayloadStatusEnum::Valid, block_hash)),
             Err(err) => Ok(PayloadStatus::new(

--- a/crates/stages/src/lib.rs
+++ b/crates/stages/src/lib.rs
@@ -56,6 +56,11 @@ mod stage;
 mod trie;
 mod util;
 
+/// The real database type we use in Reth using MDBX.
+pub type DefaultDB<'a> = LatestStateProviderRef<'a, 'a, Tx<'a, RW, WriteMap>>;
+use reth_db::mdbx::{tx::Tx, WriteMap, RW};
+use reth_provider::LatestStateProviderRef;
+
 #[allow(missing_docs)]
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;

--- a/crates/stages/src/sets.rs
+++ b/crates/stages/src/sets.rs
@@ -170,7 +170,7 @@ impl<DB: Database> StageSet<DB> for ExecutionStages {
     fn builder(self) -> StageSetBuilder<DB> {
         StageSetBuilder::default()
             .add_stage(SenderRecoveryStage::default())
-            .add_stage(ExecutionStage { chain_spec: self.chain_spec, ..Default::default() })
+            .add_stage(ExecutionStage::<crate::DefaultDB<'_>>::from(self.chain_spec))
     }
 }
 

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -11,7 +11,7 @@ use reth_db::{
 };
 use reth_executor::{execution_result::AccountChangeSet, executor::Executor};
 use reth_interfaces::provider::ProviderError;
-use reth_primitives::{Address, Block, ChainSpec, Hardfork, StorageEntry, H256, MAINNET, U256};
+use reth_primitives::{Address, Block, ChainSpec, Hardfork, StorageEntry, H256, U256};
 use reth_provider::{LatestStateProviderRef, StateProvider, Transaction};
 use reth_revm::database::{State, SubState};
 use tracing::*;

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -1,6 +1,6 @@
 use crate::{
-    exec_or_return, ExecAction, ExecInput, ExecOutput, Stage, StageError, StageId, UnwindInput,
-    UnwindOutput,
+    exec_or_return, DefaultDB, ExecAction, ExecInput, ExecOutput, Stage, StageError, StageId,
+    UnwindInput, UnwindOutput,
 };
 use reth_db::{
     cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO},
@@ -9,12 +9,11 @@ use reth_db::{
     tables,
     transaction::{DbTx, DbTxMut},
 };
-use reth_executor::execution_result::AccountChangeSet;
+use reth_executor::{execution_result::AccountChangeSet, executor::Executor};
 use reth_interfaces::provider::ProviderError;
 use reth_primitives::{Address, Block, ChainSpec, Hardfork, StorageEntry, H256, MAINNET, U256};
-use reth_provider::{LatestStateProviderRef, Transaction};
+use reth_provider::{LatestStateProviderRef, StateProvider, Transaction};
 use reth_revm::database::{State, SubState};
-use std::fmt::Debug;
 use tracing::*;
 
 /// The [`StageId`] of the execution stage.
@@ -48,24 +47,35 @@ pub const EXECUTION: StageId = StageId("Execution");
 /// - [tables::AccountHistory] to remove change set and apply old values to
 /// - [tables::PlainAccountState] [tables::StorageHistory] to remove change set and apply old values
 /// to [tables::PlainStorageState]
-#[derive(Debug)]
-pub struct ExecutionStage {
-    /// Executor configuration.
-    pub chain_spec: ChainSpec,
+// false positive, we cannot derive it if !DB: Debug.
+#[allow(missing_debug_implementations)]
+pub struct ExecutionStage<'a, DB = DefaultDB<'a>>
+where
+    DB: StateProvider,
+{
+    /// The stage's internal executor
+    pub executor: Executor<'a, DB>,
     /// Commit threshold
     pub commit_threshold: u64,
 }
 
-impl Default for ExecutionStage {
-    fn default() -> Self {
-        Self { chain_spec: MAINNET.clone(), commit_threshold: 1_000 }
+impl<'a, DB: StateProvider> From<Executor<'a, DB>> for ExecutionStage<'a, DB> {
+    fn from(executor: Executor<'a, DB>) -> Self {
+        Self { executor, commit_threshold: 1_000 }
     }
 }
 
-impl ExecutionStage {
+impl<'a, DB: StateProvider> From<ChainSpec> for ExecutionStage<'a, DB> {
+    fn from(chain_spec: ChainSpec) -> Self {
+        let executor = Executor::from(chain_spec);
+        Self::from(executor)
+    }
+}
+
+impl<'a, S: StateProvider> ExecutionStage<'a, S> {
     /// Execute the stage.
     pub fn execute_inner<DB: Database>(
-        &self,
+        &mut self,
         tx: &mut Transaction<'_, DB>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
@@ -87,7 +97,6 @@ impl ExecutionStage {
         let mut tx_cursor = tx.cursor_read::<tables::Transactions>()?;
         // Skip sender recovery and load signer from database.
         let mut tx_sender = tx.cursor_read::<tables::TxSenders>()?;
-
         // Get block headers and bodies
         let block_batch = headers_cursor
             .walk_range(start_block..=end_block)?
@@ -106,6 +115,7 @@ impl ExecutionStage {
             .collect::<Result<Vec<_>, _>>()?;
 
         // Create state provider with cached state
+
         let mut state_provider = SubState::new(State::new(LatestStateProviderRef::new(&**tx)));
 
         // Fetch transactions, execute them and generate results
@@ -143,14 +153,15 @@ impl ExecutionStage {
 
             trace!(target: "sync::stages::execution", number = block_number, txs = transactions.len(), "Executing block");
 
-            let changeset = reth_executor::executor::execute_and_verify_receipt(
-                &Block { header, body: transactions, ommers, withdrawals },
-                td,
-                Some(signers),
-                &self.chain_spec,
-                &mut state_provider,
-            )
-            .map_err(|error| StageError::ExecutionError { block: block_number, error })?;
+            // Configure the executor to use the current state.
+            let mut executor = self.executor.with_db(&mut state_provider);
+            let changeset = executor
+                .execute_and_verify_receipt(
+                    &Block { header, body: transactions, ommers, withdrawals },
+                    td,
+                    Some(signers),
+                )
+                .map_err(|error| StageError::ExecutionError { block: block_number, error })?;
             block_change_patches.push((changeset, block_number));
         }
 
@@ -160,8 +171,11 @@ impl ExecutionStage {
 
         // apply changes to plain database.
         for (results, block_number) in block_change_patches.into_iter() {
-            let spurious_dragon_active =
-                self.chain_spec.fork(Hardfork::SpuriousDragon).active_at_block(block_number);
+            let spurious_dragon_active = self
+                .executor
+                .chain_spec
+                .fork(Hardfork::SpuriousDragon)
+                .active_at_block(block_number);
             // insert state change set
             for result in results.tx_changesets.into_iter() {
                 for (address, account_change_set) in result.changeset.into_iter() {
@@ -266,15 +280,15 @@ impl ExecutionStage {
     }
 }
 
-impl ExecutionStage {
+impl<'a, DB: StateProvider> ExecutionStage<'a, DB> {
     /// Create new execution stage with specified config.
-    pub fn new(chain_spec: ChainSpec, commit_threshold: u64) -> Self {
-        Self { chain_spec, commit_threshold }
+    pub fn new(executor: Executor<'a, DB>, commit_threshold: u64) -> Self {
+        Self { executor, commit_threshold }
     }
 }
 
 #[async_trait::async_trait]
-impl<DB: Database> Stage<DB> for ExecutionStage {
+impl<State: StateProvider, DB: Database> Stage<DB> for ExecutionStage<'_, State> {
     /// Return the id of the stage
     fn id(&self) -> StageId {
         EXECUTION
@@ -448,11 +462,8 @@ mod tests {
         db_tx.put::<tables::Bytecodes>(code_hash, code.to_vec()).unwrap();
         tx.commit().unwrap();
 
-        // execute
-        let mut execution_stage = ExecutionStage {
-            chain_spec: ChainSpecBuilder::mainnet().berlin_activated().build(),
-            ..Default::default()
-        };
+        let chain_spec = ChainSpecBuilder::mainnet().berlin_activated().build();
+        let mut execution_stage = ExecutionStage::<DefaultDB<'_>>::from(chain_spec);
         let output = execution_stage.execute(&mut tx, input).await.unwrap();
         tx.commit().unwrap();
         assert_eq!(output, ExecOutput { stage_progress: 1, done: true });
@@ -536,14 +547,12 @@ mod tests {
         tx.commit().unwrap();
 
         // execute
-        let mut execution_stage = ExecutionStage {
-            chain_spec: ChainSpecBuilder::mainnet().berlin_activated().build(),
-            ..Default::default()
-        };
+        let chain_spec = ChainSpecBuilder::mainnet().berlin_activated().build();
+        let mut execution_stage = ExecutionStage::<DefaultDB<'_>>::from(chain_spec);
         let _ = execution_stage.execute(&mut tx, input).await.unwrap();
         tx.commit().unwrap();
 
-        let o = ExecutionStage::default()
+        let o = ExecutionStage::<DefaultDB<'_>>::from(MAINNET.clone())
             .unwind(&mut tx, UnwindInput { stage_progress: 1, unwind_to: 0, bad_block: None })
             .await
             .unwrap();
@@ -624,10 +633,8 @@ mod tests {
         tx.commit().unwrap();
 
         // execute
-        let mut execution_stage = ExecutionStage {
-            chain_spec: ChainSpecBuilder::mainnet().berlin_activated().build(),
-            ..Default::default()
-        };
+        let chain_spec = ChainSpecBuilder::mainnet().berlin_activated().build();
+        let mut execution_stage = ExecutionStage::<DefaultDB<'_>>::from(chain_spec);
         let _ = execution_stage.execute(&mut tx, input).await.unwrap();
         tx.commit().unwrap();
 

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -406,20 +406,18 @@ impl<State: StateProvider, DB: Database> Stage<DB> for ExecutionStage<'_, State>
 
 #[cfg(test)]
 mod tests {
-    use std::ops::{Deref, DerefMut};
-
-    use crate::test_utils::{TestTransaction, PREV_STAGE_ID};
-
     use super::*;
+    use crate::test_utils::{TestTransaction, PREV_STAGE_ID};
     use reth_db::{
         mdbx::{test_utils::create_test_db, EnvKind, WriteMap},
         models::AccountBeforeTx,
     };
     use reth_primitives::{
-        hex_literal::hex, keccak256, Account, ChainSpecBuilder, SealedBlock, H160, U256,
+        hex_literal::hex, keccak256, Account, ChainSpecBuilder, SealedBlock, H160, MAINNET, U256,
     };
     use reth_provider::insert_canonical_block;
     use reth_rlp::Decodable;
+    use std::ops::{Deref, DerefMut};
 
     #[tokio::test]
     async fn sanity_execution_of_block() {


### PR DESCRIPTION
Before, we had a weird pattern IMO where we'd call a `execut_and_verify_with_receipts` function with 5 arguments, and instantiating a new executor each time. That would make it really ugly if we wanted to integrate with the feature from PR #1567 as it'd require that we pass around the configuration for the inspectors. Instead, in this PR we refactor it so that the ExecutionStage now owns an Executor. It makes more sense this way, as we want the stage to basically be a coordinator around the 1-2 functions of the executor that are used across blocks (vs tracking more data than that).