### PR TITLE
fix: `seek_by_key_subkey` usage on `HistoricalStateProvider`

### DIFF
--- a/crates/storage/db/src/abstraction/cursor.rs
+++ b/crates/storage/db/src/abstraction/cursor.rs
@@ -73,7 +73,7 @@ pub trait DbDupCursorRO<'tx, T: DupSort> {
     /// Returns the next `value` of a duplicate `key`.
     fn next_dup_val(&mut self) -> ValueOnlyResult<T>;
 
-    /// Seek by key and subkey
+    /// Seek by key and subkey. Make sure that the returned value subkey matches the queried one.
     fn seek_by_key_subkey(&mut self, key: T::Key, subkey: T::SubKey) -> ValueOnlyResult<T>;
 
     /// Returns an iterator starting at a key greater or equal than `start_key` of a DupSort

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -56,6 +56,7 @@ impl<'a, 'b, TX: DbTx<'a>> AccountProvider for HistoricalStateProviderRef<'a, 'b
                 .tx
                 .cursor_dup_read::<tables::AccountChangeSet>()?
                 .seek_by_key_subkey(changeset_transition_id, address)?
+                .filter(|acc| acc.address == address)
                 .ok_or(ProviderError::AccountChangeset {
                     transition_id: changeset_transition_id,
                     address,
@@ -95,6 +96,7 @@ impl<'a, 'b, TX: DbTx<'a>> StateProvider for HistoricalStateProviderRef<'a, 'b, 
                 .tx
                 .cursor_dup_read::<tables::StorageChangeSet>()?
                 .seek_by_key_subkey((changeset_transition_id, address).into(), storage_key)?
+                .filter(|entry| entry.key == storage_key)
                 .ok_or(ProviderError::StorageChangeset {
                     transition_id: changeset_transition_id,
                     address,
@@ -107,8 +109,9 @@ impl<'a, 'b, TX: DbTx<'a>> StateProvider for HistoricalStateProviderRef<'a, 'b, 
             Ok(self
                 .tx
                 .cursor_dup_read::<tables::PlainStorageState>()?
-                .seek_by_key_subkey(address, storage_key)
-                .map(|r| r.map(|entry| entry.value))?)
+                .seek_by_key_subkey(address, storage_key)?
+                .filter(|entry| entry.key == storage_key)
+                .map(|entry| entry.value))
         }
     }
 


### PR DESCRIPTION
As the title suggests. We were not filtering for the returned value.