### PR TITLE
feat(rpc): add `eth_coinbase` implementation

### DIFF
--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -73,10 +73,10 @@ where
     EthApiClient::block_transaction_count_by_hash(client, hash).await.unwrap();
     EthApiClient::block_uncles_count_by_hash(client, hash).await.unwrap();
     EthApiClient::block_uncles_count_by_number(client, block_number).await.unwrap();
+    EthApiClient::author(client).await.unwrap();
 
     // Unimplemented
     assert!(is_unimplemented(EthApiClient::syncing(client).await.err().unwrap()));
-    assert!(is_unimplemented(EthApiClient::author(client).await.err().unwrap()));
     assert!(is_unimplemented(
         EthApiClient::uncle_by_block_hash_and_index(client, hash, index).await.err().unwrap()
     ));

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -41,7 +41,7 @@ where
 
     /// Handler for: `eth_coinbase`
     async fn author(&self) -> Result<Address> {
-        Err(internal_rpc_err("unimplemented"))
+        Ok(self.pool().status().coinbase)
     }
 
     /// Handler for: `eth_accounts`

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -1,3 +1,5 @@
+use reth_primitives::Address;
+
 /// Guarantees max transactions for one sender, compatible with geth/erigon
 pub(crate) const MAX_ACCOUNT_SLOTS_PER_SENDER: usize = 16;
 
@@ -12,6 +14,8 @@ pub struct PoolConfig {
     pub queued_limit: SubPoolLimit,
     /// Max number of executable transaction slots guaranteed per account
     pub max_account_slots: usize,
+    /// The address of the pool owner.
+    pub coinbase: Address,
 }
 
 impl Default for PoolConfig {
@@ -21,6 +25,7 @@ impl Default for PoolConfig {
             basefee_limit: Default::default(),
             queued_limit: Default::default(),
             max_account_slots: MAX_ACCOUNT_SLOTS_PER_SENDER,
+            coinbase: Default::default(),
         }
     }
 }

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -89,14 +89,12 @@ pub use crate::{
     validate::{TransactionValidationOutcome, TransactionValidator},
 };
 use crate::{
-    error::PoolResult,
-    pool::PoolInner,
-    traits::{NewTransactionEvent, PoolSize},
-    validate::ValidPoolTransaction,
+    error::PoolResult, pool::PoolInner, traits::NewTransactionEvent, validate::ValidPoolTransaction,
 };
-use reth_primitives::{TxHash, U256};
+use reth_primitives::{Address, TxHash, U256};
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::mpsc::Receiver;
+use traits::PoolStatus;
 
 mod config;
 pub mod error;
@@ -190,8 +188,8 @@ where
 {
     type Transaction = T::Transaction;
 
-    fn status(&self) -> PoolSize {
-        self.pool.size()
+    fn status(&self) -> PoolStatus {
+        PoolStatus { size: self.pool.size(), coinbase: Address::zero() }
     }
 
     fn on_new_block(&self, event: OnNewBlockEvent) {

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -25,7 +25,7 @@ pub trait TransactionPool: Send + Sync + Clone {
     type Transaction: PoolTransaction;
 
     /// Returns stats about the pool.
-    fn status(&self) -> PoolSize;
+    fn status(&self) -> PoolStatus;
 
     /// Event listener for when a new block was mined.
     ///
@@ -424,6 +424,15 @@ impl IntoRecoveredTransaction for PooledTransaction {
 }
 
 /// Represents the current status of the pool.
+#[derive(Debug, Clone)]
+pub struct PoolStatus {
+    /// Address of the pool owner.
+    pub coinbase: Address,
+    /// Stats about the size of the pool.
+    pub size: PoolSize,
+}
+
+/// Stats about the size of the pool.
 #[derive(Debug, Clone)]
 pub struct PoolSize {
     /// Number of transactions in the _pending_ sub-pool.


### PR DESCRIPTION
Ref: https://github.com/paradigmxyz/reth/issues/1225

This PR adds the implementation for the `eth_coinbase` endpoint.

The coinbase is stored as part of the `Pool` configuration, and accessed via the `TransactionPool::status` method.