### PR TITLE
feat(rpc): Add RpcModuleConfig and integrate in builder

### DIFF
--- a/crates/rpc/rpc-builder/src/eth.rs
+++ b/crates/rpc/rpc-builder/src/eth.rs
@@ -1,0 +1,25 @@
+use reth_rpc::{
+    eth::cache::{EthStateCache, EthStateCacheConfig},
+    EthApi, EthFilter, EthPubSub,
+};
+use serde::{Deserialize, Serialize};
+
+/// All handlers for the `eth` namespace
+#[derive(Debug, Clone)]
+pub struct EthHandlers<Client, Pool, Network, Events> {
+    /// Main `eth_` request handler
+    pub api: EthApi<Client, Pool, Network>,
+    /// The async caching layer used by the eth handlers
+    pub eth_cache: EthStateCache,
+    /// Polling based filter handler available on all transports
+    pub filter: EthFilter<Client, Pool>,
+    /// Handler for subscriptions only available for transports that support it (ws, ipc)
+    pub pubsub: Option<EthPubSub<Client, Pool, Events>>,
+}
+
+/// Additional config values for the eth namespace
+#[derive(Debug, Clone, Eq, PartialEq, Default, Serialize, Deserialize)]
+pub struct EthConfig {
+    /// Settings for the caching layer
+    pub cache: EthStateCacheConfig,
+}

--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -58,7 +58,6 @@ pub trait EthApiSpec: Send + Sync {
 /// the main impls. This way [`EthApi`] is not limited to [`jsonrpsee`] and can be used standalone
 /// or in other network handlers (for example ipc).
 #[derive(Clone)]
-#[allow(missing_debug_implementations)]
 pub struct EthApi<Client, Pool, Network> {
     /// All nested fields bundled together.
     inner: Arc<EthApiInner<Client, Pool, Network>>,
@@ -169,6 +168,12 @@ where
         &self,
     ) -> Result<Option<<Client as StateProviderFactory>::HistorySP<'_>>> {
         self.state_at_block_number(BlockNumberOrTag::Latest)
+    }
+}
+
+impl<Client, Pool, Events> std::fmt::Debug for EthApi<Client, Pool, Events> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EthApi").finish_non_exhaustive()
     }
 }
 

--- a/crates/rpc/rpc/src/eth/cache.rs
+++ b/crates/rpc/rpc/src/eth/cache.rs
@@ -32,7 +32,7 @@ type BlockLruCache<L> = MultiConsumerLruCache<H256, Block, L, BlockResponseSende
 type EnvLruCache<L> = MultiConsumerLruCache<H256, (CfgEnv, BlockEnv), L, EnvResponseSender>;
 
 /// Settings for the [EthStateCache]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EthStateCacheConfig {
     /// Max number of bytes for cached block data.

--- a/crates/rpc/rpc/src/eth/pubsub.rs
+++ b/crates/rpc/rpc/src/eth/pubsub.rs
@@ -18,7 +18,8 @@ use tokio_stream::{
 
 /// `Eth` pubsub RPC implementation.
 ///
-/// This handles
+/// This handles `eth_subscribe` RPC calls.
+#[derive(Clone)]
 pub struct EthPubSub<Client, Pool, Events> {
     /// All nested fields bundled together.
     inner: EthPubSubInner<Client, Pool, Events>,


### PR DESCRIPTION
extends how the `eth` namespace is configured, because there'll be multiple handlers for
* main
* filter
* pubsub

This adds another config so handler specific settings can be configured in the builder pipeline.