### PR TITLE
chore: `get_evm_evn` -> `get_evm_env`

### DIFF
--- a/crates/rpc/rpc/src/eth/cache.rs
+++ b/crates/rpc/rpc/src/eth/cache.rs
@@ -125,7 +125,7 @@ impl EthStateCache {
     ///
     /// Returns an error if the corresponding header (required for populating the envs) was not
     /// found.
-    pub(crate) async fn get_evm_evn(&self, block_hash: H256) -> Result<(CfgEnv, BlockEnv)> {
+    pub(crate) async fn get_evm_env(&self, block_hash: H256) -> Result<(CfgEnv, BlockEnv)> {
         let (response_tx, rx) = oneshot::channel();
         let _ = self.to_service.send(CacheAction::GetEnv { block_hash, response_tx });
         rx.await.map_err(|_| ProviderError::CacheServiceUnavailable)?


### PR DESCRIPTION
Fixes a typo