### PR TITLE
ci: no longer pin nightly version

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -25,7 +25,6 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2022-12-27
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
perhaps this is linked to the sanity issues:

https://github.com/paradigmxyz/reth/issues/1636