### PR TITLE
perf(provider): remove redundant lookup

### DIFF
--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -62,11 +62,7 @@ impl<DB: Database> HeaderProvider for ShareableDatabase<DB> {
     }
 
     fn header_by_number(&self, num: BlockNumber) -> Result<Option<Header>> {
-        if let Some(hash) = self.db.view(|tx| tx.get::<tables::CanonicalHeaders>(num))?? {
-            self.header(&hash)
-        } else {
-            Ok(None)
-        }
+        Ok(self.db.view(|tx| tx.get::<tables::Headers>(num))??)
     }
 
     fn header_td(&self, hash: &BlockHash) -> Result<Option<U256>> {


### PR DESCRIPTION
Remove redundant lookups in `header_by_number` which affects the performance of various provider functions.

## Previous Behavior
```
num -> hash
hash -> num
num -> header
```

## Current Behavior
```
num -> header
```