### PR TITLE
feat: add `debug-fast` profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,11 @@ members = [
 exclude = ["crate-template"]
 default-members = ["bin/reth"]
 
+# Like release, but with full debug symbols. Useful for e.g. `perf`.
+[profile.debug-fast]
+inherits = "release"
+debug = true
+
 [patch.crates-io]
 revm = { git = "https://github.com/bluealloy/revm" }
 revm-primitives = { git = "https://github.com/bluealloy/revm" }


### PR DESCRIPTION
This profile is like `release`, except it contains full debug symbols. Useful for running e.g. `perf` or `gdb`, which depends on debug symbols.