### PR TITLE
fix: return zero latestValidHash pre-merge

### DIFF
--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -4,7 +4,7 @@ use reth_interfaces::consensus::ForkchoiceState;
 use reth_primitives::{
     proofs::{self, EMPTY_LIST_HASH},
     BlockHash, BlockId, BlockNumber, ChainSpec, Hardfork, Header, SealedBlock, TransactionSigned,
-    H64, U256,
+    H256, H64, U256,
 };
 use reth_provider::{
     BlockExecutor, BlockProvider, EvmEnvProvider, ExecutorFactory, HeaderProvider,
@@ -291,7 +291,8 @@ impl<Client: HeaderProvider + BlockProvider + StateProviderFactory + EvmEnvProvi
         if !self.chain_spec.fork(Hardfork::Paris).active_at_ttd(parent_td, U256::ZERO) {
             return Ok(PayloadStatus::from_status(PayloadStatusEnum::Invalid {
                 validation_error: EngineApiError::PayloadPreMerge.to_string(),
-            }))
+            })
+            .with_latest_valid_hash(H256::zero()))
         }
 
         if block.timestamp <= parent.timestamp {
@@ -646,7 +647,8 @@ mod tests {
 
             let expected_result = PayloadStatus::from_status(PayloadStatusEnum::Invalid {
                 validation_error: EngineApiError::PayloadPreMerge.to_string(),
-            });
+            })
+            .with_latest_valid_hash(H256::zero());
             assert_matches!(result_rx.await, Ok(Ok(result)) => assert_eq!(result, expected_result));
         }
 

--- a/crates/rpc/rpc-types/src/eth/engine.rs
+++ b/crates/rpc/rpc-types/src/eth/engine.rs
@@ -145,6 +145,11 @@ impl PayloadStatus {
     pub fn from_status(status: PayloadStatusEnum) -> Self {
         Self { status, latest_valid_hash: None }
     }
+
+    pub fn with_latest_valid_hash(mut self, latest_valid_hash: H256) -> Self {
+        self.latest_valid_hash = Some(latest_valid_hash);
+        self
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
Returns a zero `latestValidHash` when `engine_newPayload` is called with a pre-merge parent hash. Modified existing tests to reflect the correct behavior.

Introduces `PayloadStatus::with_latest_valid_hash` for using a non-null `latestValidHash` with an invalid `PayloadStatus`.  

Satisfies this condition of the [engine API spec for NewPayload](https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#specification):

> Client software MUST respond to this method call in the following way:
>
> ... other conditions
>
> * `{status: INVALID, latestValidHash: 0x0000000000000000000000000000000000000000000000000000000000000000, validationError: errorMessage | null}` if terminal block conditions are not satisfied
 
Fixes #1676