### PR TITLE
chore: remove redundant handshake traces

### DIFF
--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -66,7 +66,6 @@ where
         let our_status_bytes = our_status_bytes.freeze();
         self.inner.send(our_status_bytes).await?;
 
-        tracing::trace!("waiting for eth status from peer");
         let their_msg_res = self.inner.next().await;
 
         let their_msg = match their_msg_res {

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -90,8 +90,6 @@ where
         P2PMessage::Hello(hello.clone()).encode(&mut raw_hello_bytes);
         self.inner.send(raw_hello_bytes.into()).await?;
 
-        tracing::trace!("waiting for p2p hello from peer");
-
         let first_message_bytes = tokio::time::timeout(HANDSHAKE_TIMEOUT, self.inner.next())
             .await
             .or(Err(P2PStreamError::HandshakeError(P2PHandshakeError::Timeout)))?


### PR DESCRIPTION
These traces are sort of redundant now that we trace the `Hello` and `Status` for each handshake, and they don't emit much useful information