### PR TITLE
feat(txpool): default transaction ordering

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -81,7 +81,7 @@
 
 pub use crate::{
     config::PoolConfig,
-    ordering::TransactionOrdering,
+    ordering::{CostOrdering, TransactionOrdering},
     traits::{
         BestTransactions, OnNewBlockEvent, PoolTransaction, PooledTransaction, PropagateKind,
         PropagatedTransactions, TransactionOrigin, TransactionPool,

--- a/crates/transaction-pool/src/ordering.rs
+++ b/crates/transaction-pool/src/ordering.rs
@@ -1,6 +1,6 @@
-use crate::{traits::PoolTransaction, PooledTransaction};
+use crate::traits::PoolTransaction;
 use reth_primitives::U256;
-use std::fmt;
+use std::{fmt, marker::PhantomData};
 
 /// Transaction ordering trait to determine the order of transactions.
 ///
@@ -26,11 +26,14 @@ pub trait TransactionOrdering: Send + Sync + 'static {
 /// the higher the priority of this transaction is.
 #[derive(Debug, Default)]
 #[non_exhaustive]
-pub struct CostOrdering;
+pub struct CostOrdering<T>(PhantomData<T>);
 
-impl TransactionOrdering for CostOrdering {
+impl<T> TransactionOrdering for CostOrdering<T>
+where
+    T: PoolTransaction + 'static,
+{
     type Priority = U256;
-    type Transaction = PooledTransaction;
+    type Transaction = T;
 
     fn priority(&self, transaction: &Self::Transaction) -> Self::Priority {
         transaction.cost()

--- a/crates/transaction-pool/src/ordering.rs
+++ b/crates/transaction-pool/src/ordering.rs
@@ -1,4 +1,5 @@
-use crate::traits::PoolTransaction;
+use crate::{traits::PoolTransaction, PooledTransaction};
+use reth_primitives::U256;
 use std::fmt;
 
 /// Transaction ordering trait to determine the order of transactions.
@@ -17,4 +18,21 @@ pub trait TransactionOrdering: Send + Sync + 'static {
 
     /// Returns the priority score for the given transaction.
     fn priority(&self, transaction: &Self::Transaction) -> Self::Priority;
+}
+
+/// Default ordering for the pool.
+///
+/// The transactions are ordered by their cost. The higher the cost,
+/// the higher the priority of this transaction is.
+#[derive(Debug, Default)]
+#[non_exhaustive]
+pub struct CostOrdering;
+
+impl TransactionOrdering for CostOrdering {
+    type Priority = U256;
+    type Transaction = PooledTransaction;
+
+    fn priority(&self, transaction: &Self::Transaction) -> Self::Priority {
+        transaction.cost()
+    }
 }


### PR DESCRIPTION
Closes #1642 
Implements default transaction ordering by cost.

I will create a new issue to track the heuristics for "worst" transactions in the parked pools.