### PR TITLE
fix(txpool): proper nonce ordering in parked pools

### DIFF
--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -1,5 +1,7 @@
 use crate::{
-    identifier::TransactionId, pool::size::SizeTracker, PoolTransaction, ValidPoolTransaction,
+    identifier::{SenderId, TransactionId},
+    pool::size::SizeTracker,
+    PoolTransaction, ValidPoolTransaction,
 };
 use fnv::FnvHashMap;
 use std::{cmp::Ordering, collections::BTreeSet, ops::Deref, sync::Arc};
@@ -18,16 +20,17 @@ pub(crate) struct ParkedPool<T: ParkedOrd> {
     ///
     /// This way we can determine when transactions where submitted to the pool.
     submission_id: u64,
-    /// _All_ Transactions that are currently inside the pool grouped by their identifier.
-    by_id: FnvHashMap<TransactionId, ParkedPoolTransaction<T>>,
-    /// All transactions sorted by their order function.
-    ///
-    /// The higher, the better.
+    /// All transactions grouped by their senders.
+    all: FnvHashMap<SenderId, BTreeSet<ParkedPoolTransaction<T>>>,
+    /// The collection of single transaction per sender ordered by their
+    /// order function.
     best: BTreeSet<ParkedPoolTransaction<T>>,
     /// Keeps track of the size of this pool.
     ///
     /// See also [`PoolTransaction::size`].
     size_of: SizeTracker,
+    /// Keeps track of the pool len.
+    len: usize,
 }
 
 // === impl ParkedPool ===
@@ -40,16 +43,27 @@ impl<T: ParkedOrd> ParkedPool<T> {
     /// If the transaction is already included.
     pub(crate) fn add_transaction(&mut self, tx: Arc<ValidPoolTransaction<T::Transaction>>) {
         let id = *tx.id();
-        assert!(!self.by_id.contains_key(&id), "transaction already included");
+        assert!(!self.exists_by_id(&id), "transaction already included");
         let submission_id = self.next_id();
 
         // keep track of size
         self.size_of += tx.size();
+        // keep track of len
+        self.len += 1;
 
-        let transaction = ParkedPoolTransaction { submission_id, transaction: tx.into() };
+        let transaction: ParkedPoolTransaction<T> =
+            ParkedPoolTransaction { submission_id, transaction: tx.into() };
 
-        self.by_id.insert(id, transaction.clone());
-        self.best.insert(transaction);
+        if let Some(existing) =
+            self.best.iter().find(|t| t.transaction.sender_id() == id.sender).cloned()
+        {
+            if transaction.transaction.nonce() < existing.transaction.nonce() {
+                self.best.remove(&existing);
+                self.best.insert(transaction.clone());
+            }
+        }
+
+        self.all.entry(id.sender).or_default().insert(transaction);
     }
 
     /// Removes the transaction from the pool
@@ -57,20 +71,41 @@ impl<T: ParkedOrd> ParkedPool<T> {
         &mut self,
         id: &TransactionId,
     ) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
-        // remove from queues
-        let tx = self.by_id.remove(id)?;
+        // Find target transaction
+        let sender_txs = self.all.get_mut(&id.sender)?;
+        let tx = sender_txs.iter().find(|tx| tx.transaction.id().eq(id)).cloned()?;
+
+        // Remove it from all transactions collection
+        sender_txs.remove(&tx);
+        // Remove it from best transactions if it's there
         self.best.remove(&tx);
 
         // keep track of size
         self.size_of -= tx.transaction.size();
+        // keep track of len
+        self.len -= 1;
 
         Some(tx.transaction.into())
     }
 
     /// Removes the worst transaction from this pool.
     pub(crate) fn pop_worst(&mut self) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
-        let worst = self.best.iter().next().map(|tx| *tx.transaction.id())?;
+        let worst = self.get_worst()?;
         self.remove_transaction(&worst)
+    }
+
+    fn get_worst(&self) -> Option<TransactionId> {
+        // Retrieve worst transaction id from ordered list.
+        let worst_id = self.best.first().map(|tx| *tx.transaction.id())?;
+        // Retrieve the highest nonce transaction for the sender with the worst transaction.
+        self.all.get(&worst_id.sender).and_then(|txs| txs.last()).map(|tx| *tx.transaction.id())
+    }
+
+    fn exists_by_id(&self, id: &TransactionId) -> bool {
+        self.all
+            .get(&id.sender)
+            .map(|txs| txs.iter().any(|tx| tx.transaction.id().eq(id)))
+            .unwrap_or_default()
     }
 
     fn next_id(&mut self) -> u64 {
@@ -86,13 +121,13 @@ impl<T: ParkedOrd> ParkedPool<T> {
 
     /// Number of transactions in the entire pool
     pub(crate) fn len(&self) -> usize {
-        self.by_id.len()
+        self.len
     }
 
     /// Whether the pool is empty
     #[cfg(test)]
     pub(crate) fn is_empty(&self) -> bool {
-        self.by_id.is_empty()
+        self.len == 0
     }
 }
 
@@ -100,9 +135,10 @@ impl<T: ParkedOrd> Default for ParkedPool<T> {
     fn default() -> Self {
         Self {
             submission_id: 0,
-            by_id: Default::default(),
+            all: Default::default(),
             best: Default::default(),
             size_of: Default::default(),
+            len: 0,
         }
     }
 }
@@ -137,12 +173,25 @@ impl<T: ParkedOrd> PartialOrd<Self> for ParkedPoolTransaction<T> {
 
 impl<T: ParkedOrd> Ord for ParkedPoolTransaction<T> {
     fn cmp(&self, other: &Self) -> Ordering {
-        // This compares by the transactions first, and only if two tx are equal this compares
-        // the unique `submission_id`.
-        // "better" transactions are Greater
-        self.transaction
-            .cmp(&other.transaction)
-            .then_with(|| other.submission_id.cmp(&self.submission_id))
+        // The first order comparison function depends on the context of the comparison.
+        // The collection guarantees that the contexts do not overlap.
+        //
+        // 1. If the senders are the same, we assume that all of the transactions we are
+        //    comparing are from the same sender. The nonce will be used for determining the order.
+        //
+        // 2. If the senders are different, we assume that all of the transactions we are
+        //    comparing are from different senders. The underlying order function will be used for
+        //    determining the order.
+        let first_order_cmp = if self.transaction.sender_id().eq(&other.transaction.sender_id()) {
+            self.transaction.nonce().cmp(&other.transaction.nonce())
+        } else {
+            self.transaction.cmp(&other.transaction)
+        };
+
+        // If the transactions are equal according to the first order comparison function,
+        // then we will use the unique `submission_id`. Better transactions have greater
+        // `submission_id`.
+        first_order_cmp.then_with(|| other.submission_id.cmp(&self.submission_id))
     }
 }
 


### PR DESCRIPTION
## Recap

_Parked pools_ are pools with transactions that are parked waiting for external changes (e.g. basefee, ancestors, balance).

## Problem Statement & Solution

The `Ord` trait requires total order and makes it impossible to reliably build an ordered list with transactions from different senders and/or different nonces. This PR introduces grouping transactions by sender and keeping in the ordered list only one transaction per sender at any given point.

## Example

Previously, if we called `pop_worst` function on the parked pool with default ordering (by cost; see #1704), we would evict the transaction with the lowest transaction cost. It is wrong to consider it the worst transaction, since it might have a low nonce and get unlocked sooner than other higher cost transactions in the parked pool. 

The behavior of `pop_worst` function for parked pools was changed to evict the transaction with the highest nonce for the sender whose lowest nonce transaction has the worst cost. 


cc @mattsse open for discussion