### PR TITLE
refactor(sync): td stage consensus checks

### DIFF
--- a/bin/reth/src/chain/import.rs
+++ b/bin/reth/src/chain/import.rs
@@ -152,10 +152,10 @@ impl ImportCommand {
                     NoopStatusUpdater::default(),
                     factory.clone(),
                 )
-                .set(TotalDifficultyStage {
-                    chain_spec: self.chain.clone(),
-                    commit_threshold: config.stages.total_difficulty.commit_threshold,
-                })
+                .set(
+                    TotalDifficultyStage::new(consensus.clone())
+                        .with_commit_threshold(config.stages.total_difficulty.commit_threshold),
+                )
                 .set(SenderRecoveryStage {
                     commit_threshold: config.stages.sender_recovery.commit_threshold,
                 })

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -454,10 +454,10 @@ impl Command {
                     updater,
                     factory.clone(),
                 )
-                .set(TotalDifficultyStage {
-                    chain_spec: self.chain.clone(),
-                    commit_threshold: stage_conf.total_difficulty.commit_threshold,
-                })
+                .set(
+                    TotalDifficultyStage::new(consensus.clone())
+                        .with_commit_threshold(stage_conf.total_difficulty.commit_threshold),
+                )
                 .set(SenderRecoveryStage {
                     commit_threshold: stage_conf.sender_recovery.commit_threshold,
                 })

--- a/crates/stages/src/sets.rs
+++ b/crates/stages/src/sets.rs
@@ -140,7 +140,7 @@ where
     fn builder(self) -> StageSetBuilder<DB> {
         StageSetBuilder::default()
             .add_stage(HeaderStage::new(self.header_downloader, self.consensus.clone()))
-            .add_stage(TotalDifficultyStage::default())
+            .add_stage(TotalDifficultyStage::new(self.consensus.clone()))
             .add_stage(BodyStage { downloader: self.body_downloader, consensus: self.consensus })
     }
 }


### PR DESCRIPTION
Refactor td stage to use consensus client instead of embedded checks for additional header validation