### PR TITLE
fix(sync): preincrement tx transition ids

### DIFF
--- a/crates/storage/db/src/tables/mod.rs
+++ b/crates/storage/db/src/tables/mod.rs
@@ -177,7 +177,7 @@ table!(
     /// Stores the mapping of block number to state transition id.
     /// The block transition marks the final state at the end of the block.
     /// Increment the transition if the block contains an addition block reward.
-    /// If the block does not have a reward and transaction, the transition will be the same as the
+    /// If the block does not have a reward and transactions, the transition will be the same as the
     /// transition at the last transaction of this block.
     ( BlockTransitionIndex ) BlockNumber | TransitionId
 );

--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -155,22 +155,15 @@ where
         Ok(last_transition_id)
     }
 
-    /// Get the next start transaction id and transition for the `block` by looking at the previous
-    /// block. Returns Zero/Zero for Genesis.
-    pub fn get_next_block_ids(
-        &self,
-        block: BlockNumber,
-    ) -> Result<(TxNumber, TransitionId), TransactionError> {
+    /// Get next start transaction id for the block by looking the the previous block.
+    /// Returns `0` for genesis.
+    pub fn get_next_tx_id(&self, block: BlockNumber) -> Result<TxNumber, TransactionError> {
         if block == 0 {
-            return Ok((0, 0))
+            return Ok(0)
         }
 
-        let prev_number = block - 1;
-        let prev_body = self.get_block_body(prev_number)?;
-        let last_transition = self
-            .get::<tables::BlockTransitionIndex>(prev_number)?
-            .ok_or(ProviderError::BlockTransition { block_number: prev_number })?;
-        Ok((prev_body.start_tx_id + prev_body.tx_count, last_transition))
+        let prev_body = self.get_block_body(block - 1)?;
+        Ok(prev_body.start_tx_id + prev_body.tx_count)
     }
 
     /// Query the block header by number


### PR DESCRIPTION
Previously, we had gaps in transition enumeration in blocks that have some transactions **and** a reward.

Example: 
Supposedly, the last block transition is `5` and we are inserting block number 3 with 3 transactions and a reward.
1, 2 and 3 txs would be inserted at indexes 5, 6, 7 and reward at index 9.

WARNING: this is a **breaking** change.