### PR TITLE
chore(txpool): remove Arc for internals

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -148,8 +148,8 @@ where
     T: TransactionOrdering<Transaction = <V as TransactionValidator>::Transaction>,
 {
     /// Create a new transaction pool instance.
-    pub fn new(client: Arc<V>, ordering: Arc<T>, config: PoolConfig) -> Self {
-        Self { pool: Arc::new(PoolInner::new(client, ordering, config)) }
+    pub fn new(validator: V, ordering: T, config: PoolConfig) -> Self {
+        Self { pool: Arc::new(PoolInner::new(validator, ordering, config)) }
     }
 
     /// Returns the wrapped pool.
@@ -302,7 +302,7 @@ where
     }
 }
 
-impl<V: TransactionValidator, O: TransactionOrdering> Clone for Pool<V, O> {
+impl<V: TransactionValidator, T: TransactionOrdering> Clone for Pool<V, T> {
     fn clone(&self) -> Self {
         Self { pool: Arc::clone(&self.pool) }
     }

--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -83,7 +83,7 @@ mod tests {
 
     #[test]
     fn test_best_iter() {
-        let mut pool = PendingPool::new(Arc::new(MockOrdering::default()));
+        let mut pool = PendingPool::new(MockOrdering::default());
         let mut f = MockTransactionFactory::default();
 
         let num_tx = 10;
@@ -109,7 +109,7 @@ mod tests {
 
     #[test]
     fn test_best_iter_invalid() {
-        let mut pool = PendingPool::new(Arc::new(MockOrdering::default()));
+        let mut pool = PendingPool::new(MockOrdering::default());
         let mut f = MockTransactionFactory::default();
 
         let num_tx = 10;

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -100,7 +100,7 @@ pub struct PoolInner<V: TransactionValidator, T: TransactionOrdering> {
     /// Internal mapping of addresses to plain ints.
     identifiers: RwLock<SenderIdentifiers>,
     /// Transaction validation.
-    validator: Arc<V>,
+    validator: V,
     /// The internal pool that manages all transactions.
     pool: RwLock<TxPool<T>>,
     /// Pool settings.
@@ -115,13 +115,13 @@ pub struct PoolInner<V: TransactionValidator, T: TransactionOrdering> {
 
 // === impl PoolInner ===
 
-impl<V: TransactionValidator, T: TransactionOrdering> PoolInner<V, T>
+impl<V, T> PoolInner<V, T>
 where
     V: TransactionValidator,
     T: TransactionOrdering<Transaction = <V as TransactionValidator>::Transaction>,
 {
     /// Create a new transaction pool instance.
-    pub(crate) fn new(validator: Arc<V>, ordering: Arc<T>, config: PoolConfig) -> Self {
+    pub(crate) fn new(validator: V, ordering: T, config: PoolConfig) -> Self {
         Self {
             identifiers: Default::default(),
             validator,

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -22,7 +22,7 @@ use std::{
 /// is also pending, then this will be moved to the `independent` queue.
 pub(crate) struct PendingPool<T: TransactionOrdering> {
     /// How to order transactions.
-    ordering: Arc<T>,
+    ordering: T,
     /// Keeps track of transactions inserted in the pool.
     ///
     /// This way we can determine when transactions where submitted to the pool.
@@ -46,7 +46,7 @@ pub(crate) struct PendingPool<T: TransactionOrdering> {
 
 impl<T: TransactionOrdering> PendingPool<T> {
     /// Create a new pool instance.
-    pub(crate) fn new(ordering: Arc<T>) -> Self {
+    pub(crate) fn new(ordering: T) -> Self {
         Self {
             ordering,
             submission_id: 0,

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -98,7 +98,7 @@ pub struct TxPool<T: TransactionOrdering> {
 
 impl<T: TransactionOrdering> TxPool<T> {
     /// Create a new graph pool instance.
-    pub(crate) fn new(ordering: Arc<T>, config: PoolConfig) -> Self {
+    pub(crate) fn new(ordering: T, config: PoolConfig) -> Self {
         Self {
             sender_info: Default::default(),
             pending_pool: PendingPool::new(ordering),

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -23,7 +23,7 @@ pub type MockValidTx = ValidPoolTransaction<MockTransaction>;
 
 /// Create an empty `TxPool`
 pub(crate) fn mock_tx_pool() -> MockTxPool {
-    MockTxPool::new(Arc::new(Default::default()), Default::default())
+    MockTxPool::new(Default::default(), Default::default())
 }
 
 /// Sets the value for the field

--- a/crates/transaction-pool/src/test_utils/mod.rs
+++ b/crates/transaction-pool/src/test_utils/mod.rs
@@ -16,11 +16,7 @@ pub type TestPool = Pool<NoopTransactionValidator<MockTransaction>, MockOrdering
 
 /// Returns a new [Pool] used for testing purposes
 pub fn testing_pool() -> TestPool {
-    Pool::new(
-        Arc::new(NoopTransactionValidator::default()),
-        Arc::new(MockOrdering::default()),
-        Default::default(),
-    )
+    Pool::new(NoopTransactionValidator::default(), MockOrdering::default(), Default::default())
 }
 
 // A [`TransactionValidator`] that does nothing.

--- a/crates/transaction-pool/src/test_utils/pool.rs
+++ b/crates/transaction-pool/src/test_utils/pool.rs
@@ -41,7 +41,7 @@ impl MockPool {
 
 impl Default for MockPool {
     fn default() -> Self {
-        Self { pool: TxPool::new(Arc::new(MockOrdering::default()), Default::default()) }
+        Self { pool: TxPool::new(MockOrdering::default(), Default::default()) }
     }
 }
 


### PR DESCRIPTION
everything inside `Pool` is already put in an Arc, so no need to require that the validator and ordering are also Arc