### PR TITLE
feat: add ReceiptProvider

### DIFF
--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -12,8 +12,8 @@
 mod traits;
 pub use traits::{
     AccountProvider, BlockExecutor, BlockHashProvider, BlockIdProvider, BlockProvider,
-    EvmEnvProvider, ExecutorFactory, HeaderProvider, StateProvider, StateProviderFactory,
-    TransactionsProvider, WithdrawalsProvider,
+    EvmEnvProvider, ExecutorFactory, HeaderProvider, ReceiptProvider, StateProvider,
+    StateProviderFactory, TransactionsProvider, WithdrawalsProvider,
 };
 
 /// Provider trait implementations.

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -1,13 +1,13 @@
 use crate::{
-    AccountProvider, BlockHashProvider, BlockIdProvider, BlockProvider, EvmEnvProvider,
-    HeaderProvider, StateProvider, StateProviderFactory, TransactionsProvider,
+    traits::ReceiptProvider, AccountProvider, BlockHashProvider, BlockIdProvider, BlockProvider,
+    EvmEnvProvider, HeaderProvider, StateProvider, StateProviderFactory, TransactionsProvider,
 };
 use parking_lot::Mutex;
 use reth_interfaces::Result;
 use reth_primitives::{
     keccak256, Account, Address, Block, BlockHash, BlockId, BlockNumber, BlockNumberOrTag,
-    Bytecode, Bytes, ChainInfo, Header, StorageKey, StorageValue, TransactionSigned, TxHash, H256,
-    U256,
+    Bytecode, Bytes, ChainInfo, Header, Receipt, StorageKey, StorageValue, TransactionSigned,
+    TxHash, TxNumber, H256, U256,
 };
 use revm_primitives::{BlockEnv, CfgEnv};
 use std::{collections::HashMap, ops::RangeBounds, sync::Arc};
@@ -153,6 +153,20 @@ impl TransactionsProvider for MockEthProvider {
         _range: impl RangeBounds<reth_primitives::BlockNumber>,
     ) -> Result<Vec<Vec<TransactionSigned>>> {
         unimplemented!()
+    }
+}
+
+impl ReceiptProvider for MockEthProvider {
+    fn receipt(&self, _id: TxNumber) -> Result<Option<Receipt>> {
+        Ok(None)
+    }
+
+    fn receipt_by_hash(&self, _hash: TxHash) -> Result<Option<Receipt>> {
+        Ok(None)
+    }
+
+    fn receipts_by_block(&self, _block: BlockId) -> Result<Option<Vec<Receipt>>> {
+        Ok(None)
     }
 }
 

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -1,10 +1,10 @@
 use crate::{
-    AccountProvider, BlockHashProvider, BlockIdProvider, BlockProvider, EvmEnvProvider,
-    HeaderProvider, StateProvider, StateProviderFactory, TransactionsProvider,
+    traits::ReceiptProvider, AccountProvider, BlockHashProvider, BlockIdProvider, BlockProvider,
+    EvmEnvProvider, HeaderProvider, StateProvider, StateProviderFactory, TransactionsProvider,
 };
 use reth_interfaces::Result;
 use reth_primitives::{
-    Account, Address, Block, BlockHash, BlockId, BlockNumber, Bytecode, ChainInfo, Header,
+    Account, Address, Block, BlockHash, BlockId, BlockNumber, Bytecode, ChainInfo, Header, Receipt,
     StorageKey, StorageValue, TransactionSigned, TxHash, TxNumber, H256, U256,
 };
 use revm_primitives::{BlockEnv, CfgEnv};
@@ -60,6 +60,20 @@ impl TransactionsProvider for NoopProvider {
         _range: impl RangeBounds<BlockNumber>,
     ) -> Result<Vec<Vec<TransactionSigned>>> {
         Ok(Vec::default())
+    }
+}
+
+impl ReceiptProvider for NoopProvider {
+    fn receipt(&self, _id: TxNumber) -> Result<Option<Receipt>> {
+        Ok(None)
+    }
+
+    fn receipt_by_hash(&self, _hash: TxHash) -> Result<Option<Receipt>> {
+        Ok(None)
+    }
+
+    fn receipts_by_block(&self, _block: BlockId) -> Result<Option<Vec<Receipt>>> {
+        Ok(None)
     }
 }
 

--- a/crates/storage/provider/src/traits/mod.rs
+++ b/crates/storage/provider/src/traits/mod.rs
@@ -19,7 +19,7 @@ mod header;
 pub use header::HeaderProvider;
 
 mod receipts;
-pub(crate) use receipts::ReceiptProvider;
+pub use receipts::ReceiptProvider;
 
 mod state;
 pub use state::{StateProvider, StateProviderFactory};

--- a/crates/storage/provider/src/traits/mod.rs
+++ b/crates/storage/provider/src/traits/mod.rs
@@ -18,6 +18,9 @@ pub use evm_env::EvmEnvProvider;
 mod header;
 pub use header::HeaderProvider;
 
+mod receipts;
+pub(crate) use receipts::ReceiptProvider;
+
 mod state;
 pub use state::{StateProvider, StateProviderFactory};
 

--- a/crates/storage/provider/src/traits/receipts.rs
+++ b/crates/storage/provider/src/traits/receipts.rs
@@ -3,7 +3,7 @@ use reth_primitives::{BlockId, Receipt, TxHash, TxNumber};
 
 ///  Client trait for fetching [Receipt] data .
 #[auto_impl::auto_impl(&, Arc)]
-pub(crate) trait ReceiptProvider: Send + Sync {
+pub trait ReceiptProvider: Send + Sync {
     /// Get receipt by transaction number
     fn receipt(&self, id: TxNumber) -> Result<Option<Receipt>>;
 

--- a/crates/storage/provider/src/traits/receipts.rs
+++ b/crates/storage/provider/src/traits/receipts.rs
@@ -1,0 +1,15 @@
+use reth_interfaces::Result;
+use reth_primitives::{BlockId, Receipt, TxHash, TxNumber};
+
+///  Client trait for fetching [Receipt] data .
+#[auto_impl::auto_impl(&, Arc)]
+pub(crate) trait ReceiptProvider: Send + Sync {
+    /// Get receipt by transaction number
+    fn receipt(&self, id: TxNumber) -> Result<Option<Receipt>>;
+
+    /// Get receipt by transaction hash.
+    fn receipt_by_hash(&self, hash: TxHash) -> Result<Option<Receipt>>;
+
+    /// Get receipts by block id.
+    fn receipts_by_block(&self, block: BlockId) -> Result<Option<Vec<Receipt>>>;
+}


### PR DESCRIPTION
closes #1734 

Adds `ReceiptProvider` trait for fetching receipt for a transaction or block.

this works just like the `TransactionProvider`