### PR TITLE
fix: default  to correct ws port in rpc server args

### DIFF
--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -206,7 +206,7 @@ impl RpcServerArgs {
         if self.ws {
             let socket_address = SocketAddr::new(
                 self.ws_addr.unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED)),
-                self.ws_port.unwrap_or(constants::DEFAULT_HTTP_RPC_PORT),
+                self.ws_port.unwrap_or(constants::DEFAULT_WS_RPC_PORT),
             );
             config = config.with_ws_address(socket_address).with_http(ServerBuilder::new());
         }


### PR DESCRIPTION
I believe the default ws port should be read from DEFAULT_WS_RPC_PORT