### PR TITLE
fix(rpc): use eth id provider for filter

### DIFF
--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -1,12 +1,10 @@
 use crate::{
     eth::error::EthApiError,
     result::{internal_rpc_err, rpc_error_with_code, ToRpcResult},
+    EthSubscriptionIdProvider,
 };
 use async_trait::async_trait;
-use jsonrpsee::{
-    core::RpcResult,
-    server::{IdProvider, RandomIntegerIdProvider},
-};
+use jsonrpsee::{core::RpcResult, server::IdProvider};
 use reth_primitives::{
     filter::{Filter, FilterBlockOption, FilteredParams},
     Block, U256,
@@ -36,7 +34,7 @@ impl<Client, Pool> EthFilter<Client, Pool> {
             client,
             active_filters: Default::default(),
             pool,
-            id_provider: Arc::new(RandomIntegerIdProvider),
+            id_provider: Arc::new(EthSubscriptionIdProvider::default()),
             max_logs_in_response: DEFAULT_MAX_LOGS_IN_RESPONSE,
         };
         Self { inner: Arc::new(inner) }


### PR DESCRIPTION
filter should return a QUANTITY ids as string.

instead of random alternatively, we could increment but conflicts via u128 are not likely.