### PR TITLE
fix(stages): clear pre-eip161 accounts

### DIFF
--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -185,7 +185,7 @@ where
                                     new: to_reth_acc(&account.info),
                                 }
                             } else {
-                                AccountInfoChangeSet::NoChange
+                                AccountInfoChangeSet::NoChange { is_empty: account.is_empty() }
                             };
                         entry.info = account.info.clone();
                         (account_changeset, entry)
@@ -709,7 +709,7 @@ mod tests {
 
         assert_eq!(
             changesets.changeset.get(&account1).unwrap().account,
-            AccountInfoChangeSet::NoChange,
+            AccountInfoChangeSet::NoChange { is_empty: true },
             "No change to account"
         );
         assert_eq!(

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -709,7 +709,7 @@ mod tests {
 
         assert_eq!(
             changesets.changeset.get(&account1).unwrap().account,
-            AccountInfoChangeSet::NoChange { is_empty: true },
+            AccountInfoChangeSet::NoChange { is_empty: false },
             "No change to account"
         );
         assert_eq!(

--- a/crates/storage/provider/src/execution_result.rs
+++ b/crates/storage/provider/src/execution_result.rs
@@ -1,11 +1,6 @@
 //! Output of execution.
 
-use reth_db::{
-    models::AccountBeforeTx,
-    tables,
-    transaction::{DbTx, DbTxMut},
-    Error as DbError,
-};
+use reth_db::{models::AccountBeforeTx, tables, transaction::DbTxMut, Error as DbError};
 use reth_primitives::{Account, Address, Receipt, H256, U256};
 use revm_primitives::Bytecode;
 use std::collections::BTreeMap;
@@ -66,7 +61,7 @@ pub enum AccountInfoChangeSet {
 
 impl AccountInfoChangeSet {
     /// Apply the changes from the changeset to a database transaction.
-    pub fn apply_to_db<'a, TX: DbTxMut<'a> + DbTx<'a>>(
+    pub fn apply_to_db<'a, TX: DbTxMut<'a>>(
         self,
         tx: &TX,
         address: Address,


### PR DESCRIPTION
This makes sure that empty accounts created pre-eip161 are cleared from state accordingly. 

This was causing state root mismatch at 2675000 / spurious dragon hardfork