### PR TITLE
chore(txpool): add IntoRecoveredTransaction to PoolTransaction

### DIFF
--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -250,7 +250,9 @@ impl<T> BestTransactions for std::iter::Empty<T> {
 }
 
 /// Trait for transaction types used inside the pool
-pub trait PoolTransaction: fmt::Debug + Send + Sync + FromRecoveredTransaction {
+pub trait PoolTransaction:
+    fmt::Debug + Send + Sync + FromRecoveredTransaction + IntoRecoveredTransaction
+{
     /// Hash of the transaction.
     fn hash(&self) -> &TxHash;
 

--- a/crates/transaction-pool/src/validate.rs
+++ b/crates/transaction-pool/src/validate.rs
@@ -7,8 +7,9 @@ use crate::{
     MAX_INIT_CODE_SIZE, TX_MAX_SIZE,
 };
 use reth_primitives::{
-    Address, InvalidTransactionError, TransactionKind, TxHash, EIP1559_TX_TYPE_ID,
-    EIP2930_TX_TYPE_ID, LEGACY_TX_TYPE_ID, U256,
+    Address, IntoRecoveredTransaction, InvalidTransactionError, TransactionKind,
+    TransactionSignedEcRecovered, TxHash, EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID,
+    LEGACY_TX_TYPE_ID, U256,
 };
 use reth_provider::AccountProvider;
 use std::{fmt, time::Instant};
@@ -327,6 +328,12 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
     /// The heap allocated size of this transaction.
     pub(crate) fn size(&self) -> usize {
         self.transaction.size()
+    }
+}
+
+impl<T: PoolTransaction> IntoRecoveredTransaction for ValidPoolTransaction<T> {
+    fn to_recovered_transaction(&self) -> TransactionSignedEcRecovered {
+        self.transaction.to_recovered_transaction()
     }
 }
 


### PR DESCRIPTION
add missing trait bound to `PoolTransaction`.

we want this so we can easily convert from and to `TransactionSignedEcRecovered`