### PR TITLE
fix: make ChainState provider work for Box<dyn StateProvider>

### DIFF
--- a/crates/executor/src/blockchain_tree/chain.rs
+++ b/crates/executor/src/blockchain_tree/chain.rs
@@ -348,7 +348,7 @@ mod tests {
         let mut block1 = block.clone();
         let mut block2 = block.clone();
         let mut block3 = block.clone();
-        let mut block4 = block.clone();
+        let mut block4 = block;
 
         block1.block.header.hash = block1_hash;
         block2.block.header.hash = block2_hash;
@@ -360,13 +360,13 @@ mod tests {
         let mut chain1 = Chain {
             substate: Default::default(),
             changesets: vec![],
-            blocks: BTreeMap::from([(1, block1.clone()), (2, block2.clone())]),
+            blocks: BTreeMap::from([(1, block1), (2, block2)]),
         };
 
         let chain2 = Chain {
             substate: Default::default(),
             changesets: vec![],
-            blocks: BTreeMap::from([(3, block3.clone()), (4, block4.clone())]),
+            blocks: BTreeMap::from([(3, block3), (4, block4)]),
         };
 
         assert_eq!(chain1.append_chain(chain2.clone()), Ok(()));
@@ -418,7 +418,7 @@ mod tests {
         // split in two
         assert_eq!(
             chain.clone().split(SplitAt::Hash(block1_hash)),
-            ChainSplit::Split { canonical: chain_split1.clone(), pending: chain_split2.clone() }
+            ChainSplit::Split { canonical: chain_split1, pending: chain_split2 }
         );
 
         // split at unknown block hash
@@ -433,9 +433,6 @@ mod tests {
             ChainSplit::NoSplitCanonical(chain.clone())
         );
         // split at lower number
-        assert_eq!(
-            chain.clone().split(SplitAt::Number(0)),
-            ChainSplit::NoSplitPending(chain.clone())
-        );
+        assert_eq!(chain.clone().split(SplitAt::Number(0)), ChainSplit::NoSplitPending(chain));
     }
 }

--- a/crates/storage/provider/src/providers/state/chain.rs
+++ b/crates/storage/provider/src/providers/state/chain.rs
@@ -2,7 +2,6 @@ use crate::{
     providers::state::macros::delegate_provider_impls, AccountProvider, BlockHashProvider,
     StateProvider,
 };
-use std::marker::PhantomData;
 
 /// A type that can access the state at a specific access point (block number or tag)
 ///
@@ -16,16 +15,20 @@ use std::marker::PhantomData;
 ///
 /// Note: The lifetime of this type is limited by the type that created it.
 pub struct ChainState<'a> {
-    inner: Box<dyn StateProvider>,
-    _phantom: PhantomData<&'a ()>,
+    inner: Box<dyn StateProvider + 'a>,
 }
 
 // == impl ChainState ===
 
 impl<'a> ChainState<'a> {
     /// Wraps the given [StateProvider]
-    pub fn new(inner: Box<dyn StateProvider>) -> Self {
-        Self { inner, _phantom: Default::default() }
+    pub fn boxed<S: StateProvider + 'a>(inner: S) -> Self {
+        Self::new(Box::new(inner))
+    }
+
+    /// Wraps the given [StateProvider]
+    pub fn new(inner: Box<dyn StateProvider + 'a>) -> Self {
+        Self { inner }
     }
 
     /// Returns a new provider that takes the `TX` as reference


### PR DESCRIPTION
move lifetime to dyn StateProvider type to make rust happy.

can now easily box StateProvider types.