### PR TITLE
chore(deps): remove unused deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5298,11 +5298,9 @@ name = "reth-stages"
 version = "0.1.0"
 dependencies = [
  "aquamarine",
- "arbitrary",
  "assert_matches",
  "async-trait",
  "criterion",
- "eyre",
  "futures-util",
  "itertools 0.10.5",
  "metrics",
@@ -5310,7 +5308,6 @@ dependencies = [
  "paste",
  "pin-project",
  "pprof",
- "proptest",
  "rand 0.8.5",
  "rayon",
  "reth-codecs",
@@ -5323,8 +5320,6 @@ dependencies = [
  "reth-primitives",
  "reth-provider",
  "reth-rlp",
- "serde",
- "tempfile",
  "thiserror",
  "tokio",
  "tokio-stream",

--- a/crates/stages/Cargo.toml
+++ b/crates/stages/Cargo.toml
@@ -34,16 +34,10 @@ tracing = "0.1.36"
 metrics = "0.20.1"
 
 # misc
-serde = { version = "1.0", optional = true }
 thiserror = "1.0.37"
 aquamarine = "0.2.1" #docs
-itertools = "0.10.5"
 rayon = "1.6.0"
 num-traits = "0.2.15"
-
-# arbitrary utils
-arbitrary = { version = "1.1.7", features = ["derive"], optional = true }
-proptest = { version = "1.0", optional = true }
 
 [dev-dependencies]
 # reth
@@ -54,8 +48,9 @@ reth-downloaders = { path = "../net/downloaders" }
 reth-eth-wire = { path = "../net/eth-wire" }                            # TODO(onbjerg): We only need this for [BlockBody]
 reth-executor = { path = "../executor" }
 reth-rlp = { path = "../rlp" }
+
+itertools = "0.10.5"
 tokio = { version = "*", features = ["rt", "sync", "macros"] }
-tempfile = "3.3.0"
 assert_matches = "1.5.0"
 rand = "0.8.5"
 paste = "1.0"
@@ -67,13 +62,8 @@ pprof = { version = "0.11", features = [
     "criterion",
 ] }
 criterion = { version = "0.4.0", features = ["async_futures"] }
-proptest = { version = "1.0" }
-arbitrary = { version = "1.1.7", features = ["derive"] }
-eyre = "0.6.8"
 
 [features]
-default = ["serde"]
-serde = ["dep:serde"]
 test-utils = []
 
 

--- a/crates/stages/benches/setup/mod.rs
+++ b/crates/stages/benches/setup/mod.rs
@@ -45,10 +45,10 @@ pub(crate) fn stage_unwind<S: Clone + Stage<Env<WriteMap>>>(
             .unwind(&mut db_tx, unwind)
             .await
             .map_err(|e| {
-                eyre::eyre!(format!(
+                format!(
                     "{e}\nMake sure your test database at `{}` isn't too old and incompatible with newer stage changes.",
                     tx.path.as_ref().unwrap().display()
-                ))
+                )
             })
             .unwrap();
 


### PR DESCRIPTION
remove unused deps in reth-stages

unfortunately the unused_crate_dependencies lint does not play very nice with criterion and always leads to false positives with bench code