### PR TITLE
fix: fn visibility build error

### DIFF
--- a/crates/executor/src/blockchain_tree/block_indices.rs
+++ b/crates/executor/src/blockchain_tree/block_indices.rs
@@ -247,7 +247,7 @@ impl BlockIndices {
     /// NOTE: This is not safe standalone, as it will not disconnect
     /// blocks that deppends on unwinded canonical chain. And should be
     /// used when canonical chain is reinserted inside Tree.
-    fn unwind_canonical_chain(&mut self, unwind_to: BlockNumber) {
+    pub(super) fn unwind_canonical_chain(&mut self, unwind_to: BlockNumber) {
         // this will remove all blocks numbers that are going to be replaced.
         self.canonical_chain.retain(|num, _| *num <= unwind_to);
     }


### PR DESCRIPTION
ran into a build error on a fresh clone on main, introduced in #1775; discussion there says to not expose the fn in question so `pub(super)` seems like the most restricted visibility level that fixes the issue