### PR TITLE
ci: re-introduce running CI on ubuntu-latest

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -15,9 +15,7 @@ concurrency:
 name: bench
 jobs:
   iai:
-    # Pin to `20.04` instead of `ubuntu-latest`, until ubuntu-latest migration is complete
-    # See also <https://github.com/foundry-rs/foundry/issues/3827>
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Install Valgrind
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,7 @@ name: ci
 jobs:
   lint:
     name: code lint
-    # Pin to `20.04` instead of `ubuntu-latest`, until ubuntu-latest migration is complete
-    # See also <https://github.com/foundry-rs/foundry/issues/3827>
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -18,10 +18,7 @@ jobs:
     # Skip the Fuzzing Jobs until we make them run fast and reliably. Currently they will
     # always recompile the codebase for each test and that takes way too long.
     if: false
-
-    # Pin to `20.04` instead of `ubuntu-latest`, until ubuntu-latest migration is complete
-    # See also <https://github.com/foundry-rs/foundry/issues/3827>
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         target:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,10 +16,8 @@ concurrency:
 name: integration
 jobs:
   test:
-    # Pin to `20.04` instead of `ubuntu-latest`, until ubuntu-latest migration is complete
-    # See also <https://github.com/foundry-rs/foundry/issues/3827>
     name: test (partition ${{ matrix.partition }}/${{ strategy.job-total }})
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         partition: [1, 2]

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -15,9 +15,7 @@ env:
 name: sanity
 jobs:
   dep-version-constraints:
-    # Pin to `20.04` instead of `ubuntu-latest`, until ubuntu-latest migration is complete
-    # See also <https://github.com/foundry-rs/foundry/issues/3827>
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: dep version constraints
     steps:
       - name: Checkout sources
@@ -60,9 +58,7 @@ jobs:
           filename: .github/SANITY_DEPS_ISSUE_TEMPLATE.md
 
   unused-deps:
-    # Pin to `20.04` instead of `ubuntu-latest`, until ubuntu-latest migration is complete
-    # See also <https://github.com/foundry-rs/foundry/issues/3827>
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: unused dependencies
     steps:
       - name: Checkout sources

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -15,10 +15,8 @@ concurrency:
 name: unit
 jobs:
   test:
-    # Pin to `20.04` instead of `ubuntu-latest`, until ubuntu-latest migration is complete
-    # See also <https://github.com/foundry-rs/foundry/issues/3827>
     name: test (partition ${{ matrix.partition }}/${{ strategy.job-total }})
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         partition: [1, 2, 3]


### PR DESCRIPTION
Hej there,

I want to open this PR to see if the issue with `glibc` not being available on `ubuntu-latest` mentioned here https://github.com/foundry-rs/foundry/issues/3827 is still relevant.

I went ahead to replace the pinned ubuntu version `20-04` and replaced it with `latest`, which at the time of this PR is `22-04`