### PR TITLE
chore(blockchain_tree): wrap tree database in `Arc`

### DIFF
--- a/crates/executor/src/blockchain_tree/externals.rs
+++ b/crates/executor/src/blockchain_tree/externals.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 #[derive(Debug)]
 pub struct TreeExternals<DB, C, EF> {
     /// The database, used to commit the canonical chain, or unwind it.
-    pub db: DB,
+    pub db: Arc<DB>,
     /// The consensus engine.
     pub consensus: C,
     /// The executor factory to execute blocks with.
@@ -28,7 +28,12 @@ pub struct TreeExternals<DB, C, EF> {
 
 impl<DB, C, EF> TreeExternals<DB, C, EF> {
     /// Create new tree externals.
-    pub fn new(db: DB, consensus: C, executor_factory: EF, chain_spec: Arc<ChainSpec>) -> Self {
+    pub fn new(
+        db: Arc<DB>,
+        consensus: C,
+        executor_factory: EF,
+        chain_spec: Arc<ChainSpec>,
+    ) -> Self {
         Self { db, consensus, executor_factory, chain_spec }
     }
 }

--- a/crates/executor/src/blockchain_tree/mod.rs
+++ b/crates/executor/src/blockchain_tree/mod.rs
@@ -697,7 +697,7 @@ mod tests {
 
     fn setup_externals(
         exec_res: Vec<PostState>,
-    ) -> TreeExternals<Arc<Env<WriteMap>>, Arc<TestConsensus>, TestFactory> {
+    ) -> TreeExternals<Env<WriteMap>, Arc<TestConsensus>, TestFactory> {
         let db = create_test_rw_db();
         let consensus = Arc::new(TestConsensus::default());
         let chain_spec = Arc::new(


### PR DESCRIPTION
The pipeline requires the database to be wrapped in `Arc`. Mirror this behavior to the `BlockchainTree` to avoid using two generics for essentially the same type when `Pipeline` and `BlockchainTree` are used together.