### PR TITLE
feat(rpc): impl debug_getRawBlock/Header/Tx

### DIFF
--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -491,7 +491,10 @@ where
     /// Register Debug Namespace
     pub fn register_debug(&mut self) -> &mut Self {
         let eth_api = self.eth_api();
-        self.modules.insert(RethRpcModule::Debug, DebugApi::new(eth_api).into_rpc().into());
+        self.modules.insert(
+            RethRpcModule::Debug,
+            DebugApi::new(self.client.clone(), eth_api).into_rpc().into(),
+        );
         self
     }
 
@@ -541,7 +544,9 @@ where
                         RethRpcModule::Admin => {
                             AdminApi::new(self.network.clone()).into_rpc().into()
                         }
-                        RethRpcModule::Debug => DebugApi::new(eth_api.clone()).into_rpc().into(),
+                        RethRpcModule::Debug => {
+                            DebugApi::new(self.client.clone(), eth_api.clone()).into_rpc().into()
+                        }
                         RethRpcModule::Eth => eth_api.clone().into_rpc().into(),
                         RethRpcModule::Net => {
                             NetApi::new(self.network.clone(), eth_api.clone()).into_rpc().into()

--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -130,11 +130,9 @@ where
 {
     let block_id = BlockId::Number(BlockNumberOrTag::default());
 
-    assert!(is_unimplemented(DebugApiClient::raw_header(client, block_id).await.err().unwrap()));
-    assert!(is_unimplemented(DebugApiClient::raw_block(client, block_id).await.err().unwrap()));
-    assert!(is_unimplemented(
-        DebugApiClient::raw_transaction(client, H256::default()).await.err().unwrap()
-    ));
+    DebugApiClient::raw_header(client, block_id).await.unwrap();
+    DebugApiClient::raw_block(client, block_id).await.unwrap();
+    DebugApiClient::raw_transaction(client, H256::default()).await.unwrap();
     assert!(is_unimplemented(DebugApiClient::raw_receipts(client, block_id).await.err().unwrap()));
     assert!(is_unimplemented(DebugApiClient::bad_blocks(client).await.err().unwrap()));
 }

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -138,7 +138,7 @@ where
                     self.client.convert_block_number(number_or_tag).to_rpc_result()?.ok_or(
                         jsonrpsee::core::Error::Custom("Pending block not supported".to_string()),
                     )?;
-                self.client.header_by_number(number).unwrap()
+                self.client.header_by_number(number).to_rpc_result()?
             }
         };
 

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -168,11 +168,7 @@ where
         let tx = self.eth_api.transaction_by_hash(hash).await?;
 
         let mut res = Vec::new();
-        if let Some(tx) = tx {
-            let tx = match tx {
-                TransactionSource::Pool(tx) => tx,
-                TransactionSource::Database { transaction, .. } => transaction,
-            };
+        if let Some(tx) = tx.map(TransactionSource::into_recovered) {
             tx.encode(&mut res);
         }
 


### PR DESCRIPTION
As title, starting to implement the missing methods for Hive's `rpc-compat` sim. #851 
* debug_getRawBlock / Header / Transaction

This is currently not correct, here's a hive log:
1. We seem to be encoding an additional `c0` which is an empty list, could that be withdrawals? (cc @rkrasiuk )
![image](https://user-images.githubusercontent.com/17802178/226227710-3087db97-3d1e-47e1-a7d1-56e44ea798fc.png)

```
>>  {"jsonrpc":"2.0","id":1,"method":"debug_getRawBlock","params":["0x3"]}
<<  {"jsonrpc":"2.0","result":"0xf90287f90218a0fe21bb173f43067a9f90cfc59bbb6830a7a2929b5de4a61f372a9db28e87f9aea01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347940000000000000000000000000000000000000000a061effbbcca94f0d3e02e5bd22e986ad57142acabf0cb3d129a6ad8d0f8752e94a0d911c25e97e27898680d242b7780b6faef30995c355a2d5de92e6b9a7212ad3aa0056b23fbba480696b65fe5a59b8f2148a1299103c4f57df839233af2cf4ca2d2b90100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008003834c4b408252081e80a00000000000000000000000000000000000000000000000000000000000000000880000000000000000842806be9da056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421f869f86702842806be9e82520894658bdf435d810c91414ec09147daa6db624063798203e880820a95a040ce7918eeb045ebf8c8b1887ca139d076bda00fa828a07881d442a72626c42da0156576a68e456e295e4c9cf67cf9f53151f329438916e0f24fc69d6bbb7fbacfc0","id":1}
response differs from expected:
 {
   "id": 1,
   "jsonrpc": "2.0",
-  "result": "0xf90287f90218a0fe21bb173f43067a9f90cfc59bbb6830a7a2929b5de4a61f372a9db28e87f9aea01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347940000000000000000000000000000000000000000a061effbbcca94f0d3e02e5bd22e986ad57142acabf0cb3d129a6ad8d0f8752e94a0d911c25e97e27898680d242b7780b6faef30995c355a2d5de92e6b9a7212ad3aa0056b23fbba480696b65fe5a59b8f2148a1299103c4f57df839233af2cf4ca2d2b90100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008003834c4b408252081e80a00000000000000000000000000000000000000000000000000000000000000000880000000000000000842806be9da056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421f869f86702842806be9e82520894658bdf435d810c91414ec09147daa6db624063798203e880820a95a040ce7918eeb045ebf8c8b1887ca139d076bda00fa828a07881d442a72626c42da0156576a68e456e295e4c9cf67cf9f53151f329438916e0f24fc69d6bbb7fbacfc0"
+  "result": "0xf90288f90218a0fe21bb173f43067a9f90cfc59bbb6830a7a2929b5de4a61f372a9db28e87f9aea01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347940000000000000000000000000000000000000000a061effbbcca94f0d3e02e5bd22e986ad57142acabf0cb3d129a6ad8d0f8752e94a0d911c25e97e27898680d242b7780b6faef30995c355a2d5de92e6b9a7212ad3aa0056b23fbba480696b65fe5a59b8f2148a1299103c4f57df839233af2cf4ca2d2b90100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008003834c4b408252081e80a00000000000000000000000000000000000000000000000000000000000000000880000000000000000842806be9da056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421f869f86702842806be9e82520894658bdf435d810c91414ec09147daa6db624063798203e880820a95a040ce7918eeb045ebf8c8b1887ca139d076bda00fa828a07881d442a72626c42da0156576a68e456e295e4c9cf67cf9f53151f329438916e0f24fc69d6bbb7fbacfc0c0"
 }

```

(Same below)

```
>>  {"jsonrpc":"2.0","id":1,"method":"debug_getRawBlock","params":["0x0"]}
<<  {"jsonrpc":"2.0","result":"0xf9021bf90216a00000000000000000000000000000000000000000000000000000000000000000a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347940000000000000000000000000000000000000000a0078dc6061b1d8eaa8493384b59c9c65ceb917201221d08b80c4de6770b6ec7e7a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b90100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000180834c4b40808080a00000000000000000000000000000000000000000000000000000000000000000880000000000000000843b9aca00a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421c0c0","id":1}
response differs from expected:
 {
   "id": 1,
   "jsonrpc": "2.0",
-  "result": "0xf9021bf90216a00000000000000000000000000000000000000000000000000000000000000000a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347940000000000000000000000000000000000000000a0078dc6061b1d8eaa8493384b59c9c65ceb917201221d08b80c4de6770b6ec7e7a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b90100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000180834c4b40808080a00000000000000000000000000000000000000000000000000000000000000000880000000000000000843b9aca00a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421c0c0"
+  "result": "0xf9021cf90216a00000000000000000000000000000000000000000000000000000000000000000a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347940000000000000000000000000000000000000000a0078dc6061b1d8eaa8493384b59c9c65ceb917201221d08b80c4de6770b6ec7e7a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b90100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000180834c4b40808080a00000000000000000000000000000000000000000000000000000000000000000880000000000000000843b9aca00a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421c0c0c0"
 }
```

We are not rejecting `2` as a valid input, the JSON RPC should only accept hex, not a number. cc @mattsse 

```
>>  {"jsonrpc":"2.0","id":1,"method":"debug_getRawBlock","params":["2"]}
<<  {"jsonrpc":"2.0","result":"0xf902bcf90218a0898753d8fdd8d92c1907ca21e68c7970abd290c647a202091181deec3f30a0b2a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347940000000000000000000000000000000000000000a0eb3709201a2eed4c86610af6beafb09fe914ff1eb0feaa5acb7747880c123d2fa014488a14ae59174bedee90344854fb9b6a308143ce4bf688c00f2e81a9aae2a3a0056b23fbba480696b65fe5a59b8f2148a1299103c4f57df839233af2cf4ca2d2b90100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008002834c4b408252081480a00000000000000000000000000000000000000000000000000000000000000000880000000000000000842db08786a0625ee608ff633ca6371503f9a8159a9e158f3fa9585650418562ef7bd1d1dfc9f869f86701842db0878782520894658bdf435d810c91414ec09147daa6db624063798203e880820a95a052a6f622013359249316f4c017a67bc2c659f513dac5efea43a84b6ce4e462b1a0055ba2a779eaf62efa7d641a32ea329faabf9f097d376e2e400115a5151b9470c0f4da802a94ee00000000000000000000000000000000000000820539d8010d94ee0000000000000000000000000000000000000001","id":1}
response differs from expected:
 {
   "id": 1,
   "jsonrpc": "2.0",
-  "result": "0xf902bcf90218a0898753d8fdd8d92c1907ca21e68c7970abd290c647a202091181deec3f30a0b2a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347940000000000000000000000000000000000000000a0eb3709201a2eed4c86610af6beafb09fe914ff1eb0feaa5acb7747880c123d2fa014488a14ae59174bedee90344854fb9b6a308143ce4bf688c00f2e81a9aae2a3a0056b23fbba480696b65fe5a59b8f2148a1299103c4f57df839233af2cf4ca2d2b90100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008002834c4b408252081480a00000000000000000000000000000000000000000000000000000000000000000880000000000000000842db08786a0625ee608ff633ca6371503f9a8159a9e158f3fa9585650418562ef7bd1d1dfc9f869f86701842db0878782520894658bdf435d810c91414ec09147daa6db624063798203e880820a95a052a6f622013359249316f4c017a67bc2c659f513dac5efea43a84b6ce4e462b1a0055ba2a779eaf62efa7d641a32ea329faabf9f097d376e2e400115a5151b9470c0f4da802a94ee00000000000000000000000000000000000000820539d8010d94ee0000000000000000000000000000000000000001"
+  "error": {
+    "code": -32602,
+    "message": "invalid argument 0: hex string without 0x prefix"
+  }
 }

```