### PR TITLE
feat(cli): drop execution stage

### DIFF
--- a/bin/reth/src/cli.rs
+++ b/bin/reth/src/cli.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use crate::{
     chain, db,
     dirs::{LogsDir, PlatformPath},
-    dump_stage, node, p2p,
+    drop_stage, dump_stage, node, p2p,
     runner::CliRunner,
     stage, test_eth_chain, test_vectors,
 };
@@ -31,6 +31,7 @@ pub fn run() -> eyre::Result<()> {
         Commands::Db(command) => runner.run_until_ctrl_c(command.execute()),
         Commands::Stage(command) => runner.run_until_ctrl_c(command.execute()),
         Commands::DumpStage(command) => runner.run_until_ctrl_c(command.execute()),
+        Commands::DropStage(command) => runner.run_until_ctrl_c(command.execute()),
         Commands::P2P(command) => runner.run_until_ctrl_c(command.execute()),
         Commands::TestVectors(command) => runner.run_until_ctrl_c(command.execute()),
         Commands::TestEthChain(command) => runner.run_until_ctrl_c(command.execute()),
@@ -63,6 +64,9 @@ pub enum Commands {
     /// Dumps a stage from a range into a new database.
     #[command(name = "dump-stage")]
     DumpStage(dump_stage::Command),
+    /// Drops a stage's tables from the database.
+    #[command(name = "drop-stage")]
+    DropStage(drop_stage::Command),
     /// P2P Debugging utilities
     #[command(name = "p2p")]
     P2P(p2p::Command),

--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -7,8 +7,8 @@ use clap::{Parser, Subcommand};
 use comfy_table::{Cell, Row, Table as ComfyTable};
 use eyre::WrapErr;
 use human_bytes::human_bytes;
-use reth_db::{database::Database, tables, transaction::DbTx};
-use tracing::{error, info};
+use reth_db::{database::Database, tables};
+use tracing::error;
 
 /// DB List TUI
 mod tui;

--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -1,19 +1,13 @@
 //! Database debugging tool
-use crate::dirs::{DbPath, PlatformPath};
+use crate::{
+    dirs::{DbPath, PlatformPath},
+    utils::DbTool,
+};
 use clap::{Parser, Subcommand};
 use comfy_table::{Cell, Row, Table as ComfyTable};
-use eyre::{Result, WrapErr};
+use eyre::WrapErr;
 use human_bytes::human_bytes;
-use reth_db::{
-    cursor::{DbCursorRO, Walker},
-    database::Database,
-    table::Table,
-    tables,
-    transaction::DbTx,
-};
-use reth_interfaces::test_utils::generators::random_block_range;
-use reth_provider::insert_canonical_block;
-use std::collections::BTreeMap;
+use reth_db::{database::Database, tables, transaction::DbTx};
 use tracing::{error, info};
 
 /// DB List TUI
@@ -186,58 +180,6 @@ impl Command {
             }
         }
 
-        Ok(())
-    }
-}
-
-/// Wrapper over DB that implements many useful DB queries.
-pub(crate) struct DbTool<'a, DB: Database> {
-    pub(crate) db: &'a DB,
-}
-
-impl<'a, DB: Database> DbTool<'a, DB> {
-    /// Takes a DB where the tables have already been created.
-    pub(crate) fn new(db: &'a DB) -> eyre::Result<Self> {
-        Ok(Self { db })
-    }
-
-    /// Seeds the database with some random data, only used for testing
-    fn seed(&mut self, len: u64) -> Result<()> {
-        info!(target: "reth::cli", "Generating random block range from 0 to {len}");
-        let chain = random_block_range(0..len, Default::default(), 0..64);
-
-        self.db.update(|tx| {
-            chain.into_iter().try_for_each(|block| {
-                insert_canonical_block(tx, block, None, true)?;
-                Ok::<_, eyre::Error>(())
-            })
-        })??;
-
-        info!(target: "reth::cli", "Database seeded with {len} blocks");
-        Ok(())
-    }
-
-    /// Grabs the contents of the table within a certain index range and places the
-    /// entries into a [`HashMap`][std::collections::HashMap].
-    fn list<T: Table>(&mut self, start: usize, len: usize) -> Result<BTreeMap<T::Key, T::Value>> {
-        let data = self.db.view(|tx| {
-            let mut cursor = tx.cursor_read::<T>().expect("Was not able to obtain a cursor.");
-
-            // TODO: Upstream this in the DB trait.
-            let start_walker = cursor.current().transpose();
-            let walker = Walker::new(&mut cursor, start_walker);
-
-            walker.skip(start).take(len).collect::<Vec<_>>()
-        })?;
-
-        data.into_iter()
-            .collect::<Result<BTreeMap<T::Key, T::Value>, _>>()
-            .map_err(|e| eyre::eyre!(e))
-    }
-
-    fn drop(&mut self, path: &PlatformPath<DbPath>) -> Result<()> {
-        info!(target: "reth::cli", "Dropping db at {}", path);
-        std::fs::remove_dir_all(path).wrap_err("Dropping the database failed")?;
         Ok(())
     }
 }

--- a/bin/reth/src/drop_stage.rs
+++ b/bin/reth/src/drop_stage.rs
@@ -1,0 +1,58 @@
+//! Database debugging tool
+use crate::{
+    dirs::{DbPath, PlatformPath},
+    utils::DbTool,
+    StageEnum,
+};
+use clap::Parser;
+use reth_db::{database::Database, tables, transaction::DbTxMut};
+use reth_stages::stages::EXECUTION;
+use tracing::info;
+
+/// `reth db` command
+#[derive(Debug, Parser)]
+pub struct Command {
+    /// The path to the database folder.
+    ///
+    /// Defaults to the OS-specific data directory:
+    ///
+    /// - Linux: `$XDG_DATA_HOME/reth/db` or `$HOME/.local/share/reth/db`
+    /// - Windows: `{FOLDERID_RoamingAppData}/reth/db`
+    /// - macOS: `$HOME/Library/Application Support/reth/db`
+    #[arg(global = true, long, value_name = "PATH", verbatim_doc_comment, default_value_t)]
+    db: PlatformPath<DbPath>,
+
+    stage: StageEnum,
+}
+
+impl Command {
+    /// Execute `db` command
+    pub async fn execute(&self) -> eyre::Result<()> {
+        std::fs::create_dir_all(&self.db)?;
+
+        let db = reth_db::mdbx::Env::<reth_db::mdbx::WriteMap>::open(
+            self.db.as_ref(),
+            reth_db::mdbx::EnvKind::RW,
+        )?;
+
+        let tool = DbTool::new(&db)?;
+
+        match &self.stage {
+            StageEnum::Execution => {
+                tool.db.update(|tx| {
+                    tx.clear::<tables::PlainStorageState>()?;
+                    tx.clear::<tables::AccountChangeSet>()?;
+                    tx.clear::<tables::StorageChangeSet>()?;
+                    tx.clear::<tables::Bytecodes>()?;
+                    tx.put::<tables::SyncStage>(EXECUTION.0.to_string(), 0)?;
+                    Ok::<_, eyre::Error>(())
+                })??;
+            }
+            _ => {
+                info!("Nothing to do for stage {:?}", self.stage);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/bin/reth/src/drop_stage.rs
+++ b/bin/reth/src/drop_stage.rs
@@ -40,6 +40,7 @@ impl Command {
         match &self.stage {
             StageEnum::Execution => {
                 tool.db.update(|tx| {
+                    tx.clear::<tables::PlainAccountState>()?;
                     tx.clear::<tables::PlainStorageState>()?;
                     tx.clear::<tables::AccountChangeSet>()?;
                     tx.clear::<tables::StorageChangeSet>()?;

--- a/bin/reth/src/drop_stage.rs
+++ b/bin/reth/src/drop_stage.rs
@@ -17,7 +17,7 @@ use reth_stages::stages::EXECUTION;
 use std::sync::Arc;
 use tracing::info;
 
-/// `reth db` command
+/// `reth drop-stage` command
 #[derive(Debug, Parser)]
 pub struct Command {
     /// The path to the database folder.

--- a/bin/reth/src/dump_stage/execution.rs
+++ b/bin/reth/src/dump_stage/execution.rs
@@ -1,7 +1,7 @@
 use crate::{
-    db::DbTool,
     dirs::{DbPath, PlatformPath},
     dump_stage::setup,
+    utils::DbTool,
 };
 use eyre::Result;
 use reth_db::{

--- a/bin/reth/src/dump_stage/hashing_account.rs
+++ b/bin/reth/src/dump_stage/hashing_account.rs
@@ -1,7 +1,7 @@
 use crate::{
-    db::DbTool,
     dirs::{DbPath, PlatformPath},
     dump_stage::setup,
+    utils::DbTool,
 };
 use eyre::Result;
 use reth_db::{database::Database, table::TableImporter, tables, transaction::DbTx};

--- a/bin/reth/src/dump_stage/hashing_storage.rs
+++ b/bin/reth/src/dump_stage/hashing_storage.rs
@@ -1,7 +1,7 @@
 use crate::{
-    db::DbTool,
     dirs::{DbPath, PlatformPath},
     dump_stage::setup,
+    utils::DbTool,
 };
 use eyre::Result;
 use reth_db::{database::Database, table::TableImporter, tables};

--- a/bin/reth/src/dump_stage/merkle.rs
+++ b/bin/reth/src/dump_stage/merkle.rs
@@ -1,7 +1,7 @@
 use crate::{
-    db::DbTool,
     dirs::{DbPath, PlatformPath},
     dump_stage::setup,
+    utils::DbTool,
 };
 use eyre::Result;
 use reth_db::{database::Database, table::TableImporter, tables, transaction::DbTx};

--- a/bin/reth/src/dump_stage/mod.rs
+++ b/bin/reth/src/dump_stage/mod.rs
@@ -12,8 +12,8 @@ mod merkle;
 use merkle::dump_merkle_stage;
 
 use crate::{
-    db::DbTool,
     dirs::{DbPath, PlatformPath},
+    utils::DbTool,
 };
 use clap::Parser;
 use reth_db::{

--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -12,6 +12,7 @@ pub mod chain;
 pub mod cli;
 pub mod db;
 pub mod dirs;
+pub mod drop_stage;
 pub mod dump_stage;
 pub mod node;
 pub mod p2p;
@@ -21,3 +22,11 @@ pub mod stage;
 pub mod test_eth_chain;
 pub mod test_vectors;
 pub mod utils;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, clap::ValueEnum)]
+enum StageEnum {
+    Headers,
+    Bodies,
+    Senders,
+    Execution,
+}

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     dirs::{ConfigPath, DbPath, PlatformPath},
     prometheus_exporter, StageEnum,
 };
-use clap::{Parser, ValueEnum};
+use clap::Parser;
 use reth_beacon_consensus::BeaconConsensus;
 use reth_downloaders::bodies::bodies::BodiesDownloaderBuilder;
 use reth_primitives::ChainSpec;

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -4,7 +4,7 @@
 use crate::{
     args::NetworkArgs,
     dirs::{ConfigPath, DbPath, PlatformPath},
-    prometheus_exporter,
+    prometheus_exporter, StageEnum,
 };
 use clap::{Parser, ValueEnum};
 use reth_beacon_consensus::BeaconConsensus;
@@ -84,14 +84,6 @@ pub struct Command {
 
     #[clap(flatten)]
     network: NetworkArgs,
-}
-
-#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, ValueEnum)]
-enum StageEnum {
-    Headers,
-    Bodies,
-    Senders,
-    Execution,
 }
 
 impl Command {

--- a/bin/reth/src/utils.rs
+++ b/bin/reth/src/utils.rs
@@ -1,12 +1,26 @@
 //! Common CLI utility functions.
+use crate::dirs::{DbPath, PlatformPath};
 
-use reth_interfaces::p2p::{
-    download::DownloadClient,
-    headers::client::{HeadersClient, HeadersRequest},
-    priority::Priority,
+use eyre::{Result, WrapErr};
+use reth_db::{
+    cursor::{DbCursorRO, Walker},
+    database::Database,
+    table::Table,
+    transaction::{DbTx, DbTxMut},
+};
+use reth_interfaces::{
+    p2p::{
+        download::DownloadClient,
+        headers::client::{HeadersClient, HeadersRequest},
+        priority::Priority,
+    },
+    test_utils::generators::random_block_range,
 };
 use reth_network::FetchClient;
 use reth_primitives::{BlockHashOrNumber, HeadersDirection, SealedHeader};
+use reth_provider::insert_canonical_block;
+use std::collections::BTreeMap;
+use tracing::info;
 
 /// Get a single header from network
 pub async fn get_single_header(
@@ -40,4 +54,65 @@ pub async fn get_single_header(
     }
 
     Ok(header)
+}
+
+/// Wrapper over DB that implements many useful DB queries.
+pub(crate) struct DbTool<'a, DB: Database> {
+    pub(crate) db: &'a DB,
+}
+
+impl<'a, DB: Database> DbTool<'a, DB> {
+    /// Takes a DB where the tables have already been created.
+    pub(crate) fn new(db: &'a DB) -> eyre::Result<Self> {
+        Ok(Self { db })
+    }
+
+    /// Seeds the database with some random data, only used for testing
+    pub fn seed(&mut self, len: u64) -> Result<()> {
+        info!(target: "reth::cli", "Generating random block range from 0 to {len}");
+        let chain = random_block_range(0..len, Default::default(), 0..64);
+
+        self.db.update(|tx| {
+            chain.into_iter().try_for_each(|block| {
+                insert_canonical_block(tx, block, None, true)?;
+                Ok::<_, eyre::Error>(())
+            })
+        })??;
+
+        info!(target: "reth::cli", "Database seeded with {len} blocks");
+        Ok(())
+    }
+
+    /// Grabs the contents of the table within a certain index range and places the
+    /// entries into a [`HashMap`][std::collections::HashMap].
+    pub fn list<T: Table>(
+        &mut self,
+        start: usize,
+        len: usize,
+    ) -> Result<BTreeMap<T::Key, T::Value>> {
+        let data = self.db.view(|tx| {
+            let mut cursor = tx.cursor_read::<T>().expect("Was not able to obtain a cursor.");
+
+            // TODO: Upstream this in the DB trait.
+            let start_walker = cursor.current().transpose();
+            let walker = Walker::new(&mut cursor, start_walker);
+
+            walker.skip(start).take(len).collect::<Vec<_>>()
+        })?;
+
+        data.into_iter()
+            .collect::<Result<BTreeMap<T::Key, T::Value>, _>>()
+            .map_err(|e| eyre::eyre!(e))
+    }
+
+    pub fn drop(&mut self, path: &PlatformPath<DbPath>) -> Result<()> {
+        info!(target: "reth::cli", "Dropping db at {}", path);
+        std::fs::remove_dir_all(path).wrap_err("Dropping the database failed")?;
+        Ok(())
+    }
+
+    pub fn drop_table<T: Table>(&mut self) -> Result<()> {
+        self.db.update(|tx| tx.clear::<T>())??;
+        Ok(())
+    }
 }

--- a/bin/reth/src/utils.rs
+++ b/bin/reth/src/utils.rs
@@ -105,12 +105,14 @@ impl<'a, DB: Database> DbTool<'a, DB> {
             .map_err(|e| eyre::eyre!(e))
     }
 
+    /// Drops the database at the given path.
     pub fn drop(&mut self, path: &PlatformPath<DbPath>) -> Result<()> {
         info!(target: "reth::cli", "Dropping db at {}", path);
         std::fs::remove_dir_all(path).wrap_err("Dropping the database failed")?;
         Ok(())
     }
 
+    /// Drops the provided table from the database.
     pub fn drop_table<T: Table>(&mut self) -> Result<()> {
         self.db.update(|tx| tx.clear::<T>())??;
         Ok(())

--- a/bin/reth/src/utils.rs
+++ b/bin/reth/src/utils.rs
@@ -57,7 +57,7 @@ pub async fn get_single_header(
 }
 
 /// Wrapper over DB that implements many useful DB queries.
-pub(crate) struct DbTool<'a, DB: Database> {
+pub struct DbTool<'a, DB: Database> {
     pub(crate) db: &'a DB,
 }
 

--- a/bin/reth/src/utils.rs
+++ b/bin/reth/src/utils.rs
@@ -1,6 +1,5 @@
 //! Common CLI utility functions.
 use crate::dirs::{DbPath, PlatformPath};
-
 use eyre::{Result, WrapErr};
 use reth_db::{
     cursor::{DbCursorRO, Walker},

--- a/crates/staged-sync/src/utils/init.rs
+++ b/crates/staged-sync/src/utils/init.rs
@@ -1,6 +1,6 @@
 use reth_db::{
     cursor::{DbCursorRO, DbCursorRW},
-    database::Database,
+    database::{Database, DatabaseGAT},
     mdbx::{Env, WriteMap},
     tables,
     transaction::{DbTx, DbTxMut},
@@ -59,7 +59,25 @@ pub fn init_genesis<DB: Database>(
     drop(tx);
     debug!("Writing genesis block.");
     let tx = db.tx_mut()?;
+    insert_genesis_state::<DB>(&tx, &genesis)?;
 
+    // Insert header
+    tx.put::<tables::CanonicalHeaders>(0, hash)?;
+    tx.put::<tables::HeaderNumbers>(hash, 0)?;
+    tx.put::<tables::BlockBodies>(0, Default::default())?;
+    tx.put::<tables::BlockTransitionIndex>(0, 0)?;
+    tx.put::<tables::HeaderTD>(0, header.difficulty.into())?;
+    tx.put::<tables::Headers>(0, header)?;
+
+    tx.commit()?;
+    Ok(hash)
+}
+
+/// Inserts the genesis state into the database.
+pub fn insert_genesis_state<DB: Database>(
+    tx: &<DB as DatabaseGAT<'_>>::TXMut,
+    genesis: &reth_primitives::Genesis,
+) -> Result<(), InitDatabaseError> {
     let mut account_cursor = tx.cursor_write::<tables::PlainAccountState>()?;
     let mut storage_cursor = tx.cursor_write::<tables::PlainStorageState>()?;
     let mut bytecode_cursor = tx.cursor_write::<tables::Bytecodes>()?;
@@ -89,21 +107,8 @@ pub fn init_genesis<DB: Database>(
             }
         }
     }
-    // Drop all cursor so we can commit the changes at the end of the fn.
-    drop(account_cursor);
-    drop(storage_cursor);
-    drop(bytecode_cursor);
 
-    // Insert header
-    tx.put::<tables::CanonicalHeaders>(0, hash)?;
-    tx.put::<tables::HeaderNumbers>(hash, 0)?;
-    tx.put::<tables::BlockBodies>(0, Default::default())?;
-    tx.put::<tables::BlockTransitionIndex>(0, 0)?;
-    tx.put::<tables::HeaderTD>(0, header.difficulty.into())?;
-    tx.put::<tables::Headers>(0, header)?;
-
-    tx.commit()?;
-    Ok(hash)
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/staged-sync/src/utils/init.rs
+++ b/crates/staged-sync/src/utils/init.rs
@@ -59,7 +59,7 @@ pub fn init_genesis<DB: Database>(
     drop(tx);
     debug!("Writing genesis block.");
     let tx = db.tx_mut()?;
-    insert_genesis_state::<DB>(&tx, &genesis)?;
+    insert_genesis_state::<DB>(&tx, genesis)?;
 
     // Insert header
     tx.put::<tables::CanonicalHeaders>(0, hash)?;


### PR DESCRIPTION
adds a CLI command which drops the tables related to the execution stage and its progress, allowing fresh reruns as we make bug fixes