### PR TITLE
perf: create only one `trie` cursor per trie type per merkle execute

### DIFF
--- a/crates/storage/provider/src/trie/mod.rs
+++ b/crates/storage/provider/src/trie/mod.rs
@@ -987,7 +987,7 @@ mod tests {
         });
         let expected = H256(sec_trie_root::<KeccakHasher, _, _, _>(encoded_storage).0);
         let storage_trie_cursor =
-            Arc::new(Mutex::new(self.tx.cursor_dup_write::<tables::StoragesTrie>()?));
+            Arc::new(Mutex::new(trie.tx.cursor_dup_write::<tables::StoragesTrie>().unwrap()));
         assert_matches!(
             trie.calculate_storage_root(hashed_address, storage_trie_cursor, None, None),
             Ok(got) if got.root().unwrap() == expected

--- a/crates/storage/provider/src/trie/mod.rs
+++ b/crates/storage/provider/src/trie/mod.rs
@@ -120,11 +120,12 @@ where
     }
 }
 
-type StoragesTrieCursor = Arc<Mutex<<TX as DbTxMutGAT<'tx>>::DupCursorMut<tables::StoragesTrie>>>;
+type StoragesTrieCursor<'tx, TX> =
+    Arc<Mutex<<TX as DbTxMutGAT<'tx>>::DupCursorMut<tables::StoragesTrie>>>;
 
 /// Database wrapper implementing HashDB trait, with a read-write transaction.
 pub struct DupHashDatabaseMut<'tx, TX: DbTxMutGAT<'tx>> {
-    storages_trie_cursor: StoragesTrieCursor,
+    storages_trie_cursor: StoragesTrieCursor<'tx, TX>,
     key: H256,
 }
 
@@ -190,7 +191,10 @@ where
     TX: DbTxMut<'db> + DbTx<'db> + Send + Sync,
 {
     /// Instantiates a new Database for the storage trie, with an empty root
-    pub fn new(storages_trie_cursor: StoragesTrieCursor, key: H256) -> Result<Self, TrieError> {
+    pub fn new(
+        storages_trie_cursor: StoragesTrieCursor<'tx, TX>,
+        key: H256,
+    ) -> Result<Self, TrieError> {
         let root = EMPTY_ROOT;
         {
             let mut cursor = storages_trie_cursor.lock();
@@ -206,7 +210,7 @@ where
 
     /// Instantiates a new Database for the storage trie, with an existing root
     pub fn from_root(
-        storages_trie_cursor: StoragesTrieCursor,
+        storages_trie_cursor: StoragesTrieCursor<'tx, TX>,
         key: H256,
         root: H256,
     ) -> Result<Self, TrieError> {

--- a/crates/storage/provider/src/trie/mod.rs
+++ b/crates/storage/provider/src/trie/mod.rs
@@ -120,9 +120,11 @@ where
     }
 }
 
+type StoragesTrieCursor = Arc<Mutex<<TX as DbTxMutGAT<'tx>>::DupCursorMut<tables::StoragesTrie>>>;
+
 /// Database wrapper implementing HashDB trait, with a read-write transaction.
 pub struct DupHashDatabaseMut<'tx, TX: DbTxMutGAT<'tx>> {
-    storages_trie_cursor: Arc<Mutex<<TX as DbTxMutGAT<'tx>>::DupCursorMut<tables::StoragesTrie>>>,
+    storages_trie_cursor: StoragesTrieCursor,
     key: H256,
 }
 
@@ -188,12 +190,7 @@ where
     TX: DbTxMut<'db> + DbTx<'db> + Send + Sync,
 {
     /// Instantiates a new Database for the storage trie, with an empty root
-    pub fn new(
-        storages_trie_cursor: Arc<
-            Mutex<<TX as DbTxMutGAT<'tx>>::DupCursorMut<tables::StoragesTrie>>,
-        >,
-        key: H256,
-    ) -> Result<Self, TrieError> {
+    pub fn new(storages_trie_cursor: StoragesTrieCursor, key: H256) -> Result<Self, TrieError> {
         let root = EMPTY_ROOT;
         {
             let mut cursor = storages_trie_cursor.lock();
@@ -209,9 +206,7 @@ where
 
     /// Instantiates a new Database for the storage trie, with an existing root
     pub fn from_root(
-        storages_trie_cursor: Arc<
-            Mutex<<TX as DbTxMutGAT<'tx>>::DupCursorMut<tables::StoragesTrie>>,
-        >,
+        storages_trie_cursor: StoragesTrieCursor,
         key: H256,
         root: H256,
     ) -> Result<Self, TrieError> {

--- a/crates/storage/provider/src/trie/mod.rs
+++ b/crates/storage/provider/src/trie/mod.rs
@@ -491,9 +491,7 @@ where
     fn calculate_storage_root(
         &mut self,
         address: H256,
-        storage_trie_cursor: Arc<
-            Mutex<<TX as DbTxMutGAT<'tx>>::DupCursorMut<tables::StoragesTrie>>,
-        >,
+        storage_trie_cursor: StoragesTrieCursor<'tx, TX>,
         next_storage: Option<H256>,
         previous_root: Option<H256>,
     ) -> Result<TrieProgress, TrieError> {
@@ -639,9 +637,7 @@ where
         &mut self,
         previous_root: H256,
         address: H256,
-        storage_trie_cursor: Arc<
-            Mutex<<TX as DbTxMutGAT<'tx>>::DupCursorMut<tables::StoragesTrie>>,
-        >,
+        storage_trie_cursor: StoragesTrieCursor<'tx, TX>,
         changed_storages: BTreeSet<H256>,
         next_storage: Option<H256>,
     ) -> Result<TrieProgress, TrieError> {


### PR DESCRIPTION
Otherwise, we'd be creating a couple cursors per account, which adds up. 