### PR TITLE
feat(txpool): replace testing pool with default eth pool

### DIFF
--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -16,7 +16,7 @@ reth-revm-inspectors = { path = "../../crates/revm/revm-inspectors" }
 reth-staged-sync = { path = "../../crates/staged-sync" }
 reth-stages = { path = "../../crates/stages"}
 reth-interfaces = { path = "../../crates/interfaces", features = ["test-utils"] }
-reth-transaction-pool = { path = "../../crates/transaction-pool", features = ["test-utils"] }
+reth-transaction-pool = { path = "../../crates/transaction-pool" }
 reth-beacon-consensus = { path = "../../crates/consensus/beacon" }
 reth-executor = { path = "../../crates/executor" }
 reth-rpc-engine-api = { path = "../../crates/rpc/rpc-engine-api" }

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -54,6 +54,7 @@ use reth_stages::{
     stages::{ExecutionStage, HeaderSyncMode, SenderRecoveryStage, TotalDifficultyStage, FINISH},
 };
 use reth_tasks::TaskExecutor;
+use reth_transaction_pool::EthTransactionValidator;
 use std::{
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
     path::PathBuf,
@@ -173,7 +174,7 @@ impl Command {
 
         info!(target: "reth::cli", path = %self.db, "Opening database");
         let db = Arc::new(init_db(&self.db)?);
-        let shareable_db = ShareableDatabase::new(Arc::clone(&db), self.chain.clone());
+        let shareable_db = ShareableDatabase::new(Arc::clone(&db), Arc::clone(&self.chain));
         info!(target: "reth::cli", "Database opened");
 
         self.start_metrics_endpoint()?;
@@ -193,14 +194,17 @@ impl Command {
         let network = self.start_network(network_config, &ctx.task_executor, ()).await?;
         info!(target: "reth::cli", peer_id = %network.peer_id(), local_addr = %network.local_addr(), "Connected to P2P network");
 
-        let test_transaction_pool = reth_transaction_pool::test_utils::testing_pool();
+        let transaction_pool = reth_transaction_pool::Pool::eth_pool(
+            EthTransactionValidator::new(shareable_db.clone(), Arc::clone(&self.chain)),
+            Default::default(),
+        );
         info!(target: "reth::cli", "Test transaction pool initialized");
 
         let _rpc_server = self
             .rpc
             .start_rpc_server(
                 shareable_db.clone(),
-                test_transaction_pool.clone(),
+                transaction_pool.clone(),
                 network.clone(),
                 ctx.task_executor.clone(),
             )
@@ -220,7 +224,7 @@ impl Command {
             .rpc
             .start_auth_server(
                 shareable_db,
-                test_transaction_pool,
+                transaction_pool,
                 network.clone(),
                 ctx.task_executor.clone(),
                 engine_api_handle,

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -92,13 +92,12 @@ pub use crate::{
     },
 };
 use crate::{
-    error::PoolResult,
+    error::{PoolError, PoolResult},
     pool::PoolInner,
     traits::{NewTransactionEvent, PoolSize},
 };
-
-use crate::error::PoolError;
 use reth_primitives::{TxHash, U256};
+use reth_provider::StateProviderFactory;
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::mpsc::Receiver;
 
@@ -202,6 +201,21 @@ where
     /// Whether the pool is empty
     pub fn is_empty(&self) -> bool {
         self.pool.is_empty()
+    }
+}
+
+impl<Client>
+    Pool<EthTransactionValidator<Client, PooledTransaction>, CostOrdering<PooledTransaction>>
+where
+    Client: StateProviderFactory,
+{
+    /// Returns a new [Pool] that uses the default [EthTransactionValidator] when validating
+    /// [PooledTransaction]s and ords via [CostOrdering]
+    pub fn eth_pool(
+        validator: EthTransactionValidator<Client, PooledTransaction>,
+        config: PoolConfig,
+    ) -> Self {
+        Self::new(validator, CostOrdering::default(), config)
     }
 }
 

--- a/crates/transaction-pool/src/ordering.rs
+++ b/crates/transaction-pool/src/ordering.rs
@@ -24,7 +24,7 @@ pub trait TransactionOrdering: Send + Sync + 'static {
 ///
 /// The transactions are ordered by their cost. The higher the cost,
 /// the higher the priority of this transaction is.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub struct CostOrdering<T>(PhantomData<T>);
 
@@ -37,5 +37,11 @@ where
 
     fn priority(&self, transaction: &Self::Transaction) -> Self::Priority {
         transaction.cost()
+    }
+}
+
+impl<T> Default for CostOrdering<T> {
+    fn default() -> Self {
+        Self(Default::default())
     }
 }


### PR DESCRIPTION
replaces the testing pool impl in the reth bin with the actual impl.

This uses the default eth validator and words by cost

the validator impl still needs some work ref #1793 