### PR TITLE
feat(rpc): add trace_rawTransaction handler

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
@@ -1,5 +1,6 @@
 use crate::tracing::{types::CallTraceNode, TracingInspectorConfig};
 use reth_rpc_types::{trace::parity::*, TransactionInfo};
+use std::collections::HashSet;
 
 /// A type for creating parity style traces
 #[derive(Clone, Debug)]
@@ -79,6 +80,15 @@ impl ParityTraceBuilder {
         info: TransactionInfo,
     ) -> Vec<LocalizedTransactionTrace> {
         self.into_localized_transaction_traces_iter(info).collect()
+    }
+
+    /// Returns the tracing types that are configured in the set
+    pub fn into_trace_type_traces(
+        self,
+        _trace_types: &HashSet<TraceType>,
+    ) -> (Option<Vec<TransactionTrace>>, Option<VmTrace>, Option<StateDiff>) {
+        // TODO(mattsse): impl conversion
+        (None, None, None)
     }
 
     /// Returns an iterator over all recorded traces  for `trace_transaction`

--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -160,20 +160,11 @@ where
         count: None,
     };
 
-    assert!(is_unimplemented(
-        TraceApiClient::trace_call(client, CallRequest::default(), HashSet::default(), None)
-            .await
-            .err()
-            .unwrap()
-    ));
+    TraceApiClient::trace_raw_transaction(client, Bytes::default(), HashSet::default(), None)
+        .await
+        .unwrap_err();
     assert!(is_unimplemented(
         TraceApiClient::trace_call_many(client, vec![], None).await.err().unwrap()
-    ));
-    assert!(is_unimplemented(
-        TraceApiClient::trace_raw_transaction(client, Bytes::default(), HashSet::default(), None)
-            .await
-            .err()
-            .unwrap()
     ));
     assert!(is_unimplemented(
         TraceApiClient::replay_block_transactions(client, block_id, HashSet::default())

--- a/crates/rpc/rpc-types/src/eth/trace/parity.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/parity.rs
@@ -24,20 +24,31 @@ impl TraceResult {
     }
 }
 
+/// Different Trace diagnostic targets.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum TraceType {
+    /// Default trace
     Trace,
+    /// Provides a full trace of the VM’s state throughout the execution of the transaction,
+    /// including for any subcalls.
     VmTrace,
+    /// Provides information detailing all altered portions of the Ethereum state made due to the
+    /// execution of the transaction.
     StateDiff,
 }
 
+/// The Outcome of a traced transaction with optional settings
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TraceResults {
+    /// Output of the trace
     pub output: Bytes,
+    /// Enabled if [TraceType::Trace] is provided
     pub trace: Option<Vec<TransactionTrace>>,
+    /// Enabled if [TraceType::VmTrace] is provided
     pub vm_trace: Option<VmTrace>,
+    /// Enabled if [TraceType::StateDiff] is provided
     pub state_diff: Option<StateDiff>,
 }
 

--- a/crates/rpc/rpc/src/eth/mod.rs
+++ b/crates/rpc/rpc/src/eth/mod.rs
@@ -9,6 +9,7 @@ mod logs_utils;
 mod pubsub;
 pub(crate) mod revm_utils;
 mod signer;
+pub(crate) mod utils;
 
 pub use api::{EthApi, EthApiSpec, EthTransactions, TransactionSource};
 pub use filter::EthFilter;

--- a/crates/rpc/rpc/src/eth/utils.rs
+++ b/crates/rpc/rpc/src/eth/utils.rs
@@ -1,0 +1,18 @@
+//! Commonly used code snippets
+
+use crate::eth::error::{EthApiError, EthResult};
+use reth_primitives::{Bytes, TransactionSigned, TransactionSignedEcRecovered};
+
+/// Recovers a [TransactionSignedEcRecovered] from an enveloped encoded byte stream.
+///
+/// See [TransactionSigned::decode_enveloped]
+pub(crate) fn recover_raw_transaction(data: Bytes) -> EthResult<TransactionSignedEcRecovered> {
+    if data.is_empty() {
+        return Err(EthApiError::EmptyRawTransactionData)
+    }
+
+    let transaction = TransactionSigned::decode_enveloped(data)
+        .map_err(|_| EthApiError::FailedToDecodeSignedTransaction)?;
+
+    transaction.into_ecrecovered().ok_or(EthApiError::InvalidTransactionSignature)
+}


### PR DESCRIPTION
this mostly contains some code changes to reduce code and adds `trace_rawTransaction` handler.

The actual creation of the `VmTrace` and `StateDiff` objects is left for a followup.