### PR TITLE
feat: `sync.execution.mgas_processed_total` metric

### DIFF
--- a/bin/reth/src/dump_stage/execution.rs
+++ b/bin/reth/src/dump_stage/execution.rs
@@ -98,9 +98,8 @@ async fn unwind_and_copy<DB: Database>(
 ) -> eyre::Result<()> {
     let mut unwind_tx = Transaction::new(db_tool.db)?;
 
-    let mut exec_stage = ExecutionStage::new_default_threshold(reth_executor::Factory::new(
-        Arc::new(MAINNET.clone()),
-    ));
+    let mut exec_stage =
+        ExecutionStage::new_with_factory(reth_executor::Factory::new(Arc::new(MAINNET.clone())));
 
     exec_stage
         .unwind(
@@ -129,9 +128,8 @@ async fn dry_run(
     info!(target: "reth::cli", "Executing stage. [dry-run]");
 
     let mut tx = Transaction::new(&output_db)?;
-    let mut exec_stage = ExecutionStage::new_default_threshold(reth_executor::Factory::new(
-        Arc::new(MAINNET.clone()),
-    ));
+    let mut exec_stage =
+        ExecutionStage::new_with_factory(reth_executor::Factory::new(Arc::new(MAINNET.clone())));
 
     exec_stage
         .execute(

--- a/bin/reth/src/dump_stage/merkle.rs
+++ b/bin/reth/src/dump_stage/merkle.rs
@@ -72,11 +72,9 @@ async fn unwind_and_copy<DB: Database>(
     MerkleStage::default_unwind().unwind(&mut unwind_tx, unwind).await?;
 
     // Bring Plainstate to TO (hashing stage execution requires it)
-    let mut exec_stage = ExecutionStage::new_default_threshold(reth_executor::Factory::new(
-        Arc::new(MAINNET.clone()),
-    ));
+    let mut exec_stage =
+        ExecutionStage::new(reth_executor::Factory::new(Arc::new(MAINNET.clone())), u64::MAX);
 
-    exec_stage.commit_threshold = u64::MAX;
     exec_stage
         .unwind(
             &mut unwind_tx,

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -172,8 +172,7 @@ impl Command {
             }
             StageEnum::Execution => {
                 let factory = reth_executor::Factory::new(self.chain.clone());
-                let mut stage = ExecutionStage::new(factory, 10_000);
-                stage.commit_threshold = num_blocks;
+                let mut stage = ExecutionStage::new(factory, num_blocks);
                 if !self.skip_unwind {
                     stage.unwind(&mut tx, unwind).await?;
                 }


### PR DESCRIPTION
A metric that denotes how many millions of gas the execution stage has processed.

To get the mgas/s processed, use `rate(reth_sync_execution_mgas_executed_total[$__rate_interval])` (I will open a separate PR adding this to the dashboard)