### PR TITLE
chore: move block body to primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4707,7 +4707,6 @@ dependencies = [
  "pin-project",
  "rayon",
  "reth-db",
- "reth-eth-wire",
  "reth-interfaces",
  "reth-metrics-derive",
  "reth-primitives",

--- a/crates/interfaces/src/p2p/bodies/client.rs
+++ b/crates/interfaces/src/p2p/bodies/client.rs
@@ -2,8 +2,7 @@ use std::pin::Pin;
 
 use crate::p2p::{download::DownloadClient, error::PeerRequestResult, priority::Priority};
 use futures::Future;
-use reth_eth_wire::BlockBody;
-use reth_primitives::H256;
+use reth_primitives::{BlockBody, H256};
 
 /// The bodies future type
 pub type BodiesFut = Pin<Box<dyn Future<Output = PeerRequestResult<Vec<BlockBody>>> + Send + Sync>>;

--- a/crates/interfaces/src/test_utils/bodies.rs
+++ b/crates/interfaces/src/test_utils/bodies.rs
@@ -6,8 +6,7 @@ use crate::p2p::{
 };
 use async_trait::async_trait;
 use futures::{future, Future, FutureExt};
-use reth_eth_wire::BlockBody;
-use reth_primitives::{WithPeerId, H256};
+use reth_primitives::{BlockBody, WithPeerId, H256};
 use std::{
     fmt::{Debug, Formatter},
     pin::Pin,

--- a/crates/net/downloaders/Cargo.toml
+++ b/crates/net/downloaders/Cargo.toml
@@ -11,7 +11,6 @@ description = "Implementations of various block downloaders"
 # reth
 reth-interfaces = { path = "../../interfaces" }
 reth-primitives = { path = "../../primitives" }
-reth-eth-wire = { path = "../eth-wire" }
 reth-db = { path = "../../storage/db" }
 reth-tasks = { path = "../../tasks" }
 reth-metrics-derive = { path = "../../metrics/metrics-derive" }

--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -536,9 +536,8 @@ mod tests {
     use assert_matches::assert_matches;
     use futures_util::stream::StreamExt;
     use reth_db::mdbx::{test_utils::create_test_db, EnvKind, WriteMap};
-    use reth_eth_wire::BlockBody;
     use reth_interfaces::test_utils::{generators::random_block_range, TestConsensus};
-    use reth_primitives::H256;
+    use reth_primitives::{BlockBody, H256};
     use std::{collections::HashMap, sync::Arc};
 
     // Check that the blocks are emitted in order of block number, not in order of

--- a/crates/net/downloaders/src/bodies/request.rs
+++ b/crates/net/downloaders/src/bodies/request.rs
@@ -1,6 +1,5 @@
 use crate::metrics::DownloaderMetrics;
 use futures::{Future, FutureExt};
-use reth_eth_wire::BlockBody;
 use reth_interfaces::{
     consensus::{Consensus as ConsensusTrait, Consensus},
     p2p::{
@@ -9,7 +8,7 @@ use reth_interfaces::{
         priority::Priority,
     },
 };
-use reth_primitives::{PeerId, SealedBlock, SealedHeader, WithPeerId, H256};
+use reth_primitives::{BlockBody, PeerId, SealedBlock, SealedHeader, WithPeerId, H256};
 use std::{
     collections::VecDeque,
     pin::Pin,

--- a/crates/net/downloaders/src/bodies/test_utils.rs
+++ b/crates/net/downloaders/src/bodies/test_utils.rs
@@ -6,9 +6,8 @@ use reth_db::{
     tables,
     transaction::DbTxMut,
 };
-use reth_eth_wire::BlockBody;
 use reth_interfaces::{db, p2p::bodies::response::BlockResponse};
-use reth_primitives::{Block, SealedBlock, SealedHeader, H256};
+use reth_primitives::{Block, BlockBody, SealedBlock, SealedHeader, H256};
 use std::collections::HashMap;
 
 pub(crate) fn zip_blocks<'a>(

--- a/crates/net/downloaders/src/headers/reverse_headers.rs
+++ b/crates/net/downloaders/src/headers/reverse_headers.rs
@@ -1010,8 +1010,8 @@ impl Default for ReverseHeadersDownloaderBuilder {
 impl ReverseHeadersDownloaderBuilder {
     /// Set the request batch size.
     ///
-    /// This determines the `limit` for a [GetHeaders](reth_eth_wire::GetBlockHeaders) requests, the
-    /// number of headers we ask for.
+    /// This determines the `limit` for a `GetBlockHeaders` requests, the number of headers we ask
+    /// for.
     pub fn request_limit(mut self, limit: u64) -> Self {
         self.request_limit = limit;
         self

--- a/crates/net/downloaders/src/test_utils/file_client.rs
+++ b/crates/net/downloaders/src/test_utils/file_client.rs
@@ -1,6 +1,5 @@
 use super::file_codec::BlockFileCodec;
 use itertools::Either;
-use reth_eth_wire::BlockBody;
 use reth_interfaces::{
     p2p::{
         bodies::client::{BodiesClient, BodiesFut},
@@ -12,7 +11,8 @@ use reth_interfaces::{
     sync::{SyncState, SyncStateProvider, SyncStateUpdater},
 };
 use reth_primitives::{
-    Block, BlockHash, BlockHashOrNumber, BlockNumber, Header, HeadersDirection, PeerId, H256,
+    Block, BlockBody, BlockHash, BlockHashOrNumber, BlockNumber, Header, HeadersDirection, PeerId,
+    H256,
 };
 use reth_rlp::{Decodable, Header as RlpHeader};
 use std::{

--- a/crates/net/downloaders/src/test_utils/mod.rs
+++ b/crates/net/downloaders/src/test_utils/mod.rs
@@ -2,9 +2,8 @@
 //! Test helper impls
 use crate::bodies::test_utils::create_raw_bodies;
 use futures::SinkExt;
-use reth_eth_wire::BlockBody;
 use reth_interfaces::test_utils::generators::random_block_range;
-use reth_primitives::{SealedHeader, H256};
+use reth_primitives::{BlockBody, SealedHeader, H256};
 use std::{collections::HashMap, io::SeekFrom};
 use tokio::{
     fs::File,

--- a/crates/net/downloaders/src/test_utils/test_client.rs
+++ b/crates/net/downloaders/src/test_utils/test_client.rs
@@ -1,10 +1,9 @@
-use reth_eth_wire::BlockBody;
 use reth_interfaces::p2p::{
     bodies::client::{BodiesClient, BodiesFut},
     download::DownloadClient,
     priority::Priority,
 };
-use reth_primitives::{PeerId, H256};
+use reth_primitives::{BlockBody, PeerId, H256};
 use std::{
     collections::HashMap,
     fmt::Debug,

--- a/crates/net/eth-wire/src/types/blocks.rs
+++ b/crates/net/eth-wire/src/types/blocks.rs
@@ -1,9 +1,7 @@
 //! Implements the `GetBlockHeaders`, `GetBlockBodies`, `BlockHeaders`, and `BlockBodies` message
 //! types.
 use reth_codecs::derive_arbitrary;
-use reth_primitives::{
-    Block, BlockHashOrNumber, Header, HeadersDirection, TransactionSigned, Withdrawal, H256,
-};
+use reth_primitives::{BlockBody, BlockHashOrNumber, Header, HeadersDirection, H256};
 use reth_rlp::{RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper};
 
 #[cfg(feature = "serde")]
@@ -65,35 +63,6 @@ pub struct GetBlockBodies(
 impl From<Vec<H256>> for GetBlockBodies {
     fn from(hashes: Vec<H256>) -> Self {
         GetBlockBodies(hashes)
-    }
-}
-
-// TODO(onbjerg): We should have this type in primitives
-/// A response to [`GetBlockBodies`], containing bodies if any bodies were found.
-///
-/// Withdrawals can be optionally included at the end of the RLP encoded message.
-#[derive_arbitrary(rlp, 10)]
-#[derive(Clone, Debug, PartialEq, Eq, Default, RlpEncodable, RlpDecodable)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[rlp(trailing)]
-pub struct BlockBody {
-    /// Transactions in the block
-    pub transactions: Vec<TransactionSigned>,
-    /// Uncle headers for the given block
-    pub ommers: Vec<Header>,
-    /// Withdrawals in the block.
-    pub withdrawals: Option<Vec<Withdrawal>>,
-}
-
-impl BlockBody {
-    /// Create a [`Block`](reth_primitives::Block) from the body and its header.
-    pub fn create_block(&self, header: Header) -> Block {
-        Block {
-            header,
-            body: self.transactions.clone(),
-            ommers: self.ommers.clone(),
-            withdrawals: self.withdrawals.clone(),
-        }
     }
 }
 

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -3,11 +3,11 @@
 use crate::peers::PeersHandle;
 use futures::StreamExt;
 use reth_eth_wire::{
-    BlockBodies, BlockBody, BlockHeaders, GetBlockBodies, GetBlockHeaders, GetNodeData,
-    GetReceipts, NodeData, Receipts,
+    BlockBodies, BlockHeaders, GetBlockBodies, GetBlockHeaders, GetNodeData, GetReceipts, NodeData,
+    Receipts,
 };
 use reth_interfaces::p2p::error::RequestResult;
-use reth_primitives::{BlockHashOrNumber, Header, HeadersDirection, PeerId};
+use reth_primitives::{BlockBody, BlockHashOrNumber, Header, HeadersDirection, PeerId};
 use reth_provider::{BlockProvider, HeaderProvider};
 use std::{
     borrow::Borrow,

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -2,14 +2,14 @@
 
 use crate::{message::BlockRequest, peers::PeersHandle};
 use futures::StreamExt;
-use reth_eth_wire::{BlockBody, GetBlockBodies, GetBlockHeaders};
+use reth_eth_wire::{GetBlockBodies, GetBlockHeaders};
 use reth_interfaces::p2p::{
     error::{EthResponseValidator, PeerRequestResult, RequestError, RequestResult},
     headers::client::HeadersRequest,
     priority::Priority,
 };
 use reth_network_api::ReputationChangeKind;
-use reth_primitives::{Header, PeerId, H256};
+use reth_primitives::{BlockBody, Header, PeerId, H256};
 use std::{
     collections::{HashMap, VecDeque},
     sync::{

--- a/crates/net/network/src/message.rs
+++ b/crates/net/network/src/message.rs
@@ -5,13 +5,13 @@
 
 use futures::FutureExt;
 use reth_eth_wire::{
-    capability::RawCapabilityMessage, message::RequestPair, BlockBodies, BlockBody, BlockHeaders,
-    EthMessage, GetBlockBodies, GetBlockHeaders, GetNodeData, GetPooledTransactions, GetReceipts,
-    NewBlock, NewBlockHashes, NewPooledTransactionHashes, NodeData, PooledTransactions, Receipts,
+    capability::RawCapabilityMessage, message::RequestPair, BlockBodies, BlockHeaders, EthMessage,
+    GetBlockBodies, GetBlockHeaders, GetNodeData, GetPooledTransactions, GetReceipts, NewBlock,
+    NewBlockHashes, NewPooledTransactionHashes, NodeData, PooledTransactions, Receipts,
     SharedTransactions, Transactions,
 };
 use reth_interfaces::p2p::error::{RequestError, RequestResult};
-use reth_primitives::{Bytes, Header, PeerId, Receipt, TransactionSigned, H256};
+use reth_primitives::{BlockBody, Bytes, Header, PeerId, Receipt, TransactionSigned, H256};
 use std::{
     fmt,
     sync::Arc,

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -511,10 +511,10 @@ mod tests {
     };
     use reth_eth_wire::{
         capability::{Capabilities, Capability},
-        BlockBodies, BlockBody, EthVersion, Status,
+        BlockBodies, EthVersion, Status,
     };
     use reth_interfaces::p2p::{bodies::client::BodiesClient, error::RequestError};
-    use reth_primitives::{Header, PeerId, H256};
+    use reth_primitives::{BlockBody, Header, PeerId, H256};
     use reth_provider::test_utils::NoopProvider;
     use std::{
         future::poll_fn,

--- a/crates/net/network/tests/it/requests.rs
+++ b/crates/net/network/tests/it/requests.rs
@@ -1,7 +1,6 @@
 //! Tests for eth related requests
 
 use rand::Rng;
-use reth_eth_wire::BlockBody;
 use reth_interfaces::p2p::{
     bodies::client::BodiesClient,
     headers::client::{HeadersClient, HeadersRequest},
@@ -9,7 +8,7 @@ use reth_interfaces::p2p::{
 use reth_network::test_utils::{NetworkEventStream, Testnet};
 use reth_network_api::{NetworkInfo, Peers};
 use reth_primitives::{
-    Block, Bytes, Header, HeadersDirection, Signature, Transaction, TransactionKind,
+    Block, BlockBody, Bytes, Header, HeadersDirection, Signature, Transaction, TransactionKind,
     TransactionSigned, TxEip2930, H256, U256,
 };
 use reth_provider::test_utils::MockEthProvider;

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -570,7 +570,7 @@ impl AsRef<H256> for BlockHash {
     }
 }
 
-/// A response to [`GetBlockBodies`], containing bodies if any bodies were found.
+/// A response to `GetBlockBodies`, containing bodies if any bodies were found.
 ///
 /// Withdrawals can be optionally included at the end of the RLP encoded message.
 #[derive_arbitrary(rlp, 10)]
@@ -588,7 +588,7 @@ pub struct BlockBody {
 }
 
 impl BlockBody {
-    /// Create a [`Block`](reth_primitives::Block) from the body and its header.
+    /// Create a [`Block`](Block) from the body and its header.
     pub fn create_block(&self, header: Header) -> Block {
         Block {
             header,

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -570,6 +570,35 @@ impl AsRef<H256> for BlockHash {
     }
 }
 
+/// A response to [`GetBlockBodies`], containing bodies if any bodies were found.
+///
+/// Withdrawals can be optionally included at the end of the RLP encoded message.
+#[derive_arbitrary(rlp, 10)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, RlpEncodable, RlpDecodable,
+)]
+#[rlp(trailing)]
+pub struct BlockBody {
+    /// Transactions in the block
+    pub transactions: Vec<TransactionSigned>,
+    /// Uncle headers for the given block
+    pub ommers: Vec<Header>,
+    /// Withdrawals in the block.
+    pub withdrawals: Option<Vec<Withdrawal>>,
+}
+
+impl BlockBody {
+    /// Create a [`Block`](reth_primitives::Block) from the body and its header.
+    pub fn create_block(&self, header: Header) -> Block {
+        Block {
+            header,
+            body: self.transactions.clone(),
+            ommers: self.ommers.clone(),
+            withdrawals: self.withdrawals.clone(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::{BlockId, BlockNumberOrTag::*, *};

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -39,7 +39,8 @@ pub mod proofs;
 pub use account::{Account, Bytecode};
 pub use bits::H512;
 pub use block::{
-    Block, BlockHashOrNumber, BlockId, BlockNumberOrTag, SealedBlock, SealedBlockWithSenders,
+    Block, BlockBody, BlockHashOrNumber, BlockId, BlockNumberOrTag, SealedBlock,
+    SealedBlockWithSenders,
 };
 pub use bloom::Bloom;
 pub use chain::{

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -436,7 +436,6 @@ mod tests {
             tables,
             transaction::{DbTx, DbTxMut},
         };
-        use reth_eth_wire::BlockBody;
         use reth_interfaces::{
             consensus::Consensus,
             p2p::{
@@ -454,7 +453,7 @@ mod tests {
                 TestConsensus,
             },
         };
-        use reth_primitives::{BlockNumber, SealedBlock, SealedHeader, TxNumber, H256};
+        use reth_primitives::{BlockBody, BlockNumber, SealedBlock, SealedHeader, TxNumber, H256};
         use std::{
             collections::{HashMap, VecDeque},
             ops::Range,


### PR DESCRIPTION
Fixes a TODO and reduces the need to depend on `reth_eth_wire` just for this struct.