### PR TITLE
meta: add commit sha example to bug form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -58,6 +58,7 @@ body:
   - type: input
     attributes:
       label: What version/commit are you on?
+      description: This can be obtained with e.g. `git rev-parse HEAD`
   - type: checkboxes
     id: terms
     attributes:


### PR DESCRIPTION
Add an example command for getting the commit SHA of the current commit