### PR TITLE
test: allow testing without `--all-features`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5250,6 +5250,7 @@ dependencies = [
  "reth-network-api",
  "reth-primitives",
  "reth-provider",
+ "reth-staged-sync",
  "reth-tracing",
  "secp256k1",
  "serde",

--- a/README.md
+++ b/README.md
@@ -45,16 +45,32 @@ See the [Reth Book](https://paradigmxyz.github.io/reth) for instructions on how 
 
 Rust minimum required version to build this project is 1.65.0 published 02.11.2022
 
-Prerequisites: libclang, `libclang-dev` on Debian
+Prerequisites: 
+- Debian
+  - `libclang`
+  - `libclang-dev`
 
-To test Reth, you will need to have [Geth  installed.](https://geth.ethereum.org/docs/getting-started/installing-geth)
+To fully test Reth, you will need to have [Geth installed](https://geth.ethereum.org/docs/getting-started/installing-geth), but it is possible to run a subset of tests without Geth.
+
+
+First, clone the repository:
 
 ```sh
 git clone https://github.com/paradigmxyz/reth
 cd reth
-cargo test --all
 ```
 
+Next, run the tests:
+
+```sh
+# Without Geth
+cargo test --all
+
+# With Geth
+cargo test --all --features geth-tests
+```
+
+We recommend using [`cargo nextest`]() to speed up testing. With nextest installed, simply substitute `cargo test` with `cargo nextest run`.
 
 ## Contributing and Getting Help
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
 [gh-ci]: https://github.com/paradigmxyz/reth/actions/workflows/ci.yml
 [gh-deny]: https://github.com/paradigmxyz/reth/actions/workflows/deny.yml
 [tg-badge]: https://img.shields.io/endpoint?color=neon&logo=telegram&label=chat&url=https%3A%2F%2Ftg.sumanjay.workers.dev%2Fparadigm%5Freth
-[tg-url]: https://t.me/paradigm_reth
 
 ## What is Reth? What are its goals?
 
@@ -83,9 +82,9 @@ If you have any questions, first see if the answer to your question can be found
 
 If the answer is not there:
 
--   Join the [Telegram][tg-url] to get help, or
--   Open a [discussion](https://github.com/paradigmxyz/reth/discussions/new) with your question, or
--   Open an issue with [the bug](https://github.com/paradigmxyz/reth/issues/new)
+- Join the [Telegram][tg-url] to get help, or
+- Open a [discussion](https://github.com/paradigmxyz/reth/discussions/new) with your question, or
+- Open an issue with [the bug](https://github.com/paradigmxyz/reth/issues/new)
 
 Guidelines on how to contribute can be found in our [`CONTRIBUTING.md`](./CONTRIBUTING.md). Get started with contributing in our [contributor docs](./docs)
 
@@ -113,3 +112,4 @@ We will be updating the documentation with the completion status of each compone
 We appreciate your patience until we get there. Until then, we are happy to answer all questions in the Telegram link above.
 
 [book]: https://paradigmxyz.github.io/reth/
+[tg-url]: https://t.me/paradigm_reth

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ cargo test --all
 cargo test --all --features geth-tests
 ```
 
-We recommend using [`cargo nextest`]() to speed up testing. With nextest installed, simply substitute `cargo test` with `cargo nextest run`.
+We recommend using [`cargo nextest`](https://nexte.st/) to speed up testing. With nextest installed, simply substitute `cargo test` with `cargo nextest run`.
 
 ## Contributing and Getting Help
 

--- a/README.md
+++ b/README.md
@@ -72,11 +72,17 @@ cargo test --all --features geth-tests
 
 We recommend using [`cargo nextest`](https://nexte.st/) to speed up testing. With nextest installed, simply substitute `cargo test` with `cargo nextest run`.
 
-## Contributing and Getting Help
+## Contributing
 
 If you want to contribute, or follow along with contributor discussion, you can use our [main telegram](https://t.me/paradigm_reth) to chat with us about the development of Reth!
 
-See our [Project Layout](./docs/repo/layout.md) to understand more about the repository's structure, and descriptions about each package.
+See our [contributor docs](./docs) for more information on the project.
+
+A good starting point is [Project Layout](./docs/repo/layout.md) which gives an overview of the repository's structure, and descriptions for each package.
+
+Our contributor guidelines can be found in [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+
+## Getting Help
 
 If you have any questions, first see if the answer to your question can be found in the [book][book].
 
@@ -85,8 +91,6 @@ If the answer is not there:
 - Join the [Telegram][tg-url] to get help, or
 - Open a [discussion](https://github.com/paradigmxyz/reth/discussions/new) with your question, or
 - Open an issue with [the bug](https://github.com/paradigmxyz/reth/issues/new)
-
-Guidelines on how to contribute can be found in our [`CONTRIBUTING.md`](./CONTRIBUTING.md). Get started with contributing in our [contributor docs](./docs)
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@
 [![Codecov](https://img.shields.io/codecov/c/github/paradigmxyz/reth?token=c24SDcMImE)][codecov]
 [![Telegram Chat][tg-badge]][tg-url]
 
-[tg-badge]: https://img.shields.io/endpoint?color=neon&logo=telegram&label=chat&style=flat-square&url=https%3A%2F%2Ftg.sumanjay.workers.dev%2Fparadigm%5Freth
+[codecov]: https://app.codecov.io/gh/paradigmxyz/reth
+[gh-ci]: https://github.com/paradigmxyz/reth/actions/workflows/ci.yml
+[gh-deny]: https://github.com/paradigmxyz/reth/actions/workflows/deny.yml
+[tg-badge]: https://img.shields.io/endpoint?color=neon&logo=telegram&label=chat&url=https%3A%2F%2Ftg.sumanjay.workers.dev%2Fparadigm%5Freth
 [tg-url]: https://t.me/paradigm_reth
 
 ## What is Reth? What are its goals?
@@ -99,11 +102,6 @@ None of this would have been possible without them, so big shoutout to the teams
 * [Erigon](https://github.com/ledgerwatch/erigon) (fka Turbo-Geth): Erigon pioneered the ["Staged Sync" architecture](https://erigon.substack.com/p/erigon-stage-sync-and-control-flows) that Reth is using, as well as [introduced MDBX](https://github.com/ledgerwatch/erigon/wiki/Choice-of-storage-engine) as the database of choice. We thank Erigon for pushing the state of the art research on the performance limits of Ethereum nodes.
 * [Akula](https://github.com/akula-bft/akula/): Reth uses forks of the Apache versions of Akula's [MDBX Bindings](https://github.com/paradigmxyz/reth/pull/132), [FastRLP](https://github.com/paradigmxyz/reth/pull/63) and [ECIES](https://github.com/paradigmxyz/reth/pull/80) . Given that these packages were already released under the Apache License, and they implement standardized solutions, we decided not to reimplement them to iterate faster. We thank the Akula team for their contributions to the Rust Ethereum ecosystem and for publishing these packages.
 
-[codecov]: https://app.codecov.io/gh/paradigmxyz/reth
-[gh-ci]: https://github.com/paradigmxyz/reth/actions/workflows/ci.yml
-[gh-deny]: https://github.com/paradigmxyz/reth/actions/workflows/deny.yml
-[book]: https://paradigmxyz.github.io/reth/
-
 ## 🚧 WARNING: UNDER CONSTRUCTION 🚧
 
 This project is work in progress and subject to frequent changes as we are still working on wiring up each individual node component into a full syncing pipeline.
@@ -113,3 +111,5 @@ It has not been audited for security purposes and should not be used in producti
 We will be updating the documentation with the completion status of each component, as well as include more contributing guidelines (design docs, architecture diagrams, repository layouts) and "good first issues". See the "Contributing and Getting Help" section above for more.
 
 We appreciate your patience until we get there. Until then, we are happy to answer all questions in the Telegram link above.
+
+[book]: https://paradigmxyz.github.io/reth/

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [tg-badge]: https://img.shields.io/endpoint?color=neon&logo=telegram&label=chat&style=flat-square&url=https%3A%2F%2Ftg.sumanjay.workers.dev%2Fparadigm%5Freth
 [tg-url]: https://t.me/paradigm_reth
 
-# What is Reth? What are its goals?
+## What is Reth? What are its goals?
 
 Reth (short for Rust Ethereum, [pronunciation](https://twitter.com/kelvinfichter/status/1597653609411268608)) is a new Ethereum full node implementation that is focused on being user-friendly, highly modular, as well as being fast and efficient. Reth is an Execution Layer (EL) and is compatible with all Ethereum Consensus Layer (CL) implementations that support the [Engine API](https://github.com/ethereum/execution-apis/tree/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine). It is originally built and driven forward by [Paradigm](https://paradigm.xyz/), and is licensed under the Apache and MIT licenses.
 
@@ -29,19 +29,17 @@ More concretely, our goals are:
 6. **Configurability**: We want to solve for node operators that care about fast historical queries, but also for hobbyists who cannot operate on large hardware. We also want to support teams and individuals who want both sync from genesis and via "fast sync". We envision that Reth will be configurable enough and provide configurable "profiles" for the tradeoffs that each team faces.
 
 
-# Status
+## Status
 
-The project is not ready for use. We hope to have full sync implemented sometime in January/February 2023, followed by optimizations. In the meantime, we're working on making sure every crate of the repository is well documented, abstracted and tested.
+The project is not ready for use. We hope to have full sync implemented sometime in Q1 2023, followed by optimizations. In the meantime, we're working on making sure every crate of the repository is well documented, abstracted and tested.
 
----
+## For Developers
 
-# For Developers
-
-## Running Reth
+### Running Reth
 
 See the [Reth Book](https://paradigmxyz.github.io/reth) for instructions on how to run Reth.
 
-## Build & Test
+### Build & Test
 
 Rust minimum required version to build this project is 1.65.0 published 02.11.2022
 
@@ -88,11 +86,11 @@ If the answer is not there:
 
 Guidelines on how to contribute can be found in our [`CONTRIBUTING.md`](./CONTRIBUTING.md). Get started with contributing in our [contributor docs](./docs)
 
-# Security
+## Security
 
 See [`SECURITY.md`](./SECURITY.md).
 
-# Acknowledgements
+## Acknowledgements
 
 Reth is a new implementation of the Ethereum protocol. In the process of developing the node we investigated the design decisions other nodes have made to understand what is done well, what is not, and where we can improve the status quo.
 
@@ -106,7 +104,7 @@ None of this would have been possible without them, so big shoutout to the teams
 [gh-deny]: https://github.com/paradigmxyz/reth/actions/workflows/deny.yml
 [book]: https://paradigmxyz.github.io/reth/
 
-# 🚧 WARNING: UNDER CONSTRUCTION 🚧
+## 🚧 WARNING: UNDER CONSTRUCTION 🚧
 
 This project is work in progress and subject to frequent changes as we are still working on wiring up each individual node component into a full syncing pipeline.
 

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -98,3 +98,4 @@ serial_test = "0.10"
 default = ["serde"]
 serde = ["dep:serde", "dep:humantime-serde", "secp256k1/serde", "enr?/serde", "dep:serde_json"]
 test-utils = ["reth-provider/test-utils", "dep:enr", "dep:ethers-core", "dep:tempfile"]
+geth-tests = []

--- a/crates/net/network/src/lib.rs
+++ b/crates/net/network/src/lib.rs
@@ -52,7 +52,6 @@
 //! The [`NetworkConfig`] is used to configure the network.
 //! It requires an instance of [`BlockProvider`](reth_provider::BlockProvider).
 //!
-//!
 //! ```
 //! # async fn launch() {
 //! use reth_network::config::rng_secret_key;
@@ -110,7 +109,9 @@
 //!
 //! # Features
 //!
-//! - `serde`: Enable serde support for configuration types.
+//! - `serde`: Enable serde support for configuration types (enabled by default).
+//! - `test-utils`: Various utilities helpful for writing tests
+//! - `geth-tests`: Runs tests that require Geth to be installed locally.
 
 #[cfg(any(test, feature = "test-utils"))]
 /// Common helpers for network testing.

--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -676,6 +676,7 @@ mod tests {
     use secp256k1::SecretKey;
 
     #[tokio::test(flavor = "multi_thread")]
+    #[cfg_attr(not(feature = "geth-tests"), ignore)]
     async fn test_ignored_tx_broadcasts_while_syncing() {
         reth_tracing::init_test_tracing();
 

--- a/crates/net/network/tests/it/connect.rs
+++ b/crates/net/network/tests/it/connect.rs
@@ -309,6 +309,7 @@ async fn test_connect_to_trusted_peer() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(not(feature = "geth-tests"), ignore)]
 async fn test_incoming_node_id_blacklist() {
     reth_tracing::init_test_tracing();
     tokio::time::timeout(GETH_TIMEOUT, async move {
@@ -361,6 +362,7 @@ async fn test_incoming_node_id_blacklist() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial_test::serial]
+#[cfg_attr(not(feature = "geth-tests"), ignore)]
 async fn test_incoming_connect_with_single_geth() {
     reth_tracing::init_test_tracing();
     tokio::time::timeout(GETH_TIMEOUT, async move {
@@ -404,6 +406,7 @@ async fn test_incoming_connect_with_single_geth() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial_test::serial]
+#[cfg_attr(not(feature = "geth-tests"), ignore)]
 async fn test_outgoing_connect_with_single_geth() {
     reth_tracing::init_test_tracing();
     tokio::time::timeout(GETH_TIMEOUT, async move {
@@ -449,6 +452,7 @@ async fn test_outgoing_connect_with_single_geth() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial_test::serial]
+#[cfg_attr(not(feature = "geth-tests"), ignore)]
 async fn test_geth_disconnect() {
     reth_tracing::init_test_tracing();
     tokio::time::timeout(GETH_TIMEOUT, async move {

--- a/crates/staged-sync/Cargo.toml
+++ b/crates/staged-sync/Cargo.toml
@@ -51,6 +51,10 @@ tokio = { version = "1", features = ["io-util", "net", "macros", "rt-multi-threa
 hex = { version = "0.4", optional = true }
 
 [dev-dependencies]
+# HACK(onbjerg): Workaround to enable test-utils when running tests
+# Source: https://github.com/rust-lang/cargo/issues/2911#issuecomment-749580481
+reth-staged-sync = { path = ".", features = ["test-utils"] }
+
 # reth crates
 reth-tracing = { path = "../tracing" }
 reth-downloaders = { path = "../net/downloaders" }

--- a/crates/staged-sync/Cargo.toml
+++ b/crates/staged-sync/Cargo.toml
@@ -89,3 +89,4 @@ test-utils = [
     "dep:ethers-middleware",
     "dep:async-trait"
 ]
+geth-tests = []

--- a/crates/staged-sync/src/lib.rs
+++ b/crates/staged-sync/src/lib.rs
@@ -5,7 +5,12 @@
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
 ))]
 
-//! Puts together all the Reth stages in a unified abstraction
+//! Puts together all the Reth stages in a unified abstraction.
+//!
+//! # Features
+//!
+//! - `test-utils`: Various utilities helpful for writing tests
+//! - `geth-tests`: Runs tests that require Geth to be installed locally.
 
 pub mod config;
 pub use config::Config;

--- a/crates/staged-sync/src/test_utils/clique.rs
+++ b/crates/staged-sync/src/test_utils/clique.rs
@@ -1,5 +1,4 @@
 //! Helper struct for working with a clique geth instance.
-
 use enr::k256::ecdsa::SigningKey;
 use ethers_core::utils::{Geth, GethInstance};
 use ethers_middleware::SignerMiddleware;

--- a/crates/staged-sync/tests/sync.rs
+++ b/crates/staged-sync/tests/sync.rs
@@ -15,6 +15,7 @@ use secp256k1::SecretKey;
 use std::{net::SocketAddr, sync::Arc};
 
 #[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(not(feature = "geth-tests"), ignore)]
 async fn can_peer_with_geth() {
     reth_tracing::init_test_tracing();
 


### PR DESCRIPTION
- Resolves an issue with missing dependencies in `reth-staged-sync` if the crate is tested without `test-utils` enabled on itself (using a workaround, see it's `Cargo.toml`)
- Adds a `geth-tests` feature to relevant crates to enable/disable tests that require Geth to run. If the feature is not enabled, the test is marked as ignored
- Updates testing instructions in the README, and does a small polish pass on the README as well

Closes #1879 