### PR TITLE
feat(mock) `ExtendedAccount` storage method

### DIFF
--- a/crates/rpc/rpc/src/eth/api/state.rs
+++ b/crates/rpc/rpc/src/eth/api/state.rs
@@ -95,3 +95,47 @@ where
         Ok(proof)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use reth_primitives::{StorageValue, StorageKey};
+    use reth_provider::test_utils::{MockEthProvider, NoopProvider, ExtendedAccount};
+    use reth_transaction_pool::test_utils::testing_pool;
+    use crate::eth::cache::EthStateCache;
+    use super::*;
+
+    #[tokio::test]
+    async fn test_storage() {
+        // === Noop ===
+        let pool = testing_pool();
+
+        let eth_api = EthApi::new(
+            NoopProvider::default(),
+            pool.clone(),
+            (),
+            EthStateCache::spawn(NoopProvider::default(), Default::default()),
+        );
+        let address = Address::random();
+        let storage = eth_api.storage_at(address, U256::ZERO, None).unwrap();
+        assert_eq!(storage, U256::ZERO.into());
+
+        // === Mock ===
+        let mock_provider = MockEthProvider::default();
+        let storage_value = StorageValue::from(1337);
+        let storage_key = StorageKey::random();
+        let storage = HashMap::from([(storage_key, storage_value)]);
+        let account = ExtendedAccount::new(0, U256::ZERO).extend_storage(storage);
+        mock_provider.add_account(address, account);
+
+        let eth_api = EthApi::new(
+            mock_provider.clone(),
+            pool.clone(),
+            (),
+            EthStateCache::spawn(mock_provider, Default::default()),
+        );
+
+        let storage = eth_api.storage_at(address, storage_key.into(), None).unwrap();
+        assert_eq!(storage, storage_value.into());
+    }
+}

--- a/crates/rpc/rpc/src/eth/api/state.rs
+++ b/crates/rpc/rpc/src/eth/api/state.rs
@@ -98,12 +98,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-    use reth_primitives::{StorageValue, StorageKey};
-    use reth_provider::test_utils::{MockEthProvider, NoopProvider, ExtendedAccount};
-    use reth_transaction_pool::test_utils::testing_pool;
-    use crate::eth::cache::EthStateCache;
     use super::*;
+    use crate::eth::cache::EthStateCache;
+    use reth_primitives::{StorageKey, StorageValue};
+    use reth_provider::test_utils::{ExtendedAccount, MockEthProvider, NoopProvider};
+    use reth_transaction_pool::test_utils::testing_pool;
+    use std::collections::HashMap;
 
     #[tokio::test]
     async fn test_storage() {

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -53,7 +53,7 @@ impl ExtendedAccount {
     /// the value is updated.
     pub fn extend_storage(
         mut self,
-        storage: impl IntoIterator<Item = (StorageKey, StorageValue)>
+        storage: impl IntoIterator<Item = (StorageKey, StorageValue)>,
     ) -> Self {
         self.storage.extend(storage);
         self

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -51,7 +51,10 @@ impl ExtendedAccount {
 
     /// Add storage to the extended account. If the storage key is already present,
     /// the value is updated.
-    pub fn with_storage(mut self, storage: HashMap<StorageKey, StorageValue>) -> Self {
+    pub fn extend_storage(
+        mut self,
+        storage: impl IntoIterator<Item = (StorageKey, StorageValue)>
+    ) -> Self {
         self.storage.extend(storage);
         self
     }

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -48,6 +48,13 @@ impl ExtendedAccount {
         self.bytecode = Some(Bytecode::new_raw(bytecode.into()));
         self
     }
+
+    /// Add storage to the extended account. If the storage key is already present,
+    /// the value is updated.
+    pub fn with_storage(mut self, storage: HashMap<StorageKey, StorageValue>) -> Self {
+        self.storage.extend(storage);
+        self
+    }
 }
 
 impl MockEthProvider {


### PR DESCRIPTION
- Additional method for `ExtendedAccount` to extend storage
- Test in eth rpc api state.rs

closes #1887 
