### PR TITLE
fix: parse 66 blockid str as hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5184,6 +5184,7 @@ dependencies = [
  "reth-tracing",
  "reth-transaction-pool",
  "serde",
+ "serde_json",
  "strum",
  "thiserror",
  "tokio",
@@ -5836,9 +5837,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "itoa",
  "ryu",

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -328,7 +328,14 @@ impl<'de> Deserialize<'de> for BlockId {
             where
                 E: serde::de::Error,
             {
-                Ok(BlockId::Number(v.parse().map_err(serde::de::Error::custom)?))
+                // Since there is no way to clearly distinguish between a DATA parameter and a QUANTITY parameter. A str is therefor deserialized into a Block Number: <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1898.md>
+                // However, since the hex string should be a QUANTITY, we can safely assume that if the len is 66 bytes, it is in fact a hash, ref <https://github.com/ethereum/go-ethereum/blob/ee530c0d5aa70d2c00ab5691a89ab431b73f8165/rpc/types.go#L184-L184>
+                if v.len() == 66 {
+                    Ok(BlockId::Hash(v.parse::<H256>().map_err(serde::de::Error::custom)?.into()))
+                } else {
+                    // quantity hex string or tag
+                    Ok(BlockId::Number(v.parse().map_err(serde::de::Error::custom)?))
+                }
             }
 
             fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
@@ -510,6 +517,10 @@ impl FromStr for BlockNumberOrTag {
             "earliest" => Self::Earliest,
             "pending" => Self::Pending,
             _number => {
+                // This expects either a block hash or a QUANTITY hex string: <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1898.md>
+                // therefore we assume if the len is 66, we assume this is a block hash
+                // <https://github.com/ethereum/go-ethereum/blob/ee530c0d5aa70d2c00ab5691a89ab431b73f8165/rpc/types.go#L184-L184>
+
                 let hex_string = s.trim_start_matches("0x");
                 let number = u64::from_str_radix(hex_string, 16).map_err(|err| err.to_string());
                 BlockNumberOrTag::Number(number?)
@@ -602,6 +613,7 @@ impl BlockBody {
 #[cfg(test)]
 mod test {
     use super::{BlockId, BlockNumberOrTag::*, *};
+
     /// Check parsing according to EIP-1898.
     #[test]
     fn can_parse_blockid_u64() {
@@ -663,6 +675,7 @@ mod test {
             assert_eq!(deserialized, *block_id)
         }
     }
+
     #[test]
     fn serde_blockid_number() {
         let block_id = BlockId::from(100u64);
@@ -670,6 +683,7 @@ mod test {
         let deserialized: BlockId = serde_json::from_str(&serialized).unwrap();
         assert_eq!(deserialized, block_id)
     }
+
     #[test]
     fn serde_blockid_hash() {
         let block_id = BlockId::from(H256::default());
@@ -677,6 +691,15 @@ mod test {
         let deserialized: BlockId = serde_json::from_str(&serialized).unwrap();
         assert_eq!(deserialized, block_id)
     }
+
+    #[test]
+    fn serde_blockid_hash_from_str() {
+        let val = "\"0x898753d8fdd8d92c1907ca21e68c7970abd290c647a202091181deec3f30a0b2\"";
+        let block_hash: H256 = serde_json::from_str(val).unwrap();
+        let block_id: BlockId = serde_json::from_str(val).unwrap();
+        assert_eq!(block_id, BlockId::Hash(block_hash.into()));
+    }
+
     #[test]
     fn serde_rpc_payload_block_tag() {
         let payload = r#"{"method":"eth_call","params":[{"to":"0xebe8efa441b9302a0d7eaecc277c09d20d684540","data":"0x45848dfc"},"latest"],"id":1,"jsonrpc":"2.0"}"#;

--- a/crates/rpc/rpc-builder/Cargo.toml
+++ b/crates/rpc/rpc-builder/Cargo.toml
@@ -36,3 +36,4 @@ reth-provider = { path = "../../storage/provider", features = ["test-utils"] }
 reth-network-api = { path = "../../net/network-api", features = ["test-utils"] }
 
 tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
+serde_json = "1.0.94"

--- a/crates/rpc/rpc-builder/tests/it/main.rs
+++ b/crates/rpc/rpc-builder/tests/it/main.rs
@@ -1,4 +1,5 @@
 mod http;
+mod serde;
 pub mod utils;
 
 fn main() {}

--- a/crates/rpc/rpc-builder/tests/it/serde.rs
+++ b/crates/rpc/rpc-builder/tests/it/serde.rs
@@ -1,0 +1,29 @@
+//! various serde test
+use crate::utils::launch_http;
+use jsonrpsee::{
+    core::{client::ClientT, traits::ToRpcParams, Error},
+    types::Request,
+};
+use reth_primitives::U256;
+use reth_rpc_builder::RethRpcModule;
+use serde_json::value::RawValue;
+
+struct RawRpcParams(Box<RawValue>);
+
+impl ToRpcParams for RawRpcParams {
+    fn to_rpc_params(self) -> Result<Option<Box<RawValue>>, Error> {
+        Ok(Some(self.0))
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_eth_balance_serde() {
+    let handle = launch_http(vec![RethRpcModule::Eth]).await;
+    let s = r#"{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0xaa00000000000000000000000000000000000000","0x898753d8fdd8d92c1907ca21e68c7970abd290c647a202091181deec3f30a0b2"]}"#;
+    let req: Request = serde_json::from_str(s).unwrap();
+    let client = handle.http_client().unwrap();
+
+    let params = RawRpcParams(RawValue::from_string(req.params.unwrap().to_string()).unwrap());
+
+    client.request::<U256, _>("eth_getBalance", params).await.unwrap();
+}


### PR DESCRIPTION
as explained in the docs we can assume that a input str of 66 should be a hash, this mirrors geth's behaviour:

https://github.com/ethereum/go-ethereum/blob/ee530c0d5aa70d2c00ab5691a89ab431b73f8165/rpc/types.go#L184-L203

