### PR TITLE
fix(rpc): return resource not found error code

### DIFF
--- a/crates/rpc/rpc-types/src/eth/error.rs
+++ b/crates/rpc/rpc-types/src/eth/error.rs
@@ -9,6 +9,10 @@ pub enum EthRpcErrorCode {
     ExecutionError,
     /// <https://eips.ethereum.org/EIPS/eip-1898>
     InvalidInput,
+    /// Thrown when a block wasn't found <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1898.md>
+    /// > If the block is not found, the callee SHOULD raise a JSON-RPC error (the recommended
+    /// > error code is -32001: Resource not found).
+    ResourceNotFound,
 }
 
 impl EthRpcErrorCode {
@@ -18,6 +22,7 @@ impl EthRpcErrorCode {
             EthRpcErrorCode::TransactionRejected => -32003,
             EthRpcErrorCode::ExecutionError => 3,
             EthRpcErrorCode::InvalidInput => -32000,
+            EthRpcErrorCode::ResourceNotFound => -32001,
         }
     }
 }

--- a/crates/rpc/rpc/src/eth/error.rs
+++ b/crates/rpc/rpc/src/eth/error.rs
@@ -1,6 +1,6 @@
 //! Implementation specific Errors for the `eth_` namespace.
 
-use crate::result::{internal_rpc_err, invalid_params_rpc_err, rpc_err};
+use crate::result::{internal_rpc_err, invalid_params_rpc_err, rpc_err, rpc_error_with_code};
 use jsonrpsee::core::Error as RpcError;
 use reth_primitives::{constants::SELECTOR_LEN, Address, Bytes, U256};
 use reth_rpc_types::{error::EthRpcErrorCode, BlockError};
@@ -72,7 +72,6 @@ impl From<EthApiError> for RpcError {
             EthApiError::FailedToDecodeSignedTransaction |
             EthApiError::InvalidTransactionSignature |
             EthApiError::EmptyRawTransactionData |
-            EthApiError::UnknownBlockNumber |
             EthApiError::InvalidBlockRange |
             EthApiError::ConflictingRequestGasPrice { .. } |
             EthApiError::ConflictingRequestGasPriceAndTipSet { .. } |
@@ -86,6 +85,9 @@ impl From<EthApiError> for RpcError {
             EthApiError::InvalidBlockData(_) |
             EthApiError::Internal(_) |
             EthApiError::TransactionNotFound => internal_rpc_err(error.to_string()),
+            EthApiError::UnknownBlockNumber => {
+                rpc_error_with_code(EthRpcErrorCode::ResourceNotFound.code(), error.to_string())
+            }
             EthApiError::Unsupported(msg) => internal_rpc_err(msg),
         }
     }


### PR DESCRIPTION
return Resource not found error code:

> If the block is not found, the callee SHOULD raise a JSON-RPC error (the recommended error code is -32001: Resource not found).

https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1898.md