### PR TITLE
perf(acc-hashing): use rayon threadpool to generate hashed accounts

### DIFF
--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -29,4 +29,5 @@ enum StageEnum {
     Bodies,
     Senders,
     Execution,
+    AccountHashing,
 }

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -16,7 +16,7 @@ use reth_staged_sync::{
     Config,
 };
 use reth_stages::{
-    stages::{BodyStage, ExecutionStage, SenderRecoveryStage, AccountHashingStage},
+    stages::{AccountHashingStage, BodyStage, ExecutionStage, SenderRecoveryStage},
     ExecInput, Stage, StageId, UnwindInput,
 };
 use std::{net::SocketAddr, sync::Arc};

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -16,7 +16,7 @@ use reth_staged_sync::{
     Config,
 };
 use reth_stages::{
-    stages::{BodyStage, ExecutionStage, SenderRecoveryStage},
+    stages::{BodyStage, ExecutionStage, SenderRecoveryStage, AccountHashingStage},
     ExecInput, Stage, StageId, UnwindInput,
 };
 use std::{net::SocketAddr, sync::Arc};
@@ -165,6 +165,13 @@ impl Command {
             StageEnum::Execution => {
                 let factory = reth_executor::Factory::new(self.chain.clone());
                 let mut stage = ExecutionStage::new(factory, num_blocks);
+                if !self.skip_unwind {
+                    stage.unwind(&mut tx, unwind).await?;
+                }
+                stage.execute(&mut tx, input).await?;
+            }
+            StageEnum::AccountHashing => {
+                let mut stage = AccountHashingStage::default();
                 if !self.skip_unwind {
                     stage.unwind(&mut tx, unwind).await?;
                 }

--- a/crates/stages/src/stages/hashing_account.rs
+++ b/crates/stages/src/stages/hashing_account.rs
@@ -13,9 +13,8 @@ use reth_db::{
 };
 use reth_primitives::{keccak256, AccountHashingCheckpoint};
 use reth_provider::Transaction;
-use std::{collections::BTreeMap, fmt::Debug, ops::Range};
+use std::{fmt::Debug, ops::Range};
 use tokio::sync::mpsc;
-use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::*;
 
 /// The [`StageId`] of the account hashing stage.
@@ -202,9 +201,8 @@ impl<DB: Database> Stage<DB> for AccountHashingStage {
             let next_address = {
                 let mut accounts = tx.cursor_read::<tables::PlainAccountState>()?;
 
-                let accounts_walker = accounts
-                    .walk(start_address)?
-                    .take(self.commit_threshold as usize);
+                let accounts_walker =
+                    accounts.walk(start_address)?.take(self.commit_threshold as usize);
 
                 for chunk in &accounts_walker
                     .chunks(self.commit_threshold as usize / rayon::current_num_threads())

--- a/crates/stages/src/stages/hashing_account.rs
+++ b/crates/stages/src/stages/hashing_account.rs
@@ -1,7 +1,4 @@
-use crate::{
-    stages::stream::SequentialPairStream, ExecInput, ExecOutput, Stage, StageError, StageId,
-    UnwindInput, UnwindOutput,
-};
+use crate::{ExecInput, ExecOutput, Stage, StageError, StageId, UnwindInput, UnwindOutput};
 use futures_util::StreamExt;
 use itertools::Itertools;
 use reth_codecs::Compact;
@@ -15,6 +12,7 @@ use reth_primitives::{keccak256, AccountHashingCheckpoint};
 use reth_provider::Transaction;
 use std::{fmt::Debug, ops::Range};
 use tokio::sync::mpsc;
+use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::*;
 
 /// The [`StageId`] of the account hashing stage.


### PR DESCRIPTION
Re-use the same technique from the SenderRecovery stage: https://github.com/paradigmxyz/reth/blob/724ec1b5cc4148029181d2d29c4f29e57e6b3878/crates/stages/src/stages/sender_recovery.rs#L90-L114

`cargo bench` is showing a regression in performance, interestingly enough. Maybe because the bench is small and Rayon overhead dominates? I'm gonna run this in prod and see what comes back.

Also, if we want to use the sequential stream, we'd need to make modifications to it so that it can tiebreak on keys that are not Add/One, see below

```patch
diff --git a/crates/stages/src/stages/hashing_account.rs b/crates/stages/src/stages/hashing_account.rs
index 9956bee2..2f000042 100644
--- a/crates/stages/src/stages/hashing_account.rs
+++ b/crates/stages/src/stages/hashing_account.rs
@@ -226,8 +226,13 @@ impl<DB: Database> Stage<DB> for AccountHashingStage {
                 // drop the sender to signal that we're done sending
                 drop(sender);
 
-                let mut hashed_accounts = UnboundedReceiverStream::new(rx);
+                // We sort everything inside the batch to minimize the number of cursor seeks
+                let mut hashed_accounts = SequentialPairStream::new(
+                    keccak256(start_address.unwrap_or_default()),
+                    UnboundedReceiverStream::new(rx),
+                );
                 let mut hashed_account_cursor = tx.cursor_write::<tables::HashedAccount>()?;
+
                 while let Some(account) = hashed_accounts.next().await {
                     let (k, v) = account?;
                     hashed_account_cursor.insert(k, v)?;
diff --git a/crates/stages/src/stages/stream.rs b/crates/stages/src/stages/stream.rs
index 5e8f41e3..408091bc 100644
--- a/crates/stages/src/stages/stream.rs
+++ b/crates/stages/src/stages/stream.rs
@@ -23,7 +23,11 @@ pub(crate) struct SequentialPairStream<Key: Ord, Value, St> {
 
 // === impl SequentialPairStream ===
 
-impl<Key: Ord, Value, St> SequentialPairStream<Key, Value, St> {
+impl<Err, Key: Ord, Value, St> SequentialPairStream<Key, Value, St>
+where
+    Key: Ord + Copy,
+    St: Stream<Item = Result<(Key, Value), Err>>,
+{
     /// Returns a new [SequentialPairStream] that emits the items of the given stream in order
     /// starting at the given start point.
     pub(crate) fn new(start: Key, stream: St) -> Self {
@@ -34,7 +38,7 @@ impl<Key: Ord, Value, St> SequentialPairStream<Key, Value, St> {
 /// implements Stream for any underlying Stream that returns a result
 impl<Key, Value, St, Err> Stream for SequentialPairStream<Key, Value, St>
 where
-    Key: Ord + Copy + Add<Output = Key> + One,
+    Key: Ord + Copy,
     St: Stream<Item = Result<(Key, Value), Err>>,
 {
     type Item = Result<(Key, Value), Err>;
@@ -52,7 +56,7 @@ where
                     }
                     Ordering::Equal => {
                         let next = PeekMut::pop(maybe_next);
-                        *this.next = *this.next + Key::one();
+                        // *this.next = *this.next + Key::one();
                         return Poll::Ready(Some(Ok(next.into())))
                     }
                     Ordering::Greater => {
@@ -75,7 +79,7 @@ where
                     Poll::Ready(item) => match item {
                         Some(Ok((k, v))) => {
                             if k == *this.next {
-                                *this.next = *this.next + Key::one();
+                                // *this.next = *this.next + Key::one();
                                 return Poll::Ready(Some(Ok((k, v))))
                             }
                             this.pending.push(OrderedItem(k, v));
```

Here's the flamegraph on master :
![flame-main](https://user-images.githubusercontent.com/17802178/226770671-e42bffd9-e328-41f7-9323-61d5fbf8afd1.svg)


And here's the flamegraph on this PR:
![flamegraph](https://user-images.githubusercontent.com/17802178/226771509-e601868f-ed0d-403c-b05d-9b92f2753af4.svg)


Both produced via:
```
cargo b --profile debug-fast
flamegraph -- ./target/debug-fast/reth node --debug.max-block <...> --metrics loccalhost
```

Honestly I'm not exactly sure. The gap between the two flamegraphs is the checkpoint, and some p2p logic running alongside it. There's also a big _clone thing that takes 10% of the time. The flamegraphs are going to be easier to parse if you download the file and open them locally in your svg viewer/browser (vs from the github hosted one)