### PR TITLE
fix: use Latest instead of Pending for rpc BlockId

### DIFF
--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -186,7 +186,7 @@ where
         let (res, _env) = self
             .execute_call_at(
                 request,
-                block_number.unwrap_or(BlockId::Number(BlockNumberOrTag::Pending)),
+                block_number.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest)),
                 state_overrides,
             )
             .await?;
@@ -200,7 +200,7 @@ where
         mut request: CallRequest,
         block_number: Option<BlockId>,
     ) -> Result<AccessListWithGasUsed> {
-        let block_id = block_number.unwrap_or(BlockId::Number(BlockNumberOrTag::Pending));
+        let block_id = block_number.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest));
         let access_list = self.create_access_list_at(request.clone(), block_number).await?;
         request.access_list = Some(access_list.clone());
         let gas_used = self.estimate_gas_at(request, block_id).await?;
@@ -216,7 +216,7 @@ where
         Ok(EthApi::estimate_gas_at(
             self,
             request,
-            block_number.unwrap_or(BlockId::Number(BlockNumberOrTag::Pending)),
+            block_number.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest)),
         )
         .await?)
     }

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -94,7 +94,7 @@ where
 
         let (cfg, block, at) = self
             .eth_api
-            .evm_env_at(block_id.unwrap_or(BlockId::Number(BlockNumberOrTag::Pending)))
+            .evm_env_at(block_id.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest)))
             .await?;
         let tx = tx_env_with_recovered(&tx);
         let env = Env { cfg, block, tx };


### PR DESCRIPTION
Previously we used `BlockNumberOrTag::Pending` to get the EVM environment in the `eth_estimateGas`, `eth_createAccessList`, `eth_call`, and `trace_rawTransaction` RPCs. This caused hive tests for these RPCs to fail, because we do not support pending state yet:
```diff
>>  {"jsonrpc":"2.0","id":1,"method":"eth_estimateGas","params":[{"from":"0xaa00000000000000000000000000000000000000","to":"0x0100000000000000000000000000000000000000"}]}
<<  {"jsonrpc":"2.0","error":{"code":-32603,"message":"pending state not implemented yet"},"id":1}
response differs from expected:
 {
-  "error": {
-    "code": -32603,
-    "message": "pending state not implemented yet"
-  },
   "id": 1,
   "jsonrpc": "2.0"
+  "result": "0x5208"
 }
```
 
This changes the tag to `BlockNumberOrTag::Latest`, and causes the `eth_estimateGas/estimate-simple-transfer` test to pass. Remaining `eth_call`, `eth_createAccessList`, and `eth_estimateGas` failures are now not due to the `pending state not implemented yet` failure.