### PR TITLE
chore(rpc): simplify conflicting fee fields error

### DIFF
--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -163,11 +163,7 @@ where
         };
         let transaction = match request.into_typed_request() {
             Some(tx) => tx,
-            None => {
-                return Err(EthApiError::Unsupported(
-                    "both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified",
-                ))
-            }
+            None => return Err(EthApiError::ConflictingFeeFieldsInRequest),
         };
 
         // TODO we need to update additional settings in the transaction: nonce, gaslimit, chainid,

--- a/crates/rpc/rpc/src/eth/error.rs
+++ b/crates/rpc/rpc/src/eth/error.rs
@@ -30,16 +30,10 @@ pub enum EthApiError {
     /// An internal error where prevrandao is not set in the evm's environment
     #[error("Prevrandao not in th EVM's environment after merge")]
     PrevrandaoNotSet,
-    #[error("Conflicting fee values in request. Both legacy gasPrice {gas_price} and maxFeePerGas {max_fee_per_gas} set")]
-    ConflictingRequestGasPrice { gas_price: U256, max_fee_per_gas: U256 },
-    #[error("Conflicting fee values in request. Both legacy gasPrice {gas_price} maxFeePerGas {max_fee_per_gas} and maxPriorityFeePerGas {max_priority_fee_per_gas} set")]
-    ConflictingRequestGasPriceAndTipSet {
-        gas_price: U256,
-        max_fee_per_gas: U256,
-        max_priority_fee_per_gas: U256,
-    },
-    #[error("Conflicting fee values in request. Legacy gasPrice {gas_price} and maxPriorityFeePerGas {max_priority_fee_per_gas} set")]
-    RequestLegacyGasPriceAndTipSet { gas_price: U256, max_priority_fee_per_gas: U256 },
+    /// Thrown when a call or transaction request (`eth_call`, `eth_estimateGas`,
+    /// `eth_sendTransaction`) contains conflicting fields (legacy, EIP-1559)
+    #[error("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")]
+    ConflictingFeeFieldsInRequest,
     #[error(transparent)]
     InvalidTransaction(#[from] InvalidTransactionError),
     /// Thrown when constructing an RPC block from a primitive block data failed.
@@ -73,9 +67,7 @@ impl From<EthApiError> for RpcError {
             EthApiError::InvalidTransactionSignature |
             EthApiError::EmptyRawTransactionData |
             EthApiError::InvalidBlockRange |
-            EthApiError::ConflictingRequestGasPrice { .. } |
-            EthApiError::ConflictingRequestGasPriceAndTipSet { .. } |
-            EthApiError::RequestLegacyGasPriceAndTipSet { .. } |
+            EthApiError::ConflictingFeeFieldsInRequest |
             EthApiError::Signing(_) |
             EthApiError::BothStateAndStateDiffInOverride(_) |
             EthApiError::InvalidTracerConfig => invalid_params_rpc_err(error.to_string()),

--- a/crates/rpc/rpc/src/eth/revm_utils.rs
+++ b/crates/rpc/rpc/src/eth/revm_utils.rs
@@ -189,22 +189,7 @@ impl CallFees {
                 }
                 Ok(CallFees { gas_price: max_fee, max_priority_fee_per_gas })
             }
-            (Some(gas_price), Some(max_fee_per_gas), Some(max_priority_fee_per_gas)) => {
-                Err(EthApiError::ConflictingRequestGasPriceAndTipSet {
-                    gas_price,
-                    max_fee_per_gas,
-                    max_priority_fee_per_gas,
-                })
-            }
-            (Some(gas_price), Some(max_fee_per_gas), None) => {
-                Err(EthApiError::ConflictingRequestGasPrice { gas_price, max_fee_per_gas })
-            }
-            (Some(gas_price), None, Some(max_priority_fee_per_gas)) => {
-                Err(EthApiError::RequestLegacyGasPriceAndTipSet {
-                    gas_price,
-                    max_priority_fee_per_gas,
-                })
-            }
+            _ => Err(EthApiError::ConflictingFeeFieldsInRequest),
         }
     }
 }


### PR DESCRIPTION
only use a single error for conflicting fee fields in request error.

this mirrors geth's error.