### PR TITLE
chore(rpc): add traces for server start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5090,6 +5090,7 @@ dependencies = [
  "tokio",
  "tower",
  "tower-http",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -47,6 +47,11 @@ pub struct IpcServer<B = Identity, L = ()> {
 }
 
 impl IpcServer {
+    /// Returns the configured [Endpoint]
+    pub fn endpoint(&self) -> &Endpoint {
+        &self.endpoint
+    }
+
     /// Start responding to connections requests.
     ///
     /// This will run on the tokio runtime until the server is stopped or the ServerHandle is

--- a/crates/rpc/rpc-builder/Cargo.toml
+++ b/crates/rpc/rpc-builder/Cargo.toml
@@ -18,14 +18,17 @@ reth-rpc-types = { path = "../rpc-types" }
 reth-tasks = { path = "../../tasks" }
 reth-transaction-pool = { path = "../../transaction-pool" }
 
+# rpc/net
 jsonrpsee = { version = "0.16", features = ["server"] }
 tower-http = { version = "0.3", features = ["full"] }
 tower = { version = "0.4", features = ["full"] }
 hyper = "0.14"
 
+# misc
 strum = { version = "0.24", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
+tracing = "0.1"
 
 [dev-dependencies]
 reth-tracing = { path = "../../tracing" }

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -75,6 +75,8 @@ use strum::{AsRefStr, EnumString, EnumVariantNames, ParseError, VariantNames};
 use tower::layer::util::{Identity, Stack};
 use tower_http::cors::CorsLayer;
 
+use tracing::{instrument, trace};
+
 pub use jsonrpsee::server::ServerBuilder;
 pub use reth_ipc::server::{Builder as IpcServerBuilder, Endpoint};
 
@@ -948,14 +950,21 @@ impl RpcServer {
         self.ws_local_addr
     }
 
+    /// Returns the [`Endpoint`] of the ipc server if started.
+    pub fn ipc_endpoint(&self) -> Option<&Endpoint> {
+        self.ipc.as_ref().map(|ipc| ipc.endpoint())
+    }
+
     /// Starts the configured server by spawning the servers on the tokio runtime.
     ///
     /// This returns an [RpcServerHandle] that's connected to the server task(s) until the server is
     /// stopped or the [RpcServerHandle] is dropped.
+    #[instrument(name = "start", skip_all, fields(http = ?self.http_local_addr, ws = ?self.ws_local_addr, ipc = ?self.ipc_endpoint().map(|ipc|ipc.path())), target = "rpc", level = "TRACE")]
     pub async fn start(
         self,
         modules: TransportRpcModules<()>,
     ) -> Result<RpcServerHandle, RpcError> {
+        trace!(target: "rpc", "staring RPC server");
         let TransportRpcModules { http, ws, ipc } = modules;
         let mut handle = RpcServerHandle {
             http_local_addr: self.http_local_addr,


### PR DESCRIPTION
add trace with info about server:

> TRACE start{http=Some(0.0.0.0:8545) ws=None ipc=Some("/tmp/reth.ipc")}: staring RPC server