### PR TITLE
feat: add test chain event subscriptions

### DIFF
--- a/crates/interfaces/src/test_utils/events.rs
+++ b/crates/interfaces/src/test_utils/events.rs
@@ -1,0 +1,33 @@
+use crate::events::{ChainEventSubscriptions, NewBlockNotification, NewBlockNotifications};
+use async_trait::async_trait;
+use reth_primitives::{Header, H256};
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+
+/// A test ChainEventSubscriptions
+#[derive(Clone, Default)]
+pub struct TestChainEventSubscriptions {
+    new_blocks_txs: Arc<Mutex<Vec<UnboundedSender<NewBlockNotification>>>>,
+}
+
+impl TestChainEventSubscriptions {
+    /// Adds new block to the queue that can be consumed with
+    /// [`TestChainEventSubscriptions::subscribe_new_blocks`]
+    pub fn add_new_block(&mut self, hash: H256, header: Header) {
+        let header = Arc::new(header);
+        self.new_blocks_txs
+            .lock()
+            .as_mut()
+            .unwrap()
+            .retain(|tx| tx.send(NewBlockNotification { hash, header: header.clone() }).is_ok())
+    }
+}
+
+impl ChainEventSubscriptions for TestChainEventSubscriptions {
+    fn subscribe_new_blocks(&self) -> NewBlockNotifications {
+        let (new_blocks_tx, new_blocks_rx) = unbounded_channel();
+        self.new_blocks_txs.lock().as_mut().unwrap().push(new_blocks_tx);
+
+        new_blocks_rx
+    }
+}

--- a/crates/interfaces/src/test_utils/mod.rs
+++ b/crates/interfaces/src/test_utils/mod.rs
@@ -1,10 +1,12 @@
 #![allow(unused)]
 
 mod bodies;
+mod events;
 mod headers;
 
 /// Generators for different data structures like block headers, block bodies and ranges of those.
 pub mod generators;
 
 pub use bodies::*;
+pub use events::*;
 pub use headers::*;


### PR DESCRIPTION
extracted from https://github.com/paradigmxyz/reth/pull/1408

this adds a `ChainEventSubscriptions` impl for testing purposes, we don't have this yet but need this for eth rpc pubsub.

with this type the eth pubsub installation would be unlocked