### PR TITLE
fix(execution): poststate extension

### DIFF
--- a/crates/storage/provider/src/post_state.rs
+++ b/crates/storage/provider/src/post_state.rs
@@ -269,6 +269,10 @@ impl PostState {
 
     /// Extend this [PostState] with the changes in another [PostState].
     pub fn extend(&mut self, other: PostState) {
+        if other.changes.is_empty() {
+            return
+        }
+
         self.changes.reserve(other.changes.len());
 
         let mut next_transition_id = self.current_transition_id;


### PR DESCRIPTION
Do not extend the `PostState` if there are no changes.
Bug spotted by @rakita 🎉 