### PR TITLE
fix(pipeline): ensure unwind across stages

### DIFF
--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -237,7 +237,7 @@ impl<DB: Database, U: SyncStateUpdater> Pipeline<DB, U> {
             if stage_progress < to {
                 debug!(from = %stage_progress, %to, "Unwind point too far for stage");
                 self.listeners.notify(PipelineEvent::Skipped { stage_id });
-                return Ok(())
+                continue
             }
 
             debug!(from = %stage_progress, %to, ?bad_block, "Starting unwind");


### PR DESCRIPTION
The pipeline must ensure that all of the stages are unwound to the target block instead of short-circuiting if last stage has not reached the progress