### PR TITLE
fix(sync): done flag for index history stages

### DIFF
--- a/crates/stages/src/stages/index_account_history.rs
+++ b/crates/stages/src/stages/index_account_history.rs
@@ -53,7 +53,7 @@ impl<DB: Database> Stage<DB> for IndexAccountHistoryStage {
         tx.insert_account_history_index(indices)?;
 
         info!(target: "sync::stages::index_account_history", "Stage finished");
-        Ok(ExecOutput { stage_progress: to_block, done: true })
+        Ok(ExecOutput { stage_progress: to_block, done: to_block == previous_stage_progress })
     }
 
     /// Unwind the stage.

--- a/crates/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/src/stages/index_storage_history.rs
@@ -54,7 +54,7 @@ impl<DB: Database> Stage<DB> for IndexStorageHistoryStage {
         tx.insert_storage_history_index(indices)?;
 
         info!(target: "sync::stages::index_storage_history", "Stage finished");
-        Ok(ExecOutput { stage_progress: to_block, done: true })
+        Ok(ExecOutput { stage_progress: to_block, done: to_block == previous_stage_progress })
     }
 
     /// Unwind the stage.


### PR DESCRIPTION
Set `done` flag correctly in index history stages