### PR TITLE
fix: don't write zero slots from genesis to state

### DIFF
--- a/crates/staged-sync/src/utils/init.rs
+++ b/crates/staged-sync/src/utils/init.rs
@@ -103,6 +103,9 @@ pub fn insert_genesis_state<DB: Database>(
         // insert plain storages
         if let Some(storage) = &account.storage {
             for (&key, &value) in storage {
+                if value.is_zero() {
+                    continue
+                }
                 storage_cursor.upsert(*address, StorageEntry { key, value: value.into() })?
             }
         }


### PR DESCRIPTION
Some Hive tests have storage slots with no value in them in their genesis, which propagated to the hashing stages, and ultimately the merkle stage, leading us to calculate a storage root including empty storage slots.

Closes #1905