### PR TITLE
fix(download): handle bodies range reset after unwind

### DIFF
--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -308,7 +308,7 @@ where
         tracing::trace!(target: "downloaders::bodies", ?range, prev_range = ?self.download_range, "Download range reset");
         self.clear();
         self.download_range = range;
-        return Ok(())
+        Ok(())
     }
 }
 

--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -281,27 +281,34 @@ where
     fn set_download_range(&mut self, range: Range<BlockNumber>) -> DownloadResult<()> {
         // Check if the range is valid.
         let is_valid = !range.is_empty();
-        if is_valid {
-            // Check if the provided range is the subset of the existing range.
-            let is_current_range_subset =
-                self.download_range.contains(&range.start) && range.end == self.download_range.end;
-            if is_current_range_subset {
-                tracing::trace!(target: "downloaders::bodies", ?range, "Download range already in progress");
-                // The current range already includes requested.
-                return Ok(())
-            }
-
-            // Check if the provided range is the next expected range.
-            let is_next_range = range.start >= self.download_range.end;
-            if is_next_range {
-                // New range received.
-                tracing::trace!(target: "downloaders::bodies", ?range, "New download range set");
-                self.download_range = range;
-                return Ok(())
-            }
+        if !is_valid {
+            tracing::error!(target: "downloaders::bodies", ?range, "Range is invalid");
+            return Err(DownloadError::InvalidBodyRange { range })
         }
 
-        Err(DownloadError::InvalidBodyRange { range })
+        // Check if the provided range is the subset of the existing range.
+        let is_current_range_subset =
+            self.download_range.contains(&range.start) && range.end == self.download_range.end;
+        if is_current_range_subset {
+            tracing::trace!(target: "downloaders::bodies", ?range, "Download range already in progress");
+            // The current range already includes requested.
+            return Ok(())
+        }
+
+        // Check if the provided range is the next expected range.
+        let is_next_range = range.start >= self.download_range.end;
+        if is_next_range {
+            // New range received.
+            tracing::trace!(target: "downloaders::bodies", ?range, "New download range set");
+            self.download_range = range;
+            return Ok(())
+        }
+
+        // The block range reset after unwind.
+        tracing::trace!(target: "downloaders::bodies", ?range, prev_range = ?self.download_range, "Download range reset");
+        self.clear();
+        self.download_range = range;
+        return Ok(())
     }
 }
 

--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -280,8 +280,7 @@ where
     /// downloaded or are not in progress, they will be re-requested.
     fn set_download_range(&mut self, range: Range<BlockNumber>) -> DownloadResult<()> {
         // Check if the range is valid.
-        let is_valid = !range.is_empty();
-        if !is_valid {
+        if range.is_empty() {
             tracing::error!(target: "downloaders::bodies", ?range, "Range is invalid");
             return Err(DownloadError::InvalidBodyRange { range })
         }


### PR DESCRIPTION
Previously, the bodies downloader was only able to handle the forward sync. Add support for range reset after an unwind