### PR TITLE
feat: full peer id as a debug statement

### DIFF
--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -208,7 +208,7 @@ impl Command {
             .start_network(network_config, &ctx.task_executor, transaction_pool.clone())
             .await?;
         info!(target: "reth::cli", peer_id = %network.peer_id(), local_addr = %network.local_addr(), "Connected to P2P network");
-        debug!(target: "reth::cli", "Full peer id {:?}", network.peer_id());
+        debug!(target: "reth::cli", peer_id = ?network.peer_id(), "Full peer ID");
 
         let _rpc_server = self
             .rpc

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -208,6 +208,7 @@ impl Command {
             .start_network(network_config, &ctx.task_executor, transaction_pool.clone())
             .await?;
         info!(target: "reth::cli", peer_id = %network.peer_id(), local_addr = %network.local_addr(), "Connected to P2P network");
+        debug!(target: "reth::cli", "Full peer id {:?}", network.peer_id());
 
         let _rpc_server = self
             .rpc


### PR DESCRIPTION
Adds a debug print statement to print the entire peer id. This is helpful when attempting to add a trusted peer.