### PR TITLE
fix(rpc): AccountOverride nonce type is Quantity

### DIFF
--- a/crates/rpc/rpc-types/src/eth/state.rs
+++ b/crates/rpc/rpc-types/src/eth/state.rs
@@ -13,15 +13,20 @@ pub type StateOverride = HashMap<Address, AccountOverride>;
 #[allow(missing_docs)]
 pub struct AccountOverride {
     /// Fake balance to set for the account before executing the call.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub balance: Option<U256>,
     /// Fake nonce to set for the account before executing the call.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub nonce: Option<U64>,
     /// Fake EVM bytecode to inject into the account before executing the call.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub code: Option<Bytes>,
     /// Fake key-value mapping to override all slots in the account storage before executing the
     /// call.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub state: Option<HashMap<H256, H256>>,
     /// Fake key-value mapping to override individual slots in the account storage before executing
     /// the call.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub state_diff: Option<HashMap<H256, H256>>,
 }

--- a/crates/rpc/rpc-types/src/eth/state.rs
+++ b/crates/rpc/rpc-types/src/eth/state.rs
@@ -1,6 +1,6 @@
 //! bindings for state overrides in eth_call
 
-use reth_primitives::{Address, Bytes, H256, U256};
+use reth_primitives::{Address, Bytes, H256, U256, U64};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -12,9 +12,16 @@ pub type StateOverride = HashMap<Address, AccountOverride>;
 #[serde(default, rename_all = "camelCase", deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct AccountOverride {
-    pub nonce: Option<u64>,
-    pub code: Option<Bytes>,
+    /// Fake balance to set for the account before executing the call.
     pub balance: Option<U256>,
+    /// Fake nonce to set for the account before executing the call.
+    pub nonce: Option<U64>,
+    /// Fake EVM bytecode to inject into the account before executing the call.
+    pub code: Option<Bytes>,
+    /// Fake key-value mapping to override all slots in the account storage before executing the
+    /// call.
     pub state: Option<HashMap<H256, H256>>,
+    /// Fake key-value mapping to override individual slots in the account storage before executing
+    /// the call.
     pub state_diff: Option<HashMap<H256, H256>>,
 }

--- a/crates/rpc/rpc/src/eth/api/call.rs
+++ b/crates/rpc/rpc/src/eth/api/call.rs
@@ -345,7 +345,7 @@ where
     let mut account_info = db.basic(account)?.unwrap_or_default();
 
     if let Some(nonce) = account_override.nonce {
-        account_info.nonce = nonce;
+        account_info.nonce = nonce.as_u64();
     }
     if let Some(code) = account_override.code {
         account_info.code = Some(Bytecode::new_raw(code.0));


### PR DESCRIPTION
also makes fields optional, via serde attributes, because they're not required to be `null` and can be missing entirely.