### PR TITLE
fix: do not send pooled transactions if pool is empty

### DIFF
--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -368,11 +368,14 @@ where
 
                     let mut msg_builder = PooledTransactionsHashesBuilder::new(version);
 
-                    for pooled_tx in self
-                        .pool
-                        .pooled_transactions()
-                        .into_iter()
-                        .take(NEW_POOLED_TRANSACTION_HASHES_SOFT_LIMIT)
+                    let pooled_txs = self.pool.pooled_transactions();
+                    if pooled_txs.is_empty() {
+                        // do not send a message if there are no transactions in the pool
+                        return
+                    }
+
+                    for pooled_tx in
+                        pooled_txs.into_iter().take(NEW_POOLED_TRANSACTION_HASHES_SOFT_LIMIT)
                     {
                         peer.transactions.insert(*pooled_tx.hash());
                         msg_builder.push_pooled(pooled_tx);


### PR DESCRIPTION
This prevents us from sending a `NewPooledTransactions` message if the pool is empty. This also caused a hive `devp2p` test to fail because the test requests headers, and does not expect an empty `NewPooledTransactionHashes`  as the first message.

See this workflow run for the hive failure:
https://github.com/paradigmxyz/reth/actions/runs/4505504473/jobs/7931395605?pr=1348#step:7:14
```
# failed to get block headers: unexpected message received: (*ethtest.NewPooledTransactionHashes)({
#   Types: ([]uint8) {
#   },
#   Sizes: ([]uint32) {
#   },
#   Hashes: ([]common.Hash) {
#   }
# })
```

We already ensure that the pool is not empty in other calls to `send_transactions_hashes`:
https://github.com/paradigmxyz/reth/blob/1a2a22606f51d52311438326e16903295ac23572/crates/net/network/src/transactions.rs#L242-L264