### PR TITLE
fix: incremental storage root calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,12 +652,12 @@ dependencies = [
 [[package]]
 name = "cita_trie"
 version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afe7baab47f510f52ca8dc9c0eb9082020c627c7f22285bea30edc3511f7ee29"
+source = "git+https://github.com/joshieDo/cita-trie#554acb6c7d6e8dfd6a7abc73a5705bc3efbc7215"
 dependencies = [
- "hasher",
  "parking_lot 0.12.1",
+ "reth-rlp 0.1.2 (git+https://github.com/paradigmxyz/reth)",
  "rlp",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -2400,9 +2400,6 @@ name = "hasher"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbba678b6567f27ce22870d951f4208e1dc2fef64993bd4521b1d497ef8a3aa"
-dependencies = [
- "tiny-keccak",
-]
 
 [[package]]
 name = "hashers"
@@ -4461,7 +4458,7 @@ dependencies = [
  "reth-primitives",
  "reth-provider",
  "reth-revm-inspectors",
- "reth-rlp",
+ "reth-rlp 0.1.2",
  "reth-rpc",
  "reth-rpc-builder",
  "reth-rpc-engine-api",
@@ -4574,7 +4571,7 @@ dependencies = [
  "reth-net-common",
  "reth-net-nat",
  "reth-primitives",
- "reth-rlp",
+ "reth-rlp 0.1.2",
  "reth-rlp-derive",
  "reth-tracing",
  "secp256k1",
@@ -4596,7 +4593,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "reth-net-common",
  "reth-primitives",
- "reth-rlp",
+ "reth-rlp 0.1.2",
  "reth-tracing",
  "schnellru",
  "secp256k1",
@@ -4624,7 +4621,7 @@ dependencies = [
  "reth-interfaces",
  "reth-metrics-derive",
  "reth-primitives",
- "reth-rlp",
+ "reth-rlp 0.1.2",
  "reth-tasks",
  "reth-tracing",
  "tempfile",
@@ -4654,7 +4651,7 @@ dependencies = [
  "rand 0.8.5",
  "reth-net-common",
  "reth-primitives",
- "reth-rlp",
+ "reth-rlp 0.1.2",
  "secp256k1",
  "sha2 0.10.6",
  "sha3",
@@ -4685,7 +4682,7 @@ dependencies = [
  "reth-codecs",
  "reth-ecies",
  "reth-primitives",
- "reth-rlp",
+ "reth-rlp 0.1.2",
  "reth-tracing",
  "secp256k1",
  "serde",
@@ -4715,7 +4712,7 @@ dependencies = [
  "reth-provider",
  "reth-revm",
  "reth-revm-inspectors",
- "reth-rlp",
+ "reth-rlp 0.1.2",
  "revm",
  "rlp",
  "sha3",
@@ -4878,7 +4875,7 @@ dependencies = [
  "reth-network-api",
  "reth-primitives",
  "reth-provider",
- "reth-rlp",
+ "reth-rlp 0.1.2",
  "reth-rlp-derive",
  "reth-tasks",
  "reth-tracing",
@@ -4931,7 +4928,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.8.5",
  "reth-codecs",
- "reth-rlp",
+ "reth-rlp 0.1.2",
  "reth-rlp-derive",
  "revm-primitives",
  "secp256k1",
@@ -4963,7 +4960,7 @@ dependencies = [
  "reth-interfaces",
  "reth-primitives",
  "reth-revm-primitives",
- "reth-rlp",
+ "reth-rlp 0.1.2",
  "reth-tracing",
  "revm-primitives",
  "thiserror",
@@ -5014,10 +5011,21 @@ dependencies = [
  "ethnum",
  "hex-literal",
  "pprof",
- "reth-rlp",
+ "reth-rlp 0.1.2",
  "reth-rlp-derive",
  "revm-primitives",
  "smol_str",
+]
+
+[[package]]
+name = "reth-rlp"
+version = "0.1.2"
+source = "git+https://github.com/paradigmxyz/reth#2ce72c51e10640e28def1dc8a51a01ac9021fe23"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+ "revm-primitives",
 ]
 
 [[package]]
@@ -5050,7 +5058,7 @@ dependencies = [
  "reth-primitives",
  "reth-provider",
  "reth-revm",
- "reth-rlp",
+ "reth-rlp 0.1.2",
  "reth-rpc-api",
  "reth-rpc-engine-api",
  "reth-rpc-types",
@@ -5137,7 +5145,7 @@ dependencies = [
  "reth-interfaces",
  "reth-network-api",
  "reth-primitives",
- "reth-rlp",
+ "reth-rlp 0.1.2",
  "serde",
  "serde_json",
  "thiserror",
@@ -5206,7 +5214,7 @@ dependencies = [
  "reth-metrics-derive",
  "reth-primitives",
  "reth-provider",
- "reth-rlp",
+ "reth-rlp 0.1.2",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -5252,7 +5260,7 @@ dependencies = [
  "reth-metrics-derive",
  "reth-primitives",
  "reth-provider",
- "reth-rlp",
+ "reth-rlp 0.1.2",
  "ruint",
  "serde",
  "thiserror",

--- a/crates/storage/provider/src/trie/mod.rs
+++ b/crates/storage/provider/src/trie/mod.rs
@@ -628,13 +628,7 @@ where
 
         let number_of_changed_accounts = changed_accounts.len();
         for (idx, (hashed_address, changed_storages)) in changed_accounts.into_iter().enumerate() {
-            println!("Entering with account {:?}", hashed_address);
             let res = if let Some(account) = trie.get(hashed_address.as_slice())? {
-                println!("Incrementally calculating storage root");
-                // NOTE: We need to remove the account here, because on some paths it is not
-                // re-inserted, leading to us hitting the second branch after certain checkpoints
-                // trie.remove(hashed_address.as_bytes())?;
-
                 let storage_root = EthAccount::decode(&mut account.as_slice())?.storage_root;
                 self.update_storage_root(
                     checkpoint.storage_root.take().unwrap_or(storage_root),
@@ -644,7 +638,6 @@ where
                     checkpoint.storage_key.take(),
                 )?
             } else {
-                println!("Calculating storage root from scratch");
                 self.calculate_storage_root(
                     hashed_address,
                     &mut storage_cursor,

--- a/crates/storage/provider/src/trie/mod.rs
+++ b/crates/storage/provider/src/trie/mod.rs
@@ -629,6 +629,13 @@ where
         let number_of_changed_accounts = changed_accounts.len();
         for (idx, (hashed_address, changed_storages)) in changed_accounts.into_iter().enumerate() {
             let res = if let Some(account) = trie.get(hashed_address.as_slice())? {
+                if accounts_cursor.seek_exact(hashed_address)?.is_none() {
+                    // The account was self destructed
+                    // TODO: Clear the StoragesTrie as well
+                    trie.remove(hashed_address.as_bytes())?;
+                    continue
+                }
+
                 let storage_root = EthAccount::decode(&mut account.as_slice())?.storage_root;
                 self.update_storage_root(
                     checkpoint.storage_root.take().unwrap_or(storage_root),


### PR DESCRIPTION
(All in a severe need of a clean up)

Includes a number of fixes for the `update_root` path of the `DBTrieLoader`

1. If the commit threshold is hit for an account or a storage slot, BUT it is the last storage slot or account, we don't commit a checkpoint, we return the calculated root instead. Without this, on certain sets of changed accounts/slots and a commit threshold you might end up in a loop where it never terminates
2. Fixes the `skip_while` for `changed_storages`. Previously, if the checkpoint was not the first storage slot, not all storage slots that should have been skipped would be
3. Does the same commit threshold trick for storages as with accounts (described in point 1)
4. Adds a test that is in severe need of cleanup. This test checks `update_root` works on top of an existing state root, with a changed account. This account has 2 changed storage slots and a new one to check that all changes are applied correctly. The commit threshold in this test is set to something lower than the number of changes we need to make, to ensure that the storage root is calculated correctly in this branch
5. Creates a storage trie from the previous storage root in order to load the old (possibly unchanged) storage slots. Previously, if you had slots A, B and C, and only changed slot C, the storage root would only be computed for slot C. This branch will most likely fail if the account is new

@joshieDo Does the `update_root` path handle deleted accounts? It seems like all `changed_accounts` are assumed to be a change in either their storages or their account info, but never a delete

Misc changes

- Also includes short circuits for not calculating storage roots if there is no storage for the account

cc @rkrasiuk can you check if this fixes incremental state root calculation for the blockchain tree on Sepolia?