### PR TITLE
chore: add the rest of the tables to db list

### DIFF
--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -166,14 +166,27 @@ impl Command {
                     Headers,
                     BlockBodies,
                     BlockOmmers,
+                    BlockWithdrawals,
+                    TransactionBlock,
+                    Transactions,
                     TxHashNumber,
+                    Receipts,
                     PlainStorageState,
                     PlainAccountState,
+                    Bytecodes,
                     BlockTransitionIndex,
                     TxTransitionIndex,
+                    AccountHistory,
+                    StorageHistory,
+                    AccountChangeSet,
+                    StorageChangeSet,
+                    HashedAccount,
+                    HashedStorage,
+                    AccountsTrie,
+                    StoragesTrie,
+                    TxSenders,
                     SyncStage,
-                    SyncStageProgress,
-                    Transactions
+                    SyncStageProgress
                 ]);
             }
             Subcommands::Drop => {


### PR DESCRIPTION
Adds the rest of the tables to `reth db list`.