### PR TITLE
feat(consensus): sync pipeline until tree includes head

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -7,7 +7,7 @@ use reth_interfaces::{
     sync::SyncStateUpdater,
     Error,
 };
-use reth_primitives::{BlockHash, BlockNumber, SealedBlock, H256};
+use reth_primitives::{BlockNumber, SealedBlock, H256};
 use reth_provider::ExecutorFactory;
 use reth_rpc_types::engine::{
     ExecutionPayload, ForkchoiceUpdated, PayloadAttributes, PayloadStatus, PayloadStatusEnum,

--- a/crates/executor/src/blockchain_tree/mod.rs
+++ b/crates/executor/src/blockchain_tree/mod.rs
@@ -141,9 +141,14 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
         })
     }
 
-    /// Return the tip of the canonical chain
+    /// Return block number of the tip of the canonical chain
     pub fn canonical_tip_number(&self) -> Option<BlockNumber> {
         self.block_indices.canonical_chain().last_key_value().map(|(number, _)| *number)
+    }
+
+    /// Return block hash the tip of the canonical chain
+    pub fn canonical_tip_hash(&self) -> Option<BlockHash> {
+        self.block_indices.canonical_chain().last_key_value().map(|(_, hash)| *hash)
     }
 
     /// Create a new sidechain by forking the given chain, or append the block if the parent block

--- a/crates/executor/src/blockchain_tree/mod.rs
+++ b/crates/executor/src/blockchain_tree/mod.rs
@@ -147,8 +147,8 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
     }
 
     /// Return block hash the tip of the canonical chain
-    pub fn canonical_tip_hash(&self) -> Option<BlockHash> {
-        self.block_indices.canonical_chain().last_key_value().map(|(_, hash)| *hash)
+    pub fn is_block_hash_canonical(&self, block_hash: &BlockHash) -> bool {
+        self.block_indices.is_block_hash_canonical(block_hash)
     }
 
     /// Create a new sidechain by forking the given chain, or append the block if the parent block

--- a/crates/stages/src/test_utils/set.rs
+++ b/crates/stages/src/test_utils/set.rs
@@ -1,20 +1,35 @@
 use super::{TestStage, TEST_STAGE_ID};
 use crate::{ExecOutput, StageError, StageSet, StageSetBuilder, UnwindOutput};
 use reth_db::database::Database;
-use std::collections::VecDeque;
+use std::{collections::VecDeque, time::Duration};
 
 #[derive(Default, Debug)]
 pub struct TestStages {
     exec_outputs: VecDeque<Result<ExecOutput, StageError>>,
     unwind_outputs: VecDeque<Result<UnwindOutput, StageError>>,
+    delay: Option<Duration>,
 }
 
 impl TestStages {
-    pub fn new(
+    pub fn with_exec_outputs(
+        mut self,
         exec_outputs: VecDeque<Result<ExecOutput, StageError>>,
+    ) -> Self {
+        self.exec_outputs = exec_outputs;
+        self
+    }
+
+    pub fn with_unwind_outputs(
+        mut self,
         unwind_outputs: VecDeque<Result<UnwindOutput, StageError>>,
     ) -> Self {
-        Self { exec_outputs, unwind_outputs }
+        self.unwind_outputs = unwind_outputs;
+        self
+    }
+
+    pub fn with_delay(mut self, duration: Option<Duration>) -> Self {
+        self.delay = duration;
+        self
     }
 }
 
@@ -23,7 +38,8 @@ impl<DB: Database> StageSet<DB> for TestStages {
         StageSetBuilder::default().add_stage(
             TestStage::new(TEST_STAGE_ID)
                 .with_exec(self.exec_outputs)
-                .with_unwind(self.unwind_outputs),
+                .with_unwind(self.unwind_outputs)
+                .with_delay(self.delay),
         )
     }
 }


### PR DESCRIPTION
Constantly sync the pipeline until the `BlockchainTree` tip includes the head hash.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2b955c8</samp>

This pull request introduces some changes to the consensus engine, the stages module, and the blockchain tree module. The main goals are to refactor the engine code to use a generic trait and a struct for managing different stages and forkchoice states, to add a way to test pipeline delays in the stages module, and to add a function to check the canonicality of a block hash in the blockchain tree module. The affected files are `crates/consensus/beacon/src/engine/mod.rs`, `crates/stages/src/test_utils/set.rs`, `crates/stages/src/test_utils/stage.rs`, and `crates/executor/src/blockchain_tree/mod.rs`.