### PR TITLE
test(execution): extending with empty poststate

### DIFF
--- a/crates/storage/provider/src/post_state.rs
+++ b/crates/storage/provider/src/post_state.rs
@@ -598,6 +598,25 @@ mod tests {
     };
     use std::sync::Arc;
 
+    // Ensure that the transition id is not incremented if postate is extended by another empty
+    // poststate.
+    #[test]
+    fn extend_empty() {
+        let mut a = PostState::new();
+        assert_eq!(a.current_transition_id, 0);
+
+        // Extend empty poststate with another empty poststate
+        a.extend(PostState::new());
+        assert_eq!(a.current_transition_id, 0);
+
+        // Add single transition and extend with empty poststate
+        a.create_account(Address::zero(), Account::default());
+        a.finish_transition();
+        let transition_id = a.current_transition_id;
+        a.extend(PostState::new());
+        assert_eq!(a.current_transition_id, transition_id);
+    }
+
     #[test]
     fn extend() {
         let mut a = PostState::new();


### PR DESCRIPTION
Add test covering the bug when the current transition id was incremented by extending any poststate with an empty poststate. In such case the current transition id should remain the same (as it was before extension).

Bug was fixed in #1929