### PR TITLE
fix: add remaining sepolia test vector from geth

### DIFF
--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -803,7 +803,7 @@ mod tests {
                     ForkId { hash: ForkHash([0xb9, 0x6c, 0xbd, 0x13]), next: 1677557088 },
                 ),
                 (
-                    Head { number: 1735372, timestamp: 1677557090, ..Default::default() },
+                    Head { number: 1735372, timestamp: 1677557088, ..Default::default() },
                     ForkId { hash: ForkHash([0xf7, 0xf9, 0xbc, 0x08]), next: 0 },
                 ),
             ],

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -799,6 +799,10 @@ mod tests {
                     ForkId { hash: ForkHash([0xb9, 0x6c, 0xbd, 0x13]), next: 1677557088 },
                 ),
                 (
+                    Head { number: 1735372, timestamp: 1677557087, ..Default::default() },
+                    ForkId { hash: ForkHash([0xb9, 0x6c, 0xbd, 0x13]), next: 1677557088 },
+                ),
+                (
                     Head { number: 1735372, timestamp: 1677557090, ..Default::default() },
                     ForkId { hash: ForkHash([0xf7, 0xf9, 0xbc, 0x08]), next: 0 },
                 ),


### PR DESCRIPTION
Add the remaining sepolia forkid test vector from geth:
https://github.com/ethereum/go-ethereum/blob/master/core/forkid/forkid_test.go#L123-L127