### PR TITLE
rpc: fill missing fields in send_transaction

### DIFF
--- a/crates/rpc/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc/rpc-types/src/eth/transaction/request.rs
@@ -44,7 +44,7 @@ pub struct TransactionRequest {
 impl TransactionRequest {
     /// Converts the request into a [`TypedTransactionRequest`]
     ///
-    /// Returns None if mutual exclusive fields `gasPrice` and `max_fee_per_gas` are either missing
+    /// Returns None if mutual exclusive fields `gas_price` and `max_fee_per_gas` are either missing
     /// or both set.
     pub fn into_typed_request(self) -> Option<TypedTransactionRequest> {
         let TransactionRequest {

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -10,6 +10,7 @@ use crate::{
     result::{internal_rpc_err, ToRpcResult},
 };
 use jsonrpsee::core::RpcResult as Result;
+use reth_network_api::NetworkInfo;
 use reth_primitives::{
     AccessListWithGasUsed, Address, BlockId, BlockNumberOrTag, Bytes, Header, H256, H64, U256, U64,
 };
@@ -31,7 +32,7 @@ where
     Self: EthApiSpec + EthTransactions,
     Pool: TransactionPool + 'static,
     Client: BlockProvider + HeaderProvider + StateProviderFactory + EvmEnvProvider + 'static,
-    Network: Send + Sync + 'static,
+    Network: NetworkInfo + Send + Sync + 'static,
 {
     /// Handler for: `eth_protocolVersion`
     async fn protocol_version(&self) -> Result<U64> {


### PR DESCRIPTION
Fill up remaining fields in send_transaction by using get_chain_id for chain id, get_transaction_count to get the latest nonce of the user and currently infer gas limits, gas price and max fee per gas from request