### PR TITLE
chore(rpc): improve rpc server launch error diagnostic

### DIFF
--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -2,15 +2,15 @@
 
 use crate::dirs::{JwtSecretPath, PlatformPath};
 use clap::Args;
-use jsonrpsee::{core::Error as RpcError, server::ServerHandle};
+use jsonrpsee::server::ServerHandle;
 use reth_interfaces::events::ChainEventSubscriptions;
 use reth_network_api::{NetworkInfo, Peers};
 use reth_primitives::ChainSpec;
 use reth_provider::{BlockProvider, EvmEnvProvider, HeaderProvider, StateProviderFactory};
 use reth_rpc::{JwtError, JwtSecret};
 use reth_rpc_builder::{
-    constants, IpcServerBuilder, RethRpcModule, RpcModuleSelection, RpcServerConfig,
-    RpcServerHandle, ServerBuilder, TransportRpcModuleConfig,
+    constants, error::RpcError, IpcServerBuilder, RethRpcModule, RpcModuleSelection,
+    RpcServerConfig, RpcServerHandle, ServerBuilder, TransportRpcModuleConfig,
 };
 use reth_rpc_engine_api::EngineApiHandle;
 use reth_tasks::TaskSpawner;

--- a/crates/rpc/rpc-builder/src/auth.rs
+++ b/crates/rpc/rpc-builder/src/auth.rs
@@ -1,4 +1,4 @@
-use crate::error::{RpcError, RpcHandle};
+use crate::error::{RpcError, ServerKind};
 pub use jsonrpsee::server::ServerBuilder;
 use jsonrpsee::server::{RpcModule, ServerHandle};
 use reth_network_api::{NetworkInfo, Peers};
@@ -77,7 +77,7 @@ where
     // By default, both http and ws are enabled.
     let server =
         ServerBuilder::new().set_middleware(middleware).build(socket_addr).await.map_err(
-            |err| RpcError::from_jsonrpsee_error(err, Some(RpcHandle::Auth(socket_addr))),
+            |err| RpcError::from_jsonrpsee_error(err, Some(ServerKind::Auth(socket_addr))),
         )?;
 
     server.start(module).map_err(|err| RpcError::from_jsonrpsee_error(err, None))

--- a/crates/rpc/rpc-builder/src/auth.rs
+++ b/crates/rpc/rpc-builder/src/auth.rs
@@ -75,10 +75,11 @@ where
         tower::ServiceBuilder::new().layer(AuthLayer::new(JwtAuthValidator::new(secret)));
 
     // By default, both http and ws are enabled.
-    let server =
-        ServerBuilder::new().set_middleware(middleware).build(socket_addr).await.map_err(
-            |err| RpcError::from_jsonrpsee_error(err, Some(ServerKind::Auth(socket_addr))),
-        )?;
+    let server = ServerBuilder::new()
+        .set_middleware(middleware)
+        .build(socket_addr)
+        .await
+        .map_err(|err| RpcError::from_jsonrpsee_error(err, ServerKind::Auth(socket_addr)))?;
 
-    server.start(module).map_err(|err| RpcError::from_jsonrpsee_error(err, None))
+    Ok(server.start(module)?)
 }

--- a/crates/rpc/rpc-builder/src/error.rs
+++ b/crates/rpc/rpc-builder/src/error.rs
@@ -34,7 +34,7 @@ pub enum RpcError {
     #[error("Address {0} is already in use (os error 98)")]
     AddressAlreadyInUse(ServerKind),
     /// Custom error.
-    #[error("Custom error: {0}")]
+    #[error("{0}")]
     Custom(String),
 }
 

--- a/crates/rpc/rpc-builder/src/error.rs
+++ b/crates/rpc/rpc-builder/src/error.rs
@@ -3,23 +3,23 @@ use std::net::SocketAddr;
 use jsonrpsee::core::Error as JsonRpseeError;
 use std::io::{Error as IoError, ErrorKind};
 
-/// Handle type.
+/// Rpc server kind.
 #[derive(Debug)]
-pub enum RpcHandle {
-    /// Http handle.
+pub enum ServerKind {
+    /// Http.
     Http(SocketAddr),
-    /// Websocket handle.
+    /// Websocket.
     WS(SocketAddr),
-    /// Auth handle.
+    /// Auth.
     Auth(SocketAddr),
 }
 
-impl std::fmt::Display for RpcHandle {
+impl std::fmt::Display for ServerKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            RpcHandle::Http(addr) => write!(f, "{addr} (HTTP-RPC server)"),
-            RpcHandle::WS(addr) => write!(f, "{addr} (WS-RPC server)"),
-            RpcHandle::Auth(addr) => write!(f, "{addr} (AUTH server)"),
+            ServerKind::Http(addr) => write!(f, "{addr} (HTTP-RPC server)"),
+            ServerKind::WS(addr) => write!(f, "{addr} (WS-RPC server)"),
+            ServerKind::Auth(addr) => write!(f, "{addr} (AUTH server)"),
         }
     }
 }
@@ -32,7 +32,7 @@ pub enum RpcError {
     RpcError(JsonRpseeError),
     /// Address already in use.
     #[error("Address {0} is already in use (os error 98)")]
-    AddressAlreadyInUse(RpcHandle),
+    AddressAlreadyInUse(ServerKind),
     /// Custom error.
     #[error("Custom error: {0}")]
     Custom(String),
@@ -40,7 +40,7 @@ pub enum RpcError {
 
 impl RpcError {
     /// Converts a `jsonrpsee::core::Error` to a more descriptive `RpcError`.
-    pub fn from_jsonrpsee_error(error: JsonRpseeError, handle: Option<RpcHandle>) -> RpcError {
+    pub fn from_jsonrpsee_error(error: JsonRpseeError, handle: Option<ServerKind>) -> RpcError {
         match error {
             JsonRpseeError::Transport(error) => {
                 if let Some(io_error) = error.downcast_ref::<IoError>() {

--- a/crates/rpc/rpc-builder/src/error.rs
+++ b/crates/rpc/rpc-builder/src/error.rs
@@ -62,15 +62,3 @@ impl RpcError {
         }
     }
 }
-
-impl PartialEq for RpcError {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (
-                RpcError::AddressAlreadyInUse { kind: kind1, error: error1 },
-                RpcError::AddressAlreadyInUse { kind: kind2, error: error2 },
-            ) => kind1 == kind2 && error1.raw_os_error() == error2.raw_os_error(),
-            _ => false,
-        }
-    }
-}

--- a/crates/rpc/rpc-builder/src/error.rs
+++ b/crates/rpc/rpc-builder/src/error.rs
@@ -48,13 +48,16 @@ pub enum RpcError {
 
 impl RpcError {
     /// Converts a `jsonrpsee::core::Error` to a more descriptive `RpcError`.
-    pub fn from_jsonrpsee_error(error: JsonRpseeError, handle: Option<ServerKind>) -> RpcError {
+    pub fn from_jsonrpsee_error(
+        error: JsonRpseeError,
+        server_kind: Option<ServerKind>,
+    ) -> RpcError {
         match error {
             JsonRpseeError::Transport(err) => match err.downcast::<IoError>() {
                 Ok(io_error) => {
                     if io_error.kind() == ErrorKind::AddrInUse {
                         return RpcError::AddressAlreadyInUse {
-                            kind: handle.unwrap_or(ServerKind::Unknown),
+                            kind: server_kind.unwrap_or(ServerKind::Unknown),
                             error: io_error,
                         }
                     }

--- a/crates/rpc/rpc-builder/src/error.rs
+++ b/crates/rpc/rpc-builder/src/error.rs
@@ -4,7 +4,7 @@ use jsonrpsee::core::Error as JsonRpseeError;
 use std::{io, io::ErrorKind};
 
 /// Rpc server kind.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum ServerKind {
     /// Http.
     Http(SocketAddr),
@@ -59,6 +59,18 @@ impl RpcError {
                 RpcError::RpcError(err.into())
             }
             _ => err.into(),
+        }
+    }
+}
+
+impl PartialEq for RpcError {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                RpcError::AddressAlreadyInUse { kind: kind1, error: error1 },
+                RpcError::AddressAlreadyInUse { kind: kind2, error: error2 },
+            ) => kind1 == kind2 && error1.raw_os_error() == error2.raw_os_error(),
+            _ => false,
         }
     }
 }

--- a/crates/rpc/rpc-builder/src/error.rs
+++ b/crates/rpc/rpc-builder/src/error.rs
@@ -1,0 +1,56 @@
+use std::net::SocketAddr;
+
+use jsonrpsee::core::Error as JsonRpseeError;
+use std::io::{Error as IoError, ErrorKind};
+
+/// Handle type.
+#[derive(Debug)]
+pub enum RpcHandle {
+    /// Http handle.
+    Http(SocketAddr),
+    /// Websocket handle.
+    WS(SocketAddr),
+    /// Auth handle.
+    Auth(SocketAddr),
+}
+
+impl std::fmt::Display for RpcHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RpcHandle::Http(addr) => write!(f, "{addr} (HTTP-RPC server)"),
+            RpcHandle::WS(addr) => write!(f, "{addr} (WS-RPC server)"),
+            RpcHandle::Auth(addr) => write!(f, "{addr} (AUTH server)"),
+        }
+    }
+}
+
+/// Rpc Errors.
+#[derive(Debug, thiserror::Error)]
+pub enum RpcError {
+    /// Wrapper for `jsonrpsee::core::Error`.
+    #[error(transparent)]
+    RpcError(JsonRpseeError),
+    /// Address already in use.
+    #[error("Address {0} is already in use (os error 98)")]
+    AddressAlreadyInUse(RpcHandle),
+    /// Custom error.
+    #[error("Custom error: {0}")]
+    Custom(String),
+}
+
+impl RpcError {
+    /// Converts a `jsonrpsee::core::Error` to a more descriptive `RpcError`.
+    pub fn from_jsonrpsee_error(error: JsonRpseeError, handle: Option<RpcHandle>) -> RpcError {
+        match error {
+            JsonRpseeError::Transport(error) => {
+                if let Some(io_error) = error.downcast_ref::<IoError>() {
+                    if io_error.kind() == ErrorKind::AddrInUse {
+                        return RpcError::AddressAlreadyInUse(handle.unwrap())
+                    }
+                }
+                RpcError::RpcError(JsonRpseeError::Transport(error))
+            }
+            _ => RpcError::RpcError(error),
+        }
+    }
+}

--- a/crates/rpc/rpc-builder/tests/it/main.rs
+++ b/crates/rpc/rpc-builder/tests/it/main.rs
@@ -1,5 +1,6 @@
 mod http;
 mod serde;
+mod startup;
 pub mod utils;
 
 fn main() {}

--- a/crates/rpc/rpc-builder/tests/it/startup.rs
+++ b/crates/rpc/rpc-builder/tests/it/startup.rs
@@ -1,0 +1,38 @@
+//! Startup tests
+use crate::utils::{launch_http, launch_ws, test_rpc_builder};
+use reth_rpc_builder::{
+    error::{RpcError, ServerKind},
+    RethRpcModule, RpcServerConfig, TransportRpcModuleConfig,
+};
+use std::io;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_http_addr_in_use() {
+    let handle = launch_http(vec![RethRpcModule::Admin]).await;
+    let addr = handle.http_local_addr().unwrap();
+    let builder = test_rpc_builder();
+    let server = builder.build(TransportRpcModuleConfig::set_http(vec![RethRpcModule::Admin]));
+    let result = server
+        .start_server(RpcServerConfig::http(Default::default()).with_http_address(addr))
+        .await;
+    let expected = RpcError::AddressAlreadyInUse {
+        kind: ServerKind::Http(addr),
+        error: io::Error::from(io::ErrorKind::AddrInUse),
+    };
+    assert_eq!(result.unwrap_err(), expected);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ws_addr_in_use() {
+    let handle = launch_ws(vec![RethRpcModule::Admin]).await;
+    let addr = handle.ws_local_addr().unwrap();
+    let builder = test_rpc_builder();
+    let server = builder.build(TransportRpcModuleConfig::set_ws(vec![RethRpcModule::Admin]));
+    let result =
+        server.start_server(RpcServerConfig::ws(Default::default()).with_ws_address(addr)).await;
+    let expected = RpcError::AddressAlreadyInUse {
+        kind: ServerKind::WS(addr),
+        error: io::Error::from(io::ErrorKind::AddrInUse),
+    };
+    assert_eq!(result.unwrap_err(), expected);
+}


### PR DESCRIPTION
Fixes #1940

I tested this with 2 nodes in parallel, which fails with `Address already in use (os error 98)` in https://github.com/paradigmxyz/reth/blob/cb318192ba4be1b3b2254f4873a6e1b7153ed8f2/crates/net/network/src/manager.rs#L174 before the rpc code is reached (if `--port` and ` --discovery.port` isn't set). Should this error be improved as well?