### PR TITLE
Make EthApi client, pool, network and state accessors public

### DIFF
--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -77,7 +77,7 @@ impl<Client, Pool, Network> EthApi<Client, Pool, Network> {
     }
 
     /// Returns the state cache frontend
-    pub fn cache(&self) -> &EthStateCache {
+    pub(crate) fn cache(&self) -> &EthStateCache {
         &self.inner.eth_cache
     }
 

--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -77,22 +77,22 @@ impl<Client, Pool, Network> EthApi<Client, Pool, Network> {
     }
 
     /// Returns the state cache frontend
-    pub(crate) fn cache(&self) -> &EthStateCache {
+    pub fn cache(&self) -> &EthStateCache {
         &self.inner.eth_cache
     }
 
     /// Returns the inner `Client`
-    pub(crate) fn client(&self) -> &Client {
+    pub fn client(&self) -> &Client {
         &self.inner.client
     }
 
     /// Returns the inner `Network`
-    pub(crate) fn network(&self) -> &Network {
+    pub fn network(&self) -> &Network {
         &self.inner.network
     }
 
     /// Returns the inner `Pool`
-    pub(crate) fn pool(&self) -> &Pool {
+    pub fn pool(&self) -> &Pool {
         &self.inner.pool
     }
 }
@@ -108,7 +108,7 @@ where
     }
 
     /// Returns the state at the given [BlockId] enum.
-    pub(crate) fn state_at_block_id(&self, at: BlockId) -> EthResult<ChainState<'_>> {
+    pub fn state_at_block_id(&self, at: BlockId) -> EthResult<ChainState<'_>> {
         match at {
             BlockId::Hash(hash) => Ok(self.state_at_hash(hash.into()).map(ChainState::boxed)?),
             BlockId::Number(num) => {
@@ -118,7 +118,7 @@ where
     }
 
     /// Returns the state at the given [BlockId] enum or the latest.
-    pub(crate) fn state_at_block_id_or_latest(
+    pub fn state_at_block_id_or_latest(
         &self,
         block_id: Option<BlockId>,
     ) -> EthResult<ChainState<'_>> {
@@ -132,10 +132,7 @@ where
     /// Returns the state at the given [BlockNumberOrTag] enum
     ///
     /// Returns `None` if no state available.
-    pub(crate) fn state_at_block_number(
-        &self,
-        num: BlockNumberOrTag,
-    ) -> Result<Option<ChainState<'_>>> {
+    pub fn state_at_block_number(&self, num: BlockNumberOrTag) -> Result<Option<ChainState<'_>>> {
         if let Some(number) = self.convert_block_number(num)? {
             self.state_at_number(number).map(Some)
         } else {
@@ -144,7 +141,7 @@ where
     }
 
     /// Returns the state at the given block number
-    pub(crate) fn state_at_hash(
+    pub fn state_at_hash(
         &self,
         block_hash: H256,
     ) -> Result<<Client as StateProviderFactory>::HistorySP<'_>> {
@@ -152,7 +149,7 @@ where
     }
 
     /// Returns the state at the given block number
-    pub(crate) fn state_at_number(&self, block_number: u64) -> Result<ChainState<'_>> {
+    pub fn state_at_number(&self, block_number: u64) -> Result<ChainState<'_>> {
         match self.convert_block_number(BlockNumberOrTag::Latest)? {
             Some(num) if num == block_number => self.latest_state().map(ChainState::boxed),
             _ => self.client().history_by_block_number(block_number).map(ChainState::boxed),
@@ -160,7 +157,7 @@ where
     }
 
     /// Returns the _latest_ state
-    pub(crate) fn latest_state(&self) -> Result<<Client as StateProviderFactory>::LatestSP<'_>> {
+    pub fn latest_state(&self) -> Result<<Client as StateProviderFactory>::LatestSP<'_>> {
         self.client().latest()
     }
 }


### PR DESCRIPTION
Make EthApi client, pool, network and state accessors public to allow creation of custom methods in a standalone usage of EthApi (example: access the state only once to execute batched requests)