### PR TITLE
chore(txpool): include tx object in assert message

### DIFF
--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -40,7 +40,11 @@ impl<T: ParkedOrd> ParkedPool<T> {
     /// If the transaction is already included.
     pub(crate) fn add_transaction(&mut self, tx: Arc<ValidPoolTransaction<T::Transaction>>) {
         let id = *tx.id();
-        assert!(!self.by_id.contains_key(&id), "transaction already included");
+        assert!(
+            !self.by_id.contains_key(&id),
+            "transaction already included {:?}",
+            self.by_id.contains_key(&id)
+        );
         let submission_id = self.next_id();
 
         // keep track of size

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -97,7 +97,11 @@ impl<T: TransactionOrdering> PendingPool<T> {
     ///
     /// if the transaction is already included
     pub(crate) fn add_transaction(&mut self, tx: Arc<ValidPoolTransaction<T::Transaction>>) {
-        assert!(!self.by_id.contains_key(tx.id()), "transaction already included");
+        assert!(
+            !self.by_id.contains_key(tx.id()),
+            "transaction already included {:?}",
+            self.by_id.contains_key(tx.id())
+        );
 
         let tx_id = *tx.id();
         let submission_id = self.next_id();

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -865,7 +865,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
 
         let pool_tx = PoolInternalTransaction {
             transaction: transaction.clone(),
-            subpool: SubPool::Queued,
+            subpool: state.into(),
             state,
             cumulative_cost,
         };


### PR DESCRIPTION
I believe this is due subpool state being different than expected, likely introduced/related to https://github.com/paradigmxyz/reth/pull/1972
  
this will help track down the panic:

![image](https://user-images.githubusercontent.com/19890894/227784468-ff0dc29d-7ce1-4ce4-80a3-fbb74457aa87.png)
