### PR TITLE
fix: set next value of forkid to 0 if unknown

### DIFF
--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -11,6 +11,7 @@ use crate::{
     },
 };
 pub use crate::{message::PeerRequestSender, session::handle::PeerInfo};
+
 use fnv::FnvHashMap;
 use futures::{future::Either, io, FutureExt, StreamExt};
 use reth_ecies::{stream::ECIESStream, ECIESError};

--- a/crates/net/network/tests/it/connect.rs
+++ b/crates/net/network/tests/it/connect.rs
@@ -218,7 +218,6 @@ async fn test_connect_with_boot_nodes() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore]
 async fn test_connect_to_specific() {
     reth_tracing::init_test_tracing();
     let secret_key = SecretKey::new(&mut rand::thread_rng());
@@ -242,7 +241,8 @@ async fn test_connect_to_specific() {
         tokio::join!(network, requests);
     });
 
-    let enode =     "enode://1031081ada4a530f51ac8ab6d8f48e5e2e5b033a73d8032119c2e123e0381d8e909dc78361475beaf12f1bf89343bfac14c5ad302532065a498b9150cbf4b35c@104.248.194.88:30303";
+    let enode =     "enode://04e6773667200b776384caafa16e559a3fea9a0044c7608e4005777bf9baf7cd45c671003aba186c8a1ef7a2129b08031f60bac6405486dabb1ae10fc2e59911@65.21.89.157:30314";
+    // let enode =     "enode://1031081ada4a530f51ac8ab6d8f48e5e2e5b033a73d8032119c2e123e0381d8e909dc78361475beaf12f1bf89343bfac14c5ad302532065a498b9150cbf4b35c@104.248.194.88:30303";
 
     let node: NodeRecord = enode.parse().unwrap();
 


### PR DESCRIPTION
According to https://eips.ethereum.org/EIPS/eip-2124:

> FORK_NEXT: Block number (uint64) of the next upcoming fork, or 0 if no next fork is known.

this was not taken into account when calculating the ForkId and resulted in subprotocol specific errors.

there's still something wrong when shanghai enabled, on sepolia for example see `test_connect_to_specific`