### PR TITLE
chore: use downloader and client traits where possible

### DIFF
--- a/bin/reth/src/utils.rs
+++ b/bin/reth/src/utils.rs
@@ -9,23 +9,24 @@ use reth_db::{
 };
 use reth_interfaces::{
     p2p::{
-        download::DownloadClient,
         headers::client::{HeadersClient, HeadersRequest},
         priority::Priority,
     },
     test_utils::generators::random_block_range,
 };
-use reth_network::FetchClient;
 use reth_primitives::{BlockHashOrNumber, HeadersDirection, SealedHeader};
 use reth_provider::insert_canonical_block;
 use std::collections::BTreeMap;
 use tracing::info;
 
 /// Get a single header from network
-pub async fn get_single_header(
-    client: FetchClient,
+pub async fn get_single_header<Client>(
+    client: Client,
     id: BlockHashOrNumber,
-) -> eyre::Result<SealedHeader> {
+) -> eyre::Result<SealedHeader>
+where
+    Client: HeadersClient,
+{
     let request = HeadersRequest { direction: HeadersDirection::Rising, limit: 1, start: id };
 
     let (peer_id, response) =

--- a/crates/interfaces/src/p2p/download.rs
+++ b/crates/interfaces/src/p2p/download.rs
@@ -2,6 +2,7 @@ use reth_primitives::PeerId;
 use std::fmt::Debug;
 
 /// Generic download client for peer penalization
+#[auto_impl::auto_impl(&, Arc, Box)]
 pub trait DownloadClient: Send + Sync + Debug {
     /// Penalize the peer for responding with a message
     /// that violates validation rules

--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -498,7 +498,7 @@ impl BodiesDownloaderBuilder {
     /// Consume self and return the concurrent donwloader.
     pub fn build<B, DB>(
         self,
-        client: Arc<B>,
+        client: B,
         consensus: Arc<dyn Consensus>,
         db: Arc<DB>,
     ) -> BodiesDownloader<B, DB>
@@ -515,7 +515,7 @@ impl BodiesDownloaderBuilder {
         let metrics = DownloaderMetrics::new(BODIES_DOWNLOADER_SCOPE);
         let in_progress_queue = BodiesRequestQueue::new(metrics.clone());
         BodiesDownloader {
-            client,
+            client: Arc::new(client),
             consensus,
             db,
             request_limit,

--- a/crates/primitives/src/peer.rs
+++ b/crates/primitives/src/peer.rs
@@ -10,13 +10,18 @@ pub type PeerId = H512;
 #[derive(Debug)]
 pub struct WithPeerId<T>(PeerId, pub T);
 
-impl<T> From<(H512, T)> for WithPeerId<T> {
-    fn from(value: (H512, T)) -> Self {
+impl<T> From<(PeerId, T)> for WithPeerId<T> {
+    fn from(value: (PeerId, T)) -> Self {
         Self(value.0, value.1)
     }
 }
 
 impl<T> WithPeerId<T> {
+    /// Wraps the value with the peerid.
+    pub fn new(peer: PeerId, value: T) -> Self {
+        Self(peer, value)
+    }
+
     /// Get the peer id
     pub fn peer_id(&self) -> PeerId {
         self.0

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -298,7 +298,7 @@ mod tests {
         use std::sync::Arc;
 
         pub(crate) struct HeadersTestRunner<D: HeaderDownloader> {
-            pub(crate) client: Arc<TestHeadersClient>,
+            pub(crate) client: TestHeadersClient,
             channel: (watch::Sender<H256>, watch::Receiver<H256>),
             downloader_factory: Box<dyn Fn() -> D + Send + Sync + 'static>,
             tx: TestTransaction,
@@ -306,7 +306,7 @@ mod tests {
 
         impl Default for HeadersTestRunner<TestHeaderDownloader> {
             fn default() -> Self {
-                let client = Arc::new(TestHeadersClient::default());
+                let client = TestHeadersClient::default();
                 Self {
                     client: client.clone(),
                     channel: watch::channel(H256::zero()),
@@ -416,7 +416,7 @@ mod tests {
 
         impl HeadersTestRunner<ReverseHeadersDownloader<TestHeadersClient>> {
             pub(crate) fn with_linear_downloader() -> Self {
-                let client = Arc::new(TestHeadersClient::default());
+                let client = TestHeadersClient::default();
                 Self {
                     client: client.clone(),
                     channel: watch::channel(H256::zero()),


### PR DESCRIPTION
This extracts a few changes from #1880 that are required for #1880

This mostly replaces types with traits where possible