### PR TITLE
fix(rpc): set tx receipt contract address independent of status

### DIFF
--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -318,11 +318,8 @@ where
 
         match tx.transaction.kind() {
             Create => {
-                // set contract address if creation was successful
-                if receipt.success {
-                    res_receipt.contract_address =
-                        Some(create_address(transaction.signer(), tx.transaction.nonce()));
-                }
+                res_receipt.contract_address =
+                    Some(create_address(transaction.signer(), tx.transaction.nonce()));
             }
             Call(addr) => {
                 res_receipt.to = Some(*addr);


### PR DESCRIPTION
sets the `contractAddress` field of `TransactionReceipt` even if tx failed

passes `ws/ContractDeploymentOutOfGas` hive test:

> calculated contract address: c04e53dc7a792a326a86c0b3fd021d1bb5cdfe93
out of gas tx: a2ecdc108a901744618480174b2916ea65a97f4b8e11c21cdaa83a1ed6b7ee57


geth ref:

https://github.com/ethereum/go-ethereum/blob/8990c92aea01ca07801597b00c0d83d4e2d9b811/core/state_processor.go#L131-L134