### PR TITLE
fix: set fees to zero if not provided

### DIFF
--- a/crates/rpc/rpc/src/eth/revm_utils.rs
+++ b/crates/rpc/rpc/src/eth/revm_utils.rs
@@ -168,6 +168,10 @@ impl CallFees {
         base_fee: U256,
     ) -> EthResult<CallFees> {
         match (call_gas_price, call_max_fee, call_priority_fee) {
+            (None, None, None) => {
+                // when none are specified, they are all set to zero
+                Ok(CallFees { gas_price: U256::ZERO, max_priority_fee_per_gas: None })
+            }
             (gas_price, None, None) => {
                 // request for a legacy transaction
                 // set everything to zero


### PR DESCRIPTION
This sets the base fee to zero in `eth_call`, and sets fees to zero if none are provided in the request.

The logic from geth that we should try to emulate for this is here:
https://github.com/ethereum/go-ethereum/blob/ee8e83fa5f6cb261dad2ed0a7bbcde4930c41e6c/internal/ethapi/transaction_args.go#L228-L257

Called here for geth's `DoCall`:
https://github.com/ethereum/go-ethereum/blob/ee8e83fa5f6cb261dad2ed0a7bbcde4930c41e6c/internal/ethapi/api.go#L981

Fixes #1907