### PR TITLE
docs: add more docs to `reth-db`

### DIFF
--- a/crates/storage/db/src/abstraction/common.rs
+++ b/crates/storage/db/src/abstraction/common.rs
@@ -1,10 +1,19 @@
-/// Alias type containing key value pairs.
+/// A key-value pair for table `T`.
 pub type KeyValue<T> = (<T as Table>::Key, <T as Table>::Value);
-/// Alias type for a `(key, value)` result coming from a cursor.
+
+/// A fallible key-value pair that may or may not exist.
+///
+/// The `Result` represents that the operation might fail, while the `Option` represents whether or
+/// not the entry exists.
 pub type PairResult<T> = Result<Option<KeyValue<T>>, Error>;
-/// Alias type for a `(key, value)` result coming from an iterator.
+
+/// A key-value pair coming from an iterator.
+///
+/// The `Result` represents that the operation might fail, while the `Option` represents whether or
+/// not there is another entry.
 pub type IterPairResult<T> = Option<Result<KeyValue<T>, Error>>;
-/// Alias type for a value result coming from a cursor without its key.
+
+/// A value only result for table `T`.
 pub type ValueOnlyResult<T> = Result<Option<<T as Table>::Value>, Error>;
 
 use crate::{abstraction::table::*, Error};

--- a/crates/storage/db/src/abstraction/mod.rs
+++ b/crates/storage/db/src/abstraction/mod.rs
@@ -1,4 +1,4 @@
-/// Common return types
+/// Common types used throughout the abstraction.
 pub mod common;
 /// Cursor database traits.
 pub mod cursor;

--- a/crates/storage/db/src/lib.rs
+++ b/crates/storage/db/src/lib.rs
@@ -1,4 +1,59 @@
-//! Rust database abstraction and concrete database implementations.
+//! reth's database abstraction layer with concrete implementations.
+//!
+//! The database abstraction assumes that the underlying store is a KV store subdivided into tables.
+//!
+//! One or more changes are tied to a transaction that is atomically committed to the data store at
+//! the same time. Strong consistency in what data is written and when is important for reth, so it
+//! is not possible to write data to the database outside of using a transaction.
+//!
+//! Good starting points for this crate are:
+//!
+//! - [`Database`] for the main database abstraction
+//! - [`DbTx`] (RO) and [`DbTxMut`] (RW) for the transaction abstractions.
+//! - [`DbCursorRO`] (RO) and [`DbCursorRW`] (RW) for the cursor abstractions (see below).
+//!
+//! # Cursors and Walkers
+//!
+//! The abstraction also defines a couple of helpful abstractions for iterating and writing data:
+//!
+//! - **Cursors** ([`DbCursorRO`] / [`DbCursorRW`]) for iterating data in a table. Cursors are
+//!   assumed to resolve data in a sorted manner when iterating from start to finish, and it is safe
+//!   to assume that they are efficient at doing so.
+//! - **Walkers** ([`Walker`] / [`RangeWalker`] / [`ReverseWalker`]) use cursors to walk the entries
+//!   in a table, either fully from a specific point, or over a range.
+//!
+//! Dup tables (see below) also have corresponding cursors and walkers (e.g. [`DbDupCursorRO`]).
+//! These **should** be preferred when working with dup tables, as they provide additional methods
+//! that are optimized for dup tables.
+//!
+//! # Tables
+//!
+//! reth has two types of tables: simple KV stores (one key, one value) and dup tables (one key,
+//! many values). Dup tables can be efficient for certain types of data.
+//!
+//! Keys are de/serialized using the [`Encode`] and [`Decode`] traits, and values are de/serialized
+//! ("compressed") using the [`Compress`] and [`Decompress`] traits.
+//!
+//! Tables implement the [`Table`] trait.
+//!
+//! # Overview
+//!
+//! An overview of the current data model of reth can be found in the [`tables`] module.
+//!
+//! [`Database`]: crate::abstraction::database::Database
+//! [`DbTx`]: crate::abstraction::transaction::DbTx
+//! [`DbTxMut`]: crate::abstraction::transaction::DbTxMut
+//! [`DbCursorRO`]: crate::abstraction::cursor::DbCursorRO
+//! [`DbCursorRW`]: crate::abstraction::cursor::DbCursorRW
+//! [`Walker`]: crate::abstraction::cursor::Walker
+//! [`RangeWalker`]: crate::abstraction::cursor::RangeWalker
+//! [`ReverseWalker`]: crate::abstraction::cursor::ReverseWalker
+//! [`DbDupCursorRO`]: crate::abstraction::cursor::DbDupCursorRO
+//! [`Encode`]: crate::abstraction::table::Encode
+//! [`Decode`]: crate::abstraction::table::Decode
+//! [`Compress`]: crate::abstraction::table::Compress
+//! [`Decompress`]: crate::abstraction::table::Decompress
+//! [`Table`]: crate::abstraction::table::Table
 
 #![warn(missing_docs, unreachable_pub)]
 #![deny(unused_must_use, rust_2018_idioms)]
@@ -7,7 +62,7 @@
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
 ))]
 
-/// Abstracted part of database, containing traits for transactions and cursors.
+/// Traits defining the database abstractions, such as cursors and transactions.
 pub mod abstraction;
 
 mod implementation;

--- a/crates/storage/db/src/tables/mod.rs
+++ b/crates/storage/db/src/tables/mod.rs
@@ -1,8 +1,19 @@
-//! Table and data structures
+//! Tables and data models.
+//!
+//! # Overview
+//!
+//! This module defines the tables in reth, as well as some table-related abstractions:
+//!
+//! - [`codecs`] integrates different codecs into [`Encode`] and [`Decode`]
+//! - [`models`] defines the values written to tables
+//!
+//! # Database Tour
+//!
+//! TODO(onbjerg): Find appropriate format for this...
 
 pub mod codecs;
 pub mod models;
-pub mod utils;
+pub(crate) mod utils;
 
 /// Declaration of all Database tables.
 use crate::{


### PR DESCRIPTION
Adds some more in-depth docs to `reth-db`. There is still a lot to go on this crate, but I didn't want to take too much time.

Documenting the crate did however highlight a few things:

1. We have some weird things in there that should probably live elsewhere
2. We should (at some point) try to simplify paths (e.g. the `models` module could probably just re-export the underlying models so we don't have to reach as much)