### PR TITLE
chore(txpool): add AlreadyImported variant

### DIFF
--- a/crates/rpc/rpc/src/eth/error.rs
+++ b/crates/rpc/rpc/src/eth/error.rs
@@ -341,7 +341,7 @@ impl From<PoolError> for RpcPoolError {
     fn from(err: PoolError) -> RpcPoolError {
         match err {
             PoolError::ReplacementUnderpriced(_) => RpcPoolError::ReplaceUnderpriced,
-            PoolError::ProtocolFeeCapTooLow(_, _) => RpcPoolError::Underpriced,
+            PoolError::FeeCapBelowMinimumProtocolFeeCap(_, _) => RpcPoolError::Underpriced,
             PoolError::SpammerExceededCapacity(_, _) => RpcPoolError::TxPoolOverflow,
             PoolError::DiscardedOnInsert(_) => RpcPoolError::TxPoolOverflow,
             PoolError::InvalidTransaction(_, err) => err.into(),

--- a/crates/rpc/rpc/src/eth/error.rs
+++ b/crates/rpc/rpc/src/eth/error.rs
@@ -346,6 +346,7 @@ impl From<PoolError> for RpcPoolError {
             PoolError::DiscardedOnInsert(_) => RpcPoolError::TxPoolOverflow,
             PoolError::InvalidTransaction(_, err) => err.into(),
             PoolError::Other(_, err) => RpcPoolError::Other(err),
+            PoolError::AlreadyImported(_) => RpcPoolError::AlreadyKnown,
         }
     }
 }

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -279,12 +279,12 @@ where
         self.pool.pooled_transactions_hashes()
     }
 
-    fn pooled_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
-        self.pool.pooled_transactions()
-    }
-
     fn pooled_transaction_hashes_max(&self, max: usize) -> Vec<TxHash> {
         self.pooled_transaction_hashes().into_iter().take(max).collect()
+    }
+
+    fn pooled_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.pool.pooled_transactions()
     }
 
     fn pooled_transactions_max(

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -247,9 +247,9 @@ impl<T: TransactionOrdering> TxPool<T> {
                     InsertErr::Underpriced { existing, .. } => {
                         Err(PoolError::ReplacementUnderpriced(existing))
                     }
-                    InsertErr::ProtocolFeeCapTooLow { transaction, fee_cap } => {
-                        Err(PoolError::ProtocolFeeCapTooLow(*transaction.hash(), fee_cap))
-                    }
+                    InsertErr::FeeCapBelowMinimumProtocolFeeCap { transaction, fee_cap } => Err(
+                        PoolError::FeeCapBelowMinimumProtocolFeeCap(*transaction.hash(), fee_cap),
+                    ),
                     InsertErr::ExceededSenderTransactionsCapacity { transaction } => {
                         Err(PoolError::SpammerExceededCapacity(
                             transaction.sender(),
@@ -846,7 +846,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
         // Check dynamic fee
         if let Some(fee_cap) = transaction.max_fee_per_gas() {
             if fee_cap < self.minimal_protocol_basefee {
-                return Err(InsertErr::ProtocolFeeCapTooLow { transaction, fee_cap })
+                return Err(InsertErr::FeeCapBelowMinimumProtocolFeeCap { transaction, fee_cap })
             }
             if fee_cap >= self.pending_basefee {
                 state.insert(TxState::ENOUGH_FEE_CAP_BLOCK);
@@ -1028,7 +1028,7 @@ pub(crate) enum InsertErr<T: PoolTransaction> {
     /// The transactions feeCap is lower than the chain's minimum fee requirement.
     ///
     /// See also [`MIN_PROTOCOL_BASE_FEE`]
-    ProtocolFeeCapTooLow { transaction: Arc<ValidPoolTransaction<T>>, fee_cap: u128 },
+    FeeCapBelowMinimumProtocolFeeCap { transaction: Arc<ValidPoolTransaction<T>>, fee_cap: u128 },
     /// Sender currently exceeds the configured limit for max account slots.
     ///
     /// The sender can be considered a spammer at this point.
@@ -1157,7 +1157,7 @@ mod tests {
         let mut f = MockTransactionFactory::default();
         let mut pool = AllTransactions::default();
         let tx = MockTransaction::eip1559().inc_price().inc_limit();
-        let valid_tx = f.validated(tx.clone());
+        let valid_tx = f.validated(tx);
         let InsertOk { updates, replaced_tx, move_to, state, .. } =
             pool.insert_tx(valid_tx.clone(), on_chain_balance, on_chain_nonce).unwrap();
         assert!(updates.is_empty());


### PR DESCRIPTION
blocked by #2008

Add missing `AlreadyImported` error variant.

checks if the transaction is already in the pool