### PR TITLE
refactor(rpc): extract prepare_call_env logic

### DIFF
--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -208,7 +208,7 @@ where
     ) -> Result<Bytes> {
         trace!(target: "rpc::eth", ?request, ?block_number, ?state_overrides, "Serving eth_call");
         let (res, _env) = self
-            .execute_call_at(
+            .transact_call_at(
                 request,
                 block_number.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest)),
                 state_overrides,


### PR DESCRIPTION
extract some call init logic to new standalone function, a prerequisite for #2011

rename `execute_call_at` to `transact_call_at`, #2011 will add `inspect_call_at`