### PR TITLE
fix: determine if eth_getProof blockid arg is latest

### DIFF
--- a/crates/rpc/rpc/src/eth/api/state.rs
+++ b/crates/rpc/rpc/src/eth/api/state.rs
@@ -54,27 +54,15 @@ where
         keys: Vec<H256>,
         block_id: Option<BlockId>,
     ) -> EthResult<EIP1186AccountProofResponse> {
-        let latest_block = self.client().block(BlockId::Number(BlockNumberOrTag::Latest))?;
+        let chain_info = self.client().chain_info()?;
         let block_id = block_id.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest));
 
         // if we are trying to create a proof for the latest block, but have a BlockId as input
         // that is not BlockNumberOrTag::Latest, then we need to figure out whether or not the
         // BlockId corresponds to the latest block
         let is_blockid_latest = match block_id {
-            BlockId::Number(BlockNumberOrTag::Number(num)) => {
-                if let Some(block) = latest_block {
-                    block.number == num
-                } else {
-                    false
-                }
-            }
-            BlockId::Hash(hash) => {
-                if let Some(block) = latest_block {
-                    block.hash_slow() == hash.into()
-                } else {
-                    false
-                }
-            }
+            BlockId::Number(BlockNumberOrTag::Number(num)) => num == chain_info.best_number,
+            BlockId::Hash(hash) => hash == chain_info.best_hash.into(),
             BlockId::Number(BlockNumberOrTag::Latest) => true,
             _ => false,
         };

--- a/crates/rpc/rpc/src/eth/api/state.rs
+++ b/crates/rpc/rpc/src/eth/api/state.rs
@@ -68,7 +68,7 @@ where
         };
 
         // TODO: remove when HistoricalStateProviderRef::proof is implemented
-        if is_blockid_latest {
+        if !is_blockid_latest {
             return Err(EthApiError::InvalidBlockRange)
         }
 


### PR DESCRIPTION
Previously, we would error on any `BlockId` if it was not `Latest`. If the argument passed is instead the block number or hash of the latest block as returned by `chain_info`, then we should not error.