### PR TITLE
feat(BlockchainTree): Broadcast new canonical block headers

### DIFF
--- a/crates/executor/src/blockchain_tree/shareable.rs
+++ b/crates/executor/src/blockchain_tree/shareable.rs
@@ -4,6 +4,7 @@ use reth_db::database::Database;
 use reth_interfaces::{
     blockchain_tree::{BlockStatus, BlockchainTreeEngine, BlockchainTreeViewer},
     consensus::Consensus,
+    events::{ChainEventSubscriptions, NewBlockNotifications},
     Error,
 };
 use reth_primitives::{BlockHash, BlockNumHash, BlockNumber, SealedBlockWithSenders};
@@ -80,5 +81,13 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreePendingState
     ) -> Result<Box<dyn PostStateDataProvider>, Error> {
         let Some(post_state) = self.tree.read().post_state_data(block_hash) else { panic!("")};
         Ok(Box::new(post_state))
+    }
+}
+
+impl<DB: Database, C: Consensus, EF: ExecutorFactory> ChainEventSubscriptions
+    for ShareableBlockchainTree<DB, C, EF>
+{
+    fn subscribe_new_blocks(&self) -> NewBlockNotifications {
+        self.tree.read().subscribe_new_blocks()
     }
 }

--- a/crates/interfaces/src/events.rs
+++ b/crates/interfaces/src/events.rs
@@ -1,21 +1,18 @@
-use reth_primitives::{Header, H256};
+use reth_primitives::SealedHeader;
 use std::sync::Arc;
-use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::sync::broadcast::{Receiver, Sender};
+
+/// New block notification that is Arc around [SealedHeader].
+pub type NewBlockNotification = Arc<SealedHeader>;
 
 /// Type alias for a receiver that receives [NewBlockNotification]
-pub type NewBlockNotifications = UnboundedReceiver<NewBlockNotification>;
+pub type NewBlockNotifications = Receiver<NewBlockNotification>;
+
+/// Type alias for a sender that sends [NewBlockNotification]
+pub type NewBlockNotificationsSender = Sender<NewBlockNotification>;
 
 /// A type that allows to register chain related event subscriptions.
 pub trait ChainEventSubscriptions: Send + Sync {
     /// Get notified when a new block was imported.
     fn subscribe_new_blocks(&self) -> NewBlockNotifications;
-}
-
-/// A notification that's emitted when a new block was imported.
-#[derive(Clone, Debug)]
-pub struct NewBlockNotification {
-    /// Hash of the block that was imported
-    pub hash: H256,
-    /// The block header of the new block
-    pub header: Arc<Header>,
 }

--- a/crates/interfaces/src/test_utils/events.rs
+++ b/crates/interfaces/src/test_utils/events.rs
@@ -1,31 +1,27 @@
 use crate::events::{ChainEventSubscriptions, NewBlockNotification, NewBlockNotifications};
 use async_trait::async_trait;
-use reth_primitives::{Header, H256};
+use reth_primitives::{Header, SealedHeader, H256};
 use std::sync::{Arc, Mutex};
-use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+use tokio::sync::broadcast::{self, Receiver, Sender};
 
 /// A test ChainEventSubscriptions
 #[derive(Clone, Default)]
 pub struct TestChainEventSubscriptions {
-    new_blocks_txs: Arc<Mutex<Vec<UnboundedSender<NewBlockNotification>>>>,
+    new_blocks_txs: Arc<Mutex<Vec<Sender<NewBlockNotification>>>>,
 }
 
 impl TestChainEventSubscriptions {
     /// Adds new block to the queue that can be consumed with
     /// [`TestChainEventSubscriptions::subscribe_new_blocks`]
-    pub fn add_new_block(&mut self, hash: H256, header: Header) {
+    pub fn add_new_block(&mut self, header: SealedHeader) {
         let header = Arc::new(header);
-        self.new_blocks_txs
-            .lock()
-            .as_mut()
-            .unwrap()
-            .retain(|tx| tx.send(NewBlockNotification { hash, header: header.clone() }).is_ok())
+        self.new_blocks_txs.lock().as_mut().unwrap().retain(|tx| tx.send(header.clone()).is_ok())
     }
 }
 
 impl ChainEventSubscriptions for TestChainEventSubscriptions {
     fn subscribe_new_blocks(&self) -> NewBlockNotifications {
-        let (new_blocks_tx, new_blocks_rx) = unbounded_channel();
+        let (new_blocks_tx, new_blocks_rx) = broadcast::channel(100);
         self.new_blocks_txs.lock().as_mut().unwrap().push(new_blocks_tx);
 
         new_blocks_rx


### PR DESCRIPTION
closes: #2024 

Added notification on when new blocks get canonicalized. 

Modified the event to be only `SealedHeader` and changed the `unbounded` channel to the `broadcast`. Add made some small refactoring to include the change.