### PR TITLE
feat(rpc): impl traceCall

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
@@ -1,5 +1,6 @@
 use crate::tracing::{types::CallTraceNode, TracingInspectorConfig};
 use reth_rpc_types::{trace::parity::*, TransactionInfo};
+use revm::primitives::ExecutionResult;
 use std::collections::HashSet;
 
 /// A type for creating parity style traces
@@ -80,6 +81,24 @@ impl ParityTraceBuilder {
         info: TransactionInfo,
     ) -> Vec<LocalizedTransactionTrace> {
         self.into_localized_transaction_traces_iter(info).collect()
+    }
+
+    /// Consumes the inspector and returns the trace results according to the configured trace
+    /// types.
+    pub fn into_trace_results(
+        self,
+        res: ExecutionResult,
+        trace_types: &HashSet<TraceType>,
+    ) -> TraceResults {
+        let output = match res {
+            ExecutionResult::Success { output, .. } => output.into_data(),
+            ExecutionResult::Revert { output, .. } => output,
+            ExecutionResult::Halt { .. } => Default::default(),
+        };
+
+        let (trace, vm_trace, state_diff) = self.into_trace_type_traces(trace_types);
+
+        TraceResults { output: output.into(), trace, vm_trace, state_diff }
     }
 
     /// Returns the tracing types that are configured in the set

--- a/crates/revm/revm-inspectors/src/tracing/mod.rs
+++ b/crates/revm/revm-inspectors/src/tracing/mod.rs
@@ -1,9 +1,6 @@
-use crate::{
-    stack::MaybeOwnedInspector,
-    tracing::{
-        types::{CallKind, LogCallOrder, RawLog},
-        utils::{gas_used, get_create_address},
-    },
+use crate::tracing::{
+    types::{CallKind, LogCallOrder, RawLog},
+    utils::{gas_used, get_create_address},
 };
 pub use arena::CallTraceArena;
 use reth_primitives::{bytes::Bytes, Address, H256, U256};
@@ -46,10 +43,7 @@ pub struct TracingInspector {
     /// Tracks the return value of the last call
     last_call_return_data: Option<Bytes>,
     /// The gas inspector used to track remaining gas.
-    ///
-    /// This is either owned by this inspector directly or part of a stack of inspectors, in which
-    /// case all delegated functions are no-ops.
-    gas_inspector: MaybeOwnedInspector<GasInspector>,
+    gas_inspector: GasInspector,
 }
 
 // === impl TracingInspector ===
@@ -75,20 +69,6 @@ impl TracingInspector {
     /// Consumes the Inspector and returns a [GethTraceBuilder].
     pub fn into_geth_builder(self) -> GethTraceBuilder {
         GethTraceBuilder::new(self.traces.arena, self.config)
-    }
-
-    /// Configures a [GasInspector]
-    ///
-    /// If this [TracingInspector] is part of a stack [InspectorStack](crate::stack::InspectorStack)
-    /// which already uses a [GasInspector], it can be reused as [MaybeOwnedInspector::Stacked] in
-    /// which case the `gas_inspector`'s usage will be a no-op within the context of this
-    /// [TracingInspector].
-    pub fn with_stacked_gas_inspector(
-        mut self,
-        gas_inspector: MaybeOwnedInspector<GasInspector>,
-    ) -> Self {
-        self.gas_inspector = gas_inspector;
-        self
     }
 
     /// Returns the last trace [CallTrace] index from the stack.
@@ -201,7 +181,7 @@ impl TracingInspector {
             stack,
             memory,
             memory_size: interp.memory.len(),
-            gas: self.gas_inspector.as_ref().gas_remaining(),
+            gas: self.gas_inspector.gas_remaining(),
             gas_refund_counter: interp.gas.refunded() as u64,
 
             // fields will be populated end of call
@@ -251,7 +231,7 @@ impl TracingInspector {
                 };
             }
 
-            step.gas_cost = step.gas - self.gas_inspector.as_ref().gas_remaining();
+            step.gas_cost = step.gas - self.gas_inspector.gas_remaining();
         }
 
         // set the status

--- a/crates/rpc/rpc/src/eth/api/call.rs
+++ b/crates/rpc/rpc/src/eth/api/call.rs
@@ -5,7 +5,7 @@ use crate::{
         error::{EthResult, InvalidTransactionError, RevertError},
         revm_utils::{
             build_call_evm_env, cap_tx_gas_limit_with_caller_allowance, get_precompiles, inspect,
-            prepare_call_env, transact,
+            transact,
         },
         EthTransactions,
     },
@@ -18,13 +18,12 @@ use reth_revm::{
     access_list::AccessListInspector,
     database::{State, SubState},
 };
-use reth_rpc_types::{state::StateOverride, CallRequest};
+use reth_rpc_types::CallRequest;
 use reth_transaction_pool::TransactionPool;
 use revm::{
     db::DatabaseRef,
-    primitives::{BlockEnv, CfgEnv, Env, ExecutionResult, Halt, ResultAndState, TransactTo},
+    primitives::{BlockEnv, CfgEnv, ExecutionResult, Halt, TransactTo},
 };
-use tracing::trace;
 
 // Gas per transaction not creating a contract.
 const MIN_TRANSACTION_GAS: u64 = 21_000u64;
@@ -36,22 +35,6 @@ where
     Client: BlockProvider + StateProviderFactory + EvmEnvProvider + 'static,
     Network: Send + Sync + 'static,
 {
-    /// Executes the call request at the given [BlockId]
-    pub(crate) async fn transact_call_at(
-        &self,
-        request: CallRequest,
-        at: BlockId,
-        state_overrides: Option<StateOverride>,
-    ) -> EthResult<(ResultAndState, Env)> {
-        let (cfg, block_env, at) = self.evm_env_at(at).await?;
-        let state = self.state_at(at)?;
-        let mut db = SubState::new(State::new(state));
-
-        let env = prepare_call_env(cfg, block_env, request, &mut db, state_overrides)?;
-        trace!(target: "rpc::eth::call", ?env, "Executing call");
-        transact(&mut db, env)
-    }
-
     /// Estimate gas needed for execution of the `request` at the [BlockId].
     pub(crate) async fn estimate_gas_at(
         &self,


### PR DESCRIPTION
Closes #2011

adds helper functions to `EthTransaction` trait to `transact` `inspect`.


This gets rid of the `MaybeStackedInspector<GasInpsector>` in the trace inspector, to safely make it Send.
even if executed as part of a `Stack` the overhead is negligible and for tracing rpc impl we never run a stack.