### PR TITLE
chore: convert panic into error

### DIFF
--- a/crates/executor/src/blockchain_tree/shareable.rs
+++ b/crates/executor/src/blockchain_tree/shareable.rs
@@ -83,7 +83,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreePendingState
             .tree
             .read()
             .post_state_data(block_hash)
-            .ok_or_else(|| ProviderError::UnknownBlockHash(block_hash))
+            .ok_or(ProviderError::UnknownBlockHash(block_hash))
             .map(Box::new)?;
         Ok(Box::new(post_state))
     }

--- a/crates/executor/src/blockchain_tree/shareable.rs
+++ b/crates/executor/src/blockchain_tree/shareable.rs
@@ -4,6 +4,7 @@ use reth_db::database::Database;
 use reth_interfaces::{
     blockchain_tree::{BlockStatus, BlockchainTreeEngine, BlockchainTreeViewer},
     consensus::Consensus,
+    provider::ProviderError,
     Error,
 };
 use reth_primitives::{BlockHash, BlockNumHash, BlockNumber, SealedBlockWithSenders};
@@ -78,7 +79,12 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreePendingState
         &self,
         block_hash: BlockHash,
     ) -> Result<Box<dyn PostStateDataProvider>, Error> {
-        let Some(post_state) = self.tree.read().post_state_data(block_hash) else { panic!("")};
+        let post_state = self
+            .tree
+            .read()
+            .post_state_data(block_hash)
+            .ok_or_else(|| ProviderError::UnknownBlockHash(block_hash))
+            .map(Box::new)?;
         Ok(Box::new(post_state))
     }
 }

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -1015,7 +1015,7 @@ mod tests {
         let mut executor = Executor::new(chain_spec, db);
         // touch account
         executor.commit_changes(
-            hash_map::HashMap::from([(account, RevmAccount { ..default_acc.clone() })]),
+            hash_map::HashMap::from([(account, default_acc.clone())]),
             true,
             &mut PostState::default(),
         );
@@ -1039,7 +1039,7 @@ mod tests {
         );
         // touch account
         executor.commit_changes(
-            hash_map::HashMap::from([(account, RevmAccount { ..default_acc })]),
+            hash_map::HashMap::from([(account, default_acc)]),
             true,
             &mut PostState::default(),
         );

--- a/crates/interfaces/src/provider.rs
+++ b/crates/interfaces/src/provider.rs
@@ -88,4 +88,7 @@ pub enum ProviderError {
     /// Thrown when the cache service task dropped
     #[error("cache service task stopped")]
     CacheServiceUnavailable,
+    /// Thrown when we failed to lookup a block for the pending state
+    #[error("Unknown block hash: {0:}")]
+    UnknownBlockHash(H256),
 }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3c66eb6</samp>

### Summary
🆕🛠️🚀

<!--
1.  🆕 - This emoji represents the addition of a new feature or functionality, such as the `ProviderError::UnknownBlockHash` variant.
2.  🛠️ - This emoji represents the improvement or fixing of existing code, such as the error handling and consistency for block state data in the `shareable` module.
3.  🚀 - This emoji represents the optimization or enhancement of performance, such as the simplification of the `commit_changes` method calls in the executor crate.
-->
Improved error handling and consistency for block state data in the `executor` and `interfaces` crates. Added a new error variant `ProviderError::UnknownBlockHash` to handle unknown block hashes in the `provider` trait.

> _Sing, O Muse, of the valiant code review_
> _That brought new wisdom to the shareable module_
> _Where ProviderError, swift-footed and keen-eyed,_
> _Caught the unknown block hashes with its skill._

### Walkthrough
*  Add `ProviderError::UnknownBlockHash` variant to handle block lookup errors ([link](https://github.com/paradigmxyz/reth/pull/2035/files?diff=unified&w=0#diff-b5749100ec51f41dbefd21ddce062457f70c8940280a47fa69563035feed3eecR8), [link](https://github.com/paradigmxyz/reth/pull/2035/files?diff=unified&w=0#diff-2838a91f4c27749fc62d81516221fd89fd1a32b6850d2c6c19d0aeb82c70a476R91-R93))
*  Modify `post_state_data` method to return a `Result` instead of panicking on unknown block hash ([link](https://github.com/paradigmxyz/reth/pull/2035/files?diff=unified&w=0#diff-b5749100ec51f41dbefd21ddce062457f70c8940280a47fa69563035feed3eecL82-R88))

