### PR TITLE
fix: remove gas estimation accuracy threshold

### DIFF
--- a/crates/rpc/rpc/src/eth/api/call.rs
+++ b/crates/rpc/rpc/src/eth/api/call.rs
@@ -194,8 +194,6 @@ where
             ((highest_gas_limit as u128 + lowest_gas_limit as u128) / 2) as u64,
         );
 
-        let mut last_highest_gas_limit = highest_gas_limit;
-
         // binary search
         while (highest_gas_limit - lowest_gas_limit) > 1 {
             let mut env = env.clone();
@@ -205,16 +203,6 @@ where
                 ExecutionResult::Success { .. } => {
                     // cap the highest gas limit with succeeding gas limit
                     highest_gas_limit = mid_gas_limit;
-                    // if last two successful estimations only vary by 10%, we consider this to be
-                    // sufficiently accurate
-                    const ACCURACY: u128 = 10;
-                    if (last_highest_gas_limit - highest_gas_limit) as u128 * ACCURACY /
-                        (last_highest_gas_limit as u128) <
-                        1u128
-                    {
-                        return Ok(U256::from(highest_gas_limit))
-                    }
-                    last_highest_gas_limit = highest_gas_limit;
                 }
                 ExecutionResult::Revert { .. } => {
                     // increase the lowest gas limit


### PR DESCRIPTION
Fixes #2042

Runs the gas estimation binary search to completion rather than using the accuracy threshold. This fixes estimate mismatches in `eth_estimateGas` and `eth_createAccessList` hive tests.