### PR TITLE
ci: run version constraint test partitioned

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -1,17 +1,11 @@
 # Runs a series of sanity checks for crate consumers.
 #
 # Currently the only check is that the version constraints in each `Cargo.toml` do not lead to a breaking dependency.
-#on:
-#  workflow_dispatch: {}
-#  # Once per day at 00:00 UTC
-#  schedule:
-#    - cron: '0 0 * * *'
-
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+  workflow_dispatch: {}
+  # Once per day at 00:00 UTC
+  schedule:
+    - cron: '0 0 * * *'
 
 env:
   RUSTFLAGS: -D warnings

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -1,11 +1,17 @@
 # Runs a series of sanity checks for crate consumers.
 #
 # Currently the only check is that the version constraints in each `Cargo.toml` do not lead to a breaking dependency.
+#on:
+#  workflow_dispatch: {}
+#  # Once per day at 00:00 UTC
+#  schedule:
+#    - cron: '0 0 * * *'
+
 on:
-  workflow_dispatch: {}
-  # Once per day at 00:00 UTC
-  schedule:
-    - cron: '0 0 * * *'
+  push:
+    branches:
+      - main
+  pull_request:
 
 env:
   RUSTFLAGS: -D warnings
@@ -16,12 +22,15 @@ name: sanity
 jobs:
   dep-version-constraints:
     runs-on: ubuntu-latest
-    name: dep version constraints
+    name: dep version constraints test (partition ${{ matrix.partition }}/${{ strategy.job-total }})
+    strategy:
+      matrix:
+        partition: [1, 2, 3]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
@@ -46,7 +55,10 @@ jobs:
         run: cargo update
 
       - name: Run tests
-        run: cargo nextest run --locked --workspace --all-features
+        run: |
+          cargo nextest run --locked --workspace --all-features \
+            --partition hash:${{ matrix.partition }}/${{ strategy.job-total }} \
+            -E 'kind(lib)' -E 'kind(bin)' -E 'kind(proc-macro)'
 
       - uses: JasonEtco/create-an-issue@v2
         if: ${{ failure() }}


### PR DESCRIPTION
this also uses nextest partitioning (same as unit tests) for the flaky version constraint test