### PR TITLE
chore: rm unused rpc-engine-api deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5114,16 +5114,13 @@ dependencies = [
  "assert_matches",
  "futures",
  "reth-beacon-consensus",
- "reth-executor",
  "reth-interfaces",
  "reth-primitives",
  "reth-provider",
- "reth-revm",
  "reth-rpc-types",
  "thiserror",
  "tokio",
  "tokio-stream",
- "tracing",
 ]
 
 [[package]]

--- a/crates/rpc/rpc-engine-api/Cargo.toml
+++ b/crates/rpc/rpc-engine-api/Cargo.toml
@@ -11,8 +11,6 @@ description = "Implementation of Engine API"
 reth-primitives = { path = "../../primitives" }
 reth-interfaces = { path = "../../interfaces" }
 reth-provider = { path = "../../storage/provider" }
-reth-executor = { path = "../../executor" }
-reth-revm = { path = "../../revm" }
 reth-rpc-types = { path = "../rpc-types" }
 reth-beacon-consensus = { path = "../../consensus/beacon" }
 
@@ -20,9 +18,6 @@ reth-beacon-consensus = { path = "../../consensus/beacon" }
 futures = "0.3"
 tokio = { version = "1", features = ["sync"] }
 tokio-stream = "0.1"
-
-# tracing
-tracing = "0.1"
 
 # misc
 thiserror = "1.0.37"

--- a/crates/rpc/rpc-engine-api/src/lib.rs
+++ b/crates/rpc/rpc-engine-api/src/lib.rs
@@ -1,5 +1,5 @@
 #![warn(missing_docs, unreachable_pub)]
-#![deny(unused_must_use, rust_2018_idioms)]
+#![deny(unused_must_use, rust_2018_idioms, unused_crate_dependencies)]
 #![doc(test(
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))


### PR DESCRIPTION
get rid of unused deps