### PR TITLE
perf(rpc): use caching service for fetching logs and transactions

### DIFF
--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -657,6 +657,7 @@ where
                 self.pool.clone(),
                 self.events.clone(),
                 self.network.clone(),
+                cache.clone(),
             );
 
             let eth = EthHandlers { api, cache, filter, pubsub };


### PR DESCRIPTION
add new cache function for fetching the transactions of a block.

integrate in log subscription stream