### PR TITLE
bug(cursor_walk): handle empty range

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -94,12 +94,7 @@ impl<'tx, K: TransactionKind, T: Table> DbCursorRO<'tx, T> for Cursor<'tx, K, T>
         Self: Sized,
     {
         let start = match range.start_bound().cloned() {
-            Bound::Included(key) => {
-                if matches!(range.end_bound().cloned(), Bound::Included(end_key) | Bound::Excluded(end_key) if end_key < key) {
-                    return Err(Error::Read(2))
-                }
-                self.inner.set_range(key.encode().as_ref())
-            }
+            Bound::Included(key) => self.inner.set_range(key.encode().as_ref()),
             Bound::Excluded(_key) => {
                 unreachable!("Rust doesn't allow for Bound::Excluded in starting bounds");
             }
@@ -108,7 +103,7 @@ impl<'tx, K: TransactionKind, T: Table> DbCursorRO<'tx, T> for Cursor<'tx, K, T>
         .map_err(|e| Error::Read(e.into()))?
         .map(decoder::<T>);
 
-        Ok(RangeWalker::new(self, start, range.start_bound().cloned(), range.end_bound().cloned()))
+        Ok(RangeWalker::new(self, start, range.end_bound().cloned()))
     }
 
     fn walk_back<'cursor>(

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -230,6 +230,14 @@ mod tests {
         let tx = db.tx().expect(ERROR_INIT_TX);
         let mut cursor = tx.cursor_read::<CanonicalHeaders>().unwrap();
 
+        // returning nothing
+        let mut walker = cursor.walk_range(1..1).unwrap();
+        assert_eq!(walker.next(), None);
+
+        // returning nothing if range is empty
+        let mut walker = cursor.walk_range(2..1).unwrap();
+        assert_eq!(walker.next(), None);
+
         // [1, 3)
         let mut walker = cursor.walk_range(1..3).unwrap();
         assert_eq!(walker.next(), Some(Ok((1, H256::zero()))));

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -230,14 +230,6 @@ mod tests {
         let tx = db.tx().expect(ERROR_INIT_TX);
         let mut cursor = tx.cursor_read::<CanonicalHeaders>().unwrap();
 
-        // returning nothing
-        let mut walker = cursor.walk_range(1..1).unwrap();
-        assert_eq!(walker.next(), None);
-
-        // returning nothing if range is empty
-        let mut walker = cursor.walk_range(2..1).unwrap();
-        assert_eq!(walker.next(), None);
-
         // [1, 3)
         let mut walker = cursor.walk_range(1..3).unwrap();
         assert_eq!(walker.next(), Some(Ok((1, H256::zero()))));
@@ -304,12 +296,16 @@ mod tests {
         let mut cursor = tx.cursor_read::<CanonicalHeaders>().unwrap();
 
         // start bound greater than end bound
-        let res = cursor.walk_range(3..1);
-        assert!(matches!(res, Err(Error::Read(2))));
+        let mut res = cursor.walk_range(3..1).unwrap();
+        assert_eq!(res.next(), None);
 
         // start bound greater than end bound
-        let res = cursor.walk_range(15..=2);
-        assert!(matches!(res, Err(Error::Read(2))));
+        let mut res = cursor.walk_range(15..=2).unwrap();
+        assert_eq!(res.next(), None);
+
+        // returning nothing
+        let mut walker = cursor.walk_range(1..1).unwrap();
+        assert_eq!(walker.next(), None);
     }
 
     #[test]

--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -1621,7 +1621,7 @@ mod test {
         tx.insert_hashes(
             block1.number,
             exec_res1.transitions_count() as TransitionId,
-            exec_res2.transitions_count() as TransitionId,
+            (exec_res1.transitions_count() + exec_res2.transitions_count()) as TransitionId,
             2,
             block2.hash,
             block2.state_root,


### PR DESCRIPTION
closes: #2055 

added check if range is empty to mark walker as done.

And don't error on `2..1` but mark it as done.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 409318b</samp>

### Summary
🧪🐛♻️

<!--
1.  🧪 for updating and adding tests
2. 🐛 for fixing a bug
3. ♻️ for refactoring and optimizing code
-->
This pull request simplifies and optimizes the range walking functionality of the `Cursor` trait and its implementation for `MdbxCursor` in the `reth` storage crate. It also fixes a bug in a test of the `Transaction` struct in the `provider` crate.

> _We're sailing on the `MdbxCursor` ship, with `RangeWalker` as our guide_
> _We've fixed the bugs and tests, and made the code more simplified_
> _Heave away, me hearties, heave away with pride_
> _We've done a fine code review, and now we're ready for the tide_

### Walkthrough
*  Simplify and optimize the logic of the `RangeWalker` struct for iterating over a range of keys in a cursor ([link](https://github.com/paradigmxyz/reth/pull/2057/files?diff=unified&w=0#diff-6cb34044f216014bedc2f9f09fc079a30dea1f387e1395c3b046fcc85894cb66L242-L243), [link](https://github.com/paradigmxyz/reth/pull/2057/files?diff=unified&w=0#diff-6cb34044f216014bedc2f9f09fc079a30dea1f387e1395c3b046fcc85894cb66L261-R261), [link](https://github.com/paradigmxyz/reth/pull/2057/files?diff=unified&w=0#diff-6cb34044f216014bedc2f9f09fc079a30dea1f387e1395c3b046fcc85894cb66L291-R298), [link](https://github.com/paradigmxyz/reth/pull/2057/files?diff=unified&w=0#diff-6d644e704df691f1b45aa1610ddc4394fa112b9bfd17abd3add3e1b424fc8901L111-R106))
*  Remove redundant check for the end bound of the range in the `Cursor::walk_range` method for `MdbxCursor` ([link](https://github.com/paradigmxyz/reth/pull/2057/files?diff=unified&w=0#diff-6d644e704df691f1b45aa1610ddc4394fa112b9bfd17abd3add3e1b424fc8901L97-R97))
*  Update and add tests for the `Cursor::walk_range` method for `MdbxCursor` in `crates/storage/db/src/implementation/mdbx/mod.rs` ([link](https://github.com/paradigmxyz/reth/pull/2057/files?diff=unified&w=0#diff-047121c09675075f1097b8f707a9a67b02fd89665dd3e962a861488f78a031c7L299-R308))
*  Fix bug in the `test_block_insertion` test of the `Transaction` struct in `crates/storage/provider/src/transaction.rs` by using the correct value for the `last_transition_id` field of the `BlockMetadata` struct ([link](https://github.com/paradigmxyz/reth/pull/2057/files?diff=unified&w=0#diff-243938712a9e652b6ba6409f45b6e71101f6f30fe7ec9f153c33b14a3dc61e69L1624-R1624))

