### PR TITLE
fix: make transaction errors in stages fatal

### DIFF
--- a/crates/stages/src/error.rs
+++ b/crates/stages/src/error.rs
@@ -72,7 +72,8 @@ impl StageError {
                 StageError::StageProgress(_) |
                 StageError::ExecutionError { .. } |
                 StageError::ChannelClosed |
-                StageError::Fatal(_)
+                StageError::Fatal(_) |
+                StageError::Transaction(_)
         )
     }
 }


### PR DESCRIPTION
Database transaction errors in stages are not marked as fatal, but they should be