### PR TITLE
perf: don't execute empty blocks

### DIFF
--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -381,6 +381,10 @@ where
         total_difficulty: U256,
         senders: Option<Vec<Address>>,
     ) -> Result<(PostState, u64), Error> {
+        // perf: do not execute empty blocks
+        if block.body.is_empty() {
+            return Ok((PostState::default(), 0))
+        }
         let senders = self.recover_senders(&block.body, senders)?;
 
         self.init_env(&block.header, total_difficulty);
@@ -439,11 +443,8 @@ where
         total_difficulty: U256,
         senders: Option<Vec<Address>>,
     ) -> Result<PostState, Error> {
-        let (mut post_state, cumulative_gas_used) = if block.body.is_empty() {
-            (PostState::default(), 0)
-        } else {
-            self.execute_transactions(block, total_difficulty, senders)?
-        };
+        let (mut post_state, cumulative_gas_used) =
+            self.execute_transactions(block, total_difficulty, senders)?;
 
         // Check if gas used matches the value set in header.
         if block.gas_used != cumulative_gas_used {

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -16,10 +16,7 @@ use reth_primitives::{Address, Block, U256};
 use reth_provider::{
     post_state::PostState, BlockExecutor, ExecutorFactory, LatestStateProviderRef, Transaction,
 };
-use std::{
-    sync::{Arc, Mutex},
-    time::Instant,
-};
+use std::time::Instant;
 use tracing::*;
 
 /// The [`StageId`] of the execution stage.

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -16,6 +16,10 @@ use reth_primitives::{Address, Block, U256};
 use reth_provider::{
     post_state::PostState, BlockExecutor, ExecutorFactory, LatestStateProviderRef, Transaction,
 };
+use std::{
+    sync::{Arc, Mutex},
+    time::Instant,
+};
 use tracing::*;
 
 /// The [`StageId`] of the execution stage.
@@ -182,7 +186,11 @@ impl<EF: ExecutorFactory> ExecutionStage<EF> {
 
         // put execution results to database
         let first_transition_id = tx.get_block_transition(last_block)?;
+
+        let start = Instant::now();
+        trace!(target: "sync::stages::execution", changes = state.changes().len(), accounts = state.accounts().len(), "Writing updated state to database");
         state.write_to_db(&**tx, first_transition_id)?;
+        trace!(target: "sync::stages::execution", took = ?Instant::now().duration_since(start), "Wrote state");
 
         let done = !capped;
         info!(target: "sync::stages::execution", stage_progress = end_block, done, "Sync iteration finished");


### PR DESCRIPTION
Skips all the setup for executing transactions if there are no transactions in the block, and just performs block-level transitions and checks