### PR TITLE
fix: unix only sigterm

### DIFF
--- a/bin/reth/src/runner.rs
+++ b/bin/reth/src/runner.rs
@@ -3,7 +3,6 @@
 use futures::pin_mut;
 use reth_tasks::{TaskExecutor, TaskManager};
 use std::future::Future;
-use tokio::signal::unix::SignalKind;
 use tracing::trace;
 
 /// Used to execute cli commands
@@ -113,27 +112,39 @@ where
     Ok(tasks)
 }
 
-/// Runs the future to completion or until a `ctrl-c` is received.
+/// Runs the future to completion or until:
+/// - `ctrl-c` is received.
+/// - `SIGTERM` is received (unix only).
 async fn run_until_ctrl_c<F, E>(fut: F) -> Result<(), E>
 where
     F: Future<Output = Result<(), E>>,
     E: Send + Sync + 'static + From<std::io::Error>,
 {
-    let mut stream = tokio::signal::unix::signal(SignalKind::terminate())?;
-    let sigterm = stream.recv();
-
     let ctrl_c = tokio::signal::ctrl_c();
 
-    pin_mut!(sigterm, ctrl_c, fut);
+    if cfg!(unix) {
+        let mut stream = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
+        let sigterm = stream.recv();
+        pin_mut!(sigterm, ctrl_c, fut);
 
-    tokio::select! {
-        _ = ctrl_c => {
-            trace!(target: "reth::cli",  "Received ctrl-c");
-        },
-        _ = sigterm => {
-            trace!(target: "reth::cli",  "Received SIGTERM");
-        },
-        res = fut => res?,
+        tokio::select! {
+            _ = ctrl_c => {
+                trace!(target: "reth::cli",  "Received ctrl-c");
+            },
+            _ = sigterm => {
+                trace!(target: "reth::cli",  "Received SIGTERM");
+            },
+            res = fut => res?,
+        }
+    } else {
+        pin_mut!(ctrl_c, fut);
+
+        tokio::select! {
+            _ = ctrl_c => {
+                trace!(target: "reth::cli",  "Received ctrl-c");
+            },
+            res = fut => res?,
+        }
     }
 
     Ok(())


### PR DESCRIPTION
#2070 followup that only listens for sigterm on UNIX

there's no cfg support in.

tokio-select does not support cfg, hence this becomes super annoying to implement.

I have found that it is easiest to duplicate the selection