### PR TITLE
refactor: move executors to revm crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4998,6 +4998,7 @@ dependencies = [
  "reth-provider",
  "reth-revm-inspectors",
  "reth-revm-primitives",
+ "reth-rlp",
  "revm",
  "tracing",
 ]
@@ -5222,6 +5223,7 @@ dependencies = [
  "reth-metrics-derive",
  "reth-primitives",
  "reth-provider",
+ "reth-revm",
  "reth-rlp",
  "thiserror",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4461,6 +4461,7 @@ dependencies = [
  "reth-network-api",
  "reth-primitives",
  "reth-provider",
+ "reth-revm",
  "reth-revm-inspectors",
  "reth-rlp",
  "reth-rpc",
@@ -4486,7 +4487,6 @@ version = "0.1.0"
 dependencies = [
  "futures-util",
  "reth-beacon-consensus",
- "reth-executor",
  "reth-interfaces",
  "reth-primitives",
  "reth-provider",
@@ -4732,10 +4732,7 @@ dependencies = [
  "reth-interfaces",
  "reth-primitives",
  "reth-provider",
- "reth-revm",
- "reth-revm-inspectors",
  "reth-rlp",
- "revm",
  "rlp",
  "sha3",
  "thiserror",
@@ -4994,12 +4991,15 @@ dependencies = [
 name = "reth-revm"
 version = "0.1.0"
 dependencies = [
+ "reth-consensus-common",
+ "reth-executor",
  "reth-interfaces",
  "reth-primitives",
  "reth-provider",
  "reth-revm-inspectors",
  "reth-revm-primitives",
  "revm",
+ "tracing",
 ]
 
 [[package]]

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -12,6 +12,7 @@ reth-primitives = { path = "../../crates/primitives", features = ["arbitrary"] }
 reth-db = { path = "../../crates/storage/db", features = ["mdbx", "test-utils"] }
 # TODO: Temporary use of the test-utils feature
 reth-provider = { path = "../../crates/storage/provider", features = ["test-utils"] }
+reth-revm = { path = "../../crates/revm" }
 reth-revm-inspectors = { path = "../../crates/revm/revm-inspectors" }
 reth-staged-sync = { path = "../../crates/staged-sync" }
 reth-stages = { path = "../../crates/stages"}

--- a/bin/reth/src/chain/import.rs
+++ b/bin/reth/src/chain/import.rs
@@ -138,7 +138,7 @@ impl ImportCommand {
             .into_task();
 
         let (tip_tx, tip_rx) = watch::channel(H256::zero());
-        let factory = reth_executor::Factory::new(self.chain.clone());
+        let factory = reth_revm::Factory::new(self.chain.clone());
 
         let mut pipeline = Pipeline::builder()
             .with_tip_sender(tip_tx)

--- a/bin/reth/src/dump_stage/execution.rs
+++ b/bin/reth/src/dump_stage/execution.rs
@@ -99,7 +99,7 @@ async fn unwind_and_copy<DB: Database>(
     let mut unwind_tx = Transaction::new(db_tool.db)?;
 
     let mut exec_stage =
-        ExecutionStage::new_with_factory(reth_executor::Factory::new(Arc::new(MAINNET.clone())));
+        ExecutionStage::new_with_factory(reth_revm::Factory::new(Arc::new(MAINNET.clone())));
 
     exec_stage
         .unwind(
@@ -129,7 +129,7 @@ async fn dry_run(
 
     let mut tx = Transaction::new(&output_db)?;
     let mut exec_stage =
-        ExecutionStage::new_with_factory(reth_executor::Factory::new(Arc::new(MAINNET.clone())));
+        ExecutionStage::new_with_factory(reth_revm::Factory::new(Arc::new(MAINNET.clone())));
 
     exec_stage
         .execute(

--- a/bin/reth/src/dump_stage/merkle.rs
+++ b/bin/reth/src/dump_stage/merkle.rs
@@ -73,7 +73,7 @@ async fn unwind_and_copy<DB: Database>(
 
     // Bring Plainstate to TO (hashing stage execution requires it)
     let mut exec_stage =
-        ExecutionStage::new(reth_executor::Factory::new(Arc::new(MAINNET.clone())), u64::MAX);
+        ExecutionStage::new(reth_revm::Factory::new(Arc::new(MAINNET.clone())), u64::MAX);
 
     exec_stage
         .unwind(

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -26,9 +26,8 @@ use reth_downloaders::{
     bodies::bodies::BodiesDownloaderBuilder,
     headers::reverse_headers::ReverseHeadersDownloaderBuilder,
 };
-use reth_executor::{
-    blockchain_tree::{externals::TreeExternals, BlockchainTree, ShareableBlockchainTree},
-    Factory,
+use reth_executor::blockchain_tree::{
+    externals::TreeExternals, BlockchainTree, ShareableBlockchainTree,
 };
 use reth_interfaces::{
     consensus::{Consensus, ForkchoiceState},
@@ -42,6 +41,7 @@ use reth_network::{error::NetworkError, NetworkConfig, NetworkHandle, NetworkMan
 use reth_network_api::NetworkInfo;
 use reth_primitives::{BlockHashOrNumber, ChainSpec, Head, Header, SealedHeader, H256};
 use reth_provider::{BlockProvider, HeaderProvider, ShareableDatabase};
+use reth_revm::Factory;
 use reth_revm_inspectors::stack::Hook;
 use reth_rpc_engine_api::{EngineApi, EngineApiHandle};
 use reth_staged_sync::{
@@ -587,7 +587,7 @@ impl Command {
 
         let (tip_tx, tip_rx) = watch::channel(H256::zero());
         use reth_revm_inspectors::stack::InspectorStackConfig;
-        let factory = reth_executor::Factory::new(self.chain.clone());
+        let factory = reth_revm::Factory::new(self.chain.clone());
 
         let stack_config = InspectorStackConfig {
             use_printer_tracer: self.debug.print_inspector,

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -163,7 +163,7 @@ impl Command {
                 stage.execute(&mut tx, input).await?;
             }
             StageEnum::Execution => {
-                let factory = reth_executor::Factory::new(self.chain.clone());
+                let factory = reth_revm::Factory::new(self.chain.clone());
                 let mut stage = ExecutionStage::new(factory, num_blocks);
                 if !self.skip_unwind {
                     stage.unwind(&mut tx, unwind).await?;

--- a/bin/reth/src/test_eth_chain/runner.rs
+++ b/bin/reth/src/test_eth_chain/runner.rs
@@ -194,7 +194,7 @@ pub async fn run_test(path: PathBuf) -> eyre::Result<TestOutcome> {
 
         // Initialize the execution stage
         // Hardcode the chain_id to Ethereum 1.
-        let factory = reth_executor::Factory::new(Arc::new(chain_spec));
+        let factory = reth_revm::Factory::new(Arc::new(chain_spec));
         let mut stage = ExecutionStage::new(factory, 1_000);
 
         // Call execution stage

--- a/crates/consensus/auto-seal/Cargo.toml
+++ b/crates/consensus/auto-seal/Cargo.toml
@@ -14,7 +14,6 @@ reth-primitives = { path = "../../primitives" }
 reth-interfaces = { path = "../../interfaces" }
 reth-provider = { path = "../../storage/provider" }
 reth-revm = { path = "../../revm" }
-reth-executor = { path = "../../executor" }
 reth-transaction-pool = { path = "../../transaction-pool" }
 
 # async

--- a/crates/consensus/auto-seal/src/task.rs
+++ b/crates/consensus/auto-seal/src/task.rs
@@ -1,7 +1,6 @@
 use crate::{mode::MiningMode, Storage};
 use futures_util::{future::BoxFuture, FutureExt};
 use reth_beacon_consensus::BeaconEngineMessage;
-use reth_executor::executor::Executor;
 use reth_interfaces::consensus::ForkchoiceState;
 use reth_primitives::{
     constants::{EMPTY_RECEIPTS, EMPTY_TRANSACTIONS},
@@ -9,7 +8,10 @@ use reth_primitives::{
     EMPTY_OMMER_ROOT, U256,
 };
 use reth_provider::StateProviderFactory;
-use reth_revm::database::{State, SubState};
+use reth_revm::{
+    database::{State, SubState},
+    executor::Executor,
+};
 use reth_transaction_pool::{TransactionPool, ValidPoolTransaction};
 use std::{
     collections::VecDeque,

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -16,15 +16,10 @@ normal = [
 # reth 
 reth-primitives = { path = "../primitives" }
 reth-interfaces = { path = "../interfaces" }
-reth-revm = { path = "../revm" }
-reth-revm-inspectors = { path = "../revm/revm-inspectors" }
 reth-rlp = { path = "../rlp" }
 reth-db = { path = "../storage/db" }
 reth-provider = { path = "../storage/provider" }
 reth-consensus-common = { path = "../consensus/common" }
-
-# revm
-revm = { version = "3.0.0" }
 
 # common
 thiserror = "1.0.37"

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -14,13 +14,6 @@ pub use reth_provider::post_state;
 
 pub mod blockchain_tree;
 
-/// Executor
-pub mod executor;
-
-/// ExecutorFactory impl
-pub mod factory;
-pub use factory::Factory;
-
 #[cfg(any(test, feature = "test-utils"))]
 /// Common test helpers for mocking out executor and executor factory
 pub mod test_utils;

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -21,3 +21,6 @@ revm = { version = "3.0.0" }
 
 # common
 tracing = "0.1.37"
+
+[dev-dependencies]
+reth-rlp = { path = "../rlp" }

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -13,5 +13,11 @@ reth-interfaces = { path = "../interfaces" }
 reth-provider = { path = "../storage/provider" }
 reth-revm-primitives = { path = "./revm-primitives" }
 reth-revm-inspectors = { path = "./revm-inspectors" }
+reth-executor = { path = "../executor" }
+reth-consensus-common = { path = "../consensus/common" }
 
+# revm
 revm = { version = "3.0.0" }
+
+# common
+tracing = "0.1.37"

--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -1,7 +1,9 @@
 use crate::{
     database::SubState,
     env::{fill_cfg_and_block_env, fill_tx_env},
-    into_reth_log, to_reth_acc,
+    into_reth_log,
+    stack::{InspectorStack, InspectorStackConfig},
+    to_reth_acc,
 };
 use reth_consensus_common::calc;
 use reth_executor::post_state::PostState;
@@ -11,7 +13,6 @@ use reth_primitives::{
     ReceiptWithBloom, TransactionSigned, H256, U256,
 };
 use reth_provider::{BlockExecutor, StateProvider};
-use reth_revm_inspectors::stack::{InspectorStack, InspectorStackConfig};
 use revm::{
     db::AccountState,
     primitives::{
@@ -494,6 +495,7 @@ pub fn verify_receipt<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::database::State;
     use reth_consensus_common::calc;
     use reth_primitives::{
         constants::ETH_TO_WEI, hex_literal::hex, keccak256, Account, Address, BlockNumber,
@@ -503,7 +505,6 @@ mod tests {
         post_state::{Change, Storage},
         AccountProvider, BlockHashProvider, StateProvider,
     };
-    use reth_revm::database::State;
     use reth_rlp::Decodable;
     use std::{collections::HashMap, str::FromStr};
 
@@ -785,7 +786,9 @@ mod tests {
         let mut db = StateProviderTest::default();
 
         let mut beneficiary_balance = 0;
-        for (i, dao_address) in crate::eth_dao_fork::DAO_HARDKFORK_ACCOUNTS.iter().enumerate() {
+        for (i, dao_address) in
+            reth_executor::eth_dao_fork::DAO_HARDKFORK_ACCOUNTS.iter().enumerate()
+        {
             db.insert_account(
                 *dao_address,
                 Account { balance: U256::from(i), nonce: 0x00, bytecode_hash: None },
@@ -822,22 +825,25 @@ mod tests {
         // beneficiary
         let db = executor.db();
         let dao_beneficiary =
-            db.accounts.get(&crate::eth_dao_fork::DAO_HARDFORK_BENEFICIARY).unwrap();
+            db.accounts.get(&reth_executor::eth_dao_fork::DAO_HARDFORK_BENEFICIARY).unwrap();
 
         assert_eq!(dao_beneficiary.info.balance, U256::from(beneficiary_balance));
-        for address in crate::eth_dao_fork::DAO_HARDKFORK_ACCOUNTS.iter() {
+        for address in reth_executor::eth_dao_fork::DAO_HARDKFORK_ACCOUNTS.iter() {
             let account = db.accounts.get(address).unwrap();
             assert_eq!(account.info.balance, U256::ZERO);
         }
 
         // check changesets
-        let beneficiary_state =
-            out.accounts().get(&crate::eth_dao_fork::DAO_HARDFORK_BENEFICIARY).unwrap().unwrap();
+        let beneficiary_state = out
+            .accounts()
+            .get(&reth_executor::eth_dao_fork::DAO_HARDFORK_BENEFICIARY)
+            .unwrap()
+            .unwrap();
         assert_eq!(
             beneficiary_state,
             Account { balance: U256::from(beneficiary_balance), ..Default::default() },
         );
-        for address in crate::eth_dao_fork::DAO_HARDKFORK_ACCOUNTS.iter() {
+        for address in reth_executor::eth_dao_fork::DAO_HARDKFORK_ACCOUNTS.iter() {
             let updated_account = out.accounts().get(address).unwrap().unwrap();
             assert_eq!(updated_account, Account { balance: U256::ZERO, ..Default::default() });
         }

--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -1,16 +1,16 @@
-use crate::post_state::PostState;
+use crate::{
+    database::SubState,
+    env::{fill_cfg_and_block_env, fill_tx_env},
+    into_reth_log, to_reth_acc,
+};
 use reth_consensus_common::calc;
+use reth_executor::post_state::PostState;
 use reth_interfaces::executor::Error;
 use reth_primitives::{
     Account, Address, Block, Bloom, Bytecode, ChainSpec, Hardfork, Header, Log, Receipt,
     ReceiptWithBloom, TransactionSigned, H256, U256,
 };
 use reth_provider::{BlockExecutor, StateProvider};
-use reth_revm::{
-    database::SubState,
-    env::{fill_cfg_and_block_env, fill_tx_env},
-    into_reth_log, to_reth_acc,
-};
 use reth_revm_inspectors::stack::{InspectorStack, InspectorStackConfig};
 use revm::{
     db::AccountState,
@@ -251,7 +251,7 @@ where
         let mut drained_balance = U256::ZERO;
 
         // drain all accounts ether
-        for address in crate::eth_dao_fork::DAO_HARDKFORK_ACCOUNTS {
+        for address in reth_executor::eth_dao_fork::DAO_HARDKFORK_ACCOUNTS {
             let db_account = db.load_account(address).map_err(|_| Error::ProviderError)?;
             let old = to_reth_acc(&db_account.info);
             // drain balance
@@ -262,7 +262,7 @@ where
         }
 
         // add drained ether to beneficiary.
-        let beneficiary = crate::eth_dao_fork::DAO_HARDFORK_BENEFICIARY;
+        let beneficiary = reth_executor::eth_dao_fork::DAO_HARDFORK_BENEFICIARY;
         self.increment_account_balance(beneficiary, drained_balance, post_state)?;
 
         Ok(())

--- a/crates/revm/src/factory.rs
+++ b/crates/revm/src/factory.rs
@@ -1,9 +1,9 @@
-use reth_primitives::ChainSpec;
-use reth_provider::{ExecutorFactory, StateProvider};
-use reth_revm::{
+use crate::{
     database::{State, SubState},
     stack::{InspectorStack, InspectorStackConfig},
 };
+use reth_primitives::ChainSpec;
+use reth_provider::{ExecutorFactory, StateProvider};
 
 use crate::executor::Executor;
 use std::sync::Arc;

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -10,6 +10,13 @@
 /// Contains glue code for integrating reth database into revm's [Database](revm::Database).
 pub mod database;
 
+/// revm implementation of reth block and transaction executors.
+pub mod executor;
+mod factory;
+
+/// revm executor factory.
+pub use factory::Factory;
+
 /// reexport for convenience
 pub use reth_revm_inspectors::*;
 /// reexport for convenience

--- a/crates/stages/Cargo.toml
+++ b/crates/stages/Cargo.toml
@@ -49,6 +49,7 @@ reth-downloaders = { path = "../net/downloaders" }
 reth-eth-wire = { path = "../net/eth-wire" }                            # TODO(onbjerg): We only need this for [BlockBody]
 reth-executor = { path = "../executor" }
 reth-rlp = { path = "../rlp" }
+reth-revm = { path = "../revm" }
 
 itertools = "0.10.5"
 tokio = { version = "*", features = ["rt", "sync", "macros"] }

--- a/crates/stages/src/lib.rs
+++ b/crates/stages/src/lib.rs
@@ -27,7 +27,7 @@
 //! # use reth_interfaces::consensus::Consensus;
 //! # use reth_interfaces::sync::NoopSyncStateUpdate;
 //! # use reth_interfaces::test_utils::{TestBodiesClient, TestConsensus, TestHeadersClient, TestStatusUpdater};
-//! # use reth_executor::Factory;
+//! # use reth_revm::Factory;
 //! # use reth_primitives::{PeerId, MAINNET, H256};
 //! # use reth_stages::Pipeline;
 //! # use reth_stages::sets::DefaultStages;

--- a/crates/stages/src/sets.rs
+++ b/crates/stages/src/sets.rs
@@ -14,7 +14,7 @@
 //! # use reth_interfaces::sync::NoopSyncStateUpdate;
 //! # use reth_stages::Pipeline;
 //! # use reth_stages::sets::{OfflineStages};
-//! # use reth_executor::Factory;
+//! # use reth_revm::Factory;
 //! # use reth_primitives::MAINNET;
 //! # use std::sync::Arc;
 //!
@@ -27,7 +27,7 @@
 //! ```ignore
 //! # use reth_stages::Pipeline;
 //! # use reth_stages::{StageSet, sets::OfflineStages};
-//! # use reth_executor::Factory;
+//! # use reth_revm::Factory;
 //! # use reth_primitives::MAINNET;
 //! # use std::sync::Arc;
 //! // Build a pipeline with all offline stages and a custom stage at the end.

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -287,12 +287,12 @@ mod tests {
         mdbx::{test_utils::create_test_db, EnvKind, WriteMap},
         models::AccountBeforeTx,
     };
-    use reth_executor::Factory;
     use reth_primitives::{
         hex_literal::hex, keccak256, Account, Bytecode, ChainSpecBuilder, SealedBlock,
         StorageEntry, H160, H256, U256,
     };
     use reth_provider::insert_canonical_block;
+    use reth_revm::Factory;
     use reth_rlp::Decodable;
     use std::{
         ops::{Deref, DerefMut},


### PR DESCRIPTION
The revm implementations of the executor and executor factory should live in the revm crate. This allows us to use the abstractions in the `reth-executor` crate for the revm implementation (e.g. an executor cache :))

@gakonst asked why this move, and it basically highlighted that we have two paths:

- Either we are generic over an executor (`ExecutorFactory`/`BlockExecutor`), or
- We just integrate with revm

In the first case, this PR makes sense, in the second case, we could roll the revm and executor crates into one. I think the first one is better after some thought, since it allows us to experiment with other types of execution models later on (optimistically concurrent, newer versions of revm etc.)