### PR TITLE
perf: Hashing account stage, full state

### DIFF
--- a/crates/stages/benches/setup/account_hashing.rs
+++ b/crates/stages/benches/setup/account_hashing.rs
@@ -55,7 +55,7 @@ fn find_stage_range(db: &Path) -> StageRange {
 fn generate_testdata_db(num_blocks: u64) -> (PathBuf, StageRange) {
     let opts = SeedOpts {
         blocks: 0..num_blocks + 1,
-        accounts: 0..10_000,
+        accounts: 0..100_000,
         txs: 100..150,
         transitions: 10_000 + 1,
     };

--- a/crates/stages/src/stages/hashing_account.rs
+++ b/crates/stages/src/stages/hashing_account.rs
@@ -24,7 +24,7 @@ pub struct AccountHashingStage {
     /// The threshold (in number of state transitions) for switching between incremental
     /// hashing and full storage hashing.
     pub clean_threshold: u64,
-    /// The maximum number of account to process before committing.
+    /// The maximum number of accounts to process before committing.
     pub commit_threshold: u64,
 }
 

--- a/crates/stages/src/stages/hashing_account.rs
+++ b/crates/stages/src/stages/hashing_account.rs
@@ -8,7 +8,7 @@ use reth_db::{
     tables,
     transaction::{DbTx, DbTxMut},
 };
-use reth_primitives::{keccak256, Account, AccountHashingCheckpoint, H256};
+use reth_primitives::{keccak256, AccountHashingCheckpoint};
 use reth_provider::Transaction;
 use std::{fmt::Debug, ops::Range};
 use tokio::sync::mpsc;
@@ -109,7 +109,7 @@ impl AccountHashingStage {
         use reth_interfaces::test_utils::generators::{
             random_block_range, random_eoa_account_range,
         };
-        use reth_primitives::U256;
+        use reth_primitives::{Account, H256, U256};
         use reth_provider::insert_canonical_block;
 
         let blocks = random_block_range(opts.blocks, H256::zero(), opts.txs);


### PR DESCRIPTION
It got optimized by around two times.

old way
```
draganrakita@192 reth % cargo bench --package reth-stages --bench criterion --features test-utils AccountHashing
   Compiling reth-stages v0.1.0 (/Users/draganrakita/workspace/reth/crates/stages)
    Finished bench [optimized] target(s) in 3.81s
     Running benches/criterion.rs (target/release/deps/criterion-f89f26f1148427ff)
Stages/AccountHashing   time:   [65.045 ms 65.161 ms 65.277 ms]
                        change: [+112.26% +113.86% +116.03%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
```
new way
```
    Finished bench [optimized] target(s) in 5.10s
     Running benches/criterion.rs (target/release/deps/criterion-f89f26f1148427ff)
Stages/AccountHashing   time:   [31.141 ms 31.366 ms 31.668 ms]
                        change: [-52.099% -51.767% -51.443%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
```


and i added timestamps to better see where the times are spend and i got this:
```
START READING ACCOUNTS: 0ms
READ CHUNK: 0ms
READ CHUNK: 1ms
READ CHUNK: 2ms
READ CHUNK: 3ms
READ CHUNK: 3ms
READ CHUNK: 4ms
READ CHUNK: 5ms
READ CHUNK: 5ms
READ CHUNK: 6ms
READ CHUNK: 7ms
READ CHUNK: 7ms
READ CHUNK: 8ms
READ CHUNK: 8ms
READ ALL ACCOUNTS: 8ms
RECEIVED ALL ACCOUNTS: 11ms
SORTED ALL ACCOUNTS: 12ms
INSERTED ALL ACCOUNTS: 26m
```

Reading 100_000 accounts, by chunks takes around 8ms, receiving and hashing all account take 3ms (it is done in background while reading), parallel sort around 1ms, and inserting all accounts back 14ms. Check this commit to see where prints were places: https://github.com/paradigmxyz/reth/commit/4e3249ceced9c92d35222c9b724e599b92e78b16