### PR TITLE
perf(txpool): filter by sender id

### DIFF
--- a/crates/transaction-pool/src/identifier.rs
+++ b/crates/transaction-pool/src/identifier.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 /// An internal mapping of addresses.
 ///
 /// This assigns a _unique_ `SenderId` for a new `Address`.
+/// It has capacity for 2^64 unique addresses.
 #[derive(Debug, Default)]
 pub(crate) struct SenderIdentifiers {
     /// The identifier to use next.
@@ -57,7 +58,6 @@ pub struct SenderId(u64);
 
 impl SenderId {
     /// Returns a `Bound` for `TransactionId` starting with nonce `0`
-    #[cfg(test)]
     pub(crate) fn start_bound(self) -> std::ops::Bound<TransactionId> {
         std::ops::Bound::Included(TransactionId::new(self, 0))
     }

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -330,12 +330,7 @@ where
         &self,
         sender: Address,
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
-        self.pool
-            .pooled_transactions()
-            .iter()
-            .filter(|tx| tx.transaction.sender().eq(&sender))
-            .map(Arc::clone)
-            .collect()
+        self.pool.get_transactions_by_sender(sender)
     }
 }
 

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -379,11 +379,8 @@ where
         &self,
         sender: Address,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
-        self.pooled_transactions()
-            .iter()
-            .filter(|tx| tx.transaction.sender().eq(&sender))
-            .map(Arc::clone)
-            .collect()
+        let sender_id = self.get_sender_id(sender);
+        self.pool.read().get_transactions_by_sender(sender_id)
     }
 
     /// Returns all the transactions belonging to the hashes.

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -161,6 +161,14 @@ impl<T: TransactionOrdering> TxPool<T> {
         txs.into_iter().filter_map(|tx| self.get(&tx))
     }
 
+    /// Returns all transactions sent from the given sender.
+    pub(crate) fn get_transactions_by_sender(
+        &self,
+        sender: SenderId,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        self.all_transactions.txs_iter(sender).map(|(_, tx)| Arc::clone(&tx.transaction)).collect()
+    }
+
     /// Updates the entire pool after a new block was mined.
     ///
     /// This removes all mined transactions, updates according to the new base fee and rechecks
@@ -688,8 +696,6 @@ impl<T: PoolTransaction> AllTransactions<T> {
 
     /// Returns an iterator over all transactions for the given sender, starting with the lowest
     /// nonce
-    #[cfg(test)]
-    #[allow(unused)]
     pub(crate) fn txs_iter(
         &self,
         sender: SenderId,


### PR DESCRIPTION
https://github.com/paradigmxyz/reth/pull/1976 followup that only collects transactions sent by the address `get_transactions_by_sender` instead of: `clone all + filter + collect` 