### PR TITLE
feat(BlockchainTree): Add getter for pending block hashes

### DIFF
--- a/crates/executor/src/blockchain_tree/block_indices.rs
+++ b/crates/executor/src/blockchain_tree/block_indices.rs
@@ -58,6 +58,20 @@ impl BlockIndices {
         &self.blocks_to_chain
     }
 
+    /// Return all pending block hashes. Pending blocks are considered blocks
+    /// that are extending that canonical tip by one block number.
+    pub fn pending_blocks(&self) -> (BlockNumber, Vec<BlockHash>) {
+        let canonical_tip = self.canonical_tip();
+        let pending_blocks = self
+            .fork_to_child
+            .get(&canonical_tip.hash)
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .collect();
+        (canonical_tip.number + 1, pending_blocks)
+    }
+
     /// Check if block hash belongs to canonical chain.
     pub fn is_block_hash_canonical(&self, block_hash: &BlockHash) -> bool {
         self.canonical_chain.range(self.last_finalized_block..).any(|(_, &h)| h == *block_hash)

--- a/crates/executor/src/blockchain_tree/shareable.rs
+++ b/crates/executor/src/blockchain_tree/shareable.rs
@@ -61,7 +61,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeEngine
 impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeViewer
     for ShareableBlockchainTree<DB, C, EF>
 {
-    fn pending_blocks(&self) -> BTreeMap<BlockNumber, HashSet<BlockHash>> {
+    fn blocks(&self) -> BTreeMap<BlockNumber, HashSet<BlockHash>> {
         self.tree.read().block_indices().index_of_number_to_pending_blocks().clone()
     }
 
@@ -70,7 +70,16 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeViewer
     }
 
     fn canonical_tip(&self) -> BlockNumHash {
-        self.tree.read().canonical_tip()
+        self.tree.read().block_indices().canonical_tip()
+    }
+
+    fn pending_blocks(&self) -> (BlockNumber, Vec<BlockHash>) {
+        self.tree.read().block_indices().pending_blocks()
+    }
+
+    fn pending_block(&self) -> Option<BlockNumHash> {
+        let (number, blocks) = self.tree.read().block_indices().pending_blocks();
+        blocks.first().map(|&hash| BlockNumHash { number, hash })
     }
 }
 

--- a/crates/interfaces/src/blockchain_tree.rs
+++ b/crates/interfaces/src/blockchain_tree.rs
@@ -71,13 +71,30 @@ pub enum BlockStatus {
 }
 
 /// Allows read only functionality on the blockchain tree.
+///
+/// Tree contains all blocks that are not canonical that can potentially be included
+/// as canonical chain. For better explanation we can group blocks into four groups:
+/// * Canonical chain blocks
+/// * Side chain blocks. Side chain are block that forks from canonical chain but not its tip.
+/// * Pending blocks that extend the canonical chain but are not yet included.
+/// * Future pending blocks that extend the pending blocks.
 pub trait BlockchainTreeViewer: Send + Sync {
-    /// Get all pending block numbers and their hashes.
-    fn pending_blocks(&self) -> BTreeMap<BlockNumber, HashSet<BlockHash>>;
+    /// Returns both pending and sidechain block numbers and their hashes.
+    fn blocks(&self) -> BTreeMap<BlockNumber, HashSet<BlockHash>>;
 
     /// Canonical block number and hashes best known by the tree.
     fn canonical_blocks(&self) -> BTreeMap<BlockNumber, BlockHash>;
 
     /// Return BlockchainTree best known canonical chain tip (BlockHash, BlockNumber)
     fn canonical_tip(&self) -> BlockNumHash;
+
+    /// Return block hashes that extends the canonical chain tip by one.
+    /// This is used to fetch what is considered the pending blocks, blocks that
+    /// has best chance to become canonical.
+    fn pending_blocks(&self) -> (BlockNumber, Vec<BlockHash>);
+
+    /// Return block hashes that extends the canonical chain tip by one.
+    ///
+    /// If there is no such block, return `None`.
+    fn pending_block(&self) -> Option<BlockNumHash>;
 }


### PR DESCRIPTION
Add's function that returnd pending block from blockchain tree.

Pending blocks are considered blocks that directly extend the canonical chain.