### PR TITLE
fix(cli): read existing jwt instead of recreating

### DIFF
--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -105,7 +105,11 @@ impl RpcServerArgs {
             None => {
                 let default_path = PlatformPath::<JwtSecretPath>::default();
                 let fpath = default_path.as_ref();
-                JwtSecret::try_create(fpath)
+                if fpath.exists() {
+                    JwtSecret::from_file(fpath)
+                } else {
+                    JwtSecret::try_create(fpath)
+                }
             }
         }
     }


### PR DESCRIPTION
Read existing JWT at default path instead of recreating. Mirrors [geth's behavior](https://github.com/ethereum/go-ethereum/blob/beda6c41adbc72d1e39215359cdfd75ae0d2f053/node/node.go#L341-L344)



