### PR TITLE
feat: add opcount tracer

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/mod.rs
+++ b/crates/revm/revm-inspectors/src/tracing/mod.rs
@@ -18,11 +18,13 @@ mod arena;
 mod builder;
 mod config;
 mod fourbyte;
+mod opcount;
 mod types;
 mod utils;
 pub use builder::{geth::GethTraceBuilder, parity::ParityTraceBuilder};
 pub use config::TracingInspectorConfig;
 pub use fourbyte::FourByteInspector;
+pub use opcount::OpcodeCountInspector;
 
 /// An inspector that collects call traces.
 ///

--- a/crates/revm/revm-inspectors/src/tracing/opcount.rs
+++ b/crates/revm/revm-inspectors/src/tracing/opcount.rs
@@ -1,0 +1,37 @@
+//! Opcount tracing inspector that simply counts all opcodes.
+//!
+//! See also <https://geth.ethereum.org/docs/developers/evm-tracing/built-in-tracers>
+
+use revm::{
+    interpreter::{InstructionResult, Interpreter},
+    Database, EVMData, Inspector,
+};
+
+/// An inspector that counts all opcodes.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct OpcodeCountInspector {
+    /// opcode counter
+    count: usize,
+}
+
+impl OpcodeCountInspector {
+    /// Returns the opcode counter
+    pub fn count(&self) -> usize {
+        self.count
+    }
+}
+
+impl<DB> Inspector<DB> for OpcodeCountInspector
+where
+    DB: Database,
+{
+    fn step(
+        &mut self,
+        _interp: &mut Interpreter,
+        _data: &mut EVMData<'_, DB>,
+        _is_static: bool,
+    ) -> InstructionResult {
+        self.count += 1;
+        InstructionResult::Continue
+    }
+}


### PR DESCRIPTION
adds an inspector that

> opcountTracer counts the total number of opcodes executed and simply returns the number.


ref https://geth.ethereum.org/docs/developers/evm-tracing/built-in-tracers