### PR TITLE
chore: bump revm to v3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2492,6 +2492,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
+name = "hex-literal"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcb5b3e439c92a7191df2f9bbe733de8de55c3f86368cdb1c63f8be7e9e328e"
+
+[[package]]
 name = "hkdf"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3076,7 +3082,6 @@ dependencies = [
  "ecdsa 0.14.8",
  "elliptic-curve 0.12.3",
  "sha2 0.10.6",
- "sha3",
 ]
 
 [[package]]
@@ -4667,7 +4672,7 @@ dependencies = [
  "educe",
  "futures",
  "generic-array",
- "hex-literal",
+ "hex-literal 0.3.4",
  "hmac",
  "pin-project",
  "rand 0.8.5",
@@ -4695,7 +4700,7 @@ dependencies = [
  "ethers-core",
  "futures",
  "hex",
- "hex-literal",
+ "hex-literal 0.3.4",
  "metrics",
  "pin-project",
  "proptest",
@@ -4752,7 +4757,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "futures",
- "hex-literal",
+ "hex-literal 0.3.4",
  "modular-bitfield",
  "parity-scale-codec",
  "rand 0.8.5",
@@ -4940,7 +4945,7 @@ dependencies = [
  "fixed-hash",
  "hash-db",
  "hex",
- "hex-literal",
+ "hex-literal 0.3.4",
  "impl-serde",
  "modular-bitfield",
  "once_cell",
@@ -5031,7 +5036,7 @@ dependencies = [
  "criterion",
  "ethereum-types",
  "ethnum",
- "hex-literal",
+ "hex-literal 0.3.4",
  "pprof",
  "reth-rlp",
  "reth-rlp-derive",
@@ -5278,8 +5283,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "3.0.0"
-source = "git+https://github.com/bluealloy/revm#c2ee8ff5b4f0262565fa65a6a95c2a430116fa68"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02f8e1d10d4d381e657b40c7fc704373ea5985a6a77a48a048ae0b969d5072b3"
 dependencies = [
  "auto_impl",
  "revm-interpreter",
@@ -5288,8 +5294,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "1.0.0"
-source = "git+https://github.com/bluealloy/revm#c2ee8ff5b4f0262565fa65a6a95c2a430116fa68"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd02c0cf375af9e4bc3d5ed645de9b28fe911793adce0c2b94f52ecff6818c23"
 dependencies = [
  "derive_more",
  "enumn",
@@ -5299,10 +5306,11 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "2.0.0"
-source = "git+https://github.com/bluealloy/revm#c2ee8ff5b4f0262565fa65a6a95c2a430116fa68"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95e1299235ef4580feb34b68c2ff13b59bc09dbbf6ed5f1d50ec5731f17c422"
 dependencies = [
- "k256 0.11.6",
+ "k256 0.13.0",
  "num",
  "once_cell",
  "revm-primitives",
@@ -5315,8 +5323,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "1.0.0"
-source = "git+https://github.com/bluealloy/revm#c2ee8ff5b4f0262565fa65a6a95c2a430116fa68"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f75dc073614bcab964c77a58f66755d5be6f99cd2ca438dc4a561b04f34894a"
 dependencies = [
  "arbitrary",
  "auto_impl",
@@ -5327,7 +5336,7 @@ dependencies = [
  "fixed-hash",
  "hashbrown 0.13.2",
  "hex",
- "hex-literal",
+ "hex-literal 0.4.0",
  "primitive-types",
  "proptest",
  "proptest-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,5 @@ inherits = "release"
 debug = true
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm" }
-revm-primitives = { git = "https://github.com/bluealloy/revm" }
 # patched for quantity U256 responses <https://github.com/recmo/uint/issues/224>
 ruint = { git = "https://github.com/paradigmxyz/uint" }

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -24,7 +24,7 @@ reth-provider = { path = "../storage/provider" }
 reth-consensus-common = { path = "../consensus/common" }
 
 # revm
-revm = { version = "3.0.0" }
+revm = { version = "3.1.0" }
 
 # common
 thiserror = "1.0.37"

--- a/crates/interfaces/Cargo.toml
+++ b/crates/interfaces/Cargo.toml
@@ -11,7 +11,7 @@ reth-codecs = { path = "../storage/codecs" }
 reth-primitives = { path = "../primitives" }
 reth-rpc-types = { path = "../rpc/rpc-types" }
 reth-network-api = { path = "../net/network-api" }
-revm-primitives = "1.0"
+revm-primitives = "1.1"
 async-trait = "0.1.57"
 thiserror = "1.0.37"
 auto_impl = "1.0"

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -13,7 +13,7 @@ reth-rlp = { path = "../rlp", features = ["std", "derive", "ethereum-types"] }
 reth-rlp-derive = { path = "../rlp/rlp-derive" }
 reth-codecs = { version = "0.1.0", path = "../storage/codecs" }
 
-revm-primitives = { version = "1.0", features = ["serde"] }
+revm-primitives = { version = "1.1", features = ["serde"] }
 
 # ethereum
 ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
@@ -67,7 +67,7 @@ serde_json = "1.0"
 hex-literal = "0.3"
 test-fuzz = "3.0.4"
 rand = "0.8"
-revm-primitives = { version = "1.0", features = ["arbitrary"] }
+revm-primitives = { version = "1.1", features = ["arbitrary"] }
 arbitrary = { version = "1.1.7", features = ["derive"] }
 proptest = { version = "1.0" }
 proptest-derive = "0.3"

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -14,4 +14,4 @@ reth-provider = { path = "../storage/provider" }
 reth-revm-primitives = { path = "./revm-primitives" }
 reth-revm-inspectors = { path = "./revm-inspectors" }
 
-revm = { version = "3.0.0" }
+revm = { version = "3.1.0" }

--- a/crates/revm/revm-inspectors/Cargo.toml
+++ b/crates/revm/revm-inspectors/Cargo.toml
@@ -11,7 +11,7 @@ description = "revm inspector implementations used by reth"
 reth-primitives = { path = "../../primitives" }
 reth-rpc-types = { path = "../../rpc/rpc-types" }
 
-revm = { version = "3.0.0" }
+revm = { version = "3.1.0" }
 # remove from reth and reexport from revm
 hashbrown = "0.13"
 

--- a/crates/revm/revm-primitives/Cargo.toml
+++ b/crates/revm/revm-primitives/Cargo.toml
@@ -10,4 +10,4 @@ description = "core reth specific revm utilities"
 # reth 
 reth-primitives = { path = "../../primitives" }
 
-revm = { version = "3.0.0" }
+revm = { version = "3.1.0" }

--- a/crates/rlp/Cargo.toml
+++ b/crates/rlp/Cargo.toml
@@ -13,7 +13,7 @@ bytes = { version = "1", default-features = false }
 ethnum = { version = "1", default-features = false, optional = true }
 smol_str = { version = "0.1", default-features = false, optional = true }
 ethereum-types = { version = "0.14", features = ["codec"], optional = true }
-revm-primitives = { version = "1.0.0", features = ["serde"] }
+revm-primitives = { version = "1.1.0", features = ["serde"] }
 reth-rlp-derive = { version = "0.1", path = "./rlp-derive", optional = true }
 
 [dev-dependencies]

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -25,9 +25,9 @@ reth-revm = { path = "../../revm" }
 reth-tasks = { path = "../../tasks" }
 
 # eth
-revm = { version = "3.0.0", features = ["optional_block_gas_limit", "optional_eip3607", "optional_no_base_fee"] }
+revm = { version = "3.1.0", features = ["optional_block_gas_limit", "optional_eip3607", "optional_no_base_fee"] }
 ethers-core = { git = "https://github.com/gakonst/ethers-rs", features = ["eip712"] }
-revm-primitives = { version = "1.0", features = ["serde"] }
+revm-primitives = { version = "1.1", features = ["serde"] }
 
 
 # rpc

--- a/crates/storage/codecs/Cargo.toml
+++ b/crates/storage/codecs/Cargo.toml
@@ -23,7 +23,7 @@ arbitrary = [
 [dependencies]
 bytes = "1.4"
 codecs-derive = { version = "0.1.0", path = "./derive", default-features = false }
-revm-primitives = { version = "1.0.0", features = ["serde"] }
+revm-primitives = { version = "1.1.0", features = ["serde"] }
 
 # arbitrary utils
 arbitrary = { version = "1.1.7", features = ["derive"], optional = true }
@@ -31,7 +31,7 @@ proptest = { version = "1.0", optional = true }
 proptest-derive = { version = "0.3", optional = true }
 
 [dev-dependencies]
-revm-primitives = {version = "1.0.0", features = [
+revm-primitives = {version = "1.1.0", features = [
     "serde",
     "arbitrary"
 ] }

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -17,7 +17,7 @@ reth-codecs = { path = "../codecs" }
 reth-tracing = {path = "../../tracing"}
 reth-rlp = {path = "../../rlp"}
 
-revm-primitives = "1.0.0"
+revm-primitives = "1.1.0"
 
 # trie
 cita_trie = "4.0.0"


### PR DESCRIPTION
Bump revm to v3.1.0 version

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8e39ac5</samp>

### Summary
🚚🆙🐛

<!--
1.  🚚 This emoji represents the removal of a dependency, as it suggests moving something away or deleting it.
2.  🆙 This emoji represents the updating of a dependency, as it suggests increasing or improving something.
3.  🐛 This emoji represents the fixing of a bug, as it suggests squashing or eliminating an error.
-->
This pull request updates the dependencies on the `revm` and `revm-primitives` crates in various reth crates. These crates provide the core functionality of the reth virtual machine and its interfaces. The updates include new features, bug fixes and optimizations.

> _`revm` and `primitives`_
> _New versions on crates.io_
> _Winter of updates_

### Walkthrough
*  Remove the dependency on the revm and revm-primitives crates from the git repository in `Cargo.toml` ([link](https://github.com/paradigmxyz/reth/pull/2113/files?diff=unified&w=0#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L52-L53))
*  Update the dependency on the revm-primitives crate to version 1.1.0 in several crates, including `interfaces`, `primitives`, `rlp`, `storage/codecs`, and `storage/provider` ([link](https://github.com/paradigmxyz/reth/pull/2113/files?diff=unified&w=0#diff-a2e543da1c7e078b895d8174d3db220f55e3b6235850baceef2d5ba99a0bcb03L14-R14), [link](https://github.com/paradigmxyz/reth/pull/2113/files?diff=unified&w=0#diff-8a32326c5cbb8a6bcce3d072e07c99ca58ff6ff1e00a855ba756ca54042bcaf5L16-R16), [link](https://github.com/paradigmxyz/reth/pull/2113/files?diff=unified&w=0#diff-8a32326c5cbb8a6bcce3d072e07c99ca58ff6ff1e00a855ba756ca54042bcaf5L70-R70), [link](https://github.com/paradigmxyz/reth/pull/2113/files?diff=unified&w=0#diff-f1d760b486e98603a4fced280b3e36833db85b4128df8cc02083b920b0c8f25eL16-R16), [link](https://github.com/paradigmxyz/reth/pull/2113/files?diff=unified&w=0#diff-bc98640556d69ff7a8db66ecfa76106c5fe0137c2ebcca0015d213e2753725afL26-R26), [link](https://github.com/paradigmxyz/reth/pull/2113/files?diff=unified&w=0#diff-bc98640556d69ff7a8db66ecfa76106c5fe0137c2ebcca0015d213e2753725afL34-R34), [link](https://github.com/paradigmxyz/reth/pull/2113/files?diff=unified&w=0#diff-4fd82651cc3125ba4628a60824be9deec0178bcbec7276c502ac6e03ad3a18e6L20-R20))
*  Update the dependency on the revm crate to version 3.1.0 in several crates, including `revm`, `revm-inspectors`, `revm-primitives`, and `rpc/rpc` ([link](https://github.com/paradigmxyz/reth/pull/2113/files?diff=unified&w=0#diff-4473cf61225d3bd706faaab03c472e28153526402dacbf834f3caaa9a09a28edL20-R20), [link](https://github.com/paradigmxyz/reth/pull/2113/files?diff=unified&w=0#diff-72fac36dee1deae241d0536a38a072c0353ac9842bc20d7741268282cd22bf1fL14-R14), [link](https://github.com/paradigmxyz/reth/pull/2113/files?diff=unified&w=0#diff-eb99f8d91b8ab9f36ae5e76ea7aad13d7328ae6b7680b467aba5f1bcb7340e09L13-R13), [link](https://github.com/paradigmxyz/reth/pull/2113/files?diff=unified&w=0#diff-8ba4beb37e48b64b18cc0a60b7c10491ee2dd89e05e4ed0a2ac179257952aea1L28-R30))

