### PR TITLE
feat(rpc): add overrides to trace call opts

### DIFF
--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -1,7 +1,10 @@
 use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
 use reth_primitives::{BlockId, BlockNumberOrTag, Bytes, H256};
 use reth_rpc_types::{
-    trace::geth::{BlockTraceResult, GethDebugTracingOptions, GethTraceFrame, TraceResult},
+    trace::geth::{
+        BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTraceFrame,
+        TraceResult,
+    },
     CallRequest, RichBlock,
 };
 
@@ -97,6 +100,6 @@ pub trait DebugApi {
         &self,
         request: CallRequest,
         block_number: Option<BlockId>,
-        opts: GethDebugTracingOptions,
+        opts: GethDebugTracingCallOptions,
     ) -> Result<GethTraceFrame>;
 }

--- a/crates/rpc/rpc-types/src/eth/block.rs
+++ b/crates/rpc/rpc-types/src/eth/block.rs
@@ -2,7 +2,7 @@
 use crate::Transaction;
 use reth_primitives::{
     Address, Block as PrimitiveBlock, Bloom, Bytes, Header as PrimitiveHeader, SealedHeader,
-    Withdrawal, H256, H64, U256,
+    Withdrawal, H256, H64, U256, U64,
 };
 use reth_rlp::Encodable;
 use serde::{ser::Error, Deserialize, Serialize, Serializer};
@@ -349,6 +349,27 @@ impl<T: Serialize> Serialize for Rich<T> {
             Err(S::Error::custom("Unserializable structures: expected objects"))
         }
     }
+}
+
+/// BlockOverrides is a set of header fields to override.
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+#[allow(missing_docs)]
+pub struct BlockOverrides {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub number: Option<U256>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub difficulty: Option<U256>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub time: Option<U64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gas_limit: Option<U64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub coinbase: Option<Address>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub random: Option<H256>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_fee: Option<U256>,
 }
 
 #[cfg(test)]

--- a/crates/rpc/rpc-types/src/eth/trace/geth/mod.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/geth/mod.rs
@@ -1,5 +1,6 @@
 #![allow(missing_docs)]
 
+use crate::{state::StateOverride, BlockOverrides};
 /// Geth tracing types
 use reth_primitives::{Bytes, JsonU256, H256, U256};
 use serde::{Deserialize, Serialize};
@@ -308,9 +309,6 @@ pub struct GethDefaultTracingOptions {
     /// maximum length of output, but zero means unlimited
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub limit: Option<u64>,
-    /// Chain overrides, can be used to execute a trace using future fork rules
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub overrides: Option<serde_json::Value>,
 }
 
 /// Bindings for additional `debug_traceCall` options
@@ -321,5 +319,10 @@ pub struct GethDefaultTracingOptions {
 pub struct GethDebugTracingCallOptions {
     #[serde(flatten)]
     pub tracing_options: GethDebugTracingOptions,
-    // TODO: Add stateoverrides and blockoverrides options
+    /// The state overrides to apply
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state_overrides: Option<StateOverride>,
+    /// The block overrides to apply
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block_overrides: Option<BlockOverrides>,
 }


### PR DESCRIPTION
add missing override arguments:

ref https://github.com/ethereum/go-ethereum/blob/8990c92aea01ca07801597b00c0d83d4e2d9b811/eth/tracers/api.go#L186-L192