### PR TITLE
feat(rpc): implement trace_Block

### DIFF
--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -165,6 +165,7 @@ where
         .await
         .err()
         .unwrap();
+    TraceApiClient::trace_block(client, block_id).await.err().unwrap();
 
     assert!(is_unimplemented(
         TraceApiClient::replay_block_transactions(client, block_id, HashSet::default())
@@ -172,7 +173,6 @@ where
             .err()
             .unwrap()
     ));
-    assert!(is_unimplemented(TraceApiClient::trace_block(client, block_id).await.err().unwrap()));
     assert!(is_unimplemented(
         TraceApiClient::trace_filter(client, trace_filter).await.err().unwrap()
     ));


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0182592</samp>

This pull request adds support for tracing block execution in the `rpc` crate. It implements the `trace_block` method for the `TraceApi` and `TraceApiClient` traits, and updates the test suite accordingly. It also makes some minor formatting changes in the `trace.rs` module.