### PR TITLE
fix(engine): future payload handling

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -333,7 +333,6 @@ where
 
         // Set the next pipeline state.
         loop {
-            tracing::info!("processing msgs");
             // Process all incoming messages first.
             while let Poll::Ready(Some(msg)) = this.message_rx.poll_next_unpin(cx) {
                 match msg {
@@ -371,8 +370,6 @@ where
                 }
             }
 
-            tracing::error!("forkchoice {:?}", &this.forkchoice_state);
-
             // Lookup the forkchoice state. We can't launch the pipeline without the tip.
             let forkchoice_state = match &this.forkchoice_state {
                 Some(state) => *state,
@@ -397,9 +394,6 @@ where
                                         let minimum_pipeline_progress =
                                             pipeline.minimum_progress().unwrap_or_default();
                                         if this.has_reached_max_block(minimum_pipeline_progress) {
-                                            tracing::info!(
-                                                "consensus engine reached max block, not polling"
-                                            );
                                             return Poll::Ready(Ok(()))
                                         }
                                     }
@@ -430,7 +424,6 @@ where
                     }
                 }
                 PipelineState::Idle(pipeline) => {
-                    tracing::info!("idle pipeline");
                     this.next_pipeline_state(pipeline, forkchoice_state)
                 }
             };

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -193,7 +193,10 @@ where
     ///
     /// These responses should adhere to the [Engine API Spec for
     /// `engine_newPayload`](https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#specification).
-    fn on_new_payload(&mut self, payload: ExecutionPayload) -> PayloadStatus {
+    fn on_new_payload(
+        &mut self,
+        payload: ExecutionPayload,
+    ) -> Result<PayloadStatus, reth_interfaces::Error> {
         let block_number = payload.block_number.as_u64();
         let block_hash = payload.block_hash;
         trace!(target: "consensus::engine", ?block_hash, block_number, "Received new payload");
@@ -201,9 +204,9 @@ where
             Ok(block) => block,
             Err(error) => {
                 error!(target: "consensus::engine", ?block_hash, block_number, ?error, "Invalid payload");
-                return PayloadStatus::from_status(PayloadStatusEnum::InvalidBlockHash {
+                return Ok(PayloadStatus::from_status(PayloadStatusEnum::InvalidBlockHash {
                     validation_error: error.to_string(),
-                })
+                }))
             }
         };
 
@@ -224,17 +227,31 @@ where
                     let latest_valid_hash =
                         matches!(error, Error::Execution(ExecutorError::BlockPreMerge { .. }))
                             .then_some(H256::zero());
-                    PayloadStatus::new(
-                        PayloadStatusEnum::Invalid { validation_error: error.to_string() },
-                        latest_valid_hash,
-                    )
+                    let status = match error {
+                        Error::Execution(ExecutorError::PendingBlockIsInFuture { .. }) => {
+                            if let Some(ForkchoiceState { head_block_hash, .. }) =
+                                self.forkchoice_state
+                            {
+                                if self
+                                    .db
+                                    .view(|tx| tx.get::<tables::HeaderNumbers>(head_block_hash))??
+                                    .is_none()
+                                {
+                                    self.require_pipeline_run(PipelineTarget::Head);
+                                }
+                            }
+                            PayloadStatusEnum::Syncing
+                        }
+                        error => PayloadStatusEnum::Invalid { validation_error: error.to_string() },
+                    };
+                    PayloadStatus::new(status, latest_valid_hash)
                 }
             }
         } else {
             PayloadStatus::from_status(PayloadStatusEnum::Syncing)
         };
         trace!(target: "consensus::engine", ?block_hash, block_number, ?status, "Returning payload status");
-        status
+        Ok(status)
     }
 
     /// Returns the next pipeline state depending on the current value of the next action.
@@ -316,6 +333,7 @@ where
 
         // Set the next pipeline state.
         loop {
+            tracing::info!("processing msgs");
             // Process all incoming messages first.
             while let Poll::Ready(Some(msg)) = this.message_rx.poll_next_unpin(cx) {
                 match msg {
@@ -341,11 +359,19 @@ where
                         }
                     }
                     BeaconEngineMessage::NewPayload { payload, tx } => {
-                        let response = this.on_new_payload(payload);
+                        let response = match this.on_new_payload(payload) {
+                            Ok(response) => response,
+                            Err(error) => {
+                                error!(target: "consensus::engine", ?error, "Error getting new payload response");
+                                return Poll::Ready(Err(error.into()))
+                            }
+                        };
                         let _ = tx.send(Ok(response));
                     }
                 }
             }
+
+            tracing::error!("forkchoice {:?}", &this.forkchoice_state);
 
             // Lookup the forkchoice state. We can't launch the pipeline without the tip.
             let forkchoice_state = match &this.forkchoice_state {
@@ -371,6 +397,9 @@ where
                                         let minimum_pipeline_progress =
                                             pipeline.minimum_progress().unwrap_or_default();
                                         if this.has_reached_max_block(minimum_pipeline_progress) {
+                                            tracing::info!(
+                                                "consensus engine reached max block, not polling"
+                                            );
                                             return Poll::Ready(Ok(()))
                                         }
                                     }
@@ -401,6 +430,7 @@ where
                     }
                 }
                 PipelineState::Idle(pipeline) => {
+                    tracing::info!("idle pipeline");
                     this.next_pipeline_state(pipeline, forkchoice_state)
                 }
             };

--- a/crates/interfaces/src/executor.rs
+++ b/crates/interfaces/src/executor.rs
@@ -48,7 +48,7 @@ pub enum Error {
         block_number: BlockNumber,
         last_finalized: BlockNumber,
     },
-    #[error("Can't insert block  #{block_number} {block_hash} to far in future, as last finalized block number is {last_finalized}")]
+    #[error("Block #{block_number} ({block_hash:?}) too far into the future. Last finalized block is #{last_finalized}")]
     PendingBlockIsInFuture {
         block_hash: BlockHash,
         block_number: BlockNumber,


### PR DESCRIPTION
closes #2101

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 36393c2</samp>

### Summary
:recycle::sparkles::mag:

<!--
1.  :recycle: - This emoji represents the refactoring of the error message and the formatting of the block hash. It implies that the code was improved or cleaned up without changing its functionality.
2.  :sparkles: - This emoji represents the enhancement of the `on_new_payload` function to return a `Result` type and handle errors more gracefully. It implies that the code was added or updated with new features or improvements.
3.  :mag: - This emoji represents the addition of tracing statements to the `poll` method of the `BeaconEngine` to improve logging and debugging. It implies that the code was made more visible or easier to inspect or test.
-->
This pull request improves the error handling and logging of the `BeaconEngine` in the `consensus/beacon` crate, and fixes a minor issue with the error message formatting of the `ExecutorError` enum in the `interfaces` crate.

> _`on_new_payload`_
> _returns `Result`, handles errors_
> _autumn leaves falling_

### Walkthrough
*  Change `on_new_payload` function signature to return a `Result<PayloadStatus, reth_interfaces::Error>` instead of a `PayloadStatus` ([link](https://github.com/paradigmxyz/reth/pull/2124/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544L196-R199))
*  Update `on_new_payload` function to return `Ok(PayloadStatus::from_status(...))` instead of just `PayloadStatus::from_status(...)` to match the new return type ([link](https://github.com/paradigmxyz/reth/pull/2124/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544L204-R209), [link](https://github.com/paradigmxyz/reth/pull/2124/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544L237-R254))
*  Handle `Error::Execution(ExecutorError::PendingBlockIsInFuture { .. })` error in `on_new_payload` function and return `PayloadStatusEnum::Syncing` variant if the payload block is too far ahead of the last finalized block ([link](https://github.com/paradigmxyz/reth/pull/2124/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544L227-R247))
*  Trigger a pipeline run in `on_new_payload` function if the head block hash from the forkchoice state is unknown to the database ([link](https://github.com/paradigmxyz/reth/pull/2124/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544L227-R247))
*  Handle errors from `on_new_payload` function in `poll` method of `BeaconEngine` struct and terminate the future with the error ([link](https://github.com/paradigmxyz/reth/pull/2124/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544L344-R368))
*  Add tracing statements to `poll` method of `BeaconEngine` struct to log informational and error messages when processing messages from the channel, reaching the maximum block number, or being idle ([link](https://github.com/paradigmxyz/reth/pull/2124/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544R336), [link](https://github.com/paradigmxyz/reth/pull/2124/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544R374-R375), [link](https://github.com/paradigmxyz/reth/pull/2124/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544R400-R402), [link](https://github.com/paradigmxyz/reth/pull/2124/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544R433))
*  Change error message for `ExecutorError::PendingBlockIsInFuture` variant to be more concise and consistent with the other error messages in `crates/interfaces/src/executor.rs` ([link](https://github.com/paradigmxyz/reth/pull/2124/files?diff=unified&w=0#diff-8d1a8029bf39542a9dfd4cd5664105789d3822bbe413ec0698fe4ac62f336cb6L51-R51))

