### PR TITLE
fix: sync when forkchoiceUpdated hash is unknown

### DIFF
--- a/crates/executor/src/blockchain_tree/block_indices.rs
+++ b/crates/executor/src/blockchain_tree/block_indices.rs
@@ -72,6 +72,11 @@ impl BlockIndices {
         (canonical_tip.number + 1, pending_blocks)
     }
 
+    /// Check if the block is contained in a side chain OR the canonical chain.
+    pub fn contains_block(&self, block_hash: &BlockHash) -> bool {
+        self.is_block_hash_canonical(block_hash) || self.blocks_to_chain.contains_key(block_hash)
+    }
+
     /// Check if block hash belongs to canonical chain.
     pub fn is_block_hash_canonical(&self, block_hash: &BlockHash) -> bool {
         self.canonical_chain.range(self.last_finalized_block..).any(|(_, &h)| h == *block_hash)

--- a/crates/executor/src/blockchain_tree/mod.rs
+++ b/crates/executor/src/blockchain_tree/mod.rs
@@ -590,6 +590,11 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
         Ok(())
     }
 
+    /// Check if the blockchain tree contains the hash.
+    pub fn contains_block(&self, block_hash: &BlockHash) -> bool {
+        self.block_indices.contains_block(block_hash)
+    }
+
     /// Subscribe to new blocks events.
     ///
     /// Note: Only canonical blocks are send.

--- a/crates/executor/src/blockchain_tree/shareable.rs
+++ b/crates/executor/src/blockchain_tree/shareable.rs
@@ -81,6 +81,10 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeViewer
         let (number, blocks) = self.tree.read().block_indices().pending_blocks();
         blocks.first().map(|&hash| BlockNumHash { number, hash })
     }
+
+    fn contains_block(&self, block_hash: &BlockHash) -> bool {
+        self.tree.read().contains_block(block_hash)
+    }
 }
 
 impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreePendingStateProvider

--- a/crates/interfaces/src/blockchain_tree.rs
+++ b/crates/interfaces/src/blockchain_tree.rs
@@ -97,4 +97,7 @@ pub trait BlockchainTreeViewer: Send + Sync {
     ///
     /// If there is no such block, return `None`.
     fn pending_block(&self) -> Option<BlockNumHash>;
+
+    /// Returns whether or not the block is in the tree.
+    fn contains_block(&self, block_hash: &BlockHash) -> bool;
 }


### PR DESCRIPTION
Attempts to get us to sync when we are given an unknown head hash from `engine_forkchoiceUpdatedV1`. We can't perform other engine checks if we don't have the full block.

To do this, `PipelineTarget::Hash(hash)` is added to the possible pipeline targets, and we run the pipeline until we reach the unknown hash.

* Adds `contains_block` to the `BlockchainTree`