### PR TITLE
feat: add blockValue to execution payload

### DIFF
--- a/crates/rpc/rpc-api/src/engine.rs
+++ b/crates/rpc/rpc-api/src/engine.rs
@@ -1,8 +1,8 @@
 use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
 use reth_primitives::{BlockHash, U64};
 use reth_rpc_types::engine::{
-    ExecutionPayload, ExecutionPayloadBodies, ForkchoiceState, ForkchoiceUpdated,
-    PayloadAttributes, PayloadId, PayloadStatus, TransitionConfiguration,
+    ExecutionPayload, ExecutionPayloadBodies, ExecutionPayloadEnvelope, ForkchoiceState,
+    ForkchoiceUpdated, PayloadAttributes, PayloadId, PayloadStatus, TransitionConfiguration,
 };
 
 #[cfg_attr(not(feature = "client"), rpc(server))]
@@ -43,7 +43,7 @@ pub trait EngineApi {
 
     /// See also <https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/shanghai.md#engine_getpayloadv2>
     #[method(name = "engine_getPayloadV2")]
-    async fn get_payload_v2(&self, payload_id: PayloadId) -> Result<ExecutionPayload>;
+    async fn get_payload_v2(&self, payload_id: PayloadId) -> Result<ExecutionPayloadEnvelope>;
 
     /// See also <https://github.com/ethereum/execution-apis/blob/6452a6b194d7db269bf1dbd087a267251d3cc7f8/src/engine/shanghai.md#engine_getpayloadbodiesbyhashv1>
     #[method(name = "engine_getPayloadBodiesByHashV1")]

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -4,7 +4,7 @@ use reth_beacon_consensus::BeaconEngineMessage;
 use reth_primitives::{BlockHash, BlockId, BlockNumber, ChainSpec, Hardfork};
 use reth_provider::{BlockProvider, EvmEnvProvider, HeaderProvider, StateProviderFactory};
 use reth_rpc_types::engine::{
-    ExecutionPayload, ExecutionPayloadBodies, PayloadId, TransitionConfiguration,
+    ExecutionPayloadBodies, ExecutionPayloadEnvelope, PayloadId, TransitionConfiguration,
 };
 use std::{
     future::Future,
@@ -85,7 +85,7 @@ impl<Client: HeaderProvider + BlockProvider + StateProviderFactory + EvmEnvProvi
     ///
     /// NOTE: Will always result in `PayloadUnknown` since we don't support block
     /// building for now.
-    pub fn get_payload(&self, _payload_id: PayloadId) -> Option<ExecutionPayload> {
+    pub fn get_payload(&self, _payload_id: PayloadId) -> Option<ExecutionPayloadEnvelope> {
         None
     }
 

--- a/crates/rpc/rpc-engine-api/src/message.rs
+++ b/crates/rpc/rpc-engine-api/src/message.rs
@@ -3,15 +3,15 @@ use reth_beacon_consensus::BeaconEngineSender;
 use reth_interfaces::consensus::ForkchoiceState;
 use reth_primitives::{BlockHash, BlockNumber};
 use reth_rpc_types::engine::{
-    ExecutionPayload, ExecutionPayloadBodies, ForkchoiceUpdated, PayloadAttributes, PayloadId,
-    PayloadStatus, TransitionConfiguration,
+    ExecutionPayload, ExecutionPayloadBodies, ExecutionPayloadEnvelope, ForkchoiceUpdated,
+    PayloadAttributes, PayloadId, PayloadStatus, TransitionConfiguration,
 };
 
 /// Message type for communicating with [`EngineApi`][crate::EngineApi].
 #[derive(Debug)]
 pub enum EngineApiMessage {
     /// Get payload message
-    GetPayload(PayloadId, EngineApiSender<ExecutionPayload>),
+    GetPayload(PayloadId, EngineApiSender<ExecutionPayloadEnvelope>),
     /// Get payload bodies by range message
     GetPayloadBodiesByRange(BlockNumber, u64, EngineApiSender<ExecutionPayloadBodies>),
     /// Get payload bodies by hash message

--- a/crates/rpc/rpc-types/src/eth/engine/payload.rs
+++ b/crates/rpc/rpc-types/src/eth/engine/payload.rs
@@ -20,6 +20,34 @@ impl PayloadId {
     }
 }
 
+/// This structure maps for the return value of `engine_getPayloadV2` of the beacon chain spec.
+///
+/// See also: <https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#engine_getpayloadv2>
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutionPayloadEnvelope {
+    /// Execution payload, which could be either V1 or V2
+    ///
+    /// V1 (_NO_ withdrawals) MUST be returned if the payload timestamp is lower than the Shanghai
+    /// timestamp
+    ///
+    /// V2 (_WITH_ withdrawals) MUST be returned if the payload timestamp is greater or equal to
+    /// the Shanghai timestamp
+    #[serde(rename = "executionPayload")]
+    pub payload: ExecutionPayload,
+    /// The expected value to be received by the feeRecipient in wei
+    #[serde(rename = "blockValue")]
+    pub block_value: U256,
+}
+
+impl ExecutionPayloadEnvelope {
+    /// Returns the [ExecutionPayload] for the `engine_getPayloadV1` endpoint
+    pub fn into_v1_payload(mut self) -> ExecutionPayload {
+        // ensure withdrawals are removed
+        self.payload.withdrawals.take();
+        self.payload
+    }
+}
+
 /// This structure maps on the ExecutionPayload structure of the beacon chain spec.
 ///
 /// See also: <https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/paris.md#executionpayloadv1>

--- a/crates/rpc/rpc/src/engine.rs
+++ b/crates/rpc/rpc/src/engine.rs
@@ -7,8 +7,8 @@ use reth_rpc_engine_api::{
     EngineApiError, EngineApiHandle, EngineApiMessage, EngineApiMessageVersion, EngineApiResult,
 };
 use reth_rpc_types::engine::{
-    ExecutionPayload, ExecutionPayloadBodies, ForkchoiceUpdated, PayloadAttributes, PayloadId,
-    PayloadStatus, TransitionConfiguration, CAPABILITIES,
+    ExecutionPayload, ExecutionPayloadBodies, ExecutionPayloadEnvelope, ForkchoiceUpdated,
+    PayloadAttributes, PayloadId, PayloadStatus, TransitionConfiguration, CAPABILITIES,
 };
 use std::sync::Arc;
 use tokio::sync::oneshot::{self, Receiver};
@@ -157,12 +157,14 @@ impl EngineApiServer for EngineApi {
     /// Caution: This should not return the `withdrawals` field
     async fn get_payload_v1(&self, payload_id: PayloadId) -> Result<ExecutionPayload> {
         let (tx, rx) = oneshot::channel();
-        self.delegate_request(EngineApiMessage::GetPayload(payload_id, tx), rx).await
+        self.delegate_request(EngineApiMessage::GetPayload(payload_id, tx), rx)
+            .await
+            .map(ExecutionPayloadEnvelope::into_v1_payload)
     }
 
     /// Handler for `engine_getPayloadV2`
     /// See also <https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#engine_getpayloadv2>
-    async fn get_payload_v2(&self, payload_id: PayloadId) -> Result<ExecutionPayload> {
+    async fn get_payload_v2(&self, payload_id: PayloadId) -> Result<ExecutionPayloadEnvelope> {
         let (tx, rx) = oneshot::channel();
         self.delegate_request(EngineApiMessage::GetPayload(payload_id, tx), rx).await
     }


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/2144

adds missing blockValue to `engine_getPayloadV2` response type

the getPayloadV2 response wraps the executionPayload and has the blockvalue as additional field:
https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#engine_getpayloadv2