### PR TITLE
chore(rpc): add submit hashrate impl

### DIFF
--- a/crates/rpc/rpc-api/src/eth.rs
+++ b/crates/rpc/rpc-api/src/eth.rs
@@ -209,6 +209,10 @@ pub trait EthApi {
     async fn get_work(&self) -> Result<Work>;
 
     /// Used for submitting mining hashrate.
+    ///
+    /// Can be used for remote miners to submit their hash rate.
+    /// It accepts the miner hash rate and an identifier which must be unique between nodes.
+    /// Returns `true` if the block was successfully submitted, `false` otherwise.
     #[method(name = "eth_submitHashrate")]
     async fn submit_hashrate(&self, hashrate: U256, id: H256) -> Result<bool>;
 

--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -97,6 +97,7 @@ where
     EthApiClient::syncing(client).await.unwrap();
     EthApiClient::send_transaction(client, transaction_request).await.unwrap_err();
     EthApiClient::hashrate(client).await.unwrap();
+    EthApiClient::submit_hashrate(client, U256::default(), H256::default()).await.unwrap();
 
     // Unimplemented
     assert!(is_unimplemented(EthApiClient::author(client).await.err().unwrap()));
@@ -104,12 +105,6 @@ where
     assert!(is_unimplemented(EthApiClient::max_priority_fee_per_gas(client).await.err().unwrap()));
     assert!(is_unimplemented(EthApiClient::is_mining(client).await.err().unwrap()));
     assert!(is_unimplemented(EthApiClient::get_work(client).await.err().unwrap()));
-    assert!(is_unimplemented(
-        EthApiClient::submit_hashrate(client, U256::default(), H256::default())
-            .await
-            .err()
-            .unwrap()
-    ));
     assert!(is_unimplemented(
         EthApiClient::submit_work(client, H64::default(), H256::default(), H256::default())
             .await

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -382,7 +382,7 @@ where
 
     /// Handler for: `eth_submitHashrate`
     async fn submit_hashrate(&self, _hashrate: U256, _id: H256) -> Result<bool> {
-        Err(internal_rpc_err("unimplemented"))
+        Ok(false)
     }
 
     /// Handler for: `eth_submitWork`


### PR DESCRIPTION
return false, always

https://github.com/ethereum/go-ethereum/blob/2adce0b06640aa665706d014a92cd06f0720dcab/consensus/ethash/api.go#L95-L95

builds off of #2152