### PR TITLE
feat: add engine rpc errors with codes

### DIFF
--- a/crates/rpc/rpc-types/src/eth/engine/error.rs
+++ b/crates/rpc/rpc-types/src/eth/engine/error.rs
@@ -1,0 +1,54 @@
+//! Commonly used errors for the `engine_` namespace.
+
+/// List of Engine API errors, see <https://github.com/ethereum/execution-apis/blob/main/src/engine/common.md#errors>
+#[derive(Debug, Copy, PartialEq, Eq, Clone, thiserror::Error)]
+pub enum EngineRpcError {
+    /// Invalid JSON was received by the server.
+    #[error("Invalid JSON was received by the server")]
+    ParseError,
+    /// The JSON sent is not a valid Request object.
+    #[error("The JSON sent is not a valid Request object")]
+    InvalidRequest,
+    /// The method does not exist / is not available.
+    #[error("The method does not exist / is not available")]
+    MethodNotFound,
+    /// Invalid method parameter(s).
+    #[error("Invalid method parameter(s)")]
+    InvalidParams,
+    /// Internal JSON-RPC error.
+    #[error("Internal JSON-RPC error")]
+    InternalError,
+    /// Generic client error while processing request.
+    #[error("Generic client error while processing request")]
+    ServerError,
+    /// Payload does not exist / is not available.
+    #[error("Payload does not exist / is not available")]
+    UnknownPayload,
+    /// Forkchoice state is invalid / inconsistent.
+    #[error("Forkchoice state is invalid / inconsistent")]
+    InvalidForkchoiceState,
+    /// Payload attributes are invalid / inconsistent.
+    #[error("Payload attributes are invalid / inconsistent")]
+    InvalidPayloadAttributes,
+    /// Number of requested entities is too large.
+    #[error("Number of requested entities is too large")]
+    TooLargeRequest,
+}
+
+impl EngineRpcError {
+    /// Returns the error code as `i32`
+    pub const fn code(&self) -> i32 {
+        match *self {
+            EngineRpcError::ParseError => -32700,
+            EngineRpcError::InvalidRequest => -32600,
+            EngineRpcError::MethodNotFound => -32601,
+            EngineRpcError::InvalidParams => -32602,
+            EngineRpcError::InternalError => -32603,
+            EngineRpcError::ServerError => -32000,
+            EngineRpcError::UnknownPayload => -38001,
+            EngineRpcError::InvalidForkchoiceState => -38002,
+            EngineRpcError::InvalidPayloadAttributes => -38003,
+            EngineRpcError::TooLargeRequest => -38004,
+        }
+    }
+}

--- a/crates/rpc/rpc-types/src/eth/engine/mod.rs
+++ b/crates/rpc/rpc-types/src/eth/engine/mod.rs
@@ -2,11 +2,12 @@
 
 #![allow(missing_docs)]
 
+mod error;
 mod forkchoice;
 mod payload;
 mod transition;
 
-pub use self::{forkchoice::*, payload::*, transition::*};
+pub use self::{error::*, forkchoice::*, payload::*, transition::*};
 
 /// The list of supported Engine capabilities
 pub const CAPABILITIES: [&str; 9] = [


### PR DESCRIPTION
Adds all errors from the [engine api error spec](https://github.com/ethereum/execution-apis/blob/main/src/engine/common.md#errors), so we can use the correct codes when applicable.