### PR TITLE
feat: add `reth config` cmd to dump default reth.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4486,6 +4486,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "toml 0.7.3",
  "tracing",
  "tui",
 ]

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -51,6 +51,7 @@ serde_json = "1.0"
 shellexpand = "3.0.0"
 dirs-next = "2.0.0"
 confy = "0.5"
+toml = {version = "0.7", features = ["display"]}
 
 # metrics
 metrics = "0.20.1"

--- a/bin/reth/src/cli.rs
+++ b/bin/reth/src/cli.rs
@@ -2,7 +2,7 @@
 use std::str::FromStr;
 
 use crate::{
-    chain, db,
+    chain, config, db,
     dirs::{LogsDir, PlatformPath},
     drop_stage, dump_stage, node, p2p,
     runner::CliRunner,
@@ -35,6 +35,7 @@ pub fn run() -> eyre::Result<()> {
         Commands::P2P(command) => runner.run_until_ctrl_c(command.execute()),
         Commands::TestVectors(command) => runner.run_until_ctrl_c(command.execute()),
         Commands::TestEthChain(command) => runner.run_until_ctrl_c(command.execute()),
+        Commands::Config(command) => runner.run_until_ctrl_c(command.execute()),
     }
 }
 
@@ -76,6 +77,9 @@ pub enum Commands {
     /// Generate Test Vectors
     #[command(name = "test-vectors")]
     TestVectors(test_vectors::Command),
+    /// Write default config to stdout
+    #[command(name = "config")]
+    Config(config::Command),
 }
 
 #[derive(Debug, Parser)]

--- a/bin/reth/src/cli.rs
+++ b/bin/reth/src/cli.rs
@@ -77,7 +77,7 @@ pub enum Commands {
     /// Generate Test Vectors
     #[command(name = "test-vectors")]
     TestVectors(test_vectors::Command),
-    /// Write default config to stdout
+    /// Write config to stdout
     #[command(name = "config")]
     Config(config::Command),
 }

--- a/bin/reth/src/config.rs
+++ b/bin/reth/src/config.rs
@@ -1,15 +1,45 @@
-//! CLI command to write default config to stdout
+//! CLI command to show configs
 use clap::Parser;
+use eyre::{bail, WrapErr};
 use reth_staged_sync::Config;
+
+use crate::dirs::{ConfigPath, PlatformPath};
 
 /// `reth config` command
 #[derive(Debug, Parser)]
-pub struct Command;
+pub struct Command {
+    #[clap(subcommand)]
+    command: Subcommands,
+}
+
+/// `reth config` subcommands
+#[derive(Debug, Parser)]
+pub enum Subcommands {
+    /// Show the default config
+    Default,
+    /// Show the active config
+    Show {
+        /// The path to the configuration file to use.
+        #[arg(long, value_name = "FILE", verbatim_doc_comment, default_value_t)]
+        config: PlatformPath<ConfigPath>,
+    },
+}
 
 impl Command {
-    /// Execute `config` command - write default config to stdout
+    /// Execute `config` command
     pub async fn execute(&self) -> eyre::Result<()> {
-        let config = Config::default();
+        let config = match &self.command {
+            Subcommands::Default => Config::default(),
+            Subcommands::Show { config } => {
+                // confy will create the file if it doesn't exist; we don't want this
+                if !config.as_ref().exists() {
+                    bail!("Config file does not exist: {}", config.as_ref().display());
+                }
+                confy::load_path::<Config>(&config).wrap_err_with(|| {
+                    format!("Could not load config file: {}", config.as_ref().display())
+                })?
+            }
+        };
         println!("{}", toml::to_string_pretty(&config)?);
         Ok(())
     }

--- a/bin/reth/src/config.rs
+++ b/bin/reth/src/config.rs
@@ -1,0 +1,16 @@
+//! CLI command to write default config to stdout
+use clap::Parser;
+use reth_staged_sync::Config;
+
+/// `reth config` command
+#[derive(Debug, Parser)]
+pub struct Command;
+
+impl Command {
+    /// Execute `config` command - write default config to stdout
+    pub async fn execute(&self) -> eyre::Result<()> {
+        let config = Config::default();
+        println!("{}", toml::to_string_pretty(&config)?);
+        Ok(())
+    }
+}

--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -10,6 +10,7 @@
 pub mod args;
 pub mod chain;
 pub mod cli;
+pub mod config;
 pub mod db;
 pub mod dirs;
 pub mod drop_stage;


### PR DESCRIPTION
resolves #1897 

hi, first contrib to this repo, just picked a simple issue

- didn't add test as functionality is trivial
- added `toml` crate- config io is handled by `confy` but it doesn't expose any functionality to write to string, only path. could also have written to tempfile and read back, seemed cleaner like this though
