### PR TITLE
feat: add BlockchainTreeViewer::block_by_hash

### DIFF
--- a/crates/executor/src/blockchain_tree/mod.rs
+++ b/crates/executor/src/blockchain_tree/mod.rs
@@ -147,6 +147,13 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
         &self.block_indices
     }
 
+    /// Returns the block with matching hash.
+    pub fn block_by_hash(&self, block_hash: BlockHash) -> Option<&SealedBlock> {
+        let id = self.block_indices.get_blocks_chain_id(&block_hash)?;
+        let chain = self.chains.get(&id)?;
+        chain.block(block_hash)
+    }
+
     /// Return items needed to execute on the pending state.
     /// This includes:
     ///     * `BlockHash` of canonical block that chain connects to. Needed for creating database

--- a/crates/executor/src/blockchain_tree/shareable.rs
+++ b/crates/executor/src/blockchain_tree/shareable.rs
@@ -7,7 +7,7 @@ use reth_interfaces::{
     provider::ProviderError,
     Error,
 };
-use reth_primitives::{BlockHash, BlockNumHash, BlockNumber, SealedBlockWithSenders};
+use reth_primitives::{BlockHash, BlockNumHash, BlockNumber, SealedBlock, SealedBlockWithSenders};
 use reth_provider::{
     BlockchainTreePendingStateProvider, CanonStateSubscriptions, ExecutorFactory,
     PostStateDataProvider,
@@ -65,6 +65,10 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeViewer
 {
     fn blocks(&self) -> BTreeMap<BlockNumber, HashSet<BlockHash>> {
         self.tree.read().block_indices().index_of_number_to_pending_blocks().clone()
+    }
+
+    fn block_by_hash(&self, block_hash: BlockHash) -> Option<SealedBlock> {
+        self.tree.read().block_by_hash(block_hash).cloned()
     }
 
     fn canonical_blocks(&self) -> BTreeMap<BlockNumber, BlockHash> {

--- a/crates/interfaces/src/blockchain_tree.rs
+++ b/crates/interfaces/src/blockchain_tree.rs
@@ -82,6 +82,9 @@ pub trait BlockchainTreeViewer: Send + Sync {
     /// Returns both pending and sidechain block numbers and their hashes.
     fn blocks(&self) -> BTreeMap<BlockNumber, HashSet<BlockHash>>;
 
+    /// Returns the block with matching hash.
+    fn block_by_hash(&self, hash: BlockHash) -> Option<SealedBlock>;
+
     /// Canonical block number and hashes best known by the tree.
     fn canonical_blocks(&self) -> BTreeMap<BlockNumber, BlockHash>;
 

--- a/crates/storage/provider/src/chain.rs
+++ b/crates/storage/provider/src/chain.rs
@@ -3,8 +3,8 @@
 use crate::PostState;
 use reth_interfaces::{executor::Error as ExecError, Error};
 use reth_primitives::{
-    BlockHash, BlockNumHash, BlockNumber, ForkBlock, Receipt, SealedBlockWithSenders, TransitionId,
-    TxHash,
+    BlockHash, BlockNumHash, BlockNumber, ForkBlock, Receipt, SealedBlock, SealedBlockWithSenders,
+    TransitionId, TxHash,
 };
 use std::collections::BTreeMap;
 
@@ -49,6 +49,13 @@ impl Chain {
     /// Return block inner transition ids.
     pub fn block_transitions(&self) -> &BTreeMap<BlockNumber, TransitionId> {
         &self.block_transitions
+    }
+
+    /// Returns the block with matching hash.
+    pub fn block(&self, block_hash: BlockHash) -> Option<&SealedBlock> {
+        self.blocks
+            .iter()
+            .find_map(|(_num, block)| (block.hash() == block_hash).then_some(&block.block))
     }
 
     /// Return post state of the block at the `block_number` or None if block is not known


### PR DESCRIPTION
Add helper function to get matching block from tree.

Required when building a payload:
* state after parent
* env after parent (need parent.block.header)