### PR TITLE
fix: return engine_getPayload error response

### DIFF
--- a/crates/consensus/beacon/src/engine/error.rs
+++ b/crates/consensus/beacon/src/engine/error.rs
@@ -1,28 +1,23 @@
 use reth_miner::error::PayloadBuilderError;
-use reth_rpc_types::engine::PayloadError;
+use reth_rpc_types::engine::{EngineRpcError, PayloadError};
 use reth_stages::PipelineError;
 use thiserror::Error;
 
 /// Beacon engine result.
 pub type BeaconEngineResult<Ok> = Result<Ok, BeaconEngineError>;
 
-// TODO: add conversions to codes for engine spec compliance
-// one notable variant would be UnknownPayload
 /// The error wrapper for the beacon consensus engine.
 #[derive(Error, Debug)]
 pub enum BeaconEngineError {
     /// Forkchoice zero hash head received.
     #[error("Received zero hash as forkchoice head")]
     ForkchoiceEmptyHead,
-    /// Invalid payload attributes.
-    #[error("Invalid payload attributes")]
-    InvalidPayloadAttributes,
     /// Pipeline channel closed.
     #[error("Pipeline channel closed")]
     PipelineChannelClosed,
-    /// Unknown payload
-    #[error("Unknown payload")]
-    UnknownPayload,
+    /// An error covered by the engine API standard error codes.
+    #[error(transparent)]
+    EngineApi(#[from] EngineRpcError),
     /// Encountered a payload error.
     #[error(transparent)]
     Payload(#[from] PayloadError),


### PR DESCRIPTION
Previously, we would return `Poll(Err(error))` when `on_get_payload` returns an error. Instead, we should be returning that error back to the client if it corresponds to one of the errors from the engine API spec.

Previously:
```
>> (c2356d73) {"jsonrpc":"2.0","id":2,"method":"engine_getPayloadV1","params":["0xdb5a075c19eee601"]}
<< (c2356d73) {"jsonrpc":"2.0","error":{"code":-32001,"message":"Custom error: channel closed"},"id":2}
CLMocker: Could not getPayload (c2356d73, 0xdb5a075c19eee601): Custom error: channel closed
```
Now:
```
>> (effe3338) {"jsonrpc":"2.0","id":2,"method":"engine_getPayloadV1","params":["0xf98c6886602604e5"]}
<< (effe3338) {"jsonrpc":"2.0","error":{"code":-32603,"message":"Payload does not exist / is not available"},"id":2}
```