### PR TITLE
chore(trie): add account to `trie` crate

### DIFF
--- a/crates/trie/src/account.rs
+++ b/crates/trie/src/account.rs
@@ -1,0 +1,39 @@
+use reth_primitives::{proofs::EMPTY_ROOT, Account, H256, KECCAK_EMPTY, U256};
+use reth_rlp::{RlpDecodable, RlpEncodable};
+
+/// An Ethereum account as represented in the trie.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, RlpEncodable, RlpDecodable)]
+pub struct EthAccount {
+    /// Account nonce.
+    nonce: u64,
+    /// Account balance.
+    balance: U256,
+    /// Account's storage root.
+    storage_root: H256,
+    /// Hash of the account's bytecode.
+    code_hash: H256,
+}
+
+impl From<Account> for EthAccount {
+    fn from(acc: Account) -> Self {
+        EthAccount {
+            nonce: acc.nonce,
+            balance: acc.balance,
+            storage_root: EMPTY_ROOT,
+            code_hash: acc.bytecode_hash.unwrap_or(KECCAK_EMPTY),
+        }
+    }
+}
+
+impl EthAccount {
+    /// Set storage root on account.
+    pub fn with_storage_root(mut self, storage_root: H256) -> Self {
+        self.storage_root = storage_root;
+        self
+    }
+
+    /// Get account's storage root.
+    pub fn storage_root(&self) -> H256 {
+        self.storage_root
+    }
+}


### PR DESCRIPTION
Copies over `EthAccount` from the providers to the `trie` crate.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f979835</samp>

### Summary
🌲🧑‍💻💰

<!--
1.  🌲 - This emoji represents the trie data structure, which is a tree-like structure that stores key-value pairs in a compact and efficient way. The account trie is a special kind of trie that stores Ethereum accounts by their addresses. The emoji also suggests the idea of growth and branching, which are relevant to the trie operations.
2.  🧑‍💻 - This emoji represents the code and the developer who wrote it. The code implements the serialization and deserialization logic for the `EthAccount` struct, as well as the conversion from the `Account` struct. The emoji also suggests the idea of programming and coding, which are relevant to the reth project.
3.  💰 - This emoji represents the balance and the nonce fields of the `EthAccount` struct, which are related to the economic aspects of Ethereum. The balance field stores the amount of ether that the account owns, and the nonce field stores the number of transactions that the account has sent. The emoji also suggests the idea of money and value, which are relevant to the Ethereum network.
-->
Add a new struct `EthAccount` to represent Ethereum accounts in the trie. Implement serialization, deserialization, and conversion traits for `EthAccount`, and provide methods to access and update its `storage_root` field.

> _`EthAccount` struct_
> _Serializes account trie_
> _Autumn leaves falling_

### Walkthrough
* Define and implement `EthAccount` struct for account trie logic ([link](https://github.com/paradigmxyz/reth/pull/2180/files?diff=unified&w=0#diff-0ed7e248ef4b4e937de4aa994e9fe2273543e5841f8762457a591627b2a55306R1-R39))

