### PR TITLE
feat(trie): prefix set

### DIFF
--- a/crates/primitives/src/trie/nibbles.rs
+++ b/crates/primitives/src/trie/nibbles.rs
@@ -36,6 +36,12 @@ impl From<&[u8]> for Nibbles {
     }
 }
 
+impl<const N: usize> From<&[u8; N]> for Nibbles {
+    fn from(arr: &[u8; N]) -> Self {
+        Nibbles::from_hex(arr.to_vec())
+    }
+}
+
 impl std::fmt::Debug for Nibbles {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Nibbles").field("hex_data", &hex::encode(&self.hex_data)).finish()

--- a/crates/trie/src/lib.rs
+++ b/crates/trie/src/lib.rs
@@ -14,3 +14,7 @@ pub mod nodes;
 
 /// The implementation of hash builder.
 pub mod hash_builder;
+
+/// The implementation of a container for storing intermediate changes to a trie.
+/// The container indicates when the trie has been modified.
+pub mod prefix_set;

--- a/crates/trie/src/prefix_set.rs
+++ b/crates/trie/src/prefix_set.rs
@@ -43,6 +43,11 @@ impl PrefixSet {
     pub fn len(&self) -> usize {
         self.keys.len()
     }
+
+    /// Returns `true` if the set is empty.
+    pub fn is_empty(&self) -> bool {
+        self.keys.is_empty()
+    }
 }
 
 #[cfg(test)]

--- a/crates/trie/src/prefix_set.rs
+++ b/crates/trie/src/prefix_set.rs
@@ -1,0 +1,65 @@
+use std::collections::BTreeSet;
+
+use reth_primitives::trie::Nibbles;
+
+/// A container for efficiently storing and checking for the presence of key prefixes.
+///
+/// This data structure stores a set of `Nibbles` and provides methods to insert
+/// new elements and check whether any existing element has a given prefix.
+///
+/// Internally, this implementation uses a `BTreeSet` to store the `Nibbles`, which
+/// ensures that they are always sorted and deduplicated.
+///
+/// # Examples
+///
+/// ```
+/// use reth_trie::prefix_set::PrefixSet;
+///
+/// let mut prefix_set = PrefixSet::default();
+/// prefix_set.insert(b"key1");
+/// prefix_set.insert(b"key2");
+///
+/// assert_eq!(prefix_set.contains(b"key"), true);
+/// ```
+#[derive(Debug, Default, Clone)]
+pub struct PrefixSet {
+    keys: BTreeSet<Nibbles>,
+}
+
+impl PrefixSet {
+    /// Returns `true` if any of the keys in the set has the given prefix or
+    /// if the given prefix is a prefix of any key in the set.
+    pub fn contains<T: Into<Nibbles>>(&self, prefix: T) -> bool {
+        let prefix = prefix.into();
+        self.keys.iter().any(|key| key.has_prefix(&prefix))
+    }
+
+    /// Inserts the given `nibbles` into the set.
+    pub fn insert<T: Into<Nibbles>>(&mut self, nibbles: T) {
+        self.keys.insert(nibbles.into());
+    }
+
+    /// Returns the number of elements in the set.
+    pub fn len(&self) -> usize {
+        self.keys.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_contains_with_multiple_inserts_and_duplicates() {
+        let mut prefix_set = PrefixSet::default();
+        prefix_set.insert(b"123");
+        prefix_set.insert(b"124");
+        prefix_set.insert(b"456");
+        prefix_set.insert(b"123"); // Duplicate
+
+        assert!(prefix_set.contains(b"12"));
+        assert!(prefix_set.contains(b"45"));
+        assert!(!prefix_set.contains(b"78"));
+        assert_eq!(prefix_set.len(), 3); // Length should be 3 (excluding duplicate)
+    }
+}


### PR DESCRIPTION
Adds `PrefixSet` to `trie` crate. `PrefixSet` is a container for efficiently storing and checking for the presence of key prefixes.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c84711f</samp>

### Summary
🧮🌲✅

<!--
1.  🧮 - This emoji represents the `From<&[u8; N]>` trait implementation for the `Nibbles` type, as it suggests the conversion of bytes into nibbles, which are smaller units of data. The emoji also conveys the idea of calculation and manipulation of binary data, which is relevant for the trie crate.
2.  🌲 - This emoji represents the introduction of the `prefix_set` module and the `PrefixSet` type, as it suggests the concept of a tree-like data structure, which is what a trie is. The emoji also conveys the idea of growth and branching, which is relevant for the trie operations and the tracking of changes.
3.  ✅ - This emoji represents the implementation and testing of the `PrefixSet` type and its methods, as it suggests the completion and verification of the functionality. The emoji also conveys the idea of correctness and success, which is relevant for the trie crate and its goals.
-->
This pull request adds a new `prefix_set` module to the `trie` crate, which implements a `PrefixSet` type for storing and checking key prefixes in a trie. It also implements the `From<&[u8; N]>` trait for the `Nibbles` type, which simplifies the creation of `Nibbles` from byte arrays.

> _`Nibbles` from bytes_
> _`PrefixSet` tracks trie changes_
> _Autumn of data_

### Walkthrough
*  Implement `From<&[u8; N]>` trait for `Nibbles` type to allow converting byte arrays into nibbles ([link](https://github.com/paradigmxyz/reth/pull/2181/files?diff=unified&w=0#diff-74a509e6017e8dc11b527361b4c5aef9d039c9f57bbfbc99f7393f3980bd3033R39-R44))
* Add `prefix_set` module to `trie` crate to store and check key prefixes in a trie ([link](https://github.com/paradigmxyz/reth/pull/2181/files?diff=unified&w=0#diff-e01e2ab09c945ead6cd35f5abdd632246159c736e38470648d3ff7c449452c14R17-R20))
* Define and test `PrefixSet` type using a `BTreeSet` of `Nibbles` and provide methods to insert and query elements ([link](https://github.com/paradigmxyz/reth/pull/2181/files?diff=unified&w=0#diff-8475bae2abbffe68ed5dbba337c063520929ad52a28fed967aa7a23eabf972a8R1-R65))

