### PR TITLE
feat(trie): stored nibbles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5316,6 +5316,7 @@ dependencies = [
 name = "reth-trie"
 version = "0.1.0"
 dependencies = [
+ "derive_more",
  "hex",
  "proptest",
  "reth-primitives",

--- a/crates/primitives/src/trie/mod.rs
+++ b/crates/primitives/src/trie/mod.rs
@@ -1,7 +1,7 @@
 //! Collection of trie related types.
 
 mod nibbles;
-pub use nibbles::Nibbles;
+pub use nibbles::{StoredNibbles, StoredNibblesSubKey};
 
 mod branch_node;
 pub use branch_node::BranchNodeCompact;

--- a/crates/primitives/src/trie/nibbles.rs
+++ b/crates/primitives/src/trie/nibbles.rs
@@ -34,7 +34,7 @@ impl Compact for StoredNibblesSubKey {
         padded[..self.inner.len()].copy_from_slice(&self.inner[..]);
         buf.put_slice(&padded);
         buf.put_u8(self.inner.len() as u8);
-        65 // 64 + 1
+        64 + 1
     }
 
     fn from_compact(buf: &[u8], _len: usize) -> (Self, &[u8])

--- a/crates/primitives/src/trie/nibbles.rs
+++ b/crates/primitives/src/trie/nibbles.rs
@@ -1,290 +1,48 @@
-use derive_more::{Deref, DerefMut, From, Index};
-use reth_rlp::RlpEncodableWrapper;
+use crate::Bytes;
+use derive_more::Deref;
+use reth_codecs::{main_codec, Compact};
+use serde::{Deserialize, Serialize};
 
-/// Structure representing a sequence of nibbles.
-///
-/// A nibble is a 4-bit value, and this structure is used to store
-/// the nibble sequence representing the keys in a Merkle Patricia Trie (MPT).
-/// Using nibbles simplifies trie operations and enables consistent key
-/// representation in the MPT.
-///
-/// The `hex_data` field is a `Vec<u8>` that stores the nibbles, with each
-/// `u8` value containing a single nibble. This means that each byte in
-/// `hex_data` has its upper 4 bits set to zero and the lower 4 bits
-/// representing the nibble value.
-#[derive(
-    Default,
-    Clone,
-    Eq,
-    PartialEq,
-    RlpEncodableWrapper,
-    PartialOrd,
-    Ord,
-    Index,
-    From,
-    Deref,
-    DerefMut,
-)]
-pub struct Nibbles {
-    /// The inner representation of the nibble sequence.
-    pub hex_data: Vec<u8>,
+/// The nibbles are the keys for the AccountsTrie and the subkeys for the StorageTrie.
+#[main_codec]
+#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct StoredNibbles {
+    /// The inner nibble bytes
+    pub inner: Bytes,
 }
 
-impl From<&[u8]> for Nibbles {
-    fn from(slice: &[u8]) -> Self {
-        Nibbles::from_hex(slice.to_vec())
+impl From<Vec<u8>> for StoredNibbles {
+    fn from(inner: Vec<u8>) -> Self {
+        Self { inner: inner.into() }
     }
 }
 
-impl std::fmt::Debug for Nibbles {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Nibbles").field("hex_data", &hex::encode(&self.hex_data)).finish()
+/// The representation of nibbles of the merkle trie stored in the database.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord, Deref)]
+pub struct StoredNibblesSubKey(StoredNibbles);
+
+impl From<Vec<u8>> for StoredNibblesSubKey {
+    fn from(inner: Vec<u8>) -> Self {
+        Self(StoredNibbles { inner: inner.into() })
     }
 }
 
-impl Nibbles {
-    /// Creates a new [Nibbles] instance from bytes.
-    pub fn from_hex(hex: Vec<u8>) -> Self {
-        Nibbles { hex_data: hex }
+impl Compact for StoredNibblesSubKey {
+    fn to_compact(self, buf: &mut impl bytes::BufMut) -> usize {
+        assert!(self.inner.len() <= 32);
+        let mut padded = vec![0; 32];
+        padded[..self.inner.len()].copy_from_slice(&self.inner[..]);
+        buf.put_slice(&padded);
+        buf.put_u8(self.inner.len() as u8);
+        33 // 32 + 1
     }
 
-    /// Take a byte array (slice or vector) as input and convert it into a [Nibbles] struct
-    /// containing the nibbles (half-bytes or 4 bits) that make up the input byte data.
-    pub fn unpack<T: AsRef<[u8]>>(data: T) -> Self {
-        Nibbles { hex_data: data.as_ref().iter().flat_map(|item| [item / 16, item % 16]).collect() }
-    }
-
-    /// Packs the nibbles stored in the struct into a byte vector.
-    ///
-    /// This method combines each pair of consecutive nibbles into a single byte,
-    /// effectively reducing the size of the data by a factor of two.
-    /// If the number of nibbles is odd, the last nibble is shifted left by 4 bits and
-    /// added to the packed byte vector.
-    pub fn pack(&self) -> Vec<u8> {
-        let length = (self.len() + 1) / 2;
-        if length == 0 {
-            Vec::default()
-        } else {
-            self.iter()
-                .enumerate()
-                .filter_map(|(index, nibble)| {
-                    if index % 2 == 0 {
-                        let next_nibble = self.get(index + 1).unwrap_or(&0);
-                        Some((*nibble << 4) + *next_nibble)
-                    } else {
-                        None
-                    }
-                })
-                .collect()
-        }
-    }
-
-    /// Encodes a given path leaf as a compact array of bytes, where each byte represents two
-    /// "nibbles" (half-bytes or 4 bits) of the original hex data, along with additional information
-    /// about the leaf itself.
-    ///
-    /// The method takes the following input:
-    /// `is_leaf`: A boolean value indicating whether the current node is a leaf node or not.
-    ///
-    /// The first byte of the encoded vector is set based on the `is_leaf` flag and the parity of
-    /// the hex data length (even or odd number of nibbles).
-    ///  - If the node is an extension with even length, the header byte is `0x00`.
-    ///  - If the node is an extension with odd length, the header byte is `0x10 + <first nibble>`.
-    ///  - If the node is a leaf with even length, the header byte is `0x20`.
-    ///  - If the node is a leaf with odd length, the header byte is `0x30 + <first nibble>`.
-    ///
-    /// If there is an odd number of nibbles, store the first nibble in the lower 4 bits of the
-    /// first byte of encoded.
-    ///
-    /// # Returns
-    ///
-    /// A `Vec<u8>` containing the compact byte representation of the nibble sequence, including the
-    /// header byte.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use reth_primitives::trie::Nibbles;
-    ///
-    /// // Extension node with an even path length:
-    /// let nibbles = Nibbles::from_hex(vec![0x0A, 0x0B, 0x0C, 0x0D]);
-    /// assert_eq!(nibbles.encode_path_leaf(false), vec![0x00, 0xAB, 0xCD]);
-    ///
-    /// // Extension node with an odd path length:
-    /// let nibbles = Nibbles::from_hex(vec![0x0A, 0x0B, 0x0C]);
-    /// assert_eq!(nibbles.encode_path_leaf(false), vec![0x1A, 0xBC]);
-    ///
-    /// // Leaf node with an even path length:
-    /// let nibbles = Nibbles::from_hex(vec![0x0A, 0x0B, 0x0C, 0x0D]);
-    /// assert_eq!(nibbles.encode_path_leaf(true), vec![0x20, 0xAB, 0xCD]);
-    ///
-    /// // Leaf node with an odd path length:
-    /// let nibbles = Nibbles::from_hex(vec![0x0A, 0x0B, 0x0C]);
-    /// assert_eq!(nibbles.encode_path_leaf(true), vec![0x3A, 0xBC]);
-    /// ```
-    pub fn encode_path_leaf(&self, is_leaf: bool) -> Vec<u8> {
-        let mut encoded = vec![0u8; self.len() / 2 + 1];
-        let odd_nibbles = self.len() % 2 != 0;
-
-        // Set the first byte of the encoded vector.
-        encoded[0] = match (is_leaf, odd_nibbles) {
-            (true, true) => 0x30 | self[0],
-            (true, false) => 0x20,
-            (false, true) => 0x10 | self[0],
-            (false, false) => 0x00,
-        };
-
-        let mut nibble_idx = if odd_nibbles { 1 } else { 0 };
-        for byte in encoded.iter_mut().skip(1) {
-            *byte = (self[nibble_idx] << 4) + self[nibble_idx + 1];
-            nibble_idx += 2;
-        }
-
-        encoded
-    }
-
-    /// Increments the nibble sequence by one.
-    pub fn increment(&self) -> Option<Nibbles> {
-        let mut incremented = self.hex_data.clone();
-
-        for nibble in incremented.iter_mut().rev() {
-            assert!(*nibble < 0x10);
-            if *nibble < 0xf {
-                *nibble += 1;
-                return Some(Nibbles::from(incremented))
-            } else {
-                *nibble = 0;
-            }
-        }
-
-        None
-    }
-
-    /// The last element of the hex vector is used to determine whether the nibble sequence
-    /// represents a leaf or an extension node. If the last element is 0x10 (16), then it's a leaf.
-    pub fn is_leaf(&self) -> bool {
-        self.hex_data[self.hex_data.len() - 1] == 16
-    }
-
-    /// Returns `true` if the current nibble sequence starts with the given prefix.
-    pub fn has_prefix(&self, other: &Self) -> bool {
-        self.starts_with(other)
-    }
-
-    /// Returns the nibble at the given index.
-    pub fn at(&self, i: usize) -> usize {
-        self.hex_data[i] as usize
-    }
-
-    /// Returns the last nibble of the current nibble sequence.
-    pub fn last(&self) -> Option<u8> {
-        self.hex_data.last().copied()
-    }
-
-    /// Returns the length of the common prefix between the current nibble sequence and the given.
-    pub fn common_prefix_length(&self, other: &Nibbles) -> usize {
-        let len = std::cmp::min(self.len(), other.len());
-        for i in 0..len {
-            if self[i] != other[i] {
-                return i
-            }
-        }
-        len
-    }
-
-    /// Slice the current nibbles from the given start index to the end.
-    pub fn slice_from(&self, index: usize) -> Nibbles {
-        self.slice(index, self.hex_data.len())
-    }
-
-    /// Slice the current nibbles within the provided index range.
-    pub fn slice(&self, start: usize, end: usize) -> Nibbles {
-        Nibbles::from_hex(self.hex_data[start..end].to_vec())
-    }
-
-    /// Join two nibbles together.
-    pub fn join(&self, b: &Nibbles) -> Nibbles {
-        let mut hex_data = Vec::with_capacity(self.len() + b.len());
-        hex_data.extend_from_slice(self);
-        hex_data.extend_from_slice(b);
-        Nibbles::from_hex(hex_data)
-    }
-
-    /// Extend the current nibbles with another nibbles.
-    pub fn extend(&mut self, b: &Nibbles) {
-        self.hex_data.extend_from_slice(b);
-    }
-
-    /// Truncate the current nibbles to the given length.
-    pub fn truncate(&mut self, len: usize) {
-        self.hex_data.truncate(len)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use proptest::prelude::*;
-
-    #[test]
-    fn hashed_regression() {
-        let nibbles = hex::decode("05010406040a040203030f010805020b050c04070003070e0909070f010b0a0805020301070c0a0902040b0f000f0006040a04050f020b090701000a0a040b").unwrap();
-        let nibbles = Nibbles::from(nibbles);
-        let path = nibbles.encode_path_leaf(true);
-        let expected =
-            hex::decode("351464a4233f1852b5c47037e997f1ba852317ca924bf0f064a45f2b9710aa4b")
-                .unwrap();
-        assert_eq!(path, expected);
-    }
-
-    #[test]
-    fn pack_nibbles() {
-        for (input, expected) in [
-            (vec![], vec![]),
-            (vec![0xa], vec![0xa0]),
-            (vec![0xa, 0xb], vec![0xab]),
-            (vec![0xa, 0xb, 0x2], vec![0xab, 0x20]),
-            (vec![0xa, 0xb, 0x2, 0x0], vec![0xab, 0x20]),
-            (vec![0xa, 0xb, 0x2, 0x7], vec![0xab, 0x27]),
-        ] {
-            let nibbles = Nibbles::from(input);
-            let encoded = nibbles.pack();
-            assert_eq!(encoded, expected);
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn pack_unpack_roundtrip(input in any::<Vec<u8>>()) {
-            let nibbles = Nibbles::unpack(&input);
-            let packed = nibbles.pack();
-            prop_assert_eq!(packed, input);
-        }
-
-        #[test]
-        fn encode_path_first_byte(input in any::<Vec<u8>>()) {
-            prop_assume!(!input.is_empty());
-            let input = Nibbles::unpack(input);
-            let input_is_odd = input.len() % 2 == 1;
-
-            let compact_leaf = input.encode_path_leaf(true);
-            let leaf_flag = compact_leaf[0];
-            // Check flag
-            assert_ne!(leaf_flag & 0x20, 0);
-            assert_eq!(input_is_odd, (leaf_flag & 0x10) != 0);
-            if input_is_odd {
-                assert_eq!(leaf_flag & 0x0f, *input.first().unwrap());
-            }
-
-
-            let compact_extension = input.encode_path_leaf(false);
-            let extension_flag = compact_extension[0];
-            // Check first byte
-            assert_eq!(extension_flag & 0x20, 0);
-            assert_eq!(input_is_odd, (extension_flag & 0x10) != 0);
-            if input_is_odd {
-                assert_eq!(extension_flag & 0x0f, *input.first().unwrap());
-            }
-        }
+    fn from_compact(buf: &[u8], _len: usize) -> (Self, &[u8])
+    where
+        Self: Sized,
+    {
+        let len = buf[32] as usize;
+        let inner = Vec::from(&buf[..len]).into();
+        (Self(StoredNibbles { inner }), &buf[33..])
     }
 }

--- a/crates/primitives/src/trie/nibbles.rs
+++ b/crates/primitives/src/trie/nibbles.rs
@@ -29,20 +29,20 @@ impl From<Vec<u8>> for StoredNibblesSubKey {
 
 impl Compact for StoredNibblesSubKey {
     fn to_compact(self, buf: &mut impl bytes::BufMut) -> usize {
-        assert!(self.inner.len() <= 32);
-        let mut padded = vec![0; 32];
+        assert!(self.inner.len() <= 64);
+        let mut padded = vec![0; 64];
         padded[..self.inner.len()].copy_from_slice(&self.inner[..]);
         buf.put_slice(&padded);
         buf.put_u8(self.inner.len() as u8);
-        33 // 32 + 1
+        65 // 64 + 1
     }
 
     fn from_compact(buf: &[u8], _len: usize) -> (Self, &[u8])
     where
         Self: Sized,
     {
-        let len = buf[32] as usize;
+        let len = buf[64] as usize;
         let inner = Vec::from(&buf[..len]).into();
-        (Self(StoredNibbles { inner }), &buf[33..])
+        (Self(StoredNibbles { inner }), &buf[65..])
     }
 }

--- a/crates/storage/db/src/tables/codecs/compact.rs
+++ b/crates/storage/db/src/tables/codecs/compact.rs
@@ -4,7 +4,10 @@ use crate::{
     Error,
 };
 use reth_codecs::{main_codec, Compact};
-use reth_primitives::*;
+use reth_primitives::{
+    trie::{StoredNibbles, StoredNibblesSubKey},
+    *,
+};
 
 /// Implements compression for Compact type.
 macro_rules! impl_compression_for_compact {
@@ -40,6 +43,8 @@ impl_compression_for_compact!(
     Receipt,
     TxType,
     StorageEntry,
+    StoredNibbles,
+    StoredNibblesSubKey,
     StorageTrieEntry,
     StoredBlockBodyIndices,
     StoredBlockOmmers,

--- a/crates/storage/db/src/tables/models/mod.rs
+++ b/crates/storage/db/src/tables/models/mod.rs
@@ -104,7 +104,7 @@ impl Encode for StoredNibbles {
 
     // Delegate to the Compact implementation
     fn encode(self) -> Self::Encoded {
-        let mut buf = Vec::new();
+        let mut buf = Vec::with_capacity(self.inner.len());
         self.to_compact(&mut buf);
         buf
     }

--- a/crates/storage/db/src/tables/models/mod.rs
+++ b/crates/storage/db/src/tables/models/mod.rs
@@ -122,7 +122,7 @@ impl Encode for StoredNibblesSubKey {
 
     // Delegate to the Compact implementation
     fn encode(self) -> Self::Encoded {
-        let mut buf = Vec::new();
+        let mut buf = Vec::with_capacity(65);
         self.to_compact(&mut buf);
         buf
     }

--- a/crates/storage/db/src/tables/models/mod.rs
+++ b/crates/storage/db/src/tables/models/mod.rs
@@ -1,4 +1,13 @@
 //! Implements data structures specific to the database
+use crate::{
+    table::{Decode, Encode},
+    Error,
+};
+use reth_codecs::Compact;
+use reth_primitives::{
+    trie::{StoredNibbles, StoredNibblesSubKey},
+    Address, H256,
+};
 
 pub mod accounts;
 pub mod blocks;
@@ -9,12 +18,6 @@ pub mod storage_sharded_key;
 pub use accounts::*;
 pub use blocks::*;
 pub use sharded_key::ShardedKey;
-
-use crate::{
-    table::{Decode, Encode},
-    Error,
-};
-use reth_primitives::{Address, H256};
 
 /// Macro that implements [`Encode`] and [`Decode`] for uint types.
 macro_rules! impl_uints {
@@ -93,5 +96,41 @@ impl Encode for String {
 impl Decode for String {
     fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, Error> {
         String::from_utf8(value.as_ref().to_vec()).map_err(|_| Error::DecodeError)
+    }
+}
+
+impl Encode for StoredNibbles {
+    type Encoded = Vec<u8>;
+
+    // Delegate to the Compact implementation
+    fn encode(self) -> Self::Encoded {
+        let mut buf = Vec::new();
+        self.to_compact(&mut buf);
+        buf
+    }
+}
+
+impl Decode for StoredNibbles {
+    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, Error> {
+        let buf = value.as_ref();
+        Ok(Self::from_compact(buf, buf.len()).0)
+    }
+}
+
+impl Encode for StoredNibblesSubKey {
+    type Encoded = Vec<u8>;
+
+    // Delegate to the Compact implementation
+    fn encode(self) -> Self::Encoded {
+        let mut buf = Vec::new();
+        self.to_compact(&mut buf);
+        buf
+    }
+}
+
+impl Decode for StoredNibblesSubKey {
+    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, Error> {
+        let buf = value.as_ref();
+        Ok(Self::from_compact(buf, buf.len()).0)
     }
 }

--- a/crates/trie/Cargo.toml
+++ b/crates/trie/Cargo.toml
@@ -22,6 +22,7 @@ tracing = "0.1"
 
 # misc 
 hex = "0.4"
+derive_more = "0.99"
 
 [dev-dependencies]
 # reth

--- a/crates/trie/src/hash_builder/mod.rs
+++ b/crates/trie/src/hash_builder/mod.rs
@@ -1,8 +1,11 @@
-use crate::nodes::{rlp_hash, BranchNode, ExtensionNode, LeafNode};
+use crate::{
+    nodes::{rlp_hash, BranchNode, ExtensionNode, LeafNode},
+    Nibbles,
+};
 use reth_primitives::{
     keccak256,
     proofs::EMPTY_ROOT,
-    trie::{BranchNodeCompact, Nibbles, TrieMask},
+    trie::{BranchNodeCompact, TrieMask},
     H256,
 };
 use std::fmt::Debug;
@@ -358,7 +361,7 @@ impl HashBuilder {
 mod tests {
     use super::*;
     use proptest::prelude::*;
-    use reth_primitives::{hex_literal::hex, proofs::KeccakHasher, trie::Nibbles, H256, U256};
+    use reth_primitives::{hex_literal::hex, proofs::KeccakHasher, H256, U256};
     use std::collections::{BTreeMap, HashMap};
     use tokio::sync::mpsc::unbounded_channel;
     use tokio_stream::{wrappers::UnboundedReceiverStream, StreamExt};

--- a/crates/trie/src/lib.rs
+++ b/crates/trie/src/lib.rs
@@ -14,3 +14,9 @@ pub mod nodes;
 
 /// The implementation of hash builder.
 pub mod hash_builder;
+
+/// The Ethereum account as represented in the trie.
+pub mod account;
+
+mod nibbles;
+pub use nibbles::Nibbles;

--- a/crates/trie/src/nibbles.rs
+++ b/crates/trie/src/nibbles.rs
@@ -1,0 +1,290 @@
+use derive_more::{Deref, DerefMut, From, Index};
+use reth_rlp::RlpEncodableWrapper;
+
+/// Structure representing a sequence of nibbles.
+///
+/// A nibble is a 4-bit value, and this structure is used to store
+/// the nibble sequence representing the keys in a Merkle Patricia Trie (MPT).
+/// Using nibbles simplifies trie operations and enables consistent key
+/// representation in the MPT.
+///
+/// The `hex_data` field is a `Vec<u8>` that stores the nibbles, with each
+/// `u8` value containing a single nibble. This means that each byte in
+/// `hex_data` has its upper 4 bits set to zero and the lower 4 bits
+/// representing the nibble value.
+#[derive(
+    Default,
+    Clone,
+    Eq,
+    PartialEq,
+    RlpEncodableWrapper,
+    PartialOrd,
+    Ord,
+    Index,
+    From,
+    Deref,
+    DerefMut,
+)]
+pub struct Nibbles {
+    /// The inner representation of the nibble sequence.
+    pub hex_data: Vec<u8>,
+}
+
+impl From<&[u8]> for Nibbles {
+    fn from(slice: &[u8]) -> Self {
+        Nibbles::from_hex(slice.to_vec())
+    }
+}
+
+impl std::fmt::Debug for Nibbles {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Nibbles").field("hex_data", &hex::encode(&self.hex_data)).finish()
+    }
+}
+
+impl Nibbles {
+    /// Creates a new [Nibbles] instance from bytes.
+    pub fn from_hex(hex: Vec<u8>) -> Self {
+        Nibbles { hex_data: hex }
+    }
+
+    /// Take a byte array (slice or vector) as input and convert it into a [Nibbles] struct
+    /// containing the nibbles (half-bytes or 4 bits) that make up the input byte data.
+    pub fn unpack<T: AsRef<[u8]>>(data: T) -> Self {
+        Nibbles { hex_data: data.as_ref().iter().flat_map(|item| [item / 16, item % 16]).collect() }
+    }
+
+    /// Packs the nibbles stored in the struct into a byte vector.
+    ///
+    /// This method combines each pair of consecutive nibbles into a single byte,
+    /// effectively reducing the size of the data by a factor of two.
+    /// If the number of nibbles is odd, the last nibble is shifted left by 4 bits and
+    /// added to the packed byte vector.
+    pub fn pack(&self) -> Vec<u8> {
+        let length = (self.len() + 1) / 2;
+        if length == 0 {
+            Vec::default()
+        } else {
+            self.iter()
+                .enumerate()
+                .filter_map(|(index, nibble)| {
+                    if index % 2 == 0 {
+                        let next_nibble = self.get(index + 1).unwrap_or(&0);
+                        Some((*nibble << 4) + *next_nibble)
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        }
+    }
+
+    /// Encodes a given path leaf as a compact array of bytes, where each byte represents two
+    /// "nibbles" (half-bytes or 4 bits) of the original hex data, along with additional information
+    /// about the leaf itself.
+    ///
+    /// The method takes the following input:
+    /// `is_leaf`: A boolean value indicating whether the current node is a leaf node or not.
+    ///
+    /// The first byte of the encoded vector is set based on the `is_leaf` flag and the parity of
+    /// the hex data length (even or odd number of nibbles).
+    ///  - If the node is an extension with even length, the header byte is `0x00`.
+    ///  - If the node is an extension with odd length, the header byte is `0x10 + <first nibble>`.
+    ///  - If the node is a leaf with even length, the header byte is `0x20`.
+    ///  - If the node is a leaf with odd length, the header byte is `0x30 + <first nibble>`.
+    ///
+    /// If there is an odd number of nibbles, store the first nibble in the lower 4 bits of the
+    /// first byte of encoded.
+    ///
+    /// # Returns
+    ///
+    /// A `Vec<u8>` containing the compact byte representation of the nibble sequence, including the
+    /// header byte.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use reth_primitives::trie::Nibbles;
+    ///
+    /// // Extension node with an even path length:
+    /// let nibbles = Nibbles::from_hex(vec![0x0A, 0x0B, 0x0C, 0x0D]);
+    /// assert_eq!(nibbles.encode_path_leaf(false), vec![0x00, 0xAB, 0xCD]);
+    ///
+    /// // Extension node with an odd path length:
+    /// let nibbles = Nibbles::from_hex(vec![0x0A, 0x0B, 0x0C]);
+    /// assert_eq!(nibbles.encode_path_leaf(false), vec![0x1A, 0xBC]);
+    ///
+    /// // Leaf node with an even path length:
+    /// let nibbles = Nibbles::from_hex(vec![0x0A, 0x0B, 0x0C, 0x0D]);
+    /// assert_eq!(nibbles.encode_path_leaf(true), vec![0x20, 0xAB, 0xCD]);
+    ///
+    /// // Leaf node with an odd path length:
+    /// let nibbles = Nibbles::from_hex(vec![0x0A, 0x0B, 0x0C]);
+    /// assert_eq!(nibbles.encode_path_leaf(true), vec![0x3A, 0xBC]);
+    /// ```
+    pub fn encode_path_leaf(&self, is_leaf: bool) -> Vec<u8> {
+        let mut encoded = vec![0u8; self.len() / 2 + 1];
+        let odd_nibbles = self.len() % 2 != 0;
+
+        // Set the first byte of the encoded vector.
+        encoded[0] = match (is_leaf, odd_nibbles) {
+            (true, true) => 0x30 | self[0],
+            (true, false) => 0x20,
+            (false, true) => 0x10 | self[0],
+            (false, false) => 0x00,
+        };
+
+        let mut nibble_idx = if odd_nibbles { 1 } else { 0 };
+        for byte in encoded.iter_mut().skip(1) {
+            *byte = (self[nibble_idx] << 4) + self[nibble_idx + 1];
+            nibble_idx += 2;
+        }
+
+        encoded
+    }
+
+    /// Increments the nibble sequence by one.
+    pub fn increment(&self) -> Option<Nibbles> {
+        let mut incremented = self.hex_data.clone();
+
+        for nibble in incremented.iter_mut().rev() {
+            assert!(*nibble < 0x10);
+            if *nibble < 0xf {
+                *nibble += 1;
+                return Some(Nibbles::from(incremented))
+            } else {
+                *nibble = 0;
+            }
+        }
+
+        None
+    }
+
+    /// The last element of the hex vector is used to determine whether the nibble sequence
+    /// represents a leaf or an extension node. If the last element is 0x10 (16), then it's a leaf.
+    pub fn is_leaf(&self) -> bool {
+        self.hex_data[self.hex_data.len() - 1] == 16
+    }
+
+    /// Returns `true` if the current nibble sequence starts with the given prefix.
+    pub fn has_prefix(&self, other: &Self) -> bool {
+        self.starts_with(other)
+    }
+
+    /// Returns the nibble at the given index.
+    pub fn at(&self, i: usize) -> usize {
+        self.hex_data[i] as usize
+    }
+
+    /// Returns the last nibble of the current nibble sequence.
+    pub fn last(&self) -> Option<u8> {
+        self.hex_data.last().copied()
+    }
+
+    /// Returns the length of the common prefix between the current nibble sequence and the given.
+    pub fn common_prefix_length(&self, other: &Nibbles) -> usize {
+        let len = std::cmp::min(self.len(), other.len());
+        for i in 0..len {
+            if self[i] != other[i] {
+                return i
+            }
+        }
+        len
+    }
+
+    /// Slice the current nibbles from the given start index to the end.
+    pub fn slice_from(&self, index: usize) -> Nibbles {
+        self.slice(index, self.hex_data.len())
+    }
+
+    /// Slice the current nibbles within the provided index range.
+    pub fn slice(&self, start: usize, end: usize) -> Nibbles {
+        Nibbles::from_hex(self.hex_data[start..end].to_vec())
+    }
+
+    /// Join two nibbles together.
+    pub fn join(&self, b: &Nibbles) -> Nibbles {
+        let mut hex_data = Vec::with_capacity(self.len() + b.len());
+        hex_data.extend_from_slice(self);
+        hex_data.extend_from_slice(b);
+        Nibbles::from_hex(hex_data)
+    }
+
+    /// Extend the current nibbles with another nibbles.
+    pub fn extend(&mut self, b: &Nibbles) {
+        self.hex_data.extend_from_slice(b);
+    }
+
+    /// Truncate the current nibbles to the given length.
+    pub fn truncate(&mut self, len: usize) {
+        self.hex_data.truncate(len)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    #[test]
+    fn hashed_regression() {
+        let nibbles = hex::decode("05010406040a040203030f010805020b050c04070003070e0909070f010b0a0805020301070c0a0902040b0f000f0006040a04050f020b090701000a0a040b").unwrap();
+        let nibbles = Nibbles::from(nibbles);
+        let path = nibbles.encode_path_leaf(true);
+        let expected =
+            hex::decode("351464a4233f1852b5c47037e997f1ba852317ca924bf0f064a45f2b9710aa4b")
+                .unwrap();
+        assert_eq!(path, expected);
+    }
+
+    #[test]
+    fn pack_nibbles() {
+        for (input, expected) in [
+            (vec![], vec![]),
+            (vec![0xa], vec![0xa0]),
+            (vec![0xa, 0xb], vec![0xab]),
+            (vec![0xa, 0xb, 0x2], vec![0xab, 0x20]),
+            (vec![0xa, 0xb, 0x2, 0x0], vec![0xab, 0x20]),
+            (vec![0xa, 0xb, 0x2, 0x7], vec![0xab, 0x27]),
+        ] {
+            let nibbles = Nibbles::from(input);
+            let encoded = nibbles.pack();
+            assert_eq!(encoded, expected);
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn pack_unpack_roundtrip(input in any::<Vec<u8>>()) {
+            let nibbles = Nibbles::unpack(&input);
+            let packed = nibbles.pack();
+            prop_assert_eq!(packed, input);
+        }
+
+        #[test]
+        fn encode_path_first_byte(input in any::<Vec<u8>>()) {
+            prop_assume!(!input.is_empty());
+            let input = Nibbles::unpack(input);
+            let input_is_odd = input.len() % 2 == 1;
+
+            let compact_leaf = input.encode_path_leaf(true);
+            let leaf_flag = compact_leaf[0];
+            // Check flag
+            assert_ne!(leaf_flag & 0x20, 0);
+            assert_eq!(input_is_odd, (leaf_flag & 0x10) != 0);
+            if input_is_odd {
+                assert_eq!(leaf_flag & 0x0f, *input.first().unwrap());
+            }
+
+
+            let compact_extension = input.encode_path_leaf(false);
+            let extension_flag = compact_extension[0];
+            // Check first byte
+            assert_eq!(extension_flag & 0x20, 0);
+            assert_eq!(input_is_odd, (extension_flag & 0x10) != 0);
+            if input_is_odd {
+                assert_eq!(extension_flag & 0x0f, *input.first().unwrap());
+            }
+        }
+    }
+}

--- a/crates/trie/src/nibbles.rs
+++ b/crates/trie/src/nibbles.rs
@@ -104,7 +104,7 @@ impl Nibbles {
     /// # Example
     ///
     /// ```
-    /// # use reth_primitives::trie::Nibbles;
+    /// # use reth_trie::Nibbles;
     ///
     /// // Extension node with an even path length:
     /// let nibbles = Nibbles::from_hex(vec![0x0A, 0x0B, 0x0C, 0x0D]);

--- a/crates/trie/src/nibbles.rs
+++ b/crates/trie/src/nibbles.rs
@@ -69,7 +69,7 @@ impl Nibbles {
     pub fn pack(&self) -> Vec<u8> {
         let length = (self.len() + 1) / 2;
         if length == 0 {
-            Vec::default()
+            Vec::new()
         } else {
             self.iter()
                 .enumerate()

--- a/crates/trie/src/nodes/extension.rs
+++ b/crates/trie/src/nodes/extension.rs
@@ -1,5 +1,6 @@
 use super::rlp_node;
-use reth_primitives::{bytes::BytesMut, trie::Nibbles};
+use crate::Nibbles;
+use reth_primitives::bytes::BytesMut;
 use reth_rlp::{BufMut, Encodable};
 
 /// An intermediate node that exists solely to compress the trie's paths. It contains a path segment

--- a/crates/trie/src/nodes/leaf.rs
+++ b/crates/trie/src/nodes/leaf.rs
@@ -1,5 +1,6 @@
 use super::rlp_node;
-use reth_primitives::{bytes::BytesMut, trie::Nibbles};
+use crate::Nibbles;
+use reth_primitives::bytes::BytesMut;
 use reth_rlp::{BufMut, Encodable};
 
 /// A leaf node represents the endpoint or terminal node in the trie. In other words, a leaf node is

--- a/crates/trie/src/prefix_set.rs
+++ b/crates/trie/src/prefix_set.rs
@@ -1,6 +1,5 @@
+use crate::Nibbles;
 use std::collections::BTreeSet;
-
-use reth_primitives::trie::Nibbles;
 
 /// A container for efficiently storing and checking for the presence of key prefixes.
 ///


### PR DESCRIPTION
Introduces `StoredNibbles` and `StoredNibblesSubKey`, structs which will be used as key and subkey in trie tables.
Moves `Nibbles` implementation to the `trie` crate.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6631d52</samp>

### Summary
🗜️🔀🧩

<!--
1.  🗜️ - This emoji represents compression, which is what the new types `StoredNibbles` and `StoredNibblesSubKey` do to the trie keys and subkeys. It also suggests the refactoring to improve the trie storage and encoding logic.
2.  🔀 - This emoji represents switching, which is what the change does by moving the `Nibbles` type from one crate to another and updating the imports accordingly. It also suggests the refactoring to separate the trie logic from the primitives crate and to avoid circular dependencies.
3.  🧩 - This emoji represents pieces, which is what the nibbles are. It also suggests the refactoring to improve the trie logic and usability by using the `derive_more` crate and the `Deref` and `DerefMut` traits.
-->
Refactor trie storage and encoding logic using new types `StoredNibbles` and `StoredNibblesSubKey` that implement `Encode` and `Decode` traits. Move the `Nibbles` type from the `reth_primitives` crate to the `reth_trie` crate to avoid circular dependencies and improve trie operations. Update imports and re-exports accordingly. Add `derive_more` crate dependency for convenience.

> _We're breaking the chains of the primitives_
> _We're forging the nibbles of the trie_
> _We're compressing the keys with new methods_
> _We're refactoring the code to the sky_

### Walkthrough
*  Refactor the trie storage and encoding logic by introducing new types `StoredNibbles` and `StoredNibblesSubKey` to represent the nibbles of the trie keys and subkeys in a compact and efficient way ([link](https://github.com/paradigmxyz/reth/pull/2182/files?diff=unified&w=0#diff-2b20291b814762d5362752c8e8f661c3a5f84f6ad9bf7f3be5bbdaaa9c38e95aL4-R4), [link](https://github.com/paradigmxyz/reth/pull/2182/files?diff=unified&w=0#diff-71a31b8cbc74276c0eff6604c5bf17d52e13a6b35ff8c6af9c771a587a10f1b4L7-R10), [link](https://github.com/paradigmxyz/reth/pull/2182/files?diff=unified&w=0#diff-71a31b8cbc74276c0eff6604c5bf17d52e13a6b35ff8c6af9c771a587a10f1b4R46-R47), [link](https://github.com/paradigmxyz/reth/pull/2182/files?diff=unified&w=0#diff-b485e429770783ad8654467279496e8e13c0d307213b4a5682c80ecb47287ef9R2-R10), [link](https://github.com/paradigmxyz/reth/pull/2182/files?diff=unified&w=0#diff-b485e429770783ad8654467279496e8e13c0d307213b4a5682c80ecb47287ef9R101-R136)).

