### PR TITLE
chore: accept AsRef in calculate_transaction_root

### DIFF
--- a/crates/primitives/src/proofs.rs
+++ b/crates/primitives/src/proofs.rs
@@ -36,12 +36,14 @@ impl Hasher for KeccakHasher {
 /// Calculate a transaction root.
 ///
 /// `(rlp(index), encoded(tx))` pairs.
-pub fn calculate_transaction_root<'a>(
-    transactions: impl IntoIterator<Item = &'a TransactionSigned>,
-) -> H256 {
+pub fn calculate_transaction_root<I, T>(transactions: I) -> H256
+where
+    I: IntoIterator<Item = T>,
+    T: AsRef<TransactionSigned>,
+{
     ordered_trie_root::<KeccakHasher, _>(transactions.into_iter().map(|tx| {
         let mut tx_rlp = Vec::new();
-        tx.encode_inner(&mut tx_rlp, false);
+        tx.as_ref().encode_inner(&mut tx_rlp, false);
         tx_rlp
     }))
 }

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -540,6 +540,12 @@ pub struct TransactionSigned {
     pub transaction: Transaction,
 }
 
+impl AsRef<Self> for TransactionSigned {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
 // === impl TransactionSigned ===
 
 impl TransactionSigned {


### PR DESCRIPTION
change for convenience, so `calculate_transaction_root` can be called with `TransactionSignedEcRecovered` as well