### PR TITLE
feat: add ReceiptWithBloomRef type

### DIFF
--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -64,7 +64,7 @@ pub use net::{
     SEPOLIA_BOOTNODES,
 };
 pub use peer::{PeerId, WithPeerId};
-pub use receipt::{Receipt, ReceiptWithBloom};
+pub use receipt::{Receipt, ReceiptWithBloom, ReceiptWithBloomRef};
 pub use revm_primitives::JumpMap;
 pub use serde_helper::JsonU256;
 pub use storage::{StorageEntry, StorageTrieEntry};


### PR DESCRIPTION
`ReceiptWithBloom` is required in order to compute the receipt root.

to make this more convenient with PostState, this adds a reference type `ReceiptWithBloomRef` that takes the receipt as reference