### PR TITLE
fix(engine): pipeline run conditions

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -8,7 +8,7 @@ use reth_interfaces::{
     Error,
 };
 use reth_miner::PayloadStore;
-use reth_primitives::{BlockHash, BlockNumber, Header, SealedBlock, H256};
+use reth_primitives::{BlockNumber, Header, SealedBlock, H256};
 use reth_rpc_types::engine::{
     EngineRpcError, ExecutionPayload, ExecutionPayloadEnvelope, ForkchoiceUpdated,
     PayloadAttributes, PayloadId, PayloadStatus, PayloadStatusEnum,
@@ -917,7 +917,6 @@ mod tests {
                 VecDeque::from([
                     Ok(ExecOutput { done: true, stage_progress: 0 }),
                     Ok(ExecOutput { done: true, stage_progress: 0 }),
-                    Ok(ExecOutput { done: true, stage_progress: 0 }),
                 ]),
                 Vec::default(),
             );
@@ -928,27 +927,25 @@ mod tests {
 
             let mut engine_rx = spawn_consensus_engine(consensus_engine);
 
-            let invalid_forkchoice_state = ForkchoiceState {
-                head_block_hash: H256::random(),
+            let next_head = random_block(2, Some(block1.hash), None, Some(0));
+            let next_forkchoice_state = ForkchoiceState {
+                head_block_hash: next_head.hash,
                 finalized_block_hash: block1.hash,
                 ..Default::default()
             };
 
-            let rx = env.send_forkchoice_updated(invalid_forkchoice_state);
-            let expected_result = ForkchoiceUpdated::from_status(PayloadStatusEnum::Syncing);
-            assert_matches!(rx.await, Ok(Ok(result)) => assert_eq!(result, expected_result));
+            let invalid_rx = env.send_forkchoice_updated(next_forkchoice_state);
 
-            let rx = env.send_forkchoice_updated(invalid_forkchoice_state);
-            let expected_result = ForkchoiceUpdated::from_status(PayloadStatusEnum::Syncing);
-            assert_matches!(rx.await, Ok(Ok(result)) => assert_eq!(result, expected_result));
+            // Insert next head immediately after sending forkchoice update
+            insert_blocks(env.db.as_ref(), [&next_head].into_iter());
 
-            let rx_valid = env.send_forkchoice_updated(ForkchoiceState {
-                head_block_hash: H256::random(),
-                finalized_block_hash: block1.hash,
-                ..Default::default()
-            });
             let expected_result = ForkchoiceUpdated::from_status(PayloadStatusEnum::Syncing);
-            assert_matches!(rx_valid.await, Ok(Ok(result)) => assert_eq!(result, expected_result));
+            assert_matches!(invalid_rx.await, Ok(Ok(result)) => assert_eq!(result, expected_result));
+
+            let valid_rx = env.send_forkchoice_updated(next_forkchoice_state);
+            let expected_result = ForkchoiceUpdated::from_status(PayloadStatusEnum::Valid)
+                .with_latest_valid_hash(next_head.hash);
+            assert_matches!(valid_rx.await, Ok(Ok(result)) => assert_eq!(result, expected_result));
 
             assert_matches!(engine_rx.try_recv(), Err(TryRecvError::Empty));
         }
@@ -972,7 +969,7 @@ mod tests {
             let block1 = random_block(1, Some(genesis.hash), None, Some(0));
             insert_blocks(env.db.as_ref(), [&genesis, &block1].into_iter());
 
-            let _engine = spawn_consensus_engine(consensus_engine);
+            let engine = spawn_consensus_engine(consensus_engine);
 
             let rx = env.send_forkchoice_updated(ForkchoiceState {
                 head_block_hash: H256::random(),
@@ -981,7 +978,7 @@ mod tests {
             });
             let expected_result = ForkchoiceUpdated::from_status(PayloadStatusEnum::Syncing);
             assert_matches!(rx.await, Ok(Ok(result)) => assert_eq!(result, expected_result));
-            drop(_engine);
+            drop(engine);
         }
 
         #[tokio::test]
@@ -1007,10 +1004,10 @@ mod tests {
 
             insert_blocks(env.db.as_ref(), [&genesis, &block1].into_iter());
 
-            let _engine = spawn_consensus_engine(consensus_engine);
+            let engine = spawn_consensus_engine(consensus_engine);
 
             let rx = env.send_forkchoice_updated(ForkchoiceState {
-                head_block_hash: H256::random(),
+                head_block_hash: block1.hash,
                 finalized_block_hash: block1.hash,
                 ..Default::default()
             });
@@ -1027,7 +1024,7 @@ mod tests {
             })
             .with_latest_valid_hash(H256::zero());
             assert_matches!(rx.await, Ok(Ok(result)) => assert_eq!(result, expected_result));
-            drop(_engine);
+            drop(engine);
         }
     }
 


### PR DESCRIPTION
Remove the pipeline run requirement from new payload handler as it should never be triggered there.

Require the pipeline run if the head hash doesn't exist in the database after tree restoration.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4cf7766</samp>

### Summary
🔧🚀🧪

<!--
1.  🔧 - This emoji represents refactoring or fixing something, as it suggests using a wrench or a tool to improve the code quality or functionality.
2.  🚀 - This emoji represents improving performance or efficiency, as it suggests launching something faster or farther. Reducing database queries can help speed up the forkchoice logic and avoid unnecessary overhead.
3.  🧪 - This emoji represents testing or experimenting, as it suggests using a test tube or a lab to verify the code behavior or explore new possibilities. Updating the test cases and covering more realistic scenarios can help ensure the correctness and robustness of the forkchoice logic.
-->
Refactored and improved the forkchoice logic in the `beacon` module of the `consensus` crate. Reduced database queries and added more test cases for `crates/consensus/beacon/src/engine/mod.rs`.

> _Forkchoice refactored_
> _`beacon_engine` module shines_
> _Autumn tests are fixed_

### Walkthrough
*  Refactor `restore_tree_if_possible` function to simplify logic and reduce database queries ([link](https://github.com/paradigmxyz/reth/pull/2193/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544L320-L330), [link](https://github.com/paradigmxyz/reth/pull/2193/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544L378-R386), [link](https://github.com/paradigmxyz/reth/pull/2193/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544L512-R515), [link](https://github.com/paradigmxyz/reth/pull/2193/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544L919))
*  Remove unused `BlockHash` type from imports in `crates/consensus/beacon/src/engine/mod.rs` ([link](https://github.com/paradigmxyz/reth/pull/2193/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544L11-R11))
*  Update test case for `forkchoice_updated` method to simulate race condition and assert expected results ([link](https://github.com/paradigmxyz/reth/pull/2193/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544L930-R949), [link](https://github.com/paradigmxyz/reth/pull/2193/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544L974-R972), [link](https://github.com/paradigmxyz/reth/pull/2193/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544L983-R981))
*  Change test case for `forkchoice_updated` method to use same block hash for head and finalized block ([link](https://github.com/paradigmxyz/reth/pull/2193/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544L1009-R1010), [link](https://github.com/paradigmxyz/reth/pull/2193/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544L1029-R1027))

