### PR TITLE
fix: add initial goerli forks

### DIFF
--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -56,6 +56,13 @@ pub static GOERLI: Lazy<ChainSpec> = Lazy::new(|| ChainSpec {
     ))),
     hardforks: BTreeMap::from([
         (Hardfork::Frontier, ForkCondition::Block(0)),
+        (Hardfork::Homestead, ForkCondition::Block(0)),
+        (Hardfork::Dao, ForkCondition::Block(0)),
+        (Hardfork::Tangerine, ForkCondition::Block(0)),
+        (Hardfork::SpuriousDragon, ForkCondition::Block(0)),
+        (Hardfork::Byzantium, ForkCondition::Block(0)),
+        (Hardfork::Constantinople, ForkCondition::Block(0)),
+        (Hardfork::Petersburg, ForkCondition::Block(0)),
         (Hardfork::Istanbul, ForkCondition::Block(1561651)),
         (Hardfork::Berlin, ForkCondition::Block(4460644)),
         (Hardfork::London, ForkCondition::Block(5062605)),


### PR DESCRIPTION
Previously we didn't include genesis goerli forks:
https://github.com/ethereum/go-ethereum/blob/4a9fa31450d3cdcea84735b68cd5a0a8450473f8/params/config.go#L182-L190

This adds those forks, solving the execution error from #2178 