### PR TITLE
fix(download): body consecutive range

### DIFF
--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -295,15 +295,16 @@ where
         }
 
         // Check if the provided range is the next expected range.
-        let is_next_range = range.start >= self.download_range.end;
-        if is_next_range {
+        let is_next_consecutive_range = range.start == self.download_range.end;
+        if is_next_consecutive_range {
             // New range received.
             tracing::trace!(target: "downloaders::bodies", ?range, "New download range set");
             self.download_range = range;
             return Ok(())
         }
 
-        // The block range reset after unwind.
+        // The block range is reset. This can happen either after unwind or after the bodies were
+        // written by external services (e.g. BlockchainTree).
         tracing::trace!(target: "downloaders::bodies", ?range, prev_range = ?self.download_range, "Download range reset");
         self.clear();
         self.download_range = range;


### PR DESCRIPTION
Closes #2195

## Problem

Previously the downloader reset its data only during unwind. However, BlockchainTree also introduces irregular body inserts which makes the downloader state inconsistent. 

## Solution

The downloader should preserve its state only upon receiving the next **consecutive** download range. In any other case, the downloader should reset.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2208e23</samp>

### Summary
🐛📝🚀

<!--
1.  🐛 for fixing a bug
2.  📝 for improving the documentation
3.  🚀 for enhancing the performance or reliability of the bodies downloader
-->
Fixed a bug and improved documentation in the `bodies` module of the `net` crate. The bug could cause inconsistent block syncing in the `reth` client.

> _There once was a bug in `bodies downloader`_
> _That made the block chain look like a clown's collar_
> _To fix this mess_
> _They added a reset_
> _And documented the logic much sounder_

### Walkthrough
* Fix the condition for accepting consecutive block ranges in the bodies downloader ([link](https://github.com/paradigmxyz/reth/pull/2198/files?diff=unified&w=0#diff-5bfda9652b22310557eeed1ed88ec0dffd12806986ec3f411cc6f61fc869d1f8L298-R299))
* Update the comment for the block range reset to include external services as a possible cause ([link](https://github.com/paradigmxyz/reth/pull/2198/files?diff=unified&w=0#diff-5bfda9652b22310557eeed1ed88ec0dffd12806986ec3f411cc6f61fc869d1f8L306-R307))

