### PR TITLE
feat(engine): basic beacon engine metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4515,10 +4515,12 @@ version = "0.1.0"
 dependencies = [
  "assert_matches",
  "futures",
+ "metrics",
  "reth-consensus-common",
  "reth-db",
  "reth-executor",
  "reth-interfaces",
+ "reth-metrics-derive",
  "reth-miner",
  "reth-primitives",
  "reth-provider",

--- a/crates/consensus/beacon/Cargo.toml
+++ b/crates/consensus/beacon/Cargo.toml
@@ -16,6 +16,7 @@ reth-db = { path = "../../storage/db" }
 reth-rpc-types = { path = "../../rpc/rpc-types" }
 reth-tasks = { path = "../../tasks" }
 reth-miner = { path = "../../miner" }
+reth-metrics-derive = { path = "../../metrics/metrics-derive" }
 
 # async
 tokio = { version = "1.21.2", features = ["sync"] }
@@ -25,6 +26,7 @@ futures = "0.3"
 # misc
 tracing = "0.1"
 thiserror = "1.0"
+metrics = "0.20.1"
 
 [dev-dependencies]
 # reth

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1,4 +1,5 @@
 use futures::{Future, FutureExt, StreamExt};
+use metrics::Counter;
 use reth_db::{database::Database, tables, transaction::DbTx};
 use reth_interfaces::{
     blockchain_tree::{BlockStatus, BlockchainTreeEngine},
@@ -7,6 +8,7 @@ use reth_interfaces::{
     sync::SyncStateUpdater,
     Error,
 };
+use reth_metrics_derive::Metrics;
 use reth_miner::PayloadStore;
 use reth_primitives::{BlockNumber, Header, SealedBlock, H256};
 use reth_rpc_types::engine::{
@@ -32,6 +34,20 @@ pub use message::{BeaconEngineMessage, BeaconEngineSender};
 
 mod pipeline_state;
 pub use pipeline_state::PipelineState;
+
+/// Beacon consensus engine metrics.
+#[derive(Metrics)]
+#[metrics(scope = "consensus.beacon.engine")]
+struct Metrics {
+    /// The number of times the pipeline was run.
+    pipeline_runs: Counter,
+    /// The total count of forkchoice updated messages received.
+    forkchoice_updated_messages: Counter,
+    /// The total count of new payload messages received.
+    new_payload_messages: Counter,
+    /// The total count of get payload messages received.
+    get_payload_messages: Counter,
+}
 
 /// The beacon consensus engine is the driver that switches between historical and live sync.
 ///
@@ -80,6 +96,8 @@ where
     max_block: Option<BlockNumber>,
     /// The payload store.
     payload_store: P,
+    /// Consensus engine metrics.
+    metrics: Metrics,
 }
 
 impl<DB, TS, U, BT, P> BeaconConsensusEngine<DB, TS, U, BT, P>
@@ -113,6 +131,7 @@ where
             next_action: BeaconEngineAction::None,
             max_block,
             payload_store,
+            metrics: Metrics::default(),
         }
     }
 
@@ -342,6 +361,7 @@ where
     ) -> PipelineState<DB, U> {
         let next_action = std::mem::take(&mut self.next_action);
         if let BeaconEngineAction::RunPipeline(target) = next_action {
+            self.metrics.pipeline_runs.increment(1);
             let tip = match target {
                 PipelineTarget::Head => forkchoice_state.head_block_hash,
                 PipelineTarget::Safe => forkchoice_state.safe_block_hash,
@@ -433,6 +453,7 @@ where
             while let Poll::Ready(Some(msg)) = this.message_rx.poll_next_unpin(cx) {
                 match msg {
                     BeaconEngineMessage::ForkchoiceUpdated { state, payload_attrs, tx } => {
+                        this.metrics.forkchoice_updated_messages.increment(1);
                         let response = match this.on_forkchoice_updated(state, payload_attrs) {
                             Ok(response) => response,
                             Err(error) => {
@@ -454,6 +475,7 @@ where
                         }
                     }
                     BeaconEngineMessage::NewPayload { payload, tx } => {
+                        this.metrics.new_payload_messages.increment(1);
                         let response = match this.on_new_payload(payload) {
                             Ok(response) => response,
                             Err(error) => {
@@ -464,6 +486,7 @@ where
                         let _ = tx.send(Ok(response));
                     }
                     BeaconEngineMessage::GetPayload { payload_id, tx } => {
+                        this.metrics.get_payload_messages.increment(1);
                         match this.on_get_payload(payload_id) {
                             Ok(response) => {
                                 // good response, send it back

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -37,7 +37,7 @@ pub use pipeline_state::PipelineState;
 
 /// Beacon consensus engine metrics.
 #[derive(Metrics)]
-#[metrics(scope = "consensus.beacon.engine")]
+#[metrics(scope = "consensus.engine.beacon")]
 struct Metrics {
     /// The number of times the pipeline was run.
     pipeline_runs: Counter,


### PR DESCRIPTION
Adds basic metrics to beacon consensus engine.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7f041ac</samp>

### Summary
📊🚀🧭

<!--
1.  📊 - This emoji represents metrics, data, and charts, which are relevant to the introduction of metrics support and the definition of counters for engine events.
2.  🚀 - This emoji represents speed, performance, and optimization, which are relevant to the use of the reth-metrics-derive crate to derive efficient metrics code and the update of counters for pipeline runs and message types.
3.  🧭 - This emoji represents navigation, direction, and guidance, which are relevant to the use of metrics to monitor and improve the consensus engine's behavior and performance.
-->
This pull request adds metrics support to the beacon consensus engine, which is part of the reth crate. It uses the `reth-metrics-derive` and `metrics` crates to define and update counters for engine events. It modifies the `Cargo.toml` and `engine/mod.rs` files in the `crates/consensus/beacon` directory.

> _Sing, O Muse, of the valiant code warriors who strove_
> _To enhance the beacon of consensus with metrics of skill_
> _Adding crates of reth and metrics, as gifts from above_
> _To count and track the engine's deeds, both good and ill_

### Walkthrough
*  Add metrics support for the beacon consensus engine ([link](https://github.com/paradigmxyz/reth/pull/2200/files?diff=unified&w=0#diff-356926fe389763ac2a24a7d432f5a0628ddb8ffea100792e5cba4bdfc0195d08R19), [link](https://github.com/paradigmxyz/reth/pull/2200/files?diff=unified&w=0#diff-356926fe389763ac2a24a7d432f5a0628ddb8ffea100792e5cba4bdfc0195d08R29), [link](https://github.com/paradigmxyz/reth/pull/2200/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544R2), [link](https://github.com/paradigmxyz/reth/pull/2200/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544R11), [link](https://github.com/paradigmxyz/reth/pull/2200/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544R38-R51), [link](https://github.com/paradigmxyz/reth/pull/2200/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544R99-R100), [link](https://github.com/paradigmxyz/reth/pull/2200/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544R134), [link](https://github.com/paradigmxyz/reth/pull/2200/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544R364), [link](https://github.com/paradigmxyz/reth/pull/2200/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544R456), [link](https://github.com/paradigmxyz/reth/pull/2200/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544R478), [link](https://github.com/paradigmxyz/reth/pull/2200/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544R489))
  * Import `Counter` and `Metrics` derive macro from `metrics` and `reth-metrics-derive` crates ([link](https://github.com/paradigmxyz/reth/pull/2200/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544R2), [link](https://github.com/paradigmxyz/reth/pull/2200/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544R11))
  * Define `Metrics` struct with four `Counter` fields for `pipeline_runs`, `forkchoice_updated_messages`, `new_payload_messages`, and `get_payload_messages` ([link](https://github.com/paradigmxyz/reth/pull/2200/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544R38-R51))
  * Add `metrics` field to `Engine` struct and initialize it with default `Metrics` values ([link](https://github.com/paradigmxyz/reth/pull/2200/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544R99-R100), [link](https://github.com/paradigmxyz/reth/pull/2200/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544R134))
  * Increment corresponding counters in `metrics` field whenever the engine runs the pipeline, or receives a message related to fork choice or payload ([link](https://github.com/paradigmxyz/reth/pull/2200/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544R364), [link](https://github.com/paradigmxyz/reth/pull/2200/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544R456), [link](https://github.com/paradigmxyz/reth/pull/2200/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544R478), [link](https://github.com/paradigmxyz/reth/pull/2200/files?diff=unified&w=0#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544R489))

