### PR TITLE
chore: use cost in error

### DIFF
--- a/crates/primitives/src/transaction/error.rs
+++ b/crates/primitives/src/transaction/error.rs
@@ -7,8 +7,8 @@ use crate::U256;
 pub enum InvalidTransactionError {
     #[error("Transaction eip1559 priority fee is more then max fee.")]
     PriorityFeeMoreThenMaxFee,
-    #[error("Account does not have enough funds ({available_funds:?}) to cover transaction max fee: {max_fee:?}.")]
-    InsufficientFunds { max_fee: u128, available_funds: U256 },
+    #[error("Account does not have enough funds ({available_funds:?}) to cover transaction max fee: {cost:?}.")]
+    InsufficientFunds { cost: U256, available_funds: U256 },
     #[error("Transaction nonce is not consistent.")]
     NonceNotConsistent,
     #[error("Old legacy transaction before Spurious Dragon should not have chain_id.")]

--- a/crates/primitives/src/transaction/error.rs
+++ b/crates/primitives/src/transaction/error.rs
@@ -7,7 +7,7 @@ use crate::U256;
 pub enum InvalidTransactionError {
     #[error("Transaction eip1559 priority fee is more then max fee.")]
     PriorityFeeMoreThenMaxFee,
-    #[error("Account does not have enough funds ({available_funds:?}) to cover transaction max fee: {cost:?}.")]
+    #[error("Account does not have enough funds ({available_funds:?}) to cover transaction cost: {cost:?}.")]
     InsufficientFunds { cost: U256, available_funds: U256 },
     #[error("Transaction nonce is not consistent.")]
     NonceNotConsistent,

--- a/crates/transaction-pool/src/validate.rs
+++ b/crates/transaction-pool/src/validate.rs
@@ -253,11 +253,11 @@ where
 
         // Checks for max cost
         if transaction.cost() > account.balance {
-            let max_fee = transaction.max_fee_per_gas().unwrap_or_default();
+            let cost = transaction.cost();
             return TransactionValidationOutcome::Invalid(
                 transaction,
                 InvalidTransactionError::InsufficientFunds {
-                    max_fee,
+                    cost,
                     available_funds: account.balance,
                 }
                 .into(),


### PR DESCRIPTION
the InsufficientFunds check uses `cost`, so the error also should report this instead of the fee