### PR TITLE
chore(db): clarify upsert

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -205,8 +205,9 @@ impl<'tx, T: Table> DbCursorRW<'tx, T> for Cursor<'tx, RW, T> {
     /// Database operation that will update an existing row if a specified value already
     /// exists in a table, and insert a new row if the specified value doesn't already exist
     ///
-    /// For a DUPSORT table, if the key already exists, the data value will be added to the given
-    /// key. Even if the subkeys are the same.
+    /// For a DUPSORT table, `upsert` will not actually update-or-insert. If the key already exists, it will append
+    /// the value to the subkey, even if the subkeys are the same. So if you want to properly upsert, you'll need to
+    /// `seek_exact` & `delete_current` if the key+subkey was found, before calling `upsert`.
     fn upsert(&mut self, key: T::Key, value: T::Value) -> Result<(), Error> {
         // Default `WriteFlags` is UPSERT
         self.inner

--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -205,9 +205,10 @@ impl<'tx, T: Table> DbCursorRW<'tx, T> for Cursor<'tx, RW, T> {
     /// Database operation that will update an existing row if a specified value already
     /// exists in a table, and insert a new row if the specified value doesn't already exist
     ///
-    /// For a DUPSORT table, `upsert` will not actually update-or-insert. If the key already exists, it will append
-    /// the value to the subkey, even if the subkeys are the same. So if you want to properly upsert, you'll need to
-    /// `seek_exact` & `delete_current` if the key+subkey was found, before calling `upsert`.
+    /// For a DUPSORT table, `upsert` will not actually update-or-insert. If the key already exists,
+    /// it will append the value to the subkey, even if the subkeys are the same. So if you want
+    /// to properly upsert, you'll need to `seek_exact` & `delete_current` if the key+subkey was
+    /// found, before calling `upsert`.
     fn upsert(&mut self, key: T::Key, value: T::Value) -> Result<(), Error> {
         // Default `WriteFlags` is UPSERT
         self.inner

--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -204,6 +204,9 @@ impl<'tx, K: TransactionKind, T: DupSort> DbDupCursorRO<'tx, T> for Cursor<'tx, 
 impl<'tx, T: Table> DbCursorRW<'tx, T> for Cursor<'tx, RW, T> {
     /// Database operation that will update an existing row if a specified value already
     /// exists in a table, and insert a new row if the specified value doesn't already exist
+    ///
+    /// For a DUPSORT table, if the key already exists, the data value will be added to the given
+    /// key. Even if the subkeys are the same.
     fn upsert(&mut self, key: T::Key, value: T::Value) -> Result<(), Error> {
         // Default `WriteFlags` is UPSERT
         self.inner


### PR DESCRIPTION
Amend `upsert` docs and add an upsert test

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 33078e8</samp>

### Summary
:memo::wrench::test_tube:

<!--
1.  :memo: - This emoji represents adding or updating documentation or comments, which is what the first change does.
2. :wrench: - This emoji represents fixing or improving something, which is what the second change does by enhancing the error handling and testing of the `upsert` method.
3. :test_tube: - This emoji represents adding or updating tests, which is also what the second change does by introducing a new test case.
-->
This pull request enhances the `upsert` functionality for MDBX tables in the `storage` crate. It improves error handling, documentation, and testing for the `upsert` methods in `mod.rs` and `cursor.rs`.

> _To upsert a value or key_
> _In a DUPSORT table, you see_
> _You must handle the case_
> _When there's not enough space_
> _And return a constant `MDBX_ERROR_FULL`_

### Walkthrough
* Add a comment to explain the `upsert` behavior for DUPSORT tables ([link](https://github.com/paradigmxyz/reth/pull/2216/files?diff=unified&w=0#diff-6d644e704df691f1b45aa1610ddc4394fa112b9bfd17abd3add3e1b424fc8901R207-R209))
* Test the `upsert` method for both plain and DUPSORT tables using random keys and values in `crates/storage/db/src/implementation/mdbx/mod.rs` ([link](https://github.com/paradigmxyz/reth/pull/2216/files?diff=unified&w=0#diff-047121c09675075f1097b8f707a9a67b02fd89665dd3e962a861488f78a031c7R560-R594))

