### PR TITLE
chore: move cfg block env init to PayloadAttributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4495,7 +4495,6 @@ version = "0.1.0"
 dependencies = [
  "futures-core",
  "futures-util",
- "reth-consensus-common",
  "reth-payload-builder",
  "reth-primitives",
  "reth-provider",
@@ -4945,8 +4944,10 @@ dependencies = [
  "futures-core",
  "futures-util",
  "parking_lot 0.12.1",
+ "reth-consensus-common",
  "reth-interfaces",
  "reth-primitives",
+ "reth-revm-primitives",
  "reth-rlp",
  "reth-rpc-types",
  "revm-primitives",

--- a/crates/payload/basic/Cargo.toml
+++ b/crates/payload/basic/Cargo.toml
@@ -10,7 +10,6 @@ description = "A basic payload builder for reth that uses the txpool API to buil
 [dependencies]
 ## reth
 reth-primitives = { path = "../../primitives" }
-reth-consensus-common = { path = "../../consensus/common" }
 reth-revm = { path = "../../revm" }
 reth-transaction-pool = { path = "../../transaction-pool" }
 reth-rlp = { path = "../../rlp" }

--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -13,6 +13,8 @@ reth-primitives = { path = "../../primitives" }
 reth-rpc-types = { path = "../../rpc/rpc-types" }
 reth-rlp = { path = "../../rlp" }
 reth-interfaces = { path = "../../interfaces" }
+reth-consensus-common = { path = "../../consensus/common" }
+reth-revm-primitives = { path = "../../revm/revm-primitives" }
 
 ## ethereum
 revm-primitives = "1"


### PR DESCRIPTION
A `PayloadAttributes` will lead to a new payload job wich requires a configured `revm::Env`,
moving cfg and block env init to `PayloadAttributes` makes it more convenient to configure it