### PR TITLE
fix: remove peers after incoming connection closed

### DIFF
--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -658,7 +658,7 @@ where
                                 this.swarm
                                     .state_mut()
                                     .peers_mut()
-                                    .on_active_inbound_session(peer_id, remote_addr);
+                                    .on_incoming_session_established(peer_id, remote_addr);
                             }
                             this.event_listeners.send(NetworkEvent::SessionEstablished {
                                 peer_id,


### PR DESCRIPTION
Closes #2235

if we discovered a peer via an incoming connections we only know the outgoing port of the remote peer, at which the peer will not be reachable

Fix: remove incoming peer from peerset after disconnect, but keep if it was discovered in the meantime