### PR TITLE
fix: remove inaccurate warning about engine API being unsupported

### DIFF
--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -215,13 +215,7 @@ impl Command {
                 debug!(target: "reth::cli", %tip, "Tip manually set");
                 Some(tip_rx)
             }
-            None => {
-                let warn_msg = "No tip specified. \
-                reth cannot communicate with consensus clients, \
-                so a tip must manually be provided for the online stages with --debug.tip <HASH>.";
-                warn!(target: "reth::cli", warn_msg);
-                None
-            }
+            None => None,
         };
 
         // configure blockchain tree


### PR DESCRIPTION
This warning is emitted if you don't provide a `--debug.tip` option to `reth node`. Since Reth will happily sync from a CL client the warning is confusing and wrong.