### PR TITLE
Revert "chore: enable tx inserts via p2p"

### DIFF
--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -528,15 +528,14 @@ where
                     this.on_good_import(hash);
                 }
                 Err(err) => {
-                    // if we're syncing and the transaction is bad we ignore it, otherwise we
-                    // penalize the peer that sent the bad transaction with the assumption that the
-                    // peer should have known that this transaction is bad. (e.g. consensus rules)
-                    if err.is_bad_transaction() && !this.network.is_syncing() {
+                    if err.is_bad_transaction() {
                         trace!(target: "net::tx", ?err, "Bad transaction import");
-                        this.on_bad_import(*err.hash());
-                        continue
+                        // TODO disabled until properly tested
+                        // this.on_bad_import(*err.hash());
+                        this.on_good_import(*err.hash());
+                    } else {
+                        this.on_good_import(*err.hash());
                     }
-                    this.on_good_import(*err.hash());
                 }
             }
         }

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -113,6 +113,9 @@ pub enum InvalidPoolTransactionError {
     /// respect the max_init_code_size.
     #[error("Transaction's size {0} exceeds max_init_code_size {1}.")]
     ExceedsMaxInitCodeSize(usize, usize),
+    /// Thrown if the transaction contains an invalid signature
+    #[error("Invalid sender")]
+    AccountNotFound,
     /// Thrown if the input data of a transaction is greater
     /// than some meaningful limit a user might use. This is not a consensus error
     /// making the transaction invalid, rather a DOS protection.


### PR DESCRIPTION
Reverts paradigmxyz/reth#2214

We are incorrectly reporting that we're synced, and we're penalizing good peers. We'll bring this back once we've investigated and fixed the syncing check.

We should add a eth_syncing RPC test in Hive, which should help.