### PR TITLE
Revert "Revert "chore: enable tx inserts via p2p" (#2252)"

### DIFF
--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -528,14 +528,15 @@ where
                     this.on_good_import(hash);
                 }
                 Err(err) => {
-                    if err.is_bad_transaction() {
+                    // if we're syncing and the transaction is bad we ignore it, otherwise we
+                    // penalize the peer that sent the bad transaction with the assumption that the
+                    // peer should have known that this transaction is bad. (e.g. consensus rules)
+                    if err.is_bad_transaction() && !this.network.is_syncing() {
                         trace!(target: "net::tx", ?err, "Bad transaction import");
-                        // TODO disabled until properly tested
-                        // this.on_bad_import(*err.hash());
-                        this.on_good_import(*err.hash());
-                    } else {
-                        this.on_good_import(*err.hash());
+                        this.on_bad_import(*err.hash());
+                        continue
                     }
+                    this.on_good_import(*err.hash());
                 }
             }
         }

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -113,9 +113,6 @@ pub enum InvalidPoolTransactionError {
     /// respect the max_init_code_size.
     #[error("Transaction's size {0} exceeds max_init_code_size {1}.")]
     ExceedsMaxInitCodeSize(usize, usize),
-    /// Thrown if the transaction contains an invalid signature
-    #[error("Invalid sender")]
-    AccountNotFound,
     /// Thrown if the input data of a transaction is greater
     /// than some meaningful limit a user might use. This is not a consensus error
     /// making the transaction invalid, rather a DOS protection.


### PR DESCRIPTION
This reverts commit c67c944a1fc12c02ca63d2f5b150566410ac41a5.

reverts the revert because the bug that caused the regression is fixed via:

https://github.com/paradigmxyz/reth/pull/2256