### PR TITLE
feat(cli): disable persistent logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4574,6 +4574,7 @@ dependencies = [
  "modular-bitfield",
  "page_size",
  "parity-scale-codec",
+ "parking_lot 0.12.1",
  "paste",
  "postcard",
  "pprof",

--- a/bin/reth/src/cli.rs
+++ b/bin/reth/src/cli.rs
@@ -104,8 +104,8 @@ struct Cli {
 #[command(next_help_heading = "Logging")]
 pub struct Logs {
     /// The flag to enable persistent logs.
-    #[arg(long = "log.enable-persistent", global = true, conflicts_with = "journald")]
-    enable_persistent: bool,
+    #[arg(long = "log.persistent", global = true, conflicts_with = "journald")]
+    persistent: bool,
 
     /// The path to put log files in.
     #[arg(
@@ -138,7 +138,7 @@ impl Logs {
 
         if self.journald {
             Some((reth_tracing::journald(directive).expect("Could not connect to journald"), None))
-        } else if self.enable_persistent {
+        } else if self.persistent {
             let (layer, guard) = reth_tracing::file(directive, &self.log_directory, "reth.log");
             Some((layer, Some(guard)))
         } else {

--- a/bin/reth/src/cli.rs
+++ b/bin/reth/src/cli.rs
@@ -103,6 +103,10 @@ struct Cli {
 #[derive(Debug, Args)]
 #[command(next_help_heading = "Logging")]
 pub struct Logs {
+    /// The flag to enable persistent logs.
+    #[arg(long = "log.enable-persistent", global = true, conflicts_with = "journald")]
+    enable_persistent: bool,
+
     /// The path to put log files in.
     #[arg(
         long = "log.directory",
@@ -120,10 +124,6 @@ pub struct Logs {
     /// The filter to use for logs written to the log file.
     #[arg(long = "log.filter", value_name = "FILTER", global = true, default_value = "debug")]
     filter: String,
-
-    /// The flag to disable persistent logs.
-    #[arg(long = "log.disable-persistent", global = true, conflicts_with = "log_directory")]
-    disable_persistent: bool,
 }
 
 impl Logs {
@@ -138,7 +138,7 @@ impl Logs {
 
         if self.journald {
             Some((reth_tracing::journald(directive).expect("Could not connect to journald"), None))
-        } else if !self.disable_persistent {
+        } else if self.enable_persistent {
             let (layer, guard) = reth_tracing::file(directive, &self.log_directory, "reth.log");
             Some((layer, Some(guard)))
         } else {


### PR DESCRIPTION
Currently, our logs are really verbose and the log file grows very fast. My machine ran out of disk space during full sync due to the log file growing to 777gb. 

Change default behavior to disabled persistent logs. Add an option to enable persistent logs. 

This is a temporary solution to a log file size problem. Ideally, we want to have a size limit at which the older logs would be flushed.


