### PR TITLE
refactor: add beacon engine handle

### DIFF
--- a/crates/consensus/beacon/src/engine/error.rs
+++ b/crates/consensus/beacon/src/engine/error.rs
@@ -30,6 +30,9 @@ pub enum BeaconEngineError {
     /// Common error. Wrapper around [reth_interfaces::Error].
     #[error(transparent)]
     Common(#[from] reth_interfaces::Error),
+    /// Thrown when the engine task stopped
+    #[error("beacon consensus engine task stopped")]
+    EngineUnavailable,
 }
 
 // box the pipeline error as it is a large enum.


### PR DESCRIPTION
Add a helper type that encapsulates sending `BeaconEngineMessage` to the engine.

ideally only the `BeaconEngine`  would create the channel, but for that's not quite possible because there are circular relationships, for auto mining consensus for example: requires the sender and the pipeline requires the auto mining consensus