### PR TITLE
fix: poll_tick does not register waker if ready

### DIFF
--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -1408,12 +1408,14 @@ impl Discv4Service {
 
             // trigger self lookup
             if self.config.enable_lookup && self.lookup_interval.poll_tick(cx).is_ready() {
+                let _ = self.lookup_interval.poll_tick(cx);
                 let target = self.lookup_rotator.next(&self.local_node_record.id);
                 self.lookup_with(target, None);
             }
 
             // re-ping some peers
             if self.ping_interval.poll_tick(cx).is_ready() {
+                let _ = self.ping_interval.poll_tick(cx);
                 self.re_ping_oldest();
             }
 

--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -715,6 +715,8 @@ impl PeersManager {
             }
 
             if self.refill_slots_interval.poll_tick(cx).is_ready() {
+                // this ensures the manager will be polled periodically, see [Interval::poll_tick]
+                let _ = self.refill_slots_interval.poll_tick(cx);
                 self.fill_outbound_slots();
             }
 

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -596,6 +596,7 @@ impl Future for ActiveSession {
 
             if !progress {
                 if this.internal_request_timeout_interval.poll_tick(cx).is_ready() {
+                    let _ = this.internal_request_timeout_interval.poll_tick(cx);
                     // check for timed out requests
                     if this.check_timed_out_requests(Instant::now()) {
                         let _ = this.to_session.clone().try_send(

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -262,6 +262,7 @@ where
             this.pending_block.is_none() &&
             !deadline_reached
         {
+            let _ = this.interval.poll_tick(cx);
             trace!("spawn new payload build task");
             let (tx, rx) = oneshot::channel();
             let client = this.client.clone();


### PR DESCRIPTION
`Interval::poll_tick` does not register waker if it returns ready

> Polls for the next instant in the interval to be reached.
This method can return the following values:
Poll::Pending if the next instant has not yet been reached.
Poll::Ready(instant) if the next instant has been reached.
When this method returns Poll::Pending, the current task is scheduled to receive a wakeup when the instant has elapsed. Note that on multiple calls to poll_tick, only the Waker from the Context passed to the most recent call is scheduled to receive a wakeup.

