### PR TITLE
feat(trie): hashed cursor

### DIFF
--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -34,6 +34,7 @@ parking_lot = { version = "0.12", optional = true }
 reth-db = { path = "../db", features = ["test-utils"] }
 reth-primitives = { path = "../../primitives", features = ["arbitrary", "test-utils"] }
 reth-rlp = { path = "../../rlp" }
+reth-trie = { path = "../../trie", features = ["test-utils"] }
 parking_lot = "0.12"
 
 [features]

--- a/crates/storage/provider/src/post_state.rs
+++ b/crates/storage/provider/src/post_state.rs
@@ -11,7 +11,9 @@ use reth_primitives::{
     BlockNumber, Bloom, Bytecode, Log, Receipt, StorageEntry, H256, U256,
 };
 use reth_trie::{
-    hashed_cursor::{HashedCursorFactory, HashedPostState, HashedPostStateFactory, HashedStorage},
+    hashed_cursor::{
+        HashedCursorFactory, HashedPostState, HashedPostStateCursorFactory, HashedStorage,
+    },
     StateRoot, StateRootError,
 };
 use std::collections::BTreeMap;
@@ -207,7 +209,7 @@ impl PostState {
     pub fn state_root_slow<'a, TX: DbTx<'a>>(&self, tx: &TX) -> Result<H256, StateRootError> {
         let hashed_post_state = self.hash_state_slow();
         let (account_prefixset, storage_prefixset) = hashed_post_state.construct_prefix_sets();
-        let hashed_cursor_factory = HashedPostStateFactory::new(&tx, &hashed_post_state);
+        let hashed_cursor_factory = HashedPostStateCursorFactory::new(&tx, &hashed_post_state);
         StateRoot::new(tx)
             .with_hashed_cursor_factory(&hashed_cursor_factory)
             .with_changed_account_prefixes(account_prefixset)

--- a/crates/storage/provider/src/post_state.rs
+++ b/crates/storage/provider/src/post_state.rs
@@ -206,10 +206,16 @@ impl PostState {
     }
 
     /// Calculate the state root for this [PostState].
-    pub fn state_root_slow<'a, TX: DbTx<'a>>(&self, tx: &TX) -> Result<H256, StateRootError> {
+    pub fn state_root_slow<'a, 'tx, TX: DbTx<'tx>>(
+        &self,
+        tx: &'a TX,
+    ) -> Result<H256, StateRootError>
+    where
+        'a: 'tx,
+    {
         let hashed_post_state = self.hash_state_slow();
         let (account_prefixset, storage_prefixset) = hashed_post_state.construct_prefix_sets();
-        let hashed_cursor_factory = HashedPostStateCursorFactory::new(&tx, &hashed_post_state);
+        let hashed_cursor_factory = HashedPostStateCursorFactory::new(tx, &hashed_post_state);
         StateRoot::new(tx)
             .with_hashed_cursor_factory(&hashed_cursor_factory)
             .with_changed_account_prefixes(account_prefixset)

--- a/crates/storage/provider/src/post_state.rs
+++ b/crates/storage/provider/src/post_state.rs
@@ -207,10 +207,7 @@ impl PostState {
     pub fn state_root_slow<'a, 'tx, TX: DbTx<'tx>>(
         &self,
         tx: &'a TX,
-    ) -> Result<H256, StateRootError>
-    where
-        'a: 'tx,
-    {
+    ) -> Result<H256, StateRootError> {
         let hashed_post_state = self.hash_state_slow();
         let (account_prefixset, storage_prefixset) = hashed_post_state.construct_prefix_sets();
         let hashed_cursor_factory = HashedPostStateCursorFactory::new(tx, &hashed_post_state);
@@ -530,6 +527,7 @@ mod tests {
         mdbx::{test_utils, Env, EnvKind, WriteMap},
         transaction::DbTx,
     };
+    use reth_primitives::proofs::EMPTY_ROOT;
     use std::sync::Arc;
 
     // Ensure that the transition id is not incremented if postate is extended by another empty
@@ -1126,5 +1124,15 @@ mod tests {
             )]),
             "The latest state of the storage is incorrect in the merged state"
         );
+    }
+
+    #[test]
+    fn empty_post_state_state_root() {
+        let db: Arc<Env<WriteMap>> = test_utils::create_test_db(EnvKind::RW);
+        let tx = db.tx().expect("Could not get database tx");
+
+        let post_state = PostState::new();
+        let state_root = post_state.state_root_slow(&tx).expect("Could not get state root");
+        assert_eq!(state_root, EMPTY_ROOT);
     }
 }

--- a/crates/storage/provider/src/post_state.rs
+++ b/crates/storage/provider/src/post_state.rs
@@ -11,9 +11,7 @@ use reth_primitives::{
     BlockNumber, Bloom, Bytecode, Log, Receipt, StorageEntry, H256, U256,
 };
 use reth_trie::{
-    hashed_cursor::{
-        HashedCursorFactory, HashedPostState, HashedPostStateCursorFactory, HashedStorage,
-    },
+    hashed_cursor::{HashedPostState, HashedPostStateCursorFactory, HashedStorage},
     StateRoot, StateRootError,
 };
 use std::collections::BTreeMap;
@@ -187,14 +185,14 @@ impl PostState {
     pub fn hash_state_slow(&self) -> HashedPostState {
         let mut accounts = BTreeMap::default();
         for (address, account) in self.accounts() {
-            accounts.insert(keccak256(address), account.clone());
+            accounts.insert(keccak256(address), *account);
         }
 
         let mut storages = BTreeMap::default();
         for (address, storage) in self.storage() {
             let mut hashed_storage = BTreeMap::default();
             for (slot, value) in &storage.storage {
-                hashed_storage.insert(keccak256(H256(slot.to_be_bytes())), value.clone());
+                hashed_storage.insert(keccak256(H256(slot.to_be_bytes())), *value);
             }
             storages.insert(
                 keccak256(address),

--- a/crates/trie/src/hashed_cursor/default.rs
+++ b/crates/trie/src/hashed_cursor/default.rs
@@ -36,6 +36,10 @@ impl<'tx, C> HashedStorageCursor for C
 where
     C: DbCursorRO<'tx, tables::HashedStorage> + DbDupCursorRO<'tx, tables::HashedStorage>,
 {
+    fn is_empty(&mut self, key: H256) -> Result<bool, reth_db::Error> {
+        Ok(self.seek_exact(key)?.is_none())
+    }
+
     fn seek(&mut self, key: H256, subkey: H256) -> Result<Option<StorageEntry>, reth_db::Error> {
         self.seek_by_key_subkey(key, subkey)
     }

--- a/crates/trie/src/hashed_cursor/default.rs
+++ b/crates/trie/src/hashed_cursor/default.rs
@@ -6,15 +6,15 @@ use reth_db::{
 };
 use reth_primitives::{Account, StorageEntry, H256};
 
-impl<'a, TX: DbTx<'a>> HashedCursorFactory<'a> for TX {
-    type AccountCursor<'tx> = <TX as DbTxGAT<'tx>>::Cursor<tables::HashedAccount> where Self: 'tx;
-    type StorageCursor<'tx> = <TX as DbTxGAT<'tx>>::DupCursor<tables::HashedStorage> where Self: 'tx;
+impl<'a, 'tx, TX: DbTx<'tx>> HashedCursorFactory<'a> for TX {
+    type AccountCursor = <TX as DbTxGAT<'a>>::Cursor<tables::HashedAccount> where Self: 'a;
+    type StorageCursor = <TX as DbTxGAT<'a>>::DupCursor<tables::HashedStorage> where Self: 'a;
 
-    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, reth_db::Error> {
+    fn hashed_account_cursor(&'a self) -> Result<Self::AccountCursor, reth_db::Error> {
         self.cursor_read::<tables::HashedAccount>()
     }
 
-    fn hashed_storage_cursor(&self) -> Result<Self::StorageCursor<'_>, reth_db::Error> {
+    fn hashed_storage_cursor(&'a self) -> Result<Self::StorageCursor, reth_db::Error> {
         self.cursor_dup_read::<tables::HashedStorage>()
     }
 }

--- a/crates/trie/src/hashed_cursor/default.rs
+++ b/crates/trie/src/hashed_cursor/default.rs
@@ -1,0 +1,46 @@
+use super::{HashedAccountCursor, HashedCursorFactory, HashedStorageCursor};
+use reth_db::{
+    cursor::{DbCursorRO, DbDupCursorRO},
+    tables,
+    transaction::{DbTx, DbTxGAT},
+};
+use reth_primitives::{Account, StorageEntry, H256};
+
+impl<'a, TX: DbTx<'a>> HashedCursorFactory<'a> for TX {
+    type AccountCursor<'tx> = <TX as DbTxGAT<'tx>>::Cursor<tables::HashedAccount> where Self: 'tx;
+    type StorageCursor<'tx> = <TX as DbTxGAT<'tx>>::DupCursor<tables::HashedStorage> where Self: 'tx;
+
+    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, reth_db::Error> {
+        self.cursor_read::<tables::HashedAccount>()
+    }
+
+    fn hashed_storage_cursor(&self) -> Result<Self::StorageCursor<'_>, reth_db::Error> {
+        self.cursor_dup_read::<tables::HashedStorage>()
+    }
+}
+
+impl<'tx, C> HashedAccountCursor for C
+where
+    C: DbCursorRO<'tx, tables::HashedAccount>,
+{
+    fn seek(&mut self, key: H256) -> Result<Option<(H256, Account)>, reth_db::Error> {
+        self.seek(key)
+    }
+
+    fn next(&mut self) -> Result<Option<(H256, Account)>, reth_db::Error> {
+        self.next()
+    }
+}
+
+impl<'tx, C> HashedStorageCursor for C
+where
+    C: DbCursorRO<'tx, tables::HashedStorage> + DbDupCursorRO<'tx, tables::HashedStorage>,
+{
+    fn seek(&mut self, key: H256, subkey: H256) -> Result<Option<StorageEntry>, reth_db::Error> {
+        self.seek_by_key_subkey(key, subkey)
+    }
+
+    fn next(&mut self) -> Result<Option<StorageEntry>, reth_db::Error> {
+        self.next_dup_val()
+    }
+}

--- a/crates/trie/src/hashed_cursor/mod.rs
+++ b/crates/trie/src/hashed_cursor/mod.rs
@@ -1,0 +1,44 @@
+use reth_primitives::{Account, StorageEntry, H256};
+
+/// Default implementation of the hashed state cursor traits.
+mod default;
+
+/// Implementation of hashed state cursor traits for the post state.
+mod post_state;
+pub use post_state::*;
+
+/// The factory trait for creating cursors over the hashed state.
+pub trait HashedCursorFactory<'a> {
+    /// The hashed account cursor type.
+    type AccountCursor<'tx>: HashedAccountCursor
+    where
+        Self: 'tx;
+    /// The hashed storage cursor type.
+    type StorageCursor<'tx>: HashedStorageCursor
+    where
+        Self: 'tx;
+
+    /// Returns a cursor for iterating over all hashed accounts in the state.
+    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, reth_db::Error>;
+
+    /// Returns a cursor for iterating over all hashed storage entries in the state.
+    fn hashed_storage_cursor(&self) -> Result<Self::StorageCursor<'_>, reth_db::Error>;
+}
+
+/// The cursor for iterating over hashed accounts.
+pub trait HashedAccountCursor {
+    /// Seek an entry greater or equal to the given key and position the cursor there.
+    fn seek(&mut self, key: H256) -> Result<Option<(H256, Account)>, reth_db::Error>;
+
+    /// Move the cursor to the next entry and return it.
+    fn next(&mut self) -> Result<Option<(H256, Account)>, reth_db::Error>;
+}
+
+/// The cursor for iterating over hashed storage entries.
+pub trait HashedStorageCursor {
+    /// Seek an entry greater or equal to the given key/subkey and position the cursor there.
+    fn seek(&mut self, key: H256, subkey: H256) -> Result<Option<StorageEntry>, reth_db::Error>;
+
+    /// Move the cursor to the next entry and return it.
+    fn next(&mut self) -> Result<Option<StorageEntry>, reth_db::Error>;
+}

--- a/crates/trie/src/hashed_cursor/mod.rs
+++ b/crates/trie/src/hashed_cursor/mod.rs
@@ -36,6 +36,9 @@ pub trait HashedAccountCursor {
 
 /// The cursor for iterating over hashed storage entries.
 pub trait HashedStorageCursor {
+    /// Returns `true` if there are no entries for a given key.
+    fn is_empty(&mut self, key: H256) -> Result<bool, reth_db::Error>;
+
     /// Seek an entry greater or equal to the given key/subkey and position the cursor there.
     fn seek(&mut self, key: H256, subkey: H256) -> Result<Option<StorageEntry>, reth_db::Error>;
 

--- a/crates/trie/src/hashed_cursor/mod.rs
+++ b/crates/trie/src/hashed_cursor/mod.rs
@@ -10,19 +10,19 @@ pub use post_state::*;
 /// The factory trait for creating cursors over the hashed state.
 pub trait HashedCursorFactory<'a> {
     /// The hashed account cursor type.
-    type AccountCursor<'tx>: HashedAccountCursor
+    type AccountCursor: HashedAccountCursor
     where
-        Self: 'tx;
+        Self: 'a;
     /// The hashed storage cursor type.
-    type StorageCursor<'tx>: HashedStorageCursor
+    type StorageCursor: HashedStorageCursor
     where
-        Self: 'tx;
+        Self: 'a;
 
     /// Returns a cursor for iterating over all hashed accounts in the state.
-    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, reth_db::Error>;
+    fn hashed_account_cursor(&'a self) -> Result<Self::AccountCursor, reth_db::Error>;
 
     /// Returns a cursor for iterating over all hashed storage entries in the state.
-    fn hashed_storage_cursor(&self) -> Result<Self::StorageCursor<'_>, reth_db::Error>;
+    fn hashed_storage_cursor(&'a self) -> Result<Self::StorageCursor, reth_db::Error>;
 }
 
 /// The cursor for iterating over hashed accounts.

--- a/crates/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/src/hashed_cursor/post_state.rs
@@ -146,8 +146,7 @@ where
             .post_state
             .accounts
             .iter()
-            .find(|(k, v)| k >= &&key && v.is_some())
-            .map(|(address, info)| (*address, info.unwrap()));
+            .find_map(|(k, v)| v.filter(|_| k >= &key).map(|v| (*k, v)));
         if let Some((address, account)) = post_state_item {
             // It's an exact match, return the account from post state without looking up in the
             // database.

--- a/crates/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/src/hashed_cursor/post_state.rs
@@ -1,0 +1,314 @@
+use crate::{prefix_set::PrefixSet, Nibbles};
+
+use super::{HashedAccountCursor, HashedCursorFactory, HashedStorageCursor};
+use reth_db::{
+    cursor::{DbCursorRO, DbDupCursorRO},
+    tables,
+    transaction::{DbTx, DbTxGAT},
+};
+use reth_primitives::{Account, StorageEntry, H256, U256};
+use std::collections::{BTreeMap, HashMap};
+
+/// The post state account storage with hashed slots.
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
+pub struct HashedStorage {
+    /// Whether the storage was wiped or not.
+    pub wiped: bool,
+    /// Hashed storage slots.
+    pub storage: BTreeMap<H256, U256>,
+}
+
+/// The post state with hashed addresses as keys.
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
+pub struct HashedPostState {
+    /// Map of hashed addresses to account info.
+    pub accounts: BTreeMap<H256, Option<Account>>,
+    /// Map of hashed addresses to hashed storage.
+    pub storages: BTreeMap<H256, HashedStorage>,
+}
+
+impl HashedPostState {
+    /// Construct prefix sets from hashed post state.
+    pub fn construct_prefix_sets(&self) -> (PrefixSet, HashMap<H256, PrefixSet>) {
+        // Initialize prefix sets.
+        let mut account_prefix_set = PrefixSet::default();
+        let mut storage_prefix_set: HashMap<H256, PrefixSet> = HashMap::default();
+
+        for hashed_address in self.accounts.keys() {
+            account_prefix_set.insert(Nibbles::unpack(hashed_address));
+        }
+
+        for (hashed_address, hashed_storage) in self.storages.iter() {
+            account_prefix_set.insert(Nibbles::unpack(hashed_address));
+            for hashed_slot in hashed_storage.storage.keys() {
+                storage_prefix_set
+                    .entry(*hashed_address)
+                    .or_default()
+                    .insert(Nibbles::unpack(hashed_slot));
+            }
+        }
+
+        (account_prefix_set, storage_prefix_set)
+    }
+}
+
+/// The hashed cursor factory for the post state.
+pub struct HashedPostStateFactory<'a, TX> {
+    tx: &'a TX,
+    post_state: &'a HashedPostState,
+}
+
+impl<'a, TX> HashedPostStateFactory<'a, TX> {
+    /// Create a new factory.
+    pub fn new(tx: &'a TX, post_state: &'a HashedPostState) -> Self {
+        Self { tx, post_state }
+    }
+}
+
+impl<'a, TX: DbTx<'a>> HashedCursorFactory<'a> for HashedPostStateFactory<'a, TX> {
+    type AccountCursor<'tx> = HashedPostStateAccountCursor<'a, <TX as DbTxGAT<'tx>>::Cursor<tables::HashedAccount>> where Self: 'tx;
+    type StorageCursor<'tx> = HashedPostStateStorageCursor<'a, <TX as DbTxGAT<'tx>>::DupCursor<tables::HashedStorage>> where Self: 'tx;
+
+    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, reth_db::Error> {
+        let cursor = self.tx.cursor_read::<tables::HashedAccount>()?;
+        Ok(HashedPostStateAccountCursor { post_state: self.post_state, cursor, last_account: None })
+    }
+
+    fn hashed_storage_cursor(&self) -> Result<Self::StorageCursor<'_>, reth_db::Error> {
+        let cursor = self.tx.cursor_dup_read::<tables::HashedStorage>()?;
+        Ok(HashedPostStateStorageCursor {
+            post_state: self.post_state,
+            cursor,
+            account: None,
+            last_slot: None,
+        })
+    }
+}
+
+/// The cursor to iterate over post state hashed accounts and corresponding database entries.
+/// It will always give precedence to the data from the post state.
+#[derive(Debug, Clone)]
+pub struct HashedPostStateAccountCursor<'a, C> {
+    post_state: &'a HashedPostState,
+    cursor: C,
+    last_account: Option<H256>,
+}
+
+impl<'a, 'tx, C> HashedPostStateAccountCursor<'a, C>
+where
+    C: DbCursorRO<'tx, tables::HashedAccount>,
+{
+    fn was_account_cleared(&self, account: &H256) -> bool {
+        matches!(self.post_state.accounts.get(account), Some(None))
+    }
+
+    fn next_account(
+        &self,
+        post_state_item: Option<(H256, Account)>,
+        db_item: Option<(H256, Account)>,
+    ) -> Result<Option<(H256, Account)>, reth_db::Error> {
+        let result = match (post_state_item, db_item) {
+            // If both are not empty, return the smallest of the two
+            (Some((post_state_address, post_state_account)), Some((db_address, db_account))) => {
+                if post_state_address < db_address {
+                    Some((post_state_address, post_state_account))
+                } else {
+                    Some((db_address, db_account))
+                }
+            }
+            // If the database is empty, return the post state entry
+            (Some((post_state_address, post_state_account)), None) => {
+                Some((post_state_address, post_state_account))
+            }
+            // If the post state is empty, return the database entry
+            (None, Some((db_address, db_account))) => Some((db_address, db_account)),
+            // If both are empty, return None
+            (None, None) => None,
+        };
+        Ok(result)
+    }
+}
+
+impl<'a, 'tx, C> HashedAccountCursor for HashedPostStateAccountCursor<'a, C>
+where
+    C: DbCursorRO<'tx, tables::HashedAccount>,
+{
+    fn seek(&mut self, key: H256) -> Result<Option<(H256, Account)>, reth_db::Error> {
+        self.last_account = None;
+
+        // Attempt to find the account in poststate.
+        let post_state_item = self
+            .post_state
+            .accounts
+            .iter()
+            .skip_while(|(k, v)| k < &&key || v.is_none())
+            .next()
+            .map(|(address, info)| (*address, info.unwrap().clone()));
+        if let Some((address, account)) = post_state_item {
+            // It's an exact match, return the account from post state without looking up in the
+            // database.
+            if address == key {
+                self.last_account = Some(address);
+                return Ok(Some((address, account)))
+            }
+        }
+
+        // It's not an exact match, reposition to the first greater or equal account that wasn't
+        // cleared.
+        let mut db_item = self.cursor.seek(key)?;
+        while db_item
+            .as_ref()
+            .map(|(address, _)| self.was_account_cleared(address))
+            .unwrap_or_default()
+        {
+            db_item = self.cursor.next()?;
+        }
+
+        let result = self.next_account(post_state_item, db_item)?;
+        self.last_account = result.as_ref().map(|(address, _)| *address);
+        Ok(result)
+    }
+
+    fn next(&mut self) -> Result<Option<(H256, Account)>, reth_db::Error> {
+        let last_account = match self.last_account.as_ref() {
+            Some(account) => account,
+            None => return Ok(None), // no previous entry was found
+        };
+
+        // If post state was given precedence, move the cursor forward.
+        let mut db_item = self.cursor.current()?;
+        while db_item
+            .as_ref()
+            .map(|(address, _)| address <= last_account || self.was_account_cleared(address))
+            .unwrap_or_default()
+        {
+            db_item = self.cursor.next()?;
+        }
+
+        let post_state_item = self
+            .post_state
+            .accounts
+            .iter()
+            .skip_while(|(k, v)| k <= &last_account || v.is_none())
+            .next()
+            .map(|(address, info)| (*address, info.unwrap().clone()));
+        let result = self.next_account(post_state_item, db_item)?;
+        self.last_account = result.as_ref().map(|(address, _)| *address);
+        Ok(result)
+    }
+}
+
+/// The cursor to iterate over post state hashed storages and corresponding database entries.
+/// It will always give precedence to the data from the post state.
+#[derive(Debug, Clone)]
+pub struct HashedPostStateStorageCursor<'a, C> {
+    post_state: &'a HashedPostState,
+    cursor: C,
+    account: Option<H256>,
+    last_slot: Option<H256>,
+}
+
+impl<'a, C> HashedPostStateStorageCursor<'a, C> {
+    fn was_storage_wiped(&self, account: &H256) -> bool {
+        match self.post_state.storages.get(account) {
+            Some(storage) => storage.wiped,
+            None => false,
+        }
+    }
+
+    fn next_slot(
+        &self,
+        post_state_item: Option<(&H256, &U256)>,
+        db_item: Option<StorageEntry>,
+    ) -> Result<Option<StorageEntry>, reth_db::Error> {
+        let result = match (post_state_item, db_item) {
+            // If both are not empty, return the smallest of the two
+            (Some((post_state_slot, post_state_value)), Some(db_entry)) => {
+                if post_state_slot < &&db_entry.key {
+                    Some(StorageEntry { key: *post_state_slot, value: *post_state_value })
+                } else {
+                    Some(db_entry)
+                }
+            }
+            // If the database is empty, return the post state entry
+            (Some((post_state_slot, post_state_value)), None) => {
+                Some(StorageEntry { key: *post_state_slot, value: *post_state_value })
+            }
+            // If the post state is empty, return the database entry
+            (None, Some(db_entry)) => Some(db_entry),
+            // If both are empty, return None
+            (None, None) => None,
+        };
+        Ok(result)
+    }
+}
+
+impl<'a, 'tx, C> HashedStorageCursor for HashedPostStateStorageCursor<'a, C>
+where
+    C: DbCursorRO<'tx, tables::HashedStorage> + DbDupCursorRO<'tx, tables::HashedStorage>,
+{
+    fn seek(&mut self, key: H256, subkey: H256) -> Result<Option<StorageEntry>, reth_db::Error> {
+        self.last_slot = None;
+        self.account = Some(key);
+
+        // Attempt to find the account's storage in poststate.
+        let post_state_item = self
+            .post_state
+            .storages
+            .get(&key)
+            .map(|storage| storage.storage.iter().skip_while(|(slot, _)| slot <= &&subkey))
+            .and_then(|mut iter| iter.next());
+        if let Some((slot, value)) = post_state_item {
+            // It's an exact match, return the storage slot from post state without looking up in
+            // the database.
+            if slot == &subkey {
+                self.last_slot = Some(*slot);
+                return Ok(Some(StorageEntry { key: *slot, value: *value }))
+            }
+        }
+
+        // It's not an exact match, reposition to the first greater or equal account.
+        let db_item = if self.was_storage_wiped(&key) {
+            None
+        } else {
+            self.cursor.seek_by_key_subkey(key, subkey)?
+        };
+
+        let result = self.next_slot(post_state_item, db_item)?;
+        self.last_slot = result.as_ref().map(|entry| entry.key);
+        Ok(result)
+    }
+
+    fn next(&mut self) -> Result<Option<StorageEntry>, reth_db::Error> {
+        let account = self.account.expect("`seek` must be called first");
+
+        let last_slot = match self.last_slot.as_ref() {
+            Some(account) => account,
+            None => return Ok(None), // no previous entry was found
+        };
+
+        let db_item = if self.was_storage_wiped(&account) {
+            None
+        } else {
+            // If post state was given precedence, move the cursor forward.
+            let mut db_item = self.cursor.seek_by_key_subkey(account, *last_slot)?;
+
+            // If the entry was already returned, move to the next.
+            if db_item.as_ref().map(|entry| &entry.key == last_slot).unwrap_or_default() {
+                db_item = self.cursor.next_dup_val()?;
+            }
+
+            db_item
+        };
+
+        let post_state_item = self
+            .post_state
+            .storages
+            .get(&account)
+            .map(|storage| storage.storage.iter().skip_while(|(slot, _)| slot <= &&last_slot))
+            .and_then(|mut iter| iter.next());
+        let result = self.next_slot(post_state_item, db_item)?;
+        self.last_slot = result.as_ref().map(|entry| entry.key);
+        Ok(result)
+    }
+}

--- a/crates/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/src/hashed_cursor/post_state.rs
@@ -249,6 +249,14 @@ impl<'b, 'tx, C> HashedStorageCursor for HashedPostStateStorageCursor<'b, C>
 where
     C: DbCursorRO<'tx, tables::HashedStorage> + DbDupCursorRO<'tx, tables::HashedStorage>,
 {
+    fn is_empty(&mut self, key: H256) -> Result<bool, reth_db::Error> {
+        let is_empty = match self.post_state.storages.get(&key) {
+            Some(storage) => storage.wiped && storage.storage.is_empty(),
+            None => self.cursor.seek_exact(key)?.is_none(),
+        };
+        Ok(is_empty)
+    }
+
     fn seek(&mut self, key: H256, subkey: H256) -> Result<Option<StorageEntry>, reth_db::Error> {
         self.last_slot = None;
         self.account = Some(key);

--- a/crates/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/src/hashed_cursor/post_state.rs
@@ -53,19 +53,19 @@ impl HashedPostState {
 }
 
 /// The hashed cursor factory for the post state.
-pub struct HashedPostStateFactory<'a, TX> {
+pub struct HashedPostStateCursorFactory<'a, TX> {
     tx: &'a TX,
     post_state: &'a HashedPostState,
 }
 
-impl<'a, TX> HashedPostStateFactory<'a, TX> {
+impl<'a, TX> HashedPostStateCursorFactory<'a, TX> {
     /// Create a new factory.
     pub fn new(tx: &'a TX, post_state: &'a HashedPostState) -> Self {
         Self { tx, post_state }
     }
 }
 
-impl<'a, TX: DbTx<'a>> HashedCursorFactory<'a> for HashedPostStateFactory<'a, TX> {
+impl<'a, TX: DbTx<'a>> HashedCursorFactory<'a> for HashedPostStateCursorFactory<'a, TX> {
     type AccountCursor<'tx> = HashedPostStateAccountCursor<'a, <TX as DbTxGAT<'tx>>::Cursor<tables::HashedAccount>> where Self: 'tx;
     type StorageCursor<'tx> = HashedPostStateStorageCursor<'a, <TX as DbTxGAT<'tx>>::DupCursor<tables::HashedStorage>> where Self: 'tx;
 

--- a/crates/trie/src/lib.rs
+++ b/crates/trie/src/lib.rs
@@ -28,6 +28,9 @@ pub mod prefix_set;
 /// The cursor implementations for navigating account and storage tries.
 pub mod trie_cursor;
 
+/// The cursor implementations for navigating hashed state.
+pub mod hashed_cursor;
+
 /// The trie walker for iterating over the trie nodes.
 pub mod walker;
 

--- a/crates/trie/src/trie.rs
+++ b/crates/trie/src/trie.rs
@@ -1,6 +1,7 @@
 use crate::{
     account::EthAccount,
     hash_builder::HashBuilder,
+    hashed_cursor::{HashedAccountCursor, HashedCursorFactory, HashedStorageCursor},
     nibbles::Nibbles,
     prefix_set::{PrefixSet, PrefixSetLoader},
     progress::{IntermediateStateRootState, StateRootProgress},
@@ -19,9 +20,11 @@ use reth_rlp::Encodable;
 use std::{collections::HashMap, ops::RangeInclusive};
 
 /// StateRoot is used to compute the root node of a state trie.
-pub struct StateRoot<'a, TX> {
+pub struct StateRoot<'a, TX, H> {
     /// A reference to the database transaction.
     pub tx: &'a TX,
+    /// The factory for hashed cursors.
+    pub hashed_cursor_factory: &'a H,
     /// A set of account prefixes that have changed.
     pub changed_account_prefixes: PrefixSet,
     /// A map containing storage changes with the hashed address as key and a set of storage key
@@ -33,18 +36,7 @@ pub struct StateRoot<'a, TX> {
     threshold: u64,
 }
 
-impl<'a, TX> StateRoot<'a, TX> {
-    /// Create a new [StateRoot] instance.
-    pub fn new(tx: &'a TX) -> Self {
-        Self {
-            tx,
-            changed_account_prefixes: PrefixSet::default(),
-            changed_storage_prefixes: HashMap::default(),
-            previous_state: None,
-            threshold: 100_000,
-        }
-    }
-
+impl<'a, TX, H> StateRoot<'a, TX, H> {
     /// Set the changed account prefixes.
     pub fn with_changed_account_prefixes(mut self, prefixes: PrefixSet) -> Self {
         self.changed_account_prefixes = prefixes;
@@ -74,9 +66,39 @@ impl<'a, TX> StateRoot<'a, TX> {
         self.previous_state = state;
         self
     }
+
+    /// Set the hashed cursor factory.
+    pub fn with_hashed_cursor_factory<HF>(
+        self,
+        hashed_cursor_factory: &'a HF,
+    ) -> StateRoot<'a, TX, HF> {
+        StateRoot {
+            tx: self.tx,
+            changed_account_prefixes: self.changed_account_prefixes,
+            changed_storage_prefixes: self.changed_storage_prefixes,
+            threshold: self.threshold,
+            previous_state: self.previous_state,
+            hashed_cursor_factory,
+        }
+    }
 }
 
-impl<'a, 'tx, TX: DbTx<'tx>> StateRoot<'a, TX> {
+impl<'a, 'tx, TX> StateRoot<'a, TX, TX>
+where
+    TX: DbTx<'tx> + HashedCursorFactory<'tx>,
+{
+    /// Create a new [StateRoot] instance.
+    pub fn new(tx: &'a TX) -> Self {
+        Self {
+            tx,
+            changed_account_prefixes: PrefixSet::default(),
+            changed_storage_prefixes: HashMap::default(),
+            previous_state: None,
+            threshold: 100_000,
+            hashed_cursor_factory: tx,
+        }
+    }
+
     /// Given a block number range, identifies all the accounts and storage keys that
     /// have changed.
     ///
@@ -136,7 +158,13 @@ impl<'a, 'tx, TX: DbTx<'tx>> StateRoot<'a, TX> {
         tracing::debug!(target: "loader", "incremental state root with progress");
         Self::incremental_root_calculator(tx, range)?.root_with_progress()
     }
+}
 
+impl<'a, 'tx, TX, H> StateRoot<'a, TX, H>
+where
+    TX: DbTx<'tx>,
+    H: HashedCursorFactory<'tx>,
+{
     /// Walks the intermediate nodes of existing state trie (if any) and hashed entries. Feeds the
     /// nodes into the hash builder. Collects the updates in the process.
     ///
@@ -179,7 +207,7 @@ impl<'a, 'tx, TX: DbTx<'tx>> StateRoot<'a, TX> {
         tracing::debug!(target: "loader", "calculating state root");
         let mut trie_updates = TrieUpdates::default();
 
-        let mut hashed_account_cursor = self.tx.cursor_read::<tables::HashedAccount>()?;
+        let mut hashed_account_cursor = self.hashed_cursor_factory.hashed_account_cursor()?;
         let mut trie_cursor =
             AccountTrieCursor::new(self.tx.cursor_read::<tables::AccountsTrie>()?);
 
@@ -248,6 +276,7 @@ impl<'a, 'tx, TX: DbTx<'tx>> StateRoot<'a, TX> {
                 // TODO: We can consider introducing the TrieProgress::Progress/Complete
                 // abstraction inside StorageRoot, but let's give it a try as-is for now.
                 let storage_root_calculator = StorageRoot::new_hashed(self.tx, hashed_address)
+                    .with_hashed_cursor_factory(self.hashed_cursor_factory)
                     .with_changed_prefixes(
                         self.changed_storage_prefixes
                             .get(&hashed_address)
@@ -307,16 +336,21 @@ impl<'a, 'tx, TX: DbTx<'tx>> StateRoot<'a, TX> {
 }
 
 /// StorageRoot is used to compute the root node of an account storage trie.
-pub struct StorageRoot<'a, TX> {
+pub struct StorageRoot<'a, TX, H> {
     /// A reference to the database transaction.
     pub tx: &'a TX,
+    /// The factory for hashed cursors.
+    pub hashed_cursor_factory: &'a H,
     /// The hashed address of an account.
     pub hashed_address: H256,
     /// The set of storage slot prefixes that have changed.
     pub changed_prefixes: PrefixSet,
 }
 
-impl<'a, TX> StorageRoot<'a, TX> {
+impl<'a, 'tx, TX> StorageRoot<'a, TX, TX>
+where
+    TX: DbTx<'tx> + HashedCursorFactory<'tx>,
+{
     /// Creates a new storage root calculator given an raw address.
     pub fn new(tx: &'a TX, address: Address) -> Self {
         Self::new_hashed(tx, keccak256(address))
@@ -324,7 +358,28 @@ impl<'a, TX> StorageRoot<'a, TX> {
 
     /// Creates a new storage root calculator given a hashed address.
     pub fn new_hashed(tx: &'a TX, hashed_address: H256) -> Self {
-        Self { tx, hashed_address, changed_prefixes: PrefixSet::default() }
+        Self {
+            tx,
+            hashed_address,
+            changed_prefixes: PrefixSet::default(),
+            hashed_cursor_factory: tx,
+        }
+    }
+}
+
+impl<'a, TX, H> StorageRoot<'a, TX, H> {
+    /// Creates a new storage root calculator given an raw address.
+    pub fn new_with_factory(tx: &'a TX, hashed_cursor_factory: &'a H, address: Address) -> Self {
+        Self::new_hashed_with_factory(tx, hashed_cursor_factory, keccak256(address))
+    }
+
+    /// Creates a new storage root calculator given a hashed address.
+    pub fn new_hashed_with_factory(
+        tx: &'a TX,
+        hashed_cursor_factory: &'a H,
+        hashed_address: H256,
+    ) -> Self {
+        Self { tx, hashed_address, changed_prefixes: PrefixSet::default(), hashed_cursor_factory }
     }
 
     /// Set the changed prefixes.
@@ -332,9 +387,26 @@ impl<'a, TX> StorageRoot<'a, TX> {
         self.changed_prefixes = prefixes;
         self
     }
+
+    /// Set the hashed cursor factory.
+    pub fn with_hashed_cursor_factory<HF>(
+        self,
+        hashed_cursor_factory: &'a HF,
+    ) -> StorageRoot<'a, TX, HF> {
+        StorageRoot {
+            tx: self.tx,
+            hashed_address: self.hashed_address,
+            changed_prefixes: self.changed_prefixes,
+            hashed_cursor_factory,
+        }
+    }
 }
 
-impl<'a, 'tx, TX: DbTx<'tx>> StorageRoot<'a, TX> {
+impl<'a, 'tx, TX, H> StorageRoot<'a, TX, H>
+where
+    TX: DbTx<'tx>,
+    H: HashedCursorFactory<'tx>,
+{
     /// Walks the hashed storage table entries for a given address and calculates the storage root.
     ///
     /// # Returns
@@ -357,20 +429,21 @@ impl<'a, 'tx, TX: DbTx<'tx>> StorageRoot<'a, TX> {
     fn calculate(&self, retain_updates: bool) -> Result<(H256, TrieUpdates), StorageRootError> {
         tracing::debug!(target: "trie::storage_root", hashed_address = ?self.hashed_address, "calculating storage root");
 
-        let mut hashed_storage_cursor = self.tx.cursor_dup_read::<tables::HashedStorage>()?;
+        let mut hashed_storage_cursor = self.hashed_cursor_factory.hashed_storage_cursor()?;
 
         let mut trie_cursor = StorageTrieCursor::new(
             self.tx.cursor_dup_read::<tables::StoragesTrie>()?,
             self.hashed_address,
         );
 
-        // do not add a branch node on empty storage
-        if hashed_storage_cursor.seek_exact(self.hashed_address)?.is_none() {
-            return Ok((
-                EMPTY_ROOT,
-                TrieUpdates::from([(TrieKey::StorageTrie(self.hashed_address), TrieOp::Delete)]),
-            ))
-        }
+        // TODO: fix this
+        // // do not add a branch node on empty storage
+        // if hashed_storage_cursor.seek_exact(self.hashed_address)?.is_none() {
+        //     return Ok((
+        //         EMPTY_ROOT,
+        //         TrieUpdates::from([(TrieKey::StorageTrie(self.hashed_address), TrieOp::Delete)]),
+        //     ))
+        // }
 
         let mut walker = TrieWalker::new(&mut trie_cursor, self.changed_prefixes.clone())
             .with_updates(retain_updates);
@@ -388,8 +461,7 @@ impl<'a, 'tx, TX: DbTx<'tx>> StorageRoot<'a, TX> {
             };
 
             let next_key = walker.advance()?;
-            let mut storage =
-                hashed_storage_cursor.seek_by_key_subkey(self.hashed_address, seek_key)?;
+            let mut storage = hashed_storage_cursor.seek(self.hashed_address, seek_key)?;
             while let Some(StorageEntry { key: hashed_key, value }) = storage {
                 let storage_key_nibbles = Nibbles::unpack(hashed_key);
                 if let Some(ref key) = next_key {
@@ -399,7 +471,7 @@ impl<'a, 'tx, TX: DbTx<'tx>> StorageRoot<'a, TX> {
                 }
                 hash_builder
                     .add_leaf(storage_key_nibbles, reth_rlp::encode_fixed_size(&value).as_ref());
-                storage = hashed_storage_cursor.next_dup_val()?;
+                storage = hashed_storage_cursor.next()?;
             }
         }
 

--- a/crates/trie/src/trie.rs
+++ b/crates/trie/src/trie.rs
@@ -6,16 +6,12 @@ use crate::{
     prefix_set::{PrefixSet, PrefixSetLoader},
     progress::{IntermediateStateRootState, StateRootProgress},
     trie_cursor::{AccountTrieCursor, StorageTrieCursor},
-    updates::{TrieKey, TrieOp, TrieUpdates},
+    updates::TrieUpdates,
     walker::TrieWalker,
     StateRootError, StorageRootError,
 };
-use reth_db::{
-    cursor::{DbCursorRO, DbDupCursorRO},
-    tables,
-    transaction::DbTx,
-};
-use reth_primitives::{keccak256, proofs::EMPTY_ROOT, Address, BlockNumber, StorageEntry, H256};
+use reth_db::{tables, transaction::DbTx};
+use reth_primitives::{keccak256, Address, BlockNumber, StorageEntry, H256};
 use reth_rlp::Encodable;
 use std::{collections::HashMap, ops::RangeInclusive};
 

--- a/crates/trie/src/trie.rs
+++ b/crates/trie/src/trie.rs
@@ -488,12 +488,13 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{
-        state_root, state_root_prehashed, storage_root, storage_root_prehashed,
+    use crate::{
+        test_utils::{state_root, state_root_prehashed, storage_root, storage_root_prehashed},
+        updates::{TrieKey, TrieOp},
     };
     use proptest::{prelude::ProptestConfig, proptest};
     use reth_db::{
-        cursor::DbCursorRW,
+        cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO},
         mdbx::{test_utils::create_test_rw_db, Env, WriteMap},
         tables,
         transaction::DbTxMut,
@@ -501,7 +502,7 @@ mod tests {
     use reth_primitives::{
         hex_literal::hex,
         keccak256,
-        proofs::KeccakHasher,
+        proofs::{KeccakHasher, EMPTY_ROOT},
         trie::{BranchNodeCompact, TrieMask},
         Account, Address, H256, U256,
     };

--- a/crates/trie/src/trie.rs
+++ b/crates/trie/src/trie.rs
@@ -432,7 +432,7 @@ where
             self.hashed_address,
         );
 
-        // // do not add a branch node on empty storage
+        // short circuit on empty storage
         if hashed_storage_cursor.is_empty(self.hashed_address)? {
             return Ok((
                 EMPTY_ROOT,


### PR DESCRIPTION
This PR introduces abstraction over hashed cursors and implements it for regular db transaction as well as transaction together with `PostState`.

Enables state root calculation for `PostState`.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 834f1fb</samp>

### Summary
📁🧮🌐

<!--
1.  📁 - This emoji represents the addition of new modules and submodules to the `hashed_cursor` module, which is a way of organizing the code into logical units.
2.  🧮 - This emoji represents the hashing and state root calculation functionality that is added to the `PostState` type and the `StateRoot` and `StorageRoot` structs. This is a core part of the Ethereum state transition logic and involves complex arithmetic and cryptography.
3.  🌐 - This emoji represents the abstraction over different sources of hashed state data, such as the database or the post state, using the hashed state cursor traits and the generic `HashedCursorFactory` trait. This is a way of making the code more modular and adaptable to different scenarios.
-->
This pull request adds functionality to calculate state roots and storage roots from the post state, which is a representation of the state after executing a block. It introduces a new `hashed_cursor` module in `reth_trie` that defines traits and implementations for accessing hashed state data from different sources, such as the database or the post state. It also modifies the `trie.rs` file in `reth_trie` to use these traits and a generic cursor factory in the root calculation logic. It also adds some tests and comments out an optimization that needs further work. Finally, it adds hashing and state root calculation functionality to the `PostState` type in `storage/provider`.

> _We're sailing on the `reth_trie` with a hashed state in hand_
> _We need to calculate the roots with a cursor trait so grand_
> _Heave away, me hearties, heave away with me_
> _We'll make the `PostState` work with the `HashedCursorFactory`_

