### PR TITLE
docs: add a few clarifying docs

### DIFF
--- a/crates/storage/provider/src/chain.rs
+++ b/crates/storage/provider/src/chain.rs
@@ -16,7 +16,8 @@ use std::collections::BTreeMap;
 /// Used inside the BlockchainTree.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Chain {
-    /// The state of accounts after execution of the blocks in this chain (tip of the chain).
+    /// The state of all accounts after execution of the _all_ blocks in this chain's range from
+    /// [Chain::first] to [Chain::tip], inclusive.
     ///
     /// This state also contains the individual changes that lead to the current state.
     pub state: PostState,

--- a/crates/storage/provider/src/post_state.rs
+++ b/crates/storage/provider/src/post_state.rs
@@ -217,7 +217,7 @@ impl PostState {
         }
     }
 
-    /// Get the latest state of accounts.
+    /// Get the latest state of all changed accounts.
     pub fn accounts(&self) -> &BTreeMap<Address, Option<Account>> {
         &self.accounts
     }


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d305595</samp>

Updated comments in `chain.rs` and `post_state.rs` to clarify the difference between `Chain` and `PostState` structs and how they represent account state changes.

@rakita for `Chain::Revert` is `old` inclusive? what would be the new valid tip 
* `old.first().hash`
* `old.first().parent_hash`