### PR TITLE
fix(trie): skip storing empty nibbles in storage trie

### DIFF
--- a/crates/trie/src/trie.rs
+++ b/crates/trie/src/trie.rs
@@ -190,18 +190,20 @@ impl<'a, 'tx, TX: DbTx<'tx> + DbTxMut<'tx>> StateRoot<'a, TX> {
                         }
                     }
                     BranchNodeUpdate::Storage(hashed_address, nibbles, node) => {
-                        let key: StoredNibblesSubKey = nibbles.hex_data.into();
-                        if let Some(entry) =
-                            storage_cursor.seek_by_key_subkey(hashed_address, key.clone())?
-                        {
-                            // "seek exact"
-                            if entry.nibbles == key {
-                                storage_cursor.delete_current()?;
+                        if !nibbles.is_empty() {
+                            let key: StoredNibblesSubKey = nibbles.hex_data.into();
+                            if let Some(entry) =
+                                storage_cursor.seek_by_key_subkey(hashed_address, key.clone())?
+                            {
+                                // "seek exact"
+                                if entry.nibbles == key {
+                                    storage_cursor.delete_current()?;
+                                }
                             }
-                        }
 
-                        storage_cursor
-                            .upsert(hashed_address, StorageTrieEntry { nibbles: key, node })?;
+                            storage_cursor
+                                .upsert(hashed_address, StorageTrieEntry { nibbles: key, node })?;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Don't store storage trie entry if nibbles are empty (similar to account trie entry).

Fixes incremental root calculation failures.