### PR TITLE
perf(tree): check block before inserting

### DIFF
--- a/crates/blockchain-tree/src/blockchain_tree/block_indices.rs
+++ b/crates/blockchain-tree/src/blockchain_tree/block_indices.rs
@@ -274,8 +274,9 @@ impl BlockIndices {
     }
 
     /// Used for finalization of block.
+    ///
     /// Return list of chains for removal that depend on finalized canonical chain.
-    pub fn finalize_canonical_blocks(
+    pub(crate) fn finalize_canonical_blocks(
         &mut self,
         finalized_block: BlockNumber,
         num_of_additional_canonical_hashes_to_retain: u64,


### PR DESCRIPTION
this overwrites the default `insert_block` function and adds a range check before inserting (skip expensive recovery if block not in range)

and helper function for range check