### PR TITLE
chore: update code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,9 @@
 bin/                        @onbjerg
 crates/net/                 @mattsse @Rjected
 crates/net/downloaders/     @onbjerg @rkrasiuk
-crates/executor/            @rakita
+crates/blockchain-tree/     @rakita
+crates/revm/src/            @rakita
+crates/revm/                @mattsse
 crates/stages/              @onbjerg @rkrasiuk
 crates/storage/             @rakita @joshieDo
 crates/transaction-pool/    @mattsse


### PR DESCRIPTION
update codeowner after renaming/moving executor crate