### PR TITLE
fix: insert new payloads into the tree if pipeline is syncing

### DIFF
--- a/crates/blockchain-tree/src/blockchain_tree/mod.rs
+++ b/crates/blockchain-tree/src/blockchain_tree/mod.rs
@@ -519,7 +519,8 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
         }
     }
 
-    /// Make a block and its parent part of the canonical chain.
+    /// Make a block and its parent part of the canonical chain and commit the blocks to the
+    /// database.
     ///
     /// # Note
     ///

--- a/crates/interfaces/src/blockchain_tree.rs
+++ b/crates/interfaces/src/blockchain_tree.rs
@@ -70,6 +70,23 @@ pub enum BlockStatus {
     Disconnected,
 }
 
+impl BlockStatus {
+    /// Returns `true` if the block is valid.
+    pub fn is_valid(&self) -> bool {
+        matches!(self, BlockStatus::Valid)
+    }
+
+    /// Returns `true` if the block is accepted.
+    pub fn is_accepted(&self) -> bool {
+        matches!(self, BlockStatus::Accepted)
+    }
+
+    /// Returns `true` if the block is disconnected.
+    pub fn is_disconnected(&self) -> bool {
+        matches!(self, BlockStatus::Disconnected)
+    }
+}
+
 /// Allows read only functionality on the blockchain tree.
 ///
 /// Tree contains all blocks that are not canonical that can potentially be included


### PR DESCRIPTION
currently, we're not inserting any additional payloads if pipeline is syncing.

this leads to problems where the engine has problems to follow the CL and always lags behind.

For example current behavior:
1. FCU missing block (block `n)` -> pipeline starts syncing
2. new payload (candidate for `n+1`)-> pipeline is syncing -> ingore payload
3. pipeline finished syncing to `n`
4. FCU with head `n+1` -> missing in tree because never inserted in 2. -> pipeline starts syncing to `n+1`
5. repeat...


@rakita @rkrasiuk I suspect there's an additional issue in the `on_forkchoice_update` function:
https://github.com/paradigmxyz/reth/blob/0175a82abddd2d54c091f0da19b463da7f921439/crates/consensus/beacon/src/engine/mod.rs#L254-L255

I assume we need to call `tree.finalize_block(head)` if the pipeline is syncing? so the tree is updated on every FCU (so range is updated)

this PR is linked to #2324 which makes `insert_block` more performant if the block is not in range