### PR TITLE
perf(trie): swap trie updates `BTreeMap` for `HashMap`

### DIFF
--- a/crates/primitives/src/trie/nibbles.rs
+++ b/crates/primitives/src/trie/nibbles.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 /// The nibbles are the keys for the AccountsTrie and the subkeys for the StorageTrie.
 #[main_codec]
-#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct StoredNibbles {
     /// The inner nibble bytes
     pub inner: Bytes,
@@ -18,7 +18,7 @@ impl From<Vec<u8>> for StoredNibbles {
 }
 
 /// The representation of nibbles of the merkle trie stored in the database.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord, Deref)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord, Hash, Deref)]
 pub struct StoredNibblesSubKey(StoredNibbles);
 
 impl From<Vec<u8>> for StoredNibblesSubKey {

--- a/crates/stages/src/stages/merkle.rs
+++ b/crates/stages/src/stages/merkle.rs
@@ -195,7 +195,7 @@ impl<DB: Database> Stage<DB> for MerkleStage {
             match progress {
                 StateRootProgress::Progress(state, updates) => {
                     updates.flush(tx.deref_mut())?;
-                    self.save_execution_checkpoint(tx, Some(state.into()))?;
+                    self.save_execution_checkpoint(tx, Some((*state).into()))?;
                     return Ok(ExecOutput { stage_progress: input.stage_progress(), done: false })
                 }
                 StateRootProgress::Complete(root, updates) => {

--- a/crates/trie/src/hash_builder.rs
+++ b/crates/trie/src/hash_builder.rs
@@ -8,7 +8,7 @@ use reth_primitives::{
     trie::{BranchNodeCompact, HashBuilderState, HashBuilderValue, TrieMask},
     H256,
 };
-use std::{collections::BTreeMap, fmt::Debug, sync::mpsc};
+use std::{collections::HashMap, fmt::Debug, sync::mpsc};
 
 /// A type alias for a sender of branch nodes.
 /// Branch nodes are sent by the Hash Builder to be stored in the database.
@@ -49,7 +49,7 @@ pub struct HashBuilder {
 
     stored_in_database: bool,
 
-    updated_branch_nodes: Option<BTreeMap<Nibbles, BranchNodeCompact>>,
+    updated_branch_nodes: Option<HashMap<Nibbles, BranchNodeCompact>>,
 }
 
 impl From<HashBuilderState> for HashBuilder {
@@ -95,12 +95,12 @@ impl HashBuilder {
     /// Call [HashBuilder::split] to get the updates to branch nodes.
     pub fn set_updates(&mut self, retain_updates: bool) {
         if retain_updates {
-            self.updated_branch_nodes = Some(BTreeMap::default());
+            self.updated_branch_nodes = Some(HashMap::default());
         }
     }
 
     /// Splits the [HashBuilder] into a [HashBuilder] and hash builder updates.
-    pub fn split(mut self) -> (Self, BTreeMap<Nibbles, BranchNodeCompact>) {
+    pub fn split(mut self) -> (Self, HashMap<Nibbles, BranchNodeCompact>) {
         let updates = self.updated_branch_nodes.take();
         (self, updates.unwrap_or_default())
     }

--- a/crates/trie/src/nibbles.rs
+++ b/crates/trie/src/nibbles.rs
@@ -20,6 +20,7 @@ use reth_rlp::RlpEncodableWrapper;
     RlpEncodableWrapper,
     PartialOrd,
     Ord,
+    Hash,
     Index,
     From,
     Deref,

--- a/crates/trie/src/progress.rs
+++ b/crates/trie/src/progress.rs
@@ -8,7 +8,7 @@ pub enum StateRootProgress {
     Complete(H256, TrieUpdates),
     /// The intermediate progress of state root computation.
     /// Contains the walker stack, the hash builder and the trie updates.
-    Progress(IntermediateStateRootState, TrieUpdates),
+    Progress(Box<IntermediateStateRootState>, TrieUpdates),
 }
 
 /// The intermediate state of the state root computation.

--- a/crates/trie/src/trie.rs
+++ b/crates/trie/src/trie.rs
@@ -1060,7 +1060,7 @@ mod tests {
                 }
                 _ => None,
             })
-            .collect::<BTreeMap<_, _>>();
+            .collect::<HashMap<_, _>>();
 
         assert_trie_updates(&account_updates);
     }
@@ -1080,7 +1080,7 @@ mod tests {
         // read the account updates from the db
         let mut accounts_trie = tx.cursor_read::<tables::AccountsTrie>().unwrap();
         let walker = accounts_trie.walk(None).unwrap();
-        let mut account_updates = BTreeMap::new();
+        let mut account_updates = HashMap::new();
         for item in walker {
             let (key, node) = item.unwrap();
             account_updates.insert(key.inner[..].into(), node);
@@ -1148,7 +1148,7 @@ mod tests {
                 }
                 _ => None,
             })
-            .collect::<BTreeMap<_, _>>();
+            .collect::<HashMap<_, _>>();
         assert_eq!(expected_updates, storage_updates);
 
         assert_trie_updates(&storage_updates);
@@ -1157,7 +1157,7 @@ mod tests {
     fn extension_node_storage_trie(
         tx: &mut Transaction<'_, Env<WriteMap>>,
         hashed_address: H256,
-    ) -> (H256, BTreeMap<Nibbles, BranchNodeCompact>) {
+    ) -> (H256, HashMap<Nibbles, BranchNodeCompact>) {
         let value = U256::from(1);
 
         let mut hashed_storage = tx.cursor_write::<tables::HashedStorage>().unwrap();
@@ -1208,7 +1208,7 @@ mod tests {
         hb.root()
     }
 
-    fn assert_trie_updates(account_updates: &BTreeMap<Nibbles, BranchNodeCompact>) {
+    fn assert_trie_updates(account_updates: &HashMap<Nibbles, BranchNodeCompact>) {
         assert_eq!(account_updates.len(), 2);
 
         let node = account_updates.get(&vec![0x3].into()).unwrap();

--- a/crates/trie/src/updates.rs
+++ b/crates/trie/src/updates.rs
@@ -103,7 +103,9 @@ impl TrieUpdates {
         let mut account_trie_cursor = tx.cursor_write::<tables::AccountsTrie>()?;
         let mut storage_trie_cursor = tx.cursor_dup_write::<tables::StoragesTrie>()?;
 
-        for (key, operation) in self.trie_operations {
+        let mut trie_operations = Vec::from_iter(self.trie_operations.into_iter());
+        trie_operations.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        for (key, operation) in trie_operations {
             match key {
                 TrieKey::AccountNode(nibbles) => match operation {
                     TrieOp::Delete => {

--- a/crates/trie/src/updates.rs
+++ b/crates/trie/src/updates.rs
@@ -9,7 +9,7 @@ use reth_primitives::{
     trie::{BranchNodeCompact, StorageTrieEntry, StoredNibbles, StoredNibblesSubKey},
     H256,
 };
-use std::collections::HashMap;
+use std::collections::{hash_map::IntoIter, HashMap};
 
 /// The key of a trie node.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -50,12 +50,16 @@ impl<const N: usize> From<[(TrieKey, TrieOp); N]> for TrieUpdates {
     }
 }
 
-impl TrieUpdates {
-    /// Convert the updates into an iterator.
-    pub fn into_iter(self) -> impl Iterator<Item = (TrieKey, TrieOp)> {
+impl IntoIterator for TrieUpdates {
+    type Item = (TrieKey, TrieOp);
+    type IntoIter = IntoIter<TrieKey, TrieOp>;
+
+    fn into_iter(self) -> Self::IntoIter {
         self.trie_operations.into_iter()
     }
+}
 
+impl TrieUpdates {
     /// Schedule a delete operation on a trie key.
     ///
     /// # Panics


### PR DESCRIPTION
## Problem

Flamegraph showed that calculator spends a lot of time on `BTreeMap::append`, most likely, reorganizing the collection and ensuring proper ordering.

<img width="1382" alt="Screenshot 2023-04-21 at 12 48 04" src="https://user-images.githubusercontent.com/25429261/233606034-50469835-ad03-4002-b771-68abf0a47fc8.png">


## Solution

Swap the inner collection to `HashMap`.