### PR TITLE
chore(deps): bump h2 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,9 +2345,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.16"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
+checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
 dependencies = [
  "bytes",
  "fnv",


### PR DESCRIPTION
copilot:summary

cargo deny

```
error[vulnerability]: Resource exhaustion vulnerability in h2 may lead to Denial of Service (DoS)
    ┌─ /github/workspace/Cargo.lock:214:1
    │
214 │ h2 0.3.16 registry+https://github.com/rust-lang/crates.io-index
    │ --------------------------------------------------------------- security vulnerability detected
```