### PR TITLE
style: use clear over truncate(0)

### DIFF
--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -123,7 +123,7 @@ impl<DB: Database> Stage<DB> for SenderRecoveryStage {
             rayon::spawn(move || {
                 let mut rlp_buf = Vec::with_capacity(128);
                 for entry in chunk {
-                    rlp_buf.truncate(0);
+                    rlp_buf.clear();
                     let _ = tx.send(recover(entry, &mut rlp_buf));
                 }
             });

--- a/crates/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/src/stages/tx_lookup.rs
@@ -99,7 +99,7 @@ impl<DB: Database> Stage<DB> for TransactionLookupStage {
             rayon::spawn(move || {
                 let mut rlp_buf = Vec::with_capacity(128);
                 for entry in chunk {
-                    rlp_buf.truncate(0);
+                    rlp_buf.clear();
                     let _ = tx.send(calculate_hash(entry, &mut rlp_buf));
                 }
             });


### PR DESCRIPTION
See truncate fn docs:

> Truncating when len == 0 is equivalent to calling the clear method.

https://doc.rust-lang.org/stable/std/vec/struct.Vec.html#method.truncate

