### PR TITLE
feat: Parallelize the TD stage

### DIFF
--- a/crates/consensus/auto-seal/src/lib.rs
+++ b/crates/consensus/auto-seal/src/lib.rs
@@ -60,7 +60,7 @@ impl Consensus for AutoSealConsensus {
 
     fn validate_header(
         &self,
-        _header: &SealedHeader,
+        _header: &Header,
         _total_difficulty: U256,
     ) -> Result<(), ConsensusError> {
         Ok(())

--- a/crates/consensus/beacon/src/beacon_consensus.rs
+++ b/crates/consensus/beacon/src/beacon_consensus.rs
@@ -2,7 +2,7 @@
 use reth_consensus_common::validation;
 use reth_interfaces::consensus::{Consensus, ConsensusError};
 use reth_primitives::{
-    Chain, ChainSpec, Hardfork, SealedBlock, SealedHeader, EMPTY_OMMER_ROOT, U256,
+    Chain, ChainSpec, Hardfork, SealedBlock, SealedHeader, EMPTY_OMMER_ROOT, U256, Header,
 };
 use std::sync::Arc;
 
@@ -36,7 +36,7 @@ impl Consensus for BeaconConsensus {
 
     fn validate_header(
         &self,
-        header: &SealedHeader,
+        header: &Header,
         total_difficulty: U256,
     ) -> Result<(), ConsensusError> {
         if self.chain_spec.fork(Hardfork::Paris).active_at_ttd(total_difficulty, header.difficulty)
@@ -85,7 +85,7 @@ impl Consensus for BeaconConsensus {
 ///
 /// From yellow paper: extraData: An arbitrary byte array containing data relevant to this block.
 /// This must be 32 bytes or fewer; formally Hx.
-fn validate_header_extradata(header: &SealedHeader) -> Result<(), ConsensusError> {
+fn validate_header_extradata(header: &Header) -> Result<(), ConsensusError> {
     if header.extra_data.len() > 32 {
         Err(ConsensusError::ExtraDataExceedsMax { len: header.extra_data.len() })
     } else {

--- a/crates/consensus/beacon/src/beacon_consensus.rs
+++ b/crates/consensus/beacon/src/beacon_consensus.rs
@@ -2,7 +2,7 @@
 use reth_consensus_common::validation;
 use reth_interfaces::consensus::{Consensus, ConsensusError};
 use reth_primitives::{
-    Chain, ChainSpec, Hardfork, SealedBlock, SealedHeader, EMPTY_OMMER_ROOT, U256, Header,
+    Chain, ChainSpec, Hardfork, Header, SealedBlock, SealedHeader, EMPTY_OMMER_ROOT, U256,
 };
 use std::sync::Arc;
 

--- a/crates/interfaces/src/consensus.rs
+++ b/crates/interfaces/src/consensus.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use reth_primitives::{
-    BlockHash, BlockNumber, InvalidTransactionError, SealedBlock, SealedHeader, H256, U256,
+    BlockHash, BlockNumber, InvalidTransactionError, SealedBlock, SealedHeader, H256, U256, Header,
 };
 use std::fmt::Debug;
 
@@ -29,7 +29,7 @@ pub trait Consensus: Debug + Send + Sync {
     /// Some consensus engines may want to do additional checks here.
     fn validate_header(
         &self,
-        header: &SealedHeader,
+        header: &Header,
         total_difficulty: U256,
     ) -> Result<(), ConsensusError>;
 

--- a/crates/interfaces/src/consensus.rs
+++ b/crates/interfaces/src/consensus.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use reth_primitives::{
-    BlockHash, BlockNumber, InvalidTransactionError, SealedBlock, SealedHeader, H256, U256, Header,
+    BlockHash, BlockNumber, Header, InvalidTransactionError, SealedBlock, SealedHeader, H256, U256,
 };
 use std::fmt::Debug;
 

--- a/crates/interfaces/src/test_utils/headers.rs
+++ b/crates/interfaces/src/test_utils/headers.rs
@@ -320,7 +320,7 @@ impl Consensus for TestConsensus {
 
     fn validate_header(
         &self,
-        header: &SealedHeader,
+        header: &Header,
         total_difficulty: U256,
     ) -> Result<(), ConsensusError> {
         if self.fail_validation() {

--- a/crates/storage/db/src/abstraction/cursor.rs
+++ b/crates/storage/db/src/abstraction/cursor.rs
@@ -246,17 +246,6 @@ pub struct RangeWalker<'cursor, 'tx, T: Table, CURSOR: DbCursorRO<'tx, T>> {
     /// Phantom data for 'tx. As it is only used for `DbCursorRO`.
     _tx_phantom: PhantomData<&'tx T>,
 }
-// impl<'cursor, 'tx, T: Table, CURSOR: DbCursorRO<'tx, T>> IntoIterator
-//     for RangeWalker<'cursor, 'tx, T, CURSOR>
-// {
-//     type Item = <Self as Iterator>::Item;
-
-//     type IntoIter = Self;
-
-//     fn into_iter(self) -> Self::IntoIter {
-//         self
-//     }
-// }
 
 impl<'cursor, 'tx, T: Table, CURSOR: DbCursorRO<'tx, T>> std::iter::Iterator
     for RangeWalker<'cursor, 'tx, T, CURSOR>

--- a/crates/storage/db/src/abstraction/cursor.rs
+++ b/crates/storage/db/src/abstraction/cursor.rs
@@ -246,6 +246,17 @@ pub struct RangeWalker<'cursor, 'tx, T: Table, CURSOR: DbCursorRO<'tx, T>> {
     /// Phantom data for 'tx. As it is only used for `DbCursorRO`.
     _tx_phantom: PhantomData<&'tx T>,
 }
+// impl<'cursor, 'tx, T: Table, CURSOR: DbCursorRO<'tx, T>> IntoIterator
+//     for RangeWalker<'cursor, 'tx, T, CURSOR>
+// {
+//     type Item = <Self as Iterator>::Item;
+
+//     type IntoIter = Self;
+
+//     fn into_iter(self) -> Self::IntoIter {
+//         self
+//     }
+// }
 
 impl<'cursor, 'tx, T: Table, CURSOR: DbCursorRO<'tx, T>> std::iter::Iterator
     for RangeWalker<'cursor, 'tx, T, CURSOR>

--- a/crates/storage/db/src/tables/raw.rs
+++ b/crates/storage/db/src/tables/raw.rs
@@ -56,7 +56,7 @@ impl<K: Key> RawKey<K> {
     }
 }
 
-impl<K:Key> From<K> for RawKey<K> {
+impl<K: Key> From<K> for RawKey<K> {
     fn from(key: K) -> Self {
         RawKey::new(key)
     }

--- a/crates/storage/db/src/tables/raw.rs
+++ b/crates/storage/db/src/tables/raw.rs
@@ -56,6 +56,12 @@ impl<K: Key> RawKey<K> {
     }
 }
 
+impl<K:Key> From<K> for RawKey<K> {
+    fn from(key: K) -> Self {
+        RawKey::new(key)
+    }
+}
+
 impl AsRef<[u8]> for RawKey<Vec<u8>> {
     fn as_ref(&self) -> &[u8] {
         &self.key


### PR DESCRIPTION
Parallelize the TD stage.

I little bit overdid it, but it will, in parallel read all values and calculate TD (do checks), and when the reading is finished it will continue to calculate TD (do checks) and write to DB. It is even more parallelized after merging hardfork as we know the difficulty is the same as can run all checks in parallel.

There is one shot between tasks that send TD from one task to another and it is used to cancel tasks if an error happened.

Left comment inside code that explains the flow. 

Why i think I overdid it is this stage is not that impactful, on first 1M block in mainnet there isn't a big difference and the times are around of 0.5s so it is not worth merging this. So it is not worth merging this, but i left it if someone is interested in code.

Will do 17M just to check, but it is probably I will just close this PR in few days.