### PR TITLE
fix: track exact number of transactions

### DIFF
--- a/crates/storage/db/src/tables/models/blocks.rs
+++ b/crates/storage/db/src/tables/models/blocks.rs
@@ -40,6 +40,9 @@ impl StoredBlockBodyIndices {
     }
 
     /// First transaction index.
+    ///
+    /// Caution: If the block is empty, this is the number of the first transaction
+    /// in the next non-empty block.
     pub fn first_tx_num(&self) -> TxNumber {
         self.first_tx_num
     }


### PR DESCRIPTION
closes #2342 

```
last_block.last_tx_num() - first_block.first_tx_num()
```

can overflow