### PR TITLE
feat: add payload builder service metrics

### DIFF
--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -19,6 +19,10 @@ reth-revm-primitives = { path = "../../revm/revm-primitives" }
 ## ethereum
 revm-primitives = "1.1"
 
+# metrics
+metrics = "0.20.1"
+reth-metrics-derive = { path = "../../metrics/metrics-derive" }
+
 ## async
 tokio = { version = "1", features = ["sync"] }
 tokio-stream = "0.1"

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -18,6 +18,7 @@
 //!   - [PayloadJob]: a type that can yields (better) payloads over time.
 
 pub mod error;
+mod metrics;
 mod payload;
 mod service;
 mod traits;

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -1,0 +1,30 @@
+//! Payloadbuild service metrics.
+
+use metrics::{Counter, Gauge};
+use reth_metrics_derive::Metrics;
+
+/// Transaction pool metrics
+#[derive(Metrics)]
+#[metrics(scope = "payloads")]
+pub(crate) struct PayloadBuilderServiceMetrics {
+    /// Number of active jobs
+    pub(crate) active_jobs: Gauge,
+    /// Total number of initiated jobs
+    pub(crate) initiated_jobs: Counter,
+    /// Total number of failed jobs
+    pub(crate) failed_jobs: Counter,
+}
+
+impl PayloadBuilderServiceMetrics {
+    pub(crate) fn inc_initiated_jobs(&self) {
+        self.initiated_jobs.increment(1);
+    }
+
+    pub(crate) fn inc_failed_jobs(&self) {
+        self.failed_jobs.increment(1);
+    }
+
+    pub(crate) fn set_active_jobs(&self, value: usize) {
+        self.active_jobs.set(value as f64)
+    }
+}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dfd935e</samp>

This pull request adds metrics to the `payload builder` crate. It defines a `PayloadBuilderServiceMetrics` struct with three metrics fields, and updates the `service.rs` file to use and update the metrics.


ref #2345 