### PR TITLE
fix: use a gauge for `mgas_processed` metric

### DIFF
--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -1,5 +1,5 @@
 use crate::{ExecInput, ExecOutput, Stage, StageError, StageId, UnwindInput, UnwindOutput};
-use metrics_core::Counter;
+use metrics_core::Gauge;
 use reth_db::{
     cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO},
     database::Database,
@@ -23,7 +23,7 @@ pub const EXECUTION: StageId = StageId("Execution");
 #[metrics(scope = "sync.execution")]
 pub struct ExecutionStageMetrics {
     /// The total amount of gas processed (in millions)
-    mgas_processed_total: Counter,
+    mgas_processed_total: Gauge,
 }
 
 /// The execution stage executes all transactions and
@@ -127,7 +127,7 @@ impl<EF: ExecutorFactory> ExecutionStage<EF> {
             if let Some(last_receipt) = block_state.receipts().last() {
                 self.metrics
                     .mgas_processed_total
-                    .increment(last_receipt.cumulative_gas_used / 1_000_000);
+                    .increment(last_receipt.cumulative_gas_used as f64 / 1_000_000.);
             }
             state.extend(block_state);
         }


### PR DESCRIPTION
Previously we use a `Counter` which only accepts integer increments, however since we report in millions of gas processed, we lose a lot of precision on the metric.

For example:

- Any block below 1 million gas processed is counted as 0
- Any block where the amount of gas is 1m < x < 2m gets counted as 1m gas processed

(Taken from the cache branch)