### PR TITLE
fix: only write changed storage to changesets

### DIFF
--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -470,7 +470,9 @@ pub fn commit_state_changes<DB>(
 
             // insert storage into new db account.
             cached_account.storage.extend(account.storage.into_iter().map(|(key, value)| {
-                storage_changeset.insert(key, (value.original_value(), value.present_value()));
+                if value.is_changed() {
+                    storage_changeset.insert(key, (value.original_value(), value.present_value()));
+                }
                 (key, value.present_value())
             }));
 


### PR DESCRIPTION
It is possible for revm to return storage that has not been changed, which we should not be writing to the storage changeset table.

A cursory run on Sepolia revealed that this is a lot more common than I thought.

This PR skips storage slots that have not been changed.

As an example, this would lead to useless writes to the storage changeset:

1. A contract loads slot 0 (value is 10)
2. A contract loads slot 1 and writes to it (value changes from 1 to 2)

We would write both slot 0 (old value 10) and slot 1 (old value 1) in the changeset.

This technically also lead to "no-op" writes to the plain state tables, further decreasing performance.