### PR TITLE
fix(provider): post state get didn't get receipts

### DIFF
--- a/crates/storage/provider/src/test_utils/blocks.rs
+++ b/crates/storage/provider/src/test_utils/blocks.rs
@@ -3,8 +3,8 @@
 use crate::{post_state::PostState, Transaction};
 use reth_db::{database::Database, models::StoredBlockBodyIndices, tables};
 use reth_primitives::{
-    hex_literal::hex, Account, BlockNumber, Header, SealedBlock, SealedBlockWithSenders,
-    Withdrawal, H160, H256, U256,
+    hex_literal::hex, Account, BlockNumber, Bytes, Header, Log, Receipt, SealedBlock,
+    SealedBlockWithSenders, TxType, Withdrawal, H160, H256, U256,
 };
 use reth_rlp::Decodable;
 use std::collections::BTreeMap;
@@ -112,6 +112,17 @@ fn block1(number: BlockNumber) -> (SealedBlockWithSenders, PostState) {
         BTreeMap::from([(U256::from(5), (U256::ZERO, U256::from(10)))]),
     );
 
+    post_state.add_receipt(Receipt {
+        tx_type: TxType::EIP2930,
+        success: true,
+        cumulative_gas_used: 300,
+        logs: vec![Log {
+            address: H160([0x60; 20]),
+            topics: vec![H256::from_low_u64_be(1), H256::from_low_u64_be(2)],
+            data: Bytes::default(),
+        }],
+    });
+
     (SealedBlockWithSenders { block, senders: vec![H160([0x30; 20])] }, post_state)
 }
 
@@ -141,6 +152,16 @@ fn block2(number: BlockNumber, parent_hash: H256) -> (SealedBlockWithSenders, Po
         H160([0x60; 20]),
         BTreeMap::from([(U256::from(5), (U256::from(10), U256::from(15)))]),
     );
+    post_state.add_receipt(Receipt {
+        tx_type: TxType::EIP1559,
+        success: false,
+        cumulative_gas_used: 400,
+        logs: vec![Log {
+            address: H160([0x61; 20]),
+            topics: vec![H256::from_low_u64_be(3), H256::from_low_u64_be(4)],
+            data: Bytes::default(),
+        }],
+    });
 
     (SealedBlockWithSenders { block, senders: vec![H160([0x31; 20])] }, post_state)
 }

--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -959,11 +959,9 @@ where
 
         // loop break if we are at the end of the blocks.
         for (block_number, block_body) in block_bodies.into_iter() {
-            for tx_num in block_body.tx_num_range() {
-                if let Some((receipt_tx_num, receipt)) = receipt_iter.next() {
-                    if tx_num != receipt_tx_num {
-                        block_states.entry(block_number).or_default().add_receipt(receipt);
-                    }
+            for _ in block_body.tx_num_range() {
+                if let Some((_, receipt)) = receipt_iter.next() {
+                    block_states.entry(block_number).or_default().add_receipt(receipt);
                 }
             }
         }


### PR DESCRIPTION
Provider function for getting `PostState` from database was faulty and didn't return the receipts.

Transactions get/take function for getting execution results wouldn't return any receipts from database. Those functions are used inside BlockchainTree. 

Added tests data and fixed the bug.