### PR TITLE
feat(net): add `remote_addr` to session established event

### DIFF
--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -663,6 +663,7 @@ where
                             }
                             this.event_listeners.send(NetworkEvent::SessionEstablished {
                                 peer_id,
+                                remote_addr,
                                 capabilities,
                                 version,
                                 status,
@@ -855,6 +856,8 @@ pub enum NetworkEvent {
     SessionEstablished {
         /// The identifier of the peer to which a session was established.
         peer_id: PeerId,
+        /// The remote addr of the peer to which a session was established.
+        remote_addr: SocketAddr,
         /// Capabilities the peer announced
         capabilities: Arc<Capabilities>,
         /// A request channel to the session task.

--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -795,6 +795,7 @@ mod tests {
             match ev {
                 NetworkEvent::SessionEstablished {
                     peer_id,
+                    remote_addr,
                     capabilities,
                     messages,
                     status,
@@ -803,6 +804,7 @@ mod tests {
                     // to insert a new peer in transactions peerset
                     transactions.on_network_event(NetworkEvent::SessionEstablished {
                         peer_id,
+                        remote_addr,
                         capabilities,
                         messages,
                         status,
@@ -870,12 +872,14 @@ mod tests {
             match ev {
                 NetworkEvent::SessionEstablished {
                     peer_id,
+                    remote_addr,
                     capabilities,
                     messages,
                     status,
                     version,
                 } => transactions.on_network_event(NetworkEvent::SessionEstablished {
                     peer_id,
+                    remote_addr,
                     capabilities,
                     messages,
                     status,


### PR DESCRIPTION
Adds the `remote_addr` field to `NetworkEvent::SessionEstablished`. This is very useful for subscribers listening to those events (at least in my case where I need a little more info about the connected peers)