### PR TITLE
perf(trie): reuse `buf` for rlp encoding on `HashBuilder`

### DIFF
--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -16,7 +16,7 @@ use reth_staged_sync::{
     Config,
 };
 use reth_stages::{
-    stages::{BodyStage, ExecutionStage, SenderRecoveryStage, TransactionLookupStage},
+    stages::{BodyStage, ExecutionStage, SenderRecoveryStage, TransactionLookupStage, MerkleStage},
     ExecInput, Stage, StageId, UnwindInput,
 };
 use std::{net::SocketAddr, sync::Arc};
@@ -185,6 +185,16 @@ impl Command {
             }
             StageEnum::TxLookup => {
                 let mut stage = TransactionLookupStage::new(num_blocks);
+
+                // Unwind first
+                if !self.skip_unwind {
+                    stage.unwind(&mut tx, unwind).await?;
+                }
+
+                stage.execute(&mut tx, input).await?;
+            }
+            StageEnum::Merkle => {
+                let mut stage = MerkleStage::default_execution();
 
                 // Unwind first
                 if !self.skip_unwind {

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -16,7 +16,7 @@ use reth_staged_sync::{
     Config,
 };
 use reth_stages::{
-    stages::{BodyStage, ExecutionStage, SenderRecoveryStage, TransactionLookupStage, MerkleStage},
+    stages::{BodyStage, ExecutionStage, MerkleStage, SenderRecoveryStage, TransactionLookupStage},
     ExecInput, Stage, StageId, UnwindInput,
 };
 use std::{net::SocketAddr, sync::Arc};

--- a/crates/trie/src/nodes/branch.rs
+++ b/crates/trie/src/nodes/branch.rs
@@ -1,5 +1,5 @@
 use super::{rlp_node, CHILD_INDEX_RANGE};
-use reth_primitives::{bytes::BytesMut, trie::TrieMask, H256};
+use reth_primitives::{trie::TrieMask, H256};
 use reth_rlp::{BufMut, EMPTY_STRING_CODE};
 
 /// A Branch node is only a pointer to the stack of nodes and is used to
@@ -38,9 +38,8 @@ impl<'a> BranchNode<'a> {
     }
 
     /// Returns the RLP encoding of the branch node given the state mask of children present.
-    pub fn rlp(&self, state_mask: TrieMask) -> Vec<u8> {
+    pub fn rlp(&self, state_mask: TrieMask, buf: &mut Vec<u8>) -> Vec<u8> {
         let first_child_idx = self.stack.len() - state_mask.count_ones() as usize;
-        let mut buf = BytesMut::new();
 
         // Create the RLP header from the mask elements present.
         let mut i = first_child_idx;
@@ -56,7 +55,7 @@ impl<'a> BranchNode<'a> {
                 header
             },
         );
-        header.encode(&mut buf);
+        header.encode(buf);
 
         // Extend the RLP buffer with the present children
         let mut i = first_child_idx;
@@ -72,6 +71,6 @@ impl<'a> BranchNode<'a> {
         // Is this needed?
         buf.put_u8(EMPTY_STRING_CODE);
 
-        rlp_node(&buf)
+        rlp_node(buf)
     }
 }

--- a/crates/trie/src/nodes/extension.rs
+++ b/crates/trie/src/nodes/extension.rs
@@ -1,6 +1,5 @@
 use super::rlp_node;
 use crate::Nibbles;
-use reth_primitives::bytes::BytesMut;
 use reth_rlp::{BufMut, Encodable};
 
 /// An intermediate node that exists solely to compress the trie's paths. It contains a path segment
@@ -24,10 +23,9 @@ impl<'a> ExtensionNode<'a> {
     }
 
     /// RLP encodes the node and returns either RLP(Node) or RLP(keccak(RLP(node))).
-    pub fn rlp(&self) -> Vec<u8> {
-        let mut buf = BytesMut::new();
-        self.encode(&mut buf);
-        rlp_node(&buf)
+    pub fn rlp(&self, buf: &mut Vec<u8>) -> Vec<u8> {
+        self.encode(buf);
+        rlp_node(buf)
     }
 }
 

--- a/crates/trie/src/nodes/leaf.rs
+++ b/crates/trie/src/nodes/leaf.rs
@@ -1,6 +1,5 @@
 use super::rlp_node;
 use crate::Nibbles;
-use reth_primitives::bytes::BytesMut;
 use reth_rlp::{BufMut, Encodable};
 
 /// A leaf node represents the endpoint or terminal node in the trie. In other words, a leaf node is
@@ -26,10 +25,9 @@ impl<'a> LeafNode<'a> {
 
     /// RLP encodes the node and returns either RLP(Node) or RLP(keccak(RLP(node)))
     /// depending on if the serialized node was longer than a keccak).
-    pub fn rlp(&self) -> Vec<u8> {
-        let mut out = BytesMut::new();
-        self.encode(&mut out);
-        rlp_node(&out)
+    pub fn rlp(&self, out: &mut Vec<u8>) -> Vec<u8> {
+        self.encode(out);
+        rlp_node(out)
     }
 }
 
@@ -73,7 +71,7 @@ mod tests {
         let nibble = Nibbles { hex_data: hex!("0604060f").to_vec() };
         let val = hex!("76657262").to_vec();
         let leaf = LeafNode::new(&nibble, &val);
-        let rlp = leaf.rlp();
+        let rlp = leaf.rlp(&mut vec![]);
 
         let expected = hex!("c98320646f8476657262").to_vec();
         assert_eq!(rlp, expected);

--- a/crates/trie/src/trie.rs
+++ b/crates/trie/src/trie.rs
@@ -206,6 +206,8 @@ impl<'a, 'tx, TX: DbTx<'tx>> StateRoot<'a, TX> {
         walker.set_updates(retain_updates);
         hash_builder.set_updates(retain_updates);
 
+        let mut account_rlp = Vec::with_capacity(128);
+
         while let Some(key) = last_walker_key.take().or_else(|| walker.key()) {
             // Take the last account key to make sure we take it into consideration only once.
             let (next_key, mut next_account_entry) = match last_account_key.take() {
@@ -264,7 +266,8 @@ impl<'a, 'tx, TX: DbTx<'tx>> StateRoot<'a, TX> {
                 };
 
                 let account = EthAccount::from(account).with_storage_root(storage_root);
-                let mut account_rlp = Vec::with_capacity(account.length());
+
+                account_rlp.clear();
                 account.encode(&mut &mut account_rlp);
 
                 hash_builder.add_leaf(account_nibbles, &account_rlp);

--- a/crates/trie/src/trie_cursor/storage_cursor.rs
+++ b/crates/trie/src/trie_cursor/storage_cursor.rs
@@ -81,6 +81,6 @@ mod tests {
             .unwrap();
 
         let mut cursor = StorageTrieCursor::new(cursor, hashed_address);
-        assert_eq!(cursor.seek(key.clone().into()).unwrap().unwrap().1, value);
+        assert_eq!(cursor.seek(key.into()).unwrap().unwrap().1, value);
     }
 }


### PR DESCRIPTION
Just reuses the same buf for calculating the various rlp node values. Since we either copy it or hash it on `rlp_node(...)`


### before @ 5M
![image](https://user-images.githubusercontent.com/93316087/234070030-49684e4f-3a27-496d-9e96-42557c45cf64.png)
![image](https://user-images.githubusercontent.com/93316087/234069772-4c6cfdd8-f6c6-4757-985a-5df4e2fdf325.png)

### after @ 5M
![image](https://user-images.githubusercontent.com/93316087/234070583-354199f6-750a-49f8-bcbb-071d7f2b231a.png)
![image](https://user-images.githubusercontent.com/93316087/234069674-987163ec-b59d-4582-89b1-b3b4017746da.png)
