### PR TITLE
fix: drive pipeline forever in debug.continuous

### DIFF
--- a/bin/reth/src/args/debug_args.rs
+++ b/bin/reth/src/args/debug_args.rs
@@ -10,7 +10,7 @@ pub struct DebugArgs {
     /// Prompt the downloader to download blocks one at a time.
     ///
     /// NOTE: This is for testing purposes only.
-    #[arg(long = "debug.continuous", help_heading = "Debug")]
+    #[arg(long = "debug.continuous", help_heading = "Debug", conflicts_with = "tip")]
     pub continuous: bool,
 
     /// Flag indicating whether the node should be terminated after the pipeline sync.
@@ -20,7 +20,7 @@ pub struct DebugArgs {
     /// Set the chain tip manually for testing purposes.
     ///
     /// NOTE: This is a temporary flag
-    #[arg(long = "debug.tip", help_heading = "Debug")]
+    #[arg(long = "debug.tip", help_heading = "Debug", conflicts_with = "continuous")]
     pub tip: Option<H256>,
 
     /// Runs the sync only up to the specified block.

--- a/crates/stages/src/pipeline/builder.rs
+++ b/crates/stages/src/pipeline/builder.rs
@@ -57,6 +57,13 @@ where
         self
     }
 
+    /// Tell the pipeline to continuously run the pipeline, to accomodate continuous syncing /
+    /// downloading.
+    pub fn with_continuous(mut self) -> Self {
+        self.pipeline.continuous = true;
+        self
+    }
+
     /// Set the tip sender.
     pub fn with_tip_sender(mut self, tip_tx: watch::Sender<H256>) -> Self {
         self.pipeline.tip_tx = Some(tip_tx);


### PR DESCRIPTION
Fixes #2044

The `--debug.continuous` downloader broke because it relied on the pipeline to run forever. The pipeline was previously spawned directly by the `reth node` command in a loop, but is now driven by the `BeaconConsensusEngine`. The `BeaconConsensusEngine` will not run the pipeline again if there is no new pipeline target.

This adds a flag to the `BeaconConsensusEngine` that, if set, will prompt the pipeline to run again, even if there is no new pipeline target. Because `HeaderSyncMode::Continuous` causes the downloader to always have a new / higher tip, this restores the continuous download functionality.

Sends the genesis hash as a fork choice update to the `BeaconConsensusEngine` to kick off download if `--debug.continuous` is set.