### PR TITLE
feat(net): add `client_version` to session established events

### DIFF
--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -637,6 +637,7 @@ where
                         SwarmEvent::SessionEstablished {
                             peer_id,
                             remote_addr,
+                            client_version,
                             capabilities,
                             version,
                             messages,
@@ -649,6 +650,7 @@ where
                             info!(
                                 target : "net",
                                 ?remote_addr,
+                                client_version,
                                 ?peer_id,
                                 ?total_active,
                                 "Session established"
@@ -664,6 +666,7 @@ where
                             this.event_listeners.send(NetworkEvent::SessionEstablished {
                                 peer_id,
                                 remote_addr,
+                                client_version,
                                 capabilities,
                                 version,
                                 status,
@@ -858,6 +861,8 @@ pub enum NetworkEvent {
         peer_id: PeerId,
         /// The remote addr of the peer to which a session was established.
         remote_addr: SocketAddr,
+        /// The client version of the peer to which a session was established.
+        client_version: String,
         /// Capabilities the peer announced
         capabilities: Arc<Capabilities>,
         /// A request channel to the session task.

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -462,7 +462,7 @@ impl SessionManager {
                     established: Instant::now(),
                     capabilities: Arc::clone(&capabilities),
                     commands_to_session,
-                    client_version: client_id,
+                    client_version: client_id.clone(),
                     remote_addr,
                 };
 
@@ -472,6 +472,7 @@ impl SessionManager {
                 Poll::Ready(SessionEvent::SessionEstablished {
                     peer_id,
                     remote_addr,
+                    client_version: client_id,
                     version,
                     capabilities,
                     status,
@@ -588,6 +589,7 @@ pub(crate) enum SessionEvent {
     SessionEstablished {
         peer_id: PeerId,
         remote_addr: SocketAddr,
+        client_version: String,
         capabilities: Arc<Capabilities>,
         /// negotiated eth version
         version: EthVersion,

--- a/crates/net/network/src/swarm.rs
+++ b/crates/net/network/src/swarm.rs
@@ -125,6 +125,7 @@ where
             SessionEvent::SessionEstablished {
                 peer_id,
                 remote_addr,
+                client_version,
                 capabilities,
                 version,
                 status,
@@ -142,6 +143,7 @@ where
                 Some(SwarmEvent::SessionEstablished {
                     peer_id,
                     remote_addr,
+                    client_version,
                     capabilities,
                     version,
                     messages,
@@ -390,6 +392,7 @@ pub(crate) enum SwarmEvent {
     SessionEstablished {
         peer_id: PeerId,
         remote_addr: SocketAddr,
+        client_version: String,
         capabilities: Arc<Capabilities>,
         /// negotiated eth version
         version: EthVersion,

--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -796,6 +796,7 @@ mod tests {
                 NetworkEvent::SessionEstablished {
                     peer_id,
                     remote_addr,
+                    client_version,
                     capabilities,
                     messages,
                     status,
@@ -805,6 +806,7 @@ mod tests {
                     transactions.on_network_event(NetworkEvent::SessionEstablished {
                         peer_id,
                         remote_addr,
+                        client_version,
                         capabilities,
                         messages,
                         status,
@@ -873,6 +875,7 @@ mod tests {
                 NetworkEvent::SessionEstablished {
                     peer_id,
                     remote_addr,
+                    client_version,
                     capabilities,
                     messages,
                     status,
@@ -880,6 +883,7 @@ mod tests {
                 } => transactions.on_network_event(NetworkEvent::SessionEstablished {
                     peer_id,
                     remote_addr,
+                    client_version,
                     capabilities,
                     messages,
                     status,


### PR DESCRIPTION
Adds the `client_version` field to `NetworkEvent::SessionEstablished`. Makes it easier for listeners to collect metrics on their peers.