### PR TITLE
chore: remove default todo! impl

### DIFF
--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -339,14 +339,15 @@ impl StateProviderFactory for MockEthProvider {
         Ok(Box::new(self.clone()))
     }
 
-    fn history_by_block_number(
-        &self,
-        _block: reth_primitives::BlockNumber,
-    ) -> Result<StateProviderBox<'_>> {
+    fn history_by_block_number(&self, _block: BlockNumber) -> Result<StateProviderBox<'_>> {
         todo!()
     }
 
     fn history_by_block_hash(&self, _block: BlockHash) -> Result<StateProviderBox<'_>> {
+        todo!()
+    }
+
+    fn pending(&self) -> Result<StateProviderBox<'_>> {
         todo!()
     }
 
@@ -363,14 +364,15 @@ impl StateProviderFactory for Arc<MockEthProvider> {
         Ok(Box::new(self.clone()))
     }
 
-    fn history_by_block_number(
-        &self,
-        _block: reth_primitives::BlockNumber,
-    ) -> Result<StateProviderBox<'_>> {
+    fn history_by_block_number(&self, _block: BlockNumber) -> Result<StateProviderBox<'_>> {
         todo!()
     }
 
     fn history_by_block_hash(&self, _block: BlockHash) -> Result<StateProviderBox<'_>> {
+        todo!()
+    }
+
+    fn pending(&self) -> Result<StateProviderBox<'_>> {
         todo!()
     }
 

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -197,6 +197,10 @@ impl StateProviderFactory for NoopProvider {
         Ok(Box::new(*self))
     }
 
+    fn pending(&self) -> Result<StateProviderBox<'_>> {
+        Ok(Box::new(*self))
+    }
+
     fn pending_with_provider<'a>(
         &'a self,
         _post_state_data: Box<dyn crate::PostStateDataProvider + 'a>,

--- a/crates/storage/provider/src/traits/state.rs
+++ b/crates/storage/provider/src/traits/state.rs
@@ -111,9 +111,7 @@ pub trait StateProviderFactory: Send + Sync {
     fn history_by_block_hash(&self, block: BlockHash) -> Result<StateProviderBox<'_>>;
 
     /// Storage provider for pending state.
-    fn pending(&self) -> Result<StateProviderBox<'_>> {
-        todo!()
-    }
+    fn pending(&self) -> Result<StateProviderBox<'_>>;
 
     /// Return a [StateProvider] that contains post state data provider.
     /// Used to inspect or execute transaction on the pending state.


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 86458c3</samp>

This pull request adds or modifies the `pending` method for different types of state providers in the `crates/storage/provider` crate. The `pending` method is a new abstract method in the `StateProvider` trait that returns a state provider for the pending state.