### PR TITLE
feat: add StateRootProvider trait

### DIFF
--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -15,7 +15,7 @@ pub use traits::{
     BlockchainTreePendingStateProvider, CanonStateNotification, CanonStateNotificationSender,
     CanonStateNotifications, CanonStateSubscriptions, EvmEnvProvider, ExecutorFactory,
     HeaderProvider, PostStateDataProvider, ReceiptProvider, StateProvider, StateProviderBox,
-    StateProviderFactory, TransactionsProvider, WithdrawalsProvider,
+    StateProviderFactory, StateRootProvider, TransactionsProvider, WithdrawalsProvider,
 };
 
 /// Provider trait implementations.

--- a/crates/storage/provider/src/providers/database.rs
+++ b/crates/storage/provider/src/providers/database.rs
@@ -1,11 +1,11 @@
 use crate::{
     providers::state::{historical::HistoricalStateProvider, latest::LatestStateProvider},
     traits::ReceiptProvider,
-    BlockHashProvider, BlockIdProvider, BlockProvider, EvmEnvProvider, HeaderProvider,
-    ProviderError, StateProviderBox, TransactionsProvider, WithdrawalsProvider,
+    BlockHashProvider, BlockIdProvider, BlockProvider, EvmEnvProvider, HeaderProvider, PostState,
+    ProviderError, StateProviderBox, StateRootProvider, TransactionsProvider, WithdrawalsProvider,
 };
 use reth_db::{cursor::DbCursorRO, database::Database, tables, transaction::DbTx};
-use reth_interfaces::Result;
+use reth_interfaces::{Error, Result};
 use reth_primitives::{
     Block, BlockHash, BlockId, BlockNumber, ChainInfo, ChainSpec, Hardfork, Head, Header, Receipt,
     TransactionMeta, TransactionSigned, TxHash, TxNumber, Withdrawal, H256, U256,
@@ -437,6 +437,16 @@ impl<DB: Database> EvmEnvProvider for ShareableDatabase<DB> {
             self.header_td_by_number(header.number)?.ok_or(ProviderError::HeaderNotFound)?;
         fill_cfg_env(cfg, &self.chain_spec, header, total_difficulty);
         Ok(())
+    }
+}
+
+impl<DB> StateRootProvider for ShareableDatabase<DB>
+where
+    DB: Database,
+{
+    fn state_root(&self, post_state: &PostState) -> Result<H256> {
+        let tx = self.db.tx()?;
+        post_state.state_root_slow(&tx).map_err(|err| Error::Database(err.into()))
     }
 }
 

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -1,8 +1,8 @@
 use crate::{
     BlockHashProvider, BlockIdProvider, BlockProvider, BlockchainTreePendingStateProvider,
-    CanonStateNotifications, CanonStateSubscriptions, EvmEnvProvider, HeaderProvider,
+    CanonStateNotifications, CanonStateSubscriptions, EvmEnvProvider, HeaderProvider, PostState,
     PostStateDataProvider, ReceiptProvider, StateProviderBox, StateProviderFactory,
-    TransactionsProvider, WithdrawalsProvider,
+    StateRootProvider, TransactionsProvider, WithdrawalsProvider,
 };
 use reth_db::database::Database;
 use reth_interfaces::{
@@ -287,6 +287,16 @@ where
         let state_provider = self.history_by_block_hash(canonical_fork.hash)?;
         let post_state_provider = PostStateProvider::new(state_provider, post_state_data);
         Ok(Box::new(post_state_provider))
+    }
+}
+
+impl<DB, Tree> StateRootProvider for BlockchainProvider<DB, Tree>
+where
+    DB: Database,
+    Tree: Send + Sync,
+{
+    fn state_root(&self, post_state: &PostState) -> Result<H256> {
+        self.database.state_root(post_state)
     }
 }
 

--- a/crates/storage/provider/src/traits/mod.rs
+++ b/crates/storage/provider/src/traits/mod.rs
@@ -24,7 +24,7 @@ pub use receipts::ReceiptProvider;
 mod state;
 pub use state::{
     BlockchainTreePendingStateProvider, PostStateDataProvider, StateProvider, StateProviderBox,
-    StateProviderFactory,
+    StateProviderFactory, StateRootProvider,
 };
 
 mod transactions;

--- a/crates/storage/provider/src/traits/state.rs
+++ b/crates/storage/provider/src/traits/state.rs
@@ -154,3 +154,10 @@ pub trait PostStateDataProvider: Send + Sync {
     /// Needed to create state provider.
     fn canonical_fork(&self) -> BlockNumHash;
 }
+
+/// A type that can compute the state root of a given post state.
+#[auto_impl[Box,&]]
+pub trait StateRootProvider: Send + Sync {
+    /// Returns the state root of the given block.
+    fn state_root(&self, post_state: &PostState) -> Result<H256>;
+}

--- a/crates/trie/src/errors.rs
+++ b/crates/trie/src/errors.rs
@@ -11,6 +11,15 @@ pub enum StateRootError {
     StorageRootError(#[from] StorageRootError),
 }
 
+impl From<StateRootError> for reth_db::Error {
+    fn from(err: StateRootError) -> Self {
+        match err {
+            StateRootError::DB(err) => err,
+            StateRootError::StorageRootError(StorageRootError::DB(err)) => err,
+        }
+    }
+}
+
 /// Storage root error.
 #[derive(Error, Debug)]
 pub enum StorageRootError {

--- a/crates/trie/src/lib.rs
+++ b/crates/trie/src/lib.rs
@@ -15,7 +15,7 @@ pub use nibbles::Nibbles;
 /// The Ethereum account as represented in the trie.
 pub mod account;
 
-/// Various branch nodes producde by the hash builder.
+/// Various branch nodes produced by the hash builder.
 pub mod nodes;
 
 /// The implementation of hash builder.


### PR DESCRIPTION
PostState::state_root requires a transaction that we normally do not have access to.

This adds a new trait that hides gets rid of this step.