### PR TITLE
perf: remove redundant ommers sealing

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -182,8 +182,7 @@ pub fn validate_block_standalone(
 ) -> Result<(), ConsensusError> {
     // Check ommers hash
     // TODO(onbjerg): This should probably be accessible directly on [Block]
-    let ommers_hash =
-        reth_primitives::proofs::calculate_ommers_root(block.ommers.iter().map(|h| h.as_ref()));
+    let ommers_hash = reth_primitives::proofs::calculate_ommers_root(block.ommers.iter());
     if block.header.ommers_hash != ommers_hash {
         return Err(ConsensusError::BodyOmmersHashDiff {
             got: ommers_hash,

--- a/crates/interfaces/src/test_utils/generators.rs
+++ b/crates/interfaces/src/test_utils/generators.rs
@@ -125,7 +125,7 @@ pub fn random_block(
         }
         .seal_slow(),
         body: transactions,
-        ommers: ommers.into_iter().map(Header::seal_slow).collect(),
+        ommers,
         withdrawals: None,
     }
 }

--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -584,11 +584,7 @@ mod tests {
             .map(|block| {
                 (
                     block.hash(),
-                    BlockBody {
-                        transactions: block.body,
-                        ommers: block.ommers.into_iter().map(|header| header.unseal()).collect(),
-                        withdrawals: None,
-                    },
+                    BlockBody { transactions: block.body, ommers: block.ommers, withdrawals: None },
                 )
             })
             .collect::<HashMap<_, _>>();

--- a/crates/net/downloaders/src/bodies/request.rs
+++ b/crates/net/downloaders/src/bodies/request.rs
@@ -165,7 +165,7 @@ where
                 let block = SealedBlock {
                     header: next_header,
                     body: next_body.transactions,
-                    ommers: next_body.ommers.into_iter().map(|h| h.seal_slow()).collect(),
+                    ommers: next_body.ommers,
                     withdrawals: next_body.withdrawals,
                 };
 

--- a/crates/net/downloaders/src/bodies/test_utils.rs
+++ b/crates/net/downloaders/src/bodies/test_utils.rs
@@ -24,7 +24,7 @@ pub(crate) fn zip_blocks<'a>(
                 BlockResponse::Full(SealedBlock {
                     header: header.clone(),
                     body: body.transactions,
-                    ommers: body.ommers.into_iter().map(|o| o.seal_slow()).collect(),
+                    ommers: body.ommers,
                     withdrawals: body.withdrawals,
                 })
             }

--- a/crates/net/downloaders/src/test_utils/mod.rs
+++ b/crates/net/downloaders/src/test_utils/mod.rs
@@ -28,7 +28,7 @@ pub(crate) fn generate_bodies(
                 block.hash(),
                 BlockBody {
                     transactions: block.body,
-                    ommers: block.ommers.into_iter().map(|header| header.unseal()).collect(),
+                    ommers: block.ommers,
                     withdrawals: block.withdrawals,
                 },
             )

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -36,7 +36,7 @@ impl Block {
         SealedBlock {
             header: self.header.seal_slow(),
             body: self.body,
-            ommers: self.ommers.into_iter().map(|o| o.seal_slow()).collect(),
+            ommers: self.ommers,
             withdrawals: self.withdrawals,
         }
     }
@@ -105,7 +105,7 @@ pub struct SealedBlock {
     /// Transactions with signatures.
     pub body: Vec<TransactionSigned>,
     /// Ommer/uncle headers
-    pub ommers: Vec<SealedHeader>,
+    pub ommers: Vec<Header>,
     /// Block withdrawals.
     pub withdrawals: Option<Vec<Withdrawal>>,
 }
@@ -117,7 +117,7 @@ impl SealedBlock {
     }
 
     /// Splits the sealed block into underlying components
-    pub fn split(self) -> (SealedHeader, Vec<TransactionSigned>, Vec<SealedHeader>) {
+    pub fn split(self) -> (SealedHeader, Vec<TransactionSigned>, Vec<Header>) {
         (self.header, self.body, self.ommers)
     }
 
@@ -137,7 +137,7 @@ impl SealedBlock {
         Block {
             header: self.header.unseal(),
             body: self.body,
-            ommers: self.ommers.into_iter().map(|o| o.unseal()).collect(),
+            ommers: self.ommers,
             withdrawals: self.withdrawals,
         }
     }

--- a/crates/rpc/rpc-types/src/eth/engine/payload.rs
+++ b/crates/rpc/rpc-types/src/eth/engine/payload.rs
@@ -403,7 +403,7 @@ mod tests {
         SealedBlock {
             header: transformed.header.seal_slow(),
             body: transformed.body,
-            ommers: transformed.ommers.into_iter().map(Header::seal_slow).collect(),
+            ommers: transformed.ommers,
             withdrawals: transformed.withdrawals,
         }
         .into()

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -126,16 +126,8 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
 
                     // Write ommers if any
                     if !block.ommers.is_empty() {
-                        ommers_cursor.append(
-                            block_number,
-                            StoredBlockOmmers {
-                                ommers: block
-                                    .ommers
-                                    .into_iter()
-                                    .map(|header| header.unseal())
-                                    .collect(),
-                            },
-                        )?;
+                        ommers_cursor
+                            .append(block_number, StoredBlockOmmers { ommers: block.ommers })?;
                     }
 
                     // Write withdrawals if any
@@ -438,7 +430,7 @@ mod tests {
                 block.hash(),
                 BlockBody {
                     transactions: block.body.clone(),
-                    ommers: block.ommers.iter().cloned().map(|ommer| ommer.unseal()).collect(),
+                    ommers: block.ommers.clone(),
                     withdrawals: block.withdrawals.clone(),
                 },
             )
@@ -525,13 +517,7 @@ mod tests {
                         if !progress.ommers_hash_is_empty() {
                             tx.put::<tables::BlockOmmers>(
                                 progress.number,
-                                StoredBlockOmmers {
-                                    ommers: progress
-                                        .ommers
-                                        .iter()
-                                        .map(|o| o.clone().unseal())
-                                        .collect(),
-                                },
+                                StoredBlockOmmers { ommers: progress.ommers.clone() },
                             )?;
                         }
                         Ok(())
@@ -746,7 +732,7 @@ mod tests {
                         response.push(BlockResponse::Full(SealedBlock {
                             header,
                             body: body.transactions,
-                            ommers: body.ommers.into_iter().map(|h| h.seal_slow()).collect(),
+                            ommers: body.ommers,
                             withdrawals: body.withdrawals,
                         }));
                     }

--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -754,15 +754,7 @@ where
             let mut ommers = Vec::new();
             if let Some((block_number, _)) = block_ommers.as_ref() {
                 if *block_number == main_block_number {
-                    // Seal ommers as they dont have hash.
-                    ommers = block_ommers
-                        .take()
-                        .unwrap()
-                        .1
-                        .ommers
-                        .into_iter()
-                        .map(|h| h.seal_slow())
-                        .collect();
+                    ommers = block_ommers.take().unwrap().1.ommers;
                     block_ommers = block_ommers_iter.next();
                 }
             };

--- a/crates/storage/provider/src/utils.rs
+++ b/crates/storage/provider/src/utils.rs
@@ -42,10 +42,7 @@ pub fn insert_block<'a, TX: DbTxMut<'a> + DbTx<'a>>(
 
     // insert body ommers data
     if !block.ommers.is_empty() {
-        tx.put::<tables::BlockOmmers>(
-            block.number,
-            StoredBlockOmmers { ommers: block.ommers.iter().map(|h| h.as_ref().clone()).collect() },
-        )?;
+        tx.put::<tables::BlockOmmers>(block.number, StoredBlockOmmers { ommers: block.ommers })?;
     }
 
     let mut next_tx_num =


### PR DESCRIPTION
`SealedBlock` doesn't need to have ommers as `SealedHeader`s (headers without hash is enough).

This reduces a lot of redundant code in tests as well as improves the performance of the following code path:
* Body downloader used to seal ommers for each downloaded body
https://github.com/paradigmxyz/reth/blob/c6e7ea513f85895b65f5255738c49413c0b9cf4a/crates/net/downloaders/src/bodies/request.rs#L165-L170
