### PR TITLE
chore: improve incoming connection traces

### DIFF
--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -658,7 +658,7 @@ where
                                 ?total_active,
                                 "Session established"
                             );
-                            debug!(target: "net", peer_enode=%NodeRecord::new(remote_addr, peer_id), "Established peer enode");
+                            debug!(target: "net", kind=%direction, peer_enode=%NodeRecord::new(remote_addr, peer_id), "Established peer enode");
 
                             if direction.is_incoming() {
                                 this.swarm

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -693,6 +693,15 @@ impl Direction {
     }
 }
 
+impl std::fmt::Display for Direction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Direction::Incoming => write!(f, "incoming"),
+            Direction::Outgoing(_) => write!(f, "outgoing"),
+        }
+    }
+}
+
 /// The error thrown when the max configured limit has been reached and no more connections are
 /// accepted.
 #[derive(Debug, Clone, thiserror::Error)]

--- a/crates/net/network/src/swarm.rs
+++ b/crates/net/network/src/swarm.rs
@@ -221,6 +221,7 @@ where
 
                 match self.sessions.on_incoming(stream, remote_addr) {
                     Ok(session_id) => {
+                        trace!(target: "net", ?remote_addr, "Incoming connection");
                         return Some(SwarmEvent::IncomingTcpConnection { session_id, remote_addr })
                     }
                     Err(err) => {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8786cc4</samp>

This pull request improves the logging of network sessions and connections in the `net` crate. It adds the `kind` field to the session debug log, implements the `Display` trait for the `session::Direction` enum, and adds a trace log for incoming connections in the `swarm.rs` file.

ref #2391