### PR TITLE
chore: add update ENR trace

### DIFF
--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -506,6 +506,7 @@ impl Discv4Service {
             info!(target : "discv4",  ?external_ip, "Updating external ip");
             self.local_node_record.address = external_ip;
             let _ = self.local_eip_868_enr.set_ip(external_ip, &self.secret_key);
+            info!(target : "discv4", enr=?self.local_eip_868_enr, "Updated local ENR");
         }
     }
 


### PR DESCRIPTION
add additional trace after enr updated with external IP

> 2023-04-25T14:18:18.410789Z  INFO Updating external ip external_ip=62.216.209.184
2023-04-25T14:18:18.410882Z  INFO Updated local ENR enr=Enr { id: Some("v4"), seq: 2, NodeId: 0x60710cd2e63a2c2832dbe4a3e8ab146893e01a81982c883f6481fa29bd1e2bb2, signature: "c71bb89a8d04d3f6c27dbc8959d9481b275cbfd4c00aba527cb3acfef42009fb6c2fc4736827e718c973ac85d0389bba7f453fe0670c60c8a75973f12d57c918", IpV4 UDP Socket: Some(62.216.209.184:30303), IpV6 UDP Socket: None, IpV4 TCP Socket: Some(62.216.209.184:30303), IpV6 TCP Socket: None, Other Pairs: [("eth", "c984fe3366e7831a7acb"), ("secp256k1", "a102c289b634a1980b7659537b69cf2118cd656db707904ecdb41a3d1cf51c38e802")] }


ref #2391

note, this is only logged when the external IP changes

FYI @yorickdowne 
