### PR TITLE
fix(net): syncing should be true at startup

### DIFF
--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -57,7 +57,7 @@ impl NetworkHandle {
             peers,
             network_mode,
             bandwidth_meter,
-            is_syncing: Arc::new(Default::default()),
+            is_syncing: Arc::new(AtomicBool::new(true)),
             chain_id,
         };
         Self { inner: Arc::new(inner) }

--- a/crates/net/network/tests/it/startup.rs
+++ b/crates/net/network/tests/it/startup.rs
@@ -3,6 +3,7 @@ use reth_network::{
     error::{NetworkError, ServiceKind},
     Discovery, NetworkConfigBuilder, NetworkManager,
 };
+use reth_network_api::NetworkInfo;
 use reth_provider::test_utils::NoopProvider;
 use secp256k1::SecretKey;
 use std::{
@@ -17,6 +18,17 @@ fn is_addr_in_use_kind(err: NetworkError, kind: ServiceKind) -> bool {
         }
         _ => false,
     }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_is_default_syncing() {
+    let secret_key = SecretKey::new(&mut rand::thread_rng());
+    let config = NetworkConfigBuilder::new(secret_key)
+        .disable_discovery()
+        .listener_port(0)
+        .build(NoopProvider::default());
+    let network = NetworkManager::new(config).await.unwrap();
+    assert!(network.handle().is_syncing());
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
the `is_syncing` flag should be true by at startup

it was set to false, so we enabled peer penalization from the get go

cc @yorickdowne This is a bug that affected peering