### PR TITLE
chore(txpool): don't penalize FeeCapBelowMinimumProtocolFeeCap error

### DIFF
--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -73,9 +73,11 @@ impl PoolError {
                 false
             }
             PoolError::FeeCapBelowMinimumProtocolFeeCap(_, _) => {
-                // fee cap of the tx below the technical minimum determined by the protocol: always
-                // invalid
-                true
+                // fee cap of the tx below the technical minimum determined by the protocol, see
+                // [MINIMUM_PROTOCOL_FEE_CAP](reth_primitives::constants::MIN_PROTOCOL_BASE_FEE)
+                // although this transaction will always be invalid, we do not want to penalize the
+                // sender because this check simply could not be implemented by the client
+                false
             }
             PoolError::SpammerExceededCapacity(_, _) => {
                 // spammer detected


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2387fae</samp>

Fixed a bug in the `transaction-pool` crate that incorrectly marked some transactions as invalid. This improves the fairness and usability of the `reth` node.