### PR TITLE
fix(tree): atomical execution unwind

### DIFF
--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -916,10 +916,10 @@ where
             for (address, (account, storage)) in local_plain_state.into_iter() {
                 // revert account
                 if let Some(account) = account {
-                    plain_accounts_cursor.seek_exact(address)?;
+                    let existing_entry = plain_accounts_cursor.seek_exact(address)?;
                     if let Some(account) = account {
                         plain_accounts_cursor.upsert(address, account)?;
-                    } else {
+                    } else if existing_entry.is_some() {
                         plain_accounts_cursor.delete_current()?;
                     }
                 }
@@ -940,7 +940,7 @@ where
                     // TODO: This does not use dupsort features
                     // insert value if needed
                     if storage_value != U256::ZERO {
-                        plain_storage_cursor.insert(address, storage_entry)?;
+                        plain_storage_cursor.upsert(address, storage_entry)?;
                     }
                 }
             }


### PR DESCRIPTION
First bug
* Dup cursor should use `upsert` to add values in case the table key (address) already has some values in the database. 

Second potential bug (unconfirmed)
* `delete_current` would delete any other value if the `seek_exact` found none. This might be fine because when we destroy the accounts, we still insert the `None` value into the DB, but better to be more strict and remove a potential footgun.

For more details on the expected behavior see https://github.com/paradigmxyz/reth/pull/2411