### PR TITLE
chore(consensus): Clear up the naming and intention behind checks

### DIFF
--- a/crates/blockchain-tree/src/chain.rs
+++ b/crates/blockchain-tree/src/chain.rs
@@ -149,9 +149,10 @@ impl AppendableChain {
         C: Consensus,
         EF: ExecutorFactory,
     {
-        externals.consensus.validate_header(&block, U256::MAX)?;
-        externals.consensus.pre_validate_header(&block, parent_block)?;
-        externals.consensus.pre_validate_block(&block)?;
+        externals.consensus.validate_header_with_total_difficulty(&block, U256::MAX)?;
+        externals.consensus.validate_header(&block)?;
+        externals.consensus.validate_header_agains_parent(&block, parent_block)?;
+        externals.consensus.validate_block(&block)?;
 
         let (unseal, senders) = block.into_components();
         let unseal = unseal.unseal();

--- a/crates/consensus/auto-seal/src/lib.rs
+++ b/crates/consensus/auto-seal/src/lib.rs
@@ -50,7 +50,11 @@ impl AutoSealConsensus {
 }
 
 impl Consensus for AutoSealConsensus {
-    fn pre_validate_header(
+    fn validate_header(&self, _header: &SealedHeader) -> Result<(), ConsensusError> {
+        Ok(())
+    }
+
+    fn validate_header_agains_parent(
         &self,
         _header: &SealedHeader,
         _parent: &SealedHeader,
@@ -58,7 +62,7 @@ impl Consensus for AutoSealConsensus {
         Ok(())
     }
 
-    fn validate_header(
+    fn validate_header_with_total_difficulty(
         &self,
         _header: &Header,
         _total_difficulty: U256,
@@ -66,7 +70,7 @@ impl Consensus for AutoSealConsensus {
         Ok(())
     }
 
-    fn pre_validate_block(&self, _block: &SealedBlock) -> Result<(), ConsensusError> {
+    fn validate_block(&self, _block: &SealedBlock) -> Result<(), ConsensusError> {
         Ok(())
     }
 }

--- a/crates/consensus/beacon/src/beacon_consensus.rs
+++ b/crates/consensus/beacon/src/beacon_consensus.rs
@@ -23,18 +23,21 @@ impl BeaconConsensus {
 }
 
 impl Consensus for BeaconConsensus {
-    fn pre_validate_header(
+    fn validate_header(&self, header: &SealedHeader) -> Result<(), ConsensusError> {
+        validation::validate_header_standalone(header, &self.chain_spec)?;
+        Ok(())
+    }
+
+    fn validate_header_agains_parent(
         &self,
         header: &SealedHeader,
         parent: &SealedHeader,
     ) -> Result<(), ConsensusError> {
-        validation::validate_header_standalone(header, &self.chain_spec)?;
         validation::validate_header_regarding_parent(parent, header, &self.chain_spec)?;
-
         Ok(())
     }
 
-    fn validate_header(
+    fn validate_header_with_total_difficulty(
         &self,
         header: &Header,
         total_difficulty: U256,
@@ -76,7 +79,7 @@ impl Consensus for BeaconConsensus {
         Ok(())
     }
 
-    fn pre_validate_block(&self, block: &SealedBlock) -> Result<(), ConsensusError> {
+    fn validate_block(&self, block: &SealedBlock) -> Result<(), ConsensusError> {
         validation::validate_block_standalone(block, &self.chain_spec)
     }
 }

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -256,11 +256,8 @@ pub fn validate_header_regarding_parent(
         })
     }
 
-    // difficulty check is done by consensus.
-    // TODO(onbjerg): Unsure what the check here is supposed to be, but it should be moved to
-    // [BeaconConsensus]. if chain_spec.paris_status().block_number() > Some(child.number) {
-    //    // TODO how this needs to be checked? As ice age did increment it by some formula
-    //}
+    // TODO Check difficulty increment between parent and child
+    // Ace age did increment it by some formula that we need to follow.
 
     let mut parent_gas_limit = parent.gas_limit;
 

--- a/crates/interfaces/src/consensus.rs
+++ b/crates/interfaces/src/consensus.rs
@@ -16,7 +16,7 @@ pub trait Consensus: Debug + Send + Sync {
     /// This is called on standalone header to check if all hashe
     fn validate_header(&self, header: &SealedHeader) -> Result<(), ConsensusError>;
 
-    /// Validate if the header information regarding parent are correct.
+    /// Validate that the header information regarding parent are correct.
     /// This check block number, timestamp, basefee and gas limit increment.
     ///
     /// This is called before properties that are not in the header itself (like total difficulty)

--- a/crates/interfaces/src/consensus.rs
+++ b/crates/interfaces/src/consensus.rs
@@ -11,13 +11,21 @@ pub use reth_rpc_types::engine::ForkchoiceState;
 #[async_trait]
 #[auto_impl::auto_impl(&, Arc)]
 pub trait Consensus: Debug + Send + Sync {
-    /// Validate if the header is correct and follows consensus specification.
+    /// Validate if header is correct and follows consensus specification.
+    ///
+    /// This is called on standalone header to check if all hashe
+    fn validate_header(&self, header: &SealedHeader) -> Result<(), ConsensusError>;
+
+    /// Validate if the header information regarding parent are correct.
+    /// This check block number, timestamp, basefee and gas limit increment.
     ///
     /// This is called before properties that are not in the header itself (like total difficulty)
     /// have been computed.
     ///
     /// **This should not be called for the genesis block**.
-    fn pre_validate_header(
+    ///
+    /// Note: Validating header agains parent does not include other Consensus validations.
+    fn validate_header_agains_parent(
         &self,
         header: &SealedHeader,
         parent: &SealedHeader,
@@ -27,7 +35,9 @@ pub trait Consensus: Debug + Send + Sync {
     /// computed properties (like total difficulty).
     ///
     /// Some consensus engines may want to do additional checks here.
-    fn validate_header(
+    ///
+    /// Note: validating headers with TD does not include other Consensus validation.
+    fn validate_header_with_total_difficulty(
         &self,
         header: &Header,
         total_difficulty: U256,
@@ -40,7 +50,9 @@ pub trait Consensus: Debug + Send + Sync {
     /// 11.1 "Ommer Validation".
     ///
     /// **This should not be called for the genesis block**.
-    fn pre_validate_block(&self, block: &SealedBlock) -> Result<(), ConsensusError>;
+    ///
+    /// Note: validating blocks does not include other validations of the Consensus
+    fn validate_block(&self, block: &SealedBlock) -> Result<(), ConsensusError>;
 }
 
 /// Consensus Errors

--- a/crates/interfaces/src/consensus.rs
+++ b/crates/interfaces/src/consensus.rs
@@ -24,7 +24,7 @@ pub trait Consensus: Debug + Send + Sync {
     ///
     /// **This should not be called for the genesis block**.
     ///
-    /// Note: Validating header agains parent does not include other Consensus validations.
+    /// Note: Validating header against its parent does not include other Consensus validations.
     fn validate_header_agains_parent(
         &self,
         header: &SealedHeader,

--- a/crates/interfaces/src/consensus.rs
+++ b/crates/interfaces/src/consensus.rs
@@ -17,7 +17,7 @@ pub trait Consensus: Debug + Send + Sync {
     fn validate_header(&self, header: &SealedHeader) -> Result<(), ConsensusError>;
 
     /// Validate that the header information regarding parent are correct.
-    /// This check block number, timestamp, basefee and gas limit increment.
+    /// This checks the block number, timestamp, basefee and gas limit increment.
     ///
     /// This is called before properties that are not in the header itself (like total difficulty)
     /// have been computed.

--- a/crates/interfaces/src/p2p/headers/downloader.rs
+++ b/crates/interfaces/src/p2p/headers/downloader.rs
@@ -77,7 +77,7 @@ pub fn validate_header_download(
     parent: &SealedHeader,
 ) -> DownloadResult<()> {
     ensure_parent(header, parent)?;
-    // validate header agains parent
+    // validate header against parent
     consensus
         .validate_header_agains_parent(header, parent)
         .map_err(|error| DownloadError::HeaderValidation { hash: parent.hash(), error })?;

--- a/crates/interfaces/src/p2p/headers/downloader.rs
+++ b/crates/interfaces/src/p2p/headers/downloader.rs
@@ -77,8 +77,13 @@ pub fn validate_header_download(
     parent: &SealedHeader,
 ) -> DownloadResult<()> {
     ensure_parent(header, parent)?;
+    // validate header agains parent
     consensus
-        .pre_validate_header(header, parent)
+        .validate_header_agains_parent(header, parent)
+        .map_err(|error| DownloadError::HeaderValidation { hash: parent.hash(), error })?;
+    // validate header standalone
+    consensus
+        .validate_header(header)
         .map_err(|error| DownloadError::HeaderValidation { hash: parent.hash(), error })?;
     Ok(())
 }

--- a/crates/interfaces/src/test_utils/generators.rs
+++ b/crates/interfaces/src/test_utils/generators.rs
@@ -6,6 +6,7 @@ use reth_primitives::{
 };
 use secp256k1::{KeyPair, Message as SecpMessage, Secp256k1, SecretKey, SECP256K1};
 use std::{
+    cmp::{max, min},
     collections::BTreeMap,
     ops::{Range, RangeInclusive, Sub},
 };
@@ -192,7 +193,7 @@ where
         let (prev_from, _) = state.get_mut(&from).unwrap();
         transition.push((from, *prev_from, Vec::new()));
 
-        transfer = transfer.min(prev_from.balance).max(U256::from(1));
+        transfer = max(min(transfer, prev_from.balance), U256::from(1));
         prev_from.balance = prev_from.balance.wrapping_sub(transfer);
 
         // deposit in receiving account and update storage

--- a/crates/interfaces/src/test_utils/headers.rs
+++ b/crates/interfaces/src/test_utils/headers.rs
@@ -156,7 +156,7 @@ impl Stream for TestDownload {
             }
 
             let empty = SealedHeader::default();
-            if let Err(error) = this.consensus.pre_validate_header(&empty, &empty) {
+            if let Err(error) = this.consensus.validate_header_agains_parent(&empty, &empty) {
                 this.done = true;
                 return Poll::Ready(Some(Err(DownloadError::HeaderValidation {
                     hash: empty.hash(),
@@ -306,7 +306,15 @@ impl StatusUpdater for TestStatusUpdater {
 
 #[async_trait::async_trait]
 impl Consensus for TestConsensus {
-    fn pre_validate_header(
+    fn validate_header(&self, _header: &SealedHeader) -> Result<(), ConsensusError> {
+        if self.fail_validation() {
+            Err(consensus::ConsensusError::BaseFeeMissing)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn validate_header_agains_parent(
         &self,
         header: &SealedHeader,
         parent: &SealedHeader,
@@ -318,7 +326,7 @@ impl Consensus for TestConsensus {
         }
     }
 
-    fn validate_header(
+    fn validate_header_with_total_difficulty(
         &self,
         header: &Header,
         total_difficulty: U256,
@@ -330,7 +338,7 @@ impl Consensus for TestConsensus {
         }
     }
 
-    fn pre_validate_block(&self, _block: &SealedBlock) -> Result<(), consensus::ConsensusError> {
+    fn validate_block(&self, _block: &SealedBlock) -> Result<(), consensus::ConsensusError> {
         if self.fail_validation() {
             Err(consensus::ConsensusError::BaseFeeMissing)
         } else {

--- a/crates/net/downloaders/src/bodies/request.rs
+++ b/crates/net/downloaders/src/bodies/request.rs
@@ -169,7 +169,7 @@ where
                     withdrawals: next_body.withdrawals,
                 };
 
-                if let Err(error) = self.consensus.pre_validate_block(&block) {
+                if let Err(error) = self.consensus.validate_block(&block) {
                     // Put the header back and return an error
                     let hash = block.hash();
                     self.headers.push_front(block.header);

--- a/crates/stages/src/stages/total_difficulty.rs
+++ b/crates/stages/src/stages/total_difficulty.rs
@@ -77,7 +77,7 @@ impl<DB: Database> Stage<DB> for TotalDifficultyStage {
             td += header.difficulty;
 
             self.consensus
-                .validate_header(&header, td)
+                .validate_header_with_total_difficulty(&header, td)
                 .map_err(|error| StageError::Validation { block: header.number, error })?;
             cursor_td.append(block_number, td.into())?;
         }


### PR DESCRIPTION
Rename consensus function to reflect the checks that they do.

Split `pre_validate_header` that takes header and  parent header, into:
* `validate_header` that checks the header.
* `validate_header_agains_parent` that takes header and parent header


<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0b43088</samp>

### Summary
🔧🧪🚀

<!--
1.  🔧 - This emoji represents the refactoring and improvement of the consensus interface and its testing utilities, which is the main goal of this pull request.
2.  🧪 - This emoji represents the testing and validation of blocks and headers, which is a significant part of the consensus interface and its functionality.
3.  🚀 - This emoji represents the performance and scalability of the consensus engine, which is enhanced by the more modular and consistent validation methods.
-->
This pull request refactors the consensus interface and its usage across different modules of the `reth` crate. It splits the header validation into three separate methods: `validate_header`, `validate_header_with_total_difficulty`, and `validate_header_against_parent`. It also updates the consensus implementations and the testing utilities to use the new methods. The purpose of this refactoring is to make the consensus interface more modular and consistent across different consensus engines.

> _We're refactoring the consensus interface_
> _To make it more modular and consistent_
> _So heave away, me hearties, heave away_
> _And call the `validate_header` methods_

### Walkthrough
*  Refactor the consensus interface to split the header validation into three methods: `validate_header`, `validate_header_agains_parent`, and `validate_header_with_total_difficulty` ([link](https://github.com/paradigmxyz/reth/pull/2415/files?diff=unified&w=0#diff-614a4f220b0f9ad1ee97bece6419e90691ba6e62468495308542b9e85ad8aa5aL152-R155), [link](https://github.com/paradigmxyz/reth/pull/2415/files?diff=unified&w=0#diff-5bc0c18d694356372999995109019e23444214b19c6058384ca906b5f95ffab3L53-R57), [link](https://github.com/paradigmxyz/reth/pull/2415/files?diff=unified&w=0#diff-5bc0c18d694356372999995109019e23444214b19c6058384ca906b5f95ffab3L61-R65), [link](https://github.com/paradigmxyz/reth/pull/2415/files?diff=unified&w=0#diff-070ae817b26fc2f9b534ea284dbdfa5868abea7e5299e052b93f50543fd4587fL26-R40), [link](https://github.com/paradigmxyz/reth/pull/2415/files?diff=unified&w=0#diff-b888edd502864918b163a16603e9ead71fd7eb3868f2d6f957a08a918195213fL14-R28), [link](https://github.com/paradigmxyz/reth/pull/2415/files?diff=unified&w=0#diff-b888edd502864918b163a16603e9ead71fd7eb3868f2d6f957a08a918195213fL30-R40), [link](https://github.com/paradigmxyz/reth/pull/2415/files?diff=unified&w=0#diff-b888edd502864918b163a16603e9ead71fd7eb3868f2d6f957a08a918195213fL43-R55), [link](https://github.com/paradigmxyz/reth/pull/2415/files?diff=unified&w=0#diff-0059f969874d3174d11d59fc762760588eb4fe018dedd849b57e3ac7750f1cfdL80-R87), [link](https://github.com/paradigmxyz/reth/pull/2415/files?diff=unified&w=0#diff-2f41fc3478eccdcd2b3c1c03bee14f086c732e5b492c5894cbd806e26d56c382L159-R159), [link](https://github.com/paradigmxyz/reth/pull/2415/files?diff=unified&w=0#diff-2f41fc3478eccdcd2b3c1c03bee14f086c732e5b492c5894cbd806e26d56c382L309-R317), [link](https://github.com/paradigmxyz/reth/pull/2415/files?diff=unified&w=0#diff-2f41fc3478eccdcd2b3c1c03bee14f086c732e5b492c5894cbd806e26d56c382L321-R329), [link](https://github.com/paradigmxyz/reth/pull/2415/files?diff=unified&w=0#diff-490374b2369f71e98d1ef4f77c86d4a4249a67257fc6a8039b30cfd28f69e5abL80-R80))
* Rename the `pre_validate_block` method to `validate_block` in the `Consensus` trait and its implementations ([link](https://github.com/paradigmxyz/reth/pull/2415/files?diff=unified&w=0#diff-5bc0c18d694356372999995109019e23444214b19c6058384ca906b5f95ffab3L69-R73), [link](https://github.com/paradigmxyz/reth/pull/2415/files?diff=unified&w=0#diff-070ae817b26fc2f9b534ea284dbdfa5868abea7e5299e052b93f50543fd4587fL79-R82), [link](https://github.com/paradigmxyz/reth/pull/2415/files?diff=unified&w=0#diff-b888edd502864918b163a16603e9ead71fd7eb3868f2d6f957a08a918195213fL30-R40), [link](https://github.com/paradigmxyz/reth/pull/2415/files?diff=unified&w=0#diff-2f41fc3478eccdcd2b3c1c03bee14f086c732e5b492c5894cbd806e26d56c382L333-R341), [link](https://github.com/paradigmxyz/reth/pull/2415/files?diff=unified&w=0#diff-d46aefacdec3af127f81279bde35fd79e85096a6908f26df1ae2afcb84d1fe68L172-R172))
* Clarify the comment in the `validation::validate_header_regarding_parent` function to mention the difficulty increment check ([link](https://github.com/paradigmxyz/reth/pull/2415/files?diff=unified&w=0#diff-6af93f5eb1bf31ae0c4b0257a669a44b3084168e4def801437cc99f9681491e7L259-R260))
* Improve the readability of the `test_utils::generators::generate_transition` function by using `max(min(transfer, prev_from.balance), U256::from(1))` instead of `transfer.min(prev_from.balance).max(U256::from(1))` ([link](https://github.com/paradigmxyz/reth/pull/2415/files?diff=unified&w=0#diff-90c62b02fab7dcd4385bbde147a0240f16af286ae06469b83ae4999a71f7a623R9), [link](https://github.com/paradigmxyz/reth/pull/2415/files?diff=unified&w=0#diff-90c62b02fab7dcd4385bbde147a0240f16af286ae06469b83ae4999a71f7a623L195-R196))


