### PR TITLE
feat: include SessionsConfig in reth.toml

### DIFF
--- a/crates/net/network/src/lib.rs
+++ b/crates/net/network/src/lib.rs
@@ -145,6 +145,6 @@ pub use manager::{NetworkEvent, NetworkManager};
 pub use message::PeerRequest;
 pub use network::NetworkHandle;
 pub use peers::PeersConfig;
-pub use session::PeerInfo;
+pub use session::{PeerInfo, SessionsConfig};
 
 pub use reth_eth_wire::DisconnectReason;

--- a/crates/net/network/src/session/config.rs
+++ b/crates/net/network/src/session/config.rs
@@ -74,7 +74,7 @@ impl SessionsConfig {
 /// Limits for sessions.
 ///
 /// By default, no session limits will be enforced
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SessionLimits {
     max_pending_inbound: Option<u32>,

--- a/crates/net/network/src/session/config.rs
+++ b/crates/net/network/src/session/config.rs
@@ -5,7 +5,6 @@ use crate::{
     session::{Direction, ExceedsSessionLimit},
 };
 use std::time::Duration;
-use tracing::trace;
 
 /// Default request timeout for a single request.
 ///

--- a/crates/net/network/src/session/config.rs
+++ b/crates/net/network/src/session/config.rs
@@ -5,6 +5,7 @@ use crate::{
     session::{Direction, ExceedsSessionLimit},
 };
 use std::time::Duration;
+use tracing::trace;
 
 /// Default request timeout for a single request.
 ///
@@ -17,7 +18,7 @@ pub const INITIAL_REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 pub const PROTOCOL_BREACH_REQUEST_TIMEOUT: Duration = Duration::from_secs(2 * 60);
 
 /// Configuration options when creating a [SessionManager](crate::session::SessionManager).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SessionsConfig {
     /// Size of the session command buffer (per session task).
@@ -74,7 +75,7 @@ impl SessionsConfig {
 /// Limits for sessions.
 ///
 /// By default, no session limits will be enforced
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SessionLimits {
     max_pending_inbound: Option<u32>,
@@ -139,19 +140,23 @@ impl SessionCounter {
 
     pub(crate) fn inc_pending_inbound(&mut self) {
         self.pending_inbound += 1;
+        trace!(target: "net::sessions::counter", new_pending_inbound=?self.pending_inbound, "Incremented pending inbound sessions");
     }
 
     pub(crate) fn inc_pending_outbound(&mut self) {
         self.pending_outbound += 1;
+        trace!(target: "net::sessions::counter", new_pending_outbound=?self.pending_outbound, "Incremented pending outbound sessions");
     }
 
     pub(crate) fn dec_pending(&mut self, direction: &Direction) {
         match direction {
             Direction::Outgoing(_) => {
                 self.pending_outbound -= 1;
+                trace!(target: "net::sessions::counter", new_pending_outbound=?self.pending_outbound, "Decremented pending outbound sessions");
             }
             Direction::Incoming => {
                 self.pending_inbound -= 1;
+                trace!(target: "net::sessions::counter", new_pending_outbound=?self.pending_outbound, "Decremented pending inbound sessions");
             }
         }
     }
@@ -160,9 +165,11 @@ impl SessionCounter {
         match direction {
             Direction::Outgoing(_) => {
                 self.active_outbound += 1;
+                trace!(target: "net::sessions::counter", new_active_outbound=?self.active_outbound, "Incremented active outbound sessions");
             }
             Direction::Incoming => {
                 self.active_inbound += 1;
+                trace!(target: "net::sessions::counter", new_active_inbound=?self.active_inbound, "Incremented active inbound sessions");
             }
         }
     }
@@ -171,9 +178,11 @@ impl SessionCounter {
         match direction {
             Direction::Outgoing(_) => {
                 self.active_outbound -= 1;
+                trace!(target: "net::sessions::counter", new_active_outbound=?self.active_outbound, "Decremented active outbound sessions");
             }
             Direction::Incoming => {
                 self.active_inbound -= 1;
+                trace!(target: "net::sessions::counter", new_active_inbound=?self.active_inbound, "Decremented active inbound sessions");
             }
         }
     }

--- a/crates/net/network/src/session/config.rs
+++ b/crates/net/network/src/session/config.rs
@@ -140,23 +140,19 @@ impl SessionCounter {
 
     pub(crate) fn inc_pending_inbound(&mut self) {
         self.pending_inbound += 1;
-        trace!(target: "net::sessions::counter", new_pending_inbound=?self.pending_inbound, "Incremented pending inbound sessions");
     }
 
     pub(crate) fn inc_pending_outbound(&mut self) {
         self.pending_outbound += 1;
-        trace!(target: "net::sessions::counter", new_pending_outbound=?self.pending_outbound, "Incremented pending outbound sessions");
     }
 
     pub(crate) fn dec_pending(&mut self, direction: &Direction) {
         match direction {
             Direction::Outgoing(_) => {
                 self.pending_outbound -= 1;
-                trace!(target: "net::sessions::counter", new_pending_outbound=?self.pending_outbound, "Decremented pending outbound sessions");
             }
             Direction::Incoming => {
                 self.pending_inbound -= 1;
-                trace!(target: "net::sessions::counter", new_pending_outbound=?self.pending_outbound, "Decremented pending inbound sessions");
             }
         }
     }
@@ -165,11 +161,9 @@ impl SessionCounter {
         match direction {
             Direction::Outgoing(_) => {
                 self.active_outbound += 1;
-                trace!(target: "net::sessions::counter", new_active_outbound=?self.active_outbound, "Incremented active outbound sessions");
             }
             Direction::Incoming => {
                 self.active_inbound += 1;
-                trace!(target: "net::sessions::counter", new_active_inbound=?self.active_inbound, "Incremented active inbound sessions");
             }
         }
     }
@@ -178,11 +172,9 @@ impl SessionCounter {
         match direction {
             Direction::Outgoing(_) => {
                 self.active_outbound -= 1;
-                trace!(target: "net::sessions::counter", new_active_outbound=?self.active_outbound, "Decremented active outbound sessions");
             }
             Direction::Incoming => {
                 self.active_inbound -= 1;
-                trace!(target: "net::sessions::counter", new_active_inbound=?self.active_inbound, "Decremented active inbound sessions");
             }
         }
     }

--- a/crates/net/network/src/session/config.rs
+++ b/crates/net/network/src/session/config.rs
@@ -17,7 +17,7 @@ pub const INITIAL_REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 pub const PROTOCOL_BREACH_REQUEST_TIMEOUT: Duration = Duration::from_secs(2 * 60);
 
 /// Configuration options when creating a [SessionManager](crate::session::SessionManager).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SessionsConfig {
     /// Size of the session command buffer (per session task).

--- a/crates/staged-sync/src/config.rs
+++ b/crates/staged-sync/src/config.rs
@@ -4,7 +4,7 @@ use reth_downloaders::{
     bodies::bodies::BodiesDownloaderBuilder,
     headers::reverse_headers::ReverseHeadersDownloaderBuilder,
 };
-use reth_network::{NetworkConfigBuilder, PeersConfig};
+use reth_network::{NetworkConfigBuilder, PeersConfig, SessionsConfig};
 use secp256k1::SecretKey;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -18,6 +18,8 @@ pub struct Config {
     pub stages: StageConfig,
     /// Configuration for the discovery service.
     pub peers: PeersConfig,
+    /// Configuration for peer sessions.
+    pub sessions: SessionsConfig,
 }
 
 impl Config {
@@ -36,7 +38,10 @@ impl Config {
 
         let discv4 =
             Discv4Config::builder().external_ip_resolver(Some(nat_resolution_method)).clone();
-        NetworkConfigBuilder::new(secret_key).peer_config(peer_config).discovery(discv4)
+        NetworkConfigBuilder::new(secret_key)
+            .sessions_config(self.sessions.clone())
+            .peer_config(peer_config)
+            .discovery(discv4)
     }
 }
 


### PR DESCRIPTION
Allows `SessionsConfig` values to be set in `reth.toml`. This also enforces the pending outbound sessions limit, which was not being enforced before.