### PR TITLE
fix: use historical state provider for state root

### DIFF
--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -549,6 +549,7 @@ fn build_payload<Pool, Client>(
 
         // calculate the state root
         let state_root = db.db.0.state_root(post_state)?;
+        trace!(?state_root, ?block_number, "Calculated state root for new block");
 
         // create the block header
         let transactions_root = proofs::calculate_transaction_root(executed_txs.iter());
@@ -618,6 +619,7 @@ where
 
     // calculate the state root
     let state_root = db.db.0.state_root(post_state)?;
+    trace!(?state_root, ?block_number, "Calculated state root for empty new block");
 
     let header = Header {
         parent_hash: parent_block.hash,

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -93,8 +93,10 @@ impl<'a, 'b, TX: DbTx<'a>> BlockHashProvider for HistoricalStateProviderRef<'a, 
 }
 
 impl<'a, 'b, TX: DbTx<'a>> StateRootProvider for HistoricalStateProviderRef<'a, 'b, TX> {
-    fn state_root(&self, _post_state: PostState) -> Result<H256> {
-        Err(ProviderError::StateRootNotAvailableForHistoricalBlock.into())
+    fn state_root(&self, post_state: PostState) -> Result<H256> {
+        post_state
+            .state_root_slow(self.tx)
+            .map_err(|err| reth_interfaces::Error::Database(err.into()))
     }
 }
 


### PR DESCRIPTION
PR is partially for discussion, because we may want to do this differently. Payload building needs to get the state provider for a specific block hash, so we can't use `LatestStateProvider` for calculating the state root. We use the `HistoricalStateProvider` currently:
https://github.com/paradigmxyz/reth/blob/c7341b54f07b357461e91a9c8059a85909e1e86b/crates/storage/provider/src/providers/mod.rs#L321

The `state_root` method on `HistoricalStateProvider` currently errors, so this PR implements the `state_root` method similar to how it's implemented on `LatestStateProvider`.

Question: do we need another type of StateProvider for pending state? One that is not the HistoricalStateProvider?