### PR TITLE
feat(net): fix peer backoffs to not interfere with reputation

### DIFF
--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -731,6 +731,10 @@ where
                             if let Some(reason) = reason {
                                 this.disconnect_metrics.increment(reason);
                             }
+                            this.metrics.backed_off_peers.set(
+                                this.swarm.state().peers().num_backed_off_peers().saturating_sub(1)
+                                    as f64,
+                            );
                             this.event_listeners
                                 .send(NetworkEvent::SessionClosed { peer_id, reason });
                         }
@@ -761,6 +765,10 @@ where
                             this.metrics
                                 .incoming_connections
                                 .set(this.swarm.state().peers().num_inbound_connections() as f64);
+                            this.metrics.backed_off_peers.set(
+                                this.swarm.state().peers().num_backed_off_peers().saturating_sub(1)
+                                    as f64,
+                            );
                         }
                         SwarmEvent::OutgoingPendingSessionClosed {
                             remote_addr,
@@ -795,6 +803,10 @@ where
                             this.metrics
                                 .outgoing_connections
                                 .set(this.swarm.state().peers().num_outbound_connections() as f64);
+                            this.metrics.backed_off_peers.set(
+                                this.swarm.state().peers().num_backed_off_peers().saturating_sub(1)
+                                    as f64,
+                            );
                         }
                         SwarmEvent::OutgoingConnectionError { remote_addr, peer_id, error } => {
                             trace!(
@@ -814,6 +826,10 @@ where
                             this.metrics
                                 .outgoing_connections
                                 .set(this.swarm.state().peers().num_outbound_connections() as f64);
+                            this.metrics.backed_off_peers.set(
+                                this.swarm.state().peers().num_backed_off_peers().saturating_sub(1)
+                                    as f64,
+                            );
                         }
                         SwarmEvent::BadMessage { peer_id } => {
                             this.swarm.state_mut().peers_mut().apply_reputation_change(

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -515,7 +515,10 @@ where
                 .sessions_mut()
                 .send_message(&peer_id, PeerMessage::PooledTransactions(msg)),
             NetworkHandleMessage::AddPeerAddress(peer, kind, addr) => {
-                self.swarm.state_mut().add_peer_kind(peer, kind, addr);
+                // only add peer if we are not shutting down
+                if !self.swarm.is_shutting_down() {
+                    self.swarm.state_mut().add_peer_kind(peer, kind, addr);
+                }
             }
             NetworkHandleMessage::RemovePeer(peer_id, kind) => {
                 self.swarm.state_mut().remove_peer(peer_id, kind);

--- a/crates/net/network/src/metrics.rs
+++ b/crates/net/network/src/metrics.rs
@@ -9,6 +9,9 @@ pub struct NetworkMetrics {
     /// Number of currently connected peers
     pub(crate) connected_peers: Gauge,
 
+    /// Number of currently backed off peers
+    pub(crate) backed_off_peers: Gauge,
+
     /// Number of peers known to the node
     pub(crate) tracked_peers: Gauge,
 

--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -192,6 +192,12 @@ impl PeersManager {
         self.connection_info.num_outbound
     }
 
+    /// Returns the number of currently backed off peers.
+    #[inline]
+    pub(crate) fn num_backed_off_peers(&self) -> usize {
+        self.backoff_list.len()
+    }
+
     /// Invoked when a new _incoming_ tcp connection is accepted.
     ///
     /// returns an error if the inbound ip address is on the ban list or

--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -1388,17 +1388,10 @@ mod test {
         })
         .await;
 
-        assert!(peers.ban_list.is_banned_peer(&peer));
-        assert!(peers.peers.get(&peer).is_some());
+        assert!(peers.backoff_list.contains_key(&peer));
+        assert!(peers.peers.get(&peer).unwrap().is_backed_off());
 
         tokio::time::sleep(backoff_durations.low).await;
-
-        match event!(peers) {
-            PeerAction::UnBanPeer { peer_id, .. } => {
-                assert_eq!(peer_id, peer);
-            }
-            _ => unreachable!(),
-        }
 
         match event!(peers) {
             PeerAction::Connect { peer_id, .. } => {
@@ -1406,6 +1399,9 @@ mod test {
             }
             _ => unreachable!(),
         }
+
+        assert!(!peers.backoff_list.contains_key(&peer));
+        assert!(!peers.peers.get(&peer).unwrap().is_backed_off());
     }
 
     #[tokio::test]
@@ -1455,17 +1451,10 @@ mod test {
         })
         .await;
 
-        assert!(peers.ban_list.is_banned_peer(&peer));
-        assert!(peers.peers.get(&peer).is_some());
+        assert!(peers.backoff_list.contains_key(&peer));
+        assert!(peers.peers.get(&peer).unwrap().is_backed_off());
 
         tokio::time::sleep(backoff_durations.high).await;
-
-        match event!(peers) {
-            PeerAction::UnBanPeer { peer_id, .. } => {
-                assert_eq!(peer_id, peer);
-            }
-            _ => unreachable!(),
-        }
 
         match event!(peers) {
             PeerAction::Connect { peer_id, .. } => {
@@ -1473,6 +1462,9 @@ mod test {
             }
             _ => unreachable!(),
         }
+
+        assert!(!peers.backoff_list.contains_key(&peer));
+        assert!(!peers.peers.get(&peer).unwrap().is_backed_off());
     }
 
     #[tokio::test]

--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -207,10 +207,10 @@ impl PeersManager {
         addr: IpAddr,
     ) -> Result<(), InboundConnectionError> {
         if self.ban_list.is_banned_ip(&addr) {
-            return Err(InboundConnectionError::IpBanned);
+            return Err(InboundConnectionError::IpBanned)
         }
         if !self.connection_info.has_in_capacity() {
-            return Err(InboundConnectionError::ExceedsLimit(self.connection_info.max_inbound));
+            return Err(InboundConnectionError::ExceedsLimit(self.connection_info.max_inbound))
         }
         // keep track of new connection
         self.connection_info.inc_in();
@@ -255,9 +255,9 @@ impl PeersManager {
     pub(crate) fn on_incoming_session_established(&mut self, peer_id: PeerId, addr: SocketAddr) {
         // we only need to check the peer id here as the ip address will have been checked at
         // on_inbound_pending_session. We also check if the peer is in the backoff list here.
-        if self.ban_list.is_banned_peer(&peer_id) || self.backed_off_peers.contains_key(&peer_id) {
+        if self.ban_list.is_banned_peer(&peer_id) {
             self.queued_actions.push_back(PeerAction::DisconnectBannedIncoming { peer_id });
-            return;
+            return
         }
 
         // start a new tick, so the peer is not immediately rewarded for the time since last tick
@@ -268,7 +268,7 @@ impl PeersManager {
                 let value = entry.get_mut();
                 if value.is_banned() {
                     self.queued_actions.push_back(PeerAction::DisconnectBannedIncoming { peer_id });
-                    return;
+                    return
                 }
                 value.state = PeerConnectionState::In;
             }
@@ -348,7 +348,7 @@ impl PeersManager {
                 peer.apply_reputation(reputation_change.as_i32())
             }
         } else {
-            return;
+            return
         };
 
         match outcome {
@@ -372,7 +372,7 @@ impl PeersManager {
         if let Some(mut peer) = self.peers.get_mut(peer_id) {
             peer.state = PeerConnectionState::Idle;
         } else {
-            return;
+            return
         }
         self.connection_info.decr_out()
     }
@@ -403,7 +403,7 @@ impl PeersManager {
                     // session to that peer
                     entry.get_mut().severe_backoff_counter = 0;
                     entry.get_mut().state = PeerConnectionState::Idle;
-                    return;
+                    return
                 }
             }
             Entry::Vacant(_) => return,
@@ -548,7 +548,7 @@ impl PeersManager {
         fork_id: Option<ForkId>,
     ) {
         if self.ban_list.is_banned(&peer_id, &addr.ip()) {
-            return;
+            return
         }
 
         match self.peers.entry(peer_id) {
@@ -565,7 +565,7 @@ impl PeersManager {
                     peer.remove_after_disconnect = false;
                 }
 
-                return;
+                return
             }
             Entry::Vacant(entry) => {
                 trace!(target : "net::peers", ?peer_id, ?addr, "discovered new node");
@@ -583,7 +583,7 @@ impl PeersManager {
     pub(crate) fn remove_peer(&mut self, peer_id: PeerId) {
         let Entry::Occupied(entry) = self.peers.entry(peer_id) else { return };
         if entry.get().is_trusted() {
-            return;
+            return
         }
         let mut peer = entry.remove();
 
@@ -610,7 +610,7 @@ impl PeersManager {
     pub(crate) fn remove_peer_from_trusted_set(&mut self, peer_id: PeerId) {
         let Entry::Occupied(mut entry) = self.peers.entry(peer_id) else { return };
         if !entry.get().is_trusted() {
-            return;
+            return
         }
 
         let peer = entry.get_mut();
@@ -629,23 +629,23 @@ impl PeersManager {
     /// Returns `None` if no peer is available.
     fn best_unconnected(&mut self) -> Option<(PeerId, &mut Peer)> {
         let mut unconnected = self.peers.iter_mut().filter(|(_, peer)| {
-            peer.state.is_unconnected()
-                && !peer.is_banned()
-                && !peer.is_backed_off()
-                && (!self.connect_trusted_nodes_only || peer.is_trusted())
+            peer.state.is_unconnected() &&
+                !peer.is_banned() &&
+                !peer.is_backed_off() &&
+                (!self.connect_trusted_nodes_only || peer.is_trusted())
         });
 
         // keep track of the best peer, if there's one
         let mut best_peer = unconnected.next()?;
 
         if best_peer.1.is_trusted() {
-            return Some((*best_peer.0, best_peer.1));
+            return Some((*best_peer.0, best_peer.1))
         }
 
         for maybe_better in unconnected {
             // if the peer is trusted, return it immediately
             if maybe_better.1.is_trusted() {
-                return Some((*maybe_better.0, maybe_better.1));
+                return Some((*maybe_better.0, maybe_better.1))
             }
 
             // otherwise we keep track of the best peer using the reputation
@@ -674,7 +674,7 @@ impl PeersManager {
 
                 // If best peer does not meet reputation threshold exit immediately.
                 if peer.is_banned() {
-                    break;
+                    break
                 }
 
                 trace!(target : "net::peers",  ?peer_id, addr=?peer.addr, "schedule outbound connection");
@@ -696,7 +696,7 @@ impl PeersManager {
         loop {
             // drain buffered actions
             if let Some(action) = self.queued_actions.pop_front() {
-                return Poll::Ready(action);
+                return Poll::Ready(action)
             }
 
             while let Poll::Ready(Some(cmd)) = self.handle_rx.poll_next_unpin(cx) {
@@ -724,7 +724,7 @@ impl PeersManager {
                     if let Some(peer) = self.peers.get_mut(&peer_id) {
                         peer.unban();
                     } else {
-                        continue;
+                        continue
                     }
                     self.queued_actions.push_back(PeerAction::UnBanPeer { peer_id });
                 }
@@ -736,7 +736,7 @@ impl PeersManager {
                         if let Some(peer) = self.peers.get_mut(peer_id) {
                             peer.backed_off = false;
                         }
-                        return false;
+                        return false
                     }
                     true
                 })
@@ -749,7 +749,7 @@ impl PeersManager {
             }
 
             if self.queued_actions.is_empty() {
-                return Poll::Pending;
+                return Poll::Pending
             }
         }
     }
@@ -893,15 +893,15 @@ impl Peer {
 
         if self.state.is_connected() && self.is_banned() {
             self.state.disconnect();
-            return ReputationChangeOutcome::DisconnectAndBan;
+            return ReputationChangeOutcome::DisconnectAndBan
         }
 
         if self.is_banned() && !is_banned_reputation(previous) {
-            return ReputationChangeOutcome::Ban;
+            return ReputationChangeOutcome::Ban
         }
 
         if !self.is_banned() && is_banned_reputation(previous) {
-            return ReputationChangeOutcome::Unban;
+            return ReputationChangeOutcome::Unban
         }
 
         ReputationChangeOutcome::None

--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -254,8 +254,8 @@ impl PeersManager {
     /// be scheduled.
     pub(crate) fn on_incoming_session_established(&mut self, peer_id: PeerId, addr: SocketAddr) {
         // we only need to check the peer id here as the ip address will have been checked at
-        // on_inbound_pending_session
-        if self.ban_list.is_banned_peer(&peer_id) {
+        // on_inbound_pending_session. We also check if the peer is in the backoff list here.
+        if self.ban_list.is_banned_peer(&peer_id) || self.backoff_list.contains_key(&peer_id) {
             self.queued_actions.push_back(PeerAction::DisconnectBannedIncoming { peer_id });
             return
         }

--- a/crates/net/network/src/peers/reputation.rs
+++ b/crates/net/network/src/peers/reputation.rs
@@ -26,10 +26,6 @@ const BAD_MESSAGE_REPUTATION_CHANGE: i32 = 16 * REPUTATION_UNIT;
 /// The reputation change to apply to a peer which violates protocol rules: minimal reputation
 const BAD_PROTOCOL_REPUTATION_CHANGE: i32 = i32::MIN;
 
-/// A reputation change to apply to backoff the peer. This has the same effect as marking the peer
-/// as banned.
-pub(crate) const BACKOFF_REPUTATION_CHANGE: i32 = i32::MIN;
-
 /// Returns `true` if the given reputation is below the [`BANNED_REPUTATION`] threshold
 #[inline]
 pub(crate) fn is_banned_reputation(reputation: i32) -> bool {

--- a/crates/net/network/src/swarm.rs
+++ b/crates/net/network/src/swarm.rs
@@ -284,7 +284,7 @@ where
 
     /// Checks if the node's network connection state is 'ShuttingDown'
     #[inline]
-    fn is_shutting_down(&self) -> bool {
+    pub(crate) fn is_shutting_down(&self) -> bool {
         matches!(self.net_connection_state, NetworkConnectionState::ShuttingDown)
     }
 }


### PR DESCRIPTION
Closes #2410

Implements a fix whereby the backoff mechanism interferes with peer reputation:

* Adds `backed_off: bool` field to `Peer`
* Adds `backoff_list: HashMap<PeerId, std::time::Instant>` to `PeersManager`
* When peers need to be backed off from, we mark them with `backed_off` and save the backoff expiration in `backoff_list`
* Every `unban_interval`, check the `backoff_list` and see which ones expire. We can clear those entries and mark the peers as not backed off.
* On dialing (`fill_outbound_slots` > `best_unconnected`), we check if the peer is backed off as well as banned before dialing