### PR TITLE
feat: check if blocknumber is latest block number

### DIFF
--- a/crates/interfaces/src/provider.rs
+++ b/crates/interfaces/src/provider.rs
@@ -74,8 +74,6 @@ pub enum ProviderError {
     /// Some error occurred while interacting with the state tree.
     #[error("Unknown error occurred while interacting with the state trie.")]
     StateTrie,
-    #[error("History state root, can't be calculated")]
-    HistoryStateRoot,
     /// Thrown when required header related data was not found but was required.
     #[error("requested data not found")]
     HeaderNotFound,
@@ -91,6 +89,7 @@ pub enum ProviderError {
     /// Thrown when we failed to lookup a block for the pending state
     #[error("Unknown block hash: {0:}")]
     UnknownBlockHash(H256),
+    /// Unable to compute state root on top of historical block
     #[error("Unable to compute state root on top of historical block")]
     StateRootNotAvailableForHistoricalBlock,
 }

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -299,7 +299,6 @@ where
         if let Some(pending) = self.tree.find_pending_state_provider(block) {
             return self.pending_with_provider(pending)
         }
-
         // not found in tree, check database
         self.history_by_block_hash(block)
     }

--- a/crates/storage/provider/src/providers/post_state_provider.rs
+++ b/crates/storage/provider/src/providers/post_state_provider.rs
@@ -94,6 +94,6 @@ impl<SP: StateProvider, PSDP: PostStateDataProvider> StateProvider for PostState
         _address: Address,
         _keys: &[H256],
     ) -> Result<(Vec<Bytes>, H256, Vec<Vec<Bytes>>)> {
-        Err(ProviderError::HistoryStateRoot.into())
+        Err(ProviderError::StateRootNotAvailableForHistoricalBlock.into())
     }
 }

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -149,7 +149,7 @@ impl<'a, 'b, TX: DbTx<'a>> StateProvider for HistoricalStateProviderRef<'a, 'b, 
         _address: Address,
         _keys: &[H256],
     ) -> Result<(Vec<Bytes>, H256, Vec<Vec<Bytes>>)> {
-        Err(ProviderError::HistoryStateRoot.into())
+        Err(ProviderError::StateRootNotAvailableForHistoricalBlock.into())
     }
 }
 


### PR DESCRIPTION
adds a check in `historical_state` that checks if the given block number is actually the latest, if that's the case then we can use the `latest` state directly.