### PR TITLE
fix: consensus validation method typo

### DIFF
--- a/crates/blockchain-tree/src/chain.rs
+++ b/crates/blockchain-tree/src/chain.rs
@@ -151,7 +151,7 @@ impl AppendableChain {
     {
         externals.consensus.validate_header_with_total_difficulty(&block, U256::MAX)?;
         externals.consensus.validate_header(&block)?;
-        externals.consensus.validate_header_agains_parent(&block, parent_block)?;
+        externals.consensus.validate_header_against_parent(&block, parent_block)?;
         externals.consensus.validate_block(&block)?;
 
         let (unseal, senders) = block.into_components();

--- a/crates/consensus/auto-seal/src/lib.rs
+++ b/crates/consensus/auto-seal/src/lib.rs
@@ -54,7 +54,7 @@ impl Consensus for AutoSealConsensus {
         Ok(())
     }
 
-    fn validate_header_agains_parent(
+    fn validate_header_against_parent(
         &self,
         _header: &SealedHeader,
         _parent: &SealedHeader,

--- a/crates/consensus/beacon/src/beacon_consensus.rs
+++ b/crates/consensus/beacon/src/beacon_consensus.rs
@@ -28,7 +28,7 @@ impl Consensus for BeaconConsensus {
         Ok(())
     }
 
-    fn validate_header_agains_parent(
+    fn validate_header_against_parent(
         &self,
         header: &SealedHeader,
         parent: &SealedHeader,

--- a/crates/interfaces/src/consensus.rs
+++ b/crates/interfaces/src/consensus.rs
@@ -25,7 +25,7 @@ pub trait Consensus: Debug + Send + Sync {
     /// **This should not be called for the genesis block**.
     ///
     /// Note: Validating header against its parent does not include other Consensus validations.
-    fn validate_header_agains_parent(
+    fn validate_header_against_parent(
         &self,
         header: &SealedHeader,
         parent: &SealedHeader,

--- a/crates/interfaces/src/p2p/headers/downloader.rs
+++ b/crates/interfaces/src/p2p/headers/downloader.rs
@@ -79,7 +79,7 @@ pub fn validate_header_download(
     ensure_parent(header, parent)?;
     // validate header against parent
     consensus
-        .validate_header_agains_parent(header, parent)
+        .validate_header_against_parent(header, parent)
         .map_err(|error| DownloadError::HeaderValidation { hash: parent.hash(), error })?;
     // validate header standalone
     consensus

--- a/crates/interfaces/src/test_utils/headers.rs
+++ b/crates/interfaces/src/test_utils/headers.rs
@@ -156,7 +156,7 @@ impl Stream for TestDownload {
             }
 
             let empty = SealedHeader::default();
-            if let Err(error) = this.consensus.validate_header_agains_parent(&empty, &empty) {
+            if let Err(error) = this.consensus.validate_header_against_parent(&empty, &empty) {
                 this.done = true;
                 return Poll::Ready(Some(Err(DownloadError::HeaderValidation {
                     hash: empty.hash(),
@@ -314,7 +314,7 @@ impl Consensus for TestConsensus {
         }
     }
 
-    fn validate_header_agains_parent(
+    fn validate_header_against_parent(
         &self,
         header: &SealedHeader,
         parent: &SealedHeader,

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -170,6 +170,7 @@ where
             cursor_header.insert(header_number, header)?;
             cursor_canonical.insert(header_number, header_hash)?;
         }
+
         Ok(latest)
     }
 }


### PR DESCRIPTION
`validate_header_agains_parent` -> `validate_header_against_parent`