### PR TITLE
refactor: convert payload job from stream to future

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5084,7 +5084,6 @@ dependencies = [
 name = "reth-payload-builder"
 version = "0.1.0"
 dependencies = [
- "futures-core",
  "futures-util",
  "metrics",
  "reth-interfaces",

--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -26,7 +26,6 @@ reth-metrics-derive = { path = "../../metrics/metrics-derive" }
 tokio = { version = "1", features = ["sync"] }
 tokio-stream = "0.1"
 futures-util = "0.3"
-futures-core = "0.3"
 
 ## misc
 thiserror = "1.0"

--- a/crates/payload/builder/src/test_utils.rs
+++ b/crates/payload/builder/src/test_utils.rs
@@ -4,9 +4,9 @@ use crate::{
     error::PayloadBuilderError, BuiltPayload, PayloadBuilderAttributes, PayloadBuilderHandle,
     PayloadBuilderService, PayloadJob, PayloadJobGenerator,
 };
-use futures_core::Stream;
 use reth_primitives::{Block, U256};
 use std::{
+    future::Future,
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
@@ -47,10 +47,10 @@ pub struct TestPayloadJob {
     attr: PayloadBuilderAttributes,
 }
 
-impl Stream for TestPayloadJob {
-    type Item = Result<Arc<BuiltPayload>, PayloadBuilderError>;
+impl Future for TestPayloadJob {
+    type Output = Result<(), PayloadBuilderError>;
 
-    fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
         Poll::Pending
     }
 }

--- a/crates/payload/builder/src/traits.rs
+++ b/crates/payload/builder/src/traits.rs
@@ -1,21 +1,22 @@
 //! Trait abstractions used by the payload crate.
 
 use crate::{error::PayloadBuilderError, BuiltPayload, PayloadBuilderAttributes};
-use futures_core::TryStream;
+
+use std::future::Future;
 
 use std::sync::Arc;
 
 /// A type that can build a payload.
 ///
-/// This type is a Stream that yields better payloads.
+/// This type is a Future that resolves when the job is done (e.g. timed out) or it failed. It's not
+/// supposed to return the best payload built when it resolves instead [PayloadJob::best_payload]
+/// should be used for that.
 ///
 /// A PayloadJob must always be prepared to return the best payload built so far to make there's a
 /// valid payload to deliver to the CL, so it does not miss a slot, even if the payload is empty.
 ///
 /// Note: A PayloadJob need to be cancel safe because it might be dropped after the CL has requested the payload via `engine_getPayloadV1`, See also <https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/paris.md#engine_getpayloadv1>
-pub trait PayloadJob:
-    TryStream<Ok = Arc<BuiltPayload>, Error = PayloadBuilderError> + Send + Sync
-{
+pub trait PayloadJob: Future<Output = Result<(), PayloadBuilderError>> + Send + Sync {
     /// Returns the best payload that has been built so far.
     ///
     /// Note: this is expected to be an empty block without transaction if nothing has been built


### PR DESCRIPTION
Closes #2434

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7656173</samp>

Refactored the `PayloadJob` trait and its implementations to use `Future` instead of `Stream` in the `payload` crate. This simplifies the payload building logic and allows for better error handling and retries. Updated the `payload/builder` crate to use the new trait and removed an unnecessary dependency.