### PR TITLE
fix: ensure head shares a chain with safe or finalized blocks

### DIFF
--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -185,7 +185,6 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
     ///
     /// Returns None if the block is not part of the canonical chain or any side chain.
     pub fn get_block_num(&self, block_hash: &BlockHash) -> Result<Option<u64>, Error> {
-        // NOTE: is_block_hash_canonical does not check the db
         // first check the canonical chain
         if let Some((num, _)) =
             self.block_indices.canonical_chain().iter().find(|(_, hash)| *hash == block_hash)

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -700,12 +700,8 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
         };
         let chain = self.chains.remove(&chain_id).expect("To be present");
 
-        trace!(target: "blockchain_tree", ?chain, ?chain_id, "Got chain id for block hash");
-
         // we are spliting chain as there is possibility that only part of chain get canonicalized.
         let canonical = self.split_chain(chain_id, chain, SplitAt::Hash(*block_hash));
-
-        trace!(target: "blockchain_tree", ?canonical, "Split canonical chain, finding fork block");
 
         let mut block_fork = canonical.fork_block();
         let mut block_fork_number = canonical.fork_block_number();

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -670,8 +670,12 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
         };
         let chain = self.chains.remove(&chain_id).expect("To be present");
 
+        trace!(target: "blockchain_tree", ?chain, ?chain_id, "Got chain id for block hash");
+
         // we are spliting chain as there is possibility that only part of chain get canonicalized.
         let canonical = self.split_chain(chain_id, chain, SplitAt::Hash(*block_hash));
+
+        trace!(target: "blockchain_tree", ?canonical, "Split canonical chain, finding fork block");
 
         let mut block_fork = canonical.fork_block();
         let mut block_fork_number = canonical.fork_block_number();

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -205,6 +205,9 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
     }
 
     /// Check that the block is part of the canonical chain, even if it is not in the tree's range.
+    ///
+    /// This differs from `is_block_hash_canonical` in that it will check the database if the block
+    /// is not in the tree's range.
     pub(crate) fn ensure_block_is_canonical(&self, block_hash: &BlockHash) -> Result<bool, Error> {
         Ok(self.get_block_num(block_hash)?.is_some())
     }

--- a/crates/blockchain-tree/src/shareable.rs
+++ b/crates/blockchain-tree/src/shareable.rs
@@ -132,12 +132,12 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeViewer
     }
 
     fn is_block_hash_canonical(&self, block_hash: &BlockHash) -> bool {
-        trace!(target: "blockchain_tree", "Checking if block is canonical");
+        trace!(target: "blockchain_tree", ?block_hash, "Checking if block is canonical");
         self.tree.read().block_indices().is_block_hash_canonical(block_hash)
     }
 
     fn share_chain(&self, first: &BlockHash, second: &BlockHash) -> bool {
-        trace!(target: "blockchain_tree", "Returning chain for a block");
+        trace!(target: "blockchain_tree", ?first, ?second, "Returning whether or not the two blocks share a chain");
         let tree = self.tree.read();
         let indices = tree.block_indices();
         if indices.is_block_hash_canonical(first) {
@@ -157,6 +157,12 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeViewer
 
             second_chain_index == first_chain_index
         }
+    }
+
+    fn is_block_known(&self, hash: &BlockHash) -> bool {
+        trace!(target: "blockchain_tree", ?hash, "Checking if block is known");
+        let tree = self.tree.read();
+        tree.block_indices().is_block_hash_canonical(hash) || tree.block_by_hash(*hash).is_some()
     }
 }
 

--- a/crates/blockchain-tree/src/shareable.rs
+++ b/crates/blockchain-tree/src/shareable.rs
@@ -131,6 +131,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeViewer
         self.tree.read().pending_block().cloned()
     }
 
+    // TODO: better errors for the unexpected cases here (unknown fork block with index etc.)
     fn share_chain(&self, first: &BlockHash, second: &BlockHash) -> Result<bool, Error> {
         trace!(target: "blockchain_tree", ?first, ?second, "Returning whether or not the two blocks share a chain");
         let tree = self.tree.read();
@@ -175,7 +176,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeViewer
         // if the block number of the fork block is greater than the canonical block num, because
         // the fork block by definition connects to the canonical chain, we know that the two
         // blocks share a chain
-        Ok(num >= fork_block.number)
+        Ok(fork_block.number >= num)
     }
 
     fn is_block_known(&self, hash: &BlockHash) -> Result<bool, Error> {

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -356,16 +356,24 @@ where
                 PipelineTarget::Head
             };
             self.require_pipeline_run(target);
-            return Ok(OnForkChoiceUpdated::valid(PayloadStatus::from_status(PayloadStatusEnum::Syncing)))
+            return Ok(OnForkChoiceUpdated::valid(PayloadStatus::from_status(
+                PayloadStatusEnum::Syncing,
+            )))
         }
 
-        // check if finalized is part of the same chain
-        if !self.blockchain_tree.share_chain(&state.head_block_hash, &state.finalized_block_hash) {
+        // check if finalized is part of the same chain (and not zero)
+        if !state.finalized_block_hash.is_zero() &&
+            !self
+                .blockchain_tree
+                .share_chain(&state.head_block_hash, &state.finalized_block_hash)
+        {
             return Ok(OnForkChoiceUpdated::invalid_state())
         }
 
-        // check if safe is part of the same chain as the head
-        if !self.blockchain_tree.share_chain(&state.head_block_hash, &state.safe_block_hash) {
+        // check if safe is part of the same chain as the head (and not zero)
+        if !state.safe_block_hash.is_zero() &&
+            !self.blockchain_tree.share_chain(&state.head_block_hash, &state.safe_block_hash)
+        {
             return Ok(OnForkChoiceUpdated::invalid_state())
         }
 

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -355,6 +355,8 @@ where
             } else {
                 PipelineTarget::Head
             };
+            self.forkchoice_state = Some(state);
+            // TODO: does the pipeline need to be idle here?
             self.require_pipeline_run(target);
             return Ok(OnForkChoiceUpdated::valid(PayloadStatus::from_status(
                 PayloadStatusEnum::Syncing,

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -343,8 +343,8 @@ where
 
         // TODO: is this the right check that the block exists and is VALID?
         // This is here so we know that the block is `VALID` before performing same-chain checks,
-        // if it's in the tree it should be VALID
-        if !self.blockchain_tree.is_block_known(&state.head_block_hash) {
+        // if it's in the tree or db it should be VALID
+        if !self.blockchain_tree.is_block_known(&state.head_block_hash)? {
             // If this is the first forkchoice received, start downloading from safe block
             // hash.
             let target = if is_first_forkchoice &&
@@ -365,14 +365,14 @@ where
         if !state.finalized_block_hash.is_zero() &&
             !self
                 .blockchain_tree
-                .share_chain(&state.head_block_hash, &state.finalized_block_hash)
+                .share_chain(&state.head_block_hash, &state.finalized_block_hash)?
         {
             return Ok(OnForkChoiceUpdated::invalid_state())
         }
 
         // check if safe is part of the same chain as the head (and not zero)
         if !state.safe_block_hash.is_zero() &&
-            !self.blockchain_tree.share_chain(&state.head_block_hash, &state.safe_block_hash)
+            !self.blockchain_tree.share_chain(&state.head_block_hash, &state.safe_block_hash)?
         {
             return Ok(OnForkChoiceUpdated::invalid_state())
         }

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -344,7 +344,7 @@ where
         // TODO: is this the right check that the block exists and is VALID?
         // This is here so we know that the block is `VALID` before performing same-chain checks,
         // if it's in the tree it should be VALID
-        let Some(block) = self.blockchain_tree.block_by_hash(state.head_block_hash) else {
+        if !self.blockchain_tree.is_block_known(&state.head_block_hash) {
             // If this is the first forkchoice received, start downloading from safe block
             // hash.
             let target = if is_first_forkchoice &&
@@ -357,7 +357,7 @@ where
             };
             self.require_pipeline_run(target);
             return Ok(OnForkChoiceUpdated::valid(PayloadStatus::from_status(PayloadStatusEnum::Syncing)))
-        };
+        }
 
         // check if finalized is part of the same chain
         if !self.blockchain_tree.share_chain(&state.head_block_hash, &state.finalized_block_hash) {

--- a/crates/interfaces/src/blockchain_tree.rs
+++ b/crates/interfaces/src/blockchain_tree.rs
@@ -89,6 +89,8 @@ pub trait BlockchainTreeViewer: Send + Sync {
     fn blocks(&self) -> BTreeMap<BlockNumber, HashSet<BlockHash>>;
 
     /// Returns the block with matching hash.
+    ///
+    /// This will not return blocks that are part of the canonical chain.
     fn block_by_hash(&self, hash: BlockHash) -> Option<SealedBlock>;
 
     /// Canonical block number and hashes best known by the tree.
@@ -124,4 +126,8 @@ pub trait BlockchainTreeViewer: Send + Sync {
     /// Return whether or not the two block hashes share a chain. If either does not exist in the
     /// tree and are not part of the canonical chain, this should return `false`.
     fn share_chain(&self, first: &BlockHash, second: &BlockHash) -> bool;
+
+    /// Return whether or not the block is known to either the tree or is part of the canonical
+    /// chain.
+    fn is_block_known(&self, hash: &BlockHash) -> bool;
 }

--- a/crates/interfaces/src/blockchain_tree.rs
+++ b/crates/interfaces/src/blockchain_tree.rs
@@ -117,4 +117,11 @@ pub trait BlockchainTreeViewer: Send + Sync {
     fn pending_block(&self) -> Option<SealedBlock> {
         self.block_by_hash(self.pending_block_num_hash()?.hash)
     }
+
+    /// Return whether or not the block hash is canonical.
+    fn is_block_hash_canonical(&self, hash: &BlockHash) -> bool;
+
+    /// Return whether or not the two block hashes share a chain. If either does not exist in the
+    /// tree and are not part of the canonical chain, this should return `false`.
+    fn share_chain(&self, first: &BlockHash, second: &BlockHash) -> bool;
 }

--- a/crates/interfaces/src/blockchain_tree.rs
+++ b/crates/interfaces/src/blockchain_tree.rs
@@ -120,14 +120,11 @@ pub trait BlockchainTreeViewer: Send + Sync {
         self.block_by_hash(self.pending_block_num_hash()?.hash)
     }
 
-    /// Return whether or not the block hash is canonical.
-    fn is_block_hash_canonical(&self, hash: &BlockHash) -> bool;
-
     /// Return whether or not the two block hashes share a chain. If either does not exist in the
     /// tree and are not part of the canonical chain, this should return `false`.
-    fn share_chain(&self, first: &BlockHash, second: &BlockHash) -> bool;
+    fn share_chain(&self, first: &BlockHash, second: &BlockHash) -> Result<bool, Error>;
 
     /// Return whether or not the block is known to either the tree or is part of the canonical
     /// chain.
-    fn is_block_known(&self, hash: &BlockHash) -> bool;
+    fn is_block_known(&self, hash: &BlockHash) -> Result<bool, Error>;
 }

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -405,6 +405,14 @@ where
     fn pending_block_num_hash(&self) -> Option<BlockNumHash> {
         self.tree.pending_block_num_hash()
     }
+
+    fn is_block_hash_canonical(&self, hash: &BlockHash) -> bool {
+        self.tree.is_block_hash_canonical(hash)
+    }
+
+    fn share_chain(&self, first: &BlockHash, second: &BlockHash) -> bool {
+        self.tree.share_chain(first, second)
+    }
 }
 
 impl<DB, Tree> BlockchainTreePendingStateProvider for BlockchainProvider<DB, Tree>

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -413,6 +413,10 @@ where
     fn share_chain(&self, first: &BlockHash, second: &BlockHash) -> bool {
         self.tree.share_chain(first, second)
     }
+
+    fn is_block_known(&self, hash: &BlockHash) -> bool {
+        self.tree.is_block_known(hash)
+    }
 }
 
 impl<DB, Tree> BlockchainTreePendingStateProvider for BlockchainProvider<DB, Tree>

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -406,15 +406,11 @@ where
         self.tree.pending_block_num_hash()
     }
 
-    fn is_block_hash_canonical(&self, hash: &BlockHash) -> bool {
-        self.tree.is_block_hash_canonical(hash)
-    }
-
-    fn share_chain(&self, first: &BlockHash, second: &BlockHash) -> bool {
+    fn share_chain(&self, first: &BlockHash, second: &BlockHash) -> Result<bool> {
         self.tree.share_chain(first, second)
     }
 
-    fn is_block_known(&self, hash: &BlockHash) -> bool {
+    fn is_block_known(&self, hash: &BlockHash) -> Result<bool> {
         self.tree.is_block_known(hash)
     }
 }


### PR DESCRIPTION
Previously, we did not check that the `head` hash in a fork choice update shared a chain with the `safe` / `finalized` fields in the same fork choice update. This check is part of the [Engine API specs](https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#specification-1):

> Client software MUST return -38002: Invalid forkchoice state error if the payload referenced by forkchoiceState.headBlockHash is VALID and a payload referenced by either forkchoiceState.finalizedBlockHash or forkchoiceState.safeBlockHash does not belong to the chain defined by forkchoiceState.headBlockHash.

To accomplish this, two methods are added to `BlockchainTreeViewer`:
```rust
    /// Return whether or not the two block hashes share a chain. If either does not exist in the
    /// tree and are not part of the canonical chain, this should return `false`.
    fn share_chain(&self, first: &BlockHash, second: &BlockHash) -> Result<bool, Error>;

    /// Return whether or not the block is known to either the tree or is part of the canonical
    /// chain.
    fn is_block_known(&self, hash: &BlockHash) -> Result<bool, Error>;
```

Unlike other blockchain tree methods, the implementations of these methods need to access the tree externals (the DB), which is why they return a `Result`.

When rebased on #2441, this causes the `Inconsistent Head in ForkchoiceState` hive test to pass.

TODO: need a better name for `ensure_block_is_canonical` (confusing vs `BlockIndices::is_block_hash_canonical`)