### PR TITLE
feat(txpool): add update_basefee function

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -103,6 +103,7 @@ use reth_primitives::{Address, TxHash, U256};
 use reth_provider::StateProviderFactory;
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::mpsc::Receiver;
+use tracing::{instrument, trace};
 
 mod config;
 pub mod error;
@@ -163,6 +164,13 @@ where
     /// Get the config the pool was configured with.
     pub fn config(&self) -> &PoolConfig {
         self.inner().config()
+    }
+
+    /// Sets the current block info for the pool.
+    #[instrument(skip(self), target = "txpool")]
+    pub fn set_block_info(&self, info: BlockInfo) {
+        trace!(target: "txpool", "updating pool block info");
+        self.pool.set_block_info(info)
     }
 
     /// Returns future that validates all transaction in the given iterator.

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -150,6 +150,10 @@ where
     pub(crate) fn block_info(&self) -> BlockInfo {
         self.pool.read().block_info()
     }
+    /// Returns the currently tracked block
+    pub(crate) fn set_block_info(&self, info: BlockInfo) {
+        self.pool.write().set_block_info(info)
+    }
 
     /// Returns the internal `SenderId` for this address
     pub(crate) fn get_sender_id(&self, addr: Address) -> SenderId {

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -335,8 +335,10 @@ pub trait PoolTransaction:
 
     /// Returns the EIP-1559 Max base fee the caller is willing to pay.
     ///
-    /// This will return `None` for non-EIP1559 transactions
-    fn max_fee_per_gas(&self) -> Option<u128>;
+    /// For legacy transactions this is gas_price.
+    ///
+    /// This is also commonly referred to as the "Gas Fee Cap" (`GasFeeCap`).
+    fn max_fee_per_gas(&self) -> u128;
 
     /// Returns the EIP-1559 Priority fee the caller is paying to the block author.
     ///
@@ -425,12 +427,14 @@ impl PoolTransaction for PooledTransaction {
 
     /// Returns the EIP-1559 Max base fee the caller is willing to pay.
     ///
-    /// This will return `None` for non-EIP1559 transactions
-    fn max_fee_per_gas(&self) -> Option<u128> {
+    /// For legacy transactions this is gas_price.
+    ///
+    /// This is also commonly referred to as the "Gas Fee Cap" (`GasFeeCap`).
+    fn max_fee_per_gas(&self) -> u128 {
         match &self.transaction.transaction {
-            Transaction::Legacy(_) => None,
-            Transaction::Eip2930(_) => None,
-            Transaction::Eip1559(tx) => Some(tx.max_fee_per_gas),
+            Transaction::Legacy(tx) => tx.gas_price,
+            Transaction::Eip2930(tx) => tx.gas_price,
+            Transaction::Eip1559(tx) => tx.max_fee_per_gas,
         }
     }
 

--- a/crates/transaction-pool/src/validate.rs
+++ b/crates/transaction-pool/src/validate.rs
@@ -206,7 +206,7 @@ where
         }
 
         // Ensure max_priority_fee_per_gas (if EIP1559) is less than max_fee_per_gas if any.
-        if transaction.max_priority_fee_per_gas() > transaction.max_fee_per_gas() {
+        if transaction.max_priority_fee_per_gas() > Some(transaction.max_fee_per_gas()) {
             return TransactionValidationOutcome::Invalid(
                 transaction,
                 InvalidTransactionError::TipAboveFeeCap.into(),
@@ -335,8 +335,15 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
     }
 
     /// Returns the EIP-1559 Max base fee the caller is willing to pay.
-    pub fn max_fee_per_gas(&self) -> Option<u128> {
+    ///
+    ///  For legacy transactions this is gas_price.
+    pub fn max_fee_per_gas(&self) -> u128 {
         self.transaction.max_fee_per_gas()
+    }
+
+    /// Returns the EIP-1559 Max base fee the caller is willing to pay.
+    pub fn effective_gas_price(&self) -> u128 {
+        self.transaction.effective_gas_price()
     }
 
     /// Amount of gas that should be used in executing this transaction. This is paid up-front.


### PR DESCRIPTION
ref #2402 

adds a function to set the `BlockInfo` and a `update_basefee` function that enforces the basefee constraint by reshuffling transactions based on the change in basefee