### PR TITLE
chore: track client version in tx peer

### DIFF
--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -656,7 +656,7 @@ where
                             info!(
                                 target : "net",
                                 ?remote_addr,
-                                client_version,
+                                %client_version,
                                 ?peer_id,
                                 ?total_active,
                                 "Session established"
@@ -884,7 +884,7 @@ pub enum NetworkEvent {
         /// The remote addr of the peer to which a session was established.
         remote_addr: SocketAddr,
         /// The client version of the peer to which a session was established.
-        client_version: String,
+        client_version: Arc<String>,
         /// Capabilities the peer announced
         capabilities: Arc<Capabilities>,
         /// A request channel to the session task.

--- a/crates/net/network/src/session/handle.rs
+++ b/crates/net/network/src/session/handle.rs
@@ -62,7 +62,7 @@ pub(crate) struct ActiveSessionHandle {
     /// Sender half of the command channel used send commands _to_ the spawned session
     pub(crate) commands_to_session: mpsc::Sender<SessionCommand>,
     /// The client's name and version
-    pub(crate) client_version: String,
+    pub(crate) client_version: Arc<String>,
     /// The address we're connected to
     pub(crate) remote_addr: SocketAddr,
 }
@@ -85,7 +85,7 @@ pub struct PeerInfo {
     /// The identifier of the remote peer
     pub remote_id: PeerId,
     /// The client's name and version
-    pub client_version: String,
+    pub client_version: Arc<String>,
     /// The address we're connected to
     pub remote_addr: SocketAddr,
     /// The direction of the session

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -457,6 +457,7 @@ impl SessionManager {
 
                 self.spawn(session);
 
+                let client_version = Arc::new(client_id);
                 let handle = ActiveSessionHandle {
                     direction,
                     session_id,
@@ -465,7 +466,7 @@ impl SessionManager {
                     established: Instant::now(),
                     capabilities: Arc::clone(&capabilities),
                     commands_to_session,
-                    client_version: client_id.clone(),
+                    client_version: Arc::clone(&client_version),
                     remote_addr,
                 };
 
@@ -475,7 +476,7 @@ impl SessionManager {
                 Poll::Ready(SessionEvent::SessionEstablished {
                     peer_id,
                     remote_addr,
-                    client_version: client_id,
+                    client_version,
                     version,
                     capabilities,
                     status,
@@ -592,7 +593,7 @@ pub(crate) enum SessionEvent {
     SessionEstablished {
         peer_id: PeerId,
         remote_addr: SocketAddr,
-        client_version: String,
+        client_version: Arc<String>,
         capabilities: Arc<Capabilities>,
         /// negotiated eth version
         version: EthVersion,

--- a/crates/net/network/src/swarm.rs
+++ b/crates/net/network/src/swarm.rs
@@ -393,7 +393,7 @@ pub(crate) enum SwarmEvent {
     SessionEstablished {
         peer_id: PeerId,
         remote_addr: SocketAddr,
-        client_version: String,
+        client_version: Arc<String>,
         capabilities: Arc<Capabilities>,
         /// negotiated eth version
         version: EthVersion,

--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -349,7 +349,9 @@ where
                 // remove the peer
                 self.peers.remove(&peer_id);
             }
-            NetworkEvent::SessionEstablished { peer_id, messages, version, .. } => {
+            NetworkEvent::SessionEstablished {
+                peer_id, client_version, messages, version, ..
+            } => {
                 // insert a new peer into the peerset
                 self.peers.insert(
                     peer_id,
@@ -359,6 +361,7 @@ where
                         ),
                         request_tx: messages,
                         version,
+                        client_version,
                     },
                 );
 
@@ -685,6 +688,9 @@ struct Peer {
     request_tx: PeerRequestSender,
     /// negotiated version of the session.
     version: EthVersion,
+    /// The peer's client version.
+    #[allow(unused)]
+    client_version: Arc<String>,
 }
 
 /// Commands to send to the [`TransactionsManager`](crate::transactions::TransactionsManager)


### PR DESCRIPTION
track the peer's client version in the peer struct for future debugging how certain clients behave

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 82ecc92</samp>

This pull request optimizes the memory usage and logging of the `client_version` field in the network crate. It replaces `String` with `Arc` for the `client_version` field in several types and modules, and it uses the `Display` trait instead of the `Debug` trait for logging.