### PR TITLE
chore: misc blockchain tree

### DIFF
--- a/crates/blockchain-tree/src/block_indices.rs
+++ b/crates/blockchain-tree/src/block_indices.rs
@@ -266,7 +266,7 @@ impl BlockIndices {
     /// this is function that is going to remove N number of last canonical hashes.
     ///
     /// NOTE: This is not safe standalone, as it will not disconnect
-    /// blocks that deppends on unwinded canonical chain. And should be
+    /// blocks that depends on unwinded canonical chain. And should be
     /// used when canonical chain is reinserted inside Tree.
     pub(crate) fn unwind_canonical_chain(&mut self, unwind_to: BlockNumber) {
         // this will remove all blocks numbers that are going to be replaced.
@@ -316,8 +316,8 @@ impl BlockIndices {
     }
 
     /// get canonical hash
-    pub fn canonical_hash(&self, block_number: &BlockNumber) -> Option<BlockHash> {
-        self.canonical_chain.get(block_number).cloned()
+    pub fn canonical_hash(&self, block_number: BlockNumber) -> Option<BlockHash> {
+        self.canonical_chain.get(&block_number).cloned()
     }
 
     /// get canonical tip

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -221,7 +221,8 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
     }
 
     /// Try inserting block inside the tree.
-    /// If blocks does not have parent [`BlockStatus::Disconnected`] would be returned
+    ///
+    /// If blocks does not have parent [`BlockStatus::Disconnected`] would be returned.
     pub fn try_insert_block(
         &mut self,
         block: SealedBlockWithSenders,
@@ -274,7 +275,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
             }
         }
         // if not found, check if the parent can be found inside canonical chain.
-        if Some(block.parent_hash) == self.block_indices.canonical_hash(&(block.number - 1)) {
+        if Some(block.parent_hash) == self.block_indices.canonical_hash(block.number - 1) {
             // create new chain that points to that block
             //return self.fork_canonical_chain(block.clone());
             // TODO save pending block to database
@@ -370,7 +371,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
             }
             break
         }
-        (self.block_indices.canonical_hash(&fork.number) == Some(fork.hash)).then_some(fork)
+        (self.block_indices.canonical_hash(fork.number) == Some(fork.hash)).then_some(fork)
     }
 
     /// Insert a chain into the tree.
@@ -440,7 +441,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
         }
 
         // check if block is part of canonical chain
-        if self.block_indices.canonical_hash(&block.number) == Some(block.hash()) {
+        if self.block_indices.canonical_hash(block.number) == Some(block.hash()) {
             // block is part of canonical chain
             return Ok(BlockStatus::Valid)
         }
@@ -595,7 +596,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
 
             let canon_fork = new_canon_chain.fork_block();
             // sanity check
-            if self.block_indices.canonical_hash(&canon_fork.number) != Some(canon_fork.hash) {
+            if self.block_indices.canonical_hash(canon_fork.number) != Some(canon_fork.hash) {
                 unreachable!("all chains should point to canonical chain.");
             }
 

--- a/crates/blockchain-tree/src/chain.rs
+++ b/crates/blockchain-tree/src/chain.rs
@@ -160,7 +160,7 @@ impl AppendableChain {
     }
 
     /// Validate and execute the given block, and append it to this chain.
-    pub fn append_block<DB, C, EF>(
+    pub(crate) fn append_block<DB, C, EF>(
         &mut self,
         block: SealedBlockWithSenders,
         side_chain_block_hashes: BTreeMap<BlockNumber, BlockHash>,

--- a/crates/interfaces/src/blockchain_tree.rs
+++ b/crates/interfaces/src/blockchain_tree.rs
@@ -54,9 +54,9 @@ pub trait BlockchainTreeEngine: BlockchainTreeViewer + Send + Sync {
 }
 
 /// From Engine API spec, block inclusion can be valid, accepted or invalid.
-/// Invalid case is already covered by error but we needs to make distinction
+/// Invalid case is already covered by error, but we need to make distinction
 /// between if it is valid (extends canonical chain) or just accepted (is side chain).
-/// If we dont know the block parent we are returning Disconnected status
+/// If we don't know the block parent we are returning Disconnected status
 /// as we can't make a claim if block is valid or not.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum BlockStatus {

--- a/crates/interfaces/src/consensus.rs
+++ b/crates/interfaces/src/consensus.rs
@@ -13,7 +13,7 @@ pub use reth_rpc_types::engine::ForkchoiceState;
 pub trait Consensus: Debug + Send + Sync {
     /// Validate if header is correct and follows consensus specification.
     ///
-    /// This is called on standalone header to check if all hashe
+    /// This is called on standalone header to check if all hashes are correct.
     fn validate_header(&self, header: &SealedHeader) -> Result<(), ConsensusError>;
 
     /// Validate that the header information regarding parent are correct.


### PR DESCRIPTION
fix a few typos and change one occurrence from `&u64` to `u64`