### PR TITLE
fix: consider same timestamp as parent block invalid

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -533,6 +533,7 @@ mod tests {
         parent.gas_limit = 30000000;
         parent.base_fee_per_gas = Some(0x28041f7f5);
         parent.number -= 1;
+        parent.timestamp -= 1;
 
         let ommers = Vec::new();
         let body = Vec::new();

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -249,7 +249,7 @@ pub fn validate_header_regarding_parent(
     }
 
     // timestamp in past check
-    if child.timestamp < parent.timestamp {
+    if child.timestamp <= parent.timestamp {
         return Err(ConsensusError::TimestampIsInPast {
             parent_timestamp: parent.timestamp,
             timestamp: child.timestamp,

--- a/crates/interfaces/src/consensus.rs
+++ b/crates/interfaces/src/consensus.rs
@@ -59,7 +59,7 @@ pub trait Consensus: Debug + Send + Sync {
 #[allow(missing_docs)]
 #[derive(thiserror::Error, Debug, PartialEq, Eq, Clone)]
 pub enum ConsensusError {
-    #[error("Block used gas ({gas_used:?}) is greater than gas limit ({gas_limit:?}).")]
+    #[error("Block used gas ({gas_used}) is greater than gas limit ({gas_limit}).")]
     HeaderGasUsedExceedsGasLimit { gas_used: u64, gas_limit: u64 },
     #[error("Block ommer hash ({got:?}) is different from expected: ({expected:?})")]
     BodyOmmersHashDiff { got: H256, expected: H256 },
@@ -71,25 +71,27 @@ pub enum ConsensusError {
     BodyReceiptsRootDiff { got: H256, expected: H256 },
     #[error("Block withdrawals root ({got:?}) is different from expected ({expected:?})")]
     BodyWithdrawalsRootDiff { got: H256, expected: H256 },
-    #[error("Block with [hash:{hash:?},number: {number:}] is already known.")]
+    #[error("Block with [hash:{hash:?},number: {number}] is already known.")]
     BlockKnown { hash: BlockHash, number: BlockNumber },
     #[error("Block parent [hash:{hash:?}] is not known.")]
     ParentUnknown { hash: BlockHash },
-    #[error("Block number {block_number:?} is mismatch with parent block number {parent_block_number:?}")]
+    #[error(
+        "Block number {block_number} is mismatch with parent block number {parent_block_number}"
+    )]
     ParentBlockNumberMismatch { parent_block_number: BlockNumber, block_number: BlockNumber },
     #[error(
-    "Block timestamp {timestamp:?} is in past in comparison with parent timestamp {parent_timestamp:?}."
+    "Block timestamp {timestamp} is in the past compared to the parent timestamp {parent_timestamp}."
     )]
     TimestampIsInPast { parent_timestamp: u64, timestamp: u64 },
-    #[error("Block timestamp {timestamp:?} is in future in comparison of our clock time {present_timestamp:?}.")]
+    #[error("Block timestamp {timestamp} is in the future compared to our clock time {present_timestamp}.")]
     TimestampIsInFuture { timestamp: u64, present_timestamp: u64 },
-    #[error("Child gas_limit {child_gas_limit:?} max increase is {parent_gas_limit:?}/1024.")]
+    #[error("Child gas_limit {child_gas_limit} max increase is {parent_gas_limit}/1024.")]
     GasLimitInvalidIncrease { parent_gas_limit: u64, child_gas_limit: u64 },
-    #[error("Child gas_limit {child_gas_limit:?} max decrease is {parent_gas_limit:?}/1024.")]
+    #[error("Child gas_limit {child_gas_limit} max decrease is {parent_gas_limit}/1024.")]
     GasLimitInvalidDecrease { parent_gas_limit: u64, child_gas_limit: u64 },
     #[error("Base fee missing.")]
     BaseFeeMissing,
-    #[error("Block base fee ({got:?}) is different then expected: ({expected:?}).")]
+    #[error("Block base fee ({got}) is different then expected: ({expected}).")]
     BaseFeeDiff { expected: u64, got: u64 },
     #[error("Transaction signer recovery error.")]
     TransactionSignerRecoveryError,


### PR DESCRIPTION
cons `child.timestamp == parent.timestamp` as consensus error

ref 

https://github.com/ethereum/go-ethereum/blob/8f373227ac481685148019b21ef9e1478d3ba609/consensus/beacon/consensus.go#L239-L242