### PR TITLE
chore: add beacon nonce constant

### DIFF
--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -17,7 +17,8 @@ use reth_payload_builder::{
 use reth_primitives::{
     bytes::{Bytes, BytesMut},
     constants::{
-        EMPTY_RECEIPTS, EMPTY_TRANSACTIONS, EMPTY_WITHDRAWALS, RETH_CLIENT_VERSION, SLOT_DURATION,
+        BEACON_NONCE, EMPTY_RECEIPTS, EMPTY_TRANSACTIONS, EMPTY_WITHDRAWALS, RETH_CLIENT_VERSION,
+        SLOT_DURATION,
     },
     proofs, Block, BlockNumberOrTag, ChainSpec, Header, IntoRecoveredTransaction, Receipt,
     SealedBlock, Withdrawal, EMPTY_OMMER_ROOT, H256, U256,
@@ -593,7 +594,7 @@ fn build_payload<Pool, Client>(
             logs_bloom,
             timestamp: attributes.timestamp,
             mix_hash: attributes.prev_randao,
-            nonce: 0,
+            nonce: BEACON_NONCE,
             base_fee_per_gas: Some(base_fee),
             number: parent_block.number + 1,
             gas_limit: block_gas_limit,
@@ -661,7 +662,7 @@ where
         logs_bloom: Default::default(),
         timestamp: attributes.timestamp,
         mix_hash: attributes.prev_randao,
-        nonce: 0,
+        nonce: BEACON_NONCE,
         base_fee_per_gas: Some(base_fee),
         number: parent_block.number + 1,
         gas_limit: block_gas_limit,

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -19,6 +19,9 @@ pub const SLOT_DURATION: Duration = Duration::from_secs(12);
 /// An EPOCH is a series of 32 slots (~6.4min).
 pub const EPOCH_DURATION: Duration = Duration::from_secs(12 * 32);
 
+/// The default block nonce in the beacon consensus
+pub const BEACON_NONCE: u64 = 0u64;
+
 /// The minimal value the basefee can decrease to.
 ///
 /// The `BASE_FEE_MAX_CHANGE_DENOMINATOR` <https://eips.ethereum.org/EIPS/eip-1559> is `8`, or 12.5%.


### PR DESCRIPTION
ref #2455

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4a9fb26</samp>

Added support for beacon consensus in the payload basic crate. Defined a `BEACON_NONCE` constant in the `constants` module and used it in `crates/payload/basic/src/lib.rs`.