### PR TITLE
fix: restrict start block correctly

### DIFF
--- a/crates/primitives/src/chain/info.rs
+++ b/crates/primitives/src/chain/info.rs
@@ -1,7 +1,7 @@
 use crate::{BlockNumber, BlockNumberOrTag, H256};
 
 /// Current status of the blockchain's head.
-#[derive(Default, Debug, Eq, PartialEq)]
+#[derive(Default, Clone, Debug, Eq, PartialEq)]
 pub struct ChainInfo {
     /// The block hash of the highest fully synced block.
     pub best_hash: H256,


### PR DESCRIPTION
ref https://github.com/paradigmxyz/reth/issues/2457

fixes a condition where the start block was restricted incorrectly, resulting in empty ranges

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 069a46c</samp>

Fixed a log filter bug and added unit tests in `logs_utils.rs`. Enabled cloning of `ChainInfo` struct to support the bug fix.