### PR TITLE
docs: fix comment about range restrictions

### DIFF
--- a/crates/rpc/rpc/src/eth/logs_utils.rs
+++ b/crates/rpc/rpc/src/eth/logs_utils.rs
@@ -81,18 +81,19 @@ pub(crate) fn get_filter_block_range(
     let mut from_block_number = start_block;
     let mut to_block_number = info.best_number;
 
-    // from block is maximum of block from last poll or `from_block` of filter
+    // if a `from_block` argument is provided then the `from_block_number` is the converted value or
+    // the start block if the converted value is larger than the start block, since `from_block`
+    // can't be a future block: `min(head, from_block)`
     if let Some(filter_from_block) = from_block.and_then(|num| info.convert_block_number(num)) {
         from_block_number = start_block.min(filter_from_block)
     }
 
-    // to block is max the best number
+    // upper end of the range is the converted `to_block` argument, restricted by the best block:
+    // `min(best_number,to_block_number)`
     if let Some(filter_to_block) = to_block.and_then(|num| info.convert_block_number(num)) {
-        to_block_number = filter_to_block;
-        if to_block_number > info.best_number {
-            to_block_number = info.best_number;
-        }
+        to_block_number = info.best_number.min(filter_to_block);
     }
+
     (from_block_number, to_block_number)
 }
 


### PR DESCRIPTION
followup #2460 which adds suggestions from @Rjected 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a6d40c5</samp>

Refactor and simplify the logic of `logs_utils.rs` for querying logs by block range. Remove unnecessary check and use `min` function to avoid querying past the best block.