### PR TITLE
feat: add helper for accessing pending block object

### DIFF
--- a/crates/blockchain-tree/src/block_indices.rs
+++ b/crates/blockchain-tree/src/block_indices.rs
@@ -59,6 +59,14 @@ impl BlockIndices {
         &self.blocks_to_chain
     }
 
+    /// Returns the hash and number of the pending block (the first block in the
+    /// [Self::pending_blocks]) set.
+    pub fn pending_block_num_hash(&self) -> Option<BlockNumHash> {
+        let canonical_tip = self.canonical_tip();
+        let hash = self.fork_to_child.get(&canonical_tip.hash)?.iter().next().copied()?;
+        Some(BlockNumHash { number: canonical_tip.number + 1, hash })
+    }
+
     /// Return all pending block hashes. Pending blocks are considered blocks
     /// that are extending that canonical tip by one block number.
     pub fn pending_blocks(&self) -> (BlockNumber, Vec<BlockHash>) {

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -163,6 +163,12 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
         chain.block(block_hash)
     }
 
+    /// Returns the block that's considered the `Pending` block, if it exists.
+    pub fn pending_block(&self) -> Option<&SealedBlock> {
+        let b = self.block_indices.pending_block_num_hash()?;
+        self.block_by_hash(b.hash)
+    }
+
     /// Return items needed to execute on the pending state.
     /// This includes:
     ///     * `BlockHash` of canonical block that chain connects to. Needed for creating database
@@ -888,7 +894,7 @@ mod tests {
         let externals = setup_externals(vec![exec2.clone(), exec1.clone(), exec2, exec1]);
 
         // last finalized block would be number 9.
-        setup_genesis(externals.db.clone(), genesis.clone());
+        setup_genesis(externals.db.clone(), genesis);
 
         // make tree
         let config = BlockchainTreeConfig::new(1, 2, 3, 2);

--- a/crates/blockchain-tree/src/shareable.rs
+++ b/crates/blockchain-tree/src/shareable.rs
@@ -102,10 +102,14 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeViewer
         self.tree.read().block_indices().pending_blocks()
     }
 
-    fn pending_block(&self) -> Option<BlockNumHash> {
+    fn pending_block_num_hash(&self) -> Option<BlockNumHash> {
         trace!(target: "blockchain_tree", "Returning first pending block");
-        let (number, blocks) = self.tree.read().block_indices().pending_blocks();
-        blocks.first().map(|&hash| BlockNumHash { number, hash })
+        self.tree.read().block_indices().pending_block_num_hash()
+    }
+
+    fn pending_block(&self) -> Option<SealedBlock> {
+        trace!(target: "blockchain_tree", "Returning first pending block");
+        self.tree.read().pending_block().cloned()
     }
 }
 

--- a/crates/interfaces/src/blockchain_tree.rs
+++ b/crates/interfaces/src/blockchain_tree.rs
@@ -105,5 +105,10 @@ pub trait BlockchainTreeViewer: Send + Sync {
     /// Return block hashes that extends the canonical chain tip by one.
     ///
     /// If there is no such block, return `None`.
-    fn pending_block(&self) -> Option<BlockNumHash>;
+    fn pending_block_num_hash(&self) -> Option<BlockNumHash>;
+
+    /// Returns the pending block if there is one.
+    fn pending_block(&self) -> Option<SealedBlock> {
+        self.block_by_hash(self.pending_block_num_hash()?.hash)
+    }
 }


### PR DESCRIPTION
add helper function that returns the block object

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c26d07e</samp>

This pull request adds and updates methods to access the pending block data in the `BlockchainTreeProvider` and `BlockchainProvider` traits and their implementations. This improves the performance, correctness, and simplicity of the code that depends on the pending block information. The pull request also fixes a typo in the test code of `crates/blockchain-tree/src/blockchain_tree.rs`.


@rakita 

there is no order here, so `pending` block is actually random (if there are more than 1)

https://github.com/paradigmxyz/reth/blob/c26d07eaa341de2644a42b6d0fc01041f761f6b9/crates/blockchain-tree/src/block_indices.rs#L22-L24

but we also don't know which one will be next, so I guess this seems fine?