### PR TITLE
feat: add metrics for already seen txs and hashes

### DIFF
--- a/crates/net/network/src/metrics.rs
+++ b/crates/net/network/src/metrics.rs
@@ -45,6 +45,10 @@ pub struct TransactionsManagerMetrics {
     pub(crate) propagated_transactions: Counter,
     /// Total number of reported bad transactions
     pub(crate) reported_bad_transactions: Counter,
+    /// Total number of messages with already seen hashes
+    pub(crate) messages_with_already_seen_hashes: Counter,
+    /// Total number of messages with already seen full transactions
+    pub(crate) messages_with_already_seen_transactions: Counter,
 }
 
 /// Metrics for Disconnection types


### PR DESCRIPTION
helper metrics to monitor #2451

> A node should never send a transaction back to a peer that it can determine already knows of it (either because it was previously sent or because it was informed from this peer originally). This is usually achieved by remembering a set of transaction hashes recently relayed by the peer.

not sure how well enforced this actually is

adds metrics to monitor the number of received messages that contain already-seen info