### PR TITLE
feat(rpc): add impls for gasprice and max priority fee

### DIFF
--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -155,6 +155,12 @@ impl SealedBlock {
     }
 }
 
+impl From<SealedBlock> for Block {
+    fn from(block: SealedBlock) -> Self {
+        block.unseal()
+    }
+}
+
 impl Deref for SealedBlock {
     type Target = SealedHeader;
     fn deref(&self) -> &Self::Target {

--- a/crates/rpc/rpc-api/src/eth.rs
+++ b/crates/rpc/rpc-api/src/eth.rs
@@ -176,6 +176,10 @@ pub trait EthApi {
     #[method(name = "eth_gasPrice")]
     async fn gas_price(&self) -> Result<U256>;
 
+    /// Introduced in EIP-1159, returns suggestion for the priority for dynamic fee transactions.
+    #[method(name = "eth_maxPriorityFeePerGas")]
+    async fn max_priority_fee_per_gas(&self) -> Result<U256>;
+
     /// Returns the Transaction fee history
     ///
     /// Introduced in EIP-1159 for getting information on the appropriate priority fee to use.
@@ -190,10 +194,6 @@ pub trait EthApi {
         newest_block: BlockId,
         reward_percentiles: Option<Vec<f64>>,
     ) -> Result<FeeHistory>;
-
-    /// Returns the current maxPriorityFeePerGas per gas in wei.
-    #[method(name = "eth_maxPriorityFeePerGas")]
-    async fn max_priority_fee_per_gas(&self) -> Result<U256>;
 
     /// Returns whether the client is actively mining new blocks.
     #[method(name = "eth_mining")]

--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -97,14 +97,14 @@ where
     EthApiClient::send_transaction(client, transaction_request).await.unwrap_err();
     EthApiClient::hashrate(client).await.unwrap();
     EthApiClient::submit_hashrate(client, U256::default(), H256::default()).await.unwrap();
+    EthApiClient::gas_price(client).await.unwrap();
+    EthApiClient::max_priority_fee_per_gas(client).await.unwrap();
 
     // Unimplemented
     assert!(is_unimplemented(
         EthApiClient::get_proof(client, address, vec![], None).await.err().unwrap()
     ));
     assert!(is_unimplemented(EthApiClient::author(client).await.err().unwrap()));
-    assert!(is_unimplemented(EthApiClient::gas_price(client).await.err().unwrap()));
-    assert!(is_unimplemented(EthApiClient::max_priority_fee_per_gas(client).await.err().unwrap()));
     assert!(is_unimplemented(EthApiClient::is_mining(client).await.err().unwrap()));
     assert!(is_unimplemented(EthApiClient::get_work(client).await.err().unwrap()));
     assert!(is_unimplemented(

--- a/crates/rpc/rpc/src/eth/api/block.rs
+++ b/crates/rpc/rpc/src/eth/api/block.rs
@@ -56,15 +56,19 @@ where
         Ok(self.cache().get_block_transactions(block_hash).await?.map(|txs| txs.len()))
     }
 
-    /// Returns the rpc block object for the given block id.
-    ///
-    /// If `full` is true, the block object will contain all transaction objects, otherwise it will
-    /// only contain the transaction hashes.
+    /// Returns the block header for the given block id.
+    pub(crate) async fn header(
+        &self,
+        block_id: impl Into<BlockId>,
+    ) -> EthResult<Option<reth_primitives::SealedHeader>> {
+        Ok(self.block(block_id).await?.map(|block| block.header))
+    }
+
+    /// Returns the block object for the given block id.
     pub(crate) async fn block(
         &self,
         block_id: impl Into<BlockId>,
-        full: bool,
-    ) -> EthResult<Option<RichBlock>> {
+    ) -> EthResult<Option<reth_primitives::SealedBlock>> {
         let block_id = block_id.into();
         // TODO support pending block
         let block_hash = match self.client().block_hash_for_id(block_id)? {
@@ -72,14 +76,27 @@ where
             None => return Ok(None),
         };
 
-        let block = match self.cache().get_block(block_hash).await? {
+        Ok(self.cache().get_block(block_hash).await?.map(|block| block.seal(block_hash)))
+    }
+
+    /// Returns the populated rpc block object for the given block id.
+    ///
+    /// If `full` is true, the block object will contain all transaction objects, otherwise it will
+    /// only contain the transaction hashes.
+    pub(crate) async fn rpc_block(
+        &self,
+        block_id: impl Into<BlockId>,
+        full: bool,
+    ) -> EthResult<Option<RichBlock>> {
+        let block = match self.block(block_id).await? {
             Some(block) => block,
             None => return Ok(None),
         };
-
+        let block_hash = block.hash;
         let total_difficulty =
             self.client().header_td(&block_hash)?.ok_or(EthApiError::UnknownBlockNumber)?;
-        let block = Block::from_block(block, total_difficulty, full.into(), Some(block_hash))?;
+        let block =
+            Block::from_block(block.into(), total_difficulty, full.into(), Some(block_hash))?;
         Ok(Some(block.into()))
     }
 }

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -73,7 +73,7 @@ where
     /// Handler for: `eth_getBlockByHash`
     async fn block_by_hash(&self, hash: H256, full: bool) -> Result<Option<RichBlock>> {
         trace!(target: "rpc::eth", ?hash, ?full, "Serving eth_getBlockByHash");
-        Ok(EthApi::block(self, hash, full).await?)
+        Ok(EthApi::rpc_block(self, hash, full).await?)
     }
 
     /// Handler for: `eth_getBlockByNumber`
@@ -83,7 +83,7 @@ where
         full: bool,
     ) -> Result<Option<RichBlock>> {
         trace!(target: "rpc::eth", ?number, ?full, "Serving eth_getBlockByNumber");
-        Ok(EthApi::block(self, number, full).await?)
+        Ok(EthApi::rpc_block(self, number, full).await?)
     }
 
     /// Handler for: `eth_getBlockTransactionCountByHash`
@@ -248,7 +248,14 @@ where
 
     /// Handler for: `eth_gasPrice`
     async fn gas_price(&self) -> Result<U256> {
-        Err(internal_rpc_err("unimplemented"))
+        trace!(target: "rpc::eth", "Serving eth_gasPrice");
+        return Ok(EthApi::gas_price(self).await?)
+    }
+
+    /// Handler for: `eth_maxPriorityFeePerGas`
+    async fn max_priority_fee_per_gas(&self) -> Result<U256> {
+        trace!(target: "rpc::eth", "Serving eth_maxPriorityFeePerGas");
+        return Ok(EthApi::suggested_priority_fee(self).await?)
     }
 
     // FeeHistory is calculated based on lazy evaluation of fees for historical blocks, and further
@@ -269,11 +276,6 @@ where
         trace!(target: "rpc::eth", ?block_count, ?newest_block, ?reward_percentiles, "Serving eth_feeHistory");
         return Ok(EthApi::fee_history(self, block_count.as_u64(), newest_block, reward_percentiles)
             .await?)
-    }
-
-    /// Handler for: `eth_maxPriorityFeePerGas`
-    async fn max_priority_fee_per_gas(&self) -> Result<U256> {
-        Err(internal_rpc_err("unimplemented"))
     }
 
     /// Handler for: `eth_mining`


### PR DESCRIPTION
ref #2470

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d270c85</samp>

This pull request adds support for the EIP-1559 fee market and dynamic fee transactions to the RPC API, and refactors some of the block-related methods and types. It introduces a new `eth_maxPriorityFeePerGas` RPC method, and implements the `gas_price` and `suggested_priority_fee` methods for the `EthFeesApi` trait. It also splits the `block` method of the `EthApi` trait into `header` and `block`, and adds a `rpc_block` method that returns a full RPC block object. Additionally, it implements the `From<SealedBlock>` trait for the `Block` type, which simplifies the conversion of blocks from different sources.

adds impl of `eth_gasPrice`, ref: https://github.com/ethereum/go-ethereum/blob/8f373227ac481685148019b21ef9e1478d3ba609/internal/ethapi/api.go#L62-L72

and a shim for `max priority fee` which is implemented here

https://github.com/ethereum/go-ethereum/blob/8f373227ac481685148019b21ef9e1478d3ba609/eth/gasprice/gasprice.go#L144-L150

ref https://github.com/ethereum/pm/issues/328#issuecomment-853234014