### PR TITLE
chore(engine): move head lookup for building

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -274,13 +274,12 @@ where
                         self.require_pipeline_run(PipelineTarget::Head);
                     }
 
-                    // get header for further validation
-                    let header = self
-                        .db
-                        .view(|tx| tx.get::<tables::Headers>(head_block_number))??
-                        .expect("was canonicalized, so it exists");
-
                     if let Some(attrs) = attrs {
+                        // get header for further validation
+                        let header = self
+                            .db
+                            .view(|tx| tx.get::<tables::Headers>(head_block_number))??
+                            .expect("was canonicalized, so it exists");
                         return Ok(self.process_payload_attributes(attrs, header, state))
                     }
 


### PR DESCRIPTION
Do not lookup header for head unless the payload attributes are provided