### PR TITLE
feat: add Resolve Payload function

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -29,4 +29,4 @@ pub mod test_utils;
 pub use payload::{BuiltPayload, PayloadBuilderAttributes};
 pub use reth_rpc_types::engine::PayloadId;
 pub use service::{PayloadBuilderHandle, PayloadBuilderService, PayloadStore};
-pub use traits::{PayloadJob, PayloadJobGenerator};
+pub use traits::{KeepPayloadJobAlive, PayloadJob, PayloadJobGenerator};


### PR DESCRIPTION
ref #2469

adds `[PayloadJob::resolve]` that will be invoked on `engine_getPayload` which may or may not terminate the job.

this returns a future which will be awaited by the rpc handler.
This gives the implementer a bit more control over the 1s timeout (but ideally) this sync and races where in progress finishes before we the empty payload result is ready.

The reference impl checks:
* If the in progress payload job return is available when the future is called and is a better payload, return this
* otherwise return the current best payload

if no best payload has been built yet, this is a select over `empty,inprogress`, whatever finishes first.


needs followup to integrate with RPC