### PR TITLE
refactor: roll custom canon state notification stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5158,6 +5158,7 @@ dependencies = [
  "auto_impl",
  "itertools",
  "parking_lot 0.12.1",
+ "pin-project",
  "reth-db",
  "reth-interfaces",
  "reth-primitives",

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -205,8 +205,6 @@ impl Command {
             ctx.task_executor.spawn_critical(
                 "txpool maintenance task",
                 Box::pin(async move {
-                    let chain_events = chain_events.filter_map(|event| async move { event.ok() });
-                    pin_mut!(chain_events);
                     reth_transaction_pool::maintain::maintain_transaction_pool(
                         client,
                         pool,

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -26,6 +26,7 @@ tracing = "0.1"
 thiserror = "1.0.37"
 auto_impl = "1.0"
 itertools = "0.10"
+pin-project = "1.0"
 
 # test-utils
 reth-rlp = { path = "../../rlp", optional = true }


### PR DESCRIPTION
`BroadcastStream` yields results, err if it lags behind, which makes it inconvenient to use.


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e7c6965</samp>

The pull request introduces a new `CanonStateNotificationStream` type that wraps a `BroadcastStream` of canonical state notifications and handles its errors. It also adds the `pin-project` dependency to the `storage-provider` crate, which is used to implement the `Stream` trait for the new type.