### PR TITLE
feat: use `HashBuilder` for proofs

### DIFF
--- a/crates/primitives/src/proofs.rs
+++ b/crates/primitives/src/proofs.rs
@@ -72,6 +72,7 @@ pub fn calculate_receipt_root<'a>(receipts: impl Iterator<Item = &'a ReceiptWith
 pub fn calculate_receipt_root_ref<'a>(
     receipts: impl Iterator<Item = ReceiptWithBloomRef<'a>>,
 ) -> H256 {
+    // todo
     ordered_trie_root::<KeccakHasher, _>(receipts.into_iter().map(|receipt| {
         let mut receipt_rlp = Vec::new();
         receipt.encode_inner(&mut receipt_rlp, false);

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -18,6 +18,10 @@ reth-consensus-common = { path = "../consensus/common" }
 # revm
 revm = { version = "3" }
 
+# todo: this should probably not be here, instead the fn to calculate receipts root should be adjusted in the prims crate
+reth-trie = { path = "../trie" }
+reth-rlp = { path = "../rlp" }
+
 # common
 tracing = "0.1.37"
 


### PR DESCRIPTION
Replaces `ordered_trie_root` where possible with `HashBuilder` since we have more control over how it works and therefore it's performance.

**Todo**

This is spun out of #2487 and I want to replace the impl in `primitives/src/proofs.rs`, but this requires moving the trie impl around a bit first