### PR TITLE
feat: gas based commits

### DIFF
--- a/bin/reth/src/chain/import.rs
+++ b/bin/reth/src/chain/import.rs
@@ -24,7 +24,10 @@ use reth_staged_sync::{
 };
 use reth_stages::{
     prelude::*,
-    stages::{ExecutionStage, HeaderSyncMode, SenderRecoveryStage, TotalDifficultyStage},
+    stages::{
+        ExecutionStage, ExecutionStageThresholds, HeaderSyncMode, SenderRecoveryStage,
+        TotalDifficultyStage,
+    },
 };
 use std::sync::Arc;
 use tokio::sync::watch;
@@ -162,7 +165,14 @@ impl ImportCommand {
                 .set(SenderRecoveryStage {
                     commit_threshold: config.stages.sender_recovery.commit_threshold,
                 })
-                .set(ExecutionStage::new(factory, config.stages.execution.commit_threshold)),
+                .set(ExecutionStage::new(
+                    factory,
+                    ExecutionStageThresholds {
+                        max_blocks: config.stages.execution.max_blocks,
+                        max_gas: config.stages.execution.max_gas,
+                        changeset_max_gas: config.stages.execution.changeset_max_gas,
+                    },
+                )),
             )
             .with_max_block(0)
             .build();

--- a/bin/reth/src/dump_stage/merkle.rs
+++ b/bin/reth/src/dump_stage/merkle.rs
@@ -8,7 +8,10 @@ use reth_db::{database::Database, table::TableImporter, tables};
 use reth_primitives::{BlockNumber, MAINNET};
 use reth_provider::Transaction;
 use reth_stages::{
-    stages::{AccountHashingStage, ExecutionStage, MerkleStage, StorageHashingStage},
+    stages::{
+        AccountHashingStage, ExecutionStage, ExecutionStageThresholds, MerkleStage,
+        StorageHashingStage,
+    },
     Stage, StageId, UnwindInput,
 };
 use std::{ops::DerefMut, sync::Arc};
@@ -62,8 +65,14 @@ async fn unwind_and_copy<DB: Database>(
     MerkleStage::default_unwind().unwind(&mut unwind_tx, unwind).await?;
 
     // Bring Plainstate to TO (hashing stage execution requires it)
-    let mut exec_stage =
-        ExecutionStage::new(reth_revm::Factory::new(Arc::new(MAINNET.clone())), u64::MAX);
+    let mut exec_stage = ExecutionStage::new(
+        reth_revm::Factory::new(Arc::new(MAINNET.clone())),
+        ExecutionStageThresholds {
+            max_blocks: Some(u64::MAX),
+            max_gas: None,
+            changeset_max_gas: None,
+        },
+    );
 
     exec_stage
         .unwind(

--- a/bin/reth/src/merkle_debug.rs
+++ b/bin/reth/src/merkle_debug.rs
@@ -7,8 +7,9 @@ use reth_provider::Transaction;
 use reth_staged_sync::utils::{chainspec::genesis_value_parser, init::init_db};
 use reth_stages::{
     stages::{
-        AccountHashingStage, ExecutionStage, MerkleStage, StorageHashingStage, ACCOUNT_HASHING,
-        EXECUTION, MERKLE_EXECUTION, SENDER_RECOVERY, STORAGE_HASHING,
+        AccountHashingStage, ExecutionStage, ExecutionStageThresholds, MerkleStage,
+        StorageHashingStage, ACCOUNT_HASHING, EXECUTION, MERKLE_EXECUTION, SENDER_RECOVERY,
+        STORAGE_HASHING,
     },
     ExecInput, Stage,
 };
@@ -74,8 +75,14 @@ impl Command {
                 MERKLE_EXECUTION.get_progress(tx.deref())?.unwrap_or_default());
 
         let factory = reth_revm::Factory::new(self.chain.clone());
-        let mut execution_stage = ExecutionStage::new(factory, 1);
-
+        let mut execution_stage = ExecutionStage::new(
+            factory,
+            ExecutionStageThresholds {
+                max_blocks: Some(1),
+                max_gas: None,
+                changeset_max_gas: None,
+            },
+        );
         let mut account_hashing_stage = AccountHashingStage::default();
         let mut storage_hashing_stage = StorageHashingStage::default();
         let mut merkle_stage = MerkleStage::default_execution();

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -71,7 +71,7 @@ use crate::dirs::MaybePlatformPath;
 use reth_interfaces::p2p::headers::client::HeadersClient;
 use reth_payload_builder::PayloadBuilderService;
 use reth_provider::providers::BlockchainProvider;
-use reth_stages::stages::{MERKLE_EXECUTION, MERKLE_UNWIND};
+use reth_stages::stages::{ExecutionStageThresholds, MERKLE_EXECUTION, MERKLE_UNWIND};
 
 pub mod events;
 
@@ -662,7 +662,14 @@ impl Command {
                 .set(SenderRecoveryStage {
                     commit_threshold: stage_conf.sender_recovery.commit_threshold,
                 })
-                .set(ExecutionStage::new(factory, stage_conf.execution.commit_threshold))
+                .set(ExecutionStage::new(
+                    factory,
+                    ExecutionStageThresholds {
+                        max_blocks: stage_conf.execution.max_blocks,
+                        max_gas: stage_conf.execution.max_gas,
+                        changeset_max_gas: stage_conf.execution.changeset_max_gas,
+                    },
+                ))
                 .disable_if(MERKLE_UNWIND, || self.auto_mine)
                 .disable_if(MERKLE_EXECUTION, || self.auto_mine),
             )

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -16,7 +16,10 @@ use reth_staged_sync::{
     Config,
 };
 use reth_stages::{
-    stages::{BodyStage, ExecutionStage, MerkleStage, SenderRecoveryStage, TransactionLookupStage},
+    stages::{
+        BodyStage, ExecutionStage, ExecutionStageThresholds, MerkleStage, SenderRecoveryStage,
+        TransactionLookupStage,
+    },
     ExecInput, Stage, StageId, UnwindInput,
 };
 use std::{net::SocketAddr, sync::Arc};
@@ -177,7 +180,14 @@ impl Command {
             }
             StageEnum::Execution => {
                 let factory = reth_revm::Factory::new(self.chain.clone());
-                let mut stage = ExecutionStage::new(factory, num_blocks);
+                let mut stage = ExecutionStage::new(
+                    factory,
+                    ExecutionStageThresholds {
+                        max_blocks: Some(num_blocks),
+                        max_gas: None,
+                        changeset_max_gas: None,
+                    },
+                );
                 if !self.skip_unwind {
                     stage.unwind(&mut tx, unwind).await?;
                 }

--- a/bin/reth/src/test_eth_chain/runner.rs
+++ b/bin/reth/src/test_eth_chain/runner.rs
@@ -193,7 +193,7 @@ pub async fn run_test(path: PathBuf) -> eyre::Result<TestOutcome> {
         // Initialize the execution stage
         // Hardcode the chain_id to Ethereum 1.
         let factory = reth_revm::Factory::new(Arc::new(chain_spec));
-        let mut stage = ExecutionStage::new(factory, 1_000);
+        let mut stage = ExecutionStage::new_with_factory(factory);
 
         // Call execution stage
         let input = ExecInput {

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -50,6 +50,9 @@ pub const FINNEY_TO_WEI: u128 = (GWEI_TO_WEI as u128) * 1_000_000;
 /// Multiplier for converting ether to wei.
 pub const ETH_TO_WEI: u128 = FINNEY_TO_WEI * 1000;
 
+/// Multiplier for converting mgas to gas.
+pub const MGAS_TO_GAS: u64 = 1_000_000u64;
+
 /// The Ethereum mainnet genesis hash.
 pub const MAINNET_GENESIS: H256 =
     H256(hex!("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"));

--- a/crates/staged-sync/src/config.rs
+++ b/crates/staged-sync/src/config.rs
@@ -5,6 +5,7 @@ use reth_downloaders::{
     headers::reverse_headers::ReverseHeadersDownloaderBuilder,
 };
 use reth_network::{NetworkConfigBuilder, PeersConfig, SessionsConfig};
+use reth_primitives::constants::MGAS_TO_GAS;
 use secp256k1::SecretKey;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -151,16 +152,30 @@ impl Default for SenderRecoveryConfig {
     }
 }
 
+// TODO: Replace this with a tuple struct just wrapping `ExecutionStageThresholds` in the
+// `reth-stages` crate.
 /// Execution stage configuration.
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Serialize)]
 pub struct ExecutionConfig {
-    /// The maximum number of blocks to execution before committing progress to the database.
-    pub commit_threshold: u64,
+    /// The maximum number of blocks to process before the execution stage commits.
+    pub max_blocks: Option<u64>,
+    /// The maximum amount of gas to process before the execution stage commits.
+    pub max_gas: Option<u64>,
+    /// The maximum amount of gas to processed before changesets are written to the pending
+    /// database transaction.
+    ///
+    /// If this is lower than `max_gas`, then history is periodically flushed to the database
+    /// transaction, which frees up memory.
+    pub changeset_max_gas: Option<u64>,
 }
 
 impl Default for ExecutionConfig {
     fn default() -> Self {
-        Self { commit_threshold: 5_000 }
+        Self {
+            max_blocks: Some(500_000),
+            max_gas: Some(2000 * MGAS_TO_GAS),
+            changeset_max_gas: Some(250 * MGAS_TO_GAS),
+        }
     }
 }
 

--- a/crates/stages/src/sets.rs
+++ b/crates/stages/src/sets.rs
@@ -247,7 +247,7 @@ impl<EF: ExecutorFactory, DB: Database> StageSet<DB> for ExecutionStages<EF> {
     fn builder(self) -> StageSetBuilder<DB> {
         StageSetBuilder::default()
             .add_stage(SenderRecoveryStage::default())
-            .add_stage(ExecutionStage::new(self.executor_factory, 10_000))
+            .add_stage(ExecutionStage::new_with_factory(self.executor_factory))
     }
 }
 


### PR DESCRIPTION
Allows the execution stage to commit based on amount of gas processed, while retaining the ability to also commit based on block ranges.

This PR also allows operators to periodically write changesets to the DB w/o writing plain state. This reduces the amount of memory needed to run the stage, since the largest memory consumer in this stage is the storage of changesets.

From running locally, this gives a performance boost since the stage only commits if there are relevant changes, but also uses less memory. For example, with this change, empty block ranges are not committed just to commit, they are commited only if they are the last range of blocks, or if enough gas has been processed.

Theoretically this should also make commit intervals more predictable in terms of time, since the amount of time (ideally) to process 1 million gas worth of operations should be somewhat constant. This is not really the case because of hardforks, but also because of e.g. the DOS range

Pulled from #2487, so some changes in this PR are shared