### PR TITLE
feat(execution): state change size based commits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5160,6 +5160,7 @@ name = "reth-provider"
 version = "0.1.0"
 dependencies = [
  "auto_impl",
+ "derive_more",
  "itertools",
  "parking_lot 0.12.1",
  "pin-project",

--- a/bin/reth/src/chain/import.rs
+++ b/bin/reth/src/chain/import.rs
@@ -22,7 +22,10 @@ use reth_staged_sync::{
 };
 use reth_stages::{
     prelude::*,
-    stages::{ExecutionStage, HeaderSyncMode, SenderRecoveryStage, TotalDifficultyStage},
+    stages::{
+        ExecutionStage, ExecutionStageThresholds, HeaderSyncMode, SenderRecoveryStage,
+        TotalDifficultyStage,
+    },
 };
 use std::{path::PathBuf, sync::Arc};
 use tokio::sync::watch;
@@ -169,7 +172,14 @@ impl ImportCommand {
                 .set(SenderRecoveryStage {
                     commit_threshold: config.stages.sender_recovery.commit_threshold,
                 })
-                .set(ExecutionStage::new(factory, config.stages.execution.commit_threshold)),
+                .set(ExecutionStage::new(
+                    factory,
+                    ExecutionStageThresholds {
+                        max_blocks: config.stages.execution.max_blocks,
+                        max_changes: config.stages.execution.max_changes,
+                        max_changesets: config.stages.execution.max_changesets,
+                    },
+                )),
             )
             .build();
 

--- a/bin/reth/src/merkle_debug.rs
+++ b/bin/reth/src/merkle_debug.rs
@@ -7,8 +7,9 @@ use reth_provider::Transaction;
 use reth_staged_sync::utils::{chainspec::genesis_value_parser, init::init_db};
 use reth_stages::{
     stages::{
-        AccountHashingStage, ExecutionStage, MerkleStage, StorageHashingStage, ACCOUNT_HASHING,
-        EXECUTION, MERKLE_EXECUTION, SENDER_RECOVERY, STORAGE_HASHING,
+        AccountHashingStage, ExecutionStage, ExecutionStageThresholds, MerkleStage,
+        StorageHashingStage, ACCOUNT_HASHING, EXECUTION, MERKLE_EXECUTION, SENDER_RECOVERY,
+        STORAGE_HASHING,
     },
     ExecInput, Stage,
 };
@@ -82,7 +83,14 @@ impl Command {
                 MERKLE_EXECUTION.get_progress(tx.deref())?.unwrap_or_default());
 
         let factory = reth_revm::Factory::new(self.chain.clone());
-        let mut execution_stage = ExecutionStage::new(factory, 1);
+        let mut execution_stage = ExecutionStage::new(
+            factory,
+            ExecutionStageThresholds {
+                max_blocks: Some(1),
+                max_changes: None,
+                max_changesets: None,
+            },
+        );
 
         let mut account_hashing_stage = AccountHashingStage::default();
         let mut storage_hashing_stage = StorageHashingStage::default();

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -54,7 +54,10 @@ use reth_staged_sync::{
 };
 use reth_stages::{
     prelude::*,
-    stages::{ExecutionStage, HeaderSyncMode, SenderRecoveryStage, TotalDifficultyStage, FINISH},
+    stages::{
+        ExecutionStage, ExecutionStageThresholds, HeaderSyncMode, SenderRecoveryStage,
+        TotalDifficultyStage, FINISH,
+    },
 };
 use reth_tasks::TaskExecutor;
 use reth_transaction_pool::{EthTransactionValidator, TransactionPool};
@@ -688,7 +691,14 @@ impl Command {
                 .set(SenderRecoveryStage {
                     commit_threshold: stage_conf.sender_recovery.commit_threshold,
                 })
-                .set(ExecutionStage::new(factory, stage_conf.execution.commit_threshold))
+                .set(ExecutionStage::new(
+                    factory,
+                    ExecutionStageThresholds {
+                        max_blocks: stage_conf.execution.max_blocks,
+                        max_changes: stage_conf.execution.max_changes,
+                        max_changesets: stage_conf.execution.max_changesets,
+                    },
+                ))
                 .disable_if(MERKLE_UNWIND, || self.auto_mine)
                 .disable_if(MERKLE_EXECUTION, || self.auto_mine),
             )

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -16,7 +16,10 @@ use reth_staged_sync::{
     Config,
 };
 use reth_stages::{
-    stages::{BodyStage, ExecutionStage, MerkleStage, SenderRecoveryStage, TransactionLookupStage},
+    stages::{
+        BodyStage, ExecutionStage, ExecutionStageThresholds, MerkleStage, SenderRecoveryStage,
+        TransactionLookupStage,
+    },
     ExecInput, Stage, StageId, UnwindInput,
 };
 use std::{net::SocketAddr, path::PathBuf, sync::Arc};
@@ -183,7 +186,14 @@ impl Command {
             }
             StageEnum::Execution => {
                 let factory = reth_revm::Factory::new(self.chain.clone());
-                let mut stage = ExecutionStage::new(factory, num_blocks);
+                let mut stage = ExecutionStage::new(
+                    factory,
+                    ExecutionStageThresholds {
+                        max_blocks: Some(num_blocks),
+                        max_changes: None,
+                        max_changesets: None,
+                    },
+                );
                 if !self.skip_unwind {
                     stage.unwind(&mut tx, unwind).await?;
                 }

--- a/bin/reth/src/test_eth_chain/runner.rs
+++ b/bin/reth/src/test_eth_chain/runner.rs
@@ -193,7 +193,7 @@ pub async fn run_test(path: PathBuf) -> eyre::Result<TestOutcome> {
         // Initialize the execution stage
         // Hardcode the chain_id to Ethereum 1.
         let factory = reth_revm::Factory::new(Arc::new(chain_spec));
-        let mut stage = ExecutionStage::new(factory, 1_000);
+        let mut stage = ExecutionStage::new_with_factory(factory);
 
         // Call execution stage
         let input = ExecInput {

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -50,6 +50,9 @@ pub const FINNEY_TO_WEI: u128 = (GWEI_TO_WEI as u128) * 1_000_000;
 /// Multiplier for converting ether to wei.
 pub const ETH_TO_WEI: u128 = FINNEY_TO_WEI * 1000;
 
+/// Multiplier for converting mgas to gas.
+pub const MGAS_TO_GAS: u64 = 1_000_000u64;
+
 /// The Ethereum mainnet genesis hash.
 pub const MAINNET_GENESIS: H256 =
     H256(hex!("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"));

--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -800,8 +800,8 @@ mod tests {
 
         // Clone and sort to make the test deterministic
         assert_eq!(
-            post_state.account_changes(),
-            &BTreeMap::from([(
+            post_state.account_changes().inner,
+            BTreeMap::from([(
                 block.number,
                 BTreeMap::from([
                     // New account
@@ -815,8 +815,8 @@ mod tests {
             "Account changeset did not match"
         );
         assert_eq!(
-            post_state.storage_changes(),
-            &BTreeMap::from([(
+            post_state.storage_changes().inner,
+            BTreeMap::from([(
                 block.number,
                 BTreeMap::from([(
                     account1,

--- a/crates/staged-sync/src/config.rs
+++ b/crates/staged-sync/src/config.rs
@@ -154,13 +154,25 @@ impl Default for SenderRecoveryConfig {
 /// Execution stage configuration.
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Serialize)]
 pub struct ExecutionConfig {
-    /// The maximum number of blocks to execution before committing progress to the database.
-    pub commit_threshold: u64,
+    /// The maximum number of blocks to process before the execution stage commits.
+    pub max_blocks: Option<u64>,
+    /// The maximum amount of state changes to keep in memory before the execution stage commits.
+    pub max_changes: Option<u64>,
+    /// The maximum amount of changesets to keep in memory before they are written to the pending
+    /// database transaction.
+    ///
+    /// If this is lower than `max_gas`, then history is periodically flushed to the database
+    /// transaction, which frees up memory.
+    pub max_changesets: Option<u64>,
 }
 
 impl Default for ExecutionConfig {
     fn default() -> Self {
-        Self { commit_threshold: 5_000 }
+        Self {
+            max_blocks: Some(500_000),
+            max_changes: Some(5_000_000),
+            max_changesets: Some(1_000_000),
+        }
     }
 }
 

--- a/crates/stages/src/sets.rs
+++ b/crates/stages/src/sets.rs
@@ -246,7 +246,7 @@ impl<EF: ExecutorFactory, DB: Database> StageSet<DB> for ExecutionStages<EF> {
     fn builder(self) -> StageSetBuilder<DB> {
         StageSetBuilder::default()
             .add_stage(SenderRecoveryStage::default())
-            .add_stage(ExecutionStage::new(self.executor_factory, 10_000))
+            .add_stage(ExecutionStage::new_with_factory(self.executor_factory))
     }
 }
 

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -27,6 +27,7 @@ thiserror = "1.0.37"
 auto_impl = "1.0"
 itertools = "0.10"
 pin-project = "1.0"
+derive_more = "0.99"
 
 # test-utils
 reth-rlp = { path = "../../rlp", optional = true }

--- a/crates/storage/provider/src/post_state/account.rs
+++ b/crates/storage/provider/src/post_state/account.rs
@@ -1,0 +1,73 @@
+use derive_more::Deref;
+use reth_primitives::{Account, Address, BlockNumber};
+use std::collections::{btree_map::Entry, BTreeMap};
+
+/// A mapping of `block -> address -> account` that represents what accounts were changed, and what
+/// their state were prior to that change.
+///
+/// If the prior state was `None`, then the account is new.
+#[derive(Default, Clone, Eq, PartialEq, Debug, Deref)]
+pub struct AccountChanges {
+    /// The inner mapping of block changes.
+    #[deref]
+    pub inner: BTreeMap<BlockNumber, BTreeMap<Address, Option<Account>>>,
+    /// Hand tracked change size.
+    pub size: usize,
+}
+
+impl AccountChanges {
+    /// Insert account change at specified block number. The value is **not** updated if it already
+    /// exists.
+    pub fn insert(&mut self, block: BlockNumber, address: Address, account: Option<Account>) {
+        if let Entry::Vacant(entry) = self.inner.entry(block).or_default().entry(address) {
+            self.size += 1;
+            entry.insert(account);
+        }
+    }
+
+    /// Insert account changes at specified block number. The values are **not** updated if they
+    /// already exist.
+    pub fn insert_for_block(
+        &mut self,
+        block: BlockNumber,
+        changes: BTreeMap<Address, Option<Account>>,
+    ) {
+        let block_entry = self.inner.entry(block).or_default();
+        for (address, account) in changes {
+            if let Entry::Vacant(entry) = block_entry.entry(address) {
+                entry.insert(account);
+                self.size += 1;
+            }
+        }
+    }
+
+    /// Drain and return any entries above the target block number.
+    pub fn drain_above(
+        &mut self,
+        target_block: BlockNumber,
+    ) -> BTreeMap<BlockNumber, BTreeMap<Address, Option<Account>>> {
+        let mut evicted = BTreeMap::new();
+        self.inner.retain(|block_number, accounts| {
+            if *block_number > target_block {
+                self.size -= accounts.len();
+                evicted.insert(*block_number, accounts.clone());
+                false
+            } else {
+                true
+            }
+        });
+        evicted
+    }
+
+    /// Retain entries only above specified block number.
+    pub fn retain_above(&mut self, target_block: BlockNumber) {
+        self.inner.retain(|block_number, accounts| {
+            if *block_number > target_block {
+                true
+            } else {
+                self.size -= accounts.len();
+                false
+            }
+        });
+    }
+}

--- a/crates/storage/provider/src/post_state/storage.rs
+++ b/crates/storage/provider/src/post_state/storage.rs
@@ -86,7 +86,7 @@ impl StorageChanges {
         let mut evicted = BTreeMap::new();
         self.inner.retain(|block_number, storages| {
             if *block_number > target_block {
-                // TODO: fix this with Storage::size
+                // This is fine, because it's called only on post state splits
                 self.size -=
                     storages.iter().fold(0, |acc, (_, storage)| acc + storage.storage.len());
                 evicted.insert(*block_number, storages.clone());
@@ -104,7 +104,7 @@ impl StorageChanges {
             if *block_number > target_block {
                 true
             } else {
-                // TODO: fix this with Storage::size
+                // This is fine, because it's called only on post state splits
                 self.size -=
                     storages.iter().fold(0, |acc, (_, storage)| acc + storage.storage.len());
                 false

--- a/crates/storage/provider/src/post_state/storage.rs
+++ b/crates/storage/provider/src/post_state/storage.rs
@@ -1,0 +1,114 @@
+use derive_more::Deref;
+use reth_primitives::{Address, BlockNumber, U256};
+use std::collections::{btree_map::Entry, BTreeMap};
+
+/// Storage for an account with the old and new values for each slot: (slot -> (old, new)).
+pub type StorageChangeset = BTreeMap<U256, (U256, U256)>;
+
+/// Changed storage state for the account.
+///
+/// # Wiped Storage
+///
+/// The field `wiped` denotes whether the pre-existing storage in the database should be cleared or
+/// not.
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
+pub struct ChangedStorage {
+    /// Whether the storage was wiped or not.
+    pub wiped: bool,
+    /// The storage slots.
+    pub storage: BTreeMap<U256, U256>,
+}
+
+/// Latest storage state for the account.
+///
+/// # Wiped Storage
+///
+/// The `times_wiped` field indicates the number of times the storage was wiped in this poststate.
+///
+/// If `times_wiped` is greater than 0, then the account was selfdestructed at some point, and the
+/// values contained in `storage` should be the only values written to the database.
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
+pub struct Storage {
+    /// The number of times the storage was wiped.
+    pub times_wiped: u64,
+    /// The storage slots.
+    pub storage: BTreeMap<U256, U256>,
+}
+
+impl Storage {
+    /// Returns `true` if the storage was wiped at any point.
+    pub fn wiped(&self) -> bool {
+        self.times_wiped > 0
+    }
+}
+
+/// A mapping of `block -> account -> slot -> old value` that represents what slots were changed,
+/// and what their values were prior to that change.
+#[derive(Default, Clone, Eq, PartialEq, Debug, Deref)]
+pub struct StorageChanges {
+    /// The inner mapping of block changes.
+    #[deref]
+    pub inner: BTreeMap<BlockNumber, BTreeMap<Address, ChangedStorage>>,
+    /// Hand tracked change size.
+    pub size: usize,
+}
+
+impl StorageChanges {
+    /// Set storage `wiped` flag for specified block number and address.
+    pub fn set_wiped(&mut self, block: BlockNumber, address: Address) {
+        self.inner.entry(block).or_default().entry(address).or_default().wiped = true;
+    }
+
+    /// Insert storage entries for specified block number and address.
+    pub fn insert_for_block_and_address<I>(
+        &mut self,
+        block: BlockNumber,
+        address: Address,
+        storage: I,
+    ) where
+        I: Iterator<Item = (U256, U256)>,
+    {
+        let block_entry = self.inner.entry(block).or_default();
+        let storage_entry = block_entry.entry(address).or_default();
+        for (slot, value) in storage {
+            if let Entry::Vacant(entry) = storage_entry.storage.entry(slot) {
+                entry.insert(value);
+                self.size += 1;
+            }
+        }
+    }
+
+    /// Drain and return any entries above the target block number.
+    pub fn drain_above(
+        &mut self,
+        target_block: BlockNumber,
+    ) -> BTreeMap<BlockNumber, BTreeMap<Address, ChangedStorage>> {
+        let mut evicted = BTreeMap::new();
+        self.inner.retain(|block_number, storages| {
+            if *block_number > target_block {
+                // TODO: fix this with Storage::size
+                self.size -=
+                    storages.iter().fold(0, |acc, (_, storage)| acc + storage.storage.len());
+                evicted.insert(*block_number, storages.clone());
+                false
+            } else {
+                true
+            }
+        });
+        evicted
+    }
+
+    /// Retain entries only above specified block number.
+    pub fn retain_above(&mut self, target_block: BlockNumber) {
+        self.inner.retain(|block_number, storages| {
+            if *block_number > target_block {
+                true
+            } else {
+                // TODO: fix this with Storage::size
+                self.size -=
+                    storages.iter().fold(0, |acc, (_, storage)| acc + storage.storage.len());
+                false
+            }
+        });
+    }
+}


### PR DESCRIPTION
Alternative to #2489 

## Issue

Execution stage processes blocks and commits to the database in chunks with constant size (`commit_threshold` parameter).  However, the number of rows the stage needs to modify/write varies from chunk to chunk. This might be 1-2 entries per block in 1m - 3m block range. 

In order to offset the implicit costs of database transactions, we need to implement a mechanism that normalizes the distribution of database writes across block chunks.

## Solution

`PostState` already contains all of the data that we need to write. In order to prevent iterating over nested fields and recalculating the amount of changes in the changsets, add a `size` field to memoize the changeset sizes. The `size` is updated on each modification of account/storage changesets.

## Additional notes

The `Poststate::size` is not necessarily the number of database writes we need to make since it doesn't account for storage wipes.
