### PR TITLE
feat: use chain-specific data dirs

### DIFF
--- a/bin/reth/src/args/network_args.rs
+++ b/bin/reth/src/args/network_args.rs
@@ -53,8 +53,8 @@ impl NetworkArgs {
     /// Build a [`NetworkConfigBuilder`] from a [`Config`] and a [`ChainSpec`], in addition to the
     /// values in this option struct.
     ///
-    /// The `default_peers_file` will be used as the default location to store the persistent peers file if
-    /// `no_persist_peers` is false, and there is no provided `peers_file`.
+    /// The `default_peers_file` will be used as the default location to store the persistent peers
+    /// file if `no_persist_peers` is false, and there is no provided `peers_file`.
     pub fn network_config(
         &self,
         config: &Config,

--- a/bin/reth/src/args/network_args.rs
+++ b/bin/reth/src/args/network_args.rs
@@ -1,10 +1,9 @@
 //! clap [Args](clap::Args) for network related arguments.
 
-use crate::dirs::{KnownPeersPath, MaybePlatformPath};
 use clap::Args;
 use reth_net_nat::NatResolver;
 use reth_network::NetworkConfigBuilder;
-use reth_primitives::{mainnet_nodes, Chain, ChainSpec, NodeRecord};
+use reth_primitives::{mainnet_nodes, ChainSpec, NodeRecord};
 use reth_staged_sync::Config;
 use secp256k1::SecretKey;
 use std::{path::PathBuf, sync::Arc};
@@ -32,14 +31,13 @@ pub struct NetworkArgs {
     #[arg(long, value_delimiter = ',')]
     pub bootnodes: Option<Vec<NodeRecord>>,
 
-    /// The path to the known peers file. Connected peers are
-    /// dumped to this file on node shutdown, and read on startup.
-    /// Cannot be used with --no-persist-peers
-    #[arg(long, value_name = "FILE", verbatim_doc_comment, default_value_t)]
-    pub peers_file: MaybePlatformPath<KnownPeersPath>,
+    /// The path to the known peers file. Connected peers are dumped to this file on nodes
+    /// shutdown, and read on startup. Cannot be used with `--no-persist-peers`.
+    #[arg(long, value_name = "FILE", verbatim_doc_comment, conflicts_with = "no_persist_peers")]
+    pub peers_file: Option<PathBuf>,
 
-    /// Do not persist peers. Cannot be used with --peers-file
-    #[arg(long, verbatim_doc_comment, conflicts_with = "peers_file")]
+    /// Do not persist peers.
+    #[arg(long, verbatim_doc_comment)]
     pub no_persist_peers: bool,
 
     /// NAT resolution method.
@@ -54,16 +52,22 @@ pub struct NetworkArgs {
 impl NetworkArgs {
     /// Build a [`NetworkConfigBuilder`] from a [`Config`] and a [`ChainSpec`], in addition to the
     /// values in this option struct.
+    ///
+    /// The `default_peers_file` will be used as the default location to store the persistent peers file if
+    /// `no_persist_peers` is false, and there is no provided `peers_file`.
     pub fn network_config(
         &self,
         config: &Config,
         chain_spec: Arc<ChainSpec>,
         secret_key: SecretKey,
+        default_peers_file: PathBuf,
     ) -> NetworkConfigBuilder {
         let chain_bootnodes = chain_spec.chain.bootnodes().unwrap_or_else(mainnet_nodes);
 
+        let peers_file = self.peers_file.unwrap_or(default_peers_file);
+
         let network_config_builder = config
-            .network_config(self.nat, self.persistent_peers_file(chain_spec.chain), secret_key)
+            .network_config(self.nat, self.persistent_peers_file(peers_file), secret_key)
             .boot_nodes(self.bootnodes.clone().unwrap_or(chain_bootnodes))
             .chain_spec(chain_spec);
 
@@ -74,16 +78,13 @@ impl NetworkArgs {
 // === impl NetworkArgs ===
 
 impl NetworkArgs {
-    /// If `no_persist_peers` is true then this returns the path to the persistent peers file
-    ///
-    /// Uses the input chain to determine a chain-specific path to the known peers file.
-    pub fn persistent_peers_file(&self, chain: Chain) -> Option<PathBuf> {
+    /// If `no_persist_peers` is true then this returns the path to the persistent peers file path.
+    pub fn persistent_peers_file(&self, peers_file: PathBuf) -> Option<PathBuf> {
         if self.no_persist_peers {
             return None
         }
 
-        let peers_file = self.peers_file.clone().unwrap_or_chain_default(chain);
-        Some(peers_file.into())
+        Some(peers_file)
     }
 }
 

--- a/bin/reth/src/args/network_args.rs
+++ b/bin/reth/src/args/network_args.rs
@@ -64,7 +64,7 @@ impl NetworkArgs {
     ) -> NetworkConfigBuilder {
         let chain_bootnodes = chain_spec.chain.bootnodes().unwrap_or_else(mainnet_nodes);
 
-        let peers_file = self.peers_file.unwrap_or(default_peers_file);
+        let peers_file = self.peers_file.clone().unwrap_or(default_peers_file);
 
         let network_config_builder = config
             .network_config(self.nat, self.persistent_peers_file(peers_file), secret_key)

--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -122,6 +122,7 @@ impl RpcServerArgs {
     /// Returns the handles for the launched regular RPC server(s) (if any) and the server handle
     /// for the auth server that handles the `engine_` API that's accessed by the consensus
     /// layer.
+    #[allow(clippy::too_many_arguments)]
     pub async fn start_servers<Client, Pool, Network, Tasks, Events, Engine>(
         &self,
         client: Client,

--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -1,6 +1,5 @@
 //! clap [Args](clap::Args) for RPC related arguments.
 
-use crate::dirs::{JwtSecretPath, PlatformPath};
 use clap::Args;
 use futures::FutureExt;
 use reth_network_api::{NetworkInfo, Peers};

--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -20,7 +20,7 @@ use reth_tasks::TaskSpawner;
 use reth_transaction_pool::TransactionPool;
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    path::Path,
+    path::{Path, PathBuf},
 };
 use tracing::info;
 
@@ -86,7 +86,7 @@ pub struct RpcServerArgs {
 
     /// Path to a JWT secret to use for authenticated RPC endpoints
     #[arg(long = "authrpc.jwtsecret", value_name = "PATH", global = true, required = false)]
-    auth_jwtsecret: Option<PlatformPath<JwtSecretPath>>,
+    auth_jwtsecret: Option<PathBuf>,
 }
 
 impl RpcServerArgs {
@@ -100,18 +100,19 @@ impl RpcServerArgs {
     /// If such a parameter is not given, the client SHOULD generate such a token, valid for the
     /// duration of the execution, and SHOULD store the hex-encoded secret as a jwt.hex file on
     /// the filesystem. This file can then be used to provision the counterpart client.
-    pub(crate) fn jwt_secret(&self) -> Result<JwtSecret, JwtError> {
+    ///
+    /// The `default_jwt_path` provided as an argument will be used as the default location for the
+    /// jwt secret in case the `auth_jwtsecret` argument is not provided.
+    pub(crate) fn jwt_secret(&self, default_jwt_path: PathBuf) -> Result<JwtSecret, JwtError> {
         let arg = self.auth_jwtsecret.as_ref();
         let path: Option<&Path> = arg.map(|p| p.as_ref());
         match path {
             Some(fpath) => JwtSecret::from_file(fpath),
             None => {
-                let default_path = PlatformPath::<JwtSecretPath>::default();
-                let fpath = default_path.as_ref();
-                if fpath.exists() {
-                    JwtSecret::from_file(fpath)
+                if default_jwt_path.exists() {
+                    JwtSecret::from_file(&default_jwt_path)
                 } else {
-                    JwtSecret::try_create(fpath)
+                    JwtSecret::try_create(&default_jwt_path)
                 }
             }
         }
@@ -130,6 +131,7 @@ impl RpcServerArgs {
         executor: Tasks,
         events: Events,
         engine_api: Engine,
+        jwt_secret: JwtSecret,
     ) -> Result<(RpcServerHandle, AuthServerHandle), RpcError>
     where
         Client: BlockProvider
@@ -145,7 +147,7 @@ impl RpcServerArgs {
         Events: CanonStateSubscriptions + Clone + 'static,
         Engine: EngineApiServer,
     {
-        let auth_config = self.auth_server_config()?;
+        let auth_config = self.auth_server_config(jwt_secret)?;
 
         let (rpc_modules, auth_module) = RpcModuleBuilder::default()
             .with_client(client)
@@ -213,6 +215,7 @@ impl RpcServerArgs {
         network: Network,
         executor: Tasks,
         engine_api: EngineApi<Client>,
+        jwt_secret: JwtSecret,
     ) -> Result<AuthServerHandle, RpcError>
     where
         Client: BlockProvider
@@ -230,7 +233,7 @@ impl RpcServerArgs {
             self.auth_addr.unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED)),
             self.auth_port.unwrap_or(constants::DEFAULT_AUTH_PORT),
         );
-        let secret = self.jwt_secret().map_err(|err| RpcError::Custom(err.to_string()))?;
+
         reth_rpc_builder::auth::launch(
             client,
             pool,
@@ -238,7 +241,7 @@ impl RpcServerArgs {
             executor,
             engine_api,
             socket_address,
-            secret,
+            jwt_secret,
         )
         .await
     }
@@ -294,14 +297,13 @@ impl RpcServerArgs {
     }
 
     /// Creates the [AuthServerConfig] from cli args.
-    fn auth_server_config(&self) -> Result<AuthServerConfig, RpcError> {
-        let secret = self.jwt_secret().map_err(|err| RpcError::Custom(err.to_string()))?;
+    fn auth_server_config(&self, jwt_secret: JwtSecret) -> Result<AuthServerConfig, RpcError> {
         let address = SocketAddr::new(
             self.auth_addr.unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED)),
             self.auth_port.unwrap_or(constants::DEFAULT_AUTH_PORT),
         );
 
-        Ok(AuthServerConfig::builder(secret).socket_addr(address).build())
+        Ok(AuthServerConfig::builder(jwt_secret).socket_addr(address).build())
     }
 }
 

--- a/bin/reth/src/chain/import.rs
+++ b/bin/reth/src/chain/import.rs
@@ -45,7 +45,7 @@ pub struct ImportCommand {
     /// - Windows: `{FOLDERID_RoamingAppData}/reth/`
     /// - macOS: `$HOME/Library/Application Support/reth/`
     #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
-    data_dir: MaybePlatformPath<DataDirPath>,
+    datadir: MaybePlatformPath<DataDirPath>,
 
     /// The path to the database folder. If not specified, it will be set in the data dir for the
     /// chain being used.
@@ -86,7 +86,7 @@ impl ImportCommand {
         info!(target: "reth::cli", path = %self.config.unwrap_or_chain_default(self.chain.chain), "Configuration loaded");
 
         // add network name to data dir
-        let data_dir = self.data_dir.unwrap_or_chain_default(self.chain.chain);
+        let data_dir = self.datadir.unwrap_or_chain_default(self.chain.chain);
 
         // use the overridden db path if specified
         let db_path = self.db.clone().unwrap_or(data_dir.db_path());

--- a/bin/reth/src/chain/import.rs
+++ b/bin/reth/src/chain/import.rs
@@ -47,11 +47,6 @@ pub struct ImportCommand {
     #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
     datadir: MaybePlatformPath<DataDirPath>,
 
-    /// The path to the database folder. If not specified, it will be set in the data dir for the
-    /// chain being used.
-    #[arg(long, value_name = "PATH", verbatim_doc_comment)]
-    db: Option<PathBuf>,
-
     /// The chain this node is running.
     ///
     /// Possible values are either a built-in chain or the path to a chain specification file.
@@ -89,8 +84,7 @@ impl ImportCommand {
         let config: Config = self.load_config(config_path.clone())?;
         info!(target: "reth::cli", path = ?config_path, "Configuration loaded");
 
-        // use the overridden db path if specified
-        let db_path = self.db.clone().unwrap_or(data_dir.db_path());
+        let db_path = data_dir.db_path();
 
         info!(target: "reth::cli", path = ?db_path, "Opening database");
         let db = Arc::new(init_db(db_path)?);

--- a/bin/reth/src/chain/import.rs
+++ b/bin/reth/src/chain/import.rs
@@ -14,7 +14,7 @@ use reth_downloaders::{
 use reth_interfaces::{
     consensus::Consensus, p2p::headers::client::NoopStatusUpdater, sync::SyncStateUpdater,
 };
-use reth_primitives::{Chain, ChainSpec, H256};
+use reth_primitives::{ChainSpec, H256};
 use reth_staged_sync::{
     utils::{
         chainspec::genesis_value_parser,
@@ -82,8 +82,8 @@ impl ImportCommand {
     pub async fn execute(self) -> eyre::Result<()> {
         info!(target: "reth::cli", "reth {} starting", crate_version!());
 
-        let config: Config = self.load_config_with_chain(self.chain.chain)?;
-        info!(target: "reth::cli", path = %self.config.unwrap_or_chain_default(self.chain.chain), "Configuration loaded");
+        let config: Config = self.load_config()?;
+        info!(target: "reth::cli", path = ?self.config.unwrap_or_default(), "Configuration loaded");
 
         // add network name to data dir
         let data_dir = self.datadir.unwrap_or_chain_default(self.chain.chain);
@@ -180,10 +180,10 @@ impl ImportCommand {
         Ok((pipeline, events))
     }
 
-    /// Loads the reth config based on the intended chain
-    fn load_config_with_chain(&self, chain: Chain) -> eyre::Result<Config> {
+    /// Loads the reth config
+    fn load_config(&self) -> eyre::Result<Config> {
         // add network name to config directory
-        let config_path = self.config.unwrap_or_chain_default(chain);
+        let config_path = self.config.unwrap_or_default();
         confy::load_path::<Config>(config_path.clone())
             .wrap_err_with(|| format!("Could not load config file {}", config_path))
     }

--- a/bin/reth/src/chain/init.rs
+++ b/bin/reth/src/chain/init.rs
@@ -19,7 +19,7 @@ pub struct InitCommand {
     /// - Windows: `{FOLDERID_RoamingAppData}/reth/`
     /// - macOS: `$HOME/Library/Application Support/reth/`
     #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
-    data_dir: MaybePlatformPath<DataDirPath>,
+    datadir: MaybePlatformPath<DataDirPath>,
 
     /// The path to the database folder. If not specified, it will be set in the data dir for the
     /// chain being used.
@@ -50,7 +50,7 @@ impl InitCommand {
         info!(target: "reth::cli", "reth init starting");
 
         // add network name to data dir
-        let data_dir = self.data_dir.unwrap_or_chain_default(self.chain.chain);
+        let data_dir = self.datadir.unwrap_or_chain_default(self.chain.chain);
 
         // use the overridden db path if specified
         let db_path = self.db.clone().unwrap_or(data_dir.db_path());

--- a/bin/reth/src/chain/init.rs
+++ b/bin/reth/src/chain/init.rs
@@ -1,25 +1,30 @@
-use crate::dirs::{DbPath, MaybePlatformPath};
+use crate::dirs::{DataDirPath, MaybePlatformPath};
 use clap::Parser;
 use reth_primitives::ChainSpec;
 use reth_staged_sync::utils::{
     chainspec::genesis_value_parser,
     init::{init_db, init_genesis},
 };
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 use tracing::info;
 
 /// Initializes the database with the genesis block.
 #[derive(Debug, Parser)]
 pub struct InitCommand {
-    /// The path to the database folder.
+    /// The path to the data dir for all reth files and subdirectories.
     ///
     /// Defaults to the OS-specific data directory:
     ///
-    /// - Linux: `$XDG_DATA_HOME/reth/db` or `$HOME/.local/share/reth/db`
-    /// - Windows: `{FOLDERID_RoamingAppData}/reth/db`
-    /// - macOS: `$HOME/Library/Application Support/reth/db`
-    #[arg(long, value_name = "PATH", verbatim_doc_comment, default_value_t)]
-    db: MaybePlatformPath<DbPath>,
+    /// - Linux: `$XDG_DATA_HOME/reth/` or `$HOME/.local/share/reth/`
+    /// - Windows: `{FOLDERID_RoamingAppData}/reth/`
+    /// - macOS: `$HOME/Library/Application Support/reth/`
+    #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
+    data_dir: MaybePlatformPath<DataDirPath>,
+
+    /// The path to the database folder. If not specified, it will be set in the data dir for the
+    /// chain being used.
+    #[arg(long, value_name = "PATH", verbatim_doc_comment)]
+    db: Option<PathBuf>,
 
     /// The chain this node is running.
     ///
@@ -44,10 +49,13 @@ impl InitCommand {
     pub async fn execute(self) -> eyre::Result<()> {
         info!(target: "reth::cli", "reth init starting");
 
-        // add network name to db directory
-        let db_path = self.db.unwrap_or_chain_default(self.chain.chain);
+        // add network name to data dir
+        let data_dir = self.data_dir.unwrap_or_chain_default(self.chain.chain);
 
-        info!(target: "reth::cli", path = %db_path, "Opening database");
+        // use the overridden db path if specified
+        let db_path = self.db.clone().unwrap_or(data_dir.db_path());
+
+        info!(target: "reth::cli", path = ?db_path, "Opening database");
         let db = Arc::new(init_db(&db_path)?);
         info!(target: "reth::cli", "Database opened");
 

--- a/bin/reth/src/config.rs
+++ b/bin/reth/src/config.rs
@@ -1,16 +1,16 @@
 //! CLI command to show configs
+use std::path::PathBuf;
+
 use clap::Parser;
 use eyre::{bail, WrapErr};
 use reth_staged_sync::Config;
-
-use crate::dirs::{ConfigPath, PlatformPath};
 
 /// `reth config` command
 #[derive(Debug, Parser)]
 pub struct Command {
     /// The path to the configuration file to use.
     #[arg(long, value_name = "FILE", verbatim_doc_comment)]
-    config: Option<PlatformPath<ConfigPath>>,
+    config: Option<PathBuf>,
 
     /// Show the default config
     #[arg(long, verbatim_doc_comment, conflicts_with = "config")]
@@ -25,12 +25,11 @@ impl Command {
         } else {
             let path = self.config.clone().unwrap_or_default();
             // confy will create the file if it doesn't exist; we don't want this
-            if !path.as_ref().exists() {
-                bail!("Config file does not exist: {}", path.as_ref().display());
+            if !path.exists() {
+                bail!("Config file does not exist: {}", path.display());
             }
-            confy::load_path::<Config>(path.as_ref()).wrap_err_with(|| {
-                format!("Could not load config file: {}", path.as_ref().display())
-            })?
+            confy::load_path::<Config>(&path)
+                .wrap_err_with(|| format!("Could not load config file: {}", path.display()))?
         };
         println!("{}", toml::to_string_pretty(&config)?);
         Ok(())

--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -27,7 +27,7 @@ pub struct Command {
     /// - Windows: `{FOLDERID_RoamingAppData}/reth/`
     /// - macOS: `$HOME/Library/Application Support/reth/`
     #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
-    data_dir: MaybePlatformPath<DataDirPath>,
+    datadir: MaybePlatformPath<DataDirPath>,
 
     /// The path to the database folder. If not specified, it will be set in the data dir for the
     /// chain being used.
@@ -91,7 +91,7 @@ impl Command {
     /// Execute `db` command
     pub async fn execute(self) -> eyre::Result<()> {
         // add network name to data dir
-        let data_dir = self.data_dir.unwrap_or_chain_default(self.chain.chain);
+        let data_dir = self.datadir.unwrap_or_chain_default(self.chain.chain);
 
         // use the overridden db path if specified
         let db_path = self.db.clone().unwrap_or(data_dir.db_path());

--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -1,6 +1,6 @@
 //! Database debugging tool
 use crate::{
-    dirs::{DbPath, MaybePlatformPath},
+    dirs::{DataDirPath, MaybePlatformPath},
     utils::DbTool,
 };
 use clap::{Parser, Subcommand};
@@ -10,7 +10,7 @@ use human_bytes::human_bytes;
 use reth_db::{database::Database, tables};
 use reth_primitives::ChainSpec;
 use reth_staged_sync::utils::chainspec::genesis_value_parser;
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 use tracing::error;
 
 /// DB List TUI
@@ -19,15 +19,20 @@ mod tui;
 /// `reth db` command
 #[derive(Debug, Parser)]
 pub struct Command {
-    /// The path to the database folder.
+    /// The path to the data dir for all reth files and subdirectories.
     ///
     /// Defaults to the OS-specific data directory:
     ///
-    /// - Linux: `$XDG_DATA_HOME/reth/db` or `$HOME/.local/share/reth/db`
-    /// - Windows: `{FOLDERID_RoamingAppData}/reth/db`
-    /// - macOS: `$HOME/Library/Application Support/reth/db`
-    #[arg(global = true, long, value_name = "PATH", verbatim_doc_comment, default_value_t)]
-    db: MaybePlatformPath<DbPath>,
+    /// - Linux: `$XDG_DATA_HOME/reth/` or `$HOME/.local/share/reth/`
+    /// - Windows: `{FOLDERID_RoamingAppData}/reth/`
+    /// - macOS: `$HOME/Library/Application Support/reth/`
+    #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
+    data_dir: MaybePlatformPath<DataDirPath>,
+
+    /// The path to the database folder. If not specified, it will be set in the data dir for the
+    /// chain being used.
+    #[arg(long, value_name = "PATH", verbatim_doc_comment)]
+    db: Option<PathBuf>,
 
     /// The chain this node is running.
     ///
@@ -85,8 +90,11 @@ pub struct ListArgs {
 impl Command {
     /// Execute `db` command
     pub async fn execute(self) -> eyre::Result<()> {
-        // add network name to db directory
-        let db_path = self.db.unwrap_or_chain_default(self.chain.chain);
+        // add network name to data dir
+        let data_dir = self.data_dir.unwrap_or_chain_default(self.chain.chain);
+
+        // use the overridden db path if specified
+        let db_path = self.db.clone().unwrap_or(data_dir.db_path());
 
         std::fs::create_dir_all(&db_path)?;
 
@@ -211,7 +219,7 @@ impl Command {
                 ]);
             }
             Subcommands::Drop => {
-                tool.drop(self.db.unwrap_or_chain_default(self.chain.chain))?;
+                tool.drop(db_path)?;
             }
         }
 

--- a/bin/reth/src/dirs.rs
+++ b/bin/reth/src/dirs.rs
@@ -254,14 +254,14 @@ impl<D> ChainPath<D> {
         self.0.join("db").into()
     }
 
-    /// Returns the path to the reth secret key directory for this chain.
-    pub fn p2p_path(&self) -> P2PPath<D> {
-        P2PPath(self.0.join("p2p"))
+    /// Returns the path to the reth p2p secret key for this chain.
+    pub fn p2p_secret_path(&self) -> PathBuf {
+        self.0.join("discoverysecret").into()
     }
 
-    /// Returns the path to the net directory for this chain.
-    pub fn net_path(&self) -> NetPath<D> {
-        NetPath(self.0.join("net"))
+    /// Returns the path to the known peers file for this chain.
+    pub fn known_peers_path(&self) -> PathBuf {
+        self.0.join("known-peers.json").into()
     }
 
     /// Returns the path to the config file for this chain.
@@ -269,9 +269,9 @@ impl<D> ChainPath<D> {
         self.0.join("reth.toml").into()
     }
 
-    /// Returns the path to the jwtsecret directory for this chain.
-    pub fn jwt_path(&self) -> JwtSecretPath<D> {
-        JwtSecretPath(self.0.join("jwtsecret"))
+    /// Returns the path to the jwtsecret file for this chain.
+    pub fn jwt_path(&self) -> PathBuf {
+        self.0.join("jwtsecret").into()
     }
 }
 
@@ -290,39 +290,6 @@ impl<D> Display for ChainPath<D> {
 impl<D> From<ChainPath<D>> for PathBuf {
     fn from(value: ChainPath<D>) -> Self {
         value.0.into()
-    }
-}
-
-/// A type representing a path to the reth net directory.
-#[derive(Clone, Debug, PartialEq)]
-pub struct NetPath<D>(PlatformPath<D>);
-
-impl<D> NetPath<D> {
-    /// Returns the path to the default reth known peers file for this net directory.
-    pub fn known_peers_path(&self) -> PathBuf {
-        self.0.join("known_peers.json").into()
-    }
-}
-
-/// A type representing a path to the reth jwtsecret directory.
-#[derive(Clone, Debug, PartialEq)]
-pub struct JwtSecretPath<D>(PlatformPath<D>);
-
-impl<D> JwtSecretPath<D> {
-    /// Returns the path to the default reth jwtsecret file for this jwtsecret directory.
-    pub fn jwtsecret_path(&self) -> PathBuf {
-        self.0.join("jwt.hex").into()
-    }
-}
-
-/// A type represeting a path to the reth p2p secret directory.
-#[derive(Clone, Debug, PartialEq)]
-pub struct P2PPath<D>(PlatformPath<D>);
-
-impl<D> P2PPath<D> {
-    /// Returns the path to the default reth p2p secret key file for this p2p directory.
-    pub fn p2p_secret_path(&self) -> PathBuf {
-        self.0.join("secret").into()
     }
 }
 

--- a/bin/reth/src/dirs.rs
+++ b/bin/reth/src/dirs.rs
@@ -271,7 +271,7 @@ impl<D> ChainPath<D> {
 
     /// Returns the path to the jwtsecret file for this chain.
     pub fn jwt_path(&self) -> PathBuf {
-        self.0.join("jwtsecret").into()
+        self.0.join("jwt.hex").into()
     }
 }
 

--- a/bin/reth/src/dirs.rs
+++ b/bin/reth/src/dirs.rs
@@ -70,19 +70,6 @@ impl XdgPath for DataDirPath {
     }
 }
 
-/// Returns the path to the default reth configuration file.
-///
-/// Refer to [dirs_next::data_dir] for cross-platform behavior.
-#[derive(Default, Debug, Clone)]
-#[non_exhaustive]
-pub struct ConfigPath;
-
-impl XdgPath for ConfigPath {
-    fn resolve() -> Option<PathBuf> {
-        data_dir().map(|p| p.join("reth.toml"))
-    }
-}
-
 /// Returns the path to the reth logs directory.
 ///
 /// Refer to [dirs_next::cache_dir] for cross-platform behavior.
@@ -277,6 +264,11 @@ impl<D> ChainPath<D> {
         NetPath(self.0.join("net"))
     }
 
+    /// Returns the path to the config file for this chain.
+    pub fn config_path(&self) -> PathBuf {
+        self.0.join("reth.toml").into()
+    }
+
     /// Returns the path to the jwtsecret directory for this chain.
     pub fn jwt_path(&self) -> JwtSecretPath<D> {
         JwtSecretPath(self.0.join("jwtsecret"))
@@ -345,21 +337,10 @@ mod tests {
         assert!(path.as_ref().ends_with("reth/mainnet"), "{:?}", path);
 
         let db_path = path.db_path();
-        assert!(path.as_ref().ends_with("reth/mainnet/db"), "{:?}", db_path);
+        assert!(db_path.ends_with("reth/mainnet/db"), "{:?}", db_path);
 
-        let path = MaybePlatformPath::<DataDirPath>::from_str("my/path/to/db").unwrap();
+        let path = MaybePlatformPath::<DataDirPath>::from_str("my/path/to/datadir").unwrap();
         let path = path.unwrap_or_chain_default(Chain::mainnet());
-        assert!(path.as_ref().ends_with("my/path/to/db"), "{:?}", path);
-    }
-
-    #[test]
-    fn test_maybe_config_platform_path() {
-        let path = MaybePlatformPath::<ConfigPath>::default();
-        let path = path.unwrap_or_chain_default(Chain::mainnet());
-        assert!(path.as_ref().ends_with("reth/mainnet/reth.toml"), "{:?}", path);
-
-        let path = MaybePlatformPath::<ConfigPath>::from_str("my/path/to/reth.toml").unwrap();
-        let path = path.unwrap_or_chain_default(Chain::mainnet());
-        assert!(path.as_ref().ends_with("my/path/to/reth.toml"), "{:?}", path);
+        assert!(path.as_ref().ends_with("my/path/to/datadir"), "{:?}", path);
     }
 }

--- a/bin/reth/src/dirs.rs
+++ b/bin/reth/src/dirs.rs
@@ -112,13 +112,13 @@ pub trait XdgPath {
 /// # Example
 ///
 /// ```
-/// use reth::dirs::{PlatformPath, DbPath};
+/// use reth::dirs::{PlatformPath, DataDirPath};
 /// use std::str::FromStr;
 ///
 /// // Resolves to the platform-specific database path
-/// let default: PlatformPath<DbPath> = PlatformPath::default();
-/// // Resolves to `$(pwd)/my/path/to/db`
-/// let custom: PlatformPath<DbPath> = PlatformPath::from_str("my/path/to/db").unwrap();
+/// let default: PlatformPath<DataDirPath> = PlatformPath::default();
+/// // Resolves to `$(pwd)/my/path/to/datadir`
+/// let custom: PlatformPath<DataDirPath> = PlatformPath::from_str("my/path/to/datadir").unwrap();
 ///
 /// assert_ne!(default.as_ref(), custom.as_ref());
 /// ```

--- a/bin/reth/src/dirs.rs
+++ b/bin/reth/src/dirs.rs
@@ -77,6 +77,20 @@ pub fn p2p_secret_key_dir() -> Option<PathBuf> {
     data_dir().map(|root| root.join("p2p"))
 }
 
+/// Returns the path to the reth data dir.
+#[derive(Default, Debug, Clone)]
+#[non_exhaustive]
+pub struct DataDirPath;
+
+impl XdgPath for DataDirPath {
+    fn resolve() -> Option<PathBuf> {
+        data_dir()
+    }
+}
+
+/// Data dirs will contain a subdirectory for each chain, and those chain directories will include
+/// all information for that chain, such as the p2p secret.
+
 /// Returns the path to the reth database.
 ///
 /// Refer to [dirs_next::data_dir] for cross-platform behavior.

--- a/bin/reth/src/dirs.rs
+++ b/bin/reth/src/dirs.rs
@@ -256,7 +256,7 @@ impl<D> ChainPath<D> {
 
     /// Returns the path to the reth p2p secret key for this chain.
     pub fn p2p_secret_path(&self) -> PathBuf {
-        self.0.join("discoverysecret").into()
+        self.0.join("discovery-secret").into()
     }
 
     /// Returns the path to the known peers file for this chain.

--- a/bin/reth/src/dirs.rs
+++ b/bin/reth/src/dirs.rs
@@ -209,7 +209,10 @@ pub struct MaybePlatformPath<D>(Option<PlatformPath<D>>);
 impl<D: XdgPath> MaybePlatformPath<D> {
     /// Returns the path if it is set, otherwise returns the default path for the given chain.
     pub fn unwrap_or_chain_default(&self, chain: Chain) -> ChainPath<D> {
-        ChainPath(self.0.clone().unwrap_or_else(|| PlatformPath::default().with_chain(chain).0), chain)
+        ChainPath(
+            self.0.clone().unwrap_or_else(|| PlatformPath::default().with_chain(chain).0),
+            chain,
+        )
     }
 }
 
@@ -281,7 +284,7 @@ impl<D> ChainPath<D> {
     }
 
     /// Returns the path to the jwtsecret directory for this chain.
-    pub fn jwtsecret_path(&self) -> JwtSecretPath<D> {
+    pub fn jwt_path(&self) -> JwtSecretPath<D> {
         JwtSecretPath(self.0.join("jwtsecret"))
     }
 }

--- a/bin/reth/src/drop_stage.rs
+++ b/bin/reth/src/drop_stage.rs
@@ -31,7 +31,7 @@ pub struct Command {
     /// - Windows: `{FOLDERID_RoamingAppData}/reth/`
     /// - macOS: `$HOME/Library/Application Support/reth/`
     #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
-    data_dir: MaybePlatformPath<DataDirPath>,
+    datadir: MaybePlatformPath<DataDirPath>,
 
     /// The path to the database folder. If not specified, it will be set in the data dir for the
     /// chain being used.
@@ -62,7 +62,7 @@ impl Command {
     /// Execute `db` command
     pub async fn execute(self) -> eyre::Result<()> {
         // add network name to data dir
-        let data_dir = self.data_dir.unwrap_or_chain_default(self.chain.chain);
+        let data_dir = self.datadir.unwrap_or_chain_default(self.chain.chain);
 
         // use the overridden db path if specified
         let db_path = self.db.clone().unwrap_or(data_dir.db_path());

--- a/bin/reth/src/drop_stage.rs
+++ b/bin/reth/src/drop_stage.rs
@@ -1,7 +1,7 @@
 //! Database debugging tool
 use crate::{
     args::StageEnum,
-    dirs::{DbPath, MaybePlatformPath},
+    dirs::{DataDirPath, MaybePlatformPath},
     utils::DbTool,
 };
 use clap::Parser;
@@ -17,21 +17,26 @@ use reth_stages::stages::{
     ACCOUNT_HASHING, EXECUTION, INDEX_ACCOUNT_HISTORY, INDEX_STORAGE_HISTORY, MERKLE_EXECUTION,
     MERKLE_UNWIND, STORAGE_HASHING,
 };
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 use tracing::info;
 
 /// `reth drop-stage` command
 #[derive(Debug, Parser)]
 pub struct Command {
-    /// The path to the database folder.
+    /// The path to the data dir for all reth files and subdirectories.
     ///
     /// Defaults to the OS-specific data directory:
     ///
-    /// - Linux: `$XDG_DATA_HOME/reth/db` or `$HOME/.local/share/reth/db`
-    /// - Windows: `{FOLDERID_RoamingAppData}/reth/db`
-    /// - macOS: `$HOME/Library/Application Support/reth/db`
-    #[arg(global = true, long, value_name = "PATH", verbatim_doc_comment, default_value_t)]
-    db: MaybePlatformPath<DbPath>,
+    /// - Linux: `$XDG_DATA_HOME/reth/` or `$HOME/.local/share/reth/`
+    /// - Windows: `{FOLDERID_RoamingAppData}/reth/`
+    /// - macOS: `$HOME/Library/Application Support/reth/`
+    #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
+    data_dir: MaybePlatformPath<DataDirPath>,
+
+    /// The path to the database folder. If not specified, it will be set in the data dir for the
+    /// chain being used.
+    #[arg(long, value_name = "PATH", verbatim_doc_comment)]
+    db: Option<PathBuf>,
 
     /// The chain this node is running.
     ///
@@ -56,8 +61,11 @@ pub struct Command {
 impl Command {
     /// Execute `db` command
     pub async fn execute(self) -> eyre::Result<()> {
-        // add network name to db directory
-        let db_path = self.db.unwrap_or_chain_default(self.chain.chain);
+        // add network name to data dir
+        let data_dir = self.data_dir.unwrap_or_chain_default(self.chain.chain);
+
+        // use the overridden db path if specified
+        let db_path = self.db.clone().unwrap_or(data_dir.db_path());
 
         std::fs::create_dir_all(&db_path)?;
 

--- a/bin/reth/src/dump_stage/execution.rs
+++ b/bin/reth/src/dump_stage/execution.rs
@@ -1,8 +1,4 @@
-use crate::{
-    dirs::{DbPath, PlatformPath},
-    dump_stage::setup,
-    utils::DbTool,
-};
+use crate::{dump_stage::setup, utils::DbTool};
 use eyre::Result;
 use reth_db::{
     cursor::DbCursorRO, database::Database, table::TableImporter, tables, transaction::DbTx,
@@ -10,14 +6,14 @@ use reth_db::{
 use reth_primitives::MAINNET;
 use reth_provider::Transaction;
 use reth_stages::{stages::ExecutionStage, Stage, StageId, UnwindInput};
-use std::{ops::DerefMut, sync::Arc};
+use std::{ops::DerefMut, path::PathBuf, sync::Arc};
 use tracing::info;
 
 pub(crate) async fn dump_execution_stage<DB: Database>(
     db_tool: &mut DbTool<'_, DB>,
     from: u64,
     to: u64,
-    output_db: &PlatformPath<DbPath>,
+    output_db: &PathBuf,
     should_run: bool,
 ) -> Result<()> {
     let (output_db, tip_block_number) = setup::<DB>(from, to, output_db, db_tool)?;

--- a/bin/reth/src/dump_stage/hashing_account.rs
+++ b/bin/reth/src/dump_stage/hashing_account.rs
@@ -1,21 +1,17 @@
-use crate::{
-    dirs::{DbPath, PlatformPath},
-    dump_stage::setup,
-    utils::DbTool,
-};
+use crate::{dump_stage::setup, utils::DbTool};
 use eyre::Result;
 use reth_db::{database::Database, table::TableImporter, tables};
 use reth_primitives::BlockNumber;
 use reth_provider::Transaction;
 use reth_stages::{stages::AccountHashingStage, Stage, StageId, UnwindInput};
-use std::ops::DerefMut;
+use std::{ops::DerefMut, path::PathBuf};
 use tracing::info;
 
 pub(crate) async fn dump_hashing_account_stage<DB: Database>(
     db_tool: &mut DbTool<'_, DB>,
     from: BlockNumber,
     to: BlockNumber,
-    output_db: &PlatformPath<DbPath>,
+    output_db: &PathBuf,
     should_run: bool,
 ) -> Result<()> {
     let (output_db, tip_block_number) = setup::<DB>(from, to, output_db, db_tool)?;

--- a/bin/reth/src/dump_stage/hashing_storage.rs
+++ b/bin/reth/src/dump_stage/hashing_storage.rs
@@ -1,20 +1,16 @@
-use crate::{
-    dirs::{DbPath, PlatformPath},
-    dump_stage::setup,
-    utils::DbTool,
-};
+use crate::{dump_stage::setup, utils::DbTool};
 use eyre::Result;
 use reth_db::{database::Database, table::TableImporter, tables};
 use reth_provider::Transaction;
 use reth_stages::{stages::StorageHashingStage, Stage, StageId, UnwindInput};
-use std::ops::DerefMut;
+use std::{ops::DerefMut, path::PathBuf};
 use tracing::info;
 
 pub(crate) async fn dump_hashing_storage_stage<DB: Database>(
     db_tool: &mut DbTool<'_, DB>,
     from: u64,
     to: u64,
-    output_db: &PlatformPath<DbPath>,
+    output_db: &PathBuf,
     should_run: bool,
 ) -> Result<()> {
     let (output_db, tip_block_number) = setup::<DB>(from, to, output_db, db_tool)?;

--- a/bin/reth/src/dump_stage/merkle.rs
+++ b/bin/reth/src/dump_stage/merkle.rs
@@ -1,8 +1,4 @@
-use crate::{
-    dirs::{DbPath, PlatformPath},
-    dump_stage::setup,
-    utils::DbTool,
-};
+use crate::{dump_stage::setup, utils::DbTool};
 use eyre::Result;
 use reth_db::{database::Database, table::TableImporter, tables};
 use reth_primitives::{BlockNumber, MAINNET};
@@ -11,14 +7,14 @@ use reth_stages::{
     stages::{AccountHashingStage, ExecutionStage, MerkleStage, StorageHashingStage},
     Stage, StageId, UnwindInput,
 };
-use std::{ops::DerefMut, sync::Arc};
+use std::{ops::DerefMut, path::PathBuf, sync::Arc};
 use tracing::info;
 
 pub(crate) async fn dump_merkle_stage<DB: Database>(
     db_tool: &mut DbTool<'_, DB>,
     from: BlockNumber,
     to: BlockNumber,
-    output_db: &PlatformPath<DbPath>,
+    output_db: &PathBuf,
     should_run: bool,
 ) -> Result<()> {
     let (output_db, tip_block_number) = setup::<DB>(from, to, output_db, db_tool)?;

--- a/bin/reth/src/dump_stage/mod.rs
+++ b/bin/reth/src/dump_stage/mod.rs
@@ -35,7 +35,7 @@ pub struct Command {
     /// - Windows: `{FOLDERID_RoamingAppData}/reth/`
     /// - macOS: `$HOME/Library/Application Support/reth/`
     #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
-    data_dir: MaybePlatformPath<DataDirPath>,
+    datadir: MaybePlatformPath<DataDirPath>,
 
     /// The path to the database folder. If not specified, it will be set in the data dir for the
     /// chain being used.
@@ -99,7 +99,7 @@ impl Command {
     /// Execute `dump-stage` command
     pub async fn execute(self) -> eyre::Result<()> {
         // add network name to data dir
-        let data_dir = self.data_dir.unwrap_or_chain_default(self.chain.chain);
+        let data_dir = self.datadir.unwrap_or_chain_default(self.chain.chain);
 
         // use the overridden db path if specified
         let db_path = self.db.clone().unwrap_or(data_dir.db_path());

--- a/bin/reth/src/dump_stage/mod.rs
+++ b/bin/reth/src/dump_stage/mod.rs
@@ -1,6 +1,6 @@
 //! Database debugging tool
 use crate::{
-    dirs::{DbPath, MaybePlatformPath, PlatformPath},
+    dirs::{DataDirPath, MaybePlatformPath},
     utils::DbTool,
 };
 use clap::Parser;
@@ -9,7 +9,7 @@ use reth_db::{
 };
 use reth_primitives::ChainSpec;
 use reth_staged_sync::utils::{chainspec::genesis_value_parser, init::init_db};
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 use tracing::info;
 
 mod hashing_storage;
@@ -27,15 +27,20 @@ use merkle::dump_merkle_stage;
 /// `reth dump-stage` command
 #[derive(Debug, Parser)]
 pub struct Command {
-    /// The path to the database folder.
+    /// The path to the data dir for all reth files and subdirectories.
     ///
     /// Defaults to the OS-specific data directory:
     ///
-    /// - Linux: `$XDG_DATA_HOME/reth/db` or `$HOME/.local/share/reth/db`
-    /// - Windows: `{FOLDERID_RoamingAppData}/reth/db`
-    /// - macOS: `$HOME/Library/Application Support/reth/db`
-    #[arg(long, value_name = "PATH", verbatim_doc_comment, default_value_t)]
-    db: MaybePlatformPath<DbPath>,
+    /// - Linux: `$XDG_DATA_HOME/reth/` or `$HOME/.local/share/reth/`
+    /// - Windows: `{FOLDERID_RoamingAppData}/reth/`
+    /// - macOS: `$HOME/Library/Application Support/reth/`
+    #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
+    data_dir: MaybePlatformPath<DataDirPath>,
+
+    /// The path to the database folder. If not specified, it will be set in the data dir for the
+    /// chain being used.
+    #[arg(long, value_name = "PATH", verbatim_doc_comment)]
+    db: Option<PathBuf>,
 
     /// The chain this node is running.
     ///
@@ -75,14 +80,9 @@ pub enum Stages {
 #[derive(Debug, Clone, Parser)]
 pub struct StageCommand {
     /// The path to the new database folder.
-    ///
-    /// Defaults to the OS-specific data directory:
-    ///
-    /// - Linux: `$XDG_DATA_HOME/reth/db` or `$HOME/.local/share/reth/db`
-    /// - Windows: `{FOLDERID_RoamingAppData}/reth/db`
-    /// - macOS: `$HOME/Library/Application Support/reth/db`
-    #[arg(long, value_name = "OUTPUT_PATH", verbatim_doc_comment, default_value_t)]
-    output_db: PlatformPath<DbPath>,
+    #[arg(long, value_name = "OUTPUT_PATH", verbatim_doc_comment)]
+    output_db: PathBuf,
+
     /// From which block.
     #[arg(long, short)]
     from: u64,
@@ -98,9 +98,13 @@ pub struct StageCommand {
 impl Command {
     /// Execute `dump-stage` command
     pub async fn execute(self) -> eyre::Result<()> {
-        // add network name to db directory
-        let db_path = self.db.unwrap_or_chain_default(self.chain.chain);
+        // add network name to data dir
+        let data_dir = self.data_dir.unwrap_or_chain_default(self.chain.chain);
 
+        // use the overridden db path if specified
+        let db_path = self.db.clone().unwrap_or(data_dir.db_path());
+
+        info!(target: "reth::cli", path = ?db_path, "Opening database");
         std::fs::create_dir_all(&db_path)?;
 
         // TODO: Auto-impl for Database trait
@@ -135,12 +139,12 @@ impl Command {
 pub(crate) fn setup<DB: Database>(
     from: u64,
     to: u64,
-    output_db: &PlatformPath<DbPath>,
+    output_db: &PathBuf,
     db_tool: &mut DbTool<'_, DB>,
 ) -> eyre::Result<(reth_db::mdbx::Env<reth_db::mdbx::WriteMap>, u64)> {
     assert!(from < to, "FROM block should be bigger than TO block.");
 
-    info!(target: "reth::cli", "Creating separate db at {}", output_db);
+    info!(target: "reth::cli", ?output_db, "Creating separate db");
 
     let output_db = init_db(output_db)?;
 

--- a/bin/reth/src/merkle_debug.rs
+++ b/bin/reth/src/merkle_debug.rs
@@ -25,7 +25,7 @@ pub struct Command {
     /// - Windows: `{FOLDERID_RoamingAppData}/reth/`
     /// - macOS: `$HOME/Library/Application Support/reth/`
     #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
-    data_dir: MaybePlatformPath<DataDirPath>,
+    datadir: MaybePlatformPath<DataDirPath>,
 
     /// The path to the database folder. If not specified, it will be set in the data dir for the
     /// chain being used.
@@ -62,7 +62,7 @@ impl Command {
     /// Execute `merkle-debug` command
     pub async fn execute(self) -> eyre::Result<()> {
         // add network name to data dir
-        let data_dir = self.data_dir.unwrap_or_chain_default(self.chain.chain);
+        let data_dir = self.datadir.unwrap_or_chain_default(self.chain.chain);
 
         // use the overridden db path if specified
         let db_path = self.db.clone().unwrap_or(data_dir.db_path());

--- a/bin/reth/src/merkle_debug.rs
+++ b/bin/reth/src/merkle_debug.rs
@@ -1,5 +1,5 @@
 //! Command for debugging merkle trie calculation.
-use crate::dirs::{DbPath, MaybePlatformPath};
+use crate::dirs::{DataDirPath, MaybePlatformPath};
 use clap::Parser;
 use reth_db::{cursor::DbCursorRO, tables, transaction::DbTx};
 use reth_primitives::ChainSpec;
@@ -12,20 +12,25 @@ use reth_stages::{
     },
     ExecInput, Stage,
 };
-use std::{ops::Deref, sync::Arc};
+use std::{ops::Deref, path::PathBuf, sync::Arc};
 
 /// `reth merkle-debug` command
 #[derive(Debug, Parser)]
 pub struct Command {
-    /// The path to the database folder.
+    /// The path to the data dir for all reth files and subdirectories.
     ///
     /// Defaults to the OS-specific data directory:
     ///
-    /// - Linux: `$XDG_DATA_HOME/reth/db` or `$HOME/.local/share/reth/db`
-    /// - Windows: `{FOLDERID_RoamingAppData}/reth/db`
-    /// - macOS: `$HOME/Library/Application Support/reth/db`
-    #[arg(global = true, long, value_name = "PATH", verbatim_doc_comment, default_value_t)]
-    db: MaybePlatformPath<DbPath>,
+    /// - Linux: `$XDG_DATA_HOME/reth/` or `$HOME/.local/share/reth/`
+    /// - Windows: `{FOLDERID_RoamingAppData}/reth/`
+    /// - macOS: `$HOME/Library/Application Support/reth/`
+    #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
+    data_dir: MaybePlatformPath<DataDirPath>,
+
+    /// The path to the database folder. If not specified, it will be set in the data dir for the
+    /// chain being used.
+    #[arg(long, value_name = "PATH", verbatim_doc_comment)]
+    db: Option<PathBuf>,
 
     /// The chain this node is running.
     ///
@@ -56,8 +61,11 @@ pub struct Command {
 impl Command {
     /// Execute `merkle-debug` command
     pub async fn execute(self) -> eyre::Result<()> {
-        // add network name to db directory
-        let db_path = self.db.unwrap_or_chain_default(self.chain.chain);
+        // add network name to data dir
+        let data_dir = self.data_dir.unwrap_or_chain_default(self.chain.chain);
+
+        // use the overridden db path if specified
+        let db_path = self.db.clone().unwrap_or(data_dir.db_path());
 
         std::fs::create_dir_all(&db_path)?;
 

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -78,6 +78,10 @@ pub mod events;
 /// Start the node
 #[derive(Debug, Parser)]
 pub struct Command {
+    /// The path to the data dir for all reth files and subdirectories.
+    #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
+    data_dir: MaybePlatformPath<PathBuf>,
+
     /// The path to the configuration file to use.
     #[arg(long, value_name = "FILE", verbatim_doc_comment, default_value_t)]
     config: MaybePlatformPath<ConfigPath>,

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -231,8 +231,8 @@ impl Command {
         }
 
         info!(target: "reth::cli", "Connecting to P2P network");
-        let default_secret_key_path = data_dir.p2p_path().p2p_secret_path();
-        let default_peers_path = data_dir.net_path().known_peers_path();
+        let default_secret_key_path = data_dir.p2p_secret_path();
+        let default_peers_path = data_dir.known_peers_path();
         let secret_key = get_secret_key(&default_secret_key_path)?;
         let network_config = self.load_network_config(
             &config,
@@ -376,7 +376,7 @@ impl Command {
         info!(target: "reth::cli", "Engine API handler initialized");
 
         // extract the jwt secret from the the args if possible
-        let default_jwt_path = data_dir.jwt_path().jwtsecret_path();
+        let default_jwt_path = data_dir.jwt_path();
         let jwt_secret = self.rpc.jwt_secret(default_jwt_path)?;
 
         // Start RPC servers

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -86,7 +86,7 @@ pub struct Command {
     /// - Windows: `{FOLDERID_RoamingAppData}/reth/`
     /// - macOS: `$HOME/Library/Application Support/reth/`
     #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
-    data_dir: MaybePlatformPath<DataDirPath>,
+    datadir: MaybePlatformPath<DataDirPath>,
 
     /// The path to the configuration file to use.
     #[arg(long, value_name = "FILE", verbatim_doc_comment, default_value_t)]
@@ -154,7 +154,7 @@ impl Command {
         info!(target: "reth::cli", path = %self.config.unwrap_or_chain_default(self.chain.chain), "Configuration loaded");
 
         // add network name to data dir
-        let data_dir = self.data_dir.unwrap_or_chain_default(self.chain.chain);
+        let data_dir = self.datadir.unwrap_or_chain_default(self.chain.chain);
 
         // use the overridden db path if specified
         let db_path = self.db.clone().unwrap_or(data_dir.db_path());
@@ -795,12 +795,12 @@ mod tests {
     #[test]
     fn parse_db_path() {
         let cmd = Command::try_parse_from(["reth", "--db", "my/path/to/db"]).unwrap();
-        let data_dir = cmd.data_dir.unwrap_or_chain_default(cmd.chain.chain);
+        let data_dir = cmd.datadir.unwrap_or_chain_default(cmd.chain.chain);
         let db_path = cmd.db.unwrap_or(data_dir.db_path());
         assert_eq!(db_path, Path::new("my/path/to/db"));
 
         let cmd = Command::try_parse_from(["reth"]).unwrap();
-        let data_dir = cmd.data_dir.unwrap_or_chain_default(cmd.chain.chain);
+        let data_dir = cmd.datadir.unwrap_or_chain_default(cmd.chain.chain);
         let db_path = cmd.db.unwrap_or(data_dir.db_path());
         assert!(db_path.ends_with("reth/mainnet/db"), "{:?}", cmd.config);
     }

--- a/bin/reth/src/p2p/mod.rs
+++ b/bin/reth/src/p2p/mod.rs
@@ -49,7 +49,7 @@ pub struct Command {
     /// - Windows: `{FOLDERID_RoamingAppData}/reth/`
     /// - macOS: `$HOME/Library/Application Support/reth/`
     #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
-    data_dir: MaybePlatformPath<DataDirPath>,
+    datadir: MaybePlatformPath<DataDirPath>,
 
     /// Secret key to use for this node.
     ///
@@ -115,7 +115,7 @@ impl Command {
         config.peers.connect_trusted_nodes_only = self.trusted_only;
 
         // add network name to data dir
-        let data_dir = self.data_dir.unwrap_or_chain_default(self.chain.chain);
+        let data_dir = self.datadir.unwrap_or_chain_default(self.chain.chain);
         let default_secret_key_path = data_dir.p2p_path().p2p_secret_path();
         let secret_key_path = self.p2p_secret_key.clone().unwrap_or(default_secret_key_path);
         let p2p_secret_key = get_secret_key(&secret_key_path)?;

--- a/bin/reth/src/p2p/mod.rs
+++ b/bin/reth/src/p2p/mod.rs
@@ -118,7 +118,7 @@ impl Command {
 
         config.peers.connect_trusted_nodes_only = self.trusted_only;
 
-        let default_secret_key_path = data_dir.p2p_path().p2p_secret_path();
+        let default_secret_key_path = data_dir.p2p_secret_path();
         let secret_key_path = self.p2p_secret_key.clone().unwrap_or(default_secret_key_path);
         let p2p_secret_key = get_secret_key(&secret_key_path)?;
 

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -104,9 +104,7 @@ impl Command {
         // Does not do anything on windows.
         fdlimit::raise_fd_limit();
 
-        let config: Config =
-            confy::load_path(self.config.unwrap_or_chain_default(self.chain.chain))
-                .unwrap_or_default();
+        let config: Config = confy::load_path(self.config.unwrap_or_default()).unwrap_or_default();
         info!(target: "reth::cli", "reth {} starting stage {:?}", clap::crate_version!(), self.stage);
 
         let input = ExecInput {

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -3,7 +3,7 @@
 //! Stage debugging tool
 use crate::{
     args::{get_secret_key, NetworkArgs, StageEnum},
-    dirs::{ConfigPath, DbPath, MaybePlatformPath, PlatformPath, SecretKeyPath},
+    dirs::{ConfigPath, MaybePlatformPath, PlatformPath, DataDirPath},
     prometheus_exporter,
 };
 use clap::Parser;
@@ -34,6 +34,16 @@ pub struct Command {
     /// - macOS: `$HOME/Library/Application Support/reth/db`
     #[arg(long, value_name = "PATH", verbatim_doc_comment, default_value_t)]
     db: MaybePlatformPath<DbPath>,
+
+    /// The path to the data dir for all reth files and subdirectories.
+    ///
+    /// Defaults to the OS-specific data directory:
+    ///
+    /// - Linux: `$XDG_DATA_HOME/reth/` or `$HOME/.local/share/reth/`
+    /// - Windows: `{FOLDERID_RoamingAppData}/reth/`
+    /// - macOS: `$HOME/Library/Application Support/reth/`
+    #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
+    data_dir: MaybePlatformPath<DataDirPath>,
 
     /// The path to the configuration file to use.
     #[arg(long, value_name = "FILE", verbatim_doc_comment, default_value_t)]

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -3,7 +3,7 @@
 //! Stage debugging tool
 use crate::{
     args::{get_secret_key, NetworkArgs, StageEnum},
-    dirs::{ConfigPath, DataDirPath, MaybePlatformPath, PlatformPath},
+    dirs::{ConfigPath, DataDirPath, MaybePlatformPath},
     prometheus_exporter,
 };
 use clap::Parser;
@@ -19,21 +19,15 @@ use reth_stages::{
     stages::{BodyStage, ExecutionStage, MerkleStage, SenderRecoveryStage, TransactionLookupStage},
     ExecInput, Stage, StageId, UnwindInput,
 };
-use std::{net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, path::PathBuf, sync::Arc};
 use tracing::*;
 
 /// `reth stage` command
 #[derive(Debug, Parser)]
 pub struct Command {
-    /// The path to the database folder.
-    ///
-    /// Defaults to the OS-specific data directory:
-    ///
-    /// - Linux: `$XDG_DATA_HOME/reth/db` or `$HOME/.local/share/reth/db`
-    /// - Windows: `{FOLDERID_RoamingAppData}/reth/db`
-    /// - macOS: `$HOME/Library/Application Support/reth/db`
-    #[arg(long, value_name = "PATH", verbatim_doc_comment, default_value_t)]
-    db: MaybePlatformPath<DbPath>,
+    /// The path to the configuration file to use.
+    #[arg(long, value_name = "FILE", verbatim_doc_comment, default_value_t)]
+    config: MaybePlatformPath<ConfigPath>,
 
     /// The path to the data dir for all reth files and subdirectories.
     ///
@@ -45,9 +39,10 @@ pub struct Command {
     #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
     data_dir: MaybePlatformPath<DataDirPath>,
 
-    /// The path to the configuration file to use.
-    #[arg(long, value_name = "FILE", verbatim_doc_comment, default_value_t)]
-    config: MaybePlatformPath<ConfigPath>,
+    /// The path to the database folder. If not specified, it will be set in the data dir for the
+    /// chain being used.
+    #[arg(long, value_name = "PATH", verbatim_doc_comment)]
+    db: Option<PathBuf>,
 
     /// The chain this node is running.
     ///
@@ -69,8 +64,8 @@ pub struct Command {
     /// Secret key to use for this node.
     ///
     /// This also will deterministically set the peer ID.
-    #[arg(long, value_name = "PATH", global = true, required = false, default_value_t)]
-    p2p_secret_key: PlatformPath<SecretKeyPath>,
+    #[arg(long, value_name = "PATH", global = true, required = false)]
+    p2p_secret_key: Option<PathBuf>,
 
     /// Enable Prometheus metrics.
     ///
@@ -121,9 +116,13 @@ impl Command {
 
         let unwind = UnwindInput { stage_progress: self.to, unwind_to: self.from, bad_block: None };
 
-        // add network name to db directory
-        let db_path = self.db.unwrap_or_chain_default(self.chain.chain);
+        // add network name to data dir
+        let data_dir = self.data_dir.unwrap_or_chain_default(self.chain.chain);
 
+        // use the overridden db path if specified
+        let db_path = self.db.clone().unwrap_or(data_dir.db_path());
+
+        info!(target: "reth::cli", path = ?db_path, "Opening database");
         let db = Arc::new(init_db(db_path)?);
         let mut tx = Transaction::new(db.as_ref())?;
 
@@ -146,11 +145,14 @@ impl Command {
                     });
                 }
 
-                let p2p_secret_key = get_secret_key(&self.p2p_secret_key)?;
+                let default_secret_key_path = data_dir.p2p_path().p2p_secret_path();
+                let p2p_secret_key = get_secret_key(&default_secret_key_path)?;
+
+                let default_peers_path = data_dir.net_path().known_peers_path();
 
                 let network = self
                     .network
-                    .network_config(&config, self.chain.clone(), p2p_secret_key)
+                    .network_config(&config, self.chain.clone(), p2p_secret_key, default_peers_path)
                     .build(Arc::new(ShareableDatabase::new(db.clone(), self.chain.clone())))
                     .start_network()
                     .await?;

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -144,10 +144,10 @@ impl Command {
                     });
                 }
 
-                let default_secret_key_path = data_dir.p2p_path().p2p_secret_path();
+                let default_secret_key_path = data_dir.p2p_secret_path();
                 let p2p_secret_key = get_secret_key(&default_secret_key_path)?;
 
-                let default_peers_path = data_dir.net_path().known_peers_path();
+                let default_peers_path = data_dir.known_peers_path();
 
                 let network = self
                     .network

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -39,11 +39,6 @@ pub struct Command {
     #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
     datadir: MaybePlatformPath<DataDirPath>,
 
-    /// The path to the database folder. If not specified, it will be set in the data dir for the
-    /// chain being used.
-    #[arg(long, value_name = "PATH", verbatim_doc_comment)]
-    db: Option<PathBuf>,
-
     /// The chain this node is running.
     ///
     /// Possible values are either a built-in chain or the path to a chain specification file.
@@ -119,7 +114,7 @@ impl Command {
         let unwind = UnwindInput { stage_progress: self.to, unwind_to: self.from, bad_block: None };
 
         // use the overridden db path if specified
-        let db_path = self.db.clone().unwrap_or(data_dir.db_path());
+        let db_path = data_dir.db_path();
 
         info!(target: "reth::cli", path = ?db_path, "Opening database");
         let db = Arc::new(init_db(db_path)?);

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -3,7 +3,7 @@
 //! Stage debugging tool
 use crate::{
     args::{get_secret_key, NetworkArgs, StageEnum},
-    dirs::{ConfigPath, MaybePlatformPath, PlatformPath, DataDirPath},
+    dirs::{ConfigPath, DataDirPath, MaybePlatformPath, PlatformPath},
     prometheus_exporter,
 };
 use clap::Parser;

--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -37,7 +37,7 @@ pub struct Command {
     /// - Windows: `{FOLDERID_RoamingAppData}/reth/`
     /// - macOS: `$HOME/Library/Application Support/reth/`
     #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
-    data_dir: MaybePlatformPath<DataDirPath>,
+    datadir: MaybePlatformPath<DataDirPath>,
 
     /// The path to the database folder. If not specified, it will be set in the data dir for the
     /// chain being used.
@@ -117,7 +117,7 @@ impl Command {
         let unwind = UnwindInput { stage_progress: self.to, unwind_to: self.from, bad_block: None };
 
         // add network name to data dir
-        let data_dir = self.data_dir.unwrap_or_chain_default(self.chain.chain);
+        let data_dir = self.datadir.unwrap_or_chain_default(self.chain.chain);
 
         // use the overridden db path if specified
         let db_path = self.db.clone().unwrap_or(data_dir.db_path());


### PR DESCRIPTION
WIP attempt at changing the reth directory structure to revolve around a data directory with chain-specific directories for all other node data.

The new structure will revolve around the `--datadir` command line argument, which will set up folders for chains by either their chain ID, or name (e.g. mainnet), depending on whether or not we have specific names for the chain being run.

Fixes #2179 

TODO:
 - [x] make it compile
 - [x] s/`--data-dir`/`--datadir`