### PR TITLE
feat: implement resolve step

### DIFF
--- a/crates/payload/builder/src/traits.rs
+++ b/crates/payload/builder/src/traits.rs
@@ -17,7 +17,8 @@ pub trait PayloadJob: Future<Output = Result<(), PayloadBuilderError>> + Send + 
     /// Represents the future that resolves the block that's returned to the CL.
     type ResolvePayloadFuture: Future<Output = Result<Arc<BuiltPayload>, PayloadBuilderError>>
         + Send
-        + Sync;
+        + Sync
+        + 'static;
 
     /// Returns the best payload that has been built so far.
     ///

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -127,7 +127,7 @@ where
     pub async fn get_payload_v1(&self, payload_id: PayloadId) -> EngineApiResult<ExecutionPayload> {
         Ok(self
             .payload_store
-            .get_payload(payload_id)
+            .resolve(payload_id)
             .await
             .ok_or(EngineApiError::UnknownPayload)?
             .map(|payload| (*payload).clone().into_v1_payload())?)
@@ -146,7 +146,7 @@ where
     ) -> EngineApiResult<ExecutionPayloadEnvelope> {
         Ok(self
             .payload_store
-            .get_payload(payload_id)
+            .resolve(payload_id)
             .await
             .ok_or(EngineApiError::UnknownPayload)?
             .map(|payload| (*payload).clone().into_v2_payload())?)


### PR DESCRIPTION
Closes #2469

wraps feature started in https://github.com/paradigmxyz/reth/pull/2482

if CL requests payload, we resolve the job (terminating it if the implementation requests it)

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 77f0c5f</samp>

This pull request improves the payload building process by renaming some methods, adding `resolve` methods, and modifying a trait bound. These changes allow more flexibility and control over resolving and terminating payload jobs in the `EngineApi` and the `PayloadJobGenerator` trait.