### PR TITLE
fix: --p2p-secret-key silently reverts to default location if file is not found (#2498)

### DIFF
--- a/bin/reth/src/args/secret_key.rs
+++ b/bin/reth/src/args/secret_key.rs
@@ -28,12 +28,12 @@ pub fn get_secret_key(secret_key_path: &Path) -> Result<SecretKey, SecretKeyErro
         Ok(false) => {
             if let Some(dir) = secret_key_path.parent() {
                 // Create parent directory
-                std::fs::create_dir_all(dir)?
+                std::fs::create_dir_all(dir).map_err(SecretKeyError::IOError)?;
             }
 
             let secret = rng_secret_key();
             let hex = hex_encode(secret.as_ref());
-            std::fs::write(secret_key_path, hex)?;
+            std::fs::write(secret_key_path, hex).map_err(SecretKeyError::IOError)?;
             Ok(secret)
         }
         Err(e) => Err(SecretKeyError::IOError(e)),

--- a/bin/reth/src/args/secret_key.rs
+++ b/bin/reth/src/args/secret_key.rs
@@ -28,12 +28,12 @@ pub fn get_secret_key(secret_key_path: &Path) -> Result<SecretKey, SecretKeyErro
         Ok(false) => {
             if let Some(dir) = secret_key_path.parent() {
                 // Create parent directory
-                std::fs::create_dir_all(dir).map_err(SecretKeyError::IOError)?;
+                std::fs::create_dir_all(dir)?;
             }
 
             let secret = rng_secret_key();
             let hex = hex_encode(secret.as_ref());
-            std::fs::write(secret_key_path, hex).map_err(SecretKeyError::IOError)?;
+            std::fs::write(secret_key_path, hex)?;
             Ok(secret)
         }
         Err(e) => Err(SecretKeyError::IOError(e)),

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -239,14 +239,8 @@ impl Command {
 
         let default_peers_path = data_dir.known_peers_path();
 
-        let res = get_secret_key(secret_key_path);
-        let secret_key = match res {
-            Ok(key) => key,
-            Err(e) => {
-                error!(target: "reth::cli", path = secret_key_path.to_str(), error = %e, "Error creating p2p-secret-key");
-                return Err(eyre::eyre!("Error creating p2p-secret-key"))
-            }
-        };
+        info!(target: "reth::cli", path = secret_key_path.to_str(), "Loading p2p-secret-key");
+        let secret_key = get_secret_key(secret_key_path)?;
 
         let network_config = self.load_network_config(
             &config,


### PR DESCRIPTION
Resolves #2498 