### PR TITLE
fix(stage): merkle checkpoint target

### DIFF
--- a/crates/trie/src/progress.rs
+++ b/crates/trie/src/progress.rs
@@ -1,6 +1,6 @@
 use crate::{trie_cursor::CursorSubNode, updates::TrieUpdates};
 use reth_primitives::{
-    trie::{hash_builder::HashBuilder, Nibbles, StoredSubNode},
+    trie::{hash_builder::HashBuilder, Nibbles},
     MerkleCheckpoint, H256,
 };
 
@@ -25,17 +25,6 @@ pub struct IntermediateStateRootState {
     pub last_account_key: H256,
     /// The last walker key processed.
     pub last_walker_key: Nibbles,
-}
-
-impl From<IntermediateStateRootState> for MerkleCheckpoint {
-    fn from(value: IntermediateStateRootState) -> Self {
-        Self {
-            last_account_key: value.last_account_key,
-            last_walker_key: value.last_walker_key.hex_data,
-            walker_stack: value.walker_stack.into_iter().map(StoredSubNode::from).collect(),
-            state: value.hash_builder.into(),
-        }
-    }
 }
 
 impl From<MerkleCheckpoint> for IntermediateStateRootState {


### PR DESCRIPTION
## Problem 

Previously, if the merkle stage was interrupted, then the node restarted, downloaded new blocks and hashed entries were updated, the last merkle checkpoint should be considered invalid, because it doesn't account for new entries.

## Solution

Add `target_block` to the `MerkleCheckpoint`. If the checkpoint's target block doesn't match the current target, reset the progress and start rebuilding the trie.