### PR TITLE
bench(proofs): root calculations

### DIFF
--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -103,3 +103,7 @@ test-utils = []
 [[bench]]
 name = "recover_ecdsa_crit"
 harness = false
+
+[[bench]]
+name = "trie_root"
+harness = false

--- a/crates/primitives/benches/trie_root.rs
+++ b/crates/primitives/benches/trie_root.rs
@@ -1,0 +1,89 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use proptest::{
+    prelude::*,
+    strategy::{Strategy, ValueTree},
+    test_runner::TestRunner,
+};
+use reth_primitives::{proofs::KeccakHasher, ReceiptWithBloom};
+
+/// Benchmarks different implementations of the root calculation.
+pub fn trie_root_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Receipts root calculation");
+
+    for size in [10, 100, 1_000] {
+        let group_name =
+            |description: &str| format!("receipts root | size: {size} | {description}");
+
+        let test_data = generate_test_data(size);
+        use implementations::*;
+
+        group.bench_function(group_name("triehash::ordered_trie_root"), |b| {
+            b.iter(|| {
+                let receipts = test_data.clone();
+                black_box(trie_hash_ordered_trie_root(receipts.into_iter()));
+            });
+        });
+
+        group.bench_function(group_name("HashBuilder"), |b| {
+            b.iter(|| {
+                let receipts = test_data.clone();
+                black_box(hash_builder_root(receipts));
+            });
+        });
+    }
+}
+
+fn generate_test_data(size: usize) -> Vec<ReceiptWithBloom> {
+    prop::collection::vec(any::<ReceiptWithBloom>(), size)
+        .new_tree(&mut TestRunner::new(ProptestConfig::default()))
+        .unwrap()
+        .current()
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = trie_root_benchmark
+}
+criterion_main!(benches);
+
+mod implementations {
+    use super::*;
+    use bytes::BytesMut;
+    use reth_primitives::{
+        proofs::adjust_index_for_rlp,
+        trie::{HashBuilder, Nibbles},
+        H256,
+    };
+    use reth_rlp::Encodable;
+    use std::vec::IntoIter;
+
+    pub fn trie_hash_ordered_trie_root(receipts: IntoIter<ReceiptWithBloom>) -> H256 {
+        triehash::ordered_trie_root::<KeccakHasher, _>(receipts.map(|receipt| {
+            let mut receipt_rlp = Vec::new();
+            receipt.encode_inner(&mut receipt_rlp, false);
+            receipt_rlp
+        }))
+    }
+
+    pub fn hash_builder_root(receipts: Vec<ReceiptWithBloom>) -> H256 {
+        let mut index_buffer = BytesMut::new();
+        let mut value_buffer = BytesMut::new();
+
+        let mut hb = HashBuilder::default();
+        let receipts_len = receipts.len();
+        for i in 0..receipts_len {
+            let index = adjust_index_for_rlp(i, receipts_len);
+
+            index_buffer.clear();
+            index.encode(&mut index_buffer);
+
+            value_buffer.clear();
+            receipts[index].encode_inner(&mut value_buffer, false);
+
+            hb.add_leaf(Nibbles::unpack(&index_buffer), &value_buffer);
+        }
+
+        hb.root()
+    }
+}

--- a/crates/primitives/src/proofs.rs
+++ b/crates/primitives/src/proofs.rs
@@ -33,6 +33,17 @@ impl Hasher for KeccakHasher {
     }
 }
 
+/// Adjust the index of an item for rlp encoding.
+pub const fn adjust_index_for_rlp(i: usize, len: usize) -> usize {
+    if i > 0x7f {
+        i
+    } else if i == 0x7f || i + 1 == len {
+        0
+    } else {
+        i + 1
+    }
+}
+
 /// Calculate a transaction root.
 ///
 /// `(rlp(index), encoded(tx))` pairs.

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -42,8 +42,8 @@ impl From<Receipt> for ReceiptWithBloom {
 }
 
 /// [`Receipt`] with calculated bloom filter.
-#[derive(Clone, Debug, PartialEq, Eq, Default)]
 #[main_codec]
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct ReceiptWithBloom {
     /// Bloom filter build from logs.
     pub bloom: Bloom,


### PR DESCRIPTION
`HashBuilder` is twice as good as `triehash::ordered_trie_root`

<img width="1227" alt="Screenshot 2023-05-02 at 11 41 37" src="https://user-images.githubusercontent.com/25429261/235620121-563a08a8-a4f2-4ca6-855c-6c3b056faa75.png">
