### PR TITLE
proofs: prefer `encode_list` over `encode_iter`

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -182,7 +182,7 @@ pub fn validate_block_standalone(
 ) -> Result<(), ConsensusError> {
     // Check ommers hash
     // TODO(onbjerg): This should probably be accessible directly on [Block]
-    let ommers_hash = reth_primitives::proofs::calculate_ommers_root(block.ommers.iter());
+    let ommers_hash = reth_primitives::proofs::calculate_ommers_root(&block.ommers);
     if block.header.ommers_hash != ommers_hash {
         return Err(ConsensusError::BodyOmmersHashDiff {
             got: ommers_hash,

--- a/crates/interfaces/src/test_utils/generators.rs
+++ b/crates/interfaces/src/test_utils/generators.rs
@@ -111,7 +111,7 @@ pub fn random_block(
 
     // Calculate roots
     let transactions_root = proofs::calculate_transaction_root(transactions.iter());
-    let ommers_hash = proofs::calculate_ommers_root(ommers.iter());
+    let ommers_hash = proofs::calculate_ommers_root(&ommers);
 
     SealedBlock {
         header: Header {

--- a/crates/primitives/src/proofs.rs
+++ b/crates/primitives/src/proofs.rs
@@ -80,18 +80,18 @@ pub fn calculate_receipt_root_ref<'a>(
 }
 
 /// Calculates the log root for headers.
-pub fn calculate_log_root<'a>(logs: impl Iterator<Item = &'a Log> + Clone) -> H256 {
+pub fn calculate_log_root(logs: &[Log]) -> H256 {
     //https://github.com/ethereum/go-ethereum/blob/356bbe343a30789e77bb38f25983c8f2f2bfbb47/cmd/evm/internal/t8ntool/execution.go#L255
     let mut logs_rlp = Vec::new();
-    reth_rlp::encode_iter(logs, &mut logs_rlp);
+    reth_rlp::encode_list(logs, &mut logs_rlp);
     keccak256(logs_rlp)
 }
 
 /// Calculates the root hash for ommer/uncle headers.
-pub fn calculate_ommers_root<'a>(ommers: impl Iterator<Item = &'a Header> + Clone) -> H256 {
+pub fn calculate_ommers_root(ommers: &[Header]) -> H256 {
     // RLP Encode
     let mut ommers_rlp = Vec::new();
-    reth_rlp::encode_iter(ommers, &mut ommers_rlp);
+    reth_rlp::encode_list(ommers, &mut ommers_rlp);
     keccak256(ommers_rlp)
 }
 

--- a/crates/rlp/src/encode.rs
+++ b/crates/rlp/src/encode.rs
@@ -365,6 +365,7 @@ where
     length_of_length(payload_length) + payload_length
 }
 
+/// RLP encode the list of items.
 pub fn encode_list<E, K>(v: &[K], out: &mut dyn BufMut)
 where
     E: Encodable + ?Sized,
@@ -377,6 +378,10 @@ where
     }
 }
 
+/// RLP encode an iterator over items.
+///
+/// NOTE: This function clones the iterator. If the items are expensive to clone, consider
+/// using [encode_list] instead.
 pub fn encode_iter<K>(i: impl Iterator<Item = K> + Clone, out: &mut dyn BufMut)
 where
     K: Encodable,

--- a/crates/rpc/rpc-types/src/eth/engine/payload.rs
+++ b/crates/rpc/rpc-types/src/eth/engine/payload.rs
@@ -399,7 +399,7 @@ mod tests {
         // Recalculate roots
         transformed.header.transactions_root =
             proofs::calculate_transaction_root(transformed.body.iter());
-        transformed.header.ommers_hash = proofs::calculate_ommers_root(transformed.ommers.iter());
+        transformed.header.ommers_hash = proofs::calculate_ommers_root(&transformed.ommers);
         SealedBlock {
             header: transformed.header.seal_slow(),
             body: transformed.body,


### PR DESCRIPTION
Document differences between `reth_rlp::encode_list` and `reth_rlp::encode_iter`.

Prefer `encode_list` for clarity in proof calculation.
