### PR TITLE
feat(rpc): support pending block tag

### DIFF
--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -458,11 +458,10 @@ where
         index: Index,
     ) -> EthResult<Option<Transaction>> {
         let block_id = block_id.into();
-        if let Some(block) = self.client().block(block_id)? {
-            let block_hash = self
-                .client()
-                .block_hash_for_id(block_id)?
-                .ok_or(EthApiError::UnknownBlockNumber)?;
+
+        if let Some(block) = self.block(block_id).await? {
+            let block_hash = block.hash;
+            let block = block.unseal();
             if let Some(tx_signed) = block.body.into_iter().nth(index.into()) {
                 let tx =
                     tx_signed.into_ecrecovered().ok_or(EthApiError::InvalidTransactionSignature)?;

--- a/crates/storage/provider/src/providers/database.rs
+++ b/crates/storage/provider/src/providers/database.rs
@@ -8,7 +8,7 @@ use reth_db::{cursor::DbCursorRO, database::Database, tables, transaction::DbTx}
 use reth_interfaces::Result;
 use reth_primitives::{
     Block, BlockHash, BlockId, BlockNumber, ChainInfo, ChainSpec, Hardfork, Head, Header, Receipt,
-    TransactionMeta, TransactionSigned, TxHash, TxNumber, Withdrawal, H256, U256,
+    SealedBlock, TransactionMeta, TransactionSigned, TxHash, TxNumber, Withdrawal, H256, U256,
 };
 use reth_revm_primitives::{
     config::revm_spec,
@@ -195,6 +195,10 @@ impl<DB: Database> BlockProvider for ShareableDatabase<DB> {
             }
         }
 
+        Ok(None)
+    }
+
+    fn pending_block(&self) -> Result<Option<SealedBlock>> {
         Ok(None)
     }
 

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -170,6 +170,10 @@ where
         self.database.block(id)
     }
 
+    fn pending_block(&self) -> Result<Option<SealedBlock>> {
+        Ok(self.tree.pending_block())
+    }
+
     fn ommers(&self, id: BlockId) -> Result<Option<Vec<Header>>> {
         self.database.ommers(id)
     }

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -8,8 +8,8 @@ use parking_lot::Mutex;
 use reth_interfaces::Result;
 use reth_primitives::{
     keccak256, Account, Address, Block, BlockHash, BlockId, BlockNumber, BlockNumberOrTag,
-    Bytecode, Bytes, ChainInfo, Header, Receipt, StorageKey, StorageValue, TransactionMeta,
-    TransactionSigned, TxHash, TxNumber, H256, U256,
+    Bytecode, Bytes, ChainInfo, Header, Receipt, SealedBlock, StorageKey, StorageValue,
+    TransactionMeta, TransactionSigned, TxHash, TxNumber, H256, U256,
 };
 use reth_revm_primitives::primitives::{BlockEnv, CfgEnv};
 use std::{
@@ -280,6 +280,10 @@ impl BlockProvider for MockEthProvider {
                 unreachable!("unused in network tests")
             }
         }
+    }
+
+    fn pending_block(&self) -> Result<Option<SealedBlock>> {
+        Ok(None)
     }
 
     fn ommers(&self, _id: BlockId) -> Result<Option<Vec<Header>>> {

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -7,8 +7,8 @@ use crate::{
 use reth_interfaces::Result;
 use reth_primitives::{
     Account, Address, Block, BlockHash, BlockId, BlockNumber, Bytecode, Bytes, ChainInfo, Header,
-    Receipt, StorageKey, StorageValue, TransactionMeta, TransactionSigned, TxHash, TxNumber, H256,
-    KECCAK_EMPTY, U256,
+    Receipt, SealedBlock, StorageKey, StorageValue, TransactionMeta, TransactionSigned, TxHash,
+    TxNumber, H256, KECCAK_EMPTY, U256,
 };
 use reth_revm_primitives::primitives::{BlockEnv, CfgEnv};
 use std::ops::RangeBounds;
@@ -49,6 +49,10 @@ impl BlockProvider for NoopProvider {
     }
 
     fn block(&self, _id: BlockId) -> Result<Option<Block>> {
+        Ok(None)
+    }
+
+    fn pending_block(&self) -> Result<Option<SealedBlock>> {
         Ok(None)
     }
 

--- a/crates/storage/provider/src/traits/block.rs
+++ b/crates/storage/provider/src/traits/block.rs
@@ -1,6 +1,6 @@
 use crate::{BlockIdProvider, HeaderProvider, ReceiptProvider, TransactionsProvider};
 use reth_interfaces::Result;
-use reth_primitives::{Block, BlockId, BlockNumberOrTag, Header, H256};
+use reth_primitives::{Block, BlockId, BlockNumberOrTag, Header, SealedBlock, H256};
 
 /// A helper enum that represents the origin of the requested block.
 ///
@@ -52,6 +52,12 @@ pub trait BlockProvider:
     ///
     /// Returns `None` if block is not found.
     fn block(&self, id: BlockId) -> Result<Option<Block>>;
+
+    /// Returns the pending block if available
+    ///
+    /// Note: This returns a [SealedBlock] because it's expected that this is sealed by the provider
+    /// and the caller does not know the hash.
+    fn pending_block(&self) -> Result<Option<SealedBlock>>;
 
     /// Returns the ommers/uncle headers of the given block from the database.
     ///


### PR DESCRIPTION
adds missing checks for `BlockNumber::Pending` and fetches the pending block.

pending block can be fetched directly and should not be in the caching service (already in memory).