### PR TITLE
fix: sync to max block

### DIFF
--- a/crates/net/downloaders/src/test_utils/file_client.rs
+++ b/crates/net/downloaders/src/test_utils/file_client.rs
@@ -122,6 +122,29 @@ impl FileClient {
         self.headers.get(&(self.headers.len() as u64)).map(|h| h.hash_slow())
     }
 
+    /// Returns the highest block number of this client has or `None` if empty
+    pub fn max_block(&self) -> Option<u64> {
+        self.headers.keys().max().copied()
+    }
+
+    /// Returns true if all blocks are canonical (no gaps)
+    pub fn has_canonical_blocks(&self) -> bool {
+        if self.headers.is_empty() {
+            return true
+        }
+        let mut nums = self.headers.keys().copied().collect::<Vec<_>>();
+        nums.sort_unstable();
+        let mut iter = nums.into_iter();
+        let mut lowest = iter.next().expect("not empty");
+        for next in iter {
+            if next != lowest + 1 {
+                return false
+            }
+            lowest = next;
+        }
+        true
+    }
+
     /// Use the provided bodies as the file client's block body buffer.
     pub(crate) fn with_bodies(mut self, bodies: HashMap<BlockHash, BlockBody>) -> Self {
         self.bodies = bodies;

--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -334,6 +334,8 @@ where
                 warn!(
                     target: "sync::pipeline",
                     stage = %stage_id,
+                    max_block = self.max_block,
+                    prev_block = prev_progress,
                     "Stage reached maximum block, skipping."
                 );
                 self.listeners.notify(PipelineEvent::Skipped { stage_id });


### PR DESCRIPTION
fixes rpc-compat hive suite.

we set max-block to 0 which bypassed file client sync entirely.

instead this sets max block to the highest block we have.

add check that ensures all blocks are canonical so sync works.