### PR TITLE
fix(rpc): replay transactions before tracing

### DIFF
--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -141,7 +141,8 @@ pub trait EthTransactions: Send + Sync {
 
     /// Retrieves the transaction if it exists and returns its trace.
     ///
-    /// Before the transaction is traced, all previous transaction in the block are applied to the state by executing them first
+    /// Before the transaction is traced, all previous transaction in the block are applied to the
+    /// state by executing them first
     async fn trace_transaction_in_block<F, R>(
         &self,
         hash: H256,

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -2,7 +2,7 @@
 use crate::{
     eth::{
         error::{EthApiError, EthResult, SignError},
-        revm_utils::{inspect, prepare_call_env, transact},
+        revm_utils::{inspect, prepare_call_env, replay_transactions_until, transact},
         utils::recover_raw_transaction,
     },
     EthApi, EthApiSpec,
@@ -41,7 +41,7 @@ pub trait EthTransactions: Send + Sync {
     fn state_at(&self, at: BlockId) -> EthResult<StateProviderBox<'_>>;
 
     /// Executes the closure with the state that corresponds to the given [BlockId].
-    fn with_state_at<F, T>(&self, at: BlockId, f: F) -> EthResult<T>
+    fn with_state_at_block<F, T>(&self, at: BlockId, f: F) -> EthResult<T>
     where
         F: FnOnce(StateProviderBox<'_>) -> EthResult<T>;
 
@@ -56,6 +56,14 @@ pub trait EthTransactions: Send + Sync {
     /// Returns `None` if block does not exist.
     async fn transactions_by_block(&self, block: H256)
         -> EthResult<Option<Vec<TransactionSigned>>>;
+
+    /// Get all transactions in the block with the given hash.
+    ///
+    /// Returns `None` if block does not exist.
+    async fn transactions_by_block_id(
+        &self,
+        block: BlockId,
+    ) -> EthResult<Option<Vec<TransactionSigned>>>;
 
     /// Returns the transaction by hash.
     ///
@@ -116,7 +124,9 @@ pub trait EthTransactions: Send + Sync {
     where
         I: for<'r> Inspector<CacheDB<State<StateProviderBox<'r>>>> + Send;
 
-    /// Executes the transaction at the given [BlockId] with a tracer configured by the config.
+    /// Executes the transaction on top of the given [BlockId] with a tracer configured by the
+    /// config.
+    ///
     /// The callback is then called with the [TracingInspector] and the [ResultAndState] after the
     /// configured [Env] was inspected.
     fn trace_at<F, R>(
@@ -129,8 +139,10 @@ pub trait EthTransactions: Send + Sync {
     where
         F: FnOnce(TracingInspector, ResultAndState) -> EthResult<R>;
 
-    /// Retrieves the transaction if it exists and returns its trace
-    async fn trace_transaction<F, R>(
+    /// Retrieves the transaction if it exists and returns its trace.
+    ///
+    /// Before the transaction is traced, all previous transaction in the block are applied to the state by executing them first
+    async fn trace_transaction_in_block<F, R>(
         &self,
         hash: H256,
         config: TracingInspectorConfig,
@@ -151,7 +163,7 @@ where
         self.state_at_block_id(at)
     }
 
-    fn with_state_at<F, T>(&self, at: BlockId, f: F) -> EthResult<T>
+    fn with_state_at_block<F, T>(&self, at: BlockId, f: F) -> EthResult<T>
     where
         F: FnOnce(StateProviderBox<'_>) -> EthResult<T>,
     {
@@ -183,6 +195,16 @@ where
         block: H256,
     ) -> EthResult<Option<Vec<TransactionSigned>>> {
         Ok(self.cache().get_block_transactions(block).await?)
+    }
+
+    async fn transactions_by_block_id(
+        &self,
+        block: BlockId,
+    ) -> EthResult<Option<Vec<TransactionSigned>>> {
+        match self.client().block_hash_for_id(block)? {
+            None => Ok(None),
+            Some(hash) => self.transactions_by_block(hash).await,
+        }
     }
 
     async fn transaction_by_hash(&self, hash: H256) -> EthResult<Option<TransactionSource>> {
@@ -391,7 +413,7 @@ where
     where
         F: FnOnce(TracingInspector, ResultAndState) -> EthResult<R>,
     {
-        self.with_state_at(at, |state| {
+        self.with_state_at_block(at, |state| {
             let db = SubState::new(State::new(state));
 
             let mut inspector = TracingInspector::new(config);
@@ -401,7 +423,7 @@ where
         })
     }
 
-    async fn trace_transaction<F, R>(
+    async fn trace_transaction_in_block<F, R>(
         &self,
         hash: H256,
         config: TracingInspectorConfig,
@@ -414,14 +436,27 @@ where
             None => return Ok(None),
             Some(res) => res,
         };
-
-        let (cfg, block, at) = self.evm_env_at(at).await?;
         let (tx, tx_info) = transaction.split();
-        let tx = tx_env_with_recovered(&tx);
-        let env = Env { cfg, block, tx };
 
-        // execute the trace
-        self.trace_at(env, config, at, move |insp, res| f(tx_info, insp, res)).map(Some)
+        let block_env = self.evm_env_at(at);
+        let block_txs = self.transactions_by_block_id(at);
+        let (block_env, block_txs) = futures::try_join!(block_env, block_txs)?;
+        let block_txs = block_txs.unwrap_or_default();
+        let (cfg, block_env, at) = block_env;
+
+        self.with_state_at_block(at, |state| {
+            let mut db = SubState::new(State::new(state));
+
+            // replay all transactions prior to the targeted transaction
+            replay_transactions_until(&mut db, cfg.clone(), block_env.clone(), block_txs, tx.hash)?;
+
+            let env = Env { cfg, block: block_env, tx: tx_env_with_recovered(&tx) };
+
+            let mut inspector = TracingInspector::new(config);
+            let (res, _) = inspect(db, env, &mut inspector)?;
+            f(tx_info, inspector, res)
+        })
+        .map(Some)
     }
 }
 

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -129,7 +129,7 @@ where
         let (cfg, block_env, at) = self.eth_api.evm_env_at(at).await?;
 
         // execute all transactions on top of each other and record the traces
-        self.eth_api.with_state_at(at, move |state| {
+        self.eth_api.with_state_at_block(at, move |state| {
             let mut results = Vec::with_capacity(calls.len());
             let mut db = SubState::new(State::new(state));
 
@@ -155,7 +155,7 @@ where
     ) -> EthResult<TraceResults> {
         let config = tracing_config(&trace_types);
         self.eth_api
-            .trace_transaction(hash, config, |_, inspector, res| {
+            .trace_transaction_in_block(hash, config, |_, inspector, res| {
                 let trace_res =
                     inspector.into_parity_builder().into_trace_results(res.result, &trace_types);
                 Ok(trace_res)
@@ -191,7 +191,7 @@ where
         let _permit = self.acquire_trace_permit().await;
 
         self.eth_api
-            .trace_transaction(
+            .trace_transaction_in_block(
                 hash,
                 TracingInspectorConfig::default_parity(),
                 |tx_info, inspector, _| {
@@ -226,7 +226,7 @@ where
 
         // replay all transactions of the block
         self.eth_api
-            .with_state_at(at, move |state| {
+            .with_state_at_block(at, move |state| {
                 let mut results = Vec::with_capacity(transactions.len());
                 let mut db = SubState::new(State::new(state));
 


### PR DESCRIPTION
now that we have block level granularity, we need to replay transaction in the block first.

copilot:summary


I'm not 100% sure about the state we need to apply this, I suspect we need to use `tx.block.parent_hash` and not `tx.block.hash`?