### PR TITLE
chore(tree): Add additional checks to not insert empty chain

### DIFF
--- a/crates/storage/provider/src/chain.rs
+++ b/crates/storage/provider/src/chain.rs
@@ -36,6 +36,11 @@ impl Chain {
         &self.state
     }
 
+    /// Return true if chain is empty and has no blocks.
+    pub fn is_empty(&self) -> bool {
+        self.blocks.is_empty()
+    }
+
     /// Return block number of the block hash.
     pub fn block_number(&self, block_hash: BlockHash) -> Option<BlockNumber> {
         self.blocks.iter().find_map(|(num, block)| (block.hash() == block_hash).then_some(*num))


### PR DESCRIPTION
There were some reports that tree panic when the tree chain does not have blocks.

This PR adds additional checks that would mitigate this and I added an additional error log to have more information on where potentially this can happen. 


picture:
![image](https://user-images.githubusercontent.com/13179220/235913263-f8b3078f-cfe3-4cdb-b720-6af2b0a5393d.png)
