### PR TITLE
fix: return zero hash for terminal block condition

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -275,9 +275,20 @@ where
         parent_hash: H256,
         tree_error: Option<&Error>,
     ) -> Option<H256> {
-        // check pre merge block error
-        if let Some(Error::Execution(ExecutorError::BlockPreMerge { .. })) = tree_error {
-            return Some(H256::zero())
+        // handle errors that require zero hash
+        if let Some(err) = tree_error {
+            match err {
+                Error::Execution(ExecutorError::BlockPreMerge { .. }) => {
+                    // check pre merge block error
+                    return Some(H256::zero())
+                }
+                Error::Consensus(_) => {
+                   // terminal block conditions are not satisfied
+                   // > {status: INVALID, latestValidHash: 0x0000000000000000000000000000000000000000000000000000000000000000, validationError: errorMessage | null} if terminal block conditions are not satisfied
+                   return Some(H256::zero())
+               }
+                _ => {}
+            }
         }
 
         self.blockchain_tree.find_canonical_ancestor(parent_hash)


### PR DESCRIPTION
adds another check for when to return zero hash, though I'm not sure what `terminal block condtions` means? wrong state root is definitely one

> {status: INVALID, latestValidHash: 0x0000000000000000000000000000000000000000000000000000000000000000, validationError: errorMessage | null} if terminal block conditions are not satisfied

ref https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/paris.md#engine_newpayloadv1