### PR TITLE
fix: ensure parent hash and number match

### DIFF
--- a/crates/blockchain-tree/src/block_indices.rs
+++ b/crates/blockchain-tree/src/block_indices.rs
@@ -337,9 +337,22 @@ impl BlockIndices {
         lose_chains
     }
 
-    /// get canonical hash
+    /// Returns the block hash of the canonical block with the given number.
     pub fn canonical_hash(&self, block_number: BlockNumber) -> Option<BlockHash> {
         self.canonical_chain.get(&block_number).cloned()
+    }
+
+    /// Returns the block number of the canonical block with the given hash.
+    pub fn canonical_number(&self, block_hash: BlockHash) -> Option<BlockNumber> {
+        self.canonical_chain.iter().find_map(
+            |(number, hash)| {
+                if *hash == block_hash {
+                    Some(*number)
+                } else {
+                    None
+                }
+            },
+        )
     }
 
     /// get canonical tip

--- a/crates/rpc/rpc-types/src/eth/engine/payload.rs
+++ b/crates/rpc/rpc-types/src/eth/engine/payload.rs
@@ -399,6 +399,9 @@ pub enum PayloadValidationError {
     /// Thrown when a forkchoice update's head links to a previously rejected payload.
     #[error("links to previously rejected block")]
     LinksToRejectedPayload,
+    /// Thrown when a new payload contains a wrong block number.
+    #[error("invalid block number")]
+    InvalidBlockNumber,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
this adds a check that if the parent block is part of the canonical chain then the hashes must match.

@rakita I suspect there will be additional checks like these so perhaps we should keep the actual canonical headers and not just the hashes? or perhaps a better alternative is to check if block exists in DB?

passes:
```
./hive --client reth --sim ethereum/engine --sim.limit "/Invalid Number NewPayload" 
```