### PR TITLE
perf: use jemalloc + switch to lto/low codegen units

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2936,6 +2936,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
+name = "jemalloc-sys"
+version = "0.5.3+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9bd5d616ea7ed58b571b2e209a65759664d7fb021a0819d7a790afc67e47ca1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16c2514137880c52b0b4822b563fadd38257c1f380858addb74a400889696ea6"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4583,6 +4603,7 @@ dependencies = [
  "hex",
  "human_bytes",
  "hyper",
+ "jemallocator",
  "metrics",
  "metrics-exporter-prometheus",
  "metrics-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,12 @@ default-members = ["bin/reth"]
 inherits = "release"
 debug = true
 
+[profile.maxperf]
+inherits = "release"
+lto = "fat"
+codegen-units = 1
+incremental = false
+
 [patch.crates-io]
 # patched for quantity U256 responses <https://github.com/recmo/uint/issues/224>
 ruint = { git = "https://github.com/paradigmxyz/uint" }

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -10,6 +10,10 @@ build = "build.rs"
 [build-dependencies]
 built = { version = "0.6", features = ["git2", "chrono", "semver"] }
 
+# Add jemalloc for extra perf on Linux systems.
+[target.'cfg(all(not(windows), not(target_env = "musl")))'.dependencies]
+jemallocator = "0.5.0"
+
 [dependencies]
 # reth
 reth-primitives = { path = "../../crates/primitives", features = ["arbitrary"] }

--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -26,3 +26,4 @@ pub mod test_vectors;
 pub mod utils;
 pub mod version;
 use built as _;
+use jemallocator as _;

--- a/bin/reth/src/main.rs
+++ b/bin/reth/src/main.rs
@@ -1,3 +1,8 @@
+// We use jemalloc for performance reasons
+#[cfg(all(not(windows), not(target_env = "musl")))]
+#[global_allocator]
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 fn main() {
     if let Err(err) = reth::cli::run() {
         eprintln!("Error: {err:?}");


### PR DESCRIPTION
As title. This yielded a solid 20%+ across the board. `RUSTFLAGS="-C target-cpu=native" cargo b --profile maxperf`

h/t sigmaprime team for the `maxperf` name, i had forgotten about this profile setting for a bit