### PR TITLE
fix: correct effective_gas_price

### DIFF
--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -409,7 +409,9 @@ impl Transaction {
     // 	return dst.Set(tx.GasPrice)
     // }
 
-    /// Returns the effective gas price for the given base fee
+    /// Returns the effective gas price for the given base fee.
+    ///
+    /// If the transaction is a legacy or EIP2930 transaction, the gas price is returned.
     pub fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
         let dynamic_tx = match self {
             Transaction::Legacy(tx) => return tx.gas_price,

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -369,7 +369,7 @@ impl Transaction {
     /// transactions is returned.
     ///
     /// If the `max_fee_per_gas` is less than the base fee, `None` returned.
-    pub fn effective_gas_price(&self, base_fee: Option<u64>) -> Option<u128> {
+    pub fn effective_gas_tip(&self, base_fee: Option<u64>) -> Option<u128> {
         if let Some(base_fee) = base_fee {
             let max_fee_per_gas = self.max_fee_per_gas();
             if max_fee_per_gas < base_fee as u128 {

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -400,15 +400,6 @@ impl Transaction {
         }
     }
 
-    // impls for non dynamic:
-    // func (tx *LegacyTx) effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int {
-    // 	return dst.Set(tx.GasPrice)
-    // }
-    //
-    // func (tx *AccessListTx) effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int {
-    // 	return dst.Set(tx.GasPrice)
-    // }
-
     /// Returns the effective gas price for the given base fee.
     ///
     /// If the transaction is a legacy or EIP2930 transaction, the gas price is returned.
@@ -656,23 +647,6 @@ impl Encodable for Transaction {
 }
 
 impl TxEip1559 {
-    // go function we need to impl for dynamic fee txs
-    // func (tx *DynamicFeeTx) effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int {
-    // 	if baseFee == nil {
-    // 		return dst.Set(tx.GasFeeCap)
-    // 	}
-    //
-    // 	// tip = tx.GasFeeCap - baseFee
-    // 	tip := dst.Sub(tx.GasFeeCap, baseFee)
-    // 	if tip.Cmp(tx.GasTipCap) > 0 {
-    // 		tip.Set(tx.GasTipCap)
-    // 		// ends up returning tx.GasTipCap + baseFee
-    // 	}
-    //
-    // 	// if tip < tx.GasTipCap, tip = tx.GasFeeCap - baseFee + baseFee = tx.GasFeeCap
-    // 	return tip.Add(tip, baseFee)
-    // }
-
     /// Returns the effective gas price for the given `base_fee`.
     pub fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
         match base_fee {

--- a/crates/rpc/rpc/src/eth/api/fees.rs
+++ b/crates/rpc/rpc/src/eth/api/fees.rs
@@ -129,7 +129,7 @@ where
                 let mut sorter = Vec::with_capacity(transactions.len());
                 for transaction in transactions.iter() {
                     let reward = transaction
-                        .effective_gas_price(header.base_fee_per_gas)
+                        .effective_gas_tip(header.base_fee_per_gas)
                         .ok_or(InvalidTransactionError::FeeCapTooLow)?;
 
                     sorter.push(TxGasAndReward { gas_used: header.gas_used as u128, reward })

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -596,10 +596,7 @@ where
             gas_used: Some(U256::from(gas_used)),
             contract_address: None,
             logs: Vec::with_capacity(receipt.logs.len()),
-            effective_gas_price: transaction
-                .effective_gas_price(meta.base_fee)
-                .map(U128::from)
-                .unwrap_or(U128::ZERO),
+            effective_gas_price: U128::from(transaction.effective_gas_price(meta.base_fee)),
             transaction_type: tx.transaction.tx_type().into(),
             // TODO pre-byzantium receipts have a post-transaction state root
             state_root: None,


### PR DESCRIPTION
Fixes #2571 

Uses the following go impls as guidance to fix `effective_gas_price`:
Legacy:
https://github.com/ethereum/go-ethereum/blob/dde2da0efb8e9a1812f470bc43254134cd1f8cc0/core/types/tx_legacy.go#L109-L111

Eip2930:
https://github.com/ethereum/go-ethereum/blob/dde2da0efb8e9a1812f470bc43254134cd1f8cc0/core/types/tx_access_list.go#L112-L114

Eip1559:
https://github.com/ethereum/go-ethereum/blob/dde2da0efb8e9a1812f470bc43254134cd1f8cc0/core/types/tx_dynamic_fee.go#L101-L110

Renames the old `effective_gas_price` to `effective_gas_tip` to mirror the geth function it implements, as well as in the `eth_feeHistory` impl.