### PR TITLE
chore(cli): remove `--db` options from cli commands

### DIFF
--- a/bin/reth/src/chain/init.rs
+++ b/bin/reth/src/chain/init.rs
@@ -5,7 +5,7 @@ use reth_staged_sync::utils::{
     chainspec::genesis_value_parser,
     init::{init_db, init_genesis},
 };
-use std::{path::PathBuf, sync::Arc};
+use std::{sync::Arc};
 use tracing::info;
 
 /// Initializes the database with the genesis block.
@@ -20,11 +20,6 @@ pub struct InitCommand {
     /// - macOS: `$HOME/Library/Application Support/reth/`
     #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
     datadir: MaybePlatformPath<DataDirPath>,
-
-    /// The path to the database folder. If not specified, it will be set in the data dir for the
-    /// chain being used.
-    #[arg(long, value_name = "PATH", verbatim_doc_comment)]
-    db: Option<PathBuf>,
 
     /// The chain this node is running.
     ///
@@ -51,10 +46,7 @@ impl InitCommand {
 
         // add network name to data dir
         let data_dir = self.datadir.unwrap_or_chain_default(self.chain.chain);
-
-        // use the overridden db path if specified
-        let db_path = self.db.clone().unwrap_or(data_dir.db_path());
-
+        let db_path = data_dir.db_path();
         info!(target: "reth::cli", path = ?db_path, "Opening database");
         let db = Arc::new(init_db(&db_path)?);
         info!(target: "reth::cli", "Database opened");

--- a/bin/reth/src/chain/init.rs
+++ b/bin/reth/src/chain/init.rs
@@ -5,7 +5,7 @@ use reth_staged_sync::utils::{
     chainspec::genesis_value_parser,
     init::{init_db, init_genesis},
 };
-use std::{sync::Arc};
+use std::sync::Arc;
 use tracing::info;
 
 /// Initializes the database with the genesis block.

--- a/bin/reth/src/cli.rs
+++ b/bin/reth/src/cli.rs
@@ -205,7 +205,11 @@ mod tests {
     fn test_parse_help_all_subcommands() {
         let reth = Cli::command();
         for sub_command in reth.get_subcommands() {
-            let err = Cli::try_parse_from(["reth", sub_command.get_name(), "--help"]).err().unwrap_or_else(|| panic!("Failed to parse help message {}", sub_command.get_name()));
+            let err = Cli::try_parse_from(["reth", sub_command.get_name(), "--help"])
+                .err()
+                .unwrap_or_else(|| {
+                    panic!("Failed to parse help message {}", sub_command.get_name())
+                });
 
             // --help is treated as error, but
             // > Not a true "error" as it means --help or similar was used. The help message will be sent to stdout.

--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -10,7 +10,7 @@ use human_bytes::human_bytes;
 use reth_db::{database::Database, tables};
 use reth_primitives::ChainSpec;
 use reth_staged_sync::utils::chainspec::genesis_value_parser;
-use std::{path::PathBuf, sync::Arc};
+use std::{sync::Arc};
 use tracing::error;
 
 /// DB List TUI
@@ -28,11 +28,6 @@ pub struct Command {
     /// - macOS: `$HOME/Library/Application Support/reth/`
     #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
     datadir: MaybePlatformPath<DataDirPath>,
-
-    /// The path to the database folder. If not specified, it will be set in the data dir for the
-    /// chain being used.
-    #[arg(long, value_name = "PATH", verbatim_doc_comment)]
-    db: Option<PathBuf>,
 
     /// The chain this node is running.
     ///
@@ -95,10 +90,7 @@ impl Command {
     pub async fn execute(self) -> eyre::Result<()> {
         // add network name to data dir
         let data_dir = self.datadir.unwrap_or_chain_default(self.chain.chain);
-
-        // use the overridden db path if specified
-        let db_path = self.db.clone().unwrap_or(data_dir.db_path());
-
+        let db_path = data_dir.db_path();
         std::fs::create_dir_all(&db_path)?;
 
         // TODO: Auto-impl for Database trait

--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -10,7 +10,7 @@ use human_bytes::human_bytes;
 use reth_db::{database::Database, tables};
 use reth_primitives::ChainSpec;
 use reth_staged_sync::utils::chainspec::genesis_value_parser;
-use std::{sync::Arc};
+use std::sync::Arc;
 use tracing::error;
 
 /// DB List TUI

--- a/bin/reth/src/drop_stage.rs
+++ b/bin/reth/src/drop_stage.rs
@@ -57,7 +57,7 @@ impl Command {
     /// Execute `db` command
     pub async fn execute(self) -> eyre::Result<()> {
         // add network name to data dir
-        let data_dir: crate::dirs::ChainPath<DataDirPath> = self.datadir.unwrap_or_chain_default(self.chain.chain);
+        let data_dir = self.datadir.unwrap_or_chain_default(self.chain.chain);
         let db_path = data_dir.db_path();
         std::fs::create_dir_all(&db_path)?;
 

--- a/bin/reth/src/drop_stage.rs
+++ b/bin/reth/src/drop_stage.rs
@@ -17,7 +17,7 @@ use reth_stages::stages::{
     ACCOUNT_HASHING, EXECUTION, INDEX_ACCOUNT_HISTORY, INDEX_STORAGE_HISTORY, MERKLE_EXECUTION,
     MERKLE_UNWIND, STORAGE_HASHING,
 };
-use std::{path::PathBuf, sync::Arc};
+use std::{sync::Arc};
 use tracing::info;
 
 /// `reth drop-stage` command
@@ -32,11 +32,6 @@ pub struct Command {
     /// - macOS: `$HOME/Library/Application Support/reth/`
     #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
     datadir: MaybePlatformPath<DataDirPath>,
-
-    /// The path to the database folder. If not specified, it will be set in the data dir for the
-    /// chain being used.
-    #[arg(long, value_name = "PATH", verbatim_doc_comment)]
-    db: Option<PathBuf>,
 
     /// The chain this node is running.
     ///
@@ -62,11 +57,8 @@ impl Command {
     /// Execute `db` command
     pub async fn execute(self) -> eyre::Result<()> {
         // add network name to data dir
-        let data_dir = self.datadir.unwrap_or_chain_default(self.chain.chain);
-
-        // use the overridden db path if specified
-        let db_path = self.db.clone().unwrap_or(data_dir.db_path());
-
+        let data_dir: crate::dirs::ChainPath<DataDirPath> = self.datadir.unwrap_or_chain_default(self.chain.chain);
+        let db_path = data_dir.db_path();
         std::fs::create_dir_all(&db_path)?;
 
         let db = Env::<WriteMap>::open(db_path.as_ref(), reth_db::mdbx::EnvKind::RW)?;

--- a/bin/reth/src/drop_stage.rs
+++ b/bin/reth/src/drop_stage.rs
@@ -17,7 +17,7 @@ use reth_stages::stages::{
     ACCOUNT_HASHING, EXECUTION, INDEX_ACCOUNT_HISTORY, INDEX_STORAGE_HISTORY, MERKLE_EXECUTION,
     MERKLE_UNWIND, STORAGE_HASHING,
 };
-use std::{sync::Arc};
+use std::sync::Arc;
 use tracing::info;
 
 /// `reth drop-stage` command

--- a/bin/reth/src/dump_stage/mod.rs
+++ b/bin/reth/src/dump_stage/mod.rs
@@ -37,11 +37,6 @@ pub struct Command {
     #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
     datadir: MaybePlatformPath<DataDirPath>,
 
-    /// The path to the database folder. If not specified, it will be set in the data dir for the
-    /// chain being used.
-    #[arg(long, value_name = "PATH", verbatim_doc_comment)]
-    db: Option<PathBuf>,
-
     /// The chain this node is running.
     ///
     /// Possible values are either a built-in chain or the path to a chain specification file.
@@ -100,10 +95,7 @@ impl Command {
     pub async fn execute(self) -> eyre::Result<()> {
         // add network name to data dir
         let data_dir = self.datadir.unwrap_or_chain_default(self.chain.chain);
-
-        // use the overridden db path if specified
-        let db_path = self.db.clone().unwrap_or(data_dir.db_path());
-
+        let db_path = data_dir.db_path();
         info!(target: "reth::cli", path = ?db_path, "Opening database");
         std::fs::create_dir_all(&db_path)?;
 

--- a/bin/reth/src/merkle_debug.rs
+++ b/bin/reth/src/merkle_debug.rs
@@ -12,7 +12,7 @@ use reth_stages::{
     },
     ExecInput, Stage,
 };
-use std::{ops::Deref, path::PathBuf, sync::Arc};
+use std::{ops::Deref, sync::Arc};
 
 /// `reth merkle-debug` command
 #[derive(Debug, Parser)]
@@ -26,11 +26,6 @@ pub struct Command {
     /// - macOS: `$HOME/Library/Application Support/reth/`
     #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
     datadir: MaybePlatformPath<DataDirPath>,
-
-    /// The path to the database folder. If not specified, it will be set in the data dir for the
-    /// chain being used.
-    #[arg(long, value_name = "PATH", verbatim_doc_comment)]
-    db: Option<PathBuf>,
 
     /// The chain this node is running.
     ///
@@ -63,10 +58,7 @@ impl Command {
     pub async fn execute(self) -> eyre::Result<()> {
         // add network name to data dir
         let data_dir = self.datadir.unwrap_or_chain_default(self.chain.chain);
-
-        // use the overridden db path if specified
-        let db_path = self.db.clone().unwrap_or(data_dir.db_path());
-
+        let db_path = data_dir.db_path();
         std::fs::create_dir_all(&db_path)?;
 
         let db = Arc::new(init_db(db_path)?);

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -92,11 +92,6 @@ pub struct Command {
     #[arg(long, value_name = "FILE", verbatim_doc_comment)]
     config: Option<PathBuf>,
 
-    /// The path to the database folder. If not specified, it will be set in the data dir for the
-    /// chain being used.
-    #[arg(long, value_name = "PATH", verbatim_doc_comment)]
-    db: Option<PathBuf>,
-
     /// The chain this node is running.
     ///
     /// Possible values are either a built-in chain or the path to a chain specification file.
@@ -152,9 +147,7 @@ impl Command {
         // always store reth.toml in the data dir, not the chain specific data dir
         info!(target: "reth::cli", path = ?config_path, "Configuration loaded");
 
-        // use the overridden db path if specified
-        let db_path = self.db.clone().unwrap_or(data_dir.db_path());
-
+        let db_path = data_dir.db_path();
         info!(target: "reth::cli", path = ?db_path, "Opening database");
         let db = Arc::new(init_db(&db_path)?);
         info!(target: "reth::cli", "Database opened");
@@ -797,12 +790,12 @@ mod tests {
     fn parse_db_path() {
         let cmd = Command::try_parse_from(["reth", "--db", "my/path/to/db"]).unwrap();
         let data_dir = cmd.datadir.unwrap_or_chain_default(cmd.chain.chain);
-        let db_path = cmd.db.unwrap_or(data_dir.db_path());
+        let db_path = data_dir.db_path();
         assert_eq!(db_path, Path::new("my/path/to/db"));
 
         let cmd = Command::try_parse_from(["reth"]).unwrap();
         let data_dir = cmd.datadir.unwrap_or_chain_default(cmd.chain.chain);
-        let db_path = cmd.db.unwrap_or(data_dir.db_path());
+        let db_path = data_dir.db_path();
         assert!(db_path.ends_with("reth/mainnet/db"), "{:?}", cmd.config);
     }
 }

--- a/crates/rlp/rlp-derive/src/de.rs
+++ b/crates/rlp/rlp-derive/src/de.rs
@@ -17,7 +17,7 @@ pub(crate) fn impl_decodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
         let is_opt = is_optional(field);
         if is_opt {
             if !supports_trailing_opt {
-                return Err(Error::new_spanned(field, "Optional fields are disabled. Add `#[rlp(trailing)]` attribute to the struct in order to enable"))
+                return Err(Error::new_spanned(field, "Optional fields are disabled. Add `#[rlp(trailing)]` attribute to the struct in order to enable"));
             }
             encountered_opt_item = true;
         } else if encountered_opt_item && !attributes_include(&field.attrs, "default") {

--- a/crates/rlp/rlp-derive/src/en.rs
+++ b/crates/rlp/rlp-derive/src/en.rs
@@ -26,7 +26,7 @@ pub(crate) fn impl_encodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
         let is_opt = is_optional(field);
         if is_opt {
             if !supports_trailing_opt {
-                return Err(Error::new_spanned(field, "Optional fields are disabled. Add `#[rlp(trailing)]` attribute to the struct in order to enable"))
+                return Err(Error::new_spanned(field, "Optional fields are disabled. Add `#[rlp(trailing)]` attribute to the struct in order to enable"));
             }
             encountered_opt_item = true;
         } else if encountered_opt_item {


### PR DESCRIPTION
## Description

Remove remaining `--db` options from cli commands.
Closes #2528

## Tests

1. Start a dev reth node using the default data-dir.

```bash
# clean the data-dir directory
$ rm -rf $HOME/Library/Application\ Support/reth/mainnet
$ tree $HOME/Library/Application\ Support/reth
/Users/leovct/Library/Application Support/reth

0 directories, 0 files 

# start a dev reth node using default data-dir
$ cargo run -- node --debug.tip 0xdc2d938e4cd0a149681e9e04352953ef5ab399d59bcd5b0357f6c0797470a524
...

# data-dir layout
$ tree $HOME/Library/Application\ Support/reth
/Users/leovct/Library/Application Support/reth
└── mainnet
    ├── db
    │   ├── mdbx.dat
    │   └── mdbx.lck
    ├── discovery-secret
    ├── jwt.hex
    └── reth.toml

3 directories, 5 files
```

2. Same thing but with a custom data-dir.

```bash
# clean the custom data-dir directory
$ rm -rf $HOME/temp-reth-datadir
$ tree $HOME/temp-reth-datadir
/Users/leovct/temp-reth-datadir

0 directories, 0 files

# start a dev reth node using custom data-dir
$ cargo run -- node --debug.tip 0xdc2d938e4cd0a149681e9e04352953ef5ab399d59bcd5b0357f6c0797470a524 --datadir $HOME/temp-reth-datadir
...

# data-dir layout
$ tree $HOME/temp-reth-datadir
├── db
│   ├── mdbx.dat
│   └── mdbx.lck
├── discovery-secret
├── jwt.hex
└── reth.toml

2 directories, 5 files
```
