### PR TITLE
feat(rpc): add parity trace conversion

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/builder/geth.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/geth.rs
@@ -39,8 +39,8 @@ impl GethTraceBuilder {
             // Fill in memory and storage depending on the options
             if !opts.disable_storage.unwrap_or_default() {
                 let contract_storage = storage.entry(step.contract).or_default();
-                if let Some((key, value)) = step.state_diff {
-                    contract_storage.insert(key.into(), value.into());
+                if let Some(change) = step.storage_change {
+                    contract_storage.insert(change.key.into(), change.value.into());
                     log.storage = Some(contract_storage.clone());
                 }
             }

--- a/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
@@ -104,30 +104,59 @@ impl ParityTraceBuilder {
     /// Returns the tracing types that are configured in the set
     pub fn into_trace_type_traces(
         self,
-        _trace_types: &HashSet<TraceType>,
+        trace_types: &HashSet<TraceType>,
     ) -> (Option<Vec<TransactionTrace>>, Option<VmTrace>, Option<StateDiff>) {
-        // TODO(mattsse): impl conversion
-        (None, None, None)
+        if trace_types.is_empty() || self.nodes.is_empty() {
+            return (None, None, None)
+        }
+
+        let with_traces = trace_types.contains(&TraceType::Trace);
+        let with_diff = trace_types.contains(&TraceType::StateDiff);
+
+        let vm_trace = if trace_types.contains(&TraceType::VmTrace) {
+            Some(vm_trace(&self.nodes))
+        } else {
+            None
+        };
+
+        let trace_addresses = self.trace_addresses();
+        let mut traces = Vec::with_capacity(if with_traces { self.nodes.len() } else { 0 });
+        let mut diff = StateDiff::default();
+
+        for (node, trace_address) in self.nodes.iter().zip(trace_addresses) {
+            if with_traces {
+                let trace = node.parity_transaction_trace(trace_address);
+                traces.push(trace);
+            }
+            if with_diff {
+                node.parity_update_state_diff(&mut diff);
+            }
+        }
+
+        let traces = with_traces.then_some(traces);
+        let diff = with_diff.then_some(diff);
+
+        (traces, vm_trace, diff)
     }
 
     /// Returns an iterator over all recorded traces  for `trace_transaction`
     pub fn into_transaction_traces_iter(self) -> impl Iterator<Item = TransactionTrace> {
         let trace_addresses = self.trace_addresses();
-
-        self.nodes.into_iter().zip(trace_addresses).map(|(node, trace_address)| {
-            let action = node.parity_action();
-            let output = TraceResult::parity_success(node.parity_trace_output());
-            TransactionTrace {
-                action,
-                result: Some(output),
-                trace_address,
-                subtraces: node.children.len(),
-            }
-        })
+        self.nodes
+            .into_iter()
+            .zip(trace_addresses)
+            .map(|(node, trace_address)| node.parity_transaction_trace(trace_address))
     }
 
     /// Returns the raw traces of the transaction
     pub fn into_transaction_traces(self) -> Vec<TransactionTrace> {
         self.into_transaction_traces_iter().collect()
     }
+}
+
+/// Construct the vmtrace for the entire callgraph
+fn vm_trace(nodes: &[CallTraceNode]) -> VmTrace {
+    // TODO: populate vm trace
+
+    VmTrace { code: nodes[0].trace.data.clone().into(), ops: vec![] }
 }

--- a/crates/rpc/rpc-types/src/eth/trace/parity.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/parity.rs
@@ -5,7 +5,10 @@
 
 use reth_primitives::{Address, Bytes, H256, U256, U64};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    ops::{Deref, DerefMut},
+};
 
 /// Result type for parity style transaction trace
 pub type TraceResult = crate::trace::common::TraceResult<TraceOutput, String>;
@@ -90,9 +93,23 @@ pub struct AccountDiff {
 }
 
 /// New-type for list of account diffs
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Default, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct StateDiff(pub BTreeMap<Address, AccountDiff>);
+
+impl Deref for StateDiff {
+    type Target = BTreeMap<Address, AccountDiff>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for StateDiff {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", tag = "type", content = "action")]
@@ -229,35 +246,50 @@ pub struct LocalizedTransactionTrace {
     pub block_hash: Option<H256>,
 }
 
+/// A record of a full VM trace for a CALL/CREATE.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct VmTrace {
+    /// The code to be executed.
     pub code: Bytes,
+    /// All executed instructions.
     pub ops: Vec<VmInstruction>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct VmInstruction {
+    /// The program counter.
     pub pc: usize,
+    /// The gas cost for this instruction.
     pub cost: u64,
+    /// Information concerning the execution of the operation.
     pub ex: Option<VmExecutedOperation>,
+    /// Subordinate trace of the CALL/CREATE if applicable.
     pub sub: Option<VmTrace>,
 }
 
+/// A record of an executed VM operation.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct VmExecutedOperation {
+    /// The total gas used.
     pub used: u64,
+    /// The stack item placed, if any.
     pub push: Option<H256>,
+    /// If altered, the memory delta.
     pub mem: Option<MemoryDelta>,
+    /// The altered storage value, if any.
     pub store: Option<StorageDelta>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+/// A diff of some chunk of memory.
 pub struct MemoryDelta {
+    /// Offset into memory the change begins.
     pub off: usize,
+    /// The changed data.
     pub data: Bytes,
 }
 


### PR DESCRIPTION
closes #1862

Adds (incomplete) conversions for parity VmTrace and StateDiff

the VmTrace is missing atm and should be tackled in a followup. I'll open a new issue with more details that replaces #1862.

