### PR TITLE
fix: remove transactionLogIndex from logs

### DIFF
--- a/crates/rpc/rpc-types/src/eth/log.rs
+++ b/crates/rpc/rpc-types/src/eth/log.rs
@@ -21,8 +21,6 @@ pub struct Log {
     pub transaction_index: Option<U256>,
     /// Log Index in Block
     pub log_index: Option<U256>,
-    /// Log Index in Transaction
-    pub transaction_log_index: Option<U256>,
     /// Geth Compatibility Field: whether this log was removed
     #[serde(default)]
     pub removed: bool,
@@ -40,7 +38,6 @@ impl Log {
             transaction_hash: None,
             transaction_index: None,
             log_index: None,
-            transaction_log_index: None,
             removed: false,
         }
     }
@@ -61,13 +58,12 @@ mod tests {
             transaction_hash: Some(H256::from_low_u64_be(0x1234)),
             transaction_index: Some(U256::from(0x1234)),
             log_index: Some(U256::from(0x1234)),
-            transaction_log_index: Some(U256::from(0x1234)),
             removed: false,
         };
         let serialized = serde_json::to_string(&log).unwrap();
         assert_eq!(
             serialized,
-            r#"{"address":"0x0000000000000000000000000000000000001234","topics":["0x0000000000000000000000000000000000000000000000000000000000001234"],"data":"0x1234","blockHash":"0x0000000000000000000000000000000000000000000000000000000000001234","blockNumber":"0x1234","transactionHash":"0x0000000000000000000000000000000000000000000000000000000000001234","transactionIndex":"0x1234","logIndex":"0x1234","transactionLogIndex":"0x1234","removed":false}"#
+            r#"{"address":"0x0000000000000000000000000000000000001234","topics":["0x0000000000000000000000000000000000000000000000000000000000001234"],"data":"0x1234","blockHash":"0x0000000000000000000000000000000000000000000000000000000000001234","blockNumber":"0x1234","transactionHash":"0x0000000000000000000000000000000000000000000000000000000000001234","transactionIndex":"0x1234","logIndex":"0x1234","removed":false}"#
         );
 
         let deserialized: Log = serde_json::from_str(&serialized).unwrap();

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -654,7 +654,6 @@ where
                 block_number: Some(U256::from(meta.block_number)),
                 transaction_hash: Some(meta.tx_hash),
                 transaction_index: Some(U256::from(meta.index)),
-                transaction_log_index: Some(U256::from(tx_log_idx)),
                 log_index: Some(U256::from(num_logs + tx_log_idx)),
                 removed: false,
             };

--- a/crates/rpc/rpc/src/eth/logs_utils.rs
+++ b/crates/rpc/rpc/src/eth/logs_utils.rs
@@ -33,7 +33,7 @@ pub(crate) fn append_matching_block_logs<I>(
     let mut log_index: u32 = 0;
     for (transaction_idx, (transaction_hash, receipt)) in tx_and_receipts.into_iter().enumerate() {
         let logs = receipt.logs;
-        for (transaction_log_idx, log) in logs.into_iter().enumerate() {
+        for log in logs.into_iter() {
             if log_matches_filter(block, &log, filter) {
                 let log = Log {
                     address: log.address,

--- a/crates/rpc/rpc/src/eth/logs_utils.rs
+++ b/crates/rpc/rpc/src/eth/logs_utils.rs
@@ -44,7 +44,6 @@ pub(crate) fn append_matching_block_logs<I>(
                     transaction_hash: Some(transaction_hash),
                     transaction_index: Some(U256::from(transaction_idx)),
                     log_index: Some(U256::from(log_index)),
-                    transaction_log_index: Some(U256::from(transaction_log_idx)),
                     removed,
                 };
                 all_logs.push(log);


### PR DESCRIPTION
Detected by @sslivkoff in https://github.com/paradigmxyz/reth/issues/2457

> The transactionLogIndex is not in [ETH JSON RPC Spec](https://eth.wiki/json-rpc/API#json-rpc-methods), so clients that conform to that do not have it. However, I've seen transactionLogIndex in Parity/OpenEthereum.
> Note that transactionLogIndex is not as same as logIndex (which is kind of blockLogIndex).

https://github.com/ethers-io/ethers.js/issues/1721#issuecomment-869111882

Fixes https://github.com/paradigmxyz/reth/issues/2569