### PR TITLE
chore: add transaction_type field to callrequest

### DIFF
--- a/crates/rpc/rpc-types/src/eth/call.rs
+++ b/crates/rpc/rpc-types/src/eth/call.rs
@@ -1,9 +1,9 @@
-use reth_primitives::{AccessList, Address, Bytes, U256, U64};
+use reth_primitives::{AccessList, Address, Bytes, U256, U64, U8};
 use serde::{Deserialize, Serialize};
 
 /// Call request
 #[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+#[serde(default, rename_all = "camelCase")]
 pub struct CallRequest {
     /// From
     pub from: Option<Address>,
@@ -19,7 +19,10 @@ pub struct CallRequest {
     pub gas: Option<U256>,
     /// Value
     pub value: Option<U256>,
-    /// Data
+    /// Transaction data
+    ///
+    /// This accepts both `input` and `data`
+    #[serde(alias = "input")]
     pub data: Option<Bytes>,
     /// Nonce
     pub nonce: Option<U256>,
@@ -27,6 +30,9 @@ pub struct CallRequest {
     pub chain_id: Option<U64>,
     /// AccessList
     pub access_list: Option<AccessList>,
+    /// EIP-2718 type
+    #[serde(rename = "type")]
+    pub transaction_type: Option<U8>,
 }
 
 impl CallRequest {
@@ -35,5 +41,16 @@ impl CallRequest {
     /// The returns `gas_price` (legacy) if set or `max_fee_per_gas` (EIP1559)
     pub fn fee_cap(&self) -> Option<U256> {
         self.gas_price.or(self.max_fee_per_gas)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serde_call_request() {
+        let s = r#"{"accessList":[],"data":"0x0902f1ac","to":"0xa478c2975ab1ea89e8196811f51a7b7ade33eb11","type":"0x02"}"#;
+        let _req = serde_json::from_str::<CallRequest>(s).unwrap();
     }
 }

--- a/crates/rpc/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc/rpc-types/src/eth/transaction/request.rs
@@ -2,7 +2,7 @@ use crate::eth::transaction::typed::{
     EIP1559TransactionRequest, EIP2930TransactionRequest, LegacyTransactionRequest,
     TransactionKind, TypedTransactionRequest,
 };
-use reth_primitives::{AccessList, Address, Bytes, U128, U256};
+use reth_primitives::{AccessList, Address, Bytes, U128, U256, U8};
 use serde::{Deserialize, Serialize};
 
 /// Represents _all_ transaction requests received from RPC
@@ -28,6 +28,7 @@ pub struct TransactionRequest {
     /// value of th tx in wei
     pub value: Option<U256>,
     /// Any additional data sent
+    #[serde(alias = "input")]
     pub data: Option<Bytes>,
     /// Transaction nonce
     pub nonce: Option<U256>,
@@ -36,7 +37,7 @@ pub struct TransactionRequest {
     pub access_list: Option<AccessList>,
     /// EIP-2718 type
     #[serde(rename = "type")]
-    pub transaction_type: Option<U256>,
+    pub transaction_type: Option<U8>,
 }
 
 // == impl TransactionRequest ==

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -368,6 +368,7 @@ where
                     chain_id: Some(chain_id),
                     access_list: request.access_list.clone(),
                     max_priority_fee_per_gas: Some(U256::from(max_fee_per_gas)),
+                    transaction_type: None,
                 },
                 BlockId::Number(BlockNumberOrTag::Pending),
             )

--- a/crates/rpc/rpc/src/eth/revm_utils.rs
+++ b/crates/rpc/rpc/src/eth/revm_utils.rs
@@ -211,6 +211,7 @@ pub(crate) fn create_txn_env(block_env: &BlockEnv, request: CallRequest) -> EthR
         nonce,
         access_list,
         chain_id,
+        ..
     } = request;
 
     let CallFees { max_priority_fee_per_gas, gas_price } = CallFees::ensure_fees(


### PR DESCRIPTION
Closes #2586

* add `transaction_type` to CallRequest struct
* relaxes the deny unknown fields (perhaps additional fields for L2s?)

some clients apparently send this, however this isn't even used:

ref https://github.com/ethereum/go-ethereum/blob/8f373227ac481685148019b21ef9e1478d3ba609/internal/ethapi/transaction_args.go#L37-L37