### PR TITLE
test: add malformed header check

### DIFF
--- a/crates/storage/codecs/derive/src/arbitrary.rs
+++ b/crates/storage/codecs/derive/src/arbitrary.rs
@@ -42,6 +42,17 @@ pub fn maybe_generate_tests(args: TokenStream, ast: &DeriveInput) -> TokenStream
                     assert_eq!(field, decoded);
                     // ensure buffer is fully consumed by decode
                     assert!(b.is_empty());
+
+                    // malformed header check
+                    let mut decode_buf = &mut buf.as_slice();
+                    let mut header = reth_rlp::Header::decode(decode_buf).unwrap();
+                    header.payload_length+=1;
+                    let mut b = Vec::with_capacity(decode_buf.len());
+                    header.encode(&mut b);
+                    b.extend_from_slice(decode_buf);
+                    let res = super::#type_ident::decode(&mut b.as_ref());
+                    assert!(res.is_err());
+
                 }
             });
         } else if let Ok(num) = arg.to_string().parse() {

--- a/crates/storage/codecs/derive/src/arbitrary.rs
+++ b/crates/storage/codecs/derive/src/arbitrary.rs
@@ -41,7 +41,7 @@ pub fn maybe_generate_tests(args: TokenStream, ast: &DeriveInput) -> TokenStream
                     let decoded = super::#type_ident::decode(b).unwrap();
                     assert_eq!(field, decoded);
                     // ensure buffer is fully consumed by decode
-                    assert!(b.is_empty());
+                    assert!(b.is_empty(), "buffer was not consumed entirely");
 
                     // malformed header check
                     let mut decode_buf = &mut buf.as_slice();
@@ -51,8 +51,7 @@ pub fn maybe_generate_tests(args: TokenStream, ast: &DeriveInput) -> TokenStream
                     header.encode(&mut b);
                     b.extend_from_slice(decode_buf);
                     let res = super::#type_ident::decode(&mut b.as_ref());
-                    assert!(res.is_err());
-
+                    assert!(res.is_err(), "malformed header was decoded");
                 }
             });
         } else if let Ok(num) = arg.to_string().parse() {


### PR DESCRIPTION
Closes #2065

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e8501ee</samp>

Add a test case for `RlpDecodable` trait with malformed header. This improves the test coverage and error handling for the `crates/storage/codecs/derive` crate.