### PR TITLE
feat: gas price oracle

### DIFF
--- a/crates/interfaces/src/provider.rs
+++ b/crates/interfaces/src/provider.rs
@@ -86,6 +86,9 @@ pub enum ProviderError {
     /// Thrown when the cache service task dropped
     #[error("cache service task stopped")]
     CacheServiceUnavailable,
+    /// Thrown when the gas oracle task dropped
+    #[error("gas oracle task stopped")]
+    GasPriceOracleServiceUnavailable,
     /// Thrown when we failed to lookup a block for the pending state
     #[error("Unknown block hash: {0:}")]
     UnknownBlockHash(H256),

--- a/crates/rpc/rpc-builder/src/auth.rs
+++ b/crates/rpc/rpc-builder/src/auth.rs
@@ -14,8 +14,8 @@ use reth_provider::{
     BlockProviderIdExt, EvmEnvProvider, HeaderProvider, ReceiptProviderIdExt, StateProviderFactory,
 };
 use reth_rpc::{
-    eth::cache::EthStateCache, AuthLayer, Claims, EngineEthApi, EthApi, EthFilter,
-    JwtAuthValidator, JwtSecret,
+    eth::{cache::EthStateCache, gas_oracle::GasPriceOracle},
+    AuthLayer, Claims, EngineEthApi, EthApi, EthFilter, JwtAuthValidator, JwtSecret,
 };
 use reth_rpc_api::{servers::*, EngineApiServer};
 use reth_tasks::TaskSpawner;
@@ -52,7 +52,9 @@ where
 {
     // spawn a new cache task
     let eth_cache = EthStateCache::spawn_with(client.clone(), Default::default(), executor);
-    let eth_api = EthApi::new(client.clone(), pool.clone(), network, eth_cache.clone());
+    let gas_oracle = GasPriceOracle::spawn_with(client.clone(), Default::default(), executor);
+    let eth_api =
+        EthApi::new(client.clone(), pool.clone(), network, eth_cache.clone(), gas_oracle.clone());
     let eth_filter = EthFilter::new(client, pool, eth_cache.clone(), DEFAULT_MAX_LOGS_IN_RESPONSE);
     launch_with_eth_api(eth_api, eth_filter, engine_api, socket_addr, secret).await
 }

--- a/crates/rpc/rpc-builder/src/auth.rs
+++ b/crates/rpc/rpc-builder/src/auth.rs
@@ -52,9 +52,8 @@ where
 {
     // spawn a new cache task
     let eth_cache = EthStateCache::spawn_with(client.clone(), Default::default(), executor.clone());
-    let gas_oracle = GasPriceOracle::spawn_with(client.clone(), Default::default(), executor);
-    let eth_api =
-        EthApi::new(client.clone(), pool.clone(), network, eth_cache.clone(), gas_oracle.clone());
+    let gas_oracle = GasPriceOracle::new(client.clone(), Default::default());
+    let eth_api = EthApi::new(client.clone(), pool.clone(), network, eth_cache.clone(), gas_oracle);
     let eth_filter = EthFilter::new(client, pool, eth_cache.clone(), DEFAULT_MAX_LOGS_IN_RESPONSE);
     launch_with_eth_api(eth_api, eth_filter, engine_api, socket_addr, secret).await
 }

--- a/crates/rpc/rpc-builder/src/auth.rs
+++ b/crates/rpc/rpc-builder/src/auth.rs
@@ -51,7 +51,7 @@ where
     EngineApi: EngineApiServer,
 {
     // spawn a new cache task
-    let eth_cache = EthStateCache::spawn_with(client.clone(), Default::default(), executor);
+    let eth_cache = EthStateCache::spawn_with(client.clone(), Default::default(), executor.clone());
     let gas_oracle = GasPriceOracle::spawn_with(client.clone(), Default::default(), executor);
     let eth_api =
         EthApi::new(client.clone(), pool.clone(), network, eth_cache.clone(), gas_oracle.clone());

--- a/crates/rpc/rpc-builder/src/auth.rs
+++ b/crates/rpc/rpc-builder/src/auth.rs
@@ -52,7 +52,7 @@ where
 {
     // spawn a new cache task
     let eth_cache = EthStateCache::spawn_with(client.clone(), Default::default(), executor.clone());
-    let gas_oracle = GasPriceOracle::new(client.clone(), Default::default());
+    let gas_oracle = GasPriceOracle::new(client.clone(), Default::default(), eth_cache.clone());
     let eth_api = EthApi::new(client.clone(), pool.clone(), network, eth_cache.clone(), gas_oracle);
     let eth_filter = EthFilter::new(client, pool, eth_cache.clone(), DEFAULT_MAX_LOGS_IN_RESPONSE);
     launch_with_eth_api(eth_api, eth_filter, engine_api, socket_addr, secret).await

--- a/crates/rpc/rpc-builder/src/eth.rs
+++ b/crates/rpc/rpc-builder/src/eth.rs
@@ -1,5 +1,8 @@
 use reth_rpc::{
-    eth::cache::{EthStateCache, EthStateCacheConfig},
+    eth::{
+        cache::{EthStateCache, EthStateCacheConfig},
+        gas_oracle::GasPriceOracleConfig,
+    },
     EthApi, EthFilter, EthPubSub,
 };
 use serde::{Deserialize, Serialize};
@@ -25,6 +28,8 @@ pub struct EthHandlers<Client, Pool, Network, Events> {
 pub struct EthConfig {
     /// Settings for the caching layer
     pub cache: EthStateCacheConfig,
+    /// Settings for the gas price oracle
+    pub gas_oracle: GasPriceOracleConfig,
     /// The maximum number of tracing calls that can be executed in concurrently.
     pub max_tracing_requests: usize,
     /// Maximum number of logs that can be returned in a single response in `eth_getLogs` calls.
@@ -35,6 +40,7 @@ impl Default for EthConfig {
     fn default() -> Self {
         Self {
             cache: EthStateCacheConfig::default(),
+            gas_oracle: GasPriceOracleConfig::default(),
             max_tracing_requests: 10,
             max_logs_per_response: DEFAULT_MAX_LOGS_IN_RESPONSE,
         }

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -110,8 +110,9 @@ use reth_provider::{
     StateProviderFactory,
 };
 use reth_rpc::{
-    eth::cache::EthStateCache, AdminApi, DebugApi, EngineEthApi, EthApi, EthFilter, EthPubSub,
-    EthSubscriptionIdProvider, NetApi, TraceApi, TracingCallGuard, TxPoolApi, Web3Api,
+    eth::{cache::EthStateCache, gas_oracle::GasPriceOracle},
+    AdminApi, DebugApi, EngineEthApi, EthApi, EthFilter, EthPubSub, EthSubscriptionIdProvider,
+    NetApi, TraceApi, TracingCallGuard, TxPoolApi, Web3Api,
 };
 use reth_rpc_api::{servers::*, EngineApiServer};
 use reth_tasks::TaskSpawner;
@@ -801,6 +802,11 @@ where
                 self.config.eth.cache.clone(),
                 self.executor.clone(),
             );
+            let gas_oracle = GasPriceOracle::spawn_with(
+                self.client.clone(),
+                self.config.eth.gas_oracle.clone(),
+                self.executor.clone(),
+            );
             let new_canonical_blocks = self.events.canonical_state_stream();
             let c = cache.clone();
             self.executor.spawn_critical(
@@ -815,6 +821,7 @@ where
                 self.pool.clone(),
                 self.network.clone(),
                 cache.clone(),
+                gas_oracle.clone(),
             );
             let filter = EthFilter::new(
                 self.client.clone(),

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -802,11 +802,8 @@ where
                 self.config.eth.cache.clone(),
                 self.executor.clone(),
             );
-            let gas_oracle = GasPriceOracle::spawn_with(
-                self.client.clone(),
-                self.config.eth.gas_oracle.clone(),
-                self.executor.clone(),
-            );
+            let gas_oracle =
+                GasPriceOracle::new(self.client.clone(), self.config.eth.gas_oracle.clone());
             let new_canonical_blocks = self.events.canonical_state_stream();
             let c = cache.clone();
             self.executor.spawn_critical(

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -802,8 +802,11 @@ where
                 self.config.eth.cache.clone(),
                 self.executor.clone(),
             );
-            let gas_oracle =
-                GasPriceOracle::new(self.client.clone(), self.config.eth.gas_oracle.clone());
+            let gas_oracle = GasPriceOracle::new(
+                self.client.clone(),
+                self.config.eth.gas_oracle.clone(),
+                cache.clone(),
+            );
             let new_canonical_blocks = self.events.canonical_state_stream();
             let c = cache.clone();
             self.executor.spawn_critical(

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -821,7 +821,7 @@ where
                 self.pool.clone(),
                 self.network.clone(),
                 cache.clone(),
-                gas_oracle.clone(),
+                gas_oracle,
             );
             let filter = EthFilter::new(
                 self.client.clone(),

--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -97,8 +97,8 @@ where
     EthApiClient::send_transaction(client, transaction_request).await.unwrap_err();
     EthApiClient::hashrate(client).await.unwrap();
     EthApiClient::submit_hashrate(client, U256::default(), H256::default()).await.unwrap();
-    EthApiClient::gas_price(client).await.unwrap();
-    EthApiClient::max_priority_fee_per_gas(client).await.unwrap();
+    EthApiClient::gas_price(client).await.unwrap_err();
+    EthApiClient::max_priority_fee_per_gas(client).await.unwrap_err();
 
     // Unimplemented
     assert!(is_unimplemented(

--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -97,8 +97,8 @@ where
     EthApiClient::send_transaction(client, transaction_request).await.unwrap_err();
     EthApiClient::hashrate(client).await.unwrap();
     EthApiClient::submit_hashrate(client, U256::default(), H256::default()).await.unwrap();
-    EthApiClient::gas_price(client).await.unwrap_err();
-    EthApiClient::max_priority_fee_per_gas(client).await.unwrap_err();
+    EthApiClient::gas_price(client).await.unwrap();
+    EthApiClient::max_priority_fee_per_gas(client).await.unwrap();
 
     // Unimplemented
     assert!(is_unimplemented(

--- a/crates/rpc/rpc/src/eth/api/fees.rs
+++ b/crates/rpc/rpc/src/eth/api/fees.rs
@@ -30,8 +30,7 @@ where
 
     /// Returns a suggestion for the priority fee (the tip)
     pub(crate) async fn suggested_priority_fee(&self) -> EthResult<U256> {
-        // TODO: properly implement sampling https://github.com/ethereum/pm/issues/328#issuecomment-853234014
-        Ok(U256::from(1e9 as u64))
+        Ok(self.gas_oracle().suggest_tip().await?)
     }
 
     /// Reports the fee history, for the given amount of blocks, up until the newest block

--- a/crates/rpc/rpc/src/eth/api/fees.rs
+++ b/crates/rpc/rpc/src/eth/api/fees.rs
@@ -30,7 +30,7 @@ where
 
     /// Returns a suggestion for the priority fee (the tip)
     pub(crate) async fn suggested_priority_fee(&self) -> EthResult<U256> {
-        Ok(self.gas_oracle().suggest_tip().await?)
+        Ok(self.gas_oracle().suggest_tip_cap().await?)
     }
 
     /// Reports the fee history, for the given amount of blocks, up until the newest block

--- a/crates/rpc/rpc/src/eth/api/fees.rs
+++ b/crates/rpc/rpc/src/eth/api/fees.rs
@@ -30,7 +30,7 @@ where
 
     /// Returns a suggestion for the priority fee (the tip)
     pub(crate) async fn suggested_priority_fee(&self) -> EthResult<U256> {
-        Ok(self.gas_oracle().suggest_tip_cap().await?)
+        self.gas_oracle().suggest_tip_cap().await
     }
 
     /// Reports the fee history, for the given amount of blocks, up until the newest block

--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -77,7 +77,7 @@ impl<Client, Pool, Network> EthApi<Client, Pool, Network> {
         pool: Pool,
         network: Network,
         eth_cache: EthStateCache,
-        gas_oracle: GasPriceOracle,
+        gas_oracle: GasPriceOracle<Client>,
     ) -> Self {
         let inner = EthApiInner {
             client,
@@ -101,7 +101,7 @@ impl<Client, Pool, Network> EthApi<Client, Pool, Network> {
     }
 
     /// Returns the gas oracle frontend
-    pub(crate) fn gas_oracle(&self) -> &GasPriceOracle {
+    pub(crate) fn gas_oracle(&self) -> &GasPriceOracle<Client> {
         &self.inner.gas_oracle
     }
 
@@ -258,5 +258,5 @@ struct EthApiInner<Client, Pool, Network> {
     /// The async cache frontend for eth related data
     eth_cache: EthStateCache,
     /// The async gas oracle frontend for gas price suggestions
-    gas_oracle: GasPriceOracle,
+    gas_oracle: GasPriceOracle<Client>,
 }

--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -100,6 +100,11 @@ impl<Client, Pool, Network> EthApi<Client, Pool, Network> {
         &self.inner.eth_cache
     }
 
+    /// Returns the gas oracle frontend
+    pub(crate) fn gas_oracle(&self) -> &GasPriceOracle {
+        &self.inner.gas_oracle
+    }
+
     /// Returns the inner `Client`
     pub fn client(&self) -> &Client {
         &self.inner.client

--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -5,6 +5,7 @@
 
 use crate::eth::{
     cache::EthStateCache,
+    gas_oracle::GasPriceOracle,
     error::{EthApiError, EthResult},
     signer::EthSigner,
 };
@@ -71,8 +72,21 @@ pub struct EthApi<Client, Pool, Network> {
 
 impl<Client, Pool, Network> EthApi<Client, Pool, Network> {
     /// Creates a new, shareable instance.
-    pub fn new(client: Client, pool: Pool, network: Network, eth_cache: EthStateCache) -> Self {
-        let inner = EthApiInner { client, pool, network, signers: Default::default(), eth_cache };
+    pub fn new(
+        client: Client,
+        pool: Pool,
+        network: Network,
+        eth_cache: EthStateCache,
+        gas_oracle: GasPriceOracle,
+    ) -> Self {
+        let inner = EthApiInner {
+            client,
+            pool,
+            network,
+            signers: Default::default(),
+            eth_cache,
+            gas_oracle,
+        };
         Self {
             inner: Arc::new(inner),
             fee_history_cache: FeeHistoryCache::new(
@@ -238,4 +252,6 @@ struct EthApiInner<Client, Pool, Network> {
     signers: Vec<Box<dyn EthSigner>>,
     /// The async cache frontend for eth related data
     eth_cache: EthStateCache,
+    /// The async gas oracle frontend for gas price suggestions
+    gas_oracle: GasPriceOracle,
 }

--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -5,8 +5,8 @@
 
 use crate::eth::{
     cache::EthStateCache,
-    gas_oracle::GasPriceOracle,
     error::{EthApiError, EthResult},
+    gas_oracle::GasPriceOracle,
     signer::EthSigner,
 };
 use async_trait::async_trait;

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -384,7 +384,7 @@ mod tests {
             testing_pool(),
             NoopNetwork,
             EthStateCache::spawn(NoopProvider::default(), Default::default()),
-            GasPriceOracle::spawn(NoopProvider::default(), Default::default()),
+            GasPriceOracle::new(NoopProvider::default(), Default::default()),
         );
 
         let response = <EthApi<_, _, _> as EthApiServer>::fee_history(
@@ -465,11 +465,11 @@ mod tests {
         gas_used_ratios.pop();
 
         let eth_api = EthApi::new(
-            mock_provider,
+            mock_provider.clone(),
             testing_pool(),
             NoopNetwork,
             EthStateCache::spawn(NoopProvider::default(), Default::default()),
-            GasPriceOracle::spawn(NoopProvider::default(), Default::default()),
+            GasPriceOracle::new(mock_provider, Default::default()),
         );
 
         let response = <EthApi<_, _, _> as EthApiServer>::fee_history(

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -379,12 +379,13 @@ mod tests {
     #[tokio::test]
     /// Handler for: `eth_test_fee_history`
     async fn test_fee_history() {
+        let cache = EthStateCache::spawn(NoopProvider::default(), Default::default());
         let eth_api = EthApi::new(
             NoopProvider::default(),
             testing_pool(),
             NoopNetwork,
-            EthStateCache::spawn(NoopProvider::default(), Default::default()),
-            GasPriceOracle::new(NoopProvider::default(), Default::default()),
+            cache.clone(),
+            GasPriceOracle::new(NoopProvider::default(), Default::default(), cache),
         );
 
         let response = <EthApi<_, _, _> as EthApiServer>::fee_history(
@@ -464,12 +465,13 @@ mod tests {
 
         gas_used_ratios.pop();
 
+        let cache = EthStateCache::spawn(mock_provider.clone(), Default::default());
         let eth_api = EthApi::new(
             mock_provider.clone(),
             testing_pool(),
             NoopNetwork,
-            EthStateCache::spawn(NoopProvider::default(), Default::default()),
-            GasPriceOracle::new(mock_provider, Default::default()),
+            cache.clone(),
+            GasPriceOracle::new(mock_provider, Default::default(), cache.clone()),
         );
 
         let response = <EthApi<_, _, _> as EthApiServer>::fee_history(

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -364,7 +364,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{eth::cache::EthStateCache, EthApi};
+    use crate::{
+        eth::{cache::EthStateCache, gas_oracle::GasPriceOracle},
+        EthApi,
+    };
     use jsonrpsee::types::error::INVALID_PARAMS_CODE;
     use rand::random;
     use reth_network_api::test_utils::NoopNetwork;
@@ -381,6 +384,7 @@ mod tests {
             testing_pool(),
             NoopNetwork,
             EthStateCache::spawn(NoopProvider::default(), Default::default()),
+            GasPriceOracle::spawn(NoopProvider::default(), Default::default()),
         );
 
         let response = <EthApi<_, _, _> as EthApiServer>::fee_history(
@@ -465,6 +469,7 @@ mod tests {
             testing_pool(),
             NoopNetwork,
             EthStateCache::spawn(NoopProvider::default(), Default::default()),
+            GasPriceOracle::spawn(NoopProvider::default(), Default::default()),
         );
 
         let response = <EthApi<_, _, _> as EthApiServer>::fee_history(

--- a/crates/rpc/rpc/src/eth/api/state.rs
+++ b/crates/rpc/rpc/src/eth/api/state.rs
@@ -161,7 +161,7 @@ mod tests {
             pool.clone(),
             (),
             EthStateCache::spawn(NoopProvider::default(), Default::default()),
-            GasPriceOracle::spawn(NoopProvider::default(), Default::default()),
+            GasPriceOracle::new(NoopProvider::default(), Default::default()),
         );
         let address = Address::random();
         let storage = eth_api.storage_at(address, U256::ZERO.into(), None).unwrap();
@@ -179,8 +179,8 @@ mod tests {
             mock_provider.clone(),
             pool,
             (),
-            EthStateCache::spawn(mock_provider, Default::default()),
-            GasPriceOracle::spawn(NoopProvider::default(), Default::default()),
+            EthStateCache::spawn(mock_provider.clone(), Default::default()),
+            GasPriceOracle::new(mock_provider, Default::default()),
         );
 
         let storage_key: U256 = storage_key.into();

--- a/crates/rpc/rpc/src/eth/api/state.rs
+++ b/crates/rpc/rpc/src/eth/api/state.rs
@@ -156,12 +156,13 @@ mod tests {
         // === Noop ===
         let pool = testing_pool();
 
+        let cache = EthStateCache::spawn(NoopProvider::default(), Default::default());
         let eth_api = EthApi::new(
             NoopProvider::default(),
             pool.clone(),
             (),
-            EthStateCache::spawn(NoopProvider::default(), Default::default()),
-            GasPriceOracle::new(NoopProvider::default(), Default::default()),
+            cache.clone(),
+            GasPriceOracle::new(NoopProvider::default(), Default::default(), cache),
         );
         let address = Address::random();
         let storage = eth_api.storage_at(address, U256::ZERO.into(), None).unwrap();
@@ -175,12 +176,13 @@ mod tests {
         let account = ExtendedAccount::new(0, U256::ZERO).extend_storage(storage);
         mock_provider.add_account(address, account);
 
+        let cache = EthStateCache::spawn(mock_provider.clone(), Default::default());
         let eth_api = EthApi::new(
             mock_provider.clone(),
             pool,
             (),
-            EthStateCache::spawn(mock_provider.clone(), Default::default()),
-            GasPriceOracle::new(mock_provider, Default::default()),
+            cache.clone(),
+            GasPriceOracle::new(mock_provider, Default::default(), cache),
         );
 
         let storage_key: U256 = storage_key.into();

--- a/crates/rpc/rpc/src/eth/api/state.rs
+++ b/crates/rpc/rpc/src/eth/api/state.rs
@@ -145,7 +145,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::eth::cache::EthStateCache;
+    use crate::eth::{cache::EthStateCache, gas_oracle::GasPriceOracle};
     use reth_primitives::{StorageKey, StorageValue};
     use reth_provider::test_utils::{ExtendedAccount, MockEthProvider, NoopProvider};
     use reth_transaction_pool::test_utils::testing_pool;
@@ -161,6 +161,7 @@ mod tests {
             pool.clone(),
             (),
             EthStateCache::spawn(NoopProvider::default(), Default::default()),
+            GasPriceOracle::spawn(NoopProvider::default(), Default::default()),
         );
         let address = Address::random();
         let storage = eth_api.storage_at(address, U256::ZERO.into(), None).unwrap();
@@ -179,6 +180,7 @@ mod tests {
             pool,
             (),
             EthStateCache::spawn(mock_provider, Default::default()),
+            GasPriceOracle::spawn(NoopProvider::default(), Default::default()),
         );
 
         let storage_key: U256 = storage_key.into();

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -756,7 +756,10 @@ impl From<TransactionSource> for Transaction {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{eth::cache::EthStateCache, EthApi};
+    use crate::{
+        eth::{cache::EthStateCache, gas_oracle::GasPriceOracle},
+        EthApi,
+    };
     use reth_network_api::test_utils::NoopNetwork;
     use reth_primitives::{hex_literal::hex, Bytes};
     use reth_provider::test_utils::NoopProvider;
@@ -774,6 +777,7 @@ mod tests {
             pool.clone(),
             noop_network_provider,
             EthStateCache::spawn(NoopProvider::default(), Default::default()),
+            GasPriceOracle::spawn(NoopProvider::default(), Default::default()),
         );
 
         // https://etherscan.io/tx/0xa694b71e6c128a2ed8e2e0f6770bddbe52e3bb8f10e8472f9a79ab81497a8b5d

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -776,8 +776,8 @@ mod tests {
             noop_provider,
             pool.clone(),
             noop_network_provider,
-            EthStateCache::spawn(NoopProvider::default(), Default::default()),
-            GasPriceOracle::spawn(NoopProvider::default(), Default::default()),
+            EthStateCache::spawn(noop_provider, Default::default()),
+            GasPriceOracle::new(noop_provider, Default::default()),
         );
 
         // https://etherscan.io/tx/0xa694b71e6c128a2ed8e2e0f6770bddbe52e3bb8f10e8472f9a79ab81497a8b5d

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -772,12 +772,13 @@ mod tests {
 
         let pool = testing_pool();
 
+        let cache = EthStateCache::spawn(noop_provider, Default::default());
         let eth_api = EthApi::new(
             noop_provider,
             pool.clone(),
             noop_network_provider,
-            EthStateCache::spawn(noop_provider, Default::default()),
-            GasPriceOracle::new(noop_provider, Default::default()),
+            cache.clone(),
+            GasPriceOracle::new(noop_provider, Default::default(), cache),
         );
 
         // https://etherscan.io/tx/0xa694b71e6c128a2ed8e2e0f6770bddbe52e3bb8f10e8472f9a79ab81497a8b5d

--- a/crates/rpc/rpc/src/eth/gas_oracle.rs
+++ b/crates/rpc/rpc/src/eth/gas_oracle.rs
@@ -181,7 +181,7 @@ where
         // check the cache (this will hit the disk if the block is not cached)
         let block = match self.cache.get_block(block_hash).await? {
             Some(block) => block,
-            None => return Err(EthApiError::UnknownBlockNumber),
+            None => return Ok(None),
         };
 
         // sort the transactions by effective tip

--- a/crates/rpc/rpc/src/eth/gas_oracle.rs
+++ b/crates/rpc/rpc/src/eth/gas_oracle.rs
@@ -5,7 +5,7 @@ use reth_interfaces::{Error as GeneralError, Result};
 use reth_primitives::{
     constants::GWEI_TO_WEI, BlockHashOrNumber, BlockId, BlockNumberOrTag, H256, U256,
 };
-use reth_provider::{BlockProvider, ProviderError};
+use reth_provider::{BlockProviderIdExt, ProviderError};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::Mutex;
@@ -82,7 +82,7 @@ pub struct GasPriceOracle<Client> {
 
 impl<Client> GasPriceOracle<Client>
 where
-    Client: BlockProvider + 'static,
+    Client: BlockProviderIdExt + 'static,
 {
     /// Creates and returns the [GasPriceOracle].
     pub fn new(client: Client, oracle_config: GasPriceOracleConfig, cache: EthStateCache) -> Self {

--- a/crates/rpc/rpc/src/eth/gas_oracle.rs
+++ b/crates/rpc/rpc/src/eth/gas_oracle.rs
@@ -1,0 +1,216 @@
+//! An implementation of the eth gas price oracle, used for providing gas price estimates based on
+//! previous blocks.
+use futures::StreamExt;
+use reth_interfaces::Result;
+use reth_primitives::{Block, H256, U256};
+use reth_provider::BlockProvider;
+use reth_tasks::{TaskSpawner, TokioTaskExecutor};
+use serde::{Deserialize, Serialize};
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{ready, Context, Poll},
+};
+use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
+use tokio_stream::wrappers::UnboundedReceiverStream;
+
+// go code to port to rust
+// const sampleNumber = 3 // Number of transactions sampled in a block
+
+// var (
+// 	DefaultMaxPrice    = big.NewInt(500 * params.GWei)
+// 	DefaultIgnorePrice = big.NewInt(2 * params.Wei)
+// )
+
+// type Config struct {
+// 	Blocks           int
+// 	Percentile       int
+// 	MaxHeaderHistory uint64
+// 	MaxBlockHistory  uint64
+// 	// starting latest price
+// 	Default          *big.Int `toml:",omitempty"`
+// 	MaxPrice         *big.Int `toml:",omitempty"`
+// 	IgnorePrice      *big.Int `toml:",omitempty"`
+// }
+
+/// The number of transactions sampled in a block
+pub const SAMPLE_NUMBER: u32 = 3;
+
+/// The default maximum gas price to use for the estimate
+pub const DEFAULT_MAX_PRICE: U256 = U256::from_limbs([500_000_000_000u64, 0, 0, 0]);
+
+/// The default minimum gas price, under which the sample will be ignored
+pub const DEFAULT_IGNORE_PRICE: U256 = U256::from_limbs([2u64, 0, 0, 0]);
+
+/// Settings for the [GasPriceOracle]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GasOracleConfig {
+    /// The number of blocks to sample for gas price estimates
+    pub blocks: u32,
+
+    /// The percentile of gas prices to use for the estimate
+    pub percentile: u32,
+
+    /// The maximum number of headers to keep in the cache
+    pub max_header_history: u64,
+
+    /// The maximum number of blocks to keep in the cache
+    pub max_block_history: u64,
+
+    /// The default gas price to use if there are no blocks in the cache
+    pub default: U256,
+
+    /// The maximum gas price to use for the estimate
+    pub max_price: U256,
+
+    /// The minimum gas price, under which the sample will be ignored
+    pub ignore_price: U256,
+}
+
+// the go code to port to rust
+// // Oracle recommends gas prices based on the content of recent
+// // blocks. Suitable for both light and full clients.
+// type Oracle struct {
+// 	backend     OracleBackend
+// 	lastHead    common.Hash
+// 	lastPrice   *big.Int
+// 	maxPrice    *big.Int
+// 	ignorePrice *big.Int
+// 	cacheLock   sync.RWMutex
+// 	fetchLock   sync.Mutex
+
+// 	checkBlocks, percentile           int
+// 	maxHeaderHistory, maxBlockHistory uint64
+
+// 	historyCache *lru.Cache[cacheKey, processedFees]
+// }
+
+/// Provides async access to the gas price oracle.
+///
+/// This is the frontend for the async gas price oracle which manages gas price estimates on a
+/// different task.
+#[derive(Debug, Clone)]
+pub struct GasPriceOracle {
+    to_service: UnboundedSender<GasPriceAction>,
+}
+
+/// All message variants sent to the oracle through the channel
+#[derive(Debug, Clone)]
+pub enum GasPriceAction {
+    // TODO
+}
+
+impl GasPriceOracle {
+    /// Creates and returns the [GasPriceOracle] frontend.
+    fn create<Client, Tasks>(
+        client: Client,
+        action_task_spawner: Tasks,
+        oracle_config: GasOracleConfig,
+    ) -> (Self, GasPriceOracleService<Client, Tasks>) {
+        let (to_service, rx) = unbounded_channel();
+        let service = GasPriceOracleService {
+            client,
+            oracle_config,
+            action_tx: to_service.clone(),
+            action_rx: UnboundedReceiverStream::new(rx),
+            action_task_spawner,
+        };
+        let oracle = Self { to_service };
+        (oracle, service)
+    }
+
+    /// Creates a new async gas oracle service task and spawns it to a new task via [tokio::spawn].
+    ///
+    /// See also [Self::spawn_with]
+    pub fn spawn<Client>(client: Client, config: GasOracleConfig) -> Self
+    where
+        Client: BlockProvider + Clone + Unpin + 'static,
+    {
+        Self::spawn_with(client, config, TokioTaskExecutor::default())
+    }
+
+    /// Creates a new async gas oracle service task and spawns it to a new task via the given
+    /// spawner.
+    pub fn spawn_with<Client, Tasks>(
+        client: Client,
+        config: GasOracleConfig,
+        executor: Tasks,
+    ) -> Self
+    where
+        Client: BlockProvider + Clone + Unpin + 'static,
+        Tasks: TaskSpawner + Clone + 'static,
+    {
+        let (this, service) = Self::create(client, executor.clone(), config);
+        executor.spawn_critical("eth gas price oracle", Box::pin(service));
+        this
+    }
+}
+
+/// A task that manages gas price estimates.
+///
+/// Caution: The channel for the data is _unbounded_ it is assumed that this is mainly used by the
+/// [EthApi](crate::EthApi) which is typically invoked by the RPC server, which already uses permits
+/// to limit concurrent requests.
+#[must_use = "Type does nothing unless spawned"]
+pub(crate) struct GasPriceOracleService<Client, Tasks> {
+    /// The type used to subscribe to block events and get block info
+    client: Client,
+    /// The config for the oracle
+    oracle_config: GasOracleConfig,
+    /// Sender half of the action channel.
+    action_tx: UnboundedSender<GasPriceAction>,
+    /// Receiver half of the action channel.
+    action_rx: UnboundedReceiverStream<GasPriceAction>,
+    /// The type that's used to spawn tasks that do the actual work
+    action_task_spawner: Tasks,
+}
+
+impl<Client, Tasks> GasPriceOracleService<Client, Tasks>
+where
+    Client: BlockProvider + Clone + Unpin + 'static,
+    Tasks: TaskSpawner + Clone + 'static,
+{
+    fn on_new_block(&mut self, block_hash: H256, res: Result<Option<Block>>) {
+        todo!()
+    }
+}
+
+impl<Client, Tasks> Future for GasPriceOracleService<Client, Tasks>
+where
+    Client: BlockProvider + Clone + Unpin + 'static,
+    Tasks: TaskSpawner + Clone + 'static,
+{
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+
+        loop {
+            match ready!(this.action_rx.poll_next_unpin(cx)) {
+                None => {
+                    unreachable!("can't close")
+                }
+                Some(action) => match action {},
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use reth_primitives::constants::GWEI_TO_WEI;
+
+    use super::*;
+
+    #[test]
+    fn max_price_sanity() {
+        assert_eq!(DEFAULT_MAX_PRICE, U256::from(500_000_000_000u64));
+        assert_eq!(DEFAULT_MAX_PRICE, U256::from(500 * GWEI_TO_WEI))
+    }
+
+    #[test]
+    fn ignore_price_sanity() {
+        assert_eq!(DEFAULT_IGNORE_PRICE, U256::from(2u64));
+    }
+}

--- a/crates/rpc/rpc/src/eth/gas_oracle.rs
+++ b/crates/rpc/rpc/src/eth/gas_oracle.rs
@@ -164,7 +164,9 @@ where
 
         // constrain to the max price
         if let Some(max_price) = self.oracle_config.max_price {
-            price = max_price;
+            if price > max_price {
+                price = max_price;
+            }
         }
 
         *last_price = GasPriceOracleResult { block_hash: header_hash, price };

--- a/crates/rpc/rpc/src/eth/gas_oracle.rs
+++ b/crates/rpc/rpc/src/eth/gas_oracle.rs
@@ -70,24 +70,6 @@ impl Default for GasPriceOracleConfig {
     }
 }
 
-// the go code to port to rust
-// // Oracle recommends gas prices based on the content of recent
-// // blocks. Suitable for both light and full clients.
-// type Oracle struct {
-// 	backend     OracleBackend
-// 	lastHead    common.Hash
-// 	lastPrice   *big.Int
-// 	maxPrice    *big.Int
-// 	ignorePrice *big.Int
-// 	cacheLock   sync.RWMutex
-// 	fetchLock   sync.Mutex
-
-// 	checkBlocks, percentile           int
-// 	maxHeaderHistory, maxBlockHistory uint64
-
-// 	historyCache *lru.Cache[cacheKey, processedFees]
-// }
-
 /// Provides async access to the gas price oracle.
 ///
 /// This is the frontend for the async gas price oracle which manages gas price estimates on a
@@ -188,87 +170,6 @@ where
     Client: BlockProvider + Clone + Unpin + 'static,
     Tasks: TaskSpawner + Clone + 'static,
 {
-    // go code to port to rust
-    // // SuggestTipCap returns a tip cap so that newly created transaction can have a
-    // // very high chance to be included in the following blocks.
-    // //
-    // // Note, for legacy transactions and the legacy eth_gasPrice RPC call, it will be
-    // // necessary to add the basefee to the returned number to fall back to the legacy
-    // // behavior.
-    // func (oracle *Oracle) SuggestTipCap(ctx context.Context) (*big.Int, error) {
-    // 	head, _ := oracle.backend.HeaderByNumber(ctx, rpc.LatestBlockNumber)
-    // 	headHash := head.Hash()
-    //
-    // 	// If the latest gasprice is still available, return it.
-    // 	oracle.cacheLock.RLock()
-    // 	lastHead, lastPrice := oracle.lastHead, oracle.lastPrice
-    // 	oracle.cacheLock.RUnlock()
-    // 	if headHash == lastHead {
-    // 		return new(big.Int).Set(lastPrice), nil
-    // 	}
-    // 	oracle.fetchLock.Lock()
-    // 	defer oracle.fetchLock.Unlock()
-    //
-    // 	// Try checking the cache again, maybe the last fetch fetched what we need
-    // 	oracle.cacheLock.RLock()
-    // 	lastHead, lastPrice = oracle.lastHead, oracle.lastPrice
-    // 	oracle.cacheLock.RUnlock()
-    // 	if headHash == lastHead {
-    // 		return new(big.Int).Set(lastPrice), nil
-    // 	}
-    // 	var (
-    // 		sent, exp int
-    // 		number    = head.Number.Uint64()
-    // 		result    = make(chan results, oracle.checkBlocks)
-    // 		quit      = make(chan struct{})
-    // 		results   []*big.Int
-    // 	)
-    // 	for sent < oracle.checkBlocks && number > 0 {
-    // 		go oracle.getBlockValues(ctx, number, sampleNumber, oracle.ignorePrice, result, quit)
-    // 		sent++
-    // 		exp++
-    // 		number--
-    // 	}
-    // 	for exp > 0 {
-    // 		res := <-result
-    // 		if res.err != nil {
-    // 			close(quit)
-    // 			return new(big.Int).Set(lastPrice), res.err
-    // 		}
-    // 		exp--
-    // 		// Nothing returned. There are two special cases here:
-    // 		// - The block is empty
-    // 		// - All the transactions included are sent by the miner itself.
-    // 		// In these cases, use the latest calculated price for sampling.
-    // 		if len(res.values) == 0 {
-    // 			res.values = []*big.Int{lastPrice}
-    // 		}
-    // 		// Besides, in order to collect enough data for sampling, if nothing
-    // 		// meaningful returned, try to query more blocks. But the maximum
-    // 		// is 2*checkBlocks.
-    // 		if len(res.values) == 1 && len(results)+1+exp < oracle.checkBlocks*2 && number > 0 {
-    // 			go oracle.getBlockValues(ctx, number, sampleNumber, oracle.ignorePrice, result, quit)
-    // 			sent++
-    // 			exp++
-    // 			number--
-    // 		}
-    // 		results = append(results, res.values...)
-    // 	}
-    // 	price := lastPrice
-    // 	if len(results) > 0 {
-    // 		sort.Sort(bigIntArray(results))
-    // 		price = results[(len(results)-1)*oracle.percentile/100]
-    // 	}
-    // 	if price.Cmp(oracle.maxPrice) > 0 {
-    // 		price = new(big.Int).Set(oracle.maxPrice)
-    // 	}
-    // 	oracle.cacheLock.Lock()
-    // 	oracle.lastHead = headHash
-    // 	oracle.lastPrice = price
-    // 	oracle.cacheLock.Unlock()
-    //
-    // 	return new(big.Int).Set(price), nil
-    // }
     // TODO: concurrent calls for get_block_values like in the geth impl
     fn suggest_tip_cap(&mut self) -> Result<U256> {
         // TODO: we really shouldn't have this be None, but let's get rid of these expects?
@@ -346,47 +247,6 @@ where
         Ok(price)
     }
 
-    // go code to port to rust
-    // // getBlockValues calculates the lowest transaction gas price in a given block
-    // // and sends it to the result channel. If the block is empty or all transactions
-    // // are sent by the miner itself(it doesn't make any sense to include this kind of
-    // // transaction prices for sampling), nil gasprice is returned.
-    // func (oracle *Oracle) getBlockValues(ctx context.Context, blockNum uint64, limit int,
-    // ignoreUnder *big.Int, result chan results, quit chan struct{}) { 	block, err :=
-    // oracle.backend.BlockByNumber(ctx, rpc.BlockNumber(blockNum)) 	if block == nil {
-    // 		select {
-    // 		case result <- results{nil, err}:
-    // 		case <-quit:
-    // 		}
-    // 		return
-    // 	}
-    // 	signer := types.MakeSigner(oracle.backend.ChainConfig(), block.Number(), block.Time())
-    //
-    // 	// Sort the transaction by effective tip in ascending sort.
-    // 	txs := make([]*types.Transaction, len(block.Transactions()))
-    // 	copy(txs, block.Transactions())
-    // 	sorter := newSorter(txs, block.BaseFee())
-    // 	sort.Sort(sorter)
-    //
-    // 	var prices []*big.Int
-    // 	for _, tx := range sorter.txs {
-    // 		tip, _ := tx.EffectiveGasTip(block.BaseFee())
-    // 		if ignoreUnder != nil && tip.Cmp(ignoreUnder) == -1 {
-    // 			continue
-    // 		}
-    // 		sender, err := types.Sender(signer, tx)
-    // 		if err == nil && sender != block.Coinbase() {
-    // 			prices = append(prices, tip)
-    // 			if len(prices) >= limit {
-    // 				break
-    // 			}
-    // 		}
-    // 	}
-    // 	select {
-    // 	case result <- results{prices, nil}:
-    // 	case <-quit:
-    // 	}
-    // }
     fn get_block_values(&self, block_num: u64, limit: usize) -> Result<Option<Vec<Option<U256>>>> {
         let block = match self.client.block_by_number(block_num)? {
             Some(block) => block,

--- a/crates/rpc/rpc/src/eth/gas_oracle.rs
+++ b/crates/rpc/rpc/src/eth/gas_oracle.rs
@@ -8,7 +8,6 @@ use reth_primitives::{
 };
 use reth_provider::{BlockProviderIdExt, ProviderError};
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
 use tokio::sync::Mutex;
 use tracing::warn;
 

--- a/crates/rpc/rpc/src/eth/gas_oracle.rs
+++ b/crates/rpc/rpc/src/eth/gas_oracle.rs
@@ -32,10 +32,10 @@ pub struct GasPriceOracleConfig {
     /// The maximum number of headers to keep in the cache
     pub max_header_history: u64,
 
-    /// The maximum number of blocks to keep in the cache
+    /// The maximum number of blocks for estimating gas price
     pub max_block_history: u64,
 
-    /// The default gas price to use if there are no blocks in the cache
+    /// The default gas price to use if there are no blocks to use
     pub default: Option<U256>,
 
     /// The maximum gas price to use for the estimate
@@ -59,7 +59,7 @@ impl Default for GasPriceOracleConfig {
     }
 }
 
-/// TODO: doc comment
+/// Calculates a gas price depending on recent blocks.
 #[derive(Debug)]
 pub struct GasPriceOracle<Client> {
     /// The type used to subscribe to block events and get block info
@@ -189,8 +189,7 @@ where
                 let sender = tx.recover_signer();
                 match sender {
                     Some(addr) => addr == block.beneficiary,
-                    // invalid signature - should not happen, but ignore?
-                    // TODO: figure out this case
+                    // TODO: figure out an error for this case or ignore
                     None => false,
                 }
             })

--- a/crates/rpc/rpc/src/eth/gas_oracle.rs
+++ b/crates/rpc/rpc/src/eth/gas_oracle.rs
@@ -14,25 +14,6 @@ use std::{
 use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
-// go code to port to rust
-// const sampleNumber = 3 // Number of transactions sampled in a block
-
-// var (
-// 	DefaultMaxPrice    = big.NewInt(500 * params.GWei)
-// 	DefaultIgnorePrice = big.NewInt(2 * params.Wei)
-// )
-
-// type Config struct {
-// 	Blocks           int
-// 	Percentile       int
-// 	MaxHeaderHistory uint64
-// 	MaxBlockHistory  uint64
-// 	// starting latest price
-// 	Default          *big.Int `toml:",omitempty"`
-// 	MaxPrice         *big.Int `toml:",omitempty"`
-// 	IgnorePrice      *big.Int `toml:",omitempty"`
-// }
-
 /// The number of transactions sampled in a block
 pub const SAMPLE_NUMBER: u32 = 3;
 

--- a/crates/rpc/rpc/src/eth/gas_oracle.rs
+++ b/crates/rpc/rpc/src/eth/gas_oracle.rs
@@ -197,8 +197,7 @@ where
             .collect::<Vec<_>>();
 
         // now do the sort
-        // TODO: could we cache tx effective_gas_tip? might be a lot of complexity for little use
-        txs.sort_by(|first, second| {
+        txs.sort_unstable_by(|first, second| {
             first
                 .effective_gas_tip(block.base_fee_per_gas)
                 .cmp(&second.effective_gas_tip(block.base_fee_per_gas))

--- a/crates/rpc/rpc/src/eth/gas_oracle.rs
+++ b/crates/rpc/rpc/src/eth/gas_oracle.rs
@@ -180,7 +180,7 @@ where
         let header = self
             .client
             .header_by_hash_or_number(BlockHashOrNumber::Hash(header_hash))?
-            .expect("a latest header always exists");
+            .ok_or(ProviderError::BlockHash { block_hash: header_hash })?;
 
         // if we have stored a last price, then we check whether or not it was for the same head
         if let Some(price) = &self.last_price {

--- a/crates/rpc/rpc/src/eth/gas_oracle.rs
+++ b/crates/rpc/rpc/src/eth/gas_oracle.rs
@@ -159,6 +159,11 @@ where
         Ok(price)
     }
 
+    /// Get the `limit` lowest effective tip values for the block at number `block_num`. If the
+    /// oracle has a configured `ignore_price` threshold, then tip values under that threshold will
+    /// be ignored before returning a result.
+    ///
+    /// If the block cannot be found, then this will return `None`.
     async fn get_block_values(&self, block_num: u64, limit: usize) -> Result<Option<Vec<U256>>> {
         // TODO: we could cache num -> hash as well as long as we invalidate the cache between
         // forkchoice updates

--- a/crates/rpc/rpc/src/eth/gas_oracle.rs
+++ b/crates/rpc/rpc/src/eth/gas_oracle.rs
@@ -61,14 +61,6 @@ impl Default for GasPriceOracleConfig {
     }
 }
 
-/// An error that can occur when calculating the gas price estimates
-#[derive(Debug, Clone, Error)]
-pub enum GasPriceOracleError {
-    /// A transaction failed sender recovery
-    #[error("transaction failed sender recovery")]
-    InvalidSignature,
-}
-
 /// Calculates a gas price depending on recent blocks.
 #[derive(Debug)]
 pub struct GasPriceOracle<Client> {
@@ -130,7 +122,6 @@ where
 
         // we only check a maximum of 2 * max_block_history
         for _ in 0..self.oracle_config.max_block_history * 2 {
-            // TODO - error handling
             let block_values = self
                 .get_block_values(current_block, SAMPLE_NUMBER as usize)
                 .await?

--- a/crates/rpc/rpc/src/eth/gas_oracle.rs
+++ b/crates/rpc/rpc/src/eth/gas_oracle.rs
@@ -11,7 +11,10 @@ use std::{
     pin::Pin,
     task::{ready, Context, Poll},
 };
-use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
+use tokio::sync::{
+    mpsc::{unbounded_channel, UnboundedSender},
+    oneshot,
+};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 /// The number of transactions sampled in a block
@@ -22,6 +25,9 @@ pub const DEFAULT_MAX_PRICE: U256 = U256::from_limbs([500_000_000_000u64, 0, 0, 
 
 /// The default minimum gas price, under which the sample will be ignored
 pub const DEFAULT_IGNORE_PRICE: U256 = U256::from_limbs([2u64, 0, 0, 0]);
+
+/// The type that can send the response to the requested max priority fee.
+type MaxPriorityFeeSender = oneshot::Sender<Result<U256>>;
 
 /// Settings for the [GasPriceOracle]
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -40,14 +46,16 @@ pub struct GasOracleConfig {
     pub max_block_history: u64,
 
     /// The default gas price to use if there are no blocks in the cache
-    pub default: U256,
+    pub default: Option<U256>,
 
     /// The maximum gas price to use for the estimate
-    pub max_price: U256,
+    pub max_price: Option<U256>,
 
     /// The minimum gas price, under which the sample will be ignored
-    pub ignore_price: U256,
+    pub ignore_price: Option<U256>,
 }
+
+// TODO: other config defaults
 
 // the go code to port to rust
 // // Oracle recommends gas prices based on the content of recent
@@ -77,9 +85,8 @@ pub struct GasPriceOracle {
 }
 
 /// All message variants sent to the oracle through the channel
-#[derive(Debug, Clone)]
 pub enum GasPriceAction {
-    // TODO
+    SuggestMaxPriorityFee { response_tx: MaxPriorityFeeSender },
 }
 
 impl GasPriceOracle {
@@ -155,6 +162,104 @@ where
     fn on_new_block(&mut self, block_hash: H256, res: Result<Option<Block>>) {
         todo!()
     }
+
+    //// SuggestTipCap returns a tip cap so that newly created transaction can have a
+    //// very high chance to be included in the following blocks.
+    ////
+    //// Note, for legacy transactions and the legacy eth_gasPrice RPC call, it will be
+    //// necessary to add the basefee to the returned number to fall back to the legacy
+    //// behavior.
+    //func (oracle *Oracle) SuggestTipCap(ctx context.Context) (*big.Int, error) {
+    fn suggest_tip_cap(&self) -> Result<U256> {
+        todo!()
+    }
+
+    // go code to port to rust
+    // // getBlockValues calculates the lowest transaction gas price in a given block
+    // // and sends it to the result channel. If the block is empty or all transactions
+    // // are sent by the miner itself(it doesn't make any sense to include this kind of
+    // // transaction prices for sampling), nil gasprice is returned.
+    // func (oracle *Oracle) getBlockValues(ctx context.Context, blockNum uint64, limit int,
+    // ignoreUnder *big.Int, result chan results, quit chan struct{}) { 	block, err :=
+    // oracle.backend.BlockByNumber(ctx, rpc.BlockNumber(blockNum)) 	if block == nil {
+    // 		select {
+    // 		case result <- results{nil, err}:
+    // 		case <-quit:
+    // 		}
+    // 		return
+    // 	}
+    // 	signer := types.MakeSigner(oracle.backend.ChainConfig(), block.Number(), block.Time())
+
+    // 	// Sort the transaction by effective tip in ascending sort.
+    // 	txs := make([]*types.Transaction, len(block.Transactions()))
+    // 	copy(txs, block.Transactions())
+    // 	sorter := newSorter(txs, block.BaseFee())
+    // 	sort.Sort(sorter)
+
+    // 	var prices []*big.Int
+    // 	for _, tx := range sorter.txs {
+    // 		tip, _ := tx.EffectiveGasTip(block.BaseFee())
+    // 		if ignoreUnder != nil && tip.Cmp(ignoreUnder) == -1 {
+    // 			continue
+    // 		}
+    // 		sender, err := types.Sender(signer, tx)
+    // 		if err == nil && sender != block.Coinbase() {
+    // 			prices = append(prices, tip)
+    // 			if len(prices) >= limit {
+    // 				break
+    // 			}
+    // 		}
+    // 	}
+    // 	select {
+    // 	case result <- results{prices, nil}:
+    // 	case <-quit:
+    // 	}
+    // }
+    fn get_block_values(&self, block_num: u64, limit: usize) -> Result<Option<Vec<Option<U256>>>> {
+        let block = match self.client.block_by_number(block_num)? {
+            Some(block) => block,
+            None => return Ok(None),
+        };
+
+        // sort the transactions by effective tip
+        // but first filter those that should be ignored
+        let txs = block.body.iter();
+        let mut txs = txs
+            .filter(|tx| {
+                if let Some(ignore_under) = self.oracle_config.ignore_price {
+                    if tx.effective_gas_tip(block.base_fee_per_gas).map(U256::from) <
+                        Some(ignore_under)
+                    {
+                        return true
+                    }
+                }
+
+                // recover sender, check if coinbase
+                let sender = tx.recover_signer();
+                match sender {
+                    Some(addr) => addr == block.beneficiary,
+                    // invalid signature - should not happen, but ignore?
+                    // TODO: figure out this case
+                    None => true,
+                }
+            })
+            .collect::<Vec<_>>();
+
+        // now do the sort
+        // TODO: could we cache tx effective_gas_tip? might be a lot of complexity for little use
+        txs.sort_by(|first, second| {
+            first
+                .effective_gas_tip(block.base_fee_per_gas)
+                .cmp(&second.effective_gas_tip(block.base_fee_per_gas))
+        });
+
+        Ok(Some(
+            txs[..limit]
+                .iter()
+                .map(|tx| tx.effective_gas_tip(block.base_fee_per_gas).map(U256::from))
+                .collect(),
+        ))
+    }
 }
 
 impl<Client, Tasks> Future for GasPriceOracleService<Client, Tasks>
@@ -172,7 +277,12 @@ where
                 None => {
                     unreachable!("can't close")
                 }
-                Some(action) => match action {},
+                Some(action) => match action {
+                    GasPriceAction::SuggestMaxPriorityFee { response_tx } => {
+                        todo!()
+                        // let _ = response_tx.send(result);
+                    }
+                },
             }
         }
     }

--- a/crates/rpc/rpc/src/eth/mod.rs
+++ b/crates/rpc/rpc/src/eth/mod.rs
@@ -4,6 +4,7 @@ mod api;
 pub mod cache;
 pub mod error;
 mod filter;
+pub mod gas_oracle;
 mod id_provider;
 mod logs_utils;
 mod pubsub;


### PR DESCRIPTION
This is a port of the [go-ethereum `Oracle`](https://github.com/ethereum/go-ethereum/blob/master/eth/gasprice/gasprice.go). Currently it is only integrated into `eth_gasPrice` (not `eth_feeHistory`), and tries to be as compatible as possible with the go implementation.

This is also modelled as a service, similar to the `EthStateCache`, which might be a bit overkill given its current capabilities, but it might be fine for now.

TODO:
 - [x] Remove `expect`s - still need to check what geth does in some edge cases and create error variants
 - [ ] Testing - It would be nice to have good rust unit tests, as I'm not sure to what extent hive covers this.