### PR TITLE
feat(txpool): add add_and_subscribe

### DIFF
--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1,4 +1,8 @@
-use crate::{error::PoolResult, pool::state::SubPool, validate::ValidPoolTransaction};
+use crate::{
+    error::PoolResult,
+    pool::{state::SubPool, TransactionEvents},
+    validate::ValidPoolTransaction,
+};
 use reth_primitives::{
     Address, FromRecoveredTransaction, IntoRecoveredTransaction, PeerId, Transaction,
     TransactionKind, TransactionSignedEcRecovered, TxHash, EIP1559_TX_TYPE_ID, H256, U256,
@@ -59,6 +63,18 @@ pub trait TransactionPool: Send + Sync + Clone {
     ) -> PoolResult<Vec<PoolResult<TxHash>>> {
         self.add_transactions(TransactionOrigin::External, transactions).await
     }
+
+    /// Adds an _unvalidated_ transaction into the pool and subscribe to state changes.
+    ///
+    /// This is the same as [TransactionPool::add_transaction] but returns an event stream for the
+    /// given transaction.
+    ///
+    /// Consumer: Custom
+    async fn add_transaction_and_subscribe(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Self::Transaction,
+    ) -> PoolResult<TransactionEvents>;
 
     /// Adds an _unvalidated_ transaction into the pool.
     ///

--- a/crates/transaction-pool/src/validate.rs
+++ b/crates/transaction-pool/src/validate.rs
@@ -33,6 +33,22 @@ pub enum TransactionValidationOutcome<T: PoolTransaction> {
     Error(T, Box<dyn std::error::Error + Send + Sync>),
 }
 
+impl<T: PoolTransaction> TransactionValidationOutcome<T> {
+    /// Returns the transaction that was validated.
+    pub fn transaction(&self) -> &T {
+        match self {
+            Self::Valid { transaction, .. } => transaction,
+            Self::Invalid(transaction, ..) => transaction,
+            Self::Error(transaction, ..) => transaction,
+        }
+    }
+
+    /// Returns the hash of the transactions
+    pub fn tx_hash(&self) -> TxHash {
+        *self.transaction().hash()
+    }
+}
+
 /// Provides support for validating transaction at any given state of the chain
 #[async_trait::async_trait]
 pub trait TransactionValidator: Send + Sync {


### PR DESCRIPTION
ref #2402 

add missing `add_transaction_and_subscribe` function that returns an event Stream for events specific to the transaction