### PR TITLE
fix(poststate): revert & selfdestruct bugs

### DIFF
--- a/crates/consensus/auto-seal/src/task.rs
+++ b/crates/consensus/auto-seal/src/task.rs
@@ -178,11 +178,11 @@ where
                             // clear all transactions from pool
                             pool.remove_transactions(body.iter().map(|tx| tx.hash()));
 
-                            header.receipts_root = if post_state.receipts().is_empty() {
+                            let receipts = post_state.receipts(header.number);
+                            header.receipts_root = if receipts.is_empty() {
                                 EMPTY_RECEIPTS
                             } else {
-                                let receipts_with_bloom = post_state
-                                    .receipts()
+                                let receipts_with_bloom = receipts
                                     .iter()
                                     .map(|r| r.clone().into())
                                     .collect::<Vec<ReceiptWithBloom>>();

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -622,12 +622,15 @@ fn build_payload<Pool, Client>(
             cumulative_gas_used += gas_used;
 
             // Push transaction changeset and calculate header bloom filter for receipt.
-            post_state.add_receipt(Receipt {
-                tx_type: tx.tx_type(),
-                success: result.is_success(),
-                cumulative_gas_used,
-                logs: result.logs().into_iter().map(into_reth_log).collect(),
-            });
+            post_state.add_receipt(
+                block_number,
+                Receipt {
+                    tx_type: tx.tx_type(),
+                    success: result.is_success(),
+                    cumulative_gas_used,
+                    logs: result.logs().into_iter().map(into_reth_log).collect(),
+                },
+            );
 
             // update add to total fees
             let miner_fee = tx
@@ -654,8 +657,8 @@ fn build_payload<Pool, Client>(
             attributes.withdrawals,
         )?;
 
-        let receipts_root = post_state.receipts_root();
-        let logs_bloom = post_state.logs_bloom();
+        let receipts_root = post_state.receipts_root(block_number);
+        let logs_bloom = post_state.logs_bloom(block_number);
 
         // calculate the state root
         let state_root = db.db.0.state_root(post_state)?;

--- a/crates/rpc/rpc/src/eth/cache.rs
+++ b/crates/rpc/rpc/src/eth/cache.rs
@@ -497,7 +497,7 @@ where
             if blocks.len() == 1 {
                 let block_receipts = BlockReceipts {
                     block_hash: blocks[0].hash,
-                    receipts: state.receipts().to_vec(),
+                    receipts: state.receipts(blocks[0].number).to_vec(),
                 };
                 receipts.push(block_receipts);
             }

--- a/crates/storage/provider/src/chain.rs
+++ b/crates/storage/provider/src/chain.rs
@@ -131,15 +131,15 @@ impl Chain {
     /// Attachment includes block number, block hash, transaction hash and transaction index.
     pub fn receipts_with_attachment(&self) -> Vec<BlockReceipts> {
         let mut receipt_attch = Vec::new();
-        let mut receipts = self.state().receipts().iter();
         for (block_num, block) in self.blocks().iter() {
-            let block_num_hash = BlockNumHash::new(*block_num, block.hash());
+            let mut receipts = self.state.receipts(*block_num).iter();
             let mut tx_receipts = Vec::new();
             for tx in block.body.iter() {
                 if let Some(receipt) = receipts.next() {
                     tx_receipts.push((tx.hash(), receipt.clone()));
                 }
             }
+            let block_num_hash = BlockNumHash::new(*block_num, block.hash());
             receipt_attch.push(BlockReceipts { block: block_num_hash, tx_receipts });
         }
         receipt_attch

--- a/crates/storage/provider/src/post_state/mod.rs
+++ b/crates/storage/provider/src/post_state/mod.rs
@@ -309,7 +309,7 @@ impl PostState {
             let info = removed_account_changes
                 .iter()
                 .find_map(|(_, changes)| {
-                    changes.iter().find_map(|ch| (ch.0 == &address).then(|| *ch.1))
+                    changes.iter().find_map(|ch| (ch.0 == &address).then_some(*ch.1))
                 })
                 .unwrap_or(*self.accounts.get(&address).expect("exists"));
             account_state.insert(address, info);
@@ -332,7 +332,7 @@ impl PostState {
                             changes.iter().find_map(|ch| {
                                 if ch.0 == address {
                                     match ch.1.storage.iter().find_map(|(changed_slot, value)| {
-                                        (slot == changed_slot).then(|| *value)
+                                        (slot == changed_slot).then_some(*value)
                                     }) {
                                         value @ Some(_) => Some(value),
                                         None if ch.1.wipe.is_wiped() => Some(None),

--- a/crates/storage/provider/src/post_state/mod.rs
+++ b/crates/storage/provider/src/post_state/mod.rs
@@ -490,16 +490,14 @@ impl PostState {
                 let storage_id = BlockNumberAddress((block_number, address));
 
                 // If the account was created and wiped at the same block, skip all storage changes
-                if storage.wipe.is_wiped() {
-                    if self
-                        .account_changes
+                if storage.wipe.is_wiped() &&
+                    self.account_changes
                         .get(&block_number)
                         .and_then(|changes| changes.get(&address).map(|info| info.is_none()))
                         // No account info available, fallback to `false`
                         .unwrap_or_default()
-                    {
-                        continue
-                    }
+                {
+                    continue
                 }
 
                 // If we are writing the primary storage wipe transition, the pre-existing plain

--- a/crates/storage/provider/src/post_state/mod.rs
+++ b/crates/storage/provider/src/post_state/mod.rs
@@ -316,7 +316,7 @@ impl PostState {
         }
         self.accounts = account_state;
 
-        // Revert storage state & changes
+        // Revert changes and recreate the storage state
         let removed_storage_changes = self.storage_changes.drain_above(target_block_number);
         let mut storage_state: BTreeMap<Address, Storage> = BTreeMap::default();
         for (_, storage_changes) in self.storage_changes.iter() {
@@ -626,18 +626,379 @@ mod tests {
         let mut a = PostState::new();
         a.create_account(1, Address::zero(), Account::default());
         a.destroy_account(1, Address::zero(), Account::default());
-
         assert_eq!(a.account_changes.iter().fold(0, |len, (_, changes)| len + changes.len()), 1);
 
         let mut b = PostState::new();
         b.create_account(2, Address::repeat_byte(0xff), Account::default());
-
         assert_eq!(b.account_changes.iter().fold(0, |len, (_, changes)| len + changes.len()), 1);
 
         let mut c = a.clone();
         c.extend(b.clone());
-
         assert_eq!(c.account_changes.iter().fold(0, |len, (_, changes)| len + changes.len()), 2);
+
+        let mut d = PostState::new();
+        d.create_account(3, Address::zero(), Account::default());
+        d.destroy_account(3, Address::zero(), Account::default());
+        c.extend(d);
+        assert_eq!(c.account_storage(&Address::zero()).unwrap().times_wiped, 2);
+        // Primary wipe occurred at block #1.
+        assert_eq!(
+            c.storage_changes.get(&1).unwrap().get(&Address::zero()).unwrap().wipe,
+            StorageWipe::Primary
+        );
+        // Primary wipe occurred at block #3.
+        assert_eq!(
+            c.storage_changes.get(&3).unwrap().get(&Address::zero()).unwrap().wipe,
+            StorageWipe::Secondary
+        );
+    }
+
+    #[test]
+    fn revert_to() {
+        let mut state = PostState::new();
+        let address1 = Address::repeat_byte(0);
+        let account1 = Account { nonce: 1, balance: U256::from(1), bytecode_hash: None };
+        state.create_account(1, address1, account1);
+        state.create_account(
+            2,
+            Address::repeat_byte(0xff),
+            Account { nonce: 2, balance: U256::from(2), bytecode_hash: None },
+        );
+        assert_eq!(
+            state.account_changes.iter().fold(0, |len, (_, changes)| len + changes.len()),
+            2
+        );
+
+        let revert_to = 1;
+        state.revert_to(revert_to);
+        assert_eq!(state.accounts, BTreeMap::from([(address1, Some(account1))]));
+        assert_eq!(
+            state.account_changes.iter().fold(0, |len, (_, changes)| len + changes.len()),
+            1
+        );
+    }
+
+    #[test]
+    fn wiped_revert() {
+        let address = Address::random();
+
+        let init_block_number = 0;
+        let init_account = Account { balance: U256::from(3), ..Default::default() };
+        let init_slot = U256::from(1);
+
+        // Create init state for demonstration purposes
+        // Block 0
+        // Account: exists
+        // Storage: 0x01: 1
+        let mut init_state = PostState::new();
+        init_state.create_account(init_block_number, address, init_account);
+        init_state.change_storage(
+            init_block_number,
+            address,
+            BTreeMap::from([(init_slot, (U256::ZERO, U256::from(1)))]),
+        );
+        assert_eq!(
+            init_state.storage.get(&address),
+            Some(&Storage {
+                storage: BTreeMap::from([(init_slot, U256::from(1))]),
+                times_wiped: 0
+            })
+        );
+
+        let mut post_state = PostState::new();
+        // Block 1
+        // <nothing>
+
+        // Block 2
+        // Account: destroyed
+        // Storage: wiped
+        post_state.destroy_account(2, address, init_account);
+        assert!(post_state.storage.get(&address).unwrap().wiped());
+
+        // Block 3
+        // Account: recreated
+        // Storage: wiped, then 0x01: 2
+        let recreated_account = Account { balance: U256::from(4), ..Default::default() };
+        post_state.create_account(3, address, recreated_account);
+        post_state.change_storage(
+            3,
+            address,
+            BTreeMap::from([(init_slot, (U256::ZERO, U256::from(2)))]),
+        );
+        assert!(post_state.storage.get(&address).unwrap().wiped());
+
+        // Revert to block 2
+        post_state.revert_to(2);
+        assert!(post_state.storage.get(&address).unwrap().wiped());
+        assert_eq!(
+            post_state.storage.get(&address).unwrap(),
+            &Storage { times_wiped: 1, storage: BTreeMap::default() }
+        );
+
+        // Revert to block 1
+        post_state.revert_to(1);
+        assert_eq!(post_state.storage.get(&address), None);
+    }
+
+    #[test]
+    fn split_at() {
+        let address1 = Address::random();
+        let address2 = Address::random();
+        let slot1 = U256::from(1);
+        let slot2 = U256::from(2);
+
+        let mut state = PostState::new();
+        // Block #1
+        // Create account 1 and change its storage
+        // Assume account 2 already exists in the database and change storage for it
+        state.create_account(1, address1, Account::default());
+        state.change_storage(1, address1, BTreeMap::from([(slot1, (U256::ZERO, U256::from(1)))]));
+        state.change_storage(1, address1, BTreeMap::from([(slot2, (U256::ZERO, U256::from(1)))]));
+        state.change_storage(1, address2, BTreeMap::from([(slot2, (U256::ZERO, U256::from(2)))]));
+        let block1_account_changes = (1, BTreeMap::from([(address1, None)]));
+        let block1_storage_changes = (
+            1,
+            BTreeMap::from([
+                (
+                    address1,
+                    StorageTransition {
+                        storage: BTreeMap::from([(slot1, U256::ZERO), (slot2, U256::ZERO)]),
+                        wipe: StorageWipe::None,
+                    },
+                ),
+                (
+                    address2,
+                    StorageTransition {
+                        storage: BTreeMap::from([(slot2, U256::ZERO)]),
+                        wipe: StorageWipe::None,
+                    },
+                ),
+            ]),
+        );
+        assert_eq!(
+            state.account_changes,
+            AccountChanges { inner: BTreeMap::from([block1_account_changes.clone()]), size: 1 }
+        );
+        assert_eq!(
+            state.storage_changes,
+            StorageChanges { inner: BTreeMap::from([block1_storage_changes.clone()]), size: 3 }
+        );
+
+        // Block #2
+        // Destroy account 1
+        // Change storage for account 2
+        state.destroy_account(2, address1, Account::default());
+        state.change_storage(
+            2,
+            address2,
+            BTreeMap::from([(slot2, (U256::from(2), U256::from(4)))]),
+        );
+        let account_state_after_block_2 = state.accounts.clone();
+        let storage_state_after_block_2 = state.storage.clone();
+        let block2_account_changes = (2, BTreeMap::from([(address1, Some(Account::default()))]));
+        let block2_storage_changes = (
+            2,
+            BTreeMap::from([
+                (
+                    address1,
+                    StorageTransition {
+                        storage: BTreeMap::from([(slot1, U256::from(1)), (slot2, U256::from(1))]),
+                        wipe: StorageWipe::Primary,
+                    },
+                ),
+                (
+                    address2,
+                    StorageTransition {
+                        storage: BTreeMap::from([(slot2, U256::from(2))]),
+                        wipe: StorageWipe::None,
+                    },
+                ),
+            ]),
+        );
+        assert_eq!(
+            state.account_changes,
+            AccountChanges {
+                inner: BTreeMap::from([
+                    block1_account_changes.clone(),
+                    block2_account_changes.clone()
+                ]),
+                size: 2
+            }
+        );
+        assert_eq!(
+            state.storage_changes,
+            StorageChanges {
+                inner: BTreeMap::from([
+                    block1_storage_changes.clone(),
+                    block2_storage_changes.clone()
+                ]),
+                size: 6,
+            }
+        );
+
+        // Block #3
+        // Recreate account 1
+        // Destroy account 2
+        state.create_account(3, address1, Account::default());
+        state.change_storage(
+            3,
+            address2,
+            BTreeMap::from([(slot2, (U256::from(4), U256::from(1)))]),
+        );
+        state.destroy_account(3, address2, Account::default());
+        let block3_account_changes =
+            (3, BTreeMap::from([(address1, None), (address2, Some(Account::default()))]));
+        let block3_storage_changes = (
+            3,
+            BTreeMap::from([(
+                address2,
+                StorageTransition {
+                    storage: BTreeMap::from([(slot2, U256::from(4))]),
+                    wipe: StorageWipe::Primary,
+                },
+            )]),
+        );
+        assert_eq!(
+            state.account_changes,
+            AccountChanges {
+                inner: BTreeMap::from([
+                    block1_account_changes.clone(),
+                    block2_account_changes.clone(),
+                    block3_account_changes.clone()
+                ]),
+                size: 4
+            }
+        );
+        assert_eq!(
+            state.storage_changes,
+            StorageChanges {
+                inner: BTreeMap::from([
+                    block1_storage_changes.clone(),
+                    block2_storage_changes.clone(),
+                    block3_storage_changes.clone()
+                ]),
+                size: 7,
+            }
+        );
+
+        // Block #4
+        // Destroy account 1 again
+        state.destroy_account(4, address1, Account::default());
+        let account_state_after_block_4 = state.accounts.clone();
+        let storage_state_after_block_4 = state.storage.clone();
+        let block4_account_changes = (4, BTreeMap::from([(address1, Some(Account::default()))]));
+        let block4_storage_changes = (
+            4,
+            BTreeMap::from([(
+                address1,
+                StorageTransition { storage: BTreeMap::default(), wipe: StorageWipe::Secondary },
+            )]),
+        );
+
+        // Blocks #1-4
+        // Account 1. Info: <none>. Storage: <none>. Times Wiped: 2.
+        // Account 2. Info: <none>. Storage: <none>. Times Wiped: 1.
+        assert_eq!(state.accounts, BTreeMap::from([(address1, None), (address2, None)]));
+        assert_eq!(
+            state.storage,
+            BTreeMap::from([
+                (address1, Storage { times_wiped: 2, storage: BTreeMap::default() }),
+                (address2, Storage { times_wiped: 1, storage: BTreeMap::default() })
+            ])
+        );
+        assert_eq!(
+            state.account_changes,
+            AccountChanges {
+                inner: BTreeMap::from([
+                    block1_account_changes.clone(),
+                    block2_account_changes.clone(),
+                    block3_account_changes.clone(),
+                    block4_account_changes.clone(),
+                ]),
+                size: 5
+            }
+        );
+        assert_eq!(
+            state.storage_changes,
+            StorageChanges {
+                inner: BTreeMap::from([
+                    block1_storage_changes.clone(),
+                    block2_storage_changes.clone(),
+                    block3_storage_changes.clone(),
+                    block4_storage_changes.clone(),
+                ]),
+                size: 7,
+            }
+        );
+
+        // Split state at block #2
+        let mut state_1_2 = state.clone();
+        let state_3_4 = state_1_2.split_at(2);
+
+        // Blocks #1-2
+        // Account 1. Info: <none>. Storage: <none>.
+        // Account 2. Info: exists. Storage: slot2 - 4.
+        assert_eq!(state_1_2.accounts, account_state_after_block_2);
+        assert_eq!(state_1_2.storage, storage_state_after_block_2);
+        assert_eq!(
+            state_1_2.account_changes,
+            AccountChanges {
+                inner: BTreeMap::from([
+                    block1_account_changes.clone(),
+                    block2_account_changes.clone()
+                ]),
+                size: 2
+            }
+        );
+        assert_eq!(
+            state_1_2.storage_changes,
+            StorageChanges {
+                inner: BTreeMap::from([
+                    block1_storage_changes.clone(),
+                    block2_storage_changes.clone()
+                ]),
+                size: 6,
+            }
+        );
+
+        // Plain state for blocks #3-4 should match plain state from blocks #1-4
+        // Account 1. Info: <none>. Storage: <none>.
+        // Account 2. Info: exists. Storage: slot2 - 4.
+        assert_eq!(state_3_4.accounts, account_state_after_block_4);
+        assert_eq!(state_3_4.storage, storage_state_after_block_4);
+
+        // Account changes should match
+        assert_eq!(
+            state_3_4.account_changes,
+            AccountChanges {
+                inner: BTreeMap::from([
+                    block3_account_changes.clone(),
+                    block4_account_changes.clone(),
+                ]),
+                size: 3
+            }
+        );
+        // Storage changes should match except for the wipe flag being promoted to primary
+        assert_eq!(
+            state_3_4.storage_changes,
+            StorageChanges {
+                inner: BTreeMap::from([
+                    block3_storage_changes.clone(),
+                    // Block #4. Wipe flag must be promoted to primary
+                    (
+                        4,
+                        BTreeMap::from([(
+                            address1,
+                            StorageTransition {
+                                storage: BTreeMap::default(),
+                                wipe: StorageWipe::Primary
+                            },
+                        )]),
+                    ),
+                ]),
+                size: 1,
+            }
+        )
     }
 
     #[test]
@@ -882,93 +1243,6 @@ mod tests {
             BTreeMap::from([(U256::from(0), U256::from(3)), (U256::from(2), U256::from(4))]),
             "Account A's storage should only have slots 0 and 2, and they should have values 3 and 4, respectively."
         );
-    }
-
-    #[test]
-    fn revert_to() {
-        let mut state = PostState::new();
-        let address1 = Address::repeat_byte(0);
-        let account1 = Account { nonce: 1, balance: U256::from(1), bytecode_hash: None };
-        state.create_account(1, address1, account1);
-        state.create_account(
-            2,
-            Address::repeat_byte(0xff),
-            Account { nonce: 2, balance: U256::from(2), bytecode_hash: None },
-        );
-        assert_eq!(
-            state.account_changes.iter().fold(0, |len, (_, changes)| len + changes.len()),
-            2
-        );
-
-        let revert_to = 1;
-        state.revert_to(revert_to);
-        assert_eq!(state.accounts, BTreeMap::from([(address1, Some(account1))]));
-        assert_eq!(
-            state.account_changes.iter().fold(0, |len, (_, changes)| len + changes.len()),
-            1
-        );
-    }
-
-    #[test]
-    fn wiped_revert() {
-        let address = Address::random();
-
-        let init_block_number = 0;
-        let init_account = Account { balance: U256::from(3), ..Default::default() };
-        let init_slot = U256::from(1);
-
-        // Create init state for demonstration purposes
-        // Block 0
-        // Account: exists
-        // Storage: 0x01: 1
-        let mut init_state = PostState::new();
-        init_state.create_account(init_block_number, address, init_account);
-        init_state.change_storage(
-            init_block_number,
-            address,
-            BTreeMap::from([(init_slot, (U256::ZERO, U256::from(1)))]),
-        );
-        assert_eq!(
-            init_state.storage.get(&address),
-            Some(&Storage {
-                storage: BTreeMap::from([(init_slot, U256::from(1))]),
-                times_wiped: 0
-            })
-        );
-
-        let mut post_state = PostState::new();
-        // Block 1
-        // <nothing>
-
-        // Block 2
-        // Account: destroyed
-        // Storage: wiped
-        post_state.destroy_account(2, address, init_account);
-        assert!(post_state.storage.get(&address).unwrap().wiped());
-
-        // Block 3
-        // Account: recreated
-        // Storage: wiped, then 0x01: 2
-        let recreated_account = Account { balance: U256::from(4), ..Default::default() };
-        post_state.create_account(3, address, recreated_account);
-        post_state.change_storage(
-            3,
-            address,
-            BTreeMap::from([(init_slot, (U256::ZERO, U256::from(2)))]),
-        );
-        assert!(post_state.storage.get(&address).unwrap().wiped());
-
-        // Revert to block 2
-        post_state.revert_to(2);
-        assert!(post_state.storage.get(&address).unwrap().wiped());
-        assert_eq!(
-            post_state.storage.get(&address).unwrap(),
-            &Storage { times_wiped: 1, storage: BTreeMap::default() }
-        );
-
-        // Revert to block 1
-        post_state.revert_to(1);
-        assert_eq!(post_state.storage.get(&address), None);
     }
 
     /// Checks that if an account is touched multiple times in the same block,

--- a/crates/storage/provider/src/post_state/mod.rs
+++ b/crates/storage/provider/src/post_state/mod.rs
@@ -309,10 +309,10 @@ impl PostState {
             let info = removed_account_changes
                 .iter()
                 .find_map(|(_, changes)| {
-                    changes.iter().find_map(|ch| (ch.0 == &address).then(|| ch.1.clone()))
+                    changes.iter().find_map(|ch| (ch.0 == &address).then(|| *ch.1))
                 })
-                .unwrap_or(self.accounts.get(&address).expect("exists").clone());
-            account_state.insert(address.clone(), info);
+                .unwrap_or(*self.accounts.get(&address).expect("exists"));
+            account_state.insert(address, info);
         }
         self.accounts = account_state;
 
@@ -332,7 +332,7 @@ impl PostState {
                             changes.iter().find_map(|ch| {
                                 if ch.0 == address {
                                     match ch.1.storage.iter().find_map(|(changed_slot, value)| {
-                                        (slot == changed_slot).then(|| value.clone())
+                                        (slot == changed_slot).then(|| *value)
                                     }) {
                                         value @ Some(_) => Some(value),
                                         None if ch.1.wipe.is_wiped() => Some(None),
@@ -344,7 +344,7 @@ impl PostState {
                             })
                         })
                         .unwrap_or_else(|| {
-                            self.storage.get(&address).and_then(|s| s.storage.get(slot).copied())
+                            self.storage.get(address).and_then(|s| s.storage.get(slot).copied())
                         });
                     if let Some(value) = value {
                         entry.storage.insert(*slot, value);

--- a/crates/storage/provider/src/post_state/storage.rs
+++ b/crates/storage/provider/src/post_state/storage.rs
@@ -1,22 +1,45 @@
 use derive_more::Deref;
 use reth_primitives::{Address, BlockNumber, U256};
-use std::collections::{btree_map::Entry, BTreeMap};
+use std::collections::{btree_map::Entry, BTreeMap, HashSet};
 
 /// Storage for an account with the old and new values for each slot: (slot -> (old, new)).
 pub type StorageChangeset = BTreeMap<U256, (U256, U256)>;
 
-/// Changed storage state for the account.
-///
-/// # Wiped Storage
-///
-/// The field `wiped` denotes whether the pre-existing storage in the database should be cleared or
-/// not.
+/// The storage state of the account before the state transition.
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
-pub struct ChangedStorage {
-    /// Whether the storage was wiped or not.
-    pub wiped: bool,
+pub struct StorageTransition {
+    /// The indicator of the storage wipe.
+    pub wipe: StorageWipe,
     /// The storage slots.
     pub storage: BTreeMap<U256, U256>,
+}
+
+/// The indicator of the storage wipe.
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
+pub enum StorageWipe {
+    /// The storage was not wiped at this change.
+    #[default]
+    None,
+    /// The storage was wiped for the first time in the current in-memory state.
+    ///
+    /// When writing history to the database, on the primary storage wipe the pre-existing storage
+    /// will be inserted as the storage state before this transition.
+    Primary,
+    /// The storage had been already wiped before.
+    Secondary,
+}
+
+impl StorageWipe {
+    /// Returns `true` if the wipe occurred at this transition.
+    pub fn is_wiped(&self) -> bool {
+        matches!(self, Self::Primary | Self::Secondary)
+    }
+
+    /// Returns `true` if the primary wiped occurred at this transition.
+    /// See [StorageWipe::Primary] for more details.
+    pub fn is_primary(&self) -> bool {
+        matches!(self, Self::Primary)
+    }
 }
 
 /// Latest storage state for the account.
@@ -48,28 +71,27 @@ impl Storage {
 pub struct StorageChanges {
     /// The inner mapping of block changes.
     #[deref]
-    pub inner: BTreeMap<BlockNumber, BTreeMap<Address, ChangedStorage>>,
+    pub inner: BTreeMap<BlockNumber, BTreeMap<Address, StorageTransition>>,
     /// Hand tracked change size.
     pub size: usize,
 }
 
 impl StorageChanges {
-    /// Set storage `wiped` flag for specified block number and address.
-    pub fn set_wiped(&mut self, block: BlockNumber, address: Address) {
-        self.inner.entry(block).or_default().entry(address).or_default().wiped = true;
-    }
-
     /// Insert storage entries for specified block number and address.
     pub fn insert_for_block_and_address<I>(
         &mut self,
         block: BlockNumber,
         address: Address,
+        wiped: StorageWipe,
         storage: I,
     ) where
         I: Iterator<Item = (U256, U256)>,
     {
         let block_entry = self.inner.entry(block).or_default();
         let storage_entry = block_entry.entry(address).or_default();
+        if wiped.is_wiped() {
+            storage_entry.wipe = wiped;
+        }
         for (slot, value) in storage {
             if let Entry::Vacant(entry) = storage_entry.storage.entry(slot) {
                 entry.insert(value);
@@ -82,7 +104,7 @@ impl StorageChanges {
     pub fn drain_above(
         &mut self,
         target_block: BlockNumber,
-    ) -> BTreeMap<BlockNumber, BTreeMap<Address, ChangedStorage>> {
+    ) -> BTreeMap<BlockNumber, BTreeMap<Address, StorageTransition>> {
         let mut evicted = BTreeMap::new();
         self.inner.retain(|block_number, storages| {
             if *block_number > target_block {
@@ -100,8 +122,28 @@ impl StorageChanges {
 
     /// Retain entries only above specified block number.
     pub fn retain_above(&mut self, target_block: BlockNumber) {
+        let mut observed_storage_wipes: HashSet<Address> = HashSet::default();
         self.inner.retain(|block_number, storages| {
             if *block_number > target_block {
+                for (address, storage) in storages.iter_mut() {
+                    storage.wipe = match storage.wipe {
+                        StorageWipe::Primary => {
+                            observed_storage_wipes.insert(*address);
+                            StorageWipe::Primary
+                        }
+                        StorageWipe::Secondary => {
+                            if observed_storage_wipes.contains(address) {
+                                // We already observed the storage wipe for this address
+                                StorageWipe::Secondary
+                            } else {
+                                // No wipe was observed, promote the secondary wipe to primary
+                                observed_storage_wipes.insert(*address);
+                                StorageWipe::Primary
+                            }
+                        }
+                        StorageWipe::None => StorageWipe::None, // nothing to do
+                    };
+                }
                 true
             } else {
                 // This is fine, because it's called only on post state splits

--- a/crates/storage/provider/src/test_utils/blocks.rs
+++ b/crates/storage/provider/src/test_utils/blocks.rs
@@ -112,16 +112,19 @@ fn block1(number: BlockNumber) -> (SealedBlockWithSenders, PostState) {
         BTreeMap::from([(U256::from(5), (U256::ZERO, U256::from(10)))]),
     );
 
-    post_state.add_receipt(Receipt {
-        tx_type: TxType::EIP2930,
-        success: true,
-        cumulative_gas_used: 300,
-        logs: vec![Log {
-            address: H160([0x60; 20]),
-            topics: vec![H256::from_low_u64_be(1), H256::from_low_u64_be(2)],
-            data: Bytes::default(),
-        }],
-    });
+    post_state.add_receipt(
+        number,
+        Receipt {
+            tx_type: TxType::EIP2930,
+            success: true,
+            cumulative_gas_used: 300,
+            logs: vec![Log {
+                address: H160([0x60; 20]),
+                topics: vec![H256::from_low_u64_be(1), H256::from_low_u64_be(2)],
+                data: Bytes::default(),
+            }],
+        },
+    );
 
     (SealedBlockWithSenders { block, senders: vec![H160([0x30; 20])] }, post_state)
 }
@@ -152,16 +155,19 @@ fn block2(number: BlockNumber, parent_hash: H256) -> (SealedBlockWithSenders, Po
         H160([0x60; 20]),
         BTreeMap::from([(U256::from(5), (U256::from(10), U256::from(15)))]),
     );
-    post_state.add_receipt(Receipt {
-        tx_type: TxType::EIP1559,
-        success: false,
-        cumulative_gas_used: 400,
-        logs: vec![Log {
-            address: H160([0x61; 20]),
-            topics: vec![H256::from_low_u64_be(3), H256::from_low_u64_be(4)],
-            data: Bytes::default(),
-        }],
-    });
+    post_state.add_receipt(
+        number,
+        Receipt {
+            tx_type: TxType::EIP1559,
+            success: false,
+            cumulative_gas_used: 400,
+            logs: vec![Log {
+                address: H160([0x61; 20]),
+                topics: vec![H256::from_low_u64_be(3), H256::from_low_u64_be(4)],
+                data: Bytes::default(),
+            }],
+        },
+    );
 
     (SealedBlockWithSenders { block, senders: vec![H160([0x31; 20])] }, post_state)
 }

--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -953,7 +953,10 @@ where
         for (block_number, block_body) in block_bodies.into_iter() {
             for _ in block_body.tx_num_range() {
                 if let Some((_, receipt)) = receipt_iter.next() {
-                    block_states.entry(block_number).or_default().add_receipt(receipt);
+                    block_states
+                        .entry(block_number)
+                        .or_default()
+                        .add_receipt(block_number, receipt);
                 }
             }
         }

--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -496,9 +496,6 @@ where
         let new_tip = blocks.last().unwrap();
         let new_tip_number = new_tip.number;
 
-        // Write state and changesets to the database
-        state.write_to_db(self.deref_mut())?;
-
         let first_number = blocks.first().unwrap().number;
 
         let last = blocks.last().unwrap();
@@ -510,6 +507,9 @@ where
         for block in blocks {
             self.insert_block(block)?;
         }
+
+        // Write state and changesets to the database
+        state.write_to_db(self.deref_mut())?;
 
         self.insert_hashes(first_number..=last_block_number, last_block_hash, expected_state_root)?;
 


### PR DESCRIPTION
## Issues

All 4 bugs occur in the `PostState` and are critical.

### Bug 1 - Duplicate receipts after `PostState::split_at` call

#### Description

The `PostState::split_at` function splits the state into two at a target block number. The current `PostState` is reverted to the state at the target block number, while the newly returned `PostState` is pruned from any changesets before the target block.

However, the receipts are left intact and are simply duplicated across two `PostState`s. This together with loose code around receipt insertion
https://github.com/paradigmxyz/reth/blob/07983239eb66dc114f2fd0143663602db3d401af/crates/storage/provider/src/post_state/mod.rs#L509-L522
results in a corrupted receipts table where the receipts are duplicated and written for transaction ids that don't exist yet.

#### Solution

Convert the receipts collection into a `BTreeMap` where the receipts are stored per block. Add receipt eviction in the `PostState::split_at` and `PostState::revert_to` functions. 

----
### Bug 2 - Incorrect revert of the `PostState` with selfdestruct (wiped storage)

#### Description

When the `PostState` is reverted, its plain state should be restored to the target block. Currently, the storage state for any account is continuously extended with old storage values until the target block is reached. 
https://github.com/paradigmxyz/reth/blob/07983239eb66dc114f2fd0143663602db3d401af/crates/storage/provider/src/post_state/mod.rs#L297
This code is supposed to work because when we change storage, we always write the old storage value into the changeset. However, this code doesn't account for selfdestructs.

#### Example

Consider the following storage changes for account 1:
```
Block #1: slot0: 0 -> 1
Block #2: destroyed (slot0: 1 -> 0)
Block #3: slot0: 0 -> 1 and slot1: 0 -> 1
```
If the `PostState` is reverted to block 1, the plain storage state for account 1 will incorrectly contain slot0 with value `0` and slot1 with value `1` that was modified in what is now considered a future block (block 3).

The bug is present in the example above, but not limited to it.

#### Solution

Instead of reverting plain state in `PostState::revert_to`, recreate it from all existing changesets (both before and after the target block) as well as the current plain state.

The function will remove changesets after the target block, and iterate over any changed storages in the changesets before and in the target block.
The value for the changed slot is decided according to the following rules taking precedence in descending order:
1. If the removed changesets contain the target slot for a given account, take it as it has what should be now considered a current value for this slot.
2. If the storage was wiped in any of the removed changesets, do not insert the slot back into the plain state. The database entry (if any) should be considered the current value of the slot.
3. Otherwise, take the value from the future plain state (before the revert started).
https://github.com/paradigmxyz/reth/blob/24be8bcc85b744692a82fedb502d130e86548c1e/crates/storage/provider/src/post_state/mod.rs#L329-L348

----
### Bug 3 - Duplicated changeset database entries on multiple selfdestruct within a single `PostState`

#### Description

Currently, if the selfdestruct occurs in the `PostState`, whenever we write the changesets for this account, we will select all of the previous plain storage entries in the database in order to write and preserve their values before the selfdestruct occurred.
https://github.com/paradigmxyz/reth/blob/c0cbb6a473a7c602a88b33fa8d6f6fa63e8b8dd1/crates/storage/provider/src/post_state/mod.rs#L435-L444

However, the same would be done with unchanged plain storage entries for the second, third, and every other selfdestruct after. Firstly, this bloats the database with incorrect storage changesets on secondary selfdestructs. Secondly, this leads to a corrupted database, in case we have to unwind such entries.

#### Solution

Introduce, the first and second degree for storage wipes. The database entries will be re-inserted only on `Primary` storage wipe (the first occurred). 
https://github.com/paradigmxyz/reth/blob/24be8bcc85b744692a82fedb502d130e86548c1e/crates/storage/provider/src/post_state/storage.rs#L17-L30

Additionally, on `destroy_account`, instead of clearing the accounts storage state, reinsert it as the changeset.
https://github.com/paradigmxyz/reth/blob/24be8bcc85b744692a82fedb502d130e86548c1e/crates/storage/provider/src/post_state/mod.rs#L429-L435
This ensures that we preserve correct changesets in between multiple selfdestructs.  

---- 
### Bonus - Bug 4

#### Description

Whenever the plain storage entries were selected from the database for a selfdestructed account, they took precedence over the entries in the changeset, which is not correct as the storage entry might have been changed in any block leading to the selfdestruct.
https://github.com/paradigmxyz/reth/blob/c0cbb6a473a7c602a88b33fa8d6f6fa63e8b8dd1/crates/storage/provider/src/post_state/mod.rs#L435-L444


#### Solution

Check if the key already exists, before writing the plain storage entry.

https://github.com/paradigmxyz/reth/blob/24be8bcc85b744692a82fedb502d130e86548c1e/crates/storage/provider/src/post_state/mod.rs#L509-L519