### PR TITLE
fix: make stats args global

### DIFF
--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -26,7 +26,7 @@ pub struct Command {
     /// - Linux: `$XDG_DATA_HOME/reth/` or `$HOME/.local/share/reth/`
     /// - Windows: `{FOLDERID_RoamingAppData}/reth/`
     /// - macOS: `$HOME/Library/Application Support/reth/`
-    #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
+    #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t, global = true)]
     datadir: MaybePlatformPath<DataDirPath>,
 
     /// The chain this node is running.
@@ -42,7 +42,8 @@ pub struct Command {
         value_name = "CHAIN_OR_PATH",
         verbatim_doc_comment,
         default_value = "mainnet",
-        value_parser = genesis_value_parser
+        value_parser = genesis_value_parser,
+        global = true,
     )]
     chain: Arc<ChainSpec>,
 
@@ -225,5 +226,17 @@ impl Command {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn parse_stats_globals() {
+        let cmd = Command::try_parse_from(["reth", "stats", "--datadir", "../mainnet"]).unwrap();
+        assert_eq!(cmd.datadir.as_ref(), Some(Path::new("../mainnet")));
     }
 }

--- a/bin/reth/src/dirs.rs
+++ b/bin/reth/src/dirs.rs
@@ -190,6 +190,16 @@ impl<D: XdgPath> MaybePlatformPath<D> {
         )
     }
 
+    /// Returns true if a custom path is set
+    pub fn is_some(&self) -> bool {
+        self.0.is_some()
+    }
+
+    /// Returns the path if it is set, otherwise returns `None`.
+    pub fn as_ref(&self) -> Option<&Path> {
+        self.0.as_ref().map(|p| p.as_ref())
+    }
+
     /// Returns the path if it is set, otherwise returns the default path, without any chain
     /// directory.
     pub fn unwrap_or_default(&self) -> PlatformPath<D> {


### PR DESCRIPTION
make args global so

`cargo r --bin reth -- db stats --datadir ../goerli` works