### PR TITLE
fix(rpc): initialize arena with root node

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/arena.rs
+++ b/crates/revm/revm-inspectors/src/tracing/arena.rs
@@ -3,7 +3,7 @@ use crate::tracing::types::{CallTrace, CallTraceNode, LogCallOrder};
 /// An arena of recorded traces.
 ///
 /// This type will be populated via the [TracingInspector](crate::tracing::TracingInspector).
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CallTraceArena {
     /// The arena of recorded trace nodes
     pub(crate) arena: Vec<CallTraceNode>,
@@ -41,5 +41,12 @@ impl CallTraceArena {
                 new_trace,
             ),
         }
+    }
+}
+
+impl Default for CallTraceArena {
+    fn default() -> Self {
+        // The first node is the root node
+        CallTraceArena { arena: vec![Default::default()] }
     }
 }


### PR DESCRIPTION
the arena should not be empty and should be initialized with an empty root node

ported this incorrectly:

https://github.com/foundry-rs/foundry/blob/de47eb8acd62a4d436a0a2ed4db0c8967f2f1f3d/evm/src/trace/mod.rs#L32-L43

fixes panic

> thread 'tokio-runtime-worker' panicked at 'index out of bounds: the len is 0 but the index is 0', crates/revm/revm-inspectors/src/tracing/arena.rs:18:17