### PR TITLE
doc(cli): remove reference to `reth db --db` flag in book

### DIFF
--- a/book/cli/db.md
+++ b/book/cli/db.md
@@ -31,10 +31,6 @@ Options:
           
           [default: default]
 
-      --db <PATH>
-          The path to the database folder. If not specified, it will be set in the data dir for the
-          chain being used.
-
       --chain <CHAIN_OR_PATH>
           The chain this node is running.
           


### PR DESCRIPTION
Follow-up #2575
Linked #2528 