### PR TITLE
chore: move decode_revert_reason to primitives

### DIFF
--- a/crates/primitives/src/abi.rs
+++ b/crates/primitives/src/abi.rs
@@ -1,0 +1,16 @@
+//! Eth ABI helpers.
+use crate::constants::SELECTOR_LEN;
+
+/// Returns the revert reason from the given output data, if it's an abi encoded String. Returns
+/// `None` if the output is not long enough to contain a function selector or the content is not a
+/// valid abi encoded String.
+///
+/// **Note:** it's assumed the `out` buffer starts with the call's signature
+pub fn decode_revert_reason(out: impl AsRef<[u8]>) -> Option<String> {
+    use ethers_core::abi::AbiDecode;
+    let out = out.as_ref();
+    if out.len() < SELECTOR_LEN {
+        return None
+    }
+    String::decode(&out[SELECTOR_LEN..]).ok()
+}

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -9,6 +9,7 @@
 //!
 //! This crate contains Ethereum primitive types and helper functions.
 
+pub mod abi;
 mod account;
 pub mod basefee;
 mod bits;

--- a/crates/rpc/rpc/src/eth/error.rs
+++ b/crates/rpc/rpc/src/eth/error.rs
@@ -2,7 +2,7 @@
 
 use crate::result::{internal_rpc_err, invalid_params_rpc_err, rpc_err, rpc_error_with_code};
 use jsonrpsee::core::Error as RpcError;
-use reth_primitives::{constants::SELECTOR_LEN, Address, Bytes, U256};
+use reth_primitives::{abi::decode_revert_reason, Address, Bytes, U256};
 use reth_rpc_types::{error::EthRpcErrorCode, BlockError};
 use reth_transaction_pool::error::{InvalidPoolTransactionError, PoolError};
 use revm::primitives::{EVMError, ExecutionResult, Halt, OutOfGasError};
@@ -390,16 +390,4 @@ pub(crate) fn ensure_success(result: ExecutionResult) -> EthResult<Bytes> {
             Err(InvalidTransactionError::halt(reason, gas_used).into())
         }
     }
-}
-
-/// Returns the revert reason from the `revm::TransactOut` data, if it's an abi encoded String.
-///
-/// **Note:** it's assumed the `out` buffer starts with the call's signature
-pub(crate) fn decode_revert_reason(out: impl AsRef<[u8]>) -> Option<String> {
-    use ethers_core::abi::AbiDecode;
-    let out = out.as_ref();
-    if out.len() < SELECTOR_LEN {
-        return None
-    }
-    String::decode(&out[SELECTOR_LEN..]).ok()
 }


### PR DESCRIPTION
we need this in multiple places (rpc, tracing for example)

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8f0eacb</samp>

Added `decode_revert_reason` function to `reth_primitives::abi` module and used it in `reth_rpc` crate. This improves the error handling of contract calls in the RPC layer.