### PR TITLE
chore: remove allow unused in rpc

### DIFF
--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -820,12 +820,12 @@ where
                 self.config.eth.max_logs_per_response,
             );
 
-            let pubsub = EthPubSub::new(
+            let pubsub = EthPubSub::with_spawner(
                 self.client.clone(),
                 self.pool.clone(),
                 self.events.clone(),
                 self.network.clone(),
-                cache.clone(),
+                Box::new(self.executor.clone()),
             );
 
             let eth = EthHandlers { api, cache, filter, pubsub };

--- a/crates/rpc/rpc/src/eth/api/block.rs
+++ b/crates/rpc/rpc/src/eth/api/block.rs
@@ -68,14 +68,6 @@ where
         Ok(self.cache().get_block_transactions(block_hash).await?.map(|txs| txs.len()))
     }
 
-    /// Returns the block header for the given block id.
-    pub(crate) async fn header(
-        &self,
-        block_id: impl Into<BlockId>,
-    ) -> EthResult<Option<reth_primitives::SealedHeader>> {
-        Ok(self.block(block_id).await?.map(|block| block.header))
-    }
-
     /// Returns the block object for the given block id.
     pub(crate) async fn block(
         &self,

--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -3,7 +3,11 @@
 //! The entire implementation of the namespace is quite large, hence it is divided across several
 //! files.
 
-use crate::eth::{cache::EthStateCache, signer::EthSigner};
+use crate::eth::{
+    cache::EthStateCache,
+    error::{EthApiError, EthResult},
+    signer::EthSigner,
+};
 use async_trait::async_trait;
 use reth_interfaces::Result;
 use reth_network_api::NetworkInfo;
@@ -20,7 +24,7 @@ mod server;
 mod sign;
 mod state;
 mod transactions;
-use crate::eth::error::{EthApiError, EthResult};
+
 pub use transactions::{EthTransactions, TransactionSource};
 
 /// Cache limit of block-level fee history for `eth_feeHistory` RPC method.

--- a/crates/rpc/rpc/src/eth/api/state.rs
+++ b/crates/rpc/rpc/src/eth/api/state.rs
@@ -81,6 +81,7 @@ where
         Ok(H256(value.to_be_bytes()))
     }
 
+    #[allow(unused)]
     pub(crate) fn get_proof(
         &self,
         address: Address,

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -187,6 +187,7 @@ where
 #[derive(Debug)]
 struct EthFilterInner<Client, Pool> {
     /// The transaction pool.
+    #[allow(unused)] // we need this for non standard full transactions eventually
     pool: Pool,
     /// The client that can interact with the chain.
     client: Client,

--- a/crates/rpc/rpc/src/eth/pubsub.rs
+++ b/crates/rpc/rpc/src/eth/pubsub.rs
@@ -1,5 +1,5 @@
 //! `eth_` PubSub RPC handler implementation
-use crate::eth::{cache::EthStateCache, logs_utils};
+use crate::eth::logs_utils;
 use futures::StreamExt;
 use jsonrpsee::{types::SubscriptionResult, SubscriptionSink};
 use reth_network_api::NetworkInfo;
@@ -37,21 +37,8 @@ impl<Client, Pool, Events, Network> EthPubSub<Client, Pool, Events, Network> {
     /// Creates a new, shareable instance.
     ///
     /// Subscription tasks are spawned via [tokio::task::spawn]
-    pub fn new(
-        client: Client,
-        pool: Pool,
-        chain_events: Events,
-        network: Network,
-        eth_cache: EthStateCache,
-    ) -> Self {
-        Self::with_spawner(
-            client,
-            pool,
-            chain_events,
-            network,
-            eth_cache,
-            Box::<TokioTaskExecutor>::default(),
-        )
+    pub fn new(client: Client, pool: Pool, chain_events: Events, network: Network) -> Self {
+        Self::with_spawner(client, pool, chain_events, network, Box::<TokioTaskExecutor>::default())
     }
 
     /// Creates a new, shareable instance.
@@ -60,10 +47,9 @@ impl<Client, Pool, Events, Network> EthPubSub<Client, Pool, Events, Network> {
         pool: Pool,
         chain_events: Events,
         network: Network,
-        eth_cache: EthStateCache,
         subscription_task_spawner: Box<dyn TaskSpawner>,
     ) -> Self {
-        let inner = EthPubSubInner { client, pool, chain_events, network, eth_cache };
+        let inner = EthPubSubInner { client, pool, chain_events, network };
         Self { inner, subscription_task_spawner }
     }
 }
@@ -168,12 +154,10 @@ struct EthPubSubInner<Client, Pool, Events, Network> {
     pool: Pool,
     /// The client that can interact with the chain.
     client: Client,
-    /// A type that allows to create new event subscriptions,
+    /// A type that allows to create new event subscriptions.
     chain_events: Events,
     /// The network.
     network: Network,
-    /// The async cache frontend for eth related data
-    eth_cache: EthStateCache,
 }
 
 // == impl EthPubSubInner ===

--- a/crates/rpc/rpc/src/lib.rs
+++ b/crates/rpc/rpc/src/lib.rs
@@ -4,8 +4,6 @@
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
 ))]
-// TODO remove later
-#![allow(dead_code)]
 
 //! Reth RPC implementation
 //!

--- a/crates/rpc/rpc/src/result.rs
+++ b/crates/rpc/rpc/src/result.rs
@@ -164,17 +164,12 @@ pub(crate) fn rpc_err(code: i32, msg: impl Into<String>, data: Option<&[u8]>) ->
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
 
     fn assert_rpc_result<Ok, Err, T: ToRpcResult<Ok, Err>>() {}
 
     fn to_reth_err<Ok>(o: Ok) -> reth_interfaces::Result<Ok> {
         Ok(o)
-    }
-
-    fn to_optional_reth_err<Ok>(o: Ok) -> reth_interfaces::Result<Option<Ok>> {
-        Ok(Some(o))
     }
 
     #[test]

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -37,7 +37,8 @@ pub struct TraceApi<Client, Eth> {
     client: Client,
     /// Access to commonly used code of the `eth` namespace
     eth_api: Eth,
-    /// The async cache frontend for eth related data
+    /// The async cache frontend for eth-related data
+    #[allow(unused)] // we need this for trace_filter eventually
     eth_cache: EthStateCache,
     // restrict the number of concurrent calls to `trace_*`
     tracing_call_guard: TracingCallGuard,
@@ -46,6 +47,11 @@ pub struct TraceApi<Client, Eth> {
 // === impl TraceApi ===
 
 impl<Client, Eth> TraceApi<Client, Eth> {
+    /// The client that can interact with the chain.
+    pub fn client(&self) -> &Client {
+        &self.client
+    }
+
     /// Create a new instance of the [TraceApi]
     pub fn new(
         client: Client,


### PR DESCRIPTION
* remove the allow(unused) in rpc, adds a few `allow` to fields we'll eventually use

copilot:summary



