### PR TITLE
chore: Additional logs on revert error

### DIFF
--- a/crates/blockchain-tree/src/block_buffer.rs
+++ b/crates/blockchain-tree/src/block_buffer.rs
@@ -24,15 +24,15 @@ pub struct BlockBuffer {
     ///
     /// Note: BTreeMap is used so that we can remove the finalized old blocks
     /// from the buffer
-    blocks: BufferedBlocks,
+    pub(crate) blocks: BufferedBlocks,
     /// Needed for removal of the blocks. and to connect the potential unconnected block
     /// to the connected one.
-    parent_to_child: HashMap<BlockHash, HashSet<BlockNumHash>>,
+    pub(crate) parent_to_child: HashMap<BlockHash, HashSet<BlockNumHash>>,
     /// LRU used for tracing oldest inserted blocks that are going to be
     /// first in line for evicting if `max_blocks` limit is hit.
     ///
     /// Used as counter of amount of blocks inside buffer.
-    lru: LruCache<BlockNumHash, ()>,
+    pub(crate) lru: LruCache<BlockNumHash, ()>,
 }
 
 impl BlockBuffer {

--- a/crates/blockchain-tree/src/block_indices.rs
+++ b/crates/blockchain-tree/src/block_indices.rs
@@ -12,7 +12,7 @@ use std::collections::{btree_map, hash_map, BTreeMap, BTreeSet, HashMap, HashSet
 ///
 /// It contains a list of canonical block hashes, forks to child blocks, and a mapping of block hash
 /// to chain ID.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BlockIndices {
     /// Last finalized block.
     last_finalized_block: BlockNumber,

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -876,7 +876,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
 
         let tip = tx.tip_number()?;
         let revert_range = (revert_until + 1)..=tip;
-        info!("Revert canonical chain from block: {:?}", revert_range);
+        info!("Revert canonical chain range: {:?}", revert_range);
         // read block and execution result from database. and remove traces of block from tables.
         let blocks_and_execution = tx
             .take_block_and_execution_range(self.externals.chain_spec.as_ref(), revert_range)

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -714,9 +714,12 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
     #[track_caller]
     #[instrument(skip(self), target = "blockchain_tree")]
     pub fn make_canonical(&mut self, block_hash: &BlockHash) -> Result<(), Error> {
+        let old_block_indices = self.block_indices.clone();
+        let old_buffered_blocks = self.buffered_blocks.parent_to_child.clone();
+
         // If block is already canonical don't return error.
         if self.block_indices.is_block_hash_canonical(block_hash) {
-            trace!(target: "blockchain_tree", "Block is already canonical");
+            info!(target: "blockchain_tree", "Block is already canonical");
             let td = self
                 .externals
                 .shareable_db()
@@ -729,7 +732,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
         }
 
         let Some(chain_id) = self.block_indices.get_blocks_chain_id(block_hash) else {
-            debug!(target: "blockchain_tree", "Block hash not found in block indices");
+            info!(target: "blockchain_tree", "Block hash not found in block indices");
             return Err(ExecError::BlockHashNotFoundInChain { block_hash: *block_hash }.into())
         };
         let chain = self.chains.remove(&chain_id).expect("To be present");
@@ -762,7 +765,10 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
 
         // event about new canonical chain.
         let chain_notification;
-
+        info!(
+            "Committing new canonical chain: {:?}",
+            new_canon_chain.blocks().iter().map(|(_, b)| b.num_hash()).collect::<Vec<_>>()
+        );
         // if joins to the tip;
         if new_canon_chain.fork_block_hash() == old_tip.hash {
             chain_notification =
@@ -772,13 +778,27 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
         } else {
             // it forks to canonical block that is not the tip.
 
-            let canon_fork = new_canon_chain.fork_block();
+            let canon_fork: BlockNumHash = new_canon_chain.fork_block();
             // sanity check
             if self.block_indices.canonical_hash(&canon_fork.number) != Some(canon_fork.hash) {
                 unreachable!("all chains should point to canonical chain.");
             }
 
-            let old_canon_chain = self.revert_canonical(canon_fork.number)?;
+            let old_canon_chain = self.revert_canonical(canon_fork.number);
+
+            let old_canon_chain = match old_canon_chain {
+                val @ Err(_) => {
+                    error!(
+                        "Reverting canonical chain failed with error: {:?}\n\
+                            Old BlockIndices are:{:?}\n\
+                            New BlockIndices are: {:?}\n\
+                            Old BufferedBlocks are:{:?}",
+                        val, old_block_indices, self.block_indices, old_buffered_blocks
+                    );
+                    val?
+                }
+                Ok(val) => val,
+            };
 
             // commit new canonical chain.
             self.commit_canonical(new_canon_chain.clone())?;
@@ -855,12 +875,11 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
         let mut tx = Transaction::new(&self.externals.db)?;
 
         let tip = tx.tip_number()?;
+        let revert_range = (revert_until + 1)..=tip;
+        info!("Revert canonical chain from block: {:?}", revert_range);
         // read block and execution result from database. and remove traces of block from tables.
         let blocks_and_execution = tx
-            .take_block_and_execution_range(
-                self.externals.chain_spec.as_ref(),
-                (revert_until + 1)..=tip,
-            )
+            .take_block_and_execution_range(self.externals.chain_spec.as_ref(), revert_range)
             .map_err(|e| ExecError::CanonicalRevert { inner: e.to_string() })?;
 
         tx.commit()?;


### PR DESCRIPTION
Added more logs to hunt for the revert bug that we have.

It will log all new canonical block number and hashes.
It will log revert range
In case of error on reverting canonical chain it will print all block tree indices and all new block tree indices, which should help to see the state before and after the `make_canonical`.