### PR TITLE
fix: do not panic on safe, finalized BlockIdProvider

### DIFF
--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -116,10 +116,12 @@ where
     Tree: BlockchainTreeViewer + Send + Sync,
 {
     fn safe_block_num(&self) -> Result<Option<reth_primitives::BlockNumber>> {
+        // TODO: implement with canon chain tracker
         Ok(None)
     }
 
     fn finalized_block_num(&self) -> Result<Option<reth_primitives::BlockNumber>> {
+        // TODO: implement with canon chain tracker
         Ok(None)
     }
 

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -116,11 +116,11 @@ where
     Tree: BlockchainTreeViewer + Send + Sync,
 {
     fn safe_block_num(&self) -> Result<Option<reth_primitives::BlockNumber>> {
-        todo!()
+        Ok(None)
     }
 
     fn finalized_block_num(&self) -> Result<Option<reth_primitives::BlockNumber>> {
-        todo!()
+        Ok(None)
     }
 
     fn pending_block_num_hash(&self) -> Result<Option<reth_primitives::BlockNumHash>> {


### PR DESCRIPTION
Prevents panics when we request the `safe` or `finalized` block nums, to be resolved after #2555