### PR TITLE
fix(executor): do not destroy empty accounts

### DIFF
--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -390,9 +390,13 @@ pub fn commit_state_changes<DB>(
                     panic!("Left panic to critically jumpout if happens, as every account should be hot loaded.");
                 }
             };
-            // Insert into `change` a old account and None for new account
-            // and mark storage to be mapped
-            post_state.destroy_account(block_number, address, to_reth_acc(&db_account.info));
+
+            let old = to_reth_acc(&db_account.info);
+            if !old.is_empty() {
+                // Insert into `change` a old account and None for new account
+                // and mark storage to be wiped
+                post_state.destroy_account(block_number, address, to_reth_acc(&db_account.info));
+            }
 
             // clear cached DB and mark account as not existing
             db_account.storage.clear();


### PR DESCRIPTION
## Description

If the account was created and destroyed within the same transaction, we will attempt to destroy it in the `PostState` and incorrectly insert `Some(Account::default())` changeset instead of `None`.

## Solution

Do not destroy the account if it is empty (doesn't exist).

## Addition Context

Can be reproduced at sepolia transaction [0x78e6536a5f891b4923af585144a825a99b9d8a96222dd63440781944b676221d](https://sepolia.etherscan.io/tx/0x78e6536a5f891b4923af585144a825a99b9d8a96222dd63440781944b676221d)

WARNING: This doesn't account for behavior before state clearing EIP.