### PR TITLE
fix(executor): do not insert empty changesets for touched accounts

### DIFF
--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -428,7 +428,7 @@ pub fn commit_state_changes<DB>(
                 Entry::Occupied(entry) => {
                     let entry = entry.into_mut();
 
-                    if matches!(entry.account_state, AccountState::NotExisting) {
+                    if entry.info.is_empty() {
                         let account = to_reth_acc(&account.info);
                         if !(has_state_clear_eip && account.is_empty()) {
                             post_state.create_account(block_number, address, account);


### PR DESCRIPTION
## Description

Sometimes revm can return touched unchanged accounts included in the result. Since we have a long lived `CacheDB` that spans across multiple transaction, we might have already promoted the account from `NotExisting` to `Touched`. Hence the check for `NotExisting` account state is not correct when we are deciding what should we do with the account in the `PostState`.

## Solution

Check if the database account is empty instead of account state `NotExisting`.

## Additional Context

This behavior can be observed in the changesets generated for account [0x000000000000000000636f6e736f6c652e6c6f67](https://sepolia.etherscan.io/address/0x000000000000000000636f6e736f6c652e6c6f67) (hardhat logger) in the transactions for [sepolia block #1124631](https://sepolia.etherscan.io/txs?block=1124631).

WARNING: This doesn't account for behavior before state clearing EIP.