### PR TITLE
fix(codec): Use variable length encoding for lengths on `Vec<T>` and `Option<T>`

### DIFF
--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -346,4 +346,38 @@ mod tests {
         let receipt = ReceiptWithBloom::decode(&mut &data[..]).unwrap();
         assert_eq!(receipt, expected);
     }
+
+    #[test]
+    fn gigantic_receipt() {
+        let receipt = Receipt {
+            cumulative_gas_used: 16747627,
+            success: true,
+            tx_type: TxType::Legacy,
+            logs: vec![
+                Log {
+                    address: Address::from_str("0x4bf56695415f725e43c3e04354b604bcfb6dfb6e")
+                        .unwrap(),
+                    topics: vec![H256::from_str(
+                        "0xc69dc3d7ebff79e41f525be431d5cd3cc08f80eaf0f7819054a726eeb7086eb9",
+                    )
+                    .unwrap()],
+                    data: crate::Bytes::from(vec![1; 0xffffff]),
+                },
+                Log {
+                    address: Address::from_str("0xfaca325c86bf9c2d5b413cd7b90b209be92229c2")
+                        .unwrap(),
+                    topics: vec![H256::from_str(
+                        "0x8cca58667b1e9ffa004720ac99a3d61a138181963b294d270d91c53d36402ae2",
+                    )
+                    .unwrap()],
+                    data: crate::Bytes::from(vec![1; 0xffffff]),
+                },
+            ],
+        };
+
+        let mut data = vec![];
+        receipt.clone().to_compact(&mut data);
+        let (decoded, _) = Receipt::from_compact(&data[..], data.len());
+        assert_eq!(decoded, receipt);
+    }
 }

--- a/crates/storage/codecs/src/lib.rs
+++ b/crates/storage/codecs/src/lib.rs
@@ -433,7 +433,7 @@ mod tests {
         buf.extend([1u8, 2]);
 
         let mut remaining_buf = buf.as_slice();
-        remaining_buf.advance(2 + 2 + 32 + 2 + 32);
+        remaining_buf.advance(1 + 1 + 32 + 1 + 32);
 
         assert_eq!(Vec::<H256>::from_compact(&buf, 0), (list, remaining_buf));
         assert_eq!(remaining_buf, &[1u8, 2]);

--- a/crates/storage/codecs/src/lib.rs
+++ b/crates/storage/codecs/src/lib.rs
@@ -408,7 +408,7 @@ mod tests {
 
         assert_eq!(None::<H256>.to_compact(&mut buf), 0);
         assert_eq!(opt.to_compact(&mut buf), 1);
-        assert_eq!(buf.len(), 34);
+        assert_eq!(buf.len(), 1 + 32);
 
         assert_eq!(Option::<H256>::from_compact(&buf, 1), (opt, vec![].as_slice()));
 
@@ -505,9 +505,9 @@ mod tests {
                 f_bool_t: true,                               // 1 bit  | 0 bytes
                 f_option_none: None,                          // 1 bit  | 0 bytes
                 f_option_some: Some(H256::zero()),            // 1 bit  | 32 bytes
-                f_option_some_u64: Some(0xffffu64),           // 1 bit  | 2 + 2 bytes
-                f_vec_empty: vec![],                          // 0 bits | 2 bytes
-                f_vec_some: vec![H160::zero(), H160::zero()], // 0 bits | 2 + 20*2 bytes
+                f_option_some_u64: Some(0xffffu64),           // 1 bit  | 1 + 2 bytes
+                f_vec_empty: vec![],                          // 0 bits | 1 bytes
+                f_vec_some: vec![H160::zero(), H160::zero()], // 0 bits | 1 + 20*2 bytes
             }
         }
     }
@@ -523,9 +523,9 @@ mod tests {
             1 +
             // 0 + 0 + 0 +
             32 +
-            2 + 2 +
-            2 +
-            2 + 20 * 2
+            1 + 2 +
+            1 +
+            1 + 20 * 2
         );
 
         assert_eq!(


### PR DESCRIPTION
We were using 2-fixed bytes, but there are actual cases of elements with a size bigger than `0xffff`. 
Therefore, we have to use variable length encoding.