### PR TITLE
chore: add task spawner to trace and debug

### DIFF
--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -672,9 +672,31 @@ where
         let eth_api = self.eth_api();
         self.modules.insert(
             RethRpcModule::Debug,
-            DebugApi::new(self.client.clone(), eth_api, self.tracing_call_guard.clone())
-                .into_rpc()
-                .into(),
+            DebugApi::new(
+                self.client.clone(),
+                eth_api,
+                Box::new(self.executor.clone()),
+                self.tracing_call_guard.clone(),
+            )
+            .into_rpc()
+            .into(),
+        );
+        self
+    }
+
+    /// Register Trace Namespace
+    pub fn register_trace(&mut self) -> &mut Self {
+        let eth_api = self.eth_api();
+        self.modules.insert(
+            RethRpcModule::Trace,
+            DebugApi::new(
+                self.client.clone(),
+                eth_api,
+                Box::new(self.executor.clone()),
+                self.tracing_call_guard.clone(),
+            )
+            .into_rpc()
+            .into(),
         );
         self
     }
@@ -749,6 +771,7 @@ where
                         RethRpcModule::Debug => DebugApi::new(
                             self.client.clone(),
                             eth_api.clone(),
+                            Box::new(self.executor.clone()),
                             self.tracing_call_guard.clone(),
                         )
                         .into_rpc()
@@ -768,6 +791,7 @@ where
                             self.client.clone(),
                             eth_api.clone(),
                             eth_cache.clone(),
+                            Box::new(self.executor.clone()),
                             self.tracing_call_guard.clone(),
                         )
                         .into_rpc()

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -26,6 +26,7 @@ use reth_rpc_types::{
     },
     BlockError, CallRequest, RichBlock,
 };
+use reth_tasks::TaskSpawner;
 use revm::primitives::Env;
 use revm_primitives::{db::DatabaseCommit, BlockEnv, CfgEnv};
 use tokio::sync::{AcquireError, OwnedSemaphorePermit};
@@ -41,14 +42,22 @@ pub struct DebugApi<Client, Eth> {
     eth_api: Eth,
     // restrict the number of concurrent calls to tracing calls
     tracing_call_guard: TracingCallGuard,
+    /// The type that can spawn tasks which would otherwise block.
+    #[allow(unused)]
+    task_spawner: Box<dyn TaskSpawner>,
 }
 
 // === impl DebugApi ===
 
 impl<Client, Eth> DebugApi<Client, Eth> {
     /// Create a new instance of the [DebugApi]
-    pub fn new(client: Client, eth: Eth, tracing_call_guard: TracingCallGuard) -> Self {
-        Self { client, eth_api: eth, tracing_call_guard }
+    pub fn new(
+        client: Client,
+        eth: Eth,
+        task_spawner: Box<dyn TaskSpawner>,
+        tracing_call_guard: TracingCallGuard,
+    ) -> Self {
+        Self { client, eth_api: eth, task_spawner, tracing_call_guard }
     }
 }
 

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -23,6 +23,7 @@ use reth_rpc_types::{
     trace::{filter::TraceFilter, parity::*},
     BlockError, CallRequest, Index, TransactionInfo,
 };
+use reth_tasks::TaskSpawner;
 use revm::primitives::Env;
 use revm_primitives::{db::DatabaseCommit, ExecutionResult};
 use std::collections::HashSet;
@@ -40,6 +41,9 @@ pub struct TraceApi<Client, Eth> {
     /// The async cache frontend for eth-related data
     #[allow(unused)] // we need this for trace_filter eventually
     eth_cache: EthStateCache,
+    /// The type that can spawn tasks which would otherwise be blocking.
+    #[allow(unused)]
+    task_spawner: Box<dyn TaskSpawner>,
     // restrict the number of concurrent calls to `trace_*`
     tracing_call_guard: TracingCallGuard,
 }
@@ -57,9 +61,10 @@ impl<Client, Eth> TraceApi<Client, Eth> {
         client: Client,
         eth_api: Eth,
         eth_cache: EthStateCache,
+        task_spawner: Box<dyn TaskSpawner>,
         tracing_call_guard: TracingCallGuard,
     ) -> Self {
-        Self { client, eth_api, eth_cache, tracing_call_guard }
+        Self { client, eth_api, eth_cache, task_spawner, tracing_call_guard }
     }
 
     /// Acquires a permit to execute a tracing call.


### PR DESCRIPTION
This unblocks #2643

boxing the spawner is perfectly fine, for these namespaces.
I'm still on the fence about the eth namespace though, I don't think this has any performance impact at all so I think I'll use a boxed spawner there as well.