### PR TITLE
meta: add beacon consensus code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,5 +11,5 @@ crates/transaction-pool/    @mattsse
 crates/rpc/                 @mattsse @Rjected
 crates/payload/             @mattsse @Rjected
 crates/consensus/auto-seal  @mattsse
-crates/consensus/beacon     @rkrasiuk
+crates/consensus/beacon     @rkrasiuk @mattsse @Rjected
 crates/trie                 @rkrasiuk


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bdf92ac</samp>

Update code owners for `crates/consensus/beacon` crate. This assigns more responsibility and recognition to @mattsse and @Rjected for their work on the beacon consensus protocol.