### PR TITLE
feat: add getter for last FCU timestamp

### DIFF
--- a/crates/storage/provider/src/providers/chain_info.rs
+++ b/crates/storage/provider/src/providers/chain_info.rs
@@ -13,7 +13,7 @@ impl ChainInfoTracker {
     pub(crate) fn new(head: SealedHeader) -> Self {
         Self {
             inner: Arc::new(ChainInfoInner {
-                last_forkchoice_update: RwLock::new(Instant::now()),
+                last_forkchoice_update: RwLock::new(None),
                 canonical_head: RwLock::new(head),
                 safe_block: RwLock::new(None),
                 finalized_block: RwLock::new(None),
@@ -23,12 +23,12 @@ impl ChainInfoTracker {
 
     /// Update the timestamp when we received a forkchoice update.
     pub(crate) fn on_forkchoice_update_received(&self) {
-        *self.inner.last_forkchoice_update.write() = Instant::now();
+        self.inner.last_forkchoice_update.write().replace(Instant::now());
     }
 
     /// Returns the instant when we received the latest forkchoice update.
     #[allow(unused)]
-    pub(crate) fn last_forkchoice_update_received_at(&self) -> Instant {
+    pub(crate) fn last_forkchoice_update_received_at(&self) -> Option<Instant> {
         *self.inner.last_forkchoice_update.read()
     }
 
@@ -92,7 +92,7 @@ struct ChainInfoInner {
     /// Timestamp when we received the last fork choice update.
     ///
     /// This is mainly used to track if we're connected to a beacon node.
-    last_forkchoice_update: RwLock<Instant>,
+    last_forkchoice_update: RwLock<Option<Instant>>,
     /// The canonical head of the chain.
     canonical_head: RwLock<SealedHeader>,
     /// The block that the beacon node considers safe.

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -24,6 +24,7 @@ pub use state::{
 use std::{
     collections::{BTreeMap, HashSet},
     ops::RangeBounds,
+    time::Instant,
 };
 use tracing::trace;
 
@@ -452,6 +453,10 @@ where
 
     fn set_canonical_head(&self, header: SealedHeader) {
         self.chain_info.set_canonical_head(header);
+    }
+
+    fn last_received_update_timestamp(&self) -> Option<Instant> {
+        self.chain_info.last_forkchoice_update_received_at()
     }
 }
 

--- a/crates/storage/provider/src/traits/chain_info.rs
+++ b/crates/storage/provider/src/traits/chain_info.rs
@@ -1,10 +1,15 @@
 use reth_interfaces::consensus::ForkchoiceState;
 use reth_primitives::SealedHeader;
+use std::time::Instant;
 
 /// A type that can track updates related to fork choice updates.
 pub trait CanonChainTracker: Send + Sync {
     /// Notify the tracker about a received fork choice update.
     fn on_forkchoice_update_received(&self, update: &ForkchoiceState);
+
+    /// Returns the last time a fork choice update was received from the CL
+    /// ([CanonChainTracker::on_forkchoice_update_received])
+    fn last_received_update_timestamp(&self) -> Option<Instant>;
 
     /// Sets the canonical head of the chain.
     fn set_canonical_head(&self, header: SealedHeader);


### PR DESCRIPTION
unblocks #2526

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fa716d6</samp>

Added a feature to track the last fork choice update time in the storage provider module. Changed the type of `last_forkchoice_update` in the `ChainInfo` trait and its implementations to use `Instant` instead of `u64`.