### PR TITLE
feat: impl BlockIdProvider for BlockchainProvider

### DIFF
--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -137,13 +137,11 @@ where
     Tree: BlockchainTreeViewer + Send + Sync,
 {
     fn safe_block_num(&self) -> Result<Option<reth_primitives::BlockNumber>> {
-        // TODO: implement with canon chain tracker
-        Ok(None)
+        Ok(self.chain_info.get_safe_num_hash().map(|num_hash| num_hash.number))
     }
 
     fn finalized_block_num(&self) -> Result<Option<reth_primitives::BlockNumber>> {
-        // TODO: implement with canon chain tracker
-        Ok(None)
+        Ok(self.chain_info.get_finalized_num_hash().map(|num_hash| num_hash.number))
     }
 
     fn pending_block_num_hash(&self) -> Result<Option<reth_primitives::BlockNumHash>> {


### PR DESCRIPTION
Provides full support for `safe` / `finalized` tags in RPC.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a9ca056</samp>

Implemented `safe_block_num` and `finalized_block_num` methods for `EthProvider` trait. These methods return the block numbers of the safe and finalized blocks on the Ethereum network, using the `chain_info` field of the provider.