### PR TITLE
perf: do not compile traces in release mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,6 @@ incremental = false
 [patch.crates-io]
 # patched for quantity U256 responses <https://github.com/recmo/uint/issues/224>
 ruint = { git = "https://github.com/paradigmxyz/uint" }
+
+[workspace.dependencies]
+tracing = { version = "^0.1.0", default-features = false, features = ["release_max_level_info"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,4 @@ incremental = false
 ruint = { git = "https://github.com/paradigmxyz/uint" }
 
 [workspace.dependencies]
-tracing = { version = "^0.1.0", default-features = false, features = ["release_max_level_info"] }
+tracing = { version = "^0.1.0", default-features = false }

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -94,3 +94,6 @@ backon = "0.4"
 hex = "0.4"
 thiserror = "1.0"
 pretty_assertions = "1.3.0"
+
+[features]
+only-info-logs = ["tracing/release_max_level_info"]

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -52,7 +52,7 @@ secp256k1 = { version = "0.27.0", features = [
 ] }
 
 # tracing
-tracing = "0.1"
+tracing = { workspace = true }
 
 # io
 fdlimit = "0.2.1"

--- a/crates/blockchain-tree/Cargo.toml
+++ b/crates/blockchain-tree/Cargo.toml
@@ -22,7 +22,7 @@ reth-provider = { path = "../storage/provider" }
 # common
 parking_lot = { version = "0.12"}
 lru = "0.10"
-tracing = "0.1"
+tracing = { workspace = true }
 
 # mics
 aquamarine = "0.3.0"

--- a/crates/consensus/auto-seal/Cargo.toml
+++ b/crates/consensus/auto-seal/Cargo.toml
@@ -21,7 +21,7 @@ reth-transaction-pool = { path = "../../transaction-pool" }
 futures-util = "0.3"
 tokio = { version = "1", features = ["sync", "time"] }
 tokio-stream = "0.1"
-tracing = "0.1"
+tracing = { workspace = true }
 
 [dev-dependencies]
 reth-interfaces = { path = "../../interfaces", features = ["test-utils"] }

--- a/crates/consensus/beacon/Cargo.toml
+++ b/crates/consensus/beacon/Cargo.toml
@@ -25,7 +25,7 @@ tokio-stream = "0.1.10"
 futures = "0.3"
 
 # misc
-tracing = "0.1"
+tracing = { workspace = true }
 thiserror = "1.0"
 metrics = "0.20.1"
 schnellru = "0.2"

--- a/crates/interfaces/Cargo.toml
+++ b/crates/interfaces/Cargo.toml
@@ -27,7 +27,7 @@ tokio-stream = "0.1.11"
 # misc
 auto_impl = "1.0"
 thiserror = "1.0.37"
-tracing = "0.1"
+tracing = { workspace = true }
 rand = "0.8.5"
 arbitrary = { version = "1.1.7", features = ["derive"], optional = true }
 secp256k1 = { version = "0.27.0", default-features = false, features = [

--- a/crates/net/discv4/Cargo.toml
+++ b/crates/net/discv4/Cargo.toml
@@ -34,7 +34,7 @@ tokio = { version = "1", features = ["io-util", "net", "time"] }
 tokio-stream = "0.1"
 
 # misc
-tracing = "0.1"
+tracing = { workspace = true }
 thiserror = "1.0"
 hex = "0.4"
 rand = { version = "0.8", optional = true }

--- a/crates/net/dns/Cargo.toml
+++ b/crates/net/dns/Cargo.toml
@@ -35,7 +35,7 @@ async-trait = "0.1"
 linked_hash_set = "0.1"
 schnellru = "0.2"
 thiserror = "1.0"
-tracing = "0.1"
+tracing = { workspace = true }
 parking_lot = "0.12"
 serde = { version = "1.0", optional = true }
 serde_with = { version = "2.1.0", optional = true }

--- a/crates/net/downloaders/Cargo.toml
+++ b/crates/net/downloaders/Cargo.toml
@@ -23,7 +23,7 @@ tokio = { version = "1.0", features = ["sync"] }
 tokio-stream = "0.1"
 
 # misc
-tracing = "0.1.37"
+tracing = { workspace = true }
 metrics = "0.20.1"
 rayon = "1.6.0"
 

--- a/crates/net/ecies/Cargo.toml
+++ b/crates/net/ecies/Cargo.toml
@@ -19,7 +19,7 @@ tokio-util = { version = "0.7.4", features = ["codec"] }
 pin-project = "1.0"
 
 educe = "0.4.19"
-tracing = "0.1.37"
+tracing = { workspace = true }
 
 # HeaderBytes
 generic-array = "0.14.6"

--- a/crates/net/eth-wire/Cargo.toml
+++ b/crates/net/eth-wire/Cargo.toml
@@ -26,7 +26,7 @@ tokio-util = { version = "0.7.4", features = ["io", "codec"] }
 futures = "0.3.24"
 tokio-stream = "0.1.11"
 pin-project = "1.0"
-tracing = "0.1.37"
+tracing = { workspace = true }
 snap = "1.0.5"
 smol_str = "0.1"
 metrics = "0.20.1"

--- a/crates/net/nat/Cargo.toml
+++ b/crates/net/nat/Cargo.toml
@@ -19,7 +19,7 @@ igd = { git = "https://github.com/stevefan1999-personal/rust-igd", features = [
 ] }
 
 # misc
-tracing = "0.1"
+tracing = { workspace = true }
 pin-project-lite = "0.2.9"
 tokio = { version = "1", features = ["time"] }
 thiserror = "1.0"

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -52,7 +52,7 @@ reth-metrics-derive = { path = "../../metrics/metrics-derive" }
 # misc
 auto_impl = "1"
 aquamarine = "0.3.0"
-tracing = "0.1"
+tracing = { workspace = true }
 fnv = "1.0"
 thiserror = "1.0"
 parking_lot = "0.12"

--- a/crates/payload/basic/Cargo.toml
+++ b/crates/payload/basic/Cargo.toml
@@ -30,4 +30,4 @@ futures-core = "0.3"
 futures-util = "0.3"
 
 ## misc
-tracing = "0.1"
+tracing = { workspace = true }

--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -30,7 +30,7 @@ futures-util = "0.3"
 ## misc
 thiserror = "1.0"
 sha2 = { version = "0.10", default-features = false }
-tracing = "0.1.37"
+tracing = { workspace = true }
 
 
 [features]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -37,7 +37,7 @@ secp256k1 = { version = "0.27.0", default-features = false, features = [
 crc = "3"
 
 # tracing
-tracing = "0.1"
+tracing = { workspace = true }
 
 # tokio
 tokio = { version = "1", default-features = false, features = ["sync"] }

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -19,7 +19,7 @@ reth-consensus-common = { path = "../consensus/common" }
 revm = { version = "3" }
 
 # common
-tracing = "0.1.37"
+tracing = { workspace = true }
 
 [dev-dependencies]
 reth-rlp = { path = "../rlp" }

--- a/crates/rpc/ipc/Cargo.toml
+++ b/crates/rpc/ipc/Cargo.toml
@@ -23,7 +23,7 @@ tower = "0.4"
 # misc
 jsonrpsee = { version = "0.18", features = ["server", "client"] }
 serde_json = "1.0"
-tracing = "0.1.37"
+tracing = { workspace = true }
 bytes = "1.4"
 thiserror = "1.0.37"
 

--- a/crates/rpc/rpc-builder/Cargo.toml
+++ b/crates/rpc/rpc-builder/Cargo.toml
@@ -30,7 +30,7 @@ hyper = "0.14"
 strum = { version = "0.24", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
-tracing = "0.1"
+tracing = { workspace = true }
 
 [dev-dependencies]
 reth-tracing = { path = "../../tracing" }

--- a/crates/rpc/rpc-engine-api/Cargo.toml
+++ b/crates/rpc/rpc-engine-api/Cargo.toml
@@ -24,7 +24,7 @@ async-trait = "0.1"
 thiserror = "1.0.37"
 jsonrpsee-types = "0.18"
 jsonrpsee-core = "0.18"
-tracing = "0.1"
+tracing = { workspace = true }
 
 [dev-dependencies]
 reth-interfaces = { path = "../../interfaces", features = ["test-utils"] }

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -56,7 +56,7 @@ serde_json = "1.0"
 thiserror = "1.0"
 hex = "0.4"
 rand = "0.8.5"
-tracing = "0.1"
+tracing = { workspace = true }
 tracing-futures = "0.2"
 schnellru = "0.2"
 futures = "0.3.26"

--- a/crates/staged-sync/Cargo.toml
+++ b/crates/staged-sync/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = "1.0.91"
 walkdir = "2.3.2"
 eyre = "0.6.8"
 shellexpand = "3.0.0"
-tracing = "0.1.37"
+tracing = { workspace = true }
 
 # crypto
 rand = { version = "0.8", optional = true }

--- a/crates/stages/Cargo.toml
+++ b/crates/stages/Cargo.toml
@@ -31,7 +31,7 @@ futures-util = "0.3.25"
 pin-project = "1.0.12"
 
 # observability
-tracing = "0.1.36"
+tracing = { workspace = true }
 metrics = "0.20.1"
 
 # misc

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -20,7 +20,7 @@ tokio = { version = "1.21", features = ["sync", "macros", "rt-multi-thread"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 
 # tracing
-tracing = "0.1"
+tracing = { workspace = true }
 
 # misc
 thiserror = "1.0.37"

--- a/crates/tasks/Cargo.toml
+++ b/crates/tasks/Cargo.toml
@@ -15,7 +15,7 @@ tracing-futures = "0.2"
 futures-util = "0.3"
 
 ## misc
-tracing = { version = "0.1", default-features = false }
+tracing = { workspace = true, default-features = false }
 thiserror = "1.0"
 dyn-clone = "1.0"
 

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 description = "tracing helpers"
 
 [dependencies]
-tracing = { version = "0.1", default-features = false }
+tracing = { workspace = true, default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
 tracing-appender = "0.2"
 tracing-journald = "0.3"

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -36,7 +36,7 @@ reth-metrics-derive = { path = "../metrics/metrics-derive" }
 # misc
 aquamarine = "0.3.0"
 thiserror = "1.0"
-tracing = "0.1"
+tracing = { workspace = true }
 serde = { version = "1.0", features = ["derive", "rc"], optional = true }
 fnv = "1.0.7"
 bitflags = "1.3"

--- a/crates/trie/Cargo.toml
+++ b/crates/trie/Cargo.toml
@@ -20,7 +20,7 @@ reth-db = { path = "../storage/db" }
 tokio = { version = "1.21.2", default-features = false, features = ["sync"] }
 
 # tracing
-tracing = "0.1"
+tracing = { workspace = true }
 
 # misc 
 hex = "0.4"


### PR DESCRIPTION
As title, we may be able to have higher perf by utilizing Tracing's static filters: https://docs.rs/tracing/latest/tracing/level_filters/index.html#compile-time-filters, since we have a TON of debug/trace traces across the board.


## Question: 

Right now I am doing this:
```

[workspace.dependencies]
tracing = { version = "^0.1.0", default-features = false, features = ["release_max_level_info"] }
```

I would like ideally for this to only be compiled in the `release` and `maxperf` profiles, while also having it as a workspace dep. I'm not sure how to do this yet, still fiddling with doing `workspace.maxperf.dependencies` etc.