### PR TITLE
perf: restrict bodies downloader by number of blocks

### DIFF
--- a/bin/reth/src/stage/mod.rs
+++ b/bin/reth/src/stage/mod.rs
@@ -160,8 +160,8 @@ impl Command {
                         downloader: BodiesDownloaderBuilder::default()
                             .with_stream_batch_size(batch_size as usize)
                             .with_request_limit(config.stages.bodies.downloader_request_limit)
-                            .with_max_buffered_responses(
-                                config.stages.bodies.downloader_max_buffered_responses,
+                            .with_max_buffered_blocks(
+                                config.stages.bodies.downloader_max_buffered_blocks,
                             )
                             .with_concurrent_requests_range(
                                 config.stages.bodies.downloader_min_concurrent_requests..=

--- a/crates/net/downloaders/src/bodies/queue.rs
+++ b/crates/net/downloaders/src/bodies/queue.rs
@@ -55,7 +55,7 @@ where
     }
 
     /// Add new request to the queue.
-    /// Expects sorted collection of headers.
+    /// Expects a sorted list of headers.
     pub(crate) fn push_new_request(
         &mut self,
         client: Arc<B>,

--- a/crates/net/downloaders/src/metrics.rs
+++ b/crates/net/downloaders/src/metrics.rs
@@ -27,6 +27,13 @@ pub struct DownloaderMetrics {
     /// The number of responses (can contain more than 1 item) in the internal buffer of the
     /// downloader.
     pub buffered_responses: Gauge,
+    /// The number of blocks the internal buffer of the
+    /// downloader.
+    /// These are bodies that have been received, but not cannot be committed yet because they're
+    /// not contiguous
+    pub buffered_blocks: Gauge,
+    /// The number blocks that are contiguous and are queued for insertion into the db.
+    pub queued_blocks: Gauge,
     /// The number of out-of-order requests sent by the downloader.
     /// The consumer of the download stream is able to re-request data (headers or bodies) in case
     /// it encountered a recoverable error (e.g. during insertion).

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -186,7 +186,7 @@ impl std::ops::DerefMut for SealedBlock {
 pub struct SealedBlockWithSenders {
     /// Sealed block
     pub block: SealedBlock,
-    /// List of senders that match trasanctions from block.
+    /// List of senders that match transactions from block.
     pub senders: Vec<Address>,
 }
 

--- a/crates/staged-sync/src/config.rs
+++ b/crates/staged-sync/src/config.rs
@@ -101,15 +101,26 @@ impl Default for TotalDifficultyConfig {
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Serialize)]
 pub struct BodiesConfig {
     /// The batch size of non-empty blocks per one request
+    ///
+    /// Default: 200
     pub downloader_request_limit: u64,
     /// The maximum number of block bodies returned at once from the stream
+    ///
+    /// Default: 10_000
     pub downloader_stream_batch_size: usize,
     /// Maximum amount of received bodies to buffer internally.
     /// The response contains multiple bodies.
-    pub downloader_max_buffered_responses: usize,
+    ///
+    /// Default: ~43_000 or 4GB with block size of 100kb
+    pub downloader_max_buffered_blocks: usize,
     /// The minimum number of requests to send concurrently.
+    ///
+    /// Default: 5
     pub downloader_min_concurrent_requests: usize,
     /// The maximum number of requests to send concurrently.
+    /// This is equal to the max number of peers.
+    ///
+    /// Default: 100
     pub downloader_max_concurrent_requests: usize,
 }
 
@@ -117,8 +128,9 @@ impl Default for BodiesConfig {
     fn default() -> Self {
         Self {
             downloader_request_limit: 200,
-            downloader_stream_batch_size: 10000,
-            downloader_max_buffered_responses: 1000,
+            downloader_stream_batch_size: 10_000,
+            // With high block sizes at around 100kb this will be ~4GB of buffered blocks: ~43k
+            downloader_max_buffered_blocks: 4 * 1024 * 1024 * 1024 / 100,
             downloader_min_concurrent_requests: 5,
             downloader_max_concurrent_requests: 100,
         }
@@ -130,7 +142,7 @@ impl From<BodiesConfig> for BodiesDownloaderBuilder {
         BodiesDownloaderBuilder::default()
             .with_stream_batch_size(config.downloader_stream_batch_size)
             .with_request_limit(config.downloader_request_limit)
-            .with_max_buffered_responses(config.downloader_max_buffered_responses)
+            .with_max_buffered_blocks(config.downloader_max_buffered_blocks)
             .with_concurrent_requests_range(
                 config.downloader_min_concurrent_requests..=
                     config.downloader_max_concurrent_requests,


### PR DESCRIPTION
this revises how the bodies downloader is restricted:

Before this change it was restricted by number of requests, but requests can yield many blocks. This restricts the downloader by number of buffered blocks (ideally this should be the actual memory and not number of blocks because blocks have a variable size, but this would require a few changes to track this efficiently).

This also adds metrics for buffered blocks and queued blocks

It changes the order of the poll loop:
yield first if we have enough blocks then advance, this should prevent situations where the downloader is significantly faster then yielding new batches


Note: this breaks the config again... so need to delete reth.toml, we don't support missing fields yet...