### PR TITLE
perf(rpc): improve gas price perf by skipping hash

### DIFF
--- a/crates/blockchain-tree/src/shareable.rs
+++ b/crates/blockchain-tree/src/shareable.rs
@@ -7,7 +7,9 @@ use reth_interfaces::{
     consensus::Consensus,
     Error,
 };
-use reth_primitives::{BlockHash, BlockNumHash, BlockNumber, SealedBlock, SealedBlockWithSenders};
+use reth_primitives::{
+    BlockHash, BlockNumHash, BlockNumber, SealedBlock, SealedBlockWithSenders, SealedHeader,
+};
 use reth_provider::{
     BlockchainTreePendingStateProvider, CanonStateSubscriptions, ExecutorFactory,
     PostStateDataProvider,
@@ -83,6 +85,11 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeViewer
     fn blocks(&self) -> BTreeMap<BlockNumber, HashSet<BlockHash>> {
         trace!(target: "blockchain_tree", "Returning all blocks in blockchain tree");
         self.tree.read().block_indices().block_number_to_block_hashes().clone()
+    }
+
+    fn header_by_hash(&self, hash: BlockHash) -> Option<SealedHeader> {
+        trace!(target: "blockchain_tree", ?hash, "Returning header by hash");
+        self.tree.read().block_by_hash(hash).map(|b| b.header.clone())
     }
 
     fn block_by_hash(&self, block_hash: BlockHash) -> Option<SealedBlock> {

--- a/crates/interfaces/src/blockchain_tree.rs
+++ b/crates/interfaces/src/blockchain_tree.rs
@@ -1,5 +1,7 @@
 use crate::{executor::Error as ExecutionError, Error};
-use reth_primitives::{BlockHash, BlockNumHash, BlockNumber, SealedBlock, SealedBlockWithSenders};
+use reth_primitives::{
+    BlockHash, BlockNumHash, BlockNumber, SealedBlock, SealedBlockWithSenders, SealedHeader,
+};
 use std::collections::{BTreeMap, HashSet};
 
 /// * [BlockchainTreeEngine::insert_block]: Connect block to chain, execute it and if valid insert
@@ -90,6 +92,11 @@ pub trait BlockchainTreeViewer: Send + Sync {
     /// Caution: This will not return blocks from the canonical chain.
     fn blocks(&self) -> BTreeMap<BlockNumber, HashSet<BlockHash>>;
 
+    /// Returns the header with matching hash from the tree, if it exists.
+    ///
+    /// Caution: This will not return headers from the canonical chain.
+    fn header_by_hash(&self, hash: BlockHash) -> Option<SealedHeader>;
+
     /// Returns the block with matching hash from the tree, if it exists.
     ///
     /// Caution: This will not return blocks from the canonical chain.
@@ -123,5 +130,10 @@ pub trait BlockchainTreeViewer: Send + Sync {
     /// Returns the pending block if there is one.
     fn pending_block(&self) -> Option<SealedBlock> {
         self.block_by_hash(self.pending_block_num_hash()?.hash)
+    }
+
+    /// Returns the pending block if there is one.
+    fn pending_header(&self) -> Option<SealedHeader> {
+        self.header_by_hash(self.pending_block_num_hash()?.hash)
     }
 }

--- a/crates/rpc/rpc/src/eth/gas_oracle.rs
+++ b/crates/rpc/rpc/src/eth/gas_oracle.rs
@@ -4,7 +4,7 @@ use crate::eth::{
     cache::EthStateCache,
     error::{EthApiError, EthResult, InvalidTransactionError},
 };
-use reth_primitives::{constants::GWEI_TO_WEI, BlockId, BlockNumberOrTag, H256, U256};
+use reth_primitives::{constants::GWEI_TO_WEI, BlockNumberOrTag, H256, U256};
 use reth_provider::BlockProviderIdExt;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
@@ -82,7 +82,7 @@ where
         mut oracle_config: GasPriceOracleConfig,
         cache: EthStateCache,
     ) -> Self {
-        // sanitize the perentile to be less than 100
+        // sanitize the percentile to be less than 100
         if oracle_config.percentile > 100 {
             warn!(prev_percentile=?oracle_config.percentile, "Invalid configured gas price percentile, using 100 instead");
             oracle_config.percentile = 100;
@@ -93,13 +93,10 @@ where
 
     /// Suggests a gas price estimate based on recent blocks, using the configured percentile.
     pub async fn suggest_tip_cap(&self) -> EthResult<U256> {
-        let block = self
+        let header = self
             .client
-            .block_by_id(BlockId::Number(BlockNumberOrTag::Latest))?
+            .sealed_header_by_number_or_tag(BlockNumberOrTag::Latest)?
             .ok_or(EthApiError::UnknownBlockNumber)?;
-
-        // seal for the block hash
-        let header = block.header.seal_slow();
 
         let mut last_price = self.last_price.lock().await;
 

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -8,8 +8,8 @@ use parking_lot::Mutex;
 use reth_interfaces::Result;
 use reth_primitives::{
     keccak256, Account, Address, Block, BlockHash, BlockHashOrNumber, BlockId, BlockNumber,
-    Bytecode, Bytes, ChainInfo, Header, Receipt, SealedBlock, StorageKey, StorageValue,
-    TransactionMeta, TransactionSigned, TxHash, TxNumber, H256, U256,
+    Bytecode, Bytes, ChainInfo, Header, Receipt, SealedBlock, SealedHeader, StorageKey,
+    StorageValue, TransactionMeta, TransactionSigned, TxHash, TxNumber, H256, U256,
 };
 use reth_revm_primitives::primitives::{BlockEnv, CfgEnv};
 use std::{
@@ -303,6 +303,17 @@ impl BlockProviderIdExt for MockEthProvider {
         match id {
             BlockId::Number(num) => self.block_by_number_or_tag(num),
             BlockId::Hash(hash) => self.block_by_hash(hash.block_hash),
+        }
+    }
+
+    fn sealed_header_by_id(&self, id: BlockId) -> Result<Option<SealedHeader>> {
+        self.header_by_id(id)?.map_or_else(|| Ok(None), |h| Ok(Some(h.seal_slow())))
+    }
+
+    fn header_by_id(&self, id: BlockId) -> Result<Option<Header>> {
+        match self.block_by_id(id)? {
+            None => Ok(None),
+            Some(block) => Ok(Some(block.header)),
         }
     }
 

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -7,8 +7,8 @@ use crate::{
 use reth_interfaces::Result;
 use reth_primitives::{
     Account, Address, Block, BlockHash, BlockHashOrNumber, BlockId, BlockNumber, Bytecode, Bytes,
-    ChainInfo, Header, Receipt, SealedBlock, StorageKey, StorageValue, TransactionMeta,
-    TransactionSigned, TxHash, TxNumber, H256, KECCAK_EMPTY, U256,
+    ChainInfo, Header, Receipt, SealedBlock, SealedHeader, StorageKey, StorageValue,
+    TransactionMeta, TransactionSigned, TxHash, TxNumber, H256, KECCAK_EMPTY, U256,
 };
 use reth_revm_primitives::primitives::{BlockEnv, CfgEnv};
 use std::ops::RangeBounds;
@@ -63,6 +63,14 @@ impl BlockProvider for NoopProvider {
 
 impl BlockProviderIdExt for NoopProvider {
     fn block_by_id(&self, _id: BlockId) -> Result<Option<Block>> {
+        Ok(None)
+    }
+
+    fn sealed_header_by_id(&self, _id: BlockId) -> Result<Option<SealedHeader>> {
+        Ok(None)
+    }
+
+    fn header_by_id(&self, _id: BlockId) -> Result<Option<Header>> {
         Ok(None)
     }
 

--- a/crates/storage/provider/src/traits/block.rs
+++ b/crates/storage/provider/src/traits/block.rs
@@ -3,7 +3,7 @@ use crate::{
 };
 use reth_interfaces::Result;
 use reth_primitives::{
-    Block, BlockHashOrNumber, BlockId, BlockNumberOrTag, Header, SealedBlock, H256,
+    Block, BlockHashOrNumber, BlockId, BlockNumberOrTag, Header, SealedBlock, SealedHeader, H256,
 };
 
 /// A helper enum that represents the origin of the requested block.
@@ -106,6 +106,33 @@ pub trait BlockProviderIdExt: BlockProvider + BlockIdProvider {
     ///
     /// Returns `None` if block is not found.
     fn block_by_id(&self, id: BlockId) -> Result<Option<Block>>;
+
+    /// Returns the header with matching tag from the database
+    ///
+    /// Returns `None` if header is not found.
+    fn header_by_number_or_tag(&self, id: BlockNumberOrTag) -> Result<Option<Header>> {
+        self.convert_block_number(id)?
+            .map_or_else(|| Ok(None), |num| self.header_by_hash_or_number(num.into()))
+    }
+
+    /// Returns the header with matching tag from the database
+    ///
+    /// Returns `None` if header is not found.
+    fn sealed_header_by_number_or_tag(&self, id: BlockNumberOrTag) -> Result<Option<SealedHeader>> {
+        self.convert_block_number(id)?
+            .map_or_else(|| Ok(None), |num| self.header_by_hash_or_number(num.into()))?
+            .map_or_else(|| Ok(None), |h| Ok(Some(h.seal_slow())))
+    }
+
+    /// Returns the sealed header with the matching `BlockId` from the database.
+    ///
+    /// Returns `None` if header is not found.
+    fn sealed_header_by_id(&self, id: BlockId) -> Result<Option<SealedHeader>>;
+
+    /// Returns the header with the matching `BlockId` from the database.
+    ///
+    /// Returns `None` if header is not found.
+    fn header_by_id(&self, id: BlockId) -> Result<Option<Header>>;
 
     /// Returns the ommers with the matching tag from the database.
     fn ommers_by_number_or_tag(&self, id: BlockNumberOrTag) -> Result<Option<Vec<Header>>> {


### PR DESCRIPTION
we always have the latest hash, which makes it redundant to compute the hash on every gas price call.

this adds `header_by_id` and `sealed_header_by_id` functions