### PR TITLE
fix: don't starve high priority requests

### DIFF
--- a/crates/interfaces/src/p2p/priority.rs
+++ b/crates/interfaces/src/p2p/priority.rs
@@ -8,3 +8,15 @@ pub enum Priority {
     /// Queued from the front for download requests.
     High,
 }
+
+impl Priority {
+    /// Returns `true` if this is [Priority::High]
+    pub fn is_high(&self) -> bool {
+        matches!(self, Priority::High)
+    }
+
+    /// Returns `true` if this is [Priority::Normal]
+    pub fn is_normal(&self) -> bool {
+        matches!(self, Priority::Normal)
+    }
+}


### PR DESCRIPTION
we were pushing new high priority requests to the front of the queue, which could starve already requested high-priority requests in there

Fix: insert new high-priority request to the back of the high priority-queue