### PR TITLE
fix: dont upscale concurrent request for lower peer count

### DIFF
--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -26,15 +26,6 @@ use std::{
     task::{Context, Poll},
 };
 
-/// The multiplier for the number of connected peers.
-/// This might be used as an upper bound for determining the
-/// number of concurrent requests.
-///
-/// The multiplier is needed to optimistically increase the number
-/// of concurrent requests, since we are expecting to connect to more peers
-/// in the near future.
-const CONCURRENCY_PEER_MULTIPLIER: usize = 4;
-
 /// The scope for headers downloader metrics.
 pub const BODIES_DOWNLOADER_SCOPE: &str = "downloaders.bodies";
 
@@ -169,17 +160,14 @@ where
     fn concurrent_request_limit(&self) -> usize {
         let num_peers = self.client.num_connected_peers();
 
-        // we try to keep more requests than available peers active so that there's always a
-        // followup request available for a peer
-        let dynamic_target = num_peers * CONCURRENCY_PEER_MULTIPLIER;
-        let max_dynamic = dynamic_target.max(*self.concurrent_requests_range.start());
+        let max_requests = num_peers.max(*self.concurrent_requests_range.start());
 
-        // If only a few peers are connected we keep it low
+        // if we're only connected to a few peers, we keep it low
         if num_peers < *self.concurrent_requests_range.start() {
-            return max_dynamic
+            return max_requests
         }
 
-        max_dynamic.min(*self.concurrent_requests_range.end())
+        max_requests.min(*self.concurrent_requests_range.end())
     }
 
     // Check if the stream is terminated


### PR DESCRIPTION
Compared to headers, body requests are more expensive in a few aspects:
* more expensive to validate
* larger payload: `bodies/request` << `headers/request`


The previous implementation essentially always maxed out at `100` active body requests at a time (upper limit of the configured range) which theoretically can buffer up to `200 * 100 = 20_000` full bodies. where 200 is the current number of full blocks a `BodiesRequestFuture` tries to fetch (possibly via 2 or more requests), see #2658

This means that a lot of active requests are competing for the same resources at a time. For headers this works great because we only need one response to get the entire range of headers therefore we want `scheduled requests > available peers`, but for bodies we often require a followup request which now has to compete with all the other requests.

Therefor we should really use the exact number of connected peers and not upscale to the max configured range.
I'd also suggest lowering the current max concurrent request default from 100 to 50-80 in combination with #2658
