### PR TITLE
feat: support subscriptions over IPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4969,6 +4969,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tokio-util 0.7.7",
  "tower",
  "tracing",

--- a/crates/rpc/ipc/Cargo.toml
+++ b/crates/rpc/ipc/Cargo.toml
@@ -16,6 +16,7 @@ futures = "0.3"
 parity-tokio-ipc = "0.9.0"
 tokio = { version = "1", features = ["net", "time", "rt-multi-thread"] }
 tokio-util = { version = "0.7", features = ["codec"] }
+tokio-stream = "0.1"
 async-trait = "0.1"
 pin-project = "1.0"
 tower = "0.4"
@@ -29,6 +30,7 @@ thiserror = "1.0.37"
 
 [dev-dependencies]
 tracing-test = "0.2"
+tokio-stream = { version = "0.1", features = ["sync"] }
 
 [features]
 client = ["jsonrpsee/client", "jsonrpsee/async-client"]


### PR DESCRIPTION
we were lacking support for subscriptions over IPC.

this modifies the service handler so it supports subscriptions as well, this is modelled after the jsonrpsee websocket handler.