### PR TITLE
perf: read ChainInfo from in-memory canonical block

### DIFF
--- a/crates/storage/provider/src/providers/chain_info.rs
+++ b/crates/storage/provider/src/providers/chain_info.rs
@@ -1,5 +1,5 @@
 use parking_lot::RwLock;
-use reth_primitives::{BlockNumHash, SealedHeader};
+use reth_primitives::{BlockNumHash, ChainInfo, SealedHeader};
 use std::{sync::Arc, time::Instant};
 
 /// Tracks the chain info: canonical head, safe block, finalized block.
@@ -19,6 +19,12 @@ impl ChainInfoTracker {
                 finalized_block: RwLock::new(None),
             }),
         }
+    }
+
+    /// Returns the [ChainInfo] for the canonical head.
+    pub(crate) fn chain_info(&self) -> ChainInfo {
+        let inner = self.inner.canonical_head.read();
+        ChainInfo { best_hash: inner.hash(), best_number: inner.number }
     }
 
     /// Update the timestamp when we received a forkchoice update.

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -120,7 +120,7 @@ where
     Tree: BlockchainTreeViewer + Send + Sync,
 {
     fn chain_info(&self) -> Result<ChainInfo> {
-        self.database.chain_info()
+        Ok(self.chain_info.chain_info())
     }
 
     fn best_block_number(&self) -> Result<BlockNumber> {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 18907ab</samp>

Added a method to get the canonical head block information from the `ChainInfoProvider` and updated the `DatabaseProvider` trait to use it. This improves the performance and consistency of the chain info queries.