### PR TITLE
fix(poststate): collapse account changes

### DIFF
--- a/crates/storage/provider/src/post_state/mod.rs
+++ b/crates/storage/provider/src/post_state/mod.rs
@@ -417,7 +417,7 @@ impl PostState {
         account: Account,
     ) {
         self.accounts.insert(address, Some(account));
-        self.account_changes.insert(block_number, address, None);
+        self.account_changes.insert(block_number, address, None, Some(account));
     }
 
     /// Add a changed account to the post-state.
@@ -432,7 +432,7 @@ impl PostState {
         new: Account,
     ) {
         self.accounts.insert(address, Some(new));
-        self.account_changes.insert(block_number, address, Some(old));
+        self.account_changes.insert(block_number, address, Some(old), Some(new));
     }
 
     /// Mark an account as destroyed.
@@ -443,7 +443,7 @@ impl PostState {
         account: Account,
     ) {
         self.accounts.insert(address, None);
-        self.account_changes.insert(block_number, address, Some(account));
+        self.account_changes.insert(block_number, address, Some(account), None);
 
         let storage = self.storage.entry(address).or_default();
         storage.times_wiped += 1;
@@ -668,7 +668,7 @@ mod tests {
         a.create_account(1, Address::zero(), Account::default());
         a.destroy_account(1, Address::zero(), Account::default());
 
-        assert_eq!(a.account_changes.iter().fold(0, |len, (_, changes)| len + changes.len()), 1);
+        assert_eq!(a.account_changes.iter().fold(0, |len, (_, changes)| len + changes.len()), 0);
 
         let mut b = PostState::new();
         b.create_account(2, Address::repeat_byte(0xff), Account::default());
@@ -678,7 +678,7 @@ mod tests {
         let mut c = a.clone();
         c.extend(b.clone());
 
-        assert_eq!(c.account_changes.iter().fold(0, |len, (_, changes)| len + changes.len()), 2);
+        assert_eq!(c.account_changes.iter().fold(0, |len, (_, changes)| len + changes.len()), 1);
 
         let mut d = PostState::new();
         d.create_account(3, Address::zero(), Account::default());
@@ -1794,6 +1794,32 @@ mod tests {
             )]),
             "The latest state of the storage is incorrect in the merged state"
         );
+    }
+
+    #[test]
+    fn collapsible_account_changes() {
+        let address = Address::random();
+        let mut post_state = PostState::default();
+
+        // Create account on block #1
+        let account_at_block_1 = Account { nonce: 1, ..Default::default() };
+        post_state.create_account(1, address, account_at_block_1);
+
+        // Modify account on block #2 and return it to original state.
+        post_state.change_account(
+            2,
+            address,
+            Account { nonce: 1, ..Default::default() },
+            Account { nonce: 1, balance: U256::from(1), ..Default::default() },
+        );
+        post_state.change_account(
+            2,
+            address,
+            Account { nonce: 1, balance: U256::from(1), ..Default::default() },
+            Account { nonce: 1, ..Default::default() },
+        );
+
+        assert_eq!(post_state.account_changes().get(&2).and_then(|ch| ch.get(&address)), None);
     }
 
     #[test]


### PR DESCRIPTION
## Description

Since the `PostState` attempts to aggregate the account changes onto the block level, there is a possibility that it would contain redundant account changesets.

Consider the following scenario for `account1`:
```
Block #1
Tx 1 account1: None -> Some(..) (account created)
Tx 2 account1: Some(..) -> None (account destroyed)
```

Previously, the `PostState` would keep the changeset for `account1` and the state before block 1 would be inserted into the database.

This behavior is tolerable on its own, if not for the two `unreachable` statements in `Transaction::get_take_block_execution_result_range`. This function is called during unwind triggered by the `BlockchainTree`. If such a changeset is encountered, the application would crash.
https://github.com/paradigmxyz/reth/blob/787e60083676ee29b9ce4e578279b52b239aae15/crates/storage/provider/src/transaction.rs#L866-L878

## Solution

Remove the account changeset, if the account's state before the block is the same as the current one.

## Additional Context

The same is true for storage, however, redundant storage changesets cannot currently result in the application crash. This is a performance issue and can be addressed separately.

## Why is this a breaking change?

Since this PR alters what we insert in the database, the unwind behavior might not be backwards compatible.