### PR TITLE
chore: cleanup engine api errors

### DIFF
--- a/crates/consensus/beacon/src/engine/error.rs
+++ b/crates/consensus/beacon/src/engine/error.rs
@@ -1,61 +1,61 @@
-use reth_payload_builder::error::PayloadBuilderError;
-use reth_rpc_types::engine::{EngineRpcError, ForkchoiceUpdateError, PayloadError};
+use reth_rpc_types::engine::ForkchoiceUpdateError;
 use reth_stages::PipelineError;
-use thiserror::Error;
 
 /// Beacon engine result.
-pub type BeaconEngineResult<Ok> = Result<Ok, BeaconEngineError>;
+pub type BeaconEngineResult<Ok> = Result<Ok, BeaconConsensusEngineError>;
 
-/// The error wrapper for the beacon consensus engine.
-#[derive(Error, Debug)]
-pub enum BeaconEngineError {
-    /// Forkchoice zero hash head received.
-    #[error("Received zero hash as forkchoice head")]
-    ForkchoiceEmptyHead,
+/// The error type for the beacon consensus engine service
+/// [BeaconConsensusEngine](crate::BeaconConsensusEngine)
+///
+/// Represents all possible error cases for the beacon consensus engine.
+#[derive(Debug, thiserror::Error)]
+pub enum BeaconConsensusEngineError {
     /// Pipeline channel closed.
     #[error("Pipeline channel closed")]
     PipelineChannelClosed,
-    /// An error covered by the engine API standard error codes.
-    #[error(transparent)]
-    EngineApi(#[from] EngineRpcError),
-    /// Encountered a payload error.
-    #[error(transparent)]
-    Payload(#[from] PayloadError),
-    /// Encountered an error during the payload building process.
-    #[error(transparent)]
-    PayloadBuilderError(#[from] PayloadBuilderError),
     /// Pipeline error.
     #[error(transparent)]
     Pipeline(#[from] Box<PipelineError>),
     /// Common error. Wrapper around [reth_interfaces::Error].
     #[error(transparent)]
     Common(#[from] reth_interfaces::Error),
-    /// Thrown when the engine task stopped
-    #[error("beacon consensus engine task stopped")]
-    EngineUnavailable,
 }
 
 // box the pipeline error as it is a large enum.
-impl From<PipelineError> for BeaconEngineError {
+impl From<PipelineError> for BeaconConsensusEngineError {
     fn from(e: PipelineError) -> Self {
         Self::Pipeline(Box::new(e))
     }
 }
 
 // for convenience in the beacon engine
-impl From<reth_interfaces::db::Error> for BeaconEngineError {
+impl From<reth_interfaces::db::Error> for BeaconConsensusEngineError {
     fn from(e: reth_interfaces::db::Error) -> Self {
         Self::Common(e.into())
     }
 }
 
 /// Represents error cases for an applied forkchoice update.
-#[derive(Error, Debug, Eq, PartialEq)]
+///
+/// This represents all possible error cases, that must be returned as JSON RCP errors back to the
+/// beacon node.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, thiserror::Error)]
 pub enum BeaconForkChoiceUpdateError {
     /// Thrown when a forkchoice update resulted in an error.
     #[error("Forkchoice update error: {0}")]
     ForkchoiceUpdateError(#[from] ForkchoiceUpdateError),
-    /// Thrown when the engine task stopped
+    /// Thrown when the engine task is unavailable/stopped.
+    #[error("beacon consensus engine task stopped")]
+    EngineUnavailable,
+}
+
+/// Represents all error cases when handling a new payload.
+///
+/// This represents all possible error cases that must be returned as JSON RCP errors back to the
+/// beacon node.
+#[derive(Debug, Clone, Eq, PartialEq, thiserror::Error)]
+pub enum BeaconOnNewPayloadError {
+    /// Thrown when the engine task is unavailable/stopped.
     #[error("beacon consensus engine task stopped")]
     EngineUnavailable,
 }

--- a/crates/consensus/beacon/src/engine/message.rs
+++ b/crates/consensus/beacon/src/engine/message.rs
@@ -1,4 +1,4 @@
-use crate::{BeaconConsensusEngineEvent, BeaconEngineResult};
+use crate::{engine::error::BeaconOnNewPayloadError, BeaconConsensusEngineEvent};
 use futures::{future::Either, FutureExt};
 use reth_interfaces::consensus::ForkchoiceState;
 use reth_payload_builder::error::PayloadBuilderError;
@@ -120,7 +120,7 @@ pub enum BeaconEngineMessage {
         /// The execution payload received by Engine API.
         payload: ExecutionPayload,
         /// The sender for returning payload status result.
-        tx: oneshot::Sender<BeaconEngineResult<PayloadStatus>>,
+        tx: oneshot::Sender<Result<PayloadStatus, BeaconOnNewPayloadError>>,
     },
     /// Message with updated forkchoice state.
     ForkchoiceUpdated {

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -1,6 +1,6 @@
 use crate::{EngineApiError, EngineApiMessageVersion, EngineApiResult};
 use async_trait::async_trait;
-use jsonrpsee_core::RpcResult as Result;
+use jsonrpsee_core::RpcResult;
 use reth_beacon_consensus::BeaconConsensusEngineHandle;
 use reth_interfaces::consensus::ForkchoiceState;
 use reth_payload_builder::PayloadStore;
@@ -296,14 +296,14 @@ where
     /// Handler for `engine_newPayloadV1`
     /// See also <https://github.com/ethereum/execution-apis/blob/8db51dcd2f4bdfbd9ad6e4a7560aac97010ad063/src/engine/specification.md#engine_newpayloadv1>
     /// Caution: This should not accept the `withdrawals` field
-    async fn new_payload_v1(&self, payload: ExecutionPayload) -> Result<PayloadStatus> {
+    async fn new_payload_v1(&self, payload: ExecutionPayload) -> RpcResult<PayloadStatus> {
         trace!(target: "rpc::eth", "Serving engine_newPayloadV1");
         Ok(EngineApi::new_payload_v1(self, payload).await?)
     }
 
     /// Handler for `engine_newPayloadV1`
     /// See also <https://github.com/ethereum/execution-apis/blob/8db51dcd2f4bdfbd9ad6e4a7560aac97010ad063/src/engine/specification.md#engine_newpayloadv1>
-    async fn new_payload_v2(&self, payload: ExecutionPayload) -> Result<PayloadStatus> {
+    async fn new_payload_v2(&self, payload: ExecutionPayload) -> RpcResult<PayloadStatus> {
         trace!(target: "rpc::eth", "Serving engine_newPayloadV1");
         Ok(EngineApi::new_payload_v2(self, payload).await?)
     }
@@ -316,7 +316,7 @@ where
         &self,
         fork_choice_state: ForkchoiceState,
         payload_attributes: Option<PayloadAttributes>,
-    ) -> Result<ForkchoiceUpdated> {
+    ) -> RpcResult<ForkchoiceUpdated> {
         trace!(target: "rpc::eth", "Serving engine_forkchoiceUpdatedV1");
         Ok(EngineApi::fork_choice_updated_v1(self, fork_choice_state, payload_attributes).await?)
     }
@@ -327,7 +327,7 @@ where
         &self,
         fork_choice_state: ForkchoiceState,
         payload_attributes: Option<PayloadAttributes>,
-    ) -> Result<ForkchoiceUpdated> {
+    ) -> RpcResult<ForkchoiceUpdated> {
         trace!(target: "rpc::eth", "Serving engine_forkchoiceUpdatedV2");
         Ok(EngineApi::fork_choice_updated_v2(self, fork_choice_state, payload_attributes).await?)
     }
@@ -343,7 +343,7 @@ where
     ///
     /// Note:
     /// > Client software MAY stop the corresponding build process after serving this call.
-    async fn get_payload_v1(&self, payload_id: PayloadId) -> Result<ExecutionPayload> {
+    async fn get_payload_v1(&self, payload_id: PayloadId) -> RpcResult<ExecutionPayload> {
         trace!(target: "rpc::eth", "Serving engine_getPayloadV1");
         Ok(EngineApi::get_payload_v1(self, payload_id).await?)
     }
@@ -357,7 +357,7 @@ where
     ///
     /// Note:
     /// > Client software MAY stop the corresponding build process after serving this call.
-    async fn get_payload_v2(&self, payload_id: PayloadId) -> Result<ExecutionPayloadEnvelope> {
+    async fn get_payload_v2(&self, payload_id: PayloadId) -> RpcResult<ExecutionPayloadEnvelope> {
         trace!(target: "rpc::eth", "Serving engine_getPayloadV2");
         Ok(EngineApi::get_payload_v2(self, payload_id).await?)
     }
@@ -367,7 +367,7 @@ where
     async fn get_payload_bodies_by_hash_v1(
         &self,
         block_hashes: Vec<BlockHash>,
-    ) -> Result<ExecutionPayloadBodies> {
+    ) -> RpcResult<ExecutionPayloadBodies> {
         trace!(target: "rpc::eth", "Serving engine_getPayloadBodiesByHashV1");
         Ok(EngineApi::get_payload_bodies_by_hash(self, block_hashes)?)
     }
@@ -378,7 +378,7 @@ where
         &self,
         start: U64,
         count: U64,
-    ) -> Result<ExecutionPayloadBodies> {
+    ) -> RpcResult<ExecutionPayloadBodies> {
         trace!(target: "rpc::eth", "Serving engine_getPayloadBodiesByHashV1");
         Ok(EngineApi::get_payload_bodies_by_range(self, start.as_u64(), count.as_u64())?)
     }
@@ -388,14 +388,14 @@ where
     async fn exchange_transition_configuration(
         &self,
         config: TransitionConfiguration,
-    ) -> Result<TransitionConfiguration> {
+    ) -> RpcResult<TransitionConfiguration> {
         trace!(target: "rpc::eth", "Serving engine_getPayloadBodiesByHashV1");
         Ok(EngineApi::exchange_transition_configuration(self, config)?)
     }
 
     /// Handler for `engine_exchangeCapabilitiesV1`
     /// See also <https://github.com/ethereum/execution-apis/blob/6452a6b194d7db269bf1dbd087a267251d3cc7f8/src/engine/common.md#capabilities>
-    async fn exchange_capabilities(&self, _capabilities: Vec<String>) -> Result<Vec<String>> {
+    async fn exchange_capabilities(&self, _capabilities: Vec<String>) -> RpcResult<Vec<String>> {
         Ok(CAPABILITIES.into_iter().map(str::to_owned).collect())
     }
 }

--- a/crates/rpc/rpc-types/src/eth/engine/forkchoice.rs
+++ b/crates/rpc/rpc-types/src/eth/engine/forkchoice.rs
@@ -30,8 +30,11 @@ pub struct ForkchoiceState {
     pub finalized_block_hash: H256,
 }
 
-/// A standalone forkchoice update result for RPC.
-#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+/// A standalone forkchoice update errors for RPC.
+///
+/// These are considered hard RPC errors and are _not_ returned as [PayloadStatus] or
+/// [PayloadStatusEnum::Invalid].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
 pub enum ForkchoiceUpdateError {
     /// The forkchoice update has been processed, but the requested contained invalid
     /// [PayloadAttributes](crate::engine::PayloadAttributes).
@@ -42,6 +45,9 @@ pub enum ForkchoiceUpdateError {
     /// The given [ForkchoiceState] is invalid or inconsistent.
     #[error("Invalid forkchoice state")]
     InvalidState,
+    /// Thrown when a forkchoice final block does not exist in the database.
+    #[error("final block not available in database")]
+    UnknownFinalBlock,
 }
 
 impl From<ForkchoiceUpdateError> for jsonrpsee_types::error::ErrorObject<'static> {
@@ -55,6 +61,11 @@ impl From<ForkchoiceUpdateError> for jsonrpsee_types::error::ErrorObject<'static
                 )
             }
             ForkchoiceUpdateError::InvalidState => jsonrpsee_types::error::ErrorObject::owned(
+                INVALID_FORK_CHOICE_STATE_ERROR,
+                INVALID_FORK_CHOICE_STATE_ERROR_MSG,
+                None::<()>,
+            ),
+            ForkchoiceUpdateError::UnknownFinalBlock => jsonrpsee_types::error::ErrorObject::owned(
                 INVALID_FORK_CHOICE_STATE_ERROR,
                 INVALID_FORK_CHOICE_STATE_ERROR_MSG,
                 None::<()>,

--- a/crates/rpc/rpc-types/src/eth/engine/payload.rs
+++ b/crates/rpc/rpc-types/src/eth/engine/payload.rs
@@ -187,6 +187,7 @@ impl TryFrom<ExecutionPayload> for SealedBlock {
     }
 }
 
+/// Error that can occur when handling payloads.
 #[derive(thiserror::Error, Debug)]
 pub enum PayloadError {
     /// Invalid payload extra data.
@@ -252,7 +253,7 @@ pub struct PayloadAttributes {
     pub withdrawals: Option<Vec<Withdrawal>>,
 }
 
-/// This structure contains the result of processing a payload
+/// This structure contains the result of processing a payload or fork choice update.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PayloadStatus {
@@ -393,7 +394,9 @@ impl PayloadStatusEnum {
     }
 }
 
-/// Various validation errors
+/// Various errors that can occur when validating a payload or forkchoice update.
+///
+/// This is intended for the [PayloadStatusEnum::Invalid] variant.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum PayloadValidationError {
     /// Thrown when a forkchoice update's head links to a previously rejected payload.


### PR DESCRIPTION
Closes #2249

this cleans up the engine Api / beacon errors

use dedicated error variants for FCU and new payload

remove unused/unreachable variants

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8786abf</samp>

This pull request refactors and improves the error handling and documentation for the beacon consensus engine and its integration with the RPC engine API. It introduces new error types, renames and simplifies existing ones, and updates the method signatures and comments to use them consistently. It also fixes some minor issues with imports and unused code. The affected files are mainly in the `crates/consensus/beacon` and `crates/rpc` directories.