### PR TITLE
fix: dont exit engine on failed FCU

### DIFF
--- a/crates/consensus/beacon/src/engine/error.rs
+++ b/crates/consensus/beacon/src/engine/error.rs
@@ -39,14 +39,28 @@ impl From<reth_interfaces::db::Error> for BeaconConsensusEngineError {
 ///
 /// This represents all possible error cases, that must be returned as JSON RCP errors back to the
 /// beacon node.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum BeaconForkChoiceUpdateError {
     /// Thrown when a forkchoice update resulted in an error.
     #[error("Forkchoice update error: {0}")]
     ForkchoiceUpdateError(#[from] ForkchoiceUpdateError),
+    /// Internal errors, for example, error while reading from the database.
+    #[error(transparent)]
+    Internal(Box<reth_interfaces::Error>),
     /// Thrown when the engine task is unavailable/stopped.
     #[error("beacon consensus engine task stopped")]
     EngineUnavailable,
+}
+
+impl From<reth_interfaces::Error> for BeaconForkChoiceUpdateError {
+    fn from(e: reth_interfaces::Error) -> Self {
+        Self::Internal(Box::new(e))
+    }
+}
+impl From<reth_interfaces::db::Error> for BeaconForkChoiceUpdateError {
+    fn from(e: reth_interfaces::db::Error) -> Self {
+        Self::Internal(Box::new(e.into()))
+    }
 }
 
 /// Represents all error cases when handling a new payload.

--- a/crates/consensus/beacon/src/engine/message.rs
+++ b/crates/consensus/beacon/src/engine/message.rs
@@ -19,6 +19,7 @@ use tokio::sync::{mpsc::UnboundedSender, oneshot};
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 #[derive(Debug)]
 pub struct OnForkChoiceUpdated {
+    /// Tracks if this update was valid.
     is_valid_update: bool,
     /// Returns the result of the forkchoice update.
     fut: Either<futures::future::Ready<ForkChoiceUpdateResult>, PendingPayloadId>,
@@ -129,7 +130,7 @@ pub enum BeaconEngineMessage {
         /// The payload attributes for block building.
         payload_attrs: Option<PayloadAttributes>,
         /// The sender for returning forkchoice updated result.
-        tx: oneshot::Sender<OnForkChoiceUpdated>,
+        tx: oneshot::Sender<Result<OnForkChoiceUpdated, reth_interfaces::Error>>,
     },
     /// Add a new listener for [`BeaconEngineMessage`].
     EventListener(UnboundedSender<BeaconConsensusEngineEvent>),

--- a/crates/rpc/rpc-engine-api/src/error.rs
+++ b/crates/rpc/rpc-engine-api/src/error.rs
@@ -88,9 +88,10 @@ impl From<EngineApiError> for jsonrpsee_types::error::ErrorObject<'static> {
             EngineApiError::PayloadRequestTooLarge { .. } => REQUEST_TOO_LARGE_CODE,
 
             // Error responses from the consensus engine
-            EngineApiError::ForkChoiceUpdate(err) => match err {
-                BeaconForkChoiceUpdateError::ForkchoiceUpdateError(err) => return err.into(),
+            EngineApiError::ForkChoiceUpdate(ref err) => match err {
+                BeaconForkChoiceUpdateError::ForkchoiceUpdateError(err) => return (*err).into(),
                 BeaconForkChoiceUpdateError::EngineUnavailable => INTERNAL_ERROR_CODE,
+                BeaconForkChoiceUpdateError::Internal(_) => INTERNAL_ERROR_CODE,
             },
             EngineApiError::NewPayload(ref err) => match err {
                 BeaconOnNewPayloadError::EngineUnavailable => INTERNAL_ERROR_CODE,


### PR DESCRIPTION
This is related to https://github.com/paradigmxyz/reth/issues/2673

we're currently exiting the engine if we receive a bad FCU (missing finalized block).

This makes FCU infallible, it does not exit the engine but returns an error instead.

This is an intermediary step required for #2673

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 475f886</samp>

This pull request updates the consensus engine and the RPC engine API to use the new forkchoice update API from the `reth_interfaces` crate. The new API returns a `Result` type that indicates the validity of the forkchoice update and any internal errors. The changes also refactor and simplify the error handling and message processing logic in the consensus engine and the RPC engine API.