### PR TITLE
fix: use proper base fee in auto seal

### DIFF
--- a/crates/consensus/auto-seal/src/task.rs
+++ b/crates/consensus/auto-seal/src/task.rs
@@ -124,13 +124,10 @@ where
                     let mut storage = storage.write().await;
 
                     // check previous block for base fee
-                    let base_fee_per_gas = match storage.headers.get(&storage.best_block) {
-                        Some(parent) => parent.next_block_base_fee(),
-                        None => {
-                            warn!(target: "consensus::auto", "No parent block found for auto sealed block");
-                            return None
-                        }
-                    };
+                    let base_fee_per_gas = storage
+                        .headers
+                        .get(&storage.best_block)
+                        .and_then(|parent| parent.next_block_base_fee());
 
                     let mut header = Header {
                         parent_hash: storage.best_hash,

--- a/crates/consensus/auto-seal/src/task.rs
+++ b/crates/consensus/auto-seal/src/task.rs
@@ -122,6 +122,16 @@ where
                 // the pipeline
                 this.insert_task = Some(Box::pin(async move {
                     let mut storage = storage.write().await;
+
+                    // check previous block for base fee
+                    let base_fee_per_gas = match storage.headers.get(&storage.best_block) {
+                        Some(parent) => parent.next_block_base_fee(),
+                        None => {
+                            warn!(target: "consensus::auto", "No parent block found for auto sealed block");
+                            return None
+                        }
+                    };
+
                     let mut header = Header {
                         parent_hash: storage.best_hash,
                         ommers_hash: EMPTY_OMMER_ROOT,
@@ -141,7 +151,7 @@ where
                             .as_secs(),
                         mix_hash: Default::default(),
                         nonce: 0,
-                        base_fee_per_gas: None,
+                        base_fee_per_gas,
                         extra_data: Default::default(),
                     };
 
@@ -231,15 +241,17 @@ where
 
                             // seal the block
                             let block = Block {
-                                header,
+                                header: header.clone(),
                                 body: transactions,
                                 ommers: vec![],
                                 withdrawals: None,
                             };
                             let sealed_block = block.seal_slow();
+
                             let sealed_block_with_senders =
                                 SealedBlockWithSenders::new(sealed_block, senders)
                                     .expect("senders are valid");
+
                             debug!(target: "consensus::auto", header=?sealed_block_with_senders.hash(), "sending block notification");
 
                             let chain =

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -148,8 +148,7 @@ impl ChainSpec {
     /// Get the header for the genesis block.
     pub fn genesis_header(&self) -> Header {
         // If London is activated at genesis, we set the initial base fee as per EIP-1559.
-        let base_fee_per_gas =
-            (self.fork(Hardfork::London).active_at_block(0)).then_some(EIP1559_INITIAL_BASE_FEE);
+        let base_fee_per_gas = self.initial_base_fee();
 
         // If shanghai is activated, initialize the header with an empty withdrawals hash, and
         // empty withdrawals list.
@@ -170,6 +169,12 @@ impl ChainSpec {
             withdrawals_root,
             ..Default::default()
         }
+    }
+
+    /// Get the initial base fee of the genesis block.
+    pub fn initial_base_fee(&self) -> Option<u64> {
+        // If London is activated at genesis, we set the initial base fee as per EIP-1559.
+        (self.fork(Hardfork::London).active_at_block(0)).then_some(EIP1559_INITIAL_BASE_FEE)
     }
 
     /// Get the hash of the genesis block.


### PR DESCRIPTION
ref #2689 

Previously the base fee field was not populated in auto sealed blocks. This populates the field depending on the parent block.