### PR TITLE
chore(deps): enable tracing default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,4 @@ incremental = false
 ruint = { git = "https://github.com/paradigmxyz/uint" }
 
 [workspace.dependencies]
-tracing = { version = "^0.1.0", default-features = false }
+tracing = "^0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,10 @@ members = [
 exclude = ["crate-template"]
 default-members = ["bin/reth"]
 
+# Explicitly set the resolver to version 2, which is the default for packages with edition >= 2021
+# https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html
+resolver = "2"
+
 # Like release, but with full debug symbols. Useful for e.g. `perf`.
 [profile.debug-fast]
 inherits = "release"
@@ -60,6 +64,7 @@ incremental = false
 [patch.crates-io]
 # patched for quantity U256 responses <https://github.com/recmo/uint/issues/224>
 ruint = { git = "https://github.com/paradigmxyz/uint" }
+
 
 [workspace.dependencies]
 tracing = "^0.1.0"

--- a/crates/tasks/Cargo.toml
+++ b/crates/tasks/Cargo.toml
@@ -15,7 +15,7 @@ tracing-futures = "0.2"
 futures-util = "0.3"
 
 ## misc
-tracing = { workspace = true, default-features = false }
+tracing = { workspace = true }
 thiserror = "1.0"
 dyn-clone = "1.0"
 

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 description = "tracing helpers"
 
 [dependencies]
-tracing = { workspace = true, default-features = false }
+tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
 tracing-appender = "0.2"
 tracing-journald = "0.3"


### PR DESCRIPTION
Fix broken build for some crates introduced in https://github.com/paradigmxyz/reth/pull/2652

enable default features which are just std and instrument, commonly used and always present in final tree