### PR TITLE
perf: spawn eth filter tasks

### DIFF
--- a/crates/rpc/rpc-builder/src/auth.rs
+++ b/crates/rpc/rpc-builder/src/auth.rs
@@ -61,7 +61,13 @@ where
         gas_oracle,
         Box::new(executor.clone()),
     );
-    let eth_filter = EthFilter::new(client, pool, eth_cache.clone(), DEFAULT_MAX_LOGS_IN_RESPONSE);
+    let eth_filter = EthFilter::new(
+        client,
+        pool,
+        eth_cache.clone(),
+        DEFAULT_MAX_LOGS_IN_RESPONSE,
+        Box::new(executor.clone()),
+    );
     launch_with_eth_api(eth_api, eth_filter, engine_api, socket_addr, secret).await
 }
 

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -845,19 +845,21 @@ where
                 }),
             );
 
+            let executor = Box::new(self.executor.clone());
             let api = EthApi::with_spawner(
                 self.client.clone(),
                 self.pool.clone(),
                 self.network.clone(),
                 cache.clone(),
                 gas_oracle,
-                Box::new(self.executor.clone()),
+                executor.clone(),
             );
             let filter = EthFilter::new(
                 self.client.clone(),
                 self.pool.clone(),
                 cache.clone(),
                 self.config.eth.max_logs_per_response,
+                executor.clone(),
             );
 
             let pubsub = EthPubSub::with_spawner(
@@ -865,7 +867,7 @@ where
                 self.pool.clone(),
                 self.events.clone(),
                 self.network.clone(),
-                Box::new(self.executor.clone()),
+                executor,
             );
 
             let eth = EthHandlers { api, cache, filter, pubsub };


### PR DESCRIPTION
jsonrpsee is essentially a `Vec<RequestFut>` where the `RequestFuture` is the invoked callback handler.

all of them are called on the same task, which means that long running tasks can end up starving other tasks.

while all filter handlers are very much async, applying the filters (over a long range) still takes some time, so they should all be executed on a separate task.