### PR TITLE
fix(dep): `tokio-util` is no longer optional

### DIFF
--- a/crates/net/downloaders/Cargo.toml
+++ b/crates/net/downloaders/Cargo.toml
@@ -21,6 +21,7 @@ futures-util = "0.3.25"
 pin-project = "1.0"
 tokio = { version = "1.0", features = ["sync"] }
 tokio-stream = "0.1"
+tokio-util = { version = "0.7", features = ["codec"] }
 
 # misc
 tracing = { workspace = true }
@@ -30,7 +31,6 @@ rayon = "1.6.0"
 # optional deps for the test-utils feature
 thiserror = { version = "1", optional = true }
 reth-rlp = { path = "../../rlp", optional = true }
-tokio-util = { version = "0.7", features = ["codec"], optional = true }
 tempfile = { version = "3.3", optional = true }
 itertools = { version = "0.10", optional = true }
 
@@ -41,7 +41,6 @@ reth-tracing = { path = "../../tracing" }
 
 assert_matches = "1.5.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-tokio-util = { version = "0.7", features = ["codec"] }
 reth-rlp = { path = "../../rlp" }
 itertools = "0.10"
 
@@ -49,4 +48,4 @@ thiserror = "1"
 tempfile = "3.3"
 
 [features]
-test-utils = ["dep:reth-rlp", "dep:thiserror", "dep:tokio-util", "dep:tempfile", "dep:itertools"]
+test-utils = ["dep:reth-rlp", "dep:thiserror", "dep:tempfile", "dep:itertools"]


### PR DESCRIPTION
`tokio-util` is no longer optional for `reth-downloaders` crate after #2684