### PR TITLE
chore(rpc): add InvalidStateRoot error variant

### DIFF
--- a/crates/rpc/rpc-types/src/eth/engine/payload.rs
+++ b/crates/rpc/rpc-types/src/eth/engine/payload.rs
@@ -405,6 +405,14 @@ pub enum PayloadValidationError {
     /// Thrown when a new payload contains a wrong block number.
     #[error("invalid block number")]
     InvalidBlockNumber,
+    /// Thrown when a new payload contains a wrong state root
+    #[error("invalid merkle root (remote: {remote:?} local: {local:?})")]
+    InvalidStateRoot {
+        /// The state root of the payload we received from remote (CL)
+        remote: H256,
+        /// The state root of the payload that we computed locally.
+        local: H256,
+    },
 }
 
 #[cfg(test)]


### PR DESCRIPTION
add error variant that mirrors geth's error message:

https://github.com/ethereum/go-ethereum/blob/73697529994e14996b7740730481e926d5ec3e40/core/block_validator.go#L113-L115

ref #2543