### PR TITLE
fix: check db and indices for canonical block

### DIFF
--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -167,7 +167,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
         }
 
         // check if block is part of canonical chain
-        if self.block_indices.canonical_hash(&block.number) == Some(block.hash) {
+        if self.is_block_hash_canonical(&block.hash)? {
             return Ok(Some(BlockStatus::Valid))
         }
 
@@ -275,7 +275,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
         }
 
         // if not found, check if the parent can be found inside canonical chain.
-        if Some(parent.hash) == self.block_indices.canonical_hash(&parent.number) {
+        if self.is_block_hash_canonical(&parent.hash)? {
             return self.try_append_canonical_chain(block, parent)
         }
 

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1053,6 +1053,9 @@ mod tests {
         // genesis block 10 is already canonical
         assert_eq!(tree.make_canonical(&H256::zero()), Ok(()));
 
+        // make sure is_block_hash_canonical returns true for genesis block
+        assert!(tree.is_block_hash_canonical(&H256::zero()).unwrap());
+
         // make genesis block 10 as finalized
         tree.finalize_block(10);
 
@@ -1233,6 +1236,13 @@ mod tests {
             if *old.blocks() == BTreeMap::from([(block1.number,block1.clone()),(block2a.number,block2a.clone())])
                 && *new.blocks() == BTreeMap::from([(block1a.number,block1a.clone())]));
 
+        // check that b2 and b1 are not canonical
+        assert!(!tree.is_block_hash_canonical(&block2.hash).unwrap());
+        assert!(!tree.is_block_hash_canonical(&block1.hash).unwrap());
+
+        // ensure that b1a is canonical
+        assert!(tree.is_block_hash_canonical(&block1a.hash).unwrap());
+
         // make b2 canonical
         assert_eq!(tree.make_canonical(&block2.hash()), Ok(()));
 
@@ -1260,6 +1270,9 @@ mod tests {
             Ok(CanonStateNotification::Reorg{ old, new})
             if *old.blocks() == BTreeMap::from([(block1a.number,block1a.clone())])
                 && *new.blocks() == BTreeMap::from([(block1.number,block1.clone()),(block2.number,block2.clone())]));
+
+        // check that b2 is now canonical
+        assert!(tree.is_block_hash_canonical(&block2.hash).unwrap());
 
         // finalize b1 that would make b1a removed from tree
         tree.finalize_block(11);

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -703,9 +703,12 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
 
     /// Determines whether or not a block is canonical, checking the db if necessary.
     pub fn is_block_hash_canonical(&self, hash: &BlockHash) -> Result<bool, Error> {
-        // first check the tree, then check whether or not the block is in the db.
+        // if the indices show that the block hash is not canonical, it's either in a sidechain or
+        // canonical, but in the db. If it is in a sidechain, it is not canonical. If it is not in
+        // the db, then it is not canonical.
         if !self.block_indices.is_block_hash_canonical(hash) &&
-            self.externals.shareable_db().header(hash)?.is_none()
+            (self.block_by_hash(*hash).is_some() ||
+                self.externals.shareable_db().header(hash)?.is_none())
         {
             return Ok(false)
         }

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1597,7 +1597,8 @@ mod tests {
                 .await;
 
             let expected_result = PayloadStatus::from_status(PayloadStatusEnum::Invalid {
-                validation_error: BlockExecutionError::BlockPreMerge { hash: block1.hash }.to_string(),
+                validation_error: BlockExecutionError::BlockPreMerge { hash: block1.hash }
+                    .to_string(),
             })
             .with_latest_valid_hash(H256::zero());
             assert_matches!(res, Ok(ForkchoiceUpdated { payload_status, .. }) => assert_eq!(payload_status, expected_result));

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1597,7 +1597,7 @@ mod tests {
                 .await;
 
             let expected_result = PayloadStatus::from_status(PayloadStatusEnum::Invalid {
-                validation_error: ExecutorError::BlockPreMerge { hash: block1.hash }.to_string(),
+                validation_error: BlockExecutionError::BlockPreMerge { hash: block1.hash }.to_string(),
             })
             .with_latest_valid_hash(H256::zero());
             assert_matches!(res, Ok(ForkchoiceUpdated { payload_status, .. }) => assert_eq!(payload_status, expected_result));

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -397,6 +397,16 @@ impl ChainSpecBuilder {
         self
     }
 
+    /// Enable the Paris hardfork at the given TTD.
+    ///
+    /// Does not set the merge netsplit block.
+    pub fn paris_at_ttd(self, ttd: U256) -> Self {
+        self.with_fork(
+            Hardfork::Paris,
+            ForkCondition::TTD { total_difficulty: ttd, fork_block: None },
+        )
+    }
+
     /// Enable Frontier at genesis.
     pub fn frontier_activated(mut self) -> Self {
         self.hardforks.insert(Hardfork::Frontier, ForkCondition::Block(0));


### PR DESCRIPTION
Fixes #2689

Previously we were only checking the indices when determining whether or not a block is already canonical in `make_canonical`. Calls to `engine_forkchoiceUpdated` for historical blocks would return `SYNCING` because the block would not be found in memory, and the call to `is_block_hash_canonical` would only check the canonical blocks tracked in memory.

This introduces a new method `is_block_hash_canonical` on the blockchain tree, which also checks the db if it cannot find the canonical block in memory.