### PR TITLE
fix: update rpc on continuous sync

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -905,16 +905,15 @@ where
         &self,
         block_number: BlockNumber,
     ) -> Result<SealedHeader, reth_interfaces::Error> {
-        // TODO(rjected): use the HeaderProvider once it checks the tree
         let max_hash = match self.blockchain.block_hash(block_number)? {
             Some(block) => block,
             None => return Err(Error::Provider(ProviderError::HeaderNotFound(block_number.into()))),
         };
-        let max_header = match self.blockchain.block_by_number(block_number)? {
+        let max_header = match self.blockchain.header_by_number(block_number)? {
             Some(block) => block,
             None => return Err(Error::Provider(ProviderError::HeaderNotFound(block_number.into()))),
         };
-        Ok(max_header.header.seal(max_hash))
+        Ok(max_header.seal(max_hash))
     }
 }
 

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -875,7 +875,7 @@ where
                                 Ok(Some(block)) => block,
                                 Ok(None) => {
                                     return Some(Err(Error::Provider(
-                                        ProviderError::CanonicalHeader { block_number: max_block },
+                                        ProviderError::HeaderNotFound(max_block.into()),
                                     )
                                     .into()))
                                 }
@@ -884,9 +884,9 @@ where
                             let max_header = match self.blockchain.block_by_number(max_block) {
                                 Ok(Some(block)) => block,
                                 Ok(None) => {
-                                    return Some(Err(Error::Provider(ProviderError::Header {
-                                        number: max_block,
-                                    })
+                                    return Some(Err(Error::Provider(
+                                        ProviderError::HeaderNotFound(max_block.into()),
+                                    )
                                     .into()))
                                 }
                                 Err(error) => return Some(Err(error.into())),

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -875,7 +875,8 @@ where
                                 Ok(Some(block)) => block,
                                 Ok(None) => {
                                     return Some(Err(BeaconConsensusEngineError::Common(
-                                        ProviderError::CanonicalHeader { block_number: max_block }.into(),
+                                        ProviderError::CanonicalHeader { block_number: max_block }
+                                            .into(),
                                     )))
                                 }
                                 Err(error) => return Some(Err(error.into())),

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -905,15 +905,12 @@ where
         &self,
         block_number: BlockNumber,
     ) -> Result<SealedHeader, reth_interfaces::Error> {
-        let max_hash = match self.blockchain.block_hash(block_number)? {
-            Some(block) => block,
+        let headers = self.blockchain.sealed_headers_range(block_number..=block_number)?;
+        let header = match headers.first() {
+            Some(header) => header,
             None => return Err(Error::Provider(ProviderError::HeaderNotFound(block_number.into()))),
         };
-        let max_header = match self.blockchain.header_by_number(block_number)? {
-            Some(block) => block,
-            None => return Err(Error::Provider(ProviderError::HeaderNotFound(block_number.into()))),
-        };
-        Ok(max_header.seal(max_hash))
+        Ok(header.clone())
     }
 }
 

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -874,19 +874,20 @@ where
                             let max_hash = match self.blockchain.block_hash(max_block) {
                                 Ok(Some(block)) => block,
                                 Ok(None) => {
-                                    return Some(Err(BeaconConsensusEngineError::Common(
-                                        ProviderError::CanonicalHeader { block_number: max_block }
-                                            .into(),
-                                    )))
+                                    return Some(Err(Error::Provider(
+                                        ProviderError::CanonicalHeader { block_number: max_block },
+                                    )
+                                    .into()))
                                 }
                                 Err(error) => return Some(Err(error.into())),
                             };
                             let max_header = match self.blockchain.block_by_number(max_block) {
                                 Ok(Some(block)) => block,
                                 Ok(None) => {
-                                    return Some(Err(BeaconConsensusEngineError::Common(
-                                        ProviderError::Header { number: max_block }.into(),
-                                    )))
+                                    return Some(Err(Error::Provider(ProviderError::Header {
+                                        number: max_block,
+                                    })
+                                    .into()))
                                 }
                                 Err(error) => return Some(Err(error.into())),
                             };

--- a/crates/consensus/beacon/src/engine/sync.rs
+++ b/crates/consensus/beacon/src/engine/sync.rs
@@ -90,6 +90,11 @@ where
         self.inflight_full_block_requests.retain(|req| *req.hash() != hash);
     }
 
+    /// Returns whether or not the sync controller is set to run the pipeline continuously.
+    pub(crate) fn run_pipeline_continuously(&self) -> bool {
+        self.run_pipeline_continuously
+    }
+
     /// Returns `true` if the pipeline is idle.
     pub(crate) fn is_pipeline_idle(&self) -> bool {
         self.pipeline_state.is_idle()

--- a/crates/stages/src/pipeline/ctrl.rs
+++ b/crates/stages/src/pipeline/ctrl.rs
@@ -32,4 +32,13 @@ impl ControlFlow {
     pub fn is_unwind(&self) -> bool {
         matches!(self, ControlFlow::Unwind { .. })
     }
+
+    /// Returns the pipeline progress, if the state is not `Unwind`.
+    pub fn progress(&self) -> Option<BlockNumber> {
+        match self {
+            ControlFlow::Unwind { .. } => None,
+            ControlFlow::Continue { progress } => Some(*progress),
+            ControlFlow::NoProgress { stage_progress } => *stage_progress,
+        }
+    }
 }


### PR DESCRIPTION
The `latest` tag should always be consistent with the canonical head. Before we used the `ChainInfoTracker`, we would update the latest head in the `Finish` stage, which is not correct. When not using `--debug.continuous`, we correctly update the `ChainInfoTracker`, and latest head, on a successful forkchoice update. Because `--debug.continuous` is a nonstandard sync strategy that does not rely on forkchoice updates or other CL requests, we should update the `latest` block whenever the pipeline finishes, preserving the behavior that the `Finish` stage previously fulfilled.

This PR updates the canonical head when running with `--debug.continuous` with the stage progress, whenever the pipeline finishes.

Fixes #2705 

~~This is a super hacky solution to fixing the sync test, because it inserts continuous downloader logic into the consensus engine. Mainly submitting this to highlight that we need to update how we set the `latest` block.~~

We currently only ever set the `latest` block on engine API calls, ~~and conflate the latest block with the canonical head~~ (update: this is what we should be doing and consistent with geth). ~~We might want to go back to setting the latest block in the finish stage, or something similar.~~