### PR TITLE
chore: executor error cleanup

### DIFF
--- a/crates/blockchain-tree/src/chain.rs
+++ b/crates/blockchain-tree/src/chain.rs
@@ -4,7 +4,7 @@
 //! blocks, as well as a list of the blocks the chain is composed of.
 use crate::{post_state::PostState, PostStateDataRef};
 use reth_db::database::Database;
-use reth_interfaces::{consensus::Consensus, executor::Error as ExecError, Error};
+use reth_interfaces::{consensus::Consensus, executor::BlockExecutionError, Error};
 use reth_primitives::{
     BlockHash, BlockNumber, ForkBlock, SealedBlockWithSenders, SealedHeader, U256,
 };
@@ -97,10 +97,9 @@ impl AppendableChain {
         EF: ExecutorFactory,
     {
         let parent_number = block.number - 1;
-        let parent = self
-            .blocks()
-            .get(&parent_number)
-            .ok_or(ExecError::BlockNumberNotFoundInChain { block_number: parent_number })?;
+        let parent = self.blocks().get(&parent_number).ok_or(
+            BlockExecutionError::BlockNumberNotFoundInChain { block_number: parent_number },
+        )?;
 
         let mut state = self.state.clone();
 

--- a/crates/blockchain-tree/src/shareable.rs
+++ b/crates/blockchain-tree/src/shareable.rs
@@ -45,7 +45,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeEngine
         }
         let block = block
             .seal_with_senders()
-            .ok_or(reth_interfaces::executor::Error::SenderRecoveryError)?;
+            .ok_or(reth_interfaces::executor::BlockExecutionError::SenderRecoveryError)?;
         tree.insert_block_inner(block, true)
     }
 

--- a/crates/interfaces/src/blockchain_tree.rs
+++ b/crates/interfaces/src/blockchain_tree.rs
@@ -1,4 +1,4 @@
-use crate::{executor::Error as ExecutionError, Error};
+use crate::{executor::BlockExecutionError, Error};
 use reth_primitives::{
     BlockHash, BlockNumHash, BlockNumber, SealedBlock, SealedBlockWithSenders, SealedHeader,
 };
@@ -14,13 +14,13 @@ use std::collections::{BTreeMap, HashSet};
 pub trait BlockchainTreeEngine: BlockchainTreeViewer + Send + Sync {
     /// Recover senders and call [`BlockchainTreeEngine::insert_block`].
     fn insert_block_without_senders(&self, block: SealedBlock) -> Result<BlockStatus, Error> {
-        let block = block.seal_with_senders().ok_or(ExecutionError::SenderRecoveryError)?;
+        let block = block.seal_with_senders().ok_or(BlockExecutionError::SenderRecoveryError)?;
         self.insert_block(block)
     }
 
     /// Recover senders and call [`BlockchainTreeEngine::buffer_block`].
     fn buffer_block_without_sender(&self, block: SealedBlock) -> Result<(), Error> {
-        let block = block.seal_with_senders().ok_or(ExecutionError::SenderRecoveryError)?;
+        let block = block.seal_with_senders().ok_or(BlockExecutionError::SenderRecoveryError)?;
         self.buffer_block(block)
     }
 

--- a/crates/interfaces/src/error.rs
+++ b/crates/interfaces/src/error.rs
@@ -6,7 +6,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[allow(missing_docs)]
 pub enum Error {
     #[error(transparent)]
-    Execution(#[from] crate::executor::Error),
+    Execution(#[from] crate::executor::BlockExecutionError),
 
     #[error(transparent)]
     Consensus(#[from] crate::consensus::ConsensusError),

--- a/crates/interfaces/src/executor.rs
+++ b/crates/interfaces/src/executor.rs
@@ -48,6 +48,11 @@ pub enum BlockExecutionError {
     BlockPreMerge { hash: H256 },
     #[error("Missing total difficulty")]
     MissingTotalDifficulty { hash: H256 },
+
+    /// Only used for TestExecutor
+    #[cfg(feature = "test-utils")]
+    #[error("Execution unavailable for tests")]
+    UnavailableForTest,
 }
 
 impl BlockExecutionError {

--- a/crates/interfaces/src/executor.rs
+++ b/crates/interfaces/src/executor.rs
@@ -4,23 +4,11 @@ use thiserror::Error;
 /// BlockExecutor Errors
 #[allow(missing_docs)]
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
-pub enum Error {
+pub enum BlockExecutionError {
     #[error("EVM reported invalid transaction ({hash:?}): {message}")]
     EVM { hash: H256, message: String },
-    #[error("Verification failed.")]
-    VerificationFailed,
-    #[error("Fatal internal error")]
-    ExecutionFatalError,
     #[error("Failed to recover sender for transaction")]
     SenderRecoveryError,
-    #[error("Receipt cumulative gas used {got:?} is different from expected {expected:?}")]
-    ReceiptCumulativeGasUsedDiff { got: u64, expected: u64 },
-    #[error("Receipt log count {got:?} is different from expected {expected:?}.")]
-    ReceiptLogCountDiff { got: usize, expected: usize },
-    #[error("Receipt log is different.")]
-    ReceiptLogDiff,
-    #[error("Receipt log is different.")]
-    ExecutionSuccessDiff { got: bool, expected: bool },
     #[error("Receipt root {got:?} is different than expected {expected:?}.")]
     ReceiptRootDiff { got: H256, expected: H256 },
     #[error("Header bloom filter {got:?} is different than expected {expected:?}.")]
@@ -56,15 +44,13 @@ pub enum Error {
     CanonicalRevert { inner: String },
     #[error("Transaction error on commit: {inner:?}")]
     CanonicalCommit { inner: String },
-    #[error("Transaction error on pipeline status update: {inner:?}")]
-    PipelineStatusUpdate { inner: String },
     #[error("Block {hash:?} is pre merge")]
     BlockPreMerge { hash: H256 },
     #[error("Missing total difficulty")]
     MissingTotalDifficulty { hash: H256 },
 }
 
-impl Error {
+impl BlockExecutionError {
     /// Returns `true` if the error is fatal.
     pub fn is_fatal(&self) -> bool {
         matches!(self, Self::CanonicalCommit { .. } | Self::CanonicalRevert { .. })

--- a/crates/stages/src/error.rs
+++ b/crates/stages/src/error.rs
@@ -30,7 +30,7 @@ pub enum StageError {
         block: BlockNumber,
         /// The underlying execution error.
         #[source]
-        error: executor::Error,
+        error: executor::BlockExecutionError,
     },
     /// Invalid checkpoint passed to the stage
     #[error("Invalid stage progress: {0}")]

--- a/crates/storage/provider/src/chain.rs
+++ b/crates/storage/provider/src/chain.rs
@@ -1,7 +1,7 @@
 //! Contains [Chain], a chain of blocks and their final state.
 
 use crate::PostState;
-use reth_interfaces::{executor::Error as ExecError, Error};
+use reth_interfaces::{executor::BlockExecutionError, Error};
 use reth_primitives::{
     BlockHash, BlockNumHash, BlockNumber, ForkBlock, Receipt, SealedBlock, SealedBlockWithSenders,
     TransactionSigned, TxHash,
@@ -151,7 +151,7 @@ impl Chain {
     pub fn append_chain(&mut self, chain: Chain) -> Result<(), Error> {
         let chain_tip = self.tip();
         if chain_tip.hash != chain.fork_block_hash() {
-            return Err(ExecError::AppendChainDoesntConnect {
+            return Err(BlockExecutionError::AppendChainDoesntConnect {
                 chain_tip: chain_tip.num_hash(),
                 other_chain_fork: chain.fork_block(),
             }

--- a/crates/storage/provider/src/test_utils/executor.rs
+++ b/crates/storage/provider/src/test_utils/executor.rs
@@ -1,6 +1,6 @@
 use crate::{post_state::PostState, BlockExecutor, ExecutorFactory, StateProvider};
 use parking_lot::Mutex;
-use reth_interfaces::executor::Error as ExecutionError;
+use reth_interfaces::executor::BlockExecutionError;
 use reth_primitives::{Address, Block, ChainSpec, U256};
 use std::sync::Arc;
 /// Test executor with mocked result.
@@ -12,8 +12,8 @@ impl<SP: StateProvider> BlockExecutor<SP> for TestExecutor {
         _block: &Block,
         _total_difficulty: U256,
         _senders: Option<Vec<Address>>,
-    ) -> Result<PostState, ExecutionError> {
-        self.0.clone().ok_or(ExecutionError::VerificationFailed)
+    ) -> Result<PostState, BlockExecutionError> {
+        self.0.clone().ok_or_else(|| panic!("TestExecutor should have a result"))
     }
 
     fn execute_and_verify_receipt(
@@ -21,8 +21,8 @@ impl<SP: StateProvider> BlockExecutor<SP> for TestExecutor {
         _block: &Block,
         _total_difficulty: U256,
         _senders: Option<Vec<Address>>,
-    ) -> Result<PostState, ExecutionError> {
-        self.0.clone().ok_or(ExecutionError::VerificationFailed)
+    ) -> Result<PostState, BlockExecutionError> {
+        self.0.clone().ok_or_else(|| panic!("TestExecutor should have a result"))
     }
 }
 

--- a/crates/storage/provider/src/test_utils/executor.rs
+++ b/crates/storage/provider/src/test_utils/executor.rs
@@ -13,7 +13,7 @@ impl<SP: StateProvider> BlockExecutor<SP> for TestExecutor {
         _total_difficulty: U256,
         _senders: Option<Vec<Address>>,
     ) -> Result<PostState, BlockExecutionError> {
-        self.0.clone().ok_or_else(|| panic!("TestExecutor should have a result"))
+        self.0.clone().ok_or(BlockExecutionError::UnavailableForTest)
     }
 
     fn execute_and_verify_receipt(
@@ -22,7 +22,7 @@ impl<SP: StateProvider> BlockExecutor<SP> for TestExecutor {
         _total_difficulty: U256,
         _senders: Option<Vec<Address>>,
     ) -> Result<PostState, BlockExecutionError> {
-        self.0.clone().ok_or_else(|| panic!("TestExecutor should have a result"))
+        self.0.clone().ok_or(BlockExecutionError::UnavailableForTest)
     }
 }
 

--- a/crates/storage/provider/src/traits/executor.rs
+++ b/crates/storage/provider/src/traits/executor.rs
@@ -1,7 +1,7 @@
 //! Executor Factory
 
 use crate::{post_state::PostState, StateProvider};
-use reth_interfaces::executor::Error;
+use reth_interfaces::executor::BlockExecutionError;
 use reth_primitives::{Address, Block, ChainSpec, U256};
 
 /// Executor factory that would create the EVM with particular state provider.
@@ -33,7 +33,7 @@ pub trait BlockExecutor<SP: StateProvider> {
         block: &Block,
         total_difficulty: U256,
         senders: Option<Vec<Address>>,
-    ) -> Result<PostState, Error>;
+    ) -> Result<PostState, BlockExecutionError>;
 
     /// Executes the block and checks receipts
     fn execute_and_verify_receipt(
@@ -41,5 +41,5 @@ pub trait BlockExecutor<SP: StateProvider> {
         block: &Block,
         total_difficulty: U256,
         senders: Option<Vec<Address>>,
-    ) -> Result<PostState, Error>;
+    ) -> Result<PostState, BlockExecutionError>;
 }


### PR DESCRIPTION
ref #2520 
error handling can be improved in general, this

* rename `executor::Error` to `BlockExecutionError`
* remove unused variants


This lays the ground work for #2520, a lot of `BlockExecutionError` can be removed here because they are only used in the tree