### PR TITLE
refactor: dedicated blockchain insert errors

### DIFF
--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -283,7 +283,10 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
         }
 
         // if not found, check if the parent can be found inside canonical chain.
-        if self.is_block_hash_canonical(&parent.hash)? {
+        if self
+            .is_block_hash_canonical(&parent.hash)
+            .map_err(|err| InsertBlockError::new(block.block.clone(), err.into()))?
+        {
             return self.try_append_canonical_chain(block, parent)
         }
 
@@ -763,7 +766,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
         // the db, then it is not canonical.
         if !self.block_indices.is_block_hash_canonical(hash) &&
             (self.block_by_hash(*hash).is_some() ||
-                self.externals.shareable_db().header(hash)?.is_none())
+                self.externals.database().header(hash)?.is_none())
         {
             return Ok(false)
         }

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use reth_db::{cursor::DbCursorRO, database::Database, tables, transaction::DbTx};
 use reth_interfaces::{
-    blockchain_tree::BlockStatus,
+    blockchain_tree::{error::InsertInvalidBlockError, BlockStatus},
     consensus::{Consensus, ConsensusError},
     executor::BlockExecutionError,
     Error,
@@ -25,7 +25,6 @@ use std::{
     sync::Arc,
 };
 use tracing::{debug, error, info, instrument, trace};
-use reth_interfaces::blockchain_tree::error::InsertInvalidBlockError;
 
 #[cfg_attr(doc, aquamarine::aquamarine)]
 /// Tree of chains and its identifications.
@@ -142,7 +141,8 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
     /// * if block is inside database and return [BlockStatus::Valid] if it is.
     /// * if block is inside buffer and return [BlockStatus::Disconnected] if it is.
     /// * if block is part of the side chain and return [BlockStatus::Accepted] if it is.
-    /// * if block is part of the canonical chain that tree knows, return [BlockStatus::Valid], if it is.
+    /// * if block is part of the canonical chain that tree knows, return [BlockStatus::Valid], if
+    ///   it is.
     ///
     /// Returns an error if
     ///    - an error occurred while reading from the database.
@@ -566,7 +566,10 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
     ///
     /// If the senders have not already been recovered, call
     /// [`BlockchainTree::insert_block_without_senders`] instead.
-    pub fn insert_block(&mut self, block: SealedBlockWithSenders) -> Result<BlockStatus, InsertInvalidBlockError> {
+    pub fn insert_block(
+        &mut self,
+        block: SealedBlockWithSenders,
+    ) -> Result<BlockStatus, InsertInvalidBlockError> {
         self.insert_block_inner(block, true)
     }
 

--- a/crates/blockchain-tree/src/chain.rs
+++ b/crates/blockchain-tree/src/chain.rs
@@ -145,7 +145,7 @@ impl AppendableChain {
         let unseal = unseal.unseal();
 
         //get state provider.
-        let db = externals.shareable_db();
+        let db = externals.database();
         // TODO, small perf can check if caonical fork is the latest state.
         let canonical_fork = post_state_data_provider.canonical_fork();
         let history_provider = db.history_by_block_number(canonical_fork.number)?;

--- a/crates/blockchain-tree/src/externals.rs
+++ b/crates/blockchain-tree/src/externals.rs
@@ -35,7 +35,7 @@ impl<DB, C, EF> TreeExternals<DB, C, EF> {
 
 impl<DB: Database, C, EF> TreeExternals<DB, C, EF> {
     /// Return shareable database helper structure.
-    pub fn shareable_db(&self) -> ShareableDatabase<&DB> {
+    pub fn database(&self) -> ShareableDatabase<&DB> {
         ShareableDatabase::new(&self.db, self.chain_spec.clone())
     }
 }

--- a/crates/blockchain-tree/src/shareable.rs
+++ b/crates/blockchain-tree/src/shareable.rs
@@ -4,7 +4,7 @@ use parking_lot::RwLock;
 use reth_db::database::Database;
 use reth_interfaces::{
     blockchain_tree::{
-        error::InsertInvalidBlockError, BlockStatus, BlockchainTreeEngine, BlockchainTreeViewer,
+        error::InsertBlockError, BlockStatus, BlockchainTreeEngine, BlockchainTreeViewer,
     },
     consensus::Consensus,
     Error,
@@ -42,21 +42,18 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeEngine
     fn insert_block_without_senders(
         &self,
         block: SealedBlock,
-    ) -> Result<BlockStatus, InsertInvalidBlockError> {
+    ) -> Result<BlockStatus, InsertBlockError> {
         match block.try_seal_with_senders() {
             Ok(block) => self.tree.write().insert_block_inner(block, true),
-            Err(block) => Err(InsertInvalidBlockError::sender_recovery_error(block)),
+            Err(block) => Err(InsertBlockError::sender_recovery_error(block)),
         }
     }
 
-    fn buffer_block(&self, block: SealedBlockWithSenders) -> Result<(), InsertInvalidBlockError> {
+    fn buffer_block(&self, block: SealedBlockWithSenders) -> Result<(), InsertBlockError> {
         self.tree.write().buffer_block(block)
     }
 
-    fn insert_block(
-        &self,
-        block: SealedBlockWithSenders,
-    ) -> Result<BlockStatus, InsertInvalidBlockError> {
+    fn insert_block(&self, block: SealedBlockWithSenders) -> Result<BlockStatus, InsertBlockError> {
         trace!(target: "blockchain_tree", ?block, "Inserting block");
         self.tree.write().insert_block(block)
     }

--- a/crates/blockchain-tree/src/shareable.rs
+++ b/crates/blockchain-tree/src/shareable.rs
@@ -43,14 +43,8 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeEngine
         &self,
         block: SealedBlock,
     ) -> Result<BlockStatus, InsertInvalidBlockError> {
-        let mut tree = self.tree.write();
-        // check if block is known before recovering all senders.
-        if let Some(status) = tree.is_block_known(block.num_hash())? {
-            return Ok(status)
-        }
-
         match block.try_seal_with_senders() {
-            Ok(block) => tree.insert_block_inner(block, true),
+            Ok(block) => self.tree.write().insert_block_inner(block, true),
             Err(block) => Err(InsertInvalidBlockError::sender_recovery_error(block)),
         }
     }

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -671,7 +671,7 @@ where
             // received a new payload while we're still syncing to the target
             let latest_valid_hash =
                 self.latest_valid_hash_for_invalid_payload(parent_hash, Some(&error));
-            let status = PayloadStatusEnum::Invalid { validation_error: error.to_string() };
+            let status = PayloadStatusEnum::Invalid { validation_error: error.kind().to_string() };
             PayloadStatus::new(status, latest_valid_hash)
         } else {
             // successfully buffered the block
@@ -725,7 +725,8 @@ where
 
                 let latest_valid_hash =
                     self.latest_valid_hash_for_invalid_payload(parent_hash, Some(&error));
-                let status = PayloadStatusEnum::Invalid { validation_error: error.to_string() };
+                let status =
+                    PayloadStatusEnum::Invalid { validation_error: error.kind().to_string() };
                 PayloadStatus::new(status, latest_valid_hash)
             }
         }

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -51,7 +51,7 @@ mod event;
 pub(crate) mod sync;
 
 pub use event::BeaconConsensusEngineEvent;
-use reth_interfaces::blockchain_tree::error::InsertInvalidBlockError;
+use reth_interfaces::blockchain_tree::error::InsertBlockError;
 
 /// The maximum number of invalid headers that can be tracked by the engine.
 const MAX_INVALID_HEADERS: u32 = 512u32;
@@ -270,7 +270,7 @@ where
     fn latest_valid_hash_for_invalid_payload(
         &self,
         parent_hash: H256,
-        tree_error: Option<&InsertInvalidBlockError>,
+        tree_error: Option<&InsertBlockError>,
     ) -> Option<H256> {
         // check pre merge block error
         if tree_error.map(|err| err.kind().is_block_pre_merge()).unwrap_or_default() {

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -51,6 +51,7 @@ mod event;
 pub(crate) mod sync;
 
 pub use event::BeaconConsensusEngineEvent;
+use reth_interfaces::blockchain_tree::error::InsertInvalidBlockError;
 
 /// The maximum number of invalid headers that can be tracked by the engine.
 const MAX_INVALID_HEADERS: u32 = 512u32;
@@ -269,10 +270,10 @@ where
     fn latest_valid_hash_for_invalid_payload(
         &self,
         parent_hash: H256,
-        tree_error: Option<&Error>,
+        tree_error: Option<&InsertInvalidBlockError>,
     ) -> Option<H256> {
         // check pre merge block error
-        if let Some(Error::Execution(BlockExecutionError::BlockPreMerge { .. })) = tree_error {
+        if tree_error.map(|err| err.kind().is_block_pre_merge()).unwrap_or_default() {
             return Some(H256::zero())
         }
 

--- a/crates/interfaces/src/blockchain_tree/error.rs
+++ b/crates/interfaces/src/blockchain_tree/error.rs
@@ -1,7 +1,7 @@
 //! Error handling for the blockchain tree
 
 use crate::{consensus::ConsensusError, Error};
-use reth_primitives::{SealedBlock, SealedBlockWithSenders};
+use reth_primitives::{BlockHash, BlockNumber, SealedBlock, SealedBlockWithSenders};
 use std::fmt::Formatter;
 
 /// Error thrown when inserting a block failed because the block is considered invalid.
@@ -14,7 +14,6 @@ pub struct InsertInvalidBlockError {
 // === impl InsertInvalidBlockError ===
 
 impl InsertInvalidBlockError {
-
     /// Create a new InsertInvalidBlockError
     pub fn new(block: SealedBlock, kind: InsertInvalidBlockErrorKind) -> Self {
         Self { inner: InsertInvalidBlockData::boxed(block, kind) }
@@ -82,10 +81,19 @@ pub enum InsertInvalidBlockErrorKind {
     /// Failed to recover senders for the block
     #[error("Failed to recover senders for block")]
     SenderRecovery,
-    /// Block violated consensus rules
+    /// Block violated consensus rules.
     #[error(transparent)]
     Consensus(ConsensusError),
-    /// Block violated consensus rules
+    /// Block execution failed.
     #[error(transparent)]
     Execution(Error),
+
+    #[error("Can't insert #{block_number} {block_hash} as last finalized block number is {last_finalized}")]
+    PendingBlockIsFinalized {
+        block_hash: BlockHash,
+        block_number: BlockNumber,
+        last_finalized: BlockNumber,
+    },
+    #[error("Database error")]
+    DatabaseError,
 }

--- a/crates/interfaces/src/blockchain_tree/error.rs
+++ b/crates/interfaces/src/blockchain_tree/error.rs
@@ -1,0 +1,91 @@
+//! Error handling for the blockchain tree
+
+use crate::{consensus::ConsensusError, Error};
+use reth_primitives::{SealedBlock, SealedBlockWithSenders};
+use std::fmt::Formatter;
+
+/// Error thrown when inserting a block failed because the block is considered invalid.
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct InsertInvalidBlockError {
+    inner: Box<InsertInvalidBlockData>,
+}
+
+// === impl InsertInvalidBlockError ===
+
+impl InsertInvalidBlockError {
+
+    /// Create a new InsertInvalidBlockError
+    pub fn new(block: SealedBlock, kind: InsertInvalidBlockErrorKind) -> Self {
+        Self { inner: InsertInvalidBlockData::boxed(block, kind) }
+    }
+
+    /// Create a new InsertInvalidBlockError from a consensus error
+    pub fn consensus_error(error: ConsensusError, block: SealedBlock) -> Self {
+        Self::new(block, InsertInvalidBlockErrorKind::Consensus(error))
+    }
+
+    /// Create a new InsertInvalidBlockError from a consensus error
+    pub fn sender_recovery_error(block: SealedBlock) -> Self {
+        Self::new(block, InsertInvalidBlockErrorKind::SenderRecovery)
+    }
+
+    /// Create a new InsertInvalidBlockError from an execution error
+    pub fn execution_error(error: Error, block: SealedBlock) -> Self {
+        Self::new(block, InsertInvalidBlockErrorKind::Execution(error))
+    }
+
+    /// Returns the error kind
+    #[inline]
+    pub fn kind(&self) -> &InsertInvalidBlockErrorKind {
+        &self.inner.kind
+    }
+
+    /// Returns the invalid block.
+    #[inline]
+    pub fn block(&self) -> &SealedBlock {
+        &self.inner.block
+    }
+}
+
+#[derive(Debug)]
+struct InsertInvalidBlockData {
+    block: SealedBlock,
+    kind: InsertInvalidBlockErrorKind,
+}
+
+impl std::fmt::Display for InsertInvalidBlockData {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Failed to insert block {:?}: {}", self.block.hash, self.kind)
+    }
+}
+
+impl std::error::Error for InsertInvalidBlockData {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.kind)
+    }
+}
+
+impl InsertInvalidBlockData {
+    fn new(block: SealedBlock, kind: InsertInvalidBlockErrorKind) -> Self {
+        Self { block, kind }
+    }
+
+    fn boxed(block: SealedBlock, kind: InsertInvalidBlockErrorKind) -> Box<Self> {
+        Box::new(Self::new(block, kind))
+    }
+}
+
+/// All error variants possible when inserting a block
+#[derive(Debug, thiserror::Error)]
+pub enum InsertInvalidBlockErrorKind {
+    /// Failed to recover senders for the block
+    #[error("Failed to recover senders for block")]
+    SenderRecovery,
+    /// Block violated consensus rules
+    #[error(transparent)]
+    Consensus(ConsensusError),
+    /// Block violated consensus rules
+    #[error(transparent)]
+    Execution(Error),
+}

--- a/crates/interfaces/src/blockchain_tree/mod.rs
+++ b/crates/interfaces/src/blockchain_tree/mod.rs
@@ -1,4 +1,4 @@
-use crate::{blockchain_tree::error::InsertInvalidBlockError, Error};
+use crate::{blockchain_tree::error::InsertBlockError, Error};
 use reth_primitives::{
     BlockHash, BlockNumHash, BlockNumber, SealedBlock, SealedBlockWithSenders, SealedHeader,
 };
@@ -18,32 +18,26 @@ pub trait BlockchainTreeEngine: BlockchainTreeViewer + Send + Sync {
     fn insert_block_without_senders(
         &self,
         block: SealedBlock,
-    ) -> Result<BlockStatus, InsertInvalidBlockError> {
+    ) -> Result<BlockStatus, InsertBlockError> {
         match block.try_seal_with_senders() {
             Ok(block) => self.insert_block(block),
-            Err(block) => Err(InsertInvalidBlockError::sender_recovery_error(block)),
+            Err(block) => Err(InsertBlockError::sender_recovery_error(block)),
         }
     }
 
     /// Recover senders and call [`BlockchainTreeEngine::buffer_block`].
-    fn buffer_block_without_sender(
-        &self,
-        block: SealedBlock,
-    ) -> Result<(), InsertInvalidBlockError> {
+    fn buffer_block_without_sender(&self, block: SealedBlock) -> Result<(), InsertBlockError> {
         match block.try_seal_with_senders() {
             Ok(block) => self.buffer_block(block),
-            Err(block) => Err(InsertInvalidBlockError::sender_recovery_error(block)),
+            Err(block) => Err(InsertBlockError::sender_recovery_error(block)),
         }
     }
 
     /// Buffer block with senders
-    fn buffer_block(&self, block: SealedBlockWithSenders) -> Result<(), InsertInvalidBlockError>;
+    fn buffer_block(&self, block: SealedBlockWithSenders) -> Result<(), InsertBlockError>;
 
     /// Insert block with senders
-    fn insert_block(
-        &self,
-        block: SealedBlockWithSenders,
-    ) -> Result<BlockStatus, InsertInvalidBlockError>;
+    fn insert_block(&self, block: SealedBlockWithSenders) -> Result<BlockStatus, InsertBlockError>;
 
     /// Finalize blocks up until and including `finalized_block`, and remove them from the tree.
     fn finalize_block(&self, finalized_block: BlockNumber);

--- a/crates/interfaces/src/blockchain_tree/mod.rs
+++ b/crates/interfaces/src/blockchain_tree/mod.rs
@@ -1,7 +1,4 @@
-use crate::{
-    blockchain_tree::error::InsertInvalidBlockError, consensus::ConsensusError,
-    executor::BlockExecutionError, Error,
-};
+use crate::{blockchain_tree::error::InsertInvalidBlockError, Error};
 use reth_primitives::{
     BlockHash, BlockNumHash, BlockNumber, SealedBlock, SealedBlockWithSenders, SealedHeader,
 };

--- a/crates/interfaces/src/executor.rs
+++ b/crates/interfaces/src/executor.rs
@@ -1,4 +1,4 @@
-use reth_primitives::{BlockHash, BlockNumHash, BlockNumber, Bloom, H256};
+use reth_primitives::{BlockHash, BlockNumHash, Bloom, H256};
 use thiserror::Error;
 
 /// BlockExecutor Errors
@@ -22,14 +22,13 @@ pub enum BlockExecutionError {
     BlockGasUsed { got: u64, expected: u64 },
     #[error("Provider error")]
     ProviderError,
+    // TODO(mattsse): move this to tree error
+    #[error("Block hash {block_hash} not found in blockchain tree chain")]
+    BlockHashNotFoundInChain { block_hash: BlockHash },
     #[error(
         "Appending chain on fork (other_chain_fork:?) is not possible as the tip is {chain_tip:?}"
     )]
     AppendChainDoesntConnect { chain_tip: BlockNumHash, other_chain_fork: BlockNumHash },
-    #[error("Block number #{block_number} not found in blockchain tree chain")]
-    BlockNumberNotFoundInChain { block_number: BlockNumber },
-    #[error("Block hash {block_hash} not found in blockchain tree chain")]
-    BlockHashNotFoundInChain { block_hash: BlockHash },
     #[error("Transaction error on revert: {inner:?}")]
     CanonicalRevert { inner: String },
     #[error("Transaction error on commit: {inner:?}")]

--- a/crates/interfaces/src/executor.rs
+++ b/crates/interfaces/src/executor.rs
@@ -22,20 +22,10 @@ pub enum BlockExecutionError {
     BlockGasUsed { got: u64, expected: u64 },
     #[error("Provider error")]
     ProviderError,
-    #[error("BlockChainId can't be found in BlockchainTree with internal index {chain_id}")]
-    BlockSideChainIdConsistency { chain_id: u64 },
     #[error(
         "Appending chain on fork (other_chain_fork:?) is not possible as the tip is {chain_tip:?}"
     )]
     AppendChainDoesntConnect { chain_tip: BlockNumHash, other_chain_fork: BlockNumHash },
-    #[error("Canonical chain header #{block_hash} can't be found ")]
-    CanonicalChain { block_hash: BlockHash },
-    #[error("Can't insert #{block_number} {block_hash} as last finalized block number is {last_finalized}")]
-    PendingBlockIsFinalized {
-        block_hash: BlockHash,
-        block_number: BlockNumber,
-        last_finalized: BlockNumber,
-    },
     #[error("Block number #{block_number} not found in blockchain tree chain")]
     BlockNumberNotFoundInChain { block_number: BlockNumber },
     #[error("Block hash {block_hash} not found in blockchain tree chain")]

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -146,8 +146,15 @@ impl SealedBlock {
 
     /// Seal sealed block with recovered transaction senders.
     pub fn seal_with_senders(self) -> Option<SealedBlockWithSenders> {
-        let senders = self.senders()?;
-        Some(SealedBlockWithSenders { block: self, senders })
+       self.try_seal_with_senders().ok()
+    }
+
+    /// Seal sealed block with recovered transaction senders.
+    pub fn try_seal_with_senders(self) -> Result<SealedBlockWithSenders, Self> {
+        match self.senders() {
+            Some(senders) => Ok(SealedBlockWithSenders { block: self, senders }),
+            None => Err(self),
+        }
     }
 
     /// Unseal the block

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -146,7 +146,7 @@ impl SealedBlock {
 
     /// Seal sealed block with recovered transaction senders.
     pub fn seal_with_senders(self) -> Option<SealedBlockWithSenders> {
-       self.try_seal_with_senders().ok()
+        self.try_seal_with_senders().ok()
     }
 
     /// Seal sealed block with recovered transaction senders.

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -35,6 +35,7 @@ mod state;
 use crate::{providers::chain_info::ChainInfoTracker, traits::BlockSource};
 pub use database::*;
 pub use post_state_provider::PostStateProvider;
+use reth_interfaces::blockchain_tree::error::InsertInvalidBlockError;
 
 /// The main type for interacting with the blockchain.
 ///
@@ -371,11 +372,17 @@ where
     DB: Send + Sync,
     Tree: BlockchainTreeEngine,
 {
-    fn buffer_block(&self, block: SealedBlockWithSenders) -> Result<()> {
+    fn buffer_block(
+        &self,
+        block: SealedBlockWithSenders,
+    ) -> std::result::Result<(), InsertInvalidBlockError> {
         self.tree.buffer_block(block)
     }
 
-    fn insert_block(&self, block: SealedBlockWithSenders) -> Result<BlockStatus> {
+    fn insert_block(
+        &self,
+        block: SealedBlockWithSenders,
+    ) -> std::result::Result<BlockStatus, InsertInvalidBlockError> {
         self.tree.insert_block(block)
     }
 

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -35,7 +35,7 @@ mod state;
 use crate::{providers::chain_info::ChainInfoTracker, traits::BlockSource};
 pub use database::*;
 pub use post_state_provider::PostStateProvider;
-use reth_interfaces::blockchain_tree::error::InsertInvalidBlockError;
+use reth_interfaces::blockchain_tree::error::InsertBlockError;
 
 /// The main type for interacting with the blockchain.
 ///
@@ -375,14 +375,14 @@ where
     fn buffer_block(
         &self,
         block: SealedBlockWithSenders,
-    ) -> std::result::Result<(), InsertInvalidBlockError> {
+    ) -> std::result::Result<(), InsertBlockError> {
         self.tree.buffer_block(block)
     }
 
     fn insert_block(
         &self,
         block: SealedBlockWithSenders,
-    ) -> std::result::Result<BlockStatus, InsertInvalidBlockError> {
+    ) -> std::result::Result<BlockStatus, InsertBlockError> {
         self.tree.insert_block(block)
     }
 


### PR DESCRIPTION
closes https://github.com/paradigmxyz/reth/issues/2520

adds new error type for insert operations to the blockchain tree, which make it easier to handle various error cases inside the consensus engine.

This makes error handling inside the tree a bit more cumbersome because the error is now supposed to contain the offending block, but makes it easier to use.


The error does not necessarily require the Sealedblock, if the sender needs it, it would need to clone it, however. Removing it from the error would make it a bit easier to use inside the tree. 

hmm, the more I think about this, having the block part of the error is probably not that useful?


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0ac6caf</samp>

This pull request refactors the error handling of the `blockchain_tree` crate and its dependencies to use more specific and descriptive error types for block insertion and execution failures. It also improves some function names, doc comments, and code quality in the affected modules.
