### PR TITLE
chore: remove crate-template

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ members = [
     "crates/transaction-pool",
     "crates/trie",
 ]
-exclude = ["crate-template"]
 default-members = ["bin/reth"]
 
 # Explicitly set the resolver to version 2, which is the default for packages with edition >= 2021

--- a/crate-template/Cargo.toml
+++ b/crate-template/Cargo.toml
@@ -1,9 +1,0 @@
-[package]
-name = "reth-crate-template"
-version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/paradigmxyz/reth"
-readme = "README.md"
-
-[dependencies]

--- a/crate-template/src/lib.rs
+++ b/crate-template/src/lib.rs
@@ -1,8 +1,0 @@
-#![warn(missing_docs, unreachable_pub)]
-#![deny(unused_must_use, rust_2018_idioms)]
-#![doc(test(
-    no_crate_inject,
-    attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
-))]
-
-//! reth crate template

--- a/docs/repo/layout.md
+++ b/docs/repo/layout.md
@@ -76,7 +76,6 @@ Small utility crates.
 
 - [`interfaces`](../../crates/interfaces): Traits containing common abstractions across the components used in the system. For ease of unit testing, each crate importing the interface is recommended to create mock/in-memory implementations of each trait.
 - [`tracing`](../../crates/tracing): A small utility crate to install a uniform [`tracing`][tracing] subscriber
-- [`crate-template`](../../crate-template): Template crate to use when instantiating new crates under `crates/`.
 
 [fastrlp]: https://crates.io/crates/fastrlp
 [fastrlp-derive]: https://crates.io/crates/fastrlp-derive


### PR DESCRIPTION
I don't think we need it anymore, but we can keep it if there are any objections

The only thing we want from the crate template are the `warn`/`deny`/`doc` attributes, but these are present in (almost) all other crates at this point