### PR TITLE
chore: add missing crates to codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,3 +17,4 @@ crates/blockchain-tree      @rakita @rkrasiuk
 crates/metrics              @onbjerg
 crates/tracing              @onbjerg
 crates/tasks                @mattsse
+.github/                    @onbjerg @gakonst

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,3 +13,7 @@ crates/payload/             @mattsse @Rjected
 crates/consensus/auto-seal  @mattsse
 crates/consensus/beacon     @rkrasiuk @mattsse @Rjected
 crates/trie                 @rkrasiuk
+crates/blockchain-tree      @rakita @rkrasiuk
+crates/metrics              @onbjerg
+crates/tracing              @onbjerg
+crates/tasks                @mattsse


### PR DESCRIPTION
I just assigned the people who know most about those areas of the code