### PR TITLE
chore: spawn more eth calls and add docs

### DIFF
--- a/crates/interfaces/src/executor.rs
+++ b/crates/interfaces/src/executor.rs
@@ -50,7 +50,8 @@ pub enum BlockExecutionError {
     MissingTotalDifficulty { hash: H256 },
 
     /// Only used for TestExecutor
-    #[cfg(feature = "test-utils")]
+    ///
+    /// Note: this is only used during testing, but is not feature gated for convenience.
     #[error("Execution unavailable for tests")]
     UnavailableForTest,
 }

--- a/crates/interfaces/src/executor.rs
+++ b/crates/interfaces/src/executor.rs
@@ -51,7 +51,7 @@ pub enum BlockExecutionError {
 
     /// Only used for TestExecutor
     ///
-    /// Note: this is only used during testing, but is not feature gated for convenience.
+    /// Note: this is not feature gated for convenience.
     #[error("Execution unavailable for tests")]
     UnavailableForTest,
 }

--- a/crates/rpc/rpc/src/eth/api/call.rs
+++ b/crates/rpc/rpc/src/eth/api/call.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     eth::{
-        error::{EthApiError, EthResult, InvalidTransactionError, RevertError},
+        error::{ensure_success, EthApiError, EthResult, InvalidTransactionError, RevertError},
         revm_utils::{
             build_call_evm_env, cap_tx_gas_limit_with_caller_allowance, get_precompiles, inspect,
             transact,
@@ -13,13 +13,13 @@ use crate::{
 };
 use ethers_core::utils::get_contract_address;
 use reth_network_api::NetworkInfo;
-use reth_primitives::{AccessList, BlockId, BlockNumberOrTag, U256};
+use reth_primitives::{AccessList, BlockId, BlockNumberOrTag, Bytes, U256};
 use reth_provider::{BlockProviderIdExt, EvmEnvProvider, StateProvider, StateProviderFactory};
 use reth_revm::{
     access_list::AccessListInspector,
     database::{State, SubState},
 };
-use reth_rpc_types::CallRequest;
+use reth_rpc_types::{state::StateOverride, CallRequest};
 use reth_transaction_pool::TransactionPool;
 use revm::{
     db::{CacheDB, DatabaseRef},
@@ -46,6 +46,24 @@ where
         let (cfg, block_env, at) = self.evm_env_at(at).await?;
         let state = self.state_at(at)?;
         self.estimate_gas_with(cfg, block_env, request, state)
+    }
+
+    /// Executes the call request (`eth_call`) and returns the output
+    pub(crate) async fn call(
+        &self,
+        request: CallRequest,
+        block_number: Option<BlockId>,
+        state_overrides: Option<StateOverride>,
+    ) -> EthResult<Bytes> {
+        let (res, _env) = self
+            .transact_call_at(
+                request,
+                block_number.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest)),
+                state_overrides,
+            )
+            .await?;
+
+        ensure_success(res.result)
     }
 
     /// Estimates the gas usage of the `request` with the state.

--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -126,6 +126,9 @@ where
     }
 
     /// Executes the future on a new blocking task.
+    ///
+    /// This accepts a closure that creates a new future using a clone of this type and spawns the
+    /// future onto a new task that is allowed to block.
     pub(crate) async fn on_blocking_task<C, F, R>(&self, c: C) -> EthResult<R>
     where
         C: FnOnce(Self) -> F,

--- a/crates/rpc/rpc/src/eth/api/state.rs
+++ b/crates/rpc/rpc/src/eth/api/state.rs
@@ -71,18 +71,15 @@ where
         Ok(U256::from(state.account_nonce(address)?.unwrap_or_default()))
     }
 
-    pub(crate) async fn storage_at(
+    pub(crate) fn storage_at(
         &self,
         address: Address,
         index: JsonStorageKey,
         block_id: Option<BlockId>,
     ) -> EthResult<H256> {
-        self.on_blocking_task(|this| async move {
-            let state = this.state_at_block_id_or_latest(block_id)?;
-            let value = state.storage(address, index.0)?.unwrap_or_default();
-            Ok(H256(value.to_be_bytes()))
-        })
-        .await
+        let state = self.state_at_block_id_or_latest(block_id)?;
+        let value = state.storage(address, index.0)?.unwrap_or_default();
+        Ok(H256(value.to_be_bytes()))
     }
 
     #[allow(unused)]
@@ -169,7 +166,7 @@ mod tests {
             GasPriceOracle::new(NoopProvider::default(), Default::default(), cache),
         );
         let address = Address::random();
-        let storage = eth_api.storage_at(address, U256::ZERO.into(), None).await.unwrap();
+        let storage = eth_api.storage_at(address, U256::ZERO.into(), None).unwrap();
         assert_eq!(storage, U256::ZERO.into());
 
         // === Mock ===
@@ -190,7 +187,7 @@ mod tests {
         );
 
         let storage_key: U256 = storage_key.into();
-        let storage = eth_api.storage_at(address, storage_key.into(), None).await.unwrap();
+        let storage = eth_api.storage_at(address, storage_key.into(), None).unwrap();
         assert_eq!(storage, storage_value.into());
     }
 }

--- a/crates/rpc/rpc/src/lib.rs
+++ b/crates/rpc/rpc/src/lib.rs
@@ -18,11 +18,11 @@
 //! and can reduce overall performance of all concurrent requests handled via the jsonrpsee server.
 //!
 //! To avoid this, all blocking or CPU intensive handlers must be spawned to a separate task. See
-//! the [EthApi] handler implementations for examples. The rpc-api traits make no use of the available
-//! jsonrpsee `blocking` attribute to give implementors more freedom because the `blocking` attribute
-//! and async handlers are mutually exclusive. However, as mentioned above, a lot of handlers make
-//! use of async functions, for example, for caching and are also using blocking disk-io, hence
-//! these calls are spawned as futures to a blocking task manually.
+//! the [EthApi] handler implementations for examples. The rpc-api traits make no use of the
+//! available jsonrpsee `blocking` attribute to give implementors more freedom because the
+//! `blocking` attribute and async handlers are mutually exclusive. However, as mentioned above, a
+//! lot of handlers make use of async functions, caching for example, but are also using blocking
+//! disk-io, hence these calls are spawned as futures to a blocking task manually.
 
 mod admin;
 mod call_guard;

--- a/crates/rpc/rpc/src/lib.rs
+++ b/crates/rpc/rpc/src/lib.rs
@@ -8,6 +8,21 @@
 //! Reth RPC implementation
 //!
 //! Provides the implementation of all RPC interfaces.
+//!
+//!
+//! ## Note on blocking behaviour
+//!
+//! All async RPC handlers must non-blocking, see also [What is blocking](https://ryhl.io/blog/async-what-is-blocking/).
+//!
+//! A lot of the RPC are using a mix of async and direct calls to the database, which are blocking
+//! and can reduce overall performance of all concurrent requests handled via the jsonrpsee server.
+//!
+//! To avoid this, all blocking or CPU intensive handler must be spawned to a separate task. See
+//! [EthApi] handler implementations for examples. The rpc-api traits make no use of the available
+//! jsonrpsee `blocking` attribute to give implementors more freedom because `blocking` attribute
+//! and async handlers are mutually exclusive. However, as mentioned above, a lot of handlers make
+//! use of async functions, for example, for caching and are also using blocking disk-io, hence
+//! these calls are spawned as futures to a blocking task manually.
 
 mod admin;
 mod call_guard;

--- a/crates/rpc/rpc/src/lib.rs
+++ b/crates/rpc/rpc/src/lib.rs
@@ -19,7 +19,7 @@
 //!
 //! To avoid this, all blocking or CPU intensive handlers must be spawned to a separate task. See
 //! [EthApi] handler implementations for examples. The rpc-api traits make no use of the available
-//! jsonrpsee `blocking` attribute to give implementors more freedom because `blocking` attribute
+//! jsonrpsee `blocking` attribute to give implementors more freedom because the `blocking` attribute
 //! and async handlers are mutually exclusive. However, as mentioned above, a lot of handlers make
 //! use of async functions, for example, for caching and are also using blocking disk-io, hence
 //! these calls are spawned as futures to a blocking task manually.

--- a/crates/rpc/rpc/src/lib.rs
+++ b/crates/rpc/rpc/src/lib.rs
@@ -18,7 +18,7 @@
 //! and can reduce overall performance of all concurrent requests handled via the jsonrpsee server.
 //!
 //! To avoid this, all blocking or CPU intensive handlers must be spawned to a separate task. See
-//! [EthApi] handler implementations for examples. The rpc-api traits make no use of the available
+//! the [EthApi] handler implementations for examples. The rpc-api traits make no use of the available
 //! jsonrpsee `blocking` attribute to give implementors more freedom because the `blocking` attribute
 //! and async handlers are mutually exclusive. However, as mentioned above, a lot of handlers make
 //! use of async functions, for example, for caching and are also using blocking disk-io, hence

--- a/crates/rpc/rpc/src/lib.rs
+++ b/crates/rpc/rpc/src/lib.rs
@@ -17,7 +17,7 @@
 //! A lot of the RPC are using a mix of async and direct calls to the database, which are blocking
 //! and can reduce overall performance of all concurrent requests handled via the jsonrpsee server.
 //!
-//! To avoid this, all blocking or CPU intensive handler must be spawned to a separate task. See
+//! To avoid this, all blocking or CPU intensive handlers must be spawned to a separate task. See
 //! [EthApi] handler implementations for examples. The rpc-api traits make no use of the available
 //! jsonrpsee `blocking` attribute to give implementors more freedom because `blocking` attribute
 //! and async handlers are mutually exclusive. However, as mentioned above, a lot of handlers make


### PR DESCRIPTION
spawn some additional calls onto tasks and add some docs on blocking behaviour
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4543905</samp>

This pull request refactors and extends the `EthApi` trait and its implementations to handle call requests and improve the performance of the RPC server. It also adds comments and documentation to explain the use of the `on_blocking_task` method and the principle of avoiding blocking behaviour in async Rust. It affects the files `crates/rpc/rpc/src/eth/api/call.rs`, `crates/rpc/rpc/src/eth/api/server.rs`, `crates/rpc/rpc/src/eth/api/state.rs`, `crates/interfaces/src/executor.rs`, `crates/rpc/rpc/src/eth/api/mod.rs`, and `crates/rpc/rpc/src/lib.rs`.