### PR TITLE
docs: update layout docs

### DIFF
--- a/docs/repo/layout.md
+++ b/docs/repo/layout.md
@@ -102,7 +102,7 @@ The RPC component mainly lives in [`rpc/rpc`](../../crates/rpc/rpc), which imple
 - `txpool_`
 - `web3_`
 
-The engine API (`engine_`) lives in [`rpc/rpc-engine-api`](../../crates/rpc/rpc-engine-api) (this is *not* an interface crate despite the confusing name).
+The engine API ([`engine_`][engine-spec]) lives in [`rpc/rpc-engine-api`](../../crates/rpc/rpc-engine-api) (this is *not* an interface crate despite the confusing name).
 
 There is also a crate to easily configure an RPC server: [`rpc/rpc-builder`](../../crates/rpc/rpc-builder).
 
@@ -153,3 +153,4 @@ Small utility crates.
 [jsonrpsee]: https://github.com/paritytech/jsonrpsee/
 [tracing]: https://crates.io/crates/tracing
 [eip-1459]: https://eips.ethereum.org/EIPS/eip-1459
+[engine-spec]: https://github.com/ethereum/execution-apis/tree/main/src/engine

--- a/docs/repo/layout.md
+++ b/docs/repo/layout.md
@@ -2,6 +2,18 @@
 
 This repository contains several Rust crates that implement the different building blocks of an Ethereum node. The high-level structure of the repository is as follows:
 
+Generally reth is composed of a few components, with supporting crates. The main components can be defined as:
+
+- [Storage](#storage)
+- [Networking](#networking)
+- [Consensus](#consensus)
+- [Execution](#execution)
+- [Sync](#sync)
+- [RPC](#rpc)
+- [Payloads](#payloads)
+
+The supporting crates are split into two categories: [primitives](#primitives) and [miscellaneous](#misc).
+
 ### Documentation
 
 Contributor documentation is in [`docs`](../../docs) and end-user documentation is in [`book`](../../book).
@@ -9,14 +21,6 @@ Contributor documentation is in [`docs`](../../docs) and end-user documentation 
 ### Binaries
 
 All binaries are stored in [`bin`](../../bin).
-
-### Primitives
-
-These crates define primitive types or algorithms such as RLP.
-
-- [`primitives`](../../crates/primitives): Commonly used types in Reth.
-- [`rlp`](../../crates/rlp): An implementation of RLP, forked from an earlier Apache-licensed version of [`fastrlp`][fastrlp]
-- [`rlp/rlp-derive`](../../crates/rlp/rlp-derive): Forked from an earlier Apache licenced version of the [`fastrlp-derive`][fastrlp-derive] crate, before it changed licence to GPL.
 
 ### Storage
 
@@ -28,55 +32,119 @@ These crates are related to the database.
   - Implemented backends: mdbx
 - [`storage/provider`](../../crates/storage/provider): Traits which provide a higher level api over the database to access the Ethereum state and historical data (transactions, blocks etc.)
 
+
 ### Networking
 
-These crates are related to networking (p2p and RPC), as well as networking protocols.
+These crates are related to networking (P2P).
+
+The networking component mainly lives in [`net/network`](../../crates/net/network), which handles:
+
+- Message egress/ingress
+- Peer management
+- Session management
+
+#### Common
 
 - [`net/common`](../../crates/net/common): Shared types used across multiple networking crates.
   - Contains: Peer banlist.
+- [`net/network-api`](../../crates/net/network-api): Contains traits that define the networking component as a whole. Other components that interface with the network stack only need to depend on this crate for the relevant types.
+- [`net/nat`](../../crates/net/nat): A small helper crate that resolves the external IP of the running node using various methods (such as a manually provided IP, using UPnP etc.)
 
+#### Discovery
 
-#### P2P
-
-- [`net/network`](../../crates/net/network): The main P2P networking crate, handling message egress, message ingress, peer management, and session management.
-- [`net/eth-wire`](../../crates/net/eth-wire): Implements the `eth` wire protocol and the RLPx networking stack.
 - [`net/discv4`](../../crates/net/discv4): An implementation of the [discv4][discv4] protocol
-- [`net/ipc`](../../crates/net/ipc): IPC server and client implementation for [`jsonrpsee`][jsonrpsee].
+- [`net/dns`](../../crates/net/dns): An implementation of node discovery via DNS ([EIP-1459][eip-1459])
+
+#### Protocol
+
+- [`net/eth-wire`](../../crates/net/eth-wire): Implements the `eth` wire protocol and the RLPx networking stack.
 - [`net/ecies`](../../crates/net/ecies): Implementation of the Elliptic Curve Integrated Encryption Scheme used in the RLPx handshake.
-
-#### RPC
-
-- [`net/rpc-api`](../../crates/rpc/rpc-api): RPC traits
-  - Supported transports: HTTP, WS, IPC
-  - Supported namespaces: `eth_`, `engine_`, `debug_`
-- [`net/rpc`](../../crates/rpc/rpc): Implementation of all ETH JSON RPC traits defined in `rpc-api`.
-- [`net/rpc-types`](../../crates/rpc/rpc-types): Types relevant for the RPC endpoints above, grouped by namespace
 
 #### Downloaders
 
-- [`net/downloaders`](../../crates/net/downloaders/): Block body and header downloading strategies.
+- [`net/downloaders`](../../crates/net/downloaders): Traits defining block body and header downloaders, as well as P2P implementations of both.
 
-### Ethereum
+### Consensus
 
-These crates are Ethereum-specific (e.g. EVM, consensus, transaction pools).
+Different consensus mechanisms.
 
-- [`executor`](../../crates/blockchain-tree): Blazing-fast instrumented EVM using [`revm`](https://github.com/bluealloy/revm/). Used during consensus, syncing & during transaction simulation / gas estimation.
-- [`consensus`](../../crates/consensus): Implementations of consensus protocols.
+- [`consensus/common`](../../crates/consensus/common): Common consensus functions and traits (e.g. fee calculation)
+- [`consensus/auto-seal`](../../crates/consensus/auto-seal): A consensus mechanism that auto-seals blocks for local development (also commonly known as "auto-mine")
+- [`consensus/beacon`](../../crates/consensus/beacon): Consensus mechanism that handles messages from a beacon node ("eth2")
+
+### Execution
+
+Crates related to transaction execution.
+
+- [`revm`](../../crates/revm): An implementation of an executor using `revm`
+- [`revm/revm-inspectors`](../../crates/revm/revm-inspectors): Various revm inspectors for debugging and building traces for the trace-related RPC APIs.
+- [`revm/revm-primitives`](../../crates/revm/revm-primitives): A crate for handling revm-reth type conversion
+
+### Sync
+
+These crates implement the main syncing drivers of reth.
+
+- [`blockchain-tree`](../../crates/blockchain-tree): A tree-like structure for handling multiple chains of unfinalized blocks. This is the main component during live sync (i.e. syncing at the tip)
+- [`stages`](../../crates/stages): A pipelined sync, including implementation of various stages. This is used during initial sync and is faster than the tree-like structure for longer sync ranges.
+- [`staged-sync`](../../crates/staged-sync): A catch-all for various things currently, to be removed
+
+### RPC
+
+Crates related to the RPC component (including JSONRPC and IPC transports)
+
+The RPC component mainly lives in [`rpc/rpc`](../../crates/rpc/rpc), which implements the following namespaces:
+
+- `admin_`
+- `debug_` (includes Geth-style tracing APIs)
+- `eth_`
+- `net_`
+- `trace_` (OpenEthereum-style tracing APIs)
+- `txpool_`
+- `web3_`
+
+The engine API (`engine_`) lives in [`rpc/rpc-engine-api`](../../crates/rpc/rpc-engine-api) (this is *not* an interface crate despite the confusing name).
+
+There is also a crate to easily configure an RPC server: [`rpc/rpc-builder`](../../crates/rpc/rpc-builder).
+
+#### Transports
+
+The RPC component is based on the `jsonrpsee` crate which provides JSONRPC over WebSockets and HTTP.
+
+The IPC transport lives in [`rpc/ipc`](../../crates/rpc/ipc).
+
+#### Common
+
+- [`rpc/rpc-api`](../../crates/rpc/rpc-api): RPC traits
+  - Supported transports: HTTP, WS, IPC
+  - Supported namespaces: `eth_`, `engine_`, `debug_`
+- [`rpc/rpc-types`](../../crates/rpc/rpc-types): Types relevant for the RPC endpoints above, grouped by namespace
+
+### Payloads
+
+Crates related to building and validating payloads (blocks).
+
 - [`transaction-pool`](../../crates/transaction-pool): An in-memory pending transactions pool.
+- [`payload/builder`](../../crates/payload/builder): Abstractions for payload building and a payload builder service that works with multiple kinds of payload resolvers.
+- [`payload/basic`](../../crates/payload/basic): A basic payload generator.
 
-### Staged sync
+### Primitives
 
-These crates are related to staged sync.
+These crates define primitive types or algorithms such as RLP.
 
-- [`stages`](../../crates/stages): The staged sync pipeline, including implementations of each stage.
+- [`primitives`](../../crates/primitives): Commonly used types in Reth.
+- [`rlp`](../../crates/rlp): An implementation of RLP, forked from an earlier Apache-licensed version of [`fastrlp`][fastrlp]
+- [`rlp/rlp-derive`](../../crates/rlp/rlp-derive): Forked from an earlier Apache licenced version of the [`fastrlp-derive`][fastrlp-derive] crate, before it changed licence to GPL.
+- [`trie`](../../crates/trie): An implementation of a Merkle Patricia Trie used for various roots (e.g. the state root) in Ethereum.
 
 ### Misc
 
 Small utility crates.
 
 - [`interfaces`](../../crates/interfaces): Traits containing common abstractions across the components used in the system. For ease of unit testing, each crate importing the interface is recommended to create mock/in-memory implementations of each trait.
+- [`tasks`](../../crates/tasks): An executor-agnostic task abstraction, used to spawn tasks on different async executors. Supports blocking tasks and handles panics gracefully. A tokio implementation is provided by default.
+- [`metrics/common`](../../crates/metrics/common): Common metrics types (e.g. metered channels)
+- [`metrics/metrics-derive`](../../crates/metrics/metrics-derive): A derive-style API for creating metrics
 - [`tracing`](../../crates/tracing): A small utility crate to install a uniform [`tracing`][tracing] subscriber
-- [`crate-template`](../../crate-template): Template crate to use when instantiating new crates under `crates/`.
 
 [fastrlp]: https://crates.io/crates/fastrlp
 [fastrlp-derive]: https://crates.io/crates/fastrlp-derive
@@ -84,3 +152,4 @@ Small utility crates.
 [discv4]: https://github.com/ethereum/devp2p/blob/master/discv4.md
 [jsonrpsee]: https://github.com/paritytech/jsonrpsee/
 [tracing]: https://crates.io/crates/tracing
+[eip-1459]: https://eips.ethereum.org/EIPS/eip-1459

--- a/docs/repo/layout.md
+++ b/docs/repo/layout.md
@@ -90,7 +90,7 @@ These crates implement the main syncing drivers of reth.
 
 ### RPC
 
-Crates related to the RPC component (including JSONRPC and IPC transports)
+Crates related to the RPC component (including IPC transport)
 
 The RPC component mainly lives in [`rpc/rpc`](../../crates/rpc/rpc), which implements the following namespaces:
 


### PR DESCRIPTION
We've removed and merged and split and added a lot of crates, but we have not been good at keeping the docs up to date.

This PR updates the layout docs (for contributors) to reflect the latest state of the repository (to the best of my knowledge)

[Rendered version](https://github.com/paradigmxyz/reth/blob/0b4c988d24be7570104d00d8fc8e6610635d0dc5/docs/repo/layout.md)