### PR TITLE
chore: rename Error to DatabaseError

### DIFF
--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -514,7 +514,10 @@ impl Command {
         Ok(handle)
     }
 
-    fn lookup_head(&self, db: Arc<Env<WriteMap>>) -> Result<Head, reth_interfaces::db::Error> {
+    fn lookup_head(
+        &self,
+        db: Arc<Env<WriteMap>>,
+    ) -> Result<Head, reth_interfaces::db::DatabaseError> {
         db.view(|tx| {
             let head = FINISH.get_progress(tx)?.unwrap_or_default();
             let header = tx
@@ -526,7 +529,7 @@ impl Command {
             let hash = tx
                 .get::<tables::CanonicalHeaders>(head)?
                 .expect("the hash for the latest block is missing, database is corrupt");
-            Ok::<Head, reth_interfaces::db::Error>(Head {
+            Ok::<Head, reth_interfaces::db::DatabaseError>(Head {
                 number: head,
                 hash,
                 difficulty: header.difficulty,
@@ -567,7 +570,7 @@ impl Command {
         DB: Database,
         Client: HeadersClient,
     {
-        let header = db.view(|tx| -> Result<Option<Header>, reth_db::Error> {
+        let header = db.view(|tx| -> Result<Option<Header>, reth_db::DatabaseError> {
             let number = match tip {
                 BlockHashOrNumber::Hash(hash) => tx.get::<tables::HeaderNumbers>(hash)?,
                 BlockHashOrNumber::Number(number) => Some(number),

--- a/bin/reth/src/test_eth_chain/runner.rs
+++ b/bin/reth/src/test_eth_chain/runner.rs
@@ -7,7 +7,7 @@ use reth_db::{
     mdbx::test_utils::create_test_rw_db,
     tables,
     transaction::{DbTx, DbTxMut},
-    Error as DbError,
+    DatabaseError as DbError,
 };
 use reth_primitives::{
     keccak256, Account as RethAccount, Address, Bytecode, ChainSpec, JsonU256, SealedBlock,

--- a/crates/consensus/beacon/src/engine/error.rs
+++ b/crates/consensus/beacon/src/engine/error.rs
@@ -29,8 +29,8 @@ impl From<PipelineError> for BeaconConsensusEngineError {
 }
 
 // for convenience in the beacon engine
-impl From<reth_interfaces::db::Error> for BeaconConsensusEngineError {
-    fn from(e: reth_interfaces::db::Error) -> Self {
+impl From<reth_interfaces::db::DatabaseError> for BeaconConsensusEngineError {
+    fn from(e: reth_interfaces::db::DatabaseError) -> Self {
         Self::Common(e.into())
     }
 }
@@ -57,8 +57,8 @@ impl From<reth_interfaces::Error> for BeaconForkChoiceUpdateError {
         Self::Internal(Box::new(e))
     }
 }
-impl From<reth_interfaces::db::Error> for BeaconForkChoiceUpdateError {
-    fn from(e: reth_interfaces::db::Error) -> Self {
+impl From<reth_interfaces::db::DatabaseError> for BeaconForkChoiceUpdateError {
+    fn from(e: reth_interfaces::db::DatabaseError) -> Self {
         Self::Internal(Box::new(e.into()))
     }
 }

--- a/crates/interfaces/src/db.rs
+++ b/crates/interfaces/src/db.rs
@@ -1,6 +1,6 @@
 /// Database error type. They are using u32 to represent error code.
 #[derive(Debug, thiserror::Error, PartialEq, Eq, Clone)]
-pub enum Error {
+pub enum DatabaseError {
     /// Failed to open database.
     #[error("Failed to open database: {0:?}")]
     FailedToOpen(i32),

--- a/crates/interfaces/src/error.rs
+++ b/crates/interfaces/src/error.rs
@@ -12,7 +12,7 @@ pub enum Error {
     Consensus(#[from] crate::consensus::ConsensusError),
 
     #[error(transparent)]
-    Database(#[from] crate::db::Error),
+    Database(#[from] crate::db::DatabaseError),
 
     #[error(transparent)]
     Provider(#[from] crate::provider::ProviderError),

--- a/crates/interfaces/src/p2p/error.rs
+++ b/crates/interfaces/src/p2p/error.rs
@@ -214,7 +214,7 @@ pub enum DownloadError {
     RequestError(#[from] RequestError),
     /// Error while reading data from database.
     #[error(transparent)]
-    DatabaseError(#[from] db::Error),
+    DatabaseError(#[from] db::DatabaseError),
 }
 
 #[cfg(test)]

--- a/crates/net/downloaders/src/bodies/test_utils.rs
+++ b/crates/net/downloaders/src/bodies/test_utils.rs
@@ -47,7 +47,7 @@ pub(crate) fn create_raw_bodies<'a>(
 
 #[inline]
 pub(crate) fn insert_headers(db: &Env<WriteMap>, headers: &[SealedHeader]) {
-    db.update(|tx| -> Result<(), db::Error> {
+    db.update(|tx| -> Result<(), db::DatabaseError> {
         for header in headers {
             tx.put::<tables::CanonicalHeaders>(header.number, header.hash())?;
             tx.put::<tables::Headers>(header.number, header.clone().unseal())?;

--- a/crates/staged-sync/src/utils/init.rs
+++ b/crates/staged-sync/src/utils/init.rs
@@ -38,7 +38,7 @@ pub enum InitDatabaseError {
 
     /// Low-level database error.
     #[error(transparent)]
-    DBError(#[from] reth_db::Error),
+    DBError(#[from] reth_db::DatabaseError),
 }
 
 /// Write the genesis block if it has not already been written

--- a/crates/stages/benches/setup/account_hashing.rs
+++ b/crates/stages/benches/setup/account_hashing.rs
@@ -1,6 +1,6 @@
 use super::{constants, StageRange};
 use reth_db::{
-    cursor::DbCursorRO, database::Database, tables, transaction::DbTx, Error as DbError,
+    cursor::DbCursorRO, database::Database, tables, transaction::DbTx, DatabaseError as DbError,
 };
 use reth_stages::{
     stages::{AccountHashingStage, SeedOpts},

--- a/crates/stages/src/error.rs
+++ b/crates/stages/src/error.rs
@@ -1,6 +1,7 @@
 use crate::pipeline::PipelineEvent;
 use reth_interfaces::{
-    consensus, db::Error as DbError, executor, p2p::error::DownloadError, provider::ProviderError,
+    consensus, db::DatabaseError as DbError, executor, p2p::error::DownloadError,
+    provider::ProviderError,
 };
 use reth_primitives::BlockNumber;
 use reth_provider::TransactionError;

--- a/crates/stages/src/id.rs
+++ b/crates/stages/src/id.rs
@@ -6,7 +6,7 @@ use crate::stages::{
 use reth_db::{
     tables::SyncStage,
     transaction::{DbTx, DbTxMut},
-    Error as DbError,
+    DatabaseError as DbError,
 };
 use reth_primitives::BlockNumber;
 use std::fmt::Display;

--- a/crates/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/src/stages/hashing_storage.rs
@@ -420,7 +420,7 @@ mod tests {
                 let block_number = progress.number;
                 self.tx.commit(|tx| {
                     progress.body.iter().try_for_each(
-                        |transaction| -> Result<(), reth_db::Error> {
+                        |transaction| -> Result<(), reth_db::DatabaseError> {
                             tx.put::<tables::TxHashNumber>(transaction.hash(), next_tx_num)?;
                             tx.put::<tables::Transactions>(
                                 next_tx_num,
@@ -543,7 +543,7 @@ mod tests {
             tid_address: BlockNumberAddress,
             entry: StorageEntry,
             hash: bool,
-        ) -> Result<(), reth_db::Error> {
+        ) -> Result<(), reth_db::DatabaseError> {
             let mut storage_cursor = tx.cursor_dup_write::<tables::PlainStorageState>()?;
             let prev_entry =
                 match storage_cursor.seek_by_key_subkey(tid_address.address(), entry.key)? {

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -101,7 +101,7 @@ impl<DB: Database> Stage<DB> for SenderRecoveryStage {
             // closure that would recover signer. Used as utility to wrap result
             let recover = |entry: Result<
                 (RawKey<TxNumber>, RawValue<TransactionSignedNoHash>),
-                reth_db::Error,
+                reth_db::DatabaseError,
             >,
                            rlp_buf: &mut Vec<u8>|
              -> Result<(u64, H160), Box<StageError>> {

--- a/crates/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/src/stages/tx_lookup.rs
@@ -89,7 +89,7 @@ impl<DB: Database> Stage<DB> for TransactionLookupStage {
 
             // closure that will calculate the TxHash
             let calculate_hash =
-                |entry: Result<(TxNumber, TransactionSignedNoHash), reth_db::Error>,
+                |entry: Result<(TxNumber, TransactionSignedNoHash), reth_db::DatabaseError>,
                  rlp_buf: &mut Vec<u8>|
                  -> Result<(H256, u64), Box<StageError>> {
                     let (tx_id, tx) = entry.map_err(|e| Box::new(e.into()))?;

--- a/crates/stages/src/test_utils/runner.rs
+++ b/crates/stages/src/test_utils/runner.rs
@@ -8,7 +8,7 @@ use tokio::sync::oneshot;
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum TestRunnerError {
     #[error("Database error occurred.")]
-    Database(#[from] reth_interfaces::db::Error),
+    Database(#[from] reth_interfaces::db::DatabaseError),
     #[error("Internal runner error occurred.")]
     Internal(#[from] Box<dyn std::error::Error>),
 }

--- a/crates/stages/src/test_utils/test_db.rs
+++ b/crates/stages/src/test_utils/test_db.rs
@@ -10,7 +10,7 @@ use reth_db::{
     table::Table,
     tables,
     transaction::{DbTx, DbTxMut},
-    Error as DbError,
+    DatabaseError as DbError,
 };
 use reth_primitives::{
     keccak256, Account, Address, BlockNumber, SealedBlock, SealedHeader, StorageEntry, H256, U256,

--- a/crates/storage/db/src/abstraction/common.rs
+++ b/crates/storage/db/src/abstraction/common.rs
@@ -5,18 +5,18 @@ pub type KeyValue<T> = (<T as Table>::Key, <T as Table>::Value);
 ///
 /// The `Result` represents that the operation might fail, while the `Option` represents whether or
 /// not the entry exists.
-pub type PairResult<T> = Result<Option<KeyValue<T>>, Error>;
+pub type PairResult<T> = Result<Option<KeyValue<T>>, DatabaseError>;
 
 /// A key-value pair coming from an iterator.
 ///
 /// The `Result` represents that the operation might fail, while the `Option` represents whether or
 /// not there is another entry.
-pub type IterPairResult<T> = Option<Result<KeyValue<T>, Error>>;
+pub type IterPairResult<T> = Option<Result<KeyValue<T>, DatabaseError>>;
 
 /// A value only result for table `T`.
-pub type ValueOnlyResult<T> = Result<Option<<T as Table>::Value>, Error>;
+pub type ValueOnlyResult<T> = Result<Option<<T as Table>::Value>, DatabaseError>;
 
-use crate::{abstraction::table::*, Error};
+use crate::{abstraction::table::*, DatabaseError};
 
 // Sealed trait helper to prevent misuse of the API.
 mod sealed {

--- a/crates/storage/db/src/abstraction/mock.rs
+++ b/crates/storage/db/src/abstraction/mock.rs
@@ -10,7 +10,7 @@ use crate::{
     database::{Database, DatabaseGAT},
     table::{DupSort, Table, TableImporter},
     transaction::{DbTx, DbTxGAT, DbTxMut, DbTxMutGAT},
-    Error,
+    DatabaseError,
 };
 
 /// Mock database used for testing with inner BTreeMap structure
@@ -22,11 +22,11 @@ pub struct DatabaseMock {
 }
 
 impl Database for DatabaseMock {
-    fn tx(&self) -> Result<<Self as DatabaseGAT<'_>>::TX, Error> {
+    fn tx(&self) -> Result<<Self as DatabaseGAT<'_>>::TX, DatabaseError> {
         Ok(TxMock::default())
     }
 
-    fn tx_mut(&self) -> Result<<Self as DatabaseGAT<'_>>::TXMut, Error> {
+    fn tx_mut(&self) -> Result<<Self as DatabaseGAT<'_>>::TXMut, DatabaseError> {
         Ok(TxMock::default())
     }
 }
@@ -55,11 +55,11 @@ impl<'a> DbTxMutGAT<'a> for TxMock {
 }
 
 impl<'a> DbTx<'a> for TxMock {
-    fn get<T: Table>(&self, _key: T::Key) -> Result<Option<T::Value>, Error> {
+    fn get<T: Table>(&self, _key: T::Key) -> Result<Option<T::Value>, DatabaseError> {
         todo!()
     }
 
-    fn commit(self) -> Result<bool, Error> {
+    fn commit(self) -> Result<bool, DatabaseError> {
         todo!()
     }
 
@@ -67,35 +67,43 @@ impl<'a> DbTx<'a> for TxMock {
         todo!()
     }
 
-    fn cursor_read<T: Table>(&self) -> Result<<Self as DbTxGAT<'_>>::Cursor<T>, Error> {
+    fn cursor_read<T: Table>(&self) -> Result<<Self as DbTxGAT<'_>>::Cursor<T>, DatabaseError> {
         todo!()
     }
 
-    fn cursor_dup_read<T: DupSort>(&self) -> Result<<Self as DbTxGAT<'_>>::DupCursor<T>, Error> {
+    fn cursor_dup_read<T: DupSort>(
+        &self,
+    ) -> Result<<Self as DbTxGAT<'_>>::DupCursor<T>, DatabaseError> {
         todo!()
     }
 }
 
 impl<'a> DbTxMut<'a> for TxMock {
-    fn put<T: Table>(&self, _key: T::Key, _value: T::Value) -> Result<(), Error> {
+    fn put<T: Table>(&self, _key: T::Key, _value: T::Value) -> Result<(), DatabaseError> {
         todo!()
     }
 
-    fn delete<T: Table>(&self, _key: T::Key, _value: Option<T::Value>) -> Result<bool, Error> {
+    fn delete<T: Table>(
+        &self,
+        _key: T::Key,
+        _value: Option<T::Value>,
+    ) -> Result<bool, DatabaseError> {
         todo!()
     }
 
-    fn cursor_write<T: Table>(&self) -> Result<<Self as DbTxMutGAT<'_>>::CursorMut<T>, Error> {
+    fn cursor_write<T: Table>(
+        &self,
+    ) -> Result<<Self as DbTxMutGAT<'_>>::CursorMut<T>, DatabaseError> {
         todo!()
     }
 
     fn cursor_dup_write<T: DupSort>(
         &self,
-    ) -> Result<<Self as DbTxMutGAT<'_>>::DupCursorMut<T>, Error> {
+    ) -> Result<<Self as DbTxMutGAT<'_>>::DupCursorMut<T>, DatabaseError> {
         todo!()
     }
 
-    fn clear<T: Table>(&self) -> Result<(), Error> {
+    fn clear<T: Table>(&self) -> Result<(), DatabaseError> {
         todo!()
     }
 }
@@ -139,7 +147,7 @@ impl<'tx, T: Table> DbCursorRO<'tx, T> for CursorMock {
     fn walk<'cursor>(
         &'cursor mut self,
         _start_key: Option<T::Key>,
-    ) -> Result<Walker<'cursor, 'tx, T, Self>, Error>
+    ) -> Result<Walker<'cursor, 'tx, T, Self>, DatabaseError>
     where
         Self: Sized,
     {
@@ -149,7 +157,7 @@ impl<'tx, T: Table> DbCursorRO<'tx, T> for CursorMock {
     fn walk_range<'cursor>(
         &'cursor mut self,
         _range: impl RangeBounds<T::Key>,
-    ) -> Result<RangeWalker<'cursor, 'tx, T, Self>, Error>
+    ) -> Result<RangeWalker<'cursor, 'tx, T, Self>, DatabaseError>
     where
         Self: Sized,
     {
@@ -159,7 +167,7 @@ impl<'tx, T: Table> DbCursorRO<'tx, T> for CursorMock {
     fn walk_back<'cursor>(
         &'cursor mut self,
         _start_key: Option<T::Key>,
-    ) -> Result<ReverseWalker<'cursor, 'tx, T, Self>, Error>
+    ) -> Result<ReverseWalker<'cursor, 'tx, T, Self>, DatabaseError>
     where
         Self: Sized,
     {
@@ -192,7 +200,7 @@ impl<'tx, T: DupSort> DbDupCursorRO<'tx, T> for CursorMock {
         &'cursor mut self,
         _key: Option<<T>::Key>,
         _subkey: Option<<T as DupSort>::SubKey>,
-    ) -> Result<DupWalker<'cursor, 'tx, T, Self>, Error>
+    ) -> Result<DupWalker<'cursor, 'tx, T, Self>, DatabaseError>
     where
         Self: Sized,
     {
@@ -205,7 +213,7 @@ impl<'tx, T: Table> DbCursorRW<'tx, T> for CursorMock {
         &mut self,
         _key: <T as Table>::Key,
         _value: <T as Table>::Value,
-    ) -> Result<(), Error> {
+    ) -> Result<(), DatabaseError> {
         todo!()
     }
 
@@ -213,7 +221,7 @@ impl<'tx, T: Table> DbCursorRW<'tx, T> for CursorMock {
         &mut self,
         _key: <T as Table>::Key,
         _value: <T as Table>::Value,
-    ) -> Result<(), Error> {
+    ) -> Result<(), DatabaseError> {
         todo!()
     }
 
@@ -221,21 +229,21 @@ impl<'tx, T: Table> DbCursorRW<'tx, T> for CursorMock {
         &mut self,
         _key: <T as Table>::Key,
         _value: <T as Table>::Value,
-    ) -> Result<(), Error> {
+    ) -> Result<(), DatabaseError> {
         todo!()
     }
 
-    fn delete_current(&mut self) -> Result<(), Error> {
+    fn delete_current(&mut self) -> Result<(), DatabaseError> {
         todo!()
     }
 }
 
 impl<'tx, T: DupSort> DbDupCursorRW<'tx, T> for CursorMock {
-    fn delete_current_duplicates(&mut self) -> Result<(), Error> {
+    fn delete_current_duplicates(&mut self) -> Result<(), DatabaseError> {
         todo!()
     }
 
-    fn append_dup(&mut self, _key: <T>::Key, _value: <T>::Value) -> Result<(), Error> {
+    fn append_dup(&mut self, _key: <T>::Key, _value: <T>::Value) -> Result<(), DatabaseError> {
         todo!()
     }
 }

--- a/crates/storage/db/src/abstraction/transaction.rs
+++ b/crates/storage/db/src/abstraction/transaction.rs
@@ -2,7 +2,7 @@ use crate::{
     common::{Bounds, Sealed},
     cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO, DbDupCursorRW},
     table::{DupSort, Table},
-    Error,
+    DatabaseError,
 };
 
 /// Implements the GAT method from:
@@ -35,30 +35,35 @@ pub trait DbTxMutGAT<'a, __ImplicitBounds: Sealed = Bounds<&'a Self>>: Send + Sy
 /// Read only transaction
 pub trait DbTx<'tx>: for<'a> DbTxGAT<'a> {
     /// Get value
-    fn get<T: Table>(&self, key: T::Key) -> Result<Option<T::Value>, Error>;
+    fn get<T: Table>(&self, key: T::Key) -> Result<Option<T::Value>, DatabaseError>;
     /// Commit for read only transaction will consume and free transaction and allows
     /// freeing of memory pages
-    fn commit(self) -> Result<bool, Error>;
+    fn commit(self) -> Result<bool, DatabaseError>;
     /// Drops transaction
     fn drop(self);
     /// Iterate over read only values in table.
-    fn cursor_read<T: Table>(&self) -> Result<<Self as DbTxGAT<'_>>::Cursor<T>, Error>;
+    fn cursor_read<T: Table>(&self) -> Result<<Self as DbTxGAT<'_>>::Cursor<T>, DatabaseError>;
     /// Iterate over read only values in dup sorted table.
-    fn cursor_dup_read<T: DupSort>(&self) -> Result<<Self as DbTxGAT<'_>>::DupCursor<T>, Error>;
+    fn cursor_dup_read<T: DupSort>(
+        &self,
+    ) -> Result<<Self as DbTxGAT<'_>>::DupCursor<T>, DatabaseError>;
 }
 
 /// Read write transaction that allows writing to database
 pub trait DbTxMut<'tx>: for<'a> DbTxMutGAT<'a> {
     /// Put value to database
-    fn put<T: Table>(&self, key: T::Key, value: T::Value) -> Result<(), Error>;
+    fn put<T: Table>(&self, key: T::Key, value: T::Value) -> Result<(), DatabaseError>;
     /// Delete value from database
-    fn delete<T: Table>(&self, key: T::Key, value: Option<T::Value>) -> Result<bool, Error>;
+    fn delete<T: Table>(&self, key: T::Key, value: Option<T::Value>)
+        -> Result<bool, DatabaseError>;
     /// Clears database.
-    fn clear<T: Table>(&self) -> Result<(), Error>;
+    fn clear<T: Table>(&self) -> Result<(), DatabaseError>;
     /// Cursor mut
-    fn cursor_write<T: Table>(&self) -> Result<<Self as DbTxMutGAT<'_>>::CursorMut<T>, Error>;
+    fn cursor_write<T: Table>(
+        &self,
+    ) -> Result<<Self as DbTxMutGAT<'_>>::CursorMut<T>, DatabaseError>;
     /// DupCursor mut.
     fn cursor_dup_write<T: DupSort>(
         &self,
-    ) -> Result<<Self as DbTxMutGAT<'_>>::DupCursorMut<T>, Error>;
+    ) -> Result<<Self as DbTxMutGAT<'_>>::DupCursorMut<T>, DatabaseError>;
 }

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     database::{Database, DatabaseGAT},
     tables::{TableType, TABLES},
     utils::default_page_size,
-    Error,
+    DatabaseError,
 };
 use reth_libmdbx::{
     DatabaseFlags, Environment, EnvironmentFlags, EnvironmentKind, Geometry, Mode, PageSize,
@@ -39,12 +39,16 @@ impl<'a, E: EnvironmentKind> DatabaseGAT<'a> for Env<E> {
 }
 
 impl<E: EnvironmentKind> Database for Env<E> {
-    fn tx(&self) -> Result<<Self as DatabaseGAT<'_>>::TX, Error> {
-        Ok(Tx::new(self.inner.begin_ro_txn().map_err(|e| Error::InitTransaction(e.into()))?))
+    fn tx(&self) -> Result<<Self as DatabaseGAT<'_>>::TX, DatabaseError> {
+        Ok(Tx::new(
+            self.inner.begin_ro_txn().map_err(|e| DatabaseError::InitTransaction(e.into()))?,
+        ))
     }
 
-    fn tx_mut(&self) -> Result<<Self as DatabaseGAT<'_>>::TXMut, Error> {
-        Ok(Tx::new(self.inner.begin_rw_txn().map_err(|e| Error::InitTransaction(e.into()))?))
+    fn tx_mut(&self) -> Result<<Self as DatabaseGAT<'_>>::TXMut, DatabaseError> {
+        Ok(Tx::new(
+            self.inner.begin_rw_txn().map_err(|e| DatabaseError::InitTransaction(e.into()))?,
+        ))
     }
 }
 
@@ -55,7 +59,7 @@ impl<E: EnvironmentKind> Env<E> {
     /// Opens the database at the specified path with the given `EnvKind`.
     ///
     /// It does not create the tables, for that call [`Env::create_tables`].
-    pub fn open(path: &Path, kind: EnvKind) -> Result<Env<E>, Error> {
+    pub fn open(path: &Path, kind: EnvKind) -> Result<Env<E>, DatabaseError> {
         let mode = match kind {
             EnvKind::RO => Mode::ReadOnly,
             EnvKind::RW => Mode::ReadWrite { sync_mode: SyncMode::Durable },
@@ -82,15 +86,15 @@ impl<E: EnvironmentKind> Env<E> {
                     ..Default::default()
                 })
                 .open(path)
-                .map_err(|e| Error::FailedToOpen(e.into()))?,
+                .map_err(|e| DatabaseError::FailedToOpen(e.into()))?,
         };
 
         Ok(env)
     }
 
     /// Creates all the defined tables, if necessary.
-    pub fn create_tables(&self) -> Result<(), Error> {
-        let tx = self.inner.begin_rw_txn().map_err(|e| Error::InitTransaction(e.into()))?;
+    pub fn create_tables(&self) -> Result<(), DatabaseError> {
+        let tx = self.inner.begin_rw_txn().map_err(|e| DatabaseError::InitTransaction(e.into()))?;
 
         for (table_type, table) in TABLES {
             let flags = match table_type {
@@ -98,10 +102,10 @@ impl<E: EnvironmentKind> Env<E> {
                 TableType::DupSort => DatabaseFlags::DUP_SORT,
             };
 
-            tx.create_db(Some(table), flags).map_err(|e| Error::TableCreation(e.into()))?;
+            tx.create_db(Some(table), flags).map_err(|e| DatabaseError::TableCreation(e.into()))?;
         }
 
-        tx.commit().map_err(|e| Error::Commit(e.into()))?;
+        tx.commit().map_err(|e| DatabaseError::Commit(e.into()))?;
 
         Ok(())
     }
@@ -158,7 +162,7 @@ mod tests {
         models::{AccountBeforeTx, ShardedKey},
         tables::{AccountHistory, CanonicalHeaders, Headers, PlainAccountState, PlainStorageState},
         transaction::{DbTx, DbTxMut},
-        AccountChangeSet, Error,
+        AccountChangeSet, DatabaseError,
     };
     use reth_libmdbx::{NoWriteMap, WriteMap};
     use reth_primitives::{Account, Address, Header, IntegerList, StorageEntry, H160, H256, U256};
@@ -504,7 +508,7 @@ mod tests {
         assert_eq!(cursor.current(), Ok(Some((key_to_insert, H256::zero()))));
 
         // INSERT (failure)
-        assert_eq!(cursor.insert(key_to_insert, H256::zero()), Err(Error::Write(-30799)));
+        assert_eq!(cursor.insert(key_to_insert, H256::zero()), Err(DatabaseError::Write(-30799)));
         assert_eq!(cursor.current(), Ok(Some((key_to_insert, H256::zero()))));
 
         tx.commit().expect(ERROR_COMMIT);
@@ -639,7 +643,7 @@ mod tests {
         let key_to_append = 2;
         let tx = db.tx_mut().expect(ERROR_INIT_TX);
         let mut cursor = tx.cursor_write::<CanonicalHeaders>().unwrap();
-        assert_eq!(cursor.append(key_to_append, H256::zero()), Err(Error::Write(-30418)));
+        assert_eq!(cursor.append(key_to_append, H256::zero()), Err(DatabaseError::Write(-30418)));
         assert_eq!(cursor.current(), Ok(Some((5, H256::zero())))); // the end of table
         tx.commit().expect(ERROR_COMMIT);
 
@@ -714,14 +718,14 @@ mod tests {
                 transition_id,
                 AccountBeforeTx { address: Address::from_low_u64_be(subkey_to_append), info: None }
             ),
-            Err(Error::Write(-30418))
+            Err(DatabaseError::Write(-30418))
         );
         assert_eq!(
             cursor.append(
                 transition_id - 1,
                 AccountBeforeTx { address: Address::from_low_u64_be(subkey_to_append), info: None }
             ),
-            Err(Error::Write(-30418))
+            Err(DatabaseError::Write(-30418))
         );
         assert_eq!(
             cursor.append(

--- a/crates/storage/db/src/lib.rs
+++ b/crates/storage/db/src/lib.rs
@@ -77,5 +77,5 @@ pub mod mdbx {
 }
 
 pub use abstraction::*;
-pub use reth_interfaces::db::Error;
+pub use reth_interfaces::db::DatabaseError;
 pub use tables::*;

--- a/crates/storage/db/src/tables/codecs/compact.rs
+++ b/crates/storage/db/src/tables/codecs/compact.rs
@@ -1,7 +1,6 @@
 use crate::{
     table::{Compress, Decompress},
     tables::models::*,
-    Error,
 };
 use reth_codecs::{main_codec, Compact};
 use reth_primitives::{trie::*, *};
@@ -21,7 +20,7 @@ macro_rules! impl_compression_for_compact {
 
             impl Decompress for $name
             {
-                fn decompress<B: AsRef<[u8]>>(value: B) -> Result<$name, Error> {
+                fn decompress<B: AsRef<[u8]>>(value: B) -> Result<$name, $crate::DatabaseError> {
                     let value = value.as_ref();
                     let (obj, _) = Compact::from_compact(&value, value.len());
                     Ok(obj)
@@ -68,7 +67,7 @@ macro_rules! impl_compression_fixed_compact {
 
             impl Decompress for $name
             {
-                fn decompress<B: AsRef<[u8]>>(value: B) -> Result<$name, Error> {
+                fn decompress<B: AsRef<[u8]>>(value: B) -> Result<$name, $crate::DatabaseError> {
                     let value = value.as_ref();
                     let (obj, _) = Compact::from_compact(&value, value.len());
                     Ok(obj)

--- a/crates/storage/db/src/tables/codecs/postcard.rs
+++ b/crates/storage/db/src/tables/codecs/postcard.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     table::{Decode, Encode},
-    Error,
+    DatabaseError,
 };
 use postcard::{from_bytes, to_allocvec, to_vec};
 use reth_primitives::*;

--- a/crates/storage/db/src/tables/codecs/scale.rs
+++ b/crates/storage/db/src/tables/codecs/scale.rs
@@ -1,6 +1,6 @@
 use crate::{
     table::{Compress, Decompress},
-    Error,
+    DatabaseError,
 };
 use reth_primitives::*;
 
@@ -30,8 +30,9 @@ impl<T> Decompress for T
 where
     T: ScaleValue + parity_scale_codec::Decode + Sync + Send + std::fmt::Debug,
 {
-    fn decompress<B: AsRef<[u8]>>(value: B) -> Result<T, Error> {
-        parity_scale_codec::Decode::decode(&mut value.as_ref()).map_err(|_| Error::DecodeError)
+    fn decompress<B: AsRef<[u8]>>(value: B) -> Result<T, DatabaseError> {
+        parity_scale_codec::Decode::decode(&mut value.as_ref())
+            .map_err(|_| DatabaseError::DecodeError)
     }
 }
 

--- a/crates/storage/db/src/tables/models/accounts.rs
+++ b/crates/storage/db/src/tables/models/accounts.rs
@@ -5,7 +5,7 @@ use std::ops::{Range, RangeInclusive};
 use crate::{
     impl_fixed_arbitrary,
     table::{Decode, Encode},
-    Error,
+    DatabaseError,
 };
 use bytes::Buf;
 use reth_codecs::{derive_arbitrary, Compact};
@@ -113,9 +113,10 @@ impl Encode for BlockNumberAddress {
 }
 
 impl Decode for BlockNumberAddress {
-    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, Error> {
+    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, DatabaseError> {
         let value = value.as_ref();
-        let num = u64::from_be_bytes(value[..8].try_into().map_err(|_| Error::DecodeError)?);
+        let num =
+            u64::from_be_bytes(value[..8].try_into().map_err(|_| DatabaseError::DecodeError)?);
         let hash = Address::from_slice(&value[8..]);
 
         Ok(BlockNumberAddress((num, hash)))

--- a/crates/storage/db/src/tables/models/integer_list.rs
+++ b/crates/storage/db/src/tables/models/integer_list.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     table::{Compress, Decompress},
-    Error,
+    DatabaseError,
 };
 use reth_primitives::IntegerList;
 
@@ -18,7 +18,7 @@ impl Compress for IntegerList {
 }
 
 impl Decompress for IntegerList {
-    fn decompress<B: AsRef<[u8]>>(value: B) -> Result<Self, Error> {
-        IntegerList::from_bytes(value.as_ref()).map_err(|_| Error::DecodeError)
+    fn decompress<B: AsRef<[u8]>>(value: B) -> Result<Self, DatabaseError> {
+        IntegerList::from_bytes(value.as_ref()).map_err(|_| DatabaseError::DecodeError)
     }
 }

--- a/crates/storage/db/src/tables/models/mod.rs
+++ b/crates/storage/db/src/tables/models/mod.rs
@@ -1,7 +1,7 @@
 //! Implements data structures specific to the database
 use crate::{
     table::{Decode, Encode},
-    Error,
+    DatabaseError,
 };
 use reth_codecs::Compact;
 use reth_primitives::{
@@ -34,10 +34,10 @@ macro_rules! impl_uints {
 
             impl Decode for $name
             {
-                fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, Error> {
+                fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, $crate::DatabaseError> {
                     Ok(
                         $name::from_be_bytes(
-                            value.as_ref().try_into().map_err(|_| Error::DecodeError)?
+                            value.as_ref().try_into().map_err(|_| $crate::DatabaseError::DecodeError)?
                         )
                     )
                 }
@@ -56,7 +56,7 @@ impl Encode for Vec<u8> {
 }
 
 impl Decode for Vec<u8> {
-    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, Error> {
+    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, DatabaseError> {
         Ok(value.as_ref().to_vec())
     }
 }
@@ -69,7 +69,7 @@ impl Encode for Address {
 }
 
 impl Decode for Address {
-    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, Error> {
+    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, DatabaseError> {
         Ok(Address::from_slice(value.as_ref()))
     }
 }
@@ -81,7 +81,7 @@ impl Encode for H256 {
 }
 
 impl Decode for H256 {
-    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, Error> {
+    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, DatabaseError> {
         Ok(H256::from_slice(value.as_ref()))
     }
 }
@@ -94,8 +94,8 @@ impl Encode for String {
 }
 
 impl Decode for String {
-    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, Error> {
-        String::from_utf8(value.as_ref().to_vec()).map_err(|_| Error::DecodeError)
+    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, DatabaseError> {
+        String::from_utf8(value.as_ref().to_vec()).map_err(|_| DatabaseError::DecodeError)
     }
 }
 
@@ -111,7 +111,7 @@ impl Encode for StoredNibbles {
 }
 
 impl Decode for StoredNibbles {
-    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, Error> {
+    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, DatabaseError> {
         let buf = value.as_ref();
         Ok(Self::from_compact(buf, buf.len()).0)
     }
@@ -129,7 +129,7 @@ impl Encode for StoredNibblesSubKey {
 }
 
 impl Decode for StoredNibblesSubKey {
-    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, Error> {
+    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, DatabaseError> {
         let buf = value.as_ref();
         Ok(Self::from_compact(buf, buf.len()).0)
     }

--- a/crates/storage/db/src/tables/models/sharded_key.rs
+++ b/crates/storage/db/src/tables/models/sharded_key.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     table::{Decode, Encode},
-    Error,
+    DatabaseError,
 };
 use reth_primitives::BlockNumber;
 use serde::Serialize;
@@ -49,13 +49,14 @@ impl<T> Decode for ShardedKey<T>
 where
     T: Decode,
 {
-    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, Error> {
+    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, DatabaseError> {
         let value = value.as_ref();
 
         let tx_num_index = value.len() - 8;
 
-        let highest_tx_number =
-            u64::from_be_bytes(value[tx_num_index..].try_into().map_err(|_| Error::DecodeError)?);
+        let highest_tx_number = u64::from_be_bytes(
+            value[tx_num_index..].try_into().map_err(|_| DatabaseError::DecodeError)?,
+        );
         let key = T::decode(&value[..tx_num_index])?;
 
         Ok(ShardedKey::new(key, highest_tx_number))

--- a/crates/storage/db/src/tables/models/storage_sharded_key.rs
+++ b/crates/storage/db/src/tables/models/storage_sharded_key.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     table::{Decode, Encode},
-    Error,
+    DatabaseError,
 };
 
 use reth_primitives::{BlockNumber, H160, H256};
@@ -46,12 +46,13 @@ impl Encode for StorageShardedKey {
 }
 
 impl Decode for StorageShardedKey {
-    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, Error> {
+    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, DatabaseError> {
         let value = value.as_ref();
         let tx_num_index = value.len() - 8;
 
-        let highest_tx_number =
-            u64::from_be_bytes(value[tx_num_index..].try_into().map_err(|_| Error::DecodeError)?);
+        let highest_tx_number = u64::from_be_bytes(
+            value[tx_num_index..].try_into().map_err(|_| DatabaseError::DecodeError)?,
+        );
         let address = H160::decode(&value[..20])?;
         let storage_key = H256::decode(&value[20..52])?;
 

--- a/crates/storage/db/src/tables/raw.rs
+++ b/crates/storage/db/src/tables/raw.rs
@@ -1,6 +1,6 @@
 use crate::{
     table::{Compress, Decode, Decompress, DupSort, Encode, Key, Table, Value},
-    Error,
+    DatabaseError,
 };
 use serde::Serialize;
 
@@ -51,7 +51,7 @@ impl<K: Key> RawKey<K> {
         Self { key: K::encode(key).as_ref().to_vec(), _phantom: std::marker::PhantomData }
     }
     /// Returns the raw key.
-    pub fn key(&self) -> Result<K, Error> {
+    pub fn key(&self) -> Result<K, DatabaseError> {
         K::decode(&self.key)
     }
 }
@@ -79,7 +79,7 @@ impl<K: Key> Encode for RawKey<K> {
 
 // Decode
 impl<K: Key> Decode for RawKey<K> {
-    fn decode<B: AsRef<[u8]>>(key: B) -> Result<Self, Error> {
+    fn decode<B: AsRef<[u8]>>(key: B) -> Result<Self, DatabaseError> {
         Ok(Self { key: key.as_ref().to_vec(), _phantom: std::marker::PhantomData })
     }
 }
@@ -97,7 +97,7 @@ impl<V: Value> RawValue<V> {
         Self { value: V::compress(value).as_ref().to_vec(), _phantom: std::marker::PhantomData }
     }
     /// Returns the raw value.
-    pub fn value(&self) -> Result<V, Error> {
+    pub fn value(&self) -> Result<V, DatabaseError> {
         V::decompress(&self.value)
     }
 }
@@ -126,7 +126,7 @@ impl<V: Value> Compress for RawValue<V> {
 }
 
 impl<V: Value> Decompress for RawValue<V> {
-    fn decompress<B: AsRef<[u8]>>(value: B) -> Result<Self, Error> {
+    fn decompress<B: AsRef<[u8]>>(value: B) -> Result<Self, DatabaseError> {
         Ok(Self { value: value.as_ref().to_vec(), _phantom: std::marker::PhantomData })
     }
 }

--- a/crates/storage/db/src/tables/utils.rs
+++ b/crates/storage/db/src/tables/utils.rs
@@ -1,7 +1,7 @@
 //! Small database table utilities and helper functions
 use crate::{
     table::{Decode, Decompress, Table},
-    Error,
+    DatabaseError,
 };
 
 use std::borrow::Cow;
@@ -43,7 +43,7 @@ macro_rules! impl_fixed_arbitrary {
 /// Helper function to decode a `(key, value)` pair.
 pub(crate) fn decoder<'a, T>(
     kv: (Cow<'a, [u8]>, Cow<'a, [u8]>),
-) -> Result<(T::Key, T::Value), Error>
+) -> Result<(T::Key, T::Value), DatabaseError>
 where
     T: Table,
     T::Key: Decode,
@@ -61,7 +61,9 @@ where
 }
 
 /// Helper function to decode only a value from a `(key, value)` pair.
-pub(crate) fn decode_value<'a, T>(kv: (Cow<'a, [u8]>, Cow<'a, [u8]>)) -> Result<T::Value, Error>
+pub(crate) fn decode_value<'a, T>(
+    kv: (Cow<'a, [u8]>, Cow<'a, [u8]>),
+) -> Result<T::Value, DatabaseError>
 where
     T: Table,
 {
@@ -72,7 +74,7 @@ where
 }
 
 /// Helper function to decode a value. It can be a key or subkey.
-pub(crate) fn decode_one<T>(value: Cow<'_, [u8]>) -> Result<T::Value, Error>
+pub(crate) fn decode_one<T>(value: Cow<'_, [u8]>) -> Result<T::Value, DatabaseError>
 where
     T: Table,
 {

--- a/crates/storage/provider/src/post_state/mod.rs
+++ b/crates/storage/provider/src/post_state/mod.rs
@@ -4,7 +4,7 @@ use reth_db::{
     models::{AccountBeforeTx, BlockNumberAddress},
     tables,
     transaction::{DbTx, DbTxMut},
-    Error as DbError,
+    DatabaseError as DbError,
 };
 use reth_primitives::{
     bloom::logs_bloom, keccak256, proofs::calculate_receipt_root_ref, Account, Address,

--- a/crates/storage/provider/src/providers/database.rs
+++ b/crates/storage/provider/src/providers/database.rs
@@ -486,7 +486,7 @@ impl<DB: Database> EvmEnvProvider for ShareableDatabase<DB> {
 fn read_sealed_header<'a, TX>(
     tx: &TX,
     block_number: u64,
-) -> std::result::Result<Option<(Header, BlockHash)>, reth_interfaces::db::Error>
+) -> std::result::Result<Option<(Header, BlockHash)>, reth_interfaces::db::DatabaseError>
 where
     TX: DbTx<'a> + Send + Sync,
 {
@@ -505,7 +505,7 @@ where
 fn is_latest_block_number<'a, TX>(
     tx: &TX,
     block_number: BlockNumber,
-) -> std::result::Result<bool, reth_interfaces::db::Error>
+) -> std::result::Result<bool, reth_interfaces::db::DatabaseError>
 where
     TX: DbTx<'a> + Send + Sync,
 {
@@ -520,7 +520,7 @@ where
 #[inline]
 fn best_block_number<'a, TX>(
     tx: &TX,
-) -> std::result::Result<Option<BlockNumber>, reth_interfaces::db::Error>
+) -> std::result::Result<Option<BlockNumber>, reth_interfaces::db::DatabaseError>
 where
     TX: DbTx<'a> + Send + Sync,
 {
@@ -531,7 +531,7 @@ where
 #[inline]
 fn last_canonical_header<'a, TX>(
     tx: &TX,
-) -> std::result::Result<Option<(BlockNumber, BlockHash)>, reth_interfaces::db::Error>
+) -> std::result::Result<Option<(BlockNumber, BlockHash)>, reth_interfaces::db::DatabaseError>
 where
     TX: DbTx<'a> + Send + Sync,
 {

--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -17,7 +17,7 @@ use reth_db::{
     transaction::{DbTx, DbTxMut, DbTxMutGAT},
     BlockNumberList,
 };
-use reth_interfaces::{db::Error as DbError, provider::ProviderError};
+use reth_interfaces::{db::DatabaseError as DbError, provider::ProviderError};
 use reth_primitives::{
     keccak256, Account, Address, BlockHash, BlockNumber, ChainSpec, Hardfork, Header, SealedBlock,
     SealedBlockWithSenders, StorageEntry, TransactionSigned, TransactionSignedEcRecovered,

--- a/crates/trie/src/errors.rs
+++ b/crates/trie/src/errors.rs
@@ -5,13 +5,13 @@ use thiserror::Error;
 pub enum StateRootError {
     /// Internal database error.
     #[error(transparent)]
-    DB(#[from] reth_db::Error),
+    DB(#[from] reth_db::DatabaseError),
     /// Storage root error.
     #[error(transparent)]
     StorageRootError(#[from] StorageRootError),
 }
 
-impl From<StateRootError> for reth_db::Error {
+impl From<StateRootError> for reth_db::DatabaseError {
     fn from(err: StateRootError) -> Self {
         match err {
             StateRootError::DB(err) => err,
@@ -25,5 +25,5 @@ impl From<StateRootError> for reth_db::Error {
 pub enum StorageRootError {
     /// Internal database error.
     #[error(transparent)]
-    DB(#[from] reth_db::Error),
+    DB(#[from] reth_db::DatabaseError),
 }

--- a/crates/trie/src/hashed_cursor/default.rs
+++ b/crates/trie/src/hashed_cursor/default.rs
@@ -10,11 +10,11 @@ impl<'a, 'tx, TX: DbTx<'tx>> HashedCursorFactory<'a> for TX {
     type AccountCursor = <TX as DbTxGAT<'a>>::Cursor<tables::HashedAccount> where Self: 'a;
     type StorageCursor = <TX as DbTxGAT<'a>>::DupCursor<tables::HashedStorage> where Self: 'a;
 
-    fn hashed_account_cursor(&'a self) -> Result<Self::AccountCursor, reth_db::Error> {
+    fn hashed_account_cursor(&'a self) -> Result<Self::AccountCursor, reth_db::DatabaseError> {
         self.cursor_read::<tables::HashedAccount>()
     }
 
-    fn hashed_storage_cursor(&'a self) -> Result<Self::StorageCursor, reth_db::Error> {
+    fn hashed_storage_cursor(&'a self) -> Result<Self::StorageCursor, reth_db::DatabaseError> {
         self.cursor_dup_read::<tables::HashedStorage>()
     }
 }
@@ -23,11 +23,11 @@ impl<'tx, C> HashedAccountCursor for C
 where
     C: DbCursorRO<'tx, tables::HashedAccount>,
 {
-    fn seek(&mut self, key: H256) -> Result<Option<(H256, Account)>, reth_db::Error> {
+    fn seek(&mut self, key: H256) -> Result<Option<(H256, Account)>, reth_db::DatabaseError> {
         self.seek(key)
     }
 
-    fn next(&mut self) -> Result<Option<(H256, Account)>, reth_db::Error> {
+    fn next(&mut self) -> Result<Option<(H256, Account)>, reth_db::DatabaseError> {
         self.next()
     }
 }
@@ -36,15 +36,19 @@ impl<'tx, C> HashedStorageCursor for C
 where
     C: DbCursorRO<'tx, tables::HashedStorage> + DbDupCursorRO<'tx, tables::HashedStorage>,
 {
-    fn is_empty(&mut self, key: H256) -> Result<bool, reth_db::Error> {
+    fn is_empty(&mut self, key: H256) -> Result<bool, reth_db::DatabaseError> {
         Ok(self.seek_exact(key)?.is_none())
     }
 
-    fn seek(&mut self, key: H256, subkey: H256) -> Result<Option<StorageEntry>, reth_db::Error> {
+    fn seek(
+        &mut self,
+        key: H256,
+        subkey: H256,
+    ) -> Result<Option<StorageEntry>, reth_db::DatabaseError> {
         self.seek_by_key_subkey(key, subkey)
     }
 
-    fn next(&mut self) -> Result<Option<StorageEntry>, reth_db::Error> {
+    fn next(&mut self) -> Result<Option<StorageEntry>, reth_db::DatabaseError> {
         self.next_dup_val()
     }
 }

--- a/crates/trie/src/hashed_cursor/mod.rs
+++ b/crates/trie/src/hashed_cursor/mod.rs
@@ -19,29 +19,33 @@ pub trait HashedCursorFactory<'a> {
         Self: 'a;
 
     /// Returns a cursor for iterating over all hashed accounts in the state.
-    fn hashed_account_cursor(&'a self) -> Result<Self::AccountCursor, reth_db::Error>;
+    fn hashed_account_cursor(&'a self) -> Result<Self::AccountCursor, reth_db::DatabaseError>;
 
     /// Returns a cursor for iterating over all hashed storage entries in the state.
-    fn hashed_storage_cursor(&'a self) -> Result<Self::StorageCursor, reth_db::Error>;
+    fn hashed_storage_cursor(&'a self) -> Result<Self::StorageCursor, reth_db::DatabaseError>;
 }
 
 /// The cursor for iterating over hashed accounts.
 pub trait HashedAccountCursor {
     /// Seek an entry greater or equal to the given key and position the cursor there.
-    fn seek(&mut self, key: H256) -> Result<Option<(H256, Account)>, reth_db::Error>;
+    fn seek(&mut self, key: H256) -> Result<Option<(H256, Account)>, reth_db::DatabaseError>;
 
     /// Move the cursor to the next entry and return it.
-    fn next(&mut self) -> Result<Option<(H256, Account)>, reth_db::Error>;
+    fn next(&mut self) -> Result<Option<(H256, Account)>, reth_db::DatabaseError>;
 }
 
 /// The cursor for iterating over hashed storage entries.
 pub trait HashedStorageCursor {
     /// Returns `true` if there are no entries for a given key.
-    fn is_empty(&mut self, key: H256) -> Result<bool, reth_db::Error>;
+    fn is_empty(&mut self, key: H256) -> Result<bool, reth_db::DatabaseError>;
 
     /// Seek an entry greater or equal to the given key/subkey and position the cursor there.
-    fn seek(&mut self, key: H256, subkey: H256) -> Result<Option<StorageEntry>, reth_db::Error>;
+    fn seek(
+        &mut self,
+        key: H256,
+        subkey: H256,
+    ) -> Result<Option<StorageEntry>, reth_db::DatabaseError>;
 
     /// Move the cursor to the next entry and return it.
-    fn next(&mut self) -> Result<Option<StorageEntry>, reth_db::Error>;
+    fn next(&mut self) -> Result<Option<StorageEntry>, reth_db::DatabaseError>;
 }

--- a/crates/trie/src/prefix_set/loader.rs
+++ b/crates/trie/src/prefix_set/loader.rs
@@ -5,7 +5,7 @@ use reth_db::{
     models::{AccountBeforeTx, BlockNumberAddress},
     tables,
     transaction::DbTx,
-    Error,
+    DatabaseError,
 };
 use reth_primitives::{keccak256, trie::Nibbles, BlockNumber, StorageEntry, H256};
 use std::{collections::HashMap, ops::RangeInclusive};
@@ -29,7 +29,7 @@ where
     pub fn load(
         self,
         range: RangeInclusive<BlockNumber>,
-    ) -> Result<(PrefixSet, HashMap<H256, PrefixSet>), Error> {
+    ) -> Result<(PrefixSet, HashMap<H256, PrefixSet>), DatabaseError> {
         // Initialize prefix sets.
         let mut account_prefix_set = PrefixSet::default();
         let mut storage_prefix_set: HashMap<H256, PrefixSet> = HashMap::default();

--- a/crates/trie/src/trie_cursor/account_cursor.rs
+++ b/crates/trie/src/trie_cursor/account_cursor.rs
@@ -1,6 +1,6 @@
 use super::TrieCursor;
 use crate::updates::TrieKey;
-use reth_db::{cursor::DbCursorRO, tables, Error};
+use reth_db::{cursor::DbCursorRO, tables, DatabaseError};
 use reth_primitives::trie::{BranchNodeCompact, StoredNibbles};
 
 /// A cursor over the account trie.
@@ -20,15 +20,18 @@ where
     fn seek_exact(
         &mut self,
         key: StoredNibbles,
-    ) -> Result<Option<(Vec<u8>, BranchNodeCompact)>, Error> {
+    ) -> Result<Option<(Vec<u8>, BranchNodeCompact)>, DatabaseError> {
         Ok(self.0.seek_exact(key)?.map(|value| (value.0.inner.to_vec(), value.1)))
     }
 
-    fn seek(&mut self, key: StoredNibbles) -> Result<Option<(Vec<u8>, BranchNodeCompact)>, Error> {
+    fn seek(
+        &mut self,
+        key: StoredNibbles,
+    ) -> Result<Option<(Vec<u8>, BranchNodeCompact)>, DatabaseError> {
         Ok(self.0.seek(key)?.map(|value| (value.0.inner.to_vec(), value.1)))
     }
 
-    fn current(&mut self) -> Result<Option<TrieKey>, Error> {
+    fn current(&mut self) -> Result<Option<TrieKey>, DatabaseError> {
         Ok(self.0.current()?.map(|(k, _)| TrieKey::AccountNode(k)))
     }
 }

--- a/crates/trie/src/trie_cursor/mod.rs
+++ b/crates/trie/src/trie_cursor/mod.rs
@@ -1,5 +1,5 @@
 use crate::updates::TrieKey;
-use reth_db::{table::Key, Error};
+use reth_db::{table::Key, DatabaseError};
 use reth_primitives::trie::BranchNodeCompact;
 
 mod account_cursor;
@@ -13,11 +13,12 @@ pub use self::{
 /// A cursor for navigating a trie that works with both Tables and DupSort tables.
 pub trait TrieCursor<K: Key> {
     /// Move the cursor to the key and return if it is an exact match.
-    fn seek_exact(&mut self, key: K) -> Result<Option<(Vec<u8>, BranchNodeCompact)>, Error>;
+    fn seek_exact(&mut self, key: K)
+        -> Result<Option<(Vec<u8>, BranchNodeCompact)>, DatabaseError>;
 
     /// Move the cursor to the key and return a value matching of greater than the key.
-    fn seek(&mut self, key: K) -> Result<Option<(Vec<u8>, BranchNodeCompact)>, Error>;
+    fn seek(&mut self, key: K) -> Result<Option<(Vec<u8>, BranchNodeCompact)>, DatabaseError>;
 
     /// Get the current entry.
-    fn current(&mut self) -> Result<Option<TrieKey>, Error>;
+    fn current(&mut self) -> Result<Option<TrieKey>, DatabaseError>;
 }

--- a/crates/trie/src/trie_cursor/storage_cursor.rs
+++ b/crates/trie/src/trie_cursor/storage_cursor.rs
@@ -2,7 +2,7 @@ use super::TrieCursor;
 use crate::updates::TrieKey;
 use reth_db::{
     cursor::{DbCursorRO, DbDupCursorRO},
-    tables, Error,
+    tables, DatabaseError,
 };
 use reth_primitives::{
     trie::{BranchNodeCompact, StoredNibblesSubKey},
@@ -30,7 +30,7 @@ where
     fn seek_exact(
         &mut self,
         key: StoredNibblesSubKey,
-    ) -> Result<Option<(Vec<u8>, BranchNodeCompact)>, Error> {
+    ) -> Result<Option<(Vec<u8>, BranchNodeCompact)>, DatabaseError> {
         Ok(self
             .cursor
             .seek_by_key_subkey(self.hashed_address, key.clone())?
@@ -41,14 +41,14 @@ where
     fn seek(
         &mut self,
         key: StoredNibblesSubKey,
-    ) -> Result<Option<(Vec<u8>, BranchNodeCompact)>, Error> {
+    ) -> Result<Option<(Vec<u8>, BranchNodeCompact)>, DatabaseError> {
         Ok(self
             .cursor
             .seek_by_key_subkey(self.hashed_address, key)?
             .map(|value| (value.nibbles.inner.to_vec(), value.node)))
     }
 
-    fn current(&mut self) -> Result<Option<TrieKey>, Error> {
+    fn current(&mut self) -> Result<Option<TrieKey>, DatabaseError> {
         Ok(self.cursor.current()?.map(|(k, v)| TrieKey::StorageNode(k, v.nibbles)))
     }
 }

--- a/crates/trie/src/updates.rs
+++ b/crates/trie/src/updates.rs
@@ -95,7 +95,7 @@ impl TrieUpdates {
     }
 
     /// Flush updates all aggregated updates to the database.
-    pub fn flush<'a, 'tx, TX>(self, tx: &'a TX) -> Result<(), reth_db::Error>
+    pub fn flush<'a, 'tx, TX>(self, tx: &'a TX) -> Result<(), reth_db::DatabaseError>
     where
         TX: DbTx<'tx> + DbTxMut<'tx>,
     {


### PR DESCRIPTION
we have a lot of error types and having multiple named `Error` can get a bit confusing.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a801fe5</samp>

Renamed the `Error` type from the `reth_interfaces::db` module to `DatabaseError` and updated all the modules that depend on it. This change improves the clarity and consistency of the error handling in the database abstraction layer and the stages that use it.