### PR TITLE
chore: rm duplicate transact

### DIFF
--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -611,8 +611,6 @@ fn build_payload<Pool, Client>(
                 }
             };
 
-            // let ResultAndState { result, state } =
-            evm.transact().map_err(PayloadBuilderError::EvmExecutionError)?;
             let gas_used = result.gas_used();
 
             // commit changes


### PR DESCRIPTION
redundant transact...

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 17f5960</samp>

Remove redundant code from `crates/payload/basic/src/lib.rs`. Simplify the logic of the `execute()` function for basic payload transactions.