### PR TITLE
fix: set sync state at startup to idle

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -700,11 +700,6 @@ where
                             block_hash,
                         ));
 
-                        // Update the network sync state to `Idle`.
-                        // Handles the edge case where the pipeline is never triggered, because we
-                        // are sufficiently synced.
-                        self.sync_state_updater.update_sync_state(SyncState::Idle);
-
                         PayloadStatusEnum::Valid
                     }
                     BlockStatus::Accepted => {

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -54,7 +54,7 @@ impl NetworkHandle {
             peers,
             network_mode,
             bandwidth_meter,
-            is_syncing: Arc::new(AtomicBool::new(true)),
+            is_syncing: Arc::new(AtomicBool::new(false)),
             chain_id,
         };
         Self { inner: Arc::new(inner) }

--- a/crates/net/network/tests/it/startup.rs
+++ b/crates/net/network/tests/it/startup.rs
@@ -28,7 +28,7 @@ async fn test_is_default_syncing() {
         .listener_port(0)
         .build(NoopProvider::default());
     let network = NetworkManager::new(config).await.unwrap();
-    assert!(network.handle().is_syncing());
+    assert!(!network.handle().is_syncing());
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Because the `rpc-compat` tests first run `reth import`, then run `reth node` with RPC on for the actual tests, the response to `eth_syncing` is populated with the `NetworkInner`'s default value.

If we have no CL, and are not running the pipeline (which is the case at startup), then we should return `false`.

Fixes #2708