### PR TITLE
feat: add headers stage config options

### DIFF
--- a/crates/net/downloaders/src/headers/reverse_headers.rs
+++ b/crates/net/downloaders/src/headers/reverse_headers.rs
@@ -1001,7 +1001,7 @@ impl Default for ReverseHeadersDownloaderBuilder {
         Self {
             request_limit: 1_000,
             stream_batch_size: 10_000,
-            max_concurrent_requests: 150,
+            max_concurrent_requests: 100,
             min_concurrent_requests: 5,
             max_buffered_responses: 750,
         }

--- a/crates/net/downloaders/src/headers/reverse_headers.rs
+++ b/crates/net/downloaders/src/headers/reverse_headers.rs
@@ -999,11 +999,13 @@ pub struct ReverseHeadersDownloaderBuilder {
 impl Default for ReverseHeadersDownloaderBuilder {
     fn default() -> Self {
         Self {
-            request_limit: 200,
             stream_batch_size: 10_000,
+            // This is just below the max number of headers commonly in a headers response (1024), see also <https://github.com/ethereum/go-ethereum/blob/b0d44338bbcefee044f1f635a84487cbbd8f0538/eth/protocols/eth/handler.go#L38-L40>
+            // with ~500bytes per header this around 0.5MB per request max
+            request_limit: 1_000,
             max_concurrent_requests: 100,
             min_concurrent_requests: 5,
-            max_buffered_responses: 750,
+            max_buffered_responses: 100,
         }
     }
 }

--- a/crates/net/downloaders/src/headers/reverse_headers.rs
+++ b/crates/net/downloaders/src/headers/reverse_headers.rs
@@ -999,7 +999,7 @@ pub struct ReverseHeadersDownloaderBuilder {
 impl Default for ReverseHeadersDownloaderBuilder {
     fn default() -> Self {
         Self {
-            request_limit: 1_000,
+            request_limit: 200,
             stream_batch_size: 10_000,
             max_concurrent_requests: 100,
             min_concurrent_requests: 5,

--- a/crates/staged-sync/src/config.rs
+++ b/crates/staged-sync/src/config.rs
@@ -64,7 +64,6 @@ pub struct StageConfig {
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Serialize)]
 pub struct HeadersConfig {
     /// The maximum number of requests to send concurrently.
-    /// This is upper bounded by the max number of peers.
     ///
     /// Default: 100
     pub downloader_max_concurrent_requests: usize,

--- a/crates/staged-sync/src/config.rs
+++ b/crates/staged-sync/src/config.rs
@@ -63,15 +63,33 @@ pub struct StageConfig {
 /// Header stage configuration.
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Serialize)]
 pub struct HeadersConfig {
-    /// The maximum number of headers to download before committing progress to the database.
-    pub commit_threshold: u64,
+    /// The maximum number of requests to send concurrently.
+    /// This is upper bounded by the max number of peers.
+    ///
+    /// Default: 100
+    pub downloader_max_concurrent_requests: usize,
+    /// The minimum number of requests to send concurrently.
+    ///
+    /// Default: 5
+    pub downloader_min_concurrent_requests: usize,
+    /// Maximum amount of responses to buffer internally.
+    /// The response contains multiple headers.
+    pub downloader_max_buffered_responses: usize,
     /// The maximum number of headers to request from a peer at a time.
     pub downloader_batch_size: u64,
+    /// The maximum number of headers to download before committing progress to the database.
+    pub commit_threshold: u64,
 }
 
 impl Default for HeadersConfig {
     fn default() -> Self {
-        Self { commit_threshold: 10_000, downloader_batch_size: 1000 }
+        Self {
+            commit_threshold: 10_000,
+            downloader_batch_size: 1000,
+            downloader_max_concurrent_requests: 100,
+            downloader_min_concurrent_requests: 5,
+            downloader_max_buffered_responses: 100,
+        }
     }
 }
 
@@ -79,6 +97,9 @@ impl From<HeadersConfig> for ReverseHeadersDownloaderBuilder {
     fn from(config: HeadersConfig) -> Self {
         ReverseHeadersDownloaderBuilder::default()
             .request_limit(config.downloader_batch_size)
+            .min_concurrent_requests(config.downloader_min_concurrent_requests)
+            .max_concurrent_requests(config.downloader_max_concurrent_requests)
+            .max_buffered_responses(config.downloader_max_buffered_responses)
             .stream_batch_size(config.commit_threshold as usize)
     }
 }

--- a/crates/staged-sync/src/config.rs
+++ b/crates/staged-sync/src/config.rs
@@ -75,7 +75,7 @@ pub struct HeadersConfig {
     /// The response contains multiple headers.
     pub downloader_max_buffered_responses: usize,
     /// The maximum number of headers to request from a peer at a time.
-    pub downloader_batch_size: u64,
+    pub downloader_request_limit: u64,
     /// The maximum number of headers to download before committing progress to the database.
     pub commit_threshold: u64,
 }
@@ -84,7 +84,7 @@ impl Default for HeadersConfig {
     fn default() -> Self {
         Self {
             commit_threshold: 10_000,
-            downloader_batch_size: 200,
+            downloader_request_limit: 1_000,
             downloader_max_concurrent_requests: 100,
             downloader_min_concurrent_requests: 5,
             downloader_max_buffered_responses: 100,
@@ -95,7 +95,7 @@ impl Default for HeadersConfig {
 impl From<HeadersConfig> for ReverseHeadersDownloaderBuilder {
     fn from(config: HeadersConfig) -> Self {
         ReverseHeadersDownloaderBuilder::default()
-            .request_limit(config.downloader_batch_size)
+            .request_limit(config.downloader_request_limit)
             .min_concurrent_requests(config.downloader_min_concurrent_requests)
             .max_concurrent_requests(config.downloader_max_concurrent_requests)
             .max_buffered_responses(config.downloader_max_buffered_responses)

--- a/crates/staged-sync/src/config.rs
+++ b/crates/staged-sync/src/config.rs
@@ -85,7 +85,7 @@ impl Default for HeadersConfig {
     fn default() -> Self {
         Self {
             commit_threshold: 10_000,
-            downloader_batch_size: 1000,
+            downloader_batch_size: 200,
             downloader_max_concurrent_requests: 100,
             downloader_min_concurrent_requests: 5,
             downloader_max_buffered_responses: 100,


### PR DESCRIPTION
Adds already-supported config options for the headers stage:
 * `downloader_max_concurrent_requests`
 * `downloader_min_concurrent_requests`
 * `downloader_max_buffered_responses`

This also changes the default `request_limit` from 1000 to 200, which reduces the memory usage of the headers stage (on my machine, the previous setting caused an OOM). The default max concurrent requests in the headers stage is also changed from 150 to 100.