### PR TITLE
fix: return latestValidHash from sidechains

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -276,11 +276,13 @@ where
             return Some(H256::zero())
         }
 
-        // TODO(mattsse): This could be invoked on new payload which does not make tree canonical,
-        //  which would make this inaccurate, e.g. if an invalid payload is received in this
-        //  scenario: FUC (unknown head) -> valid payload  -> invalid payload
-
-        self.blockchain.find_canonical_ancestor(parent_hash)
+        // If this is sent from new payload then the parent hash could be in a side chain, and is
+        // not necessarily canonical
+        if self.blockchain.header_by_hash(parent_hash).is_some() {
+            Some(parent_hash)
+        } else {
+            self.blockchain.find_canonical_ancestor(parent_hash)
+        }
     }
 
     /// Loads the header for the given `block_number` from the database.


### PR DESCRIPTION
Depends on #2702 

Previously, we were passing some hive engine tests, but failing their `(Syncing)` variant.

For example, the `Invalid Transaction ChainID NewPayload` test:
```
INFO[05-18|00:27:40] API: suite started                       suite=0 name=engine-api
INFO[05-18|00:27:40] API: test started                        suite=0 test=1 name="Invalid Transaction ChainID NewPayload (reth)"
INFO[05-18|00:27:41] API: client reth started                 suite=0 test=1 container=d18606f7
INFO[05-18|00:27:50] API: test ended                          suite=0 test=1 pass=true
INFO[05-18|00:27:50] API: test started                        suite=0 test=2 name="Invalid Transaction ChainID NewPayload (EIP-1559) (reth)"
INFO[05-18|00:27:51] API: client reth started                 suite=0 test=2 container=c75b9621
INFO[05-18|00:28:00] API: test ended                          suite=0 test=2 pass=true
INFO[05-18|00:28:00] API: test started                        suite=0 test=3 name="Invalid Transaction ChainID NewPayload (Syncing) (reth)"
INFO[05-18|00:28:01] API: client reth started                 suite=0 test=3 container=88d8d00f
INFO[05-18|00:28:01] API: client reth started                 suite=0 test=3 container=05a550ad
INFO[05-18|00:28:10] API: test ended                          suite=0 test=3 pass=false
INFO[05-18|00:28:10] API: suite ended                         suite=0
INFO[05-18|00:28:10] simulation ethereum/engine finished      suites=1 tests=3 failed=1
```
These `(Syncing)` tests were all failing due to errors similar to this:
```
<< (88d8d00f) {"jsonrpc":"2.0","result":{"status":"INVALID","latestValidHash":"0xaabc1ea47443d269ff62e7396b7d14338bbedfd576c0bcbdb22cfd9217d511da","validationError":"EVM reported invalid transaction (0xb0c419def38bdcf512439aa06a74ff1841d4927965016d3eb8ddc5b677a48508): Transaction(InvalidChainId)"},"id":21}
DEBUG (Invalid Transaction ChainID NewPayload (Syncing)): Failed `Expect*` routine called from: file=/source/suites/engine/tests.go, line=1934
FAIL (Invalid Transaction ChainID NewPayload (Syncing)): Unexpected LatestValidHash on EngineNewPayloadV1: 0xaabc1ea47443d269ff62e7396b7d14338bbedfd576c0bcbdb22cfd9217d511da, expected=0x1815b3c036db6d19be4a24bf71a77caa30a2499e5cbdb901e17342d2ccf2aabd
CLMocker: Closing engine client 05a550ad
```
We would previously walk the tree to return the latest valid canonical ancestor as the `lastestValidHash`, when this is not correct if we are issued requests like the following:
* Valid `forkchoiceUpdate`
* Valid `newPayload` on top of the new canonical head
* Invalid `newPayload` with a parent hash of the previous `newPayload`

The latest canonical ancestor is not the correct value for the `latestValidHash` in the response, because the first `newPayload` was valid, and is an ancestor of the invalid `newPayload`. So we should instead return the parent hash of the invalid payload as the `latestValidHash`, if it exists in the tree (this means it is valid).