### PR TITLE
fix(cli): run pipeline with debug.tip to completion after restart

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -131,11 +131,11 @@ impl BeaconConsensusEngineHandle {
 ///
 /// The consensus engine is idle until it receives the first
 /// [BeaconEngineMessage::ForkchoiceUpdated] message from the CL which would initiate the sync. At
-/// first, the consensus engine would run the [Pipeline] until the latest known block hash.
-/// Afterwards, it would attempt to create/restore the [`BlockchainTreeEngine`] from the blocks
-/// that are currently available. In case the restoration is successful, the consensus engine would
-/// run in a live sync mode, which mean it would solemnly rely on the messages from Engine API to
-/// construct the chain forward.
+/// first, the consensus engine would run the [reth_stages::Pipeline] until the latest known block
+/// hash. Afterwards, it would attempt to create/restore the [`BlockchainTreeEngine`] from the
+/// blocks that are currently available. In case the restoration is successful, the consensus engine
+/// would run in a live sync mode, which mean it would solemnly rely on the messages from Engine API
+/// to construct the chain forward.
 ///
 /// # Panics
 ///

--- a/crates/consensus/beacon/src/engine/sync.rs
+++ b/crates/consensus/beacon/src/engine/sync.rs
@@ -56,7 +56,7 @@ where
 {
     /// Create a new instance
     pub(crate) fn new(
-        pipeline: Pipeline<DB>,
+        pipeline_state: PipelineState<DB>,
         client: Client,
         pipeline_task_spawner: Box<dyn TaskSpawner>,
         run_pipeline_continuously: bool,
@@ -65,7 +65,7 @@ where
         Self {
             full_block_client: FullBlockClient::new(client),
             pipeline_task_spawner,
-            pipeline_state: PipelineState::Idle(Some(pipeline)),
+            pipeline_state,
             pending_pipeline_target: None,
             inflight_full_block_requests: Vec::new(),
             queued_events: VecDeque::new(),
@@ -251,7 +251,7 @@ pub(crate) enum EngineSyncEvent {
 /// running, it acquires the write lock over the database. This means that we cannot forward to the
 /// blockchain tree any messages that would result in database writes, since it would result in a
 /// deadlock.
-enum PipelineState<DB: Database> {
+pub enum PipelineState<DB: Database> {
     /// Pipeline is idle.
     Idle(Option<Pipeline<DB>>),
     /// Pipeline is running and waiting for a response


### PR DESCRIPTION
Alternative to #2727

## Issue

Currently, `debug.tip` cli arg is provided as a "fake" FCU to the consensus engine. This contradicts with various validation checks that the consensus engine performs on the FCU and its further decision whether the pipeline should be run or not.

## Solution

Remove "fake" FCUs. Provide the pipeline in already launched state if necessary to the consensus engine.