### PR TITLE
fix(cli): run pipeline to completion after restart

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -805,9 +805,14 @@ where
                             return Some(Ok(()))
                         }
 
-                        let Some(current_state) = self.forkchoice_state else {
-                            warn!(target: "consensus::engine", "No forkchoice state available");
-                            return None
+                        let current_state = match self.forkchoice_state {
+                            Some(state) => state,
+                            None => {
+                                // This is only possible if the node was run with `debug.tip`
+                                // argument and without CL.
+                                warn!(target: "consensus::engine", "No forkchoice state available");
+                                return None
+                            }
                         };
 
                         if ctrl.is_unwind() {


### PR DESCRIPTION
Alternative to #2726

## Issue

Currently, `debug.tip` cli arg is provided as a "fake" FCU to the consensus engine. This contradicts with various validation checks that the consensus engine performs on the FCU and its further decision whether the pipeline should be run or not.

## Solution

Remove "fake" FCUs. Provide an optional argument to the consensus engine to run the pipeline from the start with the target hash.