### PR TITLE
test: add debug info to flaky test

### DIFF
--- a/crates/net/network/tests/it/session.rs
+++ b/crates/net/network/tests/it/session.rs
@@ -65,19 +65,21 @@ async fn test_session_established_with_different_capability() {
     handle0.add_peer(*handle1.peer_id(), handle1.local_addr());
 
     let mut events = handle0.event_listener().take(2);
+    let mut latest = None;
     while let Some(event) = events.next().await {
-        match event {
+        match &event {
             NetworkEvent::PeerAdded(peer_id) => {
-                assert_eq!(handle1.peer_id(), &peer_id);
+                assert_eq!(handle1.peer_id(), peer_id);
             }
             NetworkEvent::SessionEstablished { peer_id, status, .. } => {
-                assert_eq!(handle1.peer_id(), &peer_id);
+                assert_eq!(handle1.peer_id(), peer_id);
                 assert_eq!(status.version, EthVersion::Eth66 as u8);
             }
             ev => {
-                panic!("unexpected event: {ev:?}")
+                panic!("unexpected event: {ev:?}; previously received {latest:?}")
             }
         }
+        latest = Some(event);
     }
 
     handle.terminate().await;


### PR DESCRIPTION
this test is flaky in CI

```
thread 'session::test_session_established_with_different_capability' panicked at 'unexpected event: SessionClosed { peer_id: 0x931856547726af20528a5033c822dd921424edd26d5fe0d1232f9dfbd8b45b3219983b3f918a953394cc2007c1b9b290330709d2e40dbe2b508deedbd5b68c1a, reason: None }', crates/net/network/tests/it/session.rs:78:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

   Canceling due to test failure: 0 tests still running
        PASS [   0.028s] reth-network::it startup::test_discovery_addr_in_use
------------
     Summary [ 187.411s] 49/63 tests run: 48 passed, 1 failed, 51 skipped
        FAIL [ 160.126s] reth-network::it session::test_session_established_with_different_capability
```

I assume there's an issue with the PeerAdded event 

this adds more context to the panic and displays what event we received to track this down 

