### PR TITLE
test: fix event race condition

### DIFF
--- a/crates/net/network/tests/it/session.rs
+++ b/crates/net/network/tests/it/session.rs
@@ -62,9 +62,9 @@ async fn test_session_established_with_different_capability() {
 
     let handle = net.spawn();
 
+    let mut events = handle0.event_listener().take(2);
     handle0.add_peer(*handle1.peer_id(), handle1.local_addr());
 
-    let mut events = handle0.event_listener().take(2);
     while let Some(event) = events.next().await {
         match event {
             NetworkEvent::PeerAdded(peer_id) => {


### PR DESCRIPTION
this attempts to fix flaky test

```
thread 'session::test_session_established_with_different_capability' panicked at 'unexpected event: SessionClosed { peer_id: 0x931856547726af20528a5033c822dd921424edd26d5fe0d1232f9dfbd8b45b3219983b3f918a953394cc2007c1b9b290330709d2e40dbe2b508deedbd5b68c1a, reason: None }', crates/net/network/tests/it/session.rs:78:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

   Canceling due to test failure: 0 tests still running
        PASS [   0.028s] reth-network::it startup::test_discovery_addr_in_use
------------
     Summary [ 187.411s] 49/63 tests run: 48 passed, 1 failed, 51 skipped
        FAIL [ 160.126s] reth-network::it session::test_session_established_with_different_capability
```

there's a race condition because we install the event listener after we've sent the add event, which may have already been handled before we install the listener

