### PR TITLE
test: ensure port is unused for udp and tcp

### DIFF
--- a/crates/net/network/src/test_utils/init.rs
+++ b/crates/net/network/src/test_utils/init.rs
@@ -19,28 +19,39 @@ pub fn enr_to_peer_id(enr: Enr<SigningKey>) -> PeerId {
 /// Does not guarantee that the given port is unused after the function exists, just that it was
 /// unused before the function started (i.e., it does not reserve a port).
 pub fn unused_port() -> u16 {
+    unused_tcp_addr().port()
+}
+
+/// Finds an unused tcp address
+pub fn unused_tcp_addr() -> SocketAddr {
     let listener = std::net::TcpListener::bind("127.0.0.1:0")
         .expect("Failed to create TCP listener to find unused port");
+    listener.local_addr().expect("Failed to read TCP listener local_addr to find unused port")
+}
 
-    let local_addr =
-        listener.local_addr().expect("Failed to read TCP listener local_addr to find unused port");
-    local_addr.port()
+/// Finds an unused udp port
+pub fn unused_udp_port() -> u16 {
+    unused_udp_addr().port()
+}
+/// Finds an unused udp address
+pub fn unused_udp_addr() -> SocketAddr {
+    let udp_listener = std::net::UdpSocket::bind("127.0.0.1:0")
+        .expect("Failed to create UDP listener to find unused port");
+    udp_listener.local_addr().expect("Failed to read UDP listener local_addr to find unused port")
+}
+
+/// Finds a single port that is unused for both TCP and UDP.
+pub fn unused_tcp_and_udp_port() -> u16 {
+    loop {
+        let port = unused_port();
+        if std::net::UdpSocket::bind(format!("127.0.0.1:{port}")).is_ok() {
+            return port
+        }
+    }
 }
 
 /// Creates two unused SocketAddrs, intended for use as the p2p (TCP) and discovery ports (UDP) for
 /// new reth instances.
 pub fn unused_tcp_udp() -> (SocketAddr, SocketAddr) {
-    let tcp_listener = std::net::TcpListener::bind("127.0.0.1:0")
-        .expect("Failed to create TCP listener to find unused port");
-    let tcp_addr = tcp_listener
-        .local_addr()
-        .expect("Failed to read TCP listener local_addr to find unused port");
-
-    let udp_listener = std::net::UdpSocket::bind("127.0.0.1:0")
-        .expect("Failed to create UDP listener to find unused port");
-    let udp_addr = udp_listener
-        .local_addr()
-        .expect("Failed to read UDP listener local_addr to find unused port");
-
-    (tcp_addr, udp_addr)
+    (unused_tcp_addr(), unused_udp_addr())
 }

--- a/crates/net/network/src/test_utils/mod.rs
+++ b/crates/net/network/src/test_utils/mod.rs
@@ -5,5 +5,8 @@
 mod init;
 mod testnet;
 
-pub use init::{enr_to_peer_id, unused_port, unused_tcp_udp, GETH_TIMEOUT};
+pub use init::{
+    enr_to_peer_id, unused_port, unused_tcp_addr, unused_tcp_and_udp_port, unused_tcp_udp,
+    unused_udp_addr, unused_udp_port, GETH_TIMEOUT,
+};
 pub use testnet::{NetworkEventStream, PeerConfig, Testnet};

--- a/crates/staged-sync/tests/sync.rs
+++ b/crates/staged-sync/tests/sync.rs
@@ -4,7 +4,7 @@ use ethers_core::{
 };
 use ethers_providers::Middleware;
 use reth_network::{
-    test_utils::{unused_port, unused_tcp_udp, NetworkEventStream},
+    test_utils::{unused_tcp_and_udp_port, unused_tcp_udp, NetworkEventStream},
     NetworkConfig, NetworkManager,
 };
 use reth_network_api::Peers;
@@ -69,8 +69,10 @@ async fn init_geth() -> (CliqueGethInstance, Arc<ChainSpec>) {
     );
 
     // this creates a funded geth
-    let clique_geth =
-        Geth::new().chain_id(chain_id).p2p_port(unused_port()).data_dir(dir_path.to_str().unwrap());
+    let clique_geth = Geth::new()
+        .chain_id(chain_id)
+        .p2p_port(unused_tcp_and_udp_port())
+        .data_dir(dir_path.to_str().unwrap());
 
     // build the funded geth
     let mut clique = CliqueGethInstance::new(clique_geth, None).await;


### PR DESCRIPTION
should fix flaky test where p2p port was already available

p2p port binds both to TCP and udp