### PR TITLE
refactor: rm dupe `InvalidTransactionError`s

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -94,7 +94,7 @@ pub fn validate_transaction_regarding_header(
             // EIP-1559: add more constraints to the tx validation
             // https://github.com/ethereum/EIPs/pull/3594
             if max_priority_fee_per_gas > max_fee_per_gas {
-                return Err(InvalidTransactionError::PriorityFeeMoreThenMaxFee.into())
+                return Err(InvalidTransactionError::TipAboveFeeCap.into())
             }
 
             Some(*chain_id)
@@ -109,7 +109,7 @@ pub fn validate_transaction_regarding_header(
     // https://github.com/ethereum/EIPs/pull/3594
     if let Some(base_fee_per_gas) = base_fee {
         if transaction.max_fee_per_gas() < base_fee_per_gas as u128 {
-            return Err(InvalidTransactionError::MaxFeeLessThenBaseFee.into())
+            return Err(InvalidTransactionError::FeeCapTooLow.into())
         }
     }
 

--- a/crates/interfaces/src/consensus.rs
+++ b/crates/interfaces/src/consensus.rs
@@ -89,7 +89,7 @@ pub enum ConsensusError {
     GasLimitInvalidDecrease { parent_gas_limit: u64, child_gas_limit: u64 },
     #[error("Base fee missing.")]
     BaseFeeMissing,
-    #[error("Block base fee ({got}) is different then expected: ({expected}).")]
+    #[error("Block base fee ({got}) is different than expected: ({expected}).")]
     BaseFeeDiff { expected: u64, got: u64 },
     #[error("Transaction signer recovery error.")]
     TransactionSignerRecoveryError,

--- a/crates/primitives/src/transaction/error.rs
+++ b/crates/primitives/src/transaction/error.rs
@@ -5,41 +5,43 @@ use crate::U256;
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Eq, PartialEq, thiserror::Error)]
 pub enum InvalidTransactionError {
-    #[error("Transaction eip1559 priority fee is more then max fee.")]
-    PriorityFeeMoreThenMaxFee,
-    #[error("Account does not have enough funds ({available_funds:?}) to cover transaction cost: {cost:?}.")]
+    /// The sender does not have enough funds to cover the transaction fees
+    #[error("Sender does not have enough funds ({available_funds:?}) to cover transaction fees: {cost:?}.")]
     InsufficientFunds { cost: U256, available_funds: U256 },
+    /// The nonce is lower than the account's nonce, or there is a nonce gap present.
     #[error("Transaction nonce is not consistent.")]
     NonceNotConsistent,
-    #[error("Old legacy transaction before Spurious Dragon should not have chain_id.")]
+    /// The transaction is before Spurious Dragon and has a chain ID
+    #[error("Transactions before Spurious Dragon should not have a chain ID.")]
     OldLegacyChainId,
-    #[error("Transaction chain_id does not match.")]
+    /// The chain ID in the transaction does not match the current network configuration.
+    #[error("Transaction's chain ID does not match.")]
     ChainIdMismatch,
-    #[error("Transaction max fee is less them block base fee.")]
-    MaxFeeLessThenBaseFee,
-    #[error("Eip2930 transaction is enabled after berlin hardfork.")]
+    /// The transaction requires EIP-2930 which is not enabled currently.
+    #[error("EIP-2930 transactions are not valid before Berlin.")]
     Eip2930Disabled,
-    #[error("Eip2930 transaction is enabled after london hardfork.")]
+    /// The transaction requires EIP-1559 which is not enabled currently.
+    #[error("EIP-1559 transactions are not valid before London.")]
     Eip1559Disabled,
-    /// Thrown when calculating gas usage
-    #[error("gas uint64 overflow")]
-    GasUintOverflow,
-    /// returned if the transaction is specified to use less gas than required to start the
-    /// invocation.
-    #[error("intrinsic gas too low")]
-    GasTooLow,
-    /// returned if the transaction gas exceeds the limit
-    #[error("intrinsic gas too high")]
-    GasTooHigh,
-    /// thrown if a transaction is not supported in the current network configuration.
-    #[error("transaction type not supported")]
+    /// Thrown if a transaction is not supported in the current network configuration.
+    #[error("Transaction type not supported")]
     TxTypeNotSupported,
+    /// The calculated gas of the transaction exceeds `u64::MAX`.
+    #[error("Gas overflow (maximum of u64)")]
+    GasUintOverflow,
+    /// The transaction is specified to use less gas than required to start the
+    /// invocation.
+    #[error("Intrinsic gas too low")]
+    GasTooLow,
+    /// The transaction gas exceeds the limit
+    #[error("Intrinsic gas too high")]
+    GasTooHigh,
     /// Thrown to ensure no one is able to specify a transaction with a tip higher than the total
     /// fee cap.
-    #[error("max priority fee per gas higher than max fee per gas")]
+    #[error("Max priority fee per gas higher than max fee per gas")]
     TipAboveFeeCap,
     /// Thrown post London if the transaction's fee is less than the base fee of the block
-    #[error("max fee per gas less than block base fee")]
+    #[error("Max fee per gas less than block base fee")]
     FeeCapTooLow,
     /// Thrown if the sender of a transaction is a contract.
     #[error("Transaction signer has bytecode set.")]

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -149,15 +149,13 @@ impl InvalidPoolTransactionError {
                         // transaction could just have arrived late/early
                         false
                     }
-                    InvalidTransactionError::PriorityFeeMoreThenMaxFee |
                     InvalidTransactionError::GasTooLow |
                     InvalidTransactionError::GasTooHigh |
                     InvalidTransactionError::TipAboveFeeCap => {
                         // these are technically not invalid
                         false
                     }
-                    InvalidTransactionError::FeeCapTooLow |
-                    InvalidTransactionError::MaxFeeLessThenBaseFee => {
+                    InvalidTransactionError::FeeCapTooLow => {
                         // dynamic, but not used during validation
                         false
                     }


### PR DESCRIPTION
- Four of the error variants were duplicates (i.e. we just need 2 of them)
- Some of the error variants had typos

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b12cf02</samp>

*  Rename errors related to EIP-1559 terminology and update error messages ([link](https://github.com/paradigmxyz/reth/pull/2737/files?diff=unified&w=0#diff-6af93f5eb1bf31ae0c4b0257a669a44b3084168e4def801437cc99f9681491e7L97-R97), [link](https://github.com/paradigmxyz/reth/pull/2737/files?diff=unified&w=0#diff-6af93f5eb1bf31ae0c4b0257a669a44b3084168e4def801437cc99f9681491e7L112-R112), [link](https://github.com/paradigmxyz/reth/pull/2737/files?diff=unified&w=0#diff-4f4c2263802954bba36bbe9746ca0590394be5ce2d2ba36b6866b96b2d9e5c7cL8-R44), [link](https://github.com/paradigmxyz/reth/pull/2737/files?diff=unified&w=0#diff-ceb1a8a44b9df7185b20ee1bf45a018c0e135e4aafd29dc4f0a0377d03395bd6L152), [link](https://github.com/paradigmxyz/reth/pull/2737/files?diff=unified&w=0#diff-ceb1a8a44b9df7185b20ee1bf45a018c0e135e4aafd29dc4f0a0377d03395bd6L159-R158))
* Fix typo in error message for `BaseFeeDiff` in `consensus.rs` ([link](https://github.com/paradigmxyz/reth/pull/2737/files?diff=unified&w=0#diff-b888edd502864918b163a16603e9ead71fd7eb3868f2d6f957a08a918195213fL92-R92))