### PR TITLE
refactor: expanded cli version info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,9 +138,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anyhow"
-version = "1.0.69"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "aquamarine"
@@ -509,7 +509,6 @@ checksum = "96f9cdd34d6eb553f9ea20e5bf84abb7b13c729f113fc1d8e49dc00ad9fa8738"
 dependencies = [
  "cargo-lock",
  "chrono",
- "git2",
  "semver 1.0.17",
 ]
 
@@ -2294,19 +2293,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
-name = "git2"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
-dependencies = [
- "bitflags",
- "libc",
- "libgit2-sys",
- "log",
- "url",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3209,18 +3195,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.14.2+1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3235,18 +3209,6 @@ name = "libm"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
-
-[[package]]
-name = "libz-sys"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "lifetimed-bytes"
@@ -4649,6 +4611,7 @@ dependencies = [
  "toml 0.7.3",
  "tracing",
  "tui",
+ "vergen",
 ]
 
 [[package]]
@@ -5788,9 +5751,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "rusty-fork"
@@ -7348,10 +7311,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
+name = "vergen"
+version = "8.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+checksum = "6e03272e388fb78fc79481a493424f78d77be1d55f21bcd314b5a6716e195afe"
+dependencies = [
+ "anyhow",
+ "rustversion",
+ "time",
+]
 
 [[package]]
 name = "version_check"

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -7,9 +7,6 @@ repository = "https://github.com/paradigmxyz/reth"
 readme = "README.md"
 build = "build.rs"
 
-[build-dependencies]
-built = { version = "0.6", features = ["git2", "chrono", "semver"] }
-
 # Add jemalloc for extra perf on Linux systems.
 [target.'cfg(all(not(windows), not(target_env = "musl")))'.dependencies]
 jemallocator = "0.5.0"
@@ -87,7 +84,7 @@ hyper = "0.14.25"
 
 # misc
 eyre = "0.6.8"
-clap = { version = "4", features = ["derive", "cargo"] }
+clap = { version = "4", features = ["derive"] }
 num_cpus = "1.13.0"
 tempfile = { version = "3.3.0" }
 backon = "0.4"
@@ -97,3 +94,6 @@ pretty_assertions = "1.3.0"
 
 [features]
 only-info-logs = ["tracing/release_max_level_info"]
+
+[build-dependencies]
+vergen = { version = "8.0.0", features = ["build", "cargo", "git", "gitcl"] }

--- a/bin/reth/build.rs
+++ b/bin/reth/build.rs
@@ -1,6 +1,8 @@
-fn main() {
-    let mut opts = built::Options::default();
-    opts.set_dependencies(true);
+use std::error::Error;
+use vergen::EmitBuilder;
 
-    built::write_built_file().expect("Failed to acquire build-time information");
+fn main() -> Result<(), Box<dyn Error>> {
+    // Emit the instructions
+    EmitBuilder::builder().git_sha(true).build_timestamp().cargo_features().emit()?;
+    Ok(())
 }

--- a/bin/reth/src/chain/import.rs
+++ b/bin/reth/src/chain/import.rs
@@ -1,8 +1,9 @@
 use crate::{
     dirs::{DataDirPath, MaybePlatformPath},
     node::events::{handle_events, NodeEvent},
+    short_version,
 };
-use clap::{crate_version, Parser};
+use clap::Parser;
 use eyre::Context;
 use futures::{Stream, StreamExt};
 use reth_beacon_consensus::BeaconConsensus;
@@ -77,7 +78,7 @@ pub struct ImportCommand {
 impl ImportCommand {
     /// Execute `import` command
     pub async fn execute(self) -> eyre::Result<()> {
-        info!(target: "reth::cli", "reth {} starting", crate_version!());
+        info!(target: "reth::cli", "reth {} starting", short_version!());
 
         // add network name to data dir
         let data_dir = self.datadir.unwrap_or_chain_default(self.chain.chain);

--- a/bin/reth/src/chain/import.rs
+++ b/bin/reth/src/chain/import.rs
@@ -1,7 +1,7 @@
 use crate::{
     dirs::{DataDirPath, MaybePlatformPath},
     node::events::{handle_events, NodeEvent},
-    short_version,
+    version::SHORT_VERSION,
 };
 use clap::Parser;
 use eyre::Context;
@@ -78,7 +78,7 @@ pub struct ImportCommand {
 impl ImportCommand {
     /// Execute `import` command
     pub async fn execute(self) -> eyre::Result<()> {
-        info!(target: "reth::cli", "reth {} starting", short_version!());
+        info!(target: "reth::cli", "reth {} starting", SHORT_VERSION);
 
         // add network name to data dir
         let data_dir = self.datadir.unwrap_or_chain_default(self.chain.chain);

--- a/bin/reth/src/cli.rs
+++ b/bin/reth/src/cli.rs
@@ -2,9 +2,9 @@
 use crate::{
     chain, config, db,
     dirs::{LogsDir, PlatformPath},
-    merkle_debug, node, p2p,
+    long_version, merkle_debug, node, p2p,
     runner::CliRunner,
-    stage, test_eth_chain, test_vectors,
+    short_version, stage, test_eth_chain, test_vectors,
 };
 use clap::{ArgAction, Args, Parser, Subcommand};
 use reth_tracing::{
@@ -76,7 +76,7 @@ pub enum Commands {
 }
 
 #[derive(Debug, Parser)]
-#[command(author, version = "0.1", about = "Reth", long_about = None)]
+#[command(author, version = short_version!(), long_version = long_version!(), about = "Reth", long_about = None)]
 struct Cli {
     /// The command to run
     #[clap(subcommand)]

--- a/bin/reth/src/cli.rs
+++ b/bin/reth/src/cli.rs
@@ -2,9 +2,10 @@
 use crate::{
     chain, config, db,
     dirs::{LogsDir, PlatformPath},
-    long_version, merkle_debug, node, p2p,
+    merkle_debug, node, p2p,
     runner::CliRunner,
-    short_version, stage, test_eth_chain, test_vectors,
+    stage, test_eth_chain, test_vectors,
+    version::{LONG_VERSION, SHORT_VERSION},
 };
 use clap::{ArgAction, Args, Parser, Subcommand};
 use reth_tracing::{
@@ -76,7 +77,7 @@ pub enum Commands {
 }
 
 #[derive(Debug, Parser)]
-#[command(author, version = short_version!(), long_version = long_version!(), about = "Reth", long_about = None)]
+#[command(author, version = SHORT_VERSION, long_version = LONG_VERSION, about = "Reth", long_about = None)]
 struct Cli {
     /// The command to run
     #[clap(subcommand)]

--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -22,6 +22,6 @@ pub mod stage;
 pub mod test_eth_chain;
 pub mod test_vectors;
 pub mod utils;
-pub mod version;
+mod version;
 use built as _;
 use jemallocator as _;

--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -22,6 +22,6 @@ pub mod stage;
 pub mod test_eth_chain;
 pub mod test_vectors;
 pub mod utils;
-mod version;
+pub mod version;
 use built as _;
 use jemallocator as _;

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -6,9 +6,10 @@ use crate::{
     dirs::DataDirPath,
     prometheus_exporter,
     runner::CliContext,
+    short_version,
     utils::get_single_header,
 };
-use clap::{crate_version, Parser};
+use clap::Parser;
 use eyre::Context;
 use fdlimit::raise_fd_limit;
 use futures::{pin_mut, stream::select as stream_select, StreamExt};
@@ -135,7 +136,7 @@ pub struct Command {
 impl Command {
     /// Execute `node` command
     pub async fn execute(self, ctx: CliContext) -> eyre::Result<()> {
-        info!(target: "reth::cli", "reth {} starting", crate_version!());
+        info!(target: "reth::cli", "reth {} starting", short_version!());
 
         // Raise the fd limit of the process.
         // Does not do anything on windows.

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -6,8 +6,8 @@ use crate::{
     dirs::DataDirPath,
     prometheus_exporter,
     runner::CliContext,
-    short_version,
     utils::get_single_header,
+    version::SHORT_VERSION,
 };
 use clap::Parser;
 use eyre::Context;
@@ -136,7 +136,7 @@ pub struct Command {
 impl Command {
     /// Execute `node` command
     pub async fn execute(self, ctx: CliContext) -> eyre::Result<()> {
-        info!(target: "reth::cli", "reth {} starting", short_version!());
+        info!(target: "reth::cli", "reth {} starting", SHORT_VERSION);
 
         // Raise the fd limit of the process.
         // Does not do anything on windows.

--- a/bin/reth/src/stage/run.rs
+++ b/bin/reth/src/stage/run.rs
@@ -4,7 +4,7 @@
 use crate::{
     args::{get_secret_key, NetworkArgs, StageEnum},
     dirs::{DataDirPath, MaybePlatformPath},
-    prometheus_exporter,
+    prometheus_exporter, short_version,
 };
 use clap::Parser;
 use reth_beacon_consensus::BeaconConsensus;
@@ -105,7 +105,7 @@ impl Command {
         let config_path = self.config.clone().unwrap_or(data_dir.config_path());
 
         let config: Config = confy::load_path(config_path).unwrap_or_default();
-        info!(target: "reth::cli", "reth {} starting stage {:?}", clap::crate_version!(), self.stage);
+        info!(target: "reth::cli", "reth {} starting stage {:?}", short_version!(), self.stage);
 
         // use the overridden db path if specified
         let db_path = data_dir.db_path();

--- a/bin/reth/src/stage/run.rs
+++ b/bin/reth/src/stage/run.rs
@@ -4,7 +4,8 @@
 use crate::{
     args::{get_secret_key, NetworkArgs, StageEnum},
     dirs::{DataDirPath, MaybePlatformPath},
-    prometheus_exporter, short_version,
+    prometheus_exporter,
+    version::SHORT_VERSION,
 };
 use clap::Parser;
 use reth_beacon_consensus::BeaconConsensus;
@@ -105,7 +106,7 @@ impl Command {
         let config_path = self.config.clone().unwrap_or(data_dir.config_path());
 
         let config: Config = confy::load_path(config_path).unwrap_or_default();
-        info!(target: "reth::cli", "reth {} starting stage {:?}", short_version!(), self.stage);
+        info!(target: "reth::cli", "reth {} starting stage {:?}", SHORT_VERSION, self.stage);
 
         // use the overridden db path if specified
         let db_path = data_dir.db_path();

--- a/bin/reth/src/version.rs
+++ b/bin/reth/src/version.rs
@@ -5,7 +5,11 @@
 /// - The latest version from Cargo.tom
 /// - The short SHA of the latest commit.
 ///
-/// Example: "1.2.3 (defa64b2)"
+/// # Example
+///
+/// ```text
+/// 0.1.0 (defa64b2)
+/// ```
 pub(crate) const SHORT_VERSION: &str =
     concat!(env!("CARGO_PKG_VERSION"), " (", env!("VERGEN_GIT_SHA"), ")");
 
@@ -18,7 +22,14 @@ pub(crate) const SHORT_VERSION: &str =
 /// - The build datetime
 /// - The build features
 ///
-/// Example: "1.2.3 (defa64b2)"
+/// # Example:
+///
+/// ```text
+/// Version: 0.1.0
+/// Commit SHA: defa64b2
+/// Build Timestamp: 2023-05-19T01:47:19.815651705Z
+/// Build Features: jemalloc
+/// ```
 pub(crate) const LONG_VERSION: &str = concat!(
     "Version: ",
     env!("CARGO_PKG_VERSION"),

--- a/bin/reth/src/version.rs
+++ b/bin/reth/src/version.rs
@@ -1,17 +1,15 @@
-/// Expands to the short version information for reth.
+//! Version information for reth.
+
+/// The short version information for reth.
 ///
 /// - The latest version from Cargo.tom
 /// - The short SHA of the latest commit.
 ///
 /// Example: "1.2.3 (defa64b2)"
-#[macro_export]
-macro_rules! short_version {
-    () => {
-        concat!(env!("CARGO_PKG_VERSION"), " (", env!("VERGEN_GIT_SHA"), ")")
-    };
-}
+pub(crate) const SHORT_VERSION: &str =
+    concat!(env!("CARGO_PKG_VERSION"), " (", env!("VERGEN_GIT_SHA"), ")");
 
-/// Expands to the long version information for reth.
+/// The long version information for reth.
 ///
 /// Expands to the short version information for reth.
 ///
@@ -21,21 +19,16 @@ macro_rules! short_version {
 /// - The build features
 ///
 /// Example: "1.2.3 (defa64b2)"
-#[macro_export]
-macro_rules! long_version {
-    () => {
-        concat!(
-            "Version: ",
-            env!("CARGO_PKG_VERSION"),
-            "\n",
-            "Commit SHA: ",
-            env!("VERGEN_GIT_SHA"),
-            "\n",
-            "Build Timestamp: ",
-            env!("VERGEN_BUILD_TIMESTAMP"),
-            "\n",
-            "Build Features: ",
-            env!("VERGEN_CARGO_FEATURES")
-        )
-    };
-}
+pub(crate) const LONG_VERSION: &str = concat!(
+    "Version: ",
+    env!("CARGO_PKG_VERSION"),
+    "\n",
+    "Commit SHA: ",
+    env!("VERGEN_GIT_SHA"),
+    "\n",
+    "Build Timestamp: ",
+    env!("VERGEN_BUILD_TIMESTAMP"),
+    "\n",
+    "Build Features: ",
+    env!("VERGEN_CARGO_FEATURES")
+);

--- a/bin/reth/src/version.rs
+++ b/bin/reth/src/version.rs
@@ -41,3 +41,16 @@ pub(crate) const LONG_VERSION: &str = concat!(
     "Build Features: ",
     env!("VERGEN_CARGO_FEATURES")
 );
+
+/// The version information for reth formatted for P2P.
+///
+/// - The latest version from Cargo.toml
+/// - The target triple
+///
+/// # Example
+///
+/// ```text
+/// reth/v{major}.{minor}.{patch}/{target}
+/// ```
+pub(crate) const P2P_VERSION: &str =
+    concat!("reth/v", env!("CARGO_PKG_VERSION"), "/", env!("VERGEN_CARGO_TARGET_TRIPLE"));

--- a/bin/reth/src/version.rs
+++ b/bin/reth/src/version.rs
@@ -2,7 +2,7 @@
 
 /// The short version information for reth.
 ///
-/// - The latest version from Cargo.tom
+/// - The latest version from Cargo.toml
 /// - The short SHA of the latest commit.
 ///
 /// # Example
@@ -15,9 +15,7 @@ pub(crate) const SHORT_VERSION: &str =
 
 /// The long version information for reth.
 ///
-/// Expands to the short version information for reth.
-///
-/// - The latest version from Cargo.tom
+/// - The latest version from Cargo.toml
 /// - The long SHA of the latest commit.
 /// - The build datetime
 /// - The build features

--- a/bin/reth/src/version.rs
+++ b/bin/reth/src/version.rs
@@ -1,13 +1,41 @@
-//! This module contains the version message for the program.
-include!(concat!(env!("OUT_DIR"), "/built.rs"));
+/// Expands to the short version information for reth.
+///
+/// - The latest version from Cargo.tom
+/// - The short SHA of the latest commit.
+///
+/// Example: "1.2.3 (defa64b2)"
+#[macro_export]
+macro_rules! short_version {
+    () => {
+        concat!(env!("CARGO_PKG_VERSION"), " (", env!("VERGEN_GIT_SHA"), ")")
+    };
+}
 
-const VERSION: &str = PKG_VERSION;
-const NAME: &str = PKG_NAME;
-const SHA: Option<&str> = GIT_COMMIT_HASH_SHORT;
-const OS: &str = std::env::consts::OS;
-
-/// The version message for the current program, like
-/// `reth/v0.1.0/macos-6fc95a5/`
-pub fn version_message() -> String {
-    format!("{}/v{}/{}-{}", NAME, VERSION, OS, SHA.unwrap())
+/// Expands to the long version information for reth.
+///
+/// Expands to the short version information for reth.
+///
+/// - The latest version from Cargo.tom
+/// - The long SHA of the latest commit.
+/// - The build datetime
+/// - The build features
+///
+/// Example: "1.2.3 (defa64b2)"
+#[macro_export]
+macro_rules! long_version {
+    () => {
+        concat!(
+            "Version: ",
+            env!("CARGO_PKG_VERSION"),
+            "\n",
+            "Commit SHA: ",
+            env!("VERGEN_GIT_SHA"),
+            "\n",
+            "Build Timestamp: ",
+            env!("VERGEN_BUILD_TIMESTAMP"),
+            "\n",
+            "Build Features: ",
+            env!("VERGEN_CARGO_FEATURES")
+        )
+    };
 }


### PR DESCRIPTION
There were some issues with https://github.com/paradigmxyz/reth/pull/2277, mostly that it creates a function (that is not used anywhere), which we cannot use for Clap as it expects a string literal. We could use the function if we used the builder API, but we don't.

This PR:

- Creates 2 constants for version info (short and long)
- Applies these constants to Clap and the initial log in the commands

The short version:

```
reth 0.1.0 (defa64b2)
```

The long version:

```
reth Version: 0.1.0
Commit SHA: defa64b2
Build Timestamp: 2023-05-19T01:47:19.815651705Z
Build Features:
```

Originally I intended to display the build profile as opposed to the build features, but Cargo `PROFILE` sets any profile that isn't explicity `release` to `debug` (and we want to release with the `maxperf` profile)