### PR TITLE
chore: properly convert invalid transaction errors

### DIFF
--- a/crates/primitives/src/transaction/error.rs
+++ b/crates/primitives/src/transaction/error.rs
@@ -9,6 +9,8 @@ pub enum InvalidTransactionError {
     #[error("Sender does not have enough funds ({available_funds:?}) to cover transaction fees: {cost:?}.")]
     InsufficientFunds { cost: U256, available_funds: U256 },
     /// The nonce is lower than the account's nonce, or there is a nonce gap present.
+    ///
+    /// This is a consensus error.
     #[error("Transaction nonce is not consistent.")]
     NonceNotConsistent,
     /// The transaction is before Spurious Dragon and has a chain ID

--- a/crates/rpc/rpc/src/eth/api/fees.rs
+++ b/crates/rpc/rpc/src/eth/api/fees.rs
@@ -1,7 +1,7 @@
 //! Contains RPC handler implementations for fee history.
 
 use crate::{
-    eth::error::{EthApiError, EthResult, InvalidTransactionError},
+    eth::error::{EthApiError, EthResult, RpcInvalidTransactionError},
     EthApi,
 };
 use reth_network_api::NetworkInfo;
@@ -129,7 +129,7 @@ where
                 for transaction in transactions.iter() {
                     let reward = transaction
                         .effective_gas_tip(header.base_fee_per_gas)
-                        .ok_or(InvalidTransactionError::FeeCapTooLow)?;
+                        .ok_or(RpcInvalidTransactionError::FeeCapTooLow)?;
 
                     sorter.push(TxGasAndReward { gas_used: header.gas_used as u128, reward })
                 }

--- a/crates/rpc/rpc/src/eth/api/state.rs
+++ b/crates/rpc/rpc/src/eth/api/state.rs
@@ -1,7 +1,7 @@
 //! Contains RPC handler implementations specific to state.
 
 use crate::{
-    eth::error::{EthApiError, EthResult, InvalidTransactionError},
+    eth::error::{EthApiError, EthResult, RpcInvalidTransactionError},
     EthApi,
 };
 use reth_primitives::{
@@ -62,7 +62,7 @@ where
                     .transaction
                     .nonce()
                     .checked_add(1)
-                    .ok_or(InvalidTransactionError::NonceMaxValue)?;
+                    .ok_or(RpcInvalidTransactionError::NonceMaxValue)?;
                 return Ok(U256::from(tx_count))
             }
         }

--- a/crates/rpc/rpc/src/eth/gas_oracle.rs
+++ b/crates/rpc/rpc/src/eth/gas_oracle.rs
@@ -2,7 +2,7 @@
 //! previous blocks.
 use crate::eth::{
     cache::EthStateCache,
-    error::{EthApiError, EthResult, InvalidTransactionError},
+    error::{EthApiError, EthResult, RpcInvalidTransactionError},
 };
 use reth_primitives::{constants::GWEI_TO_WEI, BlockNumberOrTag, H256, U256};
 use reth_provider::BlockProviderIdExt;
@@ -236,7 +236,7 @@ where
         for tx in txs.iter().take(limit) {
             // a `None` effective_gas_tip represents a transaction where the max_fee_per_gas is
             // less than the base fee
-            let effective_tip = tx.ok_or(InvalidTransactionError::FeeCapTooLow)?;
+            let effective_tip = tx.ok_or(RpcInvalidTransactionError::FeeCapTooLow)?;
             final_result.push(U256::from(effective_tip));
         }
 

--- a/crates/rpc/rpc/src/eth/revm_utils.rs
+++ b/crates/rpc/rpc/src/eth/revm_utils.rs
@@ -1,6 +1,6 @@
 //! utilities for working with revm
 
-use crate::eth::error::{EthApiError, EthResult, InvalidTransactionError};
+use crate::eth::error::{EthApiError, EthResult, RpcInvalidTransactionError};
 use reth_primitives::{
     AccessList, Address, TransactionSigned, TransactionSignedEcRecovered, TxHash, H256, U256,
 };
@@ -224,9 +224,9 @@ pub(crate) fn create_txn_env(block_env: &BlockEnv, request: CallRequest) -> EthR
     let gas_limit = gas.unwrap_or(block_env.gas_limit.min(U256::from(u64::MAX)));
 
     let env = TxEnv {
-        gas_limit: gas_limit.try_into().map_err(|_| InvalidTransactionError::GasUintOverflow)?,
+        gas_limit: gas_limit.try_into().map_err(|_| RpcInvalidTransactionError::GasUintOverflow)?,
         nonce: nonce
-            .map(|n| n.try_into().map_err(|_| InvalidTransactionError::NonceTooHigh))
+            .map(|n| n.try_into().map_err(|_| RpcInvalidTransactionError::NonceTooHigh))
             .transpose()?,
         caller: from.unwrap_or_default(),
         gas_price,
@@ -257,7 +257,7 @@ where
     // subtract transferred value
     allowance = allowance
         .checked_sub(env.value)
-        .ok_or_else(|| InvalidTransactionError::InsufficientFunds)?;
+        .ok_or_else(|| RpcInvalidTransactionError::InsufficientFunds)?;
 
     // cap the gas limit
     if let Ok(gas_limit) = allowance.checked_div(env.gas_price).unwrap_or_default().try_into() {
@@ -313,7 +313,7 @@ impl CallFees {
                         // Fail early
                         return Err(
                             // `max_priority_fee_per_gas` is greater than the `max_fee_per_gas`
-                            InvalidTransactionError::TipAboveFeeCap.into(),
+                            RpcInvalidTransactionError::TipAboveFeeCap.into(),
                         )
                     }
                 }


### PR DESCRIPTION
this is a followup for #2737

This hand rolls tx error conversions specifically for rpc (mirrors geth/other client errors).
The motivation for this is to maintain full control over how certain errors are reported.


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at be246b5</samp>

This pull request renames the `InvalidTransactionError` enum and its variants in the RPC module to `RpcInvalidTransactionError`, to avoid confusion with the consensus-level `InvalidTransactionError` enum in the primitives crate. This affects several files in the `./crates/rpc/rpc/src/eth/` directory that implement the Ethereum compatibility layer.