### PR TITLE
refactor: convert InsertBlockError

### DIFF
--- a/crates/consensus/beacon/src/engine/error.rs
+++ b/crates/consensus/beacon/src/engine/error.rs
@@ -67,9 +67,12 @@ impl From<reth_interfaces::db::DatabaseError> for BeaconForkChoiceUpdateError {
 ///
 /// This represents all possible error cases that must be returned as JSON RCP errors back to the
 /// beacon node.
-#[derive(Debug, Clone, Eq, PartialEq, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum BeaconOnNewPayloadError {
     /// Thrown when the engine task is unavailable/stopped.
     #[error("beacon consensus engine task stopped")]
     EngineUnavailable,
+    /// An internal error occurred, not necessarily related to the payload.
+    #[error(transparent)]
+    Internal(Box<dyn std::error::Error + Send + Sync>),
 }

--- a/crates/interfaces/src/blockchain_tree/error.rs
+++ b/crates/interfaces/src/blockchain_tree/error.rs
@@ -69,10 +69,17 @@ impl InsertBlockError {
         &self.inner.kind
     }
 
-    /// Returns the invalid block.
+    /// Returns the block that resulted in the error
     #[inline]
     pub fn block(&self) -> &SealedBlock {
         &self.inner.block
+    }
+
+    /// Consumes the type and returns the block and error kind.
+    #[inline]
+    pub fn split(self) -> (SealedBlock, InsertBlockErrorKind) {
+        let inner = *self.inner;
+        (inner.block, inner.kind)
     }
 }
 
@@ -143,6 +150,11 @@ impl InsertBlockErrorKind {
     /// Returns true if the error is an execution error
     pub fn is_execution_error(&self) -> bool {
         matches!(self, InsertBlockErrorKind::Execution(_))
+    }
+
+    /// Returns true if the error is an internal error
+    pub fn is_internal(&self) -> bool {
+        matches!(self, InsertBlockErrorKind::Internal(_))
     }
 
     /// Returns the error if it is a tree error

--- a/crates/rpc/rpc-engine-api/src/error.rs
+++ b/crates/rpc/rpc-engine-api/src/error.rs
@@ -90,10 +90,11 @@ impl From<EngineApiError> for jsonrpsee_types::error::ErrorObject<'static> {
             // Error responses from the consensus engine
             EngineApiError::ForkChoiceUpdate(ref err) => match err {
                 BeaconForkChoiceUpdateError::ForkchoiceUpdateError(err) => return (*err).into(),
-                BeaconForkChoiceUpdateError::EngineUnavailable => INTERNAL_ERROR_CODE,
+                BeaconForkChoiceUpdateError::EngineUnavailable |
                 BeaconForkChoiceUpdateError::Internal(_) => INTERNAL_ERROR_CODE,
             },
             EngineApiError::NewPayload(ref err) => match err {
+                BeaconOnNewPayloadError::Internal(_) |
                 BeaconOnNewPayloadError::EngineUnavailable => INTERNAL_ERROR_CODE,
             },
             // Any other server error


### PR DESCRIPTION
Inserting a new payload can result in various kinds of errors, but the relevant distinction is:
* whether the payload is invalid
* or internal error


The internal error would be a database error for example.

This properly maps that error variant 