### PR TITLE
fix: make vergen emit cargo target triple

### DIFF
--- a/bin/reth/build.rs
+++ b/bin/reth/build.rs
@@ -3,6 +3,11 @@ use vergen::EmitBuilder;
 
 fn main() -> Result<(), Box<dyn Error>> {
     // Emit the instructions
-    EmitBuilder::builder().git_sha(true).build_timestamp().cargo_features().emit()?;
+    EmitBuilder::builder()
+        .git_sha(true)
+        .build_timestamp()
+        .cargo_features()
+        .cargo_target_triple()
+        .emit()?;
     Ok(())
 }

--- a/bin/reth/src/version.rs
+++ b/bin/reth/src/version.rs
@@ -52,5 +52,6 @@ pub(crate) const LONG_VERSION: &str = concat!(
 /// ```text
 /// reth/v{major}.{minor}.{patch}/{target}
 /// ```
+#[allow(dead_code)]
 pub(crate) const P2P_VERSION: &str =
     concat!("reth/v", env!("CARGO_PKG_VERSION"), "/", env!("VERGEN_CARGO_TARGET_TRIPLE"));


### PR DESCRIPTION
I merged my other PR too quickly (my bad) and forgot to turn on a flag in vergen, so the build broke.