### PR TITLE
ci: disable bench comparison workflow for main

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,7 +1,4 @@
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 env:


### PR DESCRIPTION
The benchmark comparison workflow compares main to itself, which is not really useful. To save run minutes, this PR just disables the workflow on main.

Closes https://github.com/paradigmxyz/reth/issues/2755