### PR TITLE
feat: add node identity to networking stack

### DIFF
--- a/crates/net/eth-wire/src/hello.rs
+++ b/crates/net/eth-wire/src/hello.rs
@@ -84,7 +84,7 @@ impl HelloMessageBuilder {
         self
     }
 
-    /// Sets client version.
+    /// Sets protocol version.
     pub fn protocol_version(mut self, protocol_version: ProtocolVersion) -> Self {
         self.protocol_version = Some(protocol_version);
         self

--- a/crates/net/network/src/lib.rs
+++ b/crates/net/network/src/lib.rs
@@ -147,4 +147,4 @@ pub use network::NetworkHandle;
 pub use peers::PeersConfig;
 pub use session::{PeerInfo, SessionsConfig};
 
-pub use reth_eth_wire::DisconnectReason;
+pub use reth_eth_wire::{DisconnectReason, HelloBuilder, HelloMessage};


### PR DESCRIPTION
- Adds an `--identity` flag to `reth node` (defaults to the client version) to set the identity of the node in the P2P `Hello` message

Together with #2756 this closes #2746 