### PR TITLE
chore: trace return values on insert

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -690,6 +690,7 @@ where
     ///
     /// This will return `SYNCING` if the block was buffered successfully, and an error if an error
     /// occurred while buffering the block.
+    #[instrument(level = "trace", skip_all, target = "consensus::engine", ret)]
     fn try_buffer_payload(
         &mut self,
         block: SealedBlock,
@@ -701,6 +702,7 @@ where
     /// Attempts to insert a new payload into the tree.
     ///
     /// Caution: This expects that the pipeline is idle.
+    #[instrument(level = "trace", skip_all, target = "consensus::engine", ret)]
     fn try_insert_new_payload(
         &mut self,
         block: SealedBlock,


### PR DESCRIPTION
trace return values of payload handlers