### PR TITLE
chore: consistent _senders suffix

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -694,7 +694,7 @@ where
         &mut self,
         block: SealedBlock,
     ) -> Result<PayloadStatus, InsertBlockError> {
-        self.blockchain.buffer_block_without_sender(block)?;
+        self.blockchain.buffer_block_without_senders(block)?;
         Ok(PayloadStatus::from_status(PayloadStatusEnum::Syncing))
     }
 

--- a/crates/interfaces/src/blockchain_tree/mod.rs
+++ b/crates/interfaces/src/blockchain_tree/mod.rs
@@ -15,6 +15,9 @@ pub mod error;
 ///   blocks from p2p. Do reorg in tables if canonical chain if needed.
 pub trait BlockchainTreeEngine: BlockchainTreeViewer + Send + Sync {
     /// Recover senders and call [`BlockchainTreeEngine::insert_block`].
+    ///
+    /// This will recover all senders of the transactions in the block first, and then try to insert
+    /// the block.
     fn insert_block_without_senders(
         &self,
         block: SealedBlock,
@@ -26,7 +29,10 @@ pub trait BlockchainTreeEngine: BlockchainTreeViewer + Send + Sync {
     }
 
     /// Recover senders and call [`BlockchainTreeEngine::buffer_block`].
-    fn buffer_block_without_sender(&self, block: SealedBlock) -> Result<(), InsertBlockError> {
+    ///
+    /// This will recover all senders of the transactions in the block first, and then try to buffer
+    /// the block.
+    fn buffer_block_without_senders(&self, block: SealedBlock) -> Result<(), InsertBlockError> {
         match block.try_seal_with_senders() {
             Ok(block) => self.buffer_block(block),
             Err(block) => Err(InsertBlockError::sender_recovery_error(block)),


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2e06448</samp>

Improved documentation and readability of the `BlockchainTree` trait and fixed a typo in the `BeaconEngine` struct. The changes affect the files `crates/interfaces/src/blockchain_tree/mod.rs` and `crates/consensus/beacon/src/engine/mod.rs`.