### PR TITLE
feat: add canonical outcome type

### DIFF
--- a/crates/blockchain-tree/src/block_indices.rs
+++ b/crates/blockchain-tree/src/block_indices.rs
@@ -93,9 +93,17 @@ impl BlockIndices {
         (canonical_tip.number + 1, pending_blocks)
     }
 
+    /// Returns the block number of the canonical block with the given hash.
+    ///
+    /// Returns `None` if no block could be found in the canonical chain.
+    #[inline]
+    pub(crate) fn get_canonical_block_number(&self, block_hash: &BlockHash) -> Option<BlockNumber> {
+        self.canonical_chain.get_canonical_block_number(self.last_finalized_block, block_hash)
+    }
+
     /// Check if block hash belongs to canonical chain.
-    pub fn is_block_hash_canonical(&self, block_hash: &BlockHash) -> bool {
-        self.canonical_chain.is_block_hash_canonical(self.last_finalized_block, block_hash)
+    pub(crate) fn is_block_hash_canonical(&self, block_hash: &BlockHash) -> bool {
+        self.get_canonical_block_number(block_hash).is_some()
     }
 
     /// Last finalized block

--- a/crates/blockchain-tree/src/canonical_chain.rs
+++ b/crates/blockchain-tree/src/canonical_chain.rs
@@ -42,14 +42,18 @@ impl CanonicalChain {
         )
     }
 
-    /// Check if block hash belongs to canonical chain.
+    /// Returns the block number of the canonical block with the given hash.
+    ///
+    /// Returns `None` if no block could be found in the canonical chain.
     #[inline]
-    pub(crate) fn is_block_hash_canonical(
+    pub(crate) fn get_canonical_block_number(
         &self,
         last_finalized_block: BlockNumber,
         block_hash: &BlockHash,
-    ) -> bool {
-        self.chain.range(last_finalized_block..).any(|(_, &h)| h == *block_hash)
+    ) -> Option<BlockNumber> {
+        self.chain
+            .range(last_finalized_block..)
+            .find_map(|(num, &h)| (h == *block_hash).then_some(*num))
     }
 
     /// Extends all items from the given iterator to the chain.

--- a/crates/blockchain-tree/src/shareable.rs
+++ b/crates/blockchain-tree/src/shareable.rs
@@ -5,6 +5,7 @@ use reth_db::database::Database;
 use reth_interfaces::{
     blockchain_tree::{
         error::InsertBlockError, BlockStatus, BlockchainTreeEngine, BlockchainTreeViewer,
+        CanonicalOutcome,
     },
     consensus::Consensus,
     Error,
@@ -68,7 +69,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeEngine
         self.tree.write().restore_canonical_hashes(last_finalized_block)
     }
 
-    fn make_canonical(&self, block_hash: &BlockHash) -> Result<(), Error> {
+    fn make_canonical(&self, block_hash: &BlockHash) -> Result<CanonicalOutcome, Error> {
         trace!(target: "blockchain_tree", ?block_hash, "Making block canonical");
         self.tree.write().make_canonical(block_hash)
     }

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -35,7 +35,7 @@ mod state;
 use crate::{providers::chain_info::ChainInfoTracker, traits::BlockSource};
 pub use database::*;
 pub use post_state_provider::PostStateProvider;
-use reth_interfaces::blockchain_tree::error::InsertBlockError;
+use reth_interfaces::blockchain_tree::{error::InsertBlockError, CanonicalOutcome};
 
 /// The main type for interacting with the blockchain.
 ///
@@ -394,7 +394,7 @@ where
         self.tree.restore_canonical_hashes(last_finalized_block)
     }
 
-    fn make_canonical(&self, block_hash: &BlockHash) -> Result<()> {
+    fn make_canonical(&self, block_hash: &BlockHash) -> Result<CanonicalOutcome> {
         self.tree.make_canonical(block_hash)
     }
 


### PR DESCRIPTION
give the `make_canonical` function an output type that contains the new canonical header.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 815b225</samp>

This pull request enhances the blockchain tree logic and interfaces to return more information about the canonicalization process of blocks. It introduces a new enum `CanonicalOutcome` that indicates the status and header of the canonical block, and updates the methods of the `BlockchainTree`, `ShareableBlockchainTree`, `ChainProvider`, and `BlockchainTreeEngine` to use it. It also optimizes the `BeaconEngine` by using existing methods to get block headers, and adds a new method to the `BlockIndices` struct to get the canonical block number of a block hash.