### PR TITLE
feat: add sealed headers range

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -467,6 +467,13 @@ mod tests {
         fn headers_range(&self, _range: impl RangeBounds<BlockNumber>) -> Result<Vec<Header>> {
             Ok(vec![])
         }
+
+        fn sealed_headers_range(
+            &self,
+            _range: impl RangeBounds<BlockNumber>,
+        ) -> Result<Vec<SealedHeader>> {
+            Ok(vec![])
+        }
     }
 
     impl WithdrawalsProvider for Provider {

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -99,6 +99,13 @@ where
     fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> Result<Vec<Header>> {
         self.database.headers_range(range)
     }
+
+    fn sealed_headers_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> Result<Vec<SealedHeader>> {
+        self.database.sealed_headers_range(range)
+    }
 }
 
 impl<DB, Tree> BlockHashProvider for BlockchainProvider<DB, Tree>

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -135,10 +135,7 @@ impl HeaderProvider for MockEthProvider {
         Ok(Some(sum))
     }
 
-    fn headers_range(
-        &self,
-        range: impl RangeBounds<reth_primitives::BlockNumber>,
-    ) -> Result<Vec<Header>> {
+    fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> Result<Vec<Header>> {
         let lock = self.headers.lock();
 
         let mut headers: Vec<_> =
@@ -146,6 +143,13 @@ impl HeaderProvider for MockEthProvider {
         headers.sort_by_key(|header| header.number);
 
         Ok(headers)
+    }
+
+    fn sealed_headers_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> Result<Vec<SealedHeader>> {
+        Ok(self.headers_range(range)?.into_iter().map(|h| h.seal_slow()).collect())
     }
 }
 

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -166,6 +166,13 @@ impl HeaderProvider for NoopProvider {
     fn headers_range(&self, _range: impl RangeBounds<BlockNumber>) -> Result<Vec<Header>> {
         Ok(vec![])
     }
+
+    fn sealed_headers_range(
+        &self,
+        _range: impl RangeBounds<BlockNumber>,
+    ) -> Result<Vec<SealedHeader>> {
+        Ok(vec![])
+    }
 }
 
 impl AccountProvider for NoopProvider {

--- a/crates/storage/provider/src/traits/header.rs
+++ b/crates/storage/provider/src/traits/header.rs
@@ -1,6 +1,6 @@
 use auto_impl::auto_impl;
 use reth_interfaces::Result;
-use reth_primitives::{BlockHash, BlockHashOrNumber, BlockNumber, Header, U256};
+use reth_primitives::{BlockHash, BlockHashOrNumber, BlockNumber, Header, SealedHeader, U256};
 use std::ops::RangeBounds;
 
 /// Client trait for fetching `Header` related data.
@@ -33,4 +33,10 @@ pub trait HeaderProvider: Send + Sync {
 
     /// Get headers in range of block numbers
     fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> Result<Vec<Header>>;
+
+    /// Get headers in range of block numbers
+    fn sealed_headers_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> Result<Vec<SealedHeader>>;
 }


### PR DESCRIPTION
it can be useful to retrieve a range of Sealedheaders directly.
for example, retrieve the x latest canonical headers

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 639724b</samp>

This pull request adds a new method `sealed_headers_range` to the `HeaderProvider` trait and its implementations for different types of storage providers. This method allows fetching headers with block hashes from the storage provider for a given range of block numbers. This is needed for the consensus validation logic to verify the integrity of the blockchain.