### PR TITLE
feat: track full Sealed Headers in canonical chain

### DIFF
--- a/crates/blockchain-tree/src/block_indices.rs
+++ b/crates/blockchain-tree/src/block_indices.rs
@@ -38,13 +38,10 @@ pub struct BlockIndices {
 
 impl BlockIndices {
     /// Create new block indices structure
-    pub fn new(
-        last_finalized_block: BlockNumber,
-        canonical_chain: BTreeMap<BlockNumber, BlockHash>,
-    ) -> Self {
+    pub(crate) fn new(last_finalized_block: BlockNumber, canonical_chain: CanonicalChain) -> Self {
         Self {
             last_finalized_block,
-            canonical_chain: CanonicalChain::new(canonical_chain),
+            canonical_chain,
             fork_to_child: Default::default(),
             blocks_to_chain: Default::default(),
             block_number_to_block_hashes: Default::default(),
@@ -133,7 +130,7 @@ impl BlockIndices {
     }
 
     /// Update all block hashes. iterate over present and new list of canonical hashes and compare
-    /// them. Remove all missmatches, disconnect them and return all chains that needs to be
+    /// them. Remove all mismatches, disconnect them and return all chains that need to be
     /// removed.
     pub(crate) fn update_block_hashes(
         &mut self,


### PR DESCRIPTION
blocked by https://github.com/paradigmxyz/reth/pull/2769

This tries to track full SealedHeaders instead of their hash.

I'm not 100% sure this is feasible, but ideally we always have a x amount of sealed headers in the chain, which makes things like #2765 easier and would prevent 1 guaranteed look up for on FCU
