### PR TITLE
feat: add db get subcommand

### DIFF
--- a/bin/reth/src/db/get.rs
+++ b/bin/reth/src/db/get.rs
@@ -16,7 +16,7 @@ pub struct Command {
     pub table: String, // TODO: Convert to enum
 
     /// The key to get content for
-    #[arg(long, value_parser = maybe_json_value_parser)]
+    #[arg(value_parser = maybe_json_value_parser)]
     pub key: String,
 }
 
@@ -111,13 +111,12 @@ mod tests {
 
     #[test]
     fn parse_numeric_key_args() {
-        let args = CommandParser::<Command>::parse_from(["reth", "Headers", "--key", "123"]).args;
+        let args = CommandParser::<Command>::parse_from(["reth", "Headers", "123"]).args;
         assert_eq!(args.table_key::<Headers>().unwrap(), 123);
 
         let args = CommandParser::<Command>::parse_from([
             "reth",
             "HashedAccount",
-            "--key",
             "0x0ac361fe774b78f8fc4e86c1916930d150865c3fc2e21dca2e58833557608bac",
         ])
         .args;
@@ -131,14 +130,13 @@ mod tests {
     #[test]
     fn parse_string_key_args() {
         let args =
-            CommandParser::<Command>::parse_from(["reth", "SyncStage", "--key", "MerkleExecution"])
-                .args;
+            CommandParser::<Command>::parse_from(["reth", "SyncStage", "MerkleExecution"]).args;
         assert_eq!(args.table_key::<SyncStage>().unwrap(), "MerkleExecution");
     }
 
     #[test]
     fn parse_json_key_args() {
-        let args = CommandParser::<Command>::parse_from(["reth", "StorageHistory", "--key", r#"{ "address": "0x01957911244e546ce519fbac6f798958fafadb41", "sharded_key": { "key": "0x0000000000000000000000000000000000000000000000000000000000000003", "highest_block_number": 18446744073709551615 } }"#]).args;
+        let args = CommandParser::<Command>::parse_from(["reth", "StorageHistory", r#"{ "address": "0x01957911244e546ce519fbac6f798958fafadb41", "sharded_key": { "key": "0x0000000000000000000000000000000000000000000000000000000000000003", "highest_block_number": 18446744073709551615 } }"#]).args;
         assert_eq!(
             args.table_key::<StorageHistory>().unwrap(),
             StorageShardedKey::new(

--- a/bin/reth/src/db/get.rs
+++ b/bin/reth/src/db/get.rs
@@ -1,0 +1,154 @@
+use clap::Parser;
+use eyre::WrapErr;
+use reth_db::{database::Database, table::Table, tables};
+use serde::Deserialize;
+use tracing::error;
+
+use crate::utils::DbTool;
+
+#[derive(Parser, Debug)]
+/// The arguments for the `reth db get` command
+pub struct Command {
+    /// The table name
+    ///
+    /// NOTE: The dupsort tables are not supported now.
+    #[arg()]
+    pub table: String, // TODO: Convert to enum
+
+    /// The key to get content for
+    #[arg(long, value_parser = maybe_json_value_parser)]
+    pub key: String,
+}
+
+impl Command {
+    /// Execute `db get` command
+    pub fn execute<DB: Database>(self, mut tool: DbTool<'_, DB>) -> eyre::Result<()> {
+        macro_rules! table_get {
+            ([$($table:ident),*]) => {
+                match self.table.as_str() {
+                    $(stringify!($table) => {
+                        let table_key = self.table_key::<tables::$table>().wrap_err("Could not parse the given table key.")?;
+
+                        match tool.get::<tables::$table>(table_key)? {
+                            Some(content) => {
+                                println!("{}", serde_json::to_string_pretty(&content)?);
+                            }
+                            None => {
+                                error!(target: "reth::cli", "No content for the given table key.");
+                            },
+                        };
+                        return Ok(());
+                    },)*
+                    _ => {
+                        error!(target: "reth::cli", "Unknown or unsupported table.");
+                        return Ok(());
+                    }
+                }
+            }
+        }
+
+        table_get!([
+            CanonicalHeaders,
+            HeaderTD,
+            HeaderNumbers,
+            Headers,
+            BlockBodyIndices,
+            BlockOmmers,
+            BlockWithdrawals,
+            TransactionBlock,
+            Transactions,
+            TxHashNumber,
+            Receipts,
+            PlainAccountState,
+            Bytecodes,
+            AccountHistory,
+            StorageHistory,
+            HashedAccount,
+            AccountsTrie,
+            TxSenders,
+            SyncStage,
+            SyncStageProgress
+        ]);
+    }
+
+    /// Get an instance of key for given table
+    fn table_key<T: Table>(&self) -> Result<T::Key, eyre::Error>
+    where
+        for<'a> T::Key: Deserialize<'a>,
+    {
+        assert!(T::NAME == self.table);
+
+        serde_json::from_str::<T::Key>(&self.key).map_err(|e| eyre::eyre!(e))
+    }
+}
+
+/// Map the user input value to json
+fn maybe_json_value_parser(value: &str) -> Result<String, eyre::Error> {
+    if serde_json::from_str::<serde::de::IgnoredAny>(value).is_ok() {
+        Ok(value.to_string())
+    } else {
+        serde_json::to_string(&value).map_err(|e| eyre::eyre!(e))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::{Args, Parser};
+    use reth_db::{
+        models::storage_sharded_key::StorageShardedKey, HashedAccount, Headers, StorageHistory,
+        SyncStage,
+    };
+    use reth_primitives::{H160, H256};
+    use std::str::FromStr;
+
+    /// A helper type to parse Args more easily
+    #[derive(Parser)]
+    struct CommandParser<T: Args> {
+        #[clap(flatten)]
+        args: T,
+    }
+
+    #[test]
+    fn parse_numeric_key_args() {
+        let args = CommandParser::<Command>::parse_from(["reth", "Headers", "--key", "123"]).args;
+        assert_eq!(args.table_key::<Headers>().unwrap(), 123);
+
+        let args = CommandParser::<Command>::parse_from([
+            "reth",
+            "HashedAccount",
+            "--key",
+            "0x0ac361fe774b78f8fc4e86c1916930d150865c3fc2e21dca2e58833557608bac",
+        ])
+        .args;
+        assert_eq!(
+            args.table_key::<HashedAccount>().unwrap(),
+            H256::from_str("0x0ac361fe774b78f8fc4e86c1916930d150865c3fc2e21dca2e58833557608bac")
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_string_key_args() {
+        let args =
+            CommandParser::<Command>::parse_from(["reth", "SyncStage", "--key", "MerkleExecution"])
+                .args;
+        assert_eq!(args.table_key::<SyncStage>().unwrap(), "MerkleExecution");
+    }
+
+    #[test]
+    fn parse_json_key_args() {
+        let args = CommandParser::<Command>::parse_from(["reth", "StorageHistory", "--key", r#"{ "address": "0x01957911244e546ce519fbac6f798958fafadb41", "sharded_key": { "key": "0x0000000000000000000000000000000000000000000000000000000000000003", "highest_block_number": 18446744073709551615 } }"#]).args;
+        assert_eq!(
+            args.table_key::<StorageHistory>().unwrap(),
+            StorageShardedKey::new(
+                H160::from_str("0x01957911244e546ce519fbac6f798958fafadb41").unwrap(),
+                H256::from_str(
+                    "0x0000000000000000000000000000000000000000000000000000000000000003"
+                )
+                .unwrap(),
+                18446744073709551615
+            )
+        );
+    }
+}

--- a/bin/reth/src/db/get.rs
+++ b/bin/reth/src/db/get.rs
@@ -1,13 +1,12 @@
+use crate::utils::DbTool;
 use clap::Parser;
 use eyre::WrapErr;
 use reth_db::{database::Database, table::Table, tables};
 use serde::Deserialize;
 use tracing::error;
 
-use crate::utils::DbTool;
-
-#[derive(Parser, Debug)]
 /// The arguments for the `reth db get` command
+#[derive(Parser, Debug)]
 pub struct Command {
     /// The table name
     ///
@@ -76,7 +75,7 @@ impl Command {
     where
         for<'a> T::Key: Deserialize<'a>,
     {
-        assert!(T::NAME == self.table);
+        assert_eq!(T::NAME, self.table);
 
         serde_json::from_str::<T::Key>(&self.key).map_err(|e| eyre::eyre!(e))
     }

--- a/bin/reth/src/utils.rs
+++ b/bin/reth/src/utils.rs
@@ -105,6 +105,11 @@ impl<'a, DB: Database> DbTool<'a, DB> {
             .map_err(|e| eyre::eyre!(e))
     }
 
+    /// Grabs the content of the table for the given key
+    pub fn get<T: Table>(&mut self, key: T::Key) -> Result<Option<T::Value>> {
+        self.db.view(|tx| tx.get::<T>(key))?.map_err(|e| eyre::eyre!(e))
+    }
+
     /// Drops the database at the given path.
     pub fn drop(&mut self, path: impl AsRef<Path>) -> Result<()> {
         let path = path.as_ref();

--- a/crates/storage/db/src/tables/models/sharded_key.rs
+++ b/crates/storage/db/src/tables/models/sharded_key.rs
@@ -5,7 +5,7 @@ use crate::{
     DatabaseError,
 };
 use reth_primitives::BlockNumber;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// Number of indices in one shard.
 pub const NUM_OF_INDICES_IN_SHARD: usize = 100;
@@ -16,7 +16,7 @@ pub const NUM_OF_INDICES_IN_SHARD: usize = 100;
 /// `Address | 200` -> data is from block 0 to 200.
 ///
 /// `Address | 300` -> data is from block 201 to 300.
-#[derive(Debug, Default, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct ShardedKey<T> {
     /// The key for this type.
     pub key: T,

--- a/crates/storage/db/src/tables/models/storage_sharded_key.rs
+++ b/crates/storage/db/src/tables/models/storage_sharded_key.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 use reth_primitives::{BlockNumber, H160, H256};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::ShardedKey;
 
@@ -19,7 +19,7 @@ pub const NUM_OF_INDICES_IN_SHARD: usize = 100;
 /// `Address | Storagekey | 200` -> data is from transition 0 to 200.
 ///
 /// `Address | StorageKey | 300` -> data is from transition 201 to 300.
-#[derive(Debug, Default, Clone, Eq, Ord, PartialOrd, PartialEq, Serialize)]
+#[derive(Debug, Default, Clone, Eq, Ord, PartialOrd, PartialEq, Serialize, Deserialize)]
 pub struct StorageShardedKey {
     /// Storage account address.
     pub address: H160,


### PR DESCRIPTION
Added a new subcommand for db cli to get content by given table key.

Closes #1023

Sample scenarios:
- get by numeric table key: 
`reth db get Headers 1`

- get by hashed table key: 
`reth db get StoragesTrie 0x0ac361fe774b78f8fc4e86c1916930d150865c3fc2e21dca2e58833557608bac`

- get by composite table key (as json, for example `StorageShardedKey`):
`reth db get StorageHistory '{ "address": "0x01957911244e546ce519fbac6f798958fafadb41", "sharded_key": { "key": "0x0000000000000000000000000000000000000000000000000000000000000003", "highest_block_number": 18446744073709551615 } }'`

- get by string table key: 
`reth db get SyncStage SenderRecovery`

Real world example:
<img width="963" alt="image" src="https://github.com/paradigmxyz/reth/assets/1993443/a3bdcdc0-5ee6-46cc-949e-20abbd630182">

