### PR TITLE
chore: use release profile in docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
 
 # Set the build profile to be release
-ARG BUILD_PROFILE=maxperf
+ARG BUILD_PROFILE=release
 ENV BUILD_PROFILE $BUILD_PROFILE
 
 # Install system dependencies


### PR DESCRIPTION
we're still using docker a lot for debugging hive, using the maxperf profile takes significantly longer than release and slows this process down.

recommend to use release for now.

also, the current dockerfile is broken since #2677 because this tries to copy from a non existent location:

https://github.com/paradigmxyz/reth/blob/2d060399a2b5a83a2a865c8ceec1767cb7f12d9a/Dockerfile#L31-L31