### PR TITLE
chore: feature gate IpcClientBuilder

### DIFF
--- a/crates/rpc/ipc/src/client.rs
+++ b/crates/rpc/ipc/src/client.rs
@@ -101,6 +101,7 @@ impl IpcTransportClientBuilder {
     /// ```
     pub async fn build(self, path: impl AsRef<Path>) -> Result<(Sender, Receiver), IpcError> {
         let path = path.as_ref();
+
         let stream = UnixStream::connect(path)
             .await
             .map_err(|err| IpcError::FailedToConnect { path: path.to_path_buf(), err })?;

--- a/crates/rpc/ipc/src/lib.rs
+++ b/crates/rpc/ipc/src/lib.rs
@@ -7,6 +7,7 @@
 
 //! Reth IPC implementation
 
+#[cfg(unix)]
 pub mod client;
 pub mod server;
 

--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -577,7 +577,7 @@ impl<B, L> Builder<B, L> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use crate::client::IpcClientBuilder;


### PR DESCRIPTION
Closes #2777

the `IpcClientBuilder` makes use of `UnixStream` which is only available on UNIX.

for windows we need another implementation that uses tokio's named pipe:

https://docs.rs/tokio/latest/tokio/net/windows/named_pipe/index.html

Note: this only affects the client implementation which is not used by the node itself, the server is already cross platform.