### PR TITLE
feat(stages): checkpoint downloaded headers

### DIFF
--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -4,7 +4,7 @@ use futures::Stream;
 use reth_beacon_consensus::BeaconConsensusEngineEvent;
 use reth_network::{NetworkEvent, NetworkHandle};
 use reth_network_api::PeersInfo;
-use reth_primitives::{BlockNumber, StageCheckpoint};
+use reth_primitives::StageCheckpoint;
 use reth_stages::{ExecOutput, PipelineEvent, StageId};
 use std::{
     future::Future,
@@ -22,12 +22,12 @@ struct NodeState {
     /// The stage currently being executed.
     current_stage: Option<StageId>,
     /// The current checkpoint of the executing stage.
-    current_checkpoint: BlockNumber,
+    current_checkpoint: StageCheckpoint,
 }
 
 impl NodeState {
     fn new(network: Option<NetworkHandle>) -> Self {
-        Self { network, current_stage: None, current_checkpoint: 0 }
+        Self { network, current_stage: None, current_checkpoint: StageCheckpoint::new(0) }
     }
 
     fn num_connected_peers(&self) -> usize {
@@ -37,26 +37,23 @@ impl NodeState {
     /// Processes an event emitted by the pipeline
     fn handle_pipeline_event(&mut self, event: PipelineEvent) {
         match event {
-            PipelineEvent::Running { stage_id, stage_progress } => {
+            PipelineEvent::Running { stage_id, checkpoint } => {
                 let notable = self.current_stage.is_none();
                 self.current_stage = Some(stage_id);
-                self.current_checkpoint = stage_progress.unwrap_or_default();
+                self.current_checkpoint = checkpoint.unwrap_or_default();
 
                 if notable {
-                    info!(target: "reth::cli", stage = %stage_id, from = stage_progress, "Executing stage");
+                    info!(target: "reth::cli", stage = %stage_id, from = ?checkpoint, "Executing stage");
                 }
             }
-            PipelineEvent::Ran {
-                stage_id,
-                result: ExecOutput { checkpoint: StageCheckpoint { block_number, .. }, done },
-            } => {
-                let notable = block_number > self.current_checkpoint;
-                self.current_checkpoint = block_number;
+            PipelineEvent::Ran { stage_id, result: ExecOutput { checkpoint, done } } => {
+                let notable = checkpoint.block_number > self.current_checkpoint.block_number;
+                self.current_checkpoint = checkpoint;
                 if done {
                     self.current_stage = None;
-                    info!(target: "reth::cli", stage = %stage_id, checkpoint = block_number, "Stage finished executing");
+                    info!(target: "reth::cli", stage = %stage_id, checkpoint = %checkpoint, "Stage finished executing");
                 } else if notable {
-                    info!(target: "reth::cli", stage = %stage_id, checkpoint = block_number, "Stage committed progress");
+                    info!(target: "reth::cli", stage = %stage_id, checkpoint = %checkpoint, "Stage committed progress");
                 }
             }
             _ => (),
@@ -160,7 +157,7 @@ where
                 .current_stage
                 .map(|id| id.to_string())
                 .unwrap_or_else(|| "None".to_string());
-            info!(target: "reth::cli", connected_peers = this.state.num_connected_peers(), %stage, checkpoint = this.state.current_checkpoint, "Status");
+            info!(target: "reth::cli", connected_peers = this.state.num_connected_peers(), %stage, checkpoint = %this.state.current_checkpoint, "Status");
         }
 
         while let Poll::Ready(Some(event)) = this.events.as_mut().poll_next(cx) {

--- a/crates/primitives/src/checkpoints.rs
+++ b/crates/primitives/src/checkpoints.rs
@@ -133,6 +133,16 @@ pub struct HeadersCheckpoint {
     pub total_headers: u64,
 }
 
+impl Display for HeadersCheckpoint {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if self.total_headers > 0 {
+            write!(f, "{:.1}%", 100.0 * self.downloaded_headers as f64 / self.total_headers as f64)
+        } else {
+            write!(f, "{}", self.downloaded_headers)
+        }
+    }
+}
+
 /// Saves the progress of a stage.
 #[main_codec]
 #[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
@@ -201,16 +211,7 @@ impl StageCheckpoint {
 impl Display for StageCheckpoint {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self.stage_checkpoint {
-            Some(StageUnitCheckpoint::Headers(HeadersCheckpoint {
-                downloaded_headers,
-                total_headers,
-            })) => {
-                if total_headers > 0 {
-                    write!(f, "{:.1}%", 100.0 * downloaded_headers as f64 / total_headers as f64)
-                } else {
-                    write!(f, "{downloaded_headers}")
-                }
-            }
+            Some(StageUnitCheckpoint::Headers(stage_checkpoint)) => stage_checkpoint.fmt(f),
             _ => write!(f, "{}", self.block_number),
         }
     }

--- a/crates/primitives/src/checkpoints.rs
+++ b/crates/primitives/src/checkpoints.rs
@@ -165,7 +165,7 @@ impl StageCheckpoint {
         }
     }
 
-    /// Returns the storage hashing stage checkpoint, if any.
+    /// Returns the headers stage checkpoint, if any.
     pub fn headers_stage_checkpoint(&self) -> Option<HeadersCheckpoint> {
         match self.stage_checkpoint {
             Some(StageUnitCheckpoint::Headers(checkpoint)) => Some(checkpoint),
@@ -191,7 +191,7 @@ impl StageCheckpoint {
         self
     }
 
-    /// Sets the stage checkpoint to storage hashing.
+    /// Sets the stage checkpoint to headers.
     pub fn with_headers_stage_checkpoint(mut self, checkpoint: HeadersCheckpoint) -> Self {
         self.stage_checkpoint = Some(StageUnitCheckpoint::Headers(checkpoint));
         self

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -51,8 +51,8 @@ pub use chain::{
     MAINNET, SEPOLIA,
 };
 pub use checkpoints::{
-    AccountHashingCheckpoint, MerkleCheckpoint, StageCheckpoint, StageUnitCheckpoint,
-    StorageHashingCheckpoint,
+    AccountHashingCheckpoint, HeadersCheckpoint, MerkleCheckpoint, StageCheckpoint,
+    StageUnitCheckpoint, StorageHashingCheckpoint,
 };
 pub use compression::*;
 pub use constants::{

--- a/crates/stages/src/pipeline/event.rs
+++ b/crates/stages/src/pipeline/event.rs
@@ -2,7 +2,7 @@ use crate::{
     id::StageId,
     stage::{ExecOutput, UnwindInput, UnwindOutput},
 };
-use reth_primitives::BlockNumber;
+use reth_primitives::StageCheckpoint;
 
 /// An event emitted by a [Pipeline][crate::Pipeline].
 ///
@@ -18,7 +18,7 @@ pub enum PipelineEvent {
         /// The stage that is about to be run.
         stage_id: StageId,
         /// The previous checkpoint of the stage.
-        stage_progress: Option<BlockNumber>,
+        checkpoint: Option<StageCheckpoint>,
     },
     /// Emitted when a stage has run a single time.
     Ran {

--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -314,10 +314,7 @@ where
                 })
             }
 
-            self.listeners.notify(PipelineEvent::Running {
-                stage_id,
-                stage_progress: prev_checkpoint.map(|progress| progress.block_number),
-            });
+            self.listeners.notify(PipelineEvent::Running { stage_id, checkpoint: prev_checkpoint });
 
             match stage
                 .execute(&mut tx, ExecInput { previous_stage, checkpoint: prev_checkpoint })
@@ -464,12 +461,12 @@ mod tests {
         assert_eq!(
             events.collect::<Vec<PipelineEvent>>().await,
             vec![
-                PipelineEvent::Running { stage_id: StageId("A"), stage_progress: None },
+                PipelineEvent::Running { stage_id: StageId("A"), checkpoint: None },
                 PipelineEvent::Ran {
                     stage_id: StageId("A"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(20), done: true },
                 },
-                PipelineEvent::Running { stage_id: StageId("B"), stage_progress: None },
+                PipelineEvent::Running { stage_id: StageId("B"), checkpoint: None },
                 PipelineEvent::Ran {
                     stage_id: StageId("B"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(10), done: true },
@@ -517,17 +514,17 @@ mod tests {
             events.collect::<Vec<PipelineEvent>>().await,
             vec![
                 // Executing
-                PipelineEvent::Running { stage_id: StageId("A"), stage_progress: None },
+                PipelineEvent::Running { stage_id: StageId("A"), checkpoint: None },
                 PipelineEvent::Ran {
                     stage_id: StageId("A"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(100), done: true },
                 },
-                PipelineEvent::Running { stage_id: StageId("B"), stage_progress: None },
+                PipelineEvent::Running { stage_id: StageId("B"), checkpoint: None },
                 PipelineEvent::Ran {
                     stage_id: StageId("B"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(10), done: true },
                 },
-                PipelineEvent::Running { stage_id: StageId("C"), stage_progress: None },
+                PipelineEvent::Running { stage_id: StageId("C"), checkpoint: None },
                 PipelineEvent::Ran {
                     stage_id: StageId("C"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(20), done: true },
@@ -606,12 +603,12 @@ mod tests {
             events.collect::<Vec<PipelineEvent>>().await,
             vec![
                 // Executing
-                PipelineEvent::Running { stage_id: StageId("A"), stage_progress: None },
+                PipelineEvent::Running { stage_id: StageId("A"), checkpoint: None },
                 PipelineEvent::Ran {
                     stage_id: StageId("A"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(100), done: true },
                 },
-                PipelineEvent::Running { stage_id: StageId("B"), stage_progress: None },
+                PipelineEvent::Running { stage_id: StageId("B"), checkpoint: None },
                 PipelineEvent::Ran {
                     stage_id: StageId("B"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(10), done: true },
@@ -680,12 +677,12 @@ mod tests {
         assert_eq!(
             events.collect::<Vec<PipelineEvent>>().await,
             vec![
-                PipelineEvent::Running { stage_id: StageId("A"), stage_progress: None },
+                PipelineEvent::Running { stage_id: StageId("A"), checkpoint: None },
                 PipelineEvent::Ran {
                     stage_id: StageId("A"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(10), done: true },
                 },
-                PipelineEvent::Running { stage_id: StageId("B"), stage_progress: None },
+                PipelineEvent::Running { stage_id: StageId("B"), checkpoint: None },
                 PipelineEvent::Error { stage_id: StageId("B") },
                 PipelineEvent::Unwinding {
                     stage_id: StageId("A"),
@@ -699,12 +696,15 @@ mod tests {
                     stage_id: StageId("A"),
                     result: UnwindOutput { checkpoint: StageCheckpoint::new(0) },
                 },
-                PipelineEvent::Running { stage_id: StageId("A"), stage_progress: Some(0) },
+                PipelineEvent::Running {
+                    stage_id: StageId("A"),
+                    checkpoint: Some(StageCheckpoint::new(0))
+                },
                 PipelineEvent::Ran {
                     stage_id: StageId("A"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(10), done: true },
                 },
-                PipelineEvent::Running { stage_id: StageId("B"), stage_progress: None },
+                PipelineEvent::Running { stage_id: StageId("B"), checkpoint: None },
                 PipelineEvent::Ran {
                     stage_id: StageId("B"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(10), done: true },

--- a/crates/stages/src/pipeline/sync_metrics.rs
+++ b/crates/stages/src/pipeline/sync_metrics.rs
@@ -1,7 +1,7 @@
 use crate::StageId;
 use metrics::Gauge;
 use reth_metrics_derive::Metrics;
-use reth_primitives::StageCheckpoint;
+use reth_primitives::{HeadersCheckpoint, StageCheckpoint, StageUnitCheckpoint};
 use std::collections::HashMap;
 
 #[derive(Metrics)]
@@ -9,6 +9,10 @@ use std::collections::HashMap;
 pub(crate) struct StageMetrics {
     /// The block number of the last commit for a stage.
     checkpoint: Gauge,
+    /// The number of processed entities of the last commit for a stage, if applicable.
+    entities_processed: Gauge,
+    /// The number of total entities of the last commit for a stage, if applicable.
+    entities_total: Gauge,
 }
 
 #[derive(Default)]
@@ -18,11 +22,23 @@ pub(crate) struct Metrics {
 
 impl Metrics {
     pub(crate) fn stage_checkpoint(&mut self, stage_id: StageId, checkpoint: StageCheckpoint) {
-        // TODO(alexey): track other metrics from `checkpoint`
-        self.checkpoints
+        let stage_metrics = self
+            .checkpoints
             .entry(stage_id)
-            .or_insert_with(|| StageMetrics::new_with_labels(&[("stage", stage_id.to_string())]))
-            .checkpoint
-            .set(checkpoint.block_number as f64);
+            .or_insert_with(|| StageMetrics::new_with_labels(&[("stage", stage_id.to_string())]));
+
+        stage_metrics.checkpoint.set(checkpoint.block_number as f64);
+
+        #[allow(clippy::single_match)]
+        match checkpoint.stage_checkpoint {
+            Some(StageUnitCheckpoint::Headers(HeadersCheckpoint {
+                downloaded_headers,
+                total_headers,
+            })) => {
+                stage_metrics.entities_processed.set(downloaded_headers as f64);
+                stage_metrics.entities_total.set(total_headers as f64);
+            }
+            _ => (),
+        }
     }
 }

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -255,10 +255,9 @@ where
             .headers_stage_checkpoint()
             .unwrap_or(HeadersCheckpoint {
             // If for some reason (e.g. due to DB migration) we don't have `downloaded_headers`,
-            // set it to the local head block number. It is correct because on the first
-            // iteration of headers stage, local head block number equals to the total headers
-            // downloaded so far.
-            downloaded_headers: local_head,
+            // set it to the local head block number + number of block already filled in the gap.
+            downloaded_headers: local_head +
+                (target_block_number.unwrap_or_default() - tip_block_number.unwrap_or_default()),
             // Shouldn't fail because on the first iteration, we download the header for missing
             // tip, and use its block number.
             total_headers: target_block_number.unwrap_or_else(|| {

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -254,8 +254,9 @@ where
         let mut stage_checkpoint = current_progress
             .headers_stage_checkpoint()
             .unwrap_or(HeadersCheckpoint {
-            // If for some reason (e.g. due to DB migration) we don't have `downloaded_headers`,
-            // set it to the local head block number + number of block already filled in the gap.
+            // If for some reason (e.g. due to DB migration) we don't have `downloaded_headers`
+            // in the middle of headers sync, set it to the local head block number +
+            // number of block already filled in the gap.
             downloaded_headers: local_head +
                 (target_block_number.unwrap_or_default() - tip_block_number.unwrap_or_default()),
             // Shouldn't fail because on the first iteration, we download the header for missing

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -263,8 +263,8 @@ where
             // tip, and use its block number.
             total_headers: target_block_number.unwrap_or_else(|| {
                 warn!(target: "sync::stages::headers", ?tip, "No downloaded header for tip found");
-                // Safe, because `Display` impl for checkpoint will fallback to displaying just
-                // `downloaded_headers`
+                // Safe, because `Display` impl for `StageCheckpoint` will fallback to displaying
+                // just `downloaded_headers`
                 0
             }),
         });

--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -180,9 +180,10 @@ where
         Ok(td.into())
     }
 
-    /// Unwind table by some number key
+    /// Unwind table by some number key.
+    /// Returns number of rows unwound.
     #[inline]
-    pub fn unwind_table_by_num<T>(&self, num: u64) -> Result<(), DbError>
+    pub fn unwind_table_by_num<T>(&self, num: u64) -> Result<usize, DbError>
     where
         DB: Database,
         T: Table<Key = u64>,
@@ -190,10 +191,11 @@ where
         self.unwind_table::<T, _>(num, |key| key)
     }
 
-    /// Unwind the table to a provided block
+    /// Unwind the table to a provided block.
+    /// Returns number of rows unwound.
     ///
     /// Note: Key is not inclusive and specified key would stay in db.
-    pub(crate) fn unwind_table<T, F>(&self, key: u64, mut selector: F) -> Result<(), DbError>
+    pub(crate) fn unwind_table<T, F>(&self, key: u64, mut selector: F) -> Result<usize, DbError>
     where
         DB: Database,
         T: Table,
@@ -201,14 +203,17 @@ where
     {
         let mut cursor = self.cursor_write::<T>()?;
         let mut reverse_walker = cursor.walk_back(None)?;
+        let mut deleted = 0;
 
         while let Some(Ok((entry_key, _))) = reverse_walker.next() {
             if selector(entry_key.clone()) <= key {
                 break
             }
             self.delete::<T>(entry_key, None)?;
+            deleted += 1;
         }
-        Ok(())
+
+        Ok(deleted)
     }
 
     /// Unwind a table forward by a [Walker][reth_db::abstraction::cursor::Walker] on another table


### PR DESCRIPTION
Previously, headers stage didn't report any meaningful progress until the tip is reached, because headers are downloaded in the reverse order, and maximum block number doesn't change until we fill the gap:
```console
RUST_LOG=sync::pipeline=info cargo run --quiet -- node --debug.tip $(cast block --field hash 100000) --debug.max-block 100000
2023-05-23T10:36:35.440361Z  INFO Stage made progress stage=Headers checkpoint=0 done=false
2023-05-23T10:36:36.880071Z  INFO Stage made progress stage=Headers checkpoint=0 done=false
2023-05-23T10:36:37.566426Z  INFO Stage made progress stage=Headers checkpoint=0 done=false
2023-05-23T10:36:38.332547Z  INFO Stage made progress stage=Headers checkpoint=0 done=false
2023-05-23T10:36:39.082982Z  INFO Stage made progress stage=Headers checkpoint=0 done=false
2023-05-23T10:36:40.009680Z  INFO Stage made progress stage=Headers checkpoint=0 done=false
2023-05-23T10:36:41.211486Z  INFO Stage made progress stage=Headers checkpoint=0 done=false
2023-05-23T10:36:41.890457Z  INFO Stage made progress stage=Headers checkpoint=0 done=false
2023-05-23T10:36:42.555403Z  INFO Stage made progress stage=Headers checkpoint=0 done=false
2023-05-23T10:36:43.790875Z  INFO Stage made progress stage=Headers checkpoint=100000 done=true
```

Now, we report the progress in % as number of downloaded headers to total number of headers that needs to be downloaded:
```console
RUST_LOG=sync::pipeline=info cargo run --quiet -- node --debug.tip $(cast block --field hash 100000) --debug.max-block 100000
2023-05-23T10:37:46.644883Z  INFO Stage made progress stage=Headers checkpoint=10.0% done=false
2023-05-23T10:37:48.124062Z  INFO Stage made progress stage=Headers checkpoint=20.0% done=false
2023-05-23T10:37:49.945159Z  INFO Stage made progress stage=Headers checkpoint=30.0% done=false
2023-05-23T10:37:51.259381Z  INFO Stage made progress stage=Headers checkpoint=40.0% done=false
2023-05-23T10:37:53.143096Z  INFO Stage made progress stage=Headers checkpoint=50.0% done=false
2023-05-23T10:37:54.980056Z  INFO Stage made progress stage=Headers checkpoint=60.0% done=false
2023-05-23T10:37:56.417011Z  INFO Stage made progress stage=Headers checkpoint=70.0% done=false
2023-05-23T10:37:57.800093Z  INFO Stage made progress stage=Headers checkpoint=80.0% done=false
2023-05-23T10:37:59.338263Z  INFO Stage made progress stage=Headers checkpoint=90.0% done=false
2023-05-23T10:38:00.652160Z  INFO Stage made progress stage=Headers checkpoint=100.0% done=true
```

Same goes to metrics as two separate `processed` and `total` metrics, which can be represented as percentage:

<img width="1536" alt="image" src="https://github.com/paradigmxyz/reth/assets/5773434/50676da9-b21b-4f77-b86c-028ba7bd6eb6">
