### PR TITLE
refactor: get rid of boolean is known check argument

### DIFF
--- a/crates/blockchain-tree/src/block_buffer.rs
+++ b/crates/blockchain-tree/src/block_buffer.rs
@@ -45,7 +45,7 @@ impl BlockBuffer {
         }
     }
 
-    /// Insert block inside the buffer.
+    /// Insert a correct block inside the buffer.
     pub fn insert_block(&mut self, block: SealedBlockWithSenders) {
         let num_hash = block.num_hash();
 

--- a/crates/blockchain-tree/src/shareable.rs
+++ b/crates/blockchain-tree/src/shareable.rs
@@ -40,16 +40,6 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> ShareableBlockchainTree<DB
 impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeEngine
     for ShareableBlockchainTree<DB, C, EF>
 {
-    fn insert_block_without_senders(
-        &self,
-        block: SealedBlock,
-    ) -> Result<BlockStatus, InsertBlockError> {
-        match block.try_seal_with_senders() {
-            Ok(block) => self.tree.write().insert_block_inner(block, true),
-            Err(block) => Err(InsertBlockError::sender_recovery_error(block)),
-        }
-    }
-
     fn buffer_block(&self, block: SealedBlockWithSenders) -> Result<(), InsertBlockError> {
         self.tree.write().buffer_block(block)
     }


### PR DESCRIPTION
the argument was only used when a new block was inserted into the tree.

This moves the check to the insert function and removes the `insert_block_inner` which is now redundant.

prep for #2782 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b9330ee</samp>

Refactored the block buffering and insertion logic in `blockchain-tree` crate. Introduced a new `BlockBuffer` struct that handles the validation and recovery of block senders. Removed unused and redundant methods from `ShareableBlockchainTree` and `block_buffer.rs`.