### PR TITLE
refactor: rename take children function

### DIFF
--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -744,7 +744,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
     fn try_connect_buffered_blocks(&mut self, new_block: BlockNumHash) {
         trace!(target: "blockchain_tree", ?new_block, "try_connect_buffered_blocks");
 
-        let include_blocks = self.buffered_blocks.take_all_children(new_block);
+        let include_blocks = self.buffered_blocks.remove_with_children(new_block);
         // insert block children
         for block in include_blocks.into_iter() {
             // dont fail on error, just ignore the block.


### PR DESCRIPTION
rename function to `remove_with_children` because this also removes and returns the target block itself.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 79dea58</samp>

Renamed a method in the `BlockBuffer` struct and updated its usage in the `BlockchainTree` struct. This improves the readability and clarity of the code that handles buffered blocks in the blockchain tree.