### PR TITLE
chore(pipeline): remove `tip_tx` debugging-only comments

### DIFF
--- a/crates/stages/src/pipeline/builder.rs
+++ b/crates/stages/src/pipeline/builder.rs
@@ -13,9 +13,7 @@ where
     stages: Vec<BoxedStage<DB>>,
     /// The maximum block number to sync to.
     max_block: Option<BlockNumber>,
-    /// A receiver for the current chain tip to sync to
-    ///
-    /// Note: this is only used for debugging purposes.
+    /// A receiver for the current chain tip to sync to.
     tip_tx: Option<watch::Sender<H256>>,
 }
 

--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -93,9 +93,7 @@ pub struct Pipeline<DB: Database> {
     listeners: EventListeners<PipelineEvent>,
     /// Keeps track of the progress of the pipeline.
     progress: PipelineProgress,
-    /// A receiver for the current chain tip to sync to
-    ///
-    /// Note: this is only used for debugging purposes.
+    /// A receiver for the current chain tip to sync to.
     tip_tx: Option<watch::Sender<H256>>,
     metrics: Metrics,
 }


### PR DESCRIPTION
`tip_tx` isn't used for debugging purposes anymore, but is used for the `Headers` stage sync here:
https://github.com/paradigmxyz/reth/blob/7d36dea420c2817e4770e8e23f5ff660404d3e6b/crates/stages/src/stages/headers.rs#L124-L134