### PR TITLE
feat: add sealed_header to HeaderProvider for single headers

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -474,6 +474,10 @@ mod tests {
         ) -> Result<Vec<SealedHeader>> {
             Ok(vec![])
         }
+
+        fn sealed_header(&self, _block_number: BlockNumber) -> Result<Option<SealedHeader>> {
+            Ok(None)
+        }
     }
 
     impl WithdrawalsProvider for Provider {

--- a/crates/storage/provider/src/providers/database.rs
+++ b/crates/storage/provider/src/providers/database.rs
@@ -146,6 +146,19 @@ impl<DB: Database> HeaderProvider for ShareableDatabase<DB> {
             })?
             .map_err(Into::into)
     }
+
+    fn sealed_header(&self, number: BlockNumber) -> Result<Option<SealedHeader>> {
+        self.db
+            .view(|tx| -> Result<_> {
+                if let Some(header) = tx.get::<tables::Headers>(number)? {
+                    let hash = read_header_hash(tx, number)?;
+                    Ok(Some(header.seal(hash)))
+                } else {
+                    Ok(None)
+                }
+            })?
+            .map_err(Into::into)
+    }
 }
 
 impl<DB: Database> BlockHashProvider for ShareableDatabase<DB> {

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -106,6 +106,10 @@ where
     ) -> Result<Vec<SealedHeader>> {
         self.database.sealed_headers_range(range)
     }
+
+    fn sealed_header(&self, number: BlockNumber) -> Result<Option<SealedHeader>> {
+        self.database.sealed_header(number)
+    }
 }
 
 impl<DB, Tree> BlockHashProvider for BlockchainProvider<DB, Tree>

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -151,6 +151,10 @@ impl HeaderProvider for MockEthProvider {
     ) -> Result<Vec<SealedHeader>> {
         Ok(self.headers_range(range)?.into_iter().map(|h| h.seal_slow()).collect())
     }
+
+    fn sealed_header(&self, number: BlockNumber) -> Result<Option<SealedHeader>> {
+        Ok(self.header_by_number(number)?.map(|h| h.seal_slow()))
+    }
 }
 
 impl TransactionsProvider for MockEthProvider {

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -173,6 +173,10 @@ impl HeaderProvider for NoopProvider {
     ) -> Result<Vec<SealedHeader>> {
         Ok(vec![])
     }
+
+    fn sealed_header(&self, _number: BlockNumber) -> Result<Option<SealedHeader>> {
+        Ok(None)
+    }
 }
 
 impl AccountProvider for NoopProvider {

--- a/crates/storage/provider/src/traits/header.rs
+++ b/crates/storage/provider/src/traits/header.rs
@@ -39,4 +39,7 @@ pub trait HeaderProvider: Send + Sync {
         &self,
         range: impl RangeBounds<BlockNumber>,
     ) -> Result<Vec<SealedHeader>>;
+
+    /// Get a single sealed header by block number
+    fn sealed_header(&self, number: BlockNumber) -> Result<Option<SealedHeader>>;
 }


### PR DESCRIPTION
motivated by #2707
ref #2769

Adds a `sealed_header` method for retrieving just a single sealed header from the db.