### PR TITLE
fix(transaction): tx iterator for block range

### DIFF
--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -602,7 +602,7 @@ where
 
         // If this is the case then all of the blocks in the range are empty
         if last_transaction < first_transaction {
-            return Ok(Vec::new())
+            return Ok(block_bodies.into_iter().map(|(n, _)| (n, Vec::new()).collect()))
         }
 
         // Get transactions and senders

--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -602,7 +602,7 @@ where
 
         // If this is the case then all of the blocks in the range are empty
         if last_transaction < first_transaction {
-            return Ok(block_bodies.into_iter().map(|(n, _)| (n, Vec::new()).collect()))
+            return Ok(block_bodies.into_iter().map(|(n, _)| (n, Vec::new())).collect())
         }
 
         // Get transactions and senders


### PR DESCRIPTION
## Issue

In case of an block range with no transactions, the `Transaction::get_take_block_transaction_range` method might return an empty vec.
https://github.com/paradigmxyz/reth/blob/007120fe533d2e3b436a437bf8e023cc850d2fd2/crates/storage/provider/src/transaction.rs#L599-L606
Since `Transaction::get_take_block_range` zips the iterators including the one over transactions 
https://github.com/paradigmxyz/reth/blob/007120fe533d2e3b436a437bf8e023cc850d2fd2/crates/storage/provider/src/transaction.rs#L710-L714
the result will not have any data.

## Solution

Return at least the block numbers with empty vecs if there are no transactions in the block range.