### PR TITLE
chore: box incoming connections on windows

### DIFF
--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -123,7 +123,7 @@ impl IpcServer {
                 #[cfg(windows)]
                 let connections = Box::pin(connections);
                 Incoming::new(connections)
-            },
+            }
             Err(err) => {
                 on_ready.send(Err(err.to_string())).ok();
                 return Err(err)

--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -119,7 +119,11 @@ impl IpcServer {
 
         let mut connections = FutureDriver::default();
         let incoming = match self.endpoint.incoming() {
-            Ok(connections) => Incoming::new(connections),
+            Ok(connections) => {
+                #[cfg(windows)]
+                let connections = Box::pin(connections);
+                Incoming::new(connections)
+            },
             Err(err) => {
                 on_ready.send(Err(err.to_string())).ok();
                 return Err(err)


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b5dab31</samp>

Fix compilation error on Windows by pinning `NamedPipe` stream. This change modifies `crates/rpc/ipc/src/server/mod.rs` to use `Box::pin` and `#[cfg(windows)]` to make the `Incoming` struct compatible with the `FutureDriver`.