### PR TITLE
fix: really encode windows paths for mdbx this time

### DIFF
--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -8,8 +8,6 @@ use crate::{
 use byteorder::{ByteOrder, NativeEndian};
 use libc::c_uint;
 use mem::size_of;
-#[cfg(unix)]
-use std::os::unix::ffi::OsStrExt;
 use std::{
     ffi::CString,
     fmt,

--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -10,8 +10,6 @@ use libc::c_uint;
 use mem::size_of;
 #[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
-#[cfg(windows)]
-use std::os::windows::ffi::OsStrExt;
 use std::{
     ffi::CString,
     fmt,

--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -457,9 +457,23 @@ where
                     }
                 }
 
-                let path = match CString::new(path.as_os_str().as_bytes()) {
+                #[cfg(unix)]
+                fn path_to_bytes<P: AsRef<Path>>(path: P) -> Vec<u8> {
+                    use std::os::unix::ffi::OsStrExt;
+                    path.as_ref().as_os_str().as_bytes().to_vec()
+                }
+
+                #[cfg(windows)]
+                fn path_to_bytes<P: AsRef<Path>>(path: P) -> Vec<u8> {
+                    // On Windows, could use std::os::windows::ffi::OsStrExt to encode_wide(),
+                    // but we end up with a Vec<u16> instead of a Vec<u8>, so that doesn't
+                    // really help.
+                    path.as_ref().to_string_lossy().to_string().into_bytes()
+                }
+
+                let path = match CString::new(path_to_bytes(path)) {
                     Ok(path) => path,
-                    Err(..) => return Err(crate::Error::Invalid),
+                    Err(_) => return Err(Error::Invalid),
                 };
                 mdbx_result(ffi::mdbx_env_open(
                     env,


### PR DESCRIPTION
So, the `OsStrExt` for Windows doesn't have an `as_bytes` function as I assumed, only an `encode_wide` function (which uses WTF-8, the abbrevation literally does it justice) that encodes the path as a u16 slice which not helpful.

This PR removes that extension trait for Windows and instead just converts the path to a lossy string and converts that into bytes. The assumption here is that the path is "validated enough" on Rust that it should work in C as well, although that might not be the case. The important thing here is just that we pass well-formed data to MDBX so it can at least tell us that the path is invalid.

 On unix we do as we normally do as (thankfully) unix paths are just arrays of bytes.

Both strings are nul terminated using `CString`