### PR TITLE
fix: proper `#[cfg]` attrs for windows/unix

### DIFF
--- a/bin/reth/src/runner.rs
+++ b/bin/reth/src/runner.rs
@@ -145,7 +145,8 @@ where
 {
     let ctrl_c = tokio::signal::ctrl_c();
 
-    if cfg!(unix) {
+    #[cfg(unix)]
+    {
         let mut stream = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
         let sigterm = stream.recv();
         pin_mut!(sigterm, ctrl_c, fut);
@@ -159,7 +160,10 @@ where
             },
             res = fut => res?,
         }
-    } else {
+    }
+
+    #[cfg(not(unix))]
+    {
         pin_mut!(ctrl_c, fut);
 
         tokio::select! {


### PR DESCRIPTION
The `if cfg!(unix)` statement didn't save us from compilation errors on Windows for the CTRL-C handler, so I replaced them with `#[cfg(...)]` attrs instead