### PR TITLE
fix(transaction): block poststate range zip

### DIFF
--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -807,7 +807,8 @@ where
         // iterate in reverse and get plain state.
 
         // Bundle execution changeset to its particular transaction and block
-        let mut block_states: BTreeMap<BlockNumber, PostState> = BTreeMap::new();
+        let mut block_states =
+            BTreeMap::from_iter(block_bodies.iter().map(|(num, _)| (*num, PostState::default())));
 
         let mut plain_accounts_cursor = self.cursor_write::<tables::PlainAccountState>()?;
         let mut plain_storage_cursor = self.cursor_dup_write::<tables::PlainStorageState>()?;


### PR DESCRIPTION
## Issue

Similar to #2804, since are zipped w/ execution results in `Transaction::get_take_block_and_execution_range`
https://github.com/paradigmxyz/reth/blob/007120fe533d2e3b436a437bf8e023cc850d2fd2/crates/storage/provider/src/transaction.rs#L972-L973
the `PostState` must exist for each block.

`Transaction::get_take_block_execution_result_range` return value will not have a block entry if it's empty (has no changes).

## Solution

Initialize the block to `PostState` map with expected block number keys.