### PR TITLE
chore: rm `reth db seed`

### DIFF
--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -60,12 +60,6 @@ pub enum Subcommands {
     Stats,
     /// Lists the contents of a table
     List(ListArgs),
-    /// Seeds the database with random blocks on top of each other
-    Seed {
-        /// How many blocks to generate
-        #[arg(default_value = DEFAULT_NUM_ITEMS)]
-        len: u64,
-    },
     /// Deletes all database entries
     Drop,
 }
@@ -149,9 +143,6 @@ impl Command {
                 })??;
 
                 println!("{stats_table}");
-            }
-            Subcommands::Seed { len } => {
-                tool.seed(*len)?;
             }
             Subcommands::List(args) => {
                 macro_rules! table_tui {

--- a/bin/reth/src/utils.rs
+++ b/bin/reth/src/utils.rs
@@ -67,22 +67,6 @@ impl<'a, DB: Database> DbTool<'a, DB> {
         Ok(Self { db })
     }
 
-    /// Seeds the database with some random data, only used for testing
-    pub fn seed(&mut self, len: u64) -> Result<()> {
-        info!(target: "reth::cli", "Generating random block range from 0 to {len}");
-        let chain = random_block_range(0..=len - 1, Default::default(), 0..64);
-
-        self.db.update(|tx| {
-            chain.into_iter().try_for_each(|block| {
-                insert_canonical_block(tx, block, None)?;
-                Ok::<_, eyre::Error>(())
-            })
-        })??;
-
-        info!(target: "reth::cli", "Database seeded with {len} blocks");
-        Ok(())
-    }
-
     /// Grabs the contents of the table within a certain index range and places the
     /// entries into a [`HashMap`][std::collections::HashMap].
     pub fn list<T: Table>(

--- a/bin/reth/src/utils.rs
+++ b/bin/reth/src/utils.rs
@@ -7,15 +7,11 @@ use reth_db::{
     table::Table,
     transaction::{DbTx, DbTxMut},
 };
-use reth_interfaces::{
-    p2p::{
-        headers::client::{HeadersClient, HeadersRequest},
-        priority::Priority,
-    },
-    test_utils::generators::random_block_range,
+use reth_interfaces::p2p::{
+    headers::client::{HeadersClient, HeadersRequest},
+    priority::Priority,
 };
 use reth_primitives::{BlockHashOrNumber, HeadersDirection, SealedHeader};
-use reth_provider::insert_canonical_block;
 use std::{collections::BTreeMap, path::Path, time::Duration};
 use tracing::info;
 

--- a/book/cli/db.md
+++ b/book/cli/db.md
@@ -12,8 +12,6 @@ Commands:
           Lists all the tables, their entry count and their size
   list
           Lists the contents of a table
-  seed
-          Seeds the database with random blocks on top of each other
   drop
           Deletes all database entries
   help


### PR DESCRIPTION
This command has not been in use for quite some time and is not really useful anymore as the blocks are not fully valid and they do not contain any interesting data.