### PR TITLE
feat(stages): `AccountHashing` and `StorageHashing` progress

### DIFF
--- a/bin/reth/src/args/stage_args.rs
+++ b/bin/reth/src/args/stage_args.rs
@@ -8,6 +8,8 @@ pub enum StageEnum {
     Bodies,
     Senders,
     Execution,
+    AccountHashing,
+    StorageHashing,
     Hashing,
     Merkle,
     TxLookup,

--- a/bin/reth/src/stage/drop.rs
+++ b/bin/reth/src/stage/drop.rs
@@ -78,6 +78,18 @@ impl Command {
                     Ok::<_, eyre::Error>(())
                 })??;
             }
+            StageEnum::AccountHashing => tool.db.update(|tx| {
+                tx.clear::<tables::HashedAccount>()?;
+                tx.put::<tables::SyncStage>(ACCOUNT_HASHING.0.to_string(), Default::default())?;
+
+                Ok::<_, eyre::Error>(())
+            })??,
+            StageEnum::StorageHashing => tool.db.update(|tx| {
+                tx.clear::<tables::HashedStorage>()?;
+                tx.put::<tables::SyncStage>(STORAGE_HASHING.0.to_string(), Default::default())?;
+
+                Ok::<_, eyre::Error>(())
+            })??,
             StageEnum::Hashing => {
                 tool.db.update(|tx| {
                     // Clear hashed accounts

--- a/bin/reth/src/stage/run.rs
+++ b/bin/reth/src/stage/run.rs
@@ -18,12 +18,12 @@ use reth_staged_sync::{
 };
 use reth_stages::{
     stages::{
-        BodyStage, ExecutionStage, ExecutionStageThresholds, MerkleStage, SenderRecoveryStage,
-        TransactionLookupStage,
+        AccountHashingStage, BodyStage, ExecutionStage, ExecutionStageThresholds, MerkleStage,
+        SenderRecoveryStage, StorageHashingStage, TransactionLookupStage,
     },
     ExecInput, ExecOutput, Stage, StageId, UnwindInput,
 };
-use std::{net::SocketAddr, path::PathBuf, sync::Arc};
+use std::{any::Any, net::SocketAddr, ops::Deref, path::PathBuf, sync::Arc};
 use tracing::*;
 
 /// `reth stage` command
@@ -174,9 +174,7 @@ impl Command {
 
                     (Box::new(stage), None)
                 }
-                StageEnum::Senders => {
-                    (Box::new(SenderRecoveryStage { commit_threshold: batch_size }), None)
-                }
+                StageEnum::Senders => (Box::new(SenderRecoveryStage::new(batch_size)), None),
                 StageEnum::Execution => {
                     let factory = reth_revm::Factory::new(self.chain.clone());
                     (
@@ -192,21 +190,28 @@ impl Command {
                     )
                 }
                 StageEnum::TxLookup => (Box::new(TransactionLookupStage::new(batch_size)), None),
+                StageEnum::AccountHashing => {
+                    (Box::new(AccountHashingStage::new(1, batch_size)), None)
+                }
+                StageEnum::StorageHashing => {
+                    (Box::new(StorageHashingStage::new(1, batch_size)), None)
+                }
                 StageEnum::Merkle => (
                     Box::new(MerkleStage::default_execution()),
                     Some(Box::new(MerkleStage::default_unwind())),
                 ),
                 _ => return Ok(()),
             };
+        if let Some(unwind_stage) = &unwind_stage {
+            assert!(exec_stage.type_id() == unwind_stage.type_id());
+        }
+
+        let checkpoint = exec_stage.id().get_checkpoint(tx.deref())?.unwrap_or_default();
+
         let unwind_stage = unwind_stage.as_mut().unwrap_or(&mut exec_stage);
 
-        let mut input = ExecInput {
-            previous_stage: Some((StageId("No Previous Stage"), StageCheckpoint::new(self.to))),
-            checkpoint: Some(StageCheckpoint::new(self.from)),
-        };
-
         let mut unwind = UnwindInput {
-            checkpoint: StageCheckpoint::new(self.to),
+            checkpoint: checkpoint.with_block_number(self.to),
             unwind_to: self.from,
             bad_block: None,
         };
@@ -217,6 +222,11 @@ impl Command {
                 unwind.checkpoint = unwind_output.checkpoint;
             }
         }
+
+        let mut input = ExecInput {
+            previous_stage: Some((StageId("No Previous Stage"), StageCheckpoint::new(self.to))),
+            checkpoint: Some(checkpoint.with_block_number(self.from)),
+        };
 
         while let ExecOutput { checkpoint: stage_progress, done: false } =
             exec_stage.execute(&mut tx, input).await?

--- a/crates/interfaces/src/db.rs
+++ b/crates/interfaces/src/db.rs
@@ -28,4 +28,7 @@ pub enum DatabaseError {
     /// Failed to decode a key from a table.
     #[error("Error decoding value.")]
     DecodeError,
+    /// Failed to get database stats.
+    #[error("Database stats error code: {0:?}")]
+    Stats(i32),
 }

--- a/crates/primitives/src/checkpoints.rs
+++ b/crates/primitives/src/checkpoints.rs
@@ -107,18 +107,8 @@ pub struct AccountHashingCheckpoint {
     pub from: u64,
     /// Last transition id
     pub to: u64,
-    /// During execution, it's measured in accounts.
-    /// During unwinding, it's measured in changesets.
-    ///
-    /// `EntitiesCheckpoint.total` is set only during the execution.
+    /// Progress measured in accounts.
     pub progress: EntitiesCheckpoint,
-}
-
-impl AccountHashingCheckpoint {
-    /// Checks if checkpoint was set during the execution phase.
-    pub fn is_executing(&self) -> bool {
-        self.progress.total.is_some()
-    }
 }
 
 /// Saves the progress of StorageHashing stage.
@@ -133,18 +123,8 @@ pub struct StorageHashingCheckpoint {
     pub from: u64,
     /// Last transition id
     pub to: u64,
-    /// During execution, it's measured in storage entries.
-    /// During unwinding, it's measured in changesets.
-    ///
-    /// `EntitiesCheckpoint.total` is set only during the execution.
+    /// Progress measured in storage slots.
     pub progress: EntitiesCheckpoint,
-}
-
-impl StorageHashingCheckpoint {
-    /// Checks if checkpoint was set during the execution phase.
-    pub fn is_executing(&self) -> bool {
-        self.progress.total.is_some()
-    }
 }
 
 /// Saves the progress of abstract stage iterating over or downloading entities.

--- a/crates/primitives/src/checkpoints.rs
+++ b/crates/primitives/src/checkpoints.rs
@@ -337,18 +337,24 @@ mod tests {
                 address: Some(Address::from_low_u64_be(rng.gen())),
                 from: rng.gen(),
                 to: rng.gen(),
-                progress: EntitiesCheckpoint { processed: rng.gen(), total: rng.gen() },
+                progress: EntitiesCheckpoint {
+                    processed: rng.gen::<u32>() as u64,
+                    total: Some(u32::MAX as u64 + rng.gen::<u64>()),
+                },
             }),
             StageUnitCheckpoint::Storage(StorageHashingCheckpoint {
                 address: Some(Address::from_low_u64_be(rng.gen())),
                 storage: Some(H256::from_low_u64_be(rng.gen())),
                 from: rng.gen(),
                 to: rng.gen(),
-                progress: EntitiesCheckpoint { processed: rng.gen(), total: rng.gen() },
+                progress: EntitiesCheckpoint {
+                    processed: rng.gen::<u32>() as u64,
+                    total: Some(u32::MAX as u64 + rng.gen::<u64>()),
+                },
             }),
             StageUnitCheckpoint::Entities(EntitiesCheckpoint {
-                processed: rng.gen(),
-                total: rng.gen(),
+                processed: rng.gen::<u32>() as u64,
+                total: Some(u32::MAX as u64 + rng.gen::<u64>()),
             }),
         ];
 

--- a/crates/stages/src/stage.rs
+++ b/crates/stages/src/stage.rs
@@ -11,14 +11,14 @@ use std::{
 /// Stage execution input, see [Stage::execute].
 #[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
 pub struct ExecInput {
-    /// The stage that was run before the current stage and the progress it reached.
+    /// The stage that was run before the current stage and the checkpoint it reached.
     pub previous_stage: Option<(StageId, StageCheckpoint)>,
-    /// The progress of this stage the last time it was executed.
+    /// The checkpoint of this stage the last time it was executed.
     pub checkpoint: Option<StageCheckpoint>,
 }
 
 impl ExecInput {
-    /// Return the progress of the stage or default.
+    /// Return the checkpoint of the stage or default.
     pub fn checkpoint(&self) -> StageCheckpoint {
         self.checkpoint.unwrap_or_default()
     }
@@ -60,7 +60,7 @@ impl ExecInput {
 /// Stage unwind input, see [Stage::unwind].
 #[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
 pub struct UnwindInput {
-    /// The current highest progress of the stage.
+    /// The current highest checkpoint of the stage.
     pub checkpoint: StageCheckpoint,
     /// The block to unwind to.
     pub unwind_to: BlockNumber,
@@ -111,7 +111,7 @@ impl ExecOutput {
 /// The output of a stage unwinding.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct UnwindOutput {
-    /// The block at which the stage has unwound to.
+    /// The checkpoint at which the stage has unwound to.
     pub checkpoint: StageCheckpoint,
 }
 

--- a/crates/stages/src/stages/hashing_account.rs
+++ b/crates/stages/src/stages/hashing_account.rs
@@ -8,12 +8,12 @@ use reth_db::{
     transaction::{DbTx, DbTxMut},
     RawKey, RawTable,
 };
-use reth_primitives::{keccak256, AccountHashingCheckpoint, StageCheckpoint};
+use reth_primitives::{keccak256, AccountHashingCheckpoint, EntitiesCheckpoint, StageCheckpoint};
 use reth_provider::Transaction;
 use std::{
     cmp::max,
     fmt::Debug,
-    ops::{Range, RangeInclusive},
+    ops::{Deref, Range, RangeInclusive},
 };
 use tokio::sync::mpsc;
 use tracing::*;
@@ -30,6 +30,13 @@ pub struct AccountHashingStage {
     pub clean_threshold: u64,
     /// The maximum number of accounts to process before committing.
     pub commit_threshold: u64,
+}
+
+impl AccountHashingStage {
+    /// Create new instance of [AccountHashingStage].
+    pub fn new(clean_threshold: u64, commit_threshold: u64) -> Self {
+        Self { clean_threshold, commit_threshold }
+    }
 }
 
 impl Default for AccountHashingStage {
@@ -130,20 +137,19 @@ impl<DB: Database> Stage<DB> for AccountHashingStage {
         }
         let (from_block, to_block) = range.into_inner();
 
+        let stage_checkpoint =
+            input.checkpoint.and_then(|checkpoint| checkpoint.account_hashing_stage_checkpoint());
+
         // if there are more blocks then threshold it is faster to go over Plain state and hash all
         // account otherwise take changesets aggregate the sets and apply hashing to
         // AccountHashing table. Also, if we start from genesis, we need to hash from scratch, as
         // genesis accounts are not in changeset.
         if to_block - from_block > self.clean_threshold || from_block == 1 {
-            let stage_checkpoint = input
-                .checkpoint
-                .and_then(|checkpoint| checkpoint.account_hashing_stage_checkpoint());
-
             let start_address = match stage_checkpoint {
-                Some(AccountHashingCheckpoint { address: address @ Some(_), from, to })
+                Some(AccountHashingCheckpoint { address: address @ Some(_), from, to, .. })
                     // Checkpoint is only valid if the range of transitions didn't change.
                     // An already hashed account may have been changed with the new range,
-                    // and therefore should be hashed again. 
+                    // and therefore should be hashed again.
                     if from == from_block && to == to_block =>
                 {
                     debug!(target: "sync::stages::account_hashing::exec", checkpoint = ?stage_checkpoint, "Continuing inner account hashing checkpoint");
@@ -221,28 +227,40 @@ impl<DB: Database> Stage<DB> for AccountHashingStage {
                         address: Some(next_address.key().unwrap()),
                         from: from_block,
                         to: to_block,
+                        progress: EntitiesCheckpoint {
+                            processed: tx.deref().entries::<tables::HashedAccount>()? as u64,
+                            total: Some(tx.deref().entries::<tables::PlainAccountState>()? as u64),
+                        },
                     },
                 );
-                info!(target: "sync::stages::hashing_account", stage_progress = %checkpoint, is_final_range = false, "Stage iteration finished");
+
+                info!(target: "sync::stages::hashing_account", checkpoint = %checkpoint, is_final_range = false, "Stage iteration finished");
                 return Ok(ExecOutput { checkpoint, done: false })
             }
         } else {
-            // Aggregate all transition changesets and and make list of account that have been
+            // Aggregate all transition changesets and make a list of accounts that have been
             // changed.
             let lists = tx.get_addresses_of_changed_accounts(from_block..=to_block)?;
-            // iterate over plain state and get newest value.
+            // Iterate over plain state and get newest value.
             // Assumption we are okay to make is that plainstate represent
             // `previous_stage_progress` state.
-            let accounts = tx.get_plainstate_accounts(lists.into_iter())?;
-            // insert and hash accounts to hashing table
+            let accounts = tx.get_plainstate_accounts(lists)?;
+
+            // Insert and hash accounts to hashing table
             tx.insert_account_for_hashing(accounts.into_iter())?;
         }
 
-        // We finished the hashing stage, no future iterations is expected for the same block range,
-        // so no checkpoint is needed.
-        let checkpoint = input.previous_stage_checkpoint();
+        let checkpoint = input.previous_stage_checkpoint().with_account_hashing_stage_checkpoint(
+            AccountHashingCheckpoint {
+                progress: EntitiesCheckpoint {
+                    processed: tx.deref().entries::<tables::HashedAccount>()? as u64,
+                    total: Some(tx.deref().entries::<tables::PlainAccountState>()? as u64),
+                },
+                ..stage_checkpoint.unwrap_or_default()
+            },
+        );
 
-        info!(target: "sync::stages::hashing_account", stage_progress = %checkpoint, is_final_range = true, "Stage iteration finished");
+        info!(target: "sync::stages::hashing_account", checkpoint = %checkpoint, is_final_range = true, "Stage iteration finished");
         Ok(ExecOutput { checkpoint, done: true })
     }
 
@@ -255,11 +273,23 @@ impl<DB: Database> Stage<DB> for AccountHashingStage {
         let (range, unwind_progress, is_final_range) =
             input.unwind_block_range_with_threshold(self.commit_threshold);
 
-        // Aggregate all transition changesets and and make list of account that have been changed.
-        tx.unwind_account_hashing(range)?;
+        // Aggregate all transition changesets and make a list of accounts that have been changed.
+        let changesets_walked = tx.unwind_account_hashing(range)?;
 
-        info!(target: "sync::stages::hashing_account", to_block = input.unwind_to, unwind_progress, is_final_range, "Unwind iteration finished");
-        Ok(UnwindOutput { checkpoint: StageCheckpoint::new(unwind_progress) })
+        let mut stage_checkpoint =
+            input.checkpoint.account_hashing_stage_checkpoint().unwrap_or_default();
+
+        if stage_checkpoint.is_executing() {
+            stage_checkpoint.progress = EntitiesCheckpoint::default();
+        }
+
+        stage_checkpoint.progress.processed += changesets_walked as u64;
+
+        info!(target: "sync::stages::hashing_account", to_block = input.unwind_to, %unwind_progress, is_final_range, "Unwind iteration finished");
+        Ok(UnwindOutput {
+            checkpoint: StageCheckpoint::new(unwind_progress)
+                .with_account_hashing_stage_checkpoint(stage_checkpoint),
+        })
     }
 }
 
@@ -293,7 +323,24 @@ mod tests {
         let rx = runner.execute(input);
         let result = rx.await.unwrap();
 
-        assert_matches!(result, Ok(ExecOutput {checkpoint: StageCheckpoint { block_number, ..}, done: true}) if block_number == previous_stage);
+        assert_matches!(
+            result,
+            Ok(ExecOutput {
+                checkpoint: StageCheckpoint {
+                    block_number,
+                    stage_checkpoint: Some(StageUnitCheckpoint::Account(AccountHashingCheckpoint {
+                        progress: EntitiesCheckpoint {
+                            processed,
+                            total: Some(total),
+                        },
+                        ..
+                    })),
+                },
+                done: true,
+            }) if block_number == previous_stage &&
+                processed == total &&
+                total == runner.tx.table::<tables::PlainAccountState>().unwrap().len() as u64
+        );
 
         // Validate the stage execution
         assert!(runner.validate_execution(input, result.ok()).is_ok(), "execution validation");
@@ -337,11 +384,17 @@ mod tests {
                 checkpoint: StageCheckpoint {
                     block_number: 10,
                     stage_checkpoint: Some(StageUnitCheckpoint::Account(
-                        AccountHashingCheckpoint { address: Some(address), from: 11, to: 20 }
+                        AccountHashingCheckpoint {
+                            address: Some(address),
+                            from: 11,
+                            to: 20,
+                            progress: EntitiesCheckpoint { processed: 5, total: Some(total) }
+                        }
                     ))
                 },
                 done: false
-            }) if address == fifth_address
+            }) if address == fifth_address &&
+                total == runner.tx.table::<tables::PlainAccountState>().unwrap().len() as u64
         );
         assert_eq!(runner.tx.table::<tables::HashedAccount>().unwrap().len(), 5);
 
@@ -353,9 +406,21 @@ mod tests {
         assert_matches!(
             result,
             Ok(ExecOutput {
-                checkpoint: StageCheckpoint { block_number: 20, stage_checkpoint: None },
+                checkpoint: StageCheckpoint {
+                    block_number: 20,
+                    stage_checkpoint: Some(StageUnitCheckpoint::Account(
+                        AccountHashingCheckpoint {
+                            address: Some(address),
+                            from: 11,
+                            to: 20,
+                            progress: EntitiesCheckpoint { processed, total: Some(total) }
+                        }
+                    ))
+                },
                 done: true
-            })
+            }) if address == fifth_address &&
+                processed == total &&
+                total == runner.tx.table::<tables::PlainAccountState>().unwrap().len() as u64
         );
         assert_eq!(runner.tx.table::<tables::HashedAccount>().unwrap().len(), 10);
 

--- a/crates/stages/src/stages/hashing_account.rs
+++ b/crates/stages/src/stages/hashing_account.rs
@@ -8,6 +8,7 @@ use reth_db::{
     transaction::{DbTx, DbTxMut},
     RawKey, RawTable,
 };
+use reth_interfaces::db::DatabaseError;
 use reth_primitives::{keccak256, AccountHashingCheckpoint, EntitiesCheckpoint, StageCheckpoint};
 use reth_provider::Transaction;
 use std::{
@@ -137,14 +138,15 @@ impl<DB: Database> Stage<DB> for AccountHashingStage {
         }
         let (from_block, to_block) = range.into_inner();
 
-        let stage_checkpoint =
-            input.checkpoint.and_then(|checkpoint| checkpoint.account_hashing_stage_checkpoint());
-
         // if there are more blocks then threshold it is faster to go over Plain state and hash all
         // account otherwise take changesets aggregate the sets and apply hashing to
         // AccountHashing table. Also, if we start from genesis, we need to hash from scratch, as
         // genesis accounts are not in changeset.
         if to_block - from_block > self.clean_threshold || from_block == 1 {
+            let stage_checkpoint = input
+                .checkpoint
+                .and_then(|checkpoint| checkpoint.account_hashing_stage_checkpoint());
+
             let start_address = match stage_checkpoint {
                 Some(AccountHashingCheckpoint { address: address @ Some(_), from, to, .. })
                     // Checkpoint is only valid if the range of transitions didn't change.
@@ -227,10 +229,7 @@ impl<DB: Database> Stage<DB> for AccountHashingStage {
                         address: Some(next_address.key().unwrap()),
                         from: from_block,
                         to: to_block,
-                        progress: EntitiesCheckpoint {
-                            processed: tx.deref().entries::<tables::HashedAccount>()? as u64,
-                            total: Some(tx.deref().entries::<tables::PlainAccountState>()? as u64),
-                        },
+                        progress: stage_progress(tx)?,
                     },
                 );
 
@@ -245,19 +244,14 @@ impl<DB: Database> Stage<DB> for AccountHashingStage {
             // Assumption we are okay to make is that plainstate represent
             // `previous_stage_progress` state.
             let accounts = tx.get_plainstate_accounts(lists)?;
-
             // Insert and hash accounts to hashing table
             tx.insert_account_for_hashing(accounts.into_iter())?;
         }
 
+        // We finished the hashing stage, no future iterations is expected for the same block range,
+        // so no checkpoint is needed.
         let checkpoint = input.previous_stage_checkpoint().with_account_hashing_stage_checkpoint(
-            AccountHashingCheckpoint {
-                progress: EntitiesCheckpoint {
-                    processed: tx.deref().entries::<tables::HashedAccount>()? as u64,
-                    total: Some(tx.deref().entries::<tables::PlainAccountState>()? as u64),
-                },
-                ..stage_checkpoint.unwrap_or_default()
-            },
+            AccountHashingCheckpoint { progress: stage_progress(tx)?, ..Default::default() },
         );
 
         info!(target: "sync::stages::hashing_account", checkpoint = %checkpoint, is_final_range = true, "Stage iteration finished");
@@ -274,16 +268,12 @@ impl<DB: Database> Stage<DB> for AccountHashingStage {
             input.unwind_block_range_with_threshold(self.commit_threshold);
 
         // Aggregate all transition changesets and make a list of accounts that have been changed.
-        let changesets_walked = tx.unwind_account_hashing(range)?;
+        tx.unwind_account_hashing(range)?;
 
         let mut stage_checkpoint =
             input.checkpoint.account_hashing_stage_checkpoint().unwrap_or_default();
 
-        if stage_checkpoint.is_executing() {
-            stage_checkpoint.progress = EntitiesCheckpoint::default();
-        }
-
-        stage_checkpoint.progress.processed += changesets_walked as u64;
+        stage_checkpoint.progress = stage_progress(tx)?;
 
         info!(target: "sync::stages::hashing_account", to_block = input.unwind_to, %unwind_progress, is_final_range, "Unwind iteration finished");
         Ok(UnwindOutput {
@@ -291,6 +281,15 @@ impl<DB: Database> Stage<DB> for AccountHashingStage {
                 .with_account_hashing_stage_checkpoint(stage_checkpoint),
         })
     }
+}
+
+fn stage_progress<DB: Database>(
+    tx: &mut Transaction<'_, DB>,
+) -> Result<EntitiesCheckpoint, DatabaseError> {
+    Ok(EntitiesCheckpoint {
+        processed: tx.deref().entries::<tables::HashedAccount>()? as u64,
+        total: Some(tx.deref().entries::<tables::PlainAccountState>()? as u64),
+    })
 }
 
 #[cfg(test)]
@@ -410,16 +409,15 @@ mod tests {
                     block_number: 20,
                     stage_checkpoint: Some(StageUnitCheckpoint::Account(
                         AccountHashingCheckpoint {
-                            address: Some(address),
-                            from: 11,
-                            to: 20,
+                            address: None,
+                            from: 0,
+                            to: 0,
                             progress: EntitiesCheckpoint { processed, total: Some(total) }
                         }
                     ))
                 },
                 done: true
-            }) if address == fifth_address &&
-                processed == total &&
+            }) if processed == total &&
                 total == runner.tx.table::<tables::PlainAccountState>().unwrap().len() as u64
         );
         assert_eq!(runner.tx.table::<tables::HashedAccount>().unwrap().len(), 10);

--- a/crates/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/src/stages/hashing_storage.rs
@@ -176,7 +176,6 @@ impl<DB: Database> Stage<DB> for StorageHashingStage {
             // Assumption we are okay with is that plain state represent
             // `previous_stage_progress` state.
             let storages = tx.get_plainstate_storages(lists)?;
-
             tx.insert_storage_for_hashing(storages.into_iter())?;
         }
 

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -27,6 +27,13 @@ pub struct SenderRecoveryStage {
     pub commit_threshold: u64,
 }
 
+impl SenderRecoveryStage {
+    /// Create new instance of [SenderRecoveryStage].
+    pub fn new(commit_threshold: u64) -> Self {
+        Self { commit_threshold }
+    }
+}
+
 impl Default for SenderRecoveryStage {
     fn default() -> Self {
         Self { commit_threshold: 500_000 }

--- a/crates/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/src/stages/tx_lookup.rs
@@ -146,7 +146,7 @@ impl<DB: Database> Stage<DB> for TransactionLookupStage {
         }
 
         info!(target: "sync::stages::transaction_lookup", stage_progress = end_block, is_final_range, "Stage iteration finished");
-        Ok(ExecOutput { done: is_final_range, checkpoint: StageCheckpoint::new(end_block) })
+        Ok(ExecOutput { checkpoint: StageCheckpoint::new(end_block), done: is_final_range })
     }
 
     /// Unwind the stage.

--- a/crates/stages/src/test_utils/macros.rs
+++ b/crates/stages/src/test_utils/macros.rs
@@ -31,6 +31,7 @@ macro_rules! stage_test_suite {
                 let input = crate::stage::ExecInput {
                     previous_stage: Some((crate::test_utils::PREV_STAGE_ID, reth_primitives::StageCheckpoint::new(previous_stage))),
                     checkpoint: Some(reth_primitives::StageCheckpoint::new(stage_progress)),
+
                 };
                 let seed = runner.seed_execution(input).expect("failed to seed");
                 let rx = runner.execute(input);

--- a/crates/storage/db/src/abstraction/mock.rs
+++ b/crates/storage/db/src/abstraction/mock.rs
@@ -76,6 +76,10 @@ impl<'a> DbTx<'a> for TxMock {
     ) -> Result<<Self as DbTxGAT<'_>>::DupCursor<T>, DatabaseError> {
         todo!()
     }
+
+    fn entries<T: Table>(&self) -> Result<usize, DatabaseError> {
+        todo!()
+    }
 }
 
 impl<'a> DbTxMut<'a> for TxMock {

--- a/crates/storage/db/src/abstraction/transaction.rs
+++ b/crates/storage/db/src/abstraction/transaction.rs
@@ -47,6 +47,8 @@ pub trait DbTx<'tx>: for<'a> DbTxGAT<'a> {
     fn cursor_dup_read<T: DupSort>(
         &self,
     ) -> Result<<Self as DbTxGAT<'_>>::DupCursor<T>, DatabaseError>;
+    /// Returns number of entries in the table.
+    fn entries<T: Table>(&self) -> Result<usize, DatabaseError>;
 }
 
 /// Read write transaction that allows writing to database

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -115,6 +115,12 @@ impl<'tx, K: TransactionKind, E: EnvironmentKind> DbTx<'tx> for Tx<'tx, K, E> {
             .map(decode_one::<T>)
             .transpose()
     }
+
+    /// Returns number of entries in the table using cheap DB stats invocation.
+    fn entries<T: Table>(&self) -> Result<usize, DatabaseError> {
+        let table_db = self.inner.open_db(Some(T::NAME)).expect("failed to open db");
+        Ok(self.inner.db_stat(&table_db).expect("failed to get db stat").entries())
+    }
 }
 
 impl<E: EnvironmentKind> DbTxMut<'_> for Tx<'_, RW, E> {

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -118,9 +118,11 @@ impl<'tx, K: TransactionKind, E: EnvironmentKind> DbTx<'tx> for Tx<'tx, K, E> {
 
     /// Returns number of entries in the table using cheap DB stats invocation.
     fn entries<T: Table>(&self) -> Result<usize, DatabaseError> {
-        let table_db =
-            self.inner.open_db(Some(T::NAME)).map_err(|e| DatabaseError::FailedToOpen(e.into()))?;
-        Ok(self.inner.db_stat(&table_db).map_err(|e| DatabaseError::Stats(e.into()))?.entries())
+        Ok(self
+            .inner
+            .db_stat_with_dbi(self.get_dbi::<T>()?)
+            .map_err(|e| DatabaseError::Stats(e.into()))?
+            .entries())
     }
 }
 

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -118,8 +118,9 @@ impl<'tx, K: TransactionKind, E: EnvironmentKind> DbTx<'tx> for Tx<'tx, K, E> {
 
     /// Returns number of entries in the table using cheap DB stats invocation.
     fn entries<T: Table>(&self) -> Result<usize, DatabaseError> {
-        let table_db = self.inner.open_db(Some(T::NAME)).expect("failed to open db");
-        Ok(self.inner.db_stat(&table_db).expect("failed to get db stat").entries())
+        let table_db =
+            self.inner.open_db(Some(T::NAME)).map_err(|e| DatabaseError::FailedToOpen(e.into()))?;
+        Ok(self.inner.db_stat(&table_db).map_err(|e| DatabaseError::Stats(e.into()))?.entries())
     }
 }
 

--- a/crates/storage/libmdbx-rs/src/transaction.rs
+++ b/crates/storage/libmdbx-rs/src/transaction.rs
@@ -202,10 +202,15 @@ where
 
     /// Retrieves database statistics.
     pub fn db_stat<'txn>(&'txn self, db: &Database<'txn>) -> Result<Stat> {
+        self.db_stat_with_dbi(db.dbi())
+    }
+
+    /// Retrieves database statistics by the given dbi.
+    pub fn db_stat_with_dbi(&self, dbi: ffi::MDBX_dbi) -> Result<Stat> {
         unsafe {
             let mut stat = Stat::new();
             mdbx_result(txn_execute(&self.txn, |txn| {
-                ffi::mdbx_dbi_stat(txn, db.dbi(), stat.mdb_stat(), size_of::<Stat>())
+                ffi::mdbx_dbi_stat(txn, dbi, stat.mdb_stat(), size_of::<Stat>())
             }))?;
             Ok(stat)
         }

--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -288,14 +288,17 @@ where
         self.get_take_block_and_execution_range::<true>(chain_spec, range)
     }
 
-    /// Unwind and clear account hashing
+    /// Unwind and clear account hashing.
+    /// Returns the number of account changesets walked.
     pub fn unwind_account_hashing(
         &self,
         range: RangeInclusive<BlockNumber>,
-    ) -> Result<(), TransactionError> {
+    ) -> Result<usize, TransactionError> {
         let mut hashed_accounts = self.cursor_write::<tables::HashedAccount>()?;
 
-        // Aggregate all transition changesets and and make list of account that have been changed.
+        let mut changesets_walked = 0;
+
+        // Aggregate all transition changesets and make a list of accounts that have been changed.
         self.cursor_read::<tables::AccountChangeSet>()?
             .walk_range(range)?
             .collect::<Result<Vec<_>, _>>()?
@@ -306,6 +309,7 @@ where
                 BTreeMap::new(),
                 |mut accounts: BTreeMap<Address, Option<Account>>, (_, account_before)| {
                     accounts.insert(account_before.address, account_before.info);
+                    changesets_walked += 1;
                     accounts
                 },
             )
@@ -324,15 +328,19 @@ where
                 }
                 Ok(())
             })?;
-        Ok(())
+
+        Ok(changesets_walked)
     }
 
-    /// Unwind and clear storage hashing
+    /// Unwind and clear storage hashing.
+    /// Returns the number of storage changesets walked.
     pub fn unwind_storage_hashing(
         &self,
         range: Range<BlockNumberAddress>,
-    ) -> Result<(), TransactionError> {
+    ) -> Result<usize, TransactionError> {
         let mut hashed_storage = self.cursor_dup_write::<tables::HashedStorage>()?;
+
+        let mut changesets_walked = 0;
 
         // Aggregate all transition changesets and make list of accounts that have been changed.
         self.cursor_read::<tables::StorageChangeSet>()?
@@ -346,6 +354,7 @@ where
                 |mut accounts: BTreeMap<(Address, H256), U256>,
                  (BlockNumberAddress((_, address)), storage_entry)| {
                     accounts.insert((address, storage_entry.key), storage_entry.value);
+                    changesets_walked += 1;
                     accounts
                 },
             )
@@ -370,7 +379,8 @@ where
                 }
                 Ok(())
             })?;
-        Ok(())
+
+        Ok(changesets_walked)
     }
 
     /// Unwind and clear account history indices


### PR DESCRIPTION
Progress reporting for `AccountHashing` and `StorageHashing` stages measured in accounts or storage slots. At the end of every execute/unwind iteration, we check DB stats that includes uncommitted changes on plain state and hashed tables, and put these numbers as a progress of the stage into a checkpoint that's persisted to the database. Using DB stats on every iteration is cheap with MDBX because it just makes a lookup into a pre-calculated statistics and doesn't iterate over rows.

This PR includes breaking DB schema changes because of new fields in account/storage hashing stage checkpoints:
https://github.com/paradigmxyz/reth/blob/c243504a765d56284801b0dcfa84a09fe92e6410/crates/primitives/src/checkpoints.rs#L110-L111 https://github.com/paradigmxyz/reth/blob/c243504a765d56284801b0dcfa84a09fe92e6410/crates/primitives/src/checkpoints.rs#L126-L127