### PR TITLE
chore: improve stage checkpoint logs

### DIFF
--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -43,17 +43,13 @@ impl NodeState {
                 self.current_checkpoint = checkpoint.unwrap_or_default();
 
                 if notable {
-                    if let Some(checkpoint) = checkpoint {
-                        info!(
-                            target: "reth::cli",
-                            stage = %stage_id,
-                            from = checkpoint.block_number,
-                            %checkpoint,
-                            "Executing stage",
-                        );
-                    } else {
-                        info!(target: "reth::cli", stage = %stage_id, "Executing stage");
-                    }
+                    info!(
+                        target: "reth::cli",
+                        stage = %stage_id,
+                        from = self.current_checkpoint.block_number,
+                        checkpoint = %self.current_checkpoint,
+                        "Executing stage",
+                    );
                 }
             }
             PipelineEvent::Ran { stage_id, result: ExecOutput { checkpoint, done } } => {

--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -43,18 +43,38 @@ impl NodeState {
                 self.current_checkpoint = checkpoint.unwrap_or_default();
 
                 if notable {
-                    info!(target: "reth::cli", stage = %stage_id, from = ?checkpoint, "Executing stage");
+                    if let Some(checkpoint) = checkpoint {
+                        info!(
+                            target: "reth::cli",
+                            stage = %stage_id,
+                            from = checkpoint.block_number,
+                            %checkpoint,
+                            "Executing stage",
+                        );
+                    } else {
+                        info!(target: "reth::cli", stage = %stage_id, "Executing stage");
+                    }
                 }
             }
             PipelineEvent::Ran { stage_id, result: ExecOutput { checkpoint, done } } => {
-                let notable = checkpoint.block_number > self.current_checkpoint.block_number;
                 self.current_checkpoint = checkpoint;
+
                 if done {
                     self.current_stage = None;
-                    info!(target: "reth::cli", stage = %stage_id, checkpoint = %checkpoint, "Stage finished executing");
-                } else if notable {
-                    info!(target: "reth::cli", stage = %stage_id, checkpoint = %checkpoint, "Stage committed progress");
                 }
+
+                info!(
+                    target: "reth::cli",
+                    stage = %stage_id,
+                    progress = checkpoint.block_number,
+                    %checkpoint,
+                    "{}",
+                    if done {
+                        "Stage finished executing"
+                    } else {
+                        "Stage committed progress"
+                    }
+                );
             }
             _ => (),
         }

--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -323,6 +323,7 @@ where
                     info!(
                         target: "sync::pipeline",
                         stage = %stage_id,
+                        progress = checkpoint.block_number,
                         %checkpoint,
                         %done,
                         "Stage made progress"


### PR DESCRIPTION
With the new `Display` impl for `StageCheckpoint` introduced in https://github.com/paradigmxyz/reth/pull/2798, we now sometimes don't report block number in logs. This PR fixes it.