### PR TITLE
feat(stages): always report entities processed & total metrics

### DIFF
--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -135,6 +135,7 @@ where
                     .view(|tx| stage_id.get_checkpoint(tx).ok().flatten().unwrap_or_default())
                     .ok()
                     .unwrap_or_default(),
+                None,
             );
         }
     }
@@ -261,7 +262,13 @@ where
                 match output {
                     Ok(unwind_output) => {
                         stage_progress = unwind_output.checkpoint;
-                        self.metrics.stage_checkpoint(stage_id, stage_progress);
+                        self.metrics.stage_checkpoint(
+                            stage_id,
+                            stage_progress,
+                            // We assume it was set in the previous execute iteration, so it
+                            // doesn't change when we unwind.
+                            None,
+                        );
                         stage_id.save_checkpoint(tx.deref(), stage_progress)?;
 
                         self.listeners
@@ -319,7 +326,8 @@ where
                 .await
             {
                 Ok(out @ ExecOutput { checkpoint, done }) => {
-                    made_progress |= checkpoint != prev_checkpoint.unwrap_or_default();
+                    made_progress |=
+                        checkpoint.block_number != prev_checkpoint.unwrap_or_default().block_number;
                     info!(
                         target: "sync::pipeline",
                         stage = %stage_id,
@@ -327,7 +335,11 @@ where
                         %done,
                         "Stage made progress"
                     );
-                    self.metrics.stage_checkpoint(stage_id, checkpoint);
+                    self.metrics.stage_checkpoint(
+                        stage_id,
+                        checkpoint,
+                        previous_stage.map(|(_, checkpoint)| checkpoint.block_number),
+                    );
                     stage_id.save_checkpoint(tx.deref(), checkpoint)?;
 
                     self.listeners.notify(PipelineEvent::Ran { stage_id, result: out.clone() });


### PR DESCRIPTION
With the introduction of new Headers stage progress metrics in https://github.com/paradigmxyz/reth/pull/2798 and upcoming https://github.com/paradigmxyz/reth/pull/2820 changes for AccountHashing and StorageHashing stages' metrics, we have a new way to track the sync progress per stage: in % which can mean both block number and stage-specific metric like headers or hashed entities.

This PR adds reporting of `processed` and `total` metrics for each stage, which works just as block number relative to the known head for most of the stages, and as a custom metric if defined by a stage.

It will allow us to have another chart in Grafana with all stages including e.g. Headers stage not jumping instantly from 0 to tip but gradually increasing over time when we download more headers:

![image](https://github.com/paradigmxyz/reth/assets/5773434/071cc8b5-84ea-49c1-bccb-c065b7a78908)
