### PR TITLE
docs: add list of all stages

### DIFF
--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -82,6 +82,10 @@ pub type PipelineWithResult<DB> = (Pipeline<DB>, Result<ControlFlow, PipelineErr
 /// In case of a validation error (as determined by the consensus engine) in one of the stages, the
 /// pipeline will unwind the stages in reverse order of execution. It is also possible to
 /// request an unwind manually (see [Pipeline::unwind]).
+///
+/// # Defaults
+///
+/// The [DefaultStages](crate::sets::DefaultStages) are used to fully sync reth.
 pub struct Pipeline<DB: Database> {
     /// The Database
     db: DB,

--- a/crates/stages/src/sets.rs
+++ b/crates/stages/src/sets.rs
@@ -61,6 +61,20 @@ use std::sync::Arc;
 /// - [`OnlineStages`]
 /// - [`OfflineStages`]
 /// - [`FinishStage`]
+///
+/// This expands to the following series of stages:
+/// - [`HeaderStage`]
+/// - [`BodyStage`]
+/// - [`SenderRecoveryStage`]
+/// - [`ExecutionStage`]
+/// - [`MerkleStage`] (unwind)
+/// - [`AccountHashingStage`]
+/// - [`StorageHashingStage`]
+/// - [`MerkleStage`] (execution)
+/// - [`TransactionLookupStage`]
+/// - [`IndexStorageHistoryStage`]
+/// - [`IndexAccountHistoryStage`]
+/// - [`FinishStage`]
 #[derive(Debug)]
 pub struct DefaultStages<H, B, EF> {
     /// Configuration for the online stages


### PR DESCRIPTION
Closes #2254

I keep forgetting the order of stages.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1437bb7</samp>

This pull request adds documentation comments to the `Stages` trait and the `DefaultStages` struct in the `stages` crate. These comments clarify the role and functionality of the pipeline stages that reth uses to sync with the Ethereum network.