### PR TITLE
perf: use canonical block number from mem

### DIFF
--- a/crates/storage/provider/src/providers/chain_info.rs
+++ b/crates/storage/provider/src/providers/chain_info.rs
@@ -1,5 +1,5 @@
 use parking_lot::RwLock;
-use reth_primitives::{BlockNumHash, ChainInfo, SealedHeader};
+use reth_primitives::{BlockNumHash, BlockNumber, ChainInfo, SealedHeader};
 use std::{sync::Arc, time::Instant};
 
 /// Tracks the chain info: canonical head, safe block, finalized block.
@@ -60,6 +60,11 @@ impl ChainInfoTracker {
     #[allow(unused)]
     pub(crate) fn get_canonical_num_hash(&self) -> BlockNumHash {
         self.inner.canonical_head.read().num_hash()
+    }
+
+    /// Returns the canonical head of the chain.
+    pub(crate) fn get_canonical_block_number(&self) -> BlockNumber {
+        self.inner.canonical_head.read().number
     }
 
     /// Returns the safe header of the chain.

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -136,7 +136,7 @@ where
     }
 
     fn best_block_number(&self) -> Result<BlockNumber> {
-        self.database.best_block_number()
+        Ok(self.chain_info.get_canonical_block_number())
     }
 
     fn block_number(&self, hash: H256) -> Result<Option<BlockNumber>> {
@@ -149,16 +149,16 @@ where
     DB: Database,
     Tree: BlockchainTreeViewer + Send + Sync,
 {
+    fn pending_block_num_hash(&self) -> Result<Option<reth_primitives::BlockNumHash>> {
+        Ok(self.tree.pending_block_num_hash())
+    }
+
     fn safe_block_num_hash(&self) -> Result<Option<reth_primitives::BlockNumHash>> {
         Ok(self.chain_info.get_safe_num_hash())
     }
 
     fn finalized_block_num_hash(&self) -> Result<Option<reth_primitives::BlockNumHash>> {
         Ok(self.chain_info.get_finalized_num_hash())
-    }
-
-    fn pending_block_num_hash(&self) -> Result<Option<reth_primitives::BlockNumHash>> {
-        Ok(self.tree.pending_block_num_hash())
     }
 }
 

--- a/crates/storage/provider/src/traits/block_id.rs
+++ b/crates/storage/provider/src/traits/block_id.rs
@@ -15,11 +15,11 @@ pub trait BlockNumProvider: BlockHashProvider + Send + Sync {
     fn best_block_number(&self) -> Result<BlockNumber>;
 
     /// Gets the `BlockNumber` for the given hash. Returns `None` if no block with this hash exists.
-    fn block_number(&self, hash: H256) -> Result<Option<reth_primitives::BlockNumber>>;
+    fn block_number(&self, hash: H256) -> Result<Option<BlockNumber>>;
 
     /// Gets the block number for the given `BlockHashOrNumber`. Returns `None` if no block with
     /// this hash exists. If the `BlockHashOrNumber` is a `Number`, it is returned as is.
-    fn convert_hash(&self, id: BlockHashOrNumber) -> Result<Option<reth_primitives::BlockNumber>> {
+    fn convert_hash(&self, id: BlockHashOrNumber) -> Result<Option<BlockNumber>> {
         match id {
             BlockHashOrNumber::Hash(hash) => self.block_number(hash),
             BlockHashOrNumber::Number(num) => Ok(Some(num)),
@@ -53,7 +53,7 @@ pub trait BlockIdProvider: BlockNumProvider + Send + Sync {
         num: BlockNumberOrTag,
     ) -> Result<Option<reth_primitives::BlockNumber>> {
         let num = match num {
-            BlockNumberOrTag::Latest => self.chain_info()?.best_number,
+            BlockNumberOrTag::Latest => self.best_block_number()?,
             BlockNumberOrTag::Earliest => 0,
             BlockNumberOrTag::Pending => {
                 return self
@@ -61,8 +61,8 @@ pub trait BlockIdProvider: BlockNumProvider + Send + Sync {
                     .map(|res_opt| res_opt.map(|num_hash| num_hash.number))
             }
             BlockNumberOrTag::Number(num) => num,
-            BlockNumberOrTag::Finalized => return self.finalized_block_num(),
-            BlockNumberOrTag::Safe => return self.safe_block_num(),
+            BlockNumberOrTag::Finalized => return self.finalized_block_number(),
+            BlockNumberOrTag::Safe => return self.safe_block_number(),
         };
         Ok(Some(num))
     }
@@ -111,12 +111,12 @@ pub trait BlockIdProvider: BlockNumProvider + Send + Sync {
     fn finalized_block_num_hash(&self) -> Result<Option<reth_primitives::BlockNumHash>>;
 
     /// Get the safe block number.
-    fn safe_block_num(&self) -> Result<Option<reth_primitives::BlockNumber>> {
+    fn safe_block_number(&self) -> Result<Option<BlockNumber>> {
         self.safe_block_num_hash().map(|res_opt| res_opt.map(|num_hash| num_hash.number))
     }
 
     /// Get the finalized block number.
-    fn finalized_block_num(&self) -> Result<Option<reth_primitives::BlockNumber>> {
+    fn finalized_block_number(&self) -> Result<Option<BlockNumber>> {
         self.finalized_block_num_hash().map(|res_opt| res_opt.map(|num_hash| num_hash.number))
     }
 


### PR DESCRIPTION
we're already tracking the best block number == latest block == canonical head in memory, and can use this instead of always going to disk.