### PR TITLE
fix: wrong is valid if branch

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -828,10 +828,11 @@ where
                     .map(|status| status.is_valid())
                     .unwrap_or_default()
                 {
+                    // payload is valid
+                    self.sync_state_updater.update_sync_state(SyncState::Idle);
+                } else {
                     // if the payload is invalid, we run the pipeline
                     self.sync.set_pipeline_sync_target(hash);
-                } else {
-                    self.sync_state_updater.update_sync_state(SyncState::Idle);
                 }
             }
             EngineSyncEvent::PipelineStarted(target) => {

--- a/crates/consensus/beacon/src/engine/sync.rs
+++ b/crates/consensus/beacon/src/engine/sync.rs
@@ -102,6 +102,11 @@ where
 
     /// Starts requesting a full block from the network.
     pub(crate) fn download_full_block(&mut self, hash: H256) {
+        trace!(
+            target: "consensus::engine",
+            ?hash,
+            "start downloading full block."
+        );
         let request = self.full_block_client.get_full_block(hash);
         self.inflight_full_block_requests.push(request);
     }


### PR DESCRIPTION
Closes #2704

the if and else branch were switched, only set idle if valid, else trigger sync.

this would prevent a pipeline fallback if the downloader failed.