### PR TITLE
feat: track total size of buffered blocks

### DIFF
--- a/crates/interfaces/src/p2p/bodies/response.rs
+++ b/crates/interfaces/src/p2p/bodies/response.rs
@@ -18,6 +18,16 @@ impl BlockResponse {
         }
     }
 
+    /// Returns the total number of bytes of all transactions input data in the block
+    pub fn size(&self) -> usize {
+        match self {
+            BlockResponse::Full(block) => {
+                block.body.iter().map(|tx| tx.transaction.input().len()).sum()
+            }
+            BlockResponse::Empty(_) => 0,
+        }
+    }
+
     /// Return the block number
     pub fn block_number(&self) -> BlockNumber {
         self.header().number

--- a/crates/net/downloaders/src/metrics.rs
+++ b/crates/net/downloaders/src/metrics.rs
@@ -32,6 +32,8 @@ pub struct DownloaderMetrics {
     /// These are bodies that have been received, but not cannot be committed yet because they're
     /// not contiguous
     pub buffered_blocks: Gauge,
+    /// Total amount of memory used by the buffered blocks in bytes
+    pub buffered_blocks_size_bytes: Gauge,
     /// The number blocks that are contiguous and are queued for insertion into the db.
     pub queued_blocks: Gauge,
     /// The number of out-of-order requests sent by the downloader.


### PR DESCRIPTION
ref #2837

this keeps track of the size of all buffered blocks

this needs a followup to switch from enforcing num of buffered blocks to memory after we gathered some samples