### PR TITLE
perf: disable mdbx debug on release builds

### DIFF
--- a/crates/storage/libmdbx-rs/mdbx-sys/build.rs
+++ b/crates/storage/libmdbx-rs/mdbx-sys/build.rs
@@ -85,9 +85,17 @@ fn main() {
         .flag_if_supported("-Wuninitialized");
 
     let flags = format!("{:?}", cc_builder.get_compiler().cflags_env());
-    cc_builder
-        .define("MDBX_BUILD_FLAGS", flags.as_str())
-        .define("MDBX_TXN_CHECKOWNER", "0")
-        .file(mdbx.join("mdbx.c"))
-        .compile("libmdbx.a");
+    cc_builder.define("MDBX_BUILD_FLAGS", flags.as_str()).define("MDBX_TXN_CHECKOWNER", "0");
+
+    // Enable debugging on debug builds
+    #[cfg(debug_assertions)]
+    cc_builder.define("MDBX_DEBUG", "1");
+
+    // Disables debug logging on optimized builds
+    #[cfg(not(debug_assertions))]
+    {
+        cc_builder.define("NDEBUG", None).define("MDBX_DEBUG", "0");
+    }
+
+    cc_builder.file(mdbx.join("mdbx.c")).compile("libmdbx.a");
 }


### PR DESCRIPTION
On builds with no optimizations (`debug`) sets `MDBX_DEBUG=1` and on builds with optimizations sets `NDEBUG` and `MDBX_DEBUG=0`.

Currently we have always been building MDBX with `MDBX_DEBUG=1` due to the lack of the `NDEBUG` define.

See https://t.me/paradigm_reth/4017