### PR TITLE
ci: run workflows on `merge_group`

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,5 +1,6 @@
 on:
   pull_request:
+  merge_group:
 
 env:
   RUSTFLAGS: -D warnings

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - 'book/**'
       - 'book.toml'
+  merge_group:
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 env:
   RUSTFLAGS: -D warnings

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches: [main]
     paths: [Cargo.lock]
+  merge_group:
 
 env:
   RUSTFLAGS: -D warnings

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -3,6 +3,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 env:
   RUSTFLAGS: -D warnings

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,6 +3,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 env:
   RUSTFLAGS: -D warnings

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -3,6 +3,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 env:
   RUSTFLAGS: -D warnings


### PR DESCRIPTION
This is in preparation of enabling the [merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) feature on `main`.

The docs do not really outline well if using both `pull_request` and `merge_group` triggers the CI twice for each pull request. It also does not specify if the `pull_request` trigger must pass before it can be added to the merge group

If that is the case I will open a follow up PR to adjust the workflows accordingly