### PR TITLE
feat: Increment history shard size

### DIFF
--- a/crates/primitives/src/integer_list.rs
+++ b/crates/primitives/src/integer_list.rs
@@ -123,6 +123,8 @@ pub enum EliasFanoError {
 
 #[cfg(test)]
 mod test {
+    use rand::Rng;
+
     use super::*;
 
     #[test]
@@ -139,5 +141,16 @@ mod test {
 
         let blist = ef_list.to_bytes();
         assert_eq!(IntegerList::from_bytes(&blist).unwrap(), ef_list)
+    }
+
+    #[test]
+    fn check_size_of_elias_fano_size() {
+        let mut rng = rand::thread_rng();
+        let mut vals: Vec<usize> = (0..2_000).map(|_| rng.gen_range(1_000_000..=17_000_000)).collect();
+        vals.sort_unstable();
+        let list = IntegerList::new(vals).unwrap();
+        println!("SIZE OF 2k elements: {:?}", list.0.size_in_bytes());
+        // above print "SIZE OF 2k elements: 3992"
+        // for 100 entried this prints: "SIZE OF 100 elements: 346"
     }
 }

--- a/crates/primitives/src/integer_list.rs
+++ b/crates/primitives/src/integer_list.rs
@@ -123,8 +123,6 @@ pub enum EliasFanoError {
 
 #[cfg(test)]
 mod test {
-    use rand::Rng;
-
     use super::*;
 
     #[test]
@@ -141,16 +139,5 @@ mod test {
 
         let blist = ef_list.to_bytes();
         assert_eq!(IntegerList::from_bytes(&blist).unwrap(), ef_list)
-    }
-
-    #[test]
-    fn check_size_of_elias_fano_size() {
-        let mut rng = rand::thread_rng();
-        let mut vals: Vec<usize> = (0..2_000).map(|_| rng.gen_range(1_000_000..=17_000_000)).collect();
-        vals.sort_unstable();
-        let list = IntegerList::new(vals).unwrap();
-        println!("SIZE OF 2k elements: {:?}", list.0.size_in_bytes());
-        // above print "SIZE OF 2k elements: 3992"
-        // for 100 entried this prints: "SIZE OF 100 elements: 346"
     }
 }

--- a/crates/storage/db/src/tables/models/sharded_key.rs
+++ b/crates/storage/db/src/tables/models/sharded_key.rs
@@ -8,7 +8,7 @@ use reth_primitives::BlockNumber;
 use serde::{Deserialize, Serialize};
 
 /// Number of indices in one shard.
-pub const NUM_OF_INDICES_IN_SHARD: usize = 2000;
+pub const NUM_OF_INDICES_IN_SHARD: usize = 2_000;
 
 /// Sometimes data can be too big to be saved for a single key. This helps out by dividing the data
 /// into different shards. Example:

--- a/crates/storage/db/src/tables/models/sharded_key.rs
+++ b/crates/storage/db/src/tables/models/sharded_key.rs
@@ -8,7 +8,7 @@ use reth_primitives::BlockNumber;
 use serde::{Deserialize, Serialize};
 
 /// Number of indices in one shard.
-pub const NUM_OF_INDICES_IN_SHARD: usize = 100;
+pub const NUM_OF_INDICES_IN_SHARD: usize = 2000;
 
 /// Sometimes data can be too big to be saved for a single key. This helps out by dividing the data
 /// into different shards. Example:

--- a/crates/storage/db/src/tables/models/storage_sharded_key.rs
+++ b/crates/storage/db/src/tables/models/storage_sharded_key.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use super::ShardedKey;
 
 /// Number of indices in one shard.
-pub const NUM_OF_INDICES_IN_SHARD: usize = 100;
+pub const NUM_OF_INDICES_IN_SHARD: usize = 2_000;
 
 /// Sometimes data can be too big to be saved for a single key. This helps out by dividing the data
 /// into different shards. Example:


### PR DESCRIPTION
Checked the size of the shard for 2k elements and incremented the limit to it.

This is db breaking changes.

test that is done:
```rust
    #[test]
    fn check_size_of_elias_fano_size() {
        let mut rng = rand::thread_rng();
        let mut vals: Vec<usize> = (0..2_000).map(|_| rng.gen_range(1_000_000..=17_000_000)).collect();
        vals.sort_unstable();
        let list = IntegerList::new(vals).unwrap();
        println!("SIZE OF 2k elements: {:?}", list.0.size_in_bytes());
        // above print "SIZE OF 2k elements: 3992"
        // for 100 entried this prints: "SIZE OF 100 elements: 346"
    }
```

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d8f8f54</samp>

### Summary
🔬🗄️📊

<!--
1.  🔬 - This emoji represents an experiment or a test, and can be used to indicate that the change is part of a research or exploration process. It can also imply that the change is not final or stable, and may be subject to further modifications or revisions based on the results of the experiment.
2.  🗄️ - This emoji represents a database or a file cabinet, and can be used to indicate that the change affects the storage or organization of data. It can also imply that the change is related to the performance or efficiency of the database, or the access or retrieval of data.
3.  📊 - This emoji represents a chart or a graph, and can be used to indicate that the change involves some form of data analysis or measurement. It can also imply that the change is related to the quality or accuracy of the data, or the presentation or visualization of the data.
-->
This pull request adds a test function for `EliasFano` compression in `integer_list.rs` and changes the shard size constant in `sharded_key.rs` and `storage_sharded_key.rs` to experiment with database performance and efficiency.

> _To test how the database behaves_
> _They changed `NUM_OF_INDICES_IN_SHARD` in two places_
> _And added a test for `EliasFano`_
> _With random data from `rand` cargo_
> _To measure the compression it saves_

### Walkthrough
* Increase the shard size of the database from 100 to 2,000 indices per shard to test performance and storage efficiency ([link](https://github.com/paradigmxyz/reth/pull/2844/files?diff=unified&w=0#diff-fad1c110a28fcf532b1ea3b567b864a87b73210f7568e8af35ef56282cfd1d75L11-R11), [link](https://github.com/paradigmxyz/reth/pull/2844/files?diff=unified&w=0#diff-104128b0809c7c4bc04fbef1507cc0116761406bd87f42109ba0187f49e9c152L14-R14))
* Add a test function for the `IntegerList` struct to check the size of the `EliasFano` encoding used to compress the list of integers ([link](https://github.com/paradigmxyz/reth/pull/2844/files?diff=unified&w=0#diff-85ca981ae64b08296836714bd30add67763c977cbec4af00f2fbc575c210f24bR145-R155))
* Import the `rand` crate in `integer_list.rs` to generate random numbers for the test function ([link](https://github.com/paradigmxyz/reth/pull/2844/files?diff=unified&w=0#diff-85ca981ae64b08296836714bd30add67763c977cbec4af00f2fbc575c210f24bR126-R127))

