### PR TITLE
chore(sync): increase merkle clean threshold

### DIFF
--- a/crates/stages/src/stages/merkle.rs
+++ b/crates/stages/src/stages/merkle.rs
@@ -64,7 +64,7 @@ pub enum MerkleStage {
 impl MerkleStage {
     /// Stage default for the Execution variant.
     pub fn default_execution() -> Self {
-        Self::Execution { clean_threshold: 5_000 }
+        Self::Execution { clean_threshold: 50_000 }
     }
 
     /// Stage default for the Unwind variant.


### PR DESCRIPTION
## Motivation

Due to a low clean threshold, the merkle stage ends up being frequently reset & the computation is started from scratch.

NOTE: As @shekhirin pointed out, this might also lead to an infinite loop on low-end hardware since the node would be stuck recomputing the root while the chain progresses further.