### PR TITLE
fix: sync to head block instead

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -822,7 +822,6 @@ where
                 //  closing the gap either via pipeline, or by fetching the blocks via block number
                 //  [head..FCU.number]
 
-                let hash = block.hash;
                 if self
                     .try_insert_new_payload(block)
                     .map(|status| status.is_valid())
@@ -830,9 +829,9 @@ where
                 {
                     // payload is valid
                     self.sync_state_updater.update_sync_state(SyncState::Idle);
-                } else {
-                    // if the payload is invalid, we run the pipeline
-                    self.sync.set_pipeline_sync_target(hash);
+                } else if let Some(ref state) = self.forkchoice_state {
+                    // if the payload is invalid, we run the pipeline to the head block.
+                    self.sync.set_pipeline_sync_target(state.head_block_hash);
                 }
             }
             EngineSyncEvent::PipelineStarted(target) => {


### PR DESCRIPTION
Closes #2853

we incorrectly tried to sync to the payload's hash which could be invalid or even outdated.

Instead we need to sync to the latest head