### PR TITLE
perf: ignore download request if already inflight

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -558,7 +558,7 @@ where
             self.sync.set_pipeline_sync_target(target);
         } else {
             // trigger a full block download for the _missing_ new head
-            self.sync.download_full_block(state.head_block_hash)
+            self.sync.download_full_block(state.head_block_hash);
         }
 
         PayloadStatus::from_status(PayloadStatusEnum::Syncing)


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8d262d3</samp>

Refactor the `BeaconEngine` to improve the synchronization logic and fix a syntax error in `mod.rs`.