### PR TITLE
perf: store canonical number in atomic

### DIFF
--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -173,15 +173,15 @@ where
     DB: Database,
     Tree: BlockchainTreeViewer + Send + Sync,
 {
-    fn pending_block_num_hash(&self) -> Result<Option<reth_primitives::BlockNumHash>> {
+    fn pending_block_num_hash(&self) -> Result<Option<BlockNumHash>> {
         Ok(self.tree.pending_block_num_hash())
     }
 
-    fn safe_block_num_hash(&self) -> Result<Option<reth_primitives::BlockNumHash>> {
+    fn safe_block_num_hash(&self) -> Result<Option<BlockNumHash>> {
         Ok(self.chain_info.get_safe_num_hash())
     }
 
-    fn finalized_block_num_hash(&self) -> Result<Option<reth_primitives::BlockNumHash>> {
+    fn finalized_block_num_hash(&self) -> Result<Option<BlockNumHash>> {
         Ok(self.chain_info.get_finalized_num_hash())
     }
 }

--- a/crates/storage/provider/src/traits/block_id.rs
+++ b/crates/storage/provider/src/traits/block_id.rs
@@ -48,10 +48,7 @@ pub trait BlockNumProvider: BlockHashProvider + Send + Sync {
 #[auto_impl::auto_impl(&, Arc)]
 pub trait BlockIdProvider: BlockNumProvider + Send + Sync {
     /// Converts the `BlockNumberOrTag` variants to a block number.
-    fn convert_block_number(
-        &self,
-        num: BlockNumberOrTag,
-    ) -> Result<Option<reth_primitives::BlockNumber>> {
+    fn convert_block_number(&self, num: BlockNumberOrTag) -> Result<Option<BlockNumber>> {
         let num = match num {
             BlockNumberOrTag::Latest => self.best_block_number()?,
             BlockNumberOrTag::Earliest => 0,
@@ -91,10 +88,7 @@ pub trait BlockIdProvider: BlockNumProvider + Send + Sync {
     }
 
     /// Get the number of the block by matching the given id.
-    fn block_number_for_id(
-        &self,
-        block_id: BlockId,
-    ) -> Result<Option<reth_primitives::BlockNumber>> {
+    fn block_number_for_id(&self, block_id: BlockId) -> Result<Option<BlockNumber>> {
         match block_id {
             BlockId::Hash(hash) => self.block_number(hash.into()),
             BlockId::Number(num) => self.convert_block_number(num),


### PR DESCRIPTION
Closes #2830

store canonical block number in an atomic, prevents any rwlock overhead,

imo not worth doing this for safe and finalized.