### PR TITLE
ci: use `Swatinem/rust-cache@v2` everywhere

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           ref: main
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -73,7 +73,7 @@ jobs:
       RUST_LOG: info,sync=error
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -85,7 +85,7 @@ jobs:
         with:
           cache-on-failure: true
 
-      - name: Run Sync (debug)
+      - name: Run sync (${{ matrix.profile }})
         run: |
           cargo run --profile ${{ matrix.profile }} \
             --bin reth -- node \

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -81,7 +81,7 @@ jobs:
           toolchain: stable
           profile: minimal
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
 

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -74,7 +74,7 @@ jobs:
           toolchain: stable
           profile: minimal
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
       - name: Install latest nextest release


### PR DESCRIPTION
In some of our jobs we were using v1 for some reason