### PR TITLE
feat(stages): merkle execute stage progress

### DIFF
--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -554,7 +554,7 @@ where
 
         // merkle tree
         {
-            let (state_root, _, trie_updates) =
+            let (state_root, trie_updates) =
                 StateRoot::incremental_root_with_updates(self.deref_mut(), range.clone())?;
             if state_root != expected_state_root {
                 return Err(TransactionError::StateRootMismatch {
@@ -952,7 +952,7 @@ where
             self.unwind_storage_history_indices(storage_range)?;
 
             // merkle tree
-            let (new_state_root, _, trie_updates) =
+            let (new_state_root, trie_updates) =
                 StateRoot::incremental_root_with_updates(self.deref(), range.clone())?;
 
             let parent_number = range.start().saturating_sub(1);

--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -554,7 +554,7 @@ where
 
         // merkle tree
         {
-            let (state_root, trie_updates) =
+            let (state_root, _, trie_updates) =
                 StateRoot::incremental_root_with_updates(self.deref_mut(), range.clone())?;
             if state_root != expected_state_root {
                 return Err(TransactionError::StateRootMismatch {
@@ -952,7 +952,7 @@ where
             self.unwind_storage_history_indices(storage_range)?;
 
             // merkle tree
-            let (new_state_root, trie_updates) =
+            let (new_state_root, _, trie_updates) =
                 StateRoot::incremental_root_with_updates(self.deref(), range.clone())?;
 
             let parent_number = range.start().saturating_sub(1);

--- a/crates/trie/src/progress.rs
+++ b/crates/trie/src/progress.rs
@@ -8,10 +8,10 @@ use reth_primitives::{
 #[derive(Debug)]
 pub enum StateRootProgress {
     /// The complete state root computation with updates and computed root.
-    Complete(H256, TrieUpdates),
+    Complete(H256, usize, TrieUpdates),
     /// The intermediate progress of state root computation.
     /// Contains the walker stack, the hash builder and the trie updates.
-    Progress(Box<IntermediateStateRootState>, TrieUpdates),
+    Progress(Box<IntermediateStateRootState>, usize, TrieUpdates),
 }
 
 /// The intermediate state of the state root computation.

--- a/crates/trie/src/trie.rs
+++ b/crates/trie/src/trie.rs
@@ -139,7 +139,7 @@ where
     pub fn incremental_root_with_updates(
         tx: &'a TX,
         range: RangeInclusive<BlockNumber>,
-    ) -> Result<(H256, usize, TrieUpdates), StateRootError> {
+    ) -> Result<(H256, TrieUpdates), StateRootError> {
         tracing::debug!(target: "loader", "incremental state root");
         Self::incremental_root_calculator(tx, range)?.root_with_updates()
     }
@@ -172,11 +172,9 @@ where
     /// # Returns
     ///
     /// The intermediate progress of state root computation and the trie updates.
-    pub fn root_with_updates(self) -> Result<(H256, usize, TrieUpdates), StateRootError> {
+    pub fn root_with_updates(self) -> Result<(H256, TrieUpdates), StateRootError> {
         match self.with_no_threshold().calculate(true)? {
-            StateRootProgress::Complete(root, hashed_entries_walked, updates) => {
-                Ok((root, hashed_entries_walked, updates))
-            }
+            StateRootProgress::Complete(root, _, updates) => Ok((root, updates)),
             StateRootProgress::Progress(..) => unreachable!(), // unreachable threshold
         }
     }


### PR DESCRIPTION
Report progress for `MerkleExecute` stage based on the number of hashed accounts and storage slots processed vs total in database. For example, this is Sepolia Merkle stage execution after being dropped manually using CLI:

![image](https://github.com/paradigmxyz/reth/assets/5773434/66a920f5-c9c6-4572-aee2-2015b74c3212)

This PR doesn't have any breaking DB changes, as we don't need to introduce any additional checkpoint models.

---

Further work is to calculate a similar progress for `MerkleUnwind`, but currently not clear how to report it in metrics, so we could see one common `Merkle` stage chart going up when executing, and down when unwinding.