### PR TITLE
ci: various speed optimizations

### DIFF
--- a/.github/scripts/compare_iai.sh
+++ b/.github/scripts/compare_iai.sh
@@ -3,4 +3,4 @@
 # This script should be run on the main branch, after running the iai benchmarks on the target branch.
 
 # If the main branch has a better iai performance, exits in error. It ignores L2 differences, since they seem hard to stabilize across runs.
-cargo bench --package reth-db --bench iai | tee /dev/tty | awk '/((L1)|(Ins)|(RAM)|(Est))+.*\(\+[1-9]+[0-9]*\..*%\)/{f=1} END{exit f}'
+cargo bench --package reth-db --bench iai --manifest-path pr/Cargo.toml | tee /dev/tty | awk '/((L1)|(Ins)|(RAM)|(Est))+.*\(\+[1-9]+[0-9]*\..*%\)/{f=1} END{exit f}'

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -42,7 +42,10 @@ jobs:
           cache-on-failure: true
 
       - name: Generate test vectors
-        run: cargo run --bin reth --manifest-path main/Cargo.toml -- test-vectors tables
+        run: |
+          cargo run --bin reth --manifest-path main/Cargo.toml -- test-vectors tables
+          cp -r testdata main
+          mv testdata pr
 
       - name: Set main baseline
         run: cargo bench --package reth-db --bench iai --manifest-path main/Cargo.toml

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -15,40 +15,41 @@ jobs:
   iai:
     runs-on: ubuntu-latest
     steps:
-      - name: Install Valgrind
-        run: |
-          sudo apt install valgrind
+      - name: Checkout main sources
+        uses: actions/checkout@v3
+        with:
+          ref: main
+          path: main
 
       - name: Checkout PR sources
         uses: actions/checkout@v3
         with:
-          ref: main
+          clean: false
+          path: pr
+
+      - name: Install Valgrind
+        run: |
+          sudo apt install valgrind
+
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
         with:
+          workspaces: |
+            main -> target
+            pr -> target
           cache-on-failure: true
 
       - name: Generate test vectors
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --bin reth -- test-vectors tables
+        run: cargo run --bin reth -- test-vectors tables
 
       - name: Set main baseline
-        uses: actions-rs/cargo@v1
-        with:
-          command: bench
-          args: --package reth-db --bench iai
-
-      - name: Checkout main sources
-        uses: actions/checkout@v3
-        with:
-          clean: false
+        run: cargo bench --package reth-db --bench iai --manifest-path main/Cargo.toml
 
       - name: Compare PR benchmark
         shell: 'script -q -e -c "bash {0}"' # required to workaround /dev/tty not being available
-        run: |
-          ./.github/scripts/compare_iai.sh
+        run: ./.github/scripts/compare_iai.sh
 
   # Checks that benchmarks not run in CI compile
   bench-check:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -52,7 +52,8 @@ jobs:
 
       - name: Compare PR benchmark
         shell: 'script -q -e -c "bash {0}"' # required to workaround /dev/tty not being available
-        run: ./.github/scripts/compare_iai.sh
+        run: |
+          ./main/.github/scripts/compare_iai.sh
 
   # Checks that benchmarks not run in CI compile
   bench-check:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -42,7 +42,7 @@ jobs:
           cache-on-failure: true
 
       - name: Generate test vectors
-        run: cargo run --bin reth -- test-vectors tables
+        run: cargo run --bin reth --manifest-path main/Cargo.toml -- test-vectors tables
 
       - name: Set main baseline
         run: cargo bench --package reth-db --bench iai --manifest-path main/Cargo.toml

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Compare PR benchmark
         shell: 'script -q -e -c "bash {0}"' # required to workaround /dev/tty not being available
         run: |
-          ./main/.github/scripts/compare_iai.sh
+          ./pr/.github/scripts/compare_iai.sh
 
   # Checks that benchmarks not run in CI compile
   bench-check:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,7 +8,7 @@ on:
 env:
   RUSTFLAGS: -D warnings
   CARGO_TERM_COLOR: always
-  GETH_BUILD: 1.10.26-e5eb32ac
+  GETH_BUILD: 1.12.0-e501b3b0
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -64,10 +64,7 @@ jobs:
           flags: integration-tests
 
   sync:
-    name: sync / 100k blocks (${{ matrix.profile }})
-    strategy:
-      matrix:
-        profile: [release, dev]
+    name: sync / 100k blocks
     runs-on: ubuntu-latest
     env:
       RUST_LOG: info,sync=error
@@ -87,7 +84,7 @@ jobs:
 
       - name: Run sync (${{ matrix.profile }})
         run: |
-          cargo run --profile ${{ matrix.profile }} \
+          cargo run --profile release --features jemalloc,only-info-logs \
             --bin reth -- node \
             --debug.tip 0x91c90676cab257a59cd956d7cb0bceb9b1a71d79755c23c7277a0697ccfaf8c4 \
             --debug.max-block 100000 \

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,7 +8,7 @@ on:
 env:
   RUSTFLAGS: -D warnings
   CARGO_TERM_COLOR: always
-  GETH_BUILD: 1.12.0-e501b3b0
+  GETH_BUILD: 1.10.26-e5eb32ac
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        partition: [1, 2, 3]
+        partition: [1, 2, 3, 4]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3


### PR DESCRIPTION
CI is getting kind of slow (~20m) so this PR tries to reduce the testing time by:

- Removing useless jobs
- Making better use of caches and sharing resources
- Splitting tests further into smaller jobs

Changes:

- Increases the number of unit test partitions to 4 since we have added way more tests
- Removes the matrix from the sync integration job; it doesn't make a lot of sense to run the sync test for both debug and release (there is no functional difference other than speed/debug info)

CI will look a bit funky for this PR because of the way GitHub implements required checks - if this is merged, the required checks need to be replaced (e.g. there will no longer be a test (1/3) etc., it will now be test (1/4)...)
