### PR TITLE
chore: convert datagram failure error to debug

### DIFF
--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -1579,7 +1579,7 @@ pub(crate) async fn send_loop(udp: Arc<UdpSocket>, rx: EgressReceiver) {
                 trace!( target : "discv4",  ?to, ?size,"sent payload");
             }
             Err(err) => {
-                warn!( target : "discv4",  ?to, ?err,"Failed to send datagram.");
+                debug!( target : "discv4",  ?to, ?err,"Failed to send datagram.");
             }
         }
     }


### PR DESCRIPTION
this case can happen if the targeted node uses port 0.

it is not worth checking for this because redundant overhead