### PR TITLE
fix(stages): reset Merkle checkpoint

### DIFF
--- a/crates/stages/src/stages/merkle.rs
+++ b/crates/stages/src/stages/merkle.rs
@@ -161,7 +161,7 @@ impl<DB: Database> Stage<DB> for MerkleStage {
 
         let block_root = tx.get_header(current_block)?.state_root;
 
-        let checkpoint = self.get_execution_checkpoint(tx)?;
+        let mut checkpoint = self.get_execution_checkpoint(tx)?;
 
         let trie_root = if range.is_empty() {
             block_root
@@ -185,6 +185,7 @@ impl<DB: Database> Stage<DB> for MerkleStage {
                     "Rebuilding trie"
                 );
                 // Reset the checkpoint and clear trie tables
+                checkpoint = None;
                 self.save_execution_checkpoint(tx, None)?;
                 tx.clear::<tables::AccountsTrie>()?;
                 tx.clear::<tables::StoragesTrie>()?;


### PR DESCRIPTION
Previously, if the Merkle checkpoint wasn't relevant anymore, we've reset it in the table but continued to use throughout the execution iteration. Now, we reset the variable, so we start fresh without the checkpoint.

Thanks @rkrasiuk for flagging!