### PR TITLE
chore: make reth config serde default

### DIFF
--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -47,6 +47,7 @@ impl Config {
 
 /// Configuration for each stage in the pipeline.
 #[derive(Debug, Clone, Default, Deserialize, PartialEq, Serialize)]
+#[serde(default)]
 pub struct StageConfig {
     /// Header stage configuration.
     pub headers: HeadersConfig,
@@ -62,6 +63,7 @@ pub struct StageConfig {
 
 /// Header stage configuration.
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Serialize)]
+#[serde(default)]
 pub struct HeadersConfig {
     /// The maximum number of requests to send concurrently.
     ///
@@ -105,6 +107,7 @@ impl From<HeadersConfig> for ReverseHeadersDownloaderBuilder {
 
 /// Total difficulty stage configuration
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Serialize)]
+#[serde(default)]
 pub struct TotalDifficultyConfig {
     /// The maximum number of total difficulty entries to sum up before committing progress to the
     /// database.
@@ -119,6 +122,7 @@ impl Default for TotalDifficultyConfig {
 
 /// Body stage configuration.
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Serialize)]
+#[serde(default)]
 pub struct BodiesConfig {
     /// The batch size of non-empty blocks per one request
     ///
@@ -172,6 +176,7 @@ impl From<BodiesConfig> for BodiesDownloaderBuilder {
 
 /// Sender recovery stage configuration.
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(default)]
 pub struct SenderRecoveryConfig {
     /// The maximum number of blocks to process before committing progress to the database.
     pub commit_threshold: u64,
@@ -185,6 +190,7 @@ impl Default for SenderRecoveryConfig {
 
 /// Execution stage configuration.
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Serialize)]
+#[serde(default)]
 pub struct ExecutionConfig {
     /// The maximum number of blocks to process before the execution stage commits.
     pub max_blocks: Option<u64>,

--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -1043,6 +1043,7 @@ pub enum PeerAction {
 /// Config type for initiating a [`PeersManager`] instance
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 pub struct PeersConfig {
     /// How often to recheck free slots for outbound connections.
     #[cfg_attr(feature = "serde", serde(with = "humantime_serde"))]

--- a/crates/net/network/src/session/config.rs
+++ b/crates/net/network/src/session/config.rs
@@ -19,6 +19,7 @@ pub const PROTOCOL_BREACH_REQUEST_TIMEOUT: Duration = Duration::from_secs(2 * 60
 /// Configuration options when creating a [SessionManager](crate::session::SessionManager).
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 pub struct SessionsConfig {
     /// Size of the session command buffer (per session task).
     pub session_command_buffer: usize,


### PR DESCRIPTION
adds default attribute to config fields so new fields won't break older representations:


> When deserializing, any missing fields should be filled in from the struct's implementation of Default

this will make it possible to only partially configure the `Config` in reth.toml