### PR TITLE
perf: cache fork timestamps

### DIFF
--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -692,6 +692,22 @@ mod tests {
 
     // Tests that we skip any fork blocks in block #0 (the genesis ruleset)
     #[test]
+    fn test_fork_timestamps() {
+        let spec = ChainSpec::builder().chain(Chain::mainnet()).genesis(Genesis::default()).build();
+        assert!(spec.fork_timestamps.shanghai.is_none());
+
+        let spec = ChainSpec::builder()
+            .chain(Chain::mainnet())
+            .genesis(Genesis::default())
+            .with_fork(Hardfork::Shanghai, ForkCondition::Timestamp(1337))
+            .build();
+        assert_eq!(spec.fork_timestamps.shanghai, Some(1337));
+        assert!(spec.is_shanghai_activated_at_timestamp(1337));
+        assert!(!spec.is_shanghai_activated_at_timestamp(1336));
+    }
+
+    // Tests that we skip any fork blocks in block #0 (the genesis ruleset)
+    #[test]
     fn ignores_genesis_fork_blocks() {
         let spec = ChainSpec::builder()
             .chain(Chain::mainnet())

--- a/crates/primitives/src/hardfork.rs
+++ b/crates/primitives/src/hardfork.rs
@@ -158,6 +158,7 @@ mod tests {
             genesis: Genesis::default(),
             genesis_hash: None,
             hardforks: BTreeMap::from([(Hardfork::Frontier, ForkCondition::Never)]),
+            fork_timestamps: Default::default(),
         };
 
         assert_eq!(Hardfork::Frontier.fork_id(&spec), None);
@@ -170,6 +171,7 @@ mod tests {
             genesis: Genesis::default(),
             genesis_hash: None,
             hardforks: BTreeMap::from([(Hardfork::Shanghai, ForkCondition::Never)]),
+            fork_timestamps: Default::default(),
         };
 
         assert_eq!(Hardfork::Shanghai.fork_filter(&spec), None);


### PR DESCRIPTION
Closes #2881

introduces a new container type for all future timestamp-based forks, this prevents a lookup 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5af5dc0</samp>

This pull request adds a new feature to the `ChainSpec` struct that allows specifying the timestamps of hard forks in the network configuration. This enables the `ChainSpec` to determine if a fork is active or not at a given block. The feature is implemented in the files `crates/primitives/src/chain/spec.rs` and `crates/primitives/src/hardfork.rs`.