### PR TITLE
perf: combine block + receipt request

### DIFF
--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use jsonrpsee::{core::RpcResult, server::IdProvider};
-use reth_primitives::{Receipt, SealedBlock, H256};
+use reth_primitives::{Receipt, SealedBlock};
 use reth_provider::{BlockIdProvider, BlockProvider, EvmEnvProvider};
 use reth_rpc_api::EthFilterApiServer;
 use reth_rpc_types::{Filter, FilterBlockOption, FilterChanges, FilterId, FilteredParams, Log};
@@ -283,7 +283,8 @@ where
             FilterBlockOption::AtBlockHash(block_hash) => {
                 let mut all_logs = Vec::new();
                 // all matching logs in the block, if it exists
-                if let Some((block, receipts)) = self.block_and_receipts_by_hash(block_hash).await?
+                if let Some((block, receipts)) =
+                    self.eth_cache.get_sealed_block_and_receipts(block_hash).await?
                 {
                     let filter = FilteredParams::new(Some(filter));
                     logs_utils::append_matching_block_logs(
@@ -343,20 +344,7 @@ where
             None => return Ok(None),
         };
 
-        self.block_and_receipts_by_hash(block_hash).await
-    }
-
-    /// Fetches both receipts and block for the given block hash.
-    async fn block_and_receipts_by_hash(
-        &self,
-        block_hash: H256,
-    ) -> EthResult<Option<(SealedBlock, Vec<Receipt>)>> {
-        let block = self.eth_cache.get_sealed_block(block_hash);
-        let receipts = self.eth_cache.get_receipts(block_hash);
-
-        let (block, receipts) = futures::try_join!(block, receipts)?;
-
-        Ok(block.zip(receipts))
+        Ok(self.eth_cache.get_sealed_block_and_receipts(block_hash).await?)
     }
 
     /// Returns all logs in the given _inclusive_ range that match the filter


### PR DESCRIPTION
closes #2887

This adds a new cache function to fetch a block and its receipts with one call.

in the caching layer reads are spawned tasks, this will only spawn 1 task now to fetch receipts+block instead of two.

EDIT: need to think about this a bit more