### PR TITLE
fix(stages): unwind receipts in execution stage

### DIFF
--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -312,6 +312,7 @@ impl<EF: ExecutorFactory, DB: Database> Stage<DB> for ExecutionStage<EF> {
 
         // Unwind all receipts for transactions in the block range
         tx.unwind_table_by_num::<tables::Receipts>(first_tx_num)?;
+        // `unwind_table_by_num` doesn't unwind the provided key, so we need to unwind it manually
         tx.delete::<tables::Receipts>(first_tx_num, None)?;
 
         info!(target: "sync::stages::execution", to_block = input.unwind_to, unwind_progress = unwind_to, is_final_range, "Unwind iteration finished");

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -307,6 +307,13 @@ impl<EF: ExecutorFactory, DB: Database> Stage<DB> for ExecutionStage<EF> {
             tx.delete::<tables::StorageChangeSet>(key, None)?;
         }
 
+        // Look up the start index for the transaction range
+        let first_tx_num = tx.block_body_indices(*range.start())?.first_tx_num();
+
+        // Unwind all receipts for transactions in the block range
+        tx.unwind_table_by_num::<tables::Receipts>(first_tx_num)?;
+        tx.delete::<tables::Receipts>(first_tx_num, None)?;
+
         info!(target: "sync::stages::execution", to_block = input.unwind_to, unwind_progress = unwind_to, is_final_range, "Unwind iteration finished");
         Ok(UnwindOutput { checkpoint: StageCheckpoint::new(unwind_to) })
     }
@@ -548,8 +555,10 @@ mod tests {
         assert_eq!(
             db_tx.get::<tables::PlainAccountState>(miner_acc),
             Ok(None),
-            "Third account should be unwinded"
+            "Third account should be unwound"
         );
+
+        assert_eq!(db_tx.get::<tables::Receipts>(0), Ok(None), "First receipt should be unwound");
     }
 
     #[tokio::test]

--- a/crates/storage/provider/src/post_state/mod.rs
+++ b/crates/storage/provider/src/post_state/mod.rs
@@ -573,6 +573,7 @@ impl PostState {
         self.write_history_to_db(tx)?;
 
         // Write new storage state
+        tracing::trace!(target: "provider::post_state", len = self.storage.len(), "Writing new storage state");
         let mut storages_cursor = tx.cursor_dup_write::<tables::PlainStorageState>()?;
         for (address, storage) in self.storage.into_iter() {
             // If the storage was wiped at least once, remove all previous entries from the
@@ -613,13 +614,14 @@ impl PostState {
         }
 
         // Write bytecode
-        tracing::trace!(target: "provider::post_state", len = self.bytecode.len(), "Writing bytecods");
+        tracing::trace!(target: "provider::post_state", len = self.bytecode.len(), "Writing bytecodes");
         let mut bytecodes_cursor = tx.cursor_write::<tables::Bytecodes>()?;
         for (hash, bytecode) in self.bytecode.into_iter() {
             bytecodes_cursor.upsert(hash, bytecode)?;
         }
 
         // Write the receipts of the transactions
+        tracing::trace!(target: "provider::post_state", len = self.receipts.len(), "Writing receipts");
         let mut bodies_cursor = tx.cursor_read::<tables::BlockBodyIndices>()?;
         let mut receipts_cursor = tx.cursor_write::<tables::Receipts>()?;
         for (block, receipts) in self.receipts {

--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -182,6 +182,8 @@ where
 
     /// Unwind table by some number key.
     /// Returns number of rows unwound.
+    ///
+    /// Note: Key is not inclusive and specified key would stay in db.
     #[inline]
     pub fn unwind_table_by_num<T>(&self, num: u64) -> Result<usize, DbError>
     where
@@ -191,7 +193,7 @@ where
         self.unwind_table::<T, _>(num, |key| key)
     }
 
-    /// Unwind the table to a provided block.
+    /// Unwind the table to a provided number key.
     /// Returns number of rows unwound.
     ///
     /// Note: Key is not inclusive and specified key would stay in db.


### PR DESCRIPTION
During the execution of `Execution` stage, we insert receipts: https://github.com/paradigmxyz/reth/blob/b1760e7332faef690431fabeae3119a9fcb7d077/crates/storage/provider/src/post_state/mod.rs#L622-L632 but don't delete them during the unwind. It may be critical on the next execution iteration because we use `append` and it expects the keys to be inserted in ascending order.