### PR TITLE
feat: add constants for total paris difficulty

### DIFF
--- a/crates/primitives/src/hardfork.rs
+++ b/crates/primitives/src/hardfork.rs
@@ -159,6 +159,7 @@ mod tests {
             genesis_hash: None,
             hardforks: BTreeMap::from([(Hardfork::Frontier, ForkCondition::Never)]),
             fork_timestamps: Default::default(),
+            paris_block_and_final_difficulty: None,
         };
 
         assert_eq!(Hardfork::Frontier.fork_id(&spec), None);
@@ -172,6 +173,7 @@ mod tests {
             genesis_hash: None,
             hardforks: BTreeMap::from([(Hardfork::Shanghai, ForkCondition::Never)]),
             fork_timestamps: Default::default(),
+            paris_block_and_final_difficulty: None,
         };
 
         assert_eq!(Hardfork::Shanghai.fork_filter(&spec), None);


### PR DESCRIPTION
Closes #2865 

total difficulty is stored in a separate table

since this is a constant after Paris we can add a (`paris block`, final terminal difficulty) pair.

This would get rid of td lookups for RPC get_block and everytime an evm env is configured.

@onbjerg Ideally we can use this check here, but this would mean that we're returning the final difficulty even if we don't have the block synced (perhaps this is fine though?)

https://github.com/paradigmxyz/reth/blob/b5eee9aa24bccf9cb531ad7f4f0455eff62421b3/crates/storage/provider/src/providers/database.rs#L145-L145
