### PR TITLE
perf(storage): use `delete_current` when possible

### DIFF
--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -203,7 +203,7 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
             }
 
             // Delete the current body value
-            tx.delete::<tables::BlockBodyIndices>(number, None)?;
+            rev_walker.delete_current()?;
         }
 
         info!(target: "sync::stages::bodies", to_block = input.unwind_to, stage_progress = input.unwind_to, is_final_range = true, "Unwind iteration finished");

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -292,7 +292,7 @@ impl<EF: ExecutorFactory, DB: Database> Stage<DB> for ExecutionStage<EF> {
                 break
             }
             // delete all changesets
-            tx.delete::<tables::AccountChangeSet>(block_num, None)?;
+            rev_acc_changeset_walker.delete_current()?;
         }
 
         let mut rev_storage_changeset_walker = storage_changeset.walk_back(None)?;
@@ -301,7 +301,7 @@ impl<EF: ExecutorFactory, DB: Database> Stage<DB> for ExecutionStage<EF> {
                 break
             }
             // delete all changesets
-            tx.delete::<tables::StorageChangeSet>(key, None)?;
+            rev_storage_changeset_walker.delete_current()?;
         }
 
         info!(target: "sync::stages::execution", to_block = input.unwind_to, unwind_progress = unwind_to, is_final_range, "Unwind iteration finished");

--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -210,7 +210,7 @@ where
             if selector(entry_key.clone()) <= key {
                 break
             }
-            self.delete::<T>(entry_key, None)?;
+            reverse_walker.delete_current()?;
             deleted += 1;
         }
 


### PR DESCRIPTION
When using a cursor, it's better to delete current entry by using `DbCursorRW::delete_current` which calls `self.inner.del(WriteFlags::CURRENT)` internally, instead of using `DbTxMut::delete` which encodes + lookups the provided key manually.

cc & thanks @joshieDo for flagging