### PR TITLE
feat(stages): sender recovery stage progress

### DIFF
--- a/bin/reth/src/stage/drop.rs
+++ b/bin/reth/src/stage/drop.rs
@@ -63,6 +63,13 @@ impl Command {
 
         tool.db.update(|tx| {
             match &self.stage {
+                StageEnum::Senders => {
+                    tx.clear::<tables::TxSenders>()?;
+                    tx.put::<tables::SyncStage>(
+                        StageId::SenderRecovery.to_string(),
+                        Default::default(),
+                    )?;
+                }
                 StageEnum::Execution => {
                     tx.clear::<tables::PlainAccountState>()?;
                     tx.clear::<tables::PlainStorageState>()?;

--- a/crates/stages/src/stages/hashing_account.rs
+++ b/crates/stages/src/stages/hashing_account.rs
@@ -284,7 +284,7 @@ impl<DB: Database> Stage<DB> for AccountHashingStage {
 }
 
 fn stage_progress<DB: Database>(
-    tx: &mut Transaction<'_, DB>,
+    tx: &Transaction<'_, DB>,
 ) -> Result<EntitiesCheckpoint, DatabaseError> {
     Ok(EntitiesCheckpoint {
         processed: tx.deref().entries::<tables::HashedAccount>()? as u64,

--- a/crates/stages/src/stages/hashing_account.rs
+++ b/crates/stages/src/stages/hashing_account.rs
@@ -229,7 +229,7 @@ impl<DB: Database> Stage<DB> for AccountHashingStage {
                         address: Some(next_address.key().unwrap()),
                         from: from_block,
                         to: to_block,
-                        progress: stage_progress(tx)?,
+                        progress: stage_checkpoint_progress(tx)?,
                     },
                 );
 
@@ -251,7 +251,10 @@ impl<DB: Database> Stage<DB> for AccountHashingStage {
         // We finished the hashing stage, no future iterations is expected for the same block range,
         // so no checkpoint is needed.
         let checkpoint = input.previous_stage_checkpoint().with_account_hashing_stage_checkpoint(
-            AccountHashingCheckpoint { progress: stage_progress(tx)?, ..Default::default() },
+            AccountHashingCheckpoint {
+                progress: stage_checkpoint_progress(tx)?,
+                ..Default::default()
+            },
         );
 
         info!(target: "sync::stages::hashing_account", checkpoint = %checkpoint, is_final_range = true, "Stage iteration finished");
@@ -273,7 +276,7 @@ impl<DB: Database> Stage<DB> for AccountHashingStage {
         let mut stage_checkpoint =
             input.checkpoint.account_hashing_stage_checkpoint().unwrap_or_default();
 
-        stage_checkpoint.progress = stage_progress(tx)?;
+        stage_checkpoint.progress = stage_checkpoint_progress(tx)?;
 
         info!(target: "sync::stages::hashing_account", to_block = input.unwind_to, %unwind_progress, is_final_range, "Unwind iteration finished");
         Ok(UnwindOutput {
@@ -283,7 +286,7 @@ impl<DB: Database> Stage<DB> for AccountHashingStage {
     }
 }
 
-fn stage_progress<DB: Database>(
+fn stage_checkpoint_progress<DB: Database>(
     tx: &Transaction<'_, DB>,
 ) -> Result<EntitiesCheckpoint, DatabaseError> {
     Ok(EntitiesCheckpoint {

--- a/crates/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/src/stages/hashing_storage.rs
@@ -213,7 +213,7 @@ impl<DB: Database> Stage<DB> for StorageHashingStage {
 }
 
 fn stage_progress<DB: Database>(
-    tx: &mut Transaction<'_, DB>,
+    tx: &Transaction<'_, DB>,
 ) -> Result<EntitiesCheckpoint, DatabaseError> {
     Ok(EntitiesCheckpoint {
         processed: tx.deref().entries::<tables::HashedStorage>()? as u64,

--- a/crates/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/src/stages/hashing_storage.rs
@@ -160,7 +160,7 @@ impl<DB: Database> Stage<DB> for StorageHashingStage {
                         storage: current_subkey,
                         from: from_block,
                         to: to_block,
-                        progress: stage_progress(tx)?,
+                        progress: stage_checkpoint_progress(tx)?,
                     },
                 );
 
@@ -181,7 +181,10 @@ impl<DB: Database> Stage<DB> for StorageHashingStage {
         // We finished the hashing stage, no future iterations is expected for the same block range,
         // so no checkpoint is needed.
         let checkpoint = input.previous_stage_checkpoint().with_storage_hashing_stage_checkpoint(
-            StorageHashingCheckpoint { progress: stage_progress(tx)?, ..Default::default() },
+            StorageHashingCheckpoint {
+                progress: stage_checkpoint_progress(tx)?,
+                ..Default::default()
+            },
         );
 
         info!(target: "sync::stages::hashing_storage", checkpoint = %checkpoint, is_final_range = true, "Stage iteration finished");
@@ -202,7 +205,7 @@ impl<DB: Database> Stage<DB> for StorageHashingStage {
         let mut stage_checkpoint =
             input.checkpoint.storage_hashing_stage_checkpoint().unwrap_or_default();
 
-        stage_checkpoint.progress = stage_progress(tx)?;
+        stage_checkpoint.progress = stage_checkpoint_progress(tx)?;
 
         info!(target: "sync::stages::hashing_storage", to_block = input.unwind_to, %unwind_progress, is_final_range, "Unwind iteration finished");
         Ok(UnwindOutput {
@@ -212,7 +215,7 @@ impl<DB: Database> Stage<DB> for StorageHashingStage {
     }
 }
 
-fn stage_progress<DB: Database>(
+fn stage_checkpoint_progress<DB: Database>(
     tx: &Transaction<'_, DB>,
 ) -> Result<EntitiesCheckpoint, DatabaseError> {
     Ok(EntitiesCheckpoint {

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -5,9 +5,8 @@ use reth_db::{
     database::Database,
     tables,
     transaction::{DbTx, DbTxMut},
-    RawKey, RawTable, RawValue,
+    DatabaseError, RawKey, RawTable, RawValue,
 };
-use reth_interfaces::db::DatabaseError;
 use reth_primitives::{
     keccak256,
     stage::{EntitiesCheckpoint, StageCheckpoint, StageId},
@@ -114,7 +113,7 @@ impl<DB: Database> Stage<DB> for SenderRecoveryStage {
             // closure that would recover signer. Used as utility to wrap result
             let recover = |entry: Result<
                 (RawKey<TxNumber>, RawValue<TransactionSignedNoHash>),
-                reth_db::DatabaseError,
+                DatabaseError,
             >,
                            rlp_buf: &mut Vec<u8>|
              -> Result<(u64, H160), Box<StageError>> {
@@ -286,7 +285,7 @@ mod tests {
                     total: Some(total)
                 }))
             }, done: false }) if block_number == expected_progress &&
-                processed == runner.tx.inner().block_body_indices(expected_progress).unwrap().last_tx_num() &&
+                processed == runner.tx.table::<tables::TxSenders>().unwrap().len() as u64 &&
                 total == total_transactions
         );
 
@@ -305,7 +304,7 @@ mod tests {
                     total: Some(total)
                 }))
             }, done: true }) if block_number == previous_stage &&
-                processed == runner.tx.inner().block_body_indices(previous_stage).unwrap().last_tx_num() &&
+                processed == runner.tx.table::<tables::TxSenders>().unwrap().len() as u64 &&
                 total == total_transactions
         );
 

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -150,10 +150,6 @@ impl<DB: Database> Stage<DB> for SenderRecoveryStage {
             }
         }
 
-        // Drop cursors, so we can get mutable tx borrow for stage progress calculation
-        drop(tx_cursor);
-        drop(senders_cursor);
-
         let stage_checkpoint = stage_progress(tx)?;
 
         info!(target: "sync::stages::sender_recovery", stage_progress = end_block, is_final_range, "Stage iteration finished");
@@ -188,7 +184,7 @@ impl<DB: Database> Stage<DB> for SenderRecoveryStage {
 }
 
 fn stage_progress<DB: Database>(
-    tx: &mut Transaction<'_, DB>,
+    tx: &Transaction<'_, DB>,
 ) -> Result<EntitiesCheckpoint, DatabaseError> {
     Ok(EntitiesCheckpoint {
         processed: tx.deref().entries::<tables::TxSenders>()? as u64,

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -186,7 +186,9 @@ impl From<SenderRecoveryStageError> for StageError {
 mod tests {
     use assert_matches::assert_matches;
     use reth_interfaces::test_utils::generators::{random_block, random_block_range};
-    use reth_primitives::{BlockNumber, SealedBlock, TransactionSigned, H256};
+    use reth_primitives::{
+        stage::StageUnitCheckpoint, BlockNumber, SealedBlock, TransactionSigned, H256,
+    };
 
     use super::*;
     use crate::test_utils::{

--- a/crates/storage/db/src/tables/mod.rs
+++ b/crates/storage/db/src/tables/mod.rs
@@ -170,7 +170,7 @@ table!(
 
 table!(
     /// (Canonical only) Stores the transaction body for canonical transactions.
-    (  Transactions ) TxNumber | TransactionSignedNoHash
+    ( Transactions ) TxNumber | TransactionSignedNoHash
 );
 
 table!(
@@ -293,7 +293,7 @@ dupsort!(
 );
 
 table!(
-    /// Stores the transaction sender for each transaction.
+    /// Stores the transaction sender for each canonical transaction.
     /// It is needed to speed up execution stage and allows fetching signer without doing
     /// transaction signed recovery
     ( TxSenders ) TxNumber | Address


### PR DESCRIPTION
Continuing with the same idea as in https://github.com/paradigmxyz/reth/pull/2820, we calculate progress for Sender Recovery stage based on the number of entries in the `TxSenders` table vs number of entries in the `Transactions` table. Both contain only canonical transactions, so it should be correct.