### PR TITLE
feat(cli): integrate max tracing requests in cli

### DIFF
--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -37,6 +37,8 @@ pub(crate) const RPC_DEFAULT_MAX_REQUEST_SIZE_MB: u32 = 15;
 pub(crate) const RPC_DEFAULT_MAX_RESPONSE_SIZE_MB: u32 = 25;
 /// Default number of incoming connections.
 pub(crate) const RPC_DEFAULT_MAX_CONNECTIONS: u32 = 100;
+/// Default number of incoming connections.
+pub(crate) const RPC_DEFAULT_MAX_TRACING_REQUESTS: u32 = 25;
 
 /// Parameters for configuring the rpc more granularity via CLI
 #[derive(Debug, Args, PartialEq, Eq, Default)]
@@ -118,6 +120,10 @@ pub struct RpcServerArgs {
     #[arg(long, value_name = "COUNT", default_value_t = RPC_DEFAULT_MAX_CONNECTIONS)]
     pub rpc_max_connections: u32,
 
+    /// Maximum number of concurrent tracing requests.
+    #[arg(long, value_name = "COUNT", default_value_t = RPC_DEFAULT_MAX_TRACING_REQUESTS)]
+    pub rpc_max_tracing_requests: u32,
+
     /// Gas price oracle configuration.
     #[clap(flatten)]
     pub gas_price_oracle: GasPriceOracleArgs,
@@ -146,7 +152,9 @@ impl RpcServerArgs {
 
     /// Extracts the [EthConfig] from the args.
     pub fn eth_config(&self) -> EthConfig {
-        EthConfig::default().with_gpo_config(self.gas_price_oracle_config())
+        EthConfig::default()
+            .max_tracing_requests(self.rpc_max_tracing_requests)
+            .gpo_config(self.gas_price_oracle_config())
     }
 
     /// The execution layer and consensus layer clients SHOULD accept a configuration parameter:

--- a/crates/rpc/rpc-builder/src/eth.rs
+++ b/crates/rpc/rpc-builder/src/eth.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 pub(crate) const DEFAULT_MAX_LOGS_IN_RESPONSE: usize = 10_000;
 
 /// The default maximum number of concurrently executed tracing calls
-pub(crate) const DEFAULT_MAX_TRACING_REQUESTS: usize = 10;
+pub(crate) const DEFAULT_MAX_TRACING_REQUESTS: u32 = 25;
 
 /// All handlers for the `eth` namespace
 #[derive(Debug, Clone)]
@@ -34,7 +34,7 @@ pub struct EthConfig {
     /// Settings for the gas price oracle
     pub gas_oracle: GasPriceOracleConfig,
     /// The maximum number of tracing calls that can be executed in concurrently.
-    pub max_tracing_requests: usize,
+    pub max_tracing_requests: u32,
     /// Maximum number of logs that can be returned in a single response in `eth_getLogs` calls.
     pub max_logs_per_response: usize,
 }
@@ -52,25 +52,25 @@ impl Default for EthConfig {
 
 impl EthConfig {
     /// Configures the caching layer settings
-    pub fn with_state_cache(mut self, cache: EthStateCacheConfig) -> Self {
+    pub fn state_cache(mut self, cache: EthStateCacheConfig) -> Self {
         self.cache = cache;
         self
     }
 
     /// Configures the gas price oracle settings
-    pub fn with_gpo_config(mut self, gas_oracle_config: GasPriceOracleConfig) -> Self {
+    pub fn gpo_config(mut self, gas_oracle_config: GasPriceOracleConfig) -> Self {
         self.gas_oracle = gas_oracle_config;
         self
     }
 
     /// Configures the maximum number of tracing requests
-    pub fn with_max_tracing_requests(mut self, max_requests: usize) -> Self {
+    pub fn max_tracing_requests(mut self, max_requests: u32) -> Self {
         self.max_tracing_requests = max_requests;
         self
     }
 
     /// Configures the maximum number of logs per response
-    pub fn with_max_logs_per_response(mut self, max_logs: usize) -> Self {
+    pub fn max_logs_per_response(mut self, max_logs: usize) -> Self {
         self.max_logs_per_response = max_logs;
         self
     }

--- a/crates/rpc/rpc/src/call_guard.rs
+++ b/crates/rpc/rpc/src/call_guard.rs
@@ -4,14 +4,14 @@ use tokio::sync::{AcquireError, OwnedSemaphorePermit, Semaphore};
 /// RPC Tracing call guard semaphore.
 ///
 /// This is used to restrict the number of concurrent RPC requests to tracing methods like
-/// `debug_traceTransaction` because they can consume a lot of memory.
+/// `debug_traceTransaction` because they can consume a lot of memory and CPU.
 #[derive(Clone, Debug)]
 pub struct TracingCallGuard(Arc<Semaphore>);
 
 impl TracingCallGuard {
     /// Create a new `TracingCallGuard` with the given maximum number of tracing calls in parallel.
-    pub fn new(max_tracing_requests: usize) -> Self {
-        Self(Arc::new(Semaphore::new(max_tracing_requests)))
+    pub fn new(max_tracing_requests: u32) -> Self {
+        Self(Arc::new(Semaphore::new(max_tracing_requests as usize)))
     }
 
     /// See also [Semaphore::acquire_owned]


### PR DESCRIPTION
integrate the `max_tracing_requests` in cli

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a6a6e5b</samp>

Increased the tracing limit and improved the tracing API in the `rpc` and `rpc-builder` crates. Refactored some builder methods and added documentation and type annotations to the `TracingCallGuard` struct.