### PR TITLE
fix(cli): clear receipts on `stage drop execution`

### DIFF
--- a/bin/reth/src/stage/drop.rs
+++ b/bin/reth/src/stage/drop.rs
@@ -69,6 +69,7 @@ impl Command {
                     tx.clear::<tables::AccountChangeSet>()?;
                     tx.clear::<tables::StorageChangeSet>()?;
                     tx.clear::<tables::Bytecodes>()?;
+                    tx.clear::<tables::Receipts>()?;
                     tx.put::<tables::SyncStage>(
                         StageId::Execution.to_string(),
                         Default::default(),


### PR DESCRIPTION
On `./reth stages drop execution` we didn't drop receipts but as execution is the one that created them it was expected for them to be dropped.