### PR TITLE
fix: configure ipc server properly

### DIFF
--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -5,7 +5,7 @@ use clap::{
     builder::{PossibleValue, TypedValueParser},
     Arg, Args, Command,
 };
-use futures::FutureExt;
+use futures::{FutureExt, TryFutureExt};
 use reth_network_api::{NetworkInfo, Peers};
 use reth_provider::{
     BlockProviderIdExt, CanonStateSubscriptions, EvmEnvProvider, HeaderProvider,
@@ -140,6 +140,13 @@ impl RpcServerArgs {
         self.rpc_max_response_size * 1024 * 1024
     }
 
+    /// Convenience function that returns whether ipc is enabled
+    ///
+    /// By default IPC is enabled therefor it is enabled if the `ipcdisable` is false.
+    fn is_ipc_enabled(&self) -> bool {
+        !self.ipcdisable
+    }
+
     /// Extracts the gas price oracle config from the args.
     pub fn gas_price_oracle_config(&self) -> GasPriceOracleConfig {
         GasPriceOracleConfig::new(
@@ -232,11 +239,17 @@ impl RpcServerArgs {
             .build_with_auth_server(module_config, engine_api);
 
         let server_config = self.rpc_server_config();
-        let has_server = server_config.has_server();
-        let launch_rpc = rpc_modules.start_server(server_config).inspect(|_| {
-            if has_server {
-                info!(target: "reth::cli", "Started RPC server");
+        let launch_rpc = rpc_modules.start_server(server_config).map_ok(|handle| {
+            if let Some(url) = handle.ipc_endpoint() {
+                info!(target: "reth::cli", url=%url, "IPC server started");
             }
+            if let Some(addr) = handle.http_local_addr() {
+                info!(target: "reth::cli", url=%addr, "HTTP server started");
+            }
+            if let Some(addr) = handle.ws_local_addr() {
+                info!(target: "reth::cli", url=%addr, "WS server started");
+            }
+            handle
         });
 
         let launch_auth = auth_module.start_server(auth_config).inspect(|_| {
@@ -327,15 +340,27 @@ impl RpcServerArgs {
     fn transport_rpc_module_config(&self) -> TransportRpcModuleConfig {
         let mut config = TransportRpcModuleConfig::default()
             .with_config(RpcModuleConfig::new(self.eth_config()));
-        let rpc_modules =
-            RpcModuleSelection::Selection(vec![RethRpcModule::Admin, RethRpcModule::Eth]);
+
         if self.http {
-            config = config.with_http(self.http_api.as_ref().unwrap_or(&rpc_modules).clone());
+            config = config.with_http(
+                self.http_api
+                    .clone()
+                    .unwrap_or_else(|| RpcModuleSelection::standard_modules().into()),
+            );
         }
 
         if self.ws {
-            config = config.with_ws(self.ws_api.as_ref().unwrap_or(&rpc_modules).clone());
+            config = config.with_ws(
+                self.ws_api
+                    .clone()
+                    .unwrap_or_else(|| RpcModuleSelection::standard_modules().into()),
+            );
         }
+
+        if self.is_ipc_enabled() {
+            config = config.with_ipc(RpcModuleSelection::default_ipc_modules());
+        }
+
         config
     }
 
@@ -381,7 +406,7 @@ impl RpcServerArgs {
             config = config.with_ws_address(socket_address).with_ws(self.http_ws_server_builder());
         }
 
-        if !self.ipcdisable {
+        if self.is_ipc_enabled() {
             config = config.with_ipc(self.ipc_server_builder()).with_ipc_endpoint(
                 self.ipcpath.as_ref().unwrap_or(&constants::DEFAULT_IPC_ENDPOINT.to_string()),
             );
@@ -473,7 +498,7 @@ mod tests {
         assert_eq!(config.http().cloned().unwrap().into_selection(), expected);
         assert_eq!(
             config.ws().cloned().unwrap().into_selection(),
-            vec![RethRpcModule::Admin, RethRpcModule::Eth]
+            RpcModuleSelection::standard_modules()
         );
     }
 

--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -656,6 +656,21 @@ mod tests {
         assert_eq!(response, msg);
     }
 
+    #[tokio::test]
+    async fn test_ipc_modules() {
+        let endpoint = dummy_endpoint();
+        let server = Builder::default().build(&endpoint).unwrap();
+        let mut module = RpcModule::new(());
+        let msg = r#"{"admin":"1.0","debug":"1.0","engine":"1.0","eth":"1.0","ethash":"1.0","miner":"1.0","net":"1.0","rpc":"1.0","txpool":"1.0","web3":"1.0"}"#;
+        module.register_method("rpc_modules", move |_, _| msg).unwrap();
+        let handle = server.start(module).await.unwrap();
+        tokio::spawn(handle.stopped());
+
+        let client = IpcClientBuilder::default().build(endpoint).await.unwrap();
+        let response: String = client.request("rpc_modules", rpc_params![]).await.unwrap();
+        assert_eq!(response, msg);
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     #[traced_test]
     async fn test_rpc_subscription() {

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -415,6 +415,20 @@ impl RpcModuleSelection {
             .into_selection()
     }
 
+    /// Returns the [RpcModuleSelection::STANDARD_MODULES] as a selection.
+    pub fn standard_modules() -> Vec<RethRpcModule> {
+        RpcModuleSelection::try_from_selection(RpcModuleSelection::STANDARD_MODULES.iter().copied())
+            .expect("valid selection")
+            .into_selection()
+    }
+
+    /// All modules that are available by default on IPC.
+    ///
+    /// By default all modules are available on IPC.
+    pub fn default_ipc_modules() -> Vec<RethRpcModule> {
+        Self::all_modules()
+    }
+
     /// Creates a new [RpcModuleSelection::Selection] from the given items.
     ///
     /// # Example
@@ -1477,6 +1491,7 @@ impl RpcServer {
             ws_local_addr: ws_http.ws_local_addr,
             http: None,
             ws: None,
+            ipc_endpoint: None,
             ipc: None,
         };
 
@@ -1487,6 +1502,7 @@ impl RpcServer {
         if let Some((server, module)) =
             ipc_server.and_then(|server| ipc.map(|module| (server, module)))
         {
+            handle.ipc_endpoint = Some(server.endpoint().path().to_string());
             handle.ipc = Some(server.start(module).await?);
         }
 
@@ -1515,6 +1531,7 @@ pub struct RpcServerHandle {
     ws_local_addr: Option<SocketAddr>,
     http: Option<ServerHandle>,
     ws: Option<ServerHandle>,
+    ipc_endpoint: Option<String>,
     ipc: Option<ServerHandle>,
 }
 
@@ -1546,6 +1563,11 @@ impl RpcServerHandle {
         }
 
         Ok(())
+    }
+
+    /// Returns the endpoint of the launched IPC server, if any
+    pub fn ipc_endpoint(&self) -> Option<String> {
+        self.ipc_endpoint.clone()
     }
 
     /// Returns the url to the http server


### PR DESCRIPTION
Closes #2921

IPC server wasn't actually configured properly (no modules) enabled.

this enables all modules over ipc