### PR TITLE
feat: track fcu validity

### DIFF
--- a/crates/blockchain-tree/src/shareable.rs
+++ b/crates/blockchain-tree/src/shareable.rs
@@ -108,6 +108,11 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeViewer
         None
     }
 
+    fn lowest_buffered_ancestor(&self, hash: BlockHash) -> Option<SealedBlockWithSenders> {
+        trace!(target: "blockchain_tree", ?hash, "Returning lowest buffered ancestor");
+        self.tree.read().lowest_buffered_ancestor(&hash).cloned()
+    }
+
     fn canonical_tip(&self) -> BlockNumHash {
         trace!(target: "blockchain_tree", "Returning canonical tip");
         self.tree.read().block_indices().canonical_tip()

--- a/crates/consensus/beacon/src/engine/forkchoice.rs
+++ b/crates/consensus/beacon/src/engine/forkchoice.rs
@@ -1,0 +1,103 @@
+use reth_primitives::H256;
+use reth_rpc_types::engine::{ForkchoiceState, PayloadStatusEnum};
+
+/// The struct that keeps track of the received forkchoice state and their status.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ForkchoiceStateTracker {
+    /// The latest forkchoice state that we received.
+    ///
+    /// Caution: this can be invalid.
+    latest: Option<ReceivedForkchoiceState>,
+
+    /// Tracks the latest forkchoice state that we received to which we need to sync.
+    last_syncing: Option<ForkchoiceState>,
+    /// The latest valid forkchoice state that we received and processed as valid.
+    last_valid: Option<ForkchoiceState>,
+}
+
+impl ForkchoiceStateTracker {
+    /// Sets the latest forkchoice state that we received.
+    ///
+    /// If the status is valid, we also update the last valid forkchoice state.
+    pub(crate) fn set_latest(&mut self, state: ForkchoiceState, status: ForkchoiceStatus) {
+        if status.is_valid() {
+            self.set_valid(state);
+        } else if status.is_syncing() {
+            self.last_syncing = Some(state);
+        }
+
+        let received = ReceivedForkchoiceState { state, status };
+        self.latest = Some(received);
+    }
+
+    fn set_valid(&mut self, state: ForkchoiceState) {
+        // we no longer need to sync to this state.
+        self.last_syncing = None;
+
+        self.last_valid = Some(state);
+    }
+
+    /// Returns the head hash of the latest received FCU to which we need to sync.
+    pub(crate) fn sync_target(&self) -> Option<H256> {
+        self.last_syncing.as_ref().map(|s| s.head_block_hash)
+    }
+
+    /// Returns the last received ForkchoiceState to which we need to sync.
+    pub(crate) fn sync_target_state(&self) -> Option<ForkchoiceState> {
+        self.last_syncing
+    }
+
+    /// Returns true if no forkchoice state has been received yet.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.latest.is_none()
+    }
+}
+
+/// Represents a forkchoice update and tracks the status we assigned to it.
+#[derive(Debug, Clone)]
+#[allow(unused)]
+pub(crate) struct ReceivedForkchoiceState {
+    state: ForkchoiceState,
+    status: ForkchoiceStatus,
+}
+
+/// A simplified representation of [PayloadStatusEnum] specifically for FCU.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum ForkchoiceStatus {
+    /// The forkchoice state is valid.
+    Valid,
+    /// The forkchoice state is invalid.
+    Invalid,
+    /// The forkchoice state is unknown.
+    Syncing,
+}
+
+impl ForkchoiceStatus {
+    pub(crate) fn is_valid(&self) -> bool {
+        matches!(self, ForkchoiceStatus::Valid)
+    }
+
+    pub(crate) fn is_syncing(&self) -> bool {
+        matches!(self, ForkchoiceStatus::Syncing)
+    }
+
+    /// Converts the general purpose [PayloadStatusEnum] into a [ForkchoiceStatus].
+    pub(crate) fn from_payload_status(status: &PayloadStatusEnum) -> Self {
+        match status {
+            PayloadStatusEnum::Valid => ForkchoiceStatus::Valid,
+            PayloadStatusEnum::Invalid { .. } => ForkchoiceStatus::Invalid,
+            PayloadStatusEnum::Syncing => ForkchoiceStatus::Syncing,
+            PayloadStatusEnum::Accepted => {
+                // This is only returned on `newPayload` accepted would be a valid state here.
+                ForkchoiceStatus::Valid
+            }
+            PayloadStatusEnum::InvalidBlockHash { .. } => ForkchoiceStatus::Invalid,
+        }
+    }
+}
+
+impl From<PayloadStatusEnum> for ForkchoiceStatus {
+    fn from(status: PayloadStatusEnum) -> Self {
+        ForkchoiceStatus::from_payload_status(&status)
+    }
+}

--- a/crates/consensus/beacon/src/engine/message.rs
+++ b/crates/consensus/beacon/src/engine/message.rs
@@ -41,6 +41,16 @@ impl OnForkChoiceUpdated {
             fut: Either::Left(futures::future::ready(Ok(ForkchoiceUpdated::new(status)))),
         }
     }
+
+    /// Creates a new instance of `OnForkChoiceUpdated` with the given payload status, if the
+    /// forkchoice update failed due to an invalid payload.
+    pub(crate) fn with_invalid(status: PayloadStatus) -> Self {
+        Self {
+            is_valid_update: false,
+            fut: Either::Left(futures::future::ready(Ok(ForkchoiceUpdated::new(status)))),
+        }
+    }
+
     /// Creates a new instance of `OnForkChoiceUpdated` if the forkchoice update failed because the
     /// given state is considered invalid
     pub(crate) fn invalid_state() -> Self {

--- a/crates/consensus/beacon/src/engine/message.rs
+++ b/crates/consensus/beacon/src/engine/message.rs
@@ -1,4 +1,7 @@
-use crate::{engine::error::BeaconOnNewPayloadError, BeaconConsensusEngineEvent};
+use crate::{
+    engine::{error::BeaconOnNewPayloadError, forkchoice::ForkchoiceStatus},
+    BeaconConsensusEngineEvent,
+};
 use futures::{future::Either, FutureExt};
 use reth_interfaces::consensus::ForkchoiceState;
 use reth_payload_builder::error::PayloadBuilderError;
@@ -19,8 +22,11 @@ use tokio::sync::{mpsc::UnboundedSender, oneshot};
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 #[derive(Debug)]
 pub struct OnForkChoiceUpdated {
-    /// Tracks if this update was valid.
-    is_valid_update: bool,
+    /// Represents the status of the forkchoice update.
+    ///
+    /// Note: This is separate from the response `fut`, because we still can return an error
+    /// depending on the payload attributes, even if the forkchoice update itself is valid.
+    forkchoice_status: ForkchoiceStatus,
     /// Returns the result of the forkchoice update.
     fut: Either<futures::future::Ready<ForkChoiceUpdateResult>, PendingPayloadId>,
 }
@@ -30,14 +36,19 @@ pub struct OnForkChoiceUpdated {
 impl OnForkChoiceUpdated {
     /// Returns true if this update is valid
     pub(crate) fn is_valid_update(&self) -> bool {
-        self.is_valid_update
+        self.forkchoice_status.is_valid()
+    }
+
+    /// Returns the determined status of the received ForkchoiceState.
+    pub(crate) fn forkchoice_status(&self) -> ForkchoiceStatus {
+        self.forkchoice_status
     }
 
     /// Creates a new instance of `OnForkChoiceUpdated` if the forkchoice update succeeded and no
     /// payload attributes were provided.
     pub(crate) fn valid(status: PayloadStatus) -> Self {
         Self {
-            is_valid_update: status.is_valid(),
+            forkchoice_status: ForkchoiceStatus::from_payload_status(&status.status),
             fut: Either::Left(futures::future::ready(Ok(ForkchoiceUpdated::new(status)))),
         }
     }
@@ -46,7 +57,7 @@ impl OnForkChoiceUpdated {
     /// forkchoice update failed due to an invalid payload.
     pub(crate) fn with_invalid(status: PayloadStatus) -> Self {
         Self {
-            is_valid_update: false,
+            forkchoice_status: ForkchoiceStatus::from_payload_status(&status.status),
             fut: Either::Left(futures::future::ready(Ok(ForkchoiceUpdated::new(status)))),
         }
     }
@@ -55,7 +66,7 @@ impl OnForkChoiceUpdated {
     /// given state is considered invalid
     pub(crate) fn invalid_state() -> Self {
         Self {
-            is_valid_update: false,
+            forkchoice_status: ForkchoiceStatus::Invalid,
             fut: Either::Left(futures::future::ready(Err(ForkchoiceUpdateError::InvalidState))),
         }
     }
@@ -65,7 +76,7 @@ impl OnForkChoiceUpdated {
     pub(crate) fn invalid_payload_attributes() -> Self {
         Self {
             // This is valid because this is only reachable if the state and payload is valid
-            is_valid_update: true,
+            forkchoice_status: ForkchoiceStatus::Valid,
             fut: Either::Left(futures::future::ready(Err(
                 ForkchoiceUpdateError::UpdatedInvalidPayloadAttributes,
             ))),
@@ -78,7 +89,7 @@ impl OnForkChoiceUpdated {
         pending_payload_id: oneshot::Receiver<Result<PayloadId, PayloadBuilderError>>,
     ) -> Self {
         Self {
-            is_valid_update: payload_status.is_valid(),
+            forkchoice_status: ForkchoiceStatus::from_payload_status(&payload_status.status),
             fut: Either::Right(PendingPayloadId {
                 payload_status: Some(payload_status),
                 pending_payload_id,

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -873,8 +873,11 @@ where
                             }
                         };
 
-                        if let ControlFlow::Unwind { target, bad_block } = ctrl {
+                        if let ControlFlow::Unwind { bad_block, .. } = ctrl {
                             // update the `invalid_headers` cache with the new invalid headers
+                            if let Some(block) = bad_block {
+                                self.invalid_headers.insert(block);
+                            }
 
                             // Attempt to sync to the head block after unwind.
                             self.sync.set_pipeline_sync_target(current_state.head_block_hash);

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -27,7 +27,7 @@ use reth_rpc_types::engine::{
     ExecutionPayload, ForkchoiceUpdated, PayloadAttributes, PayloadStatus, PayloadStatusEnum,
     PayloadValidationError,
 };
-use reth_stages::Pipeline;
+use reth_stages::{Pipeline, ControlFlow};
 use reth_tasks::TaskSpawner;
 use schnellru::{ByLength, LruMap};
 use std::{
@@ -873,7 +873,9 @@ where
                             }
                         };
 
-                        if ctrl.is_unwind() {
+                        if let ControlFlow::Unwind { target, bad_block } = ctrl {
+                            // update the `invalid_headers` cache with the new invalid headers
+
                             // Attempt to sync to the head block after unwind.
                             self.sync.set_pipeline_sync_target(current_state.head_block_hash);
                             return None

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -27,7 +27,7 @@ use reth_rpc_types::engine::{
     ExecutionPayload, ForkchoiceUpdated, PayloadAttributes, PayloadStatus, PayloadStatusEnum,
     PayloadValidationError,
 };
-use reth_stages::{Pipeline, ControlFlow};
+use reth_stages::{ControlFlow, Pipeline};
 use reth_tasks::TaskSpawner;
 use schnellru::{ByLength, LruMap};
 use std::{

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -389,8 +389,7 @@ where
         let lowest_buffered_ancestor_fcu = self.lowest_buffered_ancestor_or(state.head_block_hash);
 
         if let Some(status) = self.check_invalid_ancestor(lowest_buffered_ancestor_fcu) {
-            // TODO: confusing - valid is returned here but the status is invalid
-            return Ok(OnForkChoiceUpdated::valid(status))
+            return Ok(OnForkChoiceUpdated::with_invalid(status))
         }
 
         // TODO: check PoW / EIP-3675 terminal block conditions for the fork choice head

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -875,9 +875,7 @@ where
 
                         if let ControlFlow::Unwind { bad_block, .. } = ctrl {
                             // update the `invalid_headers` cache with the new invalid headers
-                            if let Some(block) = bad_block {
-                                self.invalid_headers.insert(block);
-                            }
+                            self.invalid_headers.insert(bad_block);
 
                             // Attempt to sync to the head block after unwind.
                             self.sync.set_pipeline_sync_target(current_state.head_block_hash);

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -572,7 +572,7 @@ where
             // we need to first check the buffer for the head and its ancestors
             let lowest_unknown_hash = self.lowest_buffered_ancestor_or(state.head_block_hash);
 
-            trace!(target: "consensus::engine", request=?lowest_unknown_hash, "Triggering full block download for the new head");
+            trace!(target: "consensus::engine", request=?lowest_unknown_hash, "Triggering full block download for missing ancestors of the new head");
 
             // trigger a full block download for missing hash, or the parent of its lowest buffered
             // ancestor

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -896,9 +896,6 @@ where
 
                         if let ControlFlow::Unwind { bad_block, .. } = ctrl {
                             trace!(target: "consensus::engine", hash=?bad_block.hash, "Bad block detected in unwind");
-                            // Attempt to sync to the latest valid hash after unwind, because the
-                            // head may be invalid.
-                            self.sync.set_pipeline_sync_target(bad_block.parent_hash);
 
                             // update the `invalid_headers` cache with the new invalid headers
                             self.invalid_headers.insert(bad_block);

--- a/crates/interfaces/src/blockchain_tree/error.rs
+++ b/crates/interfaces/src/blockchain_tree/error.rs
@@ -25,6 +25,9 @@ pub enum BlockchainTreeError {
     BlockNumberNotFoundInChain { block_number: BlockNumber },
     #[error("Block hash {block_hash} not found in blockchain tree chain")]
     BlockHashNotFoundInChain { block_hash: BlockHash },
+    // Thrown if the block failed to buffer
+    #[error("Block with hash {block_hash} failed to buffer")]
+    BlockBufferingFailed { block_hash: BlockHash },
 }
 
 /// Error thrown when inserting a block failed because the block is considered invalid.

--- a/crates/interfaces/src/blockchain_tree/error.rs
+++ b/crates/interfaces/src/blockchain_tree/error.rs
@@ -26,7 +26,7 @@ pub enum BlockchainTreeError {
     #[error("Block hash {block_hash} not found in blockchain tree chain")]
     BlockHashNotFoundInChain { block_hash: BlockHash },
     // Thrown if the block failed to buffer
-    #[error("Block with hash {block_hash} failed to buffer")]
+    #[error("Block with hash {block_hash:?} failed to buffer")]
     BlockBufferingFailed { block_hash: BlockHash },
 }
 

--- a/crates/interfaces/src/blockchain_tree/mod.rs
+++ b/crates/interfaces/src/blockchain_tree/mod.rs
@@ -124,7 +124,10 @@ pub enum BlockStatus {
     /// (It is side chain) or hasn't been fully validated but ancestors of a payload are known.
     Accepted,
     /// If blocks is not connected to canonical chain.
-    Disconnected,
+    Disconnected {
+        /// The lowest parent block that is not connected to the canonical chain.
+        missing_parent: BlockNumHash,
+    },
 }
 
 /// Allows read only functionality on the blockchain tree.
@@ -167,6 +170,10 @@ pub trait BlockchainTreeViewer: Send + Sync {
     ///
     /// Note: this could be the given `parent_hash` if it's already canonical.
     fn find_canonical_ancestor(&self, parent_hash: BlockHash) -> Option<BlockHash>;
+
+    /// Given the hash of a block, this checks the buffered blocks for the lowest ancestor in the
+    /// buffer.
+    fn lowest_buffered_ancestor(&self, hash: BlockHash) -> Option<SealedBlockWithSenders>;
 
     /// Return BlockchainTree best known canonical chain tip (BlockHash, BlockNumber)
     fn canonical_tip(&self) -> BlockNumHash;

--- a/crates/interfaces/src/blockchain_tree/mod.rs
+++ b/crates/interfaces/src/blockchain_tree/mod.rs
@@ -173,6 +173,8 @@ pub trait BlockchainTreeViewer: Send + Sync {
 
     /// Given the hash of a block, this checks the buffered blocks for the lowest ancestor in the
     /// buffer.
+    ///
+    /// If there is a buffered block with the given hash, this returns the block itself.
     fn lowest_buffered_ancestor(&self, hash: BlockHash) -> Option<SealedBlockWithSenders>;
 
     /// Return BlockchainTree best known canonical chain tip (BlockHash, BlockNumber)

--- a/crates/interfaces/src/executor.rs
+++ b/crates/interfaces/src/executor.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 #[allow(missing_docs)]
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum BlockExecutionError {
+    // === validation errors ===
     #[error("EVM reported invalid transaction ({hash:?}): {message}")]
     EVM { hash: H256, message: String },
     #[error("Failed to recover sender for transaction")]
@@ -20,8 +21,22 @@ pub enum BlockExecutionError {
     },
     #[error("Block gas used {got} is different from expected gas used {expected}.")]
     BlockGasUsed { got: u64, expected: u64 },
+    #[error("Block {hash:?} is pre merge")]
+    BlockPreMerge { hash: H256 },
+    #[error("Missing total difficulty")]
+    MissingTotalDifficulty { hash: H256 },
+
+    // === misc provider error ===
     #[error("Provider error")]
     ProviderError,
+
+    // === transaction errors ===
+    #[error("Transaction error on revert: {inner:?}")]
+    CanonicalRevert { inner: String },
+    #[error("Transaction error on commit: {inner:?}")]
+    CanonicalCommit { inner: String },
+
+    // === tree errors ===
     // TODO(mattsse): move this to tree error
     #[error("Block hash {block_hash} not found in blockchain tree chain")]
     BlockHashNotFoundInChain { block_hash: BlockHash },
@@ -29,14 +44,6 @@ pub enum BlockExecutionError {
         "Appending chain on fork (other_chain_fork:?) is not possible as the tip is {chain_tip:?}"
     )]
     AppendChainDoesntConnect { chain_tip: BlockNumHash, other_chain_fork: BlockNumHash },
-    #[error("Transaction error on revert: {inner:?}")]
-    CanonicalRevert { inner: String },
-    #[error("Transaction error on commit: {inner:?}")]
-    CanonicalCommit { inner: String },
-    #[error("Block {hash:?} is pre merge")]
-    BlockPreMerge { hash: H256 },
-    #[error("Missing total difficulty")]
-    MissingTotalDifficulty { hash: H256 },
 
     /// Only used for TestExecutor
     ///

--- a/crates/primitives/src/transaction/signature.rs
+++ b/crates/primitives/src/transaction/signature.rs
@@ -113,7 +113,7 @@ impl Signature {
         })
     }
 
-    /// Recover signature from hash.
+    /// Recover signer address from message hash.
     pub fn recover_signer(&self, hash: H256) -> Option<Address> {
         let mut sig: [u8; 65] = [0; 65];
 

--- a/crates/stages/src/error.rs
+++ b/crates/stages/src/error.rs
@@ -71,7 +71,6 @@ impl StageError {
                 StageError::Download(_) |
                 StageError::DatabaseIntegrity(_) |
                 StageError::StageCheckpoint(_) |
-                StageError::ExecutionError { .. } |
                 StageError::ChannelClosed |
                 StageError::Fatal(_) |
                 StageError::Transaction(_)

--- a/crates/stages/src/error.rs
+++ b/crates/stages/src/error.rs
@@ -3,7 +3,7 @@ use reth_interfaces::{
     consensus, db::DatabaseError as DbError, executor, p2p::error::DownloadError,
     provider::ProviderError,
 };
-use reth_primitives::BlockNumber;
+use reth_primitives::SealedHeader;
 use reth_provider::TransactionError;
 use thiserror::Error;
 use tokio::sync::mpsc::error::SendError;
@@ -12,10 +12,10 @@ use tokio::sync::mpsc::error::SendError;
 #[derive(Error, Debug)]
 pub enum StageError {
     /// The stage encountered a state validation error.
-    #[error("Stage encountered a validation error in block {block}: {error}.")]
+    #[error("Stage encountered a validation error in block {number}: {error}.", number = block.number)]
     Validation {
         /// The block that failed validation.
-        block: BlockNumber,
+        block: SealedHeader,
         /// The underlying consensus error.
         #[source]
         error: consensus::ConsensusError,
@@ -23,12 +23,12 @@ pub enum StageError {
     /// The stage encountered a database error.
     #[error("An internal database error occurred: {0}")]
     Database(#[from] DbError),
-    #[error("Stage encountered a execution error in block {block}: {error}.")]
+    #[error("Stage encountered a execution error in block {number}: {error}.", number = block.number)]
     /// The stage encountered a execution error
     // TODO: Probably redundant, should be rolled into `Validation`
     ExecutionError {
         /// The block that failed execution.
-        block: BlockNumber,
+        block: SealedHeader,
         /// The underlying execution error.
         #[source]
         error: executor::BlockExecutionError,

--- a/crates/stages/src/pipeline/ctrl.rs
+++ b/crates/stages/src/pipeline/ctrl.rs
@@ -8,7 +8,7 @@ pub enum ControlFlow {
         /// The block to unwind to.
         target: BlockNumber,
         /// The block that caused the unwind.
-        bad_block: Option<SealedHeader>,
+        bad_block: SealedHeader,
     },
     /// The pipeline is allowed to continue executing stages.
     Continue {

--- a/crates/stages/src/pipeline/ctrl.rs
+++ b/crates/stages/src/pipeline/ctrl.rs
@@ -1,4 +1,4 @@
-use reth_primitives::BlockNumber;
+use reth_primitives::{BlockNumber, SealedHeader};
 
 /// Determines the control flow during pipeline execution.
 #[derive(Debug, Eq, PartialEq)]
@@ -8,7 +8,7 @@ pub enum ControlFlow {
         /// The block to unwind to.
         target: BlockNumber,
         /// The block that caused the unwind.
-        bad_block: Option<BlockNumber>,
+        bad_block: Option<SealedHeader>,
     },
     /// The pipeline is allowed to continue executing stages.
     Continue {

--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -382,6 +382,21 @@ where
                             target: prev_checkpoint.unwrap_or_default().block_number,
                             bad_block: block,
                         })
+                    } else if let StageError::ExecutionError { block, error } = err {
+                        warn!(
+                            target: "sync::pipeline",
+                            stage = %stage_id,
+                            bad_block = %block.number,
+                            "Stage encountered an execution error: {error}"
+                        );
+
+                        // We unwind because of an execution error. If the unwind itself fails, we
+                        // bail entirely, otherwise we restart the execution loop from the
+                        // beginning.
+                        Ok(ControlFlow::Unwind {
+                            target: prev_checkpoint.unwrap_or_default().block_number,
+                            bad_block: block,
+                        })
                     } else if err.is_fatal() {
                         error!(
                             target: "sync::pipeline",

--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -221,7 +221,7 @@ where
                 }
                 ControlFlow::Continue { progress } => self.progress.update(progress),
                 ControlFlow::Unwind { target, bad_block } => {
-                    self.unwind(target, bad_block.as_ref().map(|header| header.number)).await?;
+                    self.unwind(target, Some(bad_block.number)).await?;
                     return Ok(ControlFlow::Unwind { target, bad_block })
                 }
             }
@@ -380,7 +380,7 @@ where
                         // beginning.
                         Ok(ControlFlow::Unwind {
                             target: prev_checkpoint.unwrap_or_default().block_number,
-                            bad_block: Some(block),
+                            bad_block: block,
                         })
                     } else if err.is_fatal() {
                         error!(

--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -382,21 +382,6 @@ where
                             target: prev_checkpoint.unwrap_or_default().block_number,
                             bad_block: block,
                         })
-                    } else if let StageError::ExecutionError { block, error } = err {
-                        warn!(
-                            target: "sync::pipeline",
-                            stage = %stage_id,
-                            bad_block = %block.number,
-                            "Stage encountered an execution error: {error}"
-                        );
-
-                        // We unwind because of an execution error. If the unwind itself fails, we
-                        // bail entirely, otherwise we restart the execution loop from the
-                        // beginning.
-                        Ok(ControlFlow::Unwind {
-                            target: prev_checkpoint.unwrap_or_default().block_number,
-                            bad_block: block,
-                        })
                     } else if err.is_fatal() {
                         error!(
                             target: "sync::pipeline",

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -156,7 +156,10 @@ impl<EF: ExecutorFactory> ExecutionStage<EF> {
             let (block, senders) = block.into_components();
             let block_state = executor
                 .execute_and_verify_receipt(&block, td, Some(senders))
-                .map_err(|error| StageError::ExecutionError { block: block_number, error })?;
+                .map_err(|error| StageError::ExecutionError {
+                    block: block.header.clone().seal_slow(),
+                    error,
+                })?;
 
             // Gas metrics
             self.metrics

--- a/crates/stages/src/stages/merkle.rs
+++ b/crates/stages/src/stages/merkle.rs
@@ -10,7 +10,7 @@ use reth_primitives::{
     hex,
     stage::{MerkleCheckpoint, StageCheckpoint, StageId},
     trie::StoredSubNode,
-    BlockNumber, H256,
+    BlockNumber, H256, SealedHeader
 };
 use reth_provider::Transaction;
 use reth_trie::{IntermediateStateRootState, StateRoot, StateRootProgress};
@@ -66,20 +66,23 @@ impl MerkleStage {
         Self::Unwind
     }
 
-    /// Check that the computed state root matches the expected.
+    /// Check that the computed state root matches the root in the expected header.
     fn validate_state_root(
         &self,
         got: H256,
-        expected: H256,
+        expected: SealedHeader,
         target_block: BlockNumber,
     ) -> Result<(), StageError> {
-        if got == expected {
+        if got == expected.state_root {
             Ok(())
         } else {
             warn!(target: "sync::stages::merkle", ?target_block, ?got, ?expected, "Block's root state failed verification");
             Err(StageError::Validation {
-                block: target_block,
-                error: consensus::ConsensusError::BodyStateRootDiff { got, expected },
+                block: expected.clone(),
+                error: consensus::ConsensusError::BodyStateRootDiff {
+                    got,
+                    expected: expected.state_root,
+                },
             })
         }
     }
@@ -154,7 +157,8 @@ impl<DB: Database> Stage<DB> for MerkleStage {
         let (from_block, to_block) = range.clone().into_inner();
         let current_block = input.previous_stage_checkpoint().block_number;
 
-        let block_root = tx.get_header(current_block)?.state_root;
+        let block = tx.get_header(current_block)?;
+        let block_root = block.state_root;
 
         let mut checkpoint = self.get_execution_checkpoint(tx)?;
 
@@ -219,7 +223,7 @@ impl<DB: Database> Stage<DB> for MerkleStage {
         // Reset the checkpoint
         self.save_execution_checkpoint(tx, None)?;
 
-        self.validate_state_root(trie_root, block_root, to_block)?;
+        self.validate_state_root(trie_root, block.seal_slow(), to_block)?;
 
         info!(target: "sync::stages::merkle::exec", stage_progress = to_block, is_final_range = true, "Stage iteration finished");
         Ok(ExecOutput { checkpoint: StageCheckpoint::new(to_block), done: true })
@@ -251,8 +255,8 @@ impl<DB: Database> Stage<DB> for MerkleStage {
                     .map_err(|e| StageError::Fatal(Box::new(e)))?;
 
             // Validate the calulated state root
-            let target_root = tx.get_header(input.unwind_to)?.state_root;
-            self.validate_state_root(block_root, target_root, input.unwind_to)?;
+            let target = tx.get_header(input.unwind_to)?;
+            self.validate_state_root(block_root, target.seal_slow(), input.unwind_to)?;
 
             // Validation passed, apply unwind changes to the database.
             updates.flush(tx.deref_mut())?;

--- a/crates/stages/src/stages/merkle.rs
+++ b/crates/stages/src/stages/merkle.rs
@@ -10,7 +10,7 @@ use reth_primitives::{
     hex,
     stage::{MerkleCheckpoint, StageCheckpoint, StageId},
     trie::StoredSubNode,
-    BlockNumber, H256, SealedHeader
+    BlockNumber, SealedHeader, H256,
 };
 use reth_provider::Transaction;
 use reth_trie::{IntermediateStateRootState, StateRoot, StateRootProgress};

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -11,7 +11,7 @@ use reth_interfaces::consensus;
 use reth_primitives::{
     keccak256,
     stage::{StageCheckpoint, StageId},
-    TransactionSignedNoHash, TxNumber, H160, SealedHeader
+    SealedHeader, TransactionSignedNoHash, TxNumber, H160,
 };
 use reth_provider::{providers::read_sealed_header, Transaction};
 use std::fmt::Debug;

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -7,13 +7,12 @@ use reth_db::{
     transaction::{DbTx, DbTxMut},
     RawKey, RawTable, RawValue,
 };
-use reth_interfaces::consensus;
 use reth_primitives::{
     keccak256,
     stage::{StageCheckpoint, StageId},
-    SealedHeader, TransactionSignedNoHash, TxNumber, H160,
+    TransactionSignedNoHash, TxNumber, H160,
 };
-use reth_provider::{providers::read_sealed_header, Transaction};
+use reth_provider::Transaction;
 use std::fmt::Debug;
 use thiserror::Error;
 use tokio::sync::mpsc;
@@ -109,21 +108,16 @@ impl<DB: Database> Stage<DB> for SenderRecoveryStage {
                 reth_db::DatabaseError,
             >,
                            rlp_buf: &mut Vec<u8>|
-             -> Result<(u64, H160), Box<SenderRecoveryStageError>> {
-                let (tx_id, transaction) =
-                    entry.map_err(|e| Box::new(SenderRecoveryStageError::StageError(e.into())))?;
+             -> Result<(u64, H160), Box<StageError>> {
+                let (tx_id, transaction) = entry.map_err(|e| Box::new(e.into()))?;
                 let tx_id = tx_id.key().expect("key to be formated");
 
                 let tx = transaction.value().expect("value to be formated");
                 tx.transaction.encode_without_signature(rlp_buf);
 
-                let sender =
-                    match tx.signature.recover_signer(keccak256(rlp_buf)) {
-                        Some(sender) => Ok(sender),
-                        None => Err(SenderRecoveryStageError::FailedRecovery(
-                            FailedSenderRecoveryError { tx: tx_id },
-                        )),
-                    }?;
+                let sender = tx.signature.recover_signer(keccak256(rlp_buf)).ok_or(
+                    StageError::from(SenderRecoveryStageError::SenderRecovery { tx: tx_id }),
+                )?;
 
                 Ok((tx_id, sender))
             };
@@ -141,36 +135,7 @@ impl<DB: Database> Stage<DB> for SenderRecoveryStage {
         // Iterate over channels and append the sender in the order that they are received.
         for mut channel in channels {
             while let Some(recovered) = channel.recv().await {
-                let (tx_id, sender) = recovered.map_err(|boxed| match *boxed {
-                    SenderRecoveryStageError::FailedRecovery(err) => {
-                        // we need this so we can report the bad block
-                        let mut tx_block_cursor = match tx.cursor_read::<tables::TransactionBlock>()
-                        {
-                            Ok(cursor) => cursor,
-                            Err(e) => return e.into(),
-                        };
-
-                        // get the block number for the bad transaction
-                        // TODO: remove expect
-                        let block_number =
-                            match tx_block_cursor.seek(err.tx).map(|b| b.map(|(_, bn)| bn)) {
-                                Ok(num) => num,
-                                Err(e) => return e.into(),
-                            }
-                            .expect("tx to be in block");
-
-                        // fetch the sealed header so we can use it in the sender recovery unwind
-                        // TODO: remove expect
-                        let (header, block_hash) = match read_sealed_header(&**tx, block_number) {
-                            Ok(header_hash) => header_hash,
-                            Err(e) => return e.into(),
-                        }
-                        .expect("header to exist for block number");
-
-                        FailedSenderRecoveryError::with_block(header.seal(block_hash))
-                    }
-                    SenderRecoveryStageError::StageError(err) => err,
-                })?;
+                let (tx_id, sender) = recovered.map_err(|boxed| *boxed)?;
                 senders_cursor.append(tx_id, sender)?;
             }
         }
@@ -197,32 +162,16 @@ impl<DB: Database> Stage<DB> for SenderRecoveryStage {
     }
 }
 
-#[derive(Error, Debug)]
-#[error(transparent)]
-enum SenderRecoveryStageError {
-    /// A transaction failed sender recovery
-    FailedRecovery(FailedSenderRecoveryError),
-
-    /// A different type of stage error occurred
-    StageError(#[from] StageError),
-}
-
 // TODO(onbjerg): Should unwind
 #[derive(Error, Debug)]
-#[error("Sender recovery failed for transaction {tx}.")]
-struct FailedSenderRecoveryError {
-    /// The transaction that failed sender recovery
-    tx: TxNumber,
+enum SenderRecoveryStageError {
+    #[error("Sender recovery failed for transaction {tx}.")]
+    SenderRecovery { tx: TxNumber },
 }
 
-impl FailedSenderRecoveryError {
-    /// Creates a [StageError] populated with a transaction sender recovery error with the given
-    /// block.
-    fn with_block(block: SealedHeader) -> StageError {
-        StageError::Validation {
-            block,
-            error: consensus::ConsensusError::TransactionSignerRecoveryError,
-        }
+impl From<SenderRecoveryStageError> for StageError {
+    fn from(error: SenderRecoveryStageError) -> Self {
+        StageError::Fatal(Box::new(error))
     }
 }
 

--- a/crates/stages/src/stages/total_difficulty.rs
+++ b/crates/stages/src/stages/total_difficulty.rs
@@ -78,7 +78,7 @@ impl<DB: Database> Stage<DB> for TotalDifficultyStage {
 
             self.consensus
                 .validate_header_with_total_difficulty(&header, td)
-                .map_err(|error| StageError::Validation { block: header.number, error })?;
+                .map_err(|error| StageError::Validation { block: header.seal_slow(), error })?;
             cursor_td.append(block_number, td.into())?;
         }
         info!(target: "sync::stages::total_difficulty", stage_progress = end_block, is_final_range, "Stage iteration finished");

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -487,6 +487,10 @@ where
         self.tree.find_canonical_ancestor(hash)
     }
 
+    fn lowest_buffered_ancestor(&self, hash: BlockHash) -> Option<SealedBlockWithSenders> {
+        self.tree.lowest_buffered_ancestor(hash)
+    }
+
     fn canonical_tip(&self) -> BlockNumHash {
         self.tree.canonical_tip()
     }


### PR DESCRIPTION
blocked by #2802

closes #2916

we did not track if the received FCU was invalid,valid or syncing.

This keeps track of the status of the received FCU.

It will track the latest FCU to which we responded with SYNCING, this is the sync target to which we need to sync. before this change we triggered pipeline with the last received FCU which could be invalid.