### PR TITLE
feat(bin, pipeline): report pipeline progress

### DIFF
--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -37,7 +37,7 @@ impl NodeState {
     /// Processes an event emitted by the pipeline
     fn handle_pipeline_event(&mut self, event: PipelineEvent) {
         match event {
-            PipelineEvent::Running { stage_id, checkpoint } => {
+            PipelineEvent::Running { pipeline_progress, pipeline_total, stage_id, checkpoint } => {
                 let notable = self.current_stage.is_none();
                 self.current_stage = Some(stage_id);
                 self.current_checkpoint = checkpoint.unwrap_or_default();
@@ -46,13 +46,19 @@ impl NodeState {
                     info!(
                         target: "reth::cli",
                         stage = %stage_id,
+                        pipeline_progress = %format!("{pipeline_progress}/{pipeline_total}"),
                         from = self.current_checkpoint.block_number,
                         checkpoint = %self.current_checkpoint,
                         "Executing stage",
                     );
                 }
             }
-            PipelineEvent::Ran { stage_id, result: ExecOutput { checkpoint, done } } => {
+            PipelineEvent::Ran {
+                pipeline_progress,
+                pipeline_total,
+                stage_id,
+                result: ExecOutput { checkpoint, done },
+            } => {
                 self.current_checkpoint = checkpoint;
 
                 if done {
@@ -62,6 +68,7 @@ impl NodeState {
                 info!(
                     target: "reth::cli",
                     stage = %stage_id,
+                    pipeline_progress = %format!("{pipeline_progress}/{pipeline_total}"),
                     progress = checkpoint.block_number,
                     %checkpoint,
                     "{}",

--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -37,7 +37,7 @@ impl NodeState {
     /// Processes an event emitted by the pipeline
     fn handle_pipeline_event(&mut self, event: PipelineEvent) {
         match event {
-            PipelineEvent::Running { pipeline_progress, pipeline_total, stage_id, checkpoint } => {
+            PipelineEvent::Running { pipeline_position, pipeline_total, stage_id, checkpoint } => {
                 let notable = self.current_stage.is_none();
                 self.current_stage = Some(stage_id);
                 self.current_checkpoint = checkpoint.unwrap_or_default();
@@ -45,7 +45,7 @@ impl NodeState {
                 if notable {
                     info!(
                         target: "reth::cli",
-                        pipeline_stages = %format!("{pipeline_progress}/{pipeline_total}"),
+                        pipeline_stages = %format!("{pipeline_position}/{pipeline_total}"),
                         stage = %stage_id,
                         from = self.current_checkpoint.block_number,
                         checkpoint = %self.current_checkpoint,
@@ -54,7 +54,7 @@ impl NodeState {
                 }
             }
             PipelineEvent::Ran {
-                pipeline_progress,
+                pipeline_position,
                 pipeline_total,
                 stage_id,
                 result: ExecOutput { checkpoint, done },
@@ -67,7 +67,7 @@ impl NodeState {
 
                 info!(
                     target: "reth::cli",
-                    pipeline_stages = %format!("{pipeline_progress}/{pipeline_total}"),
+                    pipeline_stages = %format!("{pipeline_position}/{pipeline_total}"),
                     stage = %stage_id,
                     progress = checkpoint.block_number,
                     %checkpoint,

--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -45,8 +45,8 @@ impl NodeState {
                 if notable {
                     info!(
                         target: "reth::cli",
+                        pipeline_stages = %format!("{pipeline_progress}/{pipeline_total}"),
                         stage = %stage_id,
-                        pipeline_progress = %format!("{pipeline_progress}/{pipeline_total}"),
                         from = self.current_checkpoint.block_number,
                         checkpoint = %self.current_checkpoint,
                         "Executing stage",
@@ -67,8 +67,8 @@ impl NodeState {
 
                 info!(
                     target: "reth::cli",
+                    pipeline_stages = %format!("{pipeline_progress}/{pipeline_total}"),
                     stage = %stage_id,
-                    pipeline_progress = %format!("{pipeline_progress}/{pipeline_total}"),
                     progress = checkpoint.block_number,
                     %checkpoint,
                     "{}",

--- a/crates/stages/src/pipeline/event.rs
+++ b/crates/stages/src/pipeline/event.rs
@@ -13,7 +13,7 @@ pub enum PipelineEvent {
     /// Emitted when a stage is about to be run.
     Running {
         /// 1-indexed ID of the stage that is about to be run out of total stages in the pipeline.
-        pipeline_progress: usize,
+        pipeline_position: usize,
         /// Total number of stages in the pipeline.
         pipeline_total: usize,
         /// The stage that is about to be run.
@@ -24,7 +24,7 @@ pub enum PipelineEvent {
     /// Emitted when a stage has run a single time.
     Ran {
         /// 1-indexed ID of the stage that was run out of total stages in the pipeline.
-        pipeline_progress: usize,
+        pipeline_position: usize,
         /// Total number of stages in the pipeline.
         pipeline_total: usize,
         /// The stage that was run.

--- a/crates/stages/src/pipeline/event.rs
+++ b/crates/stages/src/pipeline/event.rs
@@ -12,6 +12,10 @@ use reth_primitives::stage::{StageCheckpoint, StageId};
 pub enum PipelineEvent {
     /// Emitted when a stage is about to be run.
     Running {
+        /// 1-indexed ID of the stage that is about to be run out of total stages in the pipeline.
+        pipeline_progress: usize,
+        /// Total number of stages in the pipeline.
+        pipeline_total: usize,
         /// The stage that is about to be run.
         stage_id: StageId,
         /// The previous checkpoint of the stage.
@@ -19,6 +23,10 @@ pub enum PipelineEvent {
     },
     /// Emitted when a stage has run a single time.
     Ran {
+        /// 1-indexed ID of the stage that was run out of total stages in the pipeline.
+        pipeline_progress: usize,
+        /// Total number of stages in the pipeline.
+        pipeline_total: usize,
         /// The stage that was run.
         stage_id: StageId,
         /// The result of executing the stage.

--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -491,13 +491,27 @@ mod tests {
         assert_eq!(
             events.collect::<Vec<PipelineEvent>>().await,
             vec![
-                PipelineEvent::Running { stage_id: StageId::Other("A"), checkpoint: None },
+                PipelineEvent::Running {
+                    pipeline_progress: 1,
+                    pipeline_total: 2,
+                    stage_id: StageId::Other("A"),
+                    checkpoint: None
+                },
                 PipelineEvent::Ran {
+                    pipeline_progress: 1,
+                    pipeline_total: 2,
                     stage_id: StageId::Other("A"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(20), done: true },
                 },
-                PipelineEvent::Running { stage_id: StageId::Other("B"), checkpoint: None },
+                PipelineEvent::Running {
+                    pipeline_progress: 2,
+                    pipeline_total: 2,
+                    stage_id: StageId::Other("B"),
+                    checkpoint: None
+                },
                 PipelineEvent::Ran {
+                    pipeline_progress: 2,
+                    pipeline_total: 2,
                     stage_id: StageId::Other("B"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(10), done: true },
                 },
@@ -544,18 +558,39 @@ mod tests {
             events.collect::<Vec<PipelineEvent>>().await,
             vec![
                 // Executing
-                PipelineEvent::Running { stage_id: StageId::Other("A"), checkpoint: None },
+                PipelineEvent::Running {
+                    pipeline_progress: 1,
+                    pipeline_total: 3,
+                    stage_id: StageId::Other("A"),
+                    checkpoint: None
+                },
                 PipelineEvent::Ran {
+                    pipeline_progress: 1,
+                    pipeline_total: 3,
                     stage_id: StageId::Other("A"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(100), done: true },
                 },
-                PipelineEvent::Running { stage_id: StageId::Other("B"), checkpoint: None },
+                PipelineEvent::Running {
+                    pipeline_progress: 2,
+                    pipeline_total: 3,
+                    stage_id: StageId::Other("B"),
+                    checkpoint: None
+                },
                 PipelineEvent::Ran {
+                    pipeline_progress: 2,
+                    pipeline_total: 3,
                     stage_id: StageId::Other("B"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(10), done: true },
                 },
-                PipelineEvent::Running { stage_id: StageId::Other("C"), checkpoint: None },
+                PipelineEvent::Running {
+                    pipeline_progress: 3,
+                    pipeline_total: 3,
+                    stage_id: StageId::Other("C"),
+                    checkpoint: None
+                },
                 PipelineEvent::Ran {
+                    pipeline_progress: 3,
+                    pipeline_total: 3,
                     stage_id: StageId::Other("C"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(20), done: true },
                 },
@@ -633,13 +668,27 @@ mod tests {
             events.collect::<Vec<PipelineEvent>>().await,
             vec![
                 // Executing
-                PipelineEvent::Running { stage_id: StageId::Other("A"), checkpoint: None },
+                PipelineEvent::Running {
+                    pipeline_progress: 1,
+                    pipeline_total: 2,
+                    stage_id: StageId::Other("A"),
+                    checkpoint: None
+                },
                 PipelineEvent::Ran {
+                    pipeline_progress: 1,
+                    pipeline_total: 2,
                     stage_id: StageId::Other("A"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(100), done: true },
                 },
-                PipelineEvent::Running { stage_id: StageId::Other("B"), checkpoint: None },
+                PipelineEvent::Running {
+                    pipeline_progress: 2,
+                    pipeline_total: 2,
+                    stage_id: StageId::Other("B"),
+                    checkpoint: None
+                },
                 PipelineEvent::Ran {
+                    pipeline_progress: 2,
+                    pipeline_total: 2,
                     stage_id: StageId::Other("B"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(10), done: true },
                 },
@@ -707,12 +756,24 @@ mod tests {
         assert_eq!(
             events.collect::<Vec<PipelineEvent>>().await,
             vec![
-                PipelineEvent::Running { stage_id: StageId::Other("A"), checkpoint: None },
+                PipelineEvent::Running {
+                    pipeline_progress: 1,
+                    pipeline_total: 2,
+                    stage_id: StageId::Other("A"),
+                    checkpoint: None
+                },
                 PipelineEvent::Ran {
+                    pipeline_progress: 1,
+                    pipeline_total: 2,
                     stage_id: StageId::Other("A"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(10), done: true },
                 },
-                PipelineEvent::Running { stage_id: StageId::Other("B"), checkpoint: None },
+                PipelineEvent::Running {
+                    pipeline_progress: 2,
+                    pipeline_total: 2,
+                    stage_id: StageId::Other("B"),
+                    checkpoint: None
+                },
                 PipelineEvent::Error { stage_id: StageId::Other("B") },
                 PipelineEvent::Unwinding {
                     stage_id: StageId::Other("A"),
@@ -727,15 +788,26 @@ mod tests {
                     result: UnwindOutput { checkpoint: StageCheckpoint::new(0) },
                 },
                 PipelineEvent::Running {
+                    pipeline_progress: 1,
+                    pipeline_total: 2,
                     stage_id: StageId::Other("A"),
                     checkpoint: Some(StageCheckpoint::new(0))
                 },
                 PipelineEvent::Ran {
+                    pipeline_progress: 1,
+                    pipeline_total: 2,
                     stage_id: StageId::Other("A"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(10), done: true },
                 },
-                PipelineEvent::Running { stage_id: StageId::Other("B"), checkpoint: None },
+                PipelineEvent::Running {
+                    pipeline_progress: 2,
+                    pipeline_total: 2,
+                    stage_id: StageId::Other("B"),
+                    checkpoint: None
+                },
                 PipelineEvent::Ran {
+                    pipeline_progress: 2,
+                    pipeline_total: 2,
                     stage_id: StageId::Other("B"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(10), done: true },
                 },

--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -329,7 +329,7 @@ where
             }
 
             self.listeners.notify(PipelineEvent::Running {
-                pipeline_progress: stage_index + 1,
+                pipeline_position: stage_index + 1,
                 pipeline_total: total_stages,
                 stage_id,
                 checkpoint: prev_checkpoint,
@@ -358,7 +358,7 @@ where
                     tx.save_stage_checkpoint(stage_id, checkpoint)?;
 
                     self.listeners.notify(PipelineEvent::Ran {
-                        pipeline_progress: stage_index + 1,
+                        pipeline_position: stage_index + 1,
                         pipeline_total: total_stages,
                         stage_id,
                         result: out.clone(),
@@ -492,25 +492,25 @@ mod tests {
             events.collect::<Vec<PipelineEvent>>().await,
             vec![
                 PipelineEvent::Running {
-                    pipeline_progress: 1,
+                    pipeline_position: 1,
                     pipeline_total: 2,
                     stage_id: StageId::Other("A"),
                     checkpoint: None
                 },
                 PipelineEvent::Ran {
-                    pipeline_progress: 1,
+                    pipeline_position: 1,
                     pipeline_total: 2,
                     stage_id: StageId::Other("A"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(20), done: true },
                 },
                 PipelineEvent::Running {
-                    pipeline_progress: 2,
+                    pipeline_position: 2,
                     pipeline_total: 2,
                     stage_id: StageId::Other("B"),
                     checkpoint: None
                 },
                 PipelineEvent::Ran {
-                    pipeline_progress: 2,
+                    pipeline_position: 2,
                     pipeline_total: 2,
                     stage_id: StageId::Other("B"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(10), done: true },
@@ -559,37 +559,37 @@ mod tests {
             vec![
                 // Executing
                 PipelineEvent::Running {
-                    pipeline_progress: 1,
+                    pipeline_position: 1,
                     pipeline_total: 3,
                     stage_id: StageId::Other("A"),
                     checkpoint: None
                 },
                 PipelineEvent::Ran {
-                    pipeline_progress: 1,
+                    pipeline_position: 1,
                     pipeline_total: 3,
                     stage_id: StageId::Other("A"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(100), done: true },
                 },
                 PipelineEvent::Running {
-                    pipeline_progress: 2,
+                    pipeline_position: 2,
                     pipeline_total: 3,
                     stage_id: StageId::Other("B"),
                     checkpoint: None
                 },
                 PipelineEvent::Ran {
-                    pipeline_progress: 2,
+                    pipeline_position: 2,
                     pipeline_total: 3,
                     stage_id: StageId::Other("B"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(10), done: true },
                 },
                 PipelineEvent::Running {
-                    pipeline_progress: 3,
+                    pipeline_position: 3,
                     pipeline_total: 3,
                     stage_id: StageId::Other("C"),
                     checkpoint: None
                 },
                 PipelineEvent::Ran {
-                    pipeline_progress: 3,
+                    pipeline_position: 3,
                     pipeline_total: 3,
                     stage_id: StageId::Other("C"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(20), done: true },
@@ -669,25 +669,25 @@ mod tests {
             vec![
                 // Executing
                 PipelineEvent::Running {
-                    pipeline_progress: 1,
+                    pipeline_position: 1,
                     pipeline_total: 2,
                     stage_id: StageId::Other("A"),
                     checkpoint: None
                 },
                 PipelineEvent::Ran {
-                    pipeline_progress: 1,
+                    pipeline_position: 1,
                     pipeline_total: 2,
                     stage_id: StageId::Other("A"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(100), done: true },
                 },
                 PipelineEvent::Running {
-                    pipeline_progress: 2,
+                    pipeline_position: 2,
                     pipeline_total: 2,
                     stage_id: StageId::Other("B"),
                     checkpoint: None
                 },
                 PipelineEvent::Ran {
-                    pipeline_progress: 2,
+                    pipeline_position: 2,
                     pipeline_total: 2,
                     stage_id: StageId::Other("B"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(10), done: true },
@@ -757,19 +757,19 @@ mod tests {
             events.collect::<Vec<PipelineEvent>>().await,
             vec![
                 PipelineEvent::Running {
-                    pipeline_progress: 1,
+                    pipeline_position: 1,
                     pipeline_total: 2,
                     stage_id: StageId::Other("A"),
                     checkpoint: None
                 },
                 PipelineEvent::Ran {
-                    pipeline_progress: 1,
+                    pipeline_position: 1,
                     pipeline_total: 2,
                     stage_id: StageId::Other("A"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(10), done: true },
                 },
                 PipelineEvent::Running {
-                    pipeline_progress: 2,
+                    pipeline_position: 2,
                     pipeline_total: 2,
                     stage_id: StageId::Other("B"),
                     checkpoint: None
@@ -788,25 +788,25 @@ mod tests {
                     result: UnwindOutput { checkpoint: StageCheckpoint::new(0) },
                 },
                 PipelineEvent::Running {
-                    pipeline_progress: 1,
+                    pipeline_position: 1,
                     pipeline_total: 2,
                     stage_id: StageId::Other("A"),
                     checkpoint: Some(StageCheckpoint::new(0))
                 },
                 PipelineEvent::Ran {
-                    pipeline_progress: 1,
+                    pipeline_position: 1,
                     pipeline_total: 2,
                     stage_id: StageId::Other("A"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(10), done: true },
                 },
                 PipelineEvent::Running {
-                    pipeline_progress: 2,
+                    pipeline_position: 2,
                     pipeline_total: 2,
                     stage_id: StageId::Other("B"),
                     checkpoint: None
                 },
                 PipelineEvent::Ran {
-                    pipeline_progress: 2,
+                    pipeline_position: 2,
                     pipeline_total: 2,
                     stage_id: StageId::Other("B"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(10), done: true },


### PR DESCRIPTION
During the initial sync, it's useful to know not only the progress of each individual stage in the pipeline, but also how many stages left. 

```console
2023-05-31T14:40:41.012518Z  INFO Stage committed progress pipeline_stages=3/13 stage=Bodies progress=3230000 checkpoint=3230000
```