### PR TITLE
fix: unwind on execution and senders errors

### DIFF
--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -11,7 +11,7 @@ use reth_interfaces::{
         BlockStatus, CanonicalOutcome,
     },
     consensus::{Consensus, ConsensusError},
-    executor::BlockExecutionError,
+    executor::{BlockExecutionError, BlockValidationError},
     Error,
 };
 use reth_primitives::{
@@ -375,10 +375,9 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
                 })?;
 
             // Pass the parent total difficulty to short-circuit unnecessary calculations.
-            if !self.externals.chain_spec.fork(Hardfork::Paris).active_at_ttd(parent_td, U256::ZERO)
-            {
+            if !self.externals.chain_spec.fork(Hardfork::Paris).active_at_ttd(parent_td, U256::ZERO) {
                 return Err(InsertBlockError::execution_error(
-                    BlockExecutionError::BlockPreMerge { hash: block.hash },
+                    BlockValidationError::BlockPreMerge { hash: block.hash }.into(),
                     block.block,
                 ))
             }
@@ -869,14 +868,16 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
         // If block is already canonical don't return error.
         if let Some(header) = self.find_canonical_header(block_hash)? {
             info!(target: "blockchain_tree", ?block_hash, "Block is already canonical, ignoring.");
-            let td = self
-                .externals
-                .database()
-                .provider()?
-                .header_td(block_hash)?
-                .ok_or(BlockExecutionError::MissingTotalDifficulty { hash: *block_hash })?;
+            let td = self.externals.database().provider()?.header_td(block_hash)?.ok_or(
+                BlockExecutionError::from(BlockValidationError::MissingTotalDifficulty {
+                    hash: *block_hash,
+                }),
+            )?;
             if !self.externals.chain_spec.fork(Hardfork::Paris).active_at_ttd(td, U256::ZERO) {
-                return Err(BlockExecutionError::BlockPreMerge { hash: *block_hash }.into())
+                return Err(BlockExecutionError::from(BlockValidationError::BlockPreMerge {
+                    hash: *block_hash,
+                })
+                .into())
             }
             return Ok(CanonicalOutcome::AlreadyCanonical { header })
         }

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -375,7 +375,8 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
                 })?;
 
             // Pass the parent total difficulty to short-circuit unnecessary calculations.
-            if !self.externals.chain_spec.fork(Hardfork::Paris).active_at_ttd(parent_td, U256::ZERO) {
+            if !self.externals.chain_spec.fork(Hardfork::Paris).active_at_ttd(parent_td, U256::ZERO)
+            {
                 return Err(InsertBlockError::execution_error(
                     BlockValidationError::BlockPreMerge { hash: block.hash }.into(),
                     block.block,

--- a/crates/interfaces/src/blockchain_tree/error.rs
+++ b/crates/interfaces/src/blockchain_tree/error.rs
@@ -1,6 +1,9 @@
 //! Error handling for the blockchain tree
 
-use crate::{consensus::ConsensusError, executor::BlockExecutionError};
+use crate::{
+    consensus::ConsensusError,
+    executor::{BlockExecutionError, BlockValidationError},
+};
 use reth_primitives::{BlockHash, BlockNumber, SealedBlock};
 
 /// Various error cases that can occur when a block violates tree assumptions.
@@ -173,7 +176,12 @@ impl InsertBlockErrorKind {
 
     /// Returns true if this is a block pre merge error.
     pub fn is_block_pre_merge(&self) -> bool {
-        matches!(self, InsertBlockErrorKind::Execution(BlockExecutionError::BlockPreMerge { .. }))
+        matches!(
+            self,
+            InsertBlockErrorKind::Execution(BlockExecutionError::Validation(
+                BlockValidationError::BlockPreMerge { .. }
+            ))
+        )
     }
 
     /// Returns true if the error is an execution error

--- a/crates/interfaces/src/executor.rs
+++ b/crates/interfaces/src/executor.rs
@@ -1,11 +1,10 @@
 use reth_primitives::{BlockHash, BlockNumHash, Bloom, H256};
 use thiserror::Error;
 
-/// BlockExecutor Errors
+/// Transaction validation errors
 #[allow(missing_docs)]
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
-pub enum BlockExecutionError {
-    // === validation errors ===
+pub enum BlockValidationError {
     #[error("EVM reported invalid transaction ({hash:?}): {message}")]
     EVM { hash: H256, message: String },
     #[error("Failed to recover sender for transaction")]
@@ -25,6 +24,14 @@ pub enum BlockExecutionError {
     BlockPreMerge { hash: H256 },
     #[error("Missing total difficulty")]
     MissingTotalDifficulty { hash: H256 },
+}
+
+/// BlockExecutor Errors
+#[allow(missing_docs)]
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
+pub enum BlockExecutionError {
+    #[error(transparent)]
+    Validation(#[from] BlockValidationError),
 
     // === misc provider error ===
     #[error("Provider error")]

--- a/crates/interfaces/src/provider.rs
+++ b/crates/interfaces/src/provider.rs
@@ -62,4 +62,7 @@ pub enum ProviderError {
     /// Unable to compute state root on top of historical block
     #[error("Unable to compute state root on top of historical block")]
     StateRootNotAvailableForHistoricalBlock,
+    /// Unable to find the block number for a given transaction index
+    #[error("Unable to find the block number for a given transaction index")]
+    BlockNumberForTransactionIndexNotFound,
 }

--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -390,6 +390,21 @@ where
                             target: prev_checkpoint.unwrap_or_default().block_number,
                             bad_block: block,
                         })
+                    } else if let StageError::ExecutionError { block, error } = err {
+                        warn!(
+                            target: "sync::pipeline",
+                            stage = %stage_id,
+                            bad_block = %block.number,
+                            "Stage encountered an execution error: {error}"
+                        );
+
+                        // We unwind because of an execution error. If the unwind itself fails, we
+                        // bail entirely, otherwise we restart the execution loop from the
+                        // beginning.
+                        Ok(ControlFlow::Unwind {
+                            target: prev_checkpoint.unwrap_or_default().block_number,
+                            bad_block: block,
+                        })
                     } else if err.is_fatal() {
                         error!(
                             target: "sync::pipeline",

--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -1,8 +1,8 @@
 use crate::{error::*, ExecInput, ExecOutput, Stage, StageError, UnwindInput};
 use futures_util::Future;
 use reth_db::database::Database;
-use reth_primitives::{listener::EventListeners, stage::StageId, BlockNumber, H256};
 use reth_interfaces::executor::BlockExecutionError;
+use reth_primitives::{listener::EventListeners, stage::StageId, BlockNumber, H256};
 use reth_provider::{providers::get_stage_checkpoint, Transaction};
 use std::pin::Pin;
 use tokio::sync::watch;

--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -2,6 +2,7 @@ use crate::{error::*, ExecInput, ExecOutput, Stage, StageError, UnwindInput};
 use futures_util::Future;
 use reth_db::database::Database;
 use reth_primitives::{listener::EventListeners, stage::StageId, BlockNumber, H256};
+use reth_interfaces::executor::BlockExecutionError;
 use reth_provider::{providers::get_stage_checkpoint, Transaction};
 use std::pin::Pin;
 use tokio::sync::watch;
@@ -390,7 +391,11 @@ where
                             target: prev_checkpoint.unwrap_or_default().block_number,
                             bad_block: block,
                         })
-                    } else if let StageError::ExecutionError { block, error } = err {
+                    } else if let StageError::ExecutionError {
+                        block,
+                        error: BlockExecutionError::Validation(error),
+                    } = err
+                    {
                         warn!(
                             target: "sync::pipeline",
                             stage = %stage_id,

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -125,13 +125,11 @@ impl<DB: Database> Stage<DB> for SenderRecoveryStage {
                 let tx = transaction.value().expect("value to be formated");
                 tx.transaction.encode_without_signature(rlp_buf);
 
-                let sender =
-                    match tx.signature.recover_signer(keccak256(rlp_buf)) {
-                        Some(sender) => Ok(sender),
-                        None => Err(SenderRecoveryStageError::FailedRecovery(
-                            FailedSenderRecoveryError { tx: tx_id },
-                        )),
-                    }?;
+                let sender = tx.signature.recover_signer(keccak256(rlp_buf)).ok_or(
+                    SenderRecoveryStageError::FailedRecovery(FailedSenderRecoveryError {
+                        tx: tx_id,
+                    }),
+                )?;
 
                 Ok((tx_id, sender))
             };

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -7,12 +7,13 @@ use reth_db::{
     transaction::{DbTx, DbTxMut},
     DatabaseError, RawKey, RawTable, RawValue,
 };
+use reth_interfaces::consensus;
 use reth_primitives::{
     keccak256,
     stage::{EntitiesCheckpoint, StageCheckpoint, StageId},
-    TransactionSignedNoHash, TxNumber, H160,
+    TransactionSignedNoHash, TxNumber, H160, SealedHeader,
 };
-use reth_provider::Transaction;
+use reth_provider::{providers::read_sealed_header, Transaction};
 use std::{fmt::Debug, ops::Deref};
 use thiserror::Error;
 use tokio::sync::mpsc;
@@ -116,16 +117,21 @@ impl<DB: Database> Stage<DB> for SenderRecoveryStage {
                 DatabaseError,
             >,
                            rlp_buf: &mut Vec<u8>|
-             -> Result<(u64, H160), Box<StageError>> {
-                let (tx_id, transaction) = entry.map_err(|e| Box::new(e.into()))?;
+             -> Result<(u64, H160), Box<SenderRecoveryStageError>> {
+                let (tx_id, transaction) =
+                    entry.map_err(|e| Box::new(SenderRecoveryStageError::StageError(e.into())))?;
                 let tx_id = tx_id.key().expect("key to be formated");
 
                 let tx = transaction.value().expect("value to be formated");
                 tx.transaction.encode_without_signature(rlp_buf);
 
-                let sender = tx.signature.recover_signer(keccak256(rlp_buf)).ok_or(
-                    StageError::from(SenderRecoveryStageError::SenderRecovery { tx: tx_id }),
-                )?;
+                let sender =
+                    match tx.signature.recover_signer(keccak256(rlp_buf)) {
+                        Some(sender) => Ok(sender),
+                        None => Err(SenderRecoveryStageError::FailedRecovery(
+                            FailedSenderRecoveryError { tx: tx_id },
+                        )),
+                    }?;
 
                 Ok((tx_id, sender))
             };
@@ -144,7 +150,36 @@ impl<DB: Database> Stage<DB> for SenderRecoveryStage {
         // Iterate over channels and append the sender in the order that they are received.
         for mut channel in channels {
             while let Some(recovered) = channel.recv().await {
-                let (tx_id, sender) = recovered.map_err(|boxed| *boxed)?;
+                let (tx_id, sender) = recovered.map_err(|boxed| match *boxed {
+                    SenderRecoveryStageError::FailedRecovery(err) => {
+                        // we need this so we can report the bad block
+                        let mut tx_block_cursor = match tx.cursor_read::<tables::TransactionBlock>()
+                        {
+                            Ok(cursor) => cursor,
+                            Err(e) => return e.into(),
+                        };
+
+                        // get the block number for the bad transaction
+                        // TODO: remove expect
+                        let block_number =
+                            match tx_block_cursor.seek(err.tx).map(|b| b.map(|(_, bn)| bn)) {
+                                Ok(num) => num,
+                                Err(e) => return e.into(),
+                            }
+                            .expect("tx to be in block");
+
+                        // fetch the sealed header so we can use it in the sender recovery unwind
+                        // TODO: remove expect
+                        let (header, block_hash) = match read_sealed_header(&**tx, block_number) {
+                            Ok(header_hash) => header_hash,
+                            Err(e) => return e.into(),
+                        }
+                        .expect("header to exist for block number");
+
+                        FailedSenderRecoveryError::with_block(header.seal(block_hash))
+                    }
+                    SenderRecoveryStageError::StageError(err) => err,
+                })?;
                 senders_cursor.append(tx_id, sender)?;
             }
         }
@@ -189,14 +224,31 @@ fn stage_checkpoint<DB: Database>(
 
 // TODO(onbjerg): Should unwind
 #[derive(Error, Debug)]
+#[error(transparent)]
 enum SenderRecoveryStageError {
-    #[error("Sender recovery failed for transaction {tx}.")]
-    SenderRecovery { tx: TxNumber },
+    /// A transaction failed sender recovery
+    FailedRecovery(FailedSenderRecoveryError),
+
+    /// A different type of stage error occurred
+    StageError(#[from] StageError),
 }
 
-impl From<SenderRecoveryStageError> for StageError {
-    fn from(error: SenderRecoveryStageError) -> Self {
-        StageError::Fatal(Box::new(error))
+// TODO(onbjerg): Should unwind
+#[derive(Error, Debug)]
+#[error("Sender recovery failed for transaction {tx}.")]
+struct FailedSenderRecoveryError {
+    /// The transaction that failed sender recovery
+    tx: TxNumber,
+}
+
+impl FailedSenderRecoveryError {
+    /// Creates a [StageError] populated with a transaction sender recovery error with the given
+    /// block.
+    fn with_block(block: SealedHeader) -> StageError {
+        StageError::Validation {
+            block,
+            error: consensus::ConsensusError::TransactionSignerRecoveryError,
+        }
     }
 }
 

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -11,7 +11,7 @@ use reth_interfaces::consensus;
 use reth_primitives::{
     keccak256,
     stage::{EntitiesCheckpoint, StageCheckpoint, StageId},
-    SealedHeader, TransactionSignedNoHash, TxNumber, H160,
+    TransactionSignedNoHash, TxNumber, H160,
 };
 use reth_provider::{ProviderError, Transaction};
 use std::{fmt::Debug, ops::Deref};

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -11,7 +11,7 @@ use reth_interfaces::consensus;
 use reth_primitives::{
     keccak256,
     stage::{EntitiesCheckpoint, StageCheckpoint, StageId},
-    TransactionSignedNoHash, TxNumber, H160, SealedHeader,
+    SealedHeader, TransactionSignedNoHash, TxNumber, H160,
 };
 use reth_provider::{ProviderError, Transaction};
 use std::{fmt::Debug, ops::Deref};

--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -23,8 +23,8 @@ use reth_primitives::{
     keccak256,
     stage::{StageCheckpoint, StageId},
     Account, Address, BlockHash, BlockNumber, ChainSpec, Hardfork, Header, SealedBlock,
-    SealedBlockWithSenders, StorageEntry, TransactionSigned, TransactionSignedEcRecovered, H256,
-    U256,
+    SealedBlockWithSenders, SealedHeader, StorageEntry, TransactionSigned,
+    TransactionSignedEcRecovered, H256, U256,
 };
 use reth_trie::{StateRoot, StateRootError};
 use std::{
@@ -181,6 +181,13 @@ where
             .get::<tables::HeaderTD>(block)?
             .ok_or(ProviderError::TotalDifficultyNotFound { number: block })?;
         Ok(td.into())
+    }
+
+    /// Query the sealed header by number
+    pub fn get_sealed_header(&self, number: BlockNumber) -> Result<SealedHeader, TransactionError> {
+        let header = self.get_header(number)?;
+        let block_hash = self.get_block_hash(number)?;
+        Ok(header.seal(block_hash))
     }
 
     /// Unwind table by some number key.


### PR DESCRIPTION
Followup to #2802, now unwinding on certain validation-related `BlockExecutionError`s, as well as sender stage errors. This is needed to properly track invalid blocks, so this also populates the bad block in the senders and execution stages, if one of these errors are returned.

Adds `get_sealed_header` to `Transaction`.