### PR TITLE
feat: track invalid ancestor in invalid headers cache

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -331,7 +331,6 @@ where
     /// block into the invalid header cache if the `check` hash has a known invalid ancestor.
     ///
     /// Returns a payload status response according to the engine API spec.
-    #[instrument(level = "trace", skip(self), target = "consensus::engine")]
     fn check_invalid_ancestor_with_head(
         &mut self,
         check: H256,
@@ -351,7 +350,6 @@ where
 
     /// Checks if the given `head` points to an invalid header, which requires a specific response
     /// to a forkchoice update.
-    #[instrument(level = "trace", skip(self), target = "consensus::engine")]
     fn check_invalid_ancestor(&mut self, head: H256) -> Option<PayloadStatus> {
         let parent_hash = {
             // check if the head was previously marked as invalid

--- a/crates/consensus/beacon/src/engine/sync.rs
+++ b/crates/consensus/beacon/src/engine/sync.rs
@@ -128,6 +128,11 @@ where
         self.pending_pipeline_target = Some(target);
     }
 
+    /// Unsets the pipeline sync target.
+    pub(crate) fn unset_pipeline_sync_target(&mut self) {
+        self.pending_pipeline_target = None;
+    }
+
     /// Check if the engine reached max block as specified by `max_block` parameter.
     ///
     /// Note: this is mainly for debugging purposes.
@@ -177,6 +182,7 @@ where
         match &mut self.pipeline_state {
             PipelineState::Idle(pipeline) => {
                 let target = self.pending_pipeline_target.take();
+                trace!(target: "consensus::engine", ?target, "Pipeline is idle, checking target");
 
                 if target.is_none() && !self.run_pipeline_continuously {
                     // nothing to sync
@@ -201,7 +207,10 @@ where
 
                 Some(EngineSyncEvent::PipelineStarted(target))
             }
-            PipelineState::Running(_) => None,
+            PipelineState::Running(_) => {
+                trace!(target: "consensus::engine", "Pipeline is already running, not spawning");
+                None
+            }
         }
     }
 

--- a/crates/consensus/beacon/src/engine/sync.rs
+++ b/crates/consensus/beacon/src/engine/sync.rs
@@ -177,7 +177,6 @@ where
         match &mut self.pipeline_state {
             PipelineState::Idle(pipeline) => {
                 let target = self.pending_pipeline_target.take();
-                trace!(target: "consensus::engine", ?target, "Pipeline is idle, checking target");
 
                 if target.is_none() && !self.run_pipeline_continuously {
                     // nothing to sync
@@ -202,10 +201,7 @@ where
 
                 Some(EngineSyncEvent::PipelineStarted(target))
             }
-            PipelineState::Running(_) => {
-                trace!(target: "consensus::engine", "Pipeline is already running, not spawning");
-                None
-            }
+            PipelineState::Running(_) => None,
         }
     }
 

--- a/crates/consensus/beacon/src/engine/sync.rs
+++ b/crates/consensus/beacon/src/engine/sync.rs
@@ -128,11 +128,6 @@ where
         self.pending_pipeline_target = Some(target);
     }
 
-    /// Unsets the pipeline sync target.
-    pub(crate) fn unset_pipeline_sync_target(&mut self) {
-        self.pending_pipeline_target = None;
-    }
-
     /// Check if the engine reached max block as specified by `max_block` parameter.
     ///
     /// Note: this is mainly for debugging purposes.


### PR DESCRIPTION
This modifies the headers cache to store an `Arc` to the block's lowest invalid ancestor. `try_insert_new_payload` is modified to check if the disconnected payload is an ancestor of an invalid block, and inserts it into the invalid cache if so. `check_invalid_ancestor_with_head` is added to make this process easier.

Closes #2904