### PR TITLE
fix: set reputation change for already seen txs to 0

### DIFF
--- a/crates/net/network/src/peers/reputation.rs
+++ b/crates/net/network/src/peers/reputation.rs
@@ -26,9 +26,9 @@ const BAD_MESSAGE_REPUTATION_CHANGE: i32 = 16 * REPUTATION_UNIT;
 /// The reputation change applies to a peer that has sent a transaction (full or hash) that we
 /// already know about and have already previously received from that peer.
 ///
-/// Note: We weight this very low because it is generally not a problem to get a transaction that we
-/// already know about, so only spammers are affected.
-const ALREADY_SEEN_TRANSACTION_REPUTATION_CHANGE: i32 = REPUTATION_UNIT / 2;
+/// Note: this appears to be quite common in practice, so by default this is 0, which doesn't
+/// apply any changes to the peer's reputation, effectively ignoring it.
+const ALREADY_SEEN_TRANSACTION_REPUTATION_CHANGE: i32 = 0;
 
 /// The reputation change to apply to a peer which violates protocol rules: minimal reputation
 const BAD_PROTOCOL_REPUTATION_CHANGE: i32 = i32::MIN;


### PR DESCRIPTION
Closes #2933 #2451

from the spec:

> Including hashes that the sending peer could reasonably be considered to know (due to the fact they were previously informed of because that node has itself advertised knowledge of the hashes through NewBlockHashes) is considered bad form, and may reduce the reputation of the sending node.

however, this seems to be a very common thing:

```
reth_network_messages_with_already_seen_transactions 1110                                                                 reth_network_propagated_transactions 10740
reth_network_reported_bad_transactions 21                                                                                 reth_transaction_pool_basefee_pool_size_bytes 1791688
reth_transaction_pool_basefee_pool_transactions 10001                                                                     reth_transaction_pool_inserted_transactions 78536                                                                         reth_transaction_pool_invalid_transactions 4647
reth_transaction_pool_pending_pool_size_bytes 19784                                                                       reth_transaction_pool_pending_pool_transactions 42                                                                        reth_transaction_pool_queued_pool_size_bytes 2700965
reth_transaction_pool_queued_pool_transactions 9988
reth_transaction_pool_removed_transactions 7460
```

I suggest disabling this for now and investigate how other implementations handle this, because I assume this is not only spam