### PR TITLE
feat(stages): index history stages progress

### DIFF
--- a/crates/primitives/src/stage/checkpoints.rs
+++ b/crates/primitives/src/stage/checkpoints.rs
@@ -152,7 +152,7 @@ pub struct HeadersCheckpoint {
 pub struct IndexHistoryCheckpoint {
     /// Block range which this checkpoint is valid for.
     pub block_range: CheckpointBlockRange,
-    /// Progress measured in gas.
+    /// Progress measured in changesets.
     pub progress: EntitiesCheckpoint,
 }
 

--- a/crates/primitives/src/stage/mod.rs
+++ b/crates/primitives/src/stage/mod.rs
@@ -6,6 +6,6 @@ pub use id::StageId;
 mod checkpoints;
 pub use checkpoints::{
     AccountHashingCheckpoint, CheckpointBlockRange, EntitiesCheckpoint, ExecutionCheckpoint,
-    HeadersCheckpoint, MerkleCheckpoint, StageCheckpoint, StageUnitCheckpoint,
-    StorageHashingCheckpoint,
+    HeadersCheckpoint, IndexHistoryCheckpoint, MerkleCheckpoint, StageCheckpoint,
+    StageUnitCheckpoint, StorageHashingCheckpoint,
 };

--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -141,7 +141,7 @@ where
             self.metrics.stage_checkpoint(
                 stage_id,
                 get_stage_checkpoint(&tx, stage_id)?.unwrap_or_default(),
-                None,
+                0,
             );
         }
         Ok(())
@@ -270,10 +270,11 @@ where
                     Ok(unwind_output) => {
                         checkpoint = unwind_output.checkpoint;
                         self.metrics.stage_checkpoint(
-                            stage_id, checkpoint,
+                            stage_id,
+                            checkpoint,
                             // We assume it was set in the previous execute iteration, so it
                             // doesn't change when we unwind.
-                            None,
+                            checkpoint.block_number,
                         );
                         tx.save_stage_checkpoint(stage_id, checkpoint)?;
 
@@ -346,7 +347,9 @@ where
                     self.metrics.stage_checkpoint(
                         stage_id,
                         checkpoint,
-                        previous_stage.map(|(_, checkpoint)| checkpoint.block_number),
+                        previous_stage
+                            .map(|(_, checkpoint)| checkpoint.block_number)
+                            .unwrap_or_default(),
                     );
                     tx.save_stage_checkpoint(stage_id, checkpoint)?;
 

--- a/crates/stages/src/pipeline/sync_metrics.rs
+++ b/crates/stages/src/pipeline/sync_metrics.rs
@@ -5,7 +5,8 @@ use reth_metrics::{
 use reth_primitives::{
     stage::{
         AccountHashingCheckpoint, EntitiesCheckpoint, ExecutionCheckpoint, HeadersCheckpoint,
-        StageCheckpoint, StageId, StageUnitCheckpoint, StorageHashingCheckpoint,
+        IndexHistoryCheckpoint, StageCheckpoint, StageId, StageUnitCheckpoint,
+        StorageHashingCheckpoint,
     },
     BlockNumber,
 };
@@ -56,7 +57,8 @@ impl Metrics {
                 }) |
                 StageUnitCheckpoint::Entities(progress @ EntitiesCheckpoint { .. }) |
                 StageUnitCheckpoint::Execution(ExecutionCheckpoint { progress, .. }) |
-                StageUnitCheckpoint::Headers(HeadersCheckpoint { progress, .. }),
+                StageUnitCheckpoint::Headers(HeadersCheckpoint { progress, .. }) |
+                StageUnitCheckpoint::IndexHistory(IndexHistoryCheckpoint { progress, .. }),
             ) => (progress.processed, progress.total),
             Some(StageUnitCheckpoint::Account(_) | StageUnitCheckpoint::Storage(_)) | None => {
                 (checkpoint.block_number, max_block_number)

--- a/crates/stages/src/pipeline/sync_metrics.rs
+++ b/crates/stages/src/pipeline/sync_metrics.rs
@@ -33,7 +33,7 @@ impl Metrics {
         &mut self,
         stage_id: StageId,
         checkpoint: StageCheckpoint,
-        max_block_number: Option<BlockNumber>,
+        max_block_number: BlockNumber,
     ) {
         let stage_metrics = self
             .stages
@@ -55,8 +55,6 @@ impl Metrics {
         };
 
         stage_metrics.entities_processed.set(processed as f64);
-        if let Some(total) = total {
-            stage_metrics.entities_total.set(total as f64);
-        }
+        stage_metrics.entities_total.set(total as f64);
     }
 }

--- a/crates/stages/src/stages/index_account_history.rs
+++ b/crates/stages/src/stages/index_account_history.rs
@@ -92,6 +92,15 @@ impl<DB: Database> Stage<DB> for IndexAccountHistoryStage {
     }
 }
 
+// The function proceeds as follows:
+// 1. It first checks if the checkpoint has an `IndexHistoryCheckpoint` that matches the given
+// block range. If it does, the function returns that checkpoint.
+// 2. If the checkpoint's block range end matches the current checkpoint's block number, it creates
+// a new `IndexHistoryCheckpoint` with the given block range and updates the progress with the
+// current progress.
+// 3. If none of the above conditions are met, it creates a new `IndexHistoryCheckpoint` with the
+// given block range and calculates the progress by counting the number of processed entries in the
+// `AccountChangeSet` table within the given block range.
 fn stage_checkpoint<DB: Database>(
     tx: &Transaction<'_, DB>,
     checkpoint: StageCheckpoint,

--- a/crates/stages/src/stages/index_account_history.rs
+++ b/crates/stages/src/stages/index_account_history.rs
@@ -71,11 +71,13 @@ impl<DB: Database> Stage<DB> for IndexAccountHistoryStage {
             },
         };
 
-        let (changesets, indices) = tx.get_account_transition_ids_from_changeset(range.clone())?;
+        let indices = tx.get_account_transition_ids_from_changeset(range.clone())?;
+        let changesets = indices.values().map(|blocks| blocks.len() as u64).sum::<u64>();
+
         // Insert changeset to history index
         tx.insert_account_history_index(indices)?;
 
-        stage_checkpoint.progress.processed += changesets as u64;
+        stage_checkpoint.progress.processed += changesets;
 
         info!(target: "sync::stages::index_account_history", stage_progress = *range.end(), is_final_range, "Stage iteration finished");
         Ok(ExecOutput {

--- a/crates/stages/src/stages/index_account_history.rs
+++ b/crates/stages/src/stages/index_account_history.rs
@@ -222,7 +222,7 @@ mod tests {
                             from: input.checkpoint().block_number + 1,
                             to: run_to
                         },
-                        progress: EntitiesCheckpoint { processed: 2, total: Some(2) }
+                        progress: EntitiesCheckpoint { processed: 2, total: 2 }
                     }
                 ),
                 done: true
@@ -485,7 +485,7 @@ mod tests {
             stage_checkpoint(&tx.inner(), StageCheckpoint::new(1), &(1..=2)).unwrap(),
             IndexHistoryCheckpoint {
                 block_range: CheckpointBlockRange { from: 1, to: 2 },
-                progress: EntitiesCheckpoint { processed: 2, total: Some(4) }
+                progress: EntitiesCheckpoint { processed: 2, total: 4 }
             }
         );
     }

--- a/crates/stages/src/stages/index_account_history.rs
+++ b/crates/stages/src/stages/index_account_history.rs
@@ -110,7 +110,7 @@ fn stage_checkpoint<DB: Database>(
                 block_range: CheckpointBlockRange::from(range),
                 progress: EntitiesCheckpoint {
                     processed: progress.processed,
-                    total: Some(tx.deref().entries::<tables::AccountChangeSet>()? as u64),
+                    total: tx.deref().entries::<tables::AccountChangeSet>()? as u64,
                 },
             }
         }
@@ -121,7 +121,7 @@ fn stage_checkpoint<DB: Database>(
                     .cursor_read::<tables::AccountChangeSet>()?
                     .walk_range(0..=checkpoint.block_number)?
                     .count() as u64,
-                total: Some(tx.deref().entries::<tables::AccountChangeSet>()? as u64),
+                total: tx.deref().entries::<tables::AccountChangeSet>()? as u64,
             },
         },
     })

--- a/crates/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/src/stages/index_storage_history.rs
@@ -74,10 +74,12 @@ impl<DB: Database> Stage<DB> for IndexStorageHistoryStage {
             },
         };
 
-        let (changesets, indices) = tx.get_storage_transition_ids_from_changeset(range.clone())?;
+        let indices = tx.get_storage_transition_ids_from_changeset(range.clone())?;
+        let changesets = indices.values().map(|blocks| blocks.len() as u64).sum::<u64>();
+
         tx.insert_storage_history_index(indices)?;
 
-        stage_checkpoint.progress.processed += changesets as u64;
+        stage_checkpoint.progress.processed += changesets;
 
         info!(target: "sync::stages::index_storage_history", stage_progress = *range.end(), done = is_final_range, "Stage iteration finished");
         Ok(ExecOutput {

--- a/crates/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/src/stages/index_storage_history.rs
@@ -235,7 +235,7 @@ mod tests {
                             from: input.checkpoint().block_number + 1,
                             to: run_to
                         },
-                        progress: EntitiesCheckpoint { processed: 2, total: Some(2) }
+                        progress: EntitiesCheckpoint { processed: 2, total: 2 }
                     }
                 ),
                 done: true
@@ -514,7 +514,7 @@ mod tests {
             stage_checkpoint(&tx.inner(), StageCheckpoint::new(1), &(1..=2)).unwrap(),
             IndexHistoryCheckpoint {
                 block_range: CheckpointBlockRange { from: 1, to: 2 },
-                progress: EntitiesCheckpoint { processed: 3, total: Some(6) }
+                progress: EntitiesCheckpoint { processed: 3, total: 6 }
             }
         );
     }

--- a/crates/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/src/stages/index_storage_history.rs
@@ -94,6 +94,15 @@ impl<DB: Database> Stage<DB> for IndexStorageHistoryStage {
     }
 }
 
+// The function proceeds as follows:
+// 1. It first checks if the checkpoint has an `IndexHistoryCheckpoint` that matches the given
+// block range. If it does, the function returns that checkpoint.
+// 2. If the checkpoint's block range end matches the current checkpoint's block number, it creates
+// a new `IndexHistoryCheckpoint` with the given block range and updates the progress with the
+// current progress.
+// 3. If none of the above conditions are met, it creates a new `IndexHistoryCheckpoint` with the
+// given block range and calculates the progress by counting the number of processed entries in the
+// `StorageChangeSet` table within the given block range.
 fn stage_checkpoint<DB: Database>(
     tx: &Transaction<'_, DB>,
     checkpoint: StageCheckpoint,

--- a/crates/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/src/stages/index_storage_history.rs
@@ -112,7 +112,7 @@ fn stage_checkpoint<DB: Database>(
                 block_range: CheckpointBlockRange::from(range),
                 progress: EntitiesCheckpoint {
                     processed: progress.processed,
-                    total: Some(tx.deref().entries::<tables::StorageChangeSet>()? as u64),
+                    total: tx.deref().entries::<tables::StorageChangeSet>()? as u64,
                 },
             }
         }
@@ -123,7 +123,7 @@ fn stage_checkpoint<DB: Database>(
                     .cursor_read::<tables::StorageChangeSet>()?
                     .walk_range(BlockNumberAddress::range(0..=checkpoint.block_number))?
                     .count() as u64,
-                total: Some(tx.deref().entries::<tables::StorageChangeSet>()? as u64),
+                total: tx.deref().entries::<tables::StorageChangeSet>()? as u64,
             },
         },
     })

--- a/crates/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/src/stages/index_storage_history.rs
@@ -1,12 +1,19 @@
 use crate::{ExecInput, ExecOutput, Stage, StageError, UnwindInput, UnwindOutput};
 use reth_db::{
     cursor::DbCursorRO, database::Database, models::BlockNumberAddress, tables, transaction::DbTx,
+    DatabaseError,
 };
-use reth_primitives::stage::{
-    CheckpointBlockRange, EntitiesCheckpoint, IndexHistoryCheckpoint, StageCheckpoint, StageId,
+use reth_primitives::{
+    stage::{
+        CheckpointBlockRange, EntitiesCheckpoint, IndexHistoryCheckpoint, StageCheckpoint, StageId,
+    },
+    BlockNumber,
 };
 use reth_provider::Transaction;
-use std::{fmt::Debug, ops::Deref};
+use std::{
+    fmt::Debug,
+    ops::{Deref, RangeInclusive},
+};
 use tracing::*;
 
 /// Stage is indexing history the account changesets generated in
@@ -45,34 +52,7 @@ impl<DB: Database> Stage<DB> for IndexStorageHistoryStage {
             return Ok(ExecOutput::done(target))
         }
 
-        let mut stage_checkpoint = match input.checkpoint().index_history_stage_checkpoint() {
-            Some(stage_checkpoint @ IndexHistoryCheckpoint { block_range, .. })
-                if block_range == CheckpointBlockRange::from(&range) =>
-            {
-                stage_checkpoint
-            }
-            Some(IndexHistoryCheckpoint { block_range, progress })
-                if block_range.to == *range.start() =>
-            {
-                IndexHistoryCheckpoint {
-                    block_range: CheckpointBlockRange::from(&range),
-                    progress: EntitiesCheckpoint {
-                        processed: progress.processed,
-                        total: Some(tx.deref().entries::<tables::StorageChangeSet>()? as u64),
-                    },
-                }
-            }
-            _ => IndexHistoryCheckpoint {
-                block_range: CheckpointBlockRange::from(&range),
-                progress: EntitiesCheckpoint {
-                    processed: tx
-                        .cursor_read::<tables::StorageChangeSet>()?
-                        .walk_range(BlockNumberAddress::range(0..=input.checkpoint().block_number))?
-                        .count() as u64,
-                    total: Some(tx.deref().entries::<tables::StorageChangeSet>()? as u64),
-                },
-            },
-        };
+        let mut stage_checkpoint = stage_checkpoint(tx, input.checkpoint(), &range)?;
 
         let indices = tx.get_storage_transition_ids_from_changeset(range.clone())?;
         let changesets = indices.values().map(|blocks| blocks.len() as u64).sum::<u64>();
@@ -100,23 +80,59 @@ impl<DB: Database> Stage<DB> for IndexStorageHistoryStage {
 
         let changesets = tx.unwind_storage_history_indices(BlockNumberAddress::range(range))?;
 
-        let checkpoint = if let Some(mut stage_checkpoint) =
-            input.checkpoint.entities_stage_checkpoint()
-        {
-            stage_checkpoint.processed -= changesets as u64;
-            StageCheckpoint::new(unwind_progress).with_entities_stage_checkpoint(stage_checkpoint)
-        } else {
-            StageCheckpoint::new(unwind_progress)
-        };
+        let checkpoint =
+            if let Some(mut stage_checkpoint) = input.checkpoint.index_history_stage_checkpoint() {
+                stage_checkpoint.progress.processed -= changesets as u64;
+                StageCheckpoint::new(unwind_progress)
+                    .with_index_history_stage_checkpoint(stage_checkpoint)
+            } else {
+                StageCheckpoint::new(unwind_progress)
+            };
 
         info!(target: "sync::stages::index_storage_history", to_block = input.unwind_to, unwind_progress, is_final_range, "Unwind iteration finished");
         Ok(UnwindOutput { checkpoint })
     }
 }
 
+fn stage_checkpoint<DB: Database>(
+    tx: &Transaction<'_, DB>,
+    checkpoint: StageCheckpoint,
+    range: &RangeInclusive<BlockNumber>,
+) -> Result<IndexHistoryCheckpoint, DatabaseError> {
+    Ok(match checkpoint.index_history_stage_checkpoint() {
+        Some(stage_checkpoint @ IndexHistoryCheckpoint { block_range, .. })
+            if block_range == CheckpointBlockRange::from(range) =>
+        {
+            stage_checkpoint
+        }
+        Some(IndexHistoryCheckpoint { block_range, progress })
+            if block_range.to == checkpoint.block_number =>
+        {
+            IndexHistoryCheckpoint {
+                block_range: CheckpointBlockRange::from(range),
+                progress: EntitiesCheckpoint {
+                    processed: progress.processed,
+                    total: Some(tx.deref().entries::<tables::StorageChangeSet>()? as u64),
+                },
+            }
+        }
+        _ => IndexHistoryCheckpoint {
+            block_range: CheckpointBlockRange::from(range),
+            progress: EntitiesCheckpoint {
+                processed: tx
+                    .cursor_read::<tables::StorageChangeSet>()?
+                    .walk_range(BlockNumberAddress::range(0..=checkpoint.block_number))?
+                    .count() as u64,
+                total: Some(tx.deref().entries::<tables::StorageChangeSet>()? as u64),
+            },
+        },
+    })
+}
+
 #[cfg(test)]
 mod tests {
 
+    use assert_matches::assert_matches;
     use std::collections::BTreeMap;
 
     use super::*;
@@ -431,6 +447,66 @@ mod tests {
                 (shard(2), full_list.clone()),
                 (shard(u64::MAX), vec![2, 3])
             ])
+        );
+    }
+
+    #[test]
+    fn stage_checkpoint_recalculation() {
+        let tx = TestTransaction::default();
+
+        tx.commit(|tx| {
+            tx.put::<tables::StorageChangeSet>(
+                BlockNumberAddress((1, H160(hex!("0000000000000000000000000000000000000001")))),
+                storage(H256(hex!(
+                    "0000000000000000000000000000000000000000000000000000000000000001"
+                ))),
+            )
+            .unwrap();
+            tx.put::<tables::StorageChangeSet>(
+                BlockNumberAddress((1, H160(hex!("0000000000000000000000000000000000000001")))),
+                storage(H256(hex!(
+                    "0000000000000000000000000000000000000000000000000000000000000002"
+                ))),
+            )
+            .unwrap();
+            tx.put::<tables::StorageChangeSet>(
+                BlockNumberAddress((1, H160(hex!("0000000000000000000000000000000000000002")))),
+                storage(H256(hex!(
+                    "0000000000000000000000000000000000000000000000000000000000000001"
+                ))),
+            )
+            .unwrap();
+            tx.put::<tables::StorageChangeSet>(
+                BlockNumberAddress((2, H160(hex!("0000000000000000000000000000000000000001")))),
+                storage(H256(hex!(
+                    "0000000000000000000000000000000000000000000000000000000000000001"
+                ))),
+            )
+            .unwrap();
+            tx.put::<tables::StorageChangeSet>(
+                BlockNumberAddress((2, H160(hex!("0000000000000000000000000000000000000001")))),
+                storage(H256(hex!(
+                    "0000000000000000000000000000000000000000000000000000000000000002"
+                ))),
+            )
+            .unwrap();
+            tx.put::<tables::StorageChangeSet>(
+                BlockNumberAddress((2, H160(hex!("0000000000000000000000000000000000000002")))),
+                storage(H256(hex!(
+                    "0000000000000000000000000000000000000000000000000000000000000001"
+                ))),
+            )
+            .unwrap();
+            Ok(())
+        })
+        .unwrap();
+
+        assert_matches!(
+            stage_checkpoint(&tx.inner(), StageCheckpoint::new(1), &(1..=2)).unwrap(),
+            IndexHistoryCheckpoint {
+                block_range: CheckpointBlockRange { from: 1, to: 2 },
+                progress: EntitiesCheckpoint { processed: 3, total: Some(6) }
+            }
         );
     }
 }

--- a/crates/storage/db/src/tables/mod.rs
+++ b/crates/storage/db/src/tables/mod.rs
@@ -211,7 +211,7 @@ dupsort!(
 table!(
     /// Stores pointers to block changeset with changes for each account key.
     ///
-    /// Last shard key of the storage will contains `u64::MAX` `BlockNumber`,
+    /// Last shard key of the storage will contain `u64::MAX` `BlockNumber`,
     /// this would allows us small optimization on db access when change is in plain state.
     ///
     /// Imagine having shards as:
@@ -233,7 +233,7 @@ table!(
 table!(
     /// Stores pointers to block number changeset with changes for each storage key.
     ///
-    /// Last shard key of the storage will contains `u64::MAX` `BlockNumber`,
+    /// Last shard key of the storage will contain `u64::MAX` `BlockNumber`,
     /// this would allows us small optimization on db access when change is in plain state.
     ///
     /// Imagine having shards as:

--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -391,16 +391,14 @@ where
             .cursor_read::<tables::AccountChangeSet>()?
             .walk_range(range)?
             .collect::<Result<Vec<_>, _>>()?;
+        let changesets = account_changeset.len();
 
-        let mut changesets = 0;
         let last_indices = account_changeset
             .into_iter()
             // reverse so we can get lowest transition id where we need to unwind account.
             .rev()
             // fold all account and get last transition index
             .fold(BTreeMap::new(), |mut accounts: BTreeMap<Address, u64>, (index, account)| {
-                changesets += 1;
-
                 // we just need address and lowest transition id.
                 accounts.insert(account.address, index);
                 accounts
@@ -436,8 +434,8 @@ where
             .cursor_read::<tables::StorageChangeSet>()?
             .walk_range(range)?
             .collect::<Result<Vec<_>, _>>()?;
+        let changesets = storage_changesets.len();
 
-        let mut changesets = 0;
         let last_indices = storage_changesets
             .into_iter()
             // reverse so we can get lowest transition id where we need to unwind account.
@@ -446,8 +444,6 @@ where
             .fold(
                 BTreeMap::new(),
                 |mut accounts: BTreeMap<(Address, H256), u64>, (index, storage)| {
-                    changesets += 1;
-
                     // we just need address and lowest transition id.
                     accounts.insert((index.address(), storage.key), index.block_number());
                     accounts


### PR DESCRIPTION
Progress for `Index(Account|Storage)History` measured in changesets indexed vs total.

We can't easily recalculate the `processed` field on every iteration, so we need to iteratively increment/decrement it using changesets. If we encounter a checkpoint for unknown range, we recalculate the `processed` by walking the changeset table up to processed number of blocks from the checkpoint: https://github.com/paradigmxyz/reth/blob/3b5920292b9c5c9946177c1f6fe8110c101a05b7/crates/stages/src/stages/index_account_history.rs#L117-L125