### PR TITLE
fix(stages): include block range in headers checkpoint

### DIFF
--- a/crates/primitives/src/stage/mod.rs
+++ b/crates/primitives/src/stage/mod.rs
@@ -6,5 +6,6 @@ pub use id::StageId;
 mod checkpoints;
 pub use checkpoints::{
     AccountHashingCheckpoint, CheckpointBlockRange, EntitiesCheckpoint, ExecutionCheckpoint,
-    MerkleCheckpoint, StageCheckpoint, StageUnitCheckpoint, StorageHashingCheckpoint,
+    HeadersCheckpoint, MerkleCheckpoint, StageCheckpoint, StageUnitCheckpoint,
+    StorageHashingCheckpoint,
 };

--- a/crates/stages/src/pipeline/sync_metrics.rs
+++ b/crates/stages/src/pipeline/sync_metrics.rs
@@ -4,8 +4,8 @@ use reth_metrics::{
 };
 use reth_primitives::{
     stage::{
-        AccountHashingCheckpoint, EntitiesCheckpoint, ExecutionCheckpoint, StageCheckpoint,
-        StageId, StageUnitCheckpoint, StorageHashingCheckpoint,
+        AccountHashingCheckpoint, EntitiesCheckpoint, ExecutionCheckpoint, HeadersCheckpoint,
+        StageCheckpoint, StageId, StageUnitCheckpoint, StorageHashingCheckpoint,
     },
     BlockNumber,
 };
@@ -43,10 +43,9 @@ impl Metrics {
 
         let (processed, total) = match checkpoint.stage_checkpoint {
             Some(
-                StageUnitCheckpoint::Entities(progress @ EntitiesCheckpoint { .. }) |
-                StageUnitCheckpoint::Execution(ExecutionCheckpoint { progress, .. }) |
                 // Only report metrics for hashing stages if `total` is known, otherwise it means
-                // we're unwinding and operating on changesets, rather than accounts or storage slots.
+                // we're unwinding and operating on changesets, rather than accounts or storage
+                // slots.
                 StageUnitCheckpoint::Account(AccountHashingCheckpoint {
                     progress: progress @ EntitiesCheckpoint { total: Some(_), .. },
                     ..
@@ -54,14 +53,14 @@ impl Metrics {
                 StageUnitCheckpoint::Storage(StorageHashingCheckpoint {
                     progress: progress @ EntitiesCheckpoint { total: Some(_), .. },
                     ..
-                }),
+                }) |
+                StageUnitCheckpoint::Entities(progress @ EntitiesCheckpoint { .. }) |
+                StageUnitCheckpoint::Execution(ExecutionCheckpoint { progress, .. }) |
+                StageUnitCheckpoint::Headers(HeadersCheckpoint { progress, .. }),
             ) => (progress.processed, progress.total),
-            Some(
-                StageUnitCheckpoint::Transaction(_) |
-                StageUnitCheckpoint::Account(_) |
-                StageUnitCheckpoint::Storage(_),
-            ) |
-            None => (checkpoint.block_number, max_block_number),
+            Some(StageUnitCheckpoint::Account(_) | StageUnitCheckpoint::Storage(_)) | None => {
+                (checkpoint.block_number, max_block_number)
+            }
         };
 
         stage_metrics.entities_processed.set(processed as f64);

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -11,7 +11,9 @@ use reth_interfaces::{
     provider::ProviderError,
 };
 use reth_primitives::{
-    stage::{EntitiesCheckpoint, StageCheckpoint, StageId},
+    stage::{
+        CheckpointBlockRange, EntitiesCheckpoint, HeadersCheckpoint, StageCheckpoint, StageId,
+    },
     BlockHashOrNumber, BlockNumber, SealedHeader, H256,
 };
 use reth_provider::Transaction;
@@ -249,30 +251,44 @@ where
             None
         };
 
-        let mut stage_checkpoint = current_checkpoint
-            .entities_stage_checkpoint()
-            .unwrap_or(EntitiesCheckpoint {
-            // If for some reason (e.g. due to DB migration) we don't have `processed`
-            // in the middle of headers sync, set it to the local head block number +
-            // number of block already filled in the gap.
-            processed: local_head +
-                (target_block_number.unwrap_or_default() - tip_block_number.unwrap_or_default()),
-            // Shouldn't fail because on the first iteration, we download the header for missing
-            // tip, and use its block number.
-            total: target_block_number.or_else(|| {
-                warn!(target: "sync::stages::headers", ?tip, "No downloaded header for tip found");
-                // Safe, because `Display` impl for `EntitiesCheckpoint` will fallback to displaying
-                // just `processed`
-                None
-            }),
-        });
+        let mut stage_checkpoint = match current_checkpoint.headers_stage_checkpoint() {
+            // If checkpoint block range matches our range, we take the previously used
+            // stage checkpoint as-is.
+            Some(stage_checkpoint)
+                if stage_checkpoint.block_range.from == input.checkpoint().block_number =>
+            {
+                stage_checkpoint
+            }
+            // Otherwise, we're on the first iteration of new gap sync, so we recalculate the number
+            // of already processed and total headers.
+            // `target_block_number` is guaranteed to be `Some`, because on the first iteration
+            // we download the header for missing tip and use its block number.
+            _ => {
+                HeadersCheckpoint {
+                    block_range: CheckpointBlockRange {
+                        from: input.checkpoint().block_number,
+                        to: target_block_number.expect("No downloaded header for tip found"),
+                    },
+                    progress: EntitiesCheckpoint {
+                        // Set processed to the local head block number + number
+                        // of block already filled in the gap.
+                        processed: local_head +
+                            (target_block_number.unwrap_or_default() -
+                                tip_block_number.unwrap_or_default()),
+                        total: Some(
+                            target_block_number.expect("No downloaded header for tip found"),
+                        ),
+                    },
+                }
+            }
+        };
 
         // Total headers can be updated if we received new tip from the network, and need to fill
         // the local gap.
         if let Some(target_block_number) = target_block_number {
-            stage_checkpoint.total = Some(target_block_number);
+            stage_checkpoint.progress.total = Some(target_block_number);
         }
-        stage_checkpoint.processed += downloaded_headers.len() as u64;
+        stage_checkpoint.progress.processed += downloaded_headers.len() as u64;
 
         // Write the headers to db
         self.write_headers::<DB>(tx, downloaded_headers)?.unwrap_or_default();
@@ -286,12 +302,12 @@ where
             );
             Ok(ExecOutput {
                 checkpoint: StageCheckpoint::new(checkpoint)
-                    .with_entities_stage_checkpoint(stage_checkpoint),
+                    .with_headers_stage_checkpoint(stage_checkpoint),
                 done: true,
             })
         } else {
             Ok(ExecOutput {
-                checkpoint: current_checkpoint.with_entities_stage_checkpoint(stage_checkpoint),
+                checkpoint: current_checkpoint.with_headers_stage_checkpoint(stage_checkpoint),
                 done: false,
             })
         }
@@ -550,14 +566,20 @@ mod tests {
         let result = rx.await.unwrap();
         assert_matches!( result, Ok(ExecOutput { checkpoint: StageCheckpoint {
             block_number,
-            stage_checkpoint: Some(StageUnitCheckpoint::Entities(EntitiesCheckpoint {
-                processed,
-                total: Some(total),
+            stage_checkpoint: Some(StageUnitCheckpoint::Headers(HeadersCheckpoint {
+                block_range: CheckpointBlockRange {
+                    from,
+                    to
+                },
+                progress: EntitiesCheckpoint {
+                    processed,
+                    total: Some(total),
+                }
             }))
-        }, done: true }) if block_number == tip.number
+        }, done: true }) if block_number == tip.number &&
+            from == checkpoint && to == previous_stage &&
             // -1 because we don't need to download the local head
-            && processed == checkpoint + headers.len() as u64 - 1
-            && total == tip.number);
+            processed == checkpoint + headers.len() as u64 - 1 && total == tip.number);
         assert!(runner.validate_execution(input, result.ok()).is_ok(), "validation failed");
     }
 
@@ -638,13 +660,19 @@ mod tests {
         let result = rx.await.unwrap();
         assert_matches!(result, Ok(ExecOutput { checkpoint: StageCheckpoint {
             block_number,
-            stage_checkpoint: Some(StageUnitCheckpoint::Entities(EntitiesCheckpoint {
-                processed,
-                total: Some(total),
+            stage_checkpoint: Some(StageUnitCheckpoint::Headers(HeadersCheckpoint {
+                block_range: CheckpointBlockRange {
+                    from,
+                    to
+                },
+                progress: EntitiesCheckpoint {
+                    processed,
+                    total: Some(total),
+                }
             }))
         }, done: false }) if block_number == checkpoint &&
-            processed == checkpoint + 500 &&
-            total == tip.number);
+            from == checkpoint && to == previous_stage &&
+            processed == checkpoint + 500 && total == tip.number);
 
         runner.client.clear().await;
         runner.client.extend(headers.iter().take(101).map(|h| h.clone().unseal()).rev()).await;
@@ -655,14 +683,20 @@ mod tests {
 
         assert_matches!(result, Ok(ExecOutput { checkpoint: StageCheckpoint {
             block_number,
-            stage_checkpoint: Some(StageUnitCheckpoint::Entities(EntitiesCheckpoint {
-                processed,
-                total: Some(total),
+            stage_checkpoint: Some(StageUnitCheckpoint::Headers(HeadersCheckpoint {
+                block_range: CheckpointBlockRange {
+                    from,
+                    to
+                },
+                progress: EntitiesCheckpoint {
+                    processed,
+                    total: Some(total),
+                }
             }))
-        }, done: true }) if block_number == tip.number
+        }, done: true }) if block_number == tip.number &&
+            from == checkpoint && to == previous_stage &&
             // -1 because we don't need to download the local head
-            && processed == checkpoint + headers.len() as u64 - 1
-            && total == tip.number);
+            processed == checkpoint + headers.len() as u64 - 1 && total == tip.number);
         assert!(runner.validate_execution(input, result.ok()).is_ok(), "validation failed");
     }
 }


### PR DESCRIPTION
We need to have a logic to re-calculate the checkpoint entirely. It might be out-of-date in DB in situation like `initial pipeline sync -> updates by fcu -> pipeline sync`, because during the `updates by fcu` phase, we're not updating checkpoints.

In the case of `Headers`, we need to include the block range which persisted checkpoint is valid for. If it doesn't match our current range, recalculate the whole checkpoint with respect to already downloaded headers.