### PR TITLE
feat: add Transaction setters and separate random tx signing

### DIFF
--- a/crates/interfaces/src/test_utils/generators.rs
+++ b/crates/interfaces/src/test_utils/generators.rs
@@ -72,16 +72,11 @@ pub fn random_signed_tx() -> TransactionSigned {
     let secp = Secp256k1::new();
     let key_pair = KeyPair::new(&secp, &mut rand::thread_rng());
     let tx = random_tx();
-    let signature =
-        sign_message(H256::from_slice(&key_pair.secret_bytes()[..]), tx.signature_hash()).unwrap();
-    TransactionSigned::from_transaction_and_signature(tx, signature)
+    sign_tx_with_key_pair(key_pair, tx)
 }
 
-/// Generates a random legacy [Transaction] that is signed, using the input nonce, and input
-/// keypair to sign the transaction.
-pub fn random_signed_tx_with_nonce(key_pair: KeyPair, nonce: u64) -> TransactionSigned {
-    let mut tx = random_tx();
-    tx.set_nonce(nonce);
+/// Signs the [Transaction] with the given key pair.
+pub fn sign_tx_with_key_pair(key_pair: KeyPair, tx: Transaction) -> TransactionSigned {
     let signature =
         sign_message(H256::from_slice(&key_pair.secret_bytes()[..]), tx.signature_hash()).unwrap();
     TransactionSigned::from_transaction_and_signature(tx, signature)

--- a/crates/interfaces/src/test_utils/generators.rs
+++ b/crates/interfaces/src/test_utils/generators.rs
@@ -77,6 +77,16 @@ pub fn random_signed_tx() -> TransactionSigned {
     TransactionSigned::from_transaction_and_signature(tx, signature)
 }
 
+/// Generates a random legacy [Transaction] that is signed, using the input nonce, and input
+/// keypair to sign the transaction.
+pub fn random_signed_tx_with_nonce(key_pair: KeyPair, nonce: u64) -> TransactionSigned {
+    let mut tx = random_tx();
+    tx.set_nonce(nonce);
+    let signature =
+        sign_message(H256::from_slice(&key_pair.secret_bytes()[..]), tx.signature_hash()).unwrap();
+    TransactionSigned::from_transaction_and_signature(tx, signature)
+}
+
 /// Generate a random block filled with signed transactions (generated using
 /// [random_signed_tx]). If no transaction count is provided, the number of transactions
 /// will be random, otherwise the provided count will be used.

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -233,6 +233,24 @@ impl Transaction {
             Transaction::Eip1559(tx) => tx.nonce = nonce,
         }
     }
+
+    /// This sets the transaction's value.
+    pub fn set_value(&mut self, value: u128) {
+        match self {
+            Transaction::Legacy(tx) => tx.value = value,
+            Transaction::Eip2930(tx) => tx.value = value,
+            Transaction::Eip1559(tx) => tx.value = value,
+        }
+    }
+
+    /// This sets the transaction's input field.
+    pub fn set_input(&mut self, input: Bytes) {
+        match self {
+            Transaction::Legacy(tx) => tx.input = input,
+            Transaction::Eip2930(tx) => tx.input = input,
+            Transaction::Eip1559(tx) => tx.input = input,
+        }
+    }
 }
 
 impl Compact for Transaction {

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -224,6 +224,15 @@ impl Transaction {
             }
         }
     }
+
+    /// This sets the transaction's nonce.
+    pub fn set_nonce(&mut self, nonce: u64) {
+        match self {
+            Transaction::Legacy(tx) => tx.nonce = nonce,
+            Transaction::Eip2930(tx) => tx.nonce = nonce,
+            Transaction::Eip1559(tx) => tx.nonce = nonce,
+        }
+    }
 }
 
 impl Compact for Transaction {


### PR DESCRIPTION
Adding this so we can create more realistic tests in the future, for example local invalid block and reorg testing.