### PR TITLE
fix: ignore forkchoice updates to old head

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -480,9 +480,6 @@ where
         // Terminate the sync early if it's reached the maximum user
         // configured block.
         if is_valid_response {
-            // new VALID update that moved the canonical chain forward
-            let _ = self.update_canon_chain(&state);
-
             let tip_number = self.blockchain.canonical_tip().number;
             if self.sync.has_reached_max_block(tip_number) {
                 return true
@@ -524,14 +521,24 @@ where
 
         let status = match self.blockchain.make_canonical(&state.head_block_hash) {
             Ok(outcome) => {
-                let header = outcome.into_header();
-                debug!(target: "consensus::engine", hash=?state.head_block_hash, number=header.number, "canonicalized new head");
+                if !outcome.is_already_canonical() {
+                    debug!(target: "consensus::engine", hash=?state.head_block_hash, number=outcome.header().number, "canonicalized new head");
+
+                    // new VALID update that moved the canonical chain forward
+                    let _ = self.update_canon_chain(&state);
+                } else {
+                    debug!(target: "consensus::engine", fcu_head_num=?outcome.header().number, current_head_num=?self.blockchain.canonical_tip().number, "Ignoring beacon update to old head");
+                }
 
                 if let Some(attrs) = attrs {
                     // the CL requested to build a new payload on top of this new VALID head
-                    let payload_response =
-                        self.process_payload_attributes(attrs, header.unseal(), state);
-                    trace!(target: "consensus::engine", status = ?payload_response, ?state, "Returning forkchoice status ");
+                    let payload_response = self.process_payload_attributes(
+                        attrs,
+                        outcome.into_header().unseal(),
+                        state,
+                    );
+
+                    trace!(target: "consensus::engine", status = ?payload_response, ?state, "Returning forkchoice status");
                     return Ok(payload_response)
                 }
 

--- a/crates/interfaces/src/blockchain_tree/mod.rs
+++ b/crates/interfaces/src/blockchain_tree/mod.rs
@@ -108,6 +108,11 @@ impl CanonicalOutcome {
             CanonicalOutcome::Committed { head } => head,
         }
     }
+
+    /// Returns true if the block was already canonical.
+    pub fn is_already_canonical(&self) -> bool {
+        matches!(self, CanonicalOutcome::AlreadyCanonical { .. })
+    }
 }
 
 /// From Engine API spec, block inclusion can be valid, accepted or invalid.


### PR DESCRIPTION
This causes the hive test `Re-Org Back into Canonical Chain` to pass, we would previously roll back the chain when we received a forkchoice update to a head that already exists in the canonical chain. Now we ignore the update but return valid, with the same `latestValidHash` that geth returns in this situation:
https://github.com/ethereum/go-ethereum/blob/15bd21f3c878155bc2254bb43460763298f58ad1/eth/catalyst/api.go#L297-L300