### PR TITLE
fix(rpc): remove invalid block hash variant

### DIFF
--- a/crates/consensus/beacon/src/engine/forkchoice.rs
+++ b/crates/consensus/beacon/src/engine/forkchoice.rs
@@ -91,7 +91,6 @@ impl ForkchoiceStatus {
                 // This is only returned on `newPayload` accepted would be a valid state here.
                 ForkchoiceStatus::Valid
             }
-            PayloadStatusEnum::InvalidBlockHash { .. } => ForkchoiceStatus::Invalid,
         }
     }
 }

--- a/crates/rpc/rpc-types/src/eth/engine/payload.rs
+++ b/crates/rpc/rpc-types/src/eth/engine/payload.rs
@@ -323,12 +323,7 @@ impl Serialize for PayloadStatus {
 
 impl From<PayloadError> for PayloadStatusEnum {
     fn from(error: PayloadError) -> Self {
-        match error {
-            error @ PayloadError::BlockHash { .. } => {
-                PayloadStatusEnum::InvalidBlockHash { validation_error: error.to_string() }
-            }
-            _ => PayloadStatusEnum::Invalid { validation_error: error.to_string() },
-        }
+        PayloadStatusEnum::Invalid { validation_error: error.to_string() }
     }
 }
 
@@ -356,10 +351,6 @@ pub enum PayloadStatusEnum {
     /// ACCEPTED is returned by the engine API in the following calls:
     ///   - newPayloadV1: if the payload was accepted, but not processed (side chain)
     Accepted,
-    InvalidBlockHash {
-        #[serde(rename = "validationError")]
-        validation_error: String,
-    },
 }
 
 impl PayloadStatusEnum {
@@ -370,14 +361,12 @@ impl PayloadStatusEnum {
             PayloadStatusEnum::Invalid { .. } => "INVALID",
             PayloadStatusEnum::Syncing => "SYNCING",
             PayloadStatusEnum::Accepted => "ACCEPTED",
-            PayloadStatusEnum::InvalidBlockHash { .. } => "INVALID_BLOCK_HASH",
         }
     }
 
     /// Returns the validation error if the payload status is invalid.
     pub fn validation_error(&self) -> Option<&str> {
         match self {
-            PayloadStatusEnum::InvalidBlockHash { validation_error } |
             PayloadStatusEnum::Invalid { validation_error } => Some(validation_error),
             _ => None,
         }
@@ -397,22 +386,12 @@ impl PayloadStatusEnum {
     pub fn is_invalid(&self) -> bool {
         matches!(self, PayloadStatusEnum::Invalid { .. })
     }
-
-    /// Returns true if the payload status is invalid block hash.
-    pub fn is_invalid_block_hash(&self) -> bool {
-        matches!(self, PayloadStatusEnum::InvalidBlockHash { .. })
-    }
 }
 
 impl std::fmt::Display for PayloadStatusEnum {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             PayloadStatusEnum::Invalid { validation_error } => {
-                f.write_str(self.as_str())?;
-                f.write_str(": ")?;
-                f.write_str(validation_error.as_str())
-            }
-            PayloadStatusEnum::InvalidBlockHash { validation_error } => {
                 f.write_str(self.as_str())?;
                 f.write_str(": ")?;
                 f.write_str(validation_error.as_str())


### PR DESCRIPTION
Closes #2947

this variant is deprecated with v2 and can also be removed from V1

https://github.com/ethereum/go-ethereum/pull/26696

geth also no longer has it

https://github.com/ethereum/go-ethereum/blob/73697529994e14996b7740730481e926d5ec3e40/beacon/engine/errors.go#L61-L61

