### PR TITLE
refactor(primitives, stages): make `EntitiesCheckpoint.total` non-optional

### DIFF
--- a/crates/primitives/src/stage/checkpoints.rs
+++ b/crates/primitives/src/stage/checkpoints.rs
@@ -153,16 +153,12 @@ pub struct EntitiesCheckpoint {
     /// Number of entities already processed.
     pub processed: u64,
     /// Total entities to be processed.
-    pub total: Option<u64>,
+    pub total: u64,
 }
 
 impl Display for EntitiesCheckpoint {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        if let Some(total) = self.total {
-            write!(f, "{:.1}%", 100.0 * self.processed as f64 / total as f64)
-        } else {
-            write!(f, "{}", self.processed)
-        }
+        write!(f, "{:.1}%", 100.0 * self.processed as f64 / self.total as f64)
     }
 }
 
@@ -413,7 +409,7 @@ mod tests {
                 block_range: CheckpointBlockRange { from: rng.gen(), to: rng.gen() },
                 progress: EntitiesCheckpoint {
                     processed: rng.gen::<u32>() as u64,
-                    total: Some(u32::MAX as u64 + rng.gen::<u64>()),
+                    total: u32::MAX as u64 + rng.gen::<u64>(),
                 },
             }),
             StageUnitCheckpoint::Storage(StorageHashingCheckpoint {
@@ -422,25 +418,25 @@ mod tests {
                 block_range: CheckpointBlockRange { from: rng.gen(), to: rng.gen() },
                 progress: EntitiesCheckpoint {
                     processed: rng.gen::<u32>() as u64,
-                    total: Some(u32::MAX as u64 + rng.gen::<u64>()),
+                    total: u32::MAX as u64 + rng.gen::<u64>(),
                 },
             }),
             StageUnitCheckpoint::Entities(EntitiesCheckpoint {
                 processed: rng.gen::<u32>() as u64,
-                total: Some(u32::MAX as u64 + rng.gen::<u64>()),
+                total: u32::MAX as u64 + rng.gen::<u64>(),
             }),
             StageUnitCheckpoint::Execution(ExecutionCheckpoint {
                 block_range: CheckpointBlockRange { from: rng.gen(), to: rng.gen() },
                 progress: EntitiesCheckpoint {
                     processed: rng.gen::<u32>() as u64,
-                    total: Some(u32::MAX as u64 + rng.gen::<u64>()),
+                    total: u32::MAX as u64 + rng.gen::<u64>(),
                 },
             }),
             StageUnitCheckpoint::Headers(HeadersCheckpoint {
                 block_range: CheckpointBlockRange { from: rng.gen(), to: rng.gen() },
                 progress: EntitiesCheckpoint {
                     processed: rng.gen::<u32>() as u64,
-                    total: Some(u32::MAX as u64 + rng.gen::<u64>()),
+                    total: u32::MAX as u64 + rng.gen::<u64>(),
                 },
             }),
         ];

--- a/crates/stages/src/pipeline/sync_metrics.rs
+++ b/crates/stages/src/pipeline/sync_metrics.rs
@@ -43,24 +43,13 @@ impl Metrics {
 
         let (processed, total) = match checkpoint.stage_checkpoint {
             Some(
-                // Only report metrics for hashing stages if `total` is known, otherwise it means
-                // we're unwinding and operating on changesets, rather than accounts or storage
-                // slots.
-                StageUnitCheckpoint::Account(AccountHashingCheckpoint {
-                    progress: progress @ EntitiesCheckpoint { total: Some(_), .. },
-                    ..
-                }) |
-                StageUnitCheckpoint::Storage(StorageHashingCheckpoint {
-                    progress: progress @ EntitiesCheckpoint { total: Some(_), .. },
-                    ..
-                }) |
+                StageUnitCheckpoint::Account(AccountHashingCheckpoint { progress, .. }) |
+                StageUnitCheckpoint::Storage(StorageHashingCheckpoint { progress, .. }) |
                 StageUnitCheckpoint::Entities(progress @ EntitiesCheckpoint { .. }) |
                 StageUnitCheckpoint::Execution(ExecutionCheckpoint { progress, .. }) |
                 StageUnitCheckpoint::Headers(HeadersCheckpoint { progress, .. }),
-            ) => (progress.processed, progress.total),
-            Some(StageUnitCheckpoint::Account(_) | StageUnitCheckpoint::Storage(_)) | None => {
-                (checkpoint.block_number, max_block_number)
-            }
+            ) => (progress.processed, Some(progress.total)),
+            None => (checkpoint.block_number, max_block_number),
         };
 
         stage_metrics.entities_processed.set(processed as f64);

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -222,12 +222,12 @@ fn execution_checkpoint<DB: Database>(
         // stage checkpoint and add the amount of gas from our range to the checkpoint total.
         Some(ExecutionCheckpoint {
             block_range: CheckpointBlockRange { to, .. },
-            progress: EntitiesCheckpoint { processed, total: Some(total) },
+            progress: EntitiesCheckpoint { processed, total },
         }) if to == start_block - 1 => ExecutionCheckpoint {
             block_range: CheckpointBlockRange { from: start_block, to: max_block },
             progress: EntitiesCheckpoint {
                 processed,
-                total: Some(total + calculate_gas_used_from_headers(tx, start_block..=max_block)?),
+                total: total + calculate_gas_used_from_headers(tx, start_block..=max_block)?,
             },
         },
         // If checkpoint block range ends on the same block as our range, we take the previously
@@ -250,7 +250,7 @@ fn execution_checkpoint<DB: Database>(
                 block_range: CheckpointBlockRange { from: start_block, to: max_block },
                 progress: EntitiesCheckpoint {
                     processed,
-                    total: Some(processed + after_checkpoint_block_number),
+                    total: processed + after_checkpoint_block_number,
                 },
             }
         }
@@ -263,9 +263,8 @@ fn execution_checkpoint<DB: Database>(
                 block_range: CheckpointBlockRange { from: start_block, to: max_block },
                 progress: EntitiesCheckpoint {
                     processed,
-                    total: Some(
-                        processed + calculate_gas_used_from_headers(tx, start_block..=max_block)?,
-                    ),
+                    total: processed +
+                        calculate_gas_used_from_headers(tx, start_block..=max_block)?,
                 },
             }
         }
@@ -512,7 +511,7 @@ mod tests {
 
         let previous_stage_checkpoint = ExecutionCheckpoint {
             block_range: CheckpointBlockRange { from: 0, to: 0 },
-            progress: EntitiesCheckpoint { processed: 1, total: Some(2) },
+            progress: EntitiesCheckpoint { processed: 1, total: 2 },
         };
         let previous_checkpoint = StageCheckpoint {
             block_number: 0,
@@ -544,7 +543,7 @@ mod tests {
 
         let previous_stage_checkpoint = ExecutionCheckpoint {
             block_range: CheckpointBlockRange { from: 0, to: 0 },
-            progress: EntitiesCheckpoint { processed: 1, total: Some(1) },
+            progress: EntitiesCheckpoint { processed: 1, total: 1 },
         };
         let previous_checkpoint = StageCheckpoint {
             block_number: 1,
@@ -557,10 +556,10 @@ mod tests {
             block_range: CheckpointBlockRange { from: 1, to: 1 },
             progress: EntitiesCheckpoint {
                 processed,
-                total: Some(total)
+                total
             }
         }) if processed == previous_stage_checkpoint.progress.processed &&
-            total == previous_stage_checkpoint.progress.total.unwrap() + block.gas_used);
+            total == previous_stage_checkpoint.progress.total + block.gas_used);
     }
 
     #[test]
@@ -578,7 +577,7 @@ mod tests {
 
         let previous_stage_checkpoint = ExecutionCheckpoint {
             block_range: CheckpointBlockRange { from: 0, to: 0 },
-            progress: EntitiesCheckpoint { processed: 1, total: Some(1) },
+            progress: EntitiesCheckpoint { processed: 1, total: 1 },
         };
         let previous_checkpoint = StageCheckpoint {
             block_number: 1,
@@ -591,10 +590,10 @@ mod tests {
             block_range: CheckpointBlockRange { from: 1, to: 1 },
             progress: EntitiesCheckpoint {
                 processed,
-                total: Some(total)
+                total
             }
         }) if processed == previous_stage_checkpoint.progress.processed &&
-            total == previous_stage_checkpoint.progress.total.unwrap() + block.gas_used);
+            total == previous_stage_checkpoint.progress.total + block.gas_used);
     }
 
     #[test]
@@ -618,7 +617,7 @@ mod tests {
             block_range: CheckpointBlockRange { from: 1, to: 1 },
             progress: EntitiesCheckpoint {
                 processed: 0,
-                total: Some(total)
+                total
             }
         }) if total == block.gas_used);
     }
@@ -677,7 +676,7 @@ mod tests {
                     },
                     progress: EntitiesCheckpoint {
                         processed,
-                        total: Some(total)
+                        total
                     }
                 }))
             },
@@ -786,7 +785,7 @@ mod tests {
                     },
                     progress: EntitiesCheckpoint {
                         processed: 0,
-                        total: Some(total)
+                        total
                     }
                 }))
             }

--- a/crates/stages/src/stages/hashing_account.rs
+++ b/crates/stages/src/stages/hashing_account.rs
@@ -293,7 +293,7 @@ fn stage_checkpoint_progress<DB: Database>(
 ) -> Result<EntitiesCheckpoint, DatabaseError> {
     Ok(EntitiesCheckpoint {
         processed: tx.deref().entries::<tables::HashedAccount>()? as u64,
-        total: Some(tx.deref().entries::<tables::PlainAccountState>()? as u64),
+        total: tx.deref().entries::<tables::PlainAccountState>()? as u64,
     })
 }
 
@@ -335,7 +335,7 @@ mod tests {
                     stage_checkpoint: Some(StageUnitCheckpoint::Account(AccountHashingCheckpoint {
                         progress: EntitiesCheckpoint {
                             processed,
-                            total: Some(total),
+                            total,
                         },
                         ..
                     })),
@@ -394,7 +394,7 @@ mod tests {
                                 from: 11,
                                 to: 20,
                             },
-                            progress: EntitiesCheckpoint { processed: 5, total: Some(total) }
+                            progress: EntitiesCheckpoint { processed: 5, total }
                         }
                     ))
                 },
@@ -421,7 +421,7 @@ mod tests {
                                 from: 0,
                                 to: 0,
                             },
-                            progress: EntitiesCheckpoint { processed, total: Some(total) }
+                            progress: EntitiesCheckpoint { processed, total }
                         }
                     ))
                 },

--- a/crates/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/src/stages/hashing_storage.rs
@@ -221,7 +221,7 @@ fn stage_checkpoint_progress<DB: Database>(
 ) -> Result<EntitiesCheckpoint, DatabaseError> {
     Ok(EntitiesCheckpoint {
         processed: tx.deref().entries::<tables::HashedStorage>()? as u64,
-        total: Some(tx.deref().entries::<tables::PlainStorageState>()? as u64),
+        total: tx.deref().entries::<tables::PlainStorageState>()? as u64,
     })
 }
 
@@ -281,7 +281,7 @@ mod tests {
                     assert_matches!(checkpoint.storage_hashing_stage_checkpoint(), Some(StorageHashingCheckpoint {
                         progress: EntitiesCheckpoint {
                             processed,
-                            total: Some(total),
+                            total,
                         },
                         ..
                     }) if processed == previous_checkpoint.progress.processed + 1 &&
@@ -295,7 +295,7 @@ mod tests {
                     assert_matches!(checkpoint.storage_hashing_stage_checkpoint(), Some(StorageHashingCheckpoint {
                         progress: EntitiesCheckpoint {
                             processed,
-                            total: Some(total),
+                            total,
                         },
                         ..
                     }) if processed == total &&
@@ -360,7 +360,7 @@ mod tests {
                         },
                         progress: EntitiesCheckpoint {
                             processed: 500,
-                            total: Some(total)
+                            total
                         }
                     }))
                 },
@@ -405,7 +405,7 @@ mod tests {
                             },
                             progress: EntitiesCheckpoint {
                                 processed: 502,
-                                total: Some(total)
+                                total
                             }
                         }
                     ))
@@ -437,7 +437,7 @@ mod tests {
                             },
                             progress: EntitiesCheckpoint {
                                 processed,
-                                total: Some(total)
+                                total
                             }
                         }
                     ))

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -275,9 +275,7 @@ where
                         processed: local_head +
                             (target_block_number.unwrap_or_default() -
                                 tip_block_number.unwrap_or_default()),
-                        total: Some(
-                            target_block_number.expect("No downloaded header for tip found"),
-                        ),
+                        total: target_block_number.expect("No downloaded header for tip found"),
                     },
                 }
             }
@@ -286,7 +284,7 @@ where
         // Total headers can be updated if we received new tip from the network, and need to fill
         // the local gap.
         if let Some(target_block_number) = target_block_number {
-            stage_checkpoint.progress.total = Some(target_block_number);
+            stage_checkpoint.progress.total = target_block_number;
         }
         stage_checkpoint.progress.processed += downloaded_headers.len() as u64;
 
@@ -579,7 +577,7 @@ mod tests {
                 },
                 progress: EntitiesCheckpoint {
                     processed,
-                    total: Some(total),
+                    total,
                 }
             }))
         }, done: true }) if block_number == tip.number &&
@@ -673,7 +671,7 @@ mod tests {
                 },
                 progress: EntitiesCheckpoint {
                     processed,
-                    total: Some(total),
+                    total,
                 }
             }))
         }, done: false }) if block_number == checkpoint &&
@@ -696,7 +694,7 @@ mod tests {
                 },
                 progress: EntitiesCheckpoint {
                     processed,
-                    total: Some(total),
+                    total,
                 }
             }))
         }, done: true }) if block_number == tip.number &&

--- a/crates/stages/src/stages/merkle.rs
+++ b/crates/stages/src/stages/merkle.rs
@@ -196,10 +196,8 @@ impl<DB: Database> Stage<DB> for MerkleStage {
             }
             .unwrap_or(EntitiesCheckpoint {
                 processed: 0,
-                total: Some(
-                    (tx.deref().entries::<tables::HashedAccount>()? +
-                        tx.deref().entries::<tables::HashedStorage>()?) as u64,
-                ),
+                total: (tx.deref().entries::<tables::HashedAccount>()? +
+                    tx.deref().entries::<tables::HashedStorage>()?) as u64,
             });
 
             let progress = StateRoot::new(tx.deref_mut())
@@ -251,7 +249,7 @@ impl<DB: Database> Stage<DB> for MerkleStage {
                 // branch we're just hashing all remaining accounts and storage slots we have in the
                 // database.
                 processed: total_hashed_entries,
-                total: Some(total_hashed_entries),
+                total: total_hashed_entries,
             };
 
             (root, entities_checkpoint)
@@ -285,10 +283,8 @@ impl<DB: Database> Stage<DB> for MerkleStage {
         let mut entities_checkpoint =
             input.checkpoint.entities_stage_checkpoint().unwrap_or(EntitiesCheckpoint {
                 processed: 0,
-                total: Some(
-                    (tx.deref().entries::<tables::HashedAccount>()? +
-                        tx.deref().entries::<tables::HashedStorage>()?) as u64,
-                ),
+                total: (tx.deref().entries::<tables::HashedAccount>()? +
+                    tx.deref().entries::<tables::HashedStorage>()?) as u64,
             });
 
         if input.unwind_to == 0 {
@@ -377,7 +373,7 @@ mod tests {
                     block_number,
                     stage_checkpoint: Some(StageUnitCheckpoint::Entities(EntitiesCheckpoint {
                         processed,
-                        total: Some(total)
+                        total
                     }))
                 },
                 done: true
@@ -417,7 +413,7 @@ mod tests {
                     block_number,
                     stage_checkpoint: Some(StageUnitCheckpoint::Entities(EntitiesCheckpoint {
                         processed,
-                        total: Some(total)
+                        total
                     }))
                 },
                 done: true

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -247,7 +247,7 @@ mod tests {
                 block_number,
                 stage_checkpoint: Some(StageUnitCheckpoint::Entities(EntitiesCheckpoint {
                     processed: 1,
-                    total: Some(1)
+                    total: 1
                 }))
             }, done: true }) if block_number == previous_stage
         );

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -183,7 +183,7 @@ fn stage_checkpoint<DB: Database>(
 ) -> Result<EntitiesCheckpoint, DatabaseError> {
     Ok(EntitiesCheckpoint {
         processed: tx.deref().entries::<tables::TxSenders>()? as u64,
-        total: Some(tx.deref().entries::<tables::Transactions>()? as u64),
+        total: tx.deref().entries::<tables::Transactions>()? as u64,
     })
 }
 
@@ -282,7 +282,7 @@ mod tests {
                 block_number,
                 stage_checkpoint: Some(StageUnitCheckpoint::Entities(EntitiesCheckpoint {
                     processed,
-                    total: Some(total)
+                    total
                 }))
             }, done: false }) if block_number == expected_progress &&
                 processed == runner.tx.table::<tables::TxSenders>().unwrap().len() as u64 &&
@@ -301,7 +301,7 @@ mod tests {
                 block_number,
                 stage_checkpoint: Some(StageUnitCheckpoint::Entities(EntitiesCheckpoint {
                     processed,
-                    total: Some(total)
+                    total
                 }))
             }, done: true }) if block_number == previous_stage &&
                 processed == runner.tx.table::<tables::TxSenders>().unwrap().len() as u64 &&

--- a/crates/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/src/stages/tx_lookup.rs
@@ -209,7 +209,7 @@ fn stage_checkpoint<DB: Database>(
 ) -> Result<EntitiesCheckpoint, DatabaseError> {
     Ok(EntitiesCheckpoint {
         processed: tx.deref().entries::<tables::TxHashNumber>()? as u64,
-        total: Some(tx.deref().entries::<tables::Transactions>()? as u64),
+        total: tx.deref().entries::<tables::Transactions>()? as u64,
     })
 }
 

--- a/crates/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/src/stages/tx_lookup.rs
@@ -257,7 +257,7 @@ mod tests {
                 block_number,
                 stage_checkpoint: Some(StageUnitCheckpoint::Entities(EntitiesCheckpoint {
                     processed,
-                    total: Some(total)
+                    total
                 }))
             }, done: true }) if block_number == previous_stage && processed == total &&
                 total == runner.tx.table::<tables::Transactions>().unwrap().len() as u64
@@ -291,7 +291,7 @@ mod tests {
                 block_number,
                 stage_checkpoint: Some(StageUnitCheckpoint::Entities(EntitiesCheckpoint {
                     processed,
-                    total: Some(total)
+                    total
                 }))
             }, done: false }) if block_number == expected_progress &&
                 processed == runner.tx.table::<tables::TxHashNumber>().unwrap().len() as u64 &&
@@ -310,7 +310,7 @@ mod tests {
                 block_number,
                 stage_checkpoint: Some(StageUnitCheckpoint::Entities(EntitiesCheckpoint {
                     processed,
-                    total: Some(total)
+                    total
                 }))
             }, done: true }) if block_number == previous_stage && processed == total &&
                 total == runner.tx.table::<tables::Transactions>().unwrap().len() as u64


### PR DESCRIPTION
Initially, we were calculating `(Account|Storage)Hashing` stage progress as accounts/storages for execution and changesets for unwinding. But after all, we started calculating it as hashed vs total accounts/storages for both execution and unwinding.

So now, we don't need to have `EntitiesCheckpoint.total` optional, because we always know the total amount of entities to process.