### PR TITLE
chore: dont get plain state if not shard is there

### DIFF
--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -64,6 +64,9 @@ impl<'a, 'b, TX: DbTx<'a>> AccountProvider for HistoricalStateProviderRef<'a, 'b
                     address,
                 })?;
             Ok(account.info)
+        } else if None == changeset_block_number {
+            // if there is no shard, return empty account.
+            Ok(None)
         } else {
             // if changeset is not present that means that there was history shard but we need to
             // use newest value from plain state. Or zero if none.
@@ -126,6 +129,9 @@ impl<'a, 'b, TX: DbTx<'a>> StateProvider for HistoricalStateProviderRef<'a, 'b, 
                     storage_key,
                 })?;
             Ok(Some(storage_entry.value))
+        } else if changeset_block_number == None {
+            // if there is no shards, return empty account.
+            return Ok(None);
         } else {
             // if changeset is not present that means that there was history shard but we need to
             // use newest value from plain state


### PR DESCRIPTION
Small optimization, if there are no history shards that means that there is not changes and we can return default values and not query the PlainStorage/PlainStorage. 