### PR TITLE
fix: off by one unwind range

### DIFF
--- a/bin/reth/src/stage/unwind.rs
+++ b/bin/reth/src/stage/unwind.rs
@@ -109,7 +109,7 @@ impl Subcommands {
                     .ok_or_else(|| eyre::eyre!("Block hash not found in database: {hash:?}"))?,
                 BlockHashOrNumber::Number(num) => *num,
             },
-            Subcommands::NumBlocks { amount } => last.0.saturating_sub(*amount),
+            Subcommands::NumBlocks { amount } => last.0.saturating_sub(*amount) + 1,
         };
         Ok(target..=last.0)
     }


### PR DESCRIPTION
num blocks would always be `num-blocks + 1`

eg:
`last = 5 - num-blocks = 3  == 2`,
`2..=5 = [2,3,4,5]` 