### PR TITLE
fix: implement pending evm env

### DIFF
--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -157,7 +157,7 @@ where
     TraceApiClient::trace_raw_transaction(client, Bytes::default(), HashSet::default(), None)
         .await
         .unwrap_err();
-    TraceApiClient::trace_call_many(client, vec![], None).await.err().unwrap();
+    TraceApiClient::trace_call_many(client, vec![], None).await.unwrap();
     TraceApiClient::replay_transaction(client, H256::default(), HashSet::default())
         .await
         .err()

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -184,6 +184,10 @@ impl<DB: Database> BlockProvider for ShareableDatabase<DB> {
         self.provider()?.pending_block()
     }
 
+    fn pending_header(&self) -> Result<Option<SealedHeader>> {
+        self.provider()?.pending_header()
+    }
+
     fn ommers(&self, id: BlockHashOrNumber) -> Result<Option<Vec<Header>>> {
         self.provider()?.ommers(id)
     }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -200,6 +200,10 @@ impl<'this, TX: DbTx<'this>> BlockProvider for DatabaseProvider<'this, TX> {
         Ok(None)
     }
 
+    fn pending_header(&self) -> Result<Option<SealedHeader>> {
+        Ok(None)
+    }
+
     fn ommers(&self, id: BlockHashOrNumber) -> Result<Option<Vec<Header>>> {
         if let Some(number) = self.convert_hash_or_number(id)? {
             // TODO: this can be optimized to return empty Vec post-merge

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -230,6 +230,10 @@ where
         Ok(self.tree.pending_block())
     }
 
+    fn pending_header(&self) -> Result<Option<SealedHeader>> {
+        Ok(self.tree.pending_header())
+    }
+
     fn ommers(&self, id: BlockHashOrNumber) -> Result<Option<Vec<Header>>> {
         self.database.provider()?.ommers(id)
     }

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -306,6 +306,10 @@ impl BlockProvider for MockEthProvider {
         Ok(None)
     }
 
+    fn pending_header(&self) -> Result<Option<SealedHeader>> {
+        Ok(None)
+    }
+
     fn ommers(&self, _id: BlockHashOrNumber) -> Result<Option<Vec<Header>>> {
         Ok(None)
     }

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -62,6 +62,10 @@ impl BlockProvider for NoopProvider {
         Ok(None)
     }
 
+    fn pending_header(&self) -> Result<Option<SealedHeader>> {
+        Ok(None)
+    }
+
     fn ommers(&self, _id: BlockHashOrNumber) -> Result<Option<Vec<Header>>> {
         Ok(None)
     }

--- a/crates/storage/provider/src/traits/block.rs
+++ b/crates/storage/provider/src/traits/block.rs
@@ -64,6 +64,12 @@ pub trait BlockProvider:
     /// and the caller does not know the hash.
     fn pending_block(&self) -> Result<Option<SealedBlock>>;
 
+    /// Returns the pending block header if available
+    ///
+    /// Note: This returns a [SealedHeader] because it's expected that this is sealed by the
+    /// provider and the caller does not know the hash.
+    fn pending_header(&self) -> Result<Option<SealedHeader>>;
+
     /// Returns the ommers/uncle headers of the given block from the database.
     ///
     /// Returns `None` if block is not found.


### PR DESCRIPTION
implement missing evm env for the pending tag

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b9a8b1c</samp>

This pull request adds support for the `pending` block parameter in the `EthTransactionsApi` trait by implementing the `pending_header` method in various storage provider traits and structs. This allows the RPC methods that use the `EthTransactionsApi` trait to execute transactions against the pending state.