### PR TITLE
feat(cli): db list in reverse

### DIFF
--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -172,6 +172,7 @@ impl Command {
 
                                     if args.json {
                                         let list_result = tool.list::<tables::$table>(args.skip, args.len,args.reverse)?.into_iter().collect::<Vec<_>>();
+                                        println!("LIST RESULT:{list_result:?}");
                                         println!("{}", serde_json::to_string_pretty(&list_result)?);
                                         Ok(())
                                     } else {

--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -172,7 +172,6 @@ impl Command {
 
                                     if args.json {
                                         let list_result = tool.list::<tables::$table>(args.skip, args.len,args.reverse)?.into_iter().collect::<Vec<_>>();
-                                        println!("LIST RESULT:{list_result:?}");
                                         println!("{}", serde_json::to_string_pretty(&list_result)?);
                                         Ok(())
                                     } else {

--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -177,7 +177,7 @@ impl Command {
                                     } else {
                                         tui::DbListTUI::<_, tables::$table>::new(|skip, count| {
                                             tool.list::<tables::$table>(skip, count, args.reverse).unwrap()
-                                        }, $start, $len, args.reverse, total_entries).run()
+                                        }, $start, $len, total_entries).run()
                                     }
                                 })??
                             },)*

--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -72,9 +72,12 @@ pub enum Subcommands {
 pub struct ListArgs {
     /// The table name
     table: String, // TODO: Convert to enum
-    /// Where to start iterating
+    /// Skip first N entries
     #[arg(long, short, default_value = "0")]
-    start: usize,
+    skip: usize,
+    /// Reverse the order of the entries. If enabled last table entries are read.
+    #[arg(long, short, default_value = "false")]
+    reverse: bool,
     /// How many items to take from the walker
     #[arg(long, short, default_value = DEFAULT_NUM_ITEMS)]
     len: usize,
@@ -168,13 +171,13 @@ impl Command {
                                     }
 
                                     if args.json {
-                                        let list_result = tool.list::<tables::$table>(args.start, args.len)?.into_iter().collect::<Vec<_>>();
+                                        let list_result = tool.list::<tables::$table>(args.skip, args.len,args.reverse)?.into_iter().collect::<Vec<_>>();
                                         println!("{}", serde_json::to_string_pretty(&list_result)?);
                                         Ok(())
                                     } else {
-                                        tui::DbListTUI::<_, tables::$table>::new(|start, count| {
-                                            tool.list::<tables::$table>(start, count).unwrap()
-                                        }, $start, $len, total_entries).run()
+                                        tui::DbListTUI::<_, tables::$table>::new(|skip, count| {
+                                            tool.list::<tables::$table>(skip, count, args.reverse).unwrap()
+                                        }, $start, $len, args.reverse, total_entries).run()
                                     }
                                 })??
                             },)*
@@ -186,7 +189,7 @@ impl Command {
                     }
                 }
 
-                table_tui!(args.table.as_str(), args.start, args.len => [
+                table_tui!(args.table.as_str(), args.skip, args.len => [
                     CanonicalHeaders,
                     HeaderTD,
                     HeaderNumbers,

--- a/bin/reth/src/db/tui.rs
+++ b/bin/reth/src/db/tui.rs
@@ -56,8 +56,6 @@ where
     skip: usize,
     /// The amount of entries to show per page
     count: usize,
-    /// reverse
-    reverse: bool,
     /// The total number of entries in the database
     total_entries: usize,
     /// The current view mode
@@ -75,18 +73,11 @@ where
     F: FnMut(usize, usize) -> Vec<(T::Key, T::Value)>,
 {
     /// Create a new database list TUI
-    pub(crate) fn new(
-        fetch: F,
-        skip: usize,
-        count: usize,
-        reverse: bool,
-        total_entries: usize,
-    ) -> Self {
+    pub(crate) fn new(fetch: F, skip: usize, count: usize, total_entries: usize) -> Self {
         Self {
             fetch,
             skip,
             count,
-            reverse,
             total_entries,
             mode: ViewMode::Normal,
             input: String::new(),
@@ -307,11 +298,7 @@ where
 
         let key_length = format!("{}", app.skip + app.count - 1).len();
 
-        let entries: Vec<_> = if app.reverse {
-            app.entries.iter().rev().map(|(k, _)| k).collect()
-        } else {
-            app.entries.iter().map(|(k, _)| k).collect()
-        };
+        let entries: Vec<_> = app.entries.iter().map(|(k, _)| k).collect();
 
         let formatted_keys = entries
             .into_iter()
@@ -334,11 +321,8 @@ where
             .start_corner(Corner::TopLeft);
         f.render_stateful_widget(key_list, inner_chunks[0], &mut app.list_state);
 
-        let values = if app.reverse {
-            app.entries.iter().rev().map(|(_, v)| v).collect::<Vec<_>>()
-        } else {
-            app.entries.iter().map(|(_, v)| v).collect::<Vec<_>>()
-        };
+        let values = app.entries.iter().map(|(_, v)| v).collect::<Vec<_>>();
+
         let value_display = Paragraph::new(
             app.list_state
                 .selected()

--- a/bin/reth/src/utils.rs
+++ b/bin/reth/src/utils.rs
@@ -12,7 +12,7 @@ use reth_interfaces::p2p::{
     priority::Priority,
 };
 use reth_primitives::{BlockHashOrNumber, HeadersDirection, SealedHeader};
-use std::{collections::BTreeMap, path::Path, time::Duration};
+use std::{path::Path, time::Duration};
 use tracing::info;
 
 /// Get a single header from network
@@ -70,14 +70,14 @@ impl<'a, DB: Database> DbTool<'a, DB> {
         skip: usize,
         len: usize,
         reverse: bool,
-    ) -> Result<BTreeMap<T::Key, T::Value>> {
+    ) -> Result<Vec<(T::Key, T::Value)>> {
         let data = self.db.view(|tx| {
             let mut cursor = tx.cursor_read::<T>().expect("Was not able to obtain a cursor.");
 
             if reverse {
-                cursor.walk_back(None)?.skip(skip).take(len).collect::<Result<BTreeMap<_, _>, _>>()
+                cursor.walk_back(None)?.skip(skip).take(len).collect::<Result<_, _>>()
             } else {
-                cursor.walk(None)?.skip(skip).take(len).collect::<Result<BTreeMap<_, _>, _>>()
+                cursor.walk(None)?.skip(skip).take(len).collect::<Result<_, _>>()
             }
         })?;
 

--- a/bin/reth/src/utils.rs
+++ b/bin/reth/src/utils.rs
@@ -2,7 +2,7 @@
 
 use eyre::{Result, WrapErr};
 use reth_db::{
-    cursor::{DbCursorRO, Walker},
+    cursor::DbCursorRO,
     database::Database,
     table::Table,
     transaction::{DbTx, DbTxMut},
@@ -67,22 +67,21 @@ impl<'a, DB: Database> DbTool<'a, DB> {
     /// entries into a [`HashMap`][std::collections::HashMap].
     pub fn list<T: Table>(
         &mut self,
-        start: usize,
+        skip: usize,
         len: usize,
+        reverse: bool,
     ) -> Result<BTreeMap<T::Key, T::Value>> {
         let data = self.db.view(|tx| {
             let mut cursor = tx.cursor_read::<T>().expect("Was not able to obtain a cursor.");
 
-            // TODO: Upstream this in the DB trait.
-            let start_walker = cursor.current().transpose();
-            let walker = Walker::new(&mut cursor, start_walker);
-
-            walker.skip(start).take(len).collect::<Vec<_>>()
+            if reverse {
+                cursor.walk_back(None)?.skip(skip).take(len).collect::<Result<BTreeMap<_, _>, _>>()
+            } else {
+                cursor.walk(None)?.skip(skip).take(len).collect::<Result<BTreeMap<_, _>, _>>()
+            }
         })?;
 
-        data.into_iter()
-            .collect::<Result<BTreeMap<T::Key, T::Value>, _>>()
-            .map_err(|e| eyre::eyre!(e))
+        data.map_err(|e| eyre::eyre!(e))
     }
 
     /// Grabs the content of the table for the given key


### PR DESCRIPTION
Added `--reverse` option to `db list` cli command, this will show last entries from the table.

Additionaly renames `--start` to `--skip` to better reflects what is going on.

And fixed small bug where we could potentially underflow `skip` (previously `start`) integer.