### PR TITLE
fix(stages): don't reset checkpoint total on unwind

### DIFF
--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -141,7 +141,7 @@ where
             self.metrics.stage_checkpoint(
                 stage_id,
                 get_stage_checkpoint(&tx, stage_id)?.unwrap_or_default(),
-                0,
+                None,
             );
         }
         Ok(())
@@ -270,11 +270,10 @@ where
                     Ok(unwind_output) => {
                         checkpoint = unwind_output.checkpoint;
                         self.metrics.stage_checkpoint(
-                            stage_id,
-                            checkpoint,
+                            stage_id, checkpoint,
                             // We assume it was set in the previous execute iteration, so it
                             // doesn't change when we unwind.
-                            checkpoint.block_number,
+                            None,
                         );
                         tx.save_stage_checkpoint(stage_id, checkpoint)?;
 
@@ -347,9 +346,7 @@ where
                     self.metrics.stage_checkpoint(
                         stage_id,
                         checkpoint,
-                        previous_stage
-                            .map(|(_, checkpoint)| checkpoint.block_number)
-                            .unwrap_or_default(),
+                        previous_stage.map(|(_, checkpoint)| checkpoint.block_number),
                     );
                     tx.save_stage_checkpoint(stage_id, checkpoint)?;
 

--- a/crates/stages/src/pipeline/sync_metrics.rs
+++ b/crates/stages/src/pipeline/sync_metrics.rs
@@ -33,7 +33,7 @@ impl Metrics {
         &mut self,
         stage_id: StageId,
         checkpoint: StageCheckpoint,
-        max_block_number: BlockNumber,
+        max_block_number: Option<BlockNumber>,
     ) {
         let stage_metrics = self
             .stages
@@ -50,11 +50,14 @@ impl Metrics {
                 StageUnitCheckpoint::Execution(ExecutionCheckpoint { progress, .. }) |
                 StageUnitCheckpoint::Headers(HeadersCheckpoint { progress, .. }) |
                 StageUnitCheckpoint::IndexHistory(IndexHistoryCheckpoint { progress, .. }),
-            ) => (progress.processed, progress.total),
+            ) => (progress.processed, Some(progress.total)),
             None => (checkpoint.block_number, max_block_number),
         };
 
         stage_metrics.entities_processed.set(processed as f64);
-        stage_metrics.entities_total.set(total as f64);
+
+        if let Some(total) = total {
+            stage_metrics.entities_total.set(total as f64);
+        }
     }
 }


### PR DESCRIPTION
Partially revert https://github.com/paradigmxyz/reth/pull/2949/commits/52b479b21e158ec0bd38e0ac83e9030115546b96. We don't need to reset the `total` metric when we unwind, because then we lose the `total` set by previous execution.