### PR TITLE
chore: Better debug and json serialization for elias fano list

### DIFF
--- a/bin/reth/src/db/get.rs
+++ b/bin/reth/src/db/get.rs
@@ -95,8 +95,8 @@ mod tests {
     use super::*;
     use clap::{Args, Parser};
     use reth_db::{
-        models::{storage_sharded_key::StorageShardedKey, ShardedKey}, HashedAccount, Headers, StorageHistory,
-        SyncStage, AccountHistory,
+        models::{storage_sharded_key::StorageShardedKey, ShardedKey},
+        AccountHistory, HashedAccount, Headers, StorageHistory, SyncStage,
     };
     use reth_primitives::{H160, H256};
     use std::str::FromStr;

--- a/bin/reth/src/db/get.rs
+++ b/bin/reth/src/db/get.rs
@@ -95,8 +95,8 @@ mod tests {
     use super::*;
     use clap::{Args, Parser};
     use reth_db::{
-        models::storage_sharded_key::StorageShardedKey, HashedAccount, Headers, StorageHistory,
-        SyncStage,
+        models::{storage_sharded_key::StorageShardedKey, ShardedKey}, HashedAccount, Headers, StorageHistory,
+        SyncStage, AccountHistory,
     };
     use reth_primitives::{H160, H256};
     use std::str::FromStr;
@@ -144,6 +144,18 @@ mod tests {
                     "0x0000000000000000000000000000000000000000000000000000000000000003"
                 )
                 .unwrap(),
+                18446744073709551615
+            )
+        );
+    }
+
+    #[test]
+    fn parse_json_key_for_account_history() {
+        let args = CommandParser::<Command>::parse_from(["reth", "AccountHistory", r#"{ "key": "0x4448e1273fd5a8bfdb9ed111e96889c960eee145", "highest_block_number": 18446744073709551615 }"#]).args;
+        assert_eq!(
+            args.table_key::<AccountHistory>().unwrap(),
+            ShardedKey::new(
+                H160::from_str("0x4448e1273fd5a8bfdb9ed111e96889c960eee145").unwrap(),
                 18446744073709551615
             )
         );

--- a/crates/primitives/src/integer_list.rs
+++ b/crates/primitives/src/integer_list.rs
@@ -1,5 +1,6 @@
 use serde::{
-    de::{Unexpected, Visitor},
+    de::{SeqAccess, Unexpected, Visitor},
+    ser::SerializeSeq,
     Deserialize, Deserializer, Serialize, Serializer,
 };
 use std::{fmt, ops::Deref};
@@ -75,7 +76,12 @@ impl Serialize for IntegerList {
     where
         S: Serializer,
     {
-        serializer.serialize_bytes(&self.to_bytes())
+        let vec = self.0.iter(0).collect::<Vec<usize>>();
+        let mut seq = serializer.serialize_seq(Some(self.len()))?;
+        for e in vec {
+            seq.serialize_element(&e)?;
+        }
+        seq.end()
     }
 }
 
@@ -84,15 +90,19 @@ impl<'de> Visitor<'de> for IntegerListVisitor {
     type Value = IntegerList;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str("a byte array")
+        formatter.write_str("a usize array")
     }
 
-    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    fn visit_seq<E>(self, mut seq: E) -> Result<Self::Value, E::Error>
     where
-        E: serde::de::Error,
+        E: SeqAccess<'de>,
     {
-        IntegerList::from_bytes(v)
-            .map_err(|_| serde::de::Error::invalid_type(Unexpected::Bytes(v), &self))
+        let mut list = Vec::new();
+        while let Some(item) = seq.next_element()? {
+            list.push(item);
+        }
+
+        IntegerList::new(list).map_err(|_| serde::de::Error::invalid_value(Unexpected::Seq, &self))
     }
 }
 
@@ -146,5 +156,15 @@ mod test {
 
         let blist = ef_list.to_bytes();
         assert_eq!(IntegerList::from_bytes(&blist).unwrap(), ef_list)
+    }
+
+    #[test]
+    fn serde_serialize_deserialize() {
+        let original_list = [1, 2, 3];
+        let ef_list = IntegerList::new(original_list).unwrap();
+
+        let serde_out = serde_json::to_string(&ef_list).unwrap();
+        let serde_ef_list = serde_json::from_str::<IntegerList>(&serde_out).unwrap();
+        assert_eq!(serde_ef_list, ef_list);
     }
 }

--- a/crates/primitives/src/integer_list.rs
+++ b/crates/primitives/src/integer_list.rs
@@ -2,12 +2,12 @@ use serde::{
     de::{Unexpected, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
 };
-use std::ops::Deref;
+use std::{fmt, ops::Deref};
 use sucds::{EliasFano, Searial};
 
 /// Uses EliasFano to hold a list of integers. It provides really good compression with the
 /// capability to access its elements without decoding it.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Clone, PartialEq, Eq, Default)]
 pub struct IntegerList(pub EliasFano);
 
 impl Deref for IntegerList {
@@ -15,6 +15,13 @@ impl Deref for IntegerList {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl fmt::Debug for IntegerList {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let vec: Vec<usize> = self.0.iter(0).collect();
+        write!(f, "IntegerList {:?}", vec)
     }
 }
 


### PR DESCRIPTION
Serialize,deserialize elias fano list not a bytes but as list of items.

Usage for this is inside `db get` where output is now list of integers that can be read by humans (previously it was internal elias fano compressed list)