### PR TITLE
ci: add docker release workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,6 @@ env:
   CARGO_TERM_COLOR: always
   DOCKER_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/reth
   DOCKER_USERNAME: ${{ github.repository_owner }}
-  DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   build:
@@ -32,7 +31,7 @@ jobs:
 
       - name: Log in to Docker
         run: |
-          echo "${DOCKER_PASSWORD}" | docker login ghcr.io --username ${DOCKER_USERNAME} --password-stdin
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io --username ${DOCKER_USERNAME} --password-stdin
 
       - name: Set up Docker builder
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,7 @@ env:
   RUSTFLAGS: -D warnings
   CARGO_TERM_COLOR: always
   DOCKER_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/reth
-  DOCKER_USERNAME: ${{ github.repository_owner }}
+  DOCKER_USERNAME: ${{ github.actor }}
 
 jobs:
   build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,45 @@
+name: docker
+
+on:
+  push:
+    tags:
+      - v*
+
+env:
+  REPO_NAME: ${{ github.repository_owner }}/reth
+  IMAGE_NAME: ${{ github.repository_owner }}/reth
+  RUSTFLAGS: -D warnings
+  CARGO_TERM_COLOR: always
+  DOCKER_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/reth
+  DOCKER_USERNAME: ${{ github.repository_owner }}
+  DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  build:
+    name: build and push
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Get latest version of stable Rust
+        run: rustup update stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Log in to Docker
+        run: |
+          echo "${DOCKER_PASSWORD}" | docker login ghcr.io --username ${DOCKER_USERNAME} --password-stdin
+
+      - name: Set up Docker builder
+        run: |
+          docker run --privileged --rm tonistiigi/binfmt --install arm64,amd64
+          docker buildx create --use --name cross-builder
+
+      - name: Build and push image
+        run: |
+          cargo install cross
+          env PROFILE=maxperf make docker-build-latest

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -1,0 +1,12 @@
+# This image is meant to enable cross-architecture builds.
+# It assumes the reth binary has already been compiled for `$TARGETPLATFORM` and is
+# locatable in `./dist/bin/$TARGETARCH`
+FROM --platform=$TARGETPLATFORM ubuntu:22.04
+
+# Filled by docker buildx
+ARG TARGETARCH
+
+COPY ./dist/bin/$TARGETARCH/reth /usr/local/bin/reth
+
+EXPOSE 30303 30303/udp 9000 8545 8546
+ENTRYPOINT ["/usr/local/bin/reth", "node"]


### PR DESCRIPTION
Releases a multi-arch image on tag push to ghcr.io. A lot simpler than #2682 and supersedes it, primarily because the other workflow was too hard to debug/reason about

I am currently waiting for the CI to pass a test here: https://github.com/onbjerg/reth/actions/runs/5177779153/jobs/9328314840