### PR TITLE
fix: exclude calls to precompiles in parity tracers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5538,8 +5538,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f293f351c4c203d321744e54ed7eed3d2b6eef4c140228910dde3ac9a5ea8031"
+source = "git+https://github.com/bluealloy/revm/?branch=release/v25#88337924f4d16ed1f5e4cde12a03d0cb755cd658"
 dependencies = [
  "auto_impl",
  "revm-interpreter",
@@ -5549,8 +5548,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53980a26f9b5a66d13511c35074d4b53631e157850a1d7cf1af4efc2c2b72c9"
+source = "git+https://github.com/bluealloy/revm/?branch=release/v25#88337924f4d16ed1f5e4cde12a03d0cb755cd658"
 dependencies = [
  "derive_more",
  "enumn",
@@ -5560,9 +5558,8 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a3eabf08ea9e4063f5531b8735e29344d9d6eaebaa314c58253f6c17fcdf2d"
+version = "2.0.3"
+source = "git+https://github.com/bluealloy/revm/?branch=release/v25#88337924f4d16ed1f5e4cde12a03d0cb755cd658"
 dependencies = [
  "k256 0.13.1",
  "num",
@@ -5578,8 +5575,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "304d998f466ffef72d76c7f20b05bf08a96801736a6fb1fdef47d49a292618df"
+source = "git+https://github.com/bluealloy/revm/?branch=release/v25#88337924f4d16ed1f5e4cde12a03d0cb755cd658"
 dependencies = [
  "arbitrary",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,9 @@ incremental = false
 # patched for quantity U256 responses <https://github.com/recmo/uint/issues/224>
 ruint = { git = "https://github.com/paradigmxyz/uint" }
 
+revm = { git = "https://github.com/bluealloy/revm/", branch = "release/v25" }
+revm-primitives = { git = "https://github.com/bluealloy/revm/", branch = "release/v25" }
+
 [workspace.dependencies]
 ## eth
 revm = { version = "3" }

--- a/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
@@ -124,6 +124,11 @@ impl ParityTraceBuilder {
         let mut diff = StateDiff::default();
 
         for (node, trace_address) in self.nodes.iter().zip(trace_addresses) {
+            // skip precompiles
+            if node.is_precompile() {
+                continue
+            }
+
             if with_traces {
                 let trace = node.parity_transaction_trace(trace_address);
                 traces.push(trace);
@@ -145,6 +150,7 @@ impl ParityTraceBuilder {
         self.nodes
             .into_iter()
             .zip(trace_addresses)
+            .filter(|(node, _)| !node.is_precompile())
             .map(|(node, trace_address)| node.parity_transaction_trace(trace_address))
     }
 

--- a/crates/revm/revm-inspectors/src/tracing/config.rs
+++ b/crates/revm/revm-inspectors/src/tracing/config.rs
@@ -14,6 +14,8 @@ pub struct TracingInspectorConfig {
     pub record_stack_snapshots: bool,
     /// Whether to record state diffs.
     pub record_state_diff: bool,
+    /// Whether to ignore precompile calls.
+    pub exclude_precompile_calls: bool,
 }
 
 impl TracingInspectorConfig {
@@ -24,6 +26,7 @@ impl TracingInspectorConfig {
             record_memory_snapshots: true,
             record_stack_snapshots: true,
             record_state_diff: false,
+            exclude_precompile_calls: false,
         }
     }
 
@@ -36,6 +39,7 @@ impl TracingInspectorConfig {
             record_memory_snapshots: false,
             record_stack_snapshots: false,
             record_state_diff: false,
+            exclude_precompile_calls: true,
         }
     }
 
@@ -48,6 +52,7 @@ impl TracingInspectorConfig {
             record_memory_snapshots: true,
             record_stack_snapshots: true,
             record_state_diff: true,
+            exclude_precompile_calls: false,
         }
     }
 
@@ -59,6 +64,14 @@ impl TracingInspectorConfig {
             record_state_diff: !config.disable_storage.unwrap_or_default(),
             ..Self::default_geth()
         }
+    }
+
+    /// Configure whether calls to precompiles should be ignored.
+    ///
+    /// If set to `true`, calls to precompiles without value transfers will be ignored.
+    pub fn set_exclude_precompile_calls(mut self, exclude_precompile_calls: bool) -> Self {
+        self.exclude_precompile_calls = exclude_precompile_calls;
+        self
     }
 
     /// Configure whether individual opcode level steps should be recorded

--- a/crates/revm/revm-inspectors/src/tracing/mod.rs
+++ b/crates/revm/revm-inspectors/src/tracing/mod.rs
@@ -101,6 +101,7 @@ impl TracingInspector {
     /// Starts tracking a new trace.
     ///
     /// Invoked on [Inspector::call].
+    #[allow(clippy::too_many_arguments)]
     fn start_trace_on_call(
         &mut self,
         depth: usize,
@@ -109,6 +110,7 @@ impl TracingInspector {
         value: U256,
         kind: CallKind,
         caller: Address,
+        is_precompile: bool,
     ) {
         self.trace_stack.push(self.traces.push_trace(
             0,
@@ -121,6 +123,7 @@ impl TracingInspector {
                 status: InstructionResult::Continue,
                 caller,
                 last_call_return_value: self.last_call_return_data.clone(),
+                is_precompile,
                 ..Default::default()
             },
         ));
@@ -318,6 +321,10 @@ where
             _ => (inputs.context.caller, inputs.context.address),
         };
 
+        // TODO(mattsse): check if this call is a precompile and `depth > 0 && value == 0`
+
+        let is_precompile = false;
+
         self.start_trace_on_call(
             data.journaled_state.depth() as usize,
             to,
@@ -325,6 +332,7 @@ where
             inputs.transfer.value,
             inputs.context.scheme.into(),
             from,
+            is_precompile,
         );
 
         (InstructionResult::Continue, Gas::new(0), Bytes::new())
@@ -367,6 +375,7 @@ where
             inputs.value,
             inputs.scheme.into(),
             inputs.caller,
+            false
         );
 
         (InstructionResult::Continue, None, Gas::new(inputs.gas_limit), Bytes::default())

--- a/crates/revm/revm-inspectors/src/tracing/types.rs
+++ b/crates/revm/revm-inspectors/src/tracing/types.rs
@@ -121,6 +121,8 @@ pub(crate) struct CallTrace {
     /// In other words, this is the callee if the [CallKind::Call] or the address of the created
     /// contract if [CallKind::Create].
     pub(crate) address: Address,
+    /// Whether this is a call to a precompile
+    pub(crate) is_precompile: bool,
     /// Holds the target for the selfdestruct refund target if `status` is
     /// [InstructionResult::SelfDestruct]
     pub(crate) selfdestruct_refund_target: Option<Address>,
@@ -168,6 +170,7 @@ impl Default for CallTrace {
             kind: Default::default(),
             value: Default::default(),
             data: Default::default(),
+            is_precompile: false,
             output: Default::default(),
             last_call_return_value: None,
             gas_used: Default::default(),
@@ -231,6 +234,11 @@ impl CallTraceNode {
             stack.push(item);
         }
         stack
+    }
+
+    /// Returns true if this is a call to a precompile
+    pub(crate) fn is_precompile(&self) -> bool {
+        self.trace.is_precompile
     }
 
     /// Returns the kind of call the trace belongs to

--- a/crates/revm/revm-inspectors/src/tracing/types.rs
+++ b/crates/revm/revm-inspectors/src/tracing/types.rs
@@ -122,7 +122,9 @@ pub(crate) struct CallTrace {
     /// contract if [CallKind::Create].
     pub(crate) address: Address,
     /// Whether this is a call to a precompile
-    pub(crate) is_precompile: bool,
+    ///
+    /// Note: This is an Option because not all tracers make use of this
+    pub(crate) maybe_precompile: Option<bool>,
     /// Holds the target for the selfdestruct refund target if `status` is
     /// [InstructionResult::SelfDestruct]
     pub(crate) selfdestruct_refund_target: Option<Address>,
@@ -170,7 +172,7 @@ impl Default for CallTrace {
             kind: Default::default(),
             value: Default::default(),
             data: Default::default(),
-            is_precompile: false,
+            maybe_precompile: None,
             output: Default::default(),
             last_call_return_value: None,
             gas_used: Default::default(),
@@ -238,7 +240,7 @@ impl CallTraceNode {
 
     /// Returns true if this is a call to a precompile
     pub(crate) fn is_precompile(&self) -> bool {
-        self.trace.is_precompile
+        self.trace.maybe_precompile.unwrap_or(false)
     }
 
     /// Returns the kind of call the trace belongs to


### PR DESCRIPTION
ref #2970

This adds a `is_precompile` marker to the tracer types and excludes nodes that are precompiles


~~@rakita how do I find out if a call is to a precompile?~~

## UPDATE

This currently patches https://github.com/bluealloy/revm/tree/release/v25
@rakita what#s the ETA for revm release that includes this?