### PR TITLE
fix: make GethDebugTracingOptions  args optional

### DIFF
--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -52,7 +52,7 @@ pub trait DebugApi {
     async fn debug_trace_block(
         &self,
         rlp_block: Bytes,
-        opts: GethDebugTracingOptions,
+        opts: Option<GethDebugTracingOptions>,
     ) -> RpcResult<Vec<TraceResult>>;
 
     /// Similar to `debug_traceBlock`, `debug_traceBlockByHash` accepts a block hash and will replay
@@ -62,7 +62,7 @@ pub trait DebugApi {
     async fn debug_trace_block_by_hash(
         &self,
         block: H256,
-        opts: GethDebugTracingOptions,
+        opts: Option<GethDebugTracingOptions>,
     ) -> RpcResult<Vec<TraceResult>>;
 
     /// Similar to `debug_traceBlockByNumber`, `debug_traceBlockByHash` accepts a block number
@@ -72,7 +72,7 @@ pub trait DebugApi {
     async fn debug_trace_block_by_number(
         &self,
         block: BlockNumberOrTag,
-        opts: GethDebugTracingOptions,
+        opts: Option<GethDebugTracingOptions>,
     ) -> RpcResult<Vec<TraceResult>>;
 
     /// The `debug_traceTransaction` debugging method will attempt to run the transaction in the
@@ -83,7 +83,7 @@ pub trait DebugApi {
     async fn debug_trace_transaction(
         &self,
         tx_hash: H256,
-        opts: GethDebugTracingOptions,
+        opts: Option<GethDebugTracingOptions>,
     ) -> RpcResult<GethTraceFrame>;
 
     /// The debug_traceCall method lets you run an `eth_call` within the context of the given block
@@ -100,6 +100,6 @@ pub trait DebugApi {
         &self,
         request: CallRequest,
         block_number: Option<BlockId>,
-        opts: GethDebugTracingCallOptions,
+        opts: Option<GethDebugTracingCallOptions>,
     ) -> RpcResult<GethTraceFrame>;
 }

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -415,40 +415,40 @@ where
     async fn debug_trace_block(
         &self,
         rlp_block: Bytes,
-        opts: GethDebugTracingOptions,
+        opts: Option<GethDebugTracingOptions>,
     ) -> RpcResult<Vec<TraceResult>> {
         let _permit = self.acquire_trace_permit().await;
-        Ok(DebugApi::debug_trace_raw_block(self, rlp_block, opts).await?)
+        Ok(DebugApi::debug_trace_raw_block(self, rlp_block, opts.unwrap_or_default()).await?)
     }
 
     /// Handler for `debug_traceBlockByHash`
     async fn debug_trace_block_by_hash(
         &self,
         block: H256,
-        opts: GethDebugTracingOptions,
+        opts: Option<GethDebugTracingOptions>,
     ) -> RpcResult<Vec<TraceResult>> {
         let _permit = self.acquire_trace_permit().await;
-        Ok(DebugApi::debug_trace_block(self, block.into(), opts).await?)
+        Ok(DebugApi::debug_trace_block(self, block.into(), opts.unwrap_or_default()).await?)
     }
 
     /// Handler for `debug_traceBlockByNumber`
     async fn debug_trace_block_by_number(
         &self,
         block: BlockNumberOrTag,
-        opts: GethDebugTracingOptions,
+        opts: Option<GethDebugTracingOptions>,
     ) -> RpcResult<Vec<TraceResult>> {
         let _permit = self.acquire_trace_permit().await;
-        Ok(DebugApi::debug_trace_block(self, block.into(), opts).await?)
+        Ok(DebugApi::debug_trace_block(self, block.into(), opts.unwrap_or_default()).await?)
     }
 
     /// Handler for `debug_traceTransaction`
     async fn debug_trace_transaction(
         &self,
         tx_hash: H256,
-        opts: GethDebugTracingOptions,
+        opts: Option<GethDebugTracingOptions>,
     ) -> RpcResult<GethTraceFrame> {
         let _permit = self.acquire_trace_permit().await;
-        Ok(DebugApi::debug_trace_transaction(self, tx_hash, opts).await?)
+        Ok(DebugApi::debug_trace_transaction(self, tx_hash, opts.unwrap_or_default()).await?)
     }
 
     /// Handler for `debug_traceCall`
@@ -456,10 +456,11 @@ where
         &self,
         request: CallRequest,
         block_number: Option<BlockId>,
-        opts: GethDebugTracingCallOptions,
+        opts: Option<GethDebugTracingCallOptions>,
     ) -> RpcResult<GethTraceFrame> {
         let _permit = self.acquire_trace_permit().await;
-        Ok(DebugApi::debug_trace_call(self, request, block_number, opts).await?)
+        Ok(DebugApi::debug_trace_call(self, request, block_number, opts.unwrap_or_default())
+            .await?)
     }
 }
 


### PR DESCRIPTION
not required by geth/erigon, can be null or missing

closes #2995