### PR TITLE
fix: mark downloaded block as invalid if insertion fails

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -976,7 +976,7 @@ where
             return
         }
 
-        match self.blockchain.insert_block_without_senders(block) {
+        match self.blockchain.insert_block_without_senders(block.clone()) {
             Ok(status) => {
                 match status {
                     BlockStatus::Valid => {
@@ -995,6 +995,10 @@ where
             }
             Err(err) => {
                 debug!(target: "consensus::engine", ?err, "Failed to insert downloaded block");
+                if !matches!(err.kind(), InsertBlockErrorKind::Internal(_)) {
+                    // non-internal error kinds occurr if the payload is invalid
+                    self.invalid_headers.insert(block.header);
+                }
             }
         }
     }

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -976,7 +976,7 @@ where
             return
         }
 
-        match self.blockchain.insert_block_without_senders(block.clone()) {
+        match self.blockchain.insert_block_without_senders(block) {
             Ok(status) => {
                 match status {
                     BlockStatus::Valid => {
@@ -997,7 +997,7 @@ where
                 debug!(target: "consensus::engine", ?err, "Failed to insert downloaded block");
                 if !matches!(err.kind(), InsertBlockErrorKind::Internal(_)) {
                     // non-internal error kinds occurr if the payload is invalid
-                    self.invalid_headers.insert(block.header);
+                    self.invalid_headers.insert(err.into_block().header);
                 }
             }
         }

--- a/crates/interfaces/src/blockchain_tree/error.rs
+++ b/crates/interfaces/src/blockchain_tree/error.rs
@@ -65,6 +65,12 @@ impl InsertBlockError {
         Self::new(block, InsertBlockErrorKind::Execution(error))
     }
 
+    /// Consumes the error and returns the block that resulted in the error
+    #[inline]
+    pub fn into_block(self) -> SealedBlock {
+        self.inner.block
+    }
+
     /// Returns the error kind
     #[inline]
     pub fn kind(&self) -> &InsertBlockErrorKind {


### PR DESCRIPTION
Previously, we would just log errors if a block failed insertion. Now, we mark it as invalid if it failed insertion after downloading. This fixes the hive `Invalid Ancestor Chain Re-Org, Invalid Ommers, Invalid P9', Reveal using sync` test.