### PR TITLE
feat(stages): bodies & TD progress

### DIFF
--- a/bin/reth/src/args/stage_args.rs
+++ b/bin/reth/src/args/stage_args.rs
@@ -17,4 +17,5 @@ pub enum StageEnum {
     History,
     AccountHistory,
     StorageHistory,
+    TotalDifficulty,
 }

--- a/bin/reth/src/stage/drop.rs
+++ b/bin/reth/src/stage/drop.rs
@@ -12,7 +12,7 @@ use reth_db::{
     transaction::DbTxMut,
 };
 use reth_primitives::{stage::StageId, ChainSpec};
-use reth_staged_sync::utils::init::insert_genesis_state;
+use reth_staged_sync::utils::init::{insert_genesis_header, insert_genesis_state};
 use std::sync::Arc;
 use tracing::info;
 
@@ -70,6 +70,7 @@ impl Command {
                     tx.clear::<tables::BlockOmmers>()?;
                     tx.clear::<tables::BlockWithdrawals>()?;
                     tx.put::<tables::SyncStage>(StageId::Bodies.to_string(), Default::default())?;
+                    insert_genesis_header::<Env<WriteMap>>(tx, self.chain)?;
                 }
                 StageEnum::Senders => {
                     tx.clear::<tables::TxSenders>()?;
@@ -154,6 +155,7 @@ impl Command {
                         StageId::TotalDifficulty.to_string(),
                         Default::default(),
                     )?;
+                    insert_genesis_header::<Env<WriteMap>>(tx, self.chain)?;
                 }
                 _ => {
                     info!("Nothing to do for stage {:?}", self.stage);

--- a/bin/reth/src/stage/drop.rs
+++ b/bin/reth/src/stage/drop.rs
@@ -63,6 +63,14 @@ impl Command {
 
         tool.db.update(|tx| {
             match &self.stage {
+                StageEnum::Bodies => {
+                    tx.clear::<tables::BlockBodyIndices>()?;
+                    tx.clear::<tables::Transactions>()?;
+                    tx.clear::<tables::TransactionBlock>()?;
+                    tx.clear::<tables::BlockOmmers>()?;
+                    tx.clear::<tables::BlockWithdrawals>()?;
+                    tx.put::<tables::SyncStage>(StageId::Bodies.to_string(), Default::default())?;
+                }
                 StageEnum::Senders => {
                     tx.clear::<tables::TxSenders>()?;
                     tx.put::<tables::SyncStage>(
@@ -137,6 +145,13 @@ impl Command {
                     )?;
                     tx.put::<tables::SyncStage>(
                         StageId::IndexStorageHistory.to_string(),
+                        Default::default(),
+                    )?;
+                }
+                StageEnum::TotalDifficulty => {
+                    tx.clear::<tables::HeaderTD>()?;
+                    tx.put::<tables::SyncStage>(
+                        StageId::TotalDifficulty.to_string(),
                         Default::default(),
                     )?;
                 }

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -4,7 +4,7 @@ use crate::{
     header::Head,
     proofs::genesis_state_root,
     BlockNumber, Chain, ForkFilter, ForkHash, ForkId, Genesis, GenesisAccount, Hardfork, Header,
-    H160, H256, U256,
+    SealedHeader, H160, H256, U256,
 };
 use ethers_core::utils::Genesis as EthersGenesis;
 use hex_literal::hex;
@@ -191,6 +191,11 @@ impl ChainSpec {
             withdrawals_root,
             ..Default::default()
         }
+    }
+
+    /// Get the sealed header for the genesis block.
+    pub fn sealed_genesis_header(&self) -> SealedHeader {
+        SealedHeader { header: self.genesis_header(), hash: self.genesis_hash() }
     }
 
     /// Get the initial base fee of the genesis block.

--- a/crates/staged-sync/src/utils/init.rs
+++ b/crates/staged-sync/src/utils/init.rs
@@ -71,11 +71,7 @@ pub fn init_genesis<DB: Database>(
 
     // Insert header
     let tx = db.tx_mut()?;
-    tx.put::<tables::CanonicalHeaders>(0, hash)?;
-    tx.put::<tables::HeaderNumbers>(hash, 0)?;
-    tx.put::<tables::BlockBodyIndices>(0, Default::default())?;
-    tx.put::<tables::HeaderTD>(0, header.difficulty.into())?;
-    tx.put::<tables::Headers>(0, header)?;
+    insert_genesis_header::<DB>(&tx, chain.clone())?;
 
     insert_genesis_state::<DB>(&tx, genesis)?;
 
@@ -138,6 +134,23 @@ pub fn insert_genesis_hashes<DB: Database>(
     });
     transaction.insert_storage_for_hashing(alloc_storage)?;
     transaction.commit()?;
+    Ok(())
+}
+
+/// Inserts header for the genesis state.
+pub fn insert_genesis_header<DB: Database>(
+    tx: &<DB as DatabaseGAT<'_>>::TXMut,
+    chain: Arc<ChainSpec>,
+) -> Result<(), InitDatabaseError> {
+    let header = chain.genesis_header();
+    let hash = header.hash_slow();
+
+    tx.put::<tables::CanonicalHeaders>(0, hash)?;
+    tx.put::<tables::HeaderNumbers>(hash, 0)?;
+    tx.put::<tables::BlockBodyIndices>(0, Default::default())?;
+    tx.put::<tables::HeaderTD>(0, header.difficulty.into())?;
+    tx.put::<tables::Headers>(0, header)?;
+
     Ok(())
 }
 

--- a/crates/staged-sync/src/utils/init.rs
+++ b/crates/staged-sync/src/utils/init.rs
@@ -48,8 +48,7 @@ pub fn init_genesis<DB: Database>(
 ) -> Result<H256, InitDatabaseError> {
     let genesis = chain.genesis();
 
-    let header = chain.genesis_header();
-    let hash = header.hash_slow();
+    let hash = chain.genesis_hash();
 
     let tx = db.tx()?;
     if let Some((_, db_hash)) = tx.cursor_read::<tables::CanonicalHeaders>()?.first()? {
@@ -142,14 +141,13 @@ pub fn insert_genesis_header<DB: Database>(
     tx: &<DB as DatabaseGAT<'_>>::TXMut,
     chain: Arc<ChainSpec>,
 ) -> Result<(), InitDatabaseError> {
-    let header = chain.genesis_header();
-    let hash = header.hash_slow();
+    let header = chain.sealed_genesis_header();
 
-    tx.put::<tables::CanonicalHeaders>(0, hash)?;
-    tx.put::<tables::HeaderNumbers>(hash, 0)?;
+    tx.put::<tables::CanonicalHeaders>(0, header.hash)?;
+    tx.put::<tables::HeaderNumbers>(header.hash, 0)?;
     tx.put::<tables::BlockBodyIndices>(0, Default::default())?;
     tx.put::<tables::HeaderTD>(0, header.difficulty.into())?;
-    tx.put::<tables::Headers>(0, header)?;
+    tx.put::<tables::Headers>(0, header.header)?;
 
     Ok(())
 }

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -219,6 +219,9 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
     }
 }
 
+// TODO(alexey): ideally, we want to measure Bodies stage progress in bytes, but it's hard to know
+//  beforehand how many bytes we need to download. So the good solution would be to measure the
+//  progress in gas as a proxy to size. Execution stage uses a similar approach.
 fn stage_checkpoint<DB: Database>(
     tx: &Transaction<'_, DB>,
 ) -> Result<EntitiesCheckpoint, DatabaseError> {

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -5,15 +5,16 @@ use reth_db::{
     database::Database,
     models::{StoredBlockBodyIndices, StoredBlockOmmers, StoredBlockWithdrawals},
     tables,
-    transaction::DbTxMut,
+    transaction::{DbTx, DbTxMut},
+    DatabaseError,
 };
 use reth_interfaces::{
     consensus::Consensus,
     p2p::bodies::{downloader::BodyDownloader, response::BlockResponse},
 };
-use reth_primitives::stage::{StageCheckpoint, StageId};
+use reth_primitives::stage::{EntitiesCheckpoint, StageCheckpoint, StageId};
 use reth_provider::Transaction;
-use std::sync::Arc;
+use std::{ops::Deref, sync::Arc};
 use tracing::*;
 
 // TODO(onbjerg): Metrics and events (gradual status for e.g. CLI)
@@ -154,7 +155,11 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
         // - We reached our target and the target was not limited by the batch size of the stage
         let done = highest_block == to_block;
         info!(target: "sync::stages::bodies", stage_progress = highest_block, target = to_block, is_final_range = done, "Stage iteration finished");
-        Ok(ExecOutput { checkpoint: StageCheckpoint::new(highest_block), done })
+        Ok(ExecOutput {
+            checkpoint: StageCheckpoint::new(highest_block)
+                .with_entities_stage_checkpoint(stage_checkpoint(tx)?),
+            done,
+        })
     }
 
     /// Unwind the stage.
@@ -207,8 +212,20 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
         }
 
         info!(target: "sync::stages::bodies", to_block = input.unwind_to, stage_progress = input.unwind_to, is_final_range = true, "Unwind iteration finished");
-        Ok(UnwindOutput { checkpoint: StageCheckpoint::new(input.unwind_to) })
+        Ok(UnwindOutput {
+            checkpoint: StageCheckpoint::new(input.unwind_to)
+                .with_entities_stage_checkpoint(stage_checkpoint(tx)?),
+        })
     }
+}
+
+fn stage_checkpoint<DB: Database>(
+    tx: &Transaction<'_, DB>,
+) -> Result<EntitiesCheckpoint, DatabaseError> {
+    Ok(EntitiesCheckpoint {
+        processed: tx.deref().entries::<tables::BlockBodyIndices>()? as u64,
+        total: tx.deref().entries::<tables::Headers>()? as u64,
+    })
 }
 
 #[cfg(test)]
@@ -219,6 +236,7 @@ mod tests {
         PREV_STAGE_ID,
     };
     use assert_matches::assert_matches;
+    use reth_primitives::stage::StageUnitCheckpoint;
     use test_utils::*;
 
     stage_test_suite_ext!(BodyTestRunner, body);
@@ -238,7 +256,8 @@ mod tests {
 
         // Set the batch size (max we sync per stage execution) to less than the number of blocks
         // the previous stage synced (10 vs 20)
-        runner.set_batch_size(10);
+        let batch_size = 10;
+        runner.set_batch_size(batch_size);
 
         // Run the stage
         let rx = runner.execute(input);
@@ -248,7 +267,14 @@ mod tests {
         let output = rx.await.unwrap();
         assert_matches!(
             output,
-            Ok(ExecOutput { checkpoint: StageCheckpoint { block_number, ..}, done: false }) if block_number < 200
+            Ok(ExecOutput { checkpoint: StageCheckpoint {
+                block_number,
+                stage_checkpoint: Some(StageUnitCheckpoint::Entities(EntitiesCheckpoint {
+                    processed, // 1 seeded block body + batch size
+                    total // seeded headers
+                }))
+            }, done: false }) if block_number < 200 &&
+                processed == 1 + batch_size && total == previous_stage
         );
         assert!(runner.validate_execution(input, output.ok()).is_ok(), "execution validation");
     }
@@ -278,9 +304,15 @@ mod tests {
         assert_matches!(
             output,
             Ok(ExecOutput {
-                checkpoint: StageCheckpoint { block_number: 20, stage_checkpoint: None },
+                checkpoint: StageCheckpoint {
+                    block_number: 20,
+                    stage_checkpoint: Some(StageUnitCheckpoint::Entities(EntitiesCheckpoint {
+                        processed,
+                        total
+                    }))
+                },
                 done: true
-            })
+            }) if processed == total && total == previous_stage
         );
         assert!(runner.validate_execution(input, output.ok()).is_ok(), "execution validation");
     }
@@ -298,7 +330,8 @@ mod tests {
         };
         runner.seed_execution(input).expect("failed to seed execution");
 
-        runner.set_batch_size(10);
+        let batch_size = 10;
+        runner.set_batch_size(batch_size);
 
         // Run the stage
         let rx = runner.execute(input);
@@ -307,7 +340,14 @@ mod tests {
         let first_run = rx.await.unwrap();
         assert_matches!(
             first_run,
-            Ok(ExecOutput { checkpoint: StageCheckpoint { block_number, ..}, done: false }) if block_number >= 10
+            Ok(ExecOutput { checkpoint: StageCheckpoint {
+                block_number,
+                stage_checkpoint: Some(StageUnitCheckpoint::Entities(EntitiesCheckpoint {
+                    processed,
+                    total
+                }))
+            }, done: false }) if block_number >= 10 &&
+                processed == 1 + batch_size && total == previous_stage
         );
         let first_run_checkpoint = first_run.unwrap().checkpoint;
 
@@ -322,7 +362,14 @@ mod tests {
         let output = rx.await.unwrap();
         assert_matches!(
             output,
-            Ok(ExecOutput { checkpoint: StageCheckpoint { block_number, ..}, done: true }) if block_number > first_run_checkpoint.block_number
+            Ok(ExecOutput { checkpoint: StageCheckpoint {
+                block_number,
+                stage_checkpoint: Some(StageUnitCheckpoint::Entities(EntitiesCheckpoint {
+                    processed,
+                    total
+                }))
+            }, done: true }) if block_number > first_run_checkpoint.block_number &&
+                processed == total && total == previous_stage
         );
         assert_matches!(
             runner.validate_execution(input, output.ok()),
@@ -355,7 +402,14 @@ mod tests {
         let output = rx.await.unwrap();
         assert_matches!(
             output,
-            Ok(ExecOutput { checkpoint: StageCheckpoint { block_number, ..}, done: true }) if block_number == previous_stage
+            Ok(ExecOutput { checkpoint: StageCheckpoint {
+                block_number,
+                stage_checkpoint: Some(StageUnitCheckpoint::Entities(EntitiesCheckpoint {
+                    processed,
+                    total
+                }))
+            }, done: true }) if block_number == previous_stage &&
+                processed == total && total == previous_stage
         );
         let checkpoint = output.unwrap().checkpoint;
         runner
@@ -379,7 +433,13 @@ mod tests {
         let res = runner.unwind(input).await;
         assert_matches!(
             res,
-            Ok(UnwindOutput { checkpoint: StageCheckpoint { block_number: 1, .. } })
+            Ok(UnwindOutput { checkpoint: StageCheckpoint {
+                block_number: 1,
+                stage_checkpoint: Some(StageUnitCheckpoint::Entities(EntitiesCheckpoint {
+                    processed: 1,
+                    total
+                }))
+            }}) if total == previous_stage
         );
 
         assert_matches!(runner.validate_unwind(input), Ok(_), "unwind validation");


### PR DESCRIPTION
Followup to https://github.com/paradigmxyz/reth/pull/2982. It was said that `Bodies` and `TotalDifficulty` stages are `reported as a block number, no change`, but due to that we were writing such logs (these logs are for Mainnet):
```console
2023-06-05T22:25:55.038976Z  INFO execute{stage=TotalDifficulty}: sync::pipeline: Stage committed progress stage=TotalDifficulty progress=17416699 checkpoint=17416699 done=true
```
```console
2023-06-05T22:18:04.550509Z  INFO execute{stage=Bodies}: sync::pipeline: Stage committed progress stage=Bodies progress=14750000 checkpoint=14750000 done=false
```

We know the upper bound of the stage in both cases, so we can output `checkpoint` as a progress (these logs are for Sepolia):
```console
2023-06-06T09:22:21.928780Z  INFO execute{stage=TotalDifficulty}: sync::pipeline: Stage committed progress stage=TotalDifficulty progress=3500000 checkpoint=96.3% done=false
```
```console
2023-06-06T09:48:30.270988Z  INFO execute{stage=Bodies}: sync::pipeline: Stage committed progress stage=Bodies progress=3610000 checkpoint=99.3% done=false
```