### PR TITLE
fix(bin): skip first `ConsensusLayerHealthEvents` tick

### DIFF
--- a/bin/reth/src/node/cl_events.rs
+++ b/bin/reth/src/node/cl_events.rs
@@ -7,7 +7,7 @@ use std::{
     task::{ready, Context, Poll},
     time::Duration,
 };
-use tokio::time::Interval;
+use tokio::time::{Instant, Interval};
 
 /// Interval of checking Consensus Layer client health.
 const CHECK_INTERVAL: Duration = Duration::from_secs(300);
@@ -26,11 +26,9 @@ pub struct ConsensusLayerHealthEvents {
 
 impl ConsensusLayerHealthEvents {
     /// Creates a new [ConsensusLayerHealthEvents] with the given canonical chain tracker.
-    pub async fn new(canon_chain: Box<dyn CanonChainTracker>) -> Self {
-        let mut interval = tokio::time::interval(CHECK_INTERVAL);
-        // Skip the first tick that's ready immediately after initialization to prevent the false
-        // `ConsensusLayerHealthEvent::NeverSeen` event.
-        interval.tick().await;
+    pub fn new(canon_chain: Box<dyn CanonChainTracker>) -> Self {
+        // Skip the first tick to prevent the false `ConsensusLayerHealthEvent::NeverSeen` event.
+        let interval = tokio::time::interval_at(Instant::now() + CHECK_INTERVAL, CHECK_INTERVAL);
         Self { interval, canon_chain }
     }
 }

--- a/bin/reth/src/node/cl_events.rs
+++ b/bin/reth/src/node/cl_events.rs
@@ -26,8 +26,12 @@ pub struct ConsensusLayerHealthEvents {
 
 impl ConsensusLayerHealthEvents {
     /// Creates a new [ConsensusLayerHealthEvents] with the given canonical chain tracker.
-    pub fn new(canon_chain: Box<dyn CanonChainTracker>) -> Self {
-        Self { interval: tokio::time::interval(CHECK_INTERVAL), canon_chain }
+    pub async fn new(canon_chain: Box<dyn CanonChainTracker>) -> Self {
+        let mut interval = tokio::time::interval(CHECK_INTERVAL);
+        // Skip the first tick that's ready immediately after initialization to prevent the false
+        // `ConsensusLayerHealthEvent::NeverSeen` event.
+        interval.tick().await;
+        Self { interval, canon_chain }
     }
 }
 

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -355,6 +355,7 @@ impl Command {
             if self.debug.tip.is_none() {
                 Either::Left(
                     ConsensusLayerHealthEvents::new(Box::new(blockchain_db.clone()))
+                        .await
                         .map(Into::into),
                 )
             } else {

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -355,7 +355,6 @@ impl Command {
             if self.debug.tip.is_none() {
                 Either::Left(
                     ConsensusLayerHealthEvents::new(Box::new(blockchain_db.clone()))
-                        .await
                         .map(Into::into),
                 )
             } else {


### PR DESCRIPTION
Skip the first tick that's ready immediately after `ConsensusLayerHealthEvents` initialization to prevent the false `ConsensusLayerHealthEvent::NeverSeen` event fired just after the node startup when it didn't have time to receive any CL updates.

```console
2023-06-06T08:28:17.003028Z  INFO reth::cli: reth 0.1.0 (64cbf522) starting
2023-06-06T08:28:17.003198Z  INFO reth::cli: Configuration loaded path="/home/ubuntu/.local/share/reth/sepolia/reth.toml"
2023-06-06T08:28:17.003215Z  INFO reth::cli: Opening database path="/home/ubuntu/.local/share/reth/sepolia/db"
2023-06-06T08:28:17.003878Z  INFO reth::cli: Database opened
2023-06-06T08:28:17.003889Z  INFO reth::cli: Starting metrics endpoint addr=127.0.0.1:9090
2023-06-06T08:28:17.004789Z  INFO reth::cli: Transaction pool initialized
2023-06-06T08:28:17.004805Z  INFO reth::cli: Connecting to P2P network
2023-06-06T08:28:17.004899Z  INFO net::peers: Loading saved peers file=/home/ubuntu/.local/share/reth/sepolia/known-peers.json
2023-06-06T08:28:17.036878Z  INFO reth::cli: Connected to P2P network peer_id=0xa4a8…c77c local_addr=0.0.0.0:30303
2023-06-06T08:28:17.037014Z  INFO reth::cli: Consensus engine initialized
2023-06-06T08:28:17.037028Z  INFO reth::cli: Engine API handler initialized
2023-06-06T08:28:17.037218Z  INFO reth::cli: RPC auth server started
2023-06-06T08:28:17.037287Z  INFO reth::cli: RPC IPC server started url=/tmp/reth.ipc
2023-06-06T08:28:17.037292Z  INFO reth::cli: RPC HTTP server started url=0.0.0.0:8545
2023-06-06T08:28:17.037297Z  INFO reth::cli: Starting consensus engine
2023-06-06T08:28:17.038210Z  INFO reth::cli: Status connected_peers=0 stage=None checkpoint=0
2023-06-06T08:28:17.038260Z  WARN reth::cli: Post-merge network, but never seen beacon client. Please launch one to follow the chain!
```