### PR TITLE
chore(deps): bump xml-rs to 0.8.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7713,9 +7713,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.4"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+checksum = "52839dc911083a8ef63efa4d039d1f58b5e409f923e44c80828f206f66e5541c"
 
 [[package]]
 name = "xmltree"


### PR DESCRIPTION
fixes dependabot warning: https://github.com/paradigmxyz/reth/security/dependabot/9

xml-rs is pulled in by rust-igd to parse Internet Gateway Device client messages