### PR TITLE
chore: dont set bad-function-cast warning on linux

### DIFF
--- a/crates/storage/libmdbx-rs/mdbx-sys/build.rs
+++ b/crates/storage/libmdbx-rs/mdbx-sys/build.rs
@@ -79,10 +79,10 @@ fn main() {
     mdbx.push("libmdbx");
 
     let mut cc_builder = cc::Build::new();
-    cc_builder
-        .flag_if_supported("-Wno-unused-parameter")
-        .flag_if_supported("-Wbad-function-cast")
-        .flag_if_supported("-Wuninitialized");
+    cc_builder.flag_if_supported("-Wno-unused-parameter").flag_if_supported("-Wuninitialized");
+
+    #[cfg(not(target_os = "linux"))]
+    cc_builder.flag_if_supported("-Wbad-function-cast");
 
     let flags = format!("{:?}", cc_builder.get_compiler().cflags_env());
     cc_builder.define("MDBX_BUILD_FLAGS", flags.as_str()).define("MDBX_TXN_CHECKOWNER", "0");


### PR DESCRIPTION
tbh I don't what this macro does exactly

> warning: /home/runner/work/reth/reth/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.c:2968:40: warning: cast from function call of type ‘void *’ to non-matching type ‘long int’ [-Wbad-function-cast]
warning:  2968 | #define ptr_disp(ptr, disp) ((void *)(((intptr_t)(ptr)) + ((intptr_t)(disp))))

but this should silence the warning that we got since we upgraded

eg: https://github.com/paradigmxyz/reth/actions/runs/5188918491/jobs/9353192004?pr=2987