### PR TITLE
feat: add metrics for active block downloads

### DIFF
--- a/crates/consensus/beacon/src/engine/metrics.rs
+++ b/crates/consensus/beacon/src/engine/metrics.rs
@@ -1,16 +1,24 @@
 use reth_metrics::{
-    metrics::{self, Counter},
+    metrics::{self, Counter, Gauge},
     Metrics,
 };
 
 /// Beacon consensus engine metrics.
 #[derive(Metrics)]
 #[metrics(scope = "consensus.engine.beacon")]
-pub(crate) struct Metrics {
+pub(crate) struct EngineMetrics {
     /// The number of times the pipeline was run.
     pub(crate) pipeline_runs: Counter,
     /// The total count of forkchoice updated messages received.
     pub(crate) forkchoice_updated_messages: Counter,
     /// The total count of new payload messages received.
     pub(crate) new_payload_messages: Counter,
+}
+
+/// Metrics for the `EngineSyncController`.
+#[derive(Metrics)]
+#[metrics(scope = "consensus.engine.beacon")]
+pub(crate) struct EngineSyncMetrics {
+    /// How many blocks are currently being downloaded.
+    pub(crate) active_block_downloads: Gauge,
 }

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    engine::{message::OnForkChoiceUpdated, metrics::Metrics},
+    engine::{message::OnForkChoiceUpdated, metrics::EngineMetrics},
     sync::{EngineSyncController, EngineSyncEvent},
 };
 use futures::{Future, StreamExt, TryFutureExt};
@@ -232,7 +232,7 @@ where
     /// invalid.
     invalid_headers: InvalidHeaderCache,
     /// Consensus engine metrics.
-    metrics: Metrics,
+    metrics: EngineMetrics,
 }
 
 impl<DB, BT, Client> BeaconConsensusEngine<DB, BT, Client>
@@ -318,7 +318,7 @@ where
             payload_builder,
             listeners: EventListeners::default(),
             invalid_headers: InvalidHeaderCache::new(MAX_INVALID_HEADERS),
-            metrics: Metrics::default(),
+            metrics: EngineMetrics::default(),
         };
 
         let maybe_pipeline_target = match target {


### PR DESCRIPTION
adds a new metric to monitor how many individual block requests are active