### PR TITLE
fix(storage): invalid stage checkpoints on unwind

### DIFF
--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -504,7 +504,7 @@ where
         self.calculate_history_indices(first_number..=last_block_number)?;
 
         // Update pipeline progress
-        self.update_pipeline_stages(new_tip_number)?;
+        self.update_pipeline_stages(new_tip_number, false)?;
 
         Ok(())
     }
@@ -1002,7 +1002,7 @@ where
 
             // Update pipeline progress
             if let Some(fork_number) = unwind_to {
-                self.update_pipeline_stages(fork_number)?;
+                self.update_pipeline_stages(fork_number, true)?;
             }
         }
 
@@ -1014,12 +1014,18 @@ where
     pub fn update_pipeline_stages(
         &self,
         block_number: BlockNumber,
+        drop_stage_checkpoint: bool,
     ) -> Result<(), TransactionError> {
         // iterate over all existing stages in the table and update its progress.
         let mut cursor = self.cursor_write::<tables::SyncStage>()?;
         while let Some((stage_name, checkpoint)) = cursor.next()? {
-            // TODO(alexey): do we want to invalidate stage-specific checkpoint data?
-            cursor.upsert(stage_name, StageCheckpoint { block_number, ..checkpoint })?
+            cursor.upsert(
+                stage_name,
+                StageCheckpoint {
+                    block_number,
+                    ..if drop_stage_checkpoint { Default::default() } else { checkpoint }
+                },
+            )?
         }
 
         Ok(())

--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -504,7 +504,7 @@ where
         self.calculate_history_indices(first_number..=last_block_number)?;
 
         // Update pipeline progress
-        self.update_pipeline_stages::<false>(new_tip_number)?;
+        self.update_pipeline_stages(new_tip_number, false)?;
 
         Ok(())
     }
@@ -1002,7 +1002,7 @@ where
 
             // Update pipeline progress
             if let Some(fork_number) = unwind_to {
-                self.update_pipeline_stages::<TAKE>(fork_number)?;
+                self.update_pipeline_stages(fork_number, true)?;
             }
         }
 
@@ -1011,9 +1011,10 @@ where
     }
 
     /// Update all pipeline sync stage progress.
-    pub fn update_pipeline_stages<const DROP_STAGE_CHECKPOINT: bool>(
+    pub fn update_pipeline_stages(
         &self,
         block_number: BlockNumber,
+        drop_stage_checkpoint: bool,
     ) -> Result<(), TransactionError> {
         // iterate over all existing stages in the table and update its progress.
         let mut cursor = self.cursor_write::<tables::SyncStage>()?;
@@ -1022,7 +1023,7 @@ where
                 stage_name,
                 StageCheckpoint {
                     block_number,
-                    ..if DROP_STAGE_CHECKPOINT { Default::default() } else { checkpoint }
+                    ..if drop_stage_checkpoint { Default::default() } else { checkpoint }
                 },
             )?
         }

--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -504,7 +504,7 @@ where
         self.calculate_history_indices(first_number..=last_block_number)?;
 
         // Update pipeline progress
-        self.update_pipeline_stages(new_tip_number, false)?;
+        self.update_pipeline_stages::<false>(new_tip_number)?;
 
         Ok(())
     }
@@ -1002,7 +1002,7 @@ where
 
             // Update pipeline progress
             if let Some(fork_number) = unwind_to {
-                self.update_pipeline_stages(fork_number, true)?;
+                self.update_pipeline_stages::<TAKE>(fork_number)?;
             }
         }
 
@@ -1011,10 +1011,9 @@ where
     }
 
     /// Update all pipeline sync stage progress.
-    pub fn update_pipeline_stages(
+    pub fn update_pipeline_stages<const DROP_STAGE_CHECKPOINT: bool>(
         &self,
         block_number: BlockNumber,
-        drop_stage_checkpoint: bool,
     ) -> Result<(), TransactionError> {
         // iterate over all existing stages in the table and update its progress.
         let mut cursor = self.cursor_write::<tables::SyncStage>()?;
@@ -1023,7 +1022,7 @@ where
                 stage_name,
                 StageCheckpoint {
                     block_number,
-                    ..if drop_stage_checkpoint { Default::default() } else { checkpoint }
+                    ..if DROP_STAGE_CHECKPOINT { Default::default() } else { checkpoint }
                 },
             )?
         }


### PR DESCRIPTION
`reth stage unwind` CLI uses `take_block_and_execution_range` which doesn't invalidate stage-specific checkpoints. This can lead to a situation with diverged block number and `EntitiesCheckpoint` in Headers stage. I believe, same will happen during the reorg.

Since all of our stages can recover the checkpoint progress from block number when it's missing, we can drop the stage-specific checkpoint in case of `take_block_and_execution_range`, and do nothing in case of `append_blocks_with_post_state`.