### PR TITLE
perf: only set fields if enabled

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/builder/geth.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/geth.rs
@@ -46,7 +46,7 @@ impl GethTraceBuilder {
         while let Some(CallTraceStepStackItem { trace_node, step, call_child_id }) =
             step_stack.pop_back()
         {
-            let mut log: StructLog = step.into();
+            let mut log = step.convert_to_geth_struct_log(opts);
 
             // Fill in memory and storage depending on the options
             if !opts.disable_storage.unwrap_or_default() {
@@ -55,13 +55,6 @@ impl GethTraceBuilder {
                     contract_storage.insert(change.key.into(), change.value.into());
                     log.storage = Some(contract_storage.clone());
                 }
-            }
-            if opts.disable_stack.unwrap_or_default() {
-                log.stack = None;
-            }
-
-            if !opts.enable_memory.unwrap_or_default() {
-                log.memory = None;
             }
 
             if opts.enable_return_data.unwrap_or_default() {

--- a/crates/rpc/rpc-types/src/eth/trace/geth/mod.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/geth/mod.rs
@@ -316,6 +316,28 @@ pub struct GethDefaultTracingOptions {
     pub limit: Option<u64>,
 }
 
+impl GethDefaultTracingOptions {
+    /// Returns `true` if return data capture is enabled
+    pub fn is_return_data_enabled(&self) -> bool {
+        self.enable_return_data.unwrap_or(false)
+    }
+
+    /// Returns `true` if memory capture is enabled
+    pub fn is_memory_enabled(&self) -> bool {
+        self.enable_memory.unwrap_or(false)
+    }
+
+    /// Returns `true` if stack capture is enabled
+    pub fn is_stack_enabled(&self) -> bool {
+        !self.disable_stack.unwrap_or(false)
+    }
+
+    /// Returns `true` if storage capture is enabled
+    pub fn is_storage_enabled(&self) -> bool {
+        !self.disable_storage.unwrap_or(false)
+    }
+}
+
 /// Bindings for additional `debug_traceCall` options
 ///
 /// See <https://geth.ethereum.org/docs/rpc/ns-debug#debug_tracecall>


### PR DESCRIPTION
only initialize StructLog fields if the given options require it.

This also removes `memory_size` from the RPC response, perhaps the fields should even be removed because it doesn't look like it's part of the rpc response for `StructLogRes`