### PR TITLE
fix(autoseal): use higher difficulty and fix root calc

### DIFF
--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -694,8 +694,6 @@ impl Command {
                         max_changesets: stage_conf.execution.max_changesets,
                     },
                 ))
-                .disable_if(StageId::MerkleUnwind, || self.auto_mine)
-                .disable_if(StageId::MerkleExecute, || self.auto_mine),
             )
             .build(db);
 

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -693,7 +693,7 @@ impl Command {
                         max_changes: stage_conf.execution.max_changes,
                         max_changesets: stage_conf.execution.max_changesets,
                     },
-                ))
+                )),
             )
             .build(db);
 

--- a/crates/consensus/auto-seal/src/task.rs
+++ b/crates/consensus/auto-seal/src/task.rs
@@ -183,7 +183,9 @@ where
                     match executor.execute_transactions(&block, U256::ZERO, Some(senders.clone())) {
                         Ok((post_state, gas_used)) => {
                             // apply post block changes
-                            let post_state = executor.apply_post_block_changes(&block, U256::ZERO, post_state).unwrap();
+                            let post_state = executor
+                                .apply_post_block_changes(&block, U256::ZERO, post_state)
+                                .unwrap();
 
                             let Block { mut header, body, .. } = block;
 

--- a/crates/consensus/auto-seal/src/task.rs
+++ b/crates/consensus/auto-seal/src/task.rs
@@ -140,7 +140,7 @@ where
                         receipts_root: Default::default(),
                         withdrawals_root: None,
                         logs_bloom: Default::default(),
-                        difficulty: U256::from(1),
+                        difficulty: U256::from(2),
                         number: storage.best_block + 1,
                         gas_limit: 30_000_000,
                         gas_used: 0,

--- a/crates/consensus/auto-seal/src/task.rs
+++ b/crates/consensus/auto-seal/src/task.rs
@@ -182,6 +182,9 @@ where
 
                     match executor.execute_transactions(&block, U256::ZERO, Some(senders.clone())) {
                         Ok((post_state, gas_used)) => {
+                            // apply post block changes
+                            let post_state = executor.apply_post_block_changes(&block, U256::ZERO, post_state).unwrap();
+
                             let Block { mut header, body, .. } = block;
 
                             // clear all transactions from pool
@@ -202,10 +205,14 @@ where
                                 BlockBody { transactions: body, ommers: vec![], withdrawals: None };
                             header.gas_used = gas_used;
 
+                            trace!(target: "consensus::auto", ?post_state, ?header, ?body, "executed block, calculating root");
+
                             // calculate the state root
                             let state_root =
                                 executor.db().db.0.state_root(post_state.clone()).unwrap();
                             header.state_root = state_root;
+
+                            trace!(target: "consensus::auto", root=?header.state_root, ?body, "calculated root");
 
                             storage.insert_new_block(header.clone(), body);
 

--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -271,6 +271,22 @@ where
 
         Ok((post_state, cumulative_gas_used))
     }
+
+    /// Applies the post-block changes, assuming the poststate is generated after executing
+    /// tranactions
+    pub fn apply_post_block_changes(&mut self, block: &Block, total_difficulty: U256, mut post_state: PostState) -> Result<PostState, BlockExecutionError> {
+        // Add block rewards
+        let balance_increments = self.post_block_balance_increments(block, total_difficulty);
+        for (address, increment) in balance_increments.into_iter() {
+            self.increment_account_balance(block.number, address, increment, &mut post_state)?;
+        }
+
+        // Perform DAO irregular state change
+        if self.chain_spec.fork(Hardfork::Dao).transitions_at_block(block.number) {
+            self.apply_dao_fork_changes(block.number, &mut post_state)?;
+        }
+        Ok(post_state)
+    }
 }
 
 impl<DB> BlockExecutor<DB> for Executor<DB>
@@ -283,7 +299,7 @@ where
         total_difficulty: U256,
         senders: Option<Vec<Address>>,
     ) -> Result<PostState, BlockExecutionError> {
-        let (mut post_state, cumulative_gas_used) =
+        let (post_state, cumulative_gas_used) =
             self.execute_transactions(block, total_difficulty, senders)?;
 
         // Check if gas used matches the value set in header.
@@ -295,17 +311,7 @@ where
             .into())
         }
 
-        // Add block rewards
-        let balance_increments = self.post_block_balance_increments(block, total_difficulty);
-        for (address, increment) in balance_increments.into_iter() {
-            self.increment_account_balance(block.number, address, increment, &mut post_state)?;
-        }
-
-        // Perform DAO irregular state change
-        if self.chain_spec.fork(Hardfork::Dao).transitions_at_block(block.number) {
-            self.apply_dao_fork_changes(block.number, &mut post_state)?;
-        }
-        Ok(post_state)
+        self.apply_post_block_changes(block, total_difficulty, post_state)
     }
 
     fn execute_and_verify_receipt(

--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -274,7 +274,12 @@ where
 
     /// Applies the post-block changes, assuming the poststate is generated after executing
     /// tranactions
-    pub fn apply_post_block_changes(&mut self, block: &Block, total_difficulty: U256, mut post_state: PostState) -> Result<PostState, BlockExecutionError> {
+    pub fn apply_post_block_changes(
+        &mut self,
+        block: &Block,
+        total_difficulty: U256,
+        mut post_state: PostState,
+    ) -> Result<PostState, BlockExecutionError> {
         // Add block rewards
         let balance_increments = self.post_block_balance_increments(block, total_difficulty);
         for (address, increment) in balance_increments.into_iter() {


### PR DESCRIPTION
First, this bumps the difficulty of autoseal-generated blocks to `2`, to ensure that hive tests which enable autoseal reach TTD on the first block generated, which is the only block that is executed through the pipeline.

We had disabled the merkle stages when autoseal was enabled because merkle stages were not compatible at the time. This caused incorrect root calculation in autoseal to go unnoticed.

This arised in the `Pre-TTD ForkchoiceUpdated After PoS Switch` test, when making a `getPayload` / `newPayload`-generated sidechain block canonical. Making the sidechain block canonical resulted in a state root mismatch, showing up as `CanonicalRevert`.

Previously, we were not applying post-block changes after executing transactions, which is why the state root mismatch occurred. This creates a helper method on the executor for applying post-block changes, and uses it in the auto seal engine.

Fixes #2956