### PR TITLE
feat(stages): remove changeset commit threshold in Execution

### DIFF
--- a/bin/reth/src/chain/import.rs
+++ b/bin/reth/src/chain/import.rs
@@ -174,7 +174,6 @@ impl ImportCommand {
                     ExecutionStageThresholds {
                         max_blocks: config.stages.execution.max_blocks,
                         max_changes: config.stages.execution.max_changes,
-                        max_changesets: config.stages.execution.max_changesets,
                     },
                 )),
             )

--- a/bin/reth/src/debug_cmd/execution.rs
+++ b/bin/reth/src/debug_cmd/execution.rs
@@ -143,11 +143,7 @@ impl Command {
                 })
                 .set(ExecutionStage::new(
                     factory,
-                    ExecutionStageThresholds {
-                        max_blocks: None,
-                        max_changes: None,
-                        max_changesets: None,
-                    },
+                    ExecutionStageThresholds { max_blocks: None, max_changes: None },
                 )),
             )
             .build(db);

--- a/bin/reth/src/debug_cmd/merkle.rs
+++ b/bin/reth/src/debug_cmd/merkle.rs
@@ -91,11 +91,7 @@ impl Command {
         let factory = reth_revm::Factory::new(self.chain.clone());
         let mut execution_stage = ExecutionStage::new(
             factory,
-            ExecutionStageThresholds {
-                max_blocks: Some(1),
-                max_changes: None,
-                max_changesets: None,
-            },
+            ExecutionStageThresholds { max_blocks: Some(1), max_changes: None },
         );
 
         let mut account_hashing_stage = AccountHashingStage::default();

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -691,7 +691,6 @@ impl Command {
                     ExecutionStageThresholds {
                         max_blocks: stage_conf.execution.max_blocks,
                         max_changes: stage_conf.execution.max_changes,
-                        max_changesets: stage_conf.execution.max_changesets,
                     },
                 ))
                 .disable_if(StageId::MerkleUnwind, || self.auto_mine)

--- a/bin/reth/src/stage/dump/merkle.rs
+++ b/bin/reth/src/stage/dump/merkle.rs
@@ -71,11 +71,7 @@ async fn unwind_and_copy<DB: Database>(
     // Bring Plainstate to TO (hashing stage execution requires it)
     let mut exec_stage = ExecutionStage::new(
         reth_revm::Factory::new(Arc::new(MAINNET.clone())),
-        ExecutionStageThresholds {
-            max_blocks: Some(u64::MAX),
-            max_changes: None,
-            max_changesets: None,
-        },
+        ExecutionStageThresholds { max_blocks: Some(u64::MAX), max_changes: None },
     );
 
     exec_stage

--- a/bin/reth/src/stage/run.rs
+++ b/bin/reth/src/stage/run.rs
@@ -190,7 +190,6 @@ impl Command {
                             ExecutionStageThresholds {
                                 max_blocks: Some(batch_size),
                                 max_changes: None,
-                                max_changesets: None,
                             },
                         )),
                         None,

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -196,21 +196,11 @@ pub struct ExecutionConfig {
     pub max_blocks: Option<u64>,
     /// The maximum amount of state changes to keep in memory before the execution stage commits.
     pub max_changes: Option<u64>,
-    /// The maximum amount of changesets to keep in memory before they are written to the pending
-    /// database transaction.
-    ///
-    /// If this is lower than `max_gas`, then history is periodically flushed to the database
-    /// transaction, which frees up memory.
-    pub max_changesets: Option<u64>,
 }
 
 impl Default for ExecutionConfig {
     fn default() -> Self {
-        Self {
-            max_blocks: Some(500_000),
-            max_changes: Some(5_000_000),
-            max_changesets: Some(1_000_000),
-        }
+        Self { max_blocks: Some(500_000), max_changes: Some(5_000_000) }
     }
 }
 

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -176,13 +176,13 @@ impl<EF: ExecutorFactory> ExecutionStage<EF> {
             stage_progress = block_number;
             stage_checkpoint.progress.processed += block.gas_used;
 
-            // Write history periodically to free up memory
-            if self.thresholds.should_write_history(state.changeset_size_hint() as u64) {
-                info!(target: "sync::stages::execution", ?block_number, "Writing history.");
-                state.write_history_to_db(&**tx)?;
-                info!(target: "sync::stages::execution", ?block_number, "Wrote history.");
-                // gas_since_history_write = 0;
-            }
+            // // Write history periodically to free up memory
+            // if self.thresholds.should_write_history(state.changeset_size_hint() as u64) {
+            //     info!(target: "sync::stages::execution", ?block_number, "Writing history.");
+            //     state.write_history_to_db(&**tx)?;
+            //     info!(target: "sync::stages::execution", ?block_number, "Wrote history.");
+            //     // gas_since_history_write = 0;
+            // }
 
             // Check if we should commit now
             if self.thresholds.is_end_of_batch(block_number - start_block, state.size_hint() as u64)

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -176,14 +176,6 @@ impl<EF: ExecutorFactory> ExecutionStage<EF> {
             stage_progress = block_number;
             stage_checkpoint.progress.processed += block.gas_used;
 
-            // // Write history periodically to free up memory
-            // if self.thresholds.should_write_history(state.changeset_size_hint() as u64) {
-            //     info!(target: "sync::stages::execution", ?block_number, "Writing history.");
-            //     state.write_history_to_db(&**tx)?;
-            //     info!(target: "sync::stages::execution", ?block_number, "Wrote history.");
-            //     // gas_since_history_write = 0;
-            // }
-
             // Check if we should commit now
             if self.thresholds.is_end_of_batch(block_number - start_block, state.size_hint() as u64)
             {
@@ -431,30 +423,17 @@ impl<EF: ExecutorFactory, DB: Database> Stage<DB> for ExecutionStage<EF> {
 ///
 /// If either of the thresholds (`max_blocks` and `max_changes`) are hit, then the execution stage
 /// commits all pending changes to the database.
-///
-/// A third threshold, `max_changesets`, can be set to periodically write changesets to the
-/// current database transaction, which frees up memory.
 #[derive(Debug)]
 pub struct ExecutionStageThresholds {
     /// The maximum number of blocks to process before the execution stage commits.
     pub max_blocks: Option<u64>,
     /// The maximum amount of state changes to keep in memory before the execution stage commits.
     pub max_changes: Option<u64>,
-    /// The maximum amount of changesets to keep in memory before they are written to the pending
-    /// database transaction.
-    ///
-    /// If this is lower than `max_changes`, then history is periodically flushed to the database
-    /// transaction, which frees up memory.
-    pub max_changesets: Option<u64>,
 }
 
 impl Default for ExecutionStageThresholds {
     fn default() -> Self {
-        Self {
-            max_blocks: Some(500_000),
-            max_changes: Some(5_000_000),
-            max_changesets: Some(1_000_000),
-        }
+        Self { max_blocks: Some(500_000), max_changes: Some(5_000_000) }
     }
 }
 
@@ -464,12 +443,6 @@ impl ExecutionStageThresholds {
     pub fn is_end_of_batch(&self, blocks_processed: u64, changes_processed: u64) -> bool {
         blocks_processed >= self.max_blocks.unwrap_or(u64::MAX) ||
             changes_processed >= self.max_changes.unwrap_or(u64::MAX)
-    }
-
-    /// Check if the history write threshold has been hit.
-    #[inline]
-    pub fn should_write_history(&self, history_changes: u64) -> bool {
-        history_changes >= self.max_changesets.unwrap_or(u64::MAX)
     }
 }
 
@@ -499,11 +472,7 @@ mod tests {
             Factory::new(Arc::new(ChainSpecBuilder::mainnet().berlin_activated().build()));
         ExecutionStage::new(
             factory,
-            ExecutionStageThresholds {
-                max_blocks: Some(100),
-                max_changes: None,
-                max_changesets: None,
-            },
+            ExecutionStageThresholds { max_blocks: Some(100), max_changes: None },
         )
     }
 


### PR DESCRIPTION
Due to the current Execution stage commit threshold logic, commits are infrequent and stage metric chart is jumping a lot of blocks at once. I synced Sepolia on 8ffcb3124de0c9e8821ef6213aef90e3b748ebf2:

<img width="1564" alt="image" src="https://github.com/paradigmxyz/reth/assets/5773434/30c4999d-7b3e-40c2-8a20-6fc8dd31fb3c">

---

What if we remove the changeset-based threshold completely and start relying only on number of blocks and changes (accounts + storage + bytecode + receipts + changesets) processed? I synced Sepolia with these changes again, and it improved two things:
1. Commits are more frequent now which is good because we have prettier metrics and lose less progress when node restarts
2. Memory usage peaks at 7.5GB instead of 18GB

<img width="1562" alt="image" src="https://github.com/paradigmxyz/reth/assets/5773434/65c2372a-50fc-4654-bb3a-03e35a661749">


The time it took in both cases was the same – around 1 hour 40 minutes.

