### PR TITLE
fix(bin): CL health events conditions

### DIFF
--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -237,6 +237,8 @@ where
             })
         }
 
+        self.beacon_consensus.transition_configuration_exchanged().await;
+
         // Short circuit if communicated block hash is zero
         if terminal_block_hash.is_zero() {
             return Ok(TransitionConfiguration {
@@ -250,8 +252,6 @@ where
             .client
             .block_hash(terminal_block_number.as_u64())
             .map_err(|err| EngineApiError::Internal(Box::new(err)))?;
-
-        self.beacon_consensus.transition_configuration_exchanged().await;
 
         // Transition configuration exchange is successful if block hashes match
         match local_hash {
@@ -310,14 +310,14 @@ where
     /// See also <https://github.com/ethereum/execution-apis/blob/3d627c95a4d3510a8187dd02e0250ecb4331d27e/src/engine/paris.md#engine_newpayloadv1>
     /// Caution: This should not accept the `withdrawals` field
     async fn new_payload_v1(&self, payload: ExecutionPayload) -> RpcResult<PayloadStatus> {
-        trace!(target: "rpc::eth", "Serving engine_newPayloadV1");
+        trace!(target: "rpc::engine", "Serving engine_newPayloadV1");
         Ok(EngineApi::new_payload_v1(self, payload).await?)
     }
 
     /// Handler for `engine_newPayloadV1`
     /// See also <https://github.com/ethereum/execution-apis/blob/3d627c95a4d3510a8187dd02e0250ecb4331d27e/src/engine/shanghai.md#engine_newpayloadv2>
     async fn new_payload_v2(&self, payload: ExecutionPayload) -> RpcResult<PayloadStatus> {
-        trace!(target: "rpc::eth", "Serving engine_newPayloadV1");
+        trace!(target: "rpc::engine", "Serving engine_newPayloadV1");
         Ok(EngineApi::new_payload_v2(self, payload).await?)
     }
 
@@ -330,7 +330,7 @@ where
         fork_choice_state: ForkchoiceState,
         payload_attributes: Option<PayloadAttributes>,
     ) -> RpcResult<ForkchoiceUpdated> {
-        trace!(target: "rpc::eth", "Serving engine_forkchoiceUpdatedV1");
+        trace!(target: "rpc::engine", "Serving engine_forkchoiceUpdatedV1");
         Ok(EngineApi::fork_choice_updated_v1(self, fork_choice_state, payload_attributes).await?)
     }
 
@@ -341,7 +341,7 @@ where
         fork_choice_state: ForkchoiceState,
         payload_attributes: Option<PayloadAttributes>,
     ) -> RpcResult<ForkchoiceUpdated> {
-        trace!(target: "rpc::eth", "Serving engine_forkchoiceUpdatedV2");
+        trace!(target: "rpc::engine", "Serving engine_forkchoiceUpdatedV2");
         Ok(EngineApi::fork_choice_updated_v2(self, fork_choice_state, payload_attributes).await?)
     }
 
@@ -357,7 +357,7 @@ where
     /// Note:
     /// > Client software MAY stop the corresponding build process after serving this call.
     async fn get_payload_v1(&self, payload_id: PayloadId) -> RpcResult<ExecutionPayload> {
-        trace!(target: "rpc::eth", "Serving engine_getPayloadV1");
+        trace!(target: "rpc::engine", "Serving engine_getPayloadV1");
         Ok(EngineApi::get_payload_v1(self, payload_id).await?)
     }
 
@@ -371,7 +371,7 @@ where
     /// Note:
     /// > Client software MAY stop the corresponding build process after serving this call.
     async fn get_payload_v2(&self, payload_id: PayloadId) -> RpcResult<ExecutionPayloadEnvelope> {
-        trace!(target: "rpc::eth", "Serving engine_getPayloadV2");
+        trace!(target: "rpc::engine", "Serving engine_getPayloadV2");
         Ok(EngineApi::get_payload_v2(self, payload_id).await?)
     }
 
@@ -381,7 +381,7 @@ where
         &self,
         block_hashes: Vec<BlockHash>,
     ) -> RpcResult<ExecutionPayloadBodies> {
-        trace!(target: "rpc::eth", "Serving engine_getPayloadBodiesByHashV1");
+        trace!(target: "rpc::engine", "Serving engine_getPayloadBodiesByHashV1");
         Ok(EngineApi::get_payload_bodies_by_hash(self, block_hashes)?)
     }
 
@@ -403,7 +403,7 @@ where
         start: U64,
         count: U64,
     ) -> RpcResult<ExecutionPayloadBodies> {
-        trace!(target: "rpc::eth", "Serving engine_getPayloadBodiesByHashV1");
+        trace!(target: "rpc::engine", "Serving engine_getPayloadBodiesByRangeV1");
         Ok(EngineApi::get_payload_bodies_by_range(self, start.as_u64(), count.as_u64())?)
     }
 
@@ -413,7 +413,7 @@ where
         &self,
         config: TransitionConfiguration,
     ) -> RpcResult<TransitionConfiguration> {
-        trace!(target: "rpc::eth", "Serving engine_getPayloadBodiesByHashV1");
+        trace!(target: "rpc::engine", "Serving engine_exchangeTransitionConfigurationV1");
         Ok(EngineApi::exchange_transition_configuration(self, config).await?)
     }
 


### PR DESCRIPTION
Resolves https://github.com/paradigmxyz/reth/issues/3046

Happened due to short circuiting here https://github.com/paradigmxyz/reth/blob/99a314c59bbd94a34a285369da95fb5604883c65/crates/rpc/rpc-engine-api/src/engine_api.rs#L240-L246 while `transition_configuration_exchanged()` reporting happened later https://github.com/paradigmxyz/reth/blob/99a314c59bbd94a34a285369da95fb5604883c65/crates/rpc/rpc-engine-api/src/engine_api.rs#L254

This short circuit happened on all networks because
> If `TERMINAL_BLOCK_HASH` is stubbed with `0x0000000000000000000000000000000000000000000000000000000000000000` then `TERMINAL_BLOCK_HASH` and `TERMINAL_BLOCK_NUMBER` parameters **MUST NOT** take an effect.

and Lighthouse does exactly that: https://github.com/sigp/lighthouse/blob/c547a11b0da48db6fdd03bca2c6ce2448bbcc3a9/common/eth2_network_config/built_in_network_configs/mainnet/config.yaml#L12

---

Also, this PR short circuits any CL health event checks if we recently received an FCU: https://github.com/paradigmxyz/reth/blob/2c2a4c0838c5a5a658cf3212fb2a7aafc02a2d9c/bin/reth/src/node/cl_events.rs#L49-L54
same as geth does: https://github.com/ethereum/go-ethereum/blob/73697529994e14996b7740730481e926d5ec3e40/eth/catalyst/api.go#L690