### PR TITLE
chore: clarify gas field

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/mod.rs
+++ b/crates/revm/revm-inspectors/src/tracing/mod.rs
@@ -189,7 +189,7 @@ impl TracingInspector {
             stack,
             memory,
             memory_size: interp.memory.len(),
-            gas: self.gas_inspector.gas_remaining(),
+            gas_remaining: self.gas_inspector.gas_remaining(),
             gas_refund_counter: interp.gas.refunded() as u64,
 
             // fields will be populated end of call
@@ -247,7 +247,8 @@ impl TracingInspector {
                 };
             }
 
-            step.gas_cost = step.gas - self.gas_inspector.gas_remaining();
+            // The gas cost is the difference between the recorded gas remaining at the start of the step the remaining gas here, at the end of the step.
+            step.gas_cost = step.gas_remaining - self.gas_inspector.gas_remaining();
         }
 
         // set the status

--- a/crates/revm/revm-inspectors/src/tracing/mod.rs
+++ b/crates/revm/revm-inspectors/src/tracing/mod.rs
@@ -247,7 +247,8 @@ impl TracingInspector {
                 };
             }
 
-            // The gas cost is the difference between the recorded gas remaining at the start of the step the remaining gas here, at the end of the step.
+            // The gas cost is the difference between the recorded gas remaining at the start of the
+            // step the remaining gas here, at the end of the step.
             step.gas_cost = step.gas_remaining - self.gas_inspector.gas_remaining();
         }
 

--- a/crates/revm/revm-inspectors/src/tracing/types.rs
+++ b/crates/revm/revm-inspectors/src/tracing/types.rs
@@ -452,7 +452,7 @@ pub(crate) struct CallTraceStep {
     /// Size of memory
     pub(crate) memory_size: usize,
     /// Remaining gas before step execution
-    pub(crate) gas: u64,
+    pub(crate) gas_remaining: u64,
     /// Gas refund counter before step execution
     pub(crate) gas_refund_counter: u64,
     // Fields filled in `step_end`
@@ -474,7 +474,7 @@ impl CallTraceStep {
         let mut log = StructLog {
             depth: self.depth,
             error: self.as_error(),
-            gas: self.gas,
+            gas: self.gas_remaining,
             gas_cost: self.gas_cost,
             op: self.op.to_string(),
             pc: self.pc as u64,


### PR DESCRIPTION
a field named `gas` is very ambiguous, renamed for more clarity.