### PR TITLE
feat: run pipeline only if missing range is large

### DIFF
--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -15,7 +15,7 @@ use fdlimit::raise_fd_limit;
 use futures::{future::Either, pin_mut, stream, stream_select, StreamExt};
 use reth_auto_seal_consensus::{AutoSealBuilder, AutoSealConsensus};
 use reth_basic_payload_builder::{BasicPayloadJobGenerator, BasicPayloadJobGeneratorConfig};
-use reth_beacon_consensus::{BeaconConsensus, BeaconConsensusEngine};
+use reth_beacon_consensus::{BeaconConsensus, BeaconConsensusEngine, MIN_BLOCKS_FOR_PIPELINE_RUN};
 use reth_blockchain_tree::{
     config::BlockchainTreeConfig, externals::TreeExternals, BlockchainTree, ShareableBlockchainTree,
 };
@@ -341,6 +341,7 @@ impl Command {
             self.debug.continuous,
             payload_builder.clone(),
             initial_target,
+            MIN_BLOCKS_FOR_PIPELINE_RUN,
             consensus_engine_tx,
             consensus_engine_rx,
         )?;

--- a/crates/consensus/beacon/src/engine/forkchoice.rs
+++ b/crates/consensus/beacon/src/engine/forkchoice.rs
@@ -54,11 +54,6 @@ impl ForkchoiceStateTracker {
         self.last_valid.as_ref().map(|s| s.head_block_hash)
     }
 
-    /// Returns the last valid finalized hash.
-    pub(crate) fn last_valid_finalized(&self) -> Option<H256> {
-        self.last_valid.as_ref().map(|s| s.finalized_block_hash)
-    }
-
     /// Returns the head hash of the latest received FCU to which we need to sync.
     #[allow(unused)]
     pub(crate) fn sync_target(&self) -> Option<H256> {

--- a/crates/consensus/beacon/src/engine/forkchoice.rs
+++ b/crates/consensus/beacon/src/engine/forkchoice.rs
@@ -54,6 +54,11 @@ impl ForkchoiceStateTracker {
         self.last_valid.as_ref().map(|s| s.head_block_hash)
     }
 
+    /// Returns the last valid finalized hash.
+    pub(crate) fn last_valid_finalized(&self) -> Option<H256> {
+        self.last_valid.as_ref().map(|s| s.finalized_block_hash)
+    }
+
     /// Returns the head hash of the latest received FCU to which we need to sync.
     #[allow(unused)]
     pub(crate) fn sync_target(&self) -> Option<H256> {

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -66,7 +66,7 @@ use reth_interfaces::blockchain_tree::InsertPayloadOk;
 const MAX_INVALID_HEADERS: u32 = 512u32;
 
 /// The largest gap for which the tree will be used for sync.
-const MIN_BLOCKS_FOR_PIPELINE_RUN: u64 = 128;
+pub const MIN_BLOCKS_FOR_PIPELINE_RUN: u64 = 128;
 
 /// A _shareable_ beacon consensus frontend. Used to interact with the spawned beacon consensus
 /// engine.
@@ -237,6 +237,8 @@ where
     invalid_headers: InvalidHeaderCache,
     /// Consensus engine metrics.
     metrics: EngineMetrics,
+    /// The largest gap for which the tree will be used to download and execute ranges of blocks.
+    pipeline_run_threshold: u64,
 }
 
 impl<DB, BT, Client> BeaconConsensusEngine<DB, BT, Client>
@@ -257,6 +259,7 @@ where
         run_pipeline_continuously: bool,
         payload_builder: PayloadBuilderHandle,
         target: Option<H256>,
+        pipeline_run_threshold: u64,
     ) -> Result<(Self, BeaconConsensusEngineHandle), reth_interfaces::Error> {
         let (to_engine, rx) = mpsc::unbounded_channel();
         Self::with_channel(
@@ -269,6 +272,7 @@ where
             run_pipeline_continuously,
             payload_builder,
             target,
+            pipeline_run_threshold,
             to_engine,
             rx,
         )
@@ -297,6 +301,7 @@ where
         run_pipeline_continuously: bool,
         payload_builder: PayloadBuilderHandle,
         target: Option<H256>,
+        pipeline_run_threshold: u64,
         to_engine: UnboundedSender<BeaconEngineMessage>,
         rx: UnboundedReceiver<BeaconEngineMessage>,
     ) -> Result<(Self, BeaconConsensusEngineHandle), reth_interfaces::Error> {
@@ -319,6 +324,7 @@ where
             listeners: EventListeners::default(),
             invalid_headers: InvalidHeaderCache::new(MAX_INVALID_HEADERS),
             metrics: EngineMetrics::default(),
+            pipeline_run_threshold,
         };
 
         let maybe_pipeline_target = match target {
@@ -681,7 +687,7 @@ where
 
         // we assume the FCU is valid and at least the head is missing, so we need to start syncing
         // to it
-        if self.forkchoice_state_tracker.is_empty() {
+        let target = if self.forkchoice_state_tracker.is_empty() {
             // find the appropriate target to sync to, if we don't have the safe block hash then we
             // start syncing to the safe block via pipeline first
             let target = if !state.safe_block_hash.is_zero() &&
@@ -695,16 +701,23 @@ where
             // we need to first check the buffer for the head and its ancestors
             let lowest_unknown_hash = self.lowest_buffered_ancestor_or(target);
             trace!(target: "consensus::engine", request=?lowest_unknown_hash, "Triggering full block download for missing ancestors of the new head");
-
-            self.sync.download_full_block(lowest_unknown_hash);
+            lowest_unknown_hash
         } else {
             // we need to first check the buffer for the head and its ancestors
             let lowest_unknown_hash = self.lowest_buffered_ancestor_or(state.head_block_hash);
             trace!(target: "consensus::engine", request=?lowest_unknown_hash, "Triggering full block download for missing ancestors of the new head");
+            lowest_unknown_hash
+        };
 
+        // if the threshold is zero, we should not download the block first, and just use the
+        // pipeline. Otherwise we use the tree to insert the block first
+        if self.pipeline_run_threshold == 0 {
+            // use the pipeline to sync to the target
+            self.sync.set_pipeline_sync_target(target);
+        } else {
             // trigger a full block download for missing hash, or the parent of its lowest buffered
             // ancestor
-            self.sync.download_full_block(lowest_unknown_hash);
+            self.sync.download_full_block(target);
         }
 
         PayloadStatus::from_status(PayloadStatusEnum::Syncing)
@@ -1030,7 +1043,7 @@ where
                         // pipeline
                         let head = self.blockchain.canonical_tip();
                         if missing_parent.number >= head.number &&
-                            missing_parent.number - head.number > MIN_BLOCKS_FOR_PIPELINE_RUN
+                            missing_parent.number - head.number > self.pipeline_run_threshold
                         {
                             self.sync.set_pipeline_sync_target(missing_parent.hash)
                         } else {
@@ -1439,52 +1452,109 @@ mod tests {
         }
     }
 
-    fn setup_consensus_engine(
+    struct TestConsensusEngineBuilder {
         chain_spec: Arc<ChainSpec>,
         pipeline_exec_outputs: VecDeque<Result<ExecOutput, StageError>>,
         executor_results: Vec<PostState>,
-    ) -> (TestBeaconConsensusEngine, TestEnv<Arc<Env<WriteMap>>>) {
-        reth_tracing::init_test_tracing();
-        let db = create_test_rw_db();
-        let consensus = TestConsensus::default();
-        let payload_builder = spawn_test_payload_service();
+        pipeline_run_threshold: Option<u64>,
+        max_block: Option<BlockNumber>,
+    }
 
-        let executor_factory = TestExecutorFactory::new(chain_spec.clone());
-        executor_factory.extend(executor_results);
+    impl TestConsensusEngineBuilder {
+        /// Create a new `TestConsensusEngineBuilder` with the given `ChainSpec`.
+        fn new(chain_spec: Arc<ChainSpec>) -> Self {
+            Self {
+                chain_spec,
+                pipeline_exec_outputs: VecDeque::new(),
+                executor_results: Vec::new(),
+                pipeline_run_threshold: None,
+                max_block: None,
+            }
+        }
 
-        // Setup pipeline
-        let (tip_tx, tip_rx) = watch::channel(H256::default());
-        let pipeline = Pipeline::builder()
-            .add_stages(TestStages::new(pipeline_exec_outputs, Default::default()))
-            .with_tip_sender(tip_tx)
-            .build(db.clone(), chain_spec.clone());
+        /// Set the pipeline execution outputs to use for the test consensus engine.
+        fn with_pipeline_exec_outputs(
+            mut self,
+            pipeline_exec_outputs: VecDeque<Result<ExecOutput, StageError>>,
+        ) -> Self {
+            self.pipeline_exec_outputs = pipeline_exec_outputs;
+            self
+        }
 
-        // Setup blockchain tree
-        let externals =
-            TreeExternals::new(db.clone(), consensus, executor_factory, chain_spec.clone());
-        let config = BlockchainTreeConfig::new(1, 2, 3, 2);
-        let (canon_state_notification_sender, _) = tokio::sync::broadcast::channel(3);
-        let tree = ShareableBlockchainTree::new(
-            BlockchainTree::new(externals, canon_state_notification_sender, config)
-                .expect("failed to create tree"),
-        );
-        let factory = ProviderFactory::new(db.clone(), chain_spec.clone());
-        let latest = chain_spec.genesis_header().seal_slow();
-        let blockchain_provider = BlockchainProvider::with_latest(factory, tree, latest);
-        let (engine, handle) = BeaconConsensusEngine::new(
-            NoopFullBlockClient::default(),
-            pipeline,
-            blockchain_provider,
-            Box::<TokioTaskExecutor>::default(),
-            Box::<NoopSyncStateUpdater>::default(),
-            None,
-            false,
-            payload_builder,
-            None,
-        )
-        .expect("failed to create consensus engine");
+        /// Set the executor results to use for the test consensus engine.
+        fn with_executor_results(mut self, executor_results: Vec<PostState>) -> Self {
+            self.executor_results = executor_results;
+            self
+        }
 
-        (engine, TestEnv::new(db, tip_rx, handle))
+        /// Sets the max block for the pipeline to run.
+        fn with_max_block(mut self, max_block: BlockNumber) -> Self {
+            self.max_block = Some(max_block);
+            self
+        }
+
+        /// Disables blockchain tree driven sync. This is the same as setting the pipeline run
+        /// threshold to 0.
+        fn disable_blockchain_tree_sync(mut self) -> Self {
+            self.pipeline_run_threshold = Some(0);
+            self
+        }
+
+        /// Builds the test consensus engine into a `TestConsensusEngine` and `TestEnv`.
+        fn build(self) -> (TestBeaconConsensusEngine, TestEnv<Arc<Env<WriteMap>>>) {
+            reth_tracing::init_test_tracing();
+            let db = create_test_rw_db();
+            let consensus = TestConsensus::default();
+            let payload_builder = spawn_test_payload_service();
+
+            let executor_factory = TestExecutorFactory::new(self.chain_spec.clone());
+            executor_factory.extend(self.executor_results);
+
+            // Setup pipeline
+            let (tip_tx, tip_rx) = watch::channel(H256::default());
+            let mut pipeline = Pipeline::builder()
+                .add_stages(TestStages::new(self.pipeline_exec_outputs, Default::default()))
+                .with_tip_sender(tip_tx);
+
+            if let Some(max_block) = self.max_block {
+                pipeline = pipeline.with_max_block(max_block);
+            }
+
+            let pipeline = pipeline
+                .build(db.clone(), self.chain_spec.clone());
+
+            // Setup blockchain tree
+            let externals = TreeExternals::new(
+                db.clone(),
+                consensus,
+                executor_factory,
+                self.chain_spec.clone(),
+            );
+            let config = BlockchainTreeConfig::new(1, 2, 3, 2);
+            let (canon_state_notification_sender, _) = tokio::sync::broadcast::channel(3);
+            let tree = ShareableBlockchainTree::new(
+                BlockchainTree::new(externals, canon_state_notification_sender, config)
+                    .expect("failed to create tree"),
+            );
+            let shareable_db = ProviderFactory::new(db.clone(), self.chain_spec.clone());
+            let latest = self.chain_spec.genesis_header().seal_slow();
+            let blockchain_provider = BlockchainProvider::with_latest(shareable_db, tree, latest);
+            let (engine, handle) = BeaconConsensusEngine::new(
+                NoopFullBlockClient::default(),
+                pipeline,
+                blockchain_provider,
+                Box::<TokioTaskExecutor>::default(),
+                Box::<NoopSyncStateUpdater>::default(),
+                None,
+                false,
+                payload_builder,
+                None,
+                self.pipeline_run_threshold.unwrap_or(MIN_BLOCKS_FOR_PIPELINE_RUN),
+            )
+            .expect("failed to create consensus engine");
+
+            (engine, TestEnv::new(db, tip_rx, handle))
+        }
     }
 
     fn spawn_consensus_engine(
@@ -1508,11 +1578,13 @@ mod tests {
                 .paris_activated()
                 .build(),
         );
-        let (consensus_engine, env) = setup_consensus_engine(
-            chain_spec.clone(),
-            VecDeque::from([Err(StageError::ChannelClosed)]),
-            Vec::default(),
-        );
+
+        let (consensus_engine, env) = TestConsensusEngineBuilder::new(chain_spec.clone())
+            .with_pipeline_exec_outputs(VecDeque::from([Err(StageError::ChannelClosed)]))
+            .disable_blockchain_tree_sync()
+            .with_max_block(1)
+            .build();
+
         let res = spawn_consensus_engine(consensus_engine);
 
         let _ = env
@@ -1537,11 +1609,13 @@ mod tests {
                 .paris_activated()
                 .build(),
         );
-        let (consensus_engine, env) = setup_consensus_engine(
-            chain_spec.clone(),
-            VecDeque::from([Err(StageError::ChannelClosed)]),
-            Vec::default(),
-        );
+
+        let (consensus_engine, env) = TestConsensusEngineBuilder::new(chain_spec.clone())
+            .with_pipeline_exec_outputs(VecDeque::from([Err(StageError::ChannelClosed)]))
+            .disable_blockchain_tree_sync()
+            .with_max_block(1)
+            .build();
+
         let mut rx = spawn_consensus_engine(consensus_engine);
 
         // consensus engine is idle
@@ -1577,14 +1651,15 @@ mod tests {
                 .paris_activated()
                 .build(),
         );
-        let (consensus_engine, env) = setup_consensus_engine(
-            chain_spec.clone(),
-            VecDeque::from([
+
+        let (consensus_engine, env) = TestConsensusEngineBuilder::new(chain_spec.clone())
+            .with_pipeline_exec_outputs(VecDeque::from([
                 Ok(ExecOutput { checkpoint: StageCheckpoint::new(1), done: true }),
-                Err(StageError::ChannelClosed),
-            ]),
-            Vec::default(),
-        );
+            ]))
+            .disable_blockchain_tree_sync()
+            .with_max_block(2)
+            .build();
+
         let rx = spawn_consensus_engine(consensus_engine);
 
         let _ = env
@@ -1610,15 +1685,15 @@ mod tests {
                 .paris_activated()
                 .build(),
         );
-        let (mut consensus_engine, env) = setup_consensus_engine(
-            chain_spec.clone(),
-            VecDeque::from([Ok(ExecOutput {
-                checkpoint: StageCheckpoint::new(max_block),
-                done: true,
-            })]),
-            Vec::default(),
-        );
-        consensus_engine.sync.set_max_block(max_block);
+
+        let (consensus_engine, env) = TestConsensusEngineBuilder::new(chain_spec.clone())
+            .with_pipeline_exec_outputs(VecDeque::from([Ok(ExecOutput {
+                checkpoint: StageCheckpoint::new(max_block), done: true
+            })]))
+            .with_max_block(max_block)
+            .disable_blockchain_tree_sync()
+            .build();
+
         let rx = spawn_consensus_engine(consensus_engine);
 
         let _ = env
@@ -1656,14 +1731,12 @@ mod tests {
                     .paris_activated()
                     .build(),
             );
-            let (consensus_engine, env) = setup_consensus_engine(
-                chain_spec.clone(),
-                VecDeque::from([Ok(ExecOutput {
-                    done: true,
-                    checkpoint: StageCheckpoint::new(0),
-                })]),
-                Vec::default(),
-            );
+
+            let (consensus_engine, env) = TestConsensusEngineBuilder::new(chain_spec.clone())
+                .with_pipeline_exec_outputs(VecDeque::from([Ok(ExecOutput {
+                    checkpoint: StageCheckpoint::new(0), done: true,
+                })]))
+                .build();
 
             let mut engine_rx = spawn_consensus_engine(consensus_engine);
 
@@ -1687,14 +1760,12 @@ mod tests {
                     .paris_activated()
                     .build(),
             );
-            let (consensus_engine, env) = setup_consensus_engine(
-                chain_spec.clone(),
-                VecDeque::from([Ok(ExecOutput {
-                    done: true,
-                    checkpoint: StageCheckpoint::new(0),
-                })]),
-                Vec::default(),
-            );
+
+            let (consensus_engine, env) = TestConsensusEngineBuilder::new(chain_spec.clone())
+                .with_pipeline_exec_outputs(VecDeque::from([Ok(ExecOutput {
+                    checkpoint: StageCheckpoint::new(0), done: true,
+                })]))
+                .build();
 
             let genesis = random_block(0, None, None, Some(0));
             let block1 = random_block(1, Some(genesis.hash), None, Some(0));
@@ -1735,14 +1806,14 @@ mod tests {
                     .paris_activated()
                     .build(),
             );
-            let (consensus_engine, env) = setup_consensus_engine(
-                chain_spec.clone(),
-                VecDeque::from([
-                    Ok(ExecOutput { done: true, checkpoint: StageCheckpoint::new(0) }),
-                    Ok(ExecOutput { done: true, checkpoint: StageCheckpoint::new(0) }),
-                ]),
-                Vec::default(),
-            );
+
+            let (consensus_engine, env) = TestConsensusEngineBuilder::new(chain_spec.clone())
+                .with_pipeline_exec_outputs(VecDeque::from([
+                    Ok(ExecOutput { checkpoint: StageCheckpoint::new(0), done: true }),
+                    Ok(ExecOutput { checkpoint: StageCheckpoint::new(0), done: true }),
+                ]))
+                .disable_blockchain_tree_sync()
+                .build();
 
             let genesis = random_block(0, None, None, Some(0));
             let block1 = random_block(1, Some(genesis.hash), None, Some(0));
@@ -1784,14 +1855,13 @@ mod tests {
                     .paris_activated()
                     .build(),
             );
-            let (consensus_engine, env) = setup_consensus_engine(
-                chain_spec.clone(),
-                VecDeque::from([Ok(ExecOutput {
-                    done: true,
-                    checkpoint: StageCheckpoint::new(0),
-                })]),
-                Vec::default(),
-            );
+
+            let (consensus_engine, env) = TestConsensusEngineBuilder::new(chain_spec.clone())
+                .with_pipeline_exec_outputs(VecDeque::from([Ok(ExecOutput {
+                    checkpoint: StageCheckpoint::new(0), done: true,
+                })]))
+                .disable_blockchain_tree_sync()
+                .build();
 
             let genesis = random_block(0, None, None, Some(0));
             let block1 = random_block(1, Some(genesis.hash), None, Some(0));
@@ -1821,14 +1891,13 @@ mod tests {
                     .paris_at_ttd(U256::from(3))
                     .build(),
             );
-            let (consensus_engine, env) = setup_consensus_engine(
-                chain_spec.clone(),
-                VecDeque::from([
-                    Ok(ExecOutput { done: true, checkpoint: StageCheckpoint::new(0) }),
-                    Ok(ExecOutput { done: true, checkpoint: StageCheckpoint::new(0) }),
-                ]),
-                Vec::default(),
-            );
+
+            let (consensus_engine, env) = TestConsensusEngineBuilder::new(chain_spec.clone())
+                .with_pipeline_exec_outputs(VecDeque::from([
+                    Ok(ExecOutput { checkpoint: StageCheckpoint::new(0), done: true }),
+                    Ok(ExecOutput { checkpoint: StageCheckpoint::new(0), done: true }),
+                ]))
+                .build();
 
             let genesis = random_block(0, None, None, Some(0));
             let mut block1 = random_block(1, Some(genesis.hash), None, Some(0));
@@ -1874,14 +1943,13 @@ mod tests {
                     .london_activated()
                     .build(),
             );
-            let (consensus_engine, env) = setup_consensus_engine(
-                chain_spec.clone(),
-                VecDeque::from([
-                    Ok(ExecOutput { done: true, checkpoint: StageCheckpoint::new(0) }),
-                    Ok(ExecOutput { done: true, checkpoint: StageCheckpoint::new(0) }),
-                ]),
-                Vec::default(),
-            );
+
+            let (consensus_engine, env) = TestConsensusEngineBuilder::new(chain_spec.clone())
+                .with_pipeline_exec_outputs(VecDeque::from([
+                    Ok(ExecOutput { checkpoint: StageCheckpoint::new(0), done: true }),
+                    Ok(ExecOutput { checkpoint: StageCheckpoint::new(0), done: true }),
+                ]))
+                .build();
 
             let genesis = random_block(0, None, None, Some(0));
             let block1 = random_block(1, Some(genesis.hash), None, Some(0));
@@ -1921,14 +1989,12 @@ mod tests {
                     .paris_activated()
                     .build(),
             );
-            let (consensus_engine, env) = setup_consensus_engine(
-                chain_spec.clone(),
-                VecDeque::from([Ok(ExecOutput {
-                    done: true,
-                    checkpoint: StageCheckpoint::new(0),
-                })]),
-                Vec::default(),
-            );
+
+            let (consensus_engine, env) = TestConsensusEngineBuilder::new(chain_spec.clone())
+                .with_pipeline_exec_outputs(VecDeque::from([Ok(ExecOutput {
+                    checkpoint: StageCheckpoint::new(0), done: true,
+                })]))
+                .build();
 
             let mut engine_rx = spawn_consensus_engine(consensus_engine);
 
@@ -1954,14 +2020,12 @@ mod tests {
                     .paris_activated()
                     .build(),
             );
-            let (consensus_engine, env) = setup_consensus_engine(
-                chain_spec.clone(),
-                VecDeque::from([Ok(ExecOutput {
-                    done: true,
-                    checkpoint: StageCheckpoint::new(0),
-                })]),
-                Vec::default(),
-            );
+
+            let (consensus_engine, env) = TestConsensusEngineBuilder::new(chain_spec.clone())
+                .with_pipeline_exec_outputs(VecDeque::from([Ok(ExecOutput {
+                    checkpoint: StageCheckpoint::new(0), done: true,
+                })]))
+                .build();
 
             let genesis = random_block(0, None, None, Some(0));
             let block1 = random_block(1, Some(genesis.hash), None, Some(0));
@@ -2004,14 +2068,12 @@ mod tests {
                     .paris_activated()
                     .build(),
             );
-            let (consensus_engine, env) = setup_consensus_engine(
-                chain_spec.clone(),
-                VecDeque::from([Ok(ExecOutput {
-                    done: true,
-                    checkpoint: StageCheckpoint::new(0),
-                })]),
-                Vec::default(),
-            );
+
+            let (consensus_engine, env) = TestConsensusEngineBuilder::new(chain_spec.clone())
+                .with_pipeline_exec_outputs(VecDeque::from([Ok(ExecOutput {
+                    checkpoint: StageCheckpoint::new(0), done: true,
+                })]))
+                .build();
 
             let genesis = random_block(0, None, None, Some(0));
 
@@ -2061,14 +2123,13 @@ mod tests {
                     .london_activated()
                     .build(),
             );
-            let (consensus_engine, env) = setup_consensus_engine(
-                chain_spec.clone(),
-                VecDeque::from([Ok(ExecOutput {
-                    done: true,
-                    checkpoint: StageCheckpoint::new(0),
-                })]),
-                Vec::from([exec_result2]),
-            );
+
+            let (consensus_engine, env) = TestConsensusEngineBuilder::new(chain_spec.clone())
+                .with_pipeline_exec_outputs(VecDeque::from([Ok(ExecOutput {
+                    checkpoint: StageCheckpoint::new(0), done: true,
+                })]))
+                .with_executor_results(Vec::from([exec_result2]))
+                .build();
 
             insert_blocks(
                 env.db.as_ref(),

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1680,9 +1680,10 @@ mod tests {
         );
 
         let (consensus_engine, env) = TestConsensusEngineBuilder::new(chain_spec.clone())
-            .with_pipeline_exec_outputs(VecDeque::from([
-                Ok(ExecOutput { checkpoint: StageCheckpoint::new(1), done: true }),
-            ]))
+            .with_pipeline_exec_outputs(VecDeque::from([Ok(ExecOutput {
+                checkpoint: StageCheckpoint::new(1),
+                done: true,
+            })]))
             .disable_blockchain_tree_sync()
             .with_max_block(2)
             .build();
@@ -1715,7 +1716,8 @@ mod tests {
 
         let (consensus_engine, env) = TestConsensusEngineBuilder::new(chain_spec.clone())
             .with_pipeline_exec_outputs(VecDeque::from([Ok(ExecOutput {
-                checkpoint: StageCheckpoint::new(max_block), done: true
+                checkpoint: StageCheckpoint::new(max_block),
+                done: true,
             })]))
             .with_max_block(max_block)
             .disable_blockchain_tree_sync()
@@ -1761,7 +1763,8 @@ mod tests {
 
             let (consensus_engine, env) = TestConsensusEngineBuilder::new(chain_spec.clone())
                 .with_pipeline_exec_outputs(VecDeque::from([Ok(ExecOutput {
-                    checkpoint: StageCheckpoint::new(0), done: true,
+                    checkpoint: StageCheckpoint::new(0),
+                    done: true,
                 })]))
                 .build();
 
@@ -1790,7 +1793,8 @@ mod tests {
 
             let (consensus_engine, env) = TestConsensusEngineBuilder::new(chain_spec.clone())
                 .with_pipeline_exec_outputs(VecDeque::from([Ok(ExecOutput {
-                    checkpoint: StageCheckpoint::new(0), done: true,
+                    checkpoint: StageCheckpoint::new(0),
+                    done: true,
                 })]))
                 .build();
 
@@ -1885,7 +1889,8 @@ mod tests {
 
             let (consensus_engine, env) = TestConsensusEngineBuilder::new(chain_spec.clone())
                 .with_pipeline_exec_outputs(VecDeque::from([Ok(ExecOutput {
-                    checkpoint: StageCheckpoint::new(0), done: true,
+                    checkpoint: StageCheckpoint::new(0),
+                    done: true,
                 })]))
                 .disable_blockchain_tree_sync()
                 .build();
@@ -2019,7 +2024,8 @@ mod tests {
 
             let (consensus_engine, env) = TestConsensusEngineBuilder::new(chain_spec.clone())
                 .with_pipeline_exec_outputs(VecDeque::from([Ok(ExecOutput {
-                    checkpoint: StageCheckpoint::new(0), done: true,
+                    checkpoint: StageCheckpoint::new(0),
+                    done: true,
                 })]))
                 .build();
 
@@ -2050,7 +2056,8 @@ mod tests {
 
             let (consensus_engine, env) = TestConsensusEngineBuilder::new(chain_spec.clone())
                 .with_pipeline_exec_outputs(VecDeque::from([Ok(ExecOutput {
-                    checkpoint: StageCheckpoint::new(0), done: true,
+                    checkpoint: StageCheckpoint::new(0),
+                    done: true,
                 })]))
                 .build();
 
@@ -2098,7 +2105,8 @@ mod tests {
 
             let (consensus_engine, env) = TestConsensusEngineBuilder::new(chain_spec.clone())
                 .with_pipeline_exec_outputs(VecDeque::from([Ok(ExecOutput {
-                    checkpoint: StageCheckpoint::new(0), done: true,
+                    checkpoint: StageCheckpoint::new(0),
+                    done: true,
                 })]))
                 .build();
 
@@ -2153,7 +2161,8 @@ mod tests {
 
             let (consensus_engine, env) = TestConsensusEngineBuilder::new(chain_spec.clone())
                 .with_pipeline_exec_outputs(VecDeque::from([Ok(ExecOutput {
-                    checkpoint: StageCheckpoint::new(0), done: true,
+                    checkpoint: StageCheckpoint::new(0),
+                    done: true,
                 })]))
                 .with_executor_results(Vec::from([exec_result2]))
                 .build();

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -705,7 +705,7 @@ where
 
             trace!(target: "consensus::engine", request=?lowest_unknown_hash, "Triggering pipeline with target instead of downloading");
 
-            self.sync.set_pipeline_sync_target(lowest_unknown_hash);
+            self.sync.download_full_block(lowest_unknown_hash);
         } else {
             // we need to first check the buffer for the head and its ancestors
             let lowest_unknown_hash = self.lowest_buffered_ancestor_or(state.head_block_hash);

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -65,7 +65,8 @@ use reth_interfaces::blockchain_tree::InsertPayloadOk;
 /// The maximum number of invalid headers that can be tracked by the engine.
 const MAX_INVALID_HEADERS: u32 = 512u32;
 
-/// The largest gap for which the tree will be used for sync.
+/// The largest gap for which the tree will be used for sync. See docs for `pipeline_run_threshold`
+/// for more information.
 pub const MIN_BLOCKS_FOR_PIPELINE_RUN: u64 = 128;
 
 /// A _shareable_ beacon consensus frontend. Used to interact with the spawned beacon consensus
@@ -237,7 +238,17 @@ where
     invalid_headers: InvalidHeaderCache,
     /// Consensus engine metrics.
     metrics: EngineMetrics,
-    /// The largest gap for which the tree will be used to download and execute ranges of blocks.
+    /// After downloading a block corresponding to a recent forkchoice update, the engine will
+    /// check whether or not we can connect the block to the current canonical chain. If we can't,
+    /// we need to download and execute the missing parents of that block.
+    ///
+    /// When the block can't be connected, its block number will be compared to the canonical head,
+    /// resulting in a heuristic for the number of missing blocks, or the size of the gap between
+    /// the new block and the canonical head.
+    ///
+    /// If the gap is larger than this threshold, the engine will download and execute the missing
+    /// blocks using the pipeline. Otherwise, the engine, sync controller, and blockchain tree will
+    /// be used to download and execute the missing blocks.
     pipeline_run_threshold: u64,
 }
 

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -686,9 +686,7 @@ where
 
         // we assume the FCU is valid and at least the head is missing, so we need to start syncing
         // to it
-
-        // if this is the first FCU we received from the beacon node, then we start triggering the
-        // pipeline
+        trace!(target: "consensus::engine", request=?lowest_unknown_hash, "Triggering full block download for missing ancestors of the new head");
         if self.forkchoice_state_tracker.is_empty() {
             // find the appropriate target to sync to, if we don't have the safe block hash then we
             // start syncing to the safe block via pipeline first
@@ -703,14 +701,11 @@ where
             // we need to first check the buffer for the head and its ancestors
             let lowest_unknown_hash = self.lowest_buffered_ancestor_or(target);
 
-            trace!(target: "consensus::engine", request=?lowest_unknown_hash, "Triggering pipeline with target instead of downloading");
 
             self.sync.download_full_block(lowest_unknown_hash);
         } else {
             // we need to first check the buffer for the head and its ancestors
             let lowest_unknown_hash = self.lowest_buffered_ancestor_or(state.head_block_hash);
-
-            trace!(target: "consensus::engine", request=?lowest_unknown_hash, "Triggering full block download for missing ancestors of the new head");
 
             // trigger a full block download for missing hash, or the parent of its lowest buffered
             // ancestor

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -469,7 +469,7 @@ where
     fn check_invalid_ancestor(&mut self, head: H256) -> Option<PayloadStatus> {
         let parent_hash = {
             // check if the head was previously marked as invalid
-            let header = self.invalid_headers.get(&head)?.clone();
+            let header = self.invalid_headers.get(&head)?;
             header.parent_hash
         };
 

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1061,9 +1061,6 @@ where
                         {
                             if let Some(target) = self.forkchoice_state_tracker.sync_target() {
                                 self.sync.set_pipeline_sync_target(target)
-                            } else {
-                                // TODO: This should never happen because a download can only
-                                // happen in response to a fcu which we respond SYNCING to
                             }
                         } else {
                             // continue downloading the missing parent

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1059,8 +1059,16 @@ where
                             missing_parent.number - canonical_tip_num >
                                 self.pipeline_run_threshold
                         {
-                            if let Some(target) = self.forkchoice_state_tracker.sync_target() {
-                                self.sync.set_pipeline_sync_target(target)
+                            if let Some(state) = self.forkchoice_state_tracker.sync_target_state() {
+                                // if we have already canonicalized the finalized block, we should
+                                // skip the pipeline run
+                                if Ok(None) ==
+                                    self.blockchain.header_by_hash_or_number(
+                                        state.finalized_block_hash.into(),
+                                    )
+                                {
+                                    self.sync.set_pipeline_sync_target(state.finalized_block_hash)
+                                }
                             }
                         } else {
                             // continue downloading the missing parent

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1059,7 +1059,12 @@ where
                             missing_parent.number - canonical_tip_num >
                                 self.pipeline_run_threshold
                         {
-                            self.sync.set_pipeline_sync_target(missing_parent.hash)
+                            if let Some(target) = self.forkchoice_state_tracker.sync_target() {
+                                self.sync.set_pipeline_sync_target(target)
+                            } else {
+                                // TODO: This should never happen because a download can only
+                                // happen in response to a fcu which we respond SYNCING to
+                            }
                         } else {
                             // continue downloading the missing parent
                             //

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1532,8 +1532,7 @@ mod tests {
                 pipeline = pipeline.with_max_block(max_block);
             }
 
-            let pipeline = pipeline
-                .build(db.clone(), self.chain_spec.clone());
+            let pipeline = pipeline.build(db.clone(), self.chain_spec.clone());
 
             // Setup blockchain tree
             let externals = TreeExternals::new(

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -460,15 +460,10 @@ where
 
     /// Checks if the given `head` points to an invalid header, which requires a specific response
     /// to a forkchoice update.
-    ///
-    /// Inserts the head into the invalid header cache if the head has a known invalid ancestor.
     fn check_invalid_ancestor(&mut self, head: H256) -> Option<PayloadStatus> {
         let parent_hash = {
             // check if the head was previously marked as invalid
             let header = self.invalid_headers.get(&head)?.clone();
-
-            // if so then insert with the invalid ancestor
-            self.invalid_headers.insert_with_invalid_ancestor(head, header.clone());
             header.parent_hash
         };
 
@@ -686,7 +681,6 @@ where
 
         // we assume the FCU is valid and at least the head is missing, so we need to start syncing
         // to it
-        trace!(target: "consensus::engine", request=?lowest_unknown_hash, "Triggering full block download for missing ancestors of the new head");
         if self.forkchoice_state_tracker.is_empty() {
             // find the appropriate target to sync to, if we don't have the safe block hash then we
             // start syncing to the safe block via pipeline first
@@ -700,12 +694,13 @@ where
 
             // we need to first check the buffer for the head and its ancestors
             let lowest_unknown_hash = self.lowest_buffered_ancestor_or(target);
-
+            trace!(target: "consensus::engine", request=?lowest_unknown_hash, "Triggering full block download for missing ancestors of the new head");
 
             self.sync.download_full_block(lowest_unknown_hash);
         } else {
             // we need to first check the buffer for the head and its ancestors
             let lowest_unknown_hash = self.lowest_buffered_ancestor_or(state.head_block_hash);
+            trace!(target: "consensus::engine", request=?lowest_unknown_hash, "Triggering full block download for missing ancestors of the new head");
 
             // trigger a full block download for missing hash, or the parent of its lowest buffered
             // ancestor

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1039,11 +1039,23 @@ where
                         self.try_make_sync_target_canonical(num_hash);
                     }
                     InsertPayloadOk::Inserted(BlockStatus::Disconnected { missing_parent }) => {
+                        // get the latest valid finalized block or the tip (if we don't have the
+                        // finalized block set)
+                        let fork_ancestor_num = self.forkchoice_state_tracker.last_valid_finalized().and_then(|finalized| {
+                            // now we need to actually fetch these
+                            self.blockchain.block_number(finalized).unwrap_or_else(|err| {
+                                // TODO: store full headers (or BlockNumHash) in forkchoice
+                                // state tracker if valid, so we don't need to fetch at all
+                                error!(target: "consensus::engine", ?finalized, ?err, "Failed to get block number from validated finalized block hash");
+                               None
+                            })
+                        }).unwrap_or_else(|| self.blockchain.canonical_tip().number);
+
                         // if the number of missing blocks is greater than the max, run the
                         // pipeline
-                        let head = self.blockchain.canonical_tip();
-                        if missing_parent.number >= head.number &&
-                            missing_parent.number - head.number > self.pipeline_run_threshold
+                        if missing_parent.number >= fork_ancestor_num &&
+                            missing_parent.number - fork_ancestor_num >
+                                self.pipeline_run_threshold
                         {
                             self.sync.set_pipeline_sync_target(missing_parent.hash)
                         } else {


### PR DESCRIPTION
Modifies the beacon engine to only run the pipeline if the missing range is larger than a set constant (currently 128)

should fix #2964