### PR TITLE
fix: use gas limit for gas

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/types.rs
+++ b/crates/revm/revm-inspectors/src/tracing/types.rs
@@ -373,7 +373,7 @@ impl CallTraceNode {
             from: self.trace.caller,
             to: Some(self.trace.address),
             value: Some(self.trace.value),
-            gas: U256::from(self.trace.gas_used),
+            gas: U256::from(self.trace.gas_limit),
             gas_used: U256::from(self.trace.gas_used),
             input: self.trace.data.clone().into(),
             output: Some(self.trace.output.clone().into()),


### PR DESCRIPTION
naming and documentation for gas fields is terrible...

this is apparently the gaslimit