### PR TITLE
feat(stages): unwind on detached local head

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -247,6 +247,13 @@ pub fn validate_header_regarding_parent(
         })
     }
 
+    if parent.hash != child.parent_hash {
+        return Err(ConsensusError::ParentHashMismatch {
+            expected_parent_hash: parent.hash,
+            got_parent_hash: child.parent_hash,
+        })
+    }
+
     // timestamp in past check
     if child.timestamp <= parent.timestamp {
         return Err(ConsensusError::TimestampIsInPast {

--- a/crates/interfaces/src/consensus.rs
+++ b/crates/interfaces/src/consensus.rs
@@ -74,11 +74,15 @@ pub enum ConsensusError {
     #[error("Block parent [hash:{hash:?}] is not known.")]
     ParentUnknown { hash: BlockHash },
     #[error(
-        "Block number {block_number} is mismatch with parent block number {parent_block_number}"
+        "Block number {block_number} does not match parent block number {parent_block_number}"
     )]
     ParentBlockNumberMismatch { parent_block_number: BlockNumber, block_number: BlockNumber },
     #[error(
-    "Block timestamp {timestamp} is in the past compared to the parent timestamp {parent_timestamp}."
+        "Parent hash {got_parent_hash:?} does not match the expected {expected_parent_hash:?}"
+    )]
+    ParentHashMismatch { expected_parent_hash: H256, got_parent_hash: H256 },
+    #[error(
+        "Block timestamp {timestamp} is in the past compared to the parent timestamp {parent_timestamp}."
     )]
     TimestampIsInPast { parent_timestamp: u64, timestamp: u64 },
     #[error("Block timestamp {timestamp} is in the future compared to our clock time {present_timestamp}.")]

--- a/crates/interfaces/src/p2p/error.rs
+++ b/crates/interfaces/src/p2p/error.rs
@@ -115,7 +115,7 @@ impl From<oneshot::error::RecvError> for RequestError {
 pub type DownloadResult<T> = Result<T, DownloadError>;
 
 /// The downloader error type
-#[derive(Error, Debug, Clone)]
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum DownloadError {
     /* ==================== HEADER ERRORS ==================== */
     /// Header validation failed
@@ -126,19 +126,6 @@ pub enum DownloadError {
         /// The details of validation failure
         #[source]
         error: consensus::ConsensusError,
-    },
-    /// Error when checking that the current [`Header`] has the parent's hash as the parent_hash
-    /// field, and that they have sequential block numbers.
-    #[error("Headers did not match, current number: {header_number} / current hash: {header_hash}, parent number: {parent_number} / parent_hash: {parent_hash}")]
-    MismatchedHeaders {
-        /// The header number being evaluated
-        header_number: BlockNumber,
-        /// The header hash being evaluated
-        header_hash: H256,
-        /// The parent number being evaluated
-        parent_number: BlockNumber,
-        /// The parent hash being evaluated
-        parent_hash: H256,
     },
     /// Received an invalid tip
     #[error("Received invalid tip: {received:?}. Expected {expected:?}.")]

--- a/crates/interfaces/src/p2p/headers/error.rs
+++ b/crates/interfaces/src/p2p/headers/error.rs
@@ -17,6 +17,6 @@ pub enum HeadersDownloaderError {
         /// The header we attempted to attach.
         header: SealedHeader,
         /// The error that occurred when attempting to attach the header.
-        error: ConsensusError,
+        error: Box<ConsensusError>,
     },
 }

--- a/crates/interfaces/src/p2p/headers/error.rs
+++ b/crates/interfaces/src/p2p/headers/error.rs
@@ -1,5 +1,5 @@
 use crate::consensus::ConsensusError;
-use reth_primitives::{BlockHash, BlockNumber};
+use reth_primitives::SealedHeader;
 use thiserror::Error;
 
 /// Header downloader result
@@ -10,12 +10,12 @@ pub type HeadersDownloaderResult<T> = Result<T, HeadersDownloaderError>;
 pub enum HeadersDownloaderError {
     /// The downloaded header cannot be attached to the local head,
     /// but is valid otherwise.
-    #[error("Header cannot be attached. Details: {error}.")]
-    HeaderCannotBeAttached {
-        /// The number of the header that we attempted to attach.
-        number: BlockNumber,
-        /// The hash of the header that we attempted to attach.
-        hash: BlockHash,
+    #[error("Valid downloaded header cannot be attached to the local head. Details: {error}.")]
+    DetachedHead {
+        /// The local head we attempted to attach to.
+        local_head: SealedHeader,
+        /// The header we attempted to attach.
+        header: SealedHeader,
         /// The error that occurred when attempting to attach the header.
         error: ConsensusError,
     },

--- a/crates/interfaces/src/p2p/headers/error.rs
+++ b/crates/interfaces/src/p2p/headers/error.rs
@@ -1,0 +1,22 @@
+use crate::consensus::ConsensusError;
+use reth_primitives::{BlockHash, BlockNumber};
+use thiserror::Error;
+
+/// Header downloader result
+pub type HeadersDownloaderResult<T> = Result<T, HeadersDownloaderError>;
+
+/// Error variants that can happen when sending requests to a session.
+#[derive(Debug, Error, Clone, Eq, PartialEq)]
+pub enum HeadersDownloaderError {
+    /// The downloaded header cannot be attached to the local head,
+    /// but is valid otherwise.
+    #[error("Header cannot be attached. Details: {error}.")]
+    HeaderCannotBeAttached {
+        /// The number of the header that we attempted to attach.
+        number: BlockNumber,
+        /// The hash of the header that we attempted to attach.
+        hash: BlockHash,
+        /// The error that occurred when attempting to attach the header.
+        error: ConsensusError,
+    },
+}

--- a/crates/interfaces/src/p2p/headers/mod.rs
+++ b/crates/interfaces/src/p2p/headers/mod.rs
@@ -9,3 +9,6 @@ pub mod client;
 /// [`Consensus`]: crate::consensus::Consensus
 /// [`HeadersClient`]: client::HeadersClient
 pub mod downloader;
+
+/// Header downloader error.
+pub mod error;

--- a/crates/net/downloaders/src/headers/reverse_headers.rs
+++ b/crates/net/downloaders/src/headers/reverse_headers.rs
@@ -12,6 +12,7 @@ use reth_interfaces::{
         headers::{
             client::{HeadersClient, HeadersRequest},
             downloader::{validate_header_download, HeaderDownloader, SyncTarget},
+            error::{HeadersDownloaderError, HeadersDownloaderResult},
         },
         priority::Priority,
     },
@@ -28,7 +29,8 @@ use std::{
     sync::Arc,
     task::{ready, Context, Poll},
 };
-use tracing::trace;
+use thiserror::Error;
+use tracing::{error, trace};
 
 /// A heuristic that is used to determine the number of requests that should be prepared for a peer.
 /// This should ensure that there are always requests lined up for peers to handle while the
@@ -37,6 +39,15 @@ const REQUESTS_PER_PEER_MULTIPLIER: usize = 5;
 
 /// The scope for headers downloader metrics.
 pub const HEADERS_DOWNLOADER_SCOPE: &str = "downloaders.headers";
+
+/// Wrapper for internal downloader errors.
+#[derive(Error, Debug)]
+enum ReverseHeadersDownloaderError {
+    #[error(transparent)]
+    Downloader(#[from] HeadersDownloaderError),
+    #[error(transparent)]
+    Response(#[from] HeadersResponseError),
+}
 
 /// Downloads headers concurrently.
 ///
@@ -186,6 +197,37 @@ where
         self.queued_validated_headers.last().or(self.lowest_validated_header.as_ref())
     }
 
+    /// Validate that the received header matches the expected sync target.
+    fn validate_sync_target(
+        &self,
+        header: &SealedHeader,
+        request: HeadersRequest,
+        peer_id: PeerId,
+    ) -> Result<(), HeadersResponseError> {
+        match self.existing_sync_target() {
+            SyncTargetBlock::Hash(hash) | SyncTargetBlock::HashAndNumber { hash, .. }
+                if header.hash() != hash =>
+            {
+                Err(HeadersResponseError {
+                    request,
+                    peer_id: Some(peer_id),
+                    error: DownloadError::InvalidTip { received: header.hash(), expected: hash },
+                })
+            }
+            SyncTargetBlock::Number(number) if header.number != number => {
+                Err(HeadersResponseError {
+                    request,
+                    peer_id: Some(peer_id),
+                    error: DownloadError::InvalidTipNumber {
+                        received: header.number,
+                        expected: number,
+                    },
+                })
+            }
+            _ => Ok(()),
+        }
+    }
+
     /// Processes the next headers in line.
     ///
     /// This will validate all headers and insert them into the validated buffer.
@@ -199,8 +241,7 @@ where
         request: HeadersRequest,
         headers: Vec<Header>,
         peer_id: PeerId,
-    ) -> Result<(), HeadersResponseError> {
-        let sync_target = self.existing_sync_target();
+    ) -> Result<(), ReverseHeadersDownloaderError> {
         let mut validated = Vec::with_capacity(headers.len());
 
         let sealed_headers = headers.into_par_iter().map(|h| h.seal_slow()).collect::<Vec<_>>();
@@ -211,59 +252,45 @@ where
             {
                 if let Err(error) = self.validate(validated_header, &parent) {
                     trace!(target: "downloaders::headers", ?error ,"Failed to validate header");
-                    return Err(HeadersResponseError { request, peer_id: Some(peer_id), error })
+                    return Err(
+                        HeadersResponseError { request, peer_id: Some(peer_id), error }.into()
+                    )
                 }
             } else {
-                match sync_target {
-                    SyncTargetBlock::Hash(hash) => {
-                        if parent.hash() != hash {
-                            return Err(HeadersResponseError {
-                                request,
-                                peer_id: Some(peer_id),
-                                error: DownloadError::InvalidTip {
-                                    received: parent.hash(),
-                                    expected: hash,
-                                },
-                            })
-                        }
-                    }
-                    SyncTargetBlock::Number(number) => {
-                        if parent.number != number {
-                            return Err(HeadersResponseError {
-                                request,
-                                peer_id: Some(peer_id),
-                                error: DownloadError::InvalidTipNumber {
-                                    received: parent.number,
-                                    expected: number,
-                                },
-                            })
-                        }
-                    }
-                    SyncTargetBlock::HashAndNumber { hash, .. } => {
-                        if parent.hash() != hash {
-                            return Err(HeadersResponseError {
-                                request,
-                                peer_id: Some(peer_id),
-                                error: DownloadError::InvalidTip {
-                                    received: parent.hash(),
-                                    expected: hash,
-                                },
-                            })
-                        }
-                    }
-                }
+                self.validate_sync_target(&parent, request.clone(), peer_id)?;
             }
 
             validated.push(parent);
         }
 
         // If the last (smallest) validated header attaches to the local head, validate it.
-        if let Some((last_header, head)) = validated.last().zip(self.local_head.as_ref()) {
-            if last_header.number == head.number + 1 {
-                if let Err(error) = self.validate(last_header, head) {
-                    trace!(target: "downloaders::headers", ?error ,"Failed to validate header");
-                    return Err(HeadersResponseError { request, peer_id: Some(peer_id), error })
+        if let Some((last_header, head)) = validated
+            .last_mut()
+            .zip(self.local_head.as_ref())
+            .filter(|(last, head)| last.number == head.number + 1)
+        {
+            // Every header must be valid on its own
+            if let Err(error) = self.consensus.validate_header(last_header) {
+                trace!(target: "downloaders::headers", ?error, "Failed to validate header");
+                return Err(HeadersResponseError {
+                    request,
+                    peer_id: Some(peer_id),
+                    error: DownloadError::HeaderValidation { hash: head.hash(), error },
                 }
+                .into())
+            }
+
+            // If the header is valid on its own, but not against it's parent, we return it an error
+            // `HeaderResponse::Detached`.
+            if let Err(error) = self.consensus.validate_header_against_parent(last_header, head) {
+                // Replace the last header with a detached variant
+                error!(target: "downloaders::headers", ?error, number = last_header.number, hash = ?last_header.hash, "Header cannot be attached to known canonical chain");
+                return Err(HeadersDownloaderError::HeaderCannotBeAttached {
+                    number: last_header.number,
+                    hash: last_header.hash,
+                    error,
+                }
+                .into())
             }
         }
 
@@ -318,7 +345,7 @@ where
     fn on_sync_target_outcome(
         &mut self,
         response: HeadersRequestOutcome,
-    ) -> Result<(), HeadersResponseError> {
+    ) -> Result<(), ReverseHeadersDownloaderError> {
         let sync_target = self.existing_sync_target();
         let HeadersRequestOutcome { request, outcome } = response;
         match outcome {
@@ -336,7 +363,8 @@ where
                         request,
                         peer_id: Some(peer_id),
                         error: DownloadError::EmptyResponse,
-                    })
+                    }
+                    .into())
                 }
 
                 let target = headers.remove(0).seal_slow();
@@ -351,7 +379,8 @@ where
                                     received: target.hash(),
                                     expected: hash,
                                 },
-                            })
+                            }
+                            .into())
                         }
                     }
                     SyncTargetBlock::Number(number) => {
@@ -363,7 +392,8 @@ where
                                     received: target.number,
                                     expected: number,
                                 },
-                            })
+                            }
+                            .into())
                         }
                     }
                     SyncTargetBlock::HashAndNumber { hash, .. } => {
@@ -375,7 +405,8 @@ where
                                     received: target.hash(),
                                     expected: hash,
                                 },
-                            })
+                            }
+                            .into())
                         }
                     }
                 }
@@ -389,11 +420,15 @@ where
                 self.queued_validated_headers.push(target);
 
                 // try to validate all buffered responses blocked by this successful response
-                self.try_validate_buffered().map(Err::<(), HeadersResponseError>).transpose()?;
+                self.try_validate_buffered()
+                    .map(Err::<(), ReverseHeadersDownloaderError>)
+                    .transpose()?;
 
                 Ok(())
             }
-            Err(err) => Err(HeadersResponseError { request, peer_id: None, error: err.into() }),
+            Err(err) => {
+                Err(HeadersResponseError { request, peer_id: None, error: err.into() }.into())
+            }
         }
     }
 
@@ -402,7 +437,7 @@ where
     fn on_headers_outcome(
         &mut self,
         response: HeadersRequestOutcome,
-    ) -> Result<(), HeadersResponseError> {
+    ) -> Result<(), ReverseHeadersDownloaderError> {
         let requested_block_number = response.block_number();
         let HeadersRequestOutcome { request, outcome } = response;
 
@@ -420,7 +455,8 @@ where
                         request,
                         peer_id: Some(peer_id),
                         error: DownloadError::EmptyResponse,
-                    })
+                    }
+                    .into())
                 }
 
                 if (headers.len() as u64) != request.limit {
@@ -431,7 +467,8 @@ where
                             expected: request.limit,
                         },
                         request,
-                    })
+                    }
+                    .into())
                 }
 
                 // sort headers from highest to lowest block number
@@ -450,7 +487,8 @@ where
                             received: highest.number,
                             expected: requested_block_number,
                         },
-                    })
+                    }
+                    .into())
                 }
 
                 // check if the response is the next expected
@@ -459,7 +497,7 @@ where
                     self.process_next_headers(request, headers, peer_id)?;
                     // try to validate all buffered responses blocked by this successful response
                     self.try_validate_buffered()
-                        .map(Err::<(), HeadersResponseError>)
+                        .map(Err::<(), ReverseHeadersDownloaderError>)
                         .transpose()?;
                 } else if highest.number > self.existing_local_block_number() {
                     self.metrics.buffered_responses.increment(1.);
@@ -477,7 +515,7 @@ where
             // would've been handled by the fetcher internally
             Err(err) => {
                 trace!(target: "downloaders::headers", %err, "Response error");
-                Err(HeadersResponseError { request, peer_id: None, error: err.into() })
+                Err(HeadersResponseError { request, peer_id: None, error: err.into() }.into())
             }
         }
     }
@@ -508,7 +546,7 @@ where
     /// Attempts to validate the buffered responses
     ///
     /// Returns an error if the next expected response was popped, but failed validation.
-    fn try_validate_buffered(&mut self) -> Option<HeadersResponseError> {
+    fn try_validate_buffered(&mut self) -> Option<ReverseHeadersDownloaderError> {
         loop {
             // Check to see if we've already received the next value
             let next_response = self.buffered_responses.peek_mut()?;
@@ -691,7 +729,7 @@ impl<H> Stream for ReverseHeadersDownloader<H>
 where
     H: HeadersClient + 'static,
 {
-    type Item = Vec<SealedHeader>;
+    type Item = HeadersDownloaderResult<Vec<SealedHeader>>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
@@ -713,20 +751,25 @@ where
         while let Some(mut req) = this.sync_target_request.take() {
             match req.poll_unpin(cx) {
                 Poll::Ready(outcome) => {
-                    if let Err(err) = this.on_sync_target_outcome(outcome) {
-                        trace!(target: "downloaders::headers", ?err, "invalid sync target response");
-                        if err.is_channel_closed() {
-                            // download channel closed which means the network was dropped
-                            return Poll::Ready(None)
-                        }
+                    match this.on_sync_target_outcome(outcome) {
+                        Ok(()) => break,
+                        Err(ReverseHeadersDownloaderError::Response(error)) => {
+                            trace!(target: "downloaders::headers", ?error, "invalid sync target response");
+                            if error.is_channel_closed() {
+                                // download channel closed which means the network was dropped
+                                return Poll::Ready(None)
+                            }
 
-                        this.penalize_peer(err.peer_id, &err.error);
-                        this.metrics.increment_errors(&err.error);
-                        this.sync_target_request =
-                            Some(this.request_fut(err.request, Priority::High));
-                    } else {
-                        break
-                    }
+                            this.penalize_peer(error.peer_id, &error.error);
+                            this.metrics.increment_errors(&error.error);
+                            this.sync_target_request =
+                                Some(this.request_fut(error.request, Priority::High));
+                        }
+                        Err(ReverseHeadersDownloaderError::Downloader(error)) => {
+                            this.clear();
+                            return Poll::Ready(Some(Err(error)))
+                        }
+                    };
                 }
                 Poll::Pending => {
                     this.sync_target_request = Some(req);
@@ -748,13 +791,20 @@ where
             while let Poll::Ready(Some(outcome)) = this.in_progress_queue.poll_next_unpin(cx) {
                 this.metrics.in_flight_requests.decrement(1.);
                 // handle response
-                if let Err(err) = this.on_headers_outcome(outcome) {
-                    if err.is_channel_closed() {
-                        // download channel closed which means the network was dropped
-                        return Poll::Ready(None)
+                match this.on_headers_outcome(outcome) {
+                    Ok(()) => (),
+                    Err(ReverseHeadersDownloaderError::Response(error)) => {
+                        if error.is_channel_closed() {
+                            // download channel closed which means the network was dropped
+                            return Poll::Ready(None)
+                        }
+                        this.on_headers_error(error);
                     }
-                    this.on_headers_error(err);
-                }
+                    Err(ReverseHeadersDownloaderError::Downloader(error)) => {
+                        this.clear();
+                        return Poll::Ready(Some(Err(error)))
+                    }
+                };
             }
 
             // marks the loop's exit condition: exit if no requests submitted
@@ -791,7 +841,7 @@ where
                 trace!(target: "downloaders::headers", batch=%next_batch.len(), "Returning validated batch");
 
                 this.metrics.total_flushed.increment(next_batch.len() as u64);
-                return Poll::Ready(Some(next_batch))
+                return Poll::Ready(Some(Ok(next_batch)))
             }
 
             if !progress {
@@ -807,7 +857,7 @@ where
                 return Poll::Ready(None)
             }
             this.metrics.total_flushed.increment(next_batch.len() as u64);
-            return Poll::Ready(Some(next_batch))
+            return Poll::Ready(Some(Ok(next_batch)))
         }
 
         Poll::Pending
@@ -901,6 +951,18 @@ impl HeadersResponseError {
         false
     }
 }
+
+impl std::fmt::Display for HeadersResponseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Error requesting headers from peer {:?}. Error: {}. Request: {:?}",
+            self.peer_id, self.error, self.request,
+        )
+    }
+}
+
+impl std::error::Error for HeadersResponseError {}
 
 /// The block to which we want to close the gap: (local head...sync target]
 /// This tracks the sync target block, so this could be either a block number or hash.
@@ -1333,7 +1395,7 @@ mod tests {
             .await;
 
         let headers = downloader.next().await.unwrap();
-        assert_eq!(headers, vec![p0, p1, p2,]);
+        assert_eq!(headers, Ok(vec![p0, p1, p2,]));
         assert!(downloader.buffered_responses.is_empty());
         assert!(downloader.next().await.is_none());
         assert!(downloader.next().await.is_none());
@@ -1365,12 +1427,12 @@ mod tests {
             .await;
 
         let headers = downloader.next().await.unwrap();
-        assert_eq!(headers, vec![p0]);
+        assert_eq!(headers, Ok(vec![p0]));
 
         let headers = downloader.next().await.unwrap();
-        assert_eq!(headers, vec![p1]);
+        assert_eq!(headers, Ok(vec![p1]));
         let headers = downloader.next().await.unwrap();
-        assert_eq!(headers, vec![p2]);
+        assert_eq!(headers, Ok(vec![p2]));
         assert!(downloader.next().await.is_none());
     }
 }

--- a/crates/net/downloaders/src/headers/reverse_headers.rs
+++ b/crates/net/downloaders/src/headers/reverse_headers.rs
@@ -280,14 +280,14 @@ where
                 .into())
             }
 
-            // If the header is valid on its own, but not against it's parent, we return it an error
-            // `HeaderResponse::Detached`.
+            // If the header is valid on its own, but not against its parent, we return it as
+            // detached head error.
             if let Err(error) = self.consensus.validate_header_against_parent(last_header, head) {
                 // Replace the last header with a detached variant
                 error!(target: "downloaders::headers", ?error, number = last_header.number, hash = ?last_header.hash, "Header cannot be attached to known canonical chain");
-                return Err(HeadersDownloaderError::HeaderCannotBeAttached {
-                    number: last_header.number,
-                    hash: last_header.hash,
+                return Err(HeadersDownloaderError::DetachedHead {
+                    local_head: head.clone(),
+                    header: last_header.clone(),
                     error,
                 }
                 .into())

--- a/crates/net/downloaders/src/headers/reverse_headers.rs
+++ b/crates/net/downloaders/src/headers/reverse_headers.rs
@@ -41,6 +41,7 @@ const REQUESTS_PER_PEER_MULTIPLIER: usize = 5;
 pub const HEADERS_DOWNLOADER_SCOPE: &str = "downloaders.headers";
 
 /// Wrapper for internal downloader errors.
+#[allow(clippy::large_enum_variant)]
 #[derive(Error, Debug)]
 enum ReverseHeadersDownloaderError {
     #[error(transparent)]
@@ -288,7 +289,7 @@ where
                 return Err(HeadersDownloaderError::DetachedHead {
                     local_head: head.clone(),
                     header: last_header.clone(),
-                    error,
+                    error: Box::new(error),
                 }
                 .into())
             }

--- a/crates/net/downloaders/src/test_utils/file_client.rs
+++ b/crates/net/downloaders/src/test_utils/file_client.rs
@@ -328,7 +328,7 @@ mod tests {
         downloader.update_sync_target(SyncTarget::Tip(p0.hash()));
 
         let headers = downloader.next().await.unwrap();
-        assert_eq!(headers, vec![p0, p1, p2,]);
+        assert_eq!(headers, Ok(vec![p0, p1, p2]));
         assert!(downloader.next().await.is_none());
         assert!(downloader.next().await.is_none());
     }
@@ -349,7 +349,7 @@ mod tests {
         header_downloader.update_sync_target(SyncTarget::Tip(headers.last().unwrap().hash()));
 
         // get headers first
-        let mut downloaded_headers = header_downloader.next().await.unwrap();
+        let mut downloaded_headers = header_downloader.next().await.unwrap().unwrap();
 
         // reverse to make sure it's in the right order before comparing
         downloaded_headers.reverse();

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -90,7 +90,14 @@ pub const EMPTY_TRANSACTIONS: H256 = EMPTY_SET_HASH;
 pub const EMPTY_WITHDRAWALS: H256 = EMPTY_SET_HASH;
 
 /// The number of blocks to unwind during a reorg that already became a part of canonical chain.
-pub const REORG_UNWIND_DEPTH: u64 = 3;
+///
+/// In reality, the node can end up in this particular situation very rarely. It would happen only
+/// if the node process is abruptly terminated during ongoing reorg and doesn't boot back up for
+/// long period of time.
+///
+/// Unwind depth of `3` blocks significantly reduces the chance that the reorged block is kept in
+/// the database.
+pub const BEACON_CONSENSUS_REORG_UNWIND_DEPTH: u64 = 3;
 
 #[cfg(test)]
 mod tests {

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -89,6 +89,9 @@ pub const EMPTY_TRANSACTIONS: H256 = EMPTY_SET_HASH;
 /// Withdrawals root of empty withdrawals set.
 pub const EMPTY_WITHDRAWALS: H256 = EMPTY_SET_HASH;
 
+/// The number of blocks to unwind during a reorg that already became a part of canonical chain.
+pub const REORG_UNWIND_DEPTH: u64 = 3;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/stages/src/error.rs
+++ b/crates/stages/src/error.rs
@@ -22,12 +22,20 @@ pub enum StageError {
     },
     /// The stage encountered a downloader error where the responses cannot be attached to the
     /// current head.
-    #[error("Stage encountered detached head #{number} ({hash:?})", number = local_head.number, hash = local_head.hash)]
+    #[error(
+        "Stage encountered inconsistent chain. Downloaded header #{header_number} ({header_hash:?}) is detached from local head #{head_number} ({head_hash:?}). Details: {error}.",
+        header_number = header.number,
+        header_hash = header.hash,
+        head_number = local_head.number,
+        head_hash = local_head.hash,
+    )]
     DetachedHead {
-        /// The local head header.
+        /// The local head we attempted to attach to.
         local_head: SealedHeader,
-        /// The unwind target block number.
-        unwind_to: BlockNumber,
+        /// The header we attempted to attach.
+        header: SealedHeader,
+        /// The error that occurred when attempting to attach the header.
+        error: consensus::ConsensusError,
     },
     /// The stage encountered a database error.
     #[error("An internal database error occurred: {0}")]

--- a/crates/stages/src/error.rs
+++ b/crates/stages/src/error.rs
@@ -3,7 +3,7 @@ use reth_interfaces::{
     consensus, db::DatabaseError as DbError, executor, p2p::error::DownloadError,
     provider::ProviderError,
 };
-use reth_primitives::SealedHeader;
+use reth_primitives::{BlockNumber, SealedHeader};
 use reth_provider::TransactionError;
 use thiserror::Error;
 use tokio::sync::mpsc::error::SendError;
@@ -19,6 +19,15 @@ pub enum StageError {
         /// The underlying consensus error.
         #[source]
         error: consensus::ConsensusError,
+    },
+    /// The stage encountered a downloader error where the responses cannot be attached to the
+    /// current head.
+    #[error("Stage encountered detached head #{number} ({hash:?})", number = local_head.number, hash = local_head.hash)]
+    DetachedHead {
+        /// The local head header.
+        local_head: SealedHeader,
+        /// The unwind target block number.
+        unwind_to: BlockNumber,
     },
     /// The stage encountered a database error.
     #[error("An internal database error occurred: {0}")]

--- a/crates/stages/src/error.rs
+++ b/crates/stages/src/error.rs
@@ -3,7 +3,7 @@ use reth_interfaces::{
     consensus, db::DatabaseError as DbError, executor, p2p::error::DownloadError,
     provider::ProviderError,
 };
-use reth_primitives::{BlockNumber, SealedHeader};
+use reth_primitives::SealedHeader;
 use reth_provider::TransactionError;
 use thiserror::Error;
 use tokio::sync::mpsc::error::SendError;

--- a/crates/stages/src/error.rs
+++ b/crates/stages/src/error.rs
@@ -35,7 +35,7 @@ pub enum StageError {
         /// The header we attempted to attach.
         header: SealedHeader,
         /// The error that occurred when attempting to attach the header.
-        error: consensus::ConsensusError,
+        error: Box<consensus::ConsensusError>,
     },
     /// The stage encountered a database error.
     #[error("An internal database error occurred: {0}")]

--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -2,7 +2,10 @@ use crate::{error::*, ExecInput, ExecOutput, Stage, StageError, UnwindInput};
 use futures_util::Future;
 use reth_db::database::Database;
 use reth_interfaces::executor::BlockExecutionError;
-use reth_primitives::{listener::EventListeners, stage::StageId, BlockNumber, H256};
+use reth_primitives::{
+    constants::BEACON_CONSENSUS_REORG_UNWIND_DEPTH, listener::EventListeners, stage::StageId,
+    BlockNumber, H256,
+};
 use reth_provider::{providers::get_stage_checkpoint, Transaction};
 use std::pin::Pin;
 use tokio::sync::watch;
@@ -376,16 +379,14 @@ where
                 Err(err) => {
                     self.listeners.notify(PipelineEvent::Error { stage_id });
 
-                    let out = if let StageError::DetachedHead { local_head, unwind_to } = err {
-                        warn!(
-                            target: "sync::pipeline",
-                            stage = %stage_id,
-                            current_head_number = local_head.number,
-                            current_head_hash = ?local_head.hash,
-                            "Stage encountered detached head"
-                        );
+                    let out = if let StageError::DetachedHead { local_head, header, error } = err {
+                        warn!(target: "sync::pipeline", stage = %stage_id, ?local_head, ?header, ?error, "Stage encountered detached head");
 
                         // We unwind because of a detached head.
+                        let unwind_to = local_head
+                            .number
+                            .saturating_sub(BEACON_CONSENSUS_REORG_UNWIND_DEPTH)
+                            .max(1);
                         Ok(ControlFlow::Unwind { target: unwind_to, bad_block: local_head })
                     } else if let StageError::Validation { block, error } = err {
                         warn!(

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -14,7 +14,6 @@ use reth_interfaces::{
     provider::ProviderError,
 };
 use reth_primitives::{
-    constants::BEACON_CONSENSUS_REORG_UNWIND_DEPTH,
     stage::{
         CheckpointBlockRange, EntitiesCheckpoint, HeadersCheckpoint, StageCheckpoint, StageId,
     },

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -7,10 +7,14 @@ use reth_db::{
     transaction::{DbTx, DbTxMut},
 };
 use reth_interfaces::{
-    p2p::headers::downloader::{HeaderDownloader, SyncTarget},
+    p2p::headers::{
+        downloader::{HeaderDownloader, SyncTarget},
+        error::HeadersDownloaderError,
+    },
     provider::ProviderError,
 };
 use reth_primitives::{
+    constants::REORG_UNWIND_DEPTH,
     stage::{
         CheckpointBlockRange, EntitiesCheckpoint, HeadersCheckpoint, StageCheckpoint, StageId,
     },
@@ -211,13 +215,21 @@ where
         debug!(target: "sync::stages::headers", ?tip, head = ?gap.local_head.hash(), "Commencing sync");
 
         // let the downloader know what to sync
-        self.downloader.update_sync_gap(gap.local_head, gap.target);
+        self.downloader.update_sync_gap(gap.local_head.clone(), gap.target);
 
         // The downloader returns the headers in descending order starting from the tip
         // down to the local head (latest block in db).
         // Task downloader can return `None` only if the response relaying channel was closed. This
         // is a fatal error to prevent the pipeline from running forever.
-        let downloaded_headers = self.downloader.next().await.ok_or(StageError::ChannelClosed)?;
+        let downloaded_headers = match self.downloader.next().await {
+            Some(Ok(headers)) => headers,
+            Some(Err(HeadersDownloaderError::HeaderCannotBeAttached { number, hash, error })) => {
+                error!(target: "sync::stages::headers", number, ?hash, ?error, "Cannot attach header to head");
+                let unwind_to = gap.local_head.number.saturating_sub(REORG_UNWIND_DEPTH).max(1);
+                return Err(StageError::DetachedHead { local_head: gap.local_head, unwind_to })
+            }
+            None => return Err(StageError::ChannelClosed),
+        };
 
         info!(target: "sync::stages::headers", len = downloaded_headers.len(), "Received headers");
 


### PR DESCRIPTION
## Description

Currently, if the node enters the pipeline with the local head that was reorged, the process will stall because the header downloader receives requests that fail validation because they do not attach to the local head.

## Solution

If the header downloader encounters a header that is supposed to attach to the local head (it is congruent and valid according to consensus rules), but has a different parent hash, it returns an error. The downloader error consequently triggers the unwind of the pipeline. The unwind target is computed by subtracting a new `REORG_UNWIND_DEPTH` constant from the local head.