### PR TITLE
feat(bin): log forkchoice status on FCU

### DIFF
--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -3,6 +3,7 @@
 use crate::node::cl_events::ConsensusLayerHealthEvent;
 use futures::Stream;
 use reth_beacon_consensus::BeaconConsensusEngineEvent;
+use reth_interfaces::consensus::ForkchoiceState;
 use reth_network::{NetworkEvent, NetworkHandle};
 use reth_network_api::PeersInfo;
 use reth_primitives::{
@@ -113,11 +114,13 @@ impl NodeState {
     fn handle_consensus_engine_event(&mut self, event: BeaconConsensusEngineEvent) {
         match event {
             BeaconConsensusEngineEvent::ForkchoiceUpdated(state, status) => {
+                let ForkchoiceState { head_block_hash, safe_block_hash, finalized_block_hash } =
+                    state;
                 info!(
                     target: "reth::cli",
-                    head_block_hash = %state.head_block_hash,
-                    safe_block_hash = %state.safe_block_hash,
-                    finalized_block_hash = %state.finalized_block_hash,
+                    ?head_block_hash,
+                    ?safe_block_hash,
+                    ?finalized_block_hash,
                     ?status,
                     "Forkchoice updated"
                 );

--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -112,8 +112,15 @@ impl NodeState {
 
     fn handle_consensus_engine_event(&mut self, event: BeaconConsensusEngineEvent) {
         match event {
-            BeaconConsensusEngineEvent::ForkchoiceUpdated(state) => {
-                info!(target: "reth::cli", ?state, "Forkchoice updated");
+            BeaconConsensusEngineEvent::ForkchoiceUpdated(state, status) => {
+                info!(
+                    target: "reth::cli",
+                    head_block_hash = %state.head_block_hash,
+                    safe_block_hash = %state.safe_block_hash,
+                    finalized_block_hash = %state.finalized_block_hash,
+                    ?status,
+                    "Forkchoice updated"
+                );
             }
             BeaconConsensusEngineEvent::CanonicalBlockAdded(block) => {
                 self.latest_canonical_engine_block = Some(block.number);

--- a/crates/consensus/beacon/src/engine/event.rs
+++ b/crates/consensus/beacon/src/engine/event.rs
@@ -1,3 +1,4 @@
+use crate::engine::forkchoice::ForkchoiceStatus;
 use reth_interfaces::consensus::ForkchoiceState;
 use reth_primitives::SealedBlock;
 use std::sync::Arc;
@@ -6,7 +7,7 @@ use std::sync::Arc;
 #[derive(Clone, Debug)]
 pub enum BeaconConsensusEngineEvent {
     /// The fork choice state was updated.
-    ForkchoiceUpdated(ForkchoiceState),
+    ForkchoiceUpdated(ForkchoiceState, ForkchoiceStatus),
     /// A block was added to the canonical chain.
     CanonicalBlockAdded(Arc<SealedBlock>),
     /// A block was added to the fork chain.

--- a/crates/consensus/beacon/src/engine/forkchoice.rs
+++ b/crates/consensus/beacon/src/engine/forkchoice.rs
@@ -81,7 +81,7 @@ pub(crate) struct ReceivedForkchoiceState {
 
 /// A simplified representation of [PayloadStatusEnum] specifically for FCU.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub(crate) enum ForkchoiceStatus {
+pub enum ForkchoiceStatus {
     /// The forkchoice state is valid.
     Valid,
     /// The forkchoice state is invalid.

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -475,14 +475,16 @@ where
             }
         };
 
+        let status = on_updated.forkchoice_status();
+
         // update the forkchoice state tracker
-        self.forkchoice_state_tracker.set_latest(state, on_updated.forkchoice_status());
+        self.forkchoice_state_tracker.set_latest(state, status);
 
         let is_valid_response = on_updated.is_valid_update();
         let _ = tx.send(Ok(on_updated));
 
         // notify listeners about new processed FCU
-        self.listeners.notify(BeaconConsensusEngineEvent::ForkchoiceUpdated(state));
+        self.listeners.notify(BeaconConsensusEngineEvent::ForkchoiceUpdated(state, status));
 
         // Terminate the sync early if it's reached the maximum user
         // configured block.


### PR DESCRIPTION
Resolves https://github.com/paradigmxyz/reth/issues/2942

Besides the improvement mentioned in the issue, I also split the `state` log field into three separate fields for head, safe and finalized block hashes, so that the logs are more parseable.