### PR TITLE
fix: increase tokio thread stack size 8MB

### DIFF
--- a/bin/reth/src/runner.rs
+++ b/bin/reth/src/runner.rs
@@ -114,7 +114,11 @@ pub struct CliContext {
 /// Creates a new default tokio multi-thread [Runtime](tokio::runtime::Runtime) with all features
 /// enabled
 pub fn tokio_runtime() -> Result<tokio::runtime::Runtime, std::io::Error> {
-    tokio::runtime::Builder::new_multi_thread().enable_all().build()
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        // increase stack size, mostly for RPC calls that use the evm: <https://github.com/paradigmxyz/reth/issues/3056> and  <https://github.com/bluealloy/revm/issues/305>
+        .thread_stack_size(8 * 1024 * 1024)
+        .build()
 }
 
 /// Runs the given future to completion or until a critical task panicked


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/3056

executing certain transactions can exceed the default 2MB stack size and crash rpc.

bumping this to 8MB should be enough to even execute funny tx with 1024 internal calls