### PR TITLE
feat: validate sidechain state roots

### DIFF
--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -476,7 +476,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
                     parent,
                     &self.externals,
                 )?;
-                (BlockStatus::Accepted, chain)
+                (BlockStatus::Valid, chain)
             }
         };
 
@@ -548,13 +548,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
 
             self.block_indices.insert_non_fork_block(block_number, block_hash, chain_id);
 
-            if block_kind.extends_canonical_head() {
-                // if the block can be traced back to the canonical head, we were able to fully
-                // validate it
-                Ok(BlockStatus::Valid)
-            } else {
-                Ok(BlockStatus::Accepted)
-            }
+            Ok(BlockStatus::Valid)
         } else {
             debug!(target: "blockchain_tree", ?canonical_fork, "Starting new fork from side chain");
             // the block starts a new fork
@@ -566,7 +560,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
                 &self.externals,
             )?;
             self.insert_chain(chain);
-            Ok(BlockStatus::Accepted)
+            Ok(BlockStatus::Valid)
         };
 
         // After we inserted the block, we try to connect any buffered blocks

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1075,7 +1075,10 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
 
         let (blocks, state) = chain.into_inner();
 
-        provider.append_blocks_with_post_state(blocks.into_blocks().collect(), state)?;
+        provider.append_blocks_with_post_state(blocks.into_blocks().collect(), state).map_err(|err| match err {
+            Error::Provider(err) => Error::Execution(err.into()),
+            err => err,
+        })?;
 
         provider.commit()?;
 

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1075,9 +1075,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
 
         let (blocks, state) = chain.into_inner();
 
-        provider
-            .append_blocks_with_post_state(blocks.into_blocks().collect(), state)
-            .map_err(BlockExecutionError::from)?;
+        provider.append_blocks_with_post_state(blocks.into_blocks().collect(), state)?;
 
         provider.commit()?;
 

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1420,7 +1420,7 @@ mod tests {
         // reinsert two blocks that point to canonical chain
         assert_eq!(
             tree.insert_block(block1a.clone()).unwrap(),
-            InsertPayloadOk::Inserted(BlockStatus::Accepted)
+            InsertPayloadOk::Inserted(BlockStatus::Valid)
         );
 
         TreeTester::default()
@@ -1435,7 +1435,7 @@ mod tests {
 
         assert_eq!(
             tree.insert_block(block2a.clone()).unwrap(),
-            InsertPayloadOk::Inserted(BlockStatus::Accepted)
+            InsertPayloadOk::Inserted(BlockStatus::Valid)
         );
         // Trie state:
         // b2   b2a (side chain)

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1075,10 +1075,12 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
 
         let (blocks, state) = chain.into_inner();
 
-        provider.append_blocks_with_post_state(blocks.into_blocks().collect(), state).map_err(|err| match err {
-            Error::Provider(err) => Error::Execution(err.into()),
-            err => err,
-        })?;
+        provider.append_blocks_with_post_state(blocks.into_blocks().collect(), state).map_err(
+            |err| match err {
+                Error::Provider(err) => Error::Execution(err.into()),
+                err => err,
+            },
+        )?;
 
         provider.commit()?;
 

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1066,7 +1066,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
 
         provider
             .append_blocks_with_post_state(blocks.into_blocks().collect(), state)
-            .map_err(|e| BlockExecutionError::CanonicalCommit { inner: e.to_string() })?;
+            .map_err(BlockExecutionError::from)?;
 
         provider.commit()?;
 

--- a/crates/blockchain-tree/src/chain.rs
+++ b/crates/blockchain-tree/src/chain.rs
@@ -258,12 +258,14 @@ impl AppendableChain {
         C: Consensus,
         EF: ExecutorFactory,
     {
+        // TODO: remove distinction between the two methods now that we unwind / commit for
+        // sidechain root validation?
         Self::validate_and_execute(
             block,
             parent_block,
             post_state_data_provider,
             externals,
-            BlockKind::ForksHistoricalBlock,
+            BlockKind::ExtendsCanonicalHead,
         )
     }
 

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -508,6 +508,8 @@ where
     /// Checks if the given `check` hash points to an invalid header, inserting the given `head`
     /// block into the invalid header cache if the `check` hash has a known invalid ancestor.
     ///
+    /// This also checks the `head` block itself it is invalid
+    ///
     /// Returns a payload status response according to the engine API spec if the block is known to
     /// be invalid.
     fn check_invalid_ancestor_with_head(
@@ -515,8 +517,10 @@ where
         check: H256,
         head: H256,
     ) -> Option<PayloadStatus> {
-        // check if the check hash was previously marked as invalid
-        let header = self.invalid_headers.get(&check)?;
+        // check if the check or head hash was previously marked as invalid
+        let header = self.invalid_headers
+            .get(&check)
+            .or_else(|| self.invalid_headers.get(&head))?;
 
         // populate the latest valid hash field
         let status = self.prepare_invalid_response(header.parent_hash);
@@ -609,7 +613,13 @@ where
 
         let lowest_buffered_ancestor_fcu = self.lowest_buffered_ancestor_or(state.head_block_hash);
 
-        if let Some(status) = self.check_invalid_ancestor(lowest_buffered_ancestor_fcu) {
+        // first check the buffered ancestor, invalidating the head if the buffered ancestor is
+        // invalid
+        //
+        // if the head is invalid, we also return invalid here
+        if let Some(status) = self
+            .check_invalid_ancestor_with_head(lowest_buffered_ancestor_fcu, state.head_block_hash)
+        {
             return Ok(OnForkChoiceUpdated::with_invalid(status))
         }
 

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1780,8 +1780,8 @@ mod tests {
         BeaconForkChoiceUpdateError,
     };
     use assert_matches::assert_matches;
-    use reth_primitives::{stage::StageCheckpoint, ChainSpec, ChainSpecBuilder, H256, MAINNET};
-    use reth_provider::{BlockWriter, ProviderFactory};
+    use reth_primitives::{stage::StageCheckpoint, ChainSpec, ChainSpecBuilder, H256, MAINNET, SealedBlockWithSenders};
+    use reth_provider::{BlockWriter, ProviderFactory, PostState};
     use reth_rpc_types::engine::{ForkchoiceState, ForkchoiceUpdated, PayloadStatus};
     use reth_stages::{ExecOutput, PipelineError, StageError};
     use std::{collections::VecDeque, sync::Arc, time::Duration};
@@ -2253,7 +2253,7 @@ mod tests {
             generators::{generate_keys, random_block},
         };
         use reth_primitives::{public_key_to_address, Genesis, GenesisAccount, Hardfork, U256};
-        use reth_provider::test_utils::blocks::BlockChainTestData;
+        use reth_provider::{test_utils::blocks::BlockChainTestData, PostState};
 
         #[tokio::test]
         async fn new_payload_before_forkchoice() {

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1780,8 +1780,10 @@ mod tests {
         BeaconForkChoiceUpdateError,
     };
     use assert_matches::assert_matches;
-    use reth_primitives::{stage::StageCheckpoint, ChainSpec, ChainSpecBuilder, H256, MAINNET, SealedBlockWithSenders};
-    use reth_provider::{BlockWriter, ProviderFactory, PostState};
+    use reth_primitives::{
+        stage::StageCheckpoint, ChainSpec, ChainSpecBuilder, SealedBlockWithSenders, H256, MAINNET,
+    };
+    use reth_provider::{BlockWriter, PostState, ProviderFactory};
     use reth_rpc_types::engine::{ForkchoiceState, ForkchoiceUpdated, PayloadStatus};
     use reth_stages::{ExecOutput, PipelineError, StageError};
     use std::{collections::VecDeque, sync::Arc, time::Duration};

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -518,9 +518,8 @@ where
         head: H256,
     ) -> Option<PayloadStatus> {
         // check if the check or head hash was previously marked as invalid
-        let header = self.invalid_headers
-            .get(&check)
-            .or_else(|| self.invalid_headers.get(&head))?;
+        let header =
+            self.invalid_headers.get(&check).or_else(|| self.invalid_headers.get(&head))?;
 
         // populate the latest valid hash field
         let status = self.prepare_invalid_response(header.parent_hash);

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1967,7 +1967,7 @@ mod tests {
         mut blocks: impl Iterator<Item = (&'a SealedBlockWithSenders, &'a PostState)>,
     ) {
         let factory = ProviderFactory::new(db, chain);
-        let mut provider = factory.provider_rw().unwrap();
+        let provider = factory.provider_rw().unwrap();
         blocks
             .try_for_each(|(block, state)| {
                 provider.append_blocks_with_post_state(vec![block.clone()], state.clone())

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1959,6 +1959,9 @@ mod tests {
         provider.commit().unwrap();
     }
 
+    /// This inserts blocks _and_ their PostState into the database, makes the inserted blocks
+    /// canonical, and updates the pipeline progress based on the new blocks.
+    ///
     /// Use this instead of [insert_blocks] when inserting hashes and calculating history indices
     /// for each block is needed
     fn append_blocks<'a, DB: Database>(

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1950,7 +1950,8 @@ mod tests {
         provider.commit().unwrap();
     }
 
-    /// Use this instead of [insert_blocks] when inserting hashes for each block is needed
+    /// Use this instead of [insert_blocks] when inserting hashes and calculating history indices
+    /// for each block is needed
     fn append_blocks<'a, DB: Database>(
         db: &DB,
         chain: Arc<ChainSpec>,

--- a/crates/interfaces/src/executor.rs
+++ b/crates/interfaces/src/executor.rs
@@ -1,4 +1,4 @@
-use reth_primitives::{BlockHash, BlockNumHash, Bloom, H256};
+use reth_primitives::{BlockHash, BlockNumHash, Bloom, H256, BlockNumber};
 use thiserror::Error;
 
 /// Transaction validation errors
@@ -24,6 +24,18 @@ pub enum BlockValidationError {
     BlockPreMerge { hash: H256 },
     #[error("Missing total difficulty")]
     MissingTotalDifficulty { hash: H256 },
+    /// Root mismatch
+    #[error("Merkle trie root mismatch at #{block_number} ({block_hash:?}). Got: {got:?}. Expected: {expected:?}")]
+    StateRootMismatch {
+        /// Expected root
+        expected: H256,
+        /// Calculated root
+        got: H256,
+        /// Block number
+        block_number: BlockNumber,
+        /// Block hash
+        block_hash: BlockHash,
+    },
 }
 
 /// BlockExecutor Errors

--- a/crates/interfaces/src/executor.rs
+++ b/crates/interfaces/src/executor.rs
@@ -1,4 +1,4 @@
-use reth_primitives::{BlockHash, BlockNumHash, Bloom, H256, BlockNumber};
+use reth_primitives::{BlockHash, BlockNumHash, BlockNumber, Bloom, H256};
 use thiserror::Error;
 
 /// Transaction validation errors

--- a/crates/interfaces/src/provider.rs
+++ b/crates/interfaces/src/provider.rs
@@ -1,5 +1,5 @@
-use reth_primitives::{Address, BlockHash, BlockHashOrNumber, BlockNumber, TxNumber, H256};
 use crate::executor::{BlockExecutionError, BlockValidationError};
+use reth_primitives::{Address, BlockHash, BlockHashOrNumber, BlockNumber, TxNumber, H256};
 
 /// Bundled errors variants thrown by various providers.
 #[allow(missing_docs)]

--- a/crates/interfaces/src/provider.rs
+++ b/crates/interfaces/src/provider.rs
@@ -1,4 +1,5 @@
 use reth_primitives::{Address, BlockHash, BlockHashOrNumber, BlockNumber, TxNumber, H256};
+use crate::executor::{BlockExecutionError, BlockValidationError};
 
 /// Bundled errors variants thrown by various providers.
 #[allow(missing_docs)]
@@ -96,4 +97,16 @@ pub enum ProviderError {
     },
     #[error("State at block #{0} is pruned")]
     StateAtBlockPruned(BlockNumber),
+}
+
+impl From<ProviderError> for BlockExecutionError {
+    fn from(value: ProviderError) -> Self {
+        match value {
+            ProviderError::StateRootMismatch { expected, got, block_number, block_hash } => {
+                BlockValidationError::StateRootMismatch { expected, got, block_number, block_hash }
+                    .into()
+            }
+            err => Self::CanonicalCommit { inner: err.to_string() },
+        }
+    }
 }

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -548,6 +548,7 @@ fn build_payload<Pool, Client>(
     Client: StateProviderFactory,
     Pool: TransactionPool,
 {
+    #[allow(clippy::result_large_err)]
     #[inline(always)]
     fn try_build<Pool, Client>(
         client: Client,
@@ -731,6 +732,7 @@ fn build_payload<Pool, Client>(
 }
 
 /// Builds an empty payload without any transactions.
+#[allow(clippy::result_large_err)]
 fn build_empty_payload<Client>(
     client: &Client,
     config: PayloadConfig,

--- a/crates/payload/builder/src/error.rs
+++ b/crates/payload/builder/src/error.rs
@@ -24,6 +24,12 @@ pub enum PayloadBuilderError {
     WithdrawalsBeforeShanghai,
 }
 
+impl From<reth_interfaces::Error> for Box<PayloadBuilderError> {
+    fn from(value: reth_interfaces::Error) -> Self {
+        Box::new(PayloadBuilderError::Internal(value))
+    }
+}
+
 impl From<oneshot::error::RecvError> for PayloadBuilderError {
     fn from(_: oneshot::error::RecvError) -> Self {
         PayloadBuilderError::ChannelClosed

--- a/crates/rpc/rpc-engine-api/src/error.rs
+++ b/crates/rpc/rpc-engine-api/src/error.rs
@@ -74,7 +74,13 @@ pub enum EngineApiError {
     Internal(Box<dyn std::error::Error + Send + Sync>),
     /// Fetching the payload failed
     #[error(transparent)]
-    GetPayloadError(#[from] PayloadBuilderError),
+    GetPayloadError(#[from] Box<PayloadBuilderError>),
+}
+
+impl From<PayloadBuilderError> for EngineApiError {
+    fn from(value: PayloadBuilderError) -> Self {
+        EngineApiError::GetPayloadError(Box::new(value))
+    }
 }
 
 impl From<EngineApiError> for jsonrpsee_types::error::ErrorObject<'static> {

--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -1,4 +1,4 @@
-use reth_interfaces::{db::DatabaseError as DbError, provider::ProviderError};
+use reth_interfaces::{db::DatabaseError as DbError, provider::ProviderError, executor::{BlockExecutionError, BlockValidationError}};
 use reth_primitives::{BlockHash, BlockNumber, H256};
 use reth_trie::StateRootError;
 use std::fmt::Debug;

--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -1,4 +1,8 @@
-use reth_interfaces::{db::DatabaseError as DbError, provider::ProviderError, executor::{BlockExecutionError, BlockValidationError}};
+use reth_interfaces::{
+    db::DatabaseError as DbError,
+    executor::{BlockExecutionError, BlockValidationError},
+    provider::ProviderError,
+};
 use reth_primitives::{BlockHash, BlockNumber, H256};
 use reth_trie::StateRootError;
 use std::fmt::Debug;

--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -1,8 +1,4 @@
-use reth_interfaces::{
-    db::DatabaseError as DbError,
-    executor::{BlockExecutionError, BlockValidationError},
-    provider::ProviderError,
-};
+use reth_interfaces::{db::DatabaseError as DbError, provider::ProviderError};
 use reth_primitives::{BlockHash, BlockNumber, H256};
 use reth_trie::StateRootError;
 use std::fmt::Debug;


### PR DESCRIPTION
**DO NOT MERGE**

This validates sidechain state roots by first unwinding, trying to insert the new payload, and then re-committing the unwinded data.

Fixes #3060
Fixes #3057

TODO:
 - [x] fix `latestValidHash` - currently is incorrect for invalid payloads on forks
 - [x] remove unwraps