### PR TITLE
feat(net): update peer records in the network peerset

### DIFF
--- a/crates/net/network/src/discovery.rs
+++ b/crates/net/network/src/discovery.rs
@@ -191,8 +191,9 @@ impl Discovery {
                 self.on_node_record_update(node, Some(fork_id));
                 self.queued_events.push_back(DiscoveryEvent::EnrForkId(node.id, fork_id))
             }
-            DiscoveryUpdate::Removed(node) => {
-                self.discovered_nodes.remove(&node);
+            DiscoveryUpdate::Removed(_node) => {
+                // Since we want to keep track of all nodes we have discovered here,
+                // we don't remove them when they are removed from the discv4 table.
             }
             DiscoveryUpdate::Batch(updates) => {
                 for update in updates {

--- a/crates/net/network/src/discovery.rs
+++ b/crates/net/network/src/discovery.rs
@@ -193,9 +193,15 @@ impl Discovery {
                 self.on_node_record_update(node, Some(fork_id));
                 self.queued_events.push_back(DiscoveryEvent::EnrForkId(node.id, fork_id))
             }
-            DiscoveryUpdate::Removed(_node) => {
-                // Since we want to keep track of all nodes we have discovered here,
-                // we don't remove them when they are removed from the discv4 table.
+            DiscoveryUpdate::Removed(node) => {
+                // If the node was removed from the Discv4 table, it was for good reason (i.e.
+                // liveness failure) so we remove it from our discovered nodes.
+                self.discovered_nodes.remove(&node);
+                todo!("Handle removed nodes with event");
+            }
+            DiscoveryUpdate::Expired(node) => {
+                self.discovered_nodes.remove(&node);
+                todo!("Handle expired nodes with event");
             }
             DiscoveryUpdate::Batch(updates) => {
                 for update in updates {


### PR DESCRIPTION
Closes #1415 

To Do
- [x] Keep more descriptive records of discovered peers in `Discovery` peerset
- [x] Add heartbeat to `Discovery` for checking bond durations
- [x] Add commands to discv4 to poll peer for updates (just calls discv4 `Ping`)
- [ ] Add events to notify of discovery changes
- [ ] Add event handlers to `PeersManager` to manage these events
- [ ] Tests

Questions
* Since we essentially mimic the bond expiration functionality in `Discovery`, should we remove it from `Discv4`?