### PR TITLE
fix(bin): unwind CLI `to-block` behavior

### DIFF
--- a/bin/reth/src/stage/unwind.rs
+++ b/bin/reth/src/stage/unwind.rs
@@ -109,8 +109,8 @@ impl Subcommands {
                     .ok_or_else(|| eyre::eyre!("Block hash not found in database: {hash:?}"))?,
                 BlockHashOrNumber::Number(num) => *num,
             },
-            Subcommands::NumBlocks { amount } => last.0.saturating_sub(*amount) + 1,
-        };
+            Subcommands::NumBlocks { amount } => last.0.saturating_sub(*amount),
+        } + 1;
         Ok(target..=last.0)
     }
 }


### PR DESCRIPTION
`reth stage unwind to-block` unwound to the `block_number - 1` instead of `block_number`. It worked correctly with `num-blocks` because of the `+1` we already had.

### Before
```console
➜  reth git:(alexey/process-metrics) cargo run -- db get SyncStage Execution
{
  "block_number": 100000,
  "stage_checkpoint": {
    "Execution": {
      "block_range": {
        "from": 1,
        "to": 100000
      },
      "progress": {
        "processed": 1076556951,
        "total": 1076556951
      }
    }
  }
}
➜  reth git:(alexey/process-metrics) cargo run -- stage unwind to-block 90000
Unwound 10001 blocks
➜  reth git:(alexey/process-metrics) cargo run -- db get SyncStage Execution
{
  "block_number": 89999,
  "stage_checkpoint": null
}
```

### After
```console
➜  reth git:(alexey/fix-unwind-cli-target) cargo run -- db get SyncStage Execution
{
  "block_number": 100000,
  "stage_checkpoint": {
    "Execution": {
      "block_range": {
        "from": 90000,
        "to": 100000
      },
      "progress": {
        "processed": 1076556951,
        "total": 1076556951
      }
    }
  }
}
➜  reth git:(alexey/fix-unwind-cli-target) cargo run -- stage unwind to-block 90000
Unwound 10000 blocks
➜  reth git:(alexey/fix-unwind-cli-target) cargo run -- db get SyncStage Execution
{
  "block_number": 90000,
  "stage_checkpoint": null
}
```