### PR TITLE
chore: replace todo with error

### DIFF
--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -529,7 +529,7 @@ fn trace_transaction(
                     return Ok((frame.into(), res.state))
                 }
                 GethDebugBuiltInTracerType::PreStateTracer => {
-                    todo!()
+                    Err(EthApiError::Unsupported("prestate tracer is unimplemented yet."))
                 }
                 GethDebugBuiltInTracerType::NoopTracer => {
                     Ok((NoopFrame::default().into(), Default::default()))


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at adddfda</samp>

Handle `PreStateTracer` variant in `debug_traceTransaction` RPC method. Return an error instead of panicking when using the unimplemented `PreStateTracer` in `crates/rpc/rpc/src/debug.rs`.