### PR TITLE
Set namespace in one place

### DIFF
--- a/crates/rpc/rpc-api/src/admin.rs
+++ b/crates/rpc/rpc-api/src/admin.rs
@@ -4,39 +4,39 @@ use reth_rpc_types::NodeInfo;
 
 /// Admin namespace rpc interface that gives access to several non-standard RPC methods.
 #[cfg_attr(not(feature = "client"), rpc(server))]
-#[cfg_attr(feature = "client", rpc(server, client))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "admin"))]
 #[async_trait::async_trait]
 pub trait AdminApi {
     /// Adds the given node record to the peerset.
-    #[method(name = "admin_addPeer")]
+    #[method(name = "addPeer")]
     fn add_peer(&self, record: NodeRecord) -> RpcResult<bool>;
 
     /// Disconnects from a remote node if the connection exists.
     ///
     /// Returns true if the peer was successfully removed.
-    #[method(name = "admin_removePeer")]
+    #[method(name = "removePeer")]
     fn remove_peer(&self, record: NodeRecord) -> RpcResult<bool>;
 
     /// Adds the given node record to the trusted peerset.
-    #[method(name = "admin_addTrustedPeer")]
+    #[method(name = "addTrustedPeer")]
     fn add_trusted_peer(&self, record: NodeRecord) -> RpcResult<bool>;
 
     /// Removes a remote node from the trusted peer set, but it does not disconnect it
     /// automatically.
     ///
     /// Returns true if the peer was successfully removed.
-    #[method(name = "admin_removeTrustedPeer")]
+    #[method(name = "removeTrustedPeer")]
     fn remove_trusted_peer(&self, record: NodeRecord) -> RpcResult<bool>;
 
     /// Creates an RPC subscription which serves events received from the network.
     #[subscription(
-        name = "admin_peerEvents",
-        unsubscribe = "admin_peerEvents_unsubscribe",
+        name = "peerEvents",
+        unsubscribe = "peerEvents_unsubscribe",
         item = String
     )]
     async fn subscribe_peer_events(&self) -> jsonrpsee::core::SubscriptionResult;
 
     /// Returns the ENR of the node.
-    #[method(name = "admin_nodeInfo")]
+    #[method(name = "nodeInfo")]
     async fn node_info(&self) -> RpcResult<NodeInfo>;
 }

--- a/crates/rpc/rpc-api/src/admin.rs
+++ b/crates/rpc/rpc-api/src/admin.rs
@@ -3,7 +3,7 @@ use reth_primitives::NodeRecord;
 use reth_rpc_types::NodeInfo;
 
 /// Admin namespace rpc interface that gives access to several non-standard RPC methods.
-#[cfg_attr(not(feature = "client"), rpc(server))]
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "admin"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "admin"))]
 #[async_trait::async_trait]
 pub trait AdminApi {
@@ -30,9 +30,9 @@ pub trait AdminApi {
 
     /// Creates an RPC subscription which serves events received from the network.
     #[subscription(
-        name = "peerEvents",
-        unsubscribe = "peerEvents_unsubscribe",
-        item = String
+    name = "peerEvents",
+    unsubscribe = "peerEvents_unsubscribe",
+    item = String
     )]
     async fn subscribe_peer_events(&self) -> jsonrpsee::core::SubscriptionResult;
 

--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -10,31 +10,31 @@ use reth_rpc_types::{
 
 /// Debug rpc interface.
 #[cfg_attr(not(feature = "client"), rpc(server))]
-#[cfg_attr(feature = "client", rpc(server, client))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "debug"))]
 pub trait DebugApi {
     /// Returns an RLP-encoded header.
-    #[method(name = "debug_getRawHeader")]
+    #[method(name = "getRawHeader")]
     async fn raw_header(&self, block_id: BlockId) -> RpcResult<Bytes>;
 
     /// Returns an RLP-encoded block.
-    #[method(name = "debug_getRawBlock")]
+    #[method(name = "getRawBlock")]
     async fn raw_block(&self, block_id: BlockId) -> RpcResult<Bytes>;
 
     /// Returns a EIP-2718 binary-encoded transaction.
-    #[method(name = "debug_getRawTransaction")]
+    #[method(name = "getRawTransaction")]
     async fn raw_transaction(&self, hash: H256) -> RpcResult<Bytes>;
 
     /// Returns an array of EIP-2718 binary-encoded receipts.
-    #[method(name = "debug_getRawReceipts")]
+    #[method(name = "getRawReceipts")]
     async fn raw_receipts(&self, block_id: BlockId) -> RpcResult<Vec<Bytes>>;
 
     /// Returns an array of recent bad blocks that the client has seen on the network.
-    #[method(name = "debug_getBadBlocks")]
+    #[method(name = "getBadBlocks")]
     async fn bad_blocks(&self) -> RpcResult<Vec<RichBlock>>;
 
     /// Returns the structured logs created during the execution of EVM between two blocks
     /// (excluding start) as a JSON object.
-    #[method(name = "debug_traceChain")]
+    #[method(name = "traceChain")]
     async fn debug_trace_chain(
         &self,
         start_exclusive: BlockNumberOrTag,
@@ -48,7 +48,7 @@ pub trait DebugApi {
     ///
     /// Note, the parent of this block must be present, or it will fail. For the second parameter
     /// see [GethDebugTracingOptions] reference.
-    #[method(name = "debug_traceBlock")]
+    #[method(name = "traceBlock")]
     async fn debug_trace_block(
         &self,
         rlp_block: Bytes,
@@ -58,7 +58,7 @@ pub trait DebugApi {
     /// Similar to `debug_traceBlock`, `debug_traceBlockByHash` accepts a block hash and will replay
     /// the block that is already present in the database. For the second parameter see
     /// [GethDebugTracingOptions].
-    #[method(name = "debug_traceBlockByHash")]
+    #[method(name = "traceBlockByHash")]
     async fn debug_trace_block_by_hash(
         &self,
         block: H256,
@@ -68,7 +68,7 @@ pub trait DebugApi {
     /// Similar to `debug_traceBlockByNumber`, `debug_traceBlockByHash` accepts a block number
     /// [BlockNumberOrTag] and will replay the block that is already present in the database.
     /// For the second parameter see [GethDebugTracingOptions].
-    #[method(name = "debug_traceBlockByNumber")]
+    #[method(name = "traceBlockByNumber")]
     async fn debug_trace_block_by_number(
         &self,
         block: BlockNumberOrTag,
@@ -79,7 +79,7 @@ pub trait DebugApi {
     /// exact same manner as it was executed on the network. It will replay any transaction that
     /// may have been executed prior to this one before it will finally attempt to execute the
     /// transaction that corresponds to the given hash.
-    #[method(name = "debug_traceTransaction")]
+    #[method(name = "traceTransaction")]
     async fn debug_trace_transaction(
         &self,
         tx_hash: H256,
@@ -95,7 +95,7 @@ pub trait DebugApi {
     /// The trace can be configured similar to `debug_traceTransaction`,
     /// see [GethDebugTracingOptions]. The method returns the same output as
     /// `debug_traceTransaction`.
-    #[method(name = "debug_traceCall")]
+    #[method(name = "traceCall")]
     async fn debug_trace_call(
         &self,
         request: CallRequest,

--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -9,7 +9,7 @@ use reth_rpc_types::{
 };
 
 /// Debug rpc interface.
-#[cfg_attr(not(feature = "client"), rpc(server))]
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "debug"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "debug"))]
 pub trait DebugApi {
     /// Returns an RLP-encoded header.

--- a/crates/rpc/rpc-api/src/engine.rs
+++ b/crates/rpc/rpc-api/src/engine.rs
@@ -101,23 +101,23 @@ pub trait EngineApi {
 ///
 /// Specifically for the engine auth server: <https://github.com/ethereum/execution-apis/blob/main/src/engine/common.md#underlying-protocol>
 #[cfg_attr(not(feature = "client"), rpc(server))]
-#[cfg_attr(feature = "client", rpc(server, client))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "eth"))]
 #[async_trait]
 pub trait EngineEthApi {
     /// Returns an object with data about the sync status or false.
-    #[method(name = "eth_syncing")]
+    #[method(name = "syncing")]
     fn syncing(&self) -> RpcResult<SyncStatus>;
 
     /// Returns the chain ID of the current network.
-    #[method(name = "eth_chainId")]
+    #[method(name = "chainId")]
     async fn chain_id(&self) -> RpcResult<Option<U64>>;
 
     /// Returns the number of most recent block.
-    #[method(name = "eth_blockNumber")]
+    #[method(name = "blockNumber")]
     fn block_number(&self) -> RpcResult<U256>;
 
     /// Executes a new message call immediately without creating a transaction on the block chain.
-    #[method(name = "eth_call")]
+    #[method(name = "call")]
     async fn call(
         &self,
         request: CallRequest,
@@ -126,15 +126,15 @@ pub trait EngineEthApi {
     ) -> RpcResult<Bytes>;
 
     /// Returns code at a given address at given block number.
-    #[method(name = "eth_getCode")]
+    #[method(name = "getCode")]
     async fn get_code(&self, address: Address, block_number: Option<BlockId>) -> RpcResult<Bytes>;
 
     /// Returns information about a block by hash.
-    #[method(name = "eth_getBlockByHash")]
+    #[method(name = "getBlockByHash")]
     async fn block_by_hash(&self, hash: H256, full: bool) -> RpcResult<Option<RichBlock>>;
 
     /// Returns information about a block by number.
-    #[method(name = "eth_getBlockByNumber")]
+    #[method(name = "getBlockByNumber")]
     async fn block_by_number(
         &self,
         number: BlockNumberOrTag,
@@ -142,10 +142,10 @@ pub trait EngineEthApi {
     ) -> RpcResult<Option<RichBlock>>;
 
     /// Sends signed transaction, returning its hash.
-    #[method(name = "eth_sendRawTransaction")]
+    #[method(name = "sendRawTransaction")]
     async fn send_raw_transaction(&self, bytes: Bytes) -> RpcResult<H256>;
 
     /// Returns logs matching given filter object.
-    #[method(name = "eth_getLogs")]
+    #[method(name = "getLogs")]
     async fn logs(&self, filter: Filter) -> RpcResult<Vec<Log>>;
 }

--- a/crates/rpc/rpc-api/src/engine.rs
+++ b/crates/rpc/rpc-api/src/engine.rs
@@ -10,21 +10,21 @@ use reth_rpc_types::{
 };
 
 #[cfg_attr(not(feature = "client"), rpc(server))]
-#[cfg_attr(feature = "client", rpc(server, client))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "engine"))]
 pub trait EngineApi {
     /// See also <https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/paris.md#engine_newpayloadv1>
     /// Caution: This should not accept the `withdrawals` field
-    #[method(name = "engine_newPayloadV1")]
+    #[method(name = "newPayloadV1")]
     async fn new_payload_v1(&self, payload: ExecutionPayload) -> RpcResult<PayloadStatus>;
 
     /// See also <https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/shanghai.md#engine_newpayloadv2>
-    #[method(name = "engine_newPayloadV2")]
+    #[method(name = "newPayloadV2")]
     async fn new_payload_v2(&self, payload: ExecutionPayload) -> RpcResult<PayloadStatus>;
 
     /// See also <https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/paris.md#engine_forkchoiceupdatedv1>
     ///
     /// Caution: This should not accept the `withdrawals` field
-    #[method(name = "engine_forkchoiceUpdatedV1")]
+    #[method(name = "forkchoiceUpdatedV1")]
     async fn fork_choice_updated_v1(
         &self,
         fork_choice_state: ForkchoiceState,
@@ -32,7 +32,7 @@ pub trait EngineApi {
     ) -> RpcResult<ForkchoiceUpdated>;
 
     /// See also <https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/shanghai.md#engine_forkchoiceupdatedv2>
-    #[method(name = "engine_forkchoiceUpdatedV2")]
+    #[method(name = "forkchoiceUpdatedV2")]
     async fn fork_choice_updated_v2(
         &self,
         fork_choice_state: ForkchoiceState,
@@ -48,7 +48,7 @@ pub trait EngineApi {
     ///
     /// Note:
     /// > Client software MAY stop the corresponding build process after serving this call.
-    #[method(name = "engine_getPayloadV1")]
+    #[method(name = "getPayloadV1")]
     async fn get_payload_v1(&self, payload_id: PayloadId) -> RpcResult<ExecutionPayload>;
 
     /// See also <https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/shanghai.md#engine_getpayloadv2>
@@ -56,11 +56,11 @@ pub trait EngineApi {
     /// Returns the most recent version of the payload that is available in the corresponding
     /// payload build process at the time of receiving this call. Note:
     /// > Client software MAY stop the corresponding build process after serving this call.
-    #[method(name = "engine_getPayloadV2")]
+    #[method(name = "getPayloadV2")]
     async fn get_payload_v2(&self, payload_id: PayloadId) -> RpcResult<ExecutionPayloadEnvelope>;
 
     /// See also <https://github.com/ethereum/execution-apis/blob/6452a6b194d7db269bf1dbd087a267251d3cc7f8/src/engine/shanghai.md#engine_getpayloadbodiesbyhashv1>
-    #[method(name = "engine_getPayloadBodiesByHashV1")]
+    #[method(name = "getPayloadBodiesByHashV1")]
     async fn get_payload_bodies_by_hash_v1(
         &self,
         block_hashes: Vec<BlockHash>,
@@ -78,7 +78,7 @@ pub trait EngineApi {
     /// Implementors should take care when acting on the input to this method, specifically
     /// ensuring that the range is limited properly, and that the range boundaries are computed
     /// correctly and without panics.
-    #[method(name = "engine_getPayloadBodiesByRangeV1")]
+    #[method(name = "getPayloadBodiesByRangeV1")]
     async fn get_payload_bodies_by_range_v1(
         &self,
         start: U64,
@@ -86,14 +86,14 @@ pub trait EngineApi {
     ) -> RpcResult<ExecutionPayloadBodies>;
 
     /// See also <https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/paris.md#engine_exchangetransitionconfigurationv1>
-    #[method(name = "engine_exchangeTransitionConfigurationV1")]
+    #[method(name = "exchangeTransitionConfigurationV1")]
     async fn exchange_transition_configuration(
         &self,
         transition_configuration: TransitionConfiguration,
     ) -> RpcResult<TransitionConfiguration>;
 
     /// See also <https://github.com/ethereum/execution-apis/blob/6452a6b194d7db269bf1dbd087a267251d3cc7f8/src/engine/common.md#capabilities>
-    #[method(name = "engine_exchangeCapabilities")]
+    #[method(name = "exchangeCapabilities")]
     async fn exchange_capabilities(&self, capabilities: Vec<String>) -> RpcResult<Vec<String>>;
 }
 

--- a/crates/rpc/rpc-api/src/engine.rs
+++ b/crates/rpc/rpc-api/src/engine.rs
@@ -9,7 +9,7 @@ use reth_rpc_types::{
     CallRequest, Filter, Log, RichBlock, SyncStatus,
 };
 
-#[cfg_attr(not(feature = "client"), rpc(server))]
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "engine"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "engine"))]
 pub trait EngineApi {
     /// See also <https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/paris.md#engine_newpayloadv1>
@@ -100,7 +100,7 @@ pub trait EngineApi {
 /// A subset of the ETH rpc interface: <https://ethereum.github.io/execution-apis/api-documentation/>
 ///
 /// Specifically for the engine auth server: <https://github.com/ethereum/execution-apis/blob/main/src/engine/common.md#underlying-protocol>
-#[cfg_attr(not(feature = "client"), rpc(server))]
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "eth"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "eth"))]
 #[async_trait]
 pub trait EngineEthApi {

--- a/crates/rpc/rpc-api/src/eth.rs
+++ b/crates/rpc/rpc-api/src/eth.rs
@@ -9,7 +9,7 @@ use reth_rpc_types::{
 };
 
 /// Eth rpc interface: <https://ethereum.github.io/execution-apis/api-documentation/>
-#[cfg_attr(not(feature = "client"), rpc(server))]
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "eth"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "eth"))]
 #[async_trait]
 pub trait EthApi {

--- a/crates/rpc/rpc-api/src/eth.rs
+++ b/crates/rpc/rpc-api/src/eth.rs
@@ -10,39 +10,39 @@ use reth_rpc_types::{
 
 /// Eth rpc interface: <https://ethereum.github.io/execution-apis/api-documentation/>
 #[cfg_attr(not(feature = "client"), rpc(server))]
-#[cfg_attr(feature = "client", rpc(server, client))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "eth"))]
 #[async_trait]
 pub trait EthApi {
     /// Returns the protocol version encoded as a string.
-    #[method(name = "eth_protocolVersion")]
+    #[method(name = "protocolVersion")]
     async fn protocol_version(&self) -> RpcResult<U64>;
 
     /// Returns an object with data about the sync status or false.
-    #[method(name = "eth_syncing")]
+    #[method(name = "syncing")]
     fn syncing(&self) -> RpcResult<SyncStatus>;
 
     /// Returns the client coinbase address.
-    #[method(name = "eth_coinbase")]
+    #[method(name = "coinbase")]
     async fn author(&self) -> RpcResult<Address>;
 
     /// Returns a list of addresses owned by client.
-    #[method(name = "eth_accounts")]
+    #[method(name = "accounts")]
     async fn accounts(&self) -> RpcResult<Vec<Address>>;
 
     /// Returns the number of most recent block.
-    #[method(name = "eth_blockNumber")]
+    #[method(name = "blockNumber")]
     fn block_number(&self) -> RpcResult<U256>;
 
     /// Returns the chain ID of the current network.
-    #[method(name = "eth_chainId")]
+    #[method(name = "chainId")]
     async fn chain_id(&self) -> RpcResult<Option<U64>>;
 
     /// Returns information about a block by hash.
-    #[method(name = "eth_getBlockByHash")]
+    #[method(name = "getBlockByHash")]
     async fn block_by_hash(&self, hash: H256, full: bool) -> RpcResult<Option<RichBlock>>;
 
     /// Returns information about a block by number.
-    #[method(name = "eth_getBlockByNumber")]
+    #[method(name = "getBlockByNumber")]
     async fn block_by_number(
         &self,
         number: BlockNumberOrTag,
@@ -50,29 +50,29 @@ pub trait EthApi {
     ) -> RpcResult<Option<RichBlock>>;
 
     /// Returns the number of transactions in a block from a block matching the given block hash.
-    #[method(name = "eth_getBlockTransactionCountByHash")]
+    #[method(name = "getBlockTransactionCountByHash")]
     async fn block_transaction_count_by_hash(&self, hash: H256) -> RpcResult<Option<U256>>;
 
     /// Returns the number of transactions in a block matching the given block number.
-    #[method(name = "eth_getBlockTransactionCountByNumber")]
+    #[method(name = "getBlockTransactionCountByNumber")]
     async fn block_transaction_count_by_number(
         &self,
         number: BlockNumberOrTag,
     ) -> RpcResult<Option<U256>>;
 
     /// Returns the number of uncles in a block from a block matching the given block hash.
-    #[method(name = "eth_getUncleCountByBlockHash")]
+    #[method(name = "getUncleCountByBlockHash")]
     async fn block_uncles_count_by_hash(&self, hash: H256) -> RpcResult<Option<U256>>;
 
     /// Returns the number of uncles in a block with given block number.
-    #[method(name = "eth_getUncleCountByBlockNumber")]
+    #[method(name = "getUncleCountByBlockNumber")]
     async fn block_uncles_count_by_number(
         &self,
         number: BlockNumberOrTag,
     ) -> RpcResult<Option<U256>>;
 
     /// Returns an uncle block of the given block and index.
-    #[method(name = "eth_getUncleByBlockHashAndIndex")]
+    #[method(name = "getUncleByBlockHashAndIndex")]
     async fn uncle_by_block_hash_and_index(
         &self,
         hash: H256,
@@ -80,7 +80,7 @@ pub trait EthApi {
     ) -> RpcResult<Option<RichBlock>>;
 
     /// Returns an uncle block of the given block and index.
-    #[method(name = "eth_getUncleByBlockNumberAndIndex")]
+    #[method(name = "getUncleByBlockNumberAndIndex")]
     async fn uncle_by_block_number_and_index(
         &self,
         number: BlockNumberOrTag,
@@ -88,11 +88,11 @@ pub trait EthApi {
     ) -> RpcResult<Option<RichBlock>>;
 
     /// Returns the information about a transaction requested by transaction hash.
-    #[method(name = "eth_getTransactionByHash")]
+    #[method(name = "getTransactionByHash")]
     async fn transaction_by_hash(&self, hash: H256) -> RpcResult<Option<Transaction>>;
 
     /// Returns information about a transaction by block hash and transaction index position.
-    #[method(name = "eth_getTransactionByBlockHashAndIndex")]
+    #[method(name = "getTransactionByBlockHashAndIndex")]
     async fn transaction_by_block_hash_and_index(
         &self,
         hash: H256,
@@ -100,7 +100,7 @@ pub trait EthApi {
     ) -> RpcResult<Option<Transaction>>;
 
     /// Returns information about a transaction by block number and transaction index position.
-    #[method(name = "eth_getTransactionByBlockNumberAndIndex")]
+    #[method(name = "getTransactionByBlockNumberAndIndex")]
     async fn transaction_by_block_number_and_index(
         &self,
         number: BlockNumberOrTag,
@@ -108,15 +108,15 @@ pub trait EthApi {
     ) -> RpcResult<Option<Transaction>>;
 
     /// Returns the receipt of a transaction by transaction hash.
-    #[method(name = "eth_getTransactionReceipt")]
+    #[method(name = "getTransactionReceipt")]
     async fn transaction_receipt(&self, hash: H256) -> RpcResult<Option<TransactionReceipt>>;
 
     /// Returns the balance of the account of given address.
-    #[method(name = "eth_getBalance")]
+    #[method(name = "getBalance")]
     async fn balance(&self, address: Address, block_number: Option<BlockId>) -> RpcResult<U256>;
 
     /// Returns the value from a storage position at a given address
-    #[method(name = "eth_getStorageAt")]
+    #[method(name = "getStorageAt")]
     async fn storage_at(
         &self,
         address: Address,
@@ -125,7 +125,7 @@ pub trait EthApi {
     ) -> RpcResult<H256>;
 
     /// Returns the number of transactions sent from an address at given block number.
-    #[method(name = "eth_getTransactionCount")]
+    #[method(name = "getTransactionCount")]
     async fn transaction_count(
         &self,
         address: Address,
@@ -133,11 +133,11 @@ pub trait EthApi {
     ) -> RpcResult<U256>;
 
     /// Returns code at a given address at given block number.
-    #[method(name = "eth_getCode")]
+    #[method(name = "getCode")]
     async fn get_code(&self, address: Address, block_number: Option<BlockId>) -> RpcResult<Bytes>;
 
     /// Executes a new message call immediately without creating a transaction on the block chain.
-    #[method(name = "eth_call")]
+    #[method(name = "call")]
     async fn call(
         &self,
         request: CallRequest,
@@ -159,7 +159,7 @@ pub trait EthApi {
     /// when the transaction is actually mined. Adding an accessList to your transaction does
     /// not necessary result in lower gas usage compared to a transaction without an access
     /// list.
-    #[method(name = "eth_createAccessList")]
+    #[method(name = "createAccessList")]
     async fn create_access_list(
         &self,
         request: CallRequest,
@@ -168,7 +168,7 @@ pub trait EthApi {
 
     /// Generates and returns an estimate of how much gas is necessary to allow the transaction to
     /// complete.
-    #[method(name = "eth_estimateGas")]
+    #[method(name = "estimateGas")]
     async fn estimate_gas(
         &self,
         request: CallRequest,
@@ -176,11 +176,11 @@ pub trait EthApi {
     ) -> RpcResult<U256>;
 
     /// Returns the current price per gas in wei.
-    #[method(name = "eth_gasPrice")]
+    #[method(name = "gasPrice")]
     async fn gas_price(&self) -> RpcResult<U256>;
 
     /// Introduced in EIP-1159, returns suggestion for the priority for dynamic fee transactions.
-    #[method(name = "eth_maxPriorityFeePerGas")]
+    #[method(name = "maxPriorityFeePerGas")]
     async fn max_priority_fee_per_gas(&self) -> RpcResult<U256>;
 
     /// Returns the Transaction fee history
@@ -190,7 +190,7 @@ pub trait EthApi {
     /// Returns transaction base fee per gas and effective priority fee per gas for the
     /// requested/supported block range. The returned Fee history for the returned block range
     /// can be a subsection of the requested range if not all blocks are available.
-    #[method(name = "eth_feeHistory")]
+    #[method(name = "feeHistory")]
     async fn fee_history(
         &self,
         block_count: U64,
@@ -199,16 +199,16 @@ pub trait EthApi {
     ) -> RpcResult<FeeHistory>;
 
     /// Returns whether the client is actively mining new blocks.
-    #[method(name = "eth_mining")]
+    #[method(name = "mining")]
     async fn is_mining(&self) -> RpcResult<bool>;
 
     /// Returns the number of hashes per second that the node is mining with.
-    #[method(name = "eth_hashrate")]
+    #[method(name = "hashrate")]
     async fn hashrate(&self) -> RpcResult<U256>;
 
     /// Returns the hash of the current block, the seedHash, and the boundary condition to be met
     /// (“target”)
-    #[method(name = "eth_getWork")]
+    #[method(name = "getWork")]
     async fn get_work(&self) -> RpcResult<Work>;
 
     /// Used for submitting mining hashrate.
@@ -216,39 +216,39 @@ pub trait EthApi {
     /// Can be used for remote miners to submit their hash rate.
     /// It accepts the miner hash rate and an identifier which must be unique between nodes.
     /// Returns `true` if the block was successfully submitted, `false` otherwise.
-    #[method(name = "eth_submitHashrate")]
+    #[method(name = "submitHashrate")]
     async fn submit_hashrate(&self, hashrate: U256, id: H256) -> RpcResult<bool>;
 
     /// Used for submitting a proof-of-work solution.
-    #[method(name = "eth_submitWork")]
+    #[method(name = "submitWork")]
     async fn submit_work(&self, nonce: H64, pow_hash: H256, mix_digest: H256) -> RpcResult<bool>;
 
     /// Sends transaction; will block waiting for signer to return the
     /// transaction hash.
-    #[method(name = "eth_sendTransaction")]
+    #[method(name = "sendTransaction")]
     async fn send_transaction(&self, request: TransactionRequest) -> RpcResult<H256>;
 
     /// Sends signed transaction, returning its hash.
-    #[method(name = "eth_sendRawTransaction")]
+    #[method(name = "sendRawTransaction")]
     async fn send_raw_transaction(&self, bytes: Bytes) -> RpcResult<H256>;
 
     /// Returns an Ethereum specific signature with: sign(keccak256("\x19Ethereum Signed Message:\n"
     /// + len(message) + message))).
-    #[method(name = "eth_sign")]
+    #[method(name = "sign")]
     async fn sign(&self, address: Address, message: Bytes) -> RpcResult<Bytes>;
 
     /// Signs a transaction that can be submitted to the network at a later time using with
-    /// `eth_sendRawTransaction.`
-    #[method(name = "eth_signTransaction")]
+    /// `sendRawTransaction.`
+    #[method(name = "signTransaction")]
     async fn sign_transaction(&self, transaction: CallRequest) -> RpcResult<Bytes>;
 
     /// Signs data via [EIP-712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md).
-    #[method(name = "eth_signTypedData")]
+    #[method(name = "signTypedData")]
     async fn sign_typed_data(&self, address: Address, data: serde_json::Value) -> RpcResult<Bytes>;
 
     /// Returns the account and storage values of the specified account including the Merkle-proof.
     /// This call can be used to verify that the data you are pulling from is not tampered with.
-    #[method(name = "eth_getProof")]
+    #[method(name = "getProof")]
     async fn get_proof(
         &self,
         address: Address,

--- a/crates/rpc/rpc-api/src/eth_filter.rs
+++ b/crates/rpc/rpc-api/src/eth_filter.rs
@@ -3,33 +3,33 @@ use reth_rpc_types::{Filter, FilterChanges, FilterId, Log};
 
 /// Rpc Interface for poll-based ethereum filter API.
 #[cfg_attr(not(feature = "client"), rpc(server))]
-#[cfg_attr(feature = "client", rpc(server, client))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "eth"))]
 pub trait EthFilterApi {
     /// Creates anew filter and returns its id.
-    #[method(name = "eth_newFilter")]
+    #[method(name = "newFilter")]
     async fn new_filter(&self, filter: Filter) -> RpcResult<FilterId>;
 
     /// Creates a new block filter and returns its id.
-    #[method(name = "eth_newBlockFilter")]
+    #[method(name = "newBlockFilter")]
     async fn new_block_filter(&self) -> RpcResult<FilterId>;
 
     /// Creates a pending transaction filter and returns its id.
-    #[method(name = "eth_newPendingTransactionFilter")]
+    #[method(name = "newPendingTransactionFilter")]
     async fn new_pending_transaction_filter(&self) -> RpcResult<FilterId>;
 
     /// Returns all filter changes since last poll.
-    #[method(name = "eth_getFilterChanges")]
+    #[method(name = "getFilterChanges")]
     async fn filter_changes(&self, id: FilterId) -> RpcResult<FilterChanges>;
 
     /// Returns all logs matching given filter (in a range 'from' - 'to').
-    #[method(name = "eth_getFilterLogs")]
+    #[method(name = "getFilterLogs")]
     async fn filter_logs(&self, id: FilterId) -> RpcResult<Vec<Log>>;
 
     /// Uninstalls filter.
-    #[method(name = "eth_uninstallFilter")]
+    #[method(name = "uninstallFilter")]
     async fn uninstall_filter(&self, id: FilterId) -> RpcResult<bool>;
 
     /// Returns logs matching given filter object.
-    #[method(name = "eth_getLogs")]
+    #[method(name = "getLogs")]
     async fn logs(&self, filter: Filter) -> RpcResult<Vec<Log>>;
 }

--- a/crates/rpc/rpc-api/src/eth_filter.rs
+++ b/crates/rpc/rpc-api/src/eth_filter.rs
@@ -2,8 +2,8 @@ use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_rpc_types::{Filter, FilterChanges, FilterId, Log};
 
 /// Rpc Interface for poll-based ethereum filter API.
-#[cfg_attr(not(feature = "client"), rpc(server))]
-#[cfg_attr(feature = "client", rpc(server, client, namespace = "eth"))]
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "net"))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "net"))]
 pub trait EthFilterApi {
     /// Creates anew filter and returns its id.
     #[method(name = "newFilter")]

--- a/crates/rpc/rpc-api/src/eth_pubsub.rs
+++ b/crates/rpc/rpc-api/src/eth_pubsub.rs
@@ -2,7 +2,7 @@ use jsonrpsee::proc_macros::rpc;
 use reth_rpc_types::pubsub::{Params, SubscriptionKind};
 
 /// Ethereum pub-sub rpc interface.
-#[rpc(server, namespace ="eth")]
+#[rpc(server, namespace = "eth")]
 pub trait EthPubSubApi {
     /// Create an ethereum subscription for the given params
     #[subscription(

--- a/crates/rpc/rpc-api/src/eth_pubsub.rs
+++ b/crates/rpc/rpc-api/src/eth_pubsub.rs
@@ -2,12 +2,12 @@ use jsonrpsee::proc_macros::rpc;
 use reth_rpc_types::pubsub::{Params, SubscriptionKind};
 
 /// Ethereum pub-sub rpc interface.
-#[rpc(server)]
+#[rpc(server, namespace ="eth")]
 pub trait EthPubSubApi {
     /// Create an ethereum subscription for the given params
     #[subscription(
-        name = "eth_subscribe" => "eth_subscription",
-        unsubscribe = "eth_unsubscribe",
+        name = "subscribe" => "subscription",
+        unsubscribe = "unsubscribe",
         item = reth_rpc_types::pubsub::SubscriptionResult
     )]
     async fn subscribe(

--- a/crates/rpc/rpc-api/src/net.rs
+++ b/crates/rpc/rpc-api/src/net.rs
@@ -2,7 +2,7 @@ use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_rpc_types::PeerCount;
 
 /// Net rpc interface.
-#[cfg_attr(not(feature = "client"), rpc(server))]
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "net"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "net"))]
 pub trait NetApi {
     /// Returns protocol version.

--- a/crates/rpc/rpc-api/src/net.rs
+++ b/crates/rpc/rpc-api/src/net.rs
@@ -3,18 +3,18 @@ use reth_rpc_types::PeerCount;
 
 /// Net rpc interface.
 #[cfg_attr(not(feature = "client"), rpc(server))]
-#[cfg_attr(feature = "client", rpc(server, client))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "net"))]
 pub trait NetApi {
     /// Returns protocol version.
-    #[method(name = "net_version")]
+    #[method(name = "version")]
     fn version(&self) -> RpcResult<String>;
 
     /// Returns number of peers connected to node.
-    #[method(name = "net_peerCount")]
+    #[method(name = "peerCount")]
     fn peer_count(&self) -> RpcResult<PeerCount>;
 
     /// Returns true if client is actively listening for network connections.
     /// Otherwise false.
-    #[method(name = "net_listening")]
+    #[method(name = "listening")]
     fn is_listening(&self) -> RpcResult<bool>;
 }

--- a/crates/rpc/rpc-api/src/rpc.rs
+++ b/crates/rpc/rpc-api/src/rpc.rs
@@ -3,9 +3,9 @@ use reth_rpc_types::RpcModules;
 
 /// RPC namespace, used to find the versions of all rpc modules
 #[cfg_attr(not(feature = "client"), rpc(server))]
-#[cfg_attr(feature = "client", rpc(server, client))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "rpc"))]
 pub trait RpcApi {
     /// Lists enabled APIs and the version of each.
-    #[method(name = "rpc_modules")]
+    #[method(name = "modules")]
     fn rpc_modules(&self) -> RpcResult<RpcModules>;
 }

--- a/crates/rpc/rpc-api/src/rpc.rs
+++ b/crates/rpc/rpc-api/src/rpc.rs
@@ -2,7 +2,7 @@ use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_rpc_types::RpcModules;
 
 /// RPC namespace, used to find the versions of all rpc modules
-#[cfg_attr(not(feature = "client"), rpc(server))]
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "rpc"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "rpc"))]
 pub trait RpcApi {
     /// Lists enabled APIs and the version of each.

--- a/crates/rpc/rpc-api/src/trace.rs
+++ b/crates/rpc/rpc-api/src/trace.rs
@@ -7,7 +7,7 @@ use reth_rpc_types::{
 use std::collections::HashSet;
 
 /// Ethereum trace API
-#[cfg_attr(not(feature = "client"), rpc(server))]
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "trace"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "trace"))]
 pub trait TraceApi {
     /// Executes the given call and returns a number of possible traces for it.

--- a/crates/rpc/rpc-api/src/trace.rs
+++ b/crates/rpc/rpc-api/src/trace.rs
@@ -8,10 +8,10 @@ use std::collections::HashSet;
 
 /// Ethereum trace API
 #[cfg_attr(not(feature = "client"), rpc(server))]
-#[cfg_attr(feature = "client", rpc(server, client))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "trace"))]
 pub trait TraceApi {
     /// Executes the given call and returns a number of possible traces for it.
-    #[method(name = "trace_call")]
+    #[method(name = "call")]
     async fn trace_call(
         &self,
         call: CallRequest,
@@ -22,7 +22,7 @@ pub trait TraceApi {
     /// Performs multiple call traces on top of the same block. i.e. transaction n will be executed
     /// on top of a pending block with all n-1 transactions applied (traced) first. Allows to trace
     /// dependent transactions.
-    #[method(name = "trace_callMany")]
+    #[method(name = "callMany")]
     async fn trace_call_many(
         &self,
         calls: Vec<(CallRequest, HashSet<TraceType>)>,
@@ -32,7 +32,7 @@ pub trait TraceApi {
     /// Traces a call to `eth_sendRawTransaction` without making the call, returning the traces.
     ///
     /// Expects a raw transaction data
-    #[method(name = "trace_rawTransaction")]
+    #[method(name = "rawTransaction")]
     async fn trace_raw_transaction(
         &self,
         data: Bytes,
@@ -41,7 +41,7 @@ pub trait TraceApi {
     ) -> RpcResult<TraceResults>;
 
     /// Replays all transactions in a block returning the requested traces for each transaction.
-    #[method(name = "trace_replayBlockTransactions")]
+    #[method(name = "replayBlockTransactions")]
     async fn replay_block_transactions(
         &self,
         block_id: BlockId,
@@ -49,7 +49,7 @@ pub trait TraceApi {
     ) -> RpcResult<Option<Vec<TraceResultsWithTransactionHash>>>;
 
     /// Replays a transaction, returning the traces.
-    #[method(name = "trace_replayTransaction")]
+    #[method(name = "replayTransaction")]
     async fn replay_transaction(
         &self,
         transaction: H256,
@@ -57,18 +57,18 @@ pub trait TraceApi {
     ) -> RpcResult<TraceResults>;
 
     /// Returns traces created at given block.
-    #[method(name = "trace_block")]
+    #[method(name = "block")]
     async fn trace_block(
         &self,
         block_id: BlockId,
     ) -> RpcResult<Option<Vec<LocalizedTransactionTrace>>>;
 
     /// Returns traces matching given filter
-    #[method(name = "trace_filter")]
+    #[method(name = "filter")]
     async fn trace_filter(&self, filter: TraceFilter) -> RpcResult<Vec<LocalizedTransactionTrace>>;
 
     /// Returns transaction trace at given index.
-    #[method(name = "trace_get")]
+    #[method(name = "get")]
     async fn trace_get(
         &self,
         hash: H256,
@@ -76,7 +76,7 @@ pub trait TraceApi {
     ) -> RpcResult<Option<LocalizedTransactionTrace>>;
 
     /// Returns all traces of given transaction.
-    #[method(name = "trace_transaction")]
+    #[method(name = "transaction")]
     async fn trace_transaction(
         &self,
         hash: H256,

--- a/crates/rpc/rpc-api/src/txpool.rs
+++ b/crates/rpc/rpc-api/src/txpool.rs
@@ -4,33 +4,33 @@ use reth_rpc_types::txpool::{TxpoolContent, TxpoolContentFrom, TxpoolInspect, Tx
 
 /// Txpool rpc interface.
 #[cfg_attr(not(feature = "client"), rpc(server))]
-#[cfg_attr(feature = "client", rpc(server, client))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "txpool"))]
 #[async_trait::async_trait]
 pub trait TxPoolApi {
     /// Returns the number of transactions currently pending for inclusion in the next block(s), as
     /// well as the ones that are being scheduled for future execution only.
     /// Ref: [Here](https://geth.ethereum.org/docs/rpc/ns-txpool#txpool_status)
-    #[method(name = "txpool_status")]
+    #[method(name = "status")]
     async fn txpool_status(&self) -> RpcResult<TxpoolStatus>;
 
     /// Returns a summary of all the transactions currently pending for inclusion in the next
     /// block(s), as well as the ones that are being scheduled for future execution only.
     ///
     /// See [here](https://geth.ethereum.org/docs/rpc/ns-txpool#txpool_inspect) for more details
-    #[method(name = "txpool_inspect")]
+    #[method(name = "inspect")]
     async fn txpool_inspect(&self) -> RpcResult<TxpoolInspect>;
 
     /// Retrieves the transactions contained within the txpool, returning pending as well as queued
     /// transactions of this address, grouped by nonce.
     ///
     /// See [here](https://geth.ethereum.org/docs/rpc/ns-txpool#txpool_contentFrom) for more details
-    #[method(name = "txpool_contentFrom")]
+    #[method(name = "contentFrom")]
     async fn txpool_content_from(&self, from: Address) -> RpcResult<TxpoolContentFrom>;
 
     /// Returns the details of all transactions currently pending for inclusion in the next
     /// block(s), as well as the ones that are being scheduled for future execution only.
     ///
     /// See [here](https://geth.ethereum.org/docs/rpc/ns-txpool#txpool_content) for more details
-    #[method(name = "txpool_content")]
+    #[method(name = "content")]
     async fn txpool_content(&self) -> RpcResult<TxpoolContent>;
 }

--- a/crates/rpc/rpc-api/src/txpool.rs
+++ b/crates/rpc/rpc-api/src/txpool.rs
@@ -3,7 +3,7 @@ use reth_primitives::Address;
 use reth_rpc_types::txpool::{TxpoolContent, TxpoolContentFrom, TxpoolInspect, TxpoolStatus};
 
 /// Txpool rpc interface.
-#[cfg_attr(not(feature = "client"), rpc(server))]
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "txpool"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "txpool"))]
 #[async_trait::async_trait]
 pub trait TxPoolApi {

--- a/crates/rpc/rpc-api/src/web3.rs
+++ b/crates/rpc/rpc-api/src/web3.rs
@@ -3,14 +3,14 @@ use reth_primitives::{Bytes, H256};
 
 /// Web3 rpc interface.
 #[cfg_attr(not(feature = "client"), rpc(server))]
-#[cfg_attr(feature = "client", rpc(server, client))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "web3"))]
 #[async_trait::async_trait]
 pub trait Web3Api {
     /// Returns current client version.
-    #[method(name = "web3_clientVersion")]
+    #[method(name = "clientVersion")]
     async fn client_version(&self) -> RpcResult<String>;
 
     /// Returns sha3 of the given data.
-    #[method(name = "web3_sha3")]
+    #[method(name = "sha3")]
     fn sha3(&self, input: Bytes) -> RpcResult<H256>;
 }

--- a/crates/rpc/rpc-api/src/web3.rs
+++ b/crates/rpc/rpc-api/src/web3.rs
@@ -2,7 +2,7 @@ use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_primitives::{Bytes, H256};
 
 /// Web3 rpc interface.
-#[cfg_attr(not(feature = "client"), rpc(server))]
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "web3"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "web3"))]
 #[async_trait::async_trait]
 pub trait Web3Api {


### PR DESCRIPTION
Set namespace value property for the derive macro for each JSON-RPC Namespace.

This is easier to read and easier to fork and change the prefix. E.g "eth_" -> "ovm_"