### PR TITLE
feat: add util function for fetching tagged headers

### DIFF
--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -184,10 +184,6 @@ impl<DB: Database> BlockProvider for ShareableDatabase<DB> {
         self.provider()?.pending_block()
     }
 
-    fn pending_header(&self) -> Result<Option<SealedHeader>> {
-        self.provider()?.pending_header()
-    }
-
     fn ommers(&self, id: BlockHashOrNumber) -> Result<Option<Vec<Header>>> {
         self.provider()?.ommers(id)
     }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -206,10 +206,6 @@ impl<'this, TX: DbTx<'this>> BlockProvider for DatabaseProvider<'this, TX> {
         Ok(None)
     }
 
-    fn pending_header(&self) -> Result<Option<SealedHeader>> {
-        Ok(None)
-    }
-
     fn ommers(&self, id: BlockHashOrNumber) -> Result<Option<Vec<Header>>> {
         if let Some(number) = self.convert_hash_or_number(id)? {
             // TODO: this can be optimized to return empty Vec post-merge

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -230,10 +230,6 @@ where
         Ok(self.tree.pending_block())
     }
 
-    fn pending_header(&self) -> Result<Option<SealedHeader>> {
-        Ok(self.tree.pending_header())
-    }
-
     fn ommers(&self, id: BlockHashOrNumber) -> Result<Option<Vec<Header>>> {
         self.database.provider()?.ommers(id)
     }

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -306,10 +306,6 @@ impl BlockProvider for MockEthProvider {
         Ok(None)
     }
 
-    fn pending_header(&self) -> Result<Option<SealedHeader>> {
-        Ok(None)
-    }
-
     fn ommers(&self, _id: BlockHashOrNumber) -> Result<Option<Vec<Header>>> {
         Ok(None)
     }

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -62,10 +62,6 @@ impl BlockProvider for NoopProvider {
         Ok(None)
     }
 
-    fn pending_header(&self) -> Result<Option<SealedHeader>> {
-        Ok(None)
-    }
-
     fn ommers(&self, _id: BlockHashOrNumber) -> Result<Option<Vec<Header>>> {
         Ok(None)
     }

--- a/crates/storage/provider/src/traits/block.rs
+++ b/crates/storage/provider/src/traits/block.rs
@@ -64,12 +64,6 @@ pub trait BlockProvider:
     /// and the caller does not know the hash.
     fn pending_block(&self) -> Result<Option<SealedBlock>>;
 
-    /// Returns the pending block header if available
-    ///
-    /// Note: This returns a [SealedHeader] because it's expected that this is sealed by the
-    /// provider and the caller does not know the hash.
-    fn pending_header(&self) -> Result<Option<SealedHeader>>;
-
     /// Returns the ommers/uncle headers of the given block from the database.
     ///
     /// Returns `None` if block is not found.
@@ -112,6 +106,38 @@ pub trait BlockProviderIdExt: BlockProvider + BlockIdProvider {
     /// Returns `None` if block is not found.
     fn block_by_number_or_tag(&self, id: BlockNumberOrTag) -> Result<Option<Block>> {
         self.convert_block_number(id)?.map_or_else(|| Ok(None), |num| self.block(num.into()))
+    }
+
+    /// Returns the pending block header if available
+    ///
+    /// Note: This returns a [SealedHeader] because it's expected that this is sealed by the
+    /// provider and the caller does not know the hash.
+    fn pending_header(&self) -> Result<Option<SealedHeader>> {
+        self.sealed_header_by_id(BlockNumberOrTag::Pending.into())
+    }
+
+    /// Returns the latest block header if available
+    ///
+    /// Note: This returns a [SealedHeader] because it's expected that this is sealed by the
+    /// provider and the caller does not know the hash.
+    fn latest_header(&self) -> Result<Option<SealedHeader>> {
+        self.sealed_header_by_id(BlockNumberOrTag::Latest.into())
+    }
+
+    /// Returns the safe block header if available
+    ///
+    /// Note: This returns a [SealedHeader] because it's expected that this is sealed by the
+    /// provider and the caller does not know the hash.
+    fn safe_header(&self) -> Result<Option<SealedHeader>> {
+        self.sealed_header_by_id(BlockNumberOrTag::Safe.into())
+    }
+
+    /// Returns the finalized block header if available
+    ///
+    /// Note: This returns a [SealedHeader] because it's expected that this is sealed by the
+    /// provider and the caller does not know the hash.
+    fn finalized_header(&self) -> Result<Option<SealedHeader>> {
+        self.sealed_header_by_id(BlockNumberOrTag::Finalized.into())
     }
 
     /// Returns the block with the matching `BlockId` from the database.


### PR DESCRIPTION
add a few convenience functions for fetching header by tag.

also moves the existing pending_header function to `BlockProviderIdExt` because makes more sense there