### PR TITLE
feat(rpc): add `BlockOverrides` in `trace_*`

### DIFF
--- a/crates/rpc/rpc-api/src/trace.rs
+++ b/crates/rpc/rpc-api/src/trace.rs
@@ -2,7 +2,7 @@ use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_primitives::{BlockId, Bytes, H256};
 use reth_rpc_types::{
     trace::{filter::TraceFilter, parity::*},
-    CallRequest, Index,
+    BlockOverrides, CallRequest, Index,
 };
 use std::collections::HashSet;
 
@@ -17,6 +17,7 @@ pub trait TraceApi {
         call: CallRequest,
         trace_types: HashSet<TraceType>,
         block_id: Option<BlockId>,
+        block_overrides: Option<Box<BlockOverrides>>,
     ) -> RpcResult<TraceResults>;
 
     /// Performs multiple call traces on top of the same block. i.e. transaction n will be executed

--- a/crates/rpc/rpc-api/src/trace.rs
+++ b/crates/rpc/rpc-api/src/trace.rs
@@ -1,6 +1,7 @@
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_primitives::{BlockId, Bytes, H256};
 use reth_rpc_types::{
+    state::StateOverride,
     trace::{filter::TraceFilter, parity::*},
     BlockOverrides, CallRequest, Index,
 };
@@ -17,6 +18,7 @@ pub trait TraceApi {
         call: CallRequest,
         trace_types: HashSet<TraceType>,
         block_id: Option<BlockId>,
+        state_overrides: Option<StateOverride>,
         block_overrides: Option<Box<BlockOverrides>>,
     ) -> RpcResult<TraceResults>;
 


### PR DESCRIPTION
`block_overrides` of type `BlockOverrides` is added as a last argument of `trace_*`.

Should close #3091.
