### PR TITLE
docs: add rustdoc to gh pages

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -42,6 +42,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
       - name: Install mdbook
         run: |
           mkdir mdbook
@@ -54,8 +60,15 @@ jobs:
           curl -sSL https://github.com/sgoudham/mdbook-template/releases/latest/download/mdbook-template-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook-template
           echo `pwd`/mdbook-template >> $GITHUB_PATH
 
-      - name: Build
+      - name: Build book
         run: mdbook build
+
+      - name: Build docs
+        run: RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo +nightly doc --all --no-deps
+
+      - name: Move docs to book folder
+        run: |
+          mv target/doc target/book/docs
 
       - name: Save pages artifact
         uses: actions/upload-pages-artifact@v1

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -2,14 +2,8 @@ name: book
 on:
   push:
     branches: [main]
-    paths:
-      - 'book/**'
-      - 'book.toml'
   pull_request:
     branches: [main]
-    paths:
-      - 'book/**'
-      - 'book.toml'
   merge_group:
 
 jobs:


### PR DESCRIPTION
Builds rustdocs for each crate in the workspace, along with an index page, discoverable under `/docs` on GitHub pages

Unfortunately this means that the workflows for the book will run regardless of whether or not anything was changed in the book, since we always need to update the rustdocs