### PR TITLE
fix(stages): save full block range to index history checkpoint

### DIFF
--- a/crates/net/downloaders/Cargo.toml
+++ b/crates/net/downloaders/Cargo.toml
@@ -27,9 +27,9 @@ tokio-util = { version = "0.7", features = ["codec"] }
 # misc
 tracing = { workspace = true }
 rayon = "1.6.0"
+thiserror = "1"
 
 # optional deps for the test-utils feature
-thiserror = { version = "1", optional = true }
 reth-rlp = { path = "../../rlp", optional = true }
 tempfile = { version = "3.3", optional = true }
 itertools = { version = "0.10", optional = true }
@@ -44,8 +44,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 reth-rlp = { path = "../../rlp" }
 itertools = "0.10"
 
-thiserror = "1"
 tempfile = "3.3"
 
 [features]
-test-utils = ["dep:reth-rlp", "dep:thiserror", "dep:tempfile", "dep:itertools"]
+test-utils = ["dep:reth-rlp", "dep:tempfile", "dep:itertools"]

--- a/crates/stages/src/stages/index_account_history.rs
+++ b/crates/stages/src/stages/index_account_history.rs
@@ -51,7 +51,7 @@ impl<DB: Database> Stage<DB> for IndexAccountHistoryStage {
             tx,
             input.checkpoint(),
             // It is important to provide the full block range into the checkpoint,
-            // not the one accounting for commit threshold.
+            // not the one accounting for commit threshold, to get the correct range end.
             &input.next_block_range(),
         )?;
 

--- a/crates/stages/src/stages/index_account_history.rs
+++ b/crates/stages/src/stages/index_account_history.rs
@@ -47,7 +47,13 @@ impl<DB: Database> Stage<DB> for IndexAccountHistoryStage {
 
         let (range, is_final_range) = input.next_block_range_with_threshold(self.commit_threshold);
 
-        let mut stage_checkpoint = stage_checkpoint(tx, input.checkpoint(), &range)?;
+        let mut stage_checkpoint = stage_checkpoint(
+            tx,
+            input.checkpoint(),
+            // It is important to provide the full block range into the checkpoint,
+            // not the one accounting for commit threshold.
+            &input.next_block_range(),
+        )?;
 
         let indices = tx.get_account_transition_ids_from_changeset(range.clone())?;
         let changesets = indices.values().map(|blocks| blocks.len() as u64).sum::<u64>();
@@ -429,6 +435,64 @@ mod tests {
                 (shard(u64::MAX), vec![2, 3])
             ])
         );
+    }
+
+    #[tokio::test]
+    async fn stage_checkpoint_range() {
+        // init
+        let test_tx = TestTransaction::default();
+
+        // setup
+        partial_setup(&test_tx);
+
+        // run
+        {
+            let mut stage = IndexAccountHistoryStage { commit_threshold: 4 }; // Two runs required
+            let mut tx = test_tx.inner();
+
+            let mut input = ExecInput { target: Some(5), ..Default::default() };
+            let out = stage.execute(&mut tx, input).await.unwrap();
+            assert_eq!(
+                out,
+                ExecOutput {
+                    checkpoint: StageCheckpoint::new(4).with_index_history_stage_checkpoint(
+                        IndexHistoryCheckpoint {
+                            block_range: CheckpointBlockRange { from: 1, to: 5 },
+                            progress: EntitiesCheckpoint { processed: 1, total: 2 }
+                        }
+                    ),
+                    done: false
+                }
+            );
+            input.checkpoint = Some(out.checkpoint);
+
+            let out = stage.execute(&mut tx, input).await.unwrap();
+            assert_eq!(
+                out,
+                ExecOutput {
+                    checkpoint: StageCheckpoint::new(5).with_index_history_stage_checkpoint(
+                        IndexHistoryCheckpoint {
+                            block_range: CheckpointBlockRange { from: 5, to: 5 },
+                            progress: EntitiesCheckpoint { processed: 2, total: 2 }
+                        }
+                    ),
+                    done: true
+                }
+            );
+
+            tx.commit().unwrap();
+        }
+
+        // verify
+        let table = cast(test_tx.table::<tables::AccountHistory>().unwrap());
+        assert_eq!(table, BTreeMap::from([(shard(u64::MAX), vec![4, 5])]));
+
+        // unwind
+        unwind(&test_tx, 5, 0).await;
+
+        // verify initial state
+        let table = test_tx.table::<tables::AccountHistory>().unwrap();
+        assert!(table.is_empty());
     }
 
     #[test]

--- a/crates/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/src/stages/index_storage_history.rs
@@ -50,7 +50,13 @@ impl<DB: Database> Stage<DB> for IndexStorageHistoryStage {
 
         let (range, is_final_range) = input.next_block_range_with_threshold(self.commit_threshold);
 
-        let mut stage_checkpoint = stage_checkpoint(tx, input.checkpoint(), &range)?;
+        let mut stage_checkpoint = stage_checkpoint(
+            tx,
+            input.checkpoint(),
+            // It is important to provide the full block range into the checkpoint,
+            // not the one accounting for commit threshold.
+            &input.next_block_range(),
+        )?;
 
         let indices = tx.get_storage_transition_ids_from_changeset(range.clone())?;
         let changesets = indices.values().map(|blocks| blocks.len() as u64).sum::<u64>();
@@ -444,6 +450,64 @@ mod tests {
                 (shard(u64::MAX), vec![2, 3])
             ])
         );
+    }
+
+    #[tokio::test]
+    async fn stage_checkpoint_range() {
+        // init
+        let test_tx = TestTransaction::default();
+
+        // setup
+        partial_setup(&test_tx);
+
+        // run
+        {
+            let mut stage = IndexStorageHistoryStage { commit_threshold: 4 }; // Two runs required
+            let mut tx = test_tx.inner();
+
+            let mut input = ExecInput { target: Some(5), ..Default::default() };
+            let out = stage.execute(&mut tx, input).await.unwrap();
+            assert_eq!(
+                out,
+                ExecOutput {
+                    checkpoint: StageCheckpoint::new(4).with_index_history_stage_checkpoint(
+                        IndexHistoryCheckpoint {
+                            block_range: CheckpointBlockRange { from: 1, to: 5 },
+                            progress: EntitiesCheckpoint { processed: 1, total: 2 }
+                        }
+                    ),
+                    done: false
+                }
+            );
+            input.checkpoint = Some(out.checkpoint);
+
+            let out = stage.execute(&mut tx, input).await.unwrap();
+            assert_eq!(
+                out,
+                ExecOutput {
+                    checkpoint: StageCheckpoint::new(5).with_index_history_stage_checkpoint(
+                        IndexHistoryCheckpoint {
+                            block_range: CheckpointBlockRange { from: 5, to: 5 },
+                            progress: EntitiesCheckpoint { processed: 2, total: 2 }
+                        }
+                    ),
+                    done: true
+                }
+            );
+
+            tx.commit().unwrap();
+        }
+
+        // verify
+        let table = cast(test_tx.table::<tables::StorageHistory>().unwrap());
+        assert_eq!(table, BTreeMap::from([(shard(u64::MAX), vec![4, 5])]));
+
+        // unwind
+        unwind(&test_tx, 5, 0).await;
+
+        // verify initial state
+        let table = test_tx.table::<tables::StorageHistory>().unwrap();
+        assert!(table.is_empty());
     }
 
     #[test]

--- a/crates/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/src/stages/index_storage_history.rs
@@ -54,7 +54,7 @@ impl<DB: Database> Stage<DB> for IndexStorageHistoryStage {
             tx,
             input.checkpoint(),
             // It is important to provide the full block range into the checkpoint,
-            // not the one accounting for commit threshold.
+            // not the one accounting for commit threshold, to get the correct range end.
             &input.next_block_range(),
         )?;
 


### PR DESCRIPTION
Passing a block range truncated with respect to commit threshold to `stage_checkpoint` function was incorrect, because its second match clause depends on checking the range end: https://github.com/paradigmxyz/reth/blob/5b0536bd7b593a2357d0160acfc70bfb67091cb6/crates/stages/src/stages/index_account_history.rs#L112-L113

Otherwise, we will constantly recalculate the number of changesets we already processed on every execution.