### PR TITLE
feat(bin): sort `db stats` rows

### DIFF
--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -117,7 +117,10 @@ impl Command {
                 ]);
 
                 tool.db.view(|tx| {
-                    for table in tables::TABLES.iter().map(|(_, name)| name) {
+                    let mut tables =
+                        tables::TABLES.iter().map(|(_, name)| name).collect::<Vec<_>>();
+                    tables.sort();
+                    for table in tables {
                         let table_db =
                             tx.inner.open_db(Some(table)).wrap_err("Could not open db.")?;
 


### PR DESCRIPTION
### Before

```   
| Table Name        | # Entries | Branch Pages | Leaf Pages | Overflow Pages | Total Size |
|-------------------|-----------|--------------|------------|----------------|------------|
| CanonicalHeaders  | 90001     | 1            | 542        | 0              | 8.5 MiB    |
| HeaderTD          | 90001     | 1            | 147        | 0              | 2.3 MiB    |
| HeaderNumbers     | 90001     | 3            | 485        | 0              | 7.6 MiB    |
| Headers           | 90001     | 13           | 5995       | 0              | 93.9 MiB   |
| BlockBodyIndices  | 90001     | 1            | 116        | 0              | 1.8 MiB    |
| BlockOmmers       | 7707      | 1            | 271        | 0              | 4.2 MiB    |
| BlockWithdrawals  | 0         | 0            | 0          | 0              | 0 B        |
| TransactionBlock  | 10935     | 1            | 18         | 0              | 304 KiB    |
| Transactions      | 22681     | 1            | 183        | 0              | 2.9 MiB    |
| TxHashNumber      | 22681     | 1            | 83         | 0              | 1.3 MiB    |
| Receipts          | 22681     | 1            | 35         | 0              | 576 KiB    |
| PlainAccountState | 15149     | 1            | 47         | 0              | 768 KiB    |
| PlainStorageState | 3081      | 2            | 11         | 0              | 208 KiB    |
| Bytecodes         | 172       | 1            | 15         | 1              | 272 KiB    |
| AccountHistory    | 7394      | 1            | 84         | 0              | 1.3 MiB    |
| StorageHistory    | 3336      | 1            | 39         | 0              | 640 KiB    |
| AccountChangeSet  | 142712    | 2            | 438        | 0              | 6.9 MiB    |
| StorageChangeSet  | 6241      | 1            | 24         | 0              | 400 KiB    |
| HashedAccount     | 15149     | 1            | 51         | 0              | 832 KiB    |
| HashedStorage     | 3081      | 2            | 12         | 0              | 224 KiB    |
| AccountsTrie      | 1452      | 1            | 13         | 0              | 224 KiB    |
| StoragesTrie      | 261       | 1            | 4          | 0              | 80 KiB     |
| TxSenders         | 22681     | 1            | 54         | 0              | 880 KiB    |
| SyncStage         | 13        | 0            | 1          | 0              | 16 KiB     |
| SyncStageProgress | 1         | 0            | 1          | 0              | 16 KiB     |
```

### After

```
| Table Name        | # Entries | Branch Pages | Leaf Pages | Overflow Pages | Total Size |
|-------------------|-----------|--------------|------------|----------------|------------|
| AccountChangeSet  | 142712    | 2            | 438        | 0              | 6.9 MiB    |
| AccountHistory    | 7394      | 1            | 84         | 0              | 1.3 MiB    |
| AccountsTrie      | 1452      | 1            | 13         | 0              | 224 KiB    |
| BlockBodyIndices  | 90001     | 1            | 116        | 0              | 1.8 MiB    |
| BlockOmmers       | 7707      | 1            | 271        | 0              | 4.2 MiB    |
| BlockWithdrawals  | 0         | 0            | 0          | 0              | 0 B        |
| Bytecodes         | 172       | 1            | 15         | 1              | 272 KiB    |
| CanonicalHeaders  | 90001     | 1            | 542        | 0              | 8.5 MiB    |
| HashedAccount     | 15149     | 1            | 51         | 0              | 832 KiB    |
| HashedStorage     | 3081      | 2            | 12         | 0              | 224 KiB    |
| HeaderNumbers     | 90001     | 3            | 485        | 0              | 7.6 MiB    |
| HeaderTD          | 90001     | 1            | 147        | 0              | 2.3 MiB    |
| Headers           | 90001     | 13           | 5995       | 0              | 93.9 MiB   |
| PlainAccountState | 15149     | 1            | 47         | 0              | 768 KiB    |
| PlainStorageState | 3081      | 2            | 11         | 0              | 208 KiB    |
| Receipts          | 22681     | 1            | 35         | 0              | 576 KiB    |
| StorageChangeSet  | 6241      | 1            | 24         | 0              | 400 KiB    |
| StorageHistory    | 3336      | 1            | 39         | 0              | 640 KiB    |
| StoragesTrie      | 261       | 1            | 4          | 0              | 80 KiB     |
| SyncStage         | 13        | 0            | 1          | 0              | 16 KiB     |
| SyncStageProgress | 1         | 0            | 1          | 0              | 16 KiB     |
| TransactionBlock  | 10935     | 1            | 18         | 0              | 304 KiB    |
| Transactions      | 22681     | 1            | 183        | 0              | 2.9 MiB    |
| TxHashNumber      | 22681     | 1            | 83         | 0              | 1.3 MiB    |
| TxSenders         | 22681     | 1            | 54         | 0              | 880 KiB    |
```
