### PR TITLE
chore(stages): raise transaction based commit thresholds

### DIFF
--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -184,7 +184,7 @@ pub struct SenderRecoveryConfig {
 
 impl Default for SenderRecoveryConfig {
     fn default() -> Self {
-        Self { commit_threshold: 50_000 }
+        Self { commit_threshold: 5_000_000 }
     }
 }
 

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -38,7 +38,7 @@ impl SenderRecoveryStage {
 
 impl Default for SenderRecoveryStage {
     fn default() -> Self {
-        Self { commit_threshold: 50_000 }
+        Self { commit_threshold: 5_000_000 }
     }
 }
 

--- a/crates/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/src/stages/tx_lookup.rs
@@ -31,7 +31,7 @@ pub struct TransactionLookupStage {
 
 impl Default for TransactionLookupStage {
     fn default() -> Self {
-        Self { commit_threshold: 100_000 }
+        Self { commit_threshold: 5_000_000 }
     }
 }
 


### PR DESCRIPTION
## Motivation

Raise commit thresholds for stages with transaction-based commits. This offsets the implicit costs for creating the transaction and writing to disk but also increases memory usage.

## Sepolia Benches

```
100k threshold
2023-06-13T16:59:54 to 2023-06-13T17:02:35
2min 41s total

1m threshold
2023-06-13T17:08:07 to 2023-06-13T17:09:27
1min 20s total

5m threshold
2023-06-13T17:12:47 to 2023-06-13T17:13:45
58s total

10m threshold
2023-06-13T17:17:04 to 2023-06-13T17:18:00
56s total
```