### PR TITLE
chore: use workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,35 @@ revm-primitives = { git = "https://github.com/bluealloy/revm/", branch = "releas
 ## eth
 revm = { version = "3" }
 revm-primitives = "1.1"
+reth-primitives = { path = "./crates/primitives" }
+reth-interfaces = { path = "./crates/interfaces" }
+reth-provider = { path = "./crates/storage/provider" }
+reth-rlp = { path = "./crates/rlp" }
+reth-rpc-types = { path = "./crates/rpc/rpc-types" }
+reth-metrics = { path = "./crates/metrics" }
+reth-payload-builder = { path = "./crates/payload/builder" }
+reth-transaction-pool = { path = "./crates/transaction-pool" }
+reth-tasks = { path = "./crates/tasks" }
+reth-network-api = { path = "./crates/net/network-api" }
 
 ## misc
 tracing = "^0.1.0"
+thiserror = "1.0.37"
+serde_json = "1.0.94"
+serde = { version = "1.0", default-features = false }
+rand = "0.8.5"
+
+
+## tokio
+tokio-stream = "0.1.11"
+tokio = { version = "1.21", default-features = false }
+tokio-util = { version = "0.7.4", features = ["codec"] }
+
+## async
+async-trait = "0.1.58"
+futures = "0.3.26"
+pin-project = "1.0.12"
+futures-util = "0.3.25"
+
+## crypto
+secp256k1 = { version = "0.27.0", default-features = false, features = ["global-context", "rand-std", "recovery"] }

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -10,45 +10,45 @@ repository.workspace = true
 [dependencies]
 # reth
 reth-config = { path = "../../crates/config" }
-reth-primitives = { path = "../../crates/primitives", features = ["arbitrary"] }
+reth-primitives = { workspace = true, features = ["arbitrary"] }
 reth-db = { path = "../../crates/storage/db", features = ["mdbx", "test-utils"] }
 # TODO: Temporary use of the test-utils feature
-reth-provider = { path = "../../crates/storage/provider", features = ["test-utils"] }
+reth-provider = { workspace = true, features = ["test-utils"] }
 reth-revm = { path = "../../crates/revm" }
 reth-revm-inspectors = { path = "../../crates/revm/revm-inspectors" }
 reth-staged-sync = { path = "../../crates/staged-sync" }
 reth-stages = { path = "../../crates/stages" }
-reth-interfaces = { path = "../../crates/interfaces", features = ["test-utils"] }
-reth-transaction-pool = { path = "../../crates/transaction-pool" }
+reth-interfaces = { workspace = true, features = ["test-utils"] }
+reth-transaction-pool = { workspace = true }
 reth-beacon-consensus = { path = "../../crates/consensus/beacon" }
 reth-auto-seal-consensus = { path = "../../crates/consensus/auto-seal" }
 reth-blockchain-tree = { path = "../../crates/blockchain-tree" }
 reth-rpc-engine-api = { path = "../../crates/rpc/rpc-engine-api" }
 reth-rpc-builder = { path = "../../crates/rpc/rpc-builder" }
 reth-rpc = { path = "../../crates/rpc/rpc" }
-reth-rlp = { path = "../../crates/rlp" }
+reth-rlp = { workspace = true }
 reth-network = { path = "../../crates/net/network", features = ["serde"] }
-reth-network-api = { path = "../../crates/net/network-api" }
+reth-network-api = { workspace = true }
 reth-downloaders = { path = "../../crates/net/downloaders", features = ["test-utils"] }
 reth-tracing = { path = "../../crates/tracing" }
-reth-tasks = { path = "../../crates/tasks" }
+reth-tasks = { workspace = true }
 reth-net-nat = { path = "../../crates/net/nat" }
-reth-payload-builder = { path = "../../crates/payload/builder" }
+reth-payload-builder = { workspace = true }
 reth-basic-payload-builder = { path = "../../crates/payload/basic" }
 reth-discv4 = { path = "../../crates/net/discv4" }
-reth-metrics = { path = "../../crates/metrics" }
+reth-metrics = { workspace = true }
 jemallocator = { version = "0.5.0", optional = true }
 
 # crypto
-secp256k1 = { version = "0.27.0", features = ["global-context", "rand-std", "recovery"] }
+secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery"] }
 
 # tracing
 tracing = { workspace = true }
 
 # io
 fdlimit = "0.2.1"
-serde = "1.0"
-serde_json = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
 shellexpand = "3.0.0"
 dirs-next = "2.0.0"
 confy = "0.5"
@@ -68,9 +68,9 @@ tui = "0.19.0"
 human_bytes = "0.4.1"
 
 # async
-tokio = { version = "1.21", features = ["sync", "macros", "time", "rt-multi-thread"] }
-futures = "0.3.25"
-pin-project = "1.0"
+tokio = { workspace = true, features = ["sync", "macros", "time", "rt-multi-thread"] }
+futures = { workspace = true }
+pin-project = { workspace = true }
 
 # http/rpc
 hyper = "0.14.25"
@@ -81,7 +81,7 @@ clap = { version = "4", features = ["derive"] }
 tempfile = { version = "3.3.0" }
 backon = "0.4"
 hex = "0.4"
-thiserror = "1.0"
+thiserror = { workspace = true }
 pretty_assertions = "1.3.0"
 
 [features]

--- a/crates/blockchain-tree/Cargo.toml
+++ b/crates/blockchain-tree/Cargo.toml
@@ -15,10 +15,10 @@ normal = [
 
 [dependencies]
 # reth
-reth-primitives = { path = "../primitives" }
-reth-interfaces = { path = "../interfaces" }
+reth-primitives = { workspace = true }
+reth-interfaces = { workspace = true }
 reth-db = { path = "../storage/db" }
-reth-provider = { path = "../storage/provider" }
+reth-provider = { workspace = true }
 
 # common
 parking_lot = { version = "0.12" }
@@ -31,12 +31,12 @@ linked_hash_set = "0.1.4"
 
 [dev-dependencies]
 reth-db = { path = "../storage/db", features = ["test-utils"] }
-reth-interfaces = { path = "../interfaces", features = ["test-utils"] }
-reth-primitives = { path = "../primitives", features = ["test-utils"] }
-reth-provider = { path = "../storage/provider", features = ["test-utils"] }
+reth-interfaces = { workspace = true, features = ["test-utils"] }
+reth-primitives = { workspace = true , features = ["test-utils"] }
+reth-provider = { workspace = true, features = ["test-utils"] }
 parking_lot = "0.12"
 assert_matches = "1.5"
-tokio = { version = "1", features = ["macros", "sync"] }
+tokio = { workspace = true, features = ["macros", "sync"] }
 
 [features]
 test-utils = []

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -15,11 +15,11 @@ reth-discv4 = { path = "../../crates/net/discv4" }
 reth-downloaders = { path = "../../crates/net/downloaders" }
 
 # io
-serde = "1.0"
-serde_json = "1.0.91"
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 #crypto 
-secp256k1 = { version = "0.27.0", features = ["global-context", "rand-std", "recovery"] }
+secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery"] }
 
 confy = "0.5"
 

--- a/crates/consensus/auto-seal/Cargo.toml
+++ b/crates/consensus/auto-seal/Cargo.toml
@@ -11,18 +11,18 @@ description = "A consensus impl for local testing purposes"
 [dependencies]
 # reth
 reth-beacon-consensus = { path = "../beacon" }
-reth-primitives = { path = "../../primitives" }
-reth-interfaces = { path = "../../interfaces" }
-reth-provider = { path = "../../storage/provider" }
+reth-primitives = { workspace = true }
+reth-interfaces = { workspace = true }
+reth-provider = { workspace = true }
 reth-stages = { path = "../../stages" }
 reth-revm = { path = "../../revm" }
-reth-transaction-pool = { path = "../../transaction-pool" }
+reth-transaction-pool = { workspace = true }
 
 # async
-futures-util = "0.3"
-tokio = { version = "1", features = ["sync", "time"] }
-tokio-stream = "0.1"
+futures-util = { workspace = true }
+tokio = { workspace = true, features = ["sync", "time"] }
+tokio-stream = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-reth-interfaces = { path = "../../interfaces", features = ["test-utils"] }
+reth-interfaces = { workspace = true, features = ["test-utils"] }

--- a/crates/consensus/beacon/Cargo.toml
+++ b/crates/consensus/beacon/Cargo.toml
@@ -10,34 +10,34 @@ repository.workspace = true
 [dependencies]
 # reth
 reth-consensus-common = { path = "../common" }
-reth-primitives = { path = "../../primitives" }
-reth-interfaces = { path = "../../interfaces" }
+reth-primitives = { workspace = true }
+reth-interfaces = { workspace = true }
 reth-stages = { path = "../../stages" }
 reth-db = { path = "../../storage/db" }
-reth-provider = { path = "../../storage/provider" }
-reth-rpc-types = { path = "../../rpc/rpc-types" }
-reth-tasks = { path = "../../tasks" }
-reth-payload-builder = { path = "../../payload/builder" }
-reth-metrics = { path = "../../metrics" }
+reth-provider = { workspace = true }
+reth-rpc-types = { workspace = true }
+reth-tasks = { workspace = true }
+reth-payload-builder = { workspace = true }
+reth-metrics = { workspace = true }
 
 # async
-tokio = { version = "1.21.2", features = ["sync"] }
-tokio-stream = "0.1.10"
-futures = "0.3"
+tokio = { workspace = true, features = ["sync"] }
+tokio-stream = { workspace = true }
+futures = { workspace = true }
 
 # misc
 tracing = { workspace = true }
-thiserror = "1.0"
+thiserror = { workspace = true }
 schnellru = "0.2"
 
 [dev-dependencies]
 # reth
-reth-payload-builder = { path = "../../payload/builder", features = ["test-utils"] }
-reth-interfaces = { path = "../../interfaces", features = ["test-utils"] }
+reth-payload-builder = { workspace = true, features = ["test-utils"] }
+reth-interfaces = { workspace = true, features = ["test-utils"] }
 reth-stages = { path = "../../stages", features = ["test-utils"] }
 reth-blockchain-tree = { path = "../../blockchain-tree", features = ["test-utils"] }
 reth-db = { path = "../../storage/db", features = ["test-utils"] }
-reth-provider = { path = "../../storage/provider", features = ["test-utils"] }
+reth-provider = { workspace = true, features = ["test-utils"] }
 reth-tracing = { path = "../../tracing" }
 
 assert_matches = "1.5"

--- a/crates/consensus/common/Cargo.toml
+++ b/crates/consensus/common/Cargo.toml
@@ -9,12 +9,12 @@ repository.workspace = true
 
 [dependencies]
 # reth 
-reth-primitives = { path = "../../primitives" }
-reth-interfaces = { path = "../../interfaces" }
-reth-provider = { path = "../../storage/provider" }
+reth-primitives = { workspace = true }
+reth-interfaces = { workspace = true }
+reth-provider = { workspace = true }
 
 [dev-dependencies]
-reth-interfaces = { path = "../../interfaces", features = ["test-utils"] }
-reth-provider = { path = "../../storage/provider", features = ["test-utils"] }
+reth-interfaces = { workspace = true, features = ["test-utils"] }
+reth-provider = { workspace = true, features = ["test-utils"] }
 assert_matches = "1.5.0"
 mockall = "0.11.3"

--- a/crates/interfaces/Cargo.toml
+++ b/crates/interfaces/Cargo.toml
@@ -9,9 +9,9 @@ repository.workspace = true
 
 [dependencies]
 reth-codecs = { path = "../storage/codecs" }
-reth-primitives = { path = "../primitives" }
-reth-rpc-types = { path = "../rpc/rpc-types" }
-reth-network-api = { path = "../net/network-api" }
+reth-primitives = { workspace = true }
+reth-rpc-types = { workspace = true }
+reth-network-api = { workspace = true }
 # TODO(onbjerg): We only need this for [BlockBody]
 reth-eth-wire = { path = "../net/eth-wire" }
 
@@ -20,18 +20,18 @@ revm-primitives = { workspace = true }
 parity-scale-codec = { version = "3.2.1", features = ["bytes"] }
 
 # async
-async-trait = "0.1.57"
-futures = "0.3"
-tokio = { version = "1.21.2", features = ["sync"] }
-tokio-stream = "0.1.11"
+async-trait = { workspace = true }
+futures = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+tokio-stream = { workspace = true }
 
 # misc
 auto_impl = "1.0"
-thiserror = "1.0.37"
+thiserror = { workspace = true }
 tracing = { workspace = true }
-rand = "0.8.5"
+rand = { workspace = true }
 arbitrary = { version = "1.1.7", features = ["derive"], optional = true }
-secp256k1 = { version = "0.27.0", default-features = false, features = [
+secp256k1 = { workspace = true, default-features = false, features = [
     "alloc",
     "recovery",
     "rand",
@@ -41,11 +41,11 @@ parking_lot = "0.12.1"
 
 [dev-dependencies]
 reth-db = { path = "../storage/db", features = ["test-utils"] }
-tokio = { version = "1.21.2", features = ["full"] }
-tokio-stream = { version = "0.1.11", features = ["sync"] }
+tokio = { workspace = true, features = ["full"] }
+tokio-stream = { workspace = true, features = ["sync"] }
 arbitrary = { version = "1.1.7", features = ["derive"] }
 hex-literal = "0.3"
-secp256k1 = { version = "0.27.0", default-features = false, features = [
+secp256k1 = { workspace = true, features = [
     "alloc",
     "recovery",
     "rand",

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -16,7 +16,7 @@ reth-metrics-derive = { path = "./metrics-derive" }
 metrics = "0.20.1"
 
 # async
-tokio = { version = "1.21.2", features = ["full"], optional = true }
+tokio = { workspace = true, features = ["full"], optional = true }
 
 [features]
 common = ["tokio"]

--- a/crates/net/common/Cargo.toml
+++ b/crates/net/common/Cargo.toml
@@ -12,8 +12,8 @@ Types shared across network code
 
 [dependencies]
 # reth
-reth-primitives = { path = "../../primitives" }
+reth-primitives = { workspace = true }
 
 # async
-pin-project = "1.0"
-tokio = { version = "1.21.2", features = ["full"] }
+pin-project = { workspace = true }
+tokio = { workspace = true, features = ["full"] }

--- a/crates/net/discv4/Cargo.toml
+++ b/crates/net/discv4/Cargo.toml
@@ -12,32 +12,32 @@ Ethereum network discovery
 
 [dependencies]
 # reth
-reth-primitives = { path = "../../primitives" }
-reth-rlp = { path = "../../rlp" }
+reth-primitives = { workspace = true }
+reth-rlp = { workspace = true }
 reth-rlp-derive = { path = "../../rlp/rlp-derive" }
 reth-net-common = { path = "../common" }
 reth-net-nat = { path = "../nat" }
 
 # ethereum
 discv5 = { git = "https://github.com/sigp/discv5" }
-secp256k1 = { version = "0.27.0", features = ["global-context", "rand-std", "recovery", "serde"] }
+secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery", "serde"] }
 enr = { version = "0.8.1", default-features = false, features = ["rust-secp256k1"] }
 
 # async/futures
-tokio = { version = "1", features = ["io-util", "net", "time"] }
-tokio-stream = "0.1"
+tokio = { workspace = true, features = ["io-util", "net", "time"] }
+tokio-stream = { workspace = true }
 
 # misc
 tracing = { workspace = true }
-thiserror = "1.0"
+thiserror = { workspace = true }
 hex = "0.4"
-rand = { version = "0.8", optional = true }
+rand = { workspace = true, optional = true }
 generic-array = "0.14"
-serde = { version = "1.0", optional = true }
+serde = { workspace = true, optional = true }
 
 [dev-dependencies]
-rand = "0.8"
-tokio = { version = "1", features = ["macros"] }
+rand = { workspace = true }
+tokio = { workspace = true, features = ["macros"] }
 reth-tracing = { path = "../../tracing" }
 
 [features]

--- a/crates/net/dns/Cargo.toml
+++ b/crates/net/dns/Cargo.toml
@@ -10,34 +10,34 @@ description = "Support for EIP-1459 Node Discovery via DNS"
 
 [dependencies]
 # reth
-reth-primitives = { path = "../../primitives" }
+reth-primitives = { workspace = true }
 reth-net-common = { path = "../common" }
-reth-rlp = { path = "../../rlp" }
+reth-rlp = { workspace = true }
 
 # ethereum
-secp256k1 = { version = "0.27.0", features = ["global-context", "rand-std", "recovery", "serde"] }
+secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery", "serde"] }
 enr = { version = "0.8.1", default-features = false, features = ["rust-secp256k1"] }
 
 # async/futures
-tokio = { version = "1", features = ["io-util", "net", "time"] }
-tokio-stream = "0.1"
+tokio = { workspace = true, features = ["io-util", "net", "time"] }
+tokio-stream = { workspace = true }
 
 # trust-dns
 trust-dns-resolver = "0.22"
 
 # misc
 data-encoding = "2"
-async-trait = "0.1"
+async-trait = { workspace = true }
 linked_hash_set = "0.1"
 schnellru = "0.2"
-thiserror = "1.0"
+thiserror = { workspace = true }
 tracing = { workspace = true }
 parking_lot = "0.12"
-serde = { version = "1.0", optional = true }
+serde = { workspace = true, optional = true }
 serde_with = { version = "2.1.0", optional = true }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["sync", "rt", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["sync", "rt", "rt-multi-thread"] }
 reth-tracing = { path = "../../tracing" }
 
 [features]

--- a/crates/net/downloaders/Cargo.toml
+++ b/crates/net/downloaders/Cargo.toml
@@ -10,38 +10,38 @@ description = "Implementations of various block downloaders"
 
 [dependencies]
 # reth
-reth-interfaces = { path = "../../interfaces" }
-reth-primitives = { path = "../../primitives" }
+reth-interfaces = { workspace = true }
+reth-primitives = { workspace = true }
 reth-db = { path = "../../storage/db" }
-reth-tasks = { path = "../../tasks" }
-reth-metrics = { path = "../../metrics" }
+reth-tasks = { workspace = true }
+reth-metrics = { workspace = true }
 
 # async
-futures = "0.3"
-futures-util = "0.3.25"
-pin-project = "1.0"
-tokio = { version = "1.0", features = ["sync"] }
-tokio-stream = "0.1"
-tokio-util = { version = "0.7", features = ["codec"] }
+futures = { workspace = true }
+futures-util = { workspace = true }
+pin-project = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+tokio-stream = { workspace = true }
+tokio-util = { workspace = true, features = ["codec"] }
 
 # misc
 tracing = { workspace = true }
 rayon = "1.6.0"
-thiserror = "1"
+thiserror = { workspace = true }
 
 # optional deps for the test-utils feature
-reth-rlp = { path = "../../rlp", optional = true }
+reth-rlp = { workspace = true, optional = true }
 tempfile = { version = "3.3", optional = true }
 itertools = { version = "0.10", optional = true }
 
 [dev-dependencies]
 reth-db = { path = "../../storage/db", features = ["test-utils"] }
-reth-interfaces = { path = "../../interfaces", features = ["test-utils"] }
+reth-interfaces = { workspace = true, features = ["test-utils"] }
 reth-tracing = { path = "../../tracing" }
 
 assert_matches = "1.5.0"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-reth-rlp = { path = "../../rlp" }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+reth-rlp = { workspace = true }
 itertools = "0.10"
 
 tempfile = "3.3"

--- a/crates/net/ecies/Cargo.toml
+++ b/crates/net/ecies/Cargo.toml
@@ -8,16 +8,16 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-reth-rlp = { path = "../../rlp", features = ["derive", "ethereum-types", "std"] }
-reth-primitives = { path = "../../primitives" }
+reth-rlp = { workspace = true, features = ["derive", "ethereum-types", "std"] }
+reth-primitives = { workspace = true }
 reth-net-common = { path = "../common" }
 
-futures = "0.3.24"
-thiserror = "1.0.37"
-tokio = { version = "1.21.2", features = ["full"] }
-tokio-stream = "0.1.11"
-tokio-util = { version = "0.7.4", features = ["codec"] }
-pin-project = "1.0"
+futures = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tokio-stream = { workspace = true }
+tokio-util = { workspace = true, features = ["codec"] }
+pin-project = { workspace = true }
 
 educe = "0.4.19"
 tracing = { workspace = true }
@@ -28,10 +28,10 @@ typenum = "1.15.0"
 byteorder = "1.4.3"
 
 # crypto
-rand = "0.8.5"
+rand = { workspace = true }
 ctr = "0.9.2"
 digest = "0.10.5"
-secp256k1 = { version = "0.27.0", features = ["global-context", "rand-std", "recovery"] }
+secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery"] }
 sha2 = "0.10.6"
 sha3 = "0.10.5"
 aes = "0.8.1"

--- a/crates/net/eth-wire/Cargo.toml
+++ b/crates/net/eth-wire/Cargo.toml
@@ -10,34 +10,34 @@ repository.workspace = true
 
 [dependencies]
 bytes = "1.4"
-thiserror = "1"
-serde = { version = "1", optional = true }
+thiserror = { workspace = true }
+serde = { workspace = true, optional = true }
 
 # reth
 reth-codecs = { path = "../../storage/codecs" }
-reth-primitives = { path = "../../primitives" }
+reth-primitives = { workspace = true }
 reth-ecies = { path = "../ecies" }
-reth-rlp = { path = "../../rlp", features = [
+reth-rlp = { workspace = true, features = [
     "alloc",
     "derive",
     "std",
     "ethereum-types",
     "smol_str",
 ] }
-reth-metrics = { path = "../../metrics" }
+reth-metrics = { workspace = true }
 
 # used for Chain and builders
 ethers-core = { version = "2.0.7", default-features = false }
 
-tokio = { version = "1.21.2", features = ["full"] }
-tokio-util = { version = "0.7.4", features = ["io", "codec"] }
-futures = "0.3.24"
-tokio-stream = "0.1.11"
-pin-project = "1.0"
+tokio = { workspace = true, features = ["full"] }
+tokio-util = { workspace = true, features = ["io", "codec"] }
+futures = { workspace = true }
+tokio-stream = { workspace = true }
+pin-project = { workspace = true }
 tracing = { workspace = true }
 snap = "1.0.5"
 smol_str = "0.1"
-async-trait = "0.1"
+async-trait = { workspace = true }
 
 # arbitrary utils
 arbitrary = { version = "1.1.7", features = ["derive"], optional = true }
@@ -45,16 +45,16 @@ proptest = { version = "1.0", optional = true }
 proptest-derive = { version = "0.3", optional = true }
 
 [dev-dependencies]
-reth-primitives = { path = "../../primitives", features = ["arbitrary"] }
+reth-primitives = { workspace = true, features = ["arbitrary"] }
 reth-tracing = { path = "../../tracing" }
 ethers-core = { version = "2.0.7", default-features = false }
 
 test-fuzz = "3.0.4"
-tokio-util = { version = "0.7.4", features = ["io", "codec"] }
+tokio-util = { workspace = true, features = ["io", "codec"] }
 hex-literal = "0.3"
 hex = "0.4"
-rand = "0.8"
-secp256k1 = { version = "0.27.0", features = ["global-context", "rand-std", "recovery"] }
+rand = { workspace = true }
+secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery"] }
 
 arbitrary = { version = "1.1.7", features = ["derive"] }
 proptest = { version = "1.0" }

--- a/crates/net/nat/Cargo.toml
+++ b/crates/net/nat/Cargo.toml
@@ -20,13 +20,13 @@ igd = { git = "https://github.com/stevefan1999-personal/rust-igd", features = ["
 # misc
 tracing = { workspace = true }
 pin-project-lite = "0.2.9"
-tokio = { version = "1", features = ["time"] }
-thiserror = "1.0"
+tokio = { workspace = true, features = ["time"] }
+thiserror = { workspace = true }
 serde_with = { version = "2.1.0", optional = true }
 
 [dev-dependencies]
 reth-tracing = { path = "../../tracing" }
-tokio = { version = "1", features = ["macros"] }
+tokio = { workspace = true, features = ["macros"] }
 
 [features]
 default = ["serde"]

--- a/crates/net/network-api/Cargo.toml
+++ b/crates/net/network-api/Cargo.toml
@@ -10,17 +10,17 @@ description = "Network interfaces"
 
 [dependencies]
 # reth
-reth-primitives = { path = "../../primitives" }
+reth-primitives = { workspace = true }
 reth-eth-wire = { path = "../eth-wire" }
-reth-rpc-types = { path = "../../rpc/rpc-types" }
+reth-rpc-types = { workspace = true }
 
 # io
-serde = { version = "1.0", features = ["derive"], optional = true }
+serde = { workspace = true, features = ["derive"], optional = true }
 
 # misc
-async-trait = "0.1"
-thiserror = "1.0.37"
-tokio = { version = "1.21.2", features = ["sync"] }
+async-trait = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 
 [features]
 default = ["serde"]

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -18,46 +18,46 @@ normal = [
 
 [dependencies]
 # reth
-reth-interfaces = { path = "../../interfaces" }
-reth-primitives = { path = "../../primitives" }
+reth-interfaces = { workspace = true }
+reth-primitives = { workspace = true }
 reth-net-common = { path = "../common" }
-reth-network-api = { path = "../network-api" }
+reth-network-api = { workspace = true }
 reth-discv4 = { path = "../discv4" }
 reth-dns-discovery = { path = "../dns" }
 reth-eth-wire = { path = "../eth-wire" }
 reth-ecies = { path = "../ecies" }
-reth-rlp = { path = "../../rlp" }
+reth-rlp = { workspace = true }
 reth-rlp-derive = { path = "../../rlp/rlp-derive" }
-reth-tasks = { path = "../../tasks" }
-reth-transaction-pool = { path = "../../transaction-pool" }
-reth-provider = { path = "../../storage/provider" }
-reth-metrics = { path = "../../metrics", features = ["common"] }
-reth-rpc-types = { path = "../../rpc/rpc-types" }
+reth-tasks = { workspace = true }
+reth-transaction-pool = { workspace = true }
+reth-provider = { workspace = true }
+reth-metrics = { workspace = true, features = ["common"] }
+reth-rpc-types = { workspace = true }
 
 # async/futures
-futures = "0.3"
-pin-project = "1.0"
-tokio = { version = "1", features = ["io-util", "net", "macros", "rt-multi-thread", "time"] }
-tokio-stream = "0.1"
-tokio-util = { version = "0.7", features = ["codec"] }
+futures = { workspace = true }
+pin-project = { workspace = true }
+tokio = { workspace = true, features = ["io-util", "net", "macros", "rt-multi-thread", "time"] }
+tokio-stream = { workspace = true }
+tokio-util = { workspace = true, features = ["codec"] }
 
 # io
-serde = { version = "1.0", optional = true }
+serde = { workspace = true, optional = true }
 humantime-serde = { version = "1.1", optional = true }
-serde_json = { version = "1.0", optional = true }
+serde_json = { workspace = true, optional = true }
 
 # misc
 auto_impl = "1"
 aquamarine = "0.3.0"
 tracing = { workspace = true }
 fnv = "1.0"
-thiserror = "1.0"
+thiserror = { workspace = true }
 parking_lot = "0.12"
-async-trait = "0.1"
+async-trait = { workspace = true }
 linked_hash_set = "0.1"
 linked-hash-map = "0.5.6"
-rand = "0.8"
-secp256k1 = { version = "0.27.0", features = ["global-context", "rand-std", "recovery"] }
+rand = { workspace = true }
+secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery"] }
 
 enr = { version = "0.8.1", features = ["rust-secp256k1"], optional = true }
 ethers-core = { version = "2.0.7", default-features = false, optional = true }
@@ -66,15 +66,15 @@ tempfile = { version = "3.3", optional = true }
 [dev-dependencies]
 # reth
 reth-discv4 = { path = "../discv4", features = ["test-utils"] }
-reth-interfaces = { path = "../../interfaces", features = ["test-utils"] }
+reth-interfaces = { workspace = true, features = ["test-utils"] }
 
 # we need to enable the test-utils feature in our own crate to use utils in
 # integration tests
 reth-network = { path = ".", features = ["test-utils"] }
 
-reth-provider = { path = "../../storage/provider", features = ["test-utils"] }
+reth-provider = { workspace = true, features = ["test-utils"] }
 reth-tracing = { path = "../../tracing" }
-reth-transaction-pool = { path = "../../transaction-pool", features = ["test-utils"] }
+reth-transaction-pool = { workspace = true, features = ["test-utils"] }
 
 ethers-core = { version = "2.0.7", default-features = false }
 ethers-providers = { version = "2.0.7", default-features = false }

--- a/crates/payload/basic/Cargo.toml
+++ b/crates/payload/basic/Cargo.toml
@@ -10,22 +10,22 @@ description = "A basic payload builder for reth that uses the txpool API to buil
 
 [dependencies]
 ## reth
-reth-primitives = { path = "../../primitives" }
+reth-primitives = { workspace = true }
 reth-revm = { path = "../../revm" }
-reth-transaction-pool = { path = "../../transaction-pool" }
-reth-rlp = { path = "../../rlp" }
-reth-provider = { path = "../../storage/provider" }
-reth-payload-builder = { path = "../builder" }
-reth-tasks = { path = "../../tasks" }
-reth-metrics = { path = "../../metrics" }
+reth-transaction-pool = { workspace = true }
+reth-rlp = { workspace = true }
+reth-provider = { workspace = true }
+reth-payload-builder = { workspace = true }
+reth-tasks = { workspace = true }
+reth-metrics = { workspace = true }
 
 ## ethereum
 revm = { workspace = true }
 
 ## async
-tokio = { version = "1", features = ["sync", "time"] }
+tokio = { workspace = true, features = ["sync", "time"] }
 futures-core = "0.3"
-futures-util = "0.3"
+futures-util = { workspace = true }
 
 ## misc
 tracing = { workspace = true }

--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -10,23 +10,23 @@ description = "reth payload builder"
 
 [dependencies]
 ## reth
-reth-primitives = { path = "../../primitives" }
-reth-rpc-types = { path = "../../rpc/rpc-types" }
-reth-rlp = { path = "../../rlp" }
-reth-interfaces = { path = "../../interfaces" }
+reth-primitives = { workspace = true }
+reth-rpc-types = { workspace = true }
+reth-rlp = { workspace = true }
+reth-interfaces = { workspace = true }
 reth-revm-primitives = { path = "../../revm/revm-primitives" }
-reth-metrics = { path = "../../metrics" }
+reth-metrics = { workspace = true }
 
 ## ethereum
 revm-primitives = { workspace = true }
 
 ## async
-tokio = { version = "1", features = ["sync"] }
-tokio-stream = "0.1"
-futures-util = "0.3"
+tokio = { workspace = true, features = ["sync"] }
+tokio-stream = { workspace = true }
+futures-util = { workspace = true }
 
 ## misc
-thiserror = "1.0"
+thiserror = { workspace = true }
 sha2 = { version = "0.10", default-features = false }
 tracing = { workspace = true }
 hashbrown = "0.13"

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -10,7 +10,7 @@ description = "Commonly used types in reth."
 
 [dependencies]
 # reth
-reth-rlp = { path = "../rlp", features = ["std", "derive", "ethereum-types"] }
+reth-rlp = { workspace = true, features = ["std", "derive", "ethereum-types"] }
 reth-rlp-derive = { path = "../rlp/rlp-derive" }
 reth-codecs = { version = "0.1.0", path = "../storage/codecs" }
 
@@ -26,7 +26,7 @@ ruint = { version = "1.7.0", features = ["primitive-types", "rlp"] }
 fixed-hash = { version = "0.8", default-features = false, features = ["rustc-hex"] }
 
 # crypto
-secp256k1 = { version = "0.27.0", default-features = false, features = [
+secp256k1 = { workspace = true, default-features = false, features = [
     "global-context",
     "alloc",
     "recovery",
@@ -39,15 +39,15 @@ crc = "3"
 tracing = { workspace = true }
 
 # tokio
-tokio = { version = "1", default-features = false, features = ["sync"] }
-tokio-stream = "0.1"
+tokio = { workspace = true, default-features = false, features = ["sync"] }
+tokio-stream = { workspace = true }
 
 # misc
 bytes = "1.4"
-serde = "1.0"
-serde_json = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
 serde_with = "2.1.0"
-thiserror = "1"
+thiserror = { workspace = true }
 sucds = "0.5.0"
 hex = "0.4"
 hex-literal = "0.3"
@@ -71,10 +71,10 @@ proptest-derive = { version = "0.3", optional = true }
 strum = { version = "0.24", features = ["derive"] }
 
 [dev-dependencies]
-serde_json = "1.0"
+serde_json = { workspace = true }
 hex-literal = "0.3"
 test-fuzz = "3.0.4"
-rand = "0.8"
+rand = { workspace = true }
 revm-primitives = { workspace = true, features = ["arbitrary"] }
 arbitrary = { version = "1.1.7", features = ["derive"] }
 proptest = { version = "1.0" }
@@ -82,7 +82,7 @@ proptest-derive = "0.3"
 
 # necessary so we don't hit a "undeclared 'std'": 
 # https://github.com/paradigmxyz/reth/pull/177#discussion_r1021172198 
-secp256k1 = "0.27.0"
+secp256k1 = { workspace = true }
 criterion = "0.4.0"
 pprof = { version = "0.11", features = ["flamegraph", "frame-pointer", "criterion"] }
 

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -10,9 +10,9 @@ description = "reth specific revm utilities"
 
 [dependencies]
 # reth 
-reth-primitives = { path = "../primitives" }
-reth-interfaces = { path = "../interfaces" }
-reth-provider = { path = "../storage/provider" }
+reth-primitives = { workspace = true }
+reth-interfaces = { workspace = true }
+reth-provider = { workspace = true }
 reth-revm-primitives = { path = "./revm-primitives" }
 reth-revm-inspectors = { path = "./revm-inspectors" }
 reth-consensus-common = { path = "../consensus/common" }
@@ -24,5 +24,5 @@ revm = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-reth-rlp = { path = "../rlp" }
+reth-rlp = { workspace = true }
 once_cell = "1.17.0"

--- a/crates/revm/revm-inspectors/Cargo.toml
+++ b/crates/revm/revm-inspectors/Cargo.toml
@@ -10,11 +10,11 @@ description = "revm inspector implementations used by reth"
 
 [dependencies]
 # reth 
-reth-primitives = { path = "../../primitives" }
-reth-rpc-types = { path = "../../rpc/rpc-types" }
+reth-primitives = { workspace = true }
+reth-rpc-types = { workspace = true }
 
 revm = { workspace = true }
 # remove from reth and reexport from revm
 hashbrown = "0.13"
 
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }

--- a/crates/revm/revm-primitives/Cargo.toml
+++ b/crates/revm/revm-primitives/Cargo.toml
@@ -10,6 +10,6 @@ description = "core reth specific revm utilities"
 
 [dependencies]
 # reth 
-reth-primitives = { path = "../../primitives" }
+reth-primitives = { workspace = true }
 
 revm = { workspace = true }

--- a/crates/rlp/Cargo.toml
+++ b/crates/rlp/Cargo.toml
@@ -19,7 +19,7 @@ revm-primitives = { workspace = true, features = ["serde"] }
 reth-rlp-derive = { version = "0.1", path = "./rlp-derive", optional = true }
 
 [dev-dependencies]
-reth-rlp = { path = ".", package = "reth-rlp", features = [
+reth-rlp = { workspace = true, features = [
     "derive",
     "std",
     "ethnum",

--- a/crates/rpc/ipc/Cargo.toml
+++ b/crates/rpc/ipc/Cargo.toml
@@ -13,25 +13,25 @@ IPC support for reth
 [dependencies]
 
 # async/net
-futures = "0.3"
+futures = { workspace = true }
 parity-tokio-ipc = "0.9.0"
-tokio = { version = "1", features = ["net", "time", "rt-multi-thread"] }
-tokio-util = { version = "0.7", features = ["codec"] }
-tokio-stream = "0.1"
-async-trait = "0.1"
-pin-project = "1.0"
+tokio = { workspace = true, features = ["net", "time", "rt-multi-thread"] }
+tokio-util = { workspace = true, features = ["codec"] }
+tokio-stream = { workspace = true }
+async-trait = { workspace = true }
+pin-project = { workspace = true }
 tower = "0.4"
 
 # misc
 jsonrpsee = { version = "0.18", features = ["server", "client"] }
-serde_json = "1.0"
+serde_json = { workspace = true }
 tracing = { workspace = true }
 bytes = "1.4"
-thiserror = "1.0.37"
+thiserror = { workspace = true }
 
 [dev-dependencies]
 tracing-test = "0.2"
-tokio-stream = { version = "0.1", features = ["sync"] }
+tokio-stream = { workspace = true, features = ["sync"] }
 
 [features]
 client = ["jsonrpsee/client", "jsonrpsee/async-client"]

--- a/crates/rpc/rpc-api/Cargo.toml
+++ b/crates/rpc/rpc-api/Cargo.toml
@@ -12,12 +12,12 @@ Reth RPC interfaces
 
 [dependencies]
 # reth
-reth-primitives = { path = "../../primitives" }
-reth-rpc-types = { path = "../rpc-types" }
+reth-primitives = { workspace = true }
+reth-rpc-types = { workspace = true }
 
 # misc
 jsonrpsee = { version = "0.18", features = ["server", "macros"] }
-serde_json = "1.0"
+serde_json = { workspace = true }
 
 [features]
 client = ["jsonrpsee/client", "jsonrpsee/async-client"]

--- a/crates/rpc/rpc-builder/Cargo.toml
+++ b/crates/rpc/rpc-builder/Cargo.toml
@@ -10,17 +10,17 @@ description = "Helpers for configuring RPC"
 
 [dependencies]
 # reth
-reth-primitives = { path = "../../primitives" }
+reth-primitives = { workspace = true }
 reth-ipc = { path = "../ipc" }
-reth-interfaces = { path = "../../interfaces" }
-reth-network-api = { path = "../../net/network-api" }
-reth-provider = { path = "../../storage/provider" }
+reth-interfaces = { workspace = true }
+reth-network-api = { workspace = true }
+reth-provider = { workspace = true }
 reth-rpc = { path = "../rpc" }
 reth-rpc-api = { path = "../rpc-api" }
 reth-rpc-engine-api = { path = "../rpc-engine-api" }
-reth-rpc-types = { path = "../rpc-types" }
-reth-tasks = { path = "../../tasks" }
-reth-transaction-pool = { path = "../../transaction-pool" }
+reth-rpc-types = { workspace = true }
+reth-tasks = { workspace = true }
+reth-transaction-pool = { workspace = true }
 
 # rpc/net
 jsonrpsee = { version = "0.18", features = ["server"] }
@@ -30,19 +30,19 @@ hyper = "0.14"
 
 # misc
 strum = { version = "0.24", features = ["derive"] }
-serde = { version = "1.0", features = ["derive"] }
-thiserror = "1.0"
+serde = { workspace = true, features = ["derive"] }
+thiserror = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
 reth-tracing = { path = "../../tracing" }
 reth-rpc-api = { path = "../rpc-api", features = ["client"] }
-reth-transaction-pool = { path = "../../transaction-pool", features = ["test-utils"] }
-reth-provider = { path = "../../storage/provider", features = ["test-utils"] }
-reth-network-api = { path = "../../net/network-api", features = ["test-utils"] }
-reth-interfaces = { path = "../../interfaces", features = ["test-utils"] }
+reth-transaction-pool = { workspace = true, features = ["test-utils"] }
+reth-provider = { workspace = true, features = ["test-utils"] }
+reth-network-api = { workspace = true, features = ["test-utils"] }
+reth-interfaces = { workspace = true, features = ["test-utils"] }
 reth-beacon-consensus = { path = "../../consensus/beacon" }
-reth-payload-builder = { path = "../../payload/builder", features = ["test-utils"] }
+reth-payload-builder = { workspace = true, features = ["test-utils"] }
 
-tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
-serde_json = "1.0.94"
+tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
+serde_json = { workspace = true }

--- a/crates/rpc/rpc-engine-api/Cargo.toml
+++ b/crates/rpc/rpc-engine-api/Cargo.toml
@@ -10,26 +10,26 @@ description = "Implementation of Engine API"
 
 [dependencies]
 # reth 
-reth-primitives = { path = "../../primitives" }
-reth-interfaces = { path = "../../interfaces" }
-reth-provider = { path = "../../storage/provider" }
-reth-rpc-types = { path = "../rpc-types" }
+reth-primitives = { workspace = true }
+reth-interfaces = { workspace = true }
+reth-provider = { workspace = true }
+reth-rpc-types = { workspace = true }
 reth-rpc-api = { path = "../rpc-api" }
 reth-beacon-consensus = { path = "../../consensus/beacon" }
-reth-payload-builder = { path = "../../payload/builder" }
+reth-payload-builder = { workspace = true }
 
 # async
-tokio = { version = "1", features = ["sync"] }
+tokio = { workspace = true, features = ["sync"] }
 
 # misc
-async-trait = "0.1"
-thiserror = "1.0.37"
+async-trait = { workspace = true }
+thiserror = { workspace = true }
 jsonrpsee-types = "0.18"
 jsonrpsee-core = "0.18"
 tracing = { workspace = true }
 
 [dev-dependencies]
-reth-interfaces = { path = "../../interfaces", features = ["test-utils"] }
-reth-provider = { path = "../../storage/provider", features = ["test-utils"] }
-reth-payload-builder = { path = "../../payload/builder", features = ["test-utils"] }
+reth-interfaces = { workspace = true, features = ["test-utils"] }
+reth-provider = { workspace = true, features = ["test-utils"] }
+reth-payload-builder = { workspace = true, features = ["test-utils"] }
 assert_matches = "1.5.0"

--- a/crates/rpc/rpc-testing-util/Cargo.toml
+++ b/crates/rpc/rpc-testing-util/Cargo.toml
@@ -12,17 +12,17 @@ Reth RPC testing helpers
 
 [dependencies]
 # reth
-reth-primitives = { path = "../../primitives" }
-reth-rpc-types = { path = "../rpc-types" }
+reth-primitives = { workspace = true }
+reth-rpc-types = { workspace = true }
 reth-rpc-api = { path = "../rpc-api", default-features = false, features = ["client"] }
 
 # async
-async-trait = "0.1"
-futures = "0.3"
+async-trait = { workspace = true }
+futures = { workspace = true }
 
 # misc
 jsonrpsee = { version = "0.18", features = ["client", "async-client"] }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "rt"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "rt"] }
 

--- a/crates/rpc/rpc-types/Cargo.toml
+++ b/crates/rpc/rpc-types/Cargo.toml
@@ -12,26 +12,26 @@ Reth RPC types
 
 [dependencies]
 # reth
-reth-primitives = { path = "../../primitives" }
-reth-rlp = { path = "../../rlp" }
+reth-primitives = { workspace = true }
+reth-rlp = { workspace = true }
 
 # errors
-thiserror = "1.0"
+thiserror = { workspace = true }
 
 # async
-tokio = { version = "1", features = ["sync"] }
+tokio = { workspace = true, features = ["sync"] }
 
 # misc
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 jsonrpsee-types = { version = "0.18" }
 lru = "0.9"
 
 [dev-dependencies]
 # reth
-reth-interfaces = { path = "../../interfaces", features = ["test-utils"] }
+reth-interfaces = { workspace = true, features = ["test-utils"] }
 
 # misc
-rand = "0.8"
+rand = { workspace = true }
 assert_matches = "1.5"
 similar-asserts = "1.4"

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -11,17 +11,17 @@ Reth RPC implementation
 """
 [dependencies]
 # reth
-reth-interfaces = { path = "../../interfaces" }
-reth-primitives = { path = "../../primitives" }
+reth-interfaces = { workspace = true }
+reth-primitives = { workspace = true }
 reth-rpc-api = { path = "../rpc-api" }
-reth-rlp = { path = "../../rlp" }
-reth-rpc-types = { path = "../rpc-types" }
-reth-provider = { path = "../../storage/provider", features = ["test-utils"] }
-reth-transaction-pool = { path = "../../transaction-pool", features = ["test-utils"] }
-reth-network-api = { path = "../../net/network-api", features = ["test-utils"] }
+reth-rlp = { workspace = true }
+reth-rpc-types = { workspace = true }
+reth-provider = { workspace = true, features = ["test-utils"] }
+reth-transaction-pool = { workspace = true, features = ["test-utils"] }
+reth-network-api = { workspace = true, features = ["test-utils"] }
 reth-rpc-engine-api = { path = "../rpc-engine-api" }
 reth-revm = { path = "../../revm" }
-reth-tasks = { path = "../../tasks" }
+reth-tasks = { workspace = true }
 
 # eth
 revm = { workspace = true, features = [
@@ -40,24 +40,24 @@ hyper = "0.14.24"
 jsonwebtoken = "8"
 
 # async
-async-trait = "0.1"
-tokio = { version = "1", features = ["sync"] }
+async-trait = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 tower = "0.4"
-tokio-stream = { version = "0.1", features = ["sync"] }
+tokio-stream = { workspace = true, features = ["sync"] }
 tokio-util = "0.7"
-pin-project = "1.0"
+pin-project = { workspace = true }
 
 bytes = "1.4"
-secp256k1 = { version = "0.27.0", features = ["global-context", "rand-std", "recovery"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-thiserror = "1.0"
+secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
 hex = "0.4"
-rand = "0.8.5"
+rand = { workspace = true }
 tracing = { workspace = true }
 tracing-futures = "0.2"
 schnellru = "0.2"
-futures = "0.3.26"
+futures = { workspace = true }
 
 [dev-dependencies]
 jsonrpsee = { version = "0.18", features = ["client"] }

--- a/crates/staged-sync/Cargo.toml
+++ b/crates/staged-sync/Cargo.toml
@@ -12,18 +12,18 @@ description = "Puts together all the Reth stages in a unified abstraction"
 # reth
 reth-db = { path = "../../crates/storage/db", features = ["mdbx", "test-utils"] }
 reth-discv4 = { path = "../../crates/net/discv4" }
-reth-network-api = { path = "../../crates/net/network-api" }
+reth-network-api = { workspace = true }
 reth-network = { path = "../../crates/net/network", features = ["serde"] }
 reth-downloaders = { path = "../../crates/net/downloaders" }
-reth-primitives = { path = "../../crates/primitives" }
-reth-provider = { path = "../../crates/storage/provider", features = ["test-utils"] }
+reth-primitives = { workspace = true }
+reth-provider = { workspace = true, features = ["test-utils"] }
 reth-net-nat = { path = "../../crates/net/nat" }
 reth-stages = { path = "../stages" }
-reth-interfaces = { path = "../interfaces" }
+reth-interfaces = { workspace = true }
 
 # io
 serde = "1.0"
-serde_json = "1.0.91"
+serde_json = { workspace = true }
 
 # misc
 walkdir = "2.3.2"
@@ -32,11 +32,11 @@ shellexpand = "3.0.0"
 tracing = { workspace = true }
 
 # crypto
-rand = { version = "0.8", optional = true }
-secp256k1 = { version = "0.27.0", features = ["global-context", "rand-std", "recovery"] }
+rand = { workspace = true, optional = true }
+secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery"] }
 
 # errors
-thiserror = "1"
+thiserror = { workspace = true }
 
 # enr
 enr = { version = "0.8.1", features = ["serde", "rust-secp256k1"], optional = true }
@@ -50,8 +50,8 @@ ethers-middleware = { version = "2.0.7", default-features = false, optional = tr
 ethers-signers = { version = "2.0.7", default-features = false, optional = true }
 
 # async / futures
-async-trait = { version = "0.1", optional = true }
-tokio = { version = "1", features = [
+async-trait = { workspace = true, optional = true }
+tokio = { workspace = true, features = [
     "io-util",
     "net",
     "macros",
@@ -72,11 +72,11 @@ reth-tracing = { path = "../tracing" }
 reth-downloaders = { path = "../net/downloaders" }
 
 # async/futures
-futures = "0.3"
-tokio = { version = "1", features = ["io-util", "net", "macros", "rt-multi-thread", "time"] }
+futures = { workspace = true }
+tokio = { workspace = true, features = ["io-util", "net", "macros", "rt-multi-thread", "time"] }
 
 # crypto
-secp256k1 = { version = "0.27.0", features = ["global-context", "rand-std", "recovery"] }
+secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery"] }
 
 confy = "0.5"
 

--- a/crates/stages/Cargo.toml
+++ b/crates/stages/Cargo.toml
@@ -16,26 +16,26 @@ normal = [
 
 [dependencies]
 # reth
-reth-primitives = { path = "../primitives" }
-reth-interfaces = { path = "../interfaces" }
+reth-primitives = { workspace = true }
+reth-interfaces = { workspace = true }
 reth-db = { path = "../storage/db" }
 reth-codecs = { path = "../storage/codecs" }
-reth-provider = { path = "../storage/provider" }
-reth-metrics = { path = "../metrics" }
+reth-provider = { workspace = true }
+reth-metrics = { workspace = true }
 reth-trie = { path = "../trie" }
 
 # async
-tokio = { version = "1.21.2", features = ["sync"] }
-tokio-stream = "0.1.10"
-async-trait = "0.1.57"
-futures-util = "0.3.25"
-pin-project = "1.0.12"
+tokio = { workspace = true, features = ["sync"] }
+tokio-stream = { workspace = true }
+async-trait = { workspace = true }
+futures-util = { workspace = true }
+pin-project = { workspace = true }
 
 # observability
 tracing = { workspace = true }
 
 # misc
-thiserror = "1.0.37"
+thiserror = { workspace = true }
 aquamarine = "0.3.0"
 itertools = "0.10.5"
 rayon = "1.6.0"
@@ -43,20 +43,20 @@ num-traits = "0.2.15"
 
 [dev-dependencies]
 # reth
-reth-primitives = { path = "../primitives", features = ["arbitrary"] }
+reth-primitives = { workspace = true, features = ["arbitrary"] }
 reth-db = { path = "../storage/db", features = ["test-utils", "mdbx"] }
-reth-interfaces = { path = "../interfaces", features = ["test-utils"] }
+reth-interfaces = { workspace = true, features = ["test-utils"] }
 reth-downloaders = { path = "../net/downloaders" }
 reth-eth-wire = { path = "../net/eth-wire" } # TODO(onbjerg): We only need this for [BlockBody]
 reth-blockchain-tree = { path = "../blockchain-tree" }
-reth-rlp = { path = "../rlp" }
+reth-rlp = { workspace = true }
 reth-revm = { path = "../revm" }
 reth-trie = { path = "../trie", features = ["test-utils"] }
 
 itertools = "0.10.5"
-tokio = { version = "*", features = ["rt", "sync", "macros"] }
+tokio = { workspace = true, features = ["rt", "sync", "macros"] }
 assert_matches = "1.5.0"
-rand = "0.8.5"
+rand = { workspace = true }
 paste = "1.0"
 
 # Stage benchmarks

--- a/crates/storage/codecs/derive/Cargo.toml
+++ b/crates/storage/codecs/derive/Cargo.toml
@@ -26,7 +26,7 @@ syn = { version = "2.0", features = ["full"] }
 convert_case = "0.6.0"
 
 # codecs
-serde = { version = "1.0.*", default-features = false }
+serde = { workspace = true, default-features = false }
 parity-scale-codec = { version = "3.2.1", features = ["derive", "bytes"] }
 
 [features]

--- a/crates/storage/db/Cargo.toml
+++ b/crates/storage/db/Cargo.toml
@@ -10,21 +10,21 @@ description = "Staged syncing primitives used in reth."
 
 [dependencies]
 # reth
-reth-primitives = { path = "../../primitives" }
-reth-interfaces = { path = "../../interfaces" }
+reth-primitives = { workspace = true }
+reth-interfaces = { workspace = true }
 reth-codecs = { path = "../codecs" }
 reth-libmdbx = { path = "../libmdbx-rs", optional = true, features = ["return-borrowed"] }
-reth-metrics = { path = "../../metrics" }
+reth-metrics = { workspace = true }
 
 # codecs
-serde = { version = "1.0.*", default-features = false }
+serde = { workspace = true, default-features = false }
 postcard = { version = "1.0.2", features = ["alloc"] }
 heapless = "0.7.16"
 parity-scale-codec = { version = "3.2.1", features = ["bytes"] }
-futures = "0.3.25"
-tokio-stream = "0.1.11"
-rand = "0.8.5"
-secp256k1 = { version = "0.27.0", default-features = false, features = [
+futures = { workspace = true }
+tokio-stream = { workspace = true }
+rand = { workspace = true }
+secp256k1 = { workspace = true, default-features = false, features = [
     "alloc",
     "recovery",
     "rand",
@@ -34,7 +34,7 @@ modular-bitfield = "0.11.2"
 # misc
 bytes = "1.4"
 page_size = "0.4.2"
-thiserror = "1.0.37"
+thiserror = { workspace = true }
 tempfile = { version = "3.3.0", optional = true }
 parking_lot = "0.12"
 
@@ -45,9 +45,9 @@ proptest-derive = { version = "0.3", optional = true }
 
 [dev-dependencies]
 # reth libs with arbitrary
-reth-primitives = { path = "../../primitives", features = ["arbitrary"] }
+reth-primitives = { workspace = true, features = ["arbitrary"] }
 reth-codecs = { path = "../codecs", features = ["arbitrary"] }
-reth-interfaces = { path = "../../interfaces", features = ["bench"] }
+reth-interfaces = { workspace = true, features = ["bench"] }
 
 tempfile = "3.3.0"
 test-fuzz = "3.0.4"
@@ -55,19 +55,19 @@ test-fuzz = "3.0.4"
 pprof = { version = "0.11", features = ["flamegraph", "frame-pointer", "criterion"] }
 criterion = "0.4.0"
 iai = "0.1.1"
-tokio = { version = "1.21.2", features = ["full"] }
+tokio = { workspace = true, features = ["full"] }
 reth-db = { path = ".", features = ["test-utils", "bench"] }
 
 # needed for test-fuzz to work properly, see https://github.com/paradigmxyz/reth/pull/177#discussion_r1021172198
-secp256k1 = "0.27.0"
+secp256k1 = { workspace = true }
 
-async-trait = "0.1.58"
+async-trait = { workspace = true }
 
 arbitrary = { version = "1.1.7", features = ["derive"] }
 proptest = { version = "1.0" }
 proptest-derive = "0.3"
 
-serde_json = "1.0"
+serde_json = { workspace = true }
 
 paste = "1.0"
 

--- a/crates/storage/libmdbx-rs/Cargo.toml
+++ b/crates/storage/libmdbx-rs/Cargo.toml
@@ -18,7 +18,7 @@ derive_more = "0.99"
 indexmap = "1"
 libc = "0.2"
 parking_lot = "0.12"
-thiserror = "1"
+thiserror = { workspace = true }
 
 ffi = { package = "reth-mdbx-sys", path = "./mdbx-sys" }
 
@@ -31,7 +31,7 @@ return-borrowed = []
 [dev-dependencies]
 pprof = { version = "0.11", features = ["flamegraph", "frame-pointer", "criterion"] }
 criterion = "0.4"
-rand = "0.8"
+rand = { workspace = true }
 rand_xorshift = "0.3"
 tempfile = "3"
 

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -10,34 +10,34 @@ description = "Reth storage provider."
 
 [dependencies]
 # reth
-reth-primitives = { path = "../../primitives" }
-reth-interfaces = { path = "../../interfaces" }
+reth-primitives = { workspace = true }
+reth-interfaces = { workspace = true }
 reth-revm-primitives = { path = "../../revm/revm-primitives" }
 reth-db = { path = "../db" }
 reth-trie = { path = "../../trie" }
 
 # async
-tokio = { version = "1.21", features = ["sync", "macros", "rt-multi-thread"] }
-tokio-stream = { version = "0.1", features = ["sync"] }
+tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread"] }
+tokio-stream = { workspace = true, features = ["sync"] }
 
 # tracing
 tracing = { workspace = true }
 
 # misc
-thiserror = "1.0.37"
+thiserror = { workspace = true }
 auto_impl = "1.0"
 itertools = "0.10"
-pin-project = "1.0"
+pin-project = { workspace = true }
 derive_more = "0.99"
 parking_lot = "0.12"
 
 # test-utils
-reth-rlp = { path = "../../rlp", optional = true }
+reth-rlp = { workspace = true, optional = true }
 
 [dev-dependencies]
 reth-db = { path = "../db", features = ["test-utils"] }
-reth-primitives = { path = "../../primitives", features = ["arbitrary", "test-utils"] }
-reth-rlp = { path = "../../rlp" }
+reth-primitives = { workspace = true, features = ["arbitrary", "test-utils"] }
+reth-rlp = { workspace = true }
 reth-trie = { path = "../../trie", features = ["test-utils"] }
 parking_lot = "0.12"
 

--- a/crates/tasks/Cargo.toml
+++ b/crates/tasks/Cargo.toml
@@ -11,17 +11,17 @@ description = "Task management"
 [dependencies]
 
 ## async
-tokio = { version = "1", features = ["sync", "rt"] }
+tokio = { workspace = true, features = ["sync", "rt"] }
 tracing-futures = "0.2"
-futures-util = "0.3"
+futures-util = { workspace = true }
 
 ## misc
 tracing = { workspace = true }
-thiserror = "1.0"
+thiserror = { workspace = true }
 dyn-clone = "1.0"
 
 ## rpc/metrics
-reth-metrics = { path = "../metrics" }
+reth-metrics = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["sync", "rt", "rt-multi-thread", "time", "macros"] }
+tokio = { workspace = true, features = ["sync", "rt", "rt-multi-thread", "time", "macros"] }

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -18,29 +18,29 @@ normal = [
 
 [dependencies]
 # reth
-reth-primitives = { path = "../primitives" }
-reth-provider = { path = "../storage/provider" }
-reth-interfaces = { path = "../interfaces" }
-reth-rlp = { path = "../rlp" }
-reth-metrics = { path = "../metrics" }
+reth-primitives = { workspace = true }
+reth-provider = { workspace = true }
+reth-interfaces = { workspace = true }
+reth-rlp = { workspace = true }
+reth-metrics = { workspace = true }
 
 # async/futures
-async-trait = "0.1"
-futures-util = "0.3"
+async-trait = { workspace = true}
+futures-util = { workspace = true }
 parking_lot = "0.12"
-tokio = { version = "1", default-features = false, features = ["sync"] }
+tokio = { workspace = true, default-features = false, features = ["sync"] }
 
 # misc
 aquamarine = "0.3.0"
-thiserror = "1.0"
+thiserror = { workspace = true }
 tracing = { workspace = true }
-serde = { version = "1.0", features = ["derive", "rc"], optional = true }
+serde = { workspace = true, features = ["derive", "rc"], optional = true }
 fnv = "1.0.7"
 bitflags = "1.3"
 auto_impl = "1.0"
 
 # testing
-rand = { version = "0.8", optional = true }
+rand = { workspace = true, optional = true }
 paste = { version = "1.0", optional = true }
 
 [dev-dependencies]

--- a/crates/trie/Cargo.toml
+++ b/crates/trie/Cargo.toml
@@ -12,20 +12,20 @@ Merkle trie implementation
 
 [dependencies]
 # reth
-reth-primitives = { path = "../primitives" }
-reth-interfaces = { path = "../interfaces" }
-reth-rlp = { path = "../rlp" }
+reth-primitives = { workspace = true }
+reth-interfaces = { workspace = true }
+reth-rlp = { workspace = true }
 reth-db = { path = "../storage/db" }
 
 # tokio
-tokio = { version = "1.21.2", default-features = false, features = ["sync"] }
+tokio = { workspace = true, default-features = false, features = ["sync"] }
 
 # tracing
 tracing = { workspace = true }
 
 # misc 
 hex = "0.4"
-thiserror = "1.0"
+thiserror = { workspace = true }
 derive_more = "0.99"
 
 # test-utils
@@ -33,17 +33,17 @@ triehash = { version = "0.8", optional = true }
 
 [dev-dependencies]
 # reth
-reth-primitives = { path = "../primitives", features = ["test-utils", "arbitrary"] }
+reth-primitives = { workspace = true, features = ["test-utils", "arbitrary"] }
 reth-db = { path = "../storage/db", features = ["test-utils"] }
-reth-provider = { path = "../storage/provider" }
+reth-provider = { workspace = true }
 
 # trie
 triehash = "0.8"
 
 # misc
 proptest = "1.0"
-tokio = { version = "1.21.2", default-features = false, features = ["sync", "rt", "macros"] }
-tokio-stream = "0.1.10"
+tokio = { workspace = true, default-features = false, features = ["sync", "rt", "macros"] }
+tokio-stream = { workspace = true }
 criterion = "0.4"
 
 [features]

--- a/testing/ef-tests/Cargo.toml
+++ b/testing/ef-tests/Cargo.toml
@@ -12,15 +12,15 @@ repository.workspace = true
 ef-tests = []
 
 [dependencies]
-reth-primitives = { path = "../../crates/primitives" }
+reth-primitives = { workspace = true }
 reth-db = { path = "../../crates/storage/db", features = ["mdbx", "test-utils"] }
-reth-provider = { path = "../../crates/storage/provider" }
+reth-provider = { workspace = true }
 reth-stages = { path = "../../crates/stages" }
-reth-rlp = { path = "../../crates/rlp" }
-reth-interfaces = { path = "../../crates/interfaces" }
+reth-rlp = { workspace = true }
+reth-interfaces = { workspace = true }
 reth-revm = { path = "../../crates/revm" }
 tokio = "1.28.1"
 walkdir = "2.3.3"
 serde = "1.0.163"
-serde_json = "1.0.96"
-thiserror = "1.0.40"
+serde_json = { workspace = true }
+thiserror = { workspace = true }


### PR DESCRIPTION
These were the top 21 most common dependancies, I moved them to workspace dependancies. The number is the frequency of use across all crates. I didn't move any used less than 6 times. 
Closes #3123
```
reth-primitives: 31
thiserror: 20
reth-interfaces: 16
reth-provider: 15
reth-rlp: 13
tokio-stream: 13
tokio: 26
serde: 11
reth-rpc-types: 10
async-trait: 10
reth-metrics: 9
futures: 8
serde_json: 8
secp256k1: 8
reth-payload-builder: 7
pin-project: 7
reth-transaction-pool: 6
futures-util: 6
reth-tasks: 6
rand: 6
reth-network-api: 6
tokio-util: 6
```