### PR TITLE
fix: dynamic batch size for tx lookup stage

### DIFF
--- a/crates/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/src/stages/tx_lookup.rs
@@ -65,7 +65,7 @@ impl<DB: Database> Stage<DB> for TransactionLookupStage {
         let mut tx_cursor = tx.cursor_read::<tables::Transactions>()?;
         let tx_walker = tx_cursor.walk_range(tx_range)?;
 
-        let chunk_size = tx_range_size / rayon::current_num_threads();
+        let chunk_size = (tx_range_size / rayon::current_num_threads()).max(1);
         let mut channels = Vec::with_capacity(chunk_size);
         let mut transaction_count = 0;
 

--- a/crates/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/src/stages/tx_lookup.rs
@@ -57,6 +57,7 @@ impl<DB: Database> Stage<DB> for TransactionLookupStage {
         let (tx_range, block_range) =
             input.next_block_range_with_transaction_threshold(provider, self.commit_threshold)?;
         let end_block = *block_range.end();
+        let tx_range_size = tx_range.clone().count();
 
         debug!(target: "sync::stages::transaction_lookup", ?tx_range, "Updating transaction lookup");
 
@@ -64,7 +65,7 @@ impl<DB: Database> Stage<DB> for TransactionLookupStage {
         let mut tx_cursor = tx.cursor_read::<tables::Transactions>()?;
         let tx_walker = tx_cursor.walk_range(tx_range)?;
 
-        let chunk_size = tx_range.count() / rayon::current_num_threads();
+        let chunk_size = tx_range_size / rayon::current_num_threads();
         let mut channels = Vec::with_capacity(chunk_size);
         let mut transaction_count = 0;
 

--- a/crates/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/src/stages/tx_lookup.rs
@@ -64,7 +64,7 @@ impl<DB: Database> Stage<DB> for TransactionLookupStage {
         let mut tx_cursor = tx.cursor_read::<tables::Transactions>()?;
         let tx_walker = tx_cursor.walk_range(tx_range)?;
 
-        let chunk_size = 100_000 / rayon::current_num_threads();
+        let chunk_size = tx_range.count() / rayon::current_num_threads();
         let mut channels = Vec::with_capacity(chunk_size);
         let mut transaction_count = 0;
 


### PR DESCRIPTION
We had some perf regressions on the tx lookup stage. A quick fix was implemented in #3128, but I think this fixes the underlying issue itself.

Essentially, we split the hashing work into batches. The size of these batches were determined by `100_000 / num_cpus`. Assume we are on a 16 core machine and the commit threshold of `50_000` was retained.

This gives us:

- Batch size: circa 6k
- Number of batches: circa 8

In other words, we are idling on half of our cores.

I think the reason #3128 alleviated this is because it would give us:

- Batch size: circa 6k
- Number of batches: circa 830

A more reasonable fix is to simply split the amount of available work across all threads evenly, i.e. if your commit threshold is 50k, then the batch size would be `50k / num_cpus`.

This also brings the batching logic in line with the sender recovery stage.