### PR TITLE
feat: stage eta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4605,6 +4605,7 @@ dependencies = [
  "futures",
  "hex",
  "human_bytes",
+ "humantime",
  "hyper",
  "jemallocator",
  "metrics-exporter-prometheus",

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -83,6 +83,7 @@ backon = "0.4"
 hex = "0.4"
 thiserror = "1.0"
 pretty_assertions = "1.3.0"
+humantime = "2.1.0"
 
 [features]
 jemalloc = ["dep:jemallocator"]

--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -7,7 +7,7 @@ use reth_interfaces::consensus::ForkchoiceState;
 use reth_network::{NetworkEvent, NetworkHandle};
 use reth_network_api::PeersInfo;
 use reth_primitives::{
-    stage::{StageCheckpoint, StageId},
+    stage::{EntitiesCheckpoint, StageCheckpoint, StageId},
     BlockNumber,
 };
 use reth_stages::{ExecOutput, PipelineEvent};
@@ -15,10 +15,10 @@ use std::{
     future::Future,
     pin::Pin,
     task::{Context, Poll},
-    time::Duration,
+    time::{Duration, Instant},
 };
 use tokio::time::Interval;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 /// Interval of reporting node state.
 const INFO_MESSAGE_INTERVAL: Duration = Duration::from_secs(30);
@@ -29,6 +29,8 @@ struct NodeState {
     network: Option<NetworkHandle>,
     /// The stage currently being executed.
     current_stage: Option<StageId>,
+    /// The ETA for the current stage.
+    eta: Eta,
     /// The current checkpoint of the executing stage.
     current_checkpoint: StageCheckpoint,
     /// The latest canonical block added in the consensus engine.
@@ -40,6 +42,7 @@ impl NodeState {
         Self {
             network,
             current_stage: None,
+            eta: Eta::default(),
             current_checkpoint: StageCheckpoint::new(0),
             latest_canonical_engine_block: None,
         }
@@ -56,14 +59,15 @@ impl NodeState {
                 let notable = self.current_stage.is_none();
                 self.current_stage = Some(stage_id);
                 self.current_checkpoint = checkpoint.unwrap_or_default();
+                self.eta.update(self.current_checkpoint);
 
                 if notable {
                     info!(
-                        target: "reth::cli",
                         pipeline_stages = %format!("{pipeline_position}/{pipeline_total}"),
                         stage = %stage_id,
                         from = self.current_checkpoint.block_number,
                         checkpoint = %self.current_checkpoint,
+                        eta = %self.eta,
                         "Executing stage",
                     );
                 }
@@ -79,14 +83,15 @@ impl NodeState {
 
                 if done {
                     self.current_stage = None;
+                    self.eta = Eta::default();
                 }
 
                 info!(
-                    target: "reth::cli",
                     pipeline_stages = %format!("{pipeline_position}/{pipeline_total}"),
                     stage = %stage_id,
-                    progress = checkpoint.block_number,
+                    block = checkpoint.block_number,
                     %checkpoint,
+                    eta = %self.eta,
                     "{}",
                     if done {
                         "Stage finished executing"
@@ -111,7 +116,6 @@ impl NodeState {
                 let ForkchoiceState { head_block_hash, safe_block_hash, finalized_block_hash } =
                     state;
                 info!(
-                    target: "reth::cli",
                     ?head_block_hash,
                     ?safe_block_hash,
                     ?finalized_block_hash,
@@ -122,10 +126,10 @@ impl NodeState {
             BeaconConsensusEngineEvent::CanonicalBlockAdded(block) => {
                 self.latest_canonical_engine_block = Some(block.number);
 
-                info!(target: "reth::cli", number=block.number, hash=?block.hash, "Block added to canonical chain");
+                info!(number=block.number, hash=?block.hash, "Block added to canonical chain");
             }
             BeaconConsensusEngineEvent::ForkBlockAdded(block) => {
-                info!(target: "reth::cli", number=block.number, hash=?block.hash, "Block added to fork chain");
+                info!(number=block.number, hash=?block.hash, "Block added to fork chain");
             }
         }
     }
@@ -133,16 +137,16 @@ impl NodeState {
     fn handle_consensus_layer_health_event(&self, event: ConsensusLayerHealthEvent) {
         match event {
             ConsensusLayerHealthEvent::NeverSeen => {
-                warn!(target: "reth::cli", "Post-merge network, but never seen beacon client. Please launch one to follow the chain!")
+                warn!("Post-merge network, but never seen beacon client. Please launch one to follow the chain!")
             }
             ConsensusLayerHealthEvent::HasNotBeenSeenForAWhile(period) => {
-                warn!(target: "reth::cli", ?period, "Post-merge network, but no beacon client seen for a while. Please launch one to follow the chain!")
+                warn!(?period, "Post-merge network, but no beacon client seen for a while. Please launch one to follow the chain!")
             }
             ConsensusLayerHealthEvent::NeverReceivedUpdates => {
-                warn!(target: "reth::cli", "Beacon client online, but never received consensus updates. Please ensure your beacon client is operational to follow the chain!")
+                warn!("Beacon client online, but never received consensus updates. Please ensure your beacon client is operational to follow the chain!")
             }
             ConsensusLayerHealthEvent::HaveNotReceivedUpdatesForAWhile(period) => {
-                warn!(target: "reth::cli", ?period, "Beacon client online, but no consensus updates received for a while. Please fix your beacon client to follow the chain!")
+                warn!(?period, "Beacon client online, but no consensus updates received for a while. Please fix your beacon client to follow the chain!")
             }
         }
     }
@@ -226,6 +230,7 @@ where
                     connected_peers = this.state.num_connected_peers(),
                     %stage,
                     checkpoint = %this.state.current_checkpoint,
+                    eta = %this.state.eta,
                     "Status"
                 );
             } else {
@@ -256,5 +261,65 @@ where
         }
 
         Poll::Pending
+    }
+}
+
+/// A container calculating the estimated time that a stage will complete in, based on stage
+/// checkpoints reported by the pipeline.
+///
+/// One `Eta` is only valid for a single stage.
+struct Eta {
+    /// The last stage checkpoint
+    last_checkpoint: EntitiesCheckpoint,
+    /// The last time the stage reported its checkpoint
+    last_checkpoint_time: Instant,
+    /// The amount of checkpoints recorded
+    samples: usize,
+    /// The average amount of progress made per second over all recorded checkpoints
+    velocity: Option<f64>,
+}
+
+impl Default for Eta {
+    fn default() -> Self {
+        Self {
+            last_checkpoint: EntitiesCheckpoint::default(),
+            last_checkpoint_time: Instant::now(),
+            samples: 0,
+            velocity: None,
+        }
+    }
+}
+
+impl Eta {
+    /// Update the ETA given the checkpoint.
+    fn update(&mut self, checkpoint: StageCheckpoint) {
+        let current = checkpoint.entities();
+        let processed_since_last = current.processed - self.last_checkpoint.processed;
+        let progress = processed_since_last as f64 / current.total as f64;
+        let current_velocity = progress / self.last_checkpoint_time.elapsed().as_secs_f64();
+
+        self.samples += 1;
+        let average_velocity =
+            (self.velocity.unwrap_or_default() + current_velocity) / self.samples as f64;
+
+        self.velocity = Some(average_velocity);
+        self.last_checkpoint = current;
+        self.last_checkpoint_time = Instant::now();
+    }
+}
+
+impl std::fmt::Display for Eta {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(velocity) = self.velocity {
+            let eta_secs = 1. / velocity;
+            let remaining = Duration::from_secs(eta_secs as u64)
+                .checked_sub(self.last_checkpoint_time.elapsed());
+
+            if let Some(remaining) = remaining {
+                return write!(f, "{}", humantime::format_duration(remaining))
+            }
+        }
+
+        write!(f, "unknown")
     }
 }

--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -99,17 +99,10 @@ impl NodeState {
         }
     }
 
-    fn handle_network_event(&mut self, event: NetworkEvent) {
-        match event {
-            NetworkEvent::SessionEstablished { peer_id, status, .. } => {
-                info!(target: "reth::cli", connected_peers = self.num_connected_peers(), peer_id = %peer_id, best_block = %status.blockhash, "Peer connected");
-            }
-            NetworkEvent::SessionClosed { peer_id, reason } => {
-                let reason = reason.map(|s| s.to_string()).unwrap_or_else(|| "None".to_string());
-                debug!(target: "reth::cli", connected_peers = self.num_connected_peers(), peer_id = %peer_id, %reason, "Peer disconnected.");
-            }
-            _ => (),
-        }
+    fn handle_network_event(&mut self, _: NetworkEvent) {
+        // NOTE(onbjerg): This used to log established/disconnecting sessions, but this is already
+        // logged in the networking component. I kept this stub in case we want to catch other
+        // networking events later on.
     }
 
     fn handle_consensus_engine_event(&mut self, event: BeaconConsensusEngineEvent) {

--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -292,8 +292,10 @@ impl Eta {
             let scalar = current.total as f64 / processed_since_last as f64;
             let elapsed = last_checkpoint_time.elapsed();
 
-            self.eta =
-                Some((self.eta.unwrap_or_default() + elapsed.mul_f64(scalar)).div(self.samples));
+            self.eta = Some(
+                self.eta.unwrap_or_default() * (self.samples - 1) / self.samples +
+                    elapsed.mul_f64(scalar).div(self.samples),
+            );
         }
 
         self.last_checkpoint = current;

--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -81,11 +81,6 @@ impl NodeState {
                 self.current_checkpoint = checkpoint;
                 self.eta.update(self.current_checkpoint);
 
-                if done {
-                    self.current_stage = None;
-                    self.eta = Eta::default();
-                }
-
                 info!(
                     pipeline_stages = %format!("{pipeline_position}/{pipeline_total}"),
                     stage = %stage_id,
@@ -99,6 +94,11 @@ impl NodeState {
                         "Stage committed progress"
                     }
                 );
+
+                if done {
+                    self.current_stage = None;
+                    self.eta = Eta::default();
+                }
             }
             _ => (),
         }

--- a/crates/primitives/src/stage/checkpoints.rs
+++ b/crates/primitives/src/stage/checkpoints.rs
@@ -216,6 +216,29 @@ impl StageCheckpoint {
         self.block_number = block_number;
         self
     }
+
+    /// Get the underlying [`EntitiesCheckpoint`] to determine the number of entities processed, and
+    /// the number of total entities to process.
+    pub fn entities(&self) -> EntitiesCheckpoint {
+        match self.stage_checkpoint {
+            Some(
+                StageUnitCheckpoint::Account(AccountHashingCheckpoint {
+                    progress: entities, ..
+                }) |
+                StageUnitCheckpoint::Storage(StorageHashingCheckpoint {
+                    progress: entities, ..
+                }) |
+                StageUnitCheckpoint::Entities(entities) |
+                StageUnitCheckpoint::Execution(ExecutionCheckpoint { progress: entities, .. }) |
+                StageUnitCheckpoint::Headers(HeadersCheckpoint { progress: entities, .. }) |
+                StageUnitCheckpoint::IndexHistory(IndexHistoryCheckpoint {
+                    progress: entities,
+                    ..
+                }),
+            ) => entities,
+            None => EntitiesCheckpoint::default(),
+        }
+    }
 }
 
 impl Display for StageCheckpoint {

--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -369,7 +369,7 @@ where
                     let done = out.is_done(input);
                     made_progress |=
                         checkpoint.block_number != prev_checkpoint.unwrap_or_default().block_number;
-                    info!(
+                    debug!(
                         target: "sync::pipeline",
                         stage = %stage_id,
                         progress = checkpoint.block_number,

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -22,6 +22,7 @@ use tracing_subscriber::{
 // Re-export tracing crates
 pub use tracing;
 pub use tracing_subscriber;
+use tracing_subscriber::fmt::{format::PrettyFields, FormatFields};
 
 /// A boxed tracing [Layer].
 pub type BoxedLayer<S> = Box<dyn Layer<S> + Send + Sync>;
@@ -51,8 +52,9 @@ where
 
     tracing_subscriber::fmt::layer()
         .with_ansi(with_ansi)
-        .with_target(with_target)
         .with_filter(filter)
+        .with_target(with_target)
+        .fmt_fields(PrettyFields)
         .boxed()
 }
 

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -22,7 +22,6 @@ use tracing_subscriber::{
 // Re-export tracing crates
 pub use tracing;
 pub use tracing_subscriber;
-use tracing_subscriber::fmt::{format::PrettyFields, FormatFields};
 
 /// A boxed tracing [Layer].
 pub type BoxedLayer<S> = Box<dyn Layer<S> + Send + Sync>;
@@ -52,9 +51,8 @@ where
 
     tracing_subscriber::fmt::layer()
         .with_ansi(with_ansi)
-        .with_filter(filter)
         .with_target(with_target)
-        .fmt_fields(PrettyFields)
+        .with_filter(filter)
         .boxed()
 }
 


### PR DESCRIPTION
Adds a naive ETA implementation for stage syncing and cleans up some other logs.

- It is logged during the periodic status message and on stage commits
- Demotes the stage commit log from `Pipeline` to `debug!` since it was a duplicate of what we had in the CLI
- Removes network connect/disconnect peer event logs from the node event handler since it is already logged in the networking component