### PR TITLE
Revert "refactor(stages): input target reached & output done checks"

### DIFF
--- a/bin/reth/src/debug_cmd/merkle.rs
+++ b/bin/reth/src/debug_cmd/merkle.rs
@@ -120,22 +120,30 @@ impl Command {
 
             let mut account_hashing_done = false;
             while !account_hashing_done {
-                let input = ExecInput {
-                    target: Some(block),
-                    checkpoint: progress.map(StageCheckpoint::new),
-                };
-                let output = account_hashing_stage.execute(&mut provider_rw, input).await?;
-                account_hashing_done = output.is_done(input);
+                let output = account_hashing_stage
+                    .execute(
+                        &mut provider_rw,
+                        ExecInput {
+                            target: Some(block),
+                            checkpoint: progress.map(StageCheckpoint::new),
+                        },
+                    )
+                    .await?;
+                account_hashing_done = output.done;
             }
 
             let mut storage_hashing_done = false;
             while !storage_hashing_done {
-                let input = ExecInput {
-                    target: Some(block),
-                    checkpoint: progress.map(StageCheckpoint::new),
-                };
-                let output = storage_hashing_stage.execute(&mut provider_rw, input).await?;
-                storage_hashing_done = output.is_done(input);
+                let output = storage_hashing_stage
+                    .execute(
+                        &mut provider_rw,
+                        ExecInput {
+                            target: Some(block),
+                            checkpoint: progress.map(StageCheckpoint::new),
+                        },
+                    )
+                    .await?;
+                storage_hashing_done = output.done;
             }
 
             let incremental_result = merkle_stage
@@ -165,7 +173,7 @@ impl Command {
                 loop {
                     let clean_result = merkle_stage.execute(&mut provider_rw, clean_input).await;
                     assert!(clean_result.is_ok(), "Clean state root calculation failed");
-                    if clean_result.unwrap().is_done(clean_input) {
+                    if clean_result.unwrap().done {
                         break
                     }
                 }

--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -72,8 +72,7 @@ impl NodeState {
                 pipeline_position,
                 pipeline_total,
                 stage_id,
-                result: ExecOutput { checkpoint },
-                done,
+                result: ExecOutput { checkpoint, done },
             } => {
                 self.current_checkpoint = checkpoint;
 

--- a/bin/reth/src/stage/dump/hashing_account.rs
+++ b/bin/reth/src/stage/dump/hashing_account.rs
@@ -77,11 +77,16 @@ async fn dry_run<DB: Database>(
 
     let mut exec_output = false;
     while !exec_output {
-        let exec_input = reth_stages::ExecInput {
-            target: Some(to),
-            checkpoint: Some(StageCheckpoint::new(from)),
-        };
-        exec_output = exec_stage.execute(&mut provider, exec_input).await?.is_done(exec_input);
+        exec_output = exec_stage
+            .execute(
+                &mut provider,
+                reth_stages::ExecInput {
+                    target: Some(to),
+                    checkpoint: Some(StageCheckpoint::new(from)),
+                },
+            )
+            .await?
+            .done;
     }
 
     info!(target: "reth::cli", "Success.");

--- a/bin/reth/src/stage/dump/hashing_storage.rs
+++ b/bin/reth/src/stage/dump/hashing_storage.rs
@@ -76,11 +76,16 @@ async fn dry_run<DB: Database>(
 
     let mut exec_output = false;
     while !exec_output {
-        let exec_input = reth_stages::ExecInput {
-            target: Some(to),
-            checkpoint: Some(StageCheckpoint::new(from)),
-        };
-        exec_output = exec_stage.execute(&mut provider, exec_input).await?.is_done(exec_input);
+        exec_output = exec_stage
+            .execute(
+                &mut provider,
+                reth_stages::ExecInput {
+                    target: Some(to),
+                    checkpoint: Some(StageCheckpoint::new(from)),
+                },
+            )
+            .await?
+            .done;
     }
 
     info!(target: "reth::cli", "Success.");

--- a/bin/reth/src/stage/dump/merkle.rs
+++ b/bin/reth/src/stage/dump/merkle.rs
@@ -119,17 +119,20 @@ async fn dry_run<DB: Database>(
     let mut provider = shareable_db.provider_rw()?;
     let mut exec_output = false;
     while !exec_output {
-        let exec_input = reth_stages::ExecInput {
-            target: Some(to),
-            checkpoint: Some(StageCheckpoint::new(from)),
-        };
         exec_output = MerkleStage::Execution {
-            // Forces updating the root instead of calculating from scratch
-            clean_threshold: u64::MAX,
+            clean_threshold: u64::MAX, /* Forces updating the root instead of calculating
+                                        * from
+                                        * scratch */
         }
-        .execute(&mut provider, exec_input)
+        .execute(
+            &mut provider,
+            reth_stages::ExecInput {
+                target: Some(to),
+                checkpoint: Some(StageCheckpoint::new(from)),
+            },
+        )
         .await?
-        .is_done(exec_input);
+        .done;
     }
 
     info!(target: "reth::cli", "Success.");

--- a/crates/consensus/beacon/src/engine/sync.rs
+++ b/crates/consensus/beacon/src/engine/sync.rs
@@ -83,6 +83,12 @@ where
         self.metrics.active_block_downloads.set(self.inflight_full_block_requests.len() as f64);
     }
 
+    /// Sets the max block value for testing
+    #[cfg(test)]
+    pub(crate) fn set_max_block(&mut self, block: BlockNumber) {
+        self.max_block = Some(block);
+    }
+
     /// Cancels all full block requests that are in progress.
     pub(crate) fn clear_full_block_requests(&mut self) {
         self.inflight_full_block_requests.clear();

--- a/crates/stages/src/pipeline/event.rs
+++ b/crates/stages/src/pipeline/event.rs
@@ -31,8 +31,6 @@ pub enum PipelineEvent {
         stage_id: StageId,
         /// The result of executing the stage.
         result: ExecOutput,
-        /// Stage completed executing the whole block range
-        done: bool,
     },
     /// Emitted when a stage is about to be unwound.
     Unwinding {
@@ -47,8 +45,6 @@ pub enum PipelineEvent {
         stage_id: StageId,
         /// The result of unwinding the stage.
         result: UnwindOutput,
-        /// Stage completed unwinding the whole block range
-        done: bool,
     },
     /// Emitted when a stage encounters an error either during execution or unwinding.
     Error {

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -70,6 +70,10 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
         provider: &mut DatabaseProviderRW<'_, &DB>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
+        if input.target_reached() {
+            return Ok(ExecOutput::done(input.checkpoint()))
+        }
+
         let range = input.next_block_range();
         // Update the header range on the downloader
         self.downloader.set_download_range(range.clone())?;
@@ -148,9 +152,11 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
         // The stage is "done" if:
         // - We got fewer blocks than our target
         // - We reached our target and the target was not limited by the batch size of the stage
+        let done = highest_block == to_block;
         Ok(ExecOutput {
             checkpoint: StageCheckpoint::new(highest_block)
                 .with_entities_stage_checkpoint(stage_checkpoint(provider)?),
+            done,
         })
     }
 
@@ -226,10 +232,14 @@ fn stage_checkpoint<DB: Database>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{ExecuteStageTestRunner, StageTestRunner, UnwindStageTestRunner};
+    use crate::test_utils::{
+        stage_test_suite_ext, ExecuteStageTestRunner, StageTestRunner, UnwindStageTestRunner,
+    };
     use assert_matches::assert_matches;
     use reth_primitives::stage::StageUnitCheckpoint;
     use test_utils::*;
+
+    stage_test_suite_ext!(BodyTestRunner, body);
 
     /// Checks that the stage downloads at most `batch_size` blocks.
     #[tokio::test]
@@ -263,7 +273,7 @@ mod tests {
                     processed, // 1 seeded block body + batch size
                     total // seeded headers
                 }))
-            }}) if block_number < 200 &&
+            }, done: false }) if block_number < 200 &&
                 processed == 1 + batch_size && total == previous_stage
         );
         assert!(runner.validate_execution(input, output.ok()).is_ok(), "execution validation");
@@ -300,7 +310,8 @@ mod tests {
                         processed,
                         total
                     }))
-                }
+                },
+                done: true
             }) if processed == total && total == previous_stage
         );
         assert!(runner.validate_execution(input, output.ok()).is_ok(), "execution validation");
@@ -335,7 +346,7 @@ mod tests {
                     processed,
                     total
                 }))
-            }}) if block_number >= 10 &&
+            }, done: false }) if block_number >= 10 &&
                 processed == 1 + batch_size && total == previous_stage
         );
         let first_run_checkpoint = first_run.unwrap().checkpoint;
@@ -355,7 +366,7 @@ mod tests {
                     processed,
                     total
                 }))
-            }}) if block_number > first_run_checkpoint.block_number &&
+            }, done: true }) if block_number > first_run_checkpoint.block_number &&
                 processed == total && total == previous_stage
         );
         assert_matches!(
@@ -395,7 +406,7 @@ mod tests {
                     processed,
                     total
                 }))
-            }}) if block_number == previous_stage &&
+            }, done: true }) if block_number == previous_stage &&
                 processed == total && total == previous_stage
         );
         let checkpoint = output.unwrap().checkpoint;

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -143,6 +143,10 @@ impl<EF: ExecutorFactory> ExecutionStage<EF> {
         provider: &mut DatabaseProviderRW<'_, &DB>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
+        if input.target_reached() {
+            return Ok(ExecOutput::done(input.checkpoint()))
+        }
+
         let start_block = input.next_block();
         let max_block = input.target();
 
@@ -195,9 +199,11 @@ impl<EF: ExecutorFactory> ExecutionStage<EF> {
         state.write_to_db(provider.tx_ref())?;
         trace!(target: "sync::stages::execution", took = ?start.elapsed(), "Wrote state");
 
+        let done = stage_progress == max_block;
         Ok(ExecOutput {
             checkpoint: StageCheckpoint::new(stage_progress)
                 .with_execution_stage_checkpoint(stage_checkpoint),
+            done,
         })
     }
 }
@@ -339,7 +345,7 @@ impl<EF: ExecutorFactory, DB: Database> Stage<DB> for ExecutionStage<EF> {
         let mut account_changeset = tx.cursor_dup_write::<tables::AccountChangeSet>()?;
         let mut storage_changeset = tx.cursor_dup_write::<tables::StorageChangeSet>()?;
 
-        let (range, unwind_to) =
+        let (range, unwind_to, _) =
             input.unwind_block_range_with_threshold(self.thresholds.max_blocks.unwrap_or(u64::MAX));
 
         if range.is_empty() {
@@ -663,7 +669,8 @@ mod tests {
                         total
                     }
                 }))
-            }
+            },
+            done: true
         } if processed == total && total == block.gas_used);
         let mut provider = db.provider_rw().unwrap();
         let tx = provider.tx_mut();

--- a/crates/stages/src/stages/finish.rs
+++ b/crates/stages/src/stages/finish.rs
@@ -21,7 +21,7 @@ impl<DB: Database> Stage<DB> for FinishStage {
         _provider: &mut DatabaseProviderRW<'_, &DB>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
-        Ok(ExecOutput { checkpoint: StageCheckpoint::new(input.target()) })
+        Ok(ExecOutput { checkpoint: StageCheckpoint::new(input.target()), done: true })
     }
 
     async fn unwind(
@@ -37,11 +37,13 @@ impl<DB: Database> Stage<DB> for FinishStage {
 mod tests {
     use super::*;
     use crate::test_utils::{
-        ExecuteStageTestRunner, StageTestRunner, TestRunnerError, TestTransaction,
-        UnwindStageTestRunner,
+        stage_test_suite_ext, ExecuteStageTestRunner, StageTestRunner, TestRunnerError,
+        TestTransaction, UnwindStageTestRunner,
     };
     use reth_interfaces::test_utils::generators::{random_header, random_header_range};
     use reth_primitives::SealedHeader;
+
+    stage_test_suite_ext!(FinishTestRunner, finish);
 
     #[derive(Default)]
     struct FinishTestRunner {
@@ -87,7 +89,7 @@ mod tests {
             output: Option<ExecOutput>,
         ) -> Result<(), TestRunnerError> {
             if let Some(output) = output {
-                assert!(output.is_done(input), "stage should always be done");
+                assert!(output.done, "stage should always be done");
                 assert_eq!(
                     output.checkpoint.block_number,
                     input.target(),

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -210,7 +210,7 @@ where
         // Nothing to sync
         if gap.is_closed() {
             info!(target: "sync::stages::headers", checkpoint = %current_checkpoint, target = ?tip, "Target block already reached");
-            return Ok(ExecOutput { checkpoint: current_checkpoint })
+            return Ok(ExecOutput::done(current_checkpoint))
         }
 
         debug!(target: "sync::stages::headers", ?tip, head = ?gap.local_head.hash(), "Commencing sync");
@@ -313,10 +313,12 @@ where
             Ok(ExecOutput {
                 checkpoint: StageCheckpoint::new(checkpoint)
                     .with_headers_stage_checkpoint(stage_checkpoint),
+                done: true,
             })
         } else {
             Ok(ExecOutput {
                 checkpoint: current_checkpoint.with_headers_stage_checkpoint(stage_checkpoint),
+                done: false,
             })
         }
     }
@@ -589,7 +591,7 @@ mod tests {
                     total,
                 }
             }))
-        }}) if block_number == tip.number &&
+        }, done: true }) if block_number == tip.number &&
             from == checkpoint && to == previous_stage &&
             // -1 because we don't need to download the local head
             processed == checkpoint + headers.len() as u64 - 1 && total == tip.number);
@@ -685,7 +687,7 @@ mod tests {
                     total,
                 }
             }))
-        }}) if block_number == checkpoint &&
+        }, done: false }) if block_number == checkpoint &&
             from == checkpoint && to == previous_stage &&
             processed == checkpoint + 500 && total == tip.number);
 
@@ -708,7 +710,7 @@ mod tests {
                     total,
                 }
             }))
-        }}) if block_number == tip.number &&
+        }, done: true }) if block_number == tip.number &&
             from == checkpoint && to == previous_stage &&
             // -1 because we don't need to download the local head
             processed == checkpoint + headers.len() as u64 - 1 && total == tip.number);

--- a/crates/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/src/stages/index_storage_history.rs
@@ -41,7 +41,11 @@ impl<DB: Database> Stage<DB> for IndexStorageHistoryStage {
         provider: &mut DatabaseProviderRW<'_, &DB>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
-        let range = input.next_block_range_with_threshold(self.commit_threshold);
+        if input.target_reached() {
+            return Ok(ExecOutput::done(input.checkpoint()))
+        }
+
+        let (range, is_final_range) = input.next_block_range_with_threshold(self.commit_threshold);
 
         let mut stage_checkpoint = stage_checkpoint(
             provider,
@@ -61,6 +65,7 @@ impl<DB: Database> Stage<DB> for IndexStorageHistoryStage {
         Ok(ExecOutput {
             checkpoint: StageCheckpoint::new(*range.end())
                 .with_index_history_stage_checkpoint(stage_checkpoint),
+            done: is_final_range,
         })
     }
 
@@ -70,7 +75,7 @@ impl<DB: Database> Stage<DB> for IndexStorageHistoryStage {
         provider: &mut DatabaseProviderRW<'_, &DB>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
-        let (range, unwind_progress) =
+        let (range, unwind_progress, _) =
             input.unwind_block_range_with_threshold(self.commit_threshold);
 
         let changesets =
@@ -229,10 +234,10 @@ mod tests {
                         block_range: CheckpointBlockRange { from: input.next_block(), to: run_to },
                         progress: EntitiesCheckpoint { processed: 2, total: 2 }
                     }
-                )
+                ),
+                done: true
             }
         );
-        assert!(out.is_done(input));
         provider.commit().unwrap();
     }
 
@@ -473,10 +478,10 @@ mod tests {
                             block_range: CheckpointBlockRange { from: 1, to: 5 },
                             progress: EntitiesCheckpoint { processed: 1, total: 2 }
                         }
-                    )
+                    ),
+                    done: false
                 }
             );
-            assert!(!out.is_done(input));
             input.checkpoint = Some(out.checkpoint);
 
             let out = stage.execute(&mut provider, input).await.unwrap();
@@ -488,10 +493,10 @@ mod tests {
                             block_range: CheckpointBlockRange { from: 5, to: 5 },
                             progress: EntitiesCheckpoint { processed: 2, total: 2 }
                         }
-                    )
+                    ),
+                    done: true
                 }
             );
-            assert!(out.is_done(input));
 
             provider.commit().unwrap();
         }

--- a/crates/stages/src/stages/merkle.rs
+++ b/crates/stages/src/stages/merkle.rs
@@ -144,7 +144,7 @@ impl<DB: Database> Stage<DB> for MerkleStage {
         let threshold = match self {
             MerkleStage::Unwind => {
                 info!(target: "sync::stages::merkle::unwind", "Stage is always skipped");
-                return Ok(ExecOutput { checkpoint: StageCheckpoint::new(input.target()) })
+                return Ok(ExecOutput::done(StageCheckpoint::new(input.target())))
             }
             MerkleStage::Execution { clean_threshold } => *clean_threshold,
             #[cfg(any(test, feature = "test-utils"))]
@@ -226,6 +226,7 @@ impl<DB: Database> Stage<DB> for MerkleStage {
                         checkpoint: input
                             .checkpoint()
                             .with_entities_stage_checkpoint(entities_checkpoint),
+                        done: false,
                     })
                 }
                 StateRootProgress::Complete(root, hashed_entries_walked, updates) => {
@@ -266,6 +267,7 @@ impl<DB: Database> Stage<DB> for MerkleStage {
         Ok(ExecOutput {
             checkpoint: StageCheckpoint::new(to_block)
                 .with_entities_stage_checkpoint(entities_checkpoint),
+            done: true,
         })
     }
 
@@ -328,8 +330,8 @@ impl<DB: Database> Stage<DB> for MerkleStage {
 mod tests {
     use super::*;
     use crate::test_utils::{
-        ExecuteStageTestRunner, StageTestRunner, TestRunnerError, TestTransaction,
-        UnwindStageTestRunner,
+        stage_test_suite_ext, ExecuteStageTestRunner, StageTestRunner, TestRunnerError,
+        TestTransaction, UnwindStageTestRunner,
     };
     use assert_matches::assert_matches;
     use reth_db::{
@@ -345,6 +347,8 @@ mod tests {
     };
     use reth_trie::test_utils::{state_root, state_root_prehashed};
     use std::collections::BTreeMap;
+
+    stage_test_suite_ext!(MerkleTestRunner, merkle);
 
     /// Execute from genesis so as to merkelize whole state
     #[tokio::test]
@@ -374,7 +378,8 @@ mod tests {
                         processed,
                         total
                     }))
-                }
+                },
+                done: true
             }) if block_number == previous_stage && processed == total &&
                 total == (
                     runner.tx.table::<tables::HashedAccount>().unwrap().len() +
@@ -413,7 +418,8 @@ mod tests {
                         processed,
                         total
                     }))
-                }
+                },
+                done: true
             }) if block_number == previous_stage && processed == total &&
                 total == (
                     runner.tx.table::<tables::HashedAccount>().unwrap().len() +

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -59,7 +59,11 @@ impl<DB: Database> Stage<DB> for SenderRecoveryStage {
         provider: &mut DatabaseProviderRW<'_, &DB>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
-        let (tx_range, block_range) =
+        if input.target_reached() {
+            return Ok(ExecOutput::done(input.checkpoint()))
+        }
+
+        let (tx_range, block_range, is_final_range) =
             input.next_block_range_with_transaction_threshold(provider, self.commit_threshold)?;
         let end_block = *block_range.end();
 
@@ -69,6 +73,7 @@ impl<DB: Database> Stage<DB> for SenderRecoveryStage {
             return Ok(ExecOutput {
                 checkpoint: StageCheckpoint::new(end_block)
                     .with_entities_stage_checkpoint(stage_checkpoint(provider)?),
+                done: is_final_range,
             })
         }
 
@@ -150,6 +155,7 @@ impl<DB: Database> Stage<DB> for SenderRecoveryStage {
         Ok(ExecOutput {
             checkpoint: StageCheckpoint::new(end_block)
                 .with_entities_stage_checkpoint(stage_checkpoint(provider)?),
+            done: is_final_range,
         })
     }
 
@@ -159,7 +165,7 @@ impl<DB: Database> Stage<DB> for SenderRecoveryStage {
         provider: &mut DatabaseProviderRW<'_, &DB>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
-        let (_, unwind_to) = input.unwind_block_range_with_threshold(self.commit_threshold);
+        let (_, unwind_to, _) = input.unwind_block_range_with_threshold(self.commit_threshold);
 
         // Lookup latest tx id that we should unwind to
         let latest_tx_id = provider.block_body_indices(unwind_to)?.last_tx_num();
@@ -227,9 +233,11 @@ mod tests {
 
     use super::*;
     use crate::test_utils::{
-        ExecuteStageTestRunner, StageTestRunner, TestRunnerError, TestTransaction,
-        UnwindStageTestRunner,
+        stage_test_suite_ext, ExecuteStageTestRunner, StageTestRunner, TestRunnerError,
+        TestTransaction, UnwindStageTestRunner,
     };
+
+    stage_test_suite_ext!(SenderRecoveryTestRunner, sender_recovery);
 
     /// Execute a block range with a single transaction
     #[tokio::test]
@@ -264,7 +272,7 @@ mod tests {
                     processed: 1,
                     total: 1
                 }))
-            }}) if block_number == previous_stage
+            }, done: true }) if block_number == previous_stage
         );
 
         // Validate the stage execution
@@ -303,17 +311,17 @@ mod tests {
             .unwrap_or(previous_stage);
         assert_matches!(result, Ok(_));
         assert_eq!(
-            result.as_ref().unwrap(),
-            &ExecOutput {
+            result.unwrap(),
+            ExecOutput {
                 checkpoint: StageCheckpoint::new(expected_progress).with_entities_stage_checkpoint(
                     EntitiesCheckpoint {
                         processed: runner.tx.table::<tables::TxSenders>().unwrap().len() as u64,
                         total: total_transactions
                     }
-                )
+                ),
+                done: false
             }
         );
-        assert!(!result.unwrap().is_done(first_input));
 
         // Execute second time to completion
         runner.set_threshold(u64::MAX);
@@ -328,7 +336,8 @@ mod tests {
             &ExecOutput {
                 checkpoint: StageCheckpoint::new(previous_stage).with_entities_stage_checkpoint(
                     EntitiesCheckpoint { processed: total_transactions, total: total_transactions }
-                )
+                ),
+                done: true
             }
         );
 

--- a/crates/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/src/stages/tx_lookup.rs
@@ -54,7 +54,10 @@ impl<DB: Database> Stage<DB> for TransactionLookupStage {
         provider: &mut DatabaseProviderRW<'_, &DB>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
-        let (tx_range, block_range) =
+        if input.target_reached() {
+            return Ok(ExecOutput::done(input.checkpoint()))
+        }
+        let (tx_range, block_range, is_final_range) =
             input.next_block_range_with_transaction_threshold(provider, self.commit_threshold)?;
         let end_block = *block_range.end();
 
@@ -135,6 +138,7 @@ impl<DB: Database> Stage<DB> for TransactionLookupStage {
         Ok(ExecOutput {
             checkpoint: StageCheckpoint::new(end_block)
                 .with_entities_stage_checkpoint(stage_checkpoint(provider)?),
+            done: is_final_range,
         })
     }
 
@@ -145,7 +149,7 @@ impl<DB: Database> Stage<DB> for TransactionLookupStage {
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         let tx = provider.tx_ref();
-        let (range, unwind_to) = input.unwind_block_range_with_threshold(self.commit_threshold);
+        let (range, unwind_to, _) = input.unwind_block_range_with_threshold(self.commit_threshold);
 
         // Cursors to unwind tx hash to number
         let mut body_cursor = tx.cursor_read::<tables::BlockBodyIndices>()?;
@@ -188,12 +192,15 @@ fn stage_checkpoint<DB: Database>(
 mod tests {
     use super::*;
     use crate::test_utils::{
-        ExecuteStageTestRunner, StageTestRunner, TestRunnerError, TestTransaction,
-        UnwindStageTestRunner,
+        stage_test_suite_ext, ExecuteStageTestRunner, StageTestRunner, TestRunnerError,
+        TestTransaction, UnwindStageTestRunner,
     };
     use assert_matches::assert_matches;
     use reth_interfaces::test_utils::generators::{random_block, random_block_range};
     use reth_primitives::{stage::StageUnitCheckpoint, BlockNumber, SealedBlock, H256};
+
+    // Implement stage test suite.
+    stage_test_suite_ext!(TransactionLookupTestRunner, transaction_lookup);
 
     #[tokio::test]
     async fn execute_single_transaction_lookup() {
@@ -227,7 +234,7 @@ mod tests {
                     processed,
                     total
                 }))
-            }}) if block_number == previous_stage && processed == total &&
+            }, done: true }) if block_number == previous_stage && processed == total &&
                 total == runner.tx.table::<tables::Transactions>().unwrap().len() as u64
         );
 
@@ -266,17 +273,17 @@ mod tests {
             .unwrap_or(previous_stage);
         assert_matches!(result, Ok(_));
         assert_eq!(
-            result.as_ref().unwrap(),
-            &ExecOutput {
+            result.unwrap(),
+            ExecOutput {
                 checkpoint: StageCheckpoint::new(expected_progress).with_entities_stage_checkpoint(
                     EntitiesCheckpoint {
                         processed: runner.tx.table::<tables::TxHashNumber>().unwrap().len() as u64,
                         total: total_txs
                     }
-                )
+                ),
+                done: false
             }
         );
-        assert!(!result.unwrap().is_done(first_input));
 
         // Execute second time to completion
         runner.set_threshold(u64::MAX);
@@ -291,7 +298,8 @@ mod tests {
             &ExecOutput {
                 checkpoint: StageCheckpoint::new(previous_stage).with_entities_stage_checkpoint(
                     EntitiesCheckpoint { processed: total_txs, total: total_txs }
-                )
+                ),
+                done: true
             }
         );
 

--- a/crates/stages/src/test_utils/macros.rs
+++ b/crates/stages/src/test_utils/macros.rs
@@ -42,8 +42,8 @@ macro_rules! stage_test_suite {
                 let result = rx.await.unwrap();
                 assert_matches::assert_matches!(
                     result,
-                    Ok(ref output @ ExecOutput { checkpoint })
-                        if output.is_done(input) && checkpoint.block_number == previous_stage
+                    Ok(ExecOutput { done, checkpoint })
+                        if done && checkpoint.block_number == previous_stage
                 );
 
                 // Validate the stage execution
@@ -94,8 +94,8 @@ macro_rules! stage_test_suite {
                 let result = rx.await.unwrap();
                 assert_matches::assert_matches!(
                     result,
-                    Ok(ref output @ ExecOutput { checkpoint })
-                        if output.is_done(execute_input) && checkpoint.block_number == previous_stage
+                    Ok(ExecOutput { done, checkpoint })
+                        if done && checkpoint.block_number == previous_stage
                 );
                 assert_matches::assert_matches!(runner.validate_execution(execute_input, result.ok()),Ok(_), "execution validation");
 
@@ -113,8 +113,7 @@ macro_rules! stage_test_suite {
                 // Assert the successful unwind result
                 assert_matches::assert_matches!(
                     rx,
-                    Ok(output @ UnwindOutput { checkpoint })
-                        if output.is_done(unwind_input) && checkpoint.block_number == unwind_input.unwind_to
+                    Ok(UnwindOutput { checkpoint }) if checkpoint.block_number == unwind_input.unwind_to
                 );
 
                 // Validate the stage unwind
@@ -124,4 +123,46 @@ macro_rules! stage_test_suite {
     };
 }
 
+// `execute_already_reached_target` is not suitable for the headers stage thus
+// included in the test suite extension
+macro_rules! stage_test_suite_ext {
+    ($runner:ident, $name:ident) => {
+        crate::test_utils::stage_test_suite!($runner, $name);
+
+         paste::item! {
+            /// Check that the execution is short-circuited if the target was already reached.
+            #[tokio::test]
+            async fn [< execute_already_reached_target_ $name>] () {
+                let stage_progress = 1000;
+
+                // Set up the runner
+                let mut runner = $runner::default();
+                let input = crate::stage::ExecInput {
+                    target: Some(stage_progress),
+                    checkpoint: Some(reth_primitives::stage::StageCheckpoint::new(stage_progress)),
+                };
+                let seed = runner.seed_execution(input).expect("failed to seed");
+
+                // Run stage execution
+                let rx = runner.execute(input);
+
+                // Run `after_execution` hook
+                runner.after_execution(seed).await.expect("failed to run after execution hook");
+
+                // Assert the successful result
+                let result = rx.await.unwrap();
+                assert_matches::assert_matches!(
+                    result,
+                    Ok(ExecOutput { done, checkpoint })
+                        if done && checkpoint.block_number == stage_progress
+                );
+
+                // Validate the stage execution
+                assert_matches::assert_matches!(runner.validate_execution(input, result.ok()),Ok(_), "execution validation");
+            }
+        }
+    };
+}
+
 pub(crate) use stage_test_suite;
+pub(crate) use stage_test_suite_ext;

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1108,12 +1108,6 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> DatabaseProvider<'this, TX> {
         Ok(())
     }
 
-    /// Delete stage checkpoint.
-    pub fn delete_stage_checkpoint(&self, id: StageId) -> std::result::Result<(), DatabaseError> {
-        self.tx.delete::<tables::SyncStage>(id.to_string(), None)?;
-        Ok(())
-    }
-
     /// Get stage checkpoint progress.
     pub fn get_stage_checkpoint_progress(
         &self,


### PR DESCRIPTION
Reverts paradigmxyz/reth#3119

The above PR assumes all stages are done when the checkpointed block number matches the target block number in the input, but this is not really the case - the headers stage is a special case here, since the target starts out as 0 (no prior stages have executed), and it always checkpoints at block 0, leading the stage to assume it is done immediately.

This then propagates to all other stages, the target being 0 (since the headers stage only made progress to this block), leading to an infinite loop of the pipeline where no progress is made.