### PR TITLE
fix: use serde json value for tracer config

### DIFF
--- a/crates/rpc/rpc-types/src/eth/trace/geth/call.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/geth/call.rs
@@ -68,9 +68,9 @@ mod tests {
         opts.tracing_options.tracer =
             Some(GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::CallTracer));
         opts.tracing_options.tracer_config =
-            Some(GethDebugTracerConfig::BuiltInTracer(GethDebugBuiltInTracerConfig::CallTracer(
-                CallConfig { only_top_call: Some(true), with_log: Some(true) },
-            )));
+            serde_json::to_value(CallConfig { only_top_call: Some(true), with_log: Some(true) })
+                .unwrap()
+                .into();
 
         assert_eq!(
             serde_json::to_string(&opts).unwrap(),

--- a/crates/rpc/rpc-types/src/eth/trace/geth/pre_state.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/geth/pre_state.rs
@@ -62,9 +62,8 @@ mod tests {
         opts.tracing_options.config.disable_storage = Some(false);
         opts.tracing_options.tracer =
             Some(GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::PreStateTracer));
-        opts.tracing_options.tracer_config = Some(GethDebugTracerConfig::BuiltInTracer(
-            GethDebugBuiltInTracerConfig::PreStateTracer(PreStateConfig { diff_mode: Some(true) }),
-        ));
+        opts.tracing_options.tracer_config =
+            serde_json::to_value(PreStateConfig { diff_mode: Some(true) }).unwrap().into();
 
         assert_eq!(
             serde_json::to_string(&opts).unwrap(),


### PR DESCRIPTION
Closes #3152

this uses json value as config and adds helpers for extracting the expected config type