### PR TITLE
perf: reduce allocations in changeset helpers

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -265,23 +265,22 @@ impl<'this, TX: DbTx<'this>> DatabaseProvider<'this, TX> {
         &self,
         range: RangeInclusive<BlockNumber>,
     ) -> std::result::Result<BTreeMap<(Address, H256), Vec<u64>>, TransactionError> {
-        let storage_changeset = self
-            .tx
-            .cursor_read::<tables::StorageChangeSet>()?
-            .walk_range(BlockNumberAddress::range(range))?
-            .collect::<std::result::Result<Vec<_>, _>>()?;
-
-        // fold all storages to one set of changes
-        let storage_changeset_lists = storage_changeset.into_iter().fold(
-            BTreeMap::new(),
-            |mut storages: BTreeMap<(Address, H256), Vec<u64>>, (index, storage)| {
-                storages
-                    .entry((index.address(), storage.key))
-                    .or_default()
-                    .push(index.block_number());
-                storages
-            },
-        );
+        let mut changeset_cursor = self.tx.cursor_read::<tables::StorageChangeSet>()?;
+        
+        let storage_changeset_lists =
+            changeset_cursor.walk_range(BlockNumberAddress::range(range))?.try_fold(
+                BTreeMap::new(),
+                |mut storages: BTreeMap<(Address, H256), Vec<u64>>,
+                 entry|
+                 -> std::result::Result<_, TransactionError> {
+                    let (index, storage) = entry?;
+                    storages
+                        .entry((index.address(), storage.key))
+                        .or_default()
+                        .push(index.block_number());
+                    Ok(storages)
+                },
+            )?;
 
         Ok(storage_changeset_lists)
     }
@@ -293,22 +292,20 @@ impl<'this, TX: DbTx<'this>> DatabaseProvider<'this, TX> {
         &self,
         range: RangeInclusive<BlockNumber>,
     ) -> std::result::Result<BTreeMap<Address, Vec<u64>>, TransactionError> {
-        let account_changesets = self
-            .tx
-            .cursor_read::<tables::AccountChangeSet>()?
-            .walk_range(range)?
-            .collect::<std::result::Result<Vec<_>, _>>()?;
+        let mut changeset_cursor = self.tx.cursor_read::<tables::AccountChangeSet>()?;
 
-        let account_transtions = account_changesets
-            .into_iter()
-            // fold all account to one set of changed accounts
-            .fold(
+        let account_transtions = changeset_cursor
+            .walk_range(range)?
+            .try_fold(
                 BTreeMap::new(),
-                |mut accounts: BTreeMap<Address, Vec<u64>>, (index, account)| {
+                |mut accounts: BTreeMap<Address, Vec<u64>>,
+                 entry|
+                 -> std::result::Result<_, TransactionError> {
+                    let (index, account) = entry?;
                     accounts.entry(account.address).or_default().push(index);
-                    accounts
+                    Ok(accounts)
                 },
-            );
+            )?;
 
         Ok(account_transtions)
     }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -266,7 +266,7 @@ impl<'this, TX: DbTx<'this>> DatabaseProvider<'this, TX> {
         range: RangeInclusive<BlockNumber>,
     ) -> std::result::Result<BTreeMap<(Address, H256), Vec<u64>>, TransactionError> {
         let mut changeset_cursor = self.tx.cursor_read::<tables::StorageChangeSet>()?;
-        
+
         let storage_changeset_lists =
             changeset_cursor.walk_range(BlockNumberAddress::range(range))?.try_fold(
                 BTreeMap::new(),
@@ -294,18 +294,16 @@ impl<'this, TX: DbTx<'this>> DatabaseProvider<'this, TX> {
     ) -> std::result::Result<BTreeMap<Address, Vec<u64>>, TransactionError> {
         let mut changeset_cursor = self.tx.cursor_read::<tables::AccountChangeSet>()?;
 
-        let account_transtions = changeset_cursor
-            .walk_range(range)?
-            .try_fold(
-                BTreeMap::new(),
-                |mut accounts: BTreeMap<Address, Vec<u64>>,
-                 entry|
-                 -> std::result::Result<_, TransactionError> {
-                    let (index, account) = entry?;
-                    accounts.entry(account.address).or_default().push(index);
-                    Ok(accounts)
-                },
-            )?;
+        let account_transtions = changeset_cursor.walk_range(range)?.try_fold(
+            BTreeMap::new(),
+            |mut accounts: BTreeMap<Address, Vec<u64>>,
+             entry|
+             -> std::result::Result<_, TransactionError> {
+                let (index, account) = entry?;
+                accounts.entry(account.address).or_default().push(index);
+                Ok(accounts)
+            },
+        )?;
 
         Ok(account_transtions)
     }


### PR DESCRIPTION
The history indexing stages (specifically the storage history indexing stage) can take a long time, and this is most likely due to the amount of allocations we perform (and our write pattern)

This PR reduces some of the allocations that are easier to remove, although there are more.

This is an overview of how we currently allocate:

1. We collect the changesets for a block range into a Vec (`get_storage_transition_ids_from_changeset`)
2. We then fold it into a `BTreeMap` (`get_storage_transition_ids_from_changeset`)
3. We then **delete** the last shard in the history index table (if it exists) and move the values into a new `Vec` (`insert_storage_history_index`)
4. We then **append** (potentially resizing, allocating again) the block numbers from the changesets we want to index now (`insert_storage_history_index`)
6. We then chunk the values for each `(address, slot)` pair into a set of chunks, where each chunk allocates a new `Vec` (`insert_storage_history_index`)

This PR removes the first allocation in this list, although there is potentially a way to remove some of the other allocations in `insert_storage_history_index` as well.

This fix is for both the storage and the account history indexes