### PR TITLE
feat: put blocks on right side with separate axis placement

### DIFF
--- a/etc/grafana/dashboards/overview.json
+++ b/etc/grafana/dashboards/overview.json
@@ -2533,7 +2533,20 @@
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,


### PR DESCRIPTION
Previously the buffered block size in bytes overwhelmed the entire graph:
<img width="717" alt="Screenshot 2023-06-15 at 1 53 27 AM" src="https://github.com/paradigmxyz/reth/assets/6798349/7c52c270-74c1-40b9-b4b0-e77f1625ad55">

This puts the two buffer metrics on a different axis:
<img width="717" alt="Screenshot 2023-06-15 at 1 53 10 AM" src="https://github.com/paradigmxyz/reth/assets/6798349/cb86604c-c32b-47e5-a79a-eee5488d1174">

