### PR TITLE
chore(sync): remove progress terminology from test macros

### DIFF
--- a/crates/stages/src/test_utils/macros.rs
+++ b/crates/stages/src/test_utils/macros.rs
@@ -18,19 +18,23 @@ macro_rules! stage_test_suite {
                 assert_matches::assert_matches!(result, Ok(_));
 
                 // Validate the stage execution
-                assert_matches::assert_matches!(runner.validate_execution(input, result.unwrap().ok()),Ok(_), "execution validation");
+                assert_matches::assert_matches!(
+                    runner.validate_execution(input, result.unwrap().ok()),
+                    Ok(_),
+                    "execution validation"
+                );
             }
 
             // Run the complete stage execution flow.
             #[tokio::test]
             async fn [< execute_ $name>] () {
-                let (previous_stage, stage_progress) = (500, 100);
+                let (target, current_checkpoint) = (500, 100);
 
                 // Set up the runner
                 let mut runner = $runner::default();
                 let input = crate::stage::ExecInput {
-                    target: Some(previous_stage),
-                    checkpoint: Some(reth_primitives::stage::StageCheckpoint::new(stage_progress)),
+                    target: Some(target),
+                    checkpoint: Some(reth_primitives::stage::StageCheckpoint::new(current_checkpoint)),
                 };
                 let seed = runner.seed_execution(input).expect("failed to seed");
                 let rx = runner.execute(input);
@@ -43,11 +47,15 @@ macro_rules! stage_test_suite {
                 assert_matches::assert_matches!(
                     result,
                     Ok(ExecOutput { done, checkpoint })
-                        if done && checkpoint.block_number == previous_stage
+                        if done && checkpoint.block_number == target
                 );
 
                 // Validate the stage execution
-                assert_matches::assert_matches!(runner.validate_execution(input, result.ok()),Ok(_), "execution validation");
+                assert_matches::assert_matches!(
+                    runner.validate_execution(input, result.ok()),
+                    Ok(_),
+                    "execution validation"
+                );
             }
 
             // Check that unwind does not panic on no new entries within the input range.
@@ -70,19 +78,23 @@ macro_rules! stage_test_suite {
                 );
 
                 // Validate the stage unwind
-                assert_matches::assert_matches!(runner.validate_unwind(input),Ok(_), "unwind validation");
+                assert_matches::assert_matches!(
+                    runner.validate_unwind(input),
+                    Ok(_),
+                    "unwind validation"
+                );
             }
 
             // Run complete execute and unwind flow.
             #[tokio::test]
             async fn [< unwind_ $name>] () {
-                let (previous_stage, stage_progress) = (500, 100);
+                let (target, current_checkpoint) = (500, 100);
 
                 // Set up the runner
                 let mut runner = $runner::default();
                 let execute_input = crate::stage::ExecInput {
-                    target: Some(previous_stage),
-                    checkpoint: Some(reth_primitives::stage::StageCheckpoint::new(stage_progress)),
+                    target: Some(target),
+                    checkpoint: Some(reth_primitives::stage::StageCheckpoint::new(current_checkpoint)),
                 };
                 let seed = runner.seed_execution(execute_input).expect("failed to seed");
 
@@ -95,15 +107,19 @@ macro_rules! stage_test_suite {
                 assert_matches::assert_matches!(
                     result,
                     Ok(ExecOutput { done, checkpoint })
-                        if done && checkpoint.block_number == previous_stage
+                        if done && checkpoint.block_number == target
                 );
-                assert_matches::assert_matches!(runner.validate_execution(execute_input, result.ok()),Ok(_), "execution validation");
+                assert_matches::assert_matches!(
+                    runner.validate_execution(execute_input, result.ok()),
+                    Ok(_),
+                    "execution validation"
+                );
 
 
                 // Run stage unwind
                 let unwind_input = crate::stage::UnwindInput {
-                    unwind_to: stage_progress,
-                    checkpoint: reth_primitives::stage::StageCheckpoint::new(previous_stage),
+                    unwind_to: current_checkpoint,
+                    checkpoint: reth_primitives::stage::StageCheckpoint::new(target),
                     bad_block: None,
                 };
 
@@ -117,7 +133,11 @@ macro_rules! stage_test_suite {
                 );
 
                 // Validate the stage unwind
-                assert_matches::assert_matches!(runner.validate_unwind(unwind_input),Ok(_), "unwind validation");
+                assert_matches::assert_matches!(
+                    runner.validate_unwind(unwind_input),
+                    Ok(_),
+                    "unwind validation"
+                );
             }
         }
     };
@@ -129,17 +149,17 @@ macro_rules! stage_test_suite_ext {
     ($runner:ident, $name:ident) => {
         crate::test_utils::stage_test_suite!($runner, $name);
 
-         paste::item! {
+        paste::item! {
             /// Check that the execution is short-circuited if the target was already reached.
             #[tokio::test]
             async fn [< execute_already_reached_target_ $name>] () {
-                let stage_progress = 1000;
+                let current_checkpoint = 1000;
 
                 // Set up the runner
                 let mut runner = $runner::default();
                 let input = crate::stage::ExecInput {
-                    target: Some(stage_progress),
-                    checkpoint: Some(reth_primitives::stage::StageCheckpoint::new(stage_progress)),
+                    target: Some(current_checkpoint),
+                    checkpoint: Some(reth_primitives::stage::StageCheckpoint::new(current_checkpoint)),
                 };
                 let seed = runner.seed_execution(input).expect("failed to seed");
 
@@ -154,11 +174,15 @@ macro_rules! stage_test_suite_ext {
                 assert_matches::assert_matches!(
                     result,
                     Ok(ExecOutput { done, checkpoint })
-                        if done && checkpoint.block_number == stage_progress
+                        if done && checkpoint.block_number == current_checkpoint
                 );
 
                 // Validate the stage execution
-                assert_matches::assert_matches!(runner.validate_execution(input, result.ok()),Ok(_), "execution validation");
+                assert_matches::assert_matches!(
+                    runner.validate_execution(input, result.ok()),
+                    Ok(_),
+                    "execution validation"
+                );
             }
         }
     };


### PR DESCRIPTION
## Description

Remove progress terminology by renaming variables in test macros.