### PR TITLE
fix(stages): disable index history stages checkpoints

### DIFF
--- a/crates/stages/src/stages/index_account_history.rs
+++ b/crates/stages/src/stages/index_account_history.rs
@@ -1,13 +1,8 @@
 use crate::{ExecInput, ExecOutput, Stage, StageError, UnwindInput, UnwindOutput};
-use reth_db::{cursor::DbCursorRO, database::Database, tables, transaction::DbTx, DatabaseError};
-use reth_primitives::{
-    stage::{
-        CheckpointBlockRange, EntitiesCheckpoint, IndexHistoryCheckpoint, StageCheckpoint, StageId,
-    },
-    BlockNumber,
-};
+use reth_db::database::Database;
+use reth_primitives::stage::{StageCheckpoint, StageId};
 use reth_provider::DatabaseProviderRW;
-use std::{fmt::Debug, ops::RangeInclusive};
+use std::fmt::Debug;
 
 /// Stage is indexing history the account changesets generated in
 /// [`ExecutionStage`][crate::stages::ExecutionStage]. For more information
@@ -44,7 +39,7 @@ impl<DB: Database> Stage<DB> for IndexAccountHistoryStage {
 
         let (range, is_final_range) = input.next_block_range_with_threshold(self.commit_threshold);
 
-        let indices = tx.get_account_block_numbers_from_changesets(range.clone())?;
+        let indices = provider.get_account_transition_ids_from_changeset(range.clone())?;
         indices.values().map(|blocks| blocks.len() as u64).sum::<u64>();
 
         // Insert changeset to history index
@@ -62,66 +57,11 @@ impl<DB: Database> Stage<DB> for IndexAccountHistoryStage {
         let (range, unwind_progress, _) =
             input.unwind_block_range_with_threshold(self.commit_threshold);
 
-        let changesets = provider.unwind_account_history_indices(range)?;
-
-        let checkpoint =
-            if let Some(mut stage_checkpoint) = input.checkpoint.index_history_stage_checkpoint() {
-                stage_checkpoint.progress.processed -= changesets as u64;
-                StageCheckpoint::new(unwind_progress)
-                    .with_index_history_stage_checkpoint(stage_checkpoint)
-            } else {
-                StageCheckpoint::new(unwind_progress)
-            };
+        provider.unwind_account_history_indices(range)?;
 
         // from HistoryIndex higher than that number.
-        Ok(UnwindOutput { checkpoint })
+        Ok(UnwindOutput { checkpoint: StageCheckpoint::new(unwind_progress) })
     }
-}
-
-/// The function proceeds as follows:
-/// 1. It first checks if the checkpoint has an [IndexHistoryCheckpoint] that matches the given
-/// block range. If it does, the function returns that checkpoint.
-/// 2. If the checkpoint's block range end matches the current checkpoint's block number, it creates
-/// a new [IndexHistoryCheckpoint] with the given block range and updates the progress with the
-/// current progress.
-/// 3. If none of the above conditions are met, it creates a new [IndexHistoryCheckpoint] with the
-/// given block range and calculates the progress by counting the number of processed entries in the
-/// [tables::AccountChangeSet] table within the given block range.
-#[allow(unused)]
-fn stage_checkpoint<DB: Database>(
-    provider: &DatabaseProviderRW<'_, &DB>,
-    checkpoint: StageCheckpoint,
-    range: &RangeInclusive<BlockNumber>,
-) -> Result<IndexHistoryCheckpoint, DatabaseError> {
-    Ok(match checkpoint.index_history_stage_checkpoint() {
-        Some(stage_checkpoint @ IndexHistoryCheckpoint { block_range, .. })
-            if block_range == CheckpointBlockRange::from(range) =>
-        {
-            stage_checkpoint
-        }
-        Some(IndexHistoryCheckpoint { block_range, progress })
-            if block_range.to == checkpoint.block_number =>
-        {
-            IndexHistoryCheckpoint {
-                block_range: CheckpointBlockRange::from(range),
-                progress: EntitiesCheckpoint {
-                    processed: progress.processed,
-                    total: provider.tx_ref().entries::<tables::AccountChangeSet>()? as u64,
-                },
-            }
-        }
-        _ => IndexHistoryCheckpoint {
-            block_range: CheckpointBlockRange::from(range),
-            progress: EntitiesCheckpoint {
-                processed: provider
-                    .tx_ref()
-                    .cursor_read::<tables::AccountChangeSet>()?
-                    .walk_range(0..=checkpoint.block_number)?
-                    .count() as u64,
-                total: provider.tx_ref().entries::<tables::AccountChangeSet>()? as u64,
-            },
-        },
-    })
 }
 
 #[cfg(test)]
@@ -200,18 +140,7 @@ mod tests {
         let factory = ProviderFactory::new(tx.tx.as_ref(), MAINNET.clone());
         let mut provider = factory.provider_rw().unwrap();
         let out = stage.execute(&mut provider, input).await.unwrap();
-        assert_eq!(
-            out,
-            ExecOutput {
-                checkpoint: StageCheckpoint::new(5).with_index_history_stage_checkpoint(
-                    IndexHistoryCheckpoint {
-                        block_range: CheckpointBlockRange { from: input.next_block(), to: run_to },
-                        progress: EntitiesCheckpoint { processed: 2, total: 2 }
-                    }
-                ),
-                done: true
-            }
-        );
+        assert_eq!(out, ExecOutput { checkpoint: StageCheckpoint::new(5), done: true });
         provider.commit().unwrap();
     }
 
@@ -422,118 +351,6 @@ mod tests {
                 (shard(2), full_list.clone()),
                 (shard(u64::MAX), vec![2, 3])
             ])
-        );
-    }
-
-    #[tokio::test]
-    async fn stage_checkpoint_range() {
-        // init
-        let test_tx = TestTransaction::default();
-
-        // setup
-        partial_setup(&test_tx);
-
-        // run
-        {
-            let mut stage = IndexAccountHistoryStage { commit_threshold: 4 }; // Two runs required
-            let factory = ProviderFactory::new(&test_tx.tx, MAINNET.clone());
-            let mut provider = factory.provider_rw().unwrap();
-
-            let mut input = ExecInput { target: Some(5), ..Default::default() };
-            let out = stage.execute(&mut provider, input).await.unwrap();
-            assert_eq!(
-                out,
-                ExecOutput {
-                    checkpoint: StageCheckpoint::new(4).with_index_history_stage_checkpoint(
-                        IndexHistoryCheckpoint {
-                            block_range: CheckpointBlockRange { from: 1, to: 5 },
-                            progress: EntitiesCheckpoint { processed: 1, total: 2 }
-                        }
-                    ),
-                    done: false
-                }
-            );
-            input.checkpoint = Some(out.checkpoint);
-
-            let out = stage.execute(&mut provider, input).await.unwrap();
-            assert_eq!(
-                out,
-                ExecOutput {
-                    checkpoint: StageCheckpoint::new(5).with_index_history_stage_checkpoint(
-                        IndexHistoryCheckpoint {
-                            block_range: CheckpointBlockRange { from: 5, to: 5 },
-                            progress: EntitiesCheckpoint { processed: 2, total: 2 }
-                        }
-                    ),
-                    done: true
-                }
-            );
-
-            provider.commit().unwrap();
-        }
-
-        // verify
-        let table = cast(test_tx.table::<tables::AccountHistory>().unwrap());
-        assert_eq!(table, BTreeMap::from([(shard(u64::MAX), vec![4, 5])]));
-
-        // unwind
-        unwind(&test_tx, 5, 0).await;
-
-        // verify initial state
-        let table = test_tx.table::<tables::AccountHistory>().unwrap();
-        assert!(table.is_empty());
-    }
-
-    #[test]
-    fn stage_checkpoint_recalculation() {
-        let tx = TestTransaction::default();
-
-        tx.commit(|tx| {
-            tx.put::<tables::AccountChangeSet>(
-                1,
-                AccountBeforeTx {
-                    address: H160(hex!("0000000000000000000000000000000000000001")),
-                    info: None,
-                },
-            )
-            .unwrap();
-            tx.put::<tables::AccountChangeSet>(
-                1,
-                AccountBeforeTx {
-                    address: H160(hex!("0000000000000000000000000000000000000002")),
-                    info: None,
-                },
-            )
-            .unwrap();
-            tx.put::<tables::AccountChangeSet>(
-                2,
-                AccountBeforeTx {
-                    address: H160(hex!("0000000000000000000000000000000000000001")),
-                    info: None,
-                },
-            )
-            .unwrap();
-            tx.put::<tables::AccountChangeSet>(
-                2,
-                AccountBeforeTx {
-                    address: H160(hex!("0000000000000000000000000000000000000002")),
-                    info: None,
-                },
-            )
-            .unwrap();
-            Ok(())
-        })
-        .unwrap();
-
-        let factory = ProviderFactory::new(tx.tx.as_ref(), MAINNET.clone());
-        let provider = factory.provider_rw().unwrap();
-
-        assert_matches!(
-            stage_checkpoint(&provider, StageCheckpoint::new(1), &(1..=2)).unwrap(),
-            IndexHistoryCheckpoint {
-                block_range: CheckpointBlockRange { from: 1, to: 2 },
-                progress: EntitiesCheckpoint { processed: 2, total: 4 }
-            }
         );
     }
 }

--- a/crates/stages/src/stages/index_account_history.rs
+++ b/crates/stages/src/stages/index_account_history.rs
@@ -66,7 +66,6 @@ impl<DB: Database> Stage<DB> for IndexAccountHistoryStage {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
     use reth_provider::ProviderFactory;
     use std::collections::BTreeMap;
 

--- a/crates/stages/src/stages/index_account_history.rs
+++ b/crates/stages/src/stages/index_account_history.rs
@@ -40,8 +40,6 @@ impl<DB: Database> Stage<DB> for IndexAccountHistoryStage {
         let (range, is_final_range) = input.next_block_range_with_threshold(self.commit_threshold);
 
         let indices = provider.get_account_transition_ids_from_changeset(range.clone())?;
-        indices.values().map(|blocks| blocks.len() as u64).sum::<u64>();
-
         // Insert changeset to history index
         provider.insert_account_history_index(indices)?;
 

--- a/crates/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/src/stages/index_storage_history.rs
@@ -1,16 +1,8 @@
 use crate::{ExecInput, ExecOutput, Stage, StageError, UnwindInput, UnwindOutput};
-use reth_db::{
-    cursor::DbCursorRO, database::Database, models::BlockNumberAddress, tables, transaction::DbTx,
-    DatabaseError,
-};
-use reth_primitives::{
-    stage::{
-        CheckpointBlockRange, EntitiesCheckpoint, IndexHistoryCheckpoint, StageCheckpoint, StageId,
-    },
-    BlockNumber,
-};
+use reth_db::{database::Database, models::BlockNumberAddress};
+use reth_primitives::stage::{StageCheckpoint, StageId};
 use reth_provider::DatabaseProviderRW;
-use std::{fmt::Debug, ops::RangeInclusive};
+use std::fmt::Debug;
 
 /// Stage is indexing history the account changesets generated in
 /// [`ExecutionStage`][crate::stages::ExecutionStage]. For more information
@@ -47,7 +39,7 @@ impl<DB: Database> Stage<DB> for IndexStorageHistoryStage {
 
         let (range, is_final_range) = input.next_block_range_with_threshold(self.commit_threshold);
 
-        let indices = tx.get_storage_block_numbers_from_changesets(range.clone())?;
+        let indices = provider.get_storage_transition_ids_from_changeset(range.clone())?;
         indices.values().map(|blocks| blocks.len() as u64).sum::<u64>();
 
         provider.insert_storage_history_index(indices)?;
@@ -64,72 +56,14 @@ impl<DB: Database> Stage<DB> for IndexStorageHistoryStage {
         let (range, unwind_progress, _) =
             input.unwind_block_range_with_threshold(self.commit_threshold);
 
-        let changesets =
-            provider.unwind_storage_history_indices(BlockNumberAddress::range(range))?;
+        provider.unwind_storage_history_indices(BlockNumberAddress::range(range))?;
 
-        let checkpoint =
-            if let Some(mut stage_checkpoint) = input.checkpoint.index_history_stage_checkpoint() {
-                stage_checkpoint.progress.processed -= changesets as u64;
-                StageCheckpoint::new(unwind_progress)
-                    .with_index_history_stage_checkpoint(stage_checkpoint)
-            } else {
-                StageCheckpoint::new(unwind_progress)
-            };
-
-        Ok(UnwindOutput { checkpoint })
+        Ok(UnwindOutput { checkpoint: StageCheckpoint::new(unwind_progress) })
     }
-}
-
-/// The function proceeds as follows:
-/// 1. It first checks if the checkpoint has an [IndexHistoryCheckpoint] that matches the given
-/// block range. If it does, the function returns that checkpoint.
-/// 2. If the checkpoint's block range end matches the current checkpoint's block number, it creates
-/// a new [IndexHistoryCheckpoint] with the given block range and updates the progress with the
-/// current progress.
-/// 3. If none of the above conditions are met, it creates a new [IndexHistoryCheckpoint] with the
-/// given block range and calculates the progress by counting the number of processed entries in the
-/// [tables::StorageChangeSet] table within the given block range.
-#[allow(unused)]
-fn stage_checkpoint<DB: Database>(
-    provider: &DatabaseProviderRW<'_, &DB>,
-    checkpoint: StageCheckpoint,
-    range: &RangeInclusive<BlockNumber>,
-) -> Result<IndexHistoryCheckpoint, DatabaseError> {
-    Ok(match checkpoint.index_history_stage_checkpoint() {
-        Some(stage_checkpoint @ IndexHistoryCheckpoint { block_range, .. })
-            if block_range == CheckpointBlockRange::from(range) =>
-        {
-            stage_checkpoint
-        }
-        Some(IndexHistoryCheckpoint { block_range, progress })
-            if block_range.to == checkpoint.block_number =>
-        {
-            IndexHistoryCheckpoint {
-                block_range: CheckpointBlockRange::from(range),
-                progress: EntitiesCheckpoint {
-                    processed: progress.processed,
-                    total: provider.tx_ref().entries::<tables::StorageChangeSet>()? as u64,
-                },
-            }
-        }
-        _ => IndexHistoryCheckpoint {
-            block_range: CheckpointBlockRange::from(range),
-            progress: EntitiesCheckpoint {
-                processed: provider
-                    .tx_ref()
-                    .cursor_read::<tables::StorageChangeSet>()?
-                    .walk_range(BlockNumberAddress::range(0..=checkpoint.block_number))?
-                    .count() as u64,
-                total: provider.tx_ref().entries::<tables::StorageChangeSet>()? as u64,
-            },
-        },
-    })
 }
 
 #[cfg(test)]
 mod tests {
-
-    use assert_matches::assert_matches;
     use reth_provider::ProviderFactory;
     use std::collections::BTreeMap;
 
@@ -213,18 +147,7 @@ mod tests {
         let factory = ProviderFactory::new(tx.tx.as_ref(), MAINNET.clone());
         let mut provider = factory.provider_rw().unwrap();
         let out = stage.execute(&mut provider, input).await.unwrap();
-        assert_eq!(
-            out,
-            ExecOutput {
-                checkpoint: StageCheckpoint::new(5).with_index_history_stage_checkpoint(
-                    IndexHistoryCheckpoint {
-                        block_range: CheckpointBlockRange { from: input.next_block(), to: run_to },
-                        progress: EntitiesCheckpoint { processed: 2, total: 2 }
-                    }
-                ),
-                done: true
-            }
-        );
+        assert_eq!(out, ExecOutput { checkpoint: StageCheckpoint::new(5), done: true });
         provider.commit().unwrap();
     }
 
@@ -438,128 +361,6 @@ mod tests {
                 (shard(2), full_list.clone()),
                 (shard(u64::MAX), vec![2, 3])
             ])
-        );
-    }
-
-    #[tokio::test]
-    async fn stage_checkpoint_range() {
-        // init
-        let test_tx = TestTransaction::default();
-
-        // setup
-        partial_setup(&test_tx);
-
-        // run
-        {
-            let mut stage = IndexStorageHistoryStage { commit_threshold: 4 }; // Two runs required
-            let factory = ProviderFactory::new(&test_tx.tx, MAINNET.clone());
-            let mut provider = factory.provider_rw().unwrap();
-
-            let mut input = ExecInput { target: Some(5), ..Default::default() };
-            let out = stage.execute(&mut provider, input).await.unwrap();
-            assert_eq!(
-                out,
-                ExecOutput {
-                    checkpoint: StageCheckpoint::new(4).with_index_history_stage_checkpoint(
-                        IndexHistoryCheckpoint {
-                            block_range: CheckpointBlockRange { from: 1, to: 5 },
-                            progress: EntitiesCheckpoint { processed: 1, total: 2 }
-                        }
-                    ),
-                    done: false
-                }
-            );
-            input.checkpoint = Some(out.checkpoint);
-
-            let out = stage.execute(&mut provider, input).await.unwrap();
-            assert_eq!(
-                out,
-                ExecOutput {
-                    checkpoint: StageCheckpoint::new(5).with_index_history_stage_checkpoint(
-                        IndexHistoryCheckpoint {
-                            block_range: CheckpointBlockRange { from: 5, to: 5 },
-                            progress: EntitiesCheckpoint { processed: 2, total: 2 }
-                        }
-                    ),
-                    done: true
-                }
-            );
-
-            provider.commit().unwrap();
-        }
-
-        // verify
-        let table = cast(test_tx.table::<tables::StorageHistory>().unwrap());
-        assert_eq!(table, BTreeMap::from([(shard(u64::MAX), vec![4, 5])]));
-
-        // unwind
-        unwind(&test_tx, 5, 0).await;
-
-        // verify initial state
-        let table = test_tx.table::<tables::StorageHistory>().unwrap();
-        assert!(table.is_empty());
-    }
-
-    #[test]
-    fn stage_checkpoint_recalculation() {
-        let tx = TestTransaction::default();
-
-        tx.commit(|tx| {
-            tx.put::<tables::StorageChangeSet>(
-                BlockNumberAddress((1, H160(hex!("0000000000000000000000000000000000000001")))),
-                storage(H256(hex!(
-                    "0000000000000000000000000000000000000000000000000000000000000001"
-                ))),
-            )
-            .unwrap();
-            tx.put::<tables::StorageChangeSet>(
-                BlockNumberAddress((1, H160(hex!("0000000000000000000000000000000000000001")))),
-                storage(H256(hex!(
-                    "0000000000000000000000000000000000000000000000000000000000000002"
-                ))),
-            )
-            .unwrap();
-            tx.put::<tables::StorageChangeSet>(
-                BlockNumberAddress((1, H160(hex!("0000000000000000000000000000000000000002")))),
-                storage(H256(hex!(
-                    "0000000000000000000000000000000000000000000000000000000000000001"
-                ))),
-            )
-            .unwrap();
-            tx.put::<tables::StorageChangeSet>(
-                BlockNumberAddress((2, H160(hex!("0000000000000000000000000000000000000001")))),
-                storage(H256(hex!(
-                    "0000000000000000000000000000000000000000000000000000000000000001"
-                ))),
-            )
-            .unwrap();
-            tx.put::<tables::StorageChangeSet>(
-                BlockNumberAddress((2, H160(hex!("0000000000000000000000000000000000000001")))),
-                storage(H256(hex!(
-                    "0000000000000000000000000000000000000000000000000000000000000002"
-                ))),
-            )
-            .unwrap();
-            tx.put::<tables::StorageChangeSet>(
-                BlockNumberAddress((2, H160(hex!("0000000000000000000000000000000000000002")))),
-                storage(H256(hex!(
-                    "0000000000000000000000000000000000000000000000000000000000000001"
-                ))),
-            )
-            .unwrap();
-            Ok(())
-        })
-        .unwrap();
-
-        let factory = ProviderFactory::new(tx.tx.as_ref(), MAINNET.clone());
-        let provider = factory.provider_rw().unwrap();
-
-        assert_matches!(
-            stage_checkpoint(&provider, StageCheckpoint::new(1), &(1..=2)).unwrap(),
-            IndexHistoryCheckpoint {
-                block_range: CheckpointBlockRange { from: 1, to: 2 },
-                progress: EntitiesCheckpoint { processed: 3, total: 6 }
-            }
         );
     }
 }

--- a/crates/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/src/stages/index_storage_history.rs
@@ -40,8 +40,6 @@ impl<DB: Database> Stage<DB> for IndexStorageHistoryStage {
         let (range, is_final_range) = input.next_block_range_with_threshold(self.commit_threshold);
 
         let indices = provider.get_storage_transition_ids_from_changeset(range.clone())?;
-        indices.values().map(|blocks| blocks.len() as u64).sum::<u64>();
-
         provider.insert_storage_history_index(indices)?;
 
         Ok(ExecOutput { checkpoint: StageCheckpoint::new(*range.end()), done: is_final_range })


### PR DESCRIPTION
We have more than 4 billion storage changesets on Mainnet, and counting them one by one is very expensive: https://github.com/paradigmxyz/reth/blob/ff36f78c2b487b5a44288a85973feca8441bb329/crates/stages/src/stages/index_storage_history.rs#L128-L138

This checkpoint recalculation logic was introduced in https://github.com/paradigmxyz/reth/pull/2949, and wasn't expected to be hit anytime other than on the initial sync. However, it was proven possible for the stage checkpoint to get reset on a high block number, so we needed to recalculate a lot.

This PR reverts this logic, leaving progress reporting for history indexing stages the same as before better stage checkpoints – measured in block numbers.

The better solution would be to prevent checkpoint resets at all, and the only place it happens now is here: https://github.com/paradigmxyz/reth/blob/ff36f78c2b487b5a44288a85973feca8441bb329/crates/storage/provider/src/providers/database/provider.rs#L989-L1008