### PR TITLE
chore(rpc): simplify GethTrace type

### DIFF
--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -2,7 +2,7 @@ use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_primitives::{BlockId, BlockNumberOrTag, Bytes, H256};
 use reth_rpc_types::{
     trace::geth::{
-        BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTraceFrame,
+        BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace,
         TraceResult,
     },
     CallRequest, RichBlock,
@@ -84,7 +84,7 @@ pub trait DebugApi {
         &self,
         tx_hash: H256,
         opts: Option<GethDebugTracingOptions>,
-    ) -> RpcResult<GethTraceFrame>;
+    ) -> RpcResult<GethTrace>;
 
     /// The `debug_traceCall` method lets you run an `eth_call` within the context of the given
     /// block execution using the final state of parent block as the base.
@@ -101,5 +101,5 @@ pub trait DebugApi {
         request: CallRequest,
         block_number: Option<BlockId>,
         opts: Option<GethDebugTracingCallOptions>,
-    ) -> RpcResult<GethTraceFrame>;
+    ) -> RpcResult<GethTrace>;
 }

--- a/crates/rpc/rpc-types/src/eth/trace/geth/noop.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/geth/noop.rs
@@ -1,9 +1,11 @@
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
+/// An empty frame response that's only an empty json object `{}`
 /// <https://github.com/ethereum/go-ethereum/blob/91cb6f863a965481e51d5d9c0e5ccd54796fd967/eth/tracers/native/noop.go#L34>
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NoopFrame(BTreeMap<Null, Null>);
+
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord)]
 struct Null;
 

--- a/crates/rpc/rpc-types/src/eth/trace/geth/pre_state.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/geth/pre_state.rs
@@ -14,6 +14,7 @@ pub enum PreStateFrame {
 pub struct PreStateMode(pub BTreeMap<Address, AccountState>);
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct DiffMode {
     pub pre: BTreeMap<Address, AccountState>,
     pub post: BTreeMap<Address, AccountState>,


### PR DESCRIPTION
removes the redundant wrapper type and adds a few notes about deserialization 