### PR TITLE
perf: use hashmaps for non-sortable state

### DIFF
--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -898,7 +898,7 @@ mod tests {
                 account1,
                 Storage {
                     times_wiped: 0,
-                    storage: BTreeMap::from([(U256::from(1), U256::from(2))])
+                    storage: HashMap::from([(U256::from(1), U256::from(2))])
                 }
             )]),
             "Should have changed 1 storage slot"

--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -894,7 +894,7 @@ mod tests {
         // Check final post-state
         assert_eq!(
             post_state.storage(),
-            &BTreeMap::from([(
+            &HashMap::from([(
                 account1,
                 Storage {
                     times_wiped: 0,
@@ -1256,7 +1256,7 @@ mod tests {
             false,
             &mut post_state,
         );
-        assert_eq!(post_state.accounts(), &BTreeMap::default());
+        assert_eq!(post_state.accounts(), &HashMap::default());
         assert_eq!(post_state.account_changes(), &AccountChanges::default());
 
         // Touch an empty account after state clearing EIP. The account should be destroyed.
@@ -1269,7 +1269,7 @@ mod tests {
             true,
             &mut post_state,
         );
-        assert_eq!(post_state.accounts(), &BTreeMap::from([(address, None)]));
+        assert_eq!(post_state.accounts(), &HashMap::from([(address, None)]));
         assert_eq!(
             post_state.account_changes(),
             &AccountChanges {
@@ -1306,7 +1306,7 @@ mod tests {
         );
         assert_eq!(
             post_state_before_state_clear.accounts(),
-            &BTreeMap::from([
+            &HashMap::from([
                 (address1, Some(Account::default())),
                 (address2, Some(Account::default()))
             ])
@@ -1330,7 +1330,7 @@ mod tests {
             true,
             &mut post_state_after_state_clear,
         );
-        assert_eq!(post_state_after_state_clear.accounts(), &BTreeMap::default());
+        assert_eq!(post_state_after_state_clear.accounts(), &HashMap::default());
         assert_eq!(post_state_after_state_clear.account_changes(), &AccountChanges::default());
     }
 }

--- a/crates/storage/provider/src/post_state/mod.rs
+++ b/crates/storage/provider/src/post_state/mod.rs
@@ -745,10 +745,7 @@ mod tests {
         );
         assert_eq!(
             init_state.storage.get(&address),
-            Some(&Storage {
-                storage: HashMap::from([(init_slot, U256::from(1))]),
-                times_wiped: 0
-            })
+            Some(&Storage { storage: HashMap::from([(init_slot, U256::from(1))]), times_wiped: 0 })
         );
 
         let mut post_state = PostState::new();

--- a/crates/storage/provider/src/post_state/mod.rs
+++ b/crates/storage/provider/src/post_state/mod.rs
@@ -285,7 +285,7 @@ impl PostState {
                     wiped_storage.extend(their_storage_transition.storage);
                     (wipe, wiped_storage)
                 } else {
-                    (StorageWipe::None, their_storage_transition.storage)
+                    (StorageWipe::None, their_storage_transition.storage.into_iter().collect())
                 };
                 self.storage_changes.insert_for_block_and_address(
                     block_number,
@@ -746,7 +746,7 @@ mod tests {
         assert_eq!(
             init_state.storage.get(&address),
             Some(&Storage {
-                storage: BTreeMap::from([(init_slot, U256::from(1))]),
+                storage: HashMap::from([(init_slot, U256::from(1))]),
                 times_wiped: 0
             })
         );
@@ -778,7 +778,7 @@ mod tests {
         assert!(post_state.storage.get(&address).unwrap().wiped());
         assert_eq!(
             post_state.storage.get(&address).unwrap(),
-            &Storage { times_wiped: 1, storage: BTreeMap::default() }
+            &Storage { times_wiped: 1, storage: HashMap::default() }
         );
 
         // Revert to block 1
@@ -948,8 +948,8 @@ mod tests {
         assert_eq!(
             state.storage,
             HashMap::from([
-                (address1, Storage { times_wiped: 2, storage: BTreeMap::default() }),
-                (address2, Storage { times_wiped: 1, storage: BTreeMap::default() })
+                (address1, Storage { times_wiped: 2, storage: HashMap::default() }),
+                (address2, Storage { times_wiped: 1, storage: HashMap::default() })
             ])
         );
         assert_eq!(
@@ -1010,8 +1010,8 @@ mod tests {
         assert_eq!(
             state_3_4.storage,
             HashMap::from([
-                (address1, Storage { times_wiped: 1, storage: BTreeMap::default() }),
-                (address2, Storage { times_wiped: 1, storage: BTreeMap::default() })
+                (address1, Storage { times_wiped: 1, storage: HashMap::default() }),
+                (address2, Storage { times_wiped: 1, storage: HashMap::default() })
             ])
         );
 
@@ -1493,7 +1493,7 @@ mod tests {
         // Then, we must ensure that *only* the storage from the last transition will be written
         assert_eq!(
             state.account_storage(&address_a).expect("Account A should have some storage").storage,
-            BTreeMap::from([(U256::from(0), U256::from(3)), (U256::from(2), U256::from(4))]),
+            HashMap::from([(U256::from(0), U256::from(3)), (U256::from(2), U256::from(4))]),
             "Account A's storage should only have slots 0 and 2, and they should have values 3 and 4, respectively."
         );
     }
@@ -1632,7 +1632,7 @@ mod tests {
             &HashMap::from([(
                 address,
                 Storage {
-                    storage: BTreeMap::from([
+                    storage: HashMap::from([
                         (U256::from(0), U256::from(2)),
                         (U256::from(1), U256::from(5))
                     ]),
@@ -1781,7 +1781,7 @@ mod tests {
             &HashMap::from([(
                 address,
                 Storage {
-                    storage: BTreeMap::from([(U256::from(0), U256::from(2)),]),
+                    storage: HashMap::from([(U256::from(0), U256::from(2)),]),
                     times_wiped: 0,
                 }
             )]),

--- a/crates/storage/provider/src/post_state/storage.rs
+++ b/crates/storage/provider/src/post_state/storage.rs
@@ -1,6 +1,6 @@
 use derive_more::Deref;
 use reth_primitives::{Address, BlockNumber, U256};
-use std::collections::{btree_map::Entry, BTreeMap};
+use std::collections::{btree_map::Entry, BTreeMap, HashMap};
 
 /// Storage for an account with the old and new values for each slot: (slot -> (old, new)).
 pub type StorageChangeset = BTreeMap<U256, (U256, U256)>;
@@ -55,7 +55,7 @@ pub struct Storage {
     /// The number of times the storage was wiped.
     pub times_wiped: u64,
     /// The storage slots.
-    pub storage: BTreeMap<U256, U256>,
+    pub storage: HashMap<U256, U256>,
 }
 
 impl Storage {


### PR DESCRIPTION
Account and storage plain state is inherently random access during execution. Currently, we store these in a `BTreeMap`.

By name alone, one would assume that this would perform a binary search on lookup of values, but it does not. In fact, all inserts and lookups in `BTreeMaps` use linear search, which slows down both of these operations considerably when the collection is large enough (which it often is for us).

The only reason we would want to use `BTreeMap` here over `HashMap` is if we could use the auto-sorted property of the BTree to perform faster inserts into the database, but plain state cannot be inserted in a sorted fashion, so we do not need this property

This should theoretically boost performance of execution somewhat, assuming the default hashing algorithm is fast enough. In the future we could switch the hashing algorithm for something else that is performant on small keys, since keys in both maps are 256 bits or less