### PR TITLE
docs: add some content to dev section of book

### DIFF
--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -26,4 +26,3 @@
    1. [reth stage](./cli/stage.md)
 1. [Developers](./developers/developers.md)
    1. [Contribute](./developers/contribute.md)
-   1. [Architecture](./developers/architecture.md)

--- a/book/developers/architecture.md
+++ b/book/developers/architecture.md
@@ -1,1 +1,0 @@
-# Architecture

--- a/book/developers/contribute.md
+++ b/book/developers/contribute.md
@@ -1,3 +1,9 @@
 # Contribute
 
 <!-- TODO: Add various debugging tips and tricks we use, ways to configure logging, unwinding a node etc. -->
+
+Reth has docs specifically geared for developers and contributors, including documentation on the structure and architecture of reth, the general workflow we employ, and other useful tips.
+
+You can find these docs [here](https://github.com/paradigmxyz/reth/tree/main/docs).
+
+Check out our contributing guidelines [here](https://github.com/paradigmxyz/reth/blob/main/CONTRIBUTING.md).

--- a/book/developers/developers.md
+++ b/book/developers/developers.md
@@ -1,1 +1,3 @@
 # Developers
+
+Reth is composed of several crates that can be used in standalone projects. If you are interested in using one or more of the crates, you can get an overview of them in the [developer docs](https://github.com/paradigmxyz/reth/tree/main/docs), or take a look at the [crate docs](https://paradigmxyz.github.io/reth/docs).


### PR DESCRIPTION
I removed the architecture chapter since we already have one in `/docs` (albeit outdated)