### PR TITLE
chore: Cargo.lock out of sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5455,7 +5455,6 @@ name = "reth-payload-builder"
 version = "0.1.0"
 dependencies = [
  "futures-util",
- "hashbrown 0.13.2",
  "reth-interfaces",
  "reth-metrics",
  "reth-primitives",


### PR DESCRIPTION
introduced in #3182 