### PR TITLE
feat(bin): display ETA with second precision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5455,7 +5455,6 @@ name = "reth-payload-builder"
 version = "0.1.0"
 dependencies = [
  "futures-util",
- "hashbrown 0.13.2",
  "reth-interfaces",
  "reth-metrics",
  "reth-primitives",

--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -314,3 +314,25 @@ impl std::fmt::Display for Eta {
         write!(f, "unknown")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::node::events::Eta;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn eta_display_no_milliseconds() {
+        let eta = Eta {
+            last_checkpoint_time: Some(Instant::now()),
+            eta: Some(Duration::from_millis(
+                13 * 60 * 1000 + // Minutes
+                    37 * 1000 + // Seconds
+                    999, // Milliseconds
+            )),
+            ..Default::default()
+        }
+        .to_string();
+
+        assert_eq!(eta, "13m 37s");
+    }
+}

--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -303,7 +303,11 @@ impl std::fmt::Display for Eta {
             let remaining = eta.checked_sub(last_checkpoint_time.elapsed());
 
             if let Some(remaining) = remaining {
-                return write!(f, "{}", humantime::format_duration(remaining))
+                return write!(
+                    f,
+                    "{}",
+                    humantime::format_duration(Duration::from_secs(remaining.as_secs()))
+                )
             }
         }
 


### PR DESCRIPTION
Before:
```console
2023-06-15T16:43:08.853485Z  INFO reth::cli: Status connected_peers=2 stage=Bodies checkpoint=83.3% eta=3m 54s 910ms 884us 574ns
```

After:
```console
2023-06-15T16:43:08.853485Z  INFO reth::cli: Status connected_peers=2 stage=Bodies checkpoint=83.3% eta=3m 54s
```

---

Test is not flaky:
```console
➜  reth git:(alexey/eta-display-seconds) ✗ hyperfine -w 1 -r 100 "cargo test --release --lib --package reth node::events::tests::eta_display"
Benchmark 1: cargo test --release --lib --package reth node::events::tests::eta_display
  Time (mean ± σ):     522.7 ms ±  71.7 ms    [User: 342.2 ms, System: 157.1 ms]
  Range (min … max):   477.6 ms … 1118.9 ms    100 runs
```