### PR TITLE
fix: mark state as synced when transition to live sync

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1168,7 +1168,10 @@ where
                                 sync_target_state.finalized_block_hash,
                             ) {
                                 Ok(synced) => {
-                                    if !synced {
+                                    if synced {
+                                        // we're consider this synced and transition to live sync
+                                        self.sync_state_updater.update_sync_state(SyncState::Idle);
+                                    } else {
                                         // We don't have the finalized block in the database, so
                                         // we need to run another pipeline.
                                         self.sync.set_pipeline_sync_target(


### PR DESCRIPTION
this fixes a regression introduced in https://github.com/paradigmxyz/reth/pull/3142

where the sync state is no longer updated as before

https://github.com/paradigmxyz/reth/pull/3142/files#diff-6422221acf035d27429c58dd93438246d53b548efb00b9b3cfbd610c94f8c544L1169