### PR TITLE
chore: replaces `tx.get::<Table>` with provider methods

### DIFF
--- a/bin/reth/src/debug_cmd/merkle.rs
+++ b/bin/reth/src/debug_cmd/merkle.rs
@@ -9,7 +9,7 @@ use reth_primitives::{
     stage::{StageCheckpoint, StageId},
     ChainSpec,
 };
-use reth_provider::ProviderFactory;
+use reth_provider::{ProviderFactory, StageCheckpointProvider};
 use reth_staged_sync::utils::init::init_db;
 use reth_stages::{
     stages::{

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -41,8 +41,8 @@ use reth_network::{error::NetworkError, NetworkConfig, NetworkHandle, NetworkMan
 use reth_network_api::NetworkInfo;
 use reth_primitives::{stage::StageId, BlockHashOrNumber, ChainSpec, Head, SealedHeader, H256};
 use reth_provider::{
-    providers::get_stage_checkpoint, BlockHashProvider, BlockProvider, CanonStateSubscriptions,
-    HeaderProvider, ProviderFactory,
+    BlockHashProvider, BlockProvider, CanonStateSubscriptions, HeaderProvider, ProviderFactory,
+    StageCheckpointProvider,
 };
 use reth_revm::Factory;
 use reth_revm_inspectors::stack::Hook;
@@ -508,9 +508,8 @@ impl Command {
     fn lookup_head(&self, db: Arc<Env<WriteMap>>) -> Result<Head, reth_interfaces::Error> {
         let factory = ProviderFactory::new(db, self.chain.clone());
         let provider = factory.provider()?;
-        let head = get_stage_checkpoint(provider.tx_ref(), StageId::Finish)?
-            .unwrap_or_default()
-            .block_number;
+
+        let head = provider.get_stage_checkpoint(StageId::Finish)?.unwrap_or_default().block_number;
 
         let header = provider
             .header_by_number(head)?

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -41,8 +41,8 @@ use reth_network::{error::NetworkError, NetworkConfig, NetworkHandle, NetworkMan
 use reth_network_api::NetworkInfo;
 use reth_primitives::{stage::StageId, BlockHashOrNumber, ChainSpec, Head, SealedHeader, H256};
 use reth_provider::{
-    providers::get_stage_checkpoint, BlockHashProvider, BlockNumProvider, BlockProvider,
-    CanonStateSubscriptions, HeaderProvider, ProviderFactory,
+    providers::get_stage_checkpoint, BlockHashProvider, BlockProvider, CanonStateSubscriptions,
+    HeaderProvider, ProviderFactory,
 };
 use reth_revm::Factory;
 use reth_revm_inspectors::stack::Hook;

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -23,8 +23,6 @@ use reth_config::Config;
 use reth_db::{
     database::Database,
     mdbx::{Env, WriteMap},
-    tables,
-    transaction::DbTx,
 };
 use reth_discv4::DEFAULT_DISCOVERY_PORT;
 use reth_downloaders::{
@@ -41,12 +39,10 @@ use reth_interfaces::{
 };
 use reth_network::{error::NetworkError, NetworkConfig, NetworkHandle, NetworkManager};
 use reth_network_api::NetworkInfo;
-use reth_primitives::{
-    stage::StageId, BlockHashOrNumber, ChainSpec, Head, Header, SealedHeader, H256,
-};
+use reth_primitives::{stage::StageId, BlockHashOrNumber, ChainSpec, Head, SealedHeader, H256};
 use reth_provider::{
-    providers::get_stage_checkpoint, BlockProvider, CanonStateSubscriptions, HeaderProvider,
-    ProviderFactory,
+    providers::get_stage_checkpoint, BlockHashProvider, BlockNumProvider, BlockProvider,
+    CanonStateSubscriptions, HeaderProvider, ProviderFactory,
 };
 use reth_revm::Factory;
 use reth_revm_inspectors::stack::Hook;
@@ -509,30 +505,32 @@ impl Command {
         Ok(handle)
     }
 
-    fn lookup_head(
-        &self,
-        db: Arc<Env<WriteMap>>,
-    ) -> Result<Head, reth_interfaces::db::DatabaseError> {
-        db.view(|tx| {
-            let head = get_stage_checkpoint(tx, StageId::Finish)?.unwrap_or_default().block_number;
-            let header = tx
-                .get::<tables::Headers>(head)?
-                .expect("the header for the latest block is missing, database is corrupt");
-            let total_difficulty = tx.get::<tables::HeaderTD>(head)?.expect(
-                "the total difficulty for the latest block is missing, database is corrupt",
-            );
-            let hash = tx
-                .get::<tables::CanonicalHeaders>(head)?
-                .expect("the hash for the latest block is missing, database is corrupt");
-            Ok::<Head, reth_interfaces::db::DatabaseError>(Head {
-                number: head,
-                hash,
-                difficulty: header.difficulty,
-                total_difficulty: total_difficulty.into(),
-                timestamp: header.timestamp,
-            })
-        })?
-        .map_err(Into::into)
+    fn lookup_head(&self, db: Arc<Env<WriteMap>>) -> Result<Head, reth_interfaces::Error> {
+        let factory = ProviderFactory::new(db, self.chain.clone());
+        let provider = factory.provider()?;
+        let head = get_stage_checkpoint(provider.tx_ref(), StageId::Finish)?
+            .unwrap_or_default()
+            .block_number;
+
+        let header = provider
+            .header_by_number(head)?
+            .expect("the header for the latest block is missing, database is corrupt");
+
+        let total_difficulty = provider
+            .header_td_by_number(head)?
+            .expect("the total difficulty for the latest block is missing, database is corrupt");
+
+        let hash = provider
+            .block_hash(head)?
+            .expect("the hash for the latest block is missing, database is corrupt");
+
+        Ok(Head {
+            number: head,
+            hash,
+            difficulty: header.difficulty,
+            total_difficulty,
+            timestamp: header.timestamp,
+        })
     }
 
     /// Attempt to look up the block number for the tip hash in the database.
@@ -565,13 +563,10 @@ impl Command {
         DB: Database,
         Client: HeadersClient,
     {
-        let header = db.view(|tx| -> Result<Option<Header>, reth_db::DatabaseError> {
-            let number = match tip {
-                BlockHashOrNumber::Hash(hash) => tx.get::<tables::HeaderNumbers>(hash)?,
-                BlockHashOrNumber::Number(number) => Some(number),
-            };
-            Ok(number.map(|number| tx.get::<tables::Headers>(number)).transpose()?.flatten())
-        })??;
+        let factory = ProviderFactory::new(db, self.chain.clone());
+        let provider = factory.provider()?;
+
+        let header = provider.header_by_hash_or_number(tip)?;
 
         // try to look up the header in the database
         if let Some(header) = header {

--- a/bin/reth/src/stage/run.rs
+++ b/bin/reth/src/stage/run.rs
@@ -12,7 +12,7 @@ use reth_beacon_consensus::BeaconConsensus;
 use reth_config::Config;
 use reth_downloaders::bodies::bodies::BodiesDownloaderBuilder;
 use reth_primitives::ChainSpec;
-use reth_provider::{providers::get_stage_checkpoint, ProviderFactory};
+use reth_provider::{ProviderFactory, StageCheckpointProvider};
 use reth_staged_sync::utils::init::init_db;
 use reth_stages::{
     stages::{
@@ -215,8 +215,7 @@ impl Command {
             assert!(exec_stage.type_id() == unwind_stage.type_id());
         }
 
-        let checkpoint =
-            get_stage_checkpoint(provider_rw.tx_ref(), exec_stage.id())?.unwrap_or_default();
+        let checkpoint = provider_rw.get_stage_checkpoint(exec_stage.id())?.unwrap_or_default();
 
         let unwind_stage = unwind_stage.as_mut().unwrap_or(&mut exec_stage);
 

--- a/crates/stages/benches/setup/account_hashing.rs
+++ b/crates/stages/benches/setup/account_hashing.rs
@@ -63,7 +63,7 @@ fn generate_testdata_db(num_blocks: u64) -> (PathBuf, StageRange) {
         std::fs::create_dir_all(&path).unwrap();
         println!("Account Hashing testdata not found, generating to {:?}", path.display());
         let tx = TestTransaction::new(&path);
-        let mut provider = tx.inner();
+        let mut provider = tx.inner_rw();
         let _accounts = AccountHashingStage::seed(&mut provider, opts);
         provider.commit().expect("failed to commit");
     }

--- a/crates/stages/benches/setup/mod.rs
+++ b/crates/stages/benches/setup/mod.rs
@@ -123,7 +123,7 @@ pub(crate) fn txs_testdata(num_blocks: u64) -> PathBuf {
         tx.insert_accounts_and_storages(start_state.clone()).unwrap();
 
         // make first block after genesis have valid state root
-        let (root, updates) = StateRoot::new(tx.inner().tx_ref()).root_with_updates().unwrap();
+        let (root, updates) = StateRoot::new(tx.inner_rw().tx_ref()).root_with_updates().unwrap();
         let second_block = blocks.get_mut(1).unwrap();
         let cloned_second = second_block.clone();
         let mut updated_header = cloned_second.header.unseal();
@@ -144,7 +144,7 @@ pub(crate) fn txs_testdata(num_blocks: u64) -> PathBuf {
 
         // make last block have valid state root
         let root = {
-            let tx_mut = tx.inner();
+            let tx_mut = tx.inner_rw();
             let root = StateRoot::new(tx_mut.tx_ref()).root().unwrap();
             tx_mut.commit().unwrap();
             root

--- a/crates/stages/src/stage.rs
+++ b/crates/stages/src/stage.rs
@@ -5,7 +5,7 @@ use reth_primitives::{
     stage::{StageCheckpoint, StageId},
     BlockNumber, TxNumber,
 };
-use reth_provider::{DatabaseProviderRW, ProviderError};
+use reth_provider::DatabaseProviderRW;
 use std::{
     cmp::{max, min},
     ops::RangeInclusive,
@@ -79,10 +79,7 @@ impl ExecInput {
         tx_threshold: u64,
     ) -> Result<(RangeInclusive<TxNumber>, RangeInclusive<BlockNumber>, bool), StageError> {
         let start_block = self.next_block();
-        let start_block_body = provider
-            .tx_ref()
-            .get::<tables::BlockBodyIndices>(start_block)?
-            .ok_or(ProviderError::BlockBodyIndicesNotFound(start_block))?;
+        let start_block_body = provider.block_body_indices(start_block)?;
 
         let target_block = self.target();
 

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -470,7 +470,9 @@ mod tests {
         hex_literal::hex, keccak256, stage::StageUnitCheckpoint, Account, Bytecode,
         ChainSpecBuilder, SealedBlock, StorageEntry, H160, H256, MAINNET, U256,
     };
-    use reth_provider::{insert_canonical_block, ProviderFactory};
+    use reth_provider::{
+        insert_canonical_block, AccountProvider, ProviderFactory, ReceiptProvider,
+    };
     use reth_revm::Factory;
     use reth_rlp::Decodable;
     use std::sync::Arc;
@@ -672,8 +674,9 @@ mod tests {
             },
             done: true
         } if processed == total && total == block.gas_used);
-        let mut provider = factory.provider_rw().unwrap();
-        let tx = provider.tx_mut();
+
+        let provider = factory.provider().unwrap();
+
         // check post state
         let account1 = H160(hex!("1000000000000000000000000000000000000000"));
         let account1_info =
@@ -693,24 +696,24 @@ mod tests {
 
         // assert accounts
         assert_eq!(
-            tx.get::<tables::PlainAccountState>(account1),
+            provider.basic_account(account1),
             Ok(Some(account1_info)),
             "Post changed of a account"
         );
         assert_eq!(
-            tx.get::<tables::PlainAccountState>(account2),
+            provider.basic_account(account2),
             Ok(Some(account2_info)),
             "Post changed of a account"
         );
         assert_eq!(
-            tx.get::<tables::PlainAccountState>(account3),
+            provider.basic_account(account3),
             Ok(Some(account3_info)),
             "Post changed of a account"
         );
         // assert storage
         // Get on dupsort would return only first value. This is good enough for this test.
         assert_eq!(
-            tx.get::<tables::PlainStorageState>(account1),
+            provider.tx_ref().get::<tables::PlainStorageState>(account1),
             Ok(Some(StorageEntry { key: H256::from_low_u64_be(1), value: U256::from(2) })),
             "Post changed of a account"
         );
@@ -787,26 +790,13 @@ mod tests {
         } if total == block.gas_used);
 
         // assert unwind stage
-        let db_tx = provider.tx_ref();
-        assert_eq!(
-            db_tx.get::<tables::PlainAccountState>(acc1),
-            Ok(Some(acc1_info)),
-            "Pre changed of a account"
-        );
-        assert_eq!(
-            db_tx.get::<tables::PlainAccountState>(acc2),
-            Ok(Some(acc2_info)),
-            "Post changed of a account"
-        );
+        assert_eq!(provider.basic_account(acc1), Ok(Some(acc1_info)), "Pre changed of a account");
+        assert_eq!(provider.basic_account(acc2), Ok(Some(acc2_info)), "Post changed of a account");
 
         let miner_acc = H160(hex!("2adc25665018aa1fe0e6bc666dac8fc2697ff9ba"));
-        assert_eq!(
-            db_tx.get::<tables::PlainAccountState>(miner_acc),
-            Ok(None),
-            "Third account should be unwound"
-        );
+        assert_eq!(provider.basic_account(miner_acc), Ok(None), "Third account should be unwound");
 
-        assert_eq!(db_tx.get::<tables::Receipts>(0), Ok(None), "First receipt should be unwound");
+        assert_eq!(provider.receipt(0), Ok(None), "First receipt should be unwound");
     }
 
     #[tokio::test]
@@ -878,11 +868,7 @@ mod tests {
 
         // assert unwind stage
         let provider = factory.provider_rw().unwrap();
-        assert_eq!(
-            provider.tx_ref().get::<tables::PlainAccountState>(destroyed_address),
-            Ok(None),
-            "Account was destroyed"
-        );
+        assert_eq!(provider.basic_account(destroyed_address), Ok(None), "Account was destroyed");
 
         assert_eq!(
             provider.tx_ref().get::<tables::PlainStorageState>(destroyed_address),

--- a/crates/stages/src/stages/hashing_account.rs
+++ b/crates/stages/src/stages/hashing_account.rs
@@ -532,7 +532,7 @@ mod tests {
             type Seed = Vec<(Address, Account)>;
 
             fn seed_execution(&mut self, input: ExecInput) -> Result<Self::Seed, TestRunnerError> {
-                let mut provider = self.tx.inner();
+                let mut provider = self.tx.inner_rw();
                 let res = Ok(AccountHashingStage::seed(
                     &mut provider,
                     SeedOpts { blocks: 1..=input.target(), accounts: 0..10, txs: 0..3 },

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -403,6 +403,7 @@ mod tests {
             generators::random_header_range, TestConsensus, TestHeaderDownloader, TestHeadersClient,
         };
         use reth_primitives::U256;
+        use reth_provider::{BlockHashProvider, BlockNumProvider, HeaderProvider};
         use std::sync::Arc;
 
         pub(crate) struct HeadersTestRunner<D: HeaderDownloader> {
@@ -478,26 +479,22 @@ mod tests {
                 let initial_checkpoint = input.checkpoint().block_number;
                 match output {
                     Some(output) if output.checkpoint.block_number > initial_checkpoint => {
-                        self.tx.query(|tx| {
-                            for block_num in
-                                (initial_checkpoint..output.checkpoint.block_number).rev()
-                            {
-                                // look up the header hash
-                                let hash = tx
-                                    .get::<tables::CanonicalHeaders>(block_num)?
-                                    .expect("no header hash");
+                        let provider = self.tx.factory.provider()?;
+                        for block_num in (initial_checkpoint..output.checkpoint.block_number).rev()
+                        {
+                            // look up the header hash
+                            let hash =
+                                provider.block_hash(block_num.into())?.expect("no header hash");
 
-                                // validate the header number
-                                assert_eq!(tx.get::<tables::HeaderNumbers>(hash)?, Some(block_num));
+                            // validate the header number
+                            assert_eq!(provider.block_number(hash)?, Some(block_num));
 
-                                // validate the header
-                                let header = tx.get::<tables::Headers>(block_num)?;
-                                assert!(header.is_some());
-                                let header = header.unwrap().seal_slow();
-                                assert_eq!(header.hash(), hash);
-                            }
-                            Ok(())
-                        })?;
+                            // validate the header
+                            let header = provider.header_by_number(block_num)?;
+                            assert!(header.is_some());
+                            let header = header.unwrap().seal_slow();
+                            assert_eq!(header.hash(), hash);
+                        }
                     }
                     _ => self.check_no_header_entry_above(initial_checkpoint)?,
                 };

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -483,8 +483,7 @@ mod tests {
                         for block_num in (initial_checkpoint..output.checkpoint.block_number).rev()
                         {
                             // look up the header hash
-                            let hash =
-                                provider.block_hash(block_num.into())?.expect("no header hash");
+                            let hash = provider.block_hash(block_num)?.expect("no header hash");
 
                             // validate the header number
                             assert_eq!(provider.block_number(hash)?, Some(block_num));

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -235,6 +235,7 @@ mod tests {
     use reth_primitives::{
         stage::StageUnitCheckpoint, BlockNumber, SealedBlock, TransactionSigned, H256,
     };
+    use reth_provider::TransactionsProvider;
 
     use super::*;
     use crate::test_utils::{
@@ -417,7 +418,8 @@ mod tests {
             output: Option<ExecOutput>,
         ) -> Result<(), TestRunnerError> {
             match output {
-                Some(output) => self.tx.query(|tx| {
+                Some(output) => {
+                    let provider = self.tx.inner();
                     let start_block = input.next_block();
                     let end_block = output.checkpoint.block_number;
 
@@ -425,23 +427,25 @@ mod tests {
                         return Ok(())
                     }
 
-                    let mut body_cursor = tx.cursor_read::<tables::BlockBodyIndices>()?;
+                    let mut body_cursor =
+                        provider.tx_ref().cursor_read::<tables::BlockBodyIndices>()?;
                     body_cursor.seek_exact(start_block)?;
 
                     while let Some((_, body)) = body_cursor.next()? {
                         for tx_id in body.tx_num_range() {
-                            let transaction: TransactionSigned = tx
-                                .get::<tables::Transactions>(tx_id)?
+                            let transaction: TransactionSigned = provider
+                                .transaction_by_id(tx_id)?
                                 .expect("no transaction entry")
                                 .into();
                             let signer =
                                 transaction.recover_signer().expect("failed to recover signer");
-                            assert_eq!(Some(signer), tx.get::<tables::TxSenders>(tx_id)?);
+                            assert_eq!(
+                                Some(signer),
+                                provider.tx_ref().get::<tables::TxSenders>(tx_id)?
+                            );
                         }
                     }
-
-                    Ok(())
-                })?,
+                }
                 None => self.ensure_no_senders_by_block(input.checkpoint().block_number)?,
             };
 

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -374,7 +374,7 @@ mod tests {
         /// 2. If the is no requested block entry in the bodies table,
         ///    but [tables::TxSenders] is not empty.
         fn ensure_no_senders_by_block(&self, block: BlockNumber) -> Result<(), TestRunnerError> {
-            let body_result = self.tx.inner().block_body_indices(block);
+            let body_result = self.tx.inner_rw().block_body_indices(block);
             match body_result {
                 Ok(body) => self
                     .tx
@@ -433,10 +433,8 @@ mod tests {
 
                     while let Some((_, body)) = body_cursor.next()? {
                         for tx_id in body.tx_num_range() {
-                            let transaction: TransactionSigned = provider
-                                .transaction_by_id(tx_id)?
-                                .expect("no transaction entry")
-                                .into();
+                            let transaction: TransactionSigned =
+                                provider.transaction_by_id(tx_id)?.expect("no transaction entry");
                             let signer =
                                 transaction.recover_signer().expect("failed to recover signer");
                             assert_eq!(

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -437,10 +437,7 @@ mod tests {
                                 provider.transaction_by_id(tx_id)?.expect("no transaction entry");
                             let signer =
                                 transaction.recover_signer().expect("failed to recover signer");
-                            assert_eq!(
-                                Some(signer),
-                                provider.tx_ref().get::<tables::TxSenders>(tx_id)?
-                            );
+                            assert_eq!(Some(signer), provider.transaction_sender(tx_id)?)
                         }
                     }
                 }

--- a/crates/stages/src/stages/total_difficulty.rs
+++ b/crates/stages/src/stages/total_difficulty.rs
@@ -130,6 +130,7 @@ mod tests {
         TestConsensus,
     };
     use reth_primitives::{stage::StageUnitCheckpoint, BlockNumber, SealedHeader};
+    use reth_provider::HeaderProvider;
 
     use super::*;
     use crate::test_utils::{
@@ -262,27 +263,26 @@ mod tests {
             let initial_stage_progress = input.checkpoint().block_number;
             match output {
                 Some(output) if output.checkpoint.block_number > initial_stage_progress => {
-                    self.tx.query(|tx| {
-                        let mut header_cursor = tx.cursor_read::<tables::Headers>()?;
-                        let (_, mut current_header) = header_cursor
-                            .seek_exact(initial_stage_progress)?
-                            .expect("no initial header");
-                        let mut td: U256 = tx
-                            .get::<tables::HeaderTD>(initial_stage_progress)?
-                            .expect("no initial td")
-                            .into();
+                    let provider = self.tx.inner();
 
-                        while let Some((next_key, next_header)) = header_cursor.next()? {
-                            assert_eq!(current_header.number + 1, next_header.number);
-                            td += next_header.difficulty;
-                            assert_eq!(
-                                tx.get::<tables::HeaderTD>(next_key)?.map(Into::into),
-                                Some(td)
-                            );
-                            current_header = next_header;
-                        }
-                        Ok(())
-                    })?;
+                    let mut header_cursor = provider.tx_ref().cursor_read::<tables::Headers>()?;
+                    let (_, mut current_header) = header_cursor
+                        .seek_exact(initial_stage_progress)?
+                        .expect("no initial header");
+                    let mut td: U256 = provider
+                        .header_td_by_number(initial_stage_progress)?
+                        .expect("no initial td")
+                        .into();
+
+                    while let Some((next_key, next_header)) = header_cursor.next()? {
+                        assert_eq!(current_header.number + 1, next_header.number);
+                        td += next_header.difficulty;
+                        assert_eq!(
+                            provider.header_td_by_number(next_key)?.map(Into::into),
+                            Some(td)
+                        );
+                        current_header = next_header;
+                    }
                 }
                 _ => self.check_no_td_above(initial_stage_progress)?,
             };

--- a/crates/stages/src/stages/total_difficulty.rs
+++ b/crates/stages/src/stages/total_difficulty.rs
@@ -271,8 +271,7 @@ mod tests {
                         .expect("no initial header");
                     let mut td: U256 = provider
                         .header_td_by_number(initial_stage_progress)?
-                        .expect("no initial td")
-                        .into();
+                        .expect("no initial td");
 
                     while let Some((next_key, next_header)) = header_cursor.next()? {
                         assert_eq!(current_header.number + 1, next_header.number);

--- a/crates/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/src/stages/tx_lookup.rs
@@ -199,6 +199,7 @@ mod tests {
     use assert_matches::assert_matches;
     use reth_interfaces::test_utils::generators::{random_block, random_block_range};
     use reth_primitives::{stage::StageUnitCheckpoint, BlockNumber, SealedBlock, H256};
+    use reth_provider::TransactionsProvider;
 
     // Implement stage test suite.
     stage_test_suite_ext!(TransactionLookupTestRunner, transaction_lookup);
@@ -376,7 +377,9 @@ mod tests {
             output: Option<ExecOutput>,
         ) -> Result<(), TestRunnerError> {
             match output {
-                Some(output) => self.tx.query(|tx| {
+                Some(output) => {
+                    let provider = self.tx.inner();
+
                     let start_block = input.next_block();
                     let end_block = output.checkpoint.block_number;
 
@@ -384,23 +387,18 @@ mod tests {
                         return Ok(())
                     }
 
-                    let mut body_cursor = tx.cursor_read::<tables::BlockBodyIndices>()?;
+                    let mut body_cursor =
+                        provider.tx_ref().cursor_read::<tables::BlockBodyIndices>()?;
                     body_cursor.seek_exact(start_block)?;
 
                     while let Some((_, body)) = body_cursor.next()? {
                         for tx_id in body.tx_num_range() {
-                            let transaction = tx
-                                .get::<tables::Transactions>(tx_id)?
-                                .expect("no transaction entry");
-                            assert_eq!(
-                                Some(tx_id),
-                                tx.get::<tables::TxHashNumber>(transaction.hash())?,
-                            );
+                            let transaction =
+                                provider.transaction_by_id(tx_id)?.expect("no transaction entry");
+                            assert_eq!(Some(tx_id), provider.transaction_id(transaction.hash())?);
                         }
                     }
-
-                    Ok(())
-                })?,
+                }
                 None => self.ensure_no_hash_by_block(input.checkpoint().block_number)?,
             };
             Ok(())

--- a/crates/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/src/stages/tx_lookup.rs
@@ -332,7 +332,7 @@ mod tests {
         /// 2. If the is no requested block entry in the bodies table,
         ///    but [tables::TxHashNumber] is not empty.
         fn ensure_no_hash_by_block(&self, number: BlockNumber) -> Result<(), TestRunnerError> {
-            let body_result = self.tx.inner().block_body_indices(number);
+            let body_result = self.tx.inner_rw().block_body_indices(number);
             match body_result {
                 Ok(body) => self.tx.ensure_no_entry_above_by_value::<tables::TxHashNumber, _>(
                     body.last_tx_num(),

--- a/crates/stages/src/test_utils/runner.rs
+++ b/crates/stages/src/test_utils/runner.rs
@@ -12,6 +12,8 @@ pub(crate) enum TestRunnerError {
     Database(#[from] reth_interfaces::db::DatabaseError),
     #[error("Internal runner error occurred.")]
     Internal(#[from] Box<dyn std::error::Error>),
+    #[error("Internal interface error occurred.")]
+    Interface(#[from] reth_interfaces::Error),
 }
 
 /// A generic test runner for stages.

--- a/crates/stages/src/test_utils/test_db.rs
+++ b/crates/stages/src/test_utils/test_db.rs
@@ -4,7 +4,7 @@ use reth_db::{
     mdbx::{
         test_utils::{create_test_db, create_test_db_with_path},
         tx::Tx,
-        Env, EnvKind, WriteMap, RW,
+        Env, EnvKind, WriteMap, RO, RW,
     },
     models::{AccountBeforeTx, StoredBlockBodyIndices},
     table::Table,
@@ -63,7 +63,7 @@ impl TestTransaction {
         self.factory.provider_rw().expect("failed to create db container")
     }
 
-    /// Return a database wrapped in [DatabaseProviderRW].
+    /// Return a database wrapped in [DatabaseProviderRO].
     pub fn inner(&self) -> DatabaseProviderRO<'_, Arc<Env<WriteMap>>> {
         self.factory.provider().expect("failed to create db container")
     }
@@ -87,7 +87,7 @@ impl TestTransaction {
     /// Invoke a callback with a read transaction
     pub fn query<F, R>(&self, f: F) -> Result<R, DbError>
     where
-        F: FnOnce(&Tx<'_, RW, WriteMap>) -> Result<R, DbError>,
+        F: FnOnce(&Tx<'_, RO, WriteMap>) -> Result<R, DbError>,
     {
         f(self.inner().tx_ref())
     }

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     ProviderError, StageCheckpointProvider, StateProviderBox, TransactionsProvider,
     WithdrawalsProvider,
 };
-use reth_db::{database::Database, models::StoredBlockBodyIndices, tables, transaction::DbTx};
+use reth_db::{database::Database, models::StoredBlockBodyIndices};
 use reth_interfaces::Result;
 use reth_primitives::{
     stage::{StageCheckpoint, StageId},
@@ -320,18 +320,6 @@ impl<DB: Database> EvmEnvProvider for ProviderFactory<DB> {
     fn fill_cfg_env_with_header(&self, cfg: &mut CfgEnv, header: &Header) -> Result<()> {
         self.provider()?.fill_cfg_env_with_header(cfg, header)
     }
-}
-
-/// Get checkpoint for the given stage.
-#[inline]
-pub fn get_stage_checkpoint<'a, TX>(
-    tx: &TX,
-    id: StageId,
-) -> std::result::Result<Option<StageCheckpoint>, reth_interfaces::db::DatabaseError>
-where
-    TX: DbTx<'a> + Send + Sync,
-{
-    tx.get::<tables::SyncStage>(id.to_string())
 }
 
 #[cfg(test)]

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -246,6 +246,10 @@ impl<DB: Database> TransactionsProvider for ProviderFactory<DB> {
     fn senders_by_tx_range(&self, range: impl RangeBounds<TxNumber>) -> Result<Vec<Address>> {
         self.provider()?.senders_by_tx_range(range)
     }
+
+    fn transaction_sender(&self, id: TxNumber) -> Result<Option<Address>> {
+        self.provider()?.transaction_sender(id)
+    }
 }
 
 impl<DB: Database> ReceiptProvider for ProviderFactory<DB> {

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -740,8 +740,7 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> DatabaseProvider<'this, TX> {
 
             let parent_number = range.start().saturating_sub(1);
             let parent_state_root = self
-                .tx
-                .get::<tables::Headers>(parent_number)?
+                .header_by_number(parent_number)?
                 .ok_or_else(|| ProviderError::HeaderNotFound(parent_number.into()))?
                 .state_root;
 
@@ -749,8 +748,7 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> DatabaseProvider<'this, TX> {
             // but for sake of double verification we will check it again.
             if new_state_root != parent_state_root {
                 let parent_hash = self
-                    .tx
-                    .get::<tables::CanonicalHeaders>(parent_number)?
+                    .block_hash(parent_number)?
                     .ok_or_else(|| ProviderError::HeaderNotFound(parent_number.into()))?;
                 return Err(TransactionError::UnwindStateRootMismatch {
                     got: new_state_root,

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1777,6 +1777,10 @@ impl<'this, TX: DbTx<'this>> TransactionsProvider for DatabaseProvider<'this, TX
             .map(|entry| entry.map(|sender| sender.1))
             .collect::<std::result::Result<Vec<_>, _>>()?)
     }
+
+    fn transaction_sender(&self, id: TxNumber) -> Result<Option<Address>> {
+        Ok(self.tx.get::<tables::TxSenders>(id)?)
+    }
 }
 
 impl<'this, TX: DbTx<'this>> ReceiptProvider for DatabaseProvider<'this, TX> {

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -43,8 +43,6 @@ use std::{
     sync::Arc,
 };
 
-use super::get_stage_checkpoint;
-
 /// A [`DatabaseProvider`] that holds a read-only database transaction.
 pub type DatabaseProviderRO<'this, DB> = DatabaseProvider<'this, <DB as DatabaseGAT<'this>>::TX>;
 
@@ -1072,14 +1070,6 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> DatabaseProvider<'this, TX> {
             }
         }
         Ok(())
-    }
-
-    /// Get the stage checkpoint.
-    pub fn get_stage_checkpoint(
-        &self,
-        id: StageId,
-    ) -> std::result::Result<Option<StageCheckpoint>, DatabaseError> {
-        get_stage_checkpoint(&self.tx, id)
     }
 
     /// Save stage checkpoint.

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -302,6 +302,10 @@ where
     fn senders_by_tx_range(&self, range: impl RangeBounds<TxNumber>) -> Result<Vec<Address>> {
         self.database.provider()?.senders_by_tx_range(range)
     }
+
+    fn transaction_sender(&self, id: TxNumber) -> Result<Option<Address>> {
+        self.database.provider()?.transaction_sender(id)
+    }
 }
 
 impl<DB, Tree> ReceiptProvider for BlockchainProvider<DB, Tree>

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -219,6 +219,10 @@ impl TransactionsProvider for MockEthProvider {
     ) -> Result<Vec<reth_primitives::TransactionSignedNoHash>> {
         unimplemented!()
     }
+
+    fn transaction_sender(&self, _id: TxNumber) -> Result<Option<Address>> {
+        unimplemented!()
+    }
 }
 
 impl ReceiptProvider for MockEthProvider {

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -159,6 +159,10 @@ impl TransactionsProvider for NoopProvider {
     ) -> Result<Vec<reth_primitives::TransactionSignedNoHash>> {
         Ok(Vec::default())
     }
+
+    fn transaction_sender(&self, _id: TxNumber) -> Result<Option<Address>> {
+        Ok(None)
+    }
 }
 
 impl ReceiptProvider for NoopProvider {

--- a/crates/storage/provider/src/traits/transactions.rs
+++ b/crates/storage/provider/src/traits/transactions.rs
@@ -51,4 +51,9 @@ pub trait TransactionsProvider: BlockNumProvider + Send + Sync {
 
     /// Get Senders from a tx range.
     fn senders_by_tx_range(&self, range: impl RangeBounds<TxNumber>) -> Result<Vec<Address>>;
+
+    /// Get transaction sender.
+    ///
+    /// Returns None if the transaction is not found.
+    fn transaction_sender(&self, id: TxNumber) -> Result<Option<Address>>;
 }

--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -39,6 +39,9 @@ pub enum TransactionError {
         /// Block hash
         block_hash: BlockHash,
     },
+    /// Internal interfaces error
+    #[error("Internal error")]
+    InternalError(#[from] reth_interfaces::Error),
 }
 
 #[cfg(test)]


### PR DESCRIPTION
As the title suggests. Replaces some low hanging fruit. There's some other uses, but it requires changing a few other things that I'd rather save for another PR. (eg. `assert_db` on ef-tests)

~~Waiting on https://github.com/paradigmxyz/reth/pull/3168  to be merged, so I can replace a `.get::<TxSenders` for its newly created provider function.~~