### PR TITLE
fix: shrink queued bodies and headers when drained or split

### DIFF
--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -200,8 +200,8 @@ where
         self.download_range = RangeInclusive::new(1, 0);
         self.latest_queued_block_number.take();
         self.in_progress_queue.clear();
-        self.queued_bodies.clear();
-        self.buffered_responses.clear();
+        self.queued_bodies = Vec::new();
+        self.buffered_responses = BinaryHeap::new();
         self.num_buffered_blocks = 0;
 
         // reset metrics

--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -222,6 +222,8 @@ where
     /// Removes the next response from the buffer.
     fn pop_buffered_response(&mut self) -> Option<OrderedBodiesResponse> {
         let resp = self.buffered_responses.pop()?;
+        // shrink the buffer so that it doesn't grow indefinitely
+        self.buffered_responses.shrink_to_fit();
         self.metrics.buffered_responses.decrement(1.);
         self.num_buffered_blocks -= resp.len();
         self.metrics.buffered_blocks.set(self.num_buffered_blocks as f64);

--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -270,6 +270,7 @@ where
     fn try_split_next_batch(&mut self) -> Option<Vec<BlockResponse>> {
         if self.queued_bodies.len() >= self.stream_batch_size {
             let next_batch = self.queued_bodies.drain(..self.stream_batch_size).collect::<Vec<_>>();
+            self.queued_bodies.shrink_to_fit();
             self.metrics.total_flushed.increment(next_batch.len() as u64);
             self.metrics.queued_blocks.set(self.queued_bodies.len() as f64);
             return Some(next_batch)
@@ -422,6 +423,7 @@ where
             }
             let batch_size = this.stream_batch_size.min(this.queued_bodies.len());
             let next_batch = this.queued_bodies.drain(..batch_size).collect::<Vec<_>>();
+            this.queued_bodies.shrink_to_fit();
             this.metrics.total_flushed.increment(next_batch.len() as u64);
             this.metrics.queued_blocks.set(this.queued_bodies.len() as f64);
             return Poll::Ready(Some(Ok(next_batch)))

--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -222,8 +222,6 @@ where
     /// Removes the next response from the buffer.
     fn pop_buffered_response(&mut self) -> Option<OrderedBodiesResponse> {
         let resp = self.buffered_responses.pop()?;
-        // shrink the buffer so that it doesn't grow indefinitely
-        self.buffered_responses.shrink_to_fit();
         self.metrics.buffered_responses.decrement(1.);
         self.num_buffered_blocks -= resp.len();
         self.metrics.buffered_blocks.set(self.num_buffered_blocks as f64);
@@ -412,6 +410,9 @@ where
             while let Some(buf_response) = this.try_next_buffered() {
                 this.queue_bodies(buf_response);
             }
+
+            // shrink the buffer so that it doesn't grow indefinitely
+            this.buffered_responses.shrink_to_fit();
 
             if !new_request_submitted {
                 break

--- a/crates/net/downloaders/src/headers/reverse_headers.rs
+++ b/crates/net/downloaders/src/headers/reverse_headers.rs
@@ -557,6 +557,9 @@ where
                 Ordering::Equal => {
                     let OrderedHeadersResponse { headers, request, peer_id } =
                         PeekMut::pop(next_response);
+
+                    // shrink the buffer so that it doesn't grow indefinitely
+                    self.buffered_responses.shrink_to_fit();
                     self.metrics.buffered_responses.decrement(1.);
 
                     if let Err(err) = self.process_next_headers(request, headers, peer_id) {
@@ -566,6 +569,9 @@ where
                 Ordering::Greater => {
                     self.metrics.buffered_responses.decrement(1.);
                     PeekMut::pop(next_response);
+
+                    // shrink the buffer so that it doesn't grow indefinitely
+                    self.buffered_responses.shrink_to_fit();
                 }
             }
         }

--- a/crates/net/downloaders/src/headers/reverse_headers.rs
+++ b/crates/net/downloaders/src/headers/reverse_headers.rs
@@ -333,7 +333,6 @@ where
                     .count();
                 // removes all headers that are higher than current target
                 self.queued_validated_headers.drain(..skip);
-                self.queued_validated_headers.shrink_to_fit();
             }
         } else {
             // this occurs on the initial sync target request
@@ -627,11 +626,12 @@ where
         // batch_size`, and the total memory allocated by the two buffers will be around double the
         // original size of `queued_validated_headers`.
         //
+        // These are then mem::swapped, leaving `rem` with a large capacity, but small length.
+        //
         // To prevent these allocations from leaking to the consumer, we shrink the capacity of the
-        // two buffers. The total memory allocated should then be not much more than the original
+        // new buffer. The total memory allocated should then be not much more than the original
         // size of `queued_validated_headers`.
         rem.shrink_to_fit();
-        self.queued_validated_headers.shrink_to_fit();
         rem
     }
 }

--- a/crates/net/downloaders/src/headers/reverse_headers.rs
+++ b/crates/net/downloaders/src/headers/reverse_headers.rs
@@ -1445,11 +1445,19 @@ mod tests {
 
         let headers = downloader.next().await.unwrap();
         assert_eq!(headers, Ok(vec![p0]));
+        let headers = headers.unwrap();
+        assert_eq!(headers.capacity(), headers.len());
 
         let headers = downloader.next().await.unwrap();
         assert_eq!(headers, Ok(vec![p1]));
+        let headers = headers.unwrap();
+        assert_eq!(headers.capacity(), headers.len());
+
         let headers = downloader.next().await.unwrap();
         assert_eq!(headers, Ok(vec![p2]));
+        let headers = headers.unwrap();
+        assert_eq!(headers.capacity(), headers.len());
+
         assert!(downloader.next().await.is_none());
     }
 }

--- a/crates/net/downloaders/src/headers/reverse_headers.rs
+++ b/crates/net/downloaders/src/headers/reverse_headers.rs
@@ -603,8 +603,8 @@ where
     /// Clears all requests/responses.
     fn clear(&mut self) {
         self.lowest_validated_header.take();
-        self.queued_validated_headers.clear();
-        self.buffered_responses.clear();
+        self.queued_validated_headers = Vec::new();
+        self.buffered_responses = BinaryHeap::new();
         self.in_progress_queue.clear();
 
         self.metrics.in_flight_requests.set(0.);


### PR DESCRIPTION
This fixes an OOM in the bodies stage and reduces overall memory allocations in the downloaders, by shrinking vectors whenever we `split` or `drain` them. Previously the headers downloader would effectively clone `queued_validated_headers` in terms of allocations, because `split_off` does not change the original vec's capacity. Because `queued_validated_headers` could be on the order of gigabytes, this caused an OOM.

Fixes #3175