### PR TITLE
ci: fix required checks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -67,9 +67,14 @@ jobs:
       - name: Check if benchmarks build
         run: cargo bench --all --all-features --all-targets --no-run
 
+
   bench-success:
+    if: always()
     name: bench success
     needs: bench-check
     runs-on: ubuntu-latest
     steps:
-      - run: echo Success!
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,12 @@ jobs:
         run: RUSTDOCFLAGS="-D warnings" cargo doc --all --no-deps --all-features --document-private-items
 
   lint-success:
+    if: always()
     name: lint success
     runs-on: ubuntu-latest
     needs: [lint, doc-lint]
     steps:
-      - run: echo Success!
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -68,7 +68,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: all
     steps:
-      - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@release/v1
-        with:
-          jobs: ${{ toJSON(needs) }}
+      # Note: This check is a dummy because we currently have fuzz tests disabled.
+      - run: echo OK.
+      #- name: Decide whether the needed jobs succeeded or failed
+      #  uses: re-actors/alls-green@release/v1
+      #  with:
+      #    jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -63,8 +63,12 @@ jobs:
           flags: fuzz-tests
 
   fuzz-success:
+    if: always()
     name: fuzz success
     runs-on: ubuntu-latest
     needs: all
     steps:
-      - run: echo Success!
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -91,8 +91,12 @@ jobs:
             --debug.terminate
 
   integration-success:
+    if: always()
     name: integration success
     runs-on: ubuntu-latest
     needs: [test, sync]
     steps:
-      - run: echo Success!
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -95,8 +95,12 @@ jobs:
         run: cargo test --doc --all --all-features
 
   unit-success:
+    if: always()
     name: unit success
     runs-on: ubuntu-latest
     needs: [test, eth-blockchain, doc-test]
     steps:
-      - run: echo Success!
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
We had some PRs that should not have passed the merge queue pass it anyway.

This is because our required checks are all jobs named `xyz-success` that depend on a number of other jobs to succeed. This is because GitHub only allows you to add *individual jobs* as required checks, not entire workflows, which is an insane hassle to maintain.

The issue arises when a job fails. This marks *all other* jobs as skipped. And GitHub? GitHub treats skipped as a success. This means that if *any job* failed, then GitHub would actually treat it as a success!

The fix is to always run the required checks, and use an action specifically created to solve this issue that checks whether all of its dependencies passed or not.

See also https://github.com/marketplace/actions/alls-green#why