### PR TITLE
fix: encode forkid entry in struct, accept trailing fields

### DIFF
--- a/crates/net/discv4/src/proto.rs
+++ b/crates/net/discv4/src/proto.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs)]
 
-use crate::{error::DecodePacketError, PeerId, MAX_PACKET_SIZE, MIN_PACKET_SIZE};
+use crate::{error::DecodePacketError, EnrForkIdEntry, PeerId, MAX_PACKET_SIZE, MIN_PACKET_SIZE};
 use enr::{Enr, EnrKey};
 use reth_primitives::{
     bytes::{Buf, BufMut, Bytes, BytesMut},
@@ -306,7 +306,7 @@ impl EnrResponse {
     /// See also <https://github.com/ethereum/go-ethereum/blob/9244d5cd61f3ea5a7645fdf2a1a96d53421e412f/eth/protocols/eth/discovery.go#L36>
     pub fn eth_fork_id(&self) -> Option<ForkId> {
         let mut maybe_fork_id = self.enr.0.get(b"eth")?;
-        ForkId::decode(&mut maybe_fork_id).ok()
+        EnrForkIdEntry::decode(&mut maybe_fork_id).ok().map(|entry| entry.fork_id)
     }
 }
 

--- a/crates/net/network/src/discovery.rs
+++ b/crates/net/network/src/discovery.rs
@@ -2,7 +2,7 @@
 
 use crate::error::{NetworkError, ServiceKind};
 use futures::StreamExt;
-use reth_discv4::{DiscoveryUpdate, Discv4, Discv4Config};
+use reth_discv4::{DiscoveryUpdate, Discv4, Discv4Config, EnrForkIdEntry};
 use reth_dns_discovery::{
     DnsDiscoveryConfig, DnsDiscoveryHandle, DnsDiscoveryService, DnsNodeRecordUpdate, DnsResolver,
 };
@@ -100,7 +100,8 @@ impl Discovery {
     #[allow(unused)]
     pub(crate) fn update_fork_id(&self, fork_id: ForkId) {
         if let Some(discv4) = &self.discv4 {
-            discv4.set_eip868_rlp("eth".as_bytes().to_vec(), fork_id)
+            // use forward-compatible forkid entry
+            discv4.set_eip868_rlp("eth".as_bytes().to_vec(), EnrForkIdEntry::from(fork_id))
         }
     }
 


### PR DESCRIPTION
Encodes the EIP-868 forkid value inside a struct, `EnrForkIdEntry`, instead of directly. Encode and decode tests are added with example raw RLP.

fixes #3190