### PR TITLE
chore: move stage methods to `StageCheckpointProvider` and add `StageCheckpointWriter`

### DIFF
--- a/bin/reth/src/debug_cmd/execution.rs
+++ b/bin/reth/src/debug_cmd/execution.rs
@@ -26,7 +26,7 @@ use reth_interfaces::{
 use reth_network::NetworkHandle;
 use reth_network_api::NetworkInfo;
 use reth_primitives::{stage::StageId, BlockHashOrNumber, BlockNumber, ChainSpec, H256};
-use reth_provider::{ProviderFactory, StageCheckpointProvider};
+use reth_provider::{ProviderFactory, StageCheckpointReader};
 use reth_staged_sync::utils::init::{init_db, init_genesis};
 use reth_stages::{
     sets::DefaultStages,

--- a/bin/reth/src/debug_cmd/merkle.rs
+++ b/bin/reth/src/debug_cmd/merkle.rs
@@ -9,7 +9,7 @@ use reth_primitives::{
     stage::{StageCheckpoint, StageId},
     ChainSpec,
 };
-use reth_provider::ProviderFactory;
+use reth_provider::{ProviderFactory, StageCheckpointProvider};
 use reth_staged_sync::utils::init::init_db;
 use reth_stages::{
     stages::{

--- a/bin/reth/src/debug_cmd/merkle.rs
+++ b/bin/reth/src/debug_cmd/merkle.rs
@@ -9,7 +9,7 @@ use reth_primitives::{
     stage::{StageCheckpoint, StageId},
     ChainSpec,
 };
-use reth_provider::{ProviderFactory, StageCheckpointProvider};
+use reth_provider::{ProviderFactory, StageCheckpointReader};
 use reth_staged_sync::utils::init::init_db;
 use reth_stages::{
     stages::{

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -42,7 +42,7 @@ use reth_network_api::NetworkInfo;
 use reth_primitives::{stage::StageId, BlockHashOrNumber, ChainSpec, Head, SealedHeader, H256};
 use reth_provider::{
     BlockHashProvider, BlockProvider, CanonStateSubscriptions, HeaderProvider, ProviderFactory,
-    StageCheckpointProvider,
+    StageCheckpointReader,
 };
 use reth_revm::Factory;
 use reth_revm_inspectors::stack::Hook;

--- a/bin/reth/src/stage/run.rs
+++ b/bin/reth/src/stage/run.rs
@@ -12,7 +12,7 @@ use reth_beacon_consensus::BeaconConsensus;
 use reth_config::Config;
 use reth_downloaders::bodies::bodies::BodiesDownloaderBuilder;
 use reth_primitives::ChainSpec;
-use reth_provider::{ProviderFactory, StageCheckpointProvider};
+use reth_provider::{ProviderFactory, StageCheckpointReader};
 use reth_staged_sync::utils::init::init_db;
 use reth_stages::{
     stages::{

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -21,7 +21,7 @@ use reth_primitives::{
     SealedHeader, H256, U256,
 };
 use reth_provider::{
-    BlockProvider, BlockSource, CanonChainTracker, ProviderError, StageCheckpointProvider,
+    BlockProvider, BlockSource, CanonChainTracker, ProviderError, StageCheckpointReader,
 };
 use reth_rpc_types::engine::{
     ExecutionPayload, ForkchoiceUpdated, PayloadAttributes, PayloadStatus, PayloadStatusEnum,
@@ -210,7 +210,7 @@ pub struct BeaconConsensusEngine<DB, BT, Client>
 where
     DB: Database,
     Client: HeadersClient + BodiesClient,
-    BT: BlockchainTreeEngine + BlockProvider + CanonChainTracker + StageCheckpointProvider,
+    BT: BlockchainTreeEngine + BlockProvider + CanonChainTracker + StageCheckpointReader,
 {
     /// Controls syncing triggered by engine updates.
     sync: EngineSyncController<DB, Client>,
@@ -238,11 +238,7 @@ where
 impl<DB, BT, Client> BeaconConsensusEngine<DB, BT, Client>
 where
     DB: Database + Unpin + 'static,
-    BT: BlockchainTreeEngine
-        + BlockProvider
-        + CanonChainTracker
-        + StageCheckpointProvider
-        + 'static,
+    BT: BlockchainTreeEngine + BlockProvider + CanonChainTracker + StageCheckpointReader + 'static,
     Client: HeadersClient + BodiesClient + Clone + Unpin + 'static,
 {
     /// Create a new instance of the [BeaconConsensusEngine].
@@ -1235,7 +1231,7 @@ where
     BT: BlockchainTreeEngine
         + BlockProvider
         + CanonChainTracker
-        + StageCheckpointProvider
+        + StageCheckpointReader
         + Unpin
         + 'static,
 {

--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -6,7 +6,10 @@ use reth_primitives::{
     constants::BEACON_CONSENSUS_REORG_UNWIND_DEPTH, listener::EventListeners, stage::StageId,
     BlockNumber, ChainSpec, H256,
 };
-use reth_provider::{providers::get_stage_checkpoint, ProviderFactory};
+use reth_provider::{
+    providers::get_stage_checkpoint, ProviderFactory, StageCheckpointProvider,
+    StageCheckpointWriter,
+};
 use std::{pin::Pin, sync::Arc};
 use tokio::sync::watch;
 use tokio_stream::wrappers::UnboundedReceiverStream;

--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -6,7 +6,7 @@ use reth_primitives::{
     constants::BEACON_CONSENSUS_REORG_UNWIND_DEPTH, listener::EventListeners, stage::StageId,
     BlockNumber, ChainSpec, H256,
 };
-use reth_provider::{ProviderFactory, StageCheckpointProvider, StageCheckpointWriter};
+use reth_provider::{ProviderFactory, StageCheckpointReader, StageCheckpointWriter};
 use std::{pin::Pin, sync::Arc};
 use tokio::sync::watch;
 use tokio_stream::wrappers::UnboundedReceiverStream;

--- a/crates/stages/src/stages/merkle.rs
+++ b/crates/stages/src/stages/merkle.rs
@@ -13,8 +13,7 @@ use reth_primitives::{
     BlockNumber, SealedHeader, H256,
 };
 use reth_provider::{
-    DatabaseProviderRW, HeaderProvider, ProviderError, StageCheckpointProvider,
-    StageCheckpointWriter,
+    DatabaseProviderRW, HeaderProvider, ProviderError, StageCheckpointReader, StageCheckpointWriter,
 };
 use reth_trie::{IntermediateStateRootState, StateRoot, StateRootProgress};
 use std::fmt::Debug;

--- a/crates/stages/src/stages/merkle.rs
+++ b/crates/stages/src/stages/merkle.rs
@@ -12,7 +12,10 @@ use reth_primitives::{
     trie::StoredSubNode,
     BlockNumber, SealedHeader, H256,
 };
-use reth_provider::{DatabaseProviderRW, HeaderProvider, ProviderError};
+use reth_provider::{
+    DatabaseProviderRW, HeaderProvider, ProviderError, StageCheckpointProvider,
+    StageCheckpointWriter,
+};
 use reth_trie::{IntermediateStateRootState, StateRoot, StateRootProgress};
 use std::fmt::Debug;
 use tracing::*;

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -16,7 +16,7 @@ pub use traits::{
     BlockchainTreePendingStateProvider, CanonChainTracker, CanonStateNotification,
     CanonStateNotificationSender, CanonStateNotifications, CanonStateSubscriptions, EvmEnvProvider,
     ExecutorFactory, HeaderProvider, PostStateDataProvider, ReceiptProvider, ReceiptProviderIdExt,
-    StageCheckpointProvider, StageCheckpointWriter, StateProvider, StateProviderBox,
+    StageCheckpointReader, StageCheckpointWriter, StateProvider, StateProviderBox,
     StateProviderFactory, StateRootProvider, TransactionsProvider, WithdrawalsProvider,
 };
 

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -16,8 +16,8 @@ pub use traits::{
     BlockchainTreePendingStateProvider, CanonChainTracker, CanonStateNotification,
     CanonStateNotificationSender, CanonStateNotifications, CanonStateSubscriptions, EvmEnvProvider,
     ExecutorFactory, HeaderProvider, PostStateDataProvider, ReceiptProvider, ReceiptProviderIdExt,
-    StageCheckpointProvider, StateProvider, StateProviderBox, StateProviderFactory,
-    StateRootProvider, TransactionsProvider, WithdrawalsProvider,
+    StageCheckpointProvider, StageCheckpointWriter, StateProvider, StateProviderBox,
+    StateProviderFactory, StateRootProvider, TransactionsProvider, WithdrawalsProvider,
 };
 
 /// Provider trait implementations.

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -280,6 +280,10 @@ impl<DB: Database> StageCheckpointProvider for ProviderFactory<DB> {
     fn get_stage_checkpoint(&self, id: StageId) -> Result<Option<StageCheckpoint>> {
         self.provider()?.get_stage_checkpoint(id)
     }
+
+    fn get_stage_checkpoint_progress(&self, id: StageId) -> Result<Option<Vec<u8>>> {
+        self.provider()?.get_stage_checkpoint_progress(id)
+    }
 }
 
 impl<DB: Database> EvmEnvProvider for ProviderFactory<DB> {

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     providers::state::{historical::HistoricalStateProvider, latest::LatestStateProvider},
     traits::{BlockSource, ReceiptProvider},
     BlockHashProvider, BlockNumProvider, BlockProvider, EvmEnvProvider, HeaderProvider,
-    ProviderError, StageCheckpointProvider, StateProviderBox, TransactionsProvider,
+    ProviderError, StageCheckpointReader, StateProviderBox, TransactionsProvider,
     WithdrawalsProvider,
 };
 use reth_db::{database::Database, models::StoredBlockBodyIndices};
@@ -280,7 +280,7 @@ impl<DB: Database> WithdrawalsProvider for ProviderFactory<DB> {
     }
 }
 
-impl<DB: Database> StageCheckpointProvider for ProviderFactory<DB> {
+impl<DB: Database> StageCheckpointReader for ProviderFactory<DB> {
     fn get_stage_checkpoint(&self, id: StageId) -> Result<Option<StageCheckpoint>> {
         self.provider()?.get_stage_checkpoint(id)
     }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -3,7 +3,7 @@ use crate::{
     post_state::StorageChangeset,
     traits::{AccountExtProvider, BlockSource, ReceiptProvider, StageCheckpointWriter},
     AccountProvider, BlockHashProvider, BlockNumProvider, BlockProvider, EvmEnvProvider,
-    HeaderProvider, PostState, ProviderError, StageCheckpointProvider, TransactionError,
+    HeaderProvider, PostState, ProviderError, StageCheckpointReader, TransactionError,
     TransactionsProvider, WithdrawalsProvider,
 };
 use itertools::{izip, Itertools};
@@ -1839,7 +1839,7 @@ impl<'this, TX: DbTx<'this>> EvmEnvProvider for DatabaseProvider<'this, TX> {
     }
 }
 
-impl<'this, TX: DbTx<'this>> StageCheckpointProvider for DatabaseProvider<'this, TX> {
+impl<'this, TX: DbTx<'this>> StageCheckpointReader for DatabaseProvider<'this, TX> {
     fn get_stage_checkpoint(&self, id: StageId) -> Result<Option<StageCheckpoint>> {
         Ok(self.tx.get::<tables::SyncStage>(id.to_string())?)
     }

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -348,6 +348,10 @@ where
     fn get_stage_checkpoint(&self, id: StageId) -> Result<Option<StageCheckpoint>> {
         self.database.provider()?.get_stage_checkpoint(id)
     }
+
+    fn get_stage_checkpoint_progress(&self, id: StageId) -> Result<Option<Vec<u8>>> {
+        self.database.provider()?.get_stage_checkpoint_progress(id)
+    }
 }
 
 impl<DB, Tree> EvmEnvProvider for BlockchainProvider<DB, Tree>

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     BlockHashProvider, BlockIdProvider, BlockNumProvider, BlockProvider, BlockProviderIdExt,
     BlockchainTreePendingStateProvider, CanonChainTracker, CanonStateNotifications,
     CanonStateSubscriptions, EvmEnvProvider, HeaderProvider, PostStateDataProvider, ProviderError,
-    ReceiptProvider, StageCheckpointProvider, StateProviderBox, StateProviderFactory,
+    ReceiptProvider, StageCheckpointReader, StateProviderBox, StateProviderFactory,
     TransactionsProvider, WithdrawalsProvider,
 };
 use reth_db::{database::Database, models::StoredBlockBodyIndices};
@@ -344,7 +344,7 @@ where
     }
 }
 
-impl<DB, Tree> StageCheckpointProvider for BlockchainProvider<DB, Tree>
+impl<DB, Tree> StageCheckpointReader for BlockchainProvider<DB, Tree>
 where
     DB: Database,
     Tree: Send + Sync,

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -311,6 +311,10 @@ impl StageCheckpointProvider for NoopProvider {
     fn get_stage_checkpoint(&self, _id: StageId) -> Result<Option<StageCheckpoint>> {
         Ok(None)
     }
+
+    fn get_stage_checkpoint_progress(&self, _id: StageId) -> Result<Option<Vec<u8>>> {
+        Ok(None)
+    }
 }
 
 impl WithdrawalsProvider for NoopProvider {

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -1,7 +1,7 @@
 use crate::{
     traits::{BlockSource, ReceiptProvider},
     AccountProvider, BlockHashProvider, BlockIdProvider, BlockNumProvider, BlockProvider,
-    BlockProviderIdExt, EvmEnvProvider, HeaderProvider, PostState, StageCheckpointProvider,
+    BlockProviderIdExt, EvmEnvProvider, HeaderProvider, PostState, StageCheckpointReader,
     StateProvider, StateProviderBox, StateProviderFactory, StateRootProvider, TransactionsProvider,
     WithdrawalsProvider,
 };
@@ -311,7 +311,7 @@ impl StateProviderFactory for NoopProvider {
     }
 }
 
-impl StageCheckpointProvider for NoopProvider {
+impl StageCheckpointReader for NoopProvider {
     fn get_stage_checkpoint(&self, _id: StageId) -> Result<Option<StageCheckpoint>> {
         Ok(None)
     }

--- a/crates/storage/provider/src/traits/mod.rs
+++ b/crates/storage/provider/src/traits/mod.rs
@@ -46,4 +46,4 @@ pub use chain::{
 };
 
 mod stage_checkpoint;
-pub use stage_checkpoint::StageCheckpointProvider;
+pub use stage_checkpoint::{StageCheckpointProvider, StageCheckpointWriter};

--- a/crates/storage/provider/src/traits/mod.rs
+++ b/crates/storage/provider/src/traits/mod.rs
@@ -46,4 +46,4 @@ pub use chain::{
 };
 
 mod stage_checkpoint;
-pub use stage_checkpoint::{StageCheckpointProvider, StageCheckpointWriter};
+pub use stage_checkpoint::{StageCheckpointReader, StageCheckpointWriter};

--- a/crates/storage/provider/src/traits/stage_checkpoint.rs
+++ b/crates/storage/provider/src/traits/stage_checkpoint.rs
@@ -3,7 +3,7 @@ use reth_primitives::stage::{StageCheckpoint, StageId};
 
 /// The trait for fetching stage checkpoint related data.
 #[auto_impl::auto_impl(&, Arc)]
-pub trait StageCheckpointProvider: Send + Sync {
+pub trait StageCheckpointReader: Send + Sync {
     /// Fetch the checkpoint for the given stage.
     fn get_stage_checkpoint(&self, id: StageId) -> Result<Option<StageCheckpoint>>;
 

--- a/crates/storage/provider/src/traits/stage_checkpoint.rs
+++ b/crates/storage/provider/src/traits/stage_checkpoint.rs
@@ -6,4 +6,17 @@ use reth_primitives::stage::{StageCheckpoint, StageId};
 pub trait StageCheckpointProvider: Send + Sync {
     /// Fetch the checkpoint for the given stage.
     fn get_stage_checkpoint(&self, id: StageId) -> Result<Option<StageCheckpoint>>;
+
+    /// Get stage checkpoint progress.
+    fn get_stage_checkpoint_progress(&self, id: StageId) -> Result<Option<Vec<u8>>>;
+}
+
+/// The trait for updating stage checkpoint related data.
+#[auto_impl::auto_impl(&, Arc)]
+pub trait StageCheckpointWriter: Send + Sync {
+    /// Save stage checkpoint.
+    fn save_stage_checkpoint(&self, id: StageId, checkpoint: StageCheckpoint) -> Result<()>;
+
+    /// Save stage checkpoint progress.
+    fn save_stage_checkpoint_progress(&self, id: StageId, checkpoint: Vec<u8>) -> Result<()>;
 }


### PR DESCRIPTION
Introduces the first writer provider: `StageCheckpointWriter`. Does it make sense?

 Open to name/structural changes.