### PR TITLE
chore(provider): remove transition terminology

### DIFF
--- a/crates/stages/src/stages/index_account_history.rs
+++ b/crates/stages/src/stages/index_account_history.rs
@@ -39,7 +39,7 @@ impl<DB: Database> Stage<DB> for IndexAccountHistoryStage {
 
         let (range, is_final_range) = input.next_block_range_with_threshold(self.commit_threshold);
 
-        let indices = provider.get_account_transition_ids_from_changeset(range.clone())?;
+        let indices = provider.get_account_block_numbers_from_changesets(range.clone())?;
         // Insert changeset to history index
         provider.insert_account_history_index(indices)?;
 

--- a/crates/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/src/stages/index_storage_history.rs
@@ -39,7 +39,7 @@ impl<DB: Database> Stage<DB> for IndexStorageHistoryStage {
 
         let (range, is_final_range) = input.next_block_range_with_threshold(self.commit_threshold);
 
-        let indices = provider.get_storage_transition_ids_from_changeset(range.clone())?;
+        let indices = provider.get_storage_block_numbers_from_changesets(range.clone())?;
         provider.insert_storage_history_index(indices)?;
 
         Ok(ExecOutput { checkpoint: StageCheckpoint::new(*range.end()), done: is_final_range })

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -120,7 +120,7 @@ fn unwind_account_history_shards<'a, TX: reth_db::transaction::DbTxMutGAT<'a>>(
             break
         }
         cursor.delete_current()?;
-        // check first item and if it is more and eq than `transition_id` delete current
+        // check first item and if it is more and eq than `block_number` delete current
         // item.
         let first = list.iter(0).next().expect("List can't empty");
         if first >= block_number as usize {
@@ -159,7 +159,7 @@ fn unwind_storage_history_shards<'a, TX: reth_db::transaction::DbTxMutGAT<'a>>(
             break
         }
         cursor.delete_current()?;
-        // check first item and if it is more and eq than `transition_id` delete current
+        // check first item and if it is more and eq than `block_number` delete current
         // item.
         let first = list.iter(0).next().expect("List can't empty");
         if first >= block_number as usize {
@@ -252,10 +252,10 @@ impl<'this, TX: DbTx<'this>> DatabaseProvider<'this, TX> {
             .collect::<std::result::Result<Vec<(_, _)>, _>>()
     }
 
-    /// Get all transaction ids where account got changed.
+    /// Get all block numbers where account got changed.
     ///
     /// NOTE: Get inclusive range of blocks.
-    pub fn get_storage_transition_ids_from_changeset(
+    pub fn get_storage_block_numbers_from_changesets(
         &self,
         range: RangeInclusive<BlockNumber>,
     ) -> std::result::Result<BTreeMap<(Address, H256), Vec<u64>>, TransactionError> {
@@ -279,10 +279,10 @@ impl<'this, TX: DbTx<'this>> DatabaseProvider<'this, TX> {
         Ok(storage_changeset_lists)
     }
 
-    /// Get all transaction ids where account got changed.
+    /// Get all block numbers where account got changed.
     ///
     /// NOTE: Get inclusive range of blocks.
-    pub fn get_account_transition_ids_from_changeset(
+    pub fn get_account_block_numbers_from_changesets(
         &self,
         range: RangeInclusive<BlockNumber>,
     ) -> std::result::Result<BTreeMap<Address, Vec<u64>>, TransactionError> {
@@ -363,7 +363,7 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> DatabaseProvider<'this, TX> {
     ) -> std::result::Result<(), TransactionError> {
         let mut hashed_accounts = self.tx.cursor_write::<tables::HashedAccount>()?;
 
-        // Aggregate all transition changesets and make a list of accounts that have been changed.
+        // Aggregate all block changesets and make a list of accounts that have been changed.
         self.tx
             .cursor_read::<tables::AccountChangeSet>()?
             .walk_range(range)?
@@ -406,7 +406,7 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> DatabaseProvider<'this, TX> {
     ) -> std::result::Result<(), TransactionError> {
         let mut hashed_storage = self.tx.cursor_dup_write::<tables::HashedStorage>()?;
 
-        // Aggregate all transition changesets and make list of accounts that have been changed.
+        // Aggregate all block changesets and make list of accounts that have been changed.
         self.tx
             .cursor_read::<tables::StorageChangeSet>()?
             .walk_range(range)?
@@ -465,11 +465,11 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> DatabaseProvider<'this, TX> {
 
         let last_indices = account_changeset
             .into_iter()
-            // reverse so we can get lowest transition id where we need to unwind account.
+            // reverse so we can get lowest block number where we need to unwind account.
             .rev()
-            // fold all account and get last transition index
+            // fold all account and get last block number
             .fold(BTreeMap::new(), |mut accounts: BTreeMap<Address, u64>, (index, account)| {
-                // we just need address and lowest transition id.
+                // we just need address and lowest block number.
                 accounts.insert(account.address, index);
                 accounts
             });
@@ -508,13 +508,13 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> DatabaseProvider<'this, TX> {
 
         let last_indices = storage_changesets
             .into_iter()
-            // reverse so we can get lowest transition id where we need to unwind account.
+            // reverse so we can get lowest block number where we need to unwind account.
             .rev()
-            // fold all storages and get last transition index
+            // fold all storages and get last block number
             .fold(
                 BTreeMap::new(),
                 |mut accounts: BTreeMap<(Address, H256), u64>, (index, storage)| {
-                    // we just need address and lowest transition id.
+                    // we just need address and lowest block number.
                     accounts.insert((index.address(), storage.key), index.block_number());
                     accounts
                 },
@@ -543,7 +543,7 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> DatabaseProvider<'this, TX> {
     /// of blocks.
     ///
     /// 1. Iterate over the [BlockBodyIndices][tables::BlockBodyIndices] table to get all
-    /// the transition indices.
+    /// the transaction ids.
     /// 2. Iterate over the [StorageChangeSet][tables::StorageChangeSet] table
     /// and the [AccountChangeSet][tables::AccountChangeSet] tables in reverse order to reconstruct
     /// the changesets.
@@ -570,7 +570,7 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> DatabaseProvider<'this, TX> {
             return Ok(Vec::new())
         }
 
-        // We are not removing block meta as it is used to get block transitions.
+        // We are not removing block meta as it is used to get block changesets.
         let block_bodies = self.get_or_take::<tables::BlockBodyIndices, false>(range.clone())?;
 
         // get transaction receipts
@@ -1372,13 +1372,13 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> DatabaseProvider<'this, TX> {
     ) -> std::result::Result<(), TransactionError> {
         // account history stage
         {
-            let indices = self.get_account_transition_ids_from_changeset(range.clone())?;
+            let indices = self.get_account_block_numbers_from_changesets(range.clone())?;
             self.insert_account_history_index(indices)?;
         }
 
         // storage history stage
         {
-            let indices = self.get_storage_transition_ids_from_changeset(range)?;
+            let indices = self.get_storage_block_numbers_from_changesets(range)?;
             self.insert_storage_history_index(indices)?;
         }
 
@@ -1388,8 +1388,7 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> DatabaseProvider<'this, TX> {
     /// Calculate the hashes of all changed accounts and storages, and finally calculate the state
     /// root.
     ///
-    /// The chain goes from `fork_block_number + 1` to `current_block_number`, and hashes are
-    /// calculated from `from_transition_id` to `to_transition_id`.
+    /// The hashes are calculated from `fork_block_number + 1` to `current_block_number`.
     ///
     /// The resulting state root is compared with `expected_state_root`.
     pub fn insert_hashes(


### PR DESCRIPTION
## Description

Transition terminology is a leftover from when we used transaction level changesets. Remove it from the provider.