### PR TITLE
feat: support nonce and balance changes in state diff tracers

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/builder/mod.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/mod.rs
@@ -1,4 +1,7 @@
 //! Builder types for building traces
 
-pub(crate) mod geth;
-pub(crate) mod parity;
+/// Geth style trace builders for `debug_` namespace
+pub mod geth;
+
+/// Parity style trace builders for `trace_` namespace
+pub mod parity;

--- a/crates/revm/revm-inspectors/src/tracing/mod.rs
+++ b/crates/revm/revm-inspectors/src/tracing/mod.rs
@@ -25,7 +25,10 @@ use crate::tracing::{
     arena::PushTraceKind,
     types::{CallTraceNode, StorageChange},
 };
-pub use builder::{geth::GethTraceBuilder, parity::ParityTraceBuilder};
+pub use builder::{
+    geth::{self, GethTraceBuilder},
+    parity::{self, ParityTraceBuilder},
+};
 pub use config::TracingInspectorConfig;
 pub use fourbyte::FourByteInspector;
 pub use opcount::OpcodeCountInspector;

--- a/crates/revm/revm-inspectors/src/tracing/types.rs
+++ b/crates/revm/revm-inspectors/src/tracing/types.rs
@@ -268,8 +268,6 @@ impl CallTraceNode {
             }
         }
 
-        // TODO: track nonce and balance changes
-
         // iterate over all storage diffs
         for change in self.trace.steps.iter().filter_map(|s| s.storage_change) {
             let StorageChange { key, value, had_value } = change;


### PR DESCRIPTION
Closes #2919

This integrates account.balance+nonce statediffs by comparing the all AccountInfo after the transaction against before.