### PR TITLE
feat(txpool): add price bump for `is_underpriced` transaction check

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -138,6 +138,9 @@ pub(crate) const MAX_CODE_SIZE: usize = 24576;
 // Maximum initcode to permit in a creation transaction and create instructions
 pub(crate) const MAX_INIT_CODE_SIZE: usize = 2 * MAX_CODE_SIZE;
 
+// Price bump (in %) for the transaction pool underpriced check
+pub(crate) const PRICE_BUMP: u128 = 10;
+
 /// A shareable, generic, customizable `TransactionPool` implementation.
 #[derive(Debug)]
 pub struct Pool<V: TransactionValidator, T: TransactionOrdering> {

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -975,13 +975,16 @@ impl<T: PoolTransaction> AllTransactions<T> {
         transaction_b: &ValidPoolTransaction<T>,
         price_bump: u128,
     ) -> bool {
-        let tx_a_max_fee_per_gas = transaction_a.max_fee_per_gas();
         let tx_a_max_priority_fee_per_gas =
             transaction_a.transaction.max_priority_fee_per_gas().unwrap_or(0);
+        let tx_b_max_priority_fee_per_gas =
+            transaction_b.transaction.max_priority_fee_per_gas().unwrap_or(0);
 
-        tx_a_max_fee_per_gas < tx_a_max_fee_per_gas * (100 + price_bump) / 100 ||
-            tx_a_max_priority_fee_per_gas <
-                tx_a_max_priority_fee_per_gas * (100 + price_bump) / 100 ||
+        transaction_a.max_fee_per_gas() < transaction_b.max_fee_per_gas() * (100 + price_bump) / 100 ||
+            (tx_a_max_priority_fee_per_gas <
+                tx_b_max_priority_fee_per_gas * (100 + price_bump) / 100 &&
+                tx_a_max_priority_fee_per_gas != 0 &&
+                tx_b_max_priority_fee_per_gas != 0) ||
             transaction_a.effective_gas_price() < transaction_b.effective_gas_price()
     }
 

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -985,7 +985,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
                 tx_b_max_priority_fee_per_gas * (100 + price_bump) / 100 &&
                 tx_a_max_priority_fee_per_gas != 0 &&
                 tx_b_max_priority_fee_per_gas != 0) ||
-            transaction_a.effective_gas_price() < transaction_b.effective_gas_price()
+            transaction_a.effective_gas_price() <= transaction_b.effective_gas_price()
     }
 
     /// Inserts a new transaction into the pool.

--- a/crates/transaction-pool/src/validate.rs
+++ b/crates/transaction-pool/src/validate.rs
@@ -4,7 +4,7 @@ use crate::{
     error::InvalidPoolTransactionError,
     identifier::{SenderId, TransactionId},
     traits::{PoolTransaction, TransactionOrigin},
-    MAX_INIT_CODE_SIZE, TX_MAX_SIZE,
+    MAX_INIT_CODE_SIZE, PRICE_BUMP, TX_MAX_SIZE,
 };
 use reth_primitives::{
     Address, ChainSpec, IntoRecoveredTransaction, InvalidTransactionError, TransactionKind,
@@ -369,7 +369,8 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
 
     /// Returns true if this transaction is underpriced compared to the other.
     pub(crate) fn is_underpriced(&self, other: &Self) -> bool {
-        self.transaction.effective_gas_price() <= other.transaction.effective_gas_price()
+        self.transaction.effective_gas_price() * (100 + PRICE_BUMP) / 100 <=
+            other.transaction.effective_gas_price()
     }
 
     /// Whether the transaction originated locally.

--- a/crates/transaction-pool/src/validate.rs
+++ b/crates/transaction-pool/src/validate.rs
@@ -4,7 +4,7 @@ use crate::{
     error::InvalidPoolTransactionError,
     identifier::{SenderId, TransactionId},
     traits::{PoolTransaction, TransactionOrigin},
-    MAX_INIT_CODE_SIZE, PRICE_BUMP, TX_MAX_SIZE,
+    MAX_INIT_CODE_SIZE, TX_MAX_SIZE,
 };
 use reth_primitives::{
     Address, ChainSpec, IntoRecoveredTransaction, InvalidTransactionError, TransactionKind,
@@ -365,12 +365,6 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
     /// Amount of gas that should be used in executing this transaction. This is paid up-front.
     pub fn gas_limit(&self) -> u64 {
         self.transaction.gas_limit()
-    }
-
-    /// Returns true if this transaction is underpriced compared to the other.
-    pub(crate) fn is_underpriced(&self, other: &Self) -> bool {
-        self.transaction.effective_gas_price() * (100 + PRICE_BUMP) / 100 <=
-            other.transaction.effective_gas_price()
     }
 
     /// Whether the transaction originated locally.


### PR DESCRIPTION
In go-ethereum implementation, the verification for transaction underpricing includes a price bump following the formula: `gas * (100 + priceBump) / 100`. 

In the default configuration, price bump is 10 %: https://github.com/ethereum/go-ethereum/blob/73697529994e14996b7740730481e926d5ec3e40/core/txpool/txpool.go#L188.

As a result, in this PR, a 10% price bump constant is proposed and implemented inside the `is_underpriced` transaction check.

Should solve #2958.
