### PR TITLE
feat(rpc): use log indices for address and topic filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5626,6 +5626,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "itertools",
  "jsonrpsee",
  "jsonwebtoken",
  "pin-project",

--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -8,7 +8,8 @@ use clap::{
 use futures::TryFutureExt;
 use reth_network_api::{NetworkInfo, Peers};
 use reth_provider::{
-    BlockReaderIdExt, CanonStateSubscriptions, EvmEnvProvider, HeaderProvider, StateProviderFactory,
+    BlockReaderIdExt, CanonStateSubscriptions, EvmEnvProvider, HeaderProvider, LogIndexProvider,
+    StateProviderFactory,
 };
 use reth_rpc::{
     eth::{
@@ -251,6 +252,7 @@ impl RpcServerArgs {
             + HeaderProvider
             + StateProviderFactory
             + EvmEnvProvider
+            + LogIndexProvider
             + Clone
             + Unpin
             + 'static,
@@ -311,6 +313,7 @@ impl RpcServerArgs {
             + HeaderProvider
             + StateProviderFactory
             + EvmEnvProvider
+            + LogIndexProvider
             + Clone
             + Unpin
             + 'static,
@@ -346,6 +349,7 @@ impl RpcServerArgs {
             + HeaderProvider
             + StateProviderFactory
             + EvmEnvProvider
+            + LogIndexProvider
             + Clone
             + Unpin
             + 'static,

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -475,6 +475,10 @@ mod tests {
             Ok(vec![])
         }
 
+        fn headers(&self, _numbers: &[BlockNumber]) -> Result<Vec<Option<Header>>> {
+            Ok(vec![])
+        }
+
         fn sealed_headers_range(
             &self,
             _range: impl RangeBounds<BlockNumber>,

--- a/crates/rpc/rpc-builder/src/auth.rs
+++ b/crates/rpc/rpc-builder/src/auth.rs
@@ -11,7 +11,8 @@ use jsonrpsee::{
 };
 use reth_network_api::{NetworkInfo, Peers};
 use reth_provider::{
-    BlockReaderIdExt, EvmEnvProvider, HeaderProvider, ReceiptProviderIdExt, StateProviderFactory,
+    BlockReaderIdExt, EvmEnvProvider, HeaderProvider, LogIndexProvider, ReceiptProviderIdExt,
+    StateProviderFactory,
 };
 use reth_rpc::{
     eth::{cache::EthStateCache, gas_oracle::GasPriceOracle},
@@ -43,6 +44,7 @@ where
         + HeaderProvider
         + StateProviderFactory
         + EvmEnvProvider
+        + LogIndexProvider
         + Clone
         + Unpin
         + 'static,
@@ -86,6 +88,7 @@ where
         + HeaderProvider
         + StateProviderFactory
         + EvmEnvProvider
+        + LogIndexProvider
         + Clone
         + Unpin
         + 'static,

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -113,7 +113,8 @@ use jsonrpsee::{
 use reth_ipc::server::IpcServer;
 use reth_network_api::{NetworkInfo, Peers};
 use reth_provider::{
-    BlockReader, BlockReaderIdExt, CanonStateSubscriptions, EvmEnvProvider, StateProviderFactory,
+    BlockReader, BlockReaderIdExt, CanonStateSubscriptions, EvmEnvProvider, LogIndexProvider,
+    StateProviderFactory,
 };
 use reth_rpc::{
     eth::{
@@ -169,7 +170,13 @@ pub async fn launch<Provider, Pool, Network, Tasks, Events>(
     events: Events,
 ) -> Result<RpcServerHandle, RpcError>
 where
-    Provider: BlockReaderIdExt + StateProviderFactory + EvmEnvProvider + Clone + Unpin + 'static,
+    Provider: BlockReaderIdExt
+        + StateProviderFactory
+        + EvmEnvProvider
+        + LogIndexProvider
+        + Clone
+        + Unpin
+        + 'static,
     Pool: TransactionPool + Clone + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,
@@ -268,7 +275,13 @@ impl<Provider, Pool, Network, Tasks, Events>
 impl<Provider, Pool, Network, Tasks, Events>
     RpcModuleBuilder<Provider, Pool, Network, Tasks, Events>
 where
-    Provider: BlockReaderIdExt + StateProviderFactory + EvmEnvProvider + Clone + Unpin + 'static,
+    Provider: BlockReaderIdExt
+        + StateProviderFactory
+        + EvmEnvProvider
+        + LogIndexProvider
+        + Clone
+        + Unpin
+        + 'static,
     Pool: TransactionPool + Clone + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,
@@ -485,8 +498,13 @@ impl RpcModuleSelection {
         config: RpcModuleConfig,
     ) -> RpcModule<()>
     where
-        Provider:
-            BlockReaderIdExt + StateProviderFactory + EvmEnvProvider + Clone + Unpin + 'static,
+        Provider: BlockReaderIdExt
+            + StateProviderFactory
+            + EvmEnvProvider
+            + LogIndexProvider
+            + Clone
+            + Unpin
+            + 'static,
         Pool: TransactionPool + Clone + 'static,
         Network: NetworkInfo + Peers + Clone + 'static,
         Tasks: TaskSpawner + Clone + 'static,
@@ -692,7 +710,13 @@ where
 impl<Provider, Pool, Network, Tasks, Events>
     RethModuleRegistry<Provider, Pool, Network, Tasks, Events>
 where
-    Provider: BlockReaderIdExt + StateProviderFactory + EvmEnvProvider + Clone + Unpin + 'static,
+    Provider: BlockReaderIdExt
+        + StateProviderFactory
+        + EvmEnvProvider
+        + LogIndexProvider
+        + Clone
+        + Unpin
+        + 'static,
     Pool: TransactionPool + Clone + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -58,6 +58,7 @@ tracing = { workspace = true }
 tracing-futures = "0.2"
 schnellru = "0.2"
 futures = { workspace = true }
+itertools = "0.10"
 
 [dev-dependencies]
 jsonrpsee = { version = "0.18", features = ["client"] }

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -8,11 +8,16 @@ use crate::{
     EthSubscriptionIdProvider,
 };
 use async_trait::async_trait;
+use itertools::Itertools;
 use jsonrpsee::{core::RpcResult, server::IdProvider};
-use reth_primitives::{BlockHashOrNumber, Receipt, SealedBlock};
-use reth_provider::{BlockIdReader, BlockReader, EvmEnvProvider};
+use reth_primitives::{
+    Address, BlockHashOrNumber, BlockNumber, IntegerList, Receipt, SealedBlock, H256,
+};
+use reth_provider::{BlockIdReader, BlockReader, EvmEnvProvider, LogIndexProvider};
 use reth_rpc_api::EthFilterApiServer;
-use reth_rpc_types::{Filter, FilterBlockOption, FilterChanges, FilterId, FilteredParams, Log};
+use reth_rpc_types::{
+    Filter, FilterBlockOption, FilterChanges, FilterId, FilteredParams, Log, ValueOrArray,
+};
 use reth_tasks::TaskSpawner;
 use reth_transaction_pool::TransactionPool;
 use std::{
@@ -66,7 +71,7 @@ impl<Provider, Pool> EthFilter<Provider, Pool> {
 
 impl<Provider, Pool> EthFilter<Provider, Pool>
 where
-    Provider: BlockReader + BlockIdReader + EvmEnvProvider + 'static,
+    Provider: BlockReader + BlockIdReader + EvmEnvProvider + LogIndexProvider + 'static,
     Pool: TransactionPool + 'static,
 {
     /// Executes the given filter on a new task.
@@ -178,7 +183,7 @@ where
 #[async_trait]
 impl<Provider, Pool> EthFilterApiServer for EthFilter<Provider, Pool>
 where
-    Provider: BlockReader + BlockIdReader + EvmEnvProvider + 'static,
+    Provider: BlockReader + BlockIdReader + EvmEnvProvider + LogIndexProvider + 'static,
     Pool: TransactionPool + 'static,
 {
     /// Handler for `eth_newFilter`
@@ -274,7 +279,7 @@ struct EthFilterInner<Provider, Pool> {
 
 impl<Provider, Pool> EthFilterInner<Provider, Pool>
 where
-    Provider: BlockReader + BlockIdReader + EvmEnvProvider + 'static,
+    Provider: BlockReader + BlockIdReader + EvmEnvProvider + LogIndexProvider + 'static,
     Pool: TransactionPool + 'static,
 {
     /// Returns logs matching given filter object.
@@ -365,54 +370,165 @@ where
 
         let topics = filter.has_topics().then(|| filter_params.flat_topics.clone());
 
-        // derive bloom filters from filter input
-        let address_filter = FilteredParams::address_filter(&filter.address);
-        let topics_filter = FilteredParams::topics_filter(&topics);
+        // Create log index filter
+        let mut log_index_filter =
+            LogIndexFilter::new(from_block..=to_block, self.max_headers_range);
+        if let Some(filter_address) = filter.address.as_ref() {
+            log_index_filter.install_address_filter(&self.provider, filter_address)?;
+        }
+        if let Some(topics) = topics.as_ref() {
+            log_index_filter.install_topic_filter(&self.provider, topics)?;
+        }
 
         // loop over the range of new blocks and check logs if the filter matches the log's bloom
         // filter
-        for (from, to) in
-            BlockRangeInclusiveIter::new(from_block..=to_block, self.max_headers_range)
-        {
-            let headers = self.provider.headers_range(from..=to)?;
+        for block_numbers in log_index_filter.iter() {
+            let headers = self.provider.headers(&block_numbers)?;
 
             for (idx, header) in headers.iter().enumerate() {
-                // these are consecutive headers, so we can use the parent hash of the next block to
-                // get the current header's hash
+                let header = match header {
+                    Some(header) => header,
+                    None => continue,
+                };
+
+                // If the headers are consecutive, we can use the parent hash of the next block to
+                // get the current header's hash.
                 let num_hash: BlockHashOrNumber = headers
                     .get(idx + 1)
-                    .map(|h| h.parent_hash.into())
+                    .and_then(|h| {
+                        h.as_ref()
+                            .filter(|h| header.number + 1 == h.number)
+                            .map(|h| h.parent_hash.into())
+                    })
                     .unwrap_or_else(|| header.number.into());
 
-                // only if filter matches
-                if FilteredParams::matches_address(header.logs_bloom, &address_filter) &&
-                    FilteredParams::matches_topics(header.logs_bloom, &topics_filter)
+                if let Some((block, receipts)) = self.block_and_receipts_by_number(num_hash).await?
                 {
-                    if let Some((block, receipts)) =
-                        self.block_and_receipts_by_number(num_hash).await?
-                    {
-                        let block_hash = block.hash;
+                    let block_hash = block.hash;
 
-                        logs_utils::append_matching_block_logs(
-                            &mut all_logs,
-                            &filter_params,
-                            (block.number, block_hash).into(),
-                            block.body.into_iter().map(|tx| tx.hash()).zip(receipts),
-                            false,
-                        );
+                    logs_utils::append_matching_block_logs(
+                        &mut all_logs,
+                        &filter_params,
+                        (block.number, block_hash).into(),
+                        block.body.into_iter().map(|tx| tx.hash()).zip(receipts),
+                        false,
+                    );
 
-                        // size check
-                        if all_logs.len() > self.max_logs_per_response {
-                            return Err(FilterError::QueryExceedsMaxResults(
-                                self.max_logs_per_response,
-                            ))
-                        }
+                    // size check
+                    if all_logs.len() > self.max_logs_per_response {
+                        return Err(FilterError::QueryExceedsMaxResults(self.max_logs_per_response))
                     }
                 }
             }
         }
 
         Ok(all_logs)
+    }
+}
+
+#[derive(Debug)]
+struct LogIndexFilter {
+    /// Full block range.
+    block_range: RangeInclusive<BlockNumber>,
+    /// The maximum number of headers to read at once for range filter.
+    max_headers_range: u64,
+    /// Represents the union of all block indices that match installed filters.
+    ///
+    /// Since [IntegerList] cannot be empty, `Some(None)` represents an active filter with no
+    /// matching block numbers.
+    indices: Option<Option<IntegerList>>,
+}
+
+impl LogIndexFilter {
+    fn new(block_range: RangeInclusive<BlockNumber>, max_headers_range: u64) -> Self {
+        Self { block_range, max_headers_range, indices: None }
+    }
+
+    fn iter(&self) -> Vec<Vec<BlockNumber>> {
+        match self.indices {
+            Some(Some(ref indices)) => indices
+                .iter(0)
+                .chunks(self.max_headers_range as usize)
+                .into_iter()
+                .map(|chunk| chunk.map(|num| num as u64).collect::<Vec<_>>())
+                .collect::<Vec<_>>(),
+            Some(None) => Vec::new(),
+            None => BlockRangeInclusiveIter::new(self.block_range.clone(), self.max_headers_range)
+                .collect(),
+        }
+    }
+
+    /// Returns `true` if the filter is active but has no matching block numbers.
+    fn is_empty(&self) -> bool {
+        matches!(self.indices, Some(None))
+    }
+
+    /// Change the inner indices to be the union of itself and incoming.
+    fn intersection_indices(&mut self, new_indices: Option<IntegerList>) {
+        match (&mut self.indices, new_indices) {
+            // Existing filter is already empty, no need to update.
+            (Some(None), _) => (),
+            // Incoming filter matched no block numbers, reset existing indices.
+            (_, None) => {
+                self.indices = Some(None);
+            }
+            // Existing filter has not been yet activated, so set it to the incoming indices.
+            (None, Some(new_indices)) => {
+                self.indices = Some(Some(new_indices));
+            }
+            // Both filters contain at least one block number, union them.
+            (Some(Some(existing)), Some(new_indices)) => {
+                self.indices = Some(existing.intersection(&new_indices));
+            }
+        }
+    }
+
+    fn install_address_filter(
+        &mut self,
+        provider: &impl LogIndexProvider,
+        address_filter: &ValueOrArray<Address>,
+    ) -> Result<(), FilterError> {
+        let addresses = match address_filter {
+            ValueOrArray::Value(address) => Vec::from([*address]),
+            ValueOrArray::Array(addresses) => addresses.clone(),
+        };
+        for address in addresses {
+            // Check if previous filter conditions already matched no blocks.
+            // Do this on each iteration to avoid unnecessary queries.
+            if self.is_empty() {
+                return Ok(())
+            }
+
+            let address_indices =
+                provider.log_address_indices(address, self.block_range.clone())?;
+            self.intersection_indices(address_indices);
+        }
+        Ok(())
+    }
+
+    fn install_topic_filter(
+        &mut self,
+        provider: &impl LogIndexProvider,
+        topic_filters: &[ValueOrArray<Option<H256>>],
+    ) -> Result<(), FilterError> {
+        let topics = topic_filters
+            .iter()
+            .flat_map(|topic| match topic {
+                ValueOrArray::Value(topic) => topic.map(|t| Vec::from([t])).unwrap_or_default(),
+                ValueOrArray::Array(topics) => topics.iter().flatten().copied().collect(),
+            })
+            .collect::<Vec<H256>>();
+        for topic in topics {
+            // Check if previous filter conditions already matched no blocks.
+            // Do this on each iteration to avoid unnecessary queries.
+            if self.is_empty() {
+                return Ok(())
+            }
+
+            let topic_indices = provider.log_topic_indices(topic, self.block_range.clone())?;
+            self.intersection_indices(topic_indices);
+        }
+        Ok(())
     }
 }
 
@@ -494,7 +610,7 @@ impl BlockRangeInclusiveIter {
 }
 
 impl Iterator for BlockRangeInclusiveIter {
-    type Item = (u64, u64);
+    type Item = Vec<BlockNumber>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let start = self.iter.next()?;
@@ -502,7 +618,7 @@ impl Iterator for BlockRangeInclusiveIter {
         if start > end {
             return None
         }
-        Some((start, end))
+        Some((start..=end).collect())
     }
 }
 
@@ -520,14 +636,16 @@ mod tests {
             let step = rng.gen::<u16>() as u64;
             let range = start..=end;
             let mut iter = BlockRangeInclusiveIter::new(range.clone(), step);
-            let (from, mut end) = iter.next().unwrap();
+            let block_range = iter.next().unwrap();
+            let from = *block_range.first().unwrap();
+            let mut end = *block_range.last().unwrap();
             assert_eq!(from, start);
             assert_eq!(end, (from + step).min(*range.end()));
 
-            for (next_from, next_end) in iter {
+            for next_range in iter {
                 // ensure range starts with previous end + 1
-                assert_eq!(next_from, end + 1);
-                end = next_end;
+                assert_eq!(next_range.first().cloned(), Some(end + 1));
+                end = *next_range.last().unwrap();
             }
 
             assert_eq!(end, *range.end());

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -25,10 +25,10 @@ pub use traits::{
     BlockIdReader, BlockNumReader, BlockReader, BlockReaderIdExt, BlockSource, BlockWriter,
     BlockchainTreePendingStateProvider, CanonChainTracker, CanonStateNotification,
     CanonStateNotificationSender, CanonStateNotifications, CanonStateSubscriptions, EvmEnvProvider,
-    ExecutorFactory, HashingWriter, HeaderProvider, HistoryWriter, PostStateDataProvider,
-    ReceiptProvider, ReceiptProviderIdExt, StageCheckpointReader, StageCheckpointWriter,
-    StateProvider, StateProviderBox, StateProviderFactory, StateRootProvider, StorageReader,
-    TransactionsProvider, WithdrawalsProvider,
+    ExecutorFactory, HashingWriter, HeaderProvider, HistoryWriter, LogIndexProvider,
+    PostStateDataProvider, ReceiptProvider, ReceiptProviderIdExt, StageCheckpointReader,
+    StageCheckpointWriter, StateProvider, StateProviderBox, StateProviderFactory,
+    StateRootProvider, StorageReader, TransactionsProvider, WithdrawalsProvider,
 };
 
 /// Provider trait implementations.

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -145,6 +145,10 @@ impl<DB: Database> HeaderProvider for ProviderFactory<DB> {
         self.provider()?.headers_range(range)
     }
 
+    fn headers(&self, numbers: &[BlockNumber]) -> Result<Vec<Option<Header>>> {
+        self.provider()?.headers(numbers)
+    }
+
     fn sealed_headers_range(
         &self,
         range: impl RangeBounds<BlockNumber>,

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -198,6 +198,10 @@ impl<DB: Database> BlockReader for ProviderFactory<DB> {
         self.provider()?.block(id)
     }
 
+    fn blocks(&self, ids: Vec<BlockHashOrNumber>) -> Result<Vec<Option<Block>>> {
+        self.provider()?.blocks(ids)
+    }
+
     fn pending_block(&self) -> Result<Option<SealedBlock>> {
         self.provider()?.pending_block()
     }

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -1,9 +1,10 @@
 use crate::{
     BlockHashReader, BlockIdReader, BlockNumReader, BlockReader, BlockReaderIdExt,
     BlockchainTreePendingStateProvider, CanonChainTracker, CanonStateNotifications,
-    CanonStateSubscriptions, EvmEnvProvider, HeaderProvider, PostStateDataProvider, ProviderError,
-    ReceiptProvider, ReceiptProviderIdExt, StageCheckpointReader, StateProviderBox,
-    StateProviderFactory, TransactionsProvider, WithdrawalsProvider,
+    CanonStateSubscriptions, EvmEnvProvider, HeaderProvider, LogIndexProvider,
+    PostStateDataProvider, ProviderError, ReceiptProvider, ReceiptProviderIdExt,
+    StageCheckpointReader, StateProviderBox, StateProviderFactory, TransactionsProvider,
+    WithdrawalsProvider,
 };
 use reth_db::{database::Database, models::StoredBlockBodyIndices};
 use reth_interfaces::{
@@ -14,7 +15,7 @@ use reth_interfaces::{
 use reth_primitives::{
     stage::{StageCheckpoint, StageId},
     Address, Block, BlockHash, BlockHashOrNumber, BlockId, BlockNumHash, BlockNumber,
-    BlockNumberOrTag, BlockWithSenders, ChainInfo, Header, Receipt, SealedBlock,
+    BlockNumberOrTag, BlockWithSenders, ChainInfo, Header, IntegerList, Receipt, SealedBlock,
     SealedBlockWithSenders, SealedHeader, TransactionMeta, TransactionSigned,
     TransactionSignedNoHash, TxHash, TxNumber, Withdrawal, H256, U256,
 };
@@ -25,7 +26,7 @@ pub use state::{
 };
 use std::{
     collections::{BTreeMap, HashSet},
-    ops::RangeBounds,
+    ops::{RangeBounds, RangeInclusive},
     time::Instant,
 };
 use tracing::trace;
@@ -130,6 +131,10 @@ where
 
     fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> Result<Vec<Header>> {
         self.database.provider()?.headers_range(range)
+    }
+
+    fn headers(&self, block_numbers: &[BlockNumber]) -> Result<Vec<Option<Header>>> {
+        self.database.provider()?.headers(block_numbers)
     }
 
     fn sealed_headers_range(
@@ -356,6 +361,28 @@ where
                 }
             },
         }
+    }
+}
+
+impl<DB, Tree> LogIndexProvider for BlockchainProvider<DB, Tree>
+where
+    DB: Database,
+    Tree: Send + Sync,
+{
+    fn log_address_indices(
+        &self,
+        address: Address,
+        block_range: RangeInclusive<BlockNumber>,
+    ) -> Result<Option<IntegerList>> {
+        self.database.provider()?.log_address_indices(address, block_range)
+    }
+
+    fn log_topic_indices(
+        &self,
+        topic: H256,
+        block_range: RangeInclusive<BlockNumber>,
+    ) -> Result<Option<IntegerList>> {
+        self.database.provider()?.log_topic_indices(topic, block_range)
     }
 }
 

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -234,6 +234,11 @@ where
         }
     }
 
+    fn blocks(&self, ids: Vec<BlockHashOrNumber>) -> Result<Vec<Option<Block>>> {
+        // TODO:
+        self.database.provider()?.blocks(ids)
+    }
+
     fn pending_block(&self) -> Result<Option<SealedBlock>> {
         Ok(self.tree.pending_block())
     }

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -147,6 +147,17 @@ impl HeaderProvider for MockEthProvider {
         Ok(headers)
     }
 
+    fn headers(&self, numbers: &[BlockNumber]) -> Result<Vec<Option<Header>>> {
+        let lock = self.headers.lock();
+
+        let mut headers = Vec::with_capacity(numbers.len());
+        for number in numbers {
+            headers.push(lock.values().find(|header| header.number == *number).cloned());
+        }
+
+        Ok(headers)
+    }
+
     fn sealed_headers_range(
         &self,
         range: impl RangeBounds<BlockNumber>,

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -331,6 +331,10 @@ impl BlockReader for MockEthProvider {
         }
     }
 
+    fn blocks(&self, ids: Vec<BlockHashOrNumber>) -> Result<Vec<Option<Block>>> {
+        ids.into_iter().map(|id| self.block(id)).collect::<Result<Vec<_>>>()
+    }
+
     fn pending_block(&self) -> Result<Option<SealedBlock>> {
         Ok(None)
     }

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -59,6 +59,10 @@ impl BlockReader for NoopProvider {
         Ok(None)
     }
 
+    fn blocks(&self, _ids: Vec<BlockHashOrNumber>) -> Result<Vec<Option<Block>>> {
+        Ok(Vec::new())
+    }
+
     fn pending_block(&self) -> Result<Option<SealedBlock>> {
         Ok(None)
     }

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -1,20 +1,20 @@
 use crate::{
     traits::{BlockSource, ReceiptProvider},
     AccountReader, BlockHashReader, BlockIdReader, BlockNumReader, BlockReader, BlockReaderIdExt,
-    EvmEnvProvider, HeaderProvider, PostState, ReceiptProviderIdExt, StageCheckpointReader,
-    StateProvider, StateProviderBox, StateProviderFactory, StateRootProvider, TransactionsProvider,
-    WithdrawalsProvider,
+    EvmEnvProvider, HeaderProvider, LogIndexProvider, PostState, ReceiptProviderIdExt,
+    StageCheckpointReader, StateProvider, StateProviderBox, StateProviderFactory,
+    StateRootProvider, TransactionsProvider, WithdrawalsProvider,
 };
 use reth_db::models::StoredBlockBodyIndices;
 use reth_interfaces::Result;
 use reth_primitives::{
     stage::{StageCheckpoint, StageId},
     Account, Address, Block, BlockHash, BlockHashOrNumber, BlockId, BlockNumber, Bytecode, Bytes,
-    ChainInfo, Header, Receipt, SealedBlock, SealedHeader, StorageKey, StorageValue,
+    ChainInfo, Header, IntegerList, Receipt, SealedBlock, SealedHeader, StorageKey, StorageValue,
     TransactionMeta, TransactionSigned, TxHash, TxNumber, H256, KECCAK_EMPTY, U256,
 };
 use reth_revm_primitives::primitives::{BlockEnv, CfgEnv};
-use std::ops::RangeBounds;
+use std::ops::{RangeBounds, RangeInclusive};
 
 /// Supports various api interfaces for testing purposes.
 #[derive(Debug, Clone, Default, Copy)]
@@ -185,6 +185,24 @@ impl ReceiptProvider for NoopProvider {
 
 impl ReceiptProviderIdExt for NoopProvider {}
 
+impl LogIndexProvider for NoopProvider {
+    fn log_address_indices(
+        &self,
+        _address: Address,
+        _block_range: RangeInclusive<BlockNumber>,
+    ) -> Result<Option<IntegerList>> {
+        Ok(None)
+    }
+
+    fn log_topic_indices(
+        &self,
+        _topic: H256,
+        _block_range: RangeInclusive<BlockNumber>,
+    ) -> Result<Option<IntegerList>> {
+        Ok(None)
+    }
+}
+
 impl HeaderProvider for NoopProvider {
     fn header(&self, _block_hash: &BlockHash) -> Result<Option<Header>> {
         Ok(None)
@@ -203,6 +221,10 @@ impl HeaderProvider for NoopProvider {
     }
 
     fn headers_range(&self, _range: impl RangeBounds<BlockNumber>) -> Result<Vec<Header>> {
+        Ok(vec![])
+    }
+
+    fn headers(&self, _numbers: &[BlockNumber]) -> Result<Vec<Option<Header>>> {
         Ok(vec![])
     }
 

--- a/crates/storage/provider/src/traits/block.rs
+++ b/crates/storage/provider/src/traits/block.rs
@@ -68,6 +68,9 @@ pub trait BlockReader:
     /// Returns `None` if block is not found.
     fn block(&self, id: BlockHashOrNumber) -> Result<Option<Block>>;
 
+    /// TODO:
+    fn blocks(&self, ids: Vec<BlockHashOrNumber>) -> Result<Vec<Option<Block>>>;
+
     /// Returns the pending block if available
     ///
     /// Note: This returns a [SealedBlock] because it's expected that this is sealed by the provider

--- a/crates/storage/provider/src/traits/header.rs
+++ b/crates/storage/provider/src/traits/header.rs
@@ -34,6 +34,11 @@ pub trait HeaderProvider: Send + Sync {
     /// Get headers in range of block numbers
     fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> Result<Vec<Header>>;
 
+    /// Get headers by the list of block numbers.
+    ///
+    /// NOTE: This method is more performant with sorted block numbers provided as an input.
+    fn headers(&self, numbers: &[BlockNumber]) -> Result<Vec<Option<Header>>>;
+
     /// Get headers in range of block numbers
     fn sealed_headers_range(
         &self,

--- a/crates/storage/provider/src/traits/logs.rs
+++ b/crates/storage/provider/src/traits/logs.rs
@@ -1,0 +1,26 @@
+use std::ops::RangeInclusive;
+
+use reth_interfaces::Result;
+use reth_primitives::{Address, BlockNumber, IntegerList, H256};
+
+/// Client trait for fetching [reth_primitives::Log] index data.
+#[auto_impl::auto_impl(&, Arc)]
+pub trait LogIndexProvider: Send + Sync {
+    /// Get the list of block numbers within a block range where a given address emitted a log.
+    ///
+    /// Returns `None` of no block numbers matched the address.
+    fn log_address_indices(
+        &self,
+        address: Address,
+        block_range: RangeInclusive<BlockNumber>,
+    ) -> Result<Option<IntegerList>>;
+
+    /// Get the list of block numbers within a block range where a given topic was emitted in a log.
+    ///
+    /// Returns `None` of no block numbers matched the topic.
+    fn log_topic_indices(
+        &self,
+        topic: H256,
+        block_range: RangeInclusive<BlockNumber>,
+    ) -> Result<Option<IntegerList>>;
+}

--- a/crates/storage/provider/src/traits/mod.rs
+++ b/crates/storage/provider/src/traits/mod.rs
@@ -27,6 +27,9 @@ pub use header::HeaderProvider;
 mod receipts;
 pub use receipts::{ReceiptProvider, ReceiptProviderIdExt};
 
+mod logs;
+pub use logs::LogIndexProvider;
+
 mod state;
 pub use state::{
     BlockchainTreePendingStateProvider, PostStateDataProvider, StateProvider, StateProviderBox,

--- a/crates/storage/provider/src/traits/receipts.rs
+++ b/crates/storage/provider/src/traits/receipts.rs
@@ -3,7 +3,7 @@ use reth_primitives::{BlockHashOrNumber, BlockId, BlockNumberOrTag, Receipt, TxH
 
 use crate::BlockIdReader;
 
-///  Client trait for fetching [Receipt] data .
+///  Client trait for fetching [Receipt] data.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait ReceiptProvider: Send + Sync {
     /// Get receipt by transaction number


### PR DESCRIPTION
Builds on top of #3082.

## Description

This PR modifies the matching logic of `address` and `topic` filters in `eth_getLogs` handler.