### PR TITLE
fix: set call trace gas limit with call inputs gas limit

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/mod.rs
+++ b/crates/revm/revm-inspectors/src/tracing/mod.rs
@@ -373,7 +373,6 @@ where
             inputs.transfer.value
         };
 
-
         // if calls to precompiles should be excluded, check whether this is a call to a precompile
         let maybe_precompile =
             self.config.exclude_precompile_calls.then(|| is_precompile_call(data, &to, value));

--- a/crates/revm/revm-inspectors/src/tracing/mod.rs
+++ b/crates/revm/revm-inspectors/src/tracing/mod.rs
@@ -130,6 +130,7 @@ impl TracingInspector {
         value: U256,
         kind: CallKind,
         caller: Address,
+        gas_limit: u64,
         maybe_precompile: Option<bool>,
     ) {
         // This will only be true if the inspector is configured to exclude precompiles and the call
@@ -154,6 +155,7 @@ impl TracingInspector {
                 caller,
                 last_call_return_value: self.last_call_return_data.clone(),
                 maybe_precompile,
+                gas_limit,
                 ..Default::default()
             },
         ));
@@ -178,7 +180,6 @@ impl TracingInspector {
         let trace = &mut self.traces.arena[trace_idx].trace;
 
         trace.gas_used = gas.spend();
-        trace.gas_limit = gas.limit();
         trace.status = status;
         trace.success = matches!(status, return_ok!());
         trace.output = output.clone();
@@ -372,6 +373,7 @@ where
             inputs.transfer.value
         };
 
+
         // if calls to precompiles should be excluded, check whether this is a call to a precompile
         let maybe_precompile =
             self.config.exclude_precompile_calls.then(|| is_precompile_call(data, &to, value));
@@ -383,6 +385,7 @@ where
             value,
             inputs.context.scheme.into(),
             from,
+            inputs.gas_limit,
             maybe_precompile,
         );
 
@@ -421,6 +424,7 @@ where
             inputs.value,
             inputs.scheme.into(),
             inputs.caller,
+            inputs.gas_limit,
             Some(false),
         );
 


### PR DESCRIPTION
set the correct gas limit for a call trace on call start:

ref: 

https://github.com/ledgerwatch/erigon/blob/eae2d9a79cb70dbe30b3a6b79c436872e4605458/core/blockchain.go#L340-L344