### PR TITLE
feat(config): missing stage configs

### DIFF
--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -51,14 +51,26 @@ impl Config {
 pub struct StageConfig {
     /// Header stage configuration.
     pub headers: HeadersConfig,
-    /// Total difficulty stage configuration
+    /// Total Difficulty stage configuration
     pub total_difficulty: TotalDifficultyConfig,
     /// Body stage configuration.
     pub bodies: BodiesConfig,
-    /// Sender recovery stage configuration.
+    /// Sender Recovery stage configuration.
     pub sender_recovery: SenderRecoveryConfig,
     /// Execution stage configuration.
     pub execution: ExecutionConfig,
+    /// Account Hashing stage configuration.
+    pub account_hashing: HashingConfig,
+    /// Storage Hashing stage configuration.
+    pub storage_hashing: HashingConfig,
+    /// Merkle stage configuration.
+    pub merkle: MerkleConfig,
+    /// Transaction Lookup stage configuration.
+    pub transaction_lookup: TransactionLookupConfig,
+    /// Index Account History stage configuration.
+    pub index_account_history: IndexHistoryConfig,
+    /// Index Storage History stage configuration.
+    pub index_storage_history: IndexHistoryConfig,
 }
 
 /// Header stage configuration.
@@ -201,6 +213,66 @@ pub struct ExecutionConfig {
 impl Default for ExecutionConfig {
     fn default() -> Self {
         Self { max_blocks: Some(500_000), max_changes: Some(5_000_000) }
+    }
+}
+
+/// Hashing stage configuration.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Serialize)]
+#[serde(default)]
+pub struct HashingConfig {
+    /// The threshold (in number of blocks) for switching between
+    /// incremental hashing and full hashing.
+    pub clean_threshold: u64,
+    /// The maximum number of entities to process before committing progress to the database.
+    pub commit_threshold: u64,
+}
+
+impl Default for HashingConfig {
+    fn default() -> Self {
+        Self { clean_threshold: 500_000, commit_threshold: 100_000 }
+    }
+}
+
+/// Merkle stage configuration.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Serialize)]
+#[serde(default)]
+pub struct MerkleConfig {
+    /// The threshold (in number of blocks) for switching from incremental trie building of changes
+    /// to whole rebuild.
+    pub clean_threshold: u64,
+}
+
+impl Default for MerkleConfig {
+    fn default() -> Self {
+        Self { clean_threshold: 50_000 }
+    }
+}
+
+/// Transaction Lookup stage configuration.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Serialize)]
+#[serde(default)]
+pub struct TransactionLookupConfig {
+    /// The maximum number of transactions to process before committing progress to the database.
+    pub commit_threshold: u64,
+}
+
+impl Default for TransactionLookupConfig {
+    fn default() -> Self {
+        Self { commit_threshold: 5_000_000 }
+    }
+}
+
+/// History History stage configuration.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Serialize)]
+#[serde(default)]
+pub struct IndexHistoryConfig {
+    /// The maximum number of blocks to process before committing progress to the database.
+    pub commit_threshold: u64,
+}
+
+impl Default for IndexHistoryConfig {
+    fn default() -> Self {
+        Self { commit_threshold: 100_000 }
     }
 }
 

--- a/crates/stages/src/stages/hashing_account.rs
+++ b/crates/stages/src/stages/hashing_account.rs
@@ -29,7 +29,7 @@ use tracing::*;
 /// This is preparation before generating intermediate hashes and calculating Merkle tree root.
 #[derive(Clone, Debug)]
 pub struct AccountHashingStage {
-    /// The threshold (in number of state transitions) for switching between incremental
+    /// The threshold (in number of blocks) for switching between incremental
     /// hashing and full storage hashing.
     pub clean_threshold: u64,
     /// The maximum number of accounts to process before committing.

--- a/crates/stages/src/stages/index_account_history.rs
+++ b/crates/stages/src/stages/index_account_history.rs
@@ -14,6 +14,13 @@ pub struct IndexAccountHistoryStage {
     pub commit_threshold: u64,
 }
 
+impl IndexAccountHistoryStage {
+    /// Create new instance of [IndexAccountHistoryStage].
+    pub fn new(commit_threshold: u64) -> Self {
+        Self { commit_threshold }
+    }
+}
+
 impl Default for IndexAccountHistoryStage {
     fn default() -> Self {
         Self { commit_threshold: 100_000 }

--- a/crates/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/src/stages/index_storage_history.rs
@@ -14,6 +14,13 @@ pub struct IndexStorageHistoryStage {
     pub commit_threshold: u64,
 }
 
+impl IndexStorageHistoryStage {
+    /// Create new instance of [IndexStorageHistoryStage].
+    pub fn new(commit_threshold: u64) -> Self {
+        Self { commit_threshold }
+    }
+}
+
 impl Default for IndexStorageHistoryStage {
     fn default() -> Self {
         Self { commit_threshold: 100_000 }

--- a/crates/stages/src/stages/merkle.rs
+++ b/crates/stages/src/stages/merkle.rs
@@ -44,8 +44,8 @@ use tracing::*;
 pub enum MerkleStage {
     /// The execution portion of the merkle stage.
     Execution {
-        /// The threshold for switching from incremental trie building
-        /// of changes to whole rebuild. Num of transitions.
+        /// The threshold (in number of blocks) for switching from incremental trie building
+        /// of changes to whole rebuild.
         clean_threshold: u64,
     },
     /// The unwind portion of the merkle stage.
@@ -58,14 +58,19 @@ pub enum MerkleStage {
 }
 
 impl MerkleStage {
-    /// Stage default for the Execution variant.
+    /// Stage default for the [MerkleStage::Execution].
     pub fn default_execution() -> Self {
         Self::Execution { clean_threshold: 50_000 }
     }
 
-    /// Stage default for the Unwind variant.
+    /// Stage default for the [MerkleStage::Unwind].
     pub fn default_unwind() -> Self {
         Self::Unwind
+    }
+
+    /// Create new instance of [MerkleStage::Execution].
+    pub fn new_execution(clean_threshold: u64) -> Self {
+        Self::Execution { clean_threshold }
     }
 
     /// Check that the computed state root matches the root in the expected header.


### PR DESCRIPTION
This PR makes all the pipeline stages configurable through `reth.toml`. After it's merged, also need to update the book: https://github.com/paradigmxyz/reth/pull/3173.