### PR TITLE
fix: prevent panic in trace call

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/types.rs
+++ b/crates/revm/revm-inspectors/src/tracing/types.rs
@@ -242,6 +242,7 @@ impl CallTraceNode {
     }
 
     /// Returns true if this is a call to a precompile
+    #[inline]
     pub(crate) fn is_precompile(&self) -> bool {
         self.trace.maybe_precompile.unwrap_or(false)
     }


### PR DESCRIPTION
In #3141 I excluded calls to precompiles from the result set, however precompile calls are still recorded and are therefore included in the arena.

because the trace addresses are computed for all nodes, this then caused a panic because the precompile child call was no longer present in the parent's children set.

fixes panic in `trace_block` `0xe67702`