### PR TITLE
ci: use `actions/deploy-pages@v2`

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -87,4 +87,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
We have some issues with deploying pages, unsure why, but maybe bumping to v2 helps?