### PR TITLE
chore: block gas limit constant

### DIFF
--- a/crates/consensus/auto-seal/src/task.rs
+++ b/crates/consensus/auto-seal/src/task.rs
@@ -3,7 +3,7 @@ use futures_util::{future::BoxFuture, FutureExt, StreamExt};
 use reth_beacon_consensus::BeaconEngineMessage;
 use reth_interfaces::consensus::ForkchoiceState;
 use reth_primitives::{
-    constants::{EMPTY_RECEIPTS, EMPTY_TRANSACTIONS},
+    constants::{EMPTY_RECEIPTS, EMPTY_TRANSACTIONS, ETHEREUM_BLOCK_GAS_LIMIT},
     proofs,
     stage::StageId,
     Block, BlockBody, ChainSpec, Header, IntoRecoveredTransaction, ReceiptWithBloom,
@@ -142,7 +142,7 @@ where
                         logs_bloom: Default::default(),
                         difficulty: U256::from(2),
                         number: storage.best_block + 1,
-                        gas_limit: 30_000_000,
+                        gas_limit: ETHEREUM_BLOCK_GAS_LIMIT,
                         gas_used: 0,
                         timestamp: SystemTime::now()
                             .duration_since(UNIX_EPOCH)

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -17,8 +17,8 @@ use reth_payload_builder::{
 use reth_primitives::{
     bytes::{Bytes, BytesMut},
     constants::{
-        BEACON_NONCE, EMPTY_RECEIPTS, EMPTY_TRANSACTIONS, EMPTY_WITHDRAWALS, RETH_CLIENT_VERSION,
-        SLOT_DURATION,
+        BEACON_NONCE, EMPTY_RECEIPTS, EMPTY_TRANSACTIONS, EMPTY_WITHDRAWALS,
+        ETHEREUM_BLOCK_GAS_LIMIT, RETH_CLIENT_VERSION, SLOT_DURATION,
     },
     proofs, Block, BlockNumberOrTag, ChainSpec, Header, IntoRecoveredTransaction, Receipt,
     SealedBlock, Withdrawal, EMPTY_OMMER_ROOT, H256, U256,
@@ -173,7 +173,7 @@ impl PayloadTaskGuard {
 pub struct BasicPayloadJobGeneratorConfig {
     /// Data to include in the block's extra data field.
     extradata: Bytes,
-    /// Target gas ceiling for built blocks, defaults to 30_000_000 gas.
+    /// Target gas ceiling for built blocks, defaults to [ETHEREUM_BLOCK_GAS_LIMIT] gas.
     max_gas_limit: u64,
     /// The interval at which the job should build a new payload after the last.
     interval: Duration,
@@ -219,7 +219,7 @@ impl BasicPayloadJobGeneratorConfig {
 
     /// Sets the target gas ceiling for mined blocks.
     ///
-    /// Defaults to 30_000_000 gas.
+    /// Defaults to [ETHEREUM_BLOCK_GAS_LIMIT] gas.
     pub fn max_gas_limit(mut self, max_gas_limit: u64) -> Self {
         self.max_gas_limit = max_gas_limit;
         self
@@ -232,7 +232,7 @@ impl Default for BasicPayloadJobGeneratorConfig {
         RETH_CLIENT_VERSION.as_bytes().encode(&mut extradata);
         Self {
             extradata: extradata.freeze(),
-            max_gas_limit: 30_000_000,
+            max_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT,
             interval: Duration::from_secs(1),
             // 12s slot time
             deadline: SLOT_DURATION,

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -26,6 +26,9 @@ pub const EPOCH_DURATION: Duration = Duration::from_secs(12 * 32);
 pub const BEACON_NONCE: u64 = 0u64;
 
 /// The default Ethereum block gas limit.
+///
+/// TODO: This should be a chain spec parameter.
+/// See <https://github.com/paradigmxyz/reth/issues/3233>.
 pub const ETHEREUM_BLOCK_GAS_LIMIT: u64 = 30_000_000;
 
 /// The minimal value the basefee can decrease to.

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -25,6 +25,9 @@ pub const EPOCH_DURATION: Duration = Duration::from_secs(12 * 32);
 /// The default block nonce in the beacon consensus
 pub const BEACON_NONCE: u64 = 0u64;
 
+/// The default Ethereum block gas limit.
+pub const ETHEREUM_BLOCK_GAS_LIMIT: u64 = 30_000_000;
+
 /// The minimal value the basefee can decrease to.
 ///
 /// The `BASE_FEE_MAX_CHANGE_DENOMINATOR` <https://eips.ethereum.org/EIPS/eip-1559> is `8`, or 12.5%.

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -16,7 +16,10 @@ use crate::{
     PoolConfig, PoolResult, PoolTransaction, TransactionOrdering, ValidPoolTransaction, U256,
 };
 use fnv::FnvHashMap;
-use reth_primitives::{constants::MIN_PROTOCOL_BASE_FEE, TxHash, H256};
+use reth_primitives::{
+    constants::{ETHEREUM_BLOCK_GAS_LIMIT, MIN_PROTOCOL_BASE_FEE},
+    TxHash, H256,
+};
 use std::{
     cmp::Ordering,
     collections::{btree_map::Entry, hash_map, BTreeMap, HashMap},
@@ -1163,7 +1166,7 @@ impl<T: PoolTransaction> Default for AllTransactions<T> {
         Self {
             max_account_slots: MAX_ACCOUNT_SLOTS_PER_SENDER,
             minimal_protocol_basefee: MIN_PROTOCOL_BASE_FEE,
-            block_gas_limit: 30_000_000,
+            block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT,
             by_hash: Default::default(),
             txs: Default::default(),
             tx_counter: Default::default(),

--- a/crates/transaction-pool/src/validate.rs
+++ b/crates/transaction-pool/src/validate.rs
@@ -7,9 +7,9 @@ use crate::{
     MAX_INIT_CODE_SIZE, TX_MAX_SIZE,
 };
 use reth_primitives::{
-    Address, ChainSpec, IntoRecoveredTransaction, InvalidTransactionError, TransactionKind,
-    TransactionSignedEcRecovered, TxHash, EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID,
-    LEGACY_TX_TYPE_ID, U256,
+    constants::ETHEREUM_BLOCK_GAS_LIMIT, Address, ChainSpec, IntoRecoveredTransaction,
+    InvalidTransactionError, TransactionKind, TransactionSignedEcRecovered, TxHash,
+    EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID, LEGACY_TX_TYPE_ID, U256,
 };
 use reth_provider::{AccountProvider, StateProviderFactory};
 use std::{fmt, marker::PhantomData, sync::Arc, time::Instant};
@@ -138,7 +138,7 @@ impl<Client, Tx> EthTransactionValidator<Client, Tx> {
             shanghai: true,
             eip2718: true,
             eip1559: true,
-            block_gas_limit: 30_000_000,
+            block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT,
             minimum_priority_fee: None,
             _marker: Default::default(),
         }


### PR DESCRIPTION
## Description

Replace hardcoded block gas limit with a constant across different crates. 

NOTE: Ideally, the block gas limit is configured in the chain spec and sourced from it.