### PR TITLE
chore: `AccountProvider` -> `AccountReader` & `AccountWriter`

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -4,7 +4,7 @@ use reth_primitives::{
     constants, BlockNumber, ChainSpec, Hardfork, Header, InvalidTransactionError, SealedBlock,
     SealedHeader, Transaction, TransactionSignedEcRecovered, TxEip1559, TxEip2930, TxLegacy,
 };
-use reth_provider::{AccountProvider, HeaderProvider, WithdrawalsProvider};
+use reth_provider::{AccountReader, HeaderProvider, WithdrawalsProvider};
 use std::{
     collections::{hash_map::Entry, HashMap},
     time::SystemTime,
@@ -120,7 +120,7 @@ pub fn validate_transaction_regarding_header(
 /// There is no gas check done as [REVM](https://github.com/bluealloy/revm/blob/fd0108381799662098b7ab2c429ea719d6dfbf28/crates/revm/src/evm_impl.rs#L113-L131) already checks that.
 pub fn validate_all_transaction_regarding_block_and_nonces<
     'a,
-    Provider: HeaderProvider + AccountProvider,
+    Provider: HeaderProvider + AccountReader,
 >(
     transactions: impl Iterator<Item = &'a TransactionSignedEcRecovered>,
     header: &Header,
@@ -363,7 +363,7 @@ pub fn validate_block_regarding_chain<PROV: HeaderProvider + WithdrawalsProvider
 }
 
 /// Full validation of block before execution.
-pub fn full_validation<Provider: HeaderProvider + AccountProvider + WithdrawalsProvider>(
+pub fn full_validation<Provider: HeaderProvider + AccountReader + WithdrawalsProvider>(
     block: &SealedBlock,
     provider: Provider,
     chain_spec: &ChainSpec,
@@ -444,7 +444,7 @@ mod tests {
         }
     }
 
-    impl AccountProvider for Provider {
+    impl AccountReader for Provider {
         fn basic_account(&self, _address: Address) -> Result<Option<Account>> {
             Ok(self.account)
         }

--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -654,7 +654,7 @@ mod tests {
     };
     use reth_provider::{
         post_state::{AccountChanges, Storage, StorageTransition, StorageWipe},
-        AccountProvider, BlockHashProvider, StateProvider, StateRootProvider,
+        AccountReader, BlockHashProvider, StateProvider, StateRootProvider,
     };
     use reth_rlp::Decodable;
     use std::{collections::HashMap, str::FromStr};
@@ -693,7 +693,7 @@ mod tests {
         }
     }
 
-    impl AccountProvider for StateProviderTest {
+    impl AccountReader for StateProviderTest {
         fn basic_account(&self, address: Address) -> reth_interfaces::Result<Option<Account>> {
             let ret = Ok(self.accounts.get(&address).map(|(_, acc)| *acc));
             ret

--- a/crates/rpc/rpc/src/eth/api/state.rs
+++ b/crates/rpc/rpc/src/eth/api/state.rs
@@ -9,7 +9,7 @@ use reth_primitives::{
     U256,
 };
 use reth_provider::{
-    AccountProvider, BlockProviderIdExt, EvmEnvProvider, StateProvider, StateProviderFactory,
+    AccountReader, BlockProviderIdExt, EvmEnvProvider, StateProvider, StateProviderFactory,
 };
 use reth_rpc_types::{EIP1186AccountProofResponse, StorageProof};
 use reth_transaction_pool::{PoolTransaction, TransactionPool};

--- a/crates/staged-sync/src/utils/init.rs
+++ b/crates/staged-sync/src/utils/init.rs
@@ -6,7 +6,9 @@ use reth_db::{
     transaction::{DbTx, DbTxMut},
 };
 use reth_primitives::{stage::StageId, Account, Bytecode, ChainSpec, H256, U256};
-use reth_provider::{DatabaseProviderRW, PostState, ProviderFactory, TransactionError};
+use reth_provider::{
+    AccountWriter, DatabaseProviderRW, PostState, ProviderFactory, TransactionError,
+};
 use std::{path::Path, sync::Arc};
 use tracing::debug;
 

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -422,9 +422,7 @@ mod tests {
         hex_literal::hex, keccak256, stage::StageUnitCheckpoint, Account, Bytecode,
         ChainSpecBuilder, SealedBlock, StorageEntry, H160, H256, MAINNET, U256,
     };
-    use reth_provider::{
-        insert_canonical_block, AccountProvider, ProviderFactory, ReceiptProvider,
-    };
+    use reth_provider::{insert_canonical_block, AccountReader, ProviderFactory, ReceiptProvider};
     use reth_revm::Factory;
     use reth_rlp::Decodable;
     use std::sync::Arc;

--- a/crates/stages/src/stages/hashing_account.rs
+++ b/crates/stages/src/stages/hashing_account.rs
@@ -16,7 +16,7 @@ use reth_primitives::{
         StageId,
     },
 };
-use reth_provider::{AccountExtReader, DatabaseProviderRW};
+use reth_provider::{AccountExtReader, AccountWriter, DatabaseProviderRW};
 use std::{
     cmp::max,
     fmt::Debug,

--- a/crates/stages/src/stages/hashing_account.rs
+++ b/crates/stages/src/stages/hashing_account.rs
@@ -16,7 +16,7 @@ use reth_primitives::{
         StageId,
     },
 };
-use reth_provider::{AccountExtProvider, DatabaseProviderRW};
+use reth_provider::{AccountExtReader, DatabaseProviderRW};
 use std::{
     cmp::max,
     fmt::Debug,

--- a/crates/stages/src/stages/index_account_history.rs
+++ b/crates/stages/src/stages/index_account_history.rs
@@ -1,7 +1,7 @@
 use crate::{ExecInput, ExecOutput, Stage, StageError, UnwindInput, UnwindOutput};
 use reth_db::database::Database;
 use reth_primitives::stage::{StageCheckpoint, StageId};
-use reth_provider::{AccountExtProvider, DatabaseProviderRW};
+use reth_provider::{AccountExtReader, DatabaseProviderRW};
 use std::fmt::Debug;
 
 /// Stage is indexing history the account changesets generated in

--- a/crates/stages/src/stages/index_account_history.rs
+++ b/crates/stages/src/stages/index_account_history.rs
@@ -1,7 +1,7 @@
 use crate::{ExecInput, ExecOutput, Stage, StageError, UnwindInput, UnwindOutput};
 use reth_db::database::Database;
 use reth_primitives::stage::{StageCheckpoint, StageId};
-use reth_provider::{AccountExtReader, DatabaseProviderRW};
+use reth_provider::{AccountExtReader, AccountWriter, DatabaseProviderRW};
 use std::fmt::Debug;
 
 /// Stage is indexing history the account changesets generated in

--- a/crates/stages/src/stages/index_account_history.rs
+++ b/crates/stages/src/stages/index_account_history.rs
@@ -1,7 +1,7 @@
 use crate::{ExecInput, ExecOutput, Stage, StageError, UnwindInput, UnwindOutput};
 use reth_db::database::Database;
 use reth_primitives::stage::{StageCheckpoint, StageId};
-use reth_provider::DatabaseProviderRW;
+use reth_provider::{AccountExtProvider, DatabaseProviderRW};
 use std::fmt::Debug;
 
 /// Stage is indexing history the account changesets generated in
@@ -46,7 +46,7 @@ impl<DB: Database> Stage<DB> for IndexAccountHistoryStage {
 
         let (range, is_final_range) = input.next_block_range_with_threshold(self.commit_threshold);
 
-        let indices = provider.get_account_block_numbers_from_changesets(range.clone())?;
+        let indices = provider.changed_accounts_and_blocks_with_range(range.clone())?;
         // Insert changeset to history index
         provider.insert_account_history_index(indices)?;
 

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -11,8 +11,8 @@
 /// Various provider traits.
 mod traits;
 pub use traits::{
-    AccountExtReader, AccountReader, BlockExecutor, BlockHashProvider, BlockIdProvider,
-    BlockNumProvider, BlockProvider, BlockProviderIdExt, BlockSource,
+    AccountExtReader, AccountReader, AccountWriter, BlockExecutor, BlockHashProvider,
+    BlockIdProvider, BlockNumProvider, BlockProvider, BlockProviderIdExt, BlockSource,
     BlockchainTreePendingStateProvider, CanonChainTracker, CanonStateNotification,
     CanonStateNotificationSender, CanonStateNotifications, CanonStateSubscriptions, EvmEnvProvider,
     ExecutorFactory, HeaderProvider, PostStateDataProvider, ReceiptProvider, ReceiptProviderIdExt,

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -11,7 +11,7 @@
 /// Various provider traits.
 mod traits;
 pub use traits::{
-    AccountExtProvider, AccountProvider, BlockExecutor, BlockHashProvider, BlockIdProvider,
+    AccountExtReader, AccountReader, BlockExecutor, BlockHashProvider, BlockIdProvider,
     BlockNumProvider, BlockProvider, BlockProviderIdExt, BlockSource,
     BlockchainTreePendingStateProvider, CanonChainTracker, CanonStateNotification,
     CanonStateNotificationSender, CanonStateNotifications, CanonStateSubscriptions, EvmEnvProvider,

--- a/crates/storage/provider/src/post_state/mod.rs
+++ b/crates/storage/provider/src/post_state/mod.rs
@@ -640,7 +640,7 @@ impl PostState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{AccountProvider, ProviderFactory};
+    use crate::{AccountReader, ProviderFactory};
     use reth_db::{
         database::Database,
         mdbx::{test_utils, Env, EnvKind, WriteMap},

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1,8 +1,8 @@
 use crate::{
     insert_canonical_block,
     post_state::StorageChangeset,
-    traits::{AccountExtProvider, BlockSource, ReceiptProvider, StageCheckpointWriter},
-    AccountProvider, BlockHashProvider, BlockNumProvider, BlockProvider, EvmEnvProvider,
+    traits::{AccountExtReader, BlockSource, ReceiptProvider, StageCheckpointWriter},
+    AccountReader, BlockHashProvider, BlockNumProvider, BlockProvider, EvmEnvProvider,
     HeaderProvider, PostState, ProviderError, StageCheckpointReader, TransactionError,
     TransactionsProvider, WithdrawalsProvider,
 };
@@ -1333,13 +1333,13 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> DatabaseProvider<'this, TX> {
     }
 }
 
-impl<'this, TX: DbTx<'this>> AccountProvider for DatabaseProvider<'this, TX> {
+impl<'this, TX: DbTx<'this>> AccountReader for DatabaseProvider<'this, TX> {
     fn basic_account(&self, address: Address) -> Result<Option<Account>> {
         Ok(self.tx.get::<tables::PlainAccountState>(address)?)
     }
 }
 
-impl<'this, TX: DbTx<'this>> AccountExtProvider for DatabaseProvider<'this, TX> {
+impl<'this, TX: DbTx<'this>> AccountExtReader for DatabaseProvider<'this, TX> {
     fn changed_accounts_with_range(
         &self,
         range: impl RangeBounds<BlockNumber>,

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -276,18 +276,6 @@ impl<'this, TX: DbTx<'this>> DatabaseProvider<'this, TX> {
 
         Ok(storage_changeset_lists)
     }
-
-    /// Get plainstate account from iterator
-    pub fn get_plainstate_accounts(
-        &self,
-        iter: impl IntoIterator<Item = Address>,
-    ) -> std::result::Result<Vec<(Address, Option<Account>)>, TransactionError> {
-        let mut plain_accounts = self.tx.cursor_read::<tables::PlainAccountState>()?;
-        Ok(iter
-            .into_iter()
-            .map(|address| plain_accounts.seek_exact(address).map(|a| (address, a.map(|(_, v)| v))))
-            .collect::<std::result::Result<Vec<_>, _>>()?)
-    }
 }
 
 impl<'this, TX: DbTxMut<'this> + DbTx<'this>> DatabaseProvider<'this, TX> {
@@ -1296,7 +1284,7 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> DatabaseProvider<'this, TX> {
         // account hashing stage
         {
             let lists = self.changed_accounts_with_range(range.clone())?;
-            let accounts = self.get_plainstate_accounts(lists.into_iter())?;
+            let accounts = self.basic_accounts(lists.into_iter())?;
             self.insert_account_for_hashing(accounts.into_iter())?;
         }
 

--- a/crates/storage/provider/src/providers/post_state_provider.rs
+++ b/crates/storage/provider/src/providers/post_state_provider.rs
@@ -1,5 +1,5 @@
 use crate::{
-    AccountProvider, BlockHashProvider, PostState, PostStateDataProvider, StateProvider,
+    AccountReader, BlockHashProvider, PostState, PostStateDataProvider, StateProvider,
     StateRootProvider,
 };
 use reth_interfaces::{provider::ProviderError, Result};
@@ -39,9 +39,7 @@ impl<SP: StateProvider, PSDP: PostStateDataProvider> BlockHashProvider
     }
 }
 
-impl<SP: StateProvider, PSDP: PostStateDataProvider> AccountProvider
-    for PostStateProvider<SP, PSDP>
-{
+impl<SP: StateProvider, PSDP: PostStateDataProvider> AccountReader for PostStateProvider<SP, PSDP> {
     fn basic_account(&self, address: Address) -> Result<Option<Account>> {
         if let Some(account) = self.post_state_data_provider.state().account(&address) {
             Ok(*account)

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -1,6 +1,6 @@
 use crate::{
-    providers::state::macros::delegate_provider_impls, AccountProvider, BlockHashProvider,
-    PostState, ProviderError, StateProvider, StateRootProvider,
+    providers::state::macros::delegate_provider_impls, AccountReader, BlockHashProvider, PostState,
+    ProviderError, StateProvider, StateRootProvider,
 };
 use reth_db::{
     cursor::{DbCursorRO, DbDupCursorRO},
@@ -102,7 +102,7 @@ impl<'a, 'b, TX: DbTx<'a>> HistoricalStateProviderRef<'a, 'b, TX> {
     }
 }
 
-impl<'a, 'b, TX: DbTx<'a>> AccountProvider for HistoricalStateProviderRef<'a, 'b, TX> {
+impl<'a, 'b, TX: DbTx<'a>> AccountReader for HistoricalStateProviderRef<'a, 'b, TX> {
     /// Get basic account information.
     fn basic_account(&self, address: Address) -> Result<Option<Account>> {
         match self.account_history_lookup(address)? {
@@ -219,7 +219,7 @@ delegate_provider_impls!(HistoricalStateProvider<'a, TX> where [TX: DbTx<'a>]);
 #[cfg(test)]
 mod tests {
     use crate::{
-        AccountProvider, HistoricalStateProvider, HistoricalStateProviderRef, StateProvider,
+        AccountReader, HistoricalStateProvider, HistoricalStateProviderRef, StateProvider,
     };
     use reth_db::{
         database::Database,

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -1,6 +1,6 @@
 use crate::{
-    providers::state::macros::delegate_provider_impls, AccountProvider, BlockHashProvider,
-    PostState, StateProvider, StateRootProvider,
+    providers::state::macros::delegate_provider_impls, AccountReader, BlockHashProvider, PostState,
+    StateProvider, StateRootProvider,
 };
 use reth_db::{
     cursor::{DbCursorRO, DbDupCursorRO},
@@ -28,7 +28,7 @@ impl<'a, 'b, TX: DbTx<'a>> LatestStateProviderRef<'a, 'b, TX> {
     }
 }
 
-impl<'a, 'b, TX: DbTx<'a>> AccountProvider for LatestStateProviderRef<'a, 'b, TX> {
+impl<'a, 'b, TX: DbTx<'a>> AccountReader for LatestStateProviderRef<'a, 'b, TX> {
     /// Get basic account information.
     fn basic_account(&self, address: Address) -> Result<Option<Account>> {
         self.db.get::<tables::PlainAccountState>(address).map_err(Into::into)

--- a/crates/storage/provider/src/providers/state/macros.rs
+++ b/crates/storage/provider/src/providers/state/macros.rs
@@ -23,7 +23,7 @@ pub(crate) use delegate_impls_to_as_ref;
 
 /// Delegates the provider trait implementations to the `as_ref` function of the type:
 ///
-/// [AccountProvider](crate::AccountProvider)
+/// [AccountReader](crate::AccountReader)
 /// [BlockHashProvider](crate::BlockHashProvider)
 /// [StateProvider](crate::StateProvider)
 macro_rules! delegate_provider_impls {
@@ -33,7 +33,7 @@ macro_rules! delegate_provider_impls {
             StateRootProvider $(where [$($generics)*])? {
                 fn state_root(&self, state: crate::PostState) -> reth_interfaces::Result<reth_primitives::H256>;
             }
-            AccountProvider $(where [$($generics)*])? {
+            AccountReader $(where [$($generics)*])? {
                 fn basic_account(&self, address: reth_primitives::Address) -> reth_interfaces::Result<Option<reth_primitives::Account>>;
             }
             BlockHashProvider $(where [$($generics)*])? {

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -1,6 +1,6 @@
 use crate::{
     traits::{BlockSource, ReceiptProvider},
-    AccountProvider, BlockHashProvider, BlockIdProvider, BlockNumProvider, BlockProvider,
+    AccountReader, BlockHashProvider, BlockIdProvider, BlockNumProvider, BlockProvider,
     BlockProviderIdExt, EvmEnvProvider, HeaderProvider, PostState, PostStateDataProvider,
     StateProvider, StateProviderBox, StateProviderFactory, StateRootProvider, TransactionsProvider,
     WithdrawalsProvider,
@@ -362,7 +362,7 @@ impl BlockProviderIdExt for MockEthProvider {
     }
 }
 
-impl AccountProvider for MockEthProvider {
+impl AccountReader for MockEthProvider {
     fn basic_account(&self, address: Address) -> Result<Option<Account>> {
         Ok(self.accounts.lock().get(&address).cloned().map(|a| a.account))
     }

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -1,6 +1,6 @@
 use crate::{
     traits::{BlockSource, ReceiptProvider},
-    AccountProvider, BlockHashProvider, BlockIdProvider, BlockNumProvider, BlockProvider,
+    AccountReader, BlockHashProvider, BlockIdProvider, BlockNumProvider, BlockProvider,
     BlockProviderIdExt, EvmEnvProvider, HeaderProvider, PostState, StageCheckpointReader,
     StateProvider, StateProviderBox, StateProviderFactory, StateRootProvider, TransactionsProvider,
     WithdrawalsProvider,
@@ -212,7 +212,7 @@ impl HeaderProvider for NoopProvider {
     }
 }
 
-impl AccountProvider for NoopProvider {
+impl AccountReader for NoopProvider {
     fn basic_account(&self, _address: Address) -> Result<Option<Account>> {
         Ok(None)
     }

--- a/crates/storage/provider/src/traits/account.rs
+++ b/crates/storage/provider/src/traits/account.rs
@@ -6,18 +6,18 @@ use std::{
     ops::{RangeBounds, RangeInclusive},
 };
 
-/// Account provider
+/// Account reader
 #[auto_impl(&, Arc, Box)]
-pub trait AccountProvider: Send + Sync {
+pub trait AccountReader: Send + Sync {
     /// Get basic account information.
     ///
     /// Returns `None` if the account doesn't exist.
     fn basic_account(&self, address: Address) -> Result<Option<Account>>;
 }
 
-/// Account provider
+/// Account reader
 #[auto_impl(&, Arc, Box)]
-pub trait AccountExtProvider: Send + Sync {
+pub trait AccountExtReader: Send + Sync {
     /// Iterate over account changesets and return all account address that were changed.
     fn changed_accounts_with_range(
         &self,
@@ -25,7 +25,7 @@ pub trait AccountExtProvider: Send + Sync {
     ) -> Result<BTreeSet<Address>>;
 
     /// Get basic account information for multiple accounts. A more efficient version than calling
-    /// [`AccountProvider::basic_account`] repeatedly.
+    /// [`AccountReader::basic_account`] repeatedly.
     ///
     /// Returns `None` if the account doesn't exist.
     fn basic_accounts(

--- a/crates/storage/provider/src/traits/account.rs
+++ b/crates/storage/provider/src/traits/account.rs
@@ -42,3 +42,27 @@ pub trait AccountExtReader: Send + Sync {
         range: RangeInclusive<BlockNumber>,
     ) -> Result<BTreeMap<Address, Vec<BlockNumber>>>;
 }
+
+/// Account reader
+#[auto_impl(&, Arc, Box)]
+pub trait AccountWriter: Send + Sync {
+    /// Unwind and clear account hashing
+    fn unwind_account_hashing(&self, range: RangeInclusive<BlockNumber>) -> Result<()>;
+
+    /// Unwind and clear account history indices.
+    ///
+    /// Returns number of changesets walked.
+    fn unwind_account_history_indices(&self, range: RangeInclusive<BlockNumber>) -> Result<usize>;
+
+    /// Insert account change index to database. Used inside AccountHistoryIndex stage
+    fn insert_account_history_index(
+        &self,
+        account_transitions: BTreeMap<Address, Vec<u64>>,
+    ) -> Result<()>;
+
+    /// iterate over accounts and insert them to hashing table
+    fn insert_account_for_hashing(
+        &self,
+        accounts: impl IntoIterator<Item = (Address, Option<Account>)>,
+    ) -> Result<()>;
+}

--- a/crates/storage/provider/src/traits/account.rs
+++ b/crates/storage/provider/src/traits/account.rs
@@ -1,7 +1,10 @@
 use auto_impl::auto_impl;
 use reth_interfaces::Result;
 use reth_primitives::{Account, Address, BlockNumber};
-use std::{collections::BTreeSet, ops::RangeBounds};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ops::{RangeBounds, RangeInclusive},
+};
 
 /// Account provider
 #[auto_impl(&, Arc, Box)]
@@ -29,4 +32,13 @@ pub trait AccountExtProvider: Send + Sync {
         &self,
         _iter: impl IntoIterator<Item = Address>,
     ) -> Result<Vec<(Address, Option<Account>)>>;
+
+    /// Iterate over account changesets and return all account addresses that were changed alongside
+    /// each specific set of blocks.
+    ///
+    /// NOTE: Get inclusive range of blocks.
+    fn changed_accounts_and_blocks_with_range(
+        &self,
+        range: RangeInclusive<BlockNumber>,
+    ) -> Result<BTreeMap<Address, Vec<BlockNumber>>>;
 }

--- a/crates/storage/provider/src/traits/mod.rs
+++ b/crates/storage/provider/src/traits/mod.rs
@@ -1,7 +1,7 @@
 //! Collection of common provider traits.
 
 mod account;
-pub use account::{AccountExtProvider, AccountProvider};
+pub use account::{AccountExtReader, AccountReader};
 
 mod block;
 pub use block::{BlockProvider, BlockProviderIdExt, BlockSource};

--- a/crates/storage/provider/src/traits/mod.rs
+++ b/crates/storage/provider/src/traits/mod.rs
@@ -1,7 +1,7 @@
 //! Collection of common provider traits.
 
 mod account;
-pub use account::{AccountExtReader, AccountReader};
+pub use account::{AccountExtReader, AccountReader, AccountWriter};
 
 mod block;
 pub use block::{BlockProvider, BlockProviderIdExt, BlockSource};

--- a/crates/storage/provider/src/traits/state.rs
+++ b/crates/storage/provider/src/traits/state.rs
@@ -1,4 +1,4 @@
-use super::AccountProvider;
+use super::AccountReader;
 use crate::{post_state::PostState, BlockHashProvider, BlockIdProvider};
 use auto_impl::auto_impl;
 use reth_interfaces::{provider::ProviderError, Result};
@@ -13,7 +13,7 @@ pub type StateProviderBox<'a> = Box<dyn StateProvider + 'a>;
 /// An abstraction for a type that provides state data.
 #[auto_impl(&, Arc, Box)]
 pub trait StateProvider:
-    BlockHashProvider + AccountProvider + StateRootProvider + Send + Sync
+    BlockHashProvider + AccountReader + StateRootProvider + Send + Sync
 {
     /// Get storage of given account.
     fn storage(&self, account: Address, storage_key: StorageKey) -> Result<Option<StorageValue>>;

--- a/crates/transaction-pool/src/validate.rs
+++ b/crates/transaction-pool/src/validate.rs
@@ -11,7 +11,7 @@ use reth_primitives::{
     TransactionSignedEcRecovered, TxHash, EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID,
     LEGACY_TX_TYPE_ID, U256,
 };
-use reth_provider::{AccountProvider, StateProviderFactory};
+use reth_provider::{AccountReader, StateProviderFactory};
 use std::{fmt, marker::PhantomData, sync::Arc, time::Instant};
 
 /// A Result type returned after checking a transaction's validity.


### PR DESCRIPTION
* Renames `AccountProvider` to `AccountReader` & `AccountWriter`.
* Adds `AccountWriter` and move some relevant methods there.
* Removes some duplicate methods on the provider