### PR TITLE
fix: don't send engine events for dupe payloads

### DIFF
--- a/crates/blockchain-tree/src/shareable.rs
+++ b/crates/blockchain-tree/src/shareable.rs
@@ -4,8 +4,8 @@ use parking_lot::RwLock;
 use reth_db::database::Database;
 use reth_interfaces::{
     blockchain_tree::{
-        error::InsertBlockError, BlockStatus, BlockchainTreeEngine, BlockchainTreeViewer,
-        CanonicalOutcome,
+        error::InsertBlockError, BlockchainTreeEngine, BlockchainTreeViewer, CanonicalOutcome,
+        InsertPayloadOk,
     },
     consensus::Consensus,
     Error,
@@ -44,7 +44,10 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeEngine
         self.tree.write().buffer_block(block)
     }
 
-    fn insert_block(&self, block: SealedBlockWithSenders) -> Result<BlockStatus, InsertBlockError> {
+    fn insert_block(
+        &self,
+        block: SealedBlockWithSenders,
+    ) -> Result<InsertPayloadOk, InsertBlockError> {
         trace!(target: "blockchain_tree", hash=?block.hash, number=block.number, parent_hash=?block.parent_hash, "Inserting block");
         self.tree.write().insert_block(block)
     }

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -915,7 +915,10 @@ where
                 // not known to be invalid, but we don't know anything else
                 PayloadStatusEnum::Syncing
             }
-            InsertPayloadOk::AlreadySeen(BlockStatus::Valid) => PayloadStatusEnum::Valid,
+            InsertPayloadOk::AlreadySeen(BlockStatus::Valid) => {
+                latest_valid_hash = Some(block_hash);
+                PayloadStatusEnum::Valid
+            }
             InsertPayloadOk::AlreadySeen(BlockStatus::Accepted) => PayloadStatusEnum::Accepted,
         };
         Ok(PayloadStatus::new(status, latest_valid_hash))

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -60,6 +60,7 @@ pub(crate) mod sync;
 
 use crate::engine::forkchoice::{ForkchoiceStateHash, ForkchoiceStateTracker};
 pub use event::BeaconConsensusEngineEvent;
+use reth_interfaces::blockchain_tree::InsertPayloadOk;
 
 /// The maximum number of invalid headers that can be tracked by the engine.
 const MAX_INVALID_HEADERS: u32 = 512u32;
@@ -893,16 +894,17 @@ where
         let mut latest_valid_hash = None;
         let block = Arc::new(block);
         let status = match status {
-            BlockStatus::Valid => {
+            InsertPayloadOk::Inserted(BlockStatus::Valid) => {
                 latest_valid_hash = Some(block_hash);
                 self.listeners.notify(BeaconConsensusEngineEvent::CanonicalBlockAdded(block));
                 PayloadStatusEnum::Valid
             }
-            BlockStatus::Accepted => {
+            InsertPayloadOk::Inserted(BlockStatus::Accepted) => {
                 self.listeners.notify(BeaconConsensusEngineEvent::ForkBlockAdded(block));
                 PayloadStatusEnum::Accepted
             }
-            BlockStatus::Disconnected { .. } => {
+            InsertPayloadOk::Inserted(BlockStatus::Disconnected { .. }) |
+            InsertPayloadOk::AlreadySeen(BlockStatus::Disconnected { .. }) => {
                 // check if the block's parent is already marked as invalid
                 if let Some(status) =
                     self.check_invalid_ancestor_with_head(block.parent_hash, block.hash)
@@ -913,6 +915,8 @@ where
                 // not known to be invalid, but we don't know anything else
                 PayloadStatusEnum::Syncing
             }
+            InsertPayloadOk::AlreadySeen(BlockStatus::Valid) => PayloadStatusEnum::Valid,
+            InsertPayloadOk::AlreadySeen(BlockStatus::Accepted) => PayloadStatusEnum::Accepted,
         };
         Ok(PayloadStatus::new(status, latest_valid_hash))
     }
@@ -1014,18 +1018,19 @@ where
         match self.blockchain.insert_block_without_senders(block) {
             Ok(status) => {
                 match status {
-                    BlockStatus::Valid => {
+                    InsertPayloadOk::Inserted(BlockStatus::Valid) => {
                         // block is connected to the current canonical head and is valid.
                         self.try_make_sync_target_canonical(num_hash);
                     }
-                    BlockStatus::Accepted => {
+                    InsertPayloadOk::Inserted(BlockStatus::Accepted) => {
                         // block is connected to the canonical chain, but not the current head
                         self.try_make_sync_target_canonical(num_hash);
                     }
-                    BlockStatus::Disconnected { missing_parent } => {
+                    InsertPayloadOk::Inserted(BlockStatus::Disconnected { missing_parent }) => {
                         // continue downloading the missing parent
                         self.sync.download_full_block(missing_parent.hash);
                     }
+                    _ => (),
                 }
             }
             Err(err) => {

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use reth_db::{database::Database, models::StoredBlockBodyIndices};
 use reth_interfaces::{
-    blockchain_tree::{BlockStatus, BlockchainTreeEngine, BlockchainTreeViewer},
+    blockchain_tree::{BlockchainTreeEngine, BlockchainTreeViewer},
     consensus::ForkchoiceState,
     Error, Result,
 };
@@ -37,7 +37,9 @@ mod state;
 use crate::{providers::chain_info::ChainInfoTracker, traits::BlockSource};
 pub use database::*;
 pub use post_state_provider::PostStateProvider;
-use reth_interfaces::blockchain_tree::{error::InsertBlockError, CanonicalOutcome};
+use reth_interfaces::blockchain_tree::{
+    error::InsertBlockError, CanonicalOutcome, InsertPayloadOk,
+};
 
 /// The main type for interacting with the blockchain.
 ///
@@ -537,7 +539,7 @@ where
     fn insert_block(
         &self,
         block: SealedBlockWithSenders,
-    ) -> std::result::Result<BlockStatus, InsertBlockError> {
+    ) -> std::result::Result<InsertPayloadOk, InsertBlockError> {
         self.tree.insert_block(block)
     }
 


### PR DESCRIPTION
Makes `insert_block` (and variants) return an enum that denotes whether the payload was inserted or already seen, and only sends `BeaconConsensusEngineEvent`s if the payloads have not been seen before

Closes #2843