### PR TITLE
chore: use workspace version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5314,7 +5314,7 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "0.1.6"
+version = "0.1.0"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",
@@ -5334,7 +5334,7 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "0.12.6-0"
+version = "0.1.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -5577,7 +5577,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rlp"
-version = "0.1.2"
+version = "0.1.0"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rlp-derive"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "proc-macro2 1.0.60",
  "quote 1.0.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ default-members = ["bin/reth"]
 resolver = "2"
 
 [workspace.package]
+version = "0.1.0"
 edition = "2021"
 rust-version = "1.70" # Remember to update .clippy.toml and README.md
 license = "MIT OR Apache-2.0"

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/blockchain-tree/Cargo.toml
+++ b/crates/blockchain-tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-blockchain-tree"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-config"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/consensus/auto-seal/Cargo.toml
+++ b/crates/consensus/auto-seal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-auto-seal-consensus"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/consensus/beacon/Cargo.toml
+++ b/crates/consensus/beacon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-beacon-consensus"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/consensus/common/Cargo.toml
+++ b/crates/consensus/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-consensus-common"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/interfaces/Cargo.toml
+++ b/crates/interfaces/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-interfaces"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-metrics"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/metrics/metrics-derive/Cargo.toml
+++ b/crates/metrics/metrics-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-metrics-derive"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/net/common/Cargo.toml
+++ b/crates/net/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-net-common"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/net/discv4/Cargo.toml
+++ b/crates/net/discv4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-discv4"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/net/dns/Cargo.toml
+++ b/crates/net/dns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-dns-discovery"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/net/downloaders/Cargo.toml
+++ b/crates/net/downloaders/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-downloaders"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/net/ecies/Cargo.toml
+++ b/crates/net/ecies/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-ecies"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/net/eth-wire/Cargo.toml
+++ b/crates/net/eth-wire/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "reth-eth-wire"
 description = "Implements the eth/64 and eth/65 P2P protocols"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/net/nat/Cargo.toml
+++ b/crates/net/nat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-net-nat"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/net/network-api/Cargo.toml
+++ b/crates/net/network-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-network-api"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-network"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/payload/basic/Cargo.toml
+++ b/crates/payload/basic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-basic-payload-builder"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-payload-builder"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -12,7 +12,7 @@ description = "Commonly used types in reth."
 # reth
 reth-rlp = { workspace = true, features = ["std", "derive", "ethereum-types"] }
 reth-rlp-derive = { path = "../rlp/rlp-derive" }
-reth-codecs = { version = "0.1.0", path = "../storage/codecs" }
+reth-codecs = { path = "../storage/codecs" }
 
 revm-primitives = { workspace = true, features = ["serde"] }
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-primitives"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-revm"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/revm/revm-inspectors/Cargo.toml
+++ b/crates/revm/revm-inspectors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-revm-inspectors"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/revm/revm-primitives/Cargo.toml
+++ b/crates/revm/revm-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-revm-primitives"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rlp/Cargo.toml
+++ b/crates/rlp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-rlp"
-version = "0.1.2"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license = "Apache-2.0"

--- a/crates/rlp/Cargo.toml
+++ b/crates/rlp/Cargo.toml
@@ -16,7 +16,7 @@ ethnum = { version = "1", default-features = false, optional = true }
 smol_str = { version = "0.1", default-features = false, optional = true }
 ethereum-types = { version = "0.14", features = ["codec"], optional = true }
 revm-primitives = { workspace = true, features = ["serde"] }
-reth-rlp-derive = { version = "0.1", path = "./rlp-derive", optional = true }
+reth-rlp-derive = {  path = "./rlp-derive", optional = true }
 
 [dev-dependencies]
 reth-rlp = { workspace = true, features = [

--- a/crates/rlp/rlp-derive/Cargo.toml
+++ b/crates/rlp/rlp-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-rlp-derive"
-version = "0.1.1"
+version.workspace = true
 license = "Apache-2.0"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/rpc/ipc/Cargo.toml
+++ b/crates/rpc/ipc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-ipc"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rpc/rpc-api/Cargo.toml
+++ b/crates/rpc/rpc-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-rpc-api"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rpc/rpc-builder/Cargo.toml
+++ b/crates/rpc/rpc-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-rpc-builder"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rpc/rpc-engine-api/Cargo.toml
+++ b/crates/rpc/rpc-engine-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-rpc-engine-api"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rpc/rpc-testing-util/Cargo.toml
+++ b/crates/rpc/rpc-testing-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-rpc-api-testing-util"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rpc/rpc-types/Cargo.toml
+++ b/crates/rpc/rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-rpc-types"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-rpc"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/staged-sync/Cargo.toml
+++ b/crates/staged-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-staged-sync"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/stages/Cargo.toml
+++ b/crates/stages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-stages"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/storage/codecs/Cargo.toml
+++ b/crates/storage/codecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-codecs"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/storage/codecs/Cargo.toml
+++ b/crates/storage/codecs/Cargo.toml
@@ -17,7 +17,7 @@ arbitrary = ["revm-primitives/arbitrary", "dep:arbitrary", "dep:proptest", "dep:
 
 [dependencies]
 bytes = "1.4"
-codecs-derive = { version = "0.1.0", path = "./derive", default-features = false }
+codecs-derive = { path = "./derive", default-features = false }
 revm-primitives = { workspace = true, features = ["serde"] }
 
 # arbitrary utils

--- a/crates/storage/codecs/derive/Cargo.toml
+++ b/crates/storage/codecs/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codecs-derive"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/storage/db/Cargo.toml
+++ b/crates/storage/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-db"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/storage/libmdbx-rs/Cargo.toml
+++ b/crates/storage/libmdbx-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-libmdbx"
-version = "0.1.6"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license = "Apache-2.0"

--- a/crates/storage/libmdbx-rs/mdbx-sys/Cargo.toml
+++ b/crates/storage/libmdbx-rs/mdbx-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-mdbx-sys"
-version = "0.12.6-0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license = "Apache-2.0"

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-provider"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/tasks/Cargo.toml
+++ b/crates/tasks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-tasks"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-tracing"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-transaction-pool"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trie/Cargo.toml
+++ b/crates/trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-trie"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/testing/ef-tests/Cargo.toml
+++ b/testing/ef-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ef-tests"
-version = "0.1.0"
+version.workspace = true
 description = "EF testing support for reth."
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
Since we are not going to publish to crates.io for a while, using a singular workspace version makes bumping easier