### PR TITLE
chore: `db-tools` Make target for MDBX debugging tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,8 @@ proptest-regressions/
 # Release artifacts
 dist/
 
+# Database debugging tools
+db-tools/
+
 # VSCode
 .vscode

--- a/Makefile
+++ b/Makefile
@@ -167,5 +167,5 @@ db-tools:
 		mv mdbx_stat $(FULL_DB_TOOLS_DIR)
     # `IOARENA=1` silences benchmarking info message that is printed to stderr
 	@cd crates/storage/libmdbx-rs/mdbx-sys/libmdbx && make IOARENA=1 clean > /dev/null
-	@echo "Run \"$(DB_TOOLS_DIR)/mdbx_stat -h\" for the info about MDBX db file."
-	@echo "Run \"$(DB_TOOLS_DIR)/mdbx_chk -h\" for the MDBX db file integrity check."
+	@echo "Run \"$(DB_TOOLS_DIR)/mdbx_stat\" for the info about MDBX db file."
+	@echo "Run \"$(DB_TOOLS_DIR)/mdbx_chk\" for the MDBX db file integrity check."

--- a/Makefile
+++ b/Makefile
@@ -154,10 +154,18 @@ clean:
 # Compile MDBX debugging tools
 .PHONY: db-tools
 db-tools:
-	@echo "Building MDBX debugging tools"
-	@cd crates/storage/libmdbx-rs/mdbx-sys/libmdbx && make tools
+	@echo "Building MDBX debugging tools..."
+    # `IOARENA=1` silences benchmarking info message that is printed to stderr
+	@cd crates/storage/libmdbx-rs/mdbx-sys/libmdbx && make IOARENA=1 tools > /dev/null
 	@mkdir -p $(DB_TOOLS_DIR)
-	@cd crates/storage/libmdbx-rs/mdbx-sys/libmdbx && cp mdbx_chk $(FULL_DB_TOOLS_DIR) && cp mdbx_copy $(FULL_DB_TOOLS_DIR) && cp mdbx_dump $(FULL_DB_TOOLS_DIR) && cp mdbx_drop $(FULL_DB_TOOLS_DIR) && cp mdbx_load $(FULL_DB_TOOLS_DIR) && cp mdbx_stat $(FULL_DB_TOOLS_DIR)
-	@cd crates/storage/libmdbx-rs/mdbx-sys/libmdbx && make clean
+	@cd crates/storage/libmdbx-rs/mdbx-sys/libmdbx && \
+		mv mdbx_chk $(FULL_DB_TOOLS_DIR) && \
+		mv mdbx_copy $(FULL_DB_TOOLS_DIR) && \
+		mv mdbx_dump $(FULL_DB_TOOLS_DIR) && \
+		mv mdbx_drop $(FULL_DB_TOOLS_DIR) && \
+		mv mdbx_load $(FULL_DB_TOOLS_DIR) && \
+		mv mdbx_stat $(FULL_DB_TOOLS_DIR)
+    # `IOARENA=1` silences benchmarking info message that is printed to stderr
+	@cd crates/storage/libmdbx-rs/mdbx-sys/libmdbx && make IOARENA=1 clean > /dev/null
 	@echo "Run \"$(DB_TOOLS_DIR)/mdbx_stat -h\" for the info about MDBX db file."
 	@echo "Run \"$(DB_TOOLS_DIR)/mdbx_chk -h\" for the MDBX db file integrity check."

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 # Heavily inspired by Lighthouse: https://github.com/sigp/lighthouse/blob/693886b94176faa4cb450f024696cb69cda2fe58/Makefile
 
-GIT_TAG := $(shell git describe --tags --abbrev=0)
+GIT_TAG ?= $(shell git describe --tags --abbrev=0)
 BIN_DIR = "dist/bin"
+DB_TOOLS_DIR = "db-tools"
+FULL_DB_TOOLS_DIR := $(shell pwd)/$(DB_TOOLS_DIR)/
 
 BUILD_PATH = "target"
 
@@ -148,3 +150,14 @@ clean:
 	cargo clean
 	rm -rf $(BIN_DIR)
 	rm -rf $(EF_TESTS_DIR)
+
+# Compile MDBX debugging tools
+.PHONY: db-tools
+db-tools:
+	@echo "Building MDBX debugging tools"
+	@cd crates/storage/libmdbx-rs/mdbx-sys/libmdbx && make tools
+	@mkdir -p $(DB_TOOLS_DIR)
+	@cd crates/storage/libmdbx-rs/mdbx-sys/libmdbx && cp mdbx_chk $(FULL_DB_TOOLS_DIR) && cp mdbx_copy $(FULL_DB_TOOLS_DIR) && cp mdbx_dump $(FULL_DB_TOOLS_DIR) && cp mdbx_drop $(FULL_DB_TOOLS_DIR) && cp mdbx_load $(FULL_DB_TOOLS_DIR) && cp mdbx_stat $(FULL_DB_TOOLS_DIR)
+	@cd crates/storage/libmdbx-rs/mdbx-sys/libmdbx && make clean
+	@echo "Run \"$(DB_TOOLS_DIR)/mdbx_stat -h\" for the info about MDBX db file."
+	@echo "Run \"$(DB_TOOLS_DIR)/mdbx_chk -h\" for the MDBX db file integrity check."

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 
 GIT_TAG ?= $(shell git describe --tags --abbrev=0)
 BIN_DIR = "dist/bin"
+
+MDBX_PATH = "crates/storage/libmdbx-rs/mdbx-sys/libmdbx"
 DB_TOOLS_DIR = "db-tools"
 FULL_DB_TOOLS_DIR := $(shell pwd)/$(DB_TOOLS_DIR)/
 
@@ -156,9 +158,9 @@ clean:
 db-tools:
 	@echo "Building MDBX debugging tools..."
     # `IOARENA=1` silences benchmarking info message that is printed to stderr
-	@cd crates/storage/libmdbx-rs/mdbx-sys/libmdbx && make IOARENA=1 tools > /dev/null
+	@$(MAKE) -C $(MDBX_PATH) IOARENA=1 tools > /dev/null
 	@mkdir -p $(DB_TOOLS_DIR)
-	@cd crates/storage/libmdbx-rs/mdbx-sys/libmdbx && \
+	@cd $(MDBX_PATH) && \
 		mv mdbx_chk $(FULL_DB_TOOLS_DIR) && \
 		mv mdbx_copy $(FULL_DB_TOOLS_DIR) && \
 		mv mdbx_dump $(FULL_DB_TOOLS_DIR) && \
@@ -166,6 +168,6 @@ db-tools:
 		mv mdbx_load $(FULL_DB_TOOLS_DIR) && \
 		mv mdbx_stat $(FULL_DB_TOOLS_DIR)
     # `IOARENA=1` silences benchmarking info message that is printed to stderr
-	@cd crates/storage/libmdbx-rs/mdbx-sys/libmdbx && make IOARENA=1 clean > /dev/null
+	@$(MAKE) -C $(MDBX_PATH) IOARENA=1 clean > /dev/null
 	@echo "Run \"$(DB_TOOLS_DIR)/mdbx_stat\" for the info about MDBX db file."
 	@echo "Run \"$(DB_TOOLS_DIR)/mdbx_chk\" for the MDBX db file integrity check."


### PR DESCRIPTION
### Build
```console
➜  reth (alexey/db-tools) ls db-tools
"db-tools": No such file or directory (os error 2)

➜  reth (alexey/db-tools) make db-tools                                                             
Building MDBX debugging tools...
Run "db-tools/mdbx_stat" for the info about MDBX db file.
Run "db-tools/mdbx_chk" for the MDBX db file integrity check.
```

### Run tools
```console
➜  reth (alexey/db-tools) db-tools/mdbx_stat ~/Library/Application\ Support/reth/sepolia/db/mdbx.dat
mdbx_stat v0.12.6-0-gc019631a (2023-04-29T21:30:35+03:00, T-44de01dd81ac366a7d37111eaf72726edebe5528)
Running for /Users/shekhirin/Library/Application Support/reth/sepolia/db/mdbx.dat...
Status of Main DB
  Pagesize: 16384
  Tree depth: 0
  Branch pages: 0
  Leaf pages: 0
  Overflow pages: 0
  Entries: 0

➜  reth (alexey/db-tools) db-tools/mdbx_chk ~/Library/Application\ Support/reth/sepolia/db/mdbx.dat 
mdbx_chk v0.12.6-0-gc019631a (2023-04-29T21:30:35+03:00, T-44de01dd81ac366a7d37111eaf72726edebe5528)
Running for /Users/shekhirin/Library/Application Support/reth/sepolia/db/mdbx.dat in 'read-only' mode...
Traversal b-tree by txn#3...
Scanning @MAIN for sub-database(s)...
No error is detected, elapsed 0.018 seconds
```

### Build again, shouldn't crash
```console
➜  reth (alexey/db-tools) make db-tools                                                             
Building MDBX debugging tools...
Run "db-tools/mdbx_stat" for the info about MDBX db file.
Run "db-tools/mdbx_chk" for the MDBX db file integrity check.
```

### Check `git status`, everything should be clean
```console
➜  reth (alexey/db-tools) git status
On branch alexey/db-tools
Your branch is up to date with 'origin/alexey/db-tools'.

nothing to commit, working tree clean
```