### PR TITLE
chore: decrease pipeline min blocks

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -61,13 +61,14 @@ pub(crate) mod sync;
 use crate::engine::forkchoice::{ForkchoiceStateHash, ForkchoiceStateTracker};
 pub use event::BeaconConsensusEngineEvent;
 use reth_interfaces::blockchain_tree::InsertPayloadOk;
+use reth_primitives::constants::EPOCH_SLOTS;
 
 /// The maximum number of invalid headers that can be tracked by the engine.
 const MAX_INVALID_HEADERS: u32 = 512u32;
 
 /// The largest gap for which the tree will be used for sync. See docs for `pipeline_run_threshold`
 /// for more information.
-pub const MIN_BLOCKS_FOR_PIPELINE_RUN: u64 = 128;
+pub const MIN_BLOCKS_FOR_PIPELINE_RUN: u64 = 2 * EPOCH_SLOTS;
 
 /// A _shareable_ beacon consensus frontend. Used to interact with the spawned beacon consensus
 /// engine.

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -13,6 +13,9 @@ pub const SELECTOR_LEN: usize = 4;
 /// Maximum extra data size in a block after genesis
 pub const MAXIMUM_EXTRA_DATA_SIZE: usize = 32;
 
+/// An EPOCH is a series of 32 slots.
+pub const EPOCH_SLOTS: u64 = 32;
+
 /// The duration of a slot in seconds.
 ///
 /// This is the time period of 12 seconds in which a randomly chosen validator has time to propose a
@@ -20,7 +23,7 @@ pub const MAXIMUM_EXTRA_DATA_SIZE: usize = 32;
 pub const SLOT_DURATION: Duration = Duration::from_secs(12);
 
 /// An EPOCH is a series of 32 slots (~6.4min).
-pub const EPOCH_DURATION: Duration = Duration::from_secs(12 * 32);
+pub const EPOCH_DURATION: Duration = Duration::from_secs(12 * EPOCH_SLOTS);
 
 /// The default block nonce in the beacon consensus
 pub const BEACON_NONCE: u64 = 0u64;


### PR DESCRIPTION
128 is quite a bit and can cause sideffects atm because we could end up executing all those buffered blocks which takes some time