### PR TITLE
perf: spawn engine as blocking

### DIFF
--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -392,7 +392,7 @@ impl Command {
         // Run consensus engine to completion
         let (tx, rx) = oneshot::channel();
         info!(target: "reth::cli", "Starting consensus engine");
-        ctx.task_executor.spawn_critical("consensus engine", async move {
+        ctx.task_executor.spawn_critical_blocking("consensus engine", async move {
             let res = beacon_consensus_engine.await;
             let _ = tx.send(res);
         });


### PR DESCRIPTION
consensus engine can block for longer periods (e.g. executing several blocks in a row) and should be spawned on a blocking task instead.

ref https://ryhl.io/blog/async-what-is-blocking/