### PR TITLE
fix: give js service access to modified state

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/js/bindings.rs
+++ b/crates/revm/revm-inspectors/src/tracing/js/bindings.rs
@@ -711,7 +711,11 @@ impl EvmDBInner {
         let slot = bytes_to_hash(buf);
 
         let (tx, rx) = channel();
-        if self.to_db.try_send(JsDbRequest::StorageAt { address, index: slot, resp: tx }).is_err() {
+        if self
+            .to_db
+            .try_send(JsDbRequest::StorageAt { address, index: slot.into(), resp: tx })
+            .is_err()
+        {
             return Err(JsError::from_native(JsNativeError::error().with_message(format!(
                 "Failed to read state for {address:?} at {slot:?} from database",
             ))))

--- a/crates/revm/revm-inspectors/src/tracing/js/mod.rs
+++ b/crates/revm/revm-inspectors/src/tracing/js/mod.rs
@@ -506,7 +506,7 @@ pub enum JsDbRequest {
         /// The address of the account
         address: Address,
         /// Index of the storage slot
-        index: H256,
+        index: U256,
         /// The response channel
         resp: std::sync::mpsc::Sender<Result<U256, String>>,
     },


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/3148

The JS tracers can have access to the database. reth's StateProviderBox is not shareable which makes this a bit complex, and very expensive for block traces because these use modified CachedDB which needs to be cloned and send to the JS service...

So the js service task that handles requests from the JS objects needs a clone of the `CacheDB`