### PR TITLE
fix: rm `node` from dockerfile entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
 WORKDIR app
 
+LABEL org.opencontainers.image.source=https://github.com/paradigmxyz/reth
+LABEL org.opencontainers.image.licenses="MIT OR Apache-2.0"
+
 # Builds a cargo-chef plan
 FROM chef AS planner
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ WORKDIR app
 COPY --from=builder /app/target/release/reth /usr/local/bin
 
 EXPOSE 30303 30303/udp 9000 8545 8546
-ENTRYPOINT ["/usr/local/bin/reth", "node"]
+ENTRYPOINT ["/usr/local/bin/reth"]

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -9,4 +9,4 @@ ARG TARGETARCH
 COPY ./dist/bin/$TARGETARCH/reth /usr/local/bin/reth
 
 EXPOSE 30303 30303/udp 9000 8545 8546
-ENTRYPOINT ["/usr/local/bin/reth", "node"]
+ENTRYPOINT ["/usr/local/bin/reth"]

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -3,6 +3,9 @@
 # locatable in `./dist/bin/$TARGETARCH`
 FROM --platform=$TARGETPLATFORM ubuntu:22.04
 
+LABEL org.opencontainers.image.source=https://github.com/paradigmxyz/reth
+LABEL org.opencontainers.image.licenses="MIT OR Apache-2.0"
+
 # Filled by docker buildx
 ARG TARGETARCH
 

--- a/book/installation/docker.md
+++ b/book/installation/docker.md
@@ -27,7 +27,7 @@ docker pull ghcr.io/paradigmxyz/reth:v0.0.1
 You can test the image with:
 
 ```bash
-docker run --rm ghcr.io/paradigmxyz/reth reth --version
+docker run --rm ghcr.io/paradigmxyz/reth --version
 ```
 
 If you can see the latest [Reth release](https://github.com/paradigmxyz/reth/releases) version, then you've successfully installed Reth via Docker.
@@ -43,5 +43,5 @@ docker build . -t reth:local
 The build will likely take several minutes. Once it's built, test it with:
 
 ```bash
-docker run reth:local reth --version
+docker run reth:local --version
 ```


### PR DESCRIPTION
Makes it so any arg passed to a docker container running this image is treated as an arg to `reth`, e.g. `node` would be treated as `reth node` etc.

Currently everything is being treated as an arg to `reth node`