### PR TITLE
chore: improve empty hardforks panic message

### DIFF
--- a/crates/revm/revm-primitives/src/config.rs
+++ b/crates/revm/revm-primitives/src/config.rs
@@ -42,7 +42,10 @@ pub fn revm_spec(chain_spec: &ChainSpec, block: Head) -> revm::primitives::SpecI
     } else if chain_spec.fork(Hardfork::Frontier).active_at_head(&block) {
         revm::primitives::FRONTIER
     } else {
-        panic!("wrong configuration")
+        panic!(
+            "invalid hardfork chainspec: expected at least one hardfork, got {:?}",
+            chain_spec.hardforks
+        )
     }
 }
 


### PR DESCRIPTION
ref https://github.com/paradigmxyz/reth/issues/3278

improve panic if no hardforks are configured, this is only relevant for custom chainspecs.

I think we should even catch this during parsing, and check what the common behaviour is here