### PR TITLE
perf: fetch total difficulty by block number

### DIFF
--- a/crates/rpc/rpc/src/eth/api/block.rs
+++ b/crates/rpc/rpc/src/eth/api/block.rs
@@ -102,8 +102,10 @@ where
             None => return Ok(None),
         };
         let block_hash = block.hash;
-        let total_difficulty =
-            self.provider().header_td(&block_hash)?.ok_or(EthApiError::UnknownBlockNumber)?;
+        let total_difficulty = self
+            .provider()
+            .header_td_by_number(block.number)?
+            .ok_or(EthApiError::UnknownBlockNumber)?;
         let block =
             Block::from_block(block.into(), total_difficulty, full.into(), Some(block_hash))?;
         Ok(Some(block.into()))


### PR DESCRIPTION
closes #2864

`header_td_by_number` is optimized to check against merge height post merge

and this will no longer use hash to number lookup