### PR TITLE
chore: change `metrics` default port from `9000` to `9001`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,5 +33,5 @@ WORKDIR app
 # Copy reth over from the build stage
 COPY --from=builder /app/target/release/reth /usr/local/bin
 
-EXPOSE 30303 30303/udp 9000 8545 8546
+EXPOSE 30303 30303/udp 9001 8545 8546
 ENTRYPOINT ["/usr/local/bin/reth"]

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -11,5 +11,5 @@ ARG TARGETARCH
 
 COPY ./dist/bin/$TARGETARCH/reth /usr/local/bin/reth
 
-EXPOSE 30303 30303/udp 9000 8545 8546
+EXPOSE 30303 30303/udp 9001 8545 8546
 ENTRYPOINT ["/usr/local/bin/reth"]

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -781,14 +781,14 @@ mod tests {
 
     #[test]
     fn parse_metrics_port() {
-        let cmd = Command::try_parse_from(["reth", "--metrics", "9000"]).unwrap();
-        assert_eq!(cmd.metrics, Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9000)));
+        let cmd = Command::try_parse_from(["reth", "--metrics", "9001"]).unwrap();
+        assert_eq!(cmd.metrics, Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9001)));
 
-        let cmd = Command::try_parse_from(["reth", "--metrics", ":9000"]).unwrap();
-        assert_eq!(cmd.metrics, Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9000)));
+        let cmd = Command::try_parse_from(["reth", "--metrics", ":9001"]).unwrap();
+        assert_eq!(cmd.metrics, Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9001)));
 
-        let cmd = Command::try_parse_from(["reth", "--metrics", "localhost:9000"]).unwrap();
-        assert_eq!(cmd.metrics, Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9000)));
+        let cmd = Command::try_parse_from(["reth", "--metrics", "localhost:9001"]).unwrap();
+        assert_eq!(cmd.metrics, Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9001)));
     }
 
     #[test]

--- a/book/run/observability.md
+++ b/book/run/observability.md
@@ -3,13 +3,13 @@
 Reth exposes a number of metrics, which are listed [here][metrics]. We can serve them from an HTTP endpoint by adding the `--metrics` flag:
 
 ```bash
-RUST_LOG=info reth node --metrics 127.0.0.1:9000
+RUST_LOG=info reth node --metrics 127.0.0.1:9001
 ```
 
 Now, as the node is running, you can `curl` the endpoint you provided to the `--metrics` flag to get a text dump of the metrics at that time:
 
 ```bash
-curl 127.0.0.1:9000
+curl 127.0.0.1:9001
 ```
 
 The response from this is quite descriptive, but it can be a bit verbose. Plus, it's just a snapshot of the metrics at the time that you `curl`ed the endpoint.
@@ -17,7 +17,7 @@ The response from this is quite descriptive, but it can be a bit verbose. Plus, 
 You can run the following command in a separate terminal to periodically poll the endpoint, and just print the values (without the header text) to the terminal:
 
 ```bash
-while true; do date; curl -s localhost:9000 | grep -Ev '^(#|$)' | sort; echo; sleep 10; done
+while true; do date; curl -s localhost:9001 | grep -Ev '^(#|$)' | sort; echo; sleep 10; done
 ```
 
 We're finally getting somewhere! As a final step, though, wouldn't it be great to see how these metrics progress over time (and generally, in a GUI)?
@@ -43,13 +43,13 @@ brew services start prometheus
 brew services start grafana
 ```
 
-This will start a Prometheus service which by default scrapes the metrics exposed at `localhost:9000`. If you launched reth with a different `--metrics` endpoint, you can change the Prometheus config file at `/usr/local/etc/prometheus/prometheus.yml` to point to the correct endpoint, and then restart the Prometheus service. You can also stop the service and launch Prometheus with a custom `prometheus.yml` like the one provided under [`etc/prometheus/prometheus.yml`](https://github.com/paradigmxyz/reth/blob/main/etc/prometheus/prometheus.yml) in this repo.
+This will start a Prometheus service which by default scrapes the metrics exposed at `localhost:9001`. If you launched reth with a different `--metrics` endpoint, you can change the Prometheus config file at `/usr/local/etc/prometheus/prometheus.yml` to point to the correct endpoint, and then restart the Prometheus service. You can also stop the service and launch Prometheus with a custom `prometheus.yml` like the one provided under [`etc/prometheus/prometheus.yml`](https://github.com/paradigmxyz/reth/blob/main/etc/prometheus/prometheus.yml) in this repo.
 
 Next, open up "localhost:3000" in your browser, which is the default URL for Grafana. Here, "admin" is the default for both the username and password.
 
 Once you've logged in, click on the gear icon in the lower left, and select "Data Sources". Click on "Add data source", and select "Prometheus" as the type. In the HTTP URL field, enter `http://localhost:9090`, this is the default endpoint for the Prometheus scrape endpoint. Finally, click "Save & Test".
 
-As this might be a point of confusion, `localhost:9000`, which we supplied to `--metrics`, is the endpoint that Reth exposes, from which Prometheus collects metrics. Prometheus then exposes `localhost:9090` (by default) for other services (such as Grafana) to consume Prometheus metrics.
+As this might be a point of confusion, `localhost:9001`, which we supplied to `--metrics`, is the endpoint that Reth exposes, from which Prometheus collects metrics. Prometheus then exposes `localhost:9090` (by default) for other services (such as Grafana) to consume Prometheus metrics.
 
 To configure the dashboard in Grafana, click on the squares icon in the upper left, and click on "New", then "Import". From there, click on "Upload JSON file", and select the example file in `reth/etc/grafana/overview.json`. Finally, select the Prometheus data source you just created, and click "Import".
 

--- a/etc/README.md
+++ b/etc/README.md
@@ -12,7 +12,7 @@ The files in this directory may undergo a lot of changes while reth is unstable,
 ### Docker Compose
 
 To run Grafana dashboard with example dashboard and pre-configured Prometheus data source pointing at
-the locally running Reth instance with metrics exposed on `localhost:9000`:
+the locally running Reth instance with metrics exposed on `localhost:9001`:
 ```sh
 docker compose -p reth -f ./etc/docker-monitoring.yml up
 ```

--- a/etc/prometheus/prometheus.yml
+++ b/etc/prometheus/prometheus.yml
@@ -3,4 +3,4 @@ scrape_configs:
     metrics_path: "/"
     scrape_interval: 5s
     static_configs:
-      - targets: ['localhost:9000', 'host.docker.internal:9000']
+      - targets: ['localhost:9001', 'host.docker.internal:9001']


### PR DESCRIPTION
Closes #3258 

Question: Should I also update the file [`bin/reth/src/args/utils.rs`](https://github.com/paradigmxyz/reth/blob/4dd9c9b25a4dc4c5dbc8777ac7c633757521495a/bin/reth/src/args/utils.rs#L116)? I don't think it's related to the metrics, but maybe you want to update it for consistency.