### PR TITLE
test(ethereum): ignore invalid string sequence in ethereum state tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1736,6 +1736,7 @@ dependencies = [
  "reth-rlp",
  "reth-stages",
  "serde",
+ "serde_bytes",
  "serde_json",
  "thiserror",
  "tokio",
@@ -6377,6 +6378,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/testing/ef-tests/Cargo.toml
+++ b/testing/ef-tests/Cargo.toml
@@ -24,3 +24,4 @@ walkdir = "2.3.3"
 serde = "1.0.163"
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+serde_bytes = "0.11.9"

--- a/testing/ef-tests/src/models.rs
+++ b/testing/ef-tests/src/models.rs
@@ -37,6 +37,8 @@ pub struct BlockchainTest {
     #[serde(default)]
     /// Engine spec.
     pub self_engine: SealEngine,
+    #[serde(skip)]
+    _info: serde_json::Value,
 }
 
 /// A block header in an Ethereum blockchain test.

--- a/testing/ef-tests/src/models.rs
+++ b/testing/ef-tests/src/models.rs
@@ -37,8 +37,20 @@ pub struct BlockchainTest {
     #[serde(default)]
     /// Engine spec.
     pub self_engine: SealEngine,
-    #[serde(skip)]
-    _info: serde_json::Value,
+    #[serde(rename = "_info")]
+    #[allow(unused)]
+    info: BlockchainTestInfo,
+}
+
+#[derive(Debug, PartialEq, Eq, Deserialize)]
+struct BlockchainTestInfo {
+    #[serde(rename = "filling-rpc-server")]
+    #[allow(unused)]
+    // One test has an invalid string in this field, which breaks our CI:
+    // https://github.com/ethereum/tests/blob/6c252923bdd1bd5a70f680df1214f866f76839db/GeneralStateTests/stTransactionTest/ValueOverflow.json#L5
+    // By using `serde_bytes::ByteBuf`, we ignore the validation of this field as a string.
+    // TODO(alexey): remove when `ethereum/tests` is fixed
+    filling_rpc_server: serde_bytes::ByteBuf,
 }
 
 /// A block header in an Ethereum blockchain test.


### PR DESCRIPTION
Fixes https://github.com/paradigmxyz/reth/actions/runs/5337139311/jobs/9672776651?pr=3307#step:7:111.

String fixes to `ethereum/tests` are upstreamed: https://github.com/ethereum/tests/pull/1231