### PR TITLE
chore(cli): display latest available block number in status logs

### DIFF
--- a/bin/reth/src/debug_cmd/execution.rs
+++ b/bin/reth/src/debug_cmd/execution.rs
@@ -234,26 +234,27 @@ impl Command {
             &ctx.task_executor,
         )?;
 
+        let factory = ProviderFactory::new(&db, self.chain.clone());
+        let provider = factory.provider().map_err(PipelineError::Interface)?;
+
+        let latest_block_number =
+            provider.get_stage_checkpoint(StageId::Finish)?.map(|ch| ch.block_number);
+        if latest_block_number.unwrap_or_default() >= self.to {
+            info!(target: "reth::cli", latest = latest_block_number, "Nothing to run");
+            return Ok(())
+        }
+
         let pipeline_events = pipeline.events();
         let events = stream_select(
             network.event_listener().map(Into::into),
             pipeline_events.map(Into::into),
         );
-        ctx.task_executor
-            .spawn_critical("events task", events::handle_events(Some(network.clone()), events));
+        ctx.task_executor.spawn_critical(
+            "events task",
+            events::handle_events(Some(network.clone()), latest_block_number, events),
+        );
 
-        let factory = ProviderFactory::new(&db, self.chain.clone());
-        let provider = factory.provider().map_err(PipelineError::Interface)?;
-
-        let latest_block_number =
-            provider.get_stage_checkpoint(StageId::Finish)?.unwrap_or_default().block_number;
-        if latest_block_number >= self.to {
-            info!(target: "reth::cli", latest = latest_block_number, "Nothing to run");
-            return Ok(())
-        }
-
-        let mut current_max_block = latest_block_number;
-
+        let mut current_max_block = latest_block_number.unwrap_or_default();
         while current_max_block < self.to {
             let next_block = current_max_block + 1;
             let target_block = self.to.min(current_max_block + self.interval);

--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -38,13 +38,13 @@ struct NodeState {
 }
 
 impl NodeState {
-    fn new(network: Option<NetworkHandle>) -> Self {
+    fn new(network: Option<NetworkHandle>, latest_block_number: Option<BlockNumber>) -> Self {
         Self {
             network,
             current_stage: None,
             eta: Eta::default(),
             current_checkpoint: StageCheckpoint::new(0),
-            latest_canonical_engine_block: None,
+            latest_canonical_engine_block: latest_block_number,
         }
     }
 
@@ -190,11 +190,14 @@ impl From<ConsensusLayerHealthEvent> for NodeEvent {
 
 /// Displays relevant information to the user from components of the node, and periodically
 /// displays the high-level status of the node.
-pub async fn handle_events<E>(network: Option<NetworkHandle>, events: E)
-where
+pub async fn handle_events<E>(
+    network: Option<NetworkHandle>,
+    latest_block_number: Option<BlockNumber>,
+    events: E,
+) where
     E: Stream<Item = NodeEvent> + Unpin,
 {
-    let state = NodeState::new(network);
+    let state = NodeState::new(network, latest_block_number);
 
     let mut info_interval = tokio::time::interval(INFO_MESSAGE_INTERVAL);
     info_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);


### PR DESCRIPTION
## Motivation

On bootup, the first logged status message has `latest_block=0` which doesn't always depict the latest available block.
```
2023-06-22T07:29:49.929949Z  INFO reth::cli: Status connected_peers=0 latest_block=0
```