### PR TITLE
feat: add pending receipts

### DIFF
--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -16,8 +16,8 @@ use reth_interfaces::{
     Error,
 };
 use reth_primitives::{
-    BlockHash, BlockNumHash, BlockNumber, ForkBlock, Hardfork, SealedBlock, SealedBlockWithSenders,
-    SealedHeader, U256,
+    BlockHash, BlockNumHash, BlockNumber, ForkBlock, Hardfork, Receipt, SealedBlock,
+    SealedBlockWithSenders, SealedHeader, U256,
 };
 use reth_provider::{
     chain::{ChainSplit, SplitAt},
@@ -215,6 +215,15 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
         let id = self.block_indices.get_blocks_chain_id(&block_hash)?;
         let chain = self.chains.get(&id)?;
         chain.block(block_hash)
+    }
+
+    /// Returns the block's receipts with matching hash from any side-chain.
+    ///
+    /// Caution: This will not return blocks from the canonical chain.
+    pub fn receipts_by_block_hash(&self, block_hash: BlockHash) -> Option<&[Receipt]> {
+        let id = self.block_indices.get_blocks_chain_id(&block_hash)?;
+        let chain = self.chains.get(&id)?;
+        chain.receipts_by_block_hash(block_hash)
     }
 
     /// Returns true if the block is included in a side-chain.

--- a/crates/blockchain-tree/src/shareable.rs
+++ b/crates/blockchain-tree/src/shareable.rs
@@ -11,7 +11,8 @@ use reth_interfaces::{
     Error,
 };
 use reth_primitives::{
-    BlockHash, BlockNumHash, BlockNumber, SealedBlock, SealedBlockWithSenders, SealedHeader,
+    BlockHash, BlockNumHash, BlockNumber, Receipt, SealedBlock, SealedBlockWithSenders,
+    SealedHeader,
 };
 use reth_provider::{
     BlockchainTreePendingStateProvider, CanonStateSubscriptions, ExecutorFactory,
@@ -151,6 +152,11 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeViewer
     fn pending_block(&self) -> Option<SealedBlock> {
         trace!(target: "blockchain_tree", "Returning first pending block");
         self.tree.read().pending_block().cloned()
+    }
+
+    fn receipts_by_block_hash(&self, block_hash: BlockHash) -> Option<Vec<Receipt>> {
+        let tree = self.tree.read();
+        Some(tree.receipts_by_block_hash(block_hash)?.to_vec())
     }
 }
 

--- a/crates/interfaces/src/blockchain_tree/mod.rs
+++ b/crates/interfaces/src/blockchain_tree/mod.rs
@@ -1,6 +1,7 @@
 use crate::{blockchain_tree::error::InsertBlockError, Error};
 use reth_primitives::{
-    BlockHash, BlockNumHash, BlockNumber, SealedBlock, SealedBlockWithSenders, SealedHeader,
+    BlockHash, BlockNumHash, BlockNumber, Receipt, SealedBlock, SealedBlockWithSenders,
+    SealedHeader,
 };
 use std::collections::{BTreeMap, HashSet};
 
@@ -214,6 +215,14 @@ pub trait BlockchainTreeViewer: Send + Sync {
     fn pending_block(&self) -> Option<SealedBlock> {
         self.block_by_hash(self.pending_block_num_hash()?.hash)
     }
+
+    /// Returns the pending receipts if there is one.
+    fn pending_receipts(&self) -> Option<Vec<Receipt>> {
+        self.receipts_by_block_hash(self.pending_block_num_hash()?.hash)
+    }
+
+    /// Returns the pending receipts if there is one.
+    fn receipts_by_block_hash(&self, block_hash: BlockHash) -> Option<Vec<Receipt>>;
 
     /// Returns the pending block if there is one.
     fn pending_header(&self) -> Option<SealedHeader> {

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -12,7 +12,7 @@ use crate::{
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use reth_primitives::{Account, Block, BlockId, BlockNumberOrTag, Bytes, TransactionSigned, H256};
-use reth_provider::{BlockProviderIdExt, HeaderProvider, ReceiptProviderIdExt, StateProviderBox};
+use reth_provider::{BlockProviderIdExt, HeaderProvider, StateProviderBox};
 use reth_revm::{
     database::{State, SubState},
     env::tx_env_with_recovered,

--- a/crates/storage/provider/src/chain.rs
+++ b/crates/storage/provider/src/chain.rs
@@ -126,6 +126,12 @@ impl Chain {
         Self { state, blocks: block_num_hash }
     }
 
+    /// Get all receipts for the given block.
+    pub fn receipts_by_block_hash(&self, block_hash: BlockHash) -> Option<&[Receipt]> {
+        let num = self.block_number(block_hash)?;
+        Some(self.state.receipts(num))
+    }
+
     /// Get all receipts with attachment.
     ///
     /// Attachment includes block number, block hash, transaction hash and transaction index.

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -2,8 +2,8 @@ use crate::{
     traits::{BlockSource, ReceiptProvider},
     AccountReader, BlockHashProvider, BlockIdProvider, BlockNumProvider, BlockProvider,
     BlockProviderIdExt, EvmEnvProvider, HeaderProvider, PostState, PostStateDataProvider,
-    StateProvider, StateProviderBox, StateProviderFactory, StateRootProvider, TransactionsProvider,
-    WithdrawalsProvider,
+    ReceiptProviderIdExt, StateProvider, StateProviderBox, StateProviderFactory, StateRootProvider,
+    TransactionsProvider, WithdrawalsProvider,
 };
 use parking_lot::Mutex;
 use reth_db::models::StoredBlockBodyIndices;
@@ -238,6 +238,8 @@ impl ReceiptProvider for MockEthProvider {
         Ok(None)
     }
 }
+
+impl ReceiptProviderIdExt for MockEthProvider {}
 
 impl BlockHashProvider for MockEthProvider {
     fn block_hash(&self, number: u64) -> Result<Option<H256>> {

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -1,9 +1,9 @@
 use crate::{
     traits::{BlockSource, ReceiptProvider},
     AccountReader, BlockHashProvider, BlockIdProvider, BlockNumProvider, BlockProvider,
-    BlockProviderIdExt, EvmEnvProvider, HeaderProvider, PostState, StageCheckpointReader,
-    StateProvider, StateProviderBox, StateProviderFactory, StateRootProvider, TransactionsProvider,
-    WithdrawalsProvider,
+    BlockProviderIdExt, EvmEnvProvider, HeaderProvider, PostState, ReceiptProviderIdExt,
+    StageCheckpointReader, StateProvider, StateProviderBox, StateProviderFactory,
+    StateRootProvider, TransactionsProvider, WithdrawalsProvider,
 };
 use reth_db::models::StoredBlockBodyIndices;
 use reth_interfaces::Result;
@@ -178,6 +178,8 @@ impl ReceiptProvider for NoopProvider {
         Ok(None)
     }
 }
+
+impl ReceiptProviderIdExt for NoopProvider {}
 
 impl HeaderProvider for NoopProvider {
     fn header(&self, _block_hash: &BlockHash) -> Result<Option<Header>> {

--- a/crates/storage/provider/src/traits/block.rs
+++ b/crates/storage/provider/src/traits/block.rs
@@ -1,6 +1,6 @@
 use crate::{
-    BlockIdProvider, BlockNumProvider, HeaderProvider, ReceiptProvider, TransactionsProvider,
-    WithdrawalsProvider,
+    BlockIdProvider, BlockNumProvider, HeaderProvider, ReceiptProvider, ReceiptProviderIdExt,
+    TransactionsProvider, WithdrawalsProvider,
 };
 use reth_db::models::StoredBlockBodyIndices;
 use reth_interfaces::Result;
@@ -113,7 +113,7 @@ pub trait BlockProvider:
 /// `BlockIdProvider` methods should be used to resolve `BlockId`s to block numbers or hashes, and
 /// retrieving the block should be done using the type's `BlockProvider` methods.
 #[auto_impl::auto_impl(&, Arc)]
-pub trait BlockProviderIdExt: BlockProvider + BlockIdProvider {
+pub trait BlockProviderIdExt: BlockProvider + BlockIdProvider + ReceiptProviderIdExt {
     /// Returns the block with matching tag from the database
     ///
     /// Returns `None` if block is not found.


### PR DESCRIPTION
adds additional functions to get receipts of pending block.

This removes the blanket `ReceiptProviderIdExt` and implements custom logic for BlockchainProvider to handle pending block 