### PR TITLE
feat(rpc): report JWT path in case of an IO read error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5635,6 +5635,7 @@ dependencies = [
 name = "reth-rpc"
 version = "0.1.0-alpha.1"
 dependencies = [
+ "assert_matches",
  "async-trait",
  "bytes",
  "ethers-core",
@@ -5664,6 +5665,7 @@ dependencies = [
  "secp256k1",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-stream",

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -61,3 +61,5 @@ futures = { workspace = true }
 
 [dev-dependencies]
 jsonrpsee = { version = "0.18", features = ["client"] }
+assert_matches = "1.5.0"
+tempfile = "3.5.0"

--- a/crates/rpc/rpc/src/layers/jwt_secret.rs
+++ b/crates/rpc/rpc/src/layers/jwt_secret.rs
@@ -77,17 +77,17 @@ impl JwtSecret {
     /// Tries to load a [`JwtSecret`] from the specified file path.
     /// I/O or secret validation errors might occur during read operations in the form of
     /// a [`JwtError`].
-    pub fn from_file(file_path: &Path) -> Result<Self, JwtError> {
-        let hex = std::fs::read_to_string(file_path)
-            .map_err(|err| JwtError::IORead { err, path: file_path.to_path_buf() })?;
+    pub fn from_file(fpath: &Path) -> Result<Self, JwtError> {
+        let hex = std::fs::read_to_string(fpath)
+            .map_err(|err| JwtError::IORead { err, path: fpath.to_path_buf() })?;
         let secret = JwtSecret::from_hex(hex)?;
         Ok(secret)
     }
 
     /// Creates a random [`JwtSecret`] and tries to store it at the specified path. I/O errors might
     /// occur during write operations in the form of a [`JwtError`]
-    pub fn try_create(file_path: &Path) -> Result<Self, JwtError> {
-        if let Some(dir) = file_path.parent() {
+    pub fn try_create(fpath: &Path) -> Result<Self, JwtError> {
+        if let Some(dir) = fpath.parent() {
             // Create parent directory
             std::fs::create_dir_all(dir)?
         }
@@ -95,8 +95,8 @@ impl JwtSecret {
         let secret = JwtSecret::random();
         let bytes = &secret.0;
         let hex = hex::encode(bytes);
-        std::fs::write(file_path, hex)
-            .map_err(|err| JwtError::IORead { err, path: file_path.to_path_buf() })?;
+        std::fs::write(fpath, hex)
+            .map_err(|err| JwtError::IORead { err, path: fpath.to_path_buf() })?;
         Ok(secret)
     }
 }

--- a/crates/rpc/rpc/src/layers/jwt_secret.rs
+++ b/crates/rpc/rpc/src/layers/jwt_secret.rs
@@ -28,6 +28,8 @@ pub enum JwtError {
     JwtDecodingError(String),
     #[error("IO error occurred while reading {path}: {err}")]
     IORead { err: std::io::Error, path: PathBuf },
+    #[error("IO error occurred while writing {path}: {err}")]
+    IOWrite { err: std::io::Error, path: PathBuf },
     #[error("An I/O error occurred: {0}")]
     IOError(#[from] std::io::Error),
 }
@@ -96,7 +98,7 @@ impl JwtSecret {
         let bytes = &secret.0;
         let hex = hex::encode(bytes);
         std::fs::write(fpath, hex)
-            .map_err(|err| JwtError::IORead { err, path: fpath.to_path_buf() })?;
+            .map_err(|err| JwtError::IOWrite { err, path: fpath.to_path_buf() })?;
         Ok(secret)
     }
 }


### PR DESCRIPTION
In case when user mistakenly specifies a directory as JWT secret path:
```console
➜  reth (alexey/jwt-io-error-path) mkdir jwt
➜  reth (alexey/jwt-io-error-path) cargo run -- node --authrpc.jwtsecret $(pwd)/jwt
```

We don't mention the path in the error message:
```console
Error: An I/O error occurred: Is a directory (os error 21)

Caused by:
    Is a directory (os error 21)

Location:
    bin/reth/src/node/mod.rs:376:26
```

This PR fixes it:
```console
Error: IO error occurred while reading /Users/shekhirin/Projects/reth/jwt: Is a directory (os error 21)

Location:
    bin/reth/src/node/mod.rs:376:26
```