### PR TITLE
chore(ci): add missing Hive `rpc-compat` methods

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -90,7 +90,7 @@ jobs:
             experimental: true
             # eth_ rpc methods
           - sim: ethereum/rpc-compat
-            include: [eth_blockNumber, eth_call, eth_chainId, eth_createAccessList, eth_estimateGas, eth_feeHistory, eth_getBalance, eth_getBlockBy, eth_getBlockTransactionCountBy, eth_getCode, eth_getStorage, eth_getTransactionBy, eth_getTransactionCount, eth_sendRawTransaction, eth_syncing]
+            include: [eth_blockNumber, eth_call, eth_chainId, eth_createAccessList, eth_estimateGas, eth_feeHistory, eth_getBalance, eth_getBlockBy, eth_getBlockTransactionCountBy, eth_getCode, eth_getStorage, eth_getTransactionBy, eth_getTransactionCount, eth_getTransactionReceipt, eth_sendRawTransaction, eth_syncing]
             experimental: true
             # not running eth_getProof tests because we do not support
             # eth_getProof yet


### PR DESCRIPTION
Add one missing RPC compatibility test from https://github.com/ethereum/execution-apis/tree/main/tests