### PR TITLE
chore: move `AccountWriter` methods to `HashingWriter` and `HistoryWriter`

### DIFF
--- a/crates/staged-sync/src/utils/init.rs
+++ b/crates/staged-sync/src/utils/init.rs
@@ -9,9 +9,7 @@ use reth_db::{
     version::{check_db_version_file, create_db_version_file, DatabaseVersionError},
 };
 use reth_primitives::{stage::StageId, Account, Bytecode, ChainSpec, StorageEntry, H256, U256};
-use reth_provider::{
-    AccountWriter, DatabaseProviderRW, HashingWriter, HistoryWriter, PostState, ProviderFactory,
-};
+use reth_provider::{DatabaseProviderRW, HashingWriter, HistoryWriter, PostState, ProviderFactory};
 use std::{collections::BTreeMap, fs, path::Path, sync::Arc};
 use tracing::debug;
 

--- a/crates/stages/src/stages/hashing_account.rs
+++ b/crates/stages/src/stages/hashing_account.rs
@@ -16,7 +16,7 @@ use reth_primitives::{
         StageId,
     },
 };
-use reth_provider::{AccountExtReader, AccountWriter, DatabaseProviderRW};
+use reth_provider::{AccountExtReader, DatabaseProviderRW, HashingWriter};
 use std::{
     cmp::max,
     fmt::Debug,

--- a/crates/stages/src/stages/index_account_history.rs
+++ b/crates/stages/src/stages/index_account_history.rs
@@ -1,7 +1,7 @@
 use crate::{ExecInput, ExecOutput, Stage, StageError, UnwindInput, UnwindOutput};
 use reth_db::database::Database;
 use reth_primitives::stage::{StageCheckpoint, StageId};
-use reth_provider::{AccountExtReader, AccountWriter, DatabaseProviderRW};
+use reth_provider::{AccountExtReader, DatabaseProviderRW, HistoryWriter};
 use std::fmt::Debug;
 
 /// Stage is indexing history the account changesets generated in

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -15,8 +15,8 @@
 /// Various provider traits.
 mod traits;
 pub use traits::{
-    AccountExtReader, AccountReader, AccountWriter, BlockExecutor, BlockHashProvider,
-    BlockIdProvider, BlockNumProvider, BlockProvider, BlockProviderIdExt, BlockSource,
+    AccountExtReader, AccountReader, BlockExecutor, BlockHashProvider, BlockIdProvider,
+    BlockNumProvider, BlockProvider, BlockProviderIdExt, BlockSource,
     BlockchainTreePendingStateProvider, CanonChainTracker, CanonStateNotification,
     CanonStateNotificationSender, CanonStateNotifications, CanonStateSubscriptions, EvmEnvProvider,
     ExecutorFactory, HashingWriter, HeaderProvider, HistoryWriter, PostStateDataProvider,

--- a/crates/storage/provider/src/traits/account.rs
+++ b/crates/storage/provider/src/traits/account.rs
@@ -42,27 +42,3 @@ pub trait AccountExtReader: Send + Sync {
         range: RangeInclusive<BlockNumber>,
     ) -> Result<BTreeMap<Address, Vec<BlockNumber>>>;
 }
-
-/// Account reader
-#[auto_impl(&, Arc, Box)]
-pub trait AccountWriter: Send + Sync {
-    /// Unwind and clear account hashing
-    fn unwind_account_hashing(&self, range: RangeInclusive<BlockNumber>) -> Result<()>;
-
-    /// Unwind and clear account history indices.
-    ///
-    /// Returns number of changesets walked.
-    fn unwind_account_history_indices(&self, range: RangeInclusive<BlockNumber>) -> Result<usize>;
-
-    /// Insert account change index to database. Used inside AccountHistoryIndex stage
-    fn insert_account_history_index(
-        &self,
-        account_transitions: BTreeMap<Address, Vec<u64>>,
-    ) -> Result<()>;
-
-    /// iterate over accounts and insert them to hashing table
-    fn insert_account_for_hashing(
-        &self,
-        accounts: impl IntoIterator<Item = (Address, Option<Account>)>,
-    ) -> Result<()>;
-}

--- a/crates/storage/provider/src/traits/hashing.rs
+++ b/crates/storage/provider/src/traits/hashing.rs
@@ -1,12 +1,21 @@
 use auto_impl::auto_impl;
 use reth_db::models::BlockNumberAddress;
 use reth_interfaces::Result;
-use reth_primitives::{Address, BlockNumber, StorageEntry, H256};
+use reth_primitives::{Account, Address, BlockNumber, StorageEntry, H256};
 use std::ops::{Range, RangeInclusive};
 
 /// Hashing Writer
 #[auto_impl(&, Arc, Box)]
 pub trait HashingWriter: Send + Sync {
+    /// Unwind and clear account hashing
+    fn unwind_account_hashing(&self, range: RangeInclusive<BlockNumber>) -> Result<()>;
+
+    /// iterate over accounts and insert them to hashing table
+    fn insert_account_for_hashing(
+        &self,
+        accounts: impl IntoIterator<Item = (Address, Option<Account>)>,
+    ) -> Result<()>;
+
     /// Unwind and clear storage hashing
     fn unwind_storage_hashing(&self, range: Range<BlockNumberAddress>) -> Result<()>;
 

--- a/crates/storage/provider/src/traits/hashing.rs
+++ b/crates/storage/provider/src/traits/hashing.rs
@@ -10,7 +10,7 @@ pub trait HashingWriter: Send + Sync {
     /// Unwind and clear account hashing
     fn unwind_account_hashing(&self, range: RangeInclusive<BlockNumber>) -> Result<()>;
 
-    /// iterate over accounts and insert them to hashing table
+    /// Inserts all accounts into [reth_db::tables::AccountHistory] table.
     fn insert_account_for_hashing(
         &self,
         accounts: impl IntoIterator<Item = (Address, Option<Account>)>,

--- a/crates/storage/provider/src/traits/history.rs
+++ b/crates/storage/provider/src/traits/history.rs
@@ -10,6 +10,17 @@ use std::{
 /// History Writer
 #[auto_impl(&, Arc, Box)]
 pub trait HistoryWriter: Send + Sync {
+    /// Unwind and clear account history indices.
+    ///
+    /// Returns number of changesets walked.
+    fn unwind_account_history_indices(&self, range: RangeInclusive<BlockNumber>) -> Result<usize>;
+
+    /// Insert account change index to database. Used inside AccountHistoryIndex stage
+    fn insert_account_history_index(
+        &self,
+        account_transitions: BTreeMap<Address, Vec<u64>>,
+    ) -> Result<()>;
+
     /// Unwind and clear storage history indices.
     ///
     /// Returns number of changesets walked.

--- a/crates/storage/provider/src/traits/mod.rs
+++ b/crates/storage/provider/src/traits/mod.rs
@@ -1,7 +1,7 @@
 //! Collection of common provider traits.
 
 mod account;
-pub use account::{AccountExtReader, AccountReader, AccountWriter};
+pub use account::{AccountExtReader, AccountReader};
 
 mod storage;
 pub use storage::StorageReader;


### PR DESCRIPTION
Follow up on #3285
```
HashingWriter (will move the account methods in another PR as discussed )
HistoryWriter(will move the account methods in another PR as discussed )
```

Moves the methods and remove `AccountWriter`