### PR TITLE
perf: lower pipeline run threshold to 1 epoch

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -69,7 +69,7 @@ const MAX_INVALID_HEADERS: u32 = 512u32;
 
 /// The largest gap for which the tree will be used for sync. See docs for `pipeline_run_threshold`
 /// for more information.
-pub const MIN_BLOCKS_FOR_PIPELINE_RUN: u64 = 2 * EPOCH_SLOTS;
+pub const MIN_BLOCKS_FOR_PIPELINE_RUN: u64 = EPOCH_SLOTS;
 
 /// A _shareable_ beacon consensus frontend. Used to interact with the spawned beacon consensus
 /// engine.


### PR DESCRIPTION
lower the max allowed distance for live sync

this will be the last remaining gap that we close via block chain tree and is currently blocking and can lead to timed out CL requests.

syncing > 32 blocks via pipeline is more efficient