### PR TITLE
fix: exclude non source files in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,13 @@
-/target
-/book
-/assets
-/.github
-/data
-*.tar.gz
+# ignore all
+*
+
+# exclude source files
+!/bin
+!/crates
+!/testing
+!book.toml
+!Cargo.lock
+!Cargo.toml
+!Cross.toml
+!deny.toml
+!Makefile

--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,6 @@
 
 # include dist directory, where the reth binary is located after compilation
 !/dist
+
+# include licenses
+!LICENSE-*

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
-# ignore all
+# exclude everything
 *
 
-# exclude source files
+# include source files
 !/bin
 !/crates
 !/testing
@@ -11,3 +11,6 @@
 !Cross.toml
 !deny.toml
 !Makefile
+
+# include dist directory, where the reth binary is located after compilation
+!/dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,5 +33,8 @@ WORKDIR app
 # Copy reth over from the build stage
 COPY --from=builder /app/target/release/reth /usr/local/bin
 
+# Copy licenses
+COPY LICENSE-* .
+
 EXPOSE 30303 30303/udp 9001 8545 8546
 ENTRYPOINT ["/usr/local/bin/reth"]


### PR DESCRIPTION
## Existing issue

Right now the `COPY . .` instruction in the Dockerfile copies pretty almost everything from the repository into the build container (including the .git/ directory, the Dockerfile, the README, etc.) which causes two things:
- slower builds (need to copy everything into the build container)
- Docker build cache invalidation even when files that aren't source code are changed. This leads to full rebuilds of the reth binary instead of using the existing cached build layer

## Solution

To fix this, I changed the /.dockerignore file to exclude **all but the source files required at build-time**. I've tested that this works and produces a working Docker container, while solving the issues i wrote above.

This approach to exclude all but the source files means that when new files are added to the repo that are not source files, they will be ignored by the `COPY . .` instruction. New files or directories that are required during the build stage can be whitelisted in the `.dockerignore` file.
