### PR TITLE
fix(txpool): gas cost ordering

### DIFF
--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -419,13 +419,11 @@ impl Transaction {
     ///
     /// If the transaction is a legacy or EIP2930 transaction, the gas price is returned.
     pub fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
-        let dynamic_tx = match self {
-            Transaction::Legacy(tx) => return tx.gas_price,
-            Transaction::Eip2930(tx) => return tx.gas_price,
-            Transaction::Eip1559(dynamic_tx) => dynamic_tx,
-        };
-
-        dynamic_tx.effective_gas_price(base_fee)
+        match self {
+            Transaction::Legacy(tx) => tx.gas_price,
+            Transaction::Eip2930(tx) => tx.gas_price,
+            Transaction::Eip1559(dynamic_tx) => dynamic_tx.effective_gas_price(base_fee),
+        }
     }
 
     // TODO: dedup with effective_tip_per_gas

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -95,7 +95,7 @@ use tracing::{instrument, trace};
 pub use crate::{
     config::PoolConfig,
     error::PoolResult,
-    ordering::{CostOrdering, TransactionOrdering},
+    ordering::{GasCostOrdering, TransactionOrdering},
     pool::TransactionEvents,
     traits::{
         AllPoolTransactions, BestTransactions, BlockInfo, CanonicalStateUpdate, ChangedAccount,
@@ -220,7 +220,7 @@ where
 }
 
 impl<Client>
-    Pool<EthTransactionValidator<Client, PooledTransaction>, CostOrdering<PooledTransaction>>
+    Pool<EthTransactionValidator<Client, PooledTransaction>, GasCostOrdering<PooledTransaction>>
 where
     Client: StateProviderFactory + Clone + 'static,
 {
@@ -230,7 +230,7 @@ where
         validator: EthTransactionValidator<Client, PooledTransaction>,
         config: PoolConfig,
     ) -> Self {
-        Self::new(validator, CostOrdering::default(), config)
+        Self::new(validator, GasCostOrdering::default(), config)
     }
 }
 

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -225,7 +225,7 @@ where
     Client: StateProviderFactory + Clone + 'static,
 {
     /// Returns a new [Pool] that uses the default [EthTransactionValidator] when validating
-    /// [PooledTransaction]s and ords via [CostOrdering]
+    /// [PooledTransaction]s and ords via [GasCostOrdering]
     pub fn eth_pool(
         validator: EthTransactionValidator<Client, PooledTransaction>,
         config: PoolConfig,

--- a/crates/transaction-pool/src/ordering.rs
+++ b/crates/transaction-pool/src/ordering.rs
@@ -22,7 +22,7 @@ pub trait TransactionOrdering: Send + Sync + 'static {
 
 /// Default ordering for the pool.
 ///
-/// The transactions are ordered by their cost. The higher the cost,
+/// The transactions are ordered by their gas cost. The higher the gas cost,
 /// the higher the priority of this transaction is.
 #[derive(Debug)]
 #[non_exhaustive]
@@ -36,7 +36,7 @@ where
     type Transaction = T;
 
     fn priority(&self, transaction: &Self::Transaction) -> Self::Priority {
-        transaction.cost()
+        transaction.gas_cost()
     }
 }
 

--- a/crates/transaction-pool/src/ordering.rs
+++ b/crates/transaction-pool/src/ordering.rs
@@ -26,9 +26,9 @@ pub trait TransactionOrdering: Send + Sync + 'static {
 /// the higher the priority of this transaction is.
 #[derive(Debug)]
 #[non_exhaustive]
-pub struct CostOrdering<T>(PhantomData<T>);
+pub struct GasCostOrdering<T>(PhantomData<T>);
 
-impl<T> TransactionOrdering for CostOrdering<T>
+impl<T> TransactionOrdering for GasCostOrdering<T>
 where
     T: PoolTransaction + 'static,
 {
@@ -40,7 +40,7 @@ where
     }
 }
 
-impl<T> Default for CostOrdering<T> {
+impl<T> Default for GasCostOrdering<T> {
     fn default() -> Self {
         Self(Default::default())
     }

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -255,7 +255,6 @@ where
                 let encoded_length = transaction.encoded_length();
 
                 let tx = ValidPoolTransaction {
-                    cost: transaction.cost(),
                     transaction,
                     transaction_id,
                     propagate: false,

--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -289,7 +289,7 @@ impl_ord_wrapper!(QueuedOrd);
 impl<T: PoolTransaction> Ord for QueuedOrd<T> {
     fn cmp(&self, other: &Self) -> Ordering {
         // Higher cost is better
-        self.cost.cmp(&other.cost).then_with(||
+        self.gas_cost().cmp(&other.gas_cost()).then_with(||
             // Lower timestamp is better
             other.timestamp.cmp(&self.timestamp))
     }

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -748,7 +748,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
                     tx.state.insert(TxState::NO_NONCE_GAPS);
                     tx.state.insert(TxState::NO_PARKED_ANCESTORS);
                     tx.cumulative_cost = U256::ZERO;
-                    if tx.transaction.cost > info.balance {
+                    if tx.transaction.cost() > info.balance {
                         // sender lacks sufficient funds to pay for this transaction
                         tx.state.remove(TxState::ENOUGH_BALANCE);
                     } else {
@@ -1268,7 +1268,7 @@ pub(crate) struct PoolInternalTransaction<T: PoolTransaction> {
 
 impl<T: PoolTransaction> PoolInternalTransaction<T> {
     fn next_cumulative_cost(&self) -> U256 {
-        self.cumulative_cost + self.transaction.cost
+        self.cumulative_cost + self.transaction.cost()
     }
 }
 

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -329,8 +329,15 @@ impl PoolTransaction for MockTransaction {
         }
     }
 
-    fn effective_gas_price(&self) -> u128 {
-        self.get_gas_price()
+    fn gas_cost(&self) -> U256 {
+        match self {
+            MockTransaction::Legacy { gas_price, gas_limit, .. } => {
+                U256::from(*gas_limit) * U256::from(*gas_price)
+            }
+            MockTransaction::Eip1559 { max_fee_per_gas, gas_limit, .. } => {
+                U256::from(*gas_limit) * U256::from(*max_fee_per_gas)
+            }
+        }
     }
 
     fn gas_limit(&self) -> u64 {
@@ -485,7 +492,6 @@ impl MockTransactionFactory {
         MockValidTx {
             propagate: false,
             transaction_id,
-            cost: transaction.cost(),
             transaction,
             timestamp: Instant::now(),
             origin,
@@ -511,7 +517,7 @@ impl TransactionOrdering for MockOrdering {
     type Transaction = MockTransaction;
 
     fn priority(&self, transaction: &Self::Transaction) -> Self::Priority {
-        transaction.cost()
+        transaction.gas_cost()
     }
 }
 

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -557,7 +557,7 @@ impl MockTransactionDistribution {
 #[test]
 fn test_mock_priority() {
     let o = MockOrdering;
-    let lo = MockTransaction::eip1559();
-    let hi = lo.next().inc_value();
+    let lo = MockTransaction::eip1559().with_gas_limit(100_000);
+    let hi = lo.next().inc_price();
     assert!(o.priority(&hi) > o.priority(&lo));
 }

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -284,8 +284,8 @@ where
         }
 
         // Checks for max cost
-        if transaction.cost() > account.balance {
-            let cost = transaction.cost();
+        let cost = transaction.cost();
+        if cost > account.balance {
             return TransactionValidationOutcome::Invalid(
                 transaction,
                 InvalidTransactionError::InsufficientFunds {


### PR DESCRIPTION
## Issue

Current default transaction pool ordering compares the transaction _cost_ instead of the transaction _gas cost_.

### What the hell is transaction cost?

Transaction cost is the smallest value required in the sender's account to cover the transaction:
`fee cap * gas limit + tx value`.
 See [geth for more details](https://github.com/ethereum/go-ethereum/blob/2754b197c935ee63101cbbca2752338246384fec/core/types/transaction.go#L313-L321). 

## PR Changes

* Remove unused `effective_gas_price` from `PooledTransaction`
* Remove redundant `cost` from `ValidPoolTransaction` since this value is already memoized in the underlying `PooledTransaction`
* Add `gas_cost` fn to `PoolTransaction` trait and implement it in the `PooledTransaction`: gas cost equals to`fee cap * gas limit`
* Rename `CostOrdering` to `GasCostOrdering`
* Change the `GasCostOrdering` & `QueuedOrd` to use `gas_cost()` instead of `cost()`