### PR TITLE
feat: add pending block with receipts

### DIFF
--- a/crates/blockchain-tree/src/shareable.rs
+++ b/crates/blockchain-tree/src/shareable.rs
@@ -154,6 +154,13 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeViewer
         self.tree.read().pending_block().cloned()
     }
 
+    fn pending_block_and_receipts(&self) -> Option<(SealedBlock, Vec<Receipt>)> {
+        let tree = self.tree.read();
+        let pending_block = tree.pending_block()?.clone();
+        let receipts = tree.receipts_by_block_hash(pending_block.hash)?.to_vec();
+        Some((pending_block, receipts))
+    }
+
     fn receipts_by_block_hash(&self, block_hash: BlockHash) -> Option<Vec<Receipt>> {
         let tree = self.tree.read();
         Some(tree.receipts_by_block_hash(block_hash)?.to_vec())

--- a/crates/interfaces/src/blockchain_tree/mod.rs
+++ b/crates/interfaces/src/blockchain_tree/mod.rs
@@ -216,7 +216,10 @@ pub trait BlockchainTreeViewer: Send + Sync {
         self.block_by_hash(self.pending_block_num_hash()?.hash)
     }
 
-    /// Returns the pending block and its receipts.
+    /// Returns the pending block and its receipts in one call.
+    ///
+    /// This exits to prevent a potential data race if the pending block changes in between
+    /// [Self::pending_block] and [Self::pending_receipts] calls.
     fn pending_block_and_receipts(&self) -> Option<(SealedBlock, Vec<Receipt>)>;
 
     /// Returns the pending receipts if there is one.

--- a/crates/interfaces/src/blockchain_tree/mod.rs
+++ b/crates/interfaces/src/blockchain_tree/mod.rs
@@ -218,7 +218,7 @@ pub trait BlockchainTreeViewer: Send + Sync {
 
     /// Returns the pending block and its receipts in one call.
     ///
-    /// This exits to prevent a potential data race if the pending block changes in between
+    /// This exists to prevent a potential data race if the pending block changes in between
     /// [Self::pending_block] and [Self::pending_receipts] calls.
     fn pending_block_and_receipts(&self) -> Option<(SealedBlock, Vec<Receipt>)>;
 

--- a/crates/interfaces/src/blockchain_tree/mod.rs
+++ b/crates/interfaces/src/blockchain_tree/mod.rs
@@ -216,6 +216,9 @@ pub trait BlockchainTreeViewer: Send + Sync {
         self.block_by_hash(self.pending_block_num_hash()?.hash)
     }
 
+    /// Returns the pending block and its receipts.
+    fn pending_block_and_receipts(&self) -> Option<(SealedBlock, Vec<Receipt>)>;
+
     /// Returns the pending receipts if there is one.
     fn pending_receipts(&self) -> Option<Vec<Receipt>> {
         self.receipts_by_block_hash(self.pending_block_num_hash()?.hash)

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -184,6 +184,10 @@ impl<DB: Database> BlockReader for ProviderFactory<DB> {
         self.provider()?.pending_block()
     }
 
+    fn pending_block_and_receipts(&self) -> Result<Option<(SealedBlock, Vec<Receipt>)>> {
+        self.provider()?.pending_block_and_receipts()
+    }
+
     fn ommers(&self, id: BlockHashOrNumber) -> Result<Option<Vec<Header>>> {
         self.provider()?.ommers(id)
     }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1005,6 +1005,10 @@ impl<'this, TX: DbTx<'this>> BlockReader for DatabaseProvider<'this, TX> {
         Ok(None)
     }
 
+    fn pending_block_and_receipts(&self) -> Result<Option<(SealedBlock, Vec<Receipt>)>> {
+        Ok(None)
+    }
+
     fn ommers(&self, id: BlockHashOrNumber) -> Result<Option<Vec<Header>>> {
         if let Some(number) = self.convert_hash_or_number(id)? {
             // If the Paris (Merge) hardfork block is known and block is after it, return empty

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -233,6 +233,10 @@ where
         Ok(self.tree.pending_block())
     }
 
+    fn pending_block_and_receipts(&self) -> Result<Option<(SealedBlock, Vec<Receipt>)>> {
+        Ok(self.tree.pending_block_and_receipts())
+    }
+
     fn ommers(&self, id: BlockHashOrNumber) -> Result<Option<Vec<Header>>> {
         self.database.provider()?.ommers(id)
     }
@@ -626,6 +630,10 @@ where
 
     fn pending_block_num_hash(&self) -> Option<BlockNumHash> {
         self.tree.pending_block_num_hash()
+    }
+
+    fn pending_block_and_receipts(&self) -> Option<(SealedBlock, Vec<Receipt>)> {
+        self.tree.pending_block_and_receipts()
     }
 
     fn receipts_by_block_hash(&self, block_hash: BlockHash) -> Option<Vec<Receipt>> {

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -209,14 +209,14 @@ impl TransactionsProvider for MockEthProvider {
         Ok(map.into_values().collect())
     }
 
-    fn senders_by_tx_range(&self, _range: impl RangeBounds<TxNumber>) -> Result<Vec<Address>> {
-        unimplemented!()
-    }
-
     fn transactions_by_tx_range(
         &self,
         _range: impl RangeBounds<TxNumber>,
     ) -> Result<Vec<reth_primitives::TransactionSignedNoHash>> {
+        unimplemented!()
+    }
+
+    fn senders_by_tx_range(&self, _range: impl RangeBounds<TxNumber>) -> Result<Vec<Address>> {
         unimplemented!()
     }
 
@@ -321,6 +321,10 @@ impl BlockReader for MockEthProvider {
     }
 
     fn pending_block(&self) -> Result<Option<SealedBlock>> {
+        Ok(None)
+    }
+
+    fn pending_block_and_receipts(&self) -> Result<Option<(SealedBlock, Vec<Receipt>)>> {
         Ok(None)
     }
 

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -63,6 +63,10 @@ impl BlockReader for NoopProvider {
         Ok(None)
     }
 
+    fn pending_block_and_receipts(&self) -> Result<Option<(SealedBlock, Vec<Receipt>)>> {
+        Ok(None)
+    }
+
     fn ommers(&self, _id: BlockHashOrNumber) -> Result<Option<Vec<Header>>> {
         Ok(None)
     }

--- a/crates/storage/provider/src/traits/block.rs
+++ b/crates/storage/provider/src/traits/block.rs
@@ -6,7 +6,7 @@ use reth_db::models::StoredBlockBodyIndices;
 use reth_interfaces::Result;
 use reth_primitives::{
     Block, BlockHashOrNumber, BlockId, BlockNumber, BlockNumberOrTag, BlockWithSenders, Header,
-    SealedBlock, SealedHeader, H256,
+    Receipt, SealedBlock, SealedHeader, H256,
 };
 
 /// A helper enum that represents the origin of the requested block.
@@ -71,6 +71,9 @@ pub trait BlockReader:
     /// Note: This returns a [SealedBlock] because it's expected that this is sealed by the provider
     /// and the caller does not know the hash.
     fn pending_block(&self) -> Result<Option<SealedBlock>>;
+
+    /// Returns the pending block and receipts if available.
+    fn pending_block_and_receipts(&self) -> Result<Option<(SealedBlock, Vec<Receipt>)>>;
 
     /// Returns the ommers/uncle headers of the given block from the database.
     ///


### PR DESCRIPTION
Adds another function to unblock #3321

we need to fetch this one go, because this is susceptible to a race and hence block + receipts can't be fetched in two separate calls using the existing methods