### PR TITLE
ci: split checks across pr/merge group/main

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -14,6 +14,8 @@ name: bench
 jobs:
   iai:
     runs-on: ubuntu-latest
+    # Only run benchmarks in merge groups
+    if: github.event_name != 'pull_request'
     steps:
       - name: Checkout main sources
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,4 @@
 on:
-  push:
-    branches:
-      - main
   pull_request:
   merge_group:
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,7 +1,4 @@
 on:
-  push:
-    branches:
-      - main
   pull_request:
   merge_group:
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,7 +1,4 @@
 on:
-  push:
-    branches:
-      - main
   pull_request:
   merge_group:
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -63,6 +63,8 @@ jobs:
 
   sync:
     name: sync / 100k blocks
+    # Only run sync tests in merge groups
+    if: github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     env:
       RUST_LOG: info,sync=error
@@ -92,7 +94,7 @@ jobs:
     if: always()
     name: integration success
     runs-on: ubuntu-latest
-    needs: [test, sync]
+    needs: [test]
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@release/v1

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,7 +1,4 @@
 on:
-  push:
-    branches:
-      - main
   pull_request:
   merge_group:
 


### PR DESCRIPTION
- Only runs the benchmark job in the merge group (it is slow) (the compilation check is still run)
- Remove some workflows from main, since status checks are transferred from the merge group onto the commit on main, so running the workflow again is extra work for no gain
- Only runs the sync test (integration test) in the merge group

If any of the checks fail in the merge group, the PR is kicked out of the queue and a link to the workflow run that failed is added by GitHub to the PR.

This should hopefully speed up CI a bit for PRs, and reduce run minutes on main.

Closes #3264