### PR TITLE
chore: run tests with coverage in `Makefile`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ db-tools/
 
 # VSCode
 .vscode
+
+# Coverage report
+lcov.info

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ test-unit: ## Run unit tests.
 .PHONY: cov-unit
 cov-unit: ## Run unit tests with coverage.
 	cargo llvm-cov clean --workspace
-	cargo llvm-cov nextest $(UNIT_TEST_ARGS)
+	cargo llvm-cov nextest --html $(UNIT_TEST_ARGS)
 
 .PHONY: cov-report-html
 cov-report-html: cov-unit ## Generate a HTML coverage report and open it in the browser.

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,6 @@ test-unit: ## Run unit tests.
 
 .PHONY: cov-unit
 cov-unit: ## Run unit tests with coverage.
-	cargo llvm-cov clean --workspace
 	rm -f $(COV_FILE)
 	cargo llvm-cov nextest --lcov --output-path $(COV_FILE) $(UNIT_TEST_ARGS)
 

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,14 @@ build-release-tarballs: ## Create a series of `.tar.gz` files in the BIN_DIR dir
 
 ##@ Test
 
+.PHONY: unit
+unit: ## Run unit tests with coverage.
+	cargo llvm-cov nextest --html --locked --workspace --all-features -E 'kind(lib)' -E 'kind(bin)' -E 'kind(proc-macro)'
+
+.PHONY: html
+html: ## Open coverage report in browser.
+	open target/llvm-cov/html/index.html
+
 # Downloads and unpacks Ethereum Foundation tests in the `$(EF_TESTS_DIR)` directory.
 #
 # Requires `wget` and `tar`

--- a/Makefile
+++ b/Makefile
@@ -105,12 +105,19 @@ build-release-tarballs: ## Create a series of `.tar.gz` files in the BIN_DIR dir
 
 ##@ Test
 
-.PHONY: unit
-unit: ## Run unit tests with coverage.
-	cargo llvm-cov nextest --html --locked --workspace --all-features -E 'kind(lib)' -E 'kind(bin)' -E 'kind(proc-macro)'
+UNIT_TEST_ARGS := --locked --workspace --all-features -E 'kind(lib)' -E 'kind(bin)' -E 'kind(proc-macro)'
 
-.PHONY: html
-html: ## Open coverage report in browser.
+.PHONY: test-unit
+test-unit: ## Run unit tests.
+	cargo nextest run $(UNIT_TEST_ARGS)
+
+.PHONY: cov-unit
+cov-unit: ## Run unit tests with coverage.
+	cargo llvm-cov clean --workspace
+	cargo llvm-cov nextest $(UNIT_TEST_ARGS)
+
+.PHONY: cov-report-html
+cov-report-html: cov-unit ## Generate a HTML coverage report and open it in the browser.
 	open target/llvm-cov/html/index.html
 
 # Downloads and unpacks Ethereum Foundation tests in the `$(EF_TESTS_DIR)` directory.

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ build-release-tarballs: ## Create a series of `.tar.gz` files in the BIN_DIR dir
 ##@ Test
 
 UNIT_TEST_ARGS := --locked --workspace --all-features -E 'kind(lib)' -E 'kind(bin)' -E 'kind(proc-macro)'
+COV_FILE := lcov.info
 
 .PHONY: test-unit
 test-unit: ## Run unit tests.
@@ -114,7 +115,8 @@ test-unit: ## Run unit tests.
 .PHONY: cov-unit
 cov-unit: ## Run unit tests with coverage.
 	cargo llvm-cov clean --workspace
-	cargo llvm-cov nextest $(UNIT_TEST_ARGS)
+	rm -f $(COV_FILE)
+	cargo llvm-cov nextest --lcov --output-path $(COV_FILE) $(UNIT_TEST_ARGS)
 
 .PHONY: cov-report-html
 cov-report-html: cov-unit ## Generate a HTML coverage report and open it in the browser.

--- a/Makefile
+++ b/Makefile
@@ -114,10 +114,11 @@ test-unit: ## Run unit tests.
 .PHONY: cov-unit
 cov-unit: ## Run unit tests with coverage.
 	cargo llvm-cov clean --workspace
-	cargo llvm-cov nextest --html $(UNIT_TEST_ARGS)
+	cargo llvm-cov nextest $(UNIT_TEST_ARGS)
 
 .PHONY: cov-report-html
 cov-report-html: cov-unit ## Generate a HTML coverage report and open it in the browser.
+	cargo llvm-cov report --html
 	open target/llvm-cov/html/index.html
 
 # Downloads and unpacks Ethereum Foundation tests in the `$(EF_TESTS_DIR)` directory.


### PR DESCRIPTION
Resolves #3412 

```sh
$ make
...

Test
  unit             Run unit tests with coverage.
  html             Open coverage report in browser.
  ef-tests         Runs Ethereum Foundation tests.
```

First, run `make unit` which will create the html report under `target/llvm-cov/html` and then open the report using `make html`. Here's a preview of how the report is displayed in the browser.

*edit: The `unit` target has been split into two sub targets: `test-unit` and `cov-unit`.

```sh
$ make
...

Test
  test-unit        Run unit tests.
  cov-unit         Run unit tests with coverage.
  cov-report-html  Generate a HTML coverage report and open it in the browser.
```

<img width="1212" alt="Screenshot 2023-06-27 at 10 36 58" src="https://github.com/paradigmxyz/reth/assets/28714795/756a0b80-578c-4357-af64-89ca68c1d92a">

Source: https://github.com/taiki-e/cargo-llvm-cov#usage
