### PR TITLE
feat(storage): do not require `Default` for `derive(Compact)`

### DIFF
--- a/crates/storage/codecs/derive/src/compact/enums.rs
+++ b/crates/storage/codecs/derive/src/compact/enums.rs
@@ -68,8 +68,8 @@ impl<'a> EnumHandler<'a> {
                     // Unamed type
                     self.enum_lines.push(quote! {
                         #current_variant_index => {
-                            let mut inner = #field_type::default();
-                            (inner, buf) = #field_type::#from_compact_ident(buf, buf.len());
+                            let (inner, new_buf) = #field_type::#from_compact_ident(buf, buf.len());
+                            buf = new_buf;
                             #ident::#variant_name(inner)
                         }
                     });

--- a/crates/storage/codecs/derive/src/compact/mod.rs
+++ b/crates/storage/codecs/derive/src/compact/mod.rs
@@ -277,25 +277,24 @@ mod tests {
                 }
                 fn from_compact(mut buf: &[u8], len: usize) -> (Self, &[u8]) {
                     let (flags, mut buf) = TestStructFlags::from(buf);
-                    let mut f_u64 = u64::default();
-                    (f_u64, buf) = u64::from_compact(buf, flags.f_u64_len() as usize);
-                    let mut f_u256 = U256::default();
-                    (f_u256, buf) = U256::from_compact(buf, flags.f_u256_len() as usize);
-                    let mut f_bool_t = bool::default();
-                    (f_bool_t, buf) = bool::from_compact(buf, flags.f_bool_t_len() as usize);
-                    let mut f_bool_f = bool::default();
-                    (f_bool_f, buf) = bool::from_compact(buf, flags.f_bool_f_len() as usize);
-                    let mut f_option_none = Option::default();
-                    (f_option_none, buf) = Option::from_compact(buf, flags.f_option_none_len() as usize);
-                    let mut f_option_some = Option::default();
-                    (f_option_some, buf) = Option::specialized_from_compact(buf, flags.f_option_some_len() as usize);
-                    let mut f_option_some_u64 = Option::default();
-                    (f_option_some_u64, buf) =
-                        Option::from_compact(buf, flags.f_option_some_u64_len() as usize);
-                    let mut f_vec_empty = Vec::default();
-                    (f_vec_empty, buf) = Vec::from_compact(buf, buf.len());
-                    let mut f_vec_some = Vec::default();
-                    (f_vec_some, buf) = Vec::specialized_from_compact(buf, buf.len());
+                    let (f_u64, new_buf) = u64::from_compact(buf, flags.f_u64_len() as usize);
+                    buf = new_buf;
+                    let (f_u256, new_buf) = U256::from_compact(buf, flags.f_u256_len() as usize);
+                    buf = new_buf;
+                    let (f_bool_t, new_buf) = bool::from_compact(buf, flags.f_bool_t_len() as usize);
+                    buf = new_buf;
+                    let (f_bool_f, new_buf) = bool::from_compact(buf, flags.f_bool_f_len() as usize);
+                    buf = new_buf;
+                    let (f_option_none, new_buf) = Option::from_compact(buf, flags.f_option_none_len() as usize);
+                    buf = new_buf;
+                    let (f_option_some, new_buf) = Option::specialized_from_compact(buf, flags.f_option_some_len() as usize);
+                    buf = new_buf;
+                    let (f_option_some_u64, new_buf) = Option::from_compact(buf, flags.f_option_some_u64_len() as usize);
+                    buf = new_buf;
+                    let (f_vec_empty, new_buf) = Vec::from_compact(buf, buf.len());
+                    buf = new_buf;
+                    let (f_vec_some, new_buf) = Vec::specialized_from_compact(buf, buf.len());
+                    buf = new_buf;
                     let obj = TestStruct {
                         f_u64: f_u64,
                         f_u256: f_u256,

--- a/crates/storage/codecs/derive/src/compact/structs.rs
+++ b/crates/storage/codecs/derive/src/compact/structs.rs
@@ -137,21 +137,21 @@ impl<'a> StructHandler<'a> {
             })
         } else {
             let ident_type = format_ident!("{ftype}");
-            self.lines.push(quote! {
-                let mut #name = #ident_type::default();
-            });
             if !is_flag_type(ftype) {
                 // It's a type that handles its own length requirements. (h256, Custom, ...)
                 self.lines.push(quote! {
-                    (#name, buf) = #ident_type::#from_compact_ident(buf, buf.len());
+                    let (#name, new_buf) = #ident_type::#from_compact_ident(buf, buf.len());
                 })
             } else if *is_compact {
                 self.lines.push(quote! {
-                    (#name, buf) = #ident_type::#from_compact_ident(buf, flags.#len() as usize);
+                    let (#name, new_buf) = #ident_type::#from_compact_ident(buf, flags.#len() as usize);
                 });
             } else {
                 todo!()
             }
+            self.lines.push(quote! {
+                buf = new_buf;
+            });
         }
     }
 }


### PR DESCRIPTION
`Default` was only needed to initalize a variable that will be instantly replaced, but it meant that we need to implement `Default` for all field types. It's inconvenient with enums as they often don't have any meaningful default value.