### PR TITLE
fix: docker build COPY dest should be abspath

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
-WORKDIR app
+WORKDIR /app
 
 LABEL org.opencontainers.image.source=https://github.com/paradigmxyz/reth
 LABEL org.opencontainers.image.licenses="MIT OR Apache-2.0"
@@ -28,7 +28,7 @@ RUN cargo build --profile $BUILD_PROFILE --locked --bin reth
 
 # Use Ubuntu as the release image
 FROM ubuntu AS runtime
-WORKDIR app
+WORKDIR /app
 
 # Copy reth over from the build stage
 COPY --from=builder /app/target/release/reth /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ WORKDIR app
 COPY --from=builder /app/target/release/reth /usr/local/bin
 
 # Copy licenses
-COPY LICENSE-* .
+COPY LICENSE-* ./
 
 EXPOSE 30303 30303/udp 9001 8545 8546
 ENTRYPOINT ["/usr/local/bin/reth"]


### PR DESCRIPTION
I'm building a docker image with command as below:


```bash
docker build -t xxx .
```

But meets an error:

```bash
$ docker build -t xxx .
Sending build context to Docker daemon  11.71MB
Step 1/21 : FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
 ---> 1c3f02ba4de2
Step 2/21 : WORKDIR app
 ---> Using cache
 ---> 039537a3aa96
Step 3/21 : LABEL org.opencontainers.image.source=https://github.com/paradigmxyz/reth
 ---> Using cache
 ---> 355cb6958486
Step 4/21 : LABEL org.opencontainers.image.licenses="MIT OR Apache-2.0"
 ---> Using cache
 ---> 5411b39e0054
Step 5/21 : FROM chef AS planner
 ---> 5411b39e0054
Step 6/21 : COPY . .
 ---> Using cache
 ---> 9168ea4ac5e5
Step 7/21 : RUN cargo chef prepare --recipe-path recipe.json
 ---> Using cache
 ---> 2ee1b2b21896
Step 8/21 : FROM chef AS builder
 ---> 5411b39e0054
Step 9/21 : COPY --from=planner /app/recipe.json recipe.json
 ---> Using cache
 ---> ed886d8ca573
Step 10/21 : ARG BUILD_PROFILE=release
 ---> Using cache
 ---> be638e3f8429
Step 11/21 : ENV BUILD_PROFILE $BUILD_PROFILE
 ---> Using cache
 ---> 7709a931eac9
Step 12/21 : RUN apt-get update && apt-get -y upgrade && apt-get install -y libclang-dev pkg-config
 ---> Using cache
 ---> 5f0d4291ed40
Step 13/21 : RUN cargo chef cook --profile $BUILD_PROFILE --recipe-path recipe.json
 ---> Using cache
 ---> 76e419c9e81c
Step 14/21 : COPY . .
 ---> Using cache
 ---> 198d82e44284
Step 15/21 : RUN cargo build --profile $BUILD_PROFILE --locked --bin reth
 ---> Using cache
 ---> 904dff0f2cea
Step 16/21 : FROM ubuntu AS runtime
 ---> 99284ca6cea0
Step 17/21 : WORKDIR app
 ---> Using cache
 ---> 08c45677acac
Step 18/21 : COPY --from=builder /app/target/release/reth /usr/local/bin
 ---> Using cache
 ---> fe674988c93d
Step 19/21 : COPY LICENSE-* .
When using COPY with more than one source file, the destination must be a directory and end with a /
```
