### PR TITLE
chore: support mdbx max readers error

### DIFF
--- a/crates/interfaces/src/db.rs
+++ b/crates/interfaces/src/db.rs
@@ -20,8 +20,8 @@ pub enum DatabaseError {
     #[error("Database commit error code: {0:?}")]
     Commit(i32),
     /// Failed to initiate a transaction.
-    #[error("Initialization of transaction errored with code: {0:?}")]
-    InitTransaction(i32),
+    #[error(transparent)]
+    InitTransaction(InitTransactionError),
     /// Failed to initiate a cursor.
     #[error("Initialization of cursor errored with code: {0:?}")]
     InitCursor(i32),
@@ -31,4 +31,28 @@ pub enum DatabaseError {
     /// Failed to get database stats.
     #[error("Database stats error code: {0:?}")]
     Stats(i32),
+    /// Max database transactions reached.
+    ///
+    /// This is thrown when an mdbx transaction fails to open because the lock table already has the maximum number of transactions open.
+    #[error("Too many active database readers: {0:?}")]
+    MaxReaders(i32),
+}
+
+/// Error variants that can happen when initializing a transaction.
+#[derive(Debug, thiserror::Error, PartialEq, Eq, Clone)]
+pub enum InitTransactionError {
+    /// Max database transactions reached.
+    ///
+    /// This is thrown when an mdbx transaction fails to open because the lock table already has the maximum number of transactions open.
+    #[error("Too many active database readers")]
+    MaxReaders,
+    /// Any other error that can happen when initializing a transaction.
+    #[error("Initialization of transaction errored with code: {0:?}")]
+    Other(i32)
+}
+
+impl From<i32> for InitTransactionError {
+    fn from(value: i32) -> Self {
+        todo!()
+    }
 }


### PR DESCRIPTION
Closes #3442
wip

the `DatabaseError` can be unhelpful at times because it strips the mdbx error message.

we can't add conversions from mdbxerror unless we add it as a dependency.

or we do manual conversion from i32 again

not sure yet how to proceed, wdyt @rkrasiuk @joshieDo 