### PR TITLE
feat: add database config

### DIFF
--- a/crates/storage/db/src/config.rs
+++ b/crates/storage/db/src/config.rs
@@ -1,0 +1,12 @@
+/// Configuration the database
+///
+/// This allows for the configuration of the database via [Environment](reth_libmdbx::Environment)
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
+pub struct DatabaseConfig {
+    /// The maximum number of concurrent readers for the database.
+    ///
+    /// See also [set_max_readers](reth_libmdbx::EnvironmentBuilder::set_max_readers)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_readers: Option<usize>,
+}

--- a/crates/storage/db/src/config.rs
+++ b/crates/storage/db/src/config.rs
@@ -1,6 +1,6 @@
 /// Configuration the database
 ///
-/// This allows for the configuration of the database via [Environment](reth_libmdbx::Environment)
+/// This allows the configuration of certain database settings.
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(default)]
 pub struct DatabaseConfig {

--- a/crates/storage/db/src/lib.rs
+++ b/crates/storage/db/src/lib.rs
@@ -71,10 +71,14 @@
 /// Traits defining the database abstractions, such as cursors and transactions.
 pub mod abstraction;
 
-mod implementation;
 pub mod tables;
-mod utils;
 pub mod version;
+
+/// Configuration of the database
+pub mod config;
+
+mod implementation;
+mod utils;
 
 #[cfg(feature = "mdbx")]
 /// Bindings for [MDBX](https://libmdbx.dqdkfa.ru/).


### PR DESCRIPTION
add config type for customizing database settings

@onbjerg can I add this here:

https://github.com/paradigmxyz/reth/blob/927a9965f41a35679ef349c21ecda362b152ff7d/crates/config/src/config.rs#L12-L23 
which would require a dependency to db crate

currently we're using this to open a DB

https://github.com/paradigmxyz/reth/blob/927a9965f41a35679ef349c21ecda362b152ff7d/crates/storage/db/src/implementation/mdbx/mod.rs#L59-L62

can I add another function that accepts the config as argument?

blocked by #3450