### PR TITLE
refactor: move `init_db` to `reth_db` and add `DatabaseEnv`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5027,6 +5027,7 @@ dependencies = [
  "bytes",
  "criterion",
  "derive_more",
+ "eyre",
  "futures",
  "heapless",
  "iai",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5459,6 +5459,7 @@ dependencies = [
  "reth-revm-primitives",
  "reth-rlp",
  "reth-trie",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "tracing",

--- a/bin/reth/src/chain/import.rs
+++ b/bin/reth/src/chain/import.rs
@@ -11,14 +11,14 @@ use reth_provider::{ProviderFactory, StageCheckpointReader};
 
 use crate::args::utils::genesis_value_parser;
 use reth_config::Config;
-use reth_db::database::Database;
+use reth_db::{database::Database, init_db};
 use reth_downloaders::{
     bodies::bodies::BodiesDownloaderBuilder,
     headers::reverse_headers::ReverseHeadersDownloaderBuilder, test_utils::FileClient,
 };
 use reth_interfaces::consensus::Consensus;
 use reth_primitives::{stage::StageId, ChainSpec, H256};
-use reth_staged_sync::utils::init::{init_db, init_genesis};
+use reth_staged_sync::utils::init::init_genesis;
 use reth_stages::{
     prelude::*,
     stages::{

--- a/bin/reth/src/chain/init.rs
+++ b/bin/reth/src/chain/init.rs
@@ -3,8 +3,9 @@ use crate::{
     dirs::{DataDirPath, MaybePlatformPath},
 };
 use clap::Parser;
+use reth_db::init_db;
 use reth_primitives::ChainSpec;
-use reth_staged_sync::utils::init::{init_db, init_genesis};
+use reth_staged_sync::utils::init::init_genesis;
 use std::sync::Arc;
 use tracing::info;
 

--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -12,7 +12,7 @@ use reth_db::{
     database::Database,
     mdbx::{Env, NoWriteMap, WriteMap},
     version::{get_db_version, DatabaseVersionError, DB_VERSION},
-    Tables,
+    DatabaseEngine, Tables,
 };
 use reth_primitives::ChainSpec;
 use std::{path::Path, sync::Arc};
@@ -178,7 +178,7 @@ fn read_only_db(path: &Path) -> eyre::Result<Env<NoWriteMap>> {
         .with_context(|| format!("Could not open database at path: {}", path.display()))
 }
 
-fn read_write_db(path: &Path) -> eyre::Result<Env<WriteMap>> {
+fn read_write_db(path: &Path) -> eyre::Result<DatabaseEngine> {
     Env::<WriteMap>::open(path, reth_db::mdbx::EnvKind::RW)
         .with_context(|| format!("Could not open database at path: {}", path.display()))
 }

--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -12,7 +12,7 @@ use reth_db::{
     database::Database,
     mdbx::{Env, NoWriteMap, WriteMap},
     version::{get_db_version, DatabaseVersionError, DB_VERSION},
-    DatabaseEngine, Tables,
+    DatabaseEnv, Tables,
 };
 use reth_primitives::ChainSpec;
 use std::{path::Path, sync::Arc};
@@ -178,7 +178,7 @@ fn read_only_db(path: &Path) -> eyre::Result<Env<NoWriteMap>> {
         .with_context(|| format!("Could not open database at path: {}", path.display()))
 }
 
-fn read_write_db(path: &Path) -> eyre::Result<DatabaseEngine> {
+fn read_write_db(path: &Path) -> eyre::Result<DatabaseEnv> {
     Env::<WriteMap>::open(path, reth_db::mdbx::EnvKind::RW)
         .with_context(|| format!("Could not open database at path: {}", path.display()))
 }

--- a/bin/reth/src/debug_cmd/execution.rs
+++ b/bin/reth/src/debug_cmd/execution.rs
@@ -10,7 +10,7 @@ use clap::Parser;
 use futures::{stream::select as stream_select, StreamExt};
 use reth_beacon_consensus::BeaconConsensus;
 use reth_config::Config;
-use reth_db::{database::Database, init_db, DatabaseEngine};
+use reth_db::{database::Database, init_db, DatabaseEnv};
 use reth_discv4::DEFAULT_DISCOVERY_PORT;
 use reth_downloaders::{
     bodies::bodies::BodiesDownloaderBuilder,
@@ -150,7 +150,7 @@ impl Command {
         &self,
         config: &Config,
         task_executor: TaskExecutor,
-        db: Arc<DatabaseEngine>,
+        db: Arc<DatabaseEnv>,
         network_secret_path: PathBuf,
         default_peers_path: PathBuf,
     ) -> eyre::Result<NetworkHandle> {

--- a/bin/reth/src/debug_cmd/execution.rs
+++ b/bin/reth/src/debug_cmd/execution.rs
@@ -12,6 +12,7 @@ use reth_beacon_consensus::BeaconConsensus;
 use reth_config::Config;
 use reth_db::{
     database::Database,
+    init_db,
     mdbx::{Env, WriteMap},
 };
 use reth_discv4::DEFAULT_DISCOVERY_PORT;
@@ -27,7 +28,7 @@ use reth_network::NetworkHandle;
 use reth_network_api::NetworkInfo;
 use reth_primitives::{stage::StageId, BlockHashOrNumber, BlockNumber, ChainSpec, H256};
 use reth_provider::{BlockExecutionWriter, ProviderFactory, StageCheckpointReader};
-use reth_staged_sync::utils::init::{init_db, init_genesis};
+use reth_staged_sync::utils::init::init_genesis;
 use reth_stages::{
     sets::DefaultStages,
     stages::{

--- a/bin/reth/src/debug_cmd/execution.rs
+++ b/bin/reth/src/debug_cmd/execution.rs
@@ -10,11 +10,7 @@ use clap::Parser;
 use futures::{stream::select as stream_select, StreamExt};
 use reth_beacon_consensus::BeaconConsensus;
 use reth_config::Config;
-use reth_db::{
-    database::Database,
-    init_db,
-    mdbx::{Env, WriteMap},
-};
+use reth_db::{database::Database, init_db, DatabaseEngine};
 use reth_discv4::DEFAULT_DISCOVERY_PORT;
 use reth_downloaders::{
     bodies::bodies::BodiesDownloaderBuilder,
@@ -154,7 +150,7 @@ impl Command {
         &self,
         config: &Config,
         task_executor: TaskExecutor,
-        db: Arc<Env<WriteMap>>,
+        db: Arc<DatabaseEngine>,
         network_secret_path: PathBuf,
         default_peers_path: PathBuf,
     ) -> eyre::Result<NetworkHandle> {

--- a/bin/reth/src/debug_cmd/merkle.rs
+++ b/bin/reth/src/debug_cmd/merkle.rs
@@ -4,13 +4,12 @@ use crate::{
     dirs::{DataDirPath, MaybePlatformPath},
 };
 use clap::Parser;
-use reth_db::{cursor::DbCursorRO, tables, transaction::DbTx};
+use reth_db::{cursor::DbCursorRO, init_db, tables, transaction::DbTx};
 use reth_primitives::{
     stage::{StageCheckpoint, StageId},
     ChainSpec,
 };
 use reth_provider::{ProviderFactory, StageCheckpointReader};
-use reth_staged_sync::utils::init::init_db;
 use reth_stages::{
     stages::{
         AccountHashingStage, ExecutionStage, ExecutionStageThresholds, MerkleStage,

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -22,6 +22,7 @@ use reth_blockchain_tree::{
 use reth_config::Config;
 use reth_db::{
     database::Database,
+    init_db,
     mdbx::{Env, WriteMap},
 };
 use reth_discv4::DEFAULT_DISCOVERY_PORT;
@@ -47,7 +48,7 @@ use reth_provider::{
 use reth_revm::Factory;
 use reth_revm_inspectors::stack::Hook;
 use reth_rpc_engine_api::EngineApi;
-use reth_staged_sync::utils::init::{init_db, init_genesis};
+use reth_staged_sync::utils::init::init_genesis;
 use reth_stages::{
     prelude::*,
     stages::{

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -20,11 +20,7 @@ use reth_blockchain_tree::{
     config::BlockchainTreeConfig, externals::TreeExternals, BlockchainTree, ShareableBlockchainTree,
 };
 use reth_config::Config;
-use reth_db::{
-    database::Database,
-    init_db,
-    mdbx::{Env, WriteMap},
-};
+use reth_db::{database::Database, init_db, DatabaseEngine};
 use reth_discv4::DEFAULT_DISCOVERY_PORT;
 use reth_downloaders::{
     bodies::bodies::BodiesDownloaderBuilder,
@@ -479,7 +475,7 @@ impl Command {
         }
     }
 
-    async fn start_metrics_endpoint(&self, db: Arc<Env<WriteMap>>) -> eyre::Result<()> {
+    async fn start_metrics_endpoint(&self, db: Arc<DatabaseEngine>) -> eyre::Result<()> {
         if let Some(listen_addr) = self.metrics {
             info!(target: "reth::cli", addr = %listen_addr, "Starting metrics endpoint");
 
@@ -520,7 +516,7 @@ impl Command {
         Ok(handle)
     }
 
-    fn lookup_head(&self, db: Arc<Env<WriteMap>>) -> Result<Head, reth_interfaces::Error> {
+    fn lookup_head(&self, db: Arc<DatabaseEngine>) -> Result<Head, reth_interfaces::Error> {
         let factory = ProviderFactory::new(db, self.chain.clone());
         let provider = factory.provider()?;
 
@@ -605,12 +601,12 @@ impl Command {
     fn load_network_config(
         &self,
         config: &Config,
-        db: Arc<Env<WriteMap>>,
+        db: Arc<DatabaseEngine>,
         executor: TaskExecutor,
         head: Head,
         secret_key: SecretKey,
         default_peers_path: PathBuf,
-    ) -> NetworkConfig<ProviderFactory<Arc<Env<WriteMap>>>> {
+    ) -> NetworkConfig<ProviderFactory<Arc<DatabaseEngine>>> {
         self.network
             .network_config(config, self.chain.clone(), secret_key, default_peers_path)
             .with_task_executor(Box::new(executor))

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -20,7 +20,7 @@ use reth_blockchain_tree::{
     config::BlockchainTreeConfig, externals::TreeExternals, BlockchainTree, ShareableBlockchainTree,
 };
 use reth_config::Config;
-use reth_db::{database::Database, init_db, DatabaseEngine};
+use reth_db::{database::Database, init_db, DatabaseEnv};
 use reth_discv4::DEFAULT_DISCOVERY_PORT;
 use reth_downloaders::{
     bodies::bodies::BodiesDownloaderBuilder,
@@ -475,7 +475,7 @@ impl Command {
         }
     }
 
-    async fn start_metrics_endpoint(&self, db: Arc<DatabaseEngine>) -> eyre::Result<()> {
+    async fn start_metrics_endpoint(&self, db: Arc<DatabaseEnv>) -> eyre::Result<()> {
         if let Some(listen_addr) = self.metrics {
             info!(target: "reth::cli", addr = %listen_addr, "Starting metrics endpoint");
 
@@ -516,7 +516,7 @@ impl Command {
         Ok(handle)
     }
 
-    fn lookup_head(&self, db: Arc<DatabaseEngine>) -> Result<Head, reth_interfaces::Error> {
+    fn lookup_head(&self, db: Arc<DatabaseEnv>) -> Result<Head, reth_interfaces::Error> {
         let factory = ProviderFactory::new(db, self.chain.clone());
         let provider = factory.provider()?;
 
@@ -601,12 +601,12 @@ impl Command {
     fn load_network_config(
         &self,
         config: &Config,
-        db: Arc<DatabaseEngine>,
+        db: Arc<DatabaseEnv>,
         executor: TaskExecutor,
         head: Head,
         secret_key: SecretKey,
         default_peers_path: PathBuf,
-    ) -> NetworkConfig<ProviderFactory<Arc<DatabaseEngine>>> {
+    ) -> NetworkConfig<ProviderFactory<Arc<DatabaseEnv>>> {
         self.network
             .network_config(config, self.chain.clone(), secret_key, default_peers_path)
             .with_task_executor(Box::new(executor))

--- a/bin/reth/src/prometheus_exporter.rs
+++ b/bin/reth/src/prometheus_exporter.rs
@@ -6,7 +6,7 @@ use hyper::{
 };
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 use metrics_util::layers::{PrefixLayer, Stack};
-use reth_db::{database::Database, tables, DatabaseEngine};
+use reth_db::{database::Database, tables, DatabaseEnv};
 use reth_metrics::metrics::{self, absolute_counter, describe_counter, Unit};
 use std::{convert::Infallible, net::SocketAddr, sync::Arc};
 
@@ -63,7 +63,7 @@ async fn start_endpoint<F: Fn() + Send + Sync + 'static>(
 /// Installs Prometheus as the metrics recorder and serves it over HTTP with database metrics.
 pub(crate) async fn initialize_with_db_metrics(
     listen_addr: SocketAddr,
-    db: Arc<DatabaseEngine>,
+    db: Arc<DatabaseEnv>,
 ) -> eyre::Result<()> {
     let db_stats = move || {
         // TODO: A generic stats abstraction for other DB types to deduplicate this and `reth db

--- a/bin/reth/src/prometheus_exporter.rs
+++ b/bin/reth/src/prometheus_exporter.rs
@@ -6,11 +6,7 @@ use hyper::{
 };
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 use metrics_util::layers::{PrefixLayer, Stack};
-use reth_db::{
-    database::Database,
-    mdbx::{Env, WriteMap},
-    tables,
-};
+use reth_db::{database::Database, tables, DatabaseEngine};
 use reth_metrics::metrics::{self, absolute_counter, describe_counter, Unit};
 use std::{convert::Infallible, net::SocketAddr, sync::Arc};
 
@@ -67,7 +63,7 @@ async fn start_endpoint<F: Fn() + Send + Sync + 'static>(
 /// Installs Prometheus as the metrics recorder and serves it over HTTP with database metrics.
 pub(crate) async fn initialize_with_db_metrics(
     listen_addr: SocketAddr,
-    db: Arc<Env<WriteMap>>,
+    db: Arc<DatabaseEngine>,
 ) -> eyre::Result<()> {
     let db_stats = move || {
         // TODO: A generic stats abstraction for other DB types to deduplicate this and `reth db

--- a/bin/reth/src/stage/drop.rs
+++ b/bin/reth/src/stage/drop.rs
@@ -10,7 +10,7 @@ use reth_db::{
     mdbx::{Env, WriteMap},
     tables,
     transaction::DbTxMut,
-    DatabaseEngine,
+    DatabaseEnv,
 };
 use reth_primitives::{stage::StageId, ChainSpec};
 use reth_staged_sync::utils::init::{insert_genesis_header, insert_genesis_state};
@@ -71,7 +71,7 @@ impl Command {
                     tx.clear::<tables::BlockOmmers>()?;
                     tx.clear::<tables::BlockWithdrawals>()?;
                     tx.put::<tables::SyncStage>(StageId::Bodies.to_string(), Default::default())?;
-                    insert_genesis_header::<DatabaseEngine>(tx, self.chain)?;
+                    insert_genesis_header::<DatabaseEnv>(tx, self.chain)?;
                 }
                 StageEnum::Senders => {
                     tx.clear::<tables::TxSenders>()?;
@@ -91,7 +91,7 @@ impl Command {
                         StageId::Execution.to_string(),
                         Default::default(),
                     )?;
-                    insert_genesis_state::<DatabaseEngine>(tx, self.chain.genesis())?;
+                    insert_genesis_state::<DatabaseEnv>(tx, self.chain.genesis())?;
                 }
                 StageEnum::AccountHashing => {
                     tx.clear::<tables::HashedAccount>()?;
@@ -156,7 +156,7 @@ impl Command {
                         StageId::TotalDifficulty.to_string(),
                         Default::default(),
                     )?;
-                    insert_genesis_header::<DatabaseEngine>(tx, self.chain)?;
+                    insert_genesis_header::<DatabaseEnv>(tx, self.chain)?;
                 }
                 _ => {
                     info!("Nothing to do for stage {:?}", self.stage);

--- a/bin/reth/src/stage/drop.rs
+++ b/bin/reth/src/stage/drop.rs
@@ -10,6 +10,7 @@ use reth_db::{
     mdbx::{Env, WriteMap},
     tables,
     transaction::DbTxMut,
+    DatabaseEngine,
 };
 use reth_primitives::{stage::StageId, ChainSpec};
 use reth_staged_sync::utils::init::{insert_genesis_header, insert_genesis_state};
@@ -70,7 +71,7 @@ impl Command {
                     tx.clear::<tables::BlockOmmers>()?;
                     tx.clear::<tables::BlockWithdrawals>()?;
                     tx.put::<tables::SyncStage>(StageId::Bodies.to_string(), Default::default())?;
-                    insert_genesis_header::<Env<WriteMap>>(tx, self.chain)?;
+                    insert_genesis_header::<DatabaseEngine>(tx, self.chain)?;
                 }
                 StageEnum::Senders => {
                     tx.clear::<tables::TxSenders>()?;
@@ -90,7 +91,7 @@ impl Command {
                         StageId::Execution.to_string(),
                         Default::default(),
                     )?;
-                    insert_genesis_state::<Env<WriteMap>>(tx, self.chain.genesis())?;
+                    insert_genesis_state::<DatabaseEngine>(tx, self.chain.genesis())?;
                 }
                 StageEnum::AccountHashing => {
                     tx.clear::<tables::HashedAccount>()?;
@@ -155,7 +156,7 @@ impl Command {
                         StageId::TotalDifficulty.to_string(),
                         Default::default(),
                     )?;
-                    insert_genesis_header::<Env<WriteMap>>(tx, self.chain)?;
+                    insert_genesis_header::<DatabaseEngine>(tx, self.chain)?;
                 }
                 _ => {
                     info!("Nothing to do for stage {:?}", self.stage);

--- a/bin/reth/src/stage/dump/mod.rs
+++ b/bin/reth/src/stage/dump/mod.rs
@@ -5,10 +5,10 @@ use crate::{
 };
 use clap::Parser;
 use reth_db::{
-    cursor::DbCursorRO, database::Database, table::TableImporter, tables, transaction::DbTx,
+    cursor::DbCursorRO, database::Database, init_db, table::TableImporter, tables,
+    transaction::DbTx,
 };
 use reth_primitives::ChainSpec;
-use reth_staged_sync::utils::init::init_db;
 use std::{path::PathBuf, sync::Arc};
 use tracing::info;
 

--- a/bin/reth/src/stage/run.rs
+++ b/bin/reth/src/stage/run.rs
@@ -10,10 +10,10 @@ use crate::{
 use clap::Parser;
 use reth_beacon_consensus::BeaconConsensus;
 use reth_config::Config;
+use reth_db::init_db;
 use reth_downloaders::bodies::bodies::BodiesDownloaderBuilder;
 use reth_primitives::ChainSpec;
 use reth_provider::{ProviderFactory, StageCheckpointReader};
-use reth_staged_sync::utils::init::init_db;
 use reth_stages::{
     stages::{
         AccountHashingStage, BodyStage, ExecutionStage, ExecutionStageThresholds,

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1085,7 +1085,7 @@ mod tests {
     use crate::block_buffer::BufferedBlocks;
     use assert_matches::assert_matches;
     use linked_hash_set::LinkedHashSet;
-    use reth_db::{mdbx::test_utils::create_test_rw_db, transaction::DbTxMut, DatabaseEngine};
+    use reth_db::{mdbx::test_utils::create_test_rw_db, transaction::DbTxMut, DatabaseEnv};
     use reth_interfaces::test_utils::TestConsensus;
     use reth_primitives::{
         proofs::EMPTY_ROOT, stage::StageCheckpoint, ChainSpecBuilder, H256, MAINNET,
@@ -1099,7 +1099,7 @@ mod tests {
 
     fn setup_externals(
         exec_res: Vec<PostState>,
-    ) -> TreeExternals<Arc<DatabaseEngine>, Arc<TestConsensus>, TestExecutorFactory> {
+    ) -> TreeExternals<Arc<DatabaseEnv>, Arc<TestConsensus>, TestExecutorFactory> {
         let db = create_test_rw_db();
         let consensus = Arc::new(TestConsensus::default());
         let chain_spec = Arc::new(

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1085,10 +1085,7 @@ mod tests {
     use crate::block_buffer::BufferedBlocks;
     use assert_matches::assert_matches;
     use linked_hash_set::LinkedHashSet;
-    use reth_db::{
-        mdbx::{test_utils::create_test_rw_db, Env, WriteMap},
-        transaction::DbTxMut,
-    };
+    use reth_db::{mdbx::test_utils::create_test_rw_db, transaction::DbTxMut, DatabaseEngine};
     use reth_interfaces::test_utils::TestConsensus;
     use reth_primitives::{
         proofs::EMPTY_ROOT, stage::StageCheckpoint, ChainSpecBuilder, H256, MAINNET,
@@ -1102,7 +1099,7 @@ mod tests {
 
     fn setup_externals(
         exec_res: Vec<PostState>,
-    ) -> TreeExternals<Arc<Env<WriteMap>>, Arc<TestConsensus>, TestExecutorFactory> {
+    ) -> TreeExternals<Arc<DatabaseEngine>, Arc<TestConsensus>, TestExecutorFactory> {
         let db = create_test_rw_db();
         let consensus = Arc::new(TestConsensus::default());
         let chain_spec = Arc::new(

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1361,7 +1361,7 @@ mod tests {
         config::BlockchainTreeConfig, externals::TreeExternals, post_state::PostState,
         BlockchainTree, ShareableBlockchainTree,
     };
-    use reth_db::mdbx::{test_utils::create_test_rw_db, Env, WriteMap};
+    use reth_db::{mdbx::test_utils::create_test_rw_db, DatabaseEngine};
     use reth_interfaces::{
         sync::NoopSyncStateUpdater,
         test_utils::{NoopFullBlockClient, TestConsensus},
@@ -1381,10 +1381,10 @@ mod tests {
     };
 
     type TestBeaconConsensusEngine = BeaconConsensusEngine<
-        Arc<Env<WriteMap>>,
+        Arc<DatabaseEngine>,
         BlockchainProvider<
-            Arc<Env<WriteMap>>,
-            ShareableBlockchainTree<Arc<Env<WriteMap>>, TestConsensus, TestExecutorFactory>,
+            Arc<DatabaseEngine>,
+            ShareableBlockchainTree<Arc<DatabaseEngine>, TestConsensus, TestExecutorFactory>,
         >,
         NoopFullBlockClient,
     >;
@@ -1498,7 +1498,7 @@ mod tests {
         }
 
         /// Builds the test consensus engine into a `TestConsensusEngine` and `TestEnv`.
-        fn build(self) -> (TestBeaconConsensusEngine, TestEnv<Arc<Env<WriteMap>>>) {
+        fn build(self) -> (TestBeaconConsensusEngine, TestEnv<Arc<DatabaseEngine>>) {
             reth_tracing::init_test_tracing();
             let db = create_test_rw_db();
             let consensus = TestConsensus::default();

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1361,7 +1361,7 @@ mod tests {
         config::BlockchainTreeConfig, externals::TreeExternals, post_state::PostState,
         BlockchainTree, ShareableBlockchainTree,
     };
-    use reth_db::{mdbx::test_utils::create_test_rw_db, DatabaseEngine};
+    use reth_db::{mdbx::test_utils::create_test_rw_db, DatabaseEnv};
     use reth_interfaces::{
         sync::NoopSyncStateUpdater,
         test_utils::{NoopFullBlockClient, TestConsensus},
@@ -1381,10 +1381,10 @@ mod tests {
     };
 
     type TestBeaconConsensusEngine = BeaconConsensusEngine<
-        Arc<DatabaseEngine>,
+        Arc<DatabaseEnv>,
         BlockchainProvider<
-            Arc<DatabaseEngine>,
-            ShareableBlockchainTree<Arc<DatabaseEngine>, TestConsensus, TestExecutorFactory>,
+            Arc<DatabaseEnv>,
+            ShareableBlockchainTree<Arc<DatabaseEnv>, TestConsensus, TestExecutorFactory>,
         >,
         NoopFullBlockClient,
     >;
@@ -1498,7 +1498,7 @@ mod tests {
         }
 
         /// Builds the test consensus engine into a `TestConsensusEngine` and `TestEnv`.
-        fn build(self) -> (TestBeaconConsensusEngine, TestEnv<Arc<DatabaseEngine>>) {
+        fn build(self) -> (TestBeaconConsensusEngine, TestEnv<Arc<DatabaseEnv>>) {
             reth_tracing::init_test_tracing();
             let db = create_test_rw_db();
             let consensus = TestConsensus::default();

--- a/crates/interfaces/src/blockchain_tree/error.rs
+++ b/crates/interfaces/src/blockchain_tree/error.rs
@@ -272,6 +272,7 @@ impl From<crate::Error> for InsertBlockErrorKind {
             Error::Database(err) => InsertBlockErrorKind::Internal(Box::new(err)),
             Error::Provider(err) => InsertBlockErrorKind::Internal(Box::new(err)),
             Error::Network(err) => InsertBlockErrorKind::Internal(Box::new(err)),
+            Error::Custom(err) => InsertBlockErrorKind::Internal(err.into()),
         }
     }
 }

--- a/crates/interfaces/src/error.rs
+++ b/crates/interfaces/src/error.rs
@@ -19,4 +19,7 @@ pub enum Error {
 
     #[error(transparent)]
     Network(#[from] reth_network_api::NetworkError),
+
+    #[error("{0}")]
+    Custom(std::string::String),
 }

--- a/crates/net/downloaders/src/bodies/test_utils.rs
+++ b/crates/net/downloaders/src/bodies/test_utils.rs
@@ -5,6 +5,7 @@ use reth_db::{
     mdbx::{Env, WriteMap},
     tables,
     transaction::DbTxMut,
+    DatabaseEngine,
 };
 use reth_interfaces::{db, p2p::bodies::response::BlockResponse};
 use reth_primitives::{Block, BlockBody, SealedBlock, SealedHeader, H256};
@@ -46,7 +47,7 @@ pub(crate) fn create_raw_bodies<'a>(
 }
 
 #[inline]
-pub(crate) fn insert_headers(db: &Env<WriteMap>, headers: &[SealedHeader]) {
+pub(crate) fn insert_headers(db: &DatabaseEngine, headers: &[SealedHeader]) {
     db.update(|tx| -> Result<(), db::DatabaseError> {
         for header in headers {
             tx.put::<tables::CanonicalHeaders>(header.number, header.hash())?;

--- a/crates/net/downloaders/src/bodies/test_utils.rs
+++ b/crates/net/downloaders/src/bodies/test_utils.rs
@@ -5,7 +5,7 @@ use reth_db::{
     mdbx::{Env, WriteMap},
     tables,
     transaction::DbTxMut,
-    DatabaseEngine,
+    DatabaseEnv,
 };
 use reth_interfaces::{db, p2p::bodies::response::BlockResponse};
 use reth_primitives::{Block, BlockBody, SealedBlock, SealedHeader, H256};
@@ -47,7 +47,7 @@ pub(crate) fn create_raw_bodies<'a>(
 }
 
 #[inline]
-pub(crate) fn insert_headers(db: &DatabaseEngine, headers: &[SealedHeader]) {
+pub(crate) fn insert_headers(db: &DatabaseEnv, headers: &[SealedHeader]) {
     db.update(|tx| -> Result<(), db::DatabaseError> {
         for header in headers {
             tx.put::<tables::CanonicalHeaders>(header.number, header.hash())?;

--- a/crates/staged-sync/src/utils/init.rs
+++ b/crates/staged-sync/src/utils/init.rs
@@ -176,13 +176,11 @@ pub fn insert_genesis_header<DB: Database>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use assert_matches::assert_matches;
+
     use reth_db::{
-        init_db,
         mdbx::test_utils::create_test_rw_db,
         models::{storage_sharded_key::StorageShardedKey, ShardedKey},
         table::Table,
-        version::{db_version_file_path, DatabaseVersionError},
         DatabaseEngine,
     };
     use reth_primitives::{
@@ -190,7 +188,6 @@ mod tests {
         GOERLI_GENESIS, MAINNET, MAINNET_GENESIS, SEPOLIA, SEPOLIA_GENESIS,
     };
     use std::collections::HashMap;
-    use tempfile::tempdir;
 
     fn collect_table_entries<DB, T>(
         tx: &<DB as DatabaseGAT<'_>>::TX,

--- a/crates/staged-sync/src/utils/init.rs
+++ b/crates/staged-sync/src/utils/init.rs
@@ -298,44 +298,4 @@ mod tests {
             )],
         );
     }
-
-    #[test]
-    fn db_version() {
-        let path = tempdir().unwrap();
-
-        // Database is empty
-        {
-            let db = init_db(&path);
-            assert_matches!(db, Ok(_));
-        }
-
-        // Database is not empty, current version is the same as in the file
-        {
-            let db = init_db(&path);
-            assert_matches!(db, Ok(_));
-        }
-
-        // Database is not empty, version file is malformed
-        {
-            std::fs::write(path.path().join(db_version_file_path(&path)), "invalid-version")
-                .unwrap();
-            let db = init_db(&path);
-            assert!(db.is_err());
-            assert_matches!(
-                db.unwrap_err().downcast_ref::<DatabaseVersionError>(),
-                Some(DatabaseVersionError::MalformedFile)
-            )
-        }
-
-        // Database is not empty, version file contains not matching version
-        {
-            std::fs::write(path.path().join(db_version_file_path(&path)), "0").unwrap();
-            let db = init_db(&path);
-            assert!(db.is_err());
-            assert_matches!(
-                db.unwrap_err().downcast_ref::<DatabaseVersionError>(),
-                Some(DatabaseVersionError::VersionMismatch { version: 0 })
-            )
-        }
-    }
 }

--- a/crates/staged-sync/src/utils/init.rs
+++ b/crates/staged-sync/src/utils/init.rs
@@ -181,7 +181,7 @@ mod tests {
         mdbx::test_utils::create_test_rw_db,
         models::{storage_sharded_key::StorageShardedKey, ShardedKey},
         table::Table,
-        DatabaseEngine,
+        DatabaseEnv,
     };
     use reth_primitives::{
         Address, Chain, ForkTimestamps, Genesis, GenesisAccount, IntegerList, GOERLI,
@@ -278,7 +278,7 @@ mod tests {
         let tx = db.tx().expect("failed to init tx");
 
         assert_eq!(
-            collect_table_entries::<Arc<DatabaseEngine>, tables::AccountHistory>(&tx)
+            collect_table_entries::<Arc<DatabaseEnv>, tables::AccountHistory>(&tx)
                 .expect("failed to collect"),
             vec![
                 (ShardedKey::new(address_with_balance, u64::MAX), IntegerList::new([0]).unwrap()),
@@ -287,7 +287,7 @@ mod tests {
         );
 
         assert_eq!(
-            collect_table_entries::<Arc<DatabaseEngine>, tables::StorageHistory>(&tx)
+            collect_table_entries::<Arc<DatabaseEnv>, tables::StorageHistory>(&tx)
                 .expect("failed to collect"),
             vec![(
                 StorageShardedKey::new(address_with_storage, storage_key, u64::MAX),

--- a/crates/stages/benches/criterion.rs
+++ b/crates/stages/benches/criterion.rs
@@ -3,7 +3,7 @@ use criterion::{
     BenchmarkGroup, Criterion,
 };
 use pprof::criterion::{Output, PProfProfiler};
-use reth_db::DatabaseEngine;
+use reth_db::DatabaseEnv;
 use reth_interfaces::test_utils::TestConsensus;
 use reth_primitives::{stage::StageCheckpoint, MAINNET};
 use reth_provider::ProviderFactory;
@@ -122,7 +122,7 @@ fn measure_stage_with_path<F, S>(
     stage_range: StageRange,
     label: String,
 ) where
-    S: Clone + Stage<DatabaseEngine>,
+    S: Clone + Stage<DatabaseEnv>,
     F: Fn(S, &TestTransaction, StageRange),
 {
     let tx = TestTransaction::new(&path);
@@ -152,7 +152,7 @@ fn measure_stage<F, S>(
     block_interval: std::ops::Range<u64>,
     label: String,
 ) where
-    S: Clone + Stage<DatabaseEngine>,
+    S: Clone + Stage<DatabaseEnv>,
     F: Fn(S, &TestTransaction, StageRange),
 {
     let path = setup::txs_testdata(block_interval.end);

--- a/crates/stages/benches/criterion.rs
+++ b/crates/stages/benches/criterion.rs
@@ -3,7 +3,7 @@ use criterion::{
     BenchmarkGroup, Criterion,
 };
 use pprof::criterion::{Output, PProfProfiler};
-use reth_db::mdbx::{Env, WriteMap};
+use reth_db::DatabaseEngine;
 use reth_interfaces::test_utils::TestConsensus;
 use reth_primitives::{stage::StageCheckpoint, MAINNET};
 use reth_provider::ProviderFactory;
@@ -122,7 +122,7 @@ fn measure_stage_with_path<F, S>(
     stage_range: StageRange,
     label: String,
 ) where
-    S: Clone + Stage<Env<WriteMap>>,
+    S: Clone + Stage<DatabaseEngine>,
     F: Fn(S, &TestTransaction, StageRange),
 {
     let tx = TestTransaction::new(&path);
@@ -152,7 +152,7 @@ fn measure_stage<F, S>(
     block_interval: std::ops::Range<u64>,
     label: String,
 ) where
-    S: Clone + Stage<Env<WriteMap>>,
+    S: Clone + Stage<DatabaseEngine>,
     F: Fn(S, &TestTransaction, StageRange),
 {
     let path = setup::txs_testdata(block_interval.end);

--- a/crates/stages/benches/setup/mod.rs
+++ b/crates/stages/benches/setup/mod.rs
@@ -1,9 +1,9 @@
 use itertools::concat;
 use reth_db::{
     cursor::DbCursorRO,
-    mdbx::{Env, WriteMap},
     tables,
     transaction::{DbTx, DbTxMut},
+    DatabaseEngine,
 };
 use reth_interfaces::test_utils::{
     generators,
@@ -32,7 +32,7 @@ pub use account_hashing::*;
 
 pub(crate) type StageRange = (ExecInput, UnwindInput);
 
-pub(crate) fn stage_unwind<S: Clone + Stage<Env<WriteMap>>>(
+pub(crate) fn stage_unwind<S: Clone + Stage<DatabaseEngine>>(
     stage: S,
     tx: &TestTransaction,
     range: StageRange,
@@ -60,7 +60,7 @@ pub(crate) fn stage_unwind<S: Clone + Stage<Env<WriteMap>>>(
     });
 }
 
-pub(crate) fn unwind_hashes<S: Clone + Stage<Env<WriteMap>>>(
+pub(crate) fn unwind_hashes<S: Clone + Stage<DatabaseEngine>>(
     stage: S,
     tx: &TestTransaction,
     range: StageRange,

--- a/crates/stages/benches/setup/mod.rs
+++ b/crates/stages/benches/setup/mod.rs
@@ -3,7 +3,7 @@ use reth_db::{
     cursor::DbCursorRO,
     tables,
     transaction::{DbTx, DbTxMut},
-    DatabaseEngine,
+    DatabaseEnv,
 };
 use reth_interfaces::test_utils::{
     generators,
@@ -32,7 +32,7 @@ pub use account_hashing::*;
 
 pub(crate) type StageRange = (ExecInput, UnwindInput);
 
-pub(crate) fn stage_unwind<S: Clone + Stage<DatabaseEngine>>(
+pub(crate) fn stage_unwind<S: Clone + Stage<DatabaseEnv>>(
     stage: S,
     tx: &TestTransaction,
     range: StageRange,
@@ -60,7 +60,7 @@ pub(crate) fn stage_unwind<S: Clone + Stage<DatabaseEngine>>(
     });
 }
 
-pub(crate) fn unwind_hashes<S: Clone + Stage<DatabaseEngine>>(
+pub(crate) fn unwind_hashes<S: Clone + Stage<DatabaseEnv>>(
     stage: S,
     tx: &TestTransaction,
     range: StageRange,

--- a/crates/stages/src/stage.rs
+++ b/crates/stages/src/stage.rs
@@ -5,7 +5,7 @@ use reth_primitives::{
     stage::{StageCheckpoint, StageId},
     BlockNumber, TxNumber,
 };
-use reth_provider::DatabaseProviderRW;
+use reth_provider::{BlockReader, DatabaseProviderRW, ProviderError};
 use std::{
     cmp::{max, min},
     ops::RangeInclusive,
@@ -79,7 +79,9 @@ impl ExecInput {
         tx_threshold: u64,
     ) -> Result<(RangeInclusive<TxNumber>, RangeInclusive<BlockNumber>, bool), StageError> {
         let start_block = self.next_block();
-        let start_block_body = provider.block_body_indices(start_block)?;
+        let start_block_body = provider
+            .block_body_indices(start_block)?
+            .ok_or(ProviderError::BlockBodyIndicesNotFound(start_block))?;
 
         let target_block = self.target();
 

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -459,7 +459,7 @@ mod tests {
             models::{StoredBlockBodyIndices, StoredBlockOmmers},
             tables,
             transaction::{DbTx, DbTxMut},
-            DatabaseEngine,
+            DatabaseEnv,
         };
         use reth_interfaces::{
             p2p::{
@@ -740,7 +740,7 @@ mod tests {
         /// A [BodyDownloader] that is backed by an internal [HashMap] for testing.
         #[derive(Debug)]
         pub(crate) struct TestBodyDownloader {
-            db: Arc<DatabaseEngine>,
+            db: Arc<DatabaseEnv>,
             responses: HashMap<H256, BlockBody>,
             headers: VecDeque<SealedHeader>,
             batch_size: u64,
@@ -748,7 +748,7 @@ mod tests {
 
         impl TestBodyDownloader {
             pub(crate) fn new(
-                db: Arc<DatabaseEngine>,
+                db: Arc<DatabaseEnv>,
                 responses: HashMap<H256, BlockBody>,
                 batch_size: u64,
             ) -> Self {

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -456,10 +456,10 @@ mod tests {
         use reth_db::{
             cursor::DbCursorRO,
             database::Database,
-            mdbx::{Env, WriteMap},
             models::{StoredBlockBodyIndices, StoredBlockOmmers},
             tables,
             transaction::{DbTx, DbTxMut},
+            DatabaseEngine,
         };
         use reth_interfaces::{
             p2p::{
@@ -740,7 +740,7 @@ mod tests {
         /// A [BodyDownloader] that is backed by an internal [HashMap] for testing.
         #[derive(Debug)]
         pub(crate) struct TestBodyDownloader {
-            db: Arc<Env<WriteMap>>,
+            db: Arc<DatabaseEngine>,
             responses: HashMap<H256, BlockBody>,
             headers: VecDeque<SealedHeader>,
             batch_size: u64,
@@ -748,7 +748,7 @@ mod tests {
 
         impl TestBodyDownloader {
             pub(crate) fn new(
-                db: Arc<Env<WriteMap>>,
+                db: Arc<DatabaseEngine>,
                 responses: HashMap<H256, BlockBody>,
                 batch_size: u64,
             ) -> Self {

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -353,7 +353,10 @@ impl<EF: ExecutorFactory, DB: Database> Stage<DB> for ExecutionStage<EF> {
         }
 
         // Look up the start index for the transaction range
-        let first_tx_num = provider.block_body_indices(*range.start())?.first_tx_num();
+        let first_tx_num = provider
+            .block_body_indices(*range.start())?
+            .ok_or(ProviderError::BlockBodyIndicesNotFound(*range.start()))?
+            .first_tx_num();
 
         let mut stage_checkpoint = input.checkpoint.execution_stage_checkpoint();
 

--- a/crates/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/src/stages/tx_lookup.rs
@@ -203,7 +203,7 @@ mod tests {
         generators::{random_block, random_block_range},
     };
     use reth_primitives::{stage::StageUnitCheckpoint, BlockNumber, SealedBlock, H256};
-    use reth_provider::TransactionsProvider;
+    use reth_provider::{BlockReader, ProviderError, TransactionsProvider};
 
     // Implement stage test suite.
     stage_test_suite_ext!(TransactionLookupTestRunner, transaction_lookup);
@@ -345,7 +345,11 @@ mod tests {
         /// 2. If the is no requested block entry in the bodies table, but [tables::TxHashNumber] is
         ///    not empty.
         fn ensure_no_hash_by_block(&self, number: BlockNumber) -> Result<(), TestRunnerError> {
-            let body_result = self.tx.inner_rw().block_body_indices(number);
+            let body_result = self
+                .tx
+                .inner_rw()
+                .block_body_indices(number)?
+                .ok_or(ProviderError::BlockBodyIndicesNotFound(number));
             match body_result {
                 Ok(body) => self.tx.ensure_no_entry_above_by_value::<tables::TxHashNumber, _>(
                     body.last_tx_num(),

--- a/crates/stages/src/test_utils/runner.rs
+++ b/crates/stages/src/test_utils/runner.rs
@@ -2,7 +2,7 @@ use super::TestTransaction;
 use crate::{ExecInput, ExecOutput, Stage, StageError, UnwindInput, UnwindOutput};
 use reth_db::{
     mdbx::{Env, WriteMap},
-    DatabaseEngine,
+    DatabaseEnv,
 };
 use reth_primitives::MAINNET;
 use reth_provider::ProviderFactory;
@@ -22,7 +22,7 @@ pub(crate) enum TestRunnerError {
 /// A generic test runner for stages.
 #[async_trait::async_trait]
 pub(crate) trait StageTestRunner {
-    type S: Stage<DatabaseEngine> + 'static;
+    type S: Stage<DatabaseEnv> + 'static;
 
     /// Return a reference to the database.
     fn tx(&self) -> &TestTransaction;

--- a/crates/stages/src/test_utils/runner.rs
+++ b/crates/stages/src/test_utils/runner.rs
@@ -1,6 +1,9 @@
 use super::TestTransaction;
 use crate::{ExecInput, ExecOutput, Stage, StageError, UnwindInput, UnwindOutput};
-use reth_db::mdbx::{Env, WriteMap};
+use reth_db::{
+    mdbx::{Env, WriteMap},
+    DatabaseEngine,
+};
 use reth_primitives::MAINNET;
 use reth_provider::ProviderFactory;
 use std::{borrow::Borrow, sync::Arc};
@@ -19,7 +22,7 @@ pub(crate) enum TestRunnerError {
 /// A generic test runner for stages.
 #[async_trait::async_trait]
 pub(crate) trait StageTestRunner {
-    type S: Stage<Env<WriteMap>> + 'static;
+    type S: Stage<DatabaseEngine> + 'static;
 
     /// Return a reference to the database.
     fn tx(&self) -> &TestTransaction;

--- a/crates/stages/src/test_utils/test_db.rs
+++ b/crates/stages/src/test_utils/test_db.rs
@@ -10,7 +10,7 @@ use reth_db::{
     table::Table,
     tables,
     transaction::{DbTx, DbTxMut},
-    DatabaseEngine, DatabaseError as DbError,
+    DatabaseEnv, DatabaseError as DbError,
 };
 use reth_primitives::{
     keccak256, Account, Address, BlockNumber, SealedBlock, SealedHeader, StorageEntry, H256,
@@ -35,9 +35,9 @@ use std::{
 #[derive(Debug)]
 pub struct TestTransaction {
     /// WriteMap DB
-    pub tx: Arc<DatabaseEngine>,
+    pub tx: Arc<DatabaseEnv>,
     pub path: Option<PathBuf>,
-    pub factory: ProviderFactory<Arc<DatabaseEngine>>,
+    pub factory: ProviderFactory<Arc<DatabaseEnv>>,
 }
 
 impl Default for TestTransaction {
@@ -59,17 +59,17 @@ impl TestTransaction {
     }
 
     /// Return a database wrapped in [DatabaseProviderRW].
-    pub fn inner_rw(&self) -> DatabaseProviderRW<'_, Arc<DatabaseEngine>> {
+    pub fn inner_rw(&self) -> DatabaseProviderRW<'_, Arc<DatabaseEnv>> {
         self.factory.provider_rw().expect("failed to create db container")
     }
 
     /// Return a database wrapped in [DatabaseProviderRO].
-    pub fn inner(&self) -> DatabaseProviderRO<'_, Arc<DatabaseEngine>> {
+    pub fn inner(&self) -> DatabaseProviderRO<'_, Arc<DatabaseEnv>> {
         self.factory.provider().expect("failed to create db container")
     }
 
     /// Get a pointer to an internal database.
-    pub fn inner_raw(&self) -> Arc<DatabaseEngine> {
+    pub fn inner_raw(&self) -> Arc<DatabaseEnv> {
         self.tx.clone()
     }
 

--- a/crates/stages/src/test_utils/test_db.rs
+++ b/crates/stages/src/test_utils/test_db.rs
@@ -10,7 +10,7 @@ use reth_db::{
     table::Table,
     tables,
     transaction::{DbTx, DbTxMut},
-    DatabaseError as DbError,
+    DatabaseEngine, DatabaseError as DbError,
 };
 use reth_primitives::{
     keccak256, Account, Address, BlockNumber, SealedBlock, SealedHeader, StorageEntry, H256,
@@ -35,9 +35,9 @@ use std::{
 #[derive(Debug)]
 pub struct TestTransaction {
     /// WriteMap DB
-    pub tx: Arc<Env<WriteMap>>,
+    pub tx: Arc<DatabaseEngine>,
     pub path: Option<PathBuf>,
-    pub factory: ProviderFactory<Arc<Env<WriteMap>>>,
+    pub factory: ProviderFactory<Arc<DatabaseEngine>>,
 }
 
 impl Default for TestTransaction {
@@ -59,17 +59,17 @@ impl TestTransaction {
     }
 
     /// Return a database wrapped in [DatabaseProviderRW].
-    pub fn inner_rw(&self) -> DatabaseProviderRW<'_, Arc<Env<WriteMap>>> {
+    pub fn inner_rw(&self) -> DatabaseProviderRW<'_, Arc<DatabaseEngine>> {
         self.factory.provider_rw().expect("failed to create db container")
     }
 
     /// Return a database wrapped in [DatabaseProviderRO].
-    pub fn inner(&self) -> DatabaseProviderRO<'_, Arc<Env<WriteMap>>> {
+    pub fn inner(&self) -> DatabaseProviderRO<'_, Arc<DatabaseEngine>> {
         self.factory.provider().expect("failed to create db container")
     }
 
     /// Get a pointer to an internal database.
-    pub fn inner_raw(&self) -> Arc<Env<WriteMap>> {
+    pub fn inner_raw(&self) -> Arc<DatabaseEngine> {
         self.tx.clone()
     }
 

--- a/crates/storage/db/Cargo.toml
+++ b/crates/storage/db/Cargo.toml
@@ -38,6 +38,7 @@ thiserror = { workspace = true }
 tempfile = { version = "3.3.0", optional = true }
 parking_lot = "0.12"
 derive_more = "0.99"
+eyre = "0.6.8"
 
 # arbitrary utils
 arbitrary = { version = "1.1.7", features = ["derive"], optional = true }

--- a/crates/storage/db/benches/hash_keys.rs
+++ b/crates/storage/db/benches/hash_keys.rs
@@ -163,9 +163,9 @@ where
 }
 
 fn append<T>(
-    db: Env<WriteMap>,
+    db: DatabaseEngine,
     input: Vec<(<T as Table>::Key, <T as Table>::Value)>,
-) -> Env<WriteMap>
+) -> DatabaseEngine
 where
     T: Table + Default,
 {
@@ -184,9 +184,9 @@ where
 }
 
 fn insert<T>(
-    db: Env<WriteMap>,
+    db: DatabaseEngine,
     input: Vec<(<T as Table>::Key, <T as Table>::Value)>,
-) -> Env<WriteMap>
+) -> DatabaseEngine
 where
     T: Table + Default,
 {
@@ -204,7 +204,10 @@ where
     db
 }
 
-fn put<T>(db: Env<WriteMap>, input: Vec<(<T as Table>::Key, <T as Table>::Value)>) -> Env<WriteMap>
+fn put<T>(
+    db: DatabaseEngine,
+    input: Vec<(<T as Table>::Key, <T as Table>::Value)>,
+) -> DatabaseEngine
 where
     T: Table + Default,
 {
@@ -231,7 +234,7 @@ struct TableStats {
     size: usize,
 }
 
-fn get_table_stats<T>(db: Env<WriteMap>)
+fn get_table_stats<T>(db: DatabaseEngine)
 where
     T: Table + Default,
 {

--- a/crates/storage/db/benches/hash_keys.rs
+++ b/crates/storage/db/benches/hash_keys.rs
@@ -162,10 +162,7 @@ where
     (preload, input)
 }
 
-fn append<T>(
-    db: DatabaseEngine,
-    input: Vec<(<T as Table>::Key, <T as Table>::Value)>,
-) -> DatabaseEngine
+fn append<T>(db: DatabaseEnv, input: Vec<(<T as Table>::Key, <T as Table>::Value)>) -> DatabaseEnv
 where
     T: Table + Default,
 {
@@ -183,10 +180,7 @@ where
     db
 }
 
-fn insert<T>(
-    db: DatabaseEngine,
-    input: Vec<(<T as Table>::Key, <T as Table>::Value)>,
-) -> DatabaseEngine
+fn insert<T>(db: DatabaseEnv, input: Vec<(<T as Table>::Key, <T as Table>::Value)>) -> DatabaseEnv
 where
     T: Table + Default,
 {
@@ -204,10 +198,7 @@ where
     db
 }
 
-fn put<T>(
-    db: DatabaseEngine,
-    input: Vec<(<T as Table>::Key, <T as Table>::Value)>,
-) -> DatabaseEngine
+fn put<T>(db: DatabaseEnv, input: Vec<(<T as Table>::Key, <T as Table>::Value)>) -> DatabaseEnv
 where
     T: Table + Default,
 {
@@ -234,7 +225,7 @@ struct TableStats {
     size: usize,
 }
 
-fn get_table_stats<T>(db: DatabaseEngine)
+fn get_table_stats<T>(db: DatabaseEnv)
 where
     T: Table + Default,
 {

--- a/crates/storage/db/benches/utils.rs
+++ b/crates/storage/db/benches/utils.rs
@@ -1,3 +1,4 @@
+use reth_db::DatabaseEngine;
 #[allow(unused_imports)]
 use reth_db::{
     database::Database,
@@ -51,7 +52,7 @@ where
 fn set_up_db<T>(
     bench_db_path: &Path,
     pair: &Vec<(<T as Table>::Key, bytes::Bytes, <T as Table>::Value, bytes::Bytes)>,
-) -> reth_db::mdbx::Env<WriteMap>
+) -> DatabaseEngine
 where
     T: Table + Default,
     T::Key: Default + Clone,

--- a/crates/storage/db/benches/utils.rs
+++ b/crates/storage/db/benches/utils.rs
@@ -1,4 +1,4 @@
-use reth_db::DatabaseEngine;
+use reth_db::DatabaseEnv;
 #[allow(unused_imports)]
 use reth_db::{
     database::Database,
@@ -52,7 +52,7 @@ where
 fn set_up_db<T>(
     bench_db_path: &Path,
     pair: &Vec<(<T as Table>::Key, bytes::Bytes, <T as Table>::Value, bytes::Bytes)>,
-) -> DatabaseEngine
+) -> DatabaseEnv
 where
     T: Table + Default,
     T::Key: Default + Clone,

--- a/crates/storage/db/src/lib.rs
+++ b/crates/storage/db/src/lib.rs
@@ -93,10 +93,10 @@ use mdbx::{Env, EnvKind, WriteMap};
 
 #[cfg(feature = "mdbx")]
 /// Alias type for the database engine in use.
-pub type DatabaseEngine = Env<WriteMap>;
+pub type DatabaseEnv = Env<WriteMap>;
 
 /// Opens up an existing database or creates a new one at the specified path.
-pub fn init_db<P: AsRef<std::path::Path>>(path: P) -> eyre::Result<DatabaseEngine> {
+pub fn init_db<P: AsRef<std::path::Path>>(path: P) -> eyre::Result<DatabaseEnv> {
     use crate::version::{check_db_version_file, create_db_version_file, DatabaseVersionError};
     use eyre::WrapErr;
 

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -39,6 +39,7 @@ reth-primitives = { workspace = true, features = ["arbitrary", "test-utils"] }
 reth-rlp = { workspace = true }
 reth-trie = { path = "../../trie", features = ["test-utils"] }
 parking_lot = "0.12"
+tempfile = "3.3"
 
 [features]
 test-utils = ["reth-rlp"]

--- a/crates/storage/provider/src/post_state/mod.rs
+++ b/crates/storage/provider/src/post_state/mod.rs
@@ -645,7 +645,7 @@ mod tests {
         database::Database,
         mdbx::{test_utils, EnvKind},
         transaction::DbTx,
-        DatabaseEngine,
+        DatabaseEnv,
     };
     use reth_primitives::{proofs::EMPTY_ROOT, MAINNET};
     use reth_trie::test_utils::state_root;
@@ -1067,7 +1067,7 @@ mod tests {
 
     #[test]
     fn write_to_db_account_info() {
-        let db: Arc<DatabaseEngine> = test_utils::create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEnv> = test_utils::create_test_db(EnvKind::RW);
         let factory = ProviderFactory::new(db, MAINNET.clone());
         let provider = factory.provider_rw().unwrap();
 
@@ -1136,7 +1136,7 @@ mod tests {
 
     #[test]
     fn write_to_db_storage() {
-        let db: Arc<DatabaseEngine> = test_utils::create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEnv> = test_utils::create_test_db(EnvKind::RW);
         let tx = db.tx_mut().expect("Could not get database tx");
 
         let mut post_state = PostState::new();
@@ -1272,7 +1272,7 @@ mod tests {
 
     #[test]
     fn write_to_db_multiple_selfdestructs() {
-        let db: Arc<DatabaseEngine> = test_utils::create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEnv> = test_utils::create_test_db(EnvKind::RW);
         let tx = db.tx_mut().expect("Could not get database tx");
 
         let address1 = Address::random();
@@ -1821,7 +1821,7 @@ mod tests {
 
     #[test]
     fn empty_post_state_state_root() {
-        let db: Arc<DatabaseEngine> = test_utils::create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEnv> = test_utils::create_test_db(EnvKind::RW);
         let tx = db.tx().unwrap();
 
         let post_state = PostState::new();
@@ -1840,7 +1840,7 @@ mod tests {
             })
             .collect();
 
-        let db: Arc<DatabaseEngine> = test_utils::create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEnv> = test_utils::create_test_db(EnvKind::RW);
 
         // insert initial state to the database
         db.update(|tx| {

--- a/crates/storage/provider/src/post_state/mod.rs
+++ b/crates/storage/provider/src/post_state/mod.rs
@@ -643,8 +643,9 @@ mod tests {
     use crate::{AccountReader, ProviderFactory};
     use reth_db::{
         database::Database,
-        mdbx::{test_utils, Env, EnvKind, WriteMap},
+        mdbx::{test_utils, EnvKind},
         transaction::DbTx,
+        DatabaseEngine,
     };
     use reth_primitives::{proofs::EMPTY_ROOT, MAINNET};
     use reth_trie::test_utils::state_root;
@@ -1066,7 +1067,7 @@ mod tests {
 
     #[test]
     fn write_to_db_account_info() {
-        let db: Arc<Env<WriteMap>> = test_utils::create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEngine> = test_utils::create_test_db(EnvKind::RW);
         let factory = ProviderFactory::new(db, MAINNET.clone());
         let provider = factory.provider_rw().unwrap();
 
@@ -1135,7 +1136,7 @@ mod tests {
 
     #[test]
     fn write_to_db_storage() {
-        let db: Arc<Env<WriteMap>> = test_utils::create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEngine> = test_utils::create_test_db(EnvKind::RW);
         let tx = db.tx_mut().expect("Could not get database tx");
 
         let mut post_state = PostState::new();
@@ -1271,7 +1272,7 @@ mod tests {
 
     #[test]
     fn write_to_db_multiple_selfdestructs() {
-        let db: Arc<Env<WriteMap>> = test_utils::create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEngine> = test_utils::create_test_db(EnvKind::RW);
         let tx = db.tx_mut().expect("Could not get database tx");
 
         let address1 = Address::random();
@@ -1820,7 +1821,7 @@ mod tests {
 
     #[test]
     fn empty_post_state_state_root() {
-        let db: Arc<Env<WriteMap>> = test_utils::create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEngine> = test_utils::create_test_db(EnvKind::RW);
         let tx = db.tx().unwrap();
 
         let post_state = PostState::new();
@@ -1839,7 +1840,7 @@ mod tests {
             })
             .collect();
 
-        let db: Arc<Env<WriteMap>> = test_utils::create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEngine> = test_utils::create_test_db(EnvKind::RW);
 
         // insert initial state to the database
         db.update(|tx| {

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -393,7 +393,7 @@ mod tests {
     fn provider_factory_with_database_path() {
         let chain_spec = ChainSpecBuilder::mainnet().build();
         let factory = ProviderFactory::<DatabaseEngine>::new_with_database_path(
-            &tempfile::TempDir::new().expect(ERROR_TEMPDIR).into_path(),
+            tempfile::TempDir::new().expect(ERROR_TEMPDIR).into_path(),
             Arc::new(chain_spec),
         )
         .unwrap();

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     BlockHashReader, BlockNumReader, BlockReader, EvmEnvProvider, HeaderProvider, ProviderError,
     StageCheckpointReader, StateProviderBox, TransactionsProvider, WithdrawalsProvider,
 };
-use reth_db::{database::Database, models::StoredBlockBodyIndices};
+use reth_db::{database::Database, init_db, models::StoredBlockBodyIndices, DatabaseEngine};
 use reth_interfaces::Result;
 use reth_primitives::{
     stage::{StageCheckpoint, StageId},
@@ -51,6 +51,20 @@ impl<DB> ProviderFactory<DB> {
     /// create new database provider
     pub fn new(db: DB, chain_spec: Arc<ChainSpec>) -> Self {
         Self { db, chain_spec }
+    }
+}
+
+impl<DB: Database> ProviderFactory<DB> {
+    /// create new database provider by passing a path. [`ProviderFactory`] will own the database
+    /// instance.
+    pub fn new_with_database_path<P: AsRef<std::path::Path>>(
+        path: P,
+        chain_spec: Arc<ChainSpec>,
+    ) -> Result<ProviderFactory<DatabaseEngine>> {
+        Ok(ProviderFactory::<DatabaseEngine> {
+            db: init_db(path).map_err(|e| reth_interfaces::Error::Custom(e.to_string()))?,
+            chain_spec,
+        })
     }
 }
 
@@ -333,7 +347,13 @@ impl<DB: Database> EvmEnvProvider for ProviderFactory<DB> {
 mod tests {
     use super::ProviderFactory;
     use crate::{BlockHashReader, BlockNumReader};
-    use reth_db::mdbx::{test_utils::create_test_db, EnvKind, WriteMap};
+    use reth_db::{
+        mdbx::{
+            test_utils::{create_test_db, ERROR_TEMPDIR},
+            EnvKind, WriteMap,
+        },
+        DatabaseEngine,
+    };
     use reth_primitives::{ChainSpecBuilder, H256};
     use std::sync::Arc;
 
@@ -362,6 +382,22 @@ mod tests {
         let chain_spec = ChainSpecBuilder::mainnet().build();
         let db = create_test_db::<WriteMap>(EnvKind::RW);
         let factory = ProviderFactory::new(db, Arc::new(chain_spec));
+        let provider = factory.provider().unwrap();
+        provider.block_hash(0).unwrap();
+        let provider_rw = factory.provider_rw().unwrap();
+        provider_rw.block_hash(0).unwrap();
+        provider.block_hash(0).unwrap();
+    }
+
+    #[test]
+    fn provider_factory_with_database_path() {
+        let chain_spec = ChainSpecBuilder::mainnet().build();
+        let factory = ProviderFactory::<DatabaseEngine>::new_with_database_path(
+            &tempfile::TempDir::new().expect(ERROR_TEMPDIR).into_path(),
+            Arc::new(chain_spec),
+        )
+        .unwrap();
+
         let provider = factory.provider().unwrap();
         provider.block_hash(0).unwrap();
         let provider_rw = factory.provider_rw().unwrap();

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     BlockHashReader, BlockNumReader, BlockReader, EvmEnvProvider, HeaderProvider, ProviderError,
     StageCheckpointReader, StateProviderBox, TransactionsProvider, WithdrawalsProvider,
 };
-use reth_db::{database::Database, init_db, models::StoredBlockBodyIndices, DatabaseEngine};
+use reth_db::{database::Database, init_db, models::StoredBlockBodyIndices, DatabaseEnv};
 use reth_interfaces::Result;
 use reth_primitives::{
     stage::{StageCheckpoint, StageId},
@@ -60,8 +60,8 @@ impl<DB: Database> ProviderFactory<DB> {
     pub fn new_with_database_path<P: AsRef<std::path::Path>>(
         path: P,
         chain_spec: Arc<ChainSpec>,
-    ) -> Result<ProviderFactory<DatabaseEngine>> {
-        Ok(ProviderFactory::<DatabaseEngine> {
+    ) -> Result<ProviderFactory<DatabaseEnv>> {
+        Ok(ProviderFactory::<DatabaseEnv> {
             db: init_db(path).map_err(|e| reth_interfaces::Error::Custom(e.to_string()))?,
             chain_spec,
         })
@@ -352,7 +352,7 @@ mod tests {
             test_utils::{create_test_db, ERROR_TEMPDIR},
             EnvKind, WriteMap,
         },
-        DatabaseEngine,
+        DatabaseEnv,
     };
     use reth_primitives::{ChainSpecBuilder, H256};
     use std::sync::Arc;
@@ -392,7 +392,7 @@ mod tests {
     #[test]
     fn provider_factory_with_database_path() {
         let chain_spec = ChainSpecBuilder::mainnet().build();
-        let factory = ProviderFactory::<DatabaseEngine>::new_with_database_path(
+        let factory = ProviderFactory::<DatabaseEnv>::new_with_database_path(
             tempfile::TempDir::new().expect(ERROR_TEMPDIR).into_path(),
             Arc::new(chain_spec),
         )

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -560,15 +560,6 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> DatabaseProvider<'this, TX> {
         Ok(blocks)
     }
 
-    /// Query the block body by number.
-    pub fn block_body_indices(&self, number: BlockNumber) -> Result<StoredBlockBodyIndices> {
-        let body = self
-            .tx
-            .get::<tables::BlockBodyIndices>(number)?
-            .ok_or(ProviderError::BlockBodyIndicesNotFound(number))?;
-        Ok(body)
-    }
-
     /// Unwind table by some number key.
     /// Returns number of rows unwound.
     ///

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1695,9 +1695,8 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> BlockWriter for DatabaseProvider<'
             block.difficulty
         } else {
             let parent_block_number = block.number - 1;
-            let parent_ttd =
-                self.tx.get::<tables::HeaderTD>(parent_block_number)?.unwrap_or_default();
-            parent_ttd.0 + block.difficulty
+            let parent_ttd = self.header_td_by_number(parent_block_number)?.unwrap_or_default();
+            parent_ttd + block.difficulty
         };
 
         self.tx.put::<tables::HeaderTD>(block.number, ttd.into())?;

--- a/crates/trie/src/trie.rs
+++ b/crates/trie/src/trie.rs
@@ -517,7 +517,7 @@ mod tests {
         mdbx::test_utils::create_test_rw_db,
         tables,
         transaction::DbTxMut,
-        DatabaseEngine,
+        DatabaseEnv,
     };
     use reth_primitives::{
         hex_literal::hex,
@@ -1279,7 +1279,7 @@ mod tests {
     }
 
     fn extension_node_storage_trie(
-        tx: &DatabaseProviderRW<'_, &DatabaseEngine>,
+        tx: &DatabaseProviderRW<'_, &DatabaseEnv>,
         hashed_address: H256,
     ) -> (H256, HashMap<Nibbles, BranchNodeCompact>) {
         let value = U256::from(1);
@@ -1305,7 +1305,7 @@ mod tests {
         (root, updates)
     }
 
-    fn extension_node_trie(tx: &DatabaseProviderRW<'_, &DatabaseEngine>) -> H256 {
+    fn extension_node_trie(tx: &DatabaseProviderRW<'_, &DatabaseEnv>) -> H256 {
         let a =
             Account { nonce: 0, balance: U256::from(1u64), bytecode_hash: Some(H256::random()) };
         let val = encode_account(a, None);

--- a/crates/trie/src/trie.rs
+++ b/crates/trie/src/trie.rs
@@ -514,9 +514,10 @@ mod tests {
     use proptest::{prelude::ProptestConfig, proptest};
     use reth_db::{
         cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO},
-        mdbx::{test_utils::create_test_rw_db, Env, WriteMap},
+        mdbx::test_utils::create_test_rw_db,
         tables,
         transaction::DbTxMut,
+        DatabaseEngine,
     };
     use reth_primitives::{
         hex_literal::hex,
@@ -1278,7 +1279,7 @@ mod tests {
     }
 
     fn extension_node_storage_trie(
-        tx: &DatabaseProviderRW<'_, &Env<WriteMap>>,
+        tx: &DatabaseProviderRW<'_, &DatabaseEngine>,
         hashed_address: H256,
     ) -> (H256, HashMap<Nibbles, BranchNodeCompact>) {
         let value = U256::from(1);
@@ -1304,7 +1305,7 @@ mod tests {
         (root, updates)
     }
 
-    fn extension_node_trie(tx: &DatabaseProviderRW<'_, &Env<WriteMap>>) -> H256 {
+    fn extension_node_trie(tx: &DatabaseProviderRW<'_, &DatabaseEngine>) -> H256 {
         let a =
             Account { nonce: 0, balance: U256::from(1u64), bytecode_hash: Some(H256::random()) };
         let val = encode_account(a, None);


### PR DESCRIPTION
Main:
* Moves `init_db` from `stage-sync` to `reth_db` 
* Adds an alias type for `DatabaseEnv` and spread it. Goal is to have `mdbx` mentions limited to `reth_db`, and having these feature gated.
* Add `ProviderFactory::new_with_database_path`, so we can instance the database inside the factory instead. @gakonst  is this what you had in mind?

There are still mentions of `WriteMap` and `mdbx` types across other crates, but mainly contained to the testing suites. If this gets accepted, I can take care of that on a follow-up PR.


Minor/unrelated that I saw and included:
* remove `DatabaseProvider` duplicated method: [block_body_indices](https://github.com/paradigmxyz/reth/commit/cb4d1770f5561996af4d5d51862465a1cdae182e)
* use [header_td_by_number instead of `.get::<T>` on one line](https://github.com/paradigmxyz/reth/commit/d59b313ca4359474b627ee1a2aa130a571670644)