### PR TITLE
feat: add default max readers 32000

### DIFF
--- a/crates/storage/db/src/lib.rs
+++ b/crates/storage/db/src/lib.rs
@@ -114,7 +114,7 @@ pub fn init_db<P: AsRef<std::path::Path>>(path: P) -> eyre::Result<DatabaseEnv> 
     }
     #[cfg(feature = "mdbx")]
     {
-        let db = Env::<WriteMap>::open(rpath, EnvKind::RW)?;
+        let db = DatabaseEnv::open(rpath, EnvKind::RW)?;
         db.create_tables()?;
         Ok(db)
     }

--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -6,7 +6,6 @@ use crate::{
     Mode, Transaction, TransactionKind,
 };
 use byteorder::{ByteOrder, NativeEndian};
-use libc::c_uint;
 use mem::size_of;
 use std::{
     ffi::CString,
@@ -376,7 +375,7 @@ where
     E: EnvironmentKind,
 {
     flags: EnvironmentFlags,
-    max_readers: Option<c_uint>,
+    max_readers: Option<u64>,
     max_dbs: Option<u64>,
     rp_augment_limit: Option<u64>,
     loose_limit: Option<u64>,
@@ -451,6 +450,15 @@ where
                     if let Some(v) = v {
                         mdbx_result(ffi::mdbx_env_set_option(env, opt, v))?;
                     }
+                }
+
+                // set max readers if specified
+                if let Some(max_readers) = self.max_readers {
+                    mdbx_result(ffi::mdbx_env_set_option(
+                        env,
+                        ffi::MDBX_opt_max_readers,
+                        max_readers,
+                    ))?;
                 }
 
                 #[cfg(unix)]
@@ -544,7 +552,7 @@ where
     /// This defines the number of slots in the lock table that is used to track readers in the
     /// the environment. The default is 126. Starting a read-only transaction normally ties a lock
     /// table slot to the [Transaction] object until it or the [Environment] object is destroyed.
-    pub fn set_max_readers(&mut self, max_readers: c_uint) -> &mut Self {
+    pub fn set_max_readers(&mut self, max_readers: u64) -> &mut Self {
         self.max_readers = Some(max_readers);
         self
     }


### PR DESCRIPTION
Closes #3441
Closes #3445

configure max allowed readers close to max allowed limit,

this merely bumps the size of the lock table