### PR TITLE
refactor: move `mdbx::test-utils` to `reth_db::test-utils` and add `DatabaseEnvRO`

### DIFF
--- a/bin/reth/src/db/list.rs
+++ b/bin/reth/src/db/list.rs
@@ -3,12 +3,7 @@ use clap::Parser;
 
 use super::tui::DbListTUI;
 use eyre::WrapErr;
-use reth_db::{
-    database::Database,
-    mdbx::{Env, NoWriteMap},
-    table::Table,
-    TableType, TableViewer, Tables,
-};
+use reth_db::{database::Database, table::Table, DatabaseEnvRO, TableType, TableViewer, Tables};
 use tracing::error;
 
 const DEFAULT_NUM_ITEMS: &str = "5";
@@ -34,7 +29,7 @@ pub struct Command {
 
 impl Command {
     /// Execute `db list` command
-    pub fn execute(self, tool: &DbTool<'_, Env<NoWriteMap>>) -> eyre::Result<()> {
+    pub fn execute(self, tool: &DbTool<'_, DatabaseEnvRO>) -> eyre::Result<()> {
         if self.table.table_type() == TableType::DupSort {
             error!(target: "reth::cli", "Unsupported table.");
         }
@@ -46,7 +41,7 @@ impl Command {
 }
 
 struct ListTableViewer<'a> {
-    tool: &'a DbTool<'a, Env<NoWriteMap>>,
+    tool: &'a DbTool<'a, DatabaseEnvRO>,
     args: &'a Command,
 }
 

--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -12,7 +12,7 @@ use reth_db::{
     database::Database,
     mdbx::{Env, NoWriteMap, WriteMap},
     version::{get_db_version, DatabaseVersionError, DB_VERSION},
-    DatabaseEnv, Tables,
+    DatabaseEnv, DatabaseEnvRO, Tables,
 };
 use reth_primitives::ChainSpec;
 use std::{path::Path, sync::Arc};
@@ -173,7 +173,7 @@ impl Command {
     }
 }
 
-fn read_only_db(path: &Path) -> eyre::Result<Env<NoWriteMap>> {
+fn read_only_db(path: &Path) -> eyre::Result<DatabaseEnvRO> {
     Env::<NoWriteMap>::open(path, reth_db::mdbx::EnvKind::RO)
         .with_context(|| format!("Could not open database at path: {}", path.display()))
 }

--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -10,12 +10,12 @@ use eyre::WrapErr;
 use human_bytes::human_bytes;
 use reth_db::{
     database::Database,
-    mdbx::{Env, NoWriteMap, WriteMap},
+    open_db, open_readonly_db,
     version::{get_db_version, DatabaseVersionError, DB_VERSION},
-    DatabaseEnv, DatabaseEnvRO, Tables,
+    Tables,
 };
 use reth_primitives::ChainSpec;
-use std::{path::Path, sync::Arc};
+use std::sync::Arc;
 
 mod get;
 mod list;
@@ -84,7 +84,7 @@ impl Command {
         match self.command {
             // TODO: We'll need to add this on the DB trait.
             Subcommands::Stats { .. } => {
-                let db = read_only_db(&db_path)?;
+                let db = open_readonly_db(&db_path)?;
                 let tool = DbTool::new(&db, self.chain.clone())?;
                 let mut stats_table = ComfyTable::new();
                 stats_table.load_preset(comfy_table::presets::ASCII_MARKDOWN);
@@ -135,17 +135,17 @@ impl Command {
                 println!("{stats_table}");
             }
             Subcommands::List(command) => {
-                let db = read_only_db(&db_path)?;
+                let db = open_readonly_db(&db_path)?;
                 let tool = DbTool::new(&db, self.chain.clone())?;
                 command.execute(&tool)?;
             }
             Subcommands::Get(command) => {
-                let db = read_only_db(&db_path)?;
+                let db = open_readonly_db(&db_path)?;
                 let tool = DbTool::new(&db, self.chain.clone())?;
                 command.execute(&tool)?;
             }
             Subcommands::Drop => {
-                let db = read_write_db(&db_path)?;
+                let db = open_db(&db_path)?;
                 let mut tool = DbTool::new(&db, self.chain.clone())?;
                 tool.drop(db_path)?;
             }
@@ -171,16 +171,6 @@ impl Command {
 
         Ok(())
     }
-}
-
-fn read_only_db(path: &Path) -> eyre::Result<DatabaseEnvRO> {
-    Env::<NoWriteMap>::open(path, reth_db::mdbx::EnvKind::RO)
-        .with_context(|| format!("Could not open database at path: {}", path.display()))
-}
-
-fn read_write_db(path: &Path) -> eyre::Result<DatabaseEnv> {
-    Env::<WriteMap>::open(path, reth_db::mdbx::EnvKind::RW)
-        .with_context(|| format!("Could not open database at path: {}", path.display()))
 }
 
 #[cfg(test)]

--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -10,7 +10,7 @@ use eyre::WrapErr;
 use human_bytes::human_bytes;
 use reth_db::{
     database::Database,
-    open_db, open_readonly_db,
+    open_db, open_db_read_only,
     version::{get_db_version, DatabaseVersionError, DB_VERSION},
     Tables,
 };
@@ -84,7 +84,7 @@ impl Command {
         match self.command {
             // TODO: We'll need to add this on the DB trait.
             Subcommands::Stats { .. } => {
-                let db = open_readonly_db(&db_path)?;
+                let db = open_db_read_only(&db_path)?;
                 let tool = DbTool::new(&db, self.chain.clone())?;
                 let mut stats_table = ComfyTable::new();
                 stats_table.load_preset(comfy_table::presets::ASCII_MARKDOWN);
@@ -135,12 +135,12 @@ impl Command {
                 println!("{stats_table}");
             }
             Subcommands::List(command) => {
-                let db = open_readonly_db(&db_path)?;
+                let db = open_db_read_only(&db_path)?;
                 let tool = DbTool::new(&db, self.chain.clone())?;
                 command.execute(&tool)?;
             }
             Subcommands::Get(command) => {
-                let db = open_readonly_db(&db_path)?;
+                let db = open_db_read_only(&db_path)?;
                 let tool = DbTool::new(&db, self.chain.clone())?;
                 command.execute(&tool)?;
             }

--- a/bin/reth/src/p2p/mod.rs
+++ b/bin/reth/src/p2p/mod.rs
@@ -11,7 +11,7 @@ use crate::{
 use backon::{ConstantBuilder, Retryable};
 use clap::{Parser, Subcommand};
 use reth_config::Config;
-use reth_db::mdbx::{Env, EnvKind, WriteMap};
+use reth_db::open_db;
 use reth_discv4::NatResolver;
 use reth_interfaces::p2p::bodies::client::BodiesClient;
 use reth_primitives::{BlockHashOrNumber, ChainSpec, NodeRecord};
@@ -101,7 +101,7 @@ impl Command {
     /// Execute `p2p` command
     pub async fn execute(&self) -> eyre::Result<()> {
         let tempdir = tempfile::TempDir::new()?;
-        let noop_db = Arc::new(Env::<WriteMap>::open(&tempdir.into_path(), EnvKind::RW)?);
+        let noop_db = Arc::new(open_db(&tempdir.into_path())?);
 
         // add network name to data dir
         let data_dir = self.datadir.unwrap_or_chain_default(self.chain.chain);

--- a/bin/reth/src/stage/drop.rs
+++ b/bin/reth/src/stage/drop.rs
@@ -5,13 +5,7 @@ use crate::{
     utils::DbTool,
 };
 use clap::Parser;
-use reth_db::{
-    database::Database,
-    mdbx::{Env, WriteMap},
-    tables,
-    transaction::DbTxMut,
-    DatabaseEnv,
-};
+use reth_db::{database::Database, open_db, tables, transaction::DbTxMut, DatabaseEnv};
 use reth_primitives::{stage::StageId, ChainSpec};
 use reth_staged_sync::utils::init::{insert_genesis_header, insert_genesis_state};
 use std::sync::Arc;
@@ -58,7 +52,7 @@ impl Command {
         let db_path = data_dir.db_path();
         std::fs::create_dir_all(&db_path)?;
 
-        let db = Env::<WriteMap>::open(db_path.as_ref(), reth_db::mdbx::EnvKind::RW)?;
+        let db = open_db(db_path.as_ref())?;
 
         let tool = DbTool::new(&db, self.chain.clone())?;
 

--- a/bin/reth/src/stage/dump/execution.rs
+++ b/bin/reth/src/stage/dump/execution.rs
@@ -3,6 +3,7 @@ use crate::utils::DbTool;
 use eyre::Result;
 use reth_db::{
     cursor::DbCursorRO, database::Database, table::TableImporter, tables, transaction::DbTx,
+    DatabaseEnv,
 };
 use reth_primitives::{stage::StageCheckpoint, ChainSpec};
 use reth_provider::ProviderFactory;
@@ -33,7 +34,7 @@ pub(crate) async fn dump_execution_stage<DB: Database>(
 
 /// Imports all the tables that can be copied over a range.
 fn import_tables_with_range<DB: Database>(
-    output_db: &reth_db::mdbx::Env<reth_db::mdbx::WriteMap>,
+    output_db: &DatabaseEnv,
     db_tool: &mut DbTool<'_, DB>,
     from: u64,
     to: u64,
@@ -92,7 +93,7 @@ async fn unwind_and_copy<DB: Database>(
     db_tool: &mut DbTool<'_, DB>,
     from: u64,
     tip_block_number: u64,
-    output_db: &reth_db::mdbx::Env<reth_db::mdbx::WriteMap>,
+    output_db: &DatabaseEnv,
 ) -> eyre::Result<()> {
     let factory = ProviderFactory::new(db_tool.db, db_tool.chain.clone());
     let provider = factory.provider_rw()?;

--- a/bin/reth/src/stage/dump/hashing_account.rs
+++ b/bin/reth/src/stage/dump/hashing_account.rs
@@ -1,7 +1,7 @@
 use super::setup;
 use crate::utils::DbTool;
 use eyre::Result;
-use reth_db::{database::Database, table::TableImporter, tables};
+use reth_db::{database::Database, table::TableImporter, tables, DatabaseEnv};
 use reth_primitives::{stage::StageCheckpoint, BlockNumber, ChainSpec};
 use reth_provider::ProviderFactory;
 use reth_stages::{stages::AccountHashingStage, Stage, UnwindInput};
@@ -36,7 +36,7 @@ async fn unwind_and_copy<DB: Database>(
     db_tool: &mut DbTool<'_, DB>,
     from: u64,
     tip_block_number: u64,
-    output_db: &reth_db::mdbx::Env<reth_db::mdbx::WriteMap>,
+    output_db: &DatabaseEnv,
 ) -> eyre::Result<()> {
     let factory = ProviderFactory::new(db_tool.db, db_tool.chain.clone());
     let provider = factory.provider_rw()?;

--- a/bin/reth/src/stage/dump/hashing_storage.rs
+++ b/bin/reth/src/stage/dump/hashing_storage.rs
@@ -1,7 +1,7 @@
 use super::setup;
 use crate::utils::DbTool;
 use eyre::Result;
-use reth_db::{database::Database, table::TableImporter, tables};
+use reth_db::{database::Database, table::TableImporter, tables, DatabaseEnv};
 use reth_primitives::{stage::StageCheckpoint, ChainSpec};
 use reth_provider::ProviderFactory;
 use reth_stages::{stages::StorageHashingStage, Stage, UnwindInput};
@@ -31,7 +31,7 @@ async fn unwind_and_copy<DB: Database>(
     db_tool: &mut DbTool<'_, DB>,
     from: u64,
     tip_block_number: u64,
-    output_db: &reth_db::mdbx::Env<reth_db::mdbx::WriteMap>,
+    output_db: &DatabaseEnv,
 ) -> eyre::Result<()> {
     let factory = ProviderFactory::new(db_tool.db, db_tool.chain.clone());
     let provider = factory.provider_rw()?;

--- a/bin/reth/src/stage/dump/merkle.rs
+++ b/bin/reth/src/stage/dump/merkle.rs
@@ -1,7 +1,7 @@
 use super::setup;
 use crate::utils::DbTool;
 use eyre::Result;
-use reth_db::{database::Database, table::TableImporter, tables};
+use reth_db::{database::Database, table::TableImporter, tables, DatabaseEnv};
 use reth_primitives::{stage::StageCheckpoint, BlockNumber, ChainSpec};
 use reth_provider::ProviderFactory;
 use reth_stages::{
@@ -45,7 +45,7 @@ async fn unwind_and_copy<DB: Database>(
     db_tool: &mut DbTool<'_, DB>,
     range: (u64, u64),
     tip_block_number: u64,
-    output_db: &reth_db::mdbx::Env<reth_db::mdbx::WriteMap>,
+    output_db: &DatabaseEnv,
 ) -> eyre::Result<()> {
     let (from, to) = range;
     let factory = ProviderFactory::new(db_tool.db, db_tool.chain.clone());

--- a/bin/reth/src/stage/dump/mod.rs
+++ b/bin/reth/src/stage/dump/mod.rs
@@ -6,7 +6,7 @@ use crate::{
 use clap::Parser;
 use reth_db::{
     cursor::DbCursorRO, database::Database, init_db, table::TableImporter, tables,
-    transaction::DbTx,
+    transaction::DbTx, DatabaseEnv,
 };
 use reth_primitives::ChainSpec;
 use std::{path::PathBuf, sync::Arc};
@@ -129,7 +129,7 @@ pub(crate) fn setup<DB: Database>(
     to: u64,
     output_db: &PathBuf,
     db_tool: &mut DbTool<'_, DB>,
-) -> eyre::Result<(reth_db::mdbx::Env<reth_db::mdbx::WriteMap>, u64)> {
+) -> eyre::Result<(DatabaseEnv, u64)> {
     assert!(from < to, "FROM block should be bigger than TO block.");
 
     info!(target: "reth::cli", ?output_db, "Creating separate db");

--- a/bin/reth/src/stage/unwind.rs
+++ b/bin/reth/src/stage/unwind.rs
@@ -5,13 +5,7 @@ use crate::{
     dirs::{DataDirPath, MaybePlatformPath},
 };
 use clap::{Parser, Subcommand};
-use reth_db::{
-    cursor::DbCursorRO,
-    database::Database,
-    mdbx::{Env, WriteMap},
-    tables,
-    transaction::DbTx,
-};
+use reth_db::{cursor::DbCursorRO, database::Database, open_db, tables, transaction::DbTx};
 use reth_primitives::{BlockHashOrNumber, ChainSpec};
 use reth_provider::{BlockExecutionWriter, ProviderFactory};
 use std::{ops::RangeInclusive, sync::Arc};
@@ -61,7 +55,7 @@ impl Command {
             eyre::bail!("Database {db_path:?} does not exist.")
         }
 
-        let db = Env::<WriteMap>::open(db_path.as_ref(), reth_db::mdbx::EnvKind::RW)?;
+        let db = open_db(db_path.as_ref())?;
 
         let range = self.command.unwind_range(&db)?;
 

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1085,7 +1085,7 @@ mod tests {
     use crate::block_buffer::BufferedBlocks;
     use assert_matches::assert_matches;
     use linked_hash_set::LinkedHashSet;
-    use reth_db::{mdbx::test_utils::create_test_rw_db, transaction::DbTxMut, DatabaseEnv};
+    use reth_db::{test_utils::create_test_rw_db, transaction::DbTxMut, DatabaseEnv};
     use reth_interfaces::test_utils::TestConsensus;
     use reth_primitives::{
         proofs::EMPTY_ROOT, stage::StageCheckpoint, ChainSpecBuilder, H256, MAINNET,

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1381,7 +1381,7 @@ mod tests {
         config::BlockchainTreeConfig, externals::TreeExternals, post_state::PostState,
         BlockchainTree, ShareableBlockchainTree,
     };
-    use reth_db::{mdbx::test_utils::create_test_rw_db, DatabaseEnv};
+    use reth_db::{test_utils::create_test_rw_db, DatabaseEnv};
     use reth_interfaces::{
         sync::NoopSyncStateUpdater,
         test_utils::{NoopFullBlockClient, TestConsensus},

--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -595,7 +595,7 @@ mod tests {
     };
     use assert_matches::assert_matches;
     use futures_util::stream::StreamExt;
-    use reth_db::mdbx::{test_utils::create_test_db, EnvKind, WriteMap};
+    use reth_db::test_utils::create_test_rw_db;
     use reth_interfaces::test_utils::{generators, generators::random_block_range, TestConsensus};
     use reth_primitives::{BlockBody, H256};
     use std::{collections::HashMap, sync::Arc};
@@ -605,7 +605,7 @@ mod tests {
     #[tokio::test]
     async fn streams_bodies_in_order() {
         // Generate some random blocks
-        let db = create_test_db::<WriteMap>(EnvKind::RW);
+        let db = create_test_rw_db();
         let (headers, mut bodies) = generate_bodies(0..=19);
 
         insert_headers(&db, &headers);
@@ -632,7 +632,7 @@ mod tests {
     #[tokio::test]
     async fn requests_correct_number_of_times() {
         // Generate some random blocks
-        let db = create_test_db::<WriteMap>(EnvKind::RW);
+        let db = create_test_rw_db();
         let mut rng = generators::rng();
         let blocks = random_block_range(&mut rng, 0..=199, H256::zero(), 1..2);
 
@@ -665,7 +665,7 @@ mod tests {
     #[tokio::test]
     async fn streams_bodies_in_order_after_range_reset() {
         // Generate some random blocks
-        let db = create_test_db::<WriteMap>(EnvKind::RW);
+        let db = create_test_rw_db();
         let (headers, mut bodies) = generate_bodies(0..=99);
 
         insert_headers(&db, &headers);
@@ -698,7 +698,7 @@ mod tests {
     #[tokio::test]
     async fn can_download_new_range_after_termination() {
         // Generate some random blocks
-        let db = create_test_db::<WriteMap>(EnvKind::RW);
+        let db = create_test_rw_db();
         let (headers, mut bodies) = generate_bodies(0..=199);
 
         insert_headers(&db, &headers);

--- a/crates/net/downloaders/src/bodies/task.rs
+++ b/crates/net/downloaders/src/bodies/task.rs
@@ -179,7 +179,7 @@ mod tests {
         test_utils::{generate_bodies, TestBodiesClient},
     };
     use assert_matches::assert_matches;
-    use reth_db::mdbx::{test_utils::create_test_db, EnvKind, WriteMap};
+    use reth_db::test_utils::create_test_rw_db;
     use reth_interfaces::{p2p::error::DownloadError, test_utils::TestConsensus};
     use std::sync::Arc;
 
@@ -187,7 +187,7 @@ mod tests {
     async fn download_one_by_one_on_task() {
         reth_tracing::init_test_tracing();
 
-        let db = create_test_db::<WriteMap>(EnvKind::RW);
+        let db = create_test_rw_db();
         let (headers, mut bodies) = generate_bodies(0..=19);
 
         insert_headers(&db, &headers);
@@ -216,7 +216,7 @@ mod tests {
     async fn set_download_range_error_returned() {
         reth_tracing::init_test_tracing();
 
-        let db = create_test_db::<WriteMap>(EnvKind::RW);
+        let db = create_test_rw_db();
         let downloader = BodiesDownloaderBuilder::default().build(
             Arc::new(TestBodiesClient::default()),
             Arc::new(TestConsensus::default()),

--- a/crates/net/downloaders/src/bodies/test_utils.rs
+++ b/crates/net/downloaders/src/bodies/test_utils.rs
@@ -1,12 +1,6 @@
 #![allow(unused)]
 //! Test helper impls for generating bodies
-use reth_db::{
-    database::Database,
-    mdbx::{Env, WriteMap},
-    tables,
-    transaction::DbTxMut,
-    DatabaseEnv,
-};
+use reth_db::{database::Database, tables, transaction::DbTxMut, DatabaseEnv};
 use reth_interfaces::{db, p2p::bodies::response::BlockResponse};
 use reth_primitives::{Block, BlockBody, SealedBlock, SealedHeader, H256};
 use std::collections::HashMap;

--- a/crates/net/downloaders/src/test_utils/file_client.rs
+++ b/crates/net/downloaders/src/test_utils/file_client.rs
@@ -258,7 +258,7 @@ mod tests {
     use assert_matches::assert_matches;
     use futures::SinkExt;
     use futures_util::stream::StreamExt;
-    use reth_db::mdbx::{test_utils::create_test_db, EnvKind, WriteMap};
+    use reth_db::test_utils::create_test_rw_db;
     use reth_interfaces::{
         p2p::{
             bodies::downloader::BodyDownloader,
@@ -278,7 +278,7 @@ mod tests {
     #[tokio::test]
     async fn streams_bodies_from_buffer() {
         // Generate some random blocks
-        let db = create_test_db::<WriteMap>(EnvKind::RW);
+        let db = create_test_rw_db();
         let (headers, mut bodies) = generate_bodies(0..=19);
 
         insert_headers(&db, &headers);
@@ -336,7 +336,7 @@ mod tests {
     #[tokio::test]
     async fn test_download_headers_from_file() {
         // Generate some random blocks
-        let db = create_test_db::<WriteMap>(EnvKind::RW);
+        let db = create_test_rw_db();
         let (file, headers, mut bodies) = generate_bodies_file(0..=19).await;
 
         // now try to read them back
@@ -361,7 +361,7 @@ mod tests {
     #[tokio::test]
     async fn test_download_bodies_from_file() {
         // Generate some random blocks
-        let db = create_test_db::<WriteMap>(EnvKind::RW);
+        let db = create_test_rw_db();
         let (file, headers, mut bodies) = generate_bodies_file(0..=19).await;
 
         // now try to read them back

--- a/crates/staged-sync/src/utils/init.rs
+++ b/crates/staged-sync/src/utils/init.rs
@@ -178,9 +178,9 @@ mod tests {
     use super::*;
 
     use reth_db::{
-        mdbx::test_utils::create_test_rw_db,
         models::{storage_sharded_key::StorageShardedKey, ShardedKey},
         table::Table,
+        test_utils::create_test_rw_db,
         DatabaseEnv,
     };
     use reth_primitives::{

--- a/crates/stages/src/lib.rs
+++ b/crates/stages/src/lib.rs
@@ -26,7 +26,7 @@
 //!
 //! ```
 //! # use std::sync::Arc;
-//! # use reth_db::mdbx::test_utils::create_test_rw_db;
+//! # use reth_db::test_utils::create_test_rw_db;
 //! # use reth_downloaders::bodies::bodies::BodiesDownloaderBuilder;
 //! # use reth_downloaders::headers::reverse_headers::ReverseHeadersDownloaderBuilder;
 //! # use reth_interfaces::consensus::Consensus;

--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -480,7 +480,7 @@ mod tests {
     use super::*;
     use crate::{test_utils::TestStage, UnwindOutput};
     use assert_matches::assert_matches;
-    use reth_db::mdbx::{self, test_utils, EnvKind};
+    use reth_db::test_utils::create_test_rw_db;
     use reth_interfaces::{
         consensus,
         provider::ProviderError,
@@ -519,7 +519,7 @@ mod tests {
     /// Runs a simple pipeline.
     #[tokio::test]
     async fn run_pipeline() {
-        let db = test_utils::create_test_db::<mdbx::WriteMap>(EnvKind::RW);
+        let db = create_test_rw_db();
 
         let mut pipeline = Pipeline::builder()
             .add_stage(
@@ -574,7 +574,7 @@ mod tests {
     /// Unwinds a simple pipeline.
     #[tokio::test]
     async fn unwind_pipeline() {
-        let db = test_utils::create_test_db::<mdbx::WriteMap>(EnvKind::RW);
+        let db = create_test_rw_db();
 
         let mut pipeline = Pipeline::builder()
             .add_stage(
@@ -690,7 +690,7 @@ mod tests {
     /// Unwinds a pipeline with intermediate progress.
     #[tokio::test]
     async fn unwind_pipeline_with_intermediate_progress() {
-        let db = test_utils::create_test_db::<mdbx::WriteMap>(EnvKind::RW);
+        let db = create_test_rw_db();
 
         let mut pipeline = Pipeline::builder()
             .add_stage(
@@ -777,7 +777,7 @@ mod tests {
     /// - The pipeline finishes
     #[tokio::test]
     async fn run_pipeline_with_unwind() {
-        let db = test_utils::create_test_db::<mdbx::WriteMap>(EnvKind::RW);
+        let db = create_test_rw_db();
 
         let mut pipeline = Pipeline::builder()
             .add_stage(
@@ -871,7 +871,7 @@ mod tests {
     #[tokio::test]
     async fn pipeline_error_handling() {
         // Non-fatal
-        let db = test_utils::create_test_db::<mdbx::WriteMap>(EnvKind::RW);
+        let db = create_test_rw_db();
         let mut pipeline = Pipeline::builder()
             .add_stage(
                 TestStage::new(StageId::Other("NonFatal"))
@@ -884,7 +884,7 @@ mod tests {
         assert_matches!(result, Ok(()));
 
         // Fatal
-        let db = test_utils::create_test_db::<mdbx::WriteMap>(EnvKind::RW);
+        let db = create_test_rw_db();
         let mut pipeline = Pipeline::builder()
             .add_stage(TestStage::new(StageId::Other("Fatal")).add_exec(Err(
                 StageError::DatabaseIntegrity(ProviderError::BlockBodyIndicesNotFound(5)),

--- a/crates/stages/src/sets.rs
+++ b/crates/stages/src/sets.rs
@@ -14,7 +14,7 @@
 //! # use reth_stages::sets::{OfflineStages};
 //! # use reth_revm::Factory;
 //! # use reth_primitives::MAINNET;
-//! use reth_db::mdbx::test_utils::create_test_rw_db;
+//! use reth_db::test_utils::create_test_rw_db;
 //!
 //! # let factory = Factory::new(MAINNET.clone());
 //! # let db = create_test_rw_db();

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -417,10 +417,7 @@ mod tests {
     use super::*;
     use crate::test_utils::TestTransaction;
     use assert_matches::assert_matches;
-    use reth_db::{
-        mdbx::{test_utils::create_test_db, EnvKind, WriteMap},
-        models::AccountBeforeTx,
-    };
+    use reth_db::{models::AccountBeforeTx, test_utils::create_test_rw_db};
     use reth_primitives::{
         hex_literal::hex, keccak256, stage::StageUnitCheckpoint, Account, Bytecode,
         ChainSpecBuilder, SealedBlock, StorageEntry, H160, H256, MAINNET, U256,
@@ -441,7 +438,7 @@ mod tests {
 
     #[test]
     fn execution_checkpoint_matches() {
-        let state_db = create_test_db::<WriteMap>(EnvKind::RW);
+        let state_db = create_test_rw_db();
         let factory = ProviderFactory::new(state_db.as_ref(), MAINNET.clone());
         let tx = factory.provider_rw().unwrap();
 
@@ -466,7 +463,7 @@ mod tests {
 
     #[test]
     fn execution_checkpoint_precedes() {
-        let state_db = create_test_db::<WriteMap>(EnvKind::RW);
+        let state_db = create_test_rw_db();
         let factory = ProviderFactory::new(state_db.as_ref(), MAINNET.clone());
         let provider = factory.provider_rw().unwrap();
 
@@ -502,7 +499,7 @@ mod tests {
 
     #[test]
     fn execution_checkpoint_recalculate_full_previous_some() {
-        let state_db = create_test_db::<WriteMap>(EnvKind::RW);
+        let state_db = create_test_rw_db();
         let factory = ProviderFactory::new(state_db.as_ref(), MAINNET.clone());
         let provider = factory.provider_rw().unwrap();
 
@@ -538,7 +535,7 @@ mod tests {
 
     #[test]
     fn execution_checkpoint_recalculate_full_previous_none() {
-        let state_db = create_test_db::<WriteMap>(EnvKind::RW);
+        let state_db = create_test_rw_db();
         let factory = ProviderFactory::new(state_db.as_ref(), MAINNET.clone());
         let provider = factory.provider_rw().unwrap();
 
@@ -568,7 +565,7 @@ mod tests {
     async fn sanity_execution_of_block() {
         // TODO cleanup the setup after https://github.com/paradigmxyz/reth/issues/332
         // is merged as it has similar framework
-        let state_db = create_test_db::<WriteMap>(EnvKind::RW);
+        let state_db = create_test_rw_db();
         let factory = ProviderFactory::new(state_db.as_ref(), MAINNET.clone());
         let provider = factory.provider_rw().unwrap();
         let input = ExecInput {
@@ -678,7 +675,7 @@ mod tests {
         // TODO cleanup the setup after https://github.com/paradigmxyz/reth/issues/332
         // is merged as it has similar framework
 
-        let state_db = create_test_db::<WriteMap>(EnvKind::RW);
+        let state_db = create_test_rw_db();
         let factory = ProviderFactory::new(state_db.as_ref(), MAINNET.clone());
         let provider = factory.provider_rw().unwrap();
         let input = ExecInput {

--- a/crates/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/src/stages/hashing_storage.rs
@@ -620,7 +620,7 @@ mod tests {
                 .map_err(|e| e.into())
         }
 
-        fn insert_storage_entry<'a, TX: DbTxMut<'a> + DbTx<'a>>(
+        fn insert_storage_entry<'a, TX: DbTxMut<'a>>(
             &self,
             tx: &'a TX,
             tid_address: BlockNumberAddress,

--- a/crates/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/src/stages/hashing_storage.rs
@@ -233,7 +233,6 @@ mod tests {
     use rand::Rng;
     use reth_db::{
         cursor::{DbCursorRO, DbCursorRW},
-        mdbx::{tx::Tx, WriteMap, RW},
         models::{BlockNumberAddress, StoredBlockBodyIndices},
     };
     use reth_interfaces::test_utils::{
@@ -621,9 +620,9 @@ mod tests {
                 .map_err(|e| e.into())
         }
 
-        fn insert_storage_entry(
+        fn insert_storage_entry<'a, TX: DbTxMut<'a> + DbTx<'a>>(
             &self,
-            tx: &Tx<'_, RW, WriteMap>,
+            tx: &'a TX,
             tid_address: BlockNumberAddress,
             entry: StorageEntry,
             hash: bool,

--- a/crates/stages/src/test_utils/runner.rs
+++ b/crates/stages/src/test_utils/runner.rs
@@ -1,9 +1,6 @@
 use super::TestTransaction;
 use crate::{ExecInput, ExecOutput, Stage, StageError, UnwindInput, UnwindOutput};
-use reth_db::{
-    mdbx::{Env, WriteMap},
-    DatabaseEnv,
-};
+use reth_db::DatabaseEnv;
 use reth_primitives::MAINNET;
 use reth_provider::ProviderFactory;
 use std::{borrow::Borrow, sync::Arc};

--- a/crates/stages/src/test_utils/test_db.rs
+++ b/crates/stages/src/test_utils/test_db.rs
@@ -1,14 +1,11 @@
 use reth_db::{
     common::KeyValue,
     cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO},
-    mdbx::{
-        test_utils::{create_test_db, create_test_db_with_path},
-        tx::Tx,
-        Env, EnvKind, WriteMap, RO, RW,
-    },
+    mdbx::{tx::Tx, Env, EnvKind, WriteMap, RO, RW},
     models::{AccountBeforeTx, StoredBlockBodyIndices},
     table::Table,
     tables,
+    test_utils::create_test_rw_db,
     transaction::{DbTx, DbTxMut},
     DatabaseEnv, DatabaseError as DbError,
 };
@@ -43,14 +40,14 @@ pub struct TestTransaction {
 impl Default for TestTransaction {
     /// Create a new instance of [TestTransaction]
     fn default() -> Self {
-        let tx = create_test_db::<WriteMap>(EnvKind::RW);
+        let tx = create_test_rw_db();
         Self { tx: tx.clone(), path: None, factory: ProviderFactory::new(tx, MAINNET.clone()) }
     }
 }
 
 impl TestTransaction {
     pub fn new(path: &Path) -> Self {
-        let tx = create_test_db::<WriteMap>(EnvKind::RW);
+        let tx = create_test_rw_db();
         Self {
             tx: tx.clone(),
             path: Some(path.to_path_buf()),

--- a/crates/storage/db/benches/criterion.rs
+++ b/crates/storage/db/benches/criterion.rs
@@ -131,7 +131,10 @@ where
             || {
                 // Reset DB
                 let _ = std::fs::remove_dir_all(bench_db_path);
-                (input.clone(), create_test_db_with_path::<WriteMap>(EnvKind::RW, bench_db_path))
+                (
+                    input.clone(),
+                    Arc::try_unwrap(create_test_rw_db_with_path(bench_db_path)).unwrap(),
+                )
             },
             |(input, db)| {
                 // Create TX
@@ -154,7 +157,7 @@ where
             || {
                 // Reset DB
                 let _ = std::fs::remove_dir_all(bench_db_path);
-                (input, create_test_db_with_path::<WriteMap>(EnvKind::RW, bench_db_path))
+                (input, Arc::try_unwrap(create_test_rw_db_with_path(bench_db_path)).unwrap())
             },
             |(input, db)| {
                 // Create TX
@@ -225,7 +228,10 @@ where
             || {
                 // Reset DB
                 let _ = std::fs::remove_dir_all(bench_db_path);
-                (input.clone(), create_test_db_with_path::<WriteMap>(EnvKind::RW, bench_db_path))
+                (
+                    input.clone(),
+                    Arc::try_unwrap(create_test_rw_db_with_path(bench_db_path)).unwrap(),
+                )
             },
             |(input, db)| {
                 // Create TX
@@ -249,7 +255,7 @@ where
                 // Reset DB
                 let _ = std::fs::remove_dir_all(bench_db_path);
 
-                (input, create_test_db_with_path::<WriteMap>(EnvKind::RW, bench_db_path))
+                (input, Arc::try_unwrap(create_test_rw_db_with_path(bench_db_path)).unwrap())
             },
             |(input, db)| {
                 // Create TX

--- a/crates/storage/db/benches/hash_keys.rs
+++ b/crates/storage/db/benches/hash_keys.rs
@@ -12,7 +12,6 @@ use proptest::{
 };
 use reth_db::{
     cursor::{DbCursorRW, DbDupCursorRO, DbDupCursorRW},
-    mdbx::Env,
     TxHashNumber,
 };
 use std::{collections::HashSet, time::Instant};

--- a/crates/storage/db/benches/hash_keys.rs
+++ b/crates/storage/db/benches/hash_keys.rs
@@ -86,7 +86,7 @@ where
         let setup = || {
             // Reset DB
             let _ = std::fs::remove_dir_all(bench_db_path);
-            let db = create_test_db_with_path::<WriteMap>(EnvKind::RW, bench_db_path);
+            let db = Arc::try_unwrap(create_test_rw_db_with_path(bench_db_path)).unwrap();
 
             let mut unsorted_input = unsorted_input.clone();
             if scenario_str == "append_all" {

--- a/crates/storage/db/benches/utils.rs
+++ b/crates/storage/db/benches/utils.rs
@@ -1,12 +1,12 @@
-use reth_db::DatabaseEnv;
 #[allow(unused_imports)]
 use reth_db::{
     database::Database,
-    mdbx::{test_utils::create_test_db_with_path, EnvKind, WriteMap},
     table::*,
+    test_utils::create_test_rw_db_with_path,
     transaction::{DbTx, DbTxMut},
+    DatabaseEnv,
 };
-use std::path::Path;
+use std::{path::Path, sync::Arc};
 
 /// Path where the DB is initialized for benchmarks.
 #[allow(unused)]
@@ -60,7 +60,7 @@ where
 {
     // Reset DB
     let _ = std::fs::remove_dir_all(bench_db_path);
-    let db = create_test_db_with_path::<WriteMap>(EnvKind::RW, bench_db_path);
+    let db = Arc::try_unwrap(create_test_rw_db_with_path(bench_db_path)).unwrap();
 
     {
         // Prepare data to be read

--- a/crates/storage/db/src/lib.rs
+++ b/crates/storage/db/src/lib.rs
@@ -132,7 +132,7 @@ pub fn init_db<P: AsRef<Path>>(path: P) -> eyre::Result<DatabaseEnv> {
 }
 
 /// Opens up an existing database. Read only mode. It doesn't create it or create tables if missing.
-pub fn open_readonly_db(path: &Path) -> eyre::Result<DatabaseEnvRO> {
+pub fn open_db_read_only(path: &Path) -> eyre::Result<DatabaseEnvRO> {
     #[cfg(feature = "mdbx")]
     {
         Env::<NoWriteMap>::open(path, mdbx::EnvKind::RO)
@@ -192,7 +192,7 @@ pub mod test_utils {
         {
             init_db(path.as_path()).expect(ERROR_DB_CREATION);
         }
-        Arc::new(open_readonly_db(path.as_path()).expect(ERROR_DB_OPEN))
+        Arc::new(open_db_read_only(path.as_path()).expect(ERROR_DB_OPEN))
     }
 }
 

--- a/crates/storage/db/src/lib.rs
+++ b/crates/storage/db/src/lib.rs
@@ -92,8 +92,12 @@ pub use utils::is_database_empty;
 use mdbx::{Env, EnvKind, WriteMap};
 
 #[cfg(feature = "mdbx")]
-/// Alias type for the database engine in use.
+/// Alias type for the database environment in use. Read/Write mode.
 pub type DatabaseEnv = Env<WriteMap>;
+
+#[cfg(feature = "mdbx")]
+/// Alias type for the database engine in use. Read only mode.
+pub type DatabaseEnvRO = Env<NoWriteMap>;
 
 /// Opens up an existing database or creates a new one at the specified path.
 pub fn init_db<P: AsRef<std::path::Path>>(path: P) -> eyre::Result<DatabaseEnv> {

--- a/crates/storage/db/src/lib.rs
+++ b/crates/storage/db/src/lib.rs
@@ -158,6 +158,44 @@ pub fn open_db(path: &Path) -> eyre::Result<DatabaseEnv> {
     }
 }
 
+/// Collection of database test utilities
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils {
+    use super::*;
+    use std::sync::Arc;
+
+    /// Error during database open
+    pub const ERROR_DB_OPEN: &str = "Not able to open the database file.";
+    /// Error during database creation
+    pub const ERROR_DB_CREATION: &str = "Not able to create the database file.";
+    /// Error during table creation
+    pub const ERROR_TABLE_CREATION: &str = "Not able to create tables in the database.";
+    /// Error during tempdir creation
+    pub const ERROR_TEMPDIR: &str = "Not able to create a temporary directory.";
+
+    /// Create read/write database for testing
+    pub fn create_test_rw_db() -> Arc<DatabaseEnv> {
+        Arc::new(
+            init_db(tempfile::TempDir::new().expect(ERROR_TEMPDIR).into_path())
+                .expect(ERROR_DB_CREATION),
+        )
+    }
+
+    /// Create read/write database for testing
+    pub fn create_test_rw_db_with_path<P: AsRef<Path>>(path: P) -> Arc<DatabaseEnv> {
+        Arc::new(init_db(path.as_ref()).expect(ERROR_DB_CREATION))
+    }
+
+    /// Create read only database for testing
+    pub fn create_test_ro_db() -> Arc<DatabaseEnvRO> {
+        let path = tempfile::TempDir::new().expect(ERROR_TEMPDIR).into_path();
+        {
+            init_db(path.as_path()).expect(ERROR_DB_CREATION);
+        }
+        Arc::new(open_readonly_db(path.as_path()).expect(ERROR_DB_OPEN))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{

--- a/crates/storage/provider/src/post_state/mod.rs
+++ b/crates/storage/provider/src/post_state/mod.rs
@@ -223,7 +223,7 @@ impl PostState {
     /// ```
     /// use reth_primitives::{Address, Account};
     /// use reth_provider::PostState;
-    /// use reth_db::{mdbx::{EnvKind, WriteMap}, test_utils::create_test_rw_db, database::Database};
+    /// use reth_db::{test_utils::create_test_rw_db, database::Database};
     ///
     /// // Initialize the database
     /// let db = create_test_rw_db();

--- a/crates/storage/provider/src/post_state/mod.rs
+++ b/crates/storage/provider/src/post_state/mod.rs
@@ -223,10 +223,10 @@ impl PostState {
     /// ```
     /// use reth_primitives::{Address, Account};
     /// use reth_provider::PostState;
-    /// use reth_db::{mdbx::{EnvKind, WriteMap, test_utils::create_test_db}, database::Database};
+    /// use reth_db::{mdbx::{EnvKind, WriteMap}, test_utils::create_test_rw_db, database::Database};
     ///
     /// // Initialize the database
-    /// let db = create_test_db::<WriteMap>(EnvKind::RW);
+    /// let db = create_test_rw_db();
     ///
     /// // Initialize the post state
     /// let mut post_state = PostState::new();
@@ -642,10 +642,7 @@ mod tests {
     use super::*;
     use crate::{AccountReader, ProviderFactory};
     use reth_db::{
-        database::Database,
-        mdbx::{test_utils, EnvKind},
-        transaction::DbTx,
-        DatabaseEnv,
+        database::Database, test_utils::create_test_rw_db, transaction::DbTx, DatabaseEnv,
     };
     use reth_primitives::{proofs::EMPTY_ROOT, MAINNET};
     use reth_trie::test_utils::state_root;
@@ -1067,7 +1064,7 @@ mod tests {
 
     #[test]
     fn write_to_db_account_info() {
-        let db: Arc<DatabaseEnv> = test_utils::create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEnv> = create_test_rw_db();
         let factory = ProviderFactory::new(db, MAINNET.clone());
         let provider = factory.provider_rw().unwrap();
 
@@ -1136,7 +1133,7 @@ mod tests {
 
     #[test]
     fn write_to_db_storage() {
-        let db: Arc<DatabaseEnv> = test_utils::create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEnv> = create_test_rw_db();
         let tx = db.tx_mut().expect("Could not get database tx");
 
         let mut post_state = PostState::new();
@@ -1272,7 +1269,7 @@ mod tests {
 
     #[test]
     fn write_to_db_multiple_selfdestructs() {
-        let db: Arc<DatabaseEnv> = test_utils::create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEnv> = create_test_rw_db();
         let tx = db.tx_mut().expect("Could not get database tx");
 
         let address1 = Address::random();
@@ -1821,7 +1818,7 @@ mod tests {
 
     #[test]
     fn empty_post_state_state_root() {
-        let db: Arc<DatabaseEnv> = test_utils::create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEnv> = create_test_rw_db();
         let tx = db.tx().unwrap();
 
         let post_state = PostState::new();
@@ -1840,7 +1837,7 @@ mod tests {
             })
             .collect();
 
-        let db: Arc<DatabaseEnv> = test_utils::create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEnv> = create_test_rw_db();
 
         // insert initial state to the database
         db.update(|tx| {

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -348,10 +348,7 @@ mod tests {
     use super::ProviderFactory;
     use crate::{BlockHashReader, BlockNumReader};
     use reth_db::{
-        mdbx::{
-            test_utils::{create_test_db, ERROR_TEMPDIR},
-            EnvKind, WriteMap,
-        },
+        test_utils::{create_test_rw_db, ERROR_TEMPDIR},
         DatabaseEnv,
     };
     use reth_primitives::{ChainSpecBuilder, H256};
@@ -360,7 +357,7 @@ mod tests {
     #[test]
     fn common_history_provider() {
         let chain_spec = ChainSpecBuilder::mainnet().build();
-        let db = create_test_db::<WriteMap>(EnvKind::RW);
+        let db = create_test_rw_db();
         let provider = ProviderFactory::new(db, Arc::new(chain_spec));
         let _ = provider.latest();
     }
@@ -368,7 +365,7 @@ mod tests {
     #[test]
     fn default_chain_info() {
         let chain_spec = ChainSpecBuilder::mainnet().build();
-        let db = create_test_db::<WriteMap>(EnvKind::RW);
+        let db = create_test_rw_db();
         let factory = ProviderFactory::new(db, Arc::new(chain_spec));
         let provider = factory.provider().unwrap();
 
@@ -380,7 +377,7 @@ mod tests {
     #[test]
     fn provider_flow() {
         let chain_spec = ChainSpecBuilder::mainnet().build();
-        let db = create_test_db::<WriteMap>(EnvKind::RW);
+        let db = create_test_rw_db();
         let factory = ProviderFactory::new(db, Arc::new(chain_spec));
         let provider = factory.provider().unwrap();
         provider.block_hash(0).unwrap();

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -223,9 +223,9 @@ mod tests {
     };
     use reth_db::{
         database::Database,
-        mdbx::test_utils::create_test_rw_db,
         models::{storage_sharded_key::StorageShardedKey, AccountBeforeTx, ShardedKey},
         tables,
+        test_utils::create_test_rw_db,
         transaction::{DbTx, DbTxMut},
         BlockNumberList,
     };

--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -7,9 +7,9 @@ use std::fmt::Debug;
 mod test {
     use crate::{test_utils::blocks::*, ProviderFactory, TransactionsProvider};
     use reth_db::{
-        mdbx::test_utils::create_test_rw_db,
         models::{storage_sharded_key::StorageShardedKey, ShardedKey},
         tables,
+        test_utils::create_test_rw_db,
     };
     use reth_primitives::{ChainSpecBuilder, IntegerList, H160, MAINNET, U256};
     use std::sync::Arc;

--- a/crates/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/src/hashed_cursor/post_state.rs
@@ -372,7 +372,7 @@ where
 mod tests {
     use super::*;
     use proptest::prelude::*;
-    use reth_db::{database::Database, mdbx::test_utils::create_test_rw_db, transaction::DbTxMut};
+    use reth_db::{database::Database, test_utils::create_test_rw_db, transaction::DbTxMut};
 
     fn assert_account_cursor_order<'a, 'b>(
         factory: &'a impl HashedCursorFactory<'b>,

--- a/crates/trie/src/trie.rs
+++ b/crates/trie/src/trie.rs
@@ -514,8 +514,8 @@ mod tests {
     use proptest::{prelude::ProptestConfig, proptest};
     use reth_db::{
         cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO},
-        mdbx::test_utils::create_test_rw_db,
         tables,
+        test_utils::create_test_rw_db,
         transaction::DbTxMut,
         DatabaseEnv,
     };

--- a/crates/trie/src/trie_cursor/account_cursor.rs
+++ b/crates/trie/src/trie_cursor/account_cursor.rs
@@ -42,8 +42,8 @@ mod tests {
     use super::*;
     use reth_db::{
         cursor::{DbCursorRO, DbCursorRW},
-        mdbx::test_utils::create_test_rw_db,
         tables,
+        test_utils::create_test_rw_db,
         transaction::DbTxMut,
     };
     use reth_primitives::{hex_literal::hex, MAINNET};

--- a/crates/trie/src/trie_cursor/storage_cursor.rs
+++ b/crates/trie/src/trie_cursor/storage_cursor.rs
@@ -58,7 +58,7 @@ mod tests {
 
     use super::*;
     use reth_db::{
-        cursor::DbCursorRW, mdbx::test_utils::create_test_rw_db, tables, transaction::DbTxMut,
+        cursor::DbCursorRW, tables, test_utils::create_test_rw_db, transaction::DbTxMut,
     };
     use reth_primitives::{
         trie::{BranchNodeCompact, StorageTrieEntry},

--- a/crates/trie/src/walker.rs
+++ b/crates/trie/src/walker.rs
@@ -260,7 +260,7 @@ mod tests {
     use super::*;
     use crate::trie_cursor::{AccountTrieCursor, StorageTrieCursor};
     use reth_db::{
-        cursor::DbCursorRW, mdbx::test_utils::create_test_rw_db, tables, transaction::DbTxMut,
+        cursor::DbCursorRW, tables, test_utils::create_test_rw_db, transaction::DbTxMut,
     };
     use reth_primitives::{trie::StorageTrieEntry, MAINNET};
     use reth_provider::ProviderFactory;

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -4,7 +4,7 @@ use crate::{
     models::{BlockchainTest, ForkSpec, RootOrState},
     Case, Error, Suite,
 };
-use reth_db::mdbx::test_utils::create_test_rw_db;
+use reth_db::test_utils::create_test_rw_db;
 use reth_primitives::{BlockBody, SealedBlock};
 use reth_provider::{BlockWriter, ProviderFactory};
 use reth_rlp::Decodable;


### PR DESCRIPTION
* Adds `DatabaseEnvRO` : `Env<NoWriteMap> + EnvKind::RO`
* Adds `test-utils` to `reth_db` and move the test database creation methods there

This way, all `mdbx` logic and imports are contained to `reth_db` (behind feature gates) and any transition to another db should be easier.