### PR TITLE
chore: rename invalid header metrics scope

### DIFF
--- a/crates/consensus/beacon/src/engine/invalid_headers.rs
+++ b/crates/consensus/beacon/src/engine/invalid_headers.rs
@@ -88,7 +88,7 @@ struct HeaderEntry {
 
 /// Metrics for the invalid headers cache.
 #[derive(Metrics)]
-#[metrics(scope = "invalid_header_cache")]
+#[metrics(scope = "consensus.engine.beacon.invalid_headers")]
 struct InvalidHeaderCacheMetrics {
     /// The total number of invalid headers in the cache.
     invalid_headers: Gauge,

--- a/crates/consensus/beacon/src/engine/invalid_headers.rs
+++ b/crates/consensus/beacon/src/engine/invalid_headers.rs
@@ -60,7 +60,7 @@ impl InvalidHeaderCache {
 
             // update metrics
             self.metrics.known_ancestor_inserts.increment(1);
-            self.metrics.invalid_headers.set(self.headers.len() as f64);
+            self.metrics.count.set(self.headers.len() as f64);
         }
     }
 
@@ -74,7 +74,7 @@ impl InvalidHeaderCache {
 
             // update metrics
             self.metrics.unique_inserts.increment(1);
-            self.metrics.invalid_headers.set(self.headers.len() as f64);
+            self.metrics.count.set(self.headers.len() as f64);
         }
     }
 }
@@ -91,7 +91,7 @@ struct HeaderEntry {
 #[metrics(scope = "consensus.engine.beacon.invalid_headers")]
 struct InvalidHeaderCacheMetrics {
     /// The total number of invalid headers in the cache.
-    invalid_headers: Gauge,
+    count: Gauge,
     /// The number of inserts with a known ancestor.
     known_ancestor_inserts: Counter,
     /// The number of unique invalid header inserts (i.e. without a known ancestor).


### PR DESCRIPTION
Closes #3411

rename scope and put it under existing `consensus.engine.beacon` scope