### PR TITLE
docs: update call fees docs on fallback

### DIFF
--- a/crates/rpc/rpc/src/eth/revm_utils.rs
+++ b/crates/rpc/rpc/src/eth/revm_utils.rs
@@ -384,8 +384,8 @@ impl CallFees {
     ) -> EthResult<CallFees> {
         match (call_gas_price, call_max_fee, call_priority_fee) {
             (gas_price, None, None) => {
-                // either legacy or no fee fields
-                // when none are specified, they are all set to zero
+                // either legacy transaction or no fee fields are specified
+                // when no fields are specified, set gas price to zero
                 let gas_price = gas_price.unwrap_or(U256::ZERO);
                 Ok(CallFees { gas_price, max_priority_fee_per_gas: None })
             }

--- a/crates/rpc/rpc/src/eth/revm_utils.rs
+++ b/crates/rpc/rpc/src/eth/revm_utils.rs
@@ -374,8 +374,8 @@ pub(crate) struct CallFees {
 impl CallFees {
     /// Ensures the fields of a [CallRequest] are not conflicting.
     ///
-    /// If no `gasPrice` or `maxFeePerGas` is set, then the `gas_price` in the response will
-    /// fallback to the given `basefee`.
+    /// If no `gasPrice` or `maxFeePerGas` is set, then the `gas_price` in the returned `gas_price`
+    /// will be `0`. See: <https://github.com/ethereum/go-ethereum/blob/2754b197c935ee63101cbbca2752338246384fec/internal/ethapi/transaction_args.go#L242-L255>
     fn ensure_fees(
         call_gas_price: Option<U256>,
         call_max_fee: Option<U256>,
@@ -383,14 +383,10 @@ impl CallFees {
         base_fee: U256,
     ) -> EthResult<CallFees> {
         match (call_gas_price, call_max_fee, call_priority_fee) {
-            (None, None, None) => {
-                // when none are specified, they are all set to zero
-                Ok(CallFees { gas_price: U256::ZERO, max_priority_fee_per_gas: None })
-            }
             (gas_price, None, None) => {
-                // request for a legacy transaction
-                // set everything to zero
-                let gas_price = gas_price.unwrap_or(base_fee);
+                // either legacy or no fee fields
+                // when none are specified, they are all set to zero
+                let gas_price = gas_price.unwrap_or(U256::ZERO);
                 Ok(CallFees { gas_price, max_priority_fee_per_gas: None })
             }
             (None, max_fee_per_gas, max_priority_fee_per_gas) => {
@@ -523,5 +519,17 @@ where
         logs: db.logs.clone(),
         block_hashes: db.block_hashes.clone(),
         db: Default::default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ensure_0_fallback() {
+        let CallFees { gas_price, .. } =
+            CallFees::ensure_fees(None, None, None, U256::from(99)).unwrap();
+        assert_eq!(gas_price, U256::ZERO);
     }
 }


### PR DESCRIPTION
the documented fallback was outdated.

this already mirrors geth's conversion which uses gasPrice 0 if no fields provided