### PR TITLE
fix: set missing record logs

### DIFF
--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -380,7 +380,8 @@ where
                             .map_err(|_| EthApiError::InvalidTracerConfig)?;
 
                         let mut inspector = TracingInspector::new(
-                            TracingInspectorConfig::from_geth_config(&config),
+                            TracingInspectorConfig::from_geth_config(&config)
+                                .set_record_logs(call_config.with_log.unwrap_or_default()),
                         );
 
                         let (res, _) = inspect(db, env, &mut inspector)?;


### PR DESCRIPTION
`set_record_logs` call was missing for tracing transactions