### PR TITLE
chore: mirror geth's encoding order for callframe

### DIFF
--- a/crates/rpc/rpc-types/src/eth/trace/geth/call.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/geth/call.rs
@@ -4,17 +4,13 @@ use serde::{Deserialize, Serialize};
 /// <https://github.com/ethereum/go-ethereum/blob/91cb6f863a965481e51d5d9c0e5ccd54796fd967/eth/tracers/native/call.go#L44>
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CallFrame {
-    #[serde(rename = "type")]
-    pub typ: String,
     pub from: Address,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub to: Option<Address>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub value: Option<U256>,
     #[serde(default, deserialize_with = "from_int_or_hex")]
     pub gas: U256,
     #[serde(default, deserialize_with = "from_int_or_hex", rename = "gasUsed")]
     pub gas_used: U256,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub to: Option<Address>,
     pub input: Bytes,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub output: Option<Bytes>,
@@ -26,6 +22,10 @@ pub struct CallFrame {
     pub calls: Option<Vec<CallFrame>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub logs: Option<Vec<CallLogFrame>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<U256>,
+    #[serde(rename = "type")]
+    pub typ: String,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
use same order as geth to make it easier to compare json output