### PR TITLE
chore: replace Option<Vec> with just vec

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/builder/geth.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/geth.rs
@@ -137,7 +137,7 @@ impl GethTraceBuilder {
                 // we need to ensure that calls are in order they are called: the last child node is
                 // the last call, but since we walk up the tree, we need to always
                 // insert at position 0
-                parent_frame.1.calls.get_or_insert_with(Vec::new).insert(0, call);
+                parent_frame.1.calls.insert(0, call);
             } else {
                 debug_assert!(call_frames.is_empty(), "only one root node has no parent");
                 return call

--- a/crates/revm/revm-inspectors/src/tracing/types.rs
+++ b/crates/revm/revm-inspectors/src/tracing/types.rs
@@ -378,8 +378,8 @@ impl CallTraceNode {
             output: Some(self.trace.output.clone().into()),
             error: None,
             revert_reason: None,
-            calls: None,
-            logs: None,
+            calls: Default::default(),
+            logs: Default::default(),
         };
 
         // we need to populate error and revert reason
@@ -388,17 +388,16 @@ impl CallTraceNode {
             call_frame.error = self.trace.as_error();
         }
 
-        if include_logs {
-            call_frame.logs = Some(
-                self.logs
-                    .iter()
-                    .map(|log| CallLogFrame {
-                        address: Some(self.trace.address),
-                        topics: Some(log.topics.clone()),
-                        data: Some(log.data.clone().into()),
-                    })
-                    .collect(),
-            );
+        if include_logs && !self.logs.is_empty() {
+            call_frame.logs = self
+                .logs
+                .iter()
+                .map(|log| CallLogFrame {
+                    address: Some(self.trace.address),
+                    topics: Some(log.topics.clone()),
+                    data: Some(log.data.clone().into()),
+                })
+                .collect();
         }
 
         call_frame

--- a/crates/rpc/rpc-types/src/eth/trace/geth/call.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/geth/call.rs
@@ -18,10 +18,10 @@ pub struct CallFrame {
     pub error: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revert_reason: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub calls: Option<Vec<CallFrame>>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub logs: Option<Vec<CallLogFrame>>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub calls: Vec<CallFrame>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub logs: Vec<CallLogFrame>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub value: Option<U256>,
     #[serde(rename = "type")]
@@ -83,7 +83,6 @@ mod tests {
         let _trace: CallFrame = serde_json::from_str(DEFAULT).unwrap();
         let _trace: CallFrame = serde_json::from_str(LEGACY).unwrap();
         let _trace: CallFrame = serde_json::from_str(ONLY_TOP_CALL).unwrap();
-        let trace: CallFrame = serde_json::from_str(WITH_LOG).unwrap();
-        let _logs = trace.logs.unwrap();
+        let _trace: CallFrame = serde_json::from_str(WITH_LOG).unwrap();
     }
 }


### PR DESCRIPTION
builds off of #3473

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 03ddc13</samp>

This pull request refactors the code related to the `CallFrame` struct and its usage in the Geth trace output. It improves the code readability, consistency, and efficiency.
