### PR TITLE
test: set --authrpc.port to 0 for Geth instance

### DIFF
--- a/crates/net/network/tests/it/connect.rs
+++ b/crates/net/network/tests/it/connect.rs
@@ -318,7 +318,7 @@ async fn test_incoming_node_id_blacklist() {
 
         // instantiate geth and add ourselves as a peer
         let temp_dir = tempfile::tempdir().unwrap().into_path();
-        let geth = Geth::new().data_dir(temp_dir).disable_discovery().spawn();
+        let geth = Geth::new().data_dir(temp_dir).disable_discovery().authrpc_port(0).spawn();
         let geth_endpoint = SocketAddr::new([127, 0, 0, 1].into(), geth.port());
         let provider = Provider::<Http>::try_from(format!("http://{geth_endpoint}")).unwrap();
 
@@ -371,7 +371,7 @@ async fn test_incoming_connect_with_single_geth() {
 
         // instantiate geth and add ourselves as a peer
         let temp_dir = tempfile::tempdir().unwrap().into_path();
-        let geth = Geth::new().data_dir(temp_dir).disable_discovery().spawn();
+        let geth = Geth::new().data_dir(temp_dir).disable_discovery().authrpc_port(0).spawn();
         let geth_endpoint = SocketAddr::new([127, 0, 0, 1].into(), geth.port());
         let provider = Provider::<Http>::try_from(format!("http://{geth_endpoint}")).unwrap();
 
@@ -429,7 +429,7 @@ async fn test_outgoing_connect_with_single_geth() {
 
         // instantiate geth and add ourselves as a peer
         let temp_dir = tempfile::tempdir().unwrap().into_path();
-        let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
+        let geth = Geth::new().disable_discovery().data_dir(temp_dir).authrpc_port(0).spawn();
 
         let geth_p2p_port = geth.p2p_port().unwrap();
         let geth_socket = SocketAddr::new([127, 0, 0, 1].into(), geth_p2p_port);
@@ -474,7 +474,7 @@ async fn test_geth_disconnect() {
 
         // instantiate geth and add ourselves as a peer
         let temp_dir = tempfile::tempdir().unwrap().into_path();
-        let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
+        let geth = Geth::new().disable_discovery().data_dir(temp_dir).authrpc_port(0).spawn();
 
         let geth_p2p_port = geth.p2p_port().unwrap();
         let geth_socket = SocketAddr::new([127, 0, 0, 1].into(), geth_p2p_port);


### PR DESCRIPTION
geth fails after ~2s if the auth server is already in use however the `Geth::spawn` returns once the HTTP server is up.

this sets the auth.rpc port to 0 since we don't care about it

Closes #3456