### PR TITLE
fix: use correct address for log

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/types.rs
+++ b/crates/revm/revm-inspectors/src/tracing/types.rs
@@ -35,6 +35,11 @@ impl CallKind {
     pub fn is_any_create(&self) -> bool {
         matches!(self, CallKind::Create | CallKind::Create2)
     }
+
+    /// Returns true if the call is a delegate of some sorts
+    pub fn is_delegate(&self) -> bool {
+        matches!(self, CallKind::DelegateCall | CallKind::CallCode)
+    }
 }
 
 impl std::fmt::Display for CallKind {
@@ -204,6 +209,17 @@ pub(crate) struct CallTraceNode {
 }
 
 impl CallTraceNode {
+    /// Returns the call context's execution address
+    ///
+    /// See `Inspector::call` impl of [TracingInspector](crate::tracing::TracingInspector)
+    pub(crate) fn execution_address(&self) -> Address {
+        if self.trace.kind.is_delegate() {
+            self.trace.caller
+        } else {
+            self.trace.address
+        }
+    }
+
     /// Pushes all steps onto the stack in reverse order
     /// so that the first step is on top of the stack
     pub(crate) fn push_steps_on_stack<'a>(
@@ -393,7 +409,7 @@ impl CallTraceNode {
                 .logs
                 .iter()
                 .map(|log| CallLogFrame {
-                    address: Some(self.trace.address),
+                    address: Some(self.execution_address()),
                     topics: Some(log.topics.clone()),
                     data: Some(log.data.clone().into()),
                 })


### PR DESCRIPTION
Closes #3475

In `call` we record `caller` and `to` like this:

https://github.com/paradigmxyz/reth/blob/0d950d2943fcf88f31eed9ed0c1ce8179c4f2887/crates/revm/revm-inspectors/src/tracing/mod.rs#L369-L375

we need the execution address for the log's address 