### PR TITLE
test: disable flakey test

### DIFF
--- a/crates/net/network/tests/it/connect.rs
+++ b/crates/net/network/tests/it/connect.rs
@@ -363,7 +363,8 @@ async fn test_incoming_node_id_blacklist() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial_test::serial]
-#[cfg_attr(not(feature = "geth-tests"), ignore)]
+// #[cfg_attr(not(feature = "geth-tests"), ignore)]
+#[ignore] // TODO: Re-enable once we figure out why this test is flakey
 async fn test_incoming_connect_with_single_geth() {
     reth_tracing::init_test_tracing();
     tokio::time::timeout(GETH_TIMEOUT, async move {


### PR DESCRIPTION
Unclear if it is flakey because of ethers or because of GitHub. Not reproducible locally.