### PR TITLE
chore: bump default max logs

### DIFF
--- a/crates/rpc/rpc-builder/src/auth.rs
+++ b/crates/rpc/rpc-builder/src/auth.rs
@@ -1,7 +1,7 @@
 use crate::{
     constants,
     error::{RpcError, ServerKind},
-    eth::DEFAULT_MAX_LOGS_IN_RESPONSE,
+    eth::DEFAULT_MAX_LOGS_PER_RESPONSE,
 };
 use hyper::header::AUTHORIZATION;
 pub use jsonrpsee::server::ServerBuilder;
@@ -67,7 +67,7 @@ where
         provider,
         pool,
         eth_cache.clone(),
-        DEFAULT_MAX_LOGS_IN_RESPONSE,
+        DEFAULT_MAX_LOGS_PER_RESPONSE,
         Box::new(executor.clone()),
     );
     launch_with_eth_api(eth_api, eth_filter, engine_api, socket_addr, secret).await

--- a/crates/rpc/rpc-builder/src/eth.rs
+++ b/crates/rpc/rpc-builder/src/eth.rs
@@ -8,7 +8,7 @@ use reth_rpc::{
 use serde::{Deserialize, Serialize};
 
 /// The default maximum of logs in a single response.
-pub(crate) const DEFAULT_MAX_LOGS_IN_RESPONSE: usize = 10_000;
+pub(crate) const DEFAULT_MAX_LOGS_PER_RESPONSE: usize = 20_000;
 
 /// The default maximum number of concurrently executed tracing calls
 pub(crate) const DEFAULT_MAX_TRACING_REQUESTS: u32 = 25;
@@ -45,7 +45,7 @@ impl Default for EthConfig {
             cache: EthStateCacheConfig::default(),
             gas_oracle: GasPriceOracleConfig::default(),
             max_tracing_requests: DEFAULT_MAX_TRACING_REQUESTS,
-            max_logs_per_response: DEFAULT_MAX_LOGS_IN_RESPONSE,
+            max_logs_per_response: DEFAULT_MAX_LOGS_PER_RESPONSE,
         }
     }
 }


### PR DESCRIPTION
10k logs can be Hit in a single block (nfts), doubling this seems reasonable