### PR TITLE
chore: add total-transactions metric

### DIFF
--- a/crates/transaction-pool/src/metrics.rs
+++ b/crates/transaction-pool/src/metrics.rs
@@ -30,4 +30,7 @@ pub struct TxPoolMetrics {
     pub(crate) queued_pool_transactions: Gauge,
     /// Total amount of memory used by the transactions in the queued sub-pool in bytes
     pub(crate) queued_pool_size_bytes: Gauge,
+
+    /// Number of all transactions of all sub-pools: pending + basefee + queued
+    pub(crate) total_transactions: Gauge,
 }

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -120,6 +120,7 @@ impl<T: TransactionOrdering> TxPool<T> {
             basefee_size: self.basefee_pool.size(),
             queued: self.queued_pool.len(),
             queued_size: self.queued_pool.size(),
+            total: self.all_transactions.len(),
         }
     }
 
@@ -272,6 +273,7 @@ impl<T: TransactionOrdering> TxPool<T> {
         self.metrics.basefee_pool_size_bytes.set(stats.basefee_size as f64);
         self.metrics.queued_pool_transactions.set(stats.queued as f64);
         self.metrics.queued_pool_size_bytes.set(stats.queued_size as f64);
+        self.metrics.total_transactions.set(stats.total as f64);
     }
 
     /// Adds the transaction into the pool.

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -591,6 +591,10 @@ pub struct PoolSize {
     pub queued: usize,
     /// Reported size of transactions in the _queued_ sub-pool.
     pub queued_size: usize,
+    /// Number of all transactions of all sub-pools
+    ///
+    /// Note: this is the sum of ```pending + basefee + queued```
+    pub total: usize,
 }
 
 /// Represents the current status of the pool.


### PR DESCRIPTION
while this should always be the sum of all the other size fields, it's good to have so we can check that this is actually true.

@Rjected do we have these metrics on the dashboard?