### PR TITLE
feat: add another distance check

### DIFF
--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -592,7 +592,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
     }
 
     /// Checks the block buffer for the given block.
-    pub fn get_buffered_block(&mut self, hash: &BlockHash) -> Option<&SealedBlockWithSenders> {
+    pub fn get_buffered_block(&self, hash: &BlockHash) -> Option<&SealedBlockWithSenders> {
         self.buffered_blocks.block_by_hash(hash)
     }
 

--- a/crates/blockchain-tree/src/shareable.rs
+++ b/crates/blockchain-tree/src/shareable.rs
@@ -109,6 +109,14 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeViewer
         self.tree.read().block_by_hash(block_hash).cloned()
     }
 
+    fn buffered_block_by_hash(&self, block_hash: BlockHash) -> Option<SealedBlock> {
+        self.tree.read().get_buffered_block(&block_hash).map(|b| b.block.clone())
+    }
+
+    fn buffered_header_by_hash(&self, block_hash: BlockHash) -> Option<SealedHeader> {
+        self.tree.read().get_buffered_block(&block_hash).map(|b| b.header.clone())
+    }
+
     fn canonical_blocks(&self) -> BTreeMap<BlockNumber, BlockHash> {
         trace!(target: "blockchain_tree", "Returning canonical blocks in tree");
         self.tree.read().block_indices().canonical_chain().inner().clone()

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1074,6 +1074,15 @@ where
                                     canonical_tip_num,
                                     downloaded_num_hash.number,
                                 );
+                            } else if let Some(buffered_finalized) =
+                                self.blockchain.buffered_header_by_hash(state.finalized_block_hash)
+                            {
+                                // if we have buffered the finalized block, we should check how far
+                                // we're off
+                                requires_pipeline = self.exceeds_pipeline_run_threshold(
+                                    canonical_tip_num,
+                                    buffered_finalized.number,
+                                );
                             }
                         }
 

--- a/crates/interfaces/src/blockchain_tree/mod.rs
+++ b/crates/interfaces/src/blockchain_tree/mod.rs
@@ -172,8 +172,23 @@ pub trait BlockchainTreeViewer: Send + Sync {
 
     /// Returns the block with matching hash from the tree, if it exists.
     ///
-    /// Caution: This will not return blocks from the canonical chain.
+    /// Caution: This will not return blocks from the canonical chain or buffered blocks that are
+    /// disconnected from the canonical chain.
     fn block_by_hash(&self, hash: BlockHash) -> Option<SealedBlock>;
+
+    /// Returns the _buffered_ (disconnected) block with matching hash from the internal buffer if
+    /// it exists.
+    ///
+    /// Caution: Unlike [Self::block_by_hash] this will only return blocks that are currently
+    /// disconnected from the canonical chain.
+    fn buffered_block_by_hash(&self, block_hash: BlockHash) -> Option<SealedBlock>;
+
+    /// Returns the _buffered_ (disconnected) header with matching hash from the internal buffer if
+    /// it exists.
+    ///
+    /// Caution: Unlike [Self::block_by_hash] this will only return headers that are currently
+    /// disconnected from the canonical chain.
+    fn buffered_header_by_hash(&self, block_hash: BlockHash) -> Option<SealedHeader>;
 
     /// Returns true if the tree contains the block with matching hash.
     fn contains(&self, hash: BlockHash) -> bool {

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -608,6 +608,14 @@ where
         self.tree.block_by_hash(block_hash)
     }
 
+    fn buffered_block_by_hash(&self, block_hash: BlockHash) -> Option<SealedBlock> {
+        self.tree.buffered_block_by_hash(block_hash)
+    }
+
+    fn buffered_header_by_hash(&self, block_hash: BlockHash) -> Option<SealedHeader> {
+        self.tree.buffered_header_by_hash(block_hash)
+    }
+
     fn canonical_blocks(&self) -> BTreeMap<BlockNumber, BlockHash> {
         self.tree.canonical_blocks()
     }


### PR DESCRIPTION
while we're downloading via tree, we're still receiving new payloads and FCU, so the sync target and the finalized block and hence the distance from local to head constantly moves, and can eventually exceed the targeted 1 epoch.

this adds another check to also lookup if we have the latest finalized block buffered so we can check the distance here again.

This prevents the scenario where we receive a future finalized block the `NewPayload` and therefore never have to download the finalized block if the FCU is updated. 