### PR TITLE
feat(stages, tree): update sync metrics from blockchain tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5069,6 +5069,7 @@ dependencies = [
  "reth-metrics",
  "reth-primitives",
  "reth-provider",
+ "reth-stages",
  "tokio",
  "tracing",
 ]

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -206,7 +206,7 @@ impl Command {
                 canon_state_notification_sender.clone(),
                 tree_config,
             )?
-            .with_metrics_tx(metrics_tx.clone()),
+            .with_sync_metrics_tx(metrics_tx.clone()),
         );
 
         // setup the blockchain provider
@@ -694,7 +694,7 @@ impl Command {
             if continuous { HeaderSyncMode::Continuous } else { HeaderSyncMode::Tip(tip_rx) };
         let pipeline = builder
             .with_tip_sender(tip_tx)
-            .with_metric_events(metrics_tx)
+            .with_metrics_tx(metrics_tx)
             .add_stages(
                 DefaultStages::new(
                     header_mode,

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -286,10 +286,6 @@ impl Command {
         debug!(target: "reth::cli", "Spawning payload builder service");
         ctx.task_executor.spawn_critical("payload builder service", payload_service);
 
-        debug!(target: "reth::cli", "Spawning metrics listener task");
-        let (metrics_tx, metrics_rx) = unbounded_channel();
-        let metrics_listener = MetricsListener::new(metrics_rx);
-
         let max_block = if let Some(block) = self.debug.max_block {
             Some(block)
         } else if let Some(tip) = self.debug.tip {

--- a/crates/blockchain-tree/Cargo.toml
+++ b/crates/blockchain-tree/Cargo.toml
@@ -20,6 +20,7 @@ reth-interfaces = { workspace = true }
 reth-db = { path = "../storage/db" }
 reth-metrics = { workspace = true, features = ["common"] }
 reth-provider = { workspace = true }
+reth-stages = { path = "../stages" }
 
 # common
 parking_lot = { version = "0.12" }

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -148,7 +148,8 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
         })
     }
 
-    pub fn with_metrics_tx(mut self, metrics_tx: MetricEventsSender) -> Self {
+    /// Set the sync metric events sender.
+    pub fn with_sync_metrics_tx(mut self, metrics_tx: MetricEventsSender) -> Self {
         self.sync_metrics_tx = Some(metrics_tx);
         self
     }

--- a/crates/blockchain-tree/src/shareable.rs
+++ b/crates/blockchain-tree/src/shareable.rs
@@ -44,7 +44,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeEngine
     fn buffer_block(&self, block: SealedBlockWithSenders) -> Result<(), InsertBlockError> {
         let mut tree = self.tree.write();
         let res = tree.buffer_block(block);
-        tree.update_tree_metrics();
+        tree.update_metrics();
         res
     }
 
@@ -55,7 +55,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeEngine
         trace!(target: "blockchain_tree", hash=?block.hash, number=block.number, parent_hash=?block.parent_hash, "Inserting block");
         let mut tree = self.tree.write();
         let res = tree.insert_block(block);
-        tree.update_tree_metrics();
+        tree.update_metrics();
         res
     }
 
@@ -63,14 +63,14 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeEngine
         trace!(target: "blockchain_tree", ?finalized_block, "Finalizing block");
         let mut tree = self.tree.write();
         tree.finalize_block(finalized_block);
-        tree.update_tree_metrics();
+        tree.update_metrics();
     }
 
     fn restore_canonical_hashes(&self, last_finalized_block: BlockNumber) -> Result<(), Error> {
         trace!(target: "blockchain_tree", ?last_finalized_block, "Restoring canonical hashes for last finalized block");
         let mut tree = self.tree.write();
         let res = tree.restore_canonical_hashes(last_finalized_block);
-        tree.update_tree_metrics();
+        tree.update_metrics();
         res
     }
 
@@ -78,7 +78,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeEngine
         trace!(target: "blockchain_tree", ?block_hash, "Making block canonical");
         let mut tree = self.tree.write();
         let res = tree.make_canonical(block_hash);
-        tree.update_tree_metrics();
+        tree.update_metrics();
         res
     }
 
@@ -86,7 +86,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeEngine
         trace!(target: "blockchain_tree", ?unwind_to, "Unwinding to block number");
         let mut tree = self.tree.write();
         let res = tree.unwind(unwind_to);
-        tree.update_tree_metrics();
+        tree.update_metrics();
         res
     }
 }

--- a/crates/stages/src/metrics/listener.rs
+++ b/crates/stages/src/metrics/listener.rs
@@ -1,4 +1,4 @@
-use crate::metrics::{StageMetrics, SyncMetrics};
+use crate::metrics::SyncMetrics;
 use reth_primitives::{
     stage::{StageCheckpoint, StageId},
     BlockNumber,

--- a/crates/stages/src/metrics/listener.rs
+++ b/crates/stages/src/metrics/listener.rs
@@ -50,16 +50,13 @@ impl MetricsListener {
     fn handle_event(&mut self, event: MetricEvent) {
         match event {
             MetricEvent::SyncHeight { height } => {
-                // TODO(alexey): `self.sync_metrics.stages` may not contain any stages
-                self.sync_metrics
-                    .stages
-                    .iter()
-                    .for_each(|(_, metrics)| metrics.checkpoint.set(height as f64))
+                for stage_id in StageId::ALL {
+                    let stage_metrics = self.sync_metrics.get_stage_metrics(stage_id);
+                    stage_metrics.checkpoint.set(height as f64);
+                }
             }
             MetricEvent::StageCheckpoint { stage_id, checkpoint, max_block_number } => {
-                let stage_metrics = self.sync_metrics.stages.entry(stage_id).or_insert_with(|| {
-                    StageMetrics::new_with_labels(&[("stage", stage_id.to_string())])
-                });
+                let stage_metrics = self.sync_metrics.get_stage_metrics(stage_id);
 
                 stage_metrics.checkpoint.set(checkpoint.block_number as f64);
 

--- a/crates/stages/src/metrics/sync_metrics.rs
+++ b/crates/stages/src/metrics/sync_metrics.rs
@@ -10,6 +10,14 @@ pub(crate) struct SyncMetrics {
     pub(crate) stages: HashMap<StageId, StageMetrics>,
 }
 
+impl SyncMetrics {
+    pub(crate) fn get_stage_metrics(&mut self, stage_id: StageId) -> &mut StageMetrics {
+        self.stages
+            .entry(stage_id)
+            .or_insert_with(|| StageMetrics::new_with_labels(&[("stage", stage_id.to_string())]))
+    }
+}
+
 #[derive(Metrics)]
 #[metrics(scope = "sync")]
 pub(crate) struct StageMetrics {

--- a/crates/stages/src/metrics/sync_metrics.rs
+++ b/crates/stages/src/metrics/sync_metrics.rs
@@ -11,6 +11,7 @@ pub(crate) struct SyncMetrics {
 }
 
 impl SyncMetrics {
+    /// Returns existing or initializes a new instance of [StageMetrics] for the provided [StageId].
     pub(crate) fn get_stage_metrics(&mut self, stage_id: StageId) -> &mut StageMetrics {
         self.stages
             .entry(stage_id)

--- a/crates/stages/src/pipeline/builder.rs
+++ b/crates/stages/src/pipeline/builder.rs
@@ -62,7 +62,7 @@ where
     }
 
     /// Set the metric events sender.
-    pub fn with_metric_events(mut self, metrics_tx: MetricEventsSender) -> Self {
+    pub fn with_metrics_tx(mut self, metrics_tx: MetricEventsSender) -> Self {
         self.metrics_tx = Some(metrics_tx);
         self
     }


### PR DESCRIPTION
Resolves https://github.com/paradigmxyz/reth/issues/2604

Currently, `reth_sync_checkpoint` metric is not updated after the pipeline sync is done.

This PR fixes it by sending new block heights from blockchain tree to `reth_stages::MetricsListener`, which iterates over all known stages using `StageId::ALL` and updates the `reth_sync_checkpoint` gauge value.