### PR TITLE
refactor(stages): use `MetricsListener` for Execution stage gas metric

### DIFF
--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -681,7 +681,7 @@ impl Command {
             if continuous { HeaderSyncMode::Continuous } else { HeaderSyncMode::Tip(tip_rx) };
         let pipeline = builder
             .with_tip_sender(tip_tx)
-            .with_metric_events(metrics_tx)
+            .with_metrics_tx(metrics_tx)
             .add_stages(
                 DefaultStages::new(
                     header_mode,

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -690,7 +690,7 @@ impl Command {
             if continuous { HeaderSyncMode::Continuous } else { HeaderSyncMode::Tip(tip_rx) };
         let pipeline = builder
             .with_tip_sender(tip_tx)
-            .with_metrics_tx(metrics_tx)
+            .with_metrics_tx(metrics_tx.clone())
             .add_stages(
                 DefaultStages::new(
                     header_mode,
@@ -706,13 +706,16 @@ impl Command {
                 .set(SenderRecoveryStage {
                     commit_threshold: stage_config.sender_recovery.commit_threshold,
                 })
-                .set(ExecutionStage::new(
-                    factory,
-                    ExecutionStageThresholds {
-                        max_blocks: stage_config.execution.max_blocks,
-                        max_changes: stage_config.execution.max_changes,
-                    },
-                ))
+                .set(
+                    ExecutionStage::new(
+                        factory,
+                        ExecutionStageThresholds {
+                            max_blocks: stage_config.execution.max_blocks,
+                            max_changes: stage_config.execution.max_changes,
+                        },
+                    )
+                    .with_metrics_tx(metrics_tx),
+                )
                 .set(AccountHashingStage::new(
                     stage_config.account_hashing.clean_threshold,
                     stage_config.account_hashing.commit_threshold,

--- a/crates/stages/src/metrics/listener.rs
+++ b/crates/stages/src/metrics/listener.rs
@@ -1,5 +1,6 @@
 use crate::metrics::{StageMetrics, SyncMetrics};
 use reth_primitives::{
+    constants::MGAS_TO_GAS,
     stage::{StageCheckpoint, StageId},
     BlockNumber,
 };
@@ -25,6 +26,11 @@ pub enum MetricEvent {
         /// Maximum known block number reachable by this stage.
         /// If specified, `entities_total` metric is updated.
         max_block_number: Option<BlockNumber>,
+    },
+    /// Execution stage processed some amount of gas.
+    ExecutionStageGas {
+        /// Gas processed.
+        gas: u64,
     },
 }
 
@@ -62,6 +68,11 @@ impl MetricsListener {
                     stage_metrics.entities_total.set(total as f64);
                 }
             }
+            MetricEvent::ExecutionStageGas { gas } => self
+                .sync_metrics
+                .execution_stage
+                .mgas_processed_total
+                .increment(gas as f64 / MGAS_TO_GAS as f64),
         }
     }
 }

--- a/crates/stages/src/metrics/sync_metrics.rs
+++ b/crates/stages/src/metrics/sync_metrics.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 #[derive(Debug, Default)]
 pub(crate) struct SyncMetrics {
     pub(crate) stages: HashMap<StageId, StageMetrics>,
+    pub(crate) execution_stage: ExecutionStageMetrics,
 }
 
 #[derive(Metrics)]
@@ -19,4 +20,12 @@ pub(crate) struct StageMetrics {
     pub(crate) entities_processed: Gauge,
     /// The number of total entities of the last commit for a stage, if applicable.
     pub(crate) entities_total: Gauge,
+}
+
+/// Execution stage metrics.
+#[derive(Metrics)]
+#[metrics(scope = "sync.execution")]
+pub(crate) struct ExecutionStageMetrics {
+    /// The total amount of gas processed (in millions)
+    pub(crate) mgas_processed_total: Gauge,
 }

--- a/crates/stages/src/pipeline/builder.rs
+++ b/crates/stages/src/pipeline/builder.rs
@@ -62,7 +62,7 @@ where
     }
 
     /// Set the metric events sender.
-    pub fn with_metric_events(mut self, metrics_tx: MetricEventsSender) -> Self {
+    pub fn with_metrics_tx(mut self, metrics_tx: MetricEventsSender) -> Self {
         self.metrics_tx = Some(metrics_tx);
         self
     }

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -10,12 +10,7 @@ use reth_db::{
     transaction::{DbTx, DbTxMut},
 };
 use reth_interfaces::db::DatabaseError;
-use reth_metrics::{
-    metrics::{self, Gauge},
-    Metrics,
-};
 use reth_primitives::{
-    constants::MGAS_TO_GAS,
     stage::{
         CheckpointBlockRange, EntitiesCheckpoint, ExecutionCheckpoint, StageCheckpoint, StageId,
     },
@@ -79,6 +74,7 @@ impl<EF: ExecutorFactory> ExecutionStage<EF> {
         Self::new(executor_factory, ExecutionStageThresholds::default())
     }
 
+    /// Set the metric events sender.
     pub fn with_metrics_tx(mut self, metrics_tx: MetricEventsSender) -> Self {
         self.metrics_tx = Some(metrics_tx);
         self


### PR DESCRIPTION
This PR finishes migrating all existing sync-related metrics to using `MetricsListener` which was introduced in https://github.com/paradigmxyz/reth/pull/3483.