### PR TITLE
chore: rm cached bytes gauge

### DIFF
--- a/crates/rpc/rpc/src/eth/cache.rs
+++ b/crates/rpc/rpc/src/eth/cache.rs
@@ -507,9 +507,9 @@ where
         }
     }
 
+    #[inline]
     fn update_cached_metrics(&self) {
         self.metrics.cached_count.set(self.cache.len() as f64);
-        self.metrics.cached_bytes.set(self.cache.memory_usage() as f64);
     }
 }
 
@@ -581,8 +581,6 @@ where
 struct CacheMetrics {
     /// The number of entities in the cache.
     cached_count: Gauge,
-    /// The memory usage of the cache in bytes.
-    cached_bytes: Gauge,
     /// The number of queued consumers.
     queued_consumers_count: Gauge,
 }


### PR DESCRIPTION
as discovered, this is not very useful because most of the cached data is heap allocated