### PR TITLE
docs: add additional context to internal tracing error

### DIFF
--- a/crates/rpc/rpc/src/eth/error.rs
+++ b/crates/rpc/rpc/src/eth/error.rs
@@ -68,6 +68,9 @@ pub enum EthApiError {
     #[error("invalid reward percentiles")]
     InvalidRewardPercentiles,
     /// Error thrown when a spawned tracing task failed to deliver an anticipated response.
+    ///
+    /// This only happens if the tracing task panics and is aborted before it can return a response
+    /// back to the request handler.
     #[error("internal error while tracing")]
     InternalTracingError,
     /// Error thrown when a spawned blocking task failed to deliver an anticipated response.


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7434383</samp>

Add a comment to the `TracingTaskAborted` error variant in `error.rs`. This improves the documentation of the tracing feature and the error handling logic in the RPC crate.