### PR TITLE
docs: minimum docker engine version

### DIFF
--- a/book/installation/docker.md
+++ b/book/installation/docker.md
@@ -8,8 +8,9 @@ There are two ways to obtain a Reth Docker image:
 Once you have obtained the Docker image, proceed to [Using the Docker
 image](#using-the-docker-image).
 
-**Reth requires Docker Engine version 20.10.10 or higher due to [missing support](https://docs.docker.com/engine/release-notes/20.10/#201010) for the `clone3` syscall in previous versions.**
-
+> **Note**
+>
+> Reth requires Docker Engine version 20.10.10 or higher due to [missing support](https://docs.docker.com/engine/release-notes/20.10/#201010) for the `clone3` syscall in previous versions.
 ## GitHub
 
 Reth docker images for both x86_64 and ARM64 machines are published with every release of reth on GitHub Container Registry.

--- a/book/installation/docker.md
+++ b/book/installation/docker.md
@@ -8,6 +8,8 @@ There are two ways to obtain a Reth Docker image:
 Once you have obtained the Docker image, proceed to [Using the Docker
 image](#using-the-docker-image).
 
+**Reth requires Docker Engine version 20.10.10 or higher due to [missing support](https://docs.docker.com/engine/release-notes/20.10/#201010) for the `clone3` syscall in previous versions.**
+
 ## GitHub
 
 Reth docker images for both x86_64 and ARM64 machines are published with every release of reth on GitHub Container Registry.


### PR DESCRIPTION
Add documentation regarding a minimum Docker Engine version.

Running Reth on an earlier version of Docker Engine causes a panic at startup due to a `PermissionDenied` error caused by the default Docker seccomp profile not supporting the `clone3` syscall.

some more info:
- [docker 20.10.10 changelog, added support for clone3 syscall](https://docs.docker.com/engine/release-notes/20.10/#201010)
- [thread regarding the issue, with error message](https://discourse.nixos.org/t/rust-app-in-nix-docker-container-unable-to-spawn-process/18924)