### PR TITLE
fix(rpc): fix parity tracing config

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/config.rs
+++ b/crates/revm/revm-inspectors/src/tracing/config.rs
@@ -103,6 +103,16 @@ impl TracingInspectorConfig {
         self
     }
 
+    /// Configure whether the tracer should record steps and state diffs.
+    ///
+    /// This is a convenience method for setting both [TracingInspectorConfig::set_steps] and
+    /// [TracingInspectorConfig::set_state_diffs] since tracking state diffs requires steps tracing.
+    pub fn set_steps_and_state_diffs(mut self, steps_and_diffs: bool) -> Self {
+        self.record_steps = steps_and_diffs;
+        self.record_state_diff = steps_and_diffs;
+        self
+    }
+
     /// Configure whether the tracer should record logs
     pub fn set_record_logs(mut self, record_logs: bool) -> Self {
         self.record_logs = record_logs;


### PR DESCRIPTION
fixes a config bug that would result in the bug reported in #3535

we incorrectly configured the config, because storage diff recording requires step recording, and step recording was disabled if no vmtrace was included