### PR TITLE
chore: add stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,4 +19,5 @@ jobs:
           stale-issue-message: "This issue is stale because it has been open for 14 days with no activity."
           close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
           exempt-all-milestones: true
+          exempt-all-assignees: true
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,5 +1,6 @@
 name: stale issues
 on:
+  workflow_dispatch: {}
   schedule:
     - cron: "30 1 * * *"
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+name: stale issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v8
+        with:
+          days-before-stale: 14
+          days-before-close: 7
+          stale-issue-label: "S-stale"
+          exempt-issue-labels: "M-prevent-stale"
+          stale-issue-message: "This issue is stale because it has been open for 14 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
+          exempt-all-milestones: true
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Issues and PRs will be marked as stale after 14 days of inactivity (marked with https://github.com/paradigmxyz/reth/labels/S-stale). If they remain inactive for 7 days after that, they are closed.

The following exemptions apply:

- If the issue/PR has the label https://github.com/paradigmxyz/reth/labels/M-prevent-stale
- If the issue/PR has an assignee
- If the issue/PR has a milestone

Closes https://github.com/paradigmxyz/reth/issues/1264
