### PR TITLE
fix: add missing single block body download validation

### DIFF
--- a/crates/primitives/src/peer.rs
+++ b/crates/primitives/src/peer.rs
@@ -52,3 +52,10 @@ impl<T> WithPeerId<T> {
         WithPeerId(self.0, op(self.1))
     }
 }
+
+impl<T> WithPeerId<Option<T>> {
+    /// returns `None` if the inner value is `None`, otherwise returns `Some(WithPeerId<T>)`.
+    pub fn transpose(self) -> Option<WithPeerId<T>> {
+        self.1.map(|v| WithPeerId(self.0, v))
+    }
+}


### PR DESCRIPTION
we didn't properly validate that the body response actually belongs to the header.

this adds missing checks to validate payload