### PR TITLE
docker: don't ignore examples

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,3 +17,6 @@
 
 # include licenses
 !LICENSE-*
+
+# include example files
+!/examples


### PR DESCRIPTION
I'm building the reth image with the following command:

```bash
docker build -t jsvisa/reth .
```

but failed with the following error:

```
Sending build context to Docker daemon  83.15MB
Step 1/21 : FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
 ---> 472d27704b24
Step 2/21 : WORKDIR /app
 ---> Using cache
 ---> fb0718f22efe
Step 3/21 : LABEL org.opencontainers.image.source=https://github.com/paradigmxyz/reth
 ---> Using cache
 ---> 475f992ba3e0
Step 4/21 : LABEL org.opencontainers.image.licenses="MIT OR Apache-2.0"
 ---> Using cache
 ---> 02be258ce0b8
Step 5/21 : FROM chef AS planner
 ---> 02be258ce0b8
Step 6/21 : COPY . .
 ---> 5f48eecab2ef
Step 7/21 : RUN cargo chef prepare --recipe-path recipe.json
 ---> Running in 32a40a260113
Error: Failed to compute recipe

Caused by:
    0: Cannot extract Cargo metadata
    1: `cargo metadata` exited with an error: error: failed to load manifest for workspace member `/app/examples`

       Caused by:
         failed to read `/app/examples/Cargo.toml`

       Caused by:
         No such file or directory (os error 2)
```


look forward for a while, found in [cargo.toml](./cargo.toml) we add [examples](./examples), but which was ignored by [./dockerignore](.dockerignore)