### PR TITLE
feat: add cargo binstall support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,3 +133,8 @@ futures-util = "0.3.25"
 
 ## crypto
 secp256k1 = { version = "0.27.0", default-features = false, features = ["global-context", "rand-std", "recovery"] }
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-{ target }{ archive-suffix }"
+bin-dir = "{ bin }{ binary-ext }"
+pkg-fmt = "tgz"

--- a/book/installation/binaries.md
+++ b/book/installation/binaries.md
@@ -26,3 +26,15 @@ As an example, you could install the Linux x86_64 version like so:
 1. Test the binary with `./reth --version` (it should print the version).
 2. (Optional) Move the `reth` binary to a location in your `PATH`, so the `reth` command can be called from anywhere.  
    For most Linux distros, you can move the binary to `/usr/local/bin`: `sudo cp ./reth /usr/local/bin`.
+
+Alternatively, you can use [binstall](https://github.com/cargo-bins/cargo-binstall) to install and load the binary:
+
+1. To install `binstall`, run: 
+   ```bash
+   curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+   ```
+2. Then, install `reth` with:
+   ```bash
+   cargo binstall reth
+   ```
+

--- a/book/installation/binaries.md
+++ b/book/installation/binaries.md
@@ -27,14 +27,9 @@ As an example, you could install the Linux x86_64 version like so:
 2. (Optional) Move the `reth` binary to a location in your `PATH`, so the `reth` command can be called from anywhere.  
    For most Linux distros, you can move the binary to `/usr/local/bin`: `sudo cp ./reth /usr/local/bin`.
 
-Alternatively, you can use [binstall](https://github.com/cargo-bins/cargo-binstall) to install and load the binary:
-
-1. To install `binstall`, run: 
-   ```bash
-   curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-   ```
-2. Then, install `reth` with:
-   ```bash
-   cargo binstall reth
-   ```
+### Using `cargo-binstall`
+Alternatively, if you have [binstall](https://github.com/cargo-bins/cargo-binstall) installed, you can use it to install and load the binary:
+```bash
+cargo binstall reth
+```
 


### PR DESCRIPTION
Adds binary installation support via `binstall` (https://github.com/cargo-bins/cargo-binstall).