### PR TITLE
perf: put all prefix sets in Rc

### DIFF
--- a/crates/trie/benches/prefix_set.rs
+++ b/crates/trie/benches/prefix_set.rs
@@ -7,21 +7,23 @@ use proptest::{
     test_runner::{basic_result_cache, TestRunner},
 };
 use reth_primitives::trie::Nibbles;
-use reth_trie::prefix_set::PrefixSet;
+use reth_trie::prefix_set::PrefixSetMut;
 use std::collections::BTreeSet;
 
+/// Abstractions used for benching
 pub trait PrefixSetAbstraction: Default {
     fn insert(&mut self, key: Nibbles);
     fn contains(&mut self, key: Nibbles) -> bool;
 }
 
-impl PrefixSetAbstraction for PrefixSet {
+/// Abstractions used for benching
+impl PrefixSetAbstraction for PrefixSetMut {
     fn insert(&mut self, key: Nibbles) {
         self.insert(key)
     }
 
     fn contains(&mut self, key: Nibbles) -> bool {
-        PrefixSet::contains(self, key)
+        PrefixSetMut::contains(self, key)
     }
 }
 

--- a/crates/trie/src/prefix_set/loader.rs
+++ b/crates/trie/src/prefix_set/loader.rs
@@ -1,4 +1,4 @@
-use super::PrefixSet;
+use super::PrefixSetMut;
 use derive_more::Deref;
 use reth_db::{
     cursor::DbCursorRO,
@@ -29,10 +29,10 @@ where
     pub fn load(
         self,
         range: RangeInclusive<BlockNumber>,
-    ) -> Result<(PrefixSet, HashMap<H256, PrefixSet>), DatabaseError> {
+    ) -> Result<(PrefixSetMut, HashMap<H256, PrefixSetMut>), DatabaseError> {
         // Initialize prefix sets.
-        let mut account_prefix_set = PrefixSet::default();
-        let mut storage_prefix_set: HashMap<H256, PrefixSet> = HashMap::default();
+        let mut account_prefix_set = PrefixSetMut::default();
+        let mut storage_prefix_set: HashMap<H256, PrefixSetMut> = HashMap::default();
 
         // Walk account changeset and insert account prefixes.
         let mut account_cursor = self.cursor_read::<tables::AccountChangeSet>()?;

--- a/crates/trie/src/walker.rs
+++ b/crates/trie/src/walker.rs
@@ -256,7 +256,10 @@ impl<'a, K: Key + From<Vec<u8>>, C: TrieCursor<K>> TrieWalker<'a, K, C> {
 mod tests {
 
     use super::*;
-    use crate::trie_cursor::{AccountTrieCursor, StorageTrieCursor};
+    use crate::{
+        prefix_set::PrefixSetMut,
+        trie_cursor::{AccountTrieCursor, StorageTrieCursor},
+    };
     use reth_db::{
         cursor::DbCursorRW, tables, test_utils::create_test_rw_db, transaction::DbTxMut,
     };
@@ -378,9 +381,9 @@ mod tests {
         assert_eq!(cursor.key(), None);
 
         // We insert something that's not part of the existing trie/prefix.
-        let mut changed = PrefixSet::default();
+        let mut changed = PrefixSetMut::default();
         changed.insert(&[0xF, 0x1]);
-        let mut cursor = TrieWalker::new(&mut trie, changed);
+        let mut cursor = TrieWalker::new(&mut trie, changed.freeze());
 
         // Root node
         assert_eq!(cursor.key(), Some(Nibbles::from_hex(vec![])));


### PR DESCRIPTION
we were cloning prefixsets in a hot loop:

https://github.com/paradigmxyz/reth/blob/36a659e60f13a40f6ff1f0be738ce5759ac7ff0d/crates/trie/src/trie.rs#L283-L290


this renames the `PrefixSet` to `PrefixSetMut` and adds a `PrefixSet` type that's an Rc to make clones cheap during state root calc