### PR TITLE
perf(trie): post state cursors

### DIFF
--- a/crates/storage/provider/src/post_state/mod.rs
+++ b/crates/storage/provider/src/post_state/mod.rs
@@ -258,7 +258,7 @@ impl PostState {
         &self,
         tx: &'a TX,
     ) -> Result<H256, StateRootError> {
-        let hashed_post_state = self.hash_state_slow();
+        let mut hashed_post_state = self.hash_state_slow().sorted();
         let (account_prefix_set, storage_prefix_set) = hashed_post_state.construct_prefix_sets();
         let hashed_cursor_factory = HashedPostStateCursorFactory::new(tx, &hashed_post_state);
         StateRoot::new(tx)

--- a/crates/storage/provider/src/post_state/mod.rs
+++ b/crates/storage/provider/src/post_state/mod.rs
@@ -258,7 +258,7 @@ impl PostState {
         &self,
         tx: &'a TX,
     ) -> Result<H256, StateRootError> {
-        let mut hashed_post_state = self.hash_state_slow().sorted();
+        let hashed_post_state = self.hash_state_slow().sorted();
         let (account_prefix_set, storage_prefix_set) = hashed_post_state.construct_prefix_sets();
         let hashed_cursor_factory = HashedPostStateCursorFactory::new(tx, &hashed_post_state);
         StateRoot::new(tx)

--- a/crates/storage/provider/src/post_state/mod.rs
+++ b/crates/storage/provider/src/post_state/mod.rs
@@ -209,7 +209,7 @@ impl PostState {
         for (address, storage) in self.storage() {
             let mut hashed_storage = HashedStorage::new(storage.wiped());
             for (slot, value) in &storage.storage {
-                let hashed_slot = H256(slot.to_be_bytes());
+                let hashed_slot = keccak256(H256(slot.to_be_bytes()));
                 if *value == U256::ZERO {
                     hashed_storage.insert_zero_valued_slot(hashed_slot);
                 } else {
@@ -1842,7 +1842,7 @@ mod tests {
             .map(|key| {
                 let account = Account { nonce: 1, balance: U256::from(key), bytecode_hash: None };
                 let storage =
-                    (0..10).map(|key| (H256::from_low_u64_be(key), U256::from(key))).collect();
+                    (1..11).map(|key| (H256::from_low_u64_be(key), U256::from(key))).collect();
                 (Address::from_low_u64_be(key), (account, storage))
             })
             .collect();

--- a/crates/storage/provider/src/post_state/mod.rs
+++ b/crates/storage/provider/src/post_state/mod.rs
@@ -199,9 +199,9 @@ impl PostState {
         for (address, account) in self.accounts() {
             let hashed_address = keccak256(address);
             if let Some(account) = account {
-                hashed_post_state.accounts.push((hashed_address, *account));
+                hashed_post_state.insert_account(hashed_address, *account);
             } else {
-                hashed_post_state.cleared_accounts.insert(hashed_address);
+                hashed_post_state.insert_cleared_account(hashed_address);
             }
         }
 
@@ -211,13 +211,13 @@ impl PostState {
             for (slot, value) in &storage.storage {
                 let hashed_slot = H256(slot.to_be_bytes());
                 if *value == U256::ZERO {
-                    hashed_storage.zero_valued_slots.insert(hashed_slot);
+                    hashed_storage.insert_zero_valued_slot(hashed_slot);
                 } else {
-                    hashed_storage.non_zero_valued_storage.push((hashed_slot, *value));
+                    hashed_storage.insert_non_zero_valued_storage(hashed_slot, *value);
                 }
             }
 
-            hashed_post_state.storages.insert(keccak256(address), hashed_storage);
+            hashed_post_state.insert_hashed_storage(keccak256(address), hashed_storage);
         }
 
         hashed_post_state

--- a/crates/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/src/hashed_cursor/post_state.rs
@@ -323,7 +323,7 @@ where
         // sought key.
         let mut post_state_entry = self.post_state.accounts.get(self.post_state_account_index);
         while let Some((k, _)) = post_state_entry {
-            if k > &last_account {
+            if k > last_account {
                 // Found the next entry in the post state.
                 break
             }
@@ -540,7 +540,7 @@ where
             post_state_entry = storage.non_zero_valued_storage.get(self.post_state_storage_index);
 
             while let Some((k, _)) = post_state_entry {
-                if k > &last_slot {
+                if k > last_slot {
                     // Found the next entry.
                     break
                 }

--- a/crates/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/src/hashed_cursor/post_state.rs
@@ -46,10 +46,16 @@ pub struct HashedPostState {
     /// Map of hashed addresses to hashed storage.
     pub storages: HashMap<H256, HashedStorage>,
     /// Whether the account and storage entries were sorted or not.
-    pub sorted: bool,
+    sorted: bool,
 }
 
 impl HashedPostState {
+    /// Sort and return self.
+    pub fn sorted(mut self) -> Self {
+        self.sort();
+        self
+    }
+
     /// Sort account and storage entries.
     pub fn sort(&mut self) {
         for (_, storage) in self.storages.iter_mut() {

--- a/crates/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/src/hashed_cursor/post_state.rs
@@ -58,12 +58,14 @@ impl HashedPostState {
 
     /// Sort account and storage entries.
     pub fn sort(&mut self) {
-        for (_, storage) in self.storages.iter_mut() {
-            storage.sort_storage();
-        }
+        if !self.sorted {
+            for (_, storage) in self.storages.iter_mut() {
+                storage.sort_storage();
+            }
 
-        self.accounts.sort_unstable_by_key(|(address, _)| *address);
-        self.sorted = true;
+            self.accounts.sort_unstable_by_key(|(address, _)| *address);
+            self.sorted = true;
+        }
     }
 
     /// Construct (PrefixSets)[PrefixSet] from hashed post state.

--- a/crates/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/src/hashed_cursor/post_state.rs
@@ -251,9 +251,9 @@ where
     /// The returned account key is memoized and the cursor remains positioned at that key until
     /// [HashedAccountCursor::seek] or [HashedAccountCursor::next] are called.
     fn seek(&mut self, key: H256) -> Result<Option<(H256, Account)>, reth_db::DatabaseError> {
-        // TODO: remove
-        self.last_account = None;
         debug_assert!(self.post_state.sorted, "`HashedPostState` must be pre-sorted");
+
+        self.last_account = None;
 
         // Take the next account from the post state with the key greater than or equal to the
         // sought key.


### PR DESCRIPTION
## Motivation

Closes #3515, #3580 and _maybe_ #3446.

Addresses the underlying issue of timeouts on new payloads received.

## Investigation

The preliminary investigation separately conducted by @mattsse and myself showed that the validation of a new payload was slowed down by the state root validation. Specifically, it was caused by the unsatisfactory performance of in-memory cursors (`HashedPostStateAccountCursor` & `HashedPostStateStorageCursor`).

 
<img width="1470" alt="Screenshot_2023-06-23_at_16 42 36" src="https://github.com/paradigmxyz/reth/assets/25429261/1a8c5144-65c3-42c5-ade1-8d77b236af75">

<img width="1489" alt="Screenshot_2023-06-22_at_21 05 55" src="https://github.com/paradigmxyz/reth/assets/25429261/14c6823b-67c0-4b6e-84fc-dd3e9ee00f19">

The in-memory cursors are used for constructing the state trie from intermediary nodes (contained in the database) and in-memory state changes aka `PostState` which gets morphed into a `HashedPostState`. 

The `HashedPostSate` internally stored all the changes in `BTreeMap`s: one for account and one for storage state changes. For each account/storage key lookup, the hashed post state cursors iterated through the entire `BTreeMap` until encountering a key that is greater or equal to the one sought. The lookup was done in a hot loop in [`StateRoot::calculate`](https://github.com/paradigmxyz/reth/blob/main/crates/trie/src/trie.rs#L239-L334) (similar story in [`StorageRoot::calculate`](https://github.com/paradigmxyz/reth/blob/7da36e042125397af89b9b477f9292dc676e69f8/crates/trie/src/trie.rs#L467-L492)) resulting in sub-optimal performance.

Additionally, the account and storage `BTreeMap`s contained the cleared (zeroed-out values), which should not necessarily be a part of a sorted collection.

### Why `BTreeMap` was used in the first place?

One of the requirements of the state root calculation is that the state is pre-sorted. `BTreeMap` fulfilled this requirement implicitly and should have displayed satisfactory performance on key lookups (or so I thought).

## Solution

This PR completely changes the internals of `HashedPostState` and hashed post state cursors.

 First, let's take a look at `HashedStorage`:

https://github.com/paradigmxyz/reth/blob/486315770b07be809b0cb31f343927d26d135145/crates/trie/src/hashed_cursor/post_state.rs#L11-L22

The `HashedStorage` distinguishes between zero and non-zero-valued storage entries. The former is only used for a lookup by key. The latter has to be a pre-sorted collection. The non-zero-valued storage entries are now stored in a `Vec` and should be sorted only once.

Now, to the `HashedPostState`:

https://github.com/paradigmxyz/reth/blob/486315770b07be809b0cb31f343927d26d135145/crates/trie/src/hashed_cursor/post_state.rs#L56-L67

The cleared accounts are now not a part of the pre-sorted collection since they are used only for a lookup by key.
The changed accounts are now stored in a `Vec` which should be sorted once.

The hashed post state cursors now contain a supplementary index field to denote the current cursor position within a corresponding collection in `HashedPostState`:

field `post_state_account_index` in `HashedPostStateAccountCursor`
https://github.com/paradigmxyz/reth/blob/486315770b07be809b0cb31f343927d26d135145/crates/trie/src/hashed_cursor/post_state.rs#L181-L194

and field `post_state_storage_index` in `HashedPostStateStorageCursor`
https://github.com/paradigmxyz/reth/blob/486315770b07be809b0cb31f343927d26d135145/crates/trie/src/hashed_cursor/post_state.rs#L342-L357

The indexes are only ever incremented since we know that the state root calculations only seek forward.

These complementary changes alleviate the need to iterate through the entire collection while searching for the next best key while also fulfilling the requirement of a pre-sorted collection.

## Live Testing

Scenario: Node restart after 10min downtime.

_`main`_
block range: #17626114 - gave up at #17626204 (tip was at 17626230 at a time)
server time: 07:21:51 - gave up at 07:33:52 (after ~12m)

_`rkrasiuk/perf-post-state-cursors`_
block range: #17626232 - #17626288 (65 blocks)
server time: 07:44:54 - 07:46:19 (1m 25s)
not a single timeout in LH logs

Additional Context: caught up the node to the tip before starting the downtime on the 2nd branch.