### PR TITLE
fix: use refunds for root call

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/utils.rs
+++ b/crates/revm/revm-inspectors/src/tracing/utils.rs
@@ -23,7 +23,6 @@ pub(crate) fn convert_memory(data: &[u8]) -> Vec<String> {
 
 /// Get the gas used, accounting for refunds
 #[inline]
-#[allow(unused)]
 pub(crate) fn gas_used(spec: SpecId, spent: u64, refunded: u64) -> u64 {
     let refund_quotient = if SpecId::enabled(spec, SpecId::LONDON) { 5 } else { 2 };
     spent - (refunded).min(spent / refund_quotient)


### PR DESCRIPTION
refunds are applied after execution.

the root call's gas_used should include refunds