### PR TITLE
chore: change field TransactionTrace order

### DIFF
--- a/crates/rpc/rpc-types/src/eth/trace/parity.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/parity.rs
@@ -238,12 +238,12 @@ pub enum TraceOutput {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TransactionTrace {
-    pub trace_address: Vec<usize>,
-    pub subtraces: usize,
     #[serde(flatten)]
     pub action: Action,
     #[serde(flatten)]
     pub result: Option<TraceResult>,
+    pub subtraces: usize,
+    pub trace_address: Vec<usize>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
use same order as other impls,
makes it easier to compare different outputs