### PR TITLE
fix(book): change recommended `--authrpc.port` value from 9999 to 8551

### DIFF
--- a/book/run/mainnet.md
+++ b/book/run/mainnet.md
@@ -35,7 +35,7 @@ So one might do:
 RUST_LOG=info reth node \
     --authrpc.jwtsecret /path/to/secret \
     --authrpc.addr 127.0.0.1 \
-    --authrpc.port 9999
+    --authrpc.port 8551
 ```
 
 At this point, our Reth node has started discovery, and even discovered some new peers. But it will not start syncing until you spin up the consensus layer!


### PR DESCRIPTION
We recommend to run Lighthouse with execution endpoint on port 8551 later, which is a bit confusing if people just follow the book: https://github.com/paradigmxyz/reth/blob/3c292b460294e3c4fa0dcc23c08f7334bdecf14c/book/run/mainnet.md?plain=1#L49-L54