### PR TITLE
chore(prometheus): add `localhost:9001` scrape target

### DIFF
--- a/book/installation/docker.md
+++ b/book/installation/docker.md
@@ -63,11 +63,11 @@ To run Reth with Docker, run:
 docker run \
     -v rethdata:/root/.local/share/reth/db \
     -d \
-    -p 9000:9000 \
+    -p 9001:9001 \
     --name reth \
     reth:local \
     node \
-    --metrics 0.0.0.0:9000
+    --metrics 0.0.0.0:9001
 ```
 
 The above command will create a container named `reth` and a named volume called `rethdata` for data persistence.

--- a/etc/prometheus/prometheus.yml
+++ b/etc/prometheus/prometheus.yml
@@ -3,4 +3,4 @@ scrape_configs:
     metrics_path: "/"
     scrape_interval: 5s
     static_configs:
-      - targets: ['reth:9001']
+      - targets: ['reth:9001', 'localhost:9001']


### PR DESCRIPTION
Current default Prometheus config doesn't work if Reth is running standalone, without Docker, as we describe in the book: https://paradigmxyz.github.io/reth/run/observability.html. Node exposes port 9001 on localhost, and the prometheus.yml contains only `reth:9001` target for Docker.

I added another target for `localhost:9001`, so Prometheus will always have one target that's DOWN, but also will work without adjusting the config.