### PR TITLE
feat(pruning): prune `TxSenders` during pipeline 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5576,6 +5576,7 @@ dependencies = [
  "itertools",
  "parking_lot 0.12.1",
  "pin-project",
+ "rayon",
  "reth-db",
  "reth-interfaces",
  "reth-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5538,6 +5538,7 @@ dependencies = [
  "impl-serde",
  "modular-bitfield",
  "once_cell",
+ "paste",
  "plain_hasher",
  "pprof",
  "proptest",

--- a/bin/reth/src/chain/import.rs
+++ b/bin/reth/src/chain/import.rs
@@ -159,10 +159,11 @@ impl ImportCommand {
         let (tip_tx, tip_rx) = watch::channel(H256::zero());
         let factory = reth_revm::Factory::new(self.chain.clone());
 
+        let max_block = file_client.max_block().unwrap_or(0);
         let mut pipeline = Pipeline::builder()
             .with_tip_sender(tip_tx)
             // we want to sync all blocks the file client provides or 0 if empty
-            .with_max_block(file_client.max_block().unwrap_or(0))
+            .with_max_block(max_block)
             .add_stages(
                 DefaultStages::new(
                     HeaderSyncMode::Tip(tip_rx),
@@ -184,6 +185,7 @@ impl ImportCommand {
                         max_blocks: config.stages.execution.max_blocks,
                         max_changes: config.stages.execution.max_changes,
                     },
+                    config.prune.map(|p| p.into_targets(Some(max_block))).unwrap_or_default(),
                 )),
             )
             .build(db, self.chain.clone());

--- a/bin/reth/src/chain/import.rs
+++ b/bin/reth/src/chain/import.rs
@@ -176,9 +176,10 @@ impl ImportCommand {
                     TotalDifficultyStage::new(consensus.clone())
                         .with_commit_threshold(config.stages.total_difficulty.commit_threshold),
                 )
-                .set(SenderRecoveryStage {
-                    commit_threshold: config.stages.sender_recovery.commit_threshold,
-                })
+                .set(SenderRecoveryStage::new(
+                    config.stages.sender_recovery.commit_threshold,
+                    config.prune.map(|p| p.into_targets(Some(max_block))).unwrap_or_default(),
+                ))
                 .set(ExecutionStage::new(
                     factory,
                     ExecutionStageThresholds {

--- a/bin/reth/src/debug_cmd/execution.rs
+++ b/bin/reth/src/debug_cmd/execution.rs
@@ -138,6 +138,7 @@ impl Command {
                 )
                 .set(SenderRecoveryStage {
                     commit_threshold: stage_conf.sender_recovery.commit_threshold,
+                    pruning: config.prune.map(|p| p.into_targets(None)).unwrap_or_default(),
                 })
                 .set(ExecutionStage::new(
                     factory,

--- a/bin/reth/src/debug_cmd/execution.rs
+++ b/bin/reth/src/debug_cmd/execution.rs
@@ -142,6 +142,7 @@ impl Command {
                 .set(ExecutionStage::new(
                     factory,
                     ExecutionStageThresholds { max_blocks: None, max_changes: None },
+                    config.prune.map(|p| p.into_targets(None)).unwrap_or_default(),
                 )),
             )
             .build(db, self.chain.clone());

--- a/bin/reth/src/debug_cmd/merkle.rs
+++ b/bin/reth/src/debug_cmd/merkle.rs
@@ -8,7 +8,7 @@ use reth_db::{cursor::DbCursorRO, init_db, tables, transaction::DbTx};
 use reth_primitives::{
     fs,
     stage::{StageCheckpoint, StageId},
-    ChainSpec,
+    ChainSpec, PruneTargets,
 };
 use reth_provider::{ProviderFactory, StageCheckpointReader};
 use reth_stages::{
@@ -96,6 +96,7 @@ impl Command {
         let mut execution_stage = ExecutionStage::new(
             factory,
             ExecutionStageThresholds { max_blocks: Some(1), max_changes: None },
+            PruneTargets::all(),
         );
 
         let mut account_hashing_stage = AccountHashingStage::default();

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -718,6 +718,7 @@ impl Command {
                         max_blocks: stage_config.execution.max_blocks,
                         max_changes: stage_config.execution.max_changes,
                     },
+                    config.prune.map(|p| p.into_targets(None)).unwrap_or_default(),
                 ))
                 .set(AccountHashingStage::new(
                     stage_config.account_hashing.clean_threshold,

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -709,9 +709,10 @@ impl Command {
                     TotalDifficultyStage::new(consensus)
                         .with_commit_threshold(stage_config.total_difficulty.commit_threshold),
                 )
-                .set(SenderRecoveryStage {
-                    commit_threshold: stage_config.sender_recovery.commit_threshold,
-                })
+                .set(SenderRecoveryStage::new(
+                    stage_config.sender_recovery.commit_threshold,
+                    config.prune.map(|p| p.into_targets(None)).unwrap_or_default(),
+                ))
                 .set(ExecutionStage::new(
                     factory,
                     ExecutionStageThresholds {

--- a/bin/reth/src/stage/dump/merkle.rs
+++ b/bin/reth/src/stage/dump/merkle.rs
@@ -2,7 +2,7 @@ use super::setup;
 use crate::utils::DbTool;
 use eyre::Result;
 use reth_db::{database::Database, table::TableImporter, tables, DatabaseEnv};
-use reth_primitives::{stage::StageCheckpoint, BlockNumber, ChainSpec};
+use reth_primitives::{stage::StageCheckpoint, BlockNumber, ChainSpec, PruneTargets};
 use reth_provider::ProviderFactory;
 use reth_stages::{
     stages::{
@@ -70,6 +70,7 @@ async fn unwind_and_copy<DB: Database>(
     let mut exec_stage = ExecutionStage::new(
         reth_revm::Factory::new(db_tool.chain.clone()),
         ExecutionStageThresholds { max_blocks: Some(u64::MAX), max_changes: None },
+        PruneTargets::all(),
     );
 
     exec_stage

--- a/bin/reth/src/stage/run.rs
+++ b/bin/reth/src/stage/run.rs
@@ -202,6 +202,7 @@ impl Command {
                                 max_blocks: Some(batch_size),
                                 max_changes: None,
                             },
+                            config.prune.map(|p| p.into_targets(None)).unwrap_or_default(),
                         )),
                         None,
                     )

--- a/bin/reth/src/stage/run.rs
+++ b/bin/reth/src/stage/run.rs
@@ -192,7 +192,13 @@ impl Command {
 
                     (Box::new(stage), None)
                 }
-                StageEnum::Senders => (Box::new(SenderRecoveryStage::new(batch_size)), None),
+                StageEnum::Senders => (
+                    Box::new(SenderRecoveryStage::new(
+                        batch_size,
+                        config.prune.map(|p| p.into_targets(None)).unwrap_or_default(),
+                    )),
+                    None,
+                ),
                 StageEnum::Execution => {
                     let factory = reth_revm::Factory::new(self.chain.clone());
                     (

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -5,7 +5,7 @@ use reth_downloaders::{
     headers::reverse_headers::ReverseHeadersDownloaderBuilder,
 };
 use reth_network::{NetworkConfigBuilder, PeersConfig, SessionsConfig};
-use reth_primitives::PruneMode;
+use reth_primitives::{PruneMode, PruneTarget, PruneTargets};
 use secp256k1::SecretKey;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -291,6 +291,31 @@ pub struct PruneConfig {
 impl Default for PruneConfig {
     fn default() -> Self {
         Self { block_interval: 10, parts: PruneParts::default() }
+    }
+}
+
+impl PruneConfig {
+    /// Converts a [`PruneConfig`] into an usuable [`PruneTargets`].
+    pub fn into_targets(&self, head: Option<u64>) -> PruneTargets {
+        PruneTargets {
+            sender_recovery: self
+                .parts
+                .sender_recovery
+                .map(|p| PruneTarget::new(p, head.unwrap_or_default())),
+            transaction_lookup: self
+                .parts
+                .transaction_lookup
+                .map(|p| PruneTarget::new(p, head.unwrap_or_default())),
+            receipts: self.parts.receipts.map(|p| PruneTarget::new(p, head.unwrap_or_default())),
+            account_history: self
+                .parts
+                .account_history
+                .map(|p| PruneTarget::new(p, head.unwrap_or_default())),
+            storage_history: self
+                .parts
+                .storage_history
+                .map(|p| PruneTarget::new(p, head.unwrap_or_default())),
+        }
     }
 }
 

--- a/crates/interfaces/src/provider.rs
+++ b/crates/interfaces/src/provider.rs
@@ -94,4 +94,7 @@ pub enum ProviderError {
         /// Block hash
         block_hash: BlockHash,
     },
+    /// Failed to recover signer from transaction. Relevant when pruning is involved.
+    #[error("Failed to recover signer from transaction.")]
+    SenderRecoveryFailure(TxNumber),
 }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -56,6 +56,7 @@ url = "2.3"
 impl-serde = "0.4.0"
 once_cell = "1.17.0"
 zstd = { version = "0.12", features = ["experimental"] }
+paste = "1.0"
 
 # proof related
 triehash = "0.8"

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -78,7 +78,7 @@ pub use net::{
     SEPOLIA_BOOTNODES,
 };
 pub use peer::{PeerId, WithPeerId};
-pub use prune::{PruneCheckpoint, PruneMode};
+pub use prune::{PruneCheckpoint, PruneMode, PruneTarget, PruneTargets};
 pub use receipt::{Receipt, ReceiptWithBloom, ReceiptWithBloomRef};
 pub use revm_primitives::JumpMap;
 pub use serde_helper::JsonU256;

--- a/crates/primitives/src/prune/mod.rs
+++ b/crates/primitives/src/prune/mod.rs
@@ -1,5 +1,7 @@
 mod checkpoint;
 mod mode;
+mod target;
 
 pub use checkpoint::PruneCheckpoint;
 pub use mode::PruneMode;
+pub use target::{PruneTarget, PruneTargets};

--- a/crates/primitives/src/prune/target.rs
+++ b/crates/primitives/src/prune/target.rs
@@ -2,7 +2,7 @@ use crate::{BlockNumber, PruneMode};
 use paste::paste;
 
 /// Prune target.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum PruneTarget {
     /// Prune all blocks, i.e. not save any data.
     All,
@@ -30,7 +30,7 @@ impl PruneTarget {
 }
 
 /// Pruning configuration for every part of the data that can be pruned.
-#[derive(Debug, Clone, Default, Copy)]
+#[derive(Debug, Clone, Default, Copy, Eq, PartialEq)]
 pub struct PruneTargets {
     /// Sender Recovery pruning configuration.
     pub sender_recovery: Option<PruneTarget>,

--- a/crates/primitives/src/prune/target.rs
+++ b/crates/primitives/src/prune/target.rs
@@ -57,21 +57,20 @@ macro_rules! should_prune_method {
                 }
             }
         )+
+
+        /// Sets pruning to all targets.
+        pub fn all() -> PruneTargets {
+            PruneTargets {
+                $(
+                    $config: Some(PruneTarget::All),
+                )+
+            }
+        }
+
     };
 }
 
 impl PruneTargets {
-    /// Sets pruning to all targets.
-    pub fn all() -> PruneTargets {
-        PruneTargets {
-            sender_recovery: Some(PruneTarget::All),
-            transaction_lookup: Some(PruneTarget::All),
-            receipts: Some(PruneTarget::All),
-            account_history: Some(PruneTarget::All),
-            storage_history: Some(PruneTarget::All),
-        }
-    }
-
     /// Sets pruning to no target.
     pub fn none() -> PruneTargets {
         PruneTargets::default()

--- a/crates/primitives/src/prune/target.rs
+++ b/crates/primitives/src/prune/target.rs
@@ -1,0 +1,95 @@
+use crate::{BlockNumber, PruneMode};
+use paste::paste;
+
+/// Prune target.
+#[derive(Debug, Clone, Copy)]
+pub enum PruneTarget {
+    /// Prune all blocks, i.e. not save any data.
+    All,
+    /// Prune blocks up to the specified block number, inclusive.
+    Block(BlockNumber),
+}
+
+impl PruneTarget {
+    /// Returns new target to prune towards, according to stage prune mode [PruneMode]
+    /// and current head [BlockNumber].
+    pub fn new(prune_mode: PruneMode, head: BlockNumber) -> Self {
+        match prune_mode {
+            PruneMode::Full => PruneTarget::All,
+            PruneMode::Distance(distance) => {
+                Self::Block(head.saturating_sub(distance).saturating_sub(1))
+            }
+            PruneMode::Before(before_block) => Self::Block(before_block.saturating_sub(1)),
+        }
+    }
+
+    /// Returns true if the target is [PruneTarget::All], i.e. prune all blocks.
+    pub fn is_all(&self) -> bool {
+        matches!(self, Self::All)
+    }
+}
+
+/// Pruning configuration for every part of the data that can be pruned.
+#[derive(Debug, Clone, Default, Copy)]
+pub struct PruneTargets {
+    /// Sender Recovery pruning configuration.
+    pub sender_recovery: Option<PruneTarget>,
+    /// Transaction Lookup pruning configuration.
+    pub transaction_lookup: Option<PruneTarget>,
+    /// Receipts pruning configuration.
+    pub receipts: Option<PruneTarget>,
+    /// Account History pruning configuration.
+    pub account_history: Option<PruneTarget>,
+    /// Storage History pruning configuration.
+    pub storage_history: Option<PruneTarget>,
+}
+
+macro_rules! should_prune_method {
+    ($($config:ident),+) => {
+        $(
+            paste! {
+                #[allow(missing_docs)]
+                pub fn [<should_prune_ $config>](&self, block: BlockNumber) -> bool {
+                    if let Some(config) = &self.$config {
+                        return self.should_prune(config, block)
+                    }
+                    false
+                }
+            }
+        )+
+    };
+}
+
+impl PruneTargets {
+    /// Sets pruning to all targets.
+    pub fn all() -> PruneTargets {
+        PruneTargets {
+            sender_recovery: Some(PruneTarget::All),
+            transaction_lookup: Some(PruneTarget::All),
+            receipts: Some(PruneTarget::All),
+            account_history: Some(PruneTarget::All),
+            storage_history: Some(PruneTarget::All),
+        }
+    }
+
+    /// Sets pruning to no target.
+    pub fn none() -> PruneTargets {
+        PruneTargets::default()
+    }
+
+    /// Check if target block should be pruned
+    pub fn should_prune(&self, target: &PruneTarget, block: BlockNumber) -> bool {
+        match target {
+            PruneTarget::All => true,
+            PruneTarget::Block(n) => *n >= block,
+        }
+    }
+
+    should_prune_method!(
+        sender_recovery,
+        transaction_lookup,
+        receipts,
+        account_history,
+        storage_history
+    );
+}

--- a/crates/stages/benches/criterion.rs
+++ b/crates/stages/benches/criterion.rs
@@ -51,7 +51,7 @@ fn senders(c: &mut Criterion) {
     group.sample_size(10);
 
     for batch in [1000usize, 10_000, 100_000, 250_000] {
-        let stage = SenderRecoveryStage { commit_threshold: DEFAULT_NUM_BLOCKS };
+        let stage = SenderRecoveryStage::new(DEFAULT_NUM_BLOCKS, PruneTargets::none());
         let label = format!("SendersRecovery-batch-{batch}");
 
         measure_stage(&mut group, setup::stage_unwind, stage, 0..DEFAULT_NUM_BLOCKS, label);

--- a/crates/stages/benches/criterion.rs
+++ b/crates/stages/benches/criterion.rs
@@ -5,7 +5,7 @@ use criterion::{
 use pprof::criterion::{Output, PProfProfiler};
 use reth_db::DatabaseEnv;
 use reth_interfaces::test_utils::TestConsensus;
-use reth_primitives::{stage::StageCheckpoint, MAINNET};
+use reth_primitives::{stage::StageCheckpoint, PruneTargets, MAINNET};
 use reth_provider::ProviderFactory;
 use reth_stages::{
     stages::{MerkleStage, SenderRecoveryStage, TotalDifficultyStage, TransactionLookupStage},

--- a/crates/stages/src/stage.rs
+++ b/crates/stages/src/stage.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use reth_db::{cursor::DbCursorRO, database::Database, tables, transaction::DbTx};
 use reth_primitives::{
     stage::{StageCheckpoint, StageId},
-    BlockNumber, PruneMode, TxNumber,
+    BlockNumber, TxNumber,
 };
 use reth_provider::{BlockReader, DatabaseProviderRW, ProviderError};
 use std::{
@@ -193,32 +193,4 @@ pub trait Stage<DB: Database>: Send + Sync {
         provider: &DatabaseProviderRW<'_, &DB>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError>;
-}
-
-/// Prune target.
-#[derive(Debug, Clone, Copy)]
-pub enum PruneTarget {
-    /// Prune all blocks, i.e. not save any data.
-    All,
-    /// Prune blocks up to the specified block number, inclusive.
-    Block(BlockNumber),
-}
-
-impl PruneTarget {
-    /// Returns new target to prune towards, according to stage prune mode [PruneMode]
-    /// and current head [BlockNumber].
-    pub fn new(prune_mode: PruneMode, head: BlockNumber) -> Self {
-        match prune_mode {
-            PruneMode::Full => PruneTarget::All,
-            PruneMode::Distance(distance) => {
-                Self::Block(head.saturating_sub(distance).saturating_sub(1))
-            }
-            PruneMode::Before(before_block) => Self::Block(before_block.saturating_sub(1)),
-        }
-    }
-
-    /// Returns true if the target is [PruneTarget::All], i.e. prune all blocks.
-    pub fn is_all(&self) -> bool {
-        matches!(self, Self::All)
-    }
 }

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -428,7 +428,8 @@ mod tests {
     use reth_db::{models::AccountBeforeTx, test_utils::create_test_rw_db};
     use reth_primitives::{
         hex_literal::hex, keccak256, stage::StageUnitCheckpoint, Account, Bytecode,
-        ChainSpecBuilder, PruneTargets, SealedBlock, StorageEntry, H160, H256, MAINNET, U256,
+        ChainSpecBuilder, PruneTarget, PruneTargets, SealedBlock, StorageEntry, H160, H256,
+        MAINNET, U256,
     };
     use reth_provider::{AccountReader, BlockWriter, ProviderFactory, ReceiptProvider};
     use reth_revm::Factory;
@@ -895,5 +896,84 @@ mod tests {
                 )
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn test_prune() {
+        let test_tx = TestTransaction::default();
+        let factory = Arc::new(ProviderFactory::new(test_tx.tx.as_ref(), MAINNET.clone()));
+
+        let provider = factory.provider_rw().unwrap();
+        let input = ExecInput {
+            target: Some(1),
+            /// The progress of this stage the last time it was executed.
+            checkpoint: None,
+        };
+        let mut genesis_rlp = hex!("f901faf901f5a00000000000000000000000000000000000000000000000000000000000000000a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347942adc25665018aa1fe0e6bc666dac8fc2697ff9baa045571b40ae66ca7480791bbb2887286e4e4c4b1b298b191c889d6959023a32eda056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b901000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000083020000808502540be400808000a00000000000000000000000000000000000000000000000000000000000000000880000000000000000c0c0").as_slice();
+        let genesis = SealedBlock::decode(&mut genesis_rlp).unwrap();
+        let mut block_rlp = hex!("f90262f901f9a075c371ba45999d87f4542326910a11af515897aebce5265d3f6acd1f1161f82fa01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347942adc25665018aa1fe0e6bc666dac8fc2697ff9baa098f2dcd87c8ae4083e7017a05456c14eea4b1db2032126e27b3b1563d57d7cc0a08151d548273f6683169524b66ca9fe338b9ce42bc3540046c828fd939ae23bcba03f4e5c2ec5b2170b711d97ee755c160457bb58d8daa338e835ec02ae6860bbabb901000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000083020000018502540be40082a8798203e800a00000000000000000000000000000000000000000000000000000000000000000880000000000000000f863f861800a8405f5e10094100000000000000000000000000000000000000080801ba07e09e26678ed4fac08a249ebe8ed680bf9051a5e14ad223e4b2b9d26e0208f37a05f6e3f188e3e6eab7d7d3b6568f5eac7d687b08d307d3154ccd8c87b4630509bc0").as_slice();
+        let block = SealedBlock::decode(&mut block_rlp).unwrap();
+        provider.insert_block(genesis, None).unwrap();
+        provider.insert_block(block.clone(), None).unwrap();
+        provider.commit().unwrap();
+
+        // insert pre state
+        let provider = factory.provider_rw().unwrap();
+        let code = hex!("5a465a905090036002900360015500");
+        let code_hash = keccak256(hex!("5a465a905090036002900360015500"));
+        provider
+            .tx_ref()
+            .put::<tables::PlainAccountState>(
+                H160(hex!("1000000000000000000000000000000000000000")),
+                Account { nonce: 0, balance: U256::ZERO, bytecode_hash: Some(code_hash) },
+            )
+            .unwrap();
+        provider
+            .tx_ref()
+            .put::<tables::PlainAccountState>(
+                H160(hex!("a94f5374fce5edbc8e2a8697c15331677e6ebf0b")),
+                Account {
+                    nonce: 0,
+                    balance: U256::from(0x3635c9adc5dea00000u128),
+                    bytecode_hash: None,
+                },
+            )
+            .unwrap();
+        provider
+            .tx_ref()
+            .put::<tables::Bytecodes>(code_hash, Bytecode::new_raw(code.to_vec().into()))
+            .unwrap();
+        provider.commit().unwrap();
+
+        let check_pruning = |factory: Arc<ProviderFactory<_>>,
+                             pruning: PruneTargets,
+                             expect_num_receipts: usize| async move {
+            let provider = factory.provider_rw().unwrap();
+
+            let mut execution_stage = ExecutionStage::new(
+                Factory::new(Arc::new(ChainSpecBuilder::mainnet().berlin_activated().build())),
+                ExecutionStageThresholds { max_blocks: Some(100), max_changes: None },
+                pruning,
+            );
+
+            execution_stage.execute(&provider, input).await.unwrap();
+            assert_eq!(
+                provider.receipts_by_block(1.into()).unwrap().unwrap().len(),
+                expect_num_receipts
+            );
+        };
+
+        let mut prune = PruneTargets::none();
+
+        check_pruning(factory.clone(), prune, 1).await;
+
+        prune.receipts = Some(PruneTarget::All);
+        check_pruning(factory.clone(), prune, 0).await;
+
+        prune.receipts = Some(PruneTarget::Block(0));
+        check_pruning(factory.clone(), prune, 1).await;
+
+        prune.receipts = Some(PruneTarget::Block(1));
+        check_pruning(factory.clone(), prune, 0).await;
     }
 }

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -29,6 +29,7 @@ itertools = "0.10"
 pin-project = { workspace = true }
 derive_more = "0.99"
 parking_lot = "0.12"
+rayon = "1.6.0"
 
 # test-utils
 reth-rlp = { workspace = true, optional = true }


### PR DESCRIPTION
closes #3557 

Adds sender recovery pruning during execution stage

blocked by https://github.com/paradigmxyz/reth/pull/3585