### PR TITLE
fix: correct types in `libmdbx-rs` for windows

### DIFF
--- a/crates/storage/libmdbx-rs/src/cursor.rs
+++ b/crates/storage/libmdbx-rs/src/cursor.rs
@@ -11,7 +11,7 @@ use ffi::{
     MDBX_NEXT_MULTIPLE, MDBX_NEXT_NODUP, MDBX_PREV, MDBX_PREV_DUP, MDBX_PREV_MULTIPLE,
     MDBX_PREV_NODUP, MDBX_SET, MDBX_SET_KEY, MDBX_SET_LOWERBOUND, MDBX_SET_RANGE,
 };
-use libc::{c_uint, c_void};
+use libc::c_void;
 use parking_lot::Mutex;
 use std::{borrow::Cow, fmt, marker::PhantomData, mem, ptr, rc::Rc, result};
 
@@ -709,7 +709,7 @@ where
         cursor: &'cur mut Cursor<'txn, K>,
 
         /// The first operation to perform when the consumer calls Iter.next().
-        op: c_uint,
+        op: MDBX_cursor_op,
 
         _marker: PhantomData<fn(&'txn (Key, Value))>,
     },
@@ -722,7 +722,7 @@ where
     Value: TableObject<'txn>,
 {
     /// Creates a new iterator backed by the given cursor.
-    fn new(cursor: &'cur mut Cursor<'txn, K>, op: c_uint) -> Self {
+    fn new(cursor: &'cur mut Cursor<'txn, K>, op: MDBX_cursor_op) -> Self {
         IterDup::Ok { cursor, op, _marker: PhantomData }
     }
 }

--- a/crates/storage/libmdbx-rs/src/database.rs
+++ b/crates/storage/libmdbx-rs/src/database.rs
@@ -4,7 +4,7 @@ use crate::{
     transaction::{txn_execute, TransactionKind},
     Transaction,
 };
-use libc::c_uint;
+use ffi::MDBX_db_flags_t;
 use std::{ffi::CString, marker::PhantomData, ptr};
 
 /// A handle to an individual database in an environment.
@@ -24,7 +24,7 @@ impl<'txn> Database<'txn> {
     pub(crate) fn new<'env, K: TransactionKind, E: EnvironmentKind>(
         txn: &'txn Transaction<'env, K, E>,
         name: Option<&str>,
-        flags: c_uint,
+        flags: MDBX_db_flags_t,
     ) -> Result<Self> {
         let c_name = name.map(|n| CString::new(n).unwrap());
         let name_ptr = if let Some(c_name) = &c_name { c_name.as_ptr() } else { ptr::null() };

--- a/crates/storage/libmdbx-rs/src/flags.rs
+++ b/crates/storage/libmdbx-rs/src/flags.rs
@@ -1,6 +1,5 @@
 use bitflags::bitflags;
 use ffi::*;
-use libc::c_uint;
 
 /// MDBX sync mode
 #[derive(Clone, Copy, Debug)]
@@ -188,7 +187,7 @@ impl EnvironmentFlags {
 bitflags! {
     #[doc="Database options."]
     #[derive(Default)]
-    pub struct DatabaseFlags: c_uint {
+    pub struct DatabaseFlags: MDBX_env_flags_t {
         const REVERSE_KEY = MDBX_REVERSEKEY;
         const DUP_SORT = MDBX_DUPSORT;
         const INTEGER_KEY = MDBX_INTEGERKEY;
@@ -203,7 +202,7 @@ bitflags! {
 bitflags! {
     #[doc="Write options."]
     #[derive(Default)]
-    pub struct WriteFlags: c_uint {
+    pub struct WriteFlags: MDBX_env_flags_t {
         const UPSERT = MDBX_UPSERT;
         const NO_OVERWRITE = MDBX_NOOVERWRITE;
         const NO_DUP_DATA = MDBX_NODUPDATA;

--- a/crates/storage/libmdbx-rs/src/transaction.rs
+++ b/crates/storage/libmdbx-rs/src/transaction.rs
@@ -193,6 +193,9 @@ where
                 ffi::mdbx_dbi_flags_ex(txn, db.dbi(), &mut flags, ptr::null_mut())
             }))?;
         }
+
+        // The types are not the same on Windows. Great!
+        #[cfg_attr(not(windows), allow(clippy::useless_conversion))]
         Ok(DatabaseFlags::from_bits_truncate(flags.try_into().unwrap()))
     }
 

--- a/crates/storage/libmdbx-rs/src/transaction.rs
+++ b/crates/storage/libmdbx-rs/src/transaction.rs
@@ -193,7 +193,7 @@ where
                 ffi::mdbx_dbi_flags_ex(txn, db.dbi(), &mut flags, ptr::null_mut())
             }))?;
         }
-        Ok(DatabaseFlags::from_bits_truncate(flags))
+        Ok(DatabaseFlags::from_bits_truncate(flags.try_into().unwrap()))
     }
 
     /// Retrieves database statistics.


### PR DESCRIPTION
For some (unknown to me) reason `libc::c_uint` was simultaneously `u32` and `i32` when building on Windows. Using the types from the generated FFI bindings solves this.

For future reference, this is how I compiled on Windows:

I installed clang using `winget install LLVM.LLVM` (for bindgen). Rust says this about my environment:

```
rustc -vV

rustc 1.70.0 (90c541806 2023-05-31)
binary: rustc
[..]
host: x86_64-pc-windows-msvc
release: 1.70.0
LLVM version: 16.0.2
```

This also highlights that we were able to build for Windows in our release workflow when we probably shouldn't have been able to. Thus, the underlying cause of why reth doesn't work on Windows is probably that the mdbx-sys compile is not being configured correctly (e.g. missing `WIN32`/`WIN64` symbols). I will address this separately.

Compiling on Windows with these changes enables me to run the node:

![image](https://github.com/paradigmxyz/reth/assets/8862627/e8914943-21a5-429c-b73e-483707e1f471)
