### PR TITLE
docs: note that only wsl2 works

### DIFF
--- a/book/installation/source.md
+++ b/book/installation/source.md
@@ -1,6 +1,10 @@
 # Build from Source
 
-You can build Reth on Linux, macOS, and Windows WSL. 
+You can build Reth on Linux, macOS, and Windows WSL2.
+
+> **Note**
+>
+> Reth does **not** work on Windows WSL1.
 
 ## Dependencies
 


### PR DESCRIPTION
I successfully ran on WSL2, but WSL1 appears to be broken. From MDBX notes:

>libmdbx could be used in WSL2 but NOT in WSL1 environment. This is a consequence of the fundamental shortcomings of WSL1 and cannot be fixed. To avoid data loss, libmdbx returns the ENOLCK (37, "No record locks available") error when opening the database in a WSL1 environment.