### PR TITLE
feat: add error field to parity transaction traces

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/types.rs
+++ b/crates/revm/revm-inspectors/src/tracing/types.rs
@@ -6,8 +6,7 @@ use reth_rpc_types::trace::{
     geth::{CallFrame, CallLogFrame, GethDefaultTracingOptions, StructLog},
     parity::{
         Action, ActionType, CallAction, CallOutput, CallType, ChangedType, CreateAction,
-        CreateOutput, Delta, SelfdestructAction, StateDiff, TraceOutput, TraceResult,
-        TransactionTrace,
+        CreateOutput, Delta, SelfdestructAction, StateDiff, TraceOutput, TransactionTrace,
     },
 };
 use revm::interpreter::{
@@ -321,9 +320,10 @@ impl CallTraceNode {
     /// Converts this node into a parity `TransactionTrace`
     pub(crate) fn parity_transaction_trace(&self, trace_address: Vec<usize>) -> TransactionTrace {
         let action = self.parity_action();
-        let output = TraceResult::parity_success(self.parity_trace_output());
+        let output = self.parity_trace_output();
         TransactionTrace {
             action,
+            error: None,
             result: Some(output),
             trace_address,
             subtraces: self.children.len(),

--- a/crates/rpc/rpc-types/src/eth/trace/parity.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/parity.rs
@@ -10,23 +10,6 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-/// Result type for parity style transaction trace
-pub type TraceResult = crate::trace::common::TraceResult<TraceOutput, String>;
-
-// === impl TraceResult ===
-
-impl TraceResult {
-    /// Wraps the result type in a [TraceResult::Success] variant
-    pub fn parity_success(result: TraceOutput) -> Self {
-        TraceResult::Success { result }
-    }
-
-    /// Wraps the result type in a [TraceResult::Error] variant
-    pub fn parity_error(error: String) -> Self {
-        TraceResult::Error { error }
-    }
-}
-
 /// Different Trace diagnostic targets.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -241,7 +224,9 @@ pub struct TransactionTrace {
     #[serde(flatten)]
     pub action: Action,
     #[serde(flatten)]
-    pub result: Option<TraceResult>,
+    pub error: Option<String>,
+    #[serde(flatten)]
+    pub result: Option<TraceOutput>,
     pub subtraces: usize,
     pub trace_address: Vec<usize>,
 }

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -635,6 +635,7 @@ fn reward_trace(header: &SealedHeader, reward: RewardAction) -> LocalizedTransac
             trace_address: vec![],
             subtraces: 0,
             action: Action::Reward(reward),
+            error: None,
             result: None,
         },
     }


### PR DESCRIPTION
Closes #3600. 

Removed TraceResult wrapper type and added explicit Error field to parity TransactionTrace.