### PR TITLE
chore: remove network-api test-utils feature

### DIFF
--- a/crates/net/network-api/Cargo.toml
+++ b/crates/net/network-api/Cargo.toml
@@ -25,4 +25,3 @@ tokio = { workspace = true, features = ["sync"] }
 [features]
 default = ["serde"]
 serde = ["dep:serde"]
-test-utils = []

--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -32,9 +32,8 @@ pub mod error;
 /// Reputation score
 pub mod reputation;
 
-#[cfg(feature = "test-utils")]
-/// Implementation of network traits for testing purposes.
-pub mod test_utils;
+/// Implementation of network traits for that does nothing.
+pub mod noop;
 
 /// Provides general purpose information about the network.
 #[async_trait]

--- a/crates/net/network-api/src/noop.rs
+++ b/crates/net/network-api/src/noop.rs
@@ -1,3 +1,8 @@
+//! A network implementation that does nothing.
+//!
+//! This is useful for wiring components together that don't require network but still need to be
+//! generic over it.
+
 use crate::{
     NetworkError, NetworkInfo, PeerKind, Peers, PeersInfo, Reputation, ReputationChangeKind,
 };
@@ -11,6 +16,7 @@ use std::net::{IpAddr, SocketAddr};
 ///
 /// Intended for testing purposes where network is not used.
 #[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct NoopNetwork;
 
 #[async_trait]

--- a/crates/rpc/rpc-builder/Cargo.toml
+++ b/crates/rpc/rpc-builder/Cargo.toml
@@ -39,7 +39,7 @@ reth-tracing = { path = "../../tracing" }
 reth-rpc-api = { path = "../rpc-api", features = ["client"] }
 reth-transaction-pool = { workspace = true, features = ["test-utils"] }
 reth-provider = { workspace = true, features = ["test-utils"] }
-reth-network-api = { workspace = true, features = ["test-utils"] }
+reth-network-api = { workspace = true }
 reth-interfaces = { workspace = true, features = ["test-utils"] }
 reth-beacon-consensus = { path = "../../consensus/beacon" }
 reth-payload-builder = { workspace = true, features = ["test-utils"] }

--- a/crates/rpc/rpc-builder/tests/it/utils.rs
+++ b/crates/rpc/rpc-builder/tests/it/utils.rs
@@ -101,7 +101,7 @@ pub fn test_rpc_builder() -> RpcModuleBuilder<
     RpcModuleBuilder::default()
         .with_provider(NoopProvider::default())
         .with_pool(testing_pool())
-        .with_network(NoopNetwork)
+        .with_network(NoopNetwork::default())
         .with_executor(TokioTaskExecutor::default())
         .with_events(TestCanonStateSubscriptions::default())
 }

--- a/crates/rpc/rpc-builder/tests/it/utils.rs
+++ b/crates/rpc/rpc-builder/tests/it/utils.rs
@@ -1,5 +1,5 @@
 use reth_beacon_consensus::BeaconConsensusEngineHandle;
-use reth_network_api::test_utils::NoopNetwork;
+use reth_network_api::noop::NoopNetwork;
 use reth_payload_builder::test_utils::spawn_test_payload_service;
 use reth_primitives::MAINNET;
 use reth_provider::test_utils::{NoopProvider, TestCanonStateSubscriptions};

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -18,7 +18,7 @@ reth-rlp = { workspace = true }
 reth-rpc-types = { workspace = true }
 reth-provider = { workspace = true, features = ["test-utils"] }
 reth-transaction-pool = { workspace = true, features = ["test-utils"] }
-reth-network-api = { workspace = true, features = ["test-utils"] }
+reth-network-api = { workspace = true }
 reth-rpc-engine-api = { path = "../rpc-engine-api" }
 reth-revm = { path = "../../revm" }
 reth-tasks = { workspace = true }

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -424,7 +424,7 @@ mod tests {
         EthApi::new(
             provider.clone(),
             testing_pool(),
-            NoopNetwork,
+            NoopNetwork::default(),
             cache.clone(),
             GasPriceOracle::new(provider, Default::default(), cache),
         )

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -396,7 +396,7 @@ mod tests {
     };
     use jsonrpsee::types::error::INVALID_PARAMS_CODE;
     use reth_interfaces::test_utils::{generators, generators::Rng};
-    use reth_network_api::test_utils::NoopNetwork;
+    use reth_network_api::noop::NoopNetwork;
     use reth_primitives::{
         basefee::calculate_next_block_base_fee, Block, BlockNumberOrTag, Header, TransactionSigned,
         H256, U256,

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -892,7 +892,7 @@ mod tests {
         eth::{cache::EthStateCache, gas_oracle::GasPriceOracle},
         EthApi,
     };
-    use reth_network_api::test_utils::NoopNetwork;
+    use reth_network_api::noop::NoopNetwork;
     use reth_primitives::{hex_literal::hex, Bytes};
     use reth_provider::test_utils::NoopProvider;
     use reth_transaction_pool::{test_utils::testing_pool, TransactionPool};

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -900,7 +900,7 @@ mod tests {
     #[tokio::test]
     async fn send_raw_transaction() {
         let noop_provider = NoopProvider::default();
-        let noop_network_provider = NoopNetwork;
+        let noop_network_provider = NoopNetwork::default();
 
         let pool = testing_pool();
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -18,7 +18,7 @@ reth-revm = { workspace = true }
 reth-blockchain-tree = { workspace = true }
 reth-beacon-consensus = { workspace = true }
 reth-network-api = { workspace = true }
-reth-transaction-pool = { workspace = true, features = ["test-utils"] }
+reth-transaction-pool = { workspace = true }
 reth-tasks = { workspace = true }
 
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -17,7 +17,7 @@ reth-rpc-types = { workspace = true }
 reth-revm = { workspace = true }
 reth-blockchain-tree = { workspace = true }
 reth-beacon-consensus = { workspace = true }
-reth-network-api = { workspace = true, features = ["test-utils"] }
+reth-network-api = { workspace = true }
 reth-transaction-pool = { workspace = true, features = ["test-utils"] }
 reth-tasks = { workspace = true }
 

--- a/examples/db-access.rs
+++ b/examples/db-access.rs
@@ -18,7 +18,7 @@ fn main() -> eyre::Result<()> {
     // Opens a RO handle to the database file.
     // TODO: Should be able to do `ProviderFactory::new_with_db_path_ro(...)` instead of
     // doing in 2 steps.
-    let db = open_db_read_only(&Path::new(&std::env::var("RETH_DB_PATH")?), None)?;
+    let db = open_db_read_only(Path::new(&std::env::var("RETH_DB_PATH")?), None)?;
 
     // Instantiate a provider factory for Ethereum mainnet using the provided DB.
     // TODO: Should the DB version include the spec so that you do not need to specify it here?
@@ -197,7 +197,7 @@ fn receipts_provider_example<T: ReceiptProvider + TransactionsProvider + HeaderP
     {
         let receipts = provider.receipt(header_num)?.ok_or(eyre::eyre!("receipt not found"))?;
         for log in &receipts.logs {
-            if filter_params.filter_address(log) && filter_params.filter_topics(&log) {
+            if filter_params.filter_address(log) && filter_params.filter_topics(log) {
                 // Do something with the log e.g. decode it.
                 println!("Matching log found! {log:?}")
             }

--- a/examples/rpc-db.rs
+++ b/examples/rpc-db.rs
@@ -17,7 +17,7 @@ use reth_blockchain_tree::{
 };
 use reth_revm::Factory as ExecutionFactory;
 // Configuring the network parts, ideally also wouldn't ned to think about this.
-use reth_network_api::test_utils::NoopNetwork;
+use reth_network_api::noop::NoopNetwork;
 use reth_provider::test_utils::TestCanonStateSubscriptions;
 use reth_tasks::TokioTaskExecutor;
 use reth_transaction_pool::test_utils::testing_pool;

--- a/examples/rpc-db.rs
+++ b/examples/rpc-db.rs
@@ -20,8 +20,7 @@ use reth_revm::Factory as ExecutionFactory;
 use reth_network_api::noop::NoopNetwork;
 use reth_provider::test_utils::TestCanonStateSubscriptions;
 use reth_tasks::TokioTaskExecutor;
-use reth_transaction_pool::test_utils::testing_pool;
-
+use reth_transaction_pool::noop::NoopTransactionPool;
 use std::{path::Path, sync::Arc};
 
 // Example illustrating how to run the ETH JSON RPC API as standalone over a DB file.
@@ -30,7 +29,7 @@ use std::{path::Path, sync::Arc};
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
     // 1. Setup the DB
-    let db = Arc::new(open_db_read_only(&Path::new(&std::env::var("RETH_DB_PATH")?), None)?);
+    let db = Arc::new(open_db_read_only(Path::new(&std::env::var("RETH_DB_PATH")?), None)?);
     let spec = Arc::new(ChainSpecBuilder::mainnet().build());
     let factory = ProviderFactory::new(db.clone(), spec.clone());
 
@@ -47,20 +46,18 @@ async fn main() -> eyre::Result<()> {
 
         let tree = ShareableBlockchainTree::new(BlockchainTree::new(
             externals,
-            canon_state_notification_sender.clone(),
+            canon_state_notification_sender,
             tree_config,
         )?);
 
         BlockchainProvider::new(factory, tree)?
     };
 
-    let noop_pool = testing_pool();
     let rpc_builder = RpcModuleBuilder::default()
         .with_provider(provider)
-        // Rest is just defaults
-        // TODO: How do we make this easier to configure?
-        .with_pool(noop_pool)
-        .with_network(NoopNetwork)
+        // Rest is just noops that do nothing
+        .with_pool(NoopTransactionPool::default())
+        .with_network(NoopNetwork::default())
         .with_executor(TokioTaskExecutor::default())
         .with_events(TestCanonStateSubscriptions::default());
 


### PR DESCRIPTION
no need to put this behind feature.

renamed to mod noop.

this will be useful for upcoming rpc-builder ergonomics