### PR TITLE
chore: move BeaconConsensusEngineHandle to separate file

### DIFF
--- a/crates/consensus/beacon/src/engine/handle.rs
+++ b/crates/consensus/beacon/src/engine/handle.rs
@@ -11,10 +11,10 @@ use reth_rpc_types::engine::{
 use tokio::sync::{mpsc, mpsc::UnboundedSender, oneshot};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
-/// A _shareable_ beacon consensus frontend. Used to interact with the spawned beacon consensus
-/// engine.
+/// A _shareable_ beacon consensus frontend type. Used to interact with the spawned beacon consensus
+/// engine task.
 ///
-/// See also [`BeaconConsensusEngine`].
+/// See also [`BeaconConsensusEngine`](crate::engine::BeaconConsensusEngine).
 #[derive(Clone, Debug)]
 pub struct BeaconConsensusEngineHandle {
     pub(crate) to_engine: UnboundedSender<BeaconEngineMessage>,

--- a/crates/consensus/beacon/src/engine/handle.rs
+++ b/crates/consensus/beacon/src/engine/handle.rs
@@ -1,0 +1,87 @@
+//! `BeaconConsensusEngine` external API
+
+use crate::{
+    engine::message::OnForkChoiceUpdated, BeaconConsensusEngineEvent, BeaconEngineMessage,
+    BeaconForkChoiceUpdateError, BeaconOnNewPayloadError,
+};
+use futures::TryFutureExt;
+use reth_rpc_types::engine::{
+    ExecutionPayload, ForkchoiceState, ForkchoiceUpdated, PayloadAttributes, PayloadStatus,
+};
+use tokio::sync::{mpsc, mpsc::UnboundedSender, oneshot};
+use tokio_stream::wrappers::UnboundedReceiverStream;
+
+/// A _shareable_ beacon consensus frontend. Used to interact with the spawned beacon consensus
+/// engine.
+///
+/// See also [`BeaconConsensusEngine`].
+#[derive(Clone, Debug)]
+pub struct BeaconConsensusEngineHandle {
+    pub(crate) to_engine: UnboundedSender<BeaconEngineMessage>,
+}
+
+// === impl BeaconConsensusEngineHandle ===
+
+impl BeaconConsensusEngineHandle {
+    /// Creates a new beacon consensus engine handle.
+    pub fn new(to_engine: UnboundedSender<BeaconEngineMessage>) -> Self {
+        Self { to_engine }
+    }
+
+    /// Sends a new payload message to the beacon consensus engine and waits for a response.
+    ///
+    /// See also <https://github.com/ethereum/execution-apis/blob/3d627c95a4d3510a8187dd02e0250ecb4331d27e/src/engine/shanghai.md#engine_newpayloadv2>
+    pub async fn new_payload(
+        &self,
+        payload: ExecutionPayload,
+    ) -> Result<PayloadStatus, BeaconOnNewPayloadError> {
+        let (tx, rx) = oneshot::channel();
+        let _ = self.to_engine.send(BeaconEngineMessage::NewPayload { payload, tx });
+        rx.await.map_err(|_| BeaconOnNewPayloadError::EngineUnavailable)?
+    }
+
+    /// Sends a forkchoice update message to the beacon consensus engine and waits for a response.
+    ///
+    /// See also <https://github.com/ethereum/execution-apis/blob/3d627c95a4d3510a8187dd02e0250ecb4331d27e/src/engine/shanghai.md#engine_forkchoiceupdatedv2>
+    pub async fn fork_choice_updated(
+        &self,
+        state: ForkchoiceState,
+        payload_attrs: Option<PayloadAttributes>,
+    ) -> Result<ForkchoiceUpdated, BeaconForkChoiceUpdateError> {
+        Ok(self
+            .send_fork_choice_updated(state, payload_attrs)
+            .map_err(|_| BeaconForkChoiceUpdateError::EngineUnavailable)
+            .await??
+            .await?)
+    }
+
+    /// Sends a forkchoice update message to the beacon consensus engine and returns the receiver to
+    /// wait for a response.
+    fn send_fork_choice_updated(
+        &self,
+        state: ForkchoiceState,
+        payload_attrs: Option<PayloadAttributes>,
+    ) -> oneshot::Receiver<Result<OnForkChoiceUpdated, reth_interfaces::Error>> {
+        let (tx, rx) = oneshot::channel();
+        let _ = self.to_engine.send(BeaconEngineMessage::ForkchoiceUpdated {
+            state,
+            payload_attrs,
+            tx,
+        });
+        rx
+    }
+
+    /// Sends a transition configuration exchagne message to the beacon consensus engine.
+    ///
+    /// See also <https://github.com/ethereum/execution-apis/blob/3d627c95a4d3510a8187dd02e0250ecb4331d27e/src/engine/paris.md#engine_exchangetransitionconfigurationv1>
+    pub async fn transition_configuration_exchanged(&self) {
+        let _ = self.to_engine.send(BeaconEngineMessage::TransitionConfigurationExchanged);
+    }
+
+    /// Creates a new [`BeaconConsensusEngineEvent`] listener stream.
+    pub fn event_listener(&self) -> UnboundedReceiverStream<BeaconConsensusEngineEvent> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let _ = self.to_engine.send(BeaconEngineMessage::EventListener(tx));
+        UnboundedReceiverStream::new(rx)
+    }
+}


### PR DESCRIPTION
the beacon engine impl is already very huge.

moves the handle type to a standalone module to make it easier to navigate in the mod.rs 