### PR TITLE
chore(txpool): emit replaced events

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -325,7 +325,7 @@ where
         &self,
         origin: TransactionOrigin,
         transaction: Self::Transaction,
-    ) -> PoolResult<TransactionEvents> {
+    ) -> PoolResult<TransactionEvents<Self::Transaction>> {
         let (_, tx) = self.validate(origin, transaction).await;
         self.pool.add_transaction_and_subscribe(origin, tx)
     }
@@ -350,11 +350,14 @@ where
         Ok(transactions)
     }
 
-    fn transaction_event_listener(&self, tx_hash: TxHash) -> Option<TransactionEvents> {
+    fn transaction_event_listener(
+        &self,
+        tx_hash: TxHash,
+    ) -> Option<TransactionEvents<Self::Transaction>> {
         self.pool.add_transaction_event_listener(tx_hash)
     }
 
-    fn all_transactions_event_listener(&self) -> AllTransactionsEvents {
+    fn all_transactions_event_listener(&self) -> AllTransactionsEvents<Self::Transaction> {
         self.pool.add_all_transactions_event_listener()
     }
 

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -41,7 +41,7 @@ impl TransactionPool for NoopTransactionPool {
         &self,
         _origin: TransactionOrigin,
         transaction: Self::Transaction,
-    ) -> PoolResult<TransactionEvents> {
+    ) -> PoolResult<TransactionEvents<Self::Transaction>> {
         let hash = *transaction.hash();
         Err(PoolError::Other(hash, Box::new(NoopInsertError::new(transaction))))
     }
@@ -69,11 +69,14 @@ impl TransactionPool for NoopTransactionPool {
             .collect())
     }
 
-    fn transaction_event_listener(&self, _tx_hash: TxHash) -> Option<TransactionEvents> {
+    fn transaction_event_listener(
+        &self,
+        _tx_hash: TxHash,
+    ) -> Option<TransactionEvents<Self::Transaction>> {
         None
     }
 
-    fn all_transactions_event_listener(&self) -> AllTransactionsEvents {
+    fn all_transactions_event_listener(&self) -> AllTransactionsEvents<Self::Transaction> {
         AllTransactionsEvents { events: mpsc::channel(1).1 }
     }
 

--- a/crates/transaction-pool/src/pool/events.rs
+++ b/crates/transaction-pool/src/pool/events.rs
@@ -1,4 +1,4 @@
-use crate::traits::PropagateKind;
+use crate::{traits::PropagateKind, PoolTransaction, ValidPoolTransaction};
 use reth_primitives::{TxHash, H256};
 use std::sync::Arc;
 
@@ -7,11 +7,11 @@ use serde::{Deserialize, Serialize};
 
 /// Wrapper around a transaction hash and the event that happened to it.
 #[derive(Debug)]
-pub struct PoolTransactionEvent(TxHash, TransactionEvent);
+pub struct PoolTransactionEvent<T: PoolTransaction>(TxHash, TransactionEvent<T>);
 
-impl PoolTransactionEvent {
+impl<T: PoolTransaction> PoolTransactionEvent<T> {
     /// Create a new transaction event.
-    pub fn new(hash: TxHash, event: TransactionEvent) -> Self {
+    pub fn new(hash: TxHash, event: TransactionEvent<T>) -> Self {
         Self(hash, event)
     }
 
@@ -21,20 +21,19 @@ impl PoolTransactionEvent {
     }
 
     /// The event that happened to the transaction.
-    pub fn event(&self) -> &TransactionEvent {
+    pub fn event(&self) -> &TransactionEvent<T> {
         &self.1
     }
 
     /// Split the event into its components.
-    pub fn split(self) -> (TxHash, TransactionEvent) {
+    pub fn split(self) -> (TxHash, TransactionEvent<T>) {
         (self.0, self.1)
     }
 }
 
 /// Various events that describe status changes of a transaction.
-#[derive(Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum TransactionEvent {
+#[derive(Debug)]
+pub enum TransactionEvent<T: PoolTransaction> {
     /// Transaction has been added to the pending pool.
     Pending,
     /// Transaction has been added to the queued pool.
@@ -44,7 +43,7 @@ pub enum TransactionEvent {
     /// Transaction has been replaced by the transaction belonging to the hash.
     ///
     /// E.g. same (sender + nonce) pair
-    Replaced(TxHash),
+    Replaced { transaction: Arc<ValidPoolTransaction<T>>, replaced_by: TxHash },
     /// Transaction was dropped due to configured limits.
     Discarded,
     /// Transaction became invalid indefinitely.
@@ -53,13 +52,25 @@ pub enum TransactionEvent {
     Propagated(Arc<Vec<PropagateKind>>),
 }
 
-impl TransactionEvent {
+impl<T: PoolTransaction> Clone for TransactionEvent<T> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Replaced { transaction, replaced_by } => Self::Replaced {
+                transaction: Arc::clone(&transaction),
+                replaced_by: replaced_by.clone(),
+            },
+            other => other.clone(),
+        }
+    }
+}
+
+impl<T: PoolTransaction> TransactionEvent<T> {
     /// Returns `true` if the event is final and no more events are expected for this transaction
     /// hash.
     pub fn is_final(&self) -> bool {
         matches!(
             self,
-            TransactionEvent::Replaced(_) |
+            TransactionEvent::Replaced { .. } |
                 TransactionEvent::Mined(_) |
                 TransactionEvent::Discarded
         )

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -68,7 +68,7 @@ pub trait TransactionPool: Send + Sync + Clone {
         &self,
         origin: TransactionOrigin,
         transaction: Self::Transaction,
-    ) -> PoolResult<TransactionEvents>;
+    ) -> PoolResult<TransactionEvents<Self::Transaction>>;
 
     /// Adds an _unvalidated_ transaction into the pool.
     ///
@@ -93,10 +93,13 @@ pub trait TransactionPool: Send + Sync + Clone {
     /// Returns a new transaction change event stream for the given transaction.
     ///
     /// Returns `None` if the transaction is not in the pool.
-    fn transaction_event_listener(&self, tx_hash: TxHash) -> Option<TransactionEvents>;
+    fn transaction_event_listener(
+        &self,
+        tx_hash: TxHash,
+    ) -> Option<TransactionEvents<Self::Transaction>>;
 
     /// Returns a new transaction change event stream for _all_ transactions in the pool.
-    fn all_transactions_event_listener(&self) -> AllTransactionsEvents;
+    fn all_transactions_event_listener(&self) -> AllTransactionsEvents<Self::Transaction>;
 
     /// Returns a new Stream that yields transactions hashes for new ready transactions.
     ///
@@ -393,6 +396,7 @@ impl<T> BestTransactions for std::iter::Empty<T> {
 }
 
 /// Trait for transaction types used inside the pool
+#[auto_impl::auto_impl(Box)]
 pub trait PoolTransaction:
     fmt::Debug + Send + Sync + FromRecoveredTransaction + IntoRecoveredTransaction
 {


### PR DESCRIPTION
## Motivation

1. Replaced transaction events were never emitted from the transaction pool. (Bug)

2. After the transaction is replaced from the transaction pool, there is no way to get information about it. (Controversial)

I will not push too hard on the second change. One could write a wrapper that would keep track of that information. I still think that it's not great that the discarded, replaced, and invalid transactions are not propagated to the listener in any way. 

If the 2nd change is not approved, I will extract the fix into a separate PR.