### PR TITLE
feat: add full pending txs to stream

### DIFF
--- a/crates/rpc/rpc/src/eth/pubsub.rs
+++ b/crates/rpc/rpc/src/eth/pubsub.rs
@@ -276,7 +276,7 @@ where
     fn full_pending_transaction_stream(
         &self,
     ) -> impl Stream<Item = NewTransactionEvent<<Pool as TransactionPool>::Transaction>> {
-        ReceiverStream::new(self.pool.new_transactions_listener())
+        self.pool.new_pending_pool_transactions_listener()
     }
 }
 


### PR DESCRIPTION
Closes #3639

At the moment we return the tx hashes for pending txs, but not the full tx. Here we add a bool flag and when its set to true we return the full tx, otherwise we keep the old behaviour of returning just the hashes.