### PR TITLE
add build profile to version info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,6 +1037,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
+name = "const-str"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aca749d3d3f5b87a0d6100509879f9cf486ab510803a4a4e1001da1ff61c2bd6"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4957,6 +4963,7 @@ dependencies = [
  "clap 4.1.8",
  "comfy-table",
  "confy",
+ "const-str",
  "crossterm",
  "dirs-next",
  "eyre",

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -85,6 +85,7 @@ hex = "0.4"
 thiserror = { workspace = true }
 pretty_assertions = "1.3.0"
 humantime = "2.1.0"
+const-str = "0.5.6"
 
 [features]
 jemalloc = ["dep:jemallocator", "dep:jemalloc-ctl"]

--- a/bin/reth/src/version.rs
+++ b/bin/reth/src/version.rs
@@ -28,7 +28,7 @@ pub(crate) const SHORT_VERSION: &str =
 /// Build Timestamp: 2023-05-19T01:47:19.815651705Z
 /// Build Features: jemalloc
 /// ```
-pub(crate) const LONG_VERSION: &str = concat!(
+pub(crate) const LONG_VERSION: &str = const_str::concat!(
     "Version: ",
     env!("CARGO_PKG_VERSION"),
     "\n",
@@ -39,7 +39,10 @@ pub(crate) const LONG_VERSION: &str = concat!(
     env!("VERGEN_BUILD_TIMESTAMP"),
     "\n",
     "Build Features: ",
-    env!("VERGEN_CARGO_FEATURES")
+    env!("VERGEN_CARGO_FEATURES"),
+    "\n",
+    "Build Profile: ",
+    build_profile_name()
 );
 
 /// The version information for reth formatted for P2P (devp2p).
@@ -74,6 +77,12 @@ pub(crate) const P2P_CLIENT_VERSION: &str = concat!(
 /// ```
 pub fn default_extradata() -> String {
     format!("reth/v{}/{}", env!("CARGO_PKG_VERSION"), std::env::consts::OS)
+}
+
+const fn build_profile_name() -> &'static str {
+    // Nice hack from https://stackoverflow.com/questions/73595435/how-to-get-profile-from-cargo-toml-in-build-rs-or-at-runtime
+    let out_dir_path = const_str::split!(env!("OUT_DIR"), std::path::MAIN_SEPARATOR_STR);
+    out_dir_path[out_dir_path.len() - 4]
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Add the build profile (e.g. maxperf) to the `reth --version` output:

```
$ reth --version
reth Version: 0.1.0-alpha.1
Commit SHA: b8a54767
Build Timestamp: 2023-07-07T06:19:28.372795400Z
Build Features: jemalloc
Build Profile: release
```

A new dependency on `const-str` is added, as `vergen` removed support for named Cargo profiles in v8.0.0 (https://github.com/rustyhorde/vergen/commit/563e318f610b65538b8465fe90679739f6dc5d31).