### PR TITLE
add build profile to version info take II

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,6 +1037,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
+name = "const-str"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aca749d3d3f5b87a0d6100509879f9cf486ab510803a4a4e1001da1ff61c2bd6"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4957,6 +4963,7 @@ dependencies = [
  "clap 4.1.8",
  "comfy-table",
  "confy",
+ "const-str",
  "crossterm",
  "dirs-next",
  "eyre",

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -85,6 +85,7 @@ hex = "0.4"
 thiserror = { workspace = true }
 pretty_assertions = "1.3.0"
 humantime = "2.1.0"
+const-str = "0.5.6"
 
 [features]
 jemalloc = ["dep:jemallocator", "dep:jemalloc-ctl"]

--- a/bin/reth/src/version.rs
+++ b/bin/reth/src/version.rs
@@ -28,7 +28,7 @@ pub(crate) const SHORT_VERSION: &str =
 /// Build Timestamp: 2023-05-19T01:47:19.815651705Z
 /// Build Features: jemalloc
 /// ```
-pub(crate) const LONG_VERSION: &str = concat!(
+pub(crate) const LONG_VERSION: &str = const_str::concat!(
     "Version: ",
     env!("CARGO_PKG_VERSION"),
     "\n",
@@ -39,7 +39,10 @@ pub(crate) const LONG_VERSION: &str = concat!(
     env!("VERGEN_BUILD_TIMESTAMP"),
     "\n",
     "Build Features: ",
-    env!("VERGEN_CARGO_FEATURES")
+    env!("VERGEN_CARGO_FEATURES"),
+    "\n",
+    "Build Profile: ",
+    build_profile_name()
 );
 
 /// The version information for reth formatted for P2P (devp2p).
@@ -74,6 +77,15 @@ pub(crate) const P2P_CLIENT_VERSION: &str = concat!(
 /// ```
 pub fn default_extradata() -> String {
     format!("reth/v{}/{}", env!("CARGO_PKG_VERSION"), std::env::consts::OS)
+}
+
+const fn build_profile_name() -> &'static str {
+    // Derived from https://stackoverflow.com/questions/73595435/how-to-get-profile-from-cargo-toml-in-build-rs-or-at-runtime
+    // We split on the path separator of the *host* machine, which may be different from `std::path::MAIN_SEPARATOR_STR`.
+    const OUT_DIR: &str = env!("OUT_DIR");
+    const SEP: char = if const_str::contains!(OUT_DIR, "/") { '/' } else { '\\' };
+    let parts = const_str::split!(OUT_DIR, SEP);
+    parts[parts.len() - 4]
 }
 
 #[cfg(test)]

--- a/bin/reth/src/version.rs
+++ b/bin/reth/src/version.rs
@@ -81,7 +81,8 @@ pub fn default_extradata() -> String {
 
 const fn build_profile_name() -> &'static str {
     // Derived from https://stackoverflow.com/questions/73595435/how-to-get-profile-from-cargo-toml-in-build-rs-or-at-runtime
-    // We split on the path separator of the *host* machine, which may be different from `std::path::MAIN_SEPARATOR_STR`.
+    // We split on the path separator of the *host* machine, which may be different from
+    // `std::path::MAIN_SEPARATOR_STR`.
     const OUT_DIR: &str = env!("OUT_DIR");
     const SEP: char = if const_str::contains!(OUT_DIR, "/") { '/' } else { '\\' };
     let parts = const_str::split!(OUT_DIR, SEP);


### PR DESCRIPTION
re-do of #3652, now with proper cross-compilation

the reason that the previous version failed in CI [here](https://github.com/paradigmxyz/reth/actions/runs/5486088295/jobs/9995719536) is that it was trying to split on the Windows  path separator on Linux (the host)

I've confirmed that this updated version compiles successfully with `make build-x86_64-pc-windows-gnu` as well as ordinary `make install` on Linux.