### PR TITLE
fix(tree): update metrics only on canonical/side chain changes

### DIFF
--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1084,8 +1084,12 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
         }
     }
 
-    /// Update blockchain tree and sync metrics
-    pub(crate) fn update_metrics(&mut self) {
+    /// Update blockchain tree chains (canonical and sidechains) and sync metrics.
+    ///
+    /// NOTE: this method should not be called during the pipeline sync, because otherwise the sync
+    /// checkpoint metric will get overwritten. Buffered blocks metrics are updated in
+    /// [BlockBuffer] during the pipeline sync.
+    pub(crate) fn update_chains_metrics(&mut self) {
         let height = self.canonical_chain().tip().number;
 
         self.metrics.sidechains.set(self.chains.len() as f64);

--- a/crates/blockchain-tree/src/shareable.rs
+++ b/crates/blockchain-tree/src/shareable.rs
@@ -43,9 +43,9 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeEngine
 {
     fn buffer_block(&self, block: SealedBlockWithSenders) -> Result<(), InsertBlockError> {
         let mut tree = self.tree.write();
-        let res = tree.buffer_block(block);
-        tree.update_metrics();
-        res
+        // Blockchain tree metrics shouldn't be updated here, see
+        // `BlockchainTree::update_chains_metrics` documentation.
+        tree.buffer_block(block)
     }
 
     fn insert_block(
@@ -55,7 +55,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeEngine
         trace!(target: "blockchain_tree", hash=?block.hash, number=block.number, parent_hash=?block.parent_hash, "Inserting block");
         let mut tree = self.tree.write();
         let res = tree.insert_block(block);
-        tree.update_metrics();
+        tree.update_chains_metrics();
         res
     }
 
@@ -63,14 +63,14 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeEngine
         trace!(target: "blockchain_tree", ?finalized_block, "Finalizing block");
         let mut tree = self.tree.write();
         tree.finalize_block(finalized_block);
-        tree.update_metrics();
+        tree.update_chains_metrics();
     }
 
     fn restore_canonical_hashes(&self, last_finalized_block: BlockNumber) -> Result<(), Error> {
         trace!(target: "blockchain_tree", ?last_finalized_block, "Restoring canonical hashes for last finalized block");
         let mut tree = self.tree.write();
         let res = tree.restore_canonical_hashes(last_finalized_block);
-        tree.update_metrics();
+        tree.update_chains_metrics();
         res
     }
 
@@ -78,7 +78,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeEngine
         trace!(target: "blockchain_tree", ?block_hash, "Making block canonical");
         let mut tree = self.tree.write();
         let res = tree.make_canonical(block_hash);
-        tree.update_metrics();
+        tree.update_chains_metrics();
         res
     }
 
@@ -86,7 +86,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeEngine
         trace!(target: "blockchain_tree", ?unwind_to, "Unwinding to block number");
         let mut tree = self.tree.write();
         let res = tree.unwind(unwind_to);
-        tree.update_metrics();
+        tree.update_chains_metrics();
         res
     }
 }


### PR DESCRIPTION
The bug this PR fixes was introduced in https://github.com/paradigmxyz/reth/pull/3507.

During the live sync on every new FCU or payload, blockchain tree processes new update, modifies the canonical or side chain, and updates metrics (which are common for both blockchain tree and pipeline syncs).

But during the pipeline sync, blockchain tree can't do any updates, so it buffers the block for further processing when the pipeline finishes. However, it still updates metrics: https://github.com/paradigmxyz/reth/blob/1330fc11df1a89aa58b5c0a79d8d8720f6b0e374/crates/blockchain-tree/src/shareable.rs#L44-L49

Since we didn't modify the actual tree and only buffered a block, the metrics will get updated with the current state of blockchain tree: https://github.com/paradigmxyz/reth/blob/1330fc11df1a89aa58b5c0a79d8d8720f6b0e374/crates/blockchain-tree/src/blockchain_tree.rs#L1088-L1096

The problem arises when we do an update to metrics during the pipeline sync (initial or on large range of missing blocks):
1. Pipeline sync updates metrics with new checkpoint reached by the stage.
2. New FCU or payload arrives, blockchain tree can't process it and buffers the block, and STILL updates metrics with the current blockchain tree, overwriting the updates to metrics made by pipeline. If it's an initial sync, metrics get updated with `0`, because we don't have any canonical chain in the blockchain tree yet.
3. Pipeline sync updates metrics again, overwriting the previously set `0` by blockchain tree.

This produces such dashboard (notice spiky chart which demonstrates the behaviour with `0 -> pipeline sync metric -> 0 -> pipeline sync metric` metric value):

<img src="https://github.com/paradigmxyz/reth/assets/5773434/1a8c132e-341d-4a71-b55f-144cefbd5c3f" width="400" /> <img src="https://github.com/paradigmxyz/reth/assets/5773434/495970ba-649f-43ae-8edc-ff61c224548a" width="400" />


---

This PR fixes this behaviour by updating the blockchain tree metrics ONLY during the actual modification of the blockchain tree, i.e. doesn't update metrics during the block buffering.