### PR TITLE
fix: transaction calls on the reth-provider should not generate a hash by default

### DIFF
--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -395,7 +395,7 @@ where
                 None => return Ok(None),
             };
 
-            this.build_transaction_receipt(tx, meta, receipt).await.map(Some)
+            this.build_transaction_receipt(tx.into(), meta, receipt).await.map(Some)
         })
         .await
     }
@@ -667,7 +667,7 @@ where
             Some(recpts) => recpts,
             None => return Err(EthApiError::UnknownBlockNumber),
         };
-        build_transaction_receipt_with_block_receipts(tx, meta, receipt, &all_receipts)
+        build_transaction_receipt_with_block_receipts(tx.into(), meta, receipt, &all_receipts)
     }
 }
 

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -395,7 +395,7 @@ where
                 None => return Ok(None),
             };
 
-            this.build_transaction_receipt(tx.into(), meta, receipt).await.map(Some)
+            this.build_transaction_receipt(tx, meta, receipt).await.map(Some)
         })
         .await
     }
@@ -667,7 +667,7 @@ where
             Some(recpts) => recpts,
             None => return Err(EthApiError::UnknownBlockNumber),
         };
-        build_transaction_receipt_with_block_receipts(tx.into(), meta, receipt, &all_receipts)
+        build_transaction_receipt_with_block_receipts(tx, meta, receipt, &all_receipts)
     }
 }
 

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -228,6 +228,10 @@ impl<DB: Database> TransactionsProvider for ProviderFactory<DB> {
         self.provider()?.transaction_by_id(id)
     }
 
+    fn transaction_by_id_no_hash(&self, id: TxNumber) -> Result<Option<TransactionSignedNoHash>> {
+        self.provider()?.transaction_by_id_no_hash(id)
+    }
+
     fn transaction_by_hash(&self, hash: TxHash) -> Result<Option<TransactionSigned>> {
         self.provider()?.transaction_by_hash(hash)
     }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -934,6 +934,10 @@ impl<'this, TX: DbTx<'this>> TransactionsProvider for DatabaseProvider<'this, TX
         Ok(self.tx.get::<tables::Transactions>(id)?.map(Into::into))
     }
 
+    fn transaction_by_id_no_hash(&self, id: TxNumber) -> Result<Option<TransactionSignedNoHash>> {
+        Ok(self.tx.get::<tables::Transactions>(id)?.map(Into::into))
+    }
+
     fn transaction_by_hash(&self, hash: TxHash) -> Result<Option<TransactionSigned>> {
         if let Some(id) = self.transaction_id(hash)? {
             Ok(self.transaction_by_id(id)?)

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -271,6 +271,10 @@ where
         self.database.provider()?.transaction_by_id(id)
     }
 
+    fn transaction_by_id_no_hash(&self, id: TxNumber) -> Result<Option<TransactionSignedNoHash>> {
+        self.database.provider()?.transaction_by_id_no_hash(id)
+    }
+
     fn transaction_by_hash(&self, hash: TxHash) -> Result<Option<TransactionSigned>> {
         self.database.provider()?.transaction_by_hash(hash)
     }

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -11,7 +11,8 @@ use reth_interfaces::{provider::ProviderError, Result};
 use reth_primitives::{
     keccak256, Account, Address, Block, BlockHash, BlockHashOrNumber, BlockId, BlockNumber,
     BlockWithSenders, Bytecode, Bytes, ChainInfo, Header, Receipt, SealedBlock, SealedHeader,
-    StorageKey, StorageValue, TransactionMeta, TransactionSigned, TxHash, TxNumber, H256, U256, TransactionSignedNoHash,
+    StorageKey, StorageValue, TransactionMeta, TransactionSigned, TransactionSignedNoHash,
+    TxHash, TxNumber, H256, U256,
 };
 use reth_revm_primitives::primitives::{BlockEnv, CfgEnv};
 use std::{

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -11,7 +11,7 @@ use reth_interfaces::{provider::ProviderError, Result};
 use reth_primitives::{
     keccak256, Account, Address, Block, BlockHash, BlockHashOrNumber, BlockId, BlockNumber,
     BlockWithSenders, Bytecode, Bytes, ChainInfo, Header, Receipt, SealedBlock, SealedHeader,
-    StorageKey, StorageValue, TransactionMeta, TransactionSigned, TxHash, TxNumber, H256, U256,
+    StorageKey, StorageValue, TransactionMeta, TransactionSigned, TxHash, TxNumber, H256, U256, TransactionSignedNoHash,
 };
 use reth_revm_primitives::primitives::{BlockEnv, CfgEnv};
 use std::{
@@ -165,6 +165,10 @@ impl TransactionsProvider for MockEthProvider {
     }
 
     fn transaction_by_id(&self, _id: TxNumber) -> Result<Option<TransactionSigned>> {
+        Ok(None)
+    }
+
+    fn transaction_by_id_no_hash(&self, _id: TxNumber) -> Result<Option<TransactionSignedNoHash>> {
         Ok(None)
     }
 

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -11,8 +11,8 @@ use reth_interfaces::{provider::ProviderError, Result};
 use reth_primitives::{
     keccak256, Account, Address, Block, BlockHash, BlockHashOrNumber, BlockId, BlockNumber,
     BlockWithSenders, Bytecode, Bytes, ChainInfo, Header, Receipt, SealedBlock, SealedHeader,
-    StorageKey, StorageValue, TransactionMeta, TransactionSigned, TransactionSignedNoHash,
-    TxHash, TxNumber, H256, U256,
+    StorageKey, StorageValue, TransactionMeta, TransactionSigned, TransactionSignedNoHash, TxHash,
+    TxNumber, H256, U256,
 };
 use reth_revm_primitives::primitives::{BlockEnv, CfgEnv};
 use std::{

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -11,7 +11,7 @@ use reth_primitives::{
     stage::{StageCheckpoint, StageId},
     Account, Address, Block, BlockHash, BlockHashOrNumber, BlockId, BlockNumber, Bytecode, Bytes,
     ChainInfo, ChainSpec, Header, Receipt, SealedBlock, SealedHeader, StorageKey, StorageValue,
-    TransactionMeta, TransactionSigned, TxHash, TxNumber, H256, KECCAK_EMPTY, MAINNET, U256,
+    TransactionMeta, TransactionSigned, TxHash, TxNumber, H256, KECCAK_EMPTY, MAINNET, U256, TransactionSignedNoHash,
 };
 use reth_revm_primitives::primitives::{BlockEnv, CfgEnv};
 use std::{ops::RangeBounds, sync::Arc};
@@ -127,6 +127,10 @@ impl TransactionsProvider for NoopProvider {
     }
 
     fn transaction_by_id(&self, _id: TxNumber) -> Result<Option<TransactionSigned>> {
+        Ok(None)
+    }
+
+    fn transaction_by_id_no_hash(&self, _id: TxNumber) -> Result<Option<TransactionSignedNoHash>> {
         Ok(None)
     }
 

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -11,7 +11,9 @@ use reth_primitives::{
     stage::{StageCheckpoint, StageId},
     Account, Address, Block, BlockHash, BlockHashOrNumber, BlockId, BlockNumber, Bytecode, Bytes,
     ChainInfo, ChainSpec, Header, Receipt, SealedBlock, SealedHeader, StorageKey, StorageValue,
-    TransactionMeta, TransactionSigned, TxHash, TxNumber, H256, KECCAK_EMPTY, MAINNET, U256, TransactionSignedNoHash,
+    TransactionMeta, TransactionSigned, TransactionSignedNoHash, TxHash, TxNumber, H256,
+    KECCAK_EMPTY, MAINNET, U256,
+    
 };
 use reth_revm_primitives::primitives::{BlockEnv, CfgEnv};
 use std::{ops::RangeBounds, sync::Arc};

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -13,7 +13,6 @@ use reth_primitives::{
     ChainInfo, ChainSpec, Header, Receipt, SealedBlock, SealedHeader, StorageKey, StorageValue,
     TransactionMeta, TransactionSigned, TransactionSignedNoHash, TxHash, TxNumber, H256,
     KECCAK_EMPTY, MAINNET, U256,
-    
 };
 use reth_revm_primitives::primitives::{BlockEnv, CfgEnv};
 use std::{ops::RangeBounds, sync::Arc};

--- a/crates/storage/provider/src/traits/transactions.rs
+++ b/crates/storage/provider/src/traits/transactions.rs
@@ -15,7 +15,8 @@ pub trait TransactionsProvider: BlockNumReader + Send + Sync {
     /// Returns None if the transaction is not found.
     fn transaction_id(&self, tx_hash: TxHash) -> Result<Option<TxNumber>>;
 
-    /// Get transaction by id.
+    /// Get transaction by id - computes hash everytime so more 
+    /// expensive than [TransactionsProvider::transaction_by_id_no_hash].
     fn transaction_by_id(&self, id: TxNumber) -> Result<Option<TransactionSigned>>;
 
     /// Get transaction by id without computing the hash.

--- a/crates/storage/provider/src/traits/transactions.rs
+++ b/crates/storage/provider/src/traits/transactions.rs
@@ -18,7 +18,7 @@ pub trait TransactionsProvider: BlockNumReader + Send + Sync {
     /// Get transaction by id.
     fn transaction_by_id(&self, id: TxNumber) -> Result<Option<TransactionSigned>>;
 
-    /// Get transaction by id.
+    /// Get transaction by id without computing the hash - note you can still call .hash() to generate it.
     fn transaction_by_id_no_hash(&self, id: TxNumber) -> Result<Option<TransactionSignedNoHash>>;
 
     /// Get transaction by transaction hash.

--- a/crates/storage/provider/src/traits/transactions.rs
+++ b/crates/storage/provider/src/traits/transactions.rs
@@ -15,8 +15,7 @@ pub trait TransactionsProvider: BlockNumReader + Send + Sync {
     /// Returns None if the transaction is not found.
     fn transaction_id(&self, tx_hash: TxHash) -> Result<Option<TxNumber>>;
 
-    /// Get transaction by id - computes hash everytime so more 
-    /// expensive than [TransactionsProvider::transaction_by_id_no_hash].
+    /// Get transaction by id, computes hash everytime so more expensive.
     fn transaction_by_id(&self, id: TxNumber) -> Result<Option<TransactionSigned>>;
 
     /// Get transaction by id without computing the hash.

--- a/crates/storage/provider/src/traits/transactions.rs
+++ b/crates/storage/provider/src/traits/transactions.rs
@@ -18,6 +18,9 @@ pub trait TransactionsProvider: BlockNumReader + Send + Sync {
     /// Get transaction by id.
     fn transaction_by_id(&self, id: TxNumber) -> Result<Option<TransactionSigned>>;
 
+    /// Get transaction by id.
+    fn transaction_by_id_no_hash(&self, id: TxNumber) -> Result<Option<TransactionSignedNoHash>>;
+
     /// Get transaction by transaction hash.
     fn transaction_by_hash(&self, hash: TxHash) -> Result<Option<TransactionSigned>>;
 

--- a/crates/storage/provider/src/traits/transactions.rs
+++ b/crates/storage/provider/src/traits/transactions.rs
@@ -18,7 +18,7 @@ pub trait TransactionsProvider: BlockNumReader + Send + Sync {
     /// Get transaction by id.
     fn transaction_by_id(&self, id: TxNumber) -> Result<Option<TransactionSigned>>;
 
-    /// Get transaction by id without computing the hash - note you can still call .hash() to generate it.
+    /// Get transaction by id without computing the hash.
     fn transaction_by_id_no_hash(&self, id: TxNumber) -> Result<Option<TransactionSignedNoHash>>;
 
     /// Get transaction by transaction hash.


### PR DESCRIPTION
When calling the transaction methods by default, it should not compute the tx hash (`TransactionSigned`) as this dramatically slows down the response when using it and means it computes the hash even if you do not need to use it; you have the .hash() method on the `TransactionSignedNoHash` to do this. 

(was not sure where i run `cargo fmt` as i did that and a lot of file changes so just assumed the CI may do it let me know if not)

