### PR TITLE
feat: penalize peers for not sending transactions

### DIFF
--- a/crates/net/network-api/src/reputation.rs
+++ b/crates/net/network-api/src/reputation.rs
@@ -22,6 +22,8 @@ pub enum ReputationChangeKind {
     /// > originally). This is usually achieved by remembering a set of transaction hashes recently
     /// > relayed by the peer.
     AlreadySeenTransaction,
+    /// Peer sent very few pending transactions and/or hashes after a given grace period.
+    LowPendingTransactions,
     /// Peer failed to respond in time.
     Timeout,
     /// Peer does not adhere to network protocol rules.

--- a/crates/net/network/src/metrics.rs
+++ b/crates/net/network/src/metrics.rs
@@ -53,6 +53,8 @@ pub struct TransactionsManagerMetrics {
     pub(crate) propagated_transactions: Counter,
     /// Total number of reported bad transactions
     pub(crate) reported_bad_transactions: Counter,
+    /// Total number of reported low pending transactions
+    pub(crate) reported_low_pending_transactions: Counter,
     /// Total number of messages with already seen hashes
     pub(crate) messages_with_already_seen_hashes: Counter,
     /// Total number of messages with already seen full transactions

--- a/crates/net/network/src/peers/reputation.rs
+++ b/crates/net/network/src/peers/reputation.rs
@@ -30,6 +30,10 @@ const BAD_MESSAGE_REPUTATION_CHANGE: i32 = 16 * REPUTATION_UNIT;
 /// apply any changes to the peer's reputation, effectively ignoring it.
 const ALREADY_SEEN_TRANSACTION_REPUTATION_CHANGE: i32 = 0;
 
+/// The reputation change to apply to a peer that failed to send a resonable number of pending txs
+/// consistently over time after a grace period.
+const LOW_PENDING_TRANSACTIONS_CHANGE: i32 = 5 * REPUTATION_UNIT;
+
 /// The reputation change to apply to a peer which violates protocol rules: minimal reputation
 const BAD_PROTOCOL_REPUTATION_CHANGE: i32 = i32::MIN;
 
@@ -51,6 +55,8 @@ pub struct ReputationChangeWeights {
     pub bad_transactions: Reputation,
     /// Weight for [`ReputationChangeKind::AlreadySeenTransaction`]
     pub already_seen_transactions: Reputation,
+    /// Weight for [`ReputationChangeKind::LowPendingTransactions`]
+    pub low_pending_transactions: Reputation,
     /// Weight for [`ReputationChangeKind::Timeout`]
     pub timeout: Reputation,
     /// Weight for [`ReputationChangeKind::BadProtocol`]
@@ -72,6 +78,7 @@ impl ReputationChangeWeights {
             ReputationChangeKind::BadBlock => self.bad_block.into(),
             ReputationChangeKind::BadTransactions => self.bad_transactions.into(),
             ReputationChangeKind::AlreadySeenTransaction => self.already_seen_transactions.into(),
+            ReputationChangeKind::LowPendingTransactions => self.low_pending_transactions.into(),
             ReputationChangeKind::Timeout => self.timeout.into(),
             ReputationChangeKind::BadProtocol => self.bad_protocol.into(),
             ReputationChangeKind::FailedToConnect => self.failed_to_connect.into(),
@@ -88,6 +95,7 @@ impl Default for ReputationChangeWeights {
             bad_block: BAD_MESSAGE_REPUTATION_CHANGE,
             bad_transactions: BAD_MESSAGE_REPUTATION_CHANGE,
             already_seen_transactions: ALREADY_SEEN_TRANSACTION_REPUTATION_CHANGE,
+            low_pending_transactions: LOW_PENDING_TRANSACTIONS_CHANGE,
             bad_message: BAD_MESSAGE_REPUTATION_CHANGE,
             timeout: TIMEOUT_REPUTATION_CHANGE,
             bad_protocol: BAD_PROTOCOL_REPUTATION_CHANGE,

--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -174,7 +174,7 @@ where
     fn check_peers(&mut self) {
         // only run check process if more than 5 minutes have passed
         if self.peers_last_checked.elapsed().as_secs() < 1 * 60 {
-            return;
+            return
         }
 
         self.peers_last_checked = Instant::now();


### PR DESCRIPTION
## What does it do?

Tracks when a peer is added, how many total full transactions are sent, how many transaction hashes are sent through new fields in the `Peer` struct.

Also adds a `peers_last_checked` field for polling the check function. 

### how does it work?
When a peer is added, it have the `added_on` field set. The peer then will not be checked until after the given grace period (currently 60 seconds).  After that, it will check that the peer is sending at least 10 txs & hashes  per minute. If it fails to do so, it will be penalized 5 reputation points each minute until this minimum average is met.

### open questions

There are a few magic numbers here that should perhaps be refined. 
- grace period (currently 60 seconds)
- polling interval (currently 60 seconds)
- tx measurement block (currently 60 seconds)
- min average txs per measurement block (currently 10)
- penalty amount (currently 5)

Additionally, should these be stored as some sort of a config somewhere?

