### PR TITLE
fix: expose call method so a consumer can use it

### DIFF
--- a/crates/rpc/rpc/src/eth/api/call.rs
+++ b/crates/rpc/rpc/src/eth/api/call.rs
@@ -38,11 +38,7 @@ where
     Network: NetworkInfo + Send + Sync + 'static,
 {
     /// Estimate gas needed for execution of the `request` at the [BlockId].
-    pub async fn estimate_gas_at(
-        &self,
-        request: CallRequest,
-        at: BlockId,
-    ) -> EthResult<U256> {
+    pub async fn estimate_gas_at(&self, request: CallRequest, at: BlockId) -> EthResult<U256> {
         let (cfg, block_env, at) = self.evm_env_at(at).await?;
         let state = self.state_at(at)?;
         self.estimate_gas_with(cfg, block_env, request, state)

--- a/crates/rpc/rpc/src/eth/api/call.rs
+++ b/crates/rpc/rpc/src/eth/api/call.rs
@@ -38,7 +38,7 @@ where
     Network: NetworkInfo + Send + Sync + 'static,
 {
     /// Estimate gas needed for execution of the `request` at the [BlockId].
-    pub(crate) async fn estimate_gas_at(
+    pub async fn estimate_gas_at(
         &self,
         request: CallRequest,
         at: BlockId,
@@ -49,7 +49,7 @@ where
     }
 
     /// Executes the call request (`eth_call`) and returns the output
-    pub(crate) async fn call(
+    pub async fn call(
         &self,
         request: CallRequest,
         block_number: Option<BlockId>,


### PR DESCRIPTION
call and estimate_gas_at were only callable by the crates remove that to allow consumers who install these libs to be able to call it