### PR TITLE
chore: use units on dashboard

### DIFF
--- a/etc/grafana/dashboards/overview.json
+++ b/etc/grafana/dashboards/overview.json
@@ -27,7 +27,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "10.0.1"
+      "version": "9.5.3"
     },
     {
       "type": "panel",
@@ -159,7 +159,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "10.0.1",
+      "pluginVersion": "9.5.3",
       "targets": [
         {
           "datasource": {
@@ -226,7 +226,7 @@
         "showUnfilled": true,
         "valueMode": "color"
       },
-      "pluginVersion": "10.0.1",
+      "pluginVersion": "9.5.3",
       "targets": [
         {
           "datasource": {
@@ -435,7 +435,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 34
+        "y": 17
       },
       "id": 38,
       "panels": [],
@@ -492,7 +492,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -504,7 +505,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 35
+        "y": 18
       },
       "id": 40,
       "options": {
@@ -564,7 +565,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 35
+        "y": 18
       },
       "id": 42,
       "maxDataPoints": 25,
@@ -608,7 +609,7 @@
           "unit": "percentunit"
         }
       },
-      "pluginVersion": "10.0.1",
+      "pluginVersion": "9.5.3",
       "targets": [
         {
           "datasource": {
@@ -655,7 +656,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 43
+        "y": 26
       },
       "id": 48,
       "options": {
@@ -747,7 +748,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -763,7 +765,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 43
+        "y": 26
       },
       "id": 52,
       "options": {
@@ -821,7 +823,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 51
+        "y": 34
       },
       "id": 50,
       "options": {
@@ -884,7 +886,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -988,7 +991,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 51
+        "y": 34
       },
       "id": 58,
       "options": {
@@ -1003,7 +1006,7 @@
         },
         "showHeader": true
       },
-      "pluginVersion": "10.0.1",
+      "pluginVersion": "9.5.3",
       "targets": [
         {
           "datasource": {
@@ -1029,7 +1032,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 84
+        "y": 42
       },
       "id": 46,
       "panels": [],
@@ -1084,7 +1087,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -1096,7 +1100,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 85
+        "y": 43
       },
       "id": 56,
       "options": {
@@ -1169,7 +1173,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 102
+        "y": 51
       },
       "id": 6,
       "panels": [],
@@ -1224,7 +1228,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1239,7 +1244,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 103
+        "y": 52
       },
       "id": 18,
       "options": {
@@ -1316,7 +1321,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1331,7 +1337,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 103
+        "y": 52
       },
       "id": 16,
       "options": {
@@ -1433,14 +1439,16 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "cps"
         },
         "overrides": []
       },
@@ -1448,7 +1456,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 103
+        "y": 52
       },
       "id": 8,
       "options": {
@@ -1473,7 +1481,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "reth_p2pstream_disconnected_errors{instance=~\"$instance\"}",
+          "expr": "rate(reth_p2pstream_disconnected_errors{instance=~\"$instance\"}[$__rate_interval])",
           "legendFormat": "P2P stream disconnected",
           "range": true,
           "refId": "A"
@@ -1484,7 +1492,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "reth_network_pending_session_failures{instance=~\"$instance\"}",
+          "expr": "rate(reth_network_pending_session_failures{instance=~\"$instance\"}[$__rate_interval])",
           "hide": false,
           "legendFormat": "Failed pending sessions",
           "range": true,
@@ -1496,7 +1504,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "reth_network_invalid_messages_received{instance=~\"$instance\"}",
+          "expr": "rate(reth_network_invalid_messages_received{instance=~\"$instance\"}[$__rate_interval])",
           "hide": false,
           "legendFormat": "Invalid messages",
           "range": true,
@@ -1527,7 +1535,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 111
+        "y": 60
       },
       "id": 54,
       "options": {
@@ -1691,7 +1699,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 136
+        "y": 68
       },
       "id": 24,
       "panels": [],
@@ -1745,7 +1753,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1785,7 +1794,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 137
+        "y": 69
       },
       "id": 26,
       "options": {
@@ -1899,14 +1908,16 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "cps"
         },
         "overrides": []
       },
@@ -1914,7 +1925,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 137
+        "y": 69
       },
       "id": 33,
       "options": {
@@ -1936,7 +1947,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "reth_downloaders_headers_timeout_errors{instance=~\"$instance\"}",
+          "expr": "rate(reth_downloaders_headers_timeout_errors{instance=~\"$instance\"}[$__rate_interval])",
           "legendFormat": "Request timed out",
           "range": true,
           "refId": "A"
@@ -1947,7 +1958,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "reth_downloaders_headers_unexpected_errors{instance=~\"$instance\"}",
+          "expr": "rate(reth_downloaders_headers_unexpected_errors{instance=~\"$instance\"}[$__rate_interval])",
           "hide": false,
           "legendFormat": "Unexpected error",
           "range": true,
@@ -1959,7 +1970,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "reth_downloaders_headers_validation_errors{instance=~\"$instance\"}",
+          "expr": "rate(reth_downloaders_headers_validation_errors{instance=~\"$instance\"}[$__rate_interval])",
           "hide": false,
           "legendFormat": "Invalid response",
           "range": true,
@@ -2015,7 +2026,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2030,7 +2042,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 145
+        "y": 77
       },
       "id": 36,
       "options": {
@@ -2079,7 +2091,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 170
+        "y": 85
       },
       "id": 32,
       "panels": [],
@@ -2134,14 +2146,16 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "locale"
         },
         "overrides": [
           {
@@ -2153,6 +2167,10 @@
               {
                 "id": "custom.axisPlacement",
                 "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "ops"
               }
             ]
           },
@@ -2165,6 +2183,10 @@
               {
                 "id": "custom.axisPlacement",
                 "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "ops"
               }
             ]
           }
@@ -2174,7 +2196,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 171
+        "y": 86
       },
       "id": 30,
       "options": {
@@ -2324,10 +2346,12 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
-          }
+          },
+          "unit": "cps"
         },
         "overrides": []
       },
@@ -2335,7 +2359,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 171
+        "y": 86
       },
       "id": 28,
       "options": {
@@ -2357,7 +2381,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "reth_downloaders_bodies_timeout_errors{instance=~\"$instance\"}",
+          "expr": "rate(reth_downloaders_bodies_timeout_errors{instance=~\"$instance\"}[$__rate_interval])",
           "legendFormat": "Request timed out",
           "range": true,
           "refId": "A"
@@ -2368,7 +2392,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "reth_downloaders_bodies_unexpected_errors{instance=~\"$instance\"}",
+          "expr": "rate(reth_downloaders_bodies_unexpected_errors{instance=~\"$instance\"}[$__rate_interval])",
           "hide": false,
           "legendFormat": "Unexpected error",
           "range": true,
@@ -2380,7 +2404,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "reth_downloaders_bodies_validation_errors{instance=~\"$instance\"}",
+          "expr": "rate(reth_downloaders_bodies_validation_errors{instance=~\"$instance\"}[$__rate_interval])",
           "hide": false,
           "legendFormat": "Invalid response",
           "range": true,
@@ -2436,7 +2460,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2451,7 +2476,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 179
+        "y": 94
       },
       "id": 35,
       "options": {
@@ -2540,14 +2565,16 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "bytes"
         },
         "overrides": [
           {
@@ -2559,6 +2586,10 @@
               {
                 "id": "custom.axisPlacement",
                 "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "blocks"
               }
             ]
           }
@@ -2568,7 +2599,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 179
+        "y": 94
       },
       "id": 73,
       "options": {
@@ -2592,7 +2623,7 @@
           "editorMode": "builder",
           "expr": "reth_downloaders_bodies_buffered_blocks_size_bytes{instance=~\"$instance\"}",
           "hide": false,
-          "legendFormat": "Buffered blocks size (bytes)",
+          "legendFormat": "Buffered blocks size ",
           "range": true,
           "refId": "A"
         },
@@ -2618,7 +2649,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 204
+        "y": 102
       },
       "id": 89,
       "panels": [],
@@ -2673,14 +2704,16 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -2688,7 +2721,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 205
+        "y": 103
       },
       "id": 91,
       "options": {
@@ -2711,7 +2744,7 @@
           },
           "editorMode": "builder",
           "expr": "reth_transaction_pool_basefee_pool_size_bytes{instance=~\"$instance\"}",
-          "legendFormat": "Base fee pool size (bytes)",
+          "legendFormat": "Base fee pool size",
           "range": true,
           "refId": "A"
         },
@@ -2723,7 +2756,7 @@
           "editorMode": "builder",
           "expr": "reth_transaction_pool_pending_pool_size_bytes{instance=~\"$instance\"}",
           "hide": false,
-          "legendFormat": "Pending pool size (bytes)",
+          "legendFormat": "Pending pool size",
           "range": true,
           "refId": "B"
         },
@@ -2735,7 +2768,7 @@
           "editorMode": "builder",
           "expr": "reth_transaction_pool_queued_pool_size_bytes{instance=~\"$instance\"}",
           "hide": false,
-          "legendFormat": "Queued pool size (bytes)",
+          "legendFormat": "Queued pool size",
           "range": true,
           "refId": "C"
         }
@@ -2789,7 +2822,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2804,7 +2838,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 205
+        "y": 103
       },
       "id": 92,
       "options": {
@@ -2871,7 +2905,7 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisCenteredZero": false,
+            "axisCenteredZero": true,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
@@ -2905,22 +2939,53 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "ops"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "custom.transform",
+                "value": "negative-Y"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "C"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "cps"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 213
+        "y": 111
       },
       "id": 93,
       "options": {
@@ -2931,7 +2996,7 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
+          "mode": "multi",
           "sort": "none"
         }
       },
@@ -2942,7 +3007,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "reth_transaction_pool_inserted_transactions{instance=~\"$instance\"}",
+          "expr": "increase(reth_transaction_pool_inserted_transactions{instance=~\"$instance\"}[$__rate_interval])",
           "legendFormat": "Inserted transactions",
           "range": true,
           "refId": "A"
@@ -2953,7 +3018,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "reth_transaction_pool_removed_transactions{instance=~\"$instance\"}",
+          "expr": "increase(reth_transaction_pool_removed_transactions{instance=~\"$instance\"}[$__rate_interval])",
           "hide": false,
           "legendFormat": "Removed transactions",
           "range": true,
@@ -2965,7 +3030,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "reth_transaction_pool_invalid_transactions{instance=~\"$instance\"}",
+          "expr": "increase(reth_transaction_pool_invalid_transactions{instance=~\"$instance\"}[$__rate_interval])",
           "hide": false,
           "legendFormat": "Invalid transactions",
           "range": true,
@@ -3021,7 +3086,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3036,7 +3102,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 213
+        "y": 111
       },
       "id": 94,
       "options": {
@@ -3080,7 +3146,7 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisCenteredZero": false,
+            "axisCenteredZero": true,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
@@ -3114,22 +3180,49 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "cps"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "custom.transform",
+                "value": "negative-Y"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "C"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "events"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 221
+        "y": 119
       },
       "id": 95,
       "options": {
@@ -3150,13 +3243,37 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
+          "editorMode": "builder",
+          "expr": "increase(reth_network_pool_transactions_messages_sent{instance=~\"$instance\"}[$__rate_interval])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Tx",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "builder",
+          "expr": "increase(reth_network_pool_transactions_messages_received{instance=~\"$instance\"}[$__rate_interval])",
+          "hide": false,
+          "legendFormat": "Rx",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "editorMode": "code",
           "expr": "reth_network_pool_transactions_messages_sent{instance=~\"$instance\"} - reth_network_pool_transactions_messages_received{instance=~\"$instance\"}",
           "hide": false,
-          "instant": false,
-          "legendFormat": "Total events in the channel",
+          "legendFormat": "Messages in channel",
           "range": true,
-          "refId": "A"
+          "refId": "C"
         }
       ],
       "title": "Network transaction channel",
@@ -3168,7 +3285,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 254
+        "y": 127
       },
       "id": 79,
       "panels": [],
@@ -3223,7 +3340,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3238,7 +3356,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 255
+        "y": 128
       },
       "id": 74,
       "options": {
@@ -3316,7 +3434,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3331,7 +3450,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 255
+        "y": 128
       },
       "id": 80,
       "options": {
@@ -3409,7 +3528,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3424,7 +3544,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 263
+        "y": 136
       },
       "id": 81,
       "options": {
@@ -3462,7 +3582,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 288
+        "y": 144
       },
       "id": 87,
       "panels": [],
@@ -3517,7 +3637,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3532,7 +3653,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 289
+        "y": 145
       },
       "id": 83,
       "options": {
@@ -3609,7 +3730,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3624,7 +3746,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 289
+        "y": 145
       },
       "id": 84,
       "options": {
@@ -3713,7 +3835,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3728,7 +3851,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 297
+        "y": 153
       },
       "id": 85,
       "options": {
@@ -3760,296 +3883,298 @@
       "type": "timeseries"
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 322
+        "y": 161
       },
       "id": 68,
-      "panels": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "description": "Number of active jobs",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 3,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 11,
-            "x": 0,
-            "y": 33
-          },
-          "id": 60,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "builder",
-              "expr": "reth_payloads_active_jobs{instance=~\"$instance\"}",
-              "legendFormat": "Active Jobs",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Active Jobs",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "description": "Total number of initiated jobs",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 3,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 13,
-            "x": 11,
-            "y": 33
-          },
-          "id": 62,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "builder",
-              "expr": "reth_payloads_initiated_jobs{instance=~\"$instance\"}",
-              "legendFormat": "Initiated Jobs",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Initiated Jobs",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "description": "Total number of failed jobs",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 3,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 11,
-            "x": 0,
-            "y": 41
-          },
-          "id": 64,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "builder",
-              "expr": "reth_payloads_failed_jobs{instance=~\"$instance\"}",
-              "legendFormat": "Failed Jobs",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Failed Jobs",
-          "type": "timeseries"
-        }
-      ],
+      "panels": [],
       "repeat": "instance",
       "repeatDirection": "h",
       "title": "Payload Builder ($instance)",
       "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Number of active jobs",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 3,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 11,
+        "x": 0,
+        "y": 162
+      },
+      "id": 60,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "builder",
+          "expr": "reth_payloads_active_jobs{instance=~\"$instance\"}",
+          "legendFormat": "Active Jobs",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Active Jobs",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Total number of initiated jobs",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 3,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 13,
+        "x": 11,
+        "y": 162
+      },
+      "id": 62,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "builder",
+          "expr": "reth_payloads_initiated_jobs{instance=~\"$instance\"}",
+          "legendFormat": "Initiated Jobs",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Initiated Jobs",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Total number of failed jobs",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 3,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 11,
+        "x": 0,
+        "y": 170
+      },
+      "id": 64,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "builder",
+          "expr": "reth_payloads_failed_jobs{instance=~\"$instance\"}",
+          "legendFormat": "Failed Jobs",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Failed Jobs",
+      "type": "timeseries"
     },
     {
       "collapsed": false,
@@ -4057,7 +4182,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 324
+        "y": 177
       },
       "id": 97,
       "panels": [],
@@ -4109,7 +4234,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -4125,7 +4251,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 325
+        "y": 178
       },
       "id": 98,
       "options": {
@@ -4268,7 +4394,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -4284,7 +4411,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 325
+        "y": 178
       },
       "id": 101,
       "options": {
@@ -4362,7 +4489,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -4378,7 +4506,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 333
+        "y": 186
       },
       "id": 99,
       "options": {
@@ -4456,7 +4584,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -4472,7 +4601,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 333
+        "y": 186
       },
       "id": 100,
       "options": {
@@ -4544,6 +4673,6 @@
   "timezone": "",
   "title": "reth",
   "uid": "2k8BXz24x",
-  "version": 8,
+  "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
Some adjustments to the dashboard

- The graphs that used to say `(bytes)` now use the bytes unit instead (buffer sizes, tx pool size, ...)
- The error graphs now plot cps (errors/s)
- Two graphs utilize inverted y-axis to visualize two opposing operations (insert/remove, tx/rx). The "Network transaction channel" graph wasn't really clear to me since it just plotted 0, -1 or +1 for me all the time. See example below of these two graphs

![image](https://github.com/paradigmxyz/reth/assets/8862627/12b32cd8-1dac-43b7-895f-08ce894e0735)
