### PR TITLE
fix: expose the revm_utils to consumer as needed structs from it

### DIFF
--- a/crates/rpc/rpc/src/eth/mod.rs
+++ b/crates/rpc/rpc/src/eth/mod.rs
@@ -8,7 +8,7 @@ pub mod gas_oracle;
 mod id_provider;
 mod logs_utils;
 mod pubsub;
-pub(crate) mod revm_utils;
+pub mod revm_utils;
 mod signer;
 pub(crate) mod utils;
 


### PR DESCRIPTION
stuff like `EvmOverrides` i need to be able to use the .call methods