### PR TITLE
fix: remove txn header from getPayloadBodies

### DIFF
--- a/crates/rpc/rpc-types/src/eth/engine/payload.rs
+++ b/crates/rpc/rpc-types/src/eth/engine/payload.rs
@@ -4,7 +4,7 @@ use reth_primitives::{
     Address, Block, Bloom, Bytes, Header, SealedBlock, TransactionSigned, UintTryTo, Withdrawal,
     H256, H64, U256, U64,
 };
-use reth_rlp::{Decodable, Encodable};
+use reth_rlp::Decodable;
 use serde::{ser::SerializeMap, Deserialize, Serialize, Serializer};
 
 /// The execution payload body response that allows for `null` values.
@@ -229,7 +229,7 @@ impl From<Block> for ExecutionPayloadBody {
     fn from(value: Block) -> Self {
         let transactions = value.body.into_iter().map(|tx| {
             let mut out = Vec::new();
-            tx.encode(&mut out);
+            tx.encode_enveloped(&mut out);
             out.into()
         });
         ExecutionPayloadBody {


### PR DESCRIPTION
The encoding of `SignedTransaction` in `ExecutionPayloadBody` was incorrect, which would result in bad data being returned to CLs on the `getPayloadBodies*` endpoints. This would cause Lighthouse to log errors:

> ERRO Error fetching block for peer, error: InconsistentPayloadReconstructed { slot: Slot(6803744), exec_block_hash: 0x85631119cb57a0e67c2ee2c28c9a3d68da7c95f504f24f87444dda0b687e85ff, canonical_transactions_root: 0x24ddbe07a91cb7271f0422a7379615b9996834057ee59ad5e445c6561f95e20c, reconstructed_transactions_root: 0x02462a94e4c74114f0bc380dda897587eb590a7b56ec7a6654c468eaca68f536 }, block_root: 0x0d02cd05a9a5725cd62e3b0eb50f722a636bbc49b5b62ca6a1dbbd56a52b8013, module: network::beacon_processor::worker::rpc_methods:419

The encoding issue was caused by the inclusion of an RLP header, i.e. not using the enveloped encoding.

I've tested my change manually using [this script](https://github.com/michaelsproul/eth2-scripts/blob/master/engine_payload_by_range.sh) at block 0x10d73e9, comparing stock Reth vs my branch vs Besu. After applying my patch, Reth now returns the same result as Besu (detail in this gist: https://gist.github.com/michaelsproul/5cc6052568fa7bd215967e6a0283d411).