### PR TITLE
chore(prometheus): add host.docker.internal:9001 scrape target

### DIFF
--- a/etc/prometheus/prometheus.yml
+++ b/etc/prometheus/prometheus.yml
@@ -3,7 +3,7 @@ scrape_configs:
     metrics_path: "/"
     scrape_interval: 5s
     static_configs:
-      - targets: ['reth:9001', 'localhost:9001']
+      - targets: ['reth:9001', 'localhost:9001', 'host.docker.internal:9001']
   - job_name: ethereum-metrics-exporter
     metrics_path: "/metrics"
     scrape_interval: 5s


### PR DESCRIPTION
It was removed in https://github.com/paradigmxyz/reth/commit/da58e39c26da77fe4e8f8ffdc0c60f49555a28e7, probably assuming we will only use this `prometheus.yml` when running with Docker.

This is not true, as there are three different setups:
1. Reth in Docker, Prometheus in Docker – target `reth:9001` is used
2. Reth native, Prometheus in Docker – targets `host.docker.internal:9001` for Mac and `localhost:9001` for Linux are used
3. Reth native or in Docker, Prometheus native – target `localhost:9001` is used