### PR TITLE
fix: check if value is bool

### DIFF
--- a/crates/rpc/rpc-types/src/eth/pubsub.rs
+++ b/crates/rpc/rpc-types/src/eth/pubsub.rs
@@ -104,8 +104,8 @@ pub enum Params {
     None,
     /// Log parameters.
     Logs(Box<Filter>),
-    /// New pending transaction parameters.
-    NewPendingTransactions(bool),
+    /// Boolean parameter for new pending transactions.
+    Bool(bool),
 }
 
 impl Serialize for Params {
@@ -116,7 +116,7 @@ impl Serialize for Params {
         match self {
             Params::None => (&[] as &[serde_json::Value]).serialize(serializer),
             Params::Logs(logs) => logs.serialize(serializer),
-            Params::NewPendingTransactions(full) => full.serialize(serializer),
+            Params::Bool(full) => full.serialize(serializer),
         }
     }
 }
@@ -130,6 +130,10 @@ impl<'a> Deserialize<'a> for Params {
 
         if v.is_null() {
             return Ok(Params::None)
+        }
+
+        if let Some(val) = v.as_bool() {
+            return Ok(Params::Bool(val))
         }
 
         serde_json::from_value(v)

--- a/crates/rpc/rpc/src/eth/pubsub.rs
+++ b/crates/rpc/rpc/src/eth/pubsub.rs
@@ -124,7 +124,7 @@ where
         SubscriptionKind::NewPendingTransactions => {
             if let Some(params) = params {
                 match params {
-                    Params::NewPendingTransactions(true) => {
+                    Params::Bool(true) => {
                         // full transaction objects requested
                         let stream = pubsub.full_pending_transaction_stream().map(|tx| {
                             EthSubscriptionResult::FullTransaction(Box::new(
@@ -135,7 +135,7 @@ where
                         });
                         return pipe_from_stream(accepted_sink, stream).await
                     }
-                    Params::NewPendingTransactions(false) | Params::None => {
+                    Params::Bool(false) | Params::None => {
                         // only hashes requested
                     }
                     Params::Logs(_) => {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4a56d0a</samp>

Fixed a bug in the Ethereum pub/sub API for subscribing to new pending transactions by renaming and generalizing a parameter enum variant in `rpc-types` and `rpc` crates.