### PR TITLE
feat: add performed pool state updates metric

### DIFF
--- a/crates/transaction-pool/src/metrics.rs
+++ b/crates/transaction-pool/src/metrics.rs
@@ -33,4 +33,7 @@ pub struct TxPoolMetrics {
 
     /// Number of all transactions of all sub-pools: pending + basefee + queued
     pub(crate) total_transactions: Gauge,
+
+    /// How often the pool was updated after the canonical state changed
+    pub(crate) performed_state_updates: Counter,
 }

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -261,6 +261,8 @@ impl<T: TransactionOrdering> TxPool<T> {
         // update the metrics after the update
         self.update_size_metrics();
 
+        self.metrics.performed_state_updates.increment(1);
+
         OnNewCanonicalStateOutcome { block_hash, mined: mined_transactions, promoted, discarded }
     }
 


### PR DESCRIPTION
new metric helps monitor how often the has been updated on new canonical state

would need some help adding this to dashboard -.- @onbjerg 