### PR TITLE
chore: use `transaction_by_id_no_hash` to avoid hash computation

### DIFF
--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -453,8 +453,14 @@ mod tests {
 
                     while let Some((_, body)) = body_cursor.next()? {
                         for tx_id in body.tx_num_range() {
-                            let transaction: TransactionSigned =
-                                provider.transaction_by_id(tx_id)?.expect("no transaction entry");
+                            let transaction: TransactionSigned = provider
+                                .transaction_by_id_no_hash(tx_id)?
+                                .map(|tx| TransactionSigned {
+                                    hash: Default::default(), // we don't require the hash
+                                    signature: tx.signature,
+                                    transaction: tx.transaction,
+                                })
+                                .expect("no transaction entry");
                             let signer =
                                 transaction.recover_signer().expect("failed to recover signer");
                             assert_eq!(Some(signer), provider.transaction_sender(tx_id)?)

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -935,12 +935,16 @@ impl<'this, TX: DbTx<'this>> TransactionsProvider for DatabaseProvider<'this, TX
     }
 
     fn transaction_by_id_no_hash(&self, id: TxNumber) -> Result<Option<TransactionSignedNoHash>> {
-        Ok(self.tx.get::<tables::Transactions>(id)?.map(Into::into))
+        Ok(self.tx.get::<tables::Transactions>(id)?)
     }
 
     fn transaction_by_hash(&self, hash: TxHash) -> Result<Option<TransactionSigned>> {
         if let Some(id) = self.transaction_id(hash)? {
-            Ok(self.transaction_by_id(id)?)
+            Ok(self.transaction_by_id_no_hash(id)?.map(|tx| TransactionSigned {
+                hash,
+                signature: tx.signature,
+                transaction: tx.transaction,
+            }))
         } else {
             Ok(None)
         }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -957,7 +957,12 @@ impl<'this, TX: DbTx<'this>> TransactionsProvider for DatabaseProvider<'this, TX
     ) -> Result<Option<(TransactionSigned, TransactionMeta)>> {
         let mut transaction_cursor = self.tx.cursor_read::<tables::TransactionBlock>()?;
         if let Some(transaction_id) = self.transaction_id(tx_hash)? {
-            if let Some(transaction) = self.transaction_by_id(transaction_id)? {
+            if let Some(tx) = self.transaction_by_id_no_hash(transaction_id)? {
+                let transaction = TransactionSigned {
+                    hash: tx_hash,
+                    signature: tx.signature,
+                    transaction: tx.transaction,
+                };
                 if let Some(block_number) =
                     transaction_cursor.seek(transaction_id).map(|b| b.map(|(_, bn)| bn))?
                 {

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -956,28 +956,30 @@ impl<'this, TX: DbTx<'this>> TransactionsProvider for DatabaseProvider<'this, TX
         tx_hash: TxHash,
     ) -> Result<Option<(TransactionSigned, TransactionMeta)>> {
         let mut transaction_cursor = self.tx.cursor_read::<tables::TransactionBlock>()?;
-        if let Some(transaction) = self.transaction_by_hash(tx_hash)? {
-            if let Some(block_number) =
-                transaction_cursor.seek(transaction_id).map(|b| b.map(|(_, bn)| bn))?
-            {
-                if let Some(sealed_header) = self.sealed_header(block_number)? {
-                    let (header, block_hash) = sealed_header.split();
-                    if let Some(block_body) = self.block_body_indices(block_number)? {
-                        // the index of the tx in the block is the offset:
-                        // len([start..tx_id])
-                        // SAFETY: `transaction_id` is always `>=` the block's first
-                        // index
-                        let index = transaction_id - block_body.first_tx_num();
+        if let Some(transaction_id) = self.transaction_id(tx_hash)? {
+            if let Some(transaction) = self.transaction_by_id(transaction_id)? {
+                if let Some(block_number) =
+                    transaction_cursor.seek(transaction_id).map(|b| b.map(|(_, bn)| bn))?
+                {
+                    if let Some(sealed_header) = self.sealed_header(block_number)? {
+                        let (header, block_hash) = sealed_header.split();
+                        if let Some(block_body) = self.block_body_indices(block_number)? {
+                            // the index of the tx in the block is the offset:
+                            // len([start..tx_id])
+                            // SAFETY: `transaction_id` is always `>=` the block's first
+                            // index
+                            let index = transaction_id - block_body.first_tx_num();
 
-                        let meta = TransactionMeta {
-                            tx_hash,
-                            index,
-                            block_hash,
-                            block_number,
-                            base_fee: header.base_fee_per_gas,
-                        };
+                            let meta = TransactionMeta {
+                                tx_hash,
+                                index,
+                                block_hash,
+                                block_number,
+                                base_fee: header.base_fee_per_gas,
+                            };
 
-                        return Ok(Some((transaction, meta)))
+                            return Ok(Some((transaction, meta)))
+                        }
                     }
                 }
             }


### PR DESCRIPTION
`transaction_by_hash` & ` transaction_by_hash_with_meta` were recalculating the hash, when in fact we already have it