### PR TITLE
perf: only update finalized safe if changed

### DIFF
--- a/crates/consensus/beacon/src/engine/forkchoice.rs
+++ b/crates/consensus/beacon/src/engine/forkchoice.rs
@@ -39,6 +39,8 @@ impl ForkchoiceStateTracker {
     }
 
     /// Returns the [ForkchoiceStatus] of the latest received FCU.
+    ///
+    /// Caution: this can be invalid.
     pub(crate) fn latest_status(&self) -> Option<ForkchoiceStatus> {
         self.latest.as_ref().map(|s| s.status)
     }


### PR DESCRIPTION
Closes #3723

finalized/safe only change on epoch so before we fetch from disk we should check if they even changed which is cheaper overall because stored in memory