### PR TITLE
#3667 Add Dial Success Metric

### DIFF
--- a/crates/net/network/src/metrics.rs
+++ b/crates/net/network/src/metrics.rs
@@ -45,6 +45,14 @@ pub struct NetworkMetrics {
     pub(crate) total_dropped_eth_requests_at_full_capacity: Counter,
 }
 
+/// Metrics for SessionManager
+#[derive(Metrics)]
+#[metrics(scope = "network")]
+pub struct SesssionManagerMetrics {
+    /// Number of dials that resulted in a peer being added to the peerset
+    pub(crate) total_dial_successes: Counter,
+}
+
 /// Metrics for the TransactionsManager
 #[derive(Metrics)]
 #[metrics(scope = "network")]

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -477,9 +477,8 @@ impl SessionManager {
                 self.active_sessions.insert(peer_id, handle);
                 self.counter.inc_active(&direction);
 
-                match direction {
-                    Direction::Outgoing(_) => self.metrics.total_dial_successes.increment(1),
-                    _ => {}
+                if direction.is_outgoing() {
+                    self.metrics.total_dial_successes.increment(1);
                 }
 
                 Poll::Ready(SessionEvent::SessionEstablished {
@@ -703,6 +702,11 @@ impl Direction {
     /// Returns `true` if this an incoming connection.
     pub(crate) fn is_incoming(&self) -> bool {
         matches!(self, Direction::Incoming)
+    }
+
+    /// Returns `true` if this an outgoing connection.
+    pub(crate) fn is_outgoing(&self) -> bool {
+        matches!(self, Direction::Outgoing(_))
     }
 }
 


### PR DESCRIPTION
adds a metric for how many outgoing dials resulted in an active session
closes [issue](https://github.com/paradigmxyz/reth/issues/3667)