### PR TITLE
fix: perform forkchoice update consistency checks

### DIFF
--- a/crates/blockchain-tree/src/shareable.rs
+++ b/crates/blockchain-tree/src/shareable.rs
@@ -158,6 +158,11 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeViewer
         self.tree.read().block_indices().canonical_tip()
     }
 
+    fn is_canonical(&self, hash: BlockHash) -> Result<bool, Error> {
+        trace!(target: "blockchain_tree", ?hash, "Checking if block is canonical");
+        self.tree.read().is_block_hash_canonical(&hash)
+    }
+
     fn pending_blocks(&self) -> (BlockNumber, Vec<BlockHash>) {
         trace!(target: "blockchain_tree", "Returning all pending blocks");
         self.tree.read().block_indices().pending_blocks()

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -630,7 +630,7 @@ where
                     debug!(target: "consensus::engine", hash=?state.head_block_hash, number=outcome.header().number, "canonicalized new head");
 
                     // new VALID update that moved the canonical chain forward
-                    let _ = self.update_canon_chain(outcome.header().clone(), &state);
+                    let _ = self.update_head(outcome.header().clone());
                 } else {
                     debug!(target: "consensus::engine", fcu_head_num=?outcome.header().number, current_head_num=?self.blockchain.canonical_tip().number, "Ignoring beacon update to old head");
                 }
@@ -684,8 +684,11 @@ where
     ///
     /// If the forkchoice state is consistent, this will return Ok(None). Otherwise, this will
     /// return an instance of [OnForkChoiceUpdated] that is INVALID.
+    ///
+    /// This also updates the safe and finalized blocks in the [CanonChainTracker], if they are
+    /// consistent with the head block.
     fn ensure_consistent_with_status(
-        &self,
+        &mut self,
         state: ForkchoiceState,
         status: &PayloadStatus,
     ) -> Result<Option<OnForkChoiceUpdated>, reth_interfaces::Error> {
@@ -711,8 +714,11 @@ where
     ///
     /// If the forkchoice state is consistent, this will return Ok(None). Otherwise, this will
     /// return an instance of [OnForkChoiceUpdated] that is INVALID.
+    ///
+    /// This also updates the safe and finalized blocks in the [CanonChainTracker], if they are
+    /// consistent with the head block.
     fn ensure_consistent(
-        &self,
+        &mut self,
         state: ForkchoiceState,
     ) -> Result<Option<OnForkChoiceUpdated>, reth_interfaces::Error> {
         // Ensure that the finalized block, if not zero, is known and in the canonical chain
@@ -726,6 +732,9 @@ where
             return Ok(Some(OnForkChoiceUpdated::invalid_state()))
         }
 
+        // Finalized block is consistent, so update it in the canon chain tracker.
+        self.update_finalized_block(state.finalized_block_hash)?;
+
         // Also ensure that the safe block, if not zero, is known and in the canonical chain
         // after the head block is canonicalized.
         //
@@ -737,6 +746,9 @@ where
             return Ok(Some(OnForkChoiceUpdated::invalid_state()))
         }
 
+        // Safe block is consistent, so update it in the canon chain tracker.
+        self.update_safe_block(state.safe_block_hash)?;
+
         Ok(None)
     }
 
@@ -746,12 +758,28 @@ where
     ///
     /// Additionally, updates the head used for p2p handshakes.
     ///
-    /// This should be called before issuing a VALID forkchoice update.
+    /// This also updates the tracked safe and finalized blocks, and should be called before
+    /// issuing a VALID forkchoice update.
     fn update_canon_chain(
         &self,
         head: SealedHeader,
         update: &ForkchoiceState,
     ) -> Result<(), Error> {
+        self.update_head(head)?;
+        self.update_finalized_block(update.finalized_block_hash)?;
+        self.update_safe_block(update.safe_block_hash)?;
+
+        Ok(())
+    }
+
+    /// Updates the state of the canon chain tracker based on the given head.
+    ///
+    /// This expects the given head to be the new canonical head.
+    /// Additionally, updates the head used for p2p handshakes.
+    ///
+    /// This should be called before issuing a VALID forkchoice update.
+    #[inline]
+    fn update_head(&self, head: SealedHeader) -> Result<(), reth_interfaces::Error> {
         let mut head_block = Head {
             number: head.number,
             hash: head.hash,
@@ -763,9 +791,6 @@ where
 
         // we update the the tracked header first
         self.blockchain.set_canonical_head(head);
-
-        self.update_finalized_block(update.finalized_block_hash)?;
-        self.update_safe_block(update.safe_block_hash)?;
 
         head_block.total_difficulty =
             self.blockchain.header_td_by_number(head_block.number)?.ok_or_else(|| {

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -759,7 +759,7 @@ where
     /// Additionally, updates the head used for p2p handshakes.
     ///
     /// This also updates the tracked safe and finalized blocks, and should be called before
-    /// issuing a VALID forkchoice update.
+    /// return a VALID forkchoice update response
     fn update_canon_chain(
         &self,
         head: SealedHeader,

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -761,7 +761,7 @@ where
     /// Additionally, updates the head used for p2p handshakes.
     ///
     /// This also updates the tracked safe and finalized blocks, and should be called before
-    /// return a VALID forkchoice update response
+    /// returning a VALID forkchoice update response
     fn update_canon_chain(
         &self,
         head: SealedHeader,
@@ -779,7 +779,7 @@ where
     /// This expects the given head to be the new canonical head.
     /// Additionally, updates the head used for p2p handshakes.
     ///
-    /// This should be called before issuing a VALID forkchoice update.
+    /// This should be called before returning a VALID forkchoice update response
     #[inline]
     fn update_head(&self, head: SealedHeader) -> Result<(), reth_interfaces::Error> {
         let mut head_block = Head {

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -639,7 +639,7 @@ where
                     // if we return early then we wouldn't perform these consistency checks, so we
                     // need to do them here, and should do them before we process any payload
                     // attributes
-                    if let Some(invalid_fcu_response) = self.ensure_consistent(state)? {
+                    if let Some(invalid_fcu_response) = self.ensure_consistent_state(state)? {
                         trace!(target: "consensus::engine", ?state, head=?state.head_block_hash, "Forkchoice state is inconsistent, returning invalid response");
                         return Ok(invalid_fcu_response)
                     }
@@ -669,7 +669,9 @@ where
             }
         };
 
-        if let Some(invalid_fcu_response) = self.ensure_consistent_with_status(state, &status)? {
+        if let Some(invalid_fcu_response) =
+            self.ensure_consistent_state_with_status(state, &status)?
+        {
             trace!(target: "consensus::engine", ?status, ?state, "Forkchoice state is inconsistent, returning invalid response");
             return Ok(invalid_fcu_response)
         }
@@ -687,7 +689,7 @@ where
     ///
     /// This also updates the safe and finalized blocks in the [CanonChainTracker], if they are
     /// consistent with the head block.
-    fn ensure_consistent_with_status(
+    fn ensure_consistent_state_with_status(
         &mut self,
         state: ForkchoiceState,
         status: &PayloadStatus,
@@ -703,7 +705,7 @@ where
         // we likely do not have the finalized or safe blocks, and would return an incorrect
         // INVALID status instead.
         if status.is_valid() {
-            return self.ensure_consistent(state)
+            return self.ensure_consistent_state(state)
         }
 
         Ok(None)
@@ -717,7 +719,7 @@ where
     ///
     /// This also updates the safe and finalized blocks in the [CanonChainTracker], if they are
     /// consistent with the head block.
-    fn ensure_consistent(
+    fn ensure_consistent_state(
         &mut self,
         state: ForkchoiceState,
     ) -> Result<Option<OnForkChoiceUpdated>, reth_interfaces::Error> {

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -606,6 +606,13 @@ where
             return Ok(OnForkChoiceUpdated::with_invalid(status))
         }
 
+        // ensure that the finalized block, if not zero, is known and in the canonical chain
+        if !state.finalized_block_hash.is_zero() &&
+            !self.blockchain.is_canonical(&state.finalized_block_hash)?
+        {
+            return Ok(OnForkChoiceUpdated::invalid_state())
+        }
+
         if self.sync.is_pipeline_active() {
             // We can only process new forkchoice updates if the pipeline is idle, since it requires
             // exclusive access to the database

--- a/crates/interfaces/src/blockchain_tree/mod.rs
+++ b/crates/interfaces/src/blockchain_tree/mod.rs
@@ -217,6 +217,9 @@ pub trait BlockchainTreeViewer: Send + Sync {
     /// Note: this could be the given `parent_hash` if it's already canonical.
     fn find_canonical_ancestor(&self, parent_hash: BlockHash) -> Option<BlockHash>;
 
+    /// Return whether or not the block is known and in the canonical chain.
+    fn is_canonical(&self, hash: BlockHash) -> Result<bool, Error>;
+
     /// Given the hash of a block, this checks the buffered blocks for the lowest ancestor in the
     /// buffer.
     ///

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -655,6 +655,10 @@ where
         self.tree.canonical_tip()
     }
 
+    fn is_canonical(&self, hash: BlockHash) -> std::result::Result<bool, Error> {
+        self.tree.is_canonical(hash)
+    }
+
     fn pending_blocks(&self) -> (BlockNumber, Vec<BlockHash>) {
         self.tree.pending_blocks()
     }


### PR DESCRIPTION
Previously we didn't check that the forkchoice state was consistent with the head that was made canonical, i.e., we did not check that the safe block is an ancestor of the head block, and did not check that the finalized block is an ancestor of the head / safe blocks. This adds a method to check that a block is canonical in `BlockchainTreeViewer` so we can perform these checks.

Consistency checks are done in geth _after_ the forkchoice update is processed and head block is made canonical:
https://github.com/ethereum/go-ethereum/blob/2754b197c935ee63101cbbca2752338246384fec/eth/catalyst/api.go#L315-L318

So we do the same thing here. The safe / finalized blocks are updated in the chain tracker as they are known to be consistent with the head block.

Fixes #2955

Fixes additional hive tests:
 * `Unknown HeadBlockHash`
 * `Unknown SafeBlockHash`
 * `Unknown FinalizedBlockHash`