### PR TITLE
fix(consensus): call `finalize_block` when finalized block changes.

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -715,19 +715,13 @@ where
                 return Ok(())
             }
 
-            let block_number =
-                self.blockchain.block_number(finalized_block_hash)?.ok_or_else(|| {
-                    Error::Provider(ProviderError::UnknownBlockHash(finalized_block_hash))
-                })?;
-
-            self.blockchain.finalize_block(block_number);
-
             let finalized = self
                 .blockchain
                 .find_block_by_hash(finalized_block_hash, BlockSource::Any)?
                 .ok_or_else(|| {
                     Error::Provider(ProviderError::UnknownBlockHash(finalized_block_hash))
                 })?;
+            self.blockchain.finalize_block(finalized.number);
             self.blockchain.set_finalized(finalized.header.seal(finalized_block_hash));
         }
         Ok(())

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -715,6 +715,13 @@ where
                 return Ok(())
             }
 
+            let block_number =
+                self.blockchain.block_number(finalized_block_hash)?.ok_or_else(|| {
+                    Error::Provider(ProviderError::UnknownBlockHash(finalized_block_hash))
+                })?;
+
+            self.blockchain.finalize_block(block_number);
+
             let finalized = self
                 .blockchain
                 .find_block_by_hash(finalized_block_hash, BlockSource::Any)?


### PR DESCRIPTION
This PR calls `finalize_block` from the `reth-blockchain-tree` crate in `update_finalized_block` on the `BeaconConsensusEngine`.

Closes #3722 