### PR TITLE
chore: enable jemalloc by default on unix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@
 name: release
 
 on:
-  pull_request:
   push:
     tags:
       - v*
@@ -15,17 +14,43 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  extract-version:
+    name: extract version
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Extract version
+        run: echo "VERSION=$(echo ${GITHUB_REF#refs/tags/})" >> $GITHUB_OUTPUT
+        id: extract_version
+    outputs:
+      VERSION: ${{ steps.extract_version.outputs.VERSION }}
   build:
     name: build release
     strategy:
       matrix:
-        arch: [x86_64-pc-windows-gnu]
+        arch: [aarch64-unknown-linux-gnu,
+               x86_64-unknown-linux-gnu,
+               x86_64-apple-darwin,
+               aarch64-apple-darwin,
+               x86_64-pc-windows-gnu]
         include:
+          -   arch: aarch64-unknown-linux-gnu
+              platform: ubuntu-20.04
+              profile: maxperf
+          -   arch: x86_64-unknown-linux-gnu
+              platform: ubuntu-20.04
+              profile: maxperf
+          -   arch: x86_64-apple-darwin
+              platform: macos-latest
+              profile: maxperf
+          -   arch: aarch64-apple-darwin
+              platform: macos-latest
+              profile: maxperf
           -   arch: x86_64-pc-windows-gnu
               platform: ubuntu-20.04
               profile: maxperf
 
     runs-on: ${{ matrix.platform }}
+    needs: extract-version
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -38,6 +63,16 @@ jobs:
           cache-on-failure: true
 
       # ==============================
+      # Apple M1 SDK setup
+      # ==============================
+
+      - name: Apple M1 setup
+        if: ${{ matrix.job.target == 'aarch64-apple-darwin' }}
+        run: |
+          echo "SDKROOT=$(xcrun -sdk macosx --show-sdk-path)" >> $GITHUB_ENV
+          echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version)" >> $GITHUB_ENV
+
+      # ==============================
       #       Builds
       # ==============================
 
@@ -45,3 +80,152 @@ jobs:
         run:  |
           cargo install cross
           env PROFILE=${{ matrix.profile }} make build-${{ matrix.arch }}
+
+      - name: Move cross-compiled binary
+        if:   matrix.arch != 'x86_64-pc-windows-gnu'
+        run: |
+          mkdir artifacts
+          mv target/${{ matrix.arch }}/${{ matrix.profile }}/reth ./artifacts
+
+      - name: Move cross-compiled binary (Windows)
+        if:   matrix.arch == 'x86_64-pc-windows-gnu'
+        run: |
+          mkdir artifacts
+          mv target/${{ matrix.arch }}/${{ matrix.profile }}/reth.exe ./artifacts
+
+      # ==============================
+      #       Signing
+      # ==============================
+
+      - name: Configure GPG and create artifacts
+        env:
+          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          export GPG_TTY=$(tty)
+          echo -n "$GPG_SIGNING_KEY" | base64 --decode | gpg --batch --import
+          cd artifacts
+          tar -czf reth-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz reth*
+          echo "$GPG_PASSPHRASE" | gpg --passphrase-fd 0 --pinentry-mode loopback --batch -ab reth-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz
+          mv *tar.gz* ..
+        shell: bash
+
+      # =======================================================================
+      # Upload artifacts
+      # This is required to share artifacts between different jobs
+      # =======================================================================
+      - name:  Upload artifact
+        uses:  actions/upload-artifact@v3
+        with:
+          name: reth-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz
+          path: reth-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz
+
+      - name: Upload signature
+        uses: actions/upload-artifact@v3
+        with:
+          name: reth-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz.asc
+          path: reth-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz.asc
+
+  draft-release:
+    name: draft release
+    needs:  [build, extract-version]
+    runs-on: ubuntu-20.04
+    env:
+      VERSION:  ${{ needs.extract-version.outputs.VERSION }}
+    permissions:
+      # Required to post the release
+      contents: write
+    steps:
+      # This is necessary for generating the changelog. It has to come before "Download Artifacts" or else it deletes the artifacts.
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      # ==============================
+      #       Download artifacts
+      # ==============================
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+
+      # ==============================
+      #       Create release draft
+      # ==============================
+      - name: Generate full changelog
+        id: changelog
+        run: |
+          echo "CHANGELOG<<EOF" >> $GITHUB_OUTPUT
+          echo "$(git log --pretty=format:"- %s" $(git describe --tags --abbrev=0 ${{ env.VERSION }}^)..${{ env.VERSION }})" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create release draft
+        env:
+          GITHUB_USER: ${{ github.repository_owner }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        # The formatting here is borrowed from Lighthouse (which is borrowed from OpenEthereum): https://github.com/openethereum/openethereum/blob/main/.github/workflows/build.yml
+        run: |
+          body=$(cat <<- "ENDBODY"
+          <Release Name>
+          
+          ## Testing Checklist (DELETE ME)
+          
+          - [ ] Run on testnet for 1-3 days.
+          - [ ] Resync a mainnet node.
+          - [ ] Ensure all CI checks pass.
+          
+          ## Release Checklist (DELETE ME)
+          
+          - [ ] Ensure all crates have had their versions bumped.
+          - [ ] Write the summary.
+          - [ ] Fill out the update priority.
+          - [ ] Ensure all binaries have been added.
+          - [ ] Prepare release posts (Twitter, ...).
+          
+          ## Summary
+          
+          Add a summary, including:
+          
+          - Critical bug fixes
+          - New features
+          - Any breaking changes (and what to expect)
+          
+          ## Update Priority
+          
+          This table provides priorities for which classes of users should update particular components.
+  
+          | User Class           | Priority        |
+          |----------------------|-----------------|
+          | Payload Builders     | <TODO> |
+          | Non-Payload Builders | <TODO>    |
+          
+          *See [Update Priorities](https://paradigmxyz.github.io/reth/installation/priorities.html) for more information about this table.*
+          
+          ## All Changes
+          
+          ${{ steps.changelog.outputs.CHANGELOG }}
+          
+          ## Binaries
+          
+          [See pre-built binaries documentation.](https://paradigmxyz.github.io/reth/installation/binaries.html)
+          
+          The binaries are signed with the PGP key: `A3AE 097C 8909 3A12 4049  DF1F 5391 A3C4 1005 30B4`
+          
+          | System | Architecture | Binary | PGP Signature |
+          |:---:|:---:|:---:|:---|
+          | <img src="https://simpleicons.org/icons/linux.svg" style="width: 32px;"/> | x86_64 | [reth-${{ env.VERSION }}-x86_64-unknown-linux-gnu.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/reth-${{ env.VERSION }}-x86_64-unknown-linux-gnu.tar.gz) | [PGP Signature](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/reth-${{ env.VERSION }}-x86_64-unknown-linux-gnu.tar.gz.asc) |
+          | <img src="https://simpleicons.org/icons/linux.svg" style="width: 32px;"/> | aarch64 | [reth-${{ env.VERSION }}-aarch64-unknown-linux-gnu.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/reth-${{ env.VERSION }}-aarch64-unknown-linux-gnu.tar.gz) | [PGP Signature](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/reth-${{ env.VERSION }}-aarch64-unknown-linux-gnu.tar.gz.asc) |
+          | <img src="https://simpleicons.org/icons/windows.svg" style="width: 32px;"/> | x86_64 | [reth-${{ env.VERSION }}-x86_64-pc-windows-gnu.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/reth-${{ env.VERSION }}-x86_64-pc-windows-gnu.tar.gz) | [PGP Signature](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/reth-${{ env.VERSION }}-x86_64-pc-windows-gnu.tar.gz.asc) |
+          | <img src="https://simpleicons.org/icons/apple.svg" style="width: 32px;"/> | x86_64 | [reth-${{ env.VERSION }}-x86_64-apple-darwin.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/reth-${{ env.VERSION }}-x86_64-apple-darwin.tar.gz) | [PGP Signature](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/reth-${{ env.VERSION }}-x86_64-apple-darwin.tar.gz.asc) |
+          | <img src="https://simpleicons.org/icons/apple.svg" style="width: 32px;"/> | aarch64 | [reth-${{ env.VERSION }}-aarch64-apple-darwin.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/reth-${{ env.VERSION }}-aarch64-apple-darwin.tar.gz) | [PGP Signature](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/reth-${{ env.VERSION }}-aarch64-apple-darwin.tar.gz.asc) |
+          | | | | |
+          | **System** | **Option** | - | **Resource** |
+          | <img src="https://simpleicons.org/icons/docker.svg" style="width: 32px;"/> | Docker | [${{ env.VERSION }}](https://github.com/paradigmxyz/reth/pkgs/container/reth/102974600?tag=${{ env.VERSION }}) | [${{ env.IMAGE_NAME }}](https://github.com/paradigmxyz/reth/pkgs/container/reth) |
+          ENDBODY
+          )
+          assets=()
+          for asset in ./reth-*.tar.gz*; do
+              assets+=("-a" "$asset/$asset")
+          done
+          tag_name="${{ env.VERSION }}"
+          echo "$body" | hub release create --draft "${assets[@]}" -F "-" "$tag_name"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@
 name: release
 
 on:
+  pull_request:
   push:
     tags:
       - v*
@@ -14,43 +15,17 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  extract-version:
-    name: extract version
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Extract version
-        run: echo "VERSION=$(echo ${GITHUB_REF#refs/tags/})" >> $GITHUB_OUTPUT
-        id: extract_version
-    outputs:
-      VERSION: ${{ steps.extract_version.outputs.VERSION }}
   build:
     name: build release
     strategy:
       matrix:
-        arch: [aarch64-unknown-linux-gnu,
-               x86_64-unknown-linux-gnu,
-               x86_64-apple-darwin,
-               aarch64-apple-darwin,
-               x86_64-pc-windows-gnu]
+        arch: [x86_64-pc-windows-gnu]
         include:
-          -   arch: aarch64-unknown-linux-gnu
-              platform: ubuntu-20.04
-              profile: maxperf
-          -   arch: x86_64-unknown-linux-gnu
-              platform: ubuntu-20.04
-              profile: maxperf
-          -   arch: x86_64-apple-darwin
-              platform: macos-latest
-              profile: maxperf
-          -   arch: aarch64-apple-darwin
-              platform: macos-latest
-              profile: maxperf
           -   arch: x86_64-pc-windows-gnu
               platform: ubuntu-20.04
               profile: maxperf
 
     runs-on: ${{ matrix.platform }}
-    needs: extract-version
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -63,16 +38,6 @@ jobs:
           cache-on-failure: true
 
       # ==============================
-      # Apple M1 SDK setup
-      # ==============================
-
-      - name: Apple M1 setup
-        if: ${{ matrix.job.target == 'aarch64-apple-darwin' }}
-        run: |
-          echo "SDKROOT=$(xcrun -sdk macosx --show-sdk-path)" >> $GITHUB_ENV
-          echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version)" >> $GITHUB_ENV
-
-      # ==============================
       #       Builds
       # ==============================
 
@@ -80,152 +45,3 @@ jobs:
         run:  |
           cargo install cross
           env PROFILE=${{ matrix.profile }} make build-${{ matrix.arch }}
-
-      - name: Move cross-compiled binary
-        if:   matrix.arch != 'x86_64-pc-windows-gnu'
-        run: |
-          mkdir artifacts
-          mv target/${{ matrix.arch }}/${{ matrix.profile }}/reth ./artifacts
-
-      - name: Move cross-compiled binary (Windows)
-        if:   matrix.arch == 'x86_64-pc-windows-gnu'
-        run: |
-          mkdir artifacts
-          mv target/${{ matrix.arch }}/${{ matrix.profile }}/reth.exe ./artifacts
-
-      # ==============================
-      #       Signing
-      # ==============================
-
-      - name: Configure GPG and create artifacts
-        env:
-          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        run: |
-          export GPG_TTY=$(tty)
-          echo -n "$GPG_SIGNING_KEY" | base64 --decode | gpg --batch --import
-          cd artifacts
-          tar -czf reth-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz reth*
-          echo "$GPG_PASSPHRASE" | gpg --passphrase-fd 0 --pinentry-mode loopback --batch -ab reth-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz
-          mv *tar.gz* ..
-        shell: bash
-
-      # =======================================================================
-      # Upload artifacts
-      # This is required to share artifacts between different jobs
-      # =======================================================================
-      - name:  Upload artifact
-        uses:  actions/upload-artifact@v3
-        with:
-          name: reth-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz
-          path: reth-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz
-
-      - name: Upload signature
-        uses: actions/upload-artifact@v3
-        with:
-          name: reth-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz.asc
-          path: reth-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz.asc
-
-  draft-release:
-    name: draft release
-    needs:  [build, extract-version]
-    runs-on: ubuntu-20.04
-    env:
-      VERSION:  ${{ needs.extract-version.outputs.VERSION }}
-    permissions:
-      # Required to post the release
-      contents: write
-    steps:
-      # This is necessary for generating the changelog. It has to come before "Download Artifacts" or else it deletes the artifacts.
-      - name: Checkout sources
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      # ==============================
-      #       Download artifacts
-      # ==============================
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-
-      # ==============================
-      #       Create release draft
-      # ==============================
-      - name: Generate full changelog
-        id: changelog
-        run: |
-          echo "CHANGELOG<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git log --pretty=format:"- %s" $(git describe --tags --abbrev=0 ${{ env.VERSION }}^)..${{ env.VERSION }})" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
-      - name: Create release draft
-        env:
-          GITHUB_USER: ${{ github.repository_owner }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-        # The formatting here is borrowed from Lighthouse (which is borrowed from OpenEthereum): https://github.com/openethereum/openethereum/blob/main/.github/workflows/build.yml
-        run: |
-          body=$(cat <<- "ENDBODY"
-          <Release Name>
-          
-          ## Testing Checklist (DELETE ME)
-          
-          - [ ] Run on testnet for 1-3 days.
-          - [ ] Resync a mainnet node.
-          - [ ] Ensure all CI checks pass.
-          
-          ## Release Checklist (DELETE ME)
-          
-          - [ ] Ensure all crates have had their versions bumped.
-          - [ ] Write the summary.
-          - [ ] Fill out the update priority.
-          - [ ] Ensure all binaries have been added.
-          - [ ] Prepare release posts (Twitter, ...).
-          
-          ## Summary
-          
-          Add a summary, including:
-          
-          - Critical bug fixes
-          - New features
-          - Any breaking changes (and what to expect)
-          
-          ## Update Priority
-          
-          This table provides priorities for which classes of users should update particular components.
-  
-          | User Class           | Priority        |
-          |----------------------|-----------------|
-          | Payload Builders     | <TODO> |
-          | Non-Payload Builders | <TODO>    |
-          
-          *See [Update Priorities](https://paradigmxyz.github.io/reth/installation/priorities.html) for more information about this table.*
-          
-          ## All Changes
-          
-          ${{ steps.changelog.outputs.CHANGELOG }}
-          
-          ## Binaries
-          
-          [See pre-built binaries documentation.](https://paradigmxyz.github.io/reth/installation/binaries.html)
-          
-          The binaries are signed with the PGP key: `A3AE 097C 8909 3A12 4049  DF1F 5391 A3C4 1005 30B4`
-          
-          | System | Architecture | Binary | PGP Signature |
-          |:---:|:---:|:---:|:---|
-          | <img src="https://simpleicons.org/icons/linux.svg" style="width: 32px;"/> | x86_64 | [reth-${{ env.VERSION }}-x86_64-unknown-linux-gnu.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/reth-${{ env.VERSION }}-x86_64-unknown-linux-gnu.tar.gz) | [PGP Signature](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/reth-${{ env.VERSION }}-x86_64-unknown-linux-gnu.tar.gz.asc) |
-          | <img src="https://simpleicons.org/icons/linux.svg" style="width: 32px;"/> | aarch64 | [reth-${{ env.VERSION }}-aarch64-unknown-linux-gnu.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/reth-${{ env.VERSION }}-aarch64-unknown-linux-gnu.tar.gz) | [PGP Signature](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/reth-${{ env.VERSION }}-aarch64-unknown-linux-gnu.tar.gz.asc) |
-          | <img src="https://simpleicons.org/icons/windows.svg" style="width: 32px;"/> | x86_64 | [reth-${{ env.VERSION }}-x86_64-pc-windows-gnu.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/reth-${{ env.VERSION }}-x86_64-pc-windows-gnu.tar.gz) | [PGP Signature](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/reth-${{ env.VERSION }}-x86_64-pc-windows-gnu.tar.gz.asc) |
-          | <img src="https://simpleicons.org/icons/apple.svg" style="width: 32px;"/> | x86_64 | [reth-${{ env.VERSION }}-x86_64-apple-darwin.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/reth-${{ env.VERSION }}-x86_64-apple-darwin.tar.gz) | [PGP Signature](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/reth-${{ env.VERSION }}-x86_64-apple-darwin.tar.gz.asc) |
-          | <img src="https://simpleicons.org/icons/apple.svg" style="width: 32px;"/> | aarch64 | [reth-${{ env.VERSION }}-aarch64-apple-darwin.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/reth-${{ env.VERSION }}-aarch64-apple-darwin.tar.gz) | [PGP Signature](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/reth-${{ env.VERSION }}-aarch64-apple-darwin.tar.gz.asc) |
-          | | | | |
-          | **System** | **Option** | - | **Resource** |
-          | <img src="https://simpleicons.org/icons/docker.svg" style="width: 32px;"/> | Docker | [${{ env.VERSION }}](https://github.com/paradigmxyz/reth/pkgs/container/reth/102974600?tag=${{ env.VERSION }}) | [${{ env.IMAGE_NAME }}](https://github.com/paradigmxyz/reth/pkgs/container/reth) |
-          ENDBODY
-          )
-          assets=()
-          for asset in ./reth-*.tar.gz*; do
-              assets+=("-a" "$asset/$asset")
-          done
-          tag_name="${{ env.VERSION }}"
-          echo "$body" | hub release create --draft "${assets[@]}" -F "-" "$tag_name"

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -37,8 +37,6 @@ reth-basic-payload-builder = { path = "../../crates/payload/basic" }
 reth-discv4 = { path = "../../crates/net/discv4" }
 reth-metrics = { workspace = true }
 reth-prune = { path = "../../crates/prune" }
-jemallocator = { version = "0.5.0", optional = true }
-jemalloc-ctl = { version = "0.5.0", optional = true }
 
 # crypto
 secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery"] }
@@ -87,6 +85,10 @@ thiserror = { workspace = true }
 pretty_assertions = "1.3.0"
 humantime = "2.1.0"
 const-str = "0.5.6"
+
+[target.'cfg(not(windows))'.dependencies]
+jemallocator = { version = "0.5.0", optional = true }
+jemalloc-ctl = { version = "0.5.0", optional = true }
 
 [features]
 default = ["jemalloc"]

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -89,6 +89,7 @@ humantime = "2.1.0"
 const-str = "0.5.6"
 
 [features]
+default = ["jemalloc"]
 jemalloc = ["dep:jemallocator", "dep:jemalloc-ctl"]
 jemalloc-prof = ["jemalloc", "jemallocator?/profiling"]
 min-error-logs = ["tracing/release_max_level_error"]

--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -40,5 +40,5 @@ pub mod test_vectors;
 pub mod utils;
 pub mod version;
 
-#[cfg(all(feature = "jemalloc", not(target_os = "windows")))]
+#[cfg(all(feature = "jemalloc", target_family = "unix"))]
 use jemallocator as _;

--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -40,5 +40,5 @@ pub mod test_vectors;
 pub mod utils;
 pub mod version;
 
-#[cfg(feature = "jemalloc")]
+#[cfg(all(feature = "jemalloc", not(target_os = "windows")))]
 use jemallocator as _;

--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -40,5 +40,5 @@ pub mod test_vectors;
 pub mod utils;
 pub mod version;
 
-#[cfg(all(feature = "jemalloc", target_family = "unix"))]
+#[cfg(all(feature = "jemalloc", unix))]
 use jemallocator as _;

--- a/bin/reth/src/main.rs
+++ b/bin/reth/src/main.rs
@@ -1,5 +1,5 @@
 // We use jemalloc for performance reasons
-#[cfg(all(feature = "jemalloc", target_family = "unix"))]
+#[cfg(all(feature = "jemalloc", unix))]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 

--- a/bin/reth/src/main.rs
+++ b/bin/reth/src/main.rs
@@ -1,5 +1,5 @@
 // We use jemalloc for performance reasons
-#[cfg(feature = "jemalloc")]
+#[cfg(all(feature = "jemalloc", not(target_os = "windows")))]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 

--- a/bin/reth/src/main.rs
+++ b/bin/reth/src/main.rs
@@ -1,5 +1,5 @@
 // We use jemalloc for performance reasons
-#[cfg(all(feature = "jemalloc", not(target_os = "windows")))]
+#[cfg(all(feature = "jemalloc", target_family = "unix"))]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 

--- a/bin/reth/src/prometheus_exporter.rs
+++ b/bin/reth/src/prometheus_exporter.rs
@@ -121,7 +121,7 @@ pub(crate) async fn initialize(
     Ok(())
 }
 
-#[cfg(all(feature = "jemalloc", target_family = "unix"))]
+#[cfg(all(feature = "jemalloc", unix))]
 fn collect_memory_stats() {
     use jemalloc_ctl::{epoch, stats};
     use reth_metrics::metrics::gauge;
@@ -169,7 +169,7 @@ fn collect_memory_stats() {
     }
 }
 
-#[cfg(all(feature = "jemalloc", target_family = "unix"))]
+#[cfg(all(feature = "jemalloc", unix))]
 fn describe_memory_stats() {
     use reth_metrics::metrics::describe_gauge;
 
@@ -206,8 +206,8 @@ fn describe_memory_stats() {
     );
 }
 
-#[cfg(not(all(feature = "jemalloc", target_family = "unix")))]
+#[cfg(not(all(feature = "jemalloc", unix)))]
 fn collect_memory_stats() {}
 
-#[cfg(not(all(feature = "jemalloc", target_family = "unix")))]
+#[cfg(not(all(feature = "jemalloc", unix)))]
 fn describe_memory_stats() {}

--- a/bin/reth/src/prometheus_exporter.rs
+++ b/bin/reth/src/prometheus_exporter.rs
@@ -121,7 +121,7 @@ pub(crate) async fn initialize(
     Ok(())
 }
 
-#[cfg(feature = "jemalloc")]
+#[cfg(all(feature = "jemalloc", not(target_os = "windows")))]
 fn collect_memory_stats() {
     use jemalloc_ctl::{epoch, stats};
     use reth_metrics::metrics::gauge;
@@ -169,7 +169,7 @@ fn collect_memory_stats() {
     }
 }
 
-#[cfg(feature = "jemalloc")]
+#[cfg(all(feature = "jemalloc", not(target_os = "windows")))]
 fn describe_memory_stats() {
     use reth_metrics::metrics::describe_gauge;
 
@@ -206,8 +206,8 @@ fn describe_memory_stats() {
     );
 }
 
-#[cfg(not(feature = "jemalloc"))]
+#[cfg(not(all(feature = "jemalloc", not(target_os = "windows"))))]
 fn collect_memory_stats() {}
 
-#[cfg(not(feature = "jemalloc"))]
+#[cfg(not(all(feature = "jemalloc", not(target_os = "windows"))))]
 fn describe_memory_stats() {}

--- a/bin/reth/src/prometheus_exporter.rs
+++ b/bin/reth/src/prometheus_exporter.rs
@@ -121,7 +121,7 @@ pub(crate) async fn initialize(
     Ok(())
 }
 
-#[cfg(all(feature = "jemalloc", not(target_os = "windows")))]
+#[cfg(all(feature = "jemalloc", target_family = "unix"))]
 fn collect_memory_stats() {
     use jemalloc_ctl::{epoch, stats};
     use reth_metrics::metrics::gauge;
@@ -169,7 +169,7 @@ fn collect_memory_stats() {
     }
 }
 
-#[cfg(all(feature = "jemalloc", not(target_os = "windows")))]
+#[cfg(all(feature = "jemalloc", target_family = "unix"))]
 fn describe_memory_stats() {
     use reth_metrics::metrics::describe_gauge;
 
@@ -206,8 +206,8 @@ fn describe_memory_stats() {
     );
 }
 
-#[cfg(not(all(feature = "jemalloc", not(target_os = "windows"))))]
+#[cfg(not(all(feature = "jemalloc", target_family = "unix")))]
 fn collect_memory_stats() {}
 
-#[cfg(not(all(feature = "jemalloc", not(target_os = "windows"))))]
+#[cfg(not(all(feature = "jemalloc", target_family = "unix")))]
 fn describe_memory_stats() {}


### PR DESCRIPTION
This PR additionally gates jemallocator usage by `unix` target family and enables `jemalloc` feature by default. It means the following:
1. On Unix, use jemallocator if not specified otherwise via `--no-default-features `.
2. On Windows, use default allocator. If `--features jemalloc` is specified, ignore it because Windows is not fully supported by jemalloc.

Windows builds successfully: https://github.com/paradigmxyz/reth/actions/runs/5543015346/jobs/10118463541?pr=3735