### PR TITLE
feat(txpool): add best_with_base_fee

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -394,6 +394,13 @@ where
         Box::new(self.pool.best_transactions())
     }
 
+    fn best_transactions_with_base_fee(
+        &self,
+        base_fee: u128,
+    ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<Self::Transaction>>>> {
+        self.pool.best_transactions_with_base_fee(base_fee)
+    }
+
     fn pending_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         self.pool.pending_transactions()
     }

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -110,6 +110,13 @@ impl TransactionPool for NoopTransactionPool {
         Box::new(std::iter::empty())
     }
 
+    fn best_transactions_with_base_fee(
+        &self,
+        _: u128,
+    ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<Self::Transaction>>>> {
+        Box::new(std::iter::empty())
+    }
+
     fn pending_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         vec![]
     }

--- a/crates/transaction-pool/src/ordering.rs
+++ b/crates/transaction-pool/src/ordering.rs
@@ -45,3 +45,9 @@ impl<T> Default for GasCostOrdering<T> {
         Self(Default::default())
     }
 }
+
+impl<T> Clone for GasCostOrdering<T> {
+    fn clone(&self) -> Self {
+        Self::default()
+    }
+}

--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -1,7 +1,7 @@
 use crate::{
     identifier::TransactionId,
     pool::pending::{PendingTransaction, PendingTransactionRef},
-    TransactionOrdering, ValidPoolTransaction,
+    PoolTransaction, TransactionOrdering, ValidPoolTransaction,
 };
 use reth_primitives::H256 as TxHash;
 use std::{
@@ -9,6 +9,40 @@ use std::{
     sync::Arc,
 };
 use tracing::debug;
+
+/// An iterator that returns transactions that can be executed on the current state (*best*
+/// transactions).
+///
+/// This is a wrapper around [`BestTransactions`] that also enforces a specific basefee.
+///
+/// This iterator guarantees that all transaction it returns satisfy the base fee.
+pub(crate) struct BestTransactionsWithBasefee<T: TransactionOrdering> {
+    pub(crate) best: BestTransactions<T>,
+    pub(crate) base_fee: u128,
+}
+
+impl<T: TransactionOrdering> crate::traits::BestTransactions for BestTransactionsWithBasefee<T> {
+    fn mark_invalid(&mut self, tx: &Self::Item) {
+        BestTransactions::mark_invalid(&mut self.best, tx)
+    }
+}
+
+impl<T: TransactionOrdering> Iterator for BestTransactionsWithBasefee<T> {
+    type Item = Arc<ValidPoolTransaction<T::Transaction>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // find the next transaction that satisfies the base fee
+        loop {
+            let best = self.best.next()?;
+            if best.transaction.max_fee_per_gas() < self.base_fee {
+                // tx violates base fee, mark it as invalid and continue
+                crate::traits::BestTransactions::mark_invalid(self, &best);
+            } else {
+                return Some(best)
+            }
+        }
+    }
+}
 
 /// An iterator that returns transactions that can be executed on the current state (*best*
 /// transactions).
@@ -34,6 +68,14 @@ impl<T: TransactionOrdering> BestTransactions<T> {
     /// Mark the transaction and it's descendants as invalid.
     pub(crate) fn mark_invalid(&mut self, tx: &Arc<ValidPoolTransaction<T::Transaction>>) {
         self.invalid.insert(*tx.hash());
+    }
+
+    /// Returns the ancestor the given transaction, the transaction with `nonce - 1`.
+    ///
+    /// Note: for a transaction with nonce higher than the current on chain nonce this will always
+    /// return an ancestor since all transaction in this pool are gapless.
+    pub(crate) fn ancestor(&self, id: &TransactionId) -> Option<&Arc<PendingTransaction<T>>> {
+        self.all.get(&id.unchecked_ancestor()?)
     }
 }
 

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -442,6 +442,16 @@ where
         self.pool.read().best_transactions()
     }
 
+    /// Returns an iterator that yields transactions that are ready to be included in the block with
+    /// the given base fee.
+    pub(crate) fn best_transactions_with_base_fee(
+        &self,
+        base_fee: u128,
+    ) -> Box<dyn crate::traits::BestTransactions<Item = Arc<ValidPoolTransaction<T::Transaction>>>>
+    {
+        self.pool.read().best_transactions_with_base_fee(base_fee)
+    }
+
     /// Returns all transactions from the pending sub-pool
     pub(crate) fn pending_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         self.pool.read().pending_transactions()

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -186,6 +186,31 @@ impl<T: TransactionOrdering> TxPool<T> {
         self.pending_pool.best()
     }
 
+    /// Returns an iterator that yields transactions that are ready to be included in the block with
+    /// the given base fee.
+    pub(crate) fn best_transactions_with_base_fee(
+        &self,
+        basefee: u128,
+    ) -> Box<dyn crate::traits::BestTransactions<Item = Arc<ValidPoolTransaction<T::Transaction>>>>
+    {
+        match basefee.cmp(&self.all_transactions.pending_basefee) {
+            Ordering::Equal => {
+                // fee unchanged, nothing to shift
+                Box::new(self.best_transactions())
+            }
+            Ordering::Greater => {
+                // base fee increased, we only need to enforces this on the pending pool
+                Box::new(self.pending_pool.best_with_basefee(basefee))
+            }
+            Ordering::Less => {
+                // base fee decreased, we need to move transactions from the basefee pool to the
+                // pending pool
+                let unlocked = self.basefee_pool.satisfy_base_fee_transactions(basefee);
+                Box::new(self.pending_pool.best_with_unlocked(unlocked))
+            }
+        }
+    }
+
     /// Returns all transactions from the pending sub-pool
     pub(crate) fn pending_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         self.pending_pool.all().collect()

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -175,6 +175,15 @@ pub trait TransactionPool: Send + Sync + Clone {
         &self,
     ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<Self::Transaction>>>>;
 
+    /// Returns an iterator that yields transactions that are ready for block production with the
+    /// given base fee.
+    ///
+    /// Consumer: Block production
+    fn best_transactions_with_base_fee(
+        &self,
+        base_fee: u128,
+    ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<Self::Transaction>>>>;
+
     /// Returns all transactions that can be included in the next block.
     ///
     /// This is primarily used for the `txpool_` RPC namespace: <https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool> which distinguishes between `pending` and `queued` transactions, where `pending` are transactions ready for inclusion in the next block and `queued` are transactions that are ready for inclusion in future blocks.


### PR DESCRIPTION
extends the `best` function with a basfee parameter that returns all pending transactions that satisfy the basfee.

this essentially moves unlocked txs from basefee pool to pending iterator if basefee decreased
and filters invalid transactions in the best iterator

This is useful for block building which need to enforce a certain basefee, and it could be that the pool isn't updated yet when a block building job is triggered