### PR TITLE
fix(rpc): disable balance check if call gas price is 0

### DIFF
--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -30,6 +30,7 @@ revm = { workspace = true, features = [
     "optional_block_gas_limit",
     "optional_eip3607",
     "optional_no_base_fee",
+    "optional_balance_check"
 ] }
 ethers-core = { workspace = true, features = ["eip712"] }
 revm-primitives = { workspace = true, features = ["serde"] }

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -543,8 +543,6 @@ where
         let mut db = SubState::new(State::new(state));
 
         let env = prepare_call_env(cfg, block_env, request, &mut db, overrides)?;
-        dbg!(&env.cfg);
-        dbg!(&env.block);
         inspect_and_return_db(db, env, inspector)
     }
 

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -543,6 +543,8 @@ where
         let mut db = SubState::new(State::new(state));
 
         let env = prepare_call_env(cfg, block_env, request, &mut db, overrides)?;
+        dbg!(&env.cfg);
+        dbg!(&env.block);
         inspect_and_return_db(db, env, inspector)
     }
 

--- a/crates/rpc/rpc/src/eth/revm_utils.rs
+++ b/crates/rpc/rpc/src/eth/revm_utils.rs
@@ -227,6 +227,12 @@ where
 
     let mut env = build_call_evm_env(cfg, block, request)?;
 
+    if env.tx.gas_price == U256::ZERO {
+        // if gas price is not specific or was set to 0, we disable the balance check, which
+        // bypasses the initial `LackOfFundForGasLimit` check
+        env.cfg.disable_balance_check = true;
+    }
+
     // apply state overrides
     if let Some(state_overrides) = overrides.state {
         apply_state_overrides(state_overrides, db)?;


### PR DESCRIPTION
this fixes the insufficient fund error as seen here #3721

we were missing a `disable_balance_check` in revm that happens when evm starts

```rust
        // Check if account has enough balance for gas_limit*gas_price and value transfer.
        // Transfer will be done inside `*_inner` functions.
        if balance_check > *caller_balance && !disable_balance_check {
            return Err(InvalidTransaction::LackOfFundForGasLimit {
                gas_limit: balance_check,
                balance: *caller_balance,
            }
            .into());
        }
```

this is now disabled if gas price is 0, which now behaves like other clients