### PR TITLE
fix: return null withdrawals

### DIFF
--- a/crates/rpc/rpc-api/src/engine.rs
+++ b/crates/rpc/rpc-api/src/engine.rs
@@ -2,7 +2,7 @@ use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_primitives::{Address, BlockHash, BlockId, BlockNumberOrTag, Bytes, H256, U256, U64};
 use reth_rpc_types::{
     engine::{
-        ExecutionPayload, ExecutionPayloadBodies, ExecutionPayloadEnvelope, ForkchoiceState,
+        ExecutionPayload, ExecutionPayloadBodiesV1, ExecutionPayloadEnvelope, ForkchoiceState,
         ForkchoiceUpdated, PayloadAttributes, PayloadId, PayloadStatus, TransitionConfiguration,
     },
     state::StateOverride,
@@ -64,7 +64,7 @@ pub trait EngineApi {
     async fn get_payload_bodies_by_hash_v1(
         &self,
         block_hashes: Vec<BlockHash>,
-    ) -> RpcResult<ExecutionPayloadBodies>;
+    ) -> RpcResult<ExecutionPayloadBodiesV1>;
 
     /// See also <https://github.com/ethereum/execution-apis/blob/6452a6b194d7db269bf1dbd087a267251d3cc7f8/src/engine/shanghai.md#engine_getpayloadbodiesbyrangev1>
     ///
@@ -83,7 +83,7 @@ pub trait EngineApi {
         &self,
         start: U64,
         count: U64,
-    ) -> RpcResult<ExecutionPayloadBodies>;
+    ) -> RpcResult<ExecutionPayloadBodiesV1>;
 
     /// See also <https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/paris.md#engine_exchangetransitionconfigurationv1>
     #[method(name = "exchangeTransitionConfigurationV1")]


### PR DESCRIPTION
Closes #3673

removes invalid unwrap_or_default, because this must be null pre shanghai which is enforced:

https://github.com/paradigmxyz/reth/blob/4c7f980c774c77db48abdb119028d6a94cf24952/crates/storage/provider/src/providers/database/provider.rs#L1107-L1112