### PR TITLE
chore: fix typo in RlpDecodableWrapper derive

### DIFF
--- a/crates/rlp/rlp-derive/src/de.rs
+++ b/crates/rlp/rlp-derive/src/de.rs
@@ -72,12 +72,12 @@ pub(crate) fn impl_decodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
 }
 
 pub(crate) fn impl_decodable_wrapper(ast: &syn::DeriveInput) -> Result<TokenStream> {
-    let body = parse_struct(ast, "RlpEncodableWrapper")?;
+    let body = parse_struct(ast, "RlpDecodableWrapper")?;
 
     assert_eq!(
         body.fields.iter().count(),
         1,
-        "#[derive(RlpEncodableWrapper)] is only defined for structs with one field."
+        "#[derive(RlpDecodableWrapper)] is only defined for structs with one field."
     );
 
     let name = &ast.ident;


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c8456c3</samp>

Fixed a naming inconsistency in `rlp-derive` crate that caused confusion when deriving RLP decodable wrapper types. Renamed `RlpEncodableWrapper` function and attribute to `RlpDecodableWrapper` in `de.rs`.