### PR TITLE
fix(rpc): make trace filter req field hex or decimal

### DIFF
--- a/crates/primitives/src/serde_helper/num.rs
+++ b/crates/primitives/src/serde_helper/num.rs
@@ -88,6 +88,33 @@ pub mod u64_hex_or_decimal {
         U64HexOrNumber::from(*value).serialize(s)
     }
 }
+
+/// serde functions for handling primitive optional `u64` as [U64](crate::U64)
+pub mod u64_hex_or_decimal_opt {
+    use crate::serde_helper::num::U64HexOrNumber;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    /// Deserializes an `u64` accepting a hex quantity string with optional 0x prefix or
+    /// a number
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match Option::<U64HexOrNumber>::deserialize(deserializer)? {
+            Some(val) => Ok(Some(val.into())),
+            None => Ok(None),
+        }
+    }
+
+    /// Serializes u64 as hex string
+    pub fn serialize<S: Serializer>(value: &Option<u64>, s: S) -> Result<S::Ok, S::Error> {
+        match value {
+            Some(val) => U64HexOrNumber::from(*val).serialize(s),
+            None => s.serialize_none(),
+        }
+    }
+}
+
 /// Deserializes the input into an `Option<U256>`, using [`from_int_or_hex`] to deserialize the
 /// inner value.
 pub fn from_int_or_hex_opt<'de, D>(deserializer: D) -> Result<Option<U256>, D::Error>

--- a/crates/rpc/rpc-types/src/eth/trace/filter.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/filter.rs
@@ -1,5 +1,5 @@
 //! `trace_filter` types and support
-use reth_primitives::{Address, BlockNumber};
+use reth_primitives::{serde_helper::num::u64_hex_or_decimal_opt, Address};
 use serde::{Deserialize, Serialize};
 
 /// Trace filter.
@@ -8,15 +8,30 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 pub struct TraceFilter {
     /// From block
-    pub from_block: Option<BlockNumber>,
+    #[serde(with = "u64_hex_or_decimal_opt")]
+    pub from_block: Option<u64>,
     /// To block
-    pub to_block: Option<BlockNumber>,
+    #[serde(with = "u64_hex_or_decimal_opt")]
+    pub to_block: Option<u64>,
     /// From address
     pub from_address: Option<Vec<Address>>,
     /// To address
     pub to_address: Option<Vec<Address>>,
     /// Output offset
-    pub after: Option<usize>,
+    pub after: Option<u64>,
     /// Output amount
-    pub count: Option<usize>,
+    pub count: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_filter() {
+        let s = r#"{"fromBlock":  "0x3","toBlock":  "0x5"}"#;
+        let filter: TraceFilter = serde_json::from_str(s).unwrap();
+        assert_eq!(filter.from_block, Some(3));
+        assert_eq!(filter.to_block, Some(5));
+    }
 }


### PR DESCRIPTION
ref #3721

fields were originally ints:

https://github.com/openethereum/openethereum/blob/6c2d392d867b058ff867c4373e40850ca3f96969/crates/rpc/src/v1/types/trace_filter.rs#L24-L40

erigon uses hex

https://github.com/ledgerwatch/erigon/blob/ef4ccd47736019132c1967d6921f6c4b014eb515/turbo/jsonrpc/trace_filtering.go#L951-L958

so we support hex or int