### PR TITLE
fix: add unknown block error

### DIFF
--- a/crates/rpc/rpc-types/src/eth/error.rs
+++ b/crates/rpc/rpc-types/src/eth/error.rs
@@ -13,6 +13,9 @@ pub enum EthRpcErrorCode {
     /// > If the block is not found, the callee SHOULD raise a JSON-RPC error (the recommended
     /// > error code is -32001: Resource not found).
     ResourceNotFound,
+    /// Thrown when Querying for `finalized` or `safe` block before the merge transition is
+    /// finalized, <https://github.com/ethereum/execution-apis/blob/6d17705a875e52c26826124c2a8a15ed542aeca2/src/schemas/block.yaml#L109>
+    UnknownBlock,
 }
 
 impl EthRpcErrorCode {
@@ -23,6 +26,7 @@ impl EthRpcErrorCode {
             EthRpcErrorCode::ExecutionError => 3,
             EthRpcErrorCode::InvalidInput => -32000,
             EthRpcErrorCode::ResourceNotFound => -32001,
+            EthRpcErrorCode::UnknownBlock => -39001,
         }
     }
 }

--- a/crates/rpc/rpc-types/src/eth/error.rs
+++ b/crates/rpc/rpc-types/src/eth/error.rs
@@ -13,7 +13,7 @@ pub enum EthRpcErrorCode {
     /// > If the block is not found, the callee SHOULD raise a JSON-RPC error (the recommended
     /// > error code is -32001: Resource not found).
     ResourceNotFound,
-    /// Thrown when Querying for `finalized` or `safe` block before the merge transition is
+    /// Thrown when querying for `finalized` or `safe` block before the merge transition is
     /// finalized, <https://github.com/ethereum/execution-apis/blob/6d17705a875e52c26826124c2a8a15ed542aeca2/src/schemas/block.yaml#L109>
     UnknownBlock,
 }

--- a/crates/rpc/rpc/src/eth/error.rs
+++ b/crates/rpc/rpc/src/eth/error.rs
@@ -26,9 +26,10 @@ pub enum EthApiError {
     PoolError(RpcPoolError),
     #[error("Unknown block number")]
     UnknownBlockNumber,
-    /// Thrown when querying for `finalized` or `safe` before the merge transition is finalized
+    /// Thrown when querying for `finalized` or `safe` block before the merge transition is
+    /// finalized, <https://github.com/ethereum/execution-apis/blob/6d17705a875e52c26826124c2a8a15ed542aeca2/src/schemas/block.yaml#L109>
     #[error("Unknown block")]
-    UnknownBlock,
+    UnknownSafeOrFinalizedBlock,
     #[error("Unknown block or tx index")]
     UnknownBlockOrTxIndex,
     #[error("Invalid block range")]
@@ -104,7 +105,7 @@ impl From<EthApiError> for ErrorObject<'static> {
             EthApiError::UnknownBlockNumber | EthApiError::UnknownBlockOrTxIndex => {
                 rpc_error_with_code(EthRpcErrorCode::ResourceNotFound.code(), error.to_string())
             }
-            EthApiError::UnknownBlock => {
+            EthApiError::UnknownSafeOrFinalizedBlock => {
                 rpc_error_with_code(EthRpcErrorCode::UnknownBlock.code(), error.to_string())
             }
             EthApiError::Unsupported(msg) => internal_rpc_err(msg),
@@ -153,7 +154,7 @@ impl From<reth_interfaces::provider::ProviderError> for EthApiError {
             ProviderError::TotalDifficultyNotFound { .. } |
             ProviderError::UnknownBlockHash(_) => EthApiError::UnknownBlockNumber,
             ProviderError::FinalizedBlockNotFound | ProviderError::SafeBlockNotFound => {
-                EthApiError::UnknownBlock
+                EthApiError::UnknownSafeOrFinalizedBlock
             }
             err => EthApiError::Internal(err.into()),
         }


### PR DESCRIPTION
Closes #3713 

`UnknownBlock: -39001` should only be returned when querying `finalized` or `safe` block before the merge transition is finalized. Therefore we shouldn't reuse `UnknownBlockNumber`.