### PR TITLE
fix: remove single body response check

### DIFF
--- a/crates/net/downloaders/src/bodies/request.rs
+++ b/crates/net/downloaders/src/bodies/request.rs
@@ -119,11 +119,11 @@ where
         // Increment total downloaded metric
         self.metrics.total_downloaded.increment(response_len as u64);
 
-        // Malicious peers often return a single block. Mark responses with single
-        // block when more than 1 were requested invalid.
-        // TODO: Instead of marking single block responses invalid, calculate
-        // soft response size lower limit and use that for filtering.
-        if bodies.is_empty() || (request_len != 1 && response_len == 1) {
+        // TODO: Malicious peers often return a single block even if it does not exceed the soft
+        // response limit (2MB).  this could be penalized by checking if this block and the
+        // next one exceed the soft response limit, if not then peer either does not have the next
+        // block or deliberately sent a single block.
+        if bodies.is_empty() {
             return Err(DownloadError::EmptyResponse)
         }
 


### PR DESCRIPTION
removes a check where we considered a single block response as invalid, the reason for this check was to penalize peer that only sent one block.

however, with current block (rlp) sizes two blocks can exceed the soft limit of 2MB which would result in a response of a single block which would be considered an error by reth.


this removes the check, since we can't treat these responses as invalid on their own, they can only be considered bad if we receive the next block which is left to an optional followup perf optimization.

for example: https://etherscan.io/block/17676083 

2,114,727 bytes