### PR TITLE
docs: describe windows dependencies for source builds

### DIFF
--- a/book/installation/source.md
+++ b/book/installation/source.md
@@ -28,7 +28,7 @@ operating system:
 
 - **Ubuntu**: `apt-get install libclang-dev pkg-config build-essential`
 - **macOS**: `brew install llvm pkg-config`
-- **Windows**: `choco install make; choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System'; choco install llvm; choco install protoc`
+- **Windows**: `choco install llvm`
 
 These are needed to build bindings for Reth's database.
 

--- a/book/installation/source.md
+++ b/book/installation/source.md
@@ -1,6 +1,6 @@
 # Build from Source
 
-You can build Reth on Linux, macOS, and Windows WSL2.
+You can build Reth on Linux, macOS, Windows, and Windows WSL2.
 
 > **Note**
 >
@@ -28,6 +28,7 @@ operating system:
 
 - **Ubuntu**: `apt-get install libclang-dev pkg-config build-essential`
 - **macOS**: `brew install llvm pkg-config`
+- **Windows**: `choco install make; choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System'; choco install llvm; choco install protoc`
 
 These are needed to build bindings for Reth's database.
 

--- a/book/installation/source.md
+++ b/book/installation/source.md
@@ -28,7 +28,7 @@ operating system:
 
 - **Ubuntu**: `apt-get install libclang-dev pkg-config build-essential`
 - **macOS**: `brew install llvm pkg-config`
-- **Windows**: `choco install llvm`
+- **Windows**: `choco install llvm` or `winget install LLVM.LLVM`
 
 These are needed to build bindings for Reth's database.
 


### PR DESCRIPTION
Sorry I know everyone hates supporting Windows Native but due to some unfortunate circumstances I found myself syncing a reth node in Windows 10, and so thought it might be nice to mention it within the Reth book, and how to install the deps. I did take the dep list from lighthouse, but given reth may be paired with other CL clients and users may not have necessarily read the lighthouse book it should be documented here too

I hope to make more actual PRs to reth in the future when I have more time 😆 