### PR TITLE
fix: rpc cap block range correctly

### DIFF
--- a/crates/rpc/rpc/src/eth/api/fees.rs
+++ b/crates/rpc/rpc/src/eth/api/fees.rs
@@ -60,6 +60,7 @@ where
                 truncated = max_fee_history,
                 "Sanitizing fee history block count"
             );
+            dbg!("truncate max fee history");
             block_count = max_fee_history
         }
 
@@ -67,9 +68,11 @@ where
             return Err(EthApiError::UnknownBlockNumber)
         };
 
-        // Check that we would not be querying outside of genesis
-        if end_block < block_count {
-            return Err(EthApiError::InvalidBlockRange)
+        // need to add 1 to the end block to get the correct (inclusive) range
+        let end_block_plus = end_block + 1;
+        // Ensure that we would not be querying outside of genesis
+        if end_block_plus < block_count {
+            block_count = end_block_plus;
         }
 
         // If reward percentiles were specified, we need to validate that they are monotonically
@@ -86,7 +89,8 @@ where
         //
         // Treat a request for 1 block as a request for `newest_block..=newest_block`,
         // otherwise `newest_block - 2
-        let start_block = end_block - block_count + 1;
+        // SAFETY: We ensured that block count is capped
+        let start_block = end_block_plus - block_count;
         let headers = self.provider().sealed_headers_range(start_block..=end_block)?;
         if headers.len() != block_count as usize {
             return Err(EthApiError::InvalidBlockRange)

--- a/crates/rpc/rpc/src/eth/api/fees.rs
+++ b/crates/rpc/rpc/src/eth/api/fees.rs
@@ -60,7 +60,6 @@ where
                 truncated = max_fee_history,
                 "Sanitizing fee history block count"
             );
-            dbg!("truncate max fee history");
             block_count = max_fee_history
         }
 


### PR DESCRIPTION
ref #3782

cap block range correctly instead of returning an error

ref https://github.com/ethereum/go-ethereum/blob/13c0305106438656b57afdf6a10cf7904f7f9f15/eth/gasprice/feehistory.go#L193-L196

```
{'jsonrpc': '2.0', 'method': 'eth_feeHistory', 'params': ['0xaee9aa', '0x200', []], 'id': 771836459325704840}

reth failed
response: {'jsonrpc': '2.0', 'error': {'code': -32602, 'message': 'Invalid block range'}, 'id': 771836459325704840}

```