### PR TITLE
fix(stages): update entities metrics on `SyncHeight` event

### DIFF
--- a/crates/stages/src/metrics/listener.rs
+++ b/crates/stages/src/metrics/listener.rs
@@ -59,8 +59,14 @@ impl MetricsListener {
         match event {
             MetricEvent::SyncHeight { height } => {
                 for stage_id in StageId::ALL {
-                    let stage_metrics = self.sync_metrics.get_stage_metrics(stage_id);
-                    stage_metrics.checkpoint.set(height as f64);
+                    self.handle_event(MetricEvent::StageCheckpoint {
+                        stage_id,
+                        checkpoint: StageCheckpoint {
+                            block_number: height,
+                            stage_checkpoint: None,
+                        },
+                        max_block_number: Some(height),
+                    });
                 }
             }
             MetricEvent::StageCheckpoint { stage_id, checkpoint, max_block_number } => {


### PR DESCRIPTION
On blockchain tree unwind, we reset all stage-specific checkpoints (notice `drop_stage_checkpoints = true`) https://github.com/paradigmxyz/reth/blob/99a8e0f98211be6afb49e8e04ca61ddd7e352583/crates/storage/provider/src/providers/database/provider.rs#L1674

It means that we can't restore the actual stage-specific checkpoints (e.g. the entities measured in gas for execution stage), and they default to zero.

This PR sets each stage entities metric to `Entities { processed: height, total: height }` when new live sync height is reached to make the percentage chart in Grafana always report 100%. In case of returning back to the pipeline sync, we will still update the actual stage-specific checkpoint in the database.