### PR TITLE
chore: use best with base fee

### DIFF
--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -578,12 +578,12 @@ fn build_payload<Pool, Client>(
 
         let mut cumulative_gas_used = 0;
         let block_gas_limit: u64 = initialized_block_env.gas_limit.try_into().unwrap_or(u64::MAX);
+        let base_fee = initialized_block_env.basefee.to::<u64>();
 
         let mut executed_txs = Vec::new();
-        let mut best_txs = pool.best_transactions();
+        let mut best_txs = pool.best_transactions_with_base_fee(base_fee as u128);
 
         let mut total_fees = U256::ZERO;
-        let base_fee = initialized_block_env.basefee.to::<u64>();
 
         let block_number = initialized_block_env.number.to::<u64>();
 


### PR DESCRIPTION
use new txpool function for getting best transaction for a specific basefee