### PR TITLE
chore(grafana): make instance selector single-value

### DIFF
--- a/etc/grafana/dashboards/overview.json
+++ b/etc/grafana/dashboards/overview.json
@@ -27,7 +27,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "9.5.3"
+      "version": "10.0.2"
     },
     {
       "type": "panel",
@@ -100,7 +100,7 @@
       "panels": [],
       "repeat": "instance",
       "repeatDirection": "h",
-      "title": "Overview ($instance)",
+      "title": "Overview",
       "type": "row"
     },
     {
@@ -159,7 +159,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "9.5.3",
+      "pluginVersion": "10.0.2",
       "targets": [
         {
           "datasource": {
@@ -226,7 +226,7 @@
         "showUnfilled": true,
         "valueMode": "color"
       },
-      "pluginVersion": "9.5.3",
+      "pluginVersion": "10.0.2",
       "targets": [
         {
           "datasource": {
@@ -441,7 +441,7 @@
       "panels": [],
       "repeat": "instance",
       "repeatDirection": "h",
-      "title": "Database ($instance)",
+      "title": "Database",
       "type": "row"
     },
     {
@@ -609,7 +609,7 @@
           "unit": "percentunit"
         }
       },
-      "pluginVersion": "9.5.3",
+      "pluginVersion": "10.0.2",
       "targets": [
         {
           "datasource": {
@@ -1006,7 +1006,7 @@
         },
         "showHeader": true
       },
-      "pluginVersion": "9.5.3",
+      "pluginVersion": "10.0.2",
       "targets": [
         {
           "datasource": {
@@ -1038,7 +1038,7 @@
       "panels": [],
       "repeat": "instance",
       "repeatDirection": "h",
-      "title": "Stage: Execution ($instance)",
+      "title": "Stage: Execution",
       "type": "row"
     },
     {
@@ -1179,7 +1179,7 @@
       "panels": [],
       "repeat": "instance",
       "repeatDirection": "h",
-      "title": "Networking ($instance)",
+      "title": "Networking",
       "type": "row"
     },
     {
@@ -1705,7 +1705,7 @@
       "panels": [],
       "repeat": "instance",
       "repeatDirection": "h",
-      "title": "Downloader: Headers ($instance)",
+      "title": "Downloader: Headers",
       "type": "row"
     },
     {
@@ -2097,7 +2097,7 @@
       "panels": [],
       "repeat": "instance",
       "repeatDirection": "h",
-      "title": "Downloader: Bodies ($instance)",
+      "title": "Downloader: Bodies",
       "type": "row"
     },
     {
@@ -2792,7 +2792,7 @@
       "panels": [],
       "repeat": "instance",
       "repeatDirection": "h",
-      "title": "Transaction Pool ($instance)",
+      "title": "Transaction Pool",
       "type": "row"
     },
     {
@@ -3428,7 +3428,7 @@
       "panels": [],
       "repeat": "instance",
       "repeatDirection": "h",
-      "title": "Blockchain Tree ($instance)",
+      "title": "Blockchain Tree",
       "type": "row"
     },
     {
@@ -3725,7 +3725,7 @@
       "panels": [],
       "repeat": "instance",
       "repeatDirection": "h",
-      "title": "Engine API ($instance)",
+      "title": "Engine API",
       "type": "row"
     },
     {
@@ -4031,7 +4031,7 @@
       "panels": [],
       "repeat": "instance",
       "repeatDirection": "h",
-      "title": "Payload Builder ($instance)",
+      "title": "Payload Builder",
       "type": "row"
     },
     {
@@ -4786,8 +4786,8 @@
         },
         "definition": "query_result(up)",
         "hide": 0,
-        "includeAll": true,
-        "multi": true,
+        "includeAll": false,
+        "multi": false,
         "name": "instance",
         "options": [],
         "query": {
@@ -4810,6 +4810,6 @@
   "timezone": "",
   "title": "reth",
   "uid": "2k8BXz24x",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }


### PR DESCRIPTION
We don't want to display dashboard for multiple nodes at once, the selector should be single-value.

This doesn't look good:
![image](https://github.com/paradigmxyz/reth/assets/5773434/dac50090-53e6-4e11-b126-5fe79cd58551)

See applied changes here: https://reth.paradigm.xyz/d/2k8BXz24x/reth