### PR TITLE
feat(prune): take `PruneMode::Full` into account when validating the config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5587,7 +5587,7 @@ name = "reth-prune"
 version = "0.1.0-alpha.4"
 dependencies = [
  "assert_matches",
- "itertools",
+ "itertools 0.10.5",
  "reth-db",
  "reth-interfaces",
  "reth-primitives",

--- a/crates/primitives/src/prune/target.rs
+++ b/crates/primitives/src/prune/target.rs
@@ -1,4 +1,4 @@
-use crate::{serde_helper::deserialize_opt_prune_mode_with_constraints, BlockNumber, PruneMode};
+use crate::{serde_helper::deserialize_opt_prune_mode_with_min_blocks, BlockNumber, PruneMode};
 use paste::paste;
 use serde::{Deserialize, Serialize};
 
@@ -15,7 +15,7 @@ pub struct PruneModes {
     /// Receipts pruning configuration.
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_opt_prune_mode_with_constraints::<64, false, _>"
+        deserialize_with = "deserialize_opt_prune_mode_with_min_blocks::<64, _>"
     )]
     pub receipts: Option<PruneMode>,
     /// Account History pruning configuration.

--- a/crates/primitives/src/prune/target.rs
+++ b/crates/primitives/src/prune/target.rs
@@ -27,7 +27,7 @@ pub struct PruneModes {
 }
 
 macro_rules! impl_prune_parts {
-    ($(($part:ident, $human_part:expr, $min_distance:expr)),+) => {
+    ($(($part:ident, $human_part:expr, $min_blocks:expr)),+) => {
         $(
             paste! {
                 #[doc = concat!(
@@ -53,7 +53,7 @@ macro_rules! impl_prune_parts {
                 )]
                 pub fn [<prune_to_block_ $part>](&self, tip: BlockNumber) -> Option<(BlockNumber, PruneMode)> {
                     self.$part.as_ref().and_then(|mode| {
-                        self.prune_to_block(mode, tip, $min_distance).map(|block| {
+                        self.prune_to_block(mode, tip, $min_blocks).map(|block| {
                             (block, *mode)
                         })
                     })
@@ -94,19 +94,19 @@ impl PruneModes {
     }
 
     /// Returns block up to which pruning needs to be done, inclusive, according to the provided
-    /// prune mode and tip.
+    /// prune mode, tip block number and minimum number of blocks allowed to be pruned.
     pub fn prune_to_block(
         &self,
         mode: &PruneMode,
         tip: BlockNumber,
-        min_distance: Option<u64>,
+        min_blocks: Option<u64>,
     ) -> Option<BlockNumber> {
         match mode {
-            PruneMode::Full if min_distance.unwrap_or_default() == 0 => Some(tip),
-            PruneMode::Distance(distance) if *distance >= min_distance.unwrap_or_default() => {
+            PruneMode::Full if min_blocks.unwrap_or_default() == 0 => Some(tip),
+            PruneMode::Distance(distance) if *distance >= min_blocks.unwrap_or_default() => {
                 Some(tip.saturating_sub(*distance))
             }
-            PruneMode::Before(n) if tip.saturating_sub(*n) >= min_distance.unwrap_or_default() => {
+            PruneMode::Before(n) if tip.saturating_sub(*n) >= min_blocks.unwrap_or_default() => {
                 Some(*n)
             }
             _ => None,

--- a/crates/primitives/src/prune/target.rs
+++ b/crates/primitives/src/prune/target.rs
@@ -51,9 +51,9 @@ macro_rules! impl_prune_parts {
                     $human_part,
                     " pruning needs to be done, inclusive, according to the provided tip."
                 )]
-                pub fn [<prune_to_block_ $part>](&self, tip: BlockNumber) -> Option<(BlockNumber, PruneMode)> {
+                pub fn [<prune_target_block_ $part>](&self, tip: BlockNumber) -> Option<(BlockNumber, PruneMode)> {
                     self.$part.as_ref().and_then(|mode| {
-                        self.prune_to_block(mode, tip, $min_blocks).map(|block| {
+                        self.prune_target_block(mode, tip, $min_blocks).map(|block| {
                             (block, *mode)
                         })
                     })
@@ -95,7 +95,7 @@ impl PruneModes {
 
     /// Returns block up to which pruning needs to be done, inclusive, according to the provided
     /// prune mode, tip block number and minimum number of blocks allowed to be pruned.
-    pub fn prune_to_block(
+    pub fn prune_target_block(
         &self,
         mode: &PruneMode,
         tip: BlockNumber,

--- a/crates/primitives/src/serde_helper/mod.rs
+++ b/crates/primitives/src/serde_helper/mod.rs
@@ -11,7 +11,7 @@ pub use jsonu256::*;
 
 pub mod num;
 mod prune;
-pub use prune::deserialize_opt_prune_mode_with_min_distance;
+pub use prune::deserialize_opt_prune_mode_with_constraints;
 
 /// serde functions for handling primitive `u64` as [U64](crate::U64)
 pub mod u64_hex {

--- a/crates/primitives/src/serde_helper/mod.rs
+++ b/crates/primitives/src/serde_helper/mod.rs
@@ -11,7 +11,7 @@ pub use jsonu256::*;
 
 pub mod num;
 mod prune;
-pub use prune::deserialize_opt_prune_mode_with_constraints;
+pub use prune::deserialize_opt_prune_mode_with_min_blocks;
 
 /// serde functions for handling primitive `u64` as [U64](crate::U64)
 pub mod u64_hex {

--- a/crates/primitives/src/serde_helper/prune.rs
+++ b/crates/primitives/src/serde_helper/prune.rs
@@ -1,11 +1,15 @@
 use crate::PruneMode;
 use serde::{Deserialize, Deserializer};
 
-/// Deserializes [`Option<PruneMode>`] and validates that the value contained in
-/// [PruneMode::Distance] (if any) is not less than the const generic parameter `MIN_DISTANCE`.
-pub fn deserialize_opt_prune_mode_with_min_distance<
+/// Deserializes [`Option<PruneMode>`] and validates that the value is not less than the const
+/// generic parameter `MIN_DISTANCE`.
+///
+/// 1. For [PruneMode::Full], it fails if `ALLOW_FULL == false`.
+/// 2. For [PruneMode::Distance(distance)], it fails if `distance < MIN_DISTANCE`.
+pub fn deserialize_opt_prune_mode_with_constraints<
     'de,
     const MIN_DISTANCE: u64,
+    const ALLOW_FULL: bool,
     D: Deserializer<'de>,
 >(
     deserializer: D,
@@ -13,6 +17,13 @@ pub fn deserialize_opt_prune_mode_with_min_distance<
     let prune_mode = Option::<PruneMode>::deserialize(deserializer)?;
 
     match prune_mode {
+        Some(PruneMode::Full) if !ALLOW_FULL => {
+            Err(serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str("full"),
+                // This message should have "expected" wording, so we say "to be supported"
+                &"prune mode to be supported",
+            ))
+        }
         Some(PruneMode::Distance(distance)) if distance < MIN_DISTANCE => {
             Err(serde::de::Error::invalid_value(
                 serde::de::Unexpected::Unsigned(distance),
@@ -31,11 +42,11 @@ mod test {
     use serde::Deserialize;
 
     #[test]
-    fn deserialize_opt_prune_mode_with_min_distance() {
+    fn deserialize_opt_prune_mode_with_constraints() {
         #[derive(Debug, Deserialize, PartialEq, Eq)]
         struct V(
             #[serde(
-                deserialize_with = "super::deserialize_opt_prune_mode_with_min_distance::<10, _>"
+                deserialize_with = "super::deserialize_opt_prune_mode_with_constraints::<10, _>"
             )]
             Option<PruneMode>,
         );
@@ -44,6 +55,11 @@ mod test {
         assert_matches!(
             serde_json::from_str::<V>(r#"{"distance": 9}"#),
             Err(err) if err.to_string() == "invalid value: integer `9`, expected prune mode distance not less than 10 blocks"
+        );
+
+        assert_matches!(
+            serde_json::from_str::<V>(r#""full""#),
+            Err(err) if err.to_string() == "invalid value: string \"full\", expected prune mode distance not less than 10 blocks"
         );
     }
 }

--- a/crates/primitives/src/serde_helper/prune.rs
+++ b/crates/primitives/src/serde_helper/prune.rs
@@ -22,15 +22,17 @@ pub fn deserialize_opt_prune_mode_with_min_blocks<
         Some(PruneMode::Full) if MIN_BLOCKS > 0 => {
             Err(serde::de::Error::invalid_value(
                 serde::de::Unexpected::Str("full"),
-                // This message should have "expected" wording, so we say "to be supported"
-                &format!("prune mode distance not less than {MIN_BLOCKS} blocks").as_str(),
+                // This message should have "expected" wording
+                &format!("prune mode that leaves at least {MIN_BLOCKS} blocks in the database")
+                    .as_str(),
             ))
         }
         Some(PruneMode::Distance(distance)) if distance < MIN_BLOCKS => {
             Err(serde::de::Error::invalid_value(
                 serde::de::Unexpected::Unsigned(distance),
-                // This message should have "expected" wording, so we say "not less than"
-                &format!("prune mode distance not less than {MIN_BLOCKS} blocks").as_str(),
+                // This message should have "expected" wording
+                &format!("prune mode that leaves at least {MIN_BLOCKS} blocks in the database")
+                    .as_str(),
             ))
         }
         _ => Ok(prune_mode),
@@ -56,12 +58,12 @@ mod test {
         assert!(serde_json::from_str::<V>(r#"{"distance": 10}"#).is_ok());
         assert_matches!(
             serde_json::from_str::<V>(r#"{"distance": 9}"#),
-            Err(err) if err.to_string() == "invalid value: integer `9`, expected prune mode distance not less than 10 blocks"
+            Err(err) if err.to_string() == "invalid value: integer `9`, expected prune mode that leaves at least 10 blocks in the database"
         );
 
         assert_matches!(
             serde_json::from_str::<V>(r#""full""#),
-            Err(err) if err.to_string() == "invalid value: string \"full\", expected prune mode distance not less than 10 blocks"
+            Err(err) if err.to_string() == "invalid value: string \"full\", expected prune mode that leaves at least 10 blocks in the database"
         );
     }
 }

--- a/crates/primitives/src/serde_helper/prune.rs
+++ b/crates/primitives/src/serde_helper/prune.rs
@@ -46,7 +46,7 @@ mod test {
         #[derive(Debug, Deserialize, PartialEq, Eq)]
         struct V(
             #[serde(
-                deserialize_with = "super::deserialize_opt_prune_mode_with_constraints::<10, _>"
+                deserialize_with = "super::deserialize_opt_prune_mode_with_constraints::<10, false, _>"
             )]
             Option<PruneMode>,
         );
@@ -59,7 +59,7 @@ mod test {
 
         assert_matches!(
             serde_json::from_str::<V>(r#""full""#),
-            Err(err) if err.to_string() == "invalid value: string \"full\", expected prune mode distance not less than 10 blocks"
+            Err(err) if err.to_string() == "invalid value: string \"full\", expected prune mode to be supported"
         );
     }
 }

--- a/crates/prune/src/pruner.rs
+++ b/crates/prune/src/pruner.rs
@@ -64,7 +64,9 @@ impl<DB: Database> Pruner<DB> {
     pub fn run(&mut self, tip_block_number: BlockNumber) -> PrunerResult {
         let provider = self.provider_factory.provider_rw()?;
 
-        if let Some((to_block, prune_mode)) = self.modes.prune_to_block_receipts(tip_block_number) {
+        if let Some((to_block, prune_mode)) =
+            self.modes.prune_target_block_receipts(tip_block_number)
+        {
             self.prune_receipts(&provider, to_block, prune_mode)?;
         }
 


### PR DESCRIPTION
We need to check for `PruneMode::Full` when validating the config. The difference with `Distance` is that `Full` means that we prune all data related to this part, while `Distance(0)` means that we leave only the latest block.