### PR TITLE
docs: memory profiling and OOM debugging tutorial

### DIFF
--- a/book/developers/profiling.md
+++ b/book/developers/profiling.md
@@ -26,7 +26,11 @@ Reth is in the class of rust programs that distributes to many different hardwar
 Reth is also a complex program, with many moving pieces, and it can be difficult to know where to start when debugging an OOM or other memory leak.
 Understanding how to profile memory usage is an extremely valuable skill when faced with this type of problem, and can quickly help shed light on the root cause of a memory leak.
 
-In this tutorial, we will be reviewing how to use `jemalloc` to solve these types of problems, [todo: rest of "here is what we are going to do"]().
+In this tutorial, we will be reviewing:
+ * How to monitor reth's memory usage,
+ * How to emulate a low-memory environment to lab-reproduce OOM crashes,
+ * How to enable `jemalloc` and its built-in memory profiling, and
+ * How to use `jeprof` to interpret heap profiles and identify potential root causes for a memory leak.
 
 ### Jemalloc
 

--- a/book/developers/profiling.md
+++ b/book/developers/profiling.md
@@ -1,6 +1,6 @@
 # Profiling reth
 
-#### Table of Contents  
+#### Table of Contents
  - [Memory profiling](#memory-profiling)
    - [Jemalloc](#jemalloc)
    - [Monitoring memory usage](#monitoring-memory-usage)
@@ -11,7 +11,7 @@
 
 When a program consumes all of the system's available memory (and swap, if any), the OOM killer starts killing processes that are taking up the most memory, until the system has
 memory available again. [See kernel.org for a great (although outdated) introduction to out-of-memory management.](https://www.kernel.org/doc/gorman/html/understand/understand016.html).
-Reth is in the class of rust programs that distributes to many different hardware targets, some with less memory than others. As a result, sometimes bugs can cause memory leaks or out-of-memory crashes for _some_ users, but not others.
+Reth distributes to many different hardware targets, some with less memory than others. As a result, sometimes bugs can cause memory leaks or out-of-memory crashes for _some_ users, but not others.
 Reth is also a complex program, with many moving pieces, and it can be difficult to know where to start when debugging an OOM or other memory leak.
 Understanding how to profile memory usage is an extremely valuable skill when faced with this type of problem, and can quickly help shed light on the root cause of a memory leak.
 
@@ -45,7 +45,7 @@ profile does not enable debug symbols, which are required for tools like `perf` 
 ```
 cargo build --features jemalloc-prof --profile debug-fast
 
-# May improve performance even more 
+# May improve performance even more
 RUSTFLAGS="-C target-cpu=native" cargo build --features jemalloc-prof --profile debug-fast
 ```
 

--- a/book/developers/profiling.md
+++ b/book/developers/profiling.md
@@ -1,0 +1,5 @@
+# Profiling reth
+
+
+## Memory profiling
+

--- a/book/developers/profiling.md
+++ b/book/developers/profiling.md
@@ -3,52 +3,52 @@
 #### Table of Contents  
  - [Latency profiling (WIP)](#latency-profiling)
  - [Memory profiling](#memory-profiling)
-  - [Jemalloc](#jemalloc)
-  - [Monitoring memory usage](#monitoring-memory-usage)
-  - [Limiting process memory](#limiting-process-memory)
-  - [Understanding allocation with jeprof](#understanding-allocation-with-jeprof)
+   - [Jemalloc](#jemalloc)
+   - [Monitoring memory usage](#monitoring-memory-usage)
+   - [Limiting process memory](#limiting-process-memory)
+   - [Understanding allocation with jeprof](#understanding-allocation-with-jeprof)
 
 Audience:
-* Assuming knowledge of:
- * Linux command line maturity
- * How to compile reth from source
- * How to set up grafana + reth metrics
-* Requires:
- * Linux
+ * Assuming knowledge of:
+   * Linux command line maturity
+   * How to compile reth from source
+   * How to set up grafana + reth metrics
+ * Requires:
+   * Linux
 
 ## Memory profiling
 
-* Why memory profile in general
-* How does something OOM
-* How can memory profiling
+ * Why memory profile in general
+ * How does something OOM
+ * How can memory profiling
 
 ### Jemalloc
 
-* What is jemalloc
-* What jemalloc provides (jeprof, jemalloc metrics)
-* Compiling with the `jemalloc` feature
-* Compiling with the `jemalloc-prof` feature
+ * What is jemalloc
+ * What jemalloc provides (jeprof, jemalloc metrics)
+ * Compiling with the `jemalloc` feature
+ * Compiling with the `jemalloc-prof` feature
 
 ### Monitoring memory usage
 
-* Reth's dashboard
- * Jemalloc metrics
- * Component memory metrics
+ * Reth's dashboard
+  * Jemalloc metrics
+  * Component memory metrics
 
 ### Limiting process memory
 
-* Why limit memory usage
-* What is `cgroups`
-* How to use `cgroups` to limit memory usage
-* How to make sure the cgroup limits memory usage
+ * Why limit memory usage
+ * What is `cgroups`
+ * How to use `cgroups` to limit memory usage
+ * How to make sure the cgroup limits memory usage
 
 ### Understanding allocation with jeprof
 
-* How to enable profiling with environment variables
-* What is produced by jemalloc
-* How to visualize jemalloc heap profiles
+ * How to enable profiling with environment variables
+ * What is produced by jemalloc
+ * How to visualize jemalloc heap profiles
 
 ### TODO / to resolve
-* tips?
-* how can this document give the reader more intuition on debugging memory leaks beyond providing tutorials on tools
+ * tips?
+ * how can this document give the reader more intuition on debugging memory leaks beyond providing tutorials on tools
 

--- a/book/developers/profiling.md
+++ b/book/developers/profiling.md
@@ -79,9 +79,31 @@ making it extremely useful to developers in understanding how their application 
  * How to use `cgroups` to limit memory usage
    * Enable cgroups on your system
      * grub var
+```
+GRUB_CMDLINE_LINUX_DEFAULT="cgroup_enable=memory"
+```
    * Create a cgroup
+```
+sudo cgcreate -t $USER:$USER -a $USER:$USER -g memory:rethMemory
+```
+   * Set up cgroup memory limit (this one does 8G)
+```
+echo 8G > /sys/fs/cgroup/memory/rethMemory/memory.limit_in_bytes
+```
    * Important - check swap!
-   * Using `cgexec`
+
+To check swap, use `free -m`:
+```
+ubuntu@bench-box:~/reth$ free -m
+              total        used        free      shared  buff/cache   available
+Mem:         257668       10695      218760          12       28213      244761
+Swap:          8191         159        8032
+```
+    * If swap is enabled / high then the oom will take longer
+   * Using `cgexec` to run reth
+```
+cgexec -g memory:rethMemory reth node
+```
 
 ### Understanding allocation with jeprof
 
@@ -101,10 +123,12 @@ If reth is not built properly, you will see this when you try to run reth:
 
 If this happens, jemalloc likely needs to be rebuilt with the `jemalloc-prof` feature enabled.
 
+
 If everything is working, this will output `jeprof.*.heap` files while reth is running.
 [The jemalloc website](http://jemalloc.net/jemalloc.3.html#opt.abort) has a helpful overview of the options available, for example `lg_prof_interval`, `lg_prof_sample`, `prof_leak`, and `prof_final`.
 
-Now, there should be a 
+
+Now that we have the heap snapshots, we can analyze them using `jeprof`.
 
 ### TODO / to resolve
  * how can this document give the reader more intuition on debugging memory leaks beyond providing tutorials on tools

--- a/book/developers/profiling.md
+++ b/book/developers/profiling.md
@@ -55,9 +55,12 @@ cargo build --features jemalloc-prof
 ```
 
 When performing a longer-running or performance-sensitive task with reth, such as a sync test or load benchmark, it's usually recommended to use the `maxperf` profile. However, the `maxperf`
-profile does not enable debug symbols, which are required for tools like `perf` and `jemalloc` to produce results that a human can interpret. Reth includes a performance profile with debug symbols called `debug-fast`. To compile reth with debug symbols, jemalloc, and a performance profile:
+profile does not enable debug symbols, which are required for tools like `perf` and `jemalloc` to produce results that a human can interpret. Reth includes a performance profile with debug symbols called `debug-fast`. To compile reth with debug symbols, jemalloc, profiling, and a performance profile:
 ```
 cargo build --features jemalloc-prof --profile debug-fast
+
+# May improve performance even more 
+RUSTFLAGS="-C target-cpu=native" cargo build --features jemalloc-prof --profile debug-fast
 ```
 
 ### Monitoring memory usage

--- a/book/developers/profiling.md
+++ b/book/developers/profiling.md
@@ -8,6 +8,8 @@
    - [Limiting process memory](#limiting-process-memory)
    - [Understanding allocation with jeprof](#understanding-allocation-with-jeprof)
 
+
+NEED TO WRITE INTRO
 Audience:
  * Assuming knowledge of:
    * Linux command line maturity
@@ -18,9 +20,13 @@ Audience:
 
 ## Memory profiling
 
- * Why memory profile in general
- * How does something OOM
- * How can memory profiling
+When a program consumes all of the system's available memory (and swap, if any), the OOM killer starts killing processes that are taking up the most memory, until the system has
+memory available again. [todo: go here for more info on oomkiller?]().
+Reth is in the class of rust programs that distributes to many different hardware targets, some with less memory than others. As a result, sometimes bugs can cause memory-related crashes for _some_ users, but not others.
+Reth is also a complex program, with many moving pieces, and it can be difficult to know where to start when debugging an OOM or other memory leak.
+Understanding how to profile memory usage is an extremely valuable skill when faced with this type of problem, and can quickly help shed light on the root cause of a memory leak.
+
+In this tutorial, we will be reviewing how to use `jemalloc` to solve these types of problems, [todo: rest of "here is what we are going to do"]().
 
 ### Jemalloc
 

--- a/book/developers/profiling.md
+++ b/book/developers/profiling.md
@@ -22,7 +22,7 @@ Audience:
 
 When a program consumes all of the system's available memory (and swap, if any), the OOM killer starts killing processes that are taking up the most memory, until the system has
 memory available again. [todo: go here for more info on oomkiller?]().
-Reth is in the class of rust programs that distributes to many different hardware targets, some with less memory than others. As a result, sometimes bugs can cause memory-related crashes for _some_ users, but not others.
+Reth is in the class of rust programs that distributes to many different hardware targets, some with less memory than others. As a result, sometimes bugs can cause memory leaks or out-of-memory crashes for _some_ users, but not others.
 Reth is also a complex program, with many moving pieces, and it can be difficult to know where to start when debugging an OOM or other memory leak.
 Understanding how to profile memory usage is an extremely valuable skill when faced with this type of problem, and can quickly help shed light on the root cause of a memory leak.
 

--- a/book/developers/profiling.md
+++ b/book/developers/profiling.md
@@ -1,5 +1,11 @@
 # Profiling reth
 
-
 ## Memory profiling
 
+## Jemalloc
+
+## Limiting memory and deliberate OOMs
+
+## Understanding memory usage with jeprof
+
+## Validating hardware requirements

--- a/book/developers/profiling.md
+++ b/book/developers/profiling.md
@@ -67,5 +67,7 @@ In this tutorial, we will be reviewing how to use `jemalloc` to solve these type
 
 ### TODO / to resolve
  * tips?
+ * intro / background on memory?
+ * write a brief description / introduction to the OOM acronym before using it all over the place
  * how can this document give the reader more intuition on debugging memory leaks beyond providing tutorials on tools
 

--- a/book/developers/profiling.md
+++ b/book/developers/profiling.md
@@ -10,7 +10,7 @@
 ## Memory profiling
 
 When a program consumes all of the system's available memory (and swap, if any), the OOM killer starts killing processes that are taking up the most memory, until the system has
-memory available again. [todo: go here for more info on oomkiller?]().
+memory available again. [See kernel.org for a great (although outdated) introduction to out-of-memory management.](https://www.kernel.org/doc/gorman/html/understand/understand016.html).
 Reth is in the class of rust programs that distributes to many different hardware targets, some with less memory than others. As a result, sometimes bugs can cause memory leaks or out-of-memory crashes for _some_ users, but not others.
 Reth is also a complex program, with many moving pieces, and it can be difficult to know where to start when debugging an OOM or other memory leak.
 Understanding how to profile memory usage is an extremely valuable skill when faced with this type of problem, and can quickly help shed light on the root cause of a memory leak.

--- a/book/developers/profiling.md
+++ b/book/developers/profiling.md
@@ -9,7 +9,8 @@
    - [Understanding allocation with jeprof](#understanding-allocation-with-jeprof)
 
 
-NEED TO WRITE INTRO
+[TODO: intro that lays out the below prior knowledge requirements]()
+
 Audience:
  * Assuming knowledge of:
    * Linux command line maturity

--- a/book/developers/profiling.md
+++ b/book/developers/profiling.md
@@ -37,7 +37,7 @@ In this tutorial, we will be reviewing:
 
 ### Jemalloc
 
-[Jemalloc](https://jemalloc.net/) is a general-purpose allocator that is used [across the industry for production](https://engineering.fb.com/2011/01/03/core-data/scalable-memory-allocation-using-jemalloc/), well known for its performance benefits, predictability, and profiling capabilities.
+[Jemalloc](https://jemalloc.net/) is a general-purpose allocator that is used [across the industry in production](https://engineering.fb.com/2011/01/03/core-data/scalable-memory-allocation-using-jemalloc/), well known for its performance benefits, predictability, and profiling capabilities.
 We've seen significant performance benefits in reth when using jemalloc, but will be primarily focusing on its profiling capabilities.
 Jemalloc also provides tools for analyzing and visualizing its the allocation profiles it generates, notably `jeprof`.
 

--- a/book/developers/profiling.md
+++ b/book/developers/profiling.md
@@ -71,8 +71,11 @@ RUSTFLAGS="-C target-cpu=native" cargo build --features jemalloc-prof --profile 
 
 ### Limiting process memory
 
- * Why limit memory usage
- * What is `cgroups`
+Memory leaks that cause OOMs can be difficult to trigger sometimes, and highly depend on the testing hardware. A testing machine with 128GB of RAM is not going to encounter OOMs caused by
+memory spikes or leaks as often as a machine with only 8GB of RAM. Development machines are powerful for a reason, so artificially limiting memory usage is often the best way to replicate a
+user's hardware. This can help developers debug issues that only occur on devices with limited hardware. `cgroups` is a tool that allows developers to limit the memory usage of a process,
+making it extremely useful to developers in understanding how their application performs in low-memory environments.
+
  * How to use `cgroups` to limit memory usage
    * Enable cgroups on your system
      * grub var

--- a/book/developers/profiling.md
+++ b/book/developers/profiling.md
@@ -37,11 +37,28 @@ In this tutorial, we will be reviewing:
 
 ### Jemalloc
 
- * What is jemalloc
- * What jemalloc provides (jeprof, jemalloc metrics)
- * Compiling with the `jemalloc` feature
- * Compiling with the `jemalloc-prof` feature
- * `debug-fast` for debug symbols
+[Jemalloc](https://jemalloc.net/) is a general-purpose allocator that is used [across the industry for production](https://engineering.fb.com/2011/01/03/core-data/scalable-memory-allocation-using-jemalloc/), well known for its performance benefits, predictability, and profiling capabilities.
+We've seen significant performance benefits in reth when using jemalloc, but will be primarily focusing on its profiling capabilities.
+Jemalloc also provides tools for analyzing and visualizing its the allocation profiles it generates, notably `jeprof`.
+
+
+#### Enabling jemalloc in reth
+Reth includes a `jemalloc` feature to explicitly use jemalloc instead of the system allocator:
+```
+cargo build --features jemalloc
+```
+
+While the `jemalloc` feature does enable jemalloc, reth has an additional feature, `profiling`, that must be used to enable heap profiling. This feature implicitly enables the `jemalloc`
+feature as well:
+```
+cargo build --features jemalloc-prof
+```
+
+When performing a longer-running or performance-sensitive task with reth, such as a sync test or load benchmark, it's usually recommended to use the `maxperf` profile. However, the `maxperf`
+profile does not enable debug symbols, which are required for tools like `perf` and `jemalloc` to produce results that a human can interpret. Reth includes a performance profile with debug symbols called `debug-fast`. To compile reth with debug symbols, jemalloc, and a performance profile:
+```
+cargo build --features jemalloc-prof --profile debug-fast
+```
 
 ### Monitoring memory usage
 

--- a/book/developers/profiling.md
+++ b/book/developers/profiling.md
@@ -1,11 +1,54 @@
 # Profiling reth
 
+#### Table of Contents  
+ - [Latency profiling (WIP)](#latency-profiling)
+ - [Memory profiling](#memory-profiling)
+  - [Jemalloc](#jemalloc)
+  - [Monitoring memory usage](#monitoring-memory-usage)
+  - [Limiting process memory](#limiting-process-memory)
+  - [Understanding allocation with jeprof](#understanding-allocation-with-jeprof)
+
+Audience:
+* Assuming knowledge of:
+ * Linux command line maturity
+ * How to compile reth from source
+ * How to set up grafana + reth metrics
+* Requires:
+ * Linux
+
 ## Memory profiling
 
-## Jemalloc
+* Why memory profile in general
+* How does something OOM
+* How can memory profiling
 
-## Limiting memory and deliberate OOMs
+### Jemalloc
 
-## Understanding memory usage with jeprof
+* What is jemalloc
+* What jemalloc provides (jeprof, jemalloc metrics)
+* Compiling with the `jemalloc` feature
+* Compiling with the `jemalloc-prof` feature
 
-## Validating hardware requirements
+### Monitoring memory usage
+
+* Reth's dashboard
+ * Jemalloc metrics
+ * Component memory metrics
+
+### Limiting process memory
+
+* Why limit memory usage
+* What is `cgroups`
+* How to use `cgroups` to limit memory usage
+* How to make sure the cgroup limits memory usage
+
+### Understanding allocation with jeprof
+
+* How to enable profiling with environment variables
+* What is produced by jemalloc
+* How to visualize jemalloc heap profiles
+
+### TODO / to resolve
+* tips?
+* how can this document give the reader more intuition on debugging memory leaks beyond providing tutorials on tools
+

--- a/book/developers/profiling.md
+++ b/book/developers/profiling.md
@@ -21,6 +21,8 @@ Audience:
 
 ## Memory profiling
 
+<!-- TODO: i feel like this might be jumping into things too quickly - right now the document feels like it just "starts" and starts talking about memory, would like to make a more gradual
+introduction so the reader has all the required context when they get to this paragraph -->
 When a program consumes all of the system's available memory (and swap, if any), the OOM killer starts killing processes that are taking up the most memory, until the system has
 memory available again. [todo: go here for more info on oomkiller?]().
 Reth is in the class of rust programs that distributes to many different hardware targets, some with less memory than others. As a result, sometimes bugs can cause memory leaks or out-of-memory crashes for _some_ users, but not others.

--- a/book/developers/profiling.md
+++ b/book/developers/profiling.md
@@ -65,11 +65,22 @@ RUSTFLAGS="-C target-cpu=native" cargo build --features jemalloc-prof --profile 
 
 ### Monitoring memory usage
 
- * Reth's dashboard
-  * Jemalloc metrics
-  * Component memory metrics
+Reth's dashboard has a few metrics that are important when monitoring memory usage. The **Jemalloc memory** graph shows reth's memory usage. The *allocated* label shows the memory used by the reth process which cannot be reclaimed unless reth frees that memory. This metric exceeding the available system memory would cause reth to be killed by the OOM killer.
+<img width="749" alt="Jemalloc memory" src="https://github.com/paradigmxyz/reth/assets/6798349/2653c5a2-bd7c-46a6-a593-23809389628e">
+
+Some of reth's internal components also have metrics for the memory usage of certain data structures, usually data structures that are likely to contain many elements or may consume a lot of memory at peak load.
+
+**The bodies downloader buffer**:
+<img width="749" alt="The bodies downloader buffer graph" src="https://github.com/paradigmxyz/reth/assets/6798349/75383724-24ae-4f4f-98a9-72d01731a5f9">
+
+**The blockchain tree block buffer**:
+<img width="749" alt="The blockchain tree block buffer graph" src="https://github.com/paradigmxyz/reth/assets/6798349/7162c6d4-ed18-48c1-a327-50a245dabc95">
+
+**The transaction pool subpools**:
+<img width="749" alt="The transaction pool subpool size graph" src="https://github.com/paradigmxyz/reth/assets/6798349/c5066fd6-7ff7-4e62-9226-89327c7a802c">
 
 ### Limiting process memory
+
 
 Memory leaks that cause OOMs can be difficult to trigger sometimes, and highly depend on the testing hardware. A testing machine with 128GB of RAM is not going to encounter OOMs caused by
 memory spikes or leaks as often as a machine with only 8GB of RAM. Development machines are powerful for a reason, so artificially limiting memory usage is often the best way to replicate a

--- a/book/developers/profiling.md
+++ b/book/developers/profiling.md
@@ -28,6 +28,7 @@ Audience:
  * What jemalloc provides (jeprof, jemalloc metrics)
  * Compiling with the `jemalloc` feature
  * Compiling with the `jemalloc-prof` feature
+ * `debug-fast` for debug symbols
 
 ### Monitoring memory usage
 
@@ -40,13 +41,23 @@ Audience:
  * Why limit memory usage
  * What is `cgroups`
  * How to use `cgroups` to limit memory usage
- * How to make sure the cgroup limits memory usage
+   * Enable cgroups on your system
+     * grub var
+   * Create a cgroup
+   * Important - check swap!
+   * Using `cgexec`
 
 ### Understanding allocation with jeprof
 
  * How to enable profiling with environment variables
+   * `_RJEM_MALLOC_blah=blah`
  * What is produced by jemalloc
+   * When are snapshots taken
+   * `jeprof.*.heap`
  * How to visualize jemalloc heap profiles
+   * jeprof
+   * `--pdf`
+   * flamegraphs
 
 ### TODO / to resolve
  * tips?

--- a/book/developers/profiling.md
+++ b/book/developers/profiling.md
@@ -126,4 +126,4 @@ If this happens, jemalloc likely needs to be rebuilt with the `jemalloc-prof` fe
 If everything is working, this will output `jeprof.*.heap` files while reth is running.
 [The jemalloc website](http://jemalloc.net/jemalloc.3.html#opt.abort) has a helpful overview of the options available, for example `lg_prof_interval`, `lg_prof_sample`, `prof_leak`, and `prof_final`.
 
-Now that we have the heap snapshots, we can analyze them using `jeprof`. An example of jeprof usage and output can be seen here: https://github.com/jemalloc/jemalloc/wiki/Use-Case:-Leak-Checking
+Now that we have the heap snapshots, we can analyze them using `jeprof`. An example of jeprof usage and output can be seen on the jemalloc github repository: https://github.com/jemalloc/jemalloc/wiki/Use-Case:-Leak-Checking


### PR DESCRIPTION
This distills some of my previous attempts at fixing memory leaks in reth, so that memory leak debugging can be more accessible.

I aim to give an overview on the process one should go through when faced with a memory related bug or incident, as well as provide some useful intuition for rust and reth-specific debugging. This will be a more advanced tutorial, and will assume some knowledge about linux, memory, and how to set up reth, but should otherwise be a general document that anyone can learn from.