### PR TITLE
chore: fix SessionManagerMetrics typo

### DIFF
--- a/crates/net/network/src/metrics.rs
+++ b/crates/net/network/src/metrics.rs
@@ -48,7 +48,7 @@ pub struct NetworkMetrics {
 /// Metrics for SessionManager
 #[derive(Metrics)]
 #[metrics(scope = "network")]
-pub struct SesssionManagerMetrics {
+pub struct SessionManagerMetrics {
     /// Number of dials that resulted in a peer being added to the peerset
     pub(crate) total_dial_successes: Counter,
 }

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -1,7 +1,7 @@
 //! Support for handling peer sessions.
 use crate::{
     message::PeerMessage,
-    metrics::SesssionManagerMetrics,
+    metrics::SessionManagerMetrics,
     session::{active::ActiveSession, config::SessionCounter},
 };
 pub use crate::{message::PeerRequestSender, session::handle::PeerInfo};
@@ -100,7 +100,7 @@ pub struct SessionManager {
     /// Used to measure inbound & outbound bandwidth across all managed streams
     bandwidth_meter: BandwidthMeter,
     /// Metrics for the session manager.
-    metrics: SesssionManagerMetrics,
+    metrics: SessionManagerMetrics,
 }
 
 // === impl SessionManager ===


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1189232</samp>

Renamed and corrected `Metrics` and `SessionManagerMetrics` structs in the network crate to improve clarity and consistency. Affected files are `crates/net/network/src/session/mod.rs` and `crates/net/network/src/metrics.rs`.