### PR TITLE
docs: rm link to make cargo docs happy

### DIFF
--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -13,7 +13,7 @@ use std::{fmt, time::Instant};
 mod eth;
 mod task;
 
-/// A [TransactionValidator] implementation that validates ethereum transaction.
+/// A `TransactionValidator` implementation that validates ethereum transaction.
 pub use eth::{EthTransactionValidator, EthTransactionValidatorBuilder};
 
 /// A spawnable task that performs transaction validation.


### PR DESCRIPTION
for some reason cargo docs fails to resolve the link here.

remove link so build jobs works again