### PR TITLE
chore: refactor autoseal execution into method

### DIFF
--- a/crates/consensus/auto-seal/src/lib.rs
+++ b/crates/consensus/auto-seal/src/lib.rs
@@ -21,16 +21,25 @@
 //! be mined.
 
 use reth_beacon_consensus::BeaconEngineMessage;
-use reth_interfaces::consensus::{Consensus, ConsensusError};
-use reth_primitives::{
-    BlockBody, BlockHash, BlockHashOrNumber, BlockNumber, ChainSpec, Header, SealedBlock,
-    SealedHeader, H256, U256,
+use reth_interfaces::{
+    consensus::{Consensus, ConsensusError},
+    executor::{BlockExecutionError, BlockValidationError},
 };
-use reth_provider::{BlockReaderIdExt, CanonStateNotificationSender};
+use reth_primitives::{
+    constants::{EMPTY_RECEIPTS, EMPTY_TRANSACTIONS, ETHEREUM_BLOCK_GAS_LIMIT},
+    proofs, Block, BlockBody, BlockHash, BlockHashOrNumber, BlockNumber, ChainSpec, Header,
+    ReceiptWithBloom, SealedBlock, SealedHeader, TransactionSigned, EMPTY_OMMER_ROOT, H256, U256,
+};
+use reth_provider::{BlockReaderIdExt, CanonStateNotificationSender, PostState, StateProvider};
+use reth_revm::executor::Executor;
 use reth_transaction_pool::TransactionPool;
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
 use tokio::sync::{mpsc::UnboundedSender, RwLock, RwLockReadGuard, RwLockWriteGuard};
-use tracing::trace;
+use tracing::{trace, warn};
 
 mod client;
 mod mode;
@@ -182,6 +191,7 @@ impl Storage {
     }
 }
 
+/// In-memory storage for the chain the auto seal engine is building.
 #[derive(Default, Debug)]
 pub(crate) struct StorageInner {
     /// Headers buffered for download.
@@ -231,5 +241,93 @@ impl StorageInner {
         self.headers.insert(header.number, header);
         self.bodies.insert(self.best_hash, body);
         self.hash_to_number.insert(self.best_hash, self.best_block);
+    }
+
+    /// Builds and executes a new block with the given transactions and chainspec, on the provided
+    /// [Executor].
+    ///
+    /// This returns the header of the executed block, as well as the poststate from execution.
+    pub(crate) fn build_and_execute<DB: StateProvider>(
+        &mut self,
+        transactions: Vec<TransactionSigned>,
+        executor: &mut Executor<DB>,
+    ) -> Result<(SealedHeader, PostState), BlockExecutionError> {
+        // check previous block for base fee
+        let base_fee_per_gas =
+            self.headers.get(&self.best_block).and_then(|parent| parent.next_block_base_fee());
+
+        let mut header = Header {
+            parent_hash: self.best_hash,
+            ommers_hash: EMPTY_OMMER_ROOT,
+            beneficiary: Default::default(),
+            state_root: Default::default(),
+            transactions_root: Default::default(),
+            receipts_root: Default::default(),
+            withdrawals_root: None,
+            logs_bloom: Default::default(),
+            difficulty: U256::from(2),
+            number: self.best_block + 1,
+            gas_limit: ETHEREUM_BLOCK_GAS_LIMIT,
+            gas_used: 0,
+            timestamp: SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs(),
+            mix_hash: Default::default(),
+            nonce: 0,
+            base_fee_per_gas,
+            extra_data: Default::default(),
+        };
+
+        header.transactions_root = if transactions.is_empty() {
+            EMPTY_TRANSACTIONS
+        } else {
+            proofs::calculate_transaction_root(&transactions)
+        };
+
+        let block = Block { header, body: transactions, ommers: vec![], withdrawals: None };
+
+        trace!(target: "consensus::auto", transactions=?&block.body, "executing transactions");
+
+        let senders =
+            block.body.iter().map(|tx| tx.recover_signer()).collect::<Option<Vec<_>>>().ok_or(
+                BlockExecutionError::Validation(BlockValidationError::SenderRecoveryError),
+            )?;
+
+        let (post_state, gas_used) =
+            executor.execute_transactions(&block, U256::ZERO, Some(senders.clone()))?;
+
+        // apply post block changes
+        let post_state = executor.apply_post_block_changes(&block, U256::ZERO, post_state).unwrap();
+
+        let Block { mut header, body, .. } = block;
+
+        // TODO: do in calling code if successful
+        // clear all transactions from pool
+        // pool.remove_transactions(body.iter().map(|tx| tx.hash()));
+
+        let receipts = post_state.receipts(header.number);
+        header.receipts_root = if receipts.is_empty() {
+            EMPTY_RECEIPTS
+        } else {
+            let receipts_with_bloom =
+                receipts.iter().map(|r| r.clone().into()).collect::<Vec<ReceiptWithBloom>>();
+            proofs::calculate_receipt_root(&receipts_with_bloom)
+        };
+
+        let body = BlockBody { transactions: body, ommers: vec![], withdrawals: None };
+        header.gas_used = gas_used;
+
+        trace!(target: "consensus::auto", ?post_state, ?header, ?body, "executed block, calculating root");
+
+        // calculate the state root
+        let state_root = executor.db().db.0.state_root(post_state.clone()).unwrap();
+        header.state_root = state_root;
+
+        trace!(target: "consensus::auto", root=?header.state_root, ?body, "calculated root");
+
+        self.insert_new_block(header.clone(), body);
+
+        // set new header with hash that should have been updated by insert_new_block
+        let new_header = header.seal(self.best_hash);
+
+        Ok((new_header, post_state))
     }
 }

--- a/crates/consensus/auto-seal/src/lib.rs
+++ b/crates/consensus/auto-seal/src/lib.rs
@@ -243,8 +243,7 @@ impl StorageInner {
         self.hash_to_number.insert(self.best_hash, self.best_block);
     }
 
-    /// Builds and executes a new block with the given transactions and chainspec, on the provided
-    /// [Executor].
+    /// Builds and executes a new block with the given transactions, on the provided [Executor].
     ///
     /// This returns the header of the executed block, as well as the poststate from execution.
     pub(crate) fn build_and_execute<DB: StateProvider>(
@@ -298,10 +297,6 @@ impl StorageInner {
         let post_state = executor.apply_post_block_changes(&block, U256::ZERO, post_state).unwrap();
 
         let Block { mut header, body, .. } = block;
-
-        // TODO: do in calling code if successful
-        // clear all transactions from pool
-        // pool.remove_transactions(body.iter().map(|tx| tx.hash()));
 
         let receipts = post_state.receipts(header.number);
         header.receipts_root = if receipts.is_empty() {


### PR DESCRIPTION
This refactors autoseal execution into methods on `StorageInner`, simplifying the logic in the mining task. The motivation for this PR is so `AutoSealClient` can be used in engine API integration tests. This would allow the tests to use the execution + state root logic from `Storage`, and the client logic from `AutoSealClient`.