### PR TITLE
ci: increase number of unit test partitions

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        partition: [1, 2, 3, 4]
+        partition: [1, 2, 3, 4, 5]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3


### PR DESCRIPTION
Partition 4 is taking >30 minutes which boots our PRs from the merge queue