### PR TITLE
ci: re-enable workflows on main

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,6 +1,8 @@
 on:
   pull_request:
   merge_group:
+  push:
+    branches: [main]
 
 env:
   RUSTFLAGS: -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 on:
   pull_request:
   merge_group:
+  push:
+    branches: [main]
 
 env:
   RUSTFLAGS: -D warnings

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,6 +1,8 @@
 on:
   pull_request:
   merge_group:
+  push:
+    branches: [main]
 
 env:
   RUSTFLAGS: -D warnings

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,6 +1,8 @@
 on:
   pull_request:
   merge_group:
+  push:
+    branches: [main]
 
 env:
   RUSTFLAGS: -D warnings

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,6 +1,8 @@
 on:
   pull_request:
   merge_group:
+  push:
+    branches: [main]
 
 env:
   RUSTFLAGS: -D warnings


### PR DESCRIPTION
I disabled this to save the number of pending jobs we generated for GitHub runners as there is a limit on how many runners we can occupy at any one time. I assumed that since the merge groups carry over checks from the merge group branch, they would also carry over their cache. This is not the case, so most workflows run w/o caches currently. Lame.

This re-enables the workflows on main, just to build the caches. Lame.

Closes #3616