### PR TITLE
fix(rpc): trace get is index not trace address

### DIFF
--- a/crates/rpc/rpc-api/src/trace.rs
+++ b/crates/rpc/rpc-api/src/trace.rs
@@ -71,6 +71,11 @@ pub trait TraceApi {
     async fn trace_filter(&self, filter: TraceFilter) -> RpcResult<Vec<LocalizedTransactionTrace>>;
 
     /// Returns transaction trace at given index.
+    ///
+    /// `indices` represent the index positions of the traces.
+    ///
+    /// Note: This expects a list of indices but only one is supported since this function returns a
+    /// single [LocalizedTransactionTrace].
     #[method(name = "get")]
     async fn trace_get(
         &self,

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -268,17 +268,36 @@ where
         .await
     }
 
-    /// Returns transaction trace with the given address.
+    /// Returns transaction trace objects at the given index
+    ///
+    /// Note: For compatibility reasons this only supports 1 single index, since this method is
+    /// supposed to return a single trace. See also: <https://github.com/ledgerwatch/erigon/blob/862faf054b8a0fa15962a9c73839b619886101eb/turbo/jsonrpc/trace_filtering.go#L114-L133>
+    ///
+    /// This returns `None` if `indices` is empty
     pub async fn trace_get(
         &self,
         hash: H256,
-        trace_address: Vec<usize>,
+        indices: Vec<usize>,
+    ) -> EthResult<Option<LocalizedTransactionTrace>> {
+        if indices.len() != 1 {
+            // The OG impl failed if it gets more than a single index
+            return Ok(None)
+        }
+        self.trace_get_index(hash, indices[0]).await
+    }
+
+    /// Returns transaction trace object at the given index.
+    ///
+    /// Returns `None` if the trace object at that index does not exist
+    pub async fn trace_get_index(
+        &self,
+        hash: H256,
+        index: usize,
     ) -> EthResult<Option<LocalizedTransactionTrace>> {
         match self.trace_transaction(hash).await? {
             None => Ok(None),
             Some(traces) => {
-                let trace =
-                    traces.into_iter().find(|trace| trace.trace.trace_address == trace_address);
+                let trace = traces.into_iter().nth(index);
                 Ok(trace)
             }
         }


### PR DESCRIPTION
ref https://github.com/paradigmxyz/reth/issues/3721

`trace_get` is supposed to return the index positon, not the matching trace address

this was always limited to 1 index

https://github.com/ledgerwatch/erigon/blob/862faf054b8a0fa15962a9c73839b619886101eb/turbo/jsonrpc/trace_filtering.go#L114-L133