### PR TITLE
fix(txpool): proper pool ordering, round 2

### DIFF
--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -581,7 +581,7 @@ fn build_payload<Pool, Client>(
         let base_fee = initialized_block_env.basefee.to::<u64>();
 
         let mut executed_txs = Vec::new();
-        let mut best_txs = pool.best_transactions_with_base_fee(base_fee as u128);
+        let mut best_txs = pool.best_transactions_with_base_fee(base_fee);
 
         let mut total_fees = U256::ZERO;
 

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -39,7 +39,7 @@ pub const ETHEREUM_BLOCK_GAS_LIMIT: u64 = 30_000_000;
 /// The `BASE_FEE_MAX_CHANGE_DENOMINATOR` <https://eips.ethereum.org/EIPS/eip-1559> is `8`, or 12.5%.
 /// Once the base fee has dropped to `7` WEI it cannot decrease further because 12.5% of 7 is less
 /// than 1.
-pub const MIN_PROTOCOL_BASE_FEE: u128 = 7;
+pub const MIN_PROTOCOL_BASE_FEE: u64 = 7;
 
 /// Same as [MIN_PROTOCOL_BASE_FEE] but as a U256.
 pub const MIN_PROTOCOL_BASE_FEE_U256: U256 = U256::from_limbs([7u64, 0, 0, 0]);
@@ -114,6 +114,6 @@ mod tests {
 
     #[test]
     fn min_protocol_sanity() {
-        assert_eq!(MIN_PROTOCOL_BASE_FEE_U256.to::<u128>(), MIN_PROTOCOL_BASE_FEE);
+        assert_eq!(MIN_PROTOCOL_BASE_FEE_U256.to::<u64>(), MIN_PROTOCOL_BASE_FEE);
     }
 }

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -462,7 +462,7 @@ impl Transaction {
     ///
     /// This is different than the `max_priority_fee_per_gas` method, which returns `None` for
     /// non-EIP-1559 transactions.
-    pub(crate) fn priority_fee_or_price(&self) -> u128 {
+    pub fn priority_fee_or_price(&self) -> u128 {
         match self {
             Transaction::Legacy(TxLegacy { gas_price, .. }) |
             Transaction::Eip2930(TxEip2930 { gas_price, .. }) => *gas_price,

--- a/crates/rpc/rpc/src/eth/api/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/api/pending_block.rs
@@ -50,7 +50,7 @@ impl PendingBlockEnv {
         let block_number = block_env.number.to::<u64>();
 
         let mut executed_txs = Vec::new();
-        let mut best_txs = pool.best_transactions_with_base_fee(base_fee as u128);
+        let mut best_txs = pool.best_transactions_with_base_fee(base_fee);
 
         while let Some(pool_tx) = best_txs.next() {
             // ensure we still have capacity for this transaction

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -158,7 +158,7 @@ pub use crate::{
         TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT, TXPOOL_SUBPOOL_MAX_TXS_DEFAULT,
     },
     error::PoolResult,
-    ordering::{GasCostOrdering, TransactionOrdering},
+    ordering::{MinerTipOrdering, TransactionOrdering},
     pool::{
         state::SubPool, AllTransactionsEvents, FullTransactionEvent, TransactionEvent,
         TransactionEvents,
@@ -281,12 +281,12 @@ where
 }
 
 impl<Client>
-    Pool<EthTransactionValidator<Client, PooledTransaction>, GasCostOrdering<PooledTransaction>>
+    Pool<EthTransactionValidator<Client, PooledTransaction>, MinerTipOrdering<PooledTransaction>>
 where
     Client: StateProviderFactory + Clone + 'static,
 {
     /// Returns a new [Pool] that uses the default [EthTransactionValidator] when validating
-    /// [PooledTransaction]s and ords via [GasCostOrdering]
+    /// [PooledTransaction]s and ords via [MinerTipOrdering]
     ///
     /// # Example
     ///
@@ -306,7 +306,7 @@ where
         validator: EthTransactionValidator<Client, PooledTransaction>,
         config: PoolConfig,
     ) -> Self {
-        Self::new(validator, GasCostOrdering::default(), config)
+        Self::new(validator, MinerTipOrdering::default(), config)
     }
 }
 
@@ -399,7 +399,7 @@ where
 
     fn best_transactions_with_base_fee(
         &self,
-        base_fee: u128,
+        base_fee: u64,
     ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<Self::Transaction>>>> {
         self.pool.best_transactions_with_base_fee(base_fee)
     }

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -83,7 +83,7 @@ pub async fn maintain_transaction_pool<Client, P, St, Tasks>(
         let info = BlockInfo {
             last_seen_block_hash: latest.hash,
             last_seen_block_number: latest.number,
-            pending_basefee: latest.next_block_base_fee().unwrap_or_default() as u128,
+            pending_basefee: latest.next_block_base_fee().unwrap_or_default(),
         };
         pool.set_block_info(info);
     }
@@ -205,8 +205,7 @@ pub async fn maintain_transaction_pool<Client, P, St, Tasks>(
                 }
 
                 // base fee for the next block: `new_tip+1`
-                let pending_block_base_fee =
-                    new_tip.next_block_base_fee().unwrap_or_default() as u128;
+                let pending_block_base_fee = new_tip.next_block_base_fee().unwrap_or_default();
 
                 // we know all changed account in the new chain
                 let new_changed_accounts: HashSet<_> =
@@ -282,7 +281,7 @@ pub async fn maintain_transaction_pool<Client, P, St, Tasks>(
                 let tip = blocks.tip();
 
                 // base fee for the next block: `tip+1`
-                let pending_block_base_fee = tip.next_block_base_fee().unwrap_or_default() as u128;
+                let pending_block_base_fee = tip.next_block_base_fee().unwrap_or_default();
 
                 let first_block = blocks.first();
                 trace!(

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -112,7 +112,7 @@ impl TransactionPool for NoopTransactionPool {
 
     fn best_transactions_with_base_fee(
         &self,
-        _: u128,
+        _: u64,
     ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<Self::Transaction>>>> {
         Box::new(std::iter::empty())
     }

--- a/crates/transaction-pool/src/ordering.rs
+++ b/crates/transaction-pool/src/ordering.rs
@@ -17,7 +17,7 @@ pub trait TransactionOrdering: Send + Sync + 'static {
     type Transaction: PoolTransaction;
 
     /// Returns the priority score for the given transaction.
-    fn priority(&self, transaction: &Self::Transaction, base_fee: Option<u64>) -> Self::Priority;
+    fn priority(&self, transaction: &Self::Transaction, base_fee: u64) -> Self::Priority;
 }
 
 /// Default ordering for the pool.
@@ -38,13 +38,8 @@ where
     /// Source: <https://github.com/ethereum/go-ethereum/blob/7f756dc1185d7f1eeeacb1d12341606b7135f9ea/core/txpool/legacypool/list.go#L469-L482>.
     ///
     /// NOTE: The implementation is incomplete for missing base fee.
-    fn priority(&self, transaction: &Self::Transaction, base_fee: Option<u64>) -> Self::Priority {
-        let priority = if let Some(base_fee) = base_fee {
-            transaction.effective_tip_per_gas(base_fee).expect("tx has been validated")
-        } else {
-            transaction.priority_fee_or_price()
-        };
-        U256::from(priority)
+    fn priority(&self, transaction: &Self::Transaction, base_fee: u64) -> Self::Priority {
+        U256::from(transaction.effective_tip_per_gas(base_fee).expect("tx has been validated"))
     }
 }
 

--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -18,7 +18,7 @@ use tracing::debug;
 /// This iterator guarantees that all transaction it returns satisfy the base fee.
 pub(crate) struct BestTransactionsWithBasefee<T: TransactionOrdering> {
     pub(crate) best: BestTransactions<T>,
-    pub(crate) base_fee: u128,
+    pub(crate) base_fee: u64,
 }
 
 impl<T: TransactionOrdering> crate::traits::BestTransactions for BestTransactionsWithBasefee<T> {
@@ -34,7 +34,7 @@ impl<T: TransactionOrdering> Iterator for BestTransactionsWithBasefee<T> {
         // find the next transaction that satisfies the base fee
         loop {
             let best = self.best.next()?;
-            if best.transaction.max_fee_per_gas() < self.base_fee {
+            if best.transaction.max_fee_per_gas() < self.base_fee as u128 {
                 // tx violates base fee, mark it as invalid and continue
                 crate::traits::BestTransactions::mark_invalid(self, &best);
             } else {
@@ -133,7 +133,7 @@ mod tests {
         for nonce in 0..num_tx {
             let tx = tx.clone().rng_hash().with_nonce(nonce);
             let valid_tx = f.validated(tx);
-            pool.add_transaction(Arc::new(valid_tx));
+            pool.add_transaction(Arc::new(valid_tx), 0);
         }
 
         let mut best = pool.best();
@@ -159,7 +159,7 @@ mod tests {
         for nonce in 0..num_tx {
             let tx = tx.clone().rng_hash().with_nonce(nonce);
             let valid_tx = f.validated(tx);
-            pool.add_transaction(Arc::new(valid_tx));
+            pool.add_transaction(Arc::new(valid_tx), 0);
         }
 
         let mut best = pool.best();

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -467,7 +467,7 @@ where
     /// the given base fee.
     pub(crate) fn best_transactions_with_base_fee(
         &self,
-        base_fee: u128,
+        base_fee: u64,
     ) -> Box<dyn crate::traits::BestTransactions<Item = Arc<ValidPoolTransaction<T::Transaction>>>>
     {
         self.pool.read().best_transactions_with_base_fee(base_fee)

--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -115,7 +115,7 @@ impl<T: PoolTransaction> ParkedPool<BasefeeOrd<T>> {
     /// Note: this does _not_ remove the transactions
     pub(crate) fn satisfy_base_fee_transactions(
         &self,
-        basefee: u128,
+        basefee: u64,
     ) -> Vec<Arc<ValidPoolTransaction<T>>> {
         let ids = self.satisfy_base_fee_ids(basefee);
         let mut txs = Vec::with_capacity(ids.len());
@@ -126,13 +126,13 @@ impl<T: PoolTransaction> ParkedPool<BasefeeOrd<T>> {
     }
 
     /// Returns all transactions that satisfy the given basefee.
-    fn satisfy_base_fee_ids(&self, basefee: u128) -> Vec<TransactionId> {
+    fn satisfy_base_fee_ids(&self, basefee: u64) -> Vec<TransactionId> {
         let mut transactions = Vec::new();
         {
             let mut iter = self.by_id.iter().peekable();
 
             while let Some((id, tx)) = iter.next() {
-                if tx.transaction.transaction.max_fee_per_gas() < basefee {
+                if tx.transaction.transaction.max_fee_per_gas() < basefee as u128 {
                     // still parked -> skip descendant transactions
                     'this: while let Some((peek, _)) = iter.peek() {
                         if peek.sender != id.sender {
@@ -152,7 +152,7 @@ impl<T: PoolTransaction> ParkedPool<BasefeeOrd<T>> {
     /// satisfy the given basefee.
     ///
     /// Note: the transactions are not returned in a particular order.
-    pub(crate) fn enforce_basefee(&mut self, basefee: u128) -> Vec<Arc<ValidPoolTransaction<T>>> {
+    pub(crate) fn enforce_basefee(&mut self, basefee: u64) -> Vec<Arc<ValidPoolTransaction<T>>> {
         let to_remove = self.satisfy_base_fee_ids(basefee);
 
         let mut removed = Vec::with_capacity(to_remove.len());
@@ -309,7 +309,7 @@ impl_ord_wrapper!(QueuedOrd);
 impl<T: PoolTransaction> Ord for QueuedOrd<T> {
     fn cmp(&self, other: &Self) -> Ordering {
         // Higher cost is better
-        self.gas_cost().cmp(&other.gas_cost()).then_with(||
+        self.priority_fee_or_price().cmp(&other.priority_fee_or_price()).then_with(||
             // Lower timestamp is better
             other.timestamp.cmp(&self.timestamp))
     }
@@ -330,10 +330,10 @@ mod tests {
         assert!(pool.by_id.contains_key(tx.id()));
         assert_eq!(pool.len(), 1);
 
-        let removed = pool.enforce_basefee(u128::MAX);
+        let removed = pool.enforce_basefee(u64::MAX);
         assert!(removed.is_empty());
 
-        let removed = pool.enforce_basefee(tx.max_fee_per_gas() - 1);
+        let removed = pool.enforce_basefee((tx.max_fee_per_gas() - 1) as u64);
         assert_eq!(removed.len(), 1);
         assert!(pool.is_empty());
     }
@@ -353,14 +353,14 @@ mod tests {
         assert!(pool.by_id.contains_key(descendant_tx.id()));
         assert_eq!(pool.len(), 2);
 
-        let removed = pool.enforce_basefee(u128::MAX);
+        let removed = pool.enforce_basefee(u64::MAX);
         assert!(removed.is_empty());
 
         // two dependent tx in the pool with decreasing fee
 
         {
             let mut pool2 = pool.clone();
-            let removed = pool2.enforce_basefee(descendant_tx.max_fee_per_gas());
+            let removed = pool2.enforce_basefee(descendant_tx.max_fee_per_gas() as u64);
             assert_eq!(removed.len(), 1);
             assert_eq!(pool2.len(), 1);
             // descendant got popped
@@ -369,7 +369,7 @@ mod tests {
         }
 
         // remove root transaction via root tx fee
-        let removed = pool.enforce_basefee(root_tx.max_fee_per_gas());
+        let removed = pool.enforce_basefee(root_tx.max_fee_per_gas() as u64);
         assert_eq!(removed.len(), 2);
         assert!(pool.is_empty());
     }

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -86,7 +86,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
     }
 
     /// Same as `best` but only returns transactions that satisfy the given basefee.
-    pub(crate) fn best_with_basefee(&self, base_fee: u128) -> BestTransactionsWithBasefee<T> {
+    pub(crate) fn best_with_basefee(&self, base_fee: u64) -> BestTransactionsWithBasefee<T> {
         BestTransactionsWithBasefee { best: self.best(), base_fee }
     }
 
@@ -103,13 +103,14 @@ impl<T: TransactionOrdering> PendingPool<T> {
     pub(crate) fn best_with_unlocked(
         &self,
         unlocked: Vec<Arc<ValidPoolTransaction<T::Transaction>>>,
+        base_fee: u64,
     ) -> BestTransactions<T> {
         let mut best = self.best();
         let mut submission_id = self.submission_id;
         for tx in unlocked {
             submission_id += 1;
             debug_assert!(!best.all.contains_key(tx.id()), "transaction already included");
-            let priority = self.ordering.priority(&tx.transaction);
+            let priority = self.ordering.priority(&tx.transaction, Some(base_fee));
             let tx_id = *tx.id();
             let transaction = PendingTransactionRef { submission_id, transaction: tx, priority };
             if best.ancestor(&tx_id).is_none() {
@@ -135,14 +136,14 @@ impl<T: TransactionOrdering> PendingPool<T> {
     /// Note: the transactions are not returned in a particular order.
     pub(crate) fn enforce_basefee(
         &mut self,
-        basefee: u128,
+        basefee: u64,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         let mut to_remove = Vec::new();
 
         {
             let mut iter = self.by_id.iter().peekable();
             while let Some((id, tx)) = iter.next() {
-                if tx.transaction.transaction.max_fee_per_gas() < basefee {
+                if tx.transaction.transaction.max_fee_per_gas() < basefee as u128 {
                     // this transaction no longer satisfies the basefee: remove it and all its
                     // descendants
                     to_remove.push(*id);
@@ -178,7 +179,11 @@ impl<T: TransactionOrdering> PendingPool<T> {
     /// # Panics
     ///
     /// if the transaction is already included
-    pub(crate) fn add_transaction(&mut self, tx: Arc<ValidPoolTransaction<T::Transaction>>) {
+    pub(crate) fn add_transaction(
+        &mut self,
+        tx: Arc<ValidPoolTransaction<T::Transaction>>,
+        base_fee: u64,
+    ) {
         assert!(
             !self.by_id.contains_key(tx.id()),
             "transaction already included {:?}",
@@ -188,7 +193,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
         let tx_id = *tx.id();
         let submission_id = self.next_id();
 
-        let priority = self.ordering.priority(&tx.transaction);
+        let priority = self.ordering.priority(&tx.transaction, Some(base_fee));
 
         // keep track of size
         self.size_of += tx.size();
@@ -338,7 +343,7 @@ mod tests {
         let mut f = MockTransactionFactory::default();
         let mut pool = PendingPool::new(MockOrdering::default());
         let tx = f.validated_arc(MockTransaction::eip1559().inc_price());
-        pool.add_transaction(tx.clone());
+        pool.add_transaction(tx.clone(), 0);
 
         assert!(pool.by_id.contains_key(tx.id()));
         assert_eq!(pool.len(), 1);
@@ -346,7 +351,7 @@ mod tests {
         let removed = pool.enforce_basefee(0);
         assert!(removed.is_empty());
 
-        let removed = pool.enforce_basefee(tx.max_fee_per_gas() + 1);
+        let removed = pool.enforce_basefee((tx.max_fee_per_gas() + 1) as u64);
         assert_eq!(removed.len(), 1);
         assert!(pool.is_empty());
     }
@@ -357,10 +362,10 @@ mod tests {
         let mut pool = PendingPool::new(MockOrdering::default());
         let t = MockTransaction::eip1559().inc_price_by(10);
         let root_tx = f.validated_arc(t.clone());
-        pool.add_transaction(root_tx.clone());
+        pool.add_transaction(root_tx.clone(), 0);
 
         let descendant_tx = f.validated_arc(t.inc_nonce().decr_price());
-        pool.add_transaction(descendant_tx.clone());
+        pool.add_transaction(descendant_tx.clone(), 0);
 
         assert!(pool.by_id.contains_key(root_tx.id()));
         assert!(pool.by_id.contains_key(descendant_tx.id()));
@@ -375,7 +380,7 @@ mod tests {
 
         {
             let mut pool2 = pool.clone();
-            let removed = pool2.enforce_basefee(descendant_tx.max_fee_per_gas() + 1);
+            let removed = pool2.enforce_basefee((descendant_tx.max_fee_per_gas() + 1) as u64);
             assert_eq!(removed.len(), 1);
             assert_eq!(pool2.len(), 1);
             // descendant got popped
@@ -384,7 +389,7 @@ mod tests {
         }
 
         // remove root transaction via fee
-        let removed = pool.enforce_basefee(root_tx.max_fee_per_gas() + 1);
+        let removed = pool.enforce_basefee((root_tx.max_fee_per_gas() + 1) as u64);
         assert_eq!(removed.len(), 2);
         assert!(pool.is_empty());
     }

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -110,7 +110,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
         for tx in unlocked {
             submission_id += 1;
             debug_assert!(!best.all.contains_key(tx.id()), "transaction already included");
-            let priority = self.ordering.priority(&tx.transaction, Some(base_fee));
+            let priority = self.ordering.priority(&tx.transaction, base_fee);
             let tx_id = *tx.id();
             let transaction = PendingTransactionRef { submission_id, transaction: tx, priority };
             if best.ancestor(&tx_id).is_none() {
@@ -193,7 +193,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
         let tx_id = *tx.id();
         let submission_id = self.next_id();
 
-        let priority = self.ordering.priority(&tx.transaction, Some(base_fee));
+        let priority = self.ordering.priority(&tx.transaction, base_fee);
 
         // keep track of size
         self.size_of += tx.size();

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -142,7 +142,7 @@ impl<T: TransactionOrdering> TxPool<T> {
     ///
     /// Depending on the change in direction of the basefee, this will promote or demote
     /// transactions from the basefee pool.
-    fn update_basefee(&mut self, pending_basefee: u128) {
+    fn update_basefee(&mut self, pending_basefee: u64) {
         match pending_basefee.cmp(&self.all_transactions.pending_basefee) {
             Ordering::Equal => {
                 // fee unchanged, nothing to update
@@ -195,7 +195,7 @@ impl<T: TransactionOrdering> TxPool<T> {
     /// the given base fee.
     pub(crate) fn best_transactions_with_base_fee(
         &self,
-        basefee: u128,
+        basefee: u64,
     ) -> Box<dyn crate::traits::BestTransactions<Item = Arc<ValidPoolTransaction<T::Transaction>>>>
     {
         match basefee.cmp(&self.all_transactions.pending_basefee) {
@@ -211,7 +211,7 @@ impl<T: TransactionOrdering> TxPool<T> {
                 // base fee decreased, we need to move transactions from the basefee pool to the
                 // pending pool
                 let unlocked = self.basefee_pool.satisfy_base_fee_transactions(basefee);
-                Box::new(self.pending_pool.best_with_unlocked(unlocked))
+                Box::new(self.pending_pool.best_with_unlocked(unlocked, basefee))
             }
         }
     }
@@ -545,7 +545,7 @@ impl<T: TransactionOrdering> TxPool<T> {
                 self.queued_pool.add_transaction(tx);
             }
             SubPool::Pending => {
-                self.pending_pool.add_transaction(tx);
+                self.pending_pool.add_transaction(tx, self.all_transactions.pending_basefee);
             }
             SubPool::BaseFee => {
                 self.basefee_pool.add_transaction(tx);
@@ -649,7 +649,7 @@ pub(crate) struct AllTransactions<T: PoolTransaction> {
     /// Minimum base fee required by the protocol.
     ///
     /// Transactions with a lower base fee will never be included by the chain
-    minimal_protocol_basefee: u128,
+    minimal_protocol_basefee: u64,
     /// The max gas limit of the block
     block_gas_limit: u64,
     /// Max number of executable transaction slots guaranteed per account
@@ -665,7 +665,7 @@ pub(crate) struct AllTransactions<T: PoolTransaction> {
     /// The current block hash the pool keeps track of.
     last_seen_block_hash: H256,
     /// Expected base fee for the pending block.
-    pending_basefee: u128,
+    pending_basefee: u64,
 }
 
 impl<T: PoolTransaction> AllTransactions<T> {
@@ -812,7 +812,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
             tx.state.insert(TxState::NO_PARKED_ANCESTORS);
 
             // Update the first transaction of this sender.
-            Self::update_tx_base_fee(&self.pending_basefee, tx);
+            Self::update_tx_base_fee(self.pending_basefee, tx);
             // Track if the transaction's sub-pool changed.
             Self::record_subpool_update(&mut updates, tx);
 
@@ -858,7 +858,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
                 has_parked_ancestor = !tx.state.is_pending();
 
                 // Update and record sub-pool changes.
-                Self::update_tx_base_fee(&self.pending_basefee, tx);
+                Self::update_tx_base_fee(self.pending_basefee, tx);
                 Self::record_subpool_update(&mut updates, tx);
 
                 // Advance iterator
@@ -887,9 +887,9 @@ impl<T: PoolTransaction> AllTransactions<T> {
     }
 
     /// Rechecks the transaction's dynamic fee condition.
-    fn update_tx_base_fee(pending_block_base_fee: &u128, tx: &mut PoolInternalTransaction<T>) {
+    fn update_tx_base_fee(pending_block_base_fee: u64, tx: &mut PoolInternalTransaction<T>) {
         // Recheck dynamic fee condition.
-        match tx.transaction.max_fee_per_gas().cmp(pending_block_base_fee) {
+        match tx.transaction.max_fee_per_gas().cmp(&(pending_block_base_fee as u128)) {
             Ordering::Greater | Ordering::Equal => {
                 tx.state.insert(TxState::ENOUGH_FEE_CAP_BLOCK);
             }
@@ -1070,10 +1070,10 @@ impl<T: PoolTransaction> AllTransactions<T> {
         // Check dynamic fee
         let fee_cap = transaction.max_fee_per_gas();
 
-        if fee_cap < self.minimal_protocol_basefee {
+        if fee_cap < self.minimal_protocol_basefee as u128 {
             return Err(InsertErr::FeeCapBelowMinimumProtocolFeeCap { transaction, fee_cap })
         }
-        if fee_cap >= self.pending_basefee {
+        if fee_cap >= self.pending_basefee as u128 {
             state.insert(TxState::ENOUGH_FEE_CAP_BLOCK);
         }
 
@@ -1570,7 +1570,7 @@ mod tests {
 
         let first_in_pool = pool.get(first.id()).unwrap();
 
-        assert!(tx.get_gas_price() < pool.pending_basefee);
+        assert!(tx.get_gas_price() < pool.pending_basefee as u128);
         // has nonce gap
         assert!(!first_in_pool.state.contains(TxState::NO_NONCE_GAPS));
 
@@ -1671,7 +1671,7 @@ mod tests {
 
         assert_eq!(pool.pending_pool.len(), 1);
 
-        pool.update_basefee(tx.max_fee_per_gas() + 1);
+        pool.update_basefee((tx.max_fee_per_gas() + 1) as u64);
 
         assert!(pool.pending_pool.is_empty());
         assert_eq!(pool.basefee_pool.len(), 1);

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -570,5 +570,5 @@ fn test_mock_priority() {
     let o = MockOrdering;
     let lo = MockTransaction::eip1559().with_gas_limit(100_000);
     let hi = lo.next().inc_price();
-    assert!(o.priority(&hi, None) > o.priority(&lo, None));
+    assert!(o.priority(&hi, 0) > o.priority(&lo, 0));
 }

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -527,13 +527,8 @@ impl TransactionOrdering for MockOrdering {
     type Priority = U256;
     type Transaction = MockTransaction;
 
-    fn priority(&self, transaction: &Self::Transaction, base_fee: Option<u64>) -> Self::Priority {
-        let priority = if let Some(base_fee) = base_fee {
-            transaction.effective_tip_per_gas(base_fee).expect("tx has been validated")
-        } else {
-            transaction.priority_fee_or_price()
-        };
-        U256::from(priority)
+    fn priority(&self, transaction: &Self::Transaction, base_fee: u64) -> Self::Priority {
+        U256::from(transaction.effective_tip_per_gas(base_fee).expect("tx has been validated"))
     }
 }
 

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -181,7 +181,7 @@ pub trait TransactionPool: Send + Sync + Clone {
     /// Consumer: Block production
     fn best_transactions_with_base_fee(
         &self,
-        base_fee: u128,
+        base_fee: u64,
     ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<Self::Transaction>>>>;
 
     /// Returns all transactions that can be included in the next block.
@@ -397,7 +397,7 @@ pub struct CanonicalStateUpdate {
     /// EIP-1559 Base fee of the _next_ (pending) block
     ///
     /// The base fee of a block depends on the utilization of the last block and its base fee.
-    pub pending_block_base_fee: u128,
+    pub pending_block_base_fee: u64,
     /// A set of changed accounts across a range of blocks.
     pub changed_accounts: Vec<ChangedAccount>,
     /// All mined transactions in the block range.
@@ -470,12 +470,6 @@ pub trait PoolTransaction:
     /// For legacy transactions: `gas_price * gas_limit + tx_value`.
     fn cost(&self) -> U256;
 
-    /// Returns the gas cost for this transaction.
-    ///
-    /// For EIP-1559 transactions: `max_fee_per_gas * gas_limit`.
-    /// For legacy transactions: `gas_price * gas_limit`.
-    fn gas_cost(&self) -> U256;
-
     /// Amount of gas that should be used in executing this transaction. This is paid up-front.
     fn gas_limit(&self) -> u64;
 
@@ -490,6 +484,16 @@ pub trait PoolTransaction:
     ///
     /// This will return `None` for non-EIP1559 transactions
     fn max_priority_fee_per_gas(&self) -> Option<u128>;
+
+    /// Returns the effective tip for this transaction.
+    ///
+    /// For EIP-1559 transactions: `min(max_fee_per_gas - base_fee, max_priority_fee_per_gas)`.
+    /// For legacy transactions: `gas_price - base_fee`.
+    fn effective_tip_per_gas(&self, base_fee: u64) -> Option<u128>;
+
+    /// Returns the max priority fee per gas if the transaction is an EIP-1559 transaction, and
+    /// otherwise returns the gas price.
+    fn priority_fee_or_price(&self) -> u128;
 
     /// Returns the transaction's [`TransactionKind`], which is the address of the recipient or
     /// [`TransactionKind::Create`] if the transaction is a contract creation.
@@ -525,10 +529,6 @@ pub struct PooledTransaction {
     /// For EIP-1559 transactions: `max_fee_per_gas * gas_limit + tx_value`.
     /// For legacy transactions: `gas_price * gas_limit + tx_value`.
     pub(crate) cost: U256,
-
-    /// For EIP-1559 transactions: `max_fee_per_gas * gas_limit`.
-    /// For legacy transactions: `gas_price * gas_limit`.
-    pub(crate) gas_cost: U256,
 }
 
 impl PooledTransaction {
@@ -562,12 +562,18 @@ impl PoolTransaction for PooledTransaction {
         self.cost
     }
 
-    /// Returns the gas cost for this transaction.
+    /// Returns the effective tip for this transaction.
     ///
-    /// For EIP-1559 transactions: `max_fee_per_gas * gas_limit + tx_value`.
-    /// For legacy transactions: `gas_price * gas_limit + tx_value`.
-    fn gas_cost(&self) -> U256 {
-        self.gas_cost
+    /// For EIP-1559 transactions: `min(max_fee_per_gas - base_fee, max_priority_fee_per_gas)`.
+    /// For legacy transactions: `gas_price - base_fee`.
+    fn effective_tip_per_gas(&self, base_fee: u64) -> Option<u128> {
+        self.transaction.effective_tip_per_gas(base_fee)
+    }
+
+    /// Returns the max priority fee per gas if the transaction is an EIP-1559 transaction, and
+    /// otherwise returns the gas price.
+    fn priority_fee_or_price(&self) -> u128 {
+        self.transaction.priority_fee_or_price()
     }
 
     /// Amount of gas that should be used in executing this transaction. This is paid up-front.
@@ -635,7 +641,7 @@ impl FromRecoveredTransaction for PooledTransaction {
         };
         let cost = gas_cost + U256::from(tx.value());
 
-        PooledTransaction { transaction: tx, cost, gas_cost }
+        PooledTransaction { transaction: tx, cost }
     }
 }
 
@@ -677,7 +683,7 @@ pub struct BlockInfo {
     ///
     /// Note: this is the derived base fee of the _next_ block that builds on the clock the pool is
     /// currently tracking.
-    pub pending_basefee: u128,
+    pub pending_basefee: u64,
 }
 
 /// A Stream that yields full transactions the subpool

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -164,12 +164,18 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
         self.transaction.cost()
     }
 
-    /// Returns the gas cost for this transaction.
+    /// Returns the effective tip for this transaction.
     ///
-    /// For EIP-1559 transactions: `max_fee_per_gas * gas_limit`.
-    /// For legacy transactions: `gas_price * gas_limit`.
-    pub fn gas_cost(&self) -> U256 {
-        self.transaction.gas_cost()
+    /// For EIP-1559 transactions: `min(max_fee_per_gas - base_fee, max_priority_fee_per_gas)`.
+    /// For legacy transactions: `gas_price - base_fee`.
+    pub fn effective_tip_per_gas(&self, base_fee: u64) -> Option<u128> {
+        self.transaction.effective_tip_per_gas(base_fee)
+    }
+
+    /// Returns the max priority fee per gas if the transaction is an EIP-1559 transaction, and
+    /// otherwise returns the gas price.
+    pub fn priority_fee_or_price(&self) -> u128 {
+        self.transaction.priority_fee_or_price()
     }
 
     /// Returns the EIP-1559 Max base fee the caller is willing to pay.

--- a/examples/network-txpool.rs
+++ b/examples/network-txpool.rs
@@ -10,7 +10,7 @@
 use reth_network::{config::rng_secret_key, NetworkConfig, NetworkManager};
 use reth_provider::test_utils::NoopProvider;
 use reth_transaction_pool::{
-    GasCostOrdering, PoolTransaction, PooledTransaction, TransactionOrigin, TransactionPool,
+    MinerTipOrdering, PoolTransaction, PooledTransaction, TransactionOrigin, TransactionPool,
     TransactionValidationOutcome, TransactionValidator,
 };
 
@@ -24,7 +24,7 @@ async fn main() -> eyre::Result<()> {
 
     let pool = reth_transaction_pool::Pool::new(
         OkValidator::default(),
-        GasCostOrdering::default(),
+        MinerTipOrdering::default(),
         Default::default(),
     );
 


### PR DESCRIPTION
## Description

Fix transaction pool ordering round 2.

For reference see [geth's implementation](https://github.com/ethereum/go-ethereum/blob/7f756dc1185d7f1eeeacb1d12341606b7135f9ea/core/txpool/legacypool/list.go#L469-L482).

Additionally, base fee types used in mempool were demoted to `u64`, because that's how it is represented in a header.