### PR TITLE
fix: do not perform future timestamp checks post-merge

### DIFF
--- a/crates/consensus/beacon/src/beacon_consensus.rs
+++ b/crates/consensus/beacon/src/beacon_consensus.rs
@@ -2,10 +2,10 @@
 use reth_consensus_common::validation;
 use reth_interfaces::consensus::{Consensus, ConsensusError};
 use reth_primitives::{
-    constants::MAXIMUM_EXTRA_DATA_SIZE, Chain, ChainSpec, Hardfork, Header, SealedBlock,
-    SealedHeader, EMPTY_OMMER_ROOT, U256,
+    constants::{ALLOWED_FUTURE_BLOCK_TIME_SECONDS, MAXIMUM_EXTRA_DATA_SIZE},
+    Chain, ChainSpec, Hardfork, Header, SealedBlock, SealedHeader, EMPTY_OMMER_ROOT, U256,
 };
-use std::sync::Arc;
+use std::{sync::Arc, time::SystemTime};
 
 /// Ethereum beacon consensus
 ///
@@ -59,6 +59,14 @@ impl Consensus for BeaconConsensus {
                 return Err(ConsensusError::TheMergeOmmerRootIsNotEmpty)
             }
 
+            // Post-merge, the consensus layer is expected to perform checks such that the block
+            // timestamp is a function of the slot. This is different from pre-merge, where blocks
+            // are only allowed to be in the future (compared to the system's block) by a certain
+            // threshold.
+            //
+            // Block validation with respect to the parent should ensure that the block timestamp
+            // is greater than its parent timestamp.
+
             // validate header extradata for all networks post merge
             validate_header_extradata(header)?;
 
@@ -68,6 +76,18 @@ impl Consensus for BeaconConsensus {
             // TODO Consensus checks for old blocks:
             //  * difficulty, mix_hash & nonce aka PoW stuff
             // low priority as syncing is done in reverse order
+
+            // Check if timestamp is in future. Clock can drift but this can be consensus issue.
+            let present_timestamp =
+                SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs() +
+                    ALLOWED_FUTURE_BLOCK_TIME_SECONDS;
+
+            if header.timestamp > present_timestamp {
+                return Err(ConsensusError::TimestampIsInFuture {
+                    timestamp: header.timestamp,
+                    present_timestamp,
+                })
+            }
 
             // Goerli exception:
             //  * If the network is goerli pre-merge, ignore the extradata check, since we do not

--- a/crates/consensus/beacon/src/beacon_consensus.rs
+++ b/crates/consensus/beacon/src/beacon_consensus.rs
@@ -79,10 +79,9 @@ impl Consensus for BeaconConsensus {
 
             // Check if timestamp is in future. Clock can drift but this can be consensus issue.
             let present_timestamp =
-                SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs() +
-                    ALLOWED_FUTURE_BLOCK_TIME_SECONDS;
+                SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs();
 
-            if header.timestamp > present_timestamp {
+            if header.timestamp > present_timestamp + ALLOWED_FUTURE_BLOCK_TIME_SECONDS {
                 return Err(ConsensusError::TimestampIsInFuture {
                     timestamp: header.timestamp,
                     present_timestamp,

--- a/crates/consensus/beacon/src/beacon_consensus.rs
+++ b/crates/consensus/beacon/src/beacon_consensus.rs
@@ -61,7 +61,7 @@ impl Consensus for BeaconConsensus {
 
             // Post-merge, the consensus layer is expected to perform checks such that the block
             // timestamp is a function of the slot. This is different from pre-merge, where blocks
-            // are only allowed to be in the future (compared to the system's block) by a certain
+            // are only allowed to be in the future (compared to the system's clock) by a certain
             // threshold.
             //
             // Block validation with respect to the parent should ensure that the block timestamp

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -23,16 +23,6 @@ pub fn validate_header_standalone(
         })
     }
 
-    // Check if timestamp is in future. Clock can drift but this can be consensus issue.
-    let present_timestamp =
-        SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs();
-    if header.timestamp > present_timestamp {
-        return Err(ConsensusError::TimestampIsInFuture {
-            timestamp: header.timestamp,
-            present_timestamp,
-        })
-    }
-
     // Check if base fee is set.
     if chain_spec.fork(Hardfork::London).active_at_block(header.number) &&
         header.base_fee_per_gas.is_none()

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -5,10 +5,7 @@ use reth_primitives::{
     SealedHeader, Transaction, TransactionSignedEcRecovered, TxEip1559, TxEip2930, TxLegacy,
 };
 use reth_provider::{AccountReader, HeaderProvider, WithdrawalsProvider};
-use std::{
-    collections::{hash_map::Entry, HashMap},
-    time::SystemTime,
-};
+use std::collections::{hash_map::Entry, HashMap};
 
 /// Validate header standalone
 pub fn validate_header_standalone(

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -108,6 +108,15 @@ pub const EMPTY_WITHDRAWALS: H256 = EMPTY_SET_HASH;
 /// the database.
 pub const BEACON_CONSENSUS_REORG_UNWIND_DEPTH: u64 = 3;
 
+/// Max seconds from current time allowed for blocks, before they're considered future blocks.
+///
+/// This is only used when checking whether or not the timestamp for pre-merge blocks is in the
+/// future.
+///
+/// See:
+/// <https://github.com/ethereum/go-ethereum/blob/a196f3e8a22b6ad22ced5c2e3baf32bc3ebd4ec9/consensus/ethash/consensus.go#L227-L229>
+pub const ALLOWED_FUTURE_BLOCK_TIME_SECONDS: u64 = 15;
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Previously we were performing checks on whether or not the block's timestamp is in the future. Other clients do not perform this check post-merge:
https://github.com/ethereum/go-ethereum/blob/a196f3e8a22b6ad22ced5c2e3baf32bc3ebd4ec9/consensus/beacon/consensus.go#L217-L227

And timestamp checks are supposed to be performed by the CL:

> It is absolutely verified on CL
> 
> Its just that we are attempting to not duplicate consensus logic across layers. You can easily add sanity checks to time in EL but CL preverifies. Timestamp must be accurate wrt to the outer slot in the beacon block and future slots are not processed (may be queued but would be dropped if more than a few seconds ahead)
> 
> So
> * slots are mega respected in CL
> * CL verifies that payload timestamp is a precise function of the slot


From https://github.com/ethereum/go-ethereum/pull/23761#discussion_r739190029

Fixes #3879