### PR TITLE
chore(ci): build tests in release and filter features

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Run tests
         run: |
           cargo llvm-cov nextest --lcov --output-path lcov.info \
-            --locked --workspace --all-features \
+            --release --locked --all-features --workspace --exclude examples --exclude ef-tests \
             --partition hash:${{ matrix.partition }}/${{ strategy.job-total }} \
             -E 'kind(test)'
 

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Run tests
         run: |
           cargo llvm-cov nextest --lcov --output-path lcov.info \
-            --locked --workspace --all-features \
+            --release --locked --all-features --workspace --exclude examples --exclude ef-tests  \
             --partition hash:${{ matrix.partition }}/${{ strategy.job-total }} \
             -E 'kind(lib)' -E 'kind(bin)' -E 'kind(proc-macro)'
 


### PR DESCRIPTION
For both unit and integration tests:
1. Build with release profile (to be reverted when we move to a better runner)
2. Filter `ef-tests` and `examples` if they are not needed