### PR TITLE
feat(rpc): ots_hasCode implementation

### DIFF
--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -193,9 +193,7 @@ where
     let nonce = 1;
     let block_hash = H256::default();
 
-    assert!(is_unimplemented(
-        OtterscanClient::has_code(client, address, None).await.err().unwrap()
-    ));
+    OtterscanClient::has_code(client, address, None).await.unwrap();
 
     OtterscanClient::get_api_level(client).await.unwrap();
 

--- a/crates/rpc/rpc/src/otterscan.rs
+++ b/crates/rpc/rpc/src/otterscan.rs
@@ -31,7 +31,7 @@ where
 {
     /// Handler for `ots_hasCode`
     async fn has_code(&self, address: Address, block_number: Option<BlockId>) -> RpcResult<bool> {
-        self.eth.get_code(address, block_number).await.map(|code| code.len() > 0)
+        self.eth.get_code(address, block_number).await.map(|code| !code.is_empty())
     }
 
     /// Handler for `ots_getApiLevel`

--- a/crates/rpc/rpc/src/otterscan.rs
+++ b/crates/rpc/rpc/src/otterscan.rs
@@ -31,7 +31,7 @@ where
 {
     /// Handler for `ots_hasCode`
     async fn has_code(&self, address: Address, block_number: Option<BlockId>) -> RpcResult<bool> {
-        Err(internal_rpc_err("unimplemented"))
+        self.eth.get_code(address, block_number).await.map(|code| code.len() > 0)
     }
 
     /// Handler for `ots_getApiLevel`


### PR DESCRIPTION
These changes tackle #3726 

* Add implementation of `ots_hasCode` to `ots` namespace
* Add http tests for `ots_hasCode`