### PR TITLE
ci: run bench on large runner

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -15,7 +15,8 @@ concurrency:
 name: bench
 jobs:
   iai:
-    runs-on: ubuntu-20.04
+    runs-on:
+      group: Reth
     # Only run benchmarks in merge groups
     if: github.event_name != 'pull_request'
     steps:
@@ -62,7 +63,8 @@ jobs:
   # Checks that benchmarks not run in CI compile
   bench-check:
     name: check
-    runs-on: ubuntu-20.04
+    runs-on:
+      group: Reth
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -71,8 +71,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Check if benchmarks build
-        run: cargo bench --all --all-features --all-targets --no-run
-
+        run: cargo check --workspace --benches --all-features
 
   bench-success:
     if: always()


### PR DESCRIPTION
Our longest running job is bench check because I did not move it over to the large runner in #3888 