### PR TITLE
ci: reduce partitions

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,7 +22,7 @@ jobs:
       group: Reth
     strategy:
       matrix:
-        partition: [1, 2, 3]
+        partition: [1, 2]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -21,7 +21,7 @@ jobs:
       group: Reth
     strategy:
       matrix:
-        partition: [1, 2, 3, 4, 5]
+        partition: [1, 2]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3


### PR DESCRIPTION
Since we run on large runners now, most of the time during testing is spent on compiling, which is done in each partition. In other words, we don't really save much time anymore on a higher number of partitions vs a lower number.

This PR reduces the number of partitions, which we previously increased