### PR TITLE
feat(pruner): transaction lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5588,6 +5588,7 @@ version = "0.1.0-alpha.4"
 dependencies = [
  "assert_matches",
  "itertools 0.10.5",
+ "rayon",
  "reth-db",
  "reth-interfaces",
  "reth-primitives",

--- a/crates/prune/Cargo.toml
+++ b/crates/prune/Cargo.toml
@@ -21,6 +21,7 @@ reth-interfaces = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
 itertools = "0.10"
+rayon = "1.6.0"
 
 [dev-dependencies]
 # reth

--- a/crates/prune/src/error.rs
+++ b/crates/prune/src/error.rs
@@ -4,6 +4,9 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum PrunerError {
+    #[error("Inconsistent data")]
+    InconsistentData,
+
     #[error("An interface error occurred.")]
     Interface(#[from] reth_interfaces::Error),
 

--- a/crates/prune/src/error.rs
+++ b/crates/prune/src/error.rs
@@ -4,8 +4,8 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum PrunerError {
-    #[error("Inconsistent data")]
-    InconsistentData,
+    #[error("Inconsistent data: {0}")]
+    InconsistentData(&'static str),
 
     #[error("An interface error occurred.")]
     Interface(#[from] reth_interfaces::Error),

--- a/crates/prune/src/pruner.rs
+++ b/crates/prune/src/pruner.rs
@@ -299,6 +299,14 @@ mod tests {
         let blocks = random_block_range(&mut rng, 0..=100, H256::zero(), 0..10);
         tx.insert_blocks(blocks.iter(), None).expect("insert blocks");
 
+        let mut tx_hash_numbers = Vec::new();
+        for block in &blocks {
+            for transaction in &block.body {
+                tx_hash_numbers.push((transaction.hash, tx_hash_numbers.len() as u64));
+            }
+        }
+        tx.insert_tx_hash_numbers(tx_hash_numbers).expect("insert tx hash numbers");
+
         assert_eq!(
             tx.table::<tables::Transactions>().unwrap().len(),
             blocks.iter().map(|block| block.body.len()).sum::<usize>()

--- a/crates/prune/src/pruner.rs
+++ b/crates/prune/src/pruner.rs
@@ -171,14 +171,14 @@ impl<DB: Database> Pruner<DB> {
             // Number of transactions retrieved from the database should match the tx range count
             let tx_count = tx_range.clone().count();
             if hashes.len() != tx_count {
-                return Err(PrunerError::InconsistentData)
+                return Err(PrunerError::InconsistentData(
+                    "Unexpected number of transaction hashes retrieved by transaction number range",
+                ))
             }
 
             // Pre-sort hashes to prune them in order
             hashes.sort();
 
-            // Prune transaction lookup table checking if `TxNumber` is in the tx range. The check
-            // is needed, because `TxHashNumber` table is sorted by hashes, and not
             provider.prune_table_in_batches::<tables::TxHashNumber, _>(
                 hashes,
                 self.batch_sizes.transaction_lookup,

--- a/crates/prune/src/pruner.rs
+++ b/crates/prune/src/pruner.rs
@@ -78,7 +78,7 @@ impl<DB: Database> Pruner<DB> {
         }
 
         if let Some((to_block, prune_mode)) =
-            self.modes.prune_to_block_transaction_lookup(tip_block_number)
+            self.modes.prune_target_block_transaction_lookup(tip_block_number)
         {
             self.prune_transaction_lookup(&provider, to_block, prune_mode)?;
         }

--- a/crates/prune/src/pruner.rs
+++ b/crates/prune/src/pruner.rs
@@ -201,6 +201,8 @@ impl<DB: Database> Pruner<DB> {
         let last_tx_num = *range.end();
 
         for i in range.step_by(self.batch_sizes.transaction_lookup) {
+            // The `min` ensures that the transaction range doesn't exceed the last transaction
+            // number. `last_tx_num + 1` is used to include the last transaction in the range.
             let tx_range = i..(i + self.batch_sizes.transaction_lookup as u64).min(last_tx_num + 1);
 
             // Retrieve transactions in the range and calculate their hashes in parallel

--- a/crates/prune/src/pruner.rs
+++ b/crates/prune/src/pruner.rs
@@ -228,7 +228,7 @@ impl<DB: Database> Pruner<DB> {
                     trace!(
                         target: "pruner",
                         %entries,
-                        "Pruned receipts"
+                        "Pruned transaction lookup"
                     );
                 },
             )?;

--- a/crates/prune/src/pruner.rs
+++ b/crates/prune/src/pruner.rs
@@ -198,7 +198,7 @@ impl<DB: Database> Pruner<DB> {
                 return Ok(())
             }
         };
-        let last_tx_num = range.end().clone();
+        let last_tx_num = *range.end();
 
         for i in range.step_by(self.batch_sizes.transaction_lookup) {
             let tx_range = i..(i + self.batch_sizes.transaction_lookup as u64).min(last_tx_num + 1);

--- a/crates/stages/src/test_utils/test_db.rs
+++ b/crates/stages/src/test_utils/test_db.rs
@@ -11,7 +11,7 @@ use reth_db::{
 };
 use reth_primitives::{
     keccak256, Account, Address, BlockNumber, Receipt, SealedBlock, SealedHeader, StorageEntry,
-    TxNumber, H256, MAINNET, U256,
+    TxHash, TxNumber, H256, MAINNET, U256,
 };
 use reth_provider::{DatabaseProviderRO, DatabaseProviderRW, ProviderFactory};
 use std::{
@@ -261,10 +261,21 @@ impl TestTransaction {
 
                 block.body.iter().try_for_each(|body_tx| {
                     tx.put::<tables::Transactions>(next_tx_num, body_tx.clone().into())?;
-                    tx.put::<tables::TxHashNumber>(body_tx.hash, next_tx_num)?;
                     next_tx_num += 1;
                     Ok(())
                 })
+            })
+        })
+    }
+
+    pub fn insert_tx_hash_numbers<I>(&self, tx_hash_numbers: I) -> Result<(), DbError>
+    where
+        I: IntoIterator<Item = (TxHash, TxNumber)>,
+    {
+        self.commit(|tx| {
+            tx_hash_numbers.into_iter().try_for_each(|(tx_hash, tx_num)| {
+                // Insert into tx hash numbers table.
+                tx.put::<tables::TxHashNumber>(tx_hash, tx_num)
             })
         })
     }

--- a/crates/stages/src/test_utils/test_db.rs
+++ b/crates/stages/src/test_utils/test_db.rs
@@ -261,6 +261,7 @@ impl TestTransaction {
 
                 block.body.iter().try_for_each(|body_tx| {
                     tx.put::<tables::Transactions>(next_tx_num, body_tx.clone().into())?;
+                    tx.put::<tables::TxHashNumber>(body_tx.hash, next_tx_num)?;
                     next_tx_num += 1;
                     Ok(())
                 })


### PR DESCRIPTION
Resolves https://github.com/paradigmxyz/reth/issues/3696

This PR adds pruning of transaction lookup entries from the `TxHashNumber` table. It works in the following way:
1. Calculate starting and ending transaction number according to the previously saved checkpoint (if any) and the block, to which the pruning needs to be done.
2. Because `TxHashNumber` has hashes as keys (hence, ordered by hashes), we need to retrieve the hashes for transaction numbers first. We do that in batches of 10k. So, for each 10k batch of transaction numbers, resolve their hashes in parallel.
3. Pre-sort hashes to make the deletion from the table sequential without backward jumps.
4. Prune table, passing the sorted list of hashes.
5. Repeat for each batch of 10k transaction numbers.

10k transactions take around 2MB in the memory, so we can increase batch size to decrease the number of random jumps needed during the deletion. But we also need to benchmark that.