### PR TITLE
feat(docs): add primer on all transaction types

### DIFF
--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -11,6 +11,7 @@
    1. [Mainnet or official testnets](./run/mainnet.md)
    1. [Metrics](./run/observability.md)
    1. [Configuring Reth](./run/config.md)
+   1. [Transaction types](./transactions.md)
    1. [Troubleshooting](./run/troubleshooting.md)
 1. [Interacting with Reth over JSON-RPC](./jsonrpc/intro.md)
    1. [eth](./jsonrpc/eth.md)

--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -11,7 +11,7 @@
    1. [Mainnet or official testnets](./run/mainnet.md)
    1. [Metrics](./run/observability.md)
    1. [Configuring Reth](./run/config.md)
-   1. [Transaction types](./transactions.md)
+   1. [Transaction types](./run/transactions.md)
    1. [Troubleshooting](./run/troubleshooting.md)
 1. [Interacting with Reth over JSON-RPC](./jsonrpc/intro.md)
    1. [eth](./jsonrpc/eth.md)

--- a/book/run/run-a-node.md
+++ b/book/run/run-a-node.md
@@ -6,6 +6,7 @@ In this chapter we'll go through a few different topics you'll encounter when ru
 1. [Running on mainnet or official testnets](./mainnet.md)
 1. [Logs and Observability](./observability.md)
 1. [Configuring reth.toml](./config.md)
+1. [Transaction types](./transactions.md)
 1. [Troubleshooting](./troubleshooting.md)
 
 In the future, we also intend to support the [OP Stack](https://stack.optimism.io/docs/understand/explainer/), which will allow you to run Reth as a Layer 2 client. More there soon!

--- a/book/run/transactions.md
+++ b/book/run/transactions.md
@@ -25,11 +25,11 @@ These transactions do not utilize access lists, which specify the addresses and 
 
 ## EIP-2930 Transactions
 
-Introduced in EIP-2930, transactions with type `0x1` incorporate an `accessList` parameter alongside legacy parameters. This `accessList` specifies an array of addresses and storage keys that the transaction plans to access, enabling gas savings on cross-contract calls by pre-declaring the accessed contract and storage slots. They do not include EIP-1559 fee market changes.
+Introduced in [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930), transactions with type `0x1` incorporate an `accessList` parameter alongside legacy parameters. This `accessList` specifies an array of addresses and storage keys that the transaction plans to access, enabling gas savings on cross-contract calls by pre-declaring the accessed contract and storage slots. They do not include EIP-1559 fee market changes.
 
 ## EIP-1559 Transactions
 
-EIP-1559 transactions (type `0x2`) were introduced in Ethereum's London fork to address network congestion and transaction fee overpricing caused by the historical fee market. Unlike traditional transactions, EIP-1559 transactions don't specify a gas price (`gasPrice`). Instead, they use an in-protocol, dynamically changing base fee per gas, adjusted at each block to manage network congestion.
+[EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) transactions (type `0x2`) were introduced in Ethereum's London fork to address network congestion and transaction fee overpricing caused by the historical fee market. Unlike traditional transactions, EIP-1559 transactions don't specify a gas price (`gasPrice`). Instead, they use an in-protocol, dynamically changing base fee per gas, adjusted at each block to manage network congestion.
 
 Alongside the `accessList` parameter and legacy parameters (except `gasPrice`), EIP-1559 transactions include:
 - `maxPriorityFeePerGas`, specifying the maximum fee above the base fee the sender is willing to pay,

--- a/book/run/transactions.md
+++ b/book/run/transactions.md
@@ -1,0 +1,38 @@
+# Transaction types
+
+Over time, the Ethereum network has undergone various upgrades and improvements to enhance transaction efficiency, security, and user experience. Three significant transaction types that have evolved are:
+
+- Legacy Transactions,
+- EIP-2930 Transactions,
+- EIP-1559 Transactions.
+
+Each of these transaction types brings unique features and improvements to the Ethereum network.
+
+## Legacy Transactions
+
+Legacy Transactions (type `0x0`), the traditional Ethereum transactions in use since the network's inception, include the following parameters:
+- `nonce`,
+- `gasPrice`,
+- `gasLimit`,
+- `to`,
+- `value`,
+- `data`,
+- `v`,
+- `r`,
+- `s`.
+
+These transactions do not utilize access lists, which specify the addresses and storage keys to be accessed, nor do they incorporate EIP-1559 fee market changes.
+
+## EIP-2930 Transactions
+
+Introduced in EIP-2930, transactions with type `0x1` incorporate an `accessList` parameter alongside legacy parameters. This `accessList` specifies an array of addresses and storage keys that the transaction plans to access, enabling gas savings on cross-contract calls by pre-declaring the accessed contract and storage slots. They do not include EIP-1559 fee market changes.
+
+## EIP-1559 Transactions
+
+EIP-1559 transactions (type `0x2`) were introduced in Ethereum's London fork to address network congestion and transaction fee overpricing caused by the historical fee market. Unlike traditional transactions, EIP-1559 transactions don't specify a gas price (`gasPrice`). Instead, they use an in-protocol, dynamically changing base fee per gas, adjusted at each block to manage network congestion.
+
+Alongside the `accessList` parameter and legacy parameters (except `gasPrice`), EIP-1559 transactions include:
+- `maxPriorityFeePerGas`, specifying the maximum fee above the base fee the sender is willing to pay,
+- `maxFeePerGas`, setting the maximum total fee the sender is willing to pay.
+
+The base fee is burned, while the priority fee is paid to the miner who includes the transaction, incentivizing miners to include transactions with higher priority fees per gas.

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -302,11 +302,32 @@ impl TxEip4844 {
 #[derive_arbitrary(compact)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Transaction {
-    /// Legacy transaction.
+    /// Legacy transaction (type `0x0`).
+    ///
+    /// Traditional Ethereum transactions, containing parameters `nonce`, `gasPrice`, `gasLimit`,
+    /// `to`, `value`, `data`, `v`, `r`, and `s`.
+    ///
+    /// These transactions do not utilize access lists nor do they incorporate EIP-1559 fee market
+    /// changes.
     Legacy(TxLegacy),
-    /// Transaction with an [`AccessList`] ([EIP-2930](https://eips.ethereum.org/EIPS/eip-2930)).
+    /// Transaction with an [`AccessList`] ([EIP-2930](https://eips.ethereum.org/EIPS/eip-2930)), type `0x1`.
+    ///
+    /// The `accessList` specifies an array of addresses and storage keys that the transaction
+    /// plans to access, enabling gas savings on cross-contract calls by pre-declaring the accessed
+    /// contract and storage slots.
     Eip2930(TxEip2930),
-    /// A transaction with a priority fee ([EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)).
+    /// A transaction with a priority fee ([EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)), type `0x2`.
+    ///
+    /// Unlike traditional transactions, EIP-1559 transactions use an in-protocol, dynamically
+    /// changing base fee per gas, adjusted at each block to manage network congestion.
+    ///
+    /// - `maxPriorityFeePerGas`, specifying the maximum fee above the base fee the sender is
+    ///   willing to pay
+    /// - `maxFeePerGas`, setting the maximum total fee the sender is willing to pay.
+    ///
+    /// The base fee is burned, while the priority fee is paid to the miner who includes the
+    /// transaction, incentivizing miners to include transactions with higher priority fees per
+    /// gas.
     Eip1559(TxEip1559),
 }
 


### PR DESCRIPTION
Should solve #3803.

I added the description of the different types of transactions in two places:
- In the code for new contributors who would be lost.
- In the official documentation (book) for users with a little more text.

If it is not necessary, I can remove the description in the book, but I thought it could provide additional information.