### PR TITLE
rpc server metrics impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5746,6 +5746,7 @@ dependencies = [
  "reth-beacon-consensus",
  "reth-interfaces",
  "reth-ipc",
+ "reth-metrics",
  "reth-network-api",
  "reth-payload-builder",
  "reth-primitives",

--- a/crates/rpc/rpc-builder/Cargo.toml
+++ b/crates/rpc/rpc-builder/Cargo.toml
@@ -21,6 +21,7 @@ reth-rpc-engine-api = { path = "../rpc-engine-api" }
 reth-rpc-types = { workspace = true }
 reth-tasks = { workspace = true }
 reth-transaction-pool = { workspace = true }
+reth-metrics = { workspace = true, features = ["common"] }
 
 # rpc/net
 jsonrpsee = { version = "0.18", features = ["server"] }

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -103,8 +103,7 @@
 //! }
 //! ```
 
-use crate::metrics::RpcServerMetrics;
-use crate::{auth::AuthRpcModule, error::WsHttpSamePortError};
+use crate::{auth::AuthRpcModule, error::WsHttpSamePortError, metrics::RpcServerMetrics};
 use constants::*;
 use error::{RpcError, ServerKind};
 use jsonrpsee::{
@@ -1196,9 +1195,9 @@ impl RpcServerConfig {
     ///
     /// If no server is configured, no server will be be launched on [RpcServerConfig::start].
     pub fn has_server(&self) -> bool {
-        self.http_server_config.is_some()
-            || self.ws_server_config.is_some()
-            || self.ipc_server_config.is_some()
+        self.http_server_config.is_some() ||
+            self.ws_server_config.is_some() ||
+            self.ipc_server_config.is_some()
     }
 
     /// Returns the [SocketAddr] of the http server
@@ -1238,9 +1237,9 @@ impl RpcServerConfig {
             .unwrap_or(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, DEFAULT_WS_RPC_PORT)));
         let metrics = RpcServerMetrics::default();
         // If both are configured on the same port, we combine them into one server.
-        if self.http_addr == self.ws_addr
-            && self.http_server_config.is_some()
-            && self.ws_server_config.is_some()
+        if self.http_addr == self.ws_addr &&
+            self.http_server_config.is_some() &&
+            self.ws_server_config.is_some()
         {
             let cors = match (self.ws_cors_domains.as_ref(), self.http_cors_domains.as_ref()) {
                 (Some(ws_cors), Some(http_cors)) => {
@@ -1249,7 +1248,7 @@ impl RpcServerConfig {
                             http_cors_domains: Some(http_cors.clone()),
                             ws_cors_domains: Some(ws_cors.clone()),
                         }
-                        .into());
+                        .into())
                     }
                     Some(ws_cors)
                 }
@@ -1275,7 +1274,7 @@ impl RpcServerConfig {
                 http_local_addr: Some(addr),
                 ws_local_addr: Some(addr),
                 server: WsHttpServers::SamePort(server),
-            });
+            })
         }
 
         let mut http_local_addr = None;

--- a/crates/rpc/rpc-builder/src/metrics.rs
+++ b/crates/rpc/rpc-builder/src/metrics.rs
@@ -1,0 +1,98 @@
+use jsonrpsee::server::logger::Logger;
+use jsonrpsee::server::logger::{HttpRequest, MethodKind, Params, TransportProtocol};
+use std::format;
+use std::net::SocketAddr;
+
+use reth_metrics::{
+    metrics::{self, counter, histogram, Gauge, Histogram},
+    Metrics,
+};
+use std::time::Instant;
+
+const METRICS_SCOPE: &str = "rpc_server";
+const CALL_LATENCY_METRIC: &str = "call_latency";
+const CALL_COUNT_METRIC: &str = "call_count";
+const CALL_ERROR_METRIC: &str = "call_error";
+
+/// Metrics for the rpc server
+#[derive(Metrics, Clone)]
+#[metrics(scope = "rpc_server")]
+pub(crate) struct RpcServerMetrics {
+    /// The number of ws requests currently being served
+    ws_req_count: Gauge,
+    /// The number of http requests currently being served
+    http_req_count: Gauge,
+    /// The number of ws sessions currently active
+    ws_session_count: Gauge,
+    /// The number of http connections currently active
+    http_session_count: Gauge,
+    /// Latency for a single request/response pair
+    request_latency: Histogram,
+}
+
+impl Logger for RpcServerMetrics {
+    type Instant = Instant;
+    fn on_connect(
+        &self,
+        _remote_addr: SocketAddr,
+        _request: &HttpRequest,
+        transport: TransportProtocol,
+    ) {
+        match transport {
+            TransportProtocol::Http => self.http_session_count.increment(1 as f64),
+            TransportProtocol::WebSocket => self.ws_session_count.increment(1 as f64),
+        }
+    }
+    fn on_request(&self, transport: TransportProtocol) -> Self::Instant {
+        match transport {
+            TransportProtocol::Http => self.http_req_count.increment(1 as f64),
+            TransportProtocol::WebSocket => self.ws_req_count.increment(1 as f64),
+        }
+        Instant::now()
+    }
+    fn on_call(
+        &self,
+        method_name: &str,
+        _params: Params<'_>,
+        _kind: MethodKind,
+        _transport: TransportProtocol,
+    ) {
+        // note that on_call will be called multiple times in case of a batch request
+        // increment method call count, use macro because derive(Metrics) doesnt seem to support dynamically configuring metric name (?)
+        let metric_call_count_name =
+            format!("{}{}{}{}{}", METRICS_SCOPE, "_", CALL_COUNT_METRIC, "_", method_name);
+        counter!(metric_call_count_name, 1); // this could be a gauge since one call here should map to one "result" in on_result
+    }
+    fn on_result(
+        &self,
+        method_name: &str,
+        success: bool,
+        started_at: Self::Instant,
+        _transport: TransportProtocol,
+    ) {
+        // capture method call latency, use macro because of the same reason stated in on_call
+        let metric_name_call_latency =
+            format!("{}{}{}{}{}", METRICS_SCOPE, "_", CALL_LATENCY_METRIC, "_", method_name);
+        histogram!(metric_name_call_latency, started_at.elapsed());
+        if !success {
+            // capture error count for method call, use macro because of the same reason stated in on_call
+            let metric_name_call_error_count =
+                format!("{}{}{}{}{}", METRICS_SCOPE, "_", CALL_ERROR_METRIC, "_", method_name);
+            counter!(metric_name_call_error_count, 1);
+        }
+    }
+    fn on_response(&self, _result: &str, started_at: Self::Instant, transport: TransportProtocol) {
+        match transport {
+            TransportProtocol::Http => self.http_req_count.decrement(1 as f64),
+            TransportProtocol::WebSocket => self.ws_req_count.decrement(1 as f64),
+        }
+        // capture request latency for this request/response pair
+        self.request_latency.record(started_at.elapsed());
+    }
+    fn on_disconnect(&self, _remote_addr: SocketAddr, transport: TransportProtocol) {
+        match transport {
+            TransportProtocol::Http => self.http_session_count.decrement(1 as f64),
+            TransportProtocol::WebSocket => self.ws_session_count.decrement(1 as f64),
+        }
+    }
+}


### PR DESCRIPTION
skeleton draft PR for [#3907](https://github.com/paradigmxyz/reth/issues/3907#issuecomment-1649925447), please excuse the formatting changes my IDE's auto save rust fmt applied. If needbe - I can change to the repo's `fmt` standard, not sure what's different with my setup

@mattsse if this looks on the right path I can keep at it - questions I have rn revolve around:

- does the adding type param `RpcServerMetrics` to the `jsonrpsee::server::Server<Identity, L: ()>` in `WsHttpServerKind` seem OK or is there a cleaner way to do it

- the metrics scope implementation rn changes relative to whether the WS/HTTP servers are combined or not, should it be that way?


and generally haven't started thinking through what exact metrics we want to track in `RpcServerMetrics`



