### PR TITLE
feat: reth db diff

### DIFF
--- a/bin/reth/src/db/diff.rs
+++ b/bin/reth/src/db/diff.rs
@@ -1,0 +1,346 @@
+use std::{collections::HashMap, hash::Hash, path::PathBuf};
+
+use crate::{
+    args::DatabaseArgs,
+    dirs::{DataDirPath, PlatformPath},
+    utils::DbTool,
+};
+use clap::Parser;
+
+use reth_db::{
+    cursor::DbCursorRO,
+    database::Database,
+    mdbx::{tx::Tx, NoWriteMap, RO},
+    open_db_read_only,
+    table::Table,
+    transaction::DbTx,
+    AccountChangeSet, AccountHistory, AccountsTrie, BlockBodyIndices, BlockOmmers,
+    BlockWithdrawals, Bytecodes, CanonicalHeaders, DatabaseEnvRO, HashedAccount, HashedStorage,
+    HeaderNumbers, HeaderTD, Headers, PlainAccountState, PlainStorageState, PruneCheckpoints,
+    Receipts, StorageChangeSet, StorageHistory, StoragesTrie, SyncStage, SyncStageProgress, Tables,
+    TransactionBlock, Transactions, TxHashNumber, TxSenders,
+};
+use tracing::error;
+
+#[derive(Parser, Debug)]
+/// The arguments for the `reth db diff` command
+pub struct Command {
+    // THE SECOND DATABASE
+    /// The path to the data dir for all reth files and subdirectories.
+    #[arg(long, verbatim_doc_comment, global = true)]
+    secondary_datadir: PlatformPath<DataDirPath>,
+
+    /// Arguments for the second database
+    #[clap(flatten)]
+    second_db: DatabaseArgs,
+
+    /// The table name to diff. If not specified, all tables are diffed.
+    #[arg(long, verbatim_doc_comment)]
+    table: Option<Tables>,
+}
+
+impl Command {
+    /// Execute `db diff` command
+    pub fn execute(self, tool: &DbTool<'_, DatabaseEnvRO>) -> eyre::Result<()> {
+        // open first db
+        let second_db_path: PathBuf = self.secondary_datadir.join("db").into();
+        let second_db = open_db_read_only(&second_db_path, self.second_db.log_level)?;
+
+        let tables = match self.table {
+            Some(table) => vec![table],
+            None => Tables::ALL.to_vec(),
+        };
+
+        for table in tables {
+            let primary_tx = tool.db.tx()?;
+            let secondary_tx = second_db.tx()?;
+
+            match table {
+                Tables::CanonicalHeaders => {
+                    find_diffs::<CanonicalHeaders>(primary_tx, secondary_tx)?
+                }
+                Tables::HeaderTD => find_diffs::<HeaderTD>(primary_tx, secondary_tx)?,
+                Tables::HeaderNumbers => find_diffs::<HeaderNumbers>(primary_tx, secondary_tx)?,
+                Tables::Headers => find_diffs::<Headers>(primary_tx, secondary_tx)?,
+                Tables::BlockBodyIndices => {
+                    find_diffs::<BlockBodyIndices>(primary_tx, secondary_tx)?
+                }
+                Tables::BlockOmmers => find_diffs::<BlockOmmers>(primary_tx, secondary_tx)?,
+                Tables::BlockWithdrawals => {
+                    find_diffs::<BlockWithdrawals>(primary_tx, secondary_tx)?
+                }
+                Tables::TransactionBlock => {
+                    find_diffs::<TransactionBlock>(primary_tx, secondary_tx)?
+                }
+                Tables::Transactions => find_diffs::<Transactions>(primary_tx, secondary_tx)?,
+                Tables::TxHashNumber => find_diffs::<TxHashNumber>(primary_tx, secondary_tx)?,
+                Tables::Receipts => find_diffs::<Receipts>(primary_tx, secondary_tx)?,
+                Tables::PlainAccountState => {
+                    find_diffs::<PlainAccountState>(primary_tx, secondary_tx)?
+                }
+                Tables::PlainStorageState => {
+                    find_diffs::<PlainStorageState>(primary_tx, secondary_tx)?
+                }
+                Tables::Bytecodes => find_diffs::<Bytecodes>(primary_tx, secondary_tx)?,
+                Tables::AccountHistory => find_diffs::<AccountHistory>(primary_tx, secondary_tx)?,
+                Tables::StorageHistory => find_diffs::<StorageHistory>(primary_tx, secondary_tx)?,
+                Tables::AccountChangeSet => {
+                    find_diffs::<AccountChangeSet>(primary_tx, secondary_tx)?
+                }
+                Tables::StorageChangeSet => {
+                    find_diffs::<StorageChangeSet>(primary_tx, secondary_tx)?
+                }
+                Tables::HashedAccount => find_diffs::<HashedAccount>(primary_tx, secondary_tx)?,
+                Tables::HashedStorage => find_diffs::<HashedStorage>(primary_tx, secondary_tx)?,
+                Tables::AccountsTrie => find_diffs::<AccountsTrie>(primary_tx, secondary_tx)?,
+                Tables::StoragesTrie => find_diffs::<StoragesTrie>(primary_tx, secondary_tx)?,
+                Tables::TxSenders => find_diffs::<TxSenders>(primary_tx, secondary_tx)?,
+                Tables::SyncStage => find_diffs::<SyncStage>(primary_tx, secondary_tx)?,
+                Tables::SyncStageProgress => {
+                    find_diffs::<SyncStageProgress>(primary_tx, secondary_tx)?
+                }
+                Tables::PruneCheckpoints => {
+                    find_diffs::<PruneCheckpoints>(primary_tx, secondary_tx)?
+                }
+            };
+        }
+
+        Ok(())
+    }
+}
+
+/// Find diffs for a table, then analyzing the result
+fn find_diffs<T: Table>(
+    primary_tx: Tx<'_, RO, NoWriteMap>,
+    secondary_tx: Tx<'_, RO, NoWriteMap>,
+) -> eyre::Result<()>
+where
+    T::Key: Hash,
+    T::Value: PartialEq,
+{
+    let result = find_diffs_advanced::<T>(&primary_tx, &secondary_tx)?;
+
+    // analyze the result and print some stats
+    let discrepancies = result.discrepancies.len();
+    let extra_elements = result.extra_elements.len();
+
+    if discrepancies > 0 {
+        error!("Found {} discrepancies in table {}", discrepancies, T::NAME);
+    }
+
+    if extra_elements > 0 {
+        error!("Found {} extra elements in table {}", extra_elements, T::NAME);
+    }
+
+    Ok(())
+}
+
+/// Find diffs for a specific table. This will walk the first table, checking the second table
+/// for each element. If the element is not found, it will be added to the extra elements set.
+fn find_diffs_simple<T: Table>(
+    primary_tx: Tx<'_, RO, NoWriteMap>,
+    secondary_tx: Tx<'_, RO, NoWriteMap>,
+) -> eyre::Result<TableDiffResult<T>>
+where
+    T::Key: Hash,
+    T::Value: PartialEq,
+{
+    // initialize the walker for the first table
+    let mut primary_cursor =
+        primary_tx.cursor_read::<T>().expect("Was not able to obtain a cursor.");
+    let primary_walker = primary_cursor.walk(None)?;
+
+    let mut secondary_cursor =
+        secondary_tx.cursor_read::<T>().expect("Was not able to obtain a cursor.");
+    let mut result = TableDiffResult::<T>::default();
+
+    for entry in primary_walker {
+        let (key, value) = entry?;
+        let secondary_value = secondary_cursor.seek_exact(key.clone())?.map(|(_, value)| value);
+
+        result.try_push_discrepancy(key, Some(value), secondary_value);
+    }
+
+    Ok(result)
+}
+
+/// This diff algorithm is slightly different, it will walk _each_ table, cross-checking for the
+/// element in the other table.
+fn find_diffs_advanced<T: Table>(
+    primary_tx: &Tx<'_, RO, NoWriteMap>,
+    secondary_tx: &Tx<'_, RO, NoWriteMap>,
+) -> eyre::Result<TableDiffResult<T>>
+where
+    T::Value: PartialEq,
+    T::Key: Hash,
+{
+    // initialize the zipped walker
+    let mut primary_zip_cursor =
+        primary_tx.cursor_read::<T>().expect("Was not able to obtain a cursor.");
+    let primary_walker = primary_zip_cursor.walk(None)?;
+
+    let mut secondary_zip_cursor =
+        secondary_tx.cursor_read::<T>().expect("Was not able to obtain a cursor.");
+    let secondary_walker = secondary_zip_cursor.walk(None)?;
+    let zipped_cursor = primary_walker.zip(secondary_walker);
+
+    // initialize the cursors for seeking when we are cross checking elements
+    let mut primary_cursor =
+        primary_tx.cursor_read::<T>().expect("Was not able to obtain a cursor.");
+
+    let mut secondary_cursor =
+        secondary_tx.cursor_read::<T>().expect("Was not able to obtain a cursor.");
+
+    let mut result = TableDiffResult::<T>::default();
+
+    // this loop will walk both tables, cross-checking for the element in the other table.
+    // it basically just loops through both tables at the same time. if the keys are different, it
+    // will check each key in the other table. if the keys are the same, it will compare the
+    // values
+    for (primary_entry, secondary_entry) in zipped_cursor {
+        let (primary_key, primary_value) = primary_entry?;
+        let (secondary_key, secondary_value) = secondary_entry?;
+
+        if primary_key != secondary_key {
+            // if the keys are different, we need to check if the key is in the other table
+            let crossed_secondary =
+                secondary_cursor.seek_exact(primary_key.clone())?.map(|(_, value)| value);
+            result.try_push_discrepancy(
+                primary_key.clone(),
+                Some(primary_value),
+                crossed_secondary,
+            );
+
+            // now do the same for the primary table
+            let crossed_primary =
+                primary_cursor.seek_exact(secondary_key.clone())?.map(|(_, value)| value);
+            result.try_push_discrepancy(
+                secondary_key.clone(),
+                crossed_primary,
+                Some(secondary_value),
+            );
+        } else {
+            // the keys are the same, so we need to compare the values
+            result.try_push_discrepancy(primary_key, Some(primary_value), Some(secondary_value));
+        }
+    }
+
+    Ok(result)
+}
+
+/// Includes a table element between two databases with the same key, but different values
+struct TableDiffElement<T: Table> {
+    /// The key for the element
+    key: T::Key,
+    /// The element in the first table
+    expected: T::Value,
+    /// The element in the second table
+    got: T::Value,
+}
+
+/// The diff result for an entire table. If the tables had the same number of elements, there will
+/// be no extra elements.
+struct TableDiffResult<T: Table>
+where
+    T::Key: Hash,
+{
+    /// All elements of the database that are different
+    discrepancies: HashMap<T::Key, TableDiffElement<T>>,
+
+    /// Any extra elements, and the table they are in
+    extra_elements: HashMap<T::Key, ExtraTableElement<T>>,
+}
+
+impl<T> Default for TableDiffResult<T>
+where
+    T: Table,
+    T::Key: Hash,
+{
+    fn default() -> Self {
+        Self { discrepancies: HashMap::new(), extra_elements: HashMap::new() }
+    }
+}
+
+impl<T: Table> TableDiffResult<T>
+where
+    T::Key: Hash,
+{
+    /// Push a diff result into the discrepancies set.
+    fn push_discrepancy(&mut self, discrepancy: TableDiffElement<T>) {
+        self.discrepancies.insert(discrepancy.key.clone(), discrepancy);
+    }
+
+    /// Push an extra element into the extra elements set.
+    fn push_extra_element(&mut self, element: ExtraTableElement<T>) {
+        self.extra_elements.insert(element.key().clone(), element);
+    }
+}
+
+impl<T> TableDiffResult<T>
+where
+    T: Table,
+    T::Key: Hash,
+    T::Value: PartialEq,
+{
+    /// Try to push a diff result into the discrepancy set, only pushing if the given elements are
+    /// different, and the discrepancy does not exist anywhere already.
+    fn try_push_discrepancy(
+        &mut self,
+        key: T::Key,
+        first: Option<T::Value>,
+        second: Option<T::Value>,
+    ) {
+        // do not bother comparing if the key is already in the discrepancies map
+        if self.discrepancies.contains_key(&key) {
+            return
+        }
+
+        // do not bother comparing if the key is already in the extra elements map
+        if self.extra_elements.contains_key(&key) {
+            return
+        }
+
+        match (first, second) {
+            (Some(first), Some(second)) => {
+                if first != second {
+                    self.push_discrepancy(TableDiffElement { key, expected: first, got: second });
+                }
+            }
+            (Some(first), None) => {
+                self.push_extra_element(ExtraTableElement::first(key, first));
+            }
+            (None, Some(second)) => {
+                self.push_extra_element(ExtraTableElement::second(key, second));
+            }
+            (None, None) => {}
+        }
+    }
+}
+
+/// A single extra element from a table
+enum ExtraTableElement<T: Table> {
+    /// The extra element is in the first table
+    First { key: T::Key, value: T::Value },
+    /// The extra element is in the second table
+    Second { key: T::Key, value: T::Value },
+}
+
+impl<T: Table> ExtraTableElement<T> {
+    /// Create a new extra element from the first table
+    fn first(key: T::Key, value: T::Value) -> Self {
+        Self::First { key, value }
+    }
+
+    /// Create a new extra element from the second table
+    fn second(key: T::Key, value: T::Value) -> Self {
+        Self::Second { key, value }
+    }
+
+    /// Return the key for the extra element
+    fn key(&self) -> &T::Key {
+        match self {
+            Self::First { key, .. } => key,
+            Self::Second { key, .. } => key,
+        }
+    }
+}

--- a/bin/reth/src/db/diff.rs
+++ b/bin/reth/src/db/diff.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, hash::Hash, path::PathBuf};
+use std::{collections::HashMap, hash::Hash, path::PathBuf, fmt::Debug};
 
 use crate::{
     args::DatabaseArgs,
@@ -132,11 +132,21 @@ where
         error!("Found {} extra elements in table {}", extra_elements, T::NAME);
     }
 
+    for discrepancy in result.discrepancies {
+        error!("Discrepancy: {:?}", discrepancy);
+    }
+
+    for extra_element in result.extra_elements {
+        error!("Extra element: {:?}", extra_element);
+    }
+
     Ok(())
 }
 
 /// Find diffs for a specific table. This will walk the first table, checking the second table
 /// for each element. If the element is not found, it will be added to the extra elements set.
+// TODO: remove this?
+#[allow(dead_code)]
 fn find_diffs_simple<T: Table>(
     primary_tx: Tx<'_, RO, NoWriteMap>,
     secondary_tx: Tx<'_, RO, NoWriteMap>,
@@ -229,6 +239,7 @@ where
 }
 
 /// Includes a table element between two databases with the same key, but different values
+#[derive(Debug)]
 struct TableDiffElement<T: Table> {
     /// The key for the element
     key: T::Key,
@@ -318,6 +329,7 @@ where
 }
 
 /// A single extra element from a table
+#[derive(Debug)]
 enum ExtraTableElement<T: Table> {
     /// The extra element is in the first table
     First { key: T::Key, value: T::Value },

--- a/bin/reth/src/db/diff.rs
+++ b/bin/reth/src/db/diff.rs
@@ -42,7 +42,7 @@ pub struct Command {
 impl Command {
     /// Execute `db diff` command
     pub fn execute(self, tool: &DbTool<'_, DatabaseEnvRO>) -> eyre::Result<()> {
-        // open first db
+        // open second db
         let second_db_path: PathBuf = self.secondary_datadir.join("db").into();
         let second_db = open_db_read_only(&second_db_path, self.second_db.log_level)?;
 

--- a/bin/reth/src/db/diff.rs
+++ b/bin/reth/src/db/diff.rs
@@ -27,7 +27,6 @@ use tracing::info;
 #[derive(Parser, Debug)]
 /// The arguments for the `reth db diff` command
 pub struct Command {
-    // THE SECOND DATABASE
     /// The path to the data dir for all reth files and subdirectories.
     #[arg(long, verbatim_doc_comment)]
     secondary_datadir: PlatformPath<DataDirPath>,
@@ -46,7 +45,19 @@ pub struct Command {
 }
 
 impl Command {
-    /// Execute `db diff` command
+    /// Execute the `db diff` command.
+    ///
+    /// This first opens the `db/` folder from the secondary datadir, where the second database is
+    /// opened read-only.
+    ///
+    /// The tool will then iterate through all key-value pairs for the primary and secondary
+    /// databases. The value for each key will be compared with its corresponding value in the
+    /// other database. If the values are different, a discrepancy will be recorded in-memory. If
+    /// one key is present in one database but not the other, this will be recorded as an "extra
+    /// element" for that database.
+    ///
+    /// The discrepancies and extra elements, along with a brief summary of the diff results are
+    /// then written to a file in the output directory.
     pub fn execute(self, tool: &DbTool<'_, DatabaseEnvRO>) -> eyre::Result<()> {
         // open second db
         let second_db_path: PathBuf = self.secondary_datadir.join("db").into();

--- a/bin/reth/src/db/diff.rs
+++ b/bin/reth/src/db/diff.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, hash::Hash, path::PathBuf, fmt::Debug};
+use std::{collections::HashMap, fmt::Debug, hash::Hash, path::PathBuf};
 
 use crate::{
     args::DatabaseArgs,
@@ -8,12 +8,7 @@ use crate::{
 use clap::Parser;
 
 use reth_db::{
-    cursor::DbCursorRO,
-    database::Database,
-    mdbx::{tx::Tx, NoWriteMap, RO},
-    open_db_read_only,
-    table::Table,
-    transaction::DbTx,
+    cursor::DbCursorRO, database::Database, open_db_read_only, table::Table, transaction::DbTx,
     AccountChangeSet, AccountHistory, AccountsTrie, BlockBodyIndices, BlockOmmers,
     BlockWithdrawals, Bytecodes, CanonicalHeaders, DatabaseEnvRO, HashedAccount, HashedStorage,
     HeaderNumbers, HeaderTD, Headers, PlainAccountState, PlainStorageState, PruneCheckpoints,
@@ -110,9 +105,9 @@ impl Command {
 }
 
 /// Find diffs for a table, then analyzing the result
-fn find_diffs<T: Table>(
-    primary_tx: Tx<'_, RO, NoWriteMap>,
-    secondary_tx: Tx<'_, RO, NoWriteMap>,
+fn find_diffs<'a, T: Table>(
+    primary_tx: impl DbTx<'a>,
+    secondary_tx: impl DbTx<'a>,
 ) -> eyre::Result<()>
 where
     T::Key: Hash,
@@ -147,9 +142,9 @@ where
 /// for each element. If the element is not found, it will be added to the extra elements set.
 // TODO: remove this?
 #[allow(dead_code)]
-fn find_diffs_simple<T: Table>(
-    primary_tx: Tx<'_, RO, NoWriteMap>,
-    secondary_tx: Tx<'_, RO, NoWriteMap>,
+fn find_diffs_simple<'a, T: Table>(
+    primary_tx: impl DbTx<'a>,
+    secondary_tx: impl DbTx<'a>,
 ) -> eyre::Result<TableDiffResult<T>>
 where
     T::Key: Hash,
@@ -176,9 +171,9 @@ where
 
 /// This diff algorithm is slightly different, it will walk _each_ table, cross-checking for the
 /// element in the other table.
-fn find_diffs_advanced<T: Table>(
-    primary_tx: &Tx<'_, RO, NoWriteMap>,
-    secondary_tx: &Tx<'_, RO, NoWriteMap>,
+fn find_diffs_advanced<'a, T: Table>(
+    primary_tx: &impl DbTx<'a>,
+    secondary_tx: &impl DbTx<'a>,
 ) -> eyre::Result<TableDiffResult<T>>
 where
     T::Value: PartialEq,

--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -18,6 +18,7 @@ use reth_primitives::ChainSpec;
 use std::sync::Arc;
 
 mod clear;
+mod diff;
 mod get;
 mod list;
 /// DB List TUI
@@ -68,6 +69,8 @@ pub enum Subcommands {
     Stats,
     /// Lists the contents of a table
     List(list::Command),
+    /// Create a diff between two database tables or two entire databases.
+    Diff(diff::Command),
     /// Gets the content of a table for the given key
     Get(get::Command),
     /// Deletes all database entries
@@ -161,6 +164,11 @@ impl Command {
                 println!("{stats_table}");
             }
             Subcommands::List(command) => {
+                let db = open_db_read_only(&db_path, self.db.log_level)?;
+                let tool = DbTool::new(&db, self.chain.clone())?;
+                command.execute(&tool)?;
+            }
+            Subcommands::Diff(command) => {
                 let db = open_db_read_only(&db_path, self.db.log_level)?;
                 let tool = DbTool::new(&db, self.chain.clone())?;
                 command.execute(&tool)?;

--- a/crates/primitives/src/prune/part.rs
+++ b/crates/primitives/src/prune/part.rs
@@ -2,7 +2,7 @@ use reth_codecs::{main_codec, Compact};
 
 /// Part of the data that can be pruned.
 #[main_codec]
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum PrunePart {
     /// Prune part responsible for the `TxSenders` table.
     SenderRecovery,

--- a/crates/storage/db/src/tables/models/accounts.rs
+++ b/crates/storage/db/src/tables/models/accounts.rs
@@ -64,7 +64,9 @@ impl Compact for AccountBeforeTx {
 /// [`StorageChangeSet`](crate::tables::StorageChangeSet)
 ///
 /// Since it's used as a key, it isn't compressed when encoding it.
-#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Ord, PartialOrd)]
+#[derive(
+    Debug, Default, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Ord, PartialOrd, Hash,
+)]
 pub struct BlockNumberAddress(pub (BlockNumber, Address));
 
 impl BlockNumberAddress {

--- a/crates/storage/db/src/tables/models/sharded_key.rs
+++ b/crates/storage/db/src/tables/models/sharded_key.rs
@@ -1,5 +1,7 @@
 //! Sharded key
 
+use std::hash::Hash;
+
 use crate::{
     table::{Decode, Encode},
     DatabaseError,
@@ -72,5 +74,15 @@ where
         let key = T::decode(&value[..tx_num_index])?;
 
         Ok(ShardedKey::new(key, highest_tx_number))
+    }
+}
+
+impl<T> Hash for ShardedKey<T>
+where
+    T: Hash,
+{
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.key.hash(state);
+        self.highest_block_number.hash(state);
     }
 }

--- a/crates/storage/db/src/tables/models/storage_sharded_key.rs
+++ b/crates/storage/db/src/tables/models/storage_sharded_key.rs
@@ -19,7 +19,9 @@ pub const NUM_OF_INDICES_IN_SHARD: usize = 2_000;
 /// `Address | Storagekey | 200` -> data is from transition 0 to 200.
 ///
 /// `Address | StorageKey | 300` -> data is from transition 201 to 300.
-#[derive(Debug, Default, Clone, Eq, Ord, PartialOrd, PartialEq, AsRef, Serialize, Deserialize)]
+#[derive(
+    Debug, Default, Clone, Eq, Ord, PartialOrd, PartialEq, AsRef, Serialize, Deserialize, Hash,
+)]
 pub struct StorageShardedKey {
     /// Storage account address.
     pub address: H160,


### PR DESCRIPTION
This adds a command, `reth db diff`, which is able to diff two reth databases, either a full DB diff or table-by-table.

Command line output example:
```
dan@Dans-MacBook-Pro-4 ~/p/reth (dan/reth-db-diff)> cargo r db diff --datadir ~/first-diff-datadir/ --secondary-datadir ~/second-diff-datadir/ --output ~/diff-results
   Compiling reth v0.1.0-alpha.4 (/Users/dan/projects/reth/bin/reth)
    Finished dev [unoptimized + debuginfo] target(s) in 12.87s
     Running `target/debug/reth db diff --datadir /Users/dan/first-diff-datadir/ --secondary-datadir /Users/dan/second-diff-datadir/ --output /Users/dan/diff-results`
2023-07-27T20:48:40.724516Z  INFO reth::db::diff: Analyzing table CanonicalHeaders...
2023-07-27T20:48:40.837339Z  INFO reth::db::diff: Done analyzing table CanonicalHeaders!
2023-07-27T20:48:40.837427Z  INFO reth::db::diff:
2023-07-27T20:48:40.837654Z  INFO reth::db::diff: Diff results for CanonicalHeaders:
2023-07-27T20:48:40.838173Z  INFO reth::db::diff: No discrepancies found in table CanonicalHeaders
2023-07-27T20:48:40.838369Z  INFO reth::db::diff: No extra elements found in table CanonicalHeaders
2023-07-27T20:48:40.838391Z  INFO reth::db::diff: Writing diff results for CanonicalHeaders to CanonicalHeaders.txt...
2023-07-27T20:48:40.839062Z  INFO reth::db::diff: Done writing diff results for CanonicalHeaders to /Users/dan/diff-results/CanonicalHeaders.txt
2023-07-27T20:48:40.839219Z  INFO reth::db::diff: Analyzing table HeaderTD...
2023-07-27T20:48:41.018847Z  INFO reth::db::diff: Done analyzing table HeaderTD!
```

Example of extra-element output (no discrepancies but a table has an extra element):
```
dan@Dans-MacBook-Pro-4 ~/p/reth (dan/reth-db-diff)> cat ~/diff-results/HeaderNumbers.txt
Diff results for HeaderNumbers
No discrepancies found in table HeaderNumbers
Found 10 extra elements in table HeaderNumbers
Extra elements:
Second { key: 0x0c1cd2b0f6213161986986a707bfa7280e9cfd31fd692b4e0acfb56339da9bc9, value: 100004 }
Second { key: 0xa93c3b8a437a216e241677827ad858e123024d0ec349f25be91f716f00760995, value: 100008 }
Second { key: 0x5c46eb47b3fd34d042768cbdecbe4c444c75704dac63e7b2aa870b4b7cbc78ef, value: 100010 }
Second { key: 0x0ba42c57b9c7317d81427594686fbb07387cffb4214ad5263574dd0e0764ed29, value: 100001 }
Second { key: 0xf96bc97790728fb5314fb5888244b0d6b7b6c527b407e2bbfd9f152a207bb144, value: 100007 }
Second { key: 0xf3784b63e43b22bc6ad90aad72e1ca55746a8e8b9a2539bc3671d894a39176fa, value: 100005 }
Second { key: 0xa36459a7b00deba23d1e2f51d1f87a4f6906caf8da443a23e058bfb7e2ac6656, value: 100002 }
Second { key: 0xf2f251f7f88622c6cae1bc963cf8f7ffd9a64412f81166f8b719d702973b8c3c, value: 100009 }
Second { key: 0x72e982b65e527aaca19e60a3da0bddd1070f2f76bba2334c8931308674cd5bff, value: 100003 }
Second { key: 0x34eec12e2f39abc569e8eb97177d855df19f4716ad472bc0f3b90231eb51e3cf, value: 100006 }
```
And discrepancy output:
```
dan@Dans-MacBook-Pro-4 ~/p/reth (dan/reth-db-diff)> cat ~/diff-results/HashedAccount.txt
Diff results for HashedAccount
Found 1 discrepancies in table HashedAccount
No extra elements found in table HashedAccount
Discrepancies:
TableDiffElement { key: 0x623afa54b237ecdf128faa469966051cff88b7dbdb0aec8062ef3fb218e22491, first: Account { nonce: 1, balance: 0x000000000000000000000000000000000000000000002a2dc2590a968a8bc1c8_U256, bytecode_hash: None }, second: Account { nonce: 1, balance: 0x000000000000000000000000000000000000000000002a2ed7e7509f9e5bc1c8_U256, bytecode_hash: None } }
```