### PR TITLE
feat(pruner): percentage progress and prune only if key exists

### DIFF
--- a/crates/prune/src/pruner.rs
+++ b/crates/prune/src/pruner.rs
@@ -206,6 +206,7 @@ impl<DB: Database> Pruner<DB> {
         };
         let last_tx_num = *range.end();
         let total = range.clone().count();
+        let mut processed = 0;
 
         for i in range.step_by(self.batch_sizes.transaction_lookup) {
             // The `min` ensures that the transaction range doesn't exceed the last transaction
@@ -230,7 +231,6 @@ impl<DB: Database> Pruner<DB> {
             // Pre-sort hashes to prune them in order
             hashes.sort();
 
-            let mut processed = 0;
             provider.prune_table_in_batches::<tables::TxHashNumber, _>(
                 hashes,
                 self.batch_sizes.transaction_lookup,

--- a/crates/prune/src/pruner.rs
+++ b/crates/prune/src/pruner.rs
@@ -229,21 +229,16 @@ impl<DB: Database> Pruner<DB> {
             }
 
             // Pre-sort hashes to prune them in order
-            hashes.sort();
+            hashes.sort_unstable();
 
-            provider.prune_table_in_batches::<tables::TxHashNumber, _>(
-                hashes,
-                self.batch_sizes.transaction_lookup,
-                |entries| {
-                    processed += entries;
-                    trace!(
-                        target: "pruner",
-                        %entries,
-                        progress = format!("{:.1}%", 100.0 * processed as f64 / total as f64),
-                        "Pruned transaction lookup"
-                    );
-                },
-            )?;
+            let entries = provider.prune_table::<tables::TxHashNumber, _>(hashes)?;
+            processed += entries;
+            trace!(
+                target: "pruner",
+                %entries,
+                progress = format!("{:.1}%", 100.0 * processed as f64 / total as f64),
+                "Pruned transaction lookup"
+            );
         }
 
         provider.save_prune_checkpoint(

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -640,7 +640,7 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> DatabaseProvider<'this, TX> {
         &self,
         keys: impl IntoIterator<Item = K>,
         batch_size: usize,
-        batch_callback: impl Fn(usize),
+        mut batch_callback: impl FnMut(usize),
     ) -> std::result::Result<usize, DatabaseError>
     where
         T: Table<Key = K>,

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -650,8 +650,9 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> DatabaseProvider<'this, TX> {
         let mut deleted = 0;
 
         for key in keys {
-            cursor.seek_exact(key)?;
-            cursor.delete_current()?;
+            if cursor.seek_exact(key)?.is_some() {
+                cursor.delete_current()?;
+            }
             deleted += 1;
 
             if deleted % batch_size == 0 {


### PR DESCRIPTION
1. Log percentage progress for pruning:
```console
2023-07-26T16:20:17.524869Z TRACE prune_transaction_lookup{to_block=3968777 prune_mode=Full}: pruner: Pruned transaction lookup entries=10000 progress="31.7%"
2023-07-26T16:20:17.559487Z TRACE prune_transaction_lookup{to_block=3968777 prune_mode=Full}: pruner: Pruned transaction lookup entries=10000 progress="31.8%"
```
2. Delete the entry only if it exists, otherwise do nothing. Previously, we were crashing. It shouldn't happen during normal operation, but can happen during manual debugging.