### PR TITLE
feat(bin): `db clear`

### DIFF
--- a/bin/reth/src/db/clear.rs
+++ b/bin/reth/src/db/clear.rs
@@ -13,7 +13,7 @@ pub struct Command {
 impl Command {
     /// Execute `db clear` command
     pub fn execute<DB: Database>(self, db: &DB) -> eyre::Result<()> {
-        self.table.view(&ClearViewer { db, args: &self })?;
+        self.table.view(&ClearViewer { db })?;
 
         Ok(())
     }
@@ -21,7 +21,6 @@ impl Command {
 
 struct ClearViewer<'a, DB: Database> {
     db: &'a DB,
-    args: &'a Command,
 }
 
 impl<DB: Database> TableViewer<()> for ClearViewer<'_, DB> {

--- a/bin/reth/src/db/clear.rs
+++ b/bin/reth/src/db/clear.rs
@@ -1,0 +1,36 @@
+use clap::Parser;
+
+use reth_db::{database::Database, table::Table, transaction::DbTxMut, TableViewer, Tables};
+
+/// The arguments for the `reth db clear` command
+#[derive(Parser, Debug)]
+pub struct Command {
+    /// Table name
+    #[arg()]
+    pub table: Tables,
+}
+
+impl Command {
+    /// Execute `db clear` command
+    pub fn execute<DB: Database>(self, db: &DB) -> eyre::Result<()> {
+        self.table.view(&ClearViewer { db, args: &self })?;
+
+        Ok(())
+    }
+}
+
+struct ClearViewer<'a, DB: Database> {
+    db: &'a DB,
+    args: &'a Command,
+}
+
+impl<DB: Database> TableViewer<()> for ClearViewer<'_, DB> {
+    type Error = eyre::Report;
+
+    fn view<T: Table>(&self) -> Result<(), Self::Error> {
+        let tx = self.db.tx_mut()?;
+        tx.clear::<T>()?;
+
+        Ok(())
+    }
+}

--- a/bin/reth/src/db/clear.rs
+++ b/bin/reth/src/db/clear.rs
@@ -1,6 +1,11 @@
 use clap::Parser;
 
-use reth_db::{database::Database, table::Table, transaction::DbTxMut, TableViewer, Tables};
+use reth_db::{
+    database::Database,
+    table::Table,
+    transaction::{DbTx, DbTxMut},
+    TableViewer, Tables,
+};
 
 /// The arguments for the `reth db clear` command
 #[derive(Parser, Debug)]
@@ -29,6 +34,7 @@ impl<DB: Database> TableViewer<()> for ClearViewer<'_, DB> {
     fn view<T: Table>(&self) -> Result<(), Self::Error> {
         let tx = self.db.tx_mut()?;
         tx.clear::<T>()?;
+        tx.commit()?;
 
         Ok(())
     }

--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -17,6 +17,7 @@ use reth_db::{
 use reth_primitives::ChainSpec;
 use std::sync::Arc;
 
+mod clear;
 mod get;
 mod list;
 /// DB List TUI
@@ -71,6 +72,8 @@ pub enum Subcommands {
     Get(get::Command),
     /// Deletes all database entries
     Drop,
+    /// Deletes all table entries
+    Clear(clear::Command),
     /// Lists current and local database versions
     Version,
     /// Returns the full database path
@@ -171,6 +174,10 @@ impl Command {
                 let db = open_db(&db_path, self.db.log_level)?;
                 let mut tool = DbTool::new(&db, self.chain.clone())?;
                 tool.drop(db_path)?;
+            }
+            Subcommands::Clear(command) => {
+                let db = open_db(&db_path, self.db.log_level)?;
+                command.execute(&db)?;
             }
             Subcommands::Version => {
                 let local_db_version = match get_db_version(&db_path) {


### PR DESCRIPTION
As per PR title. Was useful to clear prune checkpoints to start over without re-syncing the node.