### PR TITLE
Revert "test(ethereum): ignore invalid string sequence in ethereum state tests (#3307)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1742,7 +1742,6 @@ dependencies = [
  "reth-rlp",
  "reth-stages",
  "serde",
- "serde_bytes",
  "serde_json",
  "thiserror",
  "tokio",
@@ -6374,15 +6373,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/testing/ef-tests/Cargo.toml
+++ b/testing/ef-tests/Cargo.toml
@@ -24,4 +24,3 @@ walkdir = "2.3.3"
 serde = "1.0.163"
 serde_json.workspace = true
 thiserror.workspace = true
-serde_bytes = "0.11.9"

--- a/testing/ef-tests/src/models.rs
+++ b/testing/ef-tests/src/models.rs
@@ -36,20 +36,6 @@ pub struct BlockchainTest {
     #[serde(default)]
     /// Engine spec.
     pub self_engine: SealEngine,
-    #[serde(rename = "_info")]
-    #[allow(unused)]
-    info: BlockchainTestInfo,
-}
-
-#[derive(Debug, PartialEq, Eq, Deserialize)]
-struct BlockchainTestInfo {
-    #[serde(rename = "filling-rpc-server")]
-    #[allow(unused)]
-    // One test has an invalid string in this field, which breaks our CI:
-    // https://github.com/ethereum/tests/blob/6c252923bdd1bd5a70f680df1214f866f76839db/GeneralStateTests/stTransactionTest/ValueOverflow.json#L5
-    // By using `serde_bytes::ByteBuf`, we ignore the validation of this field as a string.
-    // TODO(alexey): remove when `ethereum/tests` is fixed
-    filling_rpc_server: serde_bytes::ByteBuf,
 }
 
 /// A block header in an Ethereum blockchain test.


### PR DESCRIPTION
This reverts commit 7b77fc1b6ba8023f1c20cfa5c134d5e332e2198e.

No need anymore, EF tests were fixed in https://github.com/ethereum/tests/pull/1231 and this sequence doesn't appear anymore (see e.g. https://github.com/ethereum/tests/commit/06e276776bc87817c38f6efb492bf6f4527fa904).