### PR TITLE
add defaults to some rpc server cli args

### DIFF
--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -52,7 +52,7 @@ pub(crate) const RPC_DEFAULT_MAX_CONNECTIONS: u32 = 100;
 pub(crate) const RPC_DEFAULT_MAX_TRACING_REQUESTS: u32 = 25;
 
 /// Parameters for configuring the rpc more granularity via CLI
-#[derive(Debug, Args, PartialEq, Eq, Default)]
+#[derive(Debug, Args, PartialEq, Eq)]
 #[command(next_help_heading = "RPC")]
 pub struct RpcServerArgs {
     /// Enable the HTTP-RPC server

--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -60,12 +60,12 @@ pub struct RpcServerArgs {
     pub http: bool,
 
     /// Http server address to listen on
-    #[arg(long = "http.addr")]
-    pub http_addr: Option<IpAddr>,
+    #[arg(long = "http.addr", default_value_t = IpAddr::V4(Ipv4Addr::LOCALHOST))]
+    pub http_addr: IpAddr,
 
     /// Http server port to listen on
-    #[arg(long = "http.port")]
-    pub http_port: Option<u16>,
+    #[arg(long = "http.port", default_value_t = constants::DEFAULT_HTTP_RPC_PORT)]
+    pub http_port: u16,
 
     /// Rpc Modules to be configured for the HTTP server
     #[arg(long = "http.api", value_parser = RpcModuleSelectionValueParser::default())]
@@ -80,12 +80,12 @@ pub struct RpcServerArgs {
     pub ws: bool,
 
     /// Ws server address to listen on
-    #[arg(long = "ws.addr")]
-    pub ws_addr: Option<IpAddr>,
+    #[arg(long = "ws.addr", default_value_t = IpAddr::V4(Ipv4Addr::LOCALHOST))]
+    pub ws_addr: IpAddr,
 
     /// Ws server port to listen on
-    #[arg(long = "ws.port")]
-    pub ws_port: Option<u16>,
+    #[arg(long = "ws.port", default_value_t = constants::DEFAULT_WS_RPC_PORT)]
+    pub ws_port: u16,
 
     /// Origins from which to accept WebSocket requests
     #[arg(long = "ws.origins", name = "ws.origins")]
@@ -104,8 +104,8 @@ pub struct RpcServerArgs {
     pub ipcpath: Option<String>,
 
     /// Auth server address to listen on
-    #[arg(long = "authrpc.addr")]
-    pub auth_addr: Option<IpAddr>,
+    #[arg(long = "authrpc.addr", default_value_t = IpAddr::V4(Ipv4Addr::LOCALHOST))]
+    pub auth_addr: IpAddr,
 
     /// Auth server port to listen on
     #[arg(long = "authrpc.port", default_value_t = constants::DEFAULT_AUTH_PORT)]
@@ -356,10 +356,7 @@ impl RpcServerArgs {
         Network: NetworkInfo + Peers + Clone + 'static,
         Tasks: TaskSpawner + Clone + 'static,
     {
-        let socket_address = SocketAddr::new(
-            self.auth_addr.unwrap_or(IpAddr::V4(Ipv4Addr::LOCALHOST)),
-            self.auth_port,
-        );
+        let socket_address = SocketAddr::new(self.auth_addr, self.auth_port);
 
         reth_rpc_builder::auth::launch(
             provider,
@@ -427,10 +424,7 @@ impl RpcServerArgs {
         let mut config = RpcServerConfig::default();
 
         if self.http {
-            let socket_address = SocketAddr::new(
-                self.http_addr.unwrap_or(IpAddr::V4(Ipv4Addr::LOCALHOST)),
-                self.http_port.unwrap_or(constants::DEFAULT_HTTP_RPC_PORT),
-            );
+            let socket_address = SocketAddr::new(self.http_addr, self.http_port);
             config = config
                 .with_http_address(socket_address)
                 .with_http(self.http_ws_server_builder())
@@ -439,10 +433,7 @@ impl RpcServerArgs {
         }
 
         if self.ws {
-            let socket_address = SocketAddr::new(
-                self.ws_addr.unwrap_or(IpAddr::V4(Ipv4Addr::LOCALHOST)),
-                self.ws_port.unwrap_or(constants::DEFAULT_WS_RPC_PORT),
-            );
+            let socket_address = SocketAddr::new(self.ws_addr, self.ws_port);
             config = config.with_ws_address(socket_address).with_ws(self.http_ws_server_builder());
         }
 
@@ -457,10 +448,7 @@ impl RpcServerArgs {
 
     /// Creates the [AuthServerConfig] from cli args.
     fn auth_server_config(&self, jwt_secret: JwtSecret) -> Result<AuthServerConfig, RpcError> {
-        let address = SocketAddr::new(
-            self.auth_addr.unwrap_or(IpAddr::V4(Ipv4Addr::LOCALHOST)),
-            self.auth_port,
-        );
+        let address = SocketAddr::new(self.auth_addr, self.auth_port);
 
         Ok(AuthServerConfig::builder(jwt_secret).socket_addr(address).build())
     }


### PR DESCRIPTION
Closes #3963 

This PR adds a default value and also removes the Option for the following fields:
- `auth_addr`
- `ws_addr`
- `ws_port`
- `http_addr`
- `http_port`