### PR TITLE
fix(pipeline): clear `MerkleStage` checkpoints on invalid root

### DIFF
--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -434,6 +434,7 @@ where
                         // When handling errors, we do not commit the database transaction. This
                         // leads to the Merkle stage not clearing its
                         // checkpoint, and restarting from an invalid place.
+                        drop(provider_rw);
                         provider_rw = factory.provider_rw().map_err(PipelineError::Interface)?;
                         provider_rw
                             .save_stage_checkpoint_progress(StageId::MerkleExecute, vec![])?;

--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -431,7 +431,7 @@ where
                             "Stage encountered a validation error: {error}"
                         );
 
-                        // When handling errors, we do not commit the database transaction. This
+                        // FIXME: When handling errors, we do not commit the database transaction. This
                         // leads to the Merkle stage not clearing its
                         // checkpoint, and restarting from an invalid place.
                         drop(provider_rw);

--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -431,8 +431,8 @@ where
                             "Stage encountered a validation error: {error}"
                         );
 
-                        // FIXME: When handling errors, we do not commit the database transaction. This
-                        // leads to the Merkle stage not clearing its
+                        // FIXME: When handling errors, we do not commit the database transaction.
+                        // This leads to the Merkle stage not clearing its
                         // checkpoint, and restarting from an invalid place.
                         drop(provider_rw);
                         provider_rw = factory.provider_rw().map_err(PipelineError::Interface)?;

--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -450,6 +450,18 @@ where
                             "Stage encountered an execution error: {error}"
                         );
 
+                        // When handling errors, we do not commit the database transaction. This
+                        // leads to the Merkle stage not clearing its
+                        // checkpoint, and restarting from an invalid place.
+                        provider_rw = factory.provider_rw().map_err(PipelineError::Interface)?;
+                        provider_rw
+                            .save_stage_checkpoint_progress(StageId::MerkleExecute, vec![])?;
+                        provider_rw.save_stage_checkpoint(
+                            StageId::MerkleExecute,
+                            prev_checkpoint.unwrap_or_default(),
+                        )?;
+                        provider_rw.commit()?;
+
                         // We unwind because of an execution error. If the unwind itself fails, we
                         // bail entirely, otherwise we restart the execution loop from the
                         // beginning.


### PR DESCRIPTION


While working on another branch, I noticed that the merkle stage once it fails its validation (related to my branch), it can't really recover since its checkpoint never gets cleared.

This is what happened **before** the logs from the image below.
1. Run first sync
2. Reach tip
3. Re-run the pipeline 
4. Fails MerkleStage and unwinds `AccountHashing` and `StorageHashing`.
5. MerkleUnwind fatal failure with process exit
6. Run again
7. `AccountHashing`
8. `StorageHashing` (you can see its end in the first line of the picture.
9. 
![image](https://github.com/paradigmxyz/reth/assets/93316087/5cadf2c2-0fe0-498e-958e-781c99380a4d)

Proposing that we clear `MerkleStage` checkpoints once we hit a validation error.