### PR TITLE
chore(txpool): export validation constants

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -190,24 +190,6 @@ mod traits;
 /// Common test helpers for mocking a pool
 pub mod test_utils;
 
-// TX_SLOT_SIZE is used to calculate how many data slots a single transaction
-// takes up based on its size. The slots are used as DoS protection, ensuring
-// that validating a new transaction remains a constant operation (in reality
-// O(maxslots), where max slots are 4 currently).
-pub(crate) const TX_SLOT_SIZE: usize = 32 * 1024;
-
-// TX_MAX_SIZE is the maximum size a single transaction can have. This field has
-// non-trivial consequences: larger transactions are significantly harder and
-// more expensive to propagate; larger transactions also take more resources
-// to validate whether they fit into the pool or not.
-pub(crate) const TX_MAX_SIZE: usize = 4 * TX_SLOT_SIZE; //128KB
-
-// Maximum bytecode to permit for a contract
-pub(crate) const MAX_CODE_SIZE: usize = 24576;
-
-// Maximum initcode to permit in a creation transaction and create instructions
-pub(crate) const MAX_INIT_CODE_SIZE: usize = 2 * MAX_CODE_SIZE;
-
 /// A shareable, generic, customizable `TransactionPool` implementation.
 #[derive(Debug)]
 pub struct Pool<V: TransactionValidator, T: TransactionOrdering> {

--- a/crates/transaction-pool/src/validate/constants.rs
+++ b/crates/transaction-pool/src/validate/constants.rs
@@ -1,0 +1,17 @@
+/// TX_SLOT_SIZE is used to calculate how many data slots a single transaction
+/// takes up based on its size. The slots are used as DoS protection, ensuring
+/// that validating a new transaction remains a constant operation (in reality
+/// O(maxslots), where max slots are 4 currently).
+pub const TX_SLOT_SIZE: usize = 32 * 1024;
+
+/// TX_MAX_SIZE is the maximum size a single transaction can have. This field has
+/// non-trivial consequences: larger transactions are significantly harder and
+/// more expensive to propagate; larger transactions also take more resources
+/// to validate whether they fit into the pool or not.
+pub const TX_MAX_SIZE: usize = 4 * TX_SLOT_SIZE; // 128KB
+
+/// Maximum bytecode to permit for a contract
+pub const MAX_CODE_SIZE: usize = 24576;
+
+/// Maximum initcode to permit in a creation transaction and create instructions
+pub const MAX_INIT_CODE_SIZE: usize = 2 * MAX_CODE_SIZE;

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -3,8 +3,11 @@
 use crate::{
     error::InvalidPoolTransactionError,
     traits::{PoolTransaction, TransactionOrigin},
-    validate::{task::ValidationJobSender, TransactionValidatorError, ValidationTask},
-    TransactionValidationOutcome, TransactionValidator, MAX_INIT_CODE_SIZE, TX_MAX_SIZE,
+    validate::{
+        task::ValidationJobSender, TransactionValidatorError, ValidationTask, MAX_INIT_CODE_SIZE,
+        TX_MAX_SIZE,
+    },
+    TransactionValidationOutcome, TransactionValidator,
 };
 use reth_primitives::{
     constants::ETHEREUM_BLOCK_GAS_LIMIT, ChainSpec, InvalidTransactionError, EIP1559_TX_TYPE_ID,

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -10,6 +10,7 @@ use reth_primitives::{
 };
 use std::{fmt, time::Instant};
 
+mod constants;
 mod eth;
 mod task;
 
@@ -18,6 +19,9 @@ pub use eth::{EthTransactionValidator, EthTransactionValidatorBuilder};
 
 /// A spawnable task that performs transaction validation.
 pub use task::ValidationTask;
+
+/// Validation constants.
+pub use constants::{MAX_CODE_SIZE, MAX_INIT_CODE_SIZE, TX_MAX_SIZE, TX_SLOT_SIZE};
 
 /// A Result type returned after checking a transaction's validity.
 #[derive(Debug)]


### PR DESCRIPTION
## Motivation

Re-export validation constants for external use.