### PR TITLE
ci: deny warnings only in lint jobs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
 
 env:
-  RUSTFLAGS: -D warnings
   CARGO_TERM_COLOR: always
 
 concurrency:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,6 @@ on:
 env:
   REPO_NAME: ${{ github.repository_owner }}/reth
   IMAGE_NAME: ${{ github.repository_owner }}/reth
-  RUSTFLAGS: -D warnings
   CARGO_TERM_COLOR: always
   DOCKER_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/reth
   DOCKER_USERNAME: ${{ github.actor }}

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
 
 env:
-  RUSTFLAGS: -D warnings
   CARGO_TERM_COLOR: always
 
 concurrency:

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -4,7 +4,6 @@ on:
     - cron: '0 0 * * *'
 
 env:
-  RUSTFLAGS: -D warnings
   CARGO_TERM_COLOR: always
 
 concurrency:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
 
 env:
-  RUSTFLAGS: -D warnings
   CARGO_TERM_COLOR: always
   GETH_BUILD: 1.12.0-e501b3b0
   SEED: rustethereumethereumrust

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,6 @@ on:
 env:
   REPO_NAME: ${{ github.repository_owner }}/reth
   IMAGE_NAME: ${{ github.repository_owner }}/reth
-  RUSTFLAGS: -D warnings
   CARGO_TERM_COLOR: always
 
 jobs:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
 
 env:
-  RUSTFLAGS: -D warnings
   CARGO_TERM_COLOR: always
   SEED: rustethereumethereumrust
 


### PR DESCRIPTION
Fixes #3976

I've kept `RUSTFLAGS: -D warnings` only in `ci.yml`, `deny.yml` and `sanity.yml`