### PR TITLE
fix: track full_transactions propagation when packet size limited

### DIFF
--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -253,6 +253,7 @@ where
                 }
             }
             let mut new_pooled_hashes = hashes.build();
+            let new_full_transactions = full_transactions.build();
 
             if !new_pooled_hashes.is_empty() {
                 // determine whether to send full tx objects or hashes.
@@ -267,12 +268,15 @@ where
                     // send hashes of transactions
                     self.network.send_transactions_hashes(*peer_id, new_pooled_hashes);
                 } else {
-                    // send full transactions
-                    self.network.send_transactions(*peer_id, full_transactions.build());
-
-                    for hash in new_pooled_hashes.into_iter_hashes() {
-                        propagated.0.entry(hash).or_default().push(PropagateKind::Full(*peer_id));
+                    for tx in new_full_transactions.iter() {
+                        propagated
+                            .0
+                            .entry(tx.hash())
+                            .or_default()
+                            .push(PropagateKind::Full(*peer_id));
                     }
+                    // send full transactions
+                    self.network.send_transactions(*peer_id, new_full_transactions);
                 }
             }
         }

--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -253,7 +253,6 @@ where
                 }
             }
             let mut new_pooled_hashes = hashes.build();
-            let new_full_transactions = full_transactions.build();
 
             if !new_pooled_hashes.is_empty() {
                 // determine whether to send full tx objects or hashes.
@@ -268,6 +267,8 @@ where
                     // send hashes of transactions
                     self.network.send_transactions_hashes(*peer_id, new_pooled_hashes);
                 } else {
+                    let new_full_transactions = full_transactions.build();
+
                     for tx in new_full_transactions.iter() {
                         propagated
                             .0


### PR DESCRIPTION
New to the reth codebase and rust, so feel free to correct any misunderstandings or bad patterns.

In `transactions.rs` when `full_transactions` is being built:

https://github.com/paradigmxyz/reth/blob/f41386d28e89dd436feea872178452e5302314a5/crates/net/network/src/transactions.rs#L249-L254

`hashes` and `full_transactions` can diverge when a `.push()` to the latter is limited by `MAX_FULL_TRANSACTIONS_PACKET_SIZE`

https://github.com/paradigmxyz/reth/blob/f41386d28e89dd436feea872178452e5302314a5/crates/net/network/src/transactions.rs#L636-L640

so when `PropagatedTransactions` is being updated in the snippet below, it sends the limited set `full_transactions` to peers but then updates the tracking with the full tx hash list of `new_pooled_hashes`

https://github.com/paradigmxyz/reth/blob/f41386d28e89dd436feea872178452e5302314a5/crates/net/network/src/transactions.rs#L271-L275