### PR TITLE
fix(tracing): extend Parity tracing VmExecutedOperation

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
@@ -330,7 +330,7 @@ impl ParityTraceBuilder {
 
         let maybe_execution = Some(VmExecutedOperation {
             used: step.gas_cost,
-            push: step.new_stack.map(|new_stack| new_stack.into()),
+            push: step.new_stack.into_iter().map(|new_stack| new_stack.into()).collect(),
             mem: maybe_memory,
             store: maybe_storage,
         });

--- a/crates/rpc/rpc-types/src/eth/trace/parity.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/parity.rs
@@ -315,9 +315,9 @@ pub struct VmExecutedOperation {
     pub store: Option<StorageDelta>,
 }
 
+/// A diff of some chunk of memory.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-/// A diff of some chunk of memory.
 pub struct MemoryDelta {
     /// Offset into memory the change begins.
     pub off: usize,
@@ -325,9 +325,9 @@ pub struct MemoryDelta {
     pub data: Bytes,
 }
 
+/// A diff of some storage value.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-/// A diff of some storage value.
 pub struct StorageDelta {
     pub key: U256,
     pub val: U256,

--- a/crates/rpc/rpc-types/src/eth/trace/parity.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/parity.rs
@@ -308,7 +308,7 @@ pub struct VmExecutedOperation {
     /// The total gas used.
     pub used: u64,
     /// The stack item placed, if any.
-    pub push: Option<H256>,
+    pub push: Vec<H256>,
     /// If altered, the memory delta.
     pub mem: Option<MemoryDelta>,
     /// The altered storage value, if any.
@@ -327,6 +327,7 @@ pub struct MemoryDelta {
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+/// A diff of some storage value.
 pub struct StorageDelta {
     pub key: U256,
     pub val: U256,


### PR DESCRIPTION
Convert VmExecutedOperation::push from Option<_> to Vec<_> as per ethers-rs and erigon implementation

Closes #3883