### PR TITLE
feat(rpc): ots_getBlockDetails and ots_getBlockDetailsByHash

### DIFF
--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -206,12 +206,11 @@ where
     assert!(is_unimplemented(
         OtterscanClient::trace_transaction(client, tx_hash).await.err().unwrap()
     ));
-    assert!(is_unimplemented(
-        OtterscanClient::get_block_details(client, block_number,).await.err().unwrap()
-    ));
-    assert!(is_unimplemented(
-        OtterscanClient::get_block_details_by_hash(client, block_hash).await.err().unwrap()
-    ));
+
+    OtterscanClient::get_block_details(client, block_number).await.unwrap();
+
+    OtterscanClient::get_block_details_by_hash(client, block_hash).await.unwrap();
+
     assert!(is_unimplemented(
         OtterscanClient::get_block_transactions(client, block_number, page_number, page_size,)
             .await

--- a/crates/rpc/rpc-types/src/eth/block.rs
+++ b/crates/rpc/rpc-types/src/eth/block.rs
@@ -20,6 +20,7 @@ pub enum BlockTransactions {
     /// Special case for uncle response.
     Uncle,
 }
+
 impl BlockTransactions {
     /// Check if the enum variant is
     /// used for an uncle response.

--- a/crates/rpc/rpc-types/src/otterscan.rs
+++ b/crates/rpc/rpc-types/src/otterscan.rs
@@ -1,4 +1,4 @@
-use crate::{Block, Transaction, TransactionReceipt};
+use crate::{Block, BlockTransactions, Rich, Transaction, TransactionReceipt};
 use reth_primitives::{Address, Bytes, U256};
 use serde::{Deserialize, Serialize};
 
@@ -36,7 +36,7 @@ pub struct TraceEntry {
 }
 
 /// Internal issuance struct for `BlockDetails` struct
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct InternalIssuance {
     block_reward: U256,
@@ -94,4 +94,26 @@ pub struct TransactionsWithReceipts {
 pub struct ContractCreator {
     tx: Transaction,
     creator: Address,
+}
+
+impl From<Block> for OtsBlock {
+    fn from(block: Block) -> Self {
+        let transaction_count = match &block.transactions {
+            BlockTransactions::Full(t) => t.len(),
+            BlockTransactions::Hashes(t) => t.len(),
+            BlockTransactions::Uncle => 0,
+        };
+
+        Self { block, transaction_count }
+    }
+}
+
+impl From<Rich<Block>> for BlockDetails {
+    fn from(rich_block: Rich<Block>) -> Self {
+        Self {
+            block: rich_block.inner.into(),
+            issuance: Default::default(),
+            total_fees: U256::default(),
+        }
+    }
 }

--- a/crates/rpc/rpc/src/otterscan.rs
+++ b/crates/rpc/rpc/src/otterscan.rs
@@ -59,12 +59,14 @@ where
         &self,
         block_number: BlockNumberOrTag,
     ) -> RpcResult<Option<BlockDetails>> {
-        Err(internal_rpc_err("unimplemented"))
+        let block = self.eth.block_by_number(block_number, true).await?;
+        Ok(block.map(Into::into))
     }
 
     /// Handler for `getBlockDetailsByHash`
     async fn get_block_details_by_hash(&self, block_hash: H256) -> RpcResult<Option<BlockDetails>> {
-        Err(internal_rpc_err("unimplemented"))
+        let block = self.eth.block_by_hash(block_hash, true).await?;
+        Ok(block.map(Into::into))
     }
 
     /// Handler for `getBlockTransactions`


### PR DESCRIPTION
This tackles #3726 by adding the implementations of `ots_getBlockDetails` and `ots_getBlockDetailsByHash`

* Add `ots_getBlockDetails` and `ots_getBlockDetailsByHash` implementation
* Implement From trait for `BlockDetails` from `Rich<Block>`
* Implement From trait for `OtsBlock` from `Block`
* Add Default trait for `InternalIssuance` as a placeholder