### PR TITLE
fix(Makefile): Graceful cargo-nextest install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ COV_FILE := lcov.info
 
 .PHONY: test-unit
 test-unit: ## Run unit tests.
+	cargo install cargo-nextest --locked
 	cargo nextest run $(UNIT_TEST_ARGS)
 
 .PHONY: cov-unit


### PR DESCRIPTION
Addresses #4008.

This PR is a very simple addition to the `Makefile` to install the `cargo-nextest` bin prior to executing unit tests with `cargo nextest ...`