### PR TITLE
Fix: successful execution of 'reth stage --commit' did not write results to the database

### DIFF
--- a/bin/reth/src/stage/run.rs
+++ b/bin/reth/src/stage/run.rs
@@ -265,6 +265,10 @@ impl Command {
             }
         }
 
+        if self.commit {
+            provider_rw.commit()?;
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
I followed the steps below to execute reth：
```
    reth stage drop execution
    reth stage run --commit --from 1 --to 50482 execution
    reth stage run --commit --from 50481 --to 50493 execution
```
Then I got the following error:
```
2023-08-02T06:25:09.715660Z  INFO reth::cli: reth 0.1.0-alpha.4 (b46101af) starting stage Execution
2023-08-02T06:25:09.715735Z  INFO reth::cli: Opening database path="/home/andy/.local/share/reth/mainnet/db"
2023-08-02T06:25:09.724520Z  INFO reth::cli: Database opened
Error: Stage encountered a execution error in block 50483: EVM reported invalid transaction (0x0000000000000000000000000000000000000000000000000000000000000000): Transaction(LackOfFundForGasLimit { gas_limit: 0x0000000000000000000000000000000000000000000000000df2e8f61e925fb0_U256, balance: 0x0000000000000000000000000000000000000000000000000000000000000000_U256 }).

Caused by:
    EVM reported invalid transaction (0x0000000000000000000000000000000000000000000000000000000000000000): Transaction(LackOfFundForGasLimit { gas_limit: 0x0000000000000000000000000000000000000000000000000df2e8f61e925fb0_U256, balance: 0x0000000000000000000000000000000000000000000000000000000000000000_U256 })

Location:
    /home/andy/Source/work/reth/bin/reth/src/stage/run.rs:267:13
```

I found that even with the --commit option, the results are only written to the database when the stage execute fails（To be precise, it couldn't be executed all at once）.