### PR TITLE
chore: dont penalize on dropped connections

### DIFF
--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -491,7 +491,8 @@ where
             RequestError::UnsupportedCapability => ReputationChangeKind::BadProtocol,
             RequestError::Timeout => ReputationChangeKind::Timeout,
             RequestError::ChannelClosed | RequestError::ConnectionDropped => {
-                ReputationChangeKind::Dropped
+                // peer is already disconnected
+                return
             }
             RequestError::BadResponse => ReputationChangeKind::BadTransactions,
         };
@@ -561,7 +562,8 @@ where
                     this.on_request_error(req.peer_id, req_err);
                 }
                 Poll::Ready(Err(_)) => {
-                    this.on_request_error(req.peer_id, RequestError::ConnectionDropped)
+                    // request channel closed/dropped
+                    this.on_request_error(req.peer_id, RequestError::ChannelClosed)
                 }
             }
         }


### PR DESCRIPTION
we're currently penalizing on dropped connections/closed channels

this is not useful since the connection to the peer is already terminated at that point