### PR TITLE
feat: add flag to CLI to disable colour coding of console output

### DIFF
--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -84,7 +84,8 @@ impl<Ext: RethCliExt> Cli<Ext> {
     /// If file logging is enabled, this function returns a guard that must be kept alive to ensure
     /// that all logs are flushed to disk.
     pub fn init_tracing(&self) -> eyre::Result<Option<FileWorkerGuard>> {
-        let mut layers = vec![reth_tracing::stdout(self.verbosity.directive())];
+        let mut layers =
+            vec![reth_tracing::stdout(self.verbosity.directive(), self.logs.not_coloured)];
         let guard = self.logs.layer()?.map(|(layer, guard)| {
             layers.push(layer);
             guard
@@ -158,6 +159,10 @@ pub struct Logs {
     /// The filter to use for logs written to the log file.
     #[arg(long = "log.filter", value_name = "FILTER", global = true, default_value = "error")]
     filter: String,
+
+    /// The flag to disable colour coding of console output.
+    #[arg(long = "log.not-coloured", global = true)]
+    not_coloured: bool,
 }
 
 impl Logs {

--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -231,7 +231,7 @@ impl Verbosity {
 }
 
 /// The color mode for the cli.
-#[derive(Debug, Copy, Clone, ValueEnum)]
+#[derive(Debug, Copy, Clone, ValueEnum, Eq, PartialEq)]
 pub enum ColorMode {
     /// Colors on
     Always,
@@ -255,6 +255,12 @@ impl Display for ColorMode {
 mod tests {
     use super::*;
     use clap::CommandFactory;
+
+    #[test]
+    fn parse_color_mode() {
+        let reth = Cli::<()>::try_parse_from(["reth", "node", "--color", "always"]).unwrap();
+        assert_eq!(reth.logs.color, ColorMode::Always);
+    }
 
     /// Tests that the help message is parsed correctly. This ensures that clap args are configured
     /// correctly and no conflicts are introduced via attributes that would result in a panic at

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -43,13 +43,14 @@ pub fn init(layers: Vec<BoxedLayer<Registry>>) {
 ///
 /// Colors can be disabled with `RUST_LOG_STYLE=never`, and event targets can be displayed with
 /// `RUST_LOG_TARGET=1`.
-pub fn stdout<S>(default_directive: impl Into<Directive>) -> BoxedLayer<S>
+pub fn stdout<S>(default_directive: impl Into<Directive>, not_colored: bool) -> BoxedLayer<S>
 where
     S: Subscriber,
     for<'a> S: LookupSpan<'a>,
 {
     // TODO: Auto-detect
-    let with_ansi = std::env::var("RUST_LOG_STYLE").map(|val| val != "never").unwrap_or(true);
+    let with_ansi =
+        std::env::var("RUST_LOG_STYLE").map(|val| val != "never").unwrap_or(!not_colored);
     let with_target = std::env::var("RUST_LOG_TARGET").map(|val| val != "0").unwrap_or(true);
 
     let filter =

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -43,14 +43,14 @@ pub fn init(layers: Vec<BoxedLayer<Registry>>) {
 ///
 /// Colors can be disabled with `RUST_LOG_STYLE=never`, and event targets can be displayed with
 /// `RUST_LOG_TARGET=1`.
-pub fn stdout<S>(default_directive: impl Into<Directive>, not_colored: bool) -> BoxedLayer<S>
+pub fn stdout<S>(default_directive: impl Into<Directive>, not_coloured: bool) -> BoxedLayer<S>
 where
     S: Subscriber,
     for<'a> S: LookupSpan<'a>,
 {
     // TODO: Auto-detect
     let with_ansi =
-        std::env::var("RUST_LOG_STYLE").map(|val| val != "never").unwrap_or(!not_colored);
+        std::env::var("RUST_LOG_STYLE").map(|val| val != "never").unwrap_or(!not_coloured);
     let with_target = std::env::var("RUST_LOG_TARGET").map(|val| val != "0").unwrap_or(true);
 
     let filter =

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -43,14 +43,14 @@ pub fn init(layers: Vec<BoxedLayer<Registry>>) {
 ///
 /// Colors can be disabled with `RUST_LOG_STYLE=never`, and event targets can be displayed with
 /// `RUST_LOG_TARGET=1`.
-pub fn stdout<S>(default_directive: impl Into<Directive>, not_coloured: bool) -> BoxedLayer<S>
+pub fn stdout<S>(default_directive: impl Into<Directive>, color: &str) -> BoxedLayer<S>
 where
     S: Subscriber,
     for<'a> S: LookupSpan<'a>,
 {
     // TODO: Auto-detect
     let with_ansi =
-        std::env::var("RUST_LOG_STYLE").map(|val| val != "never").unwrap_or(!not_coloured);
+        std::env::var("RUST_LOG_STYLE").map(|val| val != "never").unwrap_or(color != "never");
     let with_target = std::env::var("RUST_LOG_TARGET").map(|val| val != "0").unwrap_or(true);
 
     let filter =


### PR DESCRIPTION
Closes #4030 

This PR adds a flag `--log.not-coloured` to the CLI to disable the colour coding of console output.