### PR TITLE
fix: validate headers in full block downloader

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -26,7 +26,7 @@ use reth_primitives::{
     Head, Header, SealedBlock, SealedHeader, H256, U256,
 };
 use reth_provider::{
-    BlockIdReader, BlockReader, BlockSource, CanonChainTracker, ProviderError,
+    BlockIdReader, BlockReader, BlockSource, CanonChainTracker, ChainSpecProvider, ProviderError,
     StageCheckpointReader,
 };
 use reth_prune::Pruner;
@@ -208,6 +208,7 @@ where
         + BlockIdReader
         + CanonChainTracker
         + StageCheckpointReader
+        + ChainSpecProvider
         + 'static,
     Client: HeadersClient + BodiesClient + Clone + Unpin + 'static,
 {
@@ -279,6 +280,7 @@ where
             task_spawner.clone(),
             run_pipeline_continuously,
             max_block,
+            blockchain.chain_spec(),
         );
         let prune = pruner.map(|pruner| EnginePruneController::new(pruner, task_spawner));
         let mut this = Self {
@@ -1651,6 +1653,7 @@ where
         + BlockIdReader
         + CanonChainTracker
         + StageCheckpointReader
+        + ChainSpecProvider
         + Unpin
         + 'static,
 {

--- a/crates/interfaces/src/consensus.rs
+++ b/crates/interfaces/src/consensus.rs
@@ -31,6 +31,28 @@ pub trait Consensus: Debug + Send + Sync {
         parent: &SealedHeader,
     ) -> Result<(), ConsensusError>;
 
+    /// Validates the given headers
+    ///
+    /// This ensures that the first header is valid on its own and all subsequent headers are valid
+    /// on its own and valid against its parent.
+    ///
+    /// Note: this expects that the headers are in natural order (ascending block number)
+    fn validate_header_range(&self, headers: &[SealedHeader]) -> Result<(), ConsensusError> {
+        if headers.is_empty() {
+            return Ok(())
+        }
+        let first = headers.first().expect("checked empty");
+        self.validate_header(first)?;
+        let mut parent = first;
+        for child in headers.iter().skip(1) {
+            self.validate_header(child)?;
+            self.validate_header_against_parent(child, parent)?;
+            parent = child;
+        }
+
+        Ok(())
+    }
+
     /// Validate if the header is correct and follows the consensus specification, including
     /// computed properties (like total difficulty).
     ///


### PR DESCRIPTION
not sure if this is the exact root cause of 

https://github.com/paradigmxyz/reth/issues/3991

but it could explain it, nevertheless, this adds missing header validation in full block downloader which previously could lead to endless peer penalization if the downloaded header range was invalid.

I'd even consider removing penalization from this impl entirely, 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 829c5e9</samp>

This pull request adds the `ChainSpecProvider` and `validate_header_range()` features to the consensus and p2p interfaces, and implements them for the beacon engine and the full block client. These features allow the validation and sealing of block headers according to the chain specification parameters. The pull request also refactors some code to improve the sync logic and the test pipeline.