### PR TITLE
perf: improve ipc poll logic

### DIFF
--- a/crates/rpc/ipc/src/server/connection.rs
+++ b/crates/rpc/ipc/src/server/connection.rs
@@ -1,7 +1,7 @@
 //! A IPC connection.
 
 use crate::stream_codec::StreamCodec;
-use futures::{ready, stream::FuturesUnordered, Sink, Stream, StreamExt};
+use futures::{ready, stream::FuturesUnordered, FutureExt, Sink, Stream, StreamExt};
 use std::{
     collections::VecDeque,
     future::Future,
@@ -129,8 +129,9 @@ pub(crate) struct IpcConnDriver<T, S, Fut> {
     #[pin]
     pub(crate) conn: IpcConn<JsonRpcStream<T>>,
     pub(crate) service: S,
+    /// rpc requests in progress
     #[pin]
-    pub(crate) pending_calls: FuturesUnordered<Fut>,
+    pub(crate) active_requests: FuturesUnordered<Fut>,
     pub(crate) items: VecDeque<String>,
 }
 
@@ -145,7 +146,7 @@ impl<T, S> Future for IpcConnDriver<T, S, S::Future>
 where
     S: Service<String, Response = Option<String>> + Send + 'static,
     S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
-    S::Future: Send,
+    S::Future: Send + Unpin,
     T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
     type Output = ();
@@ -153,20 +154,21 @@ where
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut this = self.project();
 
-        loop {
-            // process calls
-            if !this.pending_calls.is_empty() {
-                while let Poll::Ready(Some(res)) = this.pending_calls.as_mut().poll_next(cx) {
-                    let item = match res {
-                        Ok(Some(resp)) => resp,
-                        Ok(None) => continue,
-                        Err(err) => err.into().to_string(),
-                    };
-                    this.items.push_back(item);
-                }
+        // items are also pushed from external
+        // this will act as a manual yield point to reduce latencies of the polling future that may
+        // submit items from an additional source (subscription)
+        let mut budget = 5;
+
+        // ensure we still have enough budget for another iteration
+        'outer: loop {
+            budget -= 1;
+            if budget == 0 {
+                // make sure we're woken up again
+                cx.waker().wake_by_ref();
+                return Poll::Pending
             }
 
-            // write to the sink
+            // write all responses to the sink
             while this.conn.as_mut().poll_ready(cx).is_ready() {
                 if let Some(item) = this.items.pop_front() {
                     if let Err(err) = this.conn.as_mut().start_send(item) {
@@ -178,17 +180,56 @@ where
                 }
             }
 
-            // read from the stream
-            match ready!(this.conn.as_mut().poll_next(cx)) {
-                Some(Ok(item)) => {
-                    let call = this.service.call(item);
-                    this.pending_calls.push(call);
+            'inner: loop {
+                let mut drained = false;
+                // drain all calls that are ready and put them in the output item queue
+                if !this.active_requests.is_empty() {
+                    if let Poll::Ready(Some(res)) = this.active_requests.as_mut().poll_next(cx) {
+                        let item = match res {
+                            Ok(Some(resp)) => resp,
+                            Ok(None) => continue 'inner,
+                            Err(err) => err.into().to_string(),
+                        };
+                        this.items.push_back(item);
+                        continue 'outer
+                    } else {
+                        drained = true;
+                    }
                 }
-                Some(Err(err)) => {
-                    tracing::warn!("IPC request failed: {:?}", err);
-                    return Poll::Ready(())
+
+                // read from the stream
+                match this.conn.as_mut().poll_next(cx) {
+                    Poll::Ready(res) => match res {
+                        Some(Ok(item)) => {
+                            let mut call = this.service.call(item);
+                            match call.poll_unpin(cx) {
+                                Poll::Ready(res) => {
+                                    let item = match res {
+                                        Ok(Some(resp)) => resp,
+                                        Ok(None) => continue 'inner,
+                                        Err(err) => err.into().to_string(),
+                                    };
+                                    this.items.push_back(item);
+                                    continue 'outer
+                                }
+                                Poll::Pending => {
+                                    this.active_requests.push(call);
+                                }
+                            }
+                        }
+                        Some(Err(err)) => {
+                            tracing::warn!("IPC request failed: {:?}", err);
+                            return Poll::Ready(())
+                        }
+                        None => return Poll::Ready(()),
+                    },
+                    Poll::Pending => {
+                        if drained || this.active_requests.is_empty() {
+                            // at this point all things are pending
+                            return Poll::Pending
+                        }
+                    }
                 }
-                None => return Poll::Ready(()),
             }
         }
     }

--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -292,7 +292,7 @@ async fn spawn_connection<S, T>(
 ) where
     S: Service<String, Response = Option<String>> + Send + 'static,
     S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
-    S::Future: Send,
+    S::Future: Send + Unpin,
     T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
     let task = tokio::task::spawn(async move {
@@ -300,7 +300,7 @@ async fn spawn_connection<S, T>(
         let conn = IpcConnDriver {
             conn,
             service,
-            pending_calls: Default::default(),
+            active_requests: Default::default(),
             items: Default::default(),
         };
         tokio::pin!(conn, rx_item);

--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -300,7 +300,7 @@ async fn spawn_connection<S, T>(
         let conn = IpcConnDriver {
             conn,
             service,
-            active_requests: Default::default(),
+            pending_calls: Default::default(),
             items: Default::default(),
         };
         tokio::pin!(conn, rx_item);


### PR DESCRIPTION
improve poll logic of ipc connection

this makes it slightly more complicated but now priorities output over input, since output is the real bottleneck if input is high.

ref #4028