### PR TITLE
fix(engine, pruner): prune poll logic, history indices

### DIFF
--- a/crates/consensus/beacon/src/engine/forkchoice.rs
+++ b/crates/consensus/beacon/src/engine/forkchoice.rs
@@ -51,6 +51,18 @@ impl ForkchoiceStateTracker {
         self.latest_status().map(|s| s.is_valid()).unwrap_or(false)
     }
 
+    /// Returns whether the latest received FCU is syncing: [ForkchoiceStatus::Syncing]
+    #[allow(unused)]
+    pub(crate) fn is_latest_syncing(&self) -> bool {
+        self.latest_status().map(|s| s.is_syncing()).unwrap_or(false)
+    }
+
+    /// Returns whether the latest received FCU is syncing: [ForkchoiceStatus::Invalid]
+    #[allow(unused)]
+    pub(crate) fn is_latest_invalid(&self) -> bool {
+        self.latest_status().map(|s| s.is_invalid()).unwrap_or(false)
+    }
+
     /// Returns the last valid head hash.
     #[allow(unused)]
     pub(crate) fn last_valid_head(&self) -> Option<H256> {
@@ -96,6 +108,10 @@ pub enum ForkchoiceStatus {
 impl ForkchoiceStatus {
     pub(crate) fn is_valid(&self) -> bool {
         matches!(self, ForkchoiceStatus::Valid)
+    }
+
+    pub(crate) fn is_invalid(&self) -> bool {
+        matches!(self, ForkchoiceStatus::Invalid)
     }
 
     pub(crate) fn is_syncing(&self) -> bool {

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1715,12 +1715,13 @@ where
 
             // Poll prune controller if all conditions are met:
             // 1. Pipeline is idle
-            // 2. Pruning is running and we need to prioritize checking its events OR no engine and
-            //  sync messages are pending and we may start pruning
-            // 3. Latest FCU status is VALID
+            // 2. Either of two:
+            //  1. Pruning is running and we need to prioritize checking its events
+            //  2. Both engine and sync messages are pending AND latest FCU status is VALID, so we
+            //     may start pruning
             if this.sync.is_pipeline_idle() &&
-                (this.is_prune_active() || is_pending) &&
-                this.forkchoice_state_tracker.is_latest_valid()
+                (this.is_prune_active() ||
+                    is_pending && this.forkchoice_state_tracker.is_latest_valid())
             {
                 if let Some(ref mut prune) = this.prune {
                     match prune.poll(cx, this.blockchain.canonical_tip().number) {

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1717,11 +1717,11 @@ where
             // 1. Pipeline is idle
             // 2. Either of two:
             //  1. Pruning is running and we need to prioritize checking its events
-            //  2. Both engine and sync messages are pending AND latest FCU status is VALID, so we
-            //     may start pruning
+            //  2. Both engine and sync messages are pending AND latest FCU status is not INVALID,
+            //     so we may start pruning
             if this.sync.is_pipeline_idle() &&
                 (this.is_prune_active() ||
-                    is_pending && this.forkchoice_state_tracker.is_latest_valid())
+                    is_pending && !this.forkchoice_state_tracker.is_latest_invalid())
             {
                 if let Some(ref mut prune) = this.prune {
                     match prune.poll(cx, this.blockchain.canonical_tip().number) {

--- a/crates/prune/src/pruner.rs
+++ b/crates/prune/src/pruner.rs
@@ -528,7 +528,7 @@ impl<DB: Database> Pruner<DB> {
                             // with the previous shard.
                             if let Some(prev_value) = cursor
                                 .prev()?
-                                .filter(|(prev_key, _)| key_matches(&prev_key, &key))
+                                .filter(|(prev_key, _)| key_matches(prev_key, &key))
                                 .map(|(_, prev_value)| prev_value)
                             {
                                 cursor.delete_current()?;

--- a/crates/prune/src/pruner.rs
+++ b/crates/prune/src/pruner.rs
@@ -241,11 +241,11 @@ impl<DB: Database> Pruner<DB> {
         provider.prune_table_with_iterator_in_batches::<tables::Receipts>(
             range,
             self.batch_sizes.receipts,
-            |entries| {
-                processed += entries;
+            |rows| {
+                processed += rows;
                 trace!(
                     target: "pruner",
-                    %entries,
+                    %rows,
                     progress = format!("{:.1}%", 100.0 * processed as f64 / total as f64),
                     "Pruned receipts"
                 );
@@ -306,11 +306,11 @@ impl<DB: Database> Pruner<DB> {
             // Pre-sort hashes to prune them in order
             hashes.sort_unstable();
 
-            let entries = provider.prune_table_with_iterator::<tables::TxHashNumber>(hashes)?;
-            processed += entries;
+            let rows = provider.prune_table_with_iterator::<tables::TxHashNumber>(hashes)?;
+            processed += rows;
             trace!(
                 target: "pruner",
-                %entries,
+                %rows,
                 progress = format!("{:.1}%", 100.0 * processed as f64 / total as f64),
                 "Pruned transaction lookup"
             );
@@ -349,11 +349,11 @@ impl<DB: Database> Pruner<DB> {
         provider.prune_table_with_range_in_batches::<tables::TxSenders>(
             range,
             self.batch_sizes.transaction_senders,
-            |entries, _| {
-                processed += entries;
+            |rows, _| {
+                processed += rows;
                 trace!(
                     target: "pruner",
-                    %entries,
+                    %rows,
                     progress = format!("{:.1}%", 100.0 * processed as f64 / total as f64),
                     "Pruned transaction senders"
                 );
@@ -402,10 +402,10 @@ impl<DB: Database> Pruner<DB> {
             |a, b| a.key == b.key,
             |key| ShardedKey::last(key.key),
             self.batch_sizes.account_history,
-            |entries| {
+            |rows| {
                 trace!(
                     target: "pruner",
-                    entries,
+                    rows,
                     "Pruned account history (indices)"
                 );
             },
@@ -454,10 +454,10 @@ impl<DB: Database> Pruner<DB> {
             |a, b| a.address == b.address && a.sharded_key.key == b.sharded_key.key,
             |key| StorageShardedKey::last(key.address, key.sharded_key.key),
             self.batch_sizes.storage_history,
-            |entries| {
+            |rows| {
                 trace!(
                     target: "pruner",
-                    entries,
+                    rows,
                     "Pruned storage history (indices)"
                 );
             },

--- a/crates/prune/src/pruner.rs
+++ b/crates/prune/src/pruner.rs
@@ -386,10 +386,11 @@ impl<DB: Database> Pruner<DB> {
         provider.prune_table_with_range_in_batches::<tables::AccountChangeSet>(
             range,
             self.batch_sizes.account_history,
-            |keys, _| {
+            |keys, rows| {
                 trace!(
                     target: "pruner",
                     %keys,
+                    %rows,
                     progress = format!("{:.1}%", 100.0 * keys as f64 / total as f64),
                     "Pruned account history (changesets)"
                 );
@@ -438,10 +439,11 @@ impl<DB: Database> Pruner<DB> {
         provider.prune_table_with_range_in_batches::<tables::StorageChangeSet>(
             range,
             self.batch_sizes.storage_history,
-            |keys, _| {
+            |keys, rows| {
                 trace!(
                     target: "pruner",
                     %keys,
+                    %rows,
                     progress = format!("{:.1}%", 100.0 * keys as f64 / total as f64),
                     "Pruned storage history (changesets)"
                 );

--- a/crates/prune/src/pruner.rs
+++ b/crates/prune/src/pruner.rs
@@ -349,7 +349,7 @@ impl<DB: Database> Pruner<DB> {
         provider.prune_table_with_range_in_batches::<tables::TxSenders>(
             range,
             self.batch_sizes.transaction_senders,
-            |entries| {
+            |entries, _| {
                 processed += entries;
                 trace!(
                     target: "pruner",
@@ -383,16 +383,14 @@ impl<DB: Database> Pruner<DB> {
         let range = from_block..=to_block;
         let total = range.clone().count();
 
-        let mut processed = 0;
         provider.prune_table_with_range_in_batches::<tables::AccountChangeSet>(
             range,
             self.batch_sizes.account_history,
-            |entries| {
-                processed += entries;
+            |keys, _| {
                 trace!(
                     target: "pruner",
-                    %entries,
-                    progress = format!("{:.1}%", 100.0 * processed as f64 / total as f64),
+                    %keys,
+                    progress = format!("{:.1}%", 100.0 * keys as f64 / total as f64),
                     "Pruned account history (changesets)"
                 );
             },
@@ -437,16 +435,14 @@ impl<DB: Database> Pruner<DB> {
         let total = block_range.clone().count();
         let range = BlockNumberAddress::range(block_range);
 
-        let mut processed = 0;
         provider.prune_table_with_range_in_batches::<tables::StorageChangeSet>(
             range,
             self.batch_sizes.storage_history,
-            |entries| {
-                processed += entries;
+            |keys, _| {
                 trace!(
                     target: "pruner",
-                    %entries,
-                    progress = format!("{:.1}%", 100.0 * processed as f64 / total as f64),
+                    %keys,
+                    progress = format!("{:.1}%", 100.0 * keys as f64 / total as f64),
                     "Pruned storage history (changesets)"
                 );
             },

--- a/crates/prune/src/pruner.rs
+++ b/crates/prune/src/pruner.rs
@@ -81,6 +81,11 @@ impl<DB: Database> Pruner<DB> {
 
     /// Run the pruner
     pub fn run(&mut self, tip_block_number: BlockNumber) -> PrunerResult {
+        trace!(
+            target: "pruner",
+            %tip_block_number,
+            "Pruner started"
+        );
         let start = Instant::now();
 
         let provider = self.provider_factory.provider_rw()?;
@@ -143,8 +148,15 @@ impl<DB: Database> Pruner<DB> {
         provider.commit()?;
         self.last_pruned_block_number = Some(tip_block_number);
 
-        self.metrics.pruner.duration_seconds.record(start.elapsed());
+        let elapsed = start.elapsed();
+        self.metrics.pruner.duration_seconds.record(elapsed);
 
+        trace!(
+            target: "pruner",
+            %tip_block_number,
+            ?elapsed,
+            "Pruner finished"
+        );
         Ok(())
     }
 

--- a/crates/prune/src/pruner.rs
+++ b/crates/prune/src/pruner.rs
@@ -433,7 +433,6 @@ impl<DB: Database> Pruner<DB> {
             .map(|checkpoint| checkpoint.block_number + 1)
             .unwrap_or_default();
         let block_range = from_block..=to_block;
-        let total = block_range.clone().count();
         let range = BlockNumberAddress::range(block_range);
 
         provider.prune_table_with_range_in_batches::<tables::StorageChangeSet>(
@@ -444,7 +443,6 @@ impl<DB: Database> Pruner<DB> {
                     target: "pruner",
                     %keys,
                     %rows,
-                    progress = format!("{:.1}%", 100.0 * keys as f64 / total as f64),
                     "Pruned storage history (changesets)"
                 );
             },

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -660,33 +660,39 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> DatabaseProvider<'this, TX> {
     }
 
     /// Prune the table for the specified key range, calling `chunk_callback` after every
-    /// `batch_size` pruned rows.
+    /// `batch_size` pruned rows with .
     ///
     /// Returns number of rows pruned.
     pub fn prune_table_with_range_in_batches<T: Table>(
         &self,
         keys: impl RangeBounds<T::Key>,
         batch_size: usize,
-        mut batch_callback: impl FnMut(usize),
-    ) -> std::result::Result<usize, DatabaseError> {
+        mut batch_callback: impl FnMut(usize, usize),
+    ) -> std::result::Result<(), DatabaseError> {
         let mut cursor = self.tx.cursor_write::<T>()?;
         let mut walker = cursor.walk_range(keys)?;
-        let mut deleted = 0;
+        let mut deleted_keys = 0;
+        let mut deleted_rows = 0;
+        let mut previous_key = None;
 
-        while walker.next().transpose()?.is_some() {
+        while let Some((key, _)) = walker.next().transpose()? {
             walker.delete_current()?;
-            deleted += 1;
+            deleted_rows += 1;
+            if previous_key.as_ref().map(|previous_key| previous_key != &key).unwrap_or(true) {
+                deleted_keys += 1;
+                previous_key = Some(key);
+            }
 
-            if deleted % batch_size == 0 {
-                batch_callback(batch_size);
+            if deleted_rows % batch_size == 0 {
+                batch_callback(deleted_keys, deleted_rows);
             }
         }
 
-        if deleted % batch_size != 0 {
-            batch_callback(deleted % batch_size);
+        if deleted_rows % batch_size != 0 {
+            batch_callback(deleted_keys, deleted_rows);
         }
 
-        Ok(deleted)
+        Ok(())
     }
 
     /// Load shard and remove it. If list is empty, last shard was full or

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -660,7 +660,8 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> DatabaseProvider<'this, TX> {
     }
 
     /// Prune the table for the specified key range, calling `chunk_callback` after every
-    /// `batch_size` pruned rows with .
+    /// `batch_size` pruned rows with number of total unique keys and total rows pruned. For dupsort
+    /// tables, these numbers will be different as one key can correspond to multiple rows.
     ///
     /// Returns number of rows pruned.
     pub fn prune_table_with_range_in_batches<T: Table>(


### PR DESCRIPTION
This PR fixes several bugs:
1. Engine poll logic changes in https://github.com/paradigmxyz/reth/pull/3954 were incorrect, because during the pruning we reply `SYNCING` to FCU requests, so pruner didn't ever stop.
2. History indices pruner didn't clean up the last shard if no more blocks are left in it.
3. History indices pruner updated the shard even if no blocks were changed in it.
4. History indices pruner reported percentage progress incorrectly for dupsort tables.

Also, history indices pruning can be unified into one generic function, as the shard pruning logic is the same between account and storage history.