### PR TITLE
feat(pipeline): prune receipts based on log emitters

### DIFF
--- a/bin/reth/src/args/pruning_args.rs
+++ b/bin/reth/src/args/pruning_args.rs
@@ -37,7 +37,7 @@ impl PruningArgs {
                         chain_spec
                             .deposit_contract
                             .as_ref()
-                            .map(|contract| (PruneMode::Before(contract.block), contract.address))
+                            .map(|contract| (contract.address, PruneMode::Before(contract.block)))
                             .into_iter()
                             .collect(),
                     ),

--- a/bin/reth/src/args/pruning_args.rs
+++ b/bin/reth/src/args/pruning_args.rs
@@ -2,7 +2,9 @@
 
 use clap::Args;
 use reth_config::config::PruneConfig;
-use reth_primitives::{ChainSpec, ContractLogsPruneConfig, PruneMode, PruneModes};
+use reth_primitives::{
+    ChainSpec, ContractLogsPruneConfig, PruneMode, PruneModes, MINIMUM_PRUNING_DISTANCE,
+};
 use std::sync::Arc;
 
 /// Parameters for pruning and full node
@@ -23,14 +25,14 @@ impl PruningArgs {
             Some(PruneConfig {
                 block_interval: 5,
                 parts: PruneModes {
-                    sender_recovery: Some(PruneMode::Distance(128)),
+                    sender_recovery: Some(PruneMode::Distance(MINIMUM_PRUNING_DISTANCE)),
                     transaction_lookup: None,
                     receipts: chain_spec
                         .deposit_contract
                         .as_ref()
                         .map(|contract| PruneMode::Before(contract.block)),
-                    account_history: Some(PruneMode::Distance(128)),
-                    storage_history: Some(PruneMode::Distance(128)),
+                    account_history: Some(PruneMode::Distance(MINIMUM_PRUNING_DISTANCE)),
+                    storage_history: Some(PruneMode::Distance(MINIMUM_PRUNING_DISTANCE)),
                     contract_logs_filter: ContractLogsPruneConfig(
                         chain_spec
                             .deposit_contract

--- a/bin/reth/src/args/pruning_args.rs
+++ b/bin/reth/src/args/pruning_args.rs
@@ -2,7 +2,7 @@
 
 use clap::Args;
 use reth_config::config::PruneConfig;
-use reth_primitives::{ChainSpec, PruneMode, PruneModes};
+use reth_primitives::{ChainSpec, ContractLogPart, PruneMode, PruneModes};
 use std::sync::Arc;
 
 /// Parameters for pruning and full node
@@ -31,13 +31,14 @@ impl PruningArgs {
                         .map(|contract| PruneMode::Before(contract.block)),
                     account_history: Some(PruneMode::Distance(128)),
                     storage_history: Some(PruneMode::Distance(128)),
-                    only_contract_logs: chain_spec
-                        .deposit_contract
-                        .as_ref()
-                        .map(|contract| vec![(contract.block, vec![contract.address])])
-                        .into_iter()
-                        .flatten()
-                        .collect(),
+                    only_contract_logs: ContractLogPart(
+                        chain_spec
+                            .deposit_contract
+                            .as_ref()
+                            .map(|contract| (PruneMode::Before(contract.block), contract.address))
+                            .into_iter()
+                            .collect(),
+                    ),
                 },
             })
         } else {

--- a/bin/reth/src/args/pruning_args.rs
+++ b/bin/reth/src/args/pruning_args.rs
@@ -2,7 +2,7 @@
 
 use clap::Args;
 use reth_config::config::PruneConfig;
-use reth_primitives::{ChainSpec, ContractLogPart, PruneMode, PruneModes};
+use reth_primitives::{ChainSpec, ContractLogsPruneConfig, PruneMode, PruneModes};
 use std::sync::Arc;
 
 /// Parameters for pruning and full node
@@ -31,7 +31,7 @@ impl PruningArgs {
                         .map(|contract| PruneMode::Before(contract.block)),
                     account_history: Some(PruneMode::Distance(128)),
                     storage_history: Some(PruneMode::Distance(128)),
-                    only_contract_logs: ContractLogPart(
+                    contract_logs_filter: ContractLogsPruneConfig(
                         chain_spec
                             .deposit_contract
                             .as_ref()

--- a/bin/reth/src/args/pruning_args.rs
+++ b/bin/reth/src/args/pruning_args.rs
@@ -31,6 +31,13 @@ impl PruningArgs {
                         .map(|contract| PruneMode::Before(contract.block)),
                     account_history: Some(PruneMode::Distance(128)),
                     storage_history: Some(PruneMode::Distance(128)),
+                    only_contract_logs: chain_spec
+                        .deposit_contract
+                        .as_ref()
+                        .map(|contract| vec![(contract.block, vec![contract.address])])
+                        .into_iter()
+                        .flatten()
+                        .collect(),
                 },
             })
         } else {

--- a/bin/reth/src/debug_cmd/execution.rs
+++ b/bin/reth/src/debug_cmd/execution.rs
@@ -147,7 +147,7 @@ impl Command {
                         .clean_threshold
                         .max(stage_conf.account_hashing.clean_threshold)
                         .max(stage_conf.storage_hashing.clean_threshold),
-                    config.prune.map(|prune| prune.parts).unwrap_or_default(),
+                    config.prune.as_ref().map(|prune| prune.parts.clone()).unwrap_or_default(),
                 )),
             )
             .build(db, self.chain.clone());

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -301,7 +301,8 @@ impl<Ext: RethCliExt> Command<Ext> {
             None
         };
 
-        let prune_config = self.pruning.prune_config(Arc::clone(&self.chain)).or(config.prune);
+        let prune_config =
+            self.pruning.prune_config(Arc::clone(&self.chain)).or(config.prune.clone());
 
         // Configure the pipeline
         let (mut pipeline, client) = if self.dev.dev {
@@ -337,7 +338,7 @@ impl<Ext: RethCliExt> Command<Ext> {
                     db.clone(),
                     &ctx.task_executor,
                     metrics_tx,
-                    prune_config,
+                    prune_config.clone(),
                     max_block,
                 )
                 .await?;
@@ -357,7 +358,7 @@ impl<Ext: RethCliExt> Command<Ext> {
                     db.clone(),
                     &ctx.task_executor,
                     metrics_tx,
-                    prune_config,
+                    prune_config.clone(),
                     max_block,
                 )
                 .await?;

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -279,7 +279,7 @@ impl Default for IndexHistoryConfig {
 }
 
 /// Pruning configuration.
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Serialize)]
 #[serde(default)]
 pub struct PruneConfig {
     /// Minimum pruning interval measured in blocks.

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -80,7 +80,7 @@ pub use net::{
 };
 pub use peer::{PeerId, WithPeerId};
 pub use prune::{
-    ContractLogPart, PruneCheckpoint, PruneMode, PruneModes, PrunePart, PrunePartError,
+    ContractLogsPruneConfig, PruneCheckpoint, PruneMode, PruneModes, PrunePart, PrunePartError,
 };
 pub use receipt::{Receipt, ReceiptWithBloom, ReceiptWithBloomRef};
 pub use revm_primitives::JumpMap;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -81,6 +81,7 @@ pub use net::{
 pub use peer::{PeerId, WithPeerId};
 pub use prune::{
     ContractLogsPruneConfig, PruneCheckpoint, PruneMode, PruneModes, PrunePart, PrunePartError,
+    MINIMUM_PRUNING_DISTANCE,
 };
 pub use receipt::{Receipt, ReceiptWithBloom, ReceiptWithBloomRef};
 pub use revm_primitives::JumpMap;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -79,7 +79,9 @@ pub use net::{
     SEPOLIA_BOOTNODES,
 };
 pub use peer::{PeerId, WithPeerId};
-pub use prune::{PruneCheckpoint, PruneMode, PruneModes, PrunePart, PrunePartError};
+pub use prune::{
+    ContractLogPart, PruneCheckpoint, PruneMode, PruneModes, PrunePart, PrunePartError,
+};
 pub use receipt::{Receipt, ReceiptWithBloom, ReceiptWithBloomRef};
 pub use revm_primitives::JumpMap;
 pub use serde_helper::JsonU256;

--- a/crates/primitives/src/prune/mod.rs
+++ b/crates/primitives/src/prune/mod.rs
@@ -6,4 +6,4 @@ mod target;
 pub use checkpoint::PruneCheckpoint;
 pub use mode::PruneMode;
 pub use part::{PrunePart, PrunePartError};
-pub use target::PruneModes;
+pub use target::{ContractLogPart, PruneModes};

--- a/crates/primitives/src/prune/mod.rs
+++ b/crates/primitives/src/prune/mod.rs
@@ -6,4 +6,39 @@ mod target;
 pub use checkpoint::PruneCheckpoint;
 pub use mode::PruneMode;
 pub use part::{PrunePart, PrunePartError};
-pub use target::{ContractLogPart, PruneModes};
+pub use target::PruneModes;
+
+use crate::{Address, BlockNumber};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Configuration for pruning receipts not associated with logs emitted by the specified contracts.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct ContractLogsPruneConfig(pub Vec<(PruneMode, Address)>);
+
+impl ContractLogsPruneConfig {
+    /// Checks if the configuration is empty
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Given the `tip` block number, flatten the struct so it can easily be queried for filtering
+    /// across a range of blocks.
+    ///
+    /// The [`BlockNumber`] key of the map should be viewed as `PruneMode::Before(block)`.
+    pub fn flatten(
+        &self,
+        tip: BlockNumber,
+    ) -> Result<BTreeMap<BlockNumber, Vec<&Address>>, PrunePartError> {
+        let mut map = BTreeMap::new();
+        for (mode, address) in self.0.iter() {
+            let block = mode
+                .prune_target_block(tip, 0, PrunePart::ContractLogs)?
+                .map(|(block, _)| block)
+                .unwrap_or_default();
+
+            map.entry(block).or_insert_with(Vec::new).push(address)
+        }
+        Ok(map)
+    }
+}

--- a/crates/primitives/src/prune/mod.rs
+++ b/crates/primitives/src/prune/mod.rs
@@ -6,7 +6,7 @@ mod target;
 pub use checkpoint::PruneCheckpoint;
 pub use mode::PruneMode;
 pub use part::{PrunePart, PrunePartError};
-pub use target::PruneModes;
+pub use target::{PruneModes, MINIMUM_PRUNING_DISTANCE};
 
 use crate::{Address, BlockNumber};
 use serde::{Deserialize, Serialize};

--- a/crates/primitives/src/prune/mod.rs
+++ b/crates/primitives/src/prune/mod.rs
@@ -21,11 +21,11 @@ impl ContractLogsPruneConfig {
         self.0.is_empty()
     }
 
-    /// Given the `tip` block number, flatten the struct so it can easily be queried for filtering
-    /// across a range of blocks.
+    /// Given the `tip` block number, consolidates the structure so it can easily be queried for
+    /// filtering across a range of blocks.
     ///
     /// The [`BlockNumber`] key of the map should be viewed as `PruneMode::Before(block)`.
-    pub fn flatten(
+    pub fn group_by_block(
         &self,
         tip: BlockNumber,
     ) -> Result<BTreeMap<BlockNumber, Vec<&Address>>, PrunePartError> {

--- a/crates/primitives/src/prune/mod.rs
+++ b/crates/primitives/src/prune/mod.rs
@@ -33,7 +33,7 @@ impl ContractLogsPruneConfig {
         let mut map = BTreeMap::new();
         for (mode, address) in self.0.iter() {
             let block = mode
-                .prune_target_block(tip, 0, PrunePart::ContractLogs)?
+                .prune_target_block(tip, 128, PrunePart::ContractLogs)?
                 .map(|(block, _)| block)
                 .unwrap_or_default();
 

--- a/crates/primitives/src/prune/mod.rs
+++ b/crates/primitives/src/prune/mod.rs
@@ -33,7 +33,7 @@ impl ContractLogsPruneConfig {
         let mut map = BTreeMap::new();
         for (mode, address) in self.0.iter() {
             let block = mode
-                .prune_target_block(tip, 128, PrunePart::ContractLogs)?
+                .prune_target_block(tip, MINIMUM_PRUNING_DISTANCE, PrunePart::ContractLogs)?
                 .map(|(block, _)| block)
                 .unwrap_or_default();
 

--- a/crates/primitives/src/prune/mod.rs
+++ b/crates/primitives/src/prune/mod.rs
@@ -32,6 +32,10 @@ impl ContractLogsPruneConfig {
     ) -> Result<BTreeMap<BlockNumber, Vec<&Address>>, PrunePartError> {
         let mut map = BTreeMap::new();
         for (mode, address) in self.0.iter() {
+            // Getting `None`, means that there is nothing to prune yet, so we need it to include in
+            // the BTreeMap (block = 0), otherwise it will be excluded.
+            // Reminder that this BTreeMap works as an inclusion list that excludes (prunes) all
+            // other receipts.
             let block = mode
                 .prune_target_block(tip, MINIMUM_PRUNING_DISTANCE, PrunePart::ContractLogs)?
                 .map(|(block, _)| block)

--- a/crates/primitives/src/prune/mod.rs
+++ b/crates/primitives/src/prune/mod.rs
@@ -13,7 +13,7 @@ pub use target::{PruneModes, MINIMUM_PRUNING_DISTANCE};
 
 /// Configuration for pruning receipts not associated with logs emitted by the specified contracts.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
-pub struct ContractLogsPruneConfig(pub Vec<(PruneMode, Address)>);
+pub struct ContractLogsPruneConfig(pub BTreeMap<Address, PruneMode>);
 
 impl ContractLogsPruneConfig {
     /// Checks if the configuration is empty
@@ -30,7 +30,7 @@ impl ContractLogsPruneConfig {
         tip: BlockNumber,
     ) -> Result<BTreeMap<BlockNumber, Vec<&Address>>, PrunePartError> {
         let mut map = BTreeMap::new();
-        for (mode, address) in self.0.iter() {
+        for (address, mode) in self.0.iter() {
             // Getting `None`, means that there is nothing to prune yet, so we need it to include in
             // the BTreeMap (block = 0), otherwise it will be excluded.
             // Reminder that this BTreeMap works as an inclusion list that excludes (prunes) all

--- a/crates/primitives/src/prune/mod.rs
+++ b/crates/primitives/src/prune/mod.rs
@@ -3,14 +3,13 @@ mod mode;
 mod part;
 mod target;
 
+use crate::{Address, BlockNumber};
 pub use checkpoint::PruneCheckpoint;
 pub use mode::PruneMode;
 pub use part::{PrunePart, PrunePartError};
-pub use target::{PruneModes, MINIMUM_PRUNING_DISTANCE};
-
-use crate::{Address, BlockNumber};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+pub use target::{PruneModes, MINIMUM_PRUNING_DISTANCE};
 
 /// Configuration for pruning receipts not associated with logs emitted by the specified contracts.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]

--- a/crates/primitives/src/prune/mode.rs
+++ b/crates/primitives/src/prune/mode.rs
@@ -23,7 +23,7 @@ impl PruneMode {
         min_blocks: u64,
         prune_part: PrunePart,
     ) -> Result<Option<(BlockNumber, PruneMode)>, PrunePartError> {
-        Ok(match self {
+        let result = match self {
             PruneMode::Full if min_blocks == 0 => Some((tip, *self)),
             PruneMode::Distance(distance) if *distance > tip => None, // Nothing to prune yet
             PruneMode::Distance(distance) if *distance >= min_blocks => {
@@ -32,7 +32,8 @@ impl PruneMode {
             PruneMode::Before(n) if *n > tip => None, // Nothing to prune yet
             PruneMode::Before(n) if tip - n >= min_blocks => Some((n - 1, *self)),
             _ => return Err(PrunePartError::Configuration(prune_part)),
-        })
+        };
+        Ok(result)
     }
 
     /// Check if target block should be pruned according to the provided prune mode and tip.
@@ -59,9 +60,77 @@ impl Default for PruneMode {
 
 #[cfg(test)]
 mod tests {
-    use crate::prune::PruneMode;
+    use crate::{prune::PruneMode, PrunePart, PrunePartError, MINIMUM_PRUNING_DISTANCE};
     use assert_matches::assert_matches;
     use serde::Deserialize;
+
+    #[test]
+    fn test_prune_target_block() {
+        let tip = 1000;
+        let min_blocks = MINIMUM_PRUNING_DISTANCE;
+        let prune_part = PrunePart::Receipts;
+
+        let tests = vec![
+            // MINIMUM_PRUNING_DISTANCE makes this impossible
+            (PruneMode::Full, Err(PrunePartError::Configuration(prune_part))),
+            // Nothing to prune
+            (PruneMode::Distance(tip + 1), Ok(None)),
+            (PruneMode::Distance(min_blocks + 1), Ok(Some(tip - (min_blocks + 1)))),
+            // Nothing to prune
+            (PruneMode::Before(tip + 1), Ok(None)),
+            (
+                PruneMode::Before(tip - MINIMUM_PRUNING_DISTANCE),
+                Ok(Some(tip - MINIMUM_PRUNING_DISTANCE - 1)),
+            ),
+            (
+                PruneMode::Before(tip - MINIMUM_PRUNING_DISTANCE - 1),
+                Ok(Some(tip - MINIMUM_PRUNING_DISTANCE - 2)),
+            ),
+            // MINIMUM_PRUNING_DISTANCE is 128
+            (PruneMode::Before(tip - 1), Err(PrunePartError::Configuration(prune_part))),
+        ];
+
+        for (index, (mode, expected_result)) in tests.into_iter().enumerate() {
+            assert_eq!(
+                mode.prune_target_block(tip, min_blocks, prune_part),
+                expected_result.map(|r| r.map(|b| (b, mode))),
+                "Test {} failed",
+                index + 1,
+            );
+        }
+
+        // Test for a scenario where there are no minimum blocks and Full can be used
+        assert_eq!(
+            PruneMode::Full.prune_target_block(tip, 0, prune_part),
+            Ok(Some((tip, PruneMode::Full))),
+        );
+    }
+
+    #[test]
+    fn test_should_prune() {
+        let tip = 1000;
+        let should_prune = true;
+
+        let tests = vec![
+            (PruneMode::Distance(tip + 1), 1, !should_prune),
+            (
+                PruneMode::Distance(MINIMUM_PRUNING_DISTANCE + 1),
+                tip - MINIMUM_PRUNING_DISTANCE - 1,
+                !should_prune,
+            ),
+            (
+                PruneMode::Distance(MINIMUM_PRUNING_DISTANCE + 1),
+                tip - MINIMUM_PRUNING_DISTANCE - 2,
+                should_prune,
+            ),
+            (PruneMode::Before(tip + 1), 1, should_prune),
+            (PruneMode::Before(tip + 1), tip + 1, !should_prune),
+        ];
+
+        for (index, (mode, block, expected_result)) in tests.into_iter().enumerate() {
+            assert_eq!(mode.should_prune(block, tip), expected_result, "Test {} failed", index + 1,);
+        }
+    }
 
     #[test]
     fn prune_mode_deserialize() {

--- a/crates/primitives/src/prune/part.rs
+++ b/crates/primitives/src/prune/part.rs
@@ -12,7 +12,7 @@ pub enum PrunePart {
     TransactionLookup,
     /// Prune part responsible for all `Receipts`.
     Receipts,
-    /// Prune part responsible for some `Receipts`.
+    /// Prune part responsible for some `Receipts` filtered by logs.
     ContractLogs,
     /// Prune part responsible for the `AccountChangeSet` and `AccountHistory` tables.
     AccountHistory,

--- a/crates/primitives/src/prune/part.rs
+++ b/crates/primitives/src/prune/part.rs
@@ -10,8 +10,10 @@ pub enum PrunePart {
     SenderRecovery,
     /// Prune part responsible for the `TxHashNumber` table.
     TransactionLookup,
-    /// Prune part responsible for the `Receipts` table.
+    /// Prune part responsible for all `Receipts`.
     Receipts,
+    /// Prune part responsible for some `Receipts`.
+    ContractLogs,
     /// Prune part responsible for the `AccountChangeSet` and `AccountHistory` tables.
     AccountHistory,
     /// Prune part responsible for the `StorageChangeSet` and `StorageHistory` tables.

--- a/crates/primitives/src/prune/part.rs
+++ b/crates/primitives/src/prune/part.rs
@@ -21,7 +21,7 @@ pub enum PrunePart {
 }
 
 /// PrunePart error type.
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq, Eq)]
 pub enum PrunePartError {
     /// Invalid configuration of a prune part.
     #[error("The configuration provided for {0} is invalid.")]

--- a/crates/primitives/src/prune/target.rs
+++ b/crates/primitives/src/prune/target.rs
@@ -5,6 +5,9 @@ use crate::{
 use paste::paste;
 use serde::{Deserialize, Serialize};
 
+/// Minimum distance necessary from the tip so blockchain tree can work correctly.
+pub const MINIMUM_PRUNING_DISTANCE: u64 = 128;
+
 /// Pruning configuration for every part of the data that can be pruned.
 #[derive(Debug, Clone, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(default)]

--- a/crates/primitives/src/prune/target.rs
+++ b/crates/primitives/src/prune/target.rs
@@ -1,10 +1,9 @@
 use crate::{
-    prune::PrunePartError, serde_helper::deserialize_opt_prune_mode_with_min_blocks, Address,
-    BlockNumber, PruneMode, PrunePart,
+    prune::PrunePartError, serde_helper::deserialize_opt_prune_mode_with_min_blocks, BlockNumber,
+    ContractLogsPruneConfig, PruneMode, PrunePart,
 };
 use paste::paste;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
 
 /// Pruning configuration for every part of the data that can be pruned.
 #[derive(Debug, Clone, Default, Deserialize, Eq, PartialEq, Serialize)]
@@ -22,7 +21,7 @@ pub struct PruneModes {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transaction_lookup: Option<PruneMode>,
     /// Configuration for pruning of receipts. This setting overrides
-    /// `PruneModes::only_contract_logs` and offers improved performance.
+    /// `PruneModes::contract_logs_filter` and offers improved performance.
     #[serde(
         skip_serializing_if = "Option::is_none",
         deserialize_with = "deserialize_opt_prune_mode_with_min_blocks::<64, _>"
@@ -45,7 +44,7 @@ pub struct PruneModes {
     ///
     /// The [`BlockNumber`] represents the starting block from which point onwards the receipts are
     /// preserved.
-    pub only_contract_logs: ContractLogPart,
+    pub contract_logs_filter: ContractLogsPruneConfig,
 }
 
 macro_rules! impl_prune_parts {
@@ -88,7 +87,7 @@ macro_rules! impl_prune_parts {
                 $(
                     $part: Some(PruneMode::Full),
                 )+
-                only_contract_logs: Default::default()
+                contract_logs_filter: Default::default()
             }
         }
 
@@ -108,35 +107,4 @@ impl PruneModes {
         (account_history, AccountHistory, Some(64)),
         (storage_history, StorageHistory, Some(64))
     );
-}
-
-/// Configuration for pruning receipts not associated with logs emitted by the specified contracts.
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
-pub struct ContractLogPart(pub Vec<(PruneMode, Address)>);
-
-impl ContractLogPart {
-    /// Checks if the configuration is empty
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    /// Given the `tip` block number, flatten the struct so it can easily be queried for filtering
-    /// across a range of blocks.
-    ///
-    /// The [`BlockNumber`] key of the map should be viewed as `PruneMode::Before(block)`.
-    pub fn flatten(
-        &self,
-        tip: BlockNumber,
-    ) -> Result<BTreeMap<BlockNumber, Vec<&Address>>, PrunePartError> {
-        let mut map = BTreeMap::new();
-        for (mode, address) in self.0.iter() {
-            let block = mode
-                .prune_target_block(tip, 0, PrunePart::ContractLogs)?
-                .map(|(block, _)| block)
-                .unwrap_or_default();
-
-            map.entry(block).or_insert_with(Vec::new).push(address)
-        }
-        Ok(map)
-    }
 }

--- a/crates/primitives/src/prune/target.rs
+++ b/crates/primitives/src/prune/target.rs
@@ -21,8 +21,8 @@ pub struct PruneModes {
     /// Transaction Lookup pruning configuration.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transaction_lookup: Option<PruneMode>,
-    /// Receipts pruning configuration. Supersedes `PruneModes::only_contract_logs` and it's more
-    /// performant.
+    /// Configuration for pruning of receipts. This setting overrides
+    /// `PruneModes::only_contract_logs` and offers improved performance.
     #[serde(
         skip_serializing_if = "Option::is_none",
         deserialize_with = "deserialize_opt_prune_mode_with_min_blocks::<64, _>"
@@ -40,8 +40,11 @@ pub struct PruneModes {
         deserialize_with = "deserialize_opt_prune_mode_with_min_blocks::<64, _>"
     )]
     pub storage_history: Option<PruneMode>,
-    /// Includes only receipts with logs that were emitted by these addresses. Excludes every
-    /// other. It's superseded by `PruneModes::receipts`.
+    /// Retains only those receipts that contain logs emitted by the specified addresses,
+    /// discarding all others. Note that this setting is overridden by `PruneModes::receipts`.
+    ///
+    /// The [`BlockNumber`] represents the starting block from which point onwards the receipts are
+    /// preserved.
     pub only_contract_logs: BTreeMap<BlockNumber, Vec<Address>>,
 }
 

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -199,7 +199,7 @@ impl<EF: ExecutorFactory> ExecutionStage<EF> {
         start_block: u64,
         max_block: u64,
     ) -> Result<PruneModes, StageError> {
-        let mut prune_modes = self.prune_modes;
+        let mut prune_modes = self.prune_modes.clone();
 
         // If we're not executing MerkleStage from scratch (by threshold or first-sync), then erase
         // changeset related pruning configurations

--- a/crates/stages/src/stages/mod.rs
+++ b/crates/stages/src/stages/mod.rs
@@ -173,34 +173,34 @@ mod tests {
         // In an unpruned configuration there is 1 receipt, 3 changed accounts and 1 changed
         // storage.
         let mut prune = PruneModes::none();
-        check_pruning(factory.clone(), prune, 1, 3, 1).await;
+        check_pruning(factory.clone(), prune.clone(), 1, 3, 1).await;
 
         prune.receipts = Some(PruneMode::Full);
         prune.account_history = Some(PruneMode::Full);
         prune.storage_history = Some(PruneMode::Full);
         // This will result in error for account_history and storage_history, which is caught.
-        check_pruning(factory.clone(), prune, 0, 0, 0).await;
+        check_pruning(factory.clone(), prune.clone(), 0, 0, 0).await;
 
         prune.receipts = Some(PruneMode::Before(1));
         prune.account_history = Some(PruneMode::Before(1));
         prune.storage_history = Some(PruneMode::Before(1));
-        check_pruning(factory.clone(), prune, 1, 3, 1).await;
+        check_pruning(factory.clone(), prune.clone(), 1, 3, 1).await;
 
         prune.receipts = Some(PruneMode::Before(2));
         prune.account_history = Some(PruneMode::Before(2));
         prune.storage_history = Some(PruneMode::Before(2));
         // The one account is the miner
-        check_pruning(factory.clone(), prune, 0, 1, 0).await;
+        check_pruning(factory.clone(), prune.clone(), 0, 1, 0).await;
 
         prune.receipts = Some(PruneMode::Distance(66));
         prune.account_history = Some(PruneMode::Distance(66));
         prune.storage_history = Some(PruneMode::Distance(66));
-        check_pruning(factory.clone(), prune, 1, 3, 1).await;
+        check_pruning(factory.clone(), prune.clone(), 1, 3, 1).await;
 
         prune.receipts = Some(PruneMode::Distance(64));
         prune.account_history = Some(PruneMode::Distance(64));
         prune.storage_history = Some(PruneMode::Distance(64));
         // The one account is the miner
-        check_pruning(factory.clone(), prune, 0, 1, 0).await;
+        check_pruning(factory.clone(), prune.clone(), 0, 1, 0).await;
     }
 }

--- a/crates/storage/provider/src/post_state/mod.rs
+++ b/crates/storage/provider/src/post_state/mod.rs
@@ -658,7 +658,7 @@ impl PostState {
             let mut receipts_cursor = tx.cursor_write::<tables::Receipts>()?;
 
             let contract_log_pruner =
-                self.prune_modes.only_contract_logs.flatten(tip).expect("TODO");
+                self.prune_modes.contract_logs_filter.flatten(tip).expect("TODO");
             // Empty implies that there is going to be
             // addresses to include in the filter in a future block. None means there isn't any kind
             // of configuration.

--- a/crates/storage/provider/src/post_state/mod.rs
+++ b/crates/storage/provider/src/post_state/mod.rs
@@ -662,7 +662,7 @@ impl PostState {
             let contract_log_pruner = self
                 .prune_modes
                 .contract_logs_filter
-                .flatten(tip)
+                .group_by_block(tip)
                 .map_err(|e| Error::Custom(e.to_string()))?;
 
             // Empty implies that there is going to be

--- a/crates/storage/provider/src/post_state/mod.rs
+++ b/crates/storage/provider/src/post_state/mod.rs
@@ -669,7 +669,7 @@ impl PostState {
 
                 if !self.prune_modes.only_contract_logs.is_empty() {
                     if address_filter.is_none() {
-                        address_filter = Some((block, vec![]));
+                        address_filter = Some((0, vec![]));
                     }
 
                     // Get all addresses higher than prev_block up to this block

--- a/crates/storage/provider/src/post_state/mod.rs
+++ b/crates/storage/provider/src/post_state/mod.rs
@@ -671,12 +671,13 @@ impl PostState {
             let mut address_filter: Option<(u64, Vec<&Address>)> = None;
 
             for (block, receipts) in self.receipts {
+                // [`PrunePart::Receipts`] takes priority over [`PrunePart::ContractLogs`]
                 if receipts.is_empty() || self.prune_modes.should_prune_receipts(block, tip) {
                     continue
                 }
 
                 // All receipts from the last 128 blocks are required for blockchain tree, even with
-                // the contract log filters.
+                // [`PrunePart::ContractLogs`].
                 let prunable_receipts =
                     PruneMode::Distance(MINIMUM_PRUNING_DISTANCE).should_prune(block, tip);
 


### PR DESCRIPTION
This allows us to only include the deposit contract receipts, alongside whatever the user chooses to keep (ref https://github.com/paradigmxyz/reth/issues/2753) . (for pipeline only)

