### PR TITLE
fix: only propagate txs that are allowed to be propagated

### DIFF
--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -130,7 +130,7 @@ impl<Pool: TransactionPool> TransactionsManager<Pool> {
         let network_events = network.event_listener();
         let (command_tx, command_rx) = mpsc::unbounded_channel();
 
-        // install a listener for new transactions
+        // install a listener for new pending transactions that are allowed to be propagated over the network
         let pending = pool.pending_transactions_listener();
 
         Self {

--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -130,7 +130,8 @@ impl<Pool: TransactionPool> TransactionsManager<Pool> {
         let network_events = network.event_listener();
         let (command_tx, command_rx) = mpsc::unbounded_channel();
 
-        // install a listener for new pending transactions that are allowed to be propagated over the network
+        // install a listener for new pending transactions that are allowed to be propagated over
+        // the network
         let pending = pool.pending_transactions_listener();
 
         Self {

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -165,8 +165,9 @@ pub use crate::{
     },
     traits::{
         AllPoolTransactions, BestTransactions, BlockInfo, CanonicalStateUpdate, ChangedAccount,
-        NewTransactionEvent, PoolSize, PoolTransaction, PooledTransaction, PropagateKind,
-        PropagatedTransactions, TransactionOrigin, TransactionPool, TransactionPoolExt,
+        NewTransactionEvent, PendingTransactionListenerKind, PoolSize, PoolTransaction,
+        PooledTransaction, PropagateKind, PropagatedTransactions, TransactionOrigin,
+        TransactionPool, TransactionPoolExt,
     },
     validate::{
         EthTransactionValidator, TransactionValidationOutcome, TransactionValidator,
@@ -343,8 +344,11 @@ where
         self.pool.add_all_transactions_event_listener()
     }
 
-    fn pending_transactions_listener(&self) -> Receiver<TxHash> {
-        self.pool.add_pending_listener()
+    fn pending_transactions_listener_for(
+        &self,
+        kind: PendingTransactionListenerKind,
+    ) -> Receiver<TxHash> {
+        self.pool.add_pending_listener(kind)
     }
 
     fn new_transactions_listener(&self) -> Receiver<NewTransactionEvent<Self::Transaction>> {

--- a/crates/transaction-pool/src/test_utils/mod.rs
+++ b/crates/transaction-pool/src/test_utils/mod.rs
@@ -5,7 +5,7 @@ mod mock;
 mod pool;
 
 use crate::{
-    noop::NoopTransactionValidator, Pool, PoolTransaction, TransactionOrigin,
+    noop::MockTransactionValidator, Pool, PoolTransaction, TransactionOrigin,
     TransactionValidationOutcome, TransactionValidator,
 };
 use async_trait::async_trait;
@@ -13,9 +13,15 @@ pub use mock::*;
 use std::{marker::PhantomData, sync::Arc};
 
 /// A [Pool] used for testing
-pub type TestPool = Pool<NoopTransactionValidator<MockTransaction>, MockOrdering>;
+pub type TestPool = Pool<MockTransactionValidator<MockTransaction>, MockOrdering>;
 
 /// Returns a new [Pool] used for testing purposes
 pub fn testing_pool() -> TestPool {
-    Pool::new(NoopTransactionValidator::default(), MockOrdering::default(), Default::default())
+    testing_pool_with_validator(MockTransactionValidator::default())
+}
+/// Returns a new [Pool] used for testing purposes
+pub fn testing_pool_with_validator(
+    validator: MockTransactionValidator<MockTransaction>,
+) -> TestPool {
+    Pool::new(validator, MockOrdering::default(), Default::default())
 }

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -117,7 +117,7 @@ pub struct ValidPoolTransaction<T: PoolTransaction> {
     pub transaction: T,
     /// The identifier for this transaction.
     pub transaction_id: TransactionId,
-    /// Whether to propagate the transaction.
+    /// Whether it is allowed to propagate the transaction.
     pub propagate: bool,
     /// Timestamp when this was added to the pool.
     pub timestamp: Instant,

--- a/crates/transaction-pool/tests/it/listeners.rs
+++ b/crates/transaction-pool/tests/it/listeners.rs
@@ -1,8 +1,11 @@
 use assert_matches::assert_matches;
 use reth_transaction_pool::{
-    test_utils::{testing_pool, MockTransactionFactory},
-    FullTransactionEvent, TransactionEvent, TransactionOrigin, TransactionPool,
+    noop::MockTransactionValidator,
+    test_utils::{testing_pool, testing_pool_with_validator, MockTransactionFactory},
+    FullTransactionEvent, PendingTransactionListenerKind, TransactionEvent, TransactionOrigin,
+    TransactionPool,
 };
+use std::{future::poll_fn, task::Poll};
 use tokio_stream::StreamExt;
 
 #[tokio::test(flavor = "multi_thread")]
@@ -36,4 +39,28 @@ async fn txpool_listener_all() {
         all_tx_events.next().await,
         Some(FullTransactionEvent::Pending(hash)) if hash == transaction.transaction.get_hash()
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn txpool_listener_propagate_only() {
+    let txpool = testing_pool_with_validator(MockTransactionValidator::no_propagate_local());
+    let mut mock_tx_factory = MockTransactionFactory::default();
+    let transaction = mock_tx_factory.create_eip1559();
+    let expected = *transaction.hash();
+    let mut listener_network = txpool.pending_transactions_listener();
+    let mut listener_all =
+        txpool.pending_transactions_listener_for(PendingTransactionListenerKind::All);
+    let result =
+        txpool.add_transaction(TransactionOrigin::Local, transaction.transaction.clone()).await;
+    assert!(result.is_ok());
+
+    let inserted = listener_all.recv().await.unwrap();
+    assert_eq!(inserted, expected);
+
+    poll_fn(|cx| {
+        // no propagation
+        assert!(listener_network.poll_recv(cx).is_pending());
+        Poll::Ready(())
+    })
+    .await;
 }


### PR DESCRIPTION
this adds a restriction that prevents the node from propagating pending transactions over the network that are marked as `propagate:false`

adds a new `PendingTransactionListenerKind` to the listener which checks if the listener is allowed to receive `propagate:false` transactions