### PR TITLE
chore: explicitly set max allowed connections for auth server

### DIFF
--- a/crates/rpc/rpc-builder/src/auth.rs
+++ b/crates/rpc/rpc-builder/src/auth.rs
@@ -215,6 +215,11 @@ impl AuthServerConfigBuilder {
                     // payload bodies limit for `engine_getPayloadBodiesByRangeV`
                     // ~750MB per response should be enough
                     .max_response_body_size(750 * 1024 * 1024)
+                    // Connections to this server are always authenticated, hence this only affects
+                    // connections from the CL or any other client that uses JWT, this should be
+                    // more than enough so that the CL (or multiple CL nodes) will never get rate
+                    // limited
+                    .max_connections(500)
                     // bump the default request size slightly, there aren't any methods exposed with
                     // dynamic request params that can exceed this
                     .max_request_body_size(25 * 1024 * 1024)


### PR DESCRIPTION
default was 100, which should be more than enough

this increases it, just to allow for more in case there are multiple CLs 