### PR TITLE
chore(engine): downgrade new payload buffering log to debug

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1062,7 +1062,7 @@ where
             self.try_insert_new_payload(block)
         } else {
             if self.is_prune_active() {
-                warn!(target: "consensus::engine", "Pruning is in progress, buffering new payload.");
+                debug!(target: "consensus::engine", "Pruning is in progress, buffering new payload.");
             }
             self.try_buffer_payload(block)
         };


### PR DESCRIPTION
Resolves https://github.com/paradigmxyz/reth/issues/4057

Otherwise we're spamming warnings when long-running pruning is active. We still need to emit warnings on missed FCUs though, as it's more critical and need to be acted on immediately.