### PR TITLE
feat(txpool) modify txpool guard to be for pipeline syncs only

### DIFF
--- a/crates/interfaces/src/sync.rs
+++ b/crates/interfaces/src/sync.rs
@@ -7,6 +7,9 @@ use reth_primitives::Head;
 pub trait SyncStateProvider: Send + Sync {
     /// Returns `true` if the network is undergoing sync.
     fn is_syncing(&self) -> bool;
+
+    /// Returns `true` if the network is undergoing an initial (pipeline) sync.
+    fn is_initially_syncing(&self) -> bool;
 }
 
 /// An updater for updating the [SyncState] and status of the network.
@@ -52,6 +55,9 @@ pub struct NoopSyncStateUpdater;
 
 impl SyncStateProvider for NoopSyncStateUpdater {
     fn is_syncing(&self) -> bool {
+        false
+    }
+    fn is_initially_syncing(&self) -> bool {
         false
     }
 }

--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -50,7 +50,7 @@ pub trait NetworkInfo: Send + Sync {
     /// Returns `true` if the network is undergoing sync.
     fn is_syncing(&self) -> bool;
 
-    /// Returns `true` if the network is undergoing an initial sync.
+    /// Returns `true` when a fresh node is initially being synced, known as a Pipeline sync
     fn is_initially_syncing(&self) -> bool;
 }
 

--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -50,7 +50,7 @@ pub trait NetworkInfo: Send + Sync {
     /// Returns `true` if the network is undergoing sync.
     fn is_syncing(&self) -> bool;
 
-    /// Returns `true` when a fresh node is initially being synced, known as a Pipeline sync
+    /// Returns `true` when a fresh node being bootstrapped is undergoing a Pipeline sync
     fn is_initially_syncing(&self) -> bool;
 }
 

--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -50,7 +50,7 @@ pub trait NetworkInfo: Send + Sync {
     /// Returns `true` if the network is undergoing sync.
     fn is_syncing(&self) -> bool;
 
-    /// Returns `true` when a fresh node being bootstrapped is undergoing a Pipeline sync
+    /// Returns `true` when the node is undergoing the very first Pipeline sync.
     fn is_initially_syncing(&self) -> bool;
 }
 

--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -49,6 +49,9 @@ pub trait NetworkInfo: Send + Sync {
 
     /// Returns `true` if the network is undergoing sync.
     fn is_syncing(&self) -> bool;
+
+    /// Returns `true` if the network is undergoing an initial sync.
+    fn is_initially_syncing(&self) -> bool;
 }
 
 /// Provides general purpose information about Peers in the network.

--- a/crates/net/network-api/src/noop.rs
+++ b/crates/net/network-api/src/noop.rs
@@ -45,6 +45,10 @@ impl NetworkInfo for NoopNetwork {
     fn is_syncing(&self) -> bool {
         false
     }
+
+    fn is_initially_syncing(&self) -> bool {
+        false
+    }
 }
 
 impl PeersInfo for NoopNetwork {

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -260,9 +260,10 @@ impl SyncStateProvider for NetworkHandle {
     }
     // used to guard the txpool
     fn is_initially_syncing(&self) -> bool {
-        let init_sync_done = self.inner.initial_sync_done.load(Ordering::Relaxed);
-        let is_currently_syncing = self.inner.is_syncing.load(Ordering::Relaxed);
-        is_currently_syncing && !init_sync_done
+        if self.inner.initial_sync_done.load(Ordering::Relaxed) {
+            return false
+        }
+        self.inner.is_syncing.load(Ordering::Relaxed)
     }
 }
 

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -262,7 +262,7 @@ impl SyncStateProvider for NetworkHandle {
     fn is_initially_syncing(&self) -> bool {
         let init_sync_done = self.inner.initial_sync_done.load(Ordering::Relaxed);
         let is_currently_syncing = self.inner.is_syncing.load(Ordering::Relaxed);
-        return is_currently_syncing && !init_sync_done
+        is_currently_syncing && !init_sync_done
     }
 }
 

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -55,6 +55,7 @@ impl NetworkHandle {
             network_mode,
             bandwidth_meter,
             is_syncing: Arc::new(AtomicBool::new(false)),
+            initial_sync_done: Arc::new(AtomicBool::new(false)),
             chain_id,
         };
         Self { inner: Arc::new(inner) }
@@ -247,18 +248,38 @@ impl NetworkInfo for NetworkHandle {
     fn is_syncing(&self) -> bool {
         SyncStateProvider::is_syncing(self)
     }
+
+    fn is_initially_syncing(&self) -> bool {
+        SyncStateProvider::is_initially_syncing(self)
+    }
 }
 
 impl SyncStateProvider for NetworkHandle {
     fn is_syncing(&self) -> bool {
         self.inner.is_syncing.load(Ordering::Relaxed)
     }
+    // used to guard the txpool
+    fn is_initially_syncing(&self) -> bool {
+        let init_sync_done = self.inner.initial_sync_done.load(Ordering::Relaxed);
+        let is_currently_syncing = self.inner.is_syncing.load(Ordering::Relaxed);
+        return is_currently_syncing && !init_sync_done
+    }
 }
 
 impl NetworkSyncUpdater for NetworkHandle {
     fn update_sync_state(&self, state: SyncState) {
-        let is_syncing = state.is_syncing();
-        self.inner.is_syncing.store(is_syncing, Ordering::Relaxed)
+        let future_state = state.is_syncing();
+        let curr_state = self.inner.is_syncing.load(Ordering::Relaxed);
+        let init_sync_done = self.inner.initial_sync_done.load(Ordering::Relaxed);
+        self.inner.is_syncing.store(future_state, Ordering::Relaxed);
+        if !init_sync_done {
+            // we've either been in Idle or pipeline Syncing here, check to see if we're
+            // moving from a pipeline sync to idle
+            if curr_state && !future_state {
+                // set initial_sync_done flag to true here, every sync after this will be a livesync
+                self.inner.initial_sync_done.store(true, Ordering::Relaxed);
+            }
+        }
     }
 
     /// Update the status of the node.
@@ -285,6 +306,8 @@ struct NetworkInner {
     bandwidth_meter: BandwidthMeter,
     /// Represents if the network is currently syncing.
     is_syncing: Arc<AtomicBool>,
+    /// Used to differentiate between an initial pipeline sync or a live sync
+    initial_sync_done: Arc<AtomicBool>,
     /// The chain id
     chain_id: Arc<AtomicU64>,
 }

--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -996,8 +996,9 @@ mod tests {
             *handle1.peer_id(),
             transactions.transactions_by_peers.get(&signed_tx.hash()).unwrap()[0]
         );
-        // assert!(!pool.is_empty()); This fails - since pool_imports doesnt make progress on adding
-        // the tx to the pool (?)
+        // This fails - since pool_imports doesnt make progress on adding the tx the pool, nothing
+        // is calling poll()
+        assert!(!pool.is_empty());
         handle.terminate().await;
     }
 


### PR DESCRIPTION
should close #4066 


the tests in `network/src/transactions.rs` need a bit of work - I think there's some bugs hiding in them rn.