### PR TITLE
fix: record push stack as vec u256

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
@@ -353,7 +353,7 @@ impl ParityTraceBuilder {
 
         let maybe_execution = Some(VmExecutedOperation {
             used: step.gas_cost,
-            push: step.new_stack.into_iter().map(|new_stack| new_stack.into()).collect(),
+            push: step.push_stack.clone().unwrap_or_default(),
             mem: maybe_memory,
             store: maybe_storage,
         });

--- a/crates/revm/revm-inspectors/src/tracing/mod.rs
+++ b/crates/revm/revm-inspectors/src/tracing/mod.rs
@@ -275,7 +275,7 @@ impl TracingInspector {
             op,
             contract: interp.contract.address,
             stack,
-            new_stack: None,
+            push_stack: None,
             memory,
             memory_size: interp.memory.len(),
             gas_remaining: self.gas_inspector.gas_remaining(),
@@ -302,7 +302,8 @@ impl TracingInspector {
         let step = &mut self.traces.arena[trace_idx].trace.steps[step_idx];
 
         if interp.stack.len() > step.stack.len() {
-            step.new_stack = interp.stack.data().last().copied();
+            // if the stack grew, we need to record the new values
+            step.push_stack = Some(interp.stack.data()[step.stack.len()..].to_vec());
         }
 
         if self.config.record_memory_snapshots {

--- a/crates/revm/revm-inspectors/src/tracing/types.rs
+++ b/crates/revm/revm-inspectors/src/tracing/types.rs
@@ -538,8 +538,8 @@ pub(crate) struct CallTraceStep {
     pub(crate) contract: Address,
     /// Stack before step execution
     pub(crate) stack: Stack,
-    /// The new stack item placed by this step if any
-    pub(crate) new_stack: Option<U256>,
+    /// The new stack items placed by this step if any
+    pub(crate) push_stack: Option<Vec<U256>>,
     /// All allocated memory in a step
     ///
     /// This will be empty if memory capture is disabled

--- a/crates/rpc/rpc-types/src/eth/trace/parity.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/parity.rs
@@ -308,7 +308,7 @@ pub struct VmExecutedOperation {
     /// The total gas used.
     pub used: u64,
     /// The stack item placed, if any.
-    pub push: Vec<H256>,
+    pub push: Vec<U256>,
     /// If altered, the memory delta.
     pub mem: Option<MemoryDelta>,
     /// The altered storage value, if any.


### PR DESCRIPTION
ref #4071

there can be multiple new stack values (PUSH_X).

change type from H256 -> U256 in rpc type, and record as vec