### PR TITLE
feat: re-export `c-kzg` types and impl rlp traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,6 +603,27 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
+version = "0.64.0"
+source = "git+https://github.com/rust-lang/rust-bindgen?rev=0de11f0a521611ac8738b7b01d19dddaf3899e66#0de11f0a521611ac8738b7b01d19dddaf3899e66"
+dependencies = [
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2 1.0.66",
+ "quote 1.0.32",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.27",
+ "which",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.65.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
@@ -906,6 +927,19 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "c-kzg"
+version = "0.1.0"
+source = "git+https://github.com/ethereum/c-kzg-4844#13cec820c08f45318f82ed4e0da0300042758b92"
+dependencies = [
+ "bindgen 0.64.0 (git+https://github.com/rust-lang/rust-bindgen?rev=0de11f0a521611ac8738b7b01d19dddaf3899e66)",
+ "cc",
+ "glob",
+ "hex",
+ "libc",
  "serde",
 ]
 
@@ -3703,7 +3737,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b18cbf29f8ff3542ba22bdce9ac610fcb75d74bb4e2b306b2a2762242025b4f"
 dependencies = [
- "bindgen 0.64.0",
+ "bindgen 0.64.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "errno 0.2.8",
  "libc",
 ]
@@ -5893,6 +5927,7 @@ dependencies = [
  "arrayvec",
  "auto_impl",
  "bytes",
+ "c-kzg",
  "criterion",
  "ethereum-types",
  "ethnum",
@@ -8217,6 +8252,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b291546d5d9d1eab74f069c77749f2cb8504a12caa20f0f2de93ddbf6f411888"
 dependencies = [
  "rustls-webpki",
+]
+
+[[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5801,6 +5801,7 @@ dependencies = [
  "arbitrary",
  "assert_matches",
  "bytes",
+ "c-kzg",
  "crc",
  "criterion",
  "crunchy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,8 @@ jsonrpsee-types = { version = "0.19" }
 
 ## crypto
 secp256k1 = { version = "0.27.0", default-features = false, features = ["global-context", "rand-std", "recovery"] }
+# for eip-4844
+c-kzg = { git = "https://github.com/ethereum/c-kzg-4844" }
 
 ### misc-testing
 proptest = "1.0"

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -31,6 +31,9 @@ secp256k1 = { workspace = true, default-features = false, features = [
     "recovery",
 ] }
 
+# for eip-4844
+c-kzg = { git = "https://github.com/ethereum/c-kzg-4844" }
+
 # used for forkid
 crc = "3"
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -22,7 +22,7 @@ crunchy = { version = "0.2.2", default-features = false, features = ["limit_256"
 ruint = { version = "1.9.0", features = ["primitive-types", "rlp"] }
 
 # Bloom
- fixed-hash = { version = "0.8", default-features = false, features = ["rustc-hex"] }
+fixed-hash = { version = "0.8", default-features = false, features = ["rustc-hex"] }
 
 # crypto
 secp256k1 = { workspace = true, default-features = false, features = [
@@ -32,7 +32,7 @@ secp256k1 = { workspace = true, default-features = false, features = [
 ] }
 
 # for eip-4844
-c-kzg = { git = "https://github.com/ethereum/c-kzg-4844" }
+c-kzg = { workspace = true }
 
 # used for forkid
 crc = "3"

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -142,6 +142,11 @@ pub mod utils {
     pub use ethers_core::types::serde_helpers;
 }
 
+/// EIP-4844 + KZG helpers
+pub mod kzg {
+    pub use c_kzg::*;
+}
+
 /// Helpers for working with serde
 pub mod serde_helper;
 

--- a/crates/rlp/Cargo.toml
+++ b/crates/rlp/Cargo.toml
@@ -19,7 +19,7 @@ revm-primitives = { workspace = true, features = ["serde"] }
 reth-rlp-derive = {  path = "./rlp-derive", optional = true }
 
 # for eip-4844
-c-kzg = { git = "https://github.com/ethereum/c-kzg-4844", optional = true }
+c-kzg = { workspace = true, optional = true }
 
 [dev-dependencies]
 reth-rlp = { workspace = true, features = [

--- a/crates/rlp/Cargo.toml
+++ b/crates/rlp/Cargo.toml
@@ -34,6 +34,7 @@ criterion = "0.5.0"
 pprof = { version = "0.12", features = ["flamegraph", "frame-pointer", "criterion"] }
 
 [features]
+default = ["kzg"]
 alloc = []
 derive = ["reth-rlp-derive"]
 std = ["alloc"]

--- a/crates/rlp/Cargo.toml
+++ b/crates/rlp/Cargo.toml
@@ -18,6 +18,9 @@ ethereum-types = { version = "0.14", features = ["codec"], optional = true }
 revm-primitives = { workspace = true, features = ["serde"] }
 reth-rlp-derive = {  path = "./rlp-derive", optional = true }
 
+# for eip-4844
+c-kzg = { git = "https://github.com/ethereum/c-kzg-4844", optional = true }
+
 [dev-dependencies]
 reth-rlp = { workspace = true, features = [
     "derive",
@@ -34,6 +37,7 @@ pprof = { version = "0.12", features = ["flamegraph", "frame-pointer", "criterio
 alloc = []
 derive = ["reth-rlp-derive"]
 std = ["alloc"]
+kzg = ["c-kzg"]
 
 [[bench]]
 name = "bench"

--- a/crates/rlp/src/encode.rs
+++ b/crates/rlp/src/encode.rs
@@ -413,6 +413,19 @@ pub fn encode_fixed_size<E: MaxEncodedLen<LEN>, const LEN: usize>(v: &E) -> Arra
     out
 }
 
+#[cfg(feature = "kzg")]
+mod kzg_support {
+    use c_kzg::Blob;
+    use super::*;
+
+    extern crate c_kzg;
+
+    impl Encodable for Blob {
+        fn encode(&self, out: &mut dyn BufMut) {
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     extern crate alloc;

--- a/crates/rlp/src/encode.rs
+++ b/crates/rlp/src/encode.rs
@@ -415,12 +415,12 @@ pub fn encode_fixed_size<E: MaxEncodedLen<LEN>, const LEN: usize>(v: &E) -> Arra
 
 #[cfg(feature = "kzg")]
 mod kzg_support {
+    extern crate c_kzg;
+
     use super::BufMut;
     use crate::{Decodable, DecodeError, Encodable};
     use c_kzg::{Blob, Bytes48, KzgCommitment, KzgProof, BYTES_PER_BLOB, BYTES_PER_COMMITMENT};
     use core::ops::Deref;
-
-    extern crate c_kzg;
 
     impl Encodable for Blob {
         fn encode(&self, out: &mut dyn BufMut) {

--- a/deny.toml
+++ b/deny.toml
@@ -84,6 +84,13 @@ name = "rustls-webpki"
 expression = "LicenseRef-rustls-webpki"
 license-files = [{ path = "LICENSE", hash = 0x001c7e6c }]
 
+[[licenses.clarify]]
+name = "c-kzg"
+expression = "Apache-2.0"
+# The crate is in `bindings/rust` so we have to go up two directories for the
+# license
+license-files = [{ path = "../../LICENSE", hash = 0x13cec820 }]
+
 # This section is considered when running `cargo deny check sources`.
 # More documentation about the 'sources' section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html


### PR DESCRIPTION
This re-exports the `c-kzg` crate in `reth-primitives` in the `kzg` module, also implementing `Encodable` and `Decodable`