### PR TITLE
feat(storage): account for pruned account/storage history

### DIFF
--- a/crates/interfaces/src/provider.rs
+++ b/crates/interfaces/src/provider.rs
@@ -94,4 +94,6 @@ pub enum ProviderError {
         /// Block hash
         block_hash: BlockHash,
     },
+    #[error("State at block #{0} is pruned")]
+    StateAtBlockPruned(BlockNumber),
 }

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -113,11 +113,11 @@ impl<DB: Database> ProviderFactory<DB> {
         // Instead, we should cap it at the latest prune checkpoint for corresponding prune part.
         if let Some(prune_checkpoint) = account_history_prune_checkpoint {
             state_provider = state_provider
-                .with_latest_account_history_block_number(prune_checkpoint.block_number);
+                .with_lowest_account_history_block_number(prune_checkpoint.block_number + 1);
         }
         if let Some(prune_checkpoint) = storage_history_prune_checkpoint {
             state_provider = state_provider
-                .with_latest_storage_history_block_number(prune_checkpoint.block_number);
+                .with_lowest_storage_history_block_number(prune_checkpoint.block_number + 1);
         }
 
         Ok(Box::new(state_provider))

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -87,7 +87,7 @@ impl<DB: Database> ProviderFactory<DB> {
     }
 
     /// Storage provider for state at that given block
-    pub fn history_by_block_number(
+    fn state_provider_by_block_number(
         &self,
         mut block_number: BlockNumber,
     ) -> Result<StateProviderBox<'_>> {
@@ -102,30 +102,42 @@ impl<DB: Database> ProviderFactory<DB> {
         // +1 as the changeset that we want is the one that was applied after this block.
         block_number += 1;
 
+        let mut state_provider = HistoricalStateProvider::new(provider.into_tx(), block_number);
+
+        // If we pruned account or storage history, we can't return state on every historical block.
+        // Instead, we should cap it at the latest prune checkpoint for corresponding prune part.
+        if let Some(prune_checkpoint) = provider.get_prune_checkpoint(PrunePart::AccountHistory)? {
+            state_provider = state_provider
+                .with_latest_account_history_block_number(prune_checkpoint.block_number);
+        }
+        if let Some(prune_checkpoint) = provider.get_prune_checkpoint(PrunePart::StorageHistory)? {
+            state_provider = state_provider
+                .with_latest_storage_history_block_number(prune_checkpoint.block_number);
+        }
+
+        Ok(Box::new(state_provider))
+    }
+
+    /// Storage provider for state at that given block
+    pub fn history_by_block_number(
+        &self,
+        block_number: BlockNumber,
+    ) -> Result<StateProviderBox<'_>> {
+        let state_provider = self.state_provider_by_block_number(block_number)?;
         trace!(target: "providers::db", ?block_number, "Returning historical state provider for block number");
-        Ok(Box::new(HistoricalStateProvider::new(provider.into_tx(), block_number)))
+        Ok(state_provider)
     }
 
     /// Storage provider for state at that given block hash
     pub fn history_by_block_hash(&self, block_hash: BlockHash) -> Result<StateProviderBox<'_>> {
-        let provider = self.provider()?;
-
-        let mut block_number = provider
+        let block_number = self
+            .provider()?
             .block_number(block_hash)?
             .ok_or(ProviderError::BlockHashNotFound(block_hash))?;
 
-        if block_number == provider.best_block_number().unwrap_or_default() &&
-            block_number == provider.last_block_number().unwrap_or_default()
-        {
-            return Ok(Box::new(LatestStateProvider::new(provider.into_tx())))
-        }
-
-        // +1 as the changeset that we want is the one that was applied after this block.
-        // as the  changeset contains old values.
-        block_number += 1;
-
-        trace!(target: "providers::db", ?block_hash, "Returning historical state provider for block hash");
-        Ok(Box::new(HistoricalStateProvider::new(provider.into_tx(), block_number)))
+        let state_provider = self.state_provider_by_block_number(block_number)?;
+        trace!(target: "providers::db", ?block_number, "Returning historical state provider for block hash");
+        Ok(state_provider)
     }
 }
 

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -102,15 +102,20 @@ impl<DB: Database> ProviderFactory<DB> {
         // +1 as the changeset that we want is the one that was applied after this block.
         block_number += 1;
 
+        let account_history_prune_checkpoint =
+            provider.get_prune_checkpoint(PrunePart::AccountHistory)?;
+        let storage_history_prune_checkpoint =
+            provider.get_prune_checkpoint(PrunePart::StorageHistory)?;
+
         let mut state_provider = HistoricalStateProvider::new(provider.into_tx(), block_number);
 
         // If we pruned account or storage history, we can't return state on every historical block.
         // Instead, we should cap it at the latest prune checkpoint for corresponding prune part.
-        if let Some(prune_checkpoint) = provider.get_prune_checkpoint(PrunePart::AccountHistory)? {
+        if let Some(prune_checkpoint) = account_history_prune_checkpoint {
             state_provider = state_provider
                 .with_latest_account_history_block_number(prune_checkpoint.block_number);
         }
-        if let Some(prune_checkpoint) = provider.get_prune_checkpoint(PrunePart::StorageHistory)? {
+        if let Some(prune_checkpoint) = storage_history_prune_checkpoint {
             state_provider = state_provider
                 .with_latest_storage_history_block_number(prune_checkpoint.block_number);
         }

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -112,12 +112,14 @@ impl<DB: Database> ProviderFactory<DB> {
         // If we pruned account or storage history, we can't return state on every historical block.
         // Instead, we should cap it at the latest prune checkpoint for corresponding prune part.
         if let Some(prune_checkpoint) = account_history_prune_checkpoint {
-            state_provider = state_provider
-                .with_lowest_account_history_block_number(prune_checkpoint.block_number + 1);
+            state_provider = state_provider.with_lowest_available_account_history_block_number(
+                prune_checkpoint.block_number + 1,
+            );
         }
         if let Some(prune_checkpoint) = storage_history_prune_checkpoint {
-            state_provider = state_provider
-                .with_lowest_storage_history_block_number(prune_checkpoint.block_number + 1);
+            state_provider = state_provider.with_lowest_available_storage_history_block_number(
+                prune_checkpoint.block_number + 1,
+            );
         }
 
         Ok(Box::new(state_provider))

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -29,7 +29,9 @@ pub struct HistoricalStateProviderRef<'a, 'b, TX: DbTx<'a>> {
     tx: &'b TX,
     /// Block number is main index for the history state of accounts and storages.
     block_number: BlockNumber,
+    /// Lowest block number at which the account history is available.
     lowest_account_history_block_number: Option<BlockNumber>,
+    /// Lowest block number at which the storage history is available.
     lowest_storage_history_block_number: Option<BlockNumber>,
     /// Phantom lifetime `'a`
     _phantom: PhantomData<&'a TX>,
@@ -42,7 +44,7 @@ pub enum HistoryInfo {
 }
 
 impl<'a, 'b, TX: DbTx<'a>> HistoricalStateProviderRef<'a, 'b, TX> {
-    /// Create new StateProvider from history transaction number
+    /// Create new StateProvider for historical block number
     pub fn new(tx: &'b TX, block_number: BlockNumber) -> Self {
         Self {
             tx,
@@ -53,6 +55,8 @@ impl<'a, 'b, TX: DbTx<'a>> HistoricalStateProviderRef<'a, 'b, TX> {
         }
     }
 
+    /// Create new StateProvider for historical block number and lowest block numbers at which
+    /// account & storage histories are available.
     pub fn new_with_lowest_history_block_numbers(
         tx: &'b TX,
         lowest_account_history_block_number: Option<BlockNumber>,
@@ -242,14 +246,16 @@ pub struct HistoricalStateProvider<'a, TX: DbTx<'a>> {
     tx: TX,
     /// State at the block number is the main indexer of the state.
     block_number: BlockNumber,
+    /// Lowest block number at which the account history is available.
     lowest_account_history_block_number: Option<BlockNumber>,
+    /// Lowest block number at which the storage history is available.
     lowest_storage_history_block_number: Option<BlockNumber>,
     /// Phantom lifetime `'a`
     _phantom: PhantomData<&'a TX>,
 }
 
 impl<'a, TX: DbTx<'a>> HistoricalStateProvider<'a, TX> {
-    /// Create new StateProvider from history transaction number
+    /// Create new StateProvider for historical block number
     pub fn new(tx: TX, block_number: BlockNumber) -> Self {
         Self {
             tx,
@@ -260,11 +266,13 @@ impl<'a, TX: DbTx<'a>> HistoricalStateProvider<'a, TX> {
         }
     }
 
+    /// Set the lowest block number at which the account history is available.
     pub fn with_lowest_account_history_block_number(mut self, block_number: BlockNumber) -> Self {
         self.lowest_account_history_block_number = Some(block_number);
         self
     }
 
+    /// Set the lowest block number at which the storage history is available.
     pub fn with_lowest_storage_history_block_number(mut self, block_number: BlockNumber) -> Self {
         self.lowest_storage_history_block_number = Some(block_number);
         self

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -1,6 +1,6 @@
 use crate::{
     providers::state::macros::delegate_provider_impls, AccountReader, BlockHashReader, PostState,
-    ProviderError, ProviderFactory, StateProvider, StateRootProvider,
+    ProviderError, StateProvider, StateRootProvider,
 };
 use reth_db::{
     cursor::{DbCursorRO, DbDupCursorRO},
@@ -29,8 +29,8 @@ pub struct HistoricalStateProviderRef<'a, 'b, TX: DbTx<'a>> {
     tx: &'b TX,
     /// Block number is main index for the history state of accounts and storages.
     block_number: BlockNumber,
-    latest_account_history_block_number: Option<BlockNumber>,
-    latest_storage_history_block_number: Option<BlockNumber>,
+    lowest_account_history_block_number: Option<BlockNumber>,
+    lowest_storage_history_block_number: Option<BlockNumber>,
     /// Phantom lifetime `'a`
     _phantom: PhantomData<&'a TX>,
 }
@@ -47,35 +47,37 @@ impl<'a, 'b, TX: DbTx<'a>> HistoricalStateProviderRef<'a, 'b, TX> {
         Self {
             tx,
             block_number,
-            latest_account_history_block_number: None,
-            latest_storage_history_block_number: None,
+            lowest_account_history_block_number: None,
+            lowest_storage_history_block_number: None,
             _phantom: PhantomData {},
         }
     }
 
-    pub fn new_with_latest_history_block_numbers(
+    pub fn new_with_lowest_history_block_numbers(
         tx: &'b TX,
-        latest_account_history_block_number: Option<BlockNumber>,
-        latest_storage_history_block_number: Option<BlockNumber>,
+        lowest_account_history_block_number: Option<BlockNumber>,
+        lowest_storage_history_block_number: Option<BlockNumber>,
         block_number: BlockNumber,
     ) -> Self {
         Self {
             tx,
             block_number,
-            latest_account_history_block_number,
-            latest_storage_history_block_number,
+            lowest_account_history_block_number,
+            lowest_storage_history_block_number,
             _phantom: PhantomData {},
         }
     }
 
     /// Lookup an account in the AccountHistory table
     pub fn account_history_lookup(&self, address: Address) -> Result<HistoryInfo> {
+        // Check if lowest available block number for storage history is more than the requested
+        // block number for this historical provider instance.
         if self
-            .latest_account_history_block_number
-            .map(|block_number| block_number >= self.block_number)
+            .lowest_account_history_block_number
+            .map(|block_number| block_number > self.block_number)
             .unwrap_or(false)
         {
-            return Ok(HistoryInfo::NotYetWritten)
+            return Err(ProviderError::StateAtBlockPruned(self.block_number).into())
         }
 
         // history key to search IntegerList of block number changesets.
@@ -89,12 +91,14 @@ impl<'a, 'b, TX: DbTx<'a>> HistoricalStateProviderRef<'a, 'b, TX> {
         address: Address,
         storage_key: StorageKey,
     ) -> Result<HistoryInfo> {
+        // Check if lowest available block number for account history is more than the requested
+        // block number for this historical provider instance.
         if self
-            .latest_storage_history_block_number
-            .map(|block_number| block_number >= self.block_number)
+            .lowest_storage_history_block_number
+            .map(|block_number| block_number > self.block_number)
             .unwrap_or(false)
         {
-            return Ok(HistoryInfo::NotYetWritten)
+            return Err(ProviderError::StateAtBlockPruned(self.block_number).into())
         }
 
         // history key to search IntegerList of block number changesets.
@@ -238,8 +242,8 @@ pub struct HistoricalStateProvider<'a, TX: DbTx<'a>> {
     tx: TX,
     /// State at the block number is the main indexer of the state.
     block_number: BlockNumber,
-    latest_account_history_block_number: Option<BlockNumber>,
-    latest_storage_history_block_number: Option<BlockNumber>,
+    lowest_account_history_block_number: Option<BlockNumber>,
+    lowest_storage_history_block_number: Option<BlockNumber>,
     /// Phantom lifetime `'a`
     _phantom: PhantomData<&'a TX>,
 }
@@ -250,29 +254,29 @@ impl<'a, TX: DbTx<'a>> HistoricalStateProvider<'a, TX> {
         Self {
             tx,
             block_number,
-            latest_account_history_block_number: None,
-            latest_storage_history_block_number: None,
+            lowest_account_history_block_number: None,
+            lowest_storage_history_block_number: None,
             _phantom: PhantomData {},
         }
     }
 
-    pub fn with_latest_account_history_block_number(mut self, block_number: BlockNumber) -> Self {
-        self.latest_account_history_block_number = Some(block_number);
+    pub fn with_lowest_account_history_block_number(mut self, block_number: BlockNumber) -> Self {
+        self.lowest_account_history_block_number = Some(block_number);
         self
     }
 
-    pub fn with_latest_storage_history_block_number(mut self, block_number: BlockNumber) -> Self {
-        self.latest_storage_history_block_number = Some(block_number);
+    pub fn with_lowest_storage_history_block_number(mut self, block_number: BlockNumber) -> Self {
+        self.lowest_storage_history_block_number = Some(block_number);
         self
     }
 
     /// Returns a new provider that takes the `TX` as reference
     #[inline(always)]
     fn as_ref<'b>(&'b self) -> HistoricalStateProviderRef<'a, 'b, TX> {
-        HistoricalStateProviderRef::new_with_latest_history_block_numbers(
+        HistoricalStateProviderRef::new_with_lowest_history_block_numbers(
             &self.tx,
-            self.latest_account_history_block_number,
-            self.latest_storage_history_block_number,
+            self.lowest_account_history_block_number,
+            self.lowest_storage_history_block_number,
             self.block_number,
         )
     }

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -529,6 +529,8 @@ mod tests {
         let db = create_test_rw_db();
         let tx = db.tx().unwrap();
 
+        // provider block_number < lowest available block number,
+        // i.e. state at provider block is pruned
         let provider = HistoricalStateProviderRef::new_with_lowest_available_blocks(
             &tx,
             2,
@@ -546,6 +548,8 @@ mod tests {
             Err(ProviderError::StateAtBlockPruned(provider.block_number).into())
         );
 
+        // provider block_number == lowest available block number,
+        // i.e. state at provider block is available
         let provider = HistoricalStateProviderRef::new_with_lowest_available_blocks(
             &tx,
             2,
@@ -560,6 +564,8 @@ mod tests {
             Ok(HistoryInfo::NotYetWritten)
         );
 
+        // provider block_number == lowest available block number,
+        // i.e. state at provider block is available
         let provider = HistoricalStateProviderRef::new_with_lowest_available_blocks(
             &tx,
             2,


### PR DESCRIPTION
Tested with requesting the `trace_transaction` for beacon deposit contract creation transaction https://etherscan.io/tx/0xe75fb554e433e03763a1560646ee22dcb74e5274b34c5ad644e7c0f619a7e1d0.

Before:
```console
ubuntu@reth1:~/reth-alexey$ cast rpc trace_transaction 0xe75fb554e433e03763a1560646ee22dcb74e5274b34c5ad644e7c0f619a7e1d0
Error:
(code: -32003, message: nonce too high, data: None)
```
After:
```console
ubuntu@reth1:~/reth-alexey$ cast rpc trace_transaction 0xe75fb554e433e03763a1560646ee22dcb74e5274b34c5ad644e7c0f619a7e1d0
Error:
(code: -32603, message: State at block #11052984 is pruned, data: None)
```

Same for other methods that use the historical state provider:
```console
ubuntu@reth1:~/reth-alexey$ cast rpc eth_getStorageAt 0x00000000219ab540356cBB839Cbe05303d7705Fa 0x0000000000000000000000000000000000000000000000000000000000000000 0x2
Error:
(code: -32603, message: State at block #3 is pruned, data: None)
```