### PR TITLE
feat: add `TransactionSigned::recover_signers`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5785,6 +5785,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rand 0.8.5",
+ "rayon",
  "reth-codecs",
  "reth-rlp",
  "reth-rlp-derive",

--- a/crates/consensus/auto-seal/src/lib.rs
+++ b/crates/consensus/auto-seal/src/lib.rs
@@ -342,10 +342,8 @@ impl StorageInner {
 
         let block = Block { header, body: transactions, ommers: vec![], withdrawals: None };
 
-        let senders =
-            block.body.iter().map(|tx| tx.recover_signer()).collect::<Option<Vec<_>>>().ok_or(
-                BlockExecutionError::Validation(BlockValidationError::SenderRecoveryError),
-            )?;
+        let senders = TransactionSigned::recover_signers(block.body.iter(), block.body.len())
+            .ok_or(BlockExecutionError::Validation(BlockValidationError::SenderRecoveryError))?;
 
         trace!(target: "consensus::auto", transactions=?&block.body, "executing transactions");
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -57,6 +57,7 @@ impl-serde = "0.4.0"
 once_cell = "1.17.0"
 zstd = { version = "0.12", features = ["experimental"] }
 paste = "1.0"
+rayon = "1.7"
 
 # proof related
 triehash = "0.8"

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -163,7 +163,7 @@ impl SealedBlock {
 
     /// Expensive operation that recovers transaction signer. See [SealedBlockWithSenders].
     pub fn senders(&self) -> Option<Vec<Address>> {
-        self.body.iter().map(|tx| tx.recover_signer()).collect::<Option<Vec<Address>>>()
+        TransactionSigned::recover_signers(self.body.iter(), self.body.len())
     }
 
     /// Seal sealed block with recovered transaction senders.

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -7,6 +7,7 @@ use bytes::{Buf, BytesMut};
 use derive_more::{AsRef, Deref};
 pub use error::InvalidTransactionError;
 pub use meta::TransactionMeta;
+use rayon::prelude::{ParallelBridge, ParallelIterator};
 use reth_codecs::{add_arbitrary_tests, derive_arbitrary, Compact};
 use reth_rlp::{
     length_of_length, Decodable, DecodeError, Encodable, Header, EMPTY_LIST_CODE, EMPTY_STRING_CODE,
@@ -847,6 +848,24 @@ impl TransactionSigned {
     pub fn recover_signer(&self) -> Option<Address> {
         let signature_hash = self.signature_hash();
         self.signature.recover_signer(signature_hash)
+    }
+
+    /// Recovers a list of signers from a transaction list iterator
+    ///
+    /// Returns `None`, if some transaction's signature is invalid, see also
+    /// [Self::recover_signer].
+    pub fn recover_signers<'a>(
+        txes: impl Iterator<Item = &'a Self> + Send,
+        num_txes: usize,
+    ) -> Option<Vec<Address>> {
+        // Arbitrary value.
+        let threshold = 10;
+
+        if num_txes < threshold {
+            txes.map(|tx| tx.recover_signer()).collect()
+        } else {
+            txes.cloned().par_bridge().map(|tx| tx.recover_signer()).collect()
+        }
     }
 
     /// Consumes the type, recover signer and return [`TransactionSignedEcRecovered`]

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -33,7 +33,8 @@ mod signature;
 mod tx_type;
 pub(crate) mod util;
 
-// Expected number of transactions where we can expect a speed-up by recovering the senders in parallel.
+// Expected number of transactions where we can expect a speed-up by recovering the senders in
+// parallel.
 const PARALLEL_SENDER_RECOVERY_THRESHOLD: usize = 10;
 
 /// A raw transaction.
@@ -861,7 +862,6 @@ impl TransactionSigned {
         txes: impl Iterator<Item = &'a Self> + Send,
         num_txes: usize,
     ) -> Option<Vec<Address>> {
-
         if num_txes < PARALLEL_SENDER_RECOVERY_THRESHOLD {
             txes.map(|tx| tx.recover_signer()).collect()
         } else {

--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -84,11 +84,8 @@ where
                 Err(BlockValidationError::SenderRecoveryError.into())
             }
         } else {
-            body.iter()
-                .map(|tx| {
-                    tx.recover_signer().ok_or(BlockValidationError::SenderRecoveryError.into())
-                })
-                .collect()
+            TransactionSigned::recover_signers(body.iter(), body.len())
+                .ok_or(BlockValidationError::SenderRecoveryError.into())
         }
     }
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -22,7 +22,10 @@ use reth_db::{
     transaction::{DbTx, DbTxMut},
     BlockNumberList, DatabaseError,
 };
-use reth_interfaces::Result;
+use reth_interfaces::{
+    executor::{BlockExecutionError, BlockValidationError},
+    Result,
+};
 use reth_primitives::{
     keccak256,
     stage::{StageCheckpoint, StageId},
@@ -1899,14 +1902,12 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> BlockWriter for DatabaseProvider<'
         let tx_iter = if Some(block.body.len()) == senders_len {
             block.body.into_iter().zip(senders.unwrap()).collect::<Vec<(_, _)>>()
         } else {
-            block
-                .body
-                .into_iter()
-                .map(|tx| {
-                    let signer = tx.recover_signer();
-                    (tx, signer.unwrap_or_default())
-                })
-                .collect::<Vec<(_, _)>>()
+            let senders = TransactionSigned::recover_signers(block.body.iter(), block.body.len())
+                .ok_or(BlockExecutionError::Validation(
+                BlockValidationError::SenderRecoveryError,
+            ))?;
+
+            block.body.into_iter().zip(senders).collect()
         };
 
         for (transaction, sender) in tx_iter {


### PR DESCRIPTION
Takes an iterator of `TransactionSigned` and uses `rayon` to recover the signers if the list is bigger than 10.

10 was kinda of an arbitrary value. I ran some tests locally using `random_signed_tx` and I got this on my machine:

```
5 transactions
[crates/interfaces/src/test_utils/generators.rs:476] stop.as_millis() = 2 # sequential
[crates/interfaces/src/test_utils/generators.rs:477] stop.as_micros() = 2234 # sequential
[crates/interfaces/src/test_utils/generators.rs:485] stop.as_millis() = 1 # rayon
[crates/interfaces/src/test_utils/generators.rs:486] stop.as_micros() = 1381 # rayon

10 transactions
[crates/interfaces/src/test_utils/generators.rs:476] stop.as_millis() = 4 # sequential
[crates/interfaces/src/test_utils/generators.rs:477] stop.as_micros() = 4378 # sequential
[crates/interfaces/src/test_utils/generators.rs:485] stop.as_millis() = 1 # rayon
[crates/interfaces/src/test_utils/generators.rs:486] stop.as_micros() = 1408 # rayon

50 transactions
[crates/interfaces/src/test_utils/generators.rs:476] stop.as_millis() = 21 # sequential
[crates/interfaces/src/test_utils/generators.rs:477] stop.as_micros() = 21463 # sequential
[crates/interfaces/src/test_utils/generators.rs:485] stop.as_millis() = 3 # rayon
[crates/interfaces/src/test_utils/generators.rs:486] stop.as_micros() = 3067 # rayon

100 transactions
[crates/interfaces/src/test_utils/generators.rs:476] stop.as_millis() = 43 # sequential
[crates/interfaces/src/test_utils/generators.rs:477] stop.as_micros() = 43153 # sequential
[crates/interfaces/src/test_utils/generators.rs:485] stop.as_millis() = 4 # rayon
[crates/interfaces/src/test_utils/generators.rs:486] stop.as_micros() = 4928 # rayon

500 transactions
[crates/interfaces/src/test_utils/generators.rs:476] stop.as_millis() = 215 # sequential
[crates/interfaces/src/test_utils/generators.rs:477] stop.as_micros() = 215356 # sequential
[crates/interfaces/src/test_utils/generators.rs:485] stop.as_millis() = 19 # rayon
[crates/interfaces/src/test_utils/generators.rs:486] stop.as_micros() = 19746 # rayon
```