### PR TITLE
fix(txpool): emit events on discarding worst txs

### DIFF
--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -377,6 +377,9 @@ where
             return added
         }
 
+        let mut listener = self.event_listener.write();
+        discarded.iter().for_each(|tx| listener.discarded(tx));
+
         // It may happen that a newly added transaction is immediately discarded, so we need to
         // adjust the result here
         added


### PR DESCRIPTION
## Description

Transaction pool should emit `Discarded` event on discarding worst transactions from the subpools after one of them exceeded the size/len limit. 