### PR TITLE
feat: add BlobTransaction network type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.27",
+ "syn 2.0.28",
  "which",
 ]
 

--- a/crates/net/eth-wire/src/types/transactions.rs
+++ b/crates/net/eth-wire/src/types/transactions.rs
@@ -51,6 +51,22 @@ impl From<PooledTransactions> for Vec<TransactionSigned> {
     }
 }
 
+/// A response to [`GetPooledTransactions`] that includes blob data, their commitments, and their
+/// corresponding proofs.
+// TODO: derive_arbitrary
+#[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct BlobTransaction {
+    /// The transaction payload.
+    pub transaction: TransactionSigned,
+    /// The transaction's blob data.
+    pub blobs: Vec<Blob>,
+    /// The transaction's blob commitments.
+    pub commitments: Vec<Bytes48>,
+    /// The transaction's blob proofs.
+    pub proofs: Vec<Bytes48>,
+}
+
 #[cfg(test)]
 mod test {
     use crate::{message::RequestPair, GetPooledTransactions, PooledTransactions};

--- a/crates/net/eth-wire/src/types/transactions.rs
+++ b/crates/net/eth-wire/src/types/transactions.rs
@@ -1,7 +1,10 @@
 //! Implements the `GetPooledTransactions` and `PooledTransactions` message types.
 use reth_codecs::derive_arbitrary;
-use reth_primitives::{TransactionSigned, H256};
-use reth_rlp::{RlpDecodableWrapper, RlpEncodableWrapper};
+use reth_primitives::{
+    kzg::{self, Blob, Bytes48, KzgProof, KzgSettings},
+    TransactionSigned, H256,
+};
+use reth_rlp::{RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -51,11 +54,34 @@ impl From<PooledTransactions> for Vec<TransactionSigned> {
     }
 }
 
+/// An error that can occur when validating a [`BlobTransaction`].
+#[derive(Debug, thiserror::Error)]
+pub enum BlobTransactionValidationError {
+    /// An error arising from failed KZG proof validation.
+    #[error("KZG proof validation failed: {0:?}")]
+    KzgProofValidation(kzg::Error),
+    /// The number of blobs, commitments, and proofs in the blob transaction payload do not match.
+    #[error("Mismatched number of blobs, commitments, and proofs. Blobs: {blobs}, commitments: {commitments}, proofs: {proofs}")]
+    MismatchedLength {
+        /// The number of blobs in the blob transaction payload.
+        blobs: usize,
+        /// The number of commitments in the blob transaction payload.
+        commitments: usize,
+        /// The number of proofs in the blob transaction payload.
+        proofs: usize,
+    },
+}
+
+impl From<kzg::Error> for BlobTransactionValidationError {
+    fn from(err: kzg::Error) -> Self {
+        Self::KzgProofValidation(err)
+    }
+}
+
 /// A response to [`GetPooledTransactions`] that includes blob data, their commitments, and their
 /// corresponding proofs.
 // TODO: derive_arbitrary
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable, Default)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BlobTransaction {
     /// The transaction payload.
     pub transaction: TransactionSigned,
@@ -65,6 +91,47 @@ pub struct BlobTransaction {
     pub commitments: Vec<Bytes48>,
     /// The transaction's blob proofs.
     pub proofs: Vec<Bytes48>,
+}
+
+impl BlobTransaction {
+    /// Verifies that the transaction's blob data, commitments, and proofs are all valid.
+    ///
+    /// Takes as input the [KzgSettings], which should contain the the parameters derived from the
+    /// KZG trusted setup.
+    ///
+    /// This ensures that the blob transaction payload has the same number of blob data elements,
+    /// commitments, and proofs. Each blob data element is verified against its commitment and
+    /// proof.
+    ///
+    /// Returns `false` if the a `(blob, commitment, proof)` tuple fails to verify.
+    pub fn validate(
+        &self,
+        proof_settings: &KzgSettings,
+    ) -> Result<bool, BlobTransactionValidationError> {
+        if self.blobs.len() != self.commitments.len() {
+            return Err(BlobTransactionValidationError::MismatchedLength {
+                blobs: self.blobs.len(),
+                commitments: self.commitments.len(),
+                proofs: self.proofs.len(),
+            })
+        }
+
+        if self.commitments.len() != self.proofs.len() {
+            return Err(BlobTransactionValidationError::MismatchedLength {
+                blobs: self.blobs.len(),
+                commitments: self.commitments.len(),
+                proofs: self.proofs.len(),
+            })
+        }
+
+        // Verify as a batch rather than one-by-one
+        Ok(KzgProof::verify_blob_kzg_proof_batch(
+            self.blobs.as_slice(),
+            self.commitments.as_slice(),
+            self.proofs.as_slice(),
+            proof_settings,
+        )?)
+    }
 }
 
 #[cfg(test)]

--- a/crates/net/eth-wire/src/types/transactions.rs
+++ b/crates/net/eth-wire/src/types/transactions.rs
@@ -80,6 +80,9 @@ impl From<kzg::Error> for BlobTransactionValidationError {
 
 /// A response to [`GetPooledTransactions`] that includes blob data, their commitments, and their
 /// corresponding proofs.
+///
+/// This is defined in [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844#networking) as an element
+/// of a [PooledTransactions] response.
 // TODO: derive_arbitrary
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable, Default)]
 pub struct BlobTransaction {

--- a/crates/net/eth-wire/src/types/transactions.rs
+++ b/crates/net/eth-wire/src/types/transactions.rs
@@ -82,7 +82,7 @@ impl BlobTransaction {
     /// commitments, and proofs. Each blob data element is verified against its commitment and
     /// proof.
     ///
-    /// Returns `false` if the a `(blob, commitment, proof)` tuple fails to verify.
+    /// Returns `false` if any blob KZG proof in the response fails to verify.
     pub fn validate(&self, proof_settings: &KzgSettings) -> Result<bool, kzg::Error> {
         // Verify as a batch
         KzgProof::verify_blob_kzg_proof_batch(


### PR DESCRIPTION
This adds the `BlobTransaction` network type, defined in [EIP-4844 Networking](https://eips.ethereum.org/EIPS/eip-4844#networking) as an element of a [PooledTransactions](https://github.com/ethereum/devp2p/blob/master/caps/eth.md#pooledtransactions-0x0a) response.

A simple validate method is added which takes the `KzgSettings` as input, batch validating the blob proofs in the response.