### PR TITLE
feat: do not propagate full 4844 transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.27",
+ "syn 2.0.28",
  "which",
 ]
 

--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -248,7 +248,7 @@ where
             let mut hashes = PooledTransactionsHashesBuilder::new(peer.version);
             let mut full_transactions = FullTransactionsBuilder::default();
 
-            // Iterate throught the transactions to propagate and fill the hashes and full
+            // Iterate through the transactions to propagate and fill the hashes and full
             // transaction lists, before deciding whether or not to send full transactions to the
             // peer.
             for tx in to_propagate.iter() {

--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -19,7 +19,8 @@ use reth_interfaces::{
 use reth_metrics::common::mpsc::UnboundedMeteredReceiver;
 use reth_network_api::{Peers, ReputationChangeKind};
 use reth_primitives::{
-    FromRecoveredTransaction, IntoRecoveredTransaction, PeerId, TransactionSigned, TxHash, H256,
+    FromRecoveredTransaction, IntoRecoveredTransaction, PeerId, TransactionSigned, TxHash, TxType,
+    H256,
 };
 use reth_rlp::Encodable;
 use reth_transaction_pool::{
@@ -247,10 +248,18 @@ where
             let mut hashes = PooledTransactionsHashesBuilder::new(peer.version);
             let mut full_transactions = FullTransactionsBuilder::default();
 
+            // Iterate throught the transactions to propagate and fill the hashes and full
+            // transaction lists, before deciding whether or not to send full transactions to the
+            // peer.
             for tx in to_propagate.iter() {
                 if peer.transactions.insert(tx.hash()) {
                     hashes.push(tx);
-                    full_transactions.push(tx);
+
+                    // Do not send full 4844 transaction hashes to peers. See EIP-4844:
+                    //  * <https://eips.ethereum.org/EIPS/eip-4844#networking>
+                    if tx.tx_type() != TxType::EIP4844 {
+                        full_transactions.push(tx);
+                    }
                 }
             }
             let mut new_pooled_hashes = hashes.build();
@@ -612,7 +621,6 @@ where
 
 /// A transaction that's about to be propagated to multiple peers.
 struct PropagateTransaction {
-    tx_type: u8,
     size: usize,
     transaction: Arc<TransactionSigned>,
 }
@@ -624,8 +632,12 @@ impl PropagateTransaction {
         self.transaction.hash()
     }
 
+    fn tx_type(&self) -> TxType {
+        self.transaction.tx_type()
+    }
+
     fn new(transaction: Arc<TransactionSigned>) -> Self {
-        Self { tx_type: transaction.tx_type().into(), size: transaction.length(), transaction }
+        Self { size: transaction.length(), transaction }
     }
 }
 
@@ -685,7 +697,7 @@ impl PooledTransactionsHashesBuilder {
             PooledTransactionsHashesBuilder::Eth68(msg) => {
                 msg.hashes.push(tx.hash());
                 msg.sizes.push(tx.size);
-                msg.types.push(tx.tx_type);
+                msg.types.push(tx.transaction.tx_type().into());
             }
         }
     }

--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -255,8 +255,14 @@ where
                 if peer.transactions.insert(tx.hash()) {
                     hashes.push(tx);
 
-                    // Do not send full 4844 transaction hashes to peers. See EIP-4844:
-                    //  * <https://eips.ethereum.org/EIPS/eip-4844#networking>
+                    // Do not send full 4844 transaction hashes to peers.
+                    //
+                    //  Nodes MUST NOT automatically broadcast blob transactions to their peers.
+                    //  Instead, those transactions are only announced using
+                    //  `NewPooledTransactionHashes` messages, and can then be manually requested
+                    //  via `GetPooledTransactions`.
+                    //
+                    // From: <https://eips.ethereum.org/EIPS/eip-4844#networking>
                     if tx.tx_type() != TxType::EIP4844 {
                         full_transactions.push(tx);
                     }


### PR DESCRIPTION
This checks the transaction type, and does not propagate the transaction if it is an EIP-4844 transaction. This implements the following part of the EIP-4844 spec:

> Nodes MUST NOT automatically broadcast blob transactions to their peers. Instead, those transactions are only announced using `NewPooledTransactionHashes` messages, and can then be manually requested via `GetPooledTransactions`.