### PR TITLE
chore: unused deps sanity check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.27",
+ "syn 2.0.28",
  "which",
 ]
 

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -411,9 +411,8 @@ mod tests {
     use reth_interfaces::test_utils::{generators, generators::Rng};
     use reth_network_api::noop::NoopNetwork;
     use reth_primitives::{
-        basefee::calculate_next_block_base_fee,
-        constants::{self, ETHEREUM_BLOCK_GAS_LIMIT},
-        BaseFeeParams, Block, BlockNumberOrTag, Header, TransactionSigned, H256, U256,
+        basefee::calculate_next_block_base_fee, constants::ETHEREUM_BLOCK_GAS_LIMIT, BaseFeeParams,
+        Block, BlockNumberOrTag, Header, TransactionSigned, H256, U256,
     };
     use reth_provider::{
         test_utils::{MockEthProvider, NoopProvider},


### PR DESCRIPTION
Fixed unused deps sanity check by removing `constants::self`

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at daaa2e1</samp>

Reformatted `server.rs` to remove unused import and follow style guidelines.