### PR TITLE
fix(trie): dangling storage hashes

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -40,7 +40,7 @@ use reth_revm_primitives::{
 };
 use reth_trie::{prefix_set::PrefixSetMut, StateRoot};
 use std::{
-    collections::{btree_map::Entry, BTreeMap, BTreeSet, HashMap},
+    collections::{btree_map::Entry, BTreeMap, BTreeSet, HashMap, HashSet},
     fmt::Debug,
     ops::{Deref, DerefMut, Range, RangeBounds, RangeInclusive},
     sync::Arc,
@@ -1411,6 +1411,7 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> HashingWriter for DatabaseProvider
         // Initialize prefix sets.
         let mut account_prefix_set = PrefixSetMut::default();
         let mut storage_prefix_set: HashMap<H256, PrefixSetMut> = HashMap::default();
+        let mut destroyed_accounts = HashSet::default();
 
         // storage hashing stage
         {
@@ -1433,8 +1434,12 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> HashingWriter for DatabaseProvider
             let lists = self.changed_accounts_with_range(range.clone())?;
             let accounts = self.basic_accounts(lists)?;
             let hashed_addresses = self.insert_account_for_hashing(accounts)?;
-            for hashed_address in hashed_addresses {
-                account_prefix_set.insert(Nibbles::unpack(hashed_address));
+            for (hashed_address, account) in hashed_addresses {
+                if account.is_some() {
+                    account_prefix_set.insert(Nibbles::unpack(hashed_address));
+                } else {
+                    destroyed_accounts.insert(hashed_address);
+                }
             }
         }
 
@@ -1447,6 +1452,7 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> HashingWriter for DatabaseProvider
                 .with_changed_storage_prefixes(
                     storage_prefix_set.into_iter().map(|(k, v)| (k, v.freeze())).collect(),
                 )
+                .with_destroyed_accounts(destroyed_accounts)
                 .root_with_updates()
                 .map_err(Into::<reth_db::DatabaseError>::into)?;
             if state_root != expected_state_root {
@@ -1561,7 +1567,10 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> HashingWriter for DatabaseProvider
         Ok(hashed_storage_keys)
     }
 
-    fn unwind_account_hashing(&self, range: RangeInclusive<BlockNumber>) -> Result<BTreeSet<H256>> {
+    fn unwind_account_hashing(
+        &self,
+        range: RangeInclusive<BlockNumber>,
+    ) -> Result<BTreeMap<H256, Option<Account>>> {
         let mut hashed_accounts_cursor = self.tx.cursor_write::<tables::HashedAccount>()?;
 
         // Aggregate all block changesets and make a list of accounts that have been changed.
@@ -1586,27 +1595,25 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> HashingWriter for DatabaseProvider
             .map(|(address, account)| (keccak256(address), account))
             .collect::<BTreeMap<_, _>>();
 
-        let hashed_account_keys = BTreeSet::from_iter(hashed_accounts.keys().copied());
-
         hashed_accounts
-            .into_iter()
+            .iter()
             // Apply values to HashedState (if Account is None remove it);
             .try_for_each(|(hashed_address, account)| -> Result<()> {
                 if let Some(account) = account {
-                    hashed_accounts_cursor.upsert(hashed_address, account)?;
-                } else if hashed_accounts_cursor.seek_exact(hashed_address)?.is_some() {
+                    hashed_accounts_cursor.upsert(*hashed_address, *account)?;
+                } else if hashed_accounts_cursor.seek_exact(*hashed_address)?.is_some() {
                     hashed_accounts_cursor.delete_current()?;
                 }
                 Ok(())
             })?;
 
-        Ok(hashed_account_keys)
+        Ok(hashed_accounts)
     }
 
     fn insert_account_for_hashing(
         &self,
         accounts: impl IntoIterator<Item = (Address, Option<Account>)>,
-    ) -> Result<BTreeSet<H256>> {
+    ) -> Result<BTreeMap<H256, Option<Account>>> {
         let mut hashed_accounts_cursor = self.tx.cursor_write::<tables::HashedAccount>()?;
 
         let hashed_accounts = accounts.into_iter().fold(
@@ -1617,18 +1624,16 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> HashingWriter for DatabaseProvider
             },
         );
 
-        let hashed_addresses = BTreeSet::from_iter(hashed_accounts.keys().copied());
-
-        hashed_accounts.into_iter().try_for_each(|(hashed_address, account)| -> Result<()> {
+        hashed_accounts.iter().try_for_each(|(hashed_address, account)| -> Result<()> {
             if let Some(account) = account {
-                hashed_accounts_cursor.upsert(hashed_address, account)?
-            } else if hashed_accounts_cursor.seek_exact(hashed_address)?.is_some() {
+                hashed_accounts_cursor.upsert(*hashed_address, *account)?
+            } else if hashed_accounts_cursor.seek_exact(*hashed_address)?.is_some() {
                 hashed_accounts_cursor.delete_current()?;
             }
             Ok(())
         })?;
 
-        Ok(hashed_addresses)
+        Ok(hashed_accounts)
     }
 }
 
@@ -1770,11 +1775,16 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> BlockExecutionWriter for DatabaseP
             // Initialize prefix sets.
             let mut account_prefix_set = PrefixSetMut::default();
             let mut storage_prefix_set: HashMap<H256, PrefixSetMut> = HashMap::default();
+            let mut destroyed_accounts = HashSet::default();
 
             // Unwind account hashes. Add changed accounts to account prefix set.
             let hashed_addresses = self.unwind_account_hashing(range.clone())?;
-            for hashed_address in hashed_addresses {
-                account_prefix_set.insert(Nibbles::unpack(hashed_address));
+            for (hashed_address, account) in hashed_addresses {
+                if account.is_some() {
+                    account_prefix_set.insert(Nibbles::unpack(hashed_address));
+                } else {
+                    destroyed_accounts.insert(hashed_address);
+                }
             }
 
             // Unwind account history indices.
@@ -1804,6 +1814,7 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> BlockExecutionWriter for DatabaseP
                 .with_changed_storage_prefixes(
                     storage_prefix_set.into_iter().map(|(k, v)| (k, v.freeze())).collect(),
                 )
+                .with_destroyed_accounts(destroyed_accounts)
                 .root_with_updates()
                 .map_err(Into::<reth_db::DatabaseError>::into)?;
 

--- a/crates/storage/provider/src/traits/hashing.rs
+++ b/crates/storage/provider/src/traits/hashing.rs
@@ -3,7 +3,7 @@ use reth_db::models::BlockNumberAddress;
 use reth_interfaces::Result;
 use reth_primitives::{Account, Address, BlockNumber, StorageEntry, H256};
 use std::{
-    collections::{BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap},
     ops::{Range, RangeInclusive},
 };
 
@@ -15,7 +15,10 @@ pub trait HashingWriter: Send + Sync {
     /// # Returns
     ///
     /// Set of hashed keys of updated accounts.
-    fn unwind_account_hashing(&self, range: RangeInclusive<BlockNumber>) -> Result<BTreeSet<H256>>;
+    fn unwind_account_hashing(
+        &self,
+        range: RangeInclusive<BlockNumber>,
+    ) -> Result<BTreeMap<H256, Option<Account>>>;
 
     /// Inserts all accounts into [reth_db::tables::AccountHistory] table.
     ///
@@ -25,7 +28,7 @@ pub trait HashingWriter: Send + Sync {
     fn insert_account_for_hashing(
         &self,
         accounts: impl IntoIterator<Item = (Address, Option<Account>)>,
-    ) -> Result<BTreeSet<H256>>;
+    ) -> Result<BTreeMap<H256, Option<Account>>>;
 
     /// Unwind and clear storage hashing
     ///

--- a/crates/trie/src/prefix_set/mod.rs
+++ b/crates/trie/src/prefix_set/mod.rs
@@ -2,7 +2,7 @@ use reth_primitives::trie::Nibbles;
 use std::rc::Rc;
 
 mod loader;
-pub use loader::PrefixSetLoader;
+pub use loader::{LoadedPrefixSets, PrefixSetLoader};
 
 /// A container for efficiently storing and checking for the presence of key prefixes.
 ///

--- a/crates/trie/src/trie.rs
+++ b/crates/trie/src/trie.rs
@@ -121,14 +121,17 @@ where
         tx: &'a TX,
         range: RangeInclusive<BlockNumber>,
     ) -> Result<Self, StateRootError> {
-        let (account_prefixes, storage_prefixes, destroyed_accounts) =
-            PrefixSetLoader::new(tx).load(range)?;
+        let loaded_prefix_sets = PrefixSetLoader::new(tx).load(range)?;
         Ok(Self::new(tx)
-            .with_changed_account_prefixes(account_prefixes.freeze())
+            .with_changed_account_prefixes(loaded_prefix_sets.account_prefix_set.freeze())
             .with_changed_storage_prefixes(
-                storage_prefixes.into_iter().map(|(k, v)| (k, v.freeze())).collect(),
+                loaded_prefix_sets
+                    .storage_prefix_sets
+                    .into_iter()
+                    .map(|(k, v)| (k, v.freeze()))
+                    .collect(),
             )
-            .with_destroyed_accounts(destroyed_accounts))
+            .with_destroyed_accounts(loaded_prefix_sets.destroyed_accounts))
     }
 
     /// Computes the state root of the trie with the changed account and storage prefixes and

--- a/crates/trie/src/trie.rs
+++ b/crates/trie/src/trie.rs
@@ -16,7 +16,10 @@ use reth_primitives::{
     Address, BlockNumber, StorageEntry, H256,
 };
 use reth_rlp::Encodable;
-use std::{collections::HashMap, ops::RangeInclusive};
+use std::{
+    collections::{HashMap, HashSet},
+    ops::RangeInclusive,
+};
 
 /// StateRoot is used to compute the root node of a state trie.
 pub struct StateRoot<'a, 'b, TX, H> {
@@ -29,6 +32,8 @@ pub struct StateRoot<'a, 'b, TX, H> {
     /// A map containing storage changes with the hashed address as key and a set of storage key
     /// prefixes as the value.
     pub changed_storage_prefixes: HashMap<H256, PrefixSet>,
+    /// A map containing keys of accounts that were destroyed.
+    pub destroyed_accounts: HashSet<H256>,
     /// Previous intermediate state.
     previous_state: Option<IntermediateStateRootState>,
     /// The number of updates after which the intermediate progress should be returned.
@@ -45,6 +50,12 @@ impl<'a, 'b, TX, H> StateRoot<'a, 'b, TX, H> {
     /// Set the changed storage prefixes.
     pub fn with_changed_storage_prefixes(mut self, prefixes: HashMap<H256, PrefixSet>) -> Self {
         self.changed_storage_prefixes = prefixes;
+        self
+    }
+
+    /// Set the destroyed accounts.
+    pub fn with_destroyed_accounts(mut self, accounts: HashSet<H256>) -> Self {
+        self.destroyed_accounts = accounts;
         self
     }
 
@@ -75,6 +86,7 @@ impl<'a, 'b, TX, H> StateRoot<'a, 'b, TX, H> {
             tx: self.tx,
             changed_account_prefixes: self.changed_account_prefixes,
             changed_storage_prefixes: self.changed_storage_prefixes,
+            destroyed_accounts: self.destroyed_accounts,
             threshold: self.threshold,
             previous_state: self.previous_state,
             hashed_cursor_factory,
@@ -92,6 +104,7 @@ where
             tx,
             changed_account_prefixes: PrefixSetMut::default().freeze(),
             changed_storage_prefixes: HashMap::default(),
+            destroyed_accounts: HashSet::default(),
             previous_state: None,
             threshold: 100_000,
             hashed_cursor_factory: tx,
@@ -108,12 +121,14 @@ where
         tx: &'a TX,
         range: RangeInclusive<BlockNumber>,
     ) -> Result<Self, StateRootError> {
-        let (account_prefixes, storage_prefixes) = PrefixSetLoader::new(tx).load(range)?;
+        let (account_prefixes, storage_prefixes, destroyed_accounts) =
+            PrefixSetLoader::new(tx).load(range)?;
         Ok(Self::new(tx)
             .with_changed_account_prefixes(account_prefixes.freeze())
             .with_changed_storage_prefixes(
                 storage_prefixes.into_iter().map(|(k, v)| (k, v.freeze())).collect(),
-            ))
+            )
+            .with_destroyed_accounts(destroyed_accounts))
     }
 
     /// Computes the state root of the trie with the changed account and storage prefixes and
@@ -342,6 +357,8 @@ where
 
         trie_updates.extend(walker_updates.into_iter());
         trie_updates.extend_with_account_updates(hash_builder_updates);
+        trie_updates
+            .extend_with_deletes(self.destroyed_accounts.into_iter().map(TrieKey::StorageTrie));
 
         Ok(StateRootProgress::Complete(root, hashed_entries_walked, trie_updates))
     }

--- a/crates/trie/src/updates.rs
+++ b/crates/trie/src/updates.rs
@@ -99,6 +99,11 @@ impl TrieUpdates {
         }));
     }
 
+    /// Extend the updates with deletes.
+    pub fn extend_with_deletes(&mut self, keys: impl Iterator<Item = TrieKey>) {
+        self.extend(keys.map(|key| (key, TrieOp::Delete)));
+    }
+
     /// Flush updates all aggregated updates to the database.
     pub fn flush<'a, 'tx, TX>(self, tx: &'a TX) -> Result<(), reth_db::DatabaseError>
     where


### PR DESCRIPTION
## Description

If we compute the state root incrementally for a block range where the account got self-destructed, there is a possibility that the intermediate hashes of its storage trie would not be deleted. If the account is re-created later, its previous intermediate hashes might be considered a part of the current storage trie. This is addressed by always removing the storage nodes for any account that has been destroyed.

Should close https://github.com/paradigmxyz/reth/issues/4107