### PR TITLE
chore: update cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.27",
+ "syn 2.0.28",
  "which",
 ]
 


### PR DESCRIPTION
out of sync