### PR TITLE
Revert "feat: add `TransactionSigned::recover_signers`"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5820,7 +5820,6 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rand 0.8.5",
- "rayon",
  "reth-codecs",
  "reth-rlp",
  "reth-rlp-derive",

--- a/crates/consensus/auto-seal/src/lib.rs
+++ b/crates/consensus/auto-seal/src/lib.rs
@@ -349,8 +349,10 @@ impl StorageInner {
 
         let block = Block { header, body: transactions, ommers: vec![], withdrawals: None };
 
-        let senders = TransactionSigned::recover_signers(block.body.iter(), block.body.len())
-            .ok_or(BlockExecutionError::Validation(BlockValidationError::SenderRecoveryError))?;
+        let senders =
+            block.body.iter().map(|tx| tx.recover_signer()).collect::<Option<Vec<_>>>().ok_or(
+                BlockExecutionError::Validation(BlockValidationError::SenderRecoveryError),
+            )?;
 
         trace!(target: "consensus::auto", transactions=?&block.body, "executing transactions");
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -60,7 +60,6 @@ impl-serde = "0.4.0"
 once_cell = "1.17.0"
 zstd = { version = "0.12", features = ["experimental"] }
 paste = "1.0"
-rayon = "1.7"
 
 # proof related
 triehash = "0.8"

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -163,7 +163,7 @@ impl SealedBlock {
 
     /// Expensive operation that recovers transaction signer. See [SealedBlockWithSenders].
     pub fn senders(&self) -> Option<Vec<Address>> {
-        TransactionSigned::recover_signers(self.body.iter(), self.body.len())
+        self.body.iter().map(|tx| tx.recover_signer()).collect::<Option<Vec<Address>>>()
     }
 
     /// Seal sealed block with recovered transaction senders.

--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -84,8 +84,11 @@ where
                 Err(BlockValidationError::SenderRecoveryError.into())
             }
         } else {
-            TransactionSigned::recover_signers(body.iter(), body.len())
-                .ok_or(BlockValidationError::SenderRecoveryError.into())
+            body.iter()
+                .map(|tx| {
+                    tx.recover_signer().ok_or(BlockValidationError::SenderRecoveryError.into())
+                })
+                .collect()
         }
     }
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -22,10 +22,7 @@ use reth_db::{
     transaction::{DbTx, DbTxMut},
     BlockNumberList, DatabaseError,
 };
-use reth_interfaces::{
-    executor::{BlockExecutionError, BlockValidationError},
-    Result,
-};
+use reth_interfaces::Result;
 use reth_primitives::{
     keccak256,
     stage::{StageCheckpoint, StageId},
@@ -1913,12 +1910,14 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> BlockWriter for DatabaseProvider<'
         let tx_iter = if Some(block.body.len()) == senders_len {
             block.body.into_iter().zip(senders.unwrap()).collect::<Vec<(_, _)>>()
         } else {
-            let senders = TransactionSigned::recover_signers(block.body.iter(), block.body.len())
-                .ok_or(BlockExecutionError::Validation(
-                BlockValidationError::SenderRecoveryError,
-            ))?;
-
-            block.body.into_iter().zip(senders).collect()
+            block
+                .body
+                .into_iter()
+                .map(|tx| {
+                    let signer = tx.recover_signer();
+                    (tx, signer.unwrap_or_default())
+                })
+                .collect::<Vec<(_, _)>>()
         };
 
         for (transaction, sender) in tx_iter {


### PR DESCRIPTION
Reverts paradigmxyz/reth#4098

rayon docs:

> The resulting iterator is not guaranteed to keep the order of the original iterator.

let's revert and reevaluate