### PR TITLE
feat(cli): full storage trie recovery

### DIFF
--- a/bin/reth/src/recover/storage_tries.rs
+++ b/bin/reth/src/recover/storage_tries.rs
@@ -5,13 +5,9 @@ use crate::{
     runner::CliContext,
 };
 use clap::Parser;
-use reth_db::{
-    cursor::{DbCursorRO, DbDupCursorRW},
-    init_db, tables,
-    transaction::DbTx,
-};
-use reth_primitives::{keccak256, ChainSpec};
-use reth_provider::{AccountExtReader, BlockNumReader, ProviderFactory};
+use reth_db::{cursor::DbCursorRO, init_db, tables, transaction::DbTx};
+use reth_primitives::ChainSpec;
+use reth_provider::ProviderFactory;
 use std::{fs, sync::Arc};
 use tracing::*;
 
@@ -44,10 +40,6 @@ pub struct Command {
         value_parser = genesis_value_parser
     )]
     chain: Arc<ChainSpec>,
-
-    /// The number of blocks in the past to look through.
-    #[arg(long, default_value_t = 100)]
-    lookback: u64,
 }
 
 impl Command {
@@ -64,31 +56,23 @@ impl Command {
         let factory = ProviderFactory::new(&db, self.chain.clone());
         let mut provider = factory.provider_rw()?;
 
-        let best_block = provider.best_block_number()?;
-
-        let block_range = best_block.saturating_sub(self.lookback)..=best_block;
-        let changed_accounts = provider.changed_accounts_with_range(block_range)?;
-        let destroyed_accounts = provider
-            .basic_accounts(changed_accounts)?
-            .into_iter()
-            .filter_map(|(address, acc)| acc.is_none().then_some(address))
-            .collect::<Vec<_>>();
-
-        info!(target: "reth::cli", destroyed = destroyed_accounts.len(), "Starting recovery of storage tries");
-
         let mut deleted_tries = 0;
         let tx_mut = provider.tx_mut();
+        let mut hashed_account_cursor = tx_mut.cursor_read::<tables::HashedAccount>()?;
         let mut storage_trie_cursor = tx_mut.cursor_dup_read::<tables::StoragesTrie>()?;
-        for address in destroyed_accounts {
-            let hashed_address = keccak256(address);
-            if storage_trie_cursor.seek_exact(hashed_address)?.is_some() {
+        let mut entry = storage_trie_cursor.first()?;
+
+        info!(target: "reth::cli", "Starting pruning of storage tries");
+        while let Some((hashed_address, _)) = entry {
+            if hashed_account_cursor.seek_exact(hashed_address)?.is_none() {
                 deleted_tries += 1;
-                trace!(target: "reth::cli", ?address, ?hashed_address, "Deleting storage trie");
-                storage_trie_cursor.delete_current_duplicates()?;
+                // storage_trie_cursor.delete_current_duplicates()?;
             }
+
+            entry = storage_trie_cursor.next()?;
         }
 
-        provider.commit()?;
+        // provider.commit()?;
         info!(target: "reth::cli", deleted = deleted_tries, "Finished recovery");
 
         Ok(())


### PR DESCRIPTION
## Description

Instead of looking for destroyed accounts within the block range, walk storage tries and delete ones that correspond to non-existing accounts.