### PR TITLE
chore: remove cargo deny rule for c-kzg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,7 +933,7 @@ dependencies = [
 [[package]]
 name = "c-kzg"
 version = "0.1.0"
-source = "git+https://github.com/ethereum/c-kzg-4844#13cec820c08f45318f82ed4e0da0300042758b92"
+source = "git+https://github.com/ethereum/c-kzg-4844#6353f689e5d2802bbaf221253b3acafe4228331c"
 dependencies = [
  "bindgen 0.64.0 (git+https://github.com/rust-lang/rust-bindgen?rev=0de11f0a521611ac8738b7b01d19dddaf3899e66)",
  "cc",

--- a/deny.toml
+++ b/deny.toml
@@ -84,13 +84,6 @@ name = "rustls-webpki"
 expression = "LicenseRef-rustls-webpki"
 license-files = [{ path = "LICENSE", hash = 0x001c7e6c }]
 
-[[licenses.clarify]]
-name = "c-kzg"
-expression = "Apache-2.0"
-# The crate is in `bindings/rust` so we have to go up two directories for the
-# license
-license-files = [{ path = "../../LICENSE", hash = 0x13cec820 }]
-
 # This section is considered when running `cargo deny check sources`.
 # More documentation about the 'sources' section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html


### PR DESCRIPTION
Now that https://github.com/ethereum/c-kzg-4844/pull/328 is merged, we can remove the cargo deny `clarify` rule