### PR TITLE
feat: download blocks in merkle debug script

### DIFF
--- a/bin/reth/src/debug_cmd/mod.rs
+++ b/bin/reth/src/debug_cmd/mod.rs
@@ -30,7 +30,7 @@ impl Command {
     pub async fn execute(self, ctx: CliContext) -> eyre::Result<()> {
         match self.command {
             Subcommands::Execution(command) => command.execute(ctx).await,
-            Subcommands::Merkle(command) => command.execute().await,
+            Subcommands::Merkle(command) => command.execute(ctx).await,
             Subcommands::InMemoryMerkle(command) => command.execute(ctx).await,
         }
     }


### PR DESCRIPTION
This improves the merkle debug script to download blocks, then run the rest of the script. Blocks are inserted before the execution stage runs.

TODO:
 - [ ] testing