### PR TITLE
fix: omit output if empty

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/types.rs
+++ b/crates/revm/revm-inspectors/src/tracing/types.rs
@@ -438,7 +438,7 @@ impl CallTraceNode {
             gas: U256::from(self.trace.gas_limit),
             gas_used: U256::from(self.trace.gas_used),
             input: self.trace.data.clone().into(),
-            output: Some(self.trace.output.clone().into()),
+            output: (!self.trace.output.is_empty()).then(|| self.trace.output.clone().into()),
             error: None,
             revert_reason: None,
             calls: Default::default(),

--- a/crates/rpc/rpc-types/src/eth/trace/geth/call.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/geth/call.rs
@@ -1,6 +1,8 @@
 use reth_primitives::{serde_helper::num::from_int_or_hex, Address, Bytes, H256, U256};
 use serde::{Deserialize, Serialize};
 
+/// The response object for `debug_traceTransaction` with `"tracer": "callTracer"`
+///
 /// <https://github.com/ethereum/go-ethereum/blob/91cb6f863a965481e51d5d9c0e5ccd54796fd967/eth/tracers/native/call.go#L44>
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CallFrame {


### PR DESCRIPTION
output should be omitted if empty:

https://github.com/ethereum/go-ethereum/blob/6e934f40f9a7edd58107725d9d766770bc128775/eth/tracers/native/call.go#L52-L52