### PR TITLE
feat(rpc): Add `address_` namespace and bindings

### DIFF
--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -22,6 +22,7 @@
    1. [trace](./jsonrpc/trace.md)
    1. [admin](./jsonrpc/admin.md)
    1. [rpc](./jsonrpc/rpc.md)
+   1. [address](./jsonrpc/address.md)
 1. [CLI Reference](./cli/cli.md)
    1. [reth node](./cli/node.md)
    1. [reth init](./cli/init.md)

--- a/book/jsonrpc/address.md
+++ b/book/jsonrpc/address.md
@@ -1,0 +1,86 @@
+# `address` Namespace
+
+The `address` API provides methods to discover transactions relevant to particular addresses.
+
+Once discovered, transactions can be obtained and examined using methods in other namespaces.
+
+## Appearances
+A relevant transaction is called an "appearance" and is defined
+here: <https://github.com/ethereum/execution-apis/pull/456>
+
+A set of appearances is a collection of transactions in which the address is involved in
+an important way. An appearance includes:
+- Sender or recipient of ether or tokens
+- Contract caller or callee
+- Contract deployer or deployed contract
+- Block reward for block producer or miner/uncle
+- Consensus layer withdrawal
+
+An appearance is a transaction identifier consisting of a block number and transaction index.
+
+## Node Size
+> Note: The `address` namespace increases the node database size
+
+The `address` namespace is separate because it involves the creation of additional database
+tables for the index that maps addresses to appearances. Users may opt in to the namespace to
+trigger the creation of the index and enable the associated JSON-RPC methods.
+
+## `address_getAppearances`
+
+Returns a set of transaction identifiers relevant to an address.
+
+See also: <https://github.com/ethereum/execution-apis/pull/453>
+
+| Client | Method invocation                                     |
+|--------|-------------------------------------------------------|
+| RPC    | `{"method": "address_getAppearances", "params": [address, opts]}` |
+
+
+
+The block range can optionally be specified either by block number or tag (`latest`, `finalized`, `safe`, `earliest`, `pending`) as the second argument.
+
+| Client | Method invocation                                     |
+|--------|-------------------------------------------------------|
+| RPC    | `{"method": "address_getAppearances", "params": [address, {"firstBlock": block, "lastBlock": block}}]}` |
+
+### Examples
+
+Discover appearances for address `0x30a4...1382`. Returns multiple transactions, the first is in block `14040913` (index `230`), the last is in block `17572135` (index `43`). Those
+transactions can now be examined more closely using other JSON-RPC methods.
+```js
+// > {"jsonrpc":"2.0","id":1,"method":"address_getAppearances","params":["0x30a4639850b3ddeaaca4f06280aa751682f11382"]}
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "result": [
+    {
+      "blockNumber": "0xd63f51",
+      "transactionIndex": "0xe6"
+    },
+    ... // ommitted
+    {
+      "blockNumber": "0x10c2127",
+      "transactionIndex": "0x2b"
+    }
+  ]
+}
+```
+
+Discover appearances for address `0x30a4...1382`, specifically between blocks `17190873` and `17190889`. Two transactions are returned.
+```js
+// > {"jsonrpc":"2.0","id":1,"method":"address_getAppearances","params":["0x30a4639850b3ddeaaca4f06280aa751682f11382",{"firstBlock":"0x1064fd9","lastBlock":"0x1064fe9"}]}
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "result": [
+    {
+      "blockNumber": "0x1064fd9",
+      "transactionIndex": "0x5f"
+    },
+    {
+      "blockNumber": "0x1064fe9",
+      "transactionIndex": "0x59"
+    }
+  ]
+}
+```

--- a/book/jsonrpc/debug.md
+++ b/book/jsonrpc/debug.md
@@ -57,7 +57,7 @@ The `debug_traceBlock` method will return a full stack trace of all invoked opco
 This expects an RLP-encoded block.
 
 > **Note**
-> 
+>
 > The parent of this block must be present, or it will fail.
 
 | Client | Method invocation                                       |

--- a/book/jsonrpc/intro.md
+++ b/book/jsonrpc/intro.md
@@ -12,16 +12,17 @@ Each namespace must be explicitly enabled.
 
 The methods are grouped into namespaces, which are listed below:
 
-| Namespace               | Description                                                                                            | Sensitive |
-|-------------------------|--------------------------------------------------------------------------------------------------------|-----------|
-| [`eth`](./eth.md)       | The `eth` API allows you to interact with Ethereum.                                                    | Maybe     |
-| [`web3`](./web3.md)     | The `web3` API provides utility functions for the web3 client.                                         | No        |
-| [`net`](./net.md)       | The `net` API provides access to network information of the node.                                      | No        |
-| [`txpool`](./txpool.md) | The `txpool` API allows you to inspect the transaction pool.                                           | No        |
-| [`debug`](./debug.md)   | The `debug` API provides several methods to inspect the Ethereum state, including Geth-style traces.   | No        |
-| [`trace`](./trace.md)   | The `trace` API provides several methods to inspect the Ethereum state, including Parity-style traces. | No        |
-| [`admin`](./admin.md)   | The `admin` API allows you to configure your node.                                                     | **Yes**   |
-| [`rpc`](./rpc.md)       | The `rpc` API provides information about the RPC server and its modules.                               | No        |
+| Namespace                 | Description                                                                                            | Sensitive |
+|---------------------------|--------------------------------------------------------------------------------------------------------|-----------|
+| [`eth`](./eth.md)         | The `eth` API allows you to interact with Ethereum.                                                    | Maybe     |
+| [`web3`](./web3.md)       | The `web3` API provides utility functions for the web3 client.                                         | No        |
+| [`net`](./net.md)         | The `net` API provides access to network information of the node.                                      | No        |
+| [`txpool`](./txpool.md)   | The `txpool` API allows you to inspect the transaction pool.                                           | No        |
+| [`debug`](./debug.md)     | The `debug` API provides several methods to inspect the Ethereum state, including Geth-style traces.   | No        |
+| [`trace`](./trace.md)     | The `trace` API provides several methods to inspect the Ethereum state, including Parity-style traces. | No        |
+| [`admin`](./admin.md)     | The `admin` API allows you to configure your node.                                                     | **Yes**   |
+| [`rpc`](./rpc.md)         | The `rpc` API provides information about the RPC server and its modules.                               | No        |
+| [`address`](./address.md) | The `address` API provides methods for finding transactions relevant to address. Increases node size.  | No        |
 
 Note that some APIs are sensitive, since they can be used to configure your node (`admin`), or access accounts stored on the node (`eth`).
 
@@ -114,7 +115,7 @@ You can use `curl`, a programming language with a low-level library, or a tool l
 As a reminder, you need to run the command below to enable all of these APIs using an HTTP transport:
 
 ```bash
-RUST_LOG=info reth node --http --http.api "admin,debug,eth,net,trace,txpool,web3,rpc"
+RUST_LOG=info reth node --http --http.api "address,admin,debug,eth,net,trace,txpool,web3,rpc"
 ```
 
 This allows you to then call:

--- a/crates/rpc/rpc-api/src/address.rs
+++ b/crates/rpc/rpc-api/src/address.rs
@@ -1,0 +1,18 @@
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use reth_primitives::Address;
+use reth_rpc_types::{AddressAppearances, BlockRange};
+
+/// address_ namespace RPC interface.
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "address"))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "address"))]
+pub trait AddressApi {
+    /// Returns transaction identifiers relevant to an address.
+    ///
+    /// See: <https://github.com/ethereum/execution-apis/pull/453/>
+    #[method(name = "getAppearances")]
+    async fn get_appearances(
+        &self,
+        address: Address,
+        range: Option<BlockRange>,
+    ) -> RpcResult<AddressAppearances>;
+}

--- a/crates/rpc/rpc-api/src/lib.rs
+++ b/crates/rpc/rpc-api/src/lib.rs
@@ -19,6 +19,7 @@
 //!
 //! - `client`: Enables JSON-RPC client support.
 
+mod address;
 mod admin;
 mod debug;
 mod engine;
@@ -39,6 +40,7 @@ pub use servers::*;
 /// Aggregates all server traits.
 pub mod servers {
     pub use crate::{
+        address::AddressApiServer,
         admin::AdminApiServer,
         debug::DebugApiServer,
         engine::{EngineApiServer, EngineEthApiServer},
@@ -63,6 +65,7 @@ pub use clients::*;
 #[cfg(feature = "client")]
 pub mod clients {
     pub use crate::{
+        address::AddressApiClient,
         admin::AdminApiClient,
         debug::DebugApiClient,
         engine::{EngineApiClient, EngineEthApiClient},

--- a/crates/rpc/rpc-types/src/address.rs
+++ b/crates/rpc/rpc-types/src/address.rs
@@ -1,0 +1,103 @@
+use reth_primitives::{BlockNumber, BlockNumberOrTag, TxIndex};
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+
+/// An inclusive range of blocks.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct BlockRange {
+    first_block: BlockNumberOrTag,
+    last_block: BlockNumberOrTag,
+}
+
+/// An address_getAppearances method response.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct AddressAppearances(Vec<RelevantTransaction>);
+
+/// A transaction identifier used in the address_getAppearances method response.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct RelevantTransaction {
+    #[serde(serialize_with = "ser_hex_u64", deserialize_with = "de_hex_u64")]
+    block_number: BlockNumber,
+    #[serde(serialize_with = "ser_hex_u64", deserialize_with = "de_hex_u64")]
+    transaction_index: TxIndex,
+}
+
+fn ser_hex_u64<S>(value: &u64, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&format!("0x{:x}", value))
+}
+
+fn de_hex_u64<'de, D>(deserializer: D) -> Result<BlockNumber, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct Hexu64Visitor;
+    impl<'de> Visitor<'de> for Hexu64Visitor {
+        type Value = u64;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("a hexadecimal u64 string")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            u64::from_str_radix(value.trim_start_matches("0x"), 16)
+                .map_err(|_err| serde::de::Error::custom("invalid hexadecimal u64 string"))
+        }
+    }
+    deserializer.deserialize_str(Hexu64Visitor)
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn serde_block_range() {
+        let range = BlockRange {
+            first_block: BlockNumberOrTag::Number(17190873),
+            last_block: BlockNumberOrTag::Number(17190889),
+        };
+
+        let serialized = serde_json::to_string(&range).unwrap();
+        assert_eq!(serialized, r#"{"firstBlock":"0x1064fd9","lastBlock":"0x1064fe9"}"#);
+        let deserialized: BlockRange = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(range, deserialized);
+    }
+
+    #[test]
+    fn serde_block_range_tags() {
+        let range = BlockRange {
+            first_block: BlockNumberOrTag::Finalized,
+            last_block: BlockNumberOrTag::Latest,
+        };
+
+        let serialized = serde_json::to_string(&range).unwrap();
+        assert_eq!(serialized, r#"{"firstBlock":"finalized","lastBlock":"latest"}"#);
+        let deserialized: BlockRange = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(range, deserialized);
+    }
+
+    #[test]
+    fn serde_appearances() {
+        let appearances = AddressAppearances(vec![
+            RelevantTransaction { block_number: 17190873, transaction_index: 95 },
+            RelevantTransaction { block_number: 17190889, transaction_index: 89 },
+        ]);
+
+        let serialized = serde_json::to_string(&appearances).unwrap();
+        assert_eq!(
+            serialized,
+            r#"[{"blockNumber":"0x1064fd9","transactionIndex":"0x5f"},{"blockNumber":"0x1064fe9","transactionIndex":"0x59"}]"#
+        );
+        let deserialized: AddressAppearances = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(appearances, deserialized);
+    }
+}

--- a/crates/rpc/rpc-types/src/lib.rs
+++ b/crates/rpc/rpc-types/src/lib.rs
@@ -15,11 +15,13 @@
 //!
 //! Provides all relevant types for the various RPC endpoints, grouped by namespace.
 
+mod address;
 mod admin;
 mod eth;
 mod otterscan;
 mod rpc;
 
+pub use address::*;
 pub use admin::*;
 pub use eth::*;
 pub use otterscan::*;

--- a/crates/rpc/rpc/src/address.rs
+++ b/crates/rpc/rpc/src/address.rs
@@ -1,0 +1,37 @@
+#![allow(dead_code, unused_variables)]
+use crate::result::internal_rpc_err;
+use async_trait::async_trait;
+use jsonrpsee::core::RpcResult;
+use reth_primitives::Address;
+use reth_rpc_api::{AddressApiServer, EthApiServer};
+use reth_rpc_types::{AddressAppearances, BlockRange};
+
+/// `address` API implementation.
+///
+/// This type provides the functionality for handling `address` related requests.
+#[derive(Debug)]
+pub struct AddressApi<Eth> {
+    eth: Eth,
+}
+
+impl<Eth> AddressApi<Eth> {
+    /// Creates a new instance of `Address`.
+    pub fn new(eth: Eth) -> Self {
+        Self { eth }
+    }
+}
+
+#[async_trait]
+impl<Eth> AddressApiServer for AddressApi<Eth>
+where
+    Eth: EthApiServer,
+{
+    /// Handler for `address_getAppearances`
+    async fn get_appearances(
+        &self,
+        address: Address,
+        range: Option<BlockRange>,
+    ) -> RpcResult<AddressAppearances> {
+        Err(internal_rpc_err("unimplemented"))
+    }
+}

--- a/crates/rpc/rpc/src/lib.rs
+++ b/crates/rpc/rpc/src/lib.rs
@@ -30,6 +30,7 @@
 //! lot of handlers make use of async functions, caching for example, but are also using blocking
 //! disk-io, hence these calls are spawned as futures to a blocking task manually.
 
+mod address;
 mod admin;
 mod debug;
 mod engine;
@@ -44,6 +45,7 @@ pub mod tracing_call;
 mod txpool;
 mod web3;
 
+pub use address::AddressApi;
 pub use admin::AdminApi;
 pub use debug::DebugApi;
 pub use engine::{EngineApi, EngineEthApi};


### PR DESCRIPTION
## Description
Progress toward:
- #4054 

## Changes
`address_` namespace addition including:
    - add `AddressApi` trait in rpc-api
    - add to RPC builder
    - add placeholder implementation for `address_getAppearances`