### PR TITLE
fix: exclude single stop vm trace instruction

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/types.rs
+++ b/crates/revm/revm-inspectors/src/tracing/types.rs
@@ -599,6 +599,12 @@ impl CallTraceStep {
         log
     }
 
+    /// Returns true if the step is a STOP opcode
+    #[inline]
+    pub(crate) fn is_stop(&self) -> bool {
+        matches!(self.op.u8(), opcode::STOP)
+    }
+
     /// Returns true if the step is a call operation, any of
     /// CALL, CALLCODE, DELEGATECALL, STATICCALL, CREATE, CREATE2
     #[inline]


### PR DESCRIPTION
special case where STOP should be excluded:

ref https://github.com/paradigmxyz/reth/issues/4071

reth rn
```json
{
    "jsonrpc": "2.0",
    "result": {
        "output": "0x",
        "stateDiff": null,
        "trace": [],
        "vmTrace": {
            "code": "0x",
            "ops": [
                {
                    "cost": 0,
                    "ex": {
                        "used": 0,
                        "push": [],
                        "mem": null,
                        "store": null
                    },
                    "pc": 0,
                    "op": "STOP"
                }
            ]
        }
    },
    "id": 1
}
```

erigon
```
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": {
        "output": "0x",
        "stateDiff": null,
        "trace": [],
        "vmTrace": {
            "code": "0x",
            "ops": []
        }
    }
}
```

with this fix:

```json
{
    "jsonrpc": "2.0",
    "result": {
        "output": "0x",
        "stateDiff": null,
        "trace": [],
        "vmTrace": {
            "code": "0x",
            "ops": []
        }
    },
    "id": 1
}
```