### PR TITLE
fix: sub field is always serialized

### DIFF
--- a/crates/rpc/rpc-types/src/eth/trace/parity.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/parity.rs
@@ -298,7 +298,6 @@ pub struct VmInstruction {
     /// The program counter.
     pub pc: usize,
     /// Subordinate trace of the CALL/CREATE if applicable.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sub: Option<VmTrace>,
     /// Stringified opcode.
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
ref #4071

field is always serialized 

https://github.com/ledgerwatch/erigon/blob/60a200fd46dcb0fa246bd4e0971690cfa111b129/turbo/jsonrpc/trace_adhoc.go#L111-L111