### PR TITLE
refactor: Split RethNodeCommandExt into two traits

### DIFF
--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     args::GasPriceOracleArgs,
-    cli::{config::RethRpcConfig, ext::RethNodeCommandExt},
+    cli::{config::RethRpcConfig, ext::RethNodeCommandConfig},
 };
 use clap::{
     builder::{PossibleValue, RangedU64ValueParser, TypedValueParser},
@@ -249,7 +249,7 @@ impl RpcServerArgs {
         Tasks: TaskSpawner + Clone + 'static,
         Events: CanonStateSubscriptions + Clone + 'static,
         Engine: EngineApiServer,
-        Ext: RethNodeCommandExt,
+        Ext: RethNodeCommandConfig,
     {
         let auth_config = self.auth_server_config(jwt_secret)?;
 

--- a/bin/reth/src/cli/ext.rs
+++ b/bin/reth/src/cli/ext.rs
@@ -32,7 +32,7 @@ impl RethCliExt for () {
 }
 
 /// A trait that allows for extending parts of the CLI with additional functionality.
-pub trait RethNodeCommandExt: fmt::Debug + clap::Args {
+pub trait RethNodeCommandConfig {
     /// Allows for registering additional RPC modules for the transports.
     ///
     /// This is expected to call the merge functions of [TransportRpcModules], for example
@@ -101,9 +101,11 @@ pub trait RethNodeCommandExt: fmt::Debug + clap::Args {
 
     // TODO move network related functions here
 }
-
+/// A trait that allows for extending parts of the CLI with additional functionality.
+pub trait RethNodeCommandExt: RethNodeCommandConfig + clap::Args + fmt::Debug {}
 /// The default configuration for the reth node command [Command](crate::node::NodeCommand).
 #[derive(Debug, Clone, Copy, Default, Args)]
 pub struct DefaultRethNodeCommandConfig;
 
+impl RethNodeCommandConfig for DefaultRethNodeCommandConfig {}
 impl RethNodeCommandExt for DefaultRethNodeCommandConfig {}

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -8,7 +8,7 @@ use crate::{
         DatabaseArgs, DebugArgs, DevArgs, NetworkArgs, PayloadBuilderArgs, PruningArgs,
         RpcServerArgs, TxPoolArgs,
     },
-    cli::ext::{RethCliExt, RethNodeCommandExt},
+    cli::ext::{RethCliExt, RethNodeCommandConfig},
     dirs::{DataDirPath, MaybePlatformPath},
     init::init_genesis,
     node::cl_events::ConsensusLayerHealthEvents,

--- a/examples/additional-rpc-namespace-in-cli/src/main.rs
+++ b/examples/additional-rpc-namespace-in-cli/src/main.rs
@@ -16,7 +16,7 @@ use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth::{
     cli::{
         config::RethRpcConfig,
-        ext::{RethCliExt, RethNodeCommandExt},
+        ext::{RethCliExt, RethNodeCommandConfig},
         Cli,
     },
     network::{NetworkInfo, Peers},
@@ -49,7 +49,7 @@ struct RethCliTxpoolExt {
     pub enable_ext: bool,
 }
 
-impl RethNodeCommandExt for RethCliTxpoolExt {
+impl RethNodeCommandConfig for RethCliTxpoolExt {
     // This is the entrypoint for the CLI to extend the RPC server with custom rpc namespaces.
     fn extend_rpc_modules<Conf, Provider, Pool, Network, Tasks, Events>(
         &mut self,


### PR DESCRIPTION
Should fix #4142