### PR TITLE
feat: Make the unwind command support a single stage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5230,6 +5230,7 @@ dependencies = [
  "eyre",
  "fdlimit",
  "futures",
+ "futures-util",
  "hex",
  "human_bytes",
  "humantime",

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -75,6 +75,7 @@ human_bytes = "0.4.1"
 tokio = { workspace = true, features = ["sync", "macros", "time", "rt-multi-thread"] }
 futures.workspace = true
 pin-project.workspace = true
+futures-util.workspace = true
 
 # http/rpc
 hyper = "0.14.25"

--- a/bin/reth/src/stage/run.rs
+++ b/bin/reth/src/stage/run.rs
@@ -187,7 +187,7 @@ impl Command {
                                     config.stages.bodies.downloader_max_concurrent_requests,
                             )
                             .build(fetch_client, consensus.clone(), db.clone()),
-                        consensus: consensus.clone(),
+                        consensus,
                     };
 
                     (Box::new(stage), None)


### PR DESCRIPTION
After adding this PR, we can unwind for a single stage by executing the following command：
```
reth stage unwind execution to-block 300000
```
