### PR TITLE
feat(revm): Add address inspector

### DIFF
--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -751,12 +751,13 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
         let factory = reth_revm::Factory::new(self.chain.clone());
 
         let stack_config = InspectorStackConfig {
+            use_address_tracer: todo!("get 'address' namespace argument"),
             use_printer_tracer: self.debug.print_inspector,
             hook: if let Some(hook_block) = self.debug.hook_block {
                 Hook::Block(hook_block)
             } else if let Some(tx) = self.debug.hook_transaction {
                 Hook::Transaction(tx)
-            } else if self.debug.hook_all {
+            } else if self.debug.hook_all /* || address_namespace_used */ {
                 Hook::All
             } else {
                 Hook::None

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -751,13 +751,13 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
         let factory = reth_revm::Factory::new(self.chain.clone());
 
         let stack_config = InspectorStackConfig {
-            use_address_tracer: todo!("get 'address' namespace argument"),
+            use_address_tracer: false, // todo: get 'address' namespace argument, use Hook::All
             use_printer_tracer: self.debug.print_inspector,
             hook: if let Some(hook_block) = self.debug.hook_block {
                 Hook::Block(hook_block)
             } else if let Some(tx) = self.debug.hook_transaction {
                 Hook::Transaction(tx)
-            } else if self.debug.hook_all /* || address_namespace_used */ {
+            } else if self.debug.hook_all {
                 Hook::All
             } else {
                 Hook::None

--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -1,0 +1,92 @@
+//! Types used by the `address` namespace to represent addresses and their appearances.
+//!
+//! See also: <https://github.com/ethereum/execution-apis/pull/456> for specification.
+
+use std::collections::HashSet;
+
+use revm_primitives::{TransactTo, TxEnv};
+
+use crate::{Address, Block, H160};
+
+/// Detects addresses present in a transaction object
+pub fn get_addresses_from_tx(tx: &TxEnv) -> HashSet<Address> {
+    let mut set = HashSet::<Address>::new();
+    set.insert(tx.caller);
+    for (address, _) in &tx.access_list {
+        set.insert(*address);
+    }
+    if let Some(addresses) = bytes_to_possible_addresses(&tx.data) {
+        for address in addresses {
+            set.insert(address);
+        }
+    }
+    if let TransactTo::Call(address) = tx.transact_to {
+        set.insert(H160(*address));
+    }
+    set
+}
+
+/// Addresses present in a block object
+#[derive(Debug, Clone)]
+pub struct BlockAddresses {
+    /// Address in the block "miner" field (miner / producer / beneficiary)
+    pub miner: Address,
+    /// Addresses in the block "withdrawals" field
+    pub withdrawals: Option<HashSet<Address>>,
+    /// Unique addresses in the "miner" field of each header in the block "uncles" field.
+    pub uncles: Option<HashSet<Address>>,
+    /// Unique addresses in the "addess" field of each object in the block "withdrawals" field.
+    pub alloc: Option<HashSet<Address>>,
+}
+
+/// Detects addresses present in a block object
+pub fn get_addresses_from_block(block: &Block) -> BlockAddresses {
+    let withdrawals = match &block.withdrawals {
+        Some(withdrawals) => {
+            let mut set = HashSet::<Address>::new();
+            for withdrawal in withdrawals {
+                set.insert(withdrawal.address);
+            }
+            Some(set)
+        }
+        None => None,
+    };
+    let uncles = match block.ommers.is_empty() {
+        true => None,
+        false => {
+            let mut set = HashSet::<Address>::new();
+            for uncle in &block.ommers {
+                set.insert(uncle.beneficiary);
+            }
+            Some(set)
+        }
+    };
+    BlockAddresses { miner: block.beneficiary, withdrawals, uncles, alloc: None }
+}
+
+/// A possible address is used when finding addresses in bytes. It may include false positives.
+///
+/// Specification: <https://github.com/ethereum/execution-apis/pull/456>
+pub type PossibleAddress = Address;
+
+/// A unique set of possible addresses.
+pub type PossibleAddresses = HashSet<PossibleAddress>;
+
+/// Searches for and returns addresses that are present in bytes.
+///
+/// See also: <https://github.com/ethereum/execution-apis/pull/456> for the algorithm specification.
+pub fn bytes_to_possible_addresses(bytes: &[u8]) -> Option<PossibleAddresses> {
+    if bytes.len() < 20 {
+        return None
+    }
+    // todo
+    None
+}
+
+/// Detects an address if present in 32 bytes.
+///
+/// See also: <https://github.com/ethereum/execution-apis/pull/456> for the algorithm specification.
+pub fn bytes32_to_possible_address(_logs: &[u8; 32]) -> Option<PossibleAddress> {
+    // todo
+    None
+}

--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -8,6 +8,19 @@ use revm_primitives::{TransactTo, TxEnv};
 
 use crate::{Address, Block, H160};
 
+/// For an address to be found in 32 by sequence, the sequence MUST NOT be smaller than this.
+///
+/// This excludes vanity addresses that start with 8 empty bytes.
+const SMALLEST: &[u8; 32] =
+    &hex_literal::hex!("00000000000000000000000000000000000000ffffffffffffffffffffffffff");
+
+/// For an address to be found in 32 by sequence, the sequence MUST start with 12 empty bytes.
+const LARGEST: &[u8; 32] =
+    &hex_literal::hex!("000000000000000000000000ffffffffffffffffffffffffffffffffffffffff");
+
+/// For an address to be found in 32 by sequence, the sequence MUST NOT end with 8 empty bytes.
+const FOUR_EMPTY_BYTES: &[u8; 4] = &[0u8; 4];
+
 /// Detects addresses present in a transaction object
 pub fn get_addresses_from_tx(tx: &TxEnv) -> HashSet<Address> {
     let mut set = HashSet::<Address>::new();
@@ -79,14 +92,97 @@ pub fn bytes_to_possible_addresses(bytes: &[u8]) -> Option<PossibleAddresses> {
     if bytes.len() < 20 {
         return None
     }
-    // todo
-    None
+    let mut set = HashSet::<Address>::new();
+    bytes
+        .chunks_exact(32)
+        .map(|c| {
+            let slice: &[u8; 32] = c.try_into().expect("Size of chunk already checked");
+            slice
+        })
+        .filter_map(bytes32_to_possible_address)
+        .for_each(|addr| {
+            set.insert(addr);
+        });
+    match set.is_empty() {
+        true => None,
+        false => Some(set),
+    }
 }
 
 /// Detects an address if present in 32 bytes.
 ///
 /// See also: <https://github.com/ethereum/execution-apis/pull/456> for the algorithm specification.
-pub fn bytes32_to_possible_address(_logs: &[u8; 32]) -> Option<PossibleAddress> {
-    // todo
-    None
+pub fn bytes32_to_possible_address(bytes: &[u8; 32]) -> Option<PossibleAddress> {
+    if bytes > LARGEST || bytes < SMALLEST {
+        return None
+    }
+    if bytes.ends_with(FOUR_EMPTY_BYTES) {
+        return None
+    }
+    Some(H160(bytes[12..].try_into().expect("Length of bytes already checked")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // Test cases from: <https://github.com/ethereum/execution-apis/pull/456>
+    #[test]
+    fn valid_addresses_in_bytes32() {
+        let maximum =
+            hex_literal::hex!("000000000000000000000000ffffffffffffffffffffffffffffffffffffffff");
+        let maximum_expected = H160(hex_literal::hex!("ffffffffffffffffffffffffffffffffffffffff"));
+        assert_eq!(bytes32_to_possible_address(&maximum).unwrap(), maximum_expected);
+
+        let minimum =
+            hex_literal::hex!("00000000000000000000000000000000000000ffffffffffffffffffffffffff");
+        let minimum_expected = H160(hex_literal::hex!("00000000000000ffffffffffffffffffffffffff"));
+        assert_eq!(bytes32_to_possible_address(&minimum).unwrap(), minimum_expected);
+
+        let max_trailing =
+            hex_literal::hex!("000000000000000000000000fffffffffffffffffffffffffffffffff0000000");
+        let maxtrail_expected = H160(hex_literal::hex!("fffffffffffffffffffffffffffffffff0000000"));
+        assert_eq!(bytes32_to_possible_address(&max_trailing).unwrap(), maxtrail_expected);
+
+        let deposit =
+            hex_literal::hex!("00000000000000000000000000000000219ab540356cbb839cbe05303d7705fa");
+        let deposit_expected = H160(hex_literal::hex!("00000000219ab540356cbb839cbe05303d7705fa"));
+        assert_eq!(bytes32_to_possible_address(&deposit).unwrap(), deposit_expected);
+
+        let nondeposit =
+            hex_literal::hex!("0000000000000000000000000219ab540356cbb839cbe05303d7705fa0000000");
+        let nondeposit_expected =
+            H160(hex_literal::hex!("0219ab540356cbb839cbe05303d7705fa0000000"));
+        assert_eq!(bytes32_to_possible_address(&nondeposit).unwrap(), nondeposit_expected);
+    }
+
+    #[test]
+    fn invalid_addresses_in_bytes32() {
+        let invalid_long_trail =
+            hex_literal::hex!("000000000000000000000000ffffffffffffffffffffffffffffffff00000000");
+        assert!(bytes32_to_possible_address(&invalid_long_trail).is_none());
+
+        let nondeposit_8_trailing =
+            hex_literal::hex!("000000000000000000000000219ab540356cbb839cbe05303d7705fa00000000");
+        assert!(bytes32_to_possible_address(&nondeposit_8_trailing).is_none());
+
+        let nondeposit_too_few_leading =
+            hex_literal::hex!("00000000219ab540356cbb839cbe05303d7705faffffffffffffffffffffffff");
+        assert!(bytes32_to_possible_address(&nondeposit_too_few_leading).is_none());
+    }
+
+    #[test]
+    fn test_addresses_in_bytes() {
+        let bytes = hex_literal::hex!("00000000000000000000000000000000219ab540356cbb839cbe05303d7705fa0000000000000000000000000219ab540356cbb839cbe05303d7705fa0000000");
+        let expected_1 = H160(hex_literal::hex!("0219ab540356cbb839cbe05303d7705fa0000000"));
+        let expected_2 = H160(hex_literal::hex!("00000000219ab540356cbb839cbe05303d7705fa"));
+        assert!(bytes_to_possible_addresses(&bytes).unwrap().contains(&expected_1));
+        assert!(bytes_to_possible_addresses(&bytes).unwrap().contains(&expected_2));
+
+        let bytes_with_extra = hex_literal::hex!("00000000000000000000000000000000219ab540356cbb839cbe05303d7705fa0000000000000000000000000219ab540356cbb839cbe05303d7705fa000000000000000");
+        assert!(bytes_to_possible_addresses(&bytes_with_extra).unwrap().contains(&expected_1));
+        assert!(bytes_to_possible_addresses(&bytes_with_extra).unwrap().contains(&expected_2));
+
+        let address_straddling_bytes32_divide = hex_literal::hex!("000000000000000000000000000000000000000000000000219ab540356cbb839cbe05303d7705fa000000000000000000000000000000000000000000000000");
+        assert!(bytes_to_possible_addresses(&address_straddling_bytes32_divide).is_none());
+    }
 }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -21,6 +21,7 @@
 //! - `test-utils`: Export utilities for testing
 pub mod abi;
 mod account;
+pub mod address;
 pub mod basefee;
 mod bits;
 pub mod blobfee;

--- a/crates/revm/revm-inspectors/src/tracing/address.rs
+++ b/crates/revm/revm-inspectors/src/tracing/address.rs
@@ -1,0 +1,152 @@
+//! Address tracing inspector
+//!
+//! When a transaction executes, an address may appear in several places.
+//! This tracer looks for potential addresses and records them.
+//!
+//! This is used to construct and index associated with the `address` namespace.
+//! The index is a map of address -> transactions.
+//!
+//! The appearance specification is located here:
+//! <https://github.com/ethereum/execution-apis/pull/456>. In addition to obvious
+//! places an address may appear (address fields in opcodes), "possible addresses"
+//! are also searched for. These are found by looking in call data and return data
+//! and applying heuristics as outlined in the spec.
+use std::collections::HashSet;
+
+use reth_primitives::{bytes::Bytes, Address};
+use revm::{
+    interpreter::{CallInputs, CreateInputs, Gas, InstructionResult},
+    primitives::{db::Database, B160},
+    EVMData, Inspector,
+};
+
+/// Address tracing inspector that records all address that appear during execution.
+#[derive(Clone, Default)]
+pub struct AddressInspector {
+    /// Unique addresses observed in the transaction
+    inner: HashSet<Address>,
+}
+
+impl AddressInspector {
+    /// Returns the addresses that appeared in the transaction
+    pub fn inner(&self) -> &HashSet<Address> {
+        &self.inner
+    }
+
+    /// Detects addresses in bytes and adds them to the current set.
+    fn extract_addresses(&mut self, bytes: &[u8]) {
+        if bytes.len() < 20 {
+            return
+        }
+
+        if let Some(addresses) = bytes_to_addresses(&bytes) {
+            for address in addresses {
+                self.inner.insert(address);
+            }
+        }
+    }
+}
+
+impl<DB: Database> Inspector<DB> for AddressInspector {
+    fn call_end(
+        &mut self,
+        _data: &mut EVMData<'_, DB>,
+        _inputs: &CallInputs,
+        remaining_gas: Gas,
+        ret: InstructionResult,
+        out: Bytes,
+        _is_static: bool,
+    ) -> (InstructionResult, Gas, Bytes) {
+        self.extract_addresses(&out);
+        (ret, remaining_gas, out)
+    }
+
+    fn create_end(
+        &mut self,
+        _data: &mut EVMData<'_, DB>,
+        _inputs: &CreateInputs,
+        ret: InstructionResult,
+        address: Option<B160>,
+        remaining_gas: Gas,
+        out: Bytes,
+    ) -> (InstructionResult, Option<B160>, Gas, Bytes) {
+        if let Some(addr) = address {
+            self.inner.insert(addr);
+        }
+        self.extract_addresses(&out);
+        (ret, address, remaining_gas, out)
+    }
+
+    fn call(
+        &mut self,
+        _data: &mut EVMData<'_, DB>,
+        inputs: &mut CallInputs,
+        _is_static: bool,
+    ) -> (InstructionResult, Gas, Bytes) {
+        self.inner.insert(inputs.contract);
+        self.inner.insert(inputs.context.address);
+        self.inner.insert(inputs.context.caller);
+        self.inner.insert(inputs.context.code_address);
+        self.extract_addresses(&inputs.input);
+        (InstructionResult::Continue, Gas::new(0), Bytes::new())
+    }
+
+    fn create(
+        &mut self,
+        _data: &mut EVMData<'_, DB>,
+        inputs: &mut CreateInputs,
+    ) -> (InstructionResult, Option<B160>, Gas, Bytes) {
+        self.inner.insert(inputs.caller);
+        (InstructionResult::Continue, None, Gas::new(0), Bytes::new())
+    }
+
+    fn selfdestruct(&mut self, contract: B160, target: B160) {
+        self.inner.insert(contract);
+        self.inner.insert(target);
+    }
+}
+
+/// Searches for and returns addresses that are present in bytes.
+///
+/// See also: <https://github.com/ethereum/execution-apis/pull/456> for the algorithm specification.
+fn bytes_to_addresses(_candidate: &[u8]) -> Option<Vec<Address>> {
+    // todo
+    None
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn count_addresses() {
+        use revm::primitives::hex_literal;
+        // Test from: https://github.com/bluealloy/revm/issues/277
+        let mut evm = revm::new();
+        let mut database = revm::InMemoryDB::default();
+        let code: revm::primitives::Bytes = hex_literal::hex!("5b597fb075978b6c412c64d169d56d839a8fe01b3f4607ed603b2c78917ce8be1430fe6101e8527ffe64706ecad72a2f5c97a95e006e279dc57081902029ce96af7edae5de116fec610208527f9fc1ef09d4dd80683858ae3ea18869fe789ddc365d8d9d800e26c9872bac5e5b6102285260276102485360d461024953601661024a53600e61024b53607d61024c53600961024d53600b61024e5360b761024f5360596102505360796102515360a061025253607261025353603a6102545360fb61025553601261025653602861025753600761025853606f61025953601761025a53606161025b53606061025c5360a661025d53602b61025e53608961025f53607a61026053606461026153608c6102625360806102635360d56102645360826102655360ae61026653607f6101e8610146610220677a814b184591c555735fdcca53617f4d2b9134b29090c87d01058e27e962047654f259595947443b1b816b65cdb6277f4b59c10a36f4e7b8658f5a5e6f5561").to_vec().into();
+
+        let acc_info = revm::primitives::AccountInfo {
+            balance: "0x100c5d668240db8e00".parse().unwrap(),
+            code_hash: revm::primitives::keccak256(&code),
+            code: Some(revm::primitives::Bytecode::new_raw(code.clone())),
+            nonce: "1".parse().unwrap(),
+        };
+        let caller = hex_literal::hex!("5fdcca53617f4d2b9134b29090c87d01058e27e0");
+        let callee = hex_literal::hex!("5fdcca53617f4d2b9134b29090c87d01058e27e9");
+
+        database.insert_account_info(revm::primitives::B160(callee), acc_info);
+        evm.database(database);
+        evm.env.tx.caller = revm::primitives::B160(caller);
+        evm.env.tx.transact_to = revm::primitives::TransactTo::Call(revm::primitives::B160(callee));
+        evm.env.tx.data = revm::primitives::Bytes::new();
+        evm.env.tx.value = revm::primitives::U256::ZERO;
+        let mut inspector = AddressInspector::default();
+        let result = evm.inspect_commit(&mut inspector).unwrap();
+        let addresses = inspector.inner();
+        assert_eq!(addresses.len(), 2);
+        assert!(addresses.contains(&B160(caller)));
+        assert!(addresses.contains(&B160(callee)));
+        // Note: Addresses from logs are retrieved from the result of the inspector
+        assert!(result.logs().is_empty());
+    }
+}

--- a/crates/revm/revm-inspectors/src/tracing/mod.rs
+++ b/crates/revm/revm-inspectors/src/tracing/mod.rs
@@ -28,7 +28,7 @@ use crate::tracing::{
     types::{CallTraceNode, StorageChange},
     utils::gas_used,
 };
-pub use address::AddressInspector;
+pub use address::{AddressInspector, get_addresses_from_tx};
 pub use builder::{
     geth::{self, GethTraceBuilder},
     parity::{self, ParityTraceBuilder},

--- a/crates/revm/revm-inspectors/src/tracing/mod.rs
+++ b/crates/revm/revm-inspectors/src/tracing/mod.rs
@@ -28,12 +28,12 @@ use crate::tracing::{
     types::{CallTraceNode, StorageChange},
     utils::gas_used,
 };
+pub use address::AddressInspector;
 pub use builder::{
     geth::{self, GethTraceBuilder},
     parity::{self, ParityTraceBuilder},
 };
 pub use config::TracingInspectorConfig;
-pub use address::AddressInspector;
 pub use fourbyte::FourByteInspector;
 pub use opcount::OpcodeCountInspector;
 

--- a/crates/revm/revm-inspectors/src/tracing/mod.rs
+++ b/crates/revm/revm-inspectors/src/tracing/mod.rs
@@ -15,6 +15,7 @@ use revm::{
 };
 use types::{CallTrace, CallTraceStep};
 
+mod address;
 mod arena;
 mod builder;
 mod config;
@@ -32,6 +33,7 @@ pub use builder::{
     parity::{self, ParityTraceBuilder},
 };
 pub use config::TracingInspectorConfig;
+pub use address::AddressInspector;
 pub use fourbyte::FourByteInspector;
 pub use opcount::OpcodeCountInspector;
 

--- a/crates/revm/revm-inspectors/src/tracing/mod.rs
+++ b/crates/revm/revm-inspectors/src/tracing/mod.rs
@@ -28,7 +28,7 @@ use crate::tracing::{
     types::{CallTraceNode, StorageChange},
     utils::gas_used,
 };
-pub use address::{AddressInspector, get_addresses_from_tx};
+pub use address::AddressInspector;
 pub use builder::{
     geth::{self, GethTraceBuilder},
     parity::{self, ParityTraceBuilder},

--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -9,11 +9,11 @@ use crate::{
 use reth_consensus_common::calc;
 use reth_interfaces::executor::{BlockExecutionError, BlockValidationError};
 use reth_primitives::{
+    address::{get_addresses_from_block, get_addresses_from_tx},
     Account, Address, Block, BlockNumber, Bloom, Bytecode, ChainSpec, Hardfork, Header, Receipt,
     ReceiptWithBloom, TransactionSigned, Withdrawal, H256, U256,
 };
 use reth_provider::{BlockExecutor, PostState, StateProvider};
-use reth_revm_inspectors::tracing::get_addresses_from_tx;
 use revm::{
     db::{AccountState, CacheDB, DatabaseRef},
     primitives::{
@@ -277,7 +277,8 @@ where
             );
         }
         if self.stack.address_tracer.is_some() {
-            todo!("Get block-based address appearances and store in db");
+            let _block_addresses = get_addresses_from_block(block);
+            todo!("Store block-based address appearances in db");
         }
         Ok((post_state, cumulative_gas_used))
     }

--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -190,6 +190,10 @@ where
         let out = if self.stack.should_inspect(&self.evm.env, hash) {
             // execution with inspector.
             let output = self.evm.inspect(&mut self.stack);
+            if let Some(address_inspector) = &self.stack.address_tracer {
+                let _appearances = address_inspector.inner();
+                todo!("store the tx-based addresses in index db");
+            }
             tracing::trace!(
                 target: "evm",
                 ?hash, ?output, ?transaction, env = ?self.evm.env,


### PR DESCRIPTION
## Description

Progress toward 
- #4054 

This PR explores extracting addresses for the `address` namespace during the Execution stage via a new inspector.
This would be gated by the `namespace` flag.

## Changes made
- New `AddressInspector` struct
- Add test case that extracts addresses using the inspector
- Connect the addresses found by the inspector to Execution stage
- Left a TODO where a separate PR can store addresses in a DB.
- Get addresses from non-evm sources (tx sender, recipient), and from block (block producer, withdrawals)
- Add functions for extracting possible addresses from bytes and bytes32, includes test cases from the spec

## To do
- [ ] Identify and remove redundancy in the address search (e..g, A contract read is a superset of a log)
- [ ] Activate the inspector when the namespace flag is enabled
