### PR TITLE
feat(db): add search to `reth db list` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,6 +847,15 @@ version = "0.17.0"
 source = "git+https://github.com/boa-dev/boa#22b014d5d5ab9fba5dc467734227558e75c66d20"
 
 [[package]]
+name = "boyer-moore-magiclen"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c77eb6b3a37f71fcd40e49b56c028ea8795c0e550afd8021e3e6a2369653035"
+dependencies = [
+ "debug-helper",
+]
+
+[[package]]
 name = "brotli"
 version = "3.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,6 +1622,12 @@ name = "data-encoding"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+
+[[package]]
+name = "debug-helper"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f578e8e2c440e7297e008bb5486a3a8a194775224bbc23729b0dbdfaeebf162e"
 
 [[package]]
 name = "debugid"
@@ -5221,6 +5236,7 @@ name = "reth"
 version = "0.1.0-alpha.6"
 dependencies = [
  "backon",
+ "boyer-moore-magiclen",
  "clap",
  "comfy-table",
  "confy",

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -89,6 +89,7 @@ thiserror.workspace = true
 pretty_assertions = "1.3.0"
 humantime = "2.1.0"
 const-str = "0.5.6"
+boyer-moore-magiclen = "0.2.16"
 
 [target.'cfg(not(windows))'.dependencies]
 jemallocator = { version = "0.5.0", optional = true }

--- a/bin/reth/src/db/list.rs
+++ b/bin/reth/src/db/list.rs
@@ -75,12 +75,12 @@ impl TableViewer<()> for ListTableViewer<'_> {
             }
 
             let search = self.args.search.as_ref()
-                .map(|search|
-                    if search.starts_with("0x") {
-                        hex::decode(search.split_at(2).1).unwrap()
-                    } else {
-                        search.as_bytes().to_vec()
-                    })
+                .map(|search| {
+                    if let Some(search) = search.strip_prefix("0x") {
+                        return hex::decode(search).unwrap()
+                    }
+                    search.as_bytes().to_vec()
+                })
                 .unwrap_or_default();
 
 

--- a/bin/reth/src/db/list.rs
+++ b/bin/reth/src/db/list.rs
@@ -22,7 +22,8 @@ pub struct Command {
     /// How many items to take from the walker
     #[arg(long, short, default_value = DEFAULT_NUM_ITEMS)]
     len: usize,
-    /// Search parameter for both keys and values. Prefix it with `0x` to search for binary data, and text otherwise.
+    /// Search parameter for both keys and values. Prefix it with `0x` to search for binary data,
+    /// and text otherwise.
     ///
     /// ATTENTION! For compressed tables (`Transactions` and `Receipts`), there might be
     /// missing results since the search uses the raw uncompressed value from the database.

--- a/bin/reth/src/db/list.rs
+++ b/bin/reth/src/db/list.rs
@@ -22,7 +22,10 @@ pub struct Command {
     /// How many items to take from the walker
     #[arg(long, short, default_value = DEFAULT_NUM_ITEMS)]
     len: usize,
-    /// Search parameter. Prefix it with `0x` to search for binary data.
+    /// Search parameter for both keys and values. Prefix it with `0x` to search for binary data, and text otherwise.
+    ///
+    /// ATTENTION! For compressed tables (`Transactions` and `Receipts`), there might be
+    /// missing results since the search uses the raw uncompressed value from the database.
     #[arg(long)]
     search: Option<String>,
     /// Returns the number of rows found.

--- a/bin/reth/src/db/tui.rs
+++ b/bin/reth/src/db/tui.rs
@@ -3,7 +3,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use reth_db::table::Table;
+use reth_db::table::{Table, TableRow};
 use std::{
     io,
     time::{Duration, Instant},
@@ -45,7 +45,7 @@ pub(crate) enum ViewMode {
 #[derive(Default)]
 pub(crate) struct DbListTUI<F, T: Table>
 where
-    F: FnMut(usize, usize) -> Vec<(T::Key, T::Value)>,
+    F: FnMut(usize, usize) -> Vec<TableRow<T>>,
 {
     /// Fetcher for the next page of items.
     ///
@@ -65,12 +65,12 @@ where
     /// The state of the key list.
     list_state: ListState,
     /// Entries to show in the TUI.
-    entries: Vec<(T::Key, T::Value)>,
+    entries: Vec<TableRow<T>>,
 }
 
 impl<F, T: Table> DbListTUI<F, T>
 where
-    F: FnMut(usize, usize) -> Vec<(T::Key, T::Value)>,
+    F: FnMut(usize, usize) -> Vec<TableRow<T>>,
 {
     /// Create a new database list TUI
     pub(crate) fn new(fetch: F, skip: usize, count: usize, total_entries: usize) -> Self {
@@ -188,7 +188,7 @@ fn event_loop<B: Backend, F, T: Table>(
     tick_rate: Duration,
 ) -> io::Result<()>
 where
-    F: FnMut(usize, usize) -> Vec<(T::Key, T::Value)>,
+    F: FnMut(usize, usize) -> Vec<TableRow<T>>,
 {
     let mut last_tick = Instant::now();
     let mut running = true;
@@ -216,7 +216,7 @@ where
 /// Handle incoming events
 fn handle_event<F, T: Table>(app: &mut DbListTUI<F, T>, event: Event) -> io::Result<bool>
 where
-    F: FnMut(usize, usize) -> Vec<(T::Key, T::Value)>,
+    F: FnMut(usize, usize) -> Vec<TableRow<T>>,
 {
     if app.mode == ViewMode::GoToPage {
         if let Event::Key(key) = event {
@@ -282,7 +282,7 @@ where
 /// Render the UI
 fn ui<B: Backend, F, T: Table>(f: &mut Frame<'_, B>, app: &mut DbListTUI<F, T>)
 where
-    F: FnMut(usize, usize) -> Vec<(T::Key, T::Value)>,
+    F: FnMut(usize, usize) -> Vec<TableRow<T>>,
 {
     let outer_chunks = Layout::default()
         .direction(Direction::Vertical)

--- a/bin/reth/src/db/tui.rs
+++ b/bin/reth/src/db/tui.rs
@@ -296,7 +296,7 @@ where
             .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
             .split(outer_chunks[0]);
 
-        let key_length = format!("{}", app.skip + app.count - 1).len();
+        let key_length = format!("{}", (app.skip + app.count).saturating_sub(1)).len();
 
         let entries: Vec<_> = app.entries.iter().map(|(k, _)| k).collect();
 
@@ -312,7 +312,7 @@ where
             .block(Block::default().borders(Borders::ALL).title(format!(
                 "Keys (Showing entries {}-{} out of {} entries)",
                 app.skip,
-                app.skip + app.entries.len() - 1,
+                (app.skip + app.entries.len()).saturating_sub(1),
                 app.total_entries
             )))
             .style(Style::default().fg(Color::White))

--- a/bin/reth/src/init.rs
+++ b/bin/reth/src/init.rs
@@ -180,7 +180,7 @@ mod tests {
 
     use reth_db::{
         models::{storage_sharded_key::StorageShardedKey, ShardedKey},
-        table::Table,
+        table::{Table, TableRow},
         test_utils::create_test_rw_db,
         DatabaseEnv,
     };
@@ -193,7 +193,7 @@ mod tests {
     #[allow(clippy::type_complexity)]
     fn collect_table_entries<DB, T>(
         tx: &<DB as DatabaseGAT<'_>>::TX,
-    ) -> Result<Vec<(T::Key, T::Value)>, InitDatabaseError>
+    ) -> Result<Vec<TableRow<T>>, InitDatabaseError>
     where
         DB: Database,
         T: Table,

--- a/bin/reth/src/test_vectors/tables.rs
+++ b/bin/reth/src/test_vectors/tables.rs
@@ -8,7 +8,7 @@ use proptest::{
     test_runner::TestRunner,
 };
 use reth_db::{
-    table::{DupSort, Table},
+    table::{DupSort, Table, TableRow},
     tables,
 };
 use reth_primitives::fs;
@@ -81,7 +81,7 @@ where
     let mut rows = vec![];
     let mut seen_keys = HashSet::new();
     let strat = proptest::collection::vec(
-        any_with::<(T::Key, T::Value)>((
+        any_with::<TableRow<T>>((
             <T::Key as Arbitrary>::Parameters::default(),
             <T::Value as Arbitrary>::Parameters::default(),
         )),
@@ -154,7 +154,7 @@ where
 }
 
 /// Save rows to file.
-fn save_to_file<T: Table>(rows: Vec<(T::Key, T::Value)>) -> eyre::Result<()>
+fn save_to_file<T: Table>(rows: Vec<TableRow<T>>) -> eyre::Result<()>
 where
     T::Key: serde::Serialize,
     T::Value: serde::Serialize,

--- a/bin/reth/src/utils.rs
+++ b/bin/reth/src/utils.rs
@@ -8,7 +8,7 @@ use reth_db::{
     database::Database,
     table::Table,
     transaction::{DbTx, DbTxMut},
-    DatabaseError, RawKey, RawTable, RawValue,
+    DatabaseError, RawTable, TableRawRow,
 };
 use reth_interfaces::p2p::{
     bodies::client::BodiesClient,
@@ -121,8 +121,8 @@ impl<'a, DB: Database> DbTool<'a, DB> {
             let mut cursor =
                 tx.cursor_read::<RawTable<T>>().expect("Was not able to obtain a cursor.");
 
-            let map_filter = |res: Result<(RawKey<T::Key>, RawValue<T::Value>), _>| {
-                if let Ok((k, v)) = res {
+            let map_filter = |row: Result<TableRawRow<T>, _>| {
+                if let Ok((k, v)) = row {
                     let result = || {
                         if filter.only_count {
                             return None

--- a/bin/reth/src/utils.rs
+++ b/bin/reth/src/utils.rs
@@ -136,8 +136,8 @@ impl<'a, DB: Database> DbTool<'a, DB> {
                     };
                     match &*bmb {
                         Some(searcher) => {
-                            if searcher.find_first_in(&v.value).is_some() ||
-                                searcher.find_first_in(&k.key).is_some()
+                            if searcher.find_first_in(&v.raw_value()).is_some() ||
+                                searcher.find_first_in(&k.raw_key()).is_some()
                             {
                                 hits += 1;
                                 return result()

--- a/bin/reth/src/utils.rs
+++ b/bin/reth/src/utils.rs
@@ -6,7 +6,7 @@ use reth_consensus_common::validation::validate_block_standalone;
 use reth_db::{
     cursor::DbCursorRO,
     database::Database,
-    table::Table,
+    table::{Table, TableRow},
     transaction::{DbTx, DbTxMut},
     DatabaseError, RawTable, TableRawRow,
 };
@@ -109,7 +109,7 @@ impl<'a, DB: Database> DbTool<'a, DB> {
     ///
     /// [`ListFilter`] can be used to further
     /// filter down the desired results. (eg. List only rows which include `0xd3adbeef`)
-    pub fn list<T: Table>(&self, filter: &ListFilter) -> Result<(Vec<(T::Key, T::Value)>, usize)> {
+    pub fn list<T: Table>(&self, filter: &ListFilter) -> Result<(Vec<TableRow<T>>, usize)> {
         let bmb = Rc::new(BMByte::from(&filter.search));
         if bmb.is_none() && filter.has_search() {
             eyre::bail!("Invalid search.")

--- a/crates/stages/src/test_utils/test_db.rs
+++ b/crates/stages/src/test_utils/test_db.rs
@@ -3,7 +3,7 @@ use reth_db::{
     cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO},
     database::DatabaseGAT,
     models::{AccountBeforeTx, StoredBlockBodyIndices},
-    table::Table,
+    table::{Table, TableRow},
     tables,
     test_utils::{create_test_rw_db, create_test_rw_db_with_path},
     transaction::{DbTx, DbTxGAT, DbTxMut, DbTxMutGAT},
@@ -122,7 +122,7 @@ impl TestTransaction {
     where
         T: Table,
         S: Clone,
-        F: FnMut(&S) -> (T::Key, T::Value),
+        F: FnMut(&S) -> TableRow<T>,
     {
         self.commit(|tx| {
             values.iter().try_for_each(|src| {
@@ -147,7 +147,7 @@ impl TestTransaction {
         T: Table,
         <T as Table>::Value: Clone,
         S: Clone,
-        F: FnMut(&Option<<T as Table>::Value>, &S) -> (T::Key, T::Value),
+        F: FnMut(&Option<<T as Table>::Value>, &S) -> TableRow<T>,
     {
         self.commit(|tx| {
             let mut cursor = tx.cursor_write::<T>()?;

--- a/crates/storage/db/benches/hash_keys.rs
+++ b/crates/storage/db/benches/hash_keys.rs
@@ -106,7 +106,7 @@ where
 
         // Iteration to be benchmarked
         let execution = |(input, db)| {
-            let mut input: Vec<(T::Key, T::Value)> = input;
+            let mut input: Vec<TableRow<T>> = input;
             if scenario_str.contains("_sorted") || scenario_str.contains("append") {
                 input.sort_by(|a, b| a.0.cmp(&b.0));
             }
@@ -134,14 +134,14 @@ where
 /// Generates two batches. The first is to be inserted into the database before running the
 /// benchmark. The second is to be benchmarked with.
 #[allow(clippy::type_complexity)]
-fn generate_batches<T>(size: usize) -> (Vec<(T::Key, T::Value)>, Vec<(T::Key, T::Value)>)
+fn generate_batches<T>(size: usize) -> (Vec<TableRow<T>>, Vec<TableRow<T>>)
 where
     T: Table + Default,
     T::Key: std::hash::Hash + Arbitrary,
     T::Value: Arbitrary,
 {
     let strat = proptest::collection::vec(
-        any_with::<(T::Key, T::Value)>((
+        any_with::<TableRow<T>>((
             <T::Key as Arbitrary>::Parameters::default(),
             <T::Value as Arbitrary>::Parameters::default(),
         )),

--- a/crates/storage/db/benches/utils.rs
+++ b/crates/storage/db/benches/utils.rs
@@ -25,7 +25,7 @@ where
     T::Key: Default + Clone + for<'de> serde::Deserialize<'de>,
     T::Value: Default + Clone + for<'de> serde::Deserialize<'de>,
 {
-    let list: Vec<(T::Key, T::Value)> = serde_json::from_reader(std::io::BufReader::new(
+    let list: Vec<TableRow<T>> = serde_json::from_reader(std::io::BufReader::new(
         std::fs::File::open(format!(
             "{}/../../../testdata/micro/db/{}.json",
             env!("CARGO_MANIFEST_DIR"),

--- a/crates/storage/db/src/abstraction/cursor.rs
+++ b/crates/storage/db/src/abstraction/cursor.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::{
     common::{IterPairResult, PairResult, ValueOnlyResult},
-    table::{DupSort, Table},
+    table::{DupSort, Table, TableRow},
     DatabaseError,
 };
 
@@ -151,7 +151,7 @@ pub struct Walker<'cursor, 'tx, T: Table, CURSOR: DbCursorRO<'tx, T>> {
 impl<'cursor, 'tx, T: Table, CURSOR: DbCursorRO<'tx, T>> std::iter::Iterator
     for Walker<'cursor, 'tx, T, CURSOR>
 {
-    type Item = Result<(T::Key, T::Value), DatabaseError>;
+    type Item = Result<TableRow<T>, DatabaseError>;
     fn next(&mut self) -> Option<Self::Item> {
         let start = self.start.take();
         if start.is_some() {
@@ -220,7 +220,7 @@ impl<'cursor, 'tx, T: Table, CURSOR: DbCursorRW<'tx, T> + DbCursorRO<'tx, T>>
 impl<'cursor, 'tx, T: Table, CURSOR: DbCursorRO<'tx, T>> std::iter::Iterator
     for ReverseWalker<'cursor, 'tx, T, CURSOR>
 {
-    type Item = Result<(T::Key, T::Value), DatabaseError>;
+    type Item = Result<TableRow<T>, DatabaseError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let start = self.start.take();
@@ -250,7 +250,7 @@ pub struct RangeWalker<'cursor, 'tx, T: Table, CURSOR: DbCursorRO<'tx, T>> {
 impl<'cursor, 'tx, T: Table, CURSOR: DbCursorRO<'tx, T>> std::iter::Iterator
     for RangeWalker<'cursor, 'tx, T, CURSOR>
 {
-    type Item = Result<(T::Key, T::Value), DatabaseError>;
+    type Item = Result<TableRow<T>, DatabaseError>;
     fn next(&mut self) -> Option<Self::Item> {
         if self.is_done {
             return None
@@ -334,7 +334,7 @@ impl<'cursor, 'tx, T: DupSort, CURSOR: DbCursorRW<'tx, T> + DbDupCursorRO<'tx, T
 impl<'cursor, 'tx, T: DupSort, CURSOR: DbDupCursorRO<'tx, T>> std::iter::Iterator
     for DupWalker<'cursor, 'tx, T, CURSOR>
 {
-    type Item = Result<(T::Key, T::Value), DatabaseError>;
+    type Item = Result<TableRow<T>, DatabaseError>;
     fn next(&mut self) -> Option<Self::Item> {
         let start = self.start.take();
         if start.is_some() {

--- a/crates/storage/db/src/abstraction/table.rs
+++ b/crates/storage/db/src/abstraction/table.rs
@@ -81,6 +81,9 @@ pub trait Table: Send + Sync + Debug + 'static {
     type Value: Value;
 }
 
+/// Tuple with `T::Key` and `T::Value`.
+pub type TableRow<T> = (<T as Table>::Key, <T as Table>::Value);
+
 /// DupSort allows for keys to be repeated in the database.
 ///
 /// Upstream docs: <https://libmdbx.dqdkfa.ru/usage.html#autotoc_md48>

--- a/crates/storage/db/src/tables/mod.rs
+++ b/crates/storage/db/src/tables/mod.rs
@@ -17,7 +17,7 @@ pub mod models;
 mod raw;
 pub(crate) mod utils;
 
-use crate::abstraction::table::{Table, TableRow};
+use crate::abstraction::table::Table;
 pub use raw::{RawDupSort, RawKey, RawTable, RawValue, TableRawRow};
 use std::{fmt::Display, str::FromStr};
 

--- a/crates/storage/db/src/tables/mod.rs
+++ b/crates/storage/db/src/tables/mod.rs
@@ -17,8 +17,8 @@ pub mod models;
 mod raw;
 pub(crate) mod utils;
 
-use crate::abstraction::table::Table;
-pub use raw::{RawDupSort, RawKey, RawTable, RawValue};
+use crate::abstraction::table::{Table, TableRow};
+pub use raw::{RawDupSort, RawKey, RawTable, RawValue, TableRawRow};
 use std::{fmt::Display, str::FromStr};
 
 /// Declaration of all Database tables.

--- a/crates/storage/db/src/tables/raw.rs
+++ b/crates/storage/db/src/tables/raw.rs
@@ -41,7 +41,8 @@ impl<T: DupSort> DupSort for RawDupSort<T> {
 /// Raw table key.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct RawKey<K: Key> {
-    key: Vec<u8>,
+    /// Inner encoded key
+    pub key: Vec<u8>,
     _phantom: std::marker::PhantomData<K>,
 }
 
@@ -87,7 +88,8 @@ impl<K: Key> Decode for RawKey<K> {
 /// Raw table value.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Serialize, Ord, Hash)]
 pub struct RawValue<V: Value> {
-    value: Vec<u8>,
+    /// Inner compressed value
+    pub value: Vec<u8>,
     _phantom: std::marker::PhantomData<V>,
 }
 

--- a/crates/storage/db/src/tables/raw.rs
+++ b/crates/storage/db/src/tables/raw.rs
@@ -4,6 +4,9 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
+/// Tuple with `RawKey<T::Key>` and `RawValue<T::Value>`.
+pub type TableRawRow<T> = (RawKey<<T as Table>::Key>, RawValue<<T as Table>::Value>);
+
 /// Raw table that can be used to access any table and its data in raw mode.
 /// This is useful for delayed decoding/encoding of data.
 #[derive(Default, Copy, Clone, Debug)]

--- a/crates/storage/db/src/tables/raw.rs
+++ b/crates/storage/db/src/tables/raw.rs
@@ -42,7 +42,7 @@ impl<T: DupSort> DupSort for RawDupSort<T> {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct RawKey<K: Key> {
     /// Inner encoded key
-    pub key: Vec<u8>,
+    key: Vec<u8>,
     _phantom: std::marker::PhantomData<K>,
 }
 
@@ -51,9 +51,13 @@ impl<K: Key> RawKey<K> {
     pub fn new(key: K) -> Self {
         Self { key: K::encode(key).as_ref().to_vec(), _phantom: std::marker::PhantomData }
     }
-    /// Returns the raw key.
+    /// Returns the decoded value.
     pub fn key(&self) -> Result<K, DatabaseError> {
         K::decode(&self.key)
+    }
+    /// Returns the raw key as seen on the database.
+    pub fn raw_key(&self) -> &Vec<u8> {
+        &self.key
     }
 }
 
@@ -89,7 +93,7 @@ impl<K: Key> Decode for RawKey<K> {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Serialize, Ord, Hash)]
 pub struct RawValue<V: Value> {
     /// Inner compressed value
-    pub value: Vec<u8>,
+    value: Vec<u8>,
     _phantom: std::marker::PhantomData<V>,
 }
 
@@ -98,9 +102,13 @@ impl<V: Value> RawValue<V> {
     pub fn new(value: V) -> Self {
         Self { value: V::compress(value).as_ref().to_vec(), _phantom: std::marker::PhantomData }
     }
-    /// Returns the raw value.
+    /// Returns the decompressed value.
     pub fn value(&self) -> Result<V, DatabaseError> {
         V::decompress(&self.value)
+    }
+    /// Returns the raw value as seen on the database.
+    pub fn raw_value(&self) -> &Vec<u8> {
+        &self.value
     }
 }
 

--- a/crates/storage/db/src/tables/utils.rs
+++ b/crates/storage/db/src/tables/utils.rs
@@ -1,6 +1,6 @@
 //! Small database table utilities and helper functions.
 use crate::{
-    table::{Decode, Decompress, Table},
+    table::{Decode, Decompress, Table, TableRow},
     DatabaseError,
 };
 use std::borrow::Cow;
@@ -42,7 +42,7 @@ macro_rules! impl_fixed_arbitrary {
 /// Helper function to decode a `(key, value)` pair.
 pub(crate) fn decoder<'a, T>(
     kv: (Cow<'a, [u8]>, Cow<'a, [u8]>),
-) -> Result<(T::Key, T::Value), DatabaseError>
+) -> Result<TableRow<T>, DatabaseError>
 where
     T: Table,
     T::Key: Decode,


### PR DESCRIPTION
- Adds search to `reth db list` with `--search`.
   -  `--search 0xff` will search for `[0xff]`
   -  `--search ff` will search for `[0x66, 0x66]`
   - search is done only over `RawKey<T>` and `RawValue<T>`, and so, it might miss certain rows on compressed tables
- Adds `--count` to just count the number of results without actually decoding/decompressing anything

