### PR TITLE
style: use unwrap or default

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
@@ -289,10 +289,7 @@ impl ParityTraceBuilder {
     ///
     /// does not have the code fields filled in
     pub fn vm_trace(&self) -> VmTrace {
-        match self.nodes.get(0) {
-            Some(current) => self.make_vm_trace(current),
-            None => VmTrace { code: Default::default(), ops: Vec::new() },
-        }
+        self.nodes.first().map(|node| self.make_vm_trace(node)).unwrap_or_default()
     }
 
     /// Returns a VM trace without the code filled in

--- a/crates/rpc/rpc-types/src/eth/trace/parity.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/parity.rs
@@ -279,7 +279,7 @@ pub struct LocalizedTransactionTrace {
 }
 
 /// A record of a full VM trace for a CALL/CREATE.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct VmTrace {
     /// The code to be executed.


### PR DESCRIPTION
style nit

@<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a44c4e5</samp>

Simplify and improve the `vm_trace` method for tracing EVM execution. Add the `Default` trait to the `VmTrace` struct to enable creating empty traces.