### PR TITLE
fix: restrict max active queries

### DIFF
--- a/crates/net/common/src/ratelimit.rs
+++ b/crates/net/common/src/ratelimit.rs
@@ -27,6 +27,11 @@ impl RateLimit {
         RateLimit { rate, state, sleep: Box::pin(tokio::time::sleep_until(until)) }
     }
 
+    /// Returns the configured limit of the [RateLimit]
+    pub fn limit(&self) -> u64 {
+        self.rate.limit()
+    }
+
     /// Checks if the [RateLimit] is ready to handle a new call
     pub fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<()> {
         match self.state {

--- a/crates/net/dns/src/query.rs
+++ b/crates/net/dns/src/query.rs
@@ -78,8 +78,8 @@ impl<R: Resolver, K: EnrKeyUnambiguous> QueryPool<R, K> {
                 return Poll::Ready(event)
             }
 
-            // queue in new queries
-            'queries: loop {
+            // queue in new queries if we have capacity
+            'queries: while self.active_queries.len() < self.rate_limit.limit() as usize {
                 if self.rate_limit.poll_ready(cx).is_ready() {
                     if let Some(query) = self.queued_queries.pop_front() {
                         self.rate_limit.tick();


### PR DESCRIPTION
ref #4155

this enforces that only x queries are active at a time

we should increase the rate separately