### PR TITLE
fix: spawn js service task on blocking pool

### DIFF
--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -538,7 +538,9 @@ where
         let (to_db_service, rx) = mpsc::channel(1);
         let (ready_tx, ready_rx) = std::sync::mpsc::channel();
         let this = self.clone();
-        self.inner.task_spawner.spawn(Box::pin(async move {
+        // this needs to be on a blocking task because it only does blocking work besides waiting
+        // for db requests
+        self.inner.task_spawner.spawn_blocking(Box::pin(async move {
             this.js_trace_db_service_task(at, rx, ready_tx, db).await
         }));
         // wait for initialization


### PR DESCRIPTION
closes #4179

the js tracer service task must be spawned on blocking pool otherwise it chokes because this task only does disk io