### PR TITLE
fix: return engine on fatal error

### DIFF
--- a/crates/interfaces/src/executor.rs
+++ b/crates/interfaces/src/executor.rs
@@ -61,6 +61,8 @@ pub enum BlockExecutionError {
 
 impl BlockExecutionError {
     /// Returns `true` if the error is fatal.
+    ///
+    /// This represents an unrecoverable database related error.
     pub fn is_fatal(&self) -> bool {
         matches!(self, Self::CanonicalCommit { .. } | Self::CanonicalRevert { .. })
     }


### PR DESCRIPTION
this will now terminate the node if we encounter a fatal unrecoverable error, (database commit).