### PR TITLE
chore(tree): log error on unreachable

### DIFF
--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -972,6 +972,12 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
             let canon_fork: BlockNumHash = new_canon_chain.fork_block();
             // sanity check
             if self.block_indices.canonical_hash(&canon_fork.number) != Some(canon_fork.hash) {
+                error!(
+                    target: "blockchain_tree",
+                    ?canon_fork,
+                    ?self.block_indices,
+                    "All chains should point to canonical chain"
+                );
                 unreachable!("all chains should point to canonical chain.");
             }
 


### PR DESCRIPTION
Unreachable panic turned out to be not that unreachable on full node, so we better log the details of this error.