### PR TITLE
fix(poststate): ignore old changed storage values after selfdestruct

### DIFF
--- a/crates/storage/provider/src/post_state/mod.rs
+++ b/crates/storage/provider/src/post_state/mod.rs
@@ -1520,7 +1520,6 @@ mod tests {
         );
         init_state.write_to_db(&tx, 0).expect("Could not write init state to DB");
 
-
         let mut post_state = PostState::new();
         post_state.destroy_account(1, address1, Account::default());
         post_state.create_account(1, address1, Account::default());
@@ -1528,7 +1527,7 @@ mod tests {
             1,
             address1,
             // 0x01 => 0 => 5
-            BTreeMap::from([(U256::from(1), (U256::ZERO, U256::from(5)))])
+            BTreeMap::from([(U256::from(1), (U256::ZERO, U256::from(5)))]),
         );
         post_state.write_to_db(&tx, 1).expect("Could not write post state to DB");
 

--- a/crates/storage/provider/src/post_state/mod.rs
+++ b/crates/storage/provider/src/post_state/mod.rs
@@ -1500,6 +1500,61 @@ mod tests {
     }
 
     #[test]
+    fn storage_change_after_selfdestruct_within_block() {
+        let db: Arc<DatabaseEnv> = create_test_rw_db();
+        let tx = db.tx_mut().expect("Could not get database tx");
+
+        let address1 = Address::random();
+
+        let mut init_state = PostState::new();
+        init_state.create_account(0, address1, Account::default());
+        init_state.change_storage(
+            0,
+            address1,
+            // 0x00 => 0 => 1
+            // 0x01 => 0 => 2
+            BTreeMap::from([
+                (U256::from(0), (U256::ZERO, U256::from(1))),
+                (U256::from(1), (U256::ZERO, U256::from(2))),
+            ]),
+        );
+        init_state.write_to_db(&tx, 0).expect("Could not write init state to DB");
+
+
+        let mut post_state = PostState::new();
+        post_state.destroy_account(1, address1, Account::default());
+        post_state.create_account(1, address1, Account::default());
+        post_state.change_storage(
+            1,
+            address1,
+            // 0x01 => 0 => 5
+            BTreeMap::from([(U256::from(1), (U256::ZERO, U256::from(5)))])
+        );
+        post_state.write_to_db(&tx, 1).expect("Could not write post state to DB");
+
+        let mut storage_changeset_cursor = tx
+            .cursor_dup_read::<tables::StorageChangeSet>()
+            .expect("Could not open plain storage state cursor");
+        let range = BlockNumberAddress::range(1..=1);
+        let mut storage_changes = storage_changeset_cursor.walk_range(range).unwrap();
+
+        assert_eq!(
+            storage_changes.next(),
+            Some(Ok((
+                BlockNumberAddress((1, address1)),
+                StorageEntry { key: H256::from_low_u64_be(0), value: U256::from(1) }
+            )))
+        );
+        assert_eq!(
+            storage_changes.next(),
+            Some(Ok((
+                BlockNumberAddress((1, address1)),
+                StorageEntry { key: H256::from_low_u64_be(1), value: U256::from(2) }
+            )))
+        );
+    }
+
+    #[test]
     fn reuse_selfdestructed_account() {
         let address_a = Address::zero();
 

--- a/crates/storage/provider/src/post_state/storage.rs
+++ b/crates/storage/provider/src/post_state/storage.rs
@@ -89,8 +89,7 @@ impl StorageChanges {
     {
         let block_entry = self.inner.entry(block).or_default();
         let storage_entry = block_entry.entry(address).or_default();
-        
-        
+
         let was_previously_wiped = storage_entry.wipe.is_wiped();
         if !was_previously_wiped {
             for (slot, value) in storage {

--- a/crates/storage/provider/src/post_state/storage.rs
+++ b/crates/storage/provider/src/post_state/storage.rs
@@ -89,14 +89,20 @@ impl StorageChanges {
     {
         let block_entry = self.inner.entry(block).or_default();
         let storage_entry = block_entry.entry(address).or_default();
+        
+        
+        let was_previously_wiped = storage_entry.wipe.is_wiped();
+        if !was_previously_wiped {
+            for (slot, value) in storage {
+                if let Entry::Vacant(entry) = storage_entry.storage.entry(slot) {
+                    entry.insert(value);
+                    self.size += 1;
+                }
+            }
+        }
+
         if wipe.is_wiped() {
             storage_entry.wipe = wipe;
-        }
-        for (slot, value) in storage {
-            if let Entry::Vacant(entry) = storage_entry.storage.entry(slot) {
-                entry.insert(value);
-                self.size += 1;
-            }
         }
     }
 


### PR DESCRIPTION
## Description

If the storage entry was changed after a primary selfdestruct within the same block, during history write its value would be written as `0` because its plain state value would be ignored by `storage.storage.contains_key(..)` checks below: 
https://github.com/paradigmxyz/reth/blob/afea377a2929208a9bb063dd201199e59632b4ac/crates/storage/provider/src/post_state/mod.rs#L555-L564

## Solution

Do not write old storage values for the block storage change, if this account was previously wiped within the same block.