### PR TITLE
perf: let sync status mirror FCU

### DIFF
--- a/crates/consensus/beacon/src/engine/message.rs
+++ b/crates/consensus/beacon/src/engine/message.rs
@@ -34,11 +34,6 @@ pub struct OnForkChoiceUpdated {
 // === impl OnForkChoiceUpdated ===
 
 impl OnForkChoiceUpdated {
-    /// Returns true if this update is valid
-    pub(crate) fn is_valid_update(&self) -> bool {
-        self.forkchoice_status.is_valid()
-    }
-
     /// Returns the determined status of the received ForkchoiceState.
     pub fn forkchoice_status(&self) -> ForkchoiceStatus {
         self.forkchoice_status


### PR DESCRIPTION
closes #4187

set sync status based on what we return for FCU

this mirrors geth's behaviour: 

https://github.com/ethereum/go-ethereum/blob/2a6beb6a39d7cb3c5906dd4465d65da6efcc73cd/eth/catalyst/api.go#L304-L304