### PR TITLE
chore(txpool): bench requires arbitrary feature

### DIFF
--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -62,5 +62,5 @@ arbitrary = ["proptest", "reth-primitives/arbitrary"]
 
 [[bench]]
 name = "reorder"
-required-features = ["test-utils"]
+required-features = ["test-utils", "arbitrary"]
 harness = false


### PR DESCRIPTION
# Description

Transaction pool `reorder` bench requires `arbitrary` feature.