### PR TITLE
chore: handle full peer request channel

### DIFF
--- a/crates/net/network/src/metrics.rs
+++ b/crates/net/network/src/metrics.rs
@@ -67,6 +67,8 @@ pub struct TransactionsManagerMetrics {
     pub(crate) messages_with_already_seen_transactions: Counter,
     /// Number of transactions about to be imported into the pool.
     pub(crate) pending_pool_imports: Gauge,
+    /// How often we failed to send a request to the peer because the channel was full.
+    pub(crate) egress_peer_channel_full: Counter,
 }
 
 /// Metrics for Disconnection types

--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -341,6 +341,10 @@ where
 
             if peer.request_tx.try_send(req).is_ok() {
                 self.inflight_requests.push(GetPooledTxRequest { peer_id, response: rx })
+            } else {
+                // peer channel is saturated, drop the request
+                self.metrics.egress_peer_channel_full.increment(1);
+                return
             }
 
             if num_already_seen > 0 {


### PR DESCRIPTION
this adds a new metric for how often we failed to send a response because the peer#s channel is already saturated (spammer)

and does not report if we failed to deliver the request