### PR TITLE
(fix)db commit on debug_traceCallMany

### DIFF
--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -421,14 +421,9 @@ where
                         )?;
 
                         // If there is more transactions, commit the database
-                        if transactions.peek().is_some() {
+                        // If there is no transactions, but more bundles, commit to the database too
+                        if transactions.peek().is_some() || bundles.peek().is_some() {
                             db.commit(state);
-                        } else {
-                            // If there is no transactions, but
-                            // more bundles, commit to the database too
-                            if bundles.peek().is_some() {
-                                db.commit(state);
-                            }
                         }
                         results.push(trace);
                     }

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -420,8 +420,15 @@ where
                             &mut db,
                         )?;
 
-                        if bundles.peek().is_none() && transactions.peek().is_none() {
+                        // If there is more transactions, commit the database
+                        if transactions.peek().is_some() {
                             db.commit(state);
+                        } else {
+                            // If there is no transactions, but
+                            // more bundles, commit to the database too
+                            if bundles.peek().is_some() {
+                                db.commit(state);
+                            }
                         }
                         results.push(trace);
                     }


### PR DESCRIPTION
Currently, `debug_callTraceMany` doesn't commit the state from the calls. This PR fixes it.

An example test script below with incrementing nonces fails against the main branch, and is fixed in the PR branch

```bash
reth node --dev --http --http.api=eth,debug
```

Testing script:
```javascript
const { ethers } = require("ethers");

const provider = new ethers.providers.JsonRpcProvider();

const main = async () => {
  const resp = await provider.send("debug_traceCallMany", [
    [
      {
        transactions: [
          {
            from: "0xb0b0b9a9e9aa1c9db991c7721a92d351db4fac99",
            nonce: "0x0",
            to: ethers.constants.AddressZero
          },
          {
            from: "0xb0b0b9a9e9aa1c9db991c7721a92d351db4fac99",
            nonce: "0x1",
            to: ethers.constants.AddressZero
          },
        ],
      },
    ],
    { blockNumber: "latest" },
    { tracer: "callTracer" },
  ]);

  console.log("response", resp);
};

main();
```
