### PR TITLE
chore: move bitflags to workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6165,7 +6165,7 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "auto_impl",
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "criterion",
  "fnv",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ ethers-middleware = { version = "2.0.8", default-features = false }
 
 ## misc
 bytes = "1.4"
+bitflags = "2.3"
 tracing = "0.1.0"
 tracing-appender = "0.2"
 thiserror = "1.0.37"

--- a/crates/storage/libmdbx-rs/Cargo.toml
+++ b/crates/storage/libmdbx-rs/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 name = "reth_libmdbx"
 
 [dependencies]
-bitflags = "2"
+bitflags.workspace = true
 byteorder = "1"
 derive_more = "0.99"
 indexmap = "1"

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -38,7 +38,7 @@ thiserror.workspace = true
 tracing.workspace = true
 serde = { workspace = true, features = ["derive", "rc"], optional = true }
 fnv = "1.0.7"
-bitflags = "1.3"
+bitflags.workspace = true
 auto_impl = "1.0"
 
 # testing

--- a/crates/transaction-pool/src/pool/state.rs
+++ b/crates/transaction-pool/src/pool/state.rs
@@ -2,7 +2,7 @@ bitflags::bitflags! {
     /// Marker to represents the current state of a transaction in the pool and from which the corresponding sub-pool is derived, depending on what bits are set.
     ///
     /// This mirrors [erigon's ephemeral state field](https://github.com/ledgerwatch/erigon/wiki/Transaction-Pool-Design#ordering-function).
-    #[derive(Default)]
+     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, PartialOrd, Ord)]
     pub(crate) struct TxState: u8 {
         /// Set to `1` if all ancestor transactions are pending.
         const NO_PARKED_ANCESTORS = 0b100000;
@@ -20,11 +20,11 @@ bitflags::bitflags! {
         /// Set to 1 if `feeCap` of the transaction meets the requirement of the pending block.
         const ENOUGH_FEE_CAP_BLOCK = 0b000010;
 
-        const PENDING_POOL_BITS = Self::NO_PARKED_ANCESTORS.bits | Self::NO_NONCE_GAPS.bits | Self::ENOUGH_BALANCE.bits | Self::NOT_TOO_MUCH_GAS.bits |  Self::ENOUGH_FEE_CAP_BLOCK.bits;
+        const PENDING_POOL_BITS = Self::NO_PARKED_ANCESTORS.bits()| Self::NO_NONCE_GAPS.bits() | Self::ENOUGH_BALANCE.bits() | Self::NOT_TOO_MUCH_GAS.bits() |  Self::ENOUGH_FEE_CAP_BLOCK.bits();
 
-        const BASE_FEE_POOL_BITS = Self::NO_PARKED_ANCESTORS.bits | Self::NO_NONCE_GAPS.bits | Self::ENOUGH_BALANCE.bits | Self::NOT_TOO_MUCH_GAS.bits;
+        const BASE_FEE_POOL_BITS = Self::NO_PARKED_ANCESTORS.bits() | Self::NO_NONCE_GAPS.bits() | Self::ENOUGH_BALANCE.bits() | Self::NOT_TOO_MUCH_GAS.bits();
 
-        const QUEUED_POOL_BITS  = Self::NO_PARKED_ANCESTORS.bits;
+        const QUEUED_POOL_BITS  = Self::NO_PARKED_ANCESTORS.bits();
 
     }
 }


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 46772ff</samp>

This pull request refactors the `bitflags` dependency across the workspace to use a single version defined in the root `Cargo.toml` file. This avoids duplication and conflicts and improves compatibility and consistency.