### PR TITLE
perf: create buffer once

### DIFF
--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -1609,8 +1609,8 @@ pub(crate) async fn receive_loop(udp: Arc<UdpSocket>, tx: IngressSender, local_i
         });
     };
 
+    let mut buf = [0; MAX_PACKET_SIZE];
     loop {
-        let mut buf = [0; MAX_PACKET_SIZE];
         let res = udp.recv_from(&mut buf).await;
         match res {
             Err(err) => {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4f51ba9</samp>

Improved UDP socket receiver performance in `discv4` crate by reusing buffer allocation. Refactored `lib.rs` to move buffer creation outside the loop.