### PR TITLE
fix: track established bonds

### DIFF
--- a/crates/net/discv4/src/config.rs
+++ b/crates/net/discv4/src/config.rs
@@ -31,7 +31,7 @@ pub struct Discv4Config {
     /// The number of allowed failures for `FindNode` requests. Default: 5.
     pub max_find_node_failures: u8,
     /// The interval to use when checking for expired nodes that need to be re-pinged. Default:
-    /// 300sec, 5min.
+    /// 10min.
     pub ping_interval: Duration,
     /// The duration of we consider a ping timed out.
     pub ping_expiration: Duration,
@@ -69,6 +69,8 @@ pub struct Discv4Config {
     /// If configured and a `external_ip_resolver` is configured, try to resolve the external ip
     /// using this interval.
     pub resolve_external_ip_interval: Option<Duration>,
+    /// The duration after which we consider a bond expired.
+    pub bond_expiration: Duration,
 }
 
 impl Discv4Config {
@@ -121,16 +123,17 @@ impl Default for Discv4Config {
             /// Every outgoing request will eventually lead to an incoming response
             udp_ingress_message_buffer: 1024,
             max_find_node_failures: 5,
-            ping_interval: Duration::from_secs(300),
+            ping_interval: Duration::from_secs(60 * 10),
             /// unified expiration and timeout durations, mirrors geth's `expiration` duration
             ping_expiration: Duration::from_secs(20),
+            bond_expiration: Duration::from_secs(60 * 60),
             enr_expiration: Duration::from_secs(20),
             neighbours_expiration: Duration::from_secs(20),
             request_timeout: Duration::from_secs(20),
 
             lookup_interval: Duration::from_secs(20),
             ban_list: Default::default(),
-            ban_duration: Some(Duration::from_secs(3600)), // 1 hour
+            ban_duration: Some(Duration::from_secs(60 * 60)), // 1 hour
             bootstrap_nodes: Default::default(),
             enable_dht_random_walk: true,
             enable_lookup: true,
@@ -197,6 +200,12 @@ impl Discv4ConfigBuilder {
     /// Sets the expiration duration for enr requests
     pub fn enr_request_expiration(&mut self, duration: Duration) -> &mut Self {
         self.config.enr_expiration = duration;
+        self
+    }
+
+    /// Sets the expiration duration for a bond with a peer
+    pub fn bond_expiration(&mut self, duration: Duration) -> &mut Self {
+        self.config.bond_expiration = duration;
         self
     }
 

--- a/crates/net/discv4/src/table.rs
+++ b/crates/net/discv4/src/table.rs
@@ -1,0 +1,35 @@
+//! Additional support for tracking nodes.
+
+use reth_primitives::PeerId;
+use std::{collections::HashMap, net::IpAddr, time::Instant};
+
+/// Keeps track of nodes from which we have received a `Pong` message.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PongTable {
+    /// The nodes we have received a `Pong` from.
+    nodes: HashMap<NodeKey, Instant>,
+}
+
+impl PongTable {
+    /// Updates the timestamp we received a `Pong` from the given node.
+    pub(crate) fn on_pong(&mut self, remote_id: PeerId, remote_ip: IpAddr) {
+        let key = NodeKey { remote_id, remote_ip };
+        self.nodes.insert(key, Instant::now());
+    }
+
+    /// Returns the timestamp we received a `Pong` from the given node.
+    pub(crate) fn last_pong(&self, remote_id: PeerId, remote_ip: IpAddr) -> Option<Instant> {
+        self.nodes.get(&NodeKey { remote_id, remote_ip }).copied()
+    }
+
+    /// Removes all nodes from the table that have not sent a `Pong` for at least `timeout`.
+    pub(crate) fn evict_expired(&mut self, now: Instant, timeout: std::time::Duration) {
+        self.nodes.retain(|_, last_pong| now - *last_pong < timeout);
+    }
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub(crate) struct NodeKey {
+    pub(crate) remote_id: PeerId,
+    pub(crate) remote_ip: IpAddr,
+}


### PR DESCRIPTION
Closes #4221

previously the discv4 impl was ignoring requests if the peer's bucket is full.
this now tracks established bonds separately and verifies bonds rather than bucket inclusion

```
./build/bin/devp2p --verbosity 5 discv4 requestenr enode://4aeb4ab6c14b23e2c4cfdce879c04b0748a20d8e9b59e25ded2a08143e265c6c25936e74cbc8e641e3312ca288673d91f2f93f8e277de3cfa444ecdaaf982052@157.90.35.166:30303
INFO [08-16|15:30:15.348] New local node record                    seq=1,692,192,615,348 id=224f5d8fef49a4b4 ip=127.0.0.1 udp=64908 tcp=0
TRACE[08-16|15:30:15.349] >> PING/v4                               id=6b36f791352f15eb addr=157.90.35.166:30303 err=nil
TRACE[08-16|15:30:15.381] << PONG/v4                               id=6b36f791352f15eb addr=157.90.35.166:30303 err=nil
TRACE[08-16|15:30:15.382] << PING/v4                               id=6b36f791352f15eb addr=157.90.35.166:30303 err=nil
TRACE[08-16|15:30:15.382] >> PONG/v4                               id=6b36f791352f15eb addr=157.90.35.166:30303 err=nil
TRACE[08-16|15:30:15.881] >> ENRREQUEST/v4                         id=6b36f791352f15eb addr=157.90.35.166:30303 err=nil
TRACE[08-16|15:30:15.906] << ENRRESPONSE/v4                        id=6b36f791352f15eb addr=157.90.35.166:30303 err=nil
enr:-Km4QLNlM6ax1LAVyEpfVB49kIczTWMgo7QPP7eWsuScLAGlY4bK33veSCLzT4234j2hu15ZM6ossxE_4rBxmwSn9i6GAX8OcbRig2V0aMfGhNzpbC2AgmlkgnY0gmlwhJ1aI6aDbGVzwQGJc2VjcDI1NmsxoQJK60q2wUsj4sTP3Oh5wEsHSKINjptZ4l3tKggUPiZcbIRzbmFwwIN0Y3CCdl-DdWRwgnZf
```

hive tests still pass:

<img width="1247" alt="image" src="https://github.com/paradigmxyz/reth/assets/19890894/30b89a15-6576-42c9-8947-71c75662b4c3">
