### PR TITLE
fix: return None instead of BlockBodyIndicesNotFound in BlockReader

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -938,14 +938,24 @@ impl<'this, TX: DbTx<'this>> BlockReader for DatabaseProvider<'this, TX> {
         }
     }
 
+    /// Returns the block with matching number from database.
+    ///
+    /// If the header for this block is not found, this returns `None`.
+    /// If the header is found, but the transactions either do not exist, or are not indexed, this
+    /// will return None.
     fn block(&self, id: BlockHashOrNumber) -> Result<Option<Block>> {
         if let Some(number) = self.convert_hash_or_number(id)? {
             if let Some(header) = self.header_by_number(number)? {
                 let withdrawals = self.withdrawals_by_block(number.into(), header.timestamp)?;
                 let ommers = self.ommers(number.into())?.unwrap_or_default();
-                let transactions = self
-                    .transactions_by_block(number.into())?
-                    .ok_or(ProviderError::BlockBodyIndicesNotFound(number))?;
+                // If the body indices are not found, this means that the transactions either do not
+                // exist in the database yet, or they do exit but are not indexed.
+                // If they exist but are not indexed, we don't have enough
+                // information to return the block anyways, so we return `None`.
+                let transactions = match self.transactions_by_block(number.into())? {
+                    Some(transactions) => transactions,
+                    None => return Ok(None),
+                };
 
                 return Ok(Some(Block { header, body: transactions, ommers, withdrawals }))
             }
@@ -986,7 +996,9 @@ impl<'this, TX: DbTx<'this>> BlockReader for DatabaseProvider<'this, TX> {
     /// **NOTE: The transactions have invalid hashes, since they would need to be calculated on the
     /// spot, and we want fast querying.**
     ///
-    /// Returns `None` if block is not found.
+    /// If the header for this block is not found, this returns `None`.
+    /// If the header is found, but the transactions either do not exist, or are not indexed, this
+    /// will return None.
     fn block_with_senders(&self, block_number: BlockNumber) -> Result<Option<BlockWithSenders>> {
         let header = self
             .header_by_number(block_number)?
@@ -996,9 +1008,16 @@ impl<'this, TX: DbTx<'this>> BlockReader for DatabaseProvider<'this, TX> {
         let withdrawals = self.withdrawals_by_block(block_number.into(), header.timestamp)?;
 
         // Get the block body
-        let body = self
-            .block_body_indices(block_number)?
-            .ok_or(ProviderError::BlockBodyIndicesNotFound(block_number))?;
+        //
+        // If the body indices are not found, this means that the transactions either do not exist
+        // in the database yet, or they do exit but are not indexed. If they exist but are not
+        // indexed, we don't have enough information to return the block anyways, so we return
+        // `None`.
+        let body = match self.block_body_indices(block_number)? {
+            Some(body) => body,
+            None => return Ok(None),
+        };
+
         let tx_range = body.tx_num_range();
 
         let (transactions, senders) = if tx_range.is_empty() {


### PR DESCRIPTION
fixes #4166

Instead of mapping the error to `None`, this modifies the `BlockReader` impls to not return the error in the first place.
