### PR TITLE
perf: remove clones in PooledTransaction encoding

### DIFF
--- a/crates/primitives/src/transaction/eip1559.rs
+++ b/crates/primitives/src/transaction/eip1559.rs
@@ -162,6 +162,14 @@ impl TxEip1559 {
         signature.encode(out);
     }
 
+    /// Output the length of the RLP signed transaction encoding. This encodes with a RLP header.
+    pub(crate) fn payload_len_with_signature(&self, signature: &Signature) -> usize {
+        let payload_length = self.fields_len() + signature.payload_len();
+        // 'transaction type byte length' + 'header length' + 'payload length'
+        let len = 1 + length_of_length(payload_length) + payload_length;
+        length_of_length(len) + len
+    }
+
     /// Get transaction type
     pub(crate) fn tx_type(&self) -> TxType {
         TxType::EIP1559

--- a/crates/primitives/src/transaction/eip2930.rs
+++ b/crates/primitives/src/transaction/eip2930.rs
@@ -141,6 +141,14 @@ impl TxEip2930 {
         signature.encode(out);
     }
 
+    /// Output the length of the RLP signed transaction encoding. This encodes with a RLP header.
+    pub(crate) fn payload_len_with_signature(&self, signature: &Signature) -> usize {
+        let payload_length = self.fields_len() + signature.payload_len();
+        // 'transaction type byte length' + 'header length' + 'payload length'
+        let len = 1 + length_of_length(payload_length) + payload_length;
+        length_of_length(len) + len
+    }
+
     /// Get transaction type
     pub(crate) fn tx_type(&self) -> TxType {
         TxType::EIP2930

--- a/crates/primitives/src/transaction/eip4844.rs
+++ b/crates/primitives/src/transaction/eip4844.rs
@@ -214,6 +214,14 @@ impl TxEip4844 {
         signature.encode(out);
     }
 
+    /// Output the length of the RLP signed transaction encoding. This encodes with a RLP header.
+    pub(crate) fn payload_len_with_signature(&self, signature: &Signature) -> usize {
+        let payload_length = self.fields_len() + signature.payload_len();
+        // 'transaction type byte length' + 'header length' + 'payload length'
+        let len = 1 + length_of_length(payload_length) + payload_length;
+        length_of_length(len) + len
+    }
+
     /// Get transaction type
     pub(crate) fn tx_type(&self) -> TxType {
         TxType::EIP4844

--- a/crates/primitives/src/transaction/legacy.rs
+++ b/crates/primitives/src/transaction/legacy.rs
@@ -1,6 +1,6 @@
 use crate::{Bytes, ChainId, Signature, TransactionKind, TxType};
 use reth_codecs::{main_codec, Compact};
-use reth_rlp::{Encodable, Header};
+use reth_rlp::{length_of_length, Encodable, Header};
 use std::mem;
 
 /// Legacy transaction.
@@ -91,6 +91,14 @@ impl TxLegacy {
         header.encode(out);
         self.encode_fields(out);
         signature.encode_with_eip155_chain_id(out, self.chain_id);
+    }
+
+    /// Output the length of the RLP signed transaction encoding.
+    pub(crate) fn payload_len_with_signature(&self, signature: &Signature) -> usize {
+        let payload_length =
+            self.fields_len() + signature.payload_len_with_eip155_chain_id(self.chain_id);
+        // 'header length' + 'payload length'
+        length_of_length(payload_length) + payload_length
     }
 
     /// Get transaction type

--- a/crates/primitives/src/transaction/pooled.rs
+++ b/crates/primitives/src/transaction/pooled.rs
@@ -142,38 +142,16 @@ impl Encodable for PooledTransactionsElement {
     /// Encodes an enveloped post EIP-4844 [PooledTransactionsElement].
     fn encode(&self, out: &mut dyn bytes::BufMut) {
         match self {
-            Self::Legacy { transaction, signature, hash } => {
-                // construct signed transaction
-                let signed_tx = TransactionSigned {
-                    transaction: Transaction::Legacy(transaction.clone()),
-                    signature: *signature,
-                    hash: *hash,
-                };
-
-                // encode signed transaction
-                signed_tx.encode(out);
+            Self::Legacy { transaction, signature, .. } => {
+                transaction.encode_with_signature(signature, out)
             }
-            Self::Eip2930 { transaction, signature, hash } => {
-                // construct signed transaction
-                let signed_tx = TransactionSigned {
-                    transaction: Transaction::Eip2930(transaction.clone()),
-                    signature: *signature,
-                    hash: *hash,
-                };
-
-                // encode signed transaction
-                signed_tx.encode(out);
+            Self::Eip2930 { transaction, signature, .. } => {
+                // encodes with header
+                transaction.encode_with_signature(signature, out, true)
             }
-            Self::Eip1559 { transaction, signature, hash } => {
-                // construct signed transaction
-                let signed_tx = TransactionSigned {
-                    transaction: Transaction::Eip1559(transaction.clone()),
-                    signature: *signature,
-                    hash: *hash,
-                };
-
-                // encode signed transaction
-                signed_tx.encode(out);
+            Self::Eip1559 { transaction, signature, .. } => {
+                // encodes with header
+                transaction.encode_with_signature(signature, out, true)
             }
             Self::BlobTransaction(blob_tx) => {
                 // The inner encoding is used with `with_header` set to true, making the final
@@ -186,35 +164,17 @@ impl Encodable for PooledTransactionsElement {
 
     fn length(&self) -> usize {
         match self {
-            Self::Legacy { transaction, signature, hash } => {
-                // construct signed transaction
-                let signed_tx = TransactionSigned {
-                    transaction: Transaction::Legacy(transaction.clone()),
-                    signature: *signature,
-                    hash: *hash,
-                };
-
-                signed_tx.length()
+            Self::Legacy { transaction, signature, .. } => {
+                // method computes the payload len with a RLP header
+                transaction.payload_len_with_signature(signature)
             }
-            Self::Eip2930 { transaction, signature, hash } => {
-                // construct signed transaction
-                let signed_tx = TransactionSigned {
-                    transaction: Transaction::Eip2930(transaction.clone()),
-                    signature: *signature,
-                    hash: *hash,
-                };
-
-                signed_tx.length()
+            Self::Eip2930 { transaction, signature, .. } => {
+                // method computes the payload len with a RLP header
+                transaction.payload_len_with_signature(signature)
             }
-            Self::Eip1559 { transaction, signature, hash } => {
-                // construct signed transaction
-                let signed_tx = TransactionSigned {
-                    transaction: Transaction::Eip1559(transaction.clone()),
-                    signature: *signature,
-                    hash: *hash,
-                };
-
-                signed_tx.length()
+            Self::Eip1559 { transaction, signature, .. } => {
+                // method computes the payload len with a RLP header
+                transaction.payload_len_with_signature(signature)
             }
             Self::BlobTransaction(blob_tx) => {
                 // the encoding uses a header, so we set `with_header` to true


### PR DESCRIPTION
Previously there were many `clone`s in the `Encodable` implementation for `PooledTransaction`. This first adds a new method called `payload_len_with_signature` on the individual transaction types, making it usable by `PooledTransaction` variants. The method is then used in the `Encodable::length` implementation, and the `encode_with_signature` method is used for `Encodable::encode`.

Fixes #4243 