### PR TITLE
chore: rename transaction

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -165,9 +165,9 @@ pub use crate::{
     },
     traits::{
         AllPoolTransactions, BestTransactions, BlockInfo, CanonicalStateUpdate, ChangedAccount,
-        NewTransactionEvent, PendingTransactionListenerKind, PoolSize, PoolTransaction,
-        PooledTransaction, PropagateKind, PropagatedTransactions, TransactionOrigin,
-        TransactionPool, TransactionPoolExt,
+        EthPooledTransaction, NewTransactionEvent, PendingTransactionListenerKind, PoolSize,
+        PoolTransaction, PropagateKind, PropagatedTransactions, TransactionOrigin, TransactionPool,
+        TransactionPoolExt,
     },
     validate::{
         EthTransactionValidator, TransactionValidationOutcome, TransactionValidator,
@@ -262,12 +262,15 @@ where
 }
 
 impl<Client>
-    Pool<EthTransactionValidator<Client, PooledTransaction>, CoinbaseTipOrdering<PooledTransaction>>
+    Pool<
+        EthTransactionValidator<Client, EthPooledTransaction>,
+        CoinbaseTipOrdering<EthPooledTransaction>,
+    >
 where
     Client: StateProviderFactory + Clone + 'static,
 {
     /// Returns a new [Pool] that uses the default [EthTransactionValidator] when validating
-    /// [PooledTransaction]s and ords via [CoinbaseTipOrdering]
+    /// [EthPooledTransaction]s and ords via [CoinbaseTipOrdering]
     ///
     /// # Example
     ///
@@ -284,7 +287,7 @@ where
     /// # }
     /// ```
     pub fn eth_pool(
-        validator: EthTransactionValidator<Client, PooledTransaction>,
+        validator: EthTransactionValidator<Client, EthPooledTransaction>,
         config: PoolConfig,
     ) -> Self {
         Self::new(validator, CoinbaseTipOrdering::default(), config)

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -5,8 +5,8 @@
 
 use crate::{
     error::PoolError, traits::PendingTransactionListenerKind, AllPoolTransactions,
-    AllTransactionsEvents, BestTransactions, BlockInfo, NewTransactionEvent, PoolResult, PoolSize,
-    PoolTransaction, PooledTransaction, PropagatedTransactions, TransactionEvents,
+    AllTransactionsEvents, BestTransactions, BlockInfo, EthPooledTransaction, NewTransactionEvent,
+    PoolResult, PoolSize, PoolTransaction, PropagatedTransactions, TransactionEvents,
     TransactionOrigin, TransactionPool, TransactionValidationOutcome, TransactionValidator,
     ValidPoolTransaction,
 };
@@ -24,7 +24,7 @@ pub struct NoopTransactionPool;
 
 #[async_trait::async_trait]
 impl TransactionPool for NoopTransactionPool {
-    type Transaction = PooledTransaction;
+    type Transaction = EthPooledTransaction;
 
     fn pool_size(&self) -> PoolSize {
         Default::default()
@@ -212,16 +212,16 @@ impl<T> Default for MockTransactionValidator<T> {
 #[derive(Debug, Clone, thiserror::Error)]
 #[error("Can't insert transaction into the noop pool that does nothing.")]
 pub struct NoopInsertError {
-    tx: PooledTransaction,
+    tx: EthPooledTransaction,
 }
 
 impl NoopInsertError {
-    fn new(tx: PooledTransaction) -> Self {
+    fn new(tx: EthPooledTransaction) -> Self {
         Self { tx }
     }
 
     /// Returns the transaction that failed to be inserted.
-    pub fn into_inner(self) -> PooledTransaction {
+    pub fn into_inner(self) -> EthPooledTransaction {
         self.tx
     }
 }

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -565,12 +565,12 @@ pub trait PoolTransaction:
     fn chain_id(&self) -> Option<u64>;
 }
 
-/// The default [PoolTransaction] for the [Pool](crate::Pool).
+/// The default [PoolTransaction] for the [Pool](crate::Pool) for Ethereum.
 ///
 /// This type is essentially a wrapper around [TransactionSignedEcRecovered] with additional fields
 /// derived from the transaction that are frequently used by the pools for ordering.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct PooledTransaction {
+pub struct EthPooledTransaction {
     /// EcRecovered transaction info
     pub(crate) transaction: TransactionSignedEcRecovered,
 
@@ -580,7 +580,7 @@ pub struct PooledTransaction {
     // TODO optional sidecar
 }
 
-impl PooledTransaction {
+impl EthPooledTransaction {
     /// Create new instance of [Self].
     pub fn new(transaction: TransactionSignedEcRecovered) -> Self {
         let gas_cost = match &transaction.transaction {
@@ -600,7 +600,7 @@ impl PooledTransaction {
     }
 }
 
-impl PoolTransaction for PooledTransaction {
+impl PoolTransaction for EthPooledTransaction {
     /// Returns hash of the transaction.
     fn hash(&self) -> &TxHash {
         self.transaction.hash_ref()
@@ -696,13 +696,13 @@ impl PoolTransaction for PooledTransaction {
     }
 }
 
-impl FromRecoveredTransaction for PooledTransaction {
+impl FromRecoveredTransaction for EthPooledTransaction {
     fn from_recovered_transaction(tx: TransactionSignedEcRecovered) -> Self {
-        PooledTransaction::new(tx)
+        EthPooledTransaction::new(tx)
     }
 }
 
-impl IntoRecoveredTransaction for PooledTransaction {
+impl IntoRecoveredTransaction for EthPooledTransaction {
     fn to_recovered_transaction(&self) -> TransactionSignedEcRecovered {
         self.transaction.clone()
     }

--- a/examples/network-txpool.rs
+++ b/examples/network-txpool.rs
@@ -10,7 +10,7 @@
 use reth_network::{config::rng_secret_key, NetworkConfig, NetworkManager};
 use reth_provider::test_utils::NoopProvider;
 use reth_transaction_pool::{
-    CoinbaseTipOrdering, PoolTransaction, EthPooledTransaction, TransactionOrigin, TransactionPool,
+    CoinbaseTipOrdering, EthPooledTransaction, PoolTransaction, TransactionOrigin, TransactionPool,
     TransactionValidationOutcome, TransactionValidator,
 };
 

--- a/examples/network-txpool.rs
+++ b/examples/network-txpool.rs
@@ -10,7 +10,7 @@
 use reth_network::{config::rng_secret_key, NetworkConfig, NetworkManager};
 use reth_provider::test_utils::NoopProvider;
 use reth_transaction_pool::{
-    CoinbaseTipOrdering, PoolTransaction, PooledTransaction, TransactionOrigin, TransactionPool,
+    CoinbaseTipOrdering, PoolTransaction, EthPooledTransaction, TransactionOrigin, TransactionPool,
     TransactionValidationOutcome, TransactionValidator,
 };
 
@@ -68,7 +68,7 @@ struct OkValidator;
 
 #[async_trait::async_trait]
 impl TransactionValidator for OkValidator {
-    type Transaction = PooledTransaction;
+    type Transaction = EthPooledTransaction;
 
     async fn validate_transaction(
         &self,


### PR DESCRIPTION
rename the transaction to make it clear that this is explicitly for eth.