### PR TITLE
dev: use U64 for `transaction_index`

### DIFF
--- a/crates/rpc/rpc-types/src/eth/transaction/receipt.rs
+++ b/crates/rpc/rpc-types/src/eth/transaction/receipt.rs
@@ -9,7 +9,7 @@ pub struct TransactionReceipt {
     /// Transaction Hash.
     pub transaction_hash: Option<H256>,
     /// Index within the block.
-    pub transaction_index: u64,
+    pub transaction_index: U64,
     /// Hash of the block this transaction was included within.
     pub block_hash: Option<H256>,
     /// Number of the block this transaction was included within.

--- a/crates/rpc/rpc-types/src/eth/transaction/receipt.rs
+++ b/crates/rpc/rpc-types/src/eth/transaction/receipt.rs
@@ -9,16 +9,14 @@ pub struct TransactionReceipt {
     /// Transaction Hash.
     pub transaction_hash: Option<H256>,
     /// Index within the block.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub transaction_index: Option<U256>,
+    pub transaction_index: u64,
     /// Hash of the block this transaction was included within.
     pub block_hash: Option<H256>,
     /// Number of the block this transaction was included within.
     pub block_number: Option<U256>,
     /// Address of the sender
     pub from: Address,
-    /// Address of the receiver. None when it's a contract creation transaction.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Address of the receiver. null when its a contract creation transaction.
     pub to: Option<Address>,
     /// Cumulative gas used within the block after this was executed.
     pub cumulative_gas_used: U256,

--- a/crates/rpc/rpc-types/src/eth/transaction/receipt.rs
+++ b/crates/rpc/rpc-types/src/eth/transaction/receipt.rs
@@ -9,6 +9,7 @@ pub struct TransactionReceipt {
     /// Transaction Hash.
     pub transaction_hash: Option<H256>,
     /// Index within the block.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub transaction_index: Option<U256>,
     /// Hash of the block this transaction was included within.
     pub block_hash: Option<H256>,
@@ -16,7 +17,8 @@ pub struct TransactionReceipt {
     pub block_number: Option<U256>,
     /// Address of the sender
     pub from: Address,
-    /// Address of the receiver. null when its a contract creation transaction.
+    /// Address of the receiver. None when it's a contract creation transaction.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub to: Option<Address>,
     /// Cumulative gas used within the block after this was executed.
     pub cumulative_gas_used: U256,

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -712,7 +712,7 @@ where
                 return match signer.sign_transaction(request, from) {
                     Ok(tx) => Ok(tx),
                     Err(e) => Err(e.into()),
-                };
+                }
             }
         }
         Err(EthApiError::InvalidTransactionSignature)

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -712,7 +712,7 @@ where
                 return match signer.sign_transaction(request, from) {
                     Ok(tx) => Ok(tx),
                     Err(e) => Err(e.into()),
-                }
+                };
             }
         }
         Err(EthApiError::InvalidTransactionSignature)
@@ -740,7 +740,7 @@ where
                     block.header.number,
                     block.header.base_fee_per_gas,
                     index.into(),
-                )))
+                )));
             }
         }
 
@@ -859,7 +859,7 @@ pub(crate) fn build_transaction_receipt_with_block_receipts(
 
     let mut res_receipt = TransactionReceipt {
         transaction_hash: Some(meta.tx_hash),
-        transaction_index: Some(U256::from(meta.index)),
+        transaction_index: meta.index,
         block_hash: Some(meta.block_hash),
         block_number: Some(U256::from(meta.block_number)),
         from: transaction.signer(),

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -740,7 +740,7 @@ where
                     block.header.number,
                     block.header.base_fee_per_gas,
                     index.into(),
-                )));
+                )))
             }
         }
 

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -859,7 +859,7 @@ pub(crate) fn build_transaction_receipt_with_block_receipts(
 
     let mut res_receipt = TransactionReceipt {
         transaction_hash: Some(meta.tx_hash),
-        transaction_index: meta.index,
+        transaction_index: meta.index.into(),
         block_hash: Some(meta.block_hash),
         block_number: Some(U256::from(meta.block_number)),
         from: transaction.signer(),


### PR DESCRIPTION
Hello, this smol pr does the following
- ~add skipping of serialization for `transaction_index` and `to`~
- use U64 for `transaction_index`
- resolve #4260 