### PR TITLE
chore: bump `metrics`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3824,15 +3824,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mach"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "mach2"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3894,54 +3885,31 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b9b8653cec6897f73b519a43fba5ee3d50f62fe9af80b428accdcc093b4a849"
-dependencies = [
- "ahash 0.7.6",
- "metrics-macros 0.6.0",
- "portable-atomic 0.3.20",
-]
-
-[[package]]
-name = "metrics"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde3af1a009ed76a778cb84fdef9e7dbbdf5775ae3e4cc1f434a6a307f6f76c5"
 dependencies = [
  "ahash 0.8.3",
- "metrics-macros 0.7.0",
- "portable-atomic 1.4.2",
+ "metrics-macros",
+ "portable-atomic",
 ]
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8603921e1f54ef386189335f288441af761e0fc61bcb552168d9cedfe63ebc70"
+checksum = "8a4964177ddfdab1e3a2b37aec7cf320e14169abb0ed73999f558136409178d5"
 dependencies = [
+ "base64 0.21.2",
  "hyper",
  "indexmap 1.9.3",
  "ipnet",
- "metrics 0.20.1",
+ "metrics",
  "metrics-util",
- "parking_lot 0.12.1",
- "portable-atomic 0.3.20",
  "quanta",
  "thiserror",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "metrics-macros"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731f8ecebd9f3a4aa847dfe75455e4757a45da40a7793d2f0b1f9b6ed18b23f3"
-dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -3963,7 +3931,7 @@ checksum = "1c93f6ad342d3f7bc14724147e2dbc6eb6fdbe5a832ace16ea23b73618e8cc17"
 dependencies = [
  "libproc",
  "mach2",
- "metrics 0.21.1",
+ "metrics",
  "once_cell",
  "procfs",
  "rlimit",
@@ -3972,20 +3940,18 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d24dc2dbae22bff6f1f9326ffce828c9f07ef9cc1e8002e5279f845432a30a"
+checksum = "111cb375987443c3de8d503580b536f77dc8416d32db62d9456db5d93bd7ac47"
 dependencies = [
  "aho-corasick 0.7.20",
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
  "indexmap 1.9.3",
- "metrics 0.20.1",
+ "metrics",
  "num_cpus",
  "ordered-float",
- "parking_lot 0.12.1",
- "portable-atomic 0.3.20",
  "quanta",
  "radix_trie",
  "sketches-ddsketch",
@@ -4360,9 +4326,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
-version = "2.10.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
+checksum = "7417b1484e3641a8791af3c3123cdc083ac60a0d262a2f281b6125d58917caf4"
 dependencies = [
  "num-traits",
 ]
@@ -4691,15 +4657,6 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "0.3.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e30165d31df606f5726b090ec7592c308a0eaf61721ff64c9a3018e344a8753e"
-dependencies = [
- "portable-atomic 1.4.2",
-]
-
-[[package]]
-name = "portable-atomic"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f32154ba0af3a075eefa1eda8bb414ee928f62303a54ea85b8d6638ff1a6ee9e"
@@ -4926,16 +4883,16 @@ dependencies = [
 
 [[package]]
 name = "quanta"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e31331286705f455e56cca62e0e717158474ff02b7936c1fa596d983f4ae27"
+checksum = "a17e662a7a8291a865152364c20c7abc5e60486ab2001e8ec10b24862de0b9ab"
 dependencies = [
  "crossbeam-utils",
  "libc",
- "mach",
+ "mach2",
  "once_cell",
  "raw-cpuid",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -5254,6 +5211,7 @@ dependencies = [
  "hyper",
  "jemalloc-ctl",
  "jemallocator",
+ "metrics",
  "metrics-exporter-prometheus",
  "metrics-process",
  "metrics-util",
@@ -5327,6 +5285,7 @@ version = "0.1.0-alpha.6"
 dependencies = [
  "futures-core",
  "futures-util",
+ "metrics",
  "reth-metrics",
  "reth-payload-builder",
  "reth-primitives",
@@ -5346,6 +5305,7 @@ version = "0.1.0-alpha.6"
 dependencies = [
  "assert_matches",
  "futures",
+ "metrics",
  "reth-blockchain-tree",
  "reth-consensus-common",
  "reth-db",
@@ -5376,6 +5336,7 @@ dependencies = [
  "assert_matches",
  "linked_hash_set",
  "lru 0.10.1",
+ "metrics",
  "parking_lot 0.12.1",
  "reth-db",
  "reth-interfaces",
@@ -5444,6 +5405,7 @@ dependencies = [
  "futures",
  "heapless",
  "iai",
+ "metrics",
  "modular-bitfield",
  "page_size",
  "parity-scale-codec",
@@ -5527,6 +5489,7 @@ dependencies = [
  "futures",
  "futures-util",
  "itertools 0.11.0",
+ "metrics",
  "pin-project",
  "rayon",
  "reth-db",
@@ -5586,6 +5549,7 @@ dependencies = [
  "futures",
  "hex",
  "hex-literal 0.3.4",
+ "metrics",
  "pin-project",
  "proptest",
  "proptest-derive",
@@ -5689,7 +5653,7 @@ name = "reth-metrics"
 version = "0.1.0-alpha.6"
 dependencies = [
  "futures",
- "metrics 0.20.1",
+ "metrics",
  "reth-metrics-derive",
  "tokio",
 ]
@@ -5698,7 +5662,7 @@ dependencies = [
 name = "reth-metrics-derive"
 version = "0.1.0-alpha.6"
 dependencies = [
- "metrics 0.20.1",
+ "metrics",
  "once_cell",
  "proc-macro2 1.0.66",
  "quote 1.0.32",
@@ -5749,6 +5713,7 @@ dependencies = [
  "humantime-serde",
  "linked-hash-map",
  "linked_hash_set",
+ "metrics",
  "parking_lot 0.12.1",
  "pin-project",
  "rand 0.8.5",
@@ -5799,6 +5764,7 @@ name = "reth-payload-builder"
 version = "0.1.0-alpha.6"
 dependencies = [
  "futures-util",
+ "metrics",
  "reth-interfaces",
  "reth-metrics",
  "reth-primitives",
@@ -5892,6 +5858,7 @@ version = "0.1.0-alpha.6"
 dependencies = [
  "assert_matches",
  "itertools 0.11.0",
+ "metrics",
  "rayon",
  "reth-db",
  "reth-interfaces",
@@ -5986,6 +5953,7 @@ dependencies = [
  "hyper",
  "jsonrpsee",
  "jsonwebtoken",
+ "metrics",
  "pin-project",
  "rand 0.8.5",
  "rayon",
@@ -6049,6 +6017,7 @@ version = "0.1.0-alpha.6"
 dependencies = [
  "hyper",
  "jsonrpsee",
+ "metrics",
  "reth-beacon-consensus",
  "reth-interfaces",
  "reth-ipc",
@@ -6130,6 +6099,7 @@ dependencies = [
  "criterion",
  "futures-util",
  "itertools 0.11.0",
+ "metrics",
  "num-traits",
  "paste",
  "pin-project",
@@ -6162,6 +6132,7 @@ version = "0.1.0-alpha.6"
 dependencies = [
  "dyn-clone",
  "futures-util",
+ "metrics",
  "reth-metrics",
  "thiserror",
  "tokio",
@@ -6191,6 +6162,7 @@ dependencies = [
  "criterion",
  "fnv",
  "futures-util",
+ "metrics",
  "parking_lot 0.12.1",
  "paste",
  "proptest",
@@ -8194,12 +8166,6 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasi"

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -38,7 +38,6 @@ reth-net-nat = { path = "../../crates/net/nat" }
 reth-payload-builder.workspace = true
 reth-basic-payload-builder = { path = "../../crates/payload/basic" }
 reth-discv4 = { path = "../../crates/net/discv4" }
-reth-metrics.workspace = true
 reth-prune = { path = "../../crates/prune" }
 reth-trie = { path = "../../crates/trie" }
 
@@ -58,9 +57,11 @@ confy = "0.5"
 toml = { version = "0.7", features = ["display"] }
 
 # metrics
-metrics-exporter-prometheus = "0.11.0"
-metrics-util = "0.14.0"
+metrics-exporter-prometheus = "0.12.1"
+metrics-util = "0.15.0"
 metrics-process = "1.0.9"
+reth-metrics.workspace = true
+metrics = "0.21.1" # Needed for `metrics-macro` to resolve the crate using `::metrics` notation
 
 # test vectors generation
 proptest.workspace = true

--- a/bin/reth/src/args/pruning_args.rs
+++ b/bin/reth/src/args/pruning_args.rs
@@ -22,7 +22,7 @@ impl PruningArgs {
     /// Returns pruning configuration.
     pub fn prune_config(&self, _chain_spec: Arc<ChainSpec>) -> eyre::Result<Option<PruneConfig>> {
         Ok(if self.full {
-            eyre::bail!("full node is not supported yet, keep an eye on next releases");
+            // eyre::bail!("full node is not supported yet, keep an eye on next releases");
             #[allow(unreachable_code)]
             Some(PruneConfig {
                 block_interval: 5,

--- a/bin/reth/src/args/pruning_args.rs
+++ b/bin/reth/src/args/pruning_args.rs
@@ -22,7 +22,7 @@ impl PruningArgs {
     /// Returns pruning configuration.
     pub fn prune_config(&self, _chain_spec: Arc<ChainSpec>) -> eyre::Result<Option<PruneConfig>> {
         Ok(if self.full {
-            // eyre::bail!("full node is not supported yet, keep an eye on next releases");
+            eyre::bail!("full node is not supported yet, keep an eye on next releases");
             #[allow(unreachable_code)]
             Some(PruneConfig {
                 block_interval: 5,

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -576,8 +576,12 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
     async fn start_metrics_endpoint(&self, db: Arc<DatabaseEnv>) -> eyre::Result<()> {
         if let Some(listen_addr) = self.metrics {
             info!(target: "reth::cli", addr = %listen_addr, "Starting metrics endpoint");
-            prometheus_exporter::initialize(listen_addr, db, metrics_process::Collector::default())
-                .await?;
+            prometheus_exporter::initialize(
+                listen_addr,
+                db,
+                metrics_process::Collector::default().prefix("reth"),
+            )
+            .await?;
         }
 
         Ok(())

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -576,12 +576,8 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
     async fn start_metrics_endpoint(&self, db: Arc<DatabaseEnv>) -> eyre::Result<()> {
         if let Some(listen_addr) = self.metrics {
             info!(target: "reth::cli", addr = %listen_addr, "Starting metrics endpoint");
-            prometheus_exporter::initialize(
-                listen_addr,
-                db,
-                metrics_process::Collector::default().prefix("reth"),
-            )
-            .await?;
+            prometheus_exporter::initialize(listen_addr, db, metrics_process::Collector::default())
+                .await?;
         }
 
         Ok(())

--- a/bin/reth/src/prometheus_exporter.rs
+++ b/bin/reth/src/prometheus_exporter.rs
@@ -7,7 +7,7 @@ use hyper::{
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 use metrics_util::layers::{PrefixLayer, Stack};
 use reth_db::{database::Database, tables, DatabaseEnv};
-use reth_metrics::metrics::{self, absolute_counter, describe_counter, Unit};
+use reth_metrics::metrics::{absolute_counter, describe_counter, Unit};
 use std::{convert::Infallible, net::SocketAddr, sync::Arc};
 
 pub(crate) trait Hook: Fn() + Send + Sync {}

--- a/crates/blockchain-tree/Cargo.toml
+++ b/crates/blockchain-tree/Cargo.toml
@@ -18,7 +18,6 @@ normal = [
 reth-primitives.workspace = true
 reth-interfaces.workspace = true
 reth-db = { path = "../storage/db" }
-reth-metrics = { workspace = true, features = ["common"] }
 reth-provider.workspace = true
 reth-stages = { path = "../stages" }
 
@@ -27,7 +26,11 @@ parking_lot.workspace = true
 lru = "0.10"
 tracing.workspace = true
 
-# mics
+# metrics
+reth-metrics = { workspace = true, features = ["common"] }
+metrics = "0.21.1" # Needed for `metrics-macro` to resolve the crate using `::metrics` notation
+
+# misc
 aquamarine = "0.3.0"
 linked_hash_set = "0.1.4"
 

--- a/crates/blockchain-tree/src/metrics.rs
+++ b/crates/blockchain-tree/src/metrics.rs
@@ -1,5 +1,5 @@
 use reth_metrics::{
-    metrics::{self, Counter, Gauge},
+    metrics::{Counter, Gauge},
     Metrics,
 };
 

--- a/crates/consensus/beacon/Cargo.toml
+++ b/crates/consensus/beacon/Cargo.toml
@@ -18,13 +18,16 @@ reth-provider.workspace = true
 reth-rpc-types.workspace = true
 reth-tasks.workspace = true
 reth-payload-builder.workspace = true
-reth-metrics.workspace = true
 reth-prune = { path = "../../prune" }
 
 # async
 tokio = { workspace = true, features = ["sync"] }
 tokio-stream.workspace = true
 futures.workspace = true
+
+# metrics
+reth-metrics.workspace = true
+metrics = "0.21.1" # Needed for `metrics-macro` to resolve the crate using `::metrics` notation
 
 # misc
 tracing.workspace = true

--- a/crates/consensus/beacon/src/engine/invalid_headers.rs
+++ b/crates/consensus/beacon/src/engine/invalid_headers.rs
@@ -1,5 +1,5 @@
 use reth_metrics::{
-    metrics::{self, Counter, Gauge},
+    metrics::{Counter, Gauge},
     Metrics,
 };
 use reth_primitives::{Header, SealedHeader, H256};

--- a/crates/consensus/beacon/src/engine/metrics.rs
+++ b/crates/consensus/beacon/src/engine/metrics.rs
@@ -1,5 +1,5 @@
 use reth_metrics::{
-    metrics::{self, Counter, Gauge, Histogram},
+    metrics::{Counter, Gauge, Histogram},
     Metrics,
 };
 

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -13,7 +13,7 @@ description = "reth metrics utilities"
 reth-metrics-derive = { path = "./metrics-derive" }
 
 # metrics
-metrics = "0.20.1"
+metrics = "0.21.1"
 
 # async
 tokio = { workspace = true, features = ["full"], optional = true }

--- a/crates/metrics/metrics-derive/Cargo.toml
+++ b/crates/metrics/metrics-derive/Cargo.toml
@@ -18,6 +18,6 @@ regex = "1.6.0"
 once_cell = "1.17.0"
 
 [dev-dependencies]
-metrics = "0.20.1"
+metrics = "0.21.1"
 trybuild = "1.0"
 serial_test = "0.10"

--- a/crates/net/downloaders/Cargo.toml
+++ b/crates/net/downloaders/Cargo.toml
@@ -14,7 +14,6 @@ reth-interfaces.workspace = true
 reth-primitives.workspace = true
 reth-db = { path = "../../storage/db" }
 reth-tasks.workspace = true
-reth-metrics.workspace = true
 
 # async
 futures.workspace = true
@@ -23,6 +22,10 @@ pin-project.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 tokio-stream.workspace = true
 tokio-util = { workspace = true, features = ["codec"] }
+
+# metrics
+reth-metrics.workspace = true
+metrics = "0.21.1" # Needed for `metrics-macro` to resolve the crate using `::metrics` notation
 
 # misc
 tracing.workspace = true

--- a/crates/net/downloaders/src/metrics.rs
+++ b/crates/net/downloaders/src/metrics.rs
@@ -1,6 +1,6 @@
 use reth_interfaces::p2p::error::DownloadError;
 use reth_metrics::{
-    metrics::{self, Counter, Gauge},
+    metrics::{Counter, Gauge},
     Metrics,
 };
 

--- a/crates/net/eth-wire/Cargo.toml
+++ b/crates/net/eth-wire/Cargo.toml
@@ -24,7 +24,10 @@ reth-rlp = { workspace = true, features = [
     "ethereum-types",
     "smol_str",
 ] }
+
+# metrics
 reth-metrics.workspace = true
+metrics = "0.21.1" # Needed for `metrics-macro` to resolve the crate using `::metrics` notation
 
 # used for Chain and builders
 ethers-core = { workspace = true, default-features = false }

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -9,7 +9,7 @@ use crate::{
 use futures::{Sink, SinkExt, StreamExt};
 use pin_project::pin_project;
 use reth_codecs::derive_arbitrary;
-use reth_metrics::metrics::{self, counter};
+use reth_metrics::metrics::counter;
 use reth_primitives::{
     bytes::{Buf, BufMut, Bytes, BytesMut},
     hex,

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -31,7 +31,6 @@ reth-rlp-derive = { path = "../../rlp/rlp-derive" }
 reth-tasks.workspace = true
 reth-transaction-pool.workspace = true
 reth-provider.workspace = true
-reth-metrics = { workspace = true, features = ["common"] }
 reth-rpc-types.workspace = true
 
 # async/futures
@@ -45,6 +44,10 @@ tokio-util = { workspace = true, features = ["codec"] }
 serde = { workspace = true, optional = true }
 humantime-serde = { version = "1.1", optional = true }
 serde_json = { workspace = true, optional = true }
+
+# metrics
+reth-metrics = { workspace = true, features = ["common"] }
+metrics = "0.21.1" # Needed for `metrics-macro` to resolve the crate using `::metrics` notation
 
 # misc
 auto_impl = "1"

--- a/crates/net/network/src/metrics.rs
+++ b/crates/net/network/src/metrics.rs
@@ -1,6 +1,6 @@
 use reth_eth_wire::DisconnectReason;
 use reth_metrics::{
-    metrics::{self, Counter, Gauge},
+    metrics::{Counter, Gauge},
     Metrics,
 };
 

--- a/crates/payload/basic/Cargo.toml
+++ b/crates/payload/basic/Cargo.toml
@@ -17,7 +17,6 @@ reth-rlp.workspace = true
 reth-provider.workspace = true
 reth-payload-builder.workspace = true
 reth-tasks.workspace = true
-reth-metrics.workspace = true
 
 ## ethereum
 revm.workspace = true
@@ -26,6 +25,10 @@ revm.workspace = true
 tokio = { workspace = true, features = ["sync", "time"] }
 futures-core = "0.3"
 futures-util.workspace = true
+
+# metrics
+reth-metrics.workspace = true
+metrics = "0.21.1" # Needed for `metrics-macro` to resolve the crate using `::metrics` notation
 
 ## misc
 tracing.workspace = true

--- a/crates/payload/basic/src/metrics.rs
+++ b/crates/payload/basic/src/metrics.rs
@@ -1,9 +1,6 @@
 //! Metrics for the payload builder impl
 
-use reth_metrics::{
-    metrics::{self, Counter},
-    Metrics,
-};
+use reth_metrics::{metrics::Counter, Metrics};
 
 /// Transaction pool metrics
 #[derive(Metrics)]

--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -15,7 +15,6 @@ reth-rpc-types.workspace = true
 reth-rlp.workspace = true
 reth-interfaces.workspace = true
 reth-revm-primitives = { path = "../../revm/revm-primitives" }
-reth-metrics.workspace = true
 
 ## ethereum
 revm-primitives.workspace = true
@@ -24,6 +23,10 @@ revm-primitives.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 tokio-stream.workspace = true
 futures-util.workspace = true
+
+## metrics
+reth-metrics.workspace = true
+metrics = "0.21.1" # Needed for `metrics-macro` to resolve the crate using `::metrics` notation
 
 ## misc
 thiserror.workspace = true

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -1,7 +1,7 @@
 //! Payload builder service metrics.
 
 use reth_metrics::{
-    metrics::{self, Counter, Gauge},
+    metrics::{Counter, Gauge},
     Metrics,
 };
 

--- a/crates/prune/Cargo.toml
+++ b/crates/prune/Cargo.toml
@@ -16,7 +16,10 @@ reth-primitives.workspace = true
 reth-db.workspace = true
 reth-provider.workspace = true
 reth-interfaces.workspace = true
+
+# metrics
 reth-metrics.workspace = true
+metrics = "0.21.1" # Needed for `metrics-macro` to resolve the crate using `::metrics` notation
 
 # misc
 tracing.workspace = true

--- a/crates/prune/src/lib.rs
+++ b/crates/prune/src/lib.rs
@@ -2,6 +2,6 @@ mod error;
 mod metrics;
 mod pruner;
 
+use crate::metrics::Metrics;
 pub use error::PrunerError;
-use metrics::Metrics;
 pub use pruner::{BatchSizes, Pruner, PrunerResult, PrunerWithResult};

--- a/crates/rpc/rpc-builder/Cargo.toml
+++ b/crates/rpc/rpc-builder/Cargo.toml
@@ -21,13 +21,16 @@ reth-rpc-engine-api = { path = "../rpc-engine-api" }
 reth-rpc-types.workspace = true
 reth-tasks.workspace = true
 reth-transaction-pool.workspace = true
-reth-metrics = { workspace = true, features = ["common"] }
 
 # rpc/net
 jsonrpsee = { workspace = true, features = ["server"] }
 tower-http = { version = "0.4", features = ["full"] }
 tower = { version = "0.4", features = ["full"] }
 hyper = "0.14"
+
+# metrics
+reth-metrics = { workspace = true, features = ["common"] }
+metrics = "0.21.1" # Needed for `metrics-macro` to resolve the crate using `::metrics` notation
 
 # misc
 strum = { workspace = true, features = ["derive"] }

--- a/crates/rpc/rpc-builder/src/metrics.rs
+++ b/crates/rpc/rpc-builder/src/metrics.rs
@@ -3,7 +3,7 @@ use jsonrpsee::{
     server::logger::{HttpRequest, Logger, MethodKind, Params, TransportProtocol},
 };
 use reth_metrics::{
-    metrics::{self, Counter, Histogram},
+    metrics::{Counter, Histogram},
     Metrics,
 };
 use std::{net::SocketAddr, time::Instant};

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -22,7 +22,6 @@ reth-network-api.workspace = true
 reth-rpc-engine-api = { path = "../rpc-engine-api" }
 reth-revm = { path = "../../revm" }
 reth-tasks.workspace = true
-reth-metrics.workspace = true
 reth-consensus-common = { path = "../../consensus/common" }
 reth-rpc-types-compat.workspace = true
 
@@ -51,6 +50,11 @@ tokio-util = "0.7"
 pin-project.workspace = true
 rayon.workspace = true
 
+# metrics
+reth-metrics.workspace = true
+metrics = "0.21.1" # Needed for `metrics-macro` to resolve the crate using `::metrics` notation
+
+# misc
 bytes.workspace = true
 secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery"] }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/rpc/rpc/src/eth/cache/metrics.rs
+++ b/crates/rpc/rpc/src/eth/cache/metrics.rs
@@ -1,7 +1,4 @@
-use reth_metrics::{
-    metrics::{self, Gauge},
-    Metrics,
-};
+use reth_metrics::{metrics::Gauge, Metrics};
 
 #[derive(Metrics)]
 #[metrics(scope = "rpc.eth_cache")]

--- a/crates/stages/Cargo.toml
+++ b/crates/stages/Cargo.toml
@@ -21,7 +21,6 @@ reth-interfaces.workspace = true
 reth-db = { path = "../storage/db" }
 reth-codecs = { path = "../storage/codecs" }
 reth-provider.workspace = true
-reth-metrics.workspace = true
 reth-trie = { path = "../trie" }
 
 # async
@@ -36,6 +35,10 @@ tracing.workspace = true
 
 # io
 serde.workspace = true
+
+# metrics
+reth-metrics.workspace = true
+metrics = "0.21.1" # Needed for `metrics-macro` to resolve the crate using `::metrics` notation
 
 # misc
 thiserror.workspace = true

--- a/crates/stages/src/lib.rs
+++ b/crates/stages/src/lib.rs
@@ -81,7 +81,7 @@ pub mod stages;
 
 pub mod sets;
 
+pub use crate::metrics::*;
 pub use error::*;
-pub use metrics::*;
 pub use pipeline::*;
 pub use stage::*;

--- a/crates/stages/src/metrics/sync_metrics.rs
+++ b/crates/stages/src/metrics/sync_metrics.rs
@@ -1,7 +1,4 @@
-use reth_metrics::{
-    metrics::{self, Gauge},
-    Metrics,
-};
+use reth_metrics::{metrics::Gauge, Metrics};
 use reth_primitives::stage::StageId;
 use std::collections::HashMap;
 

--- a/crates/storage/db/Cargo.toml
+++ b/crates/storage/db/Cargo.toml
@@ -14,7 +14,6 @@ reth-primitives.workspace = true
 reth-interfaces.workspace = true
 reth-codecs = { path = "../codecs" }
 reth-libmdbx = { path = "../libmdbx-rs", optional = true, features = ["return-borrowed"] }
-reth-metrics.workspace = true
 
 # codecs
 serde = { workspace = true, default-features = false }
@@ -30,6 +29,10 @@ secp256k1 = { workspace = true, default-features = false, features = [
     "rand",
 ], optional = true }
 modular-bitfield = "0.11.2"
+
+# metrics
+reth-metrics.workspace = true
+metrics = "0.21.1" # Needed for `metrics-macro` to resolve the crate using `::metrics` notation
 
 # misc
 bytes.workspace = true

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -10,7 +10,7 @@ use crate::{
 use parking_lot::RwLock;
 use reth_interfaces::db::DatabaseWriteOperation;
 use reth_libmdbx::{ffi::DBI, EnvironmentKind, Transaction, TransactionKind, WriteFlags, RW};
-use reth_metrics::metrics::{self, histogram};
+use reth_metrics::metrics::histogram;
 use std::{marker::PhantomData, str::FromStr, sync::Arc, time::Instant};
 
 /// Wrapper for the libmdbx transaction.

--- a/crates/tasks/Cargo.toml
+++ b/crates/tasks/Cargo.toml
@@ -15,13 +15,14 @@ tokio = { workspace = true, features = ["sync", "rt"] }
 tracing-futures = "0.2"
 futures-util.workspace = true
 
+## metrics
+reth-metrics.workspace = true
+metrics = "0.21.1" # Needed for `metrics-macro` to resolve the crate using `::metrics` notation
+
 ## misc
 tracing.workspace = true
 thiserror.workspace = true
 dyn-clone = "1.0"
-
-## rpc/metrics
-reth-metrics.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["sync", "rt", "rt-multi-thread", "time", "macros"] }

--- a/crates/tasks/src/metrics.rs
+++ b/crates/tasks/src/metrics.rs
@@ -1,8 +1,5 @@
 //! Task Executor Metrics
-use reth_metrics::{
-    metrics::{self, Counter},
-    Metrics,
-};
+use reth_metrics::{metrics::Counter, Metrics};
 
 /// Task Executor Metrics
 #[derive(Metrics, Clone)]

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -22,7 +22,6 @@ reth-primitives.workspace = true
 reth-provider.workspace = true
 reth-interfaces.workspace = true
 reth-rlp.workspace = true
-reth-metrics.workspace = true
 reth-tasks.workspace = true
 
 # async/futures
@@ -31,6 +30,10 @@ futures-util.workspace = true
 parking_lot.workspace = true
 tokio = { workspace = true, default-features = false, features = ["sync"] }
 tokio-stream.workspace = true
+
+# metrics
+reth-metrics.workspace = true
+metrics = "0.21.1" # Needed for `metrics-macro` to resolve the crate using `::metrics` notation
 
 # misc
 aquamarine = "0.3.0"

--- a/crates/transaction-pool/src/metrics.rs
+++ b/crates/transaction-pool/src/metrics.rs
@@ -1,7 +1,7 @@
 //! Transaction pool metrics.
 
 use reth_metrics::{
-    metrics::{self, Counter, Gauge},
+    metrics::{Counter, Gauge},
     Metrics,
 };
 


### PR DESCRIPTION
# Problem
`metrics-process` metrics doesn't have a `reth_` prefix.

## Root cause
`metrics-process` dependency was updated to latest version in https://github.com/paradigmxyz/reth/pull/3988, and with it the `metrics` dependency made a bump https://github.com/paradigmxyz/reth/blob/efab153cd9c4c7b6349eb46a5b9b5532ab14eb4f/Cargo.lock#L3966
while other crates depending on `metrics` continued to use older version https://github.com/paradigmxyz/reth/blob/efab153cd9c4c7b6349eb46a5b9b5532ab14eb4f/Cargo.lock#L5692

The problem with this is that `metrics-macro` uses the global `RECORDER` variable which we configure using older version of `metrics` crate https://github.com/paradigmxyz/reth/blob/efab153cd9c4c7b6349eb46a5b9b5532ab14eb4f/bin/reth/src/prometheus_exporter.rs#L34-L38 but newer version (which `metrics-process` uses) doesn't see it.

# Solution

Use the same version of `metrics` dependency everywhere, so bump it to latest `0.21.1`. The tricky part is this change https://github.com/metrics-rs/metrics/pull/358, which required defining the `metrics` dependency on the crate level (https://doc.rust-lang.org/reference/paths.html#path-qualifiers).