### PR TITLE
feat: integrate blobstore in validator

### DIFF
--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -264,14 +264,16 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
         let factory = ProviderFactory::new(Arc::clone(&db), Arc::clone(&self.chain));
         let blockchain_db = BlockchainProvider::new(factory, blockchain_tree.clone())?;
 
+        let blob_store = InMemoryBlobStore::default();
         let transaction_pool = reth_transaction_pool::Pool::eth_pool(
             TransactionValidationTaskExecutor::eth_with_additional_tasks(
                 blockchain_db.clone(),
                 Arc::clone(&self.chain),
+                blob_store.clone(),
                 ctx.task_executor.clone(),
                 1,
             ),
-            InMemoryBlobStore::default(),
+            blob_store,
             self.txpool.pool_config(),
         );
         info!(target: "reth::cli", "Transaction pool initialized");

--- a/crates/transaction-pool/src/blobstore/mod.rs
+++ b/crates/transaction-pool/src/blobstore/mod.rs
@@ -1,6 +1,7 @@
 //! Storage for blob data of EIP4844 transactions.
 
 use reth_primitives::{BlobTransactionSidecar, H256};
+use std::fmt;
 mod maintain;
 mod mem;
 mod noop;
@@ -15,7 +16,7 @@ pub use noop::NoopBlobStore;
 /// finalization).
 ///
 /// Note: this is Clone because it is expected to be wrapped in an Arc.
-pub trait BlobStore: Send + Sync + 'static {
+pub trait BlobStore: fmt::Debug + Send + Sync + 'static {
     /// Inserts the blob sidecar into the store
     fn insert(&self, tx: H256, data: BlobTransactionSidecar) -> Result<(), BlobStoreError>;
 

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -105,6 +105,7 @@
 //! use reth_transaction_pool::{TransactionValidationTaskExecutor, Pool, TransactionPool};
 //! use reth_transaction_pool::blobstore::InMemoryBlobStore;
 //!  async fn t<C>(client: C)  where C: StateProviderFactory + ChainSpecProvider + Clone + 'static{
+//!
 //!     let pool = Pool::eth_pool(
 //!         TransactionValidationTaskExecutor::eth(client, MAINNET.clone(), TokioTaskExecutor::default()),
 //!         InMemoryBlobStore::default(),
@@ -296,10 +297,11 @@ where
     /// use reth_tasks::TokioTaskExecutor;
     /// use reth_transaction_pool::{TransactionValidationTaskExecutor, Pool};
     /// use reth_transaction_pool::blobstore::InMemoryBlobStore;
-    /// # fn t<C>(client: C)  where C: StateProviderFactory + Clone + 'static{
+    /// # fn t<C>(client: C)  where C: StateProviderFactory + Clone + 'static {
+    ///     let blob_store = InMemoryBlobStore::default();
     ///     let pool = Pool::eth_pool(
-    ///         TransactionValidationTaskExecutor::eth(client, MAINNET.clone(), TokioTaskExecutor::default()),
-    ///         InMemoryBlobStore::default(),
+    ///         TransactionValidationTaskExecutor::eth(client, MAINNET.clone(), blob_store.clone(), TokioTaskExecutor::default()),
+    ///         blob_store,
     ///         Default::default(),
     ///     );
     /// # }

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -105,10 +105,10 @@
 //! use reth_transaction_pool::{TransactionValidationTaskExecutor, Pool, TransactionPool};
 //! use reth_transaction_pool::blobstore::InMemoryBlobStore;
 //!  async fn t<C>(client: C)  where C: StateProviderFactory + ChainSpecProvider + Clone + 'static{
-//!
+//!     let blob_store = InMemoryBlobStore::default();
 //!     let pool = Pool::eth_pool(
-//!         TransactionValidationTaskExecutor::eth(client, MAINNET.clone(), TokioTaskExecutor::default()),
-//!         InMemoryBlobStore::default(),
+//!         TransactionValidationTaskExecutor::eth(client, MAINNET.clone(), blob_store.clone(), TokioTaskExecutor::default()),
+//!         blob_store,
 //!         Default::default(),
 //!     );
 //!   let mut transactions = pool.pending_transactions_listener();
@@ -137,9 +137,10 @@
 //!    where C: StateProviderFactory + BlockReaderIdExt + ChainSpecProvider + Clone + 'static,
 //!     St: Stream<Item = CanonStateNotification> + Send + Unpin + 'static,
 //!     {
+//!     let blob_store = InMemoryBlobStore::default();
 //!     let pool = Pool::eth_pool(
-//!         TransactionValidationTaskExecutor::eth(client.clone(), MAINNET.clone(), TokioTaskExecutor::default()),
-//!         InMemoryBlobStore::default(),
+//!         TransactionValidationTaskExecutor::eth(client.clone(), MAINNET.clone(), blob_store.clone(), TokioTaskExecutor::default()),
+//!         blob_store,
 //!         Default::default(),
 //!     );
 //!


### PR DESCRIPTION
integrate blobstore into eth validator

it's fine to box this because we only ever use this for re-injected blob transactions