### PR TITLE
Fix: error in cmd 'reth stage run --from M( M > 1 ) --to N merkle'

### DIFF
--- a/bin/reth/src/stage/run.rs
+++ b/bin/reth/src/stage/run.rs
@@ -215,10 +215,7 @@ impl Command {
                 StageEnum::StorageHashing => {
                     (Box::new(StorageHashingStage::new(1, batch_size)), None)
                 }
-                StageEnum::Merkle => (
-                    Box::new(MerkleStage::default_execution()),
-                    Some(Box::new(MerkleStage::default_unwind())),
-                ),
+                StageEnum::Merkle => (Box::new(MerkleStage::default_execution()), None),
                 StageEnum::AccountHistory => (Box::<IndexAccountHistoryStage>::default(), None),
                 StageEnum::StorageHistory => (Box::<IndexStorageHistoryStage>::default(), None),
                 _ => return Ok(()),


### PR DESCRIPTION
I synchronized 10000 blocks，and then executed the following command：
```
# clear data of some stage 
reth stage drop senders
reth stage drop execution
reth stage drop account-hashing
reth stage drop storage-hashing
reth stage drop merkle
reth stage drop tx-lookup
reth stage drop account-history
reth stage drop storage-history

# run stage from 0 to 509
reth node --debug.max-block 509 --debug.terminate -d

# run stage from 509 to 515 
reth stage run --from 509 --to 515 senders -c
reth stage run --from 509 --to 515 execution -c
reth stage run --from 509 --to 515 account-hashing -c
reth stage run --from 509 --to 515 storage-hashing -c
reth stage run --from 509 --to 515 merkle 
```
I got the following error:

```
2023-08-19T02:47:44.660985Z  WARN sync::stages::merkle: Failed to verify block state root target_block=509 got=0xa2041110c6e30252ee6ff88b2f74c280a682c1733f41fde3586d4e36d116d101 expected=SealedHeader { header: Header { parent_hash: 0xef8a3e8e4cbbe44b19be395f04baa58fc93f68b1150f23edbe414d671fc91a72, ommers_hash: 0x5aa42fe85320daf43e9c6ba1cf629d9f8fa67eba7c4259c9ad788bcbb78f9d92, beneficiary: 0x5088d623ba0fcf0131e0897a91734a4d83596aa0, state_root: 0x4900cffb26a68bbbee66d3b0bf511d72a31d397f2d0f5068cd346f2a10e30f57, transactions_root: 0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421, receipts_root: 0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421, withdrawals_root: None, logs_bloom: 0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000, difficulty: 0x0000000000000000000000000000000000000000000000000000000517e4d4d4_U256, number: 509, gas_limit: 5000, gas_used: 0, timestamp: 1438271228, mix_hash: 0x465ef9ad3d4505bf3145777ce6e2b11f9eb70cbbfdb6c513e20a2000bd9f08d4, nonce: 17872174123867053871, base_fee_per_gas: None, blob_gas_used: None, excess_blob_gas: None, extra_data: Bytes(0x476574682f76312e302e302d66633739643332642f6c696e75782f676f312e34) }, hash: 0xd8633cad25b2f96e7d49bfba9f99ec518515d564c4a53c6fb28bbdfaef8328fb }
Error: Stage encountered a validation error in block 509: Block state root (0xa2041110c6e30252ee6ff88b2f74c280a682c1733f41fde3586d4e36d116d101) is different from expected: (0x4900cffb26a68bbbee66d3b0bf511d72a31d397f2d0f5068cd346f2a10e30f57).

Caused by:
    Block state root (0xa2041110c6e30252ee6ff88b2f74c280a682c1733f41fde3586d4e36d116d101) is different from expected: (0x4900cffb26a68bbbee66d3b0bf511d72a31d397f2d0f5068cd346f2a10e30f57)

Location:
    /home/andy/Source/work/reth/bin/reth/src/stage/run.rs:242:37
```

The reason for this bug is that when executing the merkle stage, there is no need to unwind the target to the previous block number.

