### PR TITLE
wip: Moving to Executor

### DIFF
--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -311,7 +311,7 @@ where
         // check if the deadline is reached
         if this.deadline.as_mut().poll(cx).is_ready() {
             trace!("Payload building deadline reached");
-            return Poll::Ready(Ok(()));
+            return Poll::Ready(Ok(()))
         }
 
         // check if the interval is reached
@@ -656,7 +656,7 @@ where
             // which also removes all dependent transaction from the iterator before we can
             // continue
             best_txs.mark_invalid(&pool_tx);
-            continue;
+            continue
         }
 
         // check if the job was cancelled, if so we can exit early
@@ -686,7 +686,7 @@ where
                             trace!(?err, ?tx, "skipping invalid transaction and its descendants");
                             best_txs.mark_invalid(&pool_tx);
                         }
-                        continue;
+                        continue
                     }
                     err => {
                         // this is an error that we should treat as fatal for this attempt

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -26,14 +26,13 @@ use reth_primitives::{
         BEACON_NONCE, EMPTY_RECEIPTS, EMPTY_TRANSACTIONS, EMPTY_WITHDRAWALS,
         ETHEREUM_BLOCK_GAS_LIMIT, RETH_CLIENT_VERSION, SLOT_DURATION,
     },
-    proofs, Block, BlockNumberOrTag, ChainSpec, Header, IntoRecoveredTransaction,
-    SealedBlock, Withdrawal, EMPTY_OMMER_ROOT, H256, U256,
+    proofs, Block, BlockNumberOrTag, ChainSpec, Header, IntoRecoveredTransaction, SealedBlock,
+    Withdrawal, EMPTY_OMMER_ROOT, H256, U256,
 };
 use reth_provider::{BlockReaderIdExt, BlockSource, PostState, StateProviderFactory};
-use reth_revm::executor::Executor;
 use reth_revm::{
     database::{State, SubState},
-    executor::{increment_account_balance, post_block_withdrawals_balance_increments},
+    executor::{increment_account_balance, post_block_withdrawals_balance_increments, Executor},
 };
 use reth_rlp::Encodable;
 use reth_tasks::TaskSpawner;

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -395,7 +395,7 @@ where
 
     fn best_payload(&self) -> Result<Arc<BuiltPayload>, PayloadBuilderError> {
         if let Some(ref payload) = self.best_payload {
-            return Ok(payload.clone());
+            return Ok(payload.clone())
         }
         // No payload has been built yet, but we need to return something that the CL then can
         // deliver, so we need to return an empty payload.
@@ -463,13 +463,13 @@ impl Future for ResolveBestPayload {
             if let Poll::Ready(res) = fut.poll(cx) {
                 this.maybe_better = None;
                 if let Ok(BuildOutcome::Better { payload, .. }) = res {
-                    return Poll::Ready(Ok(Arc::new(payload)));
+                    return Poll::Ready(Ok(Arc::new(payload)))
                 }
             }
         }
 
         if let Some(best) = this.best_payload.take() {
-            return Poll::Ready(Ok(best));
+            return Poll::Ready(Ok(best))
         }
 
         let mut empty_payload = this.empty_payload.take().expect("polled after completion");
@@ -661,7 +661,7 @@ where
 
         // check if the job was cancelled, if so we can exit early
         if cancel.is_cancelled() {
-            return Ok(BuildOutcome::Cancelled);
+            return Ok(BuildOutcome::Cancelled)
         }
 
         // convert tx to a signed transaction
@@ -690,7 +690,7 @@ where
                     }
                     err => {
                         // this is an error that we should treat as fatal for this attempt
-                        return Err(PayloadBuilderError::EvmExecutionError(err));
+                        return Err(PayloadBuilderError::EvmExecutionError(err))
                     }
                 }
             }
@@ -712,7 +712,7 @@ where
     // check if we have a better block
     if !is_better_payload(best_payload.as_deref(), total_fees) {
         // can skip building the block
-        return Ok(BuildOutcome::Aborted { fees: total_fees, cached_reads });
+        return Ok(BuildOutcome::Aborted { fees: total_fees, cached_reads })
     }
 
     let WithdrawalsOutcome { withdrawals_root, withdrawals } = commit_withdrawals(
@@ -868,11 +868,11 @@ where
     DB: DatabaseRef,
 {
     if !chain_spec.is_shanghai_activated_at_timestamp(timestamp) {
-        return Ok(WithdrawalsOutcome::pre_shanghai());
+        return Ok(WithdrawalsOutcome::pre_shanghai())
     }
 
     if withdrawals.is_empty() {
-        return Ok(WithdrawalsOutcome::empty());
+        return Ok(WithdrawalsOutcome::empty())
     }
 
     let balance_increments =

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1040,6 +1040,11 @@ impl TransactionSignedEcRecovered {
         self.signed_transaction
     }
 
+    /// Transform back to immutable reference of [`TransactionSigned`]
+    pub fn signed(&self) -> &TransactionSigned {
+        &self.signed_transaction
+    }
+
     /// Desolve Self to its component
     pub fn to_components(self) -> (TransactionSigned, Address) {
         (self.signed_transaction, self.signer)

--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -7,20 +7,21 @@ use crate::{
     to_reth_acc,
 };
 use reth_consensus_common::calc;
-use reth_interfaces;
-use reth_interfaces::executor::{BlockExecutionError, BlockValidationError};
+use reth_interfaces::{
+    self,
+    executor::{BlockExecutionError, BlockValidationError},
+};
 use reth_primitives::{
     Account, Address, Block, BlockNumber, Bloom, Bytecode, ChainSpec, Hardfork, Header, Receipt,
     ReceiptWithBloom, TransactionSigned, Withdrawal, H256, U256,
 };
 use reth_provider::{BlockExecutor, PostState, StateProvider};
 use reth_revm_primitives::primitives::EVMResult;
-use revm::primitives::{EVMError, ExecutionResult};
 use revm::{
     db::{AccountState, CacheDB, DatabaseRef},
     primitives::{
         hash_map::{self, Entry},
-        Account as RevmAccount, AccountInfo, ResultAndState,
+        Account as RevmAccount, AccountInfo, EVMError, ExecutionResult, ResultAndState,
     },
     EVM,
 };
@@ -195,7 +196,7 @@ where
                 ?hash, ?output, ?transaction, env = ?self.evm.env,
                 "Executed transaction"
             );
-            return output;
+            return output
         }
 
         // main execution.
@@ -525,9 +526,9 @@ pub fn commit_state_changes<DB>(
                 // the account already exists and its storage was cleared, preserve its previous
                 // state
                 AccountState::StorageCleared
-            } else if has_state_clear_eip
-                && matches!(cached_account.account_state, AccountState::NotExisting)
-                && cached_account.info.is_empty()
+            } else if has_state_clear_eip &&
+                matches!(cached_account.account_state, AccountState::NotExisting) &&
+                cached_account.info.is_empty()
             {
                 AccountState::NotExisting
             } else {

--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -220,7 +220,7 @@ where
     ) -> Result<(PostState, u64), BlockExecutionError> {
         // perf: do not execute empty blocks
         if block.body.is_empty() {
-            return Ok((PostState::default(), 0));
+            return Ok((PostState::default(), 0))
         }
         let senders = self.recover_senders(&block.body, senders)?;
 
@@ -237,7 +237,7 @@ where
                     transaction_gas_limit: transaction.gas_limit(),
                     block_available_gas,
                 }
-                .into());
+                .into())
             }
 
             let result = self.execute_and_apply(block.number, &mut post_state, transaction, sender);
@@ -250,7 +250,7 @@ where
                         hash: transaction.hash,
                         message: format!("{e:?}"),
                     }
-                    .into());
+                    .into())
                 }
             }
         }
@@ -336,7 +336,7 @@ where
                 got: cumulative_gas_used,
                 expected: block.gas_used,
             }
-            .into());
+            .into())
         }
 
         self.apply_post_block_changes(block, total_difficulty, post_state)
@@ -567,7 +567,7 @@ pub fn verify_receipt<'a>(
             got: receipts_root,
             expected: expected_receipts_root,
         }
-        .into());
+        .into())
     }
 
     // Create header log bloom.
@@ -577,7 +577,7 @@ pub fn verify_receipt<'a>(
             expected: Box::new(expected_logs_bloom),
             got: Box::new(logs_bloom),
         }
-        .into());
+        .into())
     }
 
     Ok(())

--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -450,7 +450,7 @@ pub fn commit_state_changes<DB>(
             db_account.account_state = AccountState::NotExisting;
             db_account.info = AccountInfo::default();
 
-            continue;
+            continue
         } else {
             // check if account code is new or old.
             // does it exist inside cached contracts if it doesn't it is new bytecode that


### PR DESCRIPTION
The idea of the following PR is to move the transaction execution and state changes to the Executor.

It's still mising the use of `cached_reads` in the Executor. @mattsse  what's the best way to do that? 