### PR TITLE
feat: add additional conversion trait for pooled tx element

### DIFF
--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -91,11 +91,12 @@ pub use storage::StorageEntry;
 pub use transaction::{
     util::secp256k1::{public_key_to_address, recover_signer, sign_message},
     AccessList, AccessListItem, AccessListWithGasUsed, BlobTransaction, BlobTransactionSidecar,
-    FromRecoveredTransaction, IntoRecoveredTransaction, InvalidTransactionError,
-    PooledTransactionsElement, PooledTransactionsElementEcRecovered, Signature, Transaction,
-    TransactionKind, TransactionMeta, TransactionSigned, TransactionSignedEcRecovered,
-    TransactionSignedNoHash, TxEip1559, TxEip2930, TxEip4844, TxLegacy, TxType, EIP1559_TX_TYPE_ID,
-    EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID, LEGACY_TX_TYPE_ID,
+    FromRecoveredPooledTransaction, FromRecoveredTransaction, IntoRecoveredTransaction,
+    InvalidTransactionError, PooledTransactionsElement, PooledTransactionsElementEcRecovered,
+    Signature, Transaction, TransactionKind, TransactionMeta, TransactionSigned,
+    TransactionSignedEcRecovered, TransactionSignedNoHash, TxEip1559, TxEip2930, TxEip4844,
+    TxLegacy, TxType, EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID,
+    LEGACY_TX_TYPE_ID,
 };
 pub use withdrawal::Withdrawal;
 

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1089,6 +1089,16 @@ impl FromRecoveredTransaction for TransactionSignedEcRecovered {
     }
 }
 
+/// A transaction type that can be created from a [`PooledTransactionsElementEcRecovered`]
+/// transaction.
+///
+/// This is a conversion trait that'll ensure transactions received via P2P can be converted to the
+/// transaction type that the transaction pool uses.
+pub trait FromRecoveredPooledTransaction {
+    /// Converts to this type from the given [`PooledTransactionsElementEcRecovered`].
+    fn from_recovered_transaction(tx: PooledTransactionsElementEcRecovered) -> Self;
+}
+
 /// The inverse of [`FromRecoveredTransaction`] that ensure the transaction can be sent over the
 /// network
 pub trait IntoRecoveredTransaction {

--- a/crates/primitives/src/transaction/pooled.rs
+++ b/crates/primitives/src/transaction/pooled.rs
@@ -373,6 +373,12 @@ impl PooledTransactionsElementEcRecovered {
         self.transaction
     }
 
+    /// Transform back to [`PooledTransactionsElement`]
+    pub fn into_ecrecovered_transaction(self) -> TransactionSignedEcRecovered {
+        let (tx, signer) = self.into_components();
+        tx.into_ecrecovered_transaction(signer)
+    }
+
     /// Desolve Self to its component
     pub fn into_components(self) -> (PooledTransactionsElement, Address) {
         (self.transaction, self.signer)

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -12,10 +12,10 @@ use rand::{
     prelude::Distribution,
 };
 use reth_primitives::{
-    constants::MIN_PROTOCOL_BASE_FEE, hex, Address, FromRecoveredTransaction,
-    IntoRecoveredTransaction, Signature, Transaction, TransactionKind, TransactionSigned,
-    TransactionSignedEcRecovered, TxEip1559, TxEip2930, TxEip4844, TxHash, TxLegacy, TxType, H256,
-    U128, U256,
+    constants::MIN_PROTOCOL_BASE_FEE, hex, Address, FromRecoveredPooledTransaction,
+    FromRecoveredTransaction, IntoRecoveredTransaction, PooledTransactionsElementEcRecovered,
+    Signature, Transaction, TransactionKind, TransactionSigned, TransactionSignedEcRecovered,
+    TxEip1559, TxEip2930, TxEip4844, TxHash, TxLegacy, TxType, H256, U128, U256,
 };
 use std::{ops::Range, sync::Arc, time::Instant};
 
@@ -520,6 +520,12 @@ impl FromRecoveredTransaction for MockTransaction {
                 unimplemented!()
             }
         }
+    }
+}
+
+impl FromRecoveredPooledTransaction for MockTransaction {
+    fn from_recovered_transaction(tx: PooledTransactionsElementEcRecovered) -> Self {
+        FromRecoveredTransaction::from_recovered_transaction(tx.into_ecrecovered_transaction())
     }
 }
 

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -6,8 +6,9 @@ use crate::{
 };
 use futures_util::{ready, Stream};
 use reth_primitives::{
-    Address, BlobTransactionSidecar, FromRecoveredTransaction, IntoRecoveredTransaction, PeerId,
-    PooledTransactionsElement, PooledTransactionsElementEcRecovered, Transaction, TransactionKind,
+    Address, BlobTransactionSidecar, FromRecoveredPooledTransaction, FromRecoveredTransaction,
+    IntoRecoveredTransaction, PeerId, PooledTransactionsElement,
+    PooledTransactionsElementEcRecovered, Transaction, TransactionKind,
     TransactionSignedEcRecovered, TxHash, EIP1559_TX_TYPE_ID, EIP4844_TX_TYPE_ID, H256, U256,
 };
 use reth_rlp::Encodable;
@@ -511,7 +512,12 @@ impl<T> BestTransactions for std::iter::Empty<T> {
 
 /// Trait for transaction types used inside the pool
 pub trait PoolTransaction:
-    fmt::Debug + Send + Sync + FromRecoveredTransaction + IntoRecoveredTransaction
+    fmt::Debug
+    + Send
+    + Sync
+    + FromRecoveredPooledTransaction
+    + FromRecoveredTransaction
+    + IntoRecoveredTransaction
 {
     /// Hash of the transaction.
     fn hash(&self) -> &TxHash;
@@ -755,6 +761,12 @@ impl PoolTransaction for EthPooledTransaction {
 impl FromRecoveredTransaction for EthPooledTransaction {
     fn from_recovered_transaction(tx: TransactionSignedEcRecovered) -> Self {
         EthPooledTransaction::new(tx)
+    }
+}
+
+impl FromRecoveredPooledTransaction for EthPooledTransaction {
+    fn from_recovered_transaction(tx: PooledTransactionsElementEcRecovered) -> Self {
+        EthPooledTransaction::from(tx)
     }
 }
 


### PR DESCRIPTION
add a new conversion trait that allows us to convert pooled transactions into the pool's tx type

