### PR TITLE
fix: use gas_used from execution result

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/builder/geth.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/geth.rs
@@ -110,7 +110,10 @@ impl GethTraceBuilder {
     /// Generate a geth-style traces for the call tracer.
     ///
     /// This decodes all call frames from the recorded traces.
-    pub fn geth_call_traces(&self, opts: CallConfig) -> CallFrame {
+    ///
+    /// This expects the gas used and return value for the
+    /// [ExecutionResult](revm::primitives::ExecutionResult) of the executed transaction.
+    pub fn geth_call_traces(&self, opts: CallConfig, gas_used: u64) -> CallFrame {
         if self.nodes.is_empty() {
             return Default::default()
         }
@@ -119,6 +122,7 @@ impl GethTraceBuilder {
         // first fill up the root
         let main_trace_node = &self.nodes[0];
         let mut root_call_frame = main_trace_node.geth_empty_call_frame(include_logs);
+        root_call_frame.gas_used = U256::from(gas_used);
 
         // selfdestructs are not recorded as individual call traces but are derived from
         // the call trace and are added as additional `CallFrame` objects to the parent call

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -248,9 +248,10 @@ where
                             .inner
                             .eth_api
                             .spawn_with_call_at(call, at, overrides, move |db, env| {
-                                inspect(db, env, &mut inspector)?;
-                                let frame =
-                                    inspector.into_geth_builder().geth_call_traces(call_config);
+                                let (res, _) = inspect(db, env, &mut inspector)?;
+                                let frame = inspector
+                                    .into_geth_builder()
+                                    .geth_call_traces(call_config, res.result.gas_used());
                                 Ok(frame.into())
                             })
                             .await?;
@@ -469,7 +470,9 @@ where
 
                         let (res, _) = inspect(db, env, &mut inspector)?;
 
-                        let frame = inspector.into_geth_builder().geth_call_traces(call_config);
+                        let frame = inspector
+                            .into_geth_builder()
+                            .geth_call_traces(call_config, res.result.gas_used());
 
                         return Ok((frame.into(), res.state))
                     }


### PR DESCRIPTION
within revm the final gas_used is determined outside the inspector so we currently cannot derive it during tracing (init cost for example)

this uses the output of the inspect for gas_used

ref #4262