### PR TITLE
fix: state overrides and call many args

### DIFF
--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -1,7 +1,6 @@
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_primitives::{BlockId, BlockNumberOrTag, Bytes, H256};
 use reth_rpc_types::{
-    state::StateOverride,
     trace::geth::{
         BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace,
         TraceResult,
@@ -120,8 +119,7 @@ pub trait DebugApi {
         &self,
         bundles: Vec<Bundle>,
         state_context: Option<StateContext>,
-        opts: Option<GethDebugTracingOptions>,
-        state_override: Option<StateOverride>,
+        opts: Option<GethDebugTracingCallOptions>,
     ) -> RpcResult<Vec<GethTrace>>;
 
     /// Sets the logging backtrace location. When a backtrace location is set and a log message is

--- a/crates/rpc/rpc-types/src/eth/state.rs
+++ b/crates/rpc/rpc-types/src/eth/state.rs
@@ -24,11 +24,11 @@ pub struct AccountOverride {
     /// Fake key-value mapping to override all slots in the account storage before executing the
     /// call.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub state: Option<HashMap<H256, H256>>,
+    pub state: Option<HashMap<H256, U256>>,
     /// Fake key-value mapping to override individual slots in the account storage before executing
     /// the call.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub state_diff: Option<HashMap<H256, H256>>,
+    pub state_diff: Option<HashMap<H256, U256>>,
 }
 
 #[cfg(test)]
@@ -47,5 +47,24 @@ mod tests {
             .get(&"0x0000000000000000000000000000000000000124".parse().unwrap())
             .unwrap();
         assert!(acc.code.is_some());
+    }
+    #[test]
+    fn test_state_override_state_diff() {
+        let s = r#"{
+                "0x1b5212AF6b76113afD94cD2B5a78a73B7d7A8222": {
+                    "balance": "0x39726378b58c400000",
+                    "stateDiff": {}
+                },
+                "0xdAC17F958D2ee523a2206206994597C13D831ec7": {
+                    "stateDiff": {
+                        "0xede27e4e7f3676edbf125879f17a896d6507958df3d57bda6219f1880cae8a41": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                    }
+                }
+            }"#;
+        let state_override: StateOverride = serde_json::from_str(s).unwrap();
+        let acc = state_override
+            .get(&"0x1b5212AF6b76113afD94cD2B5a78a73B7d7A8222".parse().unwrap())
+            .unwrap();
+        assert!(acc.state_diff.is_some());
     }
 }

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -25,7 +25,6 @@ use reth_revm::{
 use reth_rlp::{Decodable, Encodable};
 use reth_rpc_api::DebugApiServer;
 use reth_rpc_types::{
-    state::StateOverride,
     trace::geth::{
         BlockTraceResult, FourByteFrame, GethDebugBuiltInTracerType, GethDebugTracerType,
         GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, NoopFrame, TraceResult,
@@ -341,8 +340,7 @@ where
         &self,
         bundles: Vec<Bundle>,
         state_context: Option<StateContext>,
-        opts: Option<GethDebugTracingOptions>,
-        state_override: Option<StateOverride>,
+        opts: Option<GethDebugTracingCallOptions>,
     ) -> EthResult<Vec<GethTrace>> {
         if bundles.is_empty() {
             return Err(EthApiError::InvalidParams(String::from("bundles are empty.")))
@@ -357,8 +355,9 @@ where
             self.inner.eth_api.block_by_id(target_block),
         )?;
 
+        let opts = opts.unwrap_or_default();
         let block = block.ok_or_else(|| EthApiError::UnknownBlockNumber)?;
-        let tracing_options = opts.unwrap_or_default();
+        let GethDebugTracingCallOptions { tracing_options, state_overrides, .. } = opts;
         let gas_limit = self.inner.eth_api.call_gas_limit();
 
         // we're essentially replaying the transactions in the block here, hence we need the state
@@ -401,7 +400,7 @@ where
                     //let mut result = Vec::with_capacity(bundle.len());
                     let Bundle { transactions, block_override } = bundle;
                     let overrides =
-                        EvmOverrides::new(state_override.clone(), block_override.map(Box::new));
+                        EvmOverrides::new(state_overrides.clone(), block_override.map(Box::new));
 
                     let mut transactions = transactions.into_iter().peekable();
                     while let Some(tx) = transactions.next() {
@@ -765,12 +764,10 @@ where
         &self,
         bundles: Vec<Bundle>,
         state_context: Option<StateContext>,
-        opts: Option<GethDebugTracingOptions>,
-        state_override: Option<StateOverride>,
+        opts: Option<GethDebugTracingCallOptions>,
     ) -> RpcResult<Vec<GethTrace>> {
         let _permit = self.acquire_trace_permit().await;
-        Ok(DebugApi::debug_trace_call_many(self, bundles, state_context, opts, state_override)
-            .await?)
+        Ok(DebugApi::debug_trace_call_many(self, bundles, state_context, opts).await?)
     }
 }
 

--- a/crates/rpc/rpc/src/eth/revm_utils.rs
+++ b/crates/rpc/rpc/src/eth/revm_utils.rs
@@ -488,19 +488,13 @@ where
                 account,
                 new_account_state
                     .into_iter()
-                    .map(|(slot, value)| {
-                        (U256::from_be_bytes(slot.0), U256::from_be_bytes(value.0))
-                    })
+                    .map(|(slot, value)| (U256::from_be_bytes(slot.0), value))
                     .collect(),
             )?;
         }
         (None, Some(account_state_diff)) => {
             for (slot, value) in account_state_diff {
-                db.insert_account_storage(
-                    account,
-                    U256::from_be_bytes(slot.0),
-                    U256::from_be_bytes(value.0),
-                )?;
+                db.insert_account_storage(account, U256::from_be_bytes(slot.0), value)?;
             }
         }
     };


### PR DESCRIPTION
Closes #4295

fix 1: use `GethDebugTracingCallOptions` as args which includes the overrides, same as traceCall
fix 2: values in stateoverrides are U256