### PR TITLE
fix(pruner): history indices `cursor.prev()` emptiness check

### DIFF
--- a/crates/prune/src/pruner.rs
+++ b/crates/prune/src/pruner.rs
@@ -666,9 +666,9 @@ impl<DB: Database> Pruner<DB> {
             if key.as_ref().highest_block_number <= to_block {
                 cursor.delete_current()?;
                 if key.as_ref().highest_block_number == to_block {
-                    // Shard contains only block numbers up to the target one, so we can skip to the
-                    // next sharded key. It is guaranteed that further shards for this sharded key
-                    // will not contain the target block number, as it's in this shard.
+                    // Shard contains only block numbers up to the target one, so we can skip to
+                    // the last shard for this key. It is guaranteed that further shards for this
+                    // sharded key will not contain the target block number, as it's in this shard.
                     cursor.seek_exact(last_key(&key))?;
                 }
             }
@@ -721,8 +721,10 @@ impl<DB: Database> Pruner<DB> {
                     }
                 }
 
-                // Jump to the next address.
-                cursor.seek_exact(last_key(&key))?;
+                // Jump to the last shard for this key, if current key isn't already the last shard.
+                if key.as_ref().highest_block_number != u64::MAX {
+                    cursor.seek_exact(last_key(&key))?;
+                }
             }
 
             processed += 1;

--- a/crates/prune/src/pruner.rs
+++ b/crates/prune/src/pruner.rs
@@ -661,9 +661,9 @@ impl<DB: Database> Pruner<DB> {
         while let Some(result) = cursor.next()? {
             let (key, blocks): (T::Key, BlockNumberList) = result;
 
+            // If shard consists only of block numbers less than the target one, delete shard
+            // completely.
             if key.as_ref().highest_block_number <= to_block {
-                // If shard consists only of block numbers less than the target one, delete shard
-                // completely.
                 cursor.delete_current()?;
                 if key.as_ref().highest_block_number == to_block {
                     // Shard contains only block numbers up to the target one, so we can skip to the
@@ -671,45 +671,49 @@ impl<DB: Database> Pruner<DB> {
                     // will not contain the target block number, as it's in this shard.
                     cursor.seek_exact(last_key(&key))?;
                 }
-            } else {
-                // Shard contains block numbers that are higher than the target one, so we need to
-                // filter it. It is guaranteed that further shards for this sharded key will not
-                // contain the target block number, as it's in this shard.
+            }
+            // Shard contains block numbers that are higher than the target one, so we need to
+            // filter it. It is guaranteed that further shards for this sharded key will not
+            // contain the target block number, as it's in this shard.
+            else {
                 let new_blocks = blocks
                     .iter(0)
                     .skip_while(|block| *block <= to_block as usize)
                     .collect::<Vec<_>>();
 
+                // If there were blocks less than or equal to the target one
+                // (so the shard has changed), update the shard.
                 if blocks.len() != new_blocks.len() {
-                    // If there were blocks less than or equal to the target one
-                    // (so the shard has changed), update the shard.
+                    // If there are no more blocks in this shard, we need to remove it, as empty
+                    // shards are not allowed.
                     if new_blocks.is_empty() {
-                        // If there are no more blocks in this shard, we need to remove it, as empty
-                        // shards are not allowed.
                         if key.as_ref().highest_block_number == u64::MAX {
-                            if let Some(prev_value) = cursor
-                                .prev()?
-                                .filter(|(prev_key, _)| key_matches(prev_key, &key))
-                                .map(|(_, prev_value)| prev_value)
-                            {
-                                // If current shard is the last shard for the sharded key that has
-                                // previous shards, replace it with the previous shard.
-                                cursor.delete_current()?;
-                                // Upsert will replace the last shard for this sharded key with the
-                                // previous value.
-                                cursor.upsert(key.clone(), prev_value)?;
-                            } else {
+                            let prev_row = cursor.prev()?;
+                            match prev_row {
+                                // If current shard is the last shard for the sharded key that
+                                // has previous shards, replace it with the previous shard.
+                                Some((prev_key, prev_value)) if key_matches(&prev_key, &key) => {
+                                    cursor.delete_current()?;
+                                    // Upsert will replace the last shard for this sharded key with
+                                    // the previous value.
+                                    cursor.upsert(key.clone(), prev_value)?;
+                                }
                                 // If there's no previous shard for this sharded key,
                                 // just delete last shard completely.
-
-                                // Jump back to the original last shard.
-                                cursor.next()?;
-                                // Delete shard.
-                                cursor.delete_current()?;
+                                _ => {
+                                    // If we successfully moved the cursor to a previous row,
+                                    // jump to the original last shard.
+                                    if prev_row.is_some() {
+                                        cursor.next()?;
+                                    }
+                                    // Delete shard.
+                                    cursor.delete_current()?;
+                                }
                             }
-                        } else {
-                            // If current shard is not the last shard for this sharded key,
-                            // just delete it.
+                        }
+                        // If current shard is not the last shard for this sharded key,
+                        // just delete it.
+                        else {
                             cursor.delete_current()?;
                         }
                     } else {


### PR DESCRIPTION
## Problem

First row in `AccountHistory` and `StorageHistory` tables wasn't pruned, but instead the row after it was. The issue is in this snippet: https://github.com/paradigmxyz/reth/blob/34b68deedf401624de09fd24d63361be8f4f9987/crates/prune/src/pruner.rs#L690-L709

When we move a cursor to the previous row, it can be the first row of the table, so the cursor will not be actually moved and the `cursor.prev()` will return `None`. We assumed that we always move it, so the next movement forward via `cursor.next()` was actually going forward too much.

## Solution

Check that previous row wasn't empty and we actually moved the cursor:
https://github.com/paradigmxyz/reth/blob/434d0a04f56cdb7d57ea02512d9a1f7a4362ec38/crates/prune/src/pruner.rs#L706-L708

Also, save on a no-op `seek_exact` if we were already at the last shard: https://github.com/paradigmxyz/reth/blob/4a5d8d2fc3bf1bf8c9fa1429b30eacc5cb7c6d18/crates/prune/src/pruner.rs#L724-L727

The rest is just reformatting of the comments.

