### PR TITLE
feat: add Validator::on_new_head_block

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -486,7 +486,7 @@ where
         self.pool.set_block_info(info)
     }
 
-    fn on_canonical_state_change(&self, update: CanonicalStateUpdate) {
+    fn on_canonical_state_change(&self, update: CanonicalStateUpdate<'_>) {
         self.pool.on_canonical_state_change(update);
     }
 

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -271,13 +271,11 @@ pub async fn maintain_transaction_pool<Client, P, St, Tasks>(
 
                 // update the pool first
                 let update = CanonicalStateUpdate {
-                    hash: new_tip.hash,
-                    number: new_tip.number,
+                    new_tip: &new_tip.block,
                     pending_block_base_fee,
                     changed_accounts,
                     // all transactions mined in the new chain need to be removed from the pool
                     mined_transactions: new_mined_transactions.into_iter().collect(),
-                    timestamp: new_tip.timestamp,
                 };
                 pool.on_canonical_state_change(update);
 
@@ -348,12 +346,10 @@ pub async fn maintain_transaction_pool<Client, P, St, Tasks>(
 
                 // Canonical update
                 let update = CanonicalStateUpdate {
-                    hash: tip.hash,
-                    number: tip.number,
+                    new_tip: &tip.block,
                     pending_block_base_fee,
                     changed_accounts,
                     mined_transactions,
-                    timestamp: tip.timestamp,
                 };
                 pool.on_canonical_state_change(update);
 

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     traits::{PoolTransaction, TransactionOrigin},
 };
 use reth_primitives::{
-    Address, BlobTransactionSidecar, IntoRecoveredTransaction, TransactionKind,
+    Address, BlobTransactionSidecar, IntoRecoveredTransaction, SealedBlock, TransactionKind,
     TransactionSignedEcRecovered, TxHash, H256, U256,
 };
 use std::{fmt, time::Instant};
@@ -156,6 +156,11 @@ pub trait TransactionValidator: Send + Sync {
         origin: TransactionOrigin,
         transaction: Self::Transaction,
     ) -> TransactionValidationOutcome<Self::Transaction>;
+
+    /// Invoked when the head block changes.
+    ///
+    /// This can be used to update fork specific values (timestamp).
+    fn on_new_head_block(&self, _new_tip_block: &SealedBlock) {}
 
     /// Ensure that the code size is not greater than `max_init_code_size`.
     /// `max_init_code_size` should be configurable so this will take it as an argument.


### PR DESCRIPTION
closes #4244

this allows updating values that depend on the current height, like enabling fork based on timestamp or fees like in op-reth

cc @refcell 