### PR TITLE
docs: add `--dev` flag to book

### DIFF
--- a/book/cli/node.md
+++ b/book/cli/node.md
@@ -327,7 +327,7 @@ Dev testnet:
       --dev.block_max_transactions <BLOCK_MAX_TRANSACTIONS>
           How many transactions to mine per block
 
-      --dev.block_time <BLOCK_TIME>
+      --dev.block-time <BLOCK_TIME>
           Interval between blocks.
           
           Parses strings using [humantime::parse_duration]

--- a/book/cli/node.md
+++ b/book/cli/node.md
@@ -331,7 +331,7 @@ Dev testnet:
           Interval between blocks.
           
           Parses strings using [humantime::parse_duration]
-          --dev.block_time 12s
+          --dev.block-time 12s
 
 Logging:
       --log.persistent

--- a/book/cli/node.md
+++ b/book/cli/node.md
@@ -314,6 +314,25 @@ Database:
       --auto-mine
           Automatically mine blocks for new transactions
 
+Dev testnet:
+      --dev
+          Start the node in dev mode
+
+          This mode uses a local proof-of-authority consensus engine with either fixed block times
+          or automatically mined blocks.
+          Disables network discovery and enables local http server.
+          Prefunds 20 accounts derived by mnemonic "test test test test test test test test test test
+          test junk" with 10 000 ETH each.
+
+      --dev.block_max_transactions <BLOCK_MAX_TRANSACTIONS>
+          How many transactions to mine per block
+
+      --dev.block_time <BLOCK_TIME>
+          Interval between blocks.
+          
+          Parses strings using [humantime::parse_duration]
+          --dev.block_time 12s
+
 Logging:
       --log.persistent
           The flag to enable persistent logs

--- a/book/cli/node.md
+++ b/book/cli/node.md
@@ -324,7 +324,7 @@ Dev testnet:
           Prefunds 20 accounts derived by mnemonic "test test test test test test test test test test
           test junk" with 10 000 ETH each.
 
-      --dev.block_max_transactions <BLOCK_MAX_TRANSACTIONS>
+      --dev.block-max-transactions <BLOCK_MAX_TRANSACTIONS>
           How many transactions to mine per block
 
       --dev.block-time <BLOCK_TIME>


### PR DESCRIPTION
Adds the `--dev` flag for `reth node` to the book. Resolves #3903 