### PR TITLE
feat(bin): show db path when confirming the drop

### DIFF
--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -188,7 +188,7 @@ impl Command {
             Subcommands::Drop { force } => {
                 if !force {
                     // Ask for confirmation
-                    print!("Are you sure you want to drop the database? This cannot be undone. (y/N): ");
+                    print!("Are you sure you want to drop the database at {db_path:?}? This cannot be undone. (y/N): ");
                     // Flush the buffer to ensure the message is printed immediately
                     io::stdout().flush().unwrap();
 


### PR DESCRIPTION
Just to be sure what database you're deleting:
```console
➜  reth (main) cargo run --quiet -- db drop                                                                                                                                                                       ✭
Are you sure you want to drop the database at "/Users/shekhirin/Library/Application Support/reth/mainnet/db"? This cannot be undone. (y/N):
```