### PR TITLE
chore: bump rustls-webpki

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6471,9 +6471,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.3"
+version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261e9e0888cba427c3316e6322805653c9425240b6fd96cee7cb671ab70ab8d0"
+checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
 dependencies = [
  "ring",
  "untrusted",


### PR DESCRIPTION
Fixes failed CI: https://github.com/paradigmxyz/reth/actions/runs/5939125749/job/16104904583#step:4:49
Also see https://github.com/rustls/webpki/releases/tag/v%2F0.101.4