### PR TITLE
feat(bin): expose `db.table_entries` metric

### DIFF
--- a/bin/reth/src/prometheus_exporter.rs
+++ b/bin/reth/src/prometheus_exporter.rs
@@ -91,11 +91,13 @@ pub(crate) async fn initialize(
                 let overflow_pages = stats.overflow_pages();
                 let num_pages = leaf_pages + branch_pages + overflow_pages;
                 let table_size = page_size * num_pages;
+                let entries = stats.entries();
 
                 absolute_counter!("db.table_size", table_size as u64, "table" => table);
                 absolute_counter!("db.table_pages", leaf_pages as u64, "table" => table, "type" => "leaf");
                 absolute_counter!("db.table_pages", branch_pages as u64, "table" => table, "type" => "branch");
                 absolute_counter!("db.table_pages", overflow_pages as u64, "table" => table, "type" => "overflow");
+                absolute_counter!("db.table_entries", entries as u64, "table" => table);
             }
 
             Ok::<(), eyre::Report>(())


### PR DESCRIPTION
Tested on my local syncing Sepolia node:
```console
➜  ~  curl -s localhost:9001 | grep table_entries
# TYPE reth_db_table_entries counter
reth_db_table_entries{table="StoragesTrie"} 0
reth_db_table_entries{table="SyncStageProgress"} 0
reth_db_table_entries{table="BlockWithdrawals"} 0
reth_db_table_entries{table="AccountsTrie"} 0
reth_db_table_entries{table="BlockBodyIndices"} 1950001
reth_db_table_entries{table="PruneCheckpoints"} 0
reth_db_table_entries{table="BlockOmmers"} 49770
reth_db_table_entries{table="HeaderNumbers"} 2000001
reth_db_table_entries{table="StorageChangeSet"} 0
reth_db_table_entries{table="Receipts"} 0
reth_db_table_entries{table="Transactions"} 2452236
reth_db_table_entries{table="CanonicalHeaders"} 2000001
reth_db_table_entries{table="StorageHistory"} 0
reth_db_table_entries{table="HashedAccount"} 15
reth_db_table_entries{table="HeaderTD"} 2000001
reth_db_table_entries{table="TransactionBlock"} 475487
reth_db_table_entries{table="Headers"} 2000001
reth_db_table_entries{table="AccountChangeSet"} 15
reth_db_table_entries{table="PlainAccountState"} 15
reth_db_table_entries{table="PlainStorageState"} 0
reth_db_table_entries{table="HashedStorage"} 0
reth_db_table_entries{table="SyncStage"} 13
reth_db_table_entries{table="TxSenders"} 0
reth_db_table_entries{table="Bytecodes"} 0
reth_db_table_entries{table="TxHashNumber"} 0
reth_db_table_entries{table="AccountHistory"} 15
```