### PR TITLE
feat: add TransactionPool::get_pooled_transaction_elements

### DIFF
--- a/crates/primitives/src/transaction/eip4844.rs
+++ b/crates/primitives/src/transaction/eip4844.rs
@@ -288,6 +288,24 @@ pub struct BlobTransaction {
 }
 
 impl BlobTransaction {
+    /// Constructs a new [BlobTransaction] from a [TransactionSigned] and a
+    /// [BlobTransactionSidecar].
+    ///
+    /// Returns an error if the signed transaction is not [TxEip4844]
+    pub fn try_from_signed(
+        tx: TransactionSigned,
+        sidecar: BlobTransactionSidecar,
+    ) -> Result<Self, (TransactionSigned, BlobTransactionSidecar)> {
+        let TransactionSigned { transaction, signature, hash } = tx;
+        match transaction {
+            Transaction::Eip4844(transaction) => Ok(Self { hash, transaction, signature, sidecar }),
+            transaction => {
+                let tx = TransactionSigned { transaction, signature, hash };
+                Err((tx, sidecar))
+            }
+        }
+    }
+
     /// Verifies that the transaction's blob data, commitments, and proofs are all valid.
     ///
     /// Takes as input the [KzgSettings], which should contain the the parameters derived from the

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -156,7 +156,7 @@
 //! - `test-utils`: Export utilities for testing
 use crate::pool::PoolInner;
 use aquamarine as _;
-use reth_primitives::{Address, BlobTransactionSidecar, TxHash, U256};
+use reth_primitives::{Address, BlobTransactionSidecar, PooledTransactionsElement, TxHash, U256};
 use reth_provider::StateProviderFactory;
 use std::{
     collections::{HashMap, HashSet},
@@ -165,7 +165,10 @@ use std::{
 use tokio::sync::mpsc::Receiver;
 use tracing::{instrument, trace};
 
-use crate::blobstore::{BlobStore, BlobStoreError};
+use crate::{
+    blobstore::{BlobStore, BlobStoreError},
+    traits::GetPooledTransactionLimit,
+};
 pub use crate::{
     config::{
         PoolConfig, PriceBumpConfig, SubPoolLimit, DEFAULT_PRICE_BUMP, REPLACE_BLOB_PRICE_BUMP,
@@ -401,6 +404,14 @@ where
         max: usize,
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         self.pooled_transactions().into_iter().take(max).collect()
+    }
+
+    fn get_pooled_transaction_elements(
+        &self,
+        tx_hashes: Vec<TxHash>,
+        limit: GetPooledTransactionLimit,
+    ) -> Vec<PooledTransactionsElement> {
+        self.pool.get_pooled_transaction_elements(tx_hashes, limit)
     }
 
     fn best_transactions(

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -4,13 +4,16 @@
 //! to be generic over it.
 
 use crate::{
-    blobstore::BlobStoreError, error::PoolError, traits::PendingTransactionListenerKind,
-    validate::ValidTransaction, AllPoolTransactions, AllTransactionsEvents, BestTransactions,
-    BlockInfo, EthPooledTransaction, NewTransactionEvent, PoolResult, PoolSize, PoolTransaction,
-    PropagatedTransactions, TransactionEvents, TransactionOrigin, TransactionPool,
-    TransactionValidationOutcome, TransactionValidator, ValidPoolTransaction,
+    blobstore::BlobStoreError,
+    error::PoolError,
+    traits::{GetPooledTransactionLimit, PendingTransactionListenerKind},
+    validate::ValidTransaction,
+    AllPoolTransactions, AllTransactionsEvents, BestTransactions, BlockInfo, EthPooledTransaction,
+    NewTransactionEvent, PoolResult, PoolSize, PoolTransaction, PropagatedTransactions,
+    TransactionEvents, TransactionOrigin, TransactionPool, TransactionValidationOutcome,
+    TransactionValidator, ValidPoolTransaction,
 };
-use reth_primitives::{Address, BlobTransactionSidecar, TxHash};
+use reth_primitives::{Address, BlobTransactionSidecar, PooledTransactionsElement, TxHash};
 use std::{collections::HashSet, marker::PhantomData, sync::Arc};
 use tokio::sync::{mpsc, mpsc::Receiver};
 
@@ -105,6 +108,14 @@ impl TransactionPool for NoopTransactionPool {
         &self,
         _max: usize,
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        vec![]
+    }
+
+    fn get_pooled_transaction_elements(
+        &self,
+        _tx_hashes: Vec<TxHash>,
+        _limit: GetPooledTransactionLimit,
+    ) -> Vec<PooledTransactionsElement> {
         vec![]
     }
 


### PR DESCRIPTION
adds missing Txpool function to retrieve the `PooledTransactionsElement`.

this also makes it possible to enforce a limit 