### PR TITLE
feat: add shouldOverrideBuilder to ExecutionPayloadEnvelope

### DIFF
--- a/crates/payload/builder/src/payload.rs
+++ b/crates/payload/builder/src/payload.rs
@@ -69,7 +69,11 @@ impl From<BuiltPayload> for ExecutionPayloadEnvelope {
     fn from(value: BuiltPayload) -> Self {
         let BuiltPayload { block, fees, .. } = value;
 
-        ExecutionPayloadEnvelope { block_value: fees, payload: block.into() }
+        ExecutionPayloadEnvelope {
+            block_value: fees,
+            payload: block.into(),
+            should_override_builder: None,
+        }
     }
 }
 

--- a/crates/rpc/rpc-types/src/eth/engine/payload.rs
+++ b/crates/rpc/rpc-types/src/eth/engine/payload.rs
@@ -29,9 +29,12 @@ impl std::fmt::Display for PayloadId {
     }
 }
 
-/// This structure maps for the return value of `engine_getPayloadV2` of the beacon chain spec.
+/// This structure maps for the return value of `engine_getPayload` of the beacon chain spec, for
+/// both V2 and V3.
 ///
-/// See also: <https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#engine_getpayloadv2>
+/// See also:
+/// <https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#engine_getpayloadv2>
+/// <https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md#engine_getpayloadv3>
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExecutionPayloadEnvelope {
     /// Execution payload, which could be either V1 or V2
@@ -50,6 +53,10 @@ pub struct ExecutionPayloadEnvelope {
     // // TODO(mattsse): for V3
     // #[serde(rename = "blobsBundle", skip_serializing_if = "Option::is_none")]
     // pub blobs_bundle: Option<BlobsBundleV1>,
+    /// Introduced in V3, this represents a suggestion from the execution layer if the payload
+    /// should be used instead of an externally provided one.
+    #[serde(rename = "shouldOverrideBuilder", skip_serializing_if = "Option::is_none")]
+    pub should_override_builder: Option<bool>,
 }
 
 impl ExecutionPayloadEnvelope {


### PR DESCRIPTION
Adds the `shouldOverrideBuilder` flag from the cancun spec:

> #### Request
> 
> * method: `engine_getPayloadV3`
> * params:
>   1. `payloadId`: `DATA`, 8 Bytes - Identifier of the payload build process
> * timeout: 1s
> 
> #### Response
> 
> * result: `object`
>   - `executionPayload`: [`ExecutionPayloadV3`](https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md#ExecutionPayloadV3)
>   - `blockValue` : `QUANTITY`, 256 Bits - The expected value to be received by the `feeRecipient` in wei
>   - `blobsBundle`: [`BlobsBundleV1`](https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md#BlobsBundleV1) - Bundle with data corresponding to blob transactions included into `executionPayload`
>   - `shouldOverrideBuilder` : `BOOLEAN` - Suggestion from the execution layer to use this `executionPayload` instead of an externally provided one
> * error: code and message set in case an exception happens while getting the payload.
> 