### PR TITLE
feat(cli): allow overriding kzg trusted setup

### DIFF
--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -699,7 +699,7 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
         // try to look up the header in the database
         if let Some(header) = header {
             info!(target: "reth::cli", ?tip, "Successfully looked up tip block in the database");
-            return Ok(header.seal_slow());
+            return Ok(header.seal_slow())
         }
 
         info!(target: "reth::cli", ?tip, "Fetching tip block from the network.");
@@ -707,7 +707,7 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
             match get_single_header(&client, tip).await {
                 Ok(tip_header) => {
                     info!(target: "reth::cli", ?tip, "Successfully fetched tip");
-                    return Ok(tip_header);
+                    return Ok(tip_header)
                 }
                 Err(error) => {
                     error!(target: "reth::cli", %error, "Failed to fetch the tip. Retrying...");

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -273,7 +273,7 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
 
         let validator = if let Some(ref trusted_setup_file) = self.trusted_setup_file {
             let kzg_settings = self.load_kzg_settings(trusted_setup_file)?;
-            info!(target: "reth::cli", "Trusted setup file loaded");
+            info!(target: "reth::cli", "KZG trusted setup file loaded");
 
             TransactionValidationTaskExecutor::eth_with_kzg_settings_and_tasks(
                 blockchain_db.clone(),

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -570,7 +570,8 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
             .wrap_err_with(|| format!("Could not load config file {:?}", config_path))
     }
 
-    /// Loads the trusted setup params from a given file path.
+    /// Loads the trusted setup params from a given file path or falls back to
+    /// `MAINNET_KZG_TRUSTED_SETUP`.
     fn kzg_settings(&self) -> eyre::Result<Arc<KzgSettings>> {
         if let Some(ref trusted_setup_file) = self.trusted_setup_file {
             let trusted_setup = KzgSettings::load_trusted_setup_file(trusted_setup_file.into())
@@ -698,7 +699,7 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
         // try to look up the header in the database
         if let Some(header) = header {
             info!(target: "reth::cli", ?tip, "Successfully looked up tip block in the database");
-            return Ok(header.seal_slow())
+            return Ok(header.seal_slow());
         }
 
         info!(target: "reth::cli", ?tip, "Fetching tip block from the network.");
@@ -706,7 +707,7 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
             match get_single_header(&client, tip).await {
                 Ok(tip_header) => {
                     info!(target: "reth::cli", ?tip, "Successfully fetched tip");
-                    return Ok(tip_header)
+                    return Ok(tip_header);
                 }
                 Err(error) => {
                     error!(target: "reth::cli", %error, "Failed to fetch the tip. Retrying...");

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -218,8 +218,8 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
         let mut config: Config = self.load_config(config_path.clone())?;
 
         if let Some(ref trusted_setup_file) = self.trusted_setup_file {
-            info!(target: "reth::cli", path = ?trusted_setup_file, "Trusted setup file overridden");
             self.override_trusted_file(trusted_setup_file)?;
+            info!(target: "reth::cli", path = ?trusted_setup_file, "Trusted setup file overridden");
         };
 
         // always store reth.toml in the data dir, not the chain specific data dir

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -71,7 +71,7 @@ use reth_transaction_pool::{
 use secp256k1::SecretKey;
 use std::{
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::Arc,
 };
 use tokio::sync::{mpsc::unbounded_channel, oneshot, watch};
@@ -586,10 +586,9 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
             .wrap_err_with(|| format!("Could not load config file {:?}", config_path))
     }
 
-    fn load_kzg_settings(&self, trusted_setup_file: &PathBuf) -> eyre::Result<KzgSettings> {
-        let trusted_setup =
-            KzgSettings::load_trusted_setup_file(trusted_setup_file.as_path().into())
-                .map_err(LoadKzgSettingsError::KzgError)?;
+    fn load_kzg_settings(&self, trusted_setup_file: &Path) -> eyre::Result<KzgSettings> {
+        let trusted_setup = KzgSettings::load_trusted_setup_file(trusted_setup_file.into())
+            .map_err(LoadKzgSettingsError::KzgError)?;
 
         Ok(trusted_setup)
     }

--- a/crates/primitives/src/constants/eip4844.rs
+++ b/crates/primitives/src/constants/eip4844.rs
@@ -35,7 +35,7 @@ pub const VERSIONED_HASH_VERSION_KZG: u8 = 0x01;
 const TRUSTED_SETUP_RAW: &[u8] = include_bytes!("../../res/eip4844/trusted_setup.txt");
 
 /// KZG trusted setup
-pub static KZG_TRUSTED_SETUP: Lazy<Arc<KzgSettings>> = Lazy::new(|| {
+pub static MAINNET_KZG_TRUSTED_SETUP: Lazy<Arc<KzgSettings>> = Lazy::new(|| {
     Arc::new(
         load_trusted_setup_from_bytes(TRUSTED_SETUP_RAW).expect("Failed to load trusted setup"),
     )
@@ -69,6 +69,6 @@ mod tests {
 
     #[test]
     fn ensure_load_kzg_settings() {
-        let _settings = Arc::clone(&KZG_TRUSTED_SETUP);
+        let _settings = Arc::clone(&MAINNET_KZG_TRUSTED_SETUP);
     }
 }

--- a/crates/primitives/src/constants/eip4844.rs
+++ b/crates/primitives/src/constants/eip4844.rs
@@ -2,10 +2,7 @@
 
 use crate::kzg::KzgSettings;
 use once_cell::sync::Lazy;
-use std::{
-    io::Write,
-    sync::{Arc, Mutex},
-};
+use std::{io::Write, sync::Arc};
 
 /// Size a single field element in bytes.
 pub const FIELD_ELEMENT_BYTES: u64 = 32;
@@ -38,10 +35,10 @@ pub const VERSIONED_HASH_VERSION_KZG: u8 = 0x01;
 const TRUSTED_SETUP_RAW: &[u8] = include_bytes!("../../res/eip4844/trusted_setup.txt");
 
 /// KZG trusted setup
-pub static KZG_TRUSTED_SETUP: Lazy<Arc<Mutex<KzgSettings>>> = Lazy::new(|| {
-    Arc::new(Mutex::new(
+pub static KZG_TRUSTED_SETUP: Lazy<Arc<KzgSettings>> = Lazy::new(|| {
+    Arc::new(
         load_trusted_setup_from_bytes(TRUSTED_SETUP_RAW).expect("Failed to load trusted setup"),
-    ))
+    )
 });
 
 /// Loads the trusted setup parameters from the given bytes and returns the [KzgSettings].

--- a/crates/primitives/src/constants/eip4844.rs
+++ b/crates/primitives/src/constants/eip4844.rs
@@ -2,7 +2,10 @@
 
 use crate::kzg::KzgSettings;
 use once_cell::sync::Lazy;
-use std::{io::Write, sync::Arc};
+use std::{
+    io::Write,
+    sync::{Arc, Mutex},
+};
 
 /// Size a single field element in bytes.
 pub const FIELD_ELEMENT_BYTES: u64 = 32;
@@ -35,10 +38,10 @@ pub const VERSIONED_HASH_VERSION_KZG: u8 = 0x01;
 const TRUSTED_SETUP_RAW: &[u8] = include_bytes!("../../res/eip4844/trusted_setup.txt");
 
 /// KZG trusted setup
-pub static KZG_TRUSTED_SETUP: Lazy<Arc<KzgSettings>> = Lazy::new(|| {
-    Arc::new(
+pub static KZG_TRUSTED_SETUP: Lazy<Arc<Mutex<KzgSettings>>> = Lazy::new(|| {
+    Arc::new(Mutex::new(
         load_trusted_setup_from_bytes(TRUSTED_SETUP_RAW).expect("Failed to load trusted setup"),
-    )
+    ))
 });
 
 /// Loads the trusted setup parameters from the given bytes and returns the [KzgSettings].

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -113,7 +113,7 @@ where
                     return TransactionValidationOutcome::Invalid(
                         transaction,
                         InvalidTransactionError::Eip1559Disabled.into(),
-                    );
+                    )
                 }
             }
             EIP1559_TX_TYPE_ID => {
@@ -122,7 +122,7 @@ where
                     return TransactionValidationOutcome::Invalid(
                         transaction,
                         InvalidTransactionError::Eip1559Disabled.into(),
-                    );
+                    )
                 }
             }
             EIP4844_TX_TYPE_ID => {
@@ -131,7 +131,7 @@ where
                     return TransactionValidationOutcome::Invalid(
                         transaction,
                         InvalidTransactionError::Eip4844Disabled.into(),
-                    );
+                    )
                 }
             }
 
@@ -149,13 +149,13 @@ where
             return TransactionValidationOutcome::Invalid(
                 transaction,
                 InvalidPoolTransactionError::OversizedData(size, TX_MAX_SIZE),
-            );
+            )
         }
 
         // Check whether the init code size has been exceeded.
         if self.fork_tracker.is_shanghai_activated() {
             if let Err(err) = self.ensure_max_init_code_size(&transaction, MAX_INIT_CODE_SIZE) {
-                return TransactionValidationOutcome::Invalid(transaction, err);
+                return TransactionValidationOutcome::Invalid(transaction, err)
             }
         }
 
@@ -165,7 +165,7 @@ where
             return TransactionValidationOutcome::Invalid(
                 transaction,
                 InvalidPoolTransactionError::ExceedsGasLimit(gas_limit, self.block_gas_limit),
-            );
+            )
         }
 
         // Ensure max_priority_fee_per_gas (if EIP1559) is less than max_fee_per_gas if any.
@@ -173,19 +173,19 @@ where
             return TransactionValidationOutcome::Invalid(
                 transaction,
                 InvalidTransactionError::TipAboveFeeCap.into(),
-            );
+            )
         }
 
         // Drop non-local transactions with a fee lower than the configured fee for acceptance into
         // the pool.
-        if !origin.is_local()
-            && transaction.is_eip1559()
-            && transaction.max_priority_fee_per_gas() < self.minimum_priority_fee
+        if !origin.is_local() &&
+            transaction.is_eip1559() &&
+            transaction.max_priority_fee_per_gas() < self.minimum_priority_fee
         {
             return TransactionValidationOutcome::Invalid(
                 transaction,
                 InvalidPoolTransactionError::Underpriced,
-            );
+            )
         }
 
         // Checks for chainid
@@ -194,7 +194,7 @@ where
                 return TransactionValidationOutcome::Invalid(
                     transaction,
                     InvalidTransactionError::ChainIdMismatch.into(),
-                );
+                )
             }
         }
 
@@ -205,7 +205,7 @@ where
                 return TransactionValidationOutcome::Invalid(
                     transaction,
                     InvalidTransactionError::TxTypeNotSupported.into(),
-                );
+                )
             }
             // TODO add checks for blob tx
         }
@@ -227,7 +227,7 @@ where
             return TransactionValidationOutcome::Invalid(
                 transaction,
                 InvalidTransactionError::SignerAccountHasBytecode.into(),
-            );
+            )
         }
 
         // Checks for nonce
@@ -235,7 +235,7 @@ where
             return TransactionValidationOutcome::Invalid(
                 transaction,
                 InvalidTransactionError::NonceNotConsistent.into(),
-            );
+            )
         }
 
         // Checks for max cost
@@ -248,7 +248,7 @@ where
                     available_funds: account.balance,
                 }
                 .into(),
-            );
+            )
         }
 
         // Return the valid transaction
@@ -314,9 +314,9 @@ impl EthTransactionValidatorBuilder {
             block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT,
             minimum_priority_fee: None,
             additional_tasks: 1,
-            // default to true, can potentially take this as a param in the future
+            // default to true, can potentially take thisas a param in the future
             propagate_local_transactions: true,
-            kzg_settings: Arc::clone(&KZG_TRUSTED_SETUP),
+            kzg_settings: Arc::clone(&*KZG_TRUSTED_SETUP),
 
             // by default all transaction types are allowed
             eip2718: true,

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -314,7 +314,7 @@ impl EthTransactionValidatorBuilder {
             block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT,
             minimum_priority_fee: None,
             additional_tasks: 1,
-            // default to true, can potentially take thisas a param in the future
+            // default to true, can potentially take this as a param in the future
             propagate_local_transactions: true,
             kzg_settings: Arc::clone(&*KZG_TRUSTED_SETUP),
 

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -75,7 +75,7 @@ pub(crate) struct EthTransactionValidatorInner<Client, T> {
     propagate_local_transactions: bool,
     /// Stores the setup and parameters needed for validating KZG proofs.
     #[allow(unused)]
-    kzg_settings: Arc<std::sync::Mutex<KzgSettings>>,
+    kzg_settings: Arc<KzgSettings>,
     /// Marker for the transaction type
     _marker: PhantomData<T>,
 }
@@ -303,7 +303,7 @@ pub struct EthTransactionValidatorBuilder {
     propagate_local_transactions: bool,
 
     /// Stores the setup and parameters needed for validating KZG proofs.
-    kzg_settings: Arc<std::sync::Mutex<KzgSettings>>,
+    kzg_settings: Arc<KzgSettings>,
 }
 
 impl EthTransactionValidatorBuilder {
@@ -316,7 +316,7 @@ impl EthTransactionValidatorBuilder {
             additional_tasks: 1,
             // default to true, can potentially take this as a param in the future
             propagate_local_transactions: true,
-            kzg_settings: Arc::clone(&*KZG_TRUSTED_SETUP),
+            kzg_settings: Arc::clone(&KZG_TRUSTED_SETUP),
 
             // by default all transaction types are allowed
             eip2718: true,
@@ -376,7 +376,7 @@ impl EthTransactionValidatorBuilder {
     }
 
     /// Sets the [KzgSettings] to use for validating KZG proofs.
-    pub fn kzg_settings(mut self, kzg_settings: Arc<std::sync::Mutex<KzgSettings>>) -> Self {
+    pub fn kzg_settings(mut self, kzg_settings: Arc<KzgSettings>) -> Self {
         self.kzg_settings = kzg_settings;
         self
     }

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -8,7 +8,7 @@ use crate::{
     TransactionValidationOutcome, TransactionValidationTaskExecutor, TransactionValidator,
 };
 use reth_primitives::{
-    constants::{eip4844::KZG_TRUSTED_SETUP, ETHEREUM_BLOCK_GAS_LIMIT},
+    constants::{eip4844::MAINNET_KZG_TRUSTED_SETUP, ETHEREUM_BLOCK_GAS_LIMIT},
     kzg::KzgSettings,
     ChainSpec, InvalidTransactionError, SealedBlock, EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID,
     EIP4844_TX_TYPE_ID, LEGACY_TX_TYPE_ID,
@@ -316,7 +316,7 @@ impl EthTransactionValidatorBuilder {
             additional_tasks: 1,
             // default to true, can potentially take this as a param in the future
             propagate_local_transactions: true,
-            kzg_settings: Arc::clone(&KZG_TRUSTED_SETUP),
+            kzg_settings: Arc::clone(&MAINNET_KZG_TRUSTED_SETUP),
 
             // by default all transaction types are allowed
             eip2718: true,

--- a/crates/transaction-pool/src/validate/task.rs
+++ b/crates/transaction-pool/src/validate/task.rs
@@ -131,32 +131,6 @@ impl<Client, Tx> TransactionValidationTaskExecutor<EthTransactionValidator<Clien
             .with_additional_tasks(num_additional_tasks)
             .build_with_tasks::<Client, Tx, T, S>(client, tasks, blob_store)
     }
-
-    /// Creates a new instance for the given [ChainSpec]
-    ///
-    /// By default this will enable support for:
-    ///   - shanghai
-    ///   - eip1559
-    ///   - eip2930
-    ///
-    /// This will always spawn a validation task that performs the actual validation. It will spawn
-    /// `num_additional_tasks` additional tasks. It will override the `kzg_settings`.
-    pub fn eth_with_kzg_settings_and_tasks<T, S: BlobStore>(
-        client: Client,
-        chain_spec: Arc<ChainSpec>,
-        blob_store: S,
-        tasks: T,
-        num_additional_tasks: usize,
-        kzg_settings: KzgSettings,
-    ) -> Self
-    where
-        T: TaskSpawner,
-    {
-        EthTransactionValidatorBuilder::new(chain_spec)
-            .kzg_settings(Arc::new(kzg_settings))
-            .with_additional_tasks(num_additional_tasks)
-            .build_with_tasks::<Client, Tx, T, S>(client, tasks, blob_store)
-    }
 }
 
 impl<V> TransactionValidationTaskExecutor<V> {

--- a/crates/transaction-pool/src/validate/task.rs
+++ b/crates/transaction-pool/src/validate/task.rs
@@ -172,7 +172,7 @@ where
                 return TransactionValidationOutcome::Error(
                     hash,
                     Box::new(TransactionValidatorError::ValidationServiceUnreachable),
-                );
+                )
             }
         }
 

--- a/crates/transaction-pool/src/validate/task.rs
+++ b/crates/transaction-pool/src/validate/task.rs
@@ -7,7 +7,7 @@ use crate::{
     TransactionValidator,
 };
 use futures_util::{lock::Mutex, StreamExt};
-use reth_primitives::{kzg::KzgSettings, ChainSpec, SealedBlock};
+use reth_primitives::{ChainSpec, SealedBlock};
 use reth_tasks::TaskSpawner;
 use std::{future::Future, pin::Pin, sync::Arc};
 use tokio::{
@@ -172,7 +172,7 @@ where
                 return TransactionValidationOutcome::Error(
                     hash,
                     Box::new(TransactionValidatorError::ValidationServiceUnreachable),
-                )
+                );
             }
         }
 


### PR DESCRIPTION
## Motivation

This PR extends the CLI interface with the new flag: `--trusted-setup-file`. This allows overriding the `KzgSettings` constant in preparation for [devcun-devnet-8](https://notes.ethereum.org/@ethpandaops/dencun-devnet-8).

Closes https://github.com/paradigmxyz/reth/issues/4200.