### PR TITLE
ref(cli): remove duplicated clap arg

### DIFF
--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -43,7 +43,6 @@ pub struct Cli<Ext: RethCliExt = ()> {
     #[arg(
         long,
         value_name = "CHAIN_OR_PATH",
-        global = true,
         verbatim_doc_comment,
         default_value = "mainnet",
         value_parser = genesis_value_parser,


### PR DESCRIPTION
The `chain` cli arg is marked as `global` twice:

https://github.com/paradigmxyz/reth/blob/bfa130d1875f1e1510e181e09fced33578d70563/bin/reth/src/cli/mod.rs#L43-L50

This PR removes one of them.