### PR TITLE
feat(bin): db freelist metric

### DIFF
--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -186,8 +186,8 @@ where
     ///
     /// Note:
     ///
-    /// * LMDB stores all the freelists in the designated database 0 in each environment, and the
-    ///   freelist count is stored at the beginning of the value as `libc::size_t` in the native
+    /// * MDBX stores all the freelists in the designated database 0 in each environment, and the
+    ///   freelist count is stored at the beginning of the value as `libc::uint32_t` in the native
     ///   byte order.
     ///
     /// * It will create a read transaction to traverse the freelist database.
@@ -199,16 +199,12 @@ where
 
         for result in cursor {
             let (_key, value) = result?;
-            if value.len() < mem::size_of::<usize>() {
+            if value.len() < size_of::<usize>() {
                 return Err(Error::Corrupted)
             }
 
-            let s = &value[..mem::size_of::<usize>()];
-            if cfg!(target_pointer_width = "64") {
-                freelist += NativeEndian::read_u64(s) as usize;
-            } else {
-                freelist += NativeEndian::read_u32(s) as usize;
-            }
+            let s = &value[..size_of::<usize>()];
+            freelist += NativeEndian::read_u32(s) as usize;
         }
 
         Ok(freelist)


### PR DESCRIPTION
Resolves https://github.com/paradigmxyz/reth/issues/4287

```console
➜  reth (alexey/db-freelist-metric) ./db-tools/mdbx_stat -qff ~/Library/Application\ Support/reth/sepolia/db/mdbx.dat | grep GC
  GC: 62 pages
➜  reth (alexey/db-freelist-metric) curl -s localhost:9001 | grep '^reth_db_freelist'
reth_db_freelist 62
```

---

Implementation changes in `freelist` are due to MDBX always using 32 bits for page numbers.

LMDB page numbers: https://github.com/LMDB/lmdb/blob/c7b3cc4df6dfe8f0772fb509bdc74777667caa43/libraries/liblmdb/lmdb.h#L190-L208
MDBX page numbers: https://github.com/paradigmxyz/reth/blob/c2436a955f40457fd1888fbacebaeee35af9e60f/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx_stat.c#L2799-L2803