### PR TITLE
feat: add validate-blob to extension trait

### DIFF
--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -91,11 +91,11 @@ pub use storage::StorageEntry;
 pub use transaction::{
     util::secp256k1::{public_key_to_address, recover_signer, sign_message},
     AccessList, AccessListItem, AccessListWithGasUsed, BlobTransaction, BlobTransactionSidecar,
-    FromRecoveredPooledTransaction, FromRecoveredTransaction, IntoRecoveredTransaction,
-    InvalidTransactionError, PooledTransactionsElement, PooledTransactionsElementEcRecovered,
-    Signature, Transaction, TransactionKind, TransactionMeta, TransactionSigned,
-    TransactionSignedEcRecovered, TransactionSignedNoHash, TxEip1559, TxEip2930, TxEip4844,
-    TxLegacy, TxType, EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID,
+    BlobTransactionValidationError, FromRecoveredPooledTransaction, FromRecoveredTransaction,
+    IntoRecoveredTransaction, InvalidTransactionError, PooledTransactionsElement,
+    PooledTransactionsElementEcRecovered, Signature, Transaction, TransactionKind, TransactionMeta,
+    TransactionSigned, TransactionSignedEcRecovered, TransactionSignedNoHash, TxEip1559, TxEip2930,
+    TxEip4844, TxLegacy, TxType, EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID,
     LEGACY_TX_TYPE_ID,
 };
 pub use withdrawal::Withdrawal;

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -20,7 +20,9 @@ pub use tx_type::{
 
 pub use eip1559::TxEip1559;
 pub use eip2930::TxEip2930;
-pub use eip4844::{BlobTransaction, BlobTransactionSidecar, TxEip4844};
+pub use eip4844::{
+    BlobTransaction, BlobTransactionSidecar, BlobTransactionValidationError, TxEip4844,
+};
 pub use legacy::TxLegacy;
 pub use pooled::{PooledTransactionsElement, PooledTransactionsElementEcRecovered};
 


### PR DESCRIPTION
adds `EthPoolTransaction::validate_blob` to extension trait and add new error variant that replaces Ok(false)