### PR TITLE
feat(net): rm TODO for `DEFAULT_DISCOVERY_PORT`

### DIFF
--- a/crates/net/eth-wire/src/builder.rs
+++ b/crates/net/eth-wire/src/builder.rs
@@ -100,7 +100,6 @@ impl HelloBuilder {
                 // TODO: proper client versioning
                 client_version: "Ethereum/1.0.0".to_string(),
                 capabilities: vec![EthVersion::Eth68.into()],
-                // TODO: default port config
                 port: DEFAULT_DISCOVERY_PORT,
                 id: pubkey,
             },


### PR DESCRIPTION
`DEFAULT_DISCOVERY_PORT` constant has been pushed instead of port `30303` in #4356. As a consequence, the TODO is deleted because it is resolved.