### PR TITLE
feat(grafana): sort stages

### DIFF
--- a/etc/grafana/dashboards/overview.json
+++ b/etc/grafana/dashboards/overview.json
@@ -272,7 +272,6 @@
               "MerkleUnwind": 5,
               "SenderRecovery": 3,
               "StorageHashing": 7,
-              "Time": 13,
               "TotalDifficulty": 1,
               "TransactionLookup": 9
             }

--- a/etc/grafana/dashboards/overview.json
+++ b/etc/grafana/dashboards/overview.json
@@ -249,6 +249,36 @@
         }
       ],
       "title": "Stage checkpoints",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "AccountHashing": 6,
+              "Bodies": 2,
+              "Execution": 4,
+              "Finish": 12,
+              "Headers": 0,
+              "IndexAccountHistory": 11,
+              "IndexStorageHistory": 10,
+              "MerkleExecute": 8,
+              "MerkleUnwind": 5,
+              "SenderRecovery": 3,
+              "StorageHashing": 7,
+              "Time": 13,
+              "TotalDifficulty": 1,
+              "TransactionLookup": 9
+            }
+          }
+        }
+      ],
       "transparent": true,
       "type": "bargauge"
     },
@@ -5611,6 +5641,6 @@
   "timezone": "",
   "title": "reth",
   "uid": "2k8BXz24x",
-  "version": 6,
+  "version": 7,
   "weekStart": ""
 }


### PR DESCRIPTION
In the grafana dashboard, I think it could be easier to follow the progress if stages are in the right order
## Before
![image](https://github.com/paradigmxyz/reth/assets/11060749/f812513e-3646-44b3-b035-a3c70eaee588)

## After
![image](https://github.com/paradigmxyz/reth/assets/11060749/fd8dfc3c-aa85-4a80-8547-187004e21c82)
