### PR TITLE
chore: increase max dbs

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -73,7 +73,10 @@ impl<E: EnvironmentKind> Env<E> {
         };
 
         let mut inner_env = Environment::new();
-        inner_env.set_max_dbs(Tables::ALL.len());
+
+        // Note: We set max dbs to 256 here to allow for custom tables. This needs to be set on environment creation.
+        debug_assert!(Tables::ALL.len() <= 256, "number of tables exceed max dbs");
+        inner_env.set_max_dbs(256);
         inner_env.set_geometry(Geometry {
             // Maximum database size of 4 terabytes
             size: Some(0..(4 * TERABYTE)),
@@ -116,7 +119,7 @@ impl<E: EnvironmentKind> Env<E> {
                     LogLevel::Extra => 7,
                 });
             } else {
-                return Err(DatabaseError::LogLevelUnavailable(log_level))
+                return Err(DatabaseError::LogLevelUnavailable(log_level));
             }
         }
 

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -74,7 +74,8 @@ impl<E: EnvironmentKind> Env<E> {
 
         let mut inner_env = Environment::new();
 
-        // Note: We set max dbs to 256 here to allow for custom tables. This needs to be set on environment creation.
+        // Note: We set max dbs to 256 here to allow for custom tables. This needs to be set on
+        // environment creation.
         debug_assert!(Tables::ALL.len() <= 256, "number of tables exceed max dbs");
         inner_env.set_max_dbs(256);
         inner_env.set_geometry(Geometry {
@@ -119,7 +120,7 @@ impl<E: EnvironmentKind> Env<E> {
                     LogLevel::Extra => 7,
                 });
             } else {
-                return Err(DatabaseError::LogLevelUnavailable(log_level));
+                return Err(DatabaseError::LogLevelUnavailable(log_level))
             }
         }
 


### PR DESCRIPTION
Currently it's not possible to create custom tables if you re-use reth because MDBX needs to be hinted how many tables ("databases") there can ever exist.

This is a breaking change because:

> Controls the maximum number of named databases for the environment.
> 
> By default only unnamed key-value database could used and appropriate value should set by MDBX_opt_max_db to using any more named subDB(s). To reduce overhead, use the minimum sufficient value. This option may only set after [mdbx_env_create()](https://erthink.github.io/libmdbx/group__c__opening.html#ga109eb833997698fbb77912716596fe8e) and before [mdbx_env_open()](https://erthink.github.io/libmdbx/group__c__opening.html#gabb7dd3b10dd31639ba252df545e11768).
>
> [Link](https://erthink.github.io/libmdbx/group__c__api.html#ga671855605968c3b1f89a72e2d7b71eb3)

As a follow up, an example of using a custom table could be added. However, it is important to note that this would only work if the database is completely within the control of the developer, i.e. it cannot be a sidecar process because of MDBX limitations on 1 write tx per environment.