### PR TITLE
feat(primitives): increase transaction senders pruning batch size

### DIFF
--- a/crates/primitives/src/prune/batch_sizes.rs
+++ b/crates/primitives/src/prune/batch_sizes.rs
@@ -57,7 +57,7 @@ impl PruneBatchSizes {
         Self {
             receipts: 250,
             transaction_lookup: 250,
-            transaction_senders: 250,
+            transaction_senders: 1000,
             account_history: 1000,
             storage_history: 1000,
         }
@@ -69,7 +69,7 @@ impl PruneBatchSizes {
         Self {
             receipts: 100,
             transaction_lookup: 100,
-            transaction_senders: 100,
+            transaction_senders: 500,
             account_history: 500,
             storage_history: 500,
         }


### PR DESCRIPTION
This PR increases the `Transaction Senders` prune part batch size not sacrificing the requirement for freelist still decreasing. You can see on the chart that `TxSenders` table entries (green line, left Y axis) is decreasing faster after the batch size increase, while freelist size (yellow line, right Y axis) started decreasing slower but still below zero:

<img width="1138" alt="image" src="https://github.com/paradigmxyz/reth/assets/5773434/564d0013-97bb-4473-a6af-fecfaa2c6042">
