### PR TITLE
Add state root check in BlockchainTestCase::run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,6 +1969,7 @@ dependencies = [
  "reth-revm",
  "reth-rlp",
  "reth-stages",
+ "reth-trie",
  "serde",
  "serde_json",
  "thiserror",

--- a/testing/ef-tests/Cargo.toml
+++ b/testing/ef-tests/Cargo.toml
@@ -19,6 +19,7 @@ reth-stages = { path = "../../crates/stages" }
 reth-rlp.workspace = true
 reth-interfaces.workspace = true
 reth-revm = { path = "../../crates/revm" }
+reth-trie = { path = "../../crates/trie" }
 tokio = "1.28.1"
 walkdir = "2.3.3"
 serde = "1.0.163"

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -114,7 +114,7 @@ impl Case for BlockchainTestCase {
                 Some(RootOrState::Root(root)) => {
                     let actual_root = StateRoot::new(provider.tx_ref())
                         .root()
-                        .map_err(|err| <StateRootError as Into<DatabaseError>>::into(err))?;
+                        .map_err(<StateRootError as Into<DatabaseError>>::into)?;
                     assert_eq!(root, &actual_root);
                 }
                 Some(RootOrState::State(state)) => {

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -4,7 +4,7 @@ use crate::{
     models::{BlockchainTest, ForkSpec, RootOrState},
     Case, Error, Suite,
 };
-use reth_db::test_utils::create_test_rw_db;
+use reth_db::{tables, test_utils::create_test_rw_db, transaction::DbTx};
 use reth_primitives::{BlockBody, SealedBlock};
 use reth_provider::{BlockWriter, ProviderFactory};
 use reth_rlp::Decodable;
@@ -111,7 +111,12 @@ impl Case for BlockchainTestCase {
             // Validate post state
             match &case.post_state {
                 Some(RootOrState::Root(root)) => {
-                    // TODO: We should really check the state root here...
+                    let last_block_number = last_block.unwrap();
+                    let header = provider.tx_ref().get::<tables::Headers>(last_block_number)?.ok_or_else(|| {
+                        Error::Assertion(format!("Expected header for block number ({last_block_number:?}) is missing from DB: {self:?}"))
+                    })?;
+                    let actual_root = header.state_root;
+                    assert_eq!(root, &actual_root);
                     println!("Post-state root: #{root:?}")
                 }
                 Some(RootOrState::State(state)) => {


### PR DESCRIPTION
Closes #4369 

Add an assertion in order to check the state root if `case.post_state` corresponds to a state root.