### PR TITLE
chore: pin Grafana version in docker-compose.yml

### DIFF
--- a/etc/docker-compose.yml
+++ b/etc/docker-compose.yml
@@ -41,7 +41,7 @@ services:
 
   grafana:
     restart: unless-stopped
-    image: grafana/grafana
+    image: grafana/grafana:10.1.0
     depends_on:
       - reth
       - prometheus


### PR DESCRIPTION
When dashboard is exported, it has a Grafana version specified: https://github.com/paradigmxyz/reth/blob/80ee49b77708d227be818309a0ac1b99ffb2f57f/etc/grafana/dashboards/overview.json#L26-L31

To both prevent breaking changes and unwanted version bumps in dashboard JSON, pin the Grafana version in `docker-compose.yml` file.