### PR TITLE
chore: rename price bump arg

### DIFF
--- a/bin/reth/src/args/txpool_args.rs
+++ b/bin/reth/src/args/txpool_args.rs
@@ -35,7 +35,7 @@ pub struct TxPoolArgs {
     pub max_account_slots: usize,
 
     /// Price bump (in %) for the transaction pool underpriced check.
-    #[arg(long = "txpool.price_bump", help_heading = "TxPool", default_value_t = DEFAULT_PRICE_BUMP)]
+    #[arg(long = "txpool.pricebump", help_heading = "TxPool", default_value_t = DEFAULT_PRICE_BUMP)]
     pub price_bump: u128,
 }
 


### PR DESCRIPTION
should be "txpool.pricebump"

https://github.com/ethereum/go-ethereum/blob/e0b119884c6af1858854d2bc3d5cf67001130023/cmd/utils/flags.go#L351-L351