### PR TITLE
feat: add CancunPayloadFields for engine_newPayloadV3

### DIFF
--- a/crates/consensus/beacon/src/engine/handle.rs
+++ b/crates/consensus/beacon/src/engine/handle.rs
@@ -5,9 +5,9 @@ use crate::{
     BeaconForkChoiceUpdateError, BeaconOnNewPayloadError,
 };
 use futures::TryFutureExt;
-use reth_primitives::H256;
 use reth_rpc_types::engine::{
-    ExecutionPayload, ForkchoiceState, ForkchoiceUpdated, PayloadAttributes, PayloadStatus,
+    CancunPayloadFields, ExecutionPayload, ForkchoiceState, ForkchoiceUpdated, PayloadAttributes,
+    PayloadStatus,
 };
 use tokio::sync::{mpsc, mpsc::UnboundedSender, oneshot};
 use tokio_stream::wrappers::UnboundedReceiverStream;
@@ -35,14 +35,10 @@ impl BeaconConsensusEngineHandle {
     pub async fn new_payload(
         &self,
         payload: ExecutionPayload,
-        parent_beacon_block_root: Option<H256>,
+        cancun_fields: Option<CancunPayloadFields>,
     ) -> Result<PayloadStatus, BeaconOnNewPayloadError> {
         let (tx, rx) = oneshot::channel();
-        let _ = self.to_engine.send(BeaconEngineMessage::NewPayload {
-            payload,
-            parent_beacon_block_root,
-            tx,
-        });
+        let _ = self.to_engine.send(BeaconEngineMessage::NewPayload { payload, cancun_fields, tx });
         rx.await.map_err(|_| BeaconOnNewPayloadError::EngineUnavailable)?
     }
 

--- a/crates/consensus/beacon/src/engine/message.rs
+++ b/crates/consensus/beacon/src/engine/message.rs
@@ -5,10 +5,9 @@ use crate::{
 use futures::{future::Either, FutureExt};
 use reth_interfaces::consensus::ForkchoiceState;
 use reth_payload_builder::error::PayloadBuilderError;
-use reth_primitives::H256;
 use reth_rpc_types::engine::{
-    ExecutionPayload, ForkChoiceUpdateResult, ForkchoiceUpdateError, ForkchoiceUpdated,
-    PayloadAttributes, PayloadId, PayloadStatus, PayloadStatusEnum,
+    CancunPayloadFields, ExecutionPayload, ForkChoiceUpdateResult, ForkchoiceUpdateError,
+    ForkchoiceUpdated, PayloadAttributes, PayloadId, PayloadStatus, PayloadStatusEnum,
 };
 use std::{
     future::Future,
@@ -147,8 +146,8 @@ pub enum BeaconEngineMessage {
     NewPayload {
         /// The execution payload received by Engine API.
         payload: ExecutionPayload,
-        /// The parent beacon block root, if any.
-        parent_beacon_block_root: Option<H256>,
+        /// The cancun-related newPayload fields, if any.
+        cancun_fields: Option<CancunPayloadFields>,
         /// The sender for returning payload status result.
         tx: oneshot::Sender<Result<PayloadStatus, BeaconOnNewPayloadError>>,
     },

--- a/crates/consensus/beacon/src/engine/test_utils.rs
+++ b/crates/consensus/beacon/src/engine/test_utils.rs
@@ -27,7 +27,9 @@ use reth_provider::{
 };
 use reth_prune::Pruner;
 use reth_revm::Factory;
-use reth_rpc_types::engine::{ExecutionPayload, ForkchoiceState, ForkchoiceUpdated, PayloadStatus};
+use reth_rpc_types::engine::{
+    CancunPayloadFields, ExecutionPayload, ForkchoiceState, ForkchoiceUpdated, PayloadStatus,
+};
 use reth_stages::{
     sets::DefaultStages, stages::HeaderSyncMode, test_utils::TestStages, ExecOutput, Pipeline,
     StageError,
@@ -69,9 +71,9 @@ impl<DB> TestEnv<DB> {
     pub async fn send_new_payload<T: Into<ExecutionPayload>>(
         &self,
         payload: T,
-        parent_beacon_block_root: Option<H256>,
+        cancun_fields: Option<CancunPayloadFields>,
     ) -> Result<PayloadStatus, BeaconOnNewPayloadError> {
-        self.engine_handle.new_payload(payload.into(), parent_beacon_block_root).await
+        self.engine_handle.new_payload(payload.into(), cancun_fields).await
     }
 
     /// Sends the `ExecutionPayload` message to the consensus engine and retries if the engine
@@ -79,11 +81,11 @@ impl<DB> TestEnv<DB> {
     pub async fn send_new_payload_retry_on_syncing<T: Into<ExecutionPayload>>(
         &self,
         payload: T,
-        parent_beacon_block_root: Option<H256>,
+        cancun_fields: Option<CancunPayloadFields>,
     ) -> Result<PayloadStatus, BeaconOnNewPayloadError> {
         let payload: ExecutionPayload = payload.into();
         loop {
-            let result = self.send_new_payload(payload.clone(), parent_beacon_block_root).await?;
+            let result = self.send_new_payload(payload.clone(), cancun_fields.clone()).await?;
             if !result.is_syncing() {
                 return Ok(result)
             }

--- a/crates/rpc/rpc-types/src/eth/engine/cancun.rs
+++ b/crates/rpc/rpc-types/src/eth/engine/cancun.rs
@@ -4,6 +4,9 @@ use reth_primitives::H256;
 
 /// Fields introduced in `engine_newPayloadV3` that are not present in the `ExecutionPayload` RPC
 /// object.
+///
+/// See also:
+/// <https://github.com/ethereum/execution-apis/blob/fe8e13c288c592ec154ce25c534e26cb7ce0530d/src/engine/cancun.md#request>
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub struct CancunPayloadFields {
     /// The parent beacon block root.

--- a/crates/rpc/rpc-types/src/eth/engine/cancun.rs
+++ b/crates/rpc/rpc-types/src/eth/engine/cancun.rs
@@ -1,0 +1,14 @@
+//! Contains types related to the Cancun hardfork that will be used by RPC to communicate with the
+//! beacon consensus engine.
+use reth_primitives::H256;
+
+/// Fields introduced in `engine_newPayloadV3` that are not present in the `ExecutionPayload` RPC
+/// object.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+pub struct CancunPayloadFields {
+    /// The parent beacon block root.
+    pub parent_beacon_block_root: H256,
+
+    /// The expected blob versioned hashes.
+    pub versioned_hashes: Vec<H256>,
+}

--- a/crates/rpc/rpc-types/src/eth/engine/mod.rs
+++ b/crates/rpc/rpc-types/src/eth/engine/mod.rs
@@ -2,11 +2,12 @@
 
 #![allow(missing_docs)]
 
+mod cancun;
 mod forkchoice;
 mod payload;
 mod transition;
 
-pub use self::{forkchoice::*, payload::*, transition::*};
+pub use self::{cancun::*, forkchoice::*, payload::*, transition::*};
 
 /// The list of supported Engine capabilities
 pub const CAPABILITIES: [&str; 9] = [


### PR DESCRIPTION
This introduces a struct for the extra fields introduced in `engine_newPayloadV3`, because these fields are provided together when `engine_newPayloadV3` is called. Either they both exist, or are both `None`.