### PR TITLE
refactor: remove duplicate RPC namespaces from arguments

### DIFF
--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -477,7 +477,7 @@ impl TypedValueParser for RpcModuleSelectionValueParser {
     ) -> Result<Self::Value, clap::Error> {
         let val =
             value.to_str().ok_or_else(|| clap::Error::new(clap::error::ErrorKind::InvalidUtf8))?;
-        val.parse::<RpcModuleSelection>().map_err(|err| {
+          val.split(',').map(str::trim).collect::<std::collections::HashSet<_>>().into_iter().collect::<Vec<_>>().join(", ").parse::<RpcModuleSelection>().map_err(|err| {
             let arg = arg.map(|a| a.to_string()).unwrap_or_else(|| "...".to_owned());
             let possible_values = RethRpcModule::all_variants().to_vec().join(",");
             let msg = format!(

--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -477,14 +477,21 @@ impl TypedValueParser for RpcModuleSelectionValueParser {
     ) -> Result<Self::Value, clap::Error> {
         let val =
             value.to_str().ok_or_else(|| clap::Error::new(clap::error::ErrorKind::InvalidUtf8))?;
-          val.split(',').map(str::trim).collect::<std::collections::HashSet<_>>().into_iter().collect::<Vec<_>>().join(", ").parse::<RpcModuleSelection>().map_err(|err| {
-            let arg = arg.map(|a| a.to_string()).unwrap_or_else(|| "...".to_owned());
-            let possible_values = RethRpcModule::all_variants().to_vec().join(",");
-            let msg = format!(
+        val.split(',')
+            .map(str::trim)
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>()
+            .join(", ")
+            .parse::<RpcModuleSelection>()
+            .map_err(|err| {
+                let arg = arg.map(|a| a.to_string()).unwrap_or_else(|| "...".to_owned());
+                let possible_values = RethRpcModule::all_variants().to_vec().join(",");
+                let msg = format!(
                 "Invalid value '{val}' for {arg}: {err}.\n    [possible values: {possible_values}]"
             );
-            clap::Error::raw(clap::error::ErrorKind::InvalidValue, msg)
-        })
+                clap::Error::raw(clap::error::ErrorKind::InvalidValue, msg)
+            })
     }
 
     fn possible_values(&self) -> Option<Box<dyn Iterator<Item = PossibleValue> + '_>> {


### PR DESCRIPTION
 splits the input val by commas, trims each element, and collects them into a HashSet to automatically remove duplicates and joins them
 Should solve #3703 