### PR TITLE
feat: add blob fields to receipt type

### DIFF
--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1,5 +1,6 @@
 use crate::{
     compression::{TRANSACTION_COMPRESSOR, TRANSACTION_DECOMPRESSOR},
+    constants::eip4844::DATA_GAS_PER_BLOB,
     keccak256, Address, Bytes, TxHash, H256,
 };
 pub use access_list::{AccessList, AccessListItem, AccessListWithGasUsed};
@@ -230,6 +231,15 @@ impl Transaction {
             }
             _ => None,
         }
+    }
+
+    /// Returns the blob gas used for all blobs of the EIP-4844 transaction if it is an EIP-4844
+    /// transaction.
+    ///
+    /// This is the number of blobs times the [DATA_GAS_PER_BLOB] a single blob consumes.
+    pub fn blob_gas_used(&self) -> Option<u128> {
+        let tx = self.as_eip4844()?;
+        Some(tx.blob_versioned_hashes.len() as u128 * DATA_GAS_PER_BLOB as u128)
     }
 
     /// Return the max priority fee per gas if the transaction is an EIP-1559 transaction, and

--- a/crates/rpc/rpc-types/src/eth/transaction/receipt.rs
+++ b/crates/rpc/rpc-types/src/eth/transaction/receipt.rs
@@ -22,6 +22,14 @@ pub struct TransactionReceipt {
     /// fields in 1559-style transactions are maximums (max fee + max priority fee), the amount
     /// that's actually paid by users can only be determined post-execution
     pub effective_gas_price: U128,
+    /// Blob gas used by the eip-4844 transaction
+    ///
+    /// This is None for non eip-4844 transactions
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blob_gas_used: Option<U128>,
+    /// The price paid by the eip-4844 transaction per blob gas.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blob_gas_price: Option<U128>,
     /// Address of the sender
     pub from: Address,
     /// Address of the receiver. null when its a contract creation transaction.

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -874,6 +874,10 @@ pub(crate) fn build_transaction_receipt_with_block_receipts(
         state_root: None,
         logs_bloom: receipt.bloom_slow(),
         status_code: if receipt.success { Some(U64::from(1)) } else { Some(U64::from(0)) },
+
+        // EIP-4844 fields
+        blob_gas_price: transaction.transaction.max_fee_per_blob_gas().map(U128::from),
+        blob_gas_used: transaction.transaction.blob_gas_used().map(U128::from),
     };
 
     match tx.transaction.kind() {


### PR DESCRIPTION
adds eip-4844 fields to the transaction receipt type

gas used is `len blobs * GAS PER BLOB`
price: max_fee_per_blob field