### PR TITLE
feat(rpc): add admin_peers method

### DIFF
--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -55,6 +55,7 @@ pub trait NetworkInfo: Send + Sync {
 }
 
 /// Provides general purpose information about Peers in the network.
+#[async_trait]
 pub trait PeersInfo: Send + Sync {
     /// Returns how many peers the network is currently connected to.
     ///
@@ -63,6 +64,9 @@ pub trait PeersInfo: Send + Sync {
 
     /// Returns the Ethereum Node Record of the node.
     fn local_node_record(&self) -> NodeRecord;
+
+    /// Returns all peers node isi connected to.
+    async fn all_peers(&self) -> Vec<NodeRecord>;
 }
 
 /// Provides an API for managing the peers of the network.

--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -65,7 +65,7 @@ pub trait PeersInfo: Send + Sync {
     /// Returns the Ethereum Node Record of the node.
     fn local_node_record(&self) -> NodeRecord;
 
-    /// Returns all peers node isi connected to.
+    /// Returns all peers node is connected to.
     async fn all_peers(&self) -> Vec<NodeRecord>;
 }
 

--- a/crates/net/network-api/src/noop.rs
+++ b/crates/net/network-api/src/noop.rs
@@ -52,6 +52,7 @@ impl NetworkInfo for NoopNetwork {
     }
 }
 
+#[async_trait]
 impl PeersInfo for NoopNetwork {
     fn num_connected_peers(&self) -> usize {
         0
@@ -59,6 +60,10 @@ impl PeersInfo for NoopNetwork {
 
     fn local_node_record(&self) -> NodeRecord {
         NodeRecord::new(self.local_addr(), PeerId::random())
+    }
+
+    async fn all_peers(&self) -> Vec<NodeRecord> {
+        vec![]
     }
 }
 

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -201,7 +201,7 @@ impl PeersInfo for NetworkHandle {
     }
 
     async fn all_peers(&self) -> Vec<NodeRecord> {
-        self.inner.peers.all_peers().await
+        self.inner.peers.all_connected_peers().await
     }
 }
 

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -178,7 +178,7 @@ impl NetworkHandle {
 }
 
 // === API Implementations ===
-
+#[async_trait]
 impl PeersInfo for NetworkHandle {
     fn num_connected_peers(&self) -> usize {
         self.inner.num_active_peers.load(Ordering::Relaxed)
@@ -198,6 +198,10 @@ impl PeersInfo for NetworkHandle {
         }
 
         NodeRecord::new(socket_addr, id)
+    }
+
+    async fn all_peers(&self) -> Vec<NodeRecord> {
+        self.inner.peers.all_peers().await
     }
 }
 

--- a/crates/rpc/rpc-api/src/admin.rs
+++ b/crates/rpc/rpc-api/src/admin.rs
@@ -7,6 +7,10 @@ use reth_rpc_types::NodeInfo;
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "admin"))]
 #[async_trait::async_trait]
 pub trait AdminApi {
+    /// Returns all nodes in the peerset.
+    #[method(name = "peers")]
+    async fn all_peers(&self) -> RpcResult<Vec<NodeRecord>>;
+
     /// Adds the given node record to the peerset.
     #[method(name = "addPeer")]
     fn add_peer(&self, record: NodeRecord) -> RpcResult<bool>;

--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -26,6 +26,12 @@ impl<N> AdminApiServer for AdminApi<N>
 where
     N: NetworkInfo + Peers + 'static,
 {
+    /// Handler for `admin_peers`
+    async fn all_peers(&self) -> RpcResult<Vec<NodeRecord>> {
+        let peers = self.network.all_peers().await;
+        Ok(peers)
+    }
+
     /// Handler for `admin_addPeer`
     fn add_peer(&self, record: NodeRecord) -> RpcResult<bool> {
         self.network.add_peer(record.id, record.tcp_addr());


### PR DESCRIPTION
Addresses #4432

Added `admin_peers` to return all connected peers.

