### PR TITLE
docs: add missing field docs

### DIFF
--- a/crates/rpc/rpc-types/src/eth/engine/payload.rs
+++ b/crates/rpc/rpc-types/src/eth/engine/payload.rs
@@ -604,8 +604,11 @@ impl From<Block> for ExecutionPayloadBodyV1 {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PayloadAttributes {
+    /// Value for the `timestamp` field of the new payload
     pub timestamp: U64,
+    /// Value for the `prevRandao` field of the new payload
     pub prev_randao: H256,
+    /// Suggested value for the `feeRecipient` field of the new payload
     pub suggested_fee_recipient: Address,
     /// Array of [`Withdrawal`] enabled with V2
     /// See <https://github.com/ethereum/execution-apis/blob/6452a6b194d7db269bf1dbd087a267251d3cc7f8/src/engine/shanghai.md#payloadattributesv2>


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1069f2e</samp>

Add documentation comments for `PayloadAttributes` struct in `rpc-types` crate. This struct is used for requesting payloads from the merge engine in the Ethereum 2.0 consensus protocol.