### PR TITLE
Remove duplicate in codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,6 @@
 bin/                        @onbjerg
 crates/net/                 @mattsse @Rjected
 crates/net/downloaders/     @onbjerg @rkrasiuk
-crates/blockchain-tree/     @rakita
 crates/revm/src/            @rakita
 crates/revm/                @mattsse
 crates/stages/              @onbjerg @rkrasiuk @shekhirin


### PR DESCRIPTION
crates/blockchain-tree has two duplicate entries one with just @rakita and one with @rakita @rkrasiuk. If we remove the one with only @rakita we keep the same information.