### PR TITLE
feat: add pre-block EIP-4788 beacon root contract call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5907,9 +5907,7 @@ dependencies = [
  "reth-provider",
  "reth-revm-inspectors",
  "reth-revm-primitives",
- "reth-rlp",
  "revm",
- "secp256k1",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5901,7 +5901,6 @@ dependencies = [
 name = "reth-revm"
 version = "0.1.0-alpha.8"
 dependencies = [
- "once_cell",
  "reth-consensus-common",
  "reth-interfaces",
  "reth-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5901,13 +5901,16 @@ dependencies = [
 name = "reth-revm"
 version = "0.1.0-alpha.8"
 dependencies = [
+ "once_cell",
  "reth-consensus-common",
  "reth-interfaces",
  "reth-primitives",
  "reth-provider",
  "reth-revm-inspectors",
  "reth-revm-primitives",
+ "reth-rlp",
  "revm",
+ "secp256k1",
  "tracing",
 ]
 

--- a/crates/consensus/auto-seal/src/lib.rs
+++ b/crates/consensus/auto-seal/src/lib.rs
@@ -305,6 +305,8 @@ impl StorageInner {
         senders: Vec<Address>,
     ) -> Result<(BundleStateWithReceipts, u64), BlockExecutionError> {
         trace!(target: "consensus::auto", transactions=?&block.body, "executing transactions");
+        // TODO: there isn't really a parent beacon block root here, so not sure whether or not to
+        // call the 4788 beacon contract
 
         let (receipts, gas_used) =
             executor.execute_transactions(block, U256::ZERO, Some(senders))?;

--- a/crates/interfaces/src/executor.rs
+++ b/crates/interfaces/src/executor.rs
@@ -26,6 +26,10 @@ pub enum BlockValidationError {
     BlockPreMerge { hash: H256 },
     #[error("Missing total difficulty")]
     MissingTotalDifficulty { hash: H256 },
+    #[error("EIP-4788 Parent beacon block root missing for active Cancun block")]
+    MissingParentBeaconBlockRoot,
+    #[error("The parent beacon block root is not zero for Cancun genesis block")]
+    CancunGenesisParentBeaconBlockRootNotZero,
 }
 
 /// BlockExecutor Errors

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -33,8 +33,10 @@ use reth_primitives::{
 };
 use reth_provider::{BlockReaderIdExt, BlockSource, BundleStateWithReceipts, StateProviderFactory};
 use reth_revm::{
-    database::StateProviderDatabase, env::tx_env_with_recovered, into_reth_log,
-    state_change::{apply_pre_block_call, post_block_withdrawals_balance_increments},
+    database::StateProviderDatabase,
+    env::tx_env_with_recovered,
+    into_reth_log,
+    state_change::{apply_beacon_root_contract_call, post_block_withdrawals_balance_increments},
 };
 use reth_rlp::Encodable;
 use reth_tasks::TaskSpawner;
@@ -1015,7 +1017,7 @@ where
     evm_pre_block.database(db);
 
     // initialize a block from the env, because the pre block call needs the block itself
-    match apply_pre_block_call(
+    match apply_beacon_root_contract_call(
         chain_spec,
         attributes.timestamp,
         block_number,

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -992,7 +992,16 @@ fn commit_withdrawals<DB: Database<Error = Error>>(
     })
 }
 
-/// TODO: docs
+/// Apply the [EIP-4788](https://eips.ethereum.org/EIPS/eip-4788) pre block contract call.
+///
+/// This constructs a new [EVM](revm::EVM) with the given DB, and environment ([CfgEnv] and
+/// [BlockEnv]) to execute the pre block contract call.
+///
+/// The parent beacon block root used for the call is gathered from the given
+/// [PayloadBuilderAttributes].
+///
+/// This uses [apply_beacon_root_contract_call] to ultimately apply the beacon root contract state
+/// change.
 fn pre_block_beacon_root_contract_call<DB>(
     db: &mut DB,
     chain_spec: &ChainSpec,

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -45,6 +45,7 @@ use revm::{
     Database, DatabaseCommit, State,
 };
 use std::{
+    fmt::Debug,
     future::Future,
     pin::Pin,
     sync::{atomic::AtomicBool, Arc},
@@ -990,14 +991,18 @@ fn commit_withdrawals<DB: Database<Error = Error>>(
 }
 
 /// TODO: docs
-fn pre_block_contract_call<'a>(
-    db: State<'a, Error>,
+fn pre_block_contract_call<DB>(
+    db: State<DB>,
     chain_spec: &ChainSpec,
     block_number: u64,
     initialized_cfg: &CfgEnv,
     initialized_block_env: &BlockEnv,
     attributes: &PayloadBuilderAttributes,
-) -> Result<State<'a, Error>, PayloadBuilderError> {
+) -> Result<State<DB>, PayloadBuilderError>
+where
+    DB: Database,
+    <DB as Database>::Error: Debug,
+{
     // Configure the environment for the block.
     let env = Env {
         cfg: initialized_cfg.clone(),

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -668,7 +668,7 @@ where
     let block_number = initialized_block_env.number.to::<u64>();
 
     // apply eip-4788 pre block contract call
-    let mut db = pre_block_contract_call(
+    let mut db = pre_block_beacon_root_contract_call(
         db,
         &chain_spec,
         block_number,
@@ -891,7 +891,7 @@ where
     let block_gas_limit: u64 = initialized_block_env.gas_limit.try_into().unwrap_or(u64::MAX);
 
     // apply eip-4788 pre block contract call
-    let mut db = pre_block_contract_call(
+    let mut db = pre_block_beacon_root_contract_call(
         db,
         &chain_spec,
         block_number,
@@ -993,7 +993,7 @@ fn commit_withdrawals<DB: Database<Error = Error>>(
 }
 
 /// TODO: docs
-fn pre_block_contract_call<DB>(
+fn pre_block_beacon_root_contract_call<DB>(
     db: State<DB>,
     chain_spec: &ChainSpec,
     block_number: u64,

--- a/crates/primitives/src/constants/mod.rs
+++ b/crates/primitives/src/constants/mod.rs
@@ -1,6 +1,6 @@
 //! Ethereum protocol-related constants
 
-use crate::{H256, U256};
+use crate::{H160, H256, U256};
 use hex_literal::hex;
 use std::time::Duration;
 
@@ -131,6 +131,13 @@ pub const BEACON_CONSENSUS_REORG_UNWIND_DEPTH: u64 = 3;
 /// See:
 /// <https://github.com/ethereum/go-ethereum/blob/a196f3e8a22b6ad22ced5c2e3baf32bc3ebd4ec9/consensus/ethash/consensus.go#L227-L229>
 pub const ALLOWED_FUTURE_BLOCK_TIME_SECONDS: u64 = 15;
+
+/// The address for the beacon roots contract defined in EIP-4788.
+pub const BEACON_ROOTS_ADDRESS: H160 = H160(hex!("bEac00dDB15f3B6d645C48263dC93862413A222D"));
+
+/// The caller to be used when calling the EIP-4788 beacon roots contract at the beginning of the
+/// block.
+pub const SYSTEM_ADDRESS: H160 = H160(hex!("fffffffffffffffffffffffffffffffffffffffe"));
 
 #[cfg(test)]
 mod tests {

--- a/crates/primitives/src/constants/mod.rs
+++ b/crates/primitives/src/constants/mod.rs
@@ -133,8 +133,8 @@ pub const BEACON_CONSENSUS_REORG_UNWIND_DEPTH: u64 = 3;
 pub const ALLOWED_FUTURE_BLOCK_TIME_SECONDS: u64 = 15;
 
 /// The address for the beacon roots contract defined in EIP-4788.
-pub const BEACON_ROOTS_ADDRESS: H160 = H160(hex!("000000000000000000000000000000000000000b"));
-// pub const BEACON_ROOTS_ADDRESS: H160 = H160(hex!("bEac00dDB15f3B6d645C48263dC93862413A222D"));
+// pub const BEACON_ROOTS_ADDRESS: H160 = H160(hex!("000000000000000000000000000000000000000b"));
+pub const BEACON_ROOTS_ADDRESS: H160 = H160(hex!("bEac00dDB15f3B6d645C48263dC93862413A222D"));
 
 /// The caller to be used when calling the EIP-4788 beacon roots contract at the beginning of the
 /// block.

--- a/crates/primitives/src/constants/mod.rs
+++ b/crates/primitives/src/constants/mod.rs
@@ -133,7 +133,6 @@ pub const BEACON_CONSENSUS_REORG_UNWIND_DEPTH: u64 = 3;
 pub const ALLOWED_FUTURE_BLOCK_TIME_SECONDS: u64 = 15;
 
 /// The address for the beacon roots contract defined in EIP-4788.
-// pub const BEACON_ROOTS_ADDRESS: H160 = H160(hex!("000000000000000000000000000000000000000b"));
 pub const BEACON_ROOTS_ADDRESS: H160 = H160(hex!("bEac00dDB15f3B6d645C48263dC93862413A222D"));
 
 /// The caller to be used when calling the EIP-4788 beacon roots contract at the beginning of the

--- a/crates/primitives/src/constants/mod.rs
+++ b/crates/primitives/src/constants/mod.rs
@@ -133,7 +133,8 @@ pub const BEACON_CONSENSUS_REORG_UNWIND_DEPTH: u64 = 3;
 pub const ALLOWED_FUTURE_BLOCK_TIME_SECONDS: u64 = 15;
 
 /// The address for the beacon roots contract defined in EIP-4788.
-pub const BEACON_ROOTS_ADDRESS: H160 = H160(hex!("bEac00dDB15f3B6d645C48263dC93862413A222D"));
+pub const BEACON_ROOTS_ADDRESS: H160 = H160(hex!("000000000000000000000000000000000000000b"));
+// pub const BEACON_ROOTS_ADDRESS: H160 = H160(hex!("bEac00dDB15f3B6d645C48263dC93862413A222D"));
 
 /// The caller to be used when calling the EIP-4788 beacon roots contract at the beginning of the
 /// block.

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -18,7 +18,7 @@ reth-revm-inspectors = { path = "./revm-inspectors" }
 reth-consensus-common = { path = "../consensus/common" }
 
 # revm
-revm = { workspace = true, features = ["optional_no_base_fee"] }
+revm.workspace = true
 
 # common
 tracing.workspace = true

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -18,7 +18,7 @@ reth-revm-inspectors = { path = "./revm-inspectors" }
 reth-consensus-common = { path = "../consensus/common" }
 
 # revm
-revm.workspace = true
+revm = { workspace = true, features = ["optional_no_base_fee"] }
 
 # common
 tracing.workspace = true

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -22,11 +22,3 @@ revm.workspace = true
 
 # common
 tracing.workspace = true
-
-[dev-dependencies]
-reth-rlp.workspace = true
-
-# for creating keys, signing, mostly for eip4788 contract deployment / usage
-# tests
-reth-interfaces = { workspace = true, features = ["test-utils"] }
-secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery"] }

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -25,7 +25,6 @@ tracing.workspace = true
 
 [dev-dependencies]
 reth-rlp.workspace = true
-once_cell = "1.17.0"
 
 # for creating keys, signing, mostly for eip4788 contract deployment / usage
 # tests

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 description = "reth specific revm utilities"
 
 [dependencies]
-# reth 
+# reth
 reth-primitives.workspace = true
 reth-interfaces.workspace = true
 reth-provider.workspace = true
@@ -22,3 +22,12 @@ revm.workspace = true
 
 # common
 tracing.workspace = true
+
+[dev-dependencies]
+reth-rlp.workspace = true
+once_cell = "1.17.0"
+
+# for creating keys, signing, mostly for eip4788 contract deployment / usage
+# tests
+reth-interfaces = { workspace = true, features = ["test-utils"] }
+secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery"] }

--- a/crates/revm/revm-primitives/src/config.rs
+++ b/crates/revm/revm-primitives/src/config.rs
@@ -19,7 +19,9 @@ pub fn revm_spec_by_timestamp_after_merge(
 
 /// return revm_spec from spec configuration.
 pub fn revm_spec(chain_spec: &ChainSpec, block: Head) -> revm::primitives::SpecId {
-    if chain_spec.fork(Hardfork::Shanghai).active_at_head(&block) {
+    if chain_spec.fork(Hardfork::Cancun).active_at_head(&block) {
+        revm::primitives::CANCUN
+    } else if chain_spec.fork(Hardfork::Shanghai).active_at_head(&block) {
         revm::primitives::SHANGHAI
     } else if chain_spec.fork(Hardfork::Paris).active_at_head(&block) {
         revm::primitives::MERGE

--- a/crates/revm/revm-primitives/src/env.rs
+++ b/crates/revm/revm-primitives/src/env.rs
@@ -123,16 +123,24 @@ pub fn tx_env_with_recovered(transaction: &TransactionSignedEcRecovered) -> TxEn
 ///  part of the call
 ///  * if no code exists at `BEACON_ROOTS_ADDRESS`, the call must fail silently
 pub fn fill_tx_env_with_beacon_root_contract_call(env: &mut Env, parent_beacon_block_root: H256) {
-    env.tx.caller = SYSTEM_ADDRESS;
-    env.tx.transact_to = TransactTo::Call(BEACON_ROOTS_ADDRESS);
-    // Explicitly set nonce to None so revm does not do any nonce checks
-    env.tx.nonce = None;
-    env.tx.gas_limit = 30_000_000;
-    env.tx.value = U256::ZERO;
-    env.tx.data = parent_beacon_block_root.to_fixed_bytes().to_vec().into();
-    // Setting the gas price to zero enforces that no value is transferred as part of the call, and
-    // that the call will not count against the block's gas limit
-    env.tx.gas_price = U256::ZERO;
+    env.tx = TxEnv {
+        caller: SYSTEM_ADDRESS,
+        transact_to: TransactTo::Call(BEACON_ROOTS_ADDRESS),
+        // Explicitly set nonce to None so revm does not do any nonce checks
+        nonce: None,
+        gas_limit: 30_000_000,
+        value: U256::ZERO,
+        data: parent_beacon_block_root.to_fixed_bytes().to_vec().into(),
+        // Setting the gas price to zero enforces that no value is transferred as part of the call,
+        // and that the call will not count against the block's gas limit
+        gas_price: U256::ZERO,
+        // The chain ID check is not relevant here and is disabled if set to None
+        chain_id: None,
+        // Setting the gas priority fee to None ensures the effective gas price is derived from the
+        // `gas_price` field, which we need to be zero
+        gas_priority_fee: None,
+        access_list: Vec::new(),
+    };
 
     // ensure the block gas limit is >= the tx
     env.block.gas_limit = U256::from(env.tx.gas_limit);

--- a/crates/revm/revm-primitives/src/env.rs
+++ b/crates/revm/revm-primitives/src/env.rs
@@ -137,8 +137,8 @@ pub fn fill_tx_env_with_beacon_root_contract_call(env: &mut Env, parent_beacon_b
     // ensure the block gas limit is >= the tx
     env.block.gas_limit = U256::from(env.tx.gas_limit);
 
-    // disable the base fee check for this call
-    env.cfg.disable_base_fee = true;
+    // disable the base fee check for this call by setting the base fee to zero
+    env.block.basefee = U256::ZERO;
 }
 
 /// Fill transaction environment from [TransactionSignedEcRecovered].

--- a/crates/revm/revm-primitives/src/env.rs
+++ b/crates/revm/revm-primitives/src/env.rs
@@ -140,6 +140,9 @@ pub fn fill_tx_env_with_beacon_root_contract_call(env: &mut Env, parent_beacon_b
         // `gas_price` field, which we need to be zero
         gas_priority_fee: None,
         access_list: Vec::new(),
+        // blob fields can be None for this tx
+        blob_hashes: Vec::new(),
+        max_fee_per_blob_gas: None,
     };
 
     // ensure the block gas limit is >= the tx

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -176,7 +176,10 @@ impl<'a> EVMProcessor<'a> {
     ///
     /// If cancun is not activated or the block is the genesis block, then this is a no-op, and no
     /// state changes are made.
-    pub fn apply_beacon_root_contract_call(&mut self, block: &Block) -> Result<(), BlockExecutionError> {
+    pub fn apply_beacon_root_contract_call(
+        &mut self,
+        block: &Block,
+    ) -> Result<(), BlockExecutionError> {
         apply_beacon_root_contract_call(
             &self.chain_spec,
             block.timestamp,

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -550,8 +550,8 @@ pub fn verify_receipt<'a>(
 #[cfg(test)]
 mod tests {
     use reth_primitives::{
-        constants::BEACON_ROOTS_ADDRESS, keccak256, Account, Bytecode, Bytes, ChainSpecBuilder,
-        ForkCondition, StorageKey, MAINNET,
+        constants::{BEACON_ROOTS_ADDRESS, SYSTEM_ADDRESS},
+        keccak256, Account, Bytecode, Bytes, ChainSpecBuilder, ForkCondition, StorageKey, MAINNET,
     };
     use reth_provider::{AccountReader, BlockHashReader, StateRootProvider};
     use reth_revm_primitives::TransitionState;
@@ -755,10 +755,9 @@ mod tests {
         let mut executor = EVMProcessor::new_with_db(chain_spec, RevmDatabase::new(db));
 
         // get the env
-        // TODO: wait for https://github.com/bluealloy/revm/pull/689 to be merged
-        // let previous_env = executor.evm.env.clone();
+        let previous_env = executor.evm.env.clone();
 
-        // attempt to execute a block without parent beacon block root, expect err
+        // attempt to execute an empty block with parent beacon block root, this should not fail
         executor
             .execute_and_verify_receipt(
                 &Block { header: header.clone(), body: vec![], ommers: vec![], withdrawals: None },
@@ -770,7 +769,11 @@ mod tests {
             );
 
         // ensure that the env has not changed
-        // assert_eq!(executor.evm.env, previous_env);
+        assert_eq!(executor.evm.env, previous_env);
+
+        // ensure that the nonce of the system address account has not changed
+        let nonce = executor.db().basic(SYSTEM_ADDRESS).unwrap().unwrap().nonce;
+        assert_eq!(nonce, 0);
     }
 
     #[test]

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -570,16 +570,13 @@ pub fn verify_receipt<'a>(
 
 #[cfg(test)]
 mod tests {
-    use reth_interfaces::test_utils::generators::sign_tx_with_key_pair;
     use reth_primitives::{
-        constants::BEACON_ROOTS_ADDRESS, keccak256, public_key_to_address, Account, Bytecode,
-        Bytes, ChainSpecBuilder, ForkCondition, StorageKey, Transaction, TransactionKind, TxLegacy,
-        MAINNET,
+        constants::BEACON_ROOTS_ADDRESS, keccak256, Account, Bytecode, Bytes, ChainSpecBuilder,
+        ForkCondition, StorageKey, MAINNET,
     };
     use reth_provider::{AccountReader, BlockHashReader, StateRootProvider};
     use reth_revm_primitives::TransitionState;
     use revm::Database;
-    use secp256k1::{rand, KeyPair, Secp256k1};
     use std::{collections::HashMap, str::FromStr};
 
     use super::*;
@@ -675,15 +672,6 @@ mod tests {
 
         let mut db = StateProviderTest::default();
 
-        // set up key that we can use to construct a tx, which actually calls the beacon root
-        // contract
-        let secp = Secp256k1::new();
-        let key_pair = KeyPair::new(&secp, &mut rand::thread_rng());
-        let caller_address = public_key_to_address(key_pair.public_key());
-
-        let caller_genesis = Account { balance: U256::MAX, ..Default::default() };
-        db.insert_account(caller_address, caller_genesis, None, HashMap::new());
-
         let beacon_root_contract_code = Bytes::from_str("0x3373fffffffffffffffffffffffffffffffffffffffe14604457602036146024575f5ffd5b620180005f350680545f35146037575f5ffd5b6201800001545f5260205ff35b42620180004206555f3562018000420662018000015500").unwrap();
 
         let beacon_root_contract_account = Account {
@@ -728,46 +716,15 @@ mod tests {
 
         // fix header, set a gas limit
         header.parent_beacon_block_root = Some(H256::from_low_u64_be(0x1337));
-        header.gas_limit = u64::MAX;
-        header.gas_used = 25440;
 
-        // build and sign transaction that calls the beacon root contract
-        let transaction = Transaction::Legacy(TxLegacy {
-            chain_id: Some(1),
-            nonce: 0,
-            gas_price: 1,
-            gas_limit: u64::MAX,
-            to: TransactionKind::Call(BEACON_ROOTS_ADDRESS),
-            value: 0,
-            // caller must specify timestamp in calldata, it must be 32 bytes
-            input: Bytes::from(H256::from_low_u64_be(header.timestamp).to_fixed_bytes()),
-        });
-
-        let signed_tx = sign_tx_with_key_pair(key_pair, transaction);
-
-        // Now execute a block with a tx that calls the beacon root contract, ensure that it does
-        // not fail
+        // Now execute a block with the fixed header, ensure that it does not fail
         executor
             .execute(
-                &Block {
-                    header: header.clone(),
-                    body: vec![signed_tx],
-                    ommers: vec![],
-                    withdrawals: None,
-                },
+                &Block { header: header.clone(), body: vec![], ommers: vec![], withdrawals: None },
                 U256::ZERO,
-                Some(vec![caller_address]),
+                None,
             )
             .unwrap();
-
-        // check the receipts to ensure that the transaction didn't fail
-        let receipts = executor
-            .receipts
-            .last()
-            .expect("there should be receipts for the block we just executed");
-        assert_eq!(receipts.len(), 1);
-        let receipt = receipts.first().expect("there is one receipt");
-        assert!(receipt.success);
 
         // check the actual storage of the contract - it should be:
         // * The storage value at header.timestamp % HISTORY_BUFFER_LENGTH should be

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -774,6 +774,61 @@ mod tests {
 
         // ensure that the env has not changed
         assert_eq!(executor.evm.env, previous_env);
+    }
+
+    #[test]
+    fn eip_4788_empty_account_call() {
+        // This test ensures that we do not increment the nonce of an empty SYSTEM_ADDRESS account
+        // during the pre-block call
+        let mut db = StateProviderTest::default();
+
+        let beacon_root_contract_code = beacon_root_contract_code();
+
+        let beacon_root_contract_account = Account {
+            balance: U256::ZERO,
+            bytecode_hash: Some(keccak256(beacon_root_contract_code.clone())),
+            nonce: 1,
+        };
+
+        db.insert_account(
+            BEACON_ROOTS_ADDRESS,
+            beacon_root_contract_account,
+            Some(beacon_root_contract_code),
+            HashMap::new(),
+        );
+
+        // insert an empty SYSTEM_ADDRESS
+        db.insert_account(SYSTEM_ADDRESS, Account::default(), None, HashMap::new());
+
+        let chain_spec = Arc::new(
+            ChainSpecBuilder::from(&*MAINNET)
+                .shanghai_activated()
+                .with_fork(Hardfork::Cancun, ForkCondition::Timestamp(1))
+                .build(),
+        );
+
+        let mut executor = EVMProcessor::new_with_db(chain_spec, StateProviderDatabase::new(db));
+
+        // construct the header for block one
+        let header = Header {
+            timestamp: 1,
+            number: 1,
+            parent_beacon_block_root: Some(H256::from_low_u64_be(0x1337)),
+            ..Header::default()
+        };
+
+        executor.init_env(&header, U256::ZERO);
+
+        // attempt to execute an empty block with parent beacon block root, this should not fail
+        executor
+            .execute_and_verify_receipt(
+                &Block { header: header.clone(), body: vec![], ommers: vec![], withdrawals: None },
+                U256::ZERO,
+                None,
+            )
+            .expect(
+                "Executing a block with no transactions while cancun is active should not fail",
+            );
 
         // ensure that the nonce of the system address account has not changed
         let nonce = executor.db().basic(SYSTEM_ADDRESS).unwrap().unwrap().nonce;
@@ -791,6 +846,7 @@ mod tests {
             bytecode_hash: Some(keccak256(beacon_root_contract_code.clone())),
             nonce: 1,
         };
+
         db.insert_account(
             BEACON_ROOTS_ADDRESS,
             beacon_root_contract_account,

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -560,6 +560,11 @@ mod tests {
 
     use super::*;
 
+    /// Returns the beacon root contract code
+    fn beacon_root_contract_code() -> Bytes {
+        Bytes::from_str("0x3373fffffffffffffffffffffffffffffffffffffffe14604457602036146024575f5ffd5b620180005f350680545f35146037575f5ffd5b6201800001545f5260205ff35b6201800042064281555f359062018000015500").unwrap()
+    }
+
     #[derive(Debug, Default, Clone, Eq, PartialEq)]
     struct StateProviderTest {
         accounts: HashMap<Address, (HashMap<StorageKey, U256>, Account)>,
@@ -651,7 +656,7 @@ mod tests {
 
         let mut db = StateProviderTest::default();
 
-        let beacon_root_contract_code = Bytes::from_str("0x3373fffffffffffffffffffffffffffffffffffffffe14604457602036146024575f5ffd5b620180005f350680545f35146037575f5ffd5b6201800001545f5260205ff35b42620180004206555f3562018000420662018000015500").unwrap();
+        let beacon_root_contract_code = beacon_root_contract_code();
 
         let beacon_root_contract_account = Account {
             balance: U256::ZERO,
@@ -772,7 +777,7 @@ mod tests {
     fn eip_4788_genesis_call() {
         let mut db = StateProviderTest::default();
 
-        let beacon_root_contract_code = Bytes::from_str("0x3373fffffffffffffffffffffffffffffffffffffffe14604457602036146024575f5ffd5b620180005f350680545f35146037575f5ffd5b6201800001545f5260205ff35b42620180004206555f3562018000420662018000015500").unwrap();
+        let beacon_root_contract_code = beacon_root_contract_code();
 
         let beacon_root_contract_account = Account {
             balance: U256::ZERO,
@@ -849,7 +854,7 @@ mod tests {
 
         let mut db = StateProviderTest::default();
 
-        let beacon_root_contract_code = Bytes::from_str("0x3373fffffffffffffffffffffffffffffffffffffffe14604457602036146024575f5ffd5b620180005f350680545f35146037575f5ffd5b6201800001545f5260205ff35b42620180004206555f3562018000420662018000015500").unwrap();
+        let beacon_root_contract_code = beacon_root_contract_code();
 
         let beacon_root_contract_account = Account {
             balance: U256::ZERO,

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -694,17 +694,11 @@ mod tests {
                 .build(),
         );
 
-        // TODO: seems like this is not possible because the type built from this is not State<'a,
-        // reth_interfaces::Error>, it is State<'a, Infallible>, which is incompatible with the
-        // EVMProcessor.
-        // let mut state = StateBuilder::default().with_cached_prestate(cache_state).build();
-
-        // execute chain and verify receipts
-        // let mut executor = EVMProcessor::new_with_state(chain_spec, state);
+        // execute invalid header (no parent beacon block root)
         let mut executor = EVMProcessor::new_with_db(chain_spec, RevmDatabase::new(db));
 
         // attempt to execute a block without parent beacon block root, expect err
-        let _err = executor
+        let err = executor
             .execute_and_verify_receipt(
                 &Block { header: header.clone(), body: vec![], ommers: vec![], withdrawals: None },
                 U256::ZERO,
@@ -713,6 +707,10 @@ mod tests {
             .expect_err(
                 "Executing cancun block without parent beacon block root field should fail",
             );
+        assert_eq!(
+            err,
+            BlockExecutionError::Validation(BlockValidationError::MissingParentBeaconBlockRoot)
+        );
 
         // fix header, set a gas limit
         header.parent_beacon_block_root = Some(H256::from_low_u64_be(0x1337));

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -294,7 +294,6 @@ impl<'a> EVMProcessor<'a> {
         senders: Option<Vec<Address>>,
     ) -> Result<(Vec<Receipt>, u64), BlockExecutionError> {
         self.init_env(&block.header, total_difficulty);
-        self.apply_pre_block_call(block)?;
 
         // perf: do not execute empty blocks
         if block.body.is_empty() {
@@ -356,6 +355,7 @@ impl<'a> EVMProcessor<'a> {
         total_difficulty: U256,
         senders: Option<Vec<Address>>,
     ) -> Result<Vec<Receipt>, BlockExecutionError> {
+        self.apply_pre_block_call(block)?;
         let (receipts, cumulative_gas_used) =
             self.execute_transactions(block, total_difficulty, senders)?;
 

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -4,7 +4,7 @@ use crate::{
     eth_dao_fork::{DAO_HARDFORK_BENEFICIARY, DAO_HARDKFORK_ACCOUNTS},
     into_reth_log,
     stack::{InspectorStack, InspectorStackConfig},
-    state_change::post_block_balance_increments,
+    state_change::{apply_pre_block_call, post_block_balance_increments},
 };
 use reth_interfaces::{
     executor::{BlockExecutionError, BlockValidationError},
@@ -19,7 +19,6 @@ use reth_provider::{
     BlockExecutor, BlockExecutorStats, BundleStateWithReceipts, PrunableBlockExecutor,
     StateProvider,
 };
-use reth_revm_primitives::env::fill_tx_env_with_beacon_root_contract_call;
 use revm::{
     db::{states::bundle_state::BundleRetention, StateDBBox},
     primitives::ResultAndState,
@@ -178,34 +177,13 @@ impl<'a> EVMProcessor<'a> {
     /// If cancun is not activated or the block is the genesis block, then this is a no-op, and no
     /// state changes are made.
     pub fn apply_pre_block_call(&mut self, block: &Block) -> Result<(), BlockExecutionError> {
-        if self.chain_spec.fork(Hardfork::Cancun).active_at_timestamp(block.timestamp) {
-            // if the block number is zero (genesis block) then the parent beacon block root must
-            // be 0x0 and no system transaction may occur as per EIP-4788
-            if block.number == 0 {
-                if block.parent_beacon_block_root != Some(H256::zero()) {
-                    return Err(
-                        BlockValidationError::CancunGenesisParentBeaconBlockRootNotZero.into()
-                    )
-                }
-            } else {
-                let parent_beacon_block_root = block.parent_beacon_block_root.ok_or(
-                    BlockExecutionError::from(BlockValidationError::MissingParentBeaconBlockRoot),
-                )?;
-                fill_tx_env_with_beacon_root_contract_call(
-                    &mut self.evm.env.tx,
-                    parent_beacon_block_root,
-                );
-
-                let ResultAndState { state, .. } = self.evm.transact().map_err(|e| {
-                    BlockExecutionError::from(BlockValidationError::EVM {
-                        hash: Default::default(),
-                        message: format!("{e:?}"),
-                    })
-                })?;
-
-                self.db().commit(state);
-            }
-        }
+        apply_pre_block_call(
+            &self.chain_spec,
+            block.timestamp,
+            block.number,
+            block.parent_beacon_block_root,
+            &mut self.evm,
+        )?;
         Ok(())
     }
 

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -177,10 +177,7 @@ impl<'a> EVMProcessor<'a> {
     ///
     /// If cancun is not activated or the block is the genesis block, then this is a no-op, and no
     /// state changes are made.
-    pub fn apply_pre_block_call(
-        &mut self,
-        block: &Block,
-    ) -> Result<(), BlockExecutionError> {
+    pub fn apply_pre_block_call(&mut self, block: &Block) -> Result<(), BlockExecutionError> {
         if self.chain_spec.fork(Hardfork::Cancun).active_at_timestamp(block.timestamp) {
             // if the block number is zero (genesis block) then the parent beacon block root must
             // be 0x0 and no system transaction may occur as per EIP-4788
@@ -574,11 +571,15 @@ pub fn verify_receipt<'a>(
 #[cfg(test)]
 mod tests {
     use reth_interfaces::test_utils::generators::sign_tx_with_key_pair;
-    use reth_primitives::{constants::BEACON_ROOTS_ADDRESS, keccak256, Bytecode, Bytes, public_key_to_address, ChainSpecBuilder, ForkCondition, MAINNET, StorageKey, Account, Transaction, TxLegacy, TransactionKind};
+    use reth_primitives::{
+        constants::BEACON_ROOTS_ADDRESS, keccak256, public_key_to_address, Account, Bytecode,
+        Bytes, ChainSpecBuilder, ForkCondition, StorageKey, Transaction, TransactionKind, TxLegacy,
+        MAINNET,
+    };
     use reth_provider::{AccountReader, BlockHashReader, StateRootProvider};
     use reth_revm_primitives::TransitionState;
-    use secp256k1::{KeyPair, Secp256k1, rand};
-    use std::{str::FromStr, collections::HashMap};
+    use secp256k1::{rand, KeyPair, Secp256k1};
+    use std::{collections::HashMap, str::FromStr};
 
     use super::*;
 
@@ -634,7 +635,10 @@ mod tests {
     }
 
     impl StateRootProvider for StateProviderTest {
-        fn state_root(&self, _bundle_state: BundleStateWithReceipts) -> reth_interfaces::Result<H256> {
+        fn state_root(
+            &self,
+            _bundle_state: BundleStateWithReceipts,
+        ) -> reth_interfaces::Result<H256> {
             todo!()
         }
     }
@@ -756,7 +760,10 @@ mod tests {
             .unwrap();
 
         // check the receipts to ensure that the transaction didn't fail
-        let receipts = executor.receipts.last().expect("there should be receipts for the block we just executed");
+        let receipts = executor
+            .receipts
+            .last()
+            .expect("there should be receipts for the block we just executed");
         assert_eq!(receipts.len(), 1);
         let receipt = receipts.first().expect("there is one receipt");
         assert!(receipt.success);
@@ -772,8 +779,11 @@ mod tests {
             timestamp_index % history_buffer_length + history_buffer_length;
 
         // get timestamp storage and compare
-        let timestamp_storage =
-            executor.db().database.storage(BEACON_ROOTS_ADDRESS, U256::from(timestamp_index)).unwrap();
+        let timestamp_storage = executor
+            .db()
+            .database
+            .storage(BEACON_ROOTS_ADDRESS, U256::from(timestamp_index))
+            .unwrap();
         assert_eq!(timestamp_storage, U256::from(header.timestamp));
 
         // get parent beacon block root storage and compare
@@ -878,7 +888,8 @@ mod tests {
         // there is no system contract call so there should be NO STORAGE CHANGES
         // this means we'll check the transition state
         let state = executor.evm.db().unwrap();
-        let transition_state = state.transition_state.expect("the evm should be initialized with bundle updates");
+        let transition_state =
+            state.transition_state.expect("the evm should be initialized with bundle updates");
 
         // assert that it is the default (empty) transition state
         assert_eq!(transition_state, TransitionState::default());

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -333,6 +333,7 @@ impl<'a> EVMProcessor<'a> {
         total_difficulty: U256,
         senders: Option<Vec<Address>>,
     ) -> Result<Vec<Receipt>, BlockExecutionError> {
+        self.init_env(&block.header, total_difficulty);
         self.apply_pre_block_call(block)?;
         let (receipts, cumulative_gas_used) =
             self.execute_transactions(block, total_difficulty, senders)?;

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -578,6 +578,7 @@ mod tests {
     };
     use reth_provider::{AccountReader, BlockHashReader, StateRootProvider};
     use reth_revm_primitives::TransitionState;
+    use revm::Database;
     use secp256k1::{rand, KeyPair, Secp256k1};
     use std::{collections::HashMap, str::FromStr};
 
@@ -779,17 +780,13 @@ mod tests {
             timestamp_index % history_buffer_length + history_buffer_length;
 
         // get timestamp storage and compare
-        let timestamp_storage = executor
-            .db()
-            .database
-            .storage(BEACON_ROOTS_ADDRESS, U256::from(timestamp_index))
-            .unwrap();
+        let timestamp_storage =
+            executor.db().storage(BEACON_ROOTS_ADDRESS, U256::from(timestamp_index)).unwrap();
         assert_eq!(timestamp_storage, U256::from(header.timestamp));
 
         // get parent beacon block root storage and compare
         let parent_beacon_block_root_storage = executor
             .db()
-            .database
             .storage(BEACON_ROOTS_ADDRESS, U256::from(parent_beacon_block_root_index))
             .unwrap();
         assert_eq!(parent_beacon_block_root_storage, U256::from(0x1337));

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -819,7 +819,7 @@ mod tests {
         let mut executor = EVMProcessor::new_with_db(chain_spec, RevmDatabase::new(db));
 
         // attempt to execute a block without parent beacon block root, expect err
-        let _out = executor
+        executor
             .execute_and_verify_receipt(
                 &Block { header: header.clone(), body: vec![], ommers: vec![], withdrawals: None },
                 U256::ZERO,
@@ -877,7 +877,7 @@ mod tests {
 
         // now try to process the genesis block again, this time ensuring that a system contract
         // call does not occur
-        let out = executor
+        executor
             .execute(
                 &Block { header: header.clone(), body: vec![], ommers: vec![], withdrawals: None },
                 U256::ZERO,
@@ -888,8 +888,10 @@ mod tests {
         // there is no system contract call so there should be NO STORAGE CHANGES
         // this means we'll check the transition state
         let state = executor.evm.db().unwrap();
-        let transition_state =
-            state.transition_state.expect("the evm should be initialized with bundle updates");
+        let transition_state = state
+            .transition_state
+            .clone()
+            .expect("the evm should be initialized with bundle updates");
 
         // assert that it is the default (empty) transition state
         assert_eq!(transition_state, TransitionState::default());

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -682,7 +682,7 @@ mod tests {
         );
 
         // execute invalid header (no parent beacon block root)
-        let mut executor = EVMProcessor::new_with_db(chain_spec, RevmDatabase::new(db));
+        let mut executor = EVMProcessor::new_with_db(chain_spec, StateProviderDatabase::new(db));
 
         // attempt to execute a block without parent beacon block root, expect err
         let err = executor
@@ -723,14 +723,14 @@ mod tests {
 
         // get timestamp storage and compare
         let timestamp_storage =
-            executor.db().storage(BEACON_ROOTS_ADDRESS, U256::from(timestamp_index)).unwrap();
+            executor.db_mut().storage(BEACON_ROOTS_ADDRESS, U256::from(timestamp_index)).unwrap();
         assert_eq!(timestamp_storage, U256::from(header.timestamp));
 
         // get parent beacon block root storage and compare
         let parent_beacon_block_root_storage = executor
-            .db()
+            .db_mut()
             .storage(BEACON_ROOTS_ADDRESS, U256::from(parent_beacon_block_root_index))
-            .unwrap();
+            .expect("storage value should exist");
         assert_eq!(parent_beacon_block_root_storage, U256::from(0x1337));
     }
 
@@ -831,7 +831,7 @@ mod tests {
             );
 
         // ensure that the nonce of the system address account has not changed
-        let nonce = executor.db().basic(SYSTEM_ADDRESS).unwrap().unwrap().nonce;
+        let nonce = executor.db_mut().basic(SYSTEM_ADDRESS).unwrap().unwrap().nonce;
         assert_eq!(nonce, 0);
     }
 
@@ -941,7 +941,7 @@ mod tests {
         );
 
         // execute header
-        let mut executor = EVMProcessor::new_with_db(chain_spec, RevmDatabase::new(db));
+        let mut executor = EVMProcessor::new_with_db(chain_spec, StateProviderDatabase::new(db));
         executor.init_env(&header, U256::ZERO);
 
         // ensure that the env is configured with a base fee
@@ -968,12 +968,12 @@ mod tests {
 
         // get timestamp storage and compare
         let timestamp_storage =
-            executor.db().storage(BEACON_ROOTS_ADDRESS, U256::from(timestamp_index)).unwrap();
+            executor.db_mut().storage(BEACON_ROOTS_ADDRESS, U256::from(timestamp_index)).unwrap();
         assert_eq!(timestamp_storage, U256::from(header.timestamp));
 
         // get parent beacon block root storage and compare
         let parent_beacon_block_root_storage = executor
-            .db()
+            .db_mut()
             .storage(BEACON_ROOTS_ADDRESS, U256::from(parent_beacon_block_root_index))
             .unwrap();
         assert_eq!(parent_beacon_block_root_storage, U256::from(0x1337));

--- a/crates/revm/src/state_change.rs
+++ b/crates/revm/src/state_change.rs
@@ -4,11 +4,7 @@ use reth_primitives::{
     constants::SYSTEM_ADDRESS, Address, ChainSpec, Hardfork, Header, Withdrawal, H256, U256,
 };
 use reth_revm_primitives::{env::fill_tx_env_with_beacon_root_contract_call, Database};
-use revm::{
-    db::State,
-    primitives::{AccountStatus, ResultAndState},
-    DatabaseCommit, EVM,
-};
+use revm::{db::State, primitives::ResultAndState, DatabaseCommit, EVM};
 use std::{collections::HashMap, fmt::Debug};
 
 /// Collect all balance changes at the end of the block.
@@ -101,6 +97,7 @@ where
             };
 
             state.remove(&SYSTEM_ADDRESS);
+            state.remove(&evm.env.block.coinbase);
 
             let db = evm.db().expect("db to not be moved");
             db.commit(state);

--- a/crates/revm/src/state_change.rs
+++ b/crates/revm/src/state_change.rs
@@ -4,7 +4,7 @@ use reth_primitives::{
     constants::SYSTEM_ADDRESS, Address, ChainSpec, Hardfork, Header, Withdrawal, H256, U256,
 };
 use reth_revm_primitives::{env::fill_tx_env_with_beacon_root_contract_call, Database};
-use revm::{db::State, primitives::ResultAndState, DatabaseCommit, EVM};
+use revm::{primitives::ResultAndState, DatabaseCommit, EVM};
 use std::{collections::HashMap, fmt::Debug};
 
 /// Collect all balance changes at the end of the block.
@@ -57,12 +57,12 @@ pub fn post_block_balance_increments(
 /// If cancun is not activated or the block is the genesis block, then this is a no-op, and no
 /// state changes are made.
 #[inline]
-pub fn apply_beacon_root_contract_call<DB: Database>(
+pub fn apply_beacon_root_contract_call<DB: Database + DatabaseCommit>(
     chain_spec: &ChainSpec,
     block_timestamp: u64,
     block_number: u64,
     block_parent_beacon_block_root: Option<H256>,
-    evm: &mut EVM<State<DB>>,
+    evm: &mut EVM<DB>,
 ) -> Result<(), BlockExecutionError>
 where
     <DB as Database>::Error: Debug,

--- a/crates/revm/src/state_change.rs
+++ b/crates/revm/src/state_change.rs
@@ -57,7 +57,7 @@ pub fn post_block_balance_increments(
 /// If cancun is not activated or the block is the genesis block, then this is a no-op, and no
 /// state changes are made.
 #[inline]
-pub fn apply_pre_block_call<DB: Database>(
+pub fn apply_beacon_root_contract_call<DB: Database>(
     chain_spec: &ChainSpec,
     block_timestamp: u64,
     block_number: u64,

--- a/crates/revm/src/state_change.rs
+++ b/crates/revm/src/state_change.rs
@@ -96,10 +96,6 @@ where
                 }
             };
 
-            // TODO: re-evaluate this after 4788 implementers call, this is to prevent EIP161 state
-            // clearing of the system address, since it is touched during transact. The pyspec
-            // tests currently require the state to remain empty if it started empty, which
-            // somewhat contradicts EIP161, and clients still need consensus on what to do here.
             state.remove(&SYSTEM_ADDRESS);
             state.remove(&evm.env.block.coinbase);
 

--- a/crates/revm/src/state_change.rs
+++ b/crates/revm/src/state_change.rs
@@ -100,12 +100,7 @@ where
                 }
             };
 
-            // set the nonce to zero, and ensure account status is just [AccountStatus::Loaded]
-            // because `transact` will increment it internally
-            if let Some(system_account) = state.get_mut(&SYSTEM_ADDRESS) {
-                system_account.info.nonce = 0;
-                system_account.status = AccountStatus::Loaded;
-            }
+            state.remove(&SYSTEM_ADDRESS);
 
             let db = evm.db().expect("db to not be moved");
             db.commit(state);

--- a/crates/revm/src/state_change.rs
+++ b/crates/revm/src/state_change.rs
@@ -67,7 +67,7 @@ pub fn apply_beacon_root_contract_call<DB: Database>(
 where
     <DB as Database>::Error: Debug,
 {
-    if chain_spec.fork(Hardfork::Cancun).active_at_timestamp(block_timestamp) {
+    if chain_spec.is_cancun_activated_at_timestamp(block_timestamp) {
         // if the block number is zero (genesis block) then the parent beacon block root must
         // be 0x0 and no system transaction may occur as per EIP-4788
         if block_number == 0 {

--- a/crates/revm/src/state_change.rs
+++ b/crates/revm/src/state_change.rs
@@ -96,6 +96,10 @@ where
                 }
             };
 
+            // TODO: re-evaluate this after 4788 implementers call, this is to prevent EIP161 state
+            // clearing of the system address, since it is touched during transact. The pyspec
+            // tests currently require the state to remain empty if it started empty, which
+            // somewhat contradicts EIP161, and clients still need consensus on what to do here.
             state.remove(&SYSTEM_ADDRESS);
             state.remove(&evm.env.block.coinbase);
 


### PR DESCRIPTION
This is #4438 but using the new revm API (#3512). Adds a new method `apply_pre_block_call` which applies the cancun beacon block root contract call.