### PR TITLE
Fix: high load RPC putting node in a broken state: avoid running blocking tasks within blocking tasks

### DIFF
--- a/crates/rpc/rpc/src/eth/api/call.rs
+++ b/crates/rpc/rpc/src/eth/api/call.rs
@@ -48,10 +48,11 @@ where
     pub async fn estimate_gas_at(&self, request: CallRequest, at: BlockId) -> EthResult<U256> {
         let (cfg, block_env, at) = self.evm_env_at(at).await?;
 
-        Ok(self.on_blocking_task(|this| async move {
+        self.on_blocking_task(|this| async move {
             let state = this.state_at(at)?;
             this.estimate_gas_with(cfg, block_env, request, state)
-        }).await?)
+        })
+        .await
     }
 
     /// Executes the call request (`eth_call`) and returns the output

--- a/crates/rpc/rpc/src/eth/api/call.rs
+++ b/crates/rpc/rpc/src/eth/api/call.rs
@@ -47,8 +47,11 @@ where
     /// Estimate gas needed for execution of the `request` at the [BlockId].
     pub async fn estimate_gas_at(&self, request: CallRequest, at: BlockId) -> EthResult<U256> {
         let (cfg, block_env, at) = self.evm_env_at(at).await?;
-        let state = self.state_at(at)?;
-        self.estimate_gas_with(cfg, block_env, request, state)
+
+        Ok(self.on_blocking_task(|this| async move {
+            let state = this.state_at(at)?;
+            this.estimate_gas_with(cfg, block_env, request, state)
+        }).await?)
     }
 
     /// Executes the call request (`eth_call`) and returns the output

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -236,14 +236,7 @@ where
     ) -> Result<Bytes> {
         trace!(target: "rpc::eth", ?request, ?block_number, ?state_overrides, ?block_overrides, "Serving eth_call");
         Ok(self
-            .on_blocking_task(|this| async move {
-                this.call(
-                    request,
-                    block_number,
-                    EvmOverrides::new(state_overrides, block_overrides),
-                )
-                .await
-            })
+            .call(request, block_number, EvmOverrides::new(state_overrides, block_overrides))
             .await?)
     }
 
@@ -265,15 +258,11 @@ where
         block_number: Option<BlockId>,
     ) -> Result<AccessListWithGasUsed> {
         trace!(target: "rpc::eth", ?request, ?block_number, "Serving eth_createAccessList");
-        Ok(self
-            .on_blocking_task(|this| async move {
-                let block_id = block_number.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest));
-                let access_list = this.create_access_list_at(request.clone(), block_number).await?;
-                request.access_list = Some(access_list.clone());
-                let gas_used = this.estimate_gas_at(request, block_id).await?;
-                Ok(AccessListWithGasUsed { access_list, gas_used })
-            })
-            .await?)
+        let block_id = block_number.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest));
+        let access_list = self.create_access_list_at(request.clone(), block_number).await?;
+        request.access_list = Some(access_list.clone());
+        let gas_used = self.estimate_gas_at(request, block_id).await?;
+        Ok(AccessListWithGasUsed { access_list, gas_used })
     }
 
     /// Handler for: `eth_estimateGas`
@@ -283,15 +272,10 @@ where
         block_number: Option<BlockId>,
     ) -> Result<U256> {
         trace!(target: "rpc::eth", ?request, ?block_number, "Serving eth_estimateGas");
-        Ok(self
-            .on_blocking_task(|this| async move {
-                this.estimate_gas_at(
-                    request,
-                    block_number.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest)),
-                )
-                .await
-            })
-            .await?)
+        Ok(self.estimate_gas_at(
+            request,
+            block_number.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest)),
+        ).await?)
     }
 
     /// Handler for: `eth_gasPrice`

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -272,10 +272,12 @@ where
         block_number: Option<BlockId>,
     ) -> Result<U256> {
         trace!(target: "rpc::eth", ?request, ?block_number, "Serving eth_estimateGas");
-        Ok(self.estimate_gas_at(
-            request,
-            block_number.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest)),
-        ).await?)
+        Ok(self
+            .estimate_gas_at(
+                request,
+                block_number.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest)),
+            )
+            .await?)
     }
 
     /// Handler for: `eth_gasPrice`

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -400,20 +400,21 @@ where
     }
 
     async fn transaction_receipt(&self, hash: H256) -> EthResult<Option<TransactionReceipt>> {
-        let result = self.on_blocking_task(|this| async move {
-            let (tx, meta) = match this.provider().transaction_by_hash_with_meta(hash)? {
-                Some((tx, meta)) => (tx, meta),
-                None => return Ok(None),
-            };
+        let result = self
+            .on_blocking_task(|this| async move {
+                let (tx, meta) = match this.provider().transaction_by_hash_with_meta(hash)? {
+                    Some((tx, meta)) => (tx, meta),
+                    None => return Ok(None),
+                };
 
-            let receipt = match this.provider().receipt_by_hash(hash)? {
-                Some(recpt) => recpt,
-                None => return Ok(None),
-            };
+                let receipt = match this.provider().receipt_by_hash(hash)? {
+                    Some(recpt) => recpt,
+                    None => return Ok(None),
+                };
 
-            Ok(Some((tx, meta, receipt)))
-        })
-        .await?;
+                Ok(Some((tx, meta, receipt)))
+            })
+            .await?;
 
         let (tx, meta, receipt) = match result {
             Some((tx, meta, receipt)) => (tx, meta, receipt),


### PR DESCRIPTION
Addresses #3774 and I believe #3896.

Currently, high RPC load can put the node into a broken state. e.g `flood eth_getTransactionReceipt --rates 10000 --duration 20`.
In the broken state, the node may stop staying at the tip and RPC calls that spawn a blocking thread will forever be stuck (eth_call, eth_getTransactionReceipt and others mentioned in #3896)

This happens due to spawning a blocking thread within a blocking thread. If [512](https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html#method.max_blocking_threads) threads get spawned, any new spawn_blocking won't execute until one of them frees up.

Taking eth_getTransactionReceipt as an example, it spawns a blocking thread in `async fn transaction_receipt(&self, hash: H256) -> EthResult<Option<TransactionReceipt>>`, and then another one in `self.build_transaction_receipt(tx, meta, receipt).await.map(Some)` -> `EthStateCacheService`. Under huge RPC load, it's possible for the max threads to get spawned in `transaction_receipt` and never complete as the threads in `EthStateCacheService` are not able to run and return the data - crippling the node.

I've removed nested blocking tasks from `eth_call`, `eth_getTransactionReceipt`, `eth_estimateGas` and `eth_createAccessList`. It's possible I missed some, and I've only looked at the eth_ namespace so far.

With this change, I was unable to put the node into a broken state. I've stress tested `eth_call`, `eth_getTransactionReceipt` and some other tests from flood, and the node did not break unlike previously.
