### PR TITLE
chore(provider): refactor sender recovery

### DIFF
--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -803,9 +803,9 @@ impl TransactionSigned {
         T: IntoParallelIterator<Item = &'a Self> + IntoIterator<Item = &'a Self> + Send,
     {
         if num_txes < *PARALLEL_SENDER_RECOVERY_THRESHOLD {
-            txes.into_iter().map(|tx| tx.recover_signer()).collect()
+            txes.into_iter().map(Self::recover_signer).collect()
         } else {
-            txes.into_par_iter().map(|tx| tx.recover_signer()).collect()
+            txes.into_par_iter().map(Self::recover_signer).collect()
         }
     }
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -34,7 +34,7 @@ use reth_primitives::{
     ChainInfo, ChainSpec, Hardfork, Head, Header, PruneCheckpoint, PruneModes, PrunePart, Receipt,
     SealedBlock, SealedBlockWithSenders, SealedHeader, StorageEntry, TransactionMeta,
     TransactionSigned, TransactionSignedEcRecovered, TransactionSignedNoHash, TxHash, TxNumber,
-    Withdrawal, H160, H256, U256,
+    Withdrawal, H256, U256,
 };
 use reth_revm_primitives::{
     config::revm_spec,


### PR DESCRIPTION
## Description

Changes:
1. `Iterator::chain` can attempt to guess the capacity for the final collection whereas `Iterator::collect` and `Vec::extend` might result in re-allocation
2. Better documentation
 