### PR TITLE
add-semaphore-to-EthStateCacheService

### DIFF
--- a/crates/rpc/rpc/src/eth/cache/mod.rs
+++ b/crates/rpc/rpc/src/eth/cache/mod.rs
@@ -12,11 +12,11 @@ use schnellru::{ByLength, Limiter};
 use std::{
     future::Future,
     pin::Pin,
-    task::{ready, Context, Poll},
+    task::{ready, Context, Poll}, sync::Arc,
 };
 use tokio::sync::{
     mpsc::{unbounded_channel, UnboundedSender},
-    oneshot,
+    oneshot, Semaphore,
 };
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
@@ -51,6 +51,9 @@ type ReceiptsLruCache<L> = MultiConsumerLruCache<H256, Vec<Receipt>, L, Receipts
 
 type EnvLruCache<L> = MultiConsumerLruCache<H256, (CfgEnv, BlockEnv), L, EnvResponseSender>;
 
+/// The max concurrent database operations for `EthStateCacheService`.
+pub const MAX_CONCURRENT_DB_OPS: usize = 512;
+
 /// Provides async access to cached eth data
 ///
 /// This is the frontend for the async caching service which manages cached data on a different
@@ -78,6 +81,7 @@ impl EthStateCache {
             action_tx: to_service.clone(),
             action_rx: UnboundedReceiverStream::new(rx),
             action_task_spawner,
+            rate_limiter: Arc::new(Semaphore::new(MAX_CONCURRENT_DB_OPS)),
         };
         let cache = EthStateCache { to_service };
         (cache, service)
@@ -229,6 +233,8 @@ pub(crate) struct EthStateCacheService<
     action_rx: UnboundedReceiverStream<CacheAction>,
     /// The type that's used to spawn tasks that do the actual work
     action_task_spawner: Tasks,
+    /// Rate limiter
+    rate_limiter: Arc<Semaphore>,
 }
 
 impl<Provider, Tasks> EthStateCacheService<Provider, Tasks>
@@ -308,7 +314,10 @@ where
                             if this.full_block_cache.queue(block_hash, Either::Left(response_tx)) {
                                 let provider = this.provider.clone();
                                 let action_tx = this.action_tx.clone();
+                                let rate_limiter = this.rate_limiter.clone();
                                 this.action_task_spawner.spawn_blocking(Box::pin(async move {
+                                    // Acquire permit
+                                    let _permit = rate_limiter.acquire().await;
                                     // Only look in the database to prevent situations where we
                                     // looking up the tree is blocking
                                     let res = provider
@@ -329,7 +338,10 @@ where
                             if this.full_block_cache.queue(block_hash, Either::Right(response_tx)) {
                                 let provider = this.provider.clone();
                                 let action_tx = this.action_tx.clone();
+                                let rate_limiter = this.rate_limiter.clone();
                                 this.action_task_spawner.spawn_blocking(Box::pin(async move {
+                                    // Acquire permit
+                                    let _permit = rate_limiter.acquire().await();
                                     // Only look in the database to prevent situations where we
                                     // looking up the tree is blocking
                                     let res = provider
@@ -350,7 +362,10 @@ where
                             if this.receipts_cache.queue(block_hash, response_tx) {
                                 let provider = this.provider.clone();
                                 let action_tx = this.action_tx.clone();
+                                let rate_limiter = this.rate_limiter.clone();
                                 this.action_task_spawner.spawn_blocking(Box::pin(async move {
+                                    // Acquire permit
+                                    let _permit = rate_limiter.acquire().await;
                                     let res = provider.receipts_by_block(block_hash.into());
                                     let _ = action_tx
                                         .send(CacheAction::ReceiptsResult { block_hash, res });
@@ -369,7 +384,10 @@ where
                             if this.evm_env_cache.queue(block_hash, response_tx) {
                                 let provider = this.provider.clone();
                                 let action_tx = this.action_tx.clone();
+                                let rate_limiter = this.rate_limiter.clone();
                                 this.action_task_spawner.spawn_blocking(Box::pin(async move {
+                                    // Acquire permit
+                                    let _permit = rate_limiter.acquire().await;
                                     let mut cfg = CfgEnv::default();
                                     let mut block_env = BlockEnv::default();
                                     let res = provider


### PR DESCRIPTION
Closes #4442 

I add a `rate_limit: Arc<Semaphore>` to the `EthStateCacheService` struct.

I use 512 as max numbers of concurrent database operations but it can be easily modified thorugh the `MAX_CONCURRENT_DB_OPS` variable.

