### PR TITLE
add semaphore to EthStateCacheService

### DIFF
--- a/crates/rpc/rpc/src/eth/cache/config.rs
+++ b/crates/rpc/rpc/src/eth/cache/config.rs
@@ -21,8 +21,8 @@ pub const DEFAULT_RECEIPT_CACHE_MAX_LEN: u32 = 2000;
 /// Default cache size for the env cache: 1000 envs.
 pub const DEFAULT_ENV_CACHE_MAX_LEN: u32 = 1000;
 
-/// Default number of concurrent database operations.
-pub const DEFAULT_CONCURRENT_DB_OPS: usize = 512;
+/// Default number of concurrent database requests.
+pub const DEFAULT_CONCURRENT_DB_REQUESTS: usize = 512;
 
 /// Settings for the [EthStateCache](crate::eth::cache::EthStateCache).
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -40,10 +40,10 @@ pub struct EthStateCacheConfig {
     ///
     /// Default is 1000.
     pub max_envs: u32,
-    /// Max number of concurrent database operations.
+    /// Max number of concurrent database requests.
     ///
     /// Default is 512.
-    pub max_concurrent_db_operations: usize,
+    pub max_concurrent_db_requests: usize,
 }
 
 impl Default for EthStateCacheConfig {
@@ -52,7 +52,7 @@ impl Default for EthStateCacheConfig {
             max_blocks: DEFAULT_BLOCK_CACHE_MAX_LEN,
             max_receipts: DEFAULT_RECEIPT_CACHE_MAX_LEN,
             max_envs: DEFAULT_ENV_CACHE_MAX_LEN,
-            max_concurrent_db_operations: DEFAULT_CONCURRENT_DB_OPS,
+            max_concurrent_db_requests: DEFAULT_CONCURRENT_DB_REQUESTS,
         }
     }
 }

--- a/crates/rpc/rpc/src/eth/cache/config.rs
+++ b/crates/rpc/rpc/src/eth/cache/config.rs
@@ -21,6 +21,9 @@ pub const DEFAULT_RECEIPT_CACHE_MAX_LEN: u32 = 2000;
 /// Default cache size for the env cache: 1000 envs.
 pub const DEFAULT_ENV_CACHE_MAX_LEN: u32 = 1000;
 
+/// Default number of concurrent database operations.
+pub const DEFAULT_CONCURRENT_DB_OPS: usize = 512;
+
 /// Settings for the [EthStateCache](crate::eth::cache::EthStateCache).
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -37,6 +40,10 @@ pub struct EthStateCacheConfig {
     ///
     /// Default is 1000.
     pub max_envs: u32,
+    /// Max number of concurrent database operations.
+    ///
+    /// Default is 512.
+    pub max_concurrent_db_operations: usize,
 }
 
 impl Default for EthStateCacheConfig {
@@ -45,6 +52,7 @@ impl Default for EthStateCacheConfig {
             max_blocks: DEFAULT_BLOCK_CACHE_MAX_LEN,
             max_receipts: DEFAULT_RECEIPT_CACHE_MAX_LEN,
             max_envs: DEFAULT_ENV_CACHE_MAX_LEN,
+            max_concurrent_db_operations: DEFAULT_CONCURRENT_DB_OPS,
         }
     }
 }

--- a/crates/rpc/rpc/src/eth/cache/mod.rs
+++ b/crates/rpc/rpc/src/eth/cache/mod.rs
@@ -110,19 +110,15 @@ impl EthStateCache {
         Provider: StateProviderFactory + BlockReader + EvmEnvProvider + Clone + Unpin + 'static,
         Tasks: TaskSpawner + Clone + 'static,
     {
-        let EthStateCacheConfig {
-            max_blocks,
-            max_receipts,
-            max_envs,
-            max_concurrent_db_operations,
-        } = config;
+        let EthStateCacheConfig { max_blocks, max_receipts, max_envs, max_concurrent_db_requests } =
+            config;
         let (this, service) = Self::create(
             provider,
             executor.clone(),
             max_blocks,
             max_receipts,
             max_envs,
-            max_concurrent_db_operations,
+            max_concurrent_db_requests,
         );
         executor.spawn_critical("eth state cache", Box::pin(service));
         this


### PR DESCRIPTION
Closes #4442 

I add a `rate_limit: Arc<Semaphore>` to the `EthStateCacheService` struct.

I use 512 as max numbers of concurrent database operations but it can be easily modified thorugh the `MAX_CONCURRENT_DB_OPS` variable.