### PR TITLE
add metrics counter for finished spawned tasks

### DIFF
--- a/crates/tasks/src/metrics.rs
+++ b/crates/tasks/src/metrics.rs
@@ -7,9 +7,12 @@ use reth_metrics::{metrics::Counter, Metrics};
 pub struct TaskExecutorMetrics {
     /// Number of spawned critical tasks
     pub(crate) critical_tasks: Counter,
-
+    /// Number of finished spawned critical tasks
+    pub(crate) finished_critical_tasks: Counter,
     /// Number of spawned regular tasks
     pub(crate) regular_tasks: Counter,
+    /// Number of finished spawned regular tasks
+    pub(crate) finished_regular_tasks: Counter,
 }
 
 impl TaskExecutorMetrics {
@@ -19,5 +22,13 @@ impl TaskExecutorMetrics {
 
     pub(crate) fn inc_regular_task(&self) {
         self.regular_tasks.increment(1);
+    }
+
+    pub(crate) fn inc_finished_critical_tasks(&self) {
+        self.finished_critical_tasks.increment(1);
+    }
+
+    pub(crate) fn inc_finisehd_regular_task(&self) {
+        self.finished_regular_tasks.increment(1);
     }
 }

--- a/crates/tasks/src/metrics.rs
+++ b/crates/tasks/src/metrics.rs
@@ -20,15 +20,23 @@ impl TaskExecutorMetrics {
         self.critical_tasks.increment(1);
     }
 
-    pub(crate) fn inc_regular_task(&self) {
+    pub(crate) fn inc_regular_tasks(&self) {
         self.regular_tasks.increment(1);
     }
+}
 
-    pub(crate) fn inc_finished_critical_tasks(&self) {
-        self.finished_critical_tasks.increment(1);
+/// Helper type for increasing counters even if a task fails.
+pub struct IncCounterOnDrop(Counter);
+
+impl IncCounterOnDrop {
+    /// Create a new `IncCounterOnDrop`.
+    pub fn new(counter: Counter) -> Self {
+        IncCounterOnDrop(counter)
     }
+}
 
-    pub(crate) fn inc_finisehd_regular_task(&self) {
-        self.finished_regular_tasks.increment(1);
+impl Drop for IncCounterOnDrop {
+    fn drop(&mut self) {
+        self.0.increment(1);
     }
 }


### PR DESCRIPTION
Closes #4479 

I add two fields to `TaskExecutorMetrics`:
- `finished_critical_tasks`
- `finished_regular_tasks`

And then updates the `spawn` and `spawn_critical` functions in order to properly increase finished critical and regular tasks metrics as well.