### PR TITLE
feat(primitives): remove constraints on `SenderRecovery` pruning

### DIFF
--- a/bin/reth/src/args/pruning_args.rs
+++ b/bin/reth/src/args/pruning_args.rs
@@ -24,7 +24,7 @@ impl PruningArgs {
             Some(PruneConfig {
                 block_interval: 5,
                 parts: PruneModes {
-                    sender_recovery: Some(PruneMode::Distance(MINIMUM_PRUNING_DISTANCE)),
+                    sender_recovery: Some(PruneMode::Full),
                     transaction_lookup: None,
                     receipts: chain_spec
                         .deposit_contract

--- a/crates/primitives/src/prune/target.rs
+++ b/crates/primitives/src/prune/target.rs
@@ -13,12 +13,7 @@ pub const MINIMUM_PRUNING_DISTANCE: u64 = 128;
 #[serde(default)]
 pub struct PruneModes {
     /// Sender Recovery pruning configuration.
-    // TODO(alexey): removing min blocks restriction is possible if we start calculating the senders
-    //  dynamically on blockchain tree unwind.
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_opt_prune_mode_with_min_blocks::<64, _>"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub sender_recovery: Option<PruneMode>,
     /// Transaction Lookup pruning configuration.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/primitives/src/prune/target.rs
+++ b/crates/primitives/src/prune/target.rs
@@ -99,7 +99,7 @@ impl PruneModes {
     }
 
     impl_prune_parts!(
-        (sender_recovery, SenderRecovery, Some(64)),
+        (sender_recovery, SenderRecovery, None),
         (transaction_lookup, TransactionLookup, None),
         (receipts, Receipts, Some(64)),
         (account_history, AccountHistory, Some(64)),


### PR DESCRIPTION
Possible after https://github.com/paradigmxyz/reth/issues/3938