### PR TITLE
feat(engine): enable v3 endpoints

### DIFF
--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -472,11 +472,13 @@ where
     /// See also <https://github.com/ethereum/execution-apis/blob/fe8e13c288c592ec154ce25c534e26cb7ce0530d/src/engine/cancun.md#engine_newpayloadv3>
     async fn new_payload_v3(
         &self,
-        _payload: ExecutionPayloadV3,
-        _versioned_hashes: Vec<H256>,
-        _parent_beacon_block_root: H256,
+        payload: ExecutionPayloadV3,
+        versioned_hashes: Vec<H256>,
+        parent_beacon_block_root: H256,
     ) -> RpcResult<PayloadStatus> {
-        Err(jsonrpsee_types::error::ErrorCode::MethodNotFound.into())
+        trace!(target: "rpc::engine", "Serving engine_newPayloadV3");
+        Ok(EngineApi::new_payload_v3(self, payload, versioned_hashes, parent_beacon_block_root)
+            .await?)
     }
 
     /// Handler for `engine_forkchoiceUpdatedV1`
@@ -508,10 +510,11 @@ where
     /// See also <https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md#engine_forkchoiceupdatedv3>
     async fn fork_choice_updated_v3(
         &self,
-        _fork_choice_state: ForkchoiceState,
-        _payload_attributes: Option<PayloadAttributes>,
+        fork_choice_state: ForkchoiceState,
+        payload_attributes: Option<PayloadAttributes>,
     ) -> RpcResult<ForkchoiceUpdated> {
-        Err(jsonrpsee_types::error::ErrorCode::MethodNotFound.into())
+        trace!(target: "rpc::engine", "Serving engine_forkchoiceUpdatedV3");
+        Ok(EngineApi::fork_choice_updated_v3(self, fork_choice_state, payload_attributes).await?)
     }
 
     /// Handler for `engine_getPayloadV1`
@@ -553,11 +556,9 @@ where
     ///
     /// Note:
     /// > Provider software MAY stop the corresponding build process after serving this call.
-    async fn get_payload_v3(
-        &self,
-        _payload_id: PayloadId,
-    ) -> RpcResult<ExecutionPayloadEnvelopeV3> {
-        Err(jsonrpsee_types::error::ErrorCode::MethodNotFound.into())
+    async fn get_payload_v3(&self, payload_id: PayloadId) -> RpcResult<ExecutionPayloadEnvelopeV3> {
+        trace!(target: "rpc::engine", "Serving engine_getPayloadV3");
+        Ok(EngineApi::get_payload_v3(self, payload_id).await?)
     }
 
     /// Handler for `engine_getPayloadBodiesByHashV1`


### PR DESCRIPTION
This enables the Engine API V3 endpoints. The following check:
https://github.com/paradigmxyz/reth/blob/c0433d12e078c3604177b04448df835b4d225b76/crates/rpc/rpc-engine-api/src/engine_api.rs#L419-L421

should ensure that calls for pre-cancun payloads or attributes fail