### PR TITLE
fix(primitives): map cancun to timestamp fork

### DIFF
--- a/bin/reth/src/args/utils.rs
+++ b/bin/reth/src/args/utils.rs
@@ -44,7 +44,6 @@ pub fn genesis_value_parser(s: &str) -> eyre::Result<Arc<ChainSpec>, eyre::Error
         _ => {
             let raw = fs::read_to_string(PathBuf::from(shellexpand::full(s)?.into_owned()))?;
             let genesis: AllGenesisFormats = serde_json::from_str(&raw)?;
-            println!("genesis: {:?}", genesis);
             Arc::new(genesis.into())
         }
     })

--- a/bin/reth/src/args/utils.rs
+++ b/bin/reth/src/args/utils.rs
@@ -44,6 +44,7 @@ pub fn genesis_value_parser(s: &str) -> eyre::Result<Arc<ChainSpec>, eyre::Error
         _ => {
             let raw = fs::read_to_string(PathBuf::from(shellexpand::full(s)?.into_owned()))?;
             let genesis: AllGenesisFormats = serde_json::from_str(&raw)?;
+            println!("genesis: {:?}", genesis);
             Arc::new(genesis.into())
         }
     })

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -462,7 +462,7 @@ impl ChainSpec {
 impl From<Genesis> for ChainSpec {
     fn from(genesis: Genesis) -> Self {
         // Block-based hardforks
-        let hardfork_opts = vec![
+        let hardfork_opts = [
             (Hardfork::Homestead, genesis.config.homestead_block),
             (Hardfork::Dao, genesis.config.dao_fork_block),
             (Hardfork::Tangerine, genesis.config.eip150_block),
@@ -494,7 +494,7 @@ impl From<Genesis> for ChainSpec {
         }
 
         // Time-based hardforks
-        let time_hardfork_opts = vec![
+        let time_hardfork_opts = [
             (Hardfork::Shanghai, genesis.config.shanghai_time),
             (Hardfork::Cancun, genesis.config.cancun_time),
         ];

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -494,11 +494,16 @@ impl From<Genesis> for ChainSpec {
         }
 
         // Time-based hardforks
-        let time_hardforks = genesis
-            .config
-            .shanghai_time
-            .map(|time| (Hardfork::Shanghai, ForkCondition::Timestamp(time)))
-            .into_iter()
+        let time_hardfork_opts = vec![
+            (Hardfork::Shanghai, genesis.config.shanghai_time),
+            (Hardfork::Cancun, genesis.config.cancun_time),
+        ];
+
+        let time_hardforks = time_hardfork_opts
+            .iter()
+            .filter_map(|(hardfork, opt)| {
+                opt.map(|time| (*hardfork, ForkCondition::Timestamp(time)))
+            })
             .collect::<BTreeMap<_, _>>();
 
         hardforks.extend(time_hardforks);
@@ -1750,5 +1755,18 @@ Post-merge hard forks (timestamp based):
             .get(&"0xaa00000000000000000000000000000000000000".parse::<Address>().unwrap())
             .unwrap();
         assert_eq!(acc.balance, U256::from(1));
+    }
+
+    #[test]
+    fn test_parse_cancun_genesis_json() {
+        let s = r#"{"config":{"ethash":{},"chainId":1337,"homesteadBlock":0,"eip150Block":0,"eip155Block":0,"eip158Block":0,"byzantiumBlock":0,"constantinopleBlock":0,"petersburgBlock":0,"istanbulBlock":0,"berlinBlock":0,"londonBlock":0,"terminalTotalDifficulty":0,"terminalTotalDifficultyPassed":true,"shanghaiTime":0,"cancunTime":4661},"nonce":"0x0","timestamp":"0x0","extraData":"0x","gasLimit":"0x4c4b40","difficulty":"0x1","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","coinbase":"0x0000000000000000000000000000000000000000","alloc":{"658bdf435d810c91414ec09147daa6db62406379":{"balance":"0x487a9a304539440000"},"aa00000000000000000000000000000000000000":{"code":"0x6042","storage":{"0x0000000000000000000000000000000000000000000000000000000000000000":"0x0000000000000000000000000000000000000000000000000000000000000000","0x0100000000000000000000000000000000000000000000000000000000000000":"0x0100000000000000000000000000000000000000000000000000000000000000","0x0200000000000000000000000000000000000000000000000000000000000000":"0x0200000000000000000000000000000000000000000000000000000000000000","0x0300000000000000000000000000000000000000000000000000000000000000":"0x0000000000000000000000000000000000000000000000000000000000000303"},"balance":"0x1","nonce":"0x1"},"bb00000000000000000000000000000000000000":{"code":"0x600154600354","storage":{"0x0000000000000000000000000000000000000000000000000000000000000000":"0x0000000000000000000000000000000000000000000000000000000000000000","0x0100000000000000000000000000000000000000000000000000000000000000":"0x0100000000000000000000000000000000000000000000000000000000000000","0x0200000000000000000000000000000000000000000000000000000000000000":"0x0200000000000000000000000000000000000000000000000000000000000000","0x0300000000000000000000000000000000000000000000000000000000000000":"0x0000000000000000000000000000000000000000000000000000000000000303"},"balance":"0x2","nonce":"0x1"}},"number":"0x0","gasUsed":"0x0","parentHash":"0x0000000000000000000000000000000000000000000000000000000000000000","baseFeePerGas":"0x3b9aca00"}"#;
+        let genesis: Genesis = serde_json::from_str(s).unwrap();
+        let acc = genesis
+            .alloc
+            .get(&"0xaa00000000000000000000000000000000000000".parse::<Address>().unwrap())
+            .unwrap();
+        assert_eq!(acc.balance, U256::from(1));
+        // assert that the cancun time was picked up
+        assert_eq!(genesis.config.cancun_time, Some(4661));
     }
 }


### PR DESCRIPTION
Previously, we would not pick up on the `cancunTime` field in a `genesis.json` because the mapping was not present in `impl From<Genesis> for ChainSpec`. It would be present in the `ChainConfig` but not the underlying `hardforks` field.