### PR TITLE
fix: set trace results root trace's gas used to execution results gas

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
@@ -136,6 +136,7 @@ impl ParityTraceBuilder {
         res: ExecutionResult,
         trace_types: &HashSet<TraceType>,
     ) -> TraceResults {
+        let gas_used = res.gas_used();
         let output = match res {
             ExecutionResult::Success { output, .. } => output.into_data(),
             ExecutionResult::Revert { output, .. } => output,
@@ -144,12 +145,18 @@ impl ParityTraceBuilder {
 
         let (trace, vm_trace, state_diff) = self.into_trace_type_traces(trace_types);
 
-        TraceResults {
+        let mut trace = TraceResults {
             output: output.into(),
             trace: trace.unwrap_or_default(),
             vm_trace,
             state_diff,
-        }
+        };
+
+        // we're setting the gas used of the root trace explicitly to the gas used of the execution
+        // result
+        trace.set_root_trace_gas_used(gas_used);
+
+        trace
     }
 
     /// Consumes the inspector and returns the trace results according to the configured trace

--- a/crates/rpc/rpc-types/src/eth/trace/parity.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/parity.rs
@@ -39,6 +39,21 @@ pub struct TraceResults {
     pub vm_trace: Option<VmTrace>,
 }
 
+// === impl TraceResults ===
+
+impl TraceResults {
+    /// Sets the gas used of the root trace.
+    ///
+    /// The root trace's gasUsed should mirror the actual gas used by the transaction.
+    ///
+    /// This allows setting int manually by consuming the execution result's gas for example.
+    pub fn set_root_trace_gas_used(&mut self, gas_used: u64) {
+        if let Some(r) = self.trace.first_mut().and_then(|t| t.result.as_mut()) {
+            r.set_gas_used(gas_used)
+        }
+    }
+}
+
 /// A `FullTrace` with an additional transaction hash
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -240,13 +255,37 @@ pub struct CreateOutput {
     pub address: Address,
 }
 
+/// Represents the output of a trace.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum TraceOutput {
+    /// Output of a regular call transaction.
     Call(CallOutput),
+    /// Output of a CREATE transaction.
     Create(CreateOutput),
 }
 
+// === impl TraceOutput ===
+
+impl TraceOutput {
+    /// Returns the gas used by this trace.
+    pub fn gas_used(&self) -> U64 {
+        match self {
+            TraceOutput::Call(call) => call.gas_used,
+            TraceOutput::Create(create) => create.gas_used,
+        }
+    }
+
+    /// Sets the gas used by this trace.
+    pub fn set_gas_used(&mut self, gas_used: u64) {
+        match self {
+            TraceOutput::Call(call) => call.gas_used = U64::from(gas_used),
+            TraceOutput::Create(create) => create.gas_used = U64::from(gas_used),
+        }
+    }
+}
+
+/// A parity style trace of a transaction.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TransactionTrace {

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -268,7 +268,8 @@ where
             .await
     }
 
-    /// Executes all transactions of a block and returns a list of callback results.
+    /// Executes all transactions of a block and returns a list of callback results invoked for each
+    /// transaction in the block.
     ///
     /// This
     /// 1. fetches all transactions of the block


### PR DESCRIPTION
ref #4262

gas accounting during inspecting the gas limit already has the init costs deducted, leading to wrong gasUsed values for the root trace call.

I'm entirely sure that this could be solved by manually adding the init costs back during tracing, which would be more expensive than simply using the final gasUsed of the execution result.