### PR TITLE
#2511: extended reth-rpc example with custom rpc ext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6334,17 +6334,7 @@ dependencies = [
  "eyre",
  "futures",
  "jsonrpsee",
- "reth-beacon-consensus",
- "reth-blockchain-tree",
- "reth-db",
- "reth-network-api",
- "reth-primitives",
- "reth-provider",
- "reth-revm",
- "reth-rpc",
- "reth-rpc-builder",
- "reth-tasks",
- "reth-transaction-pool",
+ "reth",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6329,7 +6329,7 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
 name = "rpc-db"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "eyre",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6326,6 +6326,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
+name = "rpc-db"
+version = "0.1.0"
+dependencies = [
+ "eyre",
+ "futures",
+ "jsonrpsee",
+ "reth-beacon-consensus",
+ "reth-blockchain-tree",
+ "reth-db",
+ "reth-network-api",
+ "reth-primitives",
+ "reth-provider",
+ "reth-revm",
+ "reth-rpc",
+ "reth-rpc-builder",
+ "reth-tasks",
+ "reth-transaction-pool",
+ "tokio",
+]
+
+[[package]]
 name = "ruint"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ members = [
     "crates/rpc/rpc-types-compat",
     "examples",
     "examples/additional-rpc-namespace-in-cli",
+    "examples/rpc-db",
 ]
 default-members = ["bin/reth"]
 

--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -46,6 +46,25 @@ pub mod providers {
     pub use reth_provider::*;
 }
 
+/// Re-exported from `reth_primitives`.
+pub mod primitives {
+    pub use reth_primitives::*;
+}
+
+/// Re-exported from `reth_beacon_consensus`.
+pub mod beacon_consensus {
+    pub use reth_beacon_consensus::*;
+}
+/// Re-exported from `reth_blockchain_tree`.
+pub mod blockchain_tree {
+    pub use reth_blockchain_tree::*;
+}
+
+/// Re-exported from `reth_revm`.
+pub mod revm {
+    pub use reth_revm::*;
+}
+
 /// Re-exported from `reth_tasks`.
 pub mod tasks {
     pub use reth_tasks::*;
@@ -78,6 +97,10 @@ pub mod rpc {
     /// Re-exported from `reth_rpc_api`.
     pub mod api {
         pub use reth_rpc_api::*;
+    }
+    /// Re-exported from `reth_rpc::eth`.
+    pub mod eth {
+        pub use reth_rpc::eth::*;
     }
 }
 

--- a/bin/reth/src/utils.rs
+++ b/bin/reth/src/utils.rs
@@ -27,7 +27,7 @@ use std::{
 use tracing::info;
 
 /// Exposing `open_db_read_only` function
-pub mod utils {
+pub mod db {
     pub use reth_db::open_db_read_only;
 }
 

--- a/bin/reth/src/utils.rs
+++ b/bin/reth/src/utils.rs
@@ -26,7 +26,7 @@ use std::{
 };
 use tracing::info;
 
-/// Exposing the `reth_db` crate
+/// Exposing `open_db_read_only` function
 pub mod utils {
     pub use reth_db::open_db_read_only;
 }

--- a/bin/reth/src/utils.rs
+++ b/bin/reth/src/utils.rs
@@ -26,6 +26,11 @@ use std::{
 };
 use tracing::info;
 
+/// Exposing the `reth_db` crate
+pub mod utils {
+    pub use reth_db::open_db_read_only;
+}
+
 /// Get a single header from network
 pub async fn get_single_header<Client>(
     client: Client,

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -29,10 +29,6 @@ async-trait.workspace = true
 tokio.workspace = true
 
 [[example]]
-name = "rpc-db"
-path = "rpc-db.rs"
-
-[[example]]
 name = "db-access"
 path = "db-access.rs"
 

--- a/examples/rpc-db/Cargo.toml
+++ b/examples/rpc-db/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "rpc-db"
-version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version = "0.0.0"
+publish = false
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 futures.workspace = true

--- a/examples/rpc-db/Cargo.toml
+++ b/examples/rpc-db/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "rpc-db"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+eyre = "0.6.8"
+futures.workspace = true
+jsonrpsee.workspace = true
+reth-beacon-consensus.workspace = true
+reth-blockchain-tree.workspace = true
+reth-db.workspace = true
+reth-network-api.workspace = true
+reth-primitives.workspace = true
+reth-provider.workspace = true
+reth-revm.workspace = true
+reth-rpc = { version = "0.1.0-alpha.8", path = "../../crates/rpc/rpc" }
+reth-rpc-builder.workspace = true
+reth-tasks.workspace = true
+reth-transaction-pool.workspace = true
+tokio = { workspace = true, features = ["full"] }

--- a/examples/rpc-db/Cargo.toml
+++ b/examples/rpc-db/Cargo.toml
@@ -6,18 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-eyre = "0.6.8"
 futures.workspace = true
 jsonrpsee.workspace = true
-reth-beacon-consensus.workspace = true
-reth-blockchain-tree.workspace = true
-reth-db.workspace = true
-reth-network-api.workspace = true
-reth-primitives.workspace = true
-reth-provider.workspace = true
-reth-revm.workspace = true
-reth-rpc = { version = "0.1.0-alpha.8", path = "../../crates/rpc/rpc" }
-reth-rpc-builder.workspace = true
-reth-tasks.workspace = true
-reth-transaction-pool.workspace = true
+reth.workspace = true
 tokio = { workspace = true, features = ["full"] }
+eyre = "0.6.8"

--- a/examples/rpc-db/src/main.rs
+++ b/examples/rpc-db/src/main.rs
@@ -18,11 +18,11 @@ use reth_blockchain_tree::{
 use reth_revm::Factory as ExecutionFactory;
 
 // Configuring the network parts, ideally also wouldn't ned to think about this.
-use myrpc_ext::{MyRpcExt, MyRpcExtApiServer};
 use reth_provider::test_utils::TestCanonStateSubscriptions;
 use reth_tasks::TokioTaskExecutor;
 use std::{path::Path, sync::Arc};
 
+use myrpc_ext::{MyRpcExt, MyRpcExtApiServer};
 // Custom rpc extension
 pub mod myrpc_ext;
 

--- a/examples/rpc-db/src/main.rs
+++ b/examples/rpc-db/src/main.rs
@@ -1,25 +1,25 @@
 // Talking to the DB
-use reth_db::open_db_read_only;
-use reth_primitives::ChainSpecBuilder;
-use reth_provider::{providers::BlockchainProvider, ProviderFactory};
+use reth::{primitives::ChainSpecBuilder, utils::db::open_db_read_only};
 
+use reth::providers::{providers::BlockchainProvider, ProviderFactory};
 // Bringing up the RPC
-use reth_rpc_builder::{
+use reth::rpc::builder::{
     RethRpcModule, RpcModuleBuilder, RpcServerConfig, TransportRpcModuleConfig,
 };
 
 // Code which we'd ideally like to not need to import if you're only spinning up
 // read-only parts of the API and do not require access to pending state or to
 // EVM sims
-use reth_beacon_consensus::BeaconConsensus;
-use reth_blockchain_tree::{
-    BlockchainTree, BlockchainTreeConfig, ShareableBlockchainTree, TreeExternals,
+use reth::{
+    beacon_consensus::BeaconConsensus,
+    blockchain_tree::{
+        BlockchainTree, BlockchainTreeConfig, ShareableBlockchainTree, TreeExternals,
+    },
+    revm::Factory as ExecutionFactory,
 };
-use reth_revm::Factory as ExecutionFactory;
 
 // Configuring the network parts, ideally also wouldn't ned to think about this.
-use reth_provider::test_utils::TestCanonStateSubscriptions;
-use reth_tasks::TokioTaskExecutor;
+use reth::{providers::test_utils::TestCanonStateSubscriptions, tasks::TokioTaskExecutor};
 use std::{path::Path, sync::Arc};
 
 use myrpc_ext::{MyRpcExt, MyRpcExtApiServer};

--- a/examples/rpc-db/src/main.rs
+++ b/examples/rpc-db/src/main.rs
@@ -1,7 +1,21 @@
-// Talking to the DB
-use reth::{primitives::ChainSpecBuilder, utils::db::open_db_read_only};
-
-use reth::providers::{providers::BlockchainProvider, ProviderFactory};
+//! Example illustrating how to run the ETH JSON RPC API as standalone over a DB file.
+//!
+//! Run with
+//!
+//! ```not_rust
+//! cargo run -p rpc-db
+//! ```
+//!
+//! This installs an additional RPC method `myrpcExt_customMethod` that can queried via [cast](https://github.com/foundry-rs/foundry)
+//!
+//! ```sh
+//! cast rpc myrpcExt_customMethod
+//! ```
+use reth::{
+    primitives::ChainSpecBuilder,
+    providers::{providers::BlockchainProvider, ProviderFactory},
+    utils::db::open_db_read_only,
+};
 // Bringing up the RPC
 use reth::rpc::builder::{
     RethRpcModule, RpcModuleBuilder, RpcServerConfig, TransportRpcModuleConfig,
@@ -26,7 +40,6 @@ use myrpc_ext::{MyRpcExt, MyRpcExtApiServer};
 // Custom rpc extension
 pub mod myrpc_ext;
 
-// Example illustrating how to run the ETH JSON RPC API as standalone over a DB file.
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
     // 1. Setup the DB

--- a/examples/rpc-db/src/myrpc_ext.rs
+++ b/examples/rpc-db/src/myrpc_ext.rs
@@ -11,7 +11,7 @@ use reth::rpc::eth::error::EthResult;
 #[rpc(server, namespace = "myrpcExt")]
 pub trait MyRpcExtApi {
     /// Returns block 0.
-    #[method(name = "custom_method")]
+    #[method(name = "customMethod")]
     fn custom_method(&self) -> EthResult<Option<Block>>;
 }
 

--- a/examples/rpc-db/src/myrpc_ext.rs
+++ b/examples/rpc-db/src/myrpc_ext.rs
@@ -1,10 +1,9 @@
 // Reth block related imports
-use reth_primitives::Block;
-use reth_provider::BlockReaderIdExt;
+use reth::{primitives::Block, providers::BlockReaderIdExt};
 
 // Rpc related imports
 use jsonrpsee::proc_macros::rpc;
-use reth_rpc::eth::error::EthResult;
+use reth::rpc::eth::error::EthResult;
 
 /// trait interface for a custom rpc namespace: `MyRpc`
 ///

--- a/examples/rpc-db/src/myrpc_ext.rs
+++ b/examples/rpc-db/src/myrpc_ext.rs
@@ -1,0 +1,34 @@
+// Reth block related imports
+use reth_primitives::Block;
+use reth_provider::BlockReaderIdExt;
+
+// Rpc related imports
+use jsonrpsee::proc_macros::rpc;
+use reth_rpc::eth::error::EthResult;
+
+/// trait interface for a custom rpc namespace: `MyRpc`
+///
+/// This defines an additional namespace where all methods are configured as trait functions.
+#[rpc(server, namespace = "myrpcExt")]
+pub trait MyRpcExtApi {
+    /// Returns block 0.
+    #[method(name = "custom_method")]
+    fn custom_method(&self) -> EthResult<Option<Block>>;
+}
+
+/// The type that implements `myRpc` rpc namespace trait
+pub struct MyRpcExt<Provider> {
+    pub provider: Provider,
+}
+
+impl<Provider> MyRpcExtApiServer for MyRpcExt<Provider>
+where
+    Provider: BlockReaderIdExt + 'static,
+{
+    /// Showcasing how to implement a custom rpc method
+    /// using the provider.
+    fn custom_method(&self) -> EthResult<Option<Block>> {
+        let block = self.provider.block_by_number(0)?;
+        Ok(block)
+    }
+}


### PR DESCRIPTION
ref #2511

- Refactored the structure of the example as a single cargo project
- Used `with_noop_pool` and `with_noop_network` methods from `RpcModuleBuilder` instead of their Defaults
- Added `MyRpcExt` to showcase how to add custom methods on this example