### PR TITLE
fix(tasks): use `crate::metrics` to avoid ambiguity

### DIFF
--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -14,7 +14,7 @@
 //! reth task management
 
 use crate::{
-    metrics::TaskExecutorMetrics,
+    metrics::{IncCounterOnDrop, TaskExecutorMetrics},
     shutdown::{signal, Shutdown, Signal},
 };
 use dyn_clone::DynClone;
@@ -22,7 +22,6 @@ use futures_util::{
     future::{select, BoxFuture},
     pin_mut, Future, FutureExt, TryFutureExt,
 };
-use metrics::IncCounterOnDrop;
 use std::{
     any::Any,
     fmt::{Display, Formatter},


### PR DESCRIPTION
Not sure why the CI has passed, but local build was failing:
```console
error[E0659]: `metrics` is ambiguous
  --> crates/tasks/src/lib.rs:25:5
   |
25 | use metrics::IncCounterOnDrop;
   |     ^^^^^^^ ambiguous name
   |
   = note: ambiguous because of multiple potential import sources
   = note: `metrics` could refer to a crate passed with `--extern`
   = help: use `::metrics` to refer to this crate unambiguously
note: `metrics` could also refer to the module defined here
  --> crates/tasks/src/lib.rs:40:1
   |
40 | pub mod metrics;
   | ^^^^^^^^^^^^^^^^
   = help: use `crate::metrics` to refer to this module unambiguously

For more information about this error, try `rustc --explain E0659`.
error: could not compile `reth-tasks` (lib) due to previous error
```