### PR TITLE
fix: remove ambiguous use of `metrics`

### DIFF
--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -14,7 +14,7 @@
 //! reth task management
 
 use crate::{
-    metrics::TaskExecutorMetrics,
+    metrics::{IncCounterOnDrop, TaskExecutorMetrics},
     shutdown::{signal, Shutdown, Signal},
 };
 use dyn_clone::DynClone;
@@ -22,7 +22,6 @@ use futures_util::{
     future::{select, BoxFuture},
     pin_mut, Future, FutureExt, TryFutureExt,
 };
-use metrics::IncCounterOnDrop;
 use std::{
     any::Any,
     fmt::{Display, Formatter},


### PR DESCRIPTION
moves an import that caused reth to fail to compile locally due to ambiguous use of `metrics`