### PR TITLE
chore(ci): cargo check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,12 @@ jobs:
         with:
           cache-on-failure: true
 
+      - name: cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --all --all-features
+
       - name: cargo fmt
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
See https://github.com/paradigmxyz/reth/pull/4509. Both `fmt` and `clippy` didn't catch this.