### PR TITLE
fix: ensure only canonical state is returned if requested by number/hash

### DIFF
--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -200,6 +200,8 @@ where
         BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
 {
     /// Returns the state at the given [BlockId] enum.
+    ///
+    /// Note: if not [BlockNumberOrTag::Pending] then this will only return canonical state. See also <https://github.com/paradigmxyz/reth/issues/4515>
     pub fn state_at_block_id(&self, at: BlockId) -> EthResult<StateProviderBox<'_>> {
         Ok(self.provider().state_by_block_id(at)?)
     }


### PR DESCRIPTION
Closes #4515

Closes https://github.com/paradigmxyz/reth/issues/4514

while we can also lookup the pending block by number, this breaks cross-client behaviour since only canonical state should be available if requested via block number or hash.

This removes a `if num == latest + 1` check and adds more docs