### PR TITLE
fix: use max_fee_per_blob_gas in blob gas cost calc

### DIFF
--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -762,7 +762,7 @@ impl EthPooledTransaction {
 
         if let Some(blob_tx) = transaction.as_eip4844() {
             // add max blob cost
-            cost += U256::from(blob_tx.max_fee_per_gas * blob_tx.blob_gas() as u128);
+            cost += U256::from(blob_tx.max_fee_per_blob_gas * blob_tx.blob_gas() as u128);
         }
 
         Self { transaction, cost, blob_sidecar }


### PR DESCRIPTION
The max fee per blob gas should be used to calculate blob gas cost instead of 1559 max fee per gas