### PR TITLE
fix: use `blob_fee` to calculate blob_gas_used in receipts

### DIFF
--- a/crates/primitives/src/constants/eip4844.rs
+++ b/crates/primitives/src/constants/eip4844.rs
@@ -1,6 +1,6 @@
 //! [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844#parameters) protocol constants and utils for shard Blob Transactions.
 
-use crate::{kzg::KzgSettings, U256};
+use crate::{kzg::KzgSettings, U128};
 use once_cell::sync::Lazy;
 use std::{io::Write, sync::Arc};
 
@@ -67,11 +67,11 @@ pub enum LoadKzgSettingsError {
 }
 
 /// Calculates the blob fee for the given excess blob gas.
-pub fn blob_fee(excess_blob_gas: u64) -> U256 {
+pub fn blob_fee(excess_blob_gas: u64) -> U128 {
     fake_exponential(
-        U256::from(BLOB_TX_MIN_BLOB_GASPRICE),
-        U256::from(excess_blob_gas),
-        U256::from(BLOB_GASPRICE_UPDATE_FRACTION),
+        U128::from(BLOB_TX_MIN_BLOB_GASPRICE),
+        U128::from(excess_blob_gas),
+        U128::from(BLOB_GASPRICE_UPDATE_FRACTION),
     )
 }
 
@@ -80,14 +80,14 @@ pub fn blob_fee(excess_blob_gas: u64) -> U256 {
 /// This is used to calculate the blob price.
 ///
 /// See also <https://eips.ethereum.org/EIPS/eip-4844#helpers>
-pub fn fake_exponential(factor: U256, numerator: U256, denominator: U256) -> U256 {
-    let mut output = U256::ZERO;
+pub fn fake_exponential(factor: U128, numerator: U128, denominator: U128) -> U128 {
+    let mut output = U128::ZERO;
     let mut numerator_accum = factor.saturating_mul(denominator);
-    let mut i = U256::from(1u64);
-    while numerator_accum > U256::ZERO {
+    let mut i = U128::from(1u64);
+    while numerator_accum > U128::ZERO {
         output += numerator_accum;
         numerator_accum = numerator_accum * numerator / (denominator * i);
-        i += U256::from(1u64);
+        i += U128::from(1u64);
     }
     output / denominator
 }
@@ -121,8 +121,8 @@ mod tests {
             (2, 5, 2, 23),   // approximate 24.36
             (1, 50000000, 2225652, 5709098764),
         ] {
-            let res = fake_exponential(U256::from(*factor), U256::from(*num), U256::from(*denom));
-            assert_eq!(res, U256::from(*expected));
+            let res = fake_exponential(U128::from(*factor), U128::from(*num), U128::from(*denom));
+            assert_eq!(res, U128::from(*expected));
         }
     }
 }

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -4,7 +4,7 @@ use crate::{
     keccak256,
     proofs::{EMPTY_LIST_HASH, EMPTY_ROOT},
     BaseFeeParams, BlockBodyRoots, BlockHash, BlockNumHash, BlockNumber, Bloom, Bytes, H160, H256,
-    H64, U256,
+    H64, U128, U256,
 };
 use bytes::{Buf, BufMut, BytesMut};
 
@@ -187,7 +187,7 @@ impl Header {
     /// Returns the blob fee for _this_ block according to the EIP-4844 spec.
     ///
     /// Returns `None` if `excess_blob_gas` is None
-    pub fn blob_fee(&self) -> Option<U256> {
+    pub fn blob_fee(&self) -> Option<U128> {
         self.excess_blob_gas.map(blob_fee)
     }
 
@@ -196,7 +196,7 @@ impl Header {
     /// Returns `None` if `excess_blob_gas` is None.
     ///
     /// See also [Self::next_block_excess_blob_gas]
-    pub fn next_block_blob_fee(&self) -> Option<U256> {
+    pub fn next_block_blob_fee(&self) -> Option<U128> {
         self.next_block_excess_blob_gas().map(blob_fee)
     }
 

--- a/crates/primitives/src/transaction/meta.rs
+++ b/crates/primitives/src/transaction/meta.rs
@@ -13,4 +13,6 @@ pub struct TransactionMeta {
     pub block_number: u64,
     /// Base fee of the block.
     pub base_fee: Option<u64>,
+    /// The excess blob gas of the block.
+    pub excess_blob_gas: Option<u64>,
 }

--- a/crates/rpc/rpc/src/eth/api/block.rs
+++ b/crates/rpc/rpc/src/eth/api/block.rs
@@ -73,6 +73,7 @@ where
             let block_number = block.number;
             let base_fee = block.base_fee_per_gas;
             let block_hash = block.hash;
+            let excess_blob_gas = block.excess_blob_gas;
             let receipts = block
                 .body
                 .into_iter()
@@ -85,6 +86,7 @@ where
                         block_hash,
                         block_number,
                         base_fee,
+                        excess_blob_gas,
                     };
                     build_transaction_receipt_with_block_receipts(tx, meta, receipt, &receipts)
                 })

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -14,6 +14,7 @@ use crate::{
 use async_trait::async_trait;
 use reth_network_api::NetworkInfo;
 use reth_primitives::{
+    constants::eip4844::blob_fee,
     Address, BlockId, BlockNumberOrTag, Bytes, FromRecoveredPooledTransaction, Header,
     IntoRecoveredTransaction, Receipt, SealedBlock,
     TransactionKind::{Call, Create},
@@ -884,7 +885,7 @@ pub(crate) fn build_transaction_receipt_with_block_receipts(
         status_code: if receipt.success { Some(U64::from(1)) } else { Some(U64::from(0)) },
 
         // EIP-4844 fields
-        blob_gas_price: transaction.transaction.max_fee_per_blob_gas().map(U128::from),
+        blob_gas_price: meta.excess_blob_gas.map(blob_fee),
         blob_gas_used: transaction.transaction.blob_gas_used().map(U128::from),
     };
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1139,6 +1139,7 @@ impl<'this, TX: DbTx<'this>> TransactionsProvider for DatabaseProvider<'this, TX
                                 block_hash,
                                 block_number,
                                 base_fee: header.base_fee_per_gas,
+                                excess_blob_gas: header.excess_blob_gas,
                             };
 
                             return Ok(Some((transaction, meta)))


### PR DESCRIPTION
Previously we used the `max_fee_per_blob_gas` to determine `blob_gas_used` in receipts. This is not correct, because the `max_fee_per_blob_gas` is only used to bound a transaction's blob gas price, and is not used to calculate actual blob gas price. The actual blob gas price is derived from the `excess_blob_gas` in the header. The correct calculation is now added, and `excess_blob_gas` is added to `TransactionMeta`.

This also changes the precision of the blob fee methods to `U128` instead of `U256`.