### PR TITLE
refactor(storage): table names

### DIFF
--- a/bin/reth/src/args/stage_args.rs
+++ b/bin/reth/src/args/stage_args.rs
@@ -13,7 +13,7 @@ pub enum StageEnum {
     Hashing,
     Merkle,
     TxLookup,
-    AccountHistories,
-    StorageHistories,
+    AccountsHistory,
+    StoragesHistory,
     TotalDifficulty,
 }

--- a/bin/reth/src/args/stage_args.rs
+++ b/bin/reth/src/args/stage_args.rs
@@ -13,7 +13,7 @@ pub enum StageEnum {
     Hashing,
     Merkle,
     TxLookup,
-    AccountHistory,
-    StorageHistory,
+    AccountHistories,
+    StorageHistories,
     TotalDifficulty,
 }

--- a/bin/reth/src/db/diff.rs
+++ b/bin/reth/src/db/diff.rs
@@ -19,7 +19,7 @@ use reth_db::{
     AccountChangeSets, AccountHistories, AccountsTrie, BlockBodyIndices, BlockOmmers,
     BlockWithdrawals, Bytecodes, CanonicalHeaders, DatabaseEnvRO, HashedAccounts, HashedStorages,
     HeaderNumbers, HeaderTerminalDifficulties, Headers, PlainAccountState, PlainStorageState, PruneCheckpoints,
-    Receipts, StorageChangeSet, StorageHistories, StoragesTrie, SyncStages, SyncStagesProgresses, Tables,
+    Receipts, StorageChangeSets, StorageHistories, StoragesTrie, SyncStages, SyncStagesProgresses, Tables,
     TransactionBlocks, Transactions, TransactionHashNumbers, TransactionSenders,
 };
 use tracing::info;
@@ -117,8 +117,8 @@ impl Command {
                 Tables::AccountChangeSets => {
                     find_diffs::<AccountChangeSets>(primary_tx, secondary_tx, output_dir)?
                 }
-                Tables::StorageChangeSet => {
-                    find_diffs::<StorageChangeSet>(primary_tx, secondary_tx, output_dir)?
+                Tables::StorageChangeSets => {
+                    find_diffs::<StorageChangeSets>(primary_tx, secondary_tx, output_dir)?
                 }
                 Tables::HashedAccounts => {
                     find_diffs::<HashedAccounts>(primary_tx, secondary_tx, output_dir)?

--- a/bin/reth/src/db/diff.rs
+++ b/bin/reth/src/db/diff.rs
@@ -18,9 +18,10 @@ use reth_db::{
     cursor::DbCursorRO, database::Database, open_db_read_only, table::Table, transaction::DbTx,
     AccountChangeSets, AccountHistories, AccountsTrie, BlockBodyIndices, BlockOmmers,
     BlockWithdrawals, Bytecodes, CanonicalHeaders, DatabaseEnvRO, HashedAccounts, HashedStorages,
-    HeaderNumbers, HeaderTerminalDifficulties, Headers, PlainAccountState, PlainStorageState, PruneCheckpoints,
-    Receipts, StorageChangeSets, StorageHistories, StoragesTrie, SyncStages, SyncStagesProgresses, Tables,
-    TransactionBlocks, Transactions, TransactionHashNumbers, TransactionSenders,
+    HeaderNumbers, HeaderTerminalDifficulties, Headers, PlainAccountState, PlainStorageState,
+    PruneCheckpoints, Receipts, StorageChangeSets, StorageHistories, StoragesTrie, SyncStages,
+    SyncStagesProgresses, Tables, TransactionBlocks, TransactionHashNumbers, TransactionSenders,
+    Transactions,
 };
 use tracing::info;
 
@@ -77,7 +78,9 @@ impl Command {
                 Tables::CanonicalHeaders => {
                     find_diffs::<CanonicalHeaders>(primary_tx, secondary_tx, output_dir)?
                 }
-                Tables::HeaderTerminalDifficulties => find_diffs::<HeaderTerminalDifficulties>(primary_tx, secondary_tx, output_dir)?,
+                Tables::HeaderTerminalDifficulties => {
+                    find_diffs::<HeaderTerminalDifficulties>(primary_tx, secondary_tx, output_dir)?
+                }
                 Tables::HeaderNumbers => {
                     find_diffs::<HeaderNumbers>(primary_tx, secondary_tx, output_dir)?
                 }
@@ -132,8 +135,12 @@ impl Command {
                 Tables::StoragesTrie => {
                     find_diffs::<StoragesTrie>(primary_tx, secondary_tx, output_dir)?
                 }
-                Tables::TransactionSenders => find_diffs::<TransactionSenders>(primary_tx, secondary_tx, output_dir)?,
-                Tables::SyncStages => find_diffs::<SyncStages>(primary_tx, secondary_tx, output_dir)?,
+                Tables::TransactionSenders => {
+                    find_diffs::<TransactionSenders>(primary_tx, secondary_tx, output_dir)?
+                }
+                Tables::SyncStages => {
+                    find_diffs::<SyncStages>(primary_tx, secondary_tx, output_dir)?
+                }
                 Tables::SyncStagesProgresses => {
                     find_diffs::<SyncStagesProgresses>(primary_tx, secondary_tx, output_dir)?
                 }

--- a/bin/reth/src/db/diff.rs
+++ b/bin/reth/src/db/diff.rs
@@ -16,10 +16,10 @@ use clap::Parser;
 
 use reth_db::{
     cursor::DbCursorRO, database::Database, open_db_read_only, table::Table, transaction::DbTx,
-    AccountChangeSets, AccountHistories, AccountsTrie, BlockBodyIndices, BlockOmmers,
+    AccountChangeSets, AccountsHistory, AccountsTrie, BlockBodyIndices, BlockOmmers,
     BlockWithdrawals, Bytecodes, CanonicalHeaders, DatabaseEnvRO, HashedAccounts, HashedStorages,
     HeaderNumbers, HeaderTerminalDifficulties, Headers, PlainAccountState, PlainStorageState,
-    PruneCheckpoints, Receipts, StorageChangeSets, StorageHistories, StoragesTrie, SyncStages,
+    PruneCheckpoints, Receipts, StorageChangeSets, StoragesHistory, StoragesTrie, SyncStages,
     SyncStagesProgresses, Tables, TransactionBlocks, TransactionHashNumbers, TransactionSenders,
     Transactions,
 };
@@ -111,11 +111,11 @@ impl Command {
                     find_diffs::<PlainStorageState>(primary_tx, secondary_tx, output_dir)?
                 }
                 Tables::Bytecodes => find_diffs::<Bytecodes>(primary_tx, secondary_tx, output_dir)?,
-                Tables::AccountHistories => {
-                    find_diffs::<AccountHistories>(primary_tx, secondary_tx, output_dir)?
+                Tables::AccountsHistory => {
+                    find_diffs::<AccountsHistory>(primary_tx, secondary_tx, output_dir)?
                 }
-                Tables::StorageHistories => {
-                    find_diffs::<StorageHistories>(primary_tx, secondary_tx, output_dir)?
+                Tables::StoragesHistory => {
+                    find_diffs::<StoragesHistory>(primary_tx, secondary_tx, output_dir)?
                 }
                 Tables::AccountChangeSets => {
                     find_diffs::<AccountChangeSets>(primary_tx, secondary_tx, output_dir)?

--- a/bin/reth/src/db/diff.rs
+++ b/bin/reth/src/db/diff.rs
@@ -16,11 +16,11 @@ use clap::Parser;
 
 use reth_db::{
     cursor::DbCursorRO, database::Database, open_db_read_only, table::Table, transaction::DbTx,
-    AccountChangeSet, AccountHistory, AccountsTrie, BlockBodyIndices, BlockOmmers,
-    BlockWithdrawals, Bytecodes, CanonicalHeaders, DatabaseEnvRO, HashedAccount, HashedStorage,
-    HeaderNumbers, HeaderTD, Headers, PlainAccountState, PlainStorageState, PruneCheckpoints,
-    Receipts, StorageChangeSet, StorageHistory, StoragesTrie, SyncStage, SyncStageProgress, Tables,
-    TransactionBlock, Transactions, TxHashNumber, TxSenders,
+    AccountChangeSets, AccountHistories, AccountsTrie, BlockBodyIndices, BlockOmmers,
+    BlockWithdrawals, Bytecodes, CanonicalHeaders, DatabaseEnvRO, HashedAccounts, HashedStorages,
+    HeaderNumbers, HeaderTerminalDifficulties, Headers, PlainAccountState, PlainStorageState, PruneCheckpoints,
+    Receipts, StorageChangeSet, StorageHistories, StoragesTrie, SyncStages, SyncStagesProgresses, Tables,
+    TransactionBlocks, Transactions, TransactionHashNumbers, TransactionSenders,
 };
 use tracing::info;
 
@@ -77,7 +77,7 @@ impl Command {
                 Tables::CanonicalHeaders => {
                     find_diffs::<CanonicalHeaders>(primary_tx, secondary_tx, output_dir)?
                 }
-                Tables::HeaderTD => find_diffs::<HeaderTD>(primary_tx, secondary_tx, output_dir)?,
+                Tables::HeaderTerminalDifficulties => find_diffs::<HeaderTerminalDifficulties>(primary_tx, secondary_tx, output_dir)?,
                 Tables::HeaderNumbers => {
                     find_diffs::<HeaderNumbers>(primary_tx, secondary_tx, output_dir)?
                 }
@@ -91,14 +91,14 @@ impl Command {
                 Tables::BlockWithdrawals => {
                     find_diffs::<BlockWithdrawals>(primary_tx, secondary_tx, output_dir)?
                 }
-                Tables::TransactionBlock => {
-                    find_diffs::<TransactionBlock>(primary_tx, secondary_tx, output_dir)?
+                Tables::TransactionBlocks => {
+                    find_diffs::<TransactionBlocks>(primary_tx, secondary_tx, output_dir)?
                 }
                 Tables::Transactions => {
                     find_diffs::<Transactions>(primary_tx, secondary_tx, output_dir)?
                 }
-                Tables::TxHashNumber => {
-                    find_diffs::<TxHashNumber>(primary_tx, secondary_tx, output_dir)?
+                Tables::TransactionHashNumbers => {
+                    find_diffs::<TransactionHashNumbers>(primary_tx, secondary_tx, output_dir)?
                 }
                 Tables::Receipts => find_diffs::<Receipts>(primary_tx, secondary_tx, output_dir)?,
                 Tables::PlainAccountState => {
@@ -108,23 +108,23 @@ impl Command {
                     find_diffs::<PlainStorageState>(primary_tx, secondary_tx, output_dir)?
                 }
                 Tables::Bytecodes => find_diffs::<Bytecodes>(primary_tx, secondary_tx, output_dir)?,
-                Tables::AccountHistory => {
-                    find_diffs::<AccountHistory>(primary_tx, secondary_tx, output_dir)?
+                Tables::AccountHistories => {
+                    find_diffs::<AccountHistories>(primary_tx, secondary_tx, output_dir)?
                 }
-                Tables::StorageHistory => {
-                    find_diffs::<StorageHistory>(primary_tx, secondary_tx, output_dir)?
+                Tables::StorageHistories => {
+                    find_diffs::<StorageHistories>(primary_tx, secondary_tx, output_dir)?
                 }
-                Tables::AccountChangeSet => {
-                    find_diffs::<AccountChangeSet>(primary_tx, secondary_tx, output_dir)?
+                Tables::AccountChangeSets => {
+                    find_diffs::<AccountChangeSets>(primary_tx, secondary_tx, output_dir)?
                 }
                 Tables::StorageChangeSet => {
                     find_diffs::<StorageChangeSet>(primary_tx, secondary_tx, output_dir)?
                 }
-                Tables::HashedAccount => {
-                    find_diffs::<HashedAccount>(primary_tx, secondary_tx, output_dir)?
+                Tables::HashedAccounts => {
+                    find_diffs::<HashedAccounts>(primary_tx, secondary_tx, output_dir)?
                 }
-                Tables::HashedStorage => {
-                    find_diffs::<HashedStorage>(primary_tx, secondary_tx, output_dir)?
+                Tables::HashedStorages => {
+                    find_diffs::<HashedStorages>(primary_tx, secondary_tx, output_dir)?
                 }
                 Tables::AccountsTrie => {
                     find_diffs::<AccountsTrie>(primary_tx, secondary_tx, output_dir)?
@@ -132,10 +132,10 @@ impl Command {
                 Tables::StoragesTrie => {
                     find_diffs::<StoragesTrie>(primary_tx, secondary_tx, output_dir)?
                 }
-                Tables::TxSenders => find_diffs::<TxSenders>(primary_tx, secondary_tx, output_dir)?,
-                Tables::SyncStage => find_diffs::<SyncStage>(primary_tx, secondary_tx, output_dir)?,
-                Tables::SyncStageProgress => {
-                    find_diffs::<SyncStageProgress>(primary_tx, secondary_tx, output_dir)?
+                Tables::TransactionSenders => find_diffs::<TransactionSenders>(primary_tx, secondary_tx, output_dir)?,
+                Tables::SyncStages => find_diffs::<SyncStages>(primary_tx, secondary_tx, output_dir)?,
+                Tables::SyncStagesProgresses => {
+                    find_diffs::<SyncStagesProgresses>(primary_tx, secondary_tx, output_dir)?
                 }
                 Tables::PruneCheckpoints => {
                     find_diffs::<PruneCheckpoints>(primary_tx, secondary_tx, output_dir)?

--- a/bin/reth/src/db/get.rs
+++ b/bin/reth/src/db/get.rs
@@ -80,7 +80,7 @@ mod tests {
     use clap::{Args, Parser};
     use reth_db::{
         models::{storage_sharded_key::StorageShardedKey, ShardedKey},
-        AccountHistories, HashedAccounts, Headers, StorageHistories, SyncStages,
+        AccountsHistory, HashedAccounts, Headers, StoragesHistory, SyncStages,
     };
     use reth_primitives::{H160, H256};
     use std::str::FromStr;
@@ -119,9 +119,9 @@ mod tests {
 
     #[test]
     fn parse_json_key_args() {
-        let args = CommandParser::<Command>::parse_from(["reth", "StorageHistories", r#"{ "address": "0x01957911244e546ce519fbac6f798958fafadb41", "sharded_key": { "key": "0x0000000000000000000000000000000000000000000000000000000000000003", "highest_block_number": 18446744073709551615 } }"#]).args;
+        let args = CommandParser::<Command>::parse_from(["reth", "StoragesHistory", r#"{ "address": "0x01957911244e546ce519fbac6f798958fafadb41", "sharded_key": { "key": "0x0000000000000000000000000000000000000000000000000000000000000003", "highest_block_number": 18446744073709551615 } }"#]).args;
         assert_eq!(
-            args.table_key::<StorageHistories>().unwrap(),
+            args.table_key::<StoragesHistory>().unwrap(),
             StorageShardedKey::new(
                 H160::from_str("0x01957911244e546ce519fbac6f798958fafadb41").unwrap(),
                 H256::from_str(
@@ -135,9 +135,9 @@ mod tests {
 
     #[test]
     fn parse_json_key_for_account_history() {
-        let args = CommandParser::<Command>::parse_from(["reth", "AccountHistories", r#"{ "key": "0x4448e1273fd5a8bfdb9ed111e96889c960eee145", "highest_block_number": 18446744073709551615 }"#]).args;
+        let args = CommandParser::<Command>::parse_from(["reth", "AccountsHistory", r#"{ "key": "0x4448e1273fd5a8bfdb9ed111e96889c960eee145", "highest_block_number": 18446744073709551615 }"#]).args;
         assert_eq!(
-            args.table_key::<AccountHistories>().unwrap(),
+            args.table_key::<AccountsHistory>().unwrap(),
             ShardedKey::new(
                 H160::from_str("0x4448e1273fd5a8bfdb9ed111e96889c960eee145").unwrap(),
                 18446744073709551615

--- a/bin/reth/src/db/get.rs
+++ b/bin/reth/src/db/get.rs
@@ -80,7 +80,7 @@ mod tests {
     use clap::{Args, Parser};
     use reth_db::{
         models::{storage_sharded_key::StorageShardedKey, ShardedKey},
-        AccountHistory, HashedAccount, Headers, StorageHistory, SyncStage,
+        AccountHistories, HashedAccounts, Headers, StorageHistories, SyncStages,
     };
     use reth_primitives::{H160, H256};
     use std::str::FromStr;
@@ -99,12 +99,12 @@ mod tests {
 
         let args = CommandParser::<Command>::parse_from([
             "reth",
-            "HashedAccount",
+            "HashedAccounts",
             "0x0ac361fe774b78f8fc4e86c1916930d150865c3fc2e21dca2e58833557608bac",
         ])
         .args;
         assert_eq!(
-            args.table_key::<HashedAccount>().unwrap(),
+            args.table_key::<HashedAccounts>().unwrap(),
             H256::from_str("0x0ac361fe774b78f8fc4e86c1916930d150865c3fc2e21dca2e58833557608bac")
                 .unwrap()
         );
@@ -113,15 +113,15 @@ mod tests {
     #[test]
     fn parse_string_key_args() {
         let args =
-            CommandParser::<Command>::parse_from(["reth", "SyncStage", "MerkleExecution"]).args;
-        assert_eq!(args.table_key::<SyncStage>().unwrap(), "MerkleExecution");
+            CommandParser::<Command>::parse_from(["reth", "SyncStages", "MerkleExecution"]).args;
+        assert_eq!(args.table_key::<SyncStages>().unwrap(), "MerkleExecution");
     }
 
     #[test]
     fn parse_json_key_args() {
-        let args = CommandParser::<Command>::parse_from(["reth", "StorageHistory", r#"{ "address": "0x01957911244e546ce519fbac6f798958fafadb41", "sharded_key": { "key": "0x0000000000000000000000000000000000000000000000000000000000000003", "highest_block_number": 18446744073709551615 } }"#]).args;
+        let args = CommandParser::<Command>::parse_from(["reth", "StorageHistories", r#"{ "address": "0x01957911244e546ce519fbac6f798958fafadb41", "sharded_key": { "key": "0x0000000000000000000000000000000000000000000000000000000000000003", "highest_block_number": 18446744073709551615 } }"#]).args;
         assert_eq!(
-            args.table_key::<StorageHistory>().unwrap(),
+            args.table_key::<StorageHistories>().unwrap(),
             StorageShardedKey::new(
                 H160::from_str("0x01957911244e546ce519fbac6f798958fafadb41").unwrap(),
                 H256::from_str(
@@ -135,9 +135,9 @@ mod tests {
 
     #[test]
     fn parse_json_key_for_account_history() {
-        let args = CommandParser::<Command>::parse_from(["reth", "AccountHistory", r#"{ "key": "0x4448e1273fd5a8bfdb9ed111e96889c960eee145", "highest_block_number": 18446744073709551615 }"#]).args;
+        let args = CommandParser::<Command>::parse_from(["reth", "AccountHistories", r#"{ "key": "0x4448e1273fd5a8bfdb9ed111e96889c960eee145", "highest_block_number": 18446744073709551615 }"#]).args;
         assert_eq!(
-            args.table_key::<AccountHistory>().unwrap(),
+            args.table_key::<AccountHistories>().unwrap(),
             ShardedKey::new(
                 H160::from_str("0x4448e1273fd5a8bfdb9ed111e96889c960eee145").unwrap(),
                 18446744073709551615

--- a/bin/reth/src/init.rs
+++ b/bin/reth/src/init.rs
@@ -101,7 +101,7 @@ pub fn insert_genesis_state<DB: Database>(
             Account { nonce: account.nonce.unwrap_or(0), balance: account.balance, bytecode_hash },
         );
         if let Some(storage) = &account.storage {
-            let mut storage_changes = reth_provider::post_state::StorageChangeset::new();
+            let mut storage_changes = reth_provider::post_state::StorageChangeSets::new();
             for (&key, &value) in storage {
                 storage_changes
                     .insert(U256::from_be_bytes(key.0), (U256::ZERO, U256::from_be_bytes(value.0)));

--- a/bin/reth/src/init.rs
+++ b/bin/reth/src/init.rs
@@ -73,7 +73,7 @@ pub fn init_genesis<DB: Database>(
 
     // insert sync stage
     for stage in StageId::ALL.iter() {
-        tx.put::<tables::SyncStage>(stage.to_string(), Default::default())?;
+        tx.put::<tables::SyncStages>(stage.to_string(), Default::default())?;
     }
 
     tx.commit()?;
@@ -168,7 +168,7 @@ pub fn insert_genesis_header<DB: Database>(
     tx.put::<tables::CanonicalHeaders>(0, header.hash)?;
     tx.put::<tables::HeaderNumbers>(header.hash, 0)?;
     tx.put::<tables::BlockBodyIndices>(0, Default::default())?;
-    tx.put::<tables::HeaderTD>(0, header.difficulty.into())?;
+    tx.put::<tables::HeaderTerminalDifficulties>(0, header.difficulty.into())?;
     tx.put::<tables::Headers>(0, header.header)?;
 
     Ok(())
@@ -282,7 +282,7 @@ mod tests {
         let tx = db.tx().expect("failed to init tx");
 
         assert_eq!(
-            collect_table_entries::<Arc<DatabaseEnv>, tables::AccountHistory>(&tx)
+            collect_table_entries::<Arc<DatabaseEnv>, tables::AccountHistories>(&tx)
                 .expect("failed to collect"),
             vec![
                 (ShardedKey::new(address_with_balance, u64::MAX), IntegerList::new([0]).unwrap()),
@@ -291,7 +291,7 @@ mod tests {
         );
 
         assert_eq!(
-            collect_table_entries::<Arc<DatabaseEnv>, tables::StorageHistory>(&tx)
+            collect_table_entries::<Arc<DatabaseEnv>, tables::StorageHistories>(&tx)
                 .expect("failed to collect"),
             vec![(
                 StorageShardedKey::new(address_with_storage, storage_key, u64::MAX),

--- a/bin/reth/src/init.rs
+++ b/bin/reth/src/init.rs
@@ -282,7 +282,7 @@ mod tests {
         let tx = db.tx().expect("failed to init tx");
 
         assert_eq!(
-            collect_table_entries::<Arc<DatabaseEnv>, tables::AccountHistories>(&tx)
+            collect_table_entries::<Arc<DatabaseEnv>, tables::AccountsHistory>(&tx)
                 .expect("failed to collect"),
             vec![
                 (ShardedKey::new(address_with_balance, u64::MAX), IntegerList::new([0]).unwrap()),
@@ -291,7 +291,7 @@ mod tests {
         );
 
         assert_eq!(
-            collect_table_entries::<Arc<DatabaseEnv>, tables::StorageHistories>(&tx)
+            collect_table_entries::<Arc<DatabaseEnv>, tables::StoragesHistory>(&tx)
                 .expect("failed to collect"),
             vec![(
                 StorageShardedKey::new(address_with_storage, storage_key, u64::MAX),

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -63,7 +63,7 @@ use reth_stages::{
     prelude::*,
     stages::{
         AccountHashingStage, ExecutionStage, ExecutionStageThresholds, HeaderSyncMode,
-        IndexAccountHistoryStage, IndexStorageHistoryStage, MerkleStage, SenderRecoveryStage,
+        IndexAccountHistoriesStage, IndexStorageHistoriesStage, MerkleStage, SenderRecoveryStage,
         StorageHashingStage, TotalDifficultyStage, TransactionLookupStage,
     },
     MetricEventsSender, MetricsListener,
@@ -869,11 +869,11 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
                     stage_config.transaction_lookup.commit_threshold,
                     prune_modes.clone(),
                 ))
-                .set(IndexAccountHistoryStage::new(
+                .set(IndexAccountHistoriesStage::new(
                     stage_config.index_account_history.commit_threshold,
                     prune_modes.clone(),
                 ))
-                .set(IndexStorageHistoryStage::new(
+                .set(IndexStorageHistoriesStage::new(
                     stage_config.index_storage_history.commit_threshold,
                     prune_modes,
                 )),

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -63,7 +63,7 @@ use reth_stages::{
     prelude::*,
     stages::{
         AccountHashingStage, ExecutionStage, ExecutionStageThresholds, HeaderSyncMode,
-        IndexAccountHistoriesStage, IndexStorageHistoriesStage, MerkleStage, SenderRecoveryStage,
+        IndexAccountsHistoryStage, IndexStoragesHistoryStage, MerkleStage, SenderRecoveryStage,
         StorageHashingStage, TotalDifficultyStage, TransactionLookupStage,
     },
     MetricEventsSender, MetricsListener,
@@ -869,11 +869,11 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
                     stage_config.transaction_lookup.commit_threshold,
                     prune_modes.clone(),
                 ))
-                .set(IndexAccountHistoriesStage::new(
+                .set(IndexAccountsHistoryStage::new(
                     stage_config.index_account_history.commit_threshold,
                     prune_modes.clone(),
                 ))
-                .set(IndexStorageHistoriesStage::new(
+                .set(IndexStoragesHistoryStage::new(
                     stage_config.index_storage_history.commit_threshold,
                     prune_modes,
                 )),

--- a/bin/reth/src/recover/storage_tries.rs
+++ b/bin/reth/src/recover/storage_tries.rs
@@ -67,7 +67,7 @@ impl Command {
 
         let mut deleted_tries = 0;
         let tx_mut = provider.tx_mut();
-        let mut hashed_account_cursor = tx_mut.cursor_read::<tables::HashedAccount>()?;
+        let mut hashed_account_cursor = tx_mut.cursor_read::<tables::HashedAccounts>()?;
         let mut storage_trie_cursor = tx_mut.cursor_dup_read::<tables::StoragesTrie>()?;
         let mut entry = storage_trie_cursor.first()?;
 

--- a/bin/reth/src/stage/drop.rs
+++ b/bin/reth/src/stage/drop.rs
@@ -64,15 +64,15 @@ impl Command {
                 StageEnum::Bodies => {
                     tx.clear::<tables::BlockBodyIndices>()?;
                     tx.clear::<tables::Transactions>()?;
-                    tx.clear::<tables::TransactionBlock>()?;
+                    tx.clear::<tables::TransactionBlocks>()?;
                     tx.clear::<tables::BlockOmmers>()?;
                     tx.clear::<tables::BlockWithdrawals>()?;
-                    tx.put::<tables::SyncStage>(StageId::Bodies.to_string(), Default::default())?;
+                    tx.put::<tables::SyncStages>(StageId::Bodies.to_string(), Default::default())?;
                     insert_genesis_header::<DatabaseEnv>(tx, self.chain)?;
                 }
                 StageEnum::Senders => {
-                    tx.clear::<tables::TxSenders>()?;
-                    tx.put::<tables::SyncStage>(
+                    tx.clear::<tables::TransactionSenders>()?;
+                    tx.put::<tables::SyncStages>(
                         StageId::SenderRecovery.to_string(),
                         Default::default(),
                     )?;
@@ -80,41 +80,41 @@ impl Command {
                 StageEnum::Execution => {
                     tx.clear::<tables::PlainAccountState>()?;
                     tx.clear::<tables::PlainStorageState>()?;
-                    tx.clear::<tables::AccountChangeSet>()?;
+                    tx.clear::<tables::AccountChangeSets>()?;
                     tx.clear::<tables::StorageChangeSet>()?;
                     tx.clear::<tables::Bytecodes>()?;
                     tx.clear::<tables::Receipts>()?;
-                    tx.put::<tables::SyncStage>(
+                    tx.put::<tables::SyncStages>(
                         StageId::Execution.to_string(),
                         Default::default(),
                     )?;
                     insert_genesis_state::<DatabaseEnv>(tx, self.chain.genesis())?;
                 }
                 StageEnum::AccountHashing => {
-                    tx.clear::<tables::HashedAccount>()?;
-                    tx.put::<tables::SyncStage>(
+                    tx.clear::<tables::HashedAccounts>()?;
+                    tx.put::<tables::SyncStages>(
                         StageId::AccountHashing.to_string(),
                         Default::default(),
                     )?;
                 }
                 StageEnum::StorageHashing => {
-                    tx.clear::<tables::HashedStorage>()?;
-                    tx.put::<tables::SyncStage>(
+                    tx.clear::<tables::HashedStorages>()?;
+                    tx.put::<tables::SyncStages>(
                         StageId::StorageHashing.to_string(),
                         Default::default(),
                     )?;
                 }
                 StageEnum::Hashing => {
                     // Clear hashed accounts
-                    tx.clear::<tables::HashedAccount>()?;
-                    tx.put::<tables::SyncStage>(
+                    tx.clear::<tables::HashedAccounts>()?;
+                    tx.put::<tables::SyncStages>(
                         StageId::AccountHashing.to_string(),
                         Default::default(),
                     )?;
 
                     // Clear hashed storages
-                    tx.clear::<tables::HashedStorage>()?;
-                    tx.put::<tables::SyncStage>(
+                    tx.clear::<tables::HashedStorages>()?;
+                    tx.put::<tables::SyncStages>(
                         StageId::StorageHashing.to_string(),
                         Default::default(),
                     )?;
@@ -122,42 +122,42 @@ impl Command {
                 StageEnum::Merkle => {
                     tx.clear::<tables::AccountsTrie>()?;
                     tx.clear::<tables::StoragesTrie>()?;
-                    tx.put::<tables::SyncStage>(
+                    tx.put::<tables::SyncStages>(
                         StageId::MerkleExecute.to_string(),
                         Default::default(),
                     )?;
-                    tx.put::<tables::SyncStage>(
+                    tx.put::<tables::SyncStages>(
                         StageId::MerkleUnwind.to_string(),
                         Default::default(),
                     )?;
-                    tx.delete::<tables::SyncStageProgress>(
+                    tx.delete::<tables::SyncStagesProgresses>(
                         StageId::MerkleExecute.to_string(),
                         None,
                     )?;
                 }
-                StageEnum::AccountHistory | StageEnum::StorageHistory => {
-                    tx.clear::<tables::AccountHistory>()?;
-                    tx.clear::<tables::StorageHistory>()?;
-                    tx.put::<tables::SyncStage>(
-                        StageId::IndexAccountHistory.to_string(),
+                StageEnum::AccountHistories | StageEnum::StorageHistories => {
+                    tx.clear::<tables::AccountHistories>()?;
+                    tx.clear::<tables::StorageHistories>()?;
+                    tx.put::<tables::SyncStages>(
+                        StageId::IndexAccountHistories.to_string(),
                         Default::default(),
                     )?;
-                    tx.put::<tables::SyncStage>(
-                        StageId::IndexStorageHistory.to_string(),
+                    tx.put::<tables::SyncStages>(
+                        StageId::IndexStorageHistories.to_string(),
                         Default::default(),
                     )?;
                 }
                 StageEnum::TotalDifficulty => {
-                    tx.clear::<tables::HeaderTD>()?;
-                    tx.put::<tables::SyncStage>(
+                    tx.clear::<tables::HeaderTerminalDifficulties>()?;
+                    tx.put::<tables::SyncStages>(
                         StageId::TotalDifficulty.to_string(),
                         Default::default(),
                     )?;
                     insert_genesis_header::<DatabaseEnv>(tx, self.chain)?;
                 }
                 StageEnum::TxLookup => {
-                    tx.clear::<tables::TxHashNumber>()?;
-                    tx.put::<tables::SyncStage>(
+                    tx.clear::<tables::TransactionHashNumbers>()?;
+                    tx.put::<tables::SyncStages>(
                         StageId::TransactionLookup.to_string(),
                         Default::default(),
                     )?;
@@ -169,7 +169,7 @@ impl Command {
                 }
             }
 
-            tx.put::<tables::SyncStage>(StageId::Finish.to_string(), Default::default())?;
+            tx.put::<tables::SyncStages>(StageId::Finish.to_string(), Default::default())?;
 
             Ok::<_, eyre::Error>(())
         })??;

--- a/bin/reth/src/stage/drop.rs
+++ b/bin/reth/src/stage/drop.rs
@@ -135,15 +135,15 @@ impl Command {
                         None,
                     )?;
                 }
-                StageEnum::AccountHistories | StageEnum::StorageHistories => {
-                    tx.clear::<tables::AccountHistories>()?;
-                    tx.clear::<tables::StorageHistories>()?;
+                StageEnum::AccountsHistory | StageEnum::StoragesHistory => {
+                    tx.clear::<tables::AccountsHistory>()?;
+                    tx.clear::<tables::StoragesHistory>()?;
                     tx.put::<tables::SyncStages>(
-                        StageId::IndexAccountHistories.to_string(),
+                        StageId::IndexAccountsHistory.to_string(),
                         Default::default(),
                     )?;
                     tx.put::<tables::SyncStages>(
-                        StageId::IndexStorageHistories.to_string(),
+                        StageId::IndexStoragesHistory.to_string(),
                         Default::default(),
                     )?;
                 }

--- a/bin/reth/src/stage/drop.rs
+++ b/bin/reth/src/stage/drop.rs
@@ -81,7 +81,7 @@ impl Command {
                     tx.clear::<tables::PlainAccountState>()?;
                     tx.clear::<tables::PlainStorageState>()?;
                     tx.clear::<tables::AccountChangeSets>()?;
-                    tx.clear::<tables::StorageChangeSet>()?;
+                    tx.clear::<tables::StorageChangeSets>()?;
                     tx.clear::<tables::Bytecodes>()?;
                     tx.clear::<tables::Receipts>()?;
                     tx.put::<tables::SyncStages>(

--- a/bin/reth/src/stage/dump/execution.rs
+++ b/bin/reth/src/stage/dump/execution.rs
@@ -45,7 +45,11 @@ fn import_tables_with_range<DB: Database>(
         tx.import_table_with_range::<tables::CanonicalHeaders, _>(&db_tool.db.tx()?, Some(from), to)
     })??;
     output_db.update(|tx| {
-        tx.import_table_with_range::<tables::HeaderTerminalDifficulties, _>(&db_tool.db.tx()?, Some(from), to)
+        tx.import_table_with_range::<tables::HeaderTerminalDifficulties, _>(
+            &db_tool.db.tx()?,
+            Some(from),
+            to,
+        )
     })??;
     output_db.update(|tx| {
         tx.import_table_with_range::<tables::Headers, _>(&db_tool.db.tx()?, Some(from), to)
@@ -80,7 +84,11 @@ fn import_tables_with_range<DB: Database>(
     })??;
 
     output_db.update(|tx| {
-        tx.import_table_with_range::<tables::TransactionSenders, _>(&db_tool.db.tx()?, Some(from_tx), to_tx)
+        tx.import_table_with_range::<tables::TransactionSenders, _>(
+            &db_tool.db.tx()?,
+            Some(from_tx),
+            to_tx,
+        )
     })??;
 
     Ok(())

--- a/bin/reth/src/stage/dump/execution.rs
+++ b/bin/reth/src/stage/dump/execution.rs
@@ -45,7 +45,7 @@ fn import_tables_with_range<DB: Database>(
         tx.import_table_with_range::<tables::CanonicalHeaders, _>(&db_tool.db.tx()?, Some(from), to)
     })??;
     output_db.update(|tx| {
-        tx.import_table_with_range::<tables::HeaderTD, _>(&db_tool.db.tx()?, Some(from), to)
+        tx.import_table_with_range::<tables::HeaderTerminalDifficulties, _>(&db_tool.db.tx()?, Some(from), to)
     })??;
     output_db.update(|tx| {
         tx.import_table_with_range::<tables::Headers, _>(&db_tool.db.tx()?, Some(from), to)
@@ -80,7 +80,7 @@ fn import_tables_with_range<DB: Database>(
     })??;
 
     output_db.update(|tx| {
-        tx.import_table_with_range::<tables::TxSenders, _>(&db_tool.db.tx()?, Some(from_tx), to_tx)
+        tx.import_table_with_range::<tables::TransactionSenders, _>(&db_tool.db.tx()?, Some(from_tx), to_tx)
     })??;
 
     Ok(())

--- a/bin/reth/src/stage/dump/hashing_account.rs
+++ b/bin/reth/src/stage/dump/hashing_account.rs
@@ -19,7 +19,11 @@ pub(crate) async fn dump_hashing_account_stage<DB: Database>(
 
     // Import relevant AccountChangeSets
     output_db.update(|tx| {
-        tx.import_table_with_range::<tables::AccountChangeSets, _>(&db_tool.db.tx()?, Some(from), to)
+        tx.import_table_with_range::<tables::AccountChangeSets, _>(
+            &db_tool.db.tx()?,
+            Some(from),
+            to,
+        )
     })??;
 
     unwind_and_copy(db_tool, from, tip_block_number, &output_db).await?;

--- a/bin/reth/src/stage/dump/hashing_account.rs
+++ b/bin/reth/src/stage/dump/hashing_account.rs
@@ -19,7 +19,7 @@ pub(crate) async fn dump_hashing_account_stage<DB: Database>(
 
     // Import relevant AccountChangeSets
     output_db.update(|tx| {
-        tx.import_table_with_range::<tables::AccountChangeSet, _>(&db_tool.db.tx()?, Some(from), to)
+        tx.import_table_with_range::<tables::AccountChangeSets, _>(&db_tool.db.tx()?, Some(from), to)
     })??;
 
     unwind_and_copy(db_tool, from, tip_block_number, &output_db).await?;

--- a/bin/reth/src/stage/dump/hashing_storage.rs
+++ b/bin/reth/src/stage/dump/hashing_storage.rs
@@ -53,7 +53,8 @@ async fn unwind_and_copy<DB: Database>(
     // TODO optimize we can actually just get the entries we need for both these tables
     output_db
         .update(|tx| tx.import_dupsort::<tables::PlainStorageState, _>(&unwind_inner_tx))??;
-    output_db.update(|tx| tx.import_dupsort::<tables::StorageChangeSets, _>(&unwind_inner_tx))??;
+    output_db
+        .update(|tx| tx.import_dupsort::<tables::StorageChangeSets, _>(&unwind_inner_tx))??;
 
     Ok(())
 }

--- a/bin/reth/src/stage/dump/hashing_storage.rs
+++ b/bin/reth/src/stage/dump/hashing_storage.rs
@@ -53,7 +53,7 @@ async fn unwind_and_copy<DB: Database>(
     // TODO optimize we can actually just get the entries we need for both these tables
     output_db
         .update(|tx| tx.import_dupsort::<tables::PlainStorageState, _>(&unwind_inner_tx))??;
-    output_db.update(|tx| tx.import_dupsort::<tables::StorageChangeSet, _>(&unwind_inner_tx))??;
+    output_db.update(|tx| tx.import_dupsort::<tables::StorageChangeSets, _>(&unwind_inner_tx))??;
 
     Ok(())
 }

--- a/bin/reth/src/stage/dump/merkle.rs
+++ b/bin/reth/src/stage/dump/merkle.rs
@@ -99,7 +99,7 @@ async fn unwind_and_copy<DB: Database>(
     let unwind_inner_tx = provider.into_tx();
 
     // TODO optimize we can actually just get the entries we need
-    output_db.update(|tx| tx.import_dupsort::<tables::StorageChangeSet, _>(&unwind_inner_tx))??;
+    output_db.update(|tx| tx.import_dupsort::<tables::StorageChangeSets, _>(&unwind_inner_tx))??;
 
     output_db.update(|tx| tx.import_table::<tables::HashedAccounts, _>(&unwind_inner_tx))??;
     output_db.update(|tx| tx.import_dupsort::<tables::HashedStorages, _>(&unwind_inner_tx))??;

--- a/bin/reth/src/stage/dump/merkle.rs
+++ b/bin/reth/src/stage/dump/merkle.rs
@@ -28,7 +28,11 @@ pub(crate) async fn dump_merkle_stage<DB: Database>(
     })??;
 
     output_db.update(|tx| {
-        tx.import_table_with_range::<tables::AccountChangeSets, _>(&db_tool.db.tx()?, Some(from), to)
+        tx.import_table_with_range::<tables::AccountChangeSets, _>(
+            &db_tool.db.tx()?,
+            Some(from),
+            to,
+        )
     })??;
 
     unwind_and_copy(db_tool, (from, to), tip_block_number, &output_db).await?;
@@ -99,7 +103,8 @@ async fn unwind_and_copy<DB: Database>(
     let unwind_inner_tx = provider.into_tx();
 
     // TODO optimize we can actually just get the entries we need
-    output_db.update(|tx| tx.import_dupsort::<tables::StorageChangeSets, _>(&unwind_inner_tx))??;
+    output_db
+        .update(|tx| tx.import_dupsort::<tables::StorageChangeSets, _>(&unwind_inner_tx))??;
 
     output_db.update(|tx| tx.import_table::<tables::HashedAccounts, _>(&unwind_inner_tx))??;
     output_db.update(|tx| tx.import_dupsort::<tables::HashedStorages, _>(&unwind_inner_tx))??;

--- a/bin/reth/src/stage/dump/merkle.rs
+++ b/bin/reth/src/stage/dump/merkle.rs
@@ -28,7 +28,7 @@ pub(crate) async fn dump_merkle_stage<DB: Database>(
     })??;
 
     output_db.update(|tx| {
-        tx.import_table_with_range::<tables::AccountChangeSet, _>(&db_tool.db.tx()?, Some(from), to)
+        tx.import_table_with_range::<tables::AccountChangeSets, _>(&db_tool.db.tx()?, Some(from), to)
     })??;
 
     unwind_and_copy(db_tool, (from, to), tip_block_number, &output_db).await?;
@@ -101,8 +101,8 @@ async fn unwind_and_copy<DB: Database>(
     // TODO optimize we can actually just get the entries we need
     output_db.update(|tx| tx.import_dupsort::<tables::StorageChangeSet, _>(&unwind_inner_tx))??;
 
-    output_db.update(|tx| tx.import_table::<tables::HashedAccount, _>(&unwind_inner_tx))??;
-    output_db.update(|tx| tx.import_dupsort::<tables::HashedStorage, _>(&unwind_inner_tx))??;
+    output_db.update(|tx| tx.import_table::<tables::HashedAccounts, _>(&unwind_inner_tx))??;
+    output_db.update(|tx| tx.import_dupsort::<tables::HashedStorages, _>(&unwind_inner_tx))??;
     output_db.update(|tx| tx.import_table::<tables::AccountsTrie, _>(&unwind_inner_tx))??;
     output_db.update(|tx| tx.import_dupsort::<tables::StoragesTrie, _>(&unwind_inner_tx))??;
 

--- a/bin/reth/src/stage/run.rs
+++ b/bin/reth/src/stage/run.rs
@@ -17,7 +17,7 @@ use reth_provider::{ProviderFactory, StageCheckpointReader};
 use reth_stages::{
     stages::{
         AccountHashingStage, BodyStage, ExecutionStage, ExecutionStageThresholds,
-        IndexAccountHistoryStage, IndexStorageHistoryStage, MerkleStage, SenderRecoveryStage,
+        IndexAccountHistoriesStage, IndexStorageHistoriesStage, MerkleStage, SenderRecoveryStage,
         StorageHashingStage, TransactionLookupStage,
     },
     ExecInput, ExecOutput, PipelineError, Stage, UnwindInput,
@@ -221,8 +221,8 @@ impl Command {
                     Box::new(MerkleStage::default_execution()),
                     Some(Box::new(MerkleStage::default_unwind())),
                 ),
-                StageEnum::AccountHistory => (Box::<IndexAccountHistoryStage>::default(), None),
-                StageEnum::StorageHistory => (Box::<IndexStorageHistoryStage>::default(), None),
+                StageEnum::AccountHistories => (Box::<IndexAccountHistoriesStage>::default(), None),
+                StageEnum::StorageHistories => (Box::<IndexStorageHistoriesStage>::default(), None),
                 _ => return Ok(()),
             };
         if let Some(unwind_stage) = &unwind_stage {

--- a/bin/reth/src/stage/run.rs
+++ b/bin/reth/src/stage/run.rs
@@ -17,7 +17,7 @@ use reth_provider::{ProviderFactory, StageCheckpointReader};
 use reth_stages::{
     stages::{
         AccountHashingStage, BodyStage, ExecutionStage, ExecutionStageThresholds,
-        IndexAccountHistoriesStage, IndexStorageHistoriesStage, MerkleStage, SenderRecoveryStage,
+        IndexAccountsHistoryStage, IndexStoragesHistoryStage, MerkleStage, SenderRecoveryStage,
         StorageHashingStage, TransactionLookupStage,
     },
     ExecInput, ExecOutput, PipelineError, Stage, UnwindInput,
@@ -221,8 +221,8 @@ impl Command {
                     Box::new(MerkleStage::default_execution()),
                     Some(Box::new(MerkleStage::default_unwind())),
                 ),
-                StageEnum::AccountHistories => (Box::<IndexAccountHistoriesStage>::default(), None),
-                StageEnum::StorageHistories => (Box::<IndexStorageHistoriesStage>::default(), None),
+                StageEnum::AccountsHistory => (Box::<IndexAccountsHistoryStage>::default(), None),
+                StageEnum::StoragesHistory => (Box::<IndexStoragesHistoryStage>::default(), None),
                 _ => return Ok(()),
             };
         if let Some(unwind_stage) = &unwind_stage {

--- a/bin/reth/src/test_vectors/tables.rs
+++ b/bin/reth/src/test_vectors/tables.rs
@@ -58,12 +58,12 @@ pub(crate) fn generate_vectors(mut tables: Vec<String>) -> Result<()> {
 
     generate!([
         (CanonicalHeaders, PER_TABLE, TABLE),
-        (HeaderTD, PER_TABLE, TABLE),
+        (HeaderTerminalDifficulties, PER_TABLE, TABLE),
         (HeaderNumbers, PER_TABLE, TABLE),
         (Headers, PER_TABLE, TABLE),
         (BlockBodyIndices, PER_TABLE, TABLE),
         (BlockOmmers, 100, TABLE),
-        (TxHashNumber, PER_TABLE, TABLE),
+        (TransactionHashNumbers, PER_TABLE, TABLE),
         (Transactions, 100, TABLE),
         (PlainStorageState, PER_TABLE, DUPSORT),
         (PlainAccountState, PER_TABLE, TABLE)

--- a/book/run/pruning.md
+++ b/book/run/pruning.md
@@ -98,7 +98,7 @@ is completed, so the disk space is reclaimed slowly.
 
 Given the aforementioned part sizes, we get the following full node size:
 ```text
-Archive Node - Receipts - AccountHistory - StorageHistory = Full Node
+Archive Node - Receipts - AccountHistories - StorageHistories = Full Node
 ```
 ```text
 2.1TB - 240GB - 230GB - 680GB = 950GB

--- a/book/run/pruning.md
+++ b/book/run/pruning.md
@@ -98,7 +98,7 @@ is completed, so the disk space is reclaimed slowly.
 
 Given the aforementioned part sizes, we get the following full node size:
 ```text
-Archive Node - Receipts - AccountHistories - StorageHistories = Full Node
+Archive Node - Receipts - AccountsHistory - StoragesHistory = Full Node
 ```
 ```text
 2.1TB - 240GB - 230GB - 680GB = 950GB

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1191,7 +1191,7 @@ mod tests {
         }
         provider
             .tx_ref()
-            .put::<tables::SyncStage>("Finish".to_string(), StageCheckpoint::new(10))
+            .put::<tables::SyncStages>("Finish".to_string(), StageCheckpoint::new(10))
             .unwrap();
         provider.commit().unwrap();
     }

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -2128,7 +2128,7 @@ mod tests {
             insert_blocks(env.db.as_ref(), chain_spec.clone(), [&genesis, &block1].into_iter());
             env.db
                 .update(|tx| {
-                    tx.put::<tables::SyncStage>(
+                    tx.put::<tables::SyncStages>(
                         StageId::Finish.to_string(),
                         StageCheckpoint::new(block1.number),
                     )

--- a/crates/interfaces/src/provider.rs
+++ b/crates/interfaces/src/provider.rs
@@ -25,7 +25,7 @@ pub enum ProviderError {
     },
     /// The block number was found for the given address, but the changeset was not found.
     #[error("Account {address:?} ChangeSet for block #{block_number} does not exist")]
-    AccountChangeSetsNotFound {
+    AccountChangeSetNotFound {
         /// Block number found for the address
         block_number: BlockNumber,
         /// The account address

--- a/crates/interfaces/src/provider.rs
+++ b/crates/interfaces/src/provider.rs
@@ -15,7 +15,7 @@ pub enum ProviderError {
     /// The transition id was found for the given address and storage key, but the changeset was
     /// not found.
     #[error("Storage ChangeSet address: ({address:?} key: {storage_key:?}) for block:#{block_number} does not exist")]
-    StorageChangesetNotFound {
+    StorageChangeSetsNotFound {
         /// The block number found for the address and storage key
         block_number: BlockNumber,
         /// The account address

--- a/crates/interfaces/src/provider.rs
+++ b/crates/interfaces/src/provider.rs
@@ -25,7 +25,7 @@ pub enum ProviderError {
     },
     /// The block number was found for the given address, but the changeset was not found.
     #[error("Account {address:?} ChangeSet for block #{block_number} does not exist")]
-    AccountChangesetNotFound {
+    AccountChangeSetsNotFound {
         /// Block number found for the address
         block_number: BlockNumber,
         /// The account address

--- a/crates/primitives/src/prune/batch_sizes.rs
+++ b/crates/primitives/src/prune/batch_sizes.rs
@@ -17,7 +17,7 @@ pub struct PruneBatchSizes {
     /// Measured in the number of `AccountChangeSets` table rows.
     account_history: usize,
     /// Maximum number of storage history entries to prune, per block.
-    /// Measured in the number of `StorageChangeSet` table rows.
+    /// Measured in the number of `StorageChangeSets` table rows.
     storage_history: usize,
 }
 

--- a/crates/primitives/src/prune/batch_sizes.rs
+++ b/crates/primitives/src/prune/batch_sizes.rs
@@ -14,7 +14,7 @@ pub struct PruneBatchSizes {
     /// Maximum number of transaction senders to prune, per block.
     transaction_senders: usize,
     /// Maximum number of account history entries to prune, per block.
-    /// Measured in the number of `AccountChangeSet` table rows.
+    /// Measured in the number of `AccountChangeSets` table rows.
     account_history: usize,
     /// Maximum number of storage history entries to prune, per block.
     /// Measured in the number of `StorageChangeSet` table rows.

--- a/crates/primitives/src/prune/part.rs
+++ b/crates/primitives/src/prune/part.rs
@@ -14,10 +14,10 @@ pub enum PrunePart {
     Receipts,
     /// Prune part responsible for some `Receipts` filtered by logs.
     ContractLogs,
-    /// Prune part responsible for the `AccountChangeSets` and `AccountHistories` tables.
-    AccountHistories,
-    /// Prune part responsible for the `StorageChangeSets` and `StorageHistories` tables.
-    StorageHistories,
+    /// Prune part responsible for the `AccountChangeSets` and `AccountsHistory` tables.
+    AccountsHistory,
+    /// Prune part responsible for the `StorageChangeSets` and `StoragesHistory` tables.
+    StoragesHistory,
 }
 
 /// PrunePart error type.

--- a/crates/primitives/src/prune/part.rs
+++ b/crates/primitives/src/prune/part.rs
@@ -6,18 +6,18 @@ use thiserror::Error;
 #[main_codec]
 #[derive(Debug, Display, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum PrunePart {
-    /// Prune part responsible for the `TxSenders` table.
+    /// Prune part responsible for the `TransactionSenders` table.
     SenderRecovery,
-    /// Prune part responsible for the `TxHashNumber` table.
+    /// Prune part responsible for the `TransactionHashNumbers` table.
     TransactionLookup,
     /// Prune part responsible for all `Receipts`.
     Receipts,
     /// Prune part responsible for some `Receipts` filtered by logs.
     ContractLogs,
-    /// Prune part responsible for the `AccountChangeSet` and `AccountHistory` tables.
-    AccountHistory,
-    /// Prune part responsible for the `StorageChangeSet` and `StorageHistory` tables.
-    StorageHistory,
+    /// Prune part responsible for the `AccountChangeSets` and `AccountHistories` tables.
+    AccountHistories,
+    /// Prune part responsible for the `StorageChangeSet` and `StorageHistories` tables.
+    StorageHistories,
 }
 
 /// PrunePart error type.

--- a/crates/primitives/src/prune/part.rs
+++ b/crates/primitives/src/prune/part.rs
@@ -16,7 +16,7 @@ pub enum PrunePart {
     ContractLogs,
     /// Prune part responsible for the `AccountChangeSets` and `AccountHistories` tables.
     AccountHistories,
-    /// Prune part responsible for the `StorageChangeSet` and `StorageHistories` tables.
+    /// Prune part responsible for the `StorageChangeSets` and `StorageHistories` tables.
     StorageHistories,
 }
 

--- a/crates/primitives/src/prune/target.rs
+++ b/crates/primitives/src/prune/target.rs
@@ -102,7 +102,7 @@ impl PruneModes {
         (sender_recovery, SenderRecovery, None),
         (transaction_lookup, TransactionLookup, None),
         (receipts, Receipts, Some(64)),
-        (account_history, AccountHistories, Some(64)),
-        (storage_history, StorageHistories, Some(64))
+        (account_history, AccountsHistory, Some(64)),
+        (storage_history, StoragesHistory, Some(64))
     );
 }

--- a/crates/primitives/src/prune/target.rs
+++ b/crates/primitives/src/prune/target.rs
@@ -102,7 +102,7 @@ impl PruneModes {
         (sender_recovery, SenderRecovery, None),
         (transaction_lookup, TransactionLookup, None),
         (receipts, Receipts, Some(64)),
-        (account_history, AccountHistory, Some(64)),
-        (storage_history, StorageHistory, Some(64))
+        (account_history, AccountHistories, Some(64)),
+        (storage_history, StorageHistories, Some(64))
     );
 }

--- a/crates/primitives/src/stage/id.rs
+++ b/crates/primitives/src/stage/id.rs
@@ -14,8 +14,8 @@ pub enum StageId {
     StorageHashing,
     MerkleExecute,
     TransactionLookup,
-    IndexStorageHistory,
-    IndexAccountHistory,
+    IndexStorageHistories,
+    IndexAccountHistories,
     Finish,
     Other(&'static str),
 }
@@ -33,8 +33,8 @@ impl StageId {
         StageId::StorageHashing,
         StageId::MerkleExecute,
         StageId::TransactionLookup,
-        StageId::IndexStorageHistory,
-        StageId::IndexAccountHistory,
+        StageId::IndexStorageHistories,
+        StageId::IndexAccountHistories,
         StageId::Finish,
     ];
 
@@ -51,8 +51,8 @@ impl StageId {
             StageId::StorageHashing => "StorageHashing",
             StageId::MerkleExecute => "MerkleExecute",
             StageId::TransactionLookup => "TransactionLookup",
-            StageId::IndexAccountHistory => "IndexAccountHistory",
-            StageId::IndexStorageHistory => "IndexStorageHistory",
+            StageId::IndexAccountHistories => "IndexAccountHistories",
+            StageId::IndexStorageHistories => "IndexStorageHistories",
             StageId::Finish => "Finish",
             StageId::Other(s) => s,
         }
@@ -90,8 +90,8 @@ mod tests {
         assert_eq!(StageId::AccountHashing.to_string(), "AccountHashing");
         assert_eq!(StageId::StorageHashing.to_string(), "StorageHashing");
         assert_eq!(StageId::MerkleExecute.to_string(), "MerkleExecute");
-        assert_eq!(StageId::IndexAccountHistory.to_string(), "IndexAccountHistory");
-        assert_eq!(StageId::IndexStorageHistory.to_string(), "IndexStorageHistory");
+        assert_eq!(StageId::IndexAccountHistories.to_string(), "IndexAccountHistories");
+        assert_eq!(StageId::IndexStorageHistories.to_string(), "IndexStorageHistories");
         assert_eq!(StageId::TransactionLookup.to_string(), "TransactionLookup");
         assert_eq!(StageId::Finish.to_string(), "Finish");
 

--- a/crates/primitives/src/stage/id.rs
+++ b/crates/primitives/src/stage/id.rs
@@ -14,8 +14,8 @@ pub enum StageId {
     StorageHashing,
     MerkleExecute,
     TransactionLookup,
-    IndexStorageHistories,
-    IndexAccountHistories,
+    IndexStoragesHistory,
+    IndexAccountsHistory,
     Finish,
     Other(&'static str),
 }
@@ -33,8 +33,8 @@ impl StageId {
         StageId::StorageHashing,
         StageId::MerkleExecute,
         StageId::TransactionLookup,
-        StageId::IndexStorageHistories,
-        StageId::IndexAccountHistories,
+        StageId::IndexStoragesHistory,
+        StageId::IndexAccountsHistory,
         StageId::Finish,
     ];
 
@@ -51,8 +51,8 @@ impl StageId {
             StageId::StorageHashing => "StorageHashing",
             StageId::MerkleExecute => "MerkleExecute",
             StageId::TransactionLookup => "TransactionLookup",
-            StageId::IndexAccountHistories => "IndexAccountHistories",
-            StageId::IndexStorageHistories => "IndexStorageHistories",
+            StageId::IndexAccountsHistory => "IndexAccountsHistory",
+            StageId::IndexStoragesHistory => "IndexStoragesHistory",
             StageId::Finish => "Finish",
             StageId::Other(s) => s,
         }
@@ -90,8 +90,8 @@ mod tests {
         assert_eq!(StageId::AccountHashing.to_string(), "AccountHashing");
         assert_eq!(StageId::StorageHashing.to_string(), "StorageHashing");
         assert_eq!(StageId::MerkleExecute.to_string(), "MerkleExecute");
-        assert_eq!(StageId::IndexAccountHistories.to_string(), "IndexAccountHistories");
-        assert_eq!(StageId::IndexStorageHistories.to_string(), "IndexStorageHistories");
+        assert_eq!(StageId::IndexAccountsHistory.to_string(), "IndexAccountsHistory");
+        assert_eq!(StageId::IndexStoragesHistory.to_string(), "IndexStoragesHistory");
         assert_eq!(StageId::TransactionLookup.to_string(), "TransactionLookup");
         assert_eq!(StageId::Finish.to_string(), "Finish");
 

--- a/crates/primitives/src/storage.rs
+++ b/crates/primitives/src/storage.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 /// Account storage entry.
 ///
-/// `key` is the subkey when used as a value in the `StorageChangeSet` table.
+/// `key` is the subkey when used as a value in the `StorageChangeSets` table.
 #[derive_arbitrary(compact)]
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord)]
 pub struct StorageEntry {

--- a/crates/prune/src/pruner.rs
+++ b/crates/prune/src/pruner.rs
@@ -753,7 +753,7 @@ impl<DB: Database> Pruner<DB> {
         let range_end = *range.end();
 
         let mut last_changeset_pruned_block = None;
-        let (rows, done) = provider.prune_table_with_range::<tables::StorageChangeSet>(
+        let (rows, done) = provider.prune_table_with_range::<tables::StorageChangeSets>(
             BlockNumberAddress::range(range),
             self.batch_sizes.storage_history(self.min_block_interval),
             |_| false,
@@ -1381,7 +1381,7 @@ mod tests {
         assert!(storage_occurences.into_iter().any(|(_, occurrences)| occurrences > 1));
 
         assert_eq!(
-            tx.table::<tables::StorageChangeSet>().unwrap().len(),
+            tx.table::<tables::StorageChangeSets>().unwrap().len(),
             changesets.iter().flatten().flat_map(|(_, _, entries)| entries).count()
         );
 
@@ -1446,7 +1446,7 @@ mod tests {
             );
 
             assert_eq!(
-                tx.table::<tables::StorageChangeSet>().unwrap().len(),
+                tx.table::<tables::StorageChangeSets>().unwrap().len(),
                 pruned_changesets.values().flatten().count()
             );
 

--- a/crates/prune/src/pruner.rs
+++ b/crates/prune/src/pruner.rs
@@ -599,11 +599,12 @@ impl<DB: Database> Pruner<DB> {
         }
 
         let mut last_pruned_transaction = tx_range_end;
-        let (deleted, done) = provider.prune_table_with_iterator::<tables::TransactionHashNumbers>(
-            hashes,
-            self.batch_sizes.transaction_lookup(self.min_block_interval),
-            |row| last_pruned_transaction = row.1,
-        )?;
+        let (deleted, done) = provider
+            .prune_table_with_iterator::<tables::TransactionHashNumbers>(
+                hashes,
+                self.batch_sizes.transaction_lookup(self.min_block_interval),
+                |row| last_pruned_transaction = row.1,
+            )?;
         trace!(target: "pruner", %deleted, %done, "Pruned transaction lookup");
 
         let last_pruned_block = provider

--- a/crates/stages/benches/setup/mod.rs
+++ b/crates/stages/benches/setup/mod.rs
@@ -173,7 +173,10 @@ pub(crate) fn txs_testdata(num_blocks: u64) -> PathBuf {
         // initialize TD
         tx.commit(|tx| {
             let (head, _) = tx.cursor_read::<tables::Headers>()?.first()?.unwrap_or_default();
-            tx.put::<tables::HeaderTerminalDifficulties>(head, reth_primitives::U256::from(0).into())
+            tx.put::<tables::HeaderTerminalDifficulties>(
+                head,
+                reth_primitives::U256::from(0).into(),
+            )
         })
         .unwrap();
     }

--- a/crates/stages/benches/setup/mod.rs
+++ b/crates/stages/benches/setup/mod.rs
@@ -173,7 +173,7 @@ pub(crate) fn txs_testdata(num_blocks: u64) -> PathBuf {
         // initialize TD
         tx.commit(|tx| {
             let (head, _) = tx.cursor_read::<tables::Headers>()?.first()?.unwrap_or_default();
-            tx.put::<tables::HeaderTD>(head, reth_primitives::U256::from(0).into())
+            tx.put::<tables::HeaderTerminalDifficulties>(head, reth_primitives::U256::from(0).into())
         })
         .unwrap();
     }

--- a/crates/stages/src/sets.rs
+++ b/crates/stages/src/sets.rs
@@ -39,7 +39,7 @@
 use crate::{
     stages::{
         AccountHashingStage, BodyStage, ExecutionStage, FinishStage, HeaderStage, HeaderSyncMode,
-        IndexAccountHistoryStage, IndexStorageHistoryStage, MerkleStage, SenderRecoveryStage,
+        IndexAccountHistoriesStage, IndexStorageHistoriesStage, MerkleStage, SenderRecoveryStage,
         StorageHashingStage, TotalDifficultyStage, TransactionLookupStage,
     },
     StageSet, StageSetBuilder,
@@ -71,8 +71,8 @@ use std::sync::Arc;
 /// - [`StorageHashingStage`]
 /// - [`MerkleStage`] (execute)
 /// - [`TransactionLookupStage`]
-/// - [`IndexStorageHistoryStage`]
-/// - [`IndexAccountHistoryStage`]
+/// - [`IndexStorageHistoriesStage`]
+/// - [`IndexAccountHistoriesStage`]
 /// - [`FinishStage`]
 #[derive(Debug)]
 pub struct DefaultStages<H, B, EF> {
@@ -276,7 +276,7 @@ impl<DB: Database> StageSet<DB> for HistoryIndexingStages {
     fn builder(self) -> StageSetBuilder<DB> {
         StageSetBuilder::default()
             .add_stage(TransactionLookupStage::default())
-            .add_stage(IndexStorageHistoryStage::default())
-            .add_stage(IndexAccountHistoryStage::default())
+            .add_stage(IndexStorageHistoriesStage::default())
+            .add_stage(IndexAccountHistoriesStage::default())
     }
 }

--- a/crates/stages/src/sets.rs
+++ b/crates/stages/src/sets.rs
@@ -39,7 +39,7 @@
 use crate::{
     stages::{
         AccountHashingStage, BodyStage, ExecutionStage, FinishStage, HeaderStage, HeaderSyncMode,
-        IndexAccountHistoriesStage, IndexStorageHistoriesStage, MerkleStage, SenderRecoveryStage,
+        IndexAccountsHistoryStage, IndexStoragesHistoryStage, MerkleStage, SenderRecoveryStage,
         StorageHashingStage, TotalDifficultyStage, TransactionLookupStage,
     },
     StageSet, StageSetBuilder,
@@ -71,8 +71,8 @@ use std::sync::Arc;
 /// - [`StorageHashingStage`]
 /// - [`MerkleStage`] (execute)
 /// - [`TransactionLookupStage`]
-/// - [`IndexStorageHistoriesStage`]
-/// - [`IndexAccountHistoriesStage`]
+/// - [`IndexStoragesHistoryStage`]
+/// - [`IndexAccountsHistoryStage`]
 /// - [`FinishStage`]
 #[derive(Debug)]
 pub struct DefaultStages<H, B, EF> {
@@ -276,7 +276,7 @@ impl<DB: Database> StageSet<DB> for HistoryIndexingStages {
     fn builder(self) -> StageSetBuilder<DB> {
         StageSetBuilder::default()
             .add_stage(TransactionLookupStage::default())
-            .add_stage(IndexStorageHistoriesStage::default())
-            .add_stage(IndexAccountHistoriesStage::default())
+            .add_stage(IndexStoragesHistoryStage::default())
+            .add_stage(IndexAccountsHistoryStage::default())
     }
 }

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -38,7 +38,7 @@ use tracing::*;
 /// - [`BlockOmmers`][reth_db::tables::BlockOmmers]
 /// - [`BlockBodies`][reth_db::tables::BlockBodyIndices]
 /// - [`Transactions`][reth_db::tables::Transactions]
-/// - [`TransactionBlock`][reth_db::tables::TransactionBlock]
+/// - [`TransactionBlocks`][reth_db::tables::TransactionBlocks]
 ///
 /// # Genesis
 ///
@@ -83,7 +83,7 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
         let tx = provider.tx_ref();
         let mut block_indices_cursor = tx.cursor_write::<tables::BlockBodyIndices>()?;
         let mut tx_cursor = tx.cursor_write::<tables::Transactions>()?;
-        let mut tx_block_cursor = tx.cursor_write::<tables::TransactionBlock>()?;
+        let mut tx_block_cursor = tx.cursor_write::<tables::TransactionBlocks>()?;
         let mut ommers_cursor = tx.cursor_write::<tables::BlockOmmers>()?;
         let mut withdrawals_cursor = tx.cursor_write::<tables::BlockWithdrawals>()?;
 
@@ -173,7 +173,7 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
         let mut ommers_cursor = tx.cursor_write::<tables::BlockOmmers>()?;
         let mut withdrawals_cursor = tx.cursor_write::<tables::BlockWithdrawals>()?;
         // Cursors to unwind transitions
-        let mut tx_block_cursor = tx.cursor_write::<tables::TransactionBlock>()?;
+        let mut tx_block_cursor = tx.cursor_write::<tables::TransactionBlocks>()?;
 
         let mut rev_walker = body_cursor.walk_back(None)?;
         while let Some((number, block_meta)) = rev_walker.next().transpose()? {
@@ -573,7 +573,7 @@ mod tests {
                         })?;
 
                         if body.tx_count != 0 {
-                            tx.put::<tables::TransactionBlock>(
+                            tx.put::<tables::TransactionBlocks>(
                                 body.first_tx_num(),
                                 progress.number,
                             )?;
@@ -619,7 +619,7 @@ mod tests {
                 if let Some(last_tx_id) = self.get_last_tx_id()? {
                     self.tx
                         .ensure_no_entry_above::<tables::Transactions, _>(last_tx_id, |key| key)?;
-                    self.tx.ensure_no_entry_above::<tables::TransactionBlock, _>(
+                    self.tx.ensure_no_entry_above::<tables::TransactionBlocks, _>(
                         last_tx_id,
                         |key| key,
                     )?;
@@ -655,7 +655,7 @@ mod tests {
                     let mut bodies_cursor = tx.cursor_read::<tables::BlockBodyIndices>()?;
                     let mut ommers_cursor = tx.cursor_read::<tables::BlockOmmers>()?;
                     let mut transaction_cursor = tx.cursor_read::<tables::Transactions>()?;
-                    let mut tx_block_cursor = tx.cursor_read::<tables::TransactionBlock>()?;
+                    let mut tx_block_cursor = tx.cursor_read::<tables::TransactionBlocks>()?;
 
                     let first_body_key = match bodies_cursor.first()? {
                         Some((key, _)) => key,

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -45,7 +45,7 @@ use tracing::*;
 /// - [tables::PlainStorageState]
 /// - [tables::Bytecodes]
 /// - [tables::AccountChangeSets]
-/// - [tables::StorageChangeSet]
+/// - [tables::StorageChangeSets]
 ///
 /// For unwinds we are accessing:
 /// - [tables::BlockBodyIndices] get tx index to know what needs to be unwinded
@@ -348,7 +348,7 @@ impl<EF: ExecutorFactory, DB: Database> Stage<DB> for ExecutionStage<EF> {
         let tx = provider.tx_ref();
         // Acquire changeset cursors
         let mut account_changeset = tx.cursor_dup_write::<tables::AccountChangeSets>()?;
-        let mut storage_changeset = tx.cursor_dup_write::<tables::StorageChangeSet>()?;
+        let mut storage_changeset = tx.cursor_dup_write::<tables::StorageChangeSets>()?;
 
         let (range, unwind_to, _) =
             input.unwind_block_range_with_threshold(self.thresholds.max_blocks.unwrap_or(u64::MAX));
@@ -911,7 +911,7 @@ mod tests {
         assert!(plain_storage.is_empty());
 
         let account_changesets = test_tx.table::<tables::AccountChangeSets>().unwrap();
-        let storage_changesets = test_tx.table::<tables::StorageChangeSet>().unwrap();
+        let storage_changesets = test_tx.table::<tables::StorageChangeSets>().unwrap();
 
         assert_eq!(
             account_changesets,

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -50,7 +50,8 @@ use tracing::*;
 /// For unwinds we are accessing:
 /// - [tables::BlockBodyIndices] get tx index to know what needs to be unwinded
 /// - [tables::AccountHistories] to remove change set and apply old values to
-/// - [tables::PlainAccountState] [tables::StorageHistories] to remove change set and apply old values
+/// - [tables::PlainAccountState] [tables::StorageHistories] to remove change set and apply old
+///   values
 /// to [tables::PlainStorageState]
 // false positive, we cannot derive it if !DB: Debug.
 #[allow(missing_debug_implementations)]

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -49,8 +49,8 @@ use tracing::*;
 ///
 /// For unwinds we are accessing:
 /// - [tables::BlockBodyIndices] get tx index to know what needs to be unwinded
-/// - [tables::AccountHistories] to remove change set and apply old values to
-/// - [tables::PlainAccountState] [tables::StorageHistories] to remove change set and apply old
+/// - [tables::AccountsHistory] to remove change set and apply old values to
+/// - [tables::PlainAccountState] [tables::StoragesHistory] to remove change set and apply old
 ///   values
 /// to [tables::PlainStorageState]
 // false positive, we cannot derive it if !DB: Debug.

--- a/crates/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/src/stages/hashing_storage.rs
@@ -505,7 +505,10 @@ mod tests {
                 self.tx.commit(|tx| {
                     progress.body.iter().try_for_each(
                         |transaction| -> Result<(), reth_db::DatabaseError> {
-                            tx.put::<tables::TransactionHashNumbers>(transaction.hash(), next_tx_num)?;
+                            tx.put::<tables::TransactionHashNumbers>(
+                                transaction.hash(),
+                                next_tx_num,
+                            )?;
                             tx.put::<tables::Transactions>(
                                 next_tx_num,
                                 transaction.clone().into(),

--- a/crates/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/src/stages/hashing_storage.rs
@@ -655,7 +655,7 @@ mod tests {
                 tx.put::<tables::HashedStorages>(hashed_address, hashed_entry)?;
             }
 
-            tx.put::<tables::StorageChangeSet>(tid_address, prev_entry)?;
+            tx.put::<tables::StorageChangeSets>(tid_address, prev_entry)?;
             Ok(())
         }
 
@@ -664,7 +664,7 @@ mod tests {
             let target_block = input.unwind_to;
             self.tx.commit(|tx| {
                 let mut storage_cursor = tx.cursor_dup_write::<tables::PlainStorageState>()?;
-                let mut changeset_cursor = tx.cursor_dup_read::<tables::StorageChangeSet>()?;
+                let mut changeset_cursor = tx.cursor_dup_read::<tables::StorageChangeSets>()?;
 
                 let mut rev_changeset_walker = changeset_cursor.walk_back(None)?;
 

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -455,7 +455,9 @@ mod tests {
                 let head = random_header(&mut rng, start, None);
                 self.tx.insert_headers(std::iter::once(&head))?;
                 // patch td table for `update_head` call
-                self.tx.commit(|tx| tx.put::<tables::HeaderTerminalDifficulties>(head.number, U256::ZERO.into()))?;
+                self.tx.commit(|tx| {
+                    tx.put::<tables::HeaderTerminalDifficulties>(head.number, U256::ZERO.into())
+                })?;
 
                 // use previous checkpoint as seed size
                 let end = input.target.unwrap_or_default() + 1;

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -455,7 +455,7 @@ mod tests {
                 let head = random_header(&mut rng, start, None);
                 self.tx.insert_headers(std::iter::once(&head))?;
                 // patch td table for `update_head` call
-                self.tx.commit(|tx| tx.put::<tables::HeaderTD>(head.number, U256::ZERO.into()))?;
+                self.tx.commit(|tx| tx.put::<tables::HeaderTerminalDifficulties>(head.number, U256::ZERO.into()))?;
 
                 // use previous checkpoint as seed size
                 let end = input.target.unwrap_or_default() + 1;

--- a/crates/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/src/stages/index_storage_history.rs
@@ -11,9 +11,9 @@ use std::fmt::Debug;
 
 /// Stage is indexing history the account changesets generated in
 /// [`ExecutionStage`][crate::stages::ExecutionStage]. For more information
-/// on index sharding take a look at [`reth_db::tables::StorageHistories`].
+/// on index sharding take a look at [`reth_db::tables::StoragesHistory`].
 #[derive(Debug)]
-pub struct IndexStorageHistoriesStage {
+pub struct IndexStoragesHistoryStage {
     /// Number of blocks after which the control
     /// flow will be returned to the pipeline for commit.
     pub commit_threshold: u64,
@@ -21,24 +21,24 @@ pub struct IndexStorageHistoriesStage {
     pub prune_modes: PruneModes,
 }
 
-impl IndexStorageHistoriesStage {
-    /// Create new instance of [IndexStorageHistoriesStage].
+impl IndexStoragesHistoryStage {
+    /// Create new instance of [IndexStoragesHistoryStage].
     pub fn new(commit_threshold: u64, prune_modes: PruneModes) -> Self {
         Self { commit_threshold, prune_modes }
     }
 }
 
-impl Default for IndexStorageHistoriesStage {
+impl Default for IndexStoragesHistoryStage {
     fn default() -> Self {
         Self { commit_threshold: 100_000, prune_modes: PruneModes::none() }
     }
 }
 
 #[async_trait::async_trait]
-impl<DB: Database> Stage<DB> for IndexStorageHistoriesStage {
+impl<DB: Database> Stage<DB> for IndexStoragesHistoryStage {
     /// Return the id of the stage
     fn id(&self) -> StageId {
-        StageId::IndexStorageHistories
+        StageId::IndexStoragesHistory
     }
 
     /// Execute the stage.
@@ -55,9 +55,9 @@ impl<DB: Database> Stage<DB> for IndexStorageHistoriesStage {
 
                 // Save prune checkpoint only if we don't have one already.
                 // Otherwise, pruner may skip the unpruned range of blocks.
-                if provider.get_prune_checkpoint(PrunePart::StorageHistories)?.is_none() {
+                if provider.get_prune_checkpoint(PrunePart::StoragesHistory)?.is_none() {
                     provider.save_prune_checkpoint(
-                        PrunePart::StorageHistories,
+                        PrunePart::StoragesHistory,
                         PruneCheckpoint {
                             block_number: Some(target_prunable_block),
                             tx_number: None,
@@ -188,7 +188,7 @@ mod tests {
 
     async fn run(tx: &TestTransaction, run_to: u64) {
         let input = ExecInput { target: Some(run_to), ..Default::default() };
-        let mut stage = IndexStorageHistoriesStage::default();
+        let mut stage = IndexStoragesHistoryStage::default();
         let factory = ProviderFactory::new(tx.tx.as_ref(), MAINNET.clone());
         let provider = factory.provider_rw().unwrap();
         let out = stage.execute(&provider, input).await.unwrap();
@@ -202,7 +202,7 @@ mod tests {
             unwind_to,
             ..Default::default()
         };
-        let mut stage = IndexStorageHistoriesStage::default();
+        let mut stage = IndexStoragesHistoryStage::default();
         let factory = ProviderFactory::new(tx.tx.as_ref(), MAINNET.clone());
         let provider = factory.provider_rw().unwrap();
         let out = stage.unwind(&provider, input).await.unwrap();
@@ -222,14 +222,14 @@ mod tests {
         run(&tx, 5).await;
 
         // verify
-        let table = cast(tx.table::<tables::StorageHistories>().unwrap());
+        let table = cast(tx.table::<tables::StoragesHistory>().unwrap());
         assert_eq!(table, BTreeMap::from([(shard(u64::MAX), vec![4, 5]),]));
 
         // unwind
         unwind(&tx, 5, 0).await;
 
         // verify initial state
-        let table = tx.table::<tables::StorageHistories>().unwrap();
+        let table = tx.table::<tables::StoragesHistory>().unwrap();
         assert!(table.is_empty());
     }
 
@@ -241,7 +241,7 @@ mod tests {
         // setup
         partial_setup(&tx);
         tx.commit(|tx| {
-            tx.put::<tables::StorageHistories>(shard(u64::MAX), list(&[1, 2, 3])).unwrap();
+            tx.put::<tables::StoragesHistory>(shard(u64::MAX), list(&[1, 2, 3])).unwrap();
             Ok(())
         })
         .unwrap();
@@ -250,14 +250,14 @@ mod tests {
         run(&tx, 5).await;
 
         // verify
-        let table = cast(tx.table::<tables::StorageHistories>().unwrap());
+        let table = cast(tx.table::<tables::StoragesHistory>().unwrap());
         assert_eq!(table, BTreeMap::from([(shard(u64::MAX), vec![1, 2, 3, 4, 5]),]));
 
         // unwind
         unwind(&tx, 5, 0).await;
 
         // verify initial state
-        let table = cast(tx.table::<tables::StorageHistories>().unwrap());
+        let table = cast(tx.table::<tables::StoragesHistory>().unwrap());
         assert_eq!(table, BTreeMap::from([(shard(u64::MAX), vec![1, 2, 3]),]));
     }
 
@@ -273,7 +273,7 @@ mod tests {
         // setup
         partial_setup(&tx);
         tx.commit(|tx| {
-            tx.put::<tables::StorageHistories>(shard(u64::MAX), list(&full_list)).unwrap();
+            tx.put::<tables::StoragesHistory>(shard(u64::MAX), list(&full_list)).unwrap();
             Ok(())
         })
         .unwrap();
@@ -282,7 +282,7 @@ mod tests {
         run(&tx, 5).await;
 
         // verify
-        let table = cast(tx.table::<tables::StorageHistories>().unwrap());
+        let table = cast(tx.table::<tables::StoragesHistory>().unwrap());
         assert_eq!(
             table,
             BTreeMap::from([(shard(3), full_list.clone()), (shard(u64::MAX), vec![4, 5])])
@@ -292,7 +292,7 @@ mod tests {
         unwind(&tx, 5, 0).await;
 
         // verify initial state
-        let table = cast(tx.table::<tables::StorageHistories>().unwrap());
+        let table = cast(tx.table::<tables::StoragesHistory>().unwrap());
         assert_eq!(table, BTreeMap::from([(shard(u64::MAX), full_list)]));
     }
 
@@ -305,7 +305,7 @@ mod tests {
         // setup
         partial_setup(&tx);
         tx.commit(|tx| {
-            tx.put::<tables::StorageHistories>(shard(u64::MAX), list(&close_full_list)).unwrap();
+            tx.put::<tables::StoragesHistory>(shard(u64::MAX), list(&close_full_list)).unwrap();
             Ok(())
         })
         .unwrap();
@@ -316,7 +316,7 @@ mod tests {
         // verify
         close_full_list.push(4);
         close_full_list.push(5);
-        let table = cast(tx.table::<tables::StorageHistories>().unwrap());
+        let table = cast(tx.table::<tables::StoragesHistory>().unwrap());
         assert_eq!(table, BTreeMap::from([(shard(u64::MAX), close_full_list.clone()),]));
 
         // unwind
@@ -325,7 +325,7 @@ mod tests {
         // verify initial state
         close_full_list.pop();
         close_full_list.pop();
-        let table = cast(tx.table::<tables::StorageHistories>().unwrap());
+        let table = cast(tx.table::<tables::StoragesHistory>().unwrap());
         assert_eq!(table, BTreeMap::from([(shard(u64::MAX), close_full_list),]));
 
         // verify initial state
@@ -340,7 +340,7 @@ mod tests {
         // setup
         partial_setup(&tx);
         tx.commit(|tx| {
-            tx.put::<tables::StorageHistories>(shard(u64::MAX), list(&close_full_list)).unwrap();
+            tx.put::<tables::StoragesHistory>(shard(u64::MAX), list(&close_full_list)).unwrap();
             Ok(())
         })
         .unwrap();
@@ -350,7 +350,7 @@ mod tests {
 
         // verify
         close_full_list.push(4);
-        let table = cast(tx.table::<tables::StorageHistories>().unwrap());
+        let table = cast(tx.table::<tables::StoragesHistory>().unwrap());
         assert_eq!(
             table,
             BTreeMap::from([(shard(4), close_full_list.clone()), (shard(u64::MAX), vec![5])])
@@ -361,7 +361,7 @@ mod tests {
 
         // verify initial state
         close_full_list.pop();
-        let table = cast(tx.table::<tables::StorageHistories>().unwrap());
+        let table = cast(tx.table::<tables::StoragesHistory>().unwrap());
         assert_eq!(table, BTreeMap::from([(shard(u64::MAX), close_full_list),]));
     }
 
@@ -374,9 +374,9 @@ mod tests {
         // setup
         partial_setup(&tx);
         tx.commit(|tx| {
-            tx.put::<tables::StorageHistories>(shard(1), list(&full_list)).unwrap();
-            tx.put::<tables::StorageHistories>(shard(2), list(&full_list)).unwrap();
-            tx.put::<tables::StorageHistories>(shard(u64::MAX), list(&[2, 3])).unwrap();
+            tx.put::<tables::StoragesHistory>(shard(1), list(&full_list)).unwrap();
+            tx.put::<tables::StoragesHistory>(shard(2), list(&full_list)).unwrap();
+            tx.put::<tables::StoragesHistory>(shard(u64::MAX), list(&[2, 3])).unwrap();
             Ok(())
         })
         .unwrap();
@@ -384,7 +384,7 @@ mod tests {
         run(&tx, 5).await;
 
         // verify
-        let table = cast(tx.table::<tables::StorageHistories>().unwrap());
+        let table = cast(tx.table::<tables::StoragesHistory>().unwrap());
         assert_eq!(
             table,
             BTreeMap::from([
@@ -398,7 +398,7 @@ mod tests {
         unwind(&tx, 5, 0).await;
 
         // verify initial state
-        let table = cast(tx.table::<tables::StorageHistories>().unwrap());
+        let table = cast(tx.table::<tables::StoragesHistory>().unwrap());
         assert_eq!(
             table,
             BTreeMap::from([
@@ -439,7 +439,7 @@ mod tests {
 
         // run
         let input = ExecInput { target: Some(100), ..Default::default() };
-        let mut stage = IndexStorageHistoriesStage {
+        let mut stage = IndexStoragesHistoryStage {
             prune_modes: PruneModes {
                 storage_history: Some(PruneMode::Before(36)),
                 ..Default::default()
@@ -453,26 +453,26 @@ mod tests {
         provider.commit().unwrap();
 
         // verify
-        let table = cast(tx.table::<tables::StorageHistories>().unwrap());
+        let table = cast(tx.table::<tables::StoragesHistory>().unwrap());
         assert_eq!(table, BTreeMap::from([(shard(u64::MAX), vec![36, 100]),]));
 
         // unwind
         unwind(&tx, 100, 0).await;
 
         // verify initial state
-        let table = tx.table::<tables::StorageHistories>().unwrap();
+        let table = tx.table::<tables::StoragesHistory>().unwrap();
         assert!(table.is_empty());
     }
 
-    stage_test_suite_ext!(IndexStorageHistoriesTestRunner, index_storage_history);
+    stage_test_suite_ext!(IndexStoragesHistoryTestRunner, index_storage_history);
 
-    struct IndexStorageHistoriesTestRunner {
+    struct IndexStoragesHistoryTestRunner {
         pub(crate) tx: TestTransaction,
         commit_threshold: u64,
         prune_modes: PruneModes,
     }
 
-    impl Default for IndexStorageHistoriesTestRunner {
+    impl Default for IndexStoragesHistoryTestRunner {
         fn default() -> Self {
             Self {
                 tx: TestTransaction::default(),
@@ -482,8 +482,8 @@ mod tests {
         }
     }
 
-    impl StageTestRunner for IndexStorageHistoriesTestRunner {
-        type S = IndexStorageHistoriesStage;
+    impl StageTestRunner for IndexStoragesHistoryTestRunner {
+        type S = IndexStoragesHistoryStage;
 
         fn tx(&self) -> &TestTransaction {
             &self.tx
@@ -497,7 +497,7 @@ mod tests {
         }
     }
 
-    impl ExecuteStageTestRunner for IndexStorageHistoriesTestRunner {
+    impl ExecuteStageTestRunner for IndexStoragesHistoryTestRunner {
         type Seed = ();
 
         fn seed_execution(&mut self, input: ExecInput) -> Result<Self::Seed, TestRunnerError> {
@@ -595,16 +595,16 @@ mod tests {
                     };
                 }
 
-                let table = cast(self.tx.table::<tables::StorageHistories>().unwrap());
+                let table = cast(self.tx.table::<tables::StoragesHistory>().unwrap());
                 assert_eq!(table, result);
             }
             Ok(())
         }
     }
 
-    impl UnwindStageTestRunner for IndexStorageHistoriesTestRunner {
+    impl UnwindStageTestRunner for IndexStoragesHistoryTestRunner {
         fn validate_unwind(&self, _input: UnwindInput) -> Result<(), TestRunnerError> {
-            let table = self.tx.table::<tables::StorageHistories>().unwrap();
+            let table = self.tx.table::<tables::StoragesHistory>().unwrap();
             assert!(table.is_empty());
             Ok(())
         }

--- a/crates/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/src/stages/index_storage_history.rs
@@ -179,8 +179,8 @@ mod tests {
             .unwrap();
 
             // setup changeset that are going to be applied to history index
-            tx.put::<tables::StorageChangeSet>(trns(4), storage(STORAGE_KEY)).unwrap();
-            tx.put::<tables::StorageChangeSet>(trns(5), storage(STORAGE_KEY)).unwrap();
+            tx.put::<tables::StorageChangeSets>(trns(4), storage(STORAGE_KEY)).unwrap();
+            tx.put::<tables::StorageChangeSets>(trns(5), storage(STORAGE_KEY)).unwrap();
             Ok(())
         })
         .unwrap()
@@ -430,9 +430,9 @@ mod tests {
             .unwrap();
 
             // setup changeset that are going to be applied to history index
-            tx.put::<tables::StorageChangeSet>(trns(20), storage(STORAGE_KEY)).unwrap();
-            tx.put::<tables::StorageChangeSet>(trns(36), storage(STORAGE_KEY)).unwrap();
-            tx.put::<tables::StorageChangeSet>(trns(100), storage(STORAGE_KEY)).unwrap();
+            tx.put::<tables::StorageChangeSets>(trns(20), storage(STORAGE_KEY)).unwrap();
+            tx.put::<tables::StorageChangeSets>(trns(36), storage(STORAGE_KEY)).unwrap();
+            tx.put::<tables::StorageChangeSets>(trns(100), storage(STORAGE_KEY)).unwrap();
             Ok(())
         })
         .unwrap();
@@ -546,7 +546,7 @@ mod tests {
 
                 let provider = self.tx.inner();
                 let mut changeset_cursor =
-                    provider.tx_ref().cursor_read::<tables::StorageChangeSet>()?;
+                    provider.tx_ref().cursor_read::<tables::StorageChangeSets>()?;
 
                 let storage_transitions = changeset_cursor
                     .walk_range(BlockNumberAddress::range(start_block..=end_block))?

--- a/crates/stages/src/stages/merkle.rs
+++ b/crates/stages/src/stages/merkle.rs
@@ -570,7 +570,7 @@ mod tests {
             self.tx
                 .commit(|tx| {
                     let mut storage_changesets_cursor =
-                        tx.cursor_dup_read::<tables::StorageChangeSet>().unwrap();
+                        tx.cursor_dup_read::<tables::StorageChangeSets>().unwrap();
                     let mut storage_cursor =
                         tx.cursor_dup_write::<tables::HashedStorages>().unwrap();
 

--- a/crates/stages/src/stages/merkle.rs
+++ b/crates/stages/src/stages/merkle.rs
@@ -207,8 +207,8 @@ impl<DB: Database> Stage<DB> for MerkleStage {
             }
             .unwrap_or(EntitiesCheckpoint {
                 processed: 0,
-                total: (provider.tx_ref().entries::<tables::HashedAccount>()? +
-                    provider.tx_ref().entries::<tables::HashedStorage>()?)
+                total: (provider.tx_ref().entries::<tables::HashedAccounts>()? +
+                    provider.tx_ref().entries::<tables::HashedStorages>()?)
                     as u64,
             });
 
@@ -254,8 +254,8 @@ impl<DB: Database> Stage<DB> for MerkleStage {
                     .map_err(|e| StageError::Fatal(Box::new(e)))?;
             updates.flush(provider.tx_ref())?;
 
-            let total_hashed_entries = (provider.tx_ref().entries::<tables::HashedAccount>()? +
-                provider.tx_ref().entries::<tables::HashedStorage>()?)
+            let total_hashed_entries = (provider.tx_ref().entries::<tables::HashedAccounts>()? +
+                provider.tx_ref().entries::<tables::HashedStorages>()?)
                 as u64;
 
             let entities_checkpoint = EntitiesCheckpoint {
@@ -297,8 +297,8 @@ impl<DB: Database> Stage<DB> for MerkleStage {
         let mut entities_checkpoint =
             input.checkpoint.entities_stage_checkpoint().unwrap_or(EntitiesCheckpoint {
                 processed: 0,
-                total: (tx.entries::<tables::HashedAccount>()? +
-                    tx.entries::<tables::HashedStorage>()?) as u64,
+                total: (tx.entries::<tables::HashedAccounts>()? +
+                    tx.entries::<tables::HashedStorages>()?) as u64,
             });
 
         if input.unwind_to == 0 {
@@ -395,8 +395,8 @@ mod tests {
                 done: true
             }) if block_number == previous_stage && processed == total &&
                 total == (
-                    runner.tx.table::<tables::HashedAccount>().unwrap().len() +
-                    runner.tx.table::<tables::HashedStorage>().unwrap().len()
+                    runner.tx.table::<tables::HashedAccounts>().unwrap().len() +
+                    runner.tx.table::<tables::HashedStorages>().unwrap().len()
                 ) as u64
         );
 
@@ -435,8 +435,8 @@ mod tests {
                 done: true
             }) if block_number == previous_stage && processed == total &&
                 total == (
-                    runner.tx.table::<tables::HashedAccount>().unwrap().len() +
-                    runner.tx.table::<tables::HashedStorage>().unwrap().len()
+                    runner.tx.table::<tables::HashedAccounts>().unwrap().len() +
+                    runner.tx.table::<tables::HashedStorages>().unwrap().len()
                 ) as u64
         );
 
@@ -517,8 +517,8 @@ mod tests {
             // Calculate state root
             let root = self.tx.query(|tx| {
                 let mut accounts = BTreeMap::default();
-                let mut accounts_cursor = tx.cursor_read::<tables::HashedAccount>()?;
-                let mut storage_cursor = tx.cursor_dup_read::<tables::HashedStorage>()?;
+                let mut accounts_cursor = tx.cursor_read::<tables::HashedAccounts>()?;
+                let mut storage_cursor = tx.cursor_dup_read::<tables::HashedStorages>()?;
                 for entry in accounts_cursor.walk_range(..)? {
                     let (key, account) = entry?;
                     let mut storage_entries = Vec::new();
@@ -572,7 +572,7 @@ mod tests {
                     let mut storage_changesets_cursor =
                         tx.cursor_dup_read::<tables::StorageChangeSet>().unwrap();
                     let mut storage_cursor =
-                        tx.cursor_dup_write::<tables::HashedStorage>().unwrap();
+                        tx.cursor_dup_write::<tables::HashedStorages>().unwrap();
 
                     let mut tree: BTreeMap<H256, BTreeMap<H256, U256>> = BTreeMap::new();
 
@@ -606,7 +606,7 @@ mod tests {
                     }
 
                     let mut changeset_cursor =
-                        tx.cursor_dup_write::<tables::AccountChangeSet>().unwrap();
+                        tx.cursor_dup_write::<tables::AccountChangeSets>().unwrap();
                     let mut rev_changeset_walker = changeset_cursor.walk_back(None).unwrap();
 
                     while let Some((block_number, account_before_tx)) =
@@ -617,13 +617,13 @@ mod tests {
                         }
 
                         if let Some(acc) = account_before_tx.info {
-                            tx.put::<tables::HashedAccount>(
+                            tx.put::<tables::HashedAccounts>(
                                 keccak256(account_before_tx.address),
                                 acc,
                             )
                             .unwrap();
                         } else {
-                            tx.delete::<tables::HashedAccount>(
+                            tx.delete::<tables::HashedAccounts>(
                                 keccak256(account_before_tx.address),
                                 None,
                             )

--- a/crates/stages/src/stages/mod.rs
+++ b/crates/stages/src/stages/mod.rs
@@ -155,8 +155,10 @@ mod tests {
             );
 
             // Check AccountHistories
-            let mut acc_indexing_stage =
-                IndexAccountHistoriesStage { prune_modes: prune_modes.clone(), ..Default::default() };
+            let mut acc_indexing_stage = IndexAccountHistoriesStage {
+                prune_modes: prune_modes.clone(),
+                ..Default::default()
+            };
 
             if let Some(PruneMode::Full) = prune_modes.account_history {
                 // Full is not supported
@@ -169,8 +171,10 @@ mod tests {
             }
 
             // Check StorageHistories
-            let mut storage_indexing_stage =
-                IndexStorageHistoriesStage { prune_modes: prune_modes.clone(), ..Default::default() };
+            let mut storage_indexing_stage = IndexStorageHistoriesStage {
+                prune_modes: prune_modes.clone(),
+                ..Default::default()
+            };
 
             if let Some(PruneMode::Full) = prune_modes.storage_history {
                 // Full is not supported

--- a/crates/stages/src/stages/mod.rs
+++ b/crates/stages/src/stages/mod.rs
@@ -41,7 +41,7 @@ mod tests {
     use super::*;
     use crate::{
         stage::Stage,
-        stages::{ExecutionStage, IndexAccountHistoriesStage, IndexStorageHistoriesStage},
+        stages::{ExecutionStage, IndexAccountsHistoryStage, IndexStoragesHistoryStage},
         test_utils::TestTransaction,
         ExecInput,
     };
@@ -50,7 +50,7 @@ mod tests {
         mdbx::{cursor::Cursor, RW},
         tables,
         transaction::{DbTx, DbTxMut},
-        AccountHistories, DatabaseEnv,
+        AccountsHistory, DatabaseEnv,
     };
     use reth_interfaces::test_utils::generators::{self, random_block};
     use reth_primitives::{
@@ -154,8 +154,8 @@ mod tests {
                 expect_num_acc_changesets
             );
 
-            // Check AccountHistories
-            let mut acc_indexing_stage = IndexAccountHistoriesStage {
+            // Check AccountsHistory
+            let mut acc_indexing_stage = IndexAccountsHistoryStage {
                 prune_modes: prune_modes.clone(),
                 ..Default::default()
             };
@@ -165,13 +165,13 @@ mod tests {
                 assert!(acc_indexing_stage.execute(&provider, input).await.is_err());
             } else {
                 acc_indexing_stage.execute(&provider, input).await.unwrap();
-                let mut account_history: Cursor<'_, RW, AccountHistories> =
-                    provider.tx_ref().cursor_read::<tables::AccountHistories>().unwrap();
+                let mut account_history: Cursor<'_, RW, AccountsHistory> =
+                    provider.tx_ref().cursor_read::<tables::AccountsHistory>().unwrap();
                 assert_eq!(account_history.walk(None).unwrap().count(), expect_num_acc_changesets);
             }
 
-            // Check StorageHistories
-            let mut storage_indexing_stage = IndexStorageHistoriesStage {
+            // Check StoragesHistory
+            let mut storage_indexing_stage = IndexStoragesHistoryStage {
                 prune_modes: prune_modes.clone(),
                 ..Default::default()
             };
@@ -183,7 +183,7 @@ mod tests {
                 storage_indexing_stage.execute(&provider, input).await.unwrap();
 
                 let mut storage_history =
-                    provider.tx_ref().cursor_read::<tables::StorageHistories>().unwrap();
+                    provider.tx_ref().cursor_read::<tables::StoragesHistory>().unwrap();
                 assert_eq!(
                     storage_history.walk(None).unwrap().count(),
                     expect_num_storage_changesets

--- a/crates/stages/src/stages/mod.rs
+++ b/crates/stages/src/stages/mod.rs
@@ -41,7 +41,7 @@ mod tests {
     use super::*;
     use crate::{
         stage::Stage,
-        stages::{ExecutionStage, IndexAccountHistoryStage, IndexStorageHistoryStage},
+        stages::{ExecutionStage, IndexAccountHistoriesStage, IndexStorageHistoriesStage},
         test_utils::TestTransaction,
         ExecInput,
     };
@@ -50,7 +50,7 @@ mod tests {
         mdbx::{cursor::Cursor, RW},
         tables,
         transaction::{DbTx, DbTxMut},
-        AccountHistory, DatabaseEnv,
+        AccountHistories, DatabaseEnv,
     };
     use reth_interfaces::test_utils::generators::{self, random_block};
     use reth_primitives::{
@@ -154,23 +154,23 @@ mod tests {
                 expect_num_acc_changesets
             );
 
-            // Check AccountHistory
+            // Check AccountHistories
             let mut acc_indexing_stage =
-                IndexAccountHistoryStage { prune_modes: prune_modes.clone(), ..Default::default() };
+                IndexAccountHistoriesStage { prune_modes: prune_modes.clone(), ..Default::default() };
 
             if let Some(PruneMode::Full) = prune_modes.account_history {
                 // Full is not supported
                 assert!(acc_indexing_stage.execute(&provider, input).await.is_err());
             } else {
                 acc_indexing_stage.execute(&provider, input).await.unwrap();
-                let mut account_history: Cursor<'_, RW, AccountHistory> =
-                    provider.tx_ref().cursor_read::<tables::AccountHistory>().unwrap();
+                let mut account_history: Cursor<'_, RW, AccountHistories> =
+                    provider.tx_ref().cursor_read::<tables::AccountHistories>().unwrap();
                 assert_eq!(account_history.walk(None).unwrap().count(), expect_num_acc_changesets);
             }
 
-            // Check StorageHistory
+            // Check StorageHistories
             let mut storage_indexing_stage =
-                IndexStorageHistoryStage { prune_modes: prune_modes.clone(), ..Default::default() };
+                IndexStorageHistoriesStage { prune_modes: prune_modes.clone(), ..Default::default() };
 
             if let Some(PruneMode::Full) = prune_modes.storage_history {
                 // Full is not supported
@@ -179,7 +179,7 @@ mod tests {
                 storage_indexing_stage.execute(&provider, input).await.unwrap();
 
                 let mut storage_history =
-                    provider.tx_ref().cursor_read::<tables::StorageHistory>().unwrap();
+                    provider.tx_ref().cursor_read::<tables::StorageHistories>().unwrap();
                 assert_eq!(
                     storage_history.walk(None).unwrap().count(),
                     expect_num_storage_changesets

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -215,10 +215,11 @@ fn stage_checkpoint<DB: Database>(
         .and_then(|checkpoint| checkpoint.tx_number)
         .unwrap_or_default();
     Ok(EntitiesCheckpoint {
-        // If `TransactionSenders` table was pruned, we will have a number of entries in it not matching
-        // the actual number of processed transactions. To fix that, we add the number of pruned
-        // `TransactionSenders` entries.
-        processed: provider.tx_ref().entries::<tables::TransactionSenders>()? as u64 + pruned_entries,
+        // If `TransactionSenders` table was pruned, we will have a number of entries in it not
+        // matching the actual number of processed transactions. To fix that, we add the
+        // number of pruned `TransactionSenders` entries.
+        processed: provider.tx_ref().entries::<tables::TransactionSenders>()? as u64 +
+            pruned_entries,
         total: provider.tx_ref().entries::<tables::Transactions>()? as u64,
     })
 }
@@ -347,7 +348,8 @@ mod tests {
             ExecOutput {
                 checkpoint: StageCheckpoint::new(expected_progress).with_entities_stage_checkpoint(
                     EntitiesCheckpoint {
-                        processed: runner.tx.table::<tables::TransactionSenders>().unwrap().len() as u64,
+                        processed: runner.tx.table::<tables::TransactionSenders>().unwrap().len()
+                            as u64,
                         total: total_transactions
                     }
                 ),
@@ -452,10 +454,11 @@ mod tests {
 
         /// # Panics
         ///
-        /// 1. If there are any entries in the [tables::TransactionSenders] table above a given block number.
+        /// 1. If there are any entries in the [tables::TransactionSenders] table above a given
+        ///    block number.
         ///
-        /// 2. If the is no requested block entry in the bodies table, but [tables::TransactionSenders] is
-        ///    not empty.
+        /// 2. If the is no requested block entry in the bodies table, but
+        ///    [tables::TransactionSenders] is not empty.
         fn ensure_no_senders_by_block(&self, block: BlockNumber) -> Result<(), TestRunnerError> {
             let body_result = self
                 .tx
@@ -463,9 +466,10 @@ mod tests {
                 .block_body_indices(block)?
                 .ok_or(ProviderError::BlockBodyIndicesNotFound(block));
             match body_result {
-                Ok(body) => self
-                    .tx
-                    .ensure_no_entry_above::<tables::TransactionSenders, _>(body.last_tx_num(), |key| key)?,
+                Ok(body) => self.tx.ensure_no_entry_above::<tables::TransactionSenders, _>(
+                    body.last_tx_num(),
+                    |key| key,
+                )?,
                 Err(_) => {
                     assert!(self.tx.table_is_empty::<tables::TransactionSenders>()?);
                 }

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -23,7 +23,7 @@ use tracing::*;
 
 /// The sender recovery stage iterates over existing transactions,
 /// recovers the transaction signer and stores them
-/// in [`TxSenders`][reth_db::tables::TxSenders] table.
+/// in [`TransactionSenders`][reth_db::tables::TransactionSenders] table.
 #[derive(Clone, Debug)]
 pub struct SenderRecoveryStage {
     /// The size of inserted items after which the control
@@ -55,7 +55,7 @@ impl<DB: Database> Stage<DB> for SenderRecoveryStage {
     /// [`BlockBodyIndices`][reth_db::tables::BlockBodyIndices],
     /// collect transactions within that range,
     /// recover signer for each transaction and store entries in
-    /// the [`TxSenders`][reth_db::tables::TxSenders] table.
+    /// the [`TransactionSenders`][reth_db::tables::TransactionSenders] table.
     async fn execute(
         &mut self,
         provider: &DatabaseProviderRW<'_, &DB>,
@@ -82,7 +82,7 @@ impl<DB: Database> Stage<DB> for SenderRecoveryStage {
         let tx = provider.tx_ref();
 
         // Acquire the cursor for inserting elements
-        let mut senders_cursor = tx.cursor_write::<tables::TxSenders>()?;
+        let mut senders_cursor = tx.cursor_write::<tables::TransactionSenders>()?;
 
         // Acquire the cursor over the transactions
         let mut tx_cursor = tx.cursor_read::<RawTable<tables::Transactions>>()?;
@@ -137,7 +137,7 @@ impl<DB: Database> Stage<DB> for SenderRecoveryStage {
                             SenderRecoveryStageError::FailedRecovery(err) => {
                                 // get the block number for the bad transaction
                                 let block_number = tx
-                                    .get::<tables::TransactionBlock>(err.tx)?
+                                    .get::<tables::TransactionBlocks>(err.tx)?
                                     .ok_or(ProviderError::BlockNumberForTransactionIndexNotFound)?;
 
                                 // fetch the sealed header so we can use it in the sender recovery
@@ -179,7 +179,7 @@ impl<DB: Database> Stage<DB> for SenderRecoveryStage {
             .block_body_indices(unwind_to)?
             .ok_or(ProviderError::BlockBodyIndicesNotFound(unwind_to))?
             .last_tx_num();
-        provider.unwind_table_by_num::<tables::TxSenders>(latest_tx_id)?;
+        provider.unwind_table_by_num::<tables::TransactionSenders>(latest_tx_id)?;
 
         Ok(UnwindOutput {
             checkpoint: StageCheckpoint::new(unwind_to)
@@ -215,10 +215,10 @@ fn stage_checkpoint<DB: Database>(
         .and_then(|checkpoint| checkpoint.tx_number)
         .unwrap_or_default();
     Ok(EntitiesCheckpoint {
-        // If `TxSenders` table was pruned, we will have a number of entries in it not matching
+        // If `TransactionSenders` table was pruned, we will have a number of entries in it not matching
         // the actual number of processed transactions. To fix that, we add the number of pruned
-        // `TxSenders` entries.
-        processed: provider.tx_ref().entries::<tables::TxSenders>()? as u64 + pruned_entries,
+        // `TransactionSenders` entries.
+        processed: provider.tx_ref().entries::<tables::TransactionSenders>()? as u64 + pruned_entries,
         total: provider.tx_ref().entries::<tables::Transactions>()? as u64,
     })
 }
@@ -347,7 +347,7 @@ mod tests {
             ExecOutput {
                 checkpoint: StageCheckpoint::new(expected_progress).with_entities_stage_checkpoint(
                     EntitiesCheckpoint {
-                        processed: runner.tx.table::<tables::TxSenders>().unwrap().len() as u64,
+                        processed: runner.tx.table::<tables::TransactionSenders>().unwrap().len() as u64,
                         total: total_transactions
                     }
                 ),
@@ -452,9 +452,9 @@ mod tests {
 
         /// # Panics
         ///
-        /// 1. If there are any entries in the [tables::TxSenders] table above a given block number.
+        /// 1. If there are any entries in the [tables::TransactionSenders] table above a given block number.
         ///
-        /// 2. If the is no requested block entry in the bodies table, but [tables::TxSenders] is
+        /// 2. If the is no requested block entry in the bodies table, but [tables::TransactionSenders] is
         ///    not empty.
         fn ensure_no_senders_by_block(&self, block: BlockNumber) -> Result<(), TestRunnerError> {
             let body_result = self
@@ -465,9 +465,9 @@ mod tests {
             match body_result {
                 Ok(body) => self
                     .tx
-                    .ensure_no_entry_above::<tables::TxSenders, _>(body.last_tx_num(), |key| key)?,
+                    .ensure_no_entry_above::<tables::TransactionSenders, _>(body.last_tx_num(), |key| key)?,
                 Err(_) => {
-                    assert!(self.tx.table_is_empty::<tables::TxSenders>()?);
+                    assert!(self.tx.table_is_empty::<tables::TransactionSenders>()?);
                 }
             };
 

--- a/crates/stages/src/stages/total_difficulty.rs
+++ b/crates/stages/src/stages/total_difficulty.rs
@@ -18,8 +18,8 @@ use tracing::*;
 /// The total difficulty stage.
 ///
 /// This stage walks over inserted headers and computes total difficulty
-/// at each block. The entries are inserted into [`HeaderTerminalDifficulties`][reth_db::tables::HeaderTerminalDifficulties]
-/// table.
+/// at each block. The entries are inserted into
+/// [`HeaderTerminalDifficulties`][reth_db::tables::HeaderTerminalDifficulties] table.
 #[derive(Debug, Clone)]
 pub struct TotalDifficultyStage {
     /// Consensus client implementation
@@ -240,7 +240,10 @@ mod tests {
                     .map(|(_, v)| v)
                     .unwrap_or_default()
                     .into();
-                tx.put::<tables::HeaderTerminalDifficulties>(head.number, (td + head.difficulty).into())
+                tx.put::<tables::HeaderTerminalDifficulties>(
+                    head.number,
+                    (td + head.difficulty).into(),
+                )
             })?;
 
             // use previous progress as seed size
@@ -299,7 +302,8 @@ mod tests {
 
     impl TotalDifficultyTestRunner {
         fn check_no_td_above(&self, block: BlockNumber) -> Result<(), TestRunnerError> {
-            self.tx.ensure_no_entry_above::<tables::HeaderTerminalDifficulties, _>(block, |num| num)?;
+            self.tx
+                .ensure_no_entry_above::<tables::HeaderTerminalDifficulties, _>(block, |num| num)?;
             Ok(())
         }
 

--- a/crates/stages/src/stages/total_difficulty.rs
+++ b/crates/stages/src/stages/total_difficulty.rs
@@ -18,7 +18,7 @@ use tracing::*;
 /// The total difficulty stage.
 ///
 /// This stage walks over inserted headers and computes total difficulty
-/// at each block. The entries are inserted into [`HeaderTD`][reth_db::tables::HeaderTD]
+/// at each block. The entries are inserted into [`HeaderTerminalDifficulties`][reth_db::tables::HeaderTerminalDifficulties]
 /// table.
 #[derive(Debug, Clone)]
 pub struct TotalDifficultyStage {
@@ -65,7 +65,7 @@ impl<DB: Database> Stage<DB> for TotalDifficultyStage {
         debug!(target: "sync::stages::total_difficulty", start_block, end_block, "Commencing sync");
 
         // Acquire cursor over total difficulty and headers tables
-        let mut cursor_td = tx.cursor_write::<tables::HeaderTD>()?;
+        let mut cursor_td = tx.cursor_write::<tables::HeaderTerminalDifficulties>()?;
         let mut cursor_headers = tx.cursor_read::<tables::Headers>()?;
 
         // Get latest total difficulty
@@ -103,7 +103,7 @@ impl<DB: Database> Stage<DB> for TotalDifficultyStage {
     ) -> Result<UnwindOutput, StageError> {
         let (_, unwind_to, _) = input.unwind_block_range_with_threshold(self.commit_threshold);
 
-        provider.unwind_table_by_num::<tables::HeaderTD>(unwind_to)?;
+        provider.unwind_table_by_num::<tables::HeaderTerminalDifficulties>(unwind_to)?;
 
         Ok(UnwindOutput {
             checkpoint: StageCheckpoint::new(unwind_to)
@@ -116,7 +116,7 @@ fn stage_checkpoint<DB: Database>(
     provider: &DatabaseProviderRW<'_, DB>,
 ) -> Result<EntitiesCheckpoint, DatabaseError> {
     Ok(EntitiesCheckpoint {
-        processed: provider.tx_ref().entries::<tables::HeaderTD>()? as u64,
+        processed: provider.tx_ref().entries::<tables::HeaderTerminalDifficulties>()? as u64,
         total: provider.tx_ref().entries::<tables::Headers>()? as u64,
     })
 }
@@ -235,12 +235,12 @@ mod tests {
             self.tx.insert_headers(std::iter::once(&head))?;
             self.tx.commit(|tx| {
                 let td: U256 = tx
-                    .cursor_read::<tables::HeaderTD>()?
+                    .cursor_read::<tables::HeaderTerminalDifficulties>()?
                     .last()?
                     .map(|(_, v)| v)
                     .unwrap_or_default()
                     .into();
-                tx.put::<tables::HeaderTD>(head.number, (td + head.difficulty).into())
+                tx.put::<tables::HeaderTerminalDifficulties>(head.number, (td + head.difficulty).into())
             })?;
 
             // use previous progress as seed size
@@ -299,7 +299,7 @@ mod tests {
 
     impl TotalDifficultyTestRunner {
         fn check_no_td_above(&self, block: BlockNumber) -> Result<(), TestRunnerError> {
-            self.tx.ensure_no_entry_above::<tables::HeaderTD, _>(block, |num| num)?;
+            self.tx.ensure_no_entry_above::<tables::HeaderTerminalDifficulties, _>(block, |num| num)?;
             Ok(())
         }
 

--- a/crates/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/src/stages/tx_lookup.rs
@@ -24,7 +24,8 @@ use tracing::*;
 ///
 /// This stage walks over the bodies table, and sets the transaction hash of each transaction in a
 /// block to the corresponding `BlockNumber` at each block. This is written to the
-/// [`tables::TransactionHashNumbers`] This is used for looking up changesets via the transaction hash.
+/// [`tables::TransactionHashNumbers`] This is used for looking up changesets via the transaction
+/// hash.
 #[derive(Debug, Clone)]
 pub struct TransactionLookupStage {
     /// The number of lookup entries to commit at once
@@ -221,10 +222,11 @@ fn stage_checkpoint<DB: Database>(
         .map(|tx_number| tx_number + 1)
         .unwrap_or_default();
     Ok(EntitiesCheckpoint {
-        // If `TransactionHashNumbers` table was pruned, we will have a number of entries in it not matching
-        // the actual number of processed transactions. To fix that, we add the number of pruned
-        // `TransactionHashNumbers` entries.
-        processed: provider.tx_ref().entries::<tables::TransactionHashNumbers>()? as u64 + pruned_entries,
+        // If `TransactionHashNumbers` table was pruned, we will have a number of entries in it not
+        // matching the actual number of processed transactions. To fix that, we add the
+        // number of pruned `TransactionHashNumbers` entries.
+        processed: provider.tx_ref().entries::<tables::TransactionHashNumbers>()? as u64 +
+            pruned_entries,
         total: provider.tx_ref().entries::<tables::Transactions>()? as u64,
     })
 }
@@ -338,7 +340,11 @@ mod tests {
             ExecOutput {
                 checkpoint: StageCheckpoint::new(expected_progress).with_entities_stage_checkpoint(
                     EntitiesCheckpoint {
-                        processed: runner.tx.table::<tables::TransactionHashNumbers>().unwrap().len() as u64,
+                        processed: runner
+                            .tx
+                            .table::<tables::TransactionHashNumbers>()
+                            .unwrap()
+                            .len() as u64,
                         total: total_txs
                     }
                 ),
@@ -495,11 +501,11 @@ mod tests {
 
         /// # Panics
         ///
-        /// 1. If there are any entries in the [tables::TransactionHashNumbers] table above a given block
-        ///    number.
+        /// 1. If there are any entries in the [tables::TransactionHashNumbers] table above a given
+        ///    block number.
         ///
-        /// 2. If the is no requested block entry in the bodies table, but [tables::TransactionHashNumbers] is
-        ///    not empty.
+        /// 2. If the is no requested block entry in the bodies table, but
+        ///    [tables::TransactionHashNumbers] is not empty.
         fn ensure_no_hash_by_block(&self, number: BlockNumber) -> Result<(), TestRunnerError> {
             let body_result = self
                 .tx
@@ -507,10 +513,12 @@ mod tests {
                 .block_body_indices(number)?
                 .ok_or(ProviderError::BlockBodyIndicesNotFound(number));
             match body_result {
-                Ok(body) => self.tx.ensure_no_entry_above_by_value::<tables::TransactionHashNumbers, _>(
-                    body.last_tx_num(),
-                    |key| key,
-                )?,
+                Ok(body) => {
+                    self.tx.ensure_no_entry_above_by_value::<tables::TransactionHashNumbers, _>(
+                        body.last_tx_num(),
+                        |key| key,
+                    )?
+                }
                 Err(_) => {
                     assert!(self.tx.table_is_empty::<tables::TransactionHashNumbers>()?);
                 }

--- a/crates/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/src/stages/tx_lookup.rs
@@ -24,7 +24,7 @@ use tracing::*;
 ///
 /// This stage walks over the bodies table, and sets the transaction hash of each transaction in a
 /// block to the corresponding `BlockNumber` at each block. This is written to the
-/// [`tables::TxHashNumber`] This is used for looking up changesets via the transaction hash.
+/// [`tables::TransactionHashNumbers`] This is used for looking up changesets via the transaction hash.
 #[derive(Debug, Clone)]
 pub struct TransactionLookupStage {
     /// The number of lookup entries to commit at once
@@ -134,7 +134,7 @@ impl<DB: Database> Stage<DB> for TransactionLookupStage {
         // Sort before inserting the reverse lookup for hash -> tx_id.
         tx_list.par_sort_unstable_by(|txa, txb| txa.0.cmp(&txb.0));
 
-        let mut txhash_cursor = tx.cursor_write::<tables::TxHashNumber>()?;
+        let mut txhash_cursor = tx.cursor_write::<tables::TransactionHashNumbers>()?;
 
         // If the last inserted element in the database is equal or bigger than the first
         // in our set, then we need to insert inside the DB. If it is smaller then last
@@ -174,7 +174,7 @@ impl<DB: Database> Stage<DB> for TransactionLookupStage {
 
         // Cursors to unwind tx hash to number
         let mut body_cursor = tx.cursor_read::<tables::BlockBodyIndices>()?;
-        let mut tx_hash_number_cursor = tx.cursor_write::<tables::TxHashNumber>()?;
+        let mut tx_hash_number_cursor = tx.cursor_write::<tables::TransactionHashNumbers>()?;
         let mut transaction_cursor = tx.cursor_read::<tables::Transactions>()?;
         let mut rev_walker = body_cursor.walk_back(Some(*range.end()))?;
         while let Some((number, body)) = rev_walker.next().transpose()? {
@@ -221,10 +221,10 @@ fn stage_checkpoint<DB: Database>(
         .map(|tx_number| tx_number + 1)
         .unwrap_or_default();
     Ok(EntitiesCheckpoint {
-        // If `TxHashNumber` table was pruned, we will have a number of entries in it not matching
+        // If `TransactionHashNumbers` table was pruned, we will have a number of entries in it not matching
         // the actual number of processed transactions. To fix that, we add the number of pruned
-        // `TxHashNumber` entries.
-        processed: provider.tx_ref().entries::<tables::TxHashNumber>()? as u64 + pruned_entries,
+        // `TransactionHashNumbers` entries.
+        processed: provider.tx_ref().entries::<tables::TransactionHashNumbers>()? as u64 + pruned_entries,
         total: provider.tx_ref().entries::<tables::Transactions>()? as u64,
     })
 }
@@ -338,7 +338,7 @@ mod tests {
             ExecOutput {
                 checkpoint: StageCheckpoint::new(expected_progress).with_entities_stage_checkpoint(
                     EntitiesCheckpoint {
-                        processed: runner.tx.table::<tables::TxHashNumber>().unwrap().len() as u64,
+                        processed: runner.tx.table::<tables::TransactionHashNumbers>().unwrap().len() as u64,
                         total: total_txs
                     }
                 ),
@@ -495,10 +495,10 @@ mod tests {
 
         /// # Panics
         ///
-        /// 1. If there are any entries in the [tables::TxHashNumber] table above a given block
+        /// 1. If there are any entries in the [tables::TransactionHashNumbers] table above a given block
         ///    number.
         ///
-        /// 2. If the is no requested block entry in the bodies table, but [tables::TxHashNumber] is
+        /// 2. If the is no requested block entry in the bodies table, but [tables::TransactionHashNumbers] is
         ///    not empty.
         fn ensure_no_hash_by_block(&self, number: BlockNumber) -> Result<(), TestRunnerError> {
             let body_result = self
@@ -507,12 +507,12 @@ mod tests {
                 .block_body_indices(number)?
                 .ok_or(ProviderError::BlockBodyIndicesNotFound(number));
             match body_result {
-                Ok(body) => self.tx.ensure_no_entry_above_by_value::<tables::TxHashNumber, _>(
+                Ok(body) => self.tx.ensure_no_entry_above_by_value::<tables::TransactionHashNumbers, _>(
                     body.last_tx_num(),
                     |key| key,
                 )?,
                 Err(_) => {
-                    assert!(self.tx.table_is_empty::<tables::TxHashNumber>()?);
+                    assert!(self.tx.table_is_empty::<tables::TransactionHashNumbers>()?);
                 }
             };
 

--- a/crates/stages/src/test_utils/test_db.rs
+++ b/crates/stages/src/test_utils/test_db.rs
@@ -228,7 +228,7 @@ impl TestTransaction {
             headers.into_iter().try_for_each(|header| {
                 Self::insert_header(tx, header)?;
                 td += header.difficulty;
-                tx.put::<tables::HeaderTD>(header.number, td.into())
+                tx.put::<tables::HeaderTerminalDifficulties>(header.number, td.into())
             })
         })
     }
@@ -253,7 +253,7 @@ impl TestTransaction {
                 };
 
                 if !block.body.is_empty() {
-                    tx.put::<tables::TransactionBlock>(
+                    tx.put::<tables::TransactionBlocks>(
                         block_body_indices.last_tx_num(),
                         block.number,
                     )?;
@@ -276,7 +276,7 @@ impl TestTransaction {
         self.commit(|tx| {
             tx_hash_numbers.into_iter().try_for_each(|(tx_hash, tx_num)| {
                 // Insert into tx hash numbers table.
-                tx.put::<tables::TxHashNumber>(tx_hash, tx_num)
+                tx.put::<tables::TransactionHashNumbers>(tx_hash, tx_num)
             })
         })
     }
@@ -301,7 +301,7 @@ impl TestTransaction {
         self.commit(|tx| {
             transaction_senders.into_iter().try_for_each(|(tx_num, sender)| {
                 // Insert into receipts table.
-                tx.put::<tables::TxSenders>(tx_num, sender)
+                tx.put::<tables::TransactionSenders>(tx_num, sender)
             })
         })
     }
@@ -318,7 +318,7 @@ impl TestTransaction {
 
                 // Insert into account tables.
                 tx.put::<tables::PlainAccountState>(address, account)?;
-                tx.put::<tables::HashedAccount>(hashed_address, account)?;
+                tx.put::<tables::HashedAccounts>(hashed_address, account)?;
 
                 // Insert into storage tables.
                 storage.into_iter().filter(|e| e.value != U256::ZERO).try_for_each(|entry| {
@@ -333,7 +333,7 @@ impl TestTransaction {
                     }
                     cursor.upsert(address, entry)?;
 
-                    let mut cursor = tx.cursor_dup_write::<tables::HashedStorage>()?;
+                    let mut cursor = tx.cursor_dup_write::<tables::HashedStorages>()?;
                     if let Some(e) = cursor
                         .seek_by_key_subkey(hashed_address, hashed_entry.key)?
                         .filter(|e| e.key == hashed_entry.key)
@@ -363,7 +363,7 @@ impl TestTransaction {
                 changeset.into_iter().try_for_each(|(address, old_account, old_storage)| {
                     let block = offset + block as u64;
                     // Insert into account changeset.
-                    tx.put::<tables::AccountChangeSet>(
+                    tx.put::<tables::AccountChangeSets>(
                         block,
                         AccountBeforeTx { address, info: Some(old_account) },
                     )?;

--- a/crates/stages/src/test_utils/test_db.rs
+++ b/crates/stages/src/test_utils/test_db.rs
@@ -372,7 +372,7 @@ impl TestTransaction {
 
                     // Insert into storage changeset.
                     old_storage.into_iter().try_for_each(|entry| {
-                        tx.put::<tables::StorageChangeSet>(block_address, entry)
+                        tx.put::<tables::StorageChangeSets>(block_address, entry)
                     })
                 })
             })

--- a/crates/storage/db/benches/criterion.rs
+++ b/crates/storage/db/benches/criterion.rs
@@ -23,12 +23,12 @@ pub fn db(c: &mut Criterion) {
     group.warm_up_time(std::time::Duration::from_millis(200));
 
     measure_table_db::<CanonicalHeaders>(&mut group);
-    measure_table_db::<HeaderTD>(&mut group);
+    measure_table_db::<HeaderTerminalDifficulties>(&mut group);
     measure_table_db::<HeaderNumbers>(&mut group);
     measure_table_db::<Headers>(&mut group);
     measure_table_db::<BlockBodyIndices>(&mut group);
     measure_table_db::<BlockOmmers>(&mut group);
-    measure_table_db::<TxHashNumber>(&mut group);
+    measure_table_db::<TransactionHashNumbers>(&mut group);
     measure_table_db::<Transactions>(&mut group);
     measure_dupsort_db::<PlainStorageState>(&mut group);
     measure_table_db::<PlainAccountState>(&mut group);
@@ -40,12 +40,12 @@ pub fn serialization(c: &mut Criterion) {
     group.warm_up_time(std::time::Duration::from_millis(200));
 
     measure_table_serialization::<CanonicalHeaders>(&mut group);
-    measure_table_serialization::<HeaderTD>(&mut group);
+    measure_table_serialization::<HeaderTerminalDifficulties>(&mut group);
     measure_table_serialization::<HeaderNumbers>(&mut group);
     measure_table_serialization::<Headers>(&mut group);
     measure_table_serialization::<BlockBodyIndices>(&mut group);
     measure_table_serialization::<BlockOmmers>(&mut group);
-    measure_table_serialization::<TxHashNumber>(&mut group);
+    measure_table_serialization::<TransactionHashNumbers>(&mut group);
     measure_table_serialization::<Transactions>(&mut group);
     measure_table_serialization::<PlainStorageState>(&mut group);
     measure_table_serialization::<PlainAccountState>(&mut group);

--- a/crates/storage/db/benches/hash_keys.rs
+++ b/crates/storage/db/benches/hash_keys.rs
@@ -12,7 +12,7 @@ use proptest::{
 };
 use reth_db::{
     cursor::{DbCursorRW, DbDupCursorRO, DbDupCursorRW},
-    TxHashNumber,
+    TransactionHashNumbers,
 };
 use std::{collections::HashSet, time::Instant};
 use test_fuzz::runtime::num_traits::Zero;
@@ -39,7 +39,7 @@ pub fn hash_keys(c: &mut Criterion) {
     group.sample_size(10);
 
     for size in [10_000, 100_000, 1_000_000] {
-        measure_table_insertion::<TxHashNumber>(&mut group, size);
+        measure_table_insertion::<TransactionHashNumbers>(&mut group, size);
     }
 }
 

--- a/crates/storage/db/benches/iai.rs
+++ b/crates/storage/db/benches/iai.rs
@@ -65,12 +65,12 @@ macro_rules! impl_iai {
 
 impl_iai!(
     CanonicalHeaders,
-    HeaderTD,
+    HeaderTerminalDifficulties,
     HeaderNumbers,
     Headers,
     BlockBodyIndices,
     BlockOmmers,
-    TxHashNumber,
+    TransactionHashNumbers,
     Transactions,
     PlainStorageState,
     PlainAccountState

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -163,7 +163,7 @@ mod tests {
         database::Database,
         models::{AccountBeforeTx, ShardedKey},
         tables::{
-            AccountHistories, CanonicalHeaders, Headers, PlainAccountState, PlainStorageState,
+            AccountsHistory, CanonicalHeaders, Headers, PlainAccountState, PlainStorageState,
         },
         test_utils::*,
         transaction::{DbTx, DbTxMut},
@@ -957,14 +957,14 @@ mod tests {
             let key = ShardedKey::new(real_key, i * 100);
             let list: IntegerList = vec![i * 100u64].into();
 
-            db.update(|tx| tx.put::<AccountHistories>(key.clone(), list.clone()).expect(""))
+            db.update(|tx| tx.put::<AccountsHistory>(key.clone(), list.clone()).expect(""))
                 .unwrap();
         }
 
         // Seek value with non existing key.
         {
             let tx = db.tx().expect(ERROR_INIT_TX);
-            let mut cursor = tx.cursor_read::<AccountHistories>().unwrap();
+            let mut cursor = tx.cursor_read::<AccountsHistory>().unwrap();
 
             // It will seek the one greater or equal to the query. Since we have `Address | 100`,
             // `Address | 200` in the database and we're querying `Address | 150` it will return us
@@ -982,7 +982,7 @@ mod tests {
         // Seek greatest index
         {
             let tx = db.tx().expect(ERROR_INIT_TX);
-            let mut cursor = tx.cursor_read::<AccountHistories>().unwrap();
+            let mut cursor = tx.cursor_read::<AccountsHistory>().unwrap();
 
             // It will seek the MAX value of transition index and try to use prev to get first
             // biggers.

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -162,7 +162,9 @@ mod tests {
         cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO, DbDupCursorRW, ReverseWalker, Walker},
         database::Database,
         models::{AccountBeforeTx, ShardedKey},
-        tables::{AccountHistories, CanonicalHeaders, Headers, PlainAccountState, PlainStorageState},
+        tables::{
+            AccountHistories, CanonicalHeaders, Headers, PlainAccountState, PlainStorageState,
+        },
         test_utils::*,
         transaction::{DbTx, DbTxMut},
         AccountChangeSets, DatabaseError,
@@ -955,7 +957,8 @@ mod tests {
             let key = ShardedKey::new(real_key, i * 100);
             let list: IntegerList = vec![i * 100u64].into();
 
-            db.update(|tx| tx.put::<AccountHistories>(key.clone(), list.clone()).expect("")).unwrap();
+            db.update(|tx| tx.put::<AccountHistories>(key.clone(), list.clone()).expect(""))
+                .unwrap();
         }
 
         // Seek value with non existing key.

--- a/crates/storage/db/src/tables/mod.rs
+++ b/crates/storage/db/src/tables/mod.rs
@@ -176,7 +176,7 @@ tables!([
     (AccountHistories, TableType::Table),
     (StorageHistories, TableType::Table),
     (AccountChangeSets, TableType::DupSort),
-    (StorageChangeSet, TableType::DupSort),
+    (StorageChangeSets, TableType::DupSort),
     (HashedAccounts, TableType::Table),
     (HashedStorages, TableType::DupSort),
     (AccountsTrie, TableType::Table),
@@ -370,7 +370,7 @@ dupsort!(
     /// Stores the state of a storage key before a certain transaction changed it.
     /// If [`StorageEntry::value`] is zero, this means storage was not existing
     /// and needs to be removed.
-    ( StorageChangeSet ) BlockNumberAddress | [H256] StorageEntry
+    ( StorageChangeSets ) BlockNumberAddress | [H256] StorageEntry
 );
 
 table!(
@@ -452,7 +452,7 @@ mod tests {
         (TableType::Table, AccountHistories::const_name()),
         (TableType::Table, StorageHistories::const_name()),
         (TableType::DupSort, AccountChangeSets::const_name()),
-        (TableType::DupSort, StorageChangeSet::const_name()),
+        (TableType::DupSort, StorageChangeSets::const_name()),
         (TableType::Table, HashedAccounts::const_name()),
         (TableType::DupSort, HashedStorages::const_name()),
         (TableType::Table, AccountsTrie::const_name()),

--- a/crates/storage/db/src/tables/mod.rs
+++ b/crates/storage/db/src/tables/mod.rs
@@ -160,30 +160,30 @@ macro_rules! tables {
 
 tables!([
     (CanonicalHeaders, TableType::Table),
-    (HeaderTD, TableType::Table),
+    (HeaderTerminalDifficulties, TableType::Table),
     (HeaderNumbers, TableType::Table),
     (Headers, TableType::Table),
     (BlockBodyIndices, TableType::Table),
     (BlockOmmers, TableType::Table),
     (BlockWithdrawals, TableType::Table),
-    (TransactionBlock, TableType::Table),
+    (TransactionBlocks, TableType::Table),
     (Transactions, TableType::Table),
-    (TxHashNumber, TableType::Table),
+    (TransactionHashNumbers, TableType::Table),
     (Receipts, TableType::Table),
     (PlainAccountState, TableType::Table),
     (PlainStorageState, TableType::DupSort),
     (Bytecodes, TableType::Table),
-    (AccountHistory, TableType::Table),
-    (StorageHistory, TableType::Table),
-    (AccountChangeSet, TableType::DupSort),
+    (AccountHistories, TableType::Table),
+    (StorageHistories, TableType::Table),
+    (AccountChangeSets, TableType::DupSort),
     (StorageChangeSet, TableType::DupSort),
-    (HashedAccount, TableType::Table),
-    (HashedStorage, TableType::DupSort),
+    (HashedAccounts, TableType::Table),
+    (HashedStorages, TableType::DupSort),
     (AccountsTrie, TableType::Table),
     (StoragesTrie, TableType::DupSort),
-    (TxSenders, TableType::Table),
-    (SyncStage, TableType::Table),
-    (SyncStageProgress, TableType::Table),
+    (TransactionSenders, TableType::Table),
+    (SyncStages, TableType::Table),
+    (SyncStagesProgresses, TableType::Table),
     (PruneCheckpoints, TableType::Table)
 ]);
 
@@ -245,7 +245,7 @@ table!(
 
 table!(
     /// Stores the total difficulty from a block header.
-    ( HeaderTD ) BlockNumber | CompactU256
+    ( HeaderTerminalDifficulties ) BlockNumber | CompactU256
 );
 
 table!(
@@ -282,14 +282,14 @@ table!(
 
 table!(
     /// Stores the mapping of the transaction hash to the transaction number.
-    ( TxHashNumber ) TxHash | TxNumber
+    ( TransactionHashNumbers ) TxHash | TxNumber
 );
 
 table!(
     /// Stores the mapping of transaction number to the blocks number.
     ///
     /// The key is the highest transaction ID in the block.
-    ( TransactionBlock ) TxNumber | BlockNumber
+    ( TransactionBlocks ) TxNumber | BlockNumber
 );
 
 table!(
@@ -334,7 +334,7 @@ table!(
     /// * If there were no shard we would get `None` entry or entry of different storage key.
     ///
     /// Code example can be found in `reth_provider::HistoricalStateProviderRef`
-    ( AccountHistory ) ShardedKey<Address> | BlockNumberList
+    ( AccountHistories ) ShardedKey<Address> | BlockNumberList
 );
 
 table!(
@@ -356,14 +356,14 @@ table!(
     /// * If there were no shard we would get `None` entry or entry of different storage key.
     ///
     /// Code example can be found in `reth_provider::HistoricalStateProviderRef`
-    ( StorageHistory ) StorageShardedKey | BlockNumberList
+    ( StorageHistories ) StorageShardedKey | BlockNumberList
 );
 
 dupsort!(
     /// Stores the state of an account before a certain transaction changed it.
     /// Change on state can be: account is created, selfdestructed, touched while empty
     /// or changed (balance,nonce).
-    ( AccountChangeSet ) BlockNumber | [Address] AccountBeforeTx
+    ( AccountChangeSets ) BlockNumber | [Address] AccountBeforeTx
 );
 
 dupsort!(
@@ -378,7 +378,7 @@ table!(
     /// This table is in preparation for merkelization and calculation of state root.
     /// We are saving whole account data as it is needed for partial update when
     /// part of storage is changed. Benefit for merkelization is that hashed addresses are sorted.
-    ( HashedAccount ) H256 | Account
+    ( HashedAccounts ) H256 | Account
 );
 
 dupsort!(
@@ -386,7 +386,7 @@ dupsort!(
     /// hash of storage key `keccak256(key)`.
     /// This table is in preparation for merkelization and calculation of state root.
     /// Benefit for merklization is that hashed addresses/keys are sorted.
-    ( HashedStorage ) H256 | [H256] StorageEntry
+    ( HashedStorages ) H256 | [H256] StorageEntry
 );
 
 table!(
@@ -403,17 +403,17 @@ table!(
     /// Stores the transaction sender for each canonical transaction.
     /// It is needed to speed up execution stage and allows fetching signer without doing
     /// transaction signed recovery
-    ( TxSenders ) TxNumber | Address
+    ( TransactionSenders ) TxNumber | Address
 );
 
 table!(
     /// Stores the highest synced block number and stage-specific checkpoint of each stage.
-    ( SyncStage ) StageId | StageCheckpoint
+    ( SyncStages ) StageId | StageCheckpoint
 );
 
 table!(
     /// Stores arbitrary data to keep track of a stage first-sync progress.
-    ( SyncStageProgress ) StageId | Vec<u8>
+    ( SyncStagesProgresses ) StageId | Vec<u8>
 );
 
 table!(
@@ -436,30 +436,30 @@ mod tests {
 
     const TABLES: [(TableType, &str); NUM_TABLES] = [
         (TableType::Table, CanonicalHeaders::const_name()),
-        (TableType::Table, HeaderTD::const_name()),
+        (TableType::Table, HeaderTerminalDifficulties::const_name()),
         (TableType::Table, HeaderNumbers::const_name()),
         (TableType::Table, Headers::const_name()),
         (TableType::Table, BlockBodyIndices::const_name()),
         (TableType::Table, BlockOmmers::const_name()),
         (TableType::Table, BlockWithdrawals::const_name()),
-        (TableType::Table, TransactionBlock::const_name()),
+        (TableType::Table, TransactionBlocks::const_name()),
         (TableType::Table, Transactions::const_name()),
-        (TableType::Table, TxHashNumber::const_name()),
+        (TableType::Table, TransactionHashNumbers::const_name()),
         (TableType::Table, Receipts::const_name()),
         (TableType::Table, PlainAccountState::const_name()),
         (TableType::DupSort, PlainStorageState::const_name()),
         (TableType::Table, Bytecodes::const_name()),
-        (TableType::Table, AccountHistory::const_name()),
-        (TableType::Table, StorageHistory::const_name()),
-        (TableType::DupSort, AccountChangeSet::const_name()),
+        (TableType::Table, AccountHistories::const_name()),
+        (TableType::Table, StorageHistories::const_name()),
+        (TableType::DupSort, AccountChangeSets::const_name()),
         (TableType::DupSort, StorageChangeSet::const_name()),
-        (TableType::Table, HashedAccount::const_name()),
-        (TableType::DupSort, HashedStorage::const_name()),
+        (TableType::Table, HashedAccounts::const_name()),
+        (TableType::DupSort, HashedStorages::const_name()),
         (TableType::Table, AccountsTrie::const_name()),
         (TableType::DupSort, StoragesTrie::const_name()),
-        (TableType::Table, TxSenders::const_name()),
-        (TableType::Table, SyncStage::const_name()),
-        (TableType::Table, SyncStageProgress::const_name()),
+        (TableType::Table, TransactionSenders::const_name()),
+        (TableType::Table, SyncStages::const_name()),
+        (TableType::Table, SyncStagesProgresses::const_name()),
         (TableType::Table, PruneCheckpoints::const_name()),
     ];
 

--- a/crates/storage/db/src/tables/mod.rs
+++ b/crates/storage/db/src/tables/mod.rs
@@ -173,8 +173,8 @@ tables!([
     (PlainAccountState, TableType::Table),
     (PlainStorageState, TableType::DupSort),
     (Bytecodes, TableType::Table),
-    (AccountHistories, TableType::Table),
-    (StorageHistories, TableType::Table),
+    (AccountsHistory, TableType::Table),
+    (StoragesHistory, TableType::Table),
     (AccountChangeSets, TableType::DupSort),
     (StorageChangeSets, TableType::DupSort),
     (HashedAccounts, TableType::Table),
@@ -334,7 +334,7 @@ table!(
     /// * If there were no shard we would get `None` entry or entry of different storage key.
     ///
     /// Code example can be found in `reth_provider::HistoricalStateProviderRef`
-    ( AccountHistories ) ShardedKey<Address> | BlockNumberList
+    ( AccountsHistory ) ShardedKey<Address> | BlockNumberList
 );
 
 table!(
@@ -356,7 +356,7 @@ table!(
     /// * If there were no shard we would get `None` entry or entry of different storage key.
     ///
     /// Code example can be found in `reth_provider::HistoricalStateProviderRef`
-    ( StorageHistories ) StorageShardedKey | BlockNumberList
+    ( StoragesHistory ) StorageShardedKey | BlockNumberList
 );
 
 dupsort!(
@@ -449,8 +449,8 @@ mod tests {
         (TableType::Table, PlainAccountState::const_name()),
         (TableType::DupSort, PlainStorageState::const_name()),
         (TableType::Table, Bytecodes::const_name()),
-        (TableType::Table, AccountHistories::const_name()),
-        (TableType::Table, StorageHistories::const_name()),
+        (TableType::Table, AccountsHistory::const_name()),
+        (TableType::Table, StoragesHistory::const_name()),
         (TableType::DupSort, AccountChangeSets::const_name()),
         (TableType::DupSort, StorageChangeSets::const_name()),
         (TableType::Table, HashedAccounts::const_name()),

--- a/crates/storage/db/src/tables/models/accounts.rs
+++ b/crates/storage/db/src/tables/models/accounts.rs
@@ -61,7 +61,7 @@ impl Compact for AccountBeforeTx {
 }
 
 /// [`BlockNumber`] concatenated with [`Address`]. Used as the key for
-/// [`StorageChangeSet`](crate::tables::StorageChangeSet)
+/// [`StorageChangeSets`](crate::tables::StorageChangeSets)
 ///
 /// Since it's used as a key, it isn't compressed when encoding it.
 #[derive(

--- a/crates/storage/db/src/tables/models/accounts.rs
+++ b/crates/storage/db/src/tables/models/accounts.rs
@@ -12,7 +12,7 @@ use reth_codecs::{derive_arbitrary, Compact};
 use reth_primitives::{Account, Address, BlockNumber};
 use serde::{Deserialize, Serialize};
 
-/// Account as it is saved inside [`AccountChangeSet`][crate::tables::AccountChangeSet].
+/// Account as it is saved inside [`AccountChangeSets`][crate::tables::AccountChangeSets].
 ///
 /// [`Address`] is the subkey.
 #[derive_arbitrary(compact)]

--- a/crates/storage/provider/src/post_state/mod.rs
+++ b/crates/storage/provider/src/post_state/mod.rs
@@ -22,7 +22,7 @@ mod account;
 pub use account::AccountChanges;
 
 mod storage;
-pub use storage::{Storage, StorageChanges, StorageChangeSets, StorageTransition, StorageWipe};
+pub use storage::{Storage, StorageChangeSets, StorageChanges, StorageTransition, StorageWipe};
 
 // todo: rewrite all the docs for this
 /// The state of accounts after execution of one or more transactions, including receipts and new

--- a/crates/storage/provider/src/post_state/mod.rs
+++ b/crates/storage/provider/src/post_state/mod.rs
@@ -22,7 +22,7 @@ mod account;
 pub use account::AccountChanges;
 
 mod storage;
-pub use storage::{Storage, StorageChanges, StorageChangeset, StorageTransition, StorageWipe};
+pub use storage::{Storage, StorageChanges, StorageChangeSets, StorageTransition, StorageWipe};
 
 // todo: rewrite all the docs for this
 /// The state of accounts after execution of one or more transactions, including receipts and new
@@ -484,7 +484,7 @@ impl PostState {
         &mut self,
         block_number: BlockNumber,
         address: Address,
-        changeset: StorageChangeset,
+        changeset: StorageChangeSets,
     ) {
         self.storage
             .entry(address)
@@ -525,7 +525,7 @@ impl PostState {
         // Write storage changes
         tracing::trace!(target: "provider::post_state", "Writing storage changes");
         let mut storages_cursor = tx.cursor_dup_write::<tables::PlainStorageState>()?;
-        let mut storage_changeset_cursor = tx.cursor_dup_write::<tables::StorageChangeSet>()?;
+        let mut storage_changeset_cursor = tx.cursor_dup_write::<tables::StorageChangeSets>()?;
         for (block_number, storage_changes) in
             std::mem::take(&mut self.storage_changes).inner.into_iter()
         {
@@ -1281,7 +1281,7 @@ mod tests {
 
         // Check change set
         let mut changeset_cursor = tx
-            .cursor_dup_read::<tables::StorageChangeSet>()
+            .cursor_dup_read::<tables::StorageChangeSets>()
             .expect("Could not open storage changeset cursor");
         assert_eq!(
             changeset_cursor.seek_exact(BlockNumberAddress((1, address_a))).unwrap(),
@@ -1418,7 +1418,7 @@ mod tests {
         post_state.write_to_db(&tx, 0).expect("Could not write post state to DB");
 
         let mut storage_changeset_cursor = tx
-            .cursor_dup_read::<tables::StorageChangeSet>()
+            .cursor_dup_read::<tables::StorageChangeSets>()
             .expect("Could not open plain storage state cursor");
         let mut storage_changes = storage_changeset_cursor.walk_range(..).unwrap();
 

--- a/crates/storage/provider/src/post_state/storage.rs
+++ b/crates/storage/provider/src/post_state/storage.rs
@@ -3,7 +3,7 @@ use reth_primitives::{Address, BlockNumber, U256};
 use std::collections::{btree_map::Entry, BTreeMap};
 
 /// Storage for an account with the old and new values for each slot: (slot -> (old, new)).
-pub type StorageChangeset = BTreeMap<U256, (U256, U256)>;
+pub type StorageChangeSets = BTreeMap<U256, (U256, U256)>;
 
 /// The storage state of the account before the state transition.
 #[derive(Debug, Default, Clone, Eq, PartialEq)]

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -103,9 +103,9 @@ impl<DB: Database> ProviderFactory<DB> {
         block_number += 1;
 
         let account_history_prune_checkpoint =
-            provider.get_prune_checkpoint(PrunePart::AccountHistories)?;
+            provider.get_prune_checkpoint(PrunePart::AccountsHistory)?;
         let storage_history_prune_checkpoint =
-            provider.get_prune_checkpoint(PrunePart::StorageHistories)?;
+            provider.get_prune_checkpoint(PrunePart::StoragesHistory)?;
 
         let mut state_provider = HistoricalStateProvider::new(provider.into_tx(), block_number);
 

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -103,9 +103,9 @@ impl<DB: Database> ProviderFactory<DB> {
         block_number += 1;
 
         let account_history_prune_checkpoint =
-            provider.get_prune_checkpoint(PrunePart::AccountHistory)?;
+            provider.get_prune_checkpoint(PrunePart::AccountHistories)?;
         let storage_history_prune_checkpoint =
-            provider.get_prune_checkpoint(PrunePart::StorageHistory)?;
+            provider.get_prune_checkpoint(PrunePart::StorageHistories)?;
 
         let mut state_provider = HistoricalStateProvider::new(provider.into_tx(), block_number);
 
@@ -509,7 +509,7 @@ mod tests {
 
             assert_matches!(provider.insert_block(block.clone(), None, None), Ok(_));
 
-            let senders = provider.get_or_take::<tables::TxSenders, true>(range.clone());
+            let senders = provider.get_or_take::<tables::TransactionSenders, true>(range.clone());
             assert_eq!(
                 senders,
                 Ok(range

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -203,8 +203,8 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> DatabaseProvider<'this, TX> {
     /// 1. Iterate over the [BlockBodyIndices][tables::BlockBodyIndices] table to get all
     /// the transaction ids.
     /// 2. Iterate over the [StorageChangeSets][tables::StorageChangeSets] table
-    /// and the [AccountChangeSets][tables::AccountChangeSets] tables in reverse order to reconstruct
-    /// the changesets.
+    /// and the [AccountChangeSets][tables::AccountChangeSets] tables in reverse order to
+    /// reconstruct the changesets.
     ///     - In order to have both the old and new values in the changesets, we also access the
     ///       plain state tables.
     /// 3. While iterating over the changeset tables, if we encounter a new account or storage slot,
@@ -431,8 +431,9 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> DatabaseProvider<'this, TX> {
             .map(|(id, tx)| (id, tx.into()))
             .collect::<Vec<(u64, TransactionSigned)>>();
 
-        let mut senders =
-            self.get_or_take::<tables::TransactionSenders, TAKE>(first_transaction..=last_transaction)?;
+        let mut senders = self.get_or_take::<tables::TransactionSenders, TAKE>(
+            first_transaction..=last_transaction,
+        )?;
 
         // Recover senders manually if not found in db
         // SAFETY: Transactions are always guaranteed to be in the database whereas
@@ -1731,7 +1732,10 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> HistoryWriter for DatabaseProvider
         &self,
         account_transitions: BTreeMap<Address, Vec<u64>>,
     ) -> Result<()> {
-        self.append_history_index::<_, tables::AccountHistories>(account_transitions, ShardedKey::new)
+        self.append_history_index::<_, tables::AccountHistories>(
+            account_transitions,
+            ShardedKey::new,
+        )
     }
 
     fn unwind_storage_history_indices(&self, range: Range<BlockNumberAddress>) -> Result<usize> {

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1720,7 +1720,7 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> HistoryWriter for DatabaseProvider
         &self,
         storage_transitions: BTreeMap<(Address, H256), Vec<u64>>,
     ) -> Result<()> {
-        self.append_history_index::<_, tables::StorageHistories>(
+        self.append_history_index::<_, tables::StoragesHistory>(
             storage_transitions,
             |(address, storage_key), highest_block_number| {
                 StorageShardedKey::new(address, storage_key, highest_block_number)
@@ -1732,7 +1732,7 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> HistoryWriter for DatabaseProvider
         &self,
         account_transitions: BTreeMap<Address, Vec<u64>>,
     ) -> Result<()> {
-        self.append_history_index::<_, tables::AccountHistories>(
+        self.append_history_index::<_, tables::AccountsHistory>(
             account_transitions,
             ShardedKey::new,
         )
@@ -1760,9 +1760,9 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> HistoryWriter for DatabaseProvider
                 },
             );
 
-        let mut cursor = self.tx.cursor_write::<tables::StorageHistories>()?;
+        let mut cursor = self.tx.cursor_write::<tables::StoragesHistory>()?;
         for ((address, storage_key), rem_index) in last_indices {
-            let partial_shard = unwind_history_shards::<_, tables::StorageHistories, _>(
+            let partial_shard = unwind_history_shards::<_, tables::StoragesHistory, _>(
                 &mut cursor,
                 StorageShardedKey::last(address, storage_key),
                 rem_index,
@@ -1805,9 +1805,9 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> HistoryWriter for DatabaseProvider
             });
 
         // Unwind the account history index.
-        let mut cursor = self.tx.cursor_write::<tables::AccountHistories>()?;
+        let mut cursor = self.tx.cursor_write::<tables::AccountsHistory>()?;
         for (address, rem_index) in last_indices {
-            let partial_shard = unwind_history_shards::<_, tables::AccountHistories, _>(
+            let partial_shard = unwind_history_shards::<_, tables::AccountsHistory, _>(
                 &mut cursor,
                 ShardedKey::last(address),
                 rem_index,

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -26,7 +26,7 @@ use std::marker::PhantomData;
 /// - [tables::Bytecodes]
 /// - [tables::StorageHistories]
 /// - [tables::AccountChangeSets]
-/// - [tables::StorageChangeSet]
+/// - [tables::StorageChangeSets]
 pub struct HistoricalStateProviderRef<'a, 'b, TX: DbTx<'a>> {
     /// Transaction
     tx: &'b TX,
@@ -213,10 +213,10 @@ impl<'a, 'b, TX: DbTx<'a>> StateProvider for HistoricalStateProviderRef<'a, 'b, 
             HistoryInfo::NotYetWritten => Ok(None),
             HistoryInfo::InChangeset(changeset_block_number) => Ok(Some(
                 self.tx
-                    .cursor_dup_read::<tables::StorageChangeSet>()?
+                    .cursor_dup_read::<tables::StorageChangeSets>()?
                     .seek_by_key_subkey((changeset_block_number, address).into(), storage_key)?
                     .filter(|entry| entry.key == storage_key)
-                    .ok_or(ProviderError::StorageChangesetNotFound {
+                    .ok_or(ProviderError::StorageChangeSetsNotFound {
                         block_number: changeset_block_number,
                         address,
                         storage_key,
@@ -506,11 +506,11 @@ mod tests {
         let entry_at3 = StorageEntry { key: STORAGE, value: U256::from(0) };
 
         // setup
-        tx.put::<tables::StorageChangeSet>((3, ADDRESS).into(), entry_at3).unwrap();
-        tx.put::<tables::StorageChangeSet>((4, HIGHER_ADDRESS).into(), higher_entry_at4).unwrap();
-        tx.put::<tables::StorageChangeSet>((7, ADDRESS).into(), entry_at7).unwrap();
-        tx.put::<tables::StorageChangeSet>((10, ADDRESS).into(), entry_at10).unwrap();
-        tx.put::<tables::StorageChangeSet>((15, ADDRESS).into(), entry_at15).unwrap();
+        tx.put::<tables::StorageChangeSets>((3, ADDRESS).into(), entry_at3).unwrap();
+        tx.put::<tables::StorageChangeSets>((4, HIGHER_ADDRESS).into(), higher_entry_at4).unwrap();
+        tx.put::<tables::StorageChangeSets>((7, ADDRESS).into(), entry_at7).unwrap();
+        tx.put::<tables::StorageChangeSets>((10, ADDRESS).into(), entry_at10).unwrap();
+        tx.put::<tables::StorageChangeSets>((15, ADDRESS).into(), entry_at15).unwrap();
 
         // setup plain state
         tx.put::<tables::PlainStorageState>(ADDRESS, entry_plain).unwrap();

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -168,7 +168,7 @@ impl<'a, 'b, TX: DbTx<'a>> AccountReader for HistoricalStateProviderRef<'a, 'b, 
                 .cursor_dup_read::<tables::AccountChangeSets>()?
                 .seek_by_key_subkey(changeset_block_number, address)?
                 .filter(|acc| acc.address == address)
-                .ok_or(ProviderError::AccountChangeSetsNotFound {
+                .ok_or(ProviderError::AccountChangeSetNotFound {
                     block_number: changeset_block_number,
                     address,
                 })?

--- a/crates/storage/provider/src/test_utils/blocks.rs
+++ b/crates/storage/provider/src/test_utils/blocks.rs
@@ -20,7 +20,10 @@ pub fn assert_genesis_block<DB: Database>(provider: &DatabaseProviderRW<'_, DB>,
 
     assert_eq!(tx.table::<tables::HeaderNumbers>().unwrap(), vec![(h, n)]);
     assert_eq!(tx.table::<tables::CanonicalHeaders>().unwrap(), vec![(n, h)]);
-    assert_eq!(tx.table::<tables::HeaderTerminalDifficulties>().unwrap(), vec![(n, g.difficulty.into())]);
+    assert_eq!(
+        tx.table::<tables::HeaderTerminalDifficulties>().unwrap(),
+        vec![(n, g.difficulty.into())]
+    );
     assert_eq!(
         tx.table::<tables::BlockBodyIndices>().unwrap(),
         vec![(0, StoredBlockBodyIndices::default())]

--- a/crates/storage/provider/src/test_utils/blocks.rs
+++ b/crates/storage/provider/src/test_utils/blocks.rs
@@ -38,7 +38,7 @@ pub fn assert_genesis_block<DB: Database>(provider: &DatabaseProviderRW<'_, DB>,
     // TODO check after this gets done: https://github.com/paradigmxyz/reth/issues/1588
     // Bytecodes are not reverted assert_eq!(tx.table::<tables::Bytecodes>().unwrap(), vec![]);
     assert_eq!(tx.table::<tables::AccountChangeSets>().unwrap(), vec![]);
-    assert_eq!(tx.table::<tables::StorageChangeSet>().unwrap(), vec![]);
+    assert_eq!(tx.table::<tables::StorageChangeSets>().unwrap(), vec![]);
     assert_eq!(tx.table::<tables::HashedAccounts>().unwrap(), vec![]);
     assert_eq!(tx.table::<tables::HashedStorages>().unwrap(), vec![]);
     assert_eq!(tx.table::<tables::AccountsTrie>().unwrap(), vec![]);

--- a/crates/storage/provider/src/test_utils/blocks.rs
+++ b/crates/storage/provider/src/test_utils/blocks.rs
@@ -36,8 +36,8 @@ pub fn assert_genesis_block<DB: Database>(provider: &DatabaseProviderRW<'_, DB>,
     assert_eq!(tx.table::<tables::Receipts>().unwrap(), vec![]);
     assert_eq!(tx.table::<tables::PlainAccountState>().unwrap(), vec![]);
     assert_eq!(tx.table::<tables::PlainStorageState>().unwrap(), vec![]);
-    assert_eq!(tx.table::<tables::AccountHistories>().unwrap(), vec![]);
-    assert_eq!(tx.table::<tables::StorageHistories>().unwrap(), vec![]);
+    assert_eq!(tx.table::<tables::AccountsHistory>().unwrap(), vec![]);
+    assert_eq!(tx.table::<tables::StoragesHistory>().unwrap(), vec![]);
     // TODO check after this gets done: https://github.com/paradigmxyz/reth/issues/1588
     // Bytecodes are not reverted assert_eq!(tx.table::<tables::Bytecodes>().unwrap(), vec![]);
     assert_eq!(tx.table::<tables::AccountChangeSets>().unwrap(), vec![]);

--- a/crates/storage/provider/src/test_utils/blocks.rs
+++ b/crates/storage/provider/src/test_utils/blocks.rs
@@ -20,7 +20,7 @@ pub fn assert_genesis_block<DB: Database>(provider: &DatabaseProviderRW<'_, DB>,
 
     assert_eq!(tx.table::<tables::HeaderNumbers>().unwrap(), vec![(h, n)]);
     assert_eq!(tx.table::<tables::CanonicalHeaders>().unwrap(), vec![(n, h)]);
-    assert_eq!(tx.table::<tables::HeaderTD>().unwrap(), vec![(n, g.difficulty.into())]);
+    assert_eq!(tx.table::<tables::HeaderTerminalDifficulties>().unwrap(), vec![(n, g.difficulty.into())]);
     assert_eq!(
         tx.table::<tables::BlockBodyIndices>().unwrap(),
         vec![(0, StoredBlockBodyIndices::default())]
@@ -28,23 +28,23 @@ pub fn assert_genesis_block<DB: Database>(provider: &DatabaseProviderRW<'_, DB>,
     assert_eq!(tx.table::<tables::BlockOmmers>().unwrap(), vec![]);
     assert_eq!(tx.table::<tables::BlockWithdrawals>().unwrap(), vec![]);
     assert_eq!(tx.table::<tables::Transactions>().unwrap(), vec![]);
-    assert_eq!(tx.table::<tables::TransactionBlock>().unwrap(), vec![]);
-    assert_eq!(tx.table::<tables::TxHashNumber>().unwrap(), vec![]);
+    assert_eq!(tx.table::<tables::TransactionBlocks>().unwrap(), vec![]);
+    assert_eq!(tx.table::<tables::TransactionHashNumbers>().unwrap(), vec![]);
     assert_eq!(tx.table::<tables::Receipts>().unwrap(), vec![]);
     assert_eq!(tx.table::<tables::PlainAccountState>().unwrap(), vec![]);
     assert_eq!(tx.table::<tables::PlainStorageState>().unwrap(), vec![]);
-    assert_eq!(tx.table::<tables::AccountHistory>().unwrap(), vec![]);
-    assert_eq!(tx.table::<tables::StorageHistory>().unwrap(), vec![]);
+    assert_eq!(tx.table::<tables::AccountHistories>().unwrap(), vec![]);
+    assert_eq!(tx.table::<tables::StorageHistories>().unwrap(), vec![]);
     // TODO check after this gets done: https://github.com/paradigmxyz/reth/issues/1588
     // Bytecodes are not reverted assert_eq!(tx.table::<tables::Bytecodes>().unwrap(), vec![]);
-    assert_eq!(tx.table::<tables::AccountChangeSet>().unwrap(), vec![]);
+    assert_eq!(tx.table::<tables::AccountChangeSets>().unwrap(), vec![]);
     assert_eq!(tx.table::<tables::StorageChangeSet>().unwrap(), vec![]);
-    assert_eq!(tx.table::<tables::HashedAccount>().unwrap(), vec![]);
-    assert_eq!(tx.table::<tables::HashedStorage>().unwrap(), vec![]);
+    assert_eq!(tx.table::<tables::HashedAccounts>().unwrap(), vec![]);
+    assert_eq!(tx.table::<tables::HashedStorages>().unwrap(), vec![]);
     assert_eq!(tx.table::<tables::AccountsTrie>().unwrap(), vec![]);
     assert_eq!(tx.table::<tables::StoragesTrie>().unwrap(), vec![]);
-    assert_eq!(tx.table::<tables::TxSenders>().unwrap(), vec![]);
-    // SyncStage is not updated in tests
+    assert_eq!(tx.table::<tables::TransactionSenders>().unwrap(), vec![]);
+    // SyncStages is not updated in tests
 }
 
 /// Test chain with genesis, blocks, execution results

--- a/crates/storage/provider/src/traits/hashing.rs
+++ b/crates/storage/provider/src/traits/hashing.rs
@@ -20,7 +20,7 @@ pub trait HashingWriter: Send + Sync {
         range: RangeInclusive<BlockNumber>,
     ) -> Result<BTreeMap<H256, Option<Account>>>;
 
-    /// Inserts all accounts into [reth_db::tables::AccountHistory] table.
+    /// Inserts all accounts into [reth_db::tables::AccountHistories] table.
     ///
     /// # Returns
     ///

--- a/crates/storage/provider/src/traits/hashing.rs
+++ b/crates/storage/provider/src/traits/hashing.rs
@@ -20,7 +20,7 @@ pub trait HashingWriter: Send + Sync {
         range: RangeInclusive<BlockNumber>,
     ) -> Result<BTreeMap<H256, Option<Account>>>;
 
-    /// Inserts all accounts into [reth_db::tables::AccountHistories] table.
+    /// Inserts all accounts into [reth_db::tables::AccountsHistory] table.
     ///
     /// # Returns
     ///

--- a/crates/storage/provider/src/traits/history.rs
+++ b/crates/storage/provider/src/traits/history.rs
@@ -15,7 +15,7 @@ pub trait HistoryWriter: Send + Sync {
     /// Returns number of changesets walked.
     fn unwind_account_history_indices(&self, range: RangeInclusive<BlockNumber>) -> Result<usize>;
 
-    /// Insert account change index to database. Used inside AccountHistoryIndex stage
+    /// Insert account change index to database. Used inside AccountHistoriesIndex stage
     fn insert_account_history_index(
         &self,
         account_transitions: BTreeMap<Address, Vec<u64>>,
@@ -26,7 +26,7 @@ pub trait HistoryWriter: Send + Sync {
     /// Returns number of changesets walked.
     fn unwind_storage_history_indices(&self, range: Range<BlockNumberAddress>) -> Result<usize>;
 
-    /// Insert storage change index to database. Used inside StorageHistoryIndex stage
+    /// Insert storage change index to database. Used inside StorageHistoriesIndex stage
     fn insert_storage_history_index(
         &self,
         storage_transitions: BTreeMap<(Address, H256), Vec<u64>>,

--- a/crates/storage/provider/src/traits/history.rs
+++ b/crates/storage/provider/src/traits/history.rs
@@ -15,7 +15,7 @@ pub trait HistoryWriter: Send + Sync {
     /// Returns number of changesets walked.
     fn unwind_account_history_indices(&self, range: RangeInclusive<BlockNumber>) -> Result<usize>;
 
-    /// Insert account change index to database. Used inside AccountHistoriesIndex stage
+    /// Insert account change index to database. Used inside AccountsHistoryIndex stage
     fn insert_account_history_index(
         &self,
         account_transitions: BTreeMap<Address, Vec<u64>>,
@@ -26,7 +26,7 @@ pub trait HistoryWriter: Send + Sync {
     /// Returns number of changesets walked.
     fn unwind_storage_history_indices(&self, range: Range<BlockNumberAddress>) -> Result<usize>;
 
-    /// Insert storage change index to database. Used inside StorageHistoriesIndex stage
+    /// Insert storage change index to database. Used inside StoragesHistoryIndex stage
     fn insert_storage_history_index(
         &self,
         storage_transitions: BTreeMap<(Address, H256), Vec<u64>>,

--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -45,14 +45,14 @@ mod test {
         provider.append_blocks_with_post_state(vec![block1.clone()], exec_res1.clone()).unwrap();
 
         assert_eq!(
-            provider.table::<tables::AccountHistories>().unwrap(),
+            provider.table::<tables::AccountsHistory>().unwrap(),
             vec![
                 (acc1_shard_key.clone(), IntegerList::new(vec![1]).unwrap()),
                 (acc2_shard_key.clone(), IntegerList::new(vec![1]).unwrap())
             ]
         );
         assert_eq!(
-            provider.table::<tables::StorageHistories>().unwrap(),
+            provider.table::<tables::StoragesHistory>().unwrap(),
             vec![(storage1_shard_key.clone(), IntegerList::new(vec![1]).unwrap())]
         );
 
@@ -69,22 +69,22 @@ mod test {
         assert_genesis_block(&provider, genesis.clone());
 
         // check if history is empty.
-        assert_eq!(provider.table::<tables::AccountHistories>().unwrap(), vec![]);
-        assert_eq!(provider.table::<tables::StorageHistories>().unwrap(), vec![]);
+        assert_eq!(provider.table::<tables::AccountsHistory>().unwrap(), vec![]);
+        assert_eq!(provider.table::<tables::StoragesHistory>().unwrap(), vec![]);
 
         provider.append_blocks_with_post_state(vec![block1.clone()], exec_res1.clone()).unwrap();
         provider.append_blocks_with_post_state(vec![block2.clone()], exec_res2.clone()).unwrap();
 
         // check history of two blocks
         assert_eq!(
-            provider.table::<tables::AccountHistories>().unwrap(),
+            provider.table::<tables::AccountsHistory>().unwrap(),
             vec![
                 (acc1_shard_key, IntegerList::new(vec![1, 2]).unwrap()),
                 (acc2_shard_key, IntegerList::new(vec![1]).unwrap())
             ]
         );
         assert_eq!(
-            provider.table::<tables::StorageHistories>().unwrap(),
+            provider.table::<tables::StoragesHistory>().unwrap(),
             vec![(storage1_shard_key, IntegerList::new(vec![1, 2]).unwrap())]
         );
         provider.commit().unwrap();

--- a/crates/storage/provider/src/transaction.rs
+++ b/crates/storage/provider/src/transaction.rs
@@ -45,14 +45,14 @@ mod test {
         provider.append_blocks_with_post_state(vec![block1.clone()], exec_res1.clone()).unwrap();
 
         assert_eq!(
-            provider.table::<tables::AccountHistory>().unwrap(),
+            provider.table::<tables::AccountHistories>().unwrap(),
             vec![
                 (acc1_shard_key.clone(), IntegerList::new(vec![1]).unwrap()),
                 (acc2_shard_key.clone(), IntegerList::new(vec![1]).unwrap())
             ]
         );
         assert_eq!(
-            provider.table::<tables::StorageHistory>().unwrap(),
+            provider.table::<tables::StorageHistories>().unwrap(),
             vec![(storage1_shard_key.clone(), IntegerList::new(vec![1]).unwrap())]
         );
 
@@ -69,22 +69,22 @@ mod test {
         assert_genesis_block(&provider, genesis.clone());
 
         // check if history is empty.
-        assert_eq!(provider.table::<tables::AccountHistory>().unwrap(), vec![]);
-        assert_eq!(provider.table::<tables::StorageHistory>().unwrap(), vec![]);
+        assert_eq!(provider.table::<tables::AccountHistories>().unwrap(), vec![]);
+        assert_eq!(provider.table::<tables::StorageHistories>().unwrap(), vec![]);
 
         provider.append_blocks_with_post_state(vec![block1.clone()], exec_res1.clone()).unwrap();
         provider.append_blocks_with_post_state(vec![block2.clone()], exec_res2.clone()).unwrap();
 
         // check history of two blocks
         assert_eq!(
-            provider.table::<tables::AccountHistory>().unwrap(),
+            provider.table::<tables::AccountHistories>().unwrap(),
             vec![
                 (acc1_shard_key, IntegerList::new(vec![1, 2]).unwrap()),
                 (acc2_shard_key, IntegerList::new(vec![1]).unwrap())
             ]
         );
         assert_eq!(
-            provider.table::<tables::StorageHistory>().unwrap(),
+            provider.table::<tables::StorageHistories>().unwrap(),
             vec![(storage1_shard_key, IntegerList::new(vec![1, 2]).unwrap())]
         );
         provider.commit().unwrap();

--- a/crates/trie/src/hashed_cursor/default.rs
+++ b/crates/trie/src/hashed_cursor/default.rs
@@ -1,4 +1,4 @@
-use super::{HashedAccountCursor, HashedCursorFactory, HashedStorageCursor};
+use super::{HashedAccountsCursor, HashedCursorFactory, HashedStoragesCursor};
 use reth_db::{
     cursor::{DbCursorRO, DbDupCursorRO},
     tables,
@@ -7,21 +7,21 @@ use reth_db::{
 use reth_primitives::{Account, StorageEntry, H256};
 
 impl<'a, 'tx, TX: DbTx<'tx>> HashedCursorFactory<'a> for TX {
-    type AccountCursor = <TX as DbTxGAT<'a>>::Cursor<tables::HashedAccount> where Self: 'a;
-    type StorageCursor = <TX as DbTxGAT<'a>>::DupCursor<tables::HashedStorage> where Self: 'a;
+    type AccountCursor = <TX as DbTxGAT<'a>>::Cursor<tables::HashedAccounts> where Self: 'a;
+    type StorageCursor = <TX as DbTxGAT<'a>>::DupCursor<tables::HashedStorages> where Self: 'a;
 
     fn hashed_account_cursor(&'a self) -> Result<Self::AccountCursor, reth_db::DatabaseError> {
-        self.cursor_read::<tables::HashedAccount>()
+        self.cursor_read::<tables::HashedAccounts>()
     }
 
     fn hashed_storage_cursor(&'a self) -> Result<Self::StorageCursor, reth_db::DatabaseError> {
-        self.cursor_dup_read::<tables::HashedStorage>()
+        self.cursor_dup_read::<tables::HashedStorages>()
     }
 }
 
-impl<'tx, C> HashedAccountCursor for C
+impl<'tx, C> HashedAccountsCursor for C
 where
-    C: DbCursorRO<'tx, tables::HashedAccount>,
+    C: DbCursorRO<'tx, tables::HashedAccounts>,
 {
     fn seek(&mut self, key: H256) -> Result<Option<(H256, Account)>, reth_db::DatabaseError> {
         self.seek(key)
@@ -32,9 +32,9 @@ where
     }
 }
 
-impl<'tx, C> HashedStorageCursor for C
+impl<'tx, C> HashedStoragesCursor for C
 where
-    C: DbCursorRO<'tx, tables::HashedStorage> + DbDupCursorRO<'tx, tables::HashedStorage>,
+    C: DbCursorRO<'tx, tables::HashedStorages> + DbDupCursorRO<'tx, tables::HashedStorages>,
 {
     fn is_storage_empty(&mut self, key: H256) -> Result<bool, reth_db::DatabaseError> {
         Ok(self.seek_exact(key)?.is_none())

--- a/crates/trie/src/hashed_cursor/mod.rs
+++ b/crates/trie/src/hashed_cursor/mod.rs
@@ -10,11 +10,11 @@ pub use post_state::*;
 /// The factory trait for creating cursors over the hashed state.
 pub trait HashedCursorFactory<'a> {
     /// The hashed account cursor type.
-    type AccountCursor: HashedAccountCursor
+    type AccountCursor: HashedAccountsCursor
     where
         Self: 'a;
     /// The hashed storage cursor type.
-    type StorageCursor: HashedStorageCursor
+    type StorageCursor: HashedStoragesCursor
     where
         Self: 'a;
 
@@ -26,7 +26,7 @@ pub trait HashedCursorFactory<'a> {
 }
 
 /// The cursor for iterating over hashed accounts.
-pub trait HashedAccountCursor {
+pub trait HashedAccountsCursor {
     /// Seek an entry greater or equal to the given key and position the cursor there.
     fn seek(&mut self, key: H256) -> Result<Option<(H256, Account)>, reth_db::DatabaseError>;
 
@@ -35,7 +35,7 @@ pub trait HashedAccountCursor {
 }
 
 /// The cursor for iterating over hashed storage entries.
-pub trait HashedStorageCursor {
+pub trait HashedStoragesCursor {
     /// Returns `true` if there are no entries for a given key.
     fn is_storage_empty(&mut self, key: H256) -> Result<bool, reth_db::DatabaseError>;
 

--- a/crates/trie/src/prefix_set/loader.rs
+++ b/crates/trie/src/prefix_set/loader.rs
@@ -62,7 +62,7 @@ where
 
         // Walk storage changeset and insert storage prefixes as well as account prefixes if missing
         // from the account prefix set.
-        let mut storage_cursor = self.cursor_dup_read::<tables::StorageChangeSet>()?;
+        let mut storage_cursor = self.cursor_dup_read::<tables::StorageChangeSets>()?;
         let storage_range = BlockNumberAddress::range(range);
         for storage_entry in storage_cursor.walk_range(storage_range)? {
             let (BlockNumberAddress((_, address)), StorageEntry { key, .. }) = storage_entry?;

--- a/crates/trie/src/prefix_set/loader.rs
+++ b/crates/trie/src/prefix_set/loader.rs
@@ -48,7 +48,7 @@ where
         let mut loaded_prefix_sets = LoadedPrefixSets::default();
 
         // Walk account changeset and insert account prefixes.
-        let mut account_changeset_cursor = self.cursor_read::<tables::AccountChangeSet>()?;
+        let mut account_changeset_cursor = self.cursor_read::<tables::AccountChangeSets>()?;
         let mut account_plain_state_cursor = self.cursor_read::<tables::PlainAccountState>()?;
         for account_entry in account_changeset_cursor.walk_range(range.clone())? {
             let (_, AccountBeforeTx { address, .. }) = account_entry?;

--- a/crates/trie/src/proof.rs
+++ b/crates/trie/src/proof.rs
@@ -1,6 +1,6 @@
 use crate::{
     account::EthAccount,
-    hashed_cursor::{HashedAccountCursor, HashedCursorFactory},
+    hashed_cursor::{HashedAccountsCursor, HashedCursorFactory},
     prefix_set::PrefixSet,
     trie_cursor::{AccountTrieCursor, TrieCursor},
     walker::TrieWalker,

--- a/crates/trie/src/trie.rs
+++ b/crates/trie/src/trie.rs
@@ -1,6 +1,6 @@
 use crate::{
     account::EthAccount,
-    hashed_cursor::{HashedAccountCursor, HashedCursorFactory, HashedStorageCursor},
+    hashed_cursor::{HashedAccountsCursor, HashedCursorFactory, HashedStoragesCursor},
     prefix_set::{PrefixSet, PrefixSetLoader, PrefixSetMut},
     progress::{IntermediateStateRootState, StateRootProgress},
     trie_cursor::{AccountTrieCursor, StorageTrieCursor},
@@ -563,7 +563,7 @@ mod tests {
         storage: &BTreeMap<H256, U256>,
     ) {
         let hashed_address = keccak256(address);
-        tx.put::<tables::HashedAccount>(hashed_address, account).unwrap();
+        tx.put::<tables::HashedAccounts>(hashed_address, account).unwrap();
         insert_storage(tx, hashed_address, storage);
     }
 
@@ -573,7 +573,7 @@ mod tests {
         storage: &BTreeMap<H256, U256>,
     ) {
         for (k, v) in storage {
-            tx.put::<tables::HashedStorage>(
+            tx.put::<tables::HashedStorages>(
                 hashed_address,
                 StorageEntry { key: keccak256(k), value: *v },
             )
@@ -588,7 +588,7 @@ mod tests {
         let hashed_address = H256::from_low_u64_be(1);
 
         let mut hashed_storage_cursor =
-            tx.tx_ref().cursor_dup_write::<tables::HashedStorage>().unwrap();
+            tx.tx_ref().cursor_dup_write::<tables::HashedStorages>().unwrap();
         let data = inputs.iter().map(|x| H256::from_str(x).unwrap());
         let value = U256::from(0);
         for key in data {
@@ -653,7 +653,7 @@ mod tests {
             let factory = ProviderFactory::new(db.as_ref(), MAINNET.clone());
             let tx = factory.provider_rw().unwrap();
             for (key, value) in &storage {
-                tx.tx_ref().put::<tables::HashedStorage>(
+                tx.tx_ref().put::<tables::HashedStorages>(
                     hashed_address,
                     StorageEntry { key: keccak256(key), value: *value },
                 )
@@ -859,7 +859,7 @@ mod tests {
         );
 
         let mut hashed_storage_cursor =
-            tx.tx_ref().cursor_dup_write::<tables::HashedStorage>().unwrap();
+            tx.tx_ref().cursor_dup_write::<tables::HashedStorages>().unwrap();
         for (hashed_slot, value) in storage.clone() {
             hashed_storage_cursor.upsert(key3, StorageEntry { key: hashed_slot, value }).unwrap();
         }
@@ -889,9 +889,9 @@ mod tests {
         let tx = factory.provider_rw().unwrap();
 
         let mut hashed_account_cursor =
-            tx.tx_ref().cursor_write::<tables::HashedAccount>().unwrap();
+            tx.tx_ref().cursor_write::<tables::HashedAccounts>().unwrap();
         let mut hashed_storage_cursor =
-            tx.tx_ref().cursor_dup_write::<tables::HashedStorage>().unwrap();
+            tx.tx_ref().cursor_dup_write::<tables::HashedStorages>().unwrap();
 
         let mut hash_builder = HashBuilder::default();
 
@@ -1082,7 +1082,7 @@ mod tests {
 
         {
             let mut hashed_account_cursor =
-                tx.tx_ref().cursor_write::<tables::HashedAccount>().unwrap();
+                tx.tx_ref().cursor_write::<tables::HashedAccounts>().unwrap();
 
             let account = hashed_account_cursor.seek_exact(key2).unwrap().unwrap();
             hashed_account_cursor.delete_current().unwrap();
@@ -1136,7 +1136,7 @@ mod tests {
         let tx = factory.provider_rw().unwrap();
         {
             let mut hashed_account_cursor =
-                tx.tx_ref().cursor_write::<tables::HashedAccount>().unwrap();
+                tx.tx_ref().cursor_write::<tables::HashedAccounts>().unwrap();
 
             let account2 = hashed_account_cursor.seek_exact(key2).unwrap().unwrap();
             hashed_account_cursor.delete_current().unwrap();
@@ -1249,7 +1249,7 @@ mod tests {
                 let db = create_test_rw_db();
                 let factory = ProviderFactory::new(db.as_ref(), MAINNET.clone());
                 let tx = factory.provider_rw().unwrap();
-                let mut hashed_account_cursor = tx.tx_ref().cursor_write::<tables::HashedAccount>().unwrap();
+                let mut hashed_account_cursor = tx.tx_ref().cursor_write::<tables::HashedAccounts>().unwrap();
 
                 let mut state = BTreeMap::default();
                 for accounts in account_changes {
@@ -1312,7 +1312,7 @@ mod tests {
     ) -> (H256, HashMap<Nibbles, BranchNodeCompact>) {
         let value = U256::from(1);
 
-        let mut hashed_storage = tx.tx_ref().cursor_write::<tables::HashedStorage>().unwrap();
+        let mut hashed_storage = tx.tx_ref().cursor_write::<tables::HashedStorages>().unwrap();
 
         let mut hb = HashBuilder::default().with_updates(true);
 
@@ -1338,7 +1338,7 @@ mod tests {
             Account { nonce: 0, balance: U256::from(1u64), bytecode_hash: Some(H256::random()) };
         let val = encode_account(a, None);
 
-        let mut hashed_accounts = tx.tx_ref().cursor_write::<tables::HashedAccount>().unwrap();
+        let mut hashed_accounts = tx.tx_ref().cursor_write::<tables::HashedAccounts>().unwrap();
         let mut hb = HashBuilder::default();
 
         for key in [

--- a/docs/crates/db.md
+++ b/docs/crates/db.md
@@ -51,7 +51,7 @@ There are many tables within the node, all used to store different types of data
 - AccountHistories
 - StorageHistories
 - AccountChangeSets
-- StorageChangeSet
+- StorageChangeSets
 - HashedAccounts
 - HashedStorages
 - AccountsTrie

--- a/docs/crates/db.md
+++ b/docs/crates/db.md
@@ -35,7 +35,7 @@ The `Table` trait has two generic values, `Key` and `Value`, which need to imple
 There are many tables within the node, all used to store different types of data from `Headers` to `Transactions` and more. Below is a list of all of the tables. You can follow [this link](https://github.com/paradigmxyz/reth/blob/1563506aea09049a85e5cc72c2894f3f7a371581/crates/storage/db/src/tables/mod.rs#L161-L188) if you would like to see the table definitions for any of the tables below.
 
 - CanonicalHeaders
-- HeaderTD
+- HeaderTerminalDifficulties
 - HeaderNumbers
 - Headers
 - BlockBodyIndices
@@ -43,22 +43,22 @@ There are many tables within the node, all used to store different types of data
 - BlockWithdrawals
 - TransactionBlock
 - Transactions
-- TxHashNumber
+- TransactionHashNumbers
 - Receipts
 - PlainAccountState
 - PlainStorageState
 - Bytecodes
-- AccountHistory
-- StorageHistory
-- AccountChangeSet
+- AccountHistories
+- StorageHistories
+- AccountChangeSets
 - StorageChangeSet
-- HashedAccount
-- HashedStorage
+- HashedAccounts
+- HashedStorages
 - AccountsTrie
 - StoragesTrie
-- TxSenders
-- SyncStage
-- SyncStageProgress
+- TransactionSenders
+- SyncStages
+- SyncStagesProgresses
 - PruneCheckpoints
 
 <br>
@@ -264,7 +264,7 @@ This next example uses the `DbTx::cursor()` method to get a `Cursor`. The `Curso
     // Get transaction of the block that we are executing.
     let mut tx = db_tx.cursor_read::<tables::Transactions>()?;
     // Skip sender recovery and load signer from database.
-    let mut tx_sender = db_tx.cursor_read::<tables::TxSenders>()?;
+    let mut tx_sender = db_tx.cursor_read::<tables::TransactionSenders>()?;
 
 ```
 

--- a/docs/crates/db.md
+++ b/docs/crates/db.md
@@ -48,8 +48,8 @@ There are many tables within the node, all used to store different types of data
 - PlainAccountState
 - PlainStorageState
 - Bytecodes
-- AccountHistories
-- StorageHistories
+- AccountsHistory
+- StoragesHistory
 - AccountChangeSets
 - StorageChangeSets
 - HashedAccounts

--- a/docs/crates/stages.md
+++ b/docs/crates/stages.md
@@ -194,11 +194,11 @@ At the end of the `execute()` function, a familiar value is returned, `Ok(ExecOu
 * TODO: explain stage
 <br>
 
-## IndexStorageHistoryStage
+## IndexStorageHistoriesStage
 * TODO: explain stage
 <br>
 
-## IndexAccountHistoryStage
+## IndexAccountHistoriesStage
 * TODO: explain stage
 <br>
 

--- a/docs/crates/stages.md
+++ b/docs/crates/stages.md
@@ -194,11 +194,11 @@ At the end of the `execute()` function, a familiar value is returned, `Ok(ExecOu
 * TODO: explain stage
 <br>
 
-## IndexStorageHistoriesStage
+## IndexStoragesHistoryStage
 * TODO: explain stage
 <br>
 
-## IndexAccountHistoriesStage
+## IndexAccountsHistoryStage
 * TODO: explain stage
 <br>
 

--- a/docs/design/database.md
+++ b/docs/design/database.md
@@ -97,11 +97,11 @@ AccountChangeSets {
     H256 Account "PK"
     ChangeSet AccountChangeSets "Account before transition"
 }
-StorageChangeSet {
+StorageChangeSets {
     u64 BlockNumber "PK"
     H256 Account "PK"
     H256 StorageKey "PK"
-    ChangeSet StorageChangeSet "Storage entry before transition"
+    ChangeSet StorageChangeSets "Storage entry before transition"
 }
 HashedAccounts {
     H256 HashedAddress "PK"
@@ -129,9 +129,9 @@ TransactionHashNumbers ||--|| Transactions : "hash -> tx id"
 TransactionBlocks ||--|{ Transactions : "tx id -> block number"
 BlockBodyIndices ||--o{ Transactions : "block number -> tx ids"
 Headers ||--o{ AccountChangeSets : "each block has zero or more changesets"
-Headers ||--o{ StorageChangeSet : "each block has zero or more changesets"
+Headers ||--o{ StorageChangeSets : "each block has zero or more changesets"
 AccountHistories }|--|{ AccountChangeSets : index
-StorageHistories }|--|{ StorageChangeSet : index
+StorageHistories }|--|{ StorageChangeSets : index
 Headers ||--o| BlockOmmers : "each block has 0 or more ommers"
 BlockBodyIndices ||--|| Headers : "index"
 HeaderNumbers |o--|| Headers : "block hash -> block number"

--- a/docs/design/database.md
+++ b/docs/design/database.md
@@ -83,11 +83,11 @@ PlainStorageState {
     H256 StorageKey "PK"
     U256 StorageValue
 }
-AccountHistories {
+AccountsHistory {
     H256 Account "PK"
     BlockNumberList BlockNumberList "List of transitions where account was changed"
 }
-StorageHistories {
+StoragesHistory {
     H256 Account "PK"
     H256 StorageKey "PK"
     BlockNumberList BlockNumberList "List of transitions where account storage entry was changed"
@@ -130,8 +130,8 @@ TransactionBlocks ||--|{ Transactions : "tx id -> block number"
 BlockBodyIndices ||--o{ Transactions : "block number -> tx ids"
 Headers ||--o{ AccountChangeSets : "each block has zero or more changesets"
 Headers ||--o{ StorageChangeSets : "each block has zero or more changesets"
-AccountHistories }|--|{ AccountChangeSets : index
-StorageHistories }|--|{ StorageChangeSets : index
+AccountsHistory }|--|{ AccountChangeSets : index
+StoragesHistory }|--|{ StorageChangeSets : index
 Headers ||--o| BlockOmmers : "each block has 0 or more ommers"
 BlockBodyIndices ||--|| Headers : "index"
 HeaderNumbers |o--|| Headers : "block hash -> block number"

--- a/docs/design/database.md
+++ b/docs/design/database.md
@@ -58,11 +58,11 @@ Transactions {
     u64 TxNumber "PK"
     TransactionSignedNoHash Data
 }
-TxHashNumber {
+TransactionHashNumbers {
     H256 TxHash "PK"
     u64 TxNumber
 }
-TransactionBlock {
+TransactionBlocks {
     u64 MaxTxNumber "PK"
     u64 BlockNumber
 }
@@ -83,19 +83,19 @@ PlainStorageState {
     H256 StorageKey "PK"
     U256 StorageValue
 }
-AccountHistory {
+AccountHistories {
     H256 Account "PK"
     BlockNumberList BlockNumberList "List of transitions where account was changed"
 }
-StorageHistory {
+StorageHistories {
     H256 Account "PK"
     H256 StorageKey "PK"
     BlockNumberList BlockNumberList "List of transitions where account storage entry was changed"
 }
-AccountChangeSet {
+AccountChangeSets {
     u64 BlockNumber "PK"
     H256 Account "PK"
-    ChangeSet AccountChangeSet "Account before transition"
+    ChangeSet AccountChangeSets "Account before transition"
 }
 StorageChangeSet {
     u64 BlockNumber "PK"
@@ -103,13 +103,13 @@ StorageChangeSet {
     H256 StorageKey "PK"
     ChangeSet StorageChangeSet "Storage entry before transition"
 }
-HashedAccount {
+HashedAccounts {
     H256 HashedAddress "PK"
     Account Data
 }
-HashedStorage {
+HashedStorages {
     H256 HashedAddress "PK"
-    H256 HashedStorageKey "PK"
+    H256 HashedStoragesKey "PK"
     U256 StorageValue
 }
 AccountsTrie {
@@ -121,17 +121,17 @@ StoragesTrie {
     StoredNibblesSubKey NibblesSubKey "PK"
     StorageTrieEntry Node
 }
-TxSenders {
+TransactionSenders {
     u64 TxNumber "PK"
     Address Sender
 }
-TxHashNumber ||--|| Transactions : "hash -> tx id"
-TransactionBlock ||--|{ Transactions : "tx id -> block number"
+TransactionHashNumbers ||--|| Transactions : "hash -> tx id"
+TransactionBlocks ||--|{ Transactions : "tx id -> block number"
 BlockBodyIndices ||--o{ Transactions : "block number -> tx ids"
-Headers ||--o{ AccountChangeSet : "each block has zero or more changesets"
+Headers ||--o{ AccountChangeSets : "each block has zero or more changesets"
 Headers ||--o{ StorageChangeSet : "each block has zero or more changesets"
-AccountHistory }|--|{ AccountChangeSet : index
-StorageHistory }|--|{ StorageChangeSet : index
+AccountHistories }|--|{ AccountChangeSets : index
+StorageHistories }|--|{ StorageChangeSet : index
 Headers ||--o| BlockOmmers : "each block has 0 or more ommers"
 BlockBodyIndices ||--|| Headers : "index"
 HeaderNumbers |o--|| Headers : "block hash -> block number"
@@ -139,8 +139,8 @@ CanonicalHeaders |o--|| Headers : "canonical chain block number -> block hash"
 Transactions ||--|| Receipts : "each tx has a receipt"
 PlainAccountState }o--o| Bytecodes : "an account can have a bytecode"
 PlainAccountState ||--o{ PlainStorageState : "an account has 0 or more storage slots"
-Transactions ||--|| TxSenders : "a tx has exactly 1 sender"
+Transactions ||--|| TransactionSenders : "a tx has exactly 1 sender"
 
-PlainAccountState ||--|| HashedAccount : "hashed representation"
-PlainStorageState ||--|| HashedStorage : "hashed representation"
+PlainAccountState ||--|| HashedAccounts : "hashed representation"
+PlainStorageState ||--|| HashedStorages : "hashed representation"
 ```


### PR DESCRIPTION
Implements #3625. Please do not merge as it's S-breaking

New table names:

```rust
 const TABLES: [(TableType, &str); NUM_TABLES] = [
        (TableType::Table, CanonicalHeaders::const_name()),
        (TableType::Table, HeaderTerminalDifficulties::const_name()),
        (TableType::Table, HeaderNumbers::const_name()),
        (TableType::Table, Headers::const_name()),
        (TableType::Table, BlockBodyIndices::const_name()),
        (TableType::Table, BlockOmmers::const_name()),
        (TableType::Table, BlockWithdrawals::const_name()),
        (TableType::Table, TransactionBlocks::const_name()),
        (TableType::Table, Transactions::const_name()),
        (TableType::Table, TransactionHashNumbers::const_name()),
        (TableType::Table, Receipts::const_name()),
        (TableType::Table, PlainAccountState::const_name()),
        (TableType::DupSort, PlainStorageState::const_name()),
        (TableType::Table, Bytecodes::const_name()),
        (TableType::Table, AccountHistories::const_name()),
        (TableType::Table, StorageHistories::const_name()),
        (TableType::DupSort, AccountChangeSets::const_name()),
        (TableType::DupSort, StorageChangeSets::const_name()),
        (TableType::Table, HashedAccounts::const_name()),
        (TableType::DupSort, HashedStorages::const_name()),
        (TableType::Table, AccountsTrie::const_name()),
        (TableType::DupSort, StoragesTrie::const_name()),
        (TableType::Table, TransactionSenders::const_name()),
        (TableType::Table, SyncStages::const_name()),
        (TableType::Table, SyncStagesProgresses::const_name()),
        (TableType::Table, PruneCheckpoints::const_name()),
    ];
```