### PR TITLE
test: add backward compat toml test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5358,6 +5358,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "toml 0.7.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,6 +153,10 @@ enr = { version = "0.9", default-features = false, features = ["k256"] }
 # for eip-4844
 c-kzg = { git = "https://github.com/ethereum/c-kzg-4844" }
 
+## config
+confy = "0.5"
+toml = "0.7"
+
 ### misc-testing
 proptest = "1.0"
 arbitrary = "1.1"

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -62,8 +62,8 @@ serde.workspace = true
 serde_json.workspace = true
 shellexpand = "3.0.0"
 dirs-next = "2.0.0"
-confy = "0.5"
-toml = { version = "0.7", features = ["display"] }
+confy.workspace = true
+toml = { workspace = true, features = ["display"] }
 
 # metrics
 metrics-exporter-prometheus = "0.12.1"

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -23,6 +23,9 @@ serde_json.workspace = true
 # crypto
 secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery"] }
 
-confy = "0.5"
-
+# misc
+confy.workspace = true
 tempfile = "3.4"
+
+[dev-dependencies]
+toml.workspace = true

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -327,4 +327,96 @@ mod tests {
             assert_eq!(config, loaded_config);
         })
     }
+
+    // ensures config deserialization is backwards compatible
+    #[test]
+    fn test_backwards_compatibility() {
+        let alpha_0_0_8 = r"#[stages.headers]
+downloader_max_concurrent_requests = 100
+downloader_min_concurrent_requests = 5
+downloader_max_buffered_responses = 100
+downloader_request_limit = 1000
+commit_threshold = 10000
+
+[stages.total_difficulty]
+commit_threshold = 100000
+
+[stages.bodies]
+downloader_request_limit = 200
+downloader_stream_batch_size = 1000
+downloader_max_buffered_blocks_size_bytes = 2147483648
+downloader_min_concurrent_requests = 5
+downloader_max_concurrent_requests = 100
+
+[stages.sender_recovery]
+commit_threshold = 5000000
+
+[stages.execution]
+max_blocks = 500000
+max_changes = 5000000
+
+[stages.account_hashing]
+clean_threshold = 500000
+commit_threshold = 100000
+
+[stages.storage_hashing]
+clean_threshold = 500000
+commit_threshold = 100000
+
+[stages.merkle]
+clean_threshold = 50000
+
+[stages.transaction_lookup]
+commit_threshold = 5000000
+
+[stages.index_account_history]
+commit_threshold = 100000
+
+[stages.index_storage_history]
+commit_threshold = 100000
+
+[peers]
+refill_slots_interval = '1s'
+trusted_nodes = []
+connect_trusted_nodes_only = false
+max_backoff_count = 5
+ban_duration = '12h'
+
+[peers.connection_info]
+max_outbound = 100
+max_inbound = 30
+
+[peers.reputation_weights]
+bad_message = -16384
+bad_block = -16384
+bad_transactions = -16384
+already_seen_transactions = 0
+timeout = -4096
+bad_protocol = -2147483648
+failed_to_connect = -25600
+dropped = -4096
+
+[peers.backoff_durations]
+low = '30s'
+medium = '3m'
+high = '15m'
+max = '1h'
+
+[sessions]
+session_command_buffer = 32
+session_event_buffer = 260
+
+[sessions.limits]
+
+[sessions.initial_internal_request_timeout]
+secs = 20
+nanos = 0
+
+[sessions.protocol_breach_request_timeout]
+secs = 120
+nanos = 0
+#";
+
+        let _conf: Config = toml::from_str(alpha_0_0_8).unwrap();
+    }
 }


### PR DESCRIPTION
loading config from toml can easily break, for example, new field in a non-default type in the `Config` type.

This adds a new test that ensures deserialization is backward compatible and doesn't break