### PR TITLE
feat: add `cuckoofilter` to `nippy-jar`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,6 +1549,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuckoofilter"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b810a8449931679f64cd7eef1bbd0fa315801b6d5d9cdc1ace2804d6529eee18"
+dependencies = [
+ "byteorder",
+ "fnv",
+ "rand 0.7.3",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4117,9 +4131,11 @@ dependencies = [
  "bincode",
  "bloomfilter",
  "bytes",
+ "cuckoofilter",
  "memmap2 0.7.1",
  "ph",
  "serde",
+ "tempfile",
  "thiserror",
  "zstd",
 ]
@@ -6765,6 +6781,15 @@ dependencies = [
  "array-init",
  "serde",
  "smallvec 0.6.14",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab33ec92f677585af6d88c65593ae2375adde54efdbf16d597f2cbc7a6d368ff"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/crates/storage/nippy-jar/Cargo.toml
+++ b/crates/storage/nippy-jar/Cargo.toml
@@ -20,6 +20,7 @@ thiserror = "1.0"
 bincode = "1.3"
 serde = { version = "1.0",  features = ["derive"] }
 bytes = "1.5"
+cuckoofilter = { version = "0.5.0", features = ["serde_support", "serde_bytes"] }
 
 [features]
 default = []

--- a/crates/storage/nippy-jar/Cargo.toml
+++ b/crates/storage/nippy-jar/Cargo.toml
@@ -21,6 +21,7 @@ bincode = "1.3"
 serde = { version = "1.0",  features = ["derive"] }
 bytes = "1.5"
 cuckoofilter = { version = "0.5.0", features = ["serde_support", "serde_bytes"] }
+tempfile = "3.4"
 
 [features]
 default = []

--- a/crates/storage/nippy-jar/src/compression/mod.rs
+++ b/crates/storage/nippy-jar/src/compression/mod.rs
@@ -32,7 +32,7 @@ pub trait Compression {
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum Compressors {
     Zstd(Zstd),
-    // Acoids irrefutable let errors. Remove this after adding another one.
+    // Avoids irrefutable let errors. Remove this after adding another one.
     Unused,
 }
 

--- a/crates/storage/nippy-jar/src/filter/cuckoo.rs
+++ b/crates/storage/nippy-jar/src/filter/cuckoo.rs
@@ -4,9 +4,10 @@ use cuckoofilter::{self, CuckooFilter, ExportedCuckooFilter};
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::DefaultHasher;
 
+/// [CuckooFilter](https://www.cs.cmu.edu/~dga/papers/cuckoo-conext2014.pdf). It builds and provides an approximated set-membership filter to answer queries such as "Does this element belong to this set?". Has a theoretical 3% false positive rate.
 #[derive(Serialize, Deserialize)]
 pub struct Cuckoo {
-    /// Remaining number of elements that can be added.
+    /// Remaining number of elements that can be added. This is necessary because the inner implementation will fail on adding an element past capacity, **but it will still add it and remove other**: [source](https://github.com/axiomhq/rust-cuckoofilter/tree/624da891bed1dd5d002c8fa92ce0dcd301975561#notes--todos)
     remaining: usize,
 
     #[serde(skip)]

--- a/crates/storage/nippy-jar/src/filter/cuckoo.rs
+++ b/crates/storage/nippy-jar/src/filter/cuckoo.rs
@@ -1,0 +1,99 @@
+use super::Filter;
+use crate::NippyJarError;
+use cuckoofilter::{self, CuckooFilter, ExportedCuckooFilter};
+use serde::{Deserialize, Serialize};
+use std::collections::hash_map::DefaultHasher;
+
+#[derive(Serialize, Deserialize)]
+pub struct Cuckoo {
+    exported: Option<ExportedCuckooFilter>,
+    remaining: usize,
+    #[serde(skip)]
+    filter: Option<CuckooFilter<DefaultHasher>>, // TODO does it need an actual hasher?
+}
+
+impl Cuckoo {
+    pub fn new(max_capacity: usize) -> Self {
+        Cuckoo {
+            exported: None,
+            remaining: max_capacity,
+            filter: Some(CuckooFilter::with_capacity(max_capacity)),
+        }
+    }
+}
+
+impl Filter for Cuckoo {
+    fn add(&mut self, element: &[u8]) -> Result<(), NippyJarError> {
+        if self.remaining == 0 {
+            return Err(NippyJarError::FilterMaxCapacity)
+        }
+        let filter = self.filter.as_mut().ok_or(NippyJarError::FilterCuckooNotLoaded)?;
+
+        self.remaining -= 1;
+
+        Ok(filter.add(element)?)
+    }
+
+    fn contains(&self, element: &[u8]) -> Result<bool, NippyJarError> {
+        Ok(self.filter.as_ref().ok_or(NippyJarError::FilterCuckooNotLoaded)?.contains(element))
+    }
+
+    fn is_ready(&self) -> bool {
+        self.filter.is_some()
+    }
+
+    fn was_loaded(&mut self) {
+        self.filter = self.exported.take().map(Into::into);
+    }
+
+    fn freeze(&mut self) {
+        let filter = {
+            #[cfg(test)]
+            {
+                self.filter.as_ref()
+            }
+            #[cfg(not(test))]
+            {
+                self.filter.take()
+            }
+        };
+
+        if let Some(filter) = filter {
+            self.exported = Some(filter.export());
+        }
+    }
+}
+
+impl std::fmt::Debug for Cuckoo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Cuckoo {{ remaining_elements: {:?}, filter.is_some(): {:?}, exported.is_some(): {:?} }}",
+            self.remaining,
+            self.filter.is_some(),
+            self.exported.is_some()
+        )
+    }
+}
+
+impl PartialEq for Cuckoo {
+    fn eq(&self, other: &Self) -> bool {
+        self.remaining == other.remaining &&
+            match (&self.filter, &other.filter) {
+                (Some(_this), Some(_other)) => {
+                    #[cfg(not(test))]
+                    {
+                        unimplemented!("No way to figure it out without exporting (expensive), so only allow direct comparison on a test")
+                    }
+                    #[cfg(test)]
+                    {
+                        let f1 = _this.export();
+                        let f2 = _other.export();
+                        return f1.length == f2.length && f1.values == f2.values
+                    }
+                }
+                (None, None) => true,
+                _ => false,
+            }
+    }
+}

--- a/crates/storage/nippy-jar/src/filter/cuckoo.rs
+++ b/crates/storage/nippy-jar/src/filter/cuckoo.rs
@@ -39,12 +39,10 @@ impl Filter for Cuckoo {
 
 impl std::fmt::Debug for Cuckoo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Cuckoo {{ remaining_elements: {:?}, filter size: {:?} }}",
-            self.remaining,
-            self.filter.memory_usage(),
-        )
+        f.debug_struct("Cuckoo")
+            .field("remaining", &self.remaining)
+            .field("filter_size", &self.filter.memory_usage())
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/storage/nippy-jar/src/filter/cuckoo.rs
+++ b/crates/storage/nippy-jar/src/filter/cuckoo.rs
@@ -79,6 +79,7 @@ impl<'de> Deserialize<'de> for Cuckoo {
 }
 
 impl Serialize for Cuckoo {
+    /// Potentially expensive, but should be used only when creating the file.
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/crates/storage/nippy-jar/src/filter/cuckoo.rs
+++ b/crates/storage/nippy-jar/src/filter/cuckoo.rs
@@ -6,10 +6,15 @@ use std::collections::hash_map::DefaultHasher;
 
 #[derive(Serialize, Deserialize)]
 pub struct Cuckoo {
-    exported: Option<ExportedCuckooFilter>,
+    /// Remaining number of elements that can be added.
     remaining: usize,
+
     #[serde(skip)]
+    /// CuckooFilter. Needs to be exported to `self.exported` before it can be serialized.
     filter: Option<CuckooFilter<DefaultHasher>>, // TODO does it need an actual hasher?
+
+    /// Serializable Cuckoo filter.
+    exported: Option<ExportedCuckooFilter>,
 }
 
 impl Cuckoo {

--- a/crates/storage/nippy-jar/src/filter/cuckoo.rs
+++ b/crates/storage/nippy-jar/src/filter/cuckoo.rs
@@ -1,30 +1,21 @@
 use super::Filter;
 use crate::NippyJarError;
 use cuckoofilter::{self, CuckooFilter, ExportedCuckooFilter};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::hash_map::DefaultHasher;
 
 /// [CuckooFilter](https://www.cs.cmu.edu/~dga/papers/cuckoo-conext2014.pdf). It builds and provides an approximated set-membership filter to answer queries such as "Does this element belong to this set?". Has a theoretical 3% false positive rate.
-#[derive(Serialize, Deserialize)]
 pub struct Cuckoo {
     /// Remaining number of elements that can be added. This is necessary because the inner implementation will fail on adding an element past capacity, **but it will still add it and remove other**: [source](https://github.com/axiomhq/rust-cuckoofilter/tree/624da891bed1dd5d002c8fa92ce0dcd301975561#notes--todos)
     remaining: usize,
 
-    #[serde(skip)]
-    /// CuckooFilter. Needs to be exported to `self.exported` before it can be serialized.
+    /// CuckooFilter.
     filter: Option<CuckooFilter<DefaultHasher>>, // TODO does it need an actual hasher?
-
-    /// Serializable Cuckoo filter.
-    exported: Option<ExportedCuckooFilter>,
 }
 
 impl Cuckoo {
     pub fn new(max_capacity: usize) -> Self {
-        Cuckoo {
-            exported: None,
-            remaining: max_capacity,
-            filter: Some(CuckooFilter::with_capacity(max_capacity)),
-        }
+        Cuckoo { remaining: max_capacity, filter: Some(CuckooFilter::with_capacity(max_capacity)) }
     }
 }
 
@@ -43,41 +34,15 @@ impl Filter for Cuckoo {
     fn contains(&self, element: &[u8]) -> Result<bool, NippyJarError> {
         Ok(self.filter.as_ref().ok_or(NippyJarError::FilterCuckooNotLoaded)?.contains(element))
     }
-
-    fn is_ready(&self) -> bool {
-        self.filter.is_some()
-    }
-
-    fn was_loaded(&mut self) {
-        self.filter = self.exported.take().map(Into::into);
-    }
-
-    fn freeze(&mut self) {
-        let filter = {
-            #[cfg(test)]
-            {
-                self.filter.as_ref()
-            }
-            #[cfg(not(test))]
-            {
-                self.filter.take()
-            }
-        };
-
-        if let Some(filter) = filter {
-            self.exported = Some(filter.export());
-        }
-    }
 }
 
 impl std::fmt::Debug for Cuckoo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Cuckoo {{ remaining_elements: {:?}, filter.is_some(): {:?}, exported.is_some(): {:?} }}",
+            "Cuckoo {{ remaining_elements: {:?}, filter.is_some(): {:?} }}",
             self.remaining,
             self.filter.is_some(),
-            self.exported.is_some()
         )
     }
 }
@@ -101,5 +66,26 @@ impl PartialEq for Cuckoo {
                 (None, None) => true,
                 _ => false,
             }
+    }
+}
+
+impl<'de> Deserialize<'de> for Cuckoo {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let (remaining, exported): (usize, Option<ExportedCuckooFilter>) =
+            Deserialize::deserialize(deserializer)?;
+
+        Ok(Cuckoo { remaining, filter: exported.map(Into::into) })
+    }
+}
+
+impl Serialize for Cuckoo {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        (self.remaining, self.filter.as_ref().map(|f| f.export())).serialize(serializer)
     }
 }

--- a/crates/storage/nippy-jar/src/filter/mod.rs
+++ b/crates/storage/nippy-jar/src/filter/mod.rs
@@ -10,21 +10,6 @@ pub trait Filter {
 
     /// Checks if the element belongs to the inclusion list. There might be false positives.
     fn contains(&self, element: &[u8]) -> Result<bool, NippyJarError>;
-
-    /// Is the filter ready to be used.
-    fn is_ready(&self) -> bool {
-        true
-    }
-
-    /// Informs the filter algorithm that it was loaded from disk.
-    fn was_loaded(&mut self) {
-        unimplemented!()
-    }
-
-    /// Freezes the filter algorithm in use.
-    fn freeze(&mut self) {
-        unimplemented!()
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -45,27 +30,6 @@ impl Filter for Filters {
     fn contains(&self, element: &[u8]) -> Result<bool, NippyJarError> {
         match self {
             Filters::Cuckoo(c) => c.contains(element),
-            Filters::Unused => todo!(),
-        }
-    }
-
-    fn is_ready(&self) -> bool {
-        match self {
-            Filters::Cuckoo(c) => c.is_ready(),
-            Filters::Unused => todo!(),
-        }
-    }
-
-    fn was_loaded(&mut self) {
-        match self {
-            Filters::Cuckoo(c) => c.was_loaded(),
-            Filters::Unused => todo!(),
-        }
-    }
-
-    fn freeze(&mut self) {
-        match self {
-            Filters::Cuckoo(c) => c.freeze(),
             Filters::Unused => todo!(),
         }
     }

--- a/crates/storage/nippy-jar/src/filter/mod.rs
+++ b/crates/storage/nippy-jar/src/filter/mod.rs
@@ -5,18 +5,25 @@ mod cuckoo;
 pub use cuckoo::Cuckoo;
 
 pub trait Filter {
+    /// Add element to the inclusion list.
     fn add(&mut self, element: &[u8]) -> Result<(), NippyJarError>;
+
+    /// Checks if the element belongs to the inclusion list. There might be false positives.
     fn contains(&self, element: &[u8]) -> Result<bool, NippyJarError>;
+
+    /// Is the filter ready to be used.
     fn is_ready(&self) -> bool {
         true
     }
 
+    /// Informs the filter algorithm that it was loaded from disk.
     fn was_loaded(&mut self) {
-        unreachable!()
+        unimplemented!()
     }
 
+    /// Freezes the filter algorithm in use.
     fn freeze(&mut self) {
-        unreachable!()
+        unimplemented!()
     }
 }
 

--- a/crates/storage/nippy-jar/src/filter/mod.rs
+++ b/crates/storage/nippy-jar/src/filter/mod.rs
@@ -1,0 +1,53 @@
+use serde::{Deserialize, Serialize};
+use std::{io::Write, collections::hash_map::DefaultHasher};
+use cuckoofilter::{self, ExportedCuckooFilter, CuckooFilter};
+use crate::NippyJarError;
+
+pub trait Filter {
+    fn add(&mut self, element: &[u8]) -> Result<(), NippyJarError>;
+    fn contains(&self, element: &[u8]) -> bool;
+    fn is_ready(&self) -> bool {
+        true
+    }
+    fn was_loaded(&mut self);
+}
+
+#[derive(Serialize, Deserialize, PartialEq)]
+pub enum Filters {
+    Cuckoo(Cuckoo),
+    // Avoids irrefutable let errors. Remove this after adding another one.
+    Unused,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Cuckoo {
+    exported: Option<ExportedCuckooFilter>,
+    remaining: usize,
+    #[serde(skip)]
+    filter: Option<CuckooFilter<DefaultHasher>> // TODO does it need an actual hasher?
+}
+
+impl Cuckoo {
+    pub fn new(max_capacity: usize) -> Self {
+        Cuckoo { exported: None, remaining: 0, filter: Some(CuckooFilter::with_capacity(max_capacity)) }
+    }
+}
+
+impl Filter for Cuckoo {
+    fn add(&mut self, element: &[u8]) -> Result<(), NippyJarError> {
+        Ok(self.filter.as_mut().expect("exists").add(element)?)
+    }
+
+    fn contains(&self, element: &[u8]) -> bool {
+        self.filter.as_ref().expect("exists").contains(element)
+    }
+
+    fn is_ready(&self) -> bool {
+        self.filter.is_some()
+    }
+
+    fn was_loaded(&mut self) {
+        self.filter = self.exported.take().map(Into::into);
+    }
+}
+

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 use zstd::bulk::Decompressor;
 
 pub mod filter;
-use filter::{Filters, Cuckoo};
+use filter::{Cuckoo, Filter, Filters};
 
 pub mod compression;
 use compression::{Compression, Compressors};
@@ -55,8 +55,7 @@ impl NippyJar {
 
     /// Adds [`filter::Cuckoo`] filter.
     pub fn with_cuckoo_filter(mut self, max_capacity: usize) -> Self {
-        self.filter =
-            Some(Filters::Cuckoo(Cuckoo::new(max_capacity)));
+        self.filter = Some(Filters::Cuckoo(Cuckoo::new(max_capacity)));
         self
     }
 
@@ -66,8 +65,11 @@ impl NippyJar {
         let mut obj: Self = bincode::deserialize_from(&mut file)?;
 
         obj.path = Some(path.to_path_buf());
-        if let Some(comp) = &mut obj.compressor {
+        if let Some(comp) = obj.compressor.as_mut() {
             comp.was_loaded();
+        }
+        if let Some(filter) = obj.filter.as_mut() {
+            filter.was_loaded();
         }
 
         Ok(obj)
@@ -198,10 +200,28 @@ impl NippyJar {
     }
 
     /// Writes all necessary configuration to file.
-    fn freeze_config(&self, handle: &mut File) -> Result<(), NippyJarError> {
+    fn freeze_config(&mut self, handle: &mut File) -> Result<(), NippyJarError> {
         // TODO Split Dictionaries and Bloomfilters Configuration so we dont have to load everything
         // at once
+        if let Some(filter) = self.filter.as_mut() {
+            filter.freeze()
+        }
+
         Ok(bincode::serialize_into(handle, &self)?)
+    }
+}
+
+impl Filter for NippyJar {
+    fn add(&mut self, element: &[u8]) -> Result<(), NippyJarError> {
+        self.filter.as_mut().ok_or(NippyJarError::FilterMissing)?.add(element)
+    }
+
+    fn contains(&self, element: &[u8]) -> Result<bool, NippyJarError> {
+        self.filter.as_ref().ok_or(NippyJarError::FilterMissing)?.contains(element)
+    }
+
+    fn is_ready(&self) -> bool {
+        self.filter.as_ref().is_some_and(|f| f.is_ready())
     }
 }
 
@@ -223,6 +243,12 @@ pub enum NippyJarError {
     UnexpectedMissingValue(u64, u64),
     #[error("err")]
     FilterError(#[from] cuckoofilter::CuckooError),
+    #[error("NippyJar initialized without filter.")]
+    FilterMissing,
+    #[error("Filter has reached max capacity.")]
+    FilterMaxCapacity,
+    #[error("Cuckoo was not properly initialized after loaded.")]
+    FilterCuckooNotLoaded,
 }
 
 pub struct NippyJarCursor<'a> {
@@ -324,51 +350,66 @@ impl<'a> NippyJarCursor<'a> {
 mod tests {
     use super::*;
 
-    const TEST_FILE_NAME: &str = "nippyjar.nj";
+    fn test_data() -> (Vec<Vec<u8>>, Vec<Vec<u8>>) {
+        ((0..10u8).map(|a| vec![2, a]).collect(), (10..20u8).map(|a| vec![3, a]).collect())
+    }
+
+    #[test]
+    fn filter() {
+        let (col1, col2) = test_data();
+        let _num_columns = 2;
+        let num_rows = col1.len() as u64;
+        let file_path = tempfile::NamedTempFile::new().unwrap();
+
+        let mut nippy = NippyJar::new(_num_columns, false, file_path.path());
+
+        assert!(!Filter::is_ready(&nippy));
+        assert!(matches!(Filter::add(&mut nippy, &col1[0]), Err(NippyJarError::FilterMissing)));
+
+        nippy = nippy.with_cuckoo_filter(4);
+        assert!(Filter::is_ready(&nippy));
+
+        // Add col1[0]
+        assert!(!Filter::contains(&nippy, &col1[0]).unwrap());
+        assert!(Filter::add(&mut nippy, &col1[0]).is_ok());
+        assert!(Filter::contains(&nippy, &col1[0]).unwrap());
+
+        // Add col1[1]
+        assert!(!Filter::contains(&nippy, &col1[1]).unwrap());
+        assert!(Filter::add(&mut nippy, &col1[1]).is_ok());
+        assert!(Filter::contains(&nippy, &col1[1]).unwrap());
+
+        // // Add more columns until max_capacity
+        assert!(Filter::add(&mut nippy, &col1[2]).is_ok());
+        assert!(Filter::add(&mut nippy, &col1[3]).is_ok());
+        assert!(matches!(Filter::add(&mut nippy, &col1[4]), Err(NippyJarError::FilterMaxCapacity)));
+
+        nippy.freeze(vec![col1.clone(), col2.clone()], num_rows).unwrap();
+        let loaded_nippy = NippyJar::load(file_path.path()).unwrap();
+
+        assert_eq!(nippy, loaded_nippy);
+
+        assert!(Filter::contains(&loaded_nippy, &col1[0]).unwrap());
+        assert!(Filter::contains(&loaded_nippy, &col1[1]).unwrap());
+        assert!(Filter::contains(&loaded_nippy, &col1[2]).unwrap());
+        assert!(Filter::contains(&loaded_nippy, &col1[3]).unwrap());
+        assert!(!Filter::contains(&loaded_nippy, &col1[4]).unwrap());
+    }
 
     #[test]
     fn zstd() {
-        let col1 = vec![
-            vec![3, 0],
-            vec![3, 1],
-            vec![3, 2],
-            vec![3, 3],
-            vec![3, 4],
-            vec![3, 5],
-            vec![3, 6],
-            vec![3, 7],
-            vec![3, 8],
-        ];
-        let col2 = vec![
-            vec![3, 10],
-            vec![3, 11],
-            vec![3, 12],
-            vec![3, 13],
-            vec![3, 14],
-            vec![3, 15],
-            vec![3, 16],
-            vec![3, 17],
-            vec![3, 18],
-        ];
+        let (col1, col2) = test_data();
         let num_rows = col1.len() as u64;
         let _num_columns = 2;
+        let file_path = tempfile::NamedTempFile::new().unwrap();
 
-        let data_file = NippyJar::new(
-            _num_columns,
-            false,
-            &std::env::temp_dir().as_path().join(TEST_FILE_NAME),
-        );
+        let nippy = NippyJar::new(_num_columns, false, file_path.path());
+        assert!(nippy.compressor.is_none());
 
-        assert_eq!(data_file.compressor, None);
+        let mut nippy = NippyJar::new(_num_columns, false, file_path.path()).with_zstd(true, 5000);
+        assert!(nippy.compressor.is_some());
 
-        let mut data_file = NippyJar::new(
-            _num_columns,
-            false,
-            &std::env::temp_dir().as_path().join(TEST_FILE_NAME),
-        )
-        .with_zstd(true, 5000);
-
-        if let Some(Compressors::Zstd(zstd)) = &mut data_file.compressor {
+        if let Some(Compressors::Zstd(zstd)) = &mut nippy.compressor {
             assert!(matches!(zstd.generate_compressors(), Err(NippyJarError::CompressorNotReady)));
 
             // Make sure the number of column iterators match the initial set up ones.
@@ -376,8 +417,6 @@ mod tests {
                 zstd.prepare_compression(vec![col1.clone(), col2.clone(), col2.clone()]),
                 Err(NippyJarError::ColumnLenMismatch(_num_columns, 3))
             ));
-        } else {
-            panic!("Expected ZSTD compressor");
         }
 
         let data = vec![col1, col2];
@@ -385,28 +424,27 @@ mod tests {
         // If ZSTD is enabled, do not write to the file unless the column dictionaries have been
         // calculated.
         assert!(matches!(
-            data_file.freeze(data.clone(), num_rows),
+            nippy.freeze(data.clone(), num_rows),
             Err(NippyJarError::CompressorNotReady)
         ));
 
-        data_file.prepare(data.clone()).unwrap();
+        nippy.prepare(data.clone()).unwrap();
 
-        if let Some(Compressors::Zstd(zstd)) = &data_file.compressor {
+        if let Some(Compressors::Zstd(zstd)) = &nippy.compressor {
             assert!(matches!(
                 (&zstd.state, zstd.raw_dictionaries.as_ref().map(|dict| dict.len())),
                 (compression::ZstdState::Ready, Some(_num_columns))
             ));
         }
 
-        data_file.freeze(data.clone(), num_rows).unwrap();
+        nippy.freeze(data.clone(), num_rows).unwrap();
 
-        let written_data =
-            NippyJar::load(&std::env::temp_dir().as_path().join(TEST_FILE_NAME)).unwrap();
-        assert_eq!(data_file, written_data);
+        let loaded_nippy = NippyJar::load(file_path.path()).unwrap();
+        assert_eq!(nippy, loaded_nippy);
 
-        if let Some(Compressors::Zstd(zstd)) = &data_file.compressor {
+        if let Some(Compressors::Zstd(zstd)) = &nippy.compressor {
             let mut cursor = NippyJarCursor::new(
-                &written_data,
+                &loaded_nippy,
                 Some(Mutex::new(zstd.generate_decompressors().unwrap())),
             )
             .unwrap();


### PR DESCRIPTION
PR into #4512 

Adds [cuckoofilter](https://github.com/axiomhq/rust-cuckoofilter). There's some docs in the link on why it might be better than bloom filter.

This will be used to try and check what transaction or block hashes are included in the snapshot file (there is a 3% false positive rate), without it being necessarily saved in the data. 