### PR TITLE
fix: wake future after buffering pong

### DIFF
--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -401,6 +401,9 @@ where
                 _ if id == P2PMessageID::Ping as u8 => {
                     tracing::trace!("Received Ping, Sending Pong");
                     this.send_pong();
+                    // This is required because the `Sink` may not be polled externally, and if
+                    // that happens, the pong will never be sent.
+                    cx.waker().wake_by_ref();
                 }
                 _ if id == P2PMessageID::Disconnect as u8 => {
                     let reason = DisconnectReason::decode(&mut &decompress_buf[1..]).map_err(|err| {


### PR DESCRIPTION
This issue was uncovered in hive tests, where hive sends a single `Ping` after the eth handshake, and waits for a `Pong` response before sending any other requests over p2p. When this happens, we don't have any messages to send, so we never `poll_flush` the `Pong` out of the stream.

To fix this, we call the waker, so the `Sink` can be polled at least once after the `Stream` returns `Poll::Pending`.