### PR TITLE
feat: enforce replacements dont conflict

### DIFF
--- a/crates/rpc/rpc/src/eth/error.rs
+++ b/crates/rpc/rpc/src/eth/error.rs
@@ -475,6 +475,12 @@ pub enum RpcPoolError {
     /// Eip-4844 related error
     #[error(transparent)]
     Eip4844(#[from] Eip4844PoolTransactionError),
+    /// Thrown if a conflicting transaction type is already in the pool
+    ///
+    /// In other words, thrown if a transaction with the same sender that violates the exclusivity
+    /// constraint (blob vs normal tx)
+    #[error("address already reserved")]
+    AddressAlreadyReserved,
     #[error(transparent)]
     Other(Box<dyn std::error::Error + Send + Sync>),
 }
@@ -498,6 +504,9 @@ impl From<PoolError> for RpcPoolError {
             PoolError::InvalidTransaction(_, err) => err.into(),
             PoolError::Other(_, err) => RpcPoolError::Other(err),
             PoolError::AlreadyImported(_) => RpcPoolError::AlreadyKnown,
+            PoolError::ExistingConflictingTransactionType(_, _, _) => {
+                RpcPoolError::AddressAlreadyReserved
+            }
         }
     }
 }

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -295,6 +295,16 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
     pub(crate) fn size(&self) -> usize {
         self.transaction.size()
     }
+
+    /// EIP-4844 blob transactions and normal transactions are treated as mutually exclusive per
+    /// account.
+    ///
+    /// Returns true if the transaction is an EIP-4844 blob transaction and the other is not, or
+    /// vice versa.
+    #[inline]
+    pub(crate) fn tx_type_conflicts_with(&self, other: &Self) -> bool {
+        self.is_eip4844() != other.is_eip4844()
+    }
 }
 
 impl<T: PoolTransaction> IntoRecoveredTransaction for ValidPoolTransaction<T> {


### PR DESCRIPTION
ref #4538

Enforces that blobs can only replace blobs and normal can only replace normal

adds some docs