### PR TITLE
feat: Shuffle insertion on wipes storage. Use state wipe flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,9 +928,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 dependencies = [
  "serde",
 ]
@@ -6202,7 +6202,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "3.3.0"
-source = "git+https://github.com/bluealloy/revm.git#616cc7e5478fc21b2a7bfab5abe5b43c07a6ebac"
+source = "git+https://github.com/bluealloy/revm.git#26dc07dda5bf43d645b90ecaa986a3c4f6fe73b0"
 dependencies = [
  "auto_impl",
  "rayon",
@@ -6213,7 +6213,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "1.1.2"
-source = "git+https://github.com/bluealloy/revm.git#616cc7e5478fc21b2a7bfab5abe5b43c07a6ebac"
+source = "git+https://github.com/bluealloy/revm.git#26dc07dda5bf43d645b90ecaa986a3c4f6fe73b0"
 dependencies = [
  "derive_more",
  "enumn",
@@ -6224,7 +6224,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "2.0.3"
-source = "git+https://github.com/bluealloy/revm.git#616cc7e5478fc21b2a7bfab5abe5b43c07a6ebac"
+source = "git+https://github.com/bluealloy/revm.git#26dc07dda5bf43d645b90ecaa986a3c4f6fe73b0"
 dependencies = [
  "k256",
  "num",
@@ -6240,7 +6240,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "1.1.2"
-source = "git+https://github.com/bluealloy/revm.git#616cc7e5478fc21b2a7bfab5abe5b43c07a6ebac"
+source = "git+https://github.com/bluealloy/revm.git#26dc07dda5bf43d645b90ecaa986a3c4f6fe73b0"
 dependencies = [
  "arbitrary",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ proptest = "1.0"
 arbitrary = "1.1"
 assert_matches = "1.5.0"
 
-#[patch."https://github.com/bluealloy/revm.git"]
-#revm = { path = "../revm/crates/revm" }
-#revm-primitives = { path = "../revm/crates/primitives" }
+# [patch."https://github.com/bluealloy/revm.git"]
+# revm = { path = "../revm/crates/revm" }
+# revm-primitives = { path = "../revm/crates/primitives" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ ethers-middleware = { version = "2.0", default-features = false }
 
 ## misc
 aquamarine = "0.3"
-bytes = "1.4"
+bytes = "1.5"
 bitflags = "2.3"
 tracing = "0.1.0"
 tracing-appender = "0.2"
@@ -155,7 +155,7 @@ proptest = "1.0"
 arbitrary = "1.1"
 assert_matches = "1.5.0"
 
-# [patch."https://github.com/bluealloy/revm.git"]
-# revm = { path = "../revm/crates/revm" }
-# revm-primitives = { path = "../revm/crates/primitives" }
+#[patch."https://github.com/bluealloy/revm.git"]
+#revm = { path = "../revm/crates/revm" }
+#revm-primitives = { path = "../revm/crates/primitives" }
 

--- a/crates/storage/provider/src/change.rs
+++ b/crates/storage/provider/src/change.rs
@@ -597,6 +597,7 @@ mod tests {
             states::{
                 bundle_state::{BundleRetention, OriginalValuesKnown},
                 changes::PlainStorageRevert,
+                PlainStorageChangeset,
             },
             BundleState,
         },
@@ -715,7 +716,11 @@ mod tests {
         // Write plain state and reverts separately.
         let reverts = revm_bundle_state.take_all_reverts().into_plain_state_reverts();
         let plain_state = revm_bundle_state.into_plain_state_sorted(OriginalValuesKnown::Yes);
-        assert!(plain_state.storage.is_empty());
+        // Account B selfdestructed so flag for it should be present.
+        assert_eq!(
+            plain_state.storage,
+            [PlainStorageChangeset { address: address_b, wipe_storage: true, storage: vec![] }]
+        );
         assert!(plain_state.contracts.is_empty());
         StateChange(plain_state)
             .write_to_db(provider.tx_ref())

--- a/crates/storage/provider/src/change.rs
+++ b/crates/storage/provider/src/change.rs
@@ -219,11 +219,11 @@ impl BundleStateWithReceipts {
     /// Transform block number to the index of block.
     fn block_number_to_index(&self, block_number: BlockNumber) -> Option<usize> {
         if self.first_block > block_number {
-            return None;
+            return None
         }
         let index = block_number - self.first_block;
         if index >= self.receipts.len() as u64 {
-            return None;
+            return None
         }
         Some(index as usize)
     }
@@ -310,10 +310,10 @@ impl BundleStateWithReceipts {
         let last_block = self.last_block();
         let first_block = self.first_block;
         if block_number >= last_block {
-            return None;
+            return None
         }
         if block_number < first_block {
-            return Some(Self::default());
+            return Some(Self::default())
         }
 
         // detached number should be included so we are adding +1 to it.


### PR DESCRIPTION
Shuffle some things and make wipe of storage be done when iterating over plain storages.

Move insertion of plain storage changeset to be last.

Bump revm to newest main and bump bytes to 1.5.