### PR TITLE
fix: set trace results root trace's gas used to execution result gas

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
@@ -41,6 +41,26 @@ impl ParityTraceBuilder {
         self.nodes.iter().map(|node| node.trace.caller).collect()
     }
 
+    /// Manually the gas used of the root trace.
+    ///
+    /// The root trace's gasUsed should mirror the actual gas used by the transaction.
+    ///
+    /// This allows setting it manually by consuming the execution result's gas for example.
+    #[inline]
+    pub fn set_transaction_gas_used(&mut self, gas_used: u64) {
+        if let Some(node) = self.nodes.first_mut() {
+            node.trace.gas_used = gas_used;
+        }
+    }
+
+    /// Convenience function for [ParityTraceBuilder::set_transaction_gas_used] that consumes the
+    /// type.
+    #[inline]
+    pub fn with_transaction_gas_used(mut self, gas_used: u64) -> Self {
+        self.set_transaction_gas_used(gas_used);
+        self
+    }
+
     /// Returns the trace addresses of all call nodes in the set
     ///
     /// Each entry in the returned vector represents the [Self::trace_address] of the corresponding

--- a/crates/revm/revm-inspectors/src/tracing/mod.rs
+++ b/crates/revm/revm-inspectors/src/tracing/mod.rs
@@ -82,12 +82,35 @@ impl TracingInspector {
         }
     }
 
+    /// Manually the gas used of the root trace.
+    ///
+    /// This is useful if the root trace's gasUsed should mirror the actual gas used by the
+    /// transaction.
+    ///
+    /// This allows setting it manually by consuming the execution result's gas for example.
+    #[inline]
+    pub fn set_transaction_gas_used(&mut self, gas_used: u64) {
+        if let Some(node) = self.traces.arena.first_mut() {
+            node.trace.gas_used = gas_used;
+        }
+    }
+
+    /// Convenience function for [ParityTraceBuilder::set_transaction_gas_used] that consumes the
+    /// type.
+    #[inline]
+    pub fn with_transaction_gas_used(mut self, gas_used: u64) -> Self {
+        self.set_transaction_gas_used(gas_used);
+        self
+    }
+
     /// Consumes the Inspector and returns a [ParityTraceBuilder].
+    #[inline]
     pub fn into_parity_builder(self) -> ParityTraceBuilder {
         ParityTraceBuilder::new(self.traces.arena, self.spec_id, self.config)
     }
 
     /// Consumes the Inspector and returns a [GethTraceBuilder].
+    #[inline]
     pub fn into_geth_builder(self) -> GethTraceBuilder {
         GethTraceBuilder::new(self.traces.arena, self.config)
     }

--- a/crates/rpc/rpc-types/src/eth/trace/parity.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/parity.rs
@@ -46,7 +46,7 @@ impl TraceResults {
     ///
     /// The root trace's gasUsed should mirror the actual gas used by the transaction.
     ///
-    /// This allows setting int manually by consuming the execution result's gas for example.
+    /// This allows setting it manually by consuming the execution result's gas for example.
     pub fn set_root_trace_gas_used(&mut self, gas_used: u64) {
         if let Some(r) = self.trace.first_mut().and_then(|t| t.result.as_mut()) {
             r.set_gas_used(gas_used)

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -259,9 +259,11 @@ where
             .spawn_trace_transaction_in_block(
                 hash,
                 TracingInspectorConfig::default_parity(),
-                move |tx_info, inspector, _, _| {
-                    let traces =
-                        inspector.into_parity_builder().into_localized_transaction_traces(tx_info);
+                move |tx_info, inspector, res, _| {
+                    let traces = inspector
+                        .with_transaction_gas_used(res.result.gas_used())
+                        .into_parity_builder()
+                        .into_localized_transaction_traces(tx_info);
                     Ok(traces)
                 },
             )
@@ -364,9 +366,11 @@ where
         let traces = self.trace_block_with(
             block_id,
             TracingInspectorConfig::default_parity(),
-            |tx_info, inspector, _, _, _| {
-                let traces =
-                    inspector.into_parity_builder().into_localized_transaction_traces(tx_info);
+            |tx_info, inspector, res, _, _| {
+                let traces = inspector
+                    .with_transaction_gas_used(res.gas_used())
+                    .into_parity_builder()
+                    .into_localized_transaction_traces(tx_info);
                 Ok(traces)
             },
         );


### PR DESCRIPTION
ref #4262

another fix that applies changes of #4506 to more rpc calls