### PR TITLE
fix(state): store receipts in vec

### DIFF
--- a/crates/consensus/auto-seal/src/lib.rs
+++ b/crates/consensus/auto-seal/src/lib.rs
@@ -336,8 +336,10 @@ impl StorageInner {
         header.receipts_root = if receipts.is_empty() {
             EMPTY_RECEIPTS
         } else {
-            let receipts_with_bloom =
-                receipts.iter().map(|r| (**r).clone().into()).collect::<Vec<ReceiptWithBloom>>();
+            let receipts_with_bloom = receipts
+                .iter()
+                .map(|r| (*r).clone().expect("receipts have not been pruned").into())
+                .collect::<Vec<ReceiptWithBloom>>();
             header.logs_bloom =
                 receipts_with_bloom.iter().fold(Bloom::zero(), |bloom, r| bloom | r.bloom);
             proofs::calculate_receipt_root(&receipts_with_bloom)

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -24,7 +24,7 @@ use revm::{
     primitives::ResultAndState,
     DatabaseCommit, State, EVM,
 };
-use std::{collections::HashMap, sync::Arc, time::Instant};
+use std::{sync::Arc, time::Instant};
 use tracing::{debug, trace};
 
 /// Main block executor
@@ -35,9 +35,8 @@ pub struct EVMProcessor<'a> {
     stack: InspectorStack,
     /// The collection of receipts.
     /// Outer vector stores receipts for each block sequentially.
-    /// Inner [HashMap] stores receipts indexed by transaction index.
-    /// The map is used as receipts might be pruned.
-    receipts: Vec<HashMap<usize, Receipt>>,
+    /// The inner vector stores receipts that were not pruned.
+    receipts: Vec<Vec<Option<Receipt>>>,
     /// First block will be initialized to ZERO
     /// and be set to the block number of first block executed.
     first_block: Option<BlockNumber>,
@@ -310,9 +309,16 @@ impl<'a> EVMProcessor<'a> {
                     .last()
                     .map(|block_r| {
                         block_r
-                            .values()
+                            .iter()
                             .enumerate()
-                            .map(|(id, tx_r)| (id as u64, tx_r.cumulative_gas_used))
+                            .map(|(id, tx_r)| {
+                                (
+                                    id as u64,
+                                    tx_r.as_ref()
+                                        .expect("receipts have not been pruned")
+                                        .cumulative_gas_used,
+                                )
+                            })
                             .collect()
                     })
                     .unwrap_or_default(),
@@ -344,8 +350,7 @@ impl<'a> EVMProcessor<'a> {
 
     /// Save receipts to the executor.
     pub fn save_receipts(&mut self, receipts: Vec<Receipt>) -> Result<(), BlockExecutionError> {
-        // Index receipts by transaction index.
-        let mut receipts = receipts.into_iter().enumerate().collect();
+        let mut receipts = receipts.into_iter().map(Option::Some).collect();
         // Prune receipts if necessary.
         self.prune_receipts(&mut receipts)?;
         // Save receipts.
@@ -356,7 +361,7 @@ impl<'a> EVMProcessor<'a> {
     /// Prune receipts according to the pruning configuration.
     fn prune_receipts(
         &mut self,
-        receipts: &mut HashMap<usize, Receipt>,
+        receipts: &mut Vec<Option<Receipt>>,
     ) -> Result<(), PrunePartError> {
         let (first_block, tip) = match self.first_block.zip(self.tip) {
             Some((block, tip)) => (block, tip),
@@ -391,18 +396,17 @@ impl<'a> EVMProcessor<'a> {
             }
         }
 
-        receipts.retain(|_, receipt| {
+        for receipt in receipts.iter_mut() {
+            let inner_receipt = receipt.as_ref().expect("receipts have not been pruned");
+
             // If there is an address_filter, and it does not contain any of the
             // contract addresses, then remove this receipts
             if let Some((_, filter)) = &self.pruning_address_filter {
-                if !receipt.logs.iter().any(|log| filter.contains(&log.address)) {
-                    return false
+                if !inner_receipt.logs.iter().any(|log| filter.contains(&log.address)) {
+                    receipt.take();
                 }
             }
-            true
-        });
-
-        receipts.shrink_to_fit();
+        }
 
         Ok(())
     }

--- a/crates/rpc/rpc/src/eth/api/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/api/pending_block.rs
@@ -11,7 +11,7 @@ use reth_revm::{database::RevmDatabase, env::tx_env_with_recovered, into_reth_lo
 use reth_transaction_pool::TransactionPool;
 use revm::{db::states::bundle_state::BundleRetention, DatabaseCommit, State};
 use revm_primitives::{BlockEnv, CfgEnv, EVMError, Env, InvalidTransaction, ResultAndState};
-use std::{collections::HashMap, time::Instant};
+use std::time::Instant;
 
 /// Configured [BlockEnv] and [CfgEnv] for a pending block
 #[derive(Debug, Clone)]
@@ -50,8 +50,7 @@ impl PendingBlockEnv {
         let mut executed_txs = Vec::new();
         let mut best_txs = pool.best_transactions_with_base_fee(base_fee);
 
-        let mut receipt_idx = 0;
-        let mut receipts = HashMap::default();
+        let mut receipts = Vec::new();
 
         while let Some(pool_tx) = best_txs.next() {
             // ensure we still have capacity for this transaction
@@ -103,16 +102,12 @@ impl PendingBlockEnv {
             cumulative_gas_used += gas_used;
 
             // Push transaction changeset and calculate header bloom filter for receipt.
-            receipts.insert(
-                receipt_idx,
-                Receipt {
-                    tx_type: tx.tx_type(),
-                    success: result.is_success(),
-                    cumulative_gas_used,
-                    logs: result.logs().into_iter().map(into_reth_log).collect(),
-                },
-            );
-            receipt_idx += 1;
+            receipts.push(Some(Receipt {
+                tx_type: tx.tx_type(),
+                success: result.is_success(),
+                cumulative_gas_used,
+                logs: result.logs().into_iter().map(into_reth_log).collect(),
+            }));
 
             // append transaction to the list of executed transactions
             executed_txs.push(tx.into_signed());

--- a/crates/rpc/rpc/src/eth/cache/mod.rs
+++ b/crates/rpc/rpc/src/eth/cache/mod.rs
@@ -434,7 +434,9 @@ where
                             for block_receipts in receipts {
                                 this.on_new_receipts(
                                     block_receipts.block_hash,
-                                    Ok(Some(block_receipts.receipts)),
+                                    Ok(Some(
+                                        block_receipts.receipts.into_iter().flatten().collect(),
+                                    )),
                                 );
                             }
                         }
@@ -460,7 +462,7 @@ enum CacheAction {
 
 struct BlockReceipts {
     block_hash: H256,
-    receipts: Vec<Receipt>,
+    receipts: Vec<Option<Receipt>>,
 }
 
 /// Awaits for new chain events and directly inserts them into the cache so they're available
@@ -481,7 +483,7 @@ where
             for block in &blocks {
                 let block_receipts = BlockReceipts {
                     block_hash: block.hash,
-                    receipts: state.receipts_by_block(block.number).into_iter().cloned().collect(),
+                    receipts: state.receipts_by_block(block.number).to_vec(),
                 };
                 receipts.push(block_receipts);
             }

--- a/crates/storage/provider/src/chain.rs
+++ b/crates/storage/provider/src/chain.rs
@@ -137,7 +137,7 @@ impl Chain {
     /// Get all receipts for the given block.
     pub fn receipts_by_block_hash(&self, block_hash: BlockHash) -> Option<Vec<&Receipt>> {
         let num = self.block_number(block_hash)?;
-        self.state.receipts_by_block(num).into_iter().map(Option::as_ref).collect()
+        self.state.receipts_by_block(num).iter().map(Option::as_ref).collect()
     }
 
     /// Get all receipts with attachment.
@@ -148,7 +148,7 @@ impl Chain {
         for ((block_num, block), receipts) in self.blocks().iter().zip(self.state.receipts().iter())
         {
             let mut tx_receipts = Vec::new();
-            for (tx, receipt) in block.body.iter().zip(receipts.into_iter()) {
+            for (tx, receipt) in block.body.iter().zip(receipts.iter()) {
                 tx_receipts.push((
                     tx.hash(),
                     receipt.as_ref().expect("receipts have not been pruned").clone(),

--- a/crates/storage/provider/src/chain.rs
+++ b/crates/storage/provider/src/chain.rs
@@ -137,7 +137,7 @@ impl Chain {
     /// Get all receipts for the given block.
     pub fn receipts_by_block_hash(&self, block_hash: BlockHash) -> Option<Vec<&Receipt>> {
         let num = self.block_number(block_hash)?;
-        Some(self.state.receipts_by_block(num))
+        self.state.receipts_by_block(num).into_iter().map(Option::as_ref).collect()
     }
 
     /// Get all receipts with attachment.
@@ -147,12 +147,12 @@ impl Chain {
         let mut receipt_attch = Vec::new();
         for ((block_num, block), receipts) in self.blocks().iter().zip(self.state.receipts().iter())
         {
-            let mut receipts = receipts.iter();
             let mut tx_receipts = Vec::new();
-            for tx in block.body.iter() {
-                if let Some((_, receipt)) = receipts.next() {
-                    tx_receipts.push((tx.hash(), receipt.clone()));
-                }
+            for (tx, receipt) in block.body.iter().zip(receipts.into_iter()) {
+                tx_receipts.push((
+                    tx.hash(),
+                    receipt.as_ref().expect("receipts have not been pruned").clone(),
+                ));
             }
             let block_num_hash = BlockNumHash::new(*block_num, block.hash());
             receipt_attch.push(BlockReceipts { block: block_num_hash, tx_receipts });
@@ -405,7 +405,7 @@ mod tests {
                 vec![vec![(H160([2; 20]), None, vec![])]],
                 vec![],
             ),
-            vec![std::collections::HashMap::default()],
+            vec![vec![]],
             1,
         );
 
@@ -415,7 +415,7 @@ mod tests {
                 vec![vec![(H160([3; 20]), None, vec![])]],
                 vec![],
             ),
-            vec![std::collections::HashMap::default()],
+            vec![vec![]],
             2,
         );
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -337,13 +337,13 @@ impl<'this, TX: DbTxMut<'this> + DbTx<'this>> DatabaseProvider<'this, TX> {
         let mut receipts = Vec::new();
         // loop break if we are at the end of the blocks.
         for (_, block_body) in block_bodies.into_iter() {
-            let mut block_receipt = HashMap::with_capacity(block_body.tx_count as usize);
-            for (idx, _) in block_body.tx_num_range().enumerate() {
+            let mut block_receipts = Vec::with_capacity(block_body.tx_count as usize);
+            for _ in block_body.tx_num_range() {
                 if let Some((_, receipt)) = receipt_iter.next() {
-                    block_receipt.insert(idx, receipt);
+                    block_receipts.push(Some(receipt));
                 }
             }
-            receipts.push(block_receipt);
+            receipts.push(block_receipts);
         }
 
         Ok(BundleStateWithReceipts::new_init(

--- a/crates/storage/provider/src/test_utils/blocks.rs
+++ b/crates/storage/provider/src/test_utils/blocks.rs
@@ -128,19 +128,16 @@ fn block1(number: BlockNumber) -> (SealedBlockWithSenders, BundleStateWithReceip
             ]),
         )]),
         vec![],
-        vec![std::collections::HashMap::from([(
-            0,
-            Receipt {
-                tx_type: TxType::EIP2930,
-                success: true,
-                cumulative_gas_used: 300,
-                logs: vec![Log {
-                    address: H160([0x60; 20]),
-                    topics: vec![H256::from_low_u64_be(1), H256::from_low_u64_be(2)],
-                    data: Bytes::default(),
-                }],
-            },
-        )])],
+        vec![vec![Some(Receipt {
+            tx_type: TxType::EIP2930,
+            success: true,
+            cumulative_gas_used: 300,
+            logs: vec![Log {
+                address: H160([0x60; 20]),
+                topics: vec![H256::from_low_u64_be(1), H256::from_low_u64_be(2)],
+                data: Bytes::default(),
+            }],
+        })]],
         number,
     );
 
@@ -187,19 +184,16 @@ fn block2(
             )]),
         )]),
         vec![],
-        vec![std::collections::HashMap::from([(
-            0,
-            Receipt {
-                tx_type: TxType::EIP1559,
-                success: false,
-                cumulative_gas_used: 400,
-                logs: vec![Log {
-                    address: H160([0x61; 20]),
-                    topics: vec![H256::from_low_u64_be(3), H256::from_low_u64_be(4)],
-                    data: Bytes::default(),
-                }],
-            },
-        )])],
+        vec![vec![Some(Receipt {
+            tx_type: TxType::EIP1559,
+            success: false,
+            cumulative_gas_used: 400,
+            logs: vec![Log {
+                address: H160([0x61; 20]),
+                topics: vec![H256::from_low_u64_be(3), H256::from_low_u64_be(4)],
+                data: Bytes::default(),
+            }],
+        })]],
         number,
     );
     (SealedBlockWithSenders { block, senders: vec![H160([0x31; 20])] }, bundle)


### PR DESCRIPTION
Replaces #4557

## Description

`HashMap` broke the ordering guarantees in multiple places. Store receipts as `Vec<Option<Receipt>>` instead.