### PR TITLE
fix: update Status ForkId on new head

### DIFF
--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -176,12 +176,14 @@ impl SessionManager {
 
     /// Invoked on a received status update.
     ///
-    /// If the updated activated another fork, this will return a [`ForkTransition`] and updates the
-    /// active [`ForkId`](ForkId). See also [`ForkFilter::set_head`].
+    /// If the updated activated another fork, this will return a [ForkTransition] and updates the
+    /// active [ForkId]. See also [ForkFilter::set_head].
     pub(crate) fn on_status_update(&mut self, head: Head) -> Option<ForkTransition> {
         self.status.blockhash = head.hash;
         self.status.total_difficulty = head.total_difficulty;
-        self.fork_filter.set_head(head)
+        let transition = self.fork_filter.set_head(head);
+        self.status.forkid = self.fork_filter.current();
+        transition
     }
 
     /// An incoming TCP connection was received. This starts the authentication process to turn this


### PR DESCRIPTION
Previously we would only update the `ForkId` used in discovery, and the local `ForkFilter` when the head was updated. This updates the `ForkId` used in the `eth` handshake when there is a new canonical chain update.

Causes the rest of the `ForkID` cancun hive tests to pass (7 in total)