### PR TITLE
fix: use with_bundle_update to prevent take_bundle panic

### DIFF
--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -869,7 +869,10 @@ where
     debug!(parent_hash=?parent_block.hash, parent_number=parent_block.number,  "building empty payload");
 
     let state = client.state_by_block_hash(parent_block.hash)?;
-    let mut db = State::builder().with_database_boxed(Box::new(RevmDatabase::new(&state))).build();
+    let mut db = State::builder()
+        .with_database_boxed(Box::new(RevmDatabase::new(&state)))
+        .with_bundle_update()
+        .build();
 
     let base_fee = initialized_block_env.basefee.to::<u64>();
     let block_number = initialized_block_env.number.to::<u64>();


### PR DESCRIPTION
I had run into this issue when using the payload builder:
```log
2023-09-12T00:38:30.746878Z DEBUG reth_basic_payload_builder: building empty payload parent_hash=0xc350640ec651d2df0ccce26c9134de3c2a17aaa0cce73d8d3beb0eb625ca5f00 parent_number=0
thread 'tokio-runtime-worker' panicked at 'called `Option::unwrap()` on a `None` value', /usr/local/cargo/git/checkouts/revm-bf744d8ffabcbad9/26dc07d/crates/revm/src/db/states/state.rs:197:51
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This caused all payload building to fail, because the default was changed. Enabling `with_bundle_update` prevents the panic.