### PR TITLE
fix: ensure final message is always delivered

### DIFF
--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -458,6 +458,7 @@ impl SessionManager {
                     ),
                     internal_request_timeout: Arc::clone(&timeout),
                     protocol_breach_request_timeout: self.protocol_breach_request_timeout,
+                    terminate_message: None,
                 };
 
                 self.spawn(session);


### PR DESCRIPTION
Closes #4568

This ensures a Disconnect/ClosedOnConnectionError message is always delivered, previously we were relying on clone.try_send

this makes sure that we acquire a permit for this message