### PR TITLE
chore: silence clippy clone warning

### DIFF
--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -10,6 +10,7 @@
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
 ))]
+#![allow(clippy::incorrect_clone_impl_on_copy_type)]
 
 //! Commonly used types in reth.
 //!


### PR DESCRIPTION
This PR silence the clippy warning about the incorrect implementation of clone on Copy