### PR TITLE
chore(ci): different clippy action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all --all-features -- -A clippy::incorrect_clone_impl_on_copy_type -A clippy::arc_with_non_send_sync
+          args: --all --all-features
 
   doc-lint:
     name: doc lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,10 @@ jobs:
           args: --all --check
 
       - name: cargo clippy
-        uses: giraffate/clippy-action@v1
+        uses: actions-rs/clippy-check@v1
         with:
-          clippy_flags: --all --all-features -- -A clippy::incorrect_clone_impl_on_copy_type -A clippy::arc_with_non_send_sync
-          reporter: 'github-pr-check'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all --all-features -- -A clippy::incorrect_clone_impl_on_copy_type -A clippy::arc_with_non_send_sync
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   doc-lint:
     name: doc lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,11 @@ jobs:
           args: --all --check
 
       - name: cargo clippy
-        uses: actions-rs/clippy-check@v1
+        uses: giraffate/clippy-action@v1
         with:
-          args: --all --all-features -- -A clippy::incorrect_clone_impl_on_copy_type -A clippy::arc_with_non_send_sync
-          token: ${{ secrets.GITHUB_TOKEN }}
+          clippy_flags: --all --all-features -- -A clippy::incorrect_clone_impl_on_copy_type -A clippy::arc_with_non_send_sync
+          reporter: 'github-pr-check'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   doc-lint:
     name: doc lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,10 @@ jobs:
           args: --all --check
 
       - name: cargo clippy
-        uses: actions-rs/clippy-check@v1
+        uses: actions-rs/cargo@v1
         with:
+          command: clippy
           args: --all --all-features -- -A clippy::incorrect_clone_impl_on_copy_type -A clippy::arc_with_non_send_sync
-          token: ${{ secrets.GITHUB_TOKEN }}
 
   doc-lint:
     name: doc lint


### PR DESCRIPTION
`actions-rs/clippy-check` doesn't support human-readable output and JSON for GitHub annotations at the same time, so let's revert to just a simple Clippy run with nice reports: https://github.com/paradigmxyz/reth/actions/runs/6172583758/job/16753134321?pr=4579