### PR TITLE
perf(rpc): fetch range of blocks and return empty if unchanged

### DIFF
--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -90,15 +90,12 @@ where
                 Err(EthApiError::Unsupported("pending transaction filter not supported").into())
             }
             FilterKind::Block => {
-                let mut block_hashes = Vec::new();
-                for block_num in start_block..best_number {
-                    let block_hash = self
-                        .inner
-                        .provider
-                        .block_hash(block_num)?
-                        .ok_or(EthApiError::UnknownBlockNumber)?;
-                    block_hashes.push(block_hash);
-                }
+                // Note: this range is exclusive
+                let block_hashes = self
+                    .inner
+                    .provider
+                    .canonical_hashes_range(start_block, best_number)
+                    .map_err(|_| EthApiError::UnknownBlockNumber)?;
                 Ok(FilterChanges::Hashes(block_hashes))
             }
             FilterKind::Log(filter) => {

--- a/crates/storage/provider/src/traits/block_hash.rs
+++ b/crates/storage/provider/src/traits/block_hash.rs
@@ -19,5 +19,9 @@ pub trait BlockHashReader: Send + Sync {
     }
 
     /// Get headers in range of block hashes or numbers
+    ///
+    /// Returns the available hashes of that range.
+    ///
+    /// Note: The range is `start..end`, so the expected result is `[start..end)`
     fn canonical_hashes_range(&self, start: BlockNumber, end: BlockNumber) -> Result<Vec<H256>>;
 }


### PR DESCRIPTION
not sure if this will fix the bug described in #4590

but I think it does because the range should be inclusive

but this adds a perf improvement: fetch range in one call

return empty if no changes