### PR TITLE
fix: remove popped tx from total set

### DIFF
--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -637,9 +637,17 @@ impl<T: TransactionOrdering> TxPool<T> {
                         .$limit
                         .is_exceeded($this.$pool.len(), $this.$pool.size())
                     {
+                        // pops the worst transaction from the sub-pool
                         if let Some(tx) = $this.$pool.pop_worst() {
                             let id = tx.transaction_id;
+
+                            // now that the tx is removed from the sub-pool, we need to remove it also from the total set
+                            $this.all_transactions.remove_transaction(&id);
+
+                            // record the removed transaction
                             removed.push(tx);
+
+                            // this might have introduced a nonce gap, so we also discard any descendants
                             $this.remove_descendants(&id, &mut $removed);
                         }
                     }


### PR DESCRIPTION
this fixes bug causing unbounded memory growth because discarded txs were only popped from the subpool but never from the total set.

Fix: after popping a tx from the subpool also remove it from the total set

will add more tests after #4596