### PR TITLE
 feat: add perfect hashing function to `nippy-jar`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4151,6 +4151,7 @@ dependencies = [
  "cuckoofilter",
  "memmap2 0.7.1",
  "ph",
+ "rand 0.8.5",
  "serde",
  "tempfile",
  "thiserror",

--- a/crates/storage/nippy-jar/Cargo.toml
+++ b/crates/storage/nippy-jar/Cargo.toml
@@ -15,13 +15,18 @@ name = "reth_nippy_jar"
 memmap2 = "0.7.1"
 bloomfilter = "1"
 zstd = { version = "0.12", features = ["experimental", "zdict_builder"] }
-ph = "0.8.0"
+ph = "0.8"
 thiserror = "1.0"
 bincode = "1.3"
 serde = { version = "1.0",  features = ["derive"] }
 bytes = "1.5"
 cuckoofilter = { version = "0.5.0", features = ["serde_support", "serde_bytes"] }
 tempfile = "3.4"
+
+
+[dev-dependencies]
+rand = "0.8"
+
 
 [features]
 default = []

--- a/crates/storage/nippy-jar/Cargo.toml
+++ b/crates/storage/nippy-jar/Cargo.toml
@@ -15,7 +15,7 @@ name = "reth_nippy_jar"
 memmap2 = "0.7.1"
 bloomfilter = "1"
 zstd = { version = "0.12", features = ["experimental", "zdict_builder"] }
-ph = "0.8"
+ph = "0.8.0"
 thiserror = "1.0"
 bincode = "1.3"
 serde = { version = "1.0",  features = ["derive"] }

--- a/crates/storage/nippy-jar/src/compression/mod.rs
+++ b/crates/storage/nippy-jar/src/compression/mod.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 mod zstd;
 pub use zstd::{Zstd, ZstdState};
 
-pub trait Compression {
+pub trait Compression: Serialize + for<'a> Deserialize<'a> {
     /// Returns decompressed data.
     fn decompress(&self, value: &[u8]) -> Result<Vec<u8>, NippyJarError>;
 

--- a/crates/storage/nippy-jar/src/compression/mod.rs
+++ b/crates/storage/nippy-jar/src/compression/mod.rs
@@ -26,7 +26,8 @@ pub trait Compression: Serialize + for<'a> Deserialize<'a> {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(PartialEq))]
 pub enum Compressors {
     Zstd(Zstd),
     // Avoids irrefutable let errors. Remove this after adding another one.

--- a/crates/storage/nippy-jar/src/filter/cuckoo.rs
+++ b/crates/storage/nippy-jar/src/filter/cuckoo.rs
@@ -46,21 +46,14 @@ impl std::fmt::Debug for Cuckoo {
     }
 }
 
+#[cfg(test)]
 impl PartialEq for Cuckoo {
     fn eq(&self, _other: &Self) -> bool {
-        self.remaining == _other.remaining &&
-            {
-                #[cfg(not(test))]
-                {
-                    unimplemented!("No way to figure it out without exporting (expensive), so only allow direct comparison on a test")
-                }
-                #[cfg(test)]
-                {
-                    let f1 = self.filter.export();
-                    let f2 = _other.filter.export();
-                    return f1.length == f2.length && f1.values == f2.values
-                }
-            }
+        self.remaining == _other.remaining && {
+            let f1 = self.filter.export();
+            let f2 = _other.filter.export();
+            f1.length == f2.length && f1.values == f2.values
+        }
     }
 }
 

--- a/crates/storage/nippy-jar/src/filter/mod.rs
+++ b/crates/storage/nippy-jar/src/filter/mod.rs
@@ -12,7 +12,8 @@ pub trait Filter {
     fn contains(&self, element: &[u8]) -> Result<bool, NippyJarError>;
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(PartialEq))]
 pub enum Filters {
     Cuckoo(Cuckoo),
     // Avoids irrefutable let errors. Remove this after adding another one.

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -22,7 +22,8 @@ use phf::{Fmph, Functions, GoFmph, KeySet};
 
 const NIPPY_JAR_VERSION: usize = 1;
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct NippyJar {
     /// Version
     version: usize,

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -267,7 +267,7 @@ pub enum NippyJarError {
     FilterMaxCapacity,
     #[error("Cuckoo was not properly initialized after loaded.")]
     FilterCuckooNotLoaded,
-    #[error("Perfect hashing function wasn't added any keys.")]
+    #[error("Perfect hashing function doesn't have any keys added.")]
     PHFMissingKeys,
     #[error("NippyJar initialized without perfect hashing function.")]
     PHFMissing,

--- a/crates/storage/nippy-jar/src/phf/fmph.rs
+++ b/crates/storage/nippy-jar/src/phf/fmph.rs
@@ -1,0 +1,108 @@
+use super::KeySet;
+use crate::NippyJarError;
+use serde::{
+    de::Error as DeSerdeError, ser::Error as SerdeError, Deserialize, Deserializer, Serialize,
+    Serializer,
+};
+use std::{clone::Clone, hash::Hash, marker::Sync};
+
+/// Wrapper struct for [`ph::fmph::Function`]. Implementation of the following [paper](https://dl.acm.org/doi/10.1145/3596453).
+#[derive(Default)]
+pub struct Fmph {
+    function: Option<ph::fmph::Function>,
+}
+
+impl Fmph {
+    pub fn new() -> Self {
+        Self { function: None }
+    }
+}
+
+impl KeySet for Fmph {
+    fn set_keys<T: AsRef<[u8]> + Sync + Clone + Hash>(
+        &mut self,
+        keys: &[T],
+    ) -> Result<(), NippyJarError> {
+        self.function = Some(ph::fmph::Function::from(keys));
+        Ok(())
+    }
+
+    fn get_index(&self, key: &[u8]) -> Result<Option<u64>, NippyJarError> {
+        if let Some(f) = &self.function {
+            return Ok(f.get(key))
+        }
+        Err(NippyJarError::PHFMissingKeys)
+    }
+}
+
+impl PartialEq for Fmph {
+    fn eq(&self, other: &Self) -> bool {
+        match (&self.function, &other.function) {
+            (Some(func1), Some(func2)) => {
+                func1.level_sizes() == func2.level_sizes() &&
+                    func1.write_bytes() == func2.write_bytes() &&
+                    {
+                        #[cfg(not(test))]
+                        {
+                            unimplemented!("No way to figure it out without exporting ( potentially expensive), so only allow direct comparison on a test")
+                        }
+                        #[cfg(test)]
+                        {
+                            let mut f1 = Vec::with_capacity(func1.write_bytes());
+                            func1.write(&mut f1).expect("enough capacity");
+
+                            let mut f2 = Vec::with_capacity(func2.write_bytes());
+                            func2.write(&mut f2).expect("enough capacity");
+
+                            return f1 == f2
+                        }
+                    }
+            }
+            (None, None) => true,
+            _ => false,
+        }
+    }
+}
+
+impl std::fmt::Debug for Fmph {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Fmph")
+            .field("level_sizes", &self.function.as_ref().map(|f| f.level_sizes()))
+            .field("bytes_size", &self.function.as_ref().map(|f| f.write_bytes()))
+            .finish_non_exhaustive()
+    }
+}
+
+impl Serialize for Fmph {
+    /// Potentially expensive, but should be used only when creating the file.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match &self.function {
+            Some(f) => {
+                let mut v = Vec::with_capacity(f.write_bytes());
+                f.write(&mut v).map_err(S::Error::custom)?;
+                serializer.serialize_some(&v)
+            }
+            None => serializer.serialize_none(),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Fmph {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if let Some(buffer) = <Option<Vec<u8>>>::deserialize(deserializer)? {
+            return Ok(Fmph {
+                function: Some(
+                    ph::fmph::Function::read(&mut std::io::Cursor::new(buffer))
+                        .map_err(D::Error::custom)?,
+                ),
+            })
+        }
+        Ok(Fmph { function: None })
+    }
+}

--- a/crates/storage/nippy-jar/src/phf/fmph.rs
+++ b/crates/storage/nippy-jar/src/phf/fmph.rs
@@ -1,15 +1,16 @@
 use super::KeySet;
 use crate::NippyJarError;
+use ph::fmph::{Function, BuildConf};
 use serde::{
     de::Error as DeSerdeError, ser::Error as SerdeError, Deserialize, Deserializer, Serialize,
     Serializer,
 };
 use std::{clone::Clone, hash::Hash, marker::Sync};
 
-/// Wrapper struct for [`ph::fmph::Function`]. Implementation of the following [paper](https://dl.acm.org/doi/10.1145/3596453).
+/// Wrapper struct for [`Function`]. Implementation of the following [paper](https://dl.acm.org/doi/10.1145/3596453).
 #[derive(Default)]
 pub struct Fmph {
-    function: Option<ph::fmph::Function>,
+    function: Option<Function>,
 }
 
 impl Fmph {
@@ -23,7 +24,7 @@ impl KeySet for Fmph {
         &mut self,
         keys: &[T],
     ) -> Result<(), NippyJarError> {
-        self.function = Some(ph::fmph::Function::from(keys));
+        self.function = Some(Function::from_slice_with_conf(keys, BuildConf { use_multiple_threads: true, ..Default::default() }));
         Ok(())
     }
 
@@ -98,7 +99,7 @@ impl<'de> Deserialize<'de> for Fmph {
         if let Some(buffer) = <Option<Vec<u8>>>::deserialize(deserializer)? {
             return Ok(Fmph {
                 function: Some(
-                    ph::fmph::Function::read(&mut std::io::Cursor::new(buffer))
+                    Function::read(&mut std::io::Cursor::new(buffer))
                         .map_err(D::Error::custom)?,
                 ),
             })

--- a/crates/storage/nippy-jar/src/phf/fmph.rs
+++ b/crates/storage/nippy-jar/src/phf/fmph.rs
@@ -48,7 +48,7 @@ impl PartialEq for Fmph {
                     {
                         #[cfg(not(test))]
                         {
-                            unimplemented!("No way to figure it out without exporting ( potentially expensive), so only allow direct comparison on a test")
+                            unimplemented!("No way to figure it out without exporting (potentially expensive), so only allow direct comparison on a test")
                         }
                         #[cfg(test)]
                         {

--- a/crates/storage/nippy-jar/src/phf/fmph.rs
+++ b/crates/storage/nippy-jar/src/phf/fmph.rs
@@ -39,27 +39,21 @@ impl KeySet for Fmph {
     }
 }
 
+#[cfg(test)]
 impl PartialEq for Fmph {
-    fn eq(&self, other: &Self) -> bool {
-        match (&self.function, &other.function) {
+    fn eq(&self, _other: &Self) -> bool {
+        match (&self.function, &_other.function) {
             (Some(func1), Some(func2)) => {
                 func1.level_sizes() == func2.level_sizes() &&
                     func1.write_bytes() == func2.write_bytes() &&
                     {
-                        #[cfg(not(test))]
-                        {
-                            unimplemented!("No way to figure it out without exporting (potentially expensive), so only allow direct comparison on a test")
-                        }
-                        #[cfg(test)]
-                        {
-                            let mut f1 = Vec::with_capacity(func1.write_bytes());
-                            func1.write(&mut f1).expect("enough capacity");
+                        let mut f1 = Vec::with_capacity(func1.write_bytes());
+                        func1.write(&mut f1).expect("enough capacity");
 
-                            let mut f2 = Vec::with_capacity(func2.write_bytes());
-                            func2.write(&mut f2).expect("enough capacity");
+                        let mut f2 = Vec::with_capacity(func2.write_bytes());
+                        func2.write(&mut f2).expect("enough capacity");
 
-                            return f1 == f2
-                        }
+                        f1 == f2
                     }
             }
             (None, None) => true,

--- a/crates/storage/nippy-jar/src/phf/fmph.rs
+++ b/crates/storage/nippy-jar/src/phf/fmph.rs
@@ -1,6 +1,6 @@
 use super::KeySet;
 use crate::NippyJarError;
-use ph::fmph::{Function, BuildConf};
+use ph::fmph::{BuildConf, Function};
 use serde::{
     de::Error as DeSerdeError, ser::Error as SerdeError, Deserialize, Deserializer, Serialize,
     Serializer,
@@ -24,7 +24,10 @@ impl KeySet for Fmph {
         &mut self,
         keys: &[T],
     ) -> Result<(), NippyJarError> {
-        self.function = Some(Function::from_slice_with_conf(keys, BuildConf { use_multiple_threads: true, ..Default::default() }));
+        self.function = Some(Function::from_slice_with_conf(
+            keys,
+            BuildConf { use_multiple_threads: true, ..Default::default() },
+        ));
         Ok(())
     }
 
@@ -99,8 +102,7 @@ impl<'de> Deserialize<'de> for Fmph {
         if let Some(buffer) = <Option<Vec<u8>>>::deserialize(deserializer)? {
             return Ok(Fmph {
                 function: Some(
-                    Function::read(&mut std::io::Cursor::new(buffer))
-                        .map_err(D::Error::custom)?,
+                    Function::read(&mut std::io::Cursor::new(buffer)).map_err(D::Error::custom)?,
                 ),
             })
         }

--- a/crates/storage/nippy-jar/src/phf/go_fmph.rs
+++ b/crates/storage/nippy-jar/src/phf/go_fmph.rs
@@ -24,7 +24,10 @@ impl KeySet for GoFmph {
         &mut self,
         keys: &[T],
     ) -> Result<(), NippyJarError> {
-        self.function = Some(GOFunction::from_slice_with_conf(keys, GOBuildConf { use_multiple_threads: true, ..Default::default() }));
+        self.function = Some(GOFunction::from_slice_with_conf(
+            keys,
+            GOBuildConf { use_multiple_threads: true, ..Default::default() },
+        ));
         Ok(())
     }
 

--- a/crates/storage/nippy-jar/src/phf/go_fmph.rs
+++ b/crates/storage/nippy-jar/src/phf/go_fmph.rs
@@ -39,6 +39,7 @@ impl KeySet for GoFmph {
     }
 }
 
+#[cfg(test)]
 impl PartialEq for GoFmph {
     fn eq(&self, other: &Self) -> bool {
         match (&self.function, &other.function) {
@@ -46,20 +47,13 @@ impl PartialEq for GoFmph {
                 func1.level_sizes() == func2.level_sizes() &&
                     func1.write_bytes() == func2.write_bytes() &&
                     {
-                        #[cfg(not(test))]
-                        {
-                            unimplemented!("No way to figure it out without exporting ( potentially expensive), so only allow direct comparison on a test")
-                        }
-                        #[cfg(test)]
-                        {
-                            let mut f1 = Vec::with_capacity(func1.write_bytes());
-                            func1.write(&mut f1).expect("enough capacity");
+                        let mut f1 = Vec::with_capacity(func1.write_bytes());
+                        func1.write(&mut f1).expect("enough capacity");
 
-                            let mut f2 = Vec::with_capacity(func2.write_bytes());
-                            func2.write(&mut f2).expect("enough capacity");
+                        let mut f2 = Vec::with_capacity(func2.write_bytes());
+                        func2.write(&mut f2).expect("enough capacity");
 
-                            return f1 == f2
-                        }
+                        f1 == f2
                     }
             }
             (None, None) => true,

--- a/crates/storage/nippy-jar/src/phf/go_fmph.rs
+++ b/crates/storage/nippy-jar/src/phf/go_fmph.rs
@@ -1,0 +1,108 @@
+use super::KeySet;
+use crate::NippyJarError;
+use serde::{
+    de::Error as DeSerdeError, ser::Error as SerdeError, Deserialize, Deserializer, Serialize,
+    Serializer,
+};
+use std::{clone::Clone, hash::Hash, marker::Sync};
+
+/// Wrapper struct for [`ph::fmph::GOFunction`]. Implementation of the following [paper](https://dl.acm.org/doi/10.1145/3596453).
+#[derive(Default)]
+pub struct GoFmph {
+    function: Option<ph::fmph::GOFunction>,
+}
+
+impl GoFmph {
+    pub fn new() -> Self {
+        Self { function: None }
+    }
+}
+
+impl KeySet for GoFmph {
+    fn set_keys<T: AsRef<[u8]> + Sync + Clone + Hash>(
+        &mut self,
+        keys: &[T],
+    ) -> Result<(), NippyJarError> {
+        self.function = Some(ph::fmph::GOFunction::from(keys));
+        Ok(())
+    }
+
+    fn get_index(&self, key: &[u8]) -> Result<Option<u64>, NippyJarError> {
+        if let Some(f) = &self.function {
+            return Ok(f.get(key))
+        }
+        Err(NippyJarError::PHFMissingKeys)
+    }
+}
+
+impl PartialEq for GoFmph {
+    fn eq(&self, other: &Self) -> bool {
+        match (&self.function, &other.function) {
+            (Some(func1), Some(func2)) => {
+                func1.level_sizes() == func2.level_sizes() &&
+                    func1.write_bytes() == func2.write_bytes() &&
+                    {
+                        #[cfg(not(test))]
+                        {
+                            unimplemented!("No way to figure it out without exporting ( potentially expensive), so only allow direct comparison on a test")
+                        }
+                        #[cfg(test)]
+                        {
+                            let mut f1 = Vec::with_capacity(func1.write_bytes());
+                            func1.write(&mut f1).expect("enough capacity");
+
+                            let mut f2 = Vec::with_capacity(func2.write_bytes());
+                            func2.write(&mut f2).expect("enough capacity");
+
+                            return f1 == f2
+                        }
+                    }
+            }
+            (None, None) => true,
+            _ => false,
+        }
+    }
+}
+
+impl std::fmt::Debug for GoFmph {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GoFmph")
+            .field("level_sizes", &self.function.as_ref().map(|f| f.level_sizes()))
+            .field("bytes_size", &self.function.as_ref().map(|f| f.write_bytes()))
+            .finish_non_exhaustive()
+    }
+}
+
+impl Serialize for GoFmph {
+    /// Potentially expensive, but should be used only when creating the file.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match &self.function {
+            Some(f) => {
+                let mut v = Vec::with_capacity(f.write_bytes());
+                f.write(&mut v).map_err(S::Error::custom)?;
+                serializer.serialize_some(&v)
+            }
+            None => serializer.serialize_none(),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for GoFmph {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if let Some(buffer) = <Option<Vec<u8>>>::deserialize(deserializer)? {
+            return Ok(GoFmph {
+                function: Some(
+                    ph::fmph::GOFunction::read(&mut std::io::Cursor::new(buffer))
+                        .map_err(D::Error::custom)?,
+                ),
+            })
+        }
+        Ok(GoFmph { function: None })
+    }
+}

--- a/crates/storage/nippy-jar/src/phf/go_fmph.rs
+++ b/crates/storage/nippy-jar/src/phf/go_fmph.rs
@@ -1,15 +1,16 @@
 use super::KeySet;
 use crate::NippyJarError;
+use ph::fmph::{GOBuildConf, GOFunction};
 use serde::{
     de::Error as DeSerdeError, ser::Error as SerdeError, Deserialize, Deserializer, Serialize,
     Serializer,
 };
 use std::{clone::Clone, hash::Hash, marker::Sync};
 
-/// Wrapper struct for [`ph::fmph::GOFunction`]. Implementation of the following [paper](https://dl.acm.org/doi/10.1145/3596453).
+/// Wrapper struct for [`GOFunction`]. Implementation of the following [paper](https://dl.acm.org/doi/10.1145/3596453).
 #[derive(Default)]
 pub struct GoFmph {
-    function: Option<ph::fmph::GOFunction>,
+    function: Option<GOFunction>,
 }
 
 impl GoFmph {
@@ -23,7 +24,7 @@ impl KeySet for GoFmph {
         &mut self,
         keys: &[T],
     ) -> Result<(), NippyJarError> {
-        self.function = Some(ph::fmph::GOFunction::from(keys));
+        self.function = Some(GOFunction::from_slice_with_conf(keys, GOBuildConf { use_multiple_threads: true, ..Default::default() }));
         Ok(())
     }
 
@@ -98,7 +99,7 @@ impl<'de> Deserialize<'de> for GoFmph {
         if let Some(buffer) = <Option<Vec<u8>>>::deserialize(deserializer)? {
             return Ok(GoFmph {
                 function: Some(
-                    ph::fmph::GOFunction::read(&mut std::io::Cursor::new(buffer))
+                    GOFunction::read(&mut std::io::Cursor::new(buffer))
                         .map_err(D::Error::custom)?,
                 ),
             })

--- a/crates/storage/nippy-jar/src/phf/mod.rs
+++ b/crates/storage/nippy-jar/src/phf/mod.rs
@@ -1,0 +1,46 @@
+use crate::NippyJarError;
+use serde::{Deserialize, Serialize};
+use std::{clone::Clone, hash::Hash, marker::Sync};
+
+mod fmph;
+pub use fmph::Fmph;
+
+mod go_fmph;
+pub use go_fmph::GoFmph;
+
+/// Trait to build and query a perfect hashing function.
+pub trait KeySet {
+    /// Adds the key set and builds the perfect hashing function.
+    fn set_keys<T: AsRef<[u8]> + Sync + Clone + Hash>(
+        &mut self,
+        keys: &[T],
+    ) -> Result<(), NippyJarError>;
+
+    /// Get corresponding key index.
+    fn get_index(&self, key: &[u8]) -> Result<Option<u64>, NippyJarError>;
+}
+
+/// Enumerates all types of perfect hashing functions.
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub enum Functions {
+    Fmph(Fmph),
+    GoFmph(GoFmph),
+}
+
+impl KeySet for Functions {
+    fn set_keys<T: AsRef<[u8]> + Sync + Clone + Hash>(
+        &mut self,
+        keys: &[T],
+    ) -> Result<(), NippyJarError> {
+        match self {
+            Functions::Fmph(f) => f.set_keys(keys),
+            Functions::GoFmph(f) => f.set_keys(keys),
+        }
+    }
+    fn get_index(&self, key: &[u8]) -> Result<Option<u64>, NippyJarError> {
+        match self {
+            Functions::Fmph(f) => f.get_index(key),
+            Functions::GoFmph(f) => f.get_index(key),
+        }
+    }
+}

--- a/crates/storage/nippy-jar/src/phf/mod.rs
+++ b/crates/storage/nippy-jar/src/phf/mod.rs
@@ -37,6 +37,7 @@ impl KeySet for Functions {
             Functions::GoFmph(f) => f.set_keys(keys),
         }
     }
+
     fn get_index(&self, key: &[u8]) -> Result<Option<u64>, NippyJarError> {
         match self {
             Functions::Fmph(f) => f.get_index(key),

--- a/crates/storage/nippy-jar/src/phf/mod.rs
+++ b/crates/storage/nippy-jar/src/phf/mod.rs
@@ -9,7 +9,7 @@ mod go_fmph;
 pub use go_fmph::GoFmph;
 
 /// Trait to build and query a perfect hashing function.
-pub trait KeySet {
+pub trait KeySet: Serialize + for<'a> Deserialize<'a> {
     /// Adds the key set and builds the perfect hashing function.
     fn set_keys<T: AsRef<[u8]> + Sync + Clone + Hash>(
         &mut self,

--- a/crates/storage/nippy-jar/src/phf/mod.rs
+++ b/crates/storage/nippy-jar/src/phf/mod.rs
@@ -21,7 +21,8 @@ pub trait KeySet: Serialize + for<'a> Deserialize<'a> {
 }
 
 /// Enumerates all types of perfect hashing functions.
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(PartialEq))]
 pub enum Functions {
     Fmph(Fmph),
     GoFmph(GoFmph),


### PR DESCRIPTION
Adds two [implementations](https://crates.io/crates/ph) of [perfect hashing functions](https://en.wikipedia.org/wiki/Perfect_hash_function).

> In [computer science](https://en.wikipedia.org/wiki/Computer_science), a perfect hash function h for a set S is a [hash function](https://en.wikipedia.org/wiki/Hash_function) that maps distinct elements in S to a set of m integers, with no [collisions](https://en.wikipedia.org/wiki/Hash_collision). In mathematical terms, it is an [injective function](https://en.wikipedia.org/wiki/Injective_function).

This is particularly useful for when querying transactions or blocks using their hashes. Instead of storing them, and iterating over each value when querying for a specific hash, we can use this function to give us an `integer`. Then, use that to find the offset of the provided value in the file

Example: If giving the transaction hash `0xdeadbeef`  to the function would provide us the integer `5`, we could use this information to look-up in a separate list, the offset where the associated transaction is located.


