### PR TITLE
feat: sets up offset logic on `nippy-jar`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4151,6 +4151,7 @@ dependencies = [
  "cuckoofilter",
  "memmap2 0.7.1",
  "ph",
+ "rand 0.8.5",
  "serde",
  "tempfile",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4153,6 +4153,7 @@ dependencies = [
  "ph",
  "rand 0.8.5",
  "serde",
+ "sucds 0.8.0",
  "tempfile",
  "thiserror",
  "zstd",
@@ -5935,7 +5936,7 @@ dependencies = [
  "serde_with",
  "sha2",
  "strum 0.25.0",
- "sucds",
+ "sucds 0.6.0",
  "tempfile",
  "test-fuzz",
  "thiserror",
@@ -7334,6 +7335,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64accd20141dfbef67ad83c51d588146cff7810616e1bda35a975be369059533"
 dependencies = [
  "anyhow",
+]
+
+[[package]]
+name = "sucds"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab2433064439f81e28aa0ec2ded1c27a95636a7024767ded6047a57e54958d8"
+dependencies = [
+ "anyhow",
+ "num-traits",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4145,6 +4145,7 @@ dependencies = [
 name = "nippy-jar"
 version = "0.1.0-alpha.8"
 dependencies = [
+ "anyhow",
  "bincode",
  "bloomfilter",
  "bytes",

--- a/crates/storage/nippy-jar/Cargo.toml
+++ b/crates/storage/nippy-jar/Cargo.toml
@@ -15,13 +15,18 @@ name = "reth_nippy_jar"
 memmap2 = "0.7.1"
 bloomfilter = "1"
 zstd = { version = "0.12", features = ["experimental", "zdict_builder"] }
-ph = "0.8.0"
+ph = "0.8"
 thiserror = "1.0"
 bincode = "1.3"
 serde = { version = "1.0",  features = ["derive"] }
 bytes = "1.5"
 cuckoofilter = { version = "0.5.0", features = ["serde_support", "serde_bytes"] }
 tempfile = "3.4"
+
+
+[dev-dependencies]
+rand = "0.8"
+
 
 [features]
 default = []

--- a/crates/storage/nippy-jar/Cargo.toml
+++ b/crates/storage/nippy-jar/Cargo.toml
@@ -15,7 +15,7 @@ name = "reth_nippy_jar"
 memmap2 = "0.7.1"
 bloomfilter = "1"
 zstd = { version = "0.12", features = ["experimental", "zdict_builder"] }
-ph = "0.8"
+ph = "0.8.0"
 thiserror = "1.0"
 bincode = "1.3"
 serde = { version = "1.0",  features = ["derive"] }

--- a/crates/storage/nippy-jar/Cargo.toml
+++ b/crates/storage/nippy-jar/Cargo.toml
@@ -26,7 +26,7 @@ sucds = "~0.8"
 
 
 [dev-dependencies]
-rand = "0.8"
+rand = { version = "0.8", features = ["small_rng"] }
 
 
 [features]

--- a/crates/storage/nippy-jar/Cargo.toml
+++ b/crates/storage/nippy-jar/Cargo.toml
@@ -24,6 +24,8 @@ cuckoofilter = { version = "0.5.0", features = ["serde_support", "serde_bytes"] 
 tempfile = "3.4"
 sucds = "~0.8"
 
+anyhow = "1.0"
+
 
 [dev-dependencies]
 rand = { version = "0.8", features = ["small_rng"] }

--- a/crates/storage/nippy-jar/Cargo.toml
+++ b/crates/storage/nippy-jar/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1.0",  features = ["derive"] }
 bytes = "1.5"
 cuckoofilter = { version = "0.5.0", features = ["serde_support", "serde_bytes"] }
 tempfile = "3.4"
+sucds = "~0.8"
 
 
 [dev-dependencies]

--- a/crates/storage/nippy-jar/src/compression/mod.rs
+++ b/crates/storage/nippy-jar/src/compression/mod.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 mod zstd;
 pub use zstd::{Zstd, ZstdState};
 
-pub trait Compression {
+pub trait Compression: Serialize + for<'a> Deserialize<'a> {
     /// Returns decompressed data.
     fn decompress(&self, value: &[u8]) -> Result<Vec<u8>, NippyJarError>;
 

--- a/crates/storage/nippy-jar/src/compression/mod.rs
+++ b/crates/storage/nippy-jar/src/compression/mod.rs
@@ -14,6 +14,8 @@ pub trait Compression: Serialize + for<'a> Deserialize<'a> {
     fn compress_to<W: Write>(&self, src: &[u8], dest: &mut W) -> Result<(), NippyJarError>;
 
     /// Returns `true` if it's ready to compress.
+    ///
+    /// Example: it will return false, if `zstd` with dictionary is set, but wasn't generated.
     fn is_ready(&self) -> bool {
         true
     }

--- a/crates/storage/nippy-jar/src/compression/mod.rs
+++ b/crates/storage/nippy-jar/src/compression/mod.rs
@@ -5,6 +5,7 @@ use std::io::Write;
 mod zstd;
 pub use zstd::{Zstd, ZstdState};
 
+/// Trait that will compress column values
 pub trait Compression: Serialize + for<'a> Deserialize<'a> {
     /// Returns decompressed data.
     fn decompress(&self, value: &[u8]) -> Result<Vec<u8>, NippyJarError>;

--- a/crates/storage/nippy-jar/src/compression/mod.rs
+++ b/crates/storage/nippy-jar/src/compression/mod.rs
@@ -26,7 +26,8 @@ pub trait Compression: Serialize + for<'a> Deserialize<'a> {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(PartialEq))]
 pub enum Compressors {
     Zstd(Zstd),
     // Avoids irrefutable let errors. Remove this after adding another one.

--- a/crates/storage/nippy-jar/src/compression/mod.rs
+++ b/crates/storage/nippy-jar/src/compression/mod.rs
@@ -27,6 +27,7 @@ pub trait Compression: Serialize + for<'a> Deserialize<'a> {
     }
 }
 
+/// Enum with different [`Compression`] types.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
 pub enum Compressors {

--- a/crates/storage/nippy-jar/src/compression/zstd.rs
+++ b/crates/storage/nippy-jar/src/compression/zstd.rs
@@ -49,9 +49,7 @@ impl Zstd {
     /// If using dictionaries, creates a list of [`DecoderDictionary`].
     ///
     /// Consumes `self.raw_dictionaries` in the process.
-    pub fn generate_decompress_dictionaries<'a, 'b>(
-        &'a mut self,
-    ) -> Option<Vec<DecoderDictionary<'b>>> {
+    pub fn generate_decompress_dictionaries<'a>(&mut self) -> Option<Vec<DecoderDictionary<'a>>> {
         self.raw_dictionaries.take().map(|dicts| {
             // TODO Can we use ::new instead, and avoid consuming?
             dicts.iter().map(|dict| DecoderDictionary::copy(dict)).collect()
@@ -162,6 +160,7 @@ impl Compression for Zstd {
         decoder.read_exact(&mut decompressed)?;
         Ok(decompressed)
     }
+
     fn compress_to<W: Write>(&self, src: &[u8], dest: &mut W) -> Result<(), NippyJarError> {
         let level = 0;
 

--- a/crates/storage/nippy-jar/src/compression/zstd.rs
+++ b/crates/storage/nippy-jar/src/compression/zstd.rs
@@ -157,7 +157,7 @@ impl Compression for Zstd {
     fn decompress(&self, value: &[u8]) -> Result<Vec<u8>, NippyJarError> {
         let mut decompressed = Vec::with_capacity(value.len() * 2);
         let mut decoder = zstd::Decoder::new(value)?;
-        decoder.read_exact(&mut decompressed)?;
+        decoder.read_to_end(&mut decompressed)?;
         Ok(decompressed)
     }
 

--- a/crates/storage/nippy-jar/src/compression/zstd.rs
+++ b/crates/storage/nippy-jar/src/compression/zstd.rs
@@ -70,7 +70,7 @@ impl Zstd {
     }
 
     /// If using dictionaries, creates a list of [`Compressor`].
-    pub fn generate_compressors(&self) -> Result<Option<Vec<Compressor>>, NippyJarError> {
+    pub fn generate_compressors<'a>(&self) -> Result<Option<Vec<Compressor<'a>>>, NippyJarError> {
         match self.state {
             ZstdState::PendingDictionary => Err(NippyJarError::CompressorNotReady),
             ZstdState::Ready => {

--- a/crates/storage/nippy-jar/src/compression/zstd.rs
+++ b/crates/storage/nippy-jar/src/compression/zstd.rs
@@ -6,6 +6,8 @@ use std::{
 };
 use zstd::bulk::{Compressor, Decompressor};
 
+type RawDictionary = Vec<u8>;
+
 #[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
 pub enum ZstdState {
     #[default]
@@ -23,7 +25,7 @@ pub struct Zstd {
     /// Max size of a dictionary
     pub(crate) max_dict_size: usize,
     /// List of column dictionaries.
-    pub(crate) raw_dictionaries: Option<Vec<Vec<u8>>>,
+    pub(crate) raw_dictionaries: Option<Vec<RawDictionary>>,
     /// Number of columns to compress.
     columns: usize,
 }

--- a/crates/storage/nippy-jar/src/cursor.rs
+++ b/crates/storage/nippy-jar/src/cursor.rs
@@ -37,7 +37,7 @@ impl<'a> NippyJarCursor<'a> {
         zstd_decompressors: Option<Vec<Decompressor<'a>>>,
     ) -> Result<Self, NippyJarError> {
         let file = File::open(config.data_path())?;
-        
+
         // SAFETY: File is read-only and its descriptor is kept alive as long as the mmap handle.
         let mmap = unsafe { Mmap::map(&file)? };
 

--- a/crates/storage/nippy-jar/src/cursor.rs
+++ b/crates/storage/nippy-jar/src/cursor.rs
@@ -20,8 +20,6 @@ pub struct NippyJarCursor<'a> {
     tmp_buf: Vec<u8>,
     /// Cursor row position.
     row: u64,
-    /// Cursor column position.
-    col: u64,
 }
 
 impl<'a> std::fmt::Debug for NippyJarCursor<'a> {
@@ -44,14 +42,12 @@ impl<'a> NippyJarCursor<'a> {
             mmap_handle: mmap,
             tmp_buf: vec![],
             row: 0,
-            col: 0,
         })
     }
 
     /// Resets cursor to the beginning.
     pub fn reset(&mut self) {
         self.row = 0;
-        self.col = 0;
     }
 
     /// Returns a row, searching it by an entry used during [`NippyJar::prepare_index`].

--- a/crates/storage/nippy-jar/src/cursor.rs
+++ b/crates/storage/nippy-jar/src/cursor.rs
@@ -83,7 +83,7 @@ impl<'a> NippyJarCursor<'a> {
         self.next_row()
     }
 
-    /// Advances cursor to next row and returns it.
+    /// Returns the current value and advances the row.
     pub fn next_row(&mut self) -> Result<Option<Row>, NippyJarError> {
         if self.row as usize * self.jar.columns >= self.jar.offsets.len() {
             // Has reached the end
@@ -140,6 +140,8 @@ impl<'a> NippyJarCursor<'a> {
         self.next_row_with_cols::<MASK, COLUMNS>()
     }
 
+    /// Returns the current value and advances the row.
+    /// 
     /// Uses a `MASK` to only read certain columns from the row.
     pub fn next_row_with_cols<const MASK: usize, const COLUMNS: usize>(
         &mut self,

--- a/crates/storage/nippy-jar/src/cursor.rs
+++ b/crates/storage/nippy-jar/src/cursor.rs
@@ -84,8 +84,8 @@ impl<'a> NippyJarCursor<'a> {
         self.next_row()
     }
 
-    /// Returns the current value and advances the row.
-    pub fn next_row(&mut self) -> Result<Option<Row>, NippyJarError> {
+    /// Advances cursor to next row and returns it.
+    pub fn next_row(&mut self) -> Result<Option<Vec<Vec<u8>>>, NippyJarError> {
         if self.row as usize * self.jar.columns >= self.jar.offsets.len() {
             // Has reached the end
             return Ok(None)
@@ -103,24 +103,24 @@ impl<'a> NippyJarCursor<'a> {
         Ok(Some(row))
     }
 
-    /// Returns a row, searching it by a key used during [`NippyJar::prepare_index`]  by using a
+    /// Returns a row, searching it by an entry used during [`NippyJar::prepare_index`]  by using a
     /// `MASK` to only read certain columns from the row.
     ///
     /// **May return false positives.**
     ///
     /// Example usage would be querying a transactions file with a transaction hash which is **NOT**
     /// stored in file.
-    pub fn row_by_key_with_cols<const MASK: usize, const COLUMNS: usize>(
+    pub fn row_by_filter_with_cols<const MASK: usize, const COLUMNS: usize>(
         &mut self,
-        key: &[u8],
-    ) -> Result<Option<Row>, NippyJarError> {
+        value: &[u8],
+    ) -> Result<Option<Vec<Vec<u8>>>, NippyJarError> {
         if let (Some(filter), Some(phf)) = (&self.jar.filter, &self.jar.phf) {
             // TODO: is it worth to parallize both?
 
             // May have false positives
-            if filter.contains(key)? {
+            if filter.contains(value)? {
                 // May have false positives
-                if let Some(row_index) = phf.get_index(key)? {
+                if let Some(row_index) = phf.get_index(value)? {
                     self.row =
                         self.jar.offsets_index.access(row_index as usize).expect("built from same")
                             as u64;
@@ -129,24 +129,22 @@ impl<'a> NippyJarCursor<'a> {
             }
         }
 
-        Err(NippyJarError::UnsupportedFilterQuery)
+        Ok(None)
     }
 
     /// Returns a row by its number by using a `MASK` to only read certain columns from the row.
     pub fn row_by_number_with_cols<const MASK: usize, const COLUMNS: usize>(
         &mut self,
         row: usize,
-    ) -> Result<Option<Row>, NippyJarError> {
+    ) -> Result<Option<Vec<Vec<u8>>>, NippyJarError> {
         self.row = row as u64;
         self.next_row_with_cols::<MASK, COLUMNS>()
     }
 
-    /// Returns the current value and advances the row.
-    ///
     /// Uses a `MASK` to only read certain columns from the row.
     pub fn next_row_with_cols<const MASK: usize, const COLUMNS: usize>(
         &mut self,
-    ) -> Result<Option<Row>, NippyJarError> {
+    ) -> Result<Option<Vec<Vec<u8>>>, NippyJarError> {
         debug_assert!(COLUMNS == self.jar.columns);
 
         if self.row as usize * self.jar.columns >= self.jar.offsets.len() {
@@ -168,7 +166,7 @@ impl<'a> NippyJarCursor<'a> {
     }
 
     /// Takes the column index and reads the value for the corresponding column.
-    fn read_value(&mut self, column: usize, row: &mut Row) -> Result<(), NippyJarError> {
+    fn read_value(&mut self, column: usize, row: &mut Vec<Vec<u8>>) -> Result<(), NippyJarError> {
         // Find out the offset of the column value
         let offset_pos = self.row as usize * self.jar.columns + column;
         let value_offset = self.jar.offsets.select(offset_pos).expect("should exist");
@@ -181,14 +179,18 @@ impl<'a> NippyJarCursor<'a> {
             &self.mmap_handle[value_offset..next_value_offset]
         };
 
-        if let Some(zstd_dict_decompressors) = self.zstd_decompressors.as_mut() {
+        if let Some(zstd_dict_decompressors) = &self.zstd_decompressors {
+            // Uses zstd dictionaries
+            let extra_capacity = (column_value.len() * 2).saturating_sub(self.tmp_buf.capacity());
             self.tmp_buf.clear();
+            self.tmp_buf.reserve(extra_capacity);
 
-            if let Some(decompressor) = zstd_dict_decompressors.get_mut(column) {
-                Zstd::decompress_with_dictionary(column_value, &mut self.tmp_buf, decompressor)?;
-            }
-
-            debug_assert!(!self.tmp_buf.is_empty());
+            zstd_dict_decompressors
+                .lock()
+                .unwrap()
+                .get_mut(column)
+                .unwrap()
+                .decompress_to_buffer(column_value, &mut self.tmp_buf)?;
 
             row.push(self.tmp_buf.clone());
         } else if let Some(compression) = &self.jar.compressor {

--- a/crates/storage/nippy-jar/src/cursor.rs
+++ b/crates/storage/nippy-jar/src/cursor.rs
@@ -74,7 +74,7 @@ impl<'a> NippyJarCursor<'a> {
             }
         }
 
-        Ok(None)
+        Err(NippyJarError::UnsupportedFilterQuery)
     }
 
     /// Returns a row by its number.
@@ -128,7 +128,7 @@ impl<'a> NippyJarCursor<'a> {
             }
         }
 
-        Ok(None)
+        Err(NippyJarError::UnsupportedFilterQuery)
     }
 
     /// Returns a row by its number by using a `MASK` to only read certain columns from the row.
@@ -141,7 +141,7 @@ impl<'a> NippyJarCursor<'a> {
     }
 
     /// Returns the current value and advances the row.
-    /// 
+    ///
     /// Uses a `MASK` to only read certain columns from the row.
     pub fn next_row_with_cols<const MASK: usize, const COLUMNS: usize>(
         &mut self,

--- a/crates/storage/nippy-jar/src/cursor.rs
+++ b/crates/storage/nippy-jar/src/cursor.rs
@@ -37,7 +37,10 @@ impl<'a> NippyJarCursor<'a> {
         zstd_decompressors: Option<Vec<Decompressor<'a>>>,
     ) -> Result<Self, NippyJarError> {
         let file = File::open(config.data_path())?;
+        
+        // SAFETY: File is read-only and its descriptor is kept alive as long as the mmap handle.
         let mmap = unsafe { Mmap::map(&file)? };
+
         Ok(NippyJarCursor {
             jar: config,
             zstd_decompressors,

--- a/crates/storage/nippy-jar/src/cursor.rs
+++ b/crates/storage/nippy-jar/src/cursor.rs
@@ -53,20 +53,20 @@ impl<'a> NippyJarCursor<'a> {
         self.row = 0;
     }
 
-    /// Returns a row, searching it by an entry used during [`NippyJar::prepare_index`].
+    /// Returns a row, searching it by a key used during [`NippyJar::prepare_index`].
     ///
     /// **May return false positives.**
     ///
     /// Example usage would be querying a transactions file with a transaction hash which is **NOT**
     /// stored in file.
-    pub fn row_by_filter(&mut self, value: &[u8]) -> Result<Option<Row>, NippyJarError> {
+    pub fn row_by_key(&mut self, key: &[u8]) -> Result<Option<Row>, NippyJarError> {
         if let (Some(filter), Some(phf)) = (&self.jar.filter, &self.jar.phf) {
             // TODO: is it worth to parallize both?
 
             // May have false positives
-            if filter.contains(value)? {
+            if filter.contains(key)? {
                 // May have false positives
-                if let Some(row_index) = phf.get_index(value)? {
+                if let Some(row_index) = phf.get_index(key)? {
                     self.row =
                         self.jar.offsets_index.access(row_index as usize).expect("built from same")
                             as u64;
@@ -103,24 +103,24 @@ impl<'a> NippyJarCursor<'a> {
         Ok(Some(row))
     }
 
-    /// Returns a row, searching it by an entry used during [`NippyJar::prepare_index`]  by using a
+    /// Returns a row, searching it by a key used during [`NippyJar::prepare_index`]  by using a
     /// `MASK` to only read certain columns from the row.
     ///
     /// **May return false positives.**
     ///
     /// Example usage would be querying a transactions file with a transaction hash which is **NOT**
     /// stored in file.
-    pub fn row_by_filter_with_cols<const MASK: usize, const COLUMNS: usize>(
+    pub fn row_by_key_with_cols<const MASK: usize, const COLUMNS: usize>(
         &mut self,
-        value: &[u8],
+        key: &[u8],
     ) -> Result<Option<Row>, NippyJarError> {
         if let (Some(filter), Some(phf)) = (&self.jar.filter, &self.jar.phf) {
             // TODO: is it worth to parallize both?
 
             // May have false positives
-            if filter.contains(value)? {
+            if filter.contains(key)? {
                 // May have false positives
-                if let Some(row_index) = phf.get_index(value)? {
+                if let Some(row_index) = phf.get_index(key)? {
                     self.row =
                         self.jar.offsets_index.access(row_index as usize).expect("built from same")
                             as u64;

--- a/crates/storage/nippy-jar/src/cursor.rs
+++ b/crates/storage/nippy-jar/src/cursor.rs
@@ -24,7 +24,7 @@ pub struct NippyJarCursor<'a> {
 
 impl<'a> std::fmt::Debug for NippyJarCursor<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "NippyJarCursor {{ config: {:?} }}", self.jar)
+        f.debug_struct("NippyJarCursor").field("config", &self.jar).finish_non_exhaustive()
     }
 }
 

--- a/crates/storage/nippy-jar/src/cursor.rs
+++ b/crates/storage/nippy-jar/src/cursor.rs
@@ -1,0 +1,128 @@
+use crate::{compression::Compression, Filter, KeySet, NippyJar, NippyJarError};
+use std::{
+    clone::Clone,
+    fs::File,
+    io::{Read, Seek, SeekFrom},
+    sync::Mutex,
+};
+use sucds::int_vectors::Access;
+use zstd::bulk::Decompressor;
+
+pub struct NippyJarCursor<'a> {
+    config: &'a NippyJar,
+    zstd_decompressors: Option<Mutex<Vec<Decompressor<'a>>>>,
+    data_handle: File,
+    tmp_buf: Vec<u8>,
+    row: u64,
+    col: u64,
+}
+
+impl<'a> std::fmt::Debug for NippyJarCursor<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "NippyJarCursor {{ config: {:?} }}", self.config)
+    }
+}
+
+impl<'a> NippyJarCursor<'a> {
+    pub fn new(
+        config: &'a NippyJar,
+        zstd_decompressors: Option<Mutex<Vec<Decompressor<'a>>>>,
+    ) -> Result<Self, NippyJarError> {
+        Ok(NippyJarCursor {
+            config,
+            zstd_decompressors,
+            data_handle: File::open(config.data_path())?,
+            tmp_buf: vec![],
+            row: 0,
+            col: 0,
+        })
+    }
+
+    pub fn reset(&mut self) {
+        self.row = 0;
+        self.col = 0;
+    }
+
+    // eg. transaction_by_hash
+    // may have false positives
+    pub fn row_by_filter(&mut self, value: &[u8]) -> Result<Option<Vec<Vec<u8>>>, NippyJarError> {
+        if let (Some(filter), Some(phf)) = (&self.config.filter, &self.config.phf) {
+            // May have false positives
+            if filter.contains(value)? {
+                // May have false positives
+                let row_index = phf.get_index(value)?.unwrap();
+
+                self.row = self.config.offsets_index.access(row_index as usize).unwrap() as u64;
+                return self.next_row()
+            }
+        } else {
+            panic!("requires it");
+        }
+
+        panic!("didnt find it");
+    }
+
+    // eg. transaction_by_nnumber
+    pub fn row_by_number(&mut self, row: usize) -> Result<Option<Vec<Vec<u8>>>, NippyJarError> {
+        self.row = row as u64;
+        self.next_row()
+    }
+
+    pub fn next_row(&mut self) -> Result<Option<Vec<Vec<u8>>>, NippyJarError> {
+        if self.row as usize * self.config.columns == self.config.offsets.len() {
+            // Has reached the end
+            return Ok(None)
+        }
+
+        let mut row = Vec::with_capacity(self.config.columns);
+        let mut column_value = Vec::with_capacity(32);
+
+        for column in 0..self.config.columns {
+            let index_offset = self.row as usize * self.config.columns + column;
+            let value_offset = self.config.offsets.select(index_offset).unwrap();
+
+            self.data_handle.seek(SeekFrom::Start(value_offset as u64))?;
+
+            // It's the last column of the last row
+            if self.config.offsets.len() == (index_offset + 1) {
+                column_value.clear();
+                self.data_handle.read_to_end(&mut column_value)?;
+            } else {
+                let len = self.config.offsets.select(index_offset + 1).unwrap() - value_offset;
+                column_value.resize(len, 0);
+                self.data_handle.read_exact(&mut column_value[..len])?;
+            }
+
+            if let Some(zstd_dict_decompressors) = &self.zstd_decompressors {
+                // Decompress using zstd dictionaries
+                let extra_capacity =
+                    (column_value.len() * 2).saturating_sub(self.tmp_buf.capacity());
+                self.tmp_buf.clear();
+                self.tmp_buf.reserve(extra_capacity);
+
+                zstd_dict_decompressors
+                    .lock()
+                    .unwrap()
+                    .get_mut(column)
+                    .unwrap()
+                    .decompress_to_buffer(&column_value, &mut self.tmp_buf)?;
+
+                row.push(self.tmp_buf.clone());
+            } else if let Some(compression) = &self.config.compressor {
+                // Decompress using the vanilla
+                row.push(compression.decompress(&column_value)?);
+            } else {
+                // It's not compressed
+                row.push(column_value.clone())
+            }
+        }
+
+        if row.is_empty() {
+            return Ok(None)
+        }
+
+        self.row += 1;
+
+        Ok(Some(row))
+    }
+}

--- a/crates/storage/nippy-jar/src/error.rs
+++ b/crates/storage/nippy-jar/src/error.rs
@@ -29,4 +29,6 @@ pub enum NippyJarError {
     PHFMissingKeys,
     #[error("NippyJar initialized without perfect hashing function.")]
     PHFMissing,
+    #[error("NippyJar was built without an index.")]
+    UnsupportedFilterQuery,
 }

--- a/crates/storage/nippy-jar/src/error.rs
+++ b/crates/storage/nippy-jar/src/error.rs
@@ -1,5 +1,6 @@
 use thiserror::Error;
 
+/// Errors associated with [`crate::NippyJar`].
 #[derive(Debug, Error)]
 pub enum NippyJarError {
     #[error(transparent)]

--- a/crates/storage/nippy-jar/src/error.rs
+++ b/crates/storage/nippy-jar/src/error.rs
@@ -1,0 +1,29 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum NippyJarError {
+    #[error(transparent)]
+    Disconnect(#[from] std::io::Error),
+    #[error(transparent)]
+    Bincode(#[from] Box<bincode::ErrorKind>),
+    #[error("Compression was enabled, but it's not ready yet.")]
+    CompressorNotReady,
+    #[error("Decompression was enabled, but it's not ready yet.")]
+    DecompressorNotReady,
+    #[error("Number of columns does not match. {0} != {1}")]
+    ColumnLenMismatch(usize, usize),
+    #[error("UnexpectedMissingValue row: {0} col:{1}")]
+    UnexpectedMissingValue(u64, u64),
+    #[error(transparent)]
+    FilterError(#[from] cuckoofilter::CuckooError),
+    #[error("NippyJar initialized without filter.")]
+    FilterMissing,
+    #[error("Filter has reached max capacity.")]
+    FilterMaxCapacity,
+    #[error("Cuckoo was not properly initialized after loaded.")]
+    FilterCuckooNotLoaded,
+    #[error("Perfect hashing function wasn't added any keys.")]
+    PHFMissingKeys,
+    #[error("NippyJar initialized without perfect hashing function.")]
+    PHFMissing,
+}

--- a/crates/storage/nippy-jar/src/error.rs
+++ b/crates/storage/nippy-jar/src/error.rs
@@ -7,6 +7,8 @@ pub enum NippyJarError {
     Disconnect(#[from] std::io::Error),
     #[error(transparent)]
     Bincode(#[from] Box<bincode::ErrorKind>),
+    #[error(transparent)]
+    EliasFano(#[from] anyhow::Error),
     #[error("Compression was enabled, but it's not ready yet.")]
     CompressorNotReady,
     #[error("Decompression was enabled, but it's not ready yet.")]

--- a/crates/storage/nippy-jar/src/filter/cuckoo.rs
+++ b/crates/storage/nippy-jar/src/filter/cuckoo.rs
@@ -46,21 +46,14 @@ impl std::fmt::Debug for Cuckoo {
     }
 }
 
+#[cfg(test)]
 impl PartialEq for Cuckoo {
     fn eq(&self, _other: &Self) -> bool {
-        self.remaining == _other.remaining &&
-            {
-                #[cfg(not(test))]
-                {
-                    unimplemented!("No way to figure it out without exporting (expensive), so only allow direct comparison on a test")
-                }
-                #[cfg(test)]
-                {
-                    let f1 = self.filter.export();
-                    let f2 = _other.filter.export();
-                    return f1.length == f2.length && f1.values == f2.values
-                }
-            }
+        self.remaining == _other.remaining && {
+            let f1 = self.filter.export();
+            let f2 = _other.filter.export();
+            f1.length == f2.length && f1.values == f2.values
+        }
     }
 }
 

--- a/crates/storage/nippy-jar/src/filter/mod.rs
+++ b/crates/storage/nippy-jar/src/filter/mod.rs
@@ -4,11 +4,12 @@ use serde::{Deserialize, Serialize};
 mod cuckoo;
 pub use cuckoo::Cuckoo;
 
+/// Membership filter set trait.
 pub trait Filter {
     /// Add element to the inclusion list.
     fn add(&mut self, element: &[u8]) -> Result<(), NippyJarError>;
 
-    /// Checks if the element belongs to the inclusion list. There might be false positives.
+    /// Checks if the element belongs to the inclusion list. **There might be false positives.**
     fn contains(&self, element: &[u8]) -> Result<bool, NippyJarError>;
 }
 

--- a/crates/storage/nippy-jar/src/filter/mod.rs
+++ b/crates/storage/nippy-jar/src/filter/mod.rs
@@ -13,6 +13,7 @@ pub trait Filter {
     fn contains(&self, element: &[u8]) -> Result<bool, NippyJarError>;
 }
 
+/// Enum with different [`Filter`] types.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
 pub enum Filters {

--- a/crates/storage/nippy-jar/src/filter/mod.rs
+++ b/crates/storage/nippy-jar/src/filter/mod.rs
@@ -12,7 +12,8 @@ pub trait Filter {
     fn contains(&self, element: &[u8]) -> Result<bool, NippyJarError>;
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(PartialEq))]
 pub enum Filters {
     Cuckoo(Cuckoo),
     // Avoids irrefutable let errors. Remove this after adding another one.

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -22,7 +22,8 @@ use phf::{Fmph, Functions, GoFmph, KeySet};
 
 const NIPPY_JAR_VERSION: usize = 1;
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct NippyJar {
     /// Version
     version: usize,

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -102,7 +102,7 @@ impl NippyJar {
     pub fn load(path: &Path) -> Result<Self, NippyJarError> {
         // Read [`Self`] located at the data file.
         let data_file = File::open(path)?;
-        
+
         // SAFETY: File is read-only and its descriptor is kept alive as long as the mmap handle.
         let data_reader = unsafe { memmap2::Mmap::map(&data_file)? };
         let mut obj: Self = bincode::deserialize_from(data_reader.as_ref())?;
@@ -110,7 +110,7 @@ impl NippyJar {
 
         // Read the offsets lists located at the index file.
         let offsets_file = File::open(obj.index_path())?;
-        
+
         // SAFETY: File is read-only and its descriptor is kept alive as long as the mmap handle.
         let mmap = unsafe { memmap2::Mmap::map(&offsets_file)? };
         let mut offsets_reader = mmap.as_ref();

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -100,8 +100,8 @@ impl NippyJar {
         obj.path = Some(path.to_path_buf());
 
         let mut offsets_file = File::open(obj.index_path())?;
-        obj.offsets = EliasFano::deserialize_from(&mut offsets_file).unwrap();
-        obj.offsets_index = PrefixSummedEliasFano::deserialize_from(offsets_file).unwrap();
+        obj.offsets = EliasFano::deserialize_from(&mut offsets_file)?;
+        obj.offsets_index = PrefixSummedEliasFano::deserialize_from(offsets_file)?;
 
         Ok(obj)
     }
@@ -160,7 +160,7 @@ impl NippyJar {
             }
         }
 
-        self.offsets_index = PrefixSummedEliasFano::from_slice(&offsets_index).unwrap();
+        self.offsets_index = PrefixSummedEliasFano::from_slice(&offsets_index)?;
         Ok(())
     }
 
@@ -251,16 +251,16 @@ impl NippyJar {
     fn freeze_offsets(&mut self, offsets: Vec<usize>) -> Result<(), NippyJarError> {
         if !offsets.is_empty() {
             let mut builder =
-                EliasFanoBuilder::new(*offsets.last().expect("qed") + 1, offsets.len()).unwrap();
+                EliasFanoBuilder::new(*offsets.last().expect("qed") + 1, offsets.len())?;
 
             for offset in offsets {
-                builder.push(offset).unwrap();
+                builder.push(offset)?;
             }
             self.offsets = builder.build().enable_rank();
         }
         let mut file = File::create(self.index_path())?;
-        self.offsets.serialize_into(&mut file).unwrap();
-        self.offsets_index.serialize_into(file).unwrap();
+        self.offsets.serialize_into(&mut file)?;
+        self.offsets_index.serialize_into(file)?;
         Ok(())
     }
 

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -102,12 +102,16 @@ impl NippyJar {
     pub fn load(path: &Path) -> Result<Self, NippyJarError> {
         // Read [`Self`] located at the data file.
         let data_file = File::open(path)?;
+        
+        // SAFETY: File is read-only and its descriptor is kept alive as long as the mmap handle.
         let data_reader = unsafe { memmap2::Mmap::map(&data_file)? };
         let mut obj: Self = bincode::deserialize_from(data_reader.as_ref())?;
         obj.path = Some(path.to_path_buf());
 
         // Read the offsets lists located at the index file.
         let offsets_file = File::open(obj.index_path())?;
+        
+        // SAFETY: File is read-only and its descriptor is kept alive as long as the mmap handle.
         let mmap = unsafe { memmap2::Mmap::map(&offsets_file)? };
         let mut offsets_reader = mmap.as_ref();
         obj.offsets = EliasFano::deserialize_from(&mut offsets_reader)?;

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -267,7 +267,7 @@ pub enum NippyJarError {
     FilterMaxCapacity,
     #[error("Cuckoo was not properly initialized after loaded.")]
     FilterCuckooNotLoaded,
-    #[error("Perfect hashing function wasn't added any keys.")]
+    #[error("Perfect hashing function doesn't have any keys added.")]
     PHFMissingKeys,
     #[error("NippyJar initialized without perfect hashing function.")]
     PHFMissing,

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -212,10 +212,10 @@ impl NippyJar {
                     Some(value) => {
                         if let Some(compression) = &self.compressor {
                             // Special zstd case with dictionaries
-                            if let (Some(dict_compressors), Compressors::Zstd(zstd)) =
+                            if let (Some(dict_compressors), Compressors::Zstd(_)) =
                                 (maybe_zstd_compressors.as_mut(), compression)
                             {
-                                zstd.compress_with_dictionary(
+                                compression::Zstd::compress_with_dictionary(
                                     &value,
                                     &mut tmp_buf,
                                     &mut file,

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -595,16 +595,12 @@ mod tests {
 
         // Read file
         {
-            let mut loaded_nippy = NippyJar::load(file_path.path()).unwrap();
+            let loaded_nippy = NippyJar::load(file_path.path()).unwrap();
 
-            let mut dicts = vec![];
-            if let Some(Compressors::Zstd(zstd)) = loaded_nippy.compressor.as_mut() {
-                dicts = zstd.generate_decompress_dictionaries().unwrap()
-            }
-            if let Some(Compressors::Zstd(zstd)) = loaded_nippy.compressor.as_ref() {
+            if let Some(Compressors::Zstd(zstd)) = &loaded_nippy.compressor {
                 let mut cursor = NippyJarCursor::new(
                     &loaded_nippy,
-                    Some(zstd.generate_decompressors(&dicts).unwrap()),
+                    Some(Mutex::new(zstd.generate_decompressors().unwrap())),
                 )
                 .unwrap();
 
@@ -621,7 +617,7 @@ mod tests {
                     // Simulates `by_hash` queries by iterating col1 values, which were used to
                     // create the inner index.
                     let row_by_value = cursor
-                        .row_by_key_with_cols::<BLOCKS_FULL_MASK, BLOCKS_COLUMNS>(v0)
+                        .row_by_filter_with_cols::<BLOCKS_FULL_MASK, BLOCKS_COLUMNS>(v0)
                         .unwrap()
                         .unwrap();
                     assert_eq!((&row_by_value[0], &row_by_value[1]), (*v0, *v1));
@@ -640,7 +636,7 @@ mod tests {
                     // Simulates `by_hash` queries by iterating col1 values, which were used to
                     // create the inner index.
                     let row_by_value = cursor
-                        .row_by_key_with_cols::<BLOCKS_BLOCK_MASK, BLOCKS_COLUMNS>(v0)
+                        .row_by_filter_with_cols::<BLOCKS_BLOCK_MASK, BLOCKS_COLUMNS>(v0)
                         .unwrap()
                         .unwrap();
                     assert_eq!(row_by_value.len(), 1);
@@ -661,7 +657,7 @@ mod tests {
                     // Simulates `by_hash` queries by iterating col1 values, which were used to
                     // create the inner index.
                     let row_by_value = cursor
-                        .row_by_key_with_cols::<BLOCKS_WITHDRAWAL_MASK, BLOCKS_COLUMNS>(v0)
+                        .row_by_filter_with_cols::<BLOCKS_WITHDRAWAL_MASK, BLOCKS_COLUMNS>(v0)
                         .unwrap()
                         .unwrap();
                     assert_eq!(row_by_value.len(), 1);
@@ -682,7 +678,7 @@ mod tests {
                     // Simulates `by_hash` queries by iterating col1 values, which were used to
                     // create the inner index.
                     assert!(cursor
-                        .row_by_key_with_cols::<BLOCKS_EMPTY_MASK, BLOCKS_COLUMNS>(v0)
+                        .row_by_filter_with_cols::<BLOCKS_EMPTY_MASK, BLOCKS_COLUMNS>(v0)
                         .unwrap()
                         .unwrap()
                         .is_empty());

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -30,6 +30,9 @@ pub use cursor::NippyJarCursor;
 
 const NIPPY_JAR_VERSION: usize = 1;
 
+/// A [`Row`] is a list of its selected column values.
+type Row = Vec<Vec<u8>>;
+
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct NippyJar {
     /// Version
@@ -330,7 +333,9 @@ mod tests {
     use rand::{rngs::SmallRng, seq::SliceRandom, RngCore, SeedableRng};
     use std::{collections::HashSet, sync::Mutex};
 
-    fn test_data(seed: Option<u64>) -> (Vec<Vec<u8>>, Vec<Vec<u8>>) {
+    type ColumnValues = Vec<Vec<u8>>;
+
+    fn test_data(seed: Option<u64>) -> (ColumnValues, ColumnValues) {
         let value_length = 32;
         let num_rows = 100;
 

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -247,9 +247,6 @@ impl NippyJar {
             column_iterators = iterators.into_iter();
         }
 
-        // Drop mut borrow
-        drop(maybe_zstd_compressors);
-
         // Write offsets and offset index to file
         self.freeze_offsets(offsets)?;
 

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -553,7 +553,7 @@ mod tests {
                 for (row_num, (v0, v1)) in data {
                     // Simulates `by_hash` queries by iterating col1 values, which were used to
                     // create the inner index.
-                    let row_by_value = cursor.row_by_filter(v0).unwrap().unwrap();
+                    let row_by_value = cursor.row_by_key(v0).unwrap().unwrap();
                     assert_eq!((&row_by_value[0], &row_by_value[1]), (v0, v1));
 
                     // Simulates `by_number` queries
@@ -608,7 +608,7 @@ mod tests {
                     // Simulates `by_hash` queries by iterating col1 values, which were used to
                     // create the inner index.
                     let row_by_value = cursor
-                        .row_by_filter_with_cols::<BLOCKS_FULL_MASK, BLOCKS_COLUMNS>(v0)
+                        .row_by_key_with_cols::<BLOCKS_FULL_MASK, BLOCKS_COLUMNS>(v0)
                         .unwrap()
                         .unwrap();
                     assert_eq!((&row_by_value[0], &row_by_value[1]), (*v0, *v1));
@@ -627,7 +627,7 @@ mod tests {
                     // Simulates `by_hash` queries by iterating col1 values, which were used to
                     // create the inner index.
                     let row_by_value = cursor
-                        .row_by_filter_with_cols::<BLOCKS_BLOCK_MASK, BLOCKS_COLUMNS>(v0)
+                        .row_by_key_with_cols::<BLOCKS_BLOCK_MASK, BLOCKS_COLUMNS>(v0)
                         .unwrap()
                         .unwrap();
                     assert_eq!(row_by_value.len(), 1);
@@ -648,7 +648,7 @@ mod tests {
                     // Simulates `by_hash` queries by iterating col1 values, which were used to
                     // create the inner index.
                     let row_by_value = cursor
-                        .row_by_filter_with_cols::<BLOCKS_WITHDRAWAL_MASK, BLOCKS_COLUMNS>(v0)
+                        .row_by_key_with_cols::<BLOCKS_WITHDRAWAL_MASK, BLOCKS_COLUMNS>(v0)
                         .unwrap()
                         .unwrap();
                     assert_eq!(row_by_value.len(), 1);
@@ -669,7 +669,7 @@ mod tests {
                     // Simulates `by_hash` queries by iterating col1 values, which were used to
                     // create the inner index.
                     assert!(cursor
-                        .row_by_filter_with_cols::<BLOCKS_EMPTY_MASK, BLOCKS_COLUMNS>(v0)
+                        .row_by_key_with_cols::<BLOCKS_EMPTY_MASK, BLOCKS_COLUMNS>(v0)
                         .unwrap()
                         .unwrap()
                         .is_empty());

--- a/crates/storage/nippy-jar/src/phf/fmph.rs
+++ b/crates/storage/nippy-jar/src/phf/fmph.rs
@@ -1,0 +1,108 @@
+use super::KeySet;
+use crate::NippyJarError;
+use serde::{
+    de::Error as DeSerdeError, ser::Error as SerdeError, Deserialize, Deserializer, Serialize,
+    Serializer,
+};
+use std::{clone::Clone, hash::Hash, marker::Sync};
+
+/// Wrapper struct for [`ph::fmph::Function`]. Implementation of the following [paper](https://dl.acm.org/doi/10.1145/3596453).
+#[derive(Default)]
+pub struct Fmph {
+    function: Option<ph::fmph::Function>,
+}
+
+impl Fmph {
+    pub fn new() -> Self {
+        Self { function: None }
+    }
+}
+
+impl KeySet for Fmph {
+    fn set_keys<T: AsRef<[u8]> + Sync + Clone + Hash>(
+        &mut self,
+        keys: &[T],
+    ) -> Result<(), NippyJarError> {
+        self.function = Some(ph::fmph::Function::from(keys));
+        Ok(())
+    }
+
+    fn get_index(&self, key: &[u8]) -> Result<Option<u64>, NippyJarError> {
+        if let Some(f) = &self.function {
+            return Ok(f.get(key))
+        }
+        Err(NippyJarError::PHFMissingKeys)
+    }
+}
+
+impl PartialEq for Fmph {
+    fn eq(&self, other: &Self) -> bool {
+        match (&self.function, &other.function) {
+            (Some(func1), Some(func2)) => {
+                func1.level_sizes() == func2.level_sizes() &&
+                    func1.write_bytes() == func2.write_bytes() &&
+                    {
+                        #[cfg(not(test))]
+                        {
+                            unimplemented!("No way to figure it out without exporting ( potentially expensive), so only allow direct comparison on a test")
+                        }
+                        #[cfg(test)]
+                        {
+                            let mut f1 = Vec::with_capacity(func1.write_bytes());
+                            func1.write(&mut f1).expect("enough capacity");
+
+                            let mut f2 = Vec::with_capacity(func2.write_bytes());
+                            func2.write(&mut f2).expect("enough capacity");
+
+                            return f1 == f2
+                        }
+                    }
+            }
+            (None, None) => true,
+            _ => false,
+        }
+    }
+}
+
+impl std::fmt::Debug for Fmph {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Fmph")
+            .field("level_sizes", &self.function.as_ref().map(|f| f.level_sizes()))
+            .field("bytes_size", &self.function.as_ref().map(|f| f.write_bytes()))
+            .finish_non_exhaustive()
+    }
+}
+
+impl Serialize for Fmph {
+    /// Potentially expensive, but should be used only when creating the file.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match &self.function {
+            Some(f) => {
+                let mut v = Vec::with_capacity(f.write_bytes());
+                f.write(&mut v).map_err(S::Error::custom)?;
+                serializer.serialize_some(&v)
+            }
+            None => serializer.serialize_none(),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Fmph {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if let Some(buffer) = <Option<Vec<u8>>>::deserialize(deserializer)? {
+            return Ok(Fmph {
+                function: Some(
+                    ph::fmph::Function::read(&mut std::io::Cursor::new(buffer))
+                        .map_err(D::Error::custom)?,
+                ),
+            })
+        }
+        Ok(Fmph { function: None })
+    }
+}

--- a/crates/storage/nippy-jar/src/phf/fmph.rs
+++ b/crates/storage/nippy-jar/src/phf/fmph.rs
@@ -1,15 +1,16 @@
 use super::KeySet;
 use crate::NippyJarError;
+use ph::fmph::{Function, BuildConf};
 use serde::{
     de::Error as DeSerdeError, ser::Error as SerdeError, Deserialize, Deserializer, Serialize,
     Serializer,
 };
 use std::{clone::Clone, hash::Hash, marker::Sync};
 
-/// Wrapper struct for [`ph::fmph::Function`]. Implementation of the following [paper](https://dl.acm.org/doi/10.1145/3596453).
+/// Wrapper struct for [`Function`]. Implementation of the following [paper](https://dl.acm.org/doi/10.1145/3596453).
 #[derive(Default)]
 pub struct Fmph {
-    function: Option<ph::fmph::Function>,
+    function: Option<Function>,
 }
 
 impl Fmph {
@@ -23,7 +24,7 @@ impl KeySet for Fmph {
         &mut self,
         keys: &[T],
     ) -> Result<(), NippyJarError> {
-        self.function = Some(ph::fmph::Function::from(keys));
+        self.function = Some(Function::from_slice_with_conf(keys, BuildConf { use_multiple_threads: true, ..Default::default() }));
         Ok(())
     }
 
@@ -98,7 +99,7 @@ impl<'de> Deserialize<'de> for Fmph {
         if let Some(buffer) = <Option<Vec<u8>>>::deserialize(deserializer)? {
             return Ok(Fmph {
                 function: Some(
-                    ph::fmph::Function::read(&mut std::io::Cursor::new(buffer))
+                    Function::read(&mut std::io::Cursor::new(buffer))
                         .map_err(D::Error::custom)?,
                 ),
             })

--- a/crates/storage/nippy-jar/src/phf/fmph.rs
+++ b/crates/storage/nippy-jar/src/phf/fmph.rs
@@ -1,4 +1,4 @@
-use crate::{KeySet, NippyJarError};
+use crate::{NippyJarError, PerfectHashingFunction};
 use ph::fmph::{BuildConf, Function};
 use serde::{
     de::Error as DeSerdeError, ser::Error as SerdeError, Deserialize, Deserializer, Serialize,
@@ -18,7 +18,7 @@ impl Fmph {
     }
 }
 
-impl KeySet for Fmph {
+impl PerfectHashingFunction for Fmph {
     fn set_keys<T: AsRef<[u8]> + Sync + Clone + Hash>(
         &mut self,
         keys: &[T],

--- a/crates/storage/nippy-jar/src/phf/fmph.rs
+++ b/crates/storage/nippy-jar/src/phf/fmph.rs
@@ -48,7 +48,7 @@ impl PartialEq for Fmph {
                     {
                         #[cfg(not(test))]
                         {
-                            unimplemented!("No way to figure it out without exporting ( potentially expensive), so only allow direct comparison on a test")
+                            unimplemented!("No way to figure it out without exporting (potentially expensive), so only allow direct comparison on a test")
                         }
                         #[cfg(test)]
                         {

--- a/crates/storage/nippy-jar/src/phf/fmph.rs
+++ b/crates/storage/nippy-jar/src/phf/fmph.rs
@@ -39,27 +39,21 @@ impl KeySet for Fmph {
     }
 }
 
+#[cfg(test)]
 impl PartialEq for Fmph {
-    fn eq(&self, other: &Self) -> bool {
-        match (&self.function, &other.function) {
+    fn eq(&self, _other: &Self) -> bool {
+        match (&self.function, &_other.function) {
             (Some(func1), Some(func2)) => {
                 func1.level_sizes() == func2.level_sizes() &&
                     func1.write_bytes() == func2.write_bytes() &&
                     {
-                        #[cfg(not(test))]
-                        {
-                            unimplemented!("No way to figure it out without exporting (potentially expensive), so only allow direct comparison on a test")
-                        }
-                        #[cfg(test)]
-                        {
-                            let mut f1 = Vec::with_capacity(func1.write_bytes());
-                            func1.write(&mut f1).expect("enough capacity");
+                        let mut f1 = Vec::with_capacity(func1.write_bytes());
+                        func1.write(&mut f1).expect("enough capacity");
 
-                            let mut f2 = Vec::with_capacity(func2.write_bytes());
-                            func2.write(&mut f2).expect("enough capacity");
+                        let mut f2 = Vec::with_capacity(func2.write_bytes());
+                        func2.write(&mut f2).expect("enough capacity");
 
-                            return f1 == f2
-                        }
+                        f1 == f2
                     }
             }
             (None, None) => true,

--- a/crates/storage/nippy-jar/src/phf/fmph.rs
+++ b/crates/storage/nippy-jar/src/phf/fmph.rs
@@ -1,6 +1,6 @@
 use super::KeySet;
 use crate::NippyJarError;
-use ph::fmph::{Function, BuildConf};
+use ph::fmph::{BuildConf, Function};
 use serde::{
     de::Error as DeSerdeError, ser::Error as SerdeError, Deserialize, Deserializer, Serialize,
     Serializer,
@@ -24,7 +24,10 @@ impl KeySet for Fmph {
         &mut self,
         keys: &[T],
     ) -> Result<(), NippyJarError> {
-        self.function = Some(Function::from_slice_with_conf(keys, BuildConf { use_multiple_threads: true, ..Default::default() }));
+        self.function = Some(Function::from_slice_with_conf(
+            keys,
+            BuildConf { use_multiple_threads: true, ..Default::default() },
+        ));
         Ok(())
     }
 
@@ -99,8 +102,7 @@ impl<'de> Deserialize<'de> for Fmph {
         if let Some(buffer) = <Option<Vec<u8>>>::deserialize(deserializer)? {
             return Ok(Fmph {
                 function: Some(
-                    Function::read(&mut std::io::Cursor::new(buffer))
-                        .map_err(D::Error::custom)?,
+                    Function::read(&mut std::io::Cursor::new(buffer)).map_err(D::Error::custom)?,
                 ),
             })
         }

--- a/crates/storage/nippy-jar/src/phf/fmph.rs
+++ b/crates/storage/nippy-jar/src/phf/fmph.rs
@@ -1,5 +1,4 @@
-use super::KeySet;
-use crate::NippyJarError;
+use crate::{KeySet, NippyJarError};
 use ph::fmph::{BuildConf, Function};
 use serde::{
     de::Error as DeSerdeError, ser::Error as SerdeError, Deserialize, Deserializer, Serialize,

--- a/crates/storage/nippy-jar/src/phf/go_fmph.rs
+++ b/crates/storage/nippy-jar/src/phf/go_fmph.rs
@@ -24,7 +24,10 @@ impl KeySet for GoFmph {
         &mut self,
         keys: &[T],
     ) -> Result<(), NippyJarError> {
-        self.function = Some(GOFunction::from_slice_with_conf(keys, GOBuildConf { use_multiple_threads: true, ..Default::default() }));
+        self.function = Some(GOFunction::from_slice_with_conf(
+            keys,
+            GOBuildConf { use_multiple_threads: true, ..Default::default() },
+        ));
         Ok(())
     }
 

--- a/crates/storage/nippy-jar/src/phf/go_fmph.rs
+++ b/crates/storage/nippy-jar/src/phf/go_fmph.rs
@@ -1,4 +1,4 @@
-use crate::{KeySet, NippyJarError};
+use crate::{NippyJarError, PerfectHashingFunction};
 use ph::fmph::{GOBuildConf, GOFunction};
 use serde::{
     de::Error as DeSerdeError, ser::Error as SerdeError, Deserialize, Deserializer, Serialize,
@@ -18,7 +18,7 @@ impl GoFmph {
     }
 }
 
-impl KeySet for GoFmph {
+impl PerfectHashingFunction for GoFmph {
     fn set_keys<T: AsRef<[u8]> + Sync + Clone + Hash>(
         &mut self,
         keys: &[T],

--- a/crates/storage/nippy-jar/src/phf/go_fmph.rs
+++ b/crates/storage/nippy-jar/src/phf/go_fmph.rs
@@ -1,5 +1,4 @@
-use super::KeySet;
-use crate::NippyJarError;
+use crate::{KeySet, NippyJarError};
 use ph::fmph::{GOBuildConf, GOFunction};
 use serde::{
     de::Error as DeSerdeError, ser::Error as SerdeError, Deserialize, Deserializer, Serialize,

--- a/crates/storage/nippy-jar/src/phf/go_fmph.rs
+++ b/crates/storage/nippy-jar/src/phf/go_fmph.rs
@@ -39,6 +39,7 @@ impl KeySet for GoFmph {
     }
 }
 
+#[cfg(test)]
 impl PartialEq for GoFmph {
     fn eq(&self, other: &Self) -> bool {
         match (&self.function, &other.function) {
@@ -46,20 +47,13 @@ impl PartialEq for GoFmph {
                 func1.level_sizes() == func2.level_sizes() &&
                     func1.write_bytes() == func2.write_bytes() &&
                     {
-                        #[cfg(not(test))]
-                        {
-                            unimplemented!("No way to figure it out without exporting ( potentially expensive), so only allow direct comparison on a test")
-                        }
-                        #[cfg(test)]
-                        {
-                            let mut f1 = Vec::with_capacity(func1.write_bytes());
-                            func1.write(&mut f1).expect("enough capacity");
+                        let mut f1 = Vec::with_capacity(func1.write_bytes());
+                        func1.write(&mut f1).expect("enough capacity");
 
-                            let mut f2 = Vec::with_capacity(func2.write_bytes());
-                            func2.write(&mut f2).expect("enough capacity");
+                        let mut f2 = Vec::with_capacity(func2.write_bytes());
+                        func2.write(&mut f2).expect("enough capacity");
 
-                            return f1 == f2
-                        }
+                        f1 == f2
                     }
             }
             (None, None) => true,

--- a/crates/storage/nippy-jar/src/phf/go_fmph.rs
+++ b/crates/storage/nippy-jar/src/phf/go_fmph.rs
@@ -1,0 +1,108 @@
+use super::KeySet;
+use crate::NippyJarError;
+use serde::{
+    de::Error as DeSerdeError, ser::Error as SerdeError, Deserialize, Deserializer, Serialize,
+    Serializer,
+};
+use std::{clone::Clone, hash::Hash, marker::Sync};
+
+/// Wrapper struct for [`ph::fmph::GOFunction`]. Implementation of the following [paper](https://dl.acm.org/doi/10.1145/3596453).
+#[derive(Default)]
+pub struct GoFmph {
+    function: Option<ph::fmph::GOFunction>,
+}
+
+impl GoFmph {
+    pub fn new() -> Self {
+        Self { function: None }
+    }
+}
+
+impl KeySet for GoFmph {
+    fn set_keys<T: AsRef<[u8]> + Sync + Clone + Hash>(
+        &mut self,
+        keys: &[T],
+    ) -> Result<(), NippyJarError> {
+        self.function = Some(ph::fmph::GOFunction::from(keys));
+        Ok(())
+    }
+
+    fn get_index(&self, key: &[u8]) -> Result<Option<u64>, NippyJarError> {
+        if let Some(f) = &self.function {
+            return Ok(f.get(key))
+        }
+        Err(NippyJarError::PHFMissingKeys)
+    }
+}
+
+impl PartialEq for GoFmph {
+    fn eq(&self, other: &Self) -> bool {
+        match (&self.function, &other.function) {
+            (Some(func1), Some(func2)) => {
+                func1.level_sizes() == func2.level_sizes() &&
+                    func1.write_bytes() == func2.write_bytes() &&
+                    {
+                        #[cfg(not(test))]
+                        {
+                            unimplemented!("No way to figure it out without exporting ( potentially expensive), so only allow direct comparison on a test")
+                        }
+                        #[cfg(test)]
+                        {
+                            let mut f1 = Vec::with_capacity(func1.write_bytes());
+                            func1.write(&mut f1).expect("enough capacity");
+
+                            let mut f2 = Vec::with_capacity(func2.write_bytes());
+                            func2.write(&mut f2).expect("enough capacity");
+
+                            return f1 == f2
+                        }
+                    }
+            }
+            (None, None) => true,
+            _ => false,
+        }
+    }
+}
+
+impl std::fmt::Debug for GoFmph {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GoFmph")
+            .field("level_sizes", &self.function.as_ref().map(|f| f.level_sizes()))
+            .field("bytes_size", &self.function.as_ref().map(|f| f.write_bytes()))
+            .finish_non_exhaustive()
+    }
+}
+
+impl Serialize for GoFmph {
+    /// Potentially expensive, but should be used only when creating the file.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match &self.function {
+            Some(f) => {
+                let mut v = Vec::with_capacity(f.write_bytes());
+                f.write(&mut v).map_err(S::Error::custom)?;
+                serializer.serialize_some(&v)
+            }
+            None => serializer.serialize_none(),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for GoFmph {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if let Some(buffer) = <Option<Vec<u8>>>::deserialize(deserializer)? {
+            return Ok(GoFmph {
+                function: Some(
+                    ph::fmph::GOFunction::read(&mut std::io::Cursor::new(buffer))
+                        .map_err(D::Error::custom)?,
+                ),
+            })
+        }
+        Ok(GoFmph { function: None })
+    }
+}

--- a/crates/storage/nippy-jar/src/phf/go_fmph.rs
+++ b/crates/storage/nippy-jar/src/phf/go_fmph.rs
@@ -1,15 +1,16 @@
 use super::KeySet;
 use crate::NippyJarError;
+use ph::fmph::{GOBuildConf, GOFunction};
 use serde::{
     de::Error as DeSerdeError, ser::Error as SerdeError, Deserialize, Deserializer, Serialize,
     Serializer,
 };
 use std::{clone::Clone, hash::Hash, marker::Sync};
 
-/// Wrapper struct for [`ph::fmph::GOFunction`]. Implementation of the following [paper](https://dl.acm.org/doi/10.1145/3596453).
+/// Wrapper struct for [`GOFunction`]. Implementation of the following [paper](https://dl.acm.org/doi/10.1145/3596453).
 #[derive(Default)]
 pub struct GoFmph {
-    function: Option<ph::fmph::GOFunction>,
+    function: Option<GOFunction>,
 }
 
 impl GoFmph {
@@ -23,7 +24,7 @@ impl KeySet for GoFmph {
         &mut self,
         keys: &[T],
     ) -> Result<(), NippyJarError> {
-        self.function = Some(ph::fmph::GOFunction::from(keys));
+        self.function = Some(GOFunction::from_slice_with_conf(keys, GOBuildConf { use_multiple_threads: true, ..Default::default() }));
         Ok(())
     }
 
@@ -98,7 +99,7 @@ impl<'de> Deserialize<'de> for GoFmph {
         if let Some(buffer) = <Option<Vec<u8>>>::deserialize(deserializer)? {
             return Ok(GoFmph {
                 function: Some(
-                    ph::fmph::GOFunction::read(&mut std::io::Cursor::new(buffer))
+                    GOFunction::read(&mut std::io::Cursor::new(buffer))
                         .map_err(D::Error::custom)?,
                 ),
             })

--- a/crates/storage/nippy-jar/src/phf/mod.rs
+++ b/crates/storage/nippy-jar/src/phf/mod.rs
@@ -1,0 +1,46 @@
+use crate::NippyJarError;
+use serde::{Deserialize, Serialize};
+use std::{clone::Clone, hash::Hash, marker::Sync};
+
+mod fmph;
+pub use fmph::Fmph;
+
+mod go_fmph;
+pub use go_fmph::GoFmph;
+
+/// Trait to build and query a perfect hashing function.
+pub trait KeySet {
+    /// Adds the key set and builds the perfect hashing function.
+    fn set_keys<T: AsRef<[u8]> + Sync + Clone + Hash>(
+        &mut self,
+        keys: &[T],
+    ) -> Result<(), NippyJarError>;
+
+    /// Get corresponding key index.
+    fn get_index(&self, key: &[u8]) -> Result<Option<u64>, NippyJarError>;
+}
+
+/// Enumerates all types of perfect hashing functions.
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub enum Functions {
+    Fmph(Fmph),
+    GoFmph(GoFmph),
+}
+
+impl KeySet for Functions {
+    fn set_keys<T: AsRef<[u8]> + Sync + Clone + Hash>(
+        &mut self,
+        keys: &[T],
+    ) -> Result<(), NippyJarError> {
+        match self {
+            Functions::Fmph(f) => f.set_keys(keys),
+            Functions::GoFmph(f) => f.set_keys(keys),
+        }
+    }
+    fn get_index(&self, key: &[u8]) -> Result<Option<u64>, NippyJarError> {
+        match self {
+            Functions::Fmph(f) => f.get_index(key),
+            Functions::GoFmph(f) => f.get_index(key),
+        }
+    }
+}

--- a/crates/storage/nippy-jar/src/phf/mod.rs
+++ b/crates/storage/nippy-jar/src/phf/mod.rs
@@ -37,6 +37,7 @@ impl KeySet for Functions {
             Functions::GoFmph(f) => f.set_keys(keys),
         }
     }
+
     fn get_index(&self, key: &[u8]) -> Result<Option<u64>, NippyJarError> {
         match self {
             Functions::Fmph(f) => f.get_index(key),

--- a/crates/storage/nippy-jar/src/phf/mod.rs
+++ b/crates/storage/nippy-jar/src/phf/mod.rs
@@ -9,7 +9,7 @@ mod go_fmph;
 pub use go_fmph::GoFmph;
 
 /// Trait to build and query a perfect hashing function.
-pub trait KeySet {
+pub trait PerfectHashingFunction {
     /// Adds the key set and builds the perfect hashing function.
     fn set_keys<T: AsRef<[u8]> + Sync + Clone + Hash>(
         &mut self,
@@ -27,7 +27,7 @@ pub enum Functions {
     GoFmph(GoFmph),
 }
 
-impl KeySet for Functions {
+impl PerfectHashingFunction for Functions {
     fn set_keys<T: AsRef<[u8]> + Sync + Clone + Hash>(
         &mut self,
         keys: &[T],

--- a/crates/storage/nippy-jar/src/phf/mod.rs
+++ b/crates/storage/nippy-jar/src/phf/mod.rs
@@ -9,7 +9,7 @@ mod go_fmph;
 pub use go_fmph::GoFmph;
 
 /// Trait to build and query a perfect hashing function.
-pub trait KeySet {
+pub trait KeySet: Serialize + for<'a> Deserialize<'a> {
     /// Adds the key set and builds the perfect hashing function.
     fn set_keys<T: AsRef<[u8]> + Sync + Clone + Hash>(
         &mut self,

--- a/crates/storage/nippy-jar/src/phf/mod.rs
+++ b/crates/storage/nippy-jar/src/phf/mod.rs
@@ -21,7 +21,8 @@ pub trait KeySet: Serialize + for<'a> Deserialize<'a> {
 }
 
 /// Enumerates all types of perfect hashing functions.
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(PartialEq))]
 pub enum Functions {
     Fmph(Fmph),
     GoFmph(GoFmph),

--- a/crates/storage/nippy-jar/src/phf/mod.rs
+++ b/crates/storage/nippy-jar/src/phf/mod.rs
@@ -16,7 +16,7 @@ pub trait KeySet {
         keys: &[T],
     ) -> Result<(), NippyJarError>;
 
-    /// Get corresponding key index.
+    /// Get corresponding associated integer. There might be false positives.
     fn get_index(&self, key: &[u8]) -> Result<Option<u64>, NippyJarError>;
 }
 


### PR DESCRIPTION
Adds the real offset logic and brings everything together.

There are two offset lists:
* `offsets`: holds a sorted list of the data file offsets. 
  * example: `[row0_col0_value_offset, row0_col1_value_offset, row1_col0_value_offset,... rowN_colM_value_offset...]`
  * useful for `transaction_by_number`
* `offsets_index`: this is an index `PHF(value)-(random integer)->row_number`, which representation is an unsorted integer list.
  * example: `func(row0)` might return `2`, while `func(row1)` might return `0`. So the output will be: `[ row1, X, row0, ..., rowN]`  Value doesn't have to be part of the data. (imagine having a file with transactions, but not actually storing their hashes)
  * useful for `transaction_by_hash`

TL;DR can be seen implemented on `test_full_nippy_jar`, `NippyJarCursor::row_by_filter`

Also, refactored a few things and added some additional docs.

#4601 should be merged first (this is one is pointing to that branch)