### PR TITLE
refactor: split async/sync work in stages

### DIFF
--- a/bin/reth/src/debug_cmd/execution.rs
+++ b/bin/reth/src/debug_cmd/execution.rs
@@ -115,7 +115,7 @@ impl Command {
             .with_tip_sender(tip_tx)
             .add_stages(
                 DefaultStages::new(
-                    ProviderFactory::new(db.clone(), self.chain.clone()), // TODO:
+                    ProviderFactory::new(db.clone(), self.chain.clone()),
                     header_mode,
                     Arc::clone(&consensus),
                     header_downloader,

--- a/bin/reth/src/debug_cmd/execution.rs
+++ b/bin/reth/src/debug_cmd/execution.rs
@@ -31,7 +31,7 @@ use reth_provider::{BlockExecutionWriter, HeaderSyncMode, ProviderFactory, Stage
 use reth_stages::{
     sets::DefaultStages,
     stages::{ExecutionStage, ExecutionStageThresholds, SenderRecoveryStage, TotalDifficultyStage},
-    Pipeline, PipelineError, StageSet,
+    Pipeline, StageSet,
 };
 use reth_tasks::TaskExecutor;
 use std::{

--- a/bin/reth/src/debug_cmd/execution.rs
+++ b/bin/reth/src/debug_cmd/execution.rs
@@ -27,14 +27,11 @@ use reth_interfaces::{
 use reth_network::{NetworkEvents, NetworkHandle};
 use reth_network_api::NetworkInfo;
 use reth_primitives::{fs, stage::StageId, BlockHashOrNumber, BlockNumber, ChainSpec, B256};
-use reth_provider::{BlockExecutionWriter, ProviderFactory, StageCheckpointReader};
+use reth_provider::{BlockExecutionWriter, HeaderSyncMode, ProviderFactory, StageCheckpointReader};
 use reth_stages::{
     sets::DefaultStages,
-    stages::{
-        ExecutionStage, ExecutionStageThresholds, HeaderSyncMode, SenderRecoveryStage,
-        TotalDifficultyStage,
-    },
-    Pipeline, StageSet,
+    stages::{ExecutionStage, ExecutionStageThresholds, SenderRecoveryStage, TotalDifficultyStage},
+    Pipeline, PipelineError, StageSet,
 };
 use reth_tasks::TaskExecutor;
 use std::{
@@ -118,6 +115,7 @@ impl Command {
             .with_tip_sender(tip_tx)
             .add_stages(
                 DefaultStages::new(
+                    ProviderFactory::new(db.clone(), self.chain.clone()), // TODO:
                     header_mode,
                     Arc::clone(&consensus),
                     header_downloader,

--- a/bin/reth/src/debug_cmd/merkle.rs
+++ b/bin/reth/src/debug_cmd/merkle.rs
@@ -222,53 +222,42 @@ impl Command {
                     None
                 };
 
-            execution_stage
-                .execute(
-                    &provider_rw,
-                    ExecInput {
-                        target: Some(block),
-                        checkpoint: block.checked_sub(1).map(StageCheckpoint::new),
-                    },
-                )
-                .await?;
+            execution_stage.execute(
+                &provider_rw,
+                ExecInput {
+                    target: Some(block),
+                    checkpoint: block.checked_sub(1).map(StageCheckpoint::new),
+                },
+            )?;
 
             let mut account_hashing_done = false;
             while !account_hashing_done {
-                let output = account_hashing_stage
-                    .execute(
-                        &provider_rw,
-                        ExecInput {
-                            target: Some(block),
-                            checkpoint: progress.map(StageCheckpoint::new),
-                        },
-                    )
-                    .await?;
-                account_hashing_done = output.done;
-            }
-
-            let mut storage_hashing_done = false;
-            while !storage_hashing_done {
-                let output = storage_hashing_stage
-                    .execute(
-                        &provider_rw,
-                        ExecInput {
-                            target: Some(block),
-                            checkpoint: progress.map(StageCheckpoint::new),
-                        },
-                    )
-                    .await?;
-                storage_hashing_done = output.done;
-            }
-
-            let incremental_result = merkle_stage
-                .execute(
+                let output = account_hashing_stage.execute(
                     &provider_rw,
                     ExecInput {
                         target: Some(block),
                         checkpoint: progress.map(StageCheckpoint::new),
                     },
-                )
-                .await;
+                )?;
+                account_hashing_done = output.done;
+            }
+
+            let mut storage_hashing_done = false;
+            while !storage_hashing_done {
+                let output = storage_hashing_stage.execute(
+                    &provider_rw,
+                    ExecInput {
+                        target: Some(block),
+                        checkpoint: progress.map(StageCheckpoint::new),
+                    },
+                )?;
+                storage_hashing_done = output.done;
+            }
+
+            let incremental_result = merkle_stage.execute(
+                &provider_rw,
+                ExecInput { target: Some(block), checkpoint: progress.map(StageCheckpoint::new) },
+            );
 
             if incremental_result.is_err() {
                 tracing::warn!(target: "reth::cli", block, "Incremental calculation failed, retrying from scratch");
@@ -285,7 +274,7 @@ impl Command {
 
                 let clean_input = ExecInput { target: Some(block), checkpoint: None };
                 loop {
-                    let clean_result = merkle_stage.execute(&provider_rw, clean_input).await;
+                    let clean_result = merkle_stage.execute(&provider_rw, clean_input);
                     assert!(clean_result.is_ok(), "Clean state root calculation failed");
                     if clean_result.unwrap().done {
                         break

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -61,7 +61,7 @@ use reth_primitives::{
 };
 use reth_provider::{
     providers::BlockchainProvider, BlockHashReader, BlockReader, CanonStateSubscriptions,
-    HeaderProvider, ProviderFactory, StageCheckpointReader,
+    HeaderProvider, HeaderSyncMode, ProviderFactory, StageCheckpointReader,
 };
 use reth_prune::{segments::SegmentSet, Pruner};
 use reth_revm::Factory;
@@ -71,9 +71,9 @@ use reth_snapshot::HighestSnapshotsTracker;
 use reth_stages::{
     prelude::*,
     stages::{
-        AccountHashingStage, ExecutionStage, ExecutionStageThresholds, HeaderSyncMode,
-        IndexAccountHistoryStage, IndexStorageHistoryStage, MerkleStage, SenderRecoveryStage,
-        StorageHashingStage, TotalDifficultyStage, TransactionLookupStage,
+        AccountHashingStage, ExecutionStage, ExecutionStageThresholds, IndexAccountHistoryStage,
+        IndexStorageHistoryStage, MerkleStage, SenderRecoveryStage, StorageHashingStage,
+        TotalDifficultyStage, TransactionLookupStage,
     },
 };
 use reth_tasks::TaskExecutor;
@@ -896,6 +896,7 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
             .with_metrics_tx(metrics_tx.clone())
             .add_stages(
                 DefaultStages::new(
+                    ProviderFactory::new(db.clone(), self.chain.clone()),
                     header_mode,
                     Arc::clone(&consensus),
                     header_downloader,

--- a/bin/reth/src/stage/dump/execution.rs
+++ b/bin/reth/src/stage/dump/execution.rs
@@ -129,8 +129,7 @@ async fn dry_run<DB: Database>(
     info!(target: "reth::cli", "Executing stage. [dry-run]");
 
     let factory = ProviderFactory::new(&output_db, chain.clone());
-    let mut exec_stage: Box<dyn Stage<DB>> =
-        Box::new(ExecutionStage::new_with_factory(Factory::new(chain.clone())));
+    let mut exec_stage = ExecutionStage::new_with_factory(Factory::new(chain.clone()));
 
     let input =
         reth_stages::ExecInput { target: Some(to), checkpoint: Some(StageCheckpoint::new(from)) };

--- a/bin/reth/src/stage/dump/hashing_account.rs
+++ b/bin/reth/src/stage/dump/hashing_account.rs
@@ -68,10 +68,10 @@ async fn dry_run<DB: Database>(
 
     let factory = ProviderFactory::new(&output_db, chain);
     let provider = factory.provider_rw()?;
-    let mut exec_stage: Box<dyn Stage<DB>> = Box::new(AccountHashingStage {
+    let mut exec_stage = AccountHashingStage {
         clean_threshold: 1, // Forces hashing from scratch
         ..Default::default()
-    });
+    };
 
     let mut done = false;
     while !done {

--- a/bin/reth/src/stage/dump/hashing_account.rs
+++ b/bin/reth/src/stage/dump/hashing_account.rs
@@ -68,18 +68,19 @@ async fn dry_run<DB: Database>(
 
     let factory = ProviderFactory::new(&output_db, chain);
     let provider = factory.provider_rw()?;
-    let mut exec_stage = AccountHashingStage {
+    let mut stage = AccountHashingStage {
         clean_threshold: 1, // Forces hashing from scratch
         ..Default::default()
     };
 
-    let mut done = false;
-    while !done {
+    loop {
         let input = reth_stages::ExecInput {
             target: Some(to),
             checkpoint: Some(StageCheckpoint::new(from)),
         };
-        done = exec_stage.execute(&provider, input)?.done;
+        if stage.execute(&provider, input)?.done {
+            break
+        }
     }
 
     info!(target: "reth::cli", "Success.");

--- a/bin/reth/src/stage/dump/hashing_storage.rs
+++ b/bin/reth/src/stage/dump/hashing_storage.rs
@@ -67,10 +67,10 @@ async fn dry_run<DB: Database>(
 
     let factory = ProviderFactory::new(&output_db, chain);
     let provider = factory.provider_rw()?;
-    let mut exec_stage: Box<dyn Stage<DB>> = Box::new(StorageHashingStage {
+    let mut exec_stag = StorageHashingStage {
         clean_threshold: 1, // Forces hashing from scratch
         ..Default::default()
-    });
+    };
 
     let mut done = false;
     while !done {

--- a/bin/reth/src/stage/dump/hashing_storage.rs
+++ b/bin/reth/src/stage/dump/hashing_storage.rs
@@ -72,13 +72,14 @@ async fn dry_run<DB: Database>(
         ..Default::default()
     };
 
-    let mut done = false;
-    while !done {
+    loop {
         let input = reth_stages::ExecInput {
             target: Some(to),
             checkpoint: Some(StageCheckpoint::new(from)),
         };
-        done = stage.execute(&provider, input)?.done;
+        if stage.execute(&provider, input)?.done {
+            break
+        }
     }
 
     info!(target: "reth::cli", "Success.");

--- a/bin/reth/src/stage/dump/hashing_storage.rs
+++ b/bin/reth/src/stage/dump/hashing_storage.rs
@@ -67,7 +67,7 @@ async fn dry_run<DB: Database>(
 
     let factory = ProviderFactory::new(&output_db, chain);
     let provider = factory.provider_rw()?;
-    let mut exec_stag = StorageHashingStage {
+    let mut stage = StorageHashingStage {
         clean_threshold: 1, // Forces hashing from scratch
         ..Default::default()
     };
@@ -78,7 +78,7 @@ async fn dry_run<DB: Database>(
             target: Some(to),
             checkpoint: Some(StageCheckpoint::new(from)),
         };
-        done = exec_stage.execute(&provider, input)?.done;
+        done = stage.execute(&provider, input)?.done;
     }
 
     info!(target: "reth::cli", "Success.");

--- a/bin/reth/src/stage/dump/merkle.rs
+++ b/bin/reth/src/stage/dump/merkle.rs
@@ -3,15 +3,15 @@ use crate::utils::DbTool;
 use eyre::Result;
 use reth_db::{database::Database, table::TableImporter, tables, DatabaseEnv};
 use reth_primitives::{stage::StageCheckpoint, BlockNumber, ChainSpec, PruneModes};
-use reth_provider::ProviderFactory;
+use reth_provider::{DatabaseProviderRW, ProviderFactory};
 use reth_stages::{
     stages::{
         AccountHashingStage, ExecutionStage, ExecutionStageThresholds, MerkleStage,
         StorageHashingStage, MERKLE_STAGE_DEFAULT_CLEAN_THRESHOLD,
     },
-    Stage, UnwindInput,
+    ExecInput, ExecOutput, Stage, StageError, UnwindInput,
 };
-use std::{path::PathBuf, sync::Arc};
+use std::{future::poll_fn, path::PathBuf, sync::Arc};
 use tracing::info;
 
 pub(crate) async fn dump_merkle_stage<DB: Database>(
@@ -61,10 +61,10 @@ async fn unwind_and_copy<DB: Database>(
 
     // Unwind hashes all the way to FROM
 
-    StorageHashingStage::default().unwind(&provider, unwind).await.unwrap();
-    AccountHashingStage::default().unwind(&provider, unwind).await.unwrap();
+    StorageHashingStage::default().unwind(&provider, unwind).unwrap();
+    AccountHashingStage::default().unwind(&provider, unwind).unwrap();
 
-    MerkleStage::default_unwind().unwind(&provider, unwind).await?;
+    MerkleStage::default_unwind().unwind(&provider, unwind)?;
 
     // Bring Plainstate to TO (hashing stage execution requires it)
     let mut exec_stage = ExecutionStage::new(
@@ -78,27 +78,31 @@ async fn unwind_and_copy<DB: Database>(
         PruneModes::all(),
     );
 
-    exec_stage
-        .unwind(
-            &provider,
-            UnwindInput {
-                unwind_to: to,
-                checkpoint: StageCheckpoint::new(tip_block_number),
-                bad_block: None,
-            },
-        )
-        .await?;
+    exec_stage.unwind(
+        &provider,
+        UnwindInput {
+            unwind_to: to,
+            checkpoint: StageCheckpoint::new(tip_block_number),
+            bad_block: None,
+        },
+    )?;
 
     // Bring hashes to TO
 
-    AccountHashingStage { clean_threshold: u64::MAX, commit_threshold: u64::MAX }
-        .execute(&provider, execute_input)
-        .await
-        .unwrap();
-    StorageHashingStage { clean_threshold: u64::MAX, commit_threshold: u64::MAX }
-        .execute(&provider, execute_input)
-        .await
-        .unwrap();
+    poll_and_execute(
+        &mut AccountHashingStage { clean_threshold: u64::MAX, commit_threshold: u64::MAX },
+        &provider,
+        execute_input,
+    )
+    .await
+    .unwrap();
+    poll_and_execute(
+        &mut StorageHashingStage { clean_threshold: u64::MAX, commit_threshold: u64::MAX },
+        &provider,
+        execute_input,
+    )
+    .await
+    .unwrap();
 
     let unwind_inner_tx = provider.into_tx();
 
@@ -113,6 +117,15 @@ async fn unwind_and_copy<DB: Database>(
     Ok(())
 }
 
+// todo: move to test_utils in reth_stages and use it where we currently manually poll
+async fn poll_and_execute<DB: Database, S: Stage<DB>>(
+    stage: &mut S,
+    provider: &DatabaseProviderRW<'_, &DB>,
+    input: ExecInput,
+) -> Result<ExecOutput, StageError> {
+    poll_fn(|cx| stage.poll_ready(cx, input)).await.and_then(|_| stage.execute(&provider, input))
+}
+
 /// Try to re-execute the stage straightaway
 async fn dry_run<DB: Database>(
     chain: Arc<ChainSpec>,
@@ -125,11 +138,11 @@ async fn dry_run<DB: Database>(
     let provider = factory.provider_rw()?;
     let mut exec_output = false;
     while !exec_output {
-        exec_output = MerkleStage::Execution {
-            // Forces updating the root instead of calculating from scratch
-            clean_threshold: u64::MAX,
-        }
-        .execute(
+        exec_output = poll_and_execute(
+            &mut MerkleStage::Execution {
+                // Forces updating the root instead of calculating from scratch
+                clean_threshold: u64::MAX,
+            },
             &provider,
             reth_stages::ExecInput {
                 target: Some(to),

--- a/bin/reth/src/stage/dump/merkle.rs
+++ b/bin/reth/src/stage/dump/merkle.rs
@@ -118,23 +118,23 @@ async fn dry_run<DB: Database>(
     info!(target: "reth::cli", "Executing stage.");
     let factory = ProviderFactory::new(&output_db, chain);
     let provider = factory.provider_rw()?;
-    let mut done = false;
-    while !done {
-        done = MerkleStage::Execution {
-            // Forces updating the root instead of calculating from scratch
-            clean_threshold: u64::MAX,
+
+    let mut stage = MerkleStage::Execution {
+        // Forces updating the root instead of calculating from scratch
+        clean_threshold: u64::MAX,
+    };
+
+    loop {
+        let input = reth_stages::ExecInput {
+            target: Some(to),
+            checkpoint: Some(StageCheckpoint::new(from)),
+        };
+        if stage.execute(&provider, input)?.done {
+            break
         }
-        .execute(
-            &provider,
-            reth_stages::ExecInput {
-                target: Some(to),
-                checkpoint: Some(StageCheckpoint::new(from)),
-            },
-        )?
-        .done;
     }
 
-    info!(target: "reth::cli", "Success.");
+    info!(target: "reth::cli", "Success");
 
     Ok(())
 }

--- a/bin/reth/src/stage/dump/merkle.rs
+++ b/bin/reth/src/stage/dump/merkle.rs
@@ -126,9 +126,8 @@ async fn dry_run<DB: Database>(
     let mut exec_output = false;
     while !exec_output {
         exec_output = MerkleStage::Execution {
-            clean_threshold: u64::MAX, /* Forces updating the root instead of calculating
-                                        * from
-                                        * scratch */
+            // Forces updating the root instead of calculating from scratch
+            clean_threshold: u64::MAX,
         }
         .execute(
             &provider,

--- a/bin/reth/src/stage/run.rs
+++ b/bin/reth/src/stage/run.rs
@@ -175,8 +175,8 @@ impl Command {
                         .await?;
                     let fetch_client = Arc::new(network.fetch_client().await?);
 
-                    let stage = BodyStage {
-                        downloader: BodiesDownloaderBuilder::default()
+                    let stage = BodyStage::new(
+                        BodiesDownloaderBuilder::default()
                             .with_stream_batch_size(batch_size as usize)
                             .with_request_limit(config.stages.bodies.downloader_request_limit)
                             .with_max_buffered_blocks_size_bytes(
@@ -187,8 +187,8 @@ impl Command {
                                     config.stages.bodies.downloader_max_concurrent_requests,
                             )
                             .build(fetch_client, consensus.clone(), db.clone()),
-                        consensus: consensus.clone(),
-                    };
+                        consensus.clone(),
+                    );
 
                     (Box::new(stage), None)
                 }

--- a/bin/reth/src/stage/run.rs
+++ b/bin/reth/src/stage/run.rs
@@ -25,7 +25,7 @@ use reth_stages::{
         IndexAccountHistoryStage, IndexStorageHistoryStage, MerkleStage, SenderRecoveryStage,
         StorageHashingStage, TransactionLookupStage,
     },
-    ExecInput, ExecOutput, Stage, UnwindInput,
+    ExecInput, PipelineError, Stage, UnwindInput,
 };
 use std::{any::Any, net::SocketAddr, path::PathBuf, sync::Arc};
 use tracing::*;

--- a/bin/reth/src/stage/run.rs
+++ b/bin/reth/src/stage/run.rs
@@ -187,7 +187,6 @@ impl Command {
                                     config.stages.bodies.downloader_max_concurrent_requests,
                             )
                             .build(fetch_client, consensus.clone(), db.clone()),
-                        consensus.clone(),
                     );
 
                     (Box::new(stage), None)
@@ -242,7 +241,7 @@ impl Command {
 
         if !self.skip_unwind {
             while unwind.checkpoint.block_number > self.from {
-                let unwind_output = unwind_stage.unwind(&provider_rw, unwind).await?;
+                let unwind_output = unwind_stage.unwind(&provider_rw, unwind)?;
                 unwind.checkpoint = unwind_output.checkpoint;
 
                 if self.commit {
@@ -258,7 +257,7 @@ impl Command {
         };
 
         while let ExecOutput { checkpoint: stage_progress, done: false } =
-            exec_stage.execute(&provider_rw, input).await?
+            exec_stage.execute(&provider_rw, input)?
         {
             input.checkpoint = Some(stage_progress);
 

--- a/bin/reth/src/stage/run.rs
+++ b/bin/reth/src/stage/run.rs
@@ -25,7 +25,7 @@ use reth_stages::{
         IndexAccountHistoryStage, IndexStorageHistoryStage, MerkleStage, SenderRecoveryStage,
         StorageHashingStage, TransactionLookupStage,
     },
-    ExecInput, PipelineError, Stage, UnwindInput,
+    ExecInput, Stage, UnwindInput,
 };
 use std::{any::Any, net::SocketAddr, path::PathBuf, sync::Arc};
 use tracing::*;

--- a/crates/consensus/beacon/src/engine/test_utils.rs
+++ b/crates/consensus/beacon/src/engine/test_utils.rs
@@ -26,17 +26,15 @@ use reth_payload_builder::test_utils::spawn_test_payload_service;
 use reth_primitives::{BlockNumber, ChainSpec, PruneModes, Receipt, B256, U256};
 use reth_provider::{
     providers::BlockchainProvider, test_utils::TestExecutorFactory, BlockExecutor,
-    BundleStateWithReceipts, ExecutorFactory, ProviderFactory, PrunableBlockExecutor,
+    BundleStateWithReceipts, ExecutorFactory, HeaderSyncMode, ProviderFactory,
+    PrunableBlockExecutor,
 };
 use reth_prune::Pruner;
 use reth_revm::Factory;
 use reth_rpc_types::engine::{
     CancunPayloadFields, ExecutionPayload, ForkchoiceState, ForkchoiceUpdated, PayloadStatus,
 };
-use reth_stages::{
-    sets::DefaultStages, stages::HeaderSyncMode, test_utils::TestStages, ExecOutput, Pipeline,
-    StageError,
-};
+use reth_stages::{sets::DefaultStages, test_utils::TestStages, ExecOutput, Pipeline, StageError};
 use reth_tasks::TokioTaskExecutor;
 use std::{collections::VecDeque, sync::Arc};
 use tokio::sync::{oneshot, watch};
@@ -502,6 +500,7 @@ where
                     .into_task();
 
                 Pipeline::builder().add_stages(DefaultStages::new(
+                    ProviderFactory::new(db.clone(), self.base_config.chain_spec.clone()),
                     HeaderSyncMode::Tip(tip_rx.clone()),
                     Arc::clone(&consensus),
                     header_downloader,

--- a/crates/interfaces/src/provider.rs
+++ b/crates/interfaces/src/provider.rs
@@ -20,6 +20,9 @@ pub enum ProviderError {
     /// Error when recovering the sender for a transaction
     #[error("failed to recover sender for transaction")]
     SenderRecoveryError,
+    /// Inconsistent header gap.
+    #[error("inconsistent header gap in the database")]
+    InconsistentHeaderGap,
     /// The header number was not found for the given block hash.
     #[error("block hash {0} does not exist in Headers table")]
     BlockHashNotFound(BlockHash),

--- a/crates/stages/benches/criterion.rs
+++ b/crates/stages/benches/criterion.rs
@@ -138,7 +138,7 @@ fn measure_stage_with_path<F, S>(
                 let mut stage = stage.clone();
                 let factory = ProviderFactory::new(tx.tx.db(), MAINNET.clone());
                 let provider = factory.provider_rw().unwrap();
-                poll_fn(|cx| stage.poll_ready(cx, input))
+                poll_fn(|cx| stage.poll_execute_ready(cx, input))
                     .await
                     .and_then(|_| stage.execute(&provider, input))
                     .unwrap();

--- a/crates/stages/benches/criterion.rs
+++ b/crates/stages/benches/criterion.rs
@@ -12,7 +12,7 @@ use reth_stages::{
     test_utils::TestTransaction,
     ExecInput, Stage, UnwindInput,
 };
-use std::{path::PathBuf, sync::Arc};
+use std::{future::poll_fn, path::PathBuf, sync::Arc};
 
 mod setup;
 use setup::StageRange;
@@ -138,7 +138,10 @@ fn measure_stage_with_path<F, S>(
                 let mut stage = stage.clone();
                 let factory = ProviderFactory::new(tx.tx.db(), MAINNET.clone());
                 let provider = factory.provider_rw().unwrap();
-                stage.execute(&provider, input).await.unwrap();
+                poll_fn(|cx| stage.poll_ready(cx, input))
+                    .await
+                    .and_then(|_| stage.execute(&provider, input))
+                    .unwrap();
                 provider.commit().unwrap();
             },
         )

--- a/crates/stages/benches/setup/mod.rs
+++ b/crates/stages/benches/setup/mod.rs
@@ -47,7 +47,6 @@ pub(crate) fn stage_unwind<S: Clone + Stage<DatabaseEnv>>(
         // Clear previous run
         stage
             .unwind(&provider, unwind)
-            .await
             .map_err(|e| {
                 format!(
                     "{e}\nMake sure your test database at `{}` isn't too old and incompatible with newer stage changes.",
@@ -67,22 +66,20 @@ pub(crate) fn unwind_hashes<S: Clone + Stage<DatabaseEnv>>(
 ) {
     let (input, unwind) = range;
 
-    tokio::runtime::Runtime::new().unwrap().block_on(async {
-        let mut stage = stage.clone();
-        let factory = ProviderFactory::new(tx.tx.db(), MAINNET.clone());
-        let provider = factory.provider_rw().unwrap();
+    let mut stage = stage.clone();
+    let factory = ProviderFactory::new(tx.tx.db(), MAINNET.clone());
+    let provider = factory.provider_rw().unwrap();
 
-        StorageHashingStage::default().unwind(&provider, unwind).await.unwrap();
-        AccountHashingStage::default().unwind(&provider, unwind).await.unwrap();
+    StorageHashingStage::default().unwind(&provider, unwind).unwrap();
+    AccountHashingStage::default().unwind(&provider, unwind).unwrap();
 
-        // Clear previous run
-        stage.unwind(&provider, unwind).await.unwrap();
+    // Clear previous run
+    stage.unwind(&provider, unwind).unwrap();
 
-        AccountHashingStage::default().execute(&provider, input).await.unwrap();
-        StorageHashingStage::default().execute(&provider, input).await.unwrap();
+    AccountHashingStage::default().execute(&provider, input).unwrap();
+    StorageHashingStage::default().execute(&provider, input).unwrap();
 
-        provider.commit().unwrap();
-    });
+    provider.commit().unwrap();
 }
 
 // Helper for generating testdata for the benchmarks.

--- a/crates/stages/src/error.rs
+++ b/crates/stages/src/error.rs
@@ -50,6 +50,9 @@ pub enum StageError {
         #[source]
         error: Box<consensus::ConsensusError>,
     },
+    /// The headers stage is missing sync gap.
+    #[error("missing sync gap")]
+    MissingSyncGap,
     /// The stage encountered a database error.
     #[error("internal database error occurred: {0}")]
     Database(#[from] DbError),
@@ -94,6 +97,7 @@ impl StageError {
                 StageError::Download(_) |
                 StageError::DatabaseIntegrity(_) |
                 StageError::StageCheckpoint(_) |
+                StageError::MissingSyncGap |
                 StageError::ChannelClosed |
                 StageError::Fatal(_)
         )

--- a/crates/stages/src/lib.rs
+++ b/crates/stages/src/lib.rs
@@ -22,8 +22,11 @@
 //! # use reth_primitives::{PeerId, MAINNET, B256};
 //! # use reth_stages::Pipeline;
 //! # use reth_stages::sets::DefaultStages;
-//! # use reth_stages::stages::HeaderSyncMode;
 //! # use tokio::sync::watch;
+//! # use reth_provider::ProviderFactory;
+//! # use reth_provider::HeaderSyncMode;
+//! #
+//! # let chain_spec = MAINNET.clone();
 //! # let consensus: Arc<dyn Consensus> = Arc::new(TestConsensus::default());
 //! # let headers_downloader = ReverseHeadersDownloaderBuilder::default().build(
 //! #    Arc::new(TestHeadersClient::default()),
@@ -36,19 +39,20 @@
 //! #    db.clone()
 //! # );
 //! # let (tip_tx, tip_rx) = watch::channel(B256::default());
-//! # let factory = Factory::new(MAINNET.clone());
+//! # let factory = Factory::new(chain_spec.clone());
 //! // Create a pipeline that can fully sync
 //! # let pipeline =
 //! Pipeline::builder()
 //!     .with_tip_sender(tip_tx)
 //!     .add_stages(DefaultStages::new(
+//!         ProviderFactory::new(db.clone(), chain_spec.clone()),
 //!         HeaderSyncMode::Tip(tip_rx),
 //!         consensus,
 //!         headers_downloader,
 //!         bodies_downloader,
 //!         factory,
 //!     ))
-//!     .build(db, MAINNET.clone());
+//!     .build(db, chain_spec.clone());
 //! ```
 //!
 //! ## Feature Flags

--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -443,6 +443,7 @@ where
                     }
                 }
                 Err(err) => {
+                    drop(provider_rw);
                     self.listeners.notify(PipelineEvent::Error { stage_id });
                     if let Some(ctrl) = on_stage_error(&factory, stage_id, prev_checkpoint, err)? {
                         return Ok(ctrl)

--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -159,9 +159,6 @@ where
     /// pipeline and its result as a future.
     #[track_caller]
     pub fn run_as_fut(mut self, tip: Option<B256>) -> PipelineFut<DB> {
-        // TODO(onbjerg): Do we need this if we make all of this stuff sync, or should it just be a
-        // thread? If we still need it, why? Do we need more granular control over how the pipeline
-        // is run?
         // TODO: fix this in a follow up PR. ideally, consensus engine would be responsible for
         // updating metrics.
         let _ = self.register_metrics(); // ignore error
@@ -373,7 +370,7 @@ where
 
             let exec_input = ExecInput { target, checkpoint: prev_checkpoint };
 
-            if let Err(err) = poll_fn(|cx| stage.poll_ready(cx, exec_input)).await {
+            if let Err(err) = poll_fn(|cx| stage.poll_execute_ready(cx, exec_input)).await {
                 self.listeners.notify(PipelineEvent::Error { stage_id });
                 match on_stage_error(&factory, stage_id, prev_checkpoint, err)? {
                     Some(ctrl) => return Ok(ctrl),

--- a/crates/stages/src/sets.rs
+++ b/crates/stages/src/sets.rs
@@ -38,7 +38,7 @@
 //! ```
 use crate::{
     stages::{
-        AccountHashingStage, BodyStage, ExecutionStage, FinishStage, HeaderStage, HeaderSyncMode,
+        AccountHashingStage, BodyStage, ExecutionStage, FinishStage, HeaderStage,
         IndexAccountHistoryStage, IndexStorageHistoryStage, MerkleStage, SenderRecoveryStage,
         StorageHashingStage, TotalDifficultyStage, TransactionLookupStage,
     },
@@ -49,7 +49,7 @@ use reth_interfaces::{
     consensus::Consensus,
     p2p::{bodies::downloader::BodyDownloader, headers::downloader::HeaderDownloader},
 };
-use reth_provider::ExecutorFactory;
+use reth_provider::{ExecutorFactory, HeaderSyncGapProvider, HeaderSyncMode};
 use std::sync::Arc;
 
 /// A set containing all stages to run a fully syncing instance of reth.
@@ -75,16 +75,17 @@ use std::sync::Arc;
 /// - [`IndexAccountHistoryStage`]
 /// - [`FinishStage`]
 #[derive(Debug)]
-pub struct DefaultStages<H, B, EF> {
+pub struct DefaultStages<Provider, H, B, EF> {
     /// Configuration for the online stages
-    online: OnlineStages<H, B>,
+    online: OnlineStages<Provider, H, B>,
     /// Executor factory needs for execution stage
     executor_factory: EF,
 }
 
-impl<H, B, EF> DefaultStages<H, B, EF> {
+impl<Provider, H, B, EF> DefaultStages<Provider, H, B, EF> {
     /// Create a new set of default stages with default values.
     pub fn new(
+        provider: Provider,
         header_mode: HeaderSyncMode,
         consensus: Arc<dyn Consensus>,
         header_downloader: H,
@@ -95,13 +96,19 @@ impl<H, B, EF> DefaultStages<H, B, EF> {
         EF: ExecutorFactory,
     {
         Self {
-            online: OnlineStages::new(header_mode, consensus, header_downloader, body_downloader),
+            online: OnlineStages::new(
+                provider,
+                header_mode,
+                consensus,
+                header_downloader,
+                body_downloader,
+            ),
             executor_factory,
         }
     }
 }
 
-impl<H, B, EF> DefaultStages<H, B, EF>
+impl<Provider, H, B, EF> DefaultStages<Provider, H, B, EF>
 where
     EF: ExecutorFactory,
 {
@@ -114,9 +121,10 @@ where
     }
 }
 
-impl<DB, H, B, EF> StageSet<DB> for DefaultStages<H, B, EF>
+impl<DB, Provider, H, B, EF> StageSet<DB> for DefaultStages<Provider, H, B, EF>
 where
     DB: Database,
+    Provider: HeaderSyncGapProvider + 'static,
     H: HeaderDownloader + 'static,
     B: BodyDownloader + 'static,
     EF: ExecutorFactory,
@@ -131,7 +139,9 @@ where
 /// These stages *can* be run without network access if the specified downloaders are
 /// themselves offline.
 #[derive(Debug)]
-pub struct OnlineStages<H, B> {
+pub struct OnlineStages<Provider, H, B> {
+    /// Sync gap provider for the headers stage.
+    provider: Provider,
     /// The sync mode for the headers stage.
     header_mode: HeaderSyncMode,
     /// The consensus engine used to validate incoming data.
@@ -142,60 +152,64 @@ pub struct OnlineStages<H, B> {
     body_downloader: B,
 }
 
-impl<H, B> OnlineStages<H, B> {
+impl<Provider, H, B> OnlineStages<Provider, H, B> {
     /// Create a new set of online stages with default values.
     pub fn new(
+        provider: Provider,
         header_mode: HeaderSyncMode,
         consensus: Arc<dyn Consensus>,
         header_downloader: H,
         body_downloader: B,
     ) -> Self {
-        Self { header_mode, consensus, header_downloader, body_downloader }
+        Self { provider, header_mode, consensus, header_downloader, body_downloader }
     }
 }
 
-impl<H, B> OnlineStages<H, B>
+impl<Provider, H, B> OnlineStages<Provider, H, B>
 where
+    Provider: HeaderSyncGapProvider + 'static,
     H: HeaderDownloader + 'static,
     B: BodyDownloader + 'static,
 {
     /// Create a new builder using the given headers stage.
     pub fn builder_with_headers<DB: Database>(
-        headers: HeaderStage<H>,
+        headers: HeaderStage<Provider, H>,
         body_downloader: B,
         consensus: Arc<dyn Consensus>,
     ) -> StageSetBuilder<DB> {
         StageSetBuilder::default()
             .add_stage(headers)
             .add_stage(TotalDifficultyStage::new(consensus.clone()))
-            .add_stage(BodyStage::new(body_downloader, consensus))
+            .add_stage(BodyStage::new(body_downloader))
     }
 
     /// Create a new builder using the given bodies stage.
     pub fn builder_with_bodies<DB: Database>(
         bodies: BodyStage<B>,
+        provider: Provider,
         mode: HeaderSyncMode,
         header_downloader: H,
         consensus: Arc<dyn Consensus>,
     ) -> StageSetBuilder<DB> {
         StageSetBuilder::default()
-            .add_stage(HeaderStage::new(header_downloader, mode))
+            .add_stage(HeaderStage::new(provider, header_downloader, mode))
             .add_stage(TotalDifficultyStage::new(consensus.clone()))
             .add_stage(bodies)
     }
 }
 
-impl<DB, H, B> StageSet<DB> for OnlineStages<H, B>
+impl<DB, Provider, H, B> StageSet<DB> for OnlineStages<Provider, H, B>
 where
     DB: Database,
+    Provider: HeaderSyncGapProvider + 'static,
     H: HeaderDownloader + 'static,
     B: BodyDownloader + 'static,
 {
     fn builder(self) -> StageSetBuilder<DB> {
         StageSetBuilder::default()
-            .add_stage(HeaderStage::new(self.header_downloader, self.header_mode))
+            .add_stage(HeaderStage::new(self.provider, self.header_downloader, self.header_mode))
             .add_stage(TotalDifficultyStage::new(self.consensus.clone()))
-            .add_stage(BodyStage::new(self.body_downloader, self.consensus))
+            .add_stage(BodyStage::new(self.body_downloader))
     }
 }
 

--- a/crates/stages/src/sets.rs
+++ b/crates/stages/src/sets.rs
@@ -168,7 +168,7 @@ where
         StageSetBuilder::default()
             .add_stage(headers)
             .add_stage(TotalDifficultyStage::new(consensus.clone()))
-            .add_stage(BodyStage { downloader: body_downloader, consensus })
+            .add_stage(BodyStage::new(body_downloader, consensus))
     }
 
     /// Create a new builder using the given bodies stage.
@@ -195,7 +195,7 @@ where
         StageSetBuilder::default()
             .add_stage(HeaderStage::new(self.header_downloader, self.header_mode))
             .add_stage(TotalDifficultyStage::new(self.consensus.clone()))
-            .add_stage(BodyStage { downloader: self.body_downloader, consensus: self.consensus })
+            .add_stage(BodyStage::new(self.body_downloader, self.consensus))
     }
 }
 

--- a/crates/stages/src/stage.rs
+++ b/crates/stages/src/stage.rs
@@ -9,6 +9,7 @@ use reth_provider::{BlockReader, DatabaseProviderRW, ProviderError, Transactions
 use std::{
     cmp::{max, min},
     ops::{Range, RangeInclusive},
+    task::{Context, Poll},
 };
 
 /// Stage execution input, see [Stage::execute].
@@ -208,4 +209,32 @@ pub trait Stage<DB: Database>: Send + Sync {
         provider: &DatabaseProviderRW<'_, &DB>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError>;
+
+    /// Returns `Poll::Ready(Ok(()))` when the stage is ready to execute the given range.
+    ///
+    /// This method is heavily inspired by [tower]s `Service` trait. Any asynchronous tasks or
+    /// communication should be handled in `poll_ready`, e.g. moving downloaded items from
+    /// downloaders to an internal buffer in the stage.
+    ///
+    /// If the stage has any pending external state, then `Poll::Pending` is returned.
+    ///
+    /// If `Poll::Ready(Err(_))` is returned, the stage may not be able to execute anymore
+    /// depending on the specific error. In that case, an unwind must be issued instead.
+    ///
+    /// Once `Poll::Ready(Ok(()))` is returned, the stage may be executed once using `execute`.
+    /// Until the stage has been executed, repeated calls to `poll_ready` must return either
+    /// `Poll::Ready(Ok(()))` or `Poll::Ready(Err(_))`.
+    ///
+    /// Note that `poll_ready` may reserve shared resources that are consumed in a subsequent call
+    /// of `execute`, e.g. internal buffers. It is crucial for implementations to not assume that
+    /// `execute` will always be invoked and to ensure that those resources are appropriately
+    /// released if the stage is dropped before `execute` is called.
+    ///
+    /// For the same reason, it is also important that any shared resources do not exhibit
+    /// unbounded growth on repeated calls to `poll_ready`.
+    ///
+    /// Unwinds may happen without consulting `poll_ready` first.
+    fn poll_ready(&mut self, cx: &mut Context<'_>, _: ExecInput) -> Poll<Result<(), StageError>> {
+        Poll::Ready(Ok(()))
+    }
 }

--- a/crates/stages/src/stage.rs
+++ b/crates/stages/src/stage.rs
@@ -211,9 +211,9 @@ pub trait Stage<DB: Database>: Send + Sync {
 
     /// Returns `Poll::Ready(Ok(()))` when the stage is ready to execute the given range.
     ///
-    /// This method is heavily inspired by [tower]s `Service` trait. Any asynchronous tasks or
-    /// communication should be handled in `poll_ready`, e.g. moving downloaded items from
-    /// downloaders to an internal buffer in the stage.
+    /// This method is heavily inspired by [tower](https://crates.io/crates/tower)'s `Service` trait.
+    /// Any asynchronous tasks or communication should be handled in `poll_ready`, e.g. moving
+    /// downloaded items from downloaders to an internal buffer in the stage.
     ///
     /// If the stage has any pending external state, then `Poll::Pending` is returned.
     ///

--- a/crates/stages/src/stage.rs
+++ b/crates/stages/src/stage.rs
@@ -1,5 +1,4 @@
 use crate::error::StageError;
-use async_trait::async_trait;
 use reth_db::database::Database;
 use reth_primitives::{
     stage::{StageCheckpoint, StageId},
@@ -234,7 +233,11 @@ pub trait Stage<DB: Database>: Send + Sync {
     /// unbounded growth on repeated calls to `poll_ready`.
     ///
     /// Unwinds may happen without consulting `poll_ready` first.
-    fn poll_ready(&mut self, cx: &mut Context<'_>, _: ExecInput) -> Poll<Result<(), StageError>> {
+    fn poll_ready(
+        &mut self,
+        _cx: &mut Context<'_>,
+        _input: ExecInput,
+    ) -> Poll<Result<(), StageError>> {
         Poll::Ready(Ok(()))
     }
 }

--- a/crates/stages/src/stage.rs
+++ b/crates/stages/src/stage.rs
@@ -189,7 +189,6 @@ pub struct UnwindOutput {
 /// Stages are executed as part of a pipeline where they are executed serially.
 ///
 /// Stages receive [`DatabaseProviderRW`].
-#[async_trait]
 pub trait Stage<DB: Database>: Send + Sync {
     /// Get the ID of the stage.
     ///
@@ -197,14 +196,14 @@ pub trait Stage<DB: Database>: Send + Sync {
     fn id(&self) -> StageId;
 
     /// Execute the stage.
-    async fn execute(
+    fn execute(
         &mut self,
         provider: &DatabaseProviderRW<'_, &DB>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError>;
 
     /// Unwind the stage.
-    async fn unwind(
+    fn unwind(
         &mut self,
         provider: &DatabaseProviderRW<'_, &DB>,
         input: UnwindInput,

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -69,7 +69,6 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
     fn poll_ready(
         &mut self,
         cx: &mut Context<'_>,
-        // _provider: &DatabaseProviderRO<'_, &DB>,
         input: ExecInput,
     ) -> Poll<Result<(), StageError>> {
         // todo: short circuit if target is reached?
@@ -190,6 +189,8 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
         provider: &DatabaseProviderRW<'_, &DB>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
+        self.buffer.clear();
+
         let tx = provider.tx_ref();
         // Cursors to unwind bodies, ommers
         let mut body_cursor = tx.cursor_write::<tables::BlockBodyIndices>()?;

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -66,7 +66,7 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
         StageId::Bodies
     }
 
-    fn poll_ready(
+    fn poll_execute_ready(
         &mut self,
         cx: &mut Context<'_>,
         input: ExecInput,

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -71,9 +71,6 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
         cx: &mut Context<'_>,
         input: ExecInput,
     ) -> Poll<Result<(), StageError>> {
-        // todo: short circuit if target is reached?
-        // todo: check if this is bad async code
-        // todo: prob should have some other condition (i.e. more than 1 body surely)
         if input.target_reached() || !self.buffer.is_empty() {
             return Poll::Ready(Ok(()))
         }

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -56,7 +56,6 @@ pub struct BodyStage<D: BodyDownloader> {
     pub consensus: Arc<dyn Consensus>,
 }
 
-#[async_trait::async_trait]
 impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
     /// Return the id of the stage
     fn id(&self) -> StageId {
@@ -65,7 +64,7 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
 
     /// Download block bodies from the last checkpoint for this stage up until the latest synced
     /// header, limited by the stage's batch size.
-    async fn execute(
+    fn execute(
         &mut self,
         provider: &DatabaseProviderRW<'_, &DB>,
         input: ExecInput,
@@ -94,8 +93,11 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
 
         // Task downloader can return `None` only if the response relaying channel was closed. This
         // is a fatal error to prevent the pipeline from running forever.
-        let downloaded_bodies =
-            self.downloader.try_next().await?.ok_or(StageError::ChannelClosed)?;
+
+        // todo: should be in a dedicated poll rdy fn
+        /*let downloaded_bodies =
+        self.downloader.try_next().await?.ok_or(StageError::ChannelClosed)?;*/
+        let downloaded_bodies: Vec<BlockResponse> = Vec::new();
 
         trace!(target: "sync::stages::bodies", bodies_len = downloaded_bodies.len(), "Writing blocks");
 
@@ -161,7 +163,7 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
     }
 
     /// Unwind the stage.
-    async fn unwind(
+    fn unwind(
         &mut self,
         provider: &DatabaseProviderRW<'_, &DB>,
         input: UnwindInput,

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -501,7 +501,7 @@ mod tests {
     };
     use reth_provider::{AccountReader, BlockWriter, ProviderFactory, ReceiptProvider};
     use reth_revm::Factory;
-    use std::{future::poll_fn, sync::Arc};
+    use std::sync::Arc;
 
     fn stage() -> ExecutionStage<Factory> {
         let factory =
@@ -684,11 +684,8 @@ mod tests {
         provider.commit().unwrap();
 
         let provider = factory.provider_rw().unwrap();
-        let mut execution_stage = stage();
-        let output = poll_fn(|cx| stage.poll_ready(cx, input))
-            .await
-            .and_then(|_| stage.execute(&provider, input))
-            .unwrap();
+        let mut execution_stage: ExecutionStage<Factory> = stage();
+        let output = execution_stage.execute(&provider, input).unwrap();
         provider.commit().unwrap();
         assert_matches!(output, ExecOutput {
             checkpoint: StageCheckpoint {
@@ -789,7 +786,7 @@ mod tests {
         // execute
         let provider = factory.provider_rw().unwrap();
         let mut execution_stage = stage();
-        let result = execution_stage.execute(&provider, input).await.unwrap();
+        let result = execution_stage.execute(&provider, input).unwrap();
         provider.commit().unwrap();
 
         let provider = factory.provider_rw().unwrap();
@@ -799,7 +796,6 @@ mod tests {
                 &provider,
                 UnwindInput { checkpoint: result.checkpoint, unwind_to: 0, bad_block: None },
             )
-            .await
             .unwrap();
 
         assert_matches!(result, UnwindOutput {
@@ -888,7 +884,7 @@ mod tests {
         // execute
         let provider = factory.provider_rw().unwrap();
         let mut execution_stage = stage();
-        let _ = execution_stage.execute(&provider, input).await.unwrap();
+        let _ = execution_stage.execute(&provider, input).unwrap();
         provider.commit().unwrap();
 
         // assert unwind stage

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -331,7 +331,6 @@ fn calculate_gas_used_from_headers<DB: Database>(
     Ok(gas_total)
 }
 
-#[async_trait::async_trait]
 impl<EF: ExecutorFactory, DB: Database> Stage<DB> for ExecutionStage<EF> {
     /// Return the id of the stage
     fn id(&self) -> StageId {
@@ -339,7 +338,7 @@ impl<EF: ExecutorFactory, DB: Database> Stage<DB> for ExecutionStage<EF> {
     }
 
     /// Execute the stage
-    async fn execute(
+    fn execute(
         &mut self,
         provider: &DatabaseProviderRW<'_, &DB>,
         input: ExecInput,
@@ -348,7 +347,7 @@ impl<EF: ExecutorFactory, DB: Database> Stage<DB> for ExecutionStage<EF> {
     }
 
     /// Unwind the stage.
-    async fn unwind(
+    fn unwind(
         &mut self,
         provider: &DatabaseProviderRW<'_, &DB>,
         input: UnwindInput,

--- a/crates/stages/src/stages/finish.rs
+++ b/crates/stages/src/stages/finish.rs
@@ -11,7 +11,6 @@ use reth_provider::DatabaseProviderRW;
 #[non_exhaustive]
 pub struct FinishStage;
 
-// todo: re-eval if we need this stage
 impl<DB: Database> Stage<DB> for FinishStage {
     fn id(&self) -> StageId {
         StageId::Finish

--- a/crates/stages/src/stages/finish.rs
+++ b/crates/stages/src/stages/finish.rs
@@ -11,13 +11,13 @@ use reth_provider::DatabaseProviderRW;
 #[non_exhaustive]
 pub struct FinishStage;
 
-#[async_trait::async_trait]
+// todo: re-eval if we need this stage
 impl<DB: Database> Stage<DB> for FinishStage {
     fn id(&self) -> StageId {
         StageId::Finish
     }
 
-    async fn execute(
+    fn execute(
         &mut self,
         _provider: &DatabaseProviderRW<'_, &DB>,
         input: ExecInput,
@@ -25,7 +25,7 @@ impl<DB: Database> Stage<DB> for FinishStage {
         Ok(ExecOutput { checkpoint: StageCheckpoint::new(input.target()), done: true })
     }
 
-    async fn unwind(
+    fn unwind(
         &mut self,
         _provider: &DatabaseProviderRW<'_, &DB>,
         input: UnwindInput,

--- a/crates/stages/src/stages/hashing_account.rs
+++ b/crates/stages/src/stages/hashing_account.rs
@@ -21,8 +21,8 @@ use std::{
     cmp::max,
     fmt::Debug,
     ops::{Range, RangeInclusive},
+    sync::mpsc,
 };
-use tokio::sync::mpsc;
 use tracing::*;
 
 /// Account hashing stage hashes plain account.
@@ -125,7 +125,6 @@ impl AccountHashingStage {
     }
 }
 
-#[async_trait::async_trait]
 impl<DB: Database> Stage<DB> for AccountHashingStage {
     /// Return the id of the stage
     fn id(&self) -> StageId {
@@ -133,7 +132,7 @@ impl<DB: Database> Stage<DB> for AccountHashingStage {
     }
 
     /// Execute the stage.
-    async fn execute(
+    fn execute(
         &mut self,
         provider: &DatabaseProviderRW<'_, &DB>,
         input: ExecInput,
@@ -190,7 +189,7 @@ impl<DB: Database> Stage<DB> for AccountHashingStage {
                     )
                 {
                     // An _unordered_ channel to receive results from a rayon job
-                    let (tx, rx) = mpsc::unbounded_channel();
+                    let (tx, rx) = mpsc::channel();
                     channels.push(rx);
 
                     let chunk = chunk.collect::<Result<Vec<_>, _>>()?;
@@ -206,7 +205,7 @@ impl<DB: Database> Stage<DB> for AccountHashingStage {
 
                 // Iterate over channels and append the hashed accounts.
                 for mut channel in channels {
-                    while let Some(hashed) = channel.recv().await {
+                    while let Ok(hashed) = channel.recv() {
                         hashed_batch.push(hashed);
                     }
                 }
@@ -265,7 +264,7 @@ impl<DB: Database> Stage<DB> for AccountHashingStage {
     }
 
     /// Unwind the stage.
-    async fn unwind(
+    fn unwind(
         &mut self,
         provider: &DatabaseProviderRW<'_, &DB>,
         input: UnwindInput,

--- a/crates/stages/src/stages/hashing_account.rs
+++ b/crates/stages/src/stages/hashing_account.rs
@@ -204,7 +204,7 @@ impl<DB: Database> Stage<DB> for AccountHashingStage {
                 let mut hashed_batch = Vec::with_capacity(self.commit_threshold as usize);
 
                 // Iterate over channels and append the hashed accounts.
-                for mut channel in channels {
+                for channel in channels {
                     while let Ok(hashed) = channel.recv() {
                         hashed_batch.push(hashed);
                     }

--- a/crates/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/src/stages/hashing_storage.rs
@@ -44,7 +44,6 @@ impl Default for StorageHashingStage {
     }
 }
 
-#[async_trait::async_trait]
 impl<DB: Database> Stage<DB> for StorageHashingStage {
     /// Return the id of the stage
     fn id(&self) -> StageId {
@@ -52,7 +51,7 @@ impl<DB: Database> Stage<DB> for StorageHashingStage {
     }
 
     /// Execute the stage.
-    async fn execute(
+    fn execute(
         &mut self,
         provider: &DatabaseProviderRW<'_, &DB>,
         input: ExecInput,
@@ -191,7 +190,7 @@ impl<DB: Database> Stage<DB> for StorageHashingStage {
     }
 
     /// Unwind the stage.
-    async fn unwind(
+    fn unwind(
         &mut self,
         provider: &DatabaseProviderRW<'_, &DB>,
         input: UnwindInput,

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -1,5 +1,4 @@
 use crate::{ExecInput, ExecOutput, Stage, StageError, UnwindInput, UnwindOutput};
-use futures_util::StreamExt;
 use reth_db::{
     cursor::{DbCursorRO, DbCursorRW},
     database::Database,
@@ -7,10 +6,7 @@ use reth_db::{
     transaction::{DbTx, DbTxMut},
 };
 use reth_interfaces::{
-    p2p::headers::{
-        downloader::{HeaderDownloader, SyncTarget},
-        error::HeadersDownloaderError,
-    },
+    p2p::headers::downloader::{HeaderDownloader, SyncTarget},
     provider::ProviderError,
 };
 use reth_primitives::{

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -173,7 +173,7 @@ where
             return Ok(ExecOutput::done(current_checkpoint))
         }
 
-        let gap = self.sync_gap.clone().unwrap();
+        let gap = self.sync_gap.clone().unwrap(); // TODO:
         let local_head = gap.local_head.number;
         let tip = gap.target.tip();
 
@@ -270,9 +270,9 @@ where
         provider: &DatabaseProviderRW<'_, &DB>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
-        // TODO: handle bad block
         self.buffer.clear();
         self.sync_gap.take();
+
         provider.unwind_table_by_walker::<tables::CanonicalHeaders, tables::HeaderNumbers>(
             input.unwind_to + 1,
         )?;

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -118,7 +118,7 @@ where
         StageId::Headers
     }
 
-    fn poll_ready(
+    fn poll_execute_ready(
         &mut self,
         cx: &mut Context<'_>,
         input: ExecInput,

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -1,34 +1,24 @@
 use crate::{ExecInput, ExecOutput, Stage, StageError, UnwindInput, UnwindOutput};
+use futures_util::StreamExt;
 use reth_db::{
     cursor::{DbCursorRO, DbCursorRW},
-    database::Database,
+    database::{Database, DatabaseGAT},
     tables,
     transaction::{DbTx, DbTxMut},
 };
 use reth_interfaces::{
-    p2p::headers::downloader::{HeaderDownloader, SyncTarget},
+    p2p::headers::{downloader::HeaderDownloader, error::HeadersDownloaderError},
     provider::ProviderError,
 };
 use reth_primitives::{
     stage::{
         CheckpointBlockRange, EntitiesCheckpoint, HeadersCheckpoint, StageCheckpoint, StageId,
     },
-    BlockHashOrNumber, BlockNumber, SealedHeader, B256,
+    BlockHashOrNumber, BlockNumber, SealedHeader,
 };
-use reth_provider::DatabaseProviderRW;
-use tokio::sync::watch;
+use reth_provider::{DatabaseProviderRW, HeaderSyncGap, HeaderSyncGapProvider, HeaderSyncMode};
+use std::task::{ready, Context, Poll};
 use tracing::*;
-
-/// The header sync mode.
-#[derive(Debug)]
-pub enum HeaderSyncMode {
-    /// A sync mode in which the stage continuously requests the downloader for
-    /// next blocks.
-    Continuous,
-    /// A sync mode in which the stage polls the receiver for the next tip
-    /// to download from.
-    Tip(watch::Receiver<B256>),
-}
 
 /// The headers stage.
 ///
@@ -44,27 +34,33 @@ pub enum HeaderSyncMode {
 /// NOTE: This stage downloads headers in reverse. Upon returning the control flow to the pipeline,
 /// the stage checkpoint is not updated until this stage is done.
 #[derive(Debug)]
-pub struct HeaderStage<D: HeaderDownloader> {
+pub struct HeaderStage<Provider, Downloader: HeaderDownloader> {
+    /// Database handle.
+    provider: Provider,
     /// Strategy for downloading the headers
-    downloader: D,
+    downloader: Downloader,
     /// The sync mode for the stage.
     mode: HeaderSyncMode,
+    /// Current sync gap.
+    sync_gap: Option<HeaderSyncGap>,
+    /// Header buffer.
+    buffer: Vec<SealedHeader>,
 }
 
 // === impl HeaderStage ===
 
-impl<D> HeaderStage<D>
+impl<Provider, Downloader> HeaderStage<Provider, Downloader>
 where
-    D: HeaderDownloader,
+    Downloader: HeaderDownloader,
 {
     /// Create a new header stage
-    pub fn new(downloader: D, mode: HeaderSyncMode) -> Self {
-        Self { downloader, mode }
+    pub fn new(database: Provider, downloader: Downloader, mode: HeaderSyncMode) -> Self {
+        Self { provider: database, downloader, mode, sync_gap: None, buffer: Vec::new() }
     }
 
     fn is_stage_done<DB: Database>(
         &self,
-        tx: &<DB as reth_db::database::DatabaseGAT<'_>>::TXMut,
+        tx: &<DB as DatabaseGAT<'_>>::TXMut,
         checkpoint: u64,
     ) -> Result<bool, StageError> {
         let mut header_cursor = tx.cursor_read::<tables::CanonicalHeaders>()?;
@@ -75,76 +71,12 @@ where
         Ok(header_cursor.next()?.map(|(next_num, _)| head_num + 1 == next_num).unwrap_or_default())
     }
 
-    /// Get the head and tip of the range we need to sync
-    ///
-    /// See also [SyncTarget]
-    fn get_sync_gap<DB: Database>(
-        &mut self,
-        provider: &DatabaseProviderRW<'_, &DB>,
-        checkpoint: u64,
-    ) -> Result<SyncGap, StageError> {
-        // Create a cursor over canonical header hashes
-        let mut cursor = provider.tx_ref().cursor_read::<tables::CanonicalHeaders>()?;
-        let mut header_cursor = provider.tx_ref().cursor_read::<tables::Headers>()?;
-
-        // Get head hash and reposition the cursor
-        let (head_num, head_hash) = cursor
-            .seek_exact(checkpoint)?
-            .ok_or_else(|| ProviderError::HeaderNotFound(checkpoint.into()))?;
-
-        // Construct head
-        let (_, head) = header_cursor
-            .seek_exact(head_num)?
-            .ok_or_else(|| ProviderError::HeaderNotFound(head_num.into()))?;
-        let local_head = head.seal(head_hash);
-
-        // Look up the next header
-        let next_header = cursor
-            .next()?
-            .map(|(next_num, next_hash)| -> Result<SealedHeader, StageError> {
-                let (_, next) = header_cursor
-                    .seek_exact(next_num)?
-                    .ok_or_else(|| ProviderError::HeaderNotFound(next_num.into()))?;
-                Ok(next.seal(next_hash))
-            })
-            .transpose()?;
-
-        // Decide the tip or error out on invalid input.
-        // If the next element found in the cursor is not the "expected" next block per our current
-        // checkpoint, then there is a gap in the database and we should start downloading in
-        // reverse from there. Else, it should use whatever the forkchoice state reports.
-        let target = match next_header {
-            Some(header) if checkpoint + 1 != header.number => SyncTarget::Gap(header),
-            None => {
-                self.next_sync_target(head_num).ok_or(StageError::StageCheckpoint(checkpoint))?
-            }
-            _ => return Err(StageError::StageCheckpoint(checkpoint)),
-        };
-
-        Ok(SyncGap { local_head, target })
-    }
-
-    fn next_sync_target(&mut self, head: BlockNumber) -> Option<SyncTarget> {
-        match self.mode {
-            HeaderSyncMode::Tip(ref mut rx) => {
-                // TODO: this should be moved to a `poll_ready` kind of thing
-                //let tip = rx.wait_for(|tip| !tip.is_zero()).await.ok()?;
-                //Some(SyncTarget::Tip(*tip))
-                Some(SyncTarget::TipNum(head + 1)) // todo: temp
-            }
-            HeaderSyncMode::Continuous => {
-                trace!(target: "sync::stages::headers", head, "No next header found, using continuous sync strategy");
-                Some(SyncTarget::TipNum(head + 1))
-            }
-        }
-    }
-
     /// Write downloaded headers to the given transaction
     ///
     /// Note: this writes the headers with rising block numbers.
     fn write_headers<DB: Database>(
         &self,
-        tx: &<DB as reth_db::database::DatabaseGAT<'_>>::TXMut,
+        tx: &<DB as DatabaseGAT<'_>>::TXMut,
         headers: Vec<SealedHeader>,
     ) -> Result<Option<BlockNumber>, StageError> {
         trace!(target: "sync::stages::headers", len = headers.len(), "writing headers");
@@ -175,9 +107,10 @@ where
     }
 }
 
-impl<DB, D> Stage<DB> for HeaderStage<D>
+impl<DB, Provider, D> Stage<DB> for HeaderStage<Provider, D>
 where
     DB: Database,
+    Provider: HeaderSyncGapProvider,
     D: HeaderDownloader,
 {
     /// Return the id of the stage
@@ -185,20 +118,17 @@ where
         StageId::Headers
     }
 
-    /// Download the headers in reverse order (falling block numbers)
-    /// starting from the tip of the chain
-    fn execute(
+    fn poll_ready(
         &mut self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        cx: &mut Context<'_>,
         input: ExecInput,
-    ) -> Result<ExecOutput, StageError> {
-        let tx = provider.tx_ref();
+    ) -> Poll<Result<(), StageError>> {
         let current_checkpoint = input.checkpoint();
 
         // Lookup the head and tip of the sync range
-        let gap = self.get_sync_gap(provider, current_checkpoint.block_number)?;
-        let local_head = gap.local_head.number;
+        let gap = self.provider.sync_gap(self.mode.clone(), current_checkpoint.block_number)?;
         let tip = gap.target.tip();
+        self.sync_gap = Some(gap.clone());
 
         // Nothing to sync
         if gap.is_closed() {
@@ -208,7 +138,7 @@ where
                 target = ?tip,
                 "Target block already reached"
             );
-            return Ok(ExecOutput::done(current_checkpoint))
+            return Poll::Ready(Ok(()))
         }
 
         debug!(target: "sync::stages::headers", ?tip, head = ?gap.local_head.hash(), "Commencing sync");
@@ -216,34 +146,44 @@ where
         // let the downloader know what to sync
         self.downloader.update_sync_gap(gap.local_head, gap.target);
 
-        // The downloader returns the headers in descending order starting from the tip
-        // down to the local head (latest block in db).
-        // Task downloader can return `None` only if the response relaying channel was closed. This
-        // is a fatal error to prevent the pipeline from running forever.
-
-        // todo: this should be in a poll rdy fn
-        /*let downloaded_headers = match self.downloader.next().await {
-            Some(Ok(headers)) => headers,
+        let result = match ready!(self.downloader.poll_next_unpin(cx)) {
+            Some(Ok(headers)) => {
+                info!(target: "sync::stages::headers", len = headers.len(), "Received headers");
+                self.buffer.extend(headers);
+                Ok(())
+            }
             Some(Err(HeadersDownloaderError::DetachedHead { local_head, header, error })) => {
                 error!(target: "sync::stages::headers", ?error, "Cannot attach header to head");
-                return Err(StageError::DetachedHead { local_head, header, error })
+                Err(StageError::DetachedHead { local_head, header, error })
             }
-            None => return Err(StageError::ChannelClosed),
-        };*/
-        let downloaded_headers: Vec<SealedHeader> = Vec::new();
+            None => Err(StageError::ChannelClosed),
+        };
+        Poll::Ready(result)
+    }
 
-        info!(target: "sync::stages::headers", len = downloaded_headers.len(), "Received headers");
+    /// Download the headers in reverse order (falling block numbers)
+    /// starting from the tip of the chain
+    fn execute(
+        &mut self,
+        provider: &DatabaseProviderRW<'_, &DB>,
+        input: ExecInput,
+    ) -> Result<ExecOutput, StageError> {
+        let current_checkpoint = input.checkpoint();
+        if self.buffer.is_empty() {
+            return Ok(ExecOutput::done(current_checkpoint))
+        }
 
+        let gap = self.sync_gap.clone().unwrap();
+        let local_head = gap.local_head.number;
+        let tip = gap.target.tip();
+
+        let downloaded_headers = std::mem::take(&mut self.buffer);
         let tip_block_number = match tip {
             // If tip is hash and it equals to the first downloaded header's hash, we can use
             // the block number of this header as tip.
-            BlockHashOrNumber::Hash(hash) => downloaded_headers.first().and_then(|header| {
-                if header.hash == hash {
-                    Some(header.number)
-                } else {
-                    None
-                }
-            }),
+            BlockHashOrNumber::Hash(hash) => downloaded_headers
+                .first()
+                .and_then(|header| (header.hash == hash).then_some(header.number)),
             // If tip is number, we can just grab it and not resolve using downloaded headers.
             BlockHashOrNumber::Number(number) => Some(number),
         };
@@ -253,13 +193,14 @@ where
         // syncing towards, we need to take into account already synced headers from the database.
         // It is `None`, if tip didn't change and we're still downloading headers for previously
         // calculated gap.
+        let tx = provider.tx_ref();
         let target_block_number = if let Some(tip_block_number) = tip_block_number {
             let local_max_block_number = tx
                 .cursor_read::<tables::CanonicalHeaders>()?
                 .last()?
                 .map(|(canonical_block, _)| canonical_block);
 
-            Some(tip_block_number.max(local_max_block_number.unwrap_or(tip_block_number)))
+            Some(tip_block_number.max(local_max_block_number.unwrap_or_default()))
         } else {
             None
         };
@@ -277,18 +218,17 @@ where
             // `target_block_number` is guaranteed to be `Some`, because on the first iteration
             // we download the header for missing tip and use its block number.
             _ => {
+                let target = target_block_number.expect("No downloaded header for tip found");
                 HeadersCheckpoint {
                     block_range: CheckpointBlockRange {
                         from: input.checkpoint().block_number,
-                        to: target_block_number.expect("No downloaded header for tip found"),
+                        to: target,
                     },
                     progress: EntitiesCheckpoint {
                         // Set processed to the local head block number + number
                         // of block already filled in the gap.
-                        processed: local_head +
-                            (target_block_number.unwrap_or_default() -
-                                tip_block_number.unwrap_or_default()),
-                        total: target_block_number.expect("No downloaded header for tip found"),
+                        processed: local_head + (target - tip_block_number.unwrap_or_default()),
+                        total: target,
                     },
                 }
             }
@@ -331,6 +271,8 @@ where
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         // TODO: handle bad block
+        self.buffer.clear();
+        self.sync_gap.take();
         provider.unwind_table_by_walker::<tables::CanonicalHeaders, tables::HeaderNumbers>(
             input.unwind_to + 1,
         )?;
@@ -358,46 +300,22 @@ where
     }
 }
 
-/// Represents a gap to sync: from `local_head` to `target`
-#[derive(Debug)]
-pub struct SyncGap {
-    /// The local head block. Represents lower bound of sync range.
-    pub local_head: SealedHeader,
-
-    /// The sync target. Represents upper bound of sync range.
-    pub target: SyncTarget,
-}
-
-// === impl SyncGap ===
-
-impl SyncGap {
-    /// Returns `true` if the gap from the head to the target was closed
-    #[inline]
-    pub fn is_closed(&self) -> bool {
-        match self.target.tip() {
-            BlockHashOrNumber::Hash(hash) => self.local_head.hash() == hash,
-            BlockHashOrNumber::Number(num) => self.local_head.number == num,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
-
     use super::*;
     use crate::test_utils::{
         stage_test_suite, ExecuteStageTestRunner, StageTestRunner, UnwindStageTestRunner,
     };
     use assert_matches::assert_matches;
-    use rand::Rng;
-    use reth_interfaces::test_utils::{generators, generators::random_header};
-    use reth_primitives::{stage::StageUnitCheckpoint, B256, MAINNET};
+    use reth_interfaces::test_utils::generators::random_header;
+    use reth_primitives::{stage::StageUnitCheckpoint, B256};
     use reth_provider::ProviderFactory;
     use test_runner::HeadersTestRunner;
 
     mod test_runner {
         use super::*;
         use crate::test_utils::{TestRunnerError, TestTransaction};
+        use reth_db::{test_utils::TempDatabase, DatabaseEnv};
         use reth_downloaders::headers::reverse_headers::{
             ReverseHeadersDownloader, ReverseHeadersDownloaderBuilder,
         };
@@ -408,6 +326,7 @@ mod tests {
         use reth_primitives::U256;
         use reth_provider::{BlockHashReader, BlockNumReader, HeaderProvider};
         use std::sync::Arc;
+        use tokio::sync::watch;
 
         pub(crate) struct HeadersTestRunner<D: HeaderDownloader> {
             pub(crate) client: TestHeadersClient,
@@ -436,17 +355,18 @@ mod tests {
         }
 
         impl<D: HeaderDownloader + 'static> StageTestRunner for HeadersTestRunner<D> {
-            type S = HeaderStage<D>;
+            type S = HeaderStage<ProviderFactory<Arc<TempDatabase<DatabaseEnv>>>, D>;
 
             fn tx(&self) -> &TestTransaction {
                 &self.tx
             }
 
             fn stage(&self) -> Self::S {
-                HeaderStage {
-                    mode: HeaderSyncMode::Tip(self.channel.1.clone()),
-                    downloader: (*self.downloader_factory)(),
-                }
+                HeaderStage::new(
+                    self.tx.factory.clone(),
+                    (*self.downloader_factory)(),
+                    HeaderSyncMode::Tip(self.channel.1.clone()),
+                )
             }
         }
 
@@ -596,65 +516,6 @@ mod tests {
             // -1 because we don't need to download the local head
             processed == checkpoint + headers.len() as u64 - 1 && total == tip.number);
         assert!(runner.validate_execution(input, result.ok()).is_ok(), "validation failed");
-    }
-
-    /// Test the head and tip range lookup
-    #[tokio::test]
-    async fn head_and_tip_lookup() {
-        let runner = HeadersTestRunner::default();
-        let factory = ProviderFactory::new(runner.tx().tx.as_ref(), MAINNET.clone());
-        let provider = factory.provider_rw().unwrap();
-        let tx = provider.tx_ref();
-        let mut stage = runner.stage();
-
-        let mut rng = generators::rng();
-
-        let consensus_tip = rng.gen();
-        runner.send_tip(consensus_tip);
-
-        // Genesis
-        let checkpoint = 0;
-        let head = random_header(&mut rng, 0, None);
-        let gap_fill = random_header(&mut rng, 1, Some(head.hash()));
-        let gap_tip = random_header(&mut rng, 2, Some(gap_fill.hash()));
-
-        // Empty database
-        assert_matches!(
-            stage.get_sync_gap(&provider, checkpoint).await,
-            Err(StageError::DatabaseIntegrity(ProviderError::HeaderNotFound(block_number)))
-                if block_number.as_number().unwrap() == checkpoint
-        );
-
-        // Checkpoint and no gap
-        tx.put::<tables::CanonicalHeaders>(head.number, head.hash())
-            .expect("failed to write canonical");
-        tx.put::<tables::Headers>(head.number, head.clone().unseal())
-            .expect("failed to write header");
-
-        let gap = stage.get_sync_gap(&provider, checkpoint).await.unwrap();
-        assert_eq!(gap.local_head, head);
-        assert_eq!(gap.target.tip(), consensus_tip.into());
-
-        // Checkpoint and gap
-        tx.put::<tables::CanonicalHeaders>(gap_tip.number, gap_tip.hash())
-            .expect("failed to write canonical");
-        tx.put::<tables::Headers>(gap_tip.number, gap_tip.clone().unseal())
-            .expect("failed to write header");
-
-        let gap = stage.get_sync_gap(&provider, checkpoint).await.unwrap();
-        assert_eq!(gap.local_head, head);
-        assert_eq!(gap.target.tip(), gap_tip.parent_hash.into());
-
-        // Checkpoint and gap closed
-        tx.put::<tables::CanonicalHeaders>(gap_fill.number, gap_fill.hash())
-            .expect("failed to write canonical");
-        tx.put::<tables::Headers>(gap_fill.number, gap_fill.clone().unseal())
-            .expect("failed to write header");
-
-        assert_matches!(
-            stage.get_sync_gap(&provider, checkpoint).await,
-            Err(StageError::StageCheckpoint(_checkpoint)) if _checkpoint == checkpoint
-        );
     }
 
     /// Execute the stage in two steps

--- a/crates/stages/src/stages/index_account_history.rs
+++ b/crates/stages/src/stages/index_account_history.rs
@@ -35,7 +35,6 @@ impl Default for IndexAccountHistoryStage {
     }
 }
 
-#[async_trait::async_trait]
 impl<DB: Database> Stage<DB> for IndexAccountHistoryStage {
     /// Return the id of the stage
     fn id(&self) -> StageId {
@@ -43,7 +42,7 @@ impl<DB: Database> Stage<DB> for IndexAccountHistoryStage {
     }
 
     /// Execute the stage.
-    async fn execute(
+    fn execute(
         &mut self,
         provider: &DatabaseProviderRW<'_, &DB>,
         mut input: ExecInput,
@@ -86,7 +85,7 @@ impl<DB: Database> Stage<DB> for IndexAccountHistoryStage {
     }
 
     /// Unwind the stage.
-    async fn unwind(
+    fn unwind(
         &mut self,
         provider: &DatabaseProviderRW<'_, &DB>,
         input: UnwindInput,

--- a/crates/stages/src/stages/index_account_history.rs
+++ b/crates/stages/src/stages/index_account_history.rs
@@ -177,17 +177,17 @@ mod tests {
         .unwrap()
     }
 
-    async fn run(tx: &TestTransaction, run_to: u64) {
+    fn run(tx: &TestTransaction, run_to: u64) {
         let input = ExecInput { target: Some(run_to), ..Default::default() };
         let mut stage = IndexAccountHistoryStage::default();
         let factory = ProviderFactory::new(tx.tx.as_ref(), MAINNET.clone());
         let provider = factory.provider_rw().unwrap();
-        let out = stage.execute(&provider, input).await.unwrap();
+        let out = stage.execute(&provider, input).unwrap();
         assert_eq!(out, ExecOutput { checkpoint: StageCheckpoint::new(5), done: true });
         provider.commit().unwrap();
     }
 
-    async fn unwind(tx: &TestTransaction, unwind_from: u64, unwind_to: u64) {
+    fn unwind(tx: &TestTransaction, unwind_from: u64, unwind_to: u64) {
         let input = UnwindInput {
             checkpoint: StageCheckpoint::new(unwind_from),
             unwind_to,
@@ -196,7 +196,7 @@ mod tests {
         let mut stage = IndexAccountHistoryStage::default();
         let factory = ProviderFactory::new(tx.tx.as_ref(), MAINNET.clone());
         let provider = factory.provider_rw().unwrap();
-        let out = stage.unwind(&provider, input).await.unwrap();
+        let out = stage.unwind(&provider, input).unwrap();
         assert_eq!(out, UnwindOutput { checkpoint: StageCheckpoint::new(unwind_to) });
         provider.commit().unwrap();
     }
@@ -210,14 +210,14 @@ mod tests {
         partial_setup(&tx);
 
         // run
-        run(&tx, 5).await;
+        run(&tx, 5);
 
         // verify
         let table = cast(tx.table::<tables::AccountHistory>().unwrap());
         assert_eq!(table, BTreeMap::from([(shard(u64::MAX), vec![4, 5])]));
 
         // unwind
-        unwind(&tx, 5, 0).await;
+        unwind(&tx, 5, 0);
 
         // verify initial state
         let table = tx.table::<tables::AccountHistory>().unwrap();
@@ -238,14 +238,14 @@ mod tests {
         .unwrap();
 
         // run
-        run(&tx, 5).await;
+        run(&tx, 5);
 
         // verify
         let table = cast(tx.table::<tables::AccountHistory>().unwrap());
         assert_eq!(table, BTreeMap::from([(shard(u64::MAX), vec![1, 2, 3, 4, 5]),]));
 
         // unwind
-        unwind(&tx, 5, 0).await;
+        unwind(&tx, 5, 0);
 
         // verify initial state
         let table = cast(tx.table::<tables::AccountHistory>().unwrap());
@@ -267,7 +267,7 @@ mod tests {
         .unwrap();
 
         // run
-        run(&tx, 5).await;
+        run(&tx, 5);
 
         // verify
         let table = cast(tx.table::<tables::AccountHistory>().unwrap());
@@ -277,7 +277,7 @@ mod tests {
         );
 
         // unwind
-        unwind(&tx, 5, 0).await;
+        unwind(&tx, 5, 0);
 
         // verify initial state
         let table = cast(tx.table::<tables::AccountHistory>().unwrap());
@@ -299,7 +299,7 @@ mod tests {
         .unwrap();
 
         // run
-        run(&tx, 5).await;
+        run(&tx, 5);
 
         // verify
         close_full_list.push(4);
@@ -308,7 +308,7 @@ mod tests {
         assert_eq!(table, BTreeMap::from([(shard(u64::MAX), close_full_list.clone()),]));
 
         // unwind
-        unwind(&tx, 5, 0).await;
+        unwind(&tx, 5, 0);
 
         // verify initial state
         close_full_list.pop();
@@ -334,7 +334,7 @@ mod tests {
         .unwrap();
 
         // run
-        run(&tx, 5).await;
+        run(&tx, 5);
 
         // verify
         close_full_list.push(4);
@@ -345,7 +345,7 @@ mod tests {
         );
 
         // unwind
-        unwind(&tx, 5, 0).await;
+        unwind(&tx, 5, 0);
 
         // verify initial state
         close_full_list.pop();
@@ -369,7 +369,7 @@ mod tests {
         })
         .unwrap();
 
-        run(&tx, 5).await;
+        run(&tx, 5);
 
         // verify
         let table = cast(tx.table::<tables::AccountHistory>().unwrap());
@@ -383,7 +383,7 @@ mod tests {
         );
 
         // unwind
-        unwind(&tx, 5, 0).await;
+        unwind(&tx, 5, 0);
 
         // verify initial state
         let table = cast(tx.table::<tables::AccountHistory>().unwrap());
@@ -433,7 +433,7 @@ mod tests {
         };
         let factory = ProviderFactory::new(tx.tx.as_ref(), MAINNET.clone());
         let provider = factory.provider_rw().unwrap();
-        let out = stage.execute(&provider, input).await.unwrap();
+        let out = stage.execute(&provider, input).unwrap();
         assert_eq!(out, ExecOutput { checkpoint: StageCheckpoint::new(20000), done: true });
         provider.commit().unwrap();
 
@@ -442,7 +442,7 @@ mod tests {
         assert_eq!(table, BTreeMap::from([(shard(u64::MAX), vec![36, 100])]));
 
         // unwind
-        unwind(&tx, 20000, 0).await;
+        unwind(&tx, 20000, 0);
 
         // verify initial state
         let table = tx.table::<tables::AccountHistory>().unwrap();

--- a/crates/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/src/stages/index_storage_history.rs
@@ -187,17 +187,17 @@ mod tests {
         .unwrap()
     }
 
-    async fn run(tx: &TestTransaction, run_to: u64) {
+    fn run(tx: &TestTransaction, run_to: u64) {
         let input = ExecInput { target: Some(run_to), ..Default::default() };
         let mut stage = IndexStorageHistoryStage::default();
         let factory = ProviderFactory::new(tx.tx.as_ref(), MAINNET.clone());
         let provider = factory.provider_rw().unwrap();
-        let out = stage.execute(&provider, input).await.unwrap();
+        let out = stage.execute(&provider, input).unwrap();
         assert_eq!(out, ExecOutput { checkpoint: StageCheckpoint::new(5), done: true });
         provider.commit().unwrap();
     }
 
-    async fn unwind(tx: &TestTransaction, unwind_from: u64, unwind_to: u64) {
+    fn unwind(tx: &TestTransaction, unwind_from: u64, unwind_to: u64) {
         let input = UnwindInput {
             checkpoint: StageCheckpoint::new(unwind_from),
             unwind_to,
@@ -206,7 +206,7 @@ mod tests {
         let mut stage = IndexStorageHistoryStage::default();
         let factory = ProviderFactory::new(tx.tx.as_ref(), MAINNET.clone());
         let provider = factory.provider_rw().unwrap();
-        let out = stage.unwind(&provider, input).await.unwrap();
+        let out = stage.unwind(&provider, input).unwrap();
         assert_eq!(out, UnwindOutput { checkpoint: StageCheckpoint::new(unwind_to) });
         provider.commit().unwrap();
     }
@@ -220,14 +220,14 @@ mod tests {
         partial_setup(&tx);
 
         // run
-        run(&tx, 5).await;
+        run(&tx, 5);
 
         // verify
         let table = cast(tx.table::<tables::StorageHistory>().unwrap());
         assert_eq!(table, BTreeMap::from([(shard(u64::MAX), vec![4, 5]),]));
 
         // unwind
-        unwind(&tx, 5, 0).await;
+        unwind(&tx, 5, 0);
 
         // verify initial state
         let table = tx.table::<tables::StorageHistory>().unwrap();
@@ -248,14 +248,14 @@ mod tests {
         .unwrap();
 
         // run
-        run(&tx, 5).await;
+        run(&tx, 5);
 
         // verify
         let table = cast(tx.table::<tables::StorageHistory>().unwrap());
         assert_eq!(table, BTreeMap::from([(shard(u64::MAX), vec![1, 2, 3, 4, 5]),]));
 
         // unwind
-        unwind(&tx, 5, 0).await;
+        unwind(&tx, 5, 0);
 
         // verify initial state
         let table = cast(tx.table::<tables::StorageHistory>().unwrap());
@@ -280,7 +280,7 @@ mod tests {
         .unwrap();
 
         // run
-        run(&tx, 5).await;
+        run(&tx, 5);
 
         // verify
         let table = cast(tx.table::<tables::StorageHistory>().unwrap());
@@ -290,7 +290,7 @@ mod tests {
         );
 
         // unwind
-        unwind(&tx, 5, 0).await;
+        unwind(&tx, 5, 0);
 
         // verify initial state
         let table = cast(tx.table::<tables::StorageHistory>().unwrap());
@@ -312,7 +312,7 @@ mod tests {
         .unwrap();
 
         // run
-        run(&tx, 5).await;
+        run(&tx, 5);
 
         // verify
         close_full_list.push(4);
@@ -321,7 +321,7 @@ mod tests {
         assert_eq!(table, BTreeMap::from([(shard(u64::MAX), close_full_list.clone()),]));
 
         // unwind
-        unwind(&tx, 5, 0).await;
+        unwind(&tx, 5, 0);
 
         // verify initial state
         close_full_list.pop();
@@ -347,7 +347,7 @@ mod tests {
         .unwrap();
 
         // run
-        run(&tx, 5).await;
+        run(&tx, 5);
 
         // verify
         close_full_list.push(4);
@@ -358,7 +358,7 @@ mod tests {
         );
 
         // unwind
-        unwind(&tx, 5, 0).await;
+        unwind(&tx, 5, 0);
 
         // verify initial state
         close_full_list.pop();
@@ -382,7 +382,7 @@ mod tests {
         })
         .unwrap();
 
-        run(&tx, 5).await;
+        run(&tx, 5);
 
         // verify
         let table = cast(tx.table::<tables::StorageHistory>().unwrap());
@@ -396,7 +396,7 @@ mod tests {
         );
 
         // unwind
-        unwind(&tx, 5, 0).await;
+        unwind(&tx, 5, 0);
 
         // verify initial state
         let table = cast(tx.table::<tables::StorageHistory>().unwrap());
@@ -446,7 +446,7 @@ mod tests {
         };
         let factory = ProviderFactory::new(tx.tx.as_ref(), MAINNET.clone());
         let provider = factory.provider_rw().unwrap();
-        let out = stage.execute(&provider, input).await.unwrap();
+        let out = stage.execute(&provider, input).unwrap();
         assert_eq!(out, ExecOutput { checkpoint: StageCheckpoint::new(20000), done: true });
         provider.commit().unwrap();
 
@@ -455,7 +455,7 @@ mod tests {
         assert_eq!(table, BTreeMap::from([(shard(u64::MAX), vec![36, 100]),]));
 
         // unwind
-        unwind(&tx, 20000, 0).await;
+        unwind(&tx, 20000, 0);
 
         // verify initial state
         let table = tx.table::<tables::StorageHistory>().unwrap();

--- a/crates/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/src/stages/index_storage_history.rs
@@ -34,7 +34,6 @@ impl Default for IndexStorageHistoryStage {
     }
 }
 
-#[async_trait::async_trait]
 impl<DB: Database> Stage<DB> for IndexStorageHistoryStage {
     /// Return the id of the stage
     fn id(&self) -> StageId {
@@ -42,7 +41,7 @@ impl<DB: Database> Stage<DB> for IndexStorageHistoryStage {
     }
 
     /// Execute the stage.
-    async fn execute(
+    fn execute(
         &mut self,
         provider: &DatabaseProviderRW<'_, &DB>,
         mut input: ExecInput,
@@ -84,7 +83,7 @@ impl<DB: Database> Stage<DB> for IndexStorageHistoryStage {
     }
 
     /// Unwind the stage.
-    async fn unwind(
+    fn unwind(
         &mut self,
         provider: &DatabaseProviderRW<'_, &DB>,
         input: UnwindInput,

--- a/crates/stages/src/stages/merkle.rs
+++ b/crates/stages/src/stages/merkle.rs
@@ -113,7 +113,6 @@ impl MerkleStage {
     }
 }
 
-#[async_trait::async_trait]
 impl<DB: Database> Stage<DB> for MerkleStage {
     /// Return the id of the stage
     fn id(&self) -> StageId {
@@ -126,7 +125,7 @@ impl<DB: Database> Stage<DB> for MerkleStage {
     }
 
     /// Execute the stage.
-    async fn execute(
+    fn execute(
         &mut self,
         provider: &DatabaseProviderRW<'_, &DB>,
         input: ExecInput,
@@ -260,7 +259,7 @@ impl<DB: Database> Stage<DB> for MerkleStage {
     }
 
     /// Unwind the stage.
-    async fn unwind(
+    fn unwind(
         &mut self,
         provider: &DatabaseProviderRW<'_, &DB>,
         input: UnwindInput,

--- a/crates/stages/src/stages/mod.rs
+++ b/crates/stages/src/stages/mod.rs
@@ -139,7 +139,7 @@ mod tests {
                 prune_modes.clone(),
             );
 
-            execution_stage.execute(&provider, input).await.unwrap();
+            execution_stage.execute(&provider, input).unwrap();
             assert_eq!(
                 provider.receipts_by_block(1.into()).unwrap().unwrap().len(),
                 expect_num_receipts
@@ -163,9 +163,9 @@ mod tests {
 
             if let Some(PruneMode::Full) = prune_modes.account_history {
                 // Full is not supported
-                assert!(acc_indexing_stage.execute(&provider, input).await.is_err());
+                assert!(acc_indexing_stage.execute(&provider, input).is_err());
             } else {
-                acc_indexing_stage.execute(&provider, input).await.unwrap();
+                acc_indexing_stage.execute(&provider, input).unwrap();
                 let mut account_history: Cursor<RW, AccountHistory> =
                     provider.tx_ref().cursor_read::<tables::AccountHistory>().unwrap();
                 assert_eq!(account_history.walk(None).unwrap().count(), expect_num_acc_changesets);
@@ -179,9 +179,9 @@ mod tests {
 
             if let Some(PruneMode::Full) = prune_modes.storage_history {
                 // Full is not supported
-                assert!(acc_indexing_stage.execute(&provider, input).await.is_err());
+                assert!(acc_indexing_stage.execute(&provider, input).is_err());
             } else {
-                storage_indexing_stage.execute(&provider, input).await.unwrap();
+                storage_indexing_stage.execute(&provider, input).unwrap();
 
                 let mut storage_history =
                     provider.tx_ref().cursor_read::<tables::StorageHistory>().unwrap();

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -126,7 +126,7 @@ impl<DB: Database> Stage<DB> for SenderRecoveryStage {
         }
 
         // Iterate over channels and append the sender in the order that they are received.
-        for mut channel in channels {
+        for channel in channels {
             while let Ok(recovered) = channel.recv() {
                 let (tx_id, sender) = match recovered {
                     Ok(result) => result,

--- a/crates/stages/src/stages/total_difficulty.rs
+++ b/crates/stages/src/stages/total_difficulty.rs
@@ -41,7 +41,6 @@ impl TotalDifficultyStage {
     }
 }
 
-#[async_trait::async_trait]
 impl<DB: Database> Stage<DB> for TotalDifficultyStage {
     /// Return the id of the stage
     fn id(&self) -> StageId {
@@ -49,7 +48,7 @@ impl<DB: Database> Stage<DB> for TotalDifficultyStage {
     }
 
     /// Write total difficulty entries
-    async fn execute(
+    fn execute(
         &mut self,
         provider: &DatabaseProviderRW<'_, &DB>,
         input: ExecInput,
@@ -99,7 +98,7 @@ impl<DB: Database> Stage<DB> for TotalDifficultyStage {
     }
 
     /// Unwind the stage.
-    async fn unwind(
+    fn unwind(
         &mut self,
         provider: &DatabaseProviderRW<'_, &DB>,
         input: UnwindInput,

--- a/crates/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/src/stages/tx_lookup.rs
@@ -42,7 +42,6 @@ impl TransactionLookupStage {
     }
 }
 
-#[async_trait::async_trait]
 impl<DB: Database> Stage<DB> for TransactionLookupStage {
     /// Return the id of the stage
     fn id(&self) -> StageId {
@@ -50,7 +49,7 @@ impl<DB: Database> Stage<DB> for TransactionLookupStage {
     }
 
     /// Write transaction hash -> id entries
-    async fn execute(
+    fn execute(
         &mut self,
         provider: &DatabaseProviderRW<'_, &DB>,
         mut input: ExecInput,
@@ -128,7 +127,7 @@ impl<DB: Database> Stage<DB> for TransactionLookupStage {
     }
 
     /// Unwind the stage.
-    async fn unwind(
+    fn unwind(
         &mut self,
         provider: &DatabaseProviderRW<'_, &DB>,
         input: UnwindInput,

--- a/crates/stages/src/test_utils/runner.rs
+++ b/crates/stages/src/test_utils/runner.rs
@@ -49,7 +49,7 @@ pub(crate) trait ExecuteStageTestRunner: StageTestRunner {
         tokio::spawn(async move {
             let factory = ProviderFactory::new(db.db(), MAINNET.clone());
 
-            let result = poll_fn(|cx| stage.poll_ready(cx, input)).await.and_then(|_| {
+            let result = poll_fn(|cx| stage.poll_execute_ready(cx, input)).await.and_then(|_| {
                 let provider_rw = factory.provider_rw().unwrap();
                 let result = stage.execute(&provider_rw, input);
                 provider_rw.commit().expect("failed to commit");

--- a/crates/stages/src/test_utils/runner.rs
+++ b/crates/stages/src/test_utils/runner.rs
@@ -4,7 +4,7 @@ use reth_db::DatabaseEnv;
 use reth_interfaces::db::DatabaseError;
 use reth_primitives::MAINNET;
 use reth_provider::{ProviderError, ProviderFactory};
-use std::{borrow::Borrow, sync::Arc};
+use std::{borrow::Borrow, future::poll_fn, sync::Arc};
 use tokio::sync::oneshot;
 
 #[derive(thiserror::Error, Debug)]
@@ -50,7 +50,9 @@ pub(crate) trait ExecuteStageTestRunner: StageTestRunner {
             let factory = ProviderFactory::new(db.db(), MAINNET.clone());
             let provider = factory.provider_rw().unwrap();
 
-            let result = stage.execute(&provider, input).await;
+            let result = poll_fn(|cx| stage.poll_ready(cx, input))
+                .await
+                .and_then(|_| stage.execute(&provider, input));
             provider.commit().expect("failed to commit");
             tx.send(result).expect("failed to send message")
         });
@@ -76,7 +78,7 @@ pub(crate) trait UnwindStageTestRunner: StageTestRunner {
             let factory = ProviderFactory::new(db.db(), MAINNET.clone());
             let provider = factory.provider_rw().unwrap();
 
-            let result = stage.unwind(&provider, input).await;
+            let result = stage.unwind(&provider, input);
             provider.commit().expect("failed to commit");
             tx.send(result).expect("failed to send result");
         });

--- a/crates/stages/src/test_utils/stage.rs
+++ b/crates/stages/src/test_utils/stage.rs
@@ -40,7 +40,6 @@ impl TestStage {
     }
 }
 
-#[async_trait::async_trait]
 impl<DB: Database> Stage<DB> for TestStage {
     fn id(&self) -> StageId {
         self.id

--- a/crates/stages/src/test_utils/stage.rs
+++ b/crates/stages/src/test_utils/stage.rs
@@ -46,7 +46,7 @@ impl<DB: Database> Stage<DB> for TestStage {
         self.id
     }
 
-    async fn execute(
+    fn execute(
         &mut self,
         _: &DatabaseProviderRW<'_, &DB>,
         _input: ExecInput,
@@ -56,7 +56,7 @@ impl<DB: Database> Stage<DB> for TestStage {
             .unwrap_or_else(|| panic!("Test stage {} executed too many times.", self.id))
     }
 
-    async fn unwind(
+    fn unwind(
         &mut self,
         _: &DatabaseProviderRW<'_, &DB>,
         _input: UnwindInput,

--- a/crates/storage/db/src/abstraction/transaction.rs
+++ b/crates/storage/db/src/abstraction/transaction.rs
@@ -9,7 +9,7 @@ use crate::{
 /// <https://sabrinajewson.org/blog/the-better-alternative-to-lifetime-gats#the-better-gats>.
 ///
 /// Sealed trait which cannot be implemented by 3rd parties, exposed only for implementers
-pub trait DbTxGAT<'a, __ImplicitBounds: Sealed = Bounds<&'a Self>>: Send + Sync {
+pub trait DbTxGAT<'a, __ImplicitBounds: Sealed = Bounds<&'a Self>> {
     /// Cursor GAT
     type Cursor<T: Table>: DbCursorRO<T> + Send + Sync;
     /// DupCursor GAT
@@ -20,7 +20,7 @@ pub trait DbTxGAT<'a, __ImplicitBounds: Sealed = Bounds<&'a Self>>: Send + Sync 
 /// <https://sabrinajewson.org/blog/the-better-alternative-to-lifetime-gats#the-better-gats>.
 ///
 /// Sealed trait which cannot be implemented by 3rd parties, exposed only for implementers
-pub trait DbTxMutGAT<'a, __ImplicitBounds: Sealed = Bounds<&'a Self>>: Send + Sync {
+pub trait DbTxMutGAT<'a, __ImplicitBounds: Sealed = Bounds<&'a Self>> {
     /// Cursor GAT
     type CursorMut<T: Table>: DbCursorRW<T> + DbCursorRO<T> + Send + Sync;
     /// DupCursor GAT

--- a/crates/storage/db/src/abstraction/transaction.rs
+++ b/crates/storage/db/src/abstraction/transaction.rs
@@ -9,7 +9,7 @@ use crate::{
 /// <https://sabrinajewson.org/blog/the-better-alternative-to-lifetime-gats#the-better-gats>.
 ///
 /// Sealed trait which cannot be implemented by 3rd parties, exposed only for implementers
-pub trait DbTxGAT<'a, __ImplicitBounds: Sealed = Bounds<&'a Self>> {
+pub trait DbTxGAT<'a, __ImplicitBounds: Sealed = Bounds<&'a Self>>: Send + Sync {
     /// Cursor GAT
     type Cursor<T: Table>: DbCursorRO<T> + Send + Sync;
     /// DupCursor GAT
@@ -20,7 +20,7 @@ pub trait DbTxGAT<'a, __ImplicitBounds: Sealed = Bounds<&'a Self>> {
 /// <https://sabrinajewson.org/blog/the-better-alternative-to-lifetime-gats#the-better-gats>.
 ///
 /// Sealed trait which cannot be implemented by 3rd parties, exposed only for implementers
-pub trait DbTxMutGAT<'a, __ImplicitBounds: Sealed = Bounds<&'a Self>> {
+pub trait DbTxMutGAT<'a, __ImplicitBounds: Sealed = Bounds<&'a Self>>: Send + Sync {
     /// Cursor GAT
     type CursorMut<T: Table>: DbCursorRW<T> + DbCursorRO<T> + Send + Sync;
     /// DupCursor GAT

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -21,11 +21,11 @@ pub use traits::{
     BlockWriter, BlockchainTreePendingStateProvider, BundleStateDataProvider, CanonChainTracker,
     CanonStateNotification, CanonStateNotificationSender, CanonStateNotifications,
     CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader, EvmEnvProvider, ExecutorFactory,
-    HashingWriter, HeaderProvider, HistoryWriter, PrunableBlockExecutor, PruneCheckpointReader,
-    PruneCheckpointWriter, ReceiptProvider, ReceiptProviderIdExt, StageCheckpointReader,
-    StageCheckpointWriter, StateProvider, StateProviderBox, StateProviderFactory,
-    StateRootProvider, StorageReader, TransactionVariant, TransactionsProvider,
-    TransactionsProviderExt, WithdrawalsProvider,
+    HashingWriter, HeaderProvider, HeaderSyncGap, HeaderSyncGapProvider, HeaderSyncMode,
+    HistoryWriter, PrunableBlockExecutor, PruneCheckpointReader, PruneCheckpointWriter,
+    ReceiptProvider, ReceiptProviderIdExt, StageCheckpointReader, StageCheckpointWriter,
+    StateProvider, StateProviderBox, StateProviderFactory, StateRootProvider, StorageReader,
+    TransactionVariant, TransactionsProvider, TransactionsProviderExt, WithdrawalsProvider,
 };
 
 /// Provider trait implementations.

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -201,9 +201,9 @@ impl<DB: Database> HeaderSyncGapProvider for ProviderFactory<DB> {
     fn sync_gap(
         &self,
         mode: HeaderSyncMode,
-        last_uninterrupted_block: BlockNumber,
+        highest_uninterrupted_block: BlockNumber,
     ) -> RethResult<HeaderSyncGap> {
-        self.provider()?.sync_gap(mode, last_uninterrupted_block)
+        self.provider()?.sync_gap(mode, highest_uninterrupted_block)
     }
 }
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -24,16 +24,11 @@ use reth_db::{
     transaction::{DbTx, DbTxMut},
     BlockNumberList, DatabaseError,
 };
-<<<<<<< HEAD
-use reth_interfaces::provider::{ProviderResult, RootMismatch};
-=======
 use reth_interfaces::{
-    executor::{BlockExecutionError, BlockValidationError},
     p2p::headers::downloader::SyncTarget,
-    provider::RootMismatch,
+    provider::{ProviderResult, RootMismatch},
     RethError, RethResult,
 };
->>>>>>> 661876f8b (implement proper poll ready methods for headers and bodies, fix tests, add header sync gap provider)
 use reth_primitives::{
     keccak256,
     revm::{
@@ -1115,11 +1110,7 @@ impl<TX: DbTx> BlockReader for DatabaseProvider<TX> {
         &self,
         id: BlockHashOrNumber,
         transaction_kind: TransactionVariant,
-<<<<<<< HEAD
     ) -> ProviderResult<Option<BlockWithSenders>> {
-=======
-    ) -> RethResult<Option<BlockWithSenders>> {
->>>>>>> 661876f8b (implement proper poll ready methods for headers and bodies, fix tests, add header sync gap provider)
         let Some(block_number) = self.convert_hash_or_number(id)? else { return Ok(None) };
 
         let Some(header) = self.header_by_number(block_number)? else { return Ok(None) };

--- a/crates/storage/provider/src/traits/header_sync_gap.rs
+++ b/crates/storage/provider/src/traits/header_sync_gap.rs
@@ -1,0 +1,50 @@
+use auto_impl::auto_impl;
+use reth_interfaces::{p2p::headers::downloader::SyncTarget, RethResult};
+use reth_primitives::{BlockHashOrNumber, BlockNumber, SealedHeader, B256};
+use tokio::sync::watch;
+
+/// The header sync mode.
+#[derive(Clone, Debug)]
+pub enum HeaderSyncMode {
+    /// A sync mode in which the stage continuously requests the downloader for
+    /// next blocks.
+    Continuous,
+    /// A sync mode in which the stage polls the receiver for the next tip
+    /// to download from.
+    Tip(watch::Receiver<B256>),
+}
+
+/// Represents a gap to sync: from `local_head` to `target`
+#[derive(Clone, Debug)]
+pub struct HeaderSyncGap {
+    /// The local head block. Represents lower bound of sync range.
+    pub local_head: SealedHeader,
+
+    /// The sync target. Represents upper bound of sync range.
+    pub target: SyncTarget,
+}
+
+impl HeaderSyncGap {
+    /// Returns `true` if the gap from the head to the target was closed
+    #[inline]
+    pub fn is_closed(&self) -> bool {
+        match self.target.tip() {
+            BlockHashOrNumber::Hash(hash) => self.local_head.hash() == hash,
+            BlockHashOrNumber::Number(num) => self.local_head.number == num,
+        }
+    }
+}
+
+/// Client trait for determining the current headers sync gap.
+#[auto_impl(&, Arc)]
+pub trait HeaderSyncGapProvider: Send + Sync {
+    /// Find a current sync gap for the headers depending on the [HeaderSyncMode] and the last
+    /// uninterrupted block number. Last uninterrupted block represents the block number before
+    /// which there are no gaps. It's up to the caller to ensure that last uninterrupted block is
+    /// determined correctly.
+    fn sync_gap(
+        &self,
+        mode: HeaderSyncMode,
+        last_uninterrupted_block: BlockNumber,
+    ) -> RethResult<HeaderSyncGap>;
+}

--- a/crates/storage/provider/src/traits/header_sync_gap.rs
+++ b/crates/storage/provider/src/traits/header_sync_gap.rs
@@ -45,6 +45,6 @@ pub trait HeaderSyncGapProvider: Send + Sync {
     fn sync_gap(
         &self,
         mode: HeaderSyncMode,
-        last_uninterrupted_block: BlockNumber,
+        highest_uninterrupted_block: BlockNumber,
     ) -> RethResult<HeaderSyncGap>;
 }

--- a/crates/storage/provider/src/traits/mod.rs
+++ b/crates/storage/provider/src/traits/mod.rs
@@ -27,6 +27,9 @@ pub use chain_info::CanonChainTracker;
 mod header;
 pub use header::HeaderProvider;
 
+mod header_sync_gap;
+pub use header_sync_gap::{HeaderSyncGap, HeaderSyncGapProvider, HeaderSyncMode};
+
 mod receipts;
 pub use receipts::{ReceiptProvider, ReceiptProviderIdExt};
 

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -111,8 +111,7 @@ impl Case for BlockchainTestCase {
                     .expect("Could not build tokio RT")
                     .block_on(async {
                         // ignore error
-                        let _ =
-                            stage.execute(&provider, ExecInput { target, checkpoint: None }).await;
+                        let _ = stage.execute(&provider, ExecInput { target, checkpoint: None });
                     });
             }
 


### PR DESCRIPTION
This is essentially just #4215 but renamed to better reflect what the PR will now be about.

Previously, most of the work in #4215 was to try and remove the `Send + Sync` bounds for `DbTx` where possible to make it work with redb, however the transactions have since been made `Send + Sync` upstream so that is no longer needed.

Instead, this will continue work on splitting async and sync work in the stages into two parts, inspired by `tower`'s `Service` trait: async work will be done in `poll_ready`, which will tell the caller when the stage is ready to be executed, and sync work (incl. writing to the database) will be performed in `execute` as normal.

This will make it a lot clearer when things block and when they do not; most stages block in `execute` and do not really leverage async at all, some notable exceptions being the header and bodies stage.

## Assumptions

- It is assumed that unwinds will never need any async work done, so `poll_ready` is only required to be called before `execute`

(Rebasing newer work and pushing in a bit)