### PR TITLE
chore: fix doc lints

### DIFF
--- a/bin/reth/src/args/secret_key.rs
+++ b/bin/reth/src/args/secret_key.rs
@@ -8,7 +8,7 @@ use std::{
 };
 use thiserror::Error;
 
-/// Errors returned by loading a [`SecretKey`][secp256k1::SecretKey], including IO errors.
+/// Errors returned by loading a [`SecretKey`], including IO errors.
 #[derive(Error, Debug)]
 #[allow(missing_docs)]
 pub enum SecretKeyError {

--- a/crates/net/dns/src/resolver.rs
+++ b/crates/net/dns/src/resolver.rs
@@ -36,7 +36,7 @@ impl<P: ConnectionProvider> Resolver for AsyncResolver<P> {
 
 /// An asynchronous DNS resolver
 ///
-/// See also [TokioAsyncResolver](trust_dns_resolver::TokioAsyncResolver)
+/// See also [TokioAsyncResolver]
 ///
 /// ```
 /// # fn t() {

--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -297,8 +297,7 @@ where
         self.into_task_with(&TokioTaskExecutor::default())
     }
 
-    /// Convert the downloader into a [`TaskDownloader`](super::task::TaskDownloader) by spawning
-    /// it via the given spawner.
+    /// Convert the downloader into a [`TaskDownloader`] by spawning it via the given spawner.
     pub fn into_task_with<S>(self, spawner: &S) -> TaskDownloader
     where
         S: TaskSpawner,

--- a/crates/net/downloaders/src/headers/reverse_headers.rs
+++ b/crates/net/downloaders/src/headers/reverse_headers.rs
@@ -643,8 +643,7 @@ where
         self.into_task_with(&TokioTaskExecutor::default())
     }
 
-    /// Convert the downloader into a [`TaskDownloader`](super::task::TaskDownloader) by spawning
-    /// it via the given `spawner`.
+    /// Convert the downloader into a [`TaskDownloader`] by spawning it via the given `spawner`.
     pub fn into_task_with<S>(self, spawner: &S) -> TaskDownloader
     where
         S: TaskSpawner,

--- a/crates/net/downloaders/src/test_utils/file_client.rs
+++ b/crates/net/downloaders/src/test_utils/file_client.rs
@@ -56,7 +56,7 @@ pub struct FileClient {
     bodies: HashMap<BlockHash, BlockBody>,
 }
 
-/// An error that can occur when constructing and using a [`FileClient`](FileClient).
+/// An error that can occur when constructing and using a [`FileClient`].
 #[derive(Debug, Error)]
 pub enum FileClientError {
     /// An error occurred when opening or reading the file.
@@ -75,7 +75,7 @@ impl FileClient {
         FileClient::from_file(file).await
     }
 
-    /// Initialize the [`FileClient`](FileClient) with a file directly.
+    /// Initialize the [`FileClient`] with a file directly.
     pub(crate) async fn from_file(mut file: File) -> Result<Self, FileClientError> {
         // get file len from metadata before reading
         let metadata = file.metadata().await?;

--- a/crates/net/eth-wire/src/builder.rs
+++ b/crates/net/eth-wire/src/builder.rs
@@ -1,5 +1,4 @@
-//! Builder structs for [`Status`](crate::types::Status) and
-//! [`HelloMessage`](crate::HelloMessage) messages.
+//! Builder structs for [`Status`] and [`HelloMessage`] messages.
 
 use crate::{
     capability::Capability, hello::HelloMessage, p2pstream::ProtocolVersion, EthVersion, Status,
@@ -7,7 +6,7 @@ use crate::{
 use reth_discv4::DEFAULT_DISCOVERY_PORT;
 use reth_primitives::{Chain, ForkId, PeerId, H256, U256};
 
-/// Builder for [`Status`](crate::types::Status) messages.
+/// Builder for [`Status`] messages.
 ///
 /// # Example
 /// ```
@@ -43,7 +42,7 @@ pub struct StatusBuilder {
 }
 
 impl StatusBuilder {
-    /// Consumes the type and creates the actual [`Status`](crate::types::Status) message.
+    /// Consumes the type and creates the actual [`Status`] message.
     pub fn build(self) -> Status {
         self.status
     }
@@ -85,14 +84,14 @@ impl StatusBuilder {
     }
 }
 
-/// Builder for [`HelloMessage`](crate::HelloMessage) messages.
+/// Builder for [`HelloMessage`] messages.
 pub struct HelloBuilder {
     hello: HelloMessage,
 }
 
 impl HelloBuilder {
-    /// Creates a new [`HelloBuilder`](crate::builder::HelloBuilder) with default [`HelloMessage`]
-    /// values, and a `PeerId` corresponding to the given pubkey.
+    /// Creates a new [`HelloBuilder`] with default [`HelloMessage`] values, and a `PeerId`
+    /// corresponding to the given pubkey.
     pub fn new(pubkey: PeerId) -> Self {
         Self {
             hello: HelloMessage {

--- a/crates/net/eth-wire/src/disconnect.rs
+++ b/crates/net/eth-wire/src/disconnect.rs
@@ -106,8 +106,8 @@ impl TryFrom<u8> for DisconnectReason {
     }
 }
 
-/// The [`Encodable`](reth_rlp::Encodable) implementation for [`DisconnectReason`] encodes the
-/// disconnect reason in a single-element RLP list.
+/// The [`Encodable`] implementation for [`DisconnectReason`] encodes the disconnect reason in a
+/// single-element RLP list.
 impl Encodable for DisconnectReason {
     fn encode(&self, out: &mut dyn BufMut) {
         vec![*self as u8].encode(out);
@@ -117,8 +117,8 @@ impl Encodable for DisconnectReason {
     }
 }
 
-/// The [`Decodable`](reth_rlp::Decodable) implementation for [`DisconnectReason`] supports either
-/// a disconnect reason encoded a single byte or a RLP list containing the disconnect reason.
+/// The [`Decodable`] implementation for [`DisconnectReason`] supports either a disconnect reason
+/// encoded a single byte or a RLP list containing the disconnect reason.
 impl Decodable for DisconnectReason {
     fn decode(buf: &mut &[u8]) -> Result<Self, DecodeError> {
         if buf.is_empty() {

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -687,10 +687,10 @@ impl P2PMessage {
     }
 }
 
-/// The [`Encodable`](reth_rlp::Encodable) implementation for [`P2PMessage::Ping`] and
-/// [`P2PMessage::Pong`] encodes the message as RLP, and prepends a snappy header to the RLP bytes
-/// for all variants except the [`P2PMessage::Hello`] variant, because the hello message is never
-/// compressed in the `p2p` subprotocol.
+/// The [`Encodable`] implementation for [`P2PMessage::Ping`] and [`P2PMessage::Pong`] encodes the
+/// message as RLP, and prepends a snappy header to the RLP bytes for all variants except the
+/// [`P2PMessage::Hello`] variant, because the hello message is never compressed in the `p2p`
+/// subprotocol.
 impl Encodable for P2PMessage {
     fn encode(&self, out: &mut dyn BufMut) {
         (self.message_id() as u8).encode(out);
@@ -724,11 +724,12 @@ impl Encodable for P2PMessage {
     }
 }
 
-/// The [`Decodable`](reth_rlp::Decodable) implementation for [`P2PMessage`] assumes that each of
-/// the message variants are snappy compressed, except for the [`P2PMessage::Hello`] variant since
-/// the hello message is never compressed in the `p2p` subprotocol.
-/// The [`Decodable`] implementation for [`P2PMessage::Ping`] and
-/// [`P2PMessage::Pong`] expects a snappy encoded payload, see [`Encodable`] implementation.
+/// The [`Decodable`] implementation for [`P2PMessage`] assumes that each of the message variants
+/// are snappy compressed, except for the [`P2PMessage::Hello`] variant since the hello message is
+/// never compressed in the `p2p` subprotocol.
+///
+/// The [`Decodable`] implementation for [`P2PMessage::Ping`] and [`P2PMessage::Pong`] expects a
+/// snappy encoded payload, see [`Encodable`] implementation.
 impl Decodable for P2PMessage {
     fn decode(buf: &mut &[u8]) -> Result<Self, DecodeError> {
         /// Removes the snappy prefix from the Ping/Pong buffer

--- a/crates/net/eth-wire/src/types/status.rs
+++ b/crates/net/eth-wire/src/types/status.rs
@@ -67,8 +67,7 @@ impl Status {
         Default::default()
     }
 
-    /// Create a [`StatusBuilder`] from the given [`ChainSpec`](reth_primitives::ChainSpec) and
-    /// head block.
+    /// Create a [`StatusBuilder`] from the given [`ChainSpec`] and head block.
     ///
     /// Sets the `chain` and `genesis`, `blockhash`, and `forkid` fields based on the [`ChainSpec`]
     /// and head.

--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -1217,7 +1217,7 @@ impl PeersConfig {
 
 /// The durations to use when a backoff should be applied to a peer.
 ///
-/// See also [`BackoffKind`](BackoffKind).
+/// See also [`BackoffKind`].
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PeerBackoffDurations {

--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -236,7 +236,7 @@ where
     /// Propagate the transactions to all connected peers either as full objects or hashes
     ///
     /// The message for new pooled hashes depends on the negotiated version of the stream.
-    /// See [NewPooledTransactionHashes](NewPooledTransactionHashes)
+    /// See [NewPooledTransactionHashes]
     ///
     /// Note: EIP-4844 are disallowed from being broadcast in full and are only ever sent as hashes, see also <https://eips.ethereum.org/EIPS/eip-4844#networking>.
     fn propagate_transactions(
@@ -827,7 +827,7 @@ struct Peer {
     client_version: Arc<String>,
 }
 
-/// Commands to send to the [`TransactionsManager`](crate::transactions::TransactionsManager)
+/// Commands to send to the [`TransactionsManager`]
 enum TransactionsCommand {
     PropagateHash(H256),
 }

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -810,7 +810,7 @@ pub struct BlockBody {
 }
 
 impl BlockBody {
-    /// Create a [`Block`](Block) from the body and its header.
+    /// Create a [`Block`] from the body and its header.
     pub fn create_block(&self, header: Header) -> Block {
         Block {
             header,

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -463,7 +463,7 @@ impl ChainSpec {
             .unwrap_or_else(|| self.is_fork_active_at_timestamp(Hardfork::Cancun, timestamp))
     }
 
-    /// Creates a [`ForkFilter`](crate::ForkFilter) for the block described by [Head].
+    /// Creates a [`ForkFilter`] for the block described by [Head].
     pub fn fork_filter(&self, head: Head) -> ForkFilter {
         let forks = self.forks_iter().filter_map(|(_, condition)| {
             // We filter out TTD-based forks w/o a pre-known block since those do not show up in the

--- a/crates/primitives/src/serde_helper/num.rs
+++ b/crates/primitives/src/serde_helper/num.rs
@@ -69,7 +69,7 @@ impl<'de> Deserialize<'de> for U64HexOrNumber {
     }
 }
 
-/// serde functions for handling primitive `u64` as [U64](crate::U64)
+/// serde functions for handling primitive `u64` as [U64]
 pub mod u64_hex_or_decimal {
     use crate::serde_helper::num::U64HexOrNumber;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -89,7 +89,7 @@ pub mod u64_hex_or_decimal {
     }
 }
 
-/// serde functions for handling primitive optional `u64` as [U64](crate::U64)
+/// serde functions for handling primitive optional `u64` as [U64]
 pub mod u64_hex_or_decimal_opt {
     use crate::serde_helper::num::U64HexOrNumber;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/crates/revm/revm-inspectors/src/stack/mod.rs
+++ b/crates/revm/revm-inspectors/src/stack/mod.rs
@@ -8,7 +8,7 @@ use revm::{
     Database, EVMData, Inspector,
 };
 
-/// A wrapped [Inspector](revm::Inspector) that can be reused in the stack
+/// A wrapped [Inspector] that can be reused in the stack
 mod maybe_owned;
 pub use maybe_owned::MaybeOwnedInspector;
 

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -13,7 +13,7 @@
 
 //! revm utils and implementations specific to reth.
 
-/// Contains glue code for integrating reth database into revm's [Database](revm::Database).
+/// Contains glue code for integrating reth database into revm's [Database].
 pub mod database;
 
 /// revm implementation of reth block and transaction executors.

--- a/crates/rpc/rpc/src/layers/auth_layer.rs
+++ b/crates/rpc/rpc/src/layers/auth_layer.rs
@@ -48,7 +48,7 @@ where
     V: AuthValidator,
     V::ResponseBody: Body,
 {
-    /// Creates an instance of [`AuthLayer`][crate::layers::AuthLayer].
+    /// Creates an instance of [`AuthLayer`].
     /// `validator` is a generic trait able to validate requests (see [`AuthValidator`]).
     pub fn new(validator: V) -> Self {
         Self { validator }
@@ -66,9 +66,7 @@ where
     }
 }
 
-/// This type is the actual implementation of
-/// the middleware. It follows the [`Service`](tower::Service)
-/// specification to correctly proxy Http requests
+/// This type is the actual implementation of the middleware. It follows the [`Service`] specification to correctly proxy Http requests
 /// to its inner service after headers validation.
 #[allow(missing_debug_implementations)]
 pub struct AuthService<S, V> {

--- a/crates/rpc/rpc/src/layers/auth_layer.rs
+++ b/crates/rpc/rpc/src/layers/auth_layer.rs
@@ -66,8 +66,8 @@ where
     }
 }
 
-/// This type is the actual implementation of the middleware. It follows the [`Service`] specification to correctly proxy Http requests
-/// to its inner service after headers validation.
+/// This type is the actual implementation of the middleware. It follows the [`Service`]
+/// specification to correctly proxy Http requests to its inner service after headers validation.
 #[allow(missing_debug_implementations)]
 pub struct AuthService<S, V> {
     /// Performs auth validation logics

--- a/crates/rpc/rpc/src/layers/jwt_secret.rs
+++ b/crates/rpc/rpc/src/layers/jwt_secret.rs
@@ -9,7 +9,7 @@ use std::{
 };
 use thiserror::Error;
 
-/// Errors returned by the [`JwtSecret`][crate::layers::JwtSecret]
+/// Errors returned by the [`JwtSecret`]
 #[derive(Error, Debug)]
 #[allow(missing_docs)]
 pub enum JwtError {
@@ -56,7 +56,7 @@ const JWT_SIGNATURE_ALGO: Algorithm = Algorithm::HS256;
 pub struct JwtSecret([u8; 32]);
 
 impl JwtSecret {
-    /// Creates an instance of [`JwtSecret`][crate::layers::JwtSecret].
+    /// Creates an instance of [`JwtSecret`].
     ///
     /// Returns an error if one of the following applies:
     /// - `hex` is not a valid hexadecimal string
@@ -138,8 +138,7 @@ impl JwtSecret {
         Ok(())
     }
 
-    /// Generates a random [`JwtSecret`][crate::layers::JwtSecret]
-    /// containing a hex-encoded 256 bit secret key.
+    /// Generates a random [`JwtSecret`] containing a hex-encoded 256 bit secret key.
     pub fn random() -> Self {
         let random_bytes: [u8; 32] = rand::thread_rng().gen();
         let secret = hex_encode(random_bytes);

--- a/crates/rpc/rpc/src/layers/mod.rs
+++ b/crates/rpc/rpc/src/layers/mod.rs
@@ -7,15 +7,13 @@ pub use auth_layer::AuthLayer;
 pub use jwt_secret::{Claims, JwtError, JwtSecret};
 pub use jwt_validator::JwtAuthValidator;
 
-/// General purpose trait to validate Http Authorization
-/// headers. It's supposed to be integrated as a validator
-/// trait into an [`AuthLayer`][crate::layers::AuthLayer].
+/// General purpose trait to validate Http Authorization headers. It's supposed to be integrated as
+/// a validator trait into an [`AuthLayer`].
 pub trait AuthValidator {
     /// Body type of the error response
     type ResponseBody;
 
-    /// This function is invoked by the [`AuthLayer`][crate::layers::AuthLayer]
-    /// to perform validation on Http headers.
+    /// This function is invoked by the [`AuthLayer`] to perform validation on Http headers.
     /// The result conveys validation errors in the form of an Http response.
     fn validate(&self, headers: &HeaderMap) -> Result<(), Response<Self::ResponseBody>>;
 }

--- a/crates/stages/src/pipeline/builder.rs
+++ b/crates/stages/src/pipeline/builder.rs
@@ -69,7 +69,7 @@ where
 
     /// Builds the final [`Pipeline`] using the given database.
     ///
-    /// Note: it's expected that this is either an [Arc](std::sync::Arc) or an Arc wrapper type.
+    /// Note: it's expected that this is either an [Arc] or an Arc wrapper type.
     pub fn build(self, db: DB, chain_spec: Arc<ChainSpec>) -> Pipeline<DB> {
         let Self { stages, max_block, tip_tx, metrics_tx } = self;
         Pipeline {

--- a/crates/storage/libmdbx-rs/src/transaction.rs
+++ b/crates/storage/libmdbx-rs/src/transaction.rs
@@ -256,8 +256,8 @@ where
     /// case the environment must be configured to allow named databases through
     /// [EnvironmentBuilder::set_max_dbs()](crate::EnvironmentBuilder::set_max_dbs).
     ///
-    /// This function will fail with [Error::BadRslot](crate::error::Error::BadRslot) if called by a
-    /// thread with an open transaction.
+    /// This function will fail with [Error::BadRslot] if called by a thread with an open
+    /// transaction.
     pub fn create_db<'txn>(
         &'txn self,
         name: Option<&str>,

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -79,12 +79,11 @@
 //!
 //! The lowest layer is the actual pool implementations that manages (validated) transactions:
 //! [`TxPool`](crate::pool::txpool::TxPool). This is contained in a higher level pool type that
-//! guards the low level pool and handles additional listeners or metrics:
-//! [`PoolInner`](crate::pool::PoolInner)
+//! guards the low level pool and handles additional listeners or metrics: [`PoolInner`].
 //!
 //! The transaction pool will be used by separate consumers (RPC, P2P), to make sharing easier, the
-//! [`Pool`](crate::Pool) type is just an `Arc` wrapper around `PoolInner`. This is the usable type
-//! that provides the `TransactionPool` interface.
+//! [`Pool`] type is just an `Arc` wrapper around `PoolInner`. This is the usable type that provides
+//! the `TransactionPool` interface.
 //!
 //!
 //! ## Blob Transactions

--- a/crates/transaction-pool/src/pool/blob.rs
+++ b/crates/transaction-pool/src/pool/blob.rs
@@ -26,7 +26,7 @@ pub(crate) struct BlobTransactions<T: PoolTransaction> {
     all: BTreeSet<BlobTransaction<T>>,
     /// Keeps track of the size of this pool.
     ///
-    /// See also [`PoolTransaction::size`](crate::traits::PoolTransaction::size).
+    /// See also [`PoolTransaction::size`].
     size_of: SizeTracker,
 }
 


### PR DESCRIPTION
Got a bunch of `rustdoc::redundant_explicit_links` doc lint failures locally 