### PR TITLE
feat(bin): log prune config on startup

### DIFF
--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -447,7 +447,7 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
         };
 
         let pruner = prune_config.map(|prune_config| {
-            info!(target: "reth::cli", "Pruner initialized");
+            info!(target: "reth::cli", ?prune_config, "Pruner initialized");
             reth_prune::Pruner::new(
                 db.clone(),
                 self.chain.clone(),


### PR DESCRIPTION
```console
2023-09-18T17:03:20.823433Z  INFO reth::cli: Pruner initialized prune_config=PruneConfig { block_interval: 5, parts: PruneModes { sender_recovery: Some(Full), transaction_lookup: None, receipts: Some(Before(1273020)), account_history: Some(Distance(128)), storage_history: Some(Distance(128)), receipts_log_filter: ReceiptsLogPruneConfig({0x7f02c3e3c98b133055b8b348b2ac625669ed295d: Before(1273020)}) } }
```