### PR TITLE
refactor(bin): CL events conditions

### DIFF
--- a/bin/reth/src/node/cl_events.rs
+++ b/bin/reth/src/node/cl_events.rs
@@ -42,38 +42,36 @@ impl Stream for ConsensusLayerHealthEvents {
         loop {
             ready!(this.interval.poll_tick(cx));
 
-            return match (
-                this.canon_chain.last_exchanged_transition_configuration_timestamp(),
-                this.canon_chain.last_received_update_timestamp(),
-            ) {
-                // Short circuit if we recently had an FCU.
-                (_, Some(fork_choice))
-                    if fork_choice.elapsed() <= NO_FORKCHOICE_UPDATE_RECEIVED_PERIOD =>
-                {
+            if let Some(fork_choice) = this.canon_chain.last_received_update_timestamp() {
+                if fork_choice.elapsed() <= NO_FORKCHOICE_UPDATE_RECEIVED_PERIOD {
+                    // We had an FCU, and it's recent. CL is healthy.
                     continue
+                } else {
+                    // We had an FCU, but it's too old.
+                    return Poll::Ready(Some(
+                        ConsensusLayerHealthEvent::HaveNotReceivedUpdatesForAWhile(
+                            fork_choice.elapsed(),
+                        ),
+                    ))
                 }
-                // Otherwise, continue with health checks based on Transition Configuration exchange
-                // and Fork Choice update.
-                (None, None) => Poll::Ready(Some(ConsensusLayerHealthEvent::NeverSeen)),
-                (Some(_), None) => {
-                    Poll::Ready(Some(ConsensusLayerHealthEvent::NeverReceivedUpdates))
-                }
-                (Some(transition_config), _)
-                    if transition_config.elapsed() > NO_TRANSITION_CONFIG_EXCHANGED_PERIOD =>
-                {
-                    Poll::Ready(Some(ConsensusLayerHealthEvent::HasNotBeenSeenForAWhile(
+            }
+
+            if let Some(transition_config) =
+                this.canon_chain.last_exchanged_transition_configuration_timestamp()
+            {
+                if transition_config.elapsed() <= NO_TRANSITION_CONFIG_EXCHANGED_PERIOD {
+                    // We never had an FCU, but had a transition config exchange, and it's recent.
+                    return Poll::Ready(Some(ConsensusLayerHealthEvent::NeverReceivedUpdates))
+                } else {
+                    // We never had an FCU, but had a transition config exchange, but it's too old.
+                    return Poll::Ready(Some(ConsensusLayerHealthEvent::HasNotBeenSeenForAWhile(
                         transition_config.elapsed(),
                     )))
                 }
-                (Some(_), Some(fork_choice))
-                    if fork_choice.elapsed() > NO_FORKCHOICE_UPDATE_RECEIVED_PERIOD =>
-                {
-                    Poll::Ready(Some(ConsensusLayerHealthEvent::HaveNotReceivedUpdatesForAWhile(
-                        fork_choice.elapsed(),
-                    )))
-                }
-                _ => continue,
             }
+
+            // We never had both FCU and transition config exchange.
+            return Poll::Ready(Some(ConsensusLayerHealthEvent::NeverSeen))
         }
     }
 }

--- a/bin/reth/src/node/cl_events.rs
+++ b/bin/reth/src/node/cl_events.rs
@@ -54,16 +54,16 @@ impl Stream for ConsensusLayerHealthEvents {
                 }
                 // Otherwise, continue with health checks based on Transition Configuration exchange
                 // and Fork Choice update.
-                (None, _) => Poll::Ready(Some(ConsensusLayerHealthEvent::NeverSeen)),
+                (None, None) => Poll::Ready(Some(ConsensusLayerHealthEvent::NeverSeen)),
+                (Some(_), None) => {
+                    Poll::Ready(Some(ConsensusLayerHealthEvent::NeverReceivedUpdates))
+                }
                 (Some(transition_config), _)
                     if transition_config.elapsed() > NO_TRANSITION_CONFIG_EXCHANGED_PERIOD =>
                 {
                     Poll::Ready(Some(ConsensusLayerHealthEvent::HasNotBeenSeenForAWhile(
                         transition_config.elapsed(),
                     )))
-                }
-                (Some(_), None) => {
-                    Poll::Ready(Some(ConsensusLayerHealthEvent::NeverReceivedUpdates))
                 }
                 (Some(_), Some(fork_choice))
                     if fork_choice.elapsed() > NO_FORKCHOICE_UPDATE_RECEIVED_PERIOD =>


### PR DESCRIPTION
Previous match logic was incorrect, because in case of an outdated FCU but no transition config exchange, we fell into `NeverSeen` branch:
https://github.com/paradigmxyz/reth/blob/11f5f3f8d79eca8f03a6c714be338fc0c68f3faa/bin/reth/src/node/cl_events.rs#L49-L57