### PR TITLE
fix: clear buffered blocks on sync

### DIFF
--- a/crates/consensus/beacon/src/engine/sync.rs
+++ b/crates/consensus/beacon/src/engine/sync.rs
@@ -100,10 +100,11 @@ where
         self.max_block = Some(block);
     }
 
-    /// Cancels all download requests that are in progress.
+    /// Cancels all download requests that are in progress and buffered blocks.
     pub(crate) fn clear_block_download_requests(&mut self) {
         self.inflight_full_block_requests.clear();
         self.inflight_block_range_requests.clear();
+        self.range_buffered_blocks.clear();
         self.update_block_download_metrics();
     }
 


### PR DESCRIPTION
while we were clearing all inflight requests once the engine is fully synced, we did not clear already buffered blocks which are no longer required:

https://github.com/paradigmxyz/reth/blob/d1fce42dff7ef2a8b97b6d873cb4f59ed3d58654/crates/consensus/beacon/src/engine/mod.rs#L588-L592

