### PR TITLE
feat: add updated beacon root contract address

### DIFF
--- a/crates/primitives/src/constants/mod.rs
+++ b/crates/primitives/src/constants/mod.rs
@@ -133,7 +133,7 @@ pub const BEACON_CONSENSUS_REORG_UNWIND_DEPTH: u64 = 3;
 pub const ALLOWED_FUTURE_BLOCK_TIME_SECONDS: u64 = 15;
 
 /// The address for the beacon roots contract defined in EIP-4788.
-pub const BEACON_ROOTS_ADDRESS: H160 = H160(hex!("bEac00dDB15f3B6d645C48263dC93862413A222D"));
+pub const BEACON_ROOTS_ADDRESS: H160 = H160(hex!("bEAC020008aFF7331c0A389CB2AAb67597567d7a"));
 
 /// The caller to be used when calling the EIP-4788 beacon roots contract at the beginning of the
 /// block.

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -554,19 +554,18 @@ pub fn verify_receipt<'a>(
 mod tests {
     use reth_primitives::{
         constants::{BEACON_ROOTS_ADDRESS, SYSTEM_ADDRESS},
+        hex_literal::hex,
         keccak256, Account, Bytecode, Bytes, ChainSpecBuilder, ForkCondition, StorageKey, MAINNET,
     };
     use reth_provider::{AccountReader, BlockHashReader, StateRootProvider};
     use reth_revm_primitives::TransitionState;
     use revm::Database;
-    use std::{collections::HashMap, str::FromStr};
+    use std::collections::HashMap;
 
     use super::*;
 
-    /// Returns the beacon root contract code
-    fn beacon_root_contract_code() -> Bytes {
-        Bytes::from_str("0x3373fffffffffffffffffffffffffffffffffffffffe14604457602036146024575f5ffd5b620180005f350680545f35146037575f5ffd5b6201800001545f5260205ff35b6201800042064281555f359062018000015500").unwrap()
-    }
+    const BEACON_ROOT_CONTRACT_CODE: [u8; 97] =
+        hex!("3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500");
 
     #[derive(Debug, Default, Clone, Eq, PartialEq)]
     struct StateProviderTest {
@@ -659,7 +658,7 @@ mod tests {
 
         let mut db = StateProviderTest::default();
 
-        let beacon_root_contract_code = beacon_root_contract_code();
+        let beacon_root_contract_code = Bytes::from(BEACON_ROOT_CONTRACT_CODE);
 
         let beacon_root_contract_account = Account {
             balance: U256::ZERO,
@@ -782,7 +781,7 @@ mod tests {
         // during the pre-block call
         let mut db = StateProviderTest::default();
 
-        let beacon_root_contract_code = beacon_root_contract_code();
+        let beacon_root_contract_code = Bytes::from(BEACON_ROOT_CONTRACT_CODE);
 
         let beacon_root_contract_account = Account {
             balance: U256::ZERO,
@@ -839,7 +838,7 @@ mod tests {
     fn eip_4788_genesis_call() {
         let mut db = StateProviderTest::default();
 
-        let beacon_root_contract_code = beacon_root_contract_code();
+        let beacon_root_contract_code = Bytes::from(BEACON_ROOT_CONTRACT_CODE);
 
         let beacon_root_contract_account = Account {
             balance: U256::ZERO,
@@ -918,7 +917,7 @@ mod tests {
 
         let mut db = StateProviderTest::default();
 
-        let beacon_root_contract_code = beacon_root_contract_code();
+        let beacon_root_contract_code = Bytes::from(BEACON_ROOT_CONTRACT_CODE);
 
         let beacon_root_contract_account = Account {
             balance: U256::ZERO,

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -715,7 +715,7 @@ mod tests {
         // header.timestamp
         // * The storage value at header.timestamp % HISTORY_BUFFER_LENGTH + HISTORY_BUFFER_LENGTH
         // should be parent_beacon_block_root
-        let history_buffer_length = 98304u64;
+        let history_buffer_length = 8191u64;
         let timestamp_index = header.timestamp % history_buffer_length;
         let parent_beacon_block_root_index =
             timestamp_index % history_buffer_length + history_buffer_length;
@@ -960,7 +960,7 @@ mod tests {
         // header.timestamp
         // * The storage value at header.timestamp % HISTORY_BUFFER_LENGTH + HISTORY_BUFFER_LENGTH
         // should be parent_beacon_block_root
-        let history_buffer_length = 98304u64;
+        let history_buffer_length = 8191u64;
         let timestamp_index = header.timestamp % history_buffer_length;
         let parent_beacon_block_root_index =
             timestamp_index % history_buffer_length + history_buffer_length;


### PR DESCRIPTION
Updates the const beacon root contract address from https://github.com/ethereum/EIPs/pull/7672

Also updates the tests to include the new prime buffer length and post-audit bytecode.

DONOTMERGE until the hive tests are updated