### PR TITLE
fix: convert SpecId::Cancun to cancun precompile id

### DIFF
--- a/crates/rpc/rpc/src/eth/revm_utils.rs
+++ b/crates/rpc/rpc/src/eth/revm_utils.rs
@@ -107,8 +107,8 @@ pub(crate) fn get_precompiles(spec_id: &SpecId) -> Vec<reth_primitives::H160> {
         SpecId::ARROW_GLACIER |
         SpecId::GRAY_GLACIER |
         SpecId::MERGE |
-        SpecId::SHANGHAI |
-        SpecId::CANCUN => PrecompilesSpecId::BERLIN,
+        SpecId::SHANGHAI => PrecompilesSpecId::BERLIN,
+        SpecId::CANCUN => PrecompilesSpecId::CANCUN,
         SpecId::LATEST => PrecompilesSpecId::LATEST,
     };
     Precompiles::new(spec).addresses().into_iter().map(Address::from).collect()


### PR DESCRIPTION
there's now a cancun variant that extends berlin

ref 

https://github.com/paradigmxyz/reth/issues/4671