### PR TITLE
chore: simplify get precompiles

### DIFF
--- a/crates/revm/revm-inspectors/src/access_list.rs
+++ b/crates/revm/revm-inspectors/src/access_list.rs
@@ -25,10 +25,10 @@ impl AccessListInspector {
         access_list: AccessList,
         from: Address,
         to: Address,
-        precompiles: Vec<Address>,
+        precompiles: impl IntoIterator<Item = Address>,
     ) -> Self {
         AccessListInspector {
-            excluded: [from, to].iter().chain(precompiles.iter()).copied().collect(),
+            excluded: [from, to].into_iter().chain(precompiles.into_iter()).collect(),
             access_list: access_list
                 .0
                 .into_iter()

--- a/crates/revm/revm-inspectors/src/access_list.rs
+++ b/crates/revm/revm-inspectors/src/access_list.rs
@@ -28,7 +28,7 @@ impl AccessListInspector {
         precompiles: impl IntoIterator<Item = Address>,
     ) -> Self {
         AccessListInspector {
-            excluded: [from, to].into_iter().chain(precompiles.into_iter()).collect(),
+            excluded: [from, to].into_iter().chain(precompiles).collect(),
             access_list: access_list
                 .0
                 .into_iter()

--- a/crates/rpc/rpc/src/eth/api/call.rs
+++ b/crates/rpc/rpc/src/eth/api/call.rs
@@ -376,7 +376,7 @@ where
         // can consume the list since we're not using the request anymore
         let initial = request.access_list.take().unwrap_or_default();
 
-        let precompiles = get_precompiles(&env.cfg.spec_id);
+        let precompiles = get_precompiles(env.cfg.spec_id);
         let mut inspector = AccessListInspector::new(initial, from, to, precompiles);
         let (result, _env) = inspect(&mut db, env, &mut inspector)?;
 

--- a/crates/rpc/rpc/src/eth/revm_utils.rs
+++ b/crates/rpc/rpc/src/eth/revm_utils.rs
@@ -92,26 +92,10 @@ impl FillableTransaction for TransactionSigned {
 }
 
 /// Returns the addresses of the precompiles corresponding to the SpecId.
-pub(crate) fn get_precompiles(spec_id: &SpecId) -> Vec<reth_primitives::H160> {
-    let spec = match spec_id {
-        SpecId::FRONTIER | SpecId::FRONTIER_THAWING => return vec![],
-        SpecId::HOMESTEAD | SpecId::DAO_FORK | SpecId::TANGERINE | SpecId::SPURIOUS_DRAGON => {
-            PrecompilesSpecId::HOMESTEAD
-        }
-        SpecId::BYZANTIUM | SpecId::CONSTANTINOPLE | SpecId::PETERSBURG => {
-            PrecompilesSpecId::BYZANTIUM
-        }
-        SpecId::ISTANBUL | SpecId::MUIR_GLACIER => PrecompilesSpecId::ISTANBUL,
-        SpecId::BERLIN |
-        SpecId::LONDON |
-        SpecId::ARROW_GLACIER |
-        SpecId::GRAY_GLACIER |
-        SpecId::MERGE |
-        SpecId::SHANGHAI => PrecompilesSpecId::BERLIN,
-        SpecId::CANCUN => PrecompilesSpecId::CANCUN,
-        SpecId::LATEST => PrecompilesSpecId::LATEST,
-    };
-    Precompiles::new(spec).addresses().into_iter().map(Address::from).collect()
+#[inline]
+pub(crate) fn get_precompiles(spec_id: SpecId) -> impl IntoIterator<Item = Address> {
+    let spec = PrecompilesSpecId::from_spec_id(spec_id);
+    Precompiles::new(spec).addresses().into_iter().copied().map(Address::from)
 }
 
 /// Executes the [Env] against the given [Database] without committing state changes.


### PR DESCRIPTION
ref https://github.com/bluealloy/revm/pull/733

use existing conversion function and get rid of redundant vec allocation