### PR TITLE
fix: add `test_zstd_no_dictionaries`

### DIFF
--- a/crates/storage/nippy-jar/src/compression/zstd.rs
+++ b/crates/storage/nippy-jar/src/compression/zstd.rs
@@ -157,7 +157,7 @@ impl Compression for Zstd {
     fn decompress(&self, value: &[u8]) -> Result<Vec<u8>, NippyJarError> {
         let mut decompressed = Vec::with_capacity(value.len() * 2);
         let mut decoder = zstd::Decoder::new(value)?;
-        decoder.read_exact(&mut decompressed)?;
+        decoder.read_to_end(&mut decompressed)?;
         Ok(decompressed)
     }
 


### PR DESCRIPTION
Adds a fix to zstd decompression without dictionaries

PR into #4622 