### PR TITLE
refactor(engine): update sync state for r/w hooks

### DIFF
--- a/crates/consensus/beacon/src/engine/hooks/mod.rs
+++ b/crates/consensus/beacon/src/engine/hooks/mod.rs
@@ -1,4 +1,3 @@
-use reth_interfaces::sync::SyncState;
 use reth_primitives::BlockNumber;
 use std::{
     fmt::Debug,
@@ -85,10 +84,7 @@ impl EngineHookEvent {
 
 /// An action that the caller of [hook][`EngineHook`] should act upon.
 #[derive(Debug, Copy, Clone)]
-pub enum EngineHookAction {
-    /// Notify about a [SyncState] update.
-    UpdateSyncState(SyncState),
-}
+pub enum EngineHookAction {}
 
 /// An error returned by [hook][`EngineHook`].
 #[derive(Debug, thiserror::Error)]

--- a/crates/consensus/beacon/src/engine/hooks/prune.rs
+++ b/crates/consensus/beacon/src/engine/hooks/prune.rs
@@ -9,7 +9,6 @@ use crate::{
 use futures::FutureExt;
 use metrics::Counter;
 use reth_db::database::Database;
-use reth_interfaces::sync::SyncState;
 use reth_primitives::BlockNumber;
 use reth_prune::{Pruner, PrunerError, PrunerWithResult};
 use reth_tasks::TaskSpawner;
@@ -104,14 +103,7 @@ impl<DB: Database + 'static> PruneHook<DB> {
                     self.metrics.runs.increment(1);
                     self.pruner_state = PrunerState::Running(rx);
 
-                    Some((
-                        EngineHookEvent::Started,
-                        // Engine can't process any FCU/payload messages from CL while we're
-                        // pruning, as pruner needs an exclusive write access to the database. To
-                        // prevent CL from sending us unneeded updates, we need to respond `true`
-                        // on `eth_syncing` request.
-                        Some(EngineHookAction::UpdateSyncState(SyncState::Syncing)),
-                    ))
+                    Some((EngineHookEvent::Started, None))
                 } else {
                     self.pruner_state = PrunerState::Idle(Some(pruner));
                     Some((EngineHookEvent::NotReady, None))

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -4,7 +4,7 @@ use crate::{
         message::OnForkChoiceUpdated,
         metrics::EngineMetrics,
     },
-    hooks::{EngineContext, EngineHookAction, EngineHooksController},
+    hooks::{EngineContext, EngineHooksController},
     sync::{EngineSyncController, EngineSyncEvent},
 };
 use futures::{Future, StreamExt};
@@ -69,7 +69,7 @@ mod handle;
 pub use handle::BeaconConsensusEngineHandle;
 
 mod forkchoice;
-use crate::hooks::{EngineHooks, PolledHook};
+use crate::hooks::{EngineHookEvent, EngineHooks, PolledHook};
 pub use forkchoice::ForkchoiceStatus;
 
 mod metrics;
@@ -1685,19 +1685,29 @@ where
 
     fn on_hook_result(&self, result: PolledHook) -> Result<(), BeaconConsensusEngineError> {
         if let Some(action) = result.action {
-            match action {
-                EngineHookAction::UpdateSyncState(state) => {
-                    self.sync_state_updater.update_sync_state(state)
-                }
-            }
+            match action {}
         }
 
-        if result.event.is_finished() && result.db_access_level.is_read_write() {
-            // If the hook had read-write access to the database,
-            // it means that the engine may have accumulated some buffered blocks.
-            if let Err(error) = self.blockchain.connect_buffered_blocks_to_canonical_hashes() {
-                error!(target: "consensus::engine", ?error, "Error connecting buffered blocks to canonical hashes on hook result");
-                return Err(error.into())
+        if result.db_access_level.is_read_write() {
+            match result.event {
+                EngineHookEvent::NotReady => {}
+                EngineHookEvent::Started => {
+                    // If the hook has read-write access to the database, it means that the engine
+                    // can't process any FCU/payload messages from CL. To prevent CL from sending us
+                    // unneeded updates, we need to respond `true` on
+                    // `eth_syncing` request.
+                    self.sync_state_updater.update_sync_state(SyncState::Syncing)
+                }
+                EngineHookEvent::Finished(_) => {
+                    // If the hook had read-write access to the database, it means that the engine
+                    // may have accumulated some buffered blocks.
+                    if let Err(error) =
+                        self.blockchain.connect_buffered_blocks_to_canonical_hashes()
+                    {
+                        error!(target: "consensus::engine", ?error, "Error connecting buffered blocks to canonical hashes on hook result");
+                        return Err(error.into())
+                    }
+                }
             }
         }
 

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1694,8 +1694,7 @@ where
                 EngineHookEvent::Started => {
                     // If the hook has read-write access to the database, it means that the engine
                     // can't process any FCU/payload messages from CL. To prevent CL from sending us
-                    // unneeded updates, we need to respond `true` on
-                    // `eth_syncing` request.
+                    // unneeded updates, we need to respond `true` on `eth_syncing` request.
                     self.sync_state_updater.update_sync_state(SyncState::Syncing)
                 }
                 EngineHookEvent::Finished(_) => {


### PR DESCRIPTION
Same idea as in https://github.com/paradigmxyz/reth/pull/4657, but for the `UpdateSyncState` engine hook action.

It's correct, because when any hook acquires the exclusive DB write access, we should stop receiving the updates from CL: https://github.com/paradigmxyz/reth/blob/d21fad21fa49b224c873b4035620edf464f93118/crates/consensus/beacon/src/engine/mod.rs#L1695-L1697