### PR TITLE
chore: update revm and map new errors to rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6236,7 +6236,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "3.3.0"
-source = "git+https://github.com/bluealloy/revm#70cf969a25a45e3bb4e503926297d61a90c7eec5"
+source = "git+https://github.com/bluealloy/revm#cb39117aac3586ab77c67dab35da8ad81b3a0a53"
 dependencies = [
  "auto_impl",
  "revm-interpreter",
@@ -6246,7 +6246,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "1.1.2"
-source = "git+https://github.com/bluealloy/revm#70cf969a25a45e3bb4e503926297d61a90c7eec5"
+source = "git+https://github.com/bluealloy/revm#cb39117aac3586ab77c67dab35da8ad81b3a0a53"
 dependencies = [
  "derive_more",
  "enumn",
@@ -6257,7 +6257,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "2.0.3"
-source = "git+https://github.com/bluealloy/revm#70cf969a25a45e3bb4e503926297d61a90c7eec5"
+source = "git+https://github.com/bluealloy/revm#cb39117aac3586ab77c67dab35da8ad81b3a0a53"
 dependencies = [
  "c-kzg 0.1.0 (git+https://github.com/ethereum/c-kzg-4844)",
  "hex",
@@ -6275,7 +6275,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "1.1.2"
-source = "git+https://github.com/bluealloy/revm#70cf969a25a45e3bb4e503926297d61a90c7eec5"
+source = "git+https://github.com/bluealloy/revm#cb39117aac3586ab77c67dab35da8ad81b3a0a53"
 dependencies = [
  "arbitrary",
  "auto_impl",

--- a/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
@@ -398,7 +398,7 @@ impl ParityTraceBuilder {
 
         // Calculate the stack items at this step
         let push_stack = {
-            let step_op = step.op.u8();
+            let step_op = step.op.get();
             let show_stack: usize;
             if (opcode::PUSH0..=opcode::PUSH32).contains(&step_op) {
                 show_stack = 1;
@@ -482,7 +482,7 @@ impl ParityTraceBuilder {
         let cost = self
             .spec_id
             .and_then(|spec_id| {
-                spec_opcode_gas(spec_id).get(step.op.u8() as usize).map(|op| op.get_gas())
+                spec_opcode_gas(spec_id).get(step.op.get() as usize).map(|op| op.get_gas())
             })
             .unwrap_or_default();
 

--- a/crates/revm/revm-inspectors/src/tracing/js/bindings.rs
+++ b/crates/revm/revm-inspectors/src/tracing/js/bindings.rs
@@ -233,14 +233,14 @@ impl OpObj {
         let to_string = FunctionObjectBuilder::new(
             context,
             NativeFunction::from_copy_closure(move |_this, _args, _ctx| {
-                let op = OpCode::try_from_u8(value)
+                let op = OpCode::new(value)
                     .or_else(|| {
                         // if the opcode is invalid, we'll use the invalid opcode to represent it
                         // because this is invoked before the opcode is
                         // executed, the evm will eventually return a `Halt`
                         // with invalid/unknown opcode as result
                         let invalid_opcode = 0xfe;
-                        OpCode::try_from_u8(invalid_opcode)
+                        OpCode::new(invalid_opcode)
                     })
                     .expect("is valid opcode;");
                 let s = op.to_string();

--- a/crates/revm/revm-inspectors/src/tracing/mod.rs
+++ b/crates/revm/revm-inspectors/src/tracing/mod.rs
@@ -282,13 +282,13 @@ impl TracingInspector {
         let stack =
             self.config.record_stack_snapshots.then(|| interp.stack.clone()).unwrap_or_default();
 
-        let op = OpCode::try_from_u8(interp.current_opcode())
+        let op = OpCode::new(interp.current_opcode())
             .or_else(|| {
                 // if the opcode is invalid, we'll use the invalid opcode to represent it because
                 // this is invoked before the opcode is executed, the evm will eventually return a
                 // `Halt` with invalid/unknown opcode as result
                 let invalid_opcode = 0xfe;
-                OpCode::try_from_u8(invalid_opcode)
+                OpCode::new(invalid_opcode)
             })
             .expect("is valid opcode;");
 

--- a/crates/revm/revm-inspectors/src/tracing/types.rs
+++ b/crates/revm/revm-inspectors/src/tracing/types.rs
@@ -637,7 +637,7 @@ impl CallTraceStep {
     /// Returns true if the step is a STOP opcode
     #[inline]
     pub(crate) fn is_stop(&self) -> bool {
-        matches!(self.op.u8(), opcode::STOP)
+        matches!(self.op.get(), opcode::STOP)
     }
 
     /// Returns true if the step is a call operation, any of
@@ -645,7 +645,7 @@ impl CallTraceStep {
     #[inline]
     pub(crate) fn is_calllike_op(&self) -> bool {
         matches!(
-            self.op.u8(),
+            self.op.get(),
             opcode::CALL |
                 opcode::DELEGATECALL |
                 opcode::STATICCALL |

--- a/crates/rpc/rpc/src/eth/error.rs
+++ b/crates/rpc/rpc/src/eth/error.rs
@@ -296,6 +296,18 @@ pub enum RpcInvalidTransactionError {
     /// Block `blob_gas_price` is greater than tx-specified `max_fee_per_blob_gas` after Cancun.
     #[error("max fee per blob gas less than block blob gas fee")]
     BlobFeeCapTooLow,
+    /// Blob transaction has a versioned hash with an invalid blob
+    #[error("blob hash version mismatch")]
+    BlobHashVersionMismatch,
+    /// Blob transaction has no versioned hashes
+    #[error("blob transaction missing blob hashes")]
+    BlobTransactionMissingBlobHashes,
+    /// Blob transaction has too many blobs
+    #[error("blob transaction exceeds max blobs per block")]
+    TooManyBlobs,
+    /// Blob transaction is a create transaction
+    #[error("blob transaction is a create transaction")]
+    BlobTransactionIsCreate,
 }
 
 impl RpcInvalidTransactionError {
@@ -393,6 +405,16 @@ impl From<revm::primitives::InvalidTransaction> for RpcInvalidTransactionError {
             }
             InvalidTransaction::BlobGasPriceGreaterThanMax => {
                 RpcInvalidTransactionError::BlobFeeCapTooLow
+            }
+            InvalidTransaction::EmptyBlobs => {
+                RpcInvalidTransactionError::BlobTransactionMissingBlobHashes
+            }
+            InvalidTransaction::BlobVersionNotSupported => {
+                RpcInvalidTransactionError::BlobHashVersionMismatch
+            }
+            InvalidTransaction::TooManyBlobs => RpcInvalidTransactionError::TooManyBlobs,
+            InvalidTransaction::BlobCreateTransaction => {
+                RpcInvalidTransactionError::BlobTransactionIsCreate
             }
         }
     }


### PR DESCRIPTION
This updates revm, adding the new EIP-4844 related errors to `RpcInvalidTransactionError`