### PR TITLE
feat(interfaces): move `BlockHashNotFoundInChain` to `BlockchainTreeError`

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -931,7 +931,7 @@ where
                 })
                 .with_latest_valid_hash(H256::zero())
             }
-            RethError::Execution(BlockExecutionError::BlockHashNotFoundInChain { .. }) => {
+            RethError::BlockchainTree(BlockchainTreeError::BlockHashNotFoundInChain { .. }) => {
                 // This just means we couldn't find the block when attempting to make it canonical,
                 // so we should not warn the user, since this will result in us attempting to sync
                 // to a new target and is considered normal operation during sync

--- a/crates/interfaces/src/blockchain_tree/error.rs
+++ b/crates/interfaces/src/blockchain_tree/error.rs
@@ -207,6 +207,9 @@ pub enum InsertBlockErrorKind {
     /// Canonical error.
     #[error(transparent)]
     Canonical(CanonicalError),
+    /// BlockchainTree error.
+    #[error(transparent)]
+    BlockchainTree(BlockchainTreeError),
 }
 
 impl InsertBlockErrorKind {
@@ -238,7 +241,6 @@ impl InsertBlockErrorKind {
                     BlockExecutionError::Pruning(_) |
                     BlockExecutionError::CanonicalRevert { .. } |
                     BlockExecutionError::CanonicalCommit { .. } |
-                    BlockExecutionError::BlockHashNotFoundInChain { .. } |
                     BlockExecutionError::AppendChainDoesntConnect { .. } |
                     BlockExecutionError::UnavailableForTest => false,
                 }
@@ -266,6 +268,7 @@ impl InsertBlockErrorKind {
                 CanonicalError::CanonicalRevert { .. } => false,
                 CanonicalError::Validation(_) => true,
             },
+            InsertBlockErrorKind::BlockchainTree(_) => false,
         }
     }
 
@@ -327,6 +330,7 @@ impl From<crate::RethError> for InsertBlockErrorKind {
             RethError::Network(err) => InsertBlockErrorKind::Internal(Box::new(err)),
             RethError::Custom(err) => InsertBlockErrorKind::Internal(err.into()),
             RethError::Canonical(err) => InsertBlockErrorKind::Canonical(err),
+            RethError::BlockchainTree(err) => InsertBlockErrorKind::BlockchainTree(err),
         }
     }
 }

--- a/crates/interfaces/src/error.rs
+++ b/crates/interfaces/src/error.rs
@@ -23,6 +23,9 @@ pub enum RethError {
     #[error(transparent)]
     Canonical(#[from] crate::blockchain_tree::error::CanonicalError),
 
+    #[error(transparent)]
+    BlockchainTree(#[from] crate::blockchain_tree::error::BlockchainTreeError),
+
     #[error("{0}")]
     Custom(String),
 }

--- a/crates/interfaces/src/executor.rs
+++ b/crates/interfaces/src/executor.rs
@@ -1,4 +1,4 @@
-use reth_primitives::{BlockHash, BlockNumHash, Bloom, PrunePartError, H256};
+use reth_primitives::{BlockNumHash, Bloom, PrunePartError, H256};
 use thiserror::Error;
 
 /// Transaction validation errors
@@ -52,9 +52,6 @@ pub enum BlockExecutionError {
     CanonicalCommit { inner: String },
 
     // === tree errors ===
-    // TODO(mattsse): move this to tree error
-    #[error("Block hash {block_hash} not found in blockchain tree chain")]
-    BlockHashNotFoundInChain { block_hash: BlockHash },
     #[error(
         "Appending chain on fork (other_chain_fork:?) is not possible as the tip is {chain_tip:?}"
     )]


### PR DESCRIPTION
In this PR, the `BlockHashNotFoundInChain` is completely removed from the `BlockExecutionError` enum and it is moved to `BlockchainTreeError` (enum in which this error already existed). 

Necessary adjustments are made, consisting of integrating `BlockchainTreeError` errors into the `RethError` enum in order to satisfy the conditions previously met by the implementation of `BlockHashNotFoundInChain` inside `BlockExecutionError`.