### PR TITLE
fix: add excess_blob_gas for first cancun block

### DIFF
--- a/crates/payload/builder/src/payload.rs
+++ b/crates/payload/builder/src/payload.rs
@@ -13,7 +13,7 @@ use reth_rpc_types_compat::engine::payload::{
     convert_block_to_payload_field_v2, convert_standalonewithdraw_to_withdrawal,
     try_block_to_payload_v1, try_block_to_payload_v3,
 };
-use revm_primitives::{BlockEnv, CfgEnv};
+use revm_primitives::{BlockEnv, CfgEnv, SpecId};
 /// Contains the built payload.
 ///
 /// According to the [engine API specification](https://github.com/ethereum/execution-apis/blob/main/src/engine/README.md) the execution layer should build the initial version of the payload with an empty transaction set and then keep update it in order to maximize the revenue.
@@ -185,7 +185,7 @@ impl PayloadBuilderAttributes {
         // cancun now, we need to set the excess blob gas to the default value
         let excess_blob_gas = parent.next_block_blob_fee().map_or_else(
             || {
-                if chain_spec.is_cancun_activated_at_timestamp(self.timestamp) {
+                if cfg.spec_id == SpecId::CANCUN {
                     // default excess blob gas is zero
                     Some(0)
                 } else {


### PR DESCRIPTION
If the excess blob gas is missing, the EVM will otherwise return `ExcessBlobGasNotSet` to the payload builder on the first cancun block, since `next_block_blob_fee` returns `None` for pre-cancun blocks. This sets the excess blob gas to zero on the first cancun block.