### PR TITLE
feat: enable EIP-7516 hive tests

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -119,10 +119,9 @@ jobs:
           - sim: pyspec
             include: [cancun/eip1153]
             experimental: true
-          # TODO: uncomment once there are hive tests for EIP-7516
-          # - sim: pyspec
-          #   include: [cancun/eip7516]
-          #   experimental: true
+          - sim: pyspec
+            include: [cancun/eip7516]
+            experimental: true
       fail-fast: false
     needs: prepare
     name: run


### PR DESCRIPTION
EIP-7516 pyspec hive tests are added here: https://github.com/ethereum/execution-spec-tests/releases/tag/v1.0.4

This enables these new tests. They are all prefixed by [`eip7516_blobgasfee`](https://github.com/ethereum/execution-spec-tests/tree/main/tests/cancun/eip7516_blobgasfee), so the `limit` param here should cover all of them.