### PR TITLE
remove deprecated log line

### DIFF
--- a/etc/docker-compose.yml
+++ b/etc/docker-compose.yml
@@ -20,7 +20,6 @@ services:
       node
       --chain mainnet
       --metrics 0.0.0.0:9001
-      --log.persistent
       --log.directory /root/rethlogs
       --authrpc.addr 0.0.0.0
       --authrpc.port 8551


### PR DESCRIPTION
The --log-persistent flag is now default. Running the docker compose at etc/docker-compose.yml doesn't work. Flag needs to be removed. --log-persistent is now deafult.

When running the docker compose file (as described in the reth book) in etc/docker-compose.yml:

```
Usage: reth node --chain <CHAIN_OR_PATH> --metrics <SOCKET> --log.filter <FILTER>
reth-reth-1  | 
reth-reth-1  | For more information, try '--help'.
reth-reth-1  | error: unexpected argument '--log.persistent' found
reth-reth-1  | 
reth-reth-1  |   tip: a similar argument exists: '--log.filter’
```