### PR TITLE
fix: add slash to match only fork suites

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -136,15 +136,15 @@ jobs:
             include: [shanghai/eip4895]
           # Pyspec merge and earlier jobs
           - sim: pyspec
-            include: [merge]
+            include: [merge/]
           - sim: pyspec
-            include: [berlin]
+            include: [berlin/]
           - sim: pyspec
-            include: [istanbul]
+            include: [istanbul/]
           - sim: pyspec
-            include: [homestead]
+            include: [homestead/]
           - sim: pyspec
-            include: [frontier]
+            include: [frontier/]
       fail-fast: false
     needs: prepare
     name: run


### PR DESCRIPTION
Made a small mistake in #4726 - `merge` will match all tests which include the word `merge`, not just the `merge/` suite. `merge/` will match only the `merge/` suite. This fixes other pre-merge forks as well. 