### PR TITLE
fix: allow unknown fields in ExecutionPayloadV1

### DIFF
--- a/crates/rpc/rpc-types/src/eth/engine/payload.rs
+++ b/crates/rpc/rpc-types/src/eth/engine/payload.rs
@@ -119,7 +119,7 @@ pub struct ExecutionPayloadEnvelopeV3 {
 ///
 /// See also: <https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/paris.md#executionpayloadv1>
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 pub struct ExecutionPayloadV1 {
     pub parent_hash: H256,
     pub fee_recipient: Address,


### PR DESCRIPTION
Many of the pyspec hive tests send `"withdrawals": null` to `engine_newPayloadV1`, and the `deny_unknown_fields` attribute prevented these calls from succeeding. This removes `deny_unknown_fields` from `ExecutionPayloadV1` _only_. The tests from #4667 still pass.