### PR TITLE
chore: drop `smol_str`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5655,7 +5655,6 @@ dependencies = [
  "reth-tracing",
  "secp256k1",
  "serde",
- "smol_str",
  "snap",
  "test-fuzz",
  "thiserror",

--- a/crates/net/eth-wire/Cargo.toml
+++ b/crates/net/eth-wire/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 reth-codecs = { path = "../../storage/codecs" }
 reth-primitives.workspace = true
 reth-ecies = { path = "../ecies" }
-alloy-rlp = { workspace = true, features = ["derive", "smol_str"] }
+alloy-rlp = { workspace = true, features = ["derive"] }
 reth-discv4 = { path = "../discv4" }
 
 # metrics
@@ -33,7 +33,6 @@ tokio-stream.workspace = true
 pin-project.workspace = true
 tracing.workspace = true
 snap = "1.0.5"
-smol_str = "0.2"
 async-trait.workspace = true
 
 # arbitrary utils
@@ -57,7 +56,7 @@ proptest-derive.workspace = true
 
 [features]
 default = ["serde"]
-serde = ["dep:serde", "smol_str/serde"]
+serde = ["dep:serde"]
 arbitrary = ["reth-primitives/arbitrary", "dep:arbitrary", "dep:proptest", "dep:proptest-derive"]
 
 [[test]]

--- a/crates/net/eth-wire/src/capability.rs
+++ b/crates/net/eth-wire/src/capability.rs
@@ -94,7 +94,7 @@ impl proptest::arbitrary::Arbitrary for Capability {
         any_with::<String>(args) // TODO: what possible values?
             .prop_flat_map(move |name| {
                 any_with::<usize>(()) // TODO: What's the max?
-                    .prop_map(move |version| Capability { name: name.clone().into(), version })
+                    .prop_map(move |version| Capability { name: name.clone(), version })
             })
             .boxed()
     }

--- a/crates/net/eth-wire/src/capability.rs
+++ b/crates/net/eth-wire/src/capability.rs
@@ -4,7 +4,6 @@ use crate::{version::ParseVersionError, EthMessage, EthVersion};
 use alloy_rlp::{Decodable, Encodable, RlpDecodable, RlpEncodable};
 use reth_codecs::add_arbitrary_tests;
 use reth_primitives::bytes::{BufMut, Bytes};
-use smol_str::SmolStr;
 use std::fmt;
 
 #[cfg(feature = "serde")]
@@ -43,14 +42,14 @@ pub enum CapabilityMessage {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Capability {
     /// The name of the subprotocol
-    pub name: SmolStr,
+    pub name: String,
     /// The version of the subprotocol
     pub version: usize,
 }
 
 impl Capability {
     /// Create a new `Capability` with the given name and version.
-    pub fn new(name: SmolStr, version: usize) -> Self {
+    pub fn new(name: String, version: usize) -> Self {
         Self { name, version }
     }
 
@@ -83,7 +82,7 @@ impl fmt::Display for Capability {
 impl<'a> arbitrary::Arbitrary<'a> for Capability {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let version = u.int_in_range(0..=32)?; // TODO: What's the max?
-        let name: SmolStr = String::arbitrary(u)?.into(); // TODO: what possible values?
+        let name = String::arbitrary(u)?; // TODO: what possible values?
         Ok(Self { name, version })
     }
 }
@@ -189,7 +188,7 @@ pub enum SharedCapability {
     Eth { version: EthVersion, offset: u8 },
 
     /// An unknown capability.
-    UnknownCapability { name: SmolStr, version: u8, offset: u8 },
+    UnknownCapability { name: String, version: u8, offset: u8 },
 }
 
 impl SharedCapability {


### PR DESCRIPTION
Only used in one place, and is easily replaced by standard String.

Based on #4737 to avoid future conflicts.