### PR TITLE
(chore) fix reth book dockercmd with correct datadir path for volume

### DIFF
--- a/book/installation/docker.md
+++ b/book/installation/docker.md
@@ -61,7 +61,7 @@ To run Reth with Docker, run:
 
 ```bash
 docker run \
-    -v rethdata:/root/.local/share/reth/db \
+    -v rethdata:/root/.local/share/reth/mainnet/db \
     -d \
     -p 9001:9001 \
     -p 30303:30303 \


### PR DESCRIPTION
correcting the volume mount in the book docker instructions

```
2023-09-23T23:00:19.201591Z  INFO reth::cli: Opening database path="/root/.local/share/reth/mainnet/db"
2023-09-23T23:00:19.222419Z  INFO reth::cli: Database opened
```