### PR TITLE
fix: add hive job experimental flag again

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -134,6 +134,7 @@ jobs:
             experimental: true
           - sim: pyspec
             include: [shanghai/eip4895]
+            experimental: true
           # Pyspec merge and earlier jobs
           - sim: pyspec
             include: [merge/]


### PR DESCRIPTION
Missed one in #4744, unfortunately I couldn't find an easy way to lint or dry run the hive action. This should only be merged if the run in #4755 doesn't fail