### PR TITLE
perf: remove unnecessary state clone

### DIFF
--- a/crates/blockchain-tree/src/chain.rs
+++ b/crates/blockchain-tree/src/chain.rs
@@ -210,7 +210,7 @@ impl AppendableChain {
         // check state root if the block extends the canonical chain.
         if block_kind.extends_canonical_head() {
             // check state root
-            let state_root = provider.state_root(bundle_state.clone())?;
+            let state_root = provider.state_root(&bundle_state)?;
             if block.state_root != state_root {
                 return Err(ConsensusError::BodyStateRootDiff {
                     got: state_root,

--- a/crates/consensus/auto-seal/src/lib.rs
+++ b/crates/consensus/auto-seal/src/lib.rs
@@ -353,7 +353,7 @@ impl StorageInner {
         let state_root = client
             .latest()
             .map_err(|_| BlockExecutionError::ProviderError)?
-            .state_root(bundle_state.clone())
+            .state_root(bundle_state)
             .unwrap();
         header.state_root = state_root;
         Ok(header)

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -793,7 +793,7 @@ where
     let logs_bloom = bundle.block_logs_bloom(block_number).expect("Number is in range");
 
     // calculate the state root
-    let state_root = state_provider.state_root(bundle)?;
+    let state_root = state_provider.state_root(&bundle)?;
 
     // create the block header
     let transactions_root = proofs::calculate_transaction_root(&executed_txs);
@@ -909,7 +909,7 @@ where
 
     // calculate the state root
     let bundle_state = BundleStateWithReceipts::new(db.take_bundle(), vec![], block_number);
-    let state_root = state.state_root(bundle_state)?;
+    let state_root = state.state_root(&bundle_state)?;
 
     let header = Header {
         parent_hash: parent_block.hash,

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -623,7 +623,7 @@ mod tests {
     }
 
     impl StateRootProvider for StateProviderTest {
-        fn state_root(&self, _bundle_state: BundleStateWithReceipts) -> RethResult<H256> {
+        fn state_root(&self, _bundle_state: &BundleStateWithReceipts) -> RethResult<H256> {
             todo!()
         }
     }

--- a/crates/rpc/rpc/src/eth/api/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/api/pending_block.rs
@@ -193,7 +193,7 @@ impl PendingBlockEnv {
         let logs_bloom = bundle.block_logs_bloom(block_number).expect("Block is present");
 
         // calculate the state root
-        let state_root = state_provider.state_root(bundle)?;
+        let state_root = state_provider.state_root(&bundle)?;
 
         // create the block header
         let transactions_root = proofs::calculate_transaction_root(&executed_txs);

--- a/crates/storage/provider/src/providers/bundle_state_provider.rs
+++ b/crates/storage/provider/src/providers/bundle_state_provider.rs
@@ -58,10 +58,10 @@ impl<SP: StateProvider, BSDP: BundleStateDataProvider> AccountReader
 impl<SP: StateProvider, BSDP: BundleStateDataProvider> StateRootProvider
     for BundleStateProvider<SP, BSDP>
 {
-    fn state_root(&self, post_state: BundleStateWithReceipts) -> RethResult<H256> {
+    fn state_root(&self, post_state: &BundleStateWithReceipts) -> RethResult<H256> {
         let mut state = self.post_state_data_provider.state().clone();
-        state.extend(post_state);
-        self.state_provider.state_root(state)
+        state.extend(post_state.clone());
+        self.state_provider.state_root(&state)
     }
 }
 

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -205,7 +205,7 @@ impl<'a, 'b, TX: DbTx<'a>> BlockHashReader for HistoricalStateProviderRef<'a, 'b
 }
 
 impl<'a, 'b, TX: DbTx<'a>> StateRootProvider for HistoricalStateProviderRef<'a, 'b, TX> {
-    fn state_root(&self, _post_state: BundleStateWithReceipts) -> RethResult<H256> {
+    fn state_root(&self, _post_state: &BundleStateWithReceipts) -> RethResult<H256> {
         Err(ProviderError::StateRootNotAvailableForHistoricalBlock.into())
     }
 }

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -60,7 +60,7 @@ impl<'a, 'b, TX: DbTx<'a>> BlockHashReader for LatestStateProviderRef<'a, 'b, TX
 }
 
 impl<'a, 'b, TX: DbTx<'a>> StateRootProvider for LatestStateProviderRef<'a, 'b, TX> {
-    fn state_root(&self, bundle_state: BundleStateWithReceipts) -> RethResult<H256> {
+    fn state_root(&self, bundle_state: &BundleStateWithReceipts) -> RethResult<H256> {
         bundle_state.state_root_slow(self.db).map_err(|err| RethError::Database(err.into()))
     }
 }

--- a/crates/storage/provider/src/providers/state/macros.rs
+++ b/crates/storage/provider/src/providers/state/macros.rs
@@ -31,7 +31,7 @@ macro_rules! delegate_provider_impls {
         $crate::providers::state::macros::delegate_impls_to_as_ref!(
             for $target =>
             StateRootProvider $(where [$($generics)*])? {
-                fn state_root(&self, state: crate::BundleStateWithReceipts) -> reth_interfaces::RethResult<reth_primitives::H256>;
+                fn state_root(&self, state: &crate::BundleStateWithReceipts) -> reth_interfaces::RethResult<reth_primitives::H256>;
             }
             AccountReader $(where [$($generics)*])? {
                 fn basic_account(&self, address: reth_primitives::Address) -> reth_interfaces::RethResult<Option<reth_primitives::Account>>;

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -476,7 +476,7 @@ impl AccountReader for MockEthProvider {
 }
 
 impl StateRootProvider for MockEthProvider {
-    fn state_root(&self, _state: BundleStateWithReceipts) -> RethResult<H256> {
+    fn state_root(&self, _state: &BundleStateWithReceipts) -> RethResult<H256> {
         todo!()
     }
 }

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -253,7 +253,7 @@ impl ChangeSetReader for NoopProvider {
 }
 
 impl StateRootProvider for NoopProvider {
-    fn state_root(&self, _state: BundleStateWithReceipts) -> RethResult<H256> {
+    fn state_root(&self, _state: &BundleStateWithReceipts) -> RethResult<H256> {
         todo!()
     }
 }

--- a/crates/storage/provider/src/traits/state.rs
+++ b/crates/storage/provider/src/traits/state.rs
@@ -234,5 +234,5 @@ pub trait BundleStateDataProvider: Send + Sync {
 #[auto_impl[Box,&, Arc]]
 pub trait StateRootProvider: Send + Sync {
     /// Returns the state root of the BundleState on top of the current state.
-    fn state_root(&self, post_state: BundleStateWithReceipts) -> RethResult<H256>;
+    fn state_root(&self, post_state: &BundleStateWithReceipts) -> RethResult<H256>;
 }


### PR DESCRIPTION
## Description

`StateRootProvider` should not take ownership of the `BundleStateWithReceipts` as it forces an unnecessary clone of the bundle state. The need for cloning should be dictated by the implementation. 