### PR TITLE
feat: update genesis for holesky

### DIFF
--- a/bin/reth/src/dirs.rs
+++ b/bin/reth/src/dirs.rs
@@ -10,14 +10,9 @@ use std::{
 
 /// Constructs a string to be used as a path for configuration and db paths.
 pub fn config_path_prefix(chain: Chain) -> String {
-    if chain == Chain::mainnet() {
-        "mainnet".to_string()
-    } else if chain == Chain::goerli() {
-        "goerli".to_string()
-    } else if chain == Chain::sepolia() {
-        "sepolia".to_string()
-    } else {
-        chain.id().to_string()
+    match chain {
+        Chain::Named(name) => name.to_string(),
+        Chain::Id(id) => id.to_string(),
     }
 }
 
@@ -324,5 +319,20 @@ mod tests {
         let path = MaybePlatformPath::<DataDirPath>::from_str("my/path/to/datadir").unwrap();
         let path = path.unwrap_or_chain_default(Chain::mainnet());
         assert!(path.as_ref().ends_with("my/path/to/datadir"), "{:?}", path);
+    }
+
+    #[test]
+    fn test_maybe_testnet_datadir_path() {
+        let path = MaybePlatformPath::<DataDirPath>::default();
+        let path = path.unwrap_or_chain_default(Chain::goerli());
+        assert!(path.as_ref().ends_with("reth/goerli"), "{:?}", path);
+
+        let path = MaybePlatformPath::<DataDirPath>::default();
+        let path = path.unwrap_or_chain_default(Chain::holesky());
+        assert!(path.as_ref().ends_with("reth/holesky"), "{:?}", path);
+
+        let path = MaybePlatformPath::<DataDirPath>::default();
+        let path = path.unwrap_or_chain_default(Chain::sepolia());
+        assert!(path.as_ref().ends_with("reth/sepolia"), "{:?}", path);
     }
 }

--- a/crates/primitives/res/genesis/holesky.json
+++ b/crates/primitives/res/genesis/holesky.json
@@ -1,21 +1,12 @@
 {
-  "config": {
-    "chainId": 17000,
-    "homesteadBlock": 0,
-    "eip150Block": 0,
-    "eip155Block": 0,
-    "eip158Block": 0,
-    "byzantiumBlock": 0,
-    "constantinopleBlock": 0,
-    "petersburgBlock": 0,
-    "istanbulBlock": 0,
-    "berlinBlock": 0,
-    "londonBlock": 0,
-    "mergeNetsplitBlock": 0,
-    "terminalTotalDifficulty": 0,
-    "terminalTotalDifficultyPassed": true,
-    "shanghaiTime": 1696000704
-  },
+  "nonce": "0x1234",
+  "timestamp": "1695902100",
+  "extraData": "",
+  "gasLimit": "0x17D7840",
+  "difficulty": "0x01",
+  "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "coinbase": "0x0000000000000000000000000000000000000000",
+  "stateRoot": "0x69d8c9d72f6fa4ad42d4702b433707212f90db395eb54dc20bc85de253788783",
   "alloc": {
     "0x0000000000000000000000000000000000000000": {
       "balance": "1"
@@ -1003,12 +994,7 @@
       "balance": "0x084595161401484a000000"
     }
   },
-  "coinbase": "0x0000000000000000000000000000000000000000",
-  "difficulty": "0x01",
-  "extraData": "",
-  "gasLimit": "0x17D7840",
-  "nonce": "0x1234",
-  "mixhash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-  "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-  "timestamp": "1695902100"
+  "number": "0x0",
+  "gasUsed": "0x0",
+  "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
 }

--- a/crates/primitives/res/genesis/holesky.json
+++ b/crates/primitives/res/genesis/holesky.json
@@ -1,12 +1,21 @@
 {
-  "nonce": "0x1234",
-  "timestamp": "1694786100",
-  "extraData": "",
-  "gasLimit": "0x17D7840",
-  "difficulty": "0x01",
-  "mixhash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-  "coinbase": "0x0000000000000000000000000000000000000000",
-  "stateRoot": "0x69d8c9d72f6fa4ad42d4702b433707212f90db395eb54dc20bc85de253788783",
+  "config": {
+    "chainId": 17000,
+    "homesteadBlock": 0,
+    "eip150Block": 0,
+    "eip155Block": 0,
+    "eip158Block": 0,
+    "byzantiumBlock": 0,
+    "constantinopleBlock": 0,
+    "petersburgBlock": 0,
+    "istanbulBlock": 0,
+    "berlinBlock": 0,
+    "londonBlock": 0,
+    "mergeNetsplitBlock": 0,
+    "terminalTotalDifficulty": 0,
+    "terminalTotalDifficultyPassed": true,
+    "shanghaiTime": 1696000704
+  },
   "alloc": {
     "0x0000000000000000000000000000000000000000": {
       "balance": "1"
@@ -994,7 +1003,12 @@
       "balance": "0x084595161401484a000000"
     }
   },
-  "number": "0x0",
-  "gasUsed": "0x0",
-  "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+  "coinbase": "0x0000000000000000000000000000000000000000",
+  "difficulty": "0x01",
+  "extraData": "",
+  "gasLimit": "0x17D7840",
+  "nonce": "0x1234",
+  "mixhash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "timestamp": "1695902100"
 }

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -164,10 +164,10 @@ pub static HOLESKY: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
         genesis: serde_json::from_str(include_str!("../../res/genesis/holesky.json"))
             .expect("Can't deserialize Holesky genesis json"),
         genesis_hash: Some(H256(hex!(
-            "fd91bb7c01ae3f608b4d176078ca72bc7846791fdc02324481ca315ede4c9246"
+            "b5f7f912443c940f21fd611f12828d75b534364ed9e95ca4e307729a4661bde4"
         ))),
         paris_block_and_final_difficulty: Some((0, U256::from(1))),
-        fork_timestamps: ForkTimestamps::default().shanghai(1694790240),
+        fork_timestamps: ForkTimestamps::default().shanghai(1696000704),
         hardforks: BTreeMap::from([
             (Hardfork::Frontier, ForkCondition::Block(0)),
             (Hardfork::Homestead, ForkCondition::Block(0)),
@@ -183,9 +183,9 @@ pub static HOLESKY: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
             (Hardfork::London, ForkCondition::Block(0)),
             (
                 Hardfork::Paris,
-                ForkCondition::TTD { fork_block: None, total_difficulty: U256::ZERO },
+                ForkCondition::TTD { fork_block: Some(0), total_difficulty: U256::ZERO },
             ),
-            (Hardfork::Shanghai, ForkCondition::Timestamp(1694790240)),
+            (Hardfork::Shanghai, ForkCondition::Timestamp(1696000704)),
         ]),
         deposit_contract: Some(DepositContract::new(
             H160(hex!("4242424242424242424242424242424242424242")),
@@ -839,7 +839,7 @@ pub enum ForkCondition {
         /// The block number at which TTD is reached, if it is known.
         ///
         /// This should **NOT** be set unless you want this block advertised as [EIP-2124][eip2124]
-        /// `FORK_NEXT`. This is currently only the case for Sepolia.
+        /// `FORK_NEXT`. This is currently only the case for Sepolia and Holesky.
         ///
         /// [eip2124]: https://eips.ethereum.org/EIPS/eip-2124
         fork_block: Option<BlockNumber>,


### PR DESCRIPTION
Updates the genesis holesky, using the `genesis.json` from:
https://github.com/eth-clients/holesky/blob/ea39b9006210848e13f28d92e12a30548cecd41d/custom_config_data/genesis.json

Updates the Paris `fork_block` docs to note that holesky uses `mergeNetSplitBlock` in its genesis.

Also updates the datadir resolution to use each named chain's `to_string` method, so additional testnets will not need special handling.