### PR TITLE
Changes to enable validation api extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5454,6 +5454,7 @@ dependencies = [
  "reth-rpc-builder",
  "reth-rpc-engine-api",
  "reth-rpc-types",
+ "reth-rpc-types-compat",
  "reth-snapshot",
  "reth-stages",
  "reth-tasks",

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -36,6 +36,7 @@ reth-rpc-engine-api = { path = "../../crates/rpc/rpc-engine-api" }
 reth-rpc-builder = { path = "../../crates/rpc/rpc-builder" }
 reth-rpc = { path = "../../crates/rpc/rpc" }
 reth-rpc-types = { path = "../../crates/rpc/rpc-types" }
+reth-rpc-types-compat = { path = "../../crates/rpc/rpc-types-compat" }
 reth-rpc-api = { path = "../../crates/rpc/rpc-api" }
 reth-network = { path = "../../crates/net/network", features = ["serde"] }
 reth-network-api.workspace = true

--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -11,8 +11,8 @@ use clap::{
 use futures::TryFutureExt;
 use reth_network_api::{NetworkInfo, Peers};
 use reth_provider::{
-    AccountReader, BlockReaderIdExt, CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader, EvmEnvProvider,
-    HeaderProvider, StateProviderFactory,
+    AccountReader, BlockReaderIdExt, CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader,
+    EvmEnvProvider, HeaderProvider, StateProviderFactory,
 };
 use reth_rpc::{
     eth::{
@@ -188,7 +188,7 @@ impl RpcServerArgs {
     ) -> eyre::Result<(RpcServerHandle, AuthServerHandle)>
     where
         Provider: BlockReaderIdExt
-            + AccountReader 
+            + AccountReader
             + HeaderProvider
             + StateProviderFactory
             + EvmEnvProvider

--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -11,7 +11,7 @@ use clap::{
 use futures::TryFutureExt;
 use reth_network_api::{NetworkInfo, Peers};
 use reth_provider::{
-    BlockReaderIdExt, CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader, EvmEnvProvider,
+    AccountReader, BlockReaderIdExt, CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader, EvmEnvProvider,
     HeaderProvider, StateProviderFactory,
 };
 use reth_rpc::{
@@ -188,6 +188,7 @@ impl RpcServerArgs {
     ) -> eyre::Result<(RpcServerHandle, AuthServerHandle)>
     where
         Provider: BlockReaderIdExt
+            + AccountReader 
             + HeaderProvider
             + StateProviderFactory
             + EvmEnvProvider
@@ -254,6 +255,7 @@ impl RpcServerArgs {
     ) -> Result<RpcServerHandle, RpcError>
     where
         Provider: BlockReaderIdExt
+            + AccountReader
             + HeaderProvider
             + StateProviderFactory
             + EvmEnvProvider

--- a/bin/reth/src/cli/ext.rs
+++ b/bin/reth/src/cli/ext.rs
@@ -7,7 +7,7 @@ use reth_network_api::{NetworkInfo, Peers};
 use reth_payload_builder::{PayloadBuilderHandle, PayloadBuilderService};
 use reth_primitives::ChainSpec;
 use reth_provider::{
-    BlockReaderIdExt, CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader, EvmEnvProvider,
+    AccountReader, BlockReaderIdExt, CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader, EvmEnvProvider,
     StateProviderFactory,
 };
 use reth_rpc_builder::{RethModuleRegistry, TransportRpcModules};
@@ -49,6 +49,7 @@ pub trait RethNodeCommandConfig: fmt::Debug {
     where
         Conf: RethRpcConfig,
         Provider: BlockReaderIdExt
+            + AccountReader
             + StateProviderFactory
             + EvmEnvProvider
             + ChainSpecProvider
@@ -173,6 +174,7 @@ impl<T: RethNodeCommandConfig> RethNodeCommandConfig for NoArgs<T> {
     where
         Conf: RethRpcConfig,
         Provider: BlockReaderIdExt
+            + AccountReader
             + StateProviderFactory
             + EvmEnvProvider
             + ChainSpecProvider

--- a/bin/reth/src/cli/ext.rs
+++ b/bin/reth/src/cli/ext.rs
@@ -7,8 +7,8 @@ use reth_network_api::{NetworkInfo, Peers};
 use reth_payload_builder::{PayloadBuilderHandle, PayloadBuilderService};
 use reth_primitives::ChainSpec;
 use reth_provider::{
-    AccountReader, BlockReaderIdExt, CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader, EvmEnvProvider,
-    StateProviderFactory,
+    AccountReader, BlockReaderIdExt, CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader,
+    EvmEnvProvider, StateProviderFactory,
 };
 use reth_rpc_builder::{RethModuleRegistry, TransportRpcModules};
 use reth_tasks::TaskSpawner;

--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -110,6 +110,11 @@ pub mod rpc {
         pub use reth_rpc::eth::*;
     }
 
+    /// Re-exported from `reth_rpc::rpc`.
+    pub mod result {
+        pub use reth_rpc::result::*;
+    }
+
     /// Re-exported from `reth_rpc::eth`.
     pub mod types_compat {
         pub use reth_rpc_types_compat::*;

--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -62,6 +62,11 @@ pub mod blockchain_tree {
     pub use reth_blockchain_tree::*;
 }
 
+/// Re-exported from `reth_consensus_common`.
+pub mod consensus_common {
+    pub use reth_consensus_common::*;
+}
+
 /// Re-exported from `reth_revm`.
 pub mod revm {
     pub use reth_revm::*;
@@ -103,6 +108,11 @@ pub mod rpc {
     /// Re-exported from `reth_rpc::eth`.
     pub mod eth {
         pub use reth_rpc::eth::*;
+    }
+
+    /// Re-exported from `reth_rpc::eth`.
+    pub mod types_compat {
+        pub use reth_rpc_types_compat::*;
     }
 }
 

--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -116,7 +116,7 @@ pub mod rpc {
     }
 
     /// Re-exported from `reth_rpc::eth`.
-    pub mod types_compat {
+    pub mod compat {
         pub use reth_rpc_types_compat::*;
     }
 }

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -109,7 +109,7 @@ use jsonrpsee::{
 use reth_ipc::server::IpcServer;
 use reth_network_api::{NetworkInfo, Peers};
 use reth_provider::{
-    BlockReader, BlockReaderIdExt, CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader,
+    AccountReader, BlockReader, BlockReaderIdExt, CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader,
     EvmEnvProvider, StateProviderFactory,
 };
 use reth_rpc::{
@@ -173,6 +173,7 @@ pub async fn launch<Provider, Pool, Network, Tasks, Events>(
 ) -> Result<RpcServerHandle, RpcError>
 where
     Provider: BlockReaderIdExt
+        + AccountReader
         + StateProviderFactory
         + EvmEnvProvider
         + ChainSpecProvider
@@ -318,6 +319,7 @@ impl<Provider, Pool, Network, Tasks, Events>
     RpcModuleBuilder<Provider, Pool, Network, Tasks, Events>
 where
     Provider: BlockReaderIdExt
+        + AccountReader
         + StateProviderFactory
         + EvmEnvProvider
         + ChainSpecProvider
@@ -566,6 +568,7 @@ impl RpcModuleSelection {
     ) -> RpcModule<()>
     where
         Provider: BlockReaderIdExt
+            + AccountReader
             + StateProviderFactory
             + EvmEnvProvider
             + ChainSpecProvider
@@ -807,6 +810,7 @@ impl<Provider, Pool, Network, Tasks, Events>
     RethModuleRegistry<Provider, Pool, Network, Tasks, Events>
 where
     Provider: BlockReaderIdExt
+        + AccountReader
         + StateProviderFactory
         + EvmEnvProvider
         + ChainSpecProvider

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -18,13 +18,13 @@
 //!
 //! ```
 //! use reth_network_api::{NetworkInfo, Peers};
-//! use reth_provider::{BlockReaderIdExt, ChainSpecProvider, CanonStateSubscriptions, StateProviderFactory, EvmEnvProvider, ChangeSetReader};
+//! use reth_provider::{AccountReader, BlockReaderIdExt, ChainSpecProvider, CanonStateSubscriptions, StateProviderFactory, EvmEnvProvider, ChangeSetReader};
 //! use reth_rpc_builder::{RethRpcModule, RpcModuleBuilder, RpcServerConfig, ServerBuilder, TransportRpcModuleConfig};
 //! use reth_tasks::TokioTaskExecutor;
 //! use reth_transaction_pool::TransactionPool;
 //! pub async fn launch<Provider, Pool, Network, Events>(provider: Provider, pool: Pool, network: Network, events: Events)
 //! where
-//!     Provider: BlockReaderIdExt + ChainSpecProvider + ChangeSetReader + StateProviderFactory + EvmEnvProvider + Clone + Unpin + 'static,
+//!     Provider: AccountReader + BlockReaderIdExt + ChainSpecProvider + ChangeSetReader + StateProviderFactory + EvmEnvProvider + Clone + Unpin + 'static,
 //!     Pool: TransactionPool + Clone + 'static,
 //!     Network: NetworkInfo + Peers + Clone + 'static,
 //!     Events: CanonStateSubscriptions +  Clone + 'static,
@@ -51,7 +51,7 @@
 //! ```
 //! use tokio::try_join;
 //! use reth_network_api::{NetworkInfo, Peers};
-//! use reth_provider::{BlockReaderIdExt, ChainSpecProvider, CanonStateSubscriptions, StateProviderFactory, EvmEnvProvider, ChangeSetReader};
+//! use reth_provider::{AccountReader, BlockReaderIdExt, ChainSpecProvider, CanonStateSubscriptions, StateProviderFactory, EvmEnvProvider, ChangeSetReader};
 //! use reth_rpc::JwtSecret;
 //! use reth_rpc_builder::{RethRpcModule, RpcModuleBuilder, RpcServerConfig, TransportRpcModuleConfig};
 //! use reth_tasks::TokioTaskExecutor;
@@ -60,7 +60,7 @@
 //! use reth_rpc_builder::auth::AuthServerConfig;
 //! pub async fn launch<Provider, Pool, Network, Events, EngineApi>(provider: Provider, pool: Pool, network: Network, events: Events, engine_api: EngineApi)
 //! where
-//!     Provider: BlockReaderIdExt + ChainSpecProvider + ChangeSetReader + StateProviderFactory + EvmEnvProvider + Clone + Unpin + 'static,
+//!     Provider: AccountReader + BlockReaderIdExt + ChainSpecProvider + ChangeSetReader + StateProviderFactory + EvmEnvProvider + Clone + Unpin + 'static,
 //!     Pool: TransactionPool + Clone + 'static,
 //!     Network: NetworkInfo + Peers + Clone + 'static,
 //!     Events: CanonStateSubscriptions +  Clone + 'static,

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -109,8 +109,8 @@ use jsonrpsee::{
 use reth_ipc::server::IpcServer;
 use reth_network_api::{NetworkInfo, Peers};
 use reth_provider::{
-    AccountReader, BlockReader, BlockReaderIdExt, CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader,
-    EvmEnvProvider, StateProviderFactory,
+    AccountReader, BlockReader, BlockReaderIdExt, CanonStateSubscriptions, ChainSpecProvider,
+    ChangeSetReader, EvmEnvProvider, StateProviderFactory,
 };
 use reth_rpc::{
     eth::{

--- a/crates/rpc/rpc-types/src/eth/mod.rs
+++ b/crates/rpc/rpc-types/src/eth/mod.rs
@@ -21,7 +21,7 @@ mod work;
 pub use account::*;
 pub use block::*;
 pub use call::{Bundle, CallInput, CallInputError, CallRequest, EthCallResponse, StateContext};
-pub use engine::{ExecutionPayload, PayloadError};
+pub use engine::{ExecutionPayload, ExecutionPayloadV1, ExecutionPayloadV2, PayloadError, Withdrawal};
 pub use fee::{FeeHistory, TxGasAndReward};
 pub use filter::*;
 pub use index::Index;

--- a/crates/rpc/rpc-types/src/eth/mod.rs
+++ b/crates/rpc/rpc-types/src/eth/mod.rs
@@ -21,7 +21,7 @@ mod work;
 pub use account::*;
 pub use block::*;
 pub use call::{Bundle, CallInput, CallInputError, CallRequest, EthCallResponse, StateContext};
-pub use engine::{ExecutionPayload, ExecutionPayloadV1, ExecutionPayloadV2, PayloadError, Withdrawal};
+pub use engine::{ExecutionPayload, ExecutionPayloadV1, ExecutionPayloadV2, PayloadError};
 pub use fee::{FeeHistory, TxGasAndReward};
 pub use filter::*;
 pub use index::Index;

--- a/crates/rpc/rpc/src/lib.rs
+++ b/crates/rpc/rpc/src/lib.rs
@@ -54,4 +54,4 @@ pub use tracing_call::{TracingCallGuard, TracingCallPool};
 pub use txpool::TxPoolApi;
 pub use web3::Web3Api;
 
-pub(crate) mod result;
+pub mod result;

--- a/crates/rpc/rpc/src/result.rs
+++ b/crates/rpc/rpc/src/result.rs
@@ -3,7 +3,8 @@
 use crate::eth::error::EthApiError;
 use jsonrpsee::core::RpcResult;
 use reth_interfaces::RethResult;
-use reth_primitives::Block;
+use reth_primitives::{Block, SealedBlock};
+use reth_rpc_types::engine::PayloadError;
 use std::fmt::Display;
 
 /// Helper trait to easily convert various `Result` types into [`RpcResult`]
@@ -120,6 +121,28 @@ impl ToRpcResultExt for RethResult<Option<Block>> {
     fn map_ok_or_rpc_err(self) -> RpcResult<<Self as ToRpcResultExt>::Ok> {
         match self {
             Ok(block) => block.ok_or_else(|| EthApiError::UnknownBlockNumber.into()),
+            Err(err) => Err(internal_rpc_err(err.to_string())),
+        }
+    }
+}
+
+impl ToRpcResultExt for RethResult<()> {
+    type Ok = ();
+
+    fn map_ok_or_rpc_err(self) -> RpcResult<<Self as ToRpcResultExt>::Ok> {
+        match self {
+            Ok(()) => Ok(()),
+            Err(err) => Err(internal_rpc_err(err.to_string())),
+        }
+    }
+}
+
+impl ToRpcResultExt for Result<SealedBlock, PayloadError> {
+    type Ok = SealedBlock;
+
+    fn map_ok_or_rpc_err(self) -> RpcResult<<Self as ToRpcResultExt>::Ok> {
+        match self {
+            Ok(block) => Ok(block),
             Err(err) => Err(internal_rpc_err(err.to_string())),
         }
     }

--- a/crates/rpc/rpc/src/result.rs
+++ b/crates/rpc/rpc/src/result.rs
@@ -106,7 +106,7 @@ impl_to_rpc_result!(reth_interfaces::RethError);
 impl_to_rpc_result!(reth_network_api::NetworkError);
 
 /// An extension to used to apply error conversions to various result types
-pub(crate) trait ToRpcResultExt {
+pub trait ToRpcResultExt {
     /// The `Ok` variant of the [RpcResult]
     type Ok;
 

--- a/crates/rpc/rpc/src/result.rs
+++ b/crates/rpc/rpc/src/result.rs
@@ -107,7 +107,7 @@ impl_to_rpc_result!(reth_interfaces::RethError);
 impl_to_rpc_result!(reth_network_api::NetworkError);
 
 /// An extension to used to apply error conversions to various result types
-pub trait ToRpcResultExt {
+pub(crate) trait ToRpcResultExt {
     /// The `Ok` variant of the [RpcResult]
     type Ok;
 

--- a/crates/rpc/rpc/src/result.rs
+++ b/crates/rpc/rpc/src/result.rs
@@ -8,7 +8,7 @@ use reth_rpc_types::engine::PayloadError;
 use std::fmt::Display;
 
 /// Helper trait to easily convert various `Result` types into [`RpcResult`]
-pub(crate) trait ToRpcResult<Ok, Err> {
+pub trait ToRpcResult<Ok, Err> {
     /// Converts the error of the [Result] to an [RpcResult] via the `Err` [Display] impl.
     fn to_rpc_result(self) -> RpcResult<Ok>
     where

--- a/crates/rpc/rpc/src/result.rs
+++ b/crates/rpc/rpc/src/result.rs
@@ -3,7 +3,7 @@
 use crate::eth::error::EthApiError;
 use jsonrpsee::core::RpcResult;
 use reth_interfaces::RethResult;
-use reth_primitives::{Block, SealedBlock};
+use reth_primitives::Block;
 use reth_rpc_types::engine::PayloadError;
 use std::fmt::Display;
 

--- a/crates/rpc/rpc/src/result.rs
+++ b/crates/rpc/rpc/src/result.rs
@@ -102,6 +102,7 @@ macro_rules! impl_to_rpc_result {
     };
 }
 
+impl_to_rpc_result!(PayloadError);
 impl_to_rpc_result!(reth_interfaces::RethError);
 impl_to_rpc_result!(reth_network_api::NetworkError);
 
@@ -121,28 +122,6 @@ impl ToRpcResultExt for RethResult<Option<Block>> {
     fn map_ok_or_rpc_err(self) -> RpcResult<<Self as ToRpcResultExt>::Ok> {
         match self {
             Ok(block) => block.ok_or_else(|| EthApiError::UnknownBlockNumber.into()),
-            Err(err) => Err(internal_rpc_err(err.to_string())),
-        }
-    }
-}
-
-impl ToRpcResultExt for RethResult<()> {
-    type Ok = ();
-
-    fn map_ok_or_rpc_err(self) -> RpcResult<<Self as ToRpcResultExt>::Ok> {
-        match self {
-            Ok(()) => Ok(()),
-            Err(err) => Err(internal_rpc_err(err.to_string())),
-        }
-    }
-}
-
-impl ToRpcResultExt for Result<SealedBlock, PayloadError> {
-    type Ok = SealedBlock;
-
-    fn map_ok_or_rpc_err(self) -> RpcResult<<Self as ToRpcResultExt>::Ok> {
-        match self {
-            Ok(block) => Ok(block),
             Err(err) => Err(internal_rpc_err(err.to_string())),
         }
     }

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -1,12 +1,12 @@
 use crate::{
-    BlockHashReader, BlockIdReader, BlockNumReader, BlockReader, BlockReaderIdExt,
+    AccountReader, BlockHashReader, BlockIdReader, BlockNumReader, BlockReader, BlockReaderIdExt,
     BlockchainTreePendingStateProvider, BundleStateDataProvider, CanonChainTracker,
     CanonStateNotifications, CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader,
     EvmEnvProvider, HeaderProvider, ProviderError, PruneCheckpointReader, ReceiptProvider,
     ReceiptProviderIdExt, StageCheckpointReader, StateProviderBox, StateProviderFactory,
     TransactionsProvider, WithdrawalsProvider,
 };
-use reth_db::{database::Database, models::StoredBlockBodyIndices};
+use reth_db::{database::Database, models::StoredBlockBodyIndices, tables};
 use reth_interfaces::{
     blockchain_tree::{BlockchainTreeEngine, BlockchainTreeViewer},
     consensus::ForkchoiceState,
@@ -14,7 +14,7 @@ use reth_interfaces::{
 };
 use reth_primitives::{
     stage::{StageCheckpoint, StageId},
-    Address, Block, BlockHash, BlockHashOrNumber, BlockId, BlockNumHash, BlockNumber,
+    Account, Address, Block, BlockHash, BlockHashOrNumber, BlockId, BlockNumHash, BlockNumber,
     BlockNumberOrTag, BlockWithSenders, ChainInfo, ChainSpec, Header, PruneCheckpoint, PrunePart,
     Receipt, SealedBlock, SealedBlockWithSenders, SealedHeader, TransactionMeta, TransactionSigned,
     TransactionSignedNoHash, TxHash, TxNumber, Withdrawal, B256, U256,
@@ -808,5 +808,17 @@ where
         block_number: BlockNumber,
     ) -> RethResult<Vec<AccountBeforeTx>> {
         self.database.provider()?.account_block_changeset(block_number)
+    }
+}
+
+impl<DB, Tree> AccountReader for BlockchainProvider<DB, Tree> 
+where
+    DB: Database + Sync + Send,
+    Tree: Sync + Send,
+
+{
+    /// Get basic account information.
+    fn basic_account(&self, address: Address) -> RethResult<Option<Account>> {
+        self.database.provider()?.basic_account(address)
     }
 }

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     ReceiptProviderIdExt, StageCheckpointReader, StateProviderBox, StateProviderFactory,
     TransactionsProvider, WithdrawalsProvider,
 };
-use reth_db::{database::Database, models::StoredBlockBodyIndices, tables};
+use reth_db::{database::Database, models::StoredBlockBodyIndices};
 use reth_interfaces::{
     blockchain_tree::{BlockchainTreeEngine, BlockchainTreeViewer},
     consensus::ForkchoiceState,
@@ -811,11 +811,10 @@ where
     }
 }
 
-impl<DB, Tree> AccountReader for BlockchainProvider<DB, Tree> 
+impl<DB, Tree> AccountReader for BlockchainProvider<DB, Tree>
 where
     DB: Database + Sync + Send,
     Tree: Sync + Send,
-
 {
     /// Get basic account information.
     fn basic_account(&self, address: Address) -> RethResult<Option<Account>> {


### PR DESCRIPTION
These are some changes that I did to enable a specific rpc extension for validating builder payloads, see: 
https://github.com/ckoopmann/reth-block-validator/pull/1
as well as:
https://github.com/ultrasoundmoney/reth-block-validator/pull/5


The changes I had to do where:
1. Re-export `reth-rpc-types-compat` to get access to `try_into_sealed_block` [see here](https://github.com/ckoopmann/reth-block-validator/blob/6a6c91ad0bec4adb5bbbb1e110a6faab24ac7154/src/rpc/mod.rs#L63)
2. Re-export `reth-consensus-common` to get access to `full_validation` [see here](https://github.com/ckoopmann/reth-block-validator/blob/6a6c91ad0bec4adb5bbbb1e110a6faab24ac7154/src/rpc/mod.rs#L65)
3. Export `ExecutionPayloadV1, ExecutionPayloadV2` to implement a method that converts from my struct class into the `ExecutionPayload` type (necessary because of some different formatting in our api). [see here](https://github.com/ckoopmann/reth-block-validator/blob/6a6c91ad0bec4adb5bbbb1e110a6faab24ac7154/src/rpc/types.rs#L53)

4. Re-export `reth_rpc::result` to convert a RethResult to an RPC Result and add aditional implementations of `map_ok_or_rpc_error`. [see here](https://github.com/ckoopmann/reth-block-validator/blob/6a6c91ad0bec4adb5bbbb1e110a6faab24ac7154/src/rpc/mod.rs#L65C66-L65C66)

5. Add `AccountReader` trait in a few places since `full_validation` requires it.


I am also more than open to alternatives to using the above mentioned methods / datatypes in case those were intentionally not include din the library api. 

