### PR TITLE
chore: timestamp fork activation semantics

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -248,7 +248,7 @@ pub fn validate_block_standalone(
     }
 
     // EIP-4844: Shard Blob Transactions
-    if chain_spec.is_cancun_activated_at_timestamp(block.timestamp) {
+    if chain_spec.is_cancun_active_at_timestamp(block.timestamp) {
         // Check that the blob gas used in the header matches the sum of the blob gas used by each
         // blob tx
         let header_blob_gas_used = block.blob_gas_used.ok_or(ConsensusError::BlobGasUsedMissing)?;

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -803,13 +803,13 @@ where
     let mut blob_gas_used = None;
 
     // only determine cancun fields when active
-    if chain_spec.is_cancun_activated_at_timestamp(attributes.timestamp) {
+    if chain_spec.is_cancun_active_at_timestamp(attributes.timestamp) {
         // grab the blob sidecars from the executed txs
         blob_sidecars = pool.get_all_blobs_exact(
             executed_txs.iter().filter(|tx| tx.is_eip4844()).map(|tx| tx.hash).collect(),
         )?;
 
-        excess_blob_gas = if chain_spec.is_cancun_activated_at_timestamp(parent_block.timestamp) {
+        excess_blob_gas = if chain_spec.is_cancun_active_at_timestamp(parent_block.timestamp) {
             let parent_excess_blob_gas = parent_block.excess_blob_gas.unwrap_or_default();
             let parent_blob_gas_used = parent_block.blob_gas_used.unwrap_or_default();
             Some(calculate_excess_blob_gas(parent_excess_blob_gas, parent_blob_gas_used))
@@ -969,7 +969,7 @@ fn commit_withdrawals<DB: Database<Error = RethError>>(
     timestamp: u64,
     withdrawals: Vec<Withdrawal>,
 ) -> RethResult<WithdrawalsOutcome> {
-    if !chain_spec.is_shanghai_activated_at_timestamp(timestamp) {
+    if !chain_spec.is_shanghai_active_at_timestamp(timestamp) {
         return Ok(WithdrawalsOutcome::pre_shanghai())
     }
 

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -447,7 +447,7 @@ impl ChainSpec {
 
     /// Convenience method to check if [Hardfork::Shanghai] is active at a given timestamp.
     #[inline]
-    pub fn is_shanghai_activated_at_timestamp(&self, timestamp: u64) -> bool {
+    pub fn is_shanghai_active_at_timestamp(&self, timestamp: u64) -> bool {
         self.fork_timestamps
             .shanghai
             .map(|shanghai| timestamp >= shanghai)
@@ -456,7 +456,7 @@ impl ChainSpec {
 
     /// Convenience method to check if [Hardfork::Cancun] is active at a given timestamp.
     #[inline]
-    pub fn is_cancun_activated_at_timestamp(&self, timestamp: u64) -> bool {
+    pub fn is_cancun_active_at_timestamp(&self, timestamp: u64) -> bool {
         self.fork_timestamps
             .cancun
             .map(|cancun| timestamp >= cancun)
@@ -1203,8 +1203,8 @@ Post-merge hard forks (timestamp based):
             .with_fork(Hardfork::Shanghai, ForkCondition::Timestamp(1337))
             .build();
         assert_eq!(spec.fork_timestamps.shanghai, Some(1337));
-        assert!(spec.is_shanghai_activated_at_timestamp(1337));
-        assert!(!spec.is_shanghai_activated_at_timestamp(1336));
+        assert!(spec.is_shanghai_active_at_timestamp(1337));
+        assert!(!spec.is_shanghai_active_at_timestamp(1336));
     }
 
     // Tests that all predefined timestamps are correctly set up in the chainspecs

--- a/crates/revm/revm-primitives/src/config.rs
+++ b/crates/revm/revm-primitives/src/config.rs
@@ -10,9 +10,9 @@ pub fn revm_spec_by_timestamp_after_merge(
     chain_spec: &ChainSpec,
     timestamp: u64,
 ) -> revm::primitives::SpecId {
-    if chain_spec.is_cancun_activated_at_timestamp(timestamp) {
+    if chain_spec.is_cancun_active_at_timestamp(timestamp) {
         revm::primitives::CANCUN
-    } else if chain_spec.is_shanghai_activated_at_timestamp(timestamp) {
+    } else if chain_spec.is_shanghai_active_at_timestamp(timestamp) {
         revm::primitives::SHANGHAI
     } else {
         revm::primitives::MERGE

--- a/crates/revm/src/state_change.rs
+++ b/crates/revm/src/state_change.rs
@@ -67,7 +67,7 @@ pub fn apply_beacon_root_contract_call<DB: Database + DatabaseCommit>(
 where
     <DB as Database>::Error: Debug,
 {
-    if chain_spec.is_cancun_activated_at_timestamp(block_timestamp) {
+    if chain_spec.is_cancun_active_at_timestamp(block_timestamp) {
         // if the block number is zero (genesis block) then the parent beacon block root must
         // be 0x0 and no system transaction may occur as per EIP-4788
         if block_number == 0 {
@@ -137,7 +137,7 @@ pub fn insert_post_block_withdrawals_balance_increments(
     balance_increments: &mut HashMap<Address, u128>,
 ) {
     // Process withdrawals
-    if chain_spec.is_shanghai_activated_at_timestamp(block_timestamp) {
+    if chain_spec.is_shanghai_active_at_timestamp(block_timestamp) {
         if let Some(withdrawals) = withdrawals {
             for withdrawal in withdrawals {
                 *balance_increments.entry(withdrawal.address).or_default() +=

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -389,7 +389,7 @@ where
         version: EngineApiMessageVersion,
         timestamp: u64,
     ) -> EngineApiResult<()> {
-        let is_cancun = self.inner.chain_spec.is_cancun_activated_at_timestamp(timestamp);
+        let is_cancun = self.inner.chain_spec.is_cancun_active_at_timestamp(timestamp);
         if version == EngineApiMessageVersion::V2 && is_cancun {
             // From the Engine API spec:
             //

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1276,7 +1276,7 @@ impl<'this, TX: DbTx<'this>> WithdrawalsProvider for DatabaseProvider<'this, TX>
         id: BlockHashOrNumber,
         timestamp: u64,
     ) -> RethResult<Option<Vec<Withdrawal>>> {
-        if self.chain_spec.is_shanghai_activated_at_timestamp(timestamp) {
+        if self.chain_spec.is_shanghai_active_at_timestamp(timestamp) {
             if let Some(number) = self.convert_hash_or_number(id)? {
                 // If we are past shanghai, then all blocks should have a withdrawal list, even if
                 // empty

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -338,11 +338,11 @@ where
 
     fn on_new_head_block(&self, new_tip_block: &SealedBlock) {
         // update all forks
-        if self.chain_spec.is_cancun_activated_at_timestamp(new_tip_block.timestamp) {
+        if self.chain_spec.is_cancun_active_at_timestamp(new_tip_block.timestamp) {
             self.fork_tracker.cancun.store(true, std::sync::atomic::Ordering::Relaxed);
         }
 
-        if self.chain_spec.is_shanghai_activated_at_timestamp(new_tip_block.timestamp) {
+        if self.chain_spec.is_shanghai_active_at_timestamp(new_tip_block.timestamp) {
             self.fork_tracker.shanghai.store(true, std::sync::atomic::Ordering::Relaxed);
         }
     }
@@ -381,7 +381,7 @@ impl EthTransactionValidatorBuilder {
     /// Creates a new builder for the given [ChainSpec]
     pub fn new(chain_spec: Arc<ChainSpec>) -> Self {
         // If cancun is enabled at genesis, enable it
-        let cancun = chain_spec.is_cancun_activated_at_timestamp(chain_spec.genesis_timestamp());
+        let cancun = chain_spec.is_cancun_active_at_timestamp(chain_spec.genesis_timestamp());
 
         Self {
             chain_spec,


### PR DESCRIPTION
## Description

Snob PR regarding timestamp fork activation semantics.

`is_activated` means fork activation at a given timestamp (one-time action).
`is_active` conveys the meaning of fork "activeness" at a given timestamp (continuous property of the fork). 