### PR TITLE
chore(tree, engine, prune, stages, storage): improve logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6000,6 +6000,7 @@ dependencies = [
  "reth-provider",
  "reth-stages",
  "thiserror",
+ "tokio-stream",
  "tracing",
 ]
 

--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -3,7 +3,7 @@
 use crate::node::cl_events::ConsensusLayerHealthEvent;
 use futures::Stream;
 use reth_beacon_consensus::BeaconConsensusEngineEvent;
-use reth_interfaces::{blockchain_tree::CanonicalOutcome, consensus::ForkchoiceState};
+use reth_interfaces::consensus::ForkchoiceState;
 use reth_network::{NetworkEvent, NetworkHandle};
 use reth_network_api::PeersInfo;
 use reth_primitives::{
@@ -128,14 +128,9 @@ impl NodeState {
 
                 info!(number=block.number, hash=?block.hash, "Block added to canonical chain");
             }
-            BeaconConsensusEngineEvent::ChainCanonicalized(outcome, elapsed) => match outcome {
-                CanonicalOutcome::AlreadyCanonical { header } => {
-                    info!(number=header.number, header=?header.hash, ?elapsed, "Chain is already canonical");
-                }
-                CanonicalOutcome::Committed { head } => {
-                    info!(number=head.number, hash=?head.hash, ?elapsed, "Canonical chain committed");
-                }
-            },
+            BeaconConsensusEngineEvent::CanonicalChainCommitted(head, elapsed) => {
+                info!(number=head.number, hash=?head.hash, ?elapsed, "Canonical chain committed");
+            }
             BeaconConsensusEngineEvent::ForkBlockAdded(block) => {
                 info!(number=block.number, hash=?block.hash, "Block added to fork chain");
             }

--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -3,13 +3,14 @@
 use crate::node::cl_events::ConsensusLayerHealthEvent;
 use futures::Stream;
 use reth_beacon_consensus::BeaconConsensusEngineEvent;
-use reth_interfaces::consensus::ForkchoiceState;
+use reth_interfaces::{blockchain_tree::CanonicalOutcome, consensus::ForkchoiceState};
 use reth_network::{NetworkEvent, NetworkHandle};
 use reth_network_api::PeersInfo;
 use reth_primitives::{
     stage::{EntitiesCheckpoint, StageCheckpoint, StageId},
     BlockNumber,
 };
+use reth_prune::PrunerEvent;
 use reth_stages::{ExecOutput, PipelineEvent};
 use std::{
     future::Future,
@@ -127,6 +128,14 @@ impl NodeState {
 
                 info!(number=block.number, hash=?block.hash, "Block added to canonical chain");
             }
+            BeaconConsensusEngineEvent::ChainCanonicalized(outcome, elapsed) => match outcome {
+                CanonicalOutcome::AlreadyCanonical { header } => {
+                    info!(number=header.number, header=?header.hash, ?elapsed, "Chain is already canonical");
+                }
+                CanonicalOutcome::Committed { head } => {
+                    info!(number=head.number, hash=?head.hash, ?elapsed, "Canonical chain committed");
+                }
+            },
             BeaconConsensusEngineEvent::ForkBlockAdded(block) => {
                 info!(number=block.number, hash=?block.hash, "Block added to fork chain");
             }
@@ -149,6 +158,20 @@ impl NodeState {
             }
         }
     }
+
+    fn handle_pruner_event(&self, event: PrunerEvent) {
+        match event {
+            PrunerEvent::Finished { tip_block_number, elapsed, done, parts_done } => {
+                info!(
+                    tip_block_number = tip_block_number,
+                    elapsed = ?elapsed,
+                    done = done,
+                    parts_done = ?parts_done,
+                    "Pruner finished"
+                );
+            }
+        }
+    }
 }
 
 /// A node event.
@@ -162,6 +185,8 @@ pub enum NodeEvent {
     ConsensusEngine(BeaconConsensusEngineEvent),
     /// A Consensus Layer health event.
     ConsensusLayerHealth(ConsensusLayerHealthEvent),
+    /// A pruner event
+    Pruner(PrunerEvent),
 }
 
 impl From<NetworkEvent> for NodeEvent {
@@ -185,6 +210,12 @@ impl From<BeaconConsensusEngineEvent> for NodeEvent {
 impl From<ConsensusLayerHealthEvent> for NodeEvent {
     fn from(event: ConsensusLayerHealthEvent) -> Self {
         NodeEvent::ConsensusLayerHealth(event)
+    }
+}
+
+impl From<PrunerEvent> for NodeEvent {
+    fn from(event: PrunerEvent) -> Self {
+        NodeEvent::Pruner(event)
     }
 }
 
@@ -259,6 +290,9 @@ where
                 }
                 NodeEvent::ConsensusLayerHealth(event) => {
                     this.state.handle_consensus_layer_health_event(event)
+                }
+                NodeEvent::Pruner(event) => {
+                    this.state.handle_pruner_event(event);
                 }
             }
         }

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -302,7 +302,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
     ///
     /// If blocks does not have parent [`BlockStatus::Disconnected`] would be returned, in which
     /// case it is buffered for future inclusion.
-    #[instrument(skip_all, fields(block = ?block.num_hash()), target = "blockchain_tree", ret)]
+    #[instrument(level = "trace", skip_all, fields(block = ?block.num_hash()), target = "blockchain_tree", ret)]
     fn try_insert_validated_block(
         &mut self,
         block: SealedBlockWithSenders,
@@ -372,7 +372,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
     /// WARNING: this expects that the block extends the canonical chain: The block's parent is
     /// part of the canonical chain (e.g. the block's parent is the latest canonical hash). See also
     /// [Self::is_block_hash_canonical].
-    #[instrument(skip_all, target = "blockchain_tree")]
+    #[instrument(level = "trace", skip_all, target = "blockchain_tree")]
     fn try_append_canonical_chain(
         &mut self,
         block: SealedBlockWithSenders,
@@ -453,7 +453,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
     /// Try inserting a block into the given side chain.
     ///
     /// WARNING: This expects a valid side chain id, see [BlockIndices::get_blocks_chain_id]
-    #[instrument(skip_all, target = "blockchain_tree")]
+    #[instrument(level = "trace", skip_all, target = "blockchain_tree")]
     fn try_insert_block_into_side_chain(
         &mut self,
         block: SealedBlockWithSenders,
@@ -923,7 +923,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
     ///
     /// Returns `Ok` if the blocks were canonicalized, or if the blocks were already canonical.
     #[track_caller]
-    #[instrument(skip(self), target = "blockchain_tree")]
+    #[instrument(level = "trace", skip(self), target = "blockchain_tree")]
     pub fn make_canonical(&mut self, block_hash: &BlockHash) -> RethResult<CanonicalOutcome> {
         let old_block_indices = self.block_indices.clone();
         let old_buffered_blocks = self.buffered_blocks.parent_to_child.clone();
@@ -992,7 +992,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> 
 
         // event about new canonical chain.
         let chain_notification;
-        info!(
+        debug!(
             target: "blockchain_tree",
             "Committing new canonical chain: {}", DisplayBlocksChain(new_canon_chain.blocks())
         );

--- a/crates/consensus/beacon/src/engine/event.rs
+++ b/crates/consensus/beacon/src/engine/event.rs
@@ -1,6 +1,6 @@
 use crate::engine::forkchoice::ForkchoiceStatus;
-use reth_interfaces::{blockchain_tree::CanonicalOutcome, consensus::ForkchoiceState};
-use reth_primitives::SealedBlock;
+use reth_interfaces::consensus::ForkchoiceState;
+use reth_primitives::{SealedBlock, SealedHeader};
 use std::{sync::Arc, time::Duration};
 
 /// Events emitted by [crate::BeaconConsensusEngine].
@@ -10,8 +10,8 @@ pub enum BeaconConsensusEngineEvent {
     ForkchoiceUpdated(ForkchoiceState, ForkchoiceStatus),
     /// A block was added to the canonical chain.
     CanonicalBlockAdded(Arc<SealedBlock>),
-    /// A chain was canonicalized.
-    ChainCanonicalized(CanonicalOutcome, Duration),
+    /// A canonical chain was committed.
+    CanonicalChainCommitted(SealedHeader, Duration),
     /// A block was added to the fork chain.
     ForkBlockAdded(Arc<SealedBlock>),
 }

--- a/crates/consensus/beacon/src/engine/event.rs
+++ b/crates/consensus/beacon/src/engine/event.rs
@@ -1,7 +1,7 @@
 use crate::engine::forkchoice::ForkchoiceStatus;
-use reth_interfaces::consensus::ForkchoiceState;
+use reth_interfaces::{blockchain_tree::CanonicalOutcome, consensus::ForkchoiceState};
 use reth_primitives::SealedBlock;
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 /// Events emitted by [crate::BeaconConsensusEngine].
 #[derive(Clone, Debug)]
@@ -10,6 +10,8 @@ pub enum BeaconConsensusEngineEvent {
     ForkchoiceUpdated(ForkchoiceState, ForkchoiceStatus),
     /// A block was added to the canonical chain.
     CanonicalBlockAdded(Arc<SealedBlock>),
+    /// A chain was canonicalized.
+    ChainCanonicalized(CanonicalOutcome, Duration),
     /// A block was added to the fork chain.
     ForkBlockAdded(Arc<SealedBlock>),
 }

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -508,7 +508,12 @@ impl Future for ActiveSession {
                         progress = true;
                         match cmd {
                             SessionCommand::Disconnect { reason } => {
-                                info!(target: "net::session", ?reason, remote_peer_id=?this.remote_peer_id, "Received disconnect command for session");
+                                debug!(
+                                    target: "net::session",
+                                    ?reason,
+                                    remote_peer_id=?this.remote_peer_id,
+                                    "Received disconnect command for session"
+                                );
                                 let reason =
                                     reason.unwrap_or(DisconnectReason::DisconnectRequested);
 

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -38,7 +38,7 @@ use tokio::{
 };
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::PollSender;
-use tracing::{debug, info, trace};
+use tracing::{debug, trace};
 
 /// Constants for timeout updating
 

--- a/crates/prune/Cargo.toml
+++ b/crates/prune/Cargo.toml
@@ -26,6 +26,7 @@ tracing.workspace = true
 thiserror.workspace = true
 itertools.workspace = true
 rayon.workspace = true
+tokio-stream.workspace = true
 
 [dev-dependencies]
 # reth

--- a/crates/prune/src/event.rs
+++ b/crates/prune/src/event.rs
@@ -1,0 +1,14 @@
+use reth_primitives::{BlockNumber, PrunePart};
+use std::{collections::BTreeMap, time::Duration};
+
+/// An event emitted by a [Pruner][crate::Pruner].
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum PrunerEvent {
+    /// Emitted when pruner finished running.
+    Finished {
+        tip_block_number: BlockNumber,
+        elapsed: Duration,
+        done: bool,
+        parts_done: BTreeMap<PrunePart, bool>,
+    },
+}

--- a/crates/prune/src/lib.rs
+++ b/crates/prune/src/lib.rs
@@ -10,9 +10,11 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod error;
+mod event;
 mod metrics;
 mod pruner;
 
 use crate::metrics::Metrics;
 pub use error::PrunerError;
+pub use event::PrunerEvent;
 pub use pruner::{Pruner, PrunerResult, PrunerWithResult};

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -192,8 +192,14 @@ impl<EF: ExecutorFactory> ExecutionStage<EF> {
         // write output
         state.write_to_db(provider.tx_ref(), OriginalValuesKnown::Yes)?;
         let db_write_duration = time.elapsed();
-        info!(target: "sync::stages::execution", block_fetch=?fetch_block_duration, execution=?execution_duration, 
-            write_preperation=?write_preparation_duration, write=?db_write_duration, " Execution duration.");
+        debug!(
+            target: "sync::stages::execution",
+            block_fetch = ?fetch_block_duration,
+            execution = ?execution_duration,
+            write_preperation = ?write_preparation_duration,
+            write = ?db_write_duration,
+            "Execution time"
+        );
 
         executor.stats().log_info();
 

--- a/crates/storage/provider/src/traits/executor.rs
+++ b/crates/storage/provider/src/traits/executor.rs
@@ -4,7 +4,7 @@ use crate::{bundle_state::BundleStateWithReceipts, StateProvider};
 use reth_interfaces::executor::BlockExecutionError;
 use reth_primitives::{Address, Block, BlockNumber, ChainSpec, PruneModes, U256};
 use std::time::Duration;
-use tracing::info;
+use tracing::debug;
 
 /// Executor factory that would create the EVM with particular state provider.
 ///
@@ -85,13 +85,15 @@ pub struct BlockExecutorStats {
 impl BlockExecutorStats {
     /// Log duration to info level log.
     pub fn log_info(&self) {
-        info!(target: "evm",
+        debug!(
+            target: "evm",
             evm_transact = ?self.execution_duration,
             apply_state = ?self.apply_state_duration,
             apply_post_state = ?self.apply_post_execution_state_changes_duration,
             merge_transitions = ?self.merge_transitions_duration,
             receipt_root = ?self.receipt_root_duration,
             sender_recovery = ?self.sender_recovery_duration,
-            "Execution time");
+            "Execution time"
+        );
     }
 }


### PR DESCRIPTION
1. Move all `tracing::instrument` spans of blockchain tree to `TRACE` level
2. Add chain canonicalization event and log it with `INFO` level in `bin/reth/src/node/events.rs` instead of blockchain tree
3. Add pruner events and log them with `INFO` level in `bin/reth/src/node/events.rs`
4. Move Execution stage and EVM time logs to `DEBUG` level