### PR TITLE
chore: lower cargo-deny license confidence

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -33,7 +33,7 @@ skip-tree = []
 
 [licenses]
 unlicensed = "deny"
-confidence-threshold = 0.9
+confidence-threshold = 0.8
 # copyleft = "deny"
 
 # List of explicitly allowed licenses


### PR DESCRIPTION
0.8>x<0.9 confidence for (new?) unicode licenses: <https://github.com/paradigmxyz/reth/actions/runs/6312803937/job/17139583044?pr=4737>