### PR TITLE
feat: remove `ethers-core` from prod

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5987,6 +5987,7 @@ dependencies = [
  "hash-db",
  "itertools 0.11.0",
  "modular-bitfield",
+ "num_enum 0.7.0",
  "once_cell",
  "paste",
  "plain_hasher",

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -17,7 +17,7 @@ revm-primitives = { workspace = true, features = ["serde"] }
 alloy-primitives = { workspace = true, features = ["rand", "rlp"] }
 alloy-rlp = { workspace = true, features = ["arrayvec"] }
 alloy-sol-types.workspace = true
-ethers-core = { workspace = true, default-features = false }
+ethers-core = { workspace = true, default-features = false, optional = true }
 
 # crypto
 secp256k1 = { workspace = true, features = ["global-context", "recovery"] }
@@ -53,6 +53,7 @@ rayon = "1.7"
 tempfile = "3.3"
 sha2 = "0.10.7"
 itertools = "0.11"
+num_enum = "0.7"
 
 # `test-utils` feature
 plain_hasher = { version = "0.2", optional = true }
@@ -88,7 +89,7 @@ pprof = { version = "0.12", features = ["flamegraph", "frame-pointer", "criterio
 [features]
 default = []
 arbitrary = ["revm-primitives/arbitrary", "dep:arbitrary", "dep:proptest", "dep:proptest-derive"]
-test-utils = ["dep:plain_hasher", "dep:hash-db"]
+test-utils = ["dep:plain_hasher", "dep:hash-db", "dep:ethers-core"]
 
 [[bench]]
 name = "recover_ecdsa_crit"

--- a/crates/primitives/src/genesis.rs
+++ b/crates/primitives/src/genesis.rs
@@ -1,9 +1,11 @@
 use crate::{
     keccak256,
     proofs::EMPTY_ROOT,
-    serde_helper::{deserialize_json_u256, deserialize_json_u256_opt, deserialize_storage_map},
+    serde_helper::{
+        deserialize_json_u256, deserialize_json_u256_opt, deserialize_storage_map,
+        num::{u64_hex_or_decimal, u64_hex_or_decimal_opt},
+    },
     trie::{HashBuilder, Nibbles},
-    utils::serde_helpers::{deserialize_stringified_u64, deserialize_stringified_u64_opt},
     Account, Address, Bytes, H256, KECCAK_EMPTY, U256,
 };
 use alloy_rlp::{encode_fixed_size, length_of_length, Encodable, Header as RlpHeader};
@@ -19,15 +21,15 @@ pub struct Genesis {
     #[serde(default)]
     pub config: ChainConfig,
     /// The genesis header nonce.
-    #[serde(deserialize_with = "deserialize_stringified_u64")]
+    #[serde(with = "u64_hex_or_decimal")]
     pub nonce: u64,
     /// The genesis header timestamp.
-    #[serde(deserialize_with = "deserialize_stringified_u64")]
+    #[serde(with = "u64_hex_or_decimal")]
     pub timestamp: u64,
     /// The genesis header extra data.
     pub extra_data: Bytes,
     /// The genesis header gas limit.
-    #[serde(deserialize_with = "deserialize_stringified_u64")]
+    #[serde(with = "u64_hex_or_decimal")]
     pub gas_limit: u64,
     /// The genesis header difficulty.
     #[serde(deserialize_with = "deserialize_json_u256")]
@@ -45,22 +47,13 @@ pub struct Genesis {
     // should NOT be set in a real genesis file, but are included here for compatibility with
     // consensus tests, which have genesis files with these fields populated.
     /// The genesis header base fee
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_stringified_u64_opt"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt")]
     pub base_fee_per_gas: Option<u64>,
     /// The genesis header excess blob gas
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_stringified_u64_opt"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt")]
     pub excess_blob_gas: Option<u64>,
     /// The genesis header blob gas used
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_stringified_u64_opt"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt")]
     pub blob_gas_used: Option<u64>,
 }
 
@@ -141,11 +134,7 @@ impl Genesis {
 #[serde(deny_unknown_fields)]
 pub struct GenesisAccount {
     /// The nonce of the account at genesis.
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_stringified_u64_opt",
-        default
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt", default)]
     pub nonce: Option<u64>,
     /// The balance of the account at genesis.
     #[serde(deserialize_with = "deserialize_json_u256")]
@@ -264,27 +253,18 @@ pub struct ChainConfig {
     pub chain_id: u64,
 
     /// The homestead switch block (None = no fork, 0 = already homestead).
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_stringified_u64_opt"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt")]
     pub homestead_block: Option<u64>,
 
     /// The DAO fork switch block (None = no fork).
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_stringified_u64_opt"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt")]
     pub dao_fork_block: Option<u64>,
 
     /// Whether or not the node supports the DAO hard-fork.
     pub dao_fork_support: bool,
 
     /// The EIP-150 hard fork block (None = no fork).
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_stringified_u64_opt"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt")]
     pub eip150_block: Option<u64>,
 
     /// The EIP-150 hard fork hash.
@@ -292,101 +272,59 @@ pub struct ChainConfig {
     pub eip150_hash: Option<H256>,
 
     /// The EIP-155 hard fork block.
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_stringified_u64_opt"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt")]
     pub eip155_block: Option<u64>,
 
     /// The EIP-158 hard fork block.
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_stringified_u64_opt"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt")]
     pub eip158_block: Option<u64>,
 
     /// The Byzantium hard fork block.
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_stringified_u64_opt"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt")]
     pub byzantium_block: Option<u64>,
 
     /// The Constantinople hard fork block.
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_stringified_u64_opt"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt")]
     pub constantinople_block: Option<u64>,
 
     /// The Petersburg hard fork block.
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_stringified_u64_opt"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt")]
     pub petersburg_block: Option<u64>,
 
     /// The Istanbul hard fork block.
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_stringified_u64_opt"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt")]
     pub istanbul_block: Option<u64>,
 
     /// The Muir Glacier hard fork block.
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_stringified_u64_opt"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt")]
     pub muir_glacier_block: Option<u64>,
 
     /// The Berlin hard fork block.
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_stringified_u64_opt"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt")]
     pub berlin_block: Option<u64>,
 
     /// The London hard fork block.
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_stringified_u64_opt"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt")]
     pub london_block: Option<u64>,
 
     /// The Arrow Glacier hard fork block.
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_stringified_u64_opt"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt")]
     pub arrow_glacier_block: Option<u64>,
 
     /// The Gray Glacier hard fork block.
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_stringified_u64_opt"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt")]
     pub gray_glacier_block: Option<u64>,
 
     /// Virtual fork after the merge to use as a network splitter.
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_stringified_u64_opt"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt")]
     pub merge_netsplit_block: Option<u64>,
 
     /// Shanghai switch time.
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_stringified_u64_opt"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt")]
     pub shanghai_time: Option<u64>,
 
     /// Cancun switch time.
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_stringified_u64_opt"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt")]
     pub cancun_time: Option<u64>,
 
     /// Total difficulty reached that triggers the merge consensus upgrade.
@@ -423,19 +361,11 @@ pub struct EthashConfig {}
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct CliqueConfig {
     /// Number of seconds between blocks to enforce.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_stringified_u64_opt"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt")]
     pub period: Option<u64>,
 
     /// Epoch length to reset votes and checkpoints.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_stringified_u64_opt"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt")]
     pub epoch: Option<u64>,
 }
 

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -105,11 +105,6 @@ pub use revm_primitives::{self, JumpMap};
 #[cfg(any(test, feature = "arbitrary"))]
 pub use arbitrary;
 
-/// Various utilities
-pub mod utils {
-    pub use ethers_core::types::serde_helpers;
-}
-
 /// EIP-4844 + KZG helpers
 pub mod kzg {
     pub use c_kzg::*;

--- a/crates/primitives/src/serde_helper/mod.rs
+++ b/crates/primitives/src/serde_helper/mod.rs
@@ -15,7 +15,7 @@ pub mod num;
 mod prune;
 pub use prune::deserialize_opt_prune_mode_with_min_blocks;
 
-/// serde functions for handling primitive `u64` as [U64](crate::U64)
+/// serde functions for handling primitive `u64` as [`U64`].
 pub mod u64_hex {
     use super::*;
 

--- a/crates/primitives/src/serde_helper/mod.rs
+++ b/crates/primitives/src/serde_helper/mod.rs
@@ -1,23 +1,23 @@
 //! [serde] utilities.
 
-use crate::H256;
+use crate::{H256, U64};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 mod storage;
 
-use serde::Serializer;
 pub use storage::*;
 
 mod jsonu256;
 pub use jsonu256::*;
 
 pub mod num;
+
 mod prune;
 pub use prune::deserialize_opt_prune_mode_with_min_blocks;
 
 /// serde functions for handling primitive `u64` as [U64](crate::U64)
 pub mod u64_hex {
-    use crate::U64;
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use super::*;
 
     /// Deserializes an `u64` from [U64] accepting a hex quantity string with optional 0x prefix
     pub fn deserialize<'de, D>(deserializer: D) -> Result<u64, D::Error>
@@ -35,7 +35,7 @@ pub mod u64_hex {
 
 /// Serialize a byte vec as a hex string _without_ the "0x" prefix.
 ///
-/// This behaves the same as `hex::encode`.
+/// This behaves the same as [`hex::encode`](crate::hex::encode).
 pub fn serialize_hex_string_no_prefix<S, T>(x: T, s: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
@@ -44,14 +44,12 @@ where
     s.serialize_str(&crate::hex::encode(x.as_ref()))
 }
 
-/// Serialize a byte vec as a hex string _without_ 0x prefix
+/// Serialize a [H256] as a hex string _without_ the "0x" prefix.
 pub fn serialize_h256_hex_string_no_prefix<S>(x: &H256, s: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
-    let val = format!("{:?}", x);
-    // skip the 0x prefix
-    s.serialize_str(&val.as_str()[2..])
+    s.serialize_str(&format!("{x:x}"))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #4739
`Chain` is basically the last thing we need `ethers-core` for, so re-implement a small fraction of it in `reth-primitives` so we can get rid of the dependency.