### PR TITLE
fix: use u64 nonce field for prestate

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/builder/geth.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/geth.rs
@@ -196,7 +196,7 @@ impl GethTraceBuilder {
                     addr,
                     AccountState {
                         balance: Some(db_acc.balance),
-                        nonce: Some(U256::from(db_acc.nonce)),
+                        nonce: Some(db_acc.nonce),
                         code: db_acc.code.as_ref().map(|code| Bytes::from(code.original_bytes())),
                         storage: None,
                     },
@@ -210,13 +210,13 @@ impl GethTraceBuilder {
                 let db_acc = db.basic(addr)?.unwrap_or_default();
                 let pre_state = AccountState {
                     balance: Some(db_acc.balance),
-                    nonce: Some(U256::from(db_acc.nonce)),
+                    nonce: Some(db_acc.nonce),
                     code: db_acc.code.as_ref().map(|code| Bytes::from(code.original_bytes())),
                     storage: None,
                 };
                 let post_state = AccountState {
                     balance: Some(changed_acc.balance),
-                    nonce: Some(U256::from(changed_acc.nonce)),
+                    nonce: Some(changed_acc.nonce),
                     code: changed_acc.code.as_ref().map(|code| Bytes::from(code.original_bytes())),
                     storage: None,
                 };

--- a/crates/rpc/rpc-types/src/eth/trace/geth/pre_state.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/geth/pre_state.rs
@@ -10,14 +10,47 @@ pub enum PreStateFrame {
     Diff(DiffMode),
 }
 
+impl PreStateFrame {
+    /// Returns true if this trace was requested without diffmode.
+    pub fn is_default(&self) -> bool {
+        matches!(self, PreStateFrame::Default(_))
+    }
+
+    /// Returns true if this trace was requested with diffmode.
+    pub fn is_diff(&self) -> bool {
+        matches!(self, PreStateFrame::Diff(_))
+    }
+
+    /// Returns the account states after the transaction is executed if this trace was requested
+    /// without diffmode.
+    pub fn as_default(&self) -> Option<&PreStateMode> {
+        match self {
+            PreStateFrame::Default(mode) => Some(mode),
+            _ => None,
+        }
+    }
+
+    /// Returns the account states before and after the transaction is executed if this trace was
+    /// requested with diffmode.
+    pub fn as_diff(&self) -> Option<&DiffMode> {
+        match self {
+            PreStateFrame::Diff(mode) => Some(mode),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PreStateMode(pub BTreeMap<Address, AccountState>);
 
+/// Represents the account states before and after the transaction is executed.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiffMode {
-    pub pre: BTreeMap<Address, AccountState>,
+    /// The account states after the transaction is executed.
     pub post: BTreeMap<Address, AccountState>,
+    /// The account states before the transaction is executed.
+    pub pre: BTreeMap<Address, AccountState>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -30,12 +63,8 @@ pub struct AccountState {
     pub balance: Option<U256>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub code: Option<Bytes>,
-    #[serde(
-        default,
-        deserialize_with = "from_int_or_hex_opt",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub nonce: Option<U256>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nonce: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub storage: Option<BTreeMap<H256, H256>>,
 }
@@ -98,5 +127,54 @@ mod tests {
         assert!(PreStateConfig { diff_mode: Some(true) }.is_diff_mode());
         assert!(!PreStateConfig { diff_mode: Some(false) }.is_diff_mode());
         assert!(!PreStateConfig { diff_mode: None }.is_diff_mode());
+    }
+
+    #[test]
+    fn parse_prestate_default_resp() {
+        let s = r#"{
+  "0x0000000000000000000000000000000000000002": {
+    "balance": "0x0"
+  },
+  "0x008b3b2f992c0e14edaa6e2c662bec549caa8df1": {
+    "balance": "0x2638035a26d133809"
+  },
+  "0x35a9f94af726f07b5162df7e828cc9dc8439e7d0": {
+    "balance": "0x7a48734599f7284",
+    "nonce": 1133
+  },
+  "0xc8ba32cab1757528daf49033e3673fae77dcf05d": {
+    "balance": "0x0",
+    "code": "0x",
+    "nonce": 1,
+    "storage": {
+      "0x0000000000000000000000000000000000000000000000000000000000000000": "0x000000000000000000000000000000000000000000000000000000000024aea6",
+      "0x59fb7853eb21f604d010b94c123acbeae621f09ce15ee5d7616485b1e78a72e9": "0x00000000000000c42b56a52aedf18667c8ae258a0280a8912641c80c48cd9548",
+      "0x8d8ebb65ec00cb973d4fe086a607728fd1b9de14aa48208381eed9592f0dee9a": "0x00000000000000784ae4881e40b1f5ebb4437905fbb8a5914454123b0293b35f",
+      "0xff896b09014882056009dedb136458f017fcef9a4729467d0d00b4fd413fb1f1": "0x000000000000000e78ac39cb1c20e9edc753623b153705d0ccc487e31f9d6749"
+    }
+  }
+}
+"#;
+        let pre_state: PreStateFrame = serde_json::from_str(s).unwrap();
+        assert!(pre_state.is_default());
+    }
+    #[test]
+    fn parse_prestate_diff_resp() {
+        let s = r#"{
+  "post": {
+    "0x35a9f94af726f07b5162df7e828cc9dc8439e7d0": {
+      "nonce": 1135
+    }
+  },
+  "pre": {
+    "0x35a9f94af726f07b5162df7e828cc9dc8439e7d0": {
+      "balance": "0x7a48429e177130a",
+      "nonce": 1134
+    }
+  }
+}
+"#;
+        let pre_state: PreStateFrame = serde_json::from_str(s).unwrap();
+        assert!(pre_state.is_diff());
     }
 }


### PR DESCRIPTION
pre state nonce field is an u64

ref #4731

https://github.com/ethereum/go-ethereum/blob/adb9b319c9c61f092755000bf0fc4b3349f5cbbc/eth/tracers/native/prestate.go#L44-L44