### PR TITLE
fix: omit empty fields of AccountState

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/builder/geth.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/geth.rs
@@ -192,14 +192,14 @@ impl GethTraceBuilder {
             let mut prestate = PreStateMode::default();
             for (addr, _) in account_diffs {
                 let db_acc = db.basic(addr)?.unwrap_or_default();
+
                 prestate.0.insert(
                     addr,
-                    AccountState {
-                        balance: Some(db_acc.balance),
-                        nonce: Some(db_acc.nonce),
-                        code: db_acc.code.as_ref().map(|code| Bytes::from(code.original_bytes())),
-                        storage: None,
-                    },
+                    AccountState::from_account_info(
+                        db_acc.nonce,
+                        db_acc.balance,
+                        db_acc.code.as_ref().map(|code| Bytes::from(code.original_bytes())),
+                    ),
                 );
             }
             self.update_storage_from_trace(&mut prestate.0, false);
@@ -208,18 +208,16 @@ impl GethTraceBuilder {
             let mut state_diff = DiffMode::default();
             for (addr, changed_acc) in account_diffs {
                 let db_acc = db.basic(addr)?.unwrap_or_default();
-                let pre_state = AccountState {
-                    balance: Some(db_acc.balance),
-                    nonce: Some(db_acc.nonce),
-                    code: db_acc.code.as_ref().map(|code| Bytes::from(code.original_bytes())),
-                    storage: None,
-                };
-                let post_state = AccountState {
-                    balance: Some(changed_acc.balance),
-                    nonce: Some(changed_acc.nonce),
-                    code: changed_acc.code.as_ref().map(|code| Bytes::from(code.original_bytes())),
-                    storage: None,
-                };
+                let pre_state = AccountState::from_account_info(
+                    db_acc.nonce,
+                    db_acc.balance,
+                    db_acc.code.as_ref().map(|code| Bytes::from(code.original_bytes())),
+                );
+                let post_state = AccountState::from_account_info(
+                    changed_acc.nonce,
+                    changed_acc.balance,
+                    changed_acc.code.as_ref().map(|code| Bytes::from(code.original_bytes())),
+                );
                 state_diff.pre.insert(addr, pre_state);
                 state_diff.post.insert(addr, post_state);
             }

--- a/crates/revm/revm-inspectors/src/tracing/types.rs
+++ b/crates/revm/revm-inspectors/src/tracing/types.rs
@@ -517,7 +517,6 @@ impl CallTraceNode {
         let acc_state = account_states.entry(addr).or_default();
         for change in self.trace.steps.iter().filter_map(|s| s.storage_change) {
             let StorageChange { key, value, had_value } = change;
-            let storage_map = acc_state.storage.get_or_insert_with(BTreeMap::new);
             let value_to_insert = if post_value {
                 H256::from(value)
             } else {
@@ -526,7 +525,7 @@ impl CallTraceNode {
                     None => continue,
                 }
             };
-            storage_map.insert(key.into(), value_to_insert);
+            acc_state.storage.insert(key.into(), value_to_insert);
         }
     }
 }

--- a/crates/rpc/rpc-types/src/eth/trace/geth/pre_state.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/geth/pre_state.rs
@@ -53,6 +53,7 @@ pub struct DiffMode {
     pub pre: BTreeMap<Address, AccountState>,
 }
 
+/// Represents the state of an account
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AccountState {
     #[serde(
@@ -65,8 +66,24 @@ pub struct AccountState {
     pub code: Option<Bytes>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub nonce: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub storage: Option<BTreeMap<H256, H256>>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub storage: BTreeMap<H256, H256>,
+}
+
+impl AccountState {
+    /// Creates a new `AccountState` with the given account info.
+    ///
+    /// If balance is zero, it will be omitted.
+    /// If nonce is zero, it will be omitted.
+    /// If code is empty, it will be omitted.
+    pub fn from_account_info(nonce: u64, balance: U256, code: Option<Bytes>) -> Self {
+        Self {
+            balance: (balance != U256::ZERO).then_some(balance),
+            code: code.filter(|code| !code.is_empty()),
+            nonce: (nonce != 0).then_some(nonce),
+            storage: Default::default(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
fields are ommitted if zero or empty:

https://github.com/ethereum/go-ethereum/blob/adb9b319c9c61f092755000bf0fc4b3349f5cbbc/eth/tracers/native/prestate.go#L41-L46

this adds a new helper init function that checks this

ref #4731