### PR TITLE
feat: add hivetests profile

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           context: .
           tags: paradigmxyz/reth:main
+          build-args: BUILD_PROFILE=hivetests
           outputs: type=docker,dest=./artifacts/reth_image.tar
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -1,7 +1,4 @@
 on:
-  push:
-    branches:
-      - dan/add-hivetests-profile
   schedule:
     # every day
     - cron: '0 0 * * *'

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -1,4 +1,7 @@
 on:
+  push:
+    branches:
+      - dan/add-hivetests-profile
   schedule:
     # every day
     - cron: '0 0 * * *'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,12 @@ exclude = [".github/"]
 inherits = "release"
 debug = true
 
+# Meant for testing - all optimizations, but with debug assertions and overflow
+# checks
+[profile.hivetests]
+inherits = "test"
+opt-level = 3
+
 [profile.maxperf]
 inherits = "release"
 lto = "fat"

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,12 +26,16 @@ RUN cargo chef cook --profile $BUILD_PROFILE --recipe-path recipe.json
 COPY . .
 RUN cargo build --profile $BUILD_PROFILE --locked --bin reth
 
+# ARG is not resolve in COPY so we have to hack around it by copying the binary
+# to a temporary location
+RUN cp /app/target/$BUILD_PROFILE/reth /app/reth
+
 # Use Ubuntu as the release image
 FROM ubuntu AS runtime
 WORKDIR /app
 
 # Copy reth over from the build stage
-COPY --from=builder /app/target/release/reth /usr/local/bin
+COPY --from=builder /app/reth /usr/local/bin
 
 # Copy licenses
 COPY LICENSE-* ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ RUN cargo chef cook --profile $BUILD_PROFILE --recipe-path recipe.json
 COPY . .
 RUN cargo build --profile $BUILD_PROFILE --locked --bin reth
 
-# ARG is not resolve in COPY so we have to hack around it by copying the binary
-# to a temporary location
+# ARG is not resolved in COPY so we have to hack around it by copying the
+# binary to a temporary location
 RUN cp /app/target/$BUILD_PROFILE/reth /app/reth
 
 # Use Ubuntu as the release image


### PR DESCRIPTION
This adds the `hivetests` profile, which is an optimized version of the `test` profile. The docker image is also modified to support replacing the BUILD_PROFILE argument. This does not yet use the `hivetests` profile for a published image.

DONOTMERGE until the `on: push:` part of the hive workflow is removed