### PR TITLE
fix: remove zero-amount withdrawals before incrementing balances

### DIFF
--- a/crates/revm/src/state_change.rs
+++ b/crates/revm/src/state_change.rs
@@ -111,6 +111,8 @@ where
 
 /// Returns a map of addresses to their balance increments if the Shanghai hardfork is active at the
 /// given timestamp.
+///
+/// Zero-valued withdrawals are filtered out.
 #[inline]
 pub fn post_block_withdrawals_balance_increments(
     chain_spec: &ChainSpec,
@@ -129,6 +131,8 @@ pub fn post_block_withdrawals_balance_increments(
 
 /// Applies all withdrawal balance increments if shanghai is active at the given timestamp to the
 /// given `balance_increments` map.
+///
+/// Zero-valued withdrawals are filtered out.
 #[inline]
 pub fn insert_post_block_withdrawals_balance_increments(
     chain_spec: &ChainSpec,
@@ -140,8 +144,10 @@ pub fn insert_post_block_withdrawals_balance_increments(
     if chain_spec.is_shanghai_active_at_timestamp(block_timestamp) {
         if let Some(withdrawals) = withdrawals {
             for withdrawal in withdrawals {
-                *balance_increments.entry(withdrawal.address).or_default() +=
-                    withdrawal.amount_wei();
+                if withdrawal.amount > 0 {
+                    *balance_increments.entry(withdrawal.address).or_default() +=
+                        withdrawal.amount_wei();
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/paradigmxyz/reth/issues/4811

Zero amount withdrawals to precompiles were previously creating accounts for those precompiles, causing the state root failiure. The `increment_balances` method used for withdrawals assumes that the increments are non-zero. This filters out all zero-amount withdrawals before incrementing balances.