### PR TITLE
fix: do not validate increasing withdrawal indexes

### DIFF
--- a/crates/interfaces/src/consensus.rs
+++ b/crates/interfaces/src/consensus.rs
@@ -246,15 +246,6 @@ pub enum ConsensusError {
     #[error("Unexpected withdrawals root")]
     WithdrawalsRootUnexpected,
 
-    /// Error when the withdrawal index is invalid.
-    #[error("Withdrawal index #{got} is invalid. Expected: #{expected}.")]
-    WithdrawalIndexInvalid {
-        /// The actual withdrawal index.
-        got: u64,
-        /// The expected withdrawal index.
-        expected: u64,
-    },
-
     /// Error when withdrawals are missing.
     #[error("Missing withdrawals")]
     BodyWithdrawalsMissing,


### PR DESCRIPTION
This removes the `WithdrawalIndexInvalid` error completely, because hive tests from https://github.com/paradigmxyz/reth/issues/4815 do not have increasing indexes.

Fixes https://github.com/paradigmxyz/reth/issues/4815