### PR TITLE
fix: return INVALID again if block contains blob transactions pre-cancun

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1194,11 +1194,7 @@ where
             .flatten()
             .collect::<Vec<_>>();
 
-        if let Err(status) =
-            self.validate_versioned_hashes(parent_hash, block_versioned_hashes, cancun_fields)
-        {
-            return Err(status)
-        }
+        self.validate_versioned_hashes(parent_hash, block_versioned_hashes, cancun_fields)?;
 
         Ok(block)
     }

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1079,7 +1079,7 @@ where
         payload: ExecutionPayload,
         cancun_fields: Option<CancunPayloadFields>,
     ) -> Result<PayloadStatus, BeaconOnNewPayloadError> {
-        let block = match self.ensure_well_formed_payload(payload, cancun_fields)? {
+        let block = match self.ensure_well_formed_payload(payload, cancun_fields) {
             Ok(block) => block,
             Err(status) => return Ok(status),
         };
@@ -1148,7 +1148,7 @@ where
         &self,
         payload: ExecutionPayload,
         cancun_fields: Option<CancunPayloadFields>,
-    ) -> Result<Result<SealedBlock, PayloadStatus>, BeaconOnNewPayloadError> {
+    ) -> Result<SealedBlock, PayloadStatus> {
         let parent_hash = payload.parent_hash();
 
         let block_hash = payload.block_hash();
@@ -1158,15 +1158,13 @@ where
         ) {
             Ok(block) => {
                 // make sure there are no blob transactions in the payload if it is pre-cancun
-                // we perform this check before validating the block hash because INVALID_PARAMS
-                // must be returned over an INVALID response.
                 if !self.chain_spec().is_cancun_active_at_timestamp(block.timestamp) &&
                     block.has_blob_transactions()
                 {
-                    return Err(BeaconOnNewPayloadError::PreCancunBlockWithBlobTransactions)
+                    Err(PayloadError::PreCancunBlockWithBlobTransactions)
+                } else {
+                    validate_block_hash(block_hash, block)
                 }
-
-                validate_block_hash(block_hash, block)
             }
             Err(error) => Err(error),
         };
@@ -1185,7 +1183,7 @@ where
                 }
                 let status = PayloadStatusEnum::from(error);
 
-                return Ok(Err(PayloadStatus::new(status, latest_valid_hash)))
+                return Err(PayloadStatus::new(status, latest_valid_hash))
             }
         };
 
@@ -1199,10 +1197,10 @@ where
         if let Err(status) =
             self.validate_versioned_hashes(parent_hash, block_versioned_hashes, cancun_fields)
         {
-            return Ok(Err(status))
+            return Err(status)
         }
 
-        Ok(Ok(block))
+        Ok(block)
     }
 
     /// Returns the currently configured [ChainSpec].

--- a/crates/rpc/rpc-types/src/eth/engine/payload.rs
+++ b/crates/rpc/rpc-types/src/eth/engine/payload.rs
@@ -334,6 +334,9 @@ pub enum PayloadError {
     /// Invalid payload excess blob gas.
     #[error("Invalid payload excess blob gas: {0}")]
     ExcessBlobGas(U256),
+    /// Pre-cancun Payload has blob transactions.
+    #[error("Invalid payload, pre-Cancun payload has blob transactions")]
+    PreCancunBlockWithBlobTransactions,
     /// Invalid payload block hash.
     #[error("blockhash mismatch, want {consensus}, got {execution}")]
     BlockHash {


### PR DESCRIPTION
Fixes https://github.com/paradigmxyz/reth/issues/4670 again

The test now expects an `INVALID` response instead of an RPC error, so we can get rid of the double nested `Result`, and just have a `PayloadError` to represent when a pre-cancun payload has blob transactions.