### PR TITLE
fix(engine): return sync state back to Idle when hook finishes

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1743,6 +1743,10 @@ where
                     self.sync_state_updater.update_sync_state(SyncState::Syncing)
                 }
                 EngineHookEvent::Finished(_) => {
+                    // Hook with read-write access to the database has finished running, so engine
+                    // can process new FCU/payload messages from CL again. It's safe to
+                    // return `false` on `eth_syncing` request.
+                    self.sync_state_updater.update_sync_state(SyncState::Idle);
                     // If the hook had read-write access to the database, it means that the engine
                     // may have accumulated some buffered blocks.
                     if let Err(error) =


### PR DESCRIPTION
Fixes https://github.com/paradigmxyz/reth/issues/4829

We didn't explicitly set sync state to `Idle` when hook is finished, but instead relied on updating it when new FCU/payload processing finishes. Because of this, `eth_syncing` changed back to `false` only after 12s, and it seemed like pruner was running for all that time.