### PR TITLE
chore(`deps`): change revm to use evalir/revm instead of dani branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6424,7 +6424,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "3.3.0"
-source = "git+https://github.com/Danipopes/revm/?branch=alloy-rebase2#bbe05037c3ced9400dfabe14e6ab814c1a67b3c8"
+source = "git+https://github.com/Evalir/revm/?branch=reintroduce-alloy-rebased#b6eb3246197c6dfb8715a2a28dd2908e8c84aad7"
 dependencies = [
  "auto_impl",
  "revm-interpreter",
@@ -6434,7 +6434,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "1.1.2"
-source = "git+https://github.com/Danipopes/revm/?branch=alloy-rebase2#bbe05037c3ced9400dfabe14e6ab814c1a67b3c8"
+source = "git+https://github.com/Evalir/revm/?branch=reintroduce-alloy-rebased#b6eb3246197c6dfb8715a2a28dd2908e8c84aad7"
 dependencies = [
  "revm-primitives",
 ]
@@ -6442,7 +6442,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "2.0.3"
-source = "git+https://github.com/Danipopes/revm/?branch=alloy-rebase2#bbe05037c3ced9400dfabe14e6ab814c1a67b3c8"
+source = "git+https://github.com/Evalir/revm/?branch=reintroduce-alloy-rebased#b6eb3246197c6dfb8715a2a28dd2908e8c84aad7"
 dependencies = [
  "c-kzg",
  "k256",
@@ -6458,7 +6458,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "1.1.2"
-source = "git+https://github.com/Danipopes/revm/?branch=alloy-rebase2#bbe05037c3ced9400dfabe14e6ab814c1a67b3c8"
+source = "git+https://github.com/Evalir/revm/?branch=reintroduce-alloy-rebased#b6eb3246197c6dfb8715a2a28dd2908e8c84aad7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,8 +108,8 @@ reth-ecies = { path = "./crates/net/ecies" }
 
 # revm
 # TODO: Switch back to bluealloy/revm once #724 lands
-revm = { git = "https://github.com/Danipopes/revm/", branch = "alloy-rebase2" }
-revm-primitives = { git = "https://github.com/Danipopes/revm/", branch = "alloy-rebase2" }
+revm = { git = "https://github.com/Evalir/revm/", branch = "reintroduce-alloy-rebased" }
+revm-primitives = { git = "https://github.com/Evalir/revm/", branch = "reintroduce-alloy-rebased" }
 
 ## eth
 alloy-primitives = "0.3"

--- a/deny.toml
+++ b/deny.toml
@@ -96,7 +96,7 @@ unknown-registry = "warn"
 unknown-git = "deny"
 allow-git = [
     # TODO: remove, see ./Cargo.toml
-    "https://github.com/Danipopes/revm",
+    "https://github.com/Evalir/revm",
     "https://github.com/alloy-rs/core",
     # "https://github.com/bluealloy/revm",
 


### PR DESCRIPTION
https://github.com/Evalir/revm/pull/4 was merged—so we can switch to using the main PR branch for revm alloy and this should avoid getting build errors.