### PR TITLE
fix(bin): latest block in status message

### DIFF
--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -34,18 +34,18 @@ struct NodeState {
     eta: Eta,
     /// The current checkpoint of the executing stage.
     current_checkpoint: StageCheckpoint,
-    /// The latest canonical block added in the consensus engine.
-    latest_canonical_engine_block: Option<BlockNumber>,
+    /// The latest block set by either pipeline or consensus engine.
+    latest_block: Option<BlockNumber>,
 }
 
 impl NodeState {
-    fn new(network: Option<NetworkHandle>, latest_block_number: Option<BlockNumber>) -> Self {
+    fn new(network: Option<NetworkHandle>, latest_block: Option<BlockNumber>) -> Self {
         Self {
             network,
             current_stage: None,
             eta: Eta::default(),
             current_checkpoint: StageCheckpoint::new(0),
-            latest_canonical_engine_block: latest_block_number,
+            latest_block,
         }
     }
 
@@ -79,6 +79,7 @@ impl NodeState {
                 result: ExecOutput { checkpoint, done },
             } => {
                 self.current_checkpoint = checkpoint;
+                self.latest_block = Some(checkpoint.block_number);
                 self.eta.update(self.current_checkpoint);
 
                 info!(
@@ -124,7 +125,7 @@ impl NodeState {
                 );
             }
             BeaconConsensusEngineEvent::CanonicalBlockAdded(block) => {
-                self.latest_canonical_engine_block = Some(block.number);
+                self.latest_block = Some(block.number);
 
                 info!(number=block.number, hash=?block.hash, "Block added to canonical chain");
             }
@@ -270,7 +271,7 @@ where
                 info!(
                     target: "reth::cli",
                     connected_peers = this.state.num_connected_peers(),
-                    latest_block = this.state.latest_canonical_engine_block.unwrap_or(this.state.current_checkpoint.block_number),
+                    latest_block = ?this.state.latest_block,
                     "Status"
                 );
             }

--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -127,11 +127,11 @@ impl NodeState {
                 );
             }
             BeaconConsensusEngineEvent::CanonicalBlockAdded(block) => {
-                self.latest_block = Some(block.number);
-
                 info!(number=block.number, hash=?block.hash, "Block added to canonical chain");
             }
             BeaconConsensusEngineEvent::CanonicalChainCommitted(head, elapsed) => {
+                self.latest_block = Some(head.number);
+
                 info!(number=head.number, hash=?head.hash, ?elapsed, "Canonical chain committed");
             }
             BeaconConsensusEngineEvent::ForkBlockAdded(block) => {

--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -34,7 +34,7 @@ struct NodeState {
     eta: Eta,
     /// The current checkpoint of the executing stage.
     current_checkpoint: StageCheckpoint,
-    /// The latest block set by either pipeline or consensus engine.
+    /// The latest block reached by either pipeline or consensus engine.
     latest_block: Option<BlockNumber>,
 }
 
@@ -79,7 +79,9 @@ impl NodeState {
                 result: ExecOutput { checkpoint, done },
             } => {
                 self.current_checkpoint = checkpoint;
-                self.latest_block = Some(checkpoint.block_number);
+                if stage_id.is_finish() {
+                    self.latest_block = Some(checkpoint.block_number);
+                }
                 self.eta.update(self.current_checkpoint);
 
                 info!(


### PR DESCRIPTION
Ref https://github.com/paradigmxyz/reth/issues/4854#issuecomment-1740888328

Report latest block in `Status` message as the latest reached by either pipeline or blockchain tree.