### PR TITLE
fix(revm): calculate unpruned `gas_spent_by_tx`

### DIFF
--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -87,25 +87,6 @@ impl Receipts {
             &self.receipt_vec[index].iter().map(Option::as_ref).collect::<Option<Vec<_>>>()?,
         ))
     }
-
-    /// Retrieves gas spent by transactions as a vector of tuples (transaction index, gas used).
-    pub fn gas_spent_by_tx(&self) -> Result<Vec<(u64, u64)>, PrunePartError> {
-        self.last()
-            .map(|block_r| {
-                block_r
-                    .iter()
-                    .enumerate()
-                    .map(|(id, tx_r)| {
-                        if let Some(receipt) = tx_r.as_ref() {
-                            Ok((id as u64, receipt.cumulative_gas_used))
-                        } else {
-                            Err(PrunePartError::ReceiptsPruned)
-                        }
-                    })
-                    .collect::<Result<Vec<_>, PrunePartError>>()
-            })
-            .unwrap_or(Ok(vec![]))
-    }
 }
 
 impl Deref for Receipts {

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -2,7 +2,7 @@ use crate::{
     compression::{RECEIPT_COMPRESSOR, RECEIPT_DECOMPRESSOR},
     logs_bloom,
     proofs::calculate_receipt_root_ref,
-    Bloom, Log, PrunePartError, TxType, B256,
+    Bloom, Log, TxType, B256,
 };
 use alloy_rlp::{length_of_length, Decodable, Encodable};
 use bytes::{Buf, BufMut, BytesMut};

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -352,7 +352,11 @@ impl<'a> EVMProcessor<'a> {
             return Err(BlockValidationError::BlockGasUsed {
                 got: cumulative_gas_used,
                 expected: block.gas_used,
-                gas_spent_by_tx: self.receipts.gas_spent_by_tx()?,
+                gas_spent_by_tx: receipts
+                    .iter()
+                    .enumerate()
+                    .map(|(id, receipt)| (id as u64, receipt.cumulative_gas_used))
+                    .collect(),
             }
             .into())
         }


### PR DESCRIPTION
`self.receipts` is populated only after `execute_inner` returns, so `BlockValidationError::BlockGasUsed.gas_spent_by_tx` will always be either incorrect or empty.

Instead, we can calculate gas spent using the receipts returned from `self.execute_transactions`.