### PR TITLE
fix: return gas per tx in error

### DIFF
--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -66,6 +66,11 @@ impl Receipts {
         Self { receipt_vec: vec }
     }
 
+    /// Create a new `Receipts` instance from a single block receipt.
+    pub fn from_block_receipt(block_receipts: Vec<Receipt>) -> Self {
+        Self { receipt_vec: vec![block_receipts.into_iter().map(Option::Some).collect()] }
+    }
+
     /// Returns the length of the `Receipts` vector.
     pub fn len(&self) -> usize {
         self.receipt_vec.len()

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -349,10 +349,11 @@ impl<'a> EVMProcessor<'a> {
 
         // Check if gas used matches the value set in header.
         if block.gas_used != cumulative_gas_used {
+            let receipts = Receipts::from_block_receipt(receipts);
             return Err(BlockValidationError::BlockGasUsed {
                 got: cumulative_gas_used,
                 expected: block.gas_used,
-                gas_spent_by_tx: self.receipts.gas_spent_by_tx()?,
+                gas_spent_by_tx: receipts.gas_spent_by_tx()?,
             }
             .into())
         }


### PR DESCRIPTION
Small fix on error reporting. `self.receipts` were used even when new receipts were not saved.