### PR TITLE
fix: unwrap latest block for cli log

### DIFF
--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -273,7 +273,7 @@ where
                 info!(
                     target: "reth::cli",
                     connected_peers = this.state.num_connected_peers(),
-                    latest_block = ?this.state.latest_block,
+                    latest_block = this.state.latest_block.unwrap_or(this.state.current_checkpoint.block_number),
                     "Status"
                 );
             }


### PR DESCRIPTION
this restores the previous unwrap:

> Status connected_peers=3 latest_block=Some(7519)

is not great

ref #4856

we might even consider not using an option here and initialize this with the latest block on disk

https://github.com/paradigmxyz/reth/blob/2c39d96aed07c453d6d1604548079f008ec3b6a7/bin/reth/src/chain/import.rs#L122-L124

can open a good first issue for this @shekhirin ?