### PR TITLE
fix(tx-pool) make BestTransactionsAttributes public

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -154,7 +154,6 @@ use std::{
 };
 use tokio::sync::mpsc::Receiver;
 use tracing::{instrument, trace};
-use traits::BestTransactionsAttributes;
 
 pub use crate::{
     blobstore::{BlobStore, BlobStoreError},
@@ -170,11 +169,11 @@ pub use crate::{
         TransactionEvents,
     },
     traits::{
-        AllPoolTransactions, BestTransactions, BlockInfo, CanonicalStateUpdate, ChangedAccount,
-        EthBlobTransactionSidecar, EthPoolTransaction, EthPooledTransaction,
-        GetPooledTransactionLimit, NewBlobSidecar, NewTransactionEvent, PoolSize, PoolTransaction,
-        PropagateKind, PropagatedTransactions, TransactionListenerKind, TransactionOrigin,
-        TransactionPool, TransactionPoolExt,
+        AllPoolTransactions, BestTransactions, BestTransactionsAttributes, BlockInfo,
+        CanonicalStateUpdate, ChangedAccount, EthBlobTransactionSidecar, EthPoolTransaction,
+        EthPooledTransaction, GetPooledTransactionLimit, NewBlobSidecar, NewTransactionEvent,
+        PoolSize, PoolTransaction, PropagateKind, PropagatedTransactions, TransactionListenerKind,
+        TransactionOrigin, TransactionPool, TransactionPoolExt,
     },
     validate::{
         EthTransactionValidator, TransactionValidationOutcome, TransactionValidationTaskExecutor,


### PR DESCRIPTION
BestTransactionsAttributes should be pub since it's used as an argument of pub TransactionPool::best_transactions_with_attributes 