### PR TITLE
fix: check active hardforks using head block for validator

### DIFF
--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -485,6 +485,15 @@ impl EthTransactionValidatorBuilder {
         self
     }
 
+    /// Configures validation rules based on the head block's timestamp.
+    ///
+    /// For example, whether the Shanghai and Cancun hardfork is activated at launch.
+    pub fn with_head_timestamp(mut self, timestamp: u64) -> Self {
+        self.cancun = self.chain_spec.is_cancun_active_at_timestamp(timestamp);
+        self.shanghai = self.chain_spec.is_shanghai_active_at_timestamp(timestamp);
+        self
+    }
+
     /// Builds a the [EthTransactionValidator] and spawns validation tasks via the
     /// [TransactionValidationTaskExecutor]
     ///


### PR DESCRIPTION
this should fix the `Test: ForkchoiceUpdatedV2 then ForkchoiceUpdatedV3 Valid Payload Building Requests (Cancun)` hive test

previously we did not enable cancun by default, only `on_new_head` event.

this adds a new config function `with_head_timestamp` that enables cancun/shanghai support based on the head block's timestamp 
