### PR TITLE
chore: bump revm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6431,8 +6431,8 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "3.3.0"
-source = "git+https://github.com/Evalir/revm/?branch=reintroduce-alloy-rebased#988e0d7920ab20c3d0a12dd5582654a58e7f9f2c"
+version = "3.4.0"
+source = "git+https://github.com/bluealloy/revm/#4e78fbe86ef4d030968d00f461926abbcb813943"
 dependencies = [
  "auto_impl",
  "revm-interpreter",
@@ -6441,16 +6441,16 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "1.1.2"
-source = "git+https://github.com/Evalir/revm/?branch=reintroduce-alloy-rebased#988e0d7920ab20c3d0a12dd5582654a58e7f9f2c"
+version = "1.2.0"
+source = "git+https://github.com/bluealloy/revm/#4e78fbe86ef4d030968d00f461926abbcb813943"
 dependencies = [
  "revm-primitives",
 ]
 
 [[package]]
 name = "revm-precompile"
-version = "2.0.3"
-source = "git+https://github.com/Evalir/revm/?branch=reintroduce-alloy-rebased#988e0d7920ab20c3d0a12dd5582654a58e7f9f2c"
+version = "2.1.0"
+source = "git+https://github.com/bluealloy/revm/#4e78fbe86ef4d030968d00f461926abbcb813943"
 dependencies = [
  "c-kzg",
  "k256",
@@ -6465,8 +6465,8 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "1.1.2"
-source = "git+https://github.com/Evalir/revm/?branch=reintroduce-alloy-rebased#988e0d7920ab20c3d0a12dd5582654a58e7f9f2c"
+version = "1.2.0"
+source = "git+https://github.com/bluealloy/revm/#4e78fbe86ef4d030968d00f461926abbcb813943"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6431,8 +6431,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "3.4.0"
-source = "git+https://github.com/bluealloy/revm/#4e78fbe86ef4d030968d00f461926abbcb813943"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f4ca8ae0345104523b4af1a8a7ea97cfa1865cdb7a7c25d23c1a18d9b48598"
 dependencies = [
  "auto_impl",
  "revm-interpreter",
@@ -6441,16 +6442,18 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "1.2.0"
-source = "git+https://github.com/bluealloy/revm/#4e78fbe86ef4d030968d00f461926abbcb813943"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f959cafdf64a7f89b014fa73dc2325001cf654b3d9400260b212d19a2ebe3da0"
 dependencies = [
  "revm-primitives",
 ]
 
 [[package]]
 name = "revm-precompile"
-version = "2.1.0"
-source = "git+https://github.com/bluealloy/revm/#4e78fbe86ef4d030968d00f461926abbcb813943"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d360a88223d85709d2e95d4609eb1e19c649c47e28954bfabae5e92bb37e83e"
 dependencies = [
  "c-kzg",
  "k256",
@@ -6465,8 +6468,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "1.2.0"
-source = "git+https://github.com/bluealloy/revm/#4e78fbe86ef4d030968d00f461926abbcb813943"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51187b852d9e458816a2e19c81f1dd6c924077e1a8fccd16e4f044f865f299d7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,8 +107,8 @@ reth-eth-wire = { path = "./crates/net/eth-wire" }
 reth-ecies = { path = "./crates/net/ecies" }
 
 # revm
-revm = { git = "https://github.com/bluealloy/revm/" }
-revm-primitives = { git = "https://github.com/bluealloy/revm/" }
+revm = "3.5.0"
+revm-primitives = "1.3.0"
 
 ## eth
 alloy-primitives = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,9 +107,8 @@ reth-eth-wire = { path = "./crates/net/eth-wire" }
 reth-ecies = { path = "./crates/net/ecies" }
 
 # revm
-# TODO: Switch back to bluealloy/revm once #724 lands
-revm = { git = "https://github.com/Evalir/revm/", branch = "reintroduce-alloy-rebased" }
-revm-primitives = { git = "https://github.com/Evalir/revm/", branch = "reintroduce-alloy-rebased" }
+revm = { git = "https://github.com/bluealloy/revm/" }
+revm-primitives = { git = "https://github.com/bluealloy/revm/" }
 
 ## eth
 alloy-primitives = "0.4"

--- a/crates/payload/builder/src/payload.rs
+++ b/crates/payload/builder/src/payload.rs
@@ -184,7 +184,7 @@ impl PayloadBuilderAttributes {
         // if the parent block did not have excess blob gas (i.e. it was pre-cancun), but it is
         // cancun now, we need to set the excess blob gas to the default value
         let blob_excess_gas_and_price = parent
-            .next_block_blob_fee()
+            .next_block_excess_blob_gas()
             .map_or_else(
                 || {
                     if cfg.spec_id == SpecId::CANCUN {

--- a/crates/primitives/src/constants/eip4844.rs
+++ b/crates/primitives/src/constants/eip4844.rs
@@ -29,7 +29,7 @@ pub const TARGET_BLOBS_PER_BLOCK: u64 = TARGET_DATA_GAS_PER_BLOCK / DATA_GAS_PER
 pub const BLOB_GASPRICE_UPDATE_FRACTION: u64 = 3_338_477u64; // 3338477
 
 /// Minimum gas price for a data blob
-pub const BLOB_TX_MIN_BLOB_GASPRICE: u64 = 1u64;
+pub const BLOB_TX_MIN_BLOB_GASPRICE: u128 = 1u128;
 
 /// Commitment version of a KZG commitment
 pub const VERSIONED_HASH_VERSION_KZG: u8 = 0x01;

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -185,7 +185,7 @@ impl Header {
     /// Returns the blob fee for _this_ block according to the EIP-4844 spec.
     ///
     /// Returns `None` if `excess_blob_gas` is None
-    pub fn blob_fee(&self) -> Option<u64> {
+    pub fn blob_fee(&self) -> Option<u128> {
         self.excess_blob_gas.map(calc_blob_gasprice)
     }
 
@@ -194,7 +194,7 @@ impl Header {
     /// Returns `None` if `excess_blob_gas` is None.
     ///
     /// See also [Self::next_block_excess_blob_gas]
-    pub fn next_block_blob_fee(&self) -> Option<u64> {
+    pub fn next_block_blob_fee(&self) -> Option<u128> {
         self.next_block_excess_blob_gas().map(calc_blob_gasprice)
     }
 

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -815,7 +815,7 @@ pub(crate) struct AllTransactions<T: PoolTransaction> {
     /// Expected base fee for the pending block.
     pending_basefee: u64,
     /// Expected blob fee for the pending block.
-    pending_blob_fee: u64,
+    pending_blob_fee: u128,
     /// Configured price bump settings for replacements
     price_bumps: PriceBumpConfig,
 }

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -1366,7 +1366,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
             transaction =
                 self.ensure_valid_blob_transaction(transaction, on_chain_balance, ancestor)?;
             let blob_fee_cap = transaction.transaction.max_fee_per_blob_gas().unwrap_or_default();
-            if blob_fee_cap >= self.pending_blob_fee as u128 {
+            if blob_fee_cap >= self.pending_blob_fee {
                 state.insert(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK);
             }
         } else {

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -520,7 +520,7 @@ pub struct CanonicalStateUpdate<'a> {
     /// EIP-4844 blob fee of the _next_ (pending) block
     ///
     /// Only after Cancun
-    pub pending_block_blob_fee: Option<u64>,
+    pub pending_block_blob_fee: Option<u128>,
     /// A set of changed accounts across a range of blocks.
     pub changed_accounts: Vec<ChangedAccount>,
     /// All mined transactions in the block range.
@@ -1040,7 +1040,7 @@ pub struct BlockInfo {
     ///
     /// Note: this is the derived blob fee of the _next_ block that builds on the block the pool is
     /// currently tracking
-    pub pending_blob_fee: Option<u64>,
+    pub pending_blob_fee: Option<u128>,
 }
 
 /// The limit to enforce for [TransactionPool::get_pooled_transaction_elements].

--- a/deny.toml
+++ b/deny.toml
@@ -96,8 +96,7 @@ unknown-registry = "warn"
 unknown-git = "deny"
 allow-git = [
     # TODO: remove, see ./Cargo.toml
-    "https://github.com/Evalir/revm",
-    # "https://github.com/bluealloy/revm",
+    "https://github.com/bluealloy/revm",
 
     "https://github.com/ethereum/c-kzg-4844",
     "https://github.com/sigp/discv5",


### PR DESCRIPTION
This updates the revm version, which now has alloy types. A bug is also fixed in the payload builder where we were initializing the `BlobExcessGasAndPrice` with the next block's blob fee rather than the next block's excess blob gas.