### PR TITLE
feat: add `lz4` to `NippyJar` 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,17 +730,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bloomfilter"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b92db7965d438b8b4b1c1d0aedd188440a1084593c9eb7f6657e3df7e906d934"
-dependencies = [
- "bit-vec",
- "getrandom 0.2.10",
- "siphasher 1.0.0",
-]
-
-[[package]]
 name = "blst"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3913,6 +3902,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ea9b256699eda7b0387ffbc776dd625e28bde3918446381781245b7a50349d8"
+
+[[package]]
 name = "mach2"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4670,7 +4665,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
- "siphasher 0.3.11",
+ "siphasher",
 ]
 
 [[package]]
@@ -5322,6 +5317,7 @@ dependencies = [
  "pin-project",
  "pretty_assertions",
  "proptest",
+ "rand 0.8.5",
  "reth-auto-seal-consensus",
  "reth-basic-payload-builder",
  "reth-beacon-consensus",
@@ -5878,9 +5874,10 @@ version = "0.1.0-alpha.10"
 dependencies = [
  "anyhow",
  "bincode",
- "bloomfilter",
  "bytes",
  "cuckoofilter",
+ "hex",
+ "lz4_flex",
  "memmap2 0.7.1",
  "ph",
  "rand 0.8.5",
@@ -7150,12 +7147,6 @@ name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
-
-[[package]]
-name = "siphasher"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54ac45299ccbd390721be55b412d41931911f654fa99e2cb8bfb57184b2061fe"
 
 [[package]]
 name = "sketches-ddsketch"

--- a/bin/reth/src/db/snap.rs
+++ b/bin/reth/src/db/snap.rs
@@ -3,7 +3,7 @@ use clap::{clap_derive::ValueEnum, Parser};
 use eyre::WrapErr;
 use reth_db::{
     database::Database, snapshot::create_snapshot_T1_T2, table::Table, tables, transaction::DbTx,
-    DatabaseEnvRO, TableViewer,
+    DatabaseEnvRO,
 };
 use reth_nippy_jar::NippyJar;
 use reth_primitives::BlockNumber;

--- a/crates/storage/nippy-jar/Cargo.toml
+++ b/crates/storage/nippy-jar/Cargo.toml
@@ -12,21 +12,28 @@ description = "Immutable data store format"
 name = "reth_nippy_jar"
 
 [dependencies]
-memmap2 = "0.7.1"
-bloomfilter = "1"
-zstd = { version = "0.12", features = ["experimental", "zdict_builder"] }
+
+# filter
 ph = "0.8.0"
-thiserror = "1.0"
+cuckoofilter = { version = "0.5.0", features = ["serde_support", "serde_bytes"] }
+
+# compression
+zstd = { version = "0.12", features = ["experimental", "zdict_builder"] }
+lz4_flex = { version = "0.11", default-features = false }
+
+# offsets
+sucds = "~0.8"
+
+memmap2 = "0.7.1"
 bincode = "1.3"
 serde = { version = "1.0",  features = ["derive"] }
 bytes = "1.5"
-cuckoofilter = { version = "0.5.0", features = ["serde_support", "serde_bytes"] }
 tempfile = "3.4"
-sucds = "~0.8"
 tracing = "0.1.0"
 tracing-appender = "0.2"
 anyhow = "1.0"
-
+thiserror = "1.0"
+hex = "*"
 
 [dev-dependencies]
 rand = { version = "0.8", features = ["small_rng"] }

--- a/crates/storage/nippy-jar/src/compression/lz4.rs
+++ b/crates/storage/nippy-jar/src/compression/lz4.rs
@@ -1,0 +1,104 @@
+use crate::{compression::Compression, NippyJarError};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+/// Lz4 compression structure. Supports a compression dictionary per column.
+pub struct Lz4 {
+    /// Number of columns to compress.
+    columns: usize,
+}
+
+impl Lz4 {
+    /// Creates new [`Lz4`].
+    pub fn new(columns: usize) -> Self {
+        Self { columns }
+    }
+}
+
+impl Compression for Lz4 {
+    fn decompress_to(&self, value: &[u8], dest: &mut Vec<u8>) -> Result<(), NippyJarError> {
+        let previous_length = dest.len();
+
+        // SAFETY: We're setting len to the existing capacity.
+        unsafe {
+            dest.set_len(dest.capacity());
+        }
+
+        match lz4_flex::decompress_into(value, &mut dest[previous_length..]) {
+            Ok(written) => {
+                // SAFETY: `compress_into` can only write if there's enough capacity. Therefore, it
+                // shouldn't write more than our capacity.
+                unsafe {
+                    dest.set_len(previous_length + written);
+                }
+                Ok(())
+            }
+            Err(_) => {
+                // SAFETY: we are resetting it to the previous value.
+                unsafe {
+                    dest.set_len(previous_length);
+                }
+                Err(NippyJarError::OutputTooSmall)
+            }
+        }
+    }
+
+    fn decompress(&self, value: &[u8]) -> Result<Vec<u8>, NippyJarError> {
+        let mut multiplier = 1;
+
+        loop {
+            match lz4_flex::decompress(value, multiplier * value.len()) {
+                Ok(v) => return Ok(v),
+                Err(err) => {
+                    multiplier *= 2;
+                    if multiplier == 16 {
+                        return Err(NippyJarError::Custom(err.to_string()))
+                    }
+                }
+            }
+        }
+    }
+
+    fn compress_to(&self, src: &[u8], dest: &mut Vec<u8>) -> Result<usize, NippyJarError> {
+        let previous_length = dest.len();
+
+        // SAFETY: We're setting len to the existing capacity.
+        unsafe {
+            dest.set_len(dest.capacity());
+        }
+
+        match lz4_flex::compress_into(src, &mut dest[previous_length..]) {
+            Ok(written) => {
+                // SAFETY: `compress_into` can only write if there's enough capacity. Therefore, it
+                // shouldn't write more than our capacity.
+                unsafe {
+                    dest.set_len(previous_length + written);
+                }
+                Ok(written)
+            }
+            Err(_) => {
+                // SAFETY: we are resetting it to the previous value.
+                unsafe {
+                    dest.set_len(previous_length);
+                }
+                Err(NippyJarError::OutputTooSmall)
+            }
+        }
+    }
+
+    fn compress(&self, src: &[u8]) -> Result<Vec<u8>, NippyJarError> {
+        Ok(lz4_flex::compress(src))
+    }
+
+    fn is_ready(&self) -> bool {
+        true
+    }
+
+    /// If using it with dictionaries, prepares a dictionary for each column.
+    fn prepare_compression(
+        &mut self,
+        _columns: Vec<impl IntoIterator<Item = Vec<u8>>>,
+    ) -> Result<(), NippyJarError> {
+        Ok(())
+    }
+}

--- a/crates/storage/nippy-jar/src/compression/lz4.rs
+++ b/crates/storage/nippy-jar/src/compression/lz4.rs
@@ -3,14 +3,8 @@ use serde::{Deserialize, Serialize};
 
 /// Wrapper type for `lz4_flex` that implements [`Compression`].
 #[derive(Debug, PartialEq, Serialize, Deserialize, Default)]
+#[non_exhaustive]
 pub struct Lz4;
-
-impl Lz4 {
-    /// Creates new [`Lz4`].
-    pub fn new() -> Self {
-        Lz4 {}
-    }
-}
 
 impl Compression for Lz4 {
     fn decompress_to(&self, value: &[u8], dest: &mut Vec<u8>) -> Result<(), NippyJarError> {

--- a/crates/storage/nippy-jar/src/compression/lz4.rs
+++ b/crates/storage/nippy-jar/src/compression/lz4.rs
@@ -1,17 +1,14 @@
 use crate::{compression::Compression, NippyJarError};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-/// Lz4 compression structure.
-pub struct Lz4 {
-    /// Number of columns to compress.
-    columns: usize,
-}
+/// Wrapper type for `lz4_flex` that implements [`Compression`].
+#[derive(Debug, PartialEq, Serialize, Deserialize, Default)]
+pub struct Lz4;
 
 impl Lz4 {
     /// Creates new [`Lz4`].
-    pub fn new(columns: usize) -> Self {
-        Self { columns }
+    pub fn new() -> Self {
+        Lz4 {}
     }
 }
 
@@ -88,9 +85,5 @@ impl Compression for Lz4 {
 
     fn compress(&self, src: &[u8]) -> Result<Vec<u8>, NippyJarError> {
         Ok(lz4_flex::compress(src))
-    }
-
-    fn is_ready(&self) -> bool {
-        true
     }
 }

--- a/crates/storage/nippy-jar/src/compression/lz4.rs
+++ b/crates/storage/nippy-jar/src/compression/lz4.rs
@@ -2,7 +2,7 @@ use crate::{compression::Compression, NippyJarError};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
-/// Lz4 compression structure. Supports a compression dictionary per column.
+/// Lz4 compression structure.
 pub struct Lz4 {
     /// Number of columns to compress.
     columns: usize,
@@ -92,13 +92,5 @@ impl Compression for Lz4 {
 
     fn is_ready(&self) -> bool {
         true
-    }
-
-    /// If using it with dictionaries, prepares a dictionary for each column.
-    fn prepare_compression(
-        &mut self,
-        _columns: Vec<impl IntoIterator<Item = Vec<u8>>>,
-    ) -> Result<(), NippyJarError> {
-        Ok(())
     }
 }

--- a/crates/storage/nippy-jar/src/compression/mod.rs
+++ b/crates/storage/nippy-jar/src/compression/mod.rs
@@ -14,7 +14,8 @@ pub trait Compression: Serialize + for<'a> Deserialize<'a> {
     /// Returns decompressed data.
     fn decompress(&self, value: &[u8]) -> Result<Vec<u8>, NippyJarError>;
 
-    /// Appends compressed data from `src` to `dest`. `dest`. Requires `dest` to have sufficient capacity.
+    /// Appends compressed data from `src` to `dest`. `dest`. Requires `dest` to have sufficient
+    /// capacity.
     ///
     /// Returns number of bytes written to `dest`.
     fn compress_to(&self, src: &[u8], dest: &mut Vec<u8>) -> Result<usize, NippyJarError>;
@@ -44,8 +45,6 @@ pub trait Compression: Serialize + for<'a> Deserialize<'a> {
 pub enum Compressors {
     Zstd(Zstd),
     Lz4(Lz4),
-    // Avoids irrefutable let errors. Remove this after adding another one.
-    Unused,
 }
 
 impl Compression for Compressors {
@@ -53,14 +52,12 @@ impl Compression for Compressors {
         match self {
             Compressors::Zstd(zstd) => zstd.decompress_to(value, dest),
             Compressors::Lz4(lz4) => lz4.decompress_to(value, dest),
-            Compressors::Unused => unimplemented!(),
         }
     }
     fn decompress(&self, value: &[u8]) -> Result<Vec<u8>, NippyJarError> {
         match self {
             Compressors::Zstd(zstd) => zstd.decompress(value),
             Compressors::Lz4(lz4) => lz4.decompress(value),
-            Compressors::Unused => unimplemented!(),
         }
     }
 
@@ -70,7 +67,6 @@ impl Compression for Compressors {
             let result = match self {
                 Compressors::Zstd(zstd) => zstd.compress_to(src, dest),
                 Compressors::Lz4(lz4) => lz4.compress_to(src, dest),
-                Compressors::Unused => unimplemented!(),
             };
 
             match result {
@@ -89,7 +85,6 @@ impl Compression for Compressors {
         match self {
             Compressors::Zstd(zstd) => zstd.compress(src),
             Compressors::Lz4(lz4) => lz4.compress(src),
-            Compressors::Unused => unimplemented!(),
         }
     }
 
@@ -97,7 +92,6 @@ impl Compression for Compressors {
         match self {
             Compressors::Zstd(zstd) => zstd.is_ready(),
             Compressors::Lz4(lz4) => lz4.is_ready(),
-            Compressors::Unused => unimplemented!(),
         }
     }
 
@@ -108,7 +102,6 @@ impl Compression for Compressors {
         match self {
             Compressors::Zstd(zstd) => zstd.prepare_compression(columns),
             Compressors::Lz4(lz4) => lz4.prepare_compression(columns),
-            Compressors::Unused => Ok(()),
         }
     }
 }

--- a/crates/storage/nippy-jar/src/compression/mod.rs
+++ b/crates/storage/nippy-jar/src/compression/mod.rs
@@ -15,6 +15,8 @@ pub trait Compression: Serialize + for<'a> Deserialize<'a> {
     fn decompress(&self, value: &[u8]) -> Result<Vec<u8>, NippyJarError>;
 
     /// Appends compressed data from `src` to `dest`. `dest` should be allocated with enough memory.
+    /// 
+    /// Returns number of bytes written to `dest`.
     fn compress_to(&self, src: &[u8], dest: &mut Vec<u8>) -> Result<usize, NippyJarError>;
 
     /// Compresses data from `src`

--- a/crates/storage/nippy-jar/src/compression/mod.rs
+++ b/crates/storage/nippy-jar/src/compression/mod.rs
@@ -8,13 +8,13 @@ pub use self::lz4::Lz4;
 
 /// Trait that will compress column values
 pub trait Compression: Serialize + for<'a> Deserialize<'a> {
-    /// Appends decompressed data to the dest buffer. `dest` should be allocated with enough memory.
+    /// Appends decompressed data to the dest buffer. Requires `dest` to have sufficient capacity.
     fn decompress_to(&self, value: &[u8], dest: &mut Vec<u8>) -> Result<(), NippyJarError>;
 
     /// Returns decompressed data.
     fn decompress(&self, value: &[u8]) -> Result<Vec<u8>, NippyJarError>;
 
-    /// Appends compressed data from `src` to `dest`. `dest` should be allocated with enough memory.
+    /// Appends compressed data from `src` to `dest`. `dest`. Requires `dest` to have sufficient capacity.
     ///
     /// Returns number of bytes written to `dest`.
     fn compress_to(&self, src: &[u8], dest: &mut Vec<u8>) -> Result<usize, NippyJarError>;

--- a/crates/storage/nippy-jar/src/compression/mod.rs
+++ b/crates/storage/nippy-jar/src/compression/mod.rs
@@ -15,7 +15,7 @@ pub trait Compression: Serialize + for<'a> Deserialize<'a> {
     fn decompress(&self, value: &[u8]) -> Result<Vec<u8>, NippyJarError>;
 
     /// Appends compressed data from `src` to `dest`. `dest` should be allocated with enough memory.
-    /// 
+    ///
     /// Returns number of bytes written to `dest`.
     fn compress_to(&self, src: &[u8], dest: &mut Vec<u8>) -> Result<usize, NippyJarError>;
 

--- a/crates/storage/nippy-jar/src/compression/zstd.rs
+++ b/crates/storage/nippy-jar/src/compression/zstd.rs
@@ -100,10 +100,10 @@ impl Zstd {
         }
     }
 
-    /// Compresses a value using a dictionary. Reserves additional capacity for `tmp_buf` if necessary.
+    /// Compresses a value using a dictionary. Reserves additional capacity for `buffer` if necessary.
     pub fn compress_with_dictionary(
         column_value: &[u8],
-        tmp_buf: &mut Vec<u8>,
+        buffer: &mut Vec<u8>,
         handle: &mut File,
         compressor: Option<&mut Compressor<'_>>,
     ) -> Result<(), NippyJarError> {
@@ -113,16 +113,16 @@ impl Zstd {
             // enough, the compressed buffer will actually be larger. We keep retrying.
             // If we eventually fail, it probably means it's another kind of error.
             let mut multiplier = 1;
-            while let Err(err) = compressor.compress_to_buffer(column_value, tmp_buf) {
-                tmp_buf.reserve(column_value.len() * multiplier);
+            while let Err(err) = compressor.compress_to_buffer(column_value, buffer) {
+                buffer.reserve(column_value.len() * multiplier);
                 multiplier += 1;
                 if multiplier == 5 {
                     return Err(NippyJarError::Disconnect(err))
                 }
             }
 
-            handle.write_all(tmp_buf)?;
-            tmp_buf.clear();
+            handle.write_all(buffer)?;
+            buffer.clear();
         } else {
             handle.write_all(column_value)?;
         }

--- a/crates/storage/nippy-jar/src/compression/zstd.rs
+++ b/crates/storage/nippy-jar/src/compression/zstd.rs
@@ -100,7 +100,8 @@ impl Zstd {
         }
     }
 
-    /// Compresses a value using a dictionary. Reserves additional capacity for `buffer` if necessary.
+    /// Compresses a value using a dictionary. Reserves additional capacity for `buffer` if
+    /// necessary.
     pub fn compress_with_dictionary(
         column_value: &[u8],
         buffer: &mut Vec<u8>,

--- a/crates/storage/nippy-jar/src/compression/zstd.rs
+++ b/crates/storage/nippy-jar/src/compression/zstd.rs
@@ -100,7 +100,7 @@ impl Zstd {
         }
     }
 
-    /// Compresses a value using a dictionary.
+    /// Compresses a value using a dictionary. Reserves additional capacity for `tmp_buf` if necessary.
     pub fn compress_with_dictionary(
         column_value: &[u8],
         tmp_buf: &mut Vec<u8>,

--- a/crates/storage/nippy-jar/src/compression/zstd.rs
+++ b/crates/storage/nippy-jar/src/compression/zstd.rs
@@ -5,10 +5,8 @@ use std::{
     io::{Read, Write},
 };
 use tracing::*;
-use zstd::{
-    bulk::{Compressor, Decompressor},
-    dict::DecoderDictionary,
-};
+use zstd::bulk::Compressor;
+pub use zstd::{bulk::Decompressor, dict::DecoderDictionary};
 
 type RawDictionary = Vec<u8>;
 
@@ -27,7 +25,7 @@ pub struct Zstd {
     /// Compression level. A level of `0` uses zstd's default (currently `3`).
     pub(crate) level: i32,
     /// Uses custom dictionaries to compress data.
-    pub(crate) use_dict: bool,
+    pub use_dict: bool,
     /// Max size of a dictionary
     pub(crate) max_dict_size: usize,
     /// List of column dictionaries.
@@ -132,38 +130,46 @@ impl Zstd {
         Ok(())
     }
 
-    /// Decompresses a value using a dictionary to a user provided buffer.
+    /// Appends a decompressed value using a dictionary to a user provided buffer.
     pub fn decompress_with_dictionary(
         column_value: &[u8],
         output: &mut Vec<u8>,
         decompressor: &mut Decompressor<'_>,
     ) -> Result<(), NippyJarError> {
-        let mut multiplier = 1;
+        let previous_length = output.len();
 
-        // Just an estimation.
-        let required_capacity = column_value.len() * 2;
-
-        output.reserve(required_capacity.saturating_sub(output.capacity()));
-
-        // Decompressor requires the destination buffer to be big enough to write to, otherwise it
-        // fails. However, we don't know how big it will be. We keep retrying.
-        // If we eventually fail, it probably means it's another kind of error.
-        while let Err(err) = decompressor.decompress_to_buffer(column_value, output) {
-            output.reserve(
-                Decompressor::upper_bound(column_value).unwrap_or(required_capacity) * multiplier,
-            );
-
-            multiplier += 1;
-            if multiplier == 5 {
-                return Err(NippyJarError::Disconnect(err))
-            }
+        // SAFETY: We're setting len to the existing capacity.
+        unsafe {
+            output.set_len(output.capacity());
         }
 
-        Ok(())
+        match decompressor.decompress_to_buffer(column_value, &mut output[previous_length..]) {
+            Ok(written) => {
+                // SAFETY: `decompress_to_buffer` can only write if there's enough capacity.
+                // Therefore, it shouldn't write more than our capacity.
+                unsafe {
+                    output.set_len(previous_length + written);
+                }
+                Ok(())
+            }
+            Err(_) => {
+                // SAFETY: we are resetting it to the previous value.
+                unsafe {
+                    output.set_len(previous_length);
+                }
+                Err(NippyJarError::OutputTooSmall)
+            }
+        }
     }
 }
 
 impl Compression for Zstd {
+    fn decompress_to(&self, value: &[u8], dest: &mut Vec<u8>) -> Result<(), NippyJarError> {
+        let mut decoder = zstd::Decoder::with_dictionary(value, &[])?;
+        decoder.read_to_end(dest)?;
+        Ok(())
+    }
+
     fn decompress(&self, value: &[u8]) -> Result<Vec<u8>, NippyJarError> {
         let mut decompressed = Vec::with_capacity(value.len() * 2);
         let mut decoder = zstd::Decoder::new(value)?;
@@ -171,13 +177,15 @@ impl Compression for Zstd {
         Ok(decompressed)
     }
 
-    fn compress_to<W: Write>(&self, src: &[u8], dest: &mut W) -> Result<(), NippyJarError> {
+    fn compress_to(&self, src: &[u8], dest: &mut Vec<u8>) -> Result<usize, NippyJarError> {
+        let before = dest.len();
+
         let mut encoder = zstd::Encoder::new(dest, self.level)?;
         encoder.write_all(src)?;
 
-        encoder.finish()?;
+        let dest = encoder.finish()?;
 
-        Ok(())
+        Ok(dest.len() - before)
     }
 
     fn compress(&self, src: &[u8]) -> Result<Vec<u8>, NippyJarError> {

--- a/crates/storage/nippy-jar/src/cursor.rs
+++ b/crates/storage/nippy-jar/src/cursor.rs
@@ -52,6 +52,7 @@ where
             zstd_decompressors,
             file_handle: file,
             mmap_handle: mmap,
+            // Makes sure that we have enough buffer capacity to decompress any row of data.
             internal_buffer: Vec::with_capacity(jar.max_row_size),
             row: 0,
         })

--- a/crates/storage/nippy-jar/src/cursor.rs
+++ b/crates/storage/nippy-jar/src/cursor.rs
@@ -229,7 +229,7 @@ where
             let to = self.internal_buffer.len();
 
             row.push(ValueRange::Internal(from..to));
-        } else if let Some(compression) = &self.jar.compressor {
+        } else if let Some(compression) = self.jar.compressor() {
             // Uses the chosen default decompressor
             let from = self.internal_buffer.len();
             compression

--- a/crates/storage/nippy-jar/src/cursor.rs
+++ b/crates/storage/nippy-jar/src/cursor.rs
@@ -181,7 +181,6 @@ where
         }
 
         let mut row = Vec::with_capacity(COLUMNS);
-        self.internal_buffer.clear();
 
         for column in 0..COLUMNS {
             if MASK & (1 << column) != 0 {
@@ -233,7 +232,8 @@ where
         } else if let Some(compression) = &self.jar.compressor {
             // Uses the chosen default decompressor
             let from = self.internal_buffer.len();
-            compression.decompress_to(&self.mmap_handle[column_offset_range], &mut self.internal_buffer)?;
+            compression
+                .decompress_to(&self.mmap_handle[column_offset_range], &mut self.internal_buffer)?;
             let to = self.internal_buffer.len();
 
             row.push(ValueRange::Internal(from..to));

--- a/crates/storage/nippy-jar/src/cursor.rs
+++ b/crates/storage/nippy-jar/src/cursor.rs
@@ -53,7 +53,7 @@ where
             zstd_decompressors,
             file_handle: file,
             mmap_handle: mmap,
-            tmp_buf: Vec::with_capacity(1_000_000),
+            tmp_buf: Vec::with_capacity(jar.max_row_size),
             row: 0,
         })
     }

--- a/crates/storage/nippy-jar/src/error.rs
+++ b/crates/storage/nippy-jar/src/error.rs
@@ -7,6 +7,8 @@ pub enum NippyJarError {
     Internal(#[from] Box<dyn std::error::Error + Send + Sync>),
     #[error(transparent)]
     Disconnect(#[from] std::io::Error),
+    #[error("{0}")]
+    Custom(String),
     #[error(transparent)]
     Bincode(#[from] Box<bincode::ErrorKind>),
     #[error(transparent)]
@@ -33,4 +35,6 @@ pub enum NippyJarError {
     PHFMissing,
     #[error("NippyJar was built without an index.")]
     UnsupportedFilterQuery,
+    #[error("Compression or decompression requires a bigger destination output.")]
+    OutputTooSmall,
 }

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -97,7 +97,7 @@ pub struct NippyJar<H = ()> {
     /// Offsets within the file for each column value, arranged by row and column.
     #[serde(skip)]
     offsets: EliasFano,
-    /// Maximum uncompressed row size. This will enable decompression without any resizing of the
+    /// Maximum uncompressed row size of the set. This will enable decompression without any resizing of the
     /// output buffer.
     #[serde(skip)]
     max_row_size: usize,

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -97,8 +97,8 @@ pub struct NippyJar<H = ()> {
     /// Offsets within the file for each column value, arranged by row and column.
     #[serde(skip)]
     offsets: EliasFano,
-    /// Maximum uncompressed row size of the set. This will enable decompression without any resizing of the
-    /// output buffer.
+    /// Maximum uncompressed row size of the set. This will enable decompression without any
+    /// resizing of the output buffer.
     #[serde(skip)]
     max_row_size: usize,
     /// Data path for file. Index file will be `{path}.idx`

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -44,7 +44,8 @@ pub use cursor::NippyJarCursor;
 
 const NIPPY_JAR_VERSION: usize = 1;
 
-/// A [`RefRow`] is a list of column value slices pointing to either an internal buffer or a memory-mapped file.
+/// A [`RefRow`] is a list of column value slices pointing to either an internal buffer or a
+/// memory-mapped file.
 type RefRow<'a> = Vec<&'a [u8]>;
 
 /// Alias type for a column value wrapped in `Result`

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -44,8 +44,8 @@ pub use cursor::NippyJarCursor;
 
 const NIPPY_JAR_VERSION: usize = 1;
 
-/// A [`Row`] is a list of its selected column values.
-type Row<'a> = Vec<&'a [u8]>;
+/// A [`RefRow`] is a list of column value slices pointing to either an internal buffer or a memory-mapped file.
+type RefRow<'a> = Vec<&'a [u8]>;
 
 /// Alias type for a column value wrapped in `Result`
 pub type ColumnResult<T> = Result<T, Box<dyn StdError + Send + Sync>>;

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -171,7 +171,7 @@ where
 
     /// Adds [`compression::Lz4`] compression.
     pub fn with_lz4(mut self) -> Self {
-        self.compressor = Some(Compressors::Lz4(compression::Lz4::new(self.columns)));
+        self.compressor = Some(Compressors::Lz4(compression::Lz4::new()));
         self
     }
 

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -171,7 +171,7 @@ where
 
     /// Adds [`compression::Lz4`] compression.
     pub fn with_lz4(mut self) -> Self {
-        self.compressor = Some(Compressors::Lz4(compression::Lz4::new()));
+        self.compressor = Some(Compressors::Lz4(compression::Lz4::default()));
         self
     }
 

--- a/crates/storage/provider/src/providers/snapshot.rs
+++ b/crates/storage/provider/src/providers/snapshot.rs
@@ -3,25 +3,36 @@ use reth_db::{
     table::{Decompress, Table},
     HeaderTD,
 };
-use reth_interfaces::RethResult;
-use reth_nippy_jar::{NippyJar, NippyJarCursor};
+use reth_interfaces::{provider::ProviderError, RethResult};
+use reth_nippy_jar::{compression::Decompressor, NippyJar, NippyJarCursor};
 use reth_primitives::{BlockHash, BlockNumber, Header, SealedHeader, U256};
 use std::ops::RangeBounds;
 
 /// SnapshotProvider
 ///
-///  WIP Rudimentary impl just for testes
+///  WIP Rudimentary impl just for tests
 /// TODO: should be able to walk through snapshot files/block_ranges
 /// TODO: Arc over NippyJars and/or NippyJarCursors (LRU)
 #[derive(Debug)]
 pub struct SnapshotProvider<'a> {
     /// NippyJar
     pub jar: &'a NippyJar,
+    /// Starting snapshot block
+    pub jar_start_block: u64,
 }
 
 impl<'a> SnapshotProvider<'a> {
-    fn cursor(&self) -> NippyJarCursor<'a> {
+    /// Creates cursor
+    pub fn cursor(&self) -> NippyJarCursor<'a> {
         NippyJarCursor::new(self.jar, None).unwrap()
+    }
+
+    /// Creates cursor with zstd decompressors
+    pub fn cursor_with_decompressors(
+        &self,
+        decompressors: Vec<Decompressor<'a>>,
+    ) -> NippyJarCursor<'a> {
+        NippyJarCursor::new(self.jar, Some(decompressors)).unwrap()
     }
 }
 
@@ -31,7 +42,7 @@ impl<'a> HeaderProvider for SnapshotProvider<'a> {
         let mut cursor = self.cursor();
 
         let header = Header::decompress(
-            &cursor.row_by_key_with_cols::<0b01, 2>(&block_hash.0).unwrap().unwrap()[0],
+            cursor.row_by_key_with_cols::<0b01, 2>(&block_hash.0).unwrap().unwrap()[0],
         )
         .unwrap();
 
@@ -43,8 +54,14 @@ impl<'a> HeaderProvider for SnapshotProvider<'a> {
         Ok(None)
     }
 
-    fn header_by_number(&self, _num: BlockNumber) -> RethResult<Option<Header>> {
-        unimplemented!();
+    fn header_by_number(&self, num: BlockNumber) -> RethResult<Option<Header>> {
+        Header::decompress(
+            self.cursor()
+                .row_by_number_with_cols::<0b01, 2>((num - self.jar_start_block) as usize)?
+                .ok_or(ProviderError::HeaderNotFound(num.into()))?[0],
+        )
+        .map(Some)
+        .map_err(Into::into)
     }
 
     fn header_td(&self, block_hash: &BlockHash) -> RethResult<Option<U256>> {
@@ -53,8 +70,8 @@ impl<'a> HeaderProvider for SnapshotProvider<'a> {
 
         let row = cursor.row_by_key_with_cols::<0b11, 2>(&block_hash.0).unwrap().unwrap();
 
-        let header = Header::decompress(&row[0]).unwrap();
-        let td = <HeaderTD as Table>::Value::decompress(&row[1]).unwrap();
+        let header = Header::decompress(row[0]).unwrap();
+        let td = <HeaderTD as Table>::Value::decompress(row[1]).unwrap();
 
         if &header.hash_slow() == block_hash {
             return Ok(Some(td.0))
@@ -180,7 +197,7 @@ mod test {
             let jar = NippyJar::load_without_header(snap_file.path()).unwrap();
 
             let db_provider = factory.provider().unwrap();
-            let snap_provider = SnapshotProvider { jar: &jar };
+            let snap_provider = SnapshotProvider { jar: &jar, jar_start_block: 0 };
 
             assert!(!headers.is_empty());
 


### PR DESCRIPTION
stacking into #4889 

There are a couple crucial changes here.

* Adds `lz4` compression. 
* `NippyJarCursor` now returns a row as a list of slices of its inner buffer (if compressed) or slices of the mmap handle (if uncompressed). Each slice is a column value. Avoids copying data unnecessarily and assumes we're going to decode it straightaway (which is the case).
* `NippyJar` saves the maximum uncompressed row size. This way, `NippyJarCursor` can safely set an appropriate capacity to its internal buffer.
* If compressed, `next_row()` decompresses and appends all column values to the same internal buffer. On the beginning of the following `next_row()`, internal buffer is cleared. (thank you rust borrow checker <3 )

Please take special attention to the `unsafe` brackets.  Two reasons for them:
* `lz4` takes a `mut &[u8]` in its `decompress_to` implementation, and internally calls `.len()` to check if it's big enough. So we can't rely on a `Vec.capacity()`.
* `zstd_safe::decompress_to_buffer` overwrites instead of appending to `self.internal_buffer` vector.
