### PR TITLE
refactor: move broadcast channel init into tree

### DIFF
--- a/crates/blockchain-tree/Cargo.toml
+++ b/crates/blockchain-tree/Cargo.toml
@@ -25,6 +25,7 @@ reth-stages = { path = "../stages" }
 parking_lot.workspace = true
 lru = "0.11"
 tracing.workspace = true
+tokio = { workspace = true, features = ["macros", "sync"] }
 
 # metrics
 reth-metrics = { workspace = true, features = ["common"] }
@@ -41,7 +42,6 @@ reth-primitives = { workspace = true , features = ["test-utils"] }
 reth-provider = { workspace = true, features = ["test-utils"] }
 parking_lot.workspace = true
 assert_matches.workspace = true
-tokio = { workspace = true, features = ["macros", "sync"] }
 
 [features]
 test-utils = []

--- a/crates/consensus/beacon/src/engine/test_utils.rs
+++ b/crates/consensus/beacon/src/engine/test_utils.rs
@@ -506,10 +506,8 @@ where
             self.base_config.chain_spec.clone(),
         );
         let config = BlockchainTreeConfig::new(1, 2, 3, 2);
-        let (canon_state_notification_sender, _) = tokio::sync::broadcast::channel(3);
         let tree = ShareableBlockchainTree::new(
-            BlockchainTree::new(externals, canon_state_notification_sender, config, None)
-                .expect("failed to create tree"),
+            BlockchainTree::new(externals, config, None).expect("failed to create tree"),
         );
         let shareable_db = ProviderFactory::new(db.clone(), self.base_config.chain_spec.clone());
         let latest = self.base_config.chain_spec.genesis_header().seal_slow();


### PR DESCRIPTION
the broadcast channel can be created inside the tree.

this makes it easier to call `new`