### PR TITLE
refactor: simplify RethNodeCommandConfig trait

### DIFF
--- a/bin/reth/src/cli/components.rs
+++ b/bin/reth/src/cli/components.rs
@@ -1,0 +1,119 @@
+//! Components that are used by the node command.
+
+use reth_network_api::{NetworkInfo, Peers};
+use reth_primitives::ChainSpec;
+use reth_provider::{
+    AccountReader, BlockReaderIdExt, CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader,
+    EvmEnvProvider, StateProviderFactory,
+};
+use reth_tasks::TaskSpawner;
+use reth_transaction_pool::TransactionPool;
+use std::sync::Arc;
+
+/// Helper trait to unify all provider traits for simplicity.
+pub trait FullProvider:
+    BlockReaderIdExt
+    + AccountReader
+    + StateProviderFactory
+    + EvmEnvProvider
+    + ChainSpecProvider
+    + ChangeSetReader
+    + Clone
+    + Unpin
+    + 'static
+{
+}
+
+impl<T> FullProvider for T where
+    T: BlockReaderIdExt
+        + AccountReader
+        + StateProviderFactory
+        + EvmEnvProvider
+        + ChainSpecProvider
+        + ChangeSetReader
+        + Clone
+        + Unpin
+        + 'static
+{
+}
+
+/// The trait that is implemented for the Node command.
+pub trait RethNodeComponents {
+    /// The Provider type that is provided by the not itself
+    type Provider: FullProvider;
+    /// The transaction pool type
+    type Pool: TransactionPool + Clone + Unpin + 'static;
+    /// The network type used to communicate with p2p.
+    type Network: NetworkInfo + Peers + Clone + 'static;
+    /// The events type used to create subscriptions.
+    type Events: CanonStateSubscriptions + Clone + 'static;
+    /// The type that is used to spawn tasks.
+    type Tasks: TaskSpawner + Clone + Unpin + 'static;
+
+    /// Returns the instance of the provider
+    fn provider(&self) -> Self::Provider;
+
+    /// Returns the instance of the task executor.
+    fn task_executor(&self) -> Self::Tasks;
+
+    /// Returns the instance of the transaction pool.
+    fn pool(&self) -> Self::Pool;
+
+    /// Returns the instance of the network API.
+    fn network(&self) -> Self::Network;
+
+    /// Returns the instance of the events subscription handler.
+    fn events(&self) -> Self::Events;
+
+    /// Helper function to return the chain spec.
+    fn chain_spec(&self) -> Arc<ChainSpec> {
+        self.provider().chain_spec()
+    }
+}
+
+/// A Generic implementation of the RethNodeComponents trait.
+#[derive(Clone, Debug)]
+#[allow(missing_docs)]
+pub struct RethNodeComponentsImpl<Provider, Pool, Network, Events, Tasks> {
+    pub provider: Provider,
+    pub pool: Pool,
+    pub network: Network,
+    pub task_executor: Tasks,
+    pub events: Events,
+}
+
+impl<Provider, Pool, Network, Events, Tasks> RethNodeComponents
+    for RethNodeComponentsImpl<Provider, Pool, Network, Events, Tasks>
+where
+    Provider: FullProvider + Clone + 'static,
+    Tasks: TaskSpawner + Clone + Unpin + 'static,
+    Pool: TransactionPool + Clone + Unpin + 'static,
+    Network: NetworkInfo + Peers + Clone + 'static,
+    Events: CanonStateSubscriptions + Clone + 'static,
+{
+    type Provider = Provider;
+    type Pool = Pool;
+    type Network = Network;
+    type Events = Events;
+    type Tasks = Tasks;
+
+    fn provider(&self) -> Self::Provider {
+        self.provider.clone()
+    }
+
+    fn task_executor(&self) -> Self::Tasks {
+        self.task_executor.clone()
+    }
+
+    fn pool(&self) -> Self::Pool {
+        self.pool.clone()
+    }
+
+    fn network(&self) -> Self::Network {
+        self.network.clone()
+    }
+
+    fn events(&self) -> Self::Events {
+        self.events.clone()
+    }
+}

--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -19,6 +19,7 @@ use reth_tracing::{
 };
 use std::{fmt, fmt::Display, sync::Arc};
 
+pub mod components;
 pub mod config;
 pub mod ext;
 

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -9,6 +9,7 @@ use crate::{
         RpcServerArgs, TxPoolArgs,
     },
     cli::{
+        components::RethNodeComponentsImpl,
         config::RethRpcConfig,
         ext::{RethCliExt, RethNodeCommandConfig},
     },
@@ -352,17 +353,19 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
         debug!(target: "reth::cli", peer_id = ?network.peer_id(), "Full peer ID");
         let network_client = network.fetch_client().await?;
 
-        let (consensus_engine_tx, consensus_engine_rx) = unbounded_channel();
+        let components = RethNodeComponentsImpl {
+            provider: blockchain_db.clone(),
+            pool: transaction_pool.clone(),
+            network: network.clone(),
+            task_executor: ctx.task_executor.clone(),
+            events: blockchain_db.clone(),
+        };
+        self.ext.on_components_initialized(&components)?;
 
         debug!(target: "reth::cli", "Spawning payload builder service");
-        let payload_builder = self.ext.spawn_payload_builder_service(
-            &self.builder,
-            blockchain_db.clone(),
-            transaction_pool.clone(),
-            ctx.task_executor.clone(),
-            Arc::clone(&self.chain),
-        )?;
+        let payload_builder = self.ext.spawn_payload_builder_service(&self.builder, &components)?;
 
+        let (consensus_engine_tx, consensus_engine_rx) = unbounded_channel();
         let max_block = if let Some(block) = self.debug.max_block {
             Some(block)
         } else if let Some(tip) = self.debug.tip {
@@ -530,19 +533,8 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
         self.adjust_instance_ports();
 
         // Start RPC servers
-        let (_rpc_server, _auth_server) = self
-            .rpc
-            .start_servers(
-                blockchain_db.clone(),
-                transaction_pool.clone(),
-                network.clone(),
-                ctx.task_executor.clone(),
-                blockchain_tree,
-                engine_api,
-                jwt_secret,
-                &mut self.ext,
-            )
-            .await?;
+        let (_rpc_server, _auth_server) =
+            self.rpc.start_servers(&components, engine_api, jwt_secret, &mut self.ext).await?;
 
         // Run consensus engine to completion
         let (tx, rx) = oneshot::channel();
@@ -551,6 +543,8 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
             let res = beacon_consensus_engine.await;
             let _ = tx.send(res);
         });
+
+        self.ext.on_node_started(&components)?;
 
         rx.await??;
 


### PR DESCRIPTION
this includes a few changes to the RethNodeCommandConfig trait to make it slightly easier to use:

* bundle all components into a trait this gets rid of a lot of trait mess (this can be further expanded so that we eventually support custom pools etc)
* add new functions that serve as event hook for when components are initialized