### PR TITLE
fix(disc) Send find_node request only after verifiying our endpoint proof

### DIFF
--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -2313,7 +2313,6 @@ mod tests {
 
         let config = Discv4Config::builder().build();
         let (_discv4, mut service) = create_discv4_with_config(config.clone()).await;
-        let (_discv4, service2) = create_discv4_with_config(config).await;
 
         let id = PeerId::random();
         let key = kad_key(id);
@@ -2522,7 +2521,7 @@ mod tests {
 
         let config = Discv4Config::builder().external_ip_resolver(None).build();
         let (_discv4, mut service_1) = create_discv4_with_config(config.clone()).await;
-        let (_discv4, mut service_2) = create_discv4_with_config(config.clone()).await;
+        let (_discv4, mut service_2) = create_discv4_with_config(config).await;
 
         // send ping from 1 -> 2
         service_1.add_node(service_2.local_node_record);


### PR DESCRIPTION
related to #4893 

this PR adds support for the case where:
- recursive lookup has been started
- node is encountered that is Absent from our Ktable
- ping is sent to that node to start endpoint verification
- `on_pong` we add the lookup context for that node to a `pending_lookup` table
- we wait for`on_ping`, we send a pong (our endpoint proof), and attempt to send `find_node` if the node exists in the `pending_lookup` table

