### PR TITLE
fix: add blob_gas_used after succesful tx execution

### DIFF
--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -743,7 +743,6 @@ where
             }
         };
 
-        let gas_used = result.gas_used();
         // commit changes
         db.commit(state);
 
@@ -757,6 +756,8 @@ where
                 best_txs.skip_blobs();
             }
         }
+
+        let gas_used = result.gas_used();
 
         // add gas used by the transaction to cumulative gas used, before creating the receipt
         cumulative_gas_used += gas_used;

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -747,7 +747,7 @@ where
         // commit changes
         db.commit(state);
 
-        // add to the blob gas if we're going to execute the transaction
+        // add to the total blob gas used if the transaction successfully executed
         if let Some(blob_tx) = tx.transaction.as_eip4844() {
             let tx_blob_gas = blob_tx.blob_gas();
             sum_blob_gas_used += tx_blob_gas;

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -705,14 +705,6 @@ where
                 // the gas limit condition for regular transactions above.
                 best_txs.mark_invalid(&pool_tx);
                 continue
-            } else {
-                // add to the data gas if we're going to execute the transaction
-                sum_blob_gas_used += tx_blob_gas;
-
-                // if we've reached the max data gas per block, we can skip blob txs entirely
-                if sum_blob_gas_used == MAX_DATA_GAS_PER_BLOCK {
-                    best_txs.skip_blobs();
-                }
             }
         }
 
@@ -740,6 +732,7 @@ where
                             trace!(?err, ?tx, "skipping invalid transaction and its descendants");
                             best_txs.mark_invalid(&pool_tx);
                         }
+
                         continue
                     }
                     err => {
@@ -753,6 +746,17 @@ where
         let gas_used = result.gas_used();
         // commit changes
         db.commit(state);
+
+        // add to the blob gas if we're going to execute the transaction
+        if let Some(blob_tx) = tx.transaction.as_eip4844() {
+            let tx_blob_gas = blob_tx.blob_gas();
+            sum_blob_gas_used += tx_blob_gas;
+
+            // if we've reached the max data gas per block, we can skip blob txs entirely
+            if sum_blob_gas_used == MAX_DATA_GAS_PER_BLOCK {
+                best_txs.skip_blobs();
+            }
+        }
 
         // add gas used by the transaction to cumulative gas used, before creating the receipt
         cumulative_gas_used += gas_used;


### PR DESCRIPTION
Previously we were adding `blob_gas_used`, even if the tx failed execution. This caused incorrect blob gas used returned in built payloads, since the payload would contain fewer blobs. This means a subsequent `engine_newPayload` would fail.

This makes sure we only add the `blob_gas_used` if the tx succeeded.

Fixes the hive engine `cancun/Blob Transaction Ordering, Single Account` tests.