### PR TITLE
fix: always serialize zero balance

### DIFF
--- a/crates/rpc/rpc-types/src/eth/trace/geth/pre_state.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/geth/pre_state.rs
@@ -78,7 +78,7 @@ impl AccountState {
     /// If code is empty, it will be omitted.
     pub fn from_account_info(nonce: u64, balance: U256, code: Option<Bytes>) -> Self {
         Self {
-            balance: (balance != U256::ZERO).then_some(balance),
+            balance: Some(balance),
             code: code.filter(|code| !code.is_empty()),
             nonce: (nonce != 0).then_some(nonce),
             storage: Default::default(),


### PR DESCRIPTION
balance is always serialized

https://github.com/ledgerwatch/erigon/blob/4bec348e627d7d7d95bb9469b566320cad6d4108/eth/tracers/native/prestate.go#L45-L45

omitempty for pointers only covers nil