### PR TITLE
fix: filter out unchanged account states in diff mode

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/builder/geth.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/geth.rs
@@ -223,6 +223,10 @@ impl GethTraceBuilder {
             }
             self.update_storage_from_trace(&mut state_diff.pre, false);
             self.update_storage_from_trace(&mut state_diff.post, true);
+
+            // ensure we're only keeping changed entries
+            state_diff.retain_changed();
+
             Ok(PreStateFrame::Diff(state_diff))
         }
     }


### PR DESCRIPTION
Closes #4930

filters out unchanged entries from the diffmode sets, since diffmode is supposed to only include changed account states