### PR TITLE
feat: add cli ext event hooks example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1279,6 +1279,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
+name = "cli-extension-event-hooks"
+version = "0.0.0"
+dependencies = [
+ "clap",
+ "eyre",
+ "reth",
+ "tokio",
+]
+
+[[package]]
 name = "cobs"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ members = [
     "crates/rpc/rpc-types-compat",
     "examples",
     "examples/additional-rpc-namespace-in-cli",
+    "examples/cli-extension-event-hooks",
     "examples/rpc-db",
     "examples/manual-p2p",
 ]

--- a/bin/reth/src/cli/ext.rs
+++ b/bin/reth/src/cli/ext.rs
@@ -8,7 +8,7 @@ use clap::Args;
 use reth_basic_payload_builder::{BasicPayloadJobGenerator, BasicPayloadJobGeneratorConfig};
 use reth_payload_builder::{PayloadBuilderHandle, PayloadBuilderService};
 use reth_tasks::TaskSpawner;
-use std::fmt;
+use std::{fmt, marker::PhantomData};
 
 /// A trait that allows for extending parts of the CLI with additional functionality.
 ///
@@ -119,6 +119,14 @@ impl RethNodeCommandConfig for DefaultRethNodeCommandConfig {}
 
 impl RethNodeCommandConfig for () {}
 
+/// A helper type for [RethCliExt] extension that don't require any additional clap Arguments.
+#[derive(Debug, Clone, Copy)]
+pub struct NoArgsCliExt<Conf>(PhantomData<Conf>);
+
+impl<Conf: RethNodeCommandConfig> RethCliExt for NoArgsCliExt<Conf> {
+    type Node = NoArgs<Conf>;
+}
+
 /// A helper struct that allows for wrapping a [RethNodeCommandConfig] value without providing
 /// additional CLI arguments.
 ///
@@ -211,6 +219,12 @@ impl<T: RethNodeCommandConfig> RethNodeCommandConfig for NoArgs<T> {
         self.inner_mut()
             .ok_or_else(|| eyre::eyre!("config value must be set"))?
             .spawn_payload_builder_service(conf, components)
+    }
+}
+
+impl<T> From<T> for NoArgs<T> {
+    fn from(value: T) -> Self {
+        Self::with(value)
     }
 }
 

--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -167,10 +167,11 @@ pub enum Commands<Ext: RethCliExt = ()> {
 
 impl<Ext: RethCliExt> Commands<Ext> {
     /// Sets the node extension if it is the [NodeCommand](node::NodeCommand).
+    ///
+    /// This is a noop if the command is not the [NodeCommand](node::NodeCommand).
     pub fn set_node_extension(&mut self, ext: Ext::Node) {
-        match self {
-            Commands::Node(command) => command.ext = ext,
-            _ => {}
+        if let Commands::Node(command) = self {
+            command.ext = ext
         }
     }
 }

--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -113,6 +113,15 @@ impl<Ext: RethCliExt> Cli<Ext> {
         reth_tracing::init(layers);
         Ok(guard.flatten())
     }
+
+    /// Configures the given node extension.
+    pub fn with_node_extension<C>(mut self, conf: C) -> Self
+    where
+        C: Into<Ext::Node>,
+    {
+        self.command.set_node_extension(conf.into());
+        self
+    }
 }
 
 /// Convenience function for parsing CLI options, set up logging and run the chosen command.
@@ -154,6 +163,16 @@ pub enum Commands<Ext: RethCliExt = ()> {
     /// Scripts for node recovery
     #[command(name = "recover")]
     Recover(recover::Command),
+}
+
+impl<Ext: RethCliExt> Commands<Ext> {
+    /// Sets the node extension if it is the [NodeCommand](node::NodeCommand).
+    pub fn set_node_extension(&mut self, ext: Ext::Node) {
+        match self {
+            Commands::Node(command) => command.ext = ext,
+            _ => {}
+        }
+    }
 }
 
 /// The log configuration.

--- a/examples/cli-extension-event-hooks/Cargo.toml
+++ b/examples/cli-extension-event-hooks/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "cli-extension-event-hooks"
+version = "0.0.0"
+publish = false
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+reth.workspace = true
+clap.workspace = true
+eyre = "0.6"

--- a/examples/cli-extension-event-hooks/src/main.rs
+++ b/examples/cli-extension-event-hooks/src/main.rs
@@ -1,0 +1,51 @@
+//! Example for how hook into the node via the CLI extension mechanism without registering
+//! additional arguments
+//!
+//! Run with
+//!
+//! ```not_rust
+//! cargo run -p cli-extension-event-hooks -- node
+//! ```
+//!
+//! This launch the regular reth node and also print:
+//!
+//! > "All components initialized"
+//! once all components have been initialized and
+//!
+//! > "Node started"
+//! once the node has been started.
+use clap::Parser;
+use reth::cli::{
+    components::RethNodeComponents,
+    ext::{NoArgsCliExt, RethNodeCommandConfig},
+    Cli,
+};
+
+fn main() {
+    Cli::<NoArgsCliExt<MyRethConfig>>::parse()
+        .with_node_extension(MyRethConfig::default())
+        .run()
+        .unwrap();
+}
+
+/// Our custom cli args extension that adds one flag to reth default CLI.
+#[derive(Debug, Clone, Copy, Default)]
+#[non_exhaustive]
+struct MyRethConfig;
+
+impl RethNodeCommandConfig for MyRethConfig {
+    fn on_components_initialized<Reth: RethNodeComponents>(
+        &mut self,
+        _components: &Reth,
+    ) -> eyre::Result<()> {
+        println!("All components initialized");
+        Ok(())
+    }
+    fn on_node_started<Reth: RethNodeComponents>(
+        &mut self,
+        _components: &Reth,
+    ) -> eyre::Result<()> {
+        println!("Node started");
+        Ok(())
+    }
+}


### PR DESCRIPTION
add an example for how to use the new reth config hooks with no additional cli arguments

This adds a `NoArgsCliExt` that makes it easier to configure a NodeConfig that doesn't take additional cli args