### PR TITLE
feat(prune): transactions segment

### DIFF
--- a/crates/primitives/src/prune/segment.rs
+++ b/crates/primitives/src/prune/segment.rs
@@ -18,6 +18,8 @@ pub enum PruneSegment {
     AccountHistory,
     /// Prune segment responsible for the `StorageChangeSet` and `StorageHistory` tables.
     StorageHistory,
+    /// Prune segment responsible for the `Transactions` and `TxSenders` tables.
+    Transactions,
 }
 
 /// PruneSegment error type.

--- a/crates/primitives/src/prune/segment.rs
+++ b/crates/primitives/src/prune/segment.rs
@@ -18,7 +18,7 @@ pub enum PruneSegment {
     AccountHistory,
     /// Prune segment responsible for the `StorageChangeSet` and `StorageHistory` tables.
     StorageHistory,
-    /// Prune segment responsible for the `Transactions` and `TxSenders` tables.
+    /// Prune segment responsible for the `Transactions` table.
     Transactions,
 }
 

--- a/crates/prune/src/pruner.rs
+++ b/crates/prune/src/pruner.rs
@@ -103,7 +103,7 @@ impl<DB: Database> Pruner<DB> {
         let mut segments = BTreeMap::new();
 
         // TODO(alexey): prune snapshotted segments of data (headers, transactions)
-        // let highest_snapshots = *self.highest_snapshots_tracker.borrow();
+        let highest_snapshots = *self.highest_snapshots_tracker.borrow();
 
         // Multiply `delete_limit` (number of row to delete per block) by number of blocks since
         // last pruner run. `previous_tip_block_number` is close to `tip_block_number`, usually
@@ -280,6 +280,38 @@ impl<DB: Database> Pruner<DB> {
                 prune_segment = ?PruneSegment::StorageHistory,
                 "No target block to prune"
             );
+        }
+
+        if let Some(snapshots) = highest_snapshots {
+            if let (Some(to_block), true) = (snapshots.transactions, delete_limit > 0) {
+                let prune_mode = PruneMode::Before(to_block + 1);
+                trace!(
+                    target: "pruner",
+                    prune_segment = ?PruneSegment::Transactions,
+                    %to_block,
+                    ?prune_mode,
+                    "Got target block to prune"
+                );
+
+                let segment_start = Instant::now();
+                let segment = segments::Transactions::default();
+                let output = segment.prune(&provider, PruneInput { to_block, delete_limit })?;
+                if let Some(checkpoint) = output.checkpoint {
+                    segment
+                        .save_checkpoint(&provider, checkpoint.as_prune_checkpoint(prune_mode))?;
+                }
+                self.metrics
+                    .get_prune_segment_metrics(PruneSegment::Transactions)
+                    .duration_seconds
+                    .record(segment_start.elapsed());
+
+                done = done && output.done;
+                delete_limit = delete_limit.saturating_sub(output.pruned);
+                segments.insert(
+                    PruneSegment::Transactions,
+                    (PruneProgress::from_done(output.done), output.pruned),
+                );
+            }
         }
 
         provider.commit()?;

--- a/crates/prune/src/segments/mod.rs
+++ b/crates/prune/src/segments/mod.rs
@@ -1,5 +1,8 @@
 mod receipts;
+mod transactions;
+
 pub(crate) use receipts::Receipts;
+pub(crate) use transactions::Transactions;
 
 use crate::PrunerError;
 use reth_db::database::Database;
@@ -91,7 +94,7 @@ impl PruneInput {
 }
 
 /// Segment pruning output, see [Segment::prune].
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub(crate) struct PruneOutput {
     /// `true` if pruning has been completed up to the target block, and `false` if there's more
     /// data to prune in further runs.
@@ -108,9 +111,15 @@ impl PruneOutput {
     pub(crate) fn done() -> Self {
         Self { done: true, pruned: 0, checkpoint: None }
     }
+
+    /// Returns a [PruneOutput] with `done = false`, `pruned = 0` and `checkpoint = None`.
+    /// Use when pruning is needed but cannot be done.
+    pub(crate) fn not_done() -> Self {
+        Self { done: false, pruned: 0, checkpoint: None }
+    }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub(crate) struct PruneOutputCheckpoint {
     /// Highest pruned block number. If it's [None], the pruning for block `0` is not finished yet.
     pub(crate) block_number: Option<BlockNumber>,

--- a/crates/prune/src/segments/mod.rs
+++ b/crates/prune/src/segments/mod.rs
@@ -111,12 +111,6 @@ impl PruneOutput {
     pub(crate) fn done() -> Self {
         Self { done: true, pruned: 0, checkpoint: None }
     }
-
-    /// Returns a [PruneOutput] with `done = false`, `pruned = 0` and `checkpoint = None`.
-    /// Use when pruning is needed but cannot be done.
-    pub(crate) fn not_done() -> Self {
-        Self { done: false, pruned: 0, checkpoint: None }
-    }
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/crates/prune/src/segments/transactions.rs
+++ b/crates/prune/src/segments/transactions.rs
@@ -2,12 +2,9 @@ use crate::{
     segments::{PruneInput, PruneOutput, PruneOutputCheckpoint, Segment},
     PrunerError,
 };
-use itertools::Itertools;
-use reth_db::{database::Database, table::Table, tables};
-use reth_interfaces::RethResult;
-use reth_primitives::{PruneSegment, TxNumber};
+use reth_db::{database::Database, tables};
+use reth_primitives::PruneSegment;
 use reth_provider::{DatabaseProviderRW, TransactionsProvider};
-use std::ops::RangeInclusive;
 use tracing::{instrument, trace};
 
 #[derive(Default)]
@@ -31,30 +28,14 @@ impl Segment for Transactions {
             }
         };
 
-        let delete_limit = input.delete_limit / 2;
-        if delete_limit == 0 {
-            // Nothing to do, `input.delete_limit` is less than 2, so we can't prune all
-            // transactions-related tables up to the same height
-            return Ok(PruneOutput::not_done())
-        }
-
-        let results = [
-            self.prune_table::<DB, tables::Transactions>(provider, tx_range.clone(), delete_limit)?,
-            self.prune_table::<DB, tables::TxSenders>(provider, tx_range, delete_limit)?,
-        ];
-
-        if !results.iter().map(|(_, _, last_pruned_block)| last_pruned_block).all_equal() {
-            return Err(PrunerError::InconsistentData(
-                "All transactions-related tables should be pruned up to the same height",
-            ))
-        }
-
-        let (done, pruned, last_pruned_transaction) = results.into_iter().fold(
-            (true, 0, 0),
-            |(total_done, total_pruned, _), (done, pruned, last_pruned_transaction)| {
-                (total_done && done, total_pruned + pruned, last_pruned_transaction)
-            },
-        );
+        let mut last_pruned_transaction = *tx_range.end();
+        let (pruned, done) = provider.prune_table_with_range::<tables::Transactions>(
+            tx_range,
+            input.delete_limit,
+            |_| false,
+            |row| last_pruned_transaction = row.0,
+        )?;
+        trace!(target: "pruner", %pruned, %done, "Pruned transactions");
 
         let last_pruned_block = provider
             .transaction_block(last_pruned_transaction)?
@@ -71,29 +52,6 @@ impl Segment for Transactions {
                 tx_number: Some(last_pruned_transaction),
             }),
         })
-    }
-}
-
-impl Transactions {
-    /// Prune one transactions-related table.
-    ///
-    /// Returns `done`, number of pruned rows and last pruned block number.
-    fn prune_table<DB: Database, T: Table<Key = TxNumber>>(
-        &self,
-        provider: &DatabaseProviderRW<'_, DB>,
-        range: RangeInclusive<TxNumber>,
-        delete_limit: usize,
-    ) -> RethResult<(bool, usize, TxNumber)> {
-        let mut last_pruned_transaction = *range.end();
-        let (pruned, done) = provider.prune_table_with_range::<T>(
-            range,
-            delete_limit,
-            |_| false,
-            |row| last_pruned_transaction = row.0,
-        )?;
-        trace!(target: "pruner", %pruned, %done, table = %T::NAME, "Pruned transactions");
-
-        Ok((done, pruned, last_pruned_transaction))
     }
 }
 
@@ -120,23 +78,9 @@ mod tests {
         let blocks = random_block_range(&mut rng, 1..=100, B256::ZERO, 2..3);
         tx.insert_blocks(blocks.iter(), None).expect("insert blocks");
 
-        let transactions = blocks
-            .iter()
-            .flat_map(|block| &block.body)
-            .map(|transaction| transaction.try_ecrecovered())
-            .collect::<Option<Vec<_>>>()
-            .expect("recover transaction senders");
-
-        tx.insert_transaction_senders(
-            transactions
-                .iter()
-                .enumerate()
-                .map(|(i, transaction)| (i as u64, transaction.signer())),
-        )
-        .expect("insert transaction senders");
+        let transactions = blocks.iter().flat_map(|block| &block.body).collect::<Vec<_>>();
 
         assert_eq!(tx.table::<tables::Transactions>().unwrap().len(), transactions.len());
-        assert_eq!(tx.table::<tables::TxSenders>().unwrap().len(), transactions.len());
 
         let test_prune = |to_block: BlockNumber, expected_result: (bool, usize)| {
             let prune_mode = PruneMode::Before(to_block);
@@ -171,7 +115,7 @@ mod tests {
                 .take(to_block as usize)
                 .map(|block| block.body.len())
                 .sum::<usize>()
-                .min(next_tx_number_to_prune as usize + input.delete_limit / 2)
+                .min(next_tx_number_to_prune as usize + input.delete_limit)
                 .sub(1);
 
             let last_pruned_block_number = blocks
@@ -194,10 +138,6 @@ mod tests {
                 transactions.len() - (last_pruned_tx_number + 1)
             );
             assert_eq!(
-                tx.table::<tables::TxSenders>().unwrap().len(),
-                transactions.len() - (last_pruned_tx_number + 1)
-            );
-            assert_eq!(
                 tx.inner().get_prune_checkpoint(Transactions::SEGMENT).unwrap(),
                 Some(PruneCheckpoint {
                     block_number: last_pruned_block_number,
@@ -207,27 +147,7 @@ mod tests {
             );
         };
 
-        test_prune(4, (false, 10));
-        test_prune(4, (true, 6));
-    }
-
-    #[test]
-    fn prune_cannot_be_done() {
-        let tx = TestTransaction::default();
-        let mut rng = generators::rng();
-
-        let blocks = random_block_range(&mut rng, 0..=1, B256::ZERO, 1..2);
-        tx.insert_blocks(blocks.iter(), None).expect("insert blocks");
-
-        let input = PruneInput {
-            to_block: 1,
-            // Less than total number of tables for `Transactions` segment
-            delete_limit: 1,
-        };
-        let segment = Transactions::default();
-
-        let provider = tx.inner_rw();
-        let result = segment.prune(&provider, input).unwrap();
-        assert_eq!(result, PruneOutput::not_done());
+        test_prune(6, (false, 10));
+        test_prune(6, (true, 2));
     }
 }

--- a/crates/prune/src/segments/transactions.rs
+++ b/crates/prune/src/segments/transactions.rs
@@ -1,0 +1,233 @@
+use crate::{
+    segments::{PruneInput, PruneOutput, PruneOutputCheckpoint, Segment},
+    PrunerError,
+};
+use itertools::Itertools;
+use reth_db::{database::Database, table::Table, tables};
+use reth_interfaces::RethResult;
+use reth_primitives::{PruneSegment, TxNumber};
+use reth_provider::{DatabaseProviderRW, TransactionsProvider};
+use std::ops::RangeInclusive;
+use tracing::{instrument, trace};
+
+#[derive(Default)]
+#[non_exhaustive]
+pub(crate) struct Transactions;
+
+impl Segment for Transactions {
+    const SEGMENT: PruneSegment = PruneSegment::Transactions;
+
+    #[instrument(level = "trace", target = "pruner", skip(self, provider), ret)]
+    fn prune<DB: Database>(
+        &self,
+        provider: &DatabaseProviderRW<'_, DB>,
+        input: PruneInput,
+    ) -> Result<PruneOutput, PrunerError> {
+        let tx_range = match input.get_next_tx_num_range_from_checkpoint(provider, Self::SEGMENT)? {
+            Some(range) => range,
+            None => {
+                trace!(target: "pruner", "No transactions to prune");
+                return Ok(PruneOutput::done())
+            }
+        };
+
+        let delete_limit = input.delete_limit / 2;
+        if delete_limit == 0 {
+            // Nothing to do, `input.delete_limit` is less than 2, so we can't prune all
+            // transactions-related tables up to the same height
+            return Ok(PruneOutput::not_done())
+        }
+
+        let results = [
+            self.prune_table::<DB, tables::Transactions>(provider, tx_range.clone(), delete_limit)?,
+            self.prune_table::<DB, tables::TxSenders>(provider, tx_range, delete_limit)?,
+        ];
+
+        if !results.iter().map(|(_, _, last_pruned_block)| last_pruned_block).all_equal() {
+            return Err(PrunerError::InconsistentData(
+                "All transactions-related tables should be pruned up to the same height",
+            ))
+        }
+
+        let (done, pruned, last_pruned_transaction) = results.into_iter().fold(
+            (true, 0, 0),
+            |(total_done, total_pruned, _), (done, pruned, last_pruned_transaction)| {
+                (total_done && done, total_pruned + pruned, last_pruned_transaction)
+            },
+        );
+
+        let last_pruned_block = provider
+            .transaction_block(last_pruned_transaction)?
+            .ok_or(PrunerError::InconsistentData("Block for transaction is not found"))?
+            // If there's more transactions to prune, set the checkpoint block number to previous,
+            // so we could finish pruning its transactions on the next run.
+            .checked_sub(if done { 0 } else { 1 });
+
+        Ok(PruneOutput {
+            done,
+            pruned,
+            checkpoint: Some(PruneOutputCheckpoint {
+                block_number: last_pruned_block,
+                tx_number: Some(last_pruned_transaction),
+            }),
+        })
+    }
+}
+
+impl Transactions {
+    /// Prune one transactions-related table.
+    ///
+    /// Returns `done`, number of pruned rows and last pruned block number.
+    fn prune_table<DB: Database, T: Table<Key = TxNumber>>(
+        &self,
+        provider: &DatabaseProviderRW<'_, DB>,
+        range: RangeInclusive<TxNumber>,
+        delete_limit: usize,
+    ) -> RethResult<(bool, usize, TxNumber)> {
+        let mut last_pruned_transaction = *range.end();
+        let (pruned, done) = provider.prune_table_with_range::<T>(
+            range,
+            delete_limit,
+            |_| false,
+            |row| last_pruned_transaction = row.0,
+        )?;
+        trace!(target: "pruner", %pruned, %done, table = %T::NAME, "Pruned transactions");
+
+        Ok((done, pruned, last_pruned_transaction))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::segments::{PruneInput, PruneOutput, Segment, Transactions};
+    use assert_matches::assert_matches;
+    use itertools::{
+        FoldWhile::{Continue, Done},
+        Itertools,
+    };
+    use reth_db::tables;
+    use reth_interfaces::test_utils::{generators, generators::random_block_range};
+    use reth_primitives::{BlockNumber, PruneCheckpoint, PruneMode, TxNumber, B256};
+    use reth_provider::PruneCheckpointReader;
+    use reth_stages::test_utils::TestTransaction;
+    use std::ops::Sub;
+
+    #[test]
+    fn prune() {
+        let tx = TestTransaction::default();
+        let mut rng = generators::rng();
+
+        let blocks = random_block_range(&mut rng, 1..=100, B256::ZERO, 2..3);
+        tx.insert_blocks(blocks.iter(), None).expect("insert blocks");
+
+        let transactions = blocks
+            .iter()
+            .flat_map(|block| &block.body)
+            .map(|transaction| transaction.try_ecrecovered())
+            .collect::<Option<Vec<_>>>()
+            .expect("recover transaction senders");
+
+        tx.insert_transaction_senders(
+            transactions
+                .iter()
+                .enumerate()
+                .map(|(i, transaction)| (i as u64, transaction.signer())),
+        )
+        .expect("insert transaction senders");
+
+        assert_eq!(tx.table::<tables::Transactions>().unwrap().len(), transactions.len());
+        assert_eq!(tx.table::<tables::TxSenders>().unwrap().len(), transactions.len());
+
+        let test_prune = |to_block: BlockNumber, expected_result: (bool, usize)| {
+            let prune_mode = PruneMode::Before(to_block);
+            let input = PruneInput { to_block, delete_limit: 10 };
+            let segment = Transactions::default();
+
+            let next_tx_number_to_prune = tx
+                .inner()
+                .get_prune_checkpoint(Transactions::SEGMENT)
+                .unwrap()
+                .and_then(|checkpoint| checkpoint.tx_number)
+                .map(|tx_number| tx_number + 1)
+                .unwrap_or_default();
+
+            let provider = tx.inner_rw();
+            let result = segment.prune(&provider, input).unwrap();
+            assert_matches!(
+                result,
+                PruneOutput {done, pruned, checkpoint: Some(_)}
+                    if (done, pruned) == expected_result
+            );
+            segment
+                .save_checkpoint(
+                    &provider,
+                    result.checkpoint.unwrap().as_prune_checkpoint(prune_mode),
+                )
+                .unwrap();
+            provider.commit().expect("commit");
+
+            let last_pruned_tx_number = blocks
+                .iter()
+                .take(to_block as usize)
+                .map(|block| block.body.len())
+                .sum::<usize>()
+                .min(next_tx_number_to_prune as usize + input.delete_limit / 2)
+                .sub(1);
+
+            let last_pruned_block_number = blocks
+                .iter()
+                .fold_while((0, 0), |(_, mut tx_count), block| {
+                    tx_count += block.body.len();
+
+                    if tx_count > last_pruned_tx_number {
+                        Done((block.number, tx_count))
+                    } else {
+                        Continue((block.number, tx_count))
+                    }
+                })
+                .into_inner()
+                .0
+                .checked_sub(if result.done { 0 } else { 1 });
+
+            assert_eq!(
+                tx.table::<tables::Transactions>().unwrap().len(),
+                transactions.len() - (last_pruned_tx_number + 1)
+            );
+            assert_eq!(
+                tx.table::<tables::TxSenders>().unwrap().len(),
+                transactions.len() - (last_pruned_tx_number + 1)
+            );
+            assert_eq!(
+                tx.inner().get_prune_checkpoint(Transactions::SEGMENT).unwrap(),
+                Some(PruneCheckpoint {
+                    block_number: last_pruned_block_number,
+                    tx_number: Some(last_pruned_tx_number as TxNumber),
+                    prune_mode
+                })
+            );
+        };
+
+        test_prune(4, (false, 10));
+        test_prune(4, (true, 6));
+    }
+
+    #[test]
+    fn prune_cannot_be_done() {
+        let tx = TestTransaction::default();
+        let mut rng = generators::rng();
+
+        let blocks = random_block_range(&mut rng, 0..=1, B256::ZERO, 1..2);
+        tx.insert_blocks(blocks.iter(), None).expect("insert blocks");
+
+        let input = PruneInput {
+            to_block: 1,
+            // Less than total number of tables for `Transactions` segment
+            delete_limit: 1,
+        };
+        let segment = Transactions::default();
+
+        let provider = tx.inner_rw();
+        let result = segment.prune(&provider, input).unwrap();
+        assert_eq!(result, PruneOutput::not_done());
+    }
+}


### PR DESCRIPTION
Same as https://github.com/paradigmxyz/reth/pull/4936, but for headers. `Receipts`, `TransactionBlock` and `TxSenders` aren't pruned because it's unclear yet if we'll include them into the same `Transactions` snapshot.