### PR TITLE
perf: disable nagle algorithm for rlpx sessions

### DIFF
--- a/crates/net/network/src/listener.rs
+++ b/crates/net/network/src/listener.rs
@@ -42,6 +42,9 @@ impl ConnectionListener {
         let this = self.project();
         match ready!(this.incoming.poll_next(cx)) {
             Some(Ok((stream, remote_addr))) => {
+                if let Err(err) = stream.set_nodelay(true) {
+                    tracing::warn!(target : "net", "set nodelay failed: {:?}", err);
+                }
                 Poll::Ready(ListenerEvent::Incoming { stream, remote_addr })
             }
             Some(Err(err)) => Poll::Ready(ListenerEvent::Error(err)),


### PR DESCRIPTION
tokio's/rust's default for TCP_NODELAY is false

this disables nagle algorithm for peer connections to send segments as soon as possible