### PR TITLE
(chore) fix vergen git sha in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,7 +11,7 @@
 !Cross.toml
 !deny.toml
 !Makefile
-!/.git
+!/.git # include for vergen constants
 
 # include dist directory, where the reth binary is located after compilation
 !/dist

--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,7 @@
 !Cross.toml
 !deny.toml
 !Makefile
+!/.git
 
 # include dist directory, where the reth binary is located after compilation
 !/dist


### PR DESCRIPTION
fixes #4943 

```
docker logs a71872f2d198
2023-10-07T19:10:24.880442Z  INFO reth::cli: reth 0.1.0-alpha.10 (5de04430) starting
```

ref fix PR: https://github.com/CodeChain-io/codechain/pull/1494