### PR TITLE
feat: Feat/add on rpc server started hook

### DIFF
--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -37,7 +37,7 @@ reth-rpc-builder = { path = "../../crates/rpc/rpc-builder" }
 reth-rpc = { path = "../../crates/rpc/rpc" }
 reth-rpc-types = { path = "../../crates/rpc/rpc-types" }
 reth-rpc-types-compat = { path = "../../crates/rpc/rpc-types-compat" }
-reth-rpc-api = { path = "../../crates/rpc/rpc-api" }
+reth-rpc-api = { path = "../../crates/rpc/rpc-api", features = ["client"] }
 reth-network = { path = "../../crates/net/network", features = ["serde"] }
 reth-network-api.workspace = true
 reth-downloaders = { path = "../../crates/net/downloaders", features = ["test-utils"] }

--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -205,7 +205,7 @@ impl RpcServerArgs {
 
         let node_modules = RethRpcComponents { registry: &mut registry, modules: &mut modules };
         // apply configured customization
-        conf.extend_rpc_modules(self, components, node_modules)?;
+        conf.extend_rpc_modules(self, components, &node_modules)?;
 
         let server_config = self.rpc_server_config();
         let launch_rpc = modules.start_server(server_config).map_ok(|handle| {
@@ -230,7 +230,7 @@ impl RpcServerArgs {
         // launch servers concurrently
         let handles = Ok(futures::future::try_join(launch_rpc, launch_auth).await?);
 
-        conf.on_rpc_server_started(self, components, node_modules, handles)
+        conf.on_rpc_server_started(self, components, &node_modules, handles)
     }
 
     /// Convenience function for starting a rpc server with configs which extracted from cli args.

--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -202,6 +202,7 @@ impl RpcServerArgs {
             .with_events(components.events())
             .with_executor(components.task_executor())
             .build_with_auth_server(module_config, engine_api);
+
         let node_modules = RethRpcComponents { registry: &mut registry, modules: &mut modules };
         // apply configured customization
         conf.extend_rpc_modules(self, components, node_modules)?;
@@ -227,7 +228,9 @@ impl RpcServerArgs {
         });
 
         // launch servers concurrently
-        Ok(futures::future::try_join(launch_rpc, launch_auth).await?)
+        let handles = Ok(futures::future::try_join(launch_rpc, launch_auth).await?);
+
+        conf.on_rpc_server_started(self, components, node_modules, handles)
     }
 
     /// Convenience function for starting a rpc server with configs which extracted from cli args.

--- a/bin/reth/src/cli/components.rs
+++ b/bin/reth/src/cli/components.rs
@@ -6,7 +6,9 @@ use reth_provider::{
     AccountReader, BlockReaderIdExt, CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader,
     EvmEnvProvider, StateProviderFactory,
 };
-use reth_rpc_builder::{RethModuleRegistry, TransportRpcModules};
+use reth_rpc_builder::{
+    auth::AuthServerHandle, RethModuleRegistry, RpcServerHandle, TransportRpcModules,
+};
 use reth_tasks::TaskSpawner;
 use reth_transaction_pool::TransactionPool;
 use std::sync::Arc;
@@ -142,4 +144,26 @@ where
     fn events(&self) -> Self::Events {
         self.events.clone()
     }
+}
+
+/// Contains the handles to the spawned RPC servers.
+///
+/// This can be used to access the endpoints of the servers.
+///
+/// # Example
+///
+/// ```rust
+/// use reth::cli::components::RethRpcServerHandles;
+/// use reth::rpc::api::EthApiClient;
+/// # async fn t(handles: RethRpcServerHandles) {
+///    let client = handles.rpc.http_client().expect("http server not started");
+///    let block_number = client.block_number().await.unwrap();
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+pub struct RethRpcServerHandles {
+    /// The regular RPC server handle.
+    pub rpc: RpcServerHandle,
+    /// The handle to the auth server (engine API)
+    pub auth: AuthServerHandle,
 }

--- a/bin/reth/src/cli/components.rs
+++ b/bin/reth/src/cli/components.rs
@@ -6,12 +6,10 @@ use reth_provider::{
     AccountReader, BlockReaderIdExt, CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader,
     EvmEnvProvider, StateProviderFactory,
 };
-use reth_rpc_builder::{error::RpcError, RethModuleRegistry, TransportRpcModules};
+use reth_rpc_builder::{RethModuleRegistry, TransportRpcModules};
 use reth_tasks::TaskSpawner;
 use reth_transaction_pool::TransactionPool;
 use std::sync::Arc;
-
-use reth_rpc_builder::{RpcServerConfig, RpcServerHandle};
 
 /// Helper trait to unify all provider traits for simplicity.
 pub trait FullProvider:

--- a/bin/reth/src/cli/components.rs
+++ b/bin/reth/src/cli/components.rs
@@ -6,10 +6,12 @@ use reth_provider::{
     AccountReader, BlockReaderIdExt, CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader,
     EvmEnvProvider, StateProviderFactory,
 };
-use reth_rpc_builder::{RethModuleRegistry, TransportRpcModules};
+use reth_rpc_builder::{error::RpcError, RethModuleRegistry, TransportRpcModules};
 use reth_tasks::TaskSpawner;
 use reth_transaction_pool::TransactionPool;
 use std::sync::Arc;
+
+use reth_rpc_builder::{RpcServerConfig, RpcServerHandle};
 
 /// Helper trait to unify all provider traits for simplicity.
 pub trait FullProvider:

--- a/bin/reth/src/cli/ext.rs
+++ b/bin/reth/src/cli/ext.rs
@@ -10,7 +10,7 @@ use reth_payload_builder::{PayloadBuilderHandle, PayloadBuilderService};
 use reth_tasks::TaskSpawner;
 use std::{fmt, marker::PhantomData};
 
-use reth_rpc_builder::{auth::AuthServerHandle, RpcServerHandle};
+use crate::cli::components::RethRpcServerHandles;
 
 /// A trait that allows for extending parts of the CLI with additional functionality.
 ///
@@ -48,14 +48,14 @@ pub trait RethNodeCommandConfig: fmt::Debug {
         Ok(())
     }
 
-    /// Event hook called once the rpc server has been started.
+    /// Event hook called once the rpc servers has been started.
     fn on_rpc_server_started<Conf, Reth>(
         &mut self,
         config: &Conf,
         components: &Reth,
-        rpc_components: RethRpcComponents<'_, Reth>,
-        handles: eyre::Result<(RpcServerHandle, AuthServerHandle)>,
-    ) -> eyre::Result<(RpcServerHandle, AuthServerHandle)>
+        rpc_components: &RethRpcComponents<'_, Reth>,
+        handles: RethRpcServerHandles,
+    ) -> eyre::Result<()>
     where
         Conf: RethRpcConfig,
         Reth: RethNodeComponents,
@@ -63,7 +63,8 @@ pub trait RethNodeCommandConfig: fmt::Debug {
         let _ = config;
         let _ = components;
         let _ = rpc_components;
-        handles
+        let _ = handles;
+        Ok(())
     }
 
     /// Allows for registering additional RPC modules for the transports.
@@ -215,8 +216,8 @@ impl<T: RethNodeCommandConfig> RethNodeCommandConfig for NoArgs<T> {
         config: &Conf,
         components: &Reth,
         rpc_components: &RethRpcComponents<'_, Reth>,
-        handles: eyre::Result<(RpcServerHandle, AuthServerHandle)>,
-    ) -> eyre::Result<(RpcServerHandle, AuthServerHandle)>
+        handles: RethRpcServerHandles,
+    ) -> eyre::Result<()>
     where
         Conf: RethRpcConfig,
         Reth: RethNodeComponents,
@@ -224,7 +225,7 @@ impl<T: RethNodeCommandConfig> RethNodeCommandConfig for NoArgs<T> {
         if let Some(conf) = self.inner_mut() {
             conf.on_rpc_server_started(config, components, rpc_components, handles)
         } else {
-            handles
+            Ok(())
         }
     }
 

--- a/bin/reth/src/cli/ext.rs
+++ b/bin/reth/src/cli/ext.rs
@@ -53,7 +53,7 @@ pub trait RethNodeCommandConfig: fmt::Debug {
         &mut self,
         config: &Conf,
         components: &Reth,
-        rpc_components: &RethRpcComponents<'_, Reth>,
+        rpc_components: RethRpcComponents<'_, Reth>,
         handles: RethRpcServerHandles,
     ) -> eyre::Result<()>
     where
@@ -75,7 +75,7 @@ pub trait RethNodeCommandConfig: fmt::Debug {
         &mut self,
         config: &Conf,
         components: &Reth,
-        rpc_components: &RethRpcComponents<'_, Reth>,
+        rpc_components: RethRpcComponents<'_, Reth>,
     ) -> eyre::Result<()>
     where
         Conf: RethRpcConfig,
@@ -215,7 +215,7 @@ impl<T: RethNodeCommandConfig> RethNodeCommandConfig for NoArgs<T> {
         &mut self,
         config: &Conf,
         components: &Reth,
-        rpc_components: &RethRpcComponents<'_, Reth>,
+        rpc_components: RethRpcComponents<'_, Reth>,
         handles: RethRpcServerHandles,
     ) -> eyre::Result<()>
     where
@@ -233,7 +233,7 @@ impl<T: RethNodeCommandConfig> RethNodeCommandConfig for NoArgs<T> {
         &mut self,
         config: &Conf,
         components: &Reth,
-        rpc_components: &RethRpcComponents<'_, Reth>,
+        rpc_components: RethRpcComponents<'_, Reth>,
     ) -> eyre::Result<()>
     where
         Conf: RethRpcConfig,

--- a/bin/reth/src/cli/ext.rs
+++ b/bin/reth/src/cli/ext.rs
@@ -53,7 +53,7 @@ pub trait RethNodeCommandConfig: fmt::Debug {
         &mut self,
         config: &Conf,
         components: &Reth,
-        rpc_components: RethRpcComponents<'_, Reth>,
+        rpc_components: &RethRpcComponents<'_, Reth>,
         handles: eyre::Result<(RpcServerHandle, AuthServerHandle)>,
     ) -> eyre::Result<(RpcServerHandle, AuthServerHandle)>
     where
@@ -74,7 +74,7 @@ pub trait RethNodeCommandConfig: fmt::Debug {
         &mut self,
         config: &Conf,
         components: &Reth,
-        rpc_components: RethRpcComponents<'_, Reth>,
+        rpc_components: &RethRpcComponents<'_, Reth>,
     ) -> eyre::Result<()>
     where
         Conf: RethRpcConfig,
@@ -214,7 +214,7 @@ impl<T: RethNodeCommandConfig> RethNodeCommandConfig for NoArgs<T> {
         &mut self,
         config: &Conf,
         components: &Reth,
-        rpc_components: RethRpcComponents<'_, Reth>,
+        rpc_components: &RethRpcComponents<'_, Reth>,
         handles: eyre::Result<(RpcServerHandle, AuthServerHandle)>,
     ) -> eyre::Result<(RpcServerHandle, AuthServerHandle)>
     where
@@ -232,7 +232,7 @@ impl<T: RethNodeCommandConfig> RethNodeCommandConfig for NoArgs<T> {
         &mut self,
         config: &Conf,
         components: &Reth,
-        rpc_components: RethRpcComponents<'_, Reth>,
+        rpc_components: &RethRpcComponents<'_, Reth>,
     ) -> eyre::Result<()>
     where
         Conf: RethRpcConfig,

--- a/bin/reth/src/cli/ext.rs
+++ b/bin/reth/src/cli/ext.rs
@@ -53,7 +53,7 @@ pub trait RethNodeCommandConfig: fmt::Debug {
         &mut self,
         config: &Conf,
         components: &Reth,
-        rpc_components: &RethRpcComponents<'_, Reth>,
+        rpc_components: RethRpcComponents<'_, Reth>,
         handles: eyre::Result<(RpcServerHandle, AuthServerHandle)>,
     ) -> eyre::Result<(RpcServerHandle, AuthServerHandle)>
     where

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -533,7 +533,7 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
         self.adjust_instance_ports();
 
         // Start RPC servers
-        let (_rpc_server, _auth_server) =
+        let _rpc_server_handles =
             self.rpc.start_servers(&components, engine_api, jwt_secret, &mut self.ext).await?;
 
         // Run consensus engine to completion

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1478,7 +1478,7 @@ impl TransportRpcModuleConfig {
 }
 
 /// Holds installed modules per transport type.
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct TransportRpcModules<Context = ()> {
     /// The original config
     config: TransportRpcModuleConfig,


### PR DESCRIPTION
`Hey!` @mattsse  

I work on https://github.com/paradigmxyz/reth/issues/4917 

I really need your help! 

I prepared a new function,  I use the new type RethRpcComponents but I've got a borrowing issue on the line below which I don't know how to resolve in a clear manner YET:

`
cannot move out of `modules` because it is borrowed
move out of `modules` occurs hererustc[Click for full compiler diagnostic](rust-analyzer-diagnostics-view:/diagnostic%20message%20%5B0%5D?0#file%3A%2F%2F%2FUsers%2Fnil.medvedev%2FProjects%2Fmy%2Freth%2Fbin%2Freth%2Fsrc%2Fargs%2Frpc_server_args.rs)
rpc_server_args.rs(206, 82): borrow of `modules` occurs here
rpc_server_args.rs(198, 14): binding `modules` declared here
rpc_server_args.rs(233, 54): borrow later used here
`

https://github.com/allnil/reth/blob/2fc27313e4b2c381514168d2731af20eaa9c3c33/bin/reth/src/args/rpc_server_args.rs#L211C6-L211C6

I played with it in different ways but still don't know how to do it better
I will continue to work on it but maybe you could just give me a hint or show me a direction to proceed? 
Thank you!