### PR TITLE
fix: use pending block tag for actual pending block

### DIFF
--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -263,8 +263,9 @@ where
 
         let mut cfg = CfgEnv::default();
         let mut block_env = BlockEnv::default();
-        self.provider().fill_block_env_with_header(&mut block_env, origin.header())?;
-        self.provider().fill_cfg_env_with_header(&mut cfg, origin.header())?;
+        // Note: for the PENDING block we assume it is past the known merge block and thus this will
+        // not fail when looking up the total difficulty value for the blockenv.
+        self.provider().fill_env_with_header(&mut cfg, &mut block_env, origin.header())?;
 
         Ok(PendingBlockEnv { cfg, block_env, origin })
     }

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -69,8 +69,10 @@ pub trait EthTransactions: Send + Sync {
 
     /// Returns the revm evm env for the requested [BlockId]
     ///
-    /// If the [BlockId] this will return the [BlockId::Hash] of the block the env was configured
+    /// If the [BlockId] this will return the [BlockId] of the block the env was configured
     /// for.
+    /// If the [BlockId] is pending, this will return the "Pending" tag, otherwise this returns the
+    /// hash of the exact block.
     async fn evm_env_at(&self, at: BlockId) -> EthResult<(CfgEnv, BlockEnv, BlockId)>;
 
     /// Returns the revm evm env for the raw block header
@@ -279,7 +281,7 @@ where
     async fn evm_env_at(&self, at: BlockId) -> EthResult<(CfgEnv, BlockEnv, BlockId)> {
         if at.is_pending() {
             let PendingBlockEnv { cfg, block_env, origin } = self.pending_block_env_and_cfg()?;
-            Ok((cfg, block_env, origin.header().hash.into()))
+            Ok((cfg, block_env, origin.state_block_id()))
         } else {
             //  Use cached values if there is no pending block
             let block_hash = self

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -521,14 +521,20 @@ where
         state
     }
 
-    /// Storage provider for pending state.
+    /// Returns the state provider for pending state.
+    ///
+    /// If there's no pending block available then the latest state provider is returned:
+    /// [Self::latest]
     fn pending(&self) -> RethResult<StateProviderBox<'_>> {
         trace!(target: "providers::blockchain", "Getting provider for pending state");
 
         if let Some(block) = self.tree.pending_block_num_hash() {
-            let pending = self.tree.pending_state_provider(block.hash)?;
-            return self.pending_with_provider(pending)
+            if let Ok(pending) = self.tree.pending_state_provider(block.hash) {
+                return self.pending_with_provider(pending)
+            }
         }
+
+        // fallback to latest state if the pending block is not available
         self.latest()
     }
 

--- a/crates/storage/provider/src/traits/state.rs
+++ b/crates/storage/provider/src/traits/state.rs
@@ -107,7 +107,8 @@ pub trait StateProviderFactory: BlockIdReader + Send + Sync {
 
     /// Returns a [StateProvider] indexed by the given [BlockId].
     ///
-    /// Note: if a number or hash is provided this will only look at historical(canonical) state.
+    /// Note: if a number or hash is provided this will __only__ look at historical(canonical)
+    /// state.
     fn state_by_block_id(&self, block_id: BlockId) -> RethResult<StateProviderBox<'_>> {
         match block_id {
             BlockId::Number(block_number) => self.state_by_block_number_or_tag(block_number),


### PR DESCRIPTION
Closes #4965

this fixes a bug were we used the pending block (inside tree) hash to lookup the state, however the state_at fn only checks canonical blocks if a hash is provided