### PR TITLE
wip:fix: encoded length for blob transactions

### DIFF
--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -236,10 +236,13 @@ where
         request: GetPooledTransactions,
         response: oneshot::Sender<RequestResult<PooledTransactions>>,
     ) {
+        dbg!(peer_id, &request);
         if let Some(peer) = self.peers.get_mut(&peer_id) {
             let transactions = self
                 .pool
                 .get_pooled_transaction_elements(request.0, GET_POOLED_TRANSACTION_SOFT_LIMIT_SIZE);
+
+            dbg!(&transactions);
 
             // we sent a response at which point we assume that the peer is aware of the
             // transactions
@@ -290,7 +293,7 @@ where
         to_propagate: Vec<PropagateTransaction>,
     ) -> PropagatedTransactions {
         let mut propagated = PropagatedTransactions::default();
-
+        println!("propagate txs {:?}", to_propagate);
         // send full transactions to a fraction fo the connected peers (square root of the total
         // number of connected peers)
         let max_num_full = (self.peers.len() as f64).sqrt() as usize + 1;
@@ -516,6 +519,7 @@ where
 
     /// Handles dedicated transaction events related to the `eth` protocol.
     fn on_network_tx_event(&mut self, event: NetworkTransactionEvent) {
+        println!("received event {:?}", event);
         match event {
             NetworkTransactionEvent::IncomingTransactions { peer_id, msg } => {
                 // ensure we didn't receive any blob transactions as these are disallowed to be
@@ -822,6 +826,7 @@ where
 }
 
 /// A transaction that's about to be propagated to multiple peers.
+#[derive(Debug)]
 struct PropagateTransaction {
     size: usize,
     transaction: Arc<TransactionSigned>,

--- a/crates/primitives/src/transaction/eip4844.rs
+++ b/crates/primitives/src/transaction/eip4844.rs
@@ -439,7 +439,7 @@ impl BlobTransaction {
 
         let tx_length = tx_header.length() + tx_header.payload_length;
 
-        // The payload length is the length of the `tranascation_payload_body` list, plus the
+        // The payload length is the length of the `transaction_payload_body` list, plus the
         // length of the blobs, commitments, and proofs.
         let payload_length = tx_length + self.sidecar.fields_len();
 
@@ -457,7 +457,7 @@ impl BlobTransaction {
         self.sidecar.encode_inner(out);
     }
 
-    /// Ouputs the length of the RLP encoding of the blob transaction, including the tx type byte,
+    /// Outputs the length of the RLP encoding of the blob transaction, including the tx type byte,
     /// optionally including the length of a wrapping string header. If `with_header` is `false`,
     /// the length of the following will be calculated:
     /// `tx_type (0x03) || rlp([transaction_payload_body, blobs, commitments, proofs])`

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -945,7 +945,7 @@ impl PoolTransaction for EthPooledTransaction {
         self.transaction.input().as_ref()
     }
 
-    /// Returns a measurement of the heap usage of this type and all its internals.
+    /// Returns a __measurement__ of the heap usage of this type and all its internals.
     fn size(&self) -> usize {
         self.transaction.transaction.input().len()
     }

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -119,9 +119,17 @@ impl<T: PoolTransaction> ValidTransaction<T> {
     }
 
     /// Returns the length of the rlp encoded object
+    ///
+    /// Caution: This is an expensive operation and should ideally be cached
     #[inline]
     pub(crate) fn encoded_length(&self) -> usize {
-        self.transaction().encoded_length()
+        match self {
+            ValidTransaction::Valid(tx) => tx.encoded_length(),
+            ValidTransaction::ValidWithSidecar { transaction, sidecar } => {
+                // TODO
+                transaction.encoded_length() + sidecar.size()
+            }
+        }
     }
 
     /// Returns the nonce of the transaction.


### PR DESCRIPTION
Closes #4969

@Rjected this is a bit horrible with the current API, ideally, we can compute the encoded length by summarizing rlp(tx) + rlp(sidecar) but unsure if this is the best approach here.

the most performant solution would be to already track the rlp size when decoding from raw bytes, but would require a few changes.

this currently uses the `size()` function which is def wrong

> FAIL: Error executing step 3: expected size 131330, got 131316
