### PR TITLE
fix: use correct payload length for blob pooled txs

### DIFF
--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -16,7 +16,6 @@ use std::{
     task::{Context, Poll},
 };
 use tokio_stream::Stream;
-use tracing::trace;
 
 /// [`MAX_MESSAGE_SIZE`] is the maximum cap on the size of a protocol message.
 // https://github.com/ethereum/go-ethereum/blob/30602163d5d8321fbc68afdcbbaf2362b2641bde/eth/protocols/eth/protocol.go#L50
@@ -283,13 +282,9 @@ where
             return Err(EthStreamError::EthHandshakeError(EthHandshakeError::StatusNotInHandshake))
         }
 
-        trace!(target: "net::tx", "sending message, before encoding: msg={item:?}");
-
         let mut bytes = BytesMut::new();
         ProtocolMessage::from(item).encode(&mut bytes);
         let bytes = bytes.freeze();
-
-        trace!(target: "net::tx", "sending message: msg={bytes:x}");
 
         self.project().inner.start_send(bytes)?;
 

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -16,6 +16,7 @@ use std::{
     task::{Context, Poll},
 };
 use tokio_stream::Stream;
+use tracing::trace;
 
 /// [`MAX_MESSAGE_SIZE`] is the maximum cap on the size of a protocol message.
 // https://github.com/ethereum/go-ethereum/blob/30602163d5d8321fbc68afdcbbaf2362b2641bde/eth/protocols/eth/protocol.go#L50
@@ -282,9 +283,13 @@ where
             return Err(EthStreamError::EthHandshakeError(EthHandshakeError::StatusNotInHandshake))
         }
 
+        trace!(target: "net::tx", "sending message, before encoding: msg={item:?}");
+
         let mut bytes = BytesMut::new();
         ProtocolMessage::from(item).encode(&mut bytes);
         let bytes = bytes.freeze();
+
+        trace!(target: "net::tx", "sending message: msg={bytes:x}");
 
         self.project().inner.start_send(bytes)?;
 

--- a/crates/net/eth-wire/tests/pooled_transactions.rs
+++ b/crates/net/eth-wire/tests/pooled_transactions.rs
@@ -1,6 +1,6 @@
 //! Decoding tests for [`PooledTransactions`]
 use alloy_rlp::Decodable;
-use reth_eth_wire::PooledTransactions;
+use reth_eth_wire::{EthVersion, PooledTransactions, ProtocolMessage};
 use reth_primitives::{hex, Bytes, PooledTransactionsElement};
 use std::{fs, path::PathBuf};
 
@@ -11,6 +11,16 @@ fn decode_pooled_transactions_data() {
     let data = fs::read_to_string(network_data_path).expect("Unable to read file");
     let hex_data = hex::decode(data.trim()).unwrap();
     let _txs = PooledTransactions::decode(&mut &hex_data[..]).unwrap();
+}
+
+#[test]
+fn decode_request_pair_pooled_blob_transactions() {
+    let network_data_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("testdata/request_pair_pooled_blob_transactions");
+    let data = fs::read_to_string(network_data_path).expect("Unable to read file");
+    let hex_data = hex::decode(data.trim()).unwrap();
+    // let _txs = PooledTransactions::decode(&mut &hex_data[..]).unwrap();
+    let _txs = ProtocolMessage::decode_message(EthVersion::Eth68, &mut &hex_data[..]).unwrap();
 }
 
 #[test]

--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -372,6 +372,8 @@ where
         txs: Vec<TxHash>,
         peer_id: PeerId,
     ) -> Option<PropagatedTransactions> {
+        trace!(target: "net::tx", ?peer_id, "Propagating transactions to peer");
+
         let peer = self.peers.get_mut(&peer_id)?;
         let mut propagated = PropagatedTransactions::default();
 
@@ -414,6 +416,8 @@ where
     ///
     /// Note: This will only send the hashes for transactions that exist in the pool.
     fn propagate_hashes_to(&mut self, hashes: Vec<TxHash>, peer_id: PeerId) {
+        trace!(target: "net::tx", "Start propagating transactions as hashes");
+
         // This fetches a transactions from the pool, including the blob transactions, which are
         // only ever sent as hashes.
         let propagated = {

--- a/crates/primitives/src/transaction/eip4844.rs
+++ b/crates/primitives/src/transaction/eip4844.rs
@@ -603,7 +603,7 @@ impl BlobTransactionSidecar {
     }
 
     /// Outputs the RLP length of the [BlobTransactionSidecar] fields, without a RLP header.
-    pub(crate) fn fields_len(&self) -> usize {
+    pub fn fields_len(&self) -> usize {
         BlobTransactionSidecarRlp::wrap_ref(self).fields_len()
     }
 

--- a/crates/primitives/src/transaction/eip4844.rs
+++ b/crates/primitives/src/transaction/eip4844.rs
@@ -453,6 +453,9 @@ impl BlobTransaction {
         tx_header.encode(out);
         self.transaction.encode_fields(out);
 
+        // Encode the signature
+        self.signature.encode(out);
+
         // Encode the blobs, commitments, and proofs
         self.sidecar.encode_inner(out);
     }
@@ -502,7 +505,20 @@ impl BlobTransaction {
 
         // The payload length is the length of the `tranascation_payload_body` list, plus the
         // length of the blobs, commitments, and proofs.
-        tx_length + self.sidecar.fields_len()
+        let payload_length = tx_length + self.sidecar.fields_len();
+
+        // We use the calculated payload len to construct the first list header, which encompasses
+        // everything in the tx - the length of the second, inner list header is part of
+        // payload_length
+        let blob_tx_header = Header { list: true, payload_length };
+
+        // The final length is the length of:
+        //  * the outer blob tx header +
+        //  * the inner tx header +
+        //  * the inner tx fields +
+        //  * the signature fields +
+        //  * the sidecar fields
+        blob_tx_header.length() + blob_tx_header.payload_length
     }
 
     /// Decodes a [BlobTransaction] from RLP. This expects the encoding to be:
@@ -588,7 +604,7 @@ impl BlobTransactionSidecar {
 
     /// Outputs the RLP length of the [BlobTransactionSidecar] fields, without a RLP header.
     pub(crate) fn fields_len(&self) -> usize {
-        self.blobs.len() + self.commitments.len() + self.proofs.len()
+        BlobTransactionSidecarRlp::wrap_ref(self).fields_len()
     }
 
     /// Decodes the inner [BlobTransactionSidecar] fields from RLP bytes, without a RLP header.
@@ -637,6 +653,10 @@ impl BlobTransactionSidecarRlp {
         self.blobs.encode(out);
         self.commitments.encode(out);
         self.proofs.encode(out);
+    }
+
+    fn fields_len(&self) -> usize {
+        self.blobs.length() + self.commitments.length() + self.proofs.length()
     }
 
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -998,10 +998,6 @@ impl TransactionSigned {
         // decode the list header for the rest of the transaction
         let header = Header::decode(data)?;
         if !header.list {
-            println!("tx_type: {:?}", tx_type);
-            // print like first 100 bytes
-            println!("data: {:x?}", &original_encoding[..100]);
-            println!("header: {:?}", header);
             return Err(RlpError::Custom("typed tx fields must be encoded as a list"))
         }
 

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -998,6 +998,10 @@ impl TransactionSigned {
         // decode the list header for the rest of the transaction
         let header = Header::decode(data)?;
         if !header.list {
+            println!("tx_type: {:?}", tx_type);
+            // print like first 100 bytes
+            println!("data: {:x?}", &original_encoding[..100]);
+            println!("header: {:?}", header);
             return Err(RlpError::Custom("typed tx fields must be encoded as a list"))
         }
 


### PR DESCRIPTION
This addresses part of https://github.com/paradigmxyz/reth/issues/4961, making the test flaky instead of always failing. All RLP errors are resolved.

Changes the condition on whether we send hashes to this:
```rust
// determine whether to send full tx objects or hashes. If there are no full
// transactions, try to send hashes.
if peer_idx > max_num_full || full_transactions.is_empty()
```

We may want to send hashes always, though.

The sidecar length was incorrect, and we were not encoding the signature for pooled blob transactions. The payload length for pooled blob transactions was also incorrect, because it didn't incorporate the outer list header.

Created an issue for roundtrip tests: https://github.com/paradigmxyz/reth/issues/4962

Adds another large test vector for pooled txs, and performs a roundtrip encoding / decoding test with an existing known-good encoding test vector.