### PR TITLE
update trace_filter, trace block only to highest matching index

### DIFF
--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -433,7 +433,7 @@ where
                 let mut db = CacheDB::new(StateProviderDatabase::new(state));
 
                 let max_transactions =
-                    highest_index.map_or(transactions.len(), |highest| highest as usize + 1);
+                    highest_index.map_or(transactions.len(), |highest| highest as usize);
                 let transactions = transactions.into_iter().take(max_transactions).enumerate();
 
                 for (idx, tx) in transactions {
@@ -454,9 +454,13 @@ where
                     let ResultAndState { result, state } = res;
                     results.push(f(tx_info, inspector, result, &state, &db)?);
 
-                    // need to apply the state changes of this transaction before executing
-                    // the next transaction
-                    db.commit(state)
+                    // need to apply the state changes of this transaction before executing the
+-                   // next transaction
+-                   if transactions.peek().is_some() {
+                        // need to apply the state changes of this transaction before executing
+                        // the next transaction
+                        db.commit(state)
+                    }
                 }
 
                 Ok(results)

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -378,6 +378,11 @@ where
         self.trace_block_until(block_id, None, config, f).await
     }
 
+    /// Executes all transactions of a block.
+    ///
+    /// If a `highest_index` is given, this will only execute the first `highest_index`
+    /// transactions, in other words, it will stop executing transactions after the
+    /// `highest_index`th transaction.
     async fn trace_block_until<F, R>(
         &self,
         block_id: BlockId,

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -368,7 +368,7 @@ where
                 TransactionInfo,
                 TracingInspector,
                 ExecutionResult,
-                &'a revm_primitives::State,
+                &'a State,
                 &'a CacheDB<StateProviderDatabase<StateProviderBox<'a>>>,
             ) -> EthResult<R>
             + Send
@@ -390,7 +390,7 @@ where
                 TransactionInfo,
                 TracingInspector,
                 ExecutionResult,
-                &'a revm_primitives::State,
+                &'a State,
                 &'a CacheDB<StateProviderDatabase<StateProviderBox<'a>>>,
             ) -> EthResult<R>
             + Send

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -39,33 +39,6 @@ pub struct TraceApi<Provider, Eth> {
     inner: Arc<TraceApiInner<Provider, Eth>>,
 }
 
-trait TransactionCallback<R>
-where
-    Self: for<'a> Fn(
-            TransactionInfo,
-            TracingInspector,
-            ExecutionResult,
-            &'a State,
-            &'a CacheDB<StateProviderDatabase<StateProviderBox<'a>>>,
-        ) -> EthResult<R>
-        + Send
-        + 'static,
-{
-}
-
-impl<F, R> TransactionCallback<R> for F where
-    F: for<'a> Fn(
-            TransactionInfo,
-            TracingInspector,
-            ExecutionResult,
-            &'a State,
-            &'a CacheDB<StateProviderDatabase<StateProviderBox<'a>>>,
-        ) -> EthResult<R>
-        + Send
-        + 'static
-{
-}
-
 // === impl TraceApi ===
 
 impl<Provider, Eth> TraceApi<Provider, Eth> {
@@ -391,7 +364,15 @@ where
     ) -> EthResult<Option<Vec<R>>>
     where
         // This is the callback that's invoked for each transaction with
-        F: TransactionCallback<R>,
+        F: for<'a> Fn(
+                TransactionInfo,
+                TracingInspector,
+                ExecutionResult,
+                &'a revm_primitives::State,
+                &'a CacheDB<StateProviderDatabase<StateProviderBox<'a>>>,
+            ) -> EthResult<R>
+            + Send
+            + 'static,
         R: Send + 'static,
     {
         self.trace_block_until(block_id, None, config, f).await
@@ -405,7 +386,15 @@ where
         f: F,
     ) -> EthResult<Option<Vec<R>>>
     where
-        F: TransactionCallback<R>,
+        F: for<'a> Fn(
+                TransactionInfo,
+                TracingInspector,
+                ExecutionResult,
+                &'a revm_primitives::State,
+                &'a CacheDB<StateProviderDatabase<StateProviderBox<'a>>>,
+            ) -> EthResult<R>
+            + Send
+            + 'static,
         R: Send + 'static,
     {
         let ((cfg, block_env, _), block) = futures::try_join!(

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -455,8 +455,8 @@ where
                     results.push(f(tx_info, inspector, result, &state, &db)?);
 
                     // need to apply the state changes of this transaction before executing the
--                   // next transaction
--                   if transactions.peek().is_some() {
+                    // next transaction
+                    if transactions.peek().is_some() {
                         // need to apply the state changes of this transaction before executing
                         // the next transaction
                         db.commit(state)

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -434,7 +434,8 @@ where
 
                 let max_transactions =
                     highest_index.map_or(transactions.len(), |highest| highest as usize);
-                let mut transactions = transactions.into_iter().take(max_transactions).enumerate().peekable();
+                let mut transactions =
+                    transactions.into_iter().take(max_transactions).enumerate().peekable();
 
                 while let Some((idx, tx)) = transactions.next() {
                     let tx = tx.into_ecrecovered().ok_or(BlockError::InvalidSignature)?;

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -39,31 +39,30 @@ pub struct TraceApi<Provider, Eth> {
     inner: Arc<TraceApiInner<Provider, Eth>>,
 }
 
-trait TransactionCallback<R> 
+trait TransactionCallback<R>
 where
     Self: for<'a> Fn(
-        TransactionInfo,
-        TracingInspector,
-        ExecutionResult,
-        &'a State,
-        &'a CacheDB<StateProviderDatabase<StateProviderBox<'a>>>,
-    ) -> EthResult<R>
-    + Send
-    + 'static,
+            TransactionInfo,
+            TracingInspector,
+            ExecutionResult,
+            &'a State,
+            &'a CacheDB<StateProviderDatabase<StateProviderBox<'a>>>,
+        ) -> EthResult<R>
+        + Send
+        + 'static,
 {
 }
 
-impl<F, R> TransactionCallback<R> for F
-where
+impl<F, R> TransactionCallback<R> for F where
     F: for<'a> Fn(
-        TransactionInfo,
-        TracingInspector,
-        ExecutionResult,
-        &'a State,
-        &'a CacheDB<StateProviderDatabase<StateProviderBox<'a>>>,
-    ) -> EthResult<R>
-    + Send
-    + 'static,
+            TransactionInfo,
+            TracingInspector,
+            ExecutionResult,
+            &'a State,
+            &'a CacheDB<StateProviderDatabase<StateProviderBox<'a>>>,
+        ) -> EthResult<R>
+        + Send
+        + 'static
 {
 }
 
@@ -250,7 +249,7 @@ where
     ) -> EthResult<Option<LocalizedTransactionTrace>> {
         if indices.len() != 1 {
             // The OG impl failed if it gets more than a single index
-            return Ok(None)
+            return Ok(None);
         }
         self.trace_get_index(hash, indices[0]).await
     }
@@ -294,7 +293,7 @@ where
         if distance > 100 {
             return Err(EthApiError::InvalidParams(
                 "Block range too large; currently limited to 100 blocks".to_string(),
-            ))
+            ));
         }
 
         // fetch all blocks in that range
@@ -304,7 +303,7 @@ where
         let mut target_blocks = Vec::new();
         for block in blocks {
             let mut transaction_indices = HashSet::new();
-            let mut highest_matching_index = 0; 
+            let mut highest_matching_index = 0;
             for (tx_idx, tx) in block.body.iter().enumerate() {
                 let from = tx.recover_signer().ok_or(BlockError::InvalidSignature)?;
                 let to = tx.to();
@@ -330,7 +329,7 @@ where
                     if let Some(idx) = tx_info.index {
                         if !indices.contains(&idx) {
                             // only record traces for relevant transactions
-                            return Ok(None)
+                            return Ok(None);
                         }
                     }
                     let traces = inspector
@@ -433,7 +432,8 @@ where
                 let mut results = Vec::with_capacity(transactions.len());
                 let mut db = CacheDB::new(StateProviderDatabase::new(state));
 
-                let max_transactions = highest_index.map_or(transactions.len(), |highest| highest as usize + 1);
+                let max_transactions =
+                    highest_index.map_or(transactions.len(), |highest| highest as usize + 1);
                 let transactions = transactions.into_iter().take(max_transactions).enumerate();
 
                 for (idx, tx) in transactions {
@@ -512,8 +512,8 @@ where
                                 author: block.header.beneficiary,
                                 reward_type: RewardType::Uncle,
                                 value: U256::from(
-                                    block_reward(base_block_reward, block.ommers.len()) -
-                                        base_block_reward,
+                                    block_reward(base_block_reward, block.ommers.len())
+                                        - base_block_reward,
                                 ),
                             },
                         ));

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -434,9 +434,9 @@ where
 
                 let max_transactions =
                     highest_index.map_or(transactions.len(), |highest| highest as usize);
-                let transactions = transactions.into_iter().take(max_transactions).enumerate();
+                let mut transactions = transactions.into_iter().take(max_transactions).enumerate().peekable();
 
-                for (idx, tx) in transactions {
+                while let Some((idx, tx)) = transactions.next() {
                     let tx = tx.into_ecrecovered().ok_or(BlockError::InvalidSignature)?;
                     let tx_info = TransactionInfo {
                         hash: Some(tx.hash()),

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -32,7 +32,6 @@ use revm_primitives::{db::DatabaseCommit, ExecutionResult, ResultAndState, State
 use std::{collections::HashSet, sync::Arc};
 use tokio::sync::{AcquireError, OwnedSemaphorePermit};
 
-
 /// `trace` API implementation.
 ///
 /// This type provides the functionality for handling `trace` related requests.

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -311,9 +311,6 @@ where
                 TracingInspectorConfig::default_parity(),
                 move |tx_info, inspector, res, _, _| {
                     if let Some(idx) = tx_info.index {
-                        if idx > highest_idx {
-                            return Ok(None);
-                        }
                         if !indices.contains(&idx) {
                             // only record traces for relevant transactions
                             return Ok(None)
@@ -325,7 +322,7 @@ where
                         .into_localized_transaction_traces(tx_info);
                     Ok(Some(traces))
                 },
-                None,
+                highest_idx,
             );
             block_traces.push(traces);
         }

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -374,9 +374,6 @@ where
             .await
     }
 
-
-
-
     /// Executes all transactions of a block and returns a list of callback results invoked for each
     /// transaction in the block.
     ///

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -245,7 +245,7 @@ where
         }
     }
 
-    /// SME
+    /// Returns all transaction traces that match the given filter.
     fn find_relevant_blocks_to_trace(
         blocks: Vec<Block>, 
         matcher: &TraceFilterMatcher,

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -249,7 +249,7 @@ where
     ) -> EthResult<Option<LocalizedTransactionTrace>> {
         if indices.len() != 1 {
             // The OG impl failed if it gets more than a single index
-            return Ok(None);
+            return Ok(None)
         }
         self.trace_get_index(hash, indices[0]).await
     }
@@ -293,7 +293,7 @@ where
         if distance > 100 {
             return Err(EthApiError::InvalidParams(
                 "Block range too large; currently limited to 100 blocks".to_string(),
-            ));
+            ))
         }
 
         // fetch all blocks in that range
@@ -329,7 +329,7 @@ where
                     if let Some(idx) = tx_info.index {
                         if !indices.contains(&idx) {
                             // only record traces for relevant transactions
-                            return Ok(None);
+                            return Ok(None)
                         }
                     }
                     let traces = inspector
@@ -512,8 +512,8 @@ where
                                 author: block.header.beneficiary,
                                 reward_type: RewardType::Uncle,
                                 value: U256::from(
-                                    block_reward(base_block_reward, block.ommers.len())
-                                        - base_block_reward,
+                                    block_reward(base_block_reward, block.ommers.len()) -
+                                        base_block_reward,
                                 ),
                             },
                         ));

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -356,7 +356,7 @@ where
     /// 4. calls the callback with the transaction info, the execution result, the changed state
     /// _after_ the transaction [StateProviderDatabase] and the database that points to the state
     /// right _before_ the transaction.
-    async fn trace_block_with<'a, F, R>(
+    async fn trace_block_with<F, R>(
         &self,
         block_id: BlockId,
         config: TracingInspectorConfig,
@@ -378,7 +378,7 @@ where
         self.trace_block_until(block_id, None, config, f).await
     }
 
-    async fn trace_block_until<'a, F, R>(
+    async fn trace_block_until<F, R>(
         &self,
         block_id: BlockId,
         highest_index: Option<u64>,

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -32,10 +32,6 @@ use revm_primitives::{db::DatabaseCommit, ExecutionResult, ResultAndState};
 use std::{collections::HashSet, sync::Arc};
 use tokio::sync::{AcquireError, OwnedSemaphorePermit};
 
-use reth_primitives::Block;
-use reth_rpc_types::trace::filter::TraceFilterMatcher;
-
-
 
 /// `trace` API implementation.
 ///


### PR DESCRIPTION
This PR aims to address the following TODO:
```
// TODO: this could be optimized to only trace the block until the highest matching index in
// that block
```

This is my first contribution to `reth`, I've read through the CONTRIBUTING.md doc and executed all the specified checks. If there's anything I've overlooked or missed please let me know and I'll be happy to address it. 