### PR TITLE
chore: remove consensus generic

### DIFF
--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -74,7 +74,7 @@ use tracing::{debug, error, info, instrument, trace, warn};
 ///   and commit it to db. If we don't have the block, pipeline syncing should start to fetch the
 ///   blocks from p2p. Do reorg in tables if canonical chain if needed.
 #[derive(Debug)]
-pub struct BlockchainTree<DB: Database, C: Consensus, EF: ExecutorFactory> {
+pub struct BlockchainTree<DB: Database, EF: ExecutorFactory> {
     /// The tracked chains and their current data.
     chains: HashMap<BlockChainId, AppendableChain>,
     /// Unconnected block buffer.
@@ -84,7 +84,7 @@ pub struct BlockchainTree<DB: Database, C: Consensus, EF: ExecutorFactory> {
     /// Indices to block and their connection to the canonical chain.
     block_indices: BlockIndices,
     /// External components (the database, consensus engine etc.)
-    externals: TreeExternals<DB, C, EF>,
+    externals: TreeExternals<DB, EF>,
     /// Tree configuration
     config: BlockchainTreeConfig,
     /// Broadcast channel for canon state changes notifications.
@@ -96,10 +96,10 @@ pub struct BlockchainTree<DB: Database, C: Consensus, EF: ExecutorFactory> {
     prune_modes: Option<PruneModes>,
 }
 
-impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTree<DB, C, EF> {
+impl<DB: Database, EF: ExecutorFactory> BlockchainTree<DB, EF> {
     /// Create a new blockchain tree.
     pub fn new(
-        externals: TreeExternals<DB, C, EF>,
+        externals: TreeExternals<DB, EF>,
         config: BlockchainTreeConfig,
         prune_modes: Option<PruneModes>,
     ) -> RethResult<Self> {
@@ -1196,7 +1196,7 @@ mod tests {
 
     fn setup_externals(
         exec_res: Vec<BundleStateWithReceipts>,
-    ) -> TreeExternals<Arc<DatabaseEnv>, Arc<TestConsensus>, TestExecutorFactory> {
+    ) -> TreeExternals<Arc<DatabaseEnv>, TestExecutorFactory> {
         let db = create_test_rw_db();
         let consensus = Arc::new(TestConsensus::default());
         let chain_spec = Arc::new(
@@ -1281,10 +1281,7 @@ mod tests {
             self
         }
 
-        fn assert<DB: Database, C: Consensus, EF: ExecutorFactory>(
-            self,
-            tree: &BlockchainTree<DB, C, EF>,
-        ) {
+        fn assert<DB: Database, EF: ExecutorFactory>(self, tree: &BlockchainTree<DB, EF>) {
             if let Some(chain_num) = self.chain_num {
                 assert_eq!(tree.chains.len(), chain_num);
             }

--- a/crates/blockchain-tree/src/chain.rs
+++ b/crates/blockchain-tree/src/chain.rs
@@ -60,16 +60,15 @@ impl AppendableChain {
     /// Create a new chain that forks off the canonical.
     ///
     /// This will also verify the state root of the block extending the canonical chain.
-    pub fn new_canonical_head_fork<DB, C, EF>(
+    pub fn new_canonical_head_fork<DB, EF>(
         block: SealedBlockWithSenders,
         parent_header: &SealedHeader,
         canonical_block_hashes: &BTreeMap<BlockNumber, BlockHash>,
         canonical_fork: ForkBlock,
-        externals: &TreeExternals<DB, C, EF>,
+        externals: &TreeExternals<DB, EF>,
     ) -> Result<Self, InsertBlockError>
     where
         DB: Database,
-        C: Consensus,
         EF: ExecutorFactory,
     {
         let state = BundleStateWithReceipts::default();
@@ -94,16 +93,15 @@ impl AppendableChain {
     }
 
     /// Create a new chain that forks off of the canonical chain.
-    pub fn new_canonical_fork<DB, C, EF>(
+    pub fn new_canonical_fork<DB, EF>(
         block: SealedBlockWithSenders,
         parent_header: &SealedHeader,
         canonical_block_hashes: &BTreeMap<BlockNumber, BlockHash>,
         canonical_fork: ForkBlock,
-        externals: &TreeExternals<DB, C, EF>,
+        externals: &TreeExternals<DB, EF>,
     ) -> Result<Self, InsertBlockError>
     where
         DB: Database,
-        C: Consensus,
         EF: ExecutorFactory,
     {
         let state = BundleStateWithReceipts::default();
@@ -130,17 +128,16 @@ impl AppendableChain {
     /// Create a new chain that forks off of an existing sidechain.
     ///
     /// This differs from [AppendableChain::new_canonical_fork] in that this starts a new fork.
-    pub(crate) fn new_chain_fork<DB, C, EF>(
+    pub(crate) fn new_chain_fork<DB, EF>(
         &self,
         block: SealedBlockWithSenders,
         side_chain_block_hashes: BTreeMap<BlockNumber, BlockHash>,
         canonical_block_hashes: &BTreeMap<BlockNumber, BlockHash>,
         canonical_fork: ForkBlock,
-        externals: &TreeExternals<DB, C, EF>,
+        externals: &TreeExternals<DB, EF>,
     ) -> Result<Self, InsertBlockError>
     where
         DB: Database,
-        C: Consensus,
         EF: ExecutorFactory,
     {
         let parent_number = block.number - 1;
@@ -177,17 +174,16 @@ impl AppendableChain {
 
     /// Validate and execute the given block that _extends the canonical chain_, validating its
     /// state root after execution.
-    fn validate_and_execute<BSDP, DB, C, EF>(
+    fn validate_and_execute<BSDP, DB, EF>(
         block: SealedBlockWithSenders,
         parent_block: &SealedHeader,
         post_state_data_provider: BSDP,
-        externals: &TreeExternals<DB, C, EF>,
+        externals: &TreeExternals<DB, EF>,
         block_kind: BlockKind,
     ) -> RethResult<BundleStateWithReceipts>
     where
         BSDP: BundleStateDataProvider,
         DB: Database,
-        C: Consensus,
         EF: ExecutorFactory,
     {
         // some checks are done before blocks comes here.
@@ -225,16 +221,15 @@ impl AppendableChain {
 
     /// Validate and execute the given block that _extends the canonical chain_, validating its
     /// state root after execution.
-    fn validate_and_execute_canonical_head_descendant<BSDP, DB, C, EF>(
+    fn validate_and_execute_canonical_head_descendant<BSDP, DB, EF>(
         block: SealedBlockWithSenders,
         parent_block: &SealedHeader,
         post_state_data_provider: BSDP,
-        externals: &TreeExternals<DB, C, EF>,
+        externals: &TreeExternals<DB, EF>,
     ) -> RethResult<BundleStateWithReceipts>
     where
         BSDP: BundleStateDataProvider,
         DB: Database,
-        C: Consensus,
         EF: ExecutorFactory,
     {
         Self::validate_and_execute(
@@ -247,16 +242,15 @@ impl AppendableChain {
     }
 
     /// Validate and execute the given sidechain block, skipping state root validation.
-    fn validate_and_execute_sidechain<BSDP, DB, C, EF>(
+    fn validate_and_execute_sidechain<BSDP, DB, EF>(
         block: SealedBlockWithSenders,
         parent_block: &SealedHeader,
         post_state_data_provider: BSDP,
-        externals: &TreeExternals<DB, C, EF>,
+        externals: &TreeExternals<DB, EF>,
     ) -> RethResult<BundleStateWithReceipts>
     where
         BSDP: BundleStateDataProvider,
         DB: Database,
-        C: Consensus,
         EF: ExecutorFactory,
     {
         Self::validate_and_execute(
@@ -280,18 +274,17 @@ impl AppendableChain {
     /// is the canonical head, or: state root check can't be performed if the given canonical is
     /// __not__ the canonical head.
     #[track_caller]
-    pub(crate) fn append_block<DB, C, EF>(
+    pub(crate) fn append_block<DB, EF>(
         &mut self,
         block: SealedBlockWithSenders,
         side_chain_block_hashes: BTreeMap<BlockNumber, BlockHash>,
         canonical_block_hashes: &BTreeMap<BlockNumber, BlockHash>,
-        externals: &TreeExternals<DB, C, EF>,
+        externals: &TreeExternals<DB, EF>,
         canonical_fork: ForkBlock,
         block_kind: BlockKind,
     ) -> Result<(), InsertBlockError>
     where
         DB: Database,
-        C: Consensus,
         EF: ExecutorFactory,
     {
         let (_, parent_block) = self.blocks.last_key_value().expect("Chain has at least one block");

--- a/crates/blockchain-tree/src/externals.rs
+++ b/crates/blockchain-tree/src/externals.rs
@@ -1,6 +1,7 @@
 //! Blockchain tree externals.
 
 use reth_db::database::Database;
+use reth_interfaces::consensus::Consensus;
 use reth_primitives::ChainSpec;
 use reth_provider::ProviderFactory;
 use std::sync::Arc;
@@ -15,25 +16,30 @@ use std::sync::Arc;
 /// - The executor factory to execute blocks with
 /// - The chain spec
 #[derive(Debug)]
-pub struct TreeExternals<DB, C, EF> {
+pub struct TreeExternals<DB, EF> {
     /// The database, used to commit the canonical chain, or unwind it.
     pub(crate) db: DB,
     /// The consensus engine.
-    pub(crate) consensus: C,
+    pub(crate) consensus: Arc<dyn Consensus>,
     /// The executor factory to execute blocks with.
     pub(crate) executor_factory: EF,
     /// The chain spec.
     pub(crate) chain_spec: Arc<ChainSpec>,
 }
 
-impl<DB, C, EF> TreeExternals<DB, C, EF> {
+impl<DB, EF> TreeExternals<DB, EF> {
     /// Create new tree externals.
-    pub fn new(db: DB, consensus: C, executor_factory: EF, chain_spec: Arc<ChainSpec>) -> Self {
+    pub fn new(
+        db: DB,
+        consensus: Arc<dyn Consensus>,
+        executor_factory: EF,
+        chain_spec: Arc<ChainSpec>,
+    ) -> Self {
         Self { db, consensus, executor_factory, chain_spec }
     }
 }
 
-impl<DB: Database, C, EF> TreeExternals<DB, C, EF> {
+impl<DB: Database, EF> TreeExternals<DB, EF> {
     /// Return shareable database helper structure.
     pub fn database(&self) -> ProviderFactory<&DB> {
         ProviderFactory::new(&self.db, self.chain_spec.clone())

--- a/crates/blockchain-tree/src/shareable.rs
+++ b/crates/blockchain-tree/src/shareable.rs
@@ -7,7 +7,6 @@ use reth_interfaces::{
         error::InsertBlockError, BlockchainTreeEngine, BlockchainTreeViewer, CanonicalOutcome,
         InsertPayloadOk,
     },
-    consensus::Consensus,
     RethResult,
 };
 use reth_primitives::{
@@ -26,21 +25,19 @@ use tracing::trace;
 
 /// Shareable blockchain tree that is behind tokio::RwLock
 #[derive(Clone, Debug)]
-pub struct ShareableBlockchainTree<DB: Database, C: Consensus, EF: ExecutorFactory> {
+pub struct ShareableBlockchainTree<DB: Database, EF: ExecutorFactory> {
     /// BlockchainTree
-    pub tree: Arc<RwLock<BlockchainTree<DB, C, EF>>>,
+    pub tree: Arc<RwLock<BlockchainTree<DB, EF>>>,
 }
 
-impl<DB: Database, C: Consensus, EF: ExecutorFactory> ShareableBlockchainTree<DB, C, EF> {
+impl<DB: Database, EF: ExecutorFactory> ShareableBlockchainTree<DB, EF> {
     /// Create a new shareable database.
-    pub fn new(tree: BlockchainTree<DB, C, EF>) -> Self {
+    pub fn new(tree: BlockchainTree<DB, EF>) -> Self {
         Self { tree: Arc::new(RwLock::new(tree)) }
     }
 }
 
-impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeEngine
-    for ShareableBlockchainTree<DB, C, EF>
-{
+impl<DB: Database, EF: ExecutorFactory> BlockchainTreeEngine for ShareableBlockchainTree<DB, EF> {
     fn buffer_block(&self, block: SealedBlockWithSenders) -> Result<(), InsertBlockError> {
         let mut tree = self.tree.write();
         // Blockchain tree metrics shouldn't be updated here, see
@@ -103,9 +100,7 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeEngine
     }
 }
 
-impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeViewer
-    for ShareableBlockchainTree<DB, C, EF>
-{
+impl<DB: Database, EF: ExecutorFactory> BlockchainTreeViewer for ShareableBlockchainTree<DB, EF> {
     fn blocks(&self) -> BTreeMap<BlockNumber, HashSet<BlockHash>> {
         trace!(target: "blockchain_tree", "Returning all blocks in blockchain tree");
         self.tree.read().block_indices().block_number_to_block_hashes().clone()
@@ -193,8 +188,8 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreeViewer
     }
 }
 
-impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreePendingStateProvider
-    for ShareableBlockchainTree<DB, C, EF>
+impl<DB: Database, EF: ExecutorFactory> BlockchainTreePendingStateProvider
+    for ShareableBlockchainTree<DB, EF>
 {
     fn find_pending_state_provider(
         &self,
@@ -206,8 +201,8 @@ impl<DB: Database, C: Consensus, EF: ExecutorFactory> BlockchainTreePendingState
     }
 }
 
-impl<DB: Database, C: Consensus, EF: ExecutorFactory> CanonStateSubscriptions
-    for ShareableBlockchainTree<DB, C, EF>
+impl<DB: Database, EF: ExecutorFactory> CanonStateSubscriptions
+    for ShareableBlockchainTree<DB, EF>
 {
     fn subscribe_to_canonical_state(&self) -> reth_provider::CanonStateNotifications {
         trace!(target: "blockchain_tree", "Registered subscriber for canonical state");

--- a/crates/consensus/beacon/src/engine/test_utils.rs
+++ b/crates/consensus/beacon/src/engine/test_utils.rs
@@ -43,7 +43,6 @@ type TestBeaconConsensusEngine<Client> = BeaconConsensusEngine<
         Arc<DatabaseEnv>,
         ShareableBlockchainTree<
             Arc<DatabaseEnv>,
-            Arc<dyn Consensus>,
             EitherExecutorFactory<TestExecutorFactory, Factory>,
         >,
     >,
@@ -484,7 +483,7 @@ where
 
                 Pipeline::builder().add_stages(DefaultStages::new(
                     HeaderSyncMode::Tip(tip_rx.clone()),
-                    Arc::clone(&consensus) as Arc<dyn Consensus>,
+                    Arc::clone(&consensus),
                     header_downloader,
                     body_downloader,
                     executor_factory.clone(),


### PR DESCRIPTION
this gets rid of the C: Consensus generic of the tree,

we're using `Arc<dyn Consensus>` during the node command setup anyway, so we can just use this in the tree as well