### PR TITLE
chore: simplify HashedCursorFactory trait

### DIFF
--- a/bin/reth/src/debug_cmd/in_memory_merkle.rs
+++ b/bin/reth/src/debug_cmd/in_memory_merkle.rs
@@ -180,7 +180,7 @@ impl Command {
         let tx = provider.tx_ref();
         let hashed_cursor_factory = HashedPostStateCursorFactory::new(tx, &hashed_post_state);
         let (in_memory_state_root, in_memory_updates) = StateRoot::new(tx)
-            .with_hashed_cursor_factory(&hashed_cursor_factory)
+            .with_hashed_cursor_factory(hashed_cursor_factory)
             .with_changed_account_prefixes(account_prefix_set)
             .with_changed_storage_prefixes(storage_prefix_set)
             .root_with_updates()?;

--- a/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
+++ b/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
@@ -201,7 +201,7 @@ impl BundleStateWithReceipts {
         let (account_prefix_set, storage_prefix_set) = hashed_post_state.construct_prefix_sets();
         let hashed_cursor_factory = HashedPostStateCursorFactory::new(tx, &hashed_post_state);
         StateRoot::new(tx)
-            .with_hashed_cursor_factory(&hashed_cursor_factory)
+            .with_hashed_cursor_factory(hashed_cursor_factory)
             .with_changed_account_prefixes(account_prefix_set)
             .with_changed_storage_prefixes(storage_prefix_set)
             .root()

--- a/crates/trie/src/hashed_cursor/default.rs
+++ b/crates/trie/src/hashed_cursor/default.rs
@@ -6,15 +6,15 @@ use reth_db::{
 };
 use reth_primitives::{Account, StorageEntry, B256};
 
-impl<'a, 'tx, TX: DbTx<'tx>> HashedCursorFactory<'a> for TX {
-    type AccountCursor = <TX as DbTxGAT<'a>>::Cursor<tables::HashedAccount> where Self: 'a;
-    type StorageCursor = <TX as DbTxGAT<'a>>::DupCursor<tables::HashedStorage> where Self: 'a;
+impl<'a, 'tx, TX: DbTx<'tx>> HashedCursorFactory for &'a TX {
+    type AccountCursor = <TX as DbTxGAT<'a>>::Cursor<tables::HashedAccount>;
+    type StorageCursor = <TX as DbTxGAT<'a>>::DupCursor<tables::HashedStorage>;
 
-    fn hashed_account_cursor(&'a self) -> Result<Self::AccountCursor, reth_db::DatabaseError> {
+    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor, reth_db::DatabaseError> {
         self.cursor_read::<tables::HashedAccount>()
     }
 
-    fn hashed_storage_cursor(&'a self) -> Result<Self::StorageCursor, reth_db::DatabaseError> {
+    fn hashed_storage_cursor(&self) -> Result<Self::StorageCursor, reth_db::DatabaseError> {
         self.cursor_dup_read::<tables::HashedStorage>()
     }
 }

--- a/crates/trie/src/hashed_cursor/mod.rs
+++ b/crates/trie/src/hashed_cursor/mod.rs
@@ -8,21 +8,17 @@ mod post_state;
 pub use post_state::*;
 
 /// The factory trait for creating cursors over the hashed state.
-pub trait HashedCursorFactory<'a> {
+pub trait HashedCursorFactory {
     /// The hashed account cursor type.
-    type AccountCursor: HashedAccountCursor
-    where
-        Self: 'a;
+    type AccountCursor: HashedAccountCursor;
     /// The hashed storage cursor type.
-    type StorageCursor: HashedStorageCursor
-    where
-        Self: 'a;
+    type StorageCursor: HashedStorageCursor;
 
     /// Returns a cursor for iterating over all hashed accounts in the state.
-    fn hashed_account_cursor(&'a self) -> Result<Self::AccountCursor, reth_db::DatabaseError>;
+    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor, reth_db::DatabaseError>;
 
     /// Returns a cursor for iterating over all hashed storage entries in the state.
-    fn hashed_storage_cursor(&'a self) -> Result<Self::StorageCursor, reth_db::DatabaseError>;
+    fn hashed_storage_cursor(&self) -> Result<Self::StorageCursor, reth_db::DatabaseError>;
 }
 
 /// The cursor for iterating over hashed accounts.

--- a/crates/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/src/hashed_cursor/post_state.rs
@@ -170,8 +170,10 @@ impl<'a, 'b, TX> HashedPostStateCursorFactory<'a, 'b, TX> {
 }
 
 impl<'a, 'b, 'tx, TX: DbTx<'tx>> HashedCursorFactory for HashedPostStateCursorFactory<'a, 'b, TX> {
-    type AccountCursor = HashedPostStateAccountCursor<'b, <TX as DbTxGAT<'a>>::Cursor<tables::HashedAccount>>;
-    type StorageCursor = HashedPostStateStorageCursor<'b, <TX as DbTxGAT<'a>>::DupCursor<tables::HashedStorage>>;
+    type AccountCursor =
+        HashedPostStateAccountCursor<'b, <TX as DbTxGAT<'a>>::Cursor<tables::HashedAccount>>;
+    type StorageCursor =
+        HashedPostStateStorageCursor<'b, <TX as DbTxGAT<'a>>::DupCursor<tables::HashedStorage>>;
 
     fn hashed_account_cursor(&self) -> Result<Self::AccountCursor, reth_db::DatabaseError> {
         let cursor = self.tx.cursor_read::<tables::HashedAccount>()?;

--- a/crates/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/src/hashed_cursor/post_state.rs
@@ -156,6 +156,12 @@ pub struct HashedPostStateCursorFactory<'a, 'b, TX> {
     post_state: &'b HashedPostState,
 }
 
+impl<'a, 'b, TX> Clone for HashedPostStateCursorFactory<'a, 'b, TX> {
+    fn clone(&self) -> Self {
+        Self { tx: self.tx, post_state: self.post_state }
+    }
+}
+
 impl<'a, 'b, TX> HashedPostStateCursorFactory<'a, 'b, TX> {
     /// Create a new factory.
     pub fn new(tx: &'a TX, post_state: &'b HashedPostState) -> Self {
@@ -163,20 +169,16 @@ impl<'a, 'b, TX> HashedPostStateCursorFactory<'a, 'b, TX> {
     }
 }
 
-impl<'a, 'b, 'tx, TX: DbTx<'tx>> HashedCursorFactory<'a>
-    for HashedPostStateCursorFactory<'a, 'b, TX>
-where
-    'a: 'b,
-{
-    type AccountCursor = HashedPostStateAccountCursor<'b, <TX as DbTxGAT<'a>>::Cursor<tables::HashedAccount>> where Self: 'a;
-    type StorageCursor = HashedPostStateStorageCursor<'b, <TX as DbTxGAT<'a>>::DupCursor<tables::HashedStorage>> where Self: 'a;
+impl<'a, 'b, 'tx, TX: DbTx<'tx>> HashedCursorFactory for HashedPostStateCursorFactory<'a, 'b, TX> {
+    type AccountCursor = HashedPostStateAccountCursor<'b, <TX as DbTxGAT<'a>>::Cursor<tables::HashedAccount>>;
+    type StorageCursor = HashedPostStateStorageCursor<'b, <TX as DbTxGAT<'a>>::DupCursor<tables::HashedStorage>>;
 
-    fn hashed_account_cursor(&'a self) -> Result<Self::AccountCursor, reth_db::DatabaseError> {
+    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor, reth_db::DatabaseError> {
         let cursor = self.tx.cursor_read::<tables::HashedAccount>()?;
         Ok(HashedPostStateAccountCursor::new(cursor, self.post_state))
     }
 
-    fn hashed_storage_cursor(&'a self) -> Result<Self::StorageCursor, reth_db::DatabaseError> {
+    fn hashed_storage_cursor(&self) -> Result<Self::StorageCursor, reth_db::DatabaseError> {
         let cursor = self.tx.cursor_dup_read::<tables::HashedStorage>()?;
         Ok(HashedPostStateStorageCursor::new(cursor, self.post_state))
     }
@@ -544,12 +546,10 @@ mod tests {
     use reth_db::{database::Database, test_utils::create_test_rw_db, transaction::DbTxMut};
     use std::collections::BTreeMap;
 
-    fn assert_account_cursor_order<'a, 'b>(
-        factory: &'a impl HashedCursorFactory<'b>,
+    fn assert_account_cursor_order(
+        factory: &impl HashedCursorFactory,
         mut expected: impl Iterator<Item = (B256, Account)>,
-    ) where
-        'a: 'b,
-    {
+    ) {
         let mut cursor = factory.hashed_account_cursor().unwrap();
 
         let first_account = cursor.seek(B256::default()).unwrap();
@@ -563,12 +563,10 @@ mod tests {
         assert!(cursor.next().unwrap().is_none());
     }
 
-    fn assert_storage_cursor_order<'a, 'b>(
-        factory: &'a impl HashedCursorFactory<'b>,
+    fn assert_storage_cursor_order(
+        factory: &impl HashedCursorFactory,
         expected: impl Iterator<Item = (B256, BTreeMap<B256, U256>)>,
-    ) where
-        'a: 'b,
-    {
+    ) {
         let mut cursor = factory.hashed_storage_cursor().unwrap();
 
         for (account, storage) in expected {


### PR DESCRIPTION
lifetime param in trait is much harder to understand, and also cause all use place to add that lifetime param.