### PR TITLE
fix: order transactions by nonce before inserting into txpool

### DIFF
--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -653,12 +653,6 @@ where
             return
         }
 
-        // Sort response by nonce so 4844 transactions can be inserted in nonce order.
-        //
-        // This is required because the pool does not allow nonce gaps for blob transactions, and
-        // the response is not necessarily ordered by nonce.
-        transactions.sort_by_key(|tx| tx.nonce());
-
         // tracks the quality of the given transactions
         let mut has_bad_transactions = false;
         let mut num_already_seen = 0;

--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -645,7 +645,7 @@ where
     fn import_transactions(
         &mut self,
         peer_id: PeerId,
-        mut transactions: Vec<PooledTransactionsElement>,
+        transactions: Vec<PooledTransactionsElement>,
         source: TransactionSource,
     ) {
         // If the node is pipeline syncing, ignore transactions

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -734,6 +734,7 @@ where
                 // we can't fit this _blob_ transaction into the block, so we mark it as invalid,
                 // which removes its dependent transactions from the iterator. This is similar to
                 // the gas limit condition for regular transactions above.
+                trace!(target: "payload_builder", tx=?tx.hash, ?sum_blob_gas_used, ?tx_blob_gas, "skipping blob transaction because it would exceed the max data gas per block");
                 best_txs.mark_invalid(&pool_tx);
                 continue
             }

--- a/crates/primitives/src/transaction/pooled.rs
+++ b/crates/primitives/src/transaction/pooled.rs
@@ -88,6 +88,16 @@ impl PooledTransactionsElement {
         }
     }
 
+    /// Returns the transaction nonce.
+    pub fn nonce(&self) -> u64 {
+        match self {
+            Self::Legacy { transaction, .. } => transaction.nonce,
+            Self::Eip2930 { transaction, .. } => transaction.nonce,
+            Self::Eip1559 { transaction, .. } => transaction.nonce,
+            Self::BlobTransaction(blob_tx) => blob_tx.transaction.nonce,
+        }
+    }
+
     /// Recover signer from signature and hash.
     ///
     /// Returns `None` if the transaction's signature is invalid, see also [Self::recover_signer].


### PR DESCRIPTION
Fixes #4961

This test originally failed due to encoding issues, and because we did not announce hashes to peers even if there were no full transactions to announce. After these were fixed, it still ended up flaking.

Recall that the test does the following:
1. Sends 5 transactions to client A using `eth_sendRawTransaction`, each dependent on each other, with 5 blobs each (maximum is 6)
2. Sends 5 single-blob transactions to client B
3. Sends `engine_getPayload` to client A, expecting the block to have 6 blob transactions with 2 transactions:
  * 5-blob tx with nonce 0 (reth does this successfully)
  * A 1-blob tx
4. Send `newPayload` / `getPayload` for 5 more blocks, expecting all 5 blocks to be full of blobs.

When hashes were announced, they were not necessarily announced in nonce-order. This means when the block-building node sent out requests with tx hashes, it did not always receive those transactions in nonce-order. Because these transactions were inserted into the pool in this original order, the pool would sometimes reject many of these transactions for nonce-gaps, even though the response packet contained the entire dependent chain of transactions.

This resolves that issue by sorting transaction responses by nonce right before inserting into the pool. The test now passes.