### PR TITLE
chore: extract validate tx impl from trait impl

### DIFF
--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -5,7 +5,7 @@ use crate::{
     error::{Eip4844PoolTransactionError, InvalidPoolTransactionError},
     traits::TransactionOrigin,
     validate::{ValidTransaction, ValidationTask, MAX_INIT_CODE_SIZE, TX_MAX_SIZE},
-    EthBlobTransactionSidecar, EthPoolTransaction, TransactionValidationOutcome,
+    EthBlobTransactionSidecar, EthPoolTransaction, PoolTransaction, TransactionValidationOutcome,
     TransactionValidationTaskExecutor, TransactionValidator,
 };
 use reth_primitives::{
@@ -33,6 +33,23 @@ pub struct EthTransactionValidator<Client, T> {
     inner: Arc<EthTransactionValidatorInner<Client, T>>,
 }
 
+impl<Client, Tx> EthTransactionValidator<Client, Tx>
+where
+    Client: StateProviderFactory,
+    Tx: EthPoolTransaction,
+{
+    /// Validates a single transaction.
+    ///
+    /// See also [TransactionValidator::validate_transaction]
+    pub fn validate_one(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Tx,
+    ) -> TransactionValidationOutcome<Tx> {
+        self.inner.validate_one(origin, transaction)
+    }
+}
+
 #[async_trait::async_trait]
 impl<Client, Tx> TransactionValidator for EthTransactionValidator<Client, Tx>
 where
@@ -46,7 +63,7 @@ where
         origin: TransactionOrigin,
         transaction: Self::Transaction,
     ) -> TransactionValidationOutcome<Self::Transaction> {
-        self.inner.validate_transaction(origin, transaction).await
+        self.validate_one(origin, transaction)
     }
 
     fn on_new_head_block(&self, new_tip_block: &SealedBlock) {
@@ -92,19 +109,17 @@ impl<Client, Tx> EthTransactionValidatorInner<Client, Tx> {
     }
 }
 
-#[async_trait::async_trait]
-impl<Client, Tx> TransactionValidator for EthTransactionValidatorInner<Client, Tx>
+impl<Client, Tx> EthTransactionValidatorInner<Client, Tx>
 where
     Client: StateProviderFactory,
     Tx: EthPoolTransaction,
 {
-    type Transaction = Tx;
-
-    async fn validate_transaction(
+    /// Validates a single transaction.
+    fn validate_one(
         &self,
         origin: TransactionOrigin,
-        mut transaction: Self::Transaction,
-    ) -> TransactionValidationOutcome<Self::Transaction> {
+        mut transaction: Tx,
+    ) -> TransactionValidationOutcome<Tx> {
         // Checks for tx_type
         match transaction.tx_type() {
             LEGACY_TX_TYPE_ID => {
@@ -157,7 +172,7 @@ where
 
         // Check whether the init code size has been exceeded.
         if self.fork_tracker.is_shanghai_activated() {
-            if let Err(err) = self.ensure_max_init_code_size(&transaction, MAX_INIT_CODE_SIZE) {
+            if let Err(err) = ensure_max_init_code_size(&transaction, MAX_INIT_CODE_SIZE) {
                 return TransactionValidationOutcome::Invalid(transaction, err)
             }
         }
@@ -606,5 +621,21 @@ impl ForkTracker {
     /// Returns true if the Shanghai fork is activated.
     pub(crate) fn is_cancun_activated(&self) -> bool {
         self.cancun.load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
+/// Ensure that the code size is not greater than `max_init_code_size`.
+/// `max_init_code_size` should be configurable so this will take it as an argument.
+pub fn ensure_max_init_code_size<T: PoolTransaction>(
+    transaction: &T,
+    max_init_code_size: usize,
+) -> Result<(), InvalidPoolTransactionError> {
+    if transaction.kind().is_create() && transaction.input().len() > max_init_code_size {
+        Err(InvalidPoolTransactionError::ExceedsMaxInitCodeSize(
+            transaction.size(),
+            max_init_code_size,
+        ))
+    } else {
+        Ok(())
     }
 }

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     traits::{PoolTransaction, TransactionOrigin},
 };
 use reth_primitives::{
-    Address, BlobTransactionSidecar, IntoRecoveredTransaction, SealedBlock, TransactionKind,
+    Address, BlobTransactionSidecar, IntoRecoveredTransaction, SealedBlock,
     TransactionSignedEcRecovered, TxHash, B256, U256,
 };
 use std::{fmt, time::Instant};
@@ -16,7 +16,7 @@ mod eth;
 mod task;
 
 /// A `TransactionValidator` implementation that validates ethereum transaction.
-pub use eth::{EthTransactionValidator, EthTransactionValidatorBuilder};
+pub use eth::*;
 
 /// A spawnable task that performs transaction validation.
 pub use task::{TransactionValidationTaskExecutor, ValidationTask};
@@ -172,24 +172,6 @@ pub trait TransactionValidator: Send + Sync {
     ///
     /// This can be used to update fork specific values (timestamp).
     fn on_new_head_block(&self, _new_tip_block: &SealedBlock) {}
-
-    /// Ensure that the code size is not greater than `max_init_code_size`.
-    /// `max_init_code_size` should be configurable so this will take it as an argument.
-    fn ensure_max_init_code_size(
-        &self,
-        transaction: &Self::Transaction,
-        max_init_code_size: usize,
-    ) -> Result<(), InvalidPoolTransactionError> {
-        if *transaction.kind() == TransactionKind::Create && transaction.size() > max_init_code_size
-        {
-            Err(InvalidPoolTransactionError::ExceedsMaxInitCodeSize(
-                transaction.size(),
-                max_init_code_size,
-            ))
-        } else {
-            Ok(())
-        }
-    }
 }
 
 /// A valid transaction in the pool.


### PR DESCRIPTION
this moves the impl of validate_transaction to type implementation to make it easier to use.

this is also prep for something like `validate_many`