### PR TITLE
feat(ef-tests): validate state root

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ cargo test --workspace --features geth-tests
 # Note: Requires cloning https://github.com/ethereum/tests
 # 
 #   cd testing/ef-tests && git clone https://github.com/ethereum/tests ethereum-tests
-cargo test --workspace --features ef-tests
+cargo test -p ef-tests --features ef-tests
 ```
 
 We recommend using [`cargo nextest`](https://nexte.st/) to speed up testing. With nextest installed, simply substitute `cargo test` with `cargo nextest run`.

--- a/testing/ef-tests/src/models.rs
+++ b/testing/ef-tests/src/models.rs
@@ -26,7 +26,9 @@ pub struct BlockchainTest {
     /// Block data.
     pub blocks: Vec<Block>,
     /// The expected post state.
-    pub post_state: Option<RootOrState>,
+    pub post_state: Option<BTreeMap<Address, Account>>,
+    /// The expected post state merkle root.
+    pub post_state_hash: Option<B256>,
     /// The test pre-state.
     pub pre: State,
     /// Hash of the best block.
@@ -153,23 +155,28 @@ impl State {
         Tx: DbTxMut<'a>,
     {
         for (&address, account) in self.0.iter() {
+            let hashed_address = keccak256(address);
             let has_code = !account.code.is_empty();
             let code_hash = has_code.then(|| keccak256(&account.code));
-            tx.put::<tables::PlainAccountState>(
-                address,
-                RethAccount {
-                    balance: account.balance.0,
-                    nonce: account.nonce.0.to::<u64>(),
-                    bytecode_hash: code_hash,
-                },
-            )?;
+            let reth_account = RethAccount {
+                balance: account.balance.0,
+                nonce: account.nonce.0.to::<u64>(),
+                bytecode_hash: code_hash,
+            };
+            tx.put::<tables::PlainAccountState>(address, reth_account)?;
+            tx.put::<tables::HashedAccount>(hashed_address, reth_account)?;
             if let Some(code_hash) = code_hash {
                 tx.put::<tables::Bytecodes>(code_hash, Bytecode::new_raw(account.code.clone()))?;
             }
             account.storage.iter().try_for_each(|(k, v)| {
+                let storage_key = B256::from_slice(&k.0.to_be_bytes::<32>());
                 tx.put::<tables::PlainStorageState>(
                     address,
-                    StorageEntry { key: B256::from_slice(&k.0.to_be_bytes::<32>()), value: v.0 },
+                    StorageEntry { key: storage_key, value: v.0 },
+                )?;
+                tx.put::<tables::HashedStorage>(
+                    hashed_address,
+                    StorageEntry { key: keccak256(storage_key), value: v.0 },
                 )
             })?;
         }
@@ -184,16 +191,6 @@ impl Deref for State {
     fn deref(&self) -> &Self::Target {
         &self.0
     }
-}
-
-/// Merkle root hash or storage accounts.
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
-#[serde(untagged)]
-pub enum RootOrState {
-    /// If state is too big, only state root is present
-    Root(B256),
-    /// State
-    State(BTreeMap<Address, Account>),
 }
 
 /// An account.

--- a/testing/ef-tests/src/models.rs
+++ b/testing/ef-tests/src/models.rs
@@ -168,7 +168,7 @@ impl State {
             if let Some(code_hash) = code_hash {
                 tx.put::<tables::Bytecodes>(code_hash, Bytecode::new_raw(account.code.clone()))?;
             }
-            account.storage.iter().try_for_each(|(k, v)| {
+            account.storage.iter().filter(|(_, v)| v.0 != U256::ZERO).try_for_each(|(k, v)| {
                 let storage_key = B256::from_slice(&k.0.to_be_bytes::<32>());
                 tx.put::<tables::PlainStorageState>(
                     address,

--- a/testing/ef-tests/src/result.rs
+++ b/testing/ef-tests/src/result.rs
@@ -17,6 +17,9 @@ pub enum Error {
     /// The test was skipped
     #[error("Test was skipped")]
     Skipped,
+    /// No post state found in test
+    #[error("No post state found for validation")]
+    MissingPostState,
     /// An IO error occurred
     #[error("An error occurred interacting with the file system at {path}: {error}")]
     Io {


### PR DESCRIPTION
Replaces #4384

## Description 

Validate state root in EF tests.
If the test needs to be verified using state root, it will be supplied as `postStateHash`.