### PR TITLE
chore: replace deprecated hub with gh for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,4 +232,4 @@ jobs:
               assets+=("-a" "$asset/$asset")
           done
           tag_name="${{ env.VERSION }}"
-          echo "$body" | hub release create --draft "${assets[@]}" -F "-" "$tag_name"
+          echo "$body" | gh release create --draft "${assets[@]}" -F "-" "$tag_name"


### PR DESCRIPTION
**Changes introduced in this PR:**
- The tool hub that is used to create draft releases has been removed as of October 2. See: https://github.com/actions/runner-images/issues/8362
- This change replaces `hub` usage in favour of [`gh`](https://cli.github.com/manual/gh_release_create) 