### PR TITLE
fix(ef-tests): seal engine typo and deserialization

### DIFF
--- a/testing/ef-tests/src/models.rs
+++ b/testing/ef-tests/src/models.rs
@@ -35,7 +35,7 @@ pub struct BlockchainTest {
     pub network: ForkSpec,
     #[serde(default)]
     /// Engine spec.
-    pub self_engine: SealEngine,
+    pub seal_engine: SealEngine,
 }
 
 /// A block header in an Ethereum blockchain test.
@@ -357,7 +357,6 @@ impl From<ForkSpec> for ChainSpec {
 
 /// Possible seal engines.
 #[derive(Debug, PartialEq, Eq, Default, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub enum SealEngine {
     /// No consensus checks.
     #[default]


### PR DESCRIPTION
## Description

* fix typo: `self_engine` -> `seal_engine`
* fix SealEngine deserialization: should be PascalCase instead of camelCase. see [json schema](https://github.com/ethereum/tests/blob/a33949df17a1c382ffee5666e66d26bde7a089f9/JSONSchema/definitions.json#L321-L332)

NOTE: contrary to the schema we omit `SealEngine::Ethash` since it has been deprecated and no longer used