### PR TITLE
implementations for DbTx functions for TxMock

### DIFF
--- a/crates/storage/db/src/abstraction/mock.rs
+++ b/crates/storage/db/src/abstraction/mock.rs
@@ -60,25 +60,23 @@ impl<'a> DbTx<'a> for TxMock {
     }
 
     fn commit(self) -> Result<bool, DatabaseError> {
-        todo!()
+        Ok(true)
     }
 
-    fn drop(self) {
-        todo!()
-    }
+    fn drop(self) {}
 
     fn cursor_read<T: Table>(&self) -> Result<<Self as DbTxGAT<'_>>::Cursor<T>, DatabaseError> {
-        todo!()
+        Ok(CursorMock { _cursor: 0 })
     }
 
     fn cursor_dup_read<T: DupSort>(
         &self,
     ) -> Result<<Self as DbTxGAT<'_>>::DupCursor<T>, DatabaseError> {
-        todo!()
+        Ok(CursorMock { _cursor: 0 })
     }
 
     fn entries<T: Table>(&self) -> Result<usize, DatabaseError> {
-        todo!()
+        Ok(self._table.len())
     }
 }
 


### PR DESCRIPTION
Issue : https://github.com/paradigmxyz/reth/issues/4664

I tried to implement get<T: Table>(&self, _key: T::key) i used decompress and encode but i wasn't able to use decode since value doesn't implement Decode trait and i think it's not the right way to implement that get function, i show what i did 

```rust
fn get<T: Table>(&self, key: T::Key) -> Result<Option<T::Value>, DatabaseError> {
        
        let byte_key = key.encode().as_ref();

        match self._table.get(byte_key) {
            Some(value) => {
                let decompressed_data = T::Value::decompress(value.as_ref())?;
                
           
                let actual_value = T::Value::decode(&decompressed_data)?;

                Ok(Some(actual_value))
            },
            None => Ok(None),
        }
    }
```


I don't think i will be able to do this

I hope the other implementation are correct


