### PR TITLE
Revert "perf: move common_prefix_len out of loop"

### DIFF
--- a/crates/primitives/src/trie/hash_builder/mod.rs
+++ b/crates/primitives/src/trie/hash_builder/mod.rs
@@ -182,7 +182,6 @@ impl HashBuilder {
 
         tracing::debug!(target: "trie::hash_builder", ?current, ?succeeding, "updating merkle tree");
 
-        let common_prefix_len = succeeding.common_prefix_length(&current);
         let mut i = 0;
         loop {
             let span = tracing::span!(
@@ -198,6 +197,7 @@ impl HashBuilder {
             let preceding_exists = !self.groups.is_empty();
             let preceding_len: usize = self.groups.len().saturating_sub(1);
 
+            let common_prefix_len = succeeding.common_prefix_length(&current);
             let len = std::cmp::max(preceding_len, common_prefix_len);
             assert!(len < current.len());
 


### PR DESCRIPTION
Reverts paradigmxyz/reth#5036

`common_prefix_len` was inside the loop because it gets truncated at the end of the iteration. Rare case that was not hit in tests
https://github.com/paradigmxyz/reth/blob/821612cc27a174aa81cfb4789834105064ad0057/crates/primitives/src/trie/hash_builder/mod.rs#L329-L331