### PR TITLE
remove lifetime param in storage trait

### DIFF
--- a/bin/reth/src/db/diff.rs
+++ b/bin/reth/src/db/diff.rs
@@ -148,9 +148,9 @@ impl Command {
 }
 
 /// Find diffs for a table, then analyzing the result
-fn find_diffs<'a, T: Table>(
-    primary_tx: impl DbTx<'a>,
-    secondary_tx: impl DbTx<'a>,
+fn find_diffs<T: Table>(
+    primary_tx: impl DbTx,
+    secondary_tx: impl DbTx,
     output_dir: impl AsRef<Path>,
 ) -> eyre::Result<()>
 where
@@ -231,9 +231,9 @@ where
 
 /// This diff algorithm is slightly different, it will walk _each_ table, cross-checking for the
 /// element in the other table.
-fn find_diffs_advanced<'a, T: Table>(
-    primary_tx: &impl DbTx<'a>,
-    secondary_tx: &impl DbTx<'a>,
+fn find_diffs_advanced<T: Table>(
+    primary_tx: &impl DbTx,
+    secondary_tx: &impl DbTx,
 ) -> eyre::Result<TableDiffResult<T>>
 where
     T::Value: PartialEq,

--- a/crates/snapshot/src/segments/headers.rs
+++ b/crates/snapshot/src/segments/headers.rs
@@ -24,9 +24,9 @@ impl Headers {
     }
 
     // Generates the dataset to train a zstd dictionary with the most recent rows (at most 1000).
-    fn dataset_for_compression<'tx, T: Table<Key = BlockNumber>>(
+    fn dataset_for_compression<T: Table<Key = BlockNumber>>(
         &self,
-        tx: &impl DbTx<'tx>,
+        tx: &impl DbTx,
         range: &RangeInclusive<BlockNumber>,
         range_len: usize,
     ) -> RethResult<Vec<Vec<u8>>> {
@@ -40,11 +40,7 @@ impl Headers {
 }
 
 impl Segment for Headers {
-    fn snapshot<'tx>(
-        &self,
-        tx: &impl DbTx<'tx>,
-        range: RangeInclusive<BlockNumber>,
-    ) -> RethResult<()> {
+    fn snapshot(&self, tx: &impl DbTx, range: RangeInclusive<BlockNumber>) -> RethResult<()> {
         let range_len = range.clone().count();
         let mut jar = prepare_jar::<3, tables::Headers>(
             tx,

--- a/crates/snapshot/src/segments/mod.rs
+++ b/crates/snapshot/src/segments/mod.rs
@@ -18,16 +18,12 @@ pub(crate) type Rows<const COLUMNS: usize> = [Vec<Vec<u8>>; COLUMNS];
 /// A segment represents a snapshotting of some portion of the data.
 pub trait Segment {
     /// Snapshot data using the provided range.
-    fn snapshot<'tx>(
-        &self,
-        tx: &impl DbTx<'tx>,
-        range: RangeInclusive<BlockNumber>,
-    ) -> RethResult<()>;
+    fn snapshot(&self, tx: &impl DbTx, range: RangeInclusive<BlockNumber>) -> RethResult<()>;
 }
 
 /// Returns a [`NippyJar`] according to the desired configuration.
-pub(crate) fn prepare_jar<'tx, const COLUMNS: usize, T: Table>(
-    tx: &impl DbTx<'tx>,
+pub(crate) fn prepare_jar<const COLUMNS: usize, T: Table>(
+    tx: &impl DbTx,
     segment: SnapshotSegment,
     filters: Filters,
     compression: Compression,

--- a/crates/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/src/stages/hashing_storage.rs
@@ -620,9 +620,9 @@ mod tests {
                 .map_err(|e| e.into())
         }
 
-        fn insert_storage_entry<'a, TX: DbTxMut<'a>>(
+        fn insert_storage_entry<TX: DbTxMut>(
             &self,
-            tx: &'a TX,
+            tx: &TX,
             tid_address: BlockNumberAddress,
             entry: StorageEntry,
             hash: bool,

--- a/crates/stages/src/test_utils/test_db.rs
+++ b/crates/stages/src/test_utils/test_db.rs
@@ -198,10 +198,7 @@ impl TestTransaction {
     }
 
     /// Inserts a single [SealedHeader] into the corresponding tables of the headers stage.
-    fn insert_header<'a, TX: DbTxMut<'a> + DbTx<'a>>(
-        tx: &'a TX,
-        header: &SealedHeader,
-    ) -> Result<(), DbError> {
+    fn insert_header<TX: DbTxMut + DbTx>(tx: &TX, header: &SealedHeader) -> Result<(), DbError> {
         tx.put::<tables::CanonicalHeaders>(header.number, header.hash())?;
         tx.put::<tables::HeaderNumbers>(header.hash(), header.number)?;
         tx.put::<tables::Headers>(header.number, header.clone().unseal())

--- a/crates/storage/db/src/abstraction/database.rs
+++ b/crates/storage/db/src/abstraction/database.rs
@@ -12,9 +12,9 @@ use std::{fmt::Debug, sync::Arc};
 /// Sealed trait which cannot be implemented by 3rd parties, exposed only for implementers
 pub trait DatabaseGAT<'a, __ImplicitBounds: Sealed = Bounds<&'a Self>>: Send + Sync {
     /// RO database transaction
-    type TX: DbTx<'a> + Send + Sync + Debug;
+    type TX: DbTx + Send + Sync + Debug;
     /// RW database transaction
-    type TXMut: DbTxMut<'a> + DbTx<'a> + TableImporter<'a> + Send + Sync + Debug;
+    type TXMut: DbTxMut + DbTx + TableImporter + Send + Sync + Debug;
 }
 
 /// Main Database trait that spawns transactions to be executed.

--- a/crates/storage/db/src/abstraction/mock.rs
+++ b/crates/storage/db/src/abstraction/mock.rs
@@ -54,7 +54,7 @@ impl<'a> DbTxMutGAT<'a> for TxMock {
     type DupCursorMut<T: DupSort> = CursorMock;
 }
 
-impl<'a> DbTx<'a> for TxMock {
+impl DbTx for TxMock {
     fn get<T: Table>(&self, _key: T::Key) -> Result<Option<T::Value>, DatabaseError> {
         todo!()
     }
@@ -82,7 +82,7 @@ impl<'a> DbTx<'a> for TxMock {
     }
 }
 
-impl<'a> DbTxMut<'a> for TxMock {
+impl DbTxMut for TxMock {
     fn put<T: Table>(&self, _key: T::Key, _value: T::Value) -> Result<(), DatabaseError> {
         todo!()
     }
@@ -112,7 +112,7 @@ impl<'a> DbTxMut<'a> for TxMock {
     }
 }
 
-impl<'a> TableImporter<'a> for TxMock {}
+impl TableImporter for TxMock {}
 
 /// Cursor that iterates over table
 #[derive(Debug)]
@@ -120,7 +120,7 @@ pub struct CursorMock {
     _cursor: u32,
 }
 
-impl<'tx, T: Table> DbCursorRO<'tx, T> for CursorMock {
+impl<T: Table> DbCursorRO<T> for CursorMock {
     fn first(&mut self) -> PairResult<T> {
         todo!()
     }
@@ -149,30 +149,27 @@ impl<'tx, T: Table> DbCursorRO<'tx, T> for CursorMock {
         todo!()
     }
 
-    fn walk<'cursor>(
-        &'cursor mut self,
-        _start_key: Option<T::Key>,
-    ) -> Result<Walker<'cursor, 'tx, T, Self>, DatabaseError>
+    fn walk(&mut self, _start_key: Option<T::Key>) -> Result<Walker<'_, T, Self>, DatabaseError>
     where
         Self: Sized,
     {
         todo!()
     }
 
-    fn walk_range<'cursor>(
-        &'cursor mut self,
+    fn walk_range(
+        &mut self,
         _range: impl RangeBounds<T::Key>,
-    ) -> Result<RangeWalker<'cursor, 'tx, T, Self>, DatabaseError>
+    ) -> Result<RangeWalker<'_, T, Self>, DatabaseError>
     where
         Self: Sized,
     {
         todo!()
     }
 
-    fn walk_back<'cursor>(
-        &'cursor mut self,
+    fn walk_back(
+        &mut self,
         _start_key: Option<T::Key>,
-    ) -> Result<ReverseWalker<'cursor, 'tx, T, Self>, DatabaseError>
+    ) -> Result<ReverseWalker<'_, T, Self>, DatabaseError>
     where
         Self: Sized,
     {
@@ -180,7 +177,7 @@ impl<'tx, T: Table> DbCursorRO<'tx, T> for CursorMock {
     }
 }
 
-impl<'tx, T: DupSort> DbDupCursorRO<'tx, T> for CursorMock {
+impl<T: DupSort> DbDupCursorRO<T> for CursorMock {
     fn next_dup(&mut self) -> PairResult<T> {
         todo!()
     }
@@ -201,11 +198,11 @@ impl<'tx, T: DupSort> DbDupCursorRO<'tx, T> for CursorMock {
         todo!()
     }
 
-    fn walk_dup<'cursor>(
-        &'cursor mut self,
+    fn walk_dup(
+        &mut self,
         _key: Option<<T>::Key>,
         _subkey: Option<<T as DupSort>::SubKey>,
-    ) -> Result<DupWalker<'cursor, 'tx, T, Self>, DatabaseError>
+    ) -> Result<DupWalker<'_, T, Self>, DatabaseError>
     where
         Self: Sized,
     {
@@ -213,7 +210,7 @@ impl<'tx, T: DupSort> DbDupCursorRO<'tx, T> for CursorMock {
     }
 }
 
-impl<'tx, T: Table> DbCursorRW<'tx, T> for CursorMock {
+impl<T: Table> DbCursorRW<T> for CursorMock {
     fn upsert(
         &mut self,
         _key: <T as Table>::Key,
@@ -243,7 +240,7 @@ impl<'tx, T: Table> DbCursorRW<'tx, T> for CursorMock {
     }
 }
 
-impl<'tx, T: DupSort> DbDupCursorRW<'tx, T> for CursorMock {
+impl<T: DupSort> DbDupCursorRW<T> for CursorMock {
     fn delete_current_duplicates(&mut self) -> Result<(), DatabaseError> {
         todo!()
     }

--- a/crates/storage/db/src/abstraction/table.rs
+++ b/crates/storage/db/src/abstraction/table.rs
@@ -102,9 +102,9 @@ pub trait DupSort: Table {
 }
 
 /// Allows duplicating tables across databases
-pub trait TableImporter<'tx>: for<'a> DbTxMut<'a> {
+pub trait TableImporter: DbTxMut {
     /// Imports all table data from another transaction.
-    fn import_table<T: Table, R: DbTx<'tx>>(&self, source_tx: &R) -> Result<(), DatabaseError> {
+    fn import_table<T: Table, R: DbTx>(&self, source_tx: &R) -> Result<(), DatabaseError> {
         let mut destination_cursor = self.cursor_write::<T>()?;
 
         for kv in source_tx.cursor_read::<T>()?.walk(None)? {
@@ -116,7 +116,7 @@ pub trait TableImporter<'tx>: for<'a> DbTxMut<'a> {
     }
 
     /// Imports table data from another transaction within a range.
-    fn import_table_with_range<T: Table, R: DbTx<'tx>>(
+    fn import_table_with_range<T: Table, R: DbTx>(
         &self,
         source_tx: &R,
         from: Option<<T as Table>::Key>,
@@ -141,7 +141,7 @@ pub trait TableImporter<'tx>: for<'a> DbTxMut<'a> {
     }
 
     /// Imports all dupsort data from another transaction.
-    fn import_dupsort<T: DupSort, R: DbTx<'tx>>(&self, source_tx: &R) -> Result<(), DatabaseError> {
+    fn import_dupsort<T: DupSort, R: DbTx>(&self, source_tx: &R) -> Result<(), DatabaseError> {
         let mut destination_cursor = self.cursor_dup_write::<T>()?;
         let mut cursor = source_tx.cursor_dup_read::<T>()?;
 

--- a/crates/storage/db/src/abstraction/transaction.rs
+++ b/crates/storage/db/src/abstraction/transaction.rs
@@ -11,9 +11,9 @@ use crate::{
 /// Sealed trait which cannot be implemented by 3rd parties, exposed only for implementers
 pub trait DbTxGAT<'a, __ImplicitBounds: Sealed = Bounds<&'a Self>>: Send + Sync {
     /// Cursor GAT
-    type Cursor<T: Table>: DbCursorRO<'a, T> + Send + Sync;
+    type Cursor<T: Table>: DbCursorRO<T> + Send + Sync;
     /// DupCursor GAT
-    type DupCursor<T: DupSort>: DbDupCursorRO<'a, T> + DbCursorRO<'a, T> + Send + Sync;
+    type DupCursor<T: DupSort>: DbDupCursorRO<T> + DbCursorRO<T> + Send + Sync;
 }
 
 /// Implements the GAT method from:
@@ -22,18 +22,18 @@ pub trait DbTxGAT<'a, __ImplicitBounds: Sealed = Bounds<&'a Self>>: Send + Sync 
 /// Sealed trait which cannot be implemented by 3rd parties, exposed only for implementers
 pub trait DbTxMutGAT<'a, __ImplicitBounds: Sealed = Bounds<&'a Self>>: Send + Sync {
     /// Cursor GAT
-    type CursorMut<T: Table>: DbCursorRW<'a, T> + DbCursorRO<'a, T> + Send + Sync;
+    type CursorMut<T: Table>: DbCursorRW<T> + DbCursorRO<T> + Send + Sync;
     /// DupCursor GAT
-    type DupCursorMut<T: DupSort>: DbDupCursorRW<'a, T>
-        + DbCursorRW<'a, T>
-        + DbDupCursorRO<'a, T>
-        + DbCursorRO<'a, T>
+    type DupCursorMut<T: DupSort>: DbDupCursorRW<T>
+        + DbCursorRW<T>
+        + DbDupCursorRO<T>
+        + DbCursorRO<T>
         + Send
         + Sync;
 }
 
 /// Read only transaction
-pub trait DbTx<'tx>: for<'a> DbTxGAT<'a> {
+pub trait DbTx: for<'a> DbTxGAT<'a> {
     /// Get value
     fn get<T: Table>(&self, key: T::Key) -> Result<Option<T::Value>, DatabaseError>;
     /// Commit for read only transaction will consume and free transaction and allows
@@ -52,7 +52,7 @@ pub trait DbTx<'tx>: for<'a> DbTxGAT<'a> {
 }
 
 /// Read write transaction that allows writing to database
-pub trait DbTxMut<'tx>: for<'a> DbTxMutGAT<'a> {
+pub trait DbTxMut: for<'a> DbTxMutGAT<'a> {
     /// Put value to database
     fn put<T: Table>(&self, key: T::Key, value: T::Value) -> Result<(), DatabaseError>;
     /// Delete value from database

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -79,9 +79,9 @@ impl<'a, K: TransactionKind, E: EnvironmentKind> DbTxMutGAT<'a> for Tx<'_, K, E>
     type DupCursorMut<T: DupSort> = Cursor<'a, RW, T>;
 }
 
-impl<'a, E: EnvironmentKind> TableImporter<'a> for Tx<'_, RW, E> {}
+impl<E: EnvironmentKind> TableImporter for Tx<'_, RW, E> {}
 
-impl<'tx, K: TransactionKind, E: EnvironmentKind> DbTx<'tx> for Tx<'tx, K, E> {
+impl<K: TransactionKind, E: EnvironmentKind> DbTx for Tx<'_, K, E> {
     fn get<T: Table>(&self, key: T::Key) -> Result<Option<<T as Table>::Value>, DatabaseError> {
         self.inner
             .get(self.get_dbi::<T>()?, key.encode().as_ref())
@@ -123,7 +123,7 @@ impl<'tx, K: TransactionKind, E: EnvironmentKind> DbTx<'tx> for Tx<'tx, K, E> {
     }
 }
 
-impl<E: EnvironmentKind> DbTxMut<'_> for Tx<'_, RW, E> {
+impl<E: EnvironmentKind> DbTxMut for Tx<'_, RW, E> {
     fn put<T: Table>(&self, key: T::Key, value: T::Value) -> Result<(), DatabaseError> {
         let key = key.encode();
         self.inner

--- a/crates/storage/db/src/snapshot.rs
+++ b/crates/storage/db/src/snapshot.rs
@@ -32,12 +32,12 @@ macro_rules! generate_snapshot_func {
                 /// * `row_count`: Total rows to add to `NippyJar`. Must match row count in `range`.
                 /// * `nippy_jar`: Snapshot object responsible for file generation.
                 #[allow(non_snake_case)]
-                pub fn [<create_snapshot$(_ $tbl)+>]<'tx,
+                pub fn [<create_snapshot$(_ $tbl)+>]<
                     $($tbl: Table<Key=K>,)+
                     K
                 >
                 (
-                    tx: &impl DbTx<'tx>,
+                    tx: &impl DbTx,
                     range: RangeInclusive<K>,
                     additional: Option<Vec<Box<dyn Iterator<Item = Result<Vec<u8>, Box<dyn StdError + Send + Sync>>>>>>,
                     dict_compression_set: Option<Vec<impl Iterator<Item = Vec<u8>>>>,

--- a/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
+++ b/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
@@ -193,10 +193,7 @@ impl BundleStateWithReceipts {
     /// # Returns
     ///
     /// The state root for this [BundleState].
-    pub fn state_root_slow<'a, 'tx, TX: DbTx<'tx>>(
-        &self,
-        tx: &'a TX,
-    ) -> Result<B256, StateRootError> {
+    pub fn state_root_slow<TX: DbTx>(&self, tx: &TX) -> Result<B256, StateRootError> {
         let hashed_post_state = self.hash_state_slow();
         let (account_prefix_set, storage_prefix_set) = hashed_post_state.construct_prefix_sets();
         let hashed_cursor_factory = HashedPostStateCursorFactory::new(tx, &hashed_post_state);
@@ -338,7 +335,7 @@ impl BundleStateWithReceipts {
     ///
     /// `omit_changed_check` should be set to true of bundle has some of it data
     /// detached, This would make some original values not known.
-    pub fn write_to_db<'a, TX: DbTxMut<'a> + DbTx<'a>>(
+    pub fn write_to_db<TX: DbTxMut + DbTx>(
         self,
         tx: &TX,
         is_value_known: OriginalValuesKnown,

--- a/crates/storage/provider/src/bundle_state/state_changes.rs
+++ b/crates/storage/provider/src/bundle_state/state_changes.rs
@@ -21,10 +21,7 @@ impl From<StateChangeset> for StateChanges {
 
 impl StateChanges {
     /// Write the post state to the database.
-    pub fn write_to_db<'a, TX: DbTxMut<'a> + DbTx<'a>>(
-        mut self,
-        tx: &TX,
-    ) -> Result<(), DatabaseError> {
+    pub fn write_to_db<TX: DbTxMut + DbTx>(mut self, tx: &TX) -> Result<(), DatabaseError> {
         // sort all entries so they can be written to database in more performant way.
         // and take smaller memory footprint.
         self.0.accounts.par_sort_by_key(|a| a.0);

--- a/crates/storage/provider/src/bundle_state/state_reverts.rs
+++ b/crates/storage/provider/src/bundle_state/state_reverts.rs
@@ -25,7 +25,7 @@ impl StateReverts {
     /// Write reverts to database.
     ///
     /// Note:: Reverts will delete all wiped storage from plain state.
-    pub fn write_to_db<'a, TX: DbTxMut<'a> + DbTx<'a>>(
+    pub fn write_to_db<TX: DbTxMut + DbTx>(
         self,
         tx: &TX,
         first_block: BlockNumber,

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -14,7 +14,6 @@ use reth_interfaces::RethResult;
 use reth_primitives::{
     Account, Address, BlockNumber, Bytecode, Bytes, StorageKey, StorageValue, B256,
 };
-use std::marker::PhantomData;
 
 /// State provider for a given block number which takes a tx reference.
 ///
@@ -28,15 +27,13 @@ use std::marker::PhantomData;
 /// - [tables::AccountChangeSet]
 /// - [tables::StorageChangeSet]
 #[derive(Debug)]
-pub struct HistoricalStateProviderRef<'a, 'b, TX: DbTx<'a>> {
+pub struct HistoricalStateProviderRef<'b, TX: DbTx> {
     /// Transaction
     tx: &'b TX,
     /// Block number is main index for the history state of accounts and storages.
     block_number: BlockNumber,
     /// Lowest blocks at which different parts of the state are available.
     lowest_available_blocks: LowestAvailableBlocks,
-    /// Phantom lifetime `'a`
-    _phantom: PhantomData<&'a TX>,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -47,15 +44,10 @@ pub enum HistoryInfo {
     MaybeInPlainState,
 }
 
-impl<'a, 'b, TX: DbTx<'a>> HistoricalStateProviderRef<'a, 'b, TX> {
+impl<'b, TX: DbTx> HistoricalStateProviderRef<'b, TX> {
     /// Create new StateProvider for historical block number
     pub fn new(tx: &'b TX, block_number: BlockNumber) -> Self {
-        Self {
-            tx,
-            block_number,
-            lowest_available_blocks: Default::default(),
-            _phantom: PhantomData {},
-        }
+        Self { tx, block_number, lowest_available_blocks: Default::default() }
     }
 
     /// Create new StateProvider for historical block number and lowest block numbers at which
@@ -65,7 +57,7 @@ impl<'a, 'b, TX: DbTx<'a>> HistoricalStateProviderRef<'a, 'b, TX> {
         block_number: BlockNumber,
         lowest_available_blocks: LowestAvailableBlocks,
     ) -> Self {
-        Self { tx, block_number, lowest_available_blocks, _phantom: PhantomData {} }
+        Self { tx, block_number, lowest_available_blocks }
     }
 
     /// Lookup an account in the AccountHistory table
@@ -159,7 +151,7 @@ impl<'a, 'b, TX: DbTx<'a>> HistoricalStateProviderRef<'a, 'b, TX> {
     }
 }
 
-impl<'a, 'b, TX: DbTx<'a>> AccountReader for HistoricalStateProviderRef<'a, 'b, TX> {
+impl<'b, TX: DbTx> AccountReader for HistoricalStateProviderRef<'b, TX> {
     /// Get basic account information.
     fn basic_account(&self, address: Address) -> RethResult<Option<Account>> {
         match self.account_history_lookup(address)? {
@@ -181,7 +173,7 @@ impl<'a, 'b, TX: DbTx<'a>> AccountReader for HistoricalStateProviderRef<'a, 'b, 
     }
 }
 
-impl<'a, 'b, TX: DbTx<'a>> BlockHashReader for HistoricalStateProviderRef<'a, 'b, TX> {
+impl<'b, TX: DbTx> BlockHashReader for HistoricalStateProviderRef<'b, TX> {
     /// Get block hash by number.
     fn block_hash(&self, number: u64) -> RethResult<Option<B256>> {
         self.tx.get::<tables::CanonicalHeaders>(number).map_err(Into::into)
@@ -205,13 +197,13 @@ impl<'a, 'b, TX: DbTx<'a>> BlockHashReader for HistoricalStateProviderRef<'a, 'b
     }
 }
 
-impl<'a, 'b, TX: DbTx<'a>> StateRootProvider for HistoricalStateProviderRef<'a, 'b, TX> {
+impl<'b, TX: DbTx> StateRootProvider for HistoricalStateProviderRef<'b, TX> {
     fn state_root(&self, _post_state: &BundleStateWithReceipts) -> RethResult<B256> {
         Err(ProviderError::StateRootNotAvailableForHistoricalBlock.into())
     }
 }
 
-impl<'a, 'b, TX: DbTx<'a>> StateProvider for HistoricalStateProviderRef<'a, 'b, TX> {
+impl<'b, TX: DbTx> StateProvider for HistoricalStateProviderRef<'b, TX> {
     /// Get storage.
     fn storage(
         &self,
@@ -260,26 +252,19 @@ impl<'a, 'b, TX: DbTx<'a>> StateProvider for HistoricalStateProviderRef<'a, 'b, 
 /// State provider for a given block number.
 /// For more detailed description, see [HistoricalStateProviderRef].
 #[derive(Debug)]
-pub struct HistoricalStateProvider<'a, TX: DbTx<'a>> {
+pub struct HistoricalStateProvider<TX: DbTx> {
     /// Database transaction
     tx: TX,
     /// State at the block number is the main indexer of the state.
     block_number: BlockNumber,
     /// Lowest blocks at which different parts of the state are available.
     lowest_available_blocks: LowestAvailableBlocks,
-    /// Phantom lifetime `'a`
-    _phantom: PhantomData<&'a TX>,
 }
 
-impl<'a, TX: DbTx<'a>> HistoricalStateProvider<'a, TX> {
+impl<TX: DbTx> HistoricalStateProvider<TX> {
     /// Create new StateProvider for historical block number
     pub fn new(tx: TX, block_number: BlockNumber) -> Self {
-        Self {
-            tx,
-            block_number,
-            lowest_available_blocks: Default::default(),
-            _phantom: PhantomData {},
-        }
+        Self { tx, block_number, lowest_available_blocks: Default::default() }
     }
 
     /// Set the lowest block number at which the account history is available.
@@ -302,7 +287,7 @@ impl<'a, TX: DbTx<'a>> HistoricalStateProvider<'a, TX> {
 
     /// Returns a new provider that takes the `TX` as reference
     #[inline(always)]
-    fn as_ref<'b>(&'b self) -> HistoricalStateProviderRef<'a, 'b, TX> {
+    fn as_ref(&self) -> HistoricalStateProviderRef<'_, TX> {
         HistoricalStateProviderRef::new_with_lowest_available_blocks(
             &self.tx,
             self.block_number,
@@ -312,7 +297,7 @@ impl<'a, TX: DbTx<'a>> HistoricalStateProvider<'a, TX> {
 }
 
 // Delegates all provider impls to [HistoricalStateProviderRef]
-delegate_provider_impls!(HistoricalStateProvider<'a, TX> where [TX: DbTx<'a>]);
+delegate_provider_impls!(HistoricalStateProvider<TX> where [TX: DbTx]);
 
 /// Lowest blocks at which different parts of the state are available.
 /// They may be [Some] if pruning is enabled.
@@ -365,8 +350,8 @@ mod tests {
 
     fn assert_state_provider<T: StateProvider>() {}
     #[allow(unused)]
-    fn assert_historical_state_provider<'txn, T: DbTx<'txn> + 'txn>() {
-        assert_state_provider::<HistoricalStateProvider<'txn, T>>();
+    fn assert_historical_state_provider<T: DbTx>() {
+        assert_state_provider::<HistoricalStateProvider<T>>();
     }
 
     #[test]

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -11,32 +11,29 @@ use reth_interfaces::{provider::ProviderError, RethError, RethResult};
 use reth_primitives::{
     keccak256, Account, Address, BlockNumber, Bytecode, Bytes, StorageKey, StorageValue, B256,
 };
-use std::marker::PhantomData;
 
 /// State provider over latest state that takes tx reference.
 #[derive(Debug)]
-pub struct LatestStateProviderRef<'a, 'b, TX: DbTx<'a>> {
+pub struct LatestStateProviderRef<'b, TX: DbTx> {
     /// database transaction
     db: &'b TX,
-    /// Phantom data over lifetime
-    phantom: PhantomData<&'a TX>,
 }
 
-impl<'a, 'b, TX: DbTx<'a>> LatestStateProviderRef<'a, 'b, TX> {
+impl<'b, TX: DbTx> LatestStateProviderRef<'b, TX> {
     /// Create new state provider
     pub fn new(db: &'b TX) -> Self {
-        Self { db, phantom: PhantomData {} }
+        Self { db }
     }
 }
 
-impl<'a, 'b, TX: DbTx<'a>> AccountReader for LatestStateProviderRef<'a, 'b, TX> {
+impl<'b, TX: DbTx> AccountReader for LatestStateProviderRef<'b, TX> {
     /// Get basic account information.
     fn basic_account(&self, address: Address) -> RethResult<Option<Account>> {
         self.db.get::<tables::PlainAccountState>(address).map_err(Into::into)
     }
 }
 
-impl<'a, 'b, TX: DbTx<'a>> BlockHashReader for LatestStateProviderRef<'a, 'b, TX> {
+impl<'b, TX: DbTx> BlockHashReader for LatestStateProviderRef<'b, TX> {
     /// Get block hash by number.
     fn block_hash(&self, number: u64) -> RethResult<Option<B256>> {
         self.db.get::<tables::CanonicalHeaders>(number).map_err(Into::into)
@@ -60,13 +57,13 @@ impl<'a, 'b, TX: DbTx<'a>> BlockHashReader for LatestStateProviderRef<'a, 'b, TX
     }
 }
 
-impl<'a, 'b, TX: DbTx<'a>> StateRootProvider for LatestStateProviderRef<'a, 'b, TX> {
+impl<'b, TX: DbTx> StateRootProvider for LatestStateProviderRef<'b, TX> {
     fn state_root(&self, bundle_state: &BundleStateWithReceipts) -> RethResult<B256> {
         bundle_state.state_root_slow(self.db).map_err(|err| RethError::Database(err.into()))
     }
 }
 
-impl<'a, 'b, TX: DbTx<'a>> StateProvider for LatestStateProviderRef<'a, 'b, TX> {
+impl<'b, TX: DbTx> StateProvider for LatestStateProviderRef<'b, TX> {
     /// Get storage.
     fn storage(
         &self,
@@ -107,28 +104,26 @@ impl<'a, 'b, TX: DbTx<'a>> StateProvider for LatestStateProviderRef<'a, 'b, TX> 
 
 /// State provider for the latest state.
 #[derive(Debug)]
-pub struct LatestStateProvider<'a, TX: DbTx<'a>> {
+pub struct LatestStateProvider<TX: DbTx> {
     /// database transaction
     db: TX,
-    /// Phantom lifetime `'a`
-    _phantom: PhantomData<&'a TX>,
 }
 
-impl<'a, TX: DbTx<'a>> LatestStateProvider<'a, TX> {
+impl<TX: DbTx> LatestStateProvider<TX> {
     /// Create new state provider
     pub fn new(db: TX) -> Self {
-        Self { db, _phantom: PhantomData {} }
+        Self { db }
     }
 
     /// Returns a new provider that takes the `TX` as reference
     #[inline(always)]
-    fn as_ref<'b>(&'b self) -> LatestStateProviderRef<'a, 'b, TX> {
+    fn as_ref(&self) -> LatestStateProviderRef<'_, TX> {
         LatestStateProviderRef::new(&self.db)
     }
 }
 
 // Delegates all provider impls to [LatestStateProviderRef]
-delegate_provider_impls!(LatestStateProvider<'a, TX> where [TX: DbTx<'a>]);
+delegate_provider_impls!(LatestStateProvider<TX> where [TX: DbTx]);
 
 #[cfg(test)]
 mod tests {
@@ -136,7 +131,7 @@ mod tests {
 
     fn assert_state_provider<T: StateProvider>() {}
     #[allow(unused)]
-    fn assert_latest_state_provider<'txn, T: DbTx<'txn> + 'txn>() {
-        assert_state_provider::<LatestStateProvider<'txn, T>>();
+    fn assert_latest_state_provider<T: DbTx>() {
+        assert_state_provider::<LatestStateProvider<T>>();
     }
 }

--- a/crates/trie/src/hashed_cursor/default.rs
+++ b/crates/trie/src/hashed_cursor/default.rs
@@ -6,7 +6,7 @@ use reth_db::{
 };
 use reth_primitives::{Account, StorageEntry, B256};
 
-impl<'a, 'tx, TX: DbTx<'tx>> HashedCursorFactory for &'a TX {
+impl<'a, TX: DbTx> HashedCursorFactory for &'a TX {
     type AccountCursor = <TX as DbTxGAT<'a>>::Cursor<tables::HashedAccount>;
     type StorageCursor = <TX as DbTxGAT<'a>>::DupCursor<tables::HashedStorage>;
 
@@ -19,9 +19,9 @@ impl<'a, 'tx, TX: DbTx<'tx>> HashedCursorFactory for &'a TX {
     }
 }
 
-impl<'tx, C> HashedAccountCursor for C
+impl<C> HashedAccountCursor for C
 where
-    C: DbCursorRO<'tx, tables::HashedAccount>,
+    C: DbCursorRO<tables::HashedAccount>,
 {
     fn seek(&mut self, key: B256) -> Result<Option<(B256, Account)>, reth_db::DatabaseError> {
         self.seek(key)
@@ -32,9 +32,9 @@ where
     }
 }
 
-impl<'tx, C> HashedStorageCursor for C
+impl<C> HashedStorageCursor for C
 where
-    C: DbCursorRO<'tx, tables::HashedStorage> + DbDupCursorRO<'tx, tables::HashedStorage>,
+    C: DbCursorRO<tables::HashedStorage> + DbDupCursorRO<tables::HashedStorage>,
 {
     fn is_storage_empty(&mut self, key: B256) -> Result<bool, reth_db::DatabaseError> {
         Ok(self.seek_exact(key)?.is_none())

--- a/crates/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/src/hashed_cursor/post_state.rs
@@ -169,7 +169,7 @@ impl<'a, 'b, TX> HashedPostStateCursorFactory<'a, 'b, TX> {
     }
 }
 
-impl<'a, 'b, 'tx, TX: DbTx<'tx>> HashedCursorFactory for HashedPostStateCursorFactory<'a, 'b, TX> {
+impl<'a, 'b, TX: DbTx> HashedCursorFactory for HashedPostStateCursorFactory<'a, 'b, TX> {
     type AccountCursor =
         HashedPostStateAccountCursor<'b, <TX as DbTxGAT<'a>>::Cursor<tables::HashedAccount>>;
     type StorageCursor =
@@ -246,9 +246,9 @@ impl<'b, C> HashedPostStateAccountCursor<'b, C> {
     }
 }
 
-impl<'b, 'tx, C> HashedAccountCursor for HashedPostStateAccountCursor<'b, C>
+impl<'b, C> HashedAccountCursor for HashedPostStateAccountCursor<'b, C>
 where
-    C: DbCursorRO<'tx, tables::HashedAccount>,
+    C: DbCursorRO<tables::HashedAccount>,
 {
     /// Seek the next entry for a given hashed account key.
     ///
@@ -408,9 +408,9 @@ impl<'b, C> HashedPostStateStorageCursor<'b, C> {
     }
 }
 
-impl<'b, 'tx, C> HashedStorageCursor for HashedPostStateStorageCursor<'b, C>
+impl<'b, C> HashedStorageCursor for HashedPostStateStorageCursor<'b, C>
 where
-    C: DbCursorRO<'tx, tables::HashedStorage> + DbDupCursorRO<'tx, tables::HashedStorage>,
+    C: DbCursorRO<tables::HashedStorage> + DbDupCursorRO<tables::HashedStorage>,
 {
     /// Returns `true` if the account has no storage entries.
     ///

--- a/crates/trie/src/prefix_set/loader.rs
+++ b/crates/trie/src/prefix_set/loader.rs
@@ -35,10 +35,7 @@ impl<'a, TX> PrefixSetLoader<'a, TX> {
     }
 }
 
-impl<'a, 'b, TX> PrefixSetLoader<'a, TX>
-where
-    TX: DbTx<'b>,
-{
+impl<'a, TX: DbTx> PrefixSetLoader<'a, TX> {
     /// Load all account and storage changes for the given block range.
     pub fn load(
         self,

--- a/crates/trie/src/proof.rs
+++ b/crates/trie/src/proof.rs
@@ -35,9 +35,9 @@ impl<'a, TX> Proof<'a, TX, &'a TX> {
     }
 }
 
-impl<'a, 'tx, TX, H> Proof<'a, TX, H>
+impl<'a, TX, H> Proof<'a, TX, H>
 where
-    TX: DbTx<'tx>,
+    TX: DbTx,
     H: HashedCursorFactory + Clone,
 {
     /// Generate an account proof from intermediate nodes.

--- a/crates/trie/src/trie.rs
+++ b/crates/trie/src/trie.rs
@@ -95,10 +95,7 @@ impl<'a, TX, H> StateRoot<'a, TX, H> {
     }
 }
 
-impl<'a, 'tx, TX> StateRoot<'a, TX, &'a TX>
-where
-    TX: DbTx<'tx>,
-{
+impl<'a, TX: DbTx> StateRoot<'a, TX, &'a TX> {
     /// Create a new [StateRoot] instance.
     pub fn new(tx: &'a TX) -> Self {
         Self {
@@ -180,9 +177,9 @@ where
     }
 }
 
-impl<'a, 'tx, TX, H> StateRoot<'a, TX, H>
+impl<'a, TX, H> StateRoot<'a, TX, H>
 where
-    TX: DbTx<'tx>,
+    TX: DbTx,
     H: HashedCursorFactory + Clone,
 {
     /// Walks the intermediate nodes of existing state trie (if any) and hashed entries. Feeds the
@@ -381,10 +378,7 @@ pub struct StorageRoot<'a, TX, H> {
     pub changed_prefixes: PrefixSet,
 }
 
-impl<'a, 'tx, TX> StorageRoot<'a, TX, &'a TX>
-where
-    TX: DbTx<'tx>,
-{
+impl<'a, TX: DbTx> StorageRoot<'a, TX, &'a TX> {
     /// Creates a new storage root calculator given an raw address.
     pub fn new(tx: &'a TX, address: Address) -> Self {
         Self::new_hashed(tx, keccak256(address))
@@ -441,9 +435,9 @@ impl<'a, TX, H> StorageRoot<'a, TX, H> {
     }
 }
 
-impl<'a, 'tx, TX, H> StorageRoot<'a, TX, H>
+impl<'a, TX, H> StorageRoot<'a, TX, H>
 where
-    TX: DbTx<'tx>,
+    TX: DbTx,
     H: HashedCursorFactory,
 {
     /// Walks the hashed storage table entries for a given address and calculates the storage root.
@@ -559,8 +553,8 @@ mod tests {
     use reth_provider::{DatabaseProviderRW, ProviderFactory};
     use std::{collections::BTreeMap, ops::Mul, str::FromStr};
 
-    fn insert_account<'a, TX: DbTxMut<'a>>(
-        tx: &TX,
+    fn insert_account(
+        tx: &impl DbTxMut,
         address: Address,
         account: Account,
         storage: &BTreeMap<B256, U256>,
@@ -570,11 +564,7 @@ mod tests {
         insert_storage(tx, hashed_address, storage);
     }
 
-    fn insert_storage<'a, TX: DbTxMut<'a>>(
-        tx: &TX,
-        hashed_address: B256,
-        storage: &BTreeMap<B256, U256>,
-    ) {
+    fn insert_storage(tx: &impl DbTxMut, hashed_address: B256, storage: &BTreeMap<B256, U256>) {
         for (k, v) in storage {
             tx.put::<tables::HashedStorage>(
                 hashed_address,

--- a/crates/trie/src/trie_cursor/account_cursor.rs
+++ b/crates/trie/src/trie_cursor/account_cursor.rs
@@ -14,9 +14,9 @@ impl<C> AccountTrieCursor<C> {
     }
 }
 
-impl<'a, C> TrieCursor<StoredNibbles> for AccountTrieCursor<C>
+impl<C> TrieCursor<StoredNibbles> for AccountTrieCursor<C>
 where
-    C: DbCursorRO<'a, tables::AccountsTrie>,
+    C: DbCursorRO<tables::AccountsTrie>,
 {
     fn seek_exact(
         &mut self,

--- a/crates/trie/src/trie_cursor/storage_cursor.rs
+++ b/crates/trie/src/trie_cursor/storage_cursor.rs
@@ -24,9 +24,9 @@ impl<C> StorageTrieCursor<C> {
     }
 }
 
-impl<'a, C> TrieCursor<StoredNibblesSubKey> for StorageTrieCursor<C>
+impl<C> TrieCursor<StoredNibblesSubKey> for StorageTrieCursor<C>
 where
-    C: DbDupCursorRO<'a, tables::StoragesTrie> + DbCursorRO<'a, tables::StoragesTrie>,
+    C: DbDupCursorRO<tables::StoragesTrie> + DbCursorRO<tables::StoragesTrie>,
 {
     fn seek_exact(
         &mut self,

--- a/crates/trie/src/updates.rs
+++ b/crates/trie/src/updates.rs
@@ -105,10 +105,7 @@ impl TrieUpdates {
     }
 
     /// Flush updates all aggregated updates to the database.
-    pub fn flush<'a, 'tx, TX>(self, tx: &'a TX) -> Result<(), reth_db::DatabaseError>
-    where
-        TX: DbTx<'tx> + DbTxMut<'tx>,
-    {
+    pub fn flush(self, tx: &(impl DbTx + DbTxMut)) -> Result<(), reth_db::DatabaseError> {
         if self.trie_operations.is_empty() {
             return Ok(())
         }

--- a/testing/ef-tests/src/models.rs
+++ b/testing/ef-tests/src/models.rs
@@ -150,10 +150,7 @@ pub struct State(BTreeMap<Address, Account>);
 
 impl State {
     /// Write the state to the database.
-    pub fn write_to_db<'a, Tx>(&self, tx: &'a Tx) -> Result<(), Error>
-    where
-        Tx: DbTxMut<'a>,
-    {
+    pub fn write_to_db(&self, tx: &impl DbTxMut) -> Result<(), Error> {
         for (&address, account) in self.0.iter() {
             let hashed_address = keccak256(address);
             let has_code = !account.code.is_empty();
@@ -211,10 +208,7 @@ impl Account {
     /// Check that the account matches what is in the database.
     ///
     /// In case of a mismatch, `Err(Error::Assertion)` is returned.
-    pub fn assert_db<'a, Tx>(&self, address: Address, tx: &'a Tx) -> Result<(), Error>
-    where
-        Tx: DbTx<'a>,
-    {
+    pub fn assert_db(&self, address: Address, tx: &impl DbTx) -> Result<(), Error> {
         let account = tx.get::<tables::PlainAccountState>(address)?.ok_or_else(|| {
             Error::Assertion(format!("Expected account ({address:?}) is missing from DB: {self:?}"))
         })?;


### PR DESCRIPTION
Based on my understanding of lifetime, traits with lifetime param has little benefits, and will cause all use places to repeat that lifetime. Unless the trait function need borrow data from parameters, like: 
```rust
trait Trait<'borrow> {
  fn need_data_from_param(&self, data: &'borrow [u8]) -> Output;
}
```
This is the case for `Deserialize` trait in serde, and `TableObject` trait  defined in this repo in `libmdbx-rs/src/codec.rs`.