### PR TITLE
feat: add promotion and demotion for blob fee updates

### DIFF
--- a/crates/transaction-pool/src/pool/blob.rs
+++ b/crates/transaction-pool/src/pool/blob.rs
@@ -110,7 +110,7 @@ impl<T: PoolTransaction> BlobTransactions<T> {
     }
 
     /// Returns all transactions which:
-    ///  * have a `max_fee_per_blob_gas` greater than or equal to the given `blob_fee`
+    ///  * have a `max_fee_per_blob_gas` greater than or equal to the given `blob_fee`, _and_
     ///  * have a `max_fee_per_gas` greater than or equal to the given `base_fee`
     fn satisfy_pending_fee_ids(&self, pending_fees: &PendingFees) -> Vec<TransactionId> {
         let mut transactions = Vec::new();
@@ -137,7 +137,7 @@ impl<T: PoolTransaction> BlobTransactions<T> {
     }
 
     /// Removes all transactions (and their descendants) which:
-    ///  * have a `max_fee_per_blob_gas` greater than or equal to the given `blob_fee`
+    ///  * have a `max_fee_per_blob_gas` greater than or equal to the given `blob_fee`, _and_
     ///  * have a `max_fee_per_gas` greater than or equal to the given `base_fee`
     ///
     /// Note: the transactions are not returned in a particular order.

--- a/crates/transaction-pool/src/pool/blob.rs
+++ b/crates/transaction-pool/src/pool/blob.rs
@@ -9,10 +9,10 @@ use std::{
     sync::Arc,
 };
 
-/// A set of __all__ validated blob transactions in the pool.
+/// A set of validated blob transactions in the pool that are __not pending__.
 ///
-/// The purpose of this pool is keep track of blob transactions that are either pending or queued
-/// and to evict the worst blob transactions once the sub-pool is full.
+/// The purpose of this pool is keep track of blob transactions that are queued and to evict the
+/// worst blob transactions once the sub-pool is full.
 ///
 /// This expects that certain constraints are met:
 ///   - blob transactions are always gap less

--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -101,7 +101,7 @@ impl<T: ParkedOrd> ParkedPool<T> {
         self.by_id.len()
     }
 
-    /// Whether the pool is empty
+    /// Returns whether the pool is empty
     #[cfg(test)]
     #[allow(unused)]
     pub(crate) fn is_empty(&self) -> bool {

--- a/crates/transaction-pool/src/pool/state.rs
+++ b/crates/transaction-pool/src/pool/state.rs
@@ -66,7 +66,7 @@ impl TxState {
 }
 
 /// Identifier for the transaction Sub-pool
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(u8)]
 pub enum SubPool {
     /// The queued sub-pool contains transactions that are not ready to be included in the next

--- a/crates/transaction-pool/src/pool/state.rs
+++ b/crates/transaction-pool/src/pool/state.rs
@@ -190,5 +190,10 @@ mod tests {
         state.remove(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK);
         assert!(state.is_blob());
         assert!(!state.is_pending());
+
+        state.insert(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK);
+        state.remove(TxState::ENOUGH_FEE_CAP_BLOCK);
+        assert!(state.is_blob());
+        assert!(!state.is_pending());
     }
 }

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -1959,28 +1959,80 @@ mod tests {
         fn assert_single_tx_starting_subpool<T: TransactionOrdering>(&self, pool: &TxPool<T>) {
             match self.subpool {
                 SubPool::Blob => {
-                    assert_eq!(pool.blob_transactions.len(), 1);
-                    assert!(pool.pending_pool.is_empty());
-                    assert!(pool.basefee_pool.is_empty());
-                    assert!(pool.queued_pool.is_empty());
+                    assert_eq!(
+                        pool.blob_transactions.len(),
+                        1,
+                        "pool length check failed at start of test: {self:?}"
+                    );
+                    assert!(
+                        pool.pending_pool.is_empty(),
+                        "pool length check failed at start of test: {self:?}"
+                    );
+                    assert!(
+                        pool.basefee_pool.is_empty(),
+                        "pool length check failed at start of test: {self:?}"
+                    );
+                    assert!(
+                        pool.queued_pool.is_empty(),
+                        "pool length check failed at start of test: {self:?}"
+                    );
                 }
                 SubPool::Pending => {
-                    assert!(pool.blob_transactions.is_empty());
-                    assert_eq!(pool.pending_pool.len(), 1);
-                    assert!(pool.basefee_pool.is_empty());
-                    assert!(pool.queued_pool.is_empty());
+                    assert!(
+                        pool.blob_transactions.is_empty(),
+                        "pool length check failed at start of test: {self:?}"
+                    );
+                    assert_eq!(
+                        pool.pending_pool.len(),
+                        1,
+                        "pool length check failed at start of test: {self:?}"
+                    );
+                    assert!(
+                        pool.basefee_pool.is_empty(),
+                        "pool length check failed at start of test: {self:?}"
+                    );
+                    assert!(
+                        pool.queued_pool.is_empty(),
+                        "pool length check failed at start of test: {self:?}"
+                    );
                 }
                 SubPool::BaseFee => {
-                    assert!(pool.blob_transactions.is_empty());
-                    assert!(pool.pending_pool.is_empty());
-                    assert_eq!(pool.basefee_pool.len(), 1);
-                    assert!(pool.queued_pool.is_empty());
+                    assert!(
+                        pool.blob_transactions.is_empty(),
+                        "pool length check failed at start of test: {self:?}"
+                    );
+                    assert!(
+                        pool.pending_pool.is_empty(),
+                        "pool length check failed at start of test: {self:?}"
+                    );
+                    assert_eq!(
+                        pool.basefee_pool.len(),
+                        1,
+                        "pool length check failed at start of test: {self:?}"
+                    );
+                    assert!(
+                        pool.queued_pool.is_empty(),
+                        "pool length check failed at start of test: {self:?}"
+                    );
                 }
                 SubPool::Queued => {
-                    assert!(pool.blob_transactions.is_empty());
-                    assert!(pool.pending_pool.is_empty());
-                    assert!(pool.basefee_pool.is_empty());
-                    assert_eq!(pool.queued_pool.len(), 1);
+                    assert!(
+                        pool.blob_transactions.is_empty(),
+                        "pool length check failed at start of test: {self:?}"
+                    );
+                    assert!(
+                        pool.pending_pool.is_empty(),
+                        "pool length check failed at start of test: {self:?}"
+                    );
+                    assert!(
+                        pool.basefee_pool.is_empty(),
+                        "pool length check failed at start of test: {self:?}"
+                    );
+                    assert_eq!(
+                        pool.queued_pool.len(),
+                        1,
+                        "pool length check failed at start of test: {self:?}"
+                    );
                 }
             }
         }
@@ -1991,28 +2043,80 @@ mod tests {
         fn assert_single_tx_ending_subpool<T: TransactionOrdering>(&self, pool: &TxPool<T>) {
             match self.new_subpool {
                 SubPool::Blob => {
-                    assert_eq!(pool.blob_transactions.len(), 1);
-                    assert!(pool.pending_pool.is_empty());
-                    assert!(pool.basefee_pool.is_empty());
-                    assert!(pool.queued_pool.is_empty());
+                    assert_eq!(
+                        pool.blob_transactions.len(),
+                        1,
+                        "pool length check failed for end of test: {self:?}"
+                    );
+                    assert!(
+                        pool.pending_pool.is_empty(),
+                        "pool length check failed for end of test: {self:?}"
+                    );
+                    assert!(
+                        pool.basefee_pool.is_empty(),
+                        "pool length check failed for end of test: {self:?}"
+                    );
+                    assert!(
+                        pool.queued_pool.is_empty(),
+                        "pool length check failed for end of test: {self:?}"
+                    );
                 }
                 SubPool::Pending => {
-                    assert!(pool.blob_transactions.is_empty());
-                    assert_eq!(pool.pending_pool.len(), 1);
-                    assert!(pool.basefee_pool.is_empty());
-                    assert!(pool.queued_pool.is_empty());
+                    assert!(
+                        pool.blob_transactions.is_empty(),
+                        "pool length check failed for end of test: {self:?}"
+                    );
+                    assert_eq!(
+                        pool.pending_pool.len(),
+                        1,
+                        "pool length check failed for end of test: {self:?}"
+                    );
+                    assert!(
+                        pool.basefee_pool.is_empty(),
+                        "pool length check failed for end of test: {self:?}"
+                    );
+                    assert!(
+                        pool.queued_pool.is_empty(),
+                        "pool length check failed for end of test: {self:?}"
+                    );
                 }
                 SubPool::BaseFee => {
-                    assert!(pool.blob_transactions.is_empty());
-                    assert!(pool.pending_pool.is_empty());
-                    assert_eq!(pool.basefee_pool.len(), 1);
-                    assert!(pool.queued_pool.is_empty());
+                    assert!(
+                        pool.blob_transactions.is_empty(),
+                        "pool length check failed for end of test: {self:?}"
+                    );
+                    assert!(
+                        pool.pending_pool.is_empty(),
+                        "pool length check failed for end of test: {self:?}"
+                    );
+                    assert_eq!(
+                        pool.basefee_pool.len(),
+                        1,
+                        "pool length check failed for end of test: {self:?}"
+                    );
+                    assert!(
+                        pool.queued_pool.is_empty(),
+                        "pool length check failed for end of test: {self:?}"
+                    );
                 }
                 SubPool::Queued => {
-                    assert!(pool.blob_transactions.is_empty());
-                    assert!(pool.pending_pool.is_empty());
-                    assert!(pool.basefee_pool.is_empty());
-                    assert_eq!(pool.queued_pool.len(), 1);
+                    assert!(
+                        pool.blob_transactions.is_empty(),
+                        "pool length check failed for end of test: {self:?}"
+                    );
+                    assert!(
+                        pool.pending_pool.is_empty(),
+                        "pool length check failed for end of test: {self:?}"
+                    );
+                    assert!(
+                        pool.basefee_pool.is_empty(),
+                        "pool length check failed for end of test: {self:?}"
+                    );
+                    assert_eq!(
+                        pool.queued_pool.len(),
+                        1,
+                        "pool length check failed for end of test: {self:?}"
+                    );
                 }
             }
         }
@@ -2118,7 +2222,10 @@ mod tests {
 
             // check tx state and derived subpool, it should not move into the blob pool
             let internal_tx = pool.all_transactions.txs.get(&id).unwrap();
-            assert_eq!(internal_tx.subpool, promotion_test.subpool);
+            assert_eq!(
+                internal_tx.subpool, promotion_test.subpool,
+                "Subpools do not match at start of test: {promotion_test:?}"
+            );
 
             // set block info with new base fee
             block_info.pending_basefee = promotion_test.basefee_update;
@@ -2127,7 +2234,10 @@ mod tests {
 
             // check tx state and derived subpool, it should not move into the blob pool
             let internal_tx = pool.all_transactions.txs.get(&id).unwrap();
-            assert_eq!(internal_tx.subpool, promotion_test.new_subpool);
+            assert_eq!(
+                internal_tx.subpool, promotion_test.new_subpool,
+                "Subpools do not match at end of test: {promotion_test:?}"
+            );
 
             // assert new pool lengths
             promotion_test.assert_single_tx_ending_subpool(&pool);

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -1852,14 +1852,14 @@ mod tests {
         let id = *validated.id();
         pool.add_transaction(validated, on_chain_balance, on_chain_nonce).unwrap();
 
-        assert_eq!(pool.pending_pool.len(), 1);
-
+        // assert pool lengths
         assert!(pool.pending_pool.is_empty());
-        assert_eq!(pool.basefee_pool.len(), 1);
+        assert_eq!(pool.blob_transactions.len(), 1);
 
+        // check tx state and derived subpool
         let internal_tx = pool.all_transactions.txs.get(&id).unwrap();
-        assert_eq!(internal_tx.subpool, SubPool::Blob);
         assert!(!internal_tx.state.contains(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK));
+        assert_eq!(internal_tx.subpool, SubPool::Blob);
 
         // set block info so the pools are updated
         block_info.pending_blob_fee = Some(tx.max_fee_per_blob_gas().unwrap());
@@ -1867,8 +1867,12 @@ mod tests {
 
         // check that the tx is promoted
         let internal_tx = pool.all_transactions.txs.get(&id).unwrap();
-        assert_eq!(internal_tx.subpool, SubPool::Pending);
         assert!(internal_tx.state.contains(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK));
+        assert_eq!(internal_tx.subpool, SubPool::Pending);
+
+        // wait....
+        assert_eq!(pool.pending_pool.len(), 1);
+        assert_eq!(pool.blob_transactions.len(), 0);
     }
 
     #[test]

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -1953,172 +1953,60 @@ mod tests {
             }
         }
 
+        fn assert_subpool_lengths<T: TransactionOrdering>(
+            &self,
+            pool: &TxPool<T>,
+            failure_message: String,
+            check_subpool: SubPool,
+        ) {
+            match check_subpool {
+                SubPool::Blob => {
+                    assert_eq!(pool.blob_transactions.len(), 1, "{failure_message}");
+                    assert!(pool.pending_pool.is_empty(), "{failure_message}");
+                    assert!(pool.basefee_pool.is_empty(), "{failure_message}");
+                    assert!(pool.queued_pool.is_empty(), "{failure_message}");
+                }
+                SubPool::Pending => {
+                    assert!(pool.blob_transactions.is_empty(), "{failure_message}");
+                    assert_eq!(pool.pending_pool.len(), 1, "{failure_message}");
+                    assert!(pool.basefee_pool.is_empty(), "{failure_message}");
+                    assert!(pool.queued_pool.is_empty(), "{failure_message}");
+                }
+                SubPool::BaseFee => {
+                    assert!(pool.blob_transactions.is_empty(), "{failure_message}");
+                    assert!(pool.pending_pool.is_empty(), "{failure_message}");
+                    assert_eq!(pool.basefee_pool.len(), 1, "{failure_message}");
+                    assert!(pool.queued_pool.is_empty(), "{failure_message}");
+                }
+                SubPool::Queued => {
+                    assert!(pool.blob_transactions.is_empty(), "{failure_message}");
+                    assert!(pool.pending_pool.is_empty(), "{failure_message}");
+                    assert!(pool.basefee_pool.is_empty(), "{failure_message}");
+                    assert_eq!(pool.queued_pool.len(), 1, "{failure_message}");
+                }
+            }
+        }
+
         /// Runs an assertion on the provided pool, ensuring that the transaction is in the correct
         /// subpool based on the starting condition of the test, assuming the pool contains only a
         /// single transaction.
         fn assert_single_tx_starting_subpool<T: TransactionOrdering>(&self, pool: &TxPool<T>) {
-            match self.subpool {
-                SubPool::Blob => {
-                    assert_eq!(
-                        pool.blob_transactions.len(),
-                        1,
-                        "pool length check failed at start of test: {self:?}"
-                    );
-                    assert!(
-                        pool.pending_pool.is_empty(),
-                        "pool length check failed at start of test: {self:?}"
-                    );
-                    assert!(
-                        pool.basefee_pool.is_empty(),
-                        "pool length check failed at start of test: {self:?}"
-                    );
-                    assert!(
-                        pool.queued_pool.is_empty(),
-                        "pool length check failed at start of test: {self:?}"
-                    );
-                }
-                SubPool::Pending => {
-                    assert!(
-                        pool.blob_transactions.is_empty(),
-                        "pool length check failed at start of test: {self:?}"
-                    );
-                    assert_eq!(
-                        pool.pending_pool.len(),
-                        1,
-                        "pool length check failed at start of test: {self:?}"
-                    );
-                    assert!(
-                        pool.basefee_pool.is_empty(),
-                        "pool length check failed at start of test: {self:?}"
-                    );
-                    assert!(
-                        pool.queued_pool.is_empty(),
-                        "pool length check failed at start of test: {self:?}"
-                    );
-                }
-                SubPool::BaseFee => {
-                    assert!(
-                        pool.blob_transactions.is_empty(),
-                        "pool length check failed at start of test: {self:?}"
-                    );
-                    assert!(
-                        pool.pending_pool.is_empty(),
-                        "pool length check failed at start of test: {self:?}"
-                    );
-                    assert_eq!(
-                        pool.basefee_pool.len(),
-                        1,
-                        "pool length check failed at start of test: {self:?}"
-                    );
-                    assert!(
-                        pool.queued_pool.is_empty(),
-                        "pool length check failed at start of test: {self:?}"
-                    );
-                }
-                SubPool::Queued => {
-                    assert!(
-                        pool.blob_transactions.is_empty(),
-                        "pool length check failed at start of test: {self:?}"
-                    );
-                    assert!(
-                        pool.pending_pool.is_empty(),
-                        "pool length check failed at start of test: {self:?}"
-                    );
-                    assert!(
-                        pool.basefee_pool.is_empty(),
-                        "pool length check failed at start of test: {self:?}"
-                    );
-                    assert_eq!(
-                        pool.queued_pool.len(),
-                        1,
-                        "pool length check failed at start of test: {self:?}"
-                    );
-                }
-            }
+            self.assert_subpool_lengths(
+                pool,
+                format!("pool length check failed at start of test: {self:?}"),
+                self.subpool,
+            );
         }
 
         /// Runs an assertion on the provided pool, ensuring that the transaction is in the correct
         /// subpool based on the ending condition of the test, assuming the pool contains only a
         /// single transaction.
         fn assert_single_tx_ending_subpool<T: TransactionOrdering>(&self, pool: &TxPool<T>) {
-            match self.new_subpool {
-                SubPool::Blob => {
-                    assert_eq!(
-                        pool.blob_transactions.len(),
-                        1,
-                        "pool length check failed for end of test: {self:?}"
-                    );
-                    assert!(
-                        pool.pending_pool.is_empty(),
-                        "pool length check failed for end of test: {self:?}"
-                    );
-                    assert!(
-                        pool.basefee_pool.is_empty(),
-                        "pool length check failed for end of test: {self:?}"
-                    );
-                    assert!(
-                        pool.queued_pool.is_empty(),
-                        "pool length check failed for end of test: {self:?}"
-                    );
-                }
-                SubPool::Pending => {
-                    assert!(
-                        pool.blob_transactions.is_empty(),
-                        "pool length check failed for end of test: {self:?}"
-                    );
-                    assert_eq!(
-                        pool.pending_pool.len(),
-                        1,
-                        "pool length check failed for end of test: {self:?}"
-                    );
-                    assert!(
-                        pool.basefee_pool.is_empty(),
-                        "pool length check failed for end of test: {self:?}"
-                    );
-                    assert!(
-                        pool.queued_pool.is_empty(),
-                        "pool length check failed for end of test: {self:?}"
-                    );
-                }
-                SubPool::BaseFee => {
-                    assert!(
-                        pool.blob_transactions.is_empty(),
-                        "pool length check failed for end of test: {self:?}"
-                    );
-                    assert!(
-                        pool.pending_pool.is_empty(),
-                        "pool length check failed for end of test: {self:?}"
-                    );
-                    assert_eq!(
-                        pool.basefee_pool.len(),
-                        1,
-                        "pool length check failed for end of test: {self:?}"
-                    );
-                    assert!(
-                        pool.queued_pool.is_empty(),
-                        "pool length check failed for end of test: {self:?}"
-                    );
-                }
-                SubPool::Queued => {
-                    assert!(
-                        pool.blob_transactions.is_empty(),
-                        "pool length check failed for end of test: {self:?}"
-                    );
-                    assert!(
-                        pool.pending_pool.is_empty(),
-                        "pool length check failed for end of test: {self:?}"
-                    );
-                    assert!(
-                        pool.basefee_pool.is_empty(),
-                        "pool length check failed for end of test: {self:?}"
-                    );
-                    assert_eq!(
-                        pool.queued_pool.len(),
-                        1,
-                        "pool length check failed for end of test: {self:?}"
-                    );
-                }
-            }
+            self.assert_subpool_lengths(
+                pool,
+                format!("pool length check failed at end of test: {self:?}"),
+                self.new_subpool,
+            );
         }
     }
 

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -156,7 +156,7 @@ impl<T: TransactionOrdering> TxPool<T> {
                 // increased blob fee: recheck pending pool and remove all that are no longer valid
             }
             Ordering::Less => {
-                // decreased blob fee: recheck basefee pool and promote all that are now valid
+                // decreased blob fee: recheck blob pool and promote all that are now valid
             }
         }
     }

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -1614,7 +1614,7 @@ impl<T: PoolTransaction> Default for AllTransactions<T> {
 
 /// Represents updated fees for the pending block.
 #[derive(Debug, Clone)]
-pub struct PendingFees {
+pub(crate) struct PendingFees {
     /// The pending base fee
     pub base_fee: u64,
     /// The pending blob fee

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -252,12 +252,6 @@ impl<T: TransactionOrdering> TxPool<T> {
         }
     }
 
-    /// Gets the [BlockInfo] corresponding to the current pool settings
-    #[cfg(test)]
-    pub(crate) fn get_block_info(&self) -> BlockInfo {
-        self.all_transactions.get_block_info()
-    }
-
     /// Returns an iterator that yields transactions that are ready to be included in the block.
     pub(crate) fn best_transactions(&self) -> BestTransactions<T> {
         self.pending_pool.best()
@@ -932,17 +926,6 @@ impl<T: PoolTransaction> AllTransactions<T> {
         self.pending_basefee = pending_basefee;
         if let Some(pending_blob_fee) = pending_blob_fee {
             self.pending_blob_fee = pending_blob_fee;
-        }
-    }
-
-    /// Gets the [BlockInfo] corresponding to the current pool settings
-    #[cfg(test)]
-    pub(crate) fn get_block_info(&self) -> BlockInfo {
-        BlockInfo {
-            last_seen_block_hash: self.last_seen_block_hash,
-            last_seen_block_number: self.last_seen_block_number,
-            pending_basefee: self.pending_basefee,
-            pending_blob_fee: Some(self.pending_blob_fee),
         }
     }
 
@@ -1846,7 +1829,7 @@ mod tests {
         let tx = MockTransaction::eip4844().inc_price().inc_limit();
 
         // set block info so the tx is initially underpriced w.r.t. blob fee
-        let mut block_info = pool.get_block_info();
+        let mut block_info = pool.block_info();
         block_info.pending_blob_fee = Some(tx.max_fee_per_blob_gas().unwrap());
         pool.set_block_info(block_info);
 
@@ -1886,7 +1869,7 @@ mod tests {
         let tx = MockTransaction::eip4844().inc_price().inc_limit();
 
         // set block info so the tx is initially underpriced w.r.t. blob fee
-        let mut block_info = pool.get_block_info();
+        let mut block_info = pool.block_info();
         block_info.pending_blob_fee = Some(tx.max_fee_per_blob_gas().unwrap() + 1);
         pool.set_block_info(block_info);
 

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -47,12 +47,14 @@ use std::{
 ///         B3[(Queued)]
 ///         B1[(Pending)]
 ///         B2[(Basefee)]
+///         B4[(Blob)]
 ///     end
 ///   end
 ///   discard([discard])
 ///   production([Block Production])
 ///   new([New Block])
 ///   A[Incoming Tx] --> B[Validation] -->|insert| pool
+///   pool --> |if ready + blobfee too low| B4
 ///   pool --> |if ready| B1
 ///   pool --> |if ready + basfee too low| B2
 ///   pool --> |nonce gap or lack of funds| B3
@@ -60,8 +62,11 @@ use std::{
 ///   B1 --> |best| production
 ///   B2 --> |worst| discard
 ///   B3 --> |worst| discard
-///   B1 --> |increased fee| B2
-///   B2 --> |decreased fee| B1
+///   B4 --> |worst| discard
+///   B1 --> |increased blob fee| B4
+///   B4 --> |decreased blob fee| B1
+///   B1 --> |increased base fee| B2
+///   B2 --> |decreased base fee| B1
 ///   B3 --> |promote| B1
 ///   B3 -->  |promote| B2
 ///   new -->  |apply state changes| pool

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1031,6 +1031,10 @@ pub struct PoolSize {
     pub pending: usize,
     /// Reported size of transactions in the _pending_ sub-pool.
     pub pending_size: usize,
+    /// Number of transactions in the _blob_ pool.
+    pub blob: usize,
+    /// Reported size of transactions in the _blob_ pool.
+    pub blob_size: usize,
     /// Number of transactions in the _basefee_ pool.
     pub basefee: usize,
     /// Reported size of transactions in the _basefee_ sub-pool.
@@ -1051,7 +1055,7 @@ impl PoolSize {
     /// Asserts that the invariants of the pool size are met.
     #[cfg(test)]
     pub(crate) fn assert_invariants(&self) {
-        assert_eq!(self.total, self.pending + self.basefee + self.queued);
+        assert_eq!(self.total, self.pending + self.basefee + self.queued + self.blob);
     }
 }
 

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -260,6 +260,13 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
         self.transaction.cost()
     }
 
+    /// Returns the EIP-4844 max blob fee the caller is willing to pay.
+    ///
+    /// For non-EIP-4844 transactions, this returns [None].
+    pub fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        self.transaction.max_fee_per_blob_gas()
+    }
+
     /// Returns the EIP-1559 Max base fee the caller is willing to pay.
     ///
     /// For legacy transactions this is `gas_price`.


### PR DESCRIPTION
Implements demotion and promotion based on the new blob fee for each block. This follows the same general pattern as `update_base_fee`, except without extra prioritization. The `PoolSize` struct now includes the blob subpool size as well. Blob txs are now removed from the `all` set of txs.

The blob subpool now _does not include pending blob transactions_.

Two tests are added - one tests promotion, the other tests demotion from the pool.