### PR TITLE
Revert "feat(storage): make `BlockReaderIdExt` safe"

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -468,7 +468,7 @@ mod tests {
         BlockBody, BlockHash, BlockHashOrNumber, Bytes, ChainSpecBuilder, Header, Signature,
         TransactionKind, TransactionSigned, Withdrawal, MAINNET, U256,
     };
-    use std::ops::RangeInclusive;
+    use std::ops::RangeBounds;
 
     mock! {
         WithdrawalsProvider {}
@@ -539,13 +539,13 @@ mod tests {
             Ok(None)
         }
 
-        fn headers_range(&self, _range: RangeInclusive<BlockNumber>) -> RethResult<Vec<Header>> {
+        fn headers_range(&self, _range: impl RangeBounds<BlockNumber>) -> RethResult<Vec<Header>> {
             Ok(vec![])
         }
 
         fn sealed_headers_range(
             &self,
-            _range: RangeInclusive<BlockNumber>,
+            _range: impl RangeBounds<BlockNumber>,
         ) -> RethResult<Vec<SealedHeader>> {
             Ok(vec![])
         }

--- a/crates/storage/db/src/tables/models/blocks.rs
+++ b/crates/storage/db/src/tables/models/blocks.rs
@@ -2,7 +2,7 @@
 
 use reth_codecs::{main_codec, Compact};
 use reth_primitives::{Header, TxNumber, Withdrawal, B256};
-use std::ops::RangeInclusive;
+use std::ops::Range;
 
 /// Total number of transactions.
 pub type NumTransactions = u64;
@@ -28,8 +28,8 @@ pub struct StoredBlockBodyIndices {
 
 impl StoredBlockBodyIndices {
     /// Return the range of transaction ids for this block.
-    pub fn tx_num_range(&self) -> RangeInclusive<TxNumber> {
-        self.first_tx_num..=(self.first_tx_num + self.tx_count).saturating_sub(1)
+    pub fn tx_num_range(&self) -> Range<TxNumber> {
+        self.first_tx_num..self.first_tx_num + self.tx_count
     }
 
     /// Return the index of last transaction in this block unless the block
@@ -111,6 +111,6 @@ mod test {
         assert_eq!(block_indices.last_tx_num(), first_tx_num + tx_count - 1);
         assert_eq!(block_indices.next_tx_num(), first_tx_num + tx_count);
         assert_eq!(block_indices.tx_count(), tx_count);
-        assert_eq!(block_indices.tx_num_range(), first_tx_num..=first_tx_num + tx_count - 1);
+        assert_eq!(block_indices.tx_num_range(), first_tx_num..first_tx_num + tx_count);
     }
 }

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -16,7 +16,7 @@ use reth_primitives::{
 };
 use revm::primitives::{BlockEnv, CfgEnv};
 use std::{
-    ops::{Range, RangeInclusive},
+    ops::{RangeBounds, RangeInclusive},
     sync::Arc,
 };
 use tracing::trace;
@@ -170,13 +170,13 @@ impl<DB: Database> HeaderProvider for ProviderFactory<DB> {
         self.provider()?.header_td_by_number(number)
     }
 
-    fn headers_range(&self, range: RangeInclusive<BlockNumber>) -> RethResult<Vec<Header>> {
+    fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> RethResult<Vec<Header>> {
         self.provider()?.headers_range(range)
     }
 
     fn sealed_headers_range(
         &self,
-        range: RangeInclusive<BlockNumber>,
+        range: impl RangeBounds<BlockNumber>,
     ) -> RethResult<Vec<SealedHeader>> {
         self.provider()?.sealed_headers_range(range)
     }
@@ -295,19 +295,19 @@ impl<DB: Database> TransactionsProvider for ProviderFactory<DB> {
 
     fn transactions_by_block_range(
         &self,
-        range: Range<BlockNumber>,
+        range: impl RangeBounds<BlockNumber>,
     ) -> RethResult<Vec<Vec<TransactionSigned>>> {
         self.provider()?.transactions_by_block_range(range)
     }
 
     fn transactions_by_tx_range(
         &self,
-        range: RangeInclusive<TxNumber>,
+        range: impl RangeBounds<TxNumber>,
     ) -> RethResult<Vec<TransactionSignedNoHash>> {
         self.provider()?.transactions_by_tx_range(range)
     }
 
-    fn senders_by_tx_range(&self, range: RangeInclusive<TxNumber>) -> RethResult<Vec<Address>> {
+    fn senders_by_tx_range(&self, range: impl RangeBounds<TxNumber>) -> RethResult<Vec<Address>> {
         self.provider()?.senders_by_tx_range(range)
     }
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -889,7 +889,7 @@ impl<TX: DbTx> HeaderProvider for DatabaseProvider<TX> {
         Ok(self.tx.get::<tables::HeaderTD>(number)?.map(|td| td.0))
     }
 
-    fn headers_range(&self, range: RangeInclusive<BlockNumber>) -> RethResult<Vec<Header>> {
+    fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> RethResult<Vec<Header>> {
         let mut cursor = self.tx.cursor_read::<tables::Headers>()?;
         cursor
             .walk_range(range)?
@@ -899,7 +899,7 @@ impl<TX: DbTx> HeaderProvider for DatabaseProvider<TX> {
 
     fn sealed_headers_range(
         &self,
-        range: RangeInclusive<BlockNumber>,
+        range: impl RangeBounds<BlockNumber>,
     ) -> RethResult<Vec<SealedHeader>> {
         let mut headers = vec![];
         for entry in self.tx.cursor_read::<tables::Headers>()?.walk_range(range)? {
@@ -1242,7 +1242,7 @@ impl<TX: DbTx> TransactionsProvider for DatabaseProvider<TX> {
 
     fn transactions_by_block_range(
         &self,
-        range: Range<BlockNumber>,
+        range: impl RangeBounds<BlockNumber>,
     ) -> RethResult<Vec<Vec<TransactionSigned>>> {
         let mut results = Vec::new();
         let mut body_cursor = self.tx.cursor_read::<tables::BlockBodyIndices>()?;
@@ -1266,7 +1266,7 @@ impl<TX: DbTx> TransactionsProvider for DatabaseProvider<TX> {
 
     fn transactions_by_tx_range(
         &self,
-        range: RangeInclusive<TxNumber>,
+        range: impl RangeBounds<TxNumber>,
     ) -> RethResult<Vec<TransactionSignedNoHash>> {
         Ok(self
             .tx
@@ -1276,7 +1276,7 @@ impl<TX: DbTx> TransactionsProvider for DatabaseProvider<TX> {
             .collect::<Result<Vec<_>, _>>()?)
     }
 
-    fn senders_by_tx_range(&self, range: RangeInclusive<TxNumber>) -> RethResult<Vec<Address>> {
+    fn senders_by_tx_range(&self, range: impl RangeBounds<TxNumber>) -> RethResult<Vec<Address>> {
         Ok(self
             .tx
             .cursor_read::<tables::TxSenders>()?

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -22,7 +22,7 @@ use reth_primitives::{
 use revm::primitives::{BlockEnv, CfgEnv};
 use std::{
     collections::{BTreeMap, HashSet},
-    ops::{Range, RangeInclusive},
+    ops::{RangeBounds, RangeInclusive},
     sync::Arc,
     time::Instant,
 };
@@ -136,13 +136,13 @@ where
         self.database.provider()?.header_td_by_number(number)
     }
 
-    fn headers_range(&self, range: RangeInclusive<BlockNumber>) -> RethResult<Vec<Header>> {
+    fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> RethResult<Vec<Header>> {
         self.database.provider()?.headers_range(range)
     }
 
     fn sealed_headers_range(
         &self,
-        range: RangeInclusive<BlockNumber>,
+        range: impl RangeBounds<BlockNumber>,
     ) -> RethResult<Vec<SealedHeader>> {
         self.database.provider()?.sealed_headers_range(range)
     }
@@ -319,19 +319,19 @@ where
 
     fn transactions_by_block_range(
         &self,
-        range: Range<BlockNumber>,
+        range: impl RangeBounds<BlockNumber>,
     ) -> RethResult<Vec<Vec<TransactionSigned>>> {
         self.database.provider()?.transactions_by_block_range(range)
     }
 
     fn transactions_by_tx_range(
         &self,
-        range: RangeInclusive<TxNumber>,
+        range: impl RangeBounds<TxNumber>,
     ) -> RethResult<Vec<TransactionSignedNoHash>> {
         self.database.provider()?.transactions_by_tx_range(range)
     }
 
-    fn senders_by_tx_range(&self, range: RangeInclusive<TxNumber>) -> RethResult<Vec<Address>> {
+    fn senders_by_tx_range(&self, range: impl RangeBounds<TxNumber>) -> RethResult<Vec<Address>> {
         self.database.provider()?.senders_by_tx_range(range)
     }
 

--- a/crates/storage/provider/src/providers/snapshot.rs
+++ b/crates/storage/provider/src/providers/snapshot.rs
@@ -6,7 +6,7 @@ use reth_db::{
 use reth_interfaces::{provider::ProviderError, RethResult};
 use reth_nippy_jar::{compression::Decompressor, NippyJar, NippyJarCursor};
 use reth_primitives::{BlockHash, BlockNumber, Header, SealedHeader, U256};
-use std::ops::RangeInclusive;
+use std::ops::RangeBounds;
 
 /// SnapshotProvider
 ///
@@ -85,13 +85,13 @@ impl<'a> HeaderProvider for SnapshotProvider<'a> {
         unimplemented!();
     }
 
-    fn headers_range(&self, _range: RangeInclusive<BlockNumber>) -> RethResult<Vec<Header>> {
+    fn headers_range(&self, _range: impl RangeBounds<BlockNumber>) -> RethResult<Vec<Header>> {
         unimplemented!();
     }
 
     fn sealed_headers_range(
         &self,
-        _range: RangeInclusive<BlockNumber>,
+        _range: impl RangeBounds<BlockNumber>,
     ) -> RethResult<Vec<SealedHeader>> {
         unimplemented!();
     }

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -18,7 +18,7 @@ use reth_primitives::{
 use revm::primitives::{BlockEnv, CfgEnv};
 use std::{
     collections::{BTreeMap, HashMap},
-    ops::{Range, RangeInclusive},
+    ops::{RangeBounds, RangeInclusive},
     sync::Arc,
 };
 
@@ -152,7 +152,7 @@ impl HeaderProvider for MockEthProvider {
         Ok(Some(sum))
     }
 
-    fn headers_range(&self, range: RangeInclusive<BlockNumber>) -> RethResult<Vec<Header>> {
+    fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> RethResult<Vec<Header>> {
         let lock = self.headers.lock();
 
         let mut headers: Vec<_> =
@@ -164,7 +164,7 @@ impl HeaderProvider for MockEthProvider {
 
     fn sealed_headers_range(
         &self,
-        range: RangeInclusive<BlockNumber>,
+        range: impl RangeBounds<BlockNumber>,
     ) -> RethResult<Vec<SealedHeader>> {
         Ok(self.headers_range(range)?.into_iter().map(|h| h.seal_slow()).collect())
     }
@@ -265,7 +265,7 @@ impl TransactionsProvider for MockEthProvider {
 
     fn transactions_by_block_range(
         &self,
-        range: Range<reth_primitives::BlockNumber>,
+        range: impl RangeBounds<reth_primitives::BlockNumber>,
     ) -> RethResult<Vec<Vec<TransactionSigned>>> {
         // init btreemap so we can return in order
         let mut map = BTreeMap::new();
@@ -280,7 +280,7 @@ impl TransactionsProvider for MockEthProvider {
 
     fn transactions_by_tx_range(
         &self,
-        range: RangeInclusive<TxNumber>,
+        range: impl RangeBounds<TxNumber>,
     ) -> RethResult<Vec<reth_primitives::TransactionSignedNoHash>> {
         let lock = self.blocks.lock();
         let transactions = lock
@@ -299,7 +299,7 @@ impl TransactionsProvider for MockEthProvider {
         Ok(transactions)
     }
 
-    fn senders_by_tx_range(&self, range: RangeInclusive<TxNumber>) -> RethResult<Vec<Address>> {
+    fn senders_by_tx_range(&self, range: impl RangeBounds<TxNumber>) -> RethResult<Vec<Address>> {
         let lock = self.blocks.lock();
         let transactions = lock
             .values()

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -17,7 +17,7 @@ use reth_primitives::{
 };
 use revm::primitives::{BlockEnv, CfgEnv};
 use std::{
-    ops::{Range, RangeInclusive},
+    ops::{RangeBounds, RangeInclusive},
     sync::Arc,
 };
 
@@ -174,18 +174,18 @@ impl TransactionsProvider for NoopProvider {
 
     fn transactions_by_block_range(
         &self,
-        _range: Range<BlockNumber>,
+        _range: impl RangeBounds<BlockNumber>,
     ) -> RethResult<Vec<Vec<TransactionSigned>>> {
         Ok(Vec::default())
     }
 
-    fn senders_by_tx_range(&self, _range: RangeInclusive<TxNumber>) -> RethResult<Vec<Address>> {
+    fn senders_by_tx_range(&self, _range: impl RangeBounds<TxNumber>) -> RethResult<Vec<Address>> {
         Ok(Vec::default())
     }
 
     fn transactions_by_tx_range(
         &self,
-        _range: RangeInclusive<TxNumber>,
+        _range: impl RangeBounds<TxNumber>,
     ) -> RethResult<Vec<reth_primitives::TransactionSignedNoHash>> {
         Ok(Vec::default())
     }
@@ -228,13 +228,13 @@ impl HeaderProvider for NoopProvider {
         Ok(None)
     }
 
-    fn headers_range(&self, _range: RangeInclusive<BlockNumber>) -> RethResult<Vec<Header>> {
+    fn headers_range(&self, _range: impl RangeBounds<BlockNumber>) -> RethResult<Vec<Header>> {
         Ok(vec![])
     }
 
     fn sealed_headers_range(
         &self,
-        _range: RangeInclusive<BlockNumber>,
+        _range: impl RangeBounds<BlockNumber>,
     ) -> RethResult<Vec<SealedHeader>> {
         Ok(vec![])
     }

--- a/crates/storage/provider/src/traits/header.rs
+++ b/crates/storage/provider/src/traits/header.rs
@@ -1,7 +1,7 @@
 use auto_impl::auto_impl;
 use reth_interfaces::RethResult;
 use reth_primitives::{BlockHash, BlockHashOrNumber, BlockNumber, Header, SealedHeader, U256};
-use std::ops::RangeInclusive;
+use std::ops::RangeBounds;
 
 /// Client trait for fetching `Header` related data.
 #[auto_impl(&, Arc)]
@@ -35,12 +35,12 @@ pub trait HeaderProvider: Send + Sync {
     fn header_td_by_number(&self, number: BlockNumber) -> RethResult<Option<U256>>;
 
     /// Get headers in range of block numbers
-    fn headers_range(&self, range: RangeInclusive<BlockNumber>) -> RethResult<Vec<Header>>;
+    fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> RethResult<Vec<Header>>;
 
     /// Get headers in range of block numbers
     fn sealed_headers_range(
         &self,
-        range: RangeInclusive<BlockNumber>,
+        range: impl RangeBounds<BlockNumber>,
     ) -> RethResult<Vec<SealedHeader>>;
 
     /// Get a single sealed header by block number

--- a/crates/storage/provider/src/traits/transactions.rs
+++ b/crates/storage/provider/src/traits/transactions.rs
@@ -4,7 +4,7 @@ use reth_primitives::{
     Address, BlockHashOrNumber, BlockNumber, TransactionMeta, TransactionSigned,
     TransactionSignedNoHash, TxHash, TxNumber,
 };
-use std::ops::{Range, RangeInclusive};
+use std::ops::RangeBounds;
 
 ///  Client trait for fetching [TransactionSigned] related data.
 #[auto_impl::auto_impl(&, Arc)]
@@ -46,17 +46,17 @@ pub trait TransactionsProvider: BlockNumReader + Send + Sync {
     /// Get transactions by block range.
     fn transactions_by_block_range(
         &self,
-        range: Range<BlockNumber>,
+        range: impl RangeBounds<BlockNumber>,
     ) -> RethResult<Vec<Vec<TransactionSigned>>>;
 
     /// Get transactions by tx range.
     fn transactions_by_tx_range(
         &self,
-        range: RangeInclusive<TxNumber>,
+        range: impl RangeBounds<TxNumber>,
     ) -> RethResult<Vec<TransactionSignedNoHash>>;
 
     /// Get Senders from a tx range.
-    fn senders_by_tx_range(&self, range: RangeInclusive<TxNumber>) -> RethResult<Vec<Address>>;
+    fn senders_by_tx_range(&self, range: impl RangeBounds<TxNumber>) -> RethResult<Vec<Address>>;
 
     /// Get transaction sender.
     ///

--- a/examples/db-access.rs
+++ b/examples/db-access.rs
@@ -69,7 +69,7 @@ fn header_provider_example<T: HeaderProvider>(provider: T, number: u64) -> eyre:
     assert_ne!(td, U256::ZERO);
 
     // Can query headers by range as well, already sealed!
-    let headers = provider.sealed_headers_range(100..=200)?;
+    let headers = provider.sealed_headers_range(100..200)?;
     assert_eq!(headers.len(), 100);
 
     Ok(())
@@ -101,7 +101,7 @@ fn txs_provider_example<T: TransactionsProvider>(provider: T) -> eyre::Result<()
     let _block = provider.transaction_block(txid)?;
 
     // Can query the txs in the range [100, 200)
-    let _txs_by_tx_range = provider.transactions_by_tx_range(100..=200)?;
+    let _txs_by_tx_range = provider.transactions_by_tx_range(100..200)?;
     // Can query the txs in the _block_ range [100, 200)]
     let _txs_by_block_range = provider.transactions_by_block_range(100..200)?;
 


### PR DESCRIPTION
Reverts paradigmxyz/reth#5022

## Description

The PR introduced a bug where the `tx_num_range` for every block before the first transactions will be `0..=0`