### PR TITLE
feat: re-add Arbitrary for PooledTransactionsElement

### DIFF
--- a/crates/primitives/src/transaction/eip4844.rs
+++ b/crates/primitives/src/transaction/eip4844.rs
@@ -15,6 +15,19 @@ use reth_codecs::{derive_arbitrary, main_codec, Compact};
 use serde::{Deserialize, Serialize};
 use std::{mem, ops::Deref};
 
+#[cfg(any(test, feature = "arbitrary"))]
+use proptest::{
+    arbitrary::{any as proptest_any, ParamsFor},
+    collection::vec as proptest_vec,
+    strategy::{BoxedStrategy, Strategy},
+};
+
+#[cfg(any(test, feature = "arbitrary"))]
+use crate::{
+    constants::eip4844::{FIELD_ELEMENTS_PER_BLOB, MAINNET_KZG_TRUSTED_SETUP},
+    kzg::BYTES_PER_FIELD_ELEMENT,
+};
+
 /// [EIP-4844 Blob Transaction](https://eips.ethereum.org/EIPS/eip-4844#blob-transaction)
 ///
 /// A transaction with blob hashes and max blob fee
@@ -678,19 +691,6 @@ impl BlobTransactionSidecarRlp {
         })
     }
 }
-
-#[cfg(any(test, feature = "arbitrary"))]
-use proptest::{
-    arbitrary::{any as proptest_any, ParamsFor},
-    collection::vec as proptest_vec,
-    strategy::{BoxedStrategy, Strategy},
-};
-
-#[cfg(any(test, feature = "arbitrary"))]
-use crate::{
-    constants::eip4844::{FIELD_ELEMENTS_PER_BLOB, MAINNET_KZG_TRUSTED_SETUP},
-    kzg::BYTES_PER_FIELD_ELEMENT,
-};
 
 #[cfg(any(test, feature = "arbitrary"))]
 impl<'a> arbitrary::Arbitrary<'a> for BlobTransactionSidecar {

--- a/crates/primitives/src/transaction/eip4844.rs
+++ b/crates/primitives/src/transaction/eip4844.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use alloy_rlp::{length_of_length, Decodable, Encodable, Error as RlpError, Header};
 use bytes::BytesMut;
-use reth_codecs::{derive_arbitrary, main_codec, Compact};
+use reth_codecs::{main_codec, Compact};
 use serde::{Deserialize, Serialize};
 use std::{mem, ops::Deref};
 
@@ -352,11 +352,6 @@ impl From<kzg::Error> for BlobTransactionValidationError {
 ///
 /// This is defined in [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844#networking) as an element
 /// of a `PooledTransactions` response.
-///
-/// NOTE: This contains a [TransactionSigned], which could be a non-4844 transaction type, even
-/// though that would not make sense. This type is meant to be constructed using decoding methods,
-/// which should always construct the [TransactionSigned] with an EIP-4844 transaction.
-#[derive_arbitrary]
 #[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct BlobTransaction {
     /// The transaction hash.

--- a/crates/primitives/src/transaction/eip4844.rs
+++ b/crates/primitives/src/transaction/eip4844.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use alloy_rlp::{length_of_length, Decodable, Encodable, Error as RlpError, Header};
 use bytes::BytesMut;
-use reth_codecs::{main_codec, Compact};
+use reth_codecs::{derive_arbitrary, main_codec, Compact};
 use serde::{Deserialize, Serialize};
 use std::{mem, ops::Deref};
 
@@ -343,6 +343,7 @@ impl From<kzg::Error> for BlobTransactionValidationError {
 /// NOTE: This contains a [TransactionSigned], which could be a non-4844 transaction type, even
 /// though that would not make sense. This type is meant to be constructed using decoding methods,
 /// which should always construct the [TransactionSigned] with an EIP-4844 transaction.
+#[derive_arbitrary]
 #[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct BlobTransaction {
     /// The transaction hash.
@@ -688,7 +689,7 @@ use proptest::{
 #[cfg(any(test, feature = "arbitrary"))]
 use crate::{
     constants::eip4844::{FIELD_ELEMENTS_PER_BLOB, MAINNET_KZG_TRUSTED_SETUP},
-    kzg::{KzgCommitment, BYTES_PER_BLOB, BYTES_PER_FIELD_ELEMENT},
+    kzg::BYTES_PER_FIELD_ELEMENT,
 };
 
 #[cfg(any(test, feature = "arbitrary"))]
@@ -718,7 +719,7 @@ impl proptest::arbitrary::Arbitrary for BlobTransactionSidecar {
     type Parameters = ParamsFor<String>;
     type Strategy = BoxedStrategy<BlobTransactionSidecar>;
 
-    fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
         proptest_vec(proptest_vec(proptest_any::<u8>(), BYTES_PER_BLOB), 1..=5)
             .prop_map(move |blobs| {
                 let blobs = blobs

--- a/crates/primitives/src/transaction/pooled.rs
+++ b/crates/primitives/src/transaction/pooled.rs
@@ -1,18 +1,19 @@
 //! Defines the types for blob transactions, legacy, and other EIP-2718 transactions included in a
 //! response to `GetPooledTransactions`.
 use crate::{
-    Address, BlobTransaction, Bytes, Signature, Transaction, TransactionSigned,
-    TransactionSignedEcRecovered, TxEip1559, TxEip2930, TxHash, TxLegacy, B256, EIP4844_TX_TYPE_ID,
+    Address, BlobTransaction, BlobTransactionSidecar, Bytes, Signature, Transaction,
+    TransactionSigned, TransactionSignedEcRecovered, TxEip1559, TxEip2930, TxHash, TxLegacy, B256,
+    EIP4844_TX_TYPE_ID,
 };
 use alloy_rlp::{Decodable, Encodable, Error as RlpError, Header, EMPTY_LIST_CODE};
 use bytes::Buf;
 use derive_more::{AsRef, Deref};
-use reth_codecs::derive_arbitrary;
+use reth_codecs::add_arbitrary_tests;
 use serde::{Deserialize, Serialize};
 
 /// A response to `GetPooledTransactions`. This can include either a blob transaction, or a
 /// non-4844 signed transaction.
-#[derive_arbitrary(rlp)]
+#[add_arbitrary_tests]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PooledTransactionsElement {
     /// A legacy transaction
@@ -416,6 +417,49 @@ impl From<TransactionSigned> for PooledTransactionsElement {
                 })
             }
         }
+    }
+}
+
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a> arbitrary::Arbitrary<'a> for PooledTransactionsElement {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let transaction = TransactionSigned::arbitrary(u)?;
+
+        // this will have an empty sidecar
+        let pooled_txs_element = PooledTransactionsElement::from(transaction);
+
+        // generate a sidecar for blob txs
+        if let PooledTransactionsElement::BlobTransaction(mut tx) = pooled_txs_element {
+            tx.sidecar = BlobTransactionSidecar::arbitrary(u)?;
+            Ok(PooledTransactionsElement::BlobTransaction(tx))
+        } else {
+            Ok(pooled_txs_element)
+        }
+    }
+}
+
+#[cfg(any(test, feature = "arbitrary"))]
+impl proptest::arbitrary::Arbitrary for PooledTransactionsElement {
+    type Parameters = ();
+    type Strategy = proptest::strategy::BoxedStrategy<PooledTransactionsElement>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        use proptest::prelude::{any, Strategy};
+
+        any::<(TransactionSigned, BlobTransactionSidecar)>()
+            .prop_map(move |(transaction, sidecar)| {
+                // this will have an empty sidecar
+                let pooled_txs_element = PooledTransactionsElement::from(transaction);
+
+                // generate a sidecar for blob txs
+                if let PooledTransactionsElement::BlobTransaction(mut tx) = pooled_txs_element {
+                    tx.sidecar = sidecar;
+                    PooledTransactionsElement::BlobTransaction(tx)
+                } else {
+                    pooled_txs_element
+                }
+            })
+            .boxed()
     }
 }
 

--- a/crates/primitives/src/transaction/pooled.rs
+++ b/crates/primitives/src/transaction/pooled.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
 
 /// A response to `GetPooledTransactions`. This can include either a blob transaction, or a
 /// non-4844 signed transaction.
-// TODO: redo arbitrary for this encoding - the previous encoding was incorrect
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PooledTransactionsElement {
     /// A legacy transaction

--- a/crates/primitives/src/transaction/pooled.rs
+++ b/crates/primitives/src/transaction/pooled.rs
@@ -7,10 +7,12 @@ use crate::{
 use alloy_rlp::{Decodable, Encodable, Error as RlpError, Header, EMPTY_LIST_CODE};
 use bytes::Buf;
 use derive_more::{AsRef, Deref};
+use reth_codecs::derive_arbitrary;
 use serde::{Deserialize, Serialize};
 
 /// A response to `GetPooledTransactions`. This can include either a blob transaction, or a
 /// non-4844 signed transaction.
+#[derive_arbitrary(rlp)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PooledTransactionsElement {
     /// A legacy transaction


### PR DESCRIPTION
This adds `Arbitrary` for `BlobTransactionSidecar`, which allows us to derive the same trait for `BlobTransaction`, which also allows us to derive `Arbitrary` with RLP tests, for `PooledTransactionsElement`.

This is refactored from the removed implementation in #4172