### PR TITLE
fix: fix bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -83,7 +83,7 @@ body:
     id: prune-config
     attributes:
       label: What prune config do you use, if any?
-      description: `[prune]` section in `reth.toml` file
+      description: The `[prune]` section in `reth.toml` file
     validations:
       required: false
   - type: input


### PR DESCRIPTION
Noticed that the bug issue template was not showing up:
<img width="1272" alt="Screenshot 2023-10-17 at 9 49 43 PM" src="https://github.com/paradigmxyz/reth/assets/6798349/b84be5b6-4ee9-4f19-9ca9-4230ed9bd1f5">

GitHub showed this:
<img width="1167" alt="Screenshot 2023-10-17 at 9 50 39 PM" src="https://github.com/paradigmxyz/reth/assets/6798349/71a05284-476f-44bb-825b-d524300f5bd1">

Apparently `description` cannot start with a backtick. I passed the final result through a YAML linter and it said it was valid YAML