### PR TITLE
chore(merkle): remove last walker key from checkpoint

### DIFF
--- a/crates/stages/src/stages/merkle.rs
+++ b/crates/stages/src/stages/merkle.rs
@@ -7,7 +7,6 @@ use reth_db::{
 };
 use reth_interfaces::consensus;
 use reth_primitives::{
-    hex,
     stage::{EntitiesCheckpoint, MerkleCheckpoint, StageCheckpoint, StageId},
     trie::StoredSubNode,
     BlockNumber, SealedHeader, B256,
@@ -125,7 +124,6 @@ impl MerkleStage {
             debug!(
                 target: "sync::stages::merkle::exec",
                 last_account_key = ?checkpoint.last_account_key,
-                last_walker_key = ?hex::encode(&checkpoint.last_walker_key),
                 "Saving inner merkle checkpoint"
             );
             checkpoint.to_compact(&mut buf);
@@ -184,7 +182,6 @@ impl<DB: Database> Stage<DB> for MerkleStage {
                     current = ?current_block_number,
                     target = ?to_block,
                     last_account_key = ?checkpoint.last_account_key,
-                    last_walker_key = ?hex::encode(&checkpoint.last_walker_key),
                     "Continuing inner merkle checkpoint"
                 );
 


### PR DESCRIPTION
## Description

Ref https://github.com/paradigmxyz/reth/pull/5048

Remove `last_walker_key` from merkle checkpoint. This PR targets `breaking-changes` branch since it's not backwards compatible.