### PR TITLE
feat: add more rpc-api bindings

### DIFF
--- a/crates/rpc/rpc-api/src/bundle.rs
+++ b/crates/rpc/rpc-api/src/bundle.rs
@@ -1,0 +1,60 @@
+use jsonrpsee::proc_macros::rpc;
+use reth_primitives::{Bytes, B256};
+use reth_rpc_types::{
+    CancelBundleRequest, CancelPrivateTransactionRequest, EthBundleHash, EthCallBundleResponse,
+    EthCallBundleTransactionResult, EthSendBundle, PrivateTransactionRequest,
+};
+
+/// Eth bundle rpc interface.
+///
+/// See also <https://docs.flashbots.net/flashbots-auction/searchers/advanced/rpc-endpoint>
+
+/// Eth bundle rpc interface.
+///
+/// See also <https://docs.flashbots.net/flashbots-auction/searchers/advanced/rpc-endpoint>
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "eth"))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "eth"))]
+#[async_trait::async_trait]
+pub trait EthBundleApi {
+    /// `eth_sendBundle` can be used to send your bundles to the builder.
+    #[method(name = "sendBundle")]
+    async fn send_bundle(&self, bundle: EthSendBundle)
+        -> jsonrpsee::core::RpcResult<EthBundleHash>;
+
+    /// `eth_callBundle` can be used to simulate a bundle against a specific block number,
+    /// including simulating a bundle at the top of the next block.
+    #[method(name = "callBundle")]
+    async fn call_bundle(
+        &self,
+        request: EthCallBundleResponse,
+    ) -> jsonrpsee::core::RpcResult<EthCallBundleTransactionResult>;
+
+    /// `eth_cancelBundle` is used to prevent a submitted bundle from being included on-chain. See [bundle cancellations](https://docs.flashbots.net/flashbots-auction/searchers/advanced/bundle-cancellations) for more information.
+    #[method(name = "cancelBundle")]
+    async fn cancel_bundle(&self, request: CancelBundleRequest) -> jsonrpsee::core::RpcResult<()>;
+
+    /// `eth_sendPrivateTransaction` is used to send a single transaction to Flashbots. Flashbots will attempt to build a block including the transaction for the next 25 blocks. See [Private Transactions](https://docs.flashbots.net/flashbots-protect/additional-documentation/eth-sendPrivateTransaction) for more info.
+    #[method(name = "sendPrivateTransaction")]
+    async fn send_private_transaction(
+        &self,
+        request: PrivateTransactionRequest,
+    ) -> jsonrpsee::core::RpcResult<B256>;
+
+    /// The `eth_sendPrivateRawTransaction` method can be used to send private transactions to
+    /// the RPC endpoint. Private transactions are protected from frontrunning and kept
+    /// private until included in a block. A request to this endpoint needs to follow
+    /// the standard eth_sendRawTransaction
+    #[method(name = "sendPrivateRawTransaction")]
+    async fn send_private_raw_transaction(&self, bytes: Bytes) -> jsonrpsee::core::RpcResult<B256>;
+
+    /// The `eth_cancelPrivateTransaction` method stops private transactions from being
+    /// submitted for future blocks.
+    ///
+    /// A transaction can only be cancelled if the request is signed by the same key as the
+    /// eth_sendPrivateTransaction call submitting the transaction in first place.
+    #[method(name = "cancelPrivateTransaction")]
+    async fn cancel_private_transaction(
+        &self,
+        request: CancelPrivateTransactionRequest,
+    ) -> jsonrpsee::core::RpcResult<bool>;
+}

--- a/crates/rpc/rpc-api/src/lib.rs
+++ b/crates/rpc/rpc-api/src/lib.rs
@@ -16,11 +16,13 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod admin;
+mod bundle;
 mod debug;
 mod engine;
 mod eth;
 mod eth_filter;
 mod eth_pubsub;
+mod mev;
 mod net;
 mod otterscan;
 mod reth;
@@ -36,11 +38,13 @@ pub use servers::*;
 pub mod servers {
     pub use crate::{
         admin::AdminApiServer,
+        bundle::EthBundleApiServer,
         debug::DebugApiServer,
         engine::{EngineApiServer, EngineEthApiServer},
         eth::EthApiServer,
         eth_filter::EthFilterApiServer,
         eth_pubsub::EthPubSubApiServer,
+        mev::MevApiServer,
         net::NetApiServer,
         otterscan::OtterscanServer,
         reth::RethApiServer,
@@ -60,10 +64,12 @@ pub use clients::*;
 pub mod clients {
     pub use crate::{
         admin::AdminApiClient,
+        bundle::EthBundleApiClient,
         debug::DebugApiClient,
         engine::{EngineApiClient, EngineEthApiClient},
         eth::EthApiClient,
         eth_filter::EthFilterApiClient,
+        mev::MevApiClient,
         net::NetApiClient,
         otterscan::OtterscanClient,
         rpc::RpcApiServer,

--- a/crates/rpc/rpc-api/src/mev.rs
+++ b/crates/rpc/rpc-api/src/mev.rs
@@ -1,0 +1,27 @@
+use jsonrpsee::proc_macros::rpc;
+use reth_rpc_types::{
+    SendBundleRequest, SendBundleResponse, SimBundleOverrides, SimBundleResponse,
+};
+
+/// Mev rpc interface.
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "mev"))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "mev"))]
+#[async_trait::async_trait]
+pub trait MevApi {
+    /// Submitting bundles to the relay. It takes in a bundle and provides a bundle hash as a
+    /// return value.
+    #[method(name = "sendBundle")]
+    async fn send_bundle(
+        &self,
+        request: SendBundleRequest,
+    ) -> jsonrpsee::core::RpcResult<SendBundleResponse>;
+
+    /// Similar to `mev_sendBundle` but instead of submitting a bundle to the relay, it returns
+    /// a simulation result. Only fully matched bundles can be simulated.
+    #[method(name = "simBundle")]
+    async fn sim_bundle(
+        &self,
+        bundle: SendBundleRequest,
+        sim_overrides: SimBundleOverrides,
+    ) -> jsonrpsee::core::RpcResult<SimBundleResponse>;
+}


### PR DESCRIPTION
port more api bindings from:

https://github.com/paradigmxyz/mev-share-rs

this will eventually all moved to alloy, having all of it in one place is easier to manage.