### PR TITLE
perf: rm thread stack size bumps

### DIFF
--- a/bin/reth/src/runner.rs
+++ b/bin/reth/src/runner.rs
@@ -114,11 +114,7 @@ pub struct CliContext {
 /// Creates a new default tokio multi-thread [Runtime](tokio::runtime::Runtime) with all features
 /// enabled
 pub fn tokio_runtime() -> Result<tokio::runtime::Runtime, std::io::Error> {
-    tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        // increase stack size, mostly for RPC calls that use the evm: <https://github.com/paradigmxyz/reth/issues/3056> and  <https://github.com/bluealloy/revm/issues/305>
-        .thread_stack_size(8 * 1024 * 1024)
-        .build()
+    tokio::runtime::Builder::new_multi_thread().enable_all().build()
 }
 
 /// Runs the given future to completion or until a critical task panicked

--- a/crates/rpc/rpc/src/blocking_pool.rs
+++ b/crates/rpc/rpc/src/blocking_pool.rs
@@ -71,11 +71,7 @@ impl BlockingTaskPool {
     /// Uses [`rayon::ThreadPoolBuilder::build`](rayon::ThreadPoolBuilder::build) defaults but
     /// increases the stack size to 8MB.
     pub fn build() -> Result<Self, rayon::ThreadPoolBuildError> {
-        Self::builder()
-            // increase stack size, mostly for RPC calls that use the evm: <https://github.com/paradigmxyz/reth/issues/3056> and  <https://github.com/bluealloy/revm/issues/305>
-            .stack_size(8 * 1024 * 1024)
-            .build()
-            .map(Self::new)
+        Self::builder().build().map(Self::new)
     }
 
     /// Asynchronous wrapper around Rayon's


### PR DESCRIPTION
ref #5082

tracing can now be done with default stack sizes.

handled the massive delegate tx without issues:

https://github.com/paradigmxyz/reth/issues/3056