### PR TITLE
chore: return None if block does not exist

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1040,9 +1040,7 @@ impl<TX: DbTx> BlockReader for DatabaseProvider<TX> {
         &self,
         block_number: BlockNumber,
     ) -> RethResult<Option<BlockWithSenders>> {
-        let header = self
-            .header_by_number(block_number)?
-            .ok_or_else(|| ProviderError::HeaderNotFound(block_number.into()))?;
+        let Some(header) = self.header_by_number(block_number)? else { return Ok(None) };
 
         let ommers = self.ommers(block_number.into())?.unwrap_or_default();
         let withdrawals = self.withdrawals_by_block(block_number.into(), header.timestamp)?;


### PR DESCRIPTION
it would return an error if block not found which does not match the docs and would render the Option return value redundant.

this is also in line with all the other functions that return `Resutl<Option>`