### PR TITLE
feat(rpc): track cache hits and misses

### DIFF
--- a/crates/rpc/rpc/src/eth/cache/metrics.rs
+++ b/crates/rpc/rpc/src/eth/cache/metrics.rs
@@ -1,3 +1,4 @@
+use metrics::Counter;
 use reth_metrics::{metrics::Gauge, Metrics};
 
 #[derive(Metrics)]
@@ -7,4 +8,8 @@ pub(crate) struct CacheMetrics {
     pub(crate) cached_count: Gauge,
     /// The number of queued consumers.
     pub(crate) queued_consumers_count: Gauge,
+    /// The number of cache hits.
+    pub(crate) hits: Counter,
+    /// The number of cache misses.
+    pub(crate) misses: Counter,
 }

--- a/crates/rpc/rpc/src/eth/cache/multi_consumer.rs
+++ b/crates/rpc/rpc/src/eth/cache/multi_consumer.rs
@@ -70,7 +70,13 @@ where
     /// Returns a reference to the value for a given key and promotes that element to be the most
     /// recently used.
     pub fn get(&mut self, key: &K) -> Option<&mut V> {
-        self.cache.get(key)
+        let entry = self.cache.get(key);
+        if entry.is_some() {
+            self.metrics.hits.increment(1);
+        } else {
+            self.metrics.misses.increment(1);
+        }
+        entry
     }
 
     /// Inserts a new element into the map.


### PR DESCRIPTION
# Description

Track the number of cache hits and misses.
This is useful when observing the cache during load testing rpc methods.