### PR TITLE
refactor(rpc): remove `result_output` from `revm_utils`

### DIFF
--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -36,7 +36,7 @@ use reth_rpc_types::{
 use reth_tasks::TaskSpawner;
 use revm::{
     db::{CacheDB, EmptyDB},
-    primitives::{Env, ExecutionResult},
+    primitives::Env,
 };
 use revm_primitives::{
     db::{DatabaseCommit, DatabaseRef},
@@ -330,7 +330,7 @@ where
             })
             .await?;
         let gas_used = res.result.gas_used();
-        let return_value = ExecutionResult::into_output(res.result).unwrap_or_default();
+        let return_value = res.result.into_output().unwrap_or_default();
         let frame = inspector.into_geth_builder().geth_traces(gas_used, return_value, config);
 
         Ok(frame.into())
@@ -533,7 +533,7 @@ where
 
         let (res, _) = inspect(db, env, &mut inspector)?;
         let gas_used = res.result.gas_used();
-        let return_value = ExecutionResult::into_output(res.result).unwrap_or_default();
+        let return_value = res.result.into_output().unwrap_or_default();
         let frame = inspector.into_geth_builder().geth_traces(gas_used, return_value, config);
 
         Ok((frame.into(), res.state))

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -3,7 +3,7 @@ use crate::{
         error::{EthApiError, EthResult},
         revm_utils::{
             clone_into_empty_db, inspect, inspect_and_return_db, prepare_call_env,
-            replay_transactions_until, result_output, transact, EvmOverrides,
+            replay_transactions_until, transact, EvmOverrides,
         },
         EthTransactions, TransactionSource,
     },
@@ -36,7 +36,7 @@ use reth_rpc_types::{
 use reth_tasks::TaskSpawner;
 use revm::{
     db::{CacheDB, EmptyDB},
-    primitives::Env,
+    primitives::{Env, ExecutionResult},
 };
 use revm_primitives::{
     db::{DatabaseCommit, DatabaseRef},
@@ -330,7 +330,7 @@ where
             })
             .await?;
         let gas_used = res.result.gas_used();
-        let return_value = result_output(&res.result).unwrap_or_default();
+        let return_value = ExecutionResult::into_output(res.result).unwrap_or_default();
         let frame = inspector.into_geth_builder().geth_traces(gas_used, return_value, config);
 
         Ok(frame.into())
@@ -533,7 +533,7 @@ where
 
         let (res, _) = inspect(db, env, &mut inspector)?;
         let gas_used = res.result.gas_used();
-        let return_value = result_output(&res.result).unwrap_or_default();
+        let return_value = ExecutionResult::into_output(res.result).unwrap_or_default();
         let frame = inspector.into_geth_builder().geth_traces(gas_used, return_value, config);
 
         Ok((frame.into(), res.state))

--- a/crates/rpc/rpc/src/eth/revm_utils.rs
+++ b/crates/rpc/rpc/src/eth/revm_utils.rs
@@ -2,7 +2,7 @@
 
 use crate::eth::error::{EthApiError, EthResult, RpcInvalidTransactionError};
 use reth_primitives::{
-    AccessList, Address, Bytes, TransactionSigned, TransactionSignedEcRecovered, TxHash, B256, U256,
+    AccessList, Address, TransactionSigned, TransactionSignedEcRecovered, TxHash, B256, U256,
 };
 use reth_revm::env::{fill_tx_env, fill_tx_env_with_recovered};
 use reth_rpc_types::{
@@ -17,7 +17,7 @@ use revm::{
 };
 use revm_primitives::{
     db::{DatabaseCommit, DatabaseRef},
-    Bytecode, ExecutionResult,
+    Bytecode,
 };
 use tracing::trace;
 
@@ -577,18 +577,6 @@ where
         logs: db.logs.clone(),
         block_hashes: db.block_hashes.clone(),
         db: Default::default(),
-    }
-}
-
-/// Helper to get the output data from a result
-///
-/// TODO: Can be phased out when <https://github.com/bluealloy/revm/pull/509> is released
-#[inline]
-pub(crate) fn result_output(res: &ExecutionResult) -> Option<Bytes> {
-    match res {
-        ExecutionResult::Success { output, .. } => Some(output.clone().into_data()),
-        ExecutionResult::Revert { output, .. } => Some(output.clone()),
-        _ => None,
     }
 }
 


### PR DESCRIPTION
Should close #5096.