### PR TITLE
fix: use block id for block receipts

### DIFF
--- a/crates/rpc/rpc-api/src/eth.rs
+++ b/crates/rpc/rpc-api/src/eth.rs
@@ -74,10 +74,8 @@ pub trait EthApi {
 
     /// Returns all transaction receipts for a given block.
     #[method(name = "getBlockReceipts")]
-    async fn block_receipts(
-        &self,
-        number: BlockNumberOrTag,
-    ) -> RpcResult<Option<Vec<TransactionReceipt>>>;
+    async fn block_receipts(&self, block_id: BlockId)
+        -> RpcResult<Option<Vec<TransactionReceipt>>>;
 
     /// Returns an uncle block of the given block and index.
     #[method(name = "getUncleByBlockHashAndIndex")]

--- a/crates/rpc/rpc/src/eth/api/block.rs
+++ b/crates/rpc/rpc/src/eth/api/block.rs
@@ -8,7 +8,7 @@ use crate::{
     EthApi,
 };
 use reth_network_api::NetworkInfo;
-use reth_primitives::{BlockId, BlockNumberOrTag, TransactionMeta};
+use reth_primitives::{BlockId, TransactionMeta};
 
 use reth_provider::{BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, StateProviderFactory};
 use reth_rpc_types::{Index, RichBlock, TransactionReceipt};
@@ -59,13 +59,13 @@ where
     /// Returns `None` if the block wasn't found.
     pub(crate) async fn block_receipts(
         &self,
-        number: BlockNumberOrTag,
+        block_id: BlockId,
     ) -> EthResult<Option<Vec<TransactionReceipt>>> {
         let mut block_and_receipts = None;
 
-        if number.is_pending() {
+        if block_id.is_pending() {
             block_and_receipts = self.provider().pending_block_and_receipts()?;
-        } else if let Some(block_hash) = self.provider().block_hash_for_id(number.into())? {
+        } else if let Some(block_hash) = self.provider().block_hash_for_id(block_id)? {
             block_and_receipts = self.cache().get_block_and_receipts(block_hash).await?;
         }
 

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -126,12 +126,9 @@ where
     }
 
     /// Handler for: `eth_getBlockReceipts`
-    async fn block_receipts(
-        &self,
-        number: BlockNumberOrTag,
-    ) -> Result<Option<Vec<TransactionReceipt>>> {
-        trace!(target: "rpc::eth", ?number, "Serving eth_getBlockReceipts");
-        Ok(EthApi::block_receipts(self, number).await?)
+    async fn block_receipts(&self, block_id: BlockId) -> Result<Option<Vec<TransactionReceipt>>> {
+        trace!(target: "rpc::eth", ?block_id, "Serving eth_getBlockReceipts");
+        Ok(EthApi::block_receipts(self, block_id).await?)
     }
 
     /// Handler for: `eth_getUncleByBlockHashAndIndex`


### PR DESCRIPTION
Closes #5084

switch to BlockId according to execution-api specs