### PR TITLE
simplify trie walker logic

### DIFF
--- a/crates/primitives/src/trie/nibbles.rs
+++ b/crates/primitives/src/trie/nibbles.rs
@@ -82,6 +82,12 @@ impl<const N: usize> From<&[u8; N]> for Nibbles {
     }
 }
 
+impl<const N: usize> From<[u8; N]> for Nibbles {
+    fn from(arr: [u8; N]) -> Self {
+        Nibbles::from_hex(arr.to_vec())
+    }
+}
+
 impl std::fmt::Debug for Nibbles {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Nibbles").field("hex_data", &crate::hex::encode(&self.hex_data)).finish()

--- a/crates/trie/src/node_iter.rs
+++ b/crates/trie/src/node_iter.rs
@@ -90,7 +90,7 @@ where
                         return Ok(Some(AccountNode::Branch(TrieBranchNode::new(
                             key,
                             self.walker.hash().unwrap(),
-                            self.walker.children_are_in_trie(),
+                            self.walker.child_in_trie(),
                         ))))
                     }
                 }
@@ -180,7 +180,7 @@ where
                         return Ok(Some(StorageNode::Branch(TrieBranchNode::new(
                             key,
                             self.walker.hash().unwrap(),
-                            self.walker.children_are_in_trie(),
+                            self.walker.child_in_trie(),
                         ))))
                     }
                 }

--- a/crates/trie/src/proof.rs
+++ b/crates/trie/src/proof.rs
@@ -57,7 +57,7 @@ where
         // Create the walker.
         let mut prefix_set = PrefixSetMut::default();
         prefix_set.insert(target_nibbles.clone());
-        let walker = TrieWalker::new(trie_cursor, prefix_set.freeze());
+        let walker = TrieWalker::new(trie_cursor, prefix_set.freeze(), false);
 
         // Create a hash builder to rebuild the root node since it is not available in the database.
         let mut hash_builder =
@@ -124,7 +124,7 @@ where
             self.tx.cursor_dup_read::<tables::StoragesTrie>()?,
             hashed_address,
         );
-        let walker = TrieWalker::new(trie_cursor, prefix_set);
+        let walker = TrieWalker::new(trie_cursor, prefix_set, false);
 
         let mut hash_builder = HashBuilder::default().with_proof_retainer(target_nibbles);
         let mut storage_node_iter =

--- a/crates/trie/src/trie.rs
+++ b/crates/trie/src/trie.rs
@@ -234,6 +234,7 @@ where
                     trie_cursor,
                     state.walker_stack,
                     self.changed_account_prefixes,
+                    retain_updates,
                 );
                 (
                     state.hash_builder,
@@ -242,12 +243,12 @@ where
                 )
             }
             None => {
-                let walker = TrieWalker::new(trie_cursor, self.changed_account_prefixes);
+                let walker =
+                    TrieWalker::new(trie_cursor, self.changed_account_prefixes, retain_updates);
                 (HashBuilder::default(), AccountNodeIter::new(walker, hashed_account_cursor))
             }
         };
 
-        account_node_iter.walker.set_updates(retain_updates);
         hash_builder.set_updates(retain_updates);
 
         let mut account_rlp = Vec::with_capacity(128);
@@ -448,8 +449,7 @@ where
             self.tx.cursor_dup_read::<tables::StoragesTrie>()?,
             self.hashed_address,
         );
-        let walker = TrieWalker::new(trie_cursor, self.changed_prefixes.clone())
-            .with_updates(retain_updates);
+        let walker = TrieWalker::new(trie_cursor, self.changed_prefixes.clone(), retain_updates);
 
         let mut hash_builder = HashBuilder::default().with_updates(retain_updates);
 

--- a/crates/trie/src/trie.rs
+++ b/crates/trie/src/trie.rs
@@ -1161,7 +1161,6 @@ mod tests {
     }
 
     #[test]
-
     fn account_trie_around_extension_node_with_dbtrie() {
         let db = create_test_rw_db();
         let factory = ProviderFactory::new(db.as_ref(), MAINNET.clone());

--- a/crates/trie/src/trie_cursor/subnode.rs
+++ b/crates/trie/src/trie_cursor/subnode.rs
@@ -1,23 +1,17 @@
 use reth_primitives::{
-    trie::{nodes::CHILD_INDEX_RANGE, BranchNodeCompact, Nibbles, StoredSubNode},
+    trie::{nodes::CHILD_INDEX_RANGE, BranchNodeCompact, Nibbles, StoredSubNode, TrieMask},
     B256,
 };
 
 /// Cursor for iterating over a subtrie.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct CursorSubNode {
     /// The key of the current node.
     pub key: Nibbles,
     /// The index of the next child to visit.
-    pub nibble: i8,
+    pub nibble: u8,
     /// The node itself.
-    pub node: Option<BranchNodeCompact>,
-}
-
-impl Default for CursorSubNode {
-    fn default() -> Self {
-        Self::new(Nibbles::default(), None)
-    }
+    pub node: BranchNodeCompact,
 }
 
 impl std::fmt::Debug for CursorSubNode {
@@ -29,90 +23,61 @@ impl std::fmt::Debug for CursorSubNode {
             .field("tree_flag", &self.tree_flag())
             .field("hash_flag", &self.hash_flag())
             .field("hash", &self.hash())
+            .field("node", &self.node)
             .finish()
     }
 }
 
 impl From<StoredSubNode> for CursorSubNode {
     fn from(value: StoredSubNode) -> Self {
-        let nibble = match value.nibble {
-            Some(n) => n as i8,
-            None => -1,
-        };
-        Self { key: Nibbles::from_hex(value.key), nibble, node: value.node }
+        let nibble = value.nibble.unwrap_or(0);
+        let mut node = value.node.unwrap_or_default();
+        node.state_mask |= TrieMask::from_nibble(nibble);
+        Self { key: Nibbles::from_hex(value.key), nibble, node }
     }
 }
 
 impl From<CursorSubNode> for StoredSubNode {
     fn from(value: CursorSubNode) -> Self {
-        let nibble = if value.nibble >= 0 { Some(value.nibble as u8) } else { None };
-        Self { key: value.key.hex_data.to_vec(), nibble, node: value.node }
+        let nibble = Some(value.nibble);
+        Self { key: value.key.hex_data.to_vec(), nibble, node: Some(value.node) }
     }
 }
 
 impl CursorSubNode {
     /// Creates a new `CursorSubNode` from a key and an optional node.
-    pub fn new(key: Nibbles, node: Option<BranchNodeCompact>) -> Self {
+    pub fn new(key: Nibbles, node: BranchNodeCompact) -> Self {
         // Find the first nibble that is set in the state mask of the node.
-        let nibble = match &node {
-            Some(n) if n.root_hash.is_none() => {
-                CHILD_INDEX_RANGE.clone().find(|i| n.state_mask.is_bit_set(*i)).unwrap() as i8
-            }
-            _ => -1,
-        };
+        let nibble = CHILD_INDEX_RANGE.clone().find(|i| node.state_mask.is_bit_set(*i)).unwrap();
         CursorSubNode { key, node, nibble }
     }
 
     /// Returns the full key of the current node.
     pub fn full_key(&self) -> Nibbles {
         let mut out = self.key.clone();
-        if self.nibble >= 0 {
-            out.extend([self.nibble as u8]);
-        }
+        out.extend([self.nibble]);
         out
     }
 
     /// Returns `true` if the state flag is set for the current nibble.
     pub fn state_flag(&self) -> bool {
-        if let Some(node) = &self.node {
-            if self.nibble >= 0 {
-                return node.state_mask.is_bit_set(self.nibble as u8)
-            }
-        }
-        true
+        self.node.state_mask.is_bit_set(self.nibble)
     }
 
     /// Returns `true` if the tree flag is set for the current nibble.
     pub fn tree_flag(&self) -> bool {
-        if let Some(node) = &self.node {
-            if self.nibble >= 0 {
-                return node.tree_mask.is_bit_set(self.nibble as u8)
-            }
-        }
-        true
+        self.node.tree_mask.is_bit_set(self.nibble)
     }
 
     /// Returns `true` if the current nibble has a root hash.
     pub fn hash_flag(&self) -> bool {
-        match &self.node {
-            Some(node) => match self.nibble {
-                // This guy has it
-                -1 => node.root_hash.is_some(),
-                // Or get it from the children
-                _ => node.hash_mask.is_bit_set(self.nibble as u8),
-            },
-            None => false,
-        }
+        self.node.hash_mask.is_bit_set(self.nibble)
     }
 
     /// Returns the root hash of the current node, if it has one.
     pub fn hash(&self) -> Option<B256> {
         if self.hash_flag() {
-            let node = self.node.as_ref().unwrap();
-            match self.nibble {
-                -1 => node.root_hash,
-                _ => Some(node.hash_for_nibble(self.nibble as u8)),
-            }
+            Some(self.node.hash_for_nibble(self.nibble))
         } else {
             None
         }

--- a/crates/trie/src/updates.rs
+++ b/crates/trie/src/updates.rs
@@ -122,9 +122,7 @@ impl TrieUpdates {
                         }
                     }
                     TrieOp::Update(node) => {
-                        if !nibbles.inner.is_empty() {
-                            account_trie_cursor.upsert(nibbles, node)?;
-                        }
+                        account_trie_cursor.upsert(nibbles, node)?;
                     }
                 },
                 TrieKey::StorageTrie(hashed_address) => match operation {
@@ -136,21 +134,19 @@ impl TrieUpdates {
                     TrieOp::Update(..) => unreachable!("Cannot update full storage trie."),
                 },
                 TrieKey::StorageNode(hashed_address, nibbles) => {
-                    if !nibbles.inner.is_empty() {
-                        // Delete the old entry if it exists.
-                        if storage_trie_cursor
-                            .seek_by_key_subkey(hashed_address, nibbles.clone())?
-                            .filter(|e| e.nibbles == nibbles)
-                            .is_some()
-                        {
-                            storage_trie_cursor.delete_current()?;
-                        }
+                    // Delete the old entry if it exists.
+                    if storage_trie_cursor
+                        .seek_by_key_subkey(hashed_address, nibbles.clone())?
+                        .filter(|e| e.nibbles == nibbles)
+                        .is_some()
+                    {
+                        storage_trie_cursor.delete_current()?;
+                    }
 
-                        // The operation is an update, insert new entry.
-                        if let TrieOp::Update(node) = operation {
-                            storage_trie_cursor
-                                .upsert(hashed_address, StorageTrieEntry { nibbles, node })?;
-                        }
+                    // The operation is an update, insert new entry.
+                    if let TrieOp::Update(node) = operation {
+                        storage_trie_cursor
+                            .upsert(hashed_address, StorageTrieEntry { nibbles, node })?;
                     }
                 }
             };

--- a/crates/trie/src/walker.rs
+++ b/crates/trie/src/walker.rs
@@ -302,7 +302,7 @@ mod tests {
     where
         T: TrieCursor,
     {
-        let mut walker = TrieWalker::new(&mut trie, Default::default());
+        let mut walker = TrieWalker::new(&mut trie, Default::default(), false);
         assert_eq!(walker.key().unwrap(), Nibbles::from([0]));
 
         // We're traversing the path in lexigraphical order.
@@ -357,7 +357,7 @@ mod tests {
         // We insert something that's not part of the existing trie/prefix.
         let mut changed = PrefixSetMut::default();
         changed.insert([0xF, 0x1]);
-        let mut cursor = TrieWalker::new(&mut trie, changed.freeze());
+        let mut cursor = TrieWalker::new(&mut trie, changed.freeze(), false);
 
         // Root node
         assert_eq!(cursor.key(), Some(Nibbles::from_hex(vec![0x0])));


### PR DESCRIPTION
I discovered that the complexity of the current implementation is due to the root node is a special case. This leads to the need for conditional branching and special handling throughout the code, and the functions in CursorSubNode also lack clear semantics.

This pr tries to simplify it by:
1. make CursorSubNode always pointer to a valid child(0 <= nibble < 16);
2. the walker will start from key 0x0 instead empty key, it should work since they are all lower bound for any key inserted in the trie. This will make the root node act the same with other nodes, and remove all special handling.
3. ignore the `BranchNodeCompact::root_hash` field.