### PR TITLE
feat(bin): `--raw` and min size arguments for `db` commands

### DIFF
--- a/bin/reth/src/db/get.rs
+++ b/bin/reth/src/db/get.rs
@@ -17,7 +17,7 @@ pub struct Command {
     pub key: String,
 
     /// Output bytes instead of human-readable decoded value
-    #[clap(long, short)]
+    #[clap(long)]
     pub raw: bool,
 }
 

--- a/bin/reth/src/db/get.rs
+++ b/bin/reth/src/db/get.rs
@@ -1,7 +1,7 @@
 use crate::utils::DbTool;
 use clap::Parser;
 
-use reth_db::{database::Database, table::Table, TableType, TableViewer, Tables};
+use reth_db::{database::Database, table::Table, RawKey, RawTable, TableType, TableViewer, Tables};
 use tracing::error;
 
 /// The arguments for the `reth db get` command
@@ -12,9 +12,13 @@ pub struct Command {
     /// NOTE: The dupsort tables are not supported now.
     pub table: Tables,
 
-    /// The key to get content for   
+    /// The key to get content for
     #[arg(value_parser = maybe_json_value_parser)]
     pub key: String,
+
+    /// Output bytes instead of human-readable decoded value
+    #[clap(long, short)]
+    pub raw: bool,
 }
 
 impl Command {
@@ -51,9 +55,17 @@ impl<DB: Database> TableViewer<()> for GetValueViewer<'_, DB> {
         // get a key for given table
         let key = self.args.table_key::<T>()?;
 
-        match self.tool.get::<T>(key)? {
+        let content = if self.args.raw {
+            self.tool
+                .get::<RawTable<T>>(RawKey::from(key))?
+                .map(|content| format!("{:?}", content.raw_value()))
+        } else {
+            self.tool.get::<T>(key)?.as_ref().map(serde_json::to_string_pretty).transpose()?
+        };
+
+        match content {
             Some(content) => {
-                println!("{}", serde_json::to_string_pretty(&content)?);
+                println!("{}", content);
             }
             None => {
                 error!(target: "reth::cli", "No content for the given table key.");

--- a/bin/reth/src/db/list.rs
+++ b/bin/reth/src/db/list.rs
@@ -28,10 +28,15 @@ pub struct Command {
     /// missing results since the search uses the raw uncompressed value from the database.
     #[arg(long)]
     search: Option<String>,
-
-    /// Minimum size in bytes
+    /// Minimum size of row in bytes
     #[arg(long, default_value_t = 0)]
-    min_size: usize,
+    min_row_size: usize,
+    /// Minimum size of key in bytes
+    #[arg(long, default_value_t = 0)]
+    min_key_size: usize,
+    /// Minimum size of value in bytes
+    #[arg(long, default_value_t = 0)]
+    min_value_size: usize,
     /// Returns the number of rows found.
     #[arg(long, short)]
     count: bool,
@@ -66,7 +71,9 @@ impl Command {
             skip: self.skip,
             len: self.len,
             search,
-            min_size: self.min_size,
+            min_row_size: self.min_row_size,
+            min_key_size: self.min_key_size,
+            min_value_size: self.min_value_size,
             reverse: self.reverse,
             only_count: self.count,
         }

--- a/bin/reth/src/db/list.rs
+++ b/bin/reth/src/db/list.rs
@@ -2,10 +2,7 @@ use super::tui::DbListTUI;
 use crate::utils::{DbTool, ListFilter};
 use clap::Parser;
 use eyre::WrapErr;
-use reth_db::{
-    database::Database, table::Table, DatabaseEnvRO, RawKey, RawValue, TableRawRow, TableViewer,
-    Tables,
-};
+use reth_db::{database::Database, table::Table, DatabaseEnvRO, RawValue, TableViewer, Tables};
 use reth_primitives::hex;
 use std::cell::RefCell;
 use tracing::error;
@@ -31,6 +28,10 @@ pub struct Command {
     /// missing results since the search uses the raw uncompressed value from the database.
     #[arg(long)]
     search: Option<String>,
+
+    /// Minimum size in bytes
+    #[arg(long, default_value_t = 0)]
+    min_size: usize,
     /// Returns the number of rows found.
     #[arg(long, short)]
     count: bool,
@@ -65,6 +66,7 @@ impl Command {
             skip: self.skip,
             len: self.len,
             search,
+            min_size: self.min_size,
             reverse: self.reverse,
             only_count: self.count,
         }

--- a/bin/reth/src/db/tui.rs
+++ b/bin/reth/src/db/tui.rs
@@ -46,9 +46,9 @@ pub(crate) enum ViewMode {
 }
 
 enum Entries<T: Table> {
-    /// Pairs [T::Key] and [RawValue<T::Value>]
+    /// Pairs of [Table::Key] and [RawValue<Table::Value>]
     RawValues(Vec<(T::Key, RawValue<T::Value>)>),
-    /// Pairs [T::Key] and [T::Value]
+    /// Pairs of [Table::Key] and [Table::Value]
     Values(Vec<TableRow<T>>),
 }
 
@@ -63,8 +63,8 @@ impl<T: Table> Entries<T> {
         }
     }
 
-    /// Sets the internal entries [Vec], converting the [T::Value] into [RawValue<T::Value>] if
-    /// needed.
+    /// Sets the internal entries [Vec], converting the [Table::Value] into [RawValue<Table::Value>]
+    /// if needed.
     fn set(&mut self, new_entries: Vec<TableRow<T>>) {
         match self {
             Entries::RawValues(old_entries) => {
@@ -84,7 +84,7 @@ impl<T: Table> Entries<T> {
     }
 
     /// Returns an iterator over keys of the internal [Vec]. For both [Entries::RawValues] and
-    /// [Entries::Values], this iterator will yield [T::Key].
+    /// [Entries::Values], this iterator will yield [Table::Key].
     fn iter_keys(&self) -> EntriesKeyIter<'_, T> {
         EntriesKeyIter { entries: self, index: 0 }
     }

--- a/bin/reth/src/db/tui.rs
+++ b/bin/reth/src/db/tui.rs
@@ -3,7 +3,10 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use reth_db::table::{Table, TableRow};
+use reth_db::{
+    table::{Table, TableRow},
+    RawValue,
+};
 use std::{
     io,
     time::{Duration, Instant},
@@ -58,6 +61,8 @@ where
     count: usize,
     /// The total number of entries in the database
     total_entries: usize,
+    /// Output bytes instead of human-readable decoded value
+    raw: bool,
     /// The current view mode
     mode: ViewMode,
     /// The current state of the input buffer
@@ -73,12 +78,19 @@ where
     F: FnMut(usize, usize) -> Vec<TableRow<T>>,
 {
     /// Create a new database list TUI
-    pub(crate) fn new(fetch: F, skip: usize, count: usize, total_entries: usize) -> Self {
+    pub(crate) fn new(
+        fetch: F,
+        skip: usize,
+        count: usize,
+        total_entries: usize,
+        raw: bool,
+    ) -> Self {
         Self {
             fetch,
             skip,
             count,
             total_entries,
+            raw,
             mode: ViewMode::Normal,
             input: String::new(),
             list_state: ListState::default(),

--- a/bin/reth/src/utils.rs
+++ b/bin/reth/src/utils.rs
@@ -130,6 +130,10 @@ impl<'a, DB: Database> DbTool<'a, DB> {
                 if let Ok((k, v)) = row {
                     let (key, value) = (k.into_key(), v.into_value());
 
+                    if value.len() < filter.min_size {
+                        return None
+                    }
+
                     let result = || {
                         if filter.only_count {
                             return None
@@ -213,6 +217,7 @@ pub struct ListFilter {
     pub len: usize,
     /// Sequence of bytes that will be searched on values and keys from the database.
     pub search: Vec<u8>,
+    pub min_size: usize,
     /// Reverse order of entries.
     pub reverse: bool,
     /// Only counts the number of filtered entries without decoding and returning them.
@@ -220,11 +225,6 @@ pub struct ListFilter {
 }
 
 impl ListFilter {
-    /// Creates a new [`ListFilter`].
-    pub fn new(skip: usize, len: usize, search: Vec<u8>, reverse: bool, only_count: bool) -> Self {
-        ListFilter { skip, len, search, reverse, only_count }
-    }
-
     /// If `search` has a list of bytes, then filter for rows that have this sequence.
     pub fn has_search(&self) -> bool {
         !self.search.is_empty()

--- a/bin/reth/src/utils.rs
+++ b/bin/reth/src/utils.rs
@@ -130,7 +130,13 @@ impl<'a, DB: Database> DbTool<'a, DB> {
                 if let Ok((k, v)) = row {
                     let (key, value) = (k.into_key(), v.into_value());
 
-                    if value.len() < filter.min_size {
+                    if key.len() + value.len() < filter.min_row_size {
+                        return None
+                    }
+                    if key.len() < filter.min_key_size {
+                        return None
+                    }
+                    if value.len() < filter.min_value_size {
                         return None
                     }
 
@@ -217,7 +223,12 @@ pub struct ListFilter {
     pub len: usize,
     /// Sequence of bytes that will be searched on values and keys from the database.
     pub search: Vec<u8>,
-    pub min_size: usize,
+    /// Minimum row size.
+    pub min_row_size: usize,
+    /// Minimum key size.
+    pub min_key_size: usize,
+    /// Minimum value size.
+    pub min_value_size: usize,
     /// Reverse order of entries.
     pub reverse: bool,
     /// Only counts the number of filtered entries without decoding and returning them.

--- a/crates/storage/db/src/tables/raw.rs
+++ b/crates/storage/db/src/tables/raw.rs
@@ -129,6 +129,12 @@ impl<V: Value> RawValue<V> {
     }
 }
 
+impl<V: Value> From<V> for RawValue<V> {
+    fn from(value: V) -> Self {
+        RawValue::new(value)
+    }
+}
+
 impl AsRef<[u8]> for RawValue<Vec<u8>> {
     fn as_ref(&self) -> &[u8] {
         &self.value


### PR DESCRIPTION
As per PR title.

The `Entries` and `EntriesKeyIter` look like an overkill, but it's required to avoid cloning because converting between `Value` and `RawValue` consumes `self`.