### PR TITLE
fix: no value for staticcall call traces

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/types.rs
+++ b/crates/revm/revm-inspectors/src/tracing/types.rs
@@ -32,13 +32,21 @@ pub enum CallKind {
 
 impl CallKind {
     /// Returns true if the call is a create
+    #[inline]
     pub fn is_any_create(&self) -> bool {
         matches!(self, CallKind::Create | CallKind::Create2)
     }
 
     /// Returns true if the call is a delegate of some sorts
+    #[inline]
     pub fn is_delegate(&self) -> bool {
         matches!(self, CallKind::DelegateCall | CallKind::CallCode)
+    }
+
+    /// Returns true if the call is [CallKind::StaticCall].
+    #[inline]
+    pub fn is_static_call(&self) -> bool {
+        matches!(self, CallKind::StaticCall)
     }
 }
 
@@ -412,6 +420,11 @@ impl CallTraceNode {
             calls: Default::default(),
             logs: Default::default(),
         };
+
+        if self.trace.kind.is_static_call() {
+            // STATICCALL frames don't have a value
+            call_frame.value = None;
+        }
 
         // we need to populate error and revert reason
         if !self.trace.success {


### PR DESCRIPTION
```json
                 {
                        "from": "0xf239009a101b6b930a527deaab6961b6e7dec8a6",
                        "gas": "0xd2f1c",
                        "gasUsed": "0x9e6",
                        "to": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
                        "input": "0x70a08231000000000000000000000000f239009a101b6b930a527deaab6961b6e7dec8a6",
                        "output": "0x000000000000000000000000000000000000000000000000c8d5c86f9ff22b59",
                        "type": "STATICCALL"
                    },
```

geth does not include the value in staticcall, that's the reason why this value is an Option.

this sets the value to None if static call.

ref #5011