### PR TITLE
ci: update test-fuzz installation

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -41,11 +41,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: cargo-test-fuzz afl
-      - name: Force install cargo-afl
-        run: |
-          cargo install --force afl
-          cargo afl --version
+          args: cargo-test-fuzz cargo-afl
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 


### PR DESCRIPTION
Cargo-afl was split into its own binary https://github.com/rust-fuzz/afl.rs/pull/375 and the installation instructions for test-fuzz changed https://github.com/trailofbits/test-fuzz/pull/294/