### PR TITLE
chore: add convenience trait bounds

### DIFF
--- a/bin/reth/src/cli/components.rs
+++ b/bin/reth/src/cli/components.rs
@@ -41,7 +41,7 @@ impl<T> FullProvider for T where
 }
 
 /// The trait that is implemented for the Node command.
-pub trait RethNodeComponents {
+pub trait RethNodeComponents: Clone + Send + Sync + 'static {
     /// The Provider type that is provided by the not itself
     type Provider: FullProvider;
     /// The transaction pool type


### PR DESCRIPTION
this makes it easier to consume the entire type without using the components individually.