### PR TITLE
fix: record touched accounts in prestate default mode

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/builder/geth.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/geth.rs
@@ -240,7 +240,7 @@ impl GethTraceBuilder {
 
             // also need to check changed accounts for things like balance changes etc
             for (addr, _) in account_diffs {
-                 match prestate.0.entry(addr) {
+                match prestate.0.entry(addr) {
                     Entry::Vacant(entry) => {
                         let db_acc = db.basic_ref(addr)?.unwrap_or_default();
                         let code = load_account_code(&db_acc);
@@ -250,7 +250,7 @@ impl GethTraceBuilder {
                     }
                     Entry::Occupied(_) => {
                         // already recorded via touched accounts
-                    },
+                    }
                 };
             }
 

--- a/crates/revm/revm-inspectors/src/tracing/builder/geth.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/geth.rs
@@ -13,7 +13,7 @@ use revm::{
     db::DatabaseRef,
     primitives::{AccountInfo, ResultAndState, KECCAK_EMPTY},
 };
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::{btree_map::Entry, BTreeMap, HashMap, VecDeque};
 
 /// A type for creating geth style traces
 #[derive(Clone, Debug)]
@@ -208,22 +208,34 @@ impl GethTraceBuilder {
         };
 
         let account_diffs = state.into_iter().map(|(addr, acc)| (*addr, acc));
-        let is_diff = prestate_config.is_diff_mode();
-        if !is_diff {
+
+        if prestate_config.is_default_mode() {
             let mut prestate = PreStateMode::default();
-            for (addr, changed_acc) in account_diffs {
-                let db_acc = db.basic_ref(addr)?.unwrap_or_default();
-                let code = load_account_code(&db_acc);
+            // in default mode we __only__ return the touched state
+            for node in self.nodes.iter() {
+                let addr = node.trace.address;
 
-                let mut pre_state =
-                    AccountState::from_account_info(db_acc.nonce, db_acc.balance, code);
+                let acc_state = match prestate.0.entry(addr) {
+                    Entry::Vacant(entry) => {
+                        let db_acc = db.basic_ref(addr)?.unwrap_or_default();
+                        let code = load_account_code(&db_acc);
+                        let acc_state =
+                            AccountState::from_account_info(db_acc.nonce, db_acc.balance, code);
+                        entry.insert(acc_state)
+                    }
+                    Entry::Occupied(entry) => entry.into_mut(),
+                };
 
-                // handle _touched_ storage slots
-                for (key, slot) in changed_acc.storage.iter() {
-                    pre_state.storage.insert((*key).into(), slot.previous_or_original_value.into());
+                for (key, value) in node.touched_slots() {
+                    match acc_state.storage.entry(key.into()) {
+                        Entry::Vacant(entry) => {
+                            entry.insert(value.unwrap_or_default().into());
+                        }
+                        Entry::Occupied(_) => {
+                            // we've already recorded this slot
+                        }
+                    }
                 }
-
-                prestate.0.insert(addr, pre_state);
             }
             Ok(PreStateFrame::Default(prestate))
         } else {

--- a/crates/revm/revm-inspectors/src/tracing/types.rs
+++ b/crates/revm/revm-inspectors/src/tracing/types.rs
@@ -251,15 +251,15 @@ impl CallTraceNode {
     }
 
     /// Returns all storage slots touched by this trace and the value this storage had if any
+    ///
+    /// A touched slot is either a slot that was written to or read from.
+    ///
+    /// If the slot is accessed more than once, the result only includes the first time it was
+    /// accessed, in other words in only returns the original value of the slot or `None` if it did
+    /// not yet have a value.
     pub(crate) fn touched_slots(&self) -> BTreeMap<U256, Option<U256>> {
         let mut touched_slots = BTreeMap::new();
-        for change in self
-            .trace
-            .steps
-            .iter()
-            .filter_map(|s| s.storage_change.as_ref())
-            .filter(|c| c.is_sload())
-        {
+        for change in self.trace.steps.iter().filter_map(|s| s.storage_change.as_ref()) {
             match touched_slots.entry(change.key) {
                 std::collections::btree_map::Entry::Vacant(entry) => {
                     entry.insert(change.had_value);
@@ -614,13 +614,6 @@ impl CallTraceStep {
 pub(crate) enum StorageChangeReason {
     SLOAD,
     SSTORE,
-}
-
-impl StorageChange {
-    /// Returns true if the storage change is an SLOAD
-    fn is_sload(&self) -> bool {
-        matches!(self.reason, StorageChangeReason::SLOAD)
-    }
 }
 
 /// Represents a storage change during execution

--- a/crates/revm/revm-inspectors/src/tracing/types.rs
+++ b/crates/revm/revm-inspectors/src/tracing/types.rs
@@ -262,7 +262,8 @@ impl CallTraceNode {
         for change in self.trace.steps.iter().filter_map(|s| s.storage_change.as_ref()) {
             match touched_slots.entry(change.key) {
                 std::collections::btree_map::Entry::Vacant(entry) => {
-                    entry.insert(change.had_value);
+                    dbg!(change);
+                    entry.insert(Some(change.value));
                 }
                 std::collections::btree_map::Entry::Occupied(_) => {
                     // already touched

--- a/crates/revm/revm-inspectors/src/tracing/types.rs
+++ b/crates/revm/revm-inspectors/src/tracing/types.rs
@@ -250,20 +250,18 @@ impl CallTraceNode {
         }
     }
 
-    /// Returns all storage slots touched by this trace and the value this storage had if any
+    /// Returns all storage slots touched by this trace and the value this storage.
     ///
     /// A touched slot is either a slot that was written to or read from.
     ///
     /// If the slot is accessed more than once, the result only includes the first time it was
-    /// accessed, in other words in only returns the original value of the slot or `None` if it did
-    /// not yet have a value.
-    pub(crate) fn touched_slots(&self) -> BTreeMap<U256, Option<U256>> {
+    /// accessed, in other words in only returns the original value of the slot.
+    pub(crate) fn touched_slots(&self) -> BTreeMap<U256, U256> {
         let mut touched_slots = BTreeMap::new();
         for change in self.trace.steps.iter().filter_map(|s| s.storage_change.as_ref()) {
             match touched_slots.entry(change.key) {
                 std::collections::btree_map::Entry::Vacant(entry) => {
-                    dbg!(change);
-                    entry.insert(Some(change.value));
+                    entry.insert(change.value);
                 }
                 std::collections::btree_map::Entry::Occupied(_) => {
                     // already touched

--- a/crates/rpc/rpc-types/src/eth/trace/geth/pre_state.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/geth/pre_state.rs
@@ -196,6 +196,11 @@ impl AccountChangeKind {
     }
 }
 
+/// The config for the prestate tracer.
+///
+/// If `diffMode` is set to true, the response frame includes all the account and storage diffs for
+/// the transaction. If it's missing or set to false it only returns the accounts and storage
+/// necessary to execute the transaction.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PreStateConfig {

--- a/crates/rpc/rpc-types/src/eth/trace/geth/pre_state.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/geth/pre_state.rs
@@ -204,8 +204,16 @@ pub struct PreStateConfig {
 }
 
 impl PreStateConfig {
+    /// Returns true if this trace was requested with diffmode.
+    #[inline]
     pub fn is_diff_mode(&self) -> bool {
         self.diff_mode.unwrap_or_default()
+    }
+
+    /// Is default mode if diff_mode is not set
+    #[inline]
+    pub fn is_default_mode(&self) -> bool {
+        !self.is_diff_mode()
     }
 }
 

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -263,7 +263,10 @@ where
                             .into_pre_state_config()
                             .map_err(|_| EthApiError::InvalidTracerConfig)?;
                         let mut inspector = TracingInspector::new(
-                            TracingInspectorConfig::from_geth_config(&config),
+                            TracingInspectorConfig::from_geth_config(&config)
+                                // if in default mode, we need to return all touched storages, for
+                                // which we need to record steps and statediff
+                                .set_steps_and_state_diffs(prestate_config.is_default_mode()),
                         );
 
                         let frame =
@@ -490,7 +493,10 @@ where
                             .map_err(|_| EthApiError::InvalidTracerConfig)?;
 
                         let mut inspector = TracingInspector::new(
-                            TracingInspectorConfig::from_geth_config(&config),
+                            TracingInspectorConfig::from_geth_config(&config)
+                                // if in default mode, we need to return all touched storages, for
+                                // which we need to record steps and statediff
+                                .set_steps_and_state_diffs(prestate_config.is_default_mode()),
                         );
                         let (res, _) = inspect(&mut *db, env, &mut inspector)?;
 

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -268,7 +268,7 @@ where
                                 // which we need to record steps and statediff
                                 .set_steps_and_state_diffs(prestate_config.is_default_mode()),
                         );
-
+                        dbg!(&call.access_list);
                         let frame =
                             self.inner
                                 .eth_api

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -268,7 +268,7 @@ where
                                 // which we need to record steps and statediff
                                 .set_steps_and_state_diffs(prestate_config.is_default_mode()),
                         );
-                        dbg!(&call.access_list);
+
                         let frame =
                             self.inner
                                 .eth_api


### PR DESCRIPTION
prestate in default mode returns all touched accounts and their original storage values

ref #5011

this fixes most of #5011 

for some reason we're missing one storage key of WETH:

```json
        "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": {
            "storage": {
                "0x4921bcd6144d2a88b3e139dcb536293f54a29d9905c467a66747286cb90469eb": "0x00000000000000000000000000000000000000000000000108925872c471bf9b"
            }
        },
```