### PR TITLE
Remove probably obsolete parameter from docs

### DIFF
--- a/book/run/mainnet.md
+++ b/book/run/mainnet.md
@@ -60,12 +60,6 @@ RUST_LOG=info lighthouse bn \
     --execution-jwt /path/to/secret
 ```
 
-If you don't intend on running validators on your node you can add:
-
-``` bash
-  --disable-deposit-contract-sync
-```
-
 The `--checkpoint-sync-url` argument value can be replaced with any checkpoint sync endpoint from a [community maintained list](https://eth-clients.github.io/checkpoint-sync-endpoints/#mainnet). 
 
 Your Reth node should start receiving "fork choice updated" messages, and begin syncing the chain.


### PR DESCRIPTION
Hey 👋

is the `--disable-deposit-contract-sync` still available in the current code base? I stumbled upon it in the docs and was unable to find more info about it. Not in any docs nor in the code here... so I guess it might have been removed?
This MR would remove it also from the doc, preventing other people falling down this rabbil hole :D

If this parameter is indeed still available, could you maybe point me to a doc/src file with more information about it? :) 

Thanks!