### PR TITLE
feat(rpc-testing-util): rpc tracing compare testing support

### DIFF
--- a/crates/rpc/rpc-testing-util/src/trace.rs
+++ b/crates/rpc/rpc-testing-util/src/trace.rs
@@ -239,7 +239,7 @@ mod tests {
 
     #[tokio::test]
     async fn compare_trace_block_responses() {
-        let comparer = RpcComparer::new("The Reth rpc", "Another RPC here");
+        let comparer = RpcComparer::new("http://localhost:8545", "https://eth.llamarpc.com");
         let block_ids = vec![BlockId::Number(5u64.into()), BlockNumberOrTag::Latest.into()];
 
         comparer.compare_trace_block_responses(block_ids).await;

--- a/crates/rpc/rpc-testing-util/src/trace.rs
+++ b/crates/rpc/rpc-testing-util/src/trace.rs
@@ -198,15 +198,6 @@ where
     /// Fetches the `trace_block` responses for the provided block IDs from both clients
     /// and compares them. If there are inconsistencies between the two responses, this
     /// method will panic with a relevant message indicating the difference.
-    ///
-    /// # Arguments
-    ///
-    /// * `block_ids` - A collection of block IDs for which trace responses will be fetched
-    ///   and compared.
-    ///
-    /// # Panics
-    ///
-    /// If the responses from the two clients are inconsistent.
     pub async fn compare_trace_block_responses(&self, block_ids: Vec<BlockId>) {
         let stream1 = self.client1.trace_block_buffered(block_ids.clone(), 2);
         let stream2 = self.client2.trace_block_buffered(block_ids, 2);


### PR DESCRIPTION
https://github.com/paradigmxyz/reth/issues/5146


- Added function to fetch and compare data with trace_block responses  asserting that the results are consistent between both RPC (Reth and another Client).