### PR TITLE
fix: check payload length and consumed buf for pooled tx

### DIFF
--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1040,6 +1040,8 @@ impl TransactionSigned {
             return Err(RlpError::Custom("typed tx fields must be encoded as a list"))
         }
 
+        let remaining_len = data.len();
+
         // length of tx encoding = tx type byte (size = 1) + length of header + payload length
         let tx_length = 1 + header.length() + header.payload_length;
 
@@ -1052,6 +1054,11 @@ impl TransactionSigned {
         };
 
         let signature = Signature::decode(data)?;
+
+        let bytes_consumed = remaining_len - data.len();
+        if bytes_consumed != header.payload_length {
+            return Err(RlpError::UnexpectedLength)
+        }
 
         let hash = keccak256(&original_encoding[..tx_length]);
         let signed = TransactionSigned { transaction, hash, signature };

--- a/crates/primitives/src/transaction/pooled.rs
+++ b/crates/primitives/src/transaction/pooled.rs
@@ -580,25 +580,6 @@ mod tests {
     }
 
     #[test]
-    fn leading_zeros_tx_value() {
-        let leading_zeros = [
-            // this one has a correct payload length but contains a txvalue with leading zeros
-            &hex!("d4141d80808300b21d88fcbab282e13a7e53525a54")[..],
-        ];
-
-        for hex_data in leading_zeros.iter() {
-            let input_rlp = &mut &hex_data[..];
-            let res = PooledTransactionsElement::decode(input_rlp);
-
-            assert!(
-                res.is_err(),
-                "expected err after decoding rlp input: {:x?}",
-                Bytes::copy_from_slice(hex_data)
-            );
-        }
-    }
-
-    #[test]
     fn legacy_valid_pooled_decoding() {
         // d3 <- payload length, d3 - c0 = 0x13 = 19
         // 0b

--- a/crates/primitives/src/transaction/pooled.rs
+++ b/crates/primitives/src/transaction/pooled.rs
@@ -582,15 +582,15 @@ mod tests {
     #[test]
     fn legacy_valid_pooled_decoding() {
         // d3 <- payload length, d3 - c0 = 0x13 = 19
-        // 0b
-        // 02
-        // 80
-        // 80
-        // 83 c5cdeb
-        // 87 83c5acfd9e407c
-        // 56
-        // 56
-        // 56
+        // 0b <- nonce
+        // 02 <- gas_price
+        // 80 <- gas_limit
+        // 80 <- to (Create)
+        // 83 c5cdeb <- value
+        // 87 83c5acfd9e407c <- input
+        // 56 <- v (eip155, so modified with a chain id)
+        // 56 <- r
+        // 56 <- s
         let data = &hex!("d30b02808083c5cdeb8783c5acfd9e407c565656")[..];
 
         let input_rlp = &mut &data[..];

--- a/crates/primitives/src/transaction/tx_value.rs
+++ b/crates/primitives/src/transaction/tx_value.rs
@@ -150,25 +150,3 @@ impl proptest::arbitrary::Arbitrary for TxValue {
 
     type Strategy = BoxedStrategy<TxValue>;
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use alloy_primitives::hex;
-
-    #[test]
-    fn tx_value_invalid_leading_zeros() {
-        let leading_zeros = [
-            // this one has a correct payload length but contains a txvalue with leading zeros
-            &hex!("8300b21d")[..],
-            &hex!("840000b21d")[..],
-        ];
-
-        for hex_data in leading_zeros.iter() {
-            let input_rlp = &mut &hex_data[..];
-            // try to decode
-            let res = U256::decode(input_rlp);
-            assert!(res.is_err());
-        }
-    }
-}

--- a/crates/primitives/src/transaction/tx_value.rs
+++ b/crates/primitives/src/transaction/tx_value.rs
@@ -150,3 +150,25 @@ impl proptest::arbitrary::Arbitrary for TxValue {
 
     type Strategy = BoxedStrategy<TxValue>;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::hex;
+
+    #[test]
+    fn tx_value_invalid_leading_zeros() {
+        let leading_zeros = [
+            // this one has a correct payload length but contains a txvalue with leading zeros
+            &hex!("8300b21d")[..],
+            &hex!("840000b21d")[..],
+        ];
+
+        for hex_data in leading_zeros.iter() {
+            let input_rlp = &mut &hex_data[..];
+            // try to decode
+            let res = U256::decode(input_rlp);
+            assert!(res.is_err());
+        }
+    }
+}


### PR DESCRIPTION
This is one of the bugs found by #5125, we were previously allowing decoding of legacy transactions that were shorter than their payload length, as well as legacy transactions that were longer than their payload length. We will need to similarly check header lengths in other manual decodings.

Tests are added that contain RLP strings generated by the fuzzer.