### PR TITLE
perf: only record active context memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6659,7 +6659,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "3.5.0"
-source = "git+https://github.com/bluealloy/revm?rev=df44297bc3949dc9e0cec06594c62dd946708b2a#df44297bc3949dc9e0cec06594c62dd946708b2a"
+source = "git+https://github.com/bluealloy/revm?rev=6ca6c08d37714cc6660ddfe5e542cdabace08962#6ca6c08d37714cc6660ddfe5e542cdabace08962"
 dependencies = [
  "auto_impl",
  "revm-interpreter",
@@ -6669,7 +6669,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "1.3.0"
-source = "git+https://github.com/bluealloy/revm?rev=df44297bc3949dc9e0cec06594c62dd946708b2a#df44297bc3949dc9e0cec06594c62dd946708b2a"
+source = "git+https://github.com/bluealloy/revm?rev=6ca6c08d37714cc6660ddfe5e542cdabace08962#6ca6c08d37714cc6660ddfe5e542cdabace08962"
 dependencies = [
  "revm-primitives",
 ]
@@ -6677,7 +6677,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "2.2.0"
-source = "git+https://github.com/bluealloy/revm?rev=df44297bc3949dc9e0cec06594c62dd946708b2a#df44297bc3949dc9e0cec06594c62dd946708b2a"
+source = "git+https://github.com/bluealloy/revm?rev=6ca6c08d37714cc6660ddfe5e542cdabace08962#6ca6c08d37714cc6660ddfe5e542cdabace08962"
 dependencies = [
  "aurora-engine-modexp",
  "c-kzg",
@@ -6693,7 +6693,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "1.3.0"
-source = "git+https://github.com/bluealloy/revm?rev=df44297bc3949dc9e0cec06594c62dd946708b2a#df44297bc3949dc9e0cec06594c62dd946708b2a"
+source = "git+https://github.com/bluealloy/revm?rev=6ca6c08d37714cc6660ddfe5e542cdabace08962#6ca6c08d37714cc6660ddfe5e542cdabace08962"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,8 +111,8 @@ reth-ecies = { path = "./crates/net/ecies" }
 reth-tracing = { path = "./crates/tracing" }
 reth-tokio-util = { path = "crates/tokio-util" }
 # revm
-revm = { git = "https://github.com/bluealloy/revm", rev = "df44297bc3949dc9e0cec06594c62dd946708b2a" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "df44297bc3949dc9e0cec06594c62dd946708b2a" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "6ca6c08d37714cc6660ddfe5e542cdabace08962" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "6ca6c08d37714cc6660ddfe5e542cdabace08962" }
 
 ## eth
 alloy-primitives = "0.4"

--- a/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
@@ -383,7 +383,7 @@ impl ParityTraceBuilder {
         } else {
             Some(MemoryDelta {
                 off: step.memory_size,
-                data: step.memory.slice(0, step.memory.len()).to_vec().into(),
+                data: step.memory.as_bytes().to_vec().into(),
             })
         };
 

--- a/crates/revm/revm-inspectors/src/tracing/mod.rs
+++ b/crates/revm/revm-inspectors/src/tracing/mod.rs
@@ -24,7 +24,7 @@ mod types;
 mod utils;
 use crate::tracing::{
     arena::PushTraceKind,
-    types::{CallTraceNode, StorageChange, StorageChangeReason},
+    types::{CallTraceNode, RecordedMemory, StorageChange, StorageChangeReason},
     utils::gas_used,
 };
 pub use builder::{
@@ -280,7 +280,7 @@ impl TracingInspector {
         let memory = self
             .config
             .record_memory_snapshots
-            .then(|| interp.shared_memory.clone())
+            .then(|| RecordedMemory::new(interp.shared_memory.context_memory().to_vec()))
             .unwrap_or_default();
         let stack =
             self.config.record_stack_snapshots.then(|| interp.stack.clone()).unwrap_or_default();
@@ -302,8 +302,8 @@ impl TracingInspector {
             contract: interp.contract.address,
             stack,
             push_stack: None,
+            memory_size: memory.len(),
             memory,
-            memory_size: interp.shared_memory.len(),
             gas_remaining: self.gas_inspector.gas_remaining(),
             gas_refund_counter: interp.gas.refunded() as u64,
 

--- a/crates/revm/revm-inspectors/src/tracing/types.rs
+++ b/crates/revm/revm-inspectors/src/tracing/types.rs
@@ -11,7 +11,7 @@ use reth_rpc_types::trace::{
     },
 };
 use revm::interpreter::{
-    opcode, CallContext, CallScheme, CreateScheme, InstructionResult, OpCode, SharedMemory, Stack,
+    opcode, CallContext, CallScheme, CreateScheme, InstructionResult, OpCode, Stack,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, VecDeque};
@@ -518,7 +518,7 @@ pub(crate) struct CallTraceStep {
     /// All allocated memory in a step
     ///
     /// This will be empty if memory capture is disabled
-    pub(crate) memory: SharedMemory,
+    pub(crate) memory: RecordedMemory,
     /// Size of memory at the beginning of the step
     pub(crate) memory_size: usize,
     /// Remaining gas before step execution
@@ -568,7 +568,7 @@ impl CallTraceStep {
         }
 
         if opts.is_memory_enabled() {
-            log.memory = Some(convert_memory(self.memory.slice(0, self.memory.len())));
+            log.memory = Some(self.memory.memory_chunks());
         }
 
         log
@@ -622,4 +622,37 @@ pub(crate) struct StorageChange {
     pub(crate) value: U256,
     pub(crate) had_value: Option<U256>,
     pub(crate) reason: StorageChangeReason,
+}
+
+/// Represents the memory captured during execution
+///
+/// This is a wrapper around the [SharedMemory](revm::interpreter::SharedMemory) context memory.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct RecordedMemory(pub(crate) Vec<u8>);
+
+impl RecordedMemory {
+    pub(crate) fn new(mem: Vec<u8>) -> Self {
+        Self(mem)
+    }
+
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    pub(crate) fn resize(&mut self, size: usize) {
+        self.0.resize(size, 0);
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Converts the memory into 32byte hex chunks
+    pub(crate) fn memory_chunks(&self) -> Vec<String> {
+        convert_memory(self.as_bytes())
+    }
 }


### PR DESCRIPTION
with new SharedMemory, we were recording too much memory when memory recording was enabled.

this now only records the context memory which is a subset of the sharedmemory