### PR TITLE
chore: bump `revm` version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6659,7 +6659,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "3.5.0"
-source = "git+https://github.com/bluealloy/revm?rev=6ca6c08d37714cc6660ddfe5e542cdabace08962#6ca6c08d37714cc6660ddfe5e542cdabace08962"
+source = "git+https://github.com/bluealloy/revm?rev=0d78d1eb304a2ce41ddac8f03206f5a316af247b#0d78d1eb304a2ce41ddac8f03206f5a316af247b"
 dependencies = [
  "auto_impl",
  "revm-interpreter",
@@ -6669,7 +6669,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "1.3.0"
-source = "git+https://github.com/bluealloy/revm?rev=6ca6c08d37714cc6660ddfe5e542cdabace08962#6ca6c08d37714cc6660ddfe5e542cdabace08962"
+source = "git+https://github.com/bluealloy/revm?rev=0d78d1eb304a2ce41ddac8f03206f5a316af247b#0d78d1eb304a2ce41ddac8f03206f5a316af247b"
 dependencies = [
  "revm-primitives",
 ]
@@ -6677,7 +6677,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "2.2.0"
-source = "git+https://github.com/bluealloy/revm?rev=6ca6c08d37714cc6660ddfe5e542cdabace08962#6ca6c08d37714cc6660ddfe5e542cdabace08962"
+source = "git+https://github.com/bluealloy/revm?rev=0d78d1eb304a2ce41ddac8f03206f5a316af247b#0d78d1eb304a2ce41ddac8f03206f5a316af247b"
 dependencies = [
  "aurora-engine-modexp",
  "c-kzg",
@@ -6693,7 +6693,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "1.3.0"
-source = "git+https://github.com/bluealloy/revm?rev=6ca6c08d37714cc6660ddfe5e542cdabace08962#6ca6c08d37714cc6660ddfe5e542cdabace08962"
+source = "git+https://github.com/bluealloy/revm?rev=0d78d1eb304a2ce41ddac8f03206f5a316af247b#0d78d1eb304a2ce41ddac8f03206f5a316af247b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,8 +111,8 @@ reth-ecies = { path = "./crates/net/ecies" }
 reth-tracing = { path = "./crates/tracing" }
 reth-tokio-util = { path = "crates/tokio-util" }
 # revm
-revm = { git = "https://github.com/bluealloy/revm", rev = "6ca6c08d37714cc6660ddfe5e542cdabace08962" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "6ca6c08d37714cc6660ddfe5e542cdabace08962" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "0d78d1eb304a2ce41ddac8f03206f5a316af247b" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "0d78d1eb304a2ce41ddac8f03206f5a316af247b" }
 
 ## eth
 alloy-primitives = "0.4"

--- a/crates/revm/revm-inspectors/src/tracing/js/mod.rs
+++ b/crates/revm/revm-inspectors/src/tracing/js/mod.rs
@@ -274,8 +274,7 @@ impl JsInspector {
         if !self.precompiles_registered {
             return
         }
-        let precompiles =
-            PrecompileList(precompiles.addresses().into_iter().map(Into::into).collect());
+        let precompiles = PrecompileList(precompiles.addresses().into_iter().copied().collect());
 
         let _ = precompiles.register_callable(&mut self.ctx);
 


### PR DESCRIPTION
## Overview

Bumps the `revm` version, with fixes (https://github.com/bluealloy/revm/pull/824) in `revm` for `op-reth` in #4377.