### PR TITLE
feat(primitives, stages): improve checkpoint logs readability

### DIFF
--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -56,7 +56,7 @@ impl NodeState {
     /// Processes an event emitted by the pipeline
     fn handle_pipeline_event(&mut self, event: PipelineEvent) {
         match event {
-            PipelineEvent::Running { pipeline_position, pipeline_total, stage_id, checkpoint } => {
+            PipelineEvent::Running { pipeline_stages_progress, stage_id, checkpoint } => {
                 let notable = self.current_stage.is_none();
                 self.current_stage = Some(stage_id);
                 self.current_checkpoint = checkpoint.unwrap_or_default();
@@ -64,7 +64,7 @@ impl NodeState {
                 if notable {
                     if let Some(progress) = self.current_checkpoint.entities() {
                         info!(
-                            pipeline_stages = %format!("{pipeline_position}/{pipeline_total}"),
+                            pipeline_stages = %pipeline_stages_progress,
                             stage = %stage_id,
                             from = self.current_checkpoint.block_number,
                             checkpoint = %self.current_checkpoint.block_number,
@@ -74,7 +74,7 @@ impl NodeState {
                         );
                     } else {
                         info!(
-                            pipeline_stages = %format!("{pipeline_position}/{pipeline_total}"),
+                            pipeline_stages = %pipeline_stages_progress,
                             stage = %stage_id,
                             from = self.current_checkpoint.block_number,
                             checkpoint = %self.current_checkpoint.block_number,
@@ -85,8 +85,7 @@ impl NodeState {
                 }
             }
             PipelineEvent::Ran {
-                pipeline_position,
-                pipeline_total,
+                pipeline_stages_progress,
                 stage_id,
                 result: ExecOutput { checkpoint, done },
             } => {
@@ -101,7 +100,7 @@ impl NodeState {
 
                 if let Some(progress) = checkpoint.entities() {
                     info!(
-                        pipeline_stages = %format!("{pipeline_position}/{pipeline_total}"),
+                        pipeline_stages = %pipeline_stages_progress,
                         stage = %stage_id,
                         checkpoint = %checkpoint.block_number,
                         %progress,
@@ -110,7 +109,7 @@ impl NodeState {
                     );
                 } else {
                     info!(
-                        pipeline_stages = %format!("{pipeline_position}/{pipeline_total}"),
+                        pipeline_stages = %pipeline_stages_progress,
                         stage = %stage_id,
                         checkpoint = %checkpoint.block_number,
                         eta = %self.eta.fmt_for_stage(stage_id),

--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -273,24 +273,24 @@ where
         let mut this = self.project();
 
         while this.info_interval.poll_tick(cx).is_ready() {
-            if let Some(stage_id) = this.state.current_stage {
+            if let Some(stage) = this.state.current_stage {
                 if let Some(progress) = this.state.current_checkpoint.entities() {
                     info!(
                         target: "reth::cli",
                         connected_peers = this.state.num_connected_peers(),
-                        stage = %stage_id.to_string(),
+                        %stage,
                         checkpoint = %this.state.current_checkpoint.block_number,
                         %progress,
-                        eta = %this.state.eta.fmt_for_stage(stage_id),
+                        eta = %this.state.eta.fmt_for_stage(stage),
                         "Status"
                     );
                 } else {
                     info!(
                         target: "reth::cli",
                         connected_peers = this.state.num_connected_peers(),
-                        stage = %stage_id.to_string(),
+                        %stage,
                         checkpoint = %this.state.current_checkpoint.block_number,
-                        eta = %this.state.eta.fmt_for_stage(stage_id),
+                        eta = %this.state.eta.fmt_for_stage(stage),
                         "Status"
                     );
                 }

--- a/crates/primitives/src/stage/checkpoints.rs
+++ b/crates/primitives/src/stage/checkpoints.rs
@@ -246,15 +246,6 @@ impl StageCheckpoint {
     }
 }
 
-impl Display for StageCheckpoint {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self.entities() {
-            Some(entities) => entities.fmt(f),
-            None => write!(f, "{}", self.block_number),
-        }
-    }
-}
-
 // TODO(alexey): add a merkle checkpoint. Currently it's hard because [`MerkleCheckpoint`]
 //  is not a Copy type.
 /// Stage-specific checkpoint metrics.

--- a/crates/stages/src/pipeline/event.rs
+++ b/crates/stages/src/pipeline/event.rs
@@ -1,5 +1,6 @@
 use crate::stage::{ExecOutput, UnwindInput, UnwindOutput};
 use reth_primitives::stage::{StageCheckpoint, StageId};
+use std::fmt::{Display, Formatter};
 
 /// An event emitted by a [Pipeline][crate::Pipeline].
 ///
@@ -12,10 +13,8 @@ use reth_primitives::stage::{StageCheckpoint, StageId};
 pub enum PipelineEvent {
     /// Emitted when a stage is about to be run.
     Running {
-        /// 1-indexed ID of the stage that is about to be run out of total stages in the pipeline.
-        pipeline_position: usize,
-        /// Total number of stages in the pipeline.
-        pipeline_total: usize,
+        /// Pipeline stages progress.
+        pipeline_stages_progress: PipelineStagesProgress,
         /// The stage that is about to be run.
         stage_id: StageId,
         /// The previous checkpoint of the stage.
@@ -23,10 +22,8 @@ pub enum PipelineEvent {
     },
     /// Emitted when a stage has run a single time.
     Ran {
-        /// 1-indexed ID of the stage that was run out of total stages in the pipeline.
-        pipeline_position: usize,
-        /// Total number of stages in the pipeline.
-        pipeline_total: usize,
+        /// Pipeline stages progress.
+        pipeline_stages_progress: PipelineStagesProgress,
         /// The stage that was run.
         stage_id: StageId,
         /// The result of executing the stage.
@@ -60,4 +57,19 @@ pub enum PipelineEvent {
         /// The stage that was skipped.
         stage_id: StageId,
     },
+}
+
+/// Pipeline stages progress.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct PipelineStagesProgress {
+    /// 1-indexed ID of the stage that is about to be run out of total stages in the pipeline.
+    pub current: usize,
+    /// Total number of stages in the pipeline.
+    pub total: usize,
+}
+
+impl Display for PipelineStagesProgress {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.current, self.total)
+    }
 }

--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -371,8 +371,10 @@ where
             }
 
             self.listeners.notify(PipelineEvent::Running {
-                pipeline_position: stage_index + 1,
-                pipeline_total: total_stages,
+                pipeline_stages_progress: event::PipelineStagesProgress {
+                    current: stage_index + 1,
+                    total: total_stages,
+                },
                 stage_id,
                 checkpoint: prev_checkpoint,
             });
@@ -413,8 +415,10 @@ where
                     provider_rw.save_stage_checkpoint(stage_id, checkpoint)?;
 
                     self.listeners.notify(PipelineEvent::Ran {
-                        pipeline_position: stage_index + 1,
-                        pipeline_total: total_stages,
+                        pipeline_stages_progress: event::PipelineStagesProgress {
+                            current: stage_index + 1,
+                            total: total_stages,
+                        },
                         stage_id,
                         result: out.clone(),
                     });
@@ -601,26 +605,22 @@ mod tests {
             events.collect::<Vec<PipelineEvent>>().await,
             vec![
                 PipelineEvent::Running {
-                    pipeline_position: 1,
-                    pipeline_total: 2,
+                    pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 2 },
                     stage_id: StageId::Other("A"),
                     checkpoint: None
                 },
                 PipelineEvent::Ran {
-                    pipeline_position: 1,
-                    pipeline_total: 2,
+                    pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 2 },
                     stage_id: StageId::Other("A"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(20), done: true },
                 },
                 PipelineEvent::Running {
-                    pipeline_position: 2,
-                    pipeline_total: 2,
+                    pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 2 },
                     stage_id: StageId::Other("B"),
                     checkpoint: None
                 },
                 PipelineEvent::Ran {
-                    pipeline_position: 2,
-                    pipeline_total: 2,
+                    pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 2 },
                     stage_id: StageId::Other("B"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(10), done: true },
                 },
@@ -668,38 +668,32 @@ mod tests {
             vec![
                 // Executing
                 PipelineEvent::Running {
-                    pipeline_position: 1,
-                    pipeline_total: 3,
+                    pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 3 },
                     stage_id: StageId::Other("A"),
                     checkpoint: None
                 },
                 PipelineEvent::Ran {
-                    pipeline_position: 1,
-                    pipeline_total: 3,
+                    pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 3 },
                     stage_id: StageId::Other("A"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(100), done: true },
                 },
                 PipelineEvent::Running {
-                    pipeline_position: 2,
-                    pipeline_total: 3,
+                    pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 3 },
                     stage_id: StageId::Other("B"),
                     checkpoint: None
                 },
                 PipelineEvent::Ran {
-                    pipeline_position: 2,
-                    pipeline_total: 3,
+                    pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 3 },
                     stage_id: StageId::Other("B"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(10), done: true },
                 },
                 PipelineEvent::Running {
-                    pipeline_position: 3,
-                    pipeline_total: 3,
+                    pipeline_stages_progress: PipelineStagesProgress { current: 3, total: 3 },
                     stage_id: StageId::Other("C"),
                     checkpoint: None
                 },
                 PipelineEvent::Ran {
-                    pipeline_position: 3,
-                    pipeline_total: 3,
+                    pipeline_stages_progress: PipelineStagesProgress { current: 3, total: 3 },
                     stage_id: StageId::Other("C"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(20), done: true },
                 },
@@ -778,26 +772,22 @@ mod tests {
             vec![
                 // Executing
                 PipelineEvent::Running {
-                    pipeline_position: 1,
-                    pipeline_total: 2,
+                    pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 2 },
                     stage_id: StageId::Other("A"),
                     checkpoint: None
                 },
                 PipelineEvent::Ran {
-                    pipeline_position: 1,
-                    pipeline_total: 2,
+                    pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 2 },
                     stage_id: StageId::Other("A"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(100), done: true },
                 },
                 PipelineEvent::Running {
-                    pipeline_position: 2,
-                    pipeline_total: 2,
+                    pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 2 },
                     stage_id: StageId::Other("B"),
                     checkpoint: None
                 },
                 PipelineEvent::Ran {
-                    pipeline_position: 2,
-                    pipeline_total: 2,
+                    pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 2 },
                     stage_id: StageId::Other("B"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(10), done: true },
                 },
@@ -868,20 +858,17 @@ mod tests {
             events.collect::<Vec<PipelineEvent>>().await,
             vec![
                 PipelineEvent::Running {
-                    pipeline_position: 1,
-                    pipeline_total: 2,
+                    pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 2 },
                     stage_id: StageId::Other("A"),
                     checkpoint: None
                 },
                 PipelineEvent::Ran {
-                    pipeline_position: 1,
-                    pipeline_total: 2,
+                    pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 2 },
                     stage_id: StageId::Other("A"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(10), done: true },
                 },
                 PipelineEvent::Running {
-                    pipeline_position: 2,
-                    pipeline_total: 2,
+                    pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 2 },
                     stage_id: StageId::Other("B"),
                     checkpoint: None
                 },
@@ -899,26 +886,22 @@ mod tests {
                     result: UnwindOutput { checkpoint: StageCheckpoint::new(0) },
                 },
                 PipelineEvent::Running {
-                    pipeline_position: 1,
-                    pipeline_total: 2,
+                    pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 2 },
                     stage_id: StageId::Other("A"),
                     checkpoint: Some(StageCheckpoint::new(0))
                 },
                 PipelineEvent::Ran {
-                    pipeline_position: 1,
-                    pipeline_total: 2,
+                    pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 2 },
                     stage_id: StageId::Other("A"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(10), done: true },
                 },
                 PipelineEvent::Running {
-                    pipeline_position: 2,
-                    pipeline_total: 2,
+                    pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 2 },
                     stage_id: StageId::Other("B"),
                     checkpoint: None
                 },
                 PipelineEvent::Ran {
-                    pipeline_position: 2,
-                    pipeline_total: 2,
+                    pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 2 },
                     stage_id: StageId::Other("B"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(10), done: true },
                 },

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -206,7 +206,12 @@ where
 
         // Nothing to sync
         if gap.is_closed() {
-            info!(target: "sync::stages::headers", checkpoint = %current_checkpoint, target = ?tip, "Target block already reached");
+            info!(
+                target: "sync::stages::headers",
+                checkpoint = %current_checkpoint.block_number,
+                target = ?tip,
+                "Target block already reached"
+            );
             return Ok(ExecOutput::done(current_checkpoint))
         }
 


### PR DESCRIPTION
```console
2023-10-26T15:21:35.399539Z  INFO reth::node::events: Executing stage pipeline_stages=1/13 stage=Headers from=18427744 checkpoint=18427744 progress=100.0% eta=unknown
2023-10-26T15:21:35.399816Z  INFO execute{stage=Headers}: sync::stages::headers: Target block already reached checkpoint=18427744 target=Hash(0x43d6df2b4326aa863c4fb186ec07cfc3ea728a3405a7ed6c2da4e7c3d086b186)
2023-10-26T15:21:35.400127Z  INFO reth::node::events: Stage finished executing pipeline_stages=1/13 stage=Headers checkpoint=18427744 progress=100.0% eta=unknown
2023-10-26T15:21:35.400417Z  INFO reth::node::events: Executing stage pipeline_stages=2/13 stage=TotalDifficulty from=18427744 checkpoint=18427744 progress=100.0% eta=unknown
2023-10-26T15:21:35.400455Z  INFO reth::node::events: Stage finished executing pipeline_stages=2/13 stage=TotalDifficulty checkpoint=18427744 progress=100.0% eta=unknown
2023-10-26T15:21:35.400713Z  INFO reth::node::events: Executing stage pipeline_stages=3/13 stage=Bodies from=18427744 checkpoint=18427744 progress=100.0% eta=unknown
2023-10-26T15:21:35.400781Z  INFO reth::node::events: Stage finished executing pipeline_stages=3/13 stage=Bodies checkpoint=18427744 progress=100.0% eta=unknown
2023-10-26T15:21:35.401084Z  INFO reth::node::events: Executing stage pipeline_stages=4/13 stage=SenderRecovery from=18427744 checkpoint=18427744 progress=100.0% eta=unknown
2023-10-26T15:21:35.401130Z  INFO reth::node::events: Stage finished executing pipeline_stages=4/13 stage=SenderRecovery checkpoint=18427744 progress=100.0% eta=unknown
2023-10-26T15:21:35.401407Z  INFO reth::node::events: Executing stage pipeline_stages=5/13 stage=Execution from=14466361 checkpoint=14466361 progress=62.8% eta=unknown
2023-10-26T15:21:38.387337Z  INFO reth::cli: Status connected_peers=2 stage=Execution checkpoint=14466361 progress=62.8% eta=unknown
```