### PR TITLE
perf: introduce BlockValidationKind

### DIFF
--- a/crates/blockchain-tree/src/noop.rs
+++ b/crates/blockchain-tree/src/noop.rs
@@ -1,7 +1,8 @@
 use reth_interfaces::{
     blockchain_tree::{
         error::{BlockchainTreeError, InsertBlockError},
-        BlockchainTreeEngine, BlockchainTreeViewer, CanonicalOutcome, InsertPayloadOk,
+        BlockValidationKind, BlockchainTreeEngine, BlockchainTreeViewer, CanonicalOutcome,
+        InsertPayloadOk,
     },
     RethResult,
 };
@@ -30,6 +31,7 @@ impl BlockchainTreeEngine for NoopBlockchainTree {
     fn insert_block(
         &self,
         block: SealedBlockWithSenders,
+        _validation_kind: BlockValidationKind,
     ) -> Result<InsertPayloadOk, InsertBlockError> {
         Err(InsertBlockError::tree_error(
             BlockchainTreeError::BlockHashNotFoundInChain { block_hash: block.hash },

--- a/crates/blockchain-tree/src/shareable.rs
+++ b/crates/blockchain-tree/src/shareable.rs
@@ -4,8 +4,8 @@ use parking_lot::RwLock;
 use reth_db::database::Database;
 use reth_interfaces::{
     blockchain_tree::{
-        error::InsertBlockError, BlockchainTreeEngine, BlockchainTreeViewer, CanonicalOutcome,
-        InsertPayloadOk,
+        error::InsertBlockError, BlockValidationKind, BlockchainTreeEngine, BlockchainTreeViewer,
+        CanonicalOutcome, InsertPayloadOk,
     },
     RethResult,
 };
@@ -48,10 +48,11 @@ impl<DB: Database, EF: ExecutorFactory> BlockchainTreeEngine for ShareableBlockc
     fn insert_block(
         &self,
         block: SealedBlockWithSenders,
+        validation_kind: BlockValidationKind,
     ) -> Result<InsertPayloadOk, InsertBlockError> {
         trace!(target: "blockchain_tree", hash=?block.hash, number=block.number, parent_hash=?block.parent_hash, "Inserting block");
         let mut tree = self.tree.write();
-        let res = tree.insert_block(block);
+        let res = tree.insert_block(block, validation_kind);
         tree.update_chains_metrics();
         res
     }

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -72,6 +72,7 @@ pub use handle::BeaconConsensusEngineHandle;
 mod forkchoice;
 use crate::hooks::{EngineHookEvent, EngineHooks, PolledHook};
 pub use forkchoice::ForkchoiceStatus;
+use reth_interfaces::blockchain_tree::BlockValidationKind;
 
 mod metrics;
 
@@ -1294,7 +1295,9 @@ where
         debug_assert!(self.sync.is_pipeline_idle(), "pipeline must be idle");
 
         let block_hash = block.hash;
-        let status = self.blockchain.insert_block_without_senders(block.clone())?;
+        let status = self
+            .blockchain
+            .insert_block_without_senders(block.clone(), BlockValidationKind::Exhaustive)?;
         let mut latest_valid_hash = None;
         let block = Arc::new(block);
         let status = match status {
@@ -1415,7 +1418,10 @@ where
             return
         }
 
-        match self.blockchain.insert_block_without_senders(block) {
+        match self
+            .blockchain
+            .insert_block_without_senders(block, BlockValidationKind::SkipStateRootValidation)
+        {
             Ok(status) => {
                 match status {
                     InsertPayloadOk::Inserted(BlockStatus::Valid) => {

--- a/crates/interfaces/src/blockchain_tree/mod.rs
+++ b/crates/interfaces/src/blockchain_tree/mod.rs
@@ -22,9 +22,10 @@ pub trait BlockchainTreeEngine: BlockchainTreeViewer + Send + Sync {
     fn insert_block_without_senders(
         &self,
         block: SealedBlock,
+        validation_kind: BlockValidationKind,
     ) -> Result<InsertPayloadOk, InsertBlockError> {
         match block.try_seal_with_senders() {
-            Ok(block) => self.insert_block(block),
+            Ok(block) => self.insert_block(block, validation_kind),
             Err(block) => Err(InsertBlockError::sender_recovery_error(block)),
         }
     }
@@ -43,10 +44,17 @@ pub trait BlockchainTreeEngine: BlockchainTreeViewer + Send + Sync {
     /// Buffer block with senders
     fn buffer_block(&self, block: SealedBlockWithSenders) -> Result<(), InsertBlockError>;
 
-    /// Insert block with senders
+    /// Inserts block with senders
+    ///
+    /// The `validation_kind` parameter controls which validation checks are performed.
+    ///
+    /// Caution: If the block was received from the consensus layer, this should always be called
+    /// with [BlockValidationKind::Exhaustive] to validate the state root, if possible to adhere to
+    /// the engine API spec.
     fn insert_block(
         &self,
         block: SealedBlockWithSenders,
+        validation_kind: BlockValidationKind,
     ) -> Result<InsertPayloadOk, InsertBlockError>;
 
     /// Finalize blocks up until and including `finalized_block`, and remove them from the tree.
@@ -90,6 +98,48 @@ pub trait BlockchainTreeEngine: BlockchainTreeViewer + Send + Sync {
 
     /// Unwind tables and put it inside state
     fn unwind(&self, unwind_to: BlockNumber) -> RethResult<()>;
+}
+
+/// Represents the kind of validation that should be performed when inserting a block.
+///
+/// The motivation for this is that the engine API spec requires that block's state root is
+/// validated when received from the CL.
+///
+/// This step is very expensive due to how changesets are stored in the database, so we want to
+/// avoid doing it if not necessary. Blocks can also originate from the network where this step is
+/// not required.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BlockValidationKind {
+    /// All validation checks that can be performed.
+    ///
+    /// This includes validating the state root, if possible.
+    ///
+    /// Note: This should always be used when inserting blocks that originate from the consensus
+    /// layer.
+    #[default]
+    Exhaustive,
+    /// Perform all validation checks except for state root validation.
+    SkipStateRootValidation,
+}
+
+impl BlockValidationKind {
+    /// Returns true if the state root should be validated if possible.
+    pub fn is_exhaustive(&self) -> bool {
+        matches!(self, BlockValidationKind::Exhaustive)
+    }
+}
+
+impl std::fmt::Display for BlockValidationKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BlockValidationKind::Exhaustive => {
+                write!(f, "Exhaustive")
+            }
+            BlockValidationKind::SkipStateRootValidation => {
+                write!(f, "SkipStateRootValidation")
+            }
+        }
+    }
 }
 
 /// All possible outcomes of a canonicalization attempt of [BlockchainTreeEngine::make_canonical].

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -44,7 +44,7 @@ pub use bundle_state_provider::BundleStateProvider;
 pub use database::*;
 use reth_db::models::AccountBeforeTx;
 use reth_interfaces::blockchain_tree::{
-    error::InsertBlockError, CanonicalOutcome, InsertPayloadOk,
+    error::InsertBlockError, BlockValidationKind, CanonicalOutcome, InsertPayloadOk,
 };
 
 /// The main type for interacting with the blockchain.
@@ -574,8 +574,9 @@ where
     fn insert_block(
         &self,
         block: SealedBlockWithSenders,
+        validation_kind: BlockValidationKind,
     ) -> Result<InsertPayloadOk, InsertBlockError> {
-        self.tree.insert_block(block)
+        self.tree.insert_block(block, validation_kind)
     }
 
     fn finalize_block(&self, finalized_block: BlockNumber) {


### PR DESCRIPTION
This introduces a parameter for the `Tree::insert_block` which tells the tree how to validate the block.

This makes it possible to selectively require state root validation (for blocks received from CL) and skip it (for blocks downloaded from the network).

This should greatly improve performance when the node transitions from pipeline sync.

Note the `validate_and_execute` function now takes two parameters, once that describes the block, or rather what checks are even possible (state root only possible when it extends the head) and if state root check __should__ even be performed.

this also makes it possible to skip state root check we we're attaching buffered blocks to canonical side chain, which was the root cause of a lot of the perf issues.