### PR TITLE
feat(engine): downgrade pipeline inconsistency log to debug

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -347,7 +347,7 @@ where
             // If the checkpoint of any stage is less than the checkpoint of the first stage,
             // retrieve and return the block hash of the latest header and use it as the target.
             if stage_checkpoint < first_stage_checkpoint {
-                warn!(
+                debug!(
                     target: "consensus::engine",
                     first_stage_checkpoint,
                     inconsistent_stage_id = %stage_id,


### PR DESCRIPTION
This log is emitted on startup when the node was restarted during the initial sync, and it might confuse users making them think something's wrong.