### PR TITLE
fix: use correct trace_call params

### DIFF
--- a/crates/rpc/rpc-api/src/trace.rs
+++ b/crates/rpc/rpc-api/src/trace.rs
@@ -1,8 +1,9 @@
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_primitives::{BlockId, Bytes, B256};
 use reth_rpc_types::{
-    trace::{filter::TraceFilter, parity::*, tracerequest::TraceRequest},
-    CallRequest, Index,
+    state::StateOverride,
+    trace::{filter::TraceFilter, parity::*},
+    BlockOverrides, CallRequest, Index,
 };
 use std::collections::HashSet;
 
@@ -12,7 +13,14 @@ use std::collections::HashSet;
 pub trait TraceApi {
     /// Executes the given call and returns a number of possible traces for it.
     #[method(name = "call")]
-    async fn trace_call(&self, trace_request: TraceRequest) -> RpcResult<TraceResults>;
+    async fn trace_call(
+        &self,
+        call: CallRequest,
+        trace_types: HashSet<TraceType>,
+        block_id: Option<BlockId>,
+        state_overrides: Option<StateOverride>,
+        block_overrides: Option<Box<BlockOverrides>>,
+    ) -> RpcResult<TraceResults>;
 
     /// Performs multiple call traces on top of the same block. i.e. transaction n will be executed
     /// on top of a pending block with all n-1 transactions applied (traced) first. Allows to trace

--- a/crates/rpc/rpc-types/src/eth/trace/tracerequest.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/tracerequest.rs
@@ -7,9 +7,9 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
-/// Trace Request builder style function implementation
+/// Container type for `trace_call` arguments
 #[derive(Debug, Serialize, Deserialize)]
-pub struct TraceRequest {
+pub struct TraceCallRequest {
     /// call request object
     pub call: CallRequest,
     /// trace types
@@ -22,8 +22,8 @@ pub struct TraceRequest {
     pub block_overrides: Option<Box<BlockOverrides>>,
 }
 
-impl TraceRequest {
-    /// Returns a new [`TraceRequest`] given a [`CallRequest`] and [`HashSet<TraceType>`]
+impl TraceCallRequest {
+    /// Returns a new [`TraceCallRequest`] given a [`CallRequest`] and [`HashSet<TraceType>`]
     pub fn new(call: CallRequest) -> Self {
         Self {
             call,

--- a/examples/trace-transaction-cli/src/main.rs
+++ b/examples/trace-transaction-cli/src/main.rs
@@ -19,7 +19,7 @@ use reth::{
     primitives::{Address, IntoRecoveredTransaction},
     rpc::{
         compat::transaction::transaction_to_call_request,
-        types::trace::{parity::TraceType, tracerequest::TraceRequest},
+        types::trace::{parity::TraceType, tracerequest::TraceCallRequest},
     },
     tasks::TaskSpawner,
     transaction_pool::TransactionPool,
@@ -80,7 +80,7 @@ impl RethNodeCommandConfig for RethCliTxpoolExt {
                         let callrequest =
                             transaction_to_call_request(tx.to_recovered_transaction());
                         let tracerequest =
-                            TraceRequest::new(callrequest).with_trace_type(TraceType::Trace);
+                            TraceCallRequest::new(callrequest).with_trace_type(TraceType::Trace);
                         if let Ok(trace_result) = traceapi.trace_call(tracerequest).await {
                             println!(
                                 "trace result for transaction : {:?} is {:?}",


### PR DESCRIPTION
api function was wrongly assigned the new container type for all tracecall arguments

closes #5213