### PR TITLE
fix: pin `nightly` temporarily

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -55,7 +55,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly
-
+        with:
+          toolchain: nightly-2023-10-29
       - name: Install mdbook
         run: |
           mkdir mdbook

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@clippy
+        with:
+          toolchain: nightly-2023-10-29
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -30,6 +32,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly-2023-10-29
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -49,6 +53,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly
         with:
+          toolchain: nightly-2023-10-29
           components: rustfmt
       - run: cargo fmt --all --check
 


### PR DESCRIPTION
latest rust nightly is failing CI. set temporarily to a previous version meanwhile