### PR TITLE
fix: filter out empty storage entries in state diff

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
@@ -589,8 +589,9 @@ where
                 entry.code = Delta::Added(Default::default());
             }
 
-            // new storage values
-            for (key, slot) in changed_acc.storage.iter() {
+            // new storage values are marked as added,
+            // however we're filtering changed here to avoid adding entries for the zero value
+            for (key, slot) in changed_acc.storage.iter().filter(|(_, slot)| slot.is_changed()) {
                 entry.storage.insert((*key).into(), Delta::Added(slot.present_value.into()));
             }
         } else {


### PR DESCRIPTION
we're currently including storage entries like,

however nothing changed here, since value is zero

```
 "0x000000000000000000000000000000000000000000000000000000000000000b": {
                        "+": "0x0000000000000000000000000000000000000000000000000000000000000000"
                    },
```