### PR TITLE
feat: implement providers for `SnapshotJarProvider`

### DIFF
--- a/crates/interfaces/src/provider.rs
+++ b/crates/interfaces/src/provider.rs
@@ -111,4 +111,7 @@ pub enum ProviderError {
     /// State is not available for the given block number because it is pruned.
     #[error("state at block #{0} is pruned")]
     StateAtBlockPruned(BlockNumber),
+    /// Provider does not support this particular request.
+    #[error("this provider does not support this request")]
+    UnsupportedProvider,
 }

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -726,6 +726,21 @@ impl TransactionSignedNoHash {
     pub fn with_hash(self) -> TransactionSigned {
         self.into()
     }
+
+    /// Recovers a list of signers from a transaction list iterator
+    ///
+    /// Returns `None`, if some transaction's signature is invalid, see also
+    /// [Self::recover_signer].
+    pub fn recover_signers<'a, T>(txes: T, num_txes: usize) -> Option<Vec<Address>>
+    where
+        T: IntoParallelIterator<Item = &'a Self> + IntoIterator<Item = &'a Self> + Send,
+    {
+        if num_txes < *PARALLEL_SENDER_RECOVERY_THRESHOLD {
+            txes.into_iter().map(|tx| tx.recover_signer()).collect()
+        } else {
+            txes.into_par_iter().map(|tx| tx.recover_signer()).collect()
+        }
+    }
 }
 
 impl Compact for TransactionSignedNoHash {

--- a/crates/storage/db/src/snapshot/cursor.rs
+++ b/crates/storage/db/src/snapshot/cursor.rs
@@ -18,6 +18,12 @@ impl<'a> SnapshotCursor<'a> {
         Ok(Self(NippyJarCursor::with_handle(jar, mmap_handle)?))
     }
 
+    /// Returns the current `BlockNumber` or `TxNumber` of the cursor depending on the kind of
+    /// snapshot segment.
+    pub fn number(&self) -> u64 {
+        self.row_index() + self.jar().user_header().start()
+    }
+
     /// Gets a row of values.
     pub fn get(
         &mut self,

--- a/crates/storage/nippy-jar/src/cursor.rs
+++ b/crates/storage/nippy-jar/src/cursor.rs
@@ -58,8 +58,14 @@ where
         })
     }
 
+    /// Returns a reference to the related [`NippyJar`]
     pub fn jar(&self) -> &NippyJar<H> {
         self.jar
+    }
+
+    /// Returns current row index of the cursor
+    pub fn row_index(&self) -> u64 {
+        self.row
     }
 
     /// Resets cursor to the beginning.


### PR DESCRIPTION
Implements the available `Providers` for `SnapshotJarProvider`.

Next step is implementing it for the `SnapshotProvider`:
* This will be the one managing the different snapshot ranges. (eg. this block_range doesnt have, let me query the next one)
* Will implement certain methods that `SnapshotJarProvider` cannot by itself with the current snapshots. (eg. snapshots work through a big range, so getting transactions from one block is not possible without external/indexing information)