### PR TITLE
chore(tree): clarify chain split

### DIFF
--- a/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
+++ b/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
@@ -292,15 +292,13 @@ impl BundleStateWithReceipts {
     /// This plain state will contains some additional information that
     /// are is a artifacts of the lower part state.
     ///
-    /// If block number is in future, return None.
-    pub fn split_at(&mut self, block_number: BlockNumber) -> Option<Self> {
+    /// If block number is not within state range, return [None].
+    pub fn split_after(&mut self, block_number: BlockNumber) -> Option<Self> {
         let last_block = self.last_block();
         let first_block = self.first_block;
-        if block_number >= last_block {
+
+        if block_number < first_block || last_block <= block_number {
             return None
-        }
-        if block_number < first_block {
-            return Some(Self::default())
         }
 
         // detached number should be included so we are adding +1 to it.

--- a/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
+++ b/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
@@ -304,16 +304,16 @@ impl BundleStateWithReceipts {
         // detached number should be included so we are adding +1 to it.
         // for example if block number is same as first_block then
         // number of detached block shoud be 1.
-        let num_of_detached_block = (block_number - first_block) + 1;
+        let first_detached_block_idx = (block_number - first_block) + 1;
 
         let mut detached_bundle_state: BundleStateWithReceipts = self.clone();
         detached_bundle_state.revert_to(block_number);
 
         // split is done as [0, num) and [num, len]
-        let (_, this) = self.receipts.split_at(num_of_detached_block as usize);
+        let (_, this) = self.receipts.split_at(first_detached_block_idx as usize);
 
         self.receipts = Receipts::from_vec(this.to_vec().clone());
-        self.bundle.take_n_reverts(num_of_detached_block as usize);
+        self.bundle.take_n_reverts(first_detached_block_idx as usize);
 
         self.first_block = block_number + 1;
 

--- a/crates/storage/provider/src/chain.rs
+++ b/crates/storage/provider/src/chain.rs
@@ -352,9 +352,9 @@ pub enum ChainSplit {
     /// Given block split is contained in first chain.
     Split {
         /// Left contains lower block numbers that get are considered canonicalized. It ends with
-        /// the [SplitAt] block. The substate of this chain is now empty and not usable.
+        /// the [SplitAfter] block. The substate of this chain is now empty and not usable.
         canonical: Chain,
-        /// Right contains all subsequent blocks after the [SplitAt], that are still pending.
+        /// Right contains all subsequent blocks after the [SplitAfter], that are still pending.
         ///
         /// The substate of the original chain is moved here.
         pending: Chain,


### PR DESCRIPTION
## Description

The chain cannot be split _at_ block. Only before or after.