### PR TITLE
Parse Genesis Value from Memory

### DIFF
--- a/bin/reth/src/args/utils.rs
+++ b/bin/reth/src/args/utils.rs
@@ -54,8 +54,8 @@ pub fn genesis_value_parser(s: &str) -> eyre::Result<Arc<ChainSpec>, eyre::Error
                     Ok(raw) => serde_json::from_str(&raw)?,
                     Err(io_err) => {
                         // valid json may start with "\n", but must contain "{"
-                        if s.contains("{") {
-                            serde_json::from_str(&s)?
+                        if s.contains('{') {
+                            serde_json::from_str(s)?
                         } else {
                             return Err(io_err.into()) // assume invalid path
                         }

--- a/bin/reth/src/args/utils.rs
+++ b/bin/reth/src/args/utils.rs
@@ -44,10 +44,11 @@ pub fn genesis_value_parser(s: &str) -> eyre::Result<Arc<ChainSpec>, eyre::Error
         "holesky" => HOLESKY.clone(),
         "dev" => DEV.clone(),
         _ => {
-            let genesis: AllGenesisFormats = match fs::read_to_string(PathBuf::from(shellexpand::full(s)?.into_owned())) {
-                Ok(raw) => serde_json::from_str(&raw)?,
-                Err(_) => serde_json::from_str(&s)?,
-            };
+            let genesis: AllGenesisFormats =
+                match fs::read_to_string(PathBuf::from(shellexpand::full(s)?.into_owned())) {
+                    Ok(raw) => serde_json::from_str(&raw)?,
+                    Err(_) => serde_json::from_str(&s)?,
+                };
             Arc::new(genesis.into())
         }
     })
@@ -158,7 +159,7 @@ mod tests {
     }
 }
 "#;
-    genesis_value_parser(&custom_genesis_str).unwrap();
+        genesis_value_parser(&custom_genesis_str).unwrap();
     }
 
     #[test]

--- a/bin/reth/src/args/utils.rs
+++ b/bin/reth/src/args/utils.rs
@@ -38,7 +38,7 @@ pub fn chain_spec_value_parser(s: &str) -> eyre::Result<Arc<ChainSpec>, eyre::Er
 ///
 /// The value parser matches either a known chain, the path
 /// to a json file, or a json formatted string in-memory. The json can be either
-/// a serialized [ChainSpec] or a [Genesis] struct.
+/// a serialized [ChainSpec] or Genesis struct.
 pub fn genesis_value_parser(s: &str) -> eyre::Result<Arc<ChainSpec>, eyre::Error> {
     Ok(match s {
         "mainnet" => MAINNET.clone(),

--- a/bin/reth/src/args/utils.rs
+++ b/bin/reth/src/args/utils.rs
@@ -35,9 +35,9 @@ pub fn chain_spec_value_parser(s: &str) -> eyre::Result<Arc<ChainSpec>, eyre::Er
 }
 
 /// Clap value parser for [ChainSpec]s.
-/// 
+///
 /// The value parser matches either a known chain, the path
-/// to a json file, or a json formatted string in-memory. The json can be either 
+/// to a json file, or a json formatted string in-memory. The json can be either
 /// a serialized [ChainSpec] or a [Genesis] struct.
 pub fn genesis_value_parser(s: &str) -> eyre::Result<Arc<ChainSpec>, eyre::Error> {
     Ok(match s {
@@ -123,10 +123,12 @@ pub fn parse_socket_address(value: &str) -> eyre::Result<SocketAddr, SocketAddre
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
     use proptest::prelude::Rng;
-    use reth_primitives::{ChainSpecBuilder, Genesis, U256, Address, GenesisAccount, hex, ChainConfig};
+    use reth_primitives::{
+        hex, Address, ChainConfig, ChainSpecBuilder, Genesis, GenesisAccount, U256,
+    };
     use secp256k1::rand::thread_rng;
+    use std::collections::HashMap;
 
     #[test]
     fn parse_known_chain_spec() {
@@ -207,9 +209,7 @@ mod tests {
         // seed accounts after genesis struct created
         let address = hex!("6Be02d1d3665660d22FF9624b7BE0551ee1Ac91b").into();
         let account = GenesisAccount::default().with_balance(U256::from(33));
-        let genesis = genesis.extend_accounts(HashMap::from(
-            [(address, account)]
-        ));
+        let genesis = genesis.extend_accounts(HashMap::from([(address, account)]));
 
         let custom_genesis_from_struct = serde_json::to_string(&genesis).unwrap();
         let chain_from_struct = genesis_value_parser(&custom_genesis_from_struct).unwrap();

--- a/bin/reth/src/args/utils.rs
+++ b/bin/reth/src/args/utils.rs
@@ -175,7 +175,7 @@ mod tests {
 }
 "#;
 
-        let chain_from_json = genesis_value_parser(&custom_genesis_from_json).unwrap();
+        let chain_from_json = genesis_value_parser(custom_genesis_from_json).unwrap();
 
         // using structs
         let config = ChainConfig {

--- a/bin/reth/src/args/utils.rs
+++ b/bin/reth/src/args/utils.rs
@@ -117,7 +117,7 @@ mod tests {
     use secp256k1::rand::thread_rng;
 
     #[test]
-    fn parse_chain_spec_from_path() {
+    fn parse_known_chain_spec() {
         for chain in ["mainnet", "sepolia", "goerli", "holesky"] {
             chain_spec_value_parser(chain).unwrap();
             genesis_value_parser(chain).unwrap();

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -708,10 +708,10 @@ impl ForkTimestamps {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AllGenesisFormats {
-    /// The geth genesis format
-    Geth(Genesis),
     /// The reth genesis format
     Reth(ChainSpec),
+    /// The geth genesis format
+    Geth(Genesis),
 }
 
 impl From<Genesis> for AllGenesisFormats {
@@ -1189,10 +1189,10 @@ impl DepositContract {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{b256, hex, NamedChain, B256, DEV, GOERLI, HOLESKY, MAINNET, SEPOLIA, U256};
+    use crate::{b256, hex, NamedChain, B256, DEV, GOERLI, HOLESKY, MAINNET, SEPOLIA, U256, ChainConfig, GenesisAccount};
     use alloy_rlp::Encodable;
     use bytes::BytesMut;
-    use std::str::FromStr;
+    use std::{str::FromStr, collections::HashMap};
 
     fn test_fork_ids(spec: &ChainSpec, cases: &[(Head, ForkId)]) {
         for (block, expected_id) in cases {
@@ -2293,4 +2293,56 @@ Post-merge hard forks (timestamp based):
             .fork(Hardfork::Paris)
             .active_at_ttd(HOLESKY.genesis.difficulty, HOLESKY.genesis.difficulty));
     }
+
+    #[test]
+    fn test_serialization_custom_chain() {
+        // custom genesis with chain config
+        let config = ChainConfig {
+            chain_id: 2600,
+            homestead_block: Some(0),
+            eip150_block: Some(0),
+            eip155_block: Some(0),
+            eip158_block: Some(0),
+            byzantium_block: Some(0),
+            constantinople_block: Some(0),
+            petersburg_block: Some(0),
+            istanbul_block: Some(0),
+            berlin_block: Some(0),
+            london_block: Some(0),
+            shanghai_time: Some(0),
+            terminal_total_difficulty: Some(U256::ZERO),
+            terminal_total_difficulty_passed: true,
+            ..Default::default()
+        };
+        // genesis
+        let genesis = Genesis {
+            config,
+            nonce: 0,
+            timestamp: 1698688670,
+            gas_limit: 5000,
+            difficulty: U256::ZERO,
+            mix_hash: B256::ZERO,
+            coinbase: Address::ZERO,
+            ..Default::default()
+        };
+
+        // seed accounts after genesis struct created
+        let address = hex!("6Be02d1d3665660d22FF9624b7BE0551ee1Ac91b").into();
+        let account = GenesisAccount::default().with_balance(U256::from(33));
+        let genesis = genesis.extend_accounts(HashMap::from(
+            [(address, account)]
+        ));
+
+        // build chain
+        let chain_spec = ChainSpecBuilder::default()
+            .chain(2600.into())
+            .genesis(genesis)
+            .cancun_activated()
+            .build();
+
+        let serialized = serde_json::to_string(&chain_spec).unwrap();
+        let deserialized: AllGenesisFormats = serde_json::from_str(&serialized).unwrap();
+        assert!(matches!(deserialized, AllGenesisFormats::Reth(_)))
+    }
+
 }

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -1189,10 +1189,13 @@ impl DepositContract {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{b256, hex, NamedChain, B256, DEV, GOERLI, HOLESKY, MAINNET, SEPOLIA, U256, ChainConfig, GenesisAccount};
+    use crate::{
+        b256, hex, ChainConfig, GenesisAccount, NamedChain, B256, DEV, GOERLI, HOLESKY, MAINNET,
+        SEPOLIA, U256,
+    };
     use alloy_rlp::Encodable;
     use bytes::BytesMut;
-    use std::{str::FromStr, collections::HashMap};
+    use std::{collections::HashMap, str::FromStr};
 
     fn test_fork_ids(spec: &ChainSpec, cases: &[(Head, ForkId)]) {
         for (block, expected_id) in cases {
@@ -2329,9 +2332,7 @@ Post-merge hard forks (timestamp based):
         // seed accounts after genesis struct created
         let address = hex!("6Be02d1d3665660d22FF9624b7BE0551ee1Ac91b").into();
         let account = GenesisAccount::default().with_balance(U256::from(33));
-        let genesis = genesis.extend_accounts(HashMap::from(
-            [(address, account)]
-        ));
+        let genesis = genesis.extend_accounts(HashMap::from([(address, account)]));
 
         // build chain
         let chain_spec = ChainSpecBuilder::default()
@@ -2344,5 +2345,4 @@ Post-merge hard forks (timestamp based):
         let deserialized: AllGenesisFormats = serde_json::from_str(&serialized).unwrap();
         assert!(matches!(deserialized, AllGenesisFormats::Reth(_)))
     }
-
 }

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -506,8 +506,8 @@ impl ChainSpec {
         for (_, cond) in self.forks_iter() {
             // handle block based forks and the sepolia merge netsplit block edge case (TTD
             // ForkCondition with Some(block))
-            if let ForkCondition::Block(block) |
-            ForkCondition::TTD { fork_block: Some(block), .. } = cond
+            if let ForkCondition::Block(block)
+            | ForkCondition::TTD { fork_block: Some(block), .. } = cond
             {
                 if cond.active_at_head(head) {
                     if block != current_applied {
@@ -517,7 +517,7 @@ impl ChainSpec {
                 } else {
                     // we can return here because this block fork is not active, so we set the
                     // `next` value
-                    return ForkId { hash: forkhash, next: block }
+                    return ForkId { hash: forkhash, next: block };
                 }
             }
         }
@@ -538,7 +538,7 @@ impl ChainSpec {
                 // can safely return here because we have already handled all block forks and
                 // have handled all active timestamp forks, and set the next value to the
                 // timestamp that is known but not active yet
-                return ForkId { hash: forkhash, next: timestamp }
+                return ForkId { hash: forkhash, next: timestamp };
             }
         }
 
@@ -553,7 +553,7 @@ impl ChainSpec {
                 // to satisfy every timestamp ForkCondition, we find the last ForkCondition::Block
                 // if one exists, and include its block_num in the returned Head
                 if let Some(last_block_num) = self.last_block_fork_before_merge_or_timestamp() {
-                    return Head { timestamp, number: last_block_num, ..Default::default() }
+                    return Head { timestamp, number: last_block_num, ..Default::default() };
                 }
                 Head { timestamp, ..Default::default() }
             }
@@ -581,17 +581,17 @@ impl ChainSpec {
                     ForkCondition::TTD { fork_block, .. } => {
                         // handle Sepolia merge netsplit case
                         if fork_block.is_some() {
-                            return *fork_block
+                            return *fork_block;
                         }
                         // ensure curr_cond is indeed ForkCondition::Block and return block_num
                         if let ForkCondition::Block(block_num) = curr_cond {
-                            return Some(block_num)
+                            return Some(block_num);
                         }
                     }
                     ForkCondition::Timestamp(_) => {
                         // ensure curr_cond is indeed ForkCondition::Block and return block_num
                         if let ForkCondition::Block(block_num) = curr_cond {
-                            return Some(block_num)
+                            return Some(block_num);
                         }
                     }
                     ForkCondition::Block(_) | ForkCondition::Never => continue,
@@ -992,9 +992,9 @@ impl ForkCondition {
     /// - The condition is satisfied by the timestamp;
     /// - or the condition is satisfied by the total difficulty
     pub fn active_at_head(&self, head: &Head) -> bool {
-        self.active_at_block(head.number) ||
-            self.active_at_timestamp(head.timestamp) ||
-            self.active_at_ttd(head.total_difficulty, head.difficulty)
+        self.active_at_block(head.number)
+            || self.active_at_timestamp(head.timestamp)
+            || self.active_at_ttd(head.total_difficulty, head.difficulty)
     }
 
     /// Get the total terminal difficulty for this fork condition.
@@ -2298,7 +2298,7 @@ Post-merge hard forks (timestamp based):
     }
 
     #[test]
-    fn test_serialization_custom_chain() {
+    fn test_all_genesis_formats_deserialization() {
         // custom genesis with chain config
         let config = ChainConfig {
             chain_id: 2600,
@@ -2334,6 +2334,12 @@ Post-merge hard forks (timestamp based):
         let account = GenesisAccount::default().with_balance(U256::from(33));
         let genesis = genesis.extend_accounts(HashMap::from([(address, account)]));
 
+        // ensure genesis is deserialized correctly
+        let serialized_genesis = serde_json::to_string(&genesis).unwrap();
+        let deserialized_genesis: AllGenesisFormats =
+            serde_json::from_str(&serialized_genesis).unwrap();
+        assert!(matches!(deserialized_genesis, AllGenesisFormats::Geth(_)));
+
         // build chain
         let chain_spec = ChainSpecBuilder::default()
             .chain(2600.into())
@@ -2341,8 +2347,10 @@ Post-merge hard forks (timestamp based):
             .cancun_activated()
             .build();
 
-        let serialized = serde_json::to_string(&chain_spec).unwrap();
-        let deserialized: AllGenesisFormats = serde_json::from_str(&serialized).unwrap();
-        assert!(matches!(deserialized, AllGenesisFormats::Reth(_)))
+        // ensure chain spec is deserialized correctly
+        let serialized_chain_spec = serde_json::to_string(&chain_spec).unwrap();
+        let deserialized_chain_spec: AllGenesisFormats =
+            serde_json::from_str(&serialized_chain_spec).unwrap();
+        assert!(matches!(deserialized_chain_spec, AllGenesisFormats::Reth(_)))
     }
 }

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -506,8 +506,8 @@ impl ChainSpec {
         for (_, cond) in self.forks_iter() {
             // handle block based forks and the sepolia merge netsplit block edge case (TTD
             // ForkCondition with Some(block))
-            if let ForkCondition::Block(block)
-            | ForkCondition::TTD { fork_block: Some(block), .. } = cond
+            if let ForkCondition::Block(block) |
+            ForkCondition::TTD { fork_block: Some(block), .. } = cond
             {
                 if cond.active_at_head(head) {
                     if block != current_applied {
@@ -517,7 +517,7 @@ impl ChainSpec {
                 } else {
                     // we can return here because this block fork is not active, so we set the
                     // `next` value
-                    return ForkId { hash: forkhash, next: block };
+                    return ForkId { hash: forkhash, next: block }
                 }
             }
         }
@@ -538,7 +538,7 @@ impl ChainSpec {
                 // can safely return here because we have already handled all block forks and
                 // have handled all active timestamp forks, and set the next value to the
                 // timestamp that is known but not active yet
-                return ForkId { hash: forkhash, next: timestamp };
+                return ForkId { hash: forkhash, next: timestamp }
             }
         }
 
@@ -553,7 +553,7 @@ impl ChainSpec {
                 // to satisfy every timestamp ForkCondition, we find the last ForkCondition::Block
                 // if one exists, and include its block_num in the returned Head
                 if let Some(last_block_num) = self.last_block_fork_before_merge_or_timestamp() {
-                    return Head { timestamp, number: last_block_num, ..Default::default() };
+                    return Head { timestamp, number: last_block_num, ..Default::default() }
                 }
                 Head { timestamp, ..Default::default() }
             }
@@ -581,17 +581,17 @@ impl ChainSpec {
                     ForkCondition::TTD { fork_block, .. } => {
                         // handle Sepolia merge netsplit case
                         if fork_block.is_some() {
-                            return *fork_block;
+                            return *fork_block
                         }
                         // ensure curr_cond is indeed ForkCondition::Block and return block_num
                         if let ForkCondition::Block(block_num) = curr_cond {
-                            return Some(block_num);
+                            return Some(block_num)
                         }
                     }
                     ForkCondition::Timestamp(_) => {
                         // ensure curr_cond is indeed ForkCondition::Block and return block_num
                         if let ForkCondition::Block(block_num) = curr_cond {
-                            return Some(block_num);
+                            return Some(block_num)
                         }
                     }
                     ForkCondition::Block(_) | ForkCondition::Never => continue,
@@ -992,9 +992,9 @@ impl ForkCondition {
     /// - The condition is satisfied by the timestamp;
     /// - or the condition is satisfied by the total difficulty
     pub fn active_at_head(&self, head: &Head) -> bool {
-        self.active_at_block(head.number)
-            || self.active_at_timestamp(head.timestamp)
-            || self.active_at_ttd(head.total_difficulty, head.difficulty)
+        self.active_at_block(head.number) ||
+            self.active_at_timestamp(head.timestamp) ||
+            self.active_at_ttd(head.total_difficulty, head.difficulty)
     }
 
     /// Get the total terminal difficulty for this fork condition.

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -66,7 +66,7 @@ pub use constants::{
 };
 pub use eip4844::{calculate_excess_blob_gas, kzg_to_versioned_hash};
 pub use forkid::{ForkFilter, ForkHash, ForkId, ForkTransition, ValidationError};
-pub use genesis::{Genesis, GenesisAccount, ChainConfig};
+pub use genesis::{ChainConfig, Genesis, GenesisAccount};
 pub use hardfork::Hardfork;
 pub use header::{Head, Header, HeadersDirection, SealedHeader};
 pub use integer_list::IntegerList;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -66,7 +66,7 @@ pub use constants::{
 };
 pub use eip4844::{calculate_excess_blob_gas, kzg_to_versioned_hash};
 pub use forkid::{ForkFilter, ForkHash, ForkId, ForkTransition, ValidationError};
-pub use genesis::{ChainConfig, Genesis, GenesisAccount};
+pub use genesis::{Genesis, GenesisAccount};
 pub use hardfork::Hardfork;
 pub use header::{Head, Header, HeadersDirection, SealedHeader};
 pub use integer_list::IntegerList;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -66,7 +66,7 @@ pub use constants::{
 };
 pub use eip4844::{calculate_excess_blob_gas, kzg_to_versioned_hash};
 pub use forkid::{ForkFilter, ForkHash, ForkId, ForkTransition, ValidationError};
-pub use genesis::{Genesis, GenesisAccount};
+pub use genesis::{Genesis, GenesisAccount, ChainConfig};
 pub use hardfork::Hardfork;
 pub use header::{Head, Header, HeadersDirection, SealedHeader};
 pub use integer_list::IntegerList;


### PR DESCRIPTION
Try to parse CLI's chain spec from path and memory using either serialized `Genesis` or `ChainSpec` structs. This allows for better customization of the CLI when using reth as a library.

- Increased flexibility for parsing genesis by checking path to json first, then from memory
- Switch order for deserializing `AllGenesisFormats` so `ChainSpec` is deserialized correctly
- Export `ChainConfig` for creating custom `Genesis` structs
- Unit tests and comments
