### PR TITLE
fix: dev-deps rpc-types

### DIFF
--- a/crates/rpc/rpc-types/Cargo.toml
+++ b/crates/rpc/rpc-types/Cargo.toml
@@ -39,5 +39,9 @@ arbitrary = ["dep:arbitrary", "dep:proptest-derive", "dep:proptest", "alloy-prim
 
 [dev-dependencies]
 # misc
+alloy-primitives = { workspace = true, features = ["rand", "rlp", "serde", "arbitrary"] }
+arbitrary = { workspace = true, features = ["derive"] }
+proptest.workspace = true
+proptest-derive.workspace = true
 rand.workspace = true
 similar-asserts = "1.4"


### PR DESCRIPTION
make `cargo t` compile without features