### PR TITLE
Return 0 in state_root instead of todo!

### DIFF
--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -485,7 +485,8 @@ impl AccountReader for MockEthProvider {
 
 impl StateRootProvider for MockEthProvider {
     fn state_root(&self, _state: &BundleStateWithReceipts) -> RethResult<B256> {
-        todo!()
+        // TODO: implement properly
+        Ok(B256::ZERO)
     }
 }
 


### PR DESCRIPTION
It's better to return dummy values then panic so tests which "accidentally" call it but don't check would run fine