### PR TITLE
fix(rpc): return the correct withdrawal index field

### DIFF
--- a/crates/rpc/rpc-types-compat/src/block.rs
+++ b/crates/rpc/rpc-types-compat/src/block.rs
@@ -143,7 +143,7 @@ fn from_primitive_withdrawal(
     withdrawal: reth_primitives::Withdrawal,
 ) -> reth_rpc_types::Withdrawal {
     reth_rpc_types::Withdrawal {
-        index: withdrawal.validator_index,
+        index: withdrawal.index,
         address: withdrawal.address,
         validator_index: withdrawal.validator_index,
         amount: withdrawal.amount,


### PR DESCRIPTION
Previously we were returning the incorrect `index` field, using `validator_index`, which can be different.