### PR TITLE
Update overview.json – fix description of "File descriptors" panel

### DIFF
--- a/etc/grafana/dashboards/overview.json
+++ b/etc/grafana/dashboards/overview.json
@@ -5617,7 +5617,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "100% = 1 core",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {


### PR DESCRIPTION
Hey! There is an example grafana dashboard file provided for copying in [the book](https://paradigmxyz.github.io/reth/run/observability.html)

I used it by myself and found a duplicated description "100% = 1 core" in "File descriptors" panel. (duplicated from "CPU" panel)
This PR proposes to make it empty like in "Memory"

<img width="1717" alt="image" src="https://github.com/paradigmxyz/reth/assets/12694644/281acd16-7f70-464f-bf68-43e1be64c308">

So:
fixed description in "File Descriptors" panel - it was mistakenly duplicated from cpu usage