### PR TITLE
chore(tree): remove redundant BlockchainTree RethError variant

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -955,7 +955,9 @@ where
                 })
                 .with_latest_valid_hash(B256::ZERO)
             }
-            RethError::BlockchainTree(BlockchainTreeError::BlockHashNotFoundInChain { .. }) => {
+            RethError::Canonical(CanonicalError::BlockchainTree(
+                BlockchainTreeError::BlockHashNotFoundInChain { .. },
+            )) => {
                 // This just means we couldn't find the block when attempting to make it canonical,
                 // so we should not warn the user, since this will result in us attempting to sync
                 // to a new target and is considered normal operation during sync

--- a/crates/interfaces/src/blockchain_tree/error.rs
+++ b/crates/interfaces/src/blockchain_tree/error.rs
@@ -330,7 +330,6 @@ impl From<crate::RethError> for InsertBlockErrorKind {
             RethError::Network(err) => InsertBlockErrorKind::Internal(Box::new(err)),
             RethError::Custom(err) => InsertBlockErrorKind::Internal(err.into()),
             RethError::Canonical(err) => InsertBlockErrorKind::Canonical(err),
-            RethError::BlockchainTree(err) => InsertBlockErrorKind::BlockchainTree(err),
         }
     }
 }

--- a/crates/interfaces/src/error.rs
+++ b/crates/interfaces/src/error.rs
@@ -23,11 +23,14 @@ pub enum RethError {
     #[error(transparent)]
     Canonical(#[from] crate::blockchain_tree::error::CanonicalError),
 
-    #[error(transparent)]
-    BlockchainTree(#[from] crate::blockchain_tree::error::BlockchainTreeError),
-
     #[error("{0}")]
     Custom(String),
+}
+
+impl From<crate::blockchain_tree::error::BlockchainTreeError> for RethError {
+    fn from(error: crate::blockchain_tree::error::BlockchainTreeError) -> Self {
+        RethError::Canonical(error.into())
+    }
 }
 
 impl From<reth_nippy_jar::NippyJarError> for RethError {


### PR DESCRIPTION
This removes the `BlockchainTree` variant of `RethError`. This was made redundant due to `CanonicalError`, and matching on `RethError::BlockchainTree(BlockchainTree::BlockHashNotFoundInChain{ .. }))` instead of the canonical variant, caused the `Failed to canonicalize the head hash` log to run for every new FCU.

The log should be properly re-silenced now, hopefully removing some confusion in normal operation.