### PR TITLE
feat: add --rpc.jwtsecret arg

### DIFF
--- a/bin/reth/src/cli/config.rs
+++ b/bin/reth/src/cli/config.rs
@@ -63,7 +63,12 @@ pub trait RethRpcConfig {
     ///
     /// The `default_jwt_path` provided as an argument will be used as the default location for the
     /// jwt secret in case the `auth_jwtsecret` argument is not provided.
-    fn jwt_secret(&self, default_jwt_path: PathBuf) -> Result<JwtSecret, JwtError>;
+    fn auth_jwt_secret(&self, default_jwt_path: PathBuf) -> Result<JwtSecret, JwtError>;
+
+    /// Returns the configured jwt secret key for the regular rpc servers, if any.
+    ///
+    /// Note: this is not used for the auth server (engine API).
+    fn rpc_secret_key(&self) -> Option<JwtSecret>;
 }
 
 /// A trait that provides payload builder settings.

--- a/bin/reth/src/dirs.rs
+++ b/bin/reth/src/dirs.rs
@@ -260,26 +260,36 @@ impl<D> ChainPath<D> {
     }
 
     /// Returns the path to the db directory for this chain.
+    ///
+    /// `<DIR>/<CHAIN_ID>/db`
     pub fn db_path(&self) -> PathBuf {
         self.0.join("db").into()
     }
 
     /// Returns the path to the reth p2p secret key for this chain.
+    ///
+    /// `<DIR>/<CHAIN_ID>/discovery-secret`
     pub fn p2p_secret_path(&self) -> PathBuf {
         self.0.join("discovery-secret").into()
     }
 
     /// Returns the path to the known peers file for this chain.
+    ///
+    /// `<DIR>/<CHAIN_ID>/known-peers.json`
     pub fn known_peers_path(&self) -> PathBuf {
         self.0.join("known-peers.json").into()
     }
 
     /// Returns the path to the config file for this chain.
+    ///
+    /// `<DIR>/<CHAIN_ID>/reth.toml`
     pub fn config_path(&self) -> PathBuf {
         self.0.join("reth.toml").into()
     }
 
     /// Returns the path to the jwtsecret file for this chain.
+    ///
+    /// `<DIR>/<CHAIN_ID>/jwt.hex`
     pub fn jwt_path(&self) -> PathBuf {
         self.0.join("jwt.hex").into()
     }

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -521,7 +521,7 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
 
         // extract the jwt secret from the args if possible
         let default_jwt_path = data_dir.jwt_path();
-        let jwt_secret = self.rpc.jwt_secret(default_jwt_path)?;
+        let jwt_secret = self.rpc.auth_jwt_secret(default_jwt_path)?;
 
         // adjust rpc port numbers based on instance number
         self.adjust_instance_ports();

--- a/crates/rpc/rpc/src/layers/jwt_secret.rs
+++ b/crates/rpc/rpc/src/layers/jwt_secret.rs
@@ -8,6 +8,7 @@ use reth_primitives::{
 use serde::{Deserialize, Serialize};
 use std::{
     path::Path,
+    str::FromStr,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use thiserror::Error;
@@ -101,15 +102,7 @@ impl JwtSecret {
         fs::write(fpath, hex)?;
         Ok(secret)
     }
-}
 
-impl std::fmt::Debug for JwtSecret {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("JwtSecretHash").field(&"{{}}").finish()
-    }
-}
-
-impl JwtSecret {
     /// Validates a JWT token along the following rules:
     /// - The JWT signature is valid.
     /// - The JWT is signed with the `HMAC + SHA256 (HS256)` algorithm.
@@ -166,6 +159,20 @@ impl JwtSecret {
         let key = jsonwebtoken::EncodingKey::from_secret(bytes);
         let algo = jsonwebtoken::Header::new(Algorithm::HS256);
         jsonwebtoken::encode(&algo, claims, &key)
+    }
+}
+
+impl std::fmt::Debug for JwtSecret {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("JwtSecretHash").field(&"{{}}").finish()
+    }
+}
+
+impl FromStr for JwtSecret {
+    type Err = JwtError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        JwtSecret::from_hex(s)
     }
 }
 


### PR DESCRIPTION
Closes #4919

integrates jwt argument to guard http and ws endpoint.

I tried to make this as clear as possible that this is entirely separated from the `--auth.jwtscecret`, but maybe naming/docs can be improved

UX regarding user input could perhaps be improved, but need user feedback first