### PR TITLE
fix: `trace_filter` matches all transactions on empty addresses

### DIFF
--- a/crates/rpc/rpc-types/src/eth/trace/filter.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/filter.rs
@@ -70,12 +70,12 @@ impl TraceFilterMatcher {
 
         match self.mode {
             TraceFilterMode::Union => {
-                self.from_addresses.contains(&from) ||
-                    to.map_or(false, |to| self.to_addresses.contains(&to))
+                self.from_addresses.contains(&from)
+                    || to.map_or(false, |to| self.to_addresses.contains(&to))
             }
             TraceFilterMode::Intersection => {
-                self.from_addresses.contains(&from) &&
-                    to.map_or(false, |to| self.to_addresses.contains(&to))
+                self.from_addresses.contains(&from)
+                    && to.map_or(false, |to| self.to_addresses.contains(&to))
             }
         }
     }
@@ -91,5 +91,28 @@ mod tests {
         let filter: TraceFilter = serde_json::from_str(s).unwrap();
         assert_eq!(filter.from_block, Some(3));
         assert_eq!(filter.to_block, Some(5));
+    }
+
+    #[test]
+    fn test_filter_matcher() {
+        let s = r#"{"fromBlock":  "0x3","toBlock":  "0x5"}"#;
+        let filter: TraceFilter = serde_json::from_str(s).unwrap();
+        let matcher = filter.matcher();
+        assert!(
+            matcher.matches("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045".parse().unwrap(), None)
+        );
+        assert!(
+            matcher.matches("0x160f5f00288e9e1cc8655b327e081566e580a71d".parse().unwrap(), None)
+        );
+
+        let s = r#"{"fromBlock":  "0x3","toBlock":  "0x5", "fromAddress": ["0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"]}"#;
+        let filter: TraceFilter = serde_json::from_str(s).unwrap();
+        let matcher = filter.matcher();
+        assert!(
+            matcher.matches("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045".parse().unwrap(), None)
+        );
+        assert!(
+            !matcher.matches("0x160f5f00288e9e1cc8655b327e081566e580a71d".parse().unwrap(), None)
+        );
     }
 }

--- a/crates/rpc/rpc-types/src/eth/trace/filter.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/filter.rs
@@ -70,7 +70,7 @@ impl TraceFilterMatcher {
 
         match self.mode {
             TraceFilterMode::Union => {
-                self.from_addresses.contains(&from) || 
+                self.from_addresses.contains(&from) ||
                     to.map_or(false, |to| self.to_addresses.contains(&to))
             }
             TraceFilterMode::Intersection => {

--- a/crates/rpc/rpc-types/src/eth/trace/filter.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/filter.rs
@@ -70,12 +70,12 @@ impl TraceFilterMatcher {
 
         match self.mode {
             TraceFilterMode::Union => {
-                self.from_addresses.contains(&from)
-                    || to.map_or(false, |to| self.to_addresses.contains(&to))
+                self.from_addresses.contains(&from) || 
+                    to.map_or(false, |to| self.to_addresses.contains(&to))
             }
             TraceFilterMode::Intersection => {
-                self.from_addresses.contains(&from)
-                    && to.map_or(false, |to| self.to_addresses.contains(&to))
+                self.from_addresses.contains(&from) &&
+                    to.map_or(false, |to| self.to_addresses.contains(&to))
             }
         }
     }

--- a/crates/rpc/rpc-types/src/eth/trace/filter.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/filter.rs
@@ -63,6 +63,11 @@ pub struct TraceFilterMatcher {
 impl TraceFilterMatcher {
     /// Returns `true` if the given `from` and `to` addresses match this filter.
     pub fn matches(&self, from: Address, to: Option<Address>) -> bool {
+        // If `from_addresses` and `to_addresses` are empty, then match all transactions.
+        if self.from_addresses.is_empty() && self.to_addresses.is_empty() {
+            return true;
+        }
+
         match self.mode {
             TraceFilterMode::Union => {
                 self.from_addresses.contains(&from) ||


### PR DESCRIPTION
ref: https://github.com/paradigmxyz/reth/issues/4799

The default behavior for `trace_filter` in Erigon when neither `fromAddress` nor `toAddress` are specified, is to match and return all transactions in the block range.

This PR modifies the `trace_filter` implementation in Reth to match all transactions when neither address filter is specified.

This payload returns transactions from Erigon, but an empty array in Reth: (This is a Goerli block)

```bash
curl --request POST \
  --url 'http://localhost:8545' \
  --header 'Content-Type: application/json' \
  --data '{
	"method": "trace_filter",
	"params": [
		{
			"fromBlock": "0x983323",
			"toBlock": "0x983323"
		}
	],
	"id": 1,
	"jsonrpc": "2.0"
}'
```

Response from reth:
```json
{
	"jsonrpc": "2.0",
	"result": [],
	"id": 1
}
```

Response from Erigon:
```json
{
	"jsonrpc": "2.0",
	"id": 1,
	"result": [
		{
			"action": {
				"from": "0x24eaeb92580ca9a1a40e6d0148b13551f3f43855",
				"callType": "call",
				"gas": "0x2127c",
				"input": "0xfd4312be000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000000040a3ec4fc70eaf64faf6eeda4e9b2bd4742a785464053aa23afad8bd24650e86ffba01d52a7cd84480d0573725899486a0b5e55c20ff45d6628874349375d165029ac1828383d596ba6b9c874c97f3dae8b203252c2de2fa9ec809dabb4995932fef8132823c3ac25abf2126d6030ba0dd95564834b498fa7005f7c43e8b105510000000000000000000000000000000000000000000000000000000000000002000000000000000000000000edb40d000000000000000000000000001bc69880000000000000000000000002501ccf8000000000000000000000000000a7af58",
				"to": "0xf9bff8167c96ffcb86b506c008227b800cfa867e",
				"value": "0x0"
			}, 
	-- snipped for brevity
}
```