### PR TITLE
fix: `trace_filter` properly matches when `from_addresses` or `to_addresses` aren't set

### DIFF
--- a/crates/rpc/rpc-types/src/eth/trace/filter.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/filter.rs
@@ -52,7 +52,7 @@ pub enum TraceFilterMode {
     Intersection,
 }
 
-/// Helper type for matching `from` and `to` addresses.
+/// Helper type for matching `from` and `to` addresses. Empty sets match all addresses.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TraceFilterMatcher {
     mode: TraceFilterMode,
@@ -63,27 +63,40 @@ pub struct TraceFilterMatcher {
 impl TraceFilterMatcher {
     /// Returns `true` if the given `from` and `to` addresses match this filter.
     pub fn matches(&self, from: Address, to: Option<Address>) -> bool {
-        // If `from_addresses` and `to_addresses` are empty, then match all transactions.
+        // 1. If both `from_addresses` and `to_addresses` are empty, match everything.
         if self.from_addresses.is_empty() && self.to_addresses.is_empty() {
             return true;
         }
 
-        match self.mode {
-            TraceFilterMode::Union => {
-                self.from_addresses.contains(&from) ||
-                    to.map_or(false, |to| self.to_addresses.contains(&to))
-            }
-            TraceFilterMode::Intersection => {
-                self.from_addresses.contains(&from) &&
-                    to.map_or(false, |to| self.to_addresses.contains(&to))
-            }
+        let from_matches = self.from_addresses.contains(&from);
+        let to_matches = to.map_or(false, |to_addr| self.to_addresses.contains(&to_addr));
+
+        // 2. Use the filter mode to match if both `from_addresses` and `to_addresses` are defined.
+        if !self.from_addresses.is_empty() && !self.to_addresses.is_empty() {
+            return match self.mode {
+                TraceFilterMode::Union => from_matches || to_matches,
+                TraceFilterMode::Intersection => from_matches && to_matches,
+            };
         }
+
+        // 3. Match only against `to_addresses` if `from_addresses` is empty.
+        if self.from_addresses.is_empty() {
+            return to_matches;
+        }
+
+        // 4. Match only against `from_addresses` if `to_addresses` is empty.
+        if self.to_addresses.is_empty() {
+            return from_matches;
+        }
+
+        unreachable!("Should not happen, all cases are covered above")
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn test_parse_filter() {
@@ -94,25 +107,89 @@ mod tests {
     }
 
     #[test]
-    fn test_filter_matcher() {
-        let s = r#"{"fromBlock":  "0x3","toBlock":  "0x5"}"#;
-        let filter: TraceFilter = serde_json::from_str(s).unwrap();
+    fn test_filter_matcher_addresses_unspecified() {
+        let test_addr_d8 = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045".parse().unwrap();
+        let test_addr_16 = "0x160f5f00288e9e1cc8655b327e081566e580a71d".parse().unwrap();
+        let filter_json = json!({
+            "fromBlock": "0x3",
+            "toBlock": "0x5",
+        });
+        let filter: TraceFilter =
+            serde_json::from_value(filter_json).expect("Failed to parse filter");
         let matcher = filter.matcher();
-        assert!(
-            matcher.matches("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045".parse().unwrap(), None)
-        );
-        assert!(
-            matcher.matches("0x160f5f00288e9e1cc8655b327e081566e580a71d".parse().unwrap(), None)
-        );
+        assert!(matcher.matches(test_addr_d8, None));
+        assert!(matcher.matches(test_addr_16, None));
+        assert!(matcher.matches(test_addr_d8, Some(test_addr_16)));
+        assert!(matcher.matches(test_addr_16, Some(test_addr_d8)));
+    }
 
-        let s = r#"{"fromBlock":  "0x3","toBlock":  "0x5", "fromAddress": ["0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"]}"#;
-        let filter: TraceFilter = serde_json::from_str(s).unwrap();
+    #[test]
+    fn test_filter_matcher_from_address() {
+        let test_addr_d8 = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045".parse().unwrap();
+        let test_addr_16 = "0x160f5f00288e9e1cc8655b327e081566e580a71d".parse().unwrap();
+        let filter_json = json!({
+            "fromBlock": "0x3",
+            "toBlock": "0x5",
+            "fromAddress": [test_addr_d8]
+        });
+        let filter: TraceFilter = serde_json::from_value(filter_json).unwrap();
         let matcher = filter.matcher();
-        assert!(
-            matcher.matches("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045".parse().unwrap(), None)
-        );
-        assert!(
-            !matcher.matches("0x160f5f00288e9e1cc8655b327e081566e580a71d".parse().unwrap(), None)
-        );
+        assert!(matcher.matches(test_addr_d8, None));
+        assert!(!matcher.matches(test_addr_16, None));
+        assert!(matcher.matches(test_addr_d8, Some(test_addr_16)));
+        assert!(!matcher.matches(test_addr_16, Some(test_addr_d8)));
+    }
+
+    #[test]
+    fn test_filter_matcher_to_address() {
+        let test_addr_d8 = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045".parse().unwrap();
+        let test_addr_16 = "0x160f5f00288e9e1cc8655b327e081566e580a71d".parse().unwrap();
+        let filter_json = json!({
+            "fromBlock": "0x3",
+            "toBlock": "0x5",
+            "toAddress": [test_addr_d8],
+        });
+        let filter: TraceFilter = serde_json::from_value(filter_json).unwrap();
+        let matcher = filter.matcher();
+        assert!(matcher.matches(test_addr_16, Some(test_addr_d8)));
+        assert!(!matcher.matches(test_addr_16, None));
+        assert!(!matcher.matches(test_addr_d8, Some(test_addr_16)));
+    }
+
+    #[test]
+    fn test_filter_matcher_both_addresses_union() {
+        let test_addr_d8 = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045".parse().unwrap();
+        let test_addr_16 = "0x160f5f00288e9e1cc8655b327e081566e580a71d".parse().unwrap();
+        let filter_json = json!({
+            "fromBlock": "0x3",
+            "toBlock": "0x5",
+            "fromAddress": [test_addr_16],
+            "toAddress": [test_addr_d8],
+        });
+        let filter: TraceFilter = serde_json::from_value(filter_json).unwrap();
+        let matcher = filter.matcher();
+        assert!(matcher.matches(test_addr_16, Some(test_addr_d8)));
+        assert!(matcher.matches(test_addr_16, None));
+        assert!(matcher.matches(test_addr_d8, Some(test_addr_d8)));
+        assert!(!matcher.matches(test_addr_d8, Some(test_addr_16)));
+    }
+
+    #[test]
+    fn test_filter_matcher_both_addresses_intersection() {
+        let test_addr_d8 = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045".parse().unwrap();
+        let test_addr_16 = "0x160f5f00288e9e1cc8655b327e081566e580a71d".parse().unwrap();
+        let filter_json = json!({
+            "fromBlock": "0x3",
+            "toBlock": "0x5",
+            "fromAddress": [test_addr_16],
+            "toAddress": [test_addr_d8],
+            "mode": "intersection",
+        });
+        let filter: TraceFilter = serde_json::from_value(filter_json).unwrap();
+        let matcher = filter.matcher();
+        assert!(matcher.matches(test_addr_16, Some(test_addr_d8)));
+        assert!(!matcher.matches(test_addr_16, None));
+        assert!(!matcher.matches(test_addr_d8, Some(test_addr_d8)));
+        assert!(!matcher.matches(test_addr_d8, Some(test_addr_16)));
     }
 }

--- a/crates/rpc/rpc-types/src/eth/trace/filter.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/filter.rs
@@ -63,33 +63,32 @@ pub struct TraceFilterMatcher {
 impl TraceFilterMatcher {
     /// Returns `true` if the given `from` and `to` addresses match this filter.
     pub fn matches(&self, from: Address, to: Option<Address>) -> bool {
-        // 1. If both `from_addresses` and `to_addresses` are empty, match everything.
-        if self.from_addresses.is_empty() && self.to_addresses.is_empty() {
-            return true;
-        }
-
         let from_matches = self.from_addresses.contains(&from);
         let to_matches = to.map_or(false, |to_addr| self.to_addresses.contains(&to_addr));
 
-        // 2. Use the filter mode to match if both `from_addresses` and `to_addresses` are defined.
-        if !self.from_addresses.is_empty() && !self.to_addresses.is_empty() {
-            return match self.mode {
+        enum Match {
+            All,
+            From,
+            To,
+            Both(TraceFilterMode),
+        }
+
+        let match_type = match (self.from_addresses.is_empty(), self.to_addresses.is_empty()) {
+            (true, true) => Match::All,
+            (false, true) => Match::From,
+            (true, false) => Match::To,
+            (false, false) => Match::Both(self.mode),
+        };
+
+        match match_type {
+            Match::All => true,
+            Match::From => from_matches,
+            Match::To => to_matches,
+            Match::Both(mode) => match mode {
                 TraceFilterMode::Union => from_matches || to_matches,
                 TraceFilterMode::Intersection => from_matches && to_matches,
-            };
+            },
         }
-
-        // 3. Match only against `to_addresses` if `from_addresses` is empty.
-        if self.from_addresses.is_empty() {
-            return to_matches;
-        }
-
-        // 4. Match only against `from_addresses` if `to_addresses` is empty.
-        if self.to_addresses.is_empty() {
-            return from_matches;
-        }
-
-        unreachable!("Should not happen, all cases are covered above")
     }
 }
 


### PR DESCRIPTION
ref: #4799 

A follow up to #5279 that fixes a couple more cases.

In the previous PR, it handled the case where both `from_addresses` and `to_addresses` were empty, but it still had a bug where one of `from_addresses` or `to_addresses` (but not the other) was empty. The logic is that if one of them isn't specified, it shouldn't be considered when filtering the transactions.

Fix the logic by specifying all 4 possible cases as a match and returning the correct value. Only if both `from_addresses` and `to_addresses` are set does the `TraceFilterMode` apply.

I've added test cases to cover all possible variants. I wasn't sure if I should define a sub-module to group the trace filter tests, I couldn't find any examples of that being done elsewhere in the project - so I just prefixed each test with `test_filter_matcher`.