### PR TITLE
fix: bump stack size on Windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,16 @@
 [alias]
 docs = "doc --workspace --all-features --no-deps"
+
+[target.x86_64-pc-windows-msvc]
+rustflags = [
+    # Increases the stack size to 10MB, which is
+    # in line with Linux (whereas default for Windows is 1MB)
+    "-Clink-arg=/STACK:10000000",
+]
+
+[target.i686-pc-windows-msvc]
+rustflags = [
+    # Increases the stack size to 10MB, which is
+    # in line with Linux (whereas default for Windows is 1MB)
+    "-Clink-arg=/STACK:10000000",
+]


### PR DESCRIPTION
Obviously a better solution would be using less stack size, but this should suffice for now.
Reth reaches 1MB (Windows limit) inside of (or a bit after if already initialized) `init_genesis` on debug mode on `reth node --dev`.

Closes #5261
Closes #5085