### PR TITLE
fix(ci): Integration Test Specify Reth Binary 

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -76,8 +76,9 @@ jobs:
             --debug.terminate
       - name: Verify the target block hash
         run: |
-          cargo run --profile release -- \
-            db get CanonicalHeaders 100000 \
+          cargo run --profile release \
+            --bin reth -- db \
+            get CanonicalHeaders 100000 \
             | grep 0x91c90676cab257a59cd956d7cb0bceb9b1a71d79755c23c7277a0697ccfaf8c4
 
   integration-success:


### PR DESCRIPTION
**Description**

Fixes the integration test to use the `reth` bin in github ci.