### PR TITLE
fix(payload): Ethereum Payload Builder Zero Type

### DIFF
--- a/bin/reth/src/cli/ext.rs
+++ b/bin/reth/src/cli/ext.rs
@@ -115,11 +115,11 @@ pub trait RethNodeCommandConfig: fmt::Debug {
         // The default payload builder is implemented on the unit type.
         #[cfg(not(feature = "optimism"))]
         #[allow(clippy::let_unit_value)]
-        let payload_builder = reth_basic_payload_builder::EthereumPayloadBuilder;
+        let payload_builder = reth_basic_payload_builder::EthereumPayloadBuilder::default();
 
         // Optimism's payload builder is implemented on the OptimismPayloadBuilder type.
         #[cfg(feature = "optimism")]
-        let payload_builder = reth_basic_payload_builder::OptimismPayloadBuilder;
+        let payload_builder = reth_basic_payload_builder::OptimismPayloadBuilder::default();
 
         let payload_generator = BasicPayloadJobGenerator::with_builder(
             components.provider(),

--- a/bin/reth/src/cli/ext.rs
+++ b/bin/reth/src/cli/ext.rs
@@ -115,7 +115,7 @@ pub trait RethNodeCommandConfig: fmt::Debug {
         // The default payload builder is implemented on the unit type.
         #[cfg(not(feature = "optimism"))]
         #[allow(clippy::let_unit_value)]
-        let payload_builder = ();
+        let payload_builder = reth_basic_payload_builder::EthereumPayloadBuilder;
 
         // Optimism's payload builder is implemented on the OptimismPayloadBuilder type.
         #[cfg(feature = "optimism")]

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -59,7 +59,6 @@ mod metrics;
 
 /// Ethereum payload builder
 #[derive(Debug, Clone, Default)]
-#[non_exhaustive]
 pub struct EthereumPayloadBuilder;
 
 #[cfg(feature = "optimism")]

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -57,8 +57,9 @@ use tracing::{debug, trace};
 
 mod metrics;
 
+/// Ethereum payload builder
 #[cfg(not(feature = "optimism"))]
-pub type EthereumPayloadBuilder = ();
+pub struct EthereumPayloadBuilder;
 
 #[cfg(feature = "optimism")]
 mod optimism;

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -57,14 +57,15 @@ use tracing::{debug, trace};
 
 mod metrics;
 
-/// Ethereum payload builder
-#[derive(Debug, Clone, Default)]
-pub struct EthereumPayloadBuilder;
-
 #[cfg(feature = "optimism")]
 mod optimism;
 #[cfg(feature = "optimism")]
 pub use optimism::OptimismPayloadBuilder;
+
+/// Ethereum payload builder
+#[derive(Debug, Clone, Copy, Default)]
+#[non_exhaustive]
+pub struct EthereumPayloadBuilder;
 
 /// The [`PayloadJobGenerator`] that creates [`BasicPayloadJob`]s.
 #[derive(Debug)]

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -58,7 +58,8 @@ use tracing::{debug, trace};
 mod metrics;
 
 /// Ethereum payload builder
-#[cfg(not(feature = "optimism"))]
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct EthereumPayloadBuilder;
 
 #[cfg(feature = "optimism")]
@@ -68,7 +69,7 @@ pub use optimism::OptimismPayloadBuilder;
 
 /// The [`PayloadJobGenerator`] that creates [`BasicPayloadJob`]s.
 #[derive(Debug)]
-pub struct BasicPayloadJobGenerator<Client, Pool, Tasks, Builder = ()> {
+pub struct BasicPayloadJobGenerator<Client, Pool, Tasks, Builder = EthereumPayloadBuilder> {
     /// The client that can interact with the chain.
     client: Client,
     /// txpool

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -99,7 +99,14 @@ impl<Client, Pool, Tasks> BasicPayloadJobGenerator<Client, Pool, Tasks> {
         config: BasicPayloadJobGeneratorConfig,
         chain_spec: Arc<ChainSpec>,
     ) -> Self {
-        BasicPayloadJobGenerator::with_builder(client, pool, executor, config, chain_spec, EthereumPayloadBuilder)
+        BasicPayloadJobGenerator::with_builder(
+            client,
+            pool,
+            executor,
+            config,
+            chain_spec,
+            EthereumPayloadBuilder,
+        )
     }
 }
 

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -99,7 +99,7 @@ impl<Client, Pool, Tasks> BasicPayloadJobGenerator<Client, Pool, Tasks> {
         config: BasicPayloadJobGeneratorConfig,
         chain_spec: Arc<ChainSpec>,
     ) -> Self {
-        BasicPayloadJobGenerator::with_builder(client, pool, executor, config, chain_spec, ())
+        BasicPayloadJobGenerator::with_builder(client, pool, executor, config, chain_spec, EthereumPayloadBuilder)
     }
 }
 

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -721,7 +721,7 @@ pub trait PayloadBuilder<Pool, Client>: Send + Sync + Clone {
 }
 
 // Default implementation of [PayloadBuilder] for unit type
-impl<Pool, Client> PayloadBuilder<Pool, Client> for ()
+impl<Pool, Client> PayloadBuilder<Pool, Client> for EthereumPayloadBuilder
 where
     Client: StateProviderFactory,
     Pool: TransactionPool,

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -58,7 +58,7 @@ use tracing::{debug, trace};
 mod metrics;
 
 #[cfg(not(feature = "optimism"))]
-pub struct EthereumPayloadBuilder = ();
+pub type EthereumPayloadBuilder = ();
 
 #[cfg(feature = "optimism")]
 mod optimism;

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -57,6 +57,9 @@ use tracing::{debug, trace};
 
 mod metrics;
 
+#[cfg(not(feature = "optimism"))]
+pub struct EthereumPayloadBuilder = ();
+
 #[cfg(feature = "optimism")]
 mod optimism;
 #[cfg(feature = "optimism")]

--- a/crates/payload/basic/src/optimism.rs
+++ b/crates/payload/basic/src/optimism.rs
@@ -287,7 +287,8 @@ where
 }
 
 /// Optimism's payload builder
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, Default)]
+#[non_exhaustive]
 pub struct OptimismPayloadBuilder;
 
 /// Implementation of the [PayloadBuilder] trait for [OptimismPayloadBuilder].


### PR DESCRIPTION
**Description**

Defines an `EthereumPayloadBuilder` type as the empty tuple type following @gakonst's comment in https://github.com/paradigmxyz/reth/pull/4377#discussion_r1382498942