### PR TITLE
ci: fix partitions + clippy

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   test:
-    name: test (${{ matrix.network }} | ${{ matrix.partition }}/${{ strategy.job-total }})
+    name: test / ${{ matrix.network }} (${{ matrix.partition }}/2)
     runs-on:
       group: Reth
     strategy:
@@ -49,7 +49,7 @@ jobs:
             --locked --features "${{ matrix.network }}" \
             --bin ${{ steps.binary.outputs.binary }} \
             --workspace --exclude examples --exclude ef-tests \
-            --partition hash:${{ matrix.partition }}/${{ strategy.job-total }} \
+            --partition hash:${{ matrix.partition }}/2 \
             -E 'kind(test)'
 
   sync:
@@ -69,15 +69,15 @@ jobs:
           cache-on-failure: true
       - name: Run sync
         run: |
-          cargo run --profile release --features jemalloc,min-error-logs \
-            --bin reth -- node \
+          cargo run --release --features jemalloc,min-error-logs --bin reth \
+            -- node \
             --debug.tip 0x91c90676cab257a59cd956d7cb0bceb9b1a71d79755c23c7277a0697ccfaf8c4 \
             --debug.max-block 100000 \
             --debug.terminate
       - name: Verify the target block hash
         run: |
-          cargo run --profile release \
-            --bin reth -- db \
+          cargo run --release --bin reth \
+            -- db \
             get CanonicalHeaders 100000 \
             | grep 0x91c90676cab257a59cd956d7cb0bceb9b1a71d79755c23c7277a0697ccfaf8c4
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,25 +11,24 @@ env:
 
 jobs:
   clippy:
-    name: clippy
+    name: clippy / ${{ matrix.network }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       matrix:
         include:
-          - binary: "reth"
-            network: "ethereum"
-          - binary: "op-reth"
-            network: "optimism"
+          - binary: reth
+            network: ethereum
+          - binary: op-reth
+            network: optimism
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@clippy
-        with:
-          toolchain: nightly-2023-10-29
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - run: cargo clippy --bin "${{ matrix.binary }}" --workspace --features "${{ matrix.network }}"
+      - run:
+          cargo clippy --bin "${{ matrix.binary }}" --workspace --features "${{ matrix.network }}"
         env:
           RUSTFLAGS: -D warnings
 

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   test:
-    name: tests (${{ matrix.network }} | ${{ matrix.partition }}/${{ strategy.job-total }})
+    name: test / ${{ matrix.network }} (${{ matrix.partition }}/2)
     runs-on:
       group: Reth
     strategy:
@@ -47,7 +47,7 @@ jobs:
             --locked --features "${{ matrix.network }}" \
             --bin ${{ steps.binary.outputs.binary }} \
             --workspace --exclude examples --exclude ef-tests \
-            --partition hash:${{ matrix.partition }}/${{ strategy.job-total }} \
+            --partition hash:${{ matrix.partition }}/2 \
             -E "kind(lib) | kind(bin) | kind(proc-macro)"
 
   state:

--- a/crates/primitives/src/transaction/tx_value.rs
+++ b/crates/primitives/src/transaction/tx_value.rs
@@ -1,20 +1,10 @@
-#[allow(unused_imports)]
-// suppress warning for UIntTryTo, which is required only when optimism feature is disabled
-use crate::{
-    ruint::{ToUintError, UintTryFrom, UintTryTo},
-    U256,
-};
+use crate::{ruint::UintTryFrom, U256};
 use alloy_rlp::{Decodable, Encodable, Error};
 use reth_codecs::{add_arbitrary_tests, Compact};
 use serde::{Deserialize, Serialize};
 
-#[cfg(any(test, feature = "arbitrary"))]
-use proptest::{
-    arbitrary::ParamsFor,
-    strategy::{BoxedStrategy, Strategy},
-};
-
 /// TxValue is the type of the `value` field in the various Ethereum transactions structs.
+///
 /// While the field is 256 bits, for many chains it's not possible for the field to use
 /// this full precision, hence we use a wrapper type to allow for overriding of encoding.
 #[add_arbitrary_tests(compact, rlp)]
@@ -22,7 +12,7 @@ use proptest::{
 pub struct TxValue(U256);
 
 impl From<TxValue> for U256 {
-    /// unwrap Value to U256
+    #[inline]
     fn from(value: TxValue) -> U256 {
         value.0
     }
@@ -30,50 +20,31 @@ impl From<TxValue> for U256 {
 
 impl<T> From<T> for TxValue
 where
-    Self: UintTryFrom<T>,
+    U256: UintTryFrom<T>,
 {
-    /// construct a Value from misc. other uint types
+    #[inline]
+    #[track_caller]
     fn from(value: T) -> Self {
-        match Self::uint_try_from(value) {
-            Ok(n) => n,
-            Err(e) => panic!("Uint conversion error: {e}"),
-        }
-    }
-}
-
-impl UintTryFrom<U256> for TxValue {
-    #[inline]
-    fn uint_try_from(value: U256) -> Result<Self, ToUintError<Self>> {
-        Ok(Self(value))
-    }
-}
-
-impl UintTryFrom<u128> for TxValue {
-    #[inline]
-    fn uint_try_from(value: u128) -> Result<Self, ToUintError<Self>> {
-        Ok(Self(U256::from(value)))
-    }
-}
-
-impl UintTryFrom<u64> for TxValue {
-    #[inline]
-    fn uint_try_from(value: u64) -> Result<Self, ToUintError<Self>> {
-        Ok(Self(U256::from(value)))
+        Self(U256::uint_try_from(value).unwrap())
     }
 }
 
 impl Encodable for TxValue {
+    #[inline]
     fn encode(&self, out: &mut dyn bytes::BufMut) {
         self.0.encode(out)
     }
+
+    #[inline]
     fn length(&self) -> usize {
         self.0.length()
     }
 }
 
 impl Decodable for TxValue {
+    #[inline]
     fn decode(buf: &mut &[u8]) -> Result<Self, Error> {
-        Ok(TxValue(U256::decode(buf)?))
+        U256::decode(buf).map(Self)
     }
 }
 
@@ -83,7 +54,7 @@ impl Decodable for TxValue {
 /// This optimization should be disabled for chains such as Optimism, where
 /// some tx values may require more than 128-bit precision.
 impl Compact for TxValue {
-    #[allow(unreachable_code)]
+    #[inline]
     fn to_compact<B>(self, buf: &mut B) -> usize
     where
         B: bytes::BufMut + AsMut<[u8]>,
@@ -94,14 +65,11 @@ impl Compact for TxValue {
         }
         #[cfg(not(feature = "optimism"))]
         {
-            // SAFETY: For ethereum mainnet this is safe as the max value is
-            // 120000000000000000000000000 wei
-            let i: u128 = self.0.uint_try_to().expect("value could not be converted to u128");
-            i.to_compact(buf)
+            self.0.to::<u128>().to_compact(buf)
         }
     }
 
-    #[allow(unreachable_code)]
+    #[inline]
     fn from_compact(buf: &[u8], identifier: usize) -> (Self, &[u8]) {
         #[cfg(feature = "optimism")]
         {
@@ -118,35 +86,38 @@ impl Compact for TxValue {
 
 #[cfg(any(test, feature = "arbitrary"))]
 impl<'a> arbitrary::Arbitrary<'a> for TxValue {
+    #[inline]
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         #[cfg(feature = "optimism")]
         {
-            Ok(Self(U256::arbitrary(u)?))
+            U256::arbitrary(u).map(Self)
         }
-
         #[cfg(not(feature = "optimism"))]
         {
-            Ok(Self::try_from(u128::arbitrary(u)?).expect("to fit"))
+            u128::arbitrary(u).map(Self::from)
         }
     }
 }
 
 #[cfg(any(test, feature = "arbitrary"))]
 impl proptest::arbitrary::Arbitrary for TxValue {
-    type Parameters = ParamsFor<()>;
-    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+    #[cfg(feature = "optimism")]
+    type Strategy = proptest::arbitrary::Mapped<U256, Self>;
+    #[cfg(not(feature = "optimism"))]
+    type Strategy = proptest::arbitrary::Mapped<u128, Self>;
+    type Parameters = <U256 as proptest::arbitrary::Arbitrary>::Parameters;
+
+    #[inline]
+    fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
+        use proptest::strategy::Strategy;
+
         #[cfg(feature = "optimism")]
         {
-            proptest::prelude::any::<U256>().prop_map(Self).boxed()
+            proptest::prelude::any::<U256>().prop_map(Self)
         }
-
         #[cfg(not(feature = "optimism"))]
         {
-            proptest::prelude::any::<u128>()
-                .prop_map(|num| Self::try_from(num).expect("to fit"))
-                .boxed()
+            proptest::prelude::any::<u128>().prop_map(Self::from)
         }
     }
-
-    type Strategy = BoxedStrategy<TxValue>;
 }

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -238,7 +238,7 @@ impl<'a> EVMProcessor<'a> {
         }
         // increment balances
         self.db_mut()
-            .increment_balances(balance_increments.into_iter().map(|(k, v)| (k, v)))
+            .increment_balances(balance_increments)
             .map_err(|_| BlockValidationError::IncrementBalanceFailed)?;
 
         Ok(())


### PR DESCRIPTION
`strategy.jobs-total` is 4 when we only have 2 partitions per feature, so it would only run 2/4 tests.