### PR TITLE
fix(primitives): Exhaustive Matching on TxType Primitive Encoding

### DIFF
--- a/crates/primitives/src/transaction/tx_type.rs
+++ b/crates/primitives/src/transaction/tx_type.rs
@@ -72,7 +72,15 @@ impl Compact for TxType {
             TxType::Legacy => 0,
             TxType::EIP2930 => 1,
             TxType::EIP1559 => 2,
-            _ => {
+            TxType::EIP4844 => {
+                // Write the full transaction type to the buffer when encoding > 3.
+                // This allows compat decoding the [TyType] from a single byte as
+                // opposed to 2 bits for the backwards-compatible encoding.
+                buf.put_u8(self as u8);
+                3
+            }
+            #[cfg(feature = "optimism")]
+            TxType::DEPOSIT => {
                 buf.put_u8(self as u8);
                 3
             }


### PR DESCRIPTION
**Description**

Extends matching on the `TxType` to be exhaustive when performing compat encoding as requested in https://github.com/paradigmxyz/reth/pull/4377#discussion_r1376113897