### PR TITLE
fix(ci): Optimism unit / integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,19 +35,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - name: Set binary value
-        id: binary
-        run: |
-          if [[ "${{ matrix.network }}" == "ethereum" ]]; then
-            echo "binary=reth" >> $GITHUB_OUTPUT
-          else
-            echo "binary=op-reth" >> $GITHUB_OUTPUT
-          fi
       - name: Run tests
         run: |
           cargo nextest run \
             --locked --features "${{ matrix.network }}" \
-            --bin ${{ steps.binary.outputs.binary }} \
             --workspace --exclude examples --exclude ef-tests \
             --partition hash:${{ matrix.partition }}/2 \
             -E 'kind(test)'

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -33,19 +33,10 @@ jobs:
         with:
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
-      - name: Set binary value
-        id: binary
-        run: |
-          if [[ "${{ matrix.network }}" == "ethereum" ]]; then
-            echo "binary=reth" >> $GITHUB_OUTPUT
-          else
-            echo "binary=op-reth" >> $GITHUB_OUTPUT
-          fi
       - name: Run tests
         run: |
           cargo nextest run \
             --locked --features "${{ matrix.network }}" \
-            --bin ${{ steps.binary.outputs.binary }} \
             --workspace --exclude examples --exclude ef-tests \
             --partition hash:${{ matrix.partition }}/2 \
             -E "kind(lib) | kind(bin) | kind(proc-macro)"

--- a/bin/reth/src/main.rs
+++ b/bin/reth/src/main.rs
@@ -3,7 +3,7 @@
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
-#[cfg(feature = "optimism")]
+#[cfg(all(feature = "optimism", not(test)))]
 compile_error!("Cannot build the `reth` binary with the `optimism` feature flag enabled. Did you mean to build `op-reth`?");
 
 #[cfg(not(feature = "optimism"))]

--- a/crates/consensus/auto-seal/Cargo.toml
+++ b/crates/consensus/auto-seal/Cargo.toml
@@ -32,3 +32,7 @@ clap = { workspace = true }
 jsonrpsee = { workspace = true }
 eyre = { workspace = true }
 serde_json = { workspace = true }
+
+[features]
+# Included solely to ignore certain tests.
+optimism = []

--- a/crates/consensus/auto-seal/tests/it/auto_mine.rs
+++ b/crates/consensus/auto-seal/tests/it/auto_mine.rs
@@ -54,8 +54,8 @@ impl RethNodeCommandConfig for AutoMineConfig {
 /// This test is disabled for the `optimism` feature flag due to an incompatible feature set.
 /// L1 info transactions are not included automatically, which are required for `op-reth` to
 /// process transactions.
-#[cfg(not(feature = "optimism"))]
 #[test]
+#[cfg_attr(feature = "optimism", ignore)]
 pub fn test_auto_mine() {
     // create temp path for test
     let temp_path = tempfile::TempDir::new().expect("tempdir is okay").into_path();

--- a/crates/consensus/auto-seal/tests/it/auto_mine.rs
+++ b/crates/consensus/auto-seal/tests/it/auto_mine.rs
@@ -51,6 +51,10 @@ impl RethNodeCommandConfig for AutoMineConfig {
     }
 }
 
+/// This test is disabled for the `optimism` feature flag due to an incompatible feature set.
+/// L1 info transactions are not included automatically, which are required for `op-reth` to
+/// process transactions.
+#[cfg(not(feature = "optimism"))]
 #[test]
 pub fn test_auto_mine() {
     // create temp path for test

--- a/crates/primitives/src/transaction/optimism.rs
+++ b/crates/primitives/src/transaction/optimism.rs
@@ -146,6 +146,7 @@ impl TxDeposit {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::{Bytes, TransactionSigned};
     use alloy_rlp::Decodable;
     use bytes::BytesMut;
@@ -166,24 +167,9 @@ mod tests {
         tx_b.encode_enveloped(&mut buf_b);
         assert_eq!(&buf_b[..], &bytes[..]);
     }
-    #[test]
-    fn test_tx_deposit_size() {
-        let tx_deposit = TxDeposit {
-            source_hash: B256::default(),
-            from: Address::default(),
-            to: TransactionKind::default(),
-            mint: Some(100),
-            value: TxValue::default(),
-            gas_limit: 50000,
-            is_system_transaction: false,
-            input: Bytes::default(),
-        };
-
-        assert_eq!(tx_deposit.size(), mem::size_of_val(&tx_deposit));
-    }
 
     #[test]
-    fn test_encode_decode_inner() {
+    fn test_encode_decode_fields() {
         let original = TxDeposit {
             source_hash: B256::default(),
             from: Address::default(),
@@ -196,7 +182,7 @@ mod tests {
         };
 
         let mut buffer = BytesMut::new();
-        original.encode(&mut buffer, false);
+        original.encode_fields(&mut buffer);
         let decoded = TxDeposit::decode_inner(&mut &buffer[..]).expect("Failed to decode");
 
         assert_eq!(original, decoded);


### PR DESCRIPTION
## Overview

Fixes the CI such that unit / integration tests run when the `optimism` feature flag is enabled.

Also fixes some tests added in #5317 that were failing to compile, plus removed a `size` test for the `TxDeposit` type w/ an incorrect impl.