### PR TITLE
chore: add nextest config

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,3 @@
+[profile.default]
+retries = { backoff = "fixed", count = 2, delay = "1s" }
+slow-timeout = "2m"


### PR DESCRIPTION
Can only be in `.config/nextest.toml` AFAICT.
Timeouts can only be defined in the config file.
Closes #5306