### PR TITLE
feat(primitives): format stage progress with two decimal places

### DIFF
--- a/crates/primitives/src/stage/checkpoints.rs
+++ b/crates/primitives/src/stage/checkpoints.rs
@@ -174,7 +174,7 @@ pub struct EntitiesCheckpoint {
 
 impl Display for EntitiesCheckpoint {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:.1}%", 100.0 * self.processed as f64 / self.total as f64)
+        write!(f, "{:.2}%", 100.0 * self.processed as f64 / self.total as f64)
     }
 }
 


### PR DESCRIPTION
Otherwise, we show progress at high block numbers as 100%:
```console
stage=Bodies checkpoint=18501436 progress=100.0%
```

---

```rust
fn main() {
    println!("{:.1}%", 100.0 * 18501436.0 / 18503608.0);
    println!("{:.2}%", 100.0 * 18501436.0 / 18503608.0);
}
```
```console
100.0%
99.99%
```