### PR TITLE
chore(primitives): Compact TxType Unit Table Test

### DIFF
--- a/crates/primitives/src/transaction/tx_type.rs
+++ b/crates/primitives/src/transaction/tx_type.rs
@@ -117,6 +117,29 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_txtype_to_compat() {
+        let cases = vec![
+            (TxType::Legacy, 0, vec![]),
+            (TxType::EIP2930, 1, vec![]),
+            (TxType::EIP1559, 2, vec![]),
+            (TxType::EIP4844, 3, vec![EIP4844_TX_TYPE_ID]),
+            #[cfg(feature = "optimism")]
+            (TxType::DEPOSIT, 3, vec![DEPOSIT_TX_TYPE_ID]),
+        ];
+
+        for (tx_type, expected_identifier, expected_buf) in cases {
+            let mut buf = vec![];
+            let identifier = tx_type.to_compact(&mut buf);
+            assert_eq!(
+                identifier, expected_identifier,
+                "Unexpected identifier for TxType {:?}",
+                tx_type
+            );
+            assert_eq!(buf, expected_buf, "Unexpected buffer for TxType {:?}", tx_type);
+        }
+    }
+
+    #[test]
     fn test_txtype_from_compact() {
         let cases = vec![
             (TxType::Legacy, 0, vec![]),


### PR DESCRIPTION
**Description**

Adds a unit table test for compact encoding the `TxType`. 