### PR TITLE
chore: use u64 for payloadattributes directly

### DIFF
--- a/bin/reth/src/debug_cmd/build_block.rs
+++ b/bin/reth/src/debug_cmd/build_block.rs
@@ -24,7 +24,6 @@ use reth_primitives::{
     stage::StageId,
     Address, BlobTransaction, BlobTransactionSidecar, Bytes, ChainSpec, PooledTransactionsElement,
     SealedBlock, SealedBlockWithSenders, Transaction, TransactionSigned, TxEip4844, B256, U256,
-    U64,
 };
 use reth_provider::{
     providers::BlockchainProvider, BlockHashReader, BlockReader, BlockWriter, ExecutorFactory,
@@ -241,7 +240,7 @@ impl Command {
         let payload_attrs = PayloadAttributes {
             parent_beacon_block_root: self.parent_beacon_block_root,
             prev_randao: self.prev_randao,
-            timestamp: U64::from(self.timestamp),
+            timestamp: self.timestamp,
             suggested_fee_recipient: self.suggested_fee_recipient,
             // TODO: add support for withdrawals
             withdrawals: None,

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1062,7 +1062,7 @@ where
         //    client software MUST respond with -38003: `Invalid payload attributes` and MUST NOT
         //    begin a payload build process. In such an event, the forkchoiceState update MUST NOT
         //    be rolled back.
-        if attrs.timestamp.to::<u64>() <= head.timestamp {
+        if attrs.timestamp <= head.timestamp {
             return OnForkChoiceUpdated::invalid_payload_attributes()
         }
 

--- a/crates/payload/builder/src/payload.rs
+++ b/crates/payload/builder/src/payload.rs
@@ -194,7 +194,7 @@ impl PayloadBuilderAttributes {
         Ok(Self {
             id,
             parent,
-            timestamp: attributes.timestamp.to(),
+            timestamp: attributes.timestamp,
             suggested_fee_recipient: attributes.suggested_fee_recipient,
             prev_randao: attributes.prev_randao,
             withdrawals: withdraw.unwrap_or_default(),
@@ -281,7 +281,7 @@ pub(crate) fn payload_id(
     use sha2::Digest;
     let mut hasher = sha2::Sha256::new();
     hasher.update(parent.as_slice());
-    hasher.update(&attributes.timestamp.to::<u64>().to_be_bytes()[..]);
+    hasher.update(&attributes.timestamp.to_be_bytes()[..]);
     hasher.update(attributes.prev_randao.as_slice());
     hasher.update(attributes.suggested_fee_recipient.as_slice());
     if let Some(withdrawals) = &attributes.withdrawals {

--- a/crates/rpc/rpc-engine-api/src/payload.rs
+++ b/crates/rpc/rpc-engine-api/src/payload.rs
@@ -36,7 +36,7 @@ impl<'a> PayloadOrAttributes<'a> {
     pub(crate) fn timestamp(&self) -> u64 {
         match self {
             Self::ExecutionPayload { payload, .. } => payload.timestamp(),
-            Self::PayloadAttributes(attributes) => attributes.timestamp.to(),
+            Self::PayloadAttributes(attributes) => attributes.timestamp,
         }
     }
 

--- a/crates/rpc/rpc-types-compat/src/engine/payload.rs
+++ b/crates/rpc/rpc-types-compat/src/engine/payload.rs
@@ -3,7 +3,7 @@
 use reth_primitives::{
     constants::{EMPTY_OMMER_ROOT_HASH, MAXIMUM_EXTRA_DATA_SIZE, MIN_PROTOCOL_BASE_FEE_U256},
     proofs::{self},
-    Block, Header, SealedBlock, TransactionSigned, UintTryTo, Withdrawal, B256, U256, U64,
+    Block, Header, SealedBlock, TransactionSigned, UintTryTo, Withdrawal, B256, U256,
 };
 use reth_rpc_types::engine::{
     payload::{ExecutionPayloadBodyV1, ExecutionPayloadFieldV2, ExecutionPayloadInputV2},
@@ -35,10 +35,10 @@ pub fn try_payload_v1_to_block(payload: ExecutionPayloadV1) -> Result<Block, Pay
         receipts_root: payload.receipts_root,
         withdrawals_root: None,
         logs_bloom: payload.logs_bloom,
-        number: payload.block_number.to(),
-        gas_limit: payload.gas_limit.to(),
-        gas_used: payload.gas_used.to(),
-        timestamp: payload.timestamp.to(),
+        number: payload.block_number,
+        gas_limit: payload.gas_limit,
+        gas_used: payload.gas_used,
+        timestamp: payload.timestamp,
         mix_hash: payload.prev_randao,
         base_fee_per_gas: Some(
             payload
@@ -81,8 +81,8 @@ pub fn try_payload_v3_to_block(payload: ExecutionPayloadV3) -> Result<Block, Pay
     // used and excess blob gas
     let mut base_block = try_payload_v2_to_block(payload.payload_inner)?;
 
-    base_block.header.blob_gas_used = Some(payload.blob_gas_used.to());
-    base_block.header.excess_blob_gas = Some(payload.excess_blob_gas.to());
+    base_block.header.blob_gas_used = Some(payload.blob_gas_used);
+    base_block.header.excess_blob_gas = Some(payload.excess_blob_gas);
 
     Ok(base_block)
 }
@@ -119,10 +119,10 @@ pub fn try_block_to_payload_v1(value: SealedBlock) -> ExecutionPayloadV1 {
         receipts_root: value.receipts_root,
         logs_bloom: value.logs_bloom,
         prev_randao: value.mix_hash,
-        block_number: U64::from(value.number),
-        gas_limit: U64::from(value.gas_limit),
-        gas_used: U64::from(value.gas_used),
-        timestamp: U64::from(value.timestamp),
+        block_number: value.number,
+        gas_limit: value.gas_limit,
+        gas_used: value.gas_used,
+        timestamp: value.timestamp,
         extra_data: value.extra_data.clone(),
         base_fee_per_gas: U256::from(value.base_fee_per_gas.unwrap_or_default()),
         block_hash: value.hash(),
@@ -157,10 +157,10 @@ pub fn try_block_to_payload_v2(value: SealedBlock) -> ExecutionPayloadV2 {
             receipts_root: value.receipts_root,
             logs_bloom: value.logs_bloom,
             prev_randao: value.mix_hash,
-            block_number: U64::from(value.number),
-            gas_limit: U64::from(value.gas_limit),
-            gas_used: U64::from(value.gas_used),
-            timestamp: U64::from(value.timestamp),
+            block_number: value.number,
+            gas_limit: value.gas_limit,
+            gas_used: value.gas_used,
+            timestamp: value.timestamp,
             extra_data: value.extra_data.clone(),
             base_fee_per_gas: U256::from(value.base_fee_per_gas.unwrap_or_default()),
             block_hash: value.hash(),
@@ -199,10 +199,10 @@ pub fn block_to_payload_v3(value: SealedBlock) -> ExecutionPayloadV3 {
                 receipts_root: value.receipts_root,
                 logs_bloom: value.logs_bloom,
                 prev_randao: value.mix_hash,
-                block_number: U64::from(value.number),
-                gas_limit: U64::from(value.gas_limit),
-                gas_used: U64::from(value.gas_used),
-                timestamp: U64::from(value.timestamp),
+                block_number: value.number,
+                gas_limit: value.gas_limit,
+                gas_used: value.gas_used,
+                timestamp: value.timestamp,
                 extra_data: value.extra_data.clone(),
                 base_fee_per_gas: U256::from(value.base_fee_per_gas.unwrap_or_default()),
                 block_hash: value.hash(),
@@ -211,8 +211,8 @@ pub fn block_to_payload_v3(value: SealedBlock) -> ExecutionPayloadV3 {
             withdrawals,
         },
 
-        blob_gas_used: U64::from(value.blob_gas_used.unwrap_or_default()),
-        excess_blob_gas: U64::from(value.excess_blob_gas.unwrap_or_default()),
+        blob_gas_used: value.blob_gas_used.unwrap_or_default(),
+        excess_blob_gas: value.excess_blob_gas.unwrap_or_default(),
     }
 }
 
@@ -390,10 +390,10 @@ pub fn execution_payload_from_sealed_block(value: SealedBlock) -> ExecutionPaylo
         receipts_root: value.receipts_root,
         logs_bloom: value.logs_bloom,
         prev_randao: value.mix_hash,
-        block_number: U64::from(value.number),
-        gas_limit: U64::from(value.gas_limit),
-        gas_used: U64::from(value.gas_used),
-        timestamp: U64::from(value.timestamp),
+        block_number: value.number,
+        gas_limit: value.gas_limit,
+        gas_used: value.gas_used,
+        timestamp: value.timestamp,
         extra_data: value.extra_data.clone(),
         base_fee_per_gas: U256::from(value.base_fee_per_gas.unwrap_or_default()),
         block_hash: value.hash(),
@@ -403,7 +403,7 @@ pub fn execution_payload_from_sealed_block(value: SealedBlock) -> ExecutionPaylo
 
 #[cfg(test)]
 mod tests {
-    use reth_primitives::{hex, Bytes, U256, U64};
+    use reth_primitives::{hex, Bytes, U256};
     use reth_rpc_types::{engine::ExecutionPayloadV3, ExecutionPayloadV1, ExecutionPayloadV2};
 
     use super::{block_to_payload_v3, try_payload_v3_to_block};
@@ -417,13 +417,13 @@ mod tests {
             payload_inner: ExecutionPayloadV2 {
                 payload_inner: ExecutionPayloadV1 {
                     base_fee_per_gas:  U256::from(7u64),
-                    block_number: U64::from(0xa946u64),
+                    block_number: 0xa946u64,
                     block_hash: hex!("a5ddd3f286f429458a39cafc13ffe89295a7efa8eb363cf89a1a4887dbcf272b").into(),
                     logs_bloom: hex!("00200004000000000000000080000000000200000000000000000000000000000000200000000000000000000000000000000000800000000200000000000000000000000000000000000008000000200000000000000000000001000000000000000000000000000000800000000000000000000100000000000030000000000000000040000000000000000000000000000000000800080080404000000000000008000000000008200000000000200000000000000000000000000000000000000002000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000100000000000000000000").into(),
                     extra_data: hex!("d883010d03846765746888676f312e32312e31856c696e7578").into(),
-                    gas_limit: U64::from(0x1c9c380),
-                    gas_used: U64::from(0x1f4a9),
-                    timestamp: U64::from(0x651f35b8),
+                    gas_limit: 0x1c9c380,
+                    gas_used: 0x1f4a9,
+                    timestamp: 0x651f35b8,
                     fee_recipient: hex!("f97e180c050e5ab072211ad2c213eb5aee4df134").into(),
                     parent_hash: hex!("d829192799c73ef28a7332313b3c03af1f2d5da2c36f8ecfafe7a83a3bfb8d1e").into(),
                     prev_randao: hex!("753888cc4adfbeb9e24e01c84233f9d204f4a9e1273f0e29b43c4c148b2b8b7e").into(),
@@ -433,8 +433,8 @@ mod tests {
                 },
                 withdrawals: vec![],
             },
-            blob_gas_used: U64::from(0xc0000),
-            excess_blob_gas: U64::from(0x580000),
+            blob_gas_used: 0xc0000,
+            excess_blob_gas: 0x580000,
         };
 
         let mut block = try_payload_v3_to_block(new_payload.clone()).unwrap();
@@ -460,13 +460,13 @@ mod tests {
             payload_inner: ExecutionPayloadV2 {
                 payload_inner: ExecutionPayloadV1 {
                     base_fee_per_gas:  U256::from(7u64),
-                    block_number: U64::from(0xa946u64),
+                    block_number: 0xa946u64,
                     block_hash: hex!("a5ddd3f286f429458a39cafc13ffe89295a7efa8eb363cf89a1a4887dbcf272b").into(),
                     logs_bloom: hex!("00200004000000000000000080000000000200000000000000000000000000000000200000000000000000000000000000000000800000000200000000000000000000000000000000000008000000200000000000000000000001000000000000000000000000000000800000000000000000000100000000000030000000000000000040000000000000000000000000000000000800080080404000000000000008000000000008200000000000200000000000000000000000000000000000000002000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000100000000000000000000").into(),
                     extra_data: hex!("d883010d03846765746888676f312e32312e31856c696e7578").into(),
-                    gas_limit: U64::from(0x1c9c380),
-                    gas_used: U64::from(0x1f4a9),
-                    timestamp: U64::from(0x651f35b8),
+                    gas_limit: 0x1c9c380,
+                    gas_used: 0x1f4a9,
+                    timestamp: 0x651f35b8,
                     fee_recipient: hex!("f97e180c050e5ab072211ad2c213eb5aee4df134").into(),
                     parent_hash: hex!("d829192799c73ef28a7332313b3c03af1f2d5da2c36f8ecfafe7a83a3bfb8d1e").into(),
                     prev_randao: hex!("753888cc4adfbeb9e24e01c84233f9d204f4a9e1273f0e29b43c4c148b2b8b7e").into(),
@@ -476,8 +476,8 @@ mod tests {
                 },
                 withdrawals: vec![],
             },
-            blob_gas_used: U64::from(0xc0000),
-            excess_blob_gas: U64::from(0x580000),
+            blob_gas_used: 0xc0000,
+            excess_blob_gas: 0x580000,
         };
 
         let _block = try_payload_v3_to_block(new_payload.clone())

--- a/crates/rpc/rpc-types/src/beacon/payload.rs
+++ b/crates/rpc/rpc-types/src/beacon/payload.rs
@@ -13,7 +13,7 @@ use crate::{
     beacon::withdrawals::BeaconWithdrawal, engine::ExecutionPayloadV3, ExecutionPayload,
     ExecutionPayloadV1, ExecutionPayloadV2, Withdrawal,
 };
-use alloy_primitives::{Address, Bloom, Bytes, B256, U256, U64};
+use alloy_primitives::{Address, Bloom, Bytes, B256, U256};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::{serde_as, DeserializeAs, DisplayFromStr, SerializeAs};
 use std::borrow::Cow;
@@ -69,7 +69,7 @@ pub mod beacon_api_payload_attributes {
         S: Serializer,
     {
         let beacon_api_payload_attributes = BeaconPayloadAttributes {
-            timestamp: payload_attributes.timestamp.to(),
+            timestamp: payload_attributes.timestamp,
             prev_randao: payload_attributes.prev_randao,
             suggested_fee_recipient: payload_attributes.suggested_fee_recipient,
             withdrawals: payload_attributes.withdrawals.clone(),
@@ -91,7 +91,7 @@ pub mod beacon_api_payload_attributes {
     {
         let beacon_api_payload_attributes = BeaconPayloadAttributes::deserialize(deserializer)?;
         Ok(PayloadAttributes {
-            timestamp: U64::from(beacon_api_payload_attributes.timestamp),
+            timestamp: beacon_api_payload_attributes.timestamp,
             prev_randao: beacon_api_payload_attributes.prev_randao,
             suggested_fee_recipient: beacon_api_payload_attributes.suggested_fee_recipient,
             withdrawals: beacon_api_payload_attributes.withdrawals,
@@ -157,10 +157,10 @@ impl<'a> From<BeaconExecutionPayloadV1<'a>> for ExecutionPayloadV1 {
             receipts_root: receipts_root.into_owned(),
             logs_bloom: logs_bloom.into_owned(),
             prev_randao: prev_randao.into_owned(),
-            block_number: U64::from(block_number),
-            gas_limit: U64::from(gas_limit),
-            gas_used: U64::from(gas_used),
-            timestamp: U64::from(timestamp),
+            block_number,
+            gas_limit,
+            gas_used,
+            timestamp,
             extra_data: extra_data.into_owned(),
             base_fee_per_gas,
             block_hash: block_hash.into_owned(),
@@ -195,10 +195,10 @@ impl<'a> From<&'a ExecutionPayloadV1> for BeaconExecutionPayloadV1<'a> {
             receipts_root: Cow::Borrowed(receipts_root),
             logs_bloom: Cow::Borrowed(logs_bloom),
             prev_randao: Cow::Borrowed(prev_randao),
-            block_number: block_number.to(),
-            gas_limit: gas_limit.to(),
-            gas_used: gas_used.to(),
-            timestamp: timestamp.to(),
+            block_number: *block_number,
+            gas_limit: *gas_limit,
+            gas_used: *gas_used,
+            timestamp: *timestamp,
             extra_data: Cow::Borrowed(extra_data),
             base_fee_per_gas: *base_fee_per_gas,
             block_hash: Cow::Borrowed(block_hash),
@@ -294,12 +294,8 @@ struct BeaconExecutionPayloadV3<'a> {
     /// Inner V1 payload
     #[serde(flatten)]
     payload_inner: BeaconExecutionPayloadV2<'a>,
-    /// Array of [`U64`] representing blob gas used, enabled with V3
-    /// See <https://github.com/ethereum/execution-apis/blob/fe8e13c288c592ec154ce25c534e26cb7ce0530d/src/engine/cancun.md#ExecutionPayloadV3>
     #[serde_as(as = "DisplayFromStr")]
     blob_gas_used: u64,
-    /// Array of [`U64`] representing excess blob gas, enabled with V3
-    /// See <https://github.com/ethereum/execution-apis/blob/fe8e13c288c592ec154ce25c534e26cb7ce0530d/src/engine/cancun.md#ExecutionPayloadV3>
     #[serde_as(as = "DisplayFromStr")]
     excess_blob_gas: u64,
 }
@@ -307,11 +303,7 @@ struct BeaconExecutionPayloadV3<'a> {
 impl<'a> From<BeaconExecutionPayloadV3<'a>> for ExecutionPayloadV3 {
     fn from(payload: BeaconExecutionPayloadV3<'a>) -> Self {
         let BeaconExecutionPayloadV3 { payload_inner, blob_gas_used, excess_blob_gas } = payload;
-        ExecutionPayloadV3 {
-            payload_inner: payload_inner.into(),
-            blob_gas_used: U64::from(blob_gas_used),
-            excess_blob_gas: U64::from(excess_blob_gas),
-        }
+        ExecutionPayloadV3 { payload_inner: payload_inner.into(), blob_gas_used, excess_blob_gas }
     }
 }
 
@@ -320,8 +312,8 @@ impl<'a> From<&'a ExecutionPayloadV3> for BeaconExecutionPayloadV3<'a> {
         let ExecutionPayloadV3 { payload_inner, blob_gas_used, excess_blob_gas } = value;
         BeaconExecutionPayloadV3 {
             payload_inner: payload_inner.into(),
-            blob_gas_used: blob_gas_used.to(),
-            excess_blob_gas: excess_blob_gas.to(),
+            blob_gas_used: *blob_gas_used,
+            excess_blob_gas: *excess_blob_gas,
         }
     }
 }

--- a/crates/rpc/rpc-types/src/eth/engine/payload.rs
+++ b/crates/rpc/rpc-types/src/eth/engine/payload.rs
@@ -1,6 +1,6 @@
 use crate::eth::transaction::BlobTransactionSidecar;
 pub use crate::Withdrawal;
-use alloy_primitives::{Address, Bloom, Bytes, B256, B64, U256, U64};
+use alloy_primitives::{Address, Bloom, Bytes, B256, B64, U256};
 use c_kzg::{Blob, Bytes48};
 use serde::{ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
 
@@ -126,10 +126,14 @@ pub struct ExecutionPayloadV1 {
     pub receipts_root: B256,
     pub logs_bloom: Bloom,
     pub prev_randao: B256,
-    pub block_number: U64,
-    pub gas_limit: U64,
-    pub gas_used: U64,
-    pub timestamp: U64,
+    #[serde(with = "crate::serde_helpers::u64_hex")]
+    pub block_number: u64,
+    #[serde(with = "crate::serde_helpers::u64_hex")]
+    pub gas_limit: u64,
+    #[serde(with = "crate::serde_helpers::u64_hex")]
+    pub gas_used: u64,
+    #[serde(with = "crate::serde_helpers::u64_hex")]
+    pub timestamp: u64,
     pub extra_data: Bytes,
     pub base_fee_per_gas: U256,
     pub block_hash: B256,
@@ -154,7 +158,7 @@ pub struct ExecutionPayloadV2 {
 impl ExecutionPayloadV2 {
     /// Returns the timestamp for the execution payload.
     pub fn timestamp(&self) -> u64 {
-        self.payload_inner.timestamp.to()
+        self.payload_inner.timestamp
     }
 }
 
@@ -168,12 +172,14 @@ pub struct ExecutionPayloadV3 {
     #[serde(flatten)]
     pub payload_inner: ExecutionPayloadV2,
 
-    /// Array of [`U64`] representing blob gas used, enabled with V3
+    /// Array of hex [`u64`] representing blob gas used, enabled with V3
     /// See <https://github.com/ethereum/execution-apis/blob/fe8e13c288c592ec154ce25c534e26cb7ce0530d/src/engine/cancun.md#ExecutionPayloadV3>
-    pub blob_gas_used: U64,
-    /// Array of [`U64`] representing excess blob gas, enabled with V3
+    #[serde(with = "crate::serde_helpers::u64_hex")]
+    pub blob_gas_used: u64,
+    /// Array of hex[`u64`] representing excess blob gas, enabled with V3
     /// See <https://github.com/ethereum/execution-apis/blob/fe8e13c288c592ec154ce25c534e26cb7ce0530d/src/engine/cancun.md#ExecutionPayloadV3>
-    pub excess_blob_gas: U64,
+    #[serde(with = "crate::serde_helpers::u64_hex")]
+    pub excess_blob_gas: u64,
 }
 
 impl ExecutionPayloadV3 {
@@ -184,7 +190,7 @@ impl ExecutionPayloadV3 {
 
     /// Returns the timestamp for the payload.
     pub fn timestamp(&self) -> u64 {
-        self.payload_inner.payload_inner.timestamp.to()
+        self.payload_inner.payload_inner.timestamp
     }
 }
 
@@ -252,7 +258,7 @@ impl ExecutionPayload {
     /// Returns the timestamp for the payload.
     pub fn timestamp(&self) -> u64 {
         match self {
-            ExecutionPayload::V1(payload) => payload.timestamp.to(),
+            ExecutionPayload::V1(payload) => payload.timestamp,
             ExecutionPayload::V2(payload) => payload.timestamp(),
             ExecutionPayload::V3(payload) => payload.timestamp(),
         }
@@ -279,9 +285,9 @@ impl ExecutionPayload {
     /// Returns the block number for this payload.
     pub fn block_number(&self) -> u64 {
         match self {
-            ExecutionPayload::V1(payload) => payload.block_number.to(),
-            ExecutionPayload::V2(payload) => payload.payload_inner.block_number.to(),
-            ExecutionPayload::V3(payload) => payload.payload_inner.payload_inner.block_number.to(),
+            ExecutionPayload::V1(payload) => payload.block_number,
+            ExecutionPayload::V2(payload) => payload.payload_inner.block_number,
+            ExecutionPayload::V3(payload) => payload.payload_inner.payload_inner.block_number,
         }
     }
 }
@@ -385,7 +391,8 @@ pub struct ExecutionPayloadBodyV1 {
 #[serde(rename_all = "camelCase")]
 pub struct PayloadAttributes {
     /// Value for the `timestamp` field of the new payload
-    pub timestamp: U64,
+    #[serde(with = "crate::serde_helpers::u64_hex")]
+    pub timestamp: u64,
     /// Value for the `prevRandao` field of the new payload
     pub prev_randao: B256,
     /// Suggested value for the `feeRecipient` field of the new payload


### PR DESCRIPTION
replace `U64` with `u64` with serde attributes, makes it easier to handle, only need this for serde