### PR TITLE
restrict --chain flag setting for op-reth node & fix help info

### DIFF
--- a/bin/reth/src/args/utils.rs
+++ b/bin/reth/src/args/utils.rs
@@ -43,9 +43,7 @@ pub fn chain_spec_value_parser(s: &str) -> eyre::Result<Arc<ChainSpec>, eyre::Er
         #[cfg(not(feature = "optimism"))]
         "dev" => DEV.clone(),
         #[cfg(feature = "optimism")]
-        "base_goerli" => BASE_GOERLI.clone(),
-        #[cfg(feature = "optimism")]
-        "base-goerli" => BASE_GOERLI.clone(),
+        "base_goerli" | "base-goerli" => BASE_GOERLI.clone(),
         #[cfg(feature = "optimism")]
         "base" => BASE_MAINNET.clone(),
         _ => {
@@ -78,9 +76,7 @@ pub fn genesis_value_parser(s: &str) -> eyre::Result<Arc<ChainSpec>, eyre::Error
         #[cfg(not(feature = "optimism"))]
         "dev" => DEV.clone(),
         #[cfg(feature = "optimism")]
-        "base_goerli" => BASE_GOERLI.clone(),
-        #[cfg(feature = "optimism")]
-        "base-goerli" => BASE_GOERLI.clone(),
+        "base_goerli" | "base-goerli" => BASE_GOERLI.clone(),
         #[cfg(feature = "optimism")]
         "base" => BASE_MAINNET.clone(),
         _ => {

--- a/bin/reth/src/args/utils.rs
+++ b/bin/reth/src/args/utils.rs
@@ -15,6 +15,13 @@ use std::{
 #[cfg(feature = "optimism")]
 use reth_primitives::{BASE_GOERLI, BASE_MAINNET};
 
+#[cfg(feature = "optimism")]
+/// Chains supported by op-reth. First value should be used as the default.
+pub const SUPPORTED_CHAINS: &[&str] = &["base", "base_goerli"];
+#[cfg(not(feature = "optimism"))]
+/// Chains supported by reth. First value should be used as the default.
+pub const SUPPORTED_CHAINS: &[&str] = &["mainnet", "sepolia", "goerli", "holesky", "dev"];
+
 /// Helper to parse a [Duration] from seconds
 pub fn parse_duration_from_secs(arg: &str) -> eyre::Result<Duration, std::num::ParseIntError> {
     let seconds = arg.parse()?;
@@ -25,11 +32,18 @@ pub fn parse_duration_from_secs(arg: &str) -> eyre::Result<Duration, std::num::P
 /// to a custom one.
 pub fn chain_spec_value_parser(s: &str) -> eyre::Result<Arc<ChainSpec>, eyre::Error> {
     Ok(match s {
+        #[cfg(not(feature = "optimism"))]
         "mainnet" => MAINNET.clone(),
+        #[cfg(not(feature = "optimism"))]
         "goerli" => GOERLI.clone(),
+        #[cfg(not(feature = "optimism"))]
         "sepolia" => SEPOLIA.clone(),
+        #[cfg(not(feature = "optimism"))]
         "holesky" => HOLESKY.clone(),
+        #[cfg(not(feature = "optimism"))]
         "dev" => DEV.clone(),
+        #[cfg(feature = "optimism")]
+        "base_goerli" => BASE_GOERLI.clone(),
         #[cfg(feature = "optimism")]
         "base-goerli" => BASE_GOERLI.clone(),
         #[cfg(feature = "optimism")]
@@ -41,6 +55,11 @@ pub fn chain_spec_value_parser(s: &str) -> eyre::Result<Arc<ChainSpec>, eyre::Er
     })
 }
 
+/// The help info for the --chain flag
+pub fn chain_help() -> String {
+    format!("Possible values are either a built-in chain or the path to a chain specification file.\n\nBuilt-in chains:\n  {}", SUPPORTED_CHAINS.join(", "))
+}
+
 /// Clap value parser for [ChainSpec]s.
 ///
 /// The value parser matches either a known chain, the path
@@ -48,11 +67,18 @@ pub fn chain_spec_value_parser(s: &str) -> eyre::Result<Arc<ChainSpec>, eyre::Er
 /// a serialized [ChainSpec] or Genesis struct.
 pub fn genesis_value_parser(s: &str) -> eyre::Result<Arc<ChainSpec>, eyre::Error> {
     Ok(match s {
+        #[cfg(not(feature = "optimism"))]
         "mainnet" => MAINNET.clone(),
+        #[cfg(not(feature = "optimism"))]
         "goerli" => GOERLI.clone(),
+        #[cfg(not(feature = "optimism"))]
         "sepolia" => SEPOLIA.clone(),
+        #[cfg(not(feature = "optimism"))]
         "holesky" => HOLESKY.clone(),
+        #[cfg(not(feature = "optimism"))]
         "dev" => DEV.clone(),
+        #[cfg(feature = "optimism")]
+        "base_goerli" => BASE_GOERLI.clone(),
         #[cfg(feature = "optimism")]
         "base-goerli" => BASE_GOERLI.clone(),
         #[cfg(feature = "optimism")]
@@ -167,18 +193,9 @@ mod tests {
     use secp256k1::rand::thread_rng;
     use std::collections::HashMap;
 
-    #[cfg(feature = "optimism")]
-    #[test]
-    fn parse_optimism_chain_spec() {
-        for chain in ["base-goerli", "base"] {
-            chain_spec_value_parser(chain).unwrap();
-            genesis_value_parser(chain).unwrap();
-        }
-    }
-
     #[test]
     fn parse_known_chain_spec() {
-        for chain in ["mainnet", "sepolia", "goerli", "holesky"] {
+        for chain in SUPPORTED_CHAINS {
             chain_spec_value_parser(chain).unwrap();
             genesis_value_parser(chain).unwrap();
         }

--- a/bin/reth/src/args/utils.rs
+++ b/bin/reth/src/args/utils.rs
@@ -55,7 +55,7 @@ pub fn chain_spec_value_parser(s: &str) -> eyre::Result<Arc<ChainSpec>, eyre::Er
 
 /// The help info for the --chain flag
 pub fn chain_help() -> String {
-    format!("Possible values are either a built-in chain or the path to a chain specification file.\n\nBuilt-in chains:\n  {}", SUPPORTED_CHAINS.join(", "))
+    format!("The chain this node is running.\nPossible values are either a built-in chain or the path to a chain specification file.\n\nBuilt-in chains:\n    {}", SUPPORTED_CHAINS.join(", "))
 }
 
 /// Clap value parser for [ChainSpec]s.

--- a/bin/reth/src/args/utils.rs
+++ b/bin/reth/src/args/utils.rs
@@ -1,9 +1,6 @@
 //! Clap parser utilities
 
-use reth_primitives::{
-    fs, AllGenesisFormats, BlockHashOrNumber, ChainSpec, B256, DEV, GOERLI, HOLESKY, MAINNET,
-    SEPOLIA,
-};
+use reth_primitives::{fs, AllGenesisFormats, BlockHashOrNumber, ChainSpec, B256};
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs},
     path::PathBuf,
@@ -14,6 +11,9 @@ use std::{
 
 #[cfg(feature = "optimism")]
 use reth_primitives::{BASE_GOERLI, BASE_MAINNET};
+
+#[cfg(not(feature = "optimism"))]
+use reth_primitives::{DEV, GOERLI, HOLESKY, MAINNET, SEPOLIA};
 
 #[cfg(feature = "optimism")]
 /// Chains supported by op-reth. First value should be used as the default.

--- a/bin/reth/src/chain/import.rs
+++ b/bin/reth/src/chain/import.rs
@@ -10,7 +10,10 @@ use futures::{Stream, StreamExt};
 use reth_beacon_consensus::BeaconConsensus;
 use reth_provider::{ProviderFactory, StageCheckpointReader};
 
-use crate::args::{utils::genesis_value_parser, DatabaseArgs};
+use crate::args::{
+    utils::{chain_help, genesis_value_parser, SUPPORTED_CHAINS},
+    DatabaseArgs,
+};
 use reth_config::Config;
 use reth_db::{database::Database, init_db};
 use reth_downloaders::{
@@ -50,17 +53,11 @@ pub struct ImportCommand {
     /// The chain this node is running.
     ///
     /// Possible values are either a built-in chain or the path to a chain specification file.
-    ///
-    /// Built-in chains:
-    /// - mainnet
-    /// - goerli
-    /// - sepolia
-    /// - holesky
     #[arg(
         long,
         value_name = "CHAIN_OR_PATH",
-        verbatim_doc_comment,
-        default_value = "mainnet",
+        long_help = chain_help(),
+        default_value = SUPPORTED_CHAINS[0],
         value_parser = genesis_value_parser
     )]
     chain: Arc<ChainSpec>,
@@ -216,7 +213,7 @@ mod tests {
 
     #[test]
     fn parse_common_import_command_chain_args() {
-        for chain in ["mainnet", "sepolia", "goerli"] {
+        for chain in SUPPORTED_CHAINS {
             let args: ImportCommand = ImportCommand::parse_from(["reth", "--chain", chain, "."]);
             assert_eq!(args.chain.chain, chain.parse().unwrap());
         }

--- a/bin/reth/src/chain/init.rs
+++ b/bin/reth/src/chain/init.rs
@@ -1,5 +1,8 @@
 use crate::{
-    args::{utils::genesis_value_parser, DatabaseArgs},
+    args::{
+        utils::{chain_help, genesis_value_parser, SUPPORTED_CHAINS},
+        DatabaseArgs,
+    },
     dirs::{DataDirPath, MaybePlatformPath},
     init::init_genesis,
 };
@@ -25,17 +28,11 @@ pub struct InitCommand {
     /// The chain this node is running.
     ///
     /// Possible values are either a built-in chain or the path to a chain specification file.
-    ///
-    /// Built-in chains:
-    /// - mainnet
-    /// - goerli
-    /// - sepolia
-    /// - holesky
     #[arg(
         long,
         value_name = "CHAIN_OR_PATH",
-        verbatim_doc_comment,
-        default_value = "mainnet",
+        long_help = chain_help(),
+        default_value = SUPPORTED_CHAINS[0],
         value_parser = genesis_value_parser
     )]
     chain: Arc<ChainSpec>,

--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -1,6 +1,6 @@
 //! CLI definition and entrypoint to executable
 use crate::{
-    args::utils::genesis_value_parser,
+    args::utils::{chain_help, genesis_value_parser, SUPPORTED_CHAINS},
     chain,
     cli::ext::RethCliExt,
     db, debug_cmd,
@@ -36,17 +36,11 @@ pub struct Cli<Ext: RethCliExt = ()> {
     /// The chain this node is running.
     ///
     /// Possible values are either a built-in chain or the path to a chain specification file.
-    ///
-    /// Built-in chains:
-    /// - mainnet
-    /// - goerli
-    /// - sepolia
-    /// - holesky
     #[arg(
         long,
         value_name = "CHAIN_OR_PATH",
-        verbatim_doc_comment,
-        default_value = "mainnet",
+        long_help = chain_help(),
+        default_value = SUPPORTED_CHAINS[0],
         value_parser = genesis_value_parser,
         global = true,
     )]
@@ -321,6 +315,7 @@ impl Display for ColorMode {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::args::utils::SUPPORTED_CHAINS;
     use clap::CommandFactory;
 
     #[test]
@@ -356,13 +351,19 @@ mod tests {
         reth.logs.log_file_directory =
             reth.logs.log_file_directory.join(reth.chain.chain.to_string());
         let log_dir = reth.logs.log_file_directory;
-        assert!(log_dir.as_ref().ends_with("reth/logs/mainnet"), "{:?}", log_dir);
+        let end = format!("reth/logs/{}", SUPPORTED_CHAINS[0]);
+        assert!(log_dir.as_ref().ends_with(end), "{:?}", log_dir);
 
-        let mut reth = Cli::<()>::try_parse_from(["reth", "node", "--chain", "sepolia"]).unwrap();
-        reth.logs.log_file_directory =
-            reth.logs.log_file_directory.join(reth.chain.chain.to_string());
-        let log_dir = reth.logs.log_file_directory;
-        assert!(log_dir.as_ref().ends_with("reth/logs/sepolia"), "{:?}", log_dir);
+        let mut iter = SUPPORTED_CHAINS.into_iter();
+        iter.next();
+        for chain in iter {
+            let mut reth = Cli::<()>::try_parse_from(["reth", "node", "--chain", chain]).unwrap();
+            reth.logs.log_file_directory =
+                reth.logs.log_file_directory.join(reth.chain.chain.to_string());
+            let log_dir = reth.logs.log_file_directory;
+            let end = format!("reth/logs/{}", chain);
+            assert!(log_dir.as_ref().ends_with(end), "{:?}", log_dir);
+        }
     }
 
     #[test]

--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -1,6 +1,9 @@
 //! Database debugging tool
 use crate::{
-    args::{utils::genesis_value_parser, DatabaseArgs},
+    args::{
+        utils::{chain_help, genesis_value_parser, SUPPORTED_CHAINS},
+        DatabaseArgs,
+    },
     dirs::{DataDirPath, MaybePlatformPath},
     utils::DbTool,
 };
@@ -44,17 +47,11 @@ pub struct Command {
     /// The chain this node is running.
     ///
     /// Possible values are either a built-in chain or the path to a chain specification file.
-    ///
-    /// Built-in chains:
-    /// - mainnet
-    /// - goerli
-    /// - sepolia
-    /// - holesky
     #[arg(
         long,
         value_name = "CHAIN_OR_PATH",
-        verbatim_doc_comment,
-        default_value = "mainnet",
+        long_help = chain_help(),
+        default_value = SUPPORTED_CHAINS[0],
         value_parser = genesis_value_parser,
         global = true,
     )]
@@ -247,7 +244,8 @@ mod tests {
 
     #[test]
     fn parse_stats_globals() {
-        let cmd = Command::try_parse_from(["reth", "stats", "--datadir", "../mainnet"]).unwrap();
-        assert_eq!(cmd.datadir.as_ref(), Some(Path::new("../mainnet")));
+        let path = format!("../{}", SUPPORTED_CHAINS[0]);
+        let cmd = Command::try_parse_from(["reth", "stats", "--datadir", &path]).unwrap();
+        assert_eq!(cmd.datadir.as_ref(), Some(Path::new(&path)));
     }
 }

--- a/bin/reth/src/debug_cmd/build_block.rs
+++ b/bin/reth/src/debug_cmd/build_block.rs
@@ -1,6 +1,9 @@
 //! Command for debugging block building.
 use crate::{
-    args::{utils::genesis_value_parser, DatabaseArgs},
+    args::{
+        utils::{chain_help, genesis_value_parser, SUPPORTED_CHAINS},
+        DatabaseArgs,
+    },
     dirs::{DataDirPath, MaybePlatformPath},
     runner::CliContext,
 };
@@ -56,17 +59,11 @@ pub struct Command {
     /// The chain this node is running.
     ///
     /// Possible values are either a built-in chain or the path to a chain specification file.
-    ///
-    /// Built-in chains:
-    /// - mainnet
-    /// - goerli
-    /// - sepolia
-    /// - holesky
     #[arg(
         long,
         value_name = "CHAIN_OR_PATH",
-        verbatim_doc_comment,
-        default_value = "mainnet",
+        long_help = chain_help(),
+        default_value = SUPPORTED_CHAINS[0],
         value_parser = genesis_value_parser
     )]
     chain: Arc<ChainSpec>,

--- a/bin/reth/src/debug_cmd/execution.rs
+++ b/bin/reth/src/debug_cmd/execution.rs
@@ -1,6 +1,10 @@
 //! Command for debugging execution.
 use crate::{
-    args::{get_secret_key, utils::genesis_value_parser, DatabaseArgs, NetworkArgs},
+    args::{
+        get_secret_key,
+        utils::{chain_help, genesis_value_parser, SUPPORTED_CHAINS},
+        DatabaseArgs, NetworkArgs,
+    },
     dirs::{DataDirPath, MaybePlatformPath},
     init::init_genesis,
     node::events,
@@ -57,17 +61,11 @@ pub struct Command {
     /// The chain this node is running.
     ///
     /// Possible values are either a built-in chain or the path to a chain specification file.
-    ///
-    /// Built-in chains:
-    /// - mainnet
-    /// - goerli
-    /// - sepolia
-    /// - holesky
     #[arg(
         long,
         value_name = "CHAIN_OR_PATH",
-        verbatim_doc_comment,
-        default_value = "mainnet",
+        long_help = chain_help(),
+        default_value = SUPPORTED_CHAINS[0],
         value_parser = genesis_value_parser
     )]
     chain: Arc<ChainSpec>,

--- a/bin/reth/src/debug_cmd/in_memory_merkle.rs
+++ b/bin/reth/src/debug_cmd/in_memory_merkle.rs
@@ -1,6 +1,10 @@
 //! Command for debugging in-memory merkle trie calculation.
 use crate::{
-    args::{get_secret_key, utils::genesis_value_parser, DatabaseArgs, NetworkArgs},
+    args::{
+        get_secret_key,
+        utils::{chain_help, genesis_value_parser, SUPPORTED_CHAINS},
+        DatabaseArgs, NetworkArgs,
+    },
     dirs::{DataDirPath, MaybePlatformPath},
     runner::CliContext,
     utils::{get_single_body, get_single_header},
@@ -45,17 +49,11 @@ pub struct Command {
     /// The chain this node is running.
     ///
     /// Possible values are either a built-in chain or the path to a chain specification file.
-    ///
-    /// Built-in chains:
-    /// - mainnet
-    /// - goerli
-    /// - sepolia
-    /// - holesky
     #[arg(
         long,
         value_name = "CHAIN_OR_PATH",
-        verbatim_doc_comment,
-        default_value = "mainnet",
+        long_help = chain_help(),
+        default_value = SUPPORTED_CHAINS[0],
         value_parser = genesis_value_parser
     )]
     chain: Arc<ChainSpec>,

--- a/bin/reth/src/debug_cmd/merkle.rs
+++ b/bin/reth/src/debug_cmd/merkle.rs
@@ -1,6 +1,10 @@
 //! Command for debugging merkle trie calculation.
 use crate::{
-    args::{get_secret_key, utils::genesis_value_parser, DatabaseArgs, NetworkArgs},
+    args::{
+        get_secret_key,
+        utils::{chain_help, genesis_value_parser, SUPPORTED_CHAINS},
+        DatabaseArgs, NetworkArgs,
+    },
     dirs::{DataDirPath, MaybePlatformPath},
     runner::CliContext,
     utils::get_single_header,
@@ -50,17 +54,11 @@ pub struct Command {
     /// The chain this node is running.
     ///
     /// Possible values are either a built-in chain or the path to a chain specification file.
-    ///
-    /// Built-in chains:
-    /// - mainnet
-    /// - goerli
-    /// - sepolia
-    /// - holesky
     #[arg(
         long,
         value_name = "CHAIN_OR_PATH",
-        verbatim_doc_comment,
-        default_value = "mainnet",
+        long_help = chain_help(),
+        default_value = SUPPORTED_CHAINS[0],
         value_parser = genesis_value_parser
     )]
     chain: Arc<ChainSpec>,

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -4,7 +4,7 @@
 use crate::{
     args::{
         get_secret_key,
-        utils::{genesis_value_parser, parse_socket_address},
+        utils::{chain_help, genesis_value_parser, parse_socket_address, SUPPORTED_CHAINS},
         DatabaseArgs, DebugArgs, DevArgs, NetworkArgs, PayloadBuilderArgs, PruningArgs,
         RpcServerArgs, TxPoolArgs,
     },
@@ -110,18 +110,11 @@ pub struct NodeCommand<Ext: RethCliExt = ()> {
     /// The chain this node is running.
     ///
     /// Possible values are either a built-in chain or the path to a chain specification file.
-    ///
-    /// Built-in chains:
-    /// - mainnet
-    /// - goerli
-    /// - sepolia
-    /// - holesky
-    /// - dev
     #[arg(
         long,
         value_name = "CHAIN_OR_PATH",
-        verbatim_doc_comment,
-        default_value = "mainnet",
+        long_help = chain_help(),
+        default_value = SUPPORTED_CHAINS[0],
         default_value_if("dev", "true", "dev"),
         value_parser = genesis_value_parser,
         required = false,
@@ -1047,6 +1040,7 @@ async fn run_network_until_shutdown<C>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::args::utils::SUPPORTED_CHAINS;
     use reth_discv4::DEFAULT_DISCOVERY_PORT;
     use reth_primitives::DEV;
     use std::{
@@ -1062,7 +1056,7 @@ mod tests {
 
     #[test]
     fn parse_common_node_command_chain_args() {
-        for chain in ["mainnet", "sepolia", "goerli"] {
+        for chain in SUPPORTED_CHAINS {
             let args: NodeCommand = NodeCommand::<()>::parse_from(["reth", "--chain", chain]);
             assert_eq!(args.chain.chain, chain.parse().unwrap());
         }
@@ -1131,7 +1125,8 @@ mod tests {
         // always store reth.toml in the data dir, not the chain specific data dir
         let data_dir = cmd.datadir.unwrap_or_chain_default(cmd.chain.chain);
         let config_path = cmd.config.clone().unwrap_or(data_dir.config_path());
-        assert!(config_path.ends_with("reth/mainnet/reth.toml"), "{:?}", cmd.config);
+        let end = format!("reth/{}/reth.toml", SUPPORTED_CHAINS[0]);
+        assert!(config_path.ends_with(end), "{:?}", cmd.config);
     }
 
     #[test]
@@ -1139,7 +1134,8 @@ mod tests {
         let cmd = NodeCommand::<()>::try_parse_from(["reth"]).unwrap();
         let data_dir = cmd.datadir.unwrap_or_chain_default(cmd.chain.chain);
         let db_path = data_dir.db_path();
-        assert!(db_path.ends_with("reth/mainnet/db"), "{:?}", cmd.config);
+        let end = format!("reth/{}/db", SUPPORTED_CHAINS[0]);
+        assert!(db_path.ends_with(end), "{:?}", cmd.config);
 
         let cmd =
             NodeCommand::<()>::try_parse_from(["reth", "--datadir", "my/custom/path"]).unwrap();
@@ -1149,6 +1145,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "optimism"))] // dev mode not yet supported in op-reth
     fn parse_dev() {
         let cmd = NodeCommand::<()>::parse_from(["reth", "--dev"]);
         let chain = DEV.clone();

--- a/bin/reth/src/p2p/mod.rs
+++ b/bin/reth/src/p2p/mod.rs
@@ -2,7 +2,7 @@
 use crate::{
     args::{
         get_secret_key,
-        utils::{chain_spec_value_parser, hash_or_num_value_parser},
+        utils::{chain_help, chain_spec_value_parser, hash_or_num_value_parser, SUPPORTED_CHAINS},
         DatabaseArgs, DiscoveryArgs,
     },
     dirs::{DataDirPath, MaybePlatformPath},
@@ -28,17 +28,11 @@ pub struct Command {
     /// The chain this node is running.
     ///
     /// Possible values are either a built-in chain or the path to a chain specification file.
-    ///
-    /// Built-in chains:
-    /// - mainnet
-    /// - goerli
-    /// - sepolia
-    /// - holesky
     #[arg(
         long,
         value_name = "CHAIN_OR_PATH",
-        verbatim_doc_comment,
-        default_value = "mainnet",
+        long_help = chain_help(),
+        default_value = SUPPORTED_CHAINS[0],
         value_parser = chain_spec_value_parser
     )]
     chain: Arc<ChainSpec>,

--- a/bin/reth/src/recover/storage_tries.rs
+++ b/bin/reth/src/recover/storage_tries.rs
@@ -1,5 +1,5 @@
 use crate::{
-    args::utils::genesis_value_parser,
+    args::utils::{chain_help, genesis_value_parser, SUPPORTED_CHAINS},
     dirs::{DataDirPath, MaybePlatformPath},
     init::init_genesis,
     runner::CliContext,
@@ -32,17 +32,11 @@ pub struct Command {
     /// The chain this node is running.
     ///
     /// Possible values are either a built-in chain or the path to a chain specification file.
-    ///
-    /// Built-in chains:
-    /// - mainnet
-    /// - goerli
-    /// - sepolia
-    /// - holesky
     #[arg(
         long,
         value_name = "CHAIN_OR_PATH",
-        verbatim_doc_comment,
-        default_value = "mainnet",
+        long_help = chain_help(),
+        default_value = SUPPORTED_CHAINS[0],
         value_parser = genesis_value_parser
     )]
     chain: Arc<ChainSpec>,

--- a/bin/reth/src/stage/drop.rs
+++ b/bin/reth/src/stage/drop.rs
@@ -1,6 +1,9 @@
 //! Database debugging tool
 use crate::{
-    args::{utils::genesis_value_parser, DatabaseArgs, StageEnum},
+    args::{
+        utils::{chain_help, genesis_value_parser, SUPPORTED_CHAINS},
+        DatabaseArgs, StageEnum,
+    },
     dirs::{DataDirPath, MaybePlatformPath},
     init::{insert_genesis_header, insert_genesis_state},
     utils::DbTool,
@@ -27,17 +30,11 @@ pub struct Command {
     /// The chain this node is running.
     ///
     /// Possible values are either a built-in chain or the path to a chain specification file.
-    ///
-    /// Built-in chains:
-    /// - mainnet
-    /// - goerli
-    /// - sepolia
-    /// - holesky
     #[arg(
         long,
         value_name = "CHAIN_OR_PATH",
-        verbatim_doc_comment,
-        default_value = "mainnet",
+        long_help = chain_help(),
+        default_value = SUPPORTED_CHAINS[0],
         value_parser = genesis_value_parser
     )]
     chain: Arc<ChainSpec>,

--- a/bin/reth/src/stage/dump/mod.rs
+++ b/bin/reth/src/stage/dump/mod.rs
@@ -22,7 +22,10 @@ mod execution;
 use execution::dump_execution_stage;
 
 mod merkle;
-use crate::args::{utils::genesis_value_parser, DatabaseArgs};
+use crate::args::{
+    utils::{chain_help, genesis_value_parser, SUPPORTED_CHAINS},
+    DatabaseArgs,
+};
 use merkle::dump_merkle_stage;
 
 /// `reth dump-stage` command
@@ -41,17 +44,11 @@ pub struct Command {
     /// The chain this node is running.
     ///
     /// Possible values are either a built-in chain or the path to a chain specification file.
-    ///
-    /// Built-in chains:
-    /// - mainnet
-    /// - goerli
-    /// - sepolia
-    /// - holesky
     #[arg(
         long,
         value_name = "CHAIN_OR_PATH",
-        verbatim_doc_comment,
-        default_value = "mainnet",
+        long_help = chain_help(),
+        default_value = SUPPORTED_CHAINS[0],
         value_parser = genesis_value_parser
     )]
     chain: Arc<ChainSpec>,

--- a/bin/reth/src/stage/run.rs
+++ b/bin/reth/src/stage/run.rs
@@ -2,7 +2,11 @@
 //!
 //! Stage debugging tool
 use crate::{
-    args::{get_secret_key, utils::chain_spec_value_parser, DatabaseArgs, NetworkArgs, StageEnum},
+    args::{
+        get_secret_key,
+        utils::{chain_help, chain_spec_value_parser, SUPPORTED_CHAINS},
+        DatabaseArgs, NetworkArgs, StageEnum,
+    },
     dirs::{DataDirPath, MaybePlatformPath},
     prometheus_exporter,
     version::SHORT_VERSION,
@@ -45,18 +49,12 @@ pub struct Command {
     /// The chain this node is running.
     ///
     /// Possible values are either a built-in chain or the path to a chain specification file.
-    ///
-    /// Built-in chains:
-    /// - mainnet
-    /// - goerli
-    /// - sepolia
-    /// - holesky
     #[arg(
-    long,
-    value_name = "CHAIN_OR_PATH",
-    verbatim_doc_comment,
-    default_value = "mainnet",
-    value_parser = chain_spec_value_parser
+        long,
+        value_name = "CHAIN_OR_PATH",
+        long_help = chain_help(),
+        default_value = SUPPORTED_CHAINS[0],
+        value_parser = chain_spec_value_parser
     )]
     chain: Arc<ChainSpec>,
 

--- a/bin/reth/src/stage/unwind.rs
+++ b/bin/reth/src/stage/unwind.rs
@@ -1,7 +1,10 @@
 //! Unwinding a certain block range
 
 use crate::{
-    args::{utils::genesis_value_parser, DatabaseArgs},
+    args::{
+        utils::{chain_help, genesis_value_parser, SUPPORTED_CHAINS},
+        DatabaseArgs,
+    },
     dirs::{DataDirPath, MaybePlatformPath},
 };
 use clap::{Parser, Subcommand};
@@ -26,17 +29,11 @@ pub struct Command {
     /// The chain this node is running.
     ///
     /// Possible values are either a built-in chain or the path to a chain specification file.
-    ///
-    /// Built-in chains:
-    /// - mainnet
-    /// - goerli
-    /// - sepolia
-    /// - holesky
     #[arg(
         long,
         value_name = "CHAIN_OR_PATH",
-        verbatim_doc_comment,
-        default_value = "mainnet",
+        long_help = chain_help(),
+        default_value = SUPPORTED_CHAINS[0],
         value_parser = genesis_value_parser,
         global = true
     )]


### PR DESCRIPTION
- restrict set of allowed chains for op-reth to base and base-goerli only since other chains are untested and probably don't yet work, with base being the default
- fixes the command-line help documentation for the --chain flag for op-reth to print out the correct list of supported chains
- changes base-goerli chain name to snake case (base_goerli) to be consistent with previous behavior