### PR TITLE
feat: add eviction ordering for blob transactions

### DIFF
--- a/crates/transaction-pool/src/pool/blob.rs
+++ b/crates/transaction-pool/src/pool/blob.rs
@@ -542,6 +542,7 @@ mod tests {
                 pool.add_transaction(factory.validated_arc(tx.clone()));
             }
 
+            // update fees and resort the pool
             pool.pending_fees = ordering.network_fees.clone();
             pool.reprioritize();
 

--- a/crates/transaction-pool/src/pool/blob.rs
+++ b/crates/transaction-pool/src/pool/blob.rs
@@ -167,6 +167,15 @@ impl<T: PoolTransaction> BlobTransactions<T> {
     pub(crate) fn assert_invariants(&self) {
         assert_eq!(self.by_id.len(), self.all.len(), "by_id.len() != all.len()");
     }
+
+// Optimisation tradeoffs:
+//
+//   - Eviction relies on 3 fee minimums per account (exec tip, exec cap and blob cap). Maintaining
+//   these values across all transactions from the account is problematic as each transaction
+//   replacement or inclusion would require a rescan of all other transactions to recalculate the
+//   minimum. Instead, the pool maintains a rolling minimum across the nonce range. Updating all
+//   the minimums will need to be done only starting at the swapped in/out nonce and leading up to
+//   the first no-change.
 }
 
 impl<T: PoolTransaction> Default for BlobTransactions<T> {
@@ -214,72 +223,6 @@ impl<T: PoolTransaction> Ord for BlobTransaction<T> {
     }
 }
 
-// When the pool eventually reaches saturation, some old transactions - that may never execute -
-// will need to be evicted in favor of newer ones. The eviction strategy is quite complex:
-//
-//   - Exceeding capacity evicts the highest-nonce of the account with the lowest paying blob
-//   transaction anywhere in the pooled nonce-sequence, as that tx would be executed the furthest
-//   in the future and is thus blocking anything after it. The smallest is deliberately not evicted
-//   to avoid a nonce-gap.
-//
-//   - Analogously, if the pool is full, the consideration price of a new tx for evicting an old
-//   one is the smallest price in the entire nonce-sequence of the account. This avoids malicious
-//   users DoSing the pool with seemingly high paying transactions hidden behind a low-paying
-//   blocked one.
-//
-//   - Since blob transactions have 3 price parameters: execution tip, execution fee cap and data
-//   fee cap, there's no singular parameter to create a total price ordering on. What's more, since
-//   the base fee and blob fee can move independently of one another, there's no pre-defined way to
-//   combine them into a stable order either. This leads to a multi-dimensional problem to solve
-//   after every block.
-//
-//   - The first observation is that comparing 1559 base fees or 4844 blob fees needs to happen in
-//   the context of their dynamism. Since these fees jump up or down in ~1.125 multipliers (at max)
-//   across blocks, comparing fees in two transactions should be based on log1.125(fee) to
-//   eliminate noise.
-//
-//   - The second observation is that the basefee and blobfee move independently, so there's no way
-//   to split mixed txs on their own (A has higher base fee, B has higher blob fee). Rather than
-//   look at the absolute fees, the useful metric is the max time it can take to exceed the
-//   transaction's fee caps. Specifically, we're interested in the number of jumps needed to go
-//   from the current fee to the transaction's cap:
-//
-//     jumps = log1.125(txfee) - log1.125(basefee)
-//
-//   - The third observation is that the base fee tends to hover around rather than swing wildly.
-//   The number of jumps needed from the current fee starts to get less relevant the higher it is.
-//   To remove the noise here too, the pool will use log(jumps) as the delta for comparing
-//   transactions.
-//
-//     delta = sign(jumps) * log(abs(jumps))
-//
-//   - To establish a total order, we need to reduce the dimensionality of the two base fees (log
-//   jumps) to a single value. The interesting aspect from the pool's perspective is how fast will
-//   a tx get executable (fees going down, crossing the smaller negative jump counter) or
-//   non-executable (fees going up, crossing the smaller positive jump counter). As such, the pool
-//   cares only about the min of the two delta values for eviction priority.
-//
-//     priority = min(delta-basefee, delta-blobfee)
-//
-//   - The above very aggressive dimensionality and noise reduction should result in transaction
-//   being grouped into a small number of buckets, the further the fees the larger the buckets.
-//   This is good because it allows us to use the miner tip meaningfully as a splitter.
-//
-//   - For the scenario where the pool does not contain non-executable blob txs anymore, it does
-//   not make sense to grant a later eviction priority to txs with high fee caps since it could
-//   enable pool wars. As such, any positive priority will be grouped together.
-//
-//     priority = min(delta-basefee, delta-blobfee, 0)
-//
-// Optimisation tradeoffs:
-//
-//   - Eviction relies on 3 fee minimums per account (exec tip, exec cap and blob cap). Maintaining
-//   these values across all transactions from the account is problematic as each transaction
-//   replacement or inclusion would require a rescan of all other transactions to recalculate the
-//   minimum. Instead, the pool maintains a rolling minimum across the nonce range. Updating all
-//   the minimums will need to be done only starting at the swapped in/out nonce and leading up to
-//   the first no-change.
-
 /// The blob step function, attempting to compute the delta given the `max_tx_fee`, and
 /// `current_fee`.
 ///
@@ -293,8 +236,12 @@ impl<T: PoolTransaction> Ord for BlobTransaction<T> {
 /// This is suppoed to get the number of fee jumps required to get from the current fee to the
 /// fee cap, or where the transaction would not be executable any more.
 fn fee_delta(max_tx_fee: u128, current_fee: u128) -> f64 {
+    // jumps = log1.125(txfee) - log1.125(basefee)
+    // TODO: should we do this without f64?
     let jumps = (max_tx_fee as f64).log(1.125) - (current_fee as f64).log(1.125);
-    jumps.signum() * jumps.abs().log(2.0)
+    // delta = sign(jumps) * log(abs(jumps))
+    // TODO: which log here? 10? e? 2?
+    jumps.signum() * jumps.abs().log2()
 }
 
 /// Returns the priority for the transaction, based on the "delta" blob fee and priority fee.
@@ -307,7 +254,7 @@ fn blob_tx_priority(
     let delta_blob_fee = fee_delta(blob_fee_cap, blob_fee);
     let delta_priority_fee = fee_delta(max_priority_fee, base_fee);
 
-    // The priority is the minimum of the two deltas, and zero
+    // priority = min(delta-basefee, delta-blobfee, 0)
     delta_blob_fee.min(delta_priority_fee).min(0.0)
 }
 


### PR DESCRIPTION
Implements blob subpool ordering, based on geth's blob subpool ordering. This PR resorts the entire subpool when fees are updated, which is simpler but less efficient than geth's reordering logic. Reordering is necessary because there are now two fee types (and a cap for each), which can move independently of each other.