### PR TITLE
feat(rpc): record call metrics per method

### DIFF
--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -46,7 +46,10 @@ pub struct IpcServer<B = Identity, L = ()> {
     service_builder: tower::ServiceBuilder<B>,
 }
 
-impl IpcServer {
+impl<L> IpcServer<Identity, L>
+where
+    L: Logger,
+{
     /// Returns the configured [Endpoint]
     pub fn endpoint(&self) -> &Endpoint {
         &self.endpoint
@@ -162,7 +165,7 @@ impl IpcServer {
                             stop_handle: stop_handle.clone(),
                             max_subscriptions_per_connection,
                             conn_id: id,
-                            logger,
+                            logger: logger.clone(),
                             conn: Arc::new(conn),
                             bounded_subscriptions: BoundedSubscriptions::new(
                                 max_subscriptions_per_connection,

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1402,7 +1402,7 @@ impl RpcServerConfig {
                     .http
                     .as_ref()
                     .or(modules.ws.as_ref())
-                    .map(|module| RpcServerMetrics::default().with_rpc_module(module))
+                    .map(RpcServerMetrics::new)
                     .unwrap_or_default(),
             )
             .await?;
@@ -1427,11 +1427,7 @@ impl RpcServerConfig {
                 self.ws_cors_domains.take(),
                 self.jwt_secret.clone(),
                 ServerKind::WS(ws_socket_addr),
-                modules
-                    .ws
-                    .as_ref()
-                    .map(|module| RpcServerMetrics::default().with_rpc_module(module))
-                    .unwrap_or_default(),
+                modules.ws.as_ref().map(RpcServerMetrics::new).unwrap_or_default(),
             )
             .await?;
             ws_local_addr = Some(addr);
@@ -1446,11 +1442,7 @@ impl RpcServerConfig {
                 self.http_cors_domains.take(),
                 self.jwt_secret.clone(),
                 ServerKind::Http(http_socket_addr),
-                modules
-                    .http
-                    .as_ref()
-                    .map(|module| RpcServerMetrics::default().with_rpc_module(module))
-                    .unwrap_or_default(),
+                modules.http.as_ref().map(RpcServerMetrics::new).unwrap_or_default(),
             )
             .await?;
             http_local_addr = Some(addr);
@@ -1478,7 +1470,7 @@ impl RpcServerConfig {
             let metrics = modules
                 .ipc
                 .as_ref()
-                .map(|module| RpcServerMetrics::default().with_rpc_module(module))
+                .map(|module| RpcServerMetrics::new(module))
                 .unwrap_or_default();
             let ipc_path = self
                 .ipc_endpoint

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1342,13 +1342,16 @@ impl RpcServerConfig {
 
     /// Convenience function to do [RpcServerConfig::build] and [RpcServer::start] in one step
     pub async fn start(self, modules: TransportRpcModules) -> Result<RpcServerHandle, RpcError> {
-        self.build().await?.start(modules).await
+        self.build(&modules).await?.start(modules).await
     }
 
     /// Builds the ws and http server(s).
     ///
     /// If both are on the same port, they are combined into one server.
-    async fn build_ws_http(&mut self) -> Result<WsHttpServer, RpcError> {
+    async fn build_ws_http(
+        &mut self,
+        modules: &TransportRpcModules,
+    ) -> Result<WsHttpServer, RpcError> {
         let http_socket_addr = self.http_addr.unwrap_or(SocketAddr::V4(SocketAddrV4::new(
             Ipv4Addr::LOCALHOST,
             DEFAULT_HTTP_RPC_PORT,
@@ -1358,7 +1361,7 @@ impl RpcServerConfig {
         let ws_socket_addr = self
             .ws_addr
             .unwrap_or(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, DEFAULT_WS_RPC_PORT)));
-        let metrics = RpcServerMetrics::default();
+
         // If both are configured on the same port, we combine them into one server.
         if self.http_addr == self.ws_addr &&
             self.http_server_config.is_some() &&
@@ -1386,6 +1389,8 @@ impl RpcServerConfig {
             // we merge this into one server using the http setup
             self.ws_server_config.take();
 
+            modules.config.ensure_ws_http_identical()?;
+
             let builder = self.http_server_config.take().expect("is set; qed");
             let (server, addr) = WsHttpServerKind::build(
                 builder,
@@ -1393,7 +1398,12 @@ impl RpcServerConfig {
                 cors,
                 secret,
                 ServerKind::WsHttp(http_socket_addr),
-                metrics.clone(),
+                modules
+                    .http
+                    .as_ref()
+                    .or(modules.ws.as_ref())
+                    .map(|module| RpcServerMetrics::default().with_rpc_module(module))
+                    .unwrap_or_default(),
             )
             .await?;
             return Ok(WsHttpServer {
@@ -1417,7 +1427,11 @@ impl RpcServerConfig {
                 self.ws_cors_domains.take(),
                 self.jwt_secret.clone(),
                 ServerKind::WS(ws_socket_addr),
-                metrics.clone(),
+                modules
+                    .ws
+                    .as_ref()
+                    .map(|module| RpcServerMetrics::default().with_rpc_module(module))
+                    .unwrap_or_default(),
             )
             .await?;
             ws_local_addr = Some(addr);
@@ -1432,7 +1446,11 @@ impl RpcServerConfig {
                 self.http_cors_domains.take(),
                 self.jwt_secret.clone(),
                 ServerKind::Http(http_socket_addr),
-                metrics.clone(),
+                modules
+                    .http
+                    .as_ref()
+                    .map(|module| RpcServerMetrics::default().with_rpc_module(module))
+                    .unwrap_or_default(),
             )
             .await?;
             http_local_addr = Some(addr);
@@ -1452,15 +1470,20 @@ impl RpcServerConfig {
     /// This consumes the builder and returns a server.
     ///
     /// Note: The server ist not started and does nothing unless polled, See also [RpcServer::start]
-    pub async fn build(mut self) -> Result<RpcServer, RpcError> {
+    pub async fn build(mut self, modules: &TransportRpcModules) -> Result<RpcServer, RpcError> {
         let mut server = RpcServer::empty();
-        server.ws_http = self.build_ws_http().await?;
+        server.ws_http = self.build_ws_http(modules).await?;
 
         if let Some(builder) = self.ipc_server_config {
+            let metrics = modules
+                .ipc
+                .as_ref()
+                .map(|module| RpcServerMetrics::default().with_rpc_module(module))
+                .unwrap_or_default();
             let ipc_path = self
                 .ipc_endpoint
                 .unwrap_or_else(|| Endpoint::new(DEFAULT_IPC_ENDPOINT.to_string()));
-            let ipc = builder.build(ipc_path.path())?;
+            let ipc = builder.set_logger(metrics).build(ipc_path.path())?;
             server.ipc = Some(ipc);
         }
 
@@ -1825,7 +1848,7 @@ pub struct RpcServer {
     /// Configured ws,http servers
     ws_http: WsHttpServer,
     /// ipc server
-    ipc: Option<IpcServer>,
+    ipc: Option<IpcServer<Identity, RpcServerMetrics>>,
 }
 
 // === impl RpcServer ===

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1467,11 +1467,7 @@ impl RpcServerConfig {
         server.ws_http = self.build_ws_http(modules).await?;
 
         if let Some(builder) = self.ipc_server_config {
-            let metrics = modules
-                .ipc
-                .as_ref()
-                .map(|module| RpcServerMetrics::new(module))
-                .unwrap_or_default();
+            let metrics = modules.ipc.as_ref().map(RpcServerMetrics::new).unwrap_or_default();
             let ipc_path = self
                 .ipc_endpoint
                 .unwrap_or_else(|| Endpoint::new(DEFAULT_IPC_ENDPOINT.to_string()));

--- a/crates/rpc/rpc-builder/src/metrics.rs
+++ b/crates/rpc/rpc-builder/src/metrics.rs
@@ -7,7 +7,7 @@ use reth_metrics::{
     metrics::{Counter, Histogram},
     Metrics,
 };
-use std::{collections::HashMap, net::SocketAddr, ops::Deref, sync::Arc, time::Instant};
+use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Instant};
 
 /// Metrics for the RPC server
 #[derive(Default, Clone)]

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -2149,12 +2149,13 @@ impl<TX: DbTxMut + DbTx> BlockWriter for DatabaseProvider<TX> {
             let start = Instant::now();
             self.tx.put::<tables::Transactions>(next_tx_num, transaction.into())?;
             let elapsed = start.elapsed();
-            if elapsed > Duration::from_millis(100) {
+            if elapsed > Duration::from_secs(1) {
                 warn!(
                     target: "providers::db",
                     ?block_number,
                     tx_num = %next_tx_num,
                     hash = %hash,
+                    %elapsed,
                     "Transaction insertion took too long"
                 );
             }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -52,7 +52,7 @@ use std::{
     sync::{mpsc, Arc},
     time::{Duration, Instant},
 };
-use tracing::debug;
+use tracing::{debug, warn};
 
 /// A [`DatabaseProvider`] that holds a read-only database transaction.
 pub type DatabaseProviderRO<'this, DB> = DatabaseProvider<<DB as DatabaseGAT<'this>>::TX>;
@@ -2148,7 +2148,17 @@ impl<TX: DbTxMut + DbTx> BlockWriter for DatabaseProvider<TX> {
 
             let start = Instant::now();
             self.tx.put::<tables::Transactions>(next_tx_num, transaction.into())?;
-            transactions_elapsed += start.elapsed();
+            let elapsed = start.elapsed();
+            if elapsed > Duration::from_millis(100) {
+                warn!(
+                    target: "providers::db",
+                    ?block_number,
+                    tx_num = %next_tx_num,
+                    hash = %hash,
+                    "Transaction insertion took too long"
+                );
+            }
+            transactions_elapsed += elapsed;
 
             if prune_modes
                 .and_then(|modes| modes.transaction_lookup)

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -2155,7 +2155,7 @@ impl<TX: DbTxMut + DbTx> BlockWriter for DatabaseProvider<TX> {
                     ?block_number,
                     tx_num = %next_tx_num,
                     hash = %hash,
-                    %elapsed,
+                    ?elapsed,
                     "Transaction insertion took too long"
                 );
             }


### PR DESCRIPTION
Currently, we don't have RPC metrics per method, but it can be extremely useful for debugging of long-running requests. This PR fixes it, and also changes the layout of RPC server metrics to make use of labels.