### PR TITLE
chore: update nextest config

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,3 @@
 [profile.default]
-retries = { backoff = "fixed", count = 2, delay = "1s" }
-slow-timeout = "2m"
+retries = { backoff = "exponential", count = 2, delay = "2s", jitter = true }
+slow-timeout = { period = "30s", terminate-after = 4 }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,7 @@
 [profile.default]
 retries = { backoff = "exponential", count = 2, delay = "2s", jitter = true }
 slow-timeout = { period = "30s", terminate-after = 4 }
+
+[[profile.default.overrides]]
+filter = "test(general_state_tests)"
+slow-timeout = { period = "1m", terminate-after = 4 }


### PR DESCRIPTION
Misread <https://nexte.st/book/slow-tests.html>. The time string is just when it gets marked as "slow"; an additional `terminate-after` option is needed to terminate the test.