### PR TITLE
fix: prevent decoding U256 TxValue on mainnet

### DIFF
--- a/crates/primitives/src/transaction/tx_value.rs
+++ b/crates/primitives/src/transaction/tx_value.rs
@@ -44,7 +44,14 @@ impl Encodable for TxValue {
 impl Decodable for TxValue {
     #[inline]
     fn decode(buf: &mut &[u8]) -> Result<Self, Error> {
-        U256::decode(buf).map(Self)
+        #[cfg(feature = "optimism")]
+        {
+            U256::decode(buf).map(Self)
+        }
+        #[cfg(not(feature = "optimism"))]
+        {
+            u128::decode(buf).map(Self::from)
+        }
     }
 }
 


### PR DESCRIPTION
This prevents `TxValue`s larger than `U256` from being decoded when the `optimism` feature is not enabled. This means there is no chance of the node decoding a transaction with a `TxValue` larger than `U256`, and attempting to commit that value in the DB, which would panic from the `to` conversion:
https://github.com/paradigmxyz/reth/blob/db11909d1145759900a70416514c31384581f8c2/crates/primitives/src/transaction/tx_value.rs#L73-L76