### PR TITLE
feat(bin): report freelist in `db stats`

### DIFF
--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -13,7 +13,7 @@ use eyre::WrapErr;
 use human_bytes::human_bytes;
 use reth_db::{
     database::Database,
-    open_db, open_db_read_only,
+    mdbx, open_db, open_db_read_only,
     version::{get_db_version, DatabaseVersionError, DB_VERSION},
     Tables,
 };
@@ -164,6 +164,18 @@ impl Command {
                         .add_cell(Cell::new(""))
                         .add_cell(Cell::new(""))
                         .add_cell(Cell::new(human_bytes(total_size as f64)));
+                    stats_table.add_row(row);
+
+                    let freelist_size = tx.inner.env().freelist()? *
+                        tx.inner.db_stat(&mdbx::Database::freelist_db())?.page_size() as usize;
+
+                    let mut row = Row::new();
+                    row.add_cell(Cell::new("Freelist size"))
+                        .add_cell(Cell::new(""))
+                        .add_cell(Cell::new(""))
+                        .add_cell(Cell::new(""))
+                        .add_cell(Cell::new(""))
+                        .add_cell(Cell::new(human_bytes(freelist_size as f64)));
                     stats_table.add_row(row);
 
                     Ok::<(), eyre::Report>(())

--- a/bin/reth/src/db/mod.rs
+++ b/bin/reth/src/db/mod.rs
@@ -166,12 +166,13 @@ impl Command {
                         .add_cell(Cell::new(human_bytes(total_size as f64)));
                     stats_table.add_row(row);
 
-                    let freelist_size = tx.inner.env().freelist()? *
+                    let freelist = tx.inner.env().freelist()?;
+                    let freelist_size = freelist *
                         tx.inner.db_stat(&mdbx::Database::freelist_db())?.page_size() as usize;
 
                     let mut row = Row::new();
                     row.add_cell(Cell::new("Freelist size"))
-                        .add_cell(Cell::new(""))
+                        .add_cell(Cell::new(freelist))
                         .add_cell(Cell::new(""))
                         .add_cell(Cell::new(""))
                         .add_cell(Cell::new(""))

--- a/crates/storage/libmdbx-rs/src/database.rs
+++ b/crates/storage/libmdbx-rs/src/database.rs
@@ -39,7 +39,8 @@ impl<'txn> Database<'txn> {
         Self { dbi, _marker: PhantomData }
     }
 
-    pub(crate) fn freelist_db() -> Self {
+    /// Opens the freelist database with DBI `0`.
+    pub fn freelist_db() -> Self {
         Database { dbi: 0, _marker: PhantomData }
     }
 


### PR DESCRIPTION
```console
ubuntu@bench-box:~/reth-mainnet$ cargo run --quiet --bin reth -- db stats
| Table Name        | # Entries  | Branch Pages | Leaf Pages | Overflow Pages | Total Size |
|-------------------|------------|--------------|------------|----------------|------------|
| AccountChangeSet  | 16094785   | 82325        | 212481     | 0              | 1.1 GiB    |
| AccountHistory    | 520884     | 1658         | 57433      | 162            | 231.5 MiB  |
| AccountsTrie      | 20258807   | 5574         | 1015175    | 0              | 3.9 GiB    |
| BlockBodyIndices  | 18527314   | 491          | 109508     | 0              | 429.7 MiB  |
| BlockOmmers       | 1209744    | 844          | 188675     | 0              | 740.3 MiB  |
| BlockWithdrawals  | 1492374    | 954          | 213206     | 0              | 836.6 MiB  |
| Bytecodes         | 1134800    | 1560         | 100079     | 2498909        | 9.9 GiB    |
| CanonicalHeaders  | 18527314   | 3673         | 444803     | 0              | 1.7 GiB    |
| HashedAccount     | 225153344  | 72359        | 4383459    | 0              | 17 GiB     |
| HashedStorage     | 1074530996 | 652142       | 20427924   | 0              | 80.4 GiB   |
| HeaderNumbers     | 18527314   | 4634         | 332376     | 0              | 1.3 GiB    |
| HeaderTD          | 18527314   | 601          | 134257     | 0              | 526.8 MiB  |
| Headers           | 18527314   | 40397        | 4583290    | 0              | 17.6 GiB   |
| PlainAccountState | 225153344  | 37545        | 3403300    | 0              | 13.1 GiB   |
| PlainStorageState | 1074530996 | 684781       | 22634338   | 0              | 89 GiB     |
| PruneCheckpoints  | 5          | 0            | 1          | 0              | 4 KiB      |
| Receipts          | 16606569   | 5296         | 743396     | 46965          | 3 GiB      |
| StorageChangeSet  | 46810227   | 21236        | 791277     | 0              | 3.1 GiB    |
| StorageHistory    | 1487134    | 8179         | 165567     | 310            | 679.9 MiB  |
| StoragesTrie      | 94087445   | 625714       | 5653482    | 0              | 24 GiB     |
| SyncStage         | 13         | 0            | 1          | 0              | 4 KiB      |
| SyncStageProgress | 1          | 0            | 1          | 0              | 4 KiB      |
| TransactionBlock  | 16890939   | 486          | 108276     | 0              | 424.9 MiB  |
| Transactions      | 2150111334 | 451582       | 101153407  | 36868281       | 528.2 GiB  |
| TxHashNumber      | 2150111334 | 544799       | 38531207   | 0              | 149.1 GiB  |
| TxSenders         | 2019552319 | 84267        | 18874383   | 0              | 72.3 GiB   |
| ----------------- | ---------- | ------------ | ---------- | -------------- | ---------- |
| Total DB size     |            |              |            |                | 1018.6 GiB |
| Freelist size     | 1472504    |              |            |                | 5.6 GiB    |

ubuntu@bench-box:~/reth-mainnet$ curl -s localhost:9001/metrics | grep '^reth_db_freelist'
reth_db_freelist 1472504
```