### PR TITLE
chore: support static str in capability

### DIFF
--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -595,7 +595,7 @@ mod tests {
             let server_hello = HelloMessage {
                 protocol_version: ProtocolVersion::V5,
                 client_version: "bitcoind/1.0.0".to_string(),
-                capabilities: vec![Capability::new("eth".into(), EthVersion::Eth67 as usize)],
+                capabilities: vec![Capability::new_static("eth", EthVersion::Eth67 as usize)],
                 port: DEFAULT_DISCOVERY_PORT,
                 id: pk2id(&server_key.public_key(SECP256K1)),
             };
@@ -623,7 +623,7 @@ mod tests {
         let client_hello = HelloMessage {
             protocol_version: ProtocolVersion::V5,
             client_version: "bitcoind/1.0.0".to_string(),
-            capabilities: vec![Capability::new("eth".into(), EthVersion::Eth67 as usize)],
+            capabilities: vec![Capability::new_static("eth", EthVersion::Eth67 as usize)],
             port: DEFAULT_DISCOVERY_PORT,
             id: pk2id(&client_key.public_key(SECP256K1)),
         };

--- a/crates/net/eth-wire/src/hello.rs
+++ b/crates/net/eth-wire/src/hello.rs
@@ -125,7 +125,7 @@ mod tests {
         let hello = P2PMessage::Hello(HelloMessage {
             protocol_version: ProtocolVersion::V5,
             client_version: "reth/0.1.0".to_string(),
-            capabilities: vec![Capability::new("eth".into(), EthVersion::Eth67 as usize)],
+            capabilities: vec![Capability::new_static("eth", EthVersion::Eth67 as usize)],
             port: DEFAULT_DISCOVERY_PORT,
             id,
         });
@@ -145,7 +145,7 @@ mod tests {
         let hello = P2PMessage::Hello(HelloMessage {
             protocol_version: ProtocolVersion::V5,
             client_version: "reth/0.1.0".to_string(),
-            capabilities: vec![Capability::new("eth".into(), EthVersion::Eth67 as usize)],
+            capabilities: vec![Capability::new_static("eth", EthVersion::Eth67 as usize)],
             port: DEFAULT_DISCOVERY_PORT,
             id,
         });
@@ -164,7 +164,7 @@ mod tests {
         let hello = P2PMessage::Hello(HelloMessage {
             protocol_version: ProtocolVersion::V5,
             client_version: "reth/0.1.0".to_string(),
-            capabilities: vec![Capability::new("eth".into(), EthVersion::Eth67 as usize)],
+            capabilities: vec![Capability::new_static("eth", EthVersion::Eth67 as usize)],
             port: DEFAULT_DISCOVERY_PORT,
             id,
         });

--- a/crates/net/network/tests/it/session.rs
+++ b/crates/net/network/tests/it/session.rs
@@ -49,7 +49,7 @@ async fn test_session_established_with_different_capability() {
 
     let mut net = Testnet::create(1).await;
 
-    let capabilities = vec![Capability::new("eth".into(), EthVersion::Eth66 as usize)];
+    let capabilities = vec![Capability::new_static("eth", EthVersion::Eth66 as usize)];
     let p1 = PeerConfig::with_capabilities(NoopProvider::default(), capabilities);
     net.add_peer_with_config(p1).await.unwrap();
 


### PR DESCRIPTION
names are fixed, so can be 'static