### PR TITLE
chore: rm default features

### DIFF
--- a/crates/rpc/rpc-testing-util/Cargo.toml
+++ b/crates/rpc/rpc-testing-util/Cargo.toml
@@ -12,7 +12,7 @@ description = "Reth RPC testing helpers"
 # reth
 reth-primitives.workspace = true
 reth-rpc-types.workspace = true
-reth-rpc-api = { workspace = true, default-features = false, features = ["client"] }
+reth-rpc-api = { workspace = true, features = ["client"] }
 
 # async
 async-trait.workspace = true


### PR DESCRIPTION
get rid of a warning, there are no default features

> warning: /Users/Matthias/git/rust/reth/crates/rpc/rpc-testing-util/Cargo.toml: `default-features` is ignored for reth-rpc-api, since `default-features` was not specified for `workspace.dependencies.reth-rpc-api`, this could become a hard error in the future