### PR TITLE
feat: support hello message with protocols

### DIFF
--- a/bin/reth/src/args/network_args.rs
+++ b/bin/reth/src/args/network_args.rs
@@ -5,7 +5,7 @@ use clap::Args;
 use reth_config::Config;
 use reth_discv4::{DEFAULT_DISCOVERY_ADDR, DEFAULT_DISCOVERY_PORT};
 use reth_net_nat::NatResolver;
-use reth_network::{HelloMessage, NetworkConfigBuilder};
+use reth_network::{HelloMessageWithProtocols, NetworkConfigBuilder};
 use reth_primitives::{mainnet_nodes, ChainSpec, NodeRecord};
 use secp256k1::SecretKey;
 use std::{net::Ipv4Addr, path::PathBuf, sync::Arc};
@@ -108,8 +108,9 @@ impl NetworkArgs {
 
         // Configure node identity
         let peer_id = network_config_builder.get_peer_id();
-        network_config_builder = network_config_builder
-            .hello_message(HelloMessage::builder(peer_id).client_version(&self.identity).build());
+        network_config_builder = network_config_builder.hello_message(
+            HelloMessageWithProtocols::builder(peer_id).client_version(&self.identity).build(),
+        );
 
         self.discovery.apply_to_builder(network_config_builder)
     }

--- a/crates/net/eth-wire/src/builder.rs
+++ b/crates/net/eth-wire/src/builder.rs
@@ -1,10 +1,7 @@
 //! Builder structs for [`Status`] and [`HelloMessage`] messages.
 
-use crate::{
-    capability::Capability, hello::HelloMessage, p2pstream::ProtocolVersion, EthVersion, Status,
-};
-use reth_discv4::DEFAULT_DISCOVERY_PORT;
-use reth_primitives::{Chain, ForkId, PeerId, B256, U256};
+use crate::Status;
+use reth_primitives::{Chain, ForkId, B256, U256};
 
 /// Builder for [`Status`] messages.
 ///
@@ -79,64 +76,6 @@ impl StatusBuilder {
     /// Sets the fork id.
     pub fn forkid(mut self, forkid: ForkId) -> Self {
         self.status.forkid = forkid;
-        self
-    }
-}
-
-/// Builder for [`HelloMessage`] messages.
-#[derive(Debug)]
-pub struct HelloBuilder {
-    hello: HelloMessage,
-}
-
-impl HelloBuilder {
-    /// Creates a new [`HelloBuilder`] with default [`HelloMessage`] values, and a `PeerId`
-    /// corresponding to the given pubkey.
-    pub fn new(pubkey: PeerId) -> Self {
-        Self {
-            hello: HelloMessage {
-                protocol_version: ProtocolVersion::V5,
-                // TODO: proper client versioning
-                client_version: "Ethereum/1.0.0".to_string(),
-                capabilities: vec![EthVersion::Eth68.into()],
-                port: DEFAULT_DISCOVERY_PORT,
-                id: pubkey,
-            },
-        }
-    }
-
-    /// Consumes the type and creates the actual [`HelloMessage`] message.
-    pub fn build(self) -> HelloMessage {
-        self.hello
-    }
-
-    /// Sets the protocol version.
-    pub fn protocol_version(mut self, protocol_version: ProtocolVersion) -> Self {
-        self.hello.protocol_version = protocol_version;
-        self
-    }
-
-    /// Sets the client version.
-    pub fn client_version(mut self, client_version: String) -> Self {
-        self.hello.client_version = client_version;
-        self
-    }
-
-    /// Sets the capabilities.
-    pub fn capabilities(mut self, capabilities: Vec<Capability>) -> Self {
-        self.hello.capabilities = capabilities;
-        self
-    }
-
-    /// Sets the port.
-    pub fn port(mut self, port: u16) -> Self {
-        self.hello.port = port;
-        self
-    }
-
-    /// Sets the node id.
-    pub fn id(mut self, id: PeerId) -> Self {
-        self.hello.id = id;
         self
     }
 }

--- a/crates/net/eth-wire/src/builder.rs
+++ b/crates/net/eth-wire/src/builder.rs
@@ -1,4 +1,4 @@
-//! Builder structs for [`Status`] and [`HelloMessage`] messages.
+//! Builder structs for messages.
 
 use crate::Status;
 use reth_primitives::{Chain, ForkId, B256, U256};

--- a/crates/net/eth-wire/src/capability.rs
+++ b/crates/net/eth-wire/src/capability.rs
@@ -60,19 +60,24 @@ impl Capability {
         Self { name: Cow::Borrowed(name), version }
     }
 
+    /// Returns the corresponding eth capability for the given version.
+    pub const fn eth(version: EthVersion) -> Self {
+        Self::new_static("eth", version as usize)
+    }
+
     /// Returns the [EthVersion::Eth66] capability.
     pub const fn eth_66() -> Self {
-        Self::new_static("eth", EthVersion::Eth66 as usize)
+        Self::eth(EthVersion::Eth66)
     }
 
     /// Returns the [EthVersion::Eth67] capability.
     pub const fn eth_67() -> Self {
-        Self::new_static("eth", EthVersion::Eth67 as usize)
+        Self::eth(EthVersion::Eth67)
     }
 
     /// Returns the [EthVersion::Eth68] capability.
     pub const fn eth_68() -> Self {
-        Self::new_static("eth", EthVersion::Eth68 as usize)
+        Self::eth(EthVersion::Eth68)
     }
 
     /// Whether this is eth v66 protocol.
@@ -97,6 +102,13 @@ impl Capability {
 impl fmt::Display for Capability {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}/{}", self.name, self.version)
+    }
+}
+
+impl From<EthVersion> for Capability {
+    #[inline]
+    fn from(value: EthVersion) -> Self {
+        Capability::eth(value)
     }
 }
 

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -319,12 +319,10 @@ where
 mod tests {
     use super::UnauthedEthStream;
     use crate::{
-        capability::Capability,
         errors::{EthHandshakeError, EthStreamError},
-        hello::HelloMessage,
         p2pstream::{ProtocolVersion, UnauthedP2PStream},
         types::{broadcast::BlockHashNumber, EthMessage, EthVersion, Status},
-        EthStream, PassthroughCodec,
+        EthStream, HelloMessageWithProtocols, PassthroughCodec,
     };
     use futures::{SinkExt, StreamExt};
     use reth_discv4::DEFAULT_DISCOVERY_PORT;
@@ -592,10 +590,10 @@ mod tests {
             let (incoming, _) = listener.accept().await.unwrap();
             let stream = ECIESStream::incoming(incoming, server_key).await.unwrap();
 
-            let server_hello = HelloMessage {
+            let server_hello = HelloMessageWithProtocols {
                 protocol_version: ProtocolVersion::V5,
                 client_version: "bitcoind/1.0.0".to_string(),
-                capabilities: vec![Capability::new_static("eth", EthVersion::Eth67 as usize)],
+                protocols: vec![EthVersion::Eth67.into()],
                 port: DEFAULT_DISCOVERY_PORT,
                 id: pk2id(&server_key.public_key(SECP256K1)),
             };
@@ -620,10 +618,10 @@ mod tests {
         let outgoing = TcpStream::connect(local_addr).await.unwrap();
         let sink = ECIESStream::connect(outgoing, client_key, server_id).await.unwrap();
 
-        let client_hello = HelloMessage {
+        let client_hello = HelloMessageWithProtocols {
             protocol_version: ProtocolVersion::V5,
             client_version: "bitcoind/1.0.0".to_string(),
-            capabilities: vec![Capability::new_static("eth", EthVersion::Eth67 as usize)],
+            protocols: vec![EthVersion::Eth67.into()],
             port: DEFAULT_DISCOVERY_PORT,
             id: pk2id(&client_key.public_key(SECP256K1)),
         };

--- a/crates/net/eth-wire/src/hello.rs
+++ b/crates/net/eth-wire/src/hello.rs
@@ -4,12 +4,78 @@ use reth_codecs::derive_arbitrary;
 use reth_discv4::DEFAULT_DISCOVERY_PORT;
 use reth_primitives::{constants::RETH_CLIENT_VERSION, PeerId};
 
+use crate::protocol::Protocol;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+/// This is a superset of [HelloMessage] that provides additional protocol [Protocol] information
+/// about the number of messages used by each capability in order to do proper message ID
+/// multiplexing.
+///
+/// This type is required for the `p2p` handshake because the [HelloMessage] does not share the
+/// number of messages used by each capability.
+///
+/// To get the encodable [HelloMessage] without the additional protocol information, use the
+/// [HelloMessageWithProtocols::message].
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct HelloMessageWithProtocols {
+    /// The version of the `p2p` protocol.
+    pub protocol_version: ProtocolVersion,
+    /// Specifies the client software identity, as a human-readable string (e.g.
+    /// "Ethereum(++)/1.0.0").
+    pub client_version: String,
+    /// The list of supported capabilities and their versions.
+    pub protocols: Vec<Protocol>,
+    /// The port that the client is listening on, zero indicates the client is not listening.
+    pub port: u16,
+    /// The secp256k1 public key corresponding to the node's private key.
+    pub id: PeerId,
+}
+
+impl HelloMessageWithProtocols {
+    /// Starts a new `HelloMessageProtocolsBuilder`
+    ///
+    /// ```
+    /// use reth_ecies::util::pk2id;
+    /// use reth_eth_wire::HelloMessageWithProtocols;
+    /// use secp256k1::{SecretKey, SECP256K1};
+    /// let secret_key = SecretKey::new(&mut rand::thread_rng());
+    /// let id = pk2id(&secret_key.public_key(SECP256K1));
+    /// let status = HelloMessageWithProtocols::builder(id).build();
+    /// ```
+    pub fn builder(id: PeerId) -> HelloMessageBuilder {
+        HelloMessageBuilder::new(id)
+    }
+
+    /// Returns the raw [HelloMessage] without the additional protocol information.
+    pub fn message(&self) -> HelloMessage {
+        HelloMessage {
+            protocol_version: self.protocol_version,
+            client_version: self.client_version.clone(),
+            capabilities: self.protocols.iter().map(|p| p.cap.clone()).collect(),
+            port: self.port,
+            id: self.id,
+        }
+    }
+
+    /// Converts the type into a [HelloMessage] without the additional protocol information.
+    pub fn into_message(self) -> HelloMessage {
+        HelloMessage {
+            protocol_version: self.protocol_version,
+            client_version: self.client_version,
+            capabilities: self.protocols.into_iter().map(|p| p.cap).collect(),
+            port: self.port,
+            id: self.id,
+        }
+    }
+}
+
 // TODO: determine if we should allow for the extra fields at the end like EIP-706 suggests
-/// Message used in the `p2p` handshake, containing information about the supported RLPx protocol
-/// version and capabilities.
+/// Raw rlpx protocol message used in the `p2p` handshake, containing information about the
+/// supported RLPx protocol version and capabilities.
+///
+/// See als <https://github.com/ethereum/devp2p/blob/master/rlpx.md#hello-0x00>
 #[derive_arbitrary(rlp)]
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -45,6 +111,7 @@ impl HelloMessage {
     }
 }
 
+/// Builder for [`HelloMessageWithProtocols`]
 #[derive(Debug)]
 pub struct HelloMessageBuilder {
     /// The version of the `p2p` protocol.
@@ -52,8 +119,8 @@ pub struct HelloMessageBuilder {
     /// Specifies the client software identity, as a human-readable string (e.g.
     /// "Ethereum(++)/1.0.0").
     pub client_version: Option<String>,
-    /// The list of supported capabilities and their versions.
-    pub capabilities: Option<Vec<Capability>>,
+    /// The list of supported protocols.
+    pub protocols: Option<Vec<Protocol>>,
     /// The port that the client is listening on, zero indicates the client is not listening.
     pub port: Option<u16>,
     /// The secp256k1 public key corresponding to the node's private key.
@@ -65,7 +132,7 @@ pub struct HelloMessageBuilder {
 impl HelloMessageBuilder {
     /// Create a new builder to configure a [`HelloMessage`]
     pub fn new(id: PeerId) -> Self {
-        Self { protocol_version: None, client_version: None, capabilities: None, port: None, id }
+        Self { protocol_version: None, client_version: None, protocols: None, port: None, id }
     }
 
     /// Sets the port the client is listening on
@@ -74,9 +141,15 @@ impl HelloMessageBuilder {
         self
     }
 
-    /// Sets capabilities.
-    pub fn capabilities(mut self, capabilities: Vec<Capability>) -> Self {
-        self.capabilities = Some(capabilities);
+    /// Adds a new protocol to use.
+    pub fn protocol(mut self, protocols: impl Into<Protocol>) -> Self {
+        self.protocols.get_or_insert_with(Vec::new).push(protocols.into());
+        self
+    }
+
+    /// Sets protocols to use.
+    pub fn protocols(mut self, protocols: impl IntoIterator<Item = Protocol>) -> Self {
+        self.protocols.get_or_insert_with(Vec::new).extend(protocols);
         self
     }
 
@@ -93,12 +166,17 @@ impl HelloMessageBuilder {
     }
 
     /// Consumes the type and returns the configured [`HelloMessage`]
-    pub fn build(self) -> HelloMessage {
-        let Self { protocol_version, client_version, capabilities, port, id } = self;
-        HelloMessage {
+    ///
+    /// Unset fields will be set to their default values:
+    /// - `protocol_version`: [`ProtocolVersion::V5`]
+    /// - `client_version`: [`RETH_CLIENT_VERSION`]
+    /// - `capabilities`: All [EthVersion]
+    pub fn build(self) -> HelloMessageWithProtocols {
+        let Self { protocol_version, client_version, protocols, port, id } = self;
+        HelloMessageWithProtocols {
             protocol_version: protocol_version.unwrap_or_default(),
             client_version: client_version.unwrap_or_else(|| RETH_CLIENT_VERSION.to_string()),
-            capabilities: capabilities.unwrap_or_else(|| {
+            protocols: protocols.unwrap_or_else(|| {
                 vec![EthVersion::Eth68.into(), EthVersion::Eth67.into(), EthVersion::Eth66.into()]
             }),
             port: port.unwrap_or(DEFAULT_DISCOVERY_PORT),

--- a/crates/net/eth-wire/src/lib.rs
+++ b/crates/net/eth-wire/src/lib.rs
@@ -22,6 +22,7 @@ mod ethstream;
 mod hello;
 mod p2pstream;
 mod pinger;
+pub mod protocol;
 pub use builder::*;
 pub mod types;
 pub use types::*;
@@ -34,7 +35,7 @@ pub use tokio_util::codec::{
 pub use crate::{
     disconnect::{CanDisconnect, DisconnectReason},
     ethstream::{EthStream, UnauthedEthStream, MAX_MESSAGE_SIZE},
-    hello::HelloMessage,
+    hello::{HelloMessage, HelloMessageBuilder, HelloMessageWithProtocols},
     p2pstream::{
         P2PMessage, P2PMessageID, P2PStream, ProtocolVersion, UnauthedP2PStream,
         MAX_RESERVED_MESSAGE_ID,

--- a/crates/net/eth-wire/src/protocol.rs
+++ b/crates/net/eth-wire/src/protocol.rs
@@ -1,0 +1,68 @@
+//! A Protocol defines a P2P subprotocol in a RLPx connection
+
+use crate::{capability::Capability, EthVersion};
+
+/// Type that represents a [Capability] and the number of messages it uses.
+///
+/// Only the [Capability] is shared with the remote peer, assuming both parties know the number of
+/// messages used by the protocol which is used for message ID multiplexing.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Protocol {
+    /// The name of the subprotocol
+    pub cap: Capability,
+    /// The number of messages used/reserved by this protocol
+    ///
+    /// This is used for message ID multiplexing
+    pub messages: u8,
+}
+
+impl Protocol {
+    /// Create a new protocol with the given name and number of messages
+    pub const fn new(cap: Capability, messages: u8) -> Self {
+        Self { cap, messages }
+    }
+
+    /// Returns the corresponding eth capability for the given version.
+    pub const fn eth(version: EthVersion) -> Self {
+        let cap = Capability::eth(version);
+        let messages = version.total_messages();
+        Self::new(cap, messages)
+    }
+
+    /// Returns the [EthVersion::Eth66] capability.
+    pub const fn eth_66() -> Self {
+        Self::eth(EthVersion::Eth66)
+    }
+
+    /// Returns the [EthVersion::Eth67] capability.
+    pub const fn eth_67() -> Self {
+        Self::eth(EthVersion::Eth67)
+    }
+
+    /// Returns the [EthVersion::Eth68] capability.
+    pub const fn eth_68() -> Self {
+        Self::eth(EthVersion::Eth68)
+    }
+
+    /// Consumes the type and returns a tuple of the [Capability] and number of messages.
+    #[inline]
+    pub(crate) fn split(self) -> (Capability, u8) {
+        (self.cap, self.messages)
+    }
+}
+
+impl From<EthVersion> for Protocol {
+    fn from(version: EthVersion) -> Self {
+        Self::eth(version)
+    }
+}
+
+/// A helper type to keep track of the protocol version and number of messages used by the protocol.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct ProtoVersion {
+    /// Number of messages for a protocol
+    pub(crate) messages: u8,
+    /// Version of the protocol
+    pub(crate) version: usize,
+}

--- a/crates/net/eth-wire/src/types/version.rs
+++ b/crates/net/eth-wire/src/types/version.rs
@@ -1,6 +1,5 @@
 //! Support for representing the version of the `eth`. [`Capability`].
 
-use crate::capability::Capability;
 use std::str::FromStr;
 
 /// Error thrown when failed to parse a valid [`EthVersion`].
@@ -27,7 +26,7 @@ impl EthVersion {
     pub const LATEST: EthVersion = EthVersion::Eth68;
 
     /// Returns the total number of messages the protocol version supports.
-    pub fn total_messages(&self) -> u8 {
+    pub const fn total_messages(&self) -> u8 {
         match self {
             EthVersion::Eth66 => 15,
             EthVersion::Eth67 | EthVersion::Eth68 => {
@@ -108,13 +107,6 @@ impl From<EthVersion> for &'static str {
             EthVersion::Eth67 => "67",
             EthVersion::Eth68 => "68",
         }
-    }
-}
-
-impl From<EthVersion> for Capability {
-    #[inline]
-    fn from(v: EthVersion) -> Capability {
-        Capability { name: "eth".into(), version: v as usize }
     }
 }
 

--- a/crates/net/eth-wire/src/types/version.rs
+++ b/crates/net/eth-wire/src/types/version.rs
@@ -1,4 +1,5 @@
-//! Support for representing the version of the `eth`. [`Capability`].
+//! Support for representing the version of the `eth`. [`Capability`](crate::capability::Capability)
+//! and [Protocol](crate::protocol::Protocol).
 
 use std::str::FromStr;
 

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -10,7 +10,7 @@ use crate::{
 use reth_discv4::{Discv4Config, Discv4ConfigBuilder, DEFAULT_DISCOVERY_ADDRESS};
 use reth_dns_discovery::DnsDiscoveryConfig;
 use reth_ecies::util::pk2id;
-use reth_eth_wire::{HelloMessage, Status};
+use reth_eth_wire::{HelloMessage, HelloMessageWithProtocols, Status};
 use reth_primitives::{
     mainnet_nodes, sepolia_nodes, ChainSpec, ForkFilter, Head, NodeRecord, PeerId, MAINNET,
 };
@@ -68,7 +68,7 @@ pub struct NetworkConfig<C> {
     /// The `Status` message to send to peers at the beginning.
     pub status: Status,
     /// Sets the hello message for the p2p handshake in RLPx
-    pub hello_message: HelloMessage,
+    pub hello_message: HelloMessageWithProtocols,
     /// Whether to disable transaction gossip
     pub tx_gossip_disabled: bool,
     /// Optimism Network Config
@@ -158,7 +158,7 @@ pub struct NetworkConfigBuilder {
     #[serde(skip)]
     executor: Option<Box<dyn TaskSpawner>>,
     /// Sets the hello message for the p2p handshake in RLPx
-    hello_message: Option<HelloMessage>,
+    hello_message: Option<HelloMessageWithProtocols>,
     /// Head used to start set for the fork filter and status.
     head: Option<Head>,
     /// Whether tx gossip is disabled
@@ -239,7 +239,7 @@ impl NetworkConfigBuilder {
     /// builder.hello_message(HelloMessage::builder(peer_id).build());
     /// # }
     /// ```
-    pub fn hello_message(mut self, hello_message: HelloMessage) -> Self {
+    pub fn hello_message(mut self, hello_message: HelloMessageWithProtocols) -> Self {
         self.hello_message = Some(hello_message);
         self
     }

--- a/crates/net/network/src/lib.rs
+++ b/crates/net/network/src/lib.rs
@@ -148,4 +148,4 @@ pub use session::{
     SessionLimits, SessionManager, SessionsConfig,
 };
 
-pub use reth_eth_wire::{DisconnectReason, HelloBuilder, HelloMessage};
+pub use reth_eth_wire::{DisconnectReason, HelloMessageWithProtocols};

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -773,7 +773,8 @@ mod tests {
     };
     use reth_ecies::util::pk2id;
     use reth_eth_wire::{
-        GetBlockBodies, HelloMessage, Status, StatusBuilder, UnauthedEthStream, UnauthedP2PStream,
+        GetBlockBodies, HelloMessageWithProtocols, Status, StatusBuilder, UnauthedEthStream,
+        UnauthedP2PStream,
     };
     use reth_net_common::bandwidth_meter::BandwidthMeter;
     use reth_primitives::{ForkFilter, Hardfork, MAINNET};
@@ -782,8 +783,8 @@ mod tests {
     use tokio::{net::TcpListener, sync::mpsc};
 
     /// Returns a testing `HelloMessage` and new secretkey
-    fn eth_hello(server_key: &SecretKey) -> HelloMessage {
-        HelloMessage::builder(pk2id(&server_key.public_key(SECP256K1))).build()
+    fn eth_hello(server_key: &SecretKey) -> HelloMessageWithProtocols {
+        HelloMessageWithProtocols::builder(pk2id(&server_key.public_key(SECP256K1))).build()
     }
 
     struct SessionBuilder {
@@ -793,7 +794,7 @@ mod tests {
         to_sessions: Vec<mpsc::Sender<SessionCommand>>,
         secret_key: SecretKey,
         local_peer_id: PeerId,
-        hello: HelloMessage,
+        hello: HelloMessageWithProtocols,
         status: Status,
         fork_filter: ForkFilter,
         next_id: usize,

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -10,7 +10,8 @@ use reth_ecies::{stream::ECIESStream, ECIESError};
 use reth_eth_wire::{
     capability::{Capabilities, CapabilityMessage},
     errors::EthStreamError,
-    DisconnectReason, EthVersion, HelloMessage, Status, UnauthedEthStream, UnauthedP2PStream,
+    DisconnectReason, EthVersion, HelloMessageWithProtocols, Status, UnauthedEthStream,
+    UnauthedP2PStream,
 };
 use reth_metrics::common::mpsc::MeteredPollSender;
 use reth_net_common::{
@@ -72,7 +73,7 @@ pub struct SessionManager {
     /// The `Status` message to send to peers.
     status: Status,
     /// THe `HelloMessage` message to send to peers.
-    hello_message: HelloMessage,
+    hello_message: HelloMessageWithProtocols,
     /// The [`ForkFilter`] used to validate the peer's `Status` message.
     fork_filter: ForkFilter,
     /// Size of the command buffer per session.
@@ -115,7 +116,7 @@ impl SessionManager {
         config: SessionsConfig,
         executor: Box<dyn TaskSpawner>,
         status: Status,
-        hello_message: HelloMessage,
+        hello_message: HelloMessageWithProtocols,
         fork_filter: ForkFilter,
         bandwidth_meter: BandwidthMeter,
     ) -> Self {
@@ -164,7 +165,7 @@ impl SessionManager {
     }
 
     /// Returns the session hello message.
-    pub fn hello_message(&self) -> HelloMessage {
+    pub fn hello_message(&self) -> HelloMessageWithProtocols {
         self.hello_message.clone()
     }
 
@@ -742,7 +743,7 @@ pub(crate) async fn start_pending_incoming_session(
     events: mpsc::Sender<PendingSessionEvent>,
     remote_addr: SocketAddr,
     secret_key: SecretKey,
-    hello: HelloMessage,
+    hello: HelloMessageWithProtocols,
     status: Status,
     fork_filter: ForkFilter,
 ) {
@@ -771,7 +772,7 @@ async fn start_pending_outbound_session(
     remote_addr: SocketAddr,
     remote_peer_id: PeerId,
     secret_key: SecretKey,
-    hello: HelloMessage,
+    hello: HelloMessageWithProtocols,
     status: Status,
     fork_filter: ForkFilter,
     bandwidth_meter: BandwidthMeter,
@@ -820,7 +821,7 @@ async fn authenticate(
     remote_addr: SocketAddr,
     secret_key: SecretKey,
     direction: Direction,
-    hello: HelloMessage,
+    hello: HelloMessageWithProtocols,
     status: Status,
     fork_filter: ForkFilter,
 ) {
@@ -896,7 +897,7 @@ async fn authenticate_stream(
     remote_addr: SocketAddr,
     local_addr: Option<SocketAddr>,
     direction: Direction,
-    hello: HelloMessage,
+    hello: HelloMessageWithProtocols,
     status: Status,
     fork_filter: ForkFilter,
 ) -> PendingSessionEvent {

--- a/crates/net/network/src/test_utils/testnet.rs
+++ b/crates/net/network/src/test_utils/testnet.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use futures::{FutureExt, StreamExt};
 use pin_project::pin_project;
-use reth_eth_wire::{capability::Capability, DisconnectReason, HelloBuilder};
+use reth_eth_wire::{protocol::Protocol, DisconnectReason, HelloMessageWithProtocols};
 use reth_network_api::{NetworkInfo, Peers};
 use reth_primitives::{PeerId, MAINNET};
 use reth_provider::{
@@ -513,12 +513,12 @@ where
     }
 
     /// Initialize the network with a given capabilities.
-    pub fn with_capabilities(client: C, capabilities: Vec<Capability>) -> Self {
+    pub fn with_protocols(client: C, protocols: impl IntoIterator<Item = Protocol>) -> Self {
         let secret_key = SecretKey::new(&mut rand::thread_rng());
 
         let builder = Self::network_config_builder(secret_key);
         let hello_message =
-            HelloBuilder::new(builder.get_peer_id()).capabilities(capabilities).build();
+            HelloMessageWithProtocols::builder(builder.get_peer_id()).protocols(protocols).build();
         let config = builder.hello_message(hello_message).build(client.clone());
 
         Self { config, client, secret_key }

--- a/crates/net/network/tests/it/session.rs
+++ b/crates/net/network/tests/it/session.rs
@@ -1,7 +1,7 @@
 //! Session tests
 
 use futures::StreamExt;
-use reth_eth_wire::{capability::Capability, EthVersion};
+use reth_eth_wire::EthVersion;
 use reth_network::{
     test_utils::{PeerConfig, Testnet},
     NetworkEvent, NetworkEvents,
@@ -49,8 +49,7 @@ async fn test_session_established_with_different_capability() {
 
     let mut net = Testnet::create(1).await;
 
-    let capabilities = vec![Capability::new_static("eth", EthVersion::Eth66 as usize)];
-    let p1 = PeerConfig::with_capabilities(NoopProvider::default(), capabilities);
+    let p1 = PeerConfig::with_protocols(NoopProvider::default(), Some(EthVersion::Eth66.into()));
     net.add_peer_with_config(p1).await.unwrap();
 
     net.for_each(|peer| assert_eq!(0, peer.num_peers()));


### PR DESCRIPTION
This introduces the `Protocols` and `HelloMessageWithProtocols` type, which is now required when handshaking p2p stream.

this way we can support any protocol, because message numbers are not exchanged via the handshake we need to rely on input data when computing the offsets for sharedcapabilities.

The `Protocols` type provides this additional information.


This will require a few followups to make it a bit nicer overall