### PR TITLE
fix: use saturating mul for max response size bytes

### DIFF
--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -350,11 +350,11 @@ impl RethRpcConfig for RpcServerArgs {
     }
 
     fn rpc_max_request_size_bytes(&self) -> u32 {
-        self.rpc_max_request_size * 1024 * 1024
+        self.rpc_max_request_size.saturating_mul(1024 * 1024)
     }
 
     fn rpc_max_response_size_bytes(&self) -> u32 {
-        self.rpc_max_response_size * 1024 * 1024
+        self.rpc_max_response_size.saturating_mul(1024 * 1024)
     }
 
     fn gas_price_oracle_config(&self) -> GasPriceOracleConfig {


### PR DESCRIPTION
closes #5376

silent overflow for max bytes

we should also add support for "max"