### PR TITLE
fix(bin) : fix overflow and allow max for rpc max response size 

### DIFF
--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -354,7 +354,7 @@ impl RethRpcConfig for RpcServerArgs {
     }
 
     fn rpc_max_response_size_bytes(&self) -> u32 {
-        self.rpc_max_response_size * 1024 * 1024
+        self.rpc_max_response_size.checked_mul(1024 * 1024).unwrap_or(u32::MAX)
     }
 
     fn gas_price_oracle_config(&self) -> GasPriceOracleConfig {


### PR DESCRIPTION
Ref : https://github.com/paradigmxyz/reth/issues/5376

 if checked_mul returns None (meaning an overflow would have occurred), unwrap_or will return u32::MAX 


this would prevent overflow by using checked_mul and would return u32::MAX on overflow