### PR TITLE
feat(bin) : max_values Macro  for CLI args parsing

### DIFF
--- a/bin/reth/src/args/types.rs
+++ b/bin/reth/src/args/types.rs
@@ -61,6 +61,8 @@ impl FromStr for MaxU32 {
 macro_rules! max_values {
     ($name:ident, $ty:ident) => {
         #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        /// A helper type for parsing "max" as the maximum value of the specified type.
+
         pub(crate) struct $name(pub(crate) $ty);
 
         impl fmt::Display for $name {

--- a/bin/reth/src/args/types.rs
+++ b/bin/reth/src/args/types.rs
@@ -2,6 +2,48 @@
 
 use std::{fmt, str::FromStr};
 
+/// A helper type that maps `u32::MAX` to `None` when parsing CLI arguments.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MaxAsNone(pub Option<u32>);
+
+impl MaxAsNone {
+    /// Returns the inner value.
+    pub const fn new(value: u32) -> Self {
+        Self(Some(value))
+    }
+
+    /// Returns the inner value or `u32::MAX` if `None`.
+    pub fn unwrap_or_max(self) -> u32 {
+        self.0.unwrap_or(u32::MAX)
+    }
+}
+
+impl fmt::Display for MaxAsNone {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            Some(value) => write!(f, "{}", value),
+            None => write!(f, "max"),
+        }
+    }
+}
+
+impl fmt::Display for ZeroAsNone {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            Some(value) => write!(f, "{}", value),
+            None => write!(f, "0"),
+        }
+    }
+}
+impl FromStr for ZeroAsNone {
+    type Err = std::num::ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let value = s.parse::<u64>()?;
+        Ok(Self(if value == 0 { None } else { Some(value) }))
+    }
+}
+
 /// A helper type that maps `0` to `None` when parsing CLI arguments.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ZeroAsNone(pub Option<u64>);
@@ -18,21 +60,23 @@ impl ZeroAsNone {
     }
 }
 
-impl fmt::Display for ZeroAsNone {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.0 {
-            Some(value) => write!(f, "{}", value),
-            None => write!(f, "0"),
-        }
-    }
-}
-
-impl FromStr for ZeroAsNone {
+impl FromStr for MaxAsNone {
     type Err = std::num::ParseIntError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let value = s.parse::<u64>()?;
-        Ok(Self(if value == 0 { None } else { Some(value) }))
+        if s == "max" {
+            Ok(Self(None))
+        } else {
+            s.parse::<u32>().map(
+                |value| {
+                    if value == u32::MAX {
+                        Self(None)
+                    } else {
+                        Self(Some(value))
+                    }
+                },
+            )
+        }
     }
 }
 
@@ -45,5 +89,12 @@ mod tests {
         let val = "0".parse::<ZeroAsNone>().unwrap();
         assert_eq!(val, ZeroAsNone(None));
         assert_eq!(val.unwrap_or_max(), u64::MAX);
+    }
+
+    #[test]
+    fn test_max_parse() {
+        let val = "max".parse::<MaxAsNone>().unwrap();
+        assert_eq!(val, MaxAsNone(None));
+        assert_eq!(val.unwrap_or_max(), u32::MAX);
     }
 }

--- a/bin/reth/src/args/types.rs
+++ b/bin/reth/src/args/types.rs
@@ -64,7 +64,6 @@ macro_rules! max_values {
 }
 max_values!(MaxU32, u32);
 max_values!(MaxU64, u64);
-max_values!(U64, u64);
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/bin/reth/src/args/types.rs
+++ b/bin/reth/src/args/types.rs
@@ -62,7 +62,8 @@ macro_rules! max_values {
         }
     };
 }
-max_values!(U32, u32);
+max_values!(MaxU32, u32);
+max_values!(MaxU64, u64);
 max_values!(U64, u64);
 #[cfg(test)]
 mod tests {

--- a/bin/reth/src/args/types.rs
+++ b/bin/reth/src/args/types.rs
@@ -58,6 +58,31 @@ impl FromStr for MaxU32 {
     }
 }
 
+macro_rules! max_values {
+    ($name:ident, $ty:ident) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub(crate) struct $name(pub(crate) $ty);
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "{}", self.0)
+            }
+        }
+
+        impl FromStr for $name {
+            type Err = ParseIntError;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                if s.eq_ignore_ascii_case("max") {
+                    Ok($name(<$ty>::MAX))
+                } else {
+                    s.parse::<$ty>().map($name)
+                }
+            }
+        }
+    };
+}
+max_values!(U32, u32);
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -79,5 +104,20 @@ mod tests {
     fn test_number_parse() {
         let val = "123".parse::<MaxU32>().unwrap();
         assert_eq!(val, MaxU32(123));
+    }
+
+    max_values!(TestU32, u32);
+    max_values!(TestU64, u64);
+
+    #[test]
+    fn parse_max() {
+        assert_eq!("max".parse::<TestU32>().unwrap().0, u32::MAX);
+        assert_eq!("max".parse::<TestU64>().unwrap().0, u64::MAX);
+    }
+
+    #[test]
+    fn parse_numeric_values() {
+        assert_eq!("123".parse::<TestU32>().unwrap().0, 123);
+        assert_eq!("456".parse::<TestU64>().unwrap().0, 456);
     }
 }

--- a/bin/reth/src/args/types.rs
+++ b/bin/reth/src/args/types.rs
@@ -36,28 +36,6 @@ impl FromStr for ZeroAsNone {
     }
 }
 
-/// A helper type for parsing "max" as `u32::MAX`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct MaxU32(pub u32);
-
-impl fmt::Display for MaxU32 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl FromStr for MaxU32 {
-    type Err = ParseIntError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s == "max" {
-            Ok(MaxU32(u32::MAX))
-        } else {
-            s.parse::<u32>().map(MaxU32)
-        }
-    }
-}
-
 macro_rules! max_values {
     ($name:ident, $ty:ident) => {
         #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -95,17 +73,5 @@ mod tests {
         let val = "0".parse::<ZeroAsNone>().unwrap();
         assert_eq!(val, ZeroAsNone(None));
         assert_eq!(val.unwrap_or_max(), u64::MAX);
-    }
-
-    #[test]
-    fn test_max_parse() {
-        let val = "max".parse::<MaxU32>().unwrap();
-        assert_eq!(val, MaxU32(u32::MAX));
-    }
-
-    #[test]
-    fn test_number_parse() {
-        let val = "123".parse::<MaxU32>().unwrap();
-        assert_eq!(val, MaxU32(123));
     }
 }

--- a/bin/reth/src/args/types.rs
+++ b/bin/reth/src/args/types.rs
@@ -85,6 +85,7 @@ macro_rules! max_values {
     };
 }
 max_values!(U32, u32);
+max_values!(U64, u64);
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -106,20 +107,5 @@ mod tests {
     fn test_number_parse() {
         let val = "123".parse::<MaxU32>().unwrap();
         assert_eq!(val, MaxU32(123));
-    }
-
-    max_values!(TestU32, u32);
-    max_values!(TestU64, u64);
-
-    #[test]
-    fn parse_max() {
-        assert_eq!("max".parse::<TestU32>().unwrap().0, u32::MAX);
-        assert_eq!("max".parse::<TestU64>().unwrap().0, u64::MAX);
-    }
-
-    #[test]
-    fn parse_numeric_values() {
-        assert_eq!("123".parse::<TestU32>().unwrap().0, 123);
-        assert_eq!("456".parse::<TestU64>().unwrap().0, 456);
     }
 }


### PR DESCRIPTION
This PR adds the max_values Macro , extending CLI argument, this macro was added because we will need in future to  turn the limit off of some data type, one example would be to limit off the size of max-response-size when user wants to go to max value ( Ref : https://github.com/paradigmxyz/reth/issues/5376) 