### PR TITLE
feat(storage): open database tx on-demand in historical state provider

### DIFF
--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -32,7 +32,7 @@ pub use traits::{
 pub mod providers;
 pub use providers::{
     DatabaseProvider, DatabaseProviderRO, DatabaseProviderRW, HistoricalStateProvider,
-    HistoricalStateProviderRef, LatestStateProvider, LatestStateProviderRef, ProviderFactory,
+    LatestStateProvider, LatestStateProviderRef, ProviderFactory,
 };
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -110,7 +110,7 @@ impl<DB: Database> ProviderFactory<DB> {
         let storage_history_prune_checkpoint =
             provider.get_prune_checkpoint(PruneSegment::StorageHistory)?;
 
-        let mut state_provider = HistoricalStateProvider::new(&self, block_number);
+        let mut state_provider = HistoricalStateProvider::new(self, block_number);
 
         // If we pruned account or storage history, we can't return state on every historical block.
         // Instead, we should cap it at the latest prune checkpoint for corresponding prune segment.

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -110,7 +110,7 @@ impl<DB: Database> ProviderFactory<DB> {
         let storage_history_prune_checkpoint =
             provider.get_prune_checkpoint(PruneSegment::StorageHistory)?;
 
-        let mut state_provider = HistoricalStateProvider::new(provider.into_tx(), block_number);
+        let mut state_provider = HistoricalStateProvider::new(&self, block_number);
 
         // If we pruned account or storage history, we can't return state on every historical block.
         // Instead, we should cap it at the latest prune checkpoint for corresponding prune segment.

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -29,7 +29,7 @@ use std::{
 use tracing::trace;
 
 pub use state::{
-    historical::{HistoricalStateProvider, HistoricalStateProviderRef},
+    historical::HistoricalStateProvider,
     latest::{LatestStateProvider, LatestStateProviderRef},
 };
 


### PR DESCRIPTION
## DO NOT MERGE: pending benchmark

When tracing a large block, we create a historical state provider with the new database transaction stored in it. This transaction persists over the lifetime of state provider.

The problem is that MDBX doesn't like long-lived read transactions, because they cause the freelist to grow too much. I ran a simple test by opening a transaction, hanging and printing the freelist size every 5 seconds:
```console
60ns 27003
5.00016648s 27003
10.000308292s 26969
15.000514439s 26969
20.000663408s 26950
25.000856272s 26950
30.000971638s 26950
35.001173426s 27540
40.001356589s 27540
45.001493403s 34658
50.001673714s 34658
55.00186815s 43913
60.002048407s 43913
65.002199858s 43913
70.00231861s 43913
75.002469058s 43913
```
as you can see, after around 30 seconds the freelist started to grow.

This PR changes the behavior of `HistoricalStateProvider`, storing the `ProviderFactory` in it instead, and opening the transaction on-demand when the data is queried. This is safe, because we query the historical data that can't change even if we don't lock the view of database using one read transaction. The only possible drawback is the overhead of opening new read transactions, so we need to benchmark this change.

We can't do the same with `LatestStateProvider`, because it requires the locked view of plain state for consistency of queries.

---

Also, this PR removes the `HistoricalStateProviderRef`, because now we take the `&ProviderFactory` everywhere.