### PR TITLE
fix(bin) : make rpc_max_response_size as MaxU32

### DIFF
--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -1,7 +1,10 @@
 //! clap [Args](clap::Args) for RPC related arguments.
 
 use crate::{
-    args::{types::ZeroAsNone, GasPriceOracleArgs},
+    args::{
+        types::{MaxU32, ZeroAsNone},
+        GasPriceOracleArgs,
+    },
     cli::{
         components::{RethNodeComponents, RethRpcComponents, RethRpcServerHandles},
         config::RethRpcConfig,
@@ -138,8 +141,8 @@ pub struct RpcServerArgs {
     pub rpc_max_request_size: u32,
 
     /// Set the maximum RPC response payload size for both HTTP and WS in megabytes.
-    #[arg(long, visible_alias = "--rpc.returndata.limit", default_value_t = RPC_DEFAULT_MAX_RESPONSE_SIZE_MB)]
-    pub rpc_max_response_size: u32,
+    #[arg(long, visible_alias = "--rpc.returndata.limit", default_value_t = MaxU32(RPC_DEFAULT_MAX_RESPONSE_SIZE_MB))]
+    pub rpc_max_response_size: MaxU32,
 
     /// Set the the maximum concurrent subscriptions per connection.
     #[arg(long, default_value_t = RPC_DEFAULT_MAX_SUBS_PER_CONN)]
@@ -354,7 +357,7 @@ impl RethRpcConfig for RpcServerArgs {
     }
 
     fn rpc_max_response_size_bytes(&self) -> u32 {
-        self.rpc_max_response_size.saturating_mul(1024 * 1024)
+        self.rpc_max_response_size.0.saturating_mul(1024 * 1024)
     }
 
     fn gas_price_oracle_config(&self) -> GasPriceOracleConfig {

--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -357,7 +357,7 @@ impl RethRpcConfig for RpcServerArgs {
     }
 
     fn rpc_max_response_size_bytes(&self) -> u32 {
-        self.rpc_max_response_size.0.saturating_mul(1024 * 1024)
+        self.rpc_max_response_size.get().saturating_mul(1024 * 1024)
     }
 
     fn gas_price_oracle_config(&self) -> GasPriceOracleConfig {

--- a/bin/reth/src/args/types.rs
+++ b/bin/reth/src/args/types.rs
@@ -43,6 +43,13 @@ macro_rules! max_values {
 
         pub struct $name(pub $ty);
 
+        impl $name {
+            /// Returns the inner value.
+            pub fn get(&self) -> $ty {
+                self.0
+            }
+        }
+
         impl fmt::Display for $name {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 write!(f, "{}", self.0)

--- a/bin/reth/src/args/types.rs
+++ b/bin/reth/src/args/types.rs
@@ -45,7 +45,7 @@ macro_rules! max_values {
 
         impl $name {
             /// Returns the inner value.
-            pub fn get(&self) -> $ty {
+            pub const fn get(&self) -> $ty {
                 self.0
             }
         }

--- a/bin/reth/src/args/types.rs
+++ b/bin/reth/src/args/types.rs
@@ -41,7 +41,7 @@ macro_rules! max_values {
         #[derive(Debug, Clone, Copy, PartialEq, Eq)]
         /// A helper type for parsing "max" as the maximum value of the specified type.
 
-        pub(crate) struct $name(pub(crate) $ty);
+        pub struct $name(pub $ty);
 
         impl fmt::Display for $name {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
This PR introduces an option to disable the current limit, allowing users to extend the range up to u32::MAX  if desired

Ref https://github.com/paradigmxyz/reth/issues/5376