### PR TITLE
feat(`rpc-types`): from U64 for `BlockHashOrNumber` and `BlockId`

### DIFF
--- a/crates/rpc/rpc-types/src/eth/block.rs
+++ b/crates/rpc/rpc-types/src/eth/block.rs
@@ -622,6 +622,12 @@ impl From<u64> for BlockHashOrNumber {
     }
 }
 
+impl From<U64> for BlockHashOrNumber {
+    fn from(value: U64) -> Self {
+        value.into_limbs()[0].into()
+    }
+}
+
 /// Allows for RLP encoding of either a block hash or block number
 impl Encodable for BlockHashOrNumber {
     fn encode(&self, out: &mut dyn bytes::BufMut) {

--- a/crates/rpc/rpc-types/src/eth/block.rs
+++ b/crates/rpc/rpc-types/src/eth/block.rs
@@ -412,7 +412,7 @@ impl From<u64> for BlockId {
 
 impl From<U64> for BlockId {
     fn from(value: U64) -> Self {
-        BlockNumberOrTag::Number(value.into_limbs()[0]).into()
+        BlockNumberOrTag::Number(value.to()).into()
     }
 }
 
@@ -630,7 +630,7 @@ impl From<u64> for BlockHashOrNumber {
 
 impl From<U64> for BlockHashOrNumber {
     fn from(value: U64) -> Self {
-        value.into_limbs()[0].into()
+        value.to::<u64>().into()
     }
 }
 

--- a/crates/rpc/rpc-types/src/eth/block.rs
+++ b/crates/rpc/rpc-types/src/eth/block.rs
@@ -410,6 +410,12 @@ impl From<u64> for BlockId {
     }
 }
 
+impl From<U64> for BlockId {
+    fn from(value: U64) -> Self {
+        BlockNumberOrTag::Number(value.into_limbs()[0]).into()
+    }
+}
+
 impl From<BlockNumberOrTag> for BlockId {
     fn from(num: BlockNumberOrTag) -> Self {
         BlockId::Number(num)


### PR DESCRIPTION
smol ergonomic improvement, surfacing from the Anvil RPC types migration