### PR TITLE
Feat/enable non namespaces

### DIFF
--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -541,7 +541,7 @@ mod tests {
 
     #[test]
     fn test_rpc_server_args_parser_none() {
-        let args = CommandParser::<RpcServerArgs>::parse_from(["reth", "--http.api"]).args;
+        let args = CommandParser::<RpcServerArgs>::parse_from(["reth", "--http.api", "none"]).args;
         let apis = args.http_api.unwrap();
         let expected = Selection(vec![]);
         assert_eq!(apis, expected);

--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -536,6 +536,14 @@ mod tests {
     }
 
     #[test]
+    fn test_rpc_server_args_parser_none() {
+        let args = CommandParser::<RpcServerArgs>::parse_from(["reth", "--http.api", "none"]).args;
+        let apis = args.http_api.unwrap();
+        let expected = RpcModuleSelection::None;
+        assert_eq!(apis, expected);
+    }
+
+    #[test]
     fn test_transport_rpc_module_config() {
         let args = CommandParser::<RpcServerArgs>::parse_from([
             "reth",

--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -502,6 +502,7 @@ impl TypedValueParser for RpcModuleSelectionValueParser {
 mod tests {
     use super::*;
     use clap::Parser;
+    use reth_rpc_builder::RpcModuleSelection::Selection;
     use std::net::SocketAddrV4;
 
     /// A helper type to parse Args more easily
@@ -540,9 +541,9 @@ mod tests {
 
     #[test]
     fn test_rpc_server_args_parser_none() {
-        let args = CommandParser::<RpcServerArgs>::parse_from(["reth", "--http.api", "none"]).args;
+        let args = CommandParser::<RpcServerArgs>::parse_from(["reth", "--http.api"]).args;
         let apis = args.http_api.unwrap();
-        let expected = RpcModuleSelection::None;
+        let expected = Selection(vec![]);
         assert_eq!(apis, expected);
     }
 

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -683,6 +683,9 @@ impl FromStr for RpcModuleSelection {
     type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Ok(RpcModuleSelection::None)
+        }
         let mut modules = s.split(',').map(str::trim).peekable();
         let first = modules.peek().copied().ok_or(ParseError::VariantNotFound)?;
         match first {
@@ -730,8 +733,6 @@ pub enum RethRpcModule {
     Reth,
     /// `ots_` module
     Ots,
-    /// none
-    None,
 }
 
 // === impl RethRpcModule ===
@@ -1038,7 +1039,6 @@ where
                                 .into_rpc()
                                 .into()
                         }
-                        RethRpcModule::None => Methods::default(),
                     })
                     .clone()
             })
@@ -2139,11 +2139,11 @@ mod tests {
 
     #[test]
     fn test_configure_transport_config_none() {
-        let config = TransportRpcModuleConfig::default().with_http([RethRpcModule::None]);
+        let config = TransportRpcModuleConfig::default().with_http(Vec::<RethRpcModule>::new());
         assert_eq!(
             config,
             TransportRpcModuleConfig {
-                http: Some(RpcModuleSelection::Selection(vec![RethRpcModule::None])),
+                http: Some(RpcModuleSelection::Selection(vec![])),
                 ws: None,
                 ipc: None,
                 config: None,


### PR DESCRIPTION
Hi @mattsse as agreed I am opening this PR in order to enable to start a reth node with empty http.api modules. This is required for any user who just wants to enable some custom RPC namespace.

