### PR TITLE
chore: remove ckzg dep from rpc types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6476,7 +6476,6 @@ dependencies = [
  "alloy-rlp",
  "arbitrary",
  "bytes",
- "c-kzg",
  "itertools 0.11.0",
  "jsonrpsee-types",
  "proptest",

--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -363,7 +363,7 @@ mod tests {
         let end = format!("reth/logs/{}", SUPPORTED_CHAINS[0]);
         assert!(log_dir.as_ref().ends_with(end), "{:?}", log_dir);
 
-        let mut iter = SUPPORTED_CHAINS.into_iter();
+        let mut iter = SUPPORTED_CHAINS.iter();
         iter.next();
         for chain in iter {
             let mut reth = Cli::<()>::try_parse_from(["reth", "node", "--chain", chain]).unwrap();

--- a/crates/payload/builder/src/payload.rs
+++ b/crates/payload/builder/src/payload.rs
@@ -12,7 +12,7 @@ use reth_rpc_types::engine::{
 
 use reth_rpc_types_compat::engine::payload::{
     block_to_payload_v3, convert_block_to_payload_field_v2,
-    convert_standalone_withdraw_to_withdrawal, from_primitive_sidecar, try_block_to_payload_v1,
+    convert_standalone_withdraw_to_withdrawal, try_block_to_payload_v1,
 };
 use revm_primitives::{BlobExcessGasAndPrice, BlockEnv, CfgEnv, SpecId};
 
@@ -116,11 +116,7 @@ impl From<BuiltPayload> for ExecutionPayloadEnvelopeV3 {
             // Spec:
             // <https://github.com/ethereum/execution-apis/blob/fe8e13c288c592ec154ce25c534e26cb7ce0530d/src/engine/cancun.md#specification-2>
             should_override_builder: false,
-            blobs_bundle: sidecars
-                .into_iter()
-                .map(from_primitive_sidecar)
-                .collect::<Vec<_>>()
-                .into(),
+            blobs_bundle: sidecars.into_iter().map(Into::into).collect::<Vec<_>>().into(),
         }
     }
 }

--- a/crates/primitives/src/transaction/sidecar.rs
+++ b/crates/primitives/src/transaction/sidecar.rs
@@ -353,6 +353,20 @@ impl BlobTransactionSidecar {
     }
 }
 
+impl From<reth_rpc_types::BlobTransactionSidecar> for BlobTransactionSidecar {
+    fn from(value: reth_rpc_types::BlobTransactionSidecar) -> Self {
+        // SAFETY: Same repr and size
+        unsafe { std::mem::transmute(value) }
+    }
+}
+
+impl From<BlobTransactionSidecar> for reth_rpc_types::BlobTransactionSidecar {
+    fn from(value: BlobTransactionSidecar) -> Self {
+        // SAFETY: Same repr and size
+        unsafe { std::mem::transmute(value) }
+    }
+}
+
 // Wrapper for c-kzg rlp
 #[repr(C)]
 struct BlobTransactionSidecarRlp {
@@ -363,6 +377,9 @@ struct BlobTransactionSidecarRlp {
 
 const _: [(); std::mem::size_of::<BlobTransactionSidecar>()] =
     [(); std::mem::size_of::<BlobTransactionSidecarRlp>()];
+
+const _: [(); std::mem::size_of::<BlobTransactionSidecar>()] =
+    [(); std::mem::size_of::<reth_rpc_types::BlobTransactionSidecar>()];
 
 impl BlobTransactionSidecarRlp {
     fn wrap_ref(other: &BlobTransactionSidecar) -> &Self {

--- a/crates/rpc/rpc-types-compat/src/engine/payload.rs
+++ b/crates/rpc/rpc-types-compat/src/engine/payload.rs
@@ -360,18 +360,6 @@ pub fn convert_to_payload_body_v1(value: Block) -> ExecutionPayloadBodyV1 {
     ExecutionPayloadBodyV1 { transactions: transactions.collect(), withdrawals: withdraw }
 }
 
-/// Transforms a [reth_primitives::BlobTransactionSidecar] into a
-/// [reth_rpc_types::BlobTransactionSidecar]
-pub fn from_primitive_sidecar(
-    sidecar: reth_primitives::BlobTransactionSidecar,
-) -> reth_rpc_types::BlobTransactionSidecar {
-    reth_rpc_types::BlobTransactionSidecar {
-        blobs: sidecar.blobs,
-        commitments: sidecar.commitments,
-        proofs: sidecar.proofs,
-    }
-}
-
 /// Transforms a [SealedBlock] into a [ExecutionPayloadV1]
 pub fn execution_payload_from_sealed_block(value: SealedBlock) -> ExecutionPayloadV1 {
     let transactions = value
@@ -403,10 +391,9 @@ pub fn execution_payload_from_sealed_block(value: SealedBlock) -> ExecutionPaylo
 
 #[cfg(test)]
 mod tests {
+    use super::{block_to_payload_v3, try_payload_v3_to_block};
     use reth_primitives::{hex, Bytes, U256};
     use reth_rpc_types::{engine::ExecutionPayloadV3, ExecutionPayloadV1, ExecutionPayloadV2};
-
-    use super::{block_to_payload_v3, try_payload_v3_to_block};
 
     #[test]
     fn roundtrip_payload_to_block() {

--- a/crates/rpc/rpc-types/Cargo.toml
+++ b/crates/rpc/rpc-types/Cargo.toml
@@ -20,7 +20,6 @@ serde_with = "3.3"
 serde_json.workspace = true
 jsonrpsee-types = { workspace = true, optional = true }
 alloy-primitives = { workspace = true, features = ["rand", "rlp", "serde"] }
-c-kzg = { workspace = true, features = ["serde"] }
 url = "2.3"
 # necessary so we don't hit a "undeclared 'std'":
 # https://github.com/paradigmxyz/reth/pull/177#discussion_r1021172198

--- a/crates/rpc/rpc-types/src/eth/engine/payload.rs
+++ b/crates/rpc/rpc-types/src/eth/engine/payload.rs
@@ -204,8 +204,11 @@ pub struct BlobsBundleV1 {
     pub blobs: Vec<Blob>,
 }
 
-impl From<Vec<BlobTransactionSidecar>> for BlobsBundleV1 {
-    fn from(sidecars: Vec<BlobTransactionSidecar>) -> Self {
+impl BlobsBundleV1 {
+    /// Creates a new blob bundle from the given sidecars.
+    ///
+    /// This folds the sidecar fields into single commit, proof, and blob vectors.
+    pub fn new(sidecars: impl IntoIterator<Item = BlobTransactionSidecar>) -> Self {
         let (commitments, proofs, blobs) = sidecars.into_iter().fold(
             (Vec::new(), Vec::new(), Vec::new()),
             |(mut commitments, mut proofs, mut blobs), sidecar| {
@@ -217,9 +220,7 @@ impl From<Vec<BlobTransactionSidecar>> for BlobsBundleV1 {
         );
         Self { commitments, proofs, blobs }
     }
-}
 
-impl BlobsBundleV1 {
     /// Take `len` blob data from the bundle.
     ///
     /// # Panics
@@ -231,6 +232,22 @@ impl BlobsBundleV1 {
             self.proofs.drain(0..len).collect(),
             self.blobs.drain(0..len).collect(),
         )
+    }
+
+    /// Returns the sidecar from the bundle
+    ///
+    /// # Panics
+    ///
+    /// If len is more than the blobs bundle len.
+    pub fn pop_sidecar(&mut self, len: usize) -> BlobTransactionSidecar {
+        let (commitments, proofs, blobs) = self.take(len);
+        BlobTransactionSidecar { commitments, proofs, blobs }
+    }
+}
+
+impl From<Vec<BlobTransactionSidecar>> for BlobsBundleV1 {
+    fn from(sidecars: Vec<BlobTransactionSidecar>) -> Self {
+        Self::new(sidecars)
     }
 }
 

--- a/crates/rpc/rpc-types/src/eth/engine/payload.rs
+++ b/crates/rpc/rpc-types/src/eth/engine/payload.rs
@@ -1,7 +1,9 @@
-use crate::eth::transaction::BlobTransactionSidecar;
 pub use crate::Withdrawal;
+use crate::{
+    eth::transaction::BlobTransactionSidecar,
+    kzg::{Blob, Bytes48},
+};
 use alloy_primitives::{Address, Bloom, Bytes, B256, B64, U256};
-use c_kzg::{Blob, Bytes48};
 use serde::{ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
 
 /// The execution payload body response that allows for `null` values.

--- a/crates/rpc/rpc-types/src/eth/transaction/kzg.rs
+++ b/crates/rpc/rpc-types/src/eth/transaction/kzg.rs
@@ -1,0 +1,12 @@
+//! KZG type bindings
+
+use alloy_primitives::FixedBytes;
+
+/// How many bytes are in a blob
+pub const BYTES_PER_BLOB: usize = 131072;
+
+/// A Blob serialized as 0x-prefixed hex string
+pub type Blob = FixedBytes<BYTES_PER_BLOB>;
+
+/// A commitment/proof serialized as 0x-prefixed hex string
+pub type Bytes48 = FixedBytes<48>;

--- a/crates/rpc/rpc-types/src/eth/transaction/mod.rs
+++ b/crates/rpc/rpc-types/src/eth/transaction/mod.rs
@@ -11,6 +11,7 @@ pub use typed::*;
 
 mod access_list;
 mod common;
+pub mod kzg;
 mod receipt;
 mod request;
 mod signature;

--- a/crates/rpc/rpc-types/src/eth/transaction/typed.rs
+++ b/crates/rpc/rpc-types/src/eth/transaction/typed.rs
@@ -3,10 +3,12 @@
 //! transaction deserialized from the json input of an RPC call. Depending on what fields are set,
 //! it can be converted into the container type [`TypedTransactionRequest`].
 
-use crate::eth::transaction::AccessList;
+use crate::{
+    eth::transaction::AccessList,
+    kzg::{Blob, Bytes48},
+};
 use alloy_primitives::{Address, Bytes, B256, U128, U256, U64};
 use alloy_rlp::{BufMut, Decodable, Encodable, Error as RlpError};
-use c_kzg::{Blob, Bytes48};
 use serde::{Deserialize, Serialize};
 
 /// Container type for various Ethereum transaction requests
@@ -136,6 +138,7 @@ impl Decodable for TransactionKind {
 
 /// This represents a set of blobs, and its corresponding commitments and proofs.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[repr(C)]
 pub struct BlobTransactionSidecar {
     /// The blob data.
     pub blobs: Vec<Blob>,


### PR DESCRIPTION
removes ckzg dep from rpc-types

used transmute for conversion between rpc and primitive, since same layout, Fixedbytes is just a transparent array

but can make this safe with

https://github.com/ethereum/c-kzg-4844/pull/380