### PR TITLE
feat(rpc-type) : make  TraceCallRequest with Default Trait 

### DIFF
--- a/crates/rpc/rpc-types/src/eth/trace/tracerequest.rs
+++ b/crates/rpc/rpc-types/src/eth/trace/tracerequest.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
 /// Container type for `trace_call` arguments
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 pub struct TraceCallRequest {
     /// call request object
     pub call: CallRequest,


### PR DESCRIPTION
Updated the TraceCallRequest struct to include the Default trait, this is useful for writing test blocks