### PR TITLE
chore: add @evalir to CODEOWNERS for rpc types related crates

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,6 +8,8 @@ crates/stages/              @onbjerg @rkrasiuk @shekhirin
 crates/storage/             @rakita @joshieDo
 crates/transaction-pool/    @mattsse
 crates/rpc/                 @mattsse @Rjected
+crates/rpc/rpc-types        @mattsse @Rjected @Evalir
+crates/rpc/rpc-types-compat @mattsse @Rjected @Evalir
 crates/payload/             @mattsse @Rjected
 crates/consensus/auto-seal  @mattsse
 crates/consensus/beacon     @rkrasiuk @mattsse @Rjected


### PR DESCRIPTION
Discussed with @mattsse — we'll eventually move to alloy-rpc-types, but in the meanwhile will help maintain this section and add any ergonomics missing on here to ensure both are in-sync in the meanwhile