### PR TITLE
feat(bin) : refactor ZeroAsNone struct to a Macro 

### DIFF
--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     args::{
-        types::{MaxU32, ZeroAsNone},
+        types::{MaxU32, ZeroAsNoneU64},
         GasPriceOracleArgs,
     },
     cli::{
@@ -157,12 +157,12 @@ pub struct RpcServerArgs {
     pub rpc_max_tracing_requests: u32,
 
     /// Maximum number of blocks that could be scanned per filter request. (0 = entire chain)
-    #[arg(long, value_name = "COUNT", default_value_t = ZeroAsNone::new(constants::DEFAULT_MAX_BLOCKS_PER_FILTER))]
-    pub rpc_max_blocks_per_filter: ZeroAsNone,
+    #[arg(long, value_name = "COUNT", default_value_t = ZeroAsNoneU64::new(constants::DEFAULT_MAX_BLOCKS_PER_FILTER))]
+    pub rpc_max_blocks_per_filter: ZeroAsNoneU64,
 
     /// Maximum number of logs that can be returned in a single response. (0 = no limit)
-    #[arg(long, value_name = "COUNT", default_value_t = ZeroAsNone::new(constants::DEFAULT_MAX_LOGS_PER_RESPONSE as u64))]
-    pub rpc_max_logs_per_response: ZeroAsNone,
+    #[arg(long, value_name = "COUNT", default_value_t = ZeroAsNoneU64::new(constants::DEFAULT_MAX_LOGS_PER_RESPONSE as u64))]
+    pub rpc_max_logs_per_response: ZeroAsNoneU64,
 
     /// Maximum gas limit for `eth_call` and call tracing RPC methods.
     #[arg(

--- a/bin/reth/src/args/types.rs
+++ b/bin/reth/src/args/types.rs
@@ -2,6 +2,8 @@
 
 use std::{fmt, num::ParseIntError, str::FromStr};
 
+/// A macro that generates types that maps "0" to "None" when parsing CLI arguments.
+
 macro_rules! zero_as_none {
     ($type_name:ident, $inner_type:ty) => {
         #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -40,8 +42,10 @@ macro_rules! zero_as_none {
     };
 }
 
-zero_as_none!(ZeroAsNone, u64);
+zero_as_none!(ZeroAsNoneU64, u64);
+zero_as_none!(ZeroAsNoneU32, u32);
 
+/// A macro that generates types that map "max" to "MAX" when parsing CLI arguments.
 macro_rules! max_values {
     ($name:ident, $ty:ident) => {
         #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -84,14 +88,15 @@ macro_rules! max_values {
 }
 max_values!(MaxU32, u32);
 max_values!(MaxU64, u64);
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_zero_parse() {
-        let val = "0".parse::<ZeroAsNone>().unwrap();
-        assert_eq!(val, ZeroAsNone(None));
+        let val = "0".parse::<ZeroAsNoneU64>().unwrap();
+        assert_eq!(val, ZeroAsNoneU64(None));
         assert_eq!(val.unwrap_or_max(), u64::MAX);
     }
 }

--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -363,7 +363,7 @@ mod tests {
         let end = format!("reth/logs/{}", SUPPORTED_CHAINS[0]);
         assert!(log_dir.as_ref().ends_with(end), "{:?}", log_dir);
 
-        let mut iter = SUPPORTED_CHAINS.into_iter();
+        let mut iter = SUPPORTED_CHAINS.iter();
         iter.next();
         for chain in iter {
             let mut reth = Cli::<()>::try_parse_from(["reth", "node", "--chain", chain]).unwrap();


### PR DESCRIPTION
refactored the ZeroAsNone struct into a macro, in future we would probably need ZeroAsNone for other type then u64, it wouuld become more easy to convert type to ZeroAsNone with this macros