### PR TITLE
feat(rpc-testing-utils) : make replay transactions reponses comparaison in RpcComparer.

### DIFF
--- a/crates/rpc/rpc-testing-util/Cargo.toml
+++ b/crates/rpc/rpc-testing-util/Cargo.toml
@@ -23,7 +23,9 @@ jsonrpsee = { workspace = true, features = ["client", "async-client"] }
 serde_json.workspace = true
 
 
-# Assertions
-pretty_assertions = "1.4.0"
+# assertions
+similar-asserts = "1.5.0"
+
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "rt"] }

--- a/crates/rpc/rpc-testing-util/Cargo.toml
+++ b/crates/rpc/rpc-testing-util/Cargo.toml
@@ -22,5 +22,8 @@ futures.workspace = true
 jsonrpsee = { workspace = true, features = ["client", "async-client"] }
 serde_json.workspace = true
 
+
+# Assertions
+pretty_assertions = "1.4.0"
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "rt"] }

--- a/crates/rpc/rpc-testing-util/src/trace.rs
+++ b/crates/rpc/rpc-testing-util/src/trace.rs
@@ -447,8 +447,9 @@ where
         while let Some((result1, result2)) = zipped_streams.next().await {
             match (result1, result2) {
                 (Ok((ref traces1_data, ref block1)), Ok((ref traces2_data, ref block2))) => {
-                    assert_eq!(
-                        traces1_data, traces2_data,
+                    pretty_assertions::assert_eq!(
+                        traces1_data,
+                        traces2_data,
                         "Mismatch in traces for block: {:?}",
                         block1
                     );
@@ -462,41 +463,6 @@ where
                         block1
                     );
                     assert_eq!(block1, block2, "Mismatch in block ids.");
-                }
-                _ => panic!("One client returned Ok while the other returned Err."),
-            }
-        }
-    }
-    /// Compares the `replay_transactions` responses from the two RPC clients.
-    pub async fn compare_replay_transaction_responses(
-        &self,
-        transaction_hashes: Vec<TxHash>,
-        trace_types: HashSet<TraceType>,
-    ) {
-        let stream1 =
-            self.client1.replay_transactions(transaction_hashes.clone(), trace_types.clone());
-        let stream2 = self.client2.replay_transactions(transaction_hashes, trace_types);
-
-        let mut zipped_streams = stream1.zip(stream2);
-
-        while let Some((result1, result2)) = zipped_streams.next().await {
-            match (result1, result2) {
-                (Ok((ref trace1_data, ref tx_hash1)), Ok((ref trace2_data, ref tx_hash2))) => {
-                    assert_eq!(
-                        trace1_data, trace2_data,
-                        "Mismatch in trace results for transaction: {:?}",
-                        tx_hash1
-                    );
-                    assert_eq!(tx_hash1, tx_hash2, "Mismatch in transaction hashes.");
-                }
-                (Err((ref err1, ref tx_hash1)), Err((ref err2, ref tx_hash2))) => {
-                    assert_eq!(
-                        format!("{:?}", err1),
-                        format!("{:?}", err2),
-                        "Different errors for transaction: {:?}",
-                        tx_hash1
-                    );
-                    assert_eq!(tx_hash1, tx_hash2, "Mismatch in transaction hashes.");
                 }
                 _ => panic!("One client returned Ok while the other returned Err."),
             }

--- a/crates/rpc/rpc-testing-util/src/trace.rs
+++ b/crates/rpc/rpc-testing-util/src/trace.rs
@@ -447,7 +447,7 @@ where
         while let Some((result1, result2)) = zipped_streams.next().await {
             match (result1, result2) {
                 (Ok((ref traces1_data, ref block1)), Ok((ref traces2_data, ref block2))) => {
-                    pretty_assertions::assert_eq!(
+                    similar_asserts::assert_eq!(
                         traces1_data,
                         traces2_data,
                         "Mismatch in traces for block: {:?}",
@@ -484,7 +484,7 @@ where
         while let Some((result1, result2)) = zipped_streams.next().await {
             match (result1, result2) {
                 (Ok((ref trace1_data, ref tx_hash1)), Ok((ref trace2_data, ref tx_hash2))) => {
-                    pretty_assertions::assert_eq!(
+                    similar_asserts::assert_eq!(
                         trace1_data,
                         trace2_data,
                         "Mismatch in trace results for transaction: {:?}",

--- a/crates/rpc/rpc-testing-util/src/trace.rs
+++ b/crates/rpc/rpc-testing-util/src/trace.rs
@@ -468,6 +468,43 @@ where
             }
         }
     }
+
+    /// Compares the `replay_transactions` responses from the two RPC clients.
+    pub async fn compare_replay_transaction_responses(
+        &self,
+        transaction_hashes: Vec<TxHash>,
+        trace_types: HashSet<TraceType>,
+    ) {
+        let stream1 =
+            self.client1.replay_transactions(transaction_hashes.clone(), trace_types.clone());
+        let stream2 = self.client2.replay_transactions(transaction_hashes, trace_types);
+
+        let mut zipped_streams = stream1.zip(stream2);
+
+        while let Some((result1, result2)) = zipped_streams.next().await {
+            match (result1, result2) {
+                (Ok((ref trace1_data, ref tx_hash1)), Ok((ref trace2_data, ref tx_hash2))) => {
+                    pretty_assertions::assert_eq!(
+                        trace1_data,
+                        trace2_data,
+                        "Mismatch in trace results for transaction: {:?}",
+                        tx_hash1
+                    );
+                    assert_eq!(tx_hash1, tx_hash2, "Mismatch in transaction hashes.");
+                }
+                (Err((ref err1, ref tx_hash1)), Err((ref err2, ref tx_hash2))) => {
+                    assert_eq!(
+                        format!("{:?}", err1),
+                        format!("{:?}", err2),
+                        "Different errors for transaction: {:?}",
+                        tx_hash1
+                    );
+                    assert_eq!(tx_hash1, tx_hash2, "Mismatch in transaction hashes.");
+                }
+                _ => panic!("One client returned Ok while the other returned Err."),
+            }
+        }
+    }
 }
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This pr introduces a new feature to the RpcComparer struct by adding the compare_replay_transaction_responses. This handle comparisons of replay_transactions responses from two different RPC clients example would be reth & geth