### PR TITLE
meta: add @joshieDo to snapshot codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -19,4 +19,5 @@ crates/metrics              @onbjerg
 crates/tracing              @onbjerg
 crates/tasks                @mattsse
 crates/prune                @shekhirin @joshieDo
+crates/snapshot             @joshieDo
 .github/                    @onbjerg @gakonst @DaniPopes


### PR DESCRIPTION
## Description

Add @joshieDo to `snapshot` code owners.