### PR TITLE
feat(rpc-testing-utils) : implement debug_traceCall JSON-RPC method

### DIFF
--- a/crates/rpc/rpc-testing-util/src/debug.rs
+++ b/crates/rpc/rpc-testing-util/src/debug.rs
@@ -4,8 +4,10 @@ use futures::{Stream, StreamExt};
 use jsonrpsee::core::Error as RpcError;
 use reth_primitives::{BlockId, TxHash, B256};
 use reth_rpc_api::{clients::DebugApiClient, EthApiClient};
-use reth_rpc_types::trace::geth::{GethDebugTracerType, GethDebugTracingOptions};
-use reth_rpc_types::CallRequest;
+use reth_rpc_types::{
+    trace::geth::{GethDebugTracerType, GethDebugTracingOptions},
+    CallRequest,
+};
 use std::{
     pin::Pin,
     task::{Context, Poll},


### PR DESCRIPTION
this PR Introduced debug_trace_call_json in DebugApiExt.  Now, tracing calls is simpler and more insightful! 🚀🔍