### PR TITLE
Fix wrong check regarding EIP-155

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -71,7 +71,7 @@ pub fn validate_transaction_regarding_header(
     let chain_id = match transaction {
         Transaction::Legacy(TxLegacy { chain_id, .. }) => {
             // EIP-155: Simple replay attack protection: https://eips.ethereum.org/EIPS/eip-155
-            if chain_spec.fork(Hardfork::SpuriousDragon).active_at_block(at_block_number) &&
+            if !chain_spec.fork(Hardfork::SpuriousDragon).active_at_block(at_block_number) &&
                 chain_id.is_some()
             {
                 return Err(InvalidTransactionError::OldLegacyChainId.into())


### PR DESCRIPTION
The current logic throws the error "transactions before Spurious Dragon should not have a chain ID" if Spurios Dragon **is active** at the given block and the chain_id is set (in a legacy Tx).

From my reading of the error message this seems to be wrong and the first condition should be negated so that the error is only thrown if SpuriosDragon **is not active**.