### PR TITLE
chore: remove unnecessary async_trait usage

### DIFF
--- a/crates/interfaces/src/consensus.rs
+++ b/crates/interfaces/src/consensus.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use reth_primitives::{
     BlockHash, BlockNumber, GotExpected, GotExpectedBoxed, Header, InvalidTransactionError,
     SealedBlock, SealedHeader, B256, U256,
@@ -9,7 +8,6 @@ use std::fmt::Debug;
 pub use reth_rpc_types::engine::ForkchoiceState;
 
 /// Consensus is a protocol that chooses canonical chain.
-#[async_trait]
 #[auto_impl::auto_impl(&, Arc)]
 pub trait Consensus: Debug + Send + Sync {
     /// Validate if header is correct and follows consensus specification.

--- a/crates/interfaces/src/test_utils/bodies.rs
+++ b/crates/interfaces/src/test_utils/bodies.rs
@@ -4,7 +4,6 @@ use crate::p2p::{
     error::PeerRequestResult,
     priority::Priority,
 };
-use async_trait::async_trait;
 use futures::{future, Future, FutureExt};
 use reth_primitives::{BlockBody, WithPeerId, B256};
 use std::{

--- a/crates/interfaces/src/test_utils/headers.rs
+++ b/crates/interfaces/src/test_utils/headers.rs
@@ -282,7 +282,6 @@ impl TestConsensus {
     }
 }
 
-#[async_trait::async_trait]
 impl Consensus for TestConsensus {
     fn validate_header(&self, _header: &SealedHeader) -> Result<(), ConsensusError> {
         if self.fail_validation() {

--- a/crates/stages/src/test_utils/runner.rs
+++ b/crates/stages/src/test_utils/runner.rs
@@ -18,7 +18,6 @@ pub(crate) enum TestRunnerError {
 }
 
 /// A generic test runner for stages.
-#[async_trait::async_trait]
 pub(crate) trait StageTestRunner {
     type S: Stage<DatabaseEnv> + 'static;
 

--- a/crates/transaction-pool/src/test_utils/mod.rs
+++ b/crates/transaction-pool/src/test_utils/mod.rs
@@ -9,7 +9,6 @@ use crate::{
     blobstore::InMemoryBlobStore, noop::MockTransactionValidator, Pool, PoolTransaction,
     TransactionOrigin, TransactionValidationOutcome, TransactionValidator,
 };
-use async_trait::async_trait;
 pub use gen::*;
 pub use mock::*;
 use std::{marker::PhantomData, sync::Arc};


### PR DESCRIPTION
## Description

Remove `async_trait` from traits that do not have async functions.