### PR TITLE
chore: put env types into container type

### DIFF
--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -221,9 +221,9 @@ where
     }
 }
 
-/// Container type for Environment internals
+/// Container type for Environment internals.
 ///
-/// This olds the the raw pointer to the MDBX environment and the transaction manager.
+/// This holds the raw pointer to the MDBX environment and the transaction manager.
 /// The env is opened via [mdbx_env_create](ffi::mdbx_env_create) and closed when this type drops.
 struct EnvironmentInner<E> {
     env: *mut ffi::MDBX_env,

--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -70,9 +70,7 @@ pub struct Environment<E>
 where
     E: EnvironmentKind,
 {
-    env: *mut ffi::MDBX_env,
-    txn_manager: Option<SyncSender<TxnManagerMessage>>,
-    _marker: PhantomData<E>,
+    inner: EnvironmentInner<E>,
 }
 
 impl<E> Environment<E>
@@ -102,7 +100,7 @@ where
     /// Requires [Mode::ReadWrite] and returns None otherwise.
     #[inline]
     pub(crate) fn txn_manager(&self) -> Option<&SyncSender<TxnManagerMessage>> {
-        self.txn_manager.as_ref()
+        self.inner.txn_manager.as_ref()
     }
 
     /// Returns a raw pointer to the underlying MDBX environment.
@@ -111,7 +109,7 @@ where
     /// environment.
     #[inline]
     pub fn env(&self) -> *mut ffi::MDBX_env {
-        self.env
+        self.inner.env
     }
 
     /// Create a read-only transaction for use with the environment.
@@ -220,6 +218,26 @@ where
         }
 
         Ok(freelist)
+    }
+}
+
+/// Container type for Environment internals
+///
+/// This olds the the raw pointer to the MDBX environment and the transaction manager.
+/// The env is opened via [mdbx_env_create](ffi::mdbx_env_create) and closed when this type drops.
+struct EnvironmentInner<E> {
+    env: *mut ffi::MDBX_env,
+    txn_manager: Option<SyncSender<TxnManagerMessage>>,
+    _marker: PhantomData<E>,
+}
+
+impl<E> Drop for EnvironmentInner<E>
+{
+    fn drop(&mut self) {
+        // Close open mdbx environment on drop
+        unsafe {
+            ffi::mdbx_env_close_ex(self.env, false);
+        }
     }
 }
 
@@ -338,18 +356,7 @@ where
     E: EnvironmentKind,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Environment").finish()
-    }
-}
-
-impl<E> Drop for Environment<E>
-where
-    E: EnvironmentKind,
-{
-    fn drop(&mut self) {
-        unsafe {
-            ffi::mdbx_env_close_ex(self.env, false);
-        }
+        f.debug_struct("Environment").finish_non_exhaustive()
     }
 }
 
@@ -511,7 +518,7 @@ where
             }
         }
 
-        let mut env = Environment { env, txn_manager: None, _marker: PhantomData };
+        let mut env = EnvironmentInner { env, txn_manager: None, _marker: PhantomData };
 
         if let Mode::ReadWrite { .. } = self.flags.mode {
             let (tx, rx) = std::sync::mpsc::sync_channel(0);
@@ -556,7 +563,7 @@ where
             env.txn_manager = Some(tx);
         }
 
-        Ok(env)
+        Ok(Environment { inner: env })
     }
 
     /// Sets the provided options in the environment.


### PR DESCRIPTION
this will allow us to eventually put this in an arc so we no longer need to borrow an Environment