### PR TITLE
refactor: transaction internals

### DIFF
--- a/crates/storage/libmdbx-rs/src/database.rs
+++ b/crates/storage/libmdbx-rs/src/database.rs
@@ -1,7 +1,7 @@
 use crate::{
     environment::EnvironmentKind,
     error::{mdbx_result, Result},
-    transaction::{txn_execute, TransactionKind},
+    transaction::TransactionKind,
     Transaction,
 };
 use ffi::MDBX_db_flags_t;
@@ -29,9 +29,9 @@ impl<'txn> Database<'txn> {
         let c_name = name.map(|n| CString::new(n).unwrap());
         let name_ptr = if let Some(c_name) = &c_name { c_name.as_ptr() } else { ptr::null() };
         let mut dbi: ffi::MDBX_dbi = 0;
-        mdbx_result(txn_execute(&txn.txn_mutex(), |txn| unsafe {
-            ffi::mdbx_dbi_open(txn, name_ptr, flags, &mut dbi)
-        }))?;
+        mdbx_result(
+            txn.txn_execute(|txn| unsafe { ffi::mdbx_dbi_open(txn, name_ptr, flags, &mut dbi) }),
+        )?;
         Ok(Self::new_from_ptr(dbi))
     }
 


### PR DESCRIPTION
this changes the transaction internals to make it actually send+sync

* removed all Rc and raw mutex
* TransactionPtr synchronizes raw pointer access at all times


it now could actually be made Clone if we refactor it a bit more

I believe this can be made a bit nicer so we guarantee drop is called when the txn pointer drops, but would tackle this in a followup, maybe even get rid of the `Kind` traits
