### PR TITLE
feat: phase out environment trait

### DIFF
--- a/bin/reth/src/db/diff.rs
+++ b/bin/reth/src/db/diff.rs
@@ -17,7 +17,7 @@ use clap::Parser;
 use reth_db::{
     cursor::DbCursorRO, database::Database, open_db_read_only, table::Table, transaction::DbTx,
     AccountChangeSet, AccountHistory, AccountsTrie, BlockBodyIndices, BlockOmmers,
-    BlockWithdrawals, Bytecodes, CanonicalHeaders, DatabaseEnvRO, HashedAccount, HashedStorage,
+    BlockWithdrawals, Bytecodes, CanonicalHeaders, DatabaseEnv, HashedAccount, HashedStorage,
     HeaderNumbers, HeaderTD, Headers, PlainAccountState, PlainStorageState, PruneCheckpoints,
     Receipts, StorageChangeSet, StorageHistory, StoragesTrie, SyncStage, SyncStageProgress, Tables,
     TransactionBlock, Transactions, TxHashNumber, TxSenders,
@@ -58,7 +58,7 @@ impl Command {
     ///
     /// The discrepancies and extra elements, along with a brief summary of the diff results are
     /// then written to a file in the output directory.
-    pub fn execute(self, tool: &DbTool<'_, DatabaseEnvRO>) -> eyre::Result<()> {
+    pub fn execute(self, tool: &DbTool<'_, DatabaseEnv>) -> eyre::Result<()> {
         // open second db
         let second_db_path: PathBuf = self.secondary_datadir.join("db").into();
         let second_db = open_db_read_only(&second_db_path, self.second_db.log_level)?;

--- a/bin/reth/src/db/list.rs
+++ b/bin/reth/src/db/list.rs
@@ -2,7 +2,7 @@ use super::tui::DbListTUI;
 use crate::utils::{DbTool, ListFilter};
 use clap::Parser;
 use eyre::WrapErr;
-use reth_db::{database::Database, table::Table, DatabaseEnvRO, RawValue, TableViewer, Tables};
+use reth_db::{database::Database, table::Table, DatabaseEnv, RawValue, TableViewer, Tables};
 use reth_primitives::hex;
 use std::cell::RefCell;
 use tracing::error;
@@ -50,7 +50,7 @@ pub struct Command {
 
 impl Command {
     /// Execute `db list` command
-    pub fn execute(self, tool: &DbTool<'_, DatabaseEnvRO>) -> eyre::Result<()> {
+    pub fn execute(self, tool: &DbTool<'_, DatabaseEnv>) -> eyre::Result<()> {
         self.table.view(&ListTableViewer { tool, args: &self })
     }
 
@@ -81,7 +81,7 @@ impl Command {
 }
 
 struct ListTableViewer<'a> {
-    tool: &'a DbTool<'a, DatabaseEnvRO>,
+    tool: &'a DbTool<'a, DatabaseEnv>,
     args: &'a Command,
 }
 

--- a/bin/reth/src/db/snapshots/bench.rs
+++ b/bin/reth/src/db/snapshots/bench.rs
@@ -1,4 +1,4 @@
-use reth_db::DatabaseEnvRO;
+use reth_db::DatabaseEnv;
 use reth_primitives::{
     snapshot::{Compression, Filters},
     ChainSpec, SnapshotSegment,
@@ -16,7 +16,7 @@ pub(crate) enum BenchKind {
 
 pub(crate) fn bench<F1, F2, R>(
     bench_kind: BenchKind,
-    db: (DatabaseEnvRO, Arc<ChainSpec>),
+    db: (DatabaseEnv, Arc<ChainSpec>),
     segment: SnapshotSegment,
     filters: Filters,
     compression: Compression,
@@ -25,7 +25,7 @@ pub(crate) fn bench<F1, F2, R>(
 ) -> eyre::Result<()>
 where
     F1: FnMut() -> eyre::Result<R>,
-    F2: Fn(DatabaseProviderRO<'_, DatabaseEnvRO>) -> eyre::Result<R>,
+    F2: Fn(DatabaseProviderRO<'_, DatabaseEnv>) -> eyre::Result<R>,
     R: Debug + PartialEq,
 {
     let (db, chain) = db;

--- a/bin/reth/src/db/snapshots/mod.rs
+++ b/bin/reth/src/db/snapshots/mod.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use itertools::Itertools;
-use reth_db::{open_db_read_only, DatabaseEnvRO};
+use reth_db::{open_db_read_only, DatabaseEnv};
 use reth_interfaces::db::LogLevel;
 use reth_primitives::{
     snapshot::{Compression, InclusionFilter, PerfectHashingFunction},
@@ -71,22 +71,21 @@ impl Command {
             if !self.only_bench {
                 for ((mode, compression), phf) in all_combinations.clone() {
                     match mode {
-                        SnapshotSegment::Headers => self
-                            .generate_headers_snapshot::<DatabaseEnvRO>(
-                                &provider,
-                                *compression,
-                                InclusionFilter::Cuckoo,
-                                *phf,
-                            )?,
+                        SnapshotSegment::Headers => self.generate_headers_snapshot::<DatabaseEnv>(
+                            &provider,
+                            *compression,
+                            InclusionFilter::Cuckoo,
+                            *phf,
+                        )?,
                         SnapshotSegment::Transactions => self
-                            .generate_transactions_snapshot::<DatabaseEnvRO>(
+                            .generate_transactions_snapshot::<DatabaseEnv>(
                                 &provider,
                                 *compression,
                                 InclusionFilter::Cuckoo,
                                 *phf,
                             )?,
                         SnapshotSegment::Receipts => self
-                            .generate_receipts_snapshot::<DatabaseEnvRO>(
+                            .generate_receipts_snapshot::<DatabaseEnv>(
                                 &provider,
                                 *compression,
                                 InclusionFilter::Cuckoo,

--- a/crates/consensus/beacon/src/engine/sync.rs
+++ b/crates/consensus/beacon/src/engine/sync.rs
@@ -395,7 +395,7 @@ mod tests {
     use assert_matches::assert_matches;
     use futures::poll;
     use reth_db::{
-        mdbx::{Env, WriteMap},
+        mdbx::DatabaseEnv,
         test_utils::{create_test_rw_db, TempDatabase},
     };
     use reth_interfaces::{p2p::either::EitherDownloader, test_utils::TestFullBlockClient};
@@ -449,7 +449,7 @@ mod tests {
         }
 
         /// Builds the pipeline.
-        fn build(self, chain_spec: Arc<ChainSpec>) -> Pipeline<Arc<TempDatabase<Env<WriteMap>>>> {
+        fn build(self, chain_spec: Arc<ChainSpec>) -> Pipeline<Arc<TempDatabase<DatabaseEnv>>> {
             reth_tracing::init_test_tracing();
             let db = create_test_rw_db();
 

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -8,8 +8,7 @@ use crate::{
 };
 use reth_interfaces::db::LogLevel;
 use reth_libmdbx::{
-    DatabaseFlags, Environment, EnvironmentFlags, EnvironmentKind, Geometry, Mode, PageSize,
-    SyncMode, RO, RW,
+    DatabaseFlags, Environment, EnvironmentFlags, Geometry, Mode, PageSize, SyncMode, RO, RW,
 };
 use std::{ops::Deref, path::Path};
 use tx::Tx;
@@ -25,7 +24,7 @@ const DEFAULT_MAX_READERS: u64 = 32_000;
 
 /// Environment used when opening a MDBX environment. RO/RW.
 #[derive(Debug)]
-pub enum EnvKind {
+pub enum DatabaseEnvKind {
     /// Read-only MDBX environment.
     RO,
     /// Read-write MDBX environment.
@@ -34,19 +33,19 @@ pub enum EnvKind {
 
 /// Wrapper for the libmdbx environment.
 #[derive(Debug)]
-pub struct Env<E: EnvironmentKind> {
+pub struct DatabaseEnv {
     /// Libmdbx-sys environment.
-    pub inner: Environment<E>,
+    pub inner: Environment,
     /// Whether to record metrics or not.
     with_metrics: bool,
 }
 
-impl<'a, E: EnvironmentKind> DatabaseGAT<'a> for Env<E> {
-    type TX = tx::Tx<'a, RO, E>;
-    type TXMut = tx::Tx<'a, RW, E>;
+impl<'a> DatabaseGAT<'a> for DatabaseEnv {
+    type TX = tx::Tx<'a, RO>;
+    type TXMut = tx::Tx<'a, RW>;
 }
 
-impl<E: EnvironmentKind> Database for Env<E> {
+impl Database for DatabaseEnv {
     fn tx(&self) -> Result<<Self as DatabaseGAT<'_>>::TX, DatabaseError> {
         Ok(Tx::new_with_metrics(
             self.inner.begin_ro_txn().map_err(|e| DatabaseError::InitTx(e.into()))?,
@@ -62,21 +61,26 @@ impl<E: EnvironmentKind> Database for Env<E> {
     }
 }
 
-impl<E: EnvironmentKind> Env<E> {
+impl DatabaseEnv {
     /// Opens the database at the specified path with the given `EnvKind`.
     ///
-    /// It does not create the tables, for that call [`Env::create_tables`].
+    /// It does not create the tables, for that call [`DatabaseEnv::create_tables`].
     pub fn open(
         path: &Path,
-        kind: EnvKind,
+        kind: DatabaseEnvKind,
         log_level: Option<LogLevel>,
-    ) -> Result<Env<E>, DatabaseError> {
+    ) -> Result<DatabaseEnv, DatabaseError> {
+        let mut inner_env = Environment::builder();
+
         let mode = match kind {
-            EnvKind::RO => Mode::ReadOnly,
-            EnvKind::RW => Mode::ReadWrite { sync_mode: SyncMode::Durable },
+            DatabaseEnvKind::RO => Mode::ReadOnly,
+            DatabaseEnvKind::RW => {
+                // enable writemap mode in RW mode
+                inner_env.write_map();
+                Mode::ReadWrite { sync_mode: SyncMode::Durable }
+            }
         };
 
-        let mut inner_env = Environment::builder();
         inner_env.set_max_dbs(Tables::ALL.len());
         inner_env.set_geometry(Geometry {
             // Maximum database size of 4 terabytes
@@ -124,7 +128,7 @@ impl<E: EnvironmentKind> Env<E> {
             }
         }
 
-        let env = Env {
+        let env = DatabaseEnv {
             inner: inner_env.open(path).map_err(|e| DatabaseError::Open(e.into()))?,
             with_metrics: false,
         };
@@ -158,8 +162,8 @@ impl<E: EnvironmentKind> Env<E> {
     }
 }
 
-impl<E: EnvironmentKind> Deref for Env<E> {
-    type Target = Environment<E>;
+impl Deref for DatabaseEnv {
+    type Target = Environment;
 
     fn deref(&self) -> &Self::Target {
         &self.inner
@@ -180,13 +184,12 @@ mod tests {
         AccountChangeSet,
     };
     use reth_interfaces::db::{DatabaseWriteError, DatabaseWriteOperation};
-    use reth_libmdbx::{NoWriteMap, WriteMap};
     use reth_primitives::{Account, Address, Header, IntegerList, StorageEntry, B256, U256};
     use std::{path::Path, str::FromStr, sync::Arc};
     use tempfile::TempDir;
 
     /// Create database for testing
-    fn create_test_db<E: EnvironmentKind>(kind: EnvKind) -> Arc<Env<E>> {
+    fn create_test_db(kind: DatabaseEnvKind) -> Arc<DatabaseEnv> {
         Arc::new(create_test_db_with_path(
             kind,
             &tempfile::TempDir::new().expect(ERROR_TEMPDIR).into_path(),
@@ -194,8 +197,8 @@ mod tests {
     }
 
     /// Create database for testing with specified path
-    fn create_test_db_with_path<E: EnvironmentKind>(kind: EnvKind, path: &Path) -> Env<E> {
-        let env = Env::<E>::open(path, kind, None).expect(ERROR_DB_CREATION);
+    fn create_test_db_with_path(kind: DatabaseEnvKind, path: &Path) -> DatabaseEnv {
+        let env = DatabaseEnv::open(path, kind, None).expect(ERROR_DB_CREATION);
         env.create_tables().expect(ERROR_TABLE_CREATION);
         env
     }
@@ -212,12 +215,12 @@ mod tests {
 
     #[test]
     fn db_creation() {
-        create_test_db::<NoWriteMap>(EnvKind::RW);
+        create_test_db(DatabaseEnvKind::RW);
     }
 
     #[test]
     fn db_manual_put_get() {
-        let env = create_test_db::<NoWriteMap>(EnvKind::RW);
+        let env = create_test_db(DatabaseEnvKind::RW);
 
         let value = Header::default();
         let key = 1u64;
@@ -236,7 +239,7 @@ mod tests {
 
     #[test]
     fn db_cursor_walk() {
-        let env = create_test_db::<NoWriteMap>(EnvKind::RW);
+        let env = create_test_db(DatabaseEnvKind::RW);
 
         let value = Header::default();
         let key = 1u64;
@@ -261,7 +264,7 @@ mod tests {
 
     #[test]
     fn db_cursor_walk_range() {
-        let db: Arc<Env<WriteMap>> = create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEnv> = create_test_db(DatabaseEnvKind::RW);
 
         // PUT (0, 0), (1, 0), (2, 0), (3, 0)
         let tx = db.tx_mut().expect(ERROR_INIT_TX);
@@ -325,7 +328,7 @@ mod tests {
 
     #[test]
     fn db_cursor_walk_range_on_dup_table() {
-        let db: Arc<Env<WriteMap>> = create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEnv> = create_test_db(DatabaseEnvKind::RW);
 
         let address0 = Address::ZERO;
         let address1 = Address::with_last_byte(1);
@@ -367,7 +370,7 @@ mod tests {
     #[allow(clippy::reversed_empty_ranges)]
     #[test]
     fn db_cursor_walk_range_invalid() {
-        let db: Arc<Env<WriteMap>> = create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEnv> = create_test_db(DatabaseEnvKind::RW);
 
         // PUT (0, 0), (1, 0), (2, 0), (3, 0)
         let tx = db.tx_mut().expect(ERROR_INIT_TX);
@@ -395,7 +398,7 @@ mod tests {
 
     #[test]
     fn db_walker() {
-        let db: Arc<Env<WriteMap>> = create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEnv> = create_test_db(DatabaseEnvKind::RW);
 
         // PUT (0, 0), (1, 0), (3, 0)
         let tx = db.tx_mut().expect(ERROR_INIT_TX);
@@ -425,7 +428,7 @@ mod tests {
 
     #[test]
     fn db_reverse_walker() {
-        let db: Arc<Env<WriteMap>> = create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEnv> = create_test_db(DatabaseEnvKind::RW);
 
         // PUT (0, 0), (1, 0), (3, 0)
         let tx = db.tx_mut().expect(ERROR_INIT_TX);
@@ -455,7 +458,7 @@ mod tests {
 
     #[test]
     fn db_walk_back() {
-        let db: Arc<Env<WriteMap>> = create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEnv> = create_test_db(DatabaseEnvKind::RW);
 
         // PUT (0, 0), (1, 0), (3, 0)
         let tx = db.tx_mut().expect(ERROR_INIT_TX);
@@ -494,7 +497,7 @@ mod tests {
 
     #[test]
     fn db_cursor_seek_exact_or_previous_key() {
-        let db: Arc<Env<WriteMap>> = create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEnv> = create_test_db(DatabaseEnvKind::RW);
 
         // PUT
         let tx = db.tx_mut().expect(ERROR_INIT_TX);
@@ -520,7 +523,7 @@ mod tests {
 
     #[test]
     fn db_cursor_insert() {
-        let db: Arc<Env<WriteMap>> = create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEnv> = create_test_db(DatabaseEnvKind::RW);
 
         // PUT
         let tx = db.tx_mut().expect(ERROR_INIT_TX);
@@ -563,7 +566,7 @@ mod tests {
 
     #[test]
     fn db_cursor_insert_dup() {
-        let db: Arc<Env<WriteMap>> = create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEnv> = create_test_db(DatabaseEnvKind::RW);
         let tx = db.tx_mut().expect(ERROR_INIT_TX);
 
         let mut dup_cursor = tx.cursor_dup_write::<PlainStorageState>().unwrap();
@@ -581,7 +584,7 @@ mod tests {
 
     #[test]
     fn db_cursor_delete_current_non_existent() {
-        let db: Arc<Env<WriteMap>> = create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEnv> = create_test_db(DatabaseEnvKind::RW);
         let tx = db.tx_mut().expect(ERROR_INIT_TX);
 
         let key1 = Address::with_last_byte(1);
@@ -609,7 +612,7 @@ mod tests {
 
     #[test]
     fn db_cursor_insert_wherever_cursor_is() {
-        let db: Arc<Env<WriteMap>> = create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEnv> = create_test_db(DatabaseEnvKind::RW);
         let tx = db.tx_mut().expect(ERROR_INIT_TX);
 
         // PUT
@@ -642,7 +645,7 @@ mod tests {
 
     #[test]
     fn db_cursor_append() {
-        let db: Arc<Env<WriteMap>> = create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEnv> = create_test_db(DatabaseEnvKind::RW);
 
         // PUT
         let tx = db.tx_mut().expect(ERROR_INIT_TX);
@@ -669,7 +672,7 @@ mod tests {
 
     #[test]
     fn db_cursor_append_failure() {
-        let db: Arc<Env<WriteMap>> = create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEnv> = create_test_db(DatabaseEnvKind::RW);
 
         // PUT
         let tx = db.tx_mut().expect(ERROR_INIT_TX);
@@ -706,7 +709,7 @@ mod tests {
 
     #[test]
     fn db_cursor_upsert() {
-        let db: Arc<Env<WriteMap>> = create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEnv> = create_test_db(DatabaseEnvKind::RW);
         let tx = db.tx_mut().expect(ERROR_INIT_TX);
 
         let mut cursor = tx.cursor_write::<PlainAccountState>().unwrap();
@@ -741,7 +744,7 @@ mod tests {
 
     #[test]
     fn db_cursor_dupsort_append() {
-        let db: Arc<Env<WriteMap>> = create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEnv> = create_test_db(DatabaseEnvKind::RW);
 
         let transition_id = 2;
 
@@ -810,28 +813,28 @@ mod tests {
             .expect(ERROR_ETH_ADDRESS);
 
         {
-            let env = create_test_db_with_path::<WriteMap>(EnvKind::RW, &path);
+            let env = create_test_db_with_path(DatabaseEnvKind::RW, &path);
 
             // PUT
             let result = env.update(|tx| {
                 tx.put::<PlainAccountState>(key, value).expect(ERROR_PUT);
                 200
             });
-            assert!(result.expect(ERROR_RETURN_VALUE) == 200);
+            assert_eq!(result.expect(ERROR_RETURN_VALUE), 200);
         }
 
-        let env = Env::<WriteMap>::open(&path, EnvKind::RO, None).expect(ERROR_DB_CREATION);
+        let env = DatabaseEnv::open(&path, DatabaseEnvKind::RO, None).expect(ERROR_DB_CREATION);
 
         // GET
         let result =
             env.view(|tx| tx.get::<PlainAccountState>(key).expect(ERROR_GET)).expect(ERROR_GET);
 
-        assert!(result == Some(value))
+        assert_eq!(result, Some(value))
     }
 
     #[test]
     fn db_dup_sort() {
-        let env = create_test_db::<NoWriteMap>(EnvKind::RW);
+        let env = create_test_db(DatabaseEnvKind::RW);
         let key = Address::from_str("0xa2c122be93b0074270ebee7f6b7292c7deb45047")
             .expect(ERROR_ETH_ADDRESS);
 
@@ -875,7 +878,7 @@ mod tests {
 
     #[test]
     fn db_iterate_over_all_dup_values() {
-        let env = create_test_db::<NoWriteMap>(EnvKind::RW);
+        let env = create_test_db(DatabaseEnvKind::RW);
         let key1 = Address::from_str("0x1111111111111111111111111111111111111111")
             .expect(ERROR_ETH_ADDRESS);
         let key2 = Address::from_str("0x2222222222222222222222222222222222222222")
@@ -921,7 +924,7 @@ mod tests {
 
     #[test]
     fn dup_value_with_same_subkey() {
-        let env = create_test_db::<NoWriteMap>(EnvKind::RW);
+        let env = create_test_db(DatabaseEnvKind::RW);
         let key1 = Address::new([0x11; 20]);
         let key2 = Address::new([0x22; 20]);
 
@@ -964,7 +967,7 @@ mod tests {
 
     #[test]
     fn db_sharded_key() {
-        let db: Arc<Env<WriteMap>> = create_test_db(EnvKind::RW);
+        let db: Arc<DatabaseEnv> = create_test_db(DatabaseEnvKind::RW);
         let real_key = Address::from_str("0xa2c122be93b0074270ebee7f6b7292c7deb45047").unwrap();
 
         for i in 1..5 {

--- a/crates/storage/libmdbx-rs/benches/utils.rs
+++ b/crates/storage/libmdbx-rs/benches/utils.rs
@@ -1,4 +1,4 @@
-use reth_libmdbx::{Environment, NoWriteMap, WriteFlags};
+use reth_libmdbx::{Environment, WriteFlags};
 use tempfile::{tempdir, TempDir};
 
 pub fn get_key(n: u32) -> String {
@@ -9,7 +9,7 @@ pub fn get_data(n: u32) -> String {
     format!("data{n}")
 }
 
-pub fn setup_bench_db(num_rows: u32) -> (TempDir, Environment<NoWriteMap>) {
+pub fn setup_bench_db(num_rows: u32) -> (TempDir, Environment) {
     let dir = tempdir().unwrap();
     let env = Environment::builder().open(dir.path()).unwrap();
 

--- a/crates/storage/libmdbx-rs/src/cursor.rs
+++ b/crates/storage/libmdbx-rs/src/cursor.rs
@@ -3,7 +3,7 @@ use crate::{
     flags::*,
     mdbx_try_optional,
     transaction::{TransactionKind, TransactionPtr, RW},
-    EnvironmentKind, TableObject, Transaction,
+    TableObject, Transaction,
 };
 use ffi::{
     MDBX_cursor_op, MDBX_FIRST, MDBX_FIRST_DUP, MDBX_GET_BOTH, MDBX_GET_BOTH_RANGE,
@@ -28,10 +28,7 @@ impl<'txn, K> Cursor<'txn, K>
 where
     K: TransactionKind,
 {
-    pub(crate) fn new<E: EnvironmentKind>(
-        txn: &'txn Transaction<'_, K, E>,
-        dbi: ffi::MDBX_dbi,
-    ) -> Result<Self> {
+    pub(crate) fn new(txn: &'txn Transaction<'_, K>, dbi: ffi::MDBX_dbi) -> Result<Self> {
         let mut cursor: *mut ffi::MDBX_cursor = ptr::null_mut();
         let txn = txn.txn_ptr();
         unsafe {

--- a/crates/storage/libmdbx-rs/src/database.rs
+++ b/crates/storage/libmdbx-rs/src/database.rs
@@ -1,5 +1,4 @@
 use crate::{
-    environment::EnvironmentKind,
     error::{mdbx_result, Result},
     transaction::TransactionKind,
     Transaction,
@@ -21,8 +20,8 @@ impl<'txn> Database<'txn> {
     ///
     /// Prefer using `Environment::open_db`, `Environment::create_db`, `TransactionExt::open_db`,
     /// or `RwTransaction::create_db`.
-    pub(crate) fn new<'env, K: TransactionKind, E: EnvironmentKind>(
-        txn: &'txn Transaction<'env, K, E>,
+    pub(crate) fn new<'env, K: TransactionKind>(
+        txn: &'txn Transaction<'env, K>,
         name: Option<&str>,
         flags: MDBX_db_flags_t,
     ) -> Result<Self> {

--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -11,7 +11,6 @@ use std::{
     ffi::CString,
     fmt,
     fmt::Debug,
-    marker::PhantomData,
     mem,
     ops::{Bound, RangeBounds},
     path::Path,
@@ -21,69 +20,41 @@ use std::{
     time::Duration,
 };
 
-/// Determines how the environment is opened.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum EnvironmentKind2 {
-    /// Open the environment in read-only mode.
-    ReadOnly,
-    /// Open the environment in read-write mode.
-    ReadWrite,
+/// Determines how data is mapped into memory
+///
+/// It only takes affect when the environment is opened.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EnvironmentKind {
+    /// Open the environment in default mode, without WRITEMAP.
+    #[default]
+    Default,
+    /// Open the environment as mdbx-WRITEMAP.
+    /// Use a writeable memory map unless the environment is opened as MDBX_RDONLY
+    /// ([Mode::ReadOnly]).
+    ///
+    /// All data will be mapped into memory in the read-write mode [Mode::ReadWrite]. This offers a
+    /// significant performance benefit, since the data will be modified directly in mapped
+    /// memory and then flushed to disk by single system call, without any memory management
+    /// nor copying.
+    ///
+    /// This mode is incompatible with nested transactions.
+    WriteMap,
 }
 
-impl EnvironmentKind2 {
-
-    /// Returns true if the environment is read-only.
+impl EnvironmentKind {
+    /// Returns true if the environment was opened as WRITEMAP.
     #[inline]
-    pub const fn is_read_only(&self) -> bool {
-        matches!(self, EnvironmentKind2::ReadOnly)
-    }
-
-    /// Returns true if the environment is read-write.
-    #[inline]
-    pub const fn is_write_only(&self) -> bool {
-        matches!(self, EnvironmentKind2::ReadWrite)
+    pub const fn is_write_map(&self) -> bool {
+        matches!(self, EnvironmentKind::WriteMap)
     }
 
     /// Additional flags required when opening the environment.
     pub(crate) fn extra_flags(&self) -> ffi::MDBX_env_flags_t {
         match self {
-            EnvironmentKind2::ReadOnly => {
-                ffi::MDBX_ENV_DEFAULTS
-            }
-            EnvironmentKind2::ReadWrite => {
-                ffi::MDBX_WRITEMAP
-            }
+            EnvironmentKind::Default => ffi::MDBX_ENV_DEFAULTS,
+            EnvironmentKind::WriteMap => ffi::MDBX_WRITEMAP,
         }
     }
-
-}
-
-mod private {
-    use super::*;
-
-    pub trait Sealed {}
-
-    impl Sealed for NoWriteMap {}
-    impl Sealed for WriteMap {}
-}
-
-pub trait EnvironmentKind: private::Sealed + Debug + 'static {
-    const EXTRA_FLAGS: ffi::MDBX_env_flags_t;
-}
-
-#[derive(Debug)]
-#[non_exhaustive]
-pub struct NoWriteMap;
-
-#[derive(Debug)]
-#[non_exhaustive]
-pub struct WriteMap;
-
-impl EnvironmentKind for NoWriteMap {
-    const EXTRA_FLAGS: ffi::MDBX_env_flags_t = ffi::MDBX_ENV_DEFAULTS;
-}
-impl EnvironmentKind for WriteMap {
-    const EXTRA_FLAGS: ffi::MDBX_env_flags_t = ffi::MDBX_WRITEMAP;
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -103,20 +74,13 @@ pub(crate) enum TxnManagerMessage {
 }
 
 /// An environment supports multiple databases, all residing in the same shared-memory map.
-pub struct Environment<E>
-where
-    E: EnvironmentKind,
-{
+pub struct Environment {
     inner: EnvironmentInner,
-    _marker: PhantomData<E>,
 }
 
-impl<E> Environment<E>
-where
-    E: EnvironmentKind,
-{
+impl Environment {
     /// Creates a new builder for specifying options for opening an MDBX environment.
-    pub fn builder() -> EnvironmentBuilder<E> {
+    pub fn builder() -> EnvironmentBuilder {
         EnvironmentBuilder {
             flags: EnvironmentFlags::default(),
             max_readers: None,
@@ -129,8 +93,18 @@ where
             spill_min_denominator: None,
             geometry: None,
             log_level: None,
-            _marker: PhantomData,
+            kind: Default::default(),
         }
+    }
+
+    /// Returns true if the environment was opened as WRITEMAP.
+    pub fn is_write_map(&self) -> bool {
+        self.inner.env_kind.is_write_map()
+    }
+
+    /// Returns the kind of the environment.
+    pub fn env_kind(&self) -> EnvironmentKind {
+        self.inner.env_kind
     }
 
     /// Returns the manager that handles transaction messages.
@@ -152,13 +126,13 @@ where
 
     /// Create a read-only transaction for use with the environment.
     #[inline]
-    pub fn begin_ro_txn(&self) -> Result<Transaction<'_, RO, E>> {
+    pub fn begin_ro_txn(&self) -> Result<Transaction<'_, RO>> {
         Transaction::new(self)
     }
 
     /// Create a read-write transaction for use with the environment. This method will block while
     /// there are any other read-write transactions open on the environment.
-    pub fn begin_rw_txn(&self) -> Result<Transaction<'_, RW, E>> {
+    pub fn begin_rw_txn(&self) -> Result<Transaction<'_, RW>> {
         let sender = self.txn_manager().ok_or(Error::Access)?;
         let txn = loop {
             let (tx, rx) = sync_channel(0);
@@ -220,9 +194,8 @@ where
     ///
     /// ```
     /// # use reth_libmdbx::Environment;
-    /// # use reth_libmdbx::NoWriteMap;
     /// let dir = tempfile::tempdir().unwrap();
-    /// let env = Environment::<NoWriteMap>::builder().open(dir.path()).unwrap();
+    /// let env = Environment::builder().open(dir.path()).unwrap();
     /// let info = env.info().unwrap();
     /// let stat = env.stat().unwrap();
     /// let freelist = env.freelist().unwrap();
@@ -265,6 +238,7 @@ where
 /// The env is opened via [mdbx_env_create](ffi::mdbx_env_create) and closed when this type drops.
 struct EnvironmentInner {
     env: *mut ffi::MDBX_env,
+    env_kind: EnvironmentKind,
     txn_manager: Option<SyncSender<TxnManagerMessage>>,
 }
 
@@ -384,15 +358,12 @@ impl Info {
     }
 }
 
-unsafe impl<E> Send for Environment<E> where E: EnvironmentKind {}
-unsafe impl<E> Sync for Environment<E> where E: EnvironmentKind {}
+unsafe impl Send for Environment {}
+unsafe impl Sync for Environment {}
 
-impl<E> fmt::Debug for Environment<E>
-where
-    E: EnvironmentKind,
-{
+impl fmt::Debug for Environment {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Environment").finish_non_exhaustive()
+        f.debug_struct("Environment").field("kind", &self.inner.env_kind).finish_non_exhaustive()
     }
 }
 
@@ -422,10 +393,7 @@ impl<R> Default for Geometry<R> {
 
 /// Options for opening or creating an environment.
 #[derive(Debug, Clone)]
-pub struct EnvironmentBuilder<E>
-where
-    E: EnvironmentKind,
-{
+pub struct EnvironmentBuilder {
     flags: EnvironmentFlags,
     max_readers: Option<u64>,
     max_dbs: Option<u64>,
@@ -437,17 +405,14 @@ where
     spill_min_denominator: Option<u64>,
     geometry: Option<Geometry<(Option<usize>, Option<usize>)>>,
     log_level: Option<ffi::MDBX_log_level_t>,
-    _marker: PhantomData<E>,
+    kind: EnvironmentKind,
 }
 
-impl<E> EnvironmentBuilder<E>
-where
-    E: EnvironmentKind,
-{
+impl EnvironmentBuilder {
     /// Open an environment.
     ///
     /// Database files will be opened with 644 permissions.
-    pub fn open(&self, path: &Path) -> Result<Environment<E>> {
+    pub fn open(&self, path: &Path) -> Result<Environment> {
         self.open_with_permissions(path, 0o644)
     }
 
@@ -458,7 +423,7 @@ where
         &self,
         path: &Path,
         mode: ffi::mdbx_mode_t,
-    ) -> Result<Environment<E>> {
+    ) -> Result<Environment> {
         let mut env: *mut ffi::MDBX_env = ptr::null_mut();
         unsafe {
             if let Some(log_level) = self.log_level {
@@ -542,7 +507,7 @@ where
                 mdbx_result(ffi::mdbx_env_open(
                     env,
                     path.as_ptr(),
-                    self.flags.make_flags() | E::EXTRA_FLAGS,
+                    self.flags.make_flags() | self.kind.extra_flags(),
                     mode,
                 ))?;
 
@@ -554,7 +519,7 @@ where
             }
         }
 
-        let mut env = EnvironmentInner { env, txn_manager: None };
+        let mut env = EnvironmentInner { env, txn_manager: None, env_kind: self.kind };
 
         if let Mode::ReadWrite { .. } = self.flags.mode {
             let (tx, rx) = std::sync::mpsc::sync_channel(0);
@@ -599,7 +564,20 @@ where
             env.txn_manager = Some(tx);
         }
 
-        Ok(Environment { inner: env, _marker: Default::default() })
+        Ok(Environment { inner: env })
+    }
+
+    /// Configures how this environment will be opened.
+    pub fn set_kind(&mut self, kind: EnvironmentKind) -> &mut Self {
+        self.kind = kind;
+        self
+    }
+
+    /// Opens the environment with mdbx WRITEMAP
+    ///
+    /// See also [EnvironmentKind]
+    pub fn write_map(&mut self) -> &mut Self {
+        self.set_kind(EnvironmentKind::WriteMap)
     }
 
     /// Sets the provided options in the environment.

--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -21,6 +21,43 @@ use std::{
     time::Duration,
 };
 
+/// Determines how the environment is opened.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnvironmentKind2 {
+    /// Open the environment in read-only mode.
+    ReadOnly,
+    /// Open the environment in read-write mode.
+    ReadWrite,
+}
+
+impl EnvironmentKind2 {
+
+    /// Returns true if the environment is read-only.
+    #[inline]
+    pub const fn is_read_only(&self) -> bool {
+        matches!(self, EnvironmentKind2::ReadOnly)
+    }
+
+    /// Returns true if the environment is read-write.
+    #[inline]
+    pub const fn is_write_only(&self) -> bool {
+        matches!(self, EnvironmentKind2::ReadWrite)
+    }
+
+    /// Additional flags required when opening the environment.
+    pub(crate) fn extra_flags(&self) -> ffi::MDBX_env_flags_t {
+        match self {
+            EnvironmentKind2::ReadOnly => {
+                ffi::MDBX_ENV_DEFAULTS
+            }
+            EnvironmentKind2::ReadWrite => {
+                ffi::MDBX_WRITEMAP
+            }
+        }
+    }
+
+}
+
 mod private {
     use super::*;
 

--- a/crates/storage/libmdbx-rs/src/error.rs
+++ b/crates/storage/libmdbx-rs/src/error.rs
@@ -55,6 +55,7 @@ pub enum Error {
     Access,
     TooLarge,
     DecodeErrorLenDiff,
+    NestedTransactionsUnsupportedWithWriteMap,
     Other(i32),
 }
 

--- a/crates/storage/libmdbx-rs/src/flags.rs
+++ b/crates/storage/libmdbx-rs/src/flags.rs
@@ -28,11 +28,11 @@ pub enum SyncMode {
     /// are recycled the MVCC snapshots corresponding to previous "steady" transactions (see
     /// below).
     ///
-    /// With [crate::WriteMap] the [SyncMode::SafeNoSync] instructs MDBX to use asynchronous
-    /// mmap-flushes to disk. Asynchronous mmap-flushes means that actually all writes will
-    /// scheduled and performed by operation system on it own manner, i.e. unordered.
-    /// MDBX itself just notify operating system that it would be nice to write data to disk, but
-    /// no more.
+    /// With [crate::EnvironmentKind::WriteMap] the [SyncMode::SafeNoSync] instructs MDBX to use
+    /// asynchronous mmap-flushes to disk. Asynchronous mmap-flushes means that actually all
+    /// writes will scheduled and performed by operation system on it own manner, i.e.
+    /// unordered. MDBX itself just notify operating system that it would be nice to write data
+    /// to disk, but no more.
     ///
     /// Depending on the platform and hardware, with [SyncMode::SafeNoSync] you may get a multiple
     /// increase of write performance, even 10 times or more.
@@ -70,17 +70,18 @@ pub enum SyncMode {
     /// you may get a multiple increase of write performance, even 100 times or more.
     ///
     /// If the filesystem preserves write order (which is rare and never provided unless explicitly
-    /// noted) and the [WriteMap](crate::WriteMap) and [EnvironmentFlags::liforeclaim] flags are
-    /// not used, then a system crash can't corrupt the database, but you can lose the last
-    /// transactions, if at least one buffer is not yet flushed to disk. The risk is governed
-    /// by how often the system flushes dirty buffers to disk and how often
-    /// [Environment::sync()](crate::Environment::sync) is called. So, transactions exhibit ACI
-    /// (atomicity, consistency, isolation) properties and only lose D (durability).
-    /// I.e. database integrity is maintained, but a system crash may undo the final transactions.
+    /// noted) and the [WriteMap](crate::EnvironmentKind::WriteMap) and
+    /// [EnvironmentFlags::liforeclaim] flags are not used, then a system crash can't corrupt
+    /// the database, but you can lose the last transactions, if at least one buffer is not yet
+    /// flushed to disk. The risk is governed by how often the system flushes dirty buffers to
+    /// disk and how often [Environment::sync()](crate::Environment::sync) is called. So,
+    /// transactions exhibit ACI (atomicity, consistency, isolation) properties and only lose D
+    /// (durability). I.e. database integrity is maintained, but a system crash may undo the
+    /// final transactions.
     ///
     /// Otherwise, if the filesystem not preserves write order (which is typically) or
-    /// [WriteMap](crate::WriteMap) or [EnvironmentFlags::liforeclaim] flags are used, you should
-    /// expect the corrupted database after a system crash.
+    /// [WriteMap](crate::EnvironmentKind::WriteMap) or [EnvironmentFlags::liforeclaim] flags are
+    /// used, you should expect the corrupted database after a system crash.
     ///
     /// So, most important thing about [SyncMode::UtterlyNoSync]:
     /// - A system crash immediately after commit the write transaction high likely lead to

--- a/crates/storage/libmdbx-rs/src/lib.rs
+++ b/crates/storage/libmdbx-rs/src/lib.rs
@@ -15,8 +15,7 @@ pub use crate::{
     cursor::{Cursor, Iter, IterDup},
     database::Database,
     environment::{
-        Environment, EnvironmentBuilder, EnvironmentKind, Geometry, Info, NoWriteMap, PageSize,
-        Stat, WriteMap,
+        Environment, EnvironmentBuilder, EnvironmentKind, Geometry, Info, PageSize, Stat,
     },
     error::{Error, Result},
     flags::*,
@@ -39,8 +38,6 @@ mod test_utils {
     use super::*;
     use byteorder::{ByteOrder, LittleEndian};
     use tempfile::tempdir;
-
-    type Environment = crate::Environment<NoWriteMap>;
 
     /// Regression test for https://github.com/danburkert/lmdb-rs/issues/21.
     /// This test reliably segfaults when run against lmbdb compiled with opt level -O3 and newer

--- a/crates/storage/libmdbx-rs/tests/cursor.rs
+++ b/crates/storage/libmdbx-rs/tests/cursor.rs
@@ -2,8 +2,6 @@ use reth_libmdbx::*;
 use std::borrow::Cow;
 use tempfile::tempdir;
 
-type Environment = reth_libmdbx::Environment<NoWriteMap>;
-
 #[test]
 fn test_get() {
     let dir = tempdir().unwrap();

--- a/crates/storage/libmdbx-rs/tests/environment.rs
+++ b/crates/storage/libmdbx-rs/tests/environment.rs
@@ -2,8 +2,6 @@ use byteorder::{ByteOrder, LittleEndian};
 use reth_libmdbx::*;
 use tempfile::tempdir;
 
-type Environment = reth_libmdbx::Environment<NoWriteMap>;
-
 #[test]
 fn test_open() {
     let dir = tempdir().unwrap();

--- a/crates/storage/libmdbx-rs/tests/transaction.rs
+++ b/crates/storage/libmdbx-rs/tests/transaction.rs
@@ -7,8 +7,6 @@ use std::{
 };
 use tempfile::tempdir;
 
-type Environment = reth_libmdbx::Environment<NoWriteMap>;
-
 #[test]
 fn test_put_get_del() {
     let dir = tempdir().unwrap();


### PR DESCRIPTION
the environment kind was super cumbersome to work with, it's only used when the environment is openened.

It also only controls the WriteMap setting (see new docs) and __not__ the mode, which is a separate setting, but only takes affect if the DB is opened in RW mode.

naming can be discussed, and we can do a few more cleanups following this PR