### PR TITLE
chore: make it harder to misuse raw pointers

### DIFF
--- a/crates/storage/libmdbx-rs/src/error.rs
+++ b/crates/storage/libmdbx-rs/src/error.rs
@@ -56,6 +56,7 @@ pub enum Error {
     TooLarge,
     DecodeErrorLenDiff,
     NestedTransactionsUnsupportedWithWriteMap,
+    WriteTransactionUnsupportedInReadOnlyMode,
     Other(i32),
 }
 


### PR DESCRIPTION
replace direct pointer access with closures,

it's still possible to get the raw pointer like this but makes it harder to misuse.

we only need this in public API for benches