### PR TITLE
fix(net): check bounds on message logging

### DIFF
--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -242,9 +242,14 @@ where
         let msg = match ProtocolMessage::decode_message(*this.version, &mut bytes.as_ref()) {
             Ok(m) => m,
             Err(err) => {
+                let msg = if bytes.len() > 50 {
+                    format!("{:02x?}...{:x?}", &bytes[..10], &bytes[bytes.len() - 10..])
+                } else {
+                    format!("{:02x?}", bytes)
+                };
                 debug!(
                     version=?this.version,
-                    msg=format!("{:02x?}...{:x?}", &bytes[..10], &bytes[bytes.len() - 10..]),
+                    %msg,
                     "failed to decode protocol message"
                 );
                 return Poll::Ready(Some(Err(err)))


### PR DESCRIPTION
Caught in runtime
```console
thread 'tokio-runtime-worker' panicked at 'range end index 10 out of range for slice of length 5', /home/ubuntu/reth/crates/net/eth-wire/src/ethstream.rs:247:53
```