### PR TITLE
feat: add rpc-api trait for call bundle

### DIFF
--- a/crates/rpc/rpc-api/src/bundle.rs
+++ b/crates/rpc/rpc-api/src/bundle.rs
@@ -1,15 +1,28 @@
+//! Additional `eth_` functions for bundles
+//!
+//! See also <https://docs.flashbots.net/flashbots-auction/searchers/advanced/rpc-endpoint>
 use jsonrpsee::proc_macros::rpc;
 use reth_primitives::{Bytes, B256};
 use reth_rpc_types::{
-    CancelBundleRequest, CancelPrivateTransactionRequest, EthBundleHash, EthCallBundleResponse,
-    EthCallBundleTransactionResult, EthSendBundle, PrivateTransactionRequest,
+    CancelBundleRequest, CancelPrivateTransactionRequest, EthBundleHash, EthCallBundle,
+    EthCallBundleResponse, EthSendBundle, PrivateTransactionRequest,
 };
 
-/// Eth bundle rpc interface.
-///
-/// See also <https://docs.flashbots.net/flashbots-auction/searchers/advanced/rpc-endpoint>
+/// A subset of the [EthBundleApi] API interface that only supports `eth_callBundle`.
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "eth"))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "eth"))]
+#[async_trait::async_trait]
+pub trait EthCallBundleApi {
+    /// `eth_callBundle` can be used to simulate a bundle against a specific block number,
+    /// including simulating a bundle at the top of the next block.
+    #[method(name = "callBundle")]
+    async fn call_bundle(
+        &self,
+        request: EthCallBundle,
+    ) -> jsonrpsee::core::RpcResult<EthCallBundleResponse>;
+}
 
-/// Eth bundle rpc interface.
+/// The __full__ Eth bundle rpc interface.
 ///
 /// See also <https://docs.flashbots.net/flashbots-auction/searchers/advanced/rpc-endpoint>
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "eth"))]
@@ -26,8 +39,8 @@ pub trait EthBundleApi {
     #[method(name = "callBundle")]
     async fn call_bundle(
         &self,
-        request: EthCallBundleResponse,
-    ) -> jsonrpsee::core::RpcResult<EthCallBundleTransactionResult>;
+        request: EthCallBundle,
+    ) -> jsonrpsee::core::RpcResult<EthCallBundleResponse>;
 
     /// `eth_cancelBundle` is used to prevent a submitted bundle from being included on-chain. See [bundle cancellations](https://docs.flashbots.net/flashbots-auction/searchers/advanced/bundle-cancellations) for more information.
     #[method(name = "cancelBundle")]

--- a/crates/rpc/rpc-api/src/lib.rs
+++ b/crates/rpc/rpc-api/src/lib.rs
@@ -38,7 +38,7 @@ pub use servers::*;
 pub mod servers {
     pub use crate::{
         admin::AdminApiServer,
-        bundle::EthBundleApiServer,
+        bundle::{EthBundleApiServer, EthCallBundleApiServer},
         debug::DebugApiServer,
         engine::{EngineApiServer, EngineEthApiServer},
         eth::EthApiServer,
@@ -64,7 +64,7 @@ pub use clients::*;
 pub mod clients {
     pub use crate::{
         admin::AdminApiClient,
-        bundle::EthBundleApiClient,
+        bundle::{EthBundleApiClient, EthCallBundleApiClient},
         debug::DebugApiClient,
         engine::{EngineApiClient, EngineEthApiClient},
         eth::EthApiClient,

--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -9,12 +9,14 @@ use crate::{
     },
     BlockingTaskGuard,
 };
+use jsonrpsee::core::RpcResult;
 use reth_primitives::{
     keccak256,
     revm_primitives::db::{DatabaseCommit, DatabaseRef},
     U256,
 };
 use reth_revm::database::StateProviderDatabase;
+use reth_rpc_api::EthCallBundleApiServer;
 use reth_rpc_types::{EthCallBundle, EthCallBundleResponse, EthCallBundleTransactionResult};
 use revm::{
     db::CacheDB,
@@ -172,6 +174,16 @@ where
                 Ok(res)
             })
             .await
+    }
+}
+
+#[async_trait::async_trait]
+impl<Eth> EthCallBundleApiServer for EthBundle<Eth>
+where
+    Eth: EthTransactions + 'static,
+{
+    async fn call_bundle(&self, request: EthCallBundle) -> RpcResult<EthCallBundleResponse> {
+        Ok(EthBundle::call_bundle(self, request).await?)
     }
 }
 


### PR DESCRIPTION
adds a subset of the full EthBundle specifically for the single eth_callBundle handler, all others require custom infrastructure but this call is still useful on a vanilla node

ref https://github.com/paradigmxyz/reth/issues/5444