### PR TITLE
fix: fetch 4844 blob before reinjected reorged blob txs

### DIFF
--- a/crates/net/network/src/transactions.rs
+++ b/crates/net/network/src/transactions.rs
@@ -734,7 +734,7 @@ where
                     }
                     Entry::Vacant(entry) => {
                         // this is a new transaction that should be imported into the pool
-                        let pool_transaction = <Pool::Transaction as FromRecoveredPooledTransaction>::from_recovered_transaction(tx);
+                        let pool_transaction = <Pool::Transaction as FromRecoveredPooledTransaction>::from_recovered_pooled_transaction(tx);
 
                         let pool = self.pool.clone();
 

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1484,7 +1484,7 @@ impl FromRecoveredTransaction for TransactionSignedEcRecovered {
 #[cfg(feature = "c-kzg")]
 pub trait FromRecoveredPooledTransaction {
     /// Converts to this type from the given [`PooledTransactionsElementEcRecovered`].
-    fn from_recovered_transaction(tx: PooledTransactionsElementEcRecovered) -> Self;
+    fn from_recovered_pooled_transaction(tx: PooledTransactionsElementEcRecovered) -> Self;
 }
 
 /// The inverse of [`FromRecoveredTransaction`] that ensure the transaction can be sent over the

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -491,7 +491,7 @@ where
         self.forward_to_sequencer(&tx).await?;
 
         let recovered = recover_raw_transaction(tx)?;
-        let pool_transaction = <Pool::Transaction>::from_recovered_transaction(recovered);
+        let pool_transaction = <Pool::Transaction>::from_recovered_pooled_transaction(recovered);
 
         // submit the transaction to the pool with a `Local` origin
         let hash = self.pool().add_transaction(TransactionOrigin::Local, pool_transaction).await?;
@@ -578,7 +578,8 @@ where
         let recovered =
             signed_tx.into_ecrecovered().ok_or(EthApiError::InvalidTransactionSignature)?;
 
-        let pool_transaction = <Pool::Transaction>::from_recovered_transaction(recovered.into());
+        let pool_transaction =
+            <Pool::Transaction>::from_recovered_pooled_transaction(recovered.into());
 
         // submit the transaction to the pool with a `Local` origin
         let hash = self.pool().add_transaction(TransactionOrigin::Local, pool_transaction).await?;

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -778,7 +778,7 @@ impl FromRecoveredTransaction for MockTransaction {
 }
 
 impl FromRecoveredPooledTransaction for MockTransaction {
-    fn from_recovered_transaction(tx: PooledTransactionsElementEcRecovered) -> Self {
+    fn from_recovered_pooled_transaction(tx: PooledTransactionsElementEcRecovered) -> Self {
         FromRecoveredTransaction::from_recovered_transaction(tx.into_ecrecovered_transaction())
     }
 }

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -921,6 +921,10 @@ impl PoolTransaction for EthPooledTransaction {
         }
     }
 
+    fn access_list(&self) -> Option<&AccessList> {
+        self.transaction.access_list()
+    }
+
     /// Returns the EIP-1559 Priority fee the caller is paying to the block author.
     ///
     /// This will return `None` for non-EIP1559 transactions
@@ -937,10 +941,6 @@ impl PoolTransaction for EthPooledTransaction {
 
     fn max_fee_per_blob_gas(&self) -> Option<u128> {
         self.transaction.max_fee_per_blob_gas()
-    }
-
-    fn access_list(&self) -> Option<&AccessList> {
-        self.transaction.access_list()
     }
 
     /// Returns the effective tip for this transaction.
@@ -1029,7 +1029,7 @@ impl FromRecoveredTransaction for EthPooledTransaction {
 }
 
 impl FromRecoveredPooledTransaction for EthPooledTransaction {
-    fn from_recovered_transaction(tx: PooledTransactionsElementEcRecovered) -> Self {
+    fn from_recovered_pooled_transaction(tx: PooledTransactionsElementEcRecovered) -> Self {
         EthPooledTransaction::from(tx)
     }
 }

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -771,8 +771,9 @@ mod tests {
         let data = hex::decode(raw).unwrap();
         let tx = PooledTransactionsElement::decode_enveloped(data.into()).unwrap();
 
-        let transaction =
-            EthPooledTransaction::from_recovered_transaction(tx.try_into_ecrecovered().unwrap());
+        let transaction = EthPooledTransaction::from_recovered_pooled_transaction(
+            tx.try_into_ecrecovered().unwrap(),
+        );
         let res = ensure_intrinsic_gas(&transaction, false);
         assert!(res.is_ok());
         let res = ensure_intrinsic_gas(&transaction, true);


### PR DESCRIPTION
we need the blob for reorged transactions to accurately set the encoded length for p2p

this fetches the blob from the store if a reorged tx is an eip4844