### PR TITLE
chore(op-reth): Add temporary `Canyon` warning

### DIFF
--- a/bin/reth/src/optimism.rs
+++ b/bin/reth/src/optimism.rs
@@ -8,8 +8,21 @@ compile_error!("Cannot build the `op-reth` binary with the `optimism` feature fl
 
 #[cfg(feature = "optimism")]
 fn main() {
+    print_canyon_warning();
     if let Err(err) = reth::cli::run() {
         eprintln!("Error: {err:?}");
         std::process::exit(1);
     }
+}
+
+#[inline]
+fn print_canyon_warning() {
+    println!("---------------------- [ WARNING! ] ----------------------");
+    println!("`op-reth` does not currently support the Canyon Hardfork,");
+    println!("which went live on 2023-14-11 12PM EST on Sepolia and Goerli.");
+    println!("The node will cease to sync at that blocktime (1699981200).");
+    println!("Please consult the Canyon Hardfork tracking issue to follow");
+    println!("along with the progress of the hardfork implementation:");
+    println!("https://github.com/paradigmxyz/reth/issues/5210");
+    println!("----------------------------------------------------------\n");
 }

--- a/book/run/optimism.md
+++ b/book/run/optimism.md
@@ -1,5 +1,8 @@
 # Running Reth on OP Stack chains
 
+> **Note**: `op-reth` does not currently support the Canyon Hardfork, which went live on 2023-14-11 12PM EST on Sepolia and Goerli. If the network being synced has enabled Canyon, `op-reth` will cease to sync at that blocktime (`1699981200`).
+> Please consult the [Canyon Hardfork tracking issue](https://github.com/paradigmxyz/reth/issues/5210) to follow along with the progress of the hardfork implementation.
+
 `reth` ships with the `optimism` feature flag in several crates, including the binary, enabling support for OP Stack chains out of the box. Optimism has a small diff from the [L1 EELS][l1-el-spec],
 comprising of the following key changes:
 1. A new transaction type, [`0x7E (Deposit)`][deposit-spec], which is used to deposit funds from L1 to L2.


### PR DESCRIPTION
## Overview

Adds a temporary warning message on `op-reth`'s startup for the lack of support for the `Canyon` hardfork in `op-reth`.

The `Canyon` hardfork went live on Nov 14, 12PM EST on Goerli and Sepolia for superchain-compatible OP Stack chains. The tracking issue for `op-reth`'s support for the hardfork can be found in #5210.