### PR TITLE
chore: use i64 for blob priority function

### DIFF
--- a/crates/transaction-pool/src/pool/blob.rs
+++ b/crates/transaction-pool/src/pool/blob.rs
@@ -284,12 +284,19 @@ impl<T: PoolTransaction> Ord for BlobTransaction<T> {
 ///
 /// This is supposed to get the number of fee jumps required to get from the current fee to the fee
 /// cap, or where the transaction would not be executable any more.
-fn fee_delta(max_tx_fee: u128, current_fee: u128) -> f64 {
+fn fee_delta(max_tx_fee: u128, current_fee: u128) -> i64 {
     // jumps = log1.125(txfee) - log1.125(basefee)
-    // TODO: should we do this without f64?
     let jumps = (max_tx_fee as f64).log(1.125) - (current_fee as f64).log(1.125);
+
+    // cast to int, so we can use ilog2
+    let jumps = jumps as i64;
+    if jumps == 0 {
+        // can't take ilog2 of 0
+        return 0;
+    }
+
     // delta = sign(jumps) * log(abs(jumps))
-    jumps.signum() * jumps.abs().log2()
+    jumps.signum() * jumps.abs().ilog2() as i64
 }
 
 /// Returns the priority for the transaction, based on the "delta" blob fee and priority fee.
@@ -298,12 +305,12 @@ fn blob_tx_priority(
     blob_fee: u128,
     max_priority_fee: u128,
     base_fee: u128,
-) -> f64 {
+) -> i64 {
     let delta_blob_fee = fee_delta(blob_fee_cap, blob_fee);
     let delta_priority_fee = fee_delta(max_priority_fee, base_fee);
 
     // priority = min(delta-basefee, delta-blobfee, 0)
-    delta_blob_fee.min(delta_priority_fee).min(0.0)
+    delta_blob_fee.min(delta_priority_fee).min(0)
 }
 
 #[derive(Debug, Clone)]
@@ -312,7 +319,7 @@ struct BlobOrd {
     pub(crate) submission_id: u64,
     // The priority for this transaction, calculated using the [`blob_tx_priority`] function,
     // taking into account both the blob and priority fee.
-    pub(crate) priority: f64,
+    pub(crate) priority: i64,
 }
 
 impl Eq for BlobOrd {}
@@ -331,7 +338,7 @@ impl PartialOrd<Self> for BlobOrd {
 
 impl Ord for BlobOrd {
     fn cmp(&self, other: &Self) -> Ordering {
-        let ord = other.priority.total_cmp(&self.priority);
+        let ord = other.priority.cmp(&self.priority);
 
         // use submission_id to break ties
         if ord == Ordering::Equal {
@@ -565,4 +572,7 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn priority_tests() {}
 }


### PR DESCRIPTION
Changes the `fee_delta` function to output an `i64`. This also allows us to test against the geth test vectors.