### PR TITLE
feat: add benchmark for blob_tx_priority and fee_delta

### DIFF
--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -81,5 +81,5 @@ harness = false
 
 [[bench]]
 name = "priority"
-required-features = ["test-utils", "arbitrary"]
+required-features = ["arbitrary"]
 harness = false

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -78,3 +78,8 @@ optimism = [
 name = "reorder"
 required-features = ["test-utils", "arbitrary"]
 harness = false
+
+[[bench]]
+name = "priority"
+required-features = ["test-utils", "arbitrary"]
+harness = false

--- a/crates/transaction-pool/benches/priority.rs
+++ b/crates/transaction-pool/benches/priority.rs
@@ -1,0 +1,70 @@
+use criterion::{
+    black_box, criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion,
+};
+use proptest::{
+    prelude::*,
+    strategy::{Strategy, ValueTree},
+    test_runner::TestRunner,
+};
+use reth_transaction_pool::{blob_tx_priority, fee_delta};
+
+fn generate_test_data_fee_delta() -> (u128, u128) {
+    let config = ProptestConfig::default();
+    let mut runner = TestRunner::new(config);
+    prop::arbitrary::any::<(u128, u128)>().new_tree(&mut runner).unwrap().current()
+}
+
+fn generate_test_data_priority() -> (u128, u128, u128, u128) {
+    let config = ProptestConfig::default();
+    let mut runner = TestRunner::new(config);
+    prop::arbitrary::any::<(u128, u128, u128, u128)>().new_tree(&mut runner).unwrap().current()
+}
+
+fn priority_bench(
+    group: &mut BenchmarkGroup<WallTime>,
+    description: &str,
+    input_data: (u128, u128, u128, u128),
+) {
+    let group_id = format!("txpool | {}", description);
+
+    group.bench_function(group_id, |b| {
+        b.iter(|| {
+            black_box(blob_tx_priority(
+                black_box(input_data.0),
+                black_box(input_data.1),
+                black_box(input_data.2),
+                black_box(input_data.3),
+            ));
+        });
+    });
+}
+
+fn fee_jump_bench(
+    group: &mut BenchmarkGroup<WallTime>,
+    description: &str,
+    input_data: (u128, u128),
+) {
+    let group_id = format!("txpool | {}", description);
+
+    group.bench_function(group_id, |b| {
+        b.iter(|| {
+            black_box(fee_delta(black_box(input_data.0), black_box(input_data.1)));
+        });
+    });
+}
+
+pub fn blob_priority_calculation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Blob priority calculation");
+    let fee_jump_input = generate_test_data_fee_delta();
+
+    // Unstable sorting of unsorted collection
+    fee_jump_bench(&mut group, "BenchmarkDynamicFeeJumpCalculation", fee_jump_input);
+
+    let blob_priority_input = generate_test_data_priority();
+
+    // BinaryHeap that is resorted on each update
+    priority_bench(&mut group, "BenchmarkPriorityCalculation", blob_priority_input);
+}
+
+criterion_group!(priority, blob_priority_calculation);
+criterion_main!(priority);

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -162,8 +162,8 @@ pub use crate::{
     error::PoolResult,
     ordering::{CoinbaseTipOrdering, Priority, TransactionOrdering},
     pool::{
-        state::SubPool, AllTransactionsEvents, FullTransactionEvent, TransactionEvent,
-        TransactionEvents,
+        blob_tx_priority, fee_delta, state::SubPool, AllTransactionsEvents, FullTransactionEvent,
+        TransactionEvent, TransactionEvents,
     },
     traits::*,
     validate::{

--- a/crates/transaction-pool/src/pool/blob.rs
+++ b/crates/transaction-pool/src/pool/blob.rs
@@ -284,7 +284,7 @@ impl<T: PoolTransaction> Ord for BlobTransaction<T> {
 ///
 /// This is supposed to get the number of fee jumps required to get from the current fee to the fee
 /// cap, or where the transaction would not be executable any more.
-fn fee_delta(max_tx_fee: u128, current_fee: u128) -> i64 {
+pub fn fee_delta(max_tx_fee: u128, current_fee: u128) -> i64 {
     // jumps = log1.125(txfee) - log1.125(basefee)
     let jumps = (max_tx_fee as f64).log(1.125) - (current_fee as f64).log(1.125);
 
@@ -300,7 +300,7 @@ fn fee_delta(max_tx_fee: u128, current_fee: u128) -> i64 {
 }
 
 /// Returns the priority for the transaction, based on the "delta" blob fee and priority fee.
-fn blob_tx_priority(
+pub fn blob_tx_priority(
     blob_fee_cap: u128,
     blob_fee: u128,
     max_priority_fee: u128,

--- a/crates/transaction-pool/src/pool/blob.rs
+++ b/crates/transaction-pool/src/pool/blob.rs
@@ -272,6 +272,9 @@ impl<T: PoolTransaction> Ord for BlobTransaction<T> {
     }
 }
 
+/// This is the log base 2 of 1.125, which we'll use to calculate the priority
+const LOG_2_1_125: f64 = 0.16992500144231237;
+
 /// The blob step function, attempting to compute the delta given the `max_tx_fee`, and
 /// `current_fee`.
 ///
@@ -285,8 +288,27 @@ impl<T: PoolTransaction> Ord for BlobTransaction<T> {
 /// This is supposed to get the number of fee jumps required to get from the current fee to the fee
 /// cap, or where the transaction would not be executable any more.
 pub fn fee_delta(max_tx_fee: u128, current_fee: u128) -> i64 {
+    if max_tx_fee == current_fee {
+        // if these are equal, then there's no fee jump
+        return 0;
+    }
+
+    let max_tx_fee_jumps = if max_tx_fee == 0 {
+        // we can't take log2 of 0, so we set this to zero here
+        0f64
+    } else {
+        (max_tx_fee.ilog2() as f64) / LOG_2_1_125
+    };
+
+    let current_fee_jumps = if current_fee == 0 {
+        // we can't take log2 of 0, so we set this to zero here
+        0f64
+    } else {
+        (current_fee.ilog2() as f64) / LOG_2_1_125
+    };
+
     // jumps = log1.125(txfee) - log1.125(basefee)
-    let jumps = (max_tx_fee as f64).log(1.125) - (current_fee as f64).log(1.125);
+    let jumps = max_tx_fee_jumps - current_fee_jumps;
 
     // delta = sign(jumps) * log(abs(jumps))
     match (jumps as i64).cmp(&0) {

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -110,6 +110,7 @@ pub use listener::{AllTransactionsEvents, TransactionEvents};
 
 mod best;
 mod blob;
+pub use blob::{blob_tx_priority, fee_delta};
 mod parked;
 pub(crate) mod pending;
 pub(crate) mod size;


### PR DESCRIPTION
Adds a benchmark for `blob_tx_priority` and `fee_delta`. Here are the results so far:
```log
~/p/reth (dan/priority-benchmark)> cargo bench -p reth-transaction-pool --features="arbitrary" --bench priority
    Finished bench [optimized] target(s) in 0.22s
     Running benches/priority.rs (target/release/deps/priority-0ec70319c38c39df)
Gnuplot not found, using plotters backend
Blob priority calculation/txpool | BenchmarkDynamicFeeJumpCalculation
                        time:   [10.650 ns 10.660 ns 10.673 ns]
                        change: [-0.9740% -0.7717% -0.5813%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) high mild
  6 (6.00%) high severe
Blob priority calculation/txpool | BenchmarkPriorityCalculation
                        time:   [22.307 ns 22.325 ns 22.345 ns]
                        change: [-0.0786% +0.0610% +0.2148%] (p = 0.42 > 0.05)
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe

```