### PR TITLE
feat: add metrics for best and resolved payloads

### DIFF
--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -6,7 +6,7 @@ use reth_metrics::{
 };
 
 /// Payload builder service metrics
-#[derive(Metrics)]
+#[derive(Metrics, Clone)]
 #[metrics(scope = "payloads")]
 pub(crate) struct PayloadBuilderServiceMetrics {
     /// Number of active jobs
@@ -15,6 +15,14 @@ pub(crate) struct PayloadBuilderServiceMetrics {
     pub(crate) initiated_jobs: Counter,
     /// Total number of failed jobs
     pub(crate) failed_jobs: Counter,
+    /// Coinbase revenue for best payloads
+    pub(crate) best_revenue: Gauge,
+    /// Current block returned as the best payload
+    pub(crate) best_block: Gauge,
+    /// Coinbase revenue for resolved payloads
+    pub(crate) resolved_revenue: Gauge,
+    /// Current block returned as the resolved payload
+    pub(crate) resolved_block: Gauge,
 }
 
 impl PayloadBuilderServiceMetrics {
@@ -28,5 +36,15 @@ impl PayloadBuilderServiceMetrics {
 
     pub(crate) fn set_active_jobs(&self, value: usize) {
         self.active_jobs.set(value as f64)
+    }
+
+    pub(crate) fn set_best_revenue(&self, block: u64, value: f64) {
+        self.best_block.set(block as f64);
+        self.best_revenue.set(value)
+    }
+
+    pub(crate) fn set_resolved_revenue(&self, block: u64, value: f64) {
+        self.resolved_block.set(block as f64);
+        self.resolved_revenue.set(value)
     }
 }

--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -208,7 +208,16 @@ where
         &self,
         id: PayloadId,
     ) -> Option<Result<Arc<BuiltPayload>, PayloadBuilderError>> {
-        self.payload_jobs.iter().find(|(_, job_id)| *job_id == id).map(|(j, _)| j.best_payload())
+        let res = self
+            .payload_jobs
+            .iter()
+            .find(|(_, job_id)| *job_id == id)
+            .map(|(j, _)| j.best_payload());
+        if let Some(Ok(ref best)) = res {
+            self.metrics.set_best_revenue(best.block.number, best.fees().to::<u128>() as f64);
+        }
+
+        res
     }
 
     /// Returns the payload attributes for the given payload.
@@ -232,6 +241,18 @@ where
             let (_, id) = self.payload_jobs.remove(job);
             trace!(%id, "terminated resolved job");
         }
+
+        // Since the fees will not be known until the payload future is resolved / awaited, we wrap
+        // the future in a new future that will update the metrics.
+        let resolved_metrics = self.metrics.clone();
+        let fut = async move {
+            let res = fut.await;
+            if let Ok(ref payload) = res {
+                resolved_metrics
+                    .set_resolved_revenue(payload.block.number, payload.fees().to::<u128>() as f64);
+            }
+            res
+        };
 
         Some(Box::pin(fut))
     }

--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -214,6 +214,7 @@ where
             .find(|(_, job_id)| *job_id == id)
             .map(|(j, _)| j.best_payload());
         if let Some(Ok(ref best)) = res {
+            // TODO: remove `to`
             self.metrics.set_best_revenue(best.block.number, best.fees().to::<u128>() as f64);
         }
 
@@ -248,6 +249,7 @@ where
         let fut = async move {
             let res = fut.await;
             if let Ok(ref payload) = res {
+                // TODO: remove `to`
                 resolved_metrics
                     .set_resolved_revenue(payload.block.number, payload.fees().to::<u128>() as f64);
             }


### PR DESCRIPTION
Tracks fees given by best and resolved payloads. The general idea was that we should be able to track in realtime how valuable built blocks are. The rationale for putting this in the `PayloadBuilderService` is that a custom builder (custom `PayloadJobGenerator`) might be able to use this too.