### PR TITLE
feat(provider): `HeaderProvider::sealed_headers_while`

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -567,15 +567,16 @@ mod tests {
             Ok(vec![])
         }
 
-        fn sealed_headers_range(
-            &self,
-            _range: impl RangeBounds<BlockNumber>,
-        ) -> RethResult<Vec<SealedHeader>> {
-            Ok(vec![])
-        }
-
         fn sealed_header(&self, _block_number: BlockNumber) -> RethResult<Option<SealedHeader>> {
             Ok(None)
+        }
+
+        fn sealed_headers_while(
+            &self,
+            _range: impl RangeBounds<BlockNumber>,
+            _predicate: impl Fn(&SealedHeader) -> bool,
+        ) -> RethResult<Vec<SealedHeader>> {
+            Ok(vec![])
         }
     }
 

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -574,7 +574,7 @@ mod tests {
         fn sealed_headers_while(
             &self,
             _range: impl RangeBounds<BlockNumber>,
-            _predicate: impl Fn(&SealedHeader) -> bool,
+            _predicate: impl FnMut(&SealedHeader) -> bool,
         ) -> RethResult<Vec<SealedHeader>> {
             Ok(vec![])
         }

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -214,6 +214,10 @@ impl<DB: Database> HeaderProvider for ProviderFactory<DB> {
         self.provider()?.headers_range(range)
     }
 
+    fn sealed_header(&self, number: BlockNumber) -> RethResult<Option<SealedHeader>> {
+        self.provider()?.sealed_header(number)
+    }
+
     fn sealed_headers_range(
         &self,
         range: impl RangeBounds<BlockNumber>,
@@ -221,8 +225,12 @@ impl<DB: Database> HeaderProvider for ProviderFactory<DB> {
         self.provider()?.sealed_headers_range(range)
     }
 
-    fn sealed_header(&self, number: BlockNumber) -> RethResult<Option<SealedHeader>> {
-        self.provider()?.sealed_header(number)
+    fn sealed_headers_while(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+        predicate: impl Fn(&SealedHeader) -> bool,
+    ) -> RethResult<Vec<SealedHeader>> {
+        self.provider()?.sealed_headers_while(range, predicate)
     }
 }
 

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -228,7 +228,7 @@ impl<DB: Database> HeaderProvider for ProviderFactory<DB> {
     fn sealed_headers_while(
         &self,
         range: impl RangeBounds<BlockNumber>,
-        predicate: impl Fn(&SealedHeader) -> bool,
+        predicate: impl FnMut(&SealedHeader) -> bool,
     ) -> RethResult<Vec<SealedHeader>> {
         self.provider()?.sealed_headers_while(range, predicate)
     }

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -154,7 +154,7 @@ where
     fn sealed_headers_while(
         &self,
         range: impl RangeBounds<BlockNumber>,
-        predicate: impl Fn(&SealedHeader) -> bool,
+        predicate: impl FnMut(&SealedHeader) -> bool,
     ) -> RethResult<Vec<SealedHeader>> {
         self.database.provider()?.sealed_headers_while(range, predicate)
     }

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -140,6 +140,10 @@ where
         self.database.provider()?.headers_range(range)
     }
 
+    fn sealed_header(&self, number: BlockNumber) -> RethResult<Option<SealedHeader>> {
+        self.database.provider()?.sealed_header(number)
+    }
+
     fn sealed_headers_range(
         &self,
         range: impl RangeBounds<BlockNumber>,
@@ -147,8 +151,12 @@ where
         self.database.provider()?.sealed_headers_range(range)
     }
 
-    fn sealed_header(&self, number: BlockNumber) -> RethResult<Option<SealedHeader>> {
-        self.database.provider()?.sealed_header(number)
+    fn sealed_headers_while(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+        predicate: impl Fn(&SealedHeader) -> bool,
+    ) -> RethResult<Vec<SealedHeader>> {
+        self.database.provider()?.sealed_headers_while(range, predicate)
     }
 }
 

--- a/crates/storage/provider/src/providers/snapshot/jar.rs
+++ b/crates/storage/provider/src/providers/snapshot/jar.rs
@@ -105,7 +105,7 @@ impl<'a> HeaderProvider for SnapshotJarProvider<'a> {
     fn sealed_headers_while(
         &self,
         range: impl RangeBounds<BlockNumber>,
-        predicate: impl Fn(&SealedHeader) -> bool,
+        mut predicate: impl FnMut(&SealedHeader) -> bool,
     ) -> RethResult<Vec<SealedHeader>> {
         let range = to_range(range);
 

--- a/crates/storage/provider/src/providers/snapshot/jar.rs
+++ b/crates/storage/provider/src/providers/snapshot/jar.rs
@@ -95,9 +95,17 @@ impl<'a> HeaderProvider for SnapshotJarProvider<'a> {
         Ok(headers)
     }
 
-    fn sealed_headers_range(
+    fn sealed_header(&self, number: BlockNumber) -> RethResult<Option<SealedHeader>> {
+        Ok(self
+            .cursor()?
+            .get_two::<HeaderMask<Header, BlockHash>>(number.into())?
+            .map(|(header, hash)| header.seal(hash)))
+    }
+
+    fn sealed_headers_while(
         &self,
         range: impl RangeBounds<BlockNumber>,
+        predicate: impl Fn(&SealedHeader) -> bool,
     ) -> RethResult<Vec<SealedHeader>> {
         let range = to_range(range);
 
@@ -108,17 +116,14 @@ impl<'a> HeaderProvider for SnapshotJarProvider<'a> {
             if let Some((header, hash)) =
                 cursor.get_two::<HeaderMask<Header, BlockHash>>(number.into())?
             {
-                headers.push(header.seal(hash))
+                let sealed = header.seal(hash);
+                if !predicate(&sealed) {
+                    break
+                }
+                headers.push(sealed);
             }
         }
         Ok(headers)
-    }
-
-    fn sealed_header(&self, number: BlockNumber) -> RethResult<Option<SealedHeader>> {
-        Ok(self
-            .cursor()?
-            .get_two::<HeaderMask<Header, BlockHash>>(number.into())?
-            .map(|(header, hash)| header.seal(hash)))
     }
 }
 

--- a/crates/storage/provider/src/providers/snapshot/manager.rs
+++ b/crates/storage/provider/src/providers/snapshot/manager.rs
@@ -286,7 +286,7 @@ impl HeaderProvider for SnapshotProvider {
     fn sealed_headers_while(
         &self,
         _range: impl RangeBounds<BlockNumber>,
-        _predicate: impl Fn(&SealedHeader) -> bool,
+        _predicate: impl FnMut(&SealedHeader) -> bool,
     ) -> RethResult<Vec<SealedHeader>> {
         todo!()
     }

--- a/crates/storage/provider/src/providers/snapshot/manager.rs
+++ b/crates/storage/provider/src/providers/snapshot/manager.rs
@@ -113,7 +113,7 @@ impl SnapshotProvider {
                 })?)
                 .and_then(|(parsed_segment, block_range, tx_range)| {
                     if parsed_segment == segment {
-                        return Some((block_range, tx_range));
+                        return Some((block_range, tx_range))
                     }
                     None
                 })
@@ -123,7 +123,7 @@ impl SnapshotProvider {
 
         // Return cached `LoadedJar` or insert it for the first time, and then, return it.
         if let Some((block_range, tx_range)) = snapshot_ranges {
-            return Ok(Some(self.get_or_create_jar_provider(segment, &block_range, &tx_range)?));
+            return Ok(Some(self.get_or_create_jar_provider(segment, &block_range, &tx_range)?))
         }
 
         Ok(None)
@@ -171,7 +171,7 @@ impl SnapshotProvider {
             let block_start =
                 snapshots_rev_iter.peek().map(|(block_end, _)| *block_end + 1).unwrap_or(0);
             if block_start <= block {
-                return Some((block_start..=*block_end, tx_range.clone()));
+                return Some((block_start..=*block_end, tx_range.clone()))
             }
         }
         None
@@ -194,7 +194,7 @@ impl SnapshotProvider {
         while let Some((tx_end, block_range)) = snapshots_rev_iter.next() {
             let tx_start = snapshots_rev_iter.peek().map(|(tx_end, _)| *tx_end + 1).unwrap_or(0);
             if tx_start <= tx {
-                return Some((block_range.clone(), tx_start..=*tx_end));
+                return Some((block_range.clone(), tx_start..=*tx_end))
             }
         }
         None
@@ -278,16 +278,17 @@ impl HeaderProvider for SnapshotProvider {
         todo!();
     }
 
-    fn sealed_headers_range(
-        &self,
-        _range: impl RangeBounds<BlockNumber>,
-    ) -> RethResult<Vec<SealedHeader>> {
-        todo!();
-    }
-
     fn sealed_header(&self, num: BlockNumber) -> RethResult<Option<SealedHeader>> {
         self.get_segment_provider_from_block(SnapshotSegment::Headers, num, None)?
             .sealed_header(num)
+    }
+
+    fn sealed_headers_while(
+        &self,
+        _range: impl RangeBounds<BlockNumber>,
+        _predicate: impl Fn(&SealedHeader) -> bool,
+    ) -> RethResult<Vec<SealedHeader>> {
+        todo!()
     }
 }
 

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -175,7 +175,7 @@ impl HeaderProvider for MockEthProvider {
             .headers_range(range)?
             .into_iter()
             .map(|h| h.seal_slow())
-            .take_while(|h| predicate(&h))
+            .take_while(|h| predicate(h))
             .collect())
     }
 }

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -169,7 +169,7 @@ impl HeaderProvider for MockEthProvider {
     fn sealed_headers_while(
         &self,
         range: impl RangeBounds<BlockNumber>,
-        predicate: impl Fn(&SealedHeader) -> bool,
+        mut predicate: impl FnMut(&SealedHeader) -> bool,
     ) -> RethResult<Vec<SealedHeader>> {
         Ok(self
             .headers_range(range)?

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -162,15 +162,21 @@ impl HeaderProvider for MockEthProvider {
         Ok(headers)
     }
 
-    fn sealed_headers_range(
-        &self,
-        range: impl RangeBounds<BlockNumber>,
-    ) -> RethResult<Vec<SealedHeader>> {
-        Ok(self.headers_range(range)?.into_iter().map(|h| h.seal_slow()).collect())
-    }
-
     fn sealed_header(&self, number: BlockNumber) -> RethResult<Option<SealedHeader>> {
         Ok(self.header_by_number(number)?.map(|h| h.seal_slow()))
+    }
+
+    fn sealed_headers_while(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+        predicate: impl Fn(&SealedHeader) -> bool,
+    ) -> RethResult<Vec<SealedHeader>> {
+        Ok(self
+            .headers_range(range)?
+            .into_iter()
+            .map(|h| h.seal_slow())
+            .take_while(|h| predicate(&h))
+            .collect())
     }
 }
 

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -242,7 +242,7 @@ impl HeaderProvider for NoopProvider {
     fn sealed_headers_while(
         &self,
         _range: impl RangeBounds<BlockNumber>,
-        _predicate: impl Fn(&SealedHeader) -> bool,
+        _predicate: impl FnMut(&SealedHeader) -> bool,
     ) -> RethResult<Vec<SealedHeader>> {
         Ok(vec![])
     }

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -235,15 +235,16 @@ impl HeaderProvider for NoopProvider {
         Ok(vec![])
     }
 
-    fn sealed_headers_range(
-        &self,
-        _range: impl RangeBounds<BlockNumber>,
-    ) -> RethResult<Vec<SealedHeader>> {
-        Ok(vec![])
-    }
-
     fn sealed_header(&self, _number: BlockNumber) -> RethResult<Option<SealedHeader>> {
         Ok(None)
+    }
+
+    fn sealed_headers_while(
+        &self,
+        _range: impl RangeBounds<BlockNumber>,
+        _predicate: impl Fn(&SealedHeader) -> bool,
+    ) -> RethResult<Vec<SealedHeader>> {
+        Ok(vec![])
     }
 }
 

--- a/crates/storage/provider/src/traits/header.rs
+++ b/crates/storage/provider/src/traits/header.rs
@@ -37,12 +37,21 @@ pub trait HeaderProvider: Send + Sync {
     /// Get headers in range of block numbers
     fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> RethResult<Vec<Header>>;
 
-    /// Get headers in range of block numbers
+    /// Get a single sealed header by block number.
+    fn sealed_header(&self, number: BlockNumber) -> RethResult<Option<SealedHeader>>;
+
+    /// Get headers in range of block numbers.
     fn sealed_headers_range(
         &self,
         range: impl RangeBounds<BlockNumber>,
-    ) -> RethResult<Vec<SealedHeader>>;
+    ) -> RethResult<Vec<SealedHeader>> {
+        self.sealed_headers_while(range, |_| true)
+    }
 
-    /// Get a single sealed header by block number
-    fn sealed_header(&self, number: BlockNumber) -> RethResult<Option<SealedHeader>>;
+    /// Get sealed headers while `predicate` returns `true` or the range is exhausted.
+    fn sealed_headers_while(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+        predicate: impl Fn(&SealedHeader) -> bool,
+    ) -> RethResult<Vec<SealedHeader>>;
 }

--- a/crates/storage/provider/src/traits/header.rs
+++ b/crates/storage/provider/src/traits/header.rs
@@ -52,6 +52,6 @@ pub trait HeaderProvider: Send + Sync {
     fn sealed_headers_while(
         &self,
         range: impl RangeBounds<BlockNumber>,
-        predicate: impl Fn(&SealedHeader) -> bool,
+        predicate: impl FnMut(&SealedHeader) -> bool,
     ) -> RethResult<Vec<SealedHeader>>;
 }


### PR DESCRIPTION
## Description

Add `HeaderProvider::sealed_headers_while` method and its implementations.
Add a default implementation to `HeaderProvider::sealed_headers_range` by making `predicate` always return `true`.

## Motivation

Preparation to replace `DB` in `BodiesDownloader` with `HeaderProvider`.
https://github.com/paradigmxyz/reth/blob/2b3a32c91140f39a4205521b7831eec8e42582a0/crates/net/downloaders/src/bodies/bodies.rs#L38-L45