### PR TITLE
chore(downloader): replace database with header provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5890,6 +5890,7 @@ dependencies = [
  "reth-interfaces",
  "reth-metrics",
  "reth-primitives",
+ "reth-provider",
  "reth-tasks",
  "reth-tracing",
  "tempfile",

--- a/bin/reth/src/chain/import.rs
+++ b/bin/reth/src/chain/import.rs
@@ -147,7 +147,11 @@ impl ImportCommand {
             .into_task();
 
         let body_downloader = BodiesDownloaderBuilder::from(config.stages.bodies)
-            .build(file_client.clone(), consensus.clone(), db.clone())
+            .build(
+                file_client.clone(),
+                consensus.clone(),
+                ProviderFactory::new(db.clone(), self.chain.clone()),
+            )
             .into_task();
 
         let (tip_tx, tip_rx) = watch::channel(B256::ZERO);

--- a/bin/reth/src/debug_cmd/execution.rs
+++ b/bin/reth/src/debug_cmd/execution.rs
@@ -102,7 +102,11 @@ impl Command {
             .into_task_with(task_executor);
 
         let body_downloader = BodiesDownloaderBuilder::from(config.stages.bodies)
-            .build(client, Arc::clone(&consensus), db.clone())
+            .build(
+                client,
+                Arc::clone(&consensus),
+                ProviderFactory::new(db.clone(), self.chain.clone()),
+            )
             .into_task_with(task_executor);
 
         let stage_conf = &config.stages;

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -617,7 +617,11 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
             .into_task_with(task_executor);
 
         let body_downloader = BodiesDownloaderBuilder::from(config.stages.bodies)
-            .build(client, Arc::clone(&consensus), db.clone())
+            .build(
+                client,
+                Arc::clone(&consensus),
+                ProviderFactory::new(db.clone(), self.chain.clone()),
+            )
             .into_task_with(task_executor);
 
         let pipeline = self

--- a/crates/interfaces/src/p2p/error.rs
+++ b/crates/interfaces/src/p2p/error.rs
@@ -1,5 +1,5 @@
 use super::headers::client::HeadersRequest;
-use crate::{consensus::ConsensusError, db};
+use crate::{consensus::ConsensusError, provider::ProviderError};
 use reth_network_api::ReputationChangeKind;
 use reth_primitives::{
     BlockHashOrNumber, BlockNumber, GotExpected, GotExpectedBoxed, Header, WithPeerId, B256,
@@ -177,9 +177,9 @@ pub enum DownloadError {
     /// Error while executing the request.
     #[error(transparent)]
     RequestError(#[from] RequestError),
-    /// Error while reading data from database.
+    /// Provider error.
     #[error(transparent)]
-    DatabaseError(#[from] db::DatabaseError),
+    Provider(#[from] ProviderError),
 }
 
 #[cfg(test)]

--- a/crates/net/downloaders/Cargo.toml
+++ b/crates/net/downloaders/Cargo.toml
@@ -12,8 +12,8 @@ description = "Implementations of various block downloaders"
 # reth
 reth-interfaces.workspace = true
 reth-primitives.workspace = true
-reth-db.workspace = true
 reth-tasks.workspace = true
+reth-provider.workspace = true
 
 # async
 futures.workspace = true
@@ -33,6 +33,7 @@ rayon.workspace = true
 thiserror.workspace = true
 
 # optional deps for the test-utils feature
+reth-db = { workspace = true, optional = true }
 alloy-rlp = { workspace = true, optional = true }
 tempfile = { workspace = true, optional = true }
 itertools = { workspace = true, optional = true }
@@ -50,4 +51,4 @@ itertools.workspace = true
 tempfile.workspace = true
 
 [features]
-test-utils = ["dep:alloy-rlp", "dep:tempfile", "dep:itertools", "reth-interfaces/test-utils"]
+test-utils = ["dep:alloy-rlp", "dep:tempfile", "dep:itertools", "reth-db/test-utils", "reth-interfaces/test-utils"]

--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -106,24 +106,21 @@ where
         //         relevant if the range consists entirely of empty headers)
         let mut collected = 0;
         let mut non_empty_headers = 0;
-        let headers = self
-            .provider
-            .sealed_headers_while(range.clone(), |header| {
-                let should_take = range.contains(&header.number) &&
-                    non_empty_headers < max_non_empty &&
-                    collected < self.stream_batch_size;
+        let headers = self.provider.sealed_headers_while(range.clone(), |header| {
+            let should_take = range.contains(&header.number) &&
+                non_empty_headers < max_non_empty &&
+                collected < self.stream_batch_size;
 
-                if should_take {
-                    collected += 1;
-                    if !header.is_empty() {
-                        non_empty_headers += 1;
-                    }
-                    true
-                } else {
-                    false
+            if should_take {
+                collected += 1;
+                if !header.is_empty() {
+                    non_empty_headers += 1;
                 }
-            })
-            .unwrap(); // TODO: decide what to do with RethError 😡
+                true
+            } else {
+                false
+            }
+        })?;
 
         Ok(Some(headers).filter(|h| !h.is_empty()))
     }

--- a/crates/net/downloaders/src/bodies/task.rs
+++ b/crates/net/downloaders/src/bodies/task.rs
@@ -42,16 +42,17 @@ impl TaskDownloader {
     /// # Example
     ///
     /// ```
-    /// use reth_db::database::Database;
     /// use reth_downloaders::bodies::{bodies::BodiesDownloaderBuilder, task::TaskDownloader};
     /// use reth_interfaces::{consensus::Consensus, p2p::bodies::client::BodiesClient};
+    /// use reth_provider::HeaderProvider;
     /// use std::sync::Arc;
-    /// fn t<B: BodiesClient + 'static, DB: Database + 'static>(
+    ///
+    /// fn t<B: BodiesClient + 'static, Provider: HeaderProvider + 'static>(
     ///     client: Arc<B>,
     ///     consensus: Arc<dyn Consensus>,
-    ///     db: Arc<DB>,
+    ///     provider: Provider,
     /// ) {
-    ///     let downloader = BodiesDownloaderBuilder::default().build(client, consensus, db);
+    ///     let downloader = BodiesDownloaderBuilder::default().build(client, consensus, provider);
     ///     let downloader = TaskDownloader::spawn(downloader);
     /// }
     /// ```
@@ -170,6 +171,8 @@ mod tests {
     use assert_matches::assert_matches;
     use reth_db::test_utils::create_test_rw_db;
     use reth_interfaces::{p2p::error::DownloadError, test_utils::TestConsensus};
+    use reth_primitives::MAINNET;
+    use reth_provider::ProviderFactory;
     use std::sync::Arc;
 
     #[tokio::test(flavor = "multi_thread")]
@@ -187,7 +190,7 @@ mod tests {
         let downloader = BodiesDownloaderBuilder::default().build(
             client.clone(),
             Arc::new(TestConsensus::default()),
-            db,
+            ProviderFactory::new(db, MAINNET.clone()),
         );
         let mut downloader = TaskDownloader::spawn(downloader);
 
@@ -209,7 +212,7 @@ mod tests {
         let downloader = BodiesDownloaderBuilder::default().build(
             Arc::new(TestBodiesClient::default()),
             Arc::new(TestConsensus::default()),
-            db,
+            ProviderFactory::new(db, MAINNET.clone()),
         );
         let mut downloader = TaskDownloader::spawn(downloader);
 

--- a/crates/net/downloaders/src/bodies/task.rs
+++ b/crates/net/downloaders/src/bodies/task.rs
@@ -47,7 +47,7 @@ impl TaskDownloader {
     /// use reth_provider::HeaderProvider;
     /// use std::sync::Arc;
     ///
-    /// fn t<B: BodiesClient + 'static, Provider: HeaderProvider + 'static>(
+    /// fn t<B: BodiesClient + 'static, Provider: HeaderProvider + Unpin + 'static>(
     ///     client: Arc<B>,
     ///     consensus: Arc<dyn Consensus>,
     ///     provider: Provider,

--- a/crates/net/downloaders/src/test_utils/file_client.rs
+++ b/crates/net/downloaders/src/test_utils/file_client.rs
@@ -267,7 +267,8 @@ mod tests {
         },
         test_utils::TestConsensus,
     };
-    use reth_primitives::SealedHeader;
+    use reth_primitives::{SealedHeader, MAINNET};
+    use reth_provider::ProviderFactory;
     use std::{
         io::{Read, Seek, SeekFrom, Write},
         sync::Arc,
@@ -291,7 +292,7 @@ mod tests {
         let mut downloader = BodiesDownloaderBuilder::default().build(
             client.clone(),
             Arc::new(TestConsensus::default()),
-            db,
+            ProviderFactory::new(db, MAINNET.clone()),
         );
         downloader.set_download_range(0..=19).expect("failed to set download range");
 
@@ -373,7 +374,7 @@ mod tests {
         let mut downloader = BodiesDownloaderBuilder::default().build(
             client.clone(),
             Arc::new(TestConsensus::default()),
-            db,
+            ProviderFactory::new(db, MAINNET.clone()),
         );
         downloader.set_download_range(0..=19).expect("failed to set download range");
 

--- a/crates/stages/src/lib.rs
+++ b/crates/stages/src/lib.rs
@@ -36,7 +36,7 @@
 //! # let bodies_downloader = BodiesDownloaderBuilder::default().build(
 //! #    Arc::new(TestBodiesClient { responder: |_| Ok((PeerId::ZERO, vec![]).into()) }),
 //! #    consensus.clone(),
-//! #    db.clone()
+//! #    ProviderFactory::new(db.clone(), MAINNET.clone())
 //! # );
 //! # let (tip_tx, tip_rx) = watch::channel(B256::default());
 //! # let factory = Factory::new(chain_spec.clone());

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -482,7 +482,7 @@ mod tests {
             tables,
             test_utils::TempDatabase,
             transaction::{DbTx, DbTxMut},
-            DatabaseEnv,
+            DatabaseEnv, DatabaseError,
         };
         use reth_interfaces::{
             p2p::{
@@ -492,7 +492,7 @@ mod tests {
                     response::BlockResponse,
                 },
                 download::DownloadClient,
-                error::DownloadResult,
+                error::{DownloadError, DownloadResult},
                 priority::Priority,
             },
             test_utils::{
@@ -778,22 +778,27 @@ mod tests {
                 &mut self,
                 range: RangeInclusive<BlockNumber>,
             ) -> DownloadResult<()> {
-                self.headers =
-                    VecDeque::from(self.db.view(|tx| -> DownloadResult<Vec<SealedHeader>> {
-                        let mut header_cursor = tx.cursor_read::<tables::Headers>()?;
+                self.headers = VecDeque::from(
+                    self.db
+                        .view(|tx| -> Result<Vec<SealedHeader>, DatabaseError> {
+                            let mut header_cursor = tx.cursor_read::<tables::Headers>()?;
 
-                        let mut canonical_cursor = tx.cursor_read::<tables::CanonicalHeaders>()?;
-                        let walker = canonical_cursor.walk_range(range)?;
+                            let mut canonical_cursor =
+                                tx.cursor_read::<tables::CanonicalHeaders>()?;
+                            let walker = canonical_cursor.walk_range(range)?;
 
-                        let mut headers = Vec::default();
-                        for entry in walker {
-                            let (num, hash) = entry?;
-                            let (_, header) =
-                                header_cursor.seek_exact(num)?.expect("missing header");
-                            headers.push(header.seal(hash));
-                        }
-                        Ok(headers)
-                    })??);
+                            let mut headers = Vec::default();
+                            for entry in walker {
+                                let (num, hash) = entry?;
+                                let (_, header) =
+                                    header_cursor.seek_exact(num)?.expect("missing header");
+                                headers.push(header.seal(hash));
+                            }
+                            Ok(headers)
+                        })
+                        .map_err(|err| DownloadError::Provider(err.into()))?
+                        .map_err(|err| DownloadError::Provider(err.into()))?,
+                );
                 Ok(())
             }
         }


### PR DESCRIPTION
## Description 

Builds on top of https://github.com/paradigmxyz/reth/pull/5470. 
Replaces generic `Database` with `HeaderProvider`.
