### PR TITLE
chore(provider): migrate providers to `ProviderError`

### DIFF
--- a/bin/reth/src/chain/import.rs
+++ b/bin/reth/src/chain/import.rs
@@ -114,7 +114,7 @@ impl ImportCommand {
         debug!(target: "reth::cli", ?tip, "Tip manually set");
 
         let factory = ProviderFactory::new(&db, self.chain.clone());
-        let provider = factory.provider().map_err(PipelineError::Interface)?;
+        let provider = factory.provider()?;
 
         let latest_block_number =
             provider.get_stage_checkpoint(StageId::Finish)?.map(|ch| ch.block_number);

--- a/bin/reth/src/debug_cmd/execution.rs
+++ b/bin/reth/src/debug_cmd/execution.rs
@@ -34,7 +34,7 @@ use reth_stages::{
         ExecutionStage, ExecutionStageThresholds, HeaderSyncMode, SenderRecoveryStage,
         TotalDifficultyStage,
     },
-    Pipeline, PipelineError, StageSet,
+    Pipeline, StageSet,
 };
 use reth_tasks::TaskExecutor;
 use std::{
@@ -234,7 +234,7 @@ impl Command {
         )?;
 
         let factory = ProviderFactory::new(&db, self.chain.clone());
-        let provider = factory.provider().map_err(PipelineError::Interface)?;
+        let provider = factory.provider()?;
 
         let latest_block_number =
             provider.get_stage_checkpoint(StageId::Finish)?.map(|ch| ch.block_number);
@@ -269,8 +269,7 @@ impl Command {
             // Unwind the pipeline without committing.
             {
                 factory
-                    .provider_rw()
-                    .map_err(PipelineError::Interface)?
+                    .provider_rw()?
                     .take_block_and_execution_range(&self.chain, next_block..=target_block)?;
             }
 

--- a/bin/reth/src/debug_cmd/in_memory_merkle.rs
+++ b/bin/reth/src/debug_cmd/in_memory_merkle.rs
@@ -194,7 +194,7 @@ impl Command {
         provider_rw.insert_block(block.clone(), None, None)?;
         block_state.write_to_db(provider_rw.tx_ref(), OriginalValuesKnown::No)?;
         let storage_lists = provider_rw.changed_storages_with_range(block.number..=block.number)?;
-        let storages = provider_rw.plainstate_storages(storage_lists)?;
+        let storages = provider_rw.plain_state_storages(storage_lists)?;
         provider_rw.insert_storage_for_hashing(storages)?;
         let account_lists = provider_rw.changed_accounts_with_range(block.number..=block.number)?;
         let accounts = provider_rw.basic_accounts(account_lists)?;

--- a/bin/reth/src/debug_cmd/merkle.rs
+++ b/bin/reth/src/debug_cmd/merkle.rs
@@ -28,7 +28,7 @@ use reth_stages::{
         AccountHashingStage, ExecutionStage, ExecutionStageThresholds, MerkleStage,
         StorageHashingStage, MERKLE_STAGE_DEFAULT_CLEAN_THRESHOLD,
     },
-    ExecInput, PipelineError, Stage,
+    ExecInput, Stage,
 };
 use reth_tasks::TaskExecutor;
 use std::{
@@ -121,7 +121,7 @@ impl Command {
         // initialize the database
         let db = Arc::new(init_db(db_path, self.db.log_level)?);
         let factory = ProviderFactory::new(&db, self.chain.clone());
-        let provider_rw = factory.provider_rw().map_err(PipelineError::Interface)?;
+        let provider_rw = factory.provider_rw()?;
 
         // Configure and build network
         let network_secret_path =

--- a/bin/reth/src/init.rs
+++ b/bin/reth/src/init.rs
@@ -33,7 +33,7 @@ pub enum InitDatabaseError {
         database_hash: B256,
     },
 
-    /// Internal error.
+    /// Provider error.
     #[error(transparent)]
     Provider(#[from] ProviderError),
 }

--- a/bin/reth/src/init.rs
+++ b/bin/reth/src/init.rs
@@ -5,14 +5,14 @@ use reth_db::{
     tables,
     transaction::{DbTx, DbTxMut},
 };
-use reth_interfaces::{db::DatabaseError, RethError};
+use reth_interfaces::{db::DatabaseError, provider::ProviderResult};
 use reth_primitives::{
     stage::StageId, Account, Bytecode, ChainSpec, Receipts, StorageEntry, B256, U256,
 };
 use reth_provider::{
     bundle_state::{BundleStateInit, RevertsInit},
     BundleStateWithReceipts, DatabaseProviderRW, HashingWriter, HistoryWriter, OriginalValuesKnown,
-    ProviderFactory,
+    ProviderError, ProviderFactory,
 };
 use std::{
     collections::{BTreeMap, HashMap},
@@ -33,13 +33,15 @@ pub enum InitDatabaseError {
         database_hash: B256,
     },
 
-    /// Low-level database error.
-    #[error(transparent)]
-    DBError(#[from] DatabaseError),
-
     /// Internal error.
     #[error(transparent)]
-    InternalError(#[from] RethError),
+    Provider(#[from] ProviderError),
+}
+
+impl From<DatabaseError> for InitDatabaseError {
+    fn from(error: DatabaseError) -> Self {
+        Self::Provider(ProviderError::Database(error))
+    }
 }
 
 /// Write the genesis block if it has not already been written
@@ -94,7 +96,7 @@ pub fn init_genesis<DB: Database>(
 pub fn insert_genesis_state<DB: Database>(
     tx: &<DB as DatabaseGAT<'_>>::TXMut,
     genesis: &reth_primitives::Genesis,
-) -> Result<(), InitDatabaseError> {
+) -> ProviderResult<()> {
     let mut state_init: BundleStateInit = HashMap::new();
     let mut reverts_init = HashMap::new();
     let mut contracts: HashMap<B256, Bytecode> = HashMap::new();
@@ -160,7 +162,7 @@ pub fn insert_genesis_state<DB: Database>(
 pub fn insert_genesis_hashes<DB: Database>(
     provider: &DatabaseProviderRW<'_, &DB>,
     genesis: &reth_primitives::Genesis,
-) -> Result<(), InitDatabaseError> {
+) -> ProviderResult<()> {
     // insert and hash accounts to hashing table
     let alloc_accounts =
         genesis.alloc.clone().into_iter().map(|(addr, account)| (addr, Some(account.into())));
@@ -184,7 +186,7 @@ pub fn insert_genesis_hashes<DB: Database>(
 pub fn insert_genesis_history<DB: Database>(
     provider: &DatabaseProviderRW<'_, &DB>,
     genesis: &reth_primitives::Genesis,
-) -> Result<(), InitDatabaseError> {
+) -> ProviderResult<()> {
     let account_transitions =
         genesis.alloc.keys().map(|addr| (*addr, vec![0])).collect::<BTreeMap<_, _>>();
     provider.insert_account_history_index(account_transitions)?;
@@ -204,7 +206,7 @@ pub fn insert_genesis_history<DB: Database>(
 pub fn insert_genesis_header<DB: Database>(
     tx: &<DB as DatabaseGAT<'_>>::TXMut,
     chain: Arc<ChainSpec>,
-) -> Result<(), InitDatabaseError> {
+) -> ProviderResult<()> {
     let header = chain.sealed_genesis_header();
 
     tx.put::<tables::CanonicalHeaders>(0, header.hash)?;

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -1153,7 +1153,7 @@ mod tests {
     #[cfg(not(feature = "optimism"))] // dev mode not yet supported in op-reth
     fn parse_dev() {
         let cmd = NodeCommand::<()>::parse_from(["reth", "--dev"]);
-        let chain = DEV.clone();
+        let chain = reth_primitives::DEV.clone();
         assert_eq!(cmd.chain.chain, chain.chain);
         assert_eq!(cmd.chain.genesis_hash, chain.genesis_hash);
         assert_eq!(

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -1048,7 +1048,6 @@ mod tests {
     use super::*;
     use crate::args::utils::SUPPORTED_CHAINS;
     use reth_discv4::DEFAULT_DISCOVERY_PORT;
-    use reth_primitives::DEV;
     use std::{
         net::{IpAddr, Ipv4Addr},
         path::Path,

--- a/bin/reth/src/stage/run.rs
+++ b/bin/reth/src/stage/run.rs
@@ -24,7 +24,7 @@ use reth_stages::{
         IndexAccountHistoryStage, IndexStorageHistoryStage, MerkleStage, SenderRecoveryStage,
         StorageHashingStage, TransactionLookupStage,
     },
-    ExecInput, ExecOutput, PipelineError, Stage, UnwindInput,
+    ExecInput, ExecOutput, Stage, UnwindInput,
 };
 use std::{any::Any, net::SocketAddr, path::PathBuf, sync::Arc};
 use tracing::*;
@@ -125,7 +125,7 @@ impl Command {
         info!(target: "reth::cli", "Database opened");
 
         let factory = ProviderFactory::new(&db, self.chain.clone());
-        let mut provider_rw = factory.provider_rw().map_err(PipelineError::Interface)?;
+        let mut provider_rw = factory.provider_rw()?;
 
         if let Some(listen_addr) = self.metrics {
             info!(target: "reth::cli", "Starting metrics endpoint at {}", listen_addr);
@@ -247,7 +247,7 @@ impl Command {
 
                 if self.commit {
                     provider_rw.commit()?;
-                    provider_rw = factory.provider_rw().map_err(PipelineError::Interface)?;
+                    provider_rw = factory.provider_rw()?;
                 }
             }
         }
@@ -264,7 +264,7 @@ impl Command {
 
             if self.commit {
                 provider_rw.commit()?;
-                provider_rw = factory.provider_rw().map_err(PipelineError::Interface)?;
+                provider_rw = factory.provider_rw()?;
             }
         }
 

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -355,7 +355,7 @@ where
                     inconsistent_stage_checkpoint = stage_checkpoint,
                     "Pipeline sync progress is inconsistent"
                 );
-                return self.blockchain.block_hash(first_stage_checkpoint)
+                return Ok(self.blockchain.block_hash(first_stage_checkpoint)?)
             }
         }
 
@@ -1670,7 +1670,7 @@ where
                         },
                         Err(error) => {
                             error!(target: "consensus::engine", ?error, "Error getting canonical header for continuous sync");
-                            return Some(Err(error.into()))
+                            return Some(Err(RethError::Provider(error).into()))
                         }
                     };
                     self.blockchain.set_canonical_head(max_header);
@@ -1836,7 +1836,10 @@ where
                     cx,
                     EngineContext {
                         tip_block_number: this.blockchain.canonical_tip().number,
-                        finalized_block_number: this.blockchain.finalized_block_number()?,
+                        finalized_block_number: this
+                            .blockchain
+                            .finalized_block_number()
+                            .map_err(RethError::Provider)?,
                     },
                 )? {
                     this.on_hook_result(result)?;
@@ -1908,7 +1911,10 @@ where
                     cx,
                     EngineContext {
                         tip_block_number: this.blockchain.canonical_tip().number,
-                        finalized_block_number: this.blockchain.finalized_block_number()?,
+                        finalized_block_number: this
+                            .blockchain
+                            .finalized_block_number()
+                            .map_err(RethError::Provider)?,
                     },
                     this.sync.is_pipeline_active(),
                 )? {

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -484,8 +484,8 @@ mod tests {
     use super::*;
     use mockall::mock;
     use reth_interfaces::{
+        provider::ProviderResult,
         test_utils::generators::{self, Rng},
-        RethResult,
     };
     use reth_primitives::{
         constants::eip4844::DATA_GAS_PER_BLOB, hex_literal::hex, proofs, Account, Address,
@@ -498,13 +498,13 @@ mod tests {
         WithdrawalsProvider {}
 
         impl WithdrawalsProvider for WithdrawalsProvider {
-            fn latest_withdrawal(&self) -> RethResult<Option<Withdrawal>> ;
+            fn latest_withdrawal(&self) -> ProviderResult<Option<Withdrawal>> ;
 
             fn withdrawals_by_block(
                 &self,
                 _id: BlockHashOrNumber,
                 _timestamp: u64,
-            ) -> RethResult<Option<Vec<Withdrawal>>> ;
+            ) -> ProviderResult<Option<Vec<Withdrawal>>> ;
         }
     }
 
@@ -537,37 +537,43 @@ mod tests {
     }
 
     impl AccountReader for Provider {
-        fn basic_account(&self, _address: Address) -> RethResult<Option<Account>> {
+        fn basic_account(&self, _address: Address) -> ProviderResult<Option<Account>> {
             Ok(self.account)
         }
     }
 
     impl HeaderProvider for Provider {
-        fn is_known(&self, _block_hash: &BlockHash) -> RethResult<bool> {
+        fn is_known(&self, _block_hash: &BlockHash) -> ProviderResult<bool> {
             Ok(self.is_known)
         }
 
-        fn header(&self, _block_number: &BlockHash) -> RethResult<Option<Header>> {
+        fn header(&self, _block_number: &BlockHash) -> ProviderResult<Option<Header>> {
             Ok(self.parent.clone())
         }
 
-        fn header_by_number(&self, _num: u64) -> RethResult<Option<Header>> {
+        fn header_by_number(&self, _num: u64) -> ProviderResult<Option<Header>> {
             Ok(self.parent.clone())
         }
 
-        fn header_td(&self, _hash: &BlockHash) -> RethResult<Option<U256>> {
+        fn header_td(&self, _hash: &BlockHash) -> ProviderResult<Option<U256>> {
             Ok(None)
         }
 
-        fn header_td_by_number(&self, _number: BlockNumber) -> RethResult<Option<U256>> {
+        fn header_td_by_number(&self, _number: BlockNumber) -> ProviderResult<Option<U256>> {
             Ok(None)
         }
 
-        fn headers_range(&self, _range: impl RangeBounds<BlockNumber>) -> RethResult<Vec<Header>> {
+        fn headers_range(
+            &self,
+            _range: impl RangeBounds<BlockNumber>,
+        ) -> ProviderResult<Vec<Header>> {
             Ok(vec![])
         }
 
-        fn sealed_header(&self, _block_number: BlockNumber) -> RethResult<Option<SealedHeader>> {
+        fn sealed_header(
+            &self,
+            _block_number: BlockNumber,
+        ) -> ProviderResult<Option<SealedHeader>> {
             Ok(None)
         }
 
@@ -575,7 +581,7 @@ mod tests {
             &self,
             _range: impl RangeBounds<BlockNumber>,
             _predicate: impl FnMut(&SealedHeader) -> bool,
-        ) -> RethResult<Vec<SealedHeader>> {
+        ) -> ProviderResult<Vec<SealedHeader>> {
             Ok(vec![])
         }
     }
@@ -585,11 +591,11 @@ mod tests {
             &self,
             _id: BlockHashOrNumber,
             _timestamp: u64,
-        ) -> RethResult<Option<Vec<Withdrawal>>> {
+        ) -> ProviderResult<Option<Vec<Withdrawal>>> {
             self.withdrawals_provider.withdrawals_by_block(_id, _timestamp)
         }
 
-        fn latest_withdrawal(&self) -> RethResult<Option<Withdrawal>> {
+        fn latest_withdrawal(&self) -> ProviderResult<Option<Withdrawal>> {
             self.withdrawals_provider.latest_withdrawal()
         }
     }

--- a/crates/interfaces/src/blockchain_tree/error.rs
+++ b/crates/interfaces/src/blockchain_tree/error.rs
@@ -3,6 +3,7 @@
 use crate::{
     consensus::ConsensusError,
     executor::{BlockExecutionError, BlockValidationError},
+    provider::ProviderError,
 };
 use reth_primitives::{BlockHash, BlockNumber, SealedBlock};
 
@@ -201,6 +202,9 @@ pub enum InsertBlockErrorKind {
     /// Block violated tree invariants.
     #[error(transparent)]
     Tree(#[from] BlockchainTreeError),
+    /// Provider error.
+    #[error(transparent)]
+    Provider(#[from] ProviderError),
     /// An internal error occurred, like interacting with the database.
     #[error(transparent)]
     Internal(#[from] Box<dyn std::error::Error + Send + Sync>),
@@ -260,7 +264,7 @@ impl InsertBlockErrorKind {
                     BlockchainTreeError::BlockBufferingFailed { .. } => false,
                 }
             }
-            InsertBlockErrorKind::Internal(_) => {
+            InsertBlockErrorKind::Provider(_) | InsertBlockErrorKind::Internal(_) => {
                 // any other error, such as database errors, are considered internal errors
                 false
             }

--- a/crates/interfaces/src/error.rs
+++ b/crates/interfaces/src/error.rs
@@ -33,12 +33,6 @@ impl From<crate::blockchain_tree::error::BlockchainTreeError> for RethError {
     }
 }
 
-impl From<reth_nippy_jar::NippyJarError> for RethError {
-    fn from(err: reth_nippy_jar::NippyJarError) -> Self {
-        RethError::Custom(err.to_string())
-    }
-}
-
 impl From<reth_primitives::fs::FsPathError> for RethError {
     fn from(err: reth_primitives::fs::FsPathError) -> Self {
         RethError::Custom(err.to_string())

--- a/crates/interfaces/src/provider.rs
+++ b/crates/interfaces/src/provider.rs
@@ -5,12 +5,27 @@ use reth_primitives::{
 use std::path::PathBuf;
 use thiserror::Error;
 
+/// Provider result type.
+pub type ProviderResult<Ok> = Result<Ok, ProviderError>;
+
+impl From<reth_nippy_jar::NippyJarError> for ProviderError {
+    fn from(err: reth_nippy_jar::NippyJarError) -> Self {
+        ProviderError::NippyJar(err.to_string())
+    }
+}
+
 /// Bundled errors variants thrown by various providers.
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 pub enum ProviderError {
     /// Database error.
     #[error(transparent)]
     Database(#[from] crate::db::DatabaseError),
+    /// Nippy jar error.
+    #[error("nippy jar error: {0}")]
+    NippyJar(String),
+    /// Error when recovering the sender for a transaction
+    #[error("failed to recover sender for transaction")]
+    SenderRecoveryError,
     /// The header number was not found for the given block hash.
     #[error("block hash {0} does not exist in Headers table")]
     BlockHashNotFound(BlockHash),

--- a/crates/interfaces/src/provider.rs
+++ b/crates/interfaces/src/provider.rs
@@ -8,12 +8,6 @@ use thiserror::Error;
 /// Provider result type.
 pub type ProviderResult<Ok> = Result<Ok, ProviderError>;
 
-impl From<reth_nippy_jar::NippyJarError> for ProviderError {
-    fn from(err: reth_nippy_jar::NippyJarError) -> Self {
-        ProviderError::NippyJar(err.to_string())
-    }
-}
-
 /// Bundled errors variants thrown by various providers.
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 pub enum ProviderError {
@@ -120,6 +114,12 @@ pub enum ProviderError {
     /// Snapshot file is not found for requested transaction.
     #[error("not able to find {0} snapshot file for transaction id {1}")]
     MissingSnapshotTx(SnapshotSegment, TxNumber),
+}
+
+impl From<reth_nippy_jar::NippyJarError> for ProviderError {
+    fn from(err: reth_nippy_jar::NippyJarError) -> Self {
+        ProviderError::NippyJar(err.to_string())
+    }
 }
 
 /// A root mismatch error at a given block height.

--- a/crates/payload/builder/src/error.rs
+++ b/crates/payload/builder/src/error.rs
@@ -17,12 +17,9 @@ pub enum PayloadBuilderError {
     /// Error occurring in the blob store.
     #[error(transparent)]
     BlobStore(#[from] BlobStoreError),
-    /// Provider error
-    #[error(transparent)]
-    Provider(#[from] ProviderError),
     /// Other internal error
     #[error(transparent)]
-    Internal(#[from] RethError), // TODO: remove?
+    Internal(#[from] RethError),
     /// Unrecoverable error during evm execution.
     #[error("evm execution error: {0}")]
     EvmExecutionError(EVMError<RethError>),
@@ -33,6 +30,12 @@ pub enum PayloadBuilderError {
     #[cfg(feature = "optimism")]
     #[error(transparent)]
     Optimism(#[from] OptimismPayloadBuilderError),
+}
+
+impl From<ProviderError> for PayloadBuilderError {
+    fn from(error: ProviderError) -> Self {
+        PayloadBuilderError::Internal(RethError::Provider(error))
+    }
 }
 
 /// Optimism specific payload building errors.

--- a/crates/payload/builder/src/error.rs
+++ b/crates/payload/builder/src/error.rs
@@ -1,6 +1,6 @@
 //! Error types emitted by types or implementations of this crate.
 
-use reth_interfaces::RethError;
+use reth_interfaces::{provider::ProviderError, RethError};
 use reth_primitives::{revm_primitives::EVMError, B256};
 use reth_transaction_pool::BlobStoreError;
 use tokio::sync::oneshot;
@@ -17,9 +17,12 @@ pub enum PayloadBuilderError {
     /// Error occurring in the blob store.
     #[error(transparent)]
     BlobStore(#[from] BlobStoreError),
+    /// Provider error
+    #[error(transparent)]
+    Provider(#[from] ProviderError),
     /// Other internal error
     #[error(transparent)]
-    Internal(#[from] RethError),
+    Internal(#[from] RethError), // TODO: remove?
     /// Unrecoverable error during evm execution.
     #[error("evm execution error: {0}")]
     EvmExecutionError(EVMError<RethError>),

--- a/crates/prune/src/segments/mod.rs
+++ b/crates/prune/src/segments/mod.rs
@@ -22,7 +22,7 @@ pub use transactions::Transactions;
 
 use crate::PrunerError;
 use reth_db::database::Database;
-use reth_interfaces::RethResult;
+use reth_interfaces::{provider::ProviderResult, RethResult};
 use reth_primitives::{BlockNumber, PruneCheckpoint, PruneMode, PruneSegment, TxNumber};
 use reth_provider::{BlockReader, DatabaseProviderRW, PruneCheckpointWriter};
 use std::ops::RangeInclusive;
@@ -54,7 +54,7 @@ pub trait Segment<DB: Database>: Debug + Send + Sync {
         &self,
         provider: &DatabaseProviderRW<'_, DB>,
         checkpoint: PruneCheckpoint,
-    ) -> RethResult<()> {
+    ) -> ProviderResult<()> {
         provider.save_prune_checkpoint(self.segment(), checkpoint)
     }
 }

--- a/crates/prune/src/segments/receipts.rs
+++ b/crates/prune/src/segments/receipts.rs
@@ -3,7 +3,7 @@ use crate::{
     PrunerError,
 };
 use reth_db::{database::Database, tables};
-use reth_interfaces::RethResult;
+use reth_interfaces::provider::ProviderResult;
 use reth_primitives::{PruneCheckpoint, PruneMode, PruneSegment};
 use reth_provider::{DatabaseProviderRW, PruneCheckpointWriter, TransactionsProvider};
 use tracing::{instrument, trace};
@@ -73,7 +73,7 @@ impl<DB: Database> Segment<DB> for Receipts {
         &self,
         provider: &DatabaseProviderRW<'_, DB>,
         checkpoint: PruneCheckpoint,
-    ) -> RethResult<()> {
+    ) -> ProviderResult<()> {
         provider.save_prune_checkpoint(PruneSegment::Receipts, checkpoint)?;
 
         // `PruneSegment::Receipts` overrides `PruneSegment::ContractLogs`, so we can preemptively

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -600,8 +600,7 @@ mod tests {
 
     impl AccountReader for StateProviderTest {
         fn basic_account(&self, address: Address) -> ProviderResult<Option<Account>> {
-            let ret = Ok(self.accounts.get(&address).map(|(_, acc)| *acc));
-            ret
+            Ok(self.accounts.get(&address).map(|(_, acc)| *acc))
         }
     }
 

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -557,7 +557,7 @@ pub fn verify_receipt<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use reth_interfaces::RethResult;
+    use reth_interfaces::provider::ProviderResult;
     use reth_primitives::{
         bytes,
         constants::{BEACON_ROOTS_ADDRESS, SYSTEM_ADDRESS},
@@ -599,14 +599,14 @@ mod tests {
     }
 
     impl AccountReader for StateProviderTest {
-        fn basic_account(&self, address: Address) -> RethResult<Option<Account>> {
+        fn basic_account(&self, address: Address) -> ProviderResult<Option<Account>> {
             let ret = Ok(self.accounts.get(&address).map(|(_, acc)| *acc));
             ret
         }
     }
 
     impl BlockHashReader for StateProviderTest {
-        fn block_hash(&self, number: u64) -> RethResult<Option<B256>> {
+        fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
             Ok(self.block_hash.get(&number).cloned())
         }
 
@@ -614,7 +614,7 @@ mod tests {
             &self,
             start: BlockNumber,
             end: BlockNumber,
-        ) -> RethResult<Vec<B256>> {
+        ) -> ProviderResult<Vec<B256>> {
             let range = start..end;
             Ok(self
                 .block_hash
@@ -625,7 +625,7 @@ mod tests {
     }
 
     impl StateRootProvider for StateProviderTest {
-        fn state_root(&self, _bundle_state: &BundleStateWithReceipts) -> RethResult<B256> {
+        fn state_root(&self, _bundle_state: &BundleStateWithReceipts) -> ProviderResult<B256> {
             unimplemented!("state root computation is not supported")
         }
     }
@@ -635,18 +635,18 @@ mod tests {
             &self,
             account: Address,
             storage_key: StorageKey,
-        ) -> RethResult<Option<reth_primitives::StorageValue>> {
+        ) -> ProviderResult<Option<reth_primitives::StorageValue>> {
             Ok(self
                 .accounts
                 .get(&account)
                 .and_then(|(storage, _)| storage.get(&storage_key).cloned()))
         }
 
-        fn bytecode_by_hash(&self, code_hash: B256) -> RethResult<Option<Bytecode>> {
+        fn bytecode_by_hash(&self, code_hash: B256) -> ProviderResult<Option<Bytecode>> {
             Ok(self.contracts.get(&code_hash).cloned())
         }
 
-        fn proof(&self, _address: Address, _keys: &[B256]) -> RethResult<AccountProof> {
+        fn proof(&self, _address: Address, _keys: &[B256]) -> ProviderResult<AccountProof> {
             unimplemented!("proof generation is not supported")
         }
     }

--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -226,12 +226,12 @@ where
 
     /// Returns the state at the given block number
     pub fn state_at_hash(&self, block_hash: B256) -> RethResult<StateProviderBox<'_>> {
-        self.provider().history_by_block_hash(block_hash)
+        Ok(self.provider().history_by_block_hash(block_hash)?)
     }
 
     /// Returns the _latest_ state
     pub fn latest_state(&self) -> RethResult<StateProviderBox<'_>> {
-        self.provider().latest()
+        Ok(self.provider().latest()?)
     }
 }
 
@@ -364,7 +364,7 @@ where
 
     /// Returns the current info for the chain
     fn chain_info(&self) -> RethResult<ChainInfo> {
-        self.provider().chain_info()
+        Ok(self.provider().chain_info()?)
     }
 
     fn accounts(&self) -> Vec<Address> {

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -11,9 +11,8 @@ use core::fmt;
 
 use async_trait::async_trait;
 use jsonrpsee::{core::RpcResult, server::IdProvider};
-use reth_interfaces::RethError;
 use reth_primitives::{BlockHashOrNumber, IntoRecoveredTransaction, Receipt, SealedBlock, TxHash};
-use reth_provider::{BlockIdReader, BlockReader, EvmEnvProvider};
+use reth_provider::{BlockIdReader, BlockReader, EvmEnvProvider, ProviderError};
 use reth_rpc_api::EthFilterApiServer;
 use reth_rpc_types::{
     Filter, FilterBlockOption, FilterChanges, FilterId, FilteredParams, Log,
@@ -690,8 +689,8 @@ impl From<FilterError> for jsonrpsee::types::error::ErrorObject<'static> {
     }
 }
 
-impl From<RethError> for FilterError {
-    fn from(err: RethError) -> Self {
+impl From<ProviderError> for FilterError {
+    fn from(err: ProviderError) -> Self {
         FilterError::EthAPIError(err.into())
     }
 }

--- a/crates/rpc/rpc/src/result.rs
+++ b/crates/rpc/rpc/src/result.rs
@@ -104,6 +104,7 @@ macro_rules! impl_to_rpc_result {
 
 impl_to_rpc_result!(PayloadError);
 impl_to_rpc_result!(reth_interfaces::RethError);
+impl_to_rpc_result!(reth_interfaces::provider::ProviderError);
 impl_to_rpc_result!(reth_network_api::NetworkError);
 
 /// An extension to used to apply error conversions to various result types

--- a/crates/snapshot/src/segments/headers.rs
+++ b/crates/snapshot/src/segments/headers.rs
@@ -3,7 +3,7 @@ use reth_db::{
     cursor::DbCursorRO, database::Database, snapshot::create_snapshot_T1_T2_T3, tables,
     transaction::DbTx, RawKey, RawTable,
 };
-use reth_interfaces::RethResult;
+use reth_interfaces::provider::ProviderResult;
 use reth_primitives::{
     snapshot::{Compression, Filters, SegmentConfig},
     BlockNumber, SnapshotSegment,
@@ -40,7 +40,7 @@ impl Segment for Headers {
         provider: &DatabaseProviderRO<'_, DB>,
         directory: impl AsRef<Path>,
         range: RangeInclusive<BlockNumber>,
-    ) -> RethResult<()> {
+    ) -> ProviderResult<()> {
         let range_len = range.clone().count();
         let mut jar = prepare_jar::<DB, 3>(
             provider,

--- a/crates/snapshot/src/segments/mod.rs
+++ b/crates/snapshot/src/segments/mod.rs
@@ -12,7 +12,7 @@ pub use receipts::Receipts;
 use reth_db::{
     cursor::DbCursorRO, database::Database, table::Table, transaction::DbTx, RawKey, RawTable,
 };
-use reth_interfaces::RethResult;
+use reth_interfaces::provider::ProviderResult;
 use reth_nippy_jar::NippyJar;
 use reth_primitives::{
     snapshot::{
@@ -34,7 +34,7 @@ pub trait Segment: Default {
         provider: &DatabaseProviderRO<'_, DB>,
         directory: impl AsRef<Path>,
         range: RangeInclusive<BlockNumber>,
-    ) -> RethResult<()>;
+    ) -> ProviderResult<()>;
 
     /// Returns this struct's [`SnapshotSegment`].
     fn segment() -> SnapshotSegment;
@@ -45,7 +45,7 @@ pub trait Segment: Default {
         provider: &DatabaseProviderRO<'_, DB>,
         range: &RangeInclusive<u64>,
         range_len: usize,
-    ) -> RethResult<Vec<Vec<u8>>> {
+    ) -> ProviderResult<Vec<Vec<u8>>> {
         let mut cursor = provider.tx_ref().cursor_read::<RawTable<T>>()?;
         Ok(cursor
             .walk_back(Some(RawKey::from(*range.end())))?
@@ -64,8 +64,8 @@ pub(crate) fn prepare_jar<DB: Database, const COLUMNS: usize>(
     segment_config: SegmentConfig,
     block_range: RangeInclusive<BlockNumber>,
     total_rows: usize,
-    prepare_compression: impl Fn() -> RethResult<Rows<COLUMNS>>,
-) -> RethResult<NippyJar<SegmentHeader>> {
+    prepare_compression: impl Fn() -> ProviderResult<Rows<COLUMNS>>,
+) -> ProviderResult<NippyJar<SegmentHeader>> {
     let tx_range = provider.transaction_range_by_block_range(block_range.clone())?;
     let mut nippy_jar = NippyJar::new(
         COLUMNS,

--- a/crates/snapshot/src/segments/receipts.rs
+++ b/crates/snapshot/src/segments/receipts.rs
@@ -1,6 +1,6 @@
 use crate::segments::{prepare_jar, Segment};
 use reth_db::{database::Database, snapshot::create_snapshot_T1, tables};
-use reth_interfaces::RethResult;
+use reth_interfaces::provider::ProviderResult;
 use reth_primitives::{
     snapshot::{Compression, Filters, SegmentConfig, SegmentHeader},
     BlockNumber, SnapshotSegment, TxNumber,
@@ -37,7 +37,7 @@ impl Segment for Receipts {
         provider: &DatabaseProviderRO<'_, DB>,
         directory: impl AsRef<Path>,
         block_range: RangeInclusive<BlockNumber>,
-    ) -> RethResult<()> {
+    ) -> ProviderResult<()> {
         let tx_range = provider.transaction_range_by_block_range(block_range.clone())?;
         let tx_range_len = tx_range.clone().count();
 

--- a/crates/snapshot/src/segments/transactions.rs
+++ b/crates/snapshot/src/segments/transactions.rs
@@ -1,6 +1,6 @@
 use crate::segments::{prepare_jar, Segment};
 use reth_db::{database::Database, snapshot::create_snapshot_T1, tables};
-use reth_interfaces::RethResult;
+use reth_interfaces::provider::ProviderResult;
 use reth_primitives::{
     snapshot::{Compression, Filters, SegmentConfig, SegmentHeader},
     BlockNumber, SnapshotSegment, TxNumber,
@@ -37,7 +37,7 @@ impl Segment for Transactions {
         provider: &DatabaseProviderRO<'_, DB>,
         directory: impl AsRef<Path>,
         block_range: RangeInclusive<BlockNumber>,
-    ) -> RethResult<()> {
+    ) -> ProviderResult<()> {
         let tx_range = provider.transaction_range_by_block_range(block_range.clone())?;
         let tx_range_len = tx_range.clone().count();
 

--- a/crates/stages/src/error.rs
+++ b/crates/stages/src/error.rs
@@ -109,9 +109,9 @@ pub enum PipelineError {
     /// The pipeline encountered a database error.
     #[error(transparent)]
     Database(#[from] DbError),
-    /// The pipeline encountered an irrecoverable error in one of the stages.
+    /// Provider error.
     #[error(transparent)]
-    Interface(#[from] RethError),
+    Provider(#[from] ProviderError),
     /// The pipeline encountered an error while trying to send an event.
     #[error("pipeline encountered an error while trying to send an event")]
     Channel(#[from] SendError<PipelineEvent>),

--- a/crates/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/src/stages/hashing_storage.rs
@@ -175,7 +175,7 @@ impl<DB: Database> Stage<DB> for StorageHashingStage {
             // iterate over plain state and get newest storage value.
             // Assumption we are okay with is that plain state represent
             // `previous_stage_progress` state.
-            let storages = provider.plainstate_storages(lists)?;
+            let storages = provider.plain_state_storages(lists)?;
             provider.insert_storage_for_hashing(storages)?;
         }
 

--- a/crates/stages/src/test_utils/runner.rs
+++ b/crates/stages/src/test_utils/runner.rs
@@ -1,9 +1,9 @@
 use super::TestTransaction;
 use crate::{ExecInput, ExecOutput, Stage, StageError, UnwindInput, UnwindOutput};
 use reth_db::DatabaseEnv;
-use reth_interfaces::{db::DatabaseError, RethError};
+use reth_interfaces::db::DatabaseError;
 use reth_primitives::MAINNET;
-use reth_provider::ProviderFactory;
+use reth_provider::{ProviderError, ProviderFactory};
 use std::{borrow::Borrow, sync::Arc};
 use tokio::sync::oneshot;
 
@@ -14,7 +14,7 @@ pub(crate) enum TestRunnerError {
     #[error(transparent)]
     Internal(#[from] Box<dyn std::error::Error>),
     #[error(transparent)]
-    Interface(#[from] RethError),
+    Provider(#[from] ProviderError),
 }
 
 /// A generic test runner for stages.

--- a/crates/storage/db/src/snapshot/cursor.rs
+++ b/crates/storage/db/src/snapshot/cursor.rs
@@ -1,7 +1,7 @@
 use super::mask::{ColumnSelectorOne, ColumnSelectorThree, ColumnSelectorTwo};
 use crate::table::Decompress;
 use derive_more::{Deref, DerefMut};
-use reth_interfaces::{RethError, RethResult};
+use reth_interfaces::provider::ProviderResult;
 use reth_nippy_jar::{MmapHandle, NippyJar, NippyJarCursor};
 use reth_primitives::{snapshot::SegmentHeader, B256};
 
@@ -11,10 +11,7 @@ pub struct SnapshotCursor<'a>(NippyJarCursor<'a, SegmentHeader>);
 
 impl<'a> SnapshotCursor<'a> {
     /// Returns a new [`SnapshotCursor`].
-    pub fn new(
-        jar: &'a NippyJar<SegmentHeader>,
-        mmap_handle: MmapHandle,
-    ) -> Result<Self, RethError> {
+    pub fn new(jar: &'a NippyJar<SegmentHeader>, mmap_handle: MmapHandle) -> ProviderResult<Self> {
         Ok(Self(NippyJarCursor::with_handle(jar, mmap_handle)?))
     }
 
@@ -29,7 +26,7 @@ impl<'a> SnapshotCursor<'a> {
         &mut self,
         key_or_num: KeyOrNumber<'_>,
         mask: usize,
-    ) -> RethResult<Option<Vec<&'_ [u8]>>> {
+    ) -> ProviderResult<Option<Vec<&'_ [u8]>>> {
         let row = match key_or_num {
             KeyOrNumber::Key(k) => self.row_by_key_with_cols(k, mask),
             KeyOrNumber::Number(n) => {
@@ -48,7 +45,7 @@ impl<'a> SnapshotCursor<'a> {
     pub fn get_one<M: ColumnSelectorOne>(
         &mut self,
         key_or_num: KeyOrNumber<'_>,
-    ) -> RethResult<Option<M::FIRST>> {
+    ) -> ProviderResult<Option<M::FIRST>> {
         let row = self.get(key_or_num, M::MASK)?;
 
         match row {
@@ -61,7 +58,7 @@ impl<'a> SnapshotCursor<'a> {
     pub fn get_two<M: ColumnSelectorTwo>(
         &mut self,
         key_or_num: KeyOrNumber<'_>,
-    ) -> RethResult<Option<(M::FIRST, M::SECOND)>> {
+    ) -> ProviderResult<Option<(M::FIRST, M::SECOND)>> {
         let row = self.get(key_or_num, M::MASK)?;
 
         match row {
@@ -75,7 +72,7 @@ impl<'a> SnapshotCursor<'a> {
     pub fn get_three<M: ColumnSelectorThree>(
         &mut self,
         key_or_num: KeyOrNumber<'_>,
-    ) -> RethResult<Option<(M::FIRST, M::SECOND, M::THIRD)>> {
+    ) -> ProviderResult<Option<(M::FIRST, M::SECOND, M::THIRD)>> {
         let row = self.get(key_or_num, M::MASK)?;
 
         match row {

--- a/crates/storage/db/src/snapshot/generation.rs
+++ b/crates/storage/db/src/snapshot/generation.rs
@@ -5,9 +5,8 @@ use crate::{
     RawKey, RawTable,
 };
 
-use reth_interfaces::RethResult;
+use reth_interfaces::provider::ProviderResult;
 use reth_nippy_jar::{ColumnResult, NippyJar, PHFKey};
-
 use reth_tracing::tracing::*;
 use serde::{Deserialize, Serialize};
 use std::{error::Error as StdError, ops::RangeInclusive};
@@ -46,7 +45,7 @@ macro_rules! generate_snapshot_func {
                     keys: Option<impl Iterator<Item = ColumnResult<impl PHFKey>>>,
                     row_count: usize,
                     nippy_jar: &mut NippyJar<H>
-                ) -> RethResult<()>
+                ) -> ProviderResult<()>
                     where K: Key + Copy
                 {
                     let additional = additional.unwrap_or_default();

--- a/crates/storage/nippy-jar/src/error.rs
+++ b/crates/storage/nippy-jar/src/error.rs
@@ -1,7 +1,7 @@
 use thiserror::Error;
 
 /// Errors associated with [`crate::NippyJar`].
-#[derive(Debug, Error)]
+#[derive(Error, Debug)]
 pub enum NippyJarError {
     #[error(transparent)]
     Internal(#[from] Box<dyn std::error::Error + Send + Sync>),

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     TransactionVariant, TransactionsProvider, WithdrawalsProvider,
 };
 use reth_db::{database::Database, init_db, models::StoredBlockBodyIndices, DatabaseEnv};
-use reth_interfaces::{db::LogLevel, RethError, RethResult};
+use reth_interfaces::{db::LogLevel, provider::ProviderResult, RethError, RethResult};
 use reth_primitives::{
     snapshot::HighestSnapshots,
     stage::{StageCheckpoint, StageId},
@@ -49,7 +49,7 @@ impl<DB: Database> ProviderFactory<DB> {
     /// Returns a provider with a created `DbTx` inside, which allows fetching data from the
     /// database using different types of providers. Example: [`HeaderProvider`]
     /// [`BlockHashReader`]. This may fail if the inner read database transaction fails to open.
-    pub fn provider(&self) -> RethResult<DatabaseProviderRO<'_, DB>> {
+    pub fn provider(&self) -> ProviderResult<DatabaseProviderRO<'_, DB>> {
         let mut provider = DatabaseProvider::new(self.db.tx()?, self.chain_spec.clone());
 
         if let Some(snapshot_provider) = &self.snapshot_provider {
@@ -63,7 +63,7 @@ impl<DB: Database> ProviderFactory<DB> {
     /// data from the database using different types of providers. Example: [`HeaderProvider`]
     /// [`BlockHashReader`].  This may fail if the inner read/write database transaction fails to
     /// open.
-    pub fn provider_rw(&self) -> RethResult<DatabaseProviderRW<'_, DB>> {
+    pub fn provider_rw(&self) -> ProviderResult<DatabaseProviderRW<'_, DB>> {
         let mut provider = DatabaseProvider::new_rw(self.db.tx_mut()?, self.chain_spec.clone());
 
         if let Some(snapshot_provider) = &self.snapshot_provider {
@@ -122,7 +122,7 @@ impl<DB: Clone> Clone for ProviderFactory<DB> {
 
 impl<DB: Database> ProviderFactory<DB> {
     /// Storage provider for latest block
-    pub fn latest(&self) -> RethResult<StateProviderBox<'_>> {
+    pub fn latest(&self) -> ProviderResult<StateProviderBox<'_>> {
         trace!(target: "providers::db", "Returning latest state provider");
         Ok(Box::new(LatestStateProvider::new(self.db.tx()?)))
     }
@@ -131,7 +131,7 @@ impl<DB: Database> ProviderFactory<DB> {
     fn state_provider_by_block_number(
         &self,
         mut block_number: BlockNumber,
-    ) -> RethResult<StateProviderBox<'_>> {
+    ) -> ProviderResult<StateProviderBox<'_>> {
         let provider = self.provider()?;
 
         if block_number == provider.best_block_number().unwrap_or_default() &&
@@ -174,14 +174,17 @@ impl<DB: Database> ProviderFactory<DB> {
     pub fn history_by_block_number(
         &self,
         block_number: BlockNumber,
-    ) -> RethResult<StateProviderBox<'_>> {
+    ) -> ProviderResult<StateProviderBox<'_>> {
         let state_provider = self.state_provider_by_block_number(block_number)?;
         trace!(target: "providers::db", ?block_number, "Returning historical state provider for block number");
         Ok(state_provider)
     }
 
     /// Storage provider for state at that given block hash
-    pub fn history_by_block_hash(&self, block_hash: BlockHash) -> RethResult<StateProviderBox<'_>> {
+    pub fn history_by_block_hash(
+        &self,
+        block_hash: BlockHash,
+    ) -> ProviderResult<StateProviderBox<'_>> {
         let block_number = self
             .provider()?
             .block_number(block_hash)?
@@ -194,34 +197,34 @@ impl<DB: Database> ProviderFactory<DB> {
 }
 
 impl<DB: Database> HeaderProvider for ProviderFactory<DB> {
-    fn header(&self, block_hash: &BlockHash) -> RethResult<Option<Header>> {
+    fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Header>> {
         self.provider()?.header(block_hash)
     }
 
-    fn header_by_number(&self, num: BlockNumber) -> RethResult<Option<Header>> {
+    fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Header>> {
         self.provider()?.header_by_number(num)
     }
 
-    fn header_td(&self, hash: &BlockHash) -> RethResult<Option<U256>> {
+    fn header_td(&self, hash: &BlockHash) -> ProviderResult<Option<U256>> {
         self.provider()?.header_td(hash)
     }
 
-    fn header_td_by_number(&self, number: BlockNumber) -> RethResult<Option<U256>> {
+    fn header_td_by_number(&self, number: BlockNumber) -> ProviderResult<Option<U256>> {
         self.provider()?.header_td_by_number(number)
     }
 
-    fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> RethResult<Vec<Header>> {
+    fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> ProviderResult<Vec<Header>> {
         self.provider()?.headers_range(range)
     }
 
-    fn sealed_header(&self, number: BlockNumber) -> RethResult<Option<SealedHeader>> {
+    fn sealed_header(&self, number: BlockNumber) -> ProviderResult<Option<SealedHeader>> {
         self.provider()?.sealed_header(number)
     }
 
     fn sealed_headers_range(
         &self,
         range: impl RangeBounds<BlockNumber>,
-    ) -> RethResult<Vec<SealedHeader>> {
+    ) -> ProviderResult<Vec<SealedHeader>> {
         self.provider()?.sealed_headers_range(range)
     }
 
@@ -229,13 +232,13 @@ impl<DB: Database> HeaderProvider for ProviderFactory<DB> {
         &self,
         range: impl RangeBounds<BlockNumber>,
         predicate: impl FnMut(&SealedHeader) -> bool,
-    ) -> RethResult<Vec<SealedHeader>> {
+    ) -> ProviderResult<Vec<SealedHeader>> {
         self.provider()?.sealed_headers_while(range, predicate)
     }
 }
 
 impl<DB: Database> BlockHashReader for ProviderFactory<DB> {
-    fn block_hash(&self, number: u64) -> RethResult<Option<B256>> {
+    fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
         self.provider()?.block_hash(number)
     }
 
@@ -243,54 +246,54 @@ impl<DB: Database> BlockHashReader for ProviderFactory<DB> {
         &self,
         start: BlockNumber,
         end: BlockNumber,
-    ) -> RethResult<Vec<B256>> {
+    ) -> ProviderResult<Vec<B256>> {
         self.provider()?.canonical_hashes_range(start, end)
     }
 }
 
 impl<DB: Database> BlockNumReader for ProviderFactory<DB> {
-    fn chain_info(&self) -> RethResult<ChainInfo> {
+    fn chain_info(&self) -> ProviderResult<ChainInfo> {
         self.provider()?.chain_info()
     }
 
-    fn best_block_number(&self) -> RethResult<BlockNumber> {
+    fn best_block_number(&self) -> ProviderResult<BlockNumber> {
         self.provider()?.best_block_number()
     }
 
-    fn last_block_number(&self) -> RethResult<BlockNumber> {
-        self.provider()?.last_block_number()
+    fn last_block_number(&self) -> ProviderResult<BlockNumber> {
+        Ok(self.provider()?.last_block_number()?)
     }
 
-    fn block_number(&self, hash: B256) -> RethResult<Option<BlockNumber>> {
-        self.provider()?.block_number(hash)
+    fn block_number(&self, hash: B256) -> ProviderResult<Option<BlockNumber>> {
+        Ok(self.provider()?.block_number(hash)?)
     }
 }
 
 impl<DB: Database> BlockReader for ProviderFactory<DB> {
-    fn find_block_by_hash(&self, hash: B256, source: BlockSource) -> RethResult<Option<Block>> {
+    fn find_block_by_hash(&self, hash: B256, source: BlockSource) -> ProviderResult<Option<Block>> {
         self.provider()?.find_block_by_hash(hash, source)
     }
 
-    fn block(&self, id: BlockHashOrNumber) -> RethResult<Option<Block>> {
+    fn block(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Block>> {
         self.provider()?.block(id)
     }
 
-    fn pending_block(&self) -> RethResult<Option<SealedBlock>> {
+    fn pending_block(&self) -> ProviderResult<Option<SealedBlock>> {
         self.provider()?.pending_block()
     }
 
-    fn pending_block_and_receipts(&self) -> RethResult<Option<(SealedBlock, Vec<Receipt>)>> {
+    fn pending_block_and_receipts(&self) -> ProviderResult<Option<(SealedBlock, Vec<Receipt>)>> {
         self.provider()?.pending_block_and_receipts()
     }
 
-    fn ommers(&self, id: BlockHashOrNumber) -> RethResult<Option<Vec<Header>>> {
+    fn ommers(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Header>>> {
         self.provider()?.ommers(id)
     }
 
     fn block_body_indices(
         &self,
         number: BlockNumber,
-    ) -> RethResult<Option<StoredBlockBodyIndices>> {
+    ) -> ProviderResult<Option<StoredBlockBodyIndices>> {
         self.provider()?.block_body_indices(number)
     }
 
@@ -298,86 +301,89 @@ impl<DB: Database> BlockReader for ProviderFactory<DB> {
         &self,
         id: BlockHashOrNumber,
         transaction_kind: TransactionVariant,
-    ) -> RethResult<Option<BlockWithSenders>> {
+    ) -> ProviderResult<Option<BlockWithSenders>> {
         self.provider()?.block_with_senders(id, transaction_kind)
     }
 
-    fn block_range(&self, range: RangeInclusive<BlockNumber>) -> RethResult<Vec<Block>> {
+    fn block_range(&self, range: RangeInclusive<BlockNumber>) -> ProviderResult<Vec<Block>> {
         self.provider()?.block_range(range)
     }
 }
 
 impl<DB: Database> TransactionsProvider for ProviderFactory<DB> {
-    fn transaction_id(&self, tx_hash: TxHash) -> RethResult<Option<TxNumber>> {
+    fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
         self.provider()?.transaction_id(tx_hash)
     }
 
-    fn transaction_by_id(&self, id: TxNumber) -> RethResult<Option<TransactionSigned>> {
+    fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<TransactionSigned>> {
         self.provider()?.transaction_by_id(id)
     }
 
     fn transaction_by_id_no_hash(
         &self,
         id: TxNumber,
-    ) -> RethResult<Option<TransactionSignedNoHash>> {
+    ) -> ProviderResult<Option<TransactionSignedNoHash>> {
         self.provider()?.transaction_by_id_no_hash(id)
     }
 
-    fn transaction_by_hash(&self, hash: TxHash) -> RethResult<Option<TransactionSigned>> {
+    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<TransactionSigned>> {
         self.provider()?.transaction_by_hash(hash)
     }
 
     fn transaction_by_hash_with_meta(
         &self,
         tx_hash: TxHash,
-    ) -> RethResult<Option<(TransactionSigned, TransactionMeta)>> {
+    ) -> ProviderResult<Option<(TransactionSigned, TransactionMeta)>> {
         self.provider()?.transaction_by_hash_with_meta(tx_hash)
     }
 
-    fn transaction_block(&self, id: TxNumber) -> RethResult<Option<BlockNumber>> {
+    fn transaction_block(&self, id: TxNumber) -> ProviderResult<Option<BlockNumber>> {
         self.provider()?.transaction_block(id)
     }
 
     fn transactions_by_block(
         &self,
         id: BlockHashOrNumber,
-    ) -> RethResult<Option<Vec<TransactionSigned>>> {
+    ) -> ProviderResult<Option<Vec<TransactionSigned>>> {
         self.provider()?.transactions_by_block(id)
     }
 
     fn transactions_by_block_range(
         &self,
         range: impl RangeBounds<BlockNumber>,
-    ) -> RethResult<Vec<Vec<TransactionSigned>>> {
+    ) -> ProviderResult<Vec<Vec<TransactionSigned>>> {
         self.provider()?.transactions_by_block_range(range)
     }
 
     fn transactions_by_tx_range(
         &self,
         range: impl RangeBounds<TxNumber>,
-    ) -> RethResult<Vec<TransactionSignedNoHash>> {
+    ) -> ProviderResult<Vec<TransactionSignedNoHash>> {
         self.provider()?.transactions_by_tx_range(range)
     }
 
-    fn senders_by_tx_range(&self, range: impl RangeBounds<TxNumber>) -> RethResult<Vec<Address>> {
+    fn senders_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Address>> {
         self.provider()?.senders_by_tx_range(range)
     }
 
-    fn transaction_sender(&self, id: TxNumber) -> RethResult<Option<Address>> {
+    fn transaction_sender(&self, id: TxNumber) -> ProviderResult<Option<Address>> {
         self.provider()?.transaction_sender(id)
     }
 }
 
 impl<DB: Database> ReceiptProvider for ProviderFactory<DB> {
-    fn receipt(&self, id: TxNumber) -> RethResult<Option<Receipt>> {
+    fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Receipt>> {
         self.provider()?.receipt(id)
     }
 
-    fn receipt_by_hash(&self, hash: TxHash) -> RethResult<Option<Receipt>> {
+    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Receipt>> {
         self.provider()?.receipt_by_hash(hash)
     }
 
-    fn receipts_by_block(&self, block: BlockHashOrNumber) -> RethResult<Option<Vec<Receipt>>> {
+    fn receipts_by_block(&self, block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
         self.provider()?.receipts_by_block(block)
     }
 }
@@ -387,21 +393,21 @@ impl<DB: Database> WithdrawalsProvider for ProviderFactory<DB> {
         &self,
         id: BlockHashOrNumber,
         timestamp: u64,
-    ) -> RethResult<Option<Vec<Withdrawal>>> {
+    ) -> ProviderResult<Option<Vec<Withdrawal>>> {
         self.provider()?.withdrawals_by_block(id, timestamp)
     }
 
-    fn latest_withdrawal(&self) -> RethResult<Option<Withdrawal>> {
+    fn latest_withdrawal(&self) -> ProviderResult<Option<Withdrawal>> {
         self.provider()?.latest_withdrawal()
     }
 }
 
 impl<DB: Database> StageCheckpointReader for ProviderFactory<DB> {
-    fn get_stage_checkpoint(&self, id: StageId) -> RethResult<Option<StageCheckpoint>> {
+    fn get_stage_checkpoint(&self, id: StageId) -> ProviderResult<Option<StageCheckpoint>> {
         self.provider()?.get_stage_checkpoint(id)
     }
 
-    fn get_stage_checkpoint_progress(&self, id: StageId) -> RethResult<Option<Vec<u8>>> {
+    fn get_stage_checkpoint_progress(&self, id: StageId) -> ProviderResult<Option<Vec<u8>>> {
         self.provider()?.get_stage_checkpoint_progress(id)
     }
 }
@@ -412,7 +418,7 @@ impl<DB: Database> EvmEnvProvider for ProviderFactory<DB> {
         cfg: &mut CfgEnv,
         block_env: &mut BlockEnv,
         at: BlockHashOrNumber,
-    ) -> RethResult<()> {
+    ) -> ProviderResult<()> {
         self.provider()?.fill_env_at(cfg, block_env, at)
     }
 
@@ -421,11 +427,15 @@ impl<DB: Database> EvmEnvProvider for ProviderFactory<DB> {
         cfg: &mut CfgEnv,
         block_env: &mut BlockEnv,
         header: &Header,
-    ) -> RethResult<()> {
+    ) -> ProviderResult<()> {
         self.provider()?.fill_env_with_header(cfg, block_env, header)
     }
 
-    fn fill_block_env_at(&self, block_env: &mut BlockEnv, at: BlockHashOrNumber) -> RethResult<()> {
+    fn fill_block_env_at(
+        &self,
+        block_env: &mut BlockEnv,
+        at: BlockHashOrNumber,
+    ) -> ProviderResult<()> {
         self.provider()?.fill_block_env_at(block_env, at)
     }
 
@@ -433,15 +443,15 @@ impl<DB: Database> EvmEnvProvider for ProviderFactory<DB> {
         &self,
         block_env: &mut BlockEnv,
         header: &Header,
-    ) -> RethResult<()> {
+    ) -> ProviderResult<()> {
         self.provider()?.fill_block_env_with_header(block_env, header)
     }
 
-    fn fill_cfg_env_at(&self, cfg: &mut CfgEnv, at: BlockHashOrNumber) -> RethResult<()> {
+    fn fill_cfg_env_at(&self, cfg: &mut CfgEnv, at: BlockHashOrNumber) -> ProviderResult<()> {
         self.provider()?.fill_cfg_env_at(cfg, at)
     }
 
-    fn fill_cfg_env_with_header(&self, cfg: &mut CfgEnv, header: &Header) -> RethResult<()> {
+    fn fill_cfg_env_with_header(&self, cfg: &mut CfgEnv, header: &Header) -> ProviderResult<()> {
         self.provider()?.fill_cfg_env_with_header(cfg, header)
     }
 }
@@ -456,7 +466,10 @@ where
 }
 
 impl<DB: Database> PruneCheckpointReader for ProviderFactory<DB> {
-    fn get_prune_checkpoint(&self, segment: PruneSegment) -> RethResult<Option<PruneCheckpoint>> {
+    fn get_prune_checkpoint(
+        &self,
+        segment: PruneSegment,
+    ) -> ProviderResult<Option<PruneCheckpoint>> {
         self.provider()?.get_prune_checkpoint(segment)
     }
 }

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -261,11 +261,11 @@ impl<DB: Database> BlockNumReader for ProviderFactory<DB> {
     }
 
     fn last_block_number(&self) -> ProviderResult<BlockNumber> {
-        Ok(self.provider()?.last_block_number()?)
+        self.provider()?.last_block_number()
     }
 
     fn block_number(&self, hash: B256) -> ProviderResult<Option<BlockNumber>> {
-        Ok(self.provider()?.block_number(hash)?)
+        self.provider()?.block_number(hash)
     }
 }
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -2063,8 +2063,7 @@ impl<TX: DbTxMut + DbTx> BlockExecutionWriter for DatabaseProvider<TX> {
                     root: GotExpected { got: new_state_root, expected: parent_state_root },
                     block_number: parent_number,
                     block_hash: parent_hash,
-                }))
-                .into())
+                })))
             }
             trie_updates.flush(&self.tx)?;
         }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -24,11 +24,7 @@ use reth_db::{
     transaction::{DbTx, DbTxMut},
     BlockNumberList, DatabaseError,
 };
-use reth_interfaces::{
-    executor::{BlockExecutionError, BlockValidationError},
-    provider::RootMismatch,
-    RethError, RethResult,
-};
+use reth_interfaces::provider::{ProviderResult, RootMismatch};
 use reth_primitives::{
     keccak256,
     revm::{
@@ -82,7 +78,7 @@ impl<DB: Database> DerefMut for DatabaseProviderRW<'_, DB> {
 
 impl<'this, DB: Database> DatabaseProviderRW<'this, DB> {
     /// Commit database transaction
-    pub fn commit(self) -> RethResult<bool> {
+    pub fn commit(self) -> ProviderResult<bool> {
         self.0.commit()
     }
 
@@ -129,7 +125,7 @@ fn unwind_history_shards<S, T, C>(
     start_key: T::Key,
     block_number: BlockNumber,
     mut shard_belongs_to_key: impl FnMut(&T::Key) -> bool,
-) -> RethResult<Vec<usize>>
+) -> ProviderResult<Vec<usize>>
 where
     T: Table<Value = BlockNumberList>,
     T::Key: AsRef<ShardedKey<S>>,
@@ -201,7 +197,7 @@ impl<TX: DbTx> DatabaseProvider<TX> {
 
 impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
     /// Commit database transaction.
-    pub fn commit(self) -> RethResult<bool> {
+    pub fn commit(self) -> ProviderResult<bool> {
         Ok(self.tx.commit()?)
     }
 
@@ -234,7 +230,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
     fn unwind_or_peek_state<const UNWIND: bool>(
         &self,
         range: RangeInclusive<BlockNumber>,
-    ) -> RethResult<BundleStateWithReceipts> {
+    ) -> ProviderResult<BundleStateWithReceipts> {
         if range.is_empty() {
             return Ok(BundleStateWithReceipts::default())
         }
@@ -409,7 +405,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
     pub(crate) fn get_take_block_transaction_range<const TAKE: bool>(
         &self,
         range: impl RangeBounds<BlockNumber> + Clone,
-    ) -> RethResult<Vec<(BlockNumber, Vec<TransactionSignedEcRecovered>)>> {
+    ) -> ProviderResult<Vec<(BlockNumber, Vec<TransactionSignedEcRecovered>)>> {
         // Raad range of block bodies to get all transactions id's of this range.
         let block_bodies = self.get_or_take::<tables::BlockBodyIndices, false>(range)?;
 
@@ -477,7 +473,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
                 missing_senders.iter().map(|(_, _, tx)| *tx).collect::<Vec<_>>(),
                 missing_senders.len(),
             )
-            .ok_or(BlockExecutionError::Validation(BlockValidationError::SenderRecoveryError))?;
+            .ok_or(ProviderError::SenderRecoveryError)?;
 
             // Insert recovered senders along with tx numbers at the corresponding indexes to the
             // original `senders` vector
@@ -547,7 +543,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
         &self,
         chain_spec: &ChainSpec,
         range: impl RangeBounds<BlockNumber> + Clone,
-    ) -> RethResult<Vec<SealedBlockWithSenders>> {
+    ) -> ProviderResult<Vec<SealedBlockWithSenders>> {
         // For block we need Headers, Bodies, Uncles, withdrawals, Transactions, Signers
 
         let block_headers = self.get_or_take::<tables::Headers, TAKE>(range.clone())?;
@@ -746,7 +742,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
 
     /// Load shard and remove it. If list is empty, last shard was full or
     /// there are no shards at all.
-    fn take_shard<T>(&self, key: T::Key) -> RethResult<Vec<u64>>
+    fn take_shard<T>(&self, key: T::Key) -> ProviderResult<Vec<u64>>
     where
         T: Table<Value = BlockNumberList>,
     {
@@ -772,7 +768,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
         &self,
         index_updates: BTreeMap<P, Vec<u64>>,
         mut sharded_key_factory: impl FnMut(P, BlockNumber) -> T::Key,
-    ) -> RethResult<()>
+    ) -> ProviderResult<()>
     where
         P: Copy,
         T: Table<Value = BlockNumberList>,
@@ -806,7 +802,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
 }
 
 impl<TX: DbTx> AccountReader for DatabaseProvider<TX> {
-    fn basic_account(&self, address: Address) -> RethResult<Option<Account>> {
+    fn basic_account(&self, address: Address) -> ProviderResult<Option<Account>> {
         Ok(self.tx.get::<tables::PlainAccountState>(address)?)
     }
 }
@@ -815,7 +811,7 @@ impl<TX: DbTx> AccountExtReader for DatabaseProvider<TX> {
     fn changed_accounts_with_range(
         &self,
         range: impl RangeBounds<BlockNumber>,
-    ) -> RethResult<BTreeSet<Address>> {
+    ) -> ProviderResult<BTreeSet<Address>> {
         self.tx
             .cursor_read::<tables::AccountChangeSet>()?
             .walk_range(range)?
@@ -828,7 +824,7 @@ impl<TX: DbTx> AccountExtReader for DatabaseProvider<TX> {
     fn basic_accounts(
         &self,
         iter: impl IntoIterator<Item = Address>,
-    ) -> RethResult<Vec<(Address, Option<Account>)>> {
+    ) -> ProviderResult<Vec<(Address, Option<Account>)>> {
         let mut plain_accounts = self.tx.cursor_read::<tables::PlainAccountState>()?;
         Ok(iter
             .into_iter()
@@ -839,12 +835,12 @@ impl<TX: DbTx> AccountExtReader for DatabaseProvider<TX> {
     fn changed_accounts_and_blocks_with_range(
         &self,
         range: RangeInclusive<BlockNumber>,
-    ) -> RethResult<BTreeMap<Address, Vec<u64>>> {
+    ) -> ProviderResult<BTreeMap<Address, Vec<u64>>> {
         let mut changeset_cursor = self.tx.cursor_read::<tables::AccountChangeSet>()?;
 
         let account_transitions = changeset_cursor.walk_range(range)?.try_fold(
             BTreeMap::new(),
-            |mut accounts: BTreeMap<Address, Vec<u64>>, entry| -> RethResult<_> {
+            |mut accounts: BTreeMap<Address, Vec<u64>>, entry| -> ProviderResult<_> {
                 let (index, account) = entry?;
                 accounts.entry(account.address).or_default().push(index);
                 Ok(accounts)
@@ -859,12 +855,12 @@ impl<TX: DbTx> ChangeSetReader for DatabaseProvider<TX> {
     fn account_block_changeset(
         &self,
         block_number: BlockNumber,
-    ) -> RethResult<Vec<AccountBeforeTx>> {
+    ) -> ProviderResult<Vec<AccountBeforeTx>> {
         let range = block_number..=block_number;
         self.tx
             .cursor_read::<tables::AccountChangeSet>()?
             .walk_range(range)?
-            .map(|result| -> RethResult<_> {
+            .map(|result| -> ProviderResult<_> {
                 let (_, account_before) = result?;
                 Ok(account_before)
             })
@@ -873,7 +869,7 @@ impl<TX: DbTx> ChangeSetReader for DatabaseProvider<TX> {
 }
 
 impl<TX: DbTx> HeaderProvider for DatabaseProvider<TX> {
-    fn header(&self, block_hash: &BlockHash) -> RethResult<Option<Header>> {
+    fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Header>> {
         if let Some(num) = self.block_number(*block_hash)? {
             Ok(self.header_by_number(num)?)
         } else {
@@ -881,11 +877,11 @@ impl<TX: DbTx> HeaderProvider for DatabaseProvider<TX> {
         }
     }
 
-    fn header_by_number(&self, num: BlockNumber) -> RethResult<Option<Header>> {
+    fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Header>> {
         Ok(self.tx.get::<tables::Headers>(num)?)
     }
 
-    fn header_td(&self, block_hash: &BlockHash) -> RethResult<Option<U256>> {
+    fn header_td(&self, block_hash: &BlockHash) -> ProviderResult<Option<U256>> {
         if let Some(num) = self.block_number(*block_hash)? {
             self.header_td_by_number(num)
         } else {
@@ -893,7 +889,7 @@ impl<TX: DbTx> HeaderProvider for DatabaseProvider<TX> {
         }
     }
 
-    fn header_td_by_number(&self, number: BlockNumber) -> RethResult<Option<U256>> {
+    fn header_td_by_number(&self, number: BlockNumber) -> ProviderResult<Option<U256>> {
         if let Some(td) = self.chain_spec.final_paris_total_difficulty(number) {
             // if this block is higher than the final paris(merge) block, return the final paris
             // difficulty
@@ -903,15 +899,15 @@ impl<TX: DbTx> HeaderProvider for DatabaseProvider<TX> {
         Ok(self.tx.get::<tables::HeaderTD>(number)?.map(|td| td.0))
     }
 
-    fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> RethResult<Vec<Header>> {
+    fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> ProviderResult<Vec<Header>> {
         let mut cursor = self.tx.cursor_read::<tables::Headers>()?;
         cursor
             .walk_range(range)?
             .map(|result| result.map(|(_, header)| header).map_err(Into::into))
-            .collect::<RethResult<Vec<_>>>()
+            .collect::<ProviderResult<Vec<_>>>()
     }
 
-    fn sealed_header(&self, number: BlockNumber) -> RethResult<Option<SealedHeader>> {
+    fn sealed_header(&self, number: BlockNumber) -> ProviderResult<Option<SealedHeader>> {
         if let Some(header) = self.header_by_number(number)? {
             let hash = self
                 .block_hash(number)?
@@ -926,7 +922,7 @@ impl<TX: DbTx> HeaderProvider for DatabaseProvider<TX> {
         &self,
         range: impl RangeBounds<BlockNumber>,
         mut predicate: impl FnMut(&SealedHeader) -> bool,
-    ) -> RethResult<Vec<SealedHeader>> {
+    ) -> ProviderResult<Vec<SealedHeader>> {
         let mut headers = vec![];
         for entry in self.tx.cursor_read::<tables::Headers>()?.walk_range(range)? {
             let (number, header) = entry?;
@@ -944,7 +940,7 @@ impl<TX: DbTx> HeaderProvider for DatabaseProvider<TX> {
 }
 
 impl<TX: DbTx> BlockHashReader for DatabaseProvider<TX> {
-    fn block_hash(&self, number: u64) -> RethResult<Option<B256>> {
+    fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
         Ok(self.tx.get::<tables::CanonicalHeaders>(number)?)
     }
 
@@ -952,41 +948,41 @@ impl<TX: DbTx> BlockHashReader for DatabaseProvider<TX> {
         &self,
         start: BlockNumber,
         end: BlockNumber,
-    ) -> RethResult<Vec<B256>> {
+    ) -> ProviderResult<Vec<B256>> {
         let range = start..end;
         let mut cursor = self.tx.cursor_read::<tables::CanonicalHeaders>()?;
         cursor
             .walk_range(range)?
             .map(|result| result.map(|(_, hash)| hash).map_err(Into::into))
-            .collect::<RethResult<Vec<_>>>()
+            .collect::<ProviderResult<Vec<_>>>()
     }
 }
 
 impl<TX: DbTx> BlockNumReader for DatabaseProvider<TX> {
-    fn chain_info(&self) -> RethResult<ChainInfo> {
+    fn chain_info(&self) -> ProviderResult<ChainInfo> {
         let best_number = self.best_block_number()?;
         let best_hash = self.block_hash(best_number)?.unwrap_or_default();
         Ok(ChainInfo { best_hash, best_number })
     }
 
-    fn best_block_number(&self) -> RethResult<BlockNumber> {
+    fn best_block_number(&self) -> ProviderResult<BlockNumber> {
         Ok(self
             .get_stage_checkpoint(StageId::Finish)?
             .map(|checkpoint| checkpoint.block_number)
             .unwrap_or_default())
     }
 
-    fn last_block_number(&self) -> RethResult<BlockNumber> {
+    fn last_block_number(&self) -> ProviderResult<BlockNumber> {
         Ok(self.tx.cursor_read::<tables::CanonicalHeaders>()?.last()?.unwrap_or_default().0)
     }
 
-    fn block_number(&self, hash: B256) -> RethResult<Option<BlockNumber>> {
+    fn block_number(&self, hash: B256) -> ProviderResult<Option<BlockNumber>> {
         Ok(self.tx.get::<tables::HeaderNumbers>(hash)?)
     }
 }
 
 impl<TX: DbTx> BlockReader for DatabaseProvider<TX> {
-    fn find_block_by_hash(&self, hash: B256, source: BlockSource) -> RethResult<Option<Block>> {
+    fn find_block_by_hash(&self, hash: B256, source: BlockSource) -> ProviderResult<Option<Block>> {
         if source.is_database() {
             self.block(hash.into())
         } else {
@@ -999,7 +995,7 @@ impl<TX: DbTx> BlockReader for DatabaseProvider<TX> {
     /// If the header for this block is not found, this returns `None`.
     /// If the header is found, but the transactions either do not exist, or are not indexed, this
     /// will return None.
-    fn block(&self, id: BlockHashOrNumber) -> RethResult<Option<Block>> {
+    fn block(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Block>> {
         if let Some(number) = self.convert_hash_or_number(id)? {
             if let Some(header) = self.header_by_number(number)? {
                 let withdrawals = self.withdrawals_by_block(number.into(), header.timestamp)?;
@@ -1020,15 +1016,15 @@ impl<TX: DbTx> BlockReader for DatabaseProvider<TX> {
         Ok(None)
     }
 
-    fn pending_block(&self) -> RethResult<Option<SealedBlock>> {
+    fn pending_block(&self) -> ProviderResult<Option<SealedBlock>> {
         Ok(None)
     }
 
-    fn pending_block_and_receipts(&self) -> RethResult<Option<(SealedBlock, Vec<Receipt>)>> {
+    fn pending_block_and_receipts(&self) -> ProviderResult<Option<(SealedBlock, Vec<Receipt>)>> {
         Ok(None)
     }
 
-    fn ommers(&self, id: BlockHashOrNumber) -> RethResult<Option<Vec<Header>>> {
+    fn ommers(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Header>>> {
         if let Some(number) = self.convert_hash_or_number(id)? {
             // If the Paris (Merge) hardfork block is known and block is after it, return empty
             // ommers.
@@ -1043,7 +1039,7 @@ impl<TX: DbTx> BlockReader for DatabaseProvider<TX> {
         Ok(None)
     }
 
-    fn block_body_indices(&self, num: u64) -> RethResult<Option<StoredBlockBodyIndices>> {
+    fn block_body_indices(&self, num: u64) -> ProviderResult<Option<StoredBlockBodyIndices>> {
         Ok(self.tx.get::<tables::BlockBodyIndices>(num)?)
     }
 
@@ -1059,7 +1055,7 @@ impl<TX: DbTx> BlockReader for DatabaseProvider<TX> {
         &self,
         id: BlockHashOrNumber,
         transaction_kind: TransactionVariant,
-    ) -> RethResult<Option<BlockWithSenders>> {
+    ) -> ProviderResult<Option<BlockWithSenders>> {
         let Some(block_number) = self.convert_hash_or_number(id)? else { return Ok(None) };
 
         let Some(header) = self.header_by_number(block_number)? else { return Ok(None) };
@@ -1102,7 +1098,7 @@ impl<TX: DbTx> BlockReader for DatabaseProvider<TX> {
         Ok(Some(Block { header, body, ommers, withdrawals }.with_senders(senders)))
     }
 
-    fn block_range(&self, range: RangeInclusive<BlockNumber>) -> RethResult<Vec<Block>> {
+    fn block_range(&self, range: RangeInclusive<BlockNumber>) -> ProviderResult<Vec<Block>> {
         if range.is_empty() {
             return Ok(Vec::new())
         }
@@ -1167,7 +1163,7 @@ impl<TX: DbTx> TransactionsProviderExt for DatabaseProvider<TX> {
     fn transaction_hashes_by_range(
         &self,
         tx_range: Range<TxNumber>,
-    ) -> RethResult<Vec<(TxHash, TxNumber)>> {
+    ) -> ProviderResult<Vec<(TxHash, TxNumber)>> {
         let mut tx_cursor = self.tx.cursor_read::<tables::Transactions>()?;
         let tx_range_size = tx_range.clone().count();
         let tx_walker = tx_cursor.walk_range(tx_range)?;
@@ -1180,7 +1176,7 @@ impl<TX: DbTx> TransactionsProviderExt for DatabaseProvider<TX> {
         fn calculate_hash(
             entry: Result<(TxNumber, TransactionSignedNoHash), DatabaseError>,
             rlp_buf: &mut Vec<u8>,
-        ) -> Result<(B256, TxNumber), Box<RethError>> {
+        ) -> Result<(B256, TxNumber), Box<ProviderError>> {
             let (tx_id, tx) = entry.map_err(|e| Box::new(e.into()))?;
             tx.transaction.encode_with_signature(&tx.signature, rlp_buf, false);
             Ok((keccak256(rlp_buf), tx_id))
@@ -1221,22 +1217,22 @@ impl<TX: DbTx> TransactionsProviderExt for DatabaseProvider<TX> {
 /// Calculates the hash of the given transaction
 
 impl<TX: DbTx> TransactionsProvider for DatabaseProvider<TX> {
-    fn transaction_id(&self, tx_hash: TxHash) -> RethResult<Option<TxNumber>> {
+    fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
         Ok(self.tx.get::<tables::TxHashNumber>(tx_hash)?)
     }
 
-    fn transaction_by_id(&self, id: TxNumber) -> RethResult<Option<TransactionSigned>> {
+    fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<TransactionSigned>> {
         Ok(self.tx.get::<tables::Transactions>(id)?.map(Into::into))
     }
 
     fn transaction_by_id_no_hash(
         &self,
         id: TxNumber,
-    ) -> RethResult<Option<TransactionSignedNoHash>> {
+    ) -> ProviderResult<Option<TransactionSignedNoHash>> {
         Ok(self.tx.get::<tables::Transactions>(id)?)
     }
 
-    fn transaction_by_hash(&self, hash: TxHash) -> RethResult<Option<TransactionSigned>> {
+    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<TransactionSigned>> {
         if let Some(id) = self.transaction_id(hash)? {
             Ok(self.transaction_by_id_no_hash(id)?.map(|tx| TransactionSigned {
                 hash,
@@ -1252,7 +1248,7 @@ impl<TX: DbTx> TransactionsProvider for DatabaseProvider<TX> {
     fn transaction_by_hash_with_meta(
         &self,
         tx_hash: TxHash,
-    ) -> RethResult<Option<(TransactionSigned, TransactionMeta)>> {
+    ) -> ProviderResult<Option<(TransactionSigned, TransactionMeta)>> {
         let mut transaction_cursor = self.tx.cursor_read::<tables::TransactionBlock>()?;
         if let Some(transaction_id) = self.transaction_id(tx_hash)? {
             if let Some(tx) = self.transaction_by_id_no_hash(transaction_id)? {
@@ -1292,7 +1288,7 @@ impl<TX: DbTx> TransactionsProvider for DatabaseProvider<TX> {
         Ok(None)
     }
 
-    fn transaction_block(&self, id: TxNumber) -> RethResult<Option<BlockNumber>> {
+    fn transaction_block(&self, id: TxNumber) -> ProviderResult<Option<BlockNumber>> {
         let mut cursor = self.tx.cursor_read::<tables::TransactionBlock>()?;
         Ok(cursor.seek(id)?.map(|(_, bn)| bn))
     }
@@ -1300,7 +1296,7 @@ impl<TX: DbTx> TransactionsProvider for DatabaseProvider<TX> {
     fn transactions_by_block(
         &self,
         id: BlockHashOrNumber,
-    ) -> RethResult<Option<Vec<TransactionSigned>>> {
+    ) -> ProviderResult<Option<Vec<TransactionSigned>>> {
         let mut tx_cursor = self.tx.cursor_read::<tables::Transactions>()?;
         if let Some(block_number) = self.convert_hash_or_number(id)? {
             if let Some(body) = self.block_body_indices(block_number)? {
@@ -1322,7 +1318,7 @@ impl<TX: DbTx> TransactionsProvider for DatabaseProvider<TX> {
     fn transactions_by_block_range(
         &self,
         range: impl RangeBounds<BlockNumber>,
-    ) -> RethResult<Vec<Vec<TransactionSigned>>> {
+    ) -> ProviderResult<Vec<Vec<TransactionSigned>>> {
         let mut results = Vec::new();
         let mut body_cursor = self.tx.cursor_read::<tables::BlockBodyIndices>()?;
         let mut tx_cursor = self.tx.cursor_read::<tables::Transactions>()?;
@@ -1346,7 +1342,7 @@ impl<TX: DbTx> TransactionsProvider for DatabaseProvider<TX> {
     fn transactions_by_tx_range(
         &self,
         range: impl RangeBounds<TxNumber>,
-    ) -> RethResult<Vec<TransactionSignedNoHash>> {
+    ) -> ProviderResult<Vec<TransactionSignedNoHash>> {
         Ok(self
             .tx
             .cursor_read::<tables::Transactions>()?
@@ -1355,7 +1351,10 @@ impl<TX: DbTx> TransactionsProvider for DatabaseProvider<TX> {
             .collect::<Result<Vec<_>, _>>()?)
     }
 
-    fn senders_by_tx_range(&self, range: impl RangeBounds<TxNumber>) -> RethResult<Vec<Address>> {
+    fn senders_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Address>> {
         Ok(self
             .tx
             .cursor_read::<tables::TxSenders>()?
@@ -1364,17 +1363,17 @@ impl<TX: DbTx> TransactionsProvider for DatabaseProvider<TX> {
             .collect::<Result<Vec<_>, _>>()?)
     }
 
-    fn transaction_sender(&self, id: TxNumber) -> RethResult<Option<Address>> {
+    fn transaction_sender(&self, id: TxNumber) -> ProviderResult<Option<Address>> {
         Ok(self.tx.get::<tables::TxSenders>(id)?)
     }
 }
 
 impl<TX: DbTx> ReceiptProvider for DatabaseProvider<TX> {
-    fn receipt(&self, id: TxNumber) -> RethResult<Option<Receipt>> {
+    fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Receipt>> {
         Ok(self.tx.get::<tables::Receipts>(id)?)
     }
 
-    fn receipt_by_hash(&self, hash: TxHash) -> RethResult<Option<Receipt>> {
+    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Receipt>> {
         if let Some(id) = self.transaction_id(hash)? {
             self.receipt(id)
         } else {
@@ -1382,7 +1381,7 @@ impl<TX: DbTx> ReceiptProvider for DatabaseProvider<TX> {
         }
     }
 
-    fn receipts_by_block(&self, block: BlockHashOrNumber) -> RethResult<Option<Vec<Receipt>>> {
+    fn receipts_by_block(&self, block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
         if let Some(number) = self.convert_hash_or_number(block)? {
             if let Some(body) = self.block_body_indices(number)? {
                 let tx_range = body.tx_num_range();
@@ -1407,7 +1406,7 @@ impl<TX: DbTx> WithdrawalsProvider for DatabaseProvider<TX> {
         &self,
         id: BlockHashOrNumber,
         timestamp: u64,
-    ) -> RethResult<Option<Vec<Withdrawal>>> {
+    ) -> ProviderResult<Option<Vec<Withdrawal>>> {
         if self.chain_spec.is_shanghai_active_at_timestamp(timestamp) {
             if let Some(number) = self.convert_hash_or_number(id)? {
                 // If we are past shanghai, then all blocks should have a withdrawal list, even if
@@ -1423,7 +1422,7 @@ impl<TX: DbTx> WithdrawalsProvider for DatabaseProvider<TX> {
         Ok(None)
     }
 
-    fn latest_withdrawal(&self) -> RethResult<Option<Withdrawal>> {
+    fn latest_withdrawal(&self) -> ProviderResult<Option<Withdrawal>> {
         let latest_block_withdrawal = self.tx.cursor_read::<tables::BlockWithdrawals>()?.last()?;
         Ok(latest_block_withdrawal
             .and_then(|(_, mut block_withdrawal)| block_withdrawal.withdrawals.pop()))
@@ -1436,7 +1435,7 @@ impl<TX: DbTx> EvmEnvProvider for DatabaseProvider<TX> {
         cfg: &mut CfgEnv,
         block_env: &mut BlockEnv,
         at: BlockHashOrNumber,
-    ) -> RethResult<()> {
+    ) -> ProviderResult<()> {
         let hash = self.convert_number(at)?.ok_or(ProviderError::HeaderNotFound(at))?;
         let header = self.header(&hash)?.ok_or(ProviderError::HeaderNotFound(at))?;
         self.fill_env_with_header(cfg, block_env, &header)
@@ -1447,7 +1446,7 @@ impl<TX: DbTx> EvmEnvProvider for DatabaseProvider<TX> {
         cfg: &mut CfgEnv,
         block_env: &mut BlockEnv,
         header: &Header,
-    ) -> RethResult<()> {
+    ) -> ProviderResult<()> {
         let total_difficulty = self
             .header_td_by_number(header.number)?
             .ok_or_else(|| ProviderError::HeaderNotFound(header.number.into()))?;
@@ -1455,7 +1454,11 @@ impl<TX: DbTx> EvmEnvProvider for DatabaseProvider<TX> {
         Ok(())
     }
 
-    fn fill_block_env_at(&self, block_env: &mut BlockEnv, at: BlockHashOrNumber) -> RethResult<()> {
+    fn fill_block_env_at(
+        &self,
+        block_env: &mut BlockEnv,
+        at: BlockHashOrNumber,
+    ) -> ProviderResult<()> {
         let hash = self.convert_number(at)?.ok_or(ProviderError::HeaderNotFound(at))?;
         let header = self.header(&hash)?.ok_or(ProviderError::HeaderNotFound(at))?;
 
@@ -1466,7 +1469,7 @@ impl<TX: DbTx> EvmEnvProvider for DatabaseProvider<TX> {
         &self,
         block_env: &mut BlockEnv,
         header: &Header,
-    ) -> RethResult<()> {
+    ) -> ProviderResult<()> {
         let total_difficulty = self
             .header_td_by_number(header.number)?
             .ok_or_else(|| ProviderError::HeaderNotFound(header.number.into()))?;
@@ -1486,13 +1489,13 @@ impl<TX: DbTx> EvmEnvProvider for DatabaseProvider<TX> {
         Ok(())
     }
 
-    fn fill_cfg_env_at(&self, cfg: &mut CfgEnv, at: BlockHashOrNumber) -> RethResult<()> {
+    fn fill_cfg_env_at(&self, cfg: &mut CfgEnv, at: BlockHashOrNumber) -> ProviderResult<()> {
         let hash = self.convert_number(at)?.ok_or(ProviderError::HeaderNotFound(at))?;
         let header = self.header(&hash)?.ok_or(ProviderError::HeaderNotFound(at))?;
         self.fill_cfg_env_with_header(cfg, &header)
     }
 
-    fn fill_cfg_env_with_header(&self, cfg: &mut CfgEnv, header: &Header) -> RethResult<()> {
+    fn fill_cfg_env_with_header(&self, cfg: &mut CfgEnv, header: &Header) -> ProviderResult<()> {
         let total_difficulty = self
             .header_td_by_number(header.number)?
             .ok_or_else(|| ProviderError::HeaderNotFound(header.number.into()))?;
@@ -1502,24 +1505,32 @@ impl<TX: DbTx> EvmEnvProvider for DatabaseProvider<TX> {
 }
 
 impl<TX: DbTx> StageCheckpointReader for DatabaseProvider<TX> {
-    fn get_stage_checkpoint(&self, id: StageId) -> RethResult<Option<StageCheckpoint>> {
+    fn get_stage_checkpoint(&self, id: StageId) -> ProviderResult<Option<StageCheckpoint>> {
         Ok(self.tx.get::<tables::SyncStage>(id.to_string())?)
     }
 
     /// Get stage checkpoint progress.
-    fn get_stage_checkpoint_progress(&self, id: StageId) -> RethResult<Option<Vec<u8>>> {
+    fn get_stage_checkpoint_progress(&self, id: StageId) -> ProviderResult<Option<Vec<u8>>> {
         Ok(self.tx.get::<tables::SyncStageProgress>(id.to_string())?)
     }
 }
 
 impl<TX: DbTxMut> StageCheckpointWriter for DatabaseProvider<TX> {
     /// Save stage checkpoint progress.
-    fn save_stage_checkpoint_progress(&self, id: StageId, checkpoint: Vec<u8>) -> RethResult<()> {
+    fn save_stage_checkpoint_progress(
+        &self,
+        id: StageId,
+        checkpoint: Vec<u8>,
+    ) -> ProviderResult<()> {
         Ok(self.tx.put::<tables::SyncStageProgress>(id.to_string(), checkpoint)?)
     }
 
     /// Save stage checkpoint.
-    fn save_stage_checkpoint(&self, id: StageId, checkpoint: StageCheckpoint) -> RethResult<()> {
+    fn save_stage_checkpoint(
+        &self,
+        id: StageId,
+        checkpoint: StageCheckpoint,
+    ) -> ProviderResult<()> {
         Ok(self.tx.put::<tables::SyncStage>(id.to_string(), checkpoint)?)
     }
 
@@ -1527,7 +1538,7 @@ impl<TX: DbTxMut> StageCheckpointWriter for DatabaseProvider<TX> {
         &self,
         block_number: BlockNumber,
         drop_stage_checkpoint: bool,
-    ) -> RethResult<()> {
+    ) -> ProviderResult<()> {
         // iterate over all existing stages in the table and update its progress.
         let mut cursor = self.tx.cursor_write::<tables::SyncStage>()?;
         for stage_id in StageId::ALL {
@@ -1546,10 +1557,10 @@ impl<TX: DbTxMut> StageCheckpointWriter for DatabaseProvider<TX> {
 }
 
 impl<TX: DbTx> StorageReader for DatabaseProvider<TX> {
-    fn plainstate_storages(
+    fn plain_state_storages(
         &self,
         addresses_with_keys: impl IntoIterator<Item = (Address, impl IntoIterator<Item = B256>)>,
-    ) -> RethResult<Vec<(Address, Vec<StorageEntry>)>> {
+    ) -> ProviderResult<Vec<(Address, Vec<StorageEntry>)>> {
         let mut plain_storage = self.tx.cursor_dup_read::<tables::PlainStorageState>()?;
 
         addresses_with_keys
@@ -1557,22 +1568,22 @@ impl<TX: DbTx> StorageReader for DatabaseProvider<TX> {
             .map(|(address, storage)| {
                 storage
                     .into_iter()
-                    .map(|key| -> RethResult<_> {
+                    .map(|key| -> ProviderResult<_> {
                         Ok(plain_storage
                             .seek_by_key_subkey(address, key)?
                             .filter(|v| v.key == key)
                             .unwrap_or_else(|| StorageEntry { key, value: Default::default() }))
                     })
-                    .collect::<RethResult<Vec<_>>>()
+                    .collect::<ProviderResult<Vec<_>>>()
                     .map(|storage| (address, storage))
             })
-            .collect::<RethResult<Vec<(_, _)>>>()
+            .collect::<ProviderResult<Vec<(_, _)>>>()
     }
 
     fn changed_storages_with_range(
         &self,
         range: RangeInclusive<BlockNumber>,
-    ) -> RethResult<BTreeMap<Address, BTreeSet<B256>>> {
+    ) -> ProviderResult<BTreeMap<Address, BTreeSet<B256>>> {
         self.tx
             .cursor_read::<tables::StorageChangeSet>()?
             .walk_range(BlockNumberAddress::range(range))?
@@ -1588,13 +1599,13 @@ impl<TX: DbTx> StorageReader for DatabaseProvider<TX> {
     fn changed_storages_and_blocks_with_range(
         &self,
         range: RangeInclusive<BlockNumber>,
-    ) -> RethResult<BTreeMap<(Address, B256), Vec<u64>>> {
+    ) -> ProviderResult<BTreeMap<(Address, B256), Vec<u64>>> {
         let mut changeset_cursor = self.tx.cursor_read::<tables::StorageChangeSet>()?;
 
         let storage_changeset_lists =
             changeset_cursor.walk_range(BlockNumberAddress::range(range))?.try_fold(
                 BTreeMap::new(),
-                |mut storages: BTreeMap<(Address, B256), Vec<u64>>, entry| -> RethResult<_> {
+                |mut storages: BTreeMap<(Address, B256), Vec<u64>>, entry| -> ProviderResult<_> {
                     let (index, storage) = entry?;
                     storages
                         .entry((index.address(), storage.key))
@@ -1614,7 +1625,7 @@ impl<TX: DbTxMut + DbTx> HashingWriter for DatabaseProvider<TX> {
         range: RangeInclusive<BlockNumber>,
         end_block_hash: B256,
         expected_state_root: B256,
-    ) -> RethResult<()> {
+    ) -> ProviderResult<()> {
         // Initialize prefix sets.
         let mut account_prefix_set = PrefixSetMut::default();
         let mut storage_prefix_set: HashMap<B256, PrefixSetMut> = HashMap::default();
@@ -1625,7 +1636,7 @@ impl<TX: DbTxMut + DbTx> HashingWriter for DatabaseProvider<TX> {
         // storage hashing stage
         {
             let lists = self.changed_storages_with_range(range.clone())?;
-            let storages = self.plainstate_storages(lists)?;
+            let storages = self.plain_state_storages(lists)?;
             let storage_entries = self.insert_storage_for_hashing(storages)?;
             for (hashed_address, hashed_slots) in storage_entries {
                 account_prefix_set.insert(Nibbles::unpack(hashed_address));
@@ -1670,8 +1681,7 @@ impl<TX: DbTxMut + DbTx> HashingWriter for DatabaseProvider<TX> {
                     root: GotExpected { got: state_root, expected: expected_state_root },
                     block_number: *range.end(),
                     block_hash: end_block_hash,
-                }))
-                .into())
+                })))
             }
             trie_updates.flush(&self.tx)?;
         }
@@ -1685,7 +1695,7 @@ impl<TX: DbTxMut + DbTx> HashingWriter for DatabaseProvider<TX> {
     fn unwind_storage_hashing(
         &self,
         range: Range<BlockNumberAddress>,
-    ) -> RethResult<HashMap<B256, BTreeSet<B256>>> {
+    ) -> ProviderResult<HashMap<B256, BTreeSet<B256>>> {
         let mut hashed_storage = self.tx.cursor_dup_write::<tables::HashedStorage>()?;
 
         // Aggregate all block changesets and make list of accounts that have been changed.
@@ -1719,7 +1729,7 @@ impl<TX: DbTxMut + DbTx> HashingWriter for DatabaseProvider<TX> {
         hashed_storages
             .into_iter()
             // Apply values to HashedStorage (if Value is zero just remove it);
-            .try_for_each(|((hashed_address, key), value)| -> RethResult<()> {
+            .try_for_each(|((hashed_address, key), value)| -> ProviderResult<()> {
                 if hashed_storage
                     .seek_by_key_subkey(hashed_address, key)?
                     .filter(|entry| entry.key == key)
@@ -1740,7 +1750,7 @@ impl<TX: DbTxMut + DbTx> HashingWriter for DatabaseProvider<TX> {
     fn insert_storage_for_hashing(
         &self,
         storages: impl IntoIterator<Item = (Address, impl IntoIterator<Item = StorageEntry>)>,
-    ) -> RethResult<HashMap<B256, BTreeSet<B256>>> {
+    ) -> ProviderResult<HashMap<B256, BTreeSet<B256>>> {
         // hash values
         let hashed_storages =
             storages.into_iter().fold(BTreeMap::new(), |mut map, (address, storage)| {
@@ -1761,7 +1771,7 @@ impl<TX: DbTxMut + DbTx> HashingWriter for DatabaseProvider<TX> {
         // Hash the address and key and apply them to HashedStorage (if Storage is None
         // just remove it);
         hashed_storages.into_iter().try_for_each(|(hashed_address, storage)| {
-            storage.into_iter().try_for_each(|(key, value)| -> RethResult<()> {
+            storage.into_iter().try_for_each(|(key, value)| -> ProviderResult<()> {
                 if hashed_storage_cursor
                     .seek_by_key_subkey(hashed_address, key)?
                     .filter(|entry| entry.key == key)
@@ -1783,7 +1793,7 @@ impl<TX: DbTxMut + DbTx> HashingWriter for DatabaseProvider<TX> {
     fn unwind_account_hashing(
         &self,
         range: RangeInclusive<BlockNumber>,
-    ) -> RethResult<BTreeMap<B256, Option<Account>>> {
+    ) -> ProviderResult<BTreeMap<B256, Option<Account>>> {
         let mut hashed_accounts_cursor = self.tx.cursor_write::<tables::HashedAccount>()?;
 
         // Aggregate all block changesets and make a list of accounts that have been changed.
@@ -1811,7 +1821,7 @@ impl<TX: DbTxMut + DbTx> HashingWriter for DatabaseProvider<TX> {
         hashed_accounts
             .iter()
             // Apply values to HashedState (if Account is None remove it);
-            .try_for_each(|(hashed_address, account)| -> RethResult<()> {
+            .try_for_each(|(hashed_address, account)| -> ProviderResult<()> {
                 if let Some(account) = account {
                     hashed_accounts_cursor.upsert(*hashed_address, *account)?;
                 } else if hashed_accounts_cursor.seek_exact(*hashed_address)?.is_some() {
@@ -1826,7 +1836,7 @@ impl<TX: DbTxMut + DbTx> HashingWriter for DatabaseProvider<TX> {
     fn insert_account_for_hashing(
         &self,
         accounts: impl IntoIterator<Item = (Address, Option<Account>)>,
-    ) -> RethResult<BTreeMap<B256, Option<Account>>> {
+    ) -> ProviderResult<BTreeMap<B256, Option<Account>>> {
         let mut hashed_accounts_cursor = self.tx.cursor_write::<tables::HashedAccount>()?;
 
         let hashed_accounts = accounts.into_iter().fold(
@@ -1837,7 +1847,7 @@ impl<TX: DbTxMut + DbTx> HashingWriter for DatabaseProvider<TX> {
             },
         );
 
-        hashed_accounts.iter().try_for_each(|(hashed_address, account)| -> RethResult<()> {
+        hashed_accounts.iter().try_for_each(|(hashed_address, account)| -> ProviderResult<()> {
             if let Some(account) = account {
                 hashed_accounts_cursor.upsert(*hashed_address, *account)?
             } else if hashed_accounts_cursor.seek_exact(*hashed_address)?.is_some() {
@@ -1851,7 +1861,7 @@ impl<TX: DbTxMut + DbTx> HashingWriter for DatabaseProvider<TX> {
 }
 
 impl<TX: DbTxMut + DbTx> HistoryWriter for DatabaseProvider<TX> {
-    fn update_history_indices(&self, range: RangeInclusive<BlockNumber>) -> RethResult<()> {
+    fn update_history_indices(&self, range: RangeInclusive<BlockNumber>) -> ProviderResult<()> {
         // account history stage
         {
             let indices = self.changed_accounts_and_blocks_with_range(range.clone())?;
@@ -1870,7 +1880,7 @@ impl<TX: DbTxMut + DbTx> HistoryWriter for DatabaseProvider<TX> {
     fn insert_storage_history_index(
         &self,
         storage_transitions: BTreeMap<(Address, B256), Vec<u64>>,
-    ) -> RethResult<()> {
+    ) -> ProviderResult<()> {
         self.append_history_index::<_, tables::StorageHistory>(
             storage_transitions,
             |(address, storage_key), highest_block_number| {
@@ -1882,14 +1892,14 @@ impl<TX: DbTxMut + DbTx> HistoryWriter for DatabaseProvider<TX> {
     fn insert_account_history_index(
         &self,
         account_transitions: BTreeMap<Address, Vec<u64>>,
-    ) -> RethResult<()> {
+    ) -> ProviderResult<()> {
         self.append_history_index::<_, tables::AccountHistory>(account_transitions, ShardedKey::new)
     }
 
     fn unwind_storage_history_indices(
         &self,
         range: Range<BlockNumberAddress>,
-    ) -> RethResult<usize> {
+    ) -> ProviderResult<usize> {
         let storage_changesets = self
             .tx
             .cursor_read::<tables::StorageChangeSet>()?
@@ -1939,7 +1949,7 @@ impl<TX: DbTxMut + DbTx> HistoryWriter for DatabaseProvider<TX> {
     fn unwind_account_history_indices(
         &self,
         range: RangeInclusive<BlockNumber>,
-    ) -> RethResult<usize> {
+    ) -> ProviderResult<usize> {
         let account_changeset = self
             .tx
             .cursor_read::<tables::AccountChangeSet>()?
@@ -1988,7 +1998,7 @@ impl<TX: DbTxMut + DbTx> BlockExecutionWriter for DatabaseProvider<TX> {
         &self,
         chain_spec: &ChainSpec,
         range: RangeInclusive<BlockNumber>,
-    ) -> RethResult<Chain> {
+    ) -> ProviderResult<Chain> {
         if TAKE {
             let storage_range = BlockNumberAddress::range(range.clone());
 
@@ -2086,7 +2096,7 @@ impl<TX: DbTxMut + DbTx> BlockWriter for DatabaseProvider<TX> {
         block: SealedBlock,
         senders: Option<Vec<Address>>,
         prune_modes: Option<&PruneModes>,
-    ) -> RethResult<StoredBlockBodyIndices> {
+    ) -> ProviderResult<StoredBlockBodyIndices> {
         let block_number = block.number;
 
         let mut durations_recorder = metrics::DurationsRecorder::default();
@@ -2138,9 +2148,8 @@ impl<TX: DbTxMut + DbTx> BlockWriter for DatabaseProvider<TX> {
         let tx_iter = if Some(block.body.len()) == senders_len {
             block.body.into_iter().zip(senders.unwrap()).collect::<Vec<(_, _)>>()
         } else {
-            let senders = TransactionSigned::recover_signers(&block.body, block.body.len()).ok_or(
-                BlockExecutionError::Validation(BlockValidationError::SenderRecoveryError),
-            )?;
+            let senders = TransactionSigned::recover_signers(&block.body, block.body.len())
+                .ok_or(ProviderError::SenderRecoveryError)?;
             durations_recorder.record_relative(metrics::Action::RecoverSigners);
             debug_assert_eq!(senders.len(), block.body.len(), "missing one or more senders");
             block.body.into_iter().zip(senders).collect()
@@ -2228,7 +2237,7 @@ impl<TX: DbTxMut + DbTx> BlockWriter for DatabaseProvider<TX> {
         blocks: Vec<SealedBlockWithSenders>,
         state: BundleStateWithReceipts,
         prune_modes: Option<&PruneModes>,
-    ) -> RethResult<()> {
+    ) -> ProviderResult<()> {
         if blocks.is_empty() {
             return Ok(())
         }
@@ -2273,7 +2282,10 @@ impl<TX: DbTxMut + DbTx> BlockWriter for DatabaseProvider<TX> {
 }
 
 impl<TX: DbTx> PruneCheckpointReader for DatabaseProvider<TX> {
-    fn get_prune_checkpoint(&self, segment: PruneSegment) -> RethResult<Option<PruneCheckpoint>> {
+    fn get_prune_checkpoint(
+        &self,
+        segment: PruneSegment,
+    ) -> ProviderResult<Option<PruneCheckpoint>> {
         Ok(self.tx.get::<tables::PruneCheckpoints>(segment)?)
     }
 }
@@ -2283,7 +2295,7 @@ impl<TX: DbTxMut> PruneCheckpointWriter for DatabaseProvider<TX> {
         &self,
         segment: PruneSegment,
         checkpoint: PruneCheckpoint,
-    ) -> RethResult<()> {
+    ) -> ProviderResult<()> {
         Ok(self.tx.put::<tables::PruneCheckpoints>(segment, checkpoint)?)
     }
 }

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -107,7 +107,7 @@ where
     fn ensure_canonical_block(&self, block_number: BlockNumber) -> ProviderResult<()> {
         let latest = self.best_block_number()?;
         if block_number > latest {
-            Err(ProviderError::HeaderNotFound(block_number.into()).into())
+            Err(ProviderError::HeaderNotFound(block_number.into()))
         } else {
             Ok(())
         }

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -10,6 +10,7 @@ use reth_db::{database::Database, models::StoredBlockBodyIndices};
 use reth_interfaces::{
     blockchain_tree::{BlockchainTreeEngine, BlockchainTreeViewer},
     consensus::ForkchoiceState,
+    provider::ProviderResult,
     RethError, RethResult,
 };
 use reth_primitives::{
@@ -76,7 +77,7 @@ where
 {
     /// Create a new provider using only the database and the tree, fetching the latest header from
     /// the database to initialize the provider.
-    pub fn new(database: ProviderFactory<DB>, tree: Tree) -> RethResult<Self> {
+    pub fn new(database: ProviderFactory<DB>, tree: Tree) -> ProviderResult<Self> {
         let provider = database.provider()?;
         let best: ChainInfo = provider.chain_info()?;
         match provider.header_by_number(best.best_number)? {
@@ -84,9 +85,7 @@ where
                 drop(provider);
                 Ok(Self::with_latest(database, tree, header.seal(best.best_hash)))
             }
-            None => {
-                Err(RethError::Provider(ProviderError::HeaderNotFound(best.best_number.into())))
-            }
+            None => Err(ProviderError::HeaderNotFound(best.best_number.into())),
         }
     }
 }
@@ -105,7 +104,7 @@ where
     /// Instead, we ensure that the `block_number` is within the range of the
     /// [Self::best_block_number] which is updated when a block is synced.
     #[inline]
-    fn ensure_canonical_block(&self, block_number: BlockNumber) -> RethResult<()> {
+    fn ensure_canonical_block(&self, block_number: BlockNumber) -> ProviderResult<()> {
         let latest = self.best_block_number()?;
         if block_number > latest {
             Err(ProviderError::HeaderNotFound(block_number.into()).into())
@@ -120,34 +119,34 @@ where
     DB: Database,
     Tree: Send + Sync,
 {
-    fn header(&self, block_hash: &BlockHash) -> RethResult<Option<Header>> {
+    fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Header>> {
         self.database.provider()?.header(block_hash)
     }
 
-    fn header_by_number(&self, num: BlockNumber) -> RethResult<Option<Header>> {
+    fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Header>> {
         self.database.provider()?.header_by_number(num)
     }
 
-    fn header_td(&self, hash: &BlockHash) -> RethResult<Option<U256>> {
+    fn header_td(&self, hash: &BlockHash) -> ProviderResult<Option<U256>> {
         self.database.provider()?.header_td(hash)
     }
 
-    fn header_td_by_number(&self, number: BlockNumber) -> RethResult<Option<U256>> {
+    fn header_td_by_number(&self, number: BlockNumber) -> ProviderResult<Option<U256>> {
         self.database.provider()?.header_td_by_number(number)
     }
 
-    fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> RethResult<Vec<Header>> {
+    fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> ProviderResult<Vec<Header>> {
         self.database.provider()?.headers_range(range)
     }
 
-    fn sealed_header(&self, number: BlockNumber) -> RethResult<Option<SealedHeader>> {
+    fn sealed_header(&self, number: BlockNumber) -> ProviderResult<Option<SealedHeader>> {
         self.database.provider()?.sealed_header(number)
     }
 
     fn sealed_headers_range(
         &self,
         range: impl RangeBounds<BlockNumber>,
-    ) -> RethResult<Vec<SealedHeader>> {
+    ) -> ProviderResult<Vec<SealedHeader>> {
         self.database.provider()?.sealed_headers_range(range)
     }
 
@@ -155,7 +154,7 @@ where
         &self,
         range: impl RangeBounds<BlockNumber>,
         predicate: impl FnMut(&SealedHeader) -> bool,
-    ) -> RethResult<Vec<SealedHeader>> {
+    ) -> ProviderResult<Vec<SealedHeader>> {
         self.database.provider()?.sealed_headers_while(range, predicate)
     }
 }
@@ -165,7 +164,7 @@ where
     DB: Database,
     Tree: Send + Sync,
 {
-    fn block_hash(&self, number: u64) -> RethResult<Option<B256>> {
+    fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
         self.database.provider()?.block_hash(number)
     }
 
@@ -173,7 +172,7 @@ where
         &self,
         start: BlockNumber,
         end: BlockNumber,
-    ) -> RethResult<Vec<B256>> {
+    ) -> ProviderResult<Vec<B256>> {
         self.database.provider()?.canonical_hashes_range(start, end)
     }
 }
@@ -183,19 +182,19 @@ where
     DB: Database,
     Tree: BlockchainTreeViewer + Send + Sync,
 {
-    fn chain_info(&self) -> RethResult<ChainInfo> {
+    fn chain_info(&self) -> ProviderResult<ChainInfo> {
         Ok(self.chain_info.chain_info())
     }
 
-    fn best_block_number(&self) -> RethResult<BlockNumber> {
+    fn best_block_number(&self) -> ProviderResult<BlockNumber> {
         Ok(self.chain_info.get_canonical_block_number())
     }
 
-    fn last_block_number(&self) -> RethResult<BlockNumber> {
+    fn last_block_number(&self) -> ProviderResult<BlockNumber> {
         self.database.provider()?.last_block_number()
     }
 
-    fn block_number(&self, hash: B256) -> RethResult<Option<BlockNumber>> {
+    fn block_number(&self, hash: B256) -> ProviderResult<Option<BlockNumber>> {
         self.database.provider()?.block_number(hash)
     }
 }
@@ -205,15 +204,15 @@ where
     DB: Database,
     Tree: BlockchainTreeViewer + Send + Sync,
 {
-    fn pending_block_num_hash(&self) -> RethResult<Option<BlockNumHash>> {
+    fn pending_block_num_hash(&self) -> ProviderResult<Option<BlockNumHash>> {
         Ok(self.tree.pending_block_num_hash())
     }
 
-    fn safe_block_num_hash(&self) -> RethResult<Option<BlockNumHash>> {
+    fn safe_block_num_hash(&self) -> ProviderResult<Option<BlockNumHash>> {
         Ok(self.chain_info.get_safe_num_hash())
     }
 
-    fn finalized_block_num_hash(&self) -> RethResult<Option<BlockNumHash>> {
+    fn finalized_block_num_hash(&self) -> ProviderResult<Option<BlockNumHash>> {
         Ok(self.chain_info.get_finalized_num_hash())
     }
 }
@@ -223,7 +222,7 @@ where
     DB: Database,
     Tree: BlockchainTreeViewer + Send + Sync,
 {
-    fn find_block_by_hash(&self, hash: B256, source: BlockSource) -> RethResult<Option<Block>> {
+    fn find_block_by_hash(&self, hash: B256, source: BlockSource) -> ProviderResult<Option<Block>> {
         let block = match source {
             BlockSource::Any => {
                 // check database first
@@ -242,29 +241,29 @@ where
         Ok(block)
     }
 
-    fn block(&self, id: BlockHashOrNumber) -> RethResult<Option<Block>> {
+    fn block(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Block>> {
         match id {
             BlockHashOrNumber::Hash(hash) => self.find_block_by_hash(hash, BlockSource::Any),
             BlockHashOrNumber::Number(num) => self.database.provider()?.block_by_number(num),
         }
     }
 
-    fn pending_block(&self) -> RethResult<Option<SealedBlock>> {
+    fn pending_block(&self) -> ProviderResult<Option<SealedBlock>> {
         Ok(self.tree.pending_block())
     }
 
-    fn pending_block_and_receipts(&self) -> RethResult<Option<(SealedBlock, Vec<Receipt>)>> {
+    fn pending_block_and_receipts(&self) -> ProviderResult<Option<(SealedBlock, Vec<Receipt>)>> {
         Ok(self.tree.pending_block_and_receipts())
     }
 
-    fn ommers(&self, id: BlockHashOrNumber) -> RethResult<Option<Vec<Header>>> {
+    fn ommers(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Header>>> {
         self.database.provider()?.ommers(id)
     }
 
     fn block_body_indices(
         &self,
         number: BlockNumber,
-    ) -> RethResult<Option<StoredBlockBodyIndices>> {
+    ) -> ProviderResult<Option<StoredBlockBodyIndices>> {
         self.database.provider()?.block_body_indices(number)
     }
 
@@ -278,11 +277,11 @@ where
         &self,
         id: BlockHashOrNumber,
         transaction_kind: TransactionVariant,
-    ) -> RethResult<Option<BlockWithSenders>> {
+    ) -> ProviderResult<Option<BlockWithSenders>> {
         self.database.provider()?.block_with_senders(id, transaction_kind)
     }
 
-    fn block_range(&self, range: RangeInclusive<BlockNumber>) -> RethResult<Vec<Block>> {
+    fn block_range(&self, range: RangeInclusive<BlockNumber>) -> ProviderResult<Vec<Block>> {
         self.database.provider()?.block_range(range)
     }
 }
@@ -292,62 +291,65 @@ where
     DB: Database,
     Tree: BlockchainTreeViewer + Send + Sync,
 {
-    fn transaction_id(&self, tx_hash: TxHash) -> RethResult<Option<TxNumber>> {
+    fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
         self.database.provider()?.transaction_id(tx_hash)
     }
 
-    fn transaction_by_id(&self, id: TxNumber) -> RethResult<Option<TransactionSigned>> {
+    fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<TransactionSigned>> {
         self.database.provider()?.transaction_by_id(id)
     }
 
     fn transaction_by_id_no_hash(
         &self,
         id: TxNumber,
-    ) -> RethResult<Option<TransactionSignedNoHash>> {
+    ) -> ProviderResult<Option<TransactionSignedNoHash>> {
         self.database.provider()?.transaction_by_id_no_hash(id)
     }
 
-    fn transaction_by_hash(&self, hash: TxHash) -> RethResult<Option<TransactionSigned>> {
+    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<TransactionSigned>> {
         self.database.provider()?.transaction_by_hash(hash)
     }
 
     fn transaction_by_hash_with_meta(
         &self,
         tx_hash: TxHash,
-    ) -> RethResult<Option<(TransactionSigned, TransactionMeta)>> {
+    ) -> ProviderResult<Option<(TransactionSigned, TransactionMeta)>> {
         self.database.provider()?.transaction_by_hash_with_meta(tx_hash)
     }
 
-    fn transaction_block(&self, id: TxNumber) -> RethResult<Option<BlockNumber>> {
+    fn transaction_block(&self, id: TxNumber) -> ProviderResult<Option<BlockNumber>> {
         self.database.provider()?.transaction_block(id)
     }
 
     fn transactions_by_block(
         &self,
         id: BlockHashOrNumber,
-    ) -> RethResult<Option<Vec<TransactionSigned>>> {
+    ) -> ProviderResult<Option<Vec<TransactionSigned>>> {
         self.database.provider()?.transactions_by_block(id)
     }
 
     fn transactions_by_block_range(
         &self,
         range: impl RangeBounds<BlockNumber>,
-    ) -> RethResult<Vec<Vec<TransactionSigned>>> {
+    ) -> ProviderResult<Vec<Vec<TransactionSigned>>> {
         self.database.provider()?.transactions_by_block_range(range)
     }
 
     fn transactions_by_tx_range(
         &self,
         range: impl RangeBounds<TxNumber>,
-    ) -> RethResult<Vec<TransactionSignedNoHash>> {
+    ) -> ProviderResult<Vec<TransactionSignedNoHash>> {
         self.database.provider()?.transactions_by_tx_range(range)
     }
 
-    fn senders_by_tx_range(&self, range: impl RangeBounds<TxNumber>) -> RethResult<Vec<Address>> {
+    fn senders_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Address>> {
         self.database.provider()?.senders_by_tx_range(range)
     }
 
-    fn transaction_sender(&self, id: TxNumber) -> RethResult<Option<Address>> {
+    fn transaction_sender(&self, id: TxNumber) -> ProviderResult<Option<Address>> {
         self.database.provider()?.transaction_sender(id)
     }
 }
@@ -357,15 +359,15 @@ where
     DB: Database,
     Tree: Send + Sync,
 {
-    fn receipt(&self, id: TxNumber) -> RethResult<Option<Receipt>> {
+    fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Receipt>> {
         self.database.provider()?.receipt(id)
     }
 
-    fn receipt_by_hash(&self, hash: TxHash) -> RethResult<Option<Receipt>> {
+    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Receipt>> {
         self.database.provider()?.receipt_by_hash(hash)
     }
 
-    fn receipts_by_block(&self, block: BlockHashOrNumber) -> RethResult<Option<Vec<Receipt>>> {
+    fn receipts_by_block(&self, block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
         self.database.provider()?.receipts_by_block(block)
     }
 }
@@ -374,7 +376,7 @@ where
     DB: Database,
     Tree: BlockchainTreeViewer + Send + Sync,
 {
-    fn receipts_by_block_id(&self, block: BlockId) -> RethResult<Option<Vec<Receipt>>> {
+    fn receipts_by_block_id(&self, block: BlockId) -> ProviderResult<Option<Vec<Receipt>>> {
         match block {
             BlockId::Hash(rpc_block_hash) => {
                 let mut receipts = self.receipts_by_block(rpc_block_hash.block_hash.into())?;
@@ -406,11 +408,11 @@ where
         &self,
         id: BlockHashOrNumber,
         timestamp: u64,
-    ) -> RethResult<Option<Vec<Withdrawal>>> {
+    ) -> ProviderResult<Option<Vec<Withdrawal>>> {
         self.database.provider()?.withdrawals_by_block(id, timestamp)
     }
 
-    fn latest_withdrawal(&self) -> RethResult<Option<Withdrawal>> {
+    fn latest_withdrawal(&self) -> ProviderResult<Option<Withdrawal>> {
         self.database.provider()?.latest_withdrawal()
     }
 }
@@ -420,11 +422,11 @@ where
     DB: Database,
     Tree: Send + Sync,
 {
-    fn get_stage_checkpoint(&self, id: StageId) -> RethResult<Option<StageCheckpoint>> {
+    fn get_stage_checkpoint(&self, id: StageId) -> ProviderResult<Option<StageCheckpoint>> {
         self.database.provider()?.get_stage_checkpoint(id)
     }
 
-    fn get_stage_checkpoint_progress(&self, id: StageId) -> RethResult<Option<Vec<u8>>> {
+    fn get_stage_checkpoint_progress(&self, id: StageId) -> ProviderResult<Option<Vec<u8>>> {
         self.database.provider()?.get_stage_checkpoint_progress(id)
     }
 }
@@ -439,7 +441,7 @@ where
         cfg: &mut CfgEnv,
         block_env: &mut BlockEnv,
         at: BlockHashOrNumber,
-    ) -> RethResult<()> {
+    ) -> ProviderResult<()> {
         self.database.provider()?.fill_env_at(cfg, block_env, at)
     }
 
@@ -448,11 +450,15 @@ where
         cfg: &mut CfgEnv,
         block_env: &mut BlockEnv,
         header: &Header,
-    ) -> RethResult<()> {
+    ) -> ProviderResult<()> {
         self.database.provider()?.fill_env_with_header(cfg, block_env, header)
     }
 
-    fn fill_block_env_at(&self, block_env: &mut BlockEnv, at: BlockHashOrNumber) -> RethResult<()> {
+    fn fill_block_env_at(
+        &self,
+        block_env: &mut BlockEnv,
+        at: BlockHashOrNumber,
+    ) -> ProviderResult<()> {
         self.database.provider()?.fill_block_env_at(block_env, at)
     }
 
@@ -460,15 +466,15 @@ where
         &self,
         block_env: &mut BlockEnv,
         header: &Header,
-    ) -> RethResult<()> {
+    ) -> ProviderResult<()> {
         self.database.provider()?.fill_block_env_with_header(block_env, header)
     }
 
-    fn fill_cfg_env_at(&self, cfg: &mut CfgEnv, at: BlockHashOrNumber) -> RethResult<()> {
+    fn fill_cfg_env_at(&self, cfg: &mut CfgEnv, at: BlockHashOrNumber) -> ProviderResult<()> {
         self.database.provider()?.fill_cfg_env_at(cfg, at)
     }
 
-    fn fill_cfg_env_with_header(&self, cfg: &mut CfgEnv, header: &Header) -> RethResult<()> {
+    fn fill_cfg_env_with_header(&self, cfg: &mut CfgEnv, header: &Header) -> ProviderResult<()> {
         self.database.provider()?.fill_cfg_env_with_header(cfg, header)
     }
 }
@@ -478,7 +484,10 @@ where
     DB: Database,
     Tree: Send + Sync,
 {
-    fn get_prune_checkpoint(&self, segment: PruneSegment) -> RethResult<Option<PruneCheckpoint>> {
+    fn get_prune_checkpoint(
+        &self,
+        segment: PruneSegment,
+    ) -> ProviderResult<Option<PruneCheckpoint>> {
         self.database.provider()?.get_prune_checkpoint(segment)
     }
 }
@@ -499,7 +508,7 @@ where
     Tree: BlockchainTreePendingStateProvider + BlockchainTreeViewer,
 {
     /// Storage provider for latest block
-    fn latest(&self) -> RethResult<StateProviderBox<'_>> {
+    fn latest(&self) -> ProviderResult<StateProviderBox<'_>> {
         trace!(target: "providers::blockchain", "Getting latest block state provider");
         self.database.latest()
     }
@@ -507,18 +516,18 @@ where
     fn history_by_block_number(
         &self,
         block_number: BlockNumber,
-    ) -> RethResult<StateProviderBox<'_>> {
+    ) -> ProviderResult<StateProviderBox<'_>> {
         trace!(target: "providers::blockchain", ?block_number, "Getting history by block number");
         self.ensure_canonical_block(block_number)?;
         self.database.history_by_block_number(block_number)
     }
 
-    fn history_by_block_hash(&self, block_hash: BlockHash) -> RethResult<StateProviderBox<'_>> {
+    fn history_by_block_hash(&self, block_hash: BlockHash) -> ProviderResult<StateProviderBox<'_>> {
         trace!(target: "providers::blockchain", ?block_hash, "Getting history by block hash");
         self.database.history_by_block_hash(block_hash)
     }
 
-    fn state_by_block_hash(&self, block: BlockHash) -> RethResult<StateProviderBox<'_>> {
+    fn state_by_block_hash(&self, block: BlockHash) -> ProviderResult<StateProviderBox<'_>> {
         trace!(target: "providers::blockchain", ?block, "Getting state by block hash");
         let mut state = self.history_by_block_hash(block);
 
@@ -537,7 +546,7 @@ where
     ///
     /// If there's no pending block available then the latest state provider is returned:
     /// [Self::latest]
-    fn pending(&self) -> RethResult<StateProviderBox<'_>> {
+    fn pending(&self) -> ProviderResult<StateProviderBox<'_>> {
         trace!(target: "providers::blockchain", "Getting provider for pending state");
 
         if let Some(block) = self.tree.pending_block_num_hash() {
@@ -550,7 +559,10 @@ where
         self.latest()
     }
 
-    fn pending_state_by_hash(&self, block_hash: B256) -> RethResult<Option<StateProviderBox<'_>>> {
+    fn pending_state_by_hash(
+        &self,
+        block_hash: B256,
+    ) -> ProviderResult<Option<StateProviderBox<'_>>> {
         if let Some(state) = self.tree.find_pending_state_provider(block_hash) {
             return Ok(Some(self.pending_with_provider(state)?))
         }
@@ -560,7 +572,7 @@ where
     fn pending_with_provider(
         &self,
         post_state_data: Box<dyn BundleStateDataProvider>,
-    ) -> RethResult<StateProviderBox<'_>> {
+    ) -> ProviderResult<StateProviderBox<'_>> {
         let canonical_fork = post_state_data.canonical_fork();
         trace!(target: "providers::blockchain", ?canonical_fork, "Returning post state provider");
 
@@ -714,7 +726,7 @@ where
     Self: BlockReader + BlockIdReader + ReceiptProviderIdExt,
     Tree: BlockchainTreeEngine,
 {
-    fn block_by_id(&self, id: BlockId) -> RethResult<Option<Block>> {
+    fn block_by_id(&self, id: BlockId) -> ProviderResult<Option<Block>> {
         match id {
             BlockId::Number(num) => self.block_by_number_or_tag(num),
             BlockId::Hash(hash) => {
@@ -732,23 +744,23 @@ where
         }
     }
 
-    fn header_by_number_or_tag(&self, id: BlockNumberOrTag) -> RethResult<Option<Header>> {
-        match id {
-            BlockNumberOrTag::Latest => Ok(Some(self.chain_info.get_canonical_head().unseal())),
+    fn header_by_number_or_tag(&self, id: BlockNumberOrTag) -> ProviderResult<Option<Header>> {
+        Ok(match id {
+            BlockNumberOrTag::Latest => Some(self.chain_info.get_canonical_head().unseal()),
             BlockNumberOrTag::Finalized => {
-                Ok(self.chain_info.get_finalized_header().map(|h| h.unseal()))
+                self.chain_info.get_finalized_header().map(|h| h.unseal())
             }
-            BlockNumberOrTag::Safe => Ok(self.chain_info.get_safe_header().map(|h| h.unseal())),
-            BlockNumberOrTag::Earliest => self.header_by_number(0),
-            BlockNumberOrTag::Pending => Ok(self.tree.pending_header().map(|h| h.unseal())),
-            BlockNumberOrTag::Number(num) => self.header_by_number(num),
-        }
+            BlockNumberOrTag::Safe => self.chain_info.get_safe_header().map(|h| h.unseal()),
+            BlockNumberOrTag::Earliest => self.header_by_number(0)?,
+            BlockNumberOrTag::Pending => self.tree.pending_header().map(|h| h.unseal()),
+            BlockNumberOrTag::Number(num) => self.header_by_number(num)?,
+        })
     }
 
     fn sealed_header_by_number_or_tag(
         &self,
         id: BlockNumberOrTag,
-    ) -> RethResult<Option<SealedHeader>> {
+    ) -> ProviderResult<Option<SealedHeader>> {
         match id {
             BlockNumberOrTag::Latest => Ok(Some(self.chain_info.get_canonical_head())),
             BlockNumberOrTag::Finalized => Ok(self.chain_info.get_finalized_header()),
@@ -763,23 +775,21 @@ where
         }
     }
 
-    fn sealed_header_by_id(&self, id: BlockId) -> RethResult<Option<SealedHeader>> {
-        match id {
-            BlockId::Number(num) => self.sealed_header_by_number_or_tag(num),
-            BlockId::Hash(hash) => {
-                self.header(&hash.block_hash)?.map_or_else(|| Ok(None), |h| Ok(Some(h.seal_slow())))
-            }
-        }
+    fn sealed_header_by_id(&self, id: BlockId) -> ProviderResult<Option<SealedHeader>> {
+        Ok(match id {
+            BlockId::Number(num) => self.sealed_header_by_number_or_tag(num)?,
+            BlockId::Hash(hash) => self.header(&hash.block_hash)?.map(|h| h.seal_slow()),
+        })
     }
 
-    fn header_by_id(&self, id: BlockId) -> RethResult<Option<Header>> {
-        match id {
-            BlockId::Number(num) => self.header_by_number_or_tag(num),
-            BlockId::Hash(hash) => self.header(&hash.block_hash),
-        }
+    fn header_by_id(&self, id: BlockId) -> ProviderResult<Option<Header>> {
+        Ok(match id {
+            BlockId::Number(num) => self.header_by_number_or_tag(num)?,
+            BlockId::Hash(hash) => self.header(&hash.block_hash)?,
+        })
     }
 
-    fn ommers_by_id(&self, id: BlockId) -> RethResult<Option<Vec<Header>>> {
+    fn ommers_by_id(&self, id: BlockId) -> ProviderResult<Option<Vec<Header>>> {
         match id {
             BlockId::Number(num) => self.ommers_by_number_or_tag(num),
             BlockId::Hash(hash) => {
@@ -822,7 +832,7 @@ where
     fn account_block_changeset(
         &self,
         block_number: BlockNumber,
-    ) -> RethResult<Vec<AccountBeforeTx>> {
+    ) -> ProviderResult<Vec<AccountBeforeTx>> {
         self.database.provider()?.account_block_changeset(block_number)
     }
 }
@@ -833,7 +843,7 @@ where
     Tree: Sync + Send,
 {
     /// Get basic account information.
-    fn basic_account(&self, address: Address) -> RethResult<Option<Account>> {
+    fn basic_account(&self, address: Address) -> ProviderResult<Option<Account>> {
         self.database.provider()?.basic_account(address)
     }
 }

--- a/crates/storage/provider/src/providers/snapshot/jar.rs
+++ b/crates/storage/provider/src/providers/snapshot/jar.rs
@@ -125,7 +125,7 @@ impl<'a> HeaderProvider for SnapshotJarProvider<'a> {
 
 impl<'a> BlockHashReader for SnapshotJarProvider<'a> {
     fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
-        Ok(self.cursor()?.get_one::<HeaderMask<BlockHash>>(number.into())?)
+        self.cursor()?.get_one::<HeaderMask<BlockHash>>(number.into())
     }
 
     fn canonical_hashes_range(
@@ -148,17 +148,17 @@ impl<'a> BlockHashReader for SnapshotJarProvider<'a> {
 impl<'a> BlockNumReader for SnapshotJarProvider<'a> {
     fn chain_info(&self) -> ProviderResult<ChainInfo> {
         // Information on live database
-        Err(ProviderError::UnsupportedProvider.into())
+        Err(ProviderError::UnsupportedProvider)
     }
 
     fn best_block_number(&self) -> ProviderResult<BlockNumber> {
         // Information on live database
-        Err(ProviderError::UnsupportedProvider.into())
+        Err(ProviderError::UnsupportedProvider)
     }
 
     fn last_block_number(&self) -> ProviderResult<BlockNumber> {
         // Information on live database
-        Err(ProviderError::UnsupportedProvider.into())
+        Err(ProviderError::UnsupportedProvider)
     }
 
     fn block_number(&self, hash: B256) -> ProviderResult<Option<BlockNumber>> {
@@ -190,7 +190,7 @@ impl<'a> TransactionsProvider for SnapshotJarProvider<'a> {
         &self,
         num: TxNumber,
     ) -> ProviderResult<Option<TransactionSignedNoHash>> {
-        Ok(self.cursor()?.get_one::<TransactionMask<TransactionSignedNoHash>>(num.into())?)
+        self.cursor()?.get_one::<TransactionMask<TransactionSignedNoHash>>(num.into())
     }
 
     fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<TransactionSigned>> {
@@ -205,12 +205,12 @@ impl<'a> TransactionsProvider for SnapshotJarProvider<'a> {
         _hash: TxHash,
     ) -> ProviderResult<Option<(TransactionSigned, TransactionMeta)>> {
         // Information required on indexing table [`tables::TransactionBlock`]
-        Err(ProviderError::UnsupportedProvider.into())
+        Err(ProviderError::UnsupportedProvider)
     }
 
     fn transaction_block(&self, _id: TxNumber) -> ProviderResult<Option<BlockNumber>> {
         // Information on indexing table [`tables::TransactionBlock`]
-        Err(ProviderError::UnsupportedProvider.into())
+        Err(ProviderError::UnsupportedProvider)
     }
 
     fn transactions_by_block(
@@ -219,7 +219,7 @@ impl<'a> TransactionsProvider for SnapshotJarProvider<'a> {
     ) -> ProviderResult<Option<Vec<TransactionSigned>>> {
         // Related to indexing tables. Live database should get the tx_range and call snapshot
         // provider with `transactions_by_tx_range` instead.
-        Err(ProviderError::UnsupportedProvider.into())
+        Err(ProviderError::UnsupportedProvider)
     }
 
     fn transactions_by_block_range(
@@ -228,7 +228,7 @@ impl<'a> TransactionsProvider for SnapshotJarProvider<'a> {
     ) -> ProviderResult<Vec<Vec<TransactionSigned>>> {
         // Related to indexing tables. Live database should get the tx_range and call snapshot
         // provider with `transactions_by_tx_range` instead.
-        Err(ProviderError::UnsupportedProvider.into())
+        Err(ProviderError::UnsupportedProvider)
     }
 
     fn senders_by_tx_range(
@@ -268,13 +268,13 @@ impl<'a> TransactionsProvider for SnapshotJarProvider<'a> {
 
 impl<'a> ReceiptProvider for SnapshotJarProvider<'a> {
     fn receipt(&self, num: TxNumber) -> ProviderResult<Option<Receipt>> {
-        Ok(self.cursor()?.get_one::<ReceiptMask<Receipt>>(num.into())?)
+        self.cursor()?.get_one::<ReceiptMask<Receipt>>(num.into())
     }
 
     fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Receipt>> {
         if let Some(tx_snapshot) = &self.auxiliar_jar {
             if let Some(num) = tx_snapshot.transaction_id(hash)? {
-                return Ok(self.receipt(num)?)
+                return self.receipt(num)
             }
         }
         Ok(None)
@@ -283,7 +283,7 @@ impl<'a> ReceiptProvider for SnapshotJarProvider<'a> {
     fn receipts_by_block(&self, _block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
         // Related to indexing tables. Snapshot should get the tx_range and call snapshot
         // provider with `receipt()` instead for each
-        Err(ProviderError::UnsupportedProvider.into())
+        Err(ProviderError::UnsupportedProvider)
     }
 }
 

--- a/crates/storage/provider/src/providers/snapshot/jar.rs
+++ b/crates/storage/provider/src/providers/snapshot/jar.rs
@@ -6,11 +6,7 @@ use reth_db::{
     codecs::CompactU256,
     snapshot::{HeaderMask, ReceiptMask, SnapshotCursor, TransactionMask},
 };
-use reth_interfaces::{
-    executor::{BlockExecutionError, BlockValidationError},
-    provider::ProviderError,
-    RethResult,
-};
+use reth_interfaces::provider::{ProviderError, ProviderResult};
 use reth_primitives::{
     Address, BlockHash, BlockHashOrNumber, BlockNumber, ChainInfo, Header, Receipt, SealedHeader,
     TransactionMeta, TransactionSigned, TransactionSignedNoHash, TxHash, TxNumber, B256, U256,
@@ -41,7 +37,7 @@ impl<'a> From<LoadedJarRef<'a>> for SnapshotJarProvider<'a> {
 
 impl<'a> SnapshotJarProvider<'a> {
     /// Provides a cursor for more granular data access.
-    pub fn cursor<'b>(&'b self) -> RethResult<SnapshotCursor<'a>>
+    pub fn cursor<'b>(&'b self) -> ProviderResult<SnapshotCursor<'a>>
     where
         'b: 'a,
     {
@@ -56,7 +52,7 @@ impl<'a> SnapshotJarProvider<'a> {
 }
 
 impl<'a> HeaderProvider for SnapshotJarProvider<'a> {
-    fn header(&self, block_hash: &BlockHash) -> RethResult<Option<Header>> {
+    fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Header>> {
         Ok(self
             .cursor()?
             .get_two::<HeaderMask<Header, BlockHash>>(block_hash.into())?
@@ -64,11 +60,11 @@ impl<'a> HeaderProvider for SnapshotJarProvider<'a> {
             .map(|(header, _)| header))
     }
 
-    fn header_by_number(&self, num: BlockNumber) -> RethResult<Option<Header>> {
+    fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Header>> {
         self.cursor()?.get_one::<HeaderMask<Header>>(num.into())
     }
 
-    fn header_td(&self, block_hash: &BlockHash) -> RethResult<Option<U256>> {
+    fn header_td(&self, block_hash: &BlockHash) -> ProviderResult<Option<U256>> {
         Ok(self
             .cursor()?
             .get_two::<HeaderMask<CompactU256, BlockHash>>(block_hash.into())?
@@ -76,11 +72,11 @@ impl<'a> HeaderProvider for SnapshotJarProvider<'a> {
             .map(|(td, _)| td.into()))
     }
 
-    fn header_td_by_number(&self, num: BlockNumber) -> RethResult<Option<U256>> {
+    fn header_td_by_number(&self, num: BlockNumber) -> ProviderResult<Option<U256>> {
         Ok(self.cursor()?.get_one::<HeaderMask<CompactU256>>(num.into())?.map(Into::into))
     }
 
-    fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> RethResult<Vec<Header>> {
+    fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> ProviderResult<Vec<Header>> {
         let range = to_range(range);
 
         let mut cursor = self.cursor()?;
@@ -95,7 +91,7 @@ impl<'a> HeaderProvider for SnapshotJarProvider<'a> {
         Ok(headers)
     }
 
-    fn sealed_header(&self, number: BlockNumber) -> RethResult<Option<SealedHeader>> {
+    fn sealed_header(&self, number: BlockNumber) -> ProviderResult<Option<SealedHeader>> {
         Ok(self
             .cursor()?
             .get_two::<HeaderMask<Header, BlockHash>>(number.into())?
@@ -106,7 +102,7 @@ impl<'a> HeaderProvider for SnapshotJarProvider<'a> {
         &self,
         range: impl RangeBounds<BlockNumber>,
         mut predicate: impl FnMut(&SealedHeader) -> bool,
-    ) -> RethResult<Vec<SealedHeader>> {
+    ) -> ProviderResult<Vec<SealedHeader>> {
         let range = to_range(range);
 
         let mut cursor = self.cursor()?;
@@ -128,15 +124,15 @@ impl<'a> HeaderProvider for SnapshotJarProvider<'a> {
 }
 
 impl<'a> BlockHashReader for SnapshotJarProvider<'a> {
-    fn block_hash(&self, number: u64) -> RethResult<Option<B256>> {
-        self.cursor()?.get_one::<HeaderMask<BlockHash>>(number.into())
+    fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
+        Ok(self.cursor()?.get_one::<HeaderMask<BlockHash>>(number.into())?)
     }
 
     fn canonical_hashes_range(
         &self,
         start: BlockNumber,
         end: BlockNumber,
-    ) -> RethResult<Vec<B256>> {
+    ) -> ProviderResult<Vec<B256>> {
         let mut cursor = self.cursor()?;
         let mut hashes = Vec::with_capacity((end - start) as usize);
 
@@ -150,22 +146,22 @@ impl<'a> BlockHashReader for SnapshotJarProvider<'a> {
 }
 
 impl<'a> BlockNumReader for SnapshotJarProvider<'a> {
-    fn chain_info(&self) -> RethResult<ChainInfo> {
+    fn chain_info(&self) -> ProviderResult<ChainInfo> {
         // Information on live database
         Err(ProviderError::UnsupportedProvider.into())
     }
 
-    fn best_block_number(&self) -> RethResult<BlockNumber> {
+    fn best_block_number(&self) -> ProviderResult<BlockNumber> {
         // Information on live database
         Err(ProviderError::UnsupportedProvider.into())
     }
 
-    fn last_block_number(&self) -> RethResult<BlockNumber> {
+    fn last_block_number(&self) -> ProviderResult<BlockNumber> {
         // Information on live database
         Err(ProviderError::UnsupportedProvider.into())
     }
 
-    fn block_number(&self, hash: B256) -> RethResult<Option<BlockNumber>> {
+    fn block_number(&self, hash: B256) -> ProviderResult<Option<BlockNumber>> {
         let mut cursor = self.cursor()?;
 
         Ok(cursor
@@ -175,7 +171,7 @@ impl<'a> BlockNumReader for SnapshotJarProvider<'a> {
 }
 
 impl<'a> TransactionsProvider for SnapshotJarProvider<'a> {
-    fn transaction_id(&self, hash: TxHash) -> RethResult<Option<TxNumber>> {
+    fn transaction_id(&self, hash: TxHash) -> ProviderResult<Option<TxNumber>> {
         let mut cursor = self.cursor()?;
 
         Ok(cursor
@@ -183,7 +179,7 @@ impl<'a> TransactionsProvider for SnapshotJarProvider<'a> {
             .and_then(|res| (res.hash() == hash).then(|| cursor.number())))
     }
 
-    fn transaction_by_id(&self, num: TxNumber) -> RethResult<Option<TransactionSigned>> {
+    fn transaction_by_id(&self, num: TxNumber) -> ProviderResult<Option<TransactionSigned>> {
         Ok(self
             .cursor()?
             .get_one::<TransactionMask<TransactionSignedNoHash>>(num.into())?
@@ -193,11 +189,11 @@ impl<'a> TransactionsProvider for SnapshotJarProvider<'a> {
     fn transaction_by_id_no_hash(
         &self,
         num: TxNumber,
-    ) -> RethResult<Option<TransactionSignedNoHash>> {
-        self.cursor()?.get_one::<TransactionMask<TransactionSignedNoHash>>(num.into())
+    ) -> ProviderResult<Option<TransactionSignedNoHash>> {
+        Ok(self.cursor()?.get_one::<TransactionMask<TransactionSignedNoHash>>(num.into())?)
     }
 
-    fn transaction_by_hash(&self, hash: TxHash) -> RethResult<Option<TransactionSigned>> {
+    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<TransactionSigned>> {
         Ok(self
             .cursor()?
             .get_one::<TransactionMask<TransactionSignedNoHash>>((&hash).into())?
@@ -207,12 +203,12 @@ impl<'a> TransactionsProvider for SnapshotJarProvider<'a> {
     fn transaction_by_hash_with_meta(
         &self,
         _hash: TxHash,
-    ) -> RethResult<Option<(TransactionSigned, TransactionMeta)>> {
+    ) -> ProviderResult<Option<(TransactionSigned, TransactionMeta)>> {
         // Information required on indexing table [`tables::TransactionBlock`]
         Err(ProviderError::UnsupportedProvider.into())
     }
 
-    fn transaction_block(&self, _id: TxNumber) -> RethResult<Option<BlockNumber>> {
+    fn transaction_block(&self, _id: TxNumber) -> ProviderResult<Option<BlockNumber>> {
         // Information on indexing table [`tables::TransactionBlock`]
         Err(ProviderError::UnsupportedProvider.into())
     }
@@ -220,7 +216,7 @@ impl<'a> TransactionsProvider for SnapshotJarProvider<'a> {
     fn transactions_by_block(
         &self,
         _block_id: BlockHashOrNumber,
-    ) -> RethResult<Option<Vec<TransactionSigned>>> {
+    ) -> ProviderResult<Option<Vec<TransactionSigned>>> {
         // Related to indexing tables. Live database should get the tx_range and call snapshot
         // provider with `transactions_by_tx_range` instead.
         Err(ProviderError::UnsupportedProvider.into())
@@ -229,22 +225,25 @@ impl<'a> TransactionsProvider for SnapshotJarProvider<'a> {
     fn transactions_by_block_range(
         &self,
         _range: impl RangeBounds<BlockNumber>,
-    ) -> RethResult<Vec<Vec<TransactionSigned>>> {
+    ) -> ProviderResult<Vec<Vec<TransactionSigned>>> {
         // Related to indexing tables. Live database should get the tx_range and call snapshot
         // provider with `transactions_by_tx_range` instead.
         Err(ProviderError::UnsupportedProvider.into())
     }
 
-    fn senders_by_tx_range(&self, range: impl RangeBounds<TxNumber>) -> RethResult<Vec<Address>> {
+    fn senders_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Address>> {
         let txs = self.transactions_by_tx_range(range)?;
-        Ok(TransactionSignedNoHash::recover_signers(&txs, txs.len())
-            .ok_or(BlockExecutionError::Validation(BlockValidationError::SenderRecoveryError))?)
+        TransactionSignedNoHash::recover_signers(&txs, txs.len())
+            .ok_or(ProviderError::SenderRecoveryError)
     }
 
     fn transactions_by_tx_range(
         &self,
         range: impl RangeBounds<TxNumber>,
-    ) -> RethResult<Vec<reth_primitives::TransactionSignedNoHash>> {
+    ) -> ProviderResult<Vec<reth_primitives::TransactionSignedNoHash>> {
         let range = to_range(range);
         let mut cursor = self.cursor()?;
         let mut txes = Vec::with_capacity((range.end - range.start) as usize);
@@ -259,7 +258,7 @@ impl<'a> TransactionsProvider for SnapshotJarProvider<'a> {
         Ok(txes)
     }
 
-    fn transaction_sender(&self, num: TxNumber) -> RethResult<Option<Address>> {
+    fn transaction_sender(&self, num: TxNumber) -> ProviderResult<Option<Address>> {
         Ok(self
             .cursor()?
             .get_one::<TransactionMask<TransactionSignedNoHash>>(num.into())?
@@ -268,20 +267,20 @@ impl<'a> TransactionsProvider for SnapshotJarProvider<'a> {
 }
 
 impl<'a> ReceiptProvider for SnapshotJarProvider<'a> {
-    fn receipt(&self, num: TxNumber) -> RethResult<Option<Receipt>> {
-        self.cursor()?.get_one::<ReceiptMask<Receipt>>(num.into())
+    fn receipt(&self, num: TxNumber) -> ProviderResult<Option<Receipt>> {
+        Ok(self.cursor()?.get_one::<ReceiptMask<Receipt>>(num.into())?)
     }
 
-    fn receipt_by_hash(&self, hash: TxHash) -> RethResult<Option<Receipt>> {
+    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Receipt>> {
         if let Some(tx_snapshot) = &self.auxiliar_jar {
             if let Some(num) = tx_snapshot.transaction_id(hash)? {
-                return self.receipt(num)
+                return Ok(self.receipt(num)?)
             }
         }
         Ok(None)
     }
 
-    fn receipts_by_block(&self, _block: BlockHashOrNumber) -> RethResult<Option<Vec<Receipt>>> {
+    fn receipts_by_block(&self, _block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
         // Related to indexing tables. Snapshot should get the tx_range and call snapshot
         // provider with `receipt()` instead for each
         Err(ProviderError::UnsupportedProvider.into())

--- a/crates/storage/provider/src/providers/snapshot/manager.rs
+++ b/crates/storage/provider/src/providers/snapshot/manager.rs
@@ -79,7 +79,7 @@ impl SnapshotProvider {
             || self.get_segment_ranges_from_block(segment, block),
             path,
         )?
-        .ok_or_else(|| ProviderError::MissingSnapshotBlock(segment, block).into())
+        .ok_or_else(|| ProviderError::MissingSnapshotBlock(segment, block))
     }
 
     /// Gets the [`SnapshotJarProvider`] of the requested segment and transaction.
@@ -94,7 +94,7 @@ impl SnapshotProvider {
             || self.get_segment_ranges_from_transaction(segment, tx),
             path,
         )?
-        .ok_or_else(|| ProviderError::MissingSnapshotTx(segment, tx).into())
+        .ok_or_else(|| ProviderError::MissingSnapshotTx(segment, tx))
     }
 
     /// Gets the [`SnapshotJarProvider`] of the requested segment and block or transaction.
@@ -326,7 +326,7 @@ impl BlockNumReader for SnapshotProvider {
 
 impl TransactionsProvider for SnapshotProvider {
     fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
-        Ok(self.find_snapshot(SnapshotSegment::Transactions, |jar_provider| {
+        self.find_snapshot(SnapshotSegment::Transactions, |jar_provider| {
             let mut cursor = jar_provider.cursor()?;
             if cursor
                 .get_one::<TransactionMask<TransactionSignedNoHash>>((&tx_hash).into())?
@@ -337,7 +337,7 @@ impl TransactionsProvider for SnapshotProvider {
             } else {
                 Ok(None)
             }
-        })?)
+        })
     }
 
     fn transaction_by_id(&self, num: TxNumber) -> ProviderResult<Option<TransactionSigned>> {
@@ -354,13 +354,13 @@ impl TransactionsProvider for SnapshotProvider {
     }
 
     fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<TransactionSigned>> {
-        Ok(self.find_snapshot(SnapshotSegment::Transactions, |jar_provider| {
+        self.find_snapshot(SnapshotSegment::Transactions, |jar_provider| {
             Ok(jar_provider
                 .cursor()?
                 .get_one::<TransactionMask<TransactionSignedNoHash>>((&hash).into())?
                 .map(|tx| tx.with_hash())
                 .and_then(|tx| (tx.hash_ref() == &hash).then_some(tx)))
-        })?)
+        })
     }
 
     fn transaction_by_hash_with_meta(

--- a/crates/storage/provider/src/providers/snapshot/mod.rs
+++ b/crates/storage/provider/src/providers/snapshot/mod.rs
@@ -4,7 +4,7 @@ pub use manager::SnapshotProvider;
 mod jar;
 pub use jar::SnapshotJarProvider;
 
-use reth_interfaces::RethResult;
+use reth_interfaces::provider::ProviderResult;
 use reth_nippy_jar::NippyJar;
 use reth_primitives::{snapshot::SegmentHeader, SnapshotSegment};
 use std::ops::Deref;
@@ -20,7 +20,7 @@ pub struct LoadedJar {
 }
 
 impl LoadedJar {
-    fn new(jar: NippyJar<SegmentHeader>) -> RethResult<Self> {
+    fn new(jar: NippyJar<SegmentHeader>) -> ProviderResult<Self> {
         let mmap_handle = jar.open_data()?;
         Ok(Self { jar, mmap_handle })
     }

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -63,7 +63,7 @@ impl<'b, TX: DbTx> HistoricalStateProviderRef<'b, TX> {
     /// Lookup an account in the AccountHistory table
     pub fn account_history_lookup(&self, address: Address) -> ProviderResult<HistoryInfo> {
         if !self.lowest_available_blocks.is_account_history_available(self.block_number) {
-            return Err(ProviderError::StateAtBlockPruned(self.block_number).into())
+            return Err(ProviderError::StateAtBlockPruned(self.block_number))
         }
 
         // history key to search IntegerList of block number changesets.
@@ -82,7 +82,7 @@ impl<'b, TX: DbTx> HistoricalStateProviderRef<'b, TX> {
         storage_key: StorageKey,
     ) -> ProviderResult<HistoryInfo> {
         if !self.lowest_available_blocks.is_storage_history_available(self.block_number) {
-            return Err(ProviderError::StateAtBlockPruned(self.block_number).into())
+            return Err(ProviderError::StateAtBlockPruned(self.block_number))
         }
 
         // history key to search IntegerList of block number changesets.
@@ -199,7 +199,7 @@ impl<'b, TX: DbTx> BlockHashReader for HistoricalStateProviderRef<'b, TX> {
 
 impl<'b, TX: DbTx> StateRootProvider for HistoricalStateProviderRef<'b, TX> {
     fn state_root(&self, _post_state: &BundleStateWithReceipts) -> ProviderResult<B256> {
-        Err(ProviderError::StateRootNotAvailableForHistoricalBlock.into())
+        Err(ProviderError::StateRootNotAvailableForHistoricalBlock)
     }
 }
 
@@ -241,7 +241,7 @@ impl<'b, TX: DbTx> StateProvider for HistoricalStateProviderRef<'b, TX> {
 
     /// Get account and storage proofs.
     fn proof(&self, _address: Address, _keys: &[B256]) -> ProviderResult<AccountProof> {
-        Err(ProviderError::StateRootNotAvailableForHistoricalBlock.into())
+        Err(ProviderError::StateRootNotAvailableForHistoricalBlock)
     }
 }
 
@@ -566,11 +566,11 @@ mod tests {
         );
         assert_eq!(
             provider.account_history_lookup(ADDRESS),
-            Err(ProviderError::StateAtBlockPruned(provider.block_number).into())
+            Err(ProviderError::StateAtBlockPruned(provider.block_number))
         );
         assert_eq!(
             provider.storage_history_lookup(ADDRESS, STORAGE),
-            Err(ProviderError::StateAtBlockPruned(provider.block_number).into())
+            Err(ProviderError::StateAtBlockPruned(provider.block_number))
         );
 
         // provider block_number == lowest available block number,

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -10,7 +10,7 @@ use reth_db::{
     transaction::DbTx,
     BlockNumberList,
 };
-use reth_interfaces::RethResult;
+use reth_interfaces::provider::ProviderResult;
 use reth_primitives::{
     trie::AccountProof, Account, Address, BlockNumber, Bytecode, StorageKey, StorageValue, B256,
 };
@@ -61,7 +61,7 @@ impl<'b, TX: DbTx> HistoricalStateProviderRef<'b, TX> {
     }
 
     /// Lookup an account in the AccountHistory table
-    pub fn account_history_lookup(&self, address: Address) -> RethResult<HistoryInfo> {
+    pub fn account_history_lookup(&self, address: Address) -> ProviderResult<HistoryInfo> {
         if !self.lowest_available_blocks.is_account_history_available(self.block_number) {
             return Err(ProviderError::StateAtBlockPruned(self.block_number).into())
         }
@@ -80,7 +80,7 @@ impl<'b, TX: DbTx> HistoricalStateProviderRef<'b, TX> {
         &self,
         address: Address,
         storage_key: StorageKey,
-    ) -> RethResult<HistoryInfo> {
+    ) -> ProviderResult<HistoryInfo> {
         if !self.lowest_available_blocks.is_storage_history_available(self.block_number) {
             return Err(ProviderError::StateAtBlockPruned(self.block_number).into())
         }
@@ -99,7 +99,7 @@ impl<'b, TX: DbTx> HistoricalStateProviderRef<'b, TX> {
         key: K,
         key_filter: impl Fn(&K) -> bool,
         lowest_available_block_number: Option<BlockNumber>,
-    ) -> RethResult<HistoryInfo>
+    ) -> ProviderResult<HistoryInfo>
     where
         T: Table<Key = K, Value = BlockNumberList>,
     {
@@ -153,7 +153,7 @@ impl<'b, TX: DbTx> HistoricalStateProviderRef<'b, TX> {
 
 impl<'b, TX: DbTx> AccountReader for HistoricalStateProviderRef<'b, TX> {
     /// Get basic account information.
-    fn basic_account(&self, address: Address) -> RethResult<Option<Account>> {
+    fn basic_account(&self, address: Address) -> ProviderResult<Option<Account>> {
         match self.account_history_lookup(address)? {
             HistoryInfo::NotYetWritten => Ok(None),
             HistoryInfo::InChangeset(changeset_block_number) => Ok(self
@@ -175,7 +175,7 @@ impl<'b, TX: DbTx> AccountReader for HistoricalStateProviderRef<'b, TX> {
 
 impl<'b, TX: DbTx> BlockHashReader for HistoricalStateProviderRef<'b, TX> {
     /// Get block hash by number.
-    fn block_hash(&self, number: u64) -> RethResult<Option<B256>> {
+    fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
         self.tx.get::<tables::CanonicalHeaders>(number).map_err(Into::into)
     }
 
@@ -183,7 +183,7 @@ impl<'b, TX: DbTx> BlockHashReader for HistoricalStateProviderRef<'b, TX> {
         &self,
         start: BlockNumber,
         end: BlockNumber,
-    ) -> RethResult<Vec<B256>> {
+    ) -> ProviderResult<Vec<B256>> {
         let range = start..end;
         self.tx
             .cursor_read::<tables::CanonicalHeaders>()
@@ -191,14 +191,14 @@ impl<'b, TX: DbTx> BlockHashReader for HistoricalStateProviderRef<'b, TX> {
                 cursor
                     .walk_range(range)?
                     .map(|result| result.map(|(_, hash)| hash).map_err(Into::into))
-                    .collect::<RethResult<Vec<_>>>()
+                    .collect::<ProviderResult<Vec<_>>>()
             })?
             .map_err(Into::into)
     }
 }
 
 impl<'b, TX: DbTx> StateRootProvider for HistoricalStateProviderRef<'b, TX> {
-    fn state_root(&self, _post_state: &BundleStateWithReceipts) -> RethResult<B256> {
+    fn state_root(&self, _post_state: &BundleStateWithReceipts) -> ProviderResult<B256> {
         Err(ProviderError::StateRootNotAvailableForHistoricalBlock.into())
     }
 }
@@ -209,7 +209,7 @@ impl<'b, TX: DbTx> StateProvider for HistoricalStateProviderRef<'b, TX> {
         &self,
         address: Address,
         storage_key: StorageKey,
-    ) -> RethResult<Option<StorageValue>> {
+    ) -> ProviderResult<Option<StorageValue>> {
         match self.storage_history_lookup(address, storage_key)? {
             HistoryInfo::NotYetWritten => Ok(None),
             HistoryInfo::InChangeset(changeset_block_number) => Ok(Some(
@@ -235,12 +235,12 @@ impl<'b, TX: DbTx> StateProvider for HistoricalStateProviderRef<'b, TX> {
     }
 
     /// Get account code by its hash
-    fn bytecode_by_hash(&self, code_hash: B256) -> RethResult<Option<Bytecode>> {
+    fn bytecode_by_hash(&self, code_hash: B256) -> ProviderResult<Option<Bytecode>> {
         self.tx.get::<tables::Bytecodes>(code_hash).map_err(Into::into)
     }
 
     /// Get account and storage proofs.
-    fn proof(&self, _address: Address, _keys: &[B256]) -> RethResult<AccountProof> {
+    fn proof(&self, _address: Address, _keys: &[B256]) -> ProviderResult<AccountProof> {
         Err(ProviderError::StateRootNotAvailableForHistoricalBlock.into())
     }
 }

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -7,7 +7,7 @@ use reth_db::{
     tables,
     transaction::DbTx,
 };
-use reth_interfaces::{provider::ProviderError, RethError, RethResult};
+use reth_interfaces::provider::{ProviderError, ProviderResult};
 use reth_primitives::{
     keccak256, trie::AccountProof, Account, Address, BlockNumber, Bytecode, StorageKey,
     StorageValue, B256,
@@ -29,14 +29,14 @@ impl<'b, TX: DbTx> LatestStateProviderRef<'b, TX> {
 
 impl<'b, TX: DbTx> AccountReader for LatestStateProviderRef<'b, TX> {
     /// Get basic account information.
-    fn basic_account(&self, address: Address) -> RethResult<Option<Account>> {
+    fn basic_account(&self, address: Address) -> ProviderResult<Option<Account>> {
         self.db.get::<tables::PlainAccountState>(address).map_err(Into::into)
     }
 }
 
 impl<'b, TX: DbTx> BlockHashReader for LatestStateProviderRef<'b, TX> {
     /// Get block hash by number.
-    fn block_hash(&self, number: u64) -> RethResult<Option<B256>> {
+    fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
         self.db.get::<tables::CanonicalHeaders>(number).map_err(Into::into)
     }
 
@@ -44,7 +44,7 @@ impl<'b, TX: DbTx> BlockHashReader for LatestStateProviderRef<'b, TX> {
         &self,
         start: BlockNumber,
         end: BlockNumber,
-    ) -> RethResult<Vec<B256>> {
+    ) -> ProviderResult<Vec<B256>> {
         let range = start..end;
         self.db
             .cursor_read::<tables::CanonicalHeaders>()
@@ -52,15 +52,15 @@ impl<'b, TX: DbTx> BlockHashReader for LatestStateProviderRef<'b, TX> {
                 cursor
                     .walk_range(range)?
                     .map(|result| result.map(|(_, hash)| hash).map_err(Into::into))
-                    .collect::<RethResult<Vec<_>>>()
+                    .collect::<ProviderResult<Vec<_>>>()
             })?
             .map_err(Into::into)
     }
 }
 
 impl<'b, TX: DbTx> StateRootProvider for LatestStateProviderRef<'b, TX> {
-    fn state_root(&self, bundle_state: &BundleStateWithReceipts) -> RethResult<B256> {
-        bundle_state.state_root_slow(self.db).map_err(|err| RethError::Database(err.into()))
+    fn state_root(&self, bundle_state: &BundleStateWithReceipts) -> ProviderResult<B256> {
+        bundle_state.state_root_slow(self.db).map_err(|err| ProviderError::Database(err.into()))
     }
 }
 
@@ -70,7 +70,7 @@ impl<'b, TX: DbTx> StateProvider for LatestStateProviderRef<'b, TX> {
         &self,
         account: Address,
         storage_key: StorageKey,
-    ) -> RethResult<Option<StorageValue>> {
+    ) -> ProviderResult<Option<StorageValue>> {
         let mut cursor = self.db.cursor_dup_read::<tables::PlainStorageState>()?;
         if let Some(entry) = cursor.seek_by_key_subkey(account, storage_key)? {
             if entry.key == storage_key {
@@ -81,11 +81,11 @@ impl<'b, TX: DbTx> StateProvider for LatestStateProviderRef<'b, TX> {
     }
 
     /// Get account code by its hash
-    fn bytecode_by_hash(&self, code_hash: B256) -> RethResult<Option<Bytecode>> {
+    fn bytecode_by_hash(&self, code_hash: B256) -> ProviderResult<Option<Bytecode>> {
         self.db.get::<tables::Bytecodes>(code_hash).map_err(Into::into)
     }
 
-    fn proof(&self, address: Address, _keys: &[B256]) -> RethResult<AccountProof> {
+    fn proof(&self, address: Address, _keys: &[B256]) -> ProviderResult<AccountProof> {
         let _hashed_address = keccak256(address);
         let _root = self
             .db

--- a/crates/storage/provider/src/providers/state/macros.rs
+++ b/crates/storage/provider/src/providers/state/macros.rs
@@ -31,19 +31,19 @@ macro_rules! delegate_provider_impls {
         $crate::providers::state::macros::delegate_impls_to_as_ref!(
             for $target =>
             StateRootProvider $(where [$($generics)*])? {
-                fn state_root(&self, state: &crate::BundleStateWithReceipts) -> reth_interfaces::RethResult<reth_primitives::B256>;
+                fn state_root(&self, state: &crate::BundleStateWithReceipts) -> reth_interfaces::provider::ProviderResult<reth_primitives::B256>;
             }
             AccountReader $(where [$($generics)*])? {
-                fn basic_account(&self, address: reth_primitives::Address) -> reth_interfaces::RethResult<Option<reth_primitives::Account>>;
+                fn basic_account(&self, address: reth_primitives::Address) -> reth_interfaces::provider::ProviderResult<Option<reth_primitives::Account>>;
             }
             BlockHashReader $(where [$($generics)*])? {
-                fn block_hash(&self, number: u64) -> reth_interfaces::RethResult<Option<reth_primitives::B256>>;
-                fn canonical_hashes_range(&self, start: reth_primitives::BlockNumber, end: reth_primitives::BlockNumber) -> reth_interfaces::RethResult<Vec<reth_primitives::B256>>;
+                fn block_hash(&self, number: u64) -> reth_interfaces::provider::ProviderResult<Option<reth_primitives::B256>>;
+                fn canonical_hashes_range(&self, start: reth_primitives::BlockNumber, end: reth_primitives::BlockNumber) -> reth_interfaces::provider::ProviderResult<Vec<reth_primitives::B256>>;
             }
             StateProvider $(where [$($generics)*])?{
-                fn storage(&self, account: reth_primitives::Address, storage_key: reth_primitives::StorageKey) -> reth_interfaces::RethResult<Option<reth_primitives::StorageValue>>;
-                fn proof(&self, address: reth_primitives::Address, keys: &[reth_primitives::B256]) -> reth_interfaces::RethResult<reth_primitives::trie::AccountProof>;
-                fn bytecode_by_hash(&self, code_hash: reth_primitives::B256) -> reth_interfaces::RethResult<Option<reth_primitives::Bytecode>>;
+                fn storage(&self, account: reth_primitives::Address, storage_key: reth_primitives::StorageKey) -> reth_interfaces::provider::ProviderResult<Option<reth_primitives::StorageValue>>;
+                fn proof(&self, address: reth_primitives::Address, keys: &[reth_primitives::B256]) -> reth_interfaces::provider::ProviderResult<reth_primitives::trie::AccountProof>;
+                fn bytecode_by_hash(&self, code_hash: reth_primitives::B256) -> reth_interfaces::provider::ProviderResult<Option<reth_primitives::Bytecode>>;
             }
         );
     }

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -385,11 +385,10 @@ impl BlockNumReader for MockEthProvider {
 
     fn best_block_number(&self) -> ProviderResult<BlockNumber> {
         let lock = self.headers.lock();
-        Ok(lock
-            .iter()
+        lock.iter()
             .max_by_key(|h| h.1.number)
             .map(|(_, header)| header.number)
-            .ok_or(ProviderError::BestBlockNotFound)?)
+            .ok_or(ProviderError::BestBlockNotFound)
     }
 
     fn last_block_number(&self) -> ProviderResult<BlockNumber> {

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use parking_lot::Mutex;
 use reth_db::models::{AccountBeforeTx, StoredBlockBodyIndices};
-use reth_interfaces::{provider::ProviderError, RethResult};
+use reth_interfaces::provider::{ProviderError, ProviderResult};
 use reth_primitives::{
     keccak256, trie::AccountProof, Account, Address, Block, BlockHash, BlockHashOrNumber, BlockId,
     BlockNumber, BlockWithSenders, Bytecode, Bytes, ChainInfo, ChainSpec, Header, Receipt,
@@ -124,17 +124,17 @@ impl MockEthProvider {
 }
 
 impl HeaderProvider for MockEthProvider {
-    fn header(&self, block_hash: &BlockHash) -> RethResult<Option<Header>> {
+    fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Header>> {
         let lock = self.headers.lock();
         Ok(lock.get(block_hash).cloned())
     }
 
-    fn header_by_number(&self, num: u64) -> RethResult<Option<Header>> {
+    fn header_by_number(&self, num: u64) -> ProviderResult<Option<Header>> {
         let lock = self.headers.lock();
         Ok(lock.values().find(|h| h.number == num).cloned())
     }
 
-    fn header_td(&self, hash: &BlockHash) -> RethResult<Option<U256>> {
+    fn header_td(&self, hash: &BlockHash) -> ProviderResult<Option<U256>> {
         let lock = self.headers.lock();
         Ok(lock.get(hash).map(|target| {
             lock.values()
@@ -143,7 +143,7 @@ impl HeaderProvider for MockEthProvider {
         }))
     }
 
-    fn header_td_by_number(&self, number: BlockNumber) -> RethResult<Option<U256>> {
+    fn header_td_by_number(&self, number: BlockNumber) -> ProviderResult<Option<U256>> {
         let lock = self.headers.lock();
         let sum = lock
             .values()
@@ -152,7 +152,7 @@ impl HeaderProvider for MockEthProvider {
         Ok(Some(sum))
     }
 
-    fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> RethResult<Vec<Header>> {
+    fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> ProviderResult<Vec<Header>> {
         let lock = self.headers.lock();
 
         let mut headers: Vec<_> =
@@ -162,7 +162,7 @@ impl HeaderProvider for MockEthProvider {
         Ok(headers)
     }
 
-    fn sealed_header(&self, number: BlockNumber) -> RethResult<Option<SealedHeader>> {
+    fn sealed_header(&self, number: BlockNumber) -> ProviderResult<Option<SealedHeader>> {
         Ok(self.header_by_number(number)?.map(|h| h.seal_slow()))
     }
 
@@ -170,7 +170,7 @@ impl HeaderProvider for MockEthProvider {
         &self,
         range: impl RangeBounds<BlockNumber>,
         mut predicate: impl FnMut(&SealedHeader) -> bool,
-    ) -> RethResult<Vec<SealedHeader>> {
+    ) -> ProviderResult<Vec<SealedHeader>> {
         Ok(self
             .headers_range(range)?
             .into_iter()
@@ -187,7 +187,7 @@ impl ChainSpecProvider for MockEthProvider {
 }
 
 impl TransactionsProvider for MockEthProvider {
-    fn transaction_id(&self, tx_hash: TxHash) -> RethResult<Option<TxNumber>> {
+    fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
         let lock = self.blocks.lock();
         let tx_number = lock
             .values()
@@ -198,7 +198,7 @@ impl TransactionsProvider for MockEthProvider {
         Ok(tx_number)
     }
 
-    fn transaction_by_id(&self, id: TxNumber) -> RethResult<Option<TransactionSigned>> {
+    fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<TransactionSigned>> {
         let lock = self.blocks.lock();
         let transaction = lock.values().flat_map(|block| &block.body).nth(id as usize).cloned();
 
@@ -208,7 +208,7 @@ impl TransactionsProvider for MockEthProvider {
     fn transaction_by_id_no_hash(
         &self,
         id: TxNumber,
-    ) -> RethResult<Option<TransactionSignedNoHash>> {
+    ) -> ProviderResult<Option<TransactionSignedNoHash>> {
         let lock = self.blocks.lock();
         let transaction = lock
             .values()
@@ -219,7 +219,7 @@ impl TransactionsProvider for MockEthProvider {
         Ok(transaction)
     }
 
-    fn transaction_by_hash(&self, hash: TxHash) -> RethResult<Option<TransactionSigned>> {
+    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<TransactionSigned>> {
         Ok(self
             .blocks
             .lock()
@@ -230,7 +230,7 @@ impl TransactionsProvider for MockEthProvider {
     fn transaction_by_hash_with_meta(
         &self,
         hash: TxHash,
-    ) -> RethResult<Option<(TransactionSigned, TransactionMeta)>> {
+    ) -> ProviderResult<Option<(TransactionSigned, TransactionMeta)>> {
         let lock = self.blocks.lock();
         for (block_hash, block) in lock.iter() {
             for (index, tx) in block.body.iter().enumerate() {
@@ -250,7 +250,7 @@ impl TransactionsProvider for MockEthProvider {
         Ok(None)
     }
 
-    fn transaction_block(&self, id: TxNumber) -> RethResult<Option<BlockNumber>> {
+    fn transaction_block(&self, id: TxNumber) -> ProviderResult<Option<BlockNumber>> {
         let lock = self.blocks.lock();
         let mut current_tx_number: TxNumber = 0;
         for block in lock.values() {
@@ -265,14 +265,14 @@ impl TransactionsProvider for MockEthProvider {
     fn transactions_by_block(
         &self,
         id: BlockHashOrNumber,
-    ) -> RethResult<Option<Vec<TransactionSigned>>> {
+    ) -> ProviderResult<Option<Vec<TransactionSigned>>> {
         Ok(self.block(id)?.map(|b| b.body))
     }
 
     fn transactions_by_block_range(
         &self,
         range: impl RangeBounds<reth_primitives::BlockNumber>,
-    ) -> RethResult<Vec<Vec<TransactionSigned>>> {
+    ) -> ProviderResult<Vec<Vec<TransactionSigned>>> {
         // init btreemap so we can return in order
         let mut map = BTreeMap::new();
         for (_, block) in self.blocks.lock().iter() {
@@ -287,7 +287,7 @@ impl TransactionsProvider for MockEthProvider {
     fn transactions_by_tx_range(
         &self,
         range: impl RangeBounds<TxNumber>,
-    ) -> RethResult<Vec<reth_primitives::TransactionSignedNoHash>> {
+    ) -> ProviderResult<Vec<reth_primitives::TransactionSignedNoHash>> {
         let lock = self.blocks.lock();
         let transactions = lock
             .values()
@@ -305,7 +305,10 @@ impl TransactionsProvider for MockEthProvider {
         Ok(transactions)
     }
 
-    fn senders_by_tx_range(&self, range: impl RangeBounds<TxNumber>) -> RethResult<Vec<Address>> {
+    fn senders_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Address>> {
         let lock = self.blocks.lock();
         let transactions = lock
             .values()
@@ -323,21 +326,21 @@ impl TransactionsProvider for MockEthProvider {
         Ok(transactions)
     }
 
-    fn transaction_sender(&self, id: TxNumber) -> RethResult<Option<Address>> {
+    fn transaction_sender(&self, id: TxNumber) -> ProviderResult<Option<Address>> {
         self.transaction_by_id(id).map(|tx_option| tx_option.map(|tx| tx.recover_signer().unwrap()))
     }
 }
 
 impl ReceiptProvider for MockEthProvider {
-    fn receipt(&self, _id: TxNumber) -> RethResult<Option<Receipt>> {
+    fn receipt(&self, _id: TxNumber) -> ProviderResult<Option<Receipt>> {
         Ok(None)
     }
 
-    fn receipt_by_hash(&self, _hash: TxHash) -> RethResult<Option<Receipt>> {
+    fn receipt_by_hash(&self, _hash: TxHash) -> ProviderResult<Option<Receipt>> {
         Ok(None)
     }
 
-    fn receipts_by_block(&self, _block: BlockHashOrNumber) -> RethResult<Option<Vec<Receipt>>> {
+    fn receipts_by_block(&self, _block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
         Ok(None)
     }
 }
@@ -345,7 +348,7 @@ impl ReceiptProvider for MockEthProvider {
 impl ReceiptProviderIdExt for MockEthProvider {}
 
 impl BlockHashReader for MockEthProvider {
-    fn block_hash(&self, number: u64) -> RethResult<Option<B256>> {
+    fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
         let lock = self.blocks.lock();
 
         let hash = lock.iter().find_map(|(hash, b)| (b.number == number).then_some(*hash));
@@ -356,7 +359,7 @@ impl BlockHashReader for MockEthProvider {
         &self,
         start: BlockNumber,
         end: BlockNumber,
-    ) -> RethResult<Vec<B256>> {
+    ) -> ProviderResult<Vec<B256>> {
         let range = start..end;
         let lock = self.blocks.lock();
 
@@ -369,7 +372,7 @@ impl BlockHashReader for MockEthProvider {
 }
 
 impl BlockNumReader for MockEthProvider {
-    fn chain_info(&self) -> RethResult<ChainInfo> {
+    fn chain_info(&self) -> ProviderResult<ChainInfo> {
         let best_block_number = self.best_block_number()?;
         let lock = self.headers.lock();
 
@@ -380,7 +383,7 @@ impl BlockNumReader for MockEthProvider {
             .unwrap_or_default())
     }
 
-    fn best_block_number(&self) -> RethResult<BlockNumber> {
+    fn best_block_number(&self) -> ProviderResult<BlockNumber> {
         let lock = self.headers.lock();
         Ok(lock
             .iter()
@@ -389,11 +392,11 @@ impl BlockNumReader for MockEthProvider {
             .ok_or(ProviderError::BestBlockNotFound)?)
     }
 
-    fn last_block_number(&self) -> RethResult<BlockNumber> {
+    fn last_block_number(&self) -> ProviderResult<BlockNumber> {
         self.best_block_number()
     }
 
-    fn block_number(&self, hash: B256) -> RethResult<Option<reth_primitives::BlockNumber>> {
+    fn block_number(&self, hash: B256) -> ProviderResult<Option<reth_primitives::BlockNumber>> {
         let lock = self.blocks.lock();
         let num = lock.iter().find_map(|(h, b)| (*h == hash).then_some(b.number));
         Ok(num)
@@ -401,25 +404,29 @@ impl BlockNumReader for MockEthProvider {
 }
 
 impl BlockIdReader for MockEthProvider {
-    fn pending_block_num_hash(&self) -> RethResult<Option<reth_primitives::BlockNumHash>> {
+    fn pending_block_num_hash(&self) -> ProviderResult<Option<reth_primitives::BlockNumHash>> {
         Ok(None)
     }
 
-    fn safe_block_num_hash(&self) -> RethResult<Option<reth_primitives::BlockNumHash>> {
+    fn safe_block_num_hash(&self) -> ProviderResult<Option<reth_primitives::BlockNumHash>> {
         Ok(None)
     }
 
-    fn finalized_block_num_hash(&self) -> RethResult<Option<reth_primitives::BlockNumHash>> {
+    fn finalized_block_num_hash(&self) -> ProviderResult<Option<reth_primitives::BlockNumHash>> {
         Ok(None)
     }
 }
 
 impl BlockReader for MockEthProvider {
-    fn find_block_by_hash(&self, hash: B256, _source: BlockSource) -> RethResult<Option<Block>> {
+    fn find_block_by_hash(
+        &self,
+        hash: B256,
+        _source: BlockSource,
+    ) -> ProviderResult<Option<Block>> {
         self.block(hash.into())
     }
 
-    fn block(&self, id: BlockHashOrNumber) -> RethResult<Option<Block>> {
+    fn block(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Block>> {
         let lock = self.blocks.lock();
         match id {
             BlockHashOrNumber::Hash(hash) => Ok(lock.get(&hash).cloned()),
@@ -427,19 +434,19 @@ impl BlockReader for MockEthProvider {
         }
     }
 
-    fn pending_block(&self) -> RethResult<Option<SealedBlock>> {
+    fn pending_block(&self) -> ProviderResult<Option<SealedBlock>> {
         Ok(None)
     }
 
-    fn pending_block_and_receipts(&self) -> RethResult<Option<(SealedBlock, Vec<Receipt>)>> {
+    fn pending_block_and_receipts(&self) -> ProviderResult<Option<(SealedBlock, Vec<Receipt>)>> {
         Ok(None)
     }
 
-    fn ommers(&self, _id: BlockHashOrNumber) -> RethResult<Option<Vec<Header>>> {
+    fn ommers(&self, _id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Header>>> {
         Ok(None)
     }
 
-    fn block_body_indices(&self, _num: u64) -> RethResult<Option<StoredBlockBodyIndices>> {
+    fn block_body_indices(&self, _num: u64) -> ProviderResult<Option<StoredBlockBodyIndices>> {
         Ok(None)
     }
 
@@ -447,35 +454,35 @@ impl BlockReader for MockEthProvider {
         &self,
         _id: BlockHashOrNumber,
         _transaction_kind: TransactionVariant,
-    ) -> RethResult<Option<BlockWithSenders>> {
+    ) -> ProviderResult<Option<BlockWithSenders>> {
         Ok(None)
     }
 
-    fn block_range(&self, _range: RangeInclusive<BlockNumber>) -> RethResult<Vec<Block>> {
+    fn block_range(&self, _range: RangeInclusive<BlockNumber>) -> ProviderResult<Vec<Block>> {
         Ok(vec![])
     }
 }
 
 impl BlockReaderIdExt for MockEthProvider {
-    fn block_by_id(&self, id: BlockId) -> RethResult<Option<Block>> {
+    fn block_by_id(&self, id: BlockId) -> ProviderResult<Option<Block>> {
         match id {
             BlockId::Number(num) => self.block_by_number_or_tag(num),
             BlockId::Hash(hash) => self.block_by_hash(hash.block_hash),
         }
     }
 
-    fn sealed_header_by_id(&self, id: BlockId) -> RethResult<Option<SealedHeader>> {
+    fn sealed_header_by_id(&self, id: BlockId) -> ProviderResult<Option<SealedHeader>> {
         self.header_by_id(id)?.map_or_else(|| Ok(None), |h| Ok(Some(h.seal_slow())))
     }
 
-    fn header_by_id(&self, id: BlockId) -> RethResult<Option<Header>> {
+    fn header_by_id(&self, id: BlockId) -> ProviderResult<Option<Header>> {
         match self.block_by_id(id)? {
             None => Ok(None),
             Some(block) => Ok(Some(block.header)),
         }
     }
 
-    fn ommers_by_id(&self, id: BlockId) -> RethResult<Option<Vec<Header>>> {
+    fn ommers_by_id(&self, id: BlockId) -> ProviderResult<Option<Vec<Header>>> {
         match id {
             BlockId::Number(num) => self.ommers_by_number_or_tag(num),
             BlockId::Hash(hash) => self.ommers(BlockHashOrNumber::Hash(hash.block_hash)),
@@ -484,13 +491,13 @@ impl BlockReaderIdExt for MockEthProvider {
 }
 
 impl AccountReader for MockEthProvider {
-    fn basic_account(&self, address: Address) -> RethResult<Option<Account>> {
+    fn basic_account(&self, address: Address) -> ProviderResult<Option<Account>> {
         Ok(self.accounts.lock().get(&address).cloned().map(|a| a.account))
     }
 }
 
 impl StateRootProvider for MockEthProvider {
-    fn state_root(&self, _state: &BundleStateWithReceipts) -> RethResult<B256> {
+    fn state_root(&self, _state: &BundleStateWithReceipts) -> ProviderResult<B256> {
         todo!()
     }
 }
@@ -500,12 +507,12 @@ impl StateProvider for MockEthProvider {
         &self,
         account: Address,
         storage_key: StorageKey,
-    ) -> RethResult<Option<StorageValue>> {
+    ) -> ProviderResult<Option<StorageValue>> {
         let lock = self.accounts.lock();
         Ok(lock.get(&account).and_then(|account| account.storage.get(&storage_key)).cloned())
     }
 
-    fn bytecode_by_hash(&self, code_hash: B256) -> RethResult<Option<Bytecode>> {
+    fn bytecode_by_hash(&self, code_hash: B256) -> ProviderResult<Option<Bytecode>> {
         let lock = self.accounts.lock();
         Ok(lock.values().find_map(|account| {
             match (account.account.bytecode_hash.as_ref(), account.bytecode.as_ref()) {
@@ -517,7 +524,7 @@ impl StateProvider for MockEthProvider {
         }))
     }
 
-    fn proof(&self, _address: Address, _keys: &[B256]) -> RethResult<AccountProof> {
+    fn proof(&self, _address: Address, _keys: &[B256]) -> ProviderResult<AccountProof> {
         todo!()
     }
 }
@@ -528,7 +535,7 @@ impl EvmEnvProvider for MockEthProvider {
         _cfg: &mut CfgEnv,
         _block_env: &mut BlockEnv,
         _at: BlockHashOrNumber,
-    ) -> RethResult<()> {
+    ) -> ProviderResult<()> {
         Ok(())
     }
 
@@ -537,7 +544,7 @@ impl EvmEnvProvider for MockEthProvider {
         _cfg: &mut CfgEnv,
         _block_env: &mut BlockEnv,
         _header: &Header,
-    ) -> RethResult<()> {
+    ) -> ProviderResult<()> {
         Ok(())
     }
 
@@ -545,7 +552,7 @@ impl EvmEnvProvider for MockEthProvider {
         &self,
         _block_env: &mut BlockEnv,
         _at: BlockHashOrNumber,
-    ) -> RethResult<()> {
+    ) -> ProviderResult<()> {
         Ok(())
     }
 
@@ -553,94 +560,100 @@ impl EvmEnvProvider for MockEthProvider {
         &self,
         _block_env: &mut BlockEnv,
         _header: &Header,
-    ) -> RethResult<()> {
+    ) -> ProviderResult<()> {
         Ok(())
     }
 
-    fn fill_cfg_env_at(&self, _cfg: &mut CfgEnv, _at: BlockHashOrNumber) -> RethResult<()> {
+    fn fill_cfg_env_at(&self, _cfg: &mut CfgEnv, _at: BlockHashOrNumber) -> ProviderResult<()> {
         Ok(())
     }
 
-    fn fill_cfg_env_with_header(&self, _cfg: &mut CfgEnv, _header: &Header) -> RethResult<()> {
+    fn fill_cfg_env_with_header(&self, _cfg: &mut CfgEnv, _header: &Header) -> ProviderResult<()> {
         Ok(())
     }
 }
 
 impl StateProviderFactory for MockEthProvider {
-    fn latest(&self) -> RethResult<StateProviderBox<'_>> {
+    fn latest(&self) -> ProviderResult<StateProviderBox<'_>> {
         Ok(Box::new(self.clone()))
     }
 
-    fn history_by_block_number(&self, _block: BlockNumber) -> RethResult<StateProviderBox<'_>> {
+    fn history_by_block_number(&self, _block: BlockNumber) -> ProviderResult<StateProviderBox<'_>> {
         Ok(Box::new(self.clone()))
     }
 
-    fn history_by_block_hash(&self, _block: BlockHash) -> RethResult<StateProviderBox<'_>> {
+    fn history_by_block_hash(&self, _block: BlockHash) -> ProviderResult<StateProviderBox<'_>> {
         Ok(Box::new(self.clone()))
     }
 
-    fn state_by_block_hash(&self, _block: BlockHash) -> RethResult<StateProviderBox<'_>> {
+    fn state_by_block_hash(&self, _block: BlockHash) -> ProviderResult<StateProviderBox<'_>> {
         Ok(Box::new(self.clone()))
     }
 
-    fn pending(&self) -> RethResult<StateProviderBox<'_>> {
+    fn pending(&self) -> ProviderResult<StateProviderBox<'_>> {
         Ok(Box::new(self.clone()))
     }
 
-    fn pending_state_by_hash(&self, _block_hash: B256) -> RethResult<Option<StateProviderBox<'_>>> {
+    fn pending_state_by_hash(
+        &self,
+        _block_hash: B256,
+    ) -> ProviderResult<Option<StateProviderBox<'_>>> {
         Ok(Some(Box::new(self.clone())))
     }
 
     fn pending_with_provider<'a>(
         &'a self,
         _post_state_data: Box<dyn BundleStateDataProvider + 'a>,
-    ) -> RethResult<StateProviderBox<'a>> {
+    ) -> ProviderResult<StateProviderBox<'a>> {
         Ok(Box::new(self.clone()))
     }
 }
 
 impl StateProviderFactory for Arc<MockEthProvider> {
-    fn latest(&self) -> RethResult<StateProviderBox<'_>> {
+    fn latest(&self) -> ProviderResult<StateProviderBox<'_>> {
         Ok(Box::new(self.clone()))
     }
 
-    fn history_by_block_number(&self, _block: BlockNumber) -> RethResult<StateProviderBox<'_>> {
+    fn history_by_block_number(&self, _block: BlockNumber) -> ProviderResult<StateProviderBox<'_>> {
         Ok(Box::new(self.clone()))
     }
 
-    fn history_by_block_hash(&self, _block: BlockHash) -> RethResult<StateProviderBox<'_>> {
+    fn history_by_block_hash(&self, _block: BlockHash) -> ProviderResult<StateProviderBox<'_>> {
         Ok(Box::new(self.clone()))
     }
 
-    fn state_by_block_hash(&self, _block: BlockHash) -> RethResult<StateProviderBox<'_>> {
+    fn state_by_block_hash(&self, _block: BlockHash) -> ProviderResult<StateProviderBox<'_>> {
         Ok(Box::new(self.clone()))
     }
 
-    fn pending(&self) -> RethResult<StateProviderBox<'_>> {
+    fn pending(&self) -> ProviderResult<StateProviderBox<'_>> {
         Ok(Box::new(self.clone()))
     }
 
-    fn pending_state_by_hash(&self, _block_hash: B256) -> RethResult<Option<StateProviderBox<'_>>> {
+    fn pending_state_by_hash(
+        &self,
+        _block_hash: B256,
+    ) -> ProviderResult<Option<StateProviderBox<'_>>> {
         Ok(Some(Box::new(self.clone())))
     }
 
     fn pending_with_provider<'a>(
         &'a self,
         _post_state_data: Box<dyn BundleStateDataProvider + 'a>,
-    ) -> RethResult<StateProviderBox<'a>> {
+    ) -> ProviderResult<StateProviderBox<'a>> {
         Ok(Box::new(self.clone()))
     }
 }
 
 impl WithdrawalsProvider for MockEthProvider {
-    fn latest_withdrawal(&self) -> RethResult<Option<reth_primitives::Withdrawal>> {
+    fn latest_withdrawal(&self) -> ProviderResult<Option<reth_primitives::Withdrawal>> {
         Ok(None)
     }
     fn withdrawals_by_block(
         &self,
         _id: BlockHashOrNumber,
         _timestamp: u64,
-    ) -> RethResult<Option<Vec<reth_primitives::Withdrawal>>> {
+    ) -> ProviderResult<Option<Vec<reth_primitives::Withdrawal>>> {
         Ok(None)
     }
 }
@@ -649,7 +662,7 @@ impl ChangeSetReader for MockEthProvider {
     fn account_block_changeset(
         &self,
         _block_number: BlockNumber,
-    ) -> RethResult<Vec<AccountBeforeTx>> {
+    ) -> ProviderResult<Vec<AccountBeforeTx>> {
         Ok(Vec::default())
     }
 }

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -8,7 +8,7 @@ use crate::{
     WithdrawalsProvider,
 };
 use reth_db::models::{AccountBeforeTx, StoredBlockBodyIndices};
-use reth_interfaces::RethResult;
+use reth_interfaces::provider::ProviderResult;
 use reth_primitives::{
     stage::{StageCheckpoint, StageId},
     trie::AccountProof,
@@ -36,7 +36,7 @@ impl ChainSpecProvider for NoopProvider {
 
 /// Noop implementation for testing purposes
 impl BlockHashReader for NoopProvider {
-    fn block_hash(&self, _number: u64) -> RethResult<Option<B256>> {
+    fn block_hash(&self, _number: u64) -> ProviderResult<Option<B256>> {
         Ok(None)
     }
 
@@ -44,51 +44,55 @@ impl BlockHashReader for NoopProvider {
         &self,
         _start: BlockNumber,
         _end: BlockNumber,
-    ) -> RethResult<Vec<B256>> {
+    ) -> ProviderResult<Vec<B256>> {
         Ok(vec![])
     }
 }
 
 impl BlockNumReader for NoopProvider {
-    fn chain_info(&self) -> RethResult<ChainInfo> {
+    fn chain_info(&self) -> ProviderResult<ChainInfo> {
         Ok(ChainInfo::default())
     }
 
-    fn best_block_number(&self) -> RethResult<BlockNumber> {
+    fn best_block_number(&self) -> ProviderResult<BlockNumber> {
         Ok(0)
     }
 
-    fn last_block_number(&self) -> RethResult<BlockNumber> {
+    fn last_block_number(&self) -> ProviderResult<BlockNumber> {
         Ok(0)
     }
 
-    fn block_number(&self, _hash: B256) -> RethResult<Option<BlockNumber>> {
+    fn block_number(&self, _hash: B256) -> ProviderResult<Option<BlockNumber>> {
         Ok(None)
     }
 }
 
 impl BlockReader for NoopProvider {
-    fn find_block_by_hash(&self, hash: B256, _source: BlockSource) -> RethResult<Option<Block>> {
+    fn find_block_by_hash(
+        &self,
+        hash: B256,
+        _source: BlockSource,
+    ) -> ProviderResult<Option<Block>> {
         self.block(hash.into())
     }
 
-    fn block(&self, _id: BlockHashOrNumber) -> RethResult<Option<Block>> {
+    fn block(&self, _id: BlockHashOrNumber) -> ProviderResult<Option<Block>> {
         Ok(None)
     }
 
-    fn pending_block(&self) -> RethResult<Option<SealedBlock>> {
+    fn pending_block(&self) -> ProviderResult<Option<SealedBlock>> {
         Ok(None)
     }
 
-    fn pending_block_and_receipts(&self) -> RethResult<Option<(SealedBlock, Vec<Receipt>)>> {
+    fn pending_block_and_receipts(&self) -> ProviderResult<Option<(SealedBlock, Vec<Receipt>)>> {
         Ok(None)
     }
 
-    fn ommers(&self, _id: BlockHashOrNumber) -> RethResult<Option<Vec<Header>>> {
+    fn ommers(&self, _id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Header>>> {
         Ok(None)
     }
 
-    fn block_body_indices(&self, _num: u64) -> RethResult<Option<StoredBlockBodyIndices>> {
+    fn block_body_indices(&self, _num: u64) -> ProviderResult<Option<StoredBlockBodyIndices>> {
         Ok(None)
     }
 
@@ -96,118 +100,121 @@ impl BlockReader for NoopProvider {
         &self,
         _id: BlockHashOrNumber,
         _transaction_kind: TransactionVariant,
-    ) -> RethResult<Option<reth_primitives::BlockWithSenders>> {
+    ) -> ProviderResult<Option<reth_primitives::BlockWithSenders>> {
         Ok(None)
     }
 
-    fn block_range(&self, _range: RangeInclusive<BlockNumber>) -> RethResult<Vec<Block>> {
+    fn block_range(&self, _range: RangeInclusive<BlockNumber>) -> ProviderResult<Vec<Block>> {
         Ok(vec![])
     }
 }
 
 impl BlockReaderIdExt for NoopProvider {
-    fn block_by_id(&self, _id: BlockId) -> RethResult<Option<Block>> {
+    fn block_by_id(&self, _id: BlockId) -> ProviderResult<Option<Block>> {
         Ok(None)
     }
 
-    fn sealed_header_by_id(&self, _id: BlockId) -> RethResult<Option<SealedHeader>> {
+    fn sealed_header_by_id(&self, _id: BlockId) -> ProviderResult<Option<SealedHeader>> {
         Ok(None)
     }
 
-    fn header_by_id(&self, _id: BlockId) -> RethResult<Option<Header>> {
+    fn header_by_id(&self, _id: BlockId) -> ProviderResult<Option<Header>> {
         Ok(None)
     }
 
-    fn ommers_by_id(&self, _id: BlockId) -> RethResult<Option<Vec<Header>>> {
+    fn ommers_by_id(&self, _id: BlockId) -> ProviderResult<Option<Vec<Header>>> {
         Ok(None)
     }
 }
 
 impl BlockIdReader for NoopProvider {
-    fn pending_block_num_hash(&self) -> RethResult<Option<reth_primitives::BlockNumHash>> {
+    fn pending_block_num_hash(&self) -> ProviderResult<Option<reth_primitives::BlockNumHash>> {
         Ok(None)
     }
 
-    fn safe_block_num_hash(&self) -> RethResult<Option<reth_primitives::BlockNumHash>> {
+    fn safe_block_num_hash(&self) -> ProviderResult<Option<reth_primitives::BlockNumHash>> {
         Ok(None)
     }
 
-    fn finalized_block_num_hash(&self) -> RethResult<Option<reth_primitives::BlockNumHash>> {
+    fn finalized_block_num_hash(&self) -> ProviderResult<Option<reth_primitives::BlockNumHash>> {
         Ok(None)
     }
 }
 
 impl TransactionsProvider for NoopProvider {
-    fn transaction_id(&self, _tx_hash: TxHash) -> RethResult<Option<TxNumber>> {
+    fn transaction_id(&self, _tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
         Ok(None)
     }
 
-    fn transaction_by_id(&self, _id: TxNumber) -> RethResult<Option<TransactionSigned>> {
+    fn transaction_by_id(&self, _id: TxNumber) -> ProviderResult<Option<TransactionSigned>> {
         Ok(None)
     }
 
     fn transaction_by_id_no_hash(
         &self,
         _id: TxNumber,
-    ) -> RethResult<Option<TransactionSignedNoHash>> {
+    ) -> ProviderResult<Option<TransactionSignedNoHash>> {
         Ok(None)
     }
 
-    fn transaction_by_hash(&self, _hash: TxHash) -> RethResult<Option<TransactionSigned>> {
+    fn transaction_by_hash(&self, _hash: TxHash) -> ProviderResult<Option<TransactionSigned>> {
         Ok(None)
     }
 
     fn transaction_by_hash_with_meta(
         &self,
         _hash: TxHash,
-    ) -> RethResult<Option<(TransactionSigned, TransactionMeta)>> {
+    ) -> ProviderResult<Option<(TransactionSigned, TransactionMeta)>> {
         Ok(None)
     }
 
-    fn transaction_block(&self, _id: TxNumber) -> RethResult<Option<BlockNumber>> {
+    fn transaction_block(&self, _id: TxNumber) -> ProviderResult<Option<BlockNumber>> {
         todo!()
     }
 
     fn transactions_by_block(
         &self,
         _block_id: BlockHashOrNumber,
-    ) -> RethResult<Option<Vec<TransactionSigned>>> {
+    ) -> ProviderResult<Option<Vec<TransactionSigned>>> {
         Ok(None)
     }
 
     fn transactions_by_block_range(
         &self,
         _range: impl RangeBounds<BlockNumber>,
-    ) -> RethResult<Vec<Vec<TransactionSigned>>> {
+    ) -> ProviderResult<Vec<Vec<TransactionSigned>>> {
         Ok(Vec::default())
     }
 
-    fn senders_by_tx_range(&self, _range: impl RangeBounds<TxNumber>) -> RethResult<Vec<Address>> {
+    fn senders_by_tx_range(
+        &self,
+        _range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Address>> {
         Ok(Vec::default())
     }
 
     fn transactions_by_tx_range(
         &self,
         _range: impl RangeBounds<TxNumber>,
-    ) -> RethResult<Vec<reth_primitives::TransactionSignedNoHash>> {
+    ) -> ProviderResult<Vec<reth_primitives::TransactionSignedNoHash>> {
         Ok(Vec::default())
     }
 
-    fn transaction_sender(&self, _id: TxNumber) -> RethResult<Option<Address>> {
+    fn transaction_sender(&self, _id: TxNumber) -> ProviderResult<Option<Address>> {
         Ok(None)
     }
 }
 
 impl ReceiptProvider for NoopProvider {
-    fn receipt(&self, _id: TxNumber) -> RethResult<Option<Receipt>> {
+    fn receipt(&self, _id: TxNumber) -> ProviderResult<Option<Receipt>> {
         Ok(None)
     }
 
-    fn receipt_by_hash(&self, _hash: TxHash) -> RethResult<Option<Receipt>> {
+    fn receipt_by_hash(&self, _hash: TxHash) -> ProviderResult<Option<Receipt>> {
         Ok(None)
     }
 
-    fn receipts_by_block(&self, _block: BlockHashOrNumber) -> RethResult<Option<Vec<Receipt>>> {
+    fn receipts_by_block(&self, _block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
         Ok(None)
     }
 }
@@ -215,27 +222,27 @@ impl ReceiptProvider for NoopProvider {
 impl ReceiptProviderIdExt for NoopProvider {}
 
 impl HeaderProvider for NoopProvider {
-    fn header(&self, _block_hash: &BlockHash) -> RethResult<Option<Header>> {
+    fn header(&self, _block_hash: &BlockHash) -> ProviderResult<Option<Header>> {
         Ok(None)
     }
 
-    fn header_by_number(&self, _num: u64) -> RethResult<Option<Header>> {
+    fn header_by_number(&self, _num: u64) -> ProviderResult<Option<Header>> {
         Ok(None)
     }
 
-    fn header_td(&self, _hash: &BlockHash) -> RethResult<Option<U256>> {
+    fn header_td(&self, _hash: &BlockHash) -> ProviderResult<Option<U256>> {
         Ok(None)
     }
 
-    fn header_td_by_number(&self, _number: BlockNumber) -> RethResult<Option<U256>> {
+    fn header_td_by_number(&self, _number: BlockNumber) -> ProviderResult<Option<U256>> {
         Ok(None)
     }
 
-    fn headers_range(&self, _range: impl RangeBounds<BlockNumber>) -> RethResult<Vec<Header>> {
+    fn headers_range(&self, _range: impl RangeBounds<BlockNumber>) -> ProviderResult<Vec<Header>> {
         Ok(vec![])
     }
 
-    fn sealed_header(&self, _number: BlockNumber) -> RethResult<Option<SealedHeader>> {
+    fn sealed_header(&self, _number: BlockNumber) -> ProviderResult<Option<SealedHeader>> {
         Ok(None)
     }
 
@@ -243,13 +250,13 @@ impl HeaderProvider for NoopProvider {
         &self,
         _range: impl RangeBounds<BlockNumber>,
         _predicate: impl FnMut(&SealedHeader) -> bool,
-    ) -> RethResult<Vec<SealedHeader>> {
+    ) -> ProviderResult<Vec<SealedHeader>> {
         Ok(vec![])
     }
 }
 
 impl AccountReader for NoopProvider {
-    fn basic_account(&self, _address: Address) -> RethResult<Option<Account>> {
+    fn basic_account(&self, _address: Address) -> ProviderResult<Option<Account>> {
         Ok(None)
     }
 }
@@ -258,13 +265,13 @@ impl ChangeSetReader for NoopProvider {
     fn account_block_changeset(
         &self,
         _block_number: BlockNumber,
-    ) -> RethResult<Vec<AccountBeforeTx>> {
+    ) -> ProviderResult<Vec<AccountBeforeTx>> {
         Ok(Vec::default())
     }
 }
 
 impl StateRootProvider for NoopProvider {
-    fn state_root(&self, _state: &BundleStateWithReceipts) -> RethResult<B256> {
+    fn state_root(&self, _state: &BundleStateWithReceipts) -> ProviderResult<B256> {
         Ok(B256::default())
     }
 }
@@ -274,15 +281,15 @@ impl StateProvider for NoopProvider {
         &self,
         _account: Address,
         _storage_key: StorageKey,
-    ) -> RethResult<Option<StorageValue>> {
+    ) -> ProviderResult<Option<StorageValue>> {
         Ok(None)
     }
 
-    fn bytecode_by_hash(&self, _code_hash: B256) -> RethResult<Option<Bytecode>> {
+    fn bytecode_by_hash(&self, _code_hash: B256) -> ProviderResult<Option<Bytecode>> {
         Ok(None)
     }
 
-    fn proof(&self, _address: Address, _keys: &[B256]) -> RethResult<AccountProof> {
+    fn proof(&self, _address: Address, _keys: &[B256]) -> ProviderResult<AccountProof> {
         Ok(AccountProof::default())
     }
 }
@@ -293,7 +300,7 @@ impl EvmEnvProvider for NoopProvider {
         _cfg: &mut CfgEnv,
         _block_env: &mut BlockEnv,
         _at: BlockHashOrNumber,
-    ) -> RethResult<()> {
+    ) -> ProviderResult<()> {
         Ok(())
     }
 
@@ -302,7 +309,7 @@ impl EvmEnvProvider for NoopProvider {
         _cfg: &mut CfgEnv,
         _block_env: &mut BlockEnv,
         _header: &Header,
-    ) -> RethResult<()> {
+    ) -> ProviderResult<()> {
         Ok(())
     }
 
@@ -310,7 +317,7 @@ impl EvmEnvProvider for NoopProvider {
         &self,
         _block_env: &mut BlockEnv,
         _at: BlockHashOrNumber,
-    ) -> RethResult<()> {
+    ) -> ProviderResult<()> {
         Ok(())
     }
 
@@ -318,77 +325,83 @@ impl EvmEnvProvider for NoopProvider {
         &self,
         _block_env: &mut BlockEnv,
         _header: &Header,
-    ) -> RethResult<()> {
+    ) -> ProviderResult<()> {
         Ok(())
     }
 
-    fn fill_cfg_env_at(&self, _cfg: &mut CfgEnv, _at: BlockHashOrNumber) -> RethResult<()> {
+    fn fill_cfg_env_at(&self, _cfg: &mut CfgEnv, _at: BlockHashOrNumber) -> ProviderResult<()> {
         Ok(())
     }
 
-    fn fill_cfg_env_with_header(&self, _cfg: &mut CfgEnv, _header: &Header) -> RethResult<()> {
+    fn fill_cfg_env_with_header(&self, _cfg: &mut CfgEnv, _header: &Header) -> ProviderResult<()> {
         Ok(())
     }
 }
 
 impl StateProviderFactory for NoopProvider {
-    fn latest(&self) -> RethResult<StateProviderBox<'_>> {
+    fn latest(&self) -> ProviderResult<StateProviderBox<'_>> {
         Ok(Box::new(*self))
     }
 
-    fn history_by_block_number(&self, _block: BlockNumber) -> RethResult<StateProviderBox<'_>> {
+    fn history_by_block_number(&self, _block: BlockNumber) -> ProviderResult<StateProviderBox<'_>> {
         Ok(Box::new(*self))
     }
 
-    fn history_by_block_hash(&self, _block: BlockHash) -> RethResult<StateProviderBox<'_>> {
+    fn history_by_block_hash(&self, _block: BlockHash) -> ProviderResult<StateProviderBox<'_>> {
         Ok(Box::new(*self))
     }
 
-    fn state_by_block_hash(&self, _block: BlockHash) -> RethResult<StateProviderBox<'_>> {
+    fn state_by_block_hash(&self, _block: BlockHash) -> ProviderResult<StateProviderBox<'_>> {
         Ok(Box::new(*self))
     }
 
-    fn pending(&self) -> RethResult<StateProviderBox<'_>> {
+    fn pending(&self) -> ProviderResult<StateProviderBox<'_>> {
         Ok(Box::new(*self))
     }
 
-    fn pending_state_by_hash(&self, _block_hash: B256) -> RethResult<Option<StateProviderBox<'_>>> {
+    fn pending_state_by_hash(
+        &self,
+        _block_hash: B256,
+    ) -> ProviderResult<Option<StateProviderBox<'_>>> {
         Ok(Some(Box::new(*self)))
     }
 
     fn pending_with_provider<'a>(
         &'a self,
         _post_state_data: Box<dyn crate::BundleStateDataProvider + 'a>,
-    ) -> RethResult<StateProviderBox<'a>> {
+    ) -> ProviderResult<StateProviderBox<'a>> {
         Ok(Box::new(*self))
     }
 }
 
 impl StageCheckpointReader for NoopProvider {
-    fn get_stage_checkpoint(&self, _id: StageId) -> RethResult<Option<StageCheckpoint>> {
+    fn get_stage_checkpoint(&self, _id: StageId) -> ProviderResult<Option<StageCheckpoint>> {
         Ok(None)
     }
 
-    fn get_stage_checkpoint_progress(&self, _id: StageId) -> RethResult<Option<Vec<u8>>> {
+    fn get_stage_checkpoint_progress(&self, _id: StageId) -> ProviderResult<Option<Vec<u8>>> {
         Ok(None)
     }
 }
 
 impl WithdrawalsProvider for NoopProvider {
-    fn latest_withdrawal(&self) -> RethResult<Option<reth_primitives::Withdrawal>> {
+    fn latest_withdrawal(&self) -> ProviderResult<Option<reth_primitives::Withdrawal>> {
         Ok(None)
     }
     fn withdrawals_by_block(
         &self,
         _id: BlockHashOrNumber,
         _timestamp: u64,
-    ) -> RethResult<Option<Vec<reth_primitives::Withdrawal>>> {
+    ) -> ProviderResult<Option<Vec<reth_primitives::Withdrawal>>> {
         Ok(None)
     }
 }
 
 impl PruneCheckpointReader for NoopProvider {
-    fn get_prune_checkpoint(&self, _segment: PruneSegment) -> RethResult<Option<PruneCheckpoint>> {
+    fn get_prune_checkpoint(
+        &self,
+        _segment: PruneSegment,
+    ) -> ProviderResult<Option<PruneCheckpoint>> {
         Ok(None)
     }
 }

--- a/crates/storage/provider/src/traits/account.rs
+++ b/crates/storage/provider/src/traits/account.rs
@@ -1,6 +1,6 @@
 use auto_impl::auto_impl;
 use reth_db::models::AccountBeforeTx;
-use reth_interfaces::RethResult;
+use reth_interfaces::provider::ProviderResult;
 use reth_primitives::{Account, Address, BlockNumber};
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -13,7 +13,7 @@ pub trait AccountReader: Send + Sync {
     /// Get basic account information.
     ///
     /// Returns `None` if the account doesn't exist.
-    fn basic_account(&self, address: Address) -> RethResult<Option<Account>>;
+    fn basic_account(&self, address: Address) -> ProviderResult<Option<Account>>;
 }
 
 /// Account reader
@@ -23,7 +23,7 @@ pub trait AccountExtReader: Send + Sync {
     fn changed_accounts_with_range(
         &self,
         _range: impl RangeBounds<BlockNumber>,
-    ) -> RethResult<BTreeSet<Address>>;
+    ) -> ProviderResult<BTreeSet<Address>>;
 
     /// Get basic account information for multiple accounts. A more efficient version than calling
     /// [`AccountReader::basic_account`] repeatedly.
@@ -32,7 +32,7 @@ pub trait AccountExtReader: Send + Sync {
     fn basic_accounts(
         &self,
         _iter: impl IntoIterator<Item = Address>,
-    ) -> RethResult<Vec<(Address, Option<Account>)>>;
+    ) -> ProviderResult<Vec<(Address, Option<Account>)>>;
 
     /// Iterate over account changesets and return all account addresses that were changed alongside
     /// each specific set of blocks.
@@ -41,7 +41,7 @@ pub trait AccountExtReader: Send + Sync {
     fn changed_accounts_and_blocks_with_range(
         &self,
         range: RangeInclusive<BlockNumber>,
-    ) -> RethResult<BTreeMap<Address, Vec<BlockNumber>>>;
+    ) -> ProviderResult<BTreeMap<Address, Vec<BlockNumber>>>;
 }
 
 /// AccountChange reader
@@ -51,5 +51,5 @@ pub trait ChangeSetReader: Send + Sync {
     fn account_block_changeset(
         &self,
         block_number: BlockNumber,
-    ) -> RethResult<Vec<AccountBeforeTx>>;
+    ) -> ProviderResult<Vec<AccountBeforeTx>>;
 }

--- a/crates/storage/provider/src/traits/block.rs
+++ b/crates/storage/provider/src/traits/block.rs
@@ -190,7 +190,7 @@ pub trait BlockReaderIdExt: BlockReader + BlockIdReader + ReceiptProviderIdExt {
     /// Returns `None` if header is not found.
     fn header_by_number_or_tag(&self, id: BlockNumberOrTag) -> ProviderResult<Option<Header>> {
         self.convert_block_number(id)?
-            .map_or_else(|| Ok(None), |num| Ok(self.header_by_hash_or_number(num.into())?))
+            .map_or_else(|| Ok(None), |num| self.header_by_hash_or_number(num.into()))
     }
 
     /// Returns the header with matching tag from the database

--- a/crates/storage/provider/src/traits/block.rs
+++ b/crates/storage/provider/src/traits/block.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use auto_impl::auto_impl;
 use reth_db::models::StoredBlockBodyIndices;
-use reth_interfaces::RethResult;
+use reth_interfaces::provider::ProviderResult;
 use reth_primitives::{
     Address, Block, BlockHashOrNumber, BlockId, BlockNumber, BlockNumberOrTag, BlockWithSenders,
     ChainSpec, Header, PruneModes, Receipt, SealedBlock, SealedBlockWithSenders, SealedHeader,
@@ -72,45 +72,45 @@ pub trait BlockReader:
     /// Note: this only operates on the hash because the number might be ambiguous.
     ///
     /// Returns `None` if block is not found.
-    fn find_block_by_hash(&self, hash: B256, source: BlockSource) -> RethResult<Option<Block>>;
+    fn find_block_by_hash(&self, hash: B256, source: BlockSource) -> ProviderResult<Option<Block>>;
 
     /// Returns the block with given id from the database.
     ///
     /// Returns `None` if block is not found.
-    fn block(&self, id: BlockHashOrNumber) -> RethResult<Option<Block>>;
+    fn block(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Block>>;
 
     /// Returns the pending block if available
     ///
     /// Note: This returns a [SealedBlock] because it's expected that this is sealed by the provider
     /// and the caller does not know the hash.
-    fn pending_block(&self) -> RethResult<Option<SealedBlock>>;
+    fn pending_block(&self) -> ProviderResult<Option<SealedBlock>>;
 
     /// Returns the pending block and receipts if available.
-    fn pending_block_and_receipts(&self) -> RethResult<Option<(SealedBlock, Vec<Receipt>)>>;
+    fn pending_block_and_receipts(&self) -> ProviderResult<Option<(SealedBlock, Vec<Receipt>)>>;
 
     /// Returns the ommers/uncle headers of the given block from the database.
     ///
     /// Returns `None` if block is not found.
-    fn ommers(&self, id: BlockHashOrNumber) -> RethResult<Option<Vec<Header>>>;
+    fn ommers(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Header>>>;
 
     /// Returns the block with matching hash from the database.
     ///
     /// Returns `None` if block is not found.
-    fn block_by_hash(&self, hash: B256) -> RethResult<Option<Block>> {
+    fn block_by_hash(&self, hash: B256) -> ProviderResult<Option<Block>> {
         self.block(hash.into())
     }
 
     /// Returns the block with matching number from database.
     ///
     /// Returns `None` if block is not found.
-    fn block_by_number(&self, num: u64) -> RethResult<Option<Block>> {
+    fn block_by_number(&self, num: u64) -> ProviderResult<Option<Block>> {
         self.block(num.into())
     }
 
     /// Returns the block body indices with matching number from database.
     ///
     /// Returns `None` if block is not found.
-    fn block_body_indices(&self, num: u64) -> RethResult<Option<StoredBlockBodyIndices>>;
+    fn block_body_indices(&self, num: u64) -> ProviderResult<Option<StoredBlockBodyIndices>>;
 
     /// Returns the block with senders with matching number or hash from database.
     ///
@@ -121,12 +121,12 @@ pub trait BlockReader:
         &self,
         id: BlockHashOrNumber,
         transaction_kind: TransactionVariant,
-    ) -> RethResult<Option<BlockWithSenders>>;
+    ) -> ProviderResult<Option<BlockWithSenders>>;
 
     /// Returns all blocks in the given inclusive range.
     ///
     /// Note: returns only available blocks
-    fn block_range(&self, range: RangeInclusive<BlockNumber>) -> RethResult<Vec<Block>>;
+    fn block_range(&self, range: RangeInclusive<BlockNumber>) -> ProviderResult<Vec<Block>>;
 }
 
 /// Trait extension for `BlockReader`, for types that implement `BlockId` conversion.
@@ -144,7 +144,7 @@ pub trait BlockReaderIdExt: BlockReader + BlockIdReader + ReceiptProviderIdExt {
     /// Returns the block with matching tag from the database
     ///
     /// Returns `None` if block is not found.
-    fn block_by_number_or_tag(&self, id: BlockNumberOrTag) -> RethResult<Option<Block>> {
+    fn block_by_number_or_tag(&self, id: BlockNumberOrTag) -> ProviderResult<Option<Block>> {
         self.convert_block_number(id)?.map_or_else(|| Ok(None), |num| self.block(num.into()))
     }
 
@@ -152,7 +152,7 @@ pub trait BlockReaderIdExt: BlockReader + BlockIdReader + ReceiptProviderIdExt {
     ///
     /// Note: This returns a [SealedHeader] because it's expected that this is sealed by the
     /// provider and the caller does not know the hash.
-    fn pending_header(&self) -> RethResult<Option<SealedHeader>> {
+    fn pending_header(&self) -> ProviderResult<Option<SealedHeader>> {
         self.sealed_header_by_id(BlockNumberOrTag::Pending.into())
     }
 
@@ -160,7 +160,7 @@ pub trait BlockReaderIdExt: BlockReader + BlockIdReader + ReceiptProviderIdExt {
     ///
     /// Note: This returns a [SealedHeader] because it's expected that this is sealed by the
     /// provider and the caller does not know the hash.
-    fn latest_header(&self) -> RethResult<Option<SealedHeader>> {
+    fn latest_header(&self) -> ProviderResult<Option<SealedHeader>> {
         self.sealed_header_by_id(BlockNumberOrTag::Latest.into())
     }
 
@@ -168,7 +168,7 @@ pub trait BlockReaderIdExt: BlockReader + BlockIdReader + ReceiptProviderIdExt {
     ///
     /// Note: This returns a [SealedHeader] because it's expected that this is sealed by the
     /// provider and the caller does not know the hash.
-    fn safe_header(&self) -> RethResult<Option<SealedHeader>> {
+    fn safe_header(&self) -> ProviderResult<Option<SealedHeader>> {
         self.sealed_header_by_id(BlockNumberOrTag::Safe.into())
     }
 
@@ -176,21 +176,21 @@ pub trait BlockReaderIdExt: BlockReader + BlockIdReader + ReceiptProviderIdExt {
     ///
     /// Note: This returns a [SealedHeader] because it's expected that this is sealed by the
     /// provider and the caller does not know the hash.
-    fn finalized_header(&self) -> RethResult<Option<SealedHeader>> {
+    fn finalized_header(&self) -> ProviderResult<Option<SealedHeader>> {
         self.sealed_header_by_id(BlockNumberOrTag::Finalized.into())
     }
 
     /// Returns the block with the matching `BlockId` from the database.
     ///
     /// Returns `None` if block is not found.
-    fn block_by_id(&self, id: BlockId) -> RethResult<Option<Block>>;
+    fn block_by_id(&self, id: BlockId) -> ProviderResult<Option<Block>>;
 
     /// Returns the header with matching tag from the database
     ///
     /// Returns `None` if header is not found.
-    fn header_by_number_or_tag(&self, id: BlockNumberOrTag) -> RethResult<Option<Header>> {
+    fn header_by_number_or_tag(&self, id: BlockNumberOrTag) -> ProviderResult<Option<Header>> {
         self.convert_block_number(id)?
-            .map_or_else(|| Ok(None), |num| self.header_by_hash_or_number(num.into()))
+            .map_or_else(|| Ok(None), |num| Ok(self.header_by_hash_or_number(num.into())?))
     }
 
     /// Returns the header with matching tag from the database
@@ -199,7 +199,7 @@ pub trait BlockReaderIdExt: BlockReader + BlockIdReader + ReceiptProviderIdExt {
     fn sealed_header_by_number_or_tag(
         &self,
         id: BlockNumberOrTag,
-    ) -> RethResult<Option<SealedHeader>> {
+    ) -> ProviderResult<Option<SealedHeader>> {
         self.convert_block_number(id)?
             .map_or_else(|| Ok(None), |num| self.header_by_hash_or_number(num.into()))?
             .map_or_else(|| Ok(None), |h| Ok(Some(h.seal_slow())))
@@ -208,22 +208,22 @@ pub trait BlockReaderIdExt: BlockReader + BlockIdReader + ReceiptProviderIdExt {
     /// Returns the sealed header with the matching `BlockId` from the database.
     ///
     /// Returns `None` if header is not found.
-    fn sealed_header_by_id(&self, id: BlockId) -> RethResult<Option<SealedHeader>>;
+    fn sealed_header_by_id(&self, id: BlockId) -> ProviderResult<Option<SealedHeader>>;
 
     /// Returns the header with the matching `BlockId` from the database.
     ///
     /// Returns `None` if header is not found.
-    fn header_by_id(&self, id: BlockId) -> RethResult<Option<Header>>;
+    fn header_by_id(&self, id: BlockId) -> ProviderResult<Option<Header>>;
 
     /// Returns the ommers with the matching tag from the database.
-    fn ommers_by_number_or_tag(&self, id: BlockNumberOrTag) -> RethResult<Option<Vec<Header>>> {
+    fn ommers_by_number_or_tag(&self, id: BlockNumberOrTag) -> ProviderResult<Option<Vec<Header>>> {
         self.convert_block_number(id)?.map_or_else(|| Ok(None), |num| self.ommers(num.into()))
     }
 
     /// Returns the ommers with the matching `BlockId` from the database.
     ///
     /// Returns `None` if block is not found.
-    fn ommers_by_id(&self, id: BlockId) -> RethResult<Option<Vec<Header>>>;
+    fn ommers_by_id(&self, id: BlockId) -> ProviderResult<Option<Vec<Header>>>;
 }
 
 /// BlockExecution Writer
@@ -234,7 +234,7 @@ pub trait BlockExecutionWriter: BlockWriter + BlockReader + Send + Sync {
         &self,
         chain_spec: &ChainSpec,
         range: RangeInclusive<BlockNumber>,
-    ) -> RethResult<Chain> {
+    ) -> ProviderResult<Chain> {
         self.get_or_take_block_and_execution_range::<false>(chain_spec, range)
     }
 
@@ -243,7 +243,7 @@ pub trait BlockExecutionWriter: BlockWriter + BlockReader + Send + Sync {
         &self,
         chain_spec: &ChainSpec,
         range: RangeInclusive<BlockNumber>,
-    ) -> RethResult<Chain> {
+    ) -> ProviderResult<Chain> {
         self.get_or_take_block_and_execution_range::<true>(chain_spec, range)
     }
 
@@ -252,7 +252,7 @@ pub trait BlockExecutionWriter: BlockWriter + BlockReader + Send + Sync {
         &self,
         chain_spec: &ChainSpec,
         range: RangeInclusive<BlockNumber>,
-    ) -> RethResult<Chain>;
+    ) -> ProviderResult<Chain>;
 }
 
 /// Block Writer
@@ -268,7 +268,7 @@ pub trait BlockWriter: Send + Sync {
         block: SealedBlock,
         senders: Option<Vec<Address>>,
         prune_modes: Option<&PruneModes>,
-    ) -> RethResult<StoredBlockBodyIndices>;
+    ) -> ProviderResult<StoredBlockBodyIndices>;
 
     /// Appends a batch of sealed blocks to the blockchain, including sender information, and
     /// updates the post-state.
@@ -290,5 +290,5 @@ pub trait BlockWriter: Send + Sync {
         blocks: Vec<SealedBlockWithSenders>,
         state: BundleStateWithReceipts,
         prune_modes: Option<&PruneModes>,
-    ) -> RethResult<()>;
+    ) -> ProviderResult<()>;
 }

--- a/crates/storage/provider/src/traits/block_hash.rs
+++ b/crates/storage/provider/src/traits/block_hash.rs
@@ -1,5 +1,5 @@
 use auto_impl::auto_impl;
-use reth_interfaces::RethResult;
+use reth_interfaces::provider::ProviderResult;
 use reth_primitives::{BlockHashOrNumber, BlockNumber, B256};
 
 /// Client trait for fetching block hashes by number.
@@ -7,11 +7,14 @@ use reth_primitives::{BlockHashOrNumber, BlockNumber, B256};
 pub trait BlockHashReader: Send + Sync {
     /// Get the hash of the block with the given number. Returns `None` if no block with this number
     /// exists.
-    fn block_hash(&self, number: BlockNumber) -> RethResult<Option<B256>>;
+    fn block_hash(&self, number: BlockNumber) -> ProviderResult<Option<B256>>;
 
     /// Get the hash of the block with the given number. Returns `None` if no block with this number
     /// exists.
-    fn convert_block_hash(&self, hash_or_number: BlockHashOrNumber) -> RethResult<Option<B256>> {
+    fn convert_block_hash(
+        &self,
+        hash_or_number: BlockHashOrNumber,
+    ) -> ProviderResult<Option<B256>> {
         match hash_or_number {
             BlockHashOrNumber::Hash(hash) => Ok(Some(hash)),
             BlockHashOrNumber::Number(num) => self.block_hash(num),
@@ -23,6 +26,9 @@ pub trait BlockHashReader: Send + Sync {
     /// Returns the available hashes of that range.
     ///
     /// Note: The range is `start..end`, so the expected result is `[start..end)`
-    fn canonical_hashes_range(&self, start: BlockNumber, end: BlockNumber)
-        -> RethResult<Vec<B256>>;
+    fn canonical_hashes_range(
+        &self,
+        start: BlockNumber,
+        end: BlockNumber,
+    ) -> ProviderResult<Vec<B256>>;
 }

--- a/crates/storage/provider/src/traits/block_id.rs
+++ b/crates/storage/provider/src/traits/block_id.rs
@@ -63,11 +63,11 @@ pub trait BlockIdReader: BlockNumReader + Send + Sync {
             BlockNumberOrTag::Number(num) => num,
             BlockNumberOrTag::Finalized => match self.finalized_block_number()? {
                 Some(block_number) => block_number,
-                None => return Err(ProviderError::FinalizedBlockNotFound.into()),
+                None => return Err(ProviderError::FinalizedBlockNotFound),
             },
             BlockNumberOrTag::Safe => match self.safe_block_number()? {
                 Some(block_number) => block_number,
-                None => return Err(ProviderError::SafeBlockNotFound.into()),
+                None => return Err(ProviderError::SafeBlockNotFound),
             },
         };
         Ok(Some(num))

--- a/crates/storage/provider/src/traits/block_id.rs
+++ b/crates/storage/provider/src/traits/block_id.rs
@@ -1,5 +1,5 @@
 use super::BlockHashReader;
-use reth_interfaces::{provider::ProviderError, RethResult};
+use reth_interfaces::provider::{ProviderError, ProviderResult};
 use reth_primitives::{BlockHashOrNumber, BlockId, BlockNumber, BlockNumberOrTag, ChainInfo, B256};
 
 /// Client trait for getting important block numbers (such as the latest block number), converting
@@ -9,20 +9,20 @@ use reth_primitives::{BlockHashOrNumber, BlockId, BlockNumber, BlockNumberOrTag,
 #[auto_impl::auto_impl(&, Arc)]
 pub trait BlockNumReader: BlockHashReader + Send + Sync {
     /// Returns the current info for the chain.
-    fn chain_info(&self) -> RethResult<ChainInfo>;
+    fn chain_info(&self) -> ProviderResult<ChainInfo>;
 
     /// Returns the best block number in the chain.
-    fn best_block_number(&self) -> RethResult<BlockNumber>;
+    fn best_block_number(&self) -> ProviderResult<BlockNumber>;
 
     /// Returns the last block number associated with the last canonical header in the database.
-    fn last_block_number(&self) -> RethResult<BlockNumber>;
+    fn last_block_number(&self) -> ProviderResult<BlockNumber>;
 
     /// Gets the `BlockNumber` for the given hash. Returns `None` if no block with this hash exists.
-    fn block_number(&self, hash: B256) -> RethResult<Option<BlockNumber>>;
+    fn block_number(&self, hash: B256) -> ProviderResult<Option<BlockNumber>>;
 
     /// Gets the block number for the given `BlockHashOrNumber`. Returns `None` if no block with
     /// this hash exists. If the `BlockHashOrNumber` is a `Number`, it is returned as is.
-    fn convert_hash_or_number(&self, id: BlockHashOrNumber) -> RethResult<Option<BlockNumber>> {
+    fn convert_hash_or_number(&self, id: BlockHashOrNumber) -> ProviderResult<Option<BlockNumber>> {
         match id {
             BlockHashOrNumber::Hash(hash) => self.block_number(hash),
             BlockHashOrNumber::Number(num) => Ok(Some(num)),
@@ -31,7 +31,7 @@ pub trait BlockNumReader: BlockHashReader + Send + Sync {
 
     /// Gets the block hash for the given `BlockHashOrNumber`. Returns `None` if no block with this
     /// number exists. If the `BlockHashOrNumber` is a `Hash`, it is returned as is.
-    fn convert_number(&self, id: BlockHashOrNumber) -> RethResult<Option<B256>> {
+    fn convert_number(&self, id: BlockHashOrNumber) -> ProviderResult<Option<B256>> {
         match id {
             BlockHashOrNumber::Hash(hash) => Ok(Some(hash)),
             BlockHashOrNumber::Number(num) => self.block_hash(num),
@@ -51,7 +51,7 @@ pub trait BlockNumReader: BlockHashReader + Send + Sync {
 #[auto_impl::auto_impl(&, Arc)]
 pub trait BlockIdReader: BlockNumReader + Send + Sync {
     /// Converts the `BlockNumberOrTag` variants to a block number.
-    fn convert_block_number(&self, num: BlockNumberOrTag) -> RethResult<Option<BlockNumber>> {
+    fn convert_block_number(&self, num: BlockNumberOrTag) -> ProviderResult<Option<BlockNumber>> {
         let num = match num {
             BlockNumberOrTag::Latest => self.best_block_number()?,
             BlockNumberOrTag::Earliest => 0,
@@ -74,7 +74,7 @@ pub trait BlockIdReader: BlockNumReader + Send + Sync {
     }
 
     /// Get the hash of the block by matching the given id.
-    fn block_hash_for_id(&self, block_id: BlockId) -> RethResult<Option<B256>> {
+    fn block_hash_for_id(&self, block_id: BlockId) -> ProviderResult<Option<B256>> {
         match block_id {
             BlockId::Hash(hash) => Ok(Some(hash.into())),
             BlockId::Number(num) => {
@@ -97,7 +97,7 @@ pub trait BlockIdReader: BlockNumReader + Send + Sync {
     }
 
     /// Get the number of the block by matching the given id.
-    fn block_number_for_id(&self, block_id: BlockId) -> RethResult<Option<BlockNumber>> {
+    fn block_number_for_id(&self, block_id: BlockId) -> ProviderResult<Option<BlockNumber>> {
         match block_id {
             BlockId::Hash(hash) => self.block_number(hash.into()),
             BlockId::Number(num) => self.convert_block_number(num),
@@ -105,31 +105,31 @@ pub trait BlockIdReader: BlockNumReader + Send + Sync {
     }
 
     /// Get the current pending block number and hash.
-    fn pending_block_num_hash(&self) -> RethResult<Option<reth_primitives::BlockNumHash>>;
+    fn pending_block_num_hash(&self) -> ProviderResult<Option<reth_primitives::BlockNumHash>>;
 
     /// Get the current safe block number and hash.
-    fn safe_block_num_hash(&self) -> RethResult<Option<reth_primitives::BlockNumHash>>;
+    fn safe_block_num_hash(&self) -> ProviderResult<Option<reth_primitives::BlockNumHash>>;
 
     /// Get the current finalized block number and hash.
-    fn finalized_block_num_hash(&self) -> RethResult<Option<reth_primitives::BlockNumHash>>;
+    fn finalized_block_num_hash(&self) -> ProviderResult<Option<reth_primitives::BlockNumHash>>;
 
     /// Get the safe block number.
-    fn safe_block_number(&self) -> RethResult<Option<BlockNumber>> {
+    fn safe_block_number(&self) -> ProviderResult<Option<BlockNumber>> {
         self.safe_block_num_hash().map(|res_opt| res_opt.map(|num_hash| num_hash.number))
     }
 
     /// Get the finalized block number.
-    fn finalized_block_number(&self) -> RethResult<Option<BlockNumber>> {
+    fn finalized_block_number(&self) -> ProviderResult<Option<BlockNumber>> {
         self.finalized_block_num_hash().map(|res_opt| res_opt.map(|num_hash| num_hash.number))
     }
 
     /// Get the safe block hash.
-    fn safe_block_hash(&self) -> RethResult<Option<B256>> {
+    fn safe_block_hash(&self) -> ProviderResult<Option<B256>> {
         self.safe_block_num_hash().map(|res_opt| res_opt.map(|num_hash| num_hash.hash))
     }
 
     /// Get the finalized block hash.
-    fn finalized_block_hash(&self) -> RethResult<Option<B256>> {
+    fn finalized_block_hash(&self) -> ProviderResult<Option<B256>> {
         self.finalized_block_num_hash().map(|res_opt| res_opt.map(|num_hash| num_hash.hash))
     }
 }

--- a/crates/storage/provider/src/traits/evm_env.rs
+++ b/crates/storage/provider/src/traits/evm_env.rs
@@ -1,4 +1,4 @@
-use reth_interfaces::RethResult;
+use reth_interfaces::provider::ProviderResult;
 use reth_primitives::{BlockHashOrNumber, Header};
 use revm::primitives::{BlockEnv, CfgEnv};
 
@@ -15,10 +15,10 @@ pub trait EvmEnvProvider: Send + Sync {
         cfg: &mut CfgEnv,
         block_env: &mut BlockEnv,
         at: BlockHashOrNumber,
-    ) -> RethResult<()>;
+    ) -> ProviderResult<()>;
 
     /// Fills the default [CfgEnv] and [BlockEnv] fields with values specific to the given [Header].
-    fn env_with_header(&self, header: &Header) -> RethResult<(CfgEnv, BlockEnv)> {
+    fn env_with_header(&self, header: &Header) -> ProviderResult<(CfgEnv, BlockEnv)> {
         let mut cfg = CfgEnv::default();
         let mut block_env = BlockEnv::default();
         self.fill_env_with_header(&mut cfg, &mut block_env, header)?;
@@ -31,21 +31,25 @@ pub trait EvmEnvProvider: Send + Sync {
         cfg: &mut CfgEnv,
         block_env: &mut BlockEnv,
         header: &Header,
-    ) -> RethResult<()>;
+    ) -> ProviderResult<()>;
 
     /// Fills the [BlockEnv] fields with values specific to the given [BlockHashOrNumber].
-    fn fill_block_env_at(&self, block_env: &mut BlockEnv, at: BlockHashOrNumber) -> RethResult<()>;
+    fn fill_block_env_at(
+        &self,
+        block_env: &mut BlockEnv,
+        at: BlockHashOrNumber,
+    ) -> ProviderResult<()>;
 
     /// Fills the [BlockEnv] fields with values specific to the given [Header].
     fn fill_block_env_with_header(
         &self,
         block_env: &mut BlockEnv,
         header: &Header,
-    ) -> RethResult<()>;
+    ) -> ProviderResult<()>;
 
     /// Fills the [CfgEnv] fields with values specific to the given [BlockHashOrNumber].
-    fn fill_cfg_env_at(&self, cfg: &mut CfgEnv, at: BlockHashOrNumber) -> RethResult<()>;
+    fn fill_cfg_env_at(&self, cfg: &mut CfgEnv, at: BlockHashOrNumber) -> ProviderResult<()>;
 
     /// Fills the [CfgEnv] fields with values specific to the given [Header].
-    fn fill_cfg_env_with_header(&self, cfg: &mut CfgEnv, header: &Header) -> RethResult<()>;
+    fn fill_cfg_env_with_header(&self, cfg: &mut CfgEnv, header: &Header) -> ProviderResult<()>;
 }

--- a/crates/storage/provider/src/traits/hashing.rs
+++ b/crates/storage/provider/src/traits/hashing.rs
@@ -1,6 +1,6 @@
 use auto_impl::auto_impl;
 use reth_db::models::BlockNumberAddress;
-use reth_interfaces::RethResult;
+use reth_interfaces::provider::ProviderResult;
 use reth_primitives::{Account, Address, BlockNumber, StorageEntry, B256};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
@@ -18,7 +18,7 @@ pub trait HashingWriter: Send + Sync {
     fn unwind_account_hashing(
         &self,
         range: RangeInclusive<BlockNumber>,
-    ) -> RethResult<BTreeMap<B256, Option<Account>>>;
+    ) -> ProviderResult<BTreeMap<B256, Option<Account>>>;
 
     /// Inserts all accounts into [reth_db::tables::AccountHistory] table.
     ///
@@ -28,7 +28,7 @@ pub trait HashingWriter: Send + Sync {
     fn insert_account_for_hashing(
         &self,
         accounts: impl IntoIterator<Item = (Address, Option<Account>)>,
-    ) -> RethResult<BTreeMap<B256, Option<Account>>>;
+    ) -> ProviderResult<BTreeMap<B256, Option<Account>>>;
 
     /// Unwind and clear storage hashing
     ///
@@ -38,7 +38,7 @@ pub trait HashingWriter: Send + Sync {
     fn unwind_storage_hashing(
         &self,
         range: Range<BlockNumberAddress>,
-    ) -> RethResult<HashMap<B256, BTreeSet<B256>>>;
+    ) -> ProviderResult<HashMap<B256, BTreeSet<B256>>>;
 
     /// Iterates over storages and inserts them to hashing table.
     ///
@@ -48,7 +48,7 @@ pub trait HashingWriter: Send + Sync {
     fn insert_storage_for_hashing(
         &self,
         storages: impl IntoIterator<Item = (Address, impl IntoIterator<Item = StorageEntry>)>,
-    ) -> RethResult<HashMap<B256, BTreeSet<B256>>>;
+    ) -> ProviderResult<HashMap<B256, BTreeSet<B256>>>;
 
     /// Calculate the hashes of all changed accounts and storages, and finally calculate the state
     /// root.
@@ -61,5 +61,5 @@ pub trait HashingWriter: Send + Sync {
         range: RangeInclusive<BlockNumber>,
         end_block_hash: B256,
         expected_state_root: B256,
-    ) -> RethResult<()>;
+    ) -> ProviderResult<()>;
 }

--- a/crates/storage/provider/src/traits/header.rs
+++ b/crates/storage/provider/src/traits/header.rs
@@ -1,5 +1,5 @@
 use auto_impl::auto_impl;
-use reth_interfaces::RethResult;
+use reth_interfaces::provider::ProviderResult;
 use reth_primitives::{BlockHash, BlockHashOrNumber, BlockNumber, Header, SealedHeader, U256};
 use std::ops::RangeBounds;
 
@@ -7,21 +7,21 @@ use std::ops::RangeBounds;
 #[auto_impl(&, Arc)]
 pub trait HeaderProvider: Send + Sync {
     /// Check if block is known
-    fn is_known(&self, block_hash: &BlockHash) -> RethResult<bool> {
+    fn is_known(&self, block_hash: &BlockHash) -> ProviderResult<bool> {
         self.header(block_hash).map(|header| header.is_some())
     }
 
     /// Get header by block hash
-    fn header(&self, block_hash: &BlockHash) -> RethResult<Option<Header>>;
+    fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Header>>;
 
     /// Get header by block number
-    fn header_by_number(&self, num: u64) -> RethResult<Option<Header>>;
+    fn header_by_number(&self, num: u64) -> ProviderResult<Option<Header>>;
 
     /// Get header by block number or hash
     fn header_by_hash_or_number(
         &self,
         hash_or_num: BlockHashOrNumber,
-    ) -> RethResult<Option<Header>> {
+    ) -> ProviderResult<Option<Header>> {
         match hash_or_num {
             BlockHashOrNumber::Hash(hash) => self.header(&hash),
             BlockHashOrNumber::Number(num) => self.header_by_number(num),
@@ -29,22 +29,22 @@ pub trait HeaderProvider: Send + Sync {
     }
 
     /// Get total difficulty by block hash.
-    fn header_td(&self, hash: &BlockHash) -> RethResult<Option<U256>>;
+    fn header_td(&self, hash: &BlockHash) -> ProviderResult<Option<U256>>;
 
     /// Get total difficulty by block number.
-    fn header_td_by_number(&self, number: BlockNumber) -> RethResult<Option<U256>>;
+    fn header_td_by_number(&self, number: BlockNumber) -> ProviderResult<Option<U256>>;
 
     /// Get headers in range of block numbers
-    fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> RethResult<Vec<Header>>;
+    fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> ProviderResult<Vec<Header>>;
 
     /// Get a single sealed header by block number.
-    fn sealed_header(&self, number: BlockNumber) -> RethResult<Option<SealedHeader>>;
+    fn sealed_header(&self, number: BlockNumber) -> ProviderResult<Option<SealedHeader>>;
 
     /// Get headers in range of block numbers.
     fn sealed_headers_range(
         &self,
         range: impl RangeBounds<BlockNumber>,
-    ) -> RethResult<Vec<SealedHeader>> {
+    ) -> ProviderResult<Vec<SealedHeader>> {
         self.sealed_headers_while(range, |_| true)
     }
 
@@ -53,5 +53,5 @@ pub trait HeaderProvider: Send + Sync {
         &self,
         range: impl RangeBounds<BlockNumber>,
         predicate: impl FnMut(&SealedHeader) -> bool,
-    ) -> RethResult<Vec<SealedHeader>>;
+    ) -> ProviderResult<Vec<SealedHeader>>;
 }

--- a/crates/storage/provider/src/traits/history.rs
+++ b/crates/storage/provider/src/traits/history.rs
@@ -1,6 +1,6 @@
 use auto_impl::auto_impl;
 use reth_db::models::BlockNumberAddress;
-use reth_interfaces::RethResult;
+use reth_interfaces::provider::ProviderResult;
 use reth_primitives::{Address, BlockNumber, B256};
 use std::{
     collections::BTreeMap,
@@ -16,26 +16,28 @@ pub trait HistoryWriter: Send + Sync {
     fn unwind_account_history_indices(
         &self,
         range: RangeInclusive<BlockNumber>,
-    ) -> RethResult<usize>;
+    ) -> ProviderResult<usize>;
 
     /// Insert account change index to database. Used inside AccountHistoryIndex stage
     fn insert_account_history_index(
         &self,
         account_transitions: BTreeMap<Address, Vec<u64>>,
-    ) -> RethResult<()>;
+    ) -> ProviderResult<()>;
 
     /// Unwind and clear storage history indices.
     ///
     /// Returns number of changesets walked.
-    fn unwind_storage_history_indices(&self, range: Range<BlockNumberAddress>)
-        -> RethResult<usize>;
+    fn unwind_storage_history_indices(
+        &self,
+        range: Range<BlockNumberAddress>,
+    ) -> ProviderResult<usize>;
 
     /// Insert storage change index to database. Used inside StorageHistoryIndex stage
     fn insert_storage_history_index(
         &self,
         storage_transitions: BTreeMap<(Address, B256), Vec<u64>>,
-    ) -> RethResult<()>;
+    ) -> ProviderResult<()>;
 
     /// Read account/storage changesets and update account/storage history indices.
-    fn update_history_indices(&self, range: RangeInclusive<BlockNumber>) -> RethResult<()>;
+    fn update_history_indices(&self, range: RangeInclusive<BlockNumber>) -> ProviderResult<()>;
 }

--- a/crates/storage/provider/src/traits/prune_checkpoint.rs
+++ b/crates/storage/provider/src/traits/prune_checkpoint.rs
@@ -1,11 +1,14 @@
-use reth_interfaces::RethResult;
+use reth_interfaces::provider::ProviderResult;
 use reth_primitives::{PruneCheckpoint, PruneSegment};
 
 /// The trait for fetching prune checkpoint related data.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait PruneCheckpointReader: Send + Sync {
     /// Fetch the checkpoint for the given prune segment.
-    fn get_prune_checkpoint(&self, segment: PruneSegment) -> RethResult<Option<PruneCheckpoint>>;
+    fn get_prune_checkpoint(
+        &self,
+        segment: PruneSegment,
+    ) -> ProviderResult<Option<PruneCheckpoint>>;
 }
 
 /// The trait for updating prune checkpoint related data.
@@ -16,5 +19,5 @@ pub trait PruneCheckpointWriter: Send + Sync {
         &self,
         segment: PruneSegment,
         checkpoint: PruneCheckpoint,
-    ) -> RethResult<()>;
+    ) -> ProviderResult<()>;
 }

--- a/crates/storage/provider/src/traits/receipts.rs
+++ b/crates/storage/provider/src/traits/receipts.rs
@@ -1,4 +1,4 @@
-use reth_interfaces::RethResult;
+use reth_interfaces::provider::ProviderResult;
 use reth_primitives::{BlockHashOrNumber, BlockId, BlockNumberOrTag, Receipt, TxHash, TxNumber};
 
 use crate::BlockIdReader;
@@ -9,17 +9,17 @@ pub trait ReceiptProvider: Send + Sync {
     /// Get receipt by transaction number
     ///
     /// Returns `None` if the transaction is not found.
-    fn receipt(&self, id: TxNumber) -> RethResult<Option<Receipt>>;
+    fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Receipt>>;
 
     /// Get receipt by transaction hash.
     ///
     /// Returns `None` if the transaction is not found.
-    fn receipt_by_hash(&self, hash: TxHash) -> RethResult<Option<Receipt>>;
+    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Receipt>>;
 
     /// Get receipts by block num or hash.
     ///
     /// Returns `None` if the block is not found.
-    fn receipts_by_block(&self, block: BlockHashOrNumber) -> RethResult<Option<Vec<Receipt>>>;
+    fn receipts_by_block(&self, block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>>;
 }
 
 /// Trait extension for `ReceiptProvider`, for types that implement `BlockId` conversion.
@@ -34,7 +34,7 @@ pub trait ReceiptProvider: Send + Sync {
 /// retrieving the receipts should be done using the type's `ReceiptProvider` methods.
 pub trait ReceiptProviderIdExt: ReceiptProvider + BlockIdReader {
     /// Get receipt by block id
-    fn receipts_by_block_id(&self, block: BlockId) -> RethResult<Option<Vec<Receipt>>> {
+    fn receipts_by_block_id(&self, block: BlockId) -> ProviderResult<Option<Vec<Receipt>>> {
         let id = match block {
             BlockId::Hash(hash) => BlockHashOrNumber::Hash(hash.block_hash),
             BlockId::Number(num_tag) => {
@@ -55,7 +55,7 @@ pub trait ReceiptProviderIdExt: ReceiptProvider + BlockIdReader {
     fn receipts_by_number_or_tag(
         &self,
         number_or_tag: BlockNumberOrTag,
-    ) -> RethResult<Option<Vec<Receipt>>> {
+    ) -> ProviderResult<Option<Vec<Receipt>>> {
         self.receipts_by_block_id(number_or_tag.into())
     }
 }

--- a/crates/storage/provider/src/traits/stage_checkpoint.rs
+++ b/crates/storage/provider/src/traits/stage_checkpoint.rs
@@ -1,4 +1,4 @@
-use reth_interfaces::RethResult;
+use reth_interfaces::provider::ProviderResult;
 use reth_primitives::{
     stage::{StageCheckpoint, StageId},
     BlockNumber,
@@ -8,25 +8,30 @@ use reth_primitives::{
 #[auto_impl::auto_impl(&, Arc)]
 pub trait StageCheckpointReader: Send + Sync {
     /// Fetch the checkpoint for the given stage.
-    fn get_stage_checkpoint(&self, id: StageId) -> RethResult<Option<StageCheckpoint>>;
+    fn get_stage_checkpoint(&self, id: StageId) -> ProviderResult<Option<StageCheckpoint>>;
 
     /// Get stage checkpoint progress.
-    fn get_stage_checkpoint_progress(&self, id: StageId) -> RethResult<Option<Vec<u8>>>;
+    fn get_stage_checkpoint_progress(&self, id: StageId) -> ProviderResult<Option<Vec<u8>>>;
 }
 
 /// The trait for updating stage checkpoint related data.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait StageCheckpointWriter: Send + Sync {
     /// Save stage checkpoint.
-    fn save_stage_checkpoint(&self, id: StageId, checkpoint: StageCheckpoint) -> RethResult<()>;
+    fn save_stage_checkpoint(&self, id: StageId, checkpoint: StageCheckpoint)
+        -> ProviderResult<()>;
 
     /// Save stage checkpoint progress.
-    fn save_stage_checkpoint_progress(&self, id: StageId, checkpoint: Vec<u8>) -> RethResult<()>;
+    fn save_stage_checkpoint_progress(
+        &self,
+        id: StageId,
+        checkpoint: Vec<u8>,
+    ) -> ProviderResult<()>;
 
     /// Update all pipeline sync stage progress.
     fn update_pipeline_stages(
         &self,
         block_number: BlockNumber,
         drop_stage_checkpoint: bool,
-    ) -> RethResult<()>;
+    ) -> ProviderResult<()>;
 }

--- a/crates/storage/provider/src/traits/state.rs
+++ b/crates/storage/provider/src/traits/state.rs
@@ -125,7 +125,7 @@ pub trait StateProviderFactory: BlockIdReader + Send + Sync {
                 // we can only get the finalized state by hash, not by num
                 let hash = match self.finalized_block_hash()? {
                     Some(hash) => hash,
-                    None => return Err(ProviderError::FinalizedBlockNotFound.into()),
+                    None => return Err(ProviderError::FinalizedBlockNotFound),
                 };
                 // only look at historical state
                 self.history_by_block_hash(hash)
@@ -134,7 +134,7 @@ pub trait StateProviderFactory: BlockIdReader + Send + Sync {
                 // we can only get the safe state by hash, not by num
                 let hash = match self.safe_block_hash()? {
                     Some(hash) => hash,
-                    None => return Err(ProviderError::SafeBlockNotFound.into()),
+                    None => return Err(ProviderError::SafeBlockNotFound),
                 };
 
                 self.history_by_block_hash(hash)
@@ -199,9 +199,8 @@ pub trait BlockchainTreePendingStateProvider: Send + Sync {
         &self,
         block_hash: BlockHash,
     ) -> ProviderResult<Box<dyn BundleStateDataProvider>> {
-        Ok(self
-            .find_pending_state_provider(block_hash)
-            .ok_or(ProviderError::StateForHashNotFound(block_hash))?)
+        self.find_pending_state_provider(block_hash)
+            .ok_or(ProviderError::StateForHashNotFound(block_hash))
     }
 
     /// Returns state provider if a matching block exists.

--- a/crates/storage/provider/src/traits/state.rs
+++ b/crates/storage/provider/src/traits/state.rs
@@ -1,7 +1,7 @@
 use super::AccountReader;
 use crate::{BlockHashReader, BlockIdReader, BundleStateWithReceipts};
 use auto_impl::auto_impl;
-use reth_interfaces::{provider::ProviderError, RethResult};
+use reth_interfaces::provider::{ProviderError, ProviderResult};
 use reth_primitives::{
     trie::AccountProof, Address, BlockHash, BlockId, BlockNumHash, BlockNumber, BlockNumberOrTag,
     Bytecode, StorageKey, StorageValue, B256, KECCAK_EMPTY, U256,
@@ -18,18 +18,18 @@ pub trait StateProvider: BlockHashReader + AccountReader + StateRootProvider + S
         &self,
         account: Address,
         storage_key: StorageKey,
-    ) -> RethResult<Option<StorageValue>>;
+    ) -> ProviderResult<Option<StorageValue>>;
 
     /// Get account code by its hash
-    fn bytecode_by_hash(&self, code_hash: B256) -> RethResult<Option<Bytecode>>;
+    fn bytecode_by_hash(&self, code_hash: B256) -> ProviderResult<Option<Bytecode>>;
 
     /// Get account and storage proofs.
-    fn proof(&self, address: Address, keys: &[B256]) -> RethResult<AccountProof>;
+    fn proof(&self, address: Address, keys: &[B256]) -> ProviderResult<AccountProof>;
 
     /// Get account code by its address.
     ///
     /// Returns `None` if the account doesn't exist or account is not a contract
-    fn account_code(&self, addr: Address) -> RethResult<Option<Bytecode>> {
+    fn account_code(&self, addr: Address) -> ProviderResult<Option<Bytecode>> {
         // Get basic account information
         // Returns None if acc doesn't exist
         let acc = match self.basic_account(addr)? {
@@ -52,7 +52,7 @@ pub trait StateProvider: BlockHashReader + AccountReader + StateRootProvider + S
     /// Get account balance by its address.
     ///
     /// Returns `None` if the account doesn't exist
-    fn account_balance(&self, addr: Address) -> RethResult<Option<U256>> {
+    fn account_balance(&self, addr: Address) -> ProviderResult<Option<U256>> {
         // Get basic account information
         // Returns None if acc doesn't exist
         match self.basic_account(addr)? {
@@ -64,7 +64,7 @@ pub trait StateProvider: BlockHashReader + AccountReader + StateRootProvider + S
     /// Get account nonce by its address.
     ///
     /// Returns `None` if the account doesn't exist
-    fn account_nonce(&self, addr: Address) -> RethResult<Option<u64>> {
+    fn account_nonce(&self, addr: Address) -> ProviderResult<Option<u64>> {
         // Get basic account information
         // Returns None if acc doesn't exist
         match self.basic_account(addr)? {
@@ -99,13 +99,13 @@ pub trait StateProvider: BlockHashReader + AccountReader + StateRootProvider + S
 /// to be used, since block `n` was executed on its parent block's state.
 pub trait StateProviderFactory: BlockIdReader + Send + Sync {
     /// Storage provider for latest block.
-    fn latest(&self) -> RethResult<StateProviderBox<'_>>;
+    fn latest(&self) -> ProviderResult<StateProviderBox<'_>>;
 
     /// Returns a [StateProvider] indexed by the given [BlockId].
     ///
     /// Note: if a number or hash is provided this will __only__ look at historical(canonical)
     /// state.
-    fn state_by_block_id(&self, block_id: BlockId) -> RethResult<StateProviderBox<'_>> {
+    fn state_by_block_id(&self, block_id: BlockId) -> ProviderResult<StateProviderBox<'_>> {
         match block_id {
             BlockId::Number(block_number) => self.state_by_block_number_or_tag(block_number),
             BlockId::Hash(block_hash) => self.history_by_block_hash(block_hash.into()),
@@ -118,7 +118,7 @@ pub trait StateProviderFactory: BlockIdReader + Send + Sync {
     fn state_by_block_number_or_tag(
         &self,
         number_or_tag: BlockNumberOrTag,
-    ) -> RethResult<StateProviderBox<'_>> {
+    ) -> ProviderResult<StateProviderBox<'_>> {
         match number_or_tag {
             BlockNumberOrTag::Latest => self.latest(),
             BlockNumberOrTag::Finalized => {
@@ -152,37 +152,40 @@ pub trait StateProviderFactory: BlockIdReader + Send + Sync {
     ///
     ///
     /// Note: this only looks at historical blocks, not pending blocks.
-    fn history_by_block_number(&self, block: BlockNumber) -> RethResult<StateProviderBox<'_>>;
+    fn history_by_block_number(&self, block: BlockNumber) -> ProviderResult<StateProviderBox<'_>>;
 
     /// Returns a historical [StateProvider] indexed by the given block hash.
     ///
     /// Note: this only looks at historical blocks, not pending blocks.
-    fn history_by_block_hash(&self, block: BlockHash) -> RethResult<StateProviderBox<'_>>;
+    fn history_by_block_hash(&self, block: BlockHash) -> ProviderResult<StateProviderBox<'_>>;
 
     /// Returns _any_[StateProvider] with matching block hash.
     ///
     /// This will return a [StateProvider] for either a historical or pending block.
-    fn state_by_block_hash(&self, block: BlockHash) -> RethResult<StateProviderBox<'_>>;
+    fn state_by_block_hash(&self, block: BlockHash) -> ProviderResult<StateProviderBox<'_>>;
 
     /// Storage provider for pending state.
     ///
     /// Represents the state at the block that extends the canonical chain by one.
     /// If there's no `pending` block, then this is equal to [StateProviderFactory::latest]
-    fn pending(&self) -> RethResult<StateProviderBox<'_>>;
+    fn pending(&self) -> ProviderResult<StateProviderBox<'_>>;
 
     /// Storage provider for pending state for the given block hash.
     ///
     /// Represents the state at the block that extends the canonical chain.
     ///
     /// If the block couldn't be found, returns `None`.
-    fn pending_state_by_hash(&self, block_hash: B256) -> RethResult<Option<StateProviderBox<'_>>>;
+    fn pending_state_by_hash(
+        &self,
+        block_hash: B256,
+    ) -> ProviderResult<Option<StateProviderBox<'_>>>;
 
     /// Return a [StateProvider] that contains post state data provider.
     /// Used to inspect or execute transaction on the pending state.
     fn pending_with_provider(
         &self,
         post_state_data: Box<dyn BundleStateDataProvider>,
-    ) -> RethResult<StateProviderBox<'_>>;
+    ) -> ProviderResult<StateProviderBox<'_>>;
 }
 
 /// Blockchain trait provider that gives access to the blockchain state that is not yet committed
@@ -195,7 +198,7 @@ pub trait BlockchainTreePendingStateProvider: Send + Sync {
     fn pending_state_provider(
         &self,
         block_hash: BlockHash,
-    ) -> RethResult<Box<dyn BundleStateDataProvider>> {
+    ) -> ProviderResult<Box<dyn BundleStateDataProvider>> {
         Ok(self
             .find_pending_state_provider(block_hash)
             .ok_or(ProviderError::StateForHashNotFound(block_hash))?)
@@ -231,5 +234,5 @@ pub trait BundleStateDataProvider: Send + Sync {
 #[auto_impl[Box,&, Arc]]
 pub trait StateRootProvider: Send + Sync {
     /// Returns the state root of the BundleState on top of the current state.
-    fn state_root(&self, post_state: &BundleStateWithReceipts) -> RethResult<B256>;
+    fn state_root(&self, post_state: &BundleStateWithReceipts) -> ProviderResult<B256>;
 }

--- a/crates/storage/provider/src/traits/storage.rs
+++ b/crates/storage/provider/src/traits/storage.rs
@@ -4,23 +4,23 @@ use std::{
 };
 
 use auto_impl::auto_impl;
-use reth_interfaces::RethResult;
+use reth_interfaces::provider::ProviderResult;
 use reth_primitives::{Address, BlockNumber, StorageEntry, B256};
 
 /// Storage reader
 #[auto_impl(&, Arc, Box)]
 pub trait StorageReader: Send + Sync {
     /// Get plainstate storages for addresses and storage keys.
-    fn plainstate_storages(
+    fn plain_state_storages(
         &self,
         addresses_with_keys: impl IntoIterator<Item = (Address, impl IntoIterator<Item = B256>)>,
-    ) -> RethResult<Vec<(Address, Vec<StorageEntry>)>>;
+    ) -> ProviderResult<Vec<(Address, Vec<StorageEntry>)>>;
 
     /// Iterate over storage changesets and return all storage slots that were changed.
     fn changed_storages_with_range(
         &self,
         range: RangeInclusive<BlockNumber>,
-    ) -> RethResult<BTreeMap<Address, BTreeSet<B256>>>;
+    ) -> ProviderResult<BTreeMap<Address, BTreeSet<B256>>>;
 
     /// Iterate over storage changesets and return all storage slots that were changed alongside
     /// each specific set of blocks.
@@ -29,5 +29,5 @@ pub trait StorageReader: Send + Sync {
     fn changed_storages_and_blocks_with_range(
         &self,
         range: RangeInclusive<BlockNumber>,
-    ) -> RethResult<BTreeMap<(Address, B256), Vec<u64>>>;
+    ) -> ProviderResult<BTreeMap<(Address, B256), Vec<u64>>>;
 }

--- a/crates/storage/provider/src/traits/transactions.rs
+++ b/crates/storage/provider/src/traits/transactions.rs
@@ -1,5 +1,5 @@
 use crate::{BlockNumReader, BlockReader};
-use reth_interfaces::{provider::ProviderError, RethResult};
+use reth_interfaces::provider::{ProviderError, ProviderResult};
 use reth_primitives::{
     Address, BlockHashOrNumber, BlockNumber, TransactionMeta, TransactionSigned,
     TransactionSignedNoHash, TxHash, TxNumber,
@@ -13,55 +13,58 @@ pub trait TransactionsProvider: BlockNumReader + Send + Sync {
     ///
     /// This is the inverse of [TransactionsProvider::transaction_by_id].
     /// Returns None if the transaction is not found.
-    fn transaction_id(&self, tx_hash: TxHash) -> RethResult<Option<TxNumber>>;
+    fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>>;
 
     /// Get transaction by id, computes hash everytime so more expensive.
-    fn transaction_by_id(&self, id: TxNumber) -> RethResult<Option<TransactionSigned>>;
+    fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<TransactionSigned>>;
 
     /// Get transaction by id without computing the hash.
     fn transaction_by_id_no_hash(
         &self,
         id: TxNumber,
-    ) -> RethResult<Option<TransactionSignedNoHash>>;
+    ) -> ProviderResult<Option<TransactionSignedNoHash>>;
 
     /// Get transaction by transaction hash.
-    fn transaction_by_hash(&self, hash: TxHash) -> RethResult<Option<TransactionSigned>>;
+    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<TransactionSigned>>;
 
     /// Get transaction by transaction hash and additional metadata of the block the transaction was
     /// mined in
     fn transaction_by_hash_with_meta(
         &self,
         hash: TxHash,
-    ) -> RethResult<Option<(TransactionSigned, TransactionMeta)>>;
+    ) -> ProviderResult<Option<(TransactionSigned, TransactionMeta)>>;
 
     /// Get transaction block number
-    fn transaction_block(&self, id: TxNumber) -> RethResult<Option<BlockNumber>>;
+    fn transaction_block(&self, id: TxNumber) -> ProviderResult<Option<BlockNumber>>;
 
     /// Get transactions by block id.
     fn transactions_by_block(
         &self,
         block: BlockHashOrNumber,
-    ) -> RethResult<Option<Vec<TransactionSigned>>>;
+    ) -> ProviderResult<Option<Vec<TransactionSigned>>>;
 
     /// Get transactions by block range.
     fn transactions_by_block_range(
         &self,
         range: impl RangeBounds<BlockNumber>,
-    ) -> RethResult<Vec<Vec<TransactionSigned>>>;
+    ) -> ProviderResult<Vec<Vec<TransactionSigned>>>;
 
     /// Get transactions by tx range.
     fn transactions_by_tx_range(
         &self,
         range: impl RangeBounds<TxNumber>,
-    ) -> RethResult<Vec<TransactionSignedNoHash>>;
+    ) -> ProviderResult<Vec<TransactionSignedNoHash>>;
 
     /// Get Senders from a tx range.
-    fn senders_by_tx_range(&self, range: impl RangeBounds<TxNumber>) -> RethResult<Vec<Address>>;
+    fn senders_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Address>>;
 
     /// Get transaction sender.
     ///
     /// Returns None if the transaction is not found.
-    fn transaction_sender(&self, id: TxNumber) -> RethResult<Option<Address>>;
+    fn transaction_sender(&self, id: TxNumber) -> ProviderResult<Option<Address>>;
 }
 
 ///  Client trait for fetching additional [TransactionSigned] related data.
@@ -71,7 +74,7 @@ pub trait TransactionsProviderExt: BlockReader + Send + Sync {
     fn transaction_range_by_block_range(
         &self,
         block_range: RangeInclusive<BlockNumber>,
-    ) -> RethResult<RangeInclusive<TxNumber>> {
+    ) -> ProviderResult<RangeInclusive<TxNumber>> {
         let from = self
             .block_body_indices(*block_range.start())?
             .ok_or(ProviderError::BlockBodyIndicesNotFound(*block_range.start()))?
@@ -89,5 +92,5 @@ pub trait TransactionsProviderExt: BlockReader + Send + Sync {
     fn transaction_hashes_by_range(
         &self,
         tx_range: Range<TxNumber>,
-    ) -> RethResult<Vec<(TxHash, TxNumber)>>;
+    ) -> ProviderResult<Vec<(TxHash, TxNumber)>>;
 }

--- a/crates/storage/provider/src/traits/withdrawals.rs
+++ b/crates/storage/provider/src/traits/withdrawals.rs
@@ -1,4 +1,4 @@
-use reth_interfaces::RethResult;
+use reth_interfaces::provider::ProviderResult;
 use reth_primitives::{BlockHashOrNumber, Withdrawal};
 
 ///  Client trait for fetching [Withdrawal] related data.
@@ -9,8 +9,8 @@ pub trait WithdrawalsProvider: Send + Sync {
         &self,
         id: BlockHashOrNumber,
         timestamp: u64,
-    ) -> RethResult<Option<Vec<Withdrawal>>>;
+    ) -> ProviderResult<Option<Vec<Withdrawal>>>;
 
     /// Get latest withdrawal from this block or earlier .
-    fn latest_withdrawal(&self) -> RethResult<Option<Withdrawal>>;
+    fn latest_withdrawal(&self) -> ProviderResult<Option<Withdrawal>>;
 }

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -10,14 +10,13 @@ use futures_util::{
     future::{BoxFuture, Fuse, FusedFuture},
     FutureExt, Stream, StreamExt,
 };
-use reth_interfaces::RethError;
 use reth_primitives::{
     Address, BlockHash, BlockNumber, BlockNumberOrTag, FromRecoveredPooledTransaction,
     FromRecoveredTransaction, PooledTransactionsElementEcRecovered,
 };
 use reth_provider::{
     BlockReaderIdExt, BundleStateWithReceipts, CanonStateNotification, ChainSpecProvider,
-    StateProviderFactory,
+    ProviderError, StateProviderFactory,
 };
 use reth_tasks::TaskSpawner;
 use std::{
@@ -495,7 +494,7 @@ fn load_accounts<Client, I>(
     client: Client,
     at: BlockHash,
     addresses: I,
-) -> Result<LoadedAccounts, Box<(HashSet<Address>, RethError)>>
+) -> Result<LoadedAccounts, Box<(HashSet<Address>, ProviderError)>>
 where
     I: Iterator<Item = Address>,
 

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -78,17 +78,24 @@ impl Case for BlockchainTestCase {
             let provider = factory.provider_rw().unwrap();
 
             // Insert test state
-            provider.insert_block(
-                SealedBlock::new(case.genesis_block_header.clone().into(), BlockBody::default()),
-                None,
-                None,
-            )?;
+            provider
+                .insert_block(
+                    SealedBlock::new(
+                        case.genesis_block_header.clone().into(),
+                        BlockBody::default(),
+                    ),
+                    None,
+                    None,
+                )
+                .map_err(|err| Error::RethError(err.into()))?;
             case.pre.write_to_db(provider.tx_ref())?;
 
             let mut last_block = None;
             for block in case.blocks.iter() {
                 let decoded = SealedBlock::decode(&mut block.rlp.as_ref())?;
-                provider.insert_block(decoded.clone(), None, None)?;
+                provider
+                    .insert_block(decoded.clone(), None, None)
+                    .map_err(|err| Error::RethError(err.into()))?;
                 last_block = Some(decoded);
             }
 
@@ -118,11 +125,9 @@ impl Case for BlockchainTestCase {
                 // `insert_hashes` will insert hashed data, compute the state root and match it to
                 // expected internally
                 let last_block = last_block.unwrap_or_default();
-                provider.insert_hashes(
-                    0..=last_block.number,
-                    last_block.hash,
-                    expected_state_root,
-                )?;
+                provider
+                    .insert_hashes(0..=last_block.number, last_block.hash, expected_state_root)
+                    .map_err(|err| Error::RethError(err.into()))?;
             } else {
                 return Err(Error::MissingPostState)
             }


### PR DESCRIPTION
## Description

Providers must return a `ProviderError`. Otherwise, it is impossible to reuse them in other components without adding a large `RethError` variant.

The only other error variant that was ever returned by providers was `SenderRecoveryError` which is now added to `ProviderError`