### PR TITLE
feat: get rid of cursor lifetime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4008,15 +4008,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lifetimed-bytes"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c970c8ea4c7b023a41cfa4af4c785a16694604c2f2a3b0d1f20a9bcb73fa550"
-dependencies = [
- "bytes",
-]
-
-[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6027,7 +6018,6 @@ dependencies = [
  "derive_more",
  "indexmap 2.1.0",
  "libc",
- "lifetimed-bytes",
  "parking_lot 0.12.1",
  "pprof",
  "rand 0.8.5",

--- a/crates/stages/src/stages/mod.rs
+++ b/crates/stages/src/stages/mod.rs
@@ -166,7 +166,7 @@ mod tests {
                 assert!(acc_indexing_stage.execute(&provider, input).await.is_err());
             } else {
                 acc_indexing_stage.execute(&provider, input).await.unwrap();
-                let mut account_history: Cursor<'_, RW, AccountHistory> =
+                let mut account_history: Cursor<RW, AccountHistory> =
                     provider.tx_ref().cursor_read::<tables::AccountHistory>().unwrap();
                 assert_eq!(account_history.walk(None).unwrap().count(), expect_num_acc_changesets);
             }

--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -17,15 +17,15 @@ use crate::{
 use reth_libmdbx::{self, Error as MDBXError, TransactionKind, WriteFlags, RO, RW};
 
 /// Read only Cursor.
-pub type CursorRO<'tx, T> = Cursor<'tx, RO, T>;
+pub type CursorRO<T> = Cursor<RO, T>;
 /// Read write cursor.
-pub type CursorRW<'tx, T> = Cursor<'tx, RW, T>;
+pub type CursorRW<T> = Cursor<RW, T>;
 
 /// Cursor wrapper to access KV items.
 #[derive(Debug)]
-pub struct Cursor<'tx, K: TransactionKind, T: Table> {
+pub struct Cursor<K: TransactionKind, T: Table> {
     /// Inner `libmdbx` cursor.
-    pub(crate) inner: reth_libmdbx::Cursor<'tx, K>,
+    pub(crate) inner: reth_libmdbx::Cursor<K>,
     /// Cache buffer that receives compressed values.
     buf: Vec<u8>,
     /// Whether to record metrics or not.
@@ -34,11 +34,8 @@ pub struct Cursor<'tx, K: TransactionKind, T: Table> {
     _dbi: PhantomData<T>,
 }
 
-impl<'tx, K: TransactionKind, T: Table> Cursor<'tx, K, T> {
-    pub(crate) fn new_with_metrics(
-        inner: reth_libmdbx::Cursor<'tx, K>,
-        with_metrics: bool,
-    ) -> Self {
+impl<K: TransactionKind, T: Table> Cursor<K, T> {
+    pub(crate) fn new_with_metrics(inner: reth_libmdbx::Cursor<K>, with_metrics: bool) -> Self {
         Self { inner, buf: Vec::new(), with_metrics, _dbi: PhantomData }
     }
 
@@ -81,7 +78,7 @@ macro_rules! compress_to_buf_or_ref {
     };
 }
 
-impl<K: TransactionKind, T: Table> DbCursorRO<T> for Cursor<'_, K, T> {
+impl<K: TransactionKind, T: Table> DbCursorRO<T> for Cursor<K, T> {
     fn first(&mut self) -> PairResult<T> {
         decode!(self.inner.first())
     }
@@ -164,7 +161,7 @@ impl<K: TransactionKind, T: Table> DbCursorRO<T> for Cursor<'_, K, T> {
     }
 }
 
-impl<K: TransactionKind, T: DupSort> DbDupCursorRO<T> for Cursor<'_, K, T> {
+impl<K: TransactionKind, T: DupSort> DbDupCursorRO<T> for Cursor<K, T> {
     /// Returns the next `(key, value)` pair of a DUPSORT table.
     fn next_dup(&mut self) -> PairResult<T> {
         decode!(self.inner.next_dup())
@@ -245,7 +242,7 @@ impl<K: TransactionKind, T: DupSort> DbDupCursorRO<T> for Cursor<'_, K, T> {
     }
 }
 
-impl<T: Table> DbCursorRW<T> for Cursor<'_, RW, T> {
+impl<T: Table> DbCursorRW<T> for Cursor<RW, T> {
     /// Database operation that will update an existing row if a specified value already
     /// exists in a table, and insert a new row if the specified value doesn't already exist
     ///
@@ -328,7 +325,7 @@ impl<T: Table> DbCursorRW<T> for Cursor<'_, RW, T> {
     }
 }
 
-impl<T: DupSort> DbDupCursorRW<T> for Cursor<'_, RW, T> {
+impl<T: DupSort> DbDupCursorRW<T> for Cursor<RW, T> {
     fn delete_current_duplicates(&mut self) -> Result<(), DatabaseError> {
         self.execute_with_operation_metric(Operation::CursorDeleteCurrentDuplicates, None, |this| {
             this.inner.del(WriteFlags::NO_DUP_DATA).map_err(|e| DatabaseError::Delete(e.into()))

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -75,7 +75,7 @@ impl<K: TransactionKind> Tx<K> {
     }
 
     /// Create db Cursor
-    pub fn new_cursor<T: Table>(&self) -> Result<Cursor<'_, K, T>, DatabaseError> {
+    pub fn new_cursor<T: Table>(&self) -> Result<Cursor<K, T>, DatabaseError> {
         let inner = self
             .inner
             .cursor_with_dbi(self.get_dbi::<T>()?)
@@ -168,13 +168,13 @@ impl<K: TransactionKind> Drop for MetricsHandler<K> {
 }
 
 impl<'a, K: TransactionKind> DbTxGAT<'a> for Tx<K> {
-    type Cursor<T: Table> = Cursor<'a, K, T>;
-    type DupCursor<T: DupSort> = Cursor<'a, K, T>;
+    type Cursor<T: Table> = Cursor<K, T>;
+    type DupCursor<T: DupSort> = Cursor<K, T>;
 }
 
 impl<'a, K: TransactionKind> DbTxMutGAT<'a> for Tx<K> {
-    type CursorMut<T: Table> = Cursor<'a, RW, T>;
-    type DupCursorMut<T: DupSort> = Cursor<'a, RW, T>;
+    type CursorMut<T: Table> = Cursor<RW, T>;
+    type DupCursorMut<T: DupSort> = Cursor<RW, T>;
 }
 
 impl TableImporter for Tx<RW> {}

--- a/crates/storage/libmdbx-rs/Cargo.toml
+++ b/crates/storage/libmdbx-rs/Cargo.toml
@@ -22,8 +22,6 @@ thiserror.workspace = true
 
 ffi = { package = "reth-mdbx-sys", path = "./mdbx-sys" }
 
-lifetimed-bytes = { version = "0.1", optional = true }
-
 [features]
 default = []
 return-borrowed = []

--- a/crates/storage/libmdbx-rs/benches/cursor.rs
+++ b/crates/storage/libmdbx-rs/benches/cursor.rs
@@ -33,7 +33,7 @@ fn bench_get_seq_iter(c: &mut Criterion) {
                 count += 1;
             }
 
-            fn iterate<K: TransactionKind>(cursor: &mut Cursor<'_, K>) -> Result<()> {
+            fn iterate<K: TransactionKind>(cursor: &mut Cursor<K>) -> Result<()> {
                 let mut i = 0;
                 for result in cursor.iter::<ObjectLength, ObjectLength>() {
                     let (key_len, data_len) = result?;

--- a/crates/storage/libmdbx-rs/src/cursor.rs
+++ b/crates/storage/libmdbx-rs/src/cursor.rs
@@ -65,7 +65,7 @@ where
     /// Note: The lifetime ensures that the transaction is kept alive while entries are used
     #[allow(clippy::should_implement_trait)]
     pub fn into_iter<'cur>(self) -> IntoIter<'cur, K, Cow<'cur, [u8]>, Cow<'cur, [u8]>> {
-        IntoIter::new(Cow::Owned(self), MDBX_NEXT, MDBX_NEXT)
+        IntoIter::new(self, MDBX_NEXT, MDBX_NEXT)
     }
 
     /// Retrieves a key/data pair from the cursor. Depending on the cursor op,
@@ -518,7 +518,7 @@ where
     /// fails for some reason.
     Ok {
         /// The MDBX cursor with which to iterate.
-        cursor: Cow<'cur, Cursor<K>>,
+        cursor: Cursor<K>,
 
         /// The first operation to perform when the consumer calls [Iter::next()].
         op: ffi::MDBX_cursor_op,
@@ -537,11 +537,7 @@ where
     Value: TableObject,
 {
     /// Creates a new iterator backed by the given cursor.
-    fn new(
-        cursor: Cow<'cur, Cursor<K>>,
-        op: ffi::MDBX_cursor_op,
-        next_op: ffi::MDBX_cursor_op,
-    ) -> Self {
+    fn new(cursor: Cursor<K>, op: ffi::MDBX_cursor_op, next_op: ffi::MDBX_cursor_op) -> Self {
         IntoIter::Ok { cursor, op, next_op, _marker: Default::default() }
     }
 }
@@ -755,7 +751,7 @@ where
 
                     (err_code == ffi::MDBX_SUCCESS).then(|| {
                         IntoIter::new(
-                            Cow::Owned(Cursor::new_at_position(&**cursor).unwrap()),
+                            Cursor::new_at_position(&**cursor).unwrap(),
                             ffi::MDBX_GET_CURRENT,
                             ffi::MDBX_NEXT_DUP,
                         )

--- a/crates/storage/libmdbx-rs/src/cursor.rs
+++ b/crates/storage/libmdbx-rs/src/cursor.rs
@@ -60,11 +60,21 @@ where
         self.cursor
     }
 
-    /// Returns an Iterator over key value slices
+    /// Returns an Iterator over the raw key value slices
+    ///
+    /// Note: The lifetime ensures that the transaction is kept alive while entries are used
+    pub fn into_iter_slices<'cur>(self) -> IntoIter<'cur, K, Cow<'cur, [u8]>, Cow<'cur, [u8]>> {
+        self.into_iter()
+    }
+    /// Returns an Iterator over key value pairs of the cursor
     ///
     /// Note: The lifetime ensures that the transaction is kept alive while entries are used
     #[allow(clippy::should_implement_trait)]
-    pub fn into_iter<'cur>(self) -> IntoIter<'cur, K, Cow<'cur, [u8]>, Cow<'cur, [u8]>> {
+    pub fn into_iter<'cur, Key, Value>(self) -> IntoIter<'cur, K, Key, Value>
+    where
+        Key: TableObject,
+        Value: TableObject,
+    {
         IntoIter::new(self, MDBX_NEXT, MDBX_NEXT)
     }
 

--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -208,7 +208,7 @@ impl Environment {
         let db = Database::freelist_db();
         let cursor = txn.cursor(&db)?;
 
-        for result in cursor.into_iter() {
+        for result in cursor.into_iter_slices() {
             let (_key, value) = result?;
             if value.len() < size_of::<usize>() {
                 return Err(Error::Corrupted)

--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -208,7 +208,7 @@ impl Environment {
         let db = Database::freelist_db();
         let cursor = txn.cursor(&db)?;
 
-        for result in cursor {
+        for result in cursor.into_iter() {
             let (_key, value) = result?;
             if value.len() < size_of::<usize>() {
                 return Err(Error::Corrupted)

--- a/crates/storage/libmdbx-rs/src/transaction.rs
+++ b/crates/storage/libmdbx-rs/src/transaction.rs
@@ -107,11 +107,6 @@ where
         self.inner.txn_execute(f)
     }
 
-    /// Returns a copy of the pointer to the underlying MDBX transaction.
-    pub(crate) fn txn_ptr(&self) -> TransactionPtr {
-        self.inner.txn.clone()
-    }
-
     /// Returns a copy of the raw pointer to the underlying MDBX transaction.
     #[doc(hidden)]
     pub fn txn(&self) -> *mut ffi::MDBX_txn {
@@ -151,9 +146,9 @@ where
     /// returned. Retrieval of other items requires the use of
     /// [Cursor]. If the item is not in the database, then
     /// [None] will be returned.
-    pub fn get<'txn, Key>(&'txn self, dbi: ffi::MDBX_dbi, key: &[u8]) -> Result<Option<Key>>
+    pub fn get<Key>(&self, dbi: ffi::MDBX_dbi, key: &[u8]) -> Result<Option<Key>>
     where
-        Key: TableObject<'txn>,
+        Key: TableObject,
     {
         let key_val: ffi::MDBX_val =
             ffi::MDBX_val { iov_len: key.len(), iov_base: key.as_ptr() as *mut c_void };
@@ -257,13 +252,31 @@ where
     }
 
     /// Open a new cursor on the given database.
-    pub fn cursor(&self, db: &Database) -> Result<Cursor<'_, K>> {
-        Cursor::new(self, db.dbi())
+    pub fn cursor(&self, db: &Database) -> Result<Cursor<K>> {
+        Cursor::new(self.clone(), db.dbi())
     }
 
     /// Open a new cursor on the given dbi.
-    pub fn cursor_with_dbi(&self, dbi: ffi::MDBX_dbi) -> Result<Cursor<'_, K>> {
-        Cursor::new(self, dbi)
+    pub fn cursor_with_dbi(&self, dbi: ffi::MDBX_dbi) -> Result<Cursor<K>> {
+        Cursor::new(self.clone(), dbi)
+    }
+}
+
+impl<K> Clone for Transaction<K>
+where
+    K: TransactionKind,
+{
+    fn clone(&self) -> Self {
+        Self { inner: Arc::clone(&self.inner) }
+    }
+}
+
+impl<K> fmt::Debug for Transaction<K>
+where
+    K: TransactionKind,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RoTransaction").finish_non_exhaustive()
     }
 }
 
@@ -496,15 +509,6 @@ impl Transaction<RW> {
 
             rx.recv().unwrap().map(|ptr| Transaction::new_from_ptr(self.env().clone(), ptr.0))
         })
-    }
-}
-
-impl<K> fmt::Debug for Transaction<K>
-where
-    K: TransactionKind,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RoTransaction").finish_non_exhaustive()
     }
 }
 


### PR DESCRIPTION
removes the Cursor lifetime, this is last blocker for removing the lifetime from GATs entirely