### PR TITLE
feat(bin/node) : more health monitoring for consensus layer

### DIFF
--- a/bin/reth/src/node/cl_events.rs
+++ b/bin/reth/src/node/cl_events.rs
@@ -1,7 +1,7 @@
 //! Events related to Consensus Layer health.
 
 use futures::Stream;
-use log::{info, warn};
+use super::log::{info, warn};
 use reth_provider::CanonChainTracker;
 use std::{
     fmt,

--- a/bin/reth/src/node/cl_events.rs
+++ b/bin/reth/src/node/cl_events.rs
@@ -104,6 +104,8 @@ impl Stream for ConsensusLayerHealthEvents {
         if let Some(event) = health_event {
             self.report_health_status(&event);
             return Poll::Ready(Some(event));
+        } else {
+            Poll::Pending
         }
     }
 }


### PR DESCRIPTION
- added a method called  `report_health_status` to log health events of the consensus layer. It is supposed to be more helpful for monitoring and maintenance  of the consensus layer


edit : going to open another pr for this, i don't know why clippy doesn't have error in my pc