### PR TITLE
feat: get rid of lifetime GATs

### DIFF
--- a/bin/reth/src/db/snapshots/bench.rs
+++ b/bin/reth/src/db/snapshots/bench.rs
@@ -25,7 +25,7 @@ pub(crate) fn bench<F1, F2, R>(
 ) -> eyre::Result<()>
 where
     F1: FnMut() -> eyre::Result<R>,
-    F2: Fn(DatabaseProviderRO<'_, DatabaseEnv>) -> eyre::Result<R>,
+    F2: Fn(DatabaseProviderRO<DatabaseEnv>) -> eyre::Result<R>,
     R: Debug + PartialEq,
 {
     let (db, chain) = db;

--- a/bin/reth/src/db/snapshots/headers.rs
+++ b/bin/reth/src/db/snapshots/headers.rs
@@ -22,7 +22,7 @@ use std::{
 impl Command {
     pub(crate) fn generate_headers_snapshot<DB: Database>(
         &self,
-        provider: &DatabaseProviderRO<'_, DB>,
+        provider: &DatabaseProviderRO<DB>,
         compression: Compression,
         inclusion_filter: InclusionFilter,
         phf: PerfectHashingFunction,

--- a/bin/reth/src/db/snapshots/receipts.rs
+++ b/bin/reth/src/db/snapshots/receipts.rs
@@ -22,7 +22,7 @@ use std::{
 impl Command {
     pub(crate) fn generate_receipts_snapshot<DB: Database>(
         &self,
-        provider: &DatabaseProviderRO<'_, DB>,
+        provider: &DatabaseProviderRO<DB>,
         compression: Compression,
         inclusion_filter: InclusionFilter,
         phf: PerfectHashingFunction,

--- a/bin/reth/src/db/snapshots/transactions.rs
+++ b/bin/reth/src/db/snapshots/transactions.rs
@@ -22,7 +22,7 @@ use std::{
 impl Command {
     pub(crate) fn generate_transactions_snapshot<DB: Database>(
         &self,
-        provider: &DatabaseProviderRO<'_, DB>,
+        provider: &DatabaseProviderRO<DB>,
         compression: Compression,
         inclusion_filter: InclusionFilter,
         phf: PerfectHashingFunction,

--- a/bin/reth/src/init.rs
+++ b/bin/reth/src/init.rs
@@ -1,7 +1,7 @@
 //! Reth genesis initialization utility functions.
 use reth_db::{
     cursor::DbCursorRO,
-    database::{Database, DatabaseGAT},
+    database::Database,
     tables,
     transaction::{DbTx, DbTxMut},
 };
@@ -94,7 +94,7 @@ pub fn init_genesis<DB: Database>(
 
 /// Inserts the genesis state into the database.
 pub fn insert_genesis_state<DB: Database>(
-    tx: &<DB as DatabaseGAT<'_>>::TXMut,
+    tx: &<DB as Database>::TXMut,
     genesis: &reth_primitives::Genesis,
 ) -> ProviderResult<()> {
     let mut state_init: BundleStateInit = HashMap::new();
@@ -160,7 +160,7 @@ pub fn insert_genesis_state<DB: Database>(
 
 /// Inserts hashes for the genesis state.
 pub fn insert_genesis_hashes<DB: Database>(
-    provider: &DatabaseProviderRW<'_, &DB>,
+    provider: &DatabaseProviderRW<&DB>,
     genesis: &reth_primitives::Genesis,
 ) -> ProviderResult<()> {
     // insert and hash accounts to hashing table
@@ -184,7 +184,7 @@ pub fn insert_genesis_hashes<DB: Database>(
 
 /// Inserts history indices for genesis accounts and storage.
 pub fn insert_genesis_history<DB: Database>(
-    provider: &DatabaseProviderRW<'_, &DB>,
+    provider: &DatabaseProviderRW<&DB>,
     genesis: &reth_primitives::Genesis,
 ) -> ProviderResult<()> {
     let account_transitions =
@@ -204,7 +204,7 @@ pub fn insert_genesis_history<DB: Database>(
 
 /// Inserts header for the genesis state.
 pub fn insert_genesis_header<DB: Database>(
-    tx: &<DB as DatabaseGAT<'_>>::TXMut,
+    tx: &<DB as Database>::TXMut,
     chain: Arc<ChainSpec>,
 ) -> ProviderResult<()> {
     let header = chain.sealed_genesis_header();
@@ -236,7 +236,7 @@ mod tests {
 
     #[allow(clippy::type_complexity)]
     fn collect_table_entries<DB, T>(
-        tx: &<DB as DatabaseGAT<'_>>::TX,
+        tx: &<DB as Database>::TX,
     ) -> Result<Vec<TableRow<T>>, InitDatabaseError>
     where
         DB: Database,

--- a/crates/prune/src/segments/account_history.rs
+++ b/crates/prune/src/segments/account_history.rs
@@ -32,7 +32,7 @@ impl<DB: Database> Segment<DB> for AccountHistory {
     #[instrument(level = "trace", target = "pruner", skip(self, provider), ret)]
     fn prune(
         &self,
-        provider: &DatabaseProviderRW<'_, DB>,
+        provider: &DatabaseProviderRW<DB>,
         input: PruneInput,
     ) -> Result<PruneOutput, PrunerError> {
         let range = match input.get_next_block_range() {

--- a/crates/prune/src/segments/headers.rs
+++ b/crates/prune/src/segments/headers.rs
@@ -33,7 +33,7 @@ impl<DB: Database> Segment<DB> for Headers {
     #[instrument(level = "trace", target = "pruner", skip(self, provider), ret)]
     fn prune(
         &self,
-        provider: &DatabaseProviderRW<'_, DB>,
+        provider: &DatabaseProviderRW<DB>,
         input: PruneInput,
     ) -> Result<PruneOutput, PrunerError> {
         let block_range = match input.get_next_block_range() {
@@ -91,7 +91,7 @@ impl Headers {
     /// Returns `done`, number of pruned rows and last pruned block number.
     fn prune_table<DB: Database, T: Table<Key = BlockNumber>>(
         &self,
-        provider: &DatabaseProviderRW<'_, DB>,
+        provider: &DatabaseProviderRW<DB>,
         range: RangeInclusive<BlockNumber>,
         delete_limit: usize,
     ) -> RethResult<(bool, usize, BlockNumber)> {

--- a/crates/prune/src/segments/history.rs
+++ b/crates/prune/src/segments/history.rs
@@ -14,7 +14,7 @@ use reth_provider::DatabaseProviderRW;
 ///
 /// Returns total number of processed (walked) and deleted entities.
 pub(crate) fn prune_history_indices<DB, T, SK>(
-    provider: &DatabaseProviderRW<'_, DB>,
+    provider: &DatabaseProviderRW<DB>,
     to_block: BlockNumber,
     key_matches: impl Fn(&T::Key, &T::Key) -> bool,
     last_key: impl Fn(&T::Key) -> T::Key,

--- a/crates/prune/src/segments/mod.rs
+++ b/crates/prune/src/segments/mod.rs
@@ -45,14 +45,14 @@ pub trait Segment<DB: Database>: Debug + Send + Sync {
     /// Prune data for [Self::segment] using the provided input.
     fn prune(
         &self,
-        provider: &DatabaseProviderRW<'_, DB>,
+        provider: &DatabaseProviderRW<DB>,
         input: PruneInput,
     ) -> Result<PruneOutput, PrunerError>;
 
     /// Save checkpoint for [Self::segment] to the database.
     fn save_checkpoint(
         &self,
-        provider: &DatabaseProviderRW<'_, DB>,
+        provider: &DatabaseProviderRW<DB>,
         checkpoint: PruneCheckpoint,
     ) -> ProviderResult<()> {
         provider.save_prune_checkpoint(self.segment(), checkpoint)
@@ -80,7 +80,7 @@ impl PruneInput {
     /// To get the range end: get last tx number for `to_block`.
     pub(crate) fn get_next_tx_num_range<DB: Database>(
         &self,
-        provider: &DatabaseProviderRW<'_, DB>,
+        provider: &DatabaseProviderRW<DB>,
     ) -> RethResult<Option<RangeInclusive<TxNumber>>> {
         let from_tx_number = self.previous_checkpoint
             // Checkpoint exists, prune from the next transaction after the highest pruned one

--- a/crates/prune/src/segments/receipts.rs
+++ b/crates/prune/src/segments/receipts.rs
@@ -31,7 +31,7 @@ impl<DB: Database> Segment<DB> for Receipts {
     #[instrument(level = "trace", target = "pruner", skip(self, provider), ret)]
     fn prune(
         &self,
-        provider: &DatabaseProviderRW<'_, DB>,
+        provider: &DatabaseProviderRW<DB>,
         input: PruneInput,
     ) -> Result<PruneOutput, PrunerError> {
         let tx_range = match input.get_next_tx_num_range(provider)? {
@@ -71,7 +71,7 @@ impl<DB: Database> Segment<DB> for Receipts {
 
     fn save_checkpoint(
         &self,
-        provider: &DatabaseProviderRW<'_, DB>,
+        provider: &DatabaseProviderRW<DB>,
         checkpoint: PruneCheckpoint,
     ) -> ProviderResult<()> {
         provider.save_prune_checkpoint(PruneSegment::Receipts, checkpoint)?;

--- a/crates/prune/src/segments/receipts_by_logs.rs
+++ b/crates/prune/src/segments/receipts_by_logs.rs
@@ -32,7 +32,7 @@ impl<DB: Database> Segment<DB> for ReceiptsByLogs {
     #[instrument(level = "trace", target = "pruner", skip(self, provider), ret)]
     fn prune(
         &self,
-        provider: &DatabaseProviderRW<'_, DB>,
+        provider: &DatabaseProviderRW<DB>,
         input: PruneInput,
     ) -> Result<PruneOutput, PrunerError> {
         // Contract log filtering removes every receipt possible except the ones in the list. So,

--- a/crates/prune/src/segments/sender_recovery.rs
+++ b/crates/prune/src/segments/sender_recovery.rs
@@ -30,7 +30,7 @@ impl<DB: Database> Segment<DB> for SenderRecovery {
     #[instrument(level = "trace", target = "pruner", skip(self, provider), ret)]
     fn prune(
         &self,
-        provider: &DatabaseProviderRW<'_, DB>,
+        provider: &DatabaseProviderRW<DB>,
         input: PruneInput,
     ) -> Result<PruneOutput, PrunerError> {
         let tx_range = match input.get_next_tx_num_range(provider)? {

--- a/crates/prune/src/segments/storage_history.rs
+++ b/crates/prune/src/segments/storage_history.rs
@@ -36,7 +36,7 @@ impl<DB: Database> Segment<DB> for StorageHistory {
     #[instrument(level = "trace", target = "pruner", skip(self, provider), ret)]
     fn prune(
         &self,
-        provider: &DatabaseProviderRW<'_, DB>,
+        provider: &DatabaseProviderRW<DB>,
         input: PruneInput,
     ) -> Result<PruneOutput, PrunerError> {
         let range = match input.get_next_block_range() {

--- a/crates/prune/src/segments/transaction_lookup.rs
+++ b/crates/prune/src/segments/transaction_lookup.rs
@@ -31,7 +31,7 @@ impl<DB: Database> Segment<DB> for TransactionLookup {
     #[instrument(level = "trace", target = "pruner", skip(self, provider), ret)]
     fn prune(
         &self,
-        provider: &DatabaseProviderRW<'_, DB>,
+        provider: &DatabaseProviderRW<DB>,
         input: PruneInput,
     ) -> Result<PruneOutput, PrunerError> {
         let (start, end) = match input.get_next_tx_num_range(provider)? {

--- a/crates/prune/src/segments/transactions.rs
+++ b/crates/prune/src/segments/transactions.rs
@@ -30,7 +30,7 @@ impl<DB: Database> Segment<DB> for Transactions {
     #[instrument(level = "trace", target = "pruner", skip(self, provider), ret)]
     fn prune(
         &self,
-        provider: &DatabaseProviderRW<'_, DB>,
+        provider: &DatabaseProviderRW<DB>,
         input: PruneInput,
     ) -> Result<PruneOutput, PrunerError> {
         let tx_range = match input.get_next_tx_num_range(provider)? {

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -458,7 +458,7 @@ where
         opts: GethDebugTracingOptions,
         env: Env,
         at: BlockId,
-        db: &mut SubState<StateProviderBox<'_>>,
+        db: &mut SubState<StateProviderBox>,
     ) -> EthResult<(GethTrace, revm_primitives::State)> {
         let GethDebugTracingOptions { config, tracer, tracer_config, .. } = opts;
 

--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -206,7 +206,7 @@ where
     /// Returns the state at the given [BlockId] enum.
     ///
     /// Note: if not [BlockNumberOrTag::Pending] then this will only return canonical state. See also <https://github.com/paradigmxyz/reth/issues/4515>
-    pub fn state_at_block_id(&self, at: BlockId) -> EthResult<StateProviderBox<'_>> {
+    pub fn state_at_block_id(&self, at: BlockId) -> EthResult<StateProviderBox> {
         Ok(self.provider().state_by_block_id(at)?)
     }
 
@@ -216,7 +216,7 @@ where
     pub fn state_at_block_id_or_latest(
         &self,
         block_id: Option<BlockId>,
-    ) -> EthResult<StateProviderBox<'_>> {
+    ) -> EthResult<StateProviderBox> {
         if let Some(block_id) = block_id {
             self.state_at_block_id(block_id)
         } else {
@@ -225,12 +225,12 @@ where
     }
 
     /// Returns the state at the given block number
-    pub fn state_at_hash(&self, block_hash: B256) -> RethResult<StateProviderBox<'_>> {
+    pub fn state_at_hash(&self, block_hash: B256) -> RethResult<StateProviderBox> {
         Ok(self.provider().history_by_block_hash(block_hash)?)
     }
 
     /// Returns the _latest_ state
-    pub fn latest_state(&self) -> RethResult<StateProviderBox<'_>> {
+    pub fn latest_state(&self) -> RethResult<StateProviderBox> {
         Ok(self.provider().latest()?)
     }
 }

--- a/crates/snapshot/src/segments/headers.rs
+++ b/crates/snapshot/src/segments/headers.rs
@@ -37,7 +37,7 @@ impl Segment for Headers {
 
     fn snapshot<DB: Database>(
         &self,
-        provider: &DatabaseProviderRO<'_, DB>,
+        provider: &DatabaseProviderRO<DB>,
         directory: impl AsRef<Path>,
         range: RangeInclusive<BlockNumber>,
     ) -> ProviderResult<()> {

--- a/crates/snapshot/src/segments/mod.rs
+++ b/crates/snapshot/src/segments/mod.rs
@@ -31,7 +31,7 @@ pub trait Segment: Default {
     /// file's save location.
     fn snapshot<DB: Database>(
         &self,
-        provider: &DatabaseProviderRO<'_, DB>,
+        provider: &DatabaseProviderRO<DB>,
         directory: impl AsRef<Path>,
         range: RangeInclusive<BlockNumber>,
     ) -> ProviderResult<()>;
@@ -42,7 +42,7 @@ pub trait Segment: Default {
     /// Generates the dataset to train a zstd dictionary with the most recent rows (at most 1000).
     fn dataset_for_compression<DB: Database, T: Table<Key = u64>>(
         &self,
-        provider: &DatabaseProviderRO<'_, DB>,
+        provider: &DatabaseProviderRO<DB>,
         range: &RangeInclusive<u64>,
         range_len: usize,
     ) -> ProviderResult<Vec<Vec<u8>>> {
@@ -58,7 +58,7 @@ pub trait Segment: Default {
 /// Returns a [`NippyJar`] according to the desired configuration. The `directory` parameter
 /// determines the snapshot file's save location.
 pub(crate) fn prepare_jar<DB: Database, const COLUMNS: usize>(
-    provider: &DatabaseProviderRO<'_, DB>,
+    provider: &DatabaseProviderRO<DB>,
     directory: impl AsRef<Path>,
     segment: SnapshotSegment,
     segment_config: SegmentConfig,

--- a/crates/snapshot/src/segments/receipts.rs
+++ b/crates/snapshot/src/segments/receipts.rs
@@ -34,7 +34,7 @@ impl Segment for Receipts {
 
     fn snapshot<DB: Database>(
         &self,
-        provider: &DatabaseProviderRO<'_, DB>,
+        provider: &DatabaseProviderRO<DB>,
         directory: impl AsRef<Path>,
         block_range: RangeInclusive<BlockNumber>,
     ) -> ProviderResult<()> {

--- a/crates/snapshot/src/segments/transactions.rs
+++ b/crates/snapshot/src/segments/transactions.rs
@@ -34,7 +34,7 @@ impl Segment for Transactions {
 
     fn snapshot<DB: Database>(
         &self,
-        provider: &DatabaseProviderRO<'_, DB>,
+        provider: &DatabaseProviderRO<DB>,
         directory: impl AsRef<Path>,
         block_range: RangeInclusive<BlockNumber>,
     ) -> ProviderResult<()> {

--- a/crates/snapshot/src/snapshotter.rs
+++ b/crates/snapshot/src/snapshotter.rs
@@ -291,7 +291,7 @@ impl<DB: Database> Snapshotter<DB> {
 
     fn get_snapshot_target_tx_range(
         &self,
-        provider: &DatabaseProviderRO<'_, DB>,
+        provider: &DatabaseProviderRO<DB>,
         block_to_tx_number_cache: &mut HashMap<BlockNumber, TxNumber>,
         highest_snapshot: Option<BlockNumber>,
         block_range: &RangeInclusive<BlockNumber>,

--- a/crates/stages/src/stage.rs
+++ b/crates/stages/src/stage.rs
@@ -76,7 +76,7 @@ impl ExecInput {
     /// the number of transactions exceeds the threshold.
     pub fn next_block_range_with_transaction_threshold<DB: Database>(
         &self,
-        provider: &DatabaseProviderRW<'_, DB>,
+        provider: &DatabaseProviderRW<DB>,
         tx_threshold: u64,
     ) -> Result<(Range<TxNumber>, RangeInclusive<BlockNumber>, bool), StageError> {
         let start_block = self.next_block();
@@ -234,14 +234,14 @@ pub trait Stage<DB: Database>: Send + Sync {
     /// upon invoking this method.
     fn execute(
         &mut self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        provider: &DatabaseProviderRW<&DB>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError>;
 
     /// Unwind the stage.
     fn unwind(
         &mut self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        provider: &DatabaseProviderRW<&DB>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError>;
 }

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -98,7 +98,7 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
     /// header, limited by the stage's batch size.
     fn execute(
         &mut self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        provider: &DatabaseProviderRW<&DB>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         if input.target_reached() {
@@ -185,7 +185,7 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
     /// Unwind the stage.
     fn unwind(
         &mut self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        provider: &DatabaseProviderRW<&DB>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         self.buffer.take();
@@ -245,7 +245,7 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
 //  beforehand how many bytes we need to download. So the good solution would be to measure the
 //  progress in gas as a proxy to size. Execution stage uses a similar approach.
 fn stage_checkpoint<DB: Database>(
-    provider: &DatabaseProviderRW<'_, DB>,
+    provider: &DatabaseProviderRW<DB>,
 ) -> Result<EntitiesCheckpoint, DatabaseError> {
     Ok(EntitiesCheckpoint {
         processed: provider.tx_ref().entries::<tables::BlockBodyIndices>()? as u64,

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -110,7 +110,7 @@ impl<EF: ExecutorFactory> ExecutionStage<EF> {
     /// Execute the stage.
     pub fn execute_inner<DB: Database>(
         &mut self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        provider: &DatabaseProviderRW<&DB>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         if input.target_reached() {
@@ -228,7 +228,7 @@ impl<EF: ExecutorFactory> ExecutionStage<EF> {
     /// been previously executed.
     fn adjust_prune_modes<DB: Database>(
         &self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        provider: &DatabaseProviderRW<&DB>,
         start_block: u64,
         max_block: u64,
     ) -> Result<PruneModes, StageError> {
@@ -247,7 +247,7 @@ impl<EF: ExecutorFactory> ExecutionStage<EF> {
 }
 
 fn execution_checkpoint<DB: Database>(
-    provider: &DatabaseProviderRW<'_, &DB>,
+    provider: &DatabaseProviderRW<&DB>,
     start_block: BlockNumber,
     max_block: BlockNumber,
     checkpoint: StageCheckpoint,
@@ -314,7 +314,7 @@ fn execution_checkpoint<DB: Database>(
 }
 
 fn calculate_gas_used_from_headers<DB: Database>(
-    provider: &DatabaseProviderRW<'_, &DB>,
+    provider: &DatabaseProviderRW<&DB>,
     range: RangeInclusive<BlockNumber>,
 ) -> Result<u64, DatabaseError> {
     let mut gas_total = 0;
@@ -340,7 +340,7 @@ impl<EF: ExecutorFactory, DB: Database> Stage<DB> for ExecutionStage<EF> {
     /// Execute the stage
     fn execute(
         &mut self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        provider: &DatabaseProviderRW<&DB>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         self.execute_inner(provider, input)
@@ -349,7 +349,7 @@ impl<EF: ExecutorFactory, DB: Database> Stage<DB> for ExecutionStage<EF> {
     /// Unwind the stage.
     fn unwind(
         &mut self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        provider: &DatabaseProviderRW<&DB>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         let tx = provider.tx_ref();

--- a/crates/stages/src/stages/finish.rs
+++ b/crates/stages/src/stages/finish.rs
@@ -18,7 +18,7 @@ impl<DB: Database> Stage<DB> for FinishStage {
 
     fn execute(
         &mut self,
-        _provider: &DatabaseProviderRW<'_, &DB>,
+        _provider: &DatabaseProviderRW<&DB>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         Ok(ExecOutput { checkpoint: StageCheckpoint::new(input.target()), done: true })
@@ -26,7 +26,7 @@ impl<DB: Database> Stage<DB> for FinishStage {
 
     fn unwind(
         &mut self,
-        _provider: &DatabaseProviderRW<'_, &DB>,
+        _provider: &DatabaseProviderRW<&DB>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         Ok(UnwindOutput { checkpoint: StageCheckpoint::new(input.unwind_to) })

--- a/crates/stages/src/stages/hashing_account.rs
+++ b/crates/stages/src/stages/hashing_account.rs
@@ -79,7 +79,7 @@ impl AccountHashingStage {
     /// Proceeds to go to the `BlockTransitionIndex` end, go back `transitions` and change the
     /// account state in the `AccountChangeSet` table.
     pub fn seed<DB: Database>(
-        provider: &DatabaseProviderRW<'_, DB>,
+        provider: &DatabaseProviderRW<DB>,
         opts: SeedOpts,
     ) -> Result<Vec<(reth_primitives::Address, reth_primitives::Account)>, StageError> {
         use reth_db::models::AccountBeforeTx;
@@ -134,7 +134,7 @@ impl<DB: Database> Stage<DB> for AccountHashingStage {
     /// Execute the stage.
     fn execute(
         &mut self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        provider: &DatabaseProviderRW<&DB>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         if input.target_reached() {
@@ -266,7 +266,7 @@ impl<DB: Database> Stage<DB> for AccountHashingStage {
     /// Unwind the stage.
     fn unwind(
         &mut self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        provider: &DatabaseProviderRW<&DB>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         let (range, unwind_progress, _) =
@@ -288,7 +288,7 @@ impl<DB: Database> Stage<DB> for AccountHashingStage {
 }
 
 fn stage_checkpoint_progress<DB: Database>(
-    provider: &DatabaseProviderRW<'_, &DB>,
+    provider: &DatabaseProviderRW<&DB>,
 ) -> Result<EntitiesCheckpoint, DatabaseError> {
     Ok(EntitiesCheckpoint {
         processed: provider.tx_ref().entries::<tables::HashedAccount>()? as u64,

--- a/crates/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/src/stages/hashing_storage.rs
@@ -53,7 +53,7 @@ impl<DB: Database> Stage<DB> for StorageHashingStage {
     /// Execute the stage.
     fn execute(
         &mut self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        provider: &DatabaseProviderRW<&DB>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         let tx = provider.tx_ref();
@@ -192,7 +192,7 @@ impl<DB: Database> Stage<DB> for StorageHashingStage {
     /// Unwind the stage.
     fn unwind(
         &mut self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        provider: &DatabaseProviderRW<&DB>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         let (range, unwind_progress, _) =
@@ -213,7 +213,7 @@ impl<DB: Database> Stage<DB> for StorageHashingStage {
 }
 
 fn stage_checkpoint_progress<DB: Database>(
-    provider: &DatabaseProviderRW<'_, &DB>,
+    provider: &DatabaseProviderRW<&DB>,
 ) -> Result<EntitiesCheckpoint, DatabaseError> {
     Ok(EntitiesCheckpoint {
         processed: provider.tx_ref().entries::<tables::HashedStorage>()? as u64,

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -2,7 +2,7 @@ use crate::{ExecInput, ExecOutput, Stage, StageError, UnwindInput, UnwindOutput}
 use futures_util::StreamExt;
 use reth_db::{
     cursor::{DbCursorRO, DbCursorRW},
-    database::{Database, DatabaseGAT},
+    database::Database,
     tables,
     transaction::{DbTx, DbTxMut},
 };
@@ -60,7 +60,7 @@ where
 
     fn is_stage_done<DB: Database>(
         &self,
-        tx: &<DB as DatabaseGAT<'_>>::TXMut,
+        tx: &<DB as Database>::TXMut,
         checkpoint: u64,
     ) -> Result<bool, StageError> {
         let mut header_cursor = tx.cursor_read::<tables::CanonicalHeaders>()?;
@@ -76,7 +76,7 @@ where
     /// Note: this writes the headers with rising block numbers.
     fn write_headers<DB: Database>(
         &self,
-        tx: &<DB as DatabaseGAT<'_>>::TXMut,
+        tx: &<DB as Database>::TXMut,
         headers: Vec<SealedHeader>,
     ) -> Result<Option<BlockNumber>, StageError> {
         trace!(target: "sync::stages::headers", len = headers.len(), "writing headers");
@@ -176,7 +176,7 @@ where
     /// starting from the tip of the chain
     fn execute(
         &mut self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        provider: &DatabaseProviderRW<&DB>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         let current_checkpoint = input.checkpoint();
@@ -279,7 +279,7 @@ where
     /// Unwind the stage.
     fn unwind(
         &mut self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        provider: &DatabaseProviderRW<&DB>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         self.buffer.take();

--- a/crates/stages/src/stages/index_account_history.rs
+++ b/crates/stages/src/stages/index_account_history.rs
@@ -44,7 +44,7 @@ impl<DB: Database> Stage<DB> for IndexAccountHistoryStage {
     /// Execute the stage.
     fn execute(
         &mut self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        provider: &DatabaseProviderRW<&DB>,
         mut input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         if let Some((target_prunable_block, prune_mode)) = self
@@ -87,7 +87,7 @@ impl<DB: Database> Stage<DB> for IndexAccountHistoryStage {
     /// Unwind the stage.
     fn unwind(
         &mut self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        provider: &DatabaseProviderRW<&DB>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         let (range, unwind_progress, _) =

--- a/crates/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/src/stages/index_storage_history.rs
@@ -43,7 +43,7 @@ impl<DB: Database> Stage<DB> for IndexStorageHistoryStage {
     /// Execute the stage.
     fn execute(
         &mut self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        provider: &DatabaseProviderRW<&DB>,
         mut input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         if let Some((target_prunable_block, prune_mode)) = self
@@ -85,7 +85,7 @@ impl<DB: Database> Stage<DB> for IndexStorageHistoryStage {
     /// Unwind the stage.
     fn unwind(
         &mut self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        provider: &DatabaseProviderRW<&DB>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         let (range, unwind_progress, _) =

--- a/crates/stages/src/stages/merkle.rs
+++ b/crates/stages/src/stages/merkle.rs
@@ -80,7 +80,7 @@ impl MerkleStage {
     /// Gets the hashing progress
     pub fn get_execution_checkpoint<DB: Database>(
         &self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        provider: &DatabaseProviderRW<&DB>,
     ) -> Result<Option<MerkleCheckpoint>, StageError> {
         let buf =
             provider.get_stage_checkpoint_progress(StageId::MerkleExecute)?.unwrap_or_default();
@@ -96,7 +96,7 @@ impl MerkleStage {
     /// Saves the hashing progress
     pub fn save_execution_checkpoint<DB: Database>(
         &mut self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        provider: &DatabaseProviderRW<&DB>,
         checkpoint: Option<MerkleCheckpoint>,
     ) -> Result<(), StageError> {
         let mut buf = vec![];
@@ -127,7 +127,7 @@ impl<DB: Database> Stage<DB> for MerkleStage {
     /// Execute the stage.
     fn execute(
         &mut self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        provider: &DatabaseProviderRW<&DB>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         let threshold = match self {
@@ -261,7 +261,7 @@ impl<DB: Database> Stage<DB> for MerkleStage {
     /// Unwind the stage.
     fn unwind(
         &mut self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        provider: &DatabaseProviderRW<&DB>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         let tx = provider.tx_ref();

--- a/crates/stages/src/stages/mod.rs
+++ b/crates/stages/src/stages/mod.rs
@@ -124,7 +124,7 @@ mod tests {
                              expect_num_receipts: usize,
                              expect_num_acc_changesets: usize,
                              expect_num_storage_changesets: usize| async move {
-            let provider: DatabaseProviderRW<'_, &DatabaseEnv> = factory.provider_rw().unwrap();
+            let provider: DatabaseProviderRW<&DatabaseEnv> = factory.provider_rw().unwrap();
 
             // Check execution and create receipts and changesets according to the pruning
             // configuration

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -56,7 +56,7 @@ impl<DB: Database> Stage<DB> for SenderRecoveryStage {
     /// the [`TxSenders`][reth_db::tables::TxSenders] table.
     fn execute(
         &mut self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        provider: &DatabaseProviderRW<&DB>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         if input.target_reached() {
@@ -168,7 +168,7 @@ impl<DB: Database> Stage<DB> for SenderRecoveryStage {
     /// Unwind the stage.
     fn unwind(
         &mut self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        provider: &DatabaseProviderRW<&DB>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         let (_, unwind_to, _) = input.unwind_block_range_with_threshold(self.commit_threshold);
@@ -207,7 +207,7 @@ fn recover_sender(
 }
 
 fn stage_checkpoint<DB: Database>(
-    provider: &DatabaseProviderRW<'_, &DB>,
+    provider: &DatabaseProviderRW<&DB>,
 ) -> Result<EntitiesCheckpoint, StageError> {
     let pruned_entries = provider
         .get_prune_checkpoint(PruneSegment::SenderRecovery)?

--- a/crates/stages/src/stages/total_difficulty.rs
+++ b/crates/stages/src/stages/total_difficulty.rs
@@ -50,7 +50,7 @@ impl<DB: Database> Stage<DB> for TotalDifficultyStage {
     /// Write total difficulty entries
     fn execute(
         &mut self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        provider: &DatabaseProviderRW<&DB>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         let tx = provider.tx_ref();
@@ -100,7 +100,7 @@ impl<DB: Database> Stage<DB> for TotalDifficultyStage {
     /// Unwind the stage.
     fn unwind(
         &mut self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        provider: &DatabaseProviderRW<&DB>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         let (_, unwind_to, _) = input.unwind_block_range_with_threshold(self.commit_threshold);
@@ -115,7 +115,7 @@ impl<DB: Database> Stage<DB> for TotalDifficultyStage {
 }
 
 fn stage_checkpoint<DB: Database>(
-    provider: &DatabaseProviderRW<'_, DB>,
+    provider: &DatabaseProviderRW<DB>,
 ) -> Result<EntitiesCheckpoint, DatabaseError> {
     Ok(EntitiesCheckpoint {
         processed: provider.tx_ref().entries::<tables::HeaderTD>()? as u64,

--- a/crates/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/src/stages/tx_lookup.rs
@@ -51,7 +51,7 @@ impl<DB: Database> Stage<DB> for TransactionLookupStage {
     /// Write transaction hash -> id entries
     fn execute(
         &mut self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        provider: &DatabaseProviderRW<&DB>,
         mut input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         if let Some((target_prunable_block, prune_mode)) = self
@@ -129,7 +129,7 @@ impl<DB: Database> Stage<DB> for TransactionLookupStage {
     /// Unwind the stage.
     fn unwind(
         &mut self,
-        provider: &DatabaseProviderRW<'_, &DB>,
+        provider: &DatabaseProviderRW<&DB>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         let tx = provider.tx_ref();
@@ -164,7 +164,7 @@ impl<DB: Database> Stage<DB> for TransactionLookupStage {
 }
 
 fn stage_checkpoint<DB: Database>(
-    provider: &DatabaseProviderRW<'_, &DB>,
+    provider: &DatabaseProviderRW<&DB>,
 ) -> Result<EntitiesCheckpoint, StageError> {
     let pruned_entries = provider
         .get_prune_checkpoint(PruneSegment::TransactionLookup)?

--- a/crates/stages/src/test_utils/stage.rs
+++ b/crates/stages/src/test_utils/stage.rs
@@ -47,7 +47,7 @@ impl<DB: Database> Stage<DB> for TestStage {
 
     fn execute(
         &mut self,
-        _: &DatabaseProviderRW<'_, &DB>,
+        _: &DatabaseProviderRW<&DB>,
         _input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         self.exec_outputs
@@ -57,7 +57,7 @@ impl<DB: Database> Stage<DB> for TestStage {
 
     fn unwind(
         &mut self,
-        _: &DatabaseProviderRW<'_, &DB>,
+        _: &DatabaseProviderRW<&DB>,
         _input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         self.unwind_outputs

--- a/crates/stages/src/test_utils/test_db.rs
+++ b/crates/stages/src/test_utils/test_db.rs
@@ -6,7 +6,7 @@ use reth_db::{
     table::{Table, TableRow},
     tables,
     test_utils::{create_test_rw_db, create_test_rw_db_with_path, TempDatabase},
-    transaction::{DbTx, DbTxGAT, DbTxMut, DbTxMutGAT},
+    transaction::{DbTx, DbCursors, DbTxMut, DbCursorsMut},
     DatabaseEnv, DatabaseError as DbError,
 };
 use reth_interfaces::{test_utils::generators::ChangeSet, RethResult};

--- a/crates/stages/src/test_utils/test_db.rs
+++ b/crates/stages/src/test_utils/test_db.rs
@@ -1,12 +1,12 @@
 use reth_db::{
     common::KeyValue,
     cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO},
-    database::DatabaseGAT,
+    database::Database,
     models::{AccountBeforeTx, StoredBlockBodyIndices},
     table::{Table, TableRow},
     tables,
     test_utils::{create_test_rw_db, create_test_rw_db_with_path, TempDatabase},
-    transaction::{DbTx, DbCursors, DbTxMut, DbCursorsMut},
+    transaction::{DbTx, DbTxMut},
     DatabaseEnv, DatabaseError as DbError,
 };
 use reth_interfaces::{test_utils::generators::ChangeSet, RethResult};
@@ -57,12 +57,12 @@ impl TestTransaction {
     }
 
     /// Return a database wrapped in [DatabaseProviderRW].
-    pub fn inner_rw(&self) -> DatabaseProviderRW<'_, Arc<TempDatabase<DatabaseEnv>>> {
+    pub fn inner_rw(&self) -> DatabaseProviderRW<Arc<TempDatabase<DatabaseEnv>>> {
         self.factory.provider_rw().expect("failed to create db container")
     }
 
     /// Return a database wrapped in [DatabaseProviderRO].
-    pub fn inner(&self) -> DatabaseProviderRO<'_, Arc<TempDatabase<DatabaseEnv>>> {
+    pub fn inner(&self) -> DatabaseProviderRO<Arc<TempDatabase<DatabaseEnv>>> {
         self.factory.provider().expect("failed to create db container")
     }
 
@@ -74,7 +74,7 @@ impl TestTransaction {
     /// Invoke a callback with transaction committing it afterwards
     pub fn commit<F>(&self, f: F) -> Result<(), DbError>
     where
-        F: FnOnce(&<DatabaseEnv as DatabaseGAT<'_>>::TXMut) -> Result<(), DbError>,
+        F: FnOnce(&<DatabaseEnv as Database>::TXMut) -> Result<(), DbError>,
     {
         let mut tx = self.inner_rw();
         f(tx.tx_ref())?;
@@ -85,7 +85,7 @@ impl TestTransaction {
     /// Invoke a callback with a read transaction
     pub fn query<F, R>(&self, f: F) -> Result<R, DbError>
     where
-        F: FnOnce(&<DatabaseEnv as DatabaseGAT<'_>>::TX) -> Result<R, DbError>,
+        F: FnOnce(&<DatabaseEnv as Database>::TX) -> Result<R, DbError>,
     {
         f(self.inner().tx_ref())
     }

--- a/crates/storage/db/src/abstraction/common.rs
+++ b/crates/storage/db/src/abstraction/common.rs
@@ -1,5 +1,3 @@
-pub(crate) use sealed::Sealed;
-
 use crate::{abstraction::table::*, DatabaseError};
 
 /// A key-value pair for table `T`.
@@ -36,3 +34,4 @@ mod sealed {
     #[cfg(any(test, feature = "test-utils"))]
     impl<DB: Database> Sealed for crate::test_utils::TempDatabase<DB> {}
 }
+pub(crate) use sealed::Sealed;

--- a/crates/storage/db/src/abstraction/common.rs
+++ b/crates/storage/db/src/abstraction/common.rs
@@ -1,3 +1,7 @@
+pub(crate) use sealed::Sealed;
+
+use crate::{abstraction::table::*, DatabaseError};
+
 /// A key-value pair for table `T`.
 pub type KeyValue<T> = (<T as Table>::Key, <T as Table>::Value);
 
@@ -16,13 +20,21 @@ pub type IterPairResult<T> = Option<Result<KeyValue<T>, DatabaseError>>;
 /// A value only result for table `T`.
 pub type ValueOnlyResult<T> = Result<Option<<T as Table>::Value>, DatabaseError>;
 
-use crate::{abstraction::table::*, DatabaseError};
-
-// Sealed trait helper to prevent misuse of the API.
+// Sealed trait helper to prevent misuse of the Database API.
 mod sealed {
+    use std::sync::Arc;
+    use crate::database::Database;
+    use crate::DatabaseEnv;
+    use crate::mock::DatabaseMock;
+
+    /// Sealed trait to limit the implementors of the Database trait.
     pub trait Sealed: Sized {}
-    #[allow(missing_debug_implementations)]
-    pub struct Bounds<T>(T);
-    impl<T> Sealed for Bounds<T> {}
+
+    impl<DB: Database> Sealed for &DB { }
+    impl<DB: Database> Sealed for Arc<DB> { }
+    impl Sealed for DatabaseEnv{ }
+    impl Sealed for DatabaseMock{ }
+
+    #[cfg(any(test, feature = "test-utils"))]
+    impl<DB: Database> Sealed for crate::test_utils::TempDatabase<DB>{ }
 }
-pub(crate) use sealed::{Bounds, Sealed};

--- a/crates/storage/db/src/abstraction/database.rs
+++ b/crates/storage/db/src/abstraction/database.rs
@@ -1,36 +1,31 @@
 use crate::{
-    common::Sealed,
+    abstraction::common::Sealed,
     table::TableImporter,
     transaction::{DbTx, DbTxMut},
     DatabaseError,
 };
 use std::{fmt::Debug, sync::Arc};
 
-/// Trait that provides the different transaction types.
+/// Main Database trait that can open read-only and read-write transactions.
 ///
-/// Sealed trait which cannot be implemented by 3rd parties, exposed only for implementers
-pub trait DatabaseGAT: Sealed + Send + Sync {
-
-}
-
-/// Main Database trait that spawns transactions to be executed.
-pub trait Database: DatabaseGAT {
+/// Sealed trait which cannot be implemented by 3rd parties, exposed only for consumption.
+pub trait Database: Send + Sync + Sealed {
     /// RO database transaction
     type TX: DbTx + Send + Sync + Debug;
     /// RW database transaction
     type TXMut: DbTxMut + DbTx + TableImporter + Send + Sync + Debug;
 
     /// Create read only transaction.
-    fn tx(&self) -> Result<<Self as DatabaseGAT>::TX, DatabaseError>;
+    fn tx(&self) -> Result<Self::TX, DatabaseError>;
 
     /// Create read write transaction only possible if database is open with write access.
-    fn tx_mut(&self) -> Result<<Self as DatabaseGAT>::TXMut, DatabaseError>;
+    fn tx_mut(&self) -> Result<Self::TXMut, DatabaseError>;
 
     /// Takes a function and passes a read-only transaction into it, making sure it's closed in the
     /// end of the execution.
     fn view<T, F>(&self, f: F) -> Result<T, DatabaseError>
     where
-        F: FnOnce(&<Self as DatabaseGAT>::TX) -> T,
+        F: FnOnce(&Self::TX) -> T,
     {
         let tx = self.tx()?;
 
@@ -44,7 +39,7 @@ pub trait Database: DatabaseGAT {
     /// the end of the execution.
     fn update<T, F>(&self, f: F) -> Result<T, DatabaseError>
     where
-        F: FnOnce(&<Self as DatabaseGAT>::TXMut) -> T,
+        F: FnOnce(&Self::TXMut) -> T,
     {
         let tx = self.tx_mut()?;
 
@@ -55,34 +50,27 @@ pub trait Database: DatabaseGAT {
     }
 }
 
-// Generic over Arc
-impl<DB: Database> DatabaseGAT for Arc<DB> {
-    type TX = <DB as DatabaseGAT>::TX;
-    type TXMut = <DB as DatabaseGAT>::TXMut;
-}
-
 impl<DB: Database> Database for Arc<DB> {
-    fn tx(&self) -> Result<<Self as DatabaseGAT>::TX, DatabaseError> {
+    type TX = <DB as Database>::TX;
+    type TXMut = <DB as Database>::TXMut;
+
+    fn tx(&self) -> Result<Self::TX, DatabaseError> {
         <DB as Database>::tx(self)
     }
 
-    fn tx_mut(&self) -> Result<<Self as DatabaseGAT>::TXMut, DatabaseError> {
+    fn tx_mut(&self) -> Result<Self::TXMut, DatabaseError> {
         <DB as Database>::tx_mut(self)
     }
 }
 
-// Generic over reference
-impl<DB: Database> DatabaseGAT for &DB {
-    type TX = <DB as DatabaseGAT>::TX;
-    type TXMut = <DB as DatabaseGAT>::TXMut;
-}
-
 impl<DB: Database> Database for &DB {
-    fn tx(&self) -> Result<<Self as DatabaseGAT>::TX, DatabaseError> {
+    type TX = <DB as Database>::TX;
+    type TXMut = <DB as Database>::TXMut;
+    fn tx(&self) -> Result<Self::TX, DatabaseError> {
         <DB as Database>::tx(self)
     }
 
-    fn tx_mut(&self) -> Result<<Self as DatabaseGAT>::TXMut, DatabaseError> {
+    fn tx_mut(&self) -> Result<Self::TXMut, DatabaseError> {
         <DB as Database>::tx_mut(self)
     }
 }

--- a/crates/storage/db/src/abstraction/database.rs
+++ b/crates/storage/db/src/abstraction/database.rs
@@ -10,10 +10,10 @@ use std::{fmt::Debug, sync::Arc};
 ///
 /// Sealed trait which cannot be implemented by 3rd parties, exposed only for consumption.
 pub trait Database: Send + Sync + Sealed {
-    /// RO database transaction
-    type TX: DbTx + Send + Sync + Debug;
-    /// RW database transaction
-    type TXMut: DbTxMut + DbTx + TableImporter + Send + Sync + Debug;
+    /// Read-Only database transaction
+    type TX: DbTx + Send + Sync + Debug + 'static;
+    /// Read-Write database transaction
+    type TXMut: DbTxMut + DbTx + TableImporter + Send + Sync + Debug + 'static;
 
     /// Create read only transaction.
     fn tx(&self) -> Result<Self::TX, DatabaseError>;

--- a/crates/storage/db/src/abstraction/mock.rs
+++ b/crates/storage/db/src/abstraction/mock.rs
@@ -5,7 +5,7 @@ use crate::{
         DbCursorRO, DbCursorRW, DbDupCursorRO, DbDupCursorRW, DupWalker, RangeWalker,
         ReverseWalker, Walker,
     },
-    database::{Database, DatabaseGAT},
+    database::Database,
     table::{DupSort, Table, TableImporter},
     transaction::{DbTx, DbTxMut},
     DatabaseError,
@@ -21,19 +21,15 @@ pub struct DatabaseMock {
 }
 
 impl Database for DatabaseMock {
-    fn tx(&self) -> Result<<Self as DatabaseGAT>::TX, DatabaseError> {
-        Ok(TxMock::default())
-    }
-
-    fn tx_mut(&self) -> Result<<Self as DatabaseGAT>::TXMut, DatabaseError> {
-        Ok(TxMock::default())
-    }
-}
-
-impl DatabaseGAT for DatabaseMock {
     type TX = TxMock;
-
     type TXMut = TxMock;
+    fn tx(&self) -> Result<Self::TX, DatabaseError> {
+        Ok(TxMock::default())
+    }
+
+    fn tx_mut(&self) -> Result<Self::TXMut, DatabaseError> {
+        Ok(TxMock::default())
+    }
 }
 
 /// Mock read only tx
@@ -94,9 +90,7 @@ impl DbTxMut for TxMock {
         todo!()
     }
 
-    fn cursor_dup_write<T: DupSort>(
-        &self,
-    ) -> Result<Self::DupCursorMut<T>, DatabaseError> {
+    fn cursor_dup_write<T: DupSort>(&self) -> Result<Self::DupCursorMut<T>, DatabaseError> {
         todo!()
     }
 }

--- a/crates/storage/db/src/abstraction/mock.rs
+++ b/crates/storage/db/src/abstraction/mock.rs
@@ -1,6 +1,5 @@
 //! Mock database
 use std::{collections::BTreeMap, ops::RangeBounds};
-
 use crate::{
     common::{PairResult, ValueOnlyResult},
     cursor::{
@@ -22,16 +21,16 @@ pub struct DatabaseMock {
 }
 
 impl Database for DatabaseMock {
-    fn tx(&self) -> Result<<Self as DatabaseGAT<'_>>::TX, DatabaseError> {
+    fn tx(&self) -> Result<<Self as DatabaseGAT>::TX, DatabaseError> {
         Ok(TxMock::default())
     }
 
-    fn tx_mut(&self) -> Result<<Self as DatabaseGAT<'_>>::TXMut, DatabaseError> {
+    fn tx_mut(&self) -> Result<<Self as DatabaseGAT>::TXMut, DatabaseError> {
         Ok(TxMock::default())
     }
 }
 
-impl<'a> DatabaseGAT<'a> for DatabaseMock {
+impl DatabaseGAT for DatabaseMock {
     type TX = TxMock;
 
     type TXMut = TxMock;
@@ -44,12 +43,12 @@ pub struct TxMock {
     _table: BTreeMap<Vec<u8>, Vec<u8>>,
 }
 
-impl<'a> DbTxGAT<'a> for TxMock {
+impl DbTxGAT for TxMock {
     type Cursor<T: Table> = CursorMock;
     type DupCursor<T: DupSort> = CursorMock;
 }
 
-impl<'a> DbTxMutGAT<'a> for TxMock {
+impl DbTxMutGAT for TxMock {
     type CursorMut<T: Table> = CursorMock;
     type DupCursorMut<T: DupSort> = CursorMock;
 }
@@ -65,13 +64,13 @@ impl DbTx for TxMock {
 
     fn abort(self) {}
 
-    fn cursor_read<T: Table>(&self) -> Result<<Self as DbTxGAT<'_>>::Cursor<T>, DatabaseError> {
+    fn cursor_read<T: Table>(&self) -> Result<<Self as DbTxGAT>::Cursor<T>, DatabaseError> {
         Ok(CursorMock { _cursor: 0 })
     }
 
     fn cursor_dup_read<T: DupSort>(
         &self,
-    ) -> Result<<Self as DbTxGAT<'_>>::DupCursor<T>, DatabaseError> {
+    ) -> Result<<Self as DbTxGAT>::DupCursor<T>, DatabaseError> {
         Ok(CursorMock { _cursor: 0 })
     }
 
@@ -99,13 +98,13 @@ impl DbTxMut for TxMock {
 
     fn cursor_write<T: Table>(
         &self,
-    ) -> Result<<Self as DbTxMutGAT<'_>>::CursorMut<T>, DatabaseError> {
+    ) -> Result<<Self as DbTxMutGAT>::CursorMut<T>, DatabaseError> {
         todo!()
     }
 
     fn cursor_dup_write<T: DupSort>(
         &self,
-    ) -> Result<<Self as DbTxMutGAT<'_>>::DupCursorMut<T>, DatabaseError> {
+    ) -> Result<<Self as DbTxMutGAT>::DupCursorMut<T>, DatabaseError> {
         todo!()
     }
 }

--- a/crates/storage/db/src/abstraction/transaction.rs
+++ b/crates/storage/db/src/abstraction/transaction.rs
@@ -32,9 +32,7 @@ pub trait DbTx {
     /// Iterate over read only values in table.
     fn cursor_read<T: Table>(&self) -> Result<Self::Cursor<T>, DatabaseError>;
     /// Iterate over read only values in dup sorted table.
-    fn cursor_dup_read<T: DupSort>(
-        &self,
-    ) -> Result<Self::DupCursor<T>, DatabaseError>;
+    fn cursor_dup_read<T: DupSort>(&self) -> Result<Self::DupCursor<T>, DatabaseError>;
     /// Returns number of entries in the table.
     fn entries<T: Table>(&self) -> Result<usize, DatabaseError>;
 }

--- a/crates/storage/db/src/abstraction/transaction.rs
+++ b/crates/storage/db/src/abstraction/transaction.rs
@@ -4,19 +4,8 @@ use crate::{
     DatabaseError,
 };
 
-/// Trait that provides the different read-only cursor types.
-pub trait DbCursors: Send + Sync {
-    /// Cursor GAT
-    type Cursor<T: Table>: DbCursorRO<T> + Send + Sync;
-    /// DupCursor GAT
-    type DupCursor<T: DupSort>: DbDupCursorRO<T> + DbCursorRO<T> + Send + Sync;
-}
-
-/// Trait that provides the different read-write cursor types.
-pub trait DbCursorsMut: Send + Sync {}
-
 /// Read only transaction
-pub trait DbTx {
+pub trait DbTx: Send + Sync {
     /// Cursor type for this read-only transaction
     type Cursor<T: Table>: DbCursorRO<T> + Send + Sync;
     /// DupCursor type for this read-only transaction
@@ -38,10 +27,10 @@ pub trait DbTx {
 }
 
 /// Read write transaction that allows writing to database
-pub trait DbTxMut {
-    /// Cursor GAT
+pub trait DbTxMut: Send + Sync {
+    /// Read-Write Cursor type
     type CursorMut<T: Table>: DbCursorRW<T> + DbCursorRO<T> + Send + Sync;
-    /// DupCursor GAT
+    /// Read-Write DupCursor type
     type DupCursorMut<T: DupSort>: DbDupCursorRW<T>
         + DbCursorRW<T>
         + DbDupCursorRO<T>

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -40,20 +40,20 @@ pub struct DatabaseEnv {
     with_metrics: bool,
 }
 
-impl<'a> DatabaseGAT<'a> for DatabaseEnv {
+impl DatabaseGAT for DatabaseEnv {
     type TX = tx::Tx<RO>;
     type TXMut = tx::Tx<RW>;
 }
 
 impl Database for DatabaseEnv {
-    fn tx(&self) -> Result<<Self as DatabaseGAT<'_>>::TX, DatabaseError> {
+    fn tx(&self) -> Result<<Self as DatabaseGAT>::TX, DatabaseError> {
         Ok(Tx::new_with_metrics(
             self.inner.begin_ro_txn().map_err(|e| DatabaseError::InitTx(e.into()))?,
             self.with_metrics,
         ))
     }
 
-    fn tx_mut(&self) -> Result<<Self as DatabaseGAT<'_>>::TXMut, DatabaseError> {
+    fn tx_mut(&self) -> Result<<Self as DatabaseGAT>::TXMut, DatabaseError> {
         Ok(Tx::new_with_metrics(
             self.inner.begin_rw_txn().map_err(|e| DatabaseError::InitTx(e.into()))?,
             self.with_metrics,

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -1,7 +1,7 @@
 //! Module that interacts with MDBX.
 
 use crate::{
-    database::{Database, DatabaseGAT},
+    database::Database,
     tables::{TableType, Tables},
     utils::default_page_size,
     DatabaseError,
@@ -40,20 +40,18 @@ pub struct DatabaseEnv {
     with_metrics: bool,
 }
 
-impl DatabaseGAT for DatabaseEnv {
+impl Database for DatabaseEnv {
     type TX = tx::Tx<RO>;
     type TXMut = tx::Tx<RW>;
-}
 
-impl Database for DatabaseEnv {
-    fn tx(&self) -> Result<<Self as DatabaseGAT>::TX, DatabaseError> {
+    fn tx(&self) -> Result<Self::TX, DatabaseError> {
         Ok(Tx::new_with_metrics(
             self.inner.begin_ro_txn().map_err(|e| DatabaseError::InitTx(e.into()))?,
             self.with_metrics,
         ))
     }
 
-    fn tx_mut(&self) -> Result<<Self as DatabaseGAT>::TXMut, DatabaseError> {
+    fn tx_mut(&self) -> Result<Self::TXMut, DatabaseError> {
         Ok(Tx::new_with_metrics(
             self.inner.begin_rw_txn().map_err(|e| DatabaseError::InitTx(e.into()))?,
             self.with_metrics,

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -200,9 +200,7 @@ impl<K: TransactionKind> DbTx for Tx<K> {
     }
 
     /// Iterate over read only values in database.
-    fn cursor_dup_read<T: DupSort>(
-        &self,
-    ) -> Result<Self::DupCursor<T>, DatabaseError> {
+    fn cursor_dup_read<T: DupSort>(&self) -> Result<Self::DupCursor<T>, DatabaseError> {
         self.new_cursor()
     }
 
@@ -268,9 +266,7 @@ impl DbTxMut for Tx<RW> {
         self.new_cursor()
     }
 
-    fn cursor_dup_write<T: DupSort>(
-        &self,
-    ) -> Result<Self::DupCursorMut<T>, DatabaseError> {
+    fn cursor_dup_write<T: DupSort>(&self) -> Result<Self::DupCursorMut<T>, DatabaseError> {
         self.new_cursor()
     }
 }

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -167,12 +167,12 @@ impl<K: TransactionKind> Drop for MetricsHandler<K> {
     }
 }
 
-impl<'a, K: TransactionKind> DbTxGAT<'a> for Tx<K> {
-    type Cursor<T: Table> = Cursor<'a, K, T>;
-    type DupCursor<T: DupSort> = Cursor<'a, K, T>;
+impl<K: TransactionKind> DbTxGAT for Tx<K> {
+    type Cursor<T: Table> = Cursor<'_, K, T>;
+    type DupCursor<T: DupSort> = Cursor<'_, K, T>;
 }
 
-impl<'a, K: TransactionKind> DbTxMutGAT<'a> for Tx<K> {
+impl<'a, K: TransactionKind> DbTxMutGAT for Tx<K> {
     type CursorMut<T: Table> = Cursor<'a, RW, T>;
     type DupCursorMut<T: DupSort> = Cursor<'a, RW, T>;
 }
@@ -202,14 +202,14 @@ impl<K: TransactionKind> DbTx for Tx<K> {
     }
 
     // Iterate over read only values in database.
-    fn cursor_read<T: Table>(&self) -> Result<<Self as DbTxGAT<'_>>::Cursor<T>, DatabaseError> {
+    fn cursor_read<T: Table>(&self) -> Result<<Self as DbTxGAT>::Cursor<T>, DatabaseError> {
         self.new_cursor()
     }
 
     /// Iterate over read only values in database.
     fn cursor_dup_read<T: DupSort>(
         &self,
-    ) -> Result<<Self as DbTxGAT<'_>>::DupCursor<T>, DatabaseError> {
+    ) -> Result<<Self as DbTxGAT>::DupCursor<T>, DatabaseError> {
         self.new_cursor()
     }
 
@@ -270,13 +270,13 @@ impl DbTxMut for Tx<RW> {
 
     fn cursor_write<T: Table>(
         &self,
-    ) -> Result<<Self as DbTxMutGAT<'_>>::CursorMut<T>, DatabaseError> {
+    ) -> Result<<Self as DbTxMutGAT>::CursorMut<T>, DatabaseError> {
         self.new_cursor()
     }
 
     fn cursor_dup_write<T: DupSort>(
         &self,
-    ) -> Result<<Self as DbTxMutGAT<'_>>::DupCursorMut<T>, DatabaseError> {
+    ) -> Result<<Self as DbTxMutGAT>::DupCursorMut<T>, DatabaseError> {
         self.new_cursor()
     }
 }

--- a/crates/storage/db/src/lib.rs
+++ b/crates/storage/db/src/lib.rs
@@ -153,7 +153,7 @@ pub fn open_db(path: &Path, log_level: Option<LogLevel>) -> eyre::Result<Databas
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils {
     use super::*;
-    use crate::database::{Database, DatabaseGAT};
+    use crate::database::Database;
     use std::{path::PathBuf, sync::Arc};
 
     /// Error during database open
@@ -193,17 +193,14 @@ pub mod test_utils {
         }
     }
 
-    impl<DB: Database> DatabaseGAT for TempDatabase<DB> {
-        type TX = <DB as DatabaseGAT>::TX;
-        type TXMut = <DB as DatabaseGAT>::TXMut;
-    }
-
     impl<DB: Database> Database for TempDatabase<DB> {
-        fn tx(&self) -> Result<<Self as DatabaseGAT>::TX, DatabaseError> {
+        type TX = <DB as Database>::TX;
+        type TXMut = <DB as Database>::TXMut;
+        fn tx(&self) -> Result<Self::TX, DatabaseError> {
             self.db().tx()
         }
 
-        fn tx_mut(&self) -> Result<<Self as DatabaseGAT>::TXMut, DatabaseError> {
+        fn tx_mut(&self) -> Result<Self::TXMut, DatabaseError> {
             self.db().tx_mut()
         }
     }

--- a/crates/storage/db/src/lib.rs
+++ b/crates/storage/db/src/lib.rs
@@ -193,17 +193,17 @@ pub mod test_utils {
         }
     }
 
-    impl<'a, DB: Database> DatabaseGAT<'a> for TempDatabase<DB> {
-        type TX = <DB as DatabaseGAT<'a>>::TX;
-        type TXMut = <DB as DatabaseGAT<'a>>::TXMut;
+    impl<DB: Database> DatabaseGAT for TempDatabase<DB> {
+        type TX = <DB as DatabaseGAT>::TX;
+        type TXMut = <DB as DatabaseGAT>::TXMut;
     }
 
     impl<DB: Database> Database for TempDatabase<DB> {
-        fn tx(&self) -> Result<<Self as DatabaseGAT<'_>>::TX, DatabaseError> {
+        fn tx(&self) -> Result<<Self as DatabaseGAT>::TX, DatabaseError> {
             self.db().tx()
         }
 
-        fn tx_mut(&self) -> Result<<Self as DatabaseGAT<'_>>::TXMut, DatabaseError> {
+        fn tx_mut(&self) -> Result<<Self as DatabaseGAT>::TXMut, DatabaseError> {
             self.db().tx_mut()
         }
     }

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -508,7 +508,7 @@ where
     Tree: BlockchainTreePendingStateProvider + BlockchainTreeViewer,
 {
     /// Storage provider for latest block
-    fn latest(&self) -> ProviderResult<StateProviderBox<'_>> {
+    fn latest(&self) -> ProviderResult<StateProviderBox> {
         trace!(target: "providers::blockchain", "Getting latest block state provider");
         self.database.latest()
     }
@@ -516,18 +516,18 @@ where
     fn history_by_block_number(
         &self,
         block_number: BlockNumber,
-    ) -> ProviderResult<StateProviderBox<'_>> {
+    ) -> ProviderResult<StateProviderBox> {
         trace!(target: "providers::blockchain", ?block_number, "Getting history by block number");
         self.ensure_canonical_block(block_number)?;
         self.database.history_by_block_number(block_number)
     }
 
-    fn history_by_block_hash(&self, block_hash: BlockHash) -> ProviderResult<StateProviderBox<'_>> {
+    fn history_by_block_hash(&self, block_hash: BlockHash) -> ProviderResult<StateProviderBox> {
         trace!(target: "providers::blockchain", ?block_hash, "Getting history by block hash");
         self.database.history_by_block_hash(block_hash)
     }
 
-    fn state_by_block_hash(&self, block: BlockHash) -> ProviderResult<StateProviderBox<'_>> {
+    fn state_by_block_hash(&self, block: BlockHash) -> ProviderResult<StateProviderBox> {
         trace!(target: "providers::blockchain", ?block, "Getting state by block hash");
         let mut state = self.history_by_block_hash(block);
 
@@ -546,7 +546,7 @@ where
     ///
     /// If there's no pending block available then the latest state provider is returned:
     /// [Self::latest]
-    fn pending(&self) -> ProviderResult<StateProviderBox<'_>> {
+    fn pending(&self) -> ProviderResult<StateProviderBox> {
         trace!(target: "providers::blockchain", "Getting provider for pending state");
 
         if let Some(block) = self.tree.pending_block_num_hash() {
@@ -559,10 +559,7 @@ where
         self.latest()
     }
 
-    fn pending_state_by_hash(
-        &self,
-        block_hash: B256,
-    ) -> ProviderResult<Option<StateProviderBox<'_>>> {
+    fn pending_state_by_hash(&self, block_hash: B256) -> ProviderResult<Option<StateProviderBox>> {
         if let Some(state) = self.tree.find_pending_state_provider(block_hash) {
             return Ok(Some(self.pending_with_provider(state)?))
         }
@@ -572,7 +569,7 @@ where
     fn pending_with_provider(
         &self,
         post_state_data: Box<dyn BundleStateDataProvider>,
-    ) -> ProviderResult<StateProviderBox<'_>> {
+    ) -> ProviderResult<StateProviderBox> {
         let canonical_fork = post_state_data.canonical_fork();
         trace!(target: "providers::blockchain", ?canonical_fork, "Returning post state provider");
 

--- a/crates/storage/provider/src/test_utils/blocks.rs
+++ b/crates/storage/provider/src/test_utils/blocks.rs
@@ -10,7 +10,7 @@ use reth_primitives::{
 use std::collections::HashMap;
 
 /// Assert genesis block
-pub fn assert_genesis_block<DB: Database>(provider: &DatabaseProviderRW<'_, DB>, g: SealedBlock) {
+pub fn assert_genesis_block<DB: Database>(provider: &DatabaseProviderRW<DB>, g: SealedBlock) {
     let n = g.number;
     let h = B256::ZERO;
     let tx = provider;

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -573,73 +573,67 @@ impl EvmEnvProvider for MockEthProvider {
 }
 
 impl StateProviderFactory for MockEthProvider {
-    fn latest(&self) -> ProviderResult<StateProviderBox<'_>> {
+    fn latest(&self) -> ProviderResult<StateProviderBox> {
         Ok(Box::new(self.clone()))
     }
 
-    fn history_by_block_number(&self, _block: BlockNumber) -> ProviderResult<StateProviderBox<'_>> {
+    fn history_by_block_number(&self, _block: BlockNumber) -> ProviderResult<StateProviderBox> {
         Ok(Box::new(self.clone()))
     }
 
-    fn history_by_block_hash(&self, _block: BlockHash) -> ProviderResult<StateProviderBox<'_>> {
+    fn history_by_block_hash(&self, _block: BlockHash) -> ProviderResult<StateProviderBox> {
         Ok(Box::new(self.clone()))
     }
 
-    fn state_by_block_hash(&self, _block: BlockHash) -> ProviderResult<StateProviderBox<'_>> {
+    fn state_by_block_hash(&self, _block: BlockHash) -> ProviderResult<StateProviderBox> {
         Ok(Box::new(self.clone()))
     }
 
-    fn pending(&self) -> ProviderResult<StateProviderBox<'_>> {
+    fn pending(&self) -> ProviderResult<StateProviderBox> {
         Ok(Box::new(self.clone()))
     }
 
-    fn pending_state_by_hash(
-        &self,
-        _block_hash: B256,
-    ) -> ProviderResult<Option<StateProviderBox<'_>>> {
+    fn pending_state_by_hash(&self, _block_hash: B256) -> ProviderResult<Option<StateProviderBox>> {
         Ok(Some(Box::new(self.clone())))
     }
 
     fn pending_with_provider<'a>(
         &'a self,
         _post_state_data: Box<dyn BundleStateDataProvider + 'a>,
-    ) -> ProviderResult<StateProviderBox<'a>> {
+    ) -> ProviderResult<StateProviderBox> {
         Ok(Box::new(self.clone()))
     }
 }
 
 impl StateProviderFactory for Arc<MockEthProvider> {
-    fn latest(&self) -> ProviderResult<StateProviderBox<'_>> {
+    fn latest(&self) -> ProviderResult<StateProviderBox> {
         Ok(Box::new(self.clone()))
     }
 
-    fn history_by_block_number(&self, _block: BlockNumber) -> ProviderResult<StateProviderBox<'_>> {
+    fn history_by_block_number(&self, _block: BlockNumber) -> ProviderResult<StateProviderBox> {
         Ok(Box::new(self.clone()))
     }
 
-    fn history_by_block_hash(&self, _block: BlockHash) -> ProviderResult<StateProviderBox<'_>> {
+    fn history_by_block_hash(&self, _block: BlockHash) -> ProviderResult<StateProviderBox> {
         Ok(Box::new(self.clone()))
     }
 
-    fn state_by_block_hash(&self, _block: BlockHash) -> ProviderResult<StateProviderBox<'_>> {
+    fn state_by_block_hash(&self, _block: BlockHash) -> ProviderResult<StateProviderBox> {
         Ok(Box::new(self.clone()))
     }
 
-    fn pending(&self) -> ProviderResult<StateProviderBox<'_>> {
+    fn pending(&self) -> ProviderResult<StateProviderBox> {
         Ok(Box::new(self.clone()))
     }
 
-    fn pending_state_by_hash(
-        &self,
-        _block_hash: B256,
-    ) -> ProviderResult<Option<StateProviderBox<'_>>> {
+    fn pending_state_by_hash(&self, _block_hash: B256) -> ProviderResult<Option<StateProviderBox>> {
         Ok(Some(Box::new(self.clone())))
     }
 
     fn pending_with_provider<'a>(
         &'a self,
         _post_state_data: Box<dyn BundleStateDataProvider + 'a>,
-    ) -> ProviderResult<StateProviderBox<'a>> {
+    ) -> ProviderResult<StateProviderBox> {
         Ok(Box::new(self.clone()))
     }
 }

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -339,37 +339,34 @@ impl EvmEnvProvider for NoopProvider {
 }
 
 impl StateProviderFactory for NoopProvider {
-    fn latest(&self) -> ProviderResult<StateProviderBox<'_>> {
+    fn latest(&self) -> ProviderResult<StateProviderBox> {
         Ok(Box::new(*self))
     }
 
-    fn history_by_block_number(&self, _block: BlockNumber) -> ProviderResult<StateProviderBox<'_>> {
+    fn history_by_block_number(&self, _block: BlockNumber) -> ProviderResult<StateProviderBox> {
         Ok(Box::new(*self))
     }
 
-    fn history_by_block_hash(&self, _block: BlockHash) -> ProviderResult<StateProviderBox<'_>> {
+    fn history_by_block_hash(&self, _block: BlockHash) -> ProviderResult<StateProviderBox> {
         Ok(Box::new(*self))
     }
 
-    fn state_by_block_hash(&self, _block: BlockHash) -> ProviderResult<StateProviderBox<'_>> {
+    fn state_by_block_hash(&self, _block: BlockHash) -> ProviderResult<StateProviderBox> {
         Ok(Box::new(*self))
     }
 
-    fn pending(&self) -> ProviderResult<StateProviderBox<'_>> {
+    fn pending(&self) -> ProviderResult<StateProviderBox> {
         Ok(Box::new(*self))
     }
 
-    fn pending_state_by_hash(
-        &self,
-        _block_hash: B256,
-    ) -> ProviderResult<Option<StateProviderBox<'_>>> {
+    fn pending_state_by_hash(&self, _block_hash: B256) -> ProviderResult<Option<StateProviderBox>> {
         Ok(Some(Box::new(*self)))
     }
 
     fn pending_with_provider<'a>(
         &'a self,
         _post_state_data: Box<dyn crate::BundleStateDataProvider + 'a>,
-    ) -> ProviderResult<StateProviderBox<'a>> {
+    ) -> ProviderResult<StateProviderBox> {
         Ok(Box::new(*self))
     }
 }

--- a/crates/storage/provider/src/traits/state.rs
+++ b/crates/storage/provider/src/traits/state.rs
@@ -8,7 +8,7 @@ use reth_primitives::{
 };
 
 /// Type alias of boxed [StateProvider].
-pub type StateProviderBox<'a> = Box<dyn StateProvider + 'a>;
+pub type StateProviderBox = Box<dyn StateProvider>;
 
 /// An abstraction for a type that provides state data.
 #[auto_impl(&, Arc, Box)]
@@ -99,13 +99,13 @@ pub trait StateProvider: BlockHashReader + AccountReader + StateRootProvider + S
 /// to be used, since block `n` was executed on its parent block's state.
 pub trait StateProviderFactory: BlockIdReader + Send + Sync {
     /// Storage provider for latest block.
-    fn latest(&self) -> ProviderResult<StateProviderBox<'_>>;
+    fn latest(&self) -> ProviderResult<StateProviderBox>;
 
     /// Returns a [StateProvider] indexed by the given [BlockId].
     ///
     /// Note: if a number or hash is provided this will __only__ look at historical(canonical)
     /// state.
-    fn state_by_block_id(&self, block_id: BlockId) -> ProviderResult<StateProviderBox<'_>> {
+    fn state_by_block_id(&self, block_id: BlockId) -> ProviderResult<StateProviderBox> {
         match block_id {
             BlockId::Number(block_number) => self.state_by_block_number_or_tag(block_number),
             BlockId::Hash(block_hash) => self.history_by_block_hash(block_hash.into()),
@@ -118,7 +118,7 @@ pub trait StateProviderFactory: BlockIdReader + Send + Sync {
     fn state_by_block_number_or_tag(
         &self,
         number_or_tag: BlockNumberOrTag,
-    ) -> ProviderResult<StateProviderBox<'_>> {
+    ) -> ProviderResult<StateProviderBox> {
         match number_or_tag {
             BlockNumberOrTag::Latest => self.latest(),
             BlockNumberOrTag::Finalized => {
@@ -152,40 +152,37 @@ pub trait StateProviderFactory: BlockIdReader + Send + Sync {
     ///
     ///
     /// Note: this only looks at historical blocks, not pending blocks.
-    fn history_by_block_number(&self, block: BlockNumber) -> ProviderResult<StateProviderBox<'_>>;
+    fn history_by_block_number(&self, block: BlockNumber) -> ProviderResult<StateProviderBox>;
 
     /// Returns a historical [StateProvider] indexed by the given block hash.
     ///
     /// Note: this only looks at historical blocks, not pending blocks.
-    fn history_by_block_hash(&self, block: BlockHash) -> ProviderResult<StateProviderBox<'_>>;
+    fn history_by_block_hash(&self, block: BlockHash) -> ProviderResult<StateProviderBox>;
 
     /// Returns _any_[StateProvider] with matching block hash.
     ///
     /// This will return a [StateProvider] for either a historical or pending block.
-    fn state_by_block_hash(&self, block: BlockHash) -> ProviderResult<StateProviderBox<'_>>;
+    fn state_by_block_hash(&self, block: BlockHash) -> ProviderResult<StateProviderBox>;
 
     /// Storage provider for pending state.
     ///
     /// Represents the state at the block that extends the canonical chain by one.
     /// If there's no `pending` block, then this is equal to [StateProviderFactory::latest]
-    fn pending(&self) -> ProviderResult<StateProviderBox<'_>>;
+    fn pending(&self) -> ProviderResult<StateProviderBox>;
 
     /// Storage provider for pending state for the given block hash.
     ///
     /// Represents the state at the block that extends the canonical chain.
     ///
     /// If the block couldn't be found, returns `None`.
-    fn pending_state_by_hash(
-        &self,
-        block_hash: B256,
-    ) -> ProviderResult<Option<StateProviderBox<'_>>>;
+    fn pending_state_by_hash(&self, block_hash: B256) -> ProviderResult<Option<StateProviderBox>>;
 
     /// Return a [StateProvider] that contains post state data provider.
     /// Used to inspect or execute transaction on the pending state.
     fn pending_with_provider(
         &self,
         post_state_data: Box<dyn BundleStateDataProvider>,
-    ) -> ProviderResult<StateProviderBox<'_>>;
+    ) -> ProviderResult<StateProviderBox>;
 }
 
 /// Blockchain trait provider that gives access to the blockchain state that is not yet committed

--- a/crates/trie/src/hashed_cursor/default.rs
+++ b/crates/trie/src/hashed_cursor/default.rs
@@ -2,13 +2,13 @@ use super::{HashedAccountCursor, HashedCursorFactory, HashedStorageCursor};
 use reth_db::{
     cursor::{DbCursorRO, DbDupCursorRO},
     tables,
-    transaction::{DbTx, DbTxGAT},
+    transaction::{DbTx, DbCursors},
 };
 use reth_primitives::{Account, StorageEntry, B256};
 
 impl<'a, TX: DbTx> HashedCursorFactory for &'a TX {
-    type AccountCursor = <TX as DbTxGAT<'a>>::Cursor<tables::HashedAccount>;
-    type StorageCursor = <TX as DbTxGAT<'a>>::DupCursor<tables::HashedStorage>;
+    type AccountCursor = <TX as DbCursors<'a>>::Cursor<tables::HashedAccount>;
+    type StorageCursor = <TX as DbCursors<'a>>::DupCursor<tables::HashedStorage>;
 
     fn hashed_account_cursor(&self) -> Result<Self::AccountCursor, reth_db::DatabaseError> {
         self.cursor_read::<tables::HashedAccount>()

--- a/crates/trie/src/hashed_cursor/default.rs
+++ b/crates/trie/src/hashed_cursor/default.rs
@@ -2,13 +2,13 @@ use super::{HashedAccountCursor, HashedCursorFactory, HashedStorageCursor};
 use reth_db::{
     cursor::{DbCursorRO, DbDupCursorRO},
     tables,
-    transaction::{DbTx, DbCursors},
+    transaction::DbTx,
 };
 use reth_primitives::{Account, StorageEntry, B256};
 
 impl<'a, TX: DbTx> HashedCursorFactory for &'a TX {
-    type AccountCursor = <TX as DbCursors<'a>>::Cursor<tables::HashedAccount>;
-    type StorageCursor = <TX as DbCursors<'a>>::DupCursor<tables::HashedStorage>;
+    type AccountCursor = <TX as DbTx>::Cursor<tables::HashedAccount>;
+    type StorageCursor = <TX as DbTx>::DupCursor<tables::HashedStorage>;
 
     fn hashed_account_cursor(&self) -> Result<Self::AccountCursor, reth_db::DatabaseError> {
         self.cursor_read::<tables::HashedAccount>()

--- a/crates/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/src/hashed_cursor/post_state.rs
@@ -3,7 +3,7 @@ use crate::prefix_set::{PrefixSet, PrefixSetMut};
 use reth_db::{
     cursor::{DbCursorRO, DbDupCursorRO},
     tables,
-    transaction::{DbTx, DbCursors},
+    transaction::DbTx,
 };
 use reth_primitives::{trie::Nibbles, Account, StorageEntry, B256, U256};
 use std::collections::{HashMap, HashSet};
@@ -171,9 +171,9 @@ impl<'a, 'b, TX> HashedPostStateCursorFactory<'a, 'b, TX> {
 
 impl<'a, 'b, TX: DbTx> HashedCursorFactory for HashedPostStateCursorFactory<'a, 'b, TX> {
     type AccountCursor =
-        HashedPostStateAccountCursor<'b, <TX as DbCursors<'a>>::Cursor<tables::HashedAccount>>;
+        HashedPostStateAccountCursor<'b, <TX as DbTx>::Cursor<tables::HashedAccount>>;
     type StorageCursor =
-        HashedPostStateStorageCursor<'b, <TX as DbCursors<'a>>::DupCursor<tables::HashedStorage>>;
+        HashedPostStateStorageCursor<'b, <TX as DbTx>::DupCursor<tables::HashedStorage>>;
 
     fn hashed_account_cursor(&self) -> Result<Self::AccountCursor, reth_db::DatabaseError> {
         let cursor = self.tx.cursor_read::<tables::HashedAccount>()?;

--- a/crates/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/src/hashed_cursor/post_state.rs
@@ -3,7 +3,7 @@ use crate::prefix_set::{PrefixSet, PrefixSetMut};
 use reth_db::{
     cursor::{DbCursorRO, DbDupCursorRO},
     tables,
-    transaction::{DbTx, DbTxGAT},
+    transaction::{DbTx, DbCursors},
 };
 use reth_primitives::{trie::Nibbles, Account, StorageEntry, B256, U256};
 use std::collections::{HashMap, HashSet};
@@ -171,9 +171,9 @@ impl<'a, 'b, TX> HashedPostStateCursorFactory<'a, 'b, TX> {
 
 impl<'a, 'b, TX: DbTx> HashedCursorFactory for HashedPostStateCursorFactory<'a, 'b, TX> {
     type AccountCursor =
-        HashedPostStateAccountCursor<'b, <TX as DbTxGAT<'a>>::Cursor<tables::HashedAccount>>;
+        HashedPostStateAccountCursor<'b, <TX as DbCursors<'a>>::Cursor<tables::HashedAccount>>;
     type StorageCursor =
-        HashedPostStateStorageCursor<'b, <TX as DbTxGAT<'a>>::DupCursor<tables::HashedStorage>>;
+        HashedPostStateStorageCursor<'b, <TX as DbCursors<'a>>::DupCursor<tables::HashedStorage>>;
 
     fn hashed_account_cursor(&self) -> Result<Self::AccountCursor, reth_db::DatabaseError> {
         let cursor = self.tx.cursor_read::<tables::HashedAccount>()?;

--- a/crates/trie/src/trie.rs
+++ b/crates/trie/src/trie.rs
@@ -1254,7 +1254,7 @@ mod tests {
     }
 
     fn extension_node_storage_trie(
-        tx: &DatabaseProviderRW<'_, &DatabaseEnv>,
+        tx: &DatabaseProviderRW<&DatabaseEnv>,
         hashed_address: B256,
     ) -> (B256, HashMap<Nibbles, BranchNodeCompact>) {
         let value = U256::from(1);
@@ -1282,7 +1282,7 @@ mod tests {
         (root, updates)
     }
 
-    fn extension_node_trie(tx: &DatabaseProviderRW<'_, &DatabaseEnv>) -> B256 {
+    fn extension_node_trie(tx: &DatabaseProviderRW<&DatabaseEnv>) -> B256 {
         let a =
             Account { nonce: 0, balance: U256::from(1u64), bytecode_hash: Some(B256::random()) };
         let val = encode_account(a, None);

--- a/docs/crates/db.md
+++ b/docs/crates/db.md
@@ -162,7 +162,7 @@ pub trait DbTx: Send + Sync {
 }
 ```
 
-The `TXMut` type can be any type that implements the `DbTxMut` trait, which provides a set of functions to interact with read/write transactions.
+The `TXMut` type can be any type that implements the `DbTxMut` trait, which provides a set of functions to interact with read/write transactions and the associated cursor types.
 
 [File: crates/storage/db/src/abstraction/transaction.rs](https://github.com/paradigmxyz/reth/blob/main/crates/storage/db/src/abstraction/transaction.rs#L49)
 
@@ -264,9 +264,6 @@ This next example uses the `DbTx::cursor()` method to get a `Cursor`. The `Curso
     let mut tx_sender = db_tx.cursor_read::<tables::TxSenders>()?;
 
 ```
-
-We are almost at the last stop in the tour of the `db` crate. In addition to the methods provided by the `DbTx` and `DbTxMut` traits. These traits provide various associated types related to cursors as well as methods to utilize the cursor types.
-
 
 Lets look at an examples of how cursors are used. The code snippet below contains the `unwind` method from the `BodyStage` defined in the `stages` crate. This function is responsible for unwinding any changes to the database if there is an error when executing the body stage within the Reth pipeline.
 

--- a/docs/crates/db.md
+++ b/docs/crates/db.md
@@ -173,11 +173,11 @@ pub trait DbTxMut: Send + Sync {
     type CursorMut<T: Table>: DbCursorRW<T> + DbCursorRO<T> + Send + Sync;
     /// Read-Write DupCursor type
     type DupCursorMut<T: DupSort>: DbDupCursorRW<T>
-    + DbCursorRW<T>
-    + DbDupCursorRO<T>
-    + DbCursorRO<T>
-    + Send
-    + Sync;
+        + DbCursorRW<T>
+        + DbDupCursorRO<T>
+        + DbCursorRO<T>
+        + Send
+        + Sync;
     /// Put value to database
     fn put<T: Table>(&self, key: T::Key, value: T::Value) -> Result<(), Error>;
     /// Delete value from database

--- a/docs/crates/db.md
+++ b/docs/crates/db.md
@@ -65,24 +65,23 @@ There are many tables within the node, all used to store different types of data
 
 ## Database
 
-Reth's database design revolves around it's main [Database trait](https://github.com/paradigmxyz/reth/blob/eaca2a4a7fbbdc2f5cd15eab9a8a18ede1891bda/crates/storage/db/src/abstraction/database.rs#L21), which takes advantage of [generic associated types](https://blog.rust-lang.org/2022/10/28/gats-stabilization.html) and [a few design tricks](https://sabrinajewson.org/blog/the-better-alternative-to-lifetime-gats#the-better-gats) to implement the database's functionality across many types. Let's take a quick look at the `Database` trait and how it works.
+Reth's database design revolves around it's main [Database trait](https://github.com/paradigmxyz/reth/blob/eaca2a4a7fbbdc2f5cd15eab9a8a18ede1891bda/crates/storage/db/src/abstraction/database.rs#L21), which implements the database's functionality across many types. Let's take a quick look at the `Database` trait and how it works.
 
 [File: crates/storage/db/src/abstraction/database.rs](https://github.com/paradigmxyz/reth/blob/eaca2a4a7fbbdc2f5cd15eab9a8a18ede1891bda/crates/storage/db/src/abstraction/database.rs#L21)
 
 ```rust ignore
 /// Main Database trait that spawns transactions to be executed.
-pub trait Database: for<'a> DatabaseGAT<'a> {
-    /// Create read only transaction.
-    fn tx(&self) -> Result<<Self as DatabaseGAT<'_>>::TX, Error>;
-
-    /// Create read write transaction only possible if database is open with write access.
-    fn tx_mut(&self) -> Result<<Self as DatabaseGAT<'_>>::TXMut, Error>;
+pub trait Database {
+    /// RO database transaction
+    type TX: DbTx + Send + Sync + Debug;
+    /// RW database transaction
+    type TXMut: DbTxMut + DbTx + TableImporter + Send + Sync + Debug;
 
     /// Takes a function and passes a read-only transaction into it, making sure it's closed in the
     /// end of the execution.
     fn view<T, F>(&self, f: F) -> Result<T, Error>
     where
-        F: Fn(&<Self as DatabaseGAT<'_>>::TX) -> T,
+        F: Fn(&<Self as Database>::TX) -> T,
     {
         let tx = self.tx()?;
 
@@ -96,7 +95,7 @@ pub trait Database: for<'a> DatabaseGAT<'a> {
     /// the end of the execution.
     fn update<T, F>(&self, f: F) -> Result<T, Error>
     where
-        F: Fn(&<Self as DatabaseGAT<'_>>::TXMut) -> T,
+        F: Fn(&<Self as Database>::TXMut) -> T,
     {
         let tx = self.tx_mut()?;
 
@@ -116,7 +115,7 @@ Any type that implements the `Database` trait can create a database transaction,
 pub struct Transaction<'this, DB: Database> {
     /// A handle to the DB.
     pub(crate) db: &'this DB,
-    tx: Option<<DB as DatabaseGAT<'this>>::TXMut>,
+    tx: Option<<DB as Database>::TXMut>,
 }
 
 //--snip--
@@ -134,26 +133,10 @@ where
 }
 ```
 
-The `Database` trait also implements the `DatabaseGAT` trait which defines two associated types `TX` and `TXMut`.
+The `Database` defines two associated types `TX` and `TXMut`.
 
 [File: crates/storage/db/src/abstraction/database.rs](https://github.com/paradigmxyz/reth/blob/main/crates/storage/db/src/abstraction/database.rs#L11)
 
-```rust ignore
-/// Implements the GAT method from:
-/// https://sabrinajewson.org/blog/the-better-alternative-to-lifetime-gats#the-better-gats.
-///
-/// Sealed trait which cannot be implemented by 3rd parties, exposed only for implementers
-pub trait DatabaseGAT<'a, __ImplicitBounds: Sealed = Bounds<&'a Self>>: Send + Sync {
-    /// RO database transaction
-    type TX: DbTx + Send + Sync;
-    /// RW database transaction
-    type TXMut: DbTxMut + DbTx + Send + Sync;
-}
-```
-
-In Rust, associated types are like generics in that they can be any type fitting the generic's definition, with the difference being that associated types are associated with a trait and can only be used in the context of that trait.
-
-In the code snippet above, the `DatabaseGAT` trait has two associated types, `TX` and `TXMut`.
 
 The `TX` type can be any type that implements the `DbTx` trait, which provides a set of functions to interact with read only transactions.
 
@@ -161,16 +144,21 @@ The `TX` type can be any type that implements the `DbTx` trait, which provides a
 
 ```rust ignore
 /// Read only transaction
-pub trait DbTx: for<'a> DbTxGAT<'a> {
+pub trait DbTx: Send + Sync {
+    /// Cursor type for this read-only transaction
+    type Cursor<T: Table>: DbCursorRO<T> + Send + Sync;
+    /// DupCursor type for this read-only transaction
+    type DupCursor<T: DupSort>: DbDupCursorRO<T> + DbCursorRO<T> + Send + Sync;
+    
     /// Get value
     fn get<T: Table>(&self, key: T::Key) -> Result<Option<T::Value>, Error>;
     /// Commit for read only transaction will consume and free transaction and allows
     /// freeing of memory pages
     fn commit(self) -> Result<bool, Error>;
     /// Iterate over read only values in table.
-    fn cursor<T: Table>(&self) -> Result<<Self as DbTxGAT<'_>>::Cursor<T>, Error>;
+    fn cursor<T: Table>(&self) -> Result<Self::Cursor<T>, Error>;
     /// Iterate over read only values in dup sorted table.
-    fn cursor_dup<T: DupSort>(&self) -> Result<<Self as DbTxGAT<'_>>::DupCursor<T>, Error>;
+    fn cursor_dup<T: DupSort>(&self) -> Result<Self::DupCursor<T>, Error>;
 }
 ```
 
@@ -180,7 +168,16 @@ The `TXMut` type can be any type that implements the `DbTxMut` trait, which prov
 
 ```rust ignore
 /// Read write transaction that allows writing to database
-pub trait DbTxMut: for<'a> DbTxMutGAT<'a> {
+pub trait DbTxMut: Send + Sync {
+    /// Read-Write Cursor type
+    type CursorMut<T: Table>: DbCursorRW<T> + DbCursorRO<T> + Send + Sync;
+    /// Read-Write DupCursor type
+    type DupCursorMut<T: DupSort>: DbDupCursorRW<T>
+    + DbCursorRW<T>
+    + DbDupCursorRO<T>
+    + DbCursorRO<T>
+    + Send
+    + Sync;
     /// Put value to database
     fn put<T: Table>(&self, key: T::Key, value: T::Value) -> Result<(), Error>;
     /// Delete value from database
@@ -188,11 +185,11 @@ pub trait DbTxMut: for<'a> DbTxMutGAT<'a> {
     /// Clears database.
     fn clear<T: Table>(&self) -> Result<(), Error>;
     /// Cursor for writing
-    fn cursor_write<T: Table>(&self) -> Result<<Self as DbTxMutGAT<'_>>::CursorMut<T>, Error>;
+    fn cursor_write<T: Table>(&self) -> Result<Self::CursorMut<T>, Error>;
     /// DupCursor for writing
     fn cursor_dup_write<T: DupSort>(
         &self,
-    ) -> Result<<Self as DbTxMutGAT<'_>>::DupCursorMut<T>, Error>;
+    ) -> Result<Self::DupCursorMut<T>, Error>;
 }
 ```
 
@@ -220,14 +217,14 @@ where
 
 //--snip--
 impl<'a, DB: Database> Deref for Transaction<'a, DB> {
-    type Target = <DB as DatabaseGAT<'a>>::TXMut;
+    type Target = <DB as Database>::TXMut;
     fn deref(&self) -> &Self::Target {
         self.tx.as_ref().expect("Tried getting a reference to a non-existent transaction")
     }
 }
 ```
 
-The `Transaction` struct implements the `Deref` trait, which returns a reference to its `tx` field, which is a `TxMut`. Recall that `TxMut` is a generic type on the `DatabaseGAT` trait, which is defined as `type TXMut: DbTxMut + DbTx + Send + Sync;`, giving it access to all of the functions available to `DbTx`, including the `DbTx::get()` function.
+The `Transaction` struct implements the `Deref` trait, which returns a reference to its `tx` field, which is a `TxMut`. Recall that `TxMut` is a generic type on the `Database` trait, which is defined as `type TXMut: DbTxMut + DbTx + Send + Sync;`, giving it access to all of the functions available to `DbTx`, including the `DbTx::get()` function.
 
 Notice that the function uses a [turbofish](https://techblog.tonsser.com/posts/what-is-rusts-turbofish) to define which table to use when passing in the `key` to the `DbTx::get()` function. Taking a quick look at the function definition, a generic `T` is defined that implements the `Table` trait mentioned at the beginning of this chapter.
 
@@ -268,18 +265,8 @@ This next example uses the `DbTx::cursor()` method to get a `Cursor`. The `Curso
 
 ```
 
-We are almost at the last stop in the tour of the `db` crate. In addition to the methods provided by the `DbTx` and `DbTxMut` traits, `DbTx` also inherits the `DbTxGAT` trait, while `DbTxMut` inherits `DbTxMutGAT`. These next two traits provide various associated types related to cursors as well as methods to utilize the cursor types.
+We are almost at the last stop in the tour of the `db` crate. In addition to the methods provided by the `DbTx` and `DbTxMut` traits. These traits provide various associated types related to cursors as well as methods to utilize the cursor types.
 
-[File: crates/storage/db/src/abstraction/transaction.rs](https://github.com/paradigmxyz/reth/blob/main/crates/storage/db/src/abstraction/transaction.rs#L12-L17)
-
-```rust ignore
-pub trait DbTxGAT<'a, __ImplicitBounds: Sealed = Bounds<&'a Self>>: Send + Sync {
-    /// Cursor GAT
-    type Cursor<T: Table>: DbCursorRO<'a, T> + Send + Sync;
-    /// DupCursor GAT
-    type DupCursor<T: DupSort>: DbDupCursorRO<'a, T> + DbCursorRO<'a, T> + Send + Sync;
-}
-```
 
 Lets look at an examples of how cursors are used. The code snippet below contains the `unwind` method from the `BodyStage` defined in the `stages` crate. This function is responsible for unwinding any changes to the database if there is an error when executing the body stage within the Reth pipeline.
 


### PR DESCRIPTION
~~blocked by https://github.com/paradigmxyz/reth/pull/5476~~

* no more separate GAT traits
* no more lifetimes in StateProvider

collapsed GAT traits into the traits that inherited those

