### PR TITLE
pipeline: error on missing buffer in online stages

### DIFF
--- a/crates/stages/src/error.rs
+++ b/crates/stages/src/error.rs
@@ -62,6 +62,10 @@ pub enum StageError {
     /// Invalid checkpoint passed to the stage
     #[error("invalid stage checkpoint: {0}")]
     StageCheckpoint(u64),
+    /// Missing buffer on stage execution.
+    /// Returned if stage execution was called without polling for readiness.
+    #[error("missing buffer")]
+    MissingBuffer,
     /// Download channel closed
     #[error("download channel closed")]
     ChannelClosed,
@@ -97,6 +101,7 @@ impl StageError {
                 StageError::Download(_) |
                 StageError::DatabaseIntegrity(_) |
                 StageError::StageCheckpoint(_) |
+                StageError::MissingBuffer |
                 StageError::MissingSyncGap |
                 StageError::ChannelClosed |
                 StageError::Fatal(_)

--- a/crates/stages/src/error.rs
+++ b/crates/stages/src/error.rs
@@ -62,10 +62,10 @@ pub enum StageError {
     /// Invalid checkpoint passed to the stage
     #[error("invalid stage checkpoint: {0}")]
     StageCheckpoint(u64),
-    /// Missing buffer on stage execution.
+    /// Missing download buffer on stage execution.
     /// Returned if stage execution was called without polling for readiness.
-    #[error("missing buffer")]
-    MissingBuffer,
+    #[error("missing download buffer")]
+    MissingDownloadBuffer,
     /// Download channel closed
     #[error("download channel closed")]
     ChannelClosed,
@@ -101,7 +101,7 @@ impl StageError {
                 StageError::Download(_) |
                 StageError::DatabaseIntegrity(_) |
                 StageError::StageCheckpoint(_) |
-                StageError::MissingBuffer |
+                StageError::MissingDownloadBuffer |
                 StageError::MissingSyncGap |
                 StageError::ChannelClosed |
                 StageError::Fatal(_)

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -119,7 +119,7 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
 
         debug!(target: "sync::stages::bodies", stage_progress = from_block, target = to_block, start_tx_id = next_tx_num, "Commencing sync");
 
-        let buffer = self.buffer.take().ok_or(StageError::MissingBuffer)?;
+        let buffer = self.buffer.take().ok_or(StageError::MissingDownloadBuffer)?;
         trace!(target: "sync::stages::bodies", bodies_len = buffer.len(), "Writing blocks");
         let mut highest_block = from_block;
         for response in buffer {

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -189,7 +189,7 @@ where
         let local_head = gap.local_head.number;
         let tip = gap.target.tip();
 
-        let downloaded_headers = self.buffer.take().ok_or(StageError::MissingBuffer)?;
+        let downloaded_headers = self.buffer.take().ok_or(StageError::MissingDownloadBuffer)?;
         let tip_block_number = match tip {
             // If tip is hash and it equals to the first downloaded header's hash, we can use
             // the block number of this header as tip.


### PR DESCRIPTION
## Description

Error on missing buffer in online stages. This will ensure that `Stage::poll_execute_ready` was called before `Stage::execute`.