### PR TITLE
chore: Upgrade `revm`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6635,7 +6635,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "3.5.0"
-source = "git+https://github.com/bluealloy/revm?rev=1609e07c68048909ad1682c98cf2b9baa76310b5#1609e07c68048909ad1682c98cf2b9baa76310b5"
+source = "git+https://github.com/clabby/revm?branch=cl/canyon-hardfork#2731282f33d06c35fcba15450b5014ba18cef586"
 dependencies = [
  "auto_impl",
  "revm-interpreter",
@@ -6645,7 +6645,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "1.3.0"
-source = "git+https://github.com/bluealloy/revm?rev=1609e07c68048909ad1682c98cf2b9baa76310b5#1609e07c68048909ad1682c98cf2b9baa76310b5"
+source = "git+https://github.com/clabby/revm?branch=cl/canyon-hardfork#2731282f33d06c35fcba15450b5014ba18cef586"
 dependencies = [
  "revm-primitives",
 ]
@@ -6653,7 +6653,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "2.2.0"
-source = "git+https://github.com/bluealloy/revm?rev=1609e07c68048909ad1682c98cf2b9baa76310b5#1609e07c68048909ad1682c98cf2b9baa76310b5"
+source = "git+https://github.com/clabby/revm?branch=cl/canyon-hardfork#2731282f33d06c35fcba15450b5014ba18cef586"
 dependencies = [
  "aurora-engine-modexp",
  "c-kzg",
@@ -6669,7 +6669,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "1.3.0"
-source = "git+https://github.com/bluealloy/revm?rev=1609e07c68048909ad1682c98cf2b9baa76310b5#1609e07c68048909ad1682c98cf2b9baa76310b5"
+source = "git+https://github.com/clabby/revm?branch=cl/canyon-hardfork#2731282f33d06c35fcba15450b5014ba18cef586"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,8 +135,8 @@ reth-transaction-pool = { path = "crates/transaction-pool" }
 reth-trie = { path = "crates/trie" }
 
 # revm
-revm = { git = "https://github.com/bluealloy/revm", rev = "1609e07c68048909ad1682c98cf2b9baa76310b5" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "1609e07c68048909ad1682c98cf2b9baa76310b5" }
+revm = { git = "https://github.com/clabby/revm", branch = "cl/canyon-hardfork" }
+revm-primitives = { git = "https://github.com/clabby/revm", branch = "cl/canyon-hardfork" }
 
 # eth
 alloy-primitives = "0.4"

--- a/crates/revm/revm-inspectors/src/access_list.rs
+++ b/crates/revm/revm-inspectors/src/access_list.rs
@@ -1,7 +1,7 @@
 use reth_primitives::{AccessList, AccessListItem, Address, B256};
 use revm::{
     interpreter::{opcode, Interpreter},
-    Database, EVMData, Inspector,
+    Database, EvmContext, Inspector,
 };
 use std::collections::{BTreeSet, HashMap, HashSet};
 
@@ -61,7 +61,7 @@ impl<DB> Inspector<DB> for AccessListInspector
 where
     DB: Database,
 {
-    fn step(&mut self, interpreter: &mut Interpreter<'_>, _data: &mut EVMData<'_, DB>) {
+    fn step(&mut self, interpreter: &mut Interpreter, _context: &mut EvmContext<'_, DB>) {
         match interpreter.current_opcode() {
             opcode::SLOAD | opcode::SSTORE => {
                 if let Ok(slot) = interpreter.stack().peek(0) {

--- a/crates/revm/revm-inspectors/src/stack/mod.rs
+++ b/crates/revm/revm-inspectors/src/stack/mod.rs
@@ -166,9 +166,9 @@ where
 
             // If the inspector returns a different ret or a revert with a non-empty message,
             // we assume it wants to tell us something
-            if new_result.result != result.result
-                || (new_result.result == InstructionResult::Revert
-                    && new_result.output != result.output)
+            if new_result.result != result.result ||
+                (new_result.result == InstructionResult::Revert &&
+                    new_result.output != result.output)
             {
                 return new_result;
             }

--- a/crates/revm/revm-inspectors/src/tracing/opcount.rs
+++ b/crates/revm/revm-inspectors/src/tracing/opcount.rs
@@ -2,7 +2,7 @@
 //!
 //! See also <https://geth.ethereum.org/docs/developers/evm-tracing/built-in-tracers>
 
-use revm::{interpreter::Interpreter, Database, EVMData, Inspector};
+use revm::{interpreter::Interpreter, Database, EvmContext, Inspector};
 
 /// An inspector that counts all opcodes.
 #[derive(Debug, Clone, Copy, Default)]
@@ -23,7 +23,7 @@ impl<DB> Inspector<DB> for OpcodeCountInspector
 where
     DB: Database,
 {
-    fn step(&mut self, _interp: &mut Interpreter<'_>, _data: &mut EVMData<'_, DB>) {
+    fn step(&mut self, _interp: &mut Interpreter, _data: &mut EvmContext<'_, DB>) {
         self.count += 1;
     }
 }

--- a/crates/rpc/rpc/src/eth/revm_utils.rs
+++ b/crates/rpc/rpc/src/eth/revm_utils.rs
@@ -111,7 +111,7 @@ impl FillableTransaction for TransactionSigned {
 #[inline]
 pub(crate) fn get_precompiles(spec_id: SpecId) -> impl IntoIterator<Item = Address> {
     let spec = PrecompilesSpecId::from_spec_id(spec_id);
-    Precompiles::new(spec).addresses().into_iter().copied().map(Address::from)
+    Precompiles::new(spec).addresses().copied().map(Address::from)
 }
 
 /// Executes the [Env] against the given [Database] without committing state changes.
@@ -185,7 +185,7 @@ where
     for tx in transactions.into_iter() {
         if tx.hash() == target_tx_hash {
             // reached the target transaction
-            break
+            break;
         }
 
         tx.try_fill_tx_env(&mut evm.env.tx)?;
@@ -281,7 +281,7 @@ pub(crate) fn build_call_evm_env(
 pub(crate) fn create_txn_env(block_env: &BlockEnv, request: CallRequest) -> EthResult<TxEnv> {
     // Ensure that if versioned hashes are set, they're not empty
     if request.has_empty_blob_hashes() {
-        return Err(RpcInvalidTransactionError::BlobTransactionMissingBlobHashes.into())
+        return Err(RpcInvalidTransactionError::BlobTransactionMissingBlobHashes.into());
     }
 
     let CallRequest {
@@ -429,7 +429,7 @@ impl CallFees {
                     return Err(
                         // `max_priority_fee_per_gas` is greater than the `max_fee_per_gas`
                         RpcInvalidTransactionError::TipAboveFeeCap.into(),
-                    )
+                    );
                 }
             }
             Ok(())
@@ -466,7 +466,7 @@ impl CallFees {
                 // Ensure blob_hashes are present
                 if !has_blob_hashes {
                     // Blob transaction but no blob hashes
-                    return Err(RpcInvalidTransactionError::BlobTransactionMissingBlobHashes.into())
+                    return Err(RpcInvalidTransactionError::BlobTransactionMissingBlobHashes.into());
                 }
 
                 Ok(CallFees {


### PR DESCRIPTION
## Overview

> **Note**
> Do not merge, currently patched with my own fork. Will redirect at `revm`'s head once https://github.com/bluealloy/revm/pull/871 has been merged.

Upgrades `revm` to the latest version, which includes the `Canyon` hardfork. This unblocks implementing the `Canyon` hardfork for `op-reth`, tracked in #5210.

**Metadata**
Closes #5490 