### PR TITLE
feat(primitives): Add `Canyon` Hardfork to ChainSpec

### DIFF
--- a/crates/primitives/src/hardfork.rs
+++ b/crates/primitives/src/hardfork.rs
@@ -47,6 +47,9 @@ pub enum Hardfork {
     /// Regolith
     #[cfg(feature = "optimism")]
     Regolith,
+    /// Canyon
+    #[cfg(feature = "optimism")]
+    Canyon,
 }
 
 impl Hardfork {
@@ -95,6 +98,8 @@ impl FromStr for Hardfork {
             "bedrock" => Hardfork::Bedrock,
             #[cfg(feature = "optimism")]
             "regolith" => Hardfork::Regolith,
+            #[cfg(feature = "optimism")]
+            "canyon" => Hardfork::Canyon,
             _ => return Err(format!("Unknown hardfork: {s}")),
         };
         Ok(hardfork)
@@ -163,8 +168,8 @@ mod tests {
     #[test]
     #[cfg(feature = "optimism")]
     fn check_op_hardfork_from_str() {
-        let hardfork_str = ["beDrOck", "rEgOlITH"];
-        let expected_hardforks = [Hardfork::Bedrock, Hardfork::Regolith];
+        let hardfork_str = ["beDrOck", "rEgOlITH", "cAnYoN"];
+        let expected_hardforks = [Hardfork::Bedrock, Hardfork::Regolith, Hardfork::Canyon];
 
         let hardforks: Vec<Hardfork> =
             hardfork_str.iter().map(|h| Hardfork::from_str(h).unwrap()).collect();

--- a/crates/primitives/src/revm/config.rs
+++ b/crates/primitives/src/revm/config.rs
@@ -10,10 +10,12 @@ pub fn revm_spec_by_timestamp_after_merge(
 ) -> revm_primitives::SpecId {
     #[cfg(feature = "optimism")]
     if chain_spec.is_optimism() {
-        if chain_spec.fork(Hardfork::Regolith).active_at_timestamp(timestamp) {
-            return revm_primitives::REGOLITH
+        if chain_spec.fork(Hardfork::Canyon).active_at_timestamp(timestamp) {
+            unimplemented!()
+        } else if chain_spec.fork(Hardfork::Regolith).active_at_timestamp(timestamp) {
+            return revm_primitives::REGOLITH;
         } else {
-            return revm_primitives::BEDROCK
+            return revm_primitives::BEDROCK;
         }
     }
 
@@ -30,10 +32,12 @@ pub fn revm_spec_by_timestamp_after_merge(
 pub fn revm_spec(chain_spec: &ChainSpec, block: Head) -> revm_primitives::SpecId {
     #[cfg(feature = "optimism")]
     if chain_spec.is_optimism() {
-        if chain_spec.fork(Hardfork::Regolith).active_at_head(&block) {
-            return revm_primitives::REGOLITH
+        if chain_spec.fork(Hardfork::Canyon).active_at_head(&block) {
+            unimplemented!()
+        } else if chain_spec.fork(Hardfork::Regolith).active_at_head(&block) {
+            return revm_primitives::REGOLITH;
         } else if chain_spec.fork(Hardfork::Bedrock).active_at_head(&block) {
-            return revm_primitives::BEDROCK
+            return revm_primitives::BEDROCK;
         }
     }
 
@@ -138,6 +142,11 @@ mod tests {
                 f(cs).build()
             }
 
+            // TODO: Enable once `reth` has been updated to a revm version that knows about Canyon.
+            // assert_eq!(
+            //     revm_spec(&op_cs(|cs| cs.canyon_activated()), Head::default()),
+            //     revm_primitives::CANYON
+            // );
             assert_eq!(
                 revm_spec(&op_cs(|cs| cs.bedrock_activated()), Head::default()),
                 revm_primitives::BEDROCK


### PR DESCRIPTION
## Overview

> Note: Blocked by https://github.com/bluealloy/revm/pull/871 & https://github.com/paradigmxyz/reth/pull/5489

Adds the `Canyon` hardfork to the OP Goerli and Base Goerli chainspecs.