### PR TITLE
perf(provider): compute hashes and trie updates before opening write tx

### DIFF
--- a/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
+++ b/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
@@ -154,7 +154,7 @@ impl BundleStateWithReceipts {
         hashed_state.sorted()
     }
 
-    /// Returns [StateRoot] calculator base on database and in-memory state.
+    /// Returns [StateRoot] calculator based on database and in-memory state.
     pub fn state_root_calculator<'a, 'b, TX: DbTx>(
         &self,
         tx: &'a TX,

--- a/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
+++ b/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
@@ -128,7 +128,6 @@ impl BundleStateWithReceipts {
     ///
     /// The hashed post state.
     pub fn hash_state_slow(&self) -> HashedPostState {
-        //let mut storages = BTreeMap::default();
         let mut hashed_state = HashedPostState::default();
 
         for (address, account) in self.bundle.state() {
@@ -136,7 +135,7 @@ impl BundleStateWithReceipts {
             if let Some(account) = &account.info {
                 hashed_state.insert_account(hashed_address, into_reth_acc(account.clone()))
             } else {
-                hashed_state.insert_cleared_account(hashed_address);
+                hashed_state.insert_destroyed_account(hashed_address);
             }
 
             // insert storage.
@@ -155,8 +154,8 @@ impl BundleStateWithReceipts {
         hashed_state.sorted()
     }
 
-    /// Returns [StateRoot] calculator.
-    fn state_root_calculator<'a, 'b, TX: DbTx>(
+    /// Returns [StateRoot] calculator base on database and in-memory state.
+    pub fn state_root_calculator<'a, 'b, TX: DbTx>(
         &self,
         tx: &'a TX,
         hashed_post_state: &'b HashedPostState,
@@ -167,6 +166,7 @@ impl BundleStateWithReceipts {
             .with_hashed_cursor_factory(hashed_cursor_factory)
             .with_changed_account_prefixes(account_prefix_set)
             .with_changed_storage_prefixes(storage_prefix_set)
+            .with_destroyed_accounts(hashed_post_state.destroyed_accounts())
     }
 
     /// Calculate the state root for this [BundleState].

--- a/crates/storage/provider/src/bundle_state/hashed_state_changes.rs
+++ b/crates/storage/provider/src/bundle_state/hashed_state_changes.rs
@@ -1,0 +1,77 @@
+use reth_db::{
+    cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO, DbDupCursorRW},
+    tables,
+    transaction::{DbTx, DbTxMut},
+    DatabaseError,
+};
+use reth_primitives::{Account, StorageEntry, B256, U256};
+use reth_trie::hashed_cursor::HashedPostState;
+use std::collections::BTreeMap;
+
+/// A change to the state of the world.
+#[derive(Debug, Default)]
+pub struct HashedStateChanges(pub HashedPostState);
+
+impl HashedStateChanges {
+    /// Write the bundle state to the database.
+    pub fn write_to_db<TX: DbTxMut + DbTx>(self, tx: &TX) -> Result<(), DatabaseError> {
+        // Collect hashed account changes.
+        let mut hashed_accounts = BTreeMap::<B256, Option<Account>>::default();
+        for hashed_address in self.0.destroyed_accounts {
+            hashed_accounts.insert(hashed_address, None);
+        }
+        for (hashed_address, account) in self.0.accounts {
+            hashed_accounts.insert(hashed_address, Some(account));
+        }
+
+        // Write hashed account updates.
+        let mut hashed_accounts_cursor = tx.cursor_write::<tables::HashedAccount>()?;
+        for (hashed_address, account) in hashed_accounts {
+            if let Some(account) = account {
+                hashed_accounts_cursor.upsert(hashed_address, account)?;
+            } else if hashed_accounts_cursor.seek_exact(hashed_address)?.is_some() {
+                hashed_accounts_cursor.delete_current()?;
+            }
+        }
+
+        // Collect hashed storage changes.
+        let mut hashed_storages = BTreeMap::<B256, (bool, BTreeMap<B256, U256>)>::default();
+        for (hashed_address, storage) in self.0.storages {
+            let entry = hashed_storages.entry(hashed_address).or_default();
+            if storage.wiped {
+                entry.0 |= storage.wiped;
+            }
+            for (hashed_slot, value) in storage.non_zero_valued_storage {
+                entry.1.insert(hashed_slot, value);
+            }
+            for slot in storage.zero_valued_slots {
+                entry.1.insert(slot, U256::ZERO);
+            }
+        }
+
+        // Write hashed storage changes.
+        let mut hashed_storage_cursor = tx.cursor_dup_write::<tables::HashedStorage>()?;
+        for (hashed_address, (wiped, storage)) in hashed_storages {
+            if wiped && hashed_storage_cursor.seek_exact(hashed_address)?.is_some() {
+                hashed_storage_cursor.delete_current_duplicates()?;
+            }
+
+            for (hashed_slot, value) in storage {
+                let entry = StorageEntry { key: hashed_slot, value };
+                if let Some(db_entry) =
+                    hashed_storage_cursor.seek_by_key_subkey(hashed_address, entry.key)?
+                {
+                    if db_entry.key == entry.key {
+                        hashed_storage_cursor.delete_current()?;
+                    }
+                }
+
+                if entry.value != U256::ZERO {
+                    hashed_storage_cursor.upsert(hashed_address, entry)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/storage/provider/src/bundle_state/hashed_state_changes.rs
+++ b/crates/storage/provider/src/bundle_state/hashed_state_changes.rs
@@ -8,7 +8,7 @@ use reth_primitives::{Account, StorageEntry, B256, U256};
 use reth_trie::hashed_cursor::HashedPostState;
 use std::collections::BTreeMap;
 
-/// A change to the state of the world.
+/// Changes to the hashed state.
 #[derive(Debug, Default)]
 pub struct HashedStateChanges(pub HashedPostState);
 

--- a/crates/storage/provider/src/bundle_state/mod.rs
+++ b/crates/storage/provider/src/bundle_state/mod.rs
@@ -1,11 +1,13 @@
 //! Bundle state module.
 //! This module contains all the logic related to bundle state.
 mod bundle_state_with_receipts;
+mod hashed_state_changes;
 mod state_changes;
 mod state_reverts;
 
 pub use bundle_state_with_receipts::{
     AccountRevertInit, BundleStateInit, BundleStateWithReceipts, OriginalValuesKnown, RevertsInit,
 };
+pub use hashed_state_changes::HashedStateChanges;
 pub use state_changes::StateChanges;
 pub use state_reverts::StateReverts;

--- a/crates/storage/provider/src/traits/block.rs
+++ b/crates/storage/provider/src/traits/block.rs
@@ -10,6 +10,7 @@ use reth_primitives::{
     ChainSpec, Header, PruneModes, Receipt, SealedBlock, SealedBlockWithSenders, SealedHeader,
     B256,
 };
+use reth_trie::{hashed_cursor::HashedPostState, updates::TrieUpdates};
 use std::ops::RangeInclusive;
 
 /// Enum to control transaction hash inclusion.
@@ -291,10 +292,12 @@ pub trait BlockWriter: Send + Sync {
     /// # Returns
     ///
     /// Returns `Ok(())` on success, or an error if any operation fails.
-    fn append_blocks_with_bundle_state(
+    fn append_blocks_with_state(
         &self,
         blocks: Vec<SealedBlockWithSenders>,
         state: BundleStateWithReceipts,
+        hashed_state: HashedPostState,
+        trie_updates: TrieUpdates,
         prune_modes: Option<&PruneModes>,
     ) -> ProviderResult<()>;
 }

--- a/crates/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/src/hashed_cursor/post_state.rs
@@ -38,7 +38,7 @@ impl HashedStorage {
     }
 
     /// Returns all storage slots.
-    pub fn storage_slots<'a>(&'a self) -> impl Iterator<Item = (B256, U256)> + 'a {
+    pub fn storage_slots(&self) -> impl Iterator<Item = (B256, U256)> + '_ {
         self.zero_valued_slots
             .iter()
             .map(|slot| (*slot, U256::ZERO))
@@ -98,7 +98,7 @@ impl HashedPostState {
     }
 
     /// Returns all accounts with their state.
-    pub fn accounts<'a>(&'a self) -> impl Iterator<Item = (B256, Option<Account>)> + 'a {
+    pub fn accounts(&self) -> impl Iterator<Item = (B256, Option<Account>)> + '_ {
         self.destroyed_accounts.iter().map(|hashed_address| (*hashed_address, None)).chain(
             self.accounts.iter().map(|(hashed_address, account)| (*hashed_address, Some(*account))),
         )


### PR DESCRIPTION
## Description

Continuation of the freelist saga https://github.com/paradigmxyz/reth/issues/5228

This PR aims to decrease the duration for which the write transaction is open during canonical commit. This is done by computing state hashes and merkle root with updates before opening a write transaction.