### PR TITLE
fix: dont skip gas used ratio if empty

### DIFF
--- a/crates/rpc/rpc-types/src/eth/fee.rs
+++ b/crates/rpc/rpc-types/src/eth/fee.rs
@@ -36,9 +36,8 @@ pub struct FeeHistory {
     ///
     /// # Note
     ///
-    /// The `Option` is only for compatability with Erigon and Geth.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(default)]
+    /// Empty list is skipped only for compatability with Erigon and Geth.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub base_fee_per_gas: Vec<U256>,
     /// An array of block gas used ratios. These are calculated as the ratio
     /// of `gasUsed` and `gasLimit`.
@@ -46,13 +45,11 @@ pub struct FeeHistory {
     /// # Note
     ///
     /// The `Option` is only for compatability with Erigon and Geth.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(default)]
     pub gas_used_ratio: Vec<f64>,
     /// Lowest number block of the returned range.
     pub oldest_block: U256,
     /// An (optional) array of effective priority fee per gas data points from a single
     /// block. All zeroes are returned if the block is empty.
-    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub reward: Option<Vec<Vec<U256>>>,
 }

--- a/crates/rpc/rpc-types/src/eth/fee.rs
+++ b/crates/rpc/rpc-types/src/eth/fee.rs
@@ -36,7 +36,7 @@ pub struct FeeHistory {
     ///
     /// # Note
     ///
-    /// Empty list is skipped only for compatability with Erigon and Geth.
+    /// Empty list is skipped only for compatibility with Erigon and Geth.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub base_fee_per_gas: Vec<U256>,
     /// An array of block gas used ratios. These are calculated as the ratio


### PR DESCRIPTION
ref 

https://github.com/ethereum/go-ethereum/blob/0004c6b229b787281760b14fb9460ffd9c2496f1/internal/ethapi/api.go#L84-L88

I'm keeping the Option of reward, because we currently have a PR that touches that code, can refactor this to Vec Vec after that