### PR TITLE
fix(op-reth): clear accesslist for Deposit txs

### DIFF
--- a/crates/primitives/src/revm/env.rs
+++ b/crates/primitives/src/revm/env.rs
@@ -309,6 +309,7 @@ pub fn fill_tx_env<T>(
         }
         #[cfg(feature = "optimism")]
         Transaction::Deposit(tx) => {
+            tx_env.access_list.clear();
             tx_env.gas_limit = tx.gas_limit;
             tx_env.gas_price = U256::ZERO;
             tx_env.gas_priority_fee = None;


### PR DESCRIPTION
`op-reth` cannot sync past block `3106894` on base mainnet. 

This is because `fill_tx_env` does not clear the access list for `Transaction::Deposit`.  So if the last transaction in the previous block used an access list, the next block (such as 3106894) will fail to execute due to `BlockGasUsed` mismatch error. This PR should fix that