### PR TITLE
feat(bin): improve status logs

### DIFF
--- a/bin/reth/src/chain/import.rs
+++ b/bin/reth/src/chain/import.rs
@@ -109,12 +109,12 @@ impl ImportCommand {
         pipeline.set_tip(tip);
         debug!(target: "reth::cli", ?tip, "Tip manually set");
 
-        let factory = ProviderFactory::new(&db, self.chain.clone());
+        let factory = ProviderFactory::new(db.clone(), self.chain.clone());
         let provider = factory.provider()?;
 
         let latest_block_number =
             provider.get_stage_checkpoint(StageId::Finish)?.map(|ch| ch.block_number);
-        tokio::spawn(handle_events(None, latest_block_number, events));
+        tokio::spawn(handle_events(None, latest_block_number, events, db.clone()));
 
         // Run pipeline
         info!(target: "reth::cli", "Starting sync pipeline");

--- a/bin/reth/src/debug_cmd/execution.rs
+++ b/bin/reth/src/debug_cmd/execution.rs
@@ -235,7 +235,7 @@ impl Command {
             &ctx.task_executor,
         )?;
 
-        let factory = ProviderFactory::new(&db, self.chain.clone());
+        let factory = ProviderFactory::new(db.clone(), self.chain.clone());
         let provider = factory.provider()?;
 
         let latest_block_number =
@@ -252,7 +252,7 @@ impl Command {
         );
         ctx.task_executor.spawn_critical(
             "events task",
-            events::handle_events(Some(network.clone()), latest_block_number, events),
+            events::handle_events(Some(network.clone()), latest_block_number, events, db.clone()),
         );
 
         let mut current_max_block = latest_block_number.unwrap_or_default();

--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -294,7 +294,7 @@ where
         let mut this = self.project();
 
         while this.info_interval.poll_tick(cx).is_ready() {
-            let db_freelist = this
+            let freelist = this
                 .state
                 .db
                 .freelist()
@@ -313,7 +313,7 @@ where
                 info!(
                     target: "reth::cli",
                     connected_peers = this.state.num_connected_peers(),
-                    %db_freelist,
+                    %freelist,
                     stage = %stage_id,
                     checkpoint = checkpoint.block_number,
                     %target,
@@ -325,7 +325,7 @@ where
                 info!(
                     target: "reth::cli",
                     connected_peers = this.state.num_connected_peers(),
-                    %db_freelist,
+                    %freelist,
                     %latest_block,
                     "Status"
                 );
@@ -333,7 +333,7 @@ where
                 info!(
                     target: "reth::cli",
                     connected_peers = this.state.num_connected_peers(),
-                    %db_freelist,
+                    %freelist,
                     "Status"
                 );
             }

--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -418,8 +418,8 @@ impl Eta {
     }
 }
 
-impl std::fmt::Display for Eta {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for Eta {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         if let Some((eta, last_checkpoint_time)) = self.eta.zip(self.last_checkpoint_time) {
             let remaining = eta.checked_sub(last_checkpoint_time.elapsed());
 

--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -3,6 +3,7 @@
 use crate::node::cl_events::ConsensusLayerHealthEvent;
 use futures::Stream;
 use reth_beacon_consensus::BeaconConsensusEngineEvent;
+use reth_db::DatabaseEnv;
 use reth_interfaces::consensus::ForkchoiceState;
 use reth_network::{NetworkEvent, NetworkHandle};
 use reth_network_api::PeersInfo;
@@ -15,6 +16,7 @@ use reth_stages::{ExecOutput, PipelineEvent};
 use std::{
     future::Future,
     pin::Pin,
+    sync::Arc,
     task::{Context, Poll},
     time::{Duration, Instant},
 };
@@ -26,27 +28,30 @@ const INFO_MESSAGE_INTERVAL: Duration = Duration::from_secs(25);
 
 /// The current high-level state of the node.
 struct NodeState {
+    db: Arc<DatabaseEnv>,
     /// Connection to the network.
     network: Option<NetworkHandle>,
     /// The stage currently being executed.
-    current_stage: Option<StageId>,
-    /// The ETA for the current stage.
-    eta: Eta,
-    /// The current checkpoint of the executing stage.
-    current_checkpoint: StageCheckpoint,
+    current_stage: Option<CurrentStage>,
     /// The latest block reached by either pipeline or consensus engine.
     latest_block: Option<BlockNumber>,
 }
 
+/// The stage currently being executed.
+struct CurrentStage {
+    stage_id: StageId,
+    eta: Eta,
+    checkpoint: StageCheckpoint,
+    target: Option<BlockNumber>,
+}
+
 impl NodeState {
-    fn new(network: Option<NetworkHandle>, latest_block: Option<BlockNumber>) -> Self {
-        Self {
-            network,
-            current_stage: None,
-            eta: Eta::default(),
-            current_checkpoint: StageCheckpoint::new(0),
-            latest_block,
-        }
+    fn new(
+        db: Arc<DatabaseEnv>,
+        network: Option<NetworkHandle>,
+        latest_block: Option<BlockNumber>,
+    ) -> Self {
+        Self { db, network, current_stage: None, latest_block }
     }
 
     fn num_connected_peers(&self) -> usize {
@@ -56,70 +61,84 @@ impl NodeState {
     /// Processes an event emitted by the pipeline
     fn handle_pipeline_event(&mut self, event: PipelineEvent) {
         match event {
-            PipelineEvent::Running { pipeline_stages_progress, stage_id, checkpoint } => {
-                let notable = self.current_stage.is_none();
-                self.current_stage = Some(stage_id);
-                self.current_checkpoint = checkpoint.unwrap_or_default();
+            PipelineEvent::Run { pipeline_stages_progress, stage_id, checkpoint, target } => {
+                let checkpoint = checkpoint.unwrap_or_default();
+                let current_stage = CurrentStage {
+                    stage_id,
+                    eta: match &self.current_stage {
+                        Some(current_stage) if current_stage.stage_id == stage_id => {
+                            current_stage.eta
+                        }
+                        _ => Eta::default(),
+                    },
+                    checkpoint,
+                    target,
+                };
 
-                if notable {
-                    if let Some(progress) = self.current_checkpoint.entities() {
-                        info!(
-                            pipeline_stages = %pipeline_stages_progress,
-                            stage = %stage_id,
-                            from = self.current_checkpoint.block_number,
-                            checkpoint = %self.current_checkpoint.block_number,
-                            %progress,
-                            eta = %self.eta.fmt_for_stage(stage_id),
-                            "Executing stage",
-                        );
-                    } else {
-                        info!(
-                            pipeline_stages = %pipeline_stages_progress,
-                            stage = %stage_id,
-                            from = self.current_checkpoint.block_number,
-                            checkpoint = %self.current_checkpoint.block_number,
-                            eta = %self.eta.fmt_for_stage(stage_id),
-                            "Executing stage",
-                        );
-                    }
-                }
+                let target = target.map(|target| format!("{target}")).unwrap_or("None".to_string());
+                let progress = checkpoint
+                    .entities()
+                    .and_then(|entities| entities.fmt_percentage())
+                    .unwrap_or("None".to_string());
+                let eta = current_stage.eta.fmt_for_stage(stage_id);
+
+                info!(
+                    pipeline_stages = %pipeline_stages_progress,
+                    stage = %stage_id,
+                    checkpoint = checkpoint.block_number,
+                    target,
+                    progress,
+                    eta,
+                    "Executing stage",
+                );
+
+                self.current_stage = Some(current_stage);
             }
             PipelineEvent::Ran {
                 pipeline_stages_progress,
                 stage_id,
                 result: ExecOutput { checkpoint, done },
             } => {
-                self.current_checkpoint = checkpoint;
                 if stage_id.is_finish() {
                     self.latest_block = Some(checkpoint.block_number);
                 }
-                self.eta.update(self.current_checkpoint);
 
-                let message =
-                    if done { "Stage finished executing" } else { "Stage committed progress" };
+                if let Some(current_stage) = self.current_stage.as_mut() {
+                    current_stage.checkpoint = checkpoint;
+                    current_stage.eta.update(checkpoint);
 
-                if let Some(progress) = checkpoint.entities() {
-                    info!(
-                        pipeline_stages = %pipeline_stages_progress,
-                        stage = %stage_id,
-                        checkpoint = %checkpoint.block_number,
-                        %progress,
-                        eta = %self.eta.fmt_for_stage(stage_id),
-                        "{message}",
-                    );
-                } else {
-                    info!(
-                        pipeline_stages = %pipeline_stages_progress,
-                        stage = %stage_id,
-                        checkpoint = %checkpoint.block_number,
-                        eta = %self.eta.fmt_for_stage(stage_id),
-                        "{message}",
-                    );
+                    let target = current_stage
+                        .target
+                        .map(|target| format!("{target}"))
+                        .unwrap_or("None".to_string());
+                    let progress =
+                        checkpoint.entities().and_then(|entities| entities.fmt_percentage());
+
+                    if done {
+                        info!(
+                            pipeline_stages = %pipeline_stages_progress,
+                            stage = %stage_id,
+                            checkpoint = checkpoint.block_number,
+                            target,
+                            progress,
+                            "Stage finished executing",
+                        )
+                    } else {
+                        let eta = current_stage.eta.fmt_for_stage(stage_id);
+                        info!(
+                            pipeline_stages = %pipeline_stages_progress,
+                            stage = %stage_id,
+                            checkpoint = checkpoint.block_number,
+                            target,
+                            progress,
+                            eta,
+                            "Stage committed progress",
+                        )
+                    }
                 }
 
                 if done {
                     self.current_stage = None;
-                    self.eta = Eta::default();
                 }
             }
             _ => (),
@@ -240,10 +259,11 @@ pub async fn handle_events<E>(
     network: Option<NetworkHandle>,
     latest_block_number: Option<BlockNumber>,
     events: E,
+    db: Arc<DatabaseEnv>,
 ) where
     E: Stream<Item = NodeEvent> + Unpin,
 {
-    let state = NodeState::new(network, latest_block_number);
+    let state = NodeState::new(db, network, latest_block_number);
 
     let start = tokio::time::Instant::now() + Duration::from_secs(3);
     let mut info_interval = tokio::time::interval_at(start, INFO_MESSAGE_INTERVAL);
@@ -273,32 +293,46 @@ where
         let mut this = self.project();
 
         while this.info_interval.poll_tick(cx).is_ready() {
-            if let Some(stage) = this.state.current_stage {
-                if let Some(progress) = this.state.current_checkpoint.entities() {
-                    info!(
-                        target: "reth::cli",
-                        connected_peers = this.state.num_connected_peers(),
-                        %stage,
-                        checkpoint = %this.state.current_checkpoint.block_number,
-                        %progress,
-                        eta = %this.state.eta.fmt_for_stage(stage),
-                        "Status"
-                    );
-                } else {
-                    info!(
-                        target: "reth::cli",
-                        connected_peers = this.state.num_connected_peers(),
-                        %stage,
-                        checkpoint = %this.state.current_checkpoint.block_number,
-                        eta = %this.state.eta.fmt_for_stage(stage),
-                        "Status"
-                    );
-                }
+            let db_freelist = this
+                .state
+                .db
+                .freelist()
+                .map_or("None".to_string(), |freelist| freelist.to_string());
+
+            if let Some(CurrentStage { stage_id, eta, checkpoint, target }) =
+                &this.state.current_stage
+            {
+                let target = target.map(|target| format!("{target}")).unwrap_or("None".to_string());
+                let progress = checkpoint
+                    .entities()
+                    .and_then(|entities| entities.fmt_percentage())
+                    .unwrap_or("None".to_string());
+                let eta = eta.fmt_for_stage(*stage_id);
+
+                info!(
+                    target: "reth::cli",
+                    connected_peers = this.state.num_connected_peers(),
+                    db_freelist,
+                    stage = %stage_id,
+                    checkpoint = checkpoint.block_number,
+                    target,
+                    progress,
+                    eta,
+                    "Status"
+                );
+            } else if let Some(latest_block) = this.state.latest_block {
+                info!(
+                    target: "reth::cli",
+                    connected_peers = this.state.num_connected_peers(),
+                    db_freelist,
+                    latest_block,
+                    "Status"
+                );
             } else {
                 info!(
                     target: "reth::cli",
                     connected_peers = this.state.num_connected_peers(),
-                    latest_block = this.state.latest_block.unwrap_or(this.state.current_checkpoint.block_number),
+                    db_freelist,
                     "Status"
                 );
             }
@@ -332,7 +366,7 @@ where
 /// checkpoints reported by the pipeline.
 ///
 /// One `Eta` is only valid for a single stage.
-#[derive(Default)]
+#[derive(Default, Copy, Clone)]
 struct Eta {
     /// The last stage checkpoint
     last_checkpoint: EntitiesCheckpoint,

--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -75,7 +75,7 @@ impl NodeState {
                     target,
                 };
 
-                let target = target.map(|target| format!("{target}")).unwrap_or("None".to_string());
+                let target = target.map_or("None".to_string(), |target| format!("{target}"));
                 let progress = checkpoint
                     .entities()
                     .and_then(|entities| entities.fmt_percentage())
@@ -85,10 +85,10 @@ impl NodeState {
                 info!(
                     pipeline_stages = %pipeline_stages_progress,
                     stage = %stage_id,
-                    checkpoint = checkpoint.block_number,
-                    target,
-                    progress,
-                    eta,
+                    checkpoint = %checkpoint.block_number,
+                    %target,
+                    %progress,
+                    %eta,
                     "Executing stage",
                 );
 
@@ -109,18 +109,19 @@ impl NodeState {
 
                     let target = current_stage
                         .target
-                        .map(|target| format!("{target}"))
+                        .map_or("None".to_string(), |target| format!("{target}"));
+                    let progress = checkpoint
+                        .entities()
+                        .and_then(|entities| entities.fmt_percentage())
                         .unwrap_or("None".to_string());
-                    let progress =
-                        checkpoint.entities().and_then(|entities| entities.fmt_percentage());
 
                     if done {
                         info!(
                             pipeline_stages = %pipeline_stages_progress,
                             stage = %stage_id,
-                            checkpoint = checkpoint.block_number,
-                            target,
-                            progress,
+                            checkpoint = %checkpoint.block_number,
+                            %target,
+                            %progress,
                             "Stage finished executing",
                         )
                     } else {
@@ -128,10 +129,10 @@ impl NodeState {
                         info!(
                             pipeline_stages = %pipeline_stages_progress,
                             stage = %stage_id,
-                            checkpoint = checkpoint.block_number,
-                            target,
-                            progress,
-                            eta,
+                            checkpoint = %checkpoint.block_number,
+                            %target,
+                            %progress,
+                            %eta,
                             "Stage committed progress",
                         )
                     }
@@ -302,7 +303,7 @@ where
             if let Some(CurrentStage { stage_id, eta, checkpoint, target }) =
                 &this.state.current_stage
             {
-                let target = target.map(|target| format!("{target}")).unwrap_or("None".to_string());
+                let target = target.map_or("None".to_string(), |target| format!("{target}"));
                 let progress = checkpoint
                     .entities()
                     .and_then(|entities| entities.fmt_percentage())
@@ -312,27 +313,27 @@ where
                 info!(
                     target: "reth::cli",
                     connected_peers = this.state.num_connected_peers(),
-                    db_freelist,
+                    %db_freelist,
                     stage = %stage_id,
                     checkpoint = checkpoint.block_number,
-                    target,
-                    progress,
-                    eta,
+                    %target,
+                    %progress,
+                    %eta,
                     "Status"
                 );
             } else if let Some(latest_block) = this.state.latest_block {
                 info!(
                     target: "reth::cli",
                     connected_peers = this.state.num_connected_peers(),
-                    db_freelist,
-                    latest_block,
+                    %db_freelist,
+                    %latest_block,
                     "Status"
                 );
             } else {
                 info!(
                     target: "reth::cli",
                     connected_peers = this.state.num_connected_peers(),
-                    db_freelist,
+                    %db_freelist,
                     "Status"
                 );
             }

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -515,7 +515,7 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
         );
         ctx.task_executor.spawn_critical(
             "events task",
-            events::handle_events(Some(network.clone()), Some(head.number), events),
+            events::handle_events(Some(network.clone()), Some(head.number), events, db.clone()),
         );
 
         let engine_api = EngineApi::new(

--- a/crates/primitives/src/stage/checkpoints.rs
+++ b/crates/primitives/src/stage/checkpoints.rs
@@ -5,10 +5,7 @@ use crate::{
 use bytes::{Buf, BufMut};
 use reth_codecs::{derive_arbitrary, main_codec, Compact};
 use serde::{Deserialize, Serialize};
-use std::{
-    fmt::{Display, Formatter},
-    ops::RangeInclusive,
-};
+use std::ops::RangeInclusive;
 
 /// Saves the progress of Merkle stage.
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -169,9 +166,16 @@ pub struct EntitiesCheckpoint {
     pub total: u64,
 }
 
-impl Display for EntitiesCheckpoint {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:.2}%", 100.0 * self.processed as f64 / self.total as f64)
+impl EntitiesCheckpoint {
+    /// Formats entities checkpoint as percentage, i.e. `processed / total`.
+    ///
+    /// Return [None] if `total == 0`.
+    pub fn fmt_percentage(&self) -> Option<String> {
+        if self.total == 0 {
+            return None
+        }
+
+        Some(format!("{:.2}%", 100.0 * self.processed as f64 / self.total as f64))
     }
 }
 

--- a/crates/stages/src/pipeline/event.rs
+++ b/crates/stages/src/pipeline/event.rs
@@ -1,5 +1,8 @@
 use crate::stage::{ExecOutput, UnwindInput, UnwindOutput};
-use reth_primitives::stage::{StageCheckpoint, StageId};
+use reth_primitives::{
+    stage::{StageCheckpoint, StageId},
+    BlockNumber,
+};
 use std::fmt::{Display, Formatter};
 
 /// An event emitted by a [Pipeline][crate::Pipeline].
@@ -12,13 +15,15 @@ use std::fmt::{Display, Formatter};
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum PipelineEvent {
     /// Emitted when a stage is about to be run.
-    Running {
+    Run {
         /// Pipeline stages progress.
         pipeline_stages_progress: PipelineStagesProgress,
         /// The stage that is about to be run.
         stage_id: StageId,
         /// The previous checkpoint of the stage.
         checkpoint: Option<StageCheckpoint>,
+        /// The block number up to which the stage is running, if known.
+        target: Option<BlockNumber>,
     },
     /// Emitted when a stage has run a single time.
     Ran {
@@ -30,7 +35,7 @@ pub enum PipelineEvent {
         result: ExecOutput,
     },
     /// Emitted when a stage is about to be unwound.
-    Unwinding {
+    Unwind {
         /// The stage that is about to be unwound.
         stage_id: StageId,
         /// The unwind parameters.

--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -592,7 +592,8 @@ mod tests {
                 PipelineEvent::Run {
                     pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 2 },
                     stage_id: StageId::Other("A"),
-                    checkpoint: None
+                    checkpoint: None,
+                    target: Some(10),
                 },
                 PipelineEvent::Ran {
                     pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 2 },
@@ -602,7 +603,8 @@ mod tests {
                 PipelineEvent::Run {
                     pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 2 },
                     stage_id: StageId::Other("B"),
-                    checkpoint: None
+                    checkpoint: None,
+                    target: Some(10),
                 },
                 PipelineEvent::Ran {
                     pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 2 },
@@ -655,7 +657,8 @@ mod tests {
                 PipelineEvent::Run {
                     pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 3 },
                     stage_id: StageId::Other("A"),
-                    checkpoint: None
+                    checkpoint: None,
+                    target: Some(10),
                 },
                 PipelineEvent::Ran {
                     pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 3 },
@@ -665,7 +668,8 @@ mod tests {
                 PipelineEvent::Run {
                     pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 3 },
                     stage_id: StageId::Other("B"),
-                    checkpoint: None
+                    checkpoint: None,
+                    target: Some(10),
                 },
                 PipelineEvent::Ran {
                     pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 3 },
@@ -675,7 +679,8 @@ mod tests {
                 PipelineEvent::Run {
                     pipeline_stages_progress: PipelineStagesProgress { current: 3, total: 3 },
                     stage_id: StageId::Other("C"),
-                    checkpoint: None
+                    checkpoint: None,
+                    target: Some(10),
                 },
                 PipelineEvent::Ran {
                     pipeline_stages_progress: PipelineStagesProgress { current: 3, total: 3 },
@@ -759,7 +764,8 @@ mod tests {
                 PipelineEvent::Run {
                     pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 2 },
                     stage_id: StageId::Other("A"),
-                    checkpoint: None
+                    checkpoint: None,
+                    target: Some(10),
                 },
                 PipelineEvent::Ran {
                     pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 2 },
@@ -769,7 +775,8 @@ mod tests {
                 PipelineEvent::Run {
                     pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 2 },
                     stage_id: StageId::Other("B"),
-                    checkpoint: None
+                    checkpoint: None,
+                    target: Some(10),
                 },
                 PipelineEvent::Ran {
                     pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 2 },
@@ -849,7 +856,8 @@ mod tests {
                 PipelineEvent::Run {
                     pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 2 },
                     stage_id: StageId::Other("A"),
-                    checkpoint: None
+                    checkpoint: None,
+                    target: Some(10),
                 },
                 PipelineEvent::Ran {
                     pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 2 },
@@ -859,7 +867,8 @@ mod tests {
                 PipelineEvent::Run {
                     pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 2 },
                     stage_id: StageId::Other("B"),
-                    checkpoint: None
+                    checkpoint: None,
+                    target: Some(10),
                 },
                 PipelineEvent::Error { stage_id: StageId::Other("B") },
                 PipelineEvent::Unwind {
@@ -877,7 +886,8 @@ mod tests {
                 PipelineEvent::Run {
                     pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 2 },
                     stage_id: StageId::Other("A"),
-                    checkpoint: Some(StageCheckpoint::new(0))
+                    checkpoint: Some(StageCheckpoint::new(0)),
+                    target: Some(10),
                 },
                 PipelineEvent::Ran {
                     pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 2 },
@@ -887,7 +897,8 @@ mod tests {
                 PipelineEvent::Run {
                     pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 2 },
                     stage_id: StageId::Other("B"),
-                    checkpoint: None
+                    checkpoint: None,
+                    target: Some(10),
                 },
                 PipelineEvent::Ran {
                     pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 2 },


### PR DESCRIPTION
```console
2023-11-21T21:36:42.512280Z  INFO reth::node::events: Stage committed progress pipeline_stages=5/13 stage=Execution checkpoint=3220742 target=4739945 progress=7.97% eta=9h 50m 13s
2023-11-21T21:36:42.875589Z  INFO reth::node::events: Executing stage pipeline_stages=5/13 stage=Execution checkpoint=3220742 target=4739945 progress=7.97% eta=9h 50m 13s
2023-11-21T21:36:43.333653Z  INFO reth::cli: Status connected_peers=14 freelist=101899 stage=Execution checkpoint=3220742 target=4739945 progress=7.97% eta=9h 50m 12s
```

Two main changes:
1. Report freelist size in the "Status" log
2. Report target block number in the pipeline logs