### PR TITLE
chore(deps): make c-kzg actually a feature of reth-primitives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,8 +135,8 @@ reth-transaction-pool = { path = "crates/transaction-pool" }
 reth-trie = { path = "crates/trie" }
 
 # revm
-revm = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
+revm = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze",  features = ["std", "secp256k1"], default-features = false }
+revm-primitives = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze", features = ["std"], default-features = false }
 
 # eth
 alloy-primitives = "0.4"

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -12,7 +12,8 @@ description = "Commonly used types in reth."
 # reth
 reth-codecs.workspace = true
 reth-rpc-types.workspace = true
-revm-primitives = { workspace = true, features = ["serde"] }
+revm-primitives.workspace = true
+revm.workspace = true
 
 # ethereum
 alloy-primitives = { workspace = true, features = ["rand", "rlp"] }
@@ -61,8 +62,6 @@ proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 strum = { workspace = true, features = ["derive"] }
 
-revm.workspace = true
-
 [dev-dependencies]
 serde_json.workspace = true
 test-fuzz = "4"
@@ -87,10 +86,10 @@ pprof = { workspace = true, features = ["flamegraph", "frame-pointer", "criterio
 [features]
 default = ["c-kzg"]
 arbitrary = ["revm-primitives/arbitrary", "reth-rpc-types/arbitrary", "dep:arbitrary", "dep:proptest", "dep:proptest-derive"]
-c-kzg = ["revm-primitives/c-kzg", "dep:c-kzg"]
-test-utils = ["dep:plain_hasher", "dep:hash-db", "dep:ethers-core"]
+c-kzg = ["dep:c-kzg", "revm/c-kzg", "revm-primitives/c-kzg"]
 clap = ["dep:clap"]
 optimism = ["reth-codecs/optimism", "revm-primitives/optimism", "revm/optimism"]
+test-utils = ["dep:plain_hasher", "dep:hash-db", "dep:ethers-core"]
 
 [[bench]]
 name = "recover_ecdsa_crit"


### PR DESCRIPTION
c-kzg was still pulled in via default features of revm and revm-primitives

set ws default-features of those to false and opt in via primitives feature, enabled by default


```
reth-primitives = { path = "../reth/crates/primitives", default-features = false }
```

before:

```sh
cargo tree -p c-kzg -i                                                                    ? master 
c-kzg v0.4.0
├── revm-precompile v2.2.0 (https://github.com/bluealloy/revm?branch=reth_freeze#74643d37)
│   └── revm v3.5.0 (https://github.com/bluealloy/revm?branch=reth_freeze#74643d37)
│       └── reth-primitives v0.1.0-alpha.11 (https://github.com/paradigmxyz/reth#e5b33dbe)
│           └── reth-tmp v0.1.0 (/Users/Matthias/git/rust/reth-tmp)
└── revm-primitives v1.3.0 (https://github.com/bluealloy/revm?branch=reth_freeze#74643d37)
    ├── reth-codecs v0.1.0-alpha.11 (https://github.com/paradigmxyz/reth#e5b33dbe)
    │   └── reth-primitives v0.1.0-alpha.11 (https://github.com/paradigmxyz/reth#e5b33dbe) (*)
    ├── reth-primitives v0.1.0-alpha.11 (https://github.com/paradigmxyz/reth#e5b33dbe) (*)
    ├── revm-interpreter v1.3.0 (https://github.com/bluealloy/revm?branch=reth_freeze#74643d37)
    │   └── revm v3.5.0 (https://github.com/bluealloy/revm?branch=reth_freeze#74643d37) (*)
    └── revm-precompile v2.2.0 (https://github.com/bluealloy/revm?branch=reth_freeze#74643d37) (*)
```

now

```sh
cargo tree -p c-kzg -i                                                                    ? master 
warning: nothing to print.
```