### PR TITLE
fix(tracing): reduce stack memory when tracing

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
@@ -453,10 +453,10 @@ impl ParityTraceBuilder {
                 }
             };
             let mut push_stack = step.push_stack.clone().unwrap_or_default();
-            for idx in (0..show_stack).rev() {
-                if let Some(stack) = step.stack.as_ref() {
+            if let Some(stack) = step.stack.as_ref() {
+                for idx in (0..show_stack).rev() {
                     if stack.len() > idx {
-                        push_stack.push(stack.peek(idx).unwrap_or_default())
+                        push_stack.push(stack[stack.len() - idx - 1])
                     }
                 }
             }

--- a/crates/revm/revm-inspectors/src/tracing/mod.rs
+++ b/crates/revm/revm-inspectors/src/tracing/mod.rs
@@ -282,7 +282,7 @@ impl TracingInspector {
             .record_memory_snapshots
             .then(|| RecordedMemory::new(interp.shared_memory.context_memory().to_vec()))
             .unwrap_or_default();
-        let stack = self.config.record_stack_snapshots.then(|| interp.stack.clone());
+        let stack = self.config.record_stack_snapshots.then(|| interp.stack.data().clone());
 
         let op = OpCode::new(interp.current_opcode())
             .or_else(|| {

--- a/crates/revm/revm-inspectors/src/tracing/types.rs
+++ b/crates/revm/revm-inspectors/src/tracing/types.rs
@@ -563,7 +563,7 @@ impl CallTraceStep {
         };
 
         if opts.is_stack_enabled() {
-            log.stack = self.stack.as_ref().map(|stack| stack.clone());
+            log.stack = self.stack.clone();
         }
 
         if opts.is_memory_enabled() {

--- a/crates/revm/revm-inspectors/src/tracing/types.rs
+++ b/crates/revm/revm-inspectors/src/tracing/types.rs
@@ -11,7 +11,7 @@ use reth_rpc_types::trace::{
     },
 };
 use revm::interpreter::{
-    opcode, CallContext, CallScheme, CreateScheme, InstructionResult, OpCode, Stack,
+    opcode, CallContext, CallScheme, CreateScheme, InstructionResult, OpCode,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, VecDeque};
@@ -511,7 +511,7 @@ pub(crate) struct CallTraceStep {
     /// Current contract address
     pub(crate) contract: Address,
     /// Stack before step execution
-    pub(crate) stack: Option<Stack>,
+    pub(crate) stack: Option<Vec<U256>>,
     /// The new stack items placed by this step if any
     pub(crate) push_stack: Option<Vec<U256>>,
     /// All allocated memory in a step
@@ -563,7 +563,7 @@ impl CallTraceStep {
         };
 
         if opts.is_stack_enabled() {
-            log.stack = self.stack.as_ref().map(|stack| stack.data().clone());
+            log.stack = self.stack.as_ref().map(|stack| stack.clone());
         }
 
         if opts.is_memory_enabled() {

--- a/crates/revm/revm-inspectors/src/tracing/types.rs
+++ b/crates/revm/revm-inspectors/src/tracing/types.rs
@@ -10,9 +10,7 @@ use reth_rpc_types::trace::{
         SelfdestructAction, TraceOutput, TransactionTrace,
     },
 };
-use revm::interpreter::{
-    opcode, CallContext, CallScheme, CreateScheme, InstructionResult, OpCode,
-};
+use revm::interpreter::{opcode, CallContext, CallScheme, CreateScheme, InstructionResult, OpCode};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, VecDeque};
 


### PR DESCRIPTION
A quick and easy fix for #5522 : Keep the trace stacks as a Vec<U256> rather than a Stack struct, as the latter always allocates space for a full 1024 stack items. This can add up to many GB of memory when tracing. The cloned Vec<U256> will not be fully allocated.

I believe this should not change tracing behavior.  When I was checking the parity vmTraces though, it does look like the current "push" stack element reporting is broken, so that's a separate bug that I'll file.