### PR TITLE
feat: add configure network function to cli ext

### DIFF
--- a/bin/reth/src/cli/config.rs
+++ b/bin/reth/src/cli/config.rs
@@ -1,6 +1,7 @@
 //! Config traits for various node components.
 
 use alloy_rlp::Encodable;
+use reth_network::protocol::IntoRlpxSubProtocol;
 use reth_primitives::{Bytes, BytesMut};
 use reth_rpc::{eth::gas_oracle::GasPriceOracleConfig, JwtError, JwtSecret};
 use reth_rpc_builder::{
@@ -101,4 +102,22 @@ pub trait PayloadBuilderConfig {
     /// Returns whether or not to construct the pending block.
     #[cfg(feature = "optimism")]
     fn compute_pending_block(&self) -> bool;
+}
+
+/// A trait that can be used to apply additional configuration to the network.
+pub trait RethNetworkConfig {
+    /// Adds a new additional protocol to the RLPx sub-protocol list.
+    ///
+    /// These additional protocols are negotiated during the RLPx handshake.
+    /// If both peers share the same protocol, the corresponding handler will be included alongside
+    /// the `eth` protocol.
+    ///
+    /// See also [ProtocolHandler](reth_network::protocol::ProtocolHandler)
+    fn add_rlpx_sub_protocol(&mut self, protocol: impl IntoRlpxSubProtocol);
+}
+
+impl<C> RethNetworkConfig for reth_network::NetworkManager<C> {
+    fn add_rlpx_sub_protocol(&mut self, protocol: impl IntoRlpxSubProtocol) {
+        reth_network::NetworkManager::add_rlpx_sub_protocol(self, protocol);
+    }
 }

--- a/bin/reth/src/cli/ext.rs
+++ b/bin/reth/src/cli/ext.rs
@@ -35,11 +35,12 @@ impl RethCliExt for () {
 ///
 /// The functions are invoked during the initialization of the node command in the following order:
 ///
-/// 1. [on_components_initialized](RethNodeCommandConfig::on_components_initialized)
-/// 2. [spawn_payload_builder_service](RethNodeCommandConfig::spawn_payload_builder_service)
-/// 3. [extend_rpc_modules](RethNodeCommandConfig::extend_rpc_modules)
-/// 4. [on_rpc_server_started](RethNodeCommandConfig::on_rpc_server_started)
-/// 5. [on_node_started](RethNodeCommandConfig::on_node_started)
+/// 1. [configure_network](RethNodeCommandConfig::configure_network)
+/// 2. [on_components_initialized](RethNodeCommandConfig::on_components_initialized)
+/// 3. [spawn_payload_builder_service](RethNodeCommandConfig::spawn_payload_builder_service)
+/// 4. [extend_rpc_modules](RethNodeCommandConfig::extend_rpc_modules)
+/// 5. [on_rpc_server_started](RethNodeCommandConfig::on_rpc_server_started)
+/// 6. [on_node_started](RethNodeCommandConfig::on_node_started)
 pub trait RethNodeCommandConfig: fmt::Debug {
     /// Invoked with the network configuration before the network is configured.
     ///

--- a/bin/reth/src/cli/ext.rs
+++ b/bin/reth/src/cli/ext.rs
@@ -10,7 +10,7 @@ use reth_payload_builder::{PayloadBuilderHandle, PayloadBuilderService};
 use reth_tasks::TaskSpawner;
 use std::{fmt, marker::PhantomData};
 
-use crate::cli::components::RethRpcServerHandles;
+use crate::cli::{components::RethRpcServerHandles, config::RethNetworkConfig};
 
 /// A trait that allows for extending parts of the CLI with additional functionality.
 ///
@@ -41,6 +41,23 @@ impl RethCliExt for () {
 /// 4. [on_rpc_server_started](RethNodeCommandConfig::on_rpc_server_started)
 /// 5. [on_node_started](RethNodeCommandConfig::on_node_started)
 pub trait RethNodeCommandConfig: fmt::Debug {
+    /// Invoked with the network configuration before the network is configured.
+    ///
+    /// This allows additional configuration of the network before it is launched.
+    fn configure_network<Conf, Reth>(
+        &mut self,
+        config: &mut Conf,
+        components: &Reth,
+    ) -> eyre::Result<()>
+    where
+        Conf: RethNetworkConfig,
+        Reth: RethNodeComponents,
+    {
+        let _ = config;
+        let _ = components;
+        Ok(())
+    }
+
     /// Event hook called once all components have been initialized.
     ///
     /// This is called as soon as the node components have been initialized.
@@ -224,6 +241,22 @@ impl<T> NoArgs<T> {
 }
 
 impl<T: RethNodeCommandConfig> RethNodeCommandConfig for NoArgs<T> {
+    fn configure_network<Conf, Reth>(
+        &mut self,
+        config: &mut Conf,
+        components: &Reth,
+    ) -> eyre::Result<()>
+    where
+        Conf: RethNetworkConfig,
+        Reth: RethNodeComponents,
+    {
+        if let Some(conf) = self.inner_mut() {
+            conf.configure_network(config, components)
+        } else {
+            Ok(())
+        }
+    }
+
     fn on_components_initialized<Reth: RethNodeComponents>(
         &mut self,
         components: &Reth,

--- a/crates/net/network/src/builder.rs
+++ b/crates/net/network/src/builder.rs
@@ -28,6 +28,21 @@ impl<C, Tx, Eth> NetworkBuilder<C, Tx, Eth> {
         (network, transactions, request_handler)
     }
 
+    /// Returns the network manager.
+    pub fn network(&self) -> &NetworkManager<C> {
+        &self.network
+    }
+
+    /// Returns the mutable network manager.
+    pub fn network_mut(&mut self) -> &mut NetworkManager<C> {
+        &mut self.network
+    }
+
+    /// Returns the handle to the network.
+    pub fn handle(&self) -> NetworkHandle {
+        self.network.handle().clone()
+    }
+
     /// Consumes the type and returns all fields and also return a [`NetworkHandle`].
     pub fn split_with_handle(self) -> (NetworkHandle, NetworkManager<C>, Tx, Eth) {
         let NetworkBuilder { network, transactions, request_handler } = self;

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -26,6 +26,7 @@ use crate::{
     metrics::{DisconnectMetrics, NetworkMetrics, NETWORK_POOL_TRANSACTIONS_SCOPE},
     network::{NetworkHandle, NetworkHandleMessage},
     peers::{PeersHandle, PeersManager},
+    protocol::IntoRlpxSubProtocol,
     session::SessionManager,
     state::NetworkState,
     swarm::{NetworkConnectionState, Swarm, SwarmEvent},
@@ -140,6 +141,11 @@ impl<C> NetworkManager<C> {
     /// [`EthRequestHandler`](crate::eth_requests::EthRequestHandler).
     pub fn set_eth_request_handler(&mut self, tx: mpsc::Sender<IncomingEthRequest>) {
         self.to_eth_request_handler = Some(tx);
+    }
+
+    /// Adds an additional protocol handler to the RLPx sub-protocol list.
+    pub fn add_rlpx_sub_protocol(&mut self, protocol: impl IntoRlpxSubProtocol) {
+        self.swarm.add_rlpx_sub_protocol(protocol)
     }
 
     /// Returns the [`NetworkHandle`] that can be cloned and shared.

--- a/crates/net/network/src/protocol.rs
+++ b/crates/net/network/src/protocol.rs
@@ -116,6 +116,12 @@ where
     }
 }
 
+impl IntoRlpxSubProtocol for RlpxSubProtocol {
+    fn into_rlpx_sub_protocol(self) -> RlpxSubProtocol {
+        self
+    }
+}
+
 /// Additional RLPx-based sub-protocols.
 #[derive(Debug, Default)]
 pub struct RlpxSubProtocols {

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -48,7 +48,7 @@ pub use handle::{
     SessionCommand,
 };
 
-use crate::protocol::RlpxSubProtocols;
+use crate::protocol::{IntoRlpxSubProtocol, RlpxSubProtocols};
 pub use reth_network_api::{Direction, PeerInfo};
 
 /// Internal identifier for active sessions.
@@ -103,7 +103,6 @@ pub struct SessionManager {
     /// Receiver half that listens for [`ActiveSessionMessage`] produced by pending sessions.
     active_session_rx: ReceiverStream<ActiveSessionMessage>,
     /// Additional RLPx sub-protocols to be used by the session manager.
-    #[allow(unused)]
     extra_protocols: RlpxSubProtocols,
     /// Used to measure inbound & outbound bandwidth across all managed streams
     bandwidth_meter: BandwidthMeter,
@@ -174,6 +173,11 @@ impl SessionManager {
     /// Returns the session hello message.
     pub fn hello_message(&self) -> HelloMessageWithProtocols {
         self.hello_message.clone()
+    }
+
+    /// Adds an additional protocol handler to the RLPx sub-protocol list.
+    pub(crate) fn add_rlpx_sub_protocol(&mut self, protocol: impl IntoRlpxSubProtocol) {
+        self.extra_protocols.push(protocol)
     }
 
     /// Spawns the given future onto a new task that is tracked in the `spawned_tasks`


### PR DESCRIPTION
Adds a new CLI function that can be used to apply additional settings to the network, for now limited to installing rlpx protocol handlers.


