### PR TITLE
feat(storage): report backtrace on long-lived transactions

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -26,7 +26,7 @@ use std::{
 };
 
 /// Duration after which we emit the log about long-lived database transactions.
-const LONG_TRANSACTION_DURATION: Duration = Duration::from_secs(60);
+const LONG_TRANSACTION_DURATION: Duration = Duration::from_secs(30);
 
 /// Wrapper for the libmdbx transaction.
 #[derive(Debug)]

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -23,7 +23,7 @@ use std::{
 };
 
 /// Duration after which we emit the warning log about long-lived database transactions.
-const TRANSACTION_WARNING_DURATION: Duration = Duration::from_secs(1);
+const TRANSACTION_WARNING_DURATION: Duration = Duration::from_secs(60);
 
 /// Wrapper for the libmdbx transaction.
 #[derive(Debug)]

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -196,7 +196,7 @@ impl<K: TransactionKind> MetricsHandler<K> {
                 target: "storage::db::mdbx",
                 ?open_duration,
                 ?backtrace,
-                "The database transaction was open for too long"
+                "The database transaction has been open for too long"
             );
         }
     }

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -23,7 +23,7 @@ use std::{
 };
 
 /// Duration after which we emit the warning log about long-lived database transactions.
-const TRANSACTION_WARNING_DURATION: Duration = Duration::from_secs(60);
+const TRANSACTION_WARNING_DURATION: Duration = Duration::from_secs(1);
 
 /// Wrapper for the libmdbx transaction.
 #[derive(Debug)]

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -26,7 +26,7 @@ use std::{
 };
 
 /// Duration after which we emit the log about long-lived database transactions.
-const LONG_TRANSACTION_DURATION: Duration = Duration::from_secs(1);
+const LONG_TRANSACTION_DURATION: Duration = Duration::from_secs(60);
 
 /// Wrapper for the libmdbx transaction.
 #[derive(Debug)]

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -26,7 +26,7 @@ use std::{
 };
 
 /// Duration after which we emit the log about long-lived database transactions.
-const LONG_TRANSACTION_DURATION: Duration = Duration::from_secs(30);
+const LONG_TRANSACTION_DURATION: Duration = Duration::from_secs(60);
 
 /// Wrapper for the libmdbx transaction.
 #[derive(Debug)]

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -13,7 +13,7 @@ use crate::{
 use parking_lot::RwLock;
 use reth_interfaces::db::{DatabaseWriteError, DatabaseWriteOperation};
 use reth_libmdbx::{ffi::DBI, Transaction, TransactionKind, WriteFlags, RW};
-use reth_tracing::tracing::warn;
+use reth_tracing::tracing::debug;
 use std::{
     backtrace::Backtrace,
     marker::PhantomData,
@@ -22,8 +22,8 @@ use std::{
     time::{Duration, Instant},
 };
 
-/// Duration after which we emit the warning log about long-lived database transactions.
-const TRANSACTION_WARNING_DURATION: Duration = Duration::from_secs(60);
+/// Duration after which we emit the log about long-lived database transactions.
+const LONG_TRANSACTION_DURATION: Duration = Duration::from_secs(60);
 
 /// Wrapper for the libmdbx transaction.
 #[derive(Debug)]
@@ -178,8 +178,8 @@ impl<K: TransactionKind> MetricsHandler<K> {
 impl<K: TransactionKind> Drop for MetricsHandler<K> {
     fn drop(&mut self) {
         if let Some(open_duration) = self.open_duration {
-            if open_duration > TRANSACTION_WARNING_DURATION {
-                warn!(
+            if open_duration > LONG_TRANSACTION_DURATION {
+                debug!(
                     target: "storage::db::mdbx",
                     ?open_duration,
                     backtrace = ?self.open_backtrace,

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -15,7 +15,7 @@ use reth_interfaces::db::{DatabaseWriteError, DatabaseWriteOperation};
 use reth_libmdbx::{ffi::DBI, Transaction, TransactionKind, WriteFlags, RW};
 use reth_tracing::tracing::warn;
 use std::{
-    backtrace::{Backtrace, BacktraceStatus},
+    backtrace::Backtrace,
     marker::PhantomData,
     str::FromStr,
     sync::Arc,

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -26,7 +26,7 @@ use std::{
 };
 
 /// Duration after which we emit the log about long-lived database transactions.
-const LONG_TRANSACTION_DURATION: Duration = Duration::from_secs(60);
+const LONG_TRANSACTION_DURATION: Duration = Duration::from_secs(1);
 
 /// Wrapper for the libmdbx transaction.
 #[derive(Debug)]


### PR DESCRIPTION
As per the PR title.

It's hard to identify the source of long-lived transactions, and they bother us because they are growing freelist. So let's capture and log the full backtrace once the transaction duration reaches the threshold of 30 seconds.