### PR TITLE
feat(bin/args): enhance transactionpool with --txpool.nolocals Flag

### DIFF
--- a/bin/reth/src/args/txpool_args.rs
+++ b/bin/reth/src/args/txpool_args.rs
@@ -1,11 +1,7 @@
 //! Transaction pool arguments
 
 use clap::Args;
-use reth_transaction_pool::{
-    PoolConfig, PriceBumpConfig, SubPoolLimit, DEFAULT_PRICE_BUMP, REPLACE_BLOB_PRICE_BUMP,
-    TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER, TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT,
-    TXPOOL_SUBPOOL_MAX_TXS_DEFAULT,
-};
+use reth_transaction_pool::{PoolConfig, PriceBumpConfig, SubPoolLimit, DEFAULT_PRICE_BUMP, REPLACE_BLOB_PRICE_BUMP, TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER, TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT, TXPOOL_SUBPOOL_MAX_TXS_DEFAULT, LocalTransactionConfig};
 
 /// Parameters for debugging purposes
 #[derive(Debug, Args, PartialEq, Default)]
@@ -52,7 +48,9 @@ impl TxPoolArgs {
     /// Returns transaction pool configuration.
     pub fn pool_config(&self) -> PoolConfig {
         PoolConfig {
-            no_locals: self.no_locals,
+            local_transactions_config: LocalTransactionConfig {
+                no_exemptions: self.no_locals,
+            },
             pending_limit: SubPoolLimit {
                 max_txs: self.pending_max_count,
                 max_size: self.pending_max_size * 1024 * 1024,

--- a/bin/reth/src/args/txpool_args.rs
+++ b/bin/reth/src/args/txpool_args.rs
@@ -2,9 +2,9 @@
 
 use clap::Args;
 use reth_transaction_pool::{
-    TxPoolPolicy, PoolConfig, PriceBumpConfig, SubPoolLimit, DEFAULT_PRICE_BUMP,
-    REPLACE_BLOB_PRICE_BUMP, TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
-    TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT, TXPOOL_SUBPOOL_MAX_TXS_DEFAULT,
+    PoolConfig, PriceBumpConfig, SubPoolLimit, DEFAULT_PRICE_BUMP, REPLACE_BLOB_PRICE_BUMP,
+    TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER, TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT,
+    TXPOOL_SUBPOOL_MAX_TXS_DEFAULT,
 };
 
 /// Parameters for debugging purposes
@@ -52,7 +52,7 @@ impl TxPoolArgs {
     /// Returns transaction pool configuration.
     pub fn pool_config(&self) -> PoolConfig {
         PoolConfig {
-            tx_pool_policy: TxPoolPolicy { no_locals: self.no_locals },
+            no_locals: self.no_locals,
             pending_limit: SubPoolLimit {
                 max_txs: self.pending_max_count,
                 max_size: self.pending_max_size * 1024 * 1024,

--- a/bin/reth/src/args/txpool_args.rs
+++ b/bin/reth/src/args/txpool_args.rs
@@ -2,7 +2,7 @@
 
 use clap::Args;
 use reth_transaction_pool::{
-    config::TxPoolPolicy, PoolConfig, PriceBumpConfig, SubPoolLimit, DEFAULT_PRICE_BUMP,
+    TxPoolPolicy, PoolConfig, PriceBumpConfig, SubPoolLimit, DEFAULT_PRICE_BUMP,
     REPLACE_BLOB_PRICE_BUMP, TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
     TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT, TXPOOL_SUBPOOL_MAX_TXS_DEFAULT,
 };

--- a/bin/reth/src/args/txpool_args.rs
+++ b/bin/reth/src/args/txpool_args.rs
@@ -2,9 +2,9 @@
 
 use clap::Args;
 use reth_transaction_pool::{
-    PoolConfig, PriceBumpConfig, SubPoolLimit, DEFAULT_PRICE_BUMP, REPLACE_BLOB_PRICE_BUMP,
-    TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER, TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT,
-    TXPOOL_SUBPOOL_MAX_TXS_DEFAULT,
+    config::TxPoolPolicy, PoolConfig, PriceBumpConfig, SubPoolLimit, DEFAULT_PRICE_BUMP,
+    REPLACE_BLOB_PRICE_BUMP, TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
+    TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT, TXPOOL_SUBPOOL_MAX_TXS_DEFAULT,
 };
 
 /// Parameters for debugging purposes

--- a/bin/reth/src/args/txpool_args.rs
+++ b/bin/reth/src/args/txpool_args.rs
@@ -43,12 +43,16 @@ pub struct TxPoolArgs {
     /// Price bump percentage to replace an already existing blob transaction
     #[arg(long = "blobpool.pricebump", default_value_t = REPLACE_BLOB_PRICE_BUMP)]
     pub blob_transaction_price_bump: u128,
+    /// Flag to disable local transaction exemptions.
+    #[arg(long = "txpool.nolocals")]
+    pub no_locals: bool,
 }
 
 impl TxPoolArgs {
     /// Returns transaction pool configuration.
     pub fn pool_config(&self) -> PoolConfig {
         PoolConfig {
+            tx_pool_policy: TxPoolPolicy { no_locals: self.no_locals },
             pending_limit: SubPoolLimit {
                 max_txs: self.pending_max_count,
                 max_size: self.pending_max_size * 1024 * 1024,

--- a/bin/reth/src/args/txpool_args.rs
+++ b/bin/reth/src/args/txpool_args.rs
@@ -1,7 +1,11 @@
 //! Transaction pool arguments
 
 use clap::Args;
-use reth_transaction_pool::{PoolConfig, PriceBumpConfig, SubPoolLimit, DEFAULT_PRICE_BUMP, REPLACE_BLOB_PRICE_BUMP, TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER, TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT, TXPOOL_SUBPOOL_MAX_TXS_DEFAULT, LocalTransactionConfig};
+use reth_transaction_pool::{
+    LocalTransactionConfig, PoolConfig, PriceBumpConfig, SubPoolLimit, DEFAULT_PRICE_BUMP,
+    REPLACE_BLOB_PRICE_BUMP, TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
+    TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT, TXPOOL_SUBPOOL_MAX_TXS_DEFAULT,
+};
 
 /// Parameters for debugging purposes
 #[derive(Debug, Args, PartialEq, Default)]
@@ -48,9 +52,7 @@ impl TxPoolArgs {
     /// Returns transaction pool configuration.
     pub fn pool_config(&self) -> PoolConfig {
         PoolConfig {
-            local_transactions_config: LocalTransactionConfig {
-                no_exemptions: self.no_locals,
-            },
+            local_transactions_config: LocalTransactionConfig { no_exemptions: self.no_locals },
             pending_limit: SubPoolLimit {
                 max_txs: self.pending_max_count,
                 max_size: self.pending_max_size * 1024 * 1024,

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -31,27 +31,8 @@ pub struct PoolConfig {
     /// Price bump (in %) for the transaction pool underpriced check.
     pub price_bumps: PriceBumpConfig,
     /// Flag to disable local transaction exemptions.
-    pub tx_pool_policy: TxPoolPolicy,
-}
-/// `TxPoolPolicy` holds configuration settings that dictate the behavior of the transaction pool.
-
-#[derive(Debug, Clone, Default)]
-pub struct TxPoolPolicy {
-    /// If set to `true`, local transactions (transactions originating from the local node) will
-    /// not be exempt from certain checks and limitations that are applied to non-local
-    /// transactions.
     pub no_locals: bool,
 }
-
-impl TxPoolPolicy {
-    /// Creates a new `TxPoolPolicy` with default settings.
-    pub fn new() -> Self {
-        TxPoolPolicy {
-                no_locals: false, // Set the default value for no_locals here
-            }
-    }
-}
-
 
 impl Default for PoolConfig {
     fn default() -> Self {
@@ -61,7 +42,7 @@ impl Default for PoolConfig {
             queued_limit: Default::default(),
             max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
             price_bumps: Default::default(),
-            tx_pool_policy: TxPoolPolicy::default(),
+            no_locals: false,
         }
     }
 }

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -30,8 +30,9 @@ pub struct PoolConfig {
     pub max_account_slots: usize,
     /// Price bump (in %) for the transaction pool underpriced check.
     pub price_bumps: PriceBumpConfig,
-    /// Flag to disable local transaction exemptions.
-    pub no_locals: bool,
+    /// How to handle locally received transactions:
+    /// [TransactionOrigin::Local](crate::TransactionOrigin).
+    pub local_transactions_config: LocalTransactionConfig,
 }
 
 impl Default for PoolConfig {
@@ -42,7 +43,7 @@ impl Default for PoolConfig {
             queued_limit: Default::default(),
             max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
             price_bumps: Default::default(),
-            no_locals: false,
+            local_transactions_config: Default::default(),
         }
     }
 }
@@ -100,5 +101,26 @@ impl Default for PriceBumpConfig {
             default_price_bump: DEFAULT_PRICE_BUMP,
             replace_blob_tx_price_bump: REPLACE_BLOB_PRICE_BUMP,
         }
+    }
+}
+
+/// Configuration options for the locally received transactions:
+/// [TransactionOrigin::Local](crate::TransactionOrigin)
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+pub struct LocalTransactionConfig {
+    /// Apply no exemptions to the locally received transactions.
+    ///
+    /// This includes:
+    ///   - available slots are limited to the configured `max_account_slots` of [PoolConfig]
+    ///   - no price exemptions
+    ///   - no eviction exemptions
+    pub no_exemptions: bool,
+}
+
+impl LocalTransactionConfig {
+    /// Returns whether local transactions are not exempt from the configured limits.
+    #[inline]
+    pub fn no_local_exemptions(&self) -> bool {
+        self.no_exemptions
     }
 }

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -30,8 +30,33 @@ pub struct PoolConfig {
     pub max_account_slots: usize,
     /// Price bump (in %) for the transaction pool underpriced check.
     pub price_bumps: PriceBumpConfig,
+    /// Flag to disable local transaction exemptions.
+    pub tx_pool_policy: TxPoolPolicy,
+}
+/// `TxPoolPolicy` holds configuration settings that dictate the behavior of the transaction pool.
+
+#[derive(Debug, Clone)]
+pub struct TxPoolPolicy {
+    /// If set to `true`, local transactions (transactions originating from the local node) will
+    /// not be exempt from certain checks and limitations that are applied to non-local
+    /// transactions.
+    pub no_locals: bool,
 }
 
+impl TxPoolPolicy {
+    /// Creates a new `TxPoolPolicy` with default settings.
+    pub fn new() -> Self {
+        TxPoolPolicy {
+                no_locals: false, // Set the default value for no_locals here
+            }
+    }
+}
+
+impl Default for TxPoolPolicy {
+    fn default() -> Self {
+        Self { no_locals: false }
+    }
+}
 impl Default for PoolConfig {
     fn default() -> Self {
         Self {
@@ -40,6 +65,7 @@ impl Default for PoolConfig {
             queued_limit: Default::default(),
             max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
             price_bumps: Default::default(),
+            tx_pool_policy: TxPoolPolicy::default(),
         }
     }
 }

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -35,7 +35,7 @@ pub struct PoolConfig {
 }
 /// `TxPoolPolicy` holds configuration settings that dictate the behavior of the transaction pool.
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct TxPoolPolicy {
     /// If set to `true`, local transactions (transactions originating from the local node) will
     /// not be exempt from certain checks and limitations that are applied to non-local
@@ -52,11 +52,7 @@ impl TxPoolPolicy {
     }
 }
 
-impl Default for TxPoolPolicy {
-    fn default() -> Self {
-        Self { no_locals: false }
-    }
-}
+
 impl Default for PoolConfig {
     fn default() -> Self {
         Self {

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -155,9 +155,9 @@ use tracing::{instrument, trace};
 pub use crate::{
     blobstore::{BlobStore, BlobStoreError},
     config::{
-        PoolConfig, PriceBumpConfig, SubPoolLimit, DEFAULT_PRICE_BUMP, REPLACE_BLOB_PRICE_BUMP,
-        TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER, TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT,
-        TXPOOL_SUBPOOL_MAX_TXS_DEFAULT,
+        LocalTransactionConfig, PoolConfig, PriceBumpConfig, SubPoolLimit, DEFAULT_PRICE_BUMP,
+        REPLACE_BLOB_PRICE_BUMP, TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
+        TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT, TXPOOL_SUBPOOL_MAX_TXS_DEFAULT,
     },
     error::PoolResult,
     ordering::{CoinbaseTipOrdering, Priority, TransactionOrdering},

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -1273,8 +1273,8 @@ impl<T: PoolTransaction> AllTransactions<T> {
     fn ensure_valid(
         &self,
         transaction: ValidPoolTransaction<T>,
-        pool_config: PoolConfig,
     ) -> Result<ValidPoolTransaction<T>, InsertErr<T>> {
+        let pool_config = PoolConfig::default();
         if !transaction.origin.is_local() || pool_config.no_locals {
             let current_txs =
                 self.tx_counter.get(&transaction.sender_id()).copied().unwrap_or_default();
@@ -1443,8 +1443,8 @@ impl<T: PoolTransaction> AllTransactions<T> {
         on_chain_nonce: u64,
     ) -> InsertResult<T> {
         assert!(on_chain_nonce <= transaction.nonce(), "Invalid transaction");
-        let pool_config = PoolConfig::default();
-        let mut transaction = self.ensure_valid(transaction, pool_config)?;
+
+        let mut transaction = self.ensure_valid(transaction)?;
 
         let inserted_tx_id = *transaction.id();
         let mut state = TxState::default();

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -1275,7 +1275,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
         transaction: ValidPoolTransaction<T>,
         pool_config: PoolConfig,
     ) -> Result<ValidPoolTransaction<T>, InsertErr<T>> {
-        if !transaction.origin.is_local() || pool_config.tx_pool_policy.no_locals {
+        if !transaction.origin.is_local() || pool_config.no_locals {
             let current_txs =
                 self.tx_counter.get(&transaction.sender_id()).copied().unwrap_or_default();
             if current_txs >= self.max_account_slots {
@@ -1443,9 +1443,8 @@ impl<T: PoolTransaction> AllTransactions<T> {
         on_chain_nonce: u64,
     ) -> InsertResult<T> {
         assert!(on_chain_nonce <= transaction.nonce(), "Invalid transaction");
-        let value = PoolConfig::default();
-
-        let mut transaction = self.ensure_valid(transaction, value)?;
+        let pool_config = PoolConfig::default();
+        let mut transaction = self.ensure_valid(transaction, pool_config)?;
 
         let inserted_tx_id = *transaction.id();
         let mut state = TxState::default();

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -1273,8 +1273,9 @@ impl<T: PoolTransaction> AllTransactions<T> {
     fn ensure_valid(
         &self,
         transaction: ValidPoolTransaction<T>,
+        pool_config: PoolConfig,
     ) -> Result<ValidPoolTransaction<T>, InsertErr<T>> {
-        if !transaction.origin.is_local() {
+        if !transaction.origin.is_local() || pool_config.tx_pool_policy.no_locals {
             let current_txs =
                 self.tx_counter.get(&transaction.sender_id()).copied().unwrap_or_default();
             if current_txs >= self.max_account_slots {
@@ -1442,8 +1443,9 @@ impl<T: PoolTransaction> AllTransactions<T> {
         on_chain_nonce: u64,
     ) -> InsertResult<T> {
         assert!(on_chain_nonce <= transaction.nonce(), "Invalid transaction");
+        let value = PoolConfig::default();
 
-        let mut transaction = self.ensure_valid(transaction)?;
+        let mut transaction = self.ensure_valid(transaction, value)?;
 
         let inserted_tx_id = *transaction.id();
         let mut state = TxState::default();

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -486,6 +486,8 @@ pub struct EthTransactionValidatorBuilder {
 
     /// Stores the setup and parameters needed for validating KZG proofs.
     kzg_settings: Arc<KzgSettings>,
+    /// Flag to enforce no local transaction exemptions
+    no_locals: bool,
 }
 
 impl EthTransactionValidatorBuilder {
@@ -513,12 +515,18 @@ impl EthTransactionValidatorBuilder {
 
             // TODO: can hard enable by default once mainnet transitioned
             cancun,
+            no_locals: false,
         }
     }
 
     /// Disables the Cancun fork.
     pub fn no_cancun(self) -> Self {
         self.set_cancun(false)
+    }
+    /// Set tge no locals transactions.
+    pub fn set_no_locals(mut self, no_locals: bool) -> Self {
+        self.no_locals = no_locals;
+        self
     }
 
     /// Set the Cancun fork.

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -126,7 +126,7 @@ where
     kzg_settings: Arc<KzgSettings>,
     /// Marker for the transaction type
     _marker: PhantomData<T>,
-    ///
+    /// Flag to enforce no local transaction exemptions.
     no_locals: bool,
 }
 

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -523,7 +523,8 @@ impl EthTransactionValidatorBuilder {
     pub fn no_cancun(self) -> Self {
         self.set_cancun(false)
     }
-    /// Set tge no locals transactions.
+
+    /// Whether to allow exemptions for local transaction exemptions.
     pub fn set_no_locals(mut self, no_locals: bool) -> Self {
         self.no_locals = no_locals;
         self

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -5,8 +5,8 @@ use crate::{
     error::{Eip4844PoolTransactionError, InvalidPoolTransactionError},
     traits::TransactionOrigin,
     validate::{ValidTransaction, ValidationTask, MAX_INIT_CODE_SIZE, TX_MAX_SIZE},
-    EthBlobTransactionSidecar, EthPoolTransaction, PoolTransaction, TransactionValidationOutcome,
-    TransactionValidationTaskExecutor, TransactionValidator,
+    EthBlobTransactionSidecar, EthPoolTransaction, LocalTransactionConfig, PoolTransaction,
+    TransactionValidationOutcome, TransactionValidationTaskExecutor, TransactionValidator,
 };
 use reth_primitives::{
     constants::{
@@ -124,10 +124,10 @@ where
     propagate_local_transactions: bool,
     /// Stores the setup and parameters needed for validating KZG proofs.
     kzg_settings: Arc<KzgSettings>,
+    /// How to handle [TransactionOrigin::Local](TransactionOrigin) transactions.
+    local_transactions_config: LocalTransactionConfig,
     /// Marker for the transaction type
     _marker: PhantomData<T>,
-    /// Flag to enforce no local transaction exemptions.
-    no_locals: bool,
 }
 
 // === impl EthTransactionValidatorInner ===
@@ -237,7 +237,7 @@ where
 
         // Drop non-local transactions with a fee lower than the configured fee for acceptance into
         // the pool.
-        if (!origin.is_local() || self.no_locals) &&
+        if (!origin.is_local() || self.local_transactions_config.no_local_exemptions()) &&
             transaction.is_eip1559() &&
             transaction.max_priority_fee_per_gas() < self.minimum_priority_fee
         {
@@ -486,8 +486,8 @@ pub struct EthTransactionValidatorBuilder {
 
     /// Stores the setup and parameters needed for validating KZG proofs.
     kzg_settings: Arc<KzgSettings>,
-    /// Flag to enforce no local transaction exemptions
-    no_locals: bool,
+    /// How to handle [TransactionOrigin::Local](TransactionOrigin) transactions.
+    local_transactions_config: LocalTransactionConfig,
 }
 
 impl EthTransactionValidatorBuilder {
@@ -504,6 +504,7 @@ impl EthTransactionValidatorBuilder {
             // default to true, can potentially take this as a param in the future
             propagate_local_transactions: true,
             kzg_settings: Arc::clone(&MAINNET_KZG_TRUSTED_SETUP),
+            local_transactions_config: Default::default(),
 
             // by default all transaction types are allowed
             eip2718: true,
@@ -515,7 +516,6 @@ impl EthTransactionValidatorBuilder {
 
             // TODO: can hard enable by default once mainnet transitioned
             cancun,
-            no_locals: false,
         }
     }
 
@@ -525,8 +525,11 @@ impl EthTransactionValidatorBuilder {
     }
 
     /// Whether to allow exemptions for local transaction exemptions.
-    pub fn set_no_locals(mut self, no_locals: bool) -> Self {
-        self.no_locals = no_locals;
+    pub fn set_local_transactions_config(
+        mut self,
+        local_transactions_config: LocalTransactionConfig,
+    ) -> Self {
+        self.local_transactions_config = local_transactions_config;
         self
     }
 
@@ -635,6 +638,7 @@ impl EthTransactionValidatorBuilder {
             minimum_priority_fee,
             propagate_local_transactions,
             kzg_settings,
+            local_transactions_config,
             ..
         } = self;
 
@@ -653,8 +657,8 @@ impl EthTransactionValidatorBuilder {
             propagate_local_transactions,
             blob_store: Box::new(blob_store),
             kzg_settings,
+            local_transactions_config,
             _marker: Default::default(),
-            no_locals: false,
         };
 
         EthTransactionValidator { inner: Arc::new(inner) }

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -126,6 +126,8 @@ where
     kzg_settings: Arc<KzgSettings>,
     /// Marker for the transaction type
     _marker: PhantomData<T>,
+    ///
+    no_locals: bool,
 }
 
 // === impl EthTransactionValidatorInner ===
@@ -235,7 +237,7 @@ where
 
         // Drop non-local transactions with a fee lower than the configured fee for acceptance into
         // the pool.
-        if !origin.is_local() &&
+        if (!origin.is_local() || self.no_locals) &&
             transaction.is_eip1559() &&
             transaction.max_priority_fee_per_gas() < self.minimum_priority_fee
         {
@@ -643,6 +645,7 @@ impl EthTransactionValidatorBuilder {
             blob_store: Box::new(blob_store),
             kzg_settings,
             _marker: Default::default(),
+            no_locals: false,
         };
 
         EthTransactionValidator { inner: Arc::new(inner) }


### PR DESCRIPTION
This PR introduces the --txpool.nolocals flag to improve transaction pool behavior by enabling the disabling of local exemptions for locally submitted transactions.


ref https://github.com/paradigmxyz/reth/issues/5520