### PR TITLE
chore: get almost rid of reth-primitives in tracer impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6277,6 +6277,7 @@ dependencies = [
 name = "reth-revm-inspectors"
 version = "0.1.0-alpha.11"
 dependencies = [
+ "alloy-primitives",
  "alloy-sol-types",
  "boa_engine",
  "boa_gc",

--- a/crates/revm/revm-inspectors/Cargo.toml
+++ b/crates/revm/revm-inspectors/Cargo.toml
@@ -15,6 +15,7 @@ reth-rpc-types.workspace = true
 
 # eth
 alloy-sol-types.workspace = true
+alloy-primitives.workspace = true
 
 revm.workspace = true
 

--- a/crates/revm/revm-inspectors/src/access_list.rs
+++ b/crates/revm/revm-inspectors/src/access_list.rs
@@ -1,4 +1,5 @@
-use reth_primitives::{AccessList, AccessListItem, Address, B256};
+use alloy_primitives::{Address, B256};
+use reth_primitives::{AccessList, AccessListItem};
 use revm::{
     interpreter::{opcode, Interpreter},
     Database, EVMData, Inspector,

--- a/crates/revm/revm-inspectors/src/stack/maybe_owned.rs
+++ b/crates/revm/revm-inspectors/src/stack/maybe_owned.rs
@@ -1,4 +1,4 @@
-use reth_primitives::U256;
+use alloy_primitives::U256;
 use revm::{
     interpreter::{CallInputs, CreateInputs, Gas, InstructionResult, Interpreter},
     primitives::{db::Database, Address, Bytes, B256},

--- a/crates/revm/revm-inspectors/src/stack/mod.rs
+++ b/crates/revm/revm-inspectors/src/stack/mod.rs
@@ -1,4 +1,4 @@
-use reth_primitives::{Address, Bytes, TxHash, B256, U256};
+use alloy_primitives::{Address, Bytes, B256, U256};
 use revm::{
     inspectors::CustomPrintTracer,
     interpreter::{CallInputs, CreateInputs, Gas, InstructionResult, Interpreter},
@@ -23,7 +23,7 @@ pub enum Hook {
     /// Hook on a specific block.
     Block(u64),
     /// Hook on a specific transaction hash.
-    Transaction(TxHash),
+    Transaction(B256),
     /// Hooks on every transaction in a block.
     All,
 }
@@ -62,7 +62,7 @@ impl InspectorStack {
     }
 
     /// Check if the inspector should be used.
-    pub fn should_inspect(&self, env: &Env, tx_hash: TxHash) -> bool {
+    pub fn should_inspect(&self, env: &Env, tx_hash: B256) -> bool {
         match self.hook {
             Hook::None => false,
             Hook::Block(block) => env.block.number.to::<u64>() == block,

--- a/crates/revm/revm-inspectors/src/tracing/builder/geth.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/geth.rs
@@ -5,7 +5,7 @@ use crate::tracing::{
     utils::load_account_code,
     TracingInspectorConfig,
 };
-use reth_primitives::{Address, Bytes, B256, U256};
+use alloy_primitives::{Address, Bytes, B256, U256};
 use reth_rpc_types::trace::geth::{
     AccountChangeKind, AccountState, CallConfig, CallFrame, DefaultFrame, DiffMode,
     GethDefaultTracingOptions, PreStateConfig, PreStateFrame, PreStateMode, StructLog,

--- a/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
@@ -4,7 +4,7 @@ use crate::tracing::{
     utils::load_account_code,
     TracingInspectorConfig,
 };
-use reth_primitives::{Address, U64};
+use alloy_primitives::{Address, U64};
 use reth_rpc_types::{trace::parity::*, TransactionInfo};
 use revm::{
     db::DatabaseRef,

--- a/crates/revm/revm-inspectors/src/tracing/fourbyte.rs
+++ b/crates/revm/revm-inspectors/src/tracing/fourbyte.rs
@@ -21,7 +21,7 @@
 //!
 //! See also <https://geth.ethereum.org/docs/developers/evm-tracing/built-in-tracers>
 
-use reth_primitives::{hex, Bytes, Selector};
+use alloy_primitives::{hex, Bytes, Selector};
 use reth_rpc_types::trace::geth::FourByteFrame;
 use revm::{
     interpreter::{CallInputs, Gas, InstructionResult},

--- a/crates/revm/revm-inspectors/src/tracing/js/bindings.rs
+++ b/crates/revm/revm-inspectors/src/tracing/js/bindings.rs
@@ -10,19 +10,20 @@ use crate::tracing::{
     },
     types::CallKind,
 };
+use alloy_primitives::{Address, Bytes, B256, U256};
 use boa_engine::{
     native_function::NativeFunction,
     object::{builtins::JsArrayBuffer, FunctionObjectBuilder},
     Context, JsArgs, JsError, JsNativeError, JsObject, JsResult, JsValue,
 };
 use boa_gc::{empty_trace, Finalize, Trace};
-use reth_primitives::{Account, Address, Bytes, B256, KECCAK_EMPTY, U256};
+use reth_primitives::Account;
 use revm::{
     interpreter::{
         opcode::{PUSH0, PUSH32},
         OpCode, SharedMemory, Stack,
     },
-    primitives::State,
+    primitives::{State, KECCAK_EMPTY},
 };
 use std::{cell::RefCell, rc::Rc, sync::mpsc::channel};
 use tokio::sync::mpsc;

--- a/crates/revm/revm-inspectors/src/tracing/js/builtins.rs
+++ b/crates/revm/revm-inspectors/src/tracing/js/builtins.rs
@@ -1,12 +1,12 @@
 //! Builtin functions
 
+use alloy_primitives::{hex, Address, B256, U256};
 use boa_engine::{
     object::builtins::{JsArray, JsArrayBuffer},
     property::Attribute,
     Context, JsArgs, JsError, JsNativeError, JsResult, JsString, JsValue, NativeFunction, Source,
 };
 use boa_gc::{empty_trace, Finalize, Trace};
-use reth_primitives::{hex, Address, B256, U256};
 use std::collections::HashSet;
 
 /// bigIntegerJS is the minified version of <https://github.com/peterolson/BigInteger.js>.

--- a/crates/revm/revm-inspectors/src/tracing/js/mod.rs
+++ b/crates/revm/revm-inspectors/src/tracing/js/mod.rs
@@ -10,8 +10,9 @@ use crate::tracing::{
     types::CallKind,
     utils::get_create_address,
 };
+use alloy_primitives::{Address, Bytes, B256, U256};
 use boa_engine::{Context, JsError, JsObject, JsResult, JsValue, Source};
-use reth_primitives::{Account, Address, Bytes, B256, U256};
+use reth_primitives::Account;
 use revm::{
     interpreter::{
         return_revert, CallInputs, CallScheme, CreateInputs, Gas, InstructionResult, Interpreter,

--- a/crates/revm/revm-inspectors/src/tracing/mod.rs
+++ b/crates/revm/revm-inspectors/src/tracing/mod.rs
@@ -2,8 +2,8 @@ use crate::tracing::{
     types::{CallKind, LogCallOrder, RawLog},
     utils::get_create_address,
 };
+use alloy_primitives::{Address, Bytes, B256, U256};
 pub use arena::CallTraceArena;
-use reth_primitives::{Address, Bytes, B256, U256};
 use revm::{
     inspectors::GasInspector,
     interpreter::{

--- a/crates/revm/revm-inspectors/src/tracing/types.rs
+++ b/crates/revm/revm-inspectors/src/tracing/types.rs
@@ -1,8 +1,8 @@
 //! Types for representing call trace items.
 
 use crate::tracing::{config::TraceStyle, utils::convert_memory};
+use alloy_primitives::{Address, Bytes, B256, U256, U64};
 use alloy_sol_types::decode_revert_reason;
-use reth_primitives::{Address, Bytes, B256, U256, U64};
 use reth_rpc_types::trace::{
     geth::{CallFrame, CallLogFrame, GethDefaultTracingOptions, StructLog},
     parity::{

--- a/crates/revm/revm-inspectors/src/tracing/utils.rs
+++ b/crates/revm/revm-inspectors/src/tracing/utils.rs
@@ -1,9 +1,10 @@
 //! Util functions for revm related ops
 
-use reth_primitives::{hex, revm_primitives::db::DatabaseRef, Address, Bytes, B256, KECCAK_EMPTY};
+use alloy_primitives::{hex, Address, Bytes, B256};
 use revm::{
     interpreter::CreateInputs,
-    primitives::{CreateScheme, SpecId},
+    primitives::{CreateScheme, SpecId, KECCAK_EMPTY},
+    DatabaseRef,
 };
 
 /// creates the memory data in 32byte chunks


### PR DESCRIPTION
phase out most of reth-primitives and use alloy imports

still depends on Account and acceslist types for which we need a solution
could be replaced with the rpc types variant I believe

cc @Evalir 