### PR TITLE
chore: use rpc types Accesslist in inspector

### DIFF
--- a/crates/primitives/src/transaction/access_list.rs
+++ b/crates/primitives/src/transaction/access_list.rs
@@ -82,3 +82,31 @@ impl AccessList {
             self.0.capacity() * mem::size_of::<AccessListItem>()
     }
 }
+
+impl From<reth_rpc_types::AccessList> for AccessList {
+    #[inline]
+    fn from(value: reth_rpc_types::AccessList) -> Self {
+        let converted_list = value
+            .0
+            .into_iter()
+            .map(|item| AccessListItem { address: item.address, storage_keys: item.storage_keys })
+            .collect();
+
+        AccessList(converted_list)
+    }
+}
+
+impl From<AccessList> for reth_rpc_types::AccessList {
+    #[inline]
+    fn from(value: AccessList) -> Self {
+        let list = value
+            .0
+            .into_iter()
+            .map(|item| reth_rpc_types::AccessListItem {
+                address: item.address,
+                storage_keys: item.storage_keys,
+            })
+            .collect();
+        reth_rpc_types::AccessList(list)
+    }
+}

--- a/crates/revm/revm-inspectors/src/access_list.rs
+++ b/crates/revm/revm-inspectors/src/access_list.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::{Address, B256};
-use reth_primitives::{AccessList, AccessListItem};
+use reth_rpc_types::{AccessList, AccessListItem};
 use revm::{
     interpreter::{opcode, Interpreter},
     Database, EVMData, Inspector,

--- a/crates/rpc/rpc-types-compat/src/log.rs
+++ b/crates/rpc/rpc-types-compat/src/log.rs
@@ -21,35 +21,3 @@ pub fn from_primitive_log(log: reth_primitives::Log) -> reth_rpc_types::Log {
 pub fn to_primitive_log(log: reth_rpc_types::Log) -> reth_primitives::Log {
     reth_primitives::Log { address: log.address, topics: log.topics, data: log.data }
 }
-
-/// Converts a primitive `AccessList` structure from the `reth_primitives` module into the
-/// corresponding RPC type.
-#[inline]
-pub fn from_primitive_access_list(list: reth_primitives::AccessList) -> reth_rpc_types::AccessList {
-    let converted_list: Vec<reth_rpc_types::AccessListItem> = list
-        .0
-        .into_iter()
-        .map(|item| reth_rpc_types::AccessListItem {
-            address: item.address,
-            storage_keys: item.storage_keys,
-        })
-        .collect();
-
-    reth_rpc_types::AccessList(converted_list)
-}
-
-/// Converts a primitive `AccessList` structure from the `reth_primitives` module into the
-/// corresponding RPC type.
-#[inline]
-pub fn to_primitive_access_list(list: reth_rpc_types::AccessList) -> reth_primitives::AccessList {
-    let converted_list: Vec<reth_primitives::AccessListItem> = list
-        .0
-        .into_iter()
-        .map(|item| reth_primitives::AccessListItem {
-            address: item.address,
-            storage_keys: item.storage_keys,
-        })
-        .collect();
-
-    reth_primitives::AccessList(converted_list)
-}

--- a/crates/rpc/rpc-types-compat/src/transaction/mod.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction/mod.rs
@@ -162,22 +162,6 @@ pub fn from_primitive_access_list(
     )
 }
 
-/// Convert [reth_rpc_types::AccessList] to [reth_primitives::AccessList]
-pub fn to_primitive_access_list(
-    access_list: reth_rpc_types::AccessList,
-) -> reth_primitives::AccessList {
-    reth_primitives::AccessList(
-        access_list
-            .0
-            .into_iter()
-            .map(|item| reth_primitives::AccessListItem {
-                address: item.address.0.into(),
-                storage_keys: item.storage_keys.into_iter().map(|key| key.0.into()).collect(),
-            })
-            .collect(),
-    )
-}
-
 /// Convert [TransactionSignedEcRecovered] to [CallRequest]
 pub fn transaction_to_call_request(tx: TransactionSignedEcRecovered) -> CallRequest {
     let from = tx.signer();

--- a/crates/rpc/rpc-types-compat/src/transaction/typed.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction/typed.rs
@@ -1,5 +1,3 @@
-use crate::log::to_primitive_access_list;
-
 /// Converts a typed transaction request into a primitive transaction.
 ///
 /// Returns `None` if any of the following are true:
@@ -30,7 +28,7 @@ pub fn to_primitive_transaction(
             to: to_primitive_transaction_kind(tx.kind),
             value: tx.value.into(),
             input: tx.input,
-            access_list: to_primitive_access_list(tx.access_list),
+            access_list: tx.access_list.into(),
         }),
         TypedTransactionRequest::EIP1559(tx) => Transaction::Eip1559(TxEip1559 {
             chain_id: tx.chain_id,
@@ -40,7 +38,7 @@ pub fn to_primitive_transaction(
             to: to_primitive_transaction_kind(tx.kind),
             value: tx.value.into(),
             input: tx.input,
-            access_list: to_primitive_access_list(tx.access_list),
+            access_list: tx.access_list.into(),
             max_priority_fee_per_gas: tx.max_priority_fee_per_gas.to(),
         }),
         TypedTransactionRequest::EIP4844(tx) => Transaction::Eip4844(TxEip4844 {
@@ -51,7 +49,7 @@ pub fn to_primitive_transaction(
             max_priority_fee_per_gas: tx.max_priority_fee_per_gas.to(),
             to: to_primitive_transaction_kind(tx.kind),
             value: tx.value.into(),
-            access_list: to_primitive_access_list(tx.access_list),
+            access_list: tx.access_list.into(),
             blob_versioned_hashes: tx.blob_versioned_hashes,
             max_fee_per_blob_gas: tx.max_fee_per_blob_gas.to(),
             input: tx.input,

--- a/crates/rpc/rpc/src/eth/api/call.rs
+++ b/crates/rpc/rpc/src/eth/api/call.rs
@@ -21,7 +21,6 @@ use reth_rpc_types::{
     state::StateOverride, AccessListWithGasUsed, BlockError, Bundle, CallRequest, EthCallResponse,
     StateContext,
 };
-use reth_rpc_types_compat::log::{from_primitive_access_list, to_primitive_access_list};
 use reth_transaction_pool::TransactionPool;
 use revm::{
     db::{CacheDB, DatabaseRef},
@@ -392,8 +391,7 @@ where
         let initial = request.access_list.take().unwrap_or_default();
 
         let precompiles = get_precompiles(env.cfg.spec_id);
-        let mut inspector =
-            AccessListInspector::new(to_primitive_access_list(initial), from, to, precompiles);
+        let mut inspector = AccessListInspector::new(initial, from, to, precompiles);
         let (result, env) = inspect(&mut db, env, &mut inspector)?;
 
         match result.result {
@@ -410,10 +408,10 @@ where
         let access_list = inspector.into_access_list();
 
         // calculate the gas used using the access list
-        request.access_list = Some(from_primitive_access_list(access_list.clone()));
+        request.access_list = Some(access_list.clone());
         let gas_used = self.estimate_gas_with(env.cfg, env.block, request, db.db.state())?;
 
-        Ok(AccessListWithGasUsed { access_list: from_primitive_access_list(access_list), gas_used })
+        Ok(AccessListWithGasUsed { access_list, gas_used })
     }
 }
 


### PR DESCRIPTION
use the rpc types' AccessList and not primitive

move bidirectional conversion into From impl


There's an argument for removing the primitives AccessList type altogether but would require a bit more work: implement codec for types in codec crate