### PR TITLE
feat(bin/reth) implement http rpc path prefix in RpcServerConfig 

### DIFF
--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -116,6 +116,10 @@ pub struct RpcServerArgs {
     #[arg(long = "authrpc.addr", default_value_t = IpAddr::V4(Ipv4Addr::LOCALHOST))]
     pub auth_addr: IpAddr,
 
+    /// HTTP path prefix on which JSON-RPC is served.
+    #[arg(long = "http.rpcprefix", default_value = "/")]
+    pub http_rpcprefix: String,
+
     /// Auth server port to listen on
     #[arg(long = "authrpc.port", default_value_t = constants::DEFAULT_AUTH_PORT)]
     pub auth_port: u16,
@@ -335,6 +339,9 @@ impl RpcServerArgs {
 }
 
 impl RethRpcConfig for RpcServerArgs {
+    fn http_rpc_prefix(&self) -> &str {
+        &self.http_rpcprefix
+    }
     fn is_ipc_enabled(&self) -> bool {
         // By default IPC is enabled therefor it is enabled if the `ipcdisable` is false.
         !self.ipcdisable

--- a/bin/reth/src/cli/config.rs
+++ b/bin/reth/src/cli/config.rs
@@ -15,6 +15,8 @@ use std::{borrow::Cow, path::PathBuf, time::Duration};
 /// This provides all basic config values for the RPC server and is implemented by the
 /// [RpcServerArgs](crate::args::RpcServerArgs) type.
 pub trait RethRpcConfig {
+    /// Returns the HTTP RPC path prefix.
+    fn http_rpc_prefix(&self) -> &str;
     /// Returns whether ipc is enabled.
     fn is_ipc_enabled(&self) -> bool;
 

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1230,6 +1230,8 @@ pub struct RpcServerConfig {
     ipc_endpoint: Option<Endpoint>,
     /// JWT secret for authentication
     jwt_secret: Option<JwtSecret>,
+    /// HTTP RPC path prefix.
+    http_rpcprefix: Option<String>,
 }
 
 impl fmt::Debug for RpcServerConfig {
@@ -1250,6 +1252,11 @@ impl fmt::Debug for RpcServerConfig {
 /// === impl RpcServerConfig ===
 
 impl RpcServerConfig {
+    /// Configures the HTTP RPC path prefix
+    pub fn with_http_rpc_prefix(mut self, prefix: String) -> Self {
+        self.http_rpcprefix = Some(prefix);
+        self
+    }
     /// Creates a new config with only http set
     pub fn http(config: ServerBuilder) -> Self {
         Self::default().with_http(config)


### PR DESCRIPTION
hey, hope everyone is doing good here, congrats for the alpha 11!

this pr introduce the http_rpcprefix field in RpcServerConfig [see geth ref ](https://github.com/ethereum/go-ethereum/blob/2a2013014c46844728421a1acc5ad40ca823414b/cmd/utils/flags.go#L610) it allow configuration for a custom path prefix for http rpc server