### PR TITLE
fix: use direct conversion for payload fee metrics

### DIFF
--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -248,7 +248,6 @@ where
         let fut = async move {
             let res = fut.await;
             if let Ok(ref payload) = res {
-                // TODO: remove `to`
                 resolved_metrics
                     .set_resolved_revenue(payload.block.number, f64::from(payload.fees));
             }

--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -214,8 +214,7 @@ where
             .find(|(_, job_id)| *job_id == id)
             .map(|(j, _)| j.best_payload());
         if let Some(Ok(ref best)) = res {
-            // TODO: remove `to`
-            self.metrics.set_best_revenue(best.block.number, best.fees().to::<u128>() as f64);
+            self.metrics.set_best_revenue(best.block.number, f64::from(best.fees));
         }
 
         res
@@ -251,7 +250,7 @@ where
             if let Ok(ref payload) = res {
                 // TODO: remove `to`
                 resolved_metrics
-                    .set_resolved_revenue(payload.block.number, payload.fees().to::<u128>() as f64);
+                    .set_resolved_revenue(payload.block.number, f64::from(payload.fees));
             }
             res
         };


### PR DESCRIPTION
uses `f64::from` instead of `.to::<u128>`, to do a lossy conversion instead of panicking