### PR TITLE
chore: export `StackSnapshotType`

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/mod.rs
+++ b/crates/revm/revm-inspectors/src/tracing/mod.rs
@@ -32,7 +32,7 @@ pub use builder::{
     geth::{self, GethTraceBuilder},
     parity::{self, ParityTraceBuilder},
 };
-pub use config::TracingInspectorConfig;
+pub use config::{StackSnapshotType, TracingInspectorConfig};
 pub use fourbyte::FourByteInspector;
 pub use opcount::OpcodeCountInspector;
 


### PR DESCRIPTION
It's not possible to build a custom `TracingInspectorConfig` without this type, and neither `TracingInspectorConfig::default_geth` or `TracingInspectorConfig::default_parity` matches Foundry's behavior