### PR TITLE
docs: add panics section

### DIFF
--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -54,6 +54,11 @@ impl Block {
     }
 
     /// Transform into a [`BlockWithSenders`].
+    ///
+    /// # Panics
+    ///
+    /// If the number of senders does not match the number of transactions in the block.
+    #[track_caller]
     pub fn with_senders(self, senders: Vec<Address>) -> BlockWithSenders {
         assert_eq!(self.body.len(), senders.len(), "Unequal number of senders");
 


### PR DESCRIPTION
ref #5572

But I don't even think we should panic here:

https://github.com/paradigmxyz/reth/blob/748e85fa130578490791d86b060bdc9b97d1fdbd/crates/storage/provider/src/providers/database/provider.rs#L1139-L1155

panicking here seems bad @rkrasiuk 

I guess we should recover them if the ranges don't match for any reason whatsoever.

