### PR TITLE
fix: always recover senders on mismatch

### DIFF
--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -57,10 +57,16 @@ impl Block {
     ///
     /// # Panics
     ///
-    /// If the number of senders does not match the number of transactions in the block.
+    /// If the number of senders does not match the number of transactions in the block
+    /// and the signer recovery for one of the transactions fails.
     #[track_caller]
     pub fn with_senders(self, senders: Vec<Address>) -> BlockWithSenders {
-        assert_eq!(self.body.len(), senders.len(), "Unequal number of senders");
+        let senders = if self.body.len() == senders.len() {
+            senders
+        } else {
+            TransactionSigned::recover_signers(&self.body, self.body.len())
+                .expect("stored block is valid")
+        };
 
         BlockWithSenders { block: self, senders }
     }


### PR DESCRIPTION
## Description

Senders might be empty for the pruned node upon calling `Block::with_senders` here:

https://github.com/paradigmxyz/reth/blob/748e85fa130578490791d86b060bdc9b97d1fdbd/crates/storage/provider/src/providers/database/provider.rs#L1139-L1155

## Solution

Always recover senders if the length does not match the body length.