### PR TITLE
feat: make PayloadBuilderHandle pub

### DIFF
--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -79,9 +79,9 @@ pub struct PayloadBuilderHandle {
 
 impl PayloadBuilderHandle {
     /// Creates a new payload builder handle for the given channel.
-    /// 
-    /// Note: this is only used internally by the [PayloadBuilderService] to manage the 
-    /// payload building flow. See its `Future` impl of `::poll` for implementation details.
+    ///
+    /// Note: this is only used internally by the [PayloadBuilderService] to manage the payload
+    /// building flow See [PayloadBuilderService::poll] for implementation details.
     pub fn new(to_service: mpsc::UnboundedSender<PayloadServiceCommand>) -> Self {
         Self { to_service }
     }

--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -78,7 +78,11 @@ pub struct PayloadBuilderHandle {
 // === impl PayloadBuilderHandle ===
 
 impl PayloadBuilderHandle {
-    pub(crate) fn new(to_service: mpsc::UnboundedSender<PayloadServiceCommand>) -> Self {
+    /// Creates a new payload builder handle for the given channel.
+    /// 
+    /// Note: this is only used internally by the [PayloadBuilderService] to manage the 
+    /// payload building flow. See its `Future` impl of `::poll` for implementation details.
+    pub fn new(to_service: mpsc::UnboundedSender<PayloadServiceCommand>) -> Self {
         Self { to_service }
     }
 
@@ -349,7 +353,7 @@ type PayloadFuture =
     Pin<Box<dyn Future<Output = Result<Arc<BuiltPayload>, PayloadBuilderError>> + Send + Sync>>;
 
 /// Message type for the [PayloadBuilderService].
-pub(crate) enum PayloadServiceCommand {
+pub enum PayloadServiceCommand {
     /// Start building a new payload.
     BuildNewPayload(
         PayloadBuilderAttributes,


### PR DESCRIPTION
As discussed in #5452

Public `PayloadBuilderHandle::new` makes node extensions more flexible as it allows users extending `spawn_payload_builder` to implement their own `PayloadBuilderService` logic, rather than forcing the current `Gen` implementation.