### PR TITLE
chore: bump ef-tests stack size

### DIFF
--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -104,15 +104,8 @@ impl Case for BlockchainTestCase {
                 let mut stage = ExecutionStage::new_with_factory(
                     reth_revm::EvmProcessorFactory::new(Arc::new(case.network.clone().into())),
                 );
-
                 let target = last_block.as_ref().map(|b| b.number);
-                tokio::runtime::Builder::new_current_thread()
-                    .build()
-                    .expect("Could not build tokio RT")
-                    .block_on(async {
-                        // ignore error
-                        let _ = stage.execute(&provider, ExecInput { target, checkpoint: None });
-                    });
+                let _ = stage.execute(&provider, ExecInput { target, checkpoint: None });
             }
 
             // Validate post state

--- a/testing/ef-tests/tests/tests.rs
+++ b/testing/ef-tests/tests/tests.rs
@@ -6,7 +6,18 @@ macro_rules! general_state_test {
     ($test_name:ident, $dir:ident) => {
         #[test]
         fn $test_name() {
-            BlockchainTests::new(format!("GeneralStateTests/{}", stringify!($dir))).run();
+            // TODO: can be removed with revm call-loop support
+            // <https://github.com/paradigmxyz/reth/issues/5582>
+            std::thread::Builder::new()
+                .stack_size(
+                    1024 * 1024 * 4, // 4MB
+                )
+                .spawn(move || {
+                    BlockchainTests::new(format!("GeneralStateTests/{}", stringify!($dir))).run();
+                })
+                .unwrap()
+                .join()
+                .unwrap();
         }
     };
 }


### PR DESCRIPTION
Closes #5582

temp bump ef-tests stack size.

we could enforce this via RUST_ vars but this seems easier as a tmp solution