### PR TITLE
chore: bump stacksize even more

### DIFF
--- a/testing/ef-tests/tests/tests.rs
+++ b/testing/ef-tests/tests/tests.rs
@@ -10,7 +10,7 @@ macro_rules! general_state_test {
             // <https://github.com/paradigmxyz/reth/issues/5582>
             std::thread::Builder::new()
                 .stack_size(
-                    1024 * 1024 * 4, // 4MB
+                    1024 * 1024 * 8, // 8MB
                 )
                 .spawn(move || {
                     BlockchainTests::new(format!("GeneralStateTests/{}", stringify!($dir))).run();


### PR DESCRIPTION
ref https://github.com/paradigmxyz/reth/issues/5582#issuecomment-1828989541

turns out 4mb isn't sufficient for some tests