### PR TITLE
perf(storage, mdbx): set rp augment limit

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -107,14 +107,19 @@ impl DatabaseEnv {
         //    sequence inside the DB file).
         // 1. Get some pages from the freelist, put them into the reclaimed list.
         // 2. Search through the reclaimed list for the sequence of size N.
-        // 3. a. If found, return the sequence
-        // 3. b. If not found, repeat steps 1-3. If the reclaimed list size is larger than the "rp
-        //    augment limit", stop the search and allocate new pages at the end of the file.
+        // 3. a. If found, return the sequence.
+        // 3. b. If not found, repeat steps 1-3. If the reclaimed list size is larger than
+        //    the `rp augment limit`, stop the search and allocate new pages at the end of the file:
+        //    https://github.com/paradigmxyz/reth/blob/2a4c78759178f66e30c8976ec5d243b53102fc9a/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.c#L11479-L11480.
         //
         // Basically, this parameter controls for how long do we search through the freelist before
         // trying to allocate new pages. Smaller value will make MDBX to fallback to
         // allocation faster, higher value will force MDBX to search through the freelist
         // longer until the sequence of pages is found.
+        //
+        // The default value of this parameter is set depending on the DB size. The bigger the
+        // database, the larger is `rp augment limit`.
+        // https://github.com/paradigmxyz/reth/blob/2a4c78759178f66e30c8976ec5d243b53102fc9a/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.c#L10018-L10024
         inner_env.set_rp_augment_limit(256 * 1024);
 
         if let Some(log_level) = log_level {

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -119,7 +119,11 @@ impl DatabaseEnv {
         //
         // The default value of this parameter is set depending on the DB size. The bigger the
         // database, the larger is `rp augment limit`.
-        // https://github.com/paradigmxyz/reth/blob/2a4c78759178f66e30c8976ec5d243b53102fc9a/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.c#L10018-L10024
+        // https://github.com/paradigmxyz/reth/blob/2a4c78759178f66e30c8976ec5d243b53102fc9a/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.c#L10018-L10024.
+        //
+        // Previously, MDBX set this value as `256 * 1024` constant. Let's fallback to this,
+        // because we want to prioritize freelist lookup speed over database growth.
+        // https://github.com/paradigmxyz/reth/blob/fa2b9b685ed9787636d962f4366caf34a9186e66/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.c#L16017.
         inner_env.set_rp_augment_limit(256 * 1024);
 
         if let Some(log_level) = log_level {


### PR DESCRIPTION
Resolves https://github.com/paradigmxyz/reth/issues/5228

## Explanation

https://github.com/paradigmxyz/reth/blob/a3eaa036edba2f21a4d372c1fba4b0b1d5405f40/crates/storage/db/src/implementation/mdbx/mod.rs#L102-L127

## Results

Before 12:10 – default `rp augment limit` value (which is around `137 million`)
After 12:25 – custom `rp augment limit` value set to `256 * 1024`

<img width="1140" alt="image" src="https://github.com/paradigmxyz/reth/assets/5773434/4ca17c98-258b-4e80-ae04-5c9853dc1ca9">

Note: disregard the drop of the `Freelist` chart, it's due to node having a slight downtime during the restart and many blocks being inserted at once.
