### PR TITLE
fix: add recover_signer that checks according to EIP-2

### DIFF
--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -95,7 +95,7 @@ pub use transaction::{
 };
 
 pub use transaction::{
-    util::secp256k1::{public_key_to_address, recover_signer, sign_message},
+    util::secp256k1::{public_key_to_address, recover_signer_unchecked, sign_message},
     AccessList, AccessListItem, FromRecoveredTransaction, IntoRecoveredTransaction,
     InvalidTransactionError, Signature, Transaction, TransactionKind, TransactionMeta,
     TransactionSigned, TransactionSignedEcRecovered, TransactionSignedNoHash, TxEip1559, TxEip2930,

--- a/crates/primitives/src/revm/env.rs
+++ b/crates/primitives/src/revm/env.rs
@@ -130,7 +130,7 @@ pub fn recover_header_signer(header: &Header) -> Result<Address, CliqueSignerRec
         header_to_seal.hash_slow()
     };
 
-    // TODO: does this need to be checked w.r.t EIP-2?
+    // TODO: this is currently unchecked recovery, does this need to be checked w.r.t EIP-2?
     recover_signer(&signature, &seal_hash.0).map_err(CliqueSignerRecoveryError::InvalidSignature)
 }
 

--- a/crates/primitives/src/revm/env.rs
+++ b/crates/primitives/src/revm/env.rs
@@ -129,6 +129,8 @@ pub fn recover_header_signer(header: &Header) -> Result<Address, CliqueSignerRec
         header_to_seal.extra_data = Bytes::from(header.extra_data[..signature_start_byte].to_vec());
         header_to_seal.hash_slow()
     };
+
+    // TODO: does this need to be checked w.r.t EIP-2?
     recover_signer(&signature, &seal_hash.0).map_err(CliqueSignerRecoveryError::InvalidSignature)
 }
 

--- a/crates/primitives/src/revm/env.rs
+++ b/crates/primitives/src/revm/env.rs
@@ -1,6 +1,6 @@
 use crate::{
     constants::{BEACON_ROOTS_ADDRESS, SYSTEM_ADDRESS},
-    recover_signer,
+    recover_signer_unchecked,
     revm::config::revm_spec,
     revm_primitives::{AnalysisKind, BlockEnv, CfgEnv, Env, SpecId, TransactTo, TxEnv},
     Address, Bytes, Chain, ChainSpec, Head, Header, Transaction, TransactionKind,
@@ -131,7 +131,8 @@ pub fn recover_header_signer(header: &Header) -> Result<Address, CliqueSignerRec
     };
 
     // TODO: this is currently unchecked recovery, does this need to be checked w.r.t EIP-2?
-    recover_signer(&signature, &seal_hash.0).map_err(CliqueSignerRecoveryError::InvalidSignature)
+    recover_signer_unchecked(&signature, &seal_hash.0)
+        .map_err(CliqueSignerRecoveryError::InvalidSignature)
 }
 
 /// Returns a new [TxEnv] filled with the transaction's data.

--- a/crates/primitives/src/transaction/signature.rs
+++ b/crates/primitives/src/transaction/signature.rs
@@ -135,7 +135,12 @@ impl Signature {
         })
     }
 
-    /// Recover signer from message hash, _without ensuring that the signature has a low S value_.
+    /// Recover signer from message hash, _without ensuring that the signature has a low `s`
+    /// value_.
+    ///
+    /// Using this for signature validation will succeed, even if the signature is malleable or not
+    /// compliant with EIP-2. This is provided for compatibility with old signatures which have
+    /// large `s` values.
     pub fn recover_signer_unchecked(&self, hash: B256) -> Option<Address> {
         let mut sig: [u8; 65] = [0; 65];
 

--- a/crates/primitives/src/transaction/signature.rs
+++ b/crates/primitives/src/transaction/signature.rs
@@ -80,7 +80,7 @@ impl Signature {
     pub fn v(&self, chain_id: Option<u64>) -> u64 {
         #[cfg(feature = "optimism")]
         if self.r.is_zero() && self.s.is_zero() {
-            return 0
+            return 0;
         }
 
         if let Some(chain_id) = chain_id {
@@ -107,7 +107,7 @@ impl Signature {
         } else {
             // non-EIP-155 legacy scheme, v = 27 for even y-parity, v = 28 for odd y-parity
             if v != 27 && v != 28 {
-                return Err(RlpError::Custom("invalid Ethereum signature (V is not 27 or 28)"))
+                return Err(RlpError::Custom("invalid Ethereum signature (V is not 27 or 28)"));
             }
             let odd_y_parity = v == 28;
             Ok((Signature { r, s, odd_y_parity }, None))
@@ -150,7 +150,7 @@ impl Signature {
 
         // NOTE: we are removing error from underlying crypto library as it will restrain primitive
         // errors and we care only if recovery is passing or not.
-        secp256k1::recover_signer(&sig, &hash.0).ok()
+        secp256k1::recover_signer_unchecked(&sig, &hash.0).ok()
     }
 
     /// Recover signer address from message hash. This ensures that the signature S value is
@@ -160,7 +160,7 @@ impl Signature {
     /// If the S value is too large, then this will return `None`
     pub fn recover_signer(&self, hash: B256) -> Option<Address> {
         if self.s > SECP256K1N_HALF {
-            return None
+            return None;
         }
 
         self.recover_signer_unchecked(hash)

--- a/crates/primitives/src/transaction/util.rs
+++ b/crates/primitives/src/transaction/util.rs
@@ -11,7 +11,10 @@ pub(crate) mod secp256k1 {
     /// Recovers the address of the sender using secp256k1 pubkey recovery.
     ///
     /// Converts the public key into an ethereum address by hashing the public key with keccak256.
-    pub fn recover_signer(sig: &[u8; 65], msg: &[u8; 32]) -> Result<Address, Error> {
+    ///
+    /// This does not ensure that the `s` value in the signature is low, and _just_ wraps the
+    /// underlying secp256k1 library.
+    pub fn recover_signer_unchecked(sig: &[u8; 65], msg: &[u8; 32]) -> Result<Address, Error> {
         let sig =
             RecoverableSignature::from_compact(&sig[0..64], RecoveryId::from_i32(sig[64] as i32)?)?;
 
@@ -55,6 +58,6 @@ mod tests {
         let hash = hex!("47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad");
         let out = address!("c08b5542d177ac6686946920409741463a15dddb");
 
-        assert_eq!(secp256k1::recover_signer(&sig, &hash), Ok(out));
+        assert_eq!(secp256k1::recover_signer_unchecked(&sig, &hash), Ok(out));
     }
 }


### PR DESCRIPTION
This adds another method which checks that the signature S value is greater than `secp256k1n/2`, returning `None` if so. This was specified by [EIP-2](https://eips.ethereum.org/EIPS/eip-2), and should be enforced past homestead. There are transactions with a high S value before the homestead fork, so the senders stage needs to use the `unchecked` version, which is backwards-compatible

there are transactions with a high S value historically:
https://etherscan.io/getRawTx?tx=0x9e6e19637bb625a8ff3d052b7c2fe57dc78c55a15d258d77c43d5a9c160b0384