### PR TITLE
use SealedBlockedWithSenders in block-level tracing

### DIFF
--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -779,12 +779,9 @@ where
         R: Send + 'static,
     {
         let ((cfg, block_env, _), block) =
-            futures::try_join!(self.evm_env_at(block_id), self.block_with_senders(block_id),)?;
+            futures::try_join!(self.evm_env_at(block_id), self.block_with_senders(block_id))?;
 
-        let (block, senders) = match block {
-            Some(block) => block.into_components(),
-            None => return Ok(None),
-        };
+        let Some(block) = block else { return Ok(None) };
 
         // replay all transactions of the block
         self.spawn_tracing_task_with(move |this| {
@@ -799,14 +796,13 @@ where
             // prepare transactions, we do everything upfront to reduce time spent with open state
             let max_transactions =
                 highest_index.map_or(block.body.len(), |highest| highest as usize);
-            let transactions = block
-                .body
-                .into_iter()
+            let mut results = Vec::with_capacity(max_transactions);
+
+            let mut transactions = block
+                .into_transactions_ecrecovered()
                 .take(max_transactions)
                 .enumerate()
-                .map(|(idx, tx)| -> EthResult<_> {
-                    let tx =
-                        TransactionSignedEcRecovered::from_signed_transaction(tx, senders[idx]);
+                .map(|(idx, tx)| {
                     let tx_info = TransactionInfo {
                         hash: Some(tx.hash()),
                         index: Some(idx as u64),
@@ -815,18 +811,13 @@ where
                         base_fee: Some(base_fee),
                     };
                     let tx_env = tx_env_with_recovered(&tx);
-
-                    Ok((tx_info, tx_env))
+                    (tx_info, tx_env)
                 })
-                .collect::<Result<Vec<_>, _>>()?;
-
-            let mut results = Vec::with_capacity(transactions.len());
+                .peekable();
 
             // now get the state
             let state = this.state_at(state_at.into())?;
             let mut db = CacheDB::new(StateProviderDatabase::new(state));
-
-            let mut transactions = transactions.into_iter().peekable();
 
             while let Some((tx_info, tx)) = transactions.next() {
                 let env = Env { cfg: cfg.clone(), block: block_env.clone(), tx };


### PR DESCRIPTION
Addresses #5497 

Using `block_with_senders(blockId)` to get `SealedBlockWithSenders` inside `trace_block_until` instead of `block_by_id` which returns `SealedBlock`. 

The need to recover signers during tracing is removed due to this.