### PR TITLE
Added chunk impl for parallel sender recovery

### DIFF
--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -8,10 +8,10 @@ use alloy_rlp::{
 use bytes::{Buf, BytesMut};
 use derive_more::{AsRef, Deref};
 use once_cell::sync::Lazy;
-use rayon::prelude::{IntoParallelIterator, ParallelIterator};
+use rayon::prelude::*;
 use reth_codecs::{add_arbitrary_tests, derive_arbitrary, Compact};
 use serde::{Deserialize, Serialize};
-use std::mem;
+use std::{mem, sync::mpsc, thread};
 
 pub use access_list::{AccessList, AccessListItem};
 pub use eip1559::TxEip1559;
@@ -849,7 +849,53 @@ impl TransactionSignedNoHash {
         if num_txes < *PARALLEL_SENDER_RECOVERY_THRESHOLD {
             txes.into_iter().map(|tx| tx.recover_signer()).collect()
         } else {
-            txes.into_par_iter().map(|tx| tx.recover_signer()).collect()
+            let mut recovered_signers: Vec<Address> = Vec::new();
+            let mut channels = Vec::new();
+            rayon::scope(|s| {
+                let (chunk_size, chunks) = if num_txes < 16 {
+                    (num_txes, 2)
+                } else {
+                    let chunk_size = num_txes / (num_txes / 16);
+                    let chunks = num_txes / chunk_size + 1;
+                    (chunk_size, chunks)
+                };
+                let mut iter = txes.into_iter();
+                (0..chunks).for_each(|i| {
+                    let chunk: Vec<&TransactionSignedNoHash> = if i == chunks - 1 {
+                        iter.by_ref().take(num_txes % chunk_size).collect()
+                    } else {
+                        iter.by_ref().take(chunk_size).collect()
+                    };
+                    let (recovered_senders_tx, recovered_senders_rx) = mpsc::channel();
+                    channels.push(recovered_senders_rx);
+                    // Spawn the sender recovery task onto the global rayon pool
+                    // This task will send the results through the channel after it recovered
+                    // the senders.
+                    s.spawn(move |_| {
+                        for tx in chunk {
+                            let recovery_result = tx.recover_signer();
+                            let _ = recovered_senders_tx.send(recovery_result);
+                        }
+                    });
+                })
+            });
+            thread::spawn(move || {
+                for channel in channels {
+                    while let Ok(recovered) = channel.recv() {
+                        match recovered {
+                            Some(signer) => {
+                                recovered_signers.push(signer);
+                            }
+                            None => {
+                                return None;
+                            }
+                        }
+                    }
+                }
+                Some(recovered_signers)
+            })
+            .join()
+            .unwrap()
         }
     }
 }
@@ -1003,7 +1049,53 @@ impl TransactionSigned {
         if num_txes < *PARALLEL_SENDER_RECOVERY_THRESHOLD {
             txes.into_iter().map(|tx| tx.recover_signer()).collect()
         } else {
-            txes.into_par_iter().map(|tx| tx.recover_signer()).collect()
+            let mut recovered_signers: Vec<Address> = Vec::new();
+            let mut channels = Vec::new();
+            rayon::scope(|s| {
+                let (chunk_size, chunks) = if num_txes < 16 {
+                    (num_txes, 2)
+                } else {
+                    let chunk_size = num_txes / (num_txes / 16);
+                    let chunks = num_txes / chunk_size + 1;
+                    (chunk_size, chunks)
+                };
+                let mut iter = txes.into_iter();
+                (0..chunks).for_each(|i| {
+                    let chunk: Vec<&TransactionSigned> = if i == chunks - 1 {
+                        iter.by_ref().take(num_txes % chunk_size).collect()
+                    } else {
+                        iter.by_ref().take(chunk_size).collect()
+                    };
+                    let (recovered_senders_tx, recovered_senders_rx) = mpsc::channel();
+                    channels.push(recovered_senders_rx);
+                    // Spawn the sender recovery task onto the global rayon pool
+                    // This task will send the results through the channel after it recovered
+                    // the senders.
+                    s.spawn(move |_| {
+                        for tx in chunk {
+                            let recovery_result = tx.recover_signer();
+                            let _ = recovered_senders_tx.send(recovery_result);
+                        }
+                    });
+                })
+            });
+            thread::spawn(move || {
+                for channel in channels {
+                    while let Ok(recovered) = channel.recv() {
+                        match recovered {
+                            Some(signer) => {
+                                recovered_signers.push(signer);
+                            }
+                            None => {
+                                return None;
+                            }
+                        }
+                    }
+                }
+                Some(recovered_signers)
+            })
+            .join()
+            .unwrap()
         }
     }
 


### PR DESCRIPTION
Resolving issue #5189

Creating new pull request, I was not able to run the mainnet SenderRecovery stage because of my device specs. Instead, I ran optimized tests using cargo test --package reth-primitives --release to get more reliable measurement as pointed out by @rakita. I compared the performance before/after (without/with chunks) for recovering 100,000 transactions. 

The test:

Additional crates used in mod tests:

use std::{fs::File, io::Write, time::Instant};
use rayon::prelude::*;

        #[test]
        fn benchmark_chunks_parallel_sender_recovery_100000(txes in proptest::collection::vec(proptest::prelude::any::<Transaction>(), *PARALLEL_SENDER_RECOVERY_THRESHOLD * 20000)) {
            let mut rng =rand::thread_rng();
            let secp = Secp256k1::new();
            let txes: Vec<TransactionSigned> = txes.into_iter().map(|mut tx| {
                 if let Some(chain_id) = tx.chain_id() {
                    // Otherwise we might overflow when calculating `v` on `recalculate_hash`
                    tx.set_chain_id(chain_id % (u64::MAX / 2 - 36));
                }

                let key_pair = KeyPair::new(&secp, &mut rng);

                let signature =
                    sign_message(B256::from_slice(&key_pair.secret_bytes()[..]), tx.signature_hash()).unwrap();

                TransactionSigned::from_transaction_and_signature(tx, signature)
            }).collect();

            let mut file = File::create("benchmark.txt")?;

            let start_chunk = Instant::now();
            let _par_chunk_senders = TransactionSigned::recover_signers(&txes, txes.len());
            let elapsed_chunk = start_chunk.elapsed();

            let start = Instant::now();
            let _par_senders = txes.into_par_iter().map(|tx| tx.recover_signer()).collect::<Option<Vec<_>>>();
            let elapsed = start.elapsed();

            write!(file, "Time taken for parallel recovery of 100000 addresses: {:.2?} (with chunks) and {:.2?} (without chunks)", elapsed_chunk, elapsed)?;

        }

The results:
![benchmark_run_1](https://github.com/paradigmxyz/reth/assets/98768062/58f8ed8e-2969-4a7e-b246-76427f86f65d)
![benchmark_run_2](https://github.com/paradigmxyz/reth/assets/98768062/f1742114-ceac-4859-8e26-652902368af3)
![benchmark_run_3](https://github.com/paradigmxyz/reth/assets/98768062/fd04eb60-f2df-464d-bb46-0eea3512abf9)
![benchmark_run_4](https://github.com/paradigmxyz/reth/assets/98768062/d4ce39dd-f89a-43a4-89da-61a50ec3fa1f)
![benchmark_run_5](https://github.com/paradigmxyz/reth/assets/98768062/da2946f3-e7eb-4dd0-9e78-ed41942396d7)


Chunk implementation takes 20-30% less time than the current implementation in all runs. It would be great if anyone else could run it and compare the performance. Since they are all optimized test runs, I think the estimates are reliable.
 
