### PR TITLE
feat(storage): report backtrace only on read transactions

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -183,7 +183,9 @@ impl<K: TransactionKind> MetricsHandler<K> {
     /// NOTE: Backtrace is recorded using [Backtrace::force_capture], so `RUST_BACKTRACE` env var is
     /// not needed.
     fn log_backtrace_on_long_transaction(&self) {
-        if self.backtrace_recorded.load(Ordering::Relaxed) {
+        if self.backtrace_recorded.load(Ordering::Relaxed) ||
+            self.transaction_mode() != TransactionMode::ReadOnly
+        {
             return
         }
 
@@ -196,7 +198,7 @@ impl<K: TransactionKind> MetricsHandler<K> {
                 target: "storage::db::mdbx",
                 ?open_duration,
                 ?backtrace,
-                "The database transaction has been open for too long"
+                "The database read transaction has been open for too long"
             );
         }
     }

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -176,30 +176,28 @@ impl<K: TransactionKind> MetricsHandler<K> {
         }
     }
 
-    /// Logs the backtrace of current call if the duration that the transaction has been open is
-    /// more than [LONG_TRANSACTION_DURATION].
+    /// Logs the backtrace of current call if the duration that the read transaction has been open
+    /// is more than [LONG_TRANSACTION_DURATION].
     /// The backtrace is recorded and logged just once, guaranteed by `backtrace_recorded` atomic.
     ///
     /// NOTE: Backtrace is recorded using [Backtrace::force_capture], so `RUST_BACKTRACE` env var is
     /// not needed.
     fn log_backtrace_on_long_transaction(&self) {
-        if self.backtrace_recorded.load(Ordering::Relaxed) ||
-            self.transaction_mode() != TransactionMode::ReadOnly
+        if !self.backtrace_recorded.load(Ordering::Relaxed) &&
+            self.transaction_mode() == TransactionMode::ReadOnly
         {
-            return
-        }
+            let open_duration = self.start.elapsed();
+            if open_duration > LONG_TRANSACTION_DURATION {
+                self.backtrace_recorded.store(true, Ordering::Relaxed);
 
-        let open_duration = self.start.elapsed();
-        if open_duration > LONG_TRANSACTION_DURATION {
-            self.backtrace_recorded.store(true, Ordering::Relaxed);
-
-            let backtrace = Backtrace::force_capture();
-            debug!(
-                target: "storage::db::mdbx",
-                ?open_duration,
-                ?backtrace,
-                "The database read transaction has been open for too long"
-            );
+                let backtrace = Backtrace::force_capture();
+                debug!(
+                    target: "storage::db::mdbx",
+                    ?open_duration,
+                    ?backtrace,
+                    "The database read transaction has been open for too long"
+                );
+            }
         }
     }
 }

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -184,7 +184,7 @@ impl<K: TransactionKind> MetricsHandler<K> {
     /// not needed.
     fn log_backtrace_on_long_transaction(&self) {
         if !self.backtrace_recorded.load(Ordering::Relaxed) &&
-            self.transaction_mode() == TransactionMode::ReadOnly
+            self.transaction_mode().is_read_only()
         {
             let open_duration = self.start.elapsed();
             if open_duration > LONG_TRANSACTION_DURATION {

--- a/crates/storage/db/src/metrics.rs
+++ b/crates/storage/db/src/metrics.rs
@@ -18,6 +18,11 @@ impl TransactionMode {
             TransactionMode::ReadWrite => "read-write",
         }
     }
+
+    /// Returns `true` if the transaction mode is read-only.
+    pub(crate) const fn is_read_only(&self) -> bool {
+        matches!(self, TransactionMode::ReadOnly)
+    }
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]


### PR DESCRIPTION
Minutes-long write transactions are fine, and we have plenty of them during the initial sync. Only long-lived read transactions cause problems and grow freelist.