### PR TITLE
perf(trie): prealloc in `Nibble::unpack`

### DIFF
--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -99,3 +99,7 @@ harness = false
 name = "trie_root"
 required-features = ["arbitrary", "test-utils"]
 harness = false
+
+[[bench]]
+name = "nibbles"
+harness = false

--- a/crates/primitives/benches/nibbles.rs
+++ b/crates/primitives/benches/nibbles.rs
@@ -1,0 +1,19 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use reth_primitives::trie::Nibbles;
+
+/// Benchmarks the nibble unpacking.
+pub fn nibbles_benchmark(c: &mut Criterion) {
+    c.bench_function("Nibbles unpack", |b| {
+        let raw = (1..=32).collect::<Vec<u8>>();
+        b.iter(|| {
+            Nibbles::unpack(&raw);
+        })
+    });
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = nibbles_benchmark
+}
+criterion_main!(benches);

--- a/crates/primitives/src/trie/nibbles.rs
+++ b/crates/primitives/src/trie/nibbles.rs
@@ -94,14 +94,12 @@ impl Nibbles {
     /// Take a byte array (slice or vector) as input and convert it into a [Nibbles] struct
     /// containing the nibbles (half-bytes or 4 bits) that make up the input byte data.
     pub fn unpack<T: AsRef<[u8]>>(data: T) -> Self {
-        Nibbles {
-            hex_data: Bytes::from(
-                data.as_ref()
-                    .iter()
-                    .flat_map(|item| vec![item / 16, item % 16])
-                    .collect::<Vec<u8>>(),
-            ),
+        let mut vec = Vec::with_capacity(data.as_ref().len() * 2);
+        for byte in data.as_ref() {
+            vec.push(byte / 16);
+            vec.push(byte % 16);
         }
+        Nibbles { hex_data: Bytes::from(vec) }
     }
 
     /// Packs the nibbles stored in the struct into a byte vector.


### PR DESCRIPTION
# Description

It reduces time for Nibble::unpack (-82%).

Before this change unpack was taking 33% of the StateRoot::root call and after this change it takes 5%.