### PR TITLE
perf(rpc): Use block_with_senders in tracing

### DIFF
--- a/crates/rpc/rpc/src/eth/api/call.rs
+++ b/crates/rpc/rpc/src/eth/api/call.rs
@@ -113,15 +113,13 @@ where
             if replay_block_txs {
                 // only need to replay the transactions in the block if not all transactions are
                 // to be replayed
-                let _transactions =
-                    block.into_transactions_ecrecovered().take(num_txs).enumerate().map(
-                        |(_idx, tx)| {
-                            let tx = tx_env_with_recovered(&tx);
-                            let env = Env { cfg: cfg.clone(), block: block_env.clone(), tx };
-                            let (res, _) = transact(&mut db, env).unwrap();
-                            db.commit(res.state);
-                        },
-                    );
+                let transactions = block.into_transactions_ecrecovered().take(num_txs);
+                for tx in transactions {
+                    let tx = tx_env_with_recovered(&tx);
+                    let env = Env { cfg: cfg.clone(), block: block_env.clone(), tx };
+                    let (res, _) = transact(&mut db, env)?;
+                    db.commit(res.state);
+                }
             }
 
             let block_overrides = block_override.map(Box::new);

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -1037,21 +1037,16 @@ where
         block_id: impl Into<BlockId>,
         index: Index,
     ) -> EthResult<Option<Transaction>> {
-        let block_id = block_id.into();
-
-        if let Some(block_with_senders) = self.block_with_senders(block_id).await? {
-            let (block, senders) = block_with_senders.into_components();
+        if let Some(block) = self.block_with_senders(block_id.into()).await? {
             let block_hash = block.hash;
-            let block = block.unseal();
-            if let Some(tx_signed) = block.body.into_iter().nth(index.into()) {
-                let idx: usize = index.into();
-                let tx =
-                    TransactionSignedEcRecovered::from_signed_transaction(tx_signed, senders[idx]);
+            let block_number = block.number;
+            let base_fee_per_gas = block.base_fee_per_gas;
+            if let Some(tx) = block.into_transactions_ecrecovered().nth(index.into()) {
                 return Ok(Some(from_recovered_with_block_context(
                     tx,
                     block_hash,
-                    block.header.number,
-                    block.header.base_fee_per_gas,
+                    block_number,
+                    base_fee_per_gas,
                     index.into(),
                 )))
             }


### PR DESCRIPTION
Addresses #5497 

Updated ```call_many``` and ```transaction_by_block_and_tx_index``` to use ```block_with_senders``` removing the need for recovering txns.