### PR TITLE
 feat: add MockTransactionSet for easier dependent mock txs 

### DIFF
--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -466,7 +466,7 @@ impl<T: PoolTransaction> Ord for QueuedOrd<T> {
 mod tests {
     use super::*;
     use crate::test_utils::{MockTransaction, MockTransactionFactory, MockTransactionSet};
-    use reth_primitives::address;
+    use reth_primitives::{address, TxType};
     use std::collections::HashSet;
 
     #[test]
@@ -536,46 +536,38 @@ mod tests {
         let d_sender = address!("000000000000000000000000000000000000000d");
 
         // create a chain of transactions by sender A, B, C
-        let mut tx_set =
-            MockTransactionSet::dependent(a_sender, 0, 4, reth_primitives::TxType::EIP1559);
-        let a_set = tx_set.clone().into_vec();
+        let mut tx_set = MockTransactionSet::dependent(a_sender, 0, 4, TxType::EIP1559);
+        let a = tx_set.clone().into_vec();
 
-        let b_set = MockTransactionSet::dependent(b_sender, 0, 3, reth_primitives::TxType::EIP1559)
-            .clone()
-            .into_vec();
-        tx_set.extend(b_set.clone());
+        let b = MockTransactionSet::dependent(b_sender, 0, 3, TxType::EIP1559).into_vec();
+        tx_set.extend(b.clone());
 
         // C has the same number of txs as B
-        let c_set = MockTransactionSet::dependent(c_sender, 0, 3, reth_primitives::TxType::EIP1559)
-            .clone()
-            .into_vec();
-        tx_set.extend(c_set.clone());
+        let c = MockTransactionSet::dependent(c_sender, 0, 3, TxType::EIP1559).into_vec();
+        tx_set.extend(c.clone());
 
-        let d_set = MockTransactionSet::dependent(d_sender, 0, 1, reth_primitives::TxType::EIP1559)
-            .clone()
-            .into_vec();
-        tx_set.extend(d_set.clone());
+        let d = MockTransactionSet::dependent(d_sender, 0, 1, TxType::EIP1559).into_vec();
+        tx_set.extend(d.clone());
 
         let all_txs = tx_set.into_vec();
 
         // just construct a list of all txs to add
-        let expected_parked =
-            vec![c_set[0].clone(), c_set[1].clone(), c_set[2].clone(), d_set[0].clone()]
-                .into_iter()
-                .map(|tx| (tx.sender(), tx.nonce()))
-                .collect::<HashSet<_>>();
+        let expected_parked = vec![c[0].clone(), c[1].clone(), c[2].clone(), d[0].clone()]
+            .into_iter()
+            .map(|tx| (tx.sender(), tx.nonce()))
+            .collect::<HashSet<_>>();
 
         // we expect the truncate operation to go through the senders with the most txs, removing
         // txs based on when they were submitted, removing the oldest txs first, until the pool is
         // not over the limit
         let expected_removed = vec![
-            a_set[0].clone(),
-            a_set[1].clone(),
-            a_set[2].clone(),
-            a_set[3].clone(),
-            b_set[0].clone(),
-            b_set[1].clone(),
-            b_set[2].clone(),
+            a[0].clone(),
+            a[1].clone(),
+            a[2].clone(),
+            a[3].clone(),
+            b[0].clone(),
+            b[1].clone(),
+            b[2].clone(),
         ]
         .into_iter()
         .map(|tx| (tx.sender(), tx.nonce()))
@@ -621,27 +613,20 @@ mod tests {
         // create a chain of transactions by sender A, B, C
         let mut tx_set =
             MockTransactionSet::dependent(a_sender, 0, 4, reth_primitives::TxType::EIP1559);
-        let a_set = tx_set.clone().into_vec();
-        let a1 = a_set[0].clone();
+        let a = tx_set.clone().into_vec();
 
-        let b_set = MockTransactionSet::dependent(b_sender, 0, 3, reth_primitives::TxType::EIP1559)
-            .clone()
+        let b = MockTransactionSet::dependent(b_sender, 0, 3, reth_primitives::TxType::EIP1559)
             .into_vec();
-        tx_set.extend(b_set.clone());
-        let b1 = b_set[0].clone();
+        tx_set.extend(b.clone());
 
         // C has the same number of txs as B
-        let c_set = MockTransactionSet::dependent(c_sender, 0, 3, reth_primitives::TxType::EIP1559)
-            .clone()
+        let c = MockTransactionSet::dependent(c_sender, 0, 3, reth_primitives::TxType::EIP1559)
             .into_vec();
-        tx_set.extend(c_set.clone());
-        let c1 = c_set[0].clone();
+        tx_set.extend(c.clone());
 
-        let d_set = MockTransactionSet::dependent(d_sender, 0, 1, reth_primitives::TxType::EIP1559)
-            .clone()
+        let d = MockTransactionSet::dependent(d_sender, 0, 1, reth_primitives::TxType::EIP1559)
             .into_vec();
-        tx_set.extend(d_set.clone());
-        let d1 = d_set[0].clone();
+        tx_set.extend(d.clone());
 
         let all_txs = tx_set.into_vec();
 
@@ -665,7 +650,7 @@ mod tests {
 
         // manually order the txs
         let mut pool = ParkedPool::<BasefeeOrd<_>>::default();
-        let all_txs = vec![d1, b1, c1, a1];
+        let all_txs = vec![d[0].clone(), b[0].clone(), c[0].clone(), a[0].clone()];
 
         // add all the transactions to the pool
         for tx in all_txs {

--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -152,7 +152,7 @@ impl<T: ParkedOrd> ParkedPool<T> {
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         if self.len() <= limit.max_txs {
             // if we are below the limits, we don't need to drop anything
-            return Vec::new()
+            return Vec::new();
         }
 
         let mut removed = Vec::new();
@@ -173,7 +173,7 @@ impl<T: ParkedOrd> ParkedPool<T> {
                     }
                 }
                 drop -= list.len();
-                continue
+                continue;
             }
 
             // Otherwise drop only last few transactions
@@ -252,7 +252,7 @@ impl<T: PoolTransaction> ParkedPool<BasefeeOrd<T>> {
                     // still parked -> skip descendant transactions
                     'this: while let Some((peek, _)) = iter.peek() {
                         if peek.sender != id.sender {
-                            break 'this
+                            break 'this;
                         }
                         iter.next();
                     }
@@ -465,7 +465,7 @@ impl<T: PoolTransaction> Ord for QueuedOrd<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{MockTransaction, MockTransactionFactory};
+    use crate::test_utils::{MockTransaction, MockTransactionFactory, MockTransactionSet};
     use reth_primitives::address;
     use std::collections::HashSet;
 
@@ -608,41 +608,37 @@ mod tests {
         let mut f = MockTransactionFactory::default();
         let mut pool = ParkedPool::<BasefeeOrd<_>>::default();
 
-        let a = address!("000000000000000000000000000000000000000a");
-        let b = address!("000000000000000000000000000000000000000b");
-        let c = address!("000000000000000000000000000000000000000c");
-        let d = address!("000000000000000000000000000000000000000d");
+        let a_sender = address!("000000000000000000000000000000000000000a");
+        let b_sender = address!("000000000000000000000000000000000000000b");
+        let c_sender = address!("000000000000000000000000000000000000000c");
+        let d_sender = address!("000000000000000000000000000000000000000d");
 
         // create a chain of transactions by sender A, B, C
-        let a1 = MockTransaction::eip1559().with_sender(a);
-        let a2 = a1.next();
-        let a3 = a2.next();
-        let a4 = a3.next();
+        let mut tx_set =
+            MockTransactionSet::dependent(a_sender, 0, 4, reth_primitives::TxType::EIP1559);
+        let a_set = tx_set.clone().into_vec();
+        let a1 = a_set[0].clone();
 
-        let b1 = MockTransaction::eip1559().with_sender(b);
-        let b2 = b1.next();
-        let b3 = b2.next();
+        let b_set = MockTransactionSet::dependent(b_sender, 0, 3, reth_primitives::TxType::EIP1559)
+            .clone()
+            .into_vec();
+        tx_set.extend(b_set.clone());
+        let b1 = b_set[0].clone();
 
         // C has the same number of txs as B
-        let c1 = MockTransaction::eip1559().with_sender(c);
-        let c2 = c1.next();
-        let c3 = c2.next();
+        let c_set = MockTransactionSet::dependent(c_sender, 0, 3, reth_primitives::TxType::EIP1559)
+            .clone()
+            .into_vec();
+        tx_set.extend(c_set.clone());
+        let c1 = c_set[0].clone();
 
-        let d1 = MockTransaction::eip1559().with_sender(d);
+        let d_set = MockTransactionSet::dependent(d_sender, 0, 1, reth_primitives::TxType::EIP1559)
+            .clone()
+            .into_vec();
+        tx_set.extend(d_set.clone());
+        let d1 = d_set[0].clone();
 
-        let all_txs = vec![
-            a1.clone(),
-            a2.clone(),
-            a3.clone(),
-            a4.clone(),
-            b1.clone(),
-            b2.clone(),
-            b3.clone(),
-            c1.clone(),
-            c2.clone(),
-            c3.clone(),
-            d1.clone(),
-        ];
+        let all_txs = tx_set.into_vec();
 
         // add all the transactions to the pool
         for tx in all_txs {
@@ -656,12 +652,15 @@ mod tests {
             .map(|s| s.sender_id)
             .collect::<Vec<_>>();
         assert_eq!(senders.len(), 4);
-        let expected_senders =
-            vec![d, c, b, a].into_iter().map(|s| f.ids.sender_id(&s).unwrap()).collect::<Vec<_>>();
+        let expected_senders = vec![d_sender, c_sender, b_sender, a_sender]
+            .into_iter()
+            .map(|s| f.ids.sender_id(&s).unwrap())
+            .collect::<Vec<_>>();
         assert_eq!(senders, expected_senders);
 
+        // manually order the txs
         let mut pool = ParkedPool::<BasefeeOrd<_>>::default();
-        let all_txs = vec![a1, b1, c1, d1, a2, b2, c2, a3, b3, c3, a4];
+        let all_txs = vec![d1, b1, c1, a1];
 
         // add all the transactions to the pool
         for tx in all_txs {
@@ -674,8 +673,10 @@ mod tests {
             .map(|s| s.sender_id)
             .collect::<Vec<_>>();
         assert_eq!(senders.len(), 4);
-        let expected_senders =
-            vec![a, c, b, d].into_iter().map(|s| f.ids.sender_id(&s).unwrap()).collect::<Vec<_>>();
+        let expected_senders = vec![a_sender, c_sender, b_sender, d_sender]
+            .into_iter()
+            .map(|s| f.ids.sender_id(&s).unwrap())
+            .collect::<Vec<_>>();
         assert_eq!(senders, expected_senders);
     }
 }

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -185,7 +185,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
                 // Remove all dependent transactions.
                 'this: while let Some((next_id, next_tx)) = transactions_iter.peek() {
                     if next_id.sender != id.sender {
-                        break 'this
+                        break 'this;
                     }
                     removed.push(Arc::clone(&next_tx.transaction));
                     transactions_iter.next();
@@ -228,7 +228,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
                 // Remove all dependent transactions.
                 'this: while let Some((next_id, next_tx)) = transactions_iter.peek() {
                     if next_id.sender != id.sender {
-                        break 'this
+                        break 'this;
                     }
                     removed.push(Arc::clone(&next_tx.transaction));
                     transactions_iter.next();
@@ -420,12 +420,12 @@ impl<T: TransactionOrdering> PendingPool<T> {
                         }
                     }
 
-                    return
+                    return;
                 }
 
                 if !remove_locals && tx.transaction.is_local() {
                     non_local_senders -= 1;
-                    continue
+                    continue;
                 }
 
                 total_size += tx.transaction.size();
@@ -460,7 +460,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
         self.remove_to_limit(&limit, false, &mut removed);
 
         if self.size() <= limit.max_size && self.len() <= limit.max_txs {
-            return removed
+            return removed;
         }
 
         // now repeat for local transactions
@@ -570,7 +570,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        test_utils::{MockOrdering, MockTransaction, MockTransactionFactory},
+        test_utils::{MockOrdering, MockTransaction, MockTransactionFactory, MockTransactionSet},
         PoolTransaction,
     };
 
@@ -661,31 +661,34 @@ mod tests {
         let mut f = MockTransactionFactory::default();
         let mut pool = PendingPool::new(MockOrdering::default());
 
-        let a = address!("000000000000000000000000000000000000000a");
-        let b = address!("000000000000000000000000000000000000000b");
-        let c = address!("000000000000000000000000000000000000000c");
-        let d = address!("000000000000000000000000000000000000000d");
+        let a_sender = address!("000000000000000000000000000000000000000a");
+        let b_sender = address!("000000000000000000000000000000000000000b");
+        let c_sender = address!("000000000000000000000000000000000000000c");
+        let d_sender = address!("000000000000000000000000000000000000000d");
 
         // create a chain of transactions by sender A, B, C
-        let a1 = MockTransaction::eip1559().with_sender(a);
-        let a2 = a1.next();
-        let a3 = a2.next();
-        let a4 = a3.next();
+        let mut tx_set =
+            MockTransactionSet::dependent(a_sender, 0, 4, reth_primitives::TxType::EIP1559);
+        let a_set = tx_set.clone().into_vec();
 
-        let b1 = MockTransaction::eip1559().with_sender(b);
-        let b2 = b1.next();
-        let b3 = b2.next();
+        let b_set = MockTransactionSet::dependent(b_sender, 0, 3, reth_primitives::TxType::EIP1559)
+            .clone()
+            .into_vec();
+        tx_set.extend(b_set.clone());
 
         // C has the same number of txs as B
-        let c1 = MockTransaction::eip1559().with_sender(c);
-        let c2 = c1.next();
-        let c3 = c2.next();
+        let c_set = MockTransactionSet::dependent(c_sender, 0, 3, reth_primitives::TxType::EIP1559)
+            .clone()
+            .into_vec();
+        tx_set.extend(c_set.clone());
 
-        let d1 = MockTransaction::eip1559().with_sender(d);
+        let d_set = MockTransactionSet::dependent(d_sender, 0, 1, reth_primitives::TxType::EIP1559)
+            .clone()
+            .into_vec();
+        tx_set.extend(d_set.clone());
 
         // add all the transactions to the pool
-        let all_txs =
-            vec![a1, a2, a3, a4.clone(), b1, b2, b3.clone(), c1, c2, c3.clone(), d1.clone()];
+        let all_txs = tx_set.into_vec();
         for tx in all_txs {
             pool.add_transaction(f.validated_arc(tx), 0);
         }
@@ -695,7 +698,10 @@ mod tests {
         // the independent set is the roots of each of these tx chains, these are the highest
         // nonces for each sender
         let expected_highest_nonces =
-            vec![d1, c3, b3, a4].iter().map(|tx| (tx.sender(), tx.nonce())).collect::<HashSet<_>>();
+            vec![d_set[0].clone(), c_set[2].clone(), b_set[2].clone(), a_set[3].clone()]
+                .iter()
+                .map(|tx| (tx.sender(), tx.nonce()))
+                .collect::<HashSet<_>>();
         let actual_highest_nonces = pool
             .highest_nonces
             .iter()

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -669,23 +669,20 @@ mod tests {
         // create a chain of transactions by sender A, B, C
         let mut tx_set =
             MockTransactionSet::dependent(a_sender, 0, 4, reth_primitives::TxType::EIP1559);
-        let a_set = tx_set.clone().into_vec();
+        let a = tx_set.clone().into_vec();
 
-        let b_set = MockTransactionSet::dependent(b_sender, 0, 3, reth_primitives::TxType::EIP1559)
-            .clone()
+        let b = MockTransactionSet::dependent(b_sender, 0, 3, reth_primitives::TxType::EIP1559)
             .into_vec();
-        tx_set.extend(b_set.clone());
+        tx_set.extend(b.clone());
 
         // C has the same number of txs as B
-        let c_set = MockTransactionSet::dependent(c_sender, 0, 3, reth_primitives::TxType::EIP1559)
-            .clone()
+        let c = MockTransactionSet::dependent(c_sender, 0, 3, reth_primitives::TxType::EIP1559)
             .into_vec();
-        tx_set.extend(c_set.clone());
+        tx_set.extend(c.clone());
 
-        let d_set = MockTransactionSet::dependent(d_sender, 0, 1, reth_primitives::TxType::EIP1559)
-            .clone()
+        let d = MockTransactionSet::dependent(d_sender, 0, 1, reth_primitives::TxType::EIP1559)
             .into_vec();
-        tx_set.extend(d_set.clone());
+        tx_set.extend(d.clone());
 
         // add all the transactions to the pool
         let all_txs = tx_set.into_vec();
@@ -698,7 +695,7 @@ mod tests {
         // the independent set is the roots of each of these tx chains, these are the highest
         // nonces for each sender
         let expected_highest_nonces =
-            vec![d_set[0].clone(), c_set[2].clone(), b_set[2].clone(), a_set[3].clone()]
+            vec![d[0].clone(), c[2].clone(), b[2].clone(), a[3].clone()]
                 .iter()
                 .map(|tx| (tx.sender(), tx.nonce()))
                 .collect::<HashSet<_>>();

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -694,11 +694,10 @@ mod tests {
 
         // the independent set is the roots of each of these tx chains, these are the highest
         // nonces for each sender
-        let expected_highest_nonces =
-            vec![d[0].clone(), c[2].clone(), b[2].clone(), a[3].clone()]
-                .iter()
-                .map(|tx| (tx.sender(), tx.nonce()))
-                .collect::<HashSet<_>>();
+        let expected_highest_nonces = vec![d[0].clone(), c[2].clone(), b[2].clone(), a[3].clone()]
+            .iter()
+            .map(|tx| (tx.sender(), tx.nonce()))
+            .collect::<HashSet<_>>();
         let actual_highest_nonces = pool
             .highest_nonces
             .iter()

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -1160,7 +1160,7 @@ impl MockTransactionSet {
     }
 
     /// Add transactions to the [MockTransactionSet]
-    pub fn extend(&mut self, txs: Vec<MockTransaction>) {
+    pub fn extend<T: IntoIterator<Item = MockTransaction>>(&mut self, txs: T) {
         self.transactions.extend(txs);
     }
 


### PR DESCRIPTION
Adds `MockTransactionSet`, which makes it easier to construct dependent chains of `MockTransaction`s that have the same sender. This is useful when creating test cases for transaction pool methods which operate based on senders, like `truncate_pool` and `get_senders_by_submission_id`.