### PR TITLE
perf(trie): use smallvec as the Nibbles representation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,6 +482,9 @@ name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "assert_matches"
@@ -6156,6 +6159,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
+ "arrayvec",
  "assert_matches",
  "byteorder",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,9 +482,6 @@ name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "assert_matches"
@@ -6159,7 +6156,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
- "arrayvec",
  "assert_matches",
  "byteorder",
  "bytes",
@@ -6189,6 +6185,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2",
+ "smallvec",
  "strum",
  "sucds 0.6.0",
  "tempfile",
@@ -7427,6 +7424,10 @@ name = "smallvec"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+dependencies = [
+ "arbitrary",
+ "serde",
+]
 
 [[package]]
 name = "smol_str"

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -33,7 +33,7 @@ crc = "3"
 tracing.workspace = true
 
 # misc
-smallvec = { version = "1.11", features = ["arbitrary", "serde", "union", "const_generics"] }
+smallvec = { version = "1.11", features = ["arbitrary", "serde", "union", "const_new"] }
 bytes.workspace = true
 byteorder = "1"
 clap = { workspace = true, features = ["derive"], optional = true }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -33,7 +33,7 @@ crc = "3"
 tracing.workspace = true
 
 # misc
-arrayvec = { version = "0.7", features = ["serde"] }
+smallvec = { version = "1.11", features = ["arbitrary", "serde", "union", "const_generics"] }
 bytes.workspace = true
 byteorder = "1"
 clap = { workspace = true, features = ["derive"], optional = true }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -85,6 +85,7 @@ default = ["c-kzg"]
 arbitrary = [
     "revm-primitives/arbitrary",
     "reth-rpc-types/arbitrary",
+    "reth-ethereum-forks/arbitrary",
     "dep:arbitrary",
     "dep:proptest",
     "dep:proptest-derive",

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -33,6 +33,7 @@ crc = "3"
 tracing.workspace = true
 
 # misc
+arrayvec = { version = "0.7", features = ["serde"] }
 bytes.workspace = true
 byteorder = "1"
 clap = { workspace = true, features = ["derive"], optional = true }
@@ -85,7 +86,13 @@ pprof = { workspace = true, features = ["flamegraph", "frame-pointer", "criterio
 
 [features]
 default = ["c-kzg"]
-arbitrary = ["revm-primitives/arbitrary", "reth-rpc-types/arbitrary", "dep:arbitrary", "dep:proptest", "dep:proptest-derive"]
+arbitrary = [
+    "revm-primitives/arbitrary",
+    "reth-rpc-types/arbitrary",
+    "dep:arbitrary",
+    "dep:proptest",
+    "dep:proptest-derive",
+]
 c-kzg = ["dep:c-kzg", "revm/c-kzg", "revm-primitives/c-kzg"]
 clap = ["dep:clap"]
 optimism = ["reth-codecs/optimism", "revm-primitives/optimism", "revm/optimism"]

--- a/crates/primitives/benches/nibbles.rs
+++ b/crates/primitives/benches/nibbles.rs
@@ -1,12 +1,35 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use reth_primitives::trie::Nibbles;
+use std::hint::black_box;
 
 /// Benchmarks the nibble unpacking.
 pub fn nibbles_benchmark(c: &mut Criterion) {
     let mut g = c.benchmark_group("nibbles");
-    g.bench_function("unpack", |b| {
-        let raw = (1..=32).collect::<Vec<u8>>();
-        b.iter(|| Nibbles::unpack(&raw))
+
+    g.bench_function("unpack/32", |b| {
+        let raw = (0..32).collect::<Vec<u8>>();
+        b.iter(|| Nibbles::unpack(black_box(&raw[..])))
+    });
+    g.bench_function("unpack/256", |b| {
+        let raw = (0..=255).collect::<Vec<u8>>();
+        b.iter(|| Nibbles::unpack(black_box(&raw[..])))
+    });
+    g.bench_function("unpack/4096", |b| {
+        let raw = (0..=255).collect::<Vec<u8>>().repeat(4096 / 256);
+        b.iter(|| Nibbles::unpack(black_box(&raw[..])))
+    });
+
+    g.bench_function("pack/32", |b| {
+        let raw = Nibbles::unpack((0..32).collect::<Vec<u8>>());
+        b.iter(|| black_box(&raw).pack())
+    });
+    g.bench_function("pack/256", |b| {
+        let raw = Nibbles::unpack((0..=255).collect::<Vec<u8>>());
+        b.iter(|| black_box(&raw).pack())
+    });
+    g.bench_function("pack/4096", |b| {
+        let raw = Nibbles::unpack((0..=255).collect::<Vec<u8>>().repeat(4096 / 256));
+        b.iter(|| black_box(&raw).pack())
     });
 }
 

--- a/crates/primitives/benches/nibbles.rs
+++ b/crates/primitives/benches/nibbles.rs
@@ -1,36 +1,63 @@
 use criterion::{criterion_group, criterion_main, Criterion};
+use proptest::{prelude::*, strategy::ValueTree};
 use reth_primitives::trie::Nibbles;
-use std::hint::black_box;
+use std::{hint::black_box, time::Duration};
 
 /// Benchmarks the nibble unpacking.
 pub fn nibbles_benchmark(c: &mut Criterion) {
     let mut g = c.benchmark_group("nibbles");
+    g.warm_up_time(Duration::from_secs(1));
+    g.noise_threshold(0.02);
 
     g.bench_function("unpack/32", |b| {
-        let raw = (0..32).collect::<Vec<u8>>();
-        b.iter(|| Nibbles::unpack(black_box(&raw[..])))
+        let bytes = get_bytes(32);
+        b.iter(|| Nibbles::unpack(black_box(&bytes[..])))
     });
     g.bench_function("unpack/256", |b| {
-        let raw = (0..=255).collect::<Vec<u8>>();
-        b.iter(|| Nibbles::unpack(black_box(&raw[..])))
+        let bytes = get_bytes(256);
+        b.iter(|| Nibbles::unpack(black_box(&bytes[..])))
     });
-    g.bench_function("unpack/4096", |b| {
-        let raw = (0..=255).collect::<Vec<u8>>().repeat(4096 / 256);
-        b.iter(|| Nibbles::unpack(black_box(&raw[..])))
+    g.bench_function("unpack/2048", |b| {
+        let bytes = get_bytes(2048);
+        b.iter(|| Nibbles::unpack(black_box(&bytes[..])))
     });
 
     g.bench_function("pack/32", |b| {
-        let raw = Nibbles::unpack((0..32).collect::<Vec<u8>>());
-        b.iter(|| black_box(&raw).pack())
+        let nibbles = get_nibbles(32);
+        b.iter(|| black_box(&nibbles).pack())
     });
     g.bench_function("pack/256", |b| {
-        let raw = Nibbles::unpack((0..=255).collect::<Vec<u8>>());
-        b.iter(|| black_box(&raw).pack())
+        let nibbles = get_nibbles(256);
+        b.iter(|| black_box(&nibbles).pack())
     });
-    g.bench_function("pack/4096", |b| {
-        let raw = Nibbles::unpack((0..=255).collect::<Vec<u8>>().repeat(4096 / 256));
-        b.iter(|| black_box(&raw).pack())
+    g.bench_function("pack/2048", |b| {
+        let nibbles = get_nibbles(2048);
+        b.iter(|| black_box(&nibbles).pack())
     });
+
+    g.bench_function("encode_path_leaf/31", |b| {
+        let nibbles = get_nibbles(31);
+        b.iter(|| black_box(&nibbles).encode_path_leaf(false))
+    });
+    g.bench_function("encode_path_leaf/256", |b| {
+        let nibbles = get_nibbles(256);
+        b.iter(|| black_box(&nibbles).encode_path_leaf(false))
+    });
+    g.bench_function("encode_path_leaf/2048", |b| {
+        let nibbles = get_nibbles(2048);
+        b.iter(|| black_box(&nibbles).encode_path_leaf(false))
+    });
+}
+
+fn get_nibbles(len: usize) -> Nibbles {
+    Nibbles::from_nibbles_unchecked(get_bytes(len))
+}
+
+fn get_bytes(len: usize) -> Vec<u8> {
+    proptest::collection::vec(proptest::arbitrary::any::<u8>(), len)
+        .new_tree(&mut Default::default())
+        .unwrap()
+        .current()
 }
 
 criterion_group!(benches, nibbles_benchmark);

--- a/crates/primitives/src/trie/hash_builder/mod.rs
+++ b/crates/primitives/src/trie/hash_builder/mod.rs
@@ -63,7 +63,7 @@ pub struct HashBuilder {
 impl From<HashBuilderState> for HashBuilder {
     fn from(state: HashBuilderState) -> Self {
         Self {
-            key: Nibbles::new_unchecked(state.key),
+            key: Nibbles::from_nibbles_unchecked(state.key),
             stack: state.stack,
             value: state.value,
             groups: state.groups,
@@ -564,7 +564,7 @@ mod tests {
 
         let (_, updates) = hb.split();
 
-        let update = updates.get(&Nibbles::new_unchecked(hex!("01"))).unwrap();
+        let update = updates.get(&Nibbles::from_nibbles_unchecked(hex!("01"))).unwrap();
         assert_eq!(update.state_mask, TrieMask::new(0b1111)); // 1st nibble: 0, 1, 2, 3
         assert_eq!(update.tree_mask, TrieMask::new(0));
         assert_eq!(update.hash_mask, TrieMask::new(6)); // in the 1st nibble, the ones with 1 and 2 are branches with `hashes`
@@ -634,7 +634,7 @@ mod tests {
 
         let mut hb2 = HashBuilder::default();
         // Insert the branch with the `0x6` shared prefix.
-        hb2.add_branch(Nibbles::new_unchecked([0x6]), branch_node_hash, false);
+        hb2.add_branch(Nibbles::from_nibbles_unchecked([0x6]), branch_node_hash, false);
 
         let expected = trie_root(raw_input.clone());
         assert_eq!(hb.root(), expected);

--- a/crates/primitives/src/trie/nibbles.rs
+++ b/crates/primitives/src/trie/nibbles.rs
@@ -254,6 +254,7 @@ impl Nibbles {
     /// If the number of nibbles is odd, the last nibble is shifted left by 4 bits and
     /// added to the packed byte vector.
     #[inline]
+    #[allow(clippy::collapsible_else_if)]
     pub fn pack(&self) -> SmallVec<[u8; 32]> {
         let is_odd = self.len() % 2 != 0;
         // SAFETY: checked length and `is_odd` is correct.

--- a/crates/primitives/src/trie/nibbles.rs
+++ b/crates/primitives/src/trie/nibbles.rs
@@ -360,7 +360,7 @@ impl Nibbles {
             Bound::Excluded(&n) => n,
             Bound::Unbounded => self.len(),
         };
-        Self::new_unchecked(&self[start..=end])
+        Self::new_unchecked(&self[start..end])
     }
 
     /// Join two nibbles together.

--- a/crates/primitives/src/trie/nibbles.rs
+++ b/crates/primitives/src/trie/nibbles.rs
@@ -142,14 +142,14 @@ impl From<Vec<u8>> for Nibbles {
 impl From<Nibbles> for Vec<u8> {
     #[inline]
     fn from(value: Nibbles) -> Self {
-        value.to_vec()
+        value.0.into_vec()
     }
 }
 
 impl From<Nibbles> for Bytes {
     #[inline]
     fn from(value: Nibbles) -> Self {
-        value.to_vec().into()
+        value.0.into_vec().into()
     }
 }
 

--- a/crates/primitives/src/trie/nibbles.rs
+++ b/crates/primitives/src/trie/nibbles.rs
@@ -354,10 +354,14 @@ impl Nibbles {
     ///
     /// # Returns
     ///
-    /// A `Vec<u8>` containing the compact byte representation of the nibble sequence, including the
+    /// A vector containing the compact byte representation of the nibble sequence, including the
     /// header byte.
     ///
-    /// # Example
+    /// This vector's length is `self.len() / 2 + 1`. For stack-allocated nibbles, this is at most
+    /// 33 bytes, so 36 was chosen as the stack capacity to round up to the next usize-aligned
+    /// size.
+    ///
+    /// # Examples
     ///
     /// ```
     /// # use reth_primitives::trie::Nibbles;

--- a/crates/primitives/src/trie/nodes/extension.rs
+++ b/crates/primitives/src/trie/nodes/extension.rs
@@ -1,5 +1,6 @@
 use super::{super::Nibbles, rlp_node};
 use alloy_rlp::{BufMut, Encodable};
+use smallvec::SmallVec;
 
 /// An intermediate node that exists solely to compress the trie's paths. It contains a path segment
 /// (a shared prefix of keys) and a single child pointer. Essentially, an extension node can be
@@ -10,7 +11,7 @@ use alloy_rlp::{BufMut, Encodable};
 /// complexity when performing operations on the trie.
 pub struct ExtensionNode<'a> {
     /// A common prefix for keys.
-    pub prefix: Vec<u8>,
+    pub prefix: SmallVec<[u8; 36]>,
     /// A pointer to the child.
     pub node: &'a [u8],
 }

--- a/crates/primitives/src/trie/nodes/extension.rs
+++ b/crates/primitives/src/trie/nodes/extension.rs
@@ -10,7 +10,7 @@ use smallvec::SmallVec;
 /// with a single child into one node. This simplification reduces the space and computational
 /// complexity when performing operations on the trie.
 pub struct ExtensionNode<'a> {
-    /// A common prefix for keys.
+    /// A common prefix for keys. See [`Nibbles::encode_path_leaf`] for more information.
     pub prefix: SmallVec<[u8; 36]>,
     /// A pointer to the child.
     pub node: &'a [u8],

--- a/crates/primitives/src/trie/nodes/leaf.rs
+++ b/crates/primitives/src/trie/nodes/leaf.rs
@@ -1,5 +1,6 @@
 use super::{super::Nibbles, rlp_node};
 use alloy_rlp::{BufMut, Encodable};
+use smallvec::SmallVec;
 
 /// A leaf node represents the endpoint or terminal node in the trie. In other words, a leaf node is
 /// where actual values are stored.
@@ -11,8 +12,8 @@ use alloy_rlp::{BufMut, Encodable};
 #[derive(Default)]
 pub struct LeafNode<'a> {
     /// The key path.
-    pub key: Vec<u8>,
-    /// value: SmallVec<[u8; 36]>
+    pub key: SmallVec<[u8; 36]>,
+    /// The node value.
     pub value: &'a [u8],
 }
 

--- a/crates/primitives/src/trie/nodes/leaf.rs
+++ b/crates/primitives/src/trie/nodes/leaf.rs
@@ -11,7 +11,7 @@ use smallvec::SmallVec;
 /// node means that the search has successfully found the value associated with that key.
 #[derive(Default)]
 pub struct LeafNode<'a> {
-    /// The key path.
+    /// The key path. See [`Nibbles::encode_path_leaf`] for more information.
     pub key: SmallVec<[u8; 36]>,
     /// The node value.
     pub value: &'a [u8],

--- a/crates/primitives/src/trie/nodes/leaf.rs
+++ b/crates/primitives/src/trie/nodes/leaf.rs
@@ -59,14 +59,14 @@ mod tests {
     // From manual regression test
     #[test]
     fn encode_leaf_node_nibble() {
-        let nibble = Nibbles::new_unchecked(hex!("0604060f"));
+        let nibble = Nibbles::from_nibbles_unchecked(hex!("0604060f"));
         let encoded = nibble.encode_path_leaf(true);
-        assert_eq!(encoded, hex!("20646f"));
+        assert_eq!(encoded[..], hex!("20646f"));
     }
 
     #[test]
     fn rlp_leaf_node_roundtrip() {
-        let nibble = Nibbles::new_unchecked(hex!("0604060f"));
+        let nibble = Nibbles::from_nibbles_unchecked(hex!("0604060f"));
         let val = hex!("76657262");
         let leaf = LeafNode::new(&nibble, &val);
         let rlp = leaf.rlp(&mut vec![]);

--- a/crates/storage/codecs/src/lib.rs
+++ b/crates/storage/codecs/src/lib.rs
@@ -63,7 +63,9 @@ macro_rules! impl_uint_compact {
     ($($name:tt),+) => {
         $(
             impl Compact for $name {
-                fn to_compact<B>(self, buf: &mut B) -> usize where B: bytes::BufMut + AsMut<[u8]> {
+                fn to_compact<B>(self, buf: &mut B) -> usize
+                    where B: bytes::BufMut + AsMut<[u8]>
+                {
                     let leading = self.leading_zeros() as usize / 8;
                     buf.put_slice(&self.to_be_bytes()[leading..]);
                     std::mem::size_of::<$name>() - leading
@@ -255,44 +257,49 @@ impl Compact for Bytes {
     }
 }
 
-/// Implements the [`Compact`] trait for fixed size hash types like [`B256`].
+impl<const N: usize> Compact for [u8; N] {
+    fn to_compact<B>(self, buf: &mut B) -> usize
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
+    {
+        buf.put_slice(&self);
+        N
+    }
+
+    fn from_compact(mut buf: &[u8], len: usize) -> (Self, &[u8]) {
+        if len == 0 {
+            return ([0; N], buf)
+        }
+
+        let v = buf[..N].try_into().unwrap();
+        buf.advance(N);
+        (v, buf)
+    }
+}
+
+/// Implements the [`Compact`] trait for fixed size byte array types like [`B256`].
 #[macro_export]
-macro_rules! impl_hash_compact {
+macro_rules! impl_compact_for_bytes {
     ($($name:tt),+) => {
         $(
             impl Compact for $name {
-                fn to_compact<B>(self, buf: &mut B) -> usize where B: bytes::BufMut + AsMut<[u8]> {
-                    buf.put_slice(self.as_slice());
-                    std::mem::size_of::<$name>()
-                }
-
-                fn from_compact(mut buf: &[u8], len: usize) -> (Self,&[u8]) {
-                    if len == 0 {
-                        return ($name::default(), buf)
-                    }
-
-                    let v = $name::from_slice(
-                        buf.get(..std::mem::size_of::<$name>()).expect("size not matching"),
-                    );
-                    buf.advance(std::mem::size_of::<$name>());
-                    (v, buf)
-                }
-
-                fn specialized_to_compact<B>(self, buf: &mut B) -> usize
+                fn to_compact<B>(self, buf: &mut B) -> usize
                 where
-                    B: bytes::BufMut + AsMut<[u8]> {
-                    self.to_compact(buf)
+                    B: bytes::BufMut + AsMut<[u8]>
+                {
+                    self.0.to_compact(buf)
                 }
 
-                fn specialized_from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
-                    Self::from_compact(buf, len)
+                fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
+                    let (v, buf) = <[u8; std::mem::size_of::<$name>()]>::from_compact(buf, len);
+                    (Self::from(v), buf)
                 }
             }
         )+
     };
 }
 
-impl_hash_compact!(Address, B256, B512, Bloom);
+impl_compact_for_bytes!(Address, B256, B512, Bloom);
 
 impl Compact for bool {
     /// `bool` vars go directly to the `StructFlags` and are not written to the buffer.

--- a/crates/trie/benches/prefix_set.rs
+++ b/crates/trie/benches/prefix_set.rs
@@ -94,12 +94,12 @@ fn generate_test_data(size: usize) -> (Vec<Nibbles>, Vec<Nibbles>, Vec<bool>) {
     let mut preload = vec(vec(any::<u8>(), 32), size).new_tree(&mut runner).unwrap().current();
     preload.dedup();
     preload.sort();
-    let preload = preload.into_iter().map(Nibbles::new_unchecked).collect::<Vec<_>>();
+    let preload = preload.into_iter().map(Nibbles::from_nibbles_unchecked).collect::<Vec<_>>();
 
     let mut input = vec(vec(any::<u8>(), 0..=32), size).new_tree(&mut runner).unwrap().current();
     input.dedup();
     input.sort();
-    let input = input.into_iter().map(Nibbles::new_unchecked).collect::<Vec<_>>();
+    let input = input.into_iter().map(Nibbles::from_nibbles_unchecked).collect::<Vec<_>>();
 
     let expected = input
         .iter()

--- a/crates/trie/src/prefix_set/mod.rs
+++ b/crates/trie/src/prefix_set/mod.rs
@@ -26,8 +26,8 @@ pub use loader::{LoadedPrefixSets, PrefixSetLoader};
 /// use reth_trie::prefix_set::PrefixSetMut;
 ///
 /// let mut prefix_set = PrefixSetMut::default();
-/// prefix_set.insert(Nibbles::new_unchecked(&[0xa, 0xb]));
-/// prefix_set.insert(Nibbles::new_unchecked(&[0xa, 0xb, 0xc]));
+/// prefix_set.insert(Nibbles::from_nibbles_unchecked(&[0xa, 0xb]));
+/// prefix_set.insert(Nibbles::from_nibbles_unchecked(&[0xa, 0xb, 0xc]));
 /// assert!(prefix_set.contains(&[0xa, 0xb]));
 /// assert!(prefix_set.contains(&[0xa, 0xb, 0xc]));
 /// ```
@@ -158,10 +158,10 @@ mod tests {
     #[test]
     fn test_contains_with_multiple_inserts_and_duplicates() {
         let mut prefix_set = PrefixSetMut::default();
-        prefix_set.insert(Nibbles::new_unchecked(b"123"));
-        prefix_set.insert(Nibbles::new_unchecked(b"124"));
-        prefix_set.insert(Nibbles::new_unchecked(b"456"));
-        prefix_set.insert(Nibbles::new_unchecked(b"123")); // Duplicate
+        prefix_set.insert(Nibbles::from_nibbles_unchecked(b"123"));
+        prefix_set.insert(Nibbles::from_nibbles_unchecked(b"124"));
+        prefix_set.insert(Nibbles::from_nibbles_unchecked(b"456"));
+        prefix_set.insert(Nibbles::from_nibbles_unchecked(b"123")); // Duplicate
 
         assert!(prefix_set.contains(b"12"));
         assert!(prefix_set.contains(b"45"));

--- a/crates/trie/src/trie_cursor/account_cursor.rs
+++ b/crates/trie/src/trie_cursor/account_cursor.rs
@@ -41,7 +41,6 @@ where
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
     use reth_db::{
         cursor::{DbCursorRO, DbCursorRW},

--- a/crates/trie/src/trie_cursor/subnode.rs
+++ b/crates/trie/src/trie_cursor/subnode.rs
@@ -39,7 +39,7 @@ impl From<StoredSubNode> for CursorSubNode {
             Some(n) => n as i8,
             None => -1,
         };
-        Self { key: Nibbles::new_unchecked(value.key), nibble, node: value.node }
+        Self { key: Nibbles::from_nibbles_unchecked(value.key), nibble, node: value.node }
     }
 }
 

--- a/crates/trie/src/walker.rs
+++ b/crates/trie/src/walker.rs
@@ -131,7 +131,7 @@ impl<C: TrieCursor> TrieWalker<C> {
             assert!(!node.state_mask.is_empty());
         }
 
-        Ok(entry.map(|(k, v)| (Nibbles::new_unchecked(k), v)))
+        Ok(entry.map(|(k, v)| (Nibbles::from_nibbles_unchecked(k), v)))
     }
 
     /// Consumes the next node in the trie, updating the stack.
@@ -313,7 +313,7 @@ mod tests {
         // We're traversing the path in lexigraphical order.
         for expected in expected {
             let got = walker.advance().unwrap();
-            assert_eq!(got.unwrap(), Nibbles::new_unchecked(expected.clone()));
+            assert_eq!(got.unwrap(), Nibbles::from_nibbles_unchecked(expected.clone()));
         }
 
         // There should be 8 paths traversed in total from 3 branches.
@@ -361,26 +361,26 @@ mod tests {
 
         // No changes
         let mut cursor = TrieWalker::new(&mut trie, Default::default());
-        assert_eq!(cursor.key(), Some(Nibbles::new_unchecked([]))); // root
+        assert_eq!(cursor.key(), Some(Nibbles::from_nibbles_unchecked([]))); // root
         assert!(cursor.can_skip_current_node); // due to root_hash
         cursor.advance().unwrap(); // skips to the end of trie
         assert_eq!(cursor.key(), None);
 
         // We insert something that's not part of the existing trie/prefix.
         let mut changed = PrefixSetMut::default();
-        changed.insert(Nibbles::new_unchecked([0xF, 0x1]));
+        changed.insert(Nibbles::from_nibbles_unchecked([0xF, 0x1]));
         let mut cursor = TrieWalker::new(&mut trie, changed.freeze());
 
         // Root node
-        assert_eq!(cursor.key(), Some(Nibbles::new_unchecked([])));
+        assert_eq!(cursor.key(), Some(Nibbles::from_nibbles_unchecked([])));
         // Should not be able to skip state due to the changed values
         assert!(!cursor.can_skip_current_node);
         cursor.advance().unwrap();
-        assert_eq!(cursor.key(), Some(Nibbles::new_unchecked([0x2])));
+        assert_eq!(cursor.key(), Some(Nibbles::from_nibbles_unchecked([0x2])));
         cursor.advance().unwrap();
-        assert_eq!(cursor.key(), Some(Nibbles::new_unchecked([0x2, 0x1])));
+        assert_eq!(cursor.key(), Some(Nibbles::from_nibbles_unchecked([0x2, 0x1])));
         cursor.advance().unwrap();
-        assert_eq!(cursor.key(), Some(Nibbles::new_unchecked([0x4])));
+        assert_eq!(cursor.key(), Some(Nibbles::from_nibbles_unchecked([0x4])));
 
         cursor.advance().unwrap();
         assert_eq!(cursor.key(), None); // the end of trie


### PR DESCRIPTION
Follow-up to #5631

Use `SmallVec<[u8; 64]>` as the Nibbles internal representation to allow storing bytes inline, rather than on the heap. `SmallVec` falls back to storing on the heap when the stack capacity would overflow.

Also optimize packing to account for this fact.

![image](https://github.com/paradigmxyz/reth/assets/57450786/cce8fd40-59d8-431f-bfdf-48d8194275fa)
