### PR TITLE
Make p2p connection generic and refactor dyn convenience types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6219,6 +6219,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "criterion",
+ "derive_more",
  "enr",
  "ethers-core",
  "ethers-middleware",

--- a/crates/net/eth-wire/src/multiplex.rs
+++ b/crates/net/eth-wire/src/multiplex.rs
@@ -291,6 +291,11 @@ pub struct ProtocolProxy {
 }
 
 impl ProtocolProxy {
+    /// Shared capability assigned to proxy.
+    pub fn cap(&self) -> &SharedCapability {
+        &self.cap
+    }
+
     /// Sends a _non-empty_ message on the wire.
     fn try_send(&self, msg: Bytes) -> Result<(), io::Error> {
         if msg.is_empty() {

--- a/crates/net/eth-wire/src/multiplex.rs
+++ b/crates/net/eth-wire/src/multiplex.rs
@@ -612,6 +612,7 @@ impl ProtocolStream {
     ///
     /// If the message is empty.
     #[inline]
+    #[track_caller]
     pub fn mask_msg_id(&self, mut msg: BytesMut) -> Bytes {
         msg[0] += self.shared_cap.relative_message_id_offset();
         msg.freeze()

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -54,6 +54,7 @@ metrics.workspace = true
 # misc
 auto_impl = "1"
 aquamarine.workspace = true
+derive_more = "0.99.17"
 tracing.workspace = true
 fnv = "1.0"
 thiserror.workspace = true

--- a/crates/net/network/src/protocol.rs
+++ b/crates/net/network/src/protocol.rs
@@ -189,11 +189,6 @@ pub struct RlpxSubProtocols {
 }
 
 impl RlpxSubProtocols {
-    /// Creates a new list for extra protocols.
-    pub fn new() -> Self {
-        RlpxSubProtocols { protocols: Vec::new() }
-    }
-
     /// Adds a new protocol.
     pub fn push(&mut self, protocol: impl IntoRlpxSubProtocol) {
         self.protocols.push(protocol.into_rlpx_sub_protocol());

--- a/crates/net/network/src/protocol.rs
+++ b/crates/net/network/src/protocol.rs
@@ -6,7 +6,7 @@ use derive_more::Deref;
 use futures::{Sink, Stream};
 use reth_eth_wire::{
     capability::{SharedCapabilities, SharedCapability},
-    multiplex::ProtocolProxy,
+    multiplex::ProtocolStream,
     protocol::Protocol,
     CanDisconnect,
 };
@@ -140,12 +140,22 @@ pub trait ProxyProtocol {
     fn relative_mask_msg_id(&self, msg: BytesMut) -> Bytes;
 }
 
+impl ProxyProtocol for ProtocolStream {
+    fn shared_capability(&self) -> &SharedCapability {
+        self.cap()
+    }
+
+    fn relative_mask_msg_id(&self, msg: BytesMut) -> Bytes {
+        self.mask_msg_id(msg)
+    }
+}
+
 /// Convenience type setting associated type for [`ProtocolHandler`].
 pub type DynProtocolHandler = dyn ProtocolHandler<ConnectionHandler = DynConnectionHandler>;
 
 /// Convenience type setting associated types for [`ConnectionHandler`].
 pub type DynConnectionHandler =
-    dyn ConnectionHandler<Connection = dyn Connection, P2PConnection = ProtocolProxy>;
+    dyn ConnectionHandler<Connection = dyn Connection, P2PConnection = ProtocolStream>;
 
 /// A wrapper type for a RLPx sub-protocol.
 #[derive(Debug, Deref)]

--- a/crates/net/network/tests/it/multiplex.rs
+++ b/crates/net/network/tests/it/multiplex.rs
@@ -190,7 +190,7 @@ struct PingPongConnectionHandler {
 }
 
 impl ConnectionHandler for PingPongConnectionHandler {
-    type Connection = PingPongProtoConnection;
+    type AppConnection = PingPongProtoConnection;
 
     fn protocol(&self) -> Protocol {
         PingPongProtoMessage::protocol()
@@ -210,7 +210,7 @@ impl ConnectionHandler for PingPongConnectionHandler {
         direction: Direction,
         _peer_id: PeerId,
         conn: ProtocolConnection,
-    ) -> Self::Connection {
+    ) -> Self::AppConnection {
         let (tx, rx) = mpsc::unbounded_channel();
         self.state
             .events

--- a/crates/primitives/src/transaction/signature.rs
+++ b/crates/primitives/src/transaction/signature.rs
@@ -82,7 +82,7 @@ impl Signature {
     pub fn v(&self, chain_id: Option<u64>) -> u64 {
         #[cfg(feature = "optimism")]
         if self.r.is_zero() && self.s.is_zero() {
-            return 0
+            return 0;
         }
 
         if let Some(chain_id) = chain_id {
@@ -109,7 +109,7 @@ impl Signature {
         } else {
             // non-EIP-155 legacy scheme, v = 27 for even y-parity, v = 28 for odd y-parity
             if v != 27 && v != 28 {
-                return Err(RlpError::Custom("invalid Ethereum signature (V is not 27 or 28)"))
+                return Err(RlpError::Custom("invalid Ethereum signature (V is not 27 or 28)"));
             }
             let odd_y_parity = v == 28;
             Ok((Signature { r, s, odd_y_parity }, None))
@@ -162,7 +162,7 @@ impl Signature {
     /// If the S value is too large, then this will return `None`
     pub fn recover_signer(&self, hash: B256) -> Option<Address> {
         if self.s > SECP256K1N_HALF {
-            return None
+            return None;
         }
 
         self.recover_signer_unchecked(hash)


### PR DESCRIPTION
- simplifies instantiation of protocol and connection handlers as trait objects
- generalises p2p connection
- sets default p2p connection to `ProtocolStream` since payload type constrained by underlying p2p connection
- sets default app connection to stream and sink trait objects since no constraints on payload type

related to https://github.com/paradigmxyz/reth/issues/791