### PR TITLE
feat: add Default for RpcServerArgs

### DIFF
--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -483,7 +483,7 @@ impl Default for RpcServerArgs {
             rpc_max_subscriptions_per_connection: RPC_DEFAULT_MAX_SUBS_PER_CONN.into(),
             rpc_max_connections: RPC_DEFAULT_MAX_CONNECTIONS.into(),
             rpc_max_tracing_requests: constants::DEFAULT_MAX_TRACING_REQUESTS,
-            rpc_max_blocks_per_filter: (constants::DEFAULT_MAX_BLOCKS_PER_FILTER as u64).into(),
+            rpc_max_blocks_per_filter: constants::DEFAULT_MAX_BLOCKS_PER_FILTER.into(),
             rpc_max_logs_per_response: (constants::DEFAULT_MAX_LOGS_PER_RESPONSE as u64).into(),
             rpc_gas_cap: RPC_DEFAULT_GAS_CAP.into(),
             gas_price_oracle: GasPriceOracleArgs::default(),

--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -459,6 +459,41 @@ impl RethRpcConfig for RpcServerArgs {
     }
 }
 
+impl Default for RpcServerArgs {
+    fn default() -> Self {
+        Self {
+            http: true,
+            http_addr: Ipv4Addr::LOCALHOST.into(),
+            http_port: constants::DEFAULT_HTTP_RPC_PORT,
+            http_api: None,
+            http_corsdomain: None,
+            ws: false,
+            ws_addr: Ipv4Addr::LOCALHOST.into(),
+            ws_port: constants::DEFAULT_WS_RPC_PORT,
+            ws_allowed_origins: None,
+            ws_api: None,
+            ipcdisable: false,
+            ipcpath: constants::DEFAULT_IPC_ENDPOINT.to_string(),
+            auth_addr: Ipv4Addr::LOCALHOST.into(),
+            auth_port: constants::DEFAULT_AUTH_PORT,
+            auth_jwtsecret: None,
+            rpc_jwtsecret: None,
+            rpc_max_request_size: RPC_DEFAULT_MAX_REQUEST_SIZE_MB.into(),
+            rpc_max_response_size: RPC_DEFAULT_MAX_RESPONSE_SIZE_MB.into(),
+            rpc_max_subscriptions_per_connection: RPC_DEFAULT_MAX_SUBS_PER_CONN.into(),
+            rpc_max_connections: RPC_DEFAULT_MAX_CONNECTIONS.into(),
+            rpc_max_tracing_requests: constants::DEFAULT_MAX_TRACING_REQUESTS,
+            rpc_max_blocks_per_filter: (constants::DEFAULT_MAX_BLOCKS_PER_FILTER as u64).into(),
+            rpc_max_logs_per_response: (constants::DEFAULT_MAX_LOGS_PER_RESPONSE as u64).into(),
+            rpc_gas_cap: RPC_DEFAULT_GAS_CAP.into(),
+            gas_price_oracle: GasPriceOracleArgs::default(),
+            block_cache_len: DEFAULT_BLOCK_CACHE_MAX_LEN,
+            receipt_cache_len: DEFAULT_RECEIPT_CACHE_MAX_LEN,
+            env_cache_len: DEFAULT_ENV_CACHE_MAX_LEN,
+        }
+    }
+}
+
 /// clap value parser for [RpcModuleSelection].
 #[derive(Clone, Debug, Default)]
 #[non_exhaustive]

--- a/bin/reth/src/args/types.rs
+++ b/bin/reth/src/args/types.rs
@@ -31,12 +31,19 @@ macro_rules! zero_as_none {
             }
         }
 
+        impl From<$inner_type> for $type_name {
+            #[inline]
+            fn from(value: $inner_type) -> Self {
+                Self(if value == 0 { None } else { Some(value) })
+            }
+        }
+
         impl std::str::FromStr for $type_name {
             type Err = std::num::ParseIntError;
 
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 let value = s.parse::<$inner_type>()?;
-                Ok(Self(if value == 0 { None } else { Some(value) }))
+                Ok(Self::from(value))
             }
         }
     };
@@ -98,5 +105,16 @@ mod tests {
         let val = "0".parse::<ZeroAsNoneU64>().unwrap();
         assert_eq!(val, ZeroAsNoneU64(None));
         assert_eq!(val.unwrap_or_max(), u64::MAX);
+    }
+
+    #[test]
+    fn test_from_u64() {
+        let original = 1u64;
+        let expected = ZeroAsNoneU64(Some(1u64));
+        assert_eq!(ZeroAsNoneU64::from(original), expected);
+
+        let original = 0u64;
+        let expected = ZeroAsNoneU64(None);
+        assert_eq!(ZeroAsNoneU64::from(original), expected);
     }
 }


### PR DESCRIPTION
Adds a `Default` implementation for `RpcServerArgs`, and adds a `From` impl in the `zero_as_none` macro