### PR TITLE
feat: `DatabaseProvider` delegates to `SnapshotProvider` on `TransactionsProvider` 

### DIFF
--- a/bin/reth/src/db/snapshots/headers.rs
+++ b/bin/reth/src/db/snapshots/headers.rs
@@ -50,7 +50,7 @@ impl Command {
         let path: PathBuf = SnapshotSegment::Headers
             .filename_with_configuration(filters, compression, &block_range, &tx_range)
             .into();
-        let provider = SnapshotProvider::default();
+        let provider = SnapshotProvider::new(PathBuf::default())?;
         let jar_provider = provider.get_segment_provider_from_block(
             SnapshotSegment::Headers,
             self.from,

--- a/bin/reth/src/db/snapshots/receipts.rs
+++ b/bin/reth/src/db/snapshots/receipts.rs
@@ -53,7 +53,7 @@ impl Command {
             .filename_with_configuration(filters, compression, &block_range, &tx_range)
             .into();
 
-        let provider = SnapshotProvider::default();
+        let provider = SnapshotProvider::new(PathBuf::default())?;
         let jar_provider = provider.get_segment_provider_from_block(
             SnapshotSegment::Receipts,
             self.from,

--- a/bin/reth/src/db/snapshots/transactions.rs
+++ b/bin/reth/src/db/snapshots/transactions.rs
@@ -50,7 +50,7 @@ impl Command {
         let path: PathBuf = SnapshotSegment::Transactions
             .filename_with_configuration(filters, compression, &block_range, &tx_range)
             .into();
-        let provider = SnapshotProvider::default();
+        let provider = SnapshotProvider::new(PathBuf::default())?;
         let jar_provider = provider.get_segment_provider_from_block(
             SnapshotSegment::Transactions,
             self.from,

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -263,7 +263,7 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
         )?;
 
         provider_factory = provider_factory
-            .with_snapshots(data_dir.snapshots_path(), snapshotter.highest_snapshot_receiver());
+            .with_snapshots(data_dir.snapshots_path(), snapshotter.highest_snapshot_receiver())?;
 
         self.start_metrics_endpoint(prometheus_handle, Arc::clone(&db)).await?;
 

--- a/crates/interfaces/src/provider.rs
+++ b/crates/interfaces/src/provider.rs
@@ -14,6 +14,9 @@ pub enum ProviderError {
     /// Database error.
     #[error(transparent)]
     Database(#[from] crate::db::DatabaseError),
+    /// Filesystem path error.
+    #[error("{0}")]
+    FsPathError(String),
     /// Nippy jar error.
     #[error("nippy jar error: {0}")]
     NippyJar(String),
@@ -124,6 +127,12 @@ pub enum ProviderError {
 impl From<reth_nippy_jar::NippyJarError> for ProviderError {
     fn from(err: reth_nippy_jar::NippyJarError) -> Self {
         ProviderError::NippyJar(err.to_string())
+    }
+}
+
+impl From<reth_primitives::fs::FsPathError> for ProviderError {
+    fn from(err: reth_primitives::fs::FsPathError) -> Self {
+        ProviderError::FsPathError(err.to_string())
     }
 }
 

--- a/crates/rpc/rpc-types/src/eth/filter.rs
+++ b/crates/rpc/rpc-types/src/eth/filter.rs
@@ -728,7 +728,7 @@ impl FilteredParams {
     }
 
     /// Returns `true` if the bloom matches the topics
-    pub fn matches_topics(bloom: Bloom, topic_filters: &Vec<BloomFilter>) -> bool {
+    pub fn matches_topics(bloom: Bloom, topic_filters: &[BloomFilter]) -> bool {
         if topic_filters.is_empty() {
             return true
         }

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -454,7 +454,7 @@ where
     /// Safety checks before creating and returning a [`File`] handle to write data to.
     fn freeze_check(
         &mut self,
-        columns: &Vec<impl IntoIterator<Item = ColumnResult<Vec<u8>>>>,
+        columns: &[impl IntoIterator<Item = ColumnResult<Vec<u8>>>],
     ) -> Result<File, NippyJarError> {
         if columns.len() != self.columns {
             return Err(NippyJarError::ColumnLenMismatch(self.columns, columns.len()))

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -86,12 +86,12 @@ impl<DB> ProviderFactory<DB> {
         mut self,
         snapshots_path: PathBuf,
         highest_snapshot_tracker: watch::Receiver<Option<HighestSnapshots>>,
-    ) -> Self {
+    ) -> ProviderResult<Self> {
         self.snapshot_provider = Some(Arc::new(
-            SnapshotProvider::new(snapshots_path)
+            SnapshotProvider::new(snapshots_path)?
                 .with_highest_tracker(Some(highest_snapshot_tracker)),
         ));
-        self
+        Ok(self)
     }
 }
 
@@ -397,6 +397,13 @@ impl<DB: Database> ReceiptProvider for ProviderFactory<DB> {
 
     fn receipts_by_block(&self, block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
         self.provider()?.receipts_by_block(block)
+    }
+
+    fn receipts_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Receipt>> {
+        self.provider()?.receipts_by_tx_range(range)
     }
 }
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -273,7 +273,9 @@ impl<TX: DbTx> DatabaseProvider<TX> {
             // If there is, check the maximum block or transaction number of the segment.
             let snapshot_upper_bound = match segment {
                 SnapshotSegment::Headers => provider.get_highest_snapshot_block(segment),
-                SnapshotSegment::Transactions | SnapshotSegment::Receipts => provider.get_highest_snapshot_tx(segment),
+                SnapshotSegment::Transactions | SnapshotSegment::Receipts => {
+                    provider.get_highest_snapshot_tx(segment)
+                }
             };
 
             if snapshot_upper_bound

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1604,7 +1604,12 @@ impl<TX: DbTx> TransactionsProvider for DatabaseProvider<TX> {
 
 impl<TX: DbTx> ReceiptProvider for DatabaseProvider<TX> {
     fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Receipt>> {
-        Ok(self.tx.get::<tables::Receipts>(id)?)
+        self.get_with_snapshot(
+            SnapshotSegment::Receipts,
+            id,
+            |snapshot| snapshot.receipt(id),
+            || Ok(self.tx.get::<tables::Receipts>(id)?),
+        )
     }
 
     fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Receipt>> {
@@ -1622,16 +1627,30 @@ impl<TX: DbTx> ReceiptProvider for DatabaseProvider<TX> {
                 return if tx_range.is_empty() {
                     Ok(Some(Vec::new()))
                 } else {
-                    let mut receipts_cursor = self.tx.cursor_read::<tables::Receipts>()?;
-                    let receipts = receipts_cursor
-                        .walk_range(tx_range)?
-                        .map(|result| result.map(|(_, receipt)| receipt))
-                        .collect::<Result<Vec<_>, _>>()?;
-                    Ok(Some(receipts))
+                    self.receipts_by_tx_range(tx_range).map(Some)
                 }
             }
         }
         Ok(None)
+    }
+
+    fn receipts_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Receipt>> {
+        self.get_range_with_snapshot(
+            SnapshotSegment::Receipts,
+            to_range(range),
+            |snapshot, range, _| snapshot.receipts_by_tx_range(range),
+            |range, _| {
+                self.tx
+                    .cursor_read::<tables::Receipts>()?
+                    .walk_range(range)?
+                    .map(|result| result.map_err(Into::into).map(|(_, receipt)| receipt))
+                    .collect::<Result<Vec<_>, _>>()
+            },
+            |_| true,
+        )
     }
 }
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -273,7 +273,7 @@ impl<TX: DbTx> DatabaseProvider<TX> {
             // If there is, check the maximum block or transaction number of the segment.
             let snapshot_upper_bound = match segment {
                 SnapshotSegment::Headers => provider.get_highest_snapshot_block(segment),
-                _ => provider.get_highest_snapshot_tx(segment),
+                SnapshotSegment::Transactions | SnapshotSegment::Receipts => provider.get_highest_snapshot_tx(segment),
             };
 
             if snapshot_upper_bound

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -253,7 +253,7 @@ impl<TX: DbTx> DatabaseProvider<TX> {
     ///
     /// # Arguments
     /// * `segment` - The segment of the snapshot to check against.
-    /// * `number` - Requested block or tx number
+    /// * `index_key` - Requested index key, usually a block or transaction number.
     /// * `fetch_from_snapshot` - A closure that defines how to fetch the data from the snapshot
     ///   provider.
     /// * `fetch_from_database` - A closure that defines how to fetch the data from the database

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1345,53 +1345,63 @@ impl<TX: DbTx> TransactionsProviderExt for DatabaseProvider<TX> {
         &self,
         tx_range: Range<TxNumber>,
     ) -> ProviderResult<Vec<(TxHash, TxNumber)>> {
-        let mut tx_cursor = self.tx.cursor_read::<tables::Transactions>()?;
-        let tx_range_size = tx_range.clone().count();
-        let tx_walker = tx_cursor.walk_range(tx_range)?;
+        self.get_range_with_snapshot(
+            SnapshotSegment::Transactions,
+            tx_range,
+            |snapshot, range, _| snapshot.transaction_hashes_by_range(range),
+            |tx_range, _| {
+                let mut tx_cursor = self.tx.cursor_read::<tables::Transactions>()?;
+                let tx_range_size = tx_range.clone().count();
+                let tx_walker = tx_cursor.walk_range(tx_range)?;
 
-        let chunk_size = (tx_range_size / rayon::current_num_threads()).max(1);
-        let mut channels = Vec::with_capacity(chunk_size);
-        let mut transaction_count = 0;
+                let chunk_size = (tx_range_size / rayon::current_num_threads()).max(1);
+                let mut channels = Vec::with_capacity(chunk_size);
+                let mut transaction_count = 0;
 
-        #[inline]
-        fn calculate_hash(
-            entry: Result<(TxNumber, TransactionSignedNoHash), DatabaseError>,
-            rlp_buf: &mut Vec<u8>,
-        ) -> Result<(B256, TxNumber), Box<ProviderError>> {
-            let (tx_id, tx) = entry.map_err(|e| Box::new(e.into()))?;
-            tx.transaction.encode_with_signature(&tx.signature, rlp_buf, false);
-            Ok((keccak256(rlp_buf), tx_id))
-        }
-
-        for chunk in &tx_walker.chunks(chunk_size) {
-            let (tx, rx) = mpsc::channel();
-            channels.push(rx);
-
-            // Note: Unfortunate side-effect of how chunk is designed in itertools (it is not Send)
-            let chunk: Vec<_> = chunk.collect();
-            transaction_count += chunk.len();
-
-            // Spawn the task onto the global rayon pool
-            // This task will send the results through the channel after it has calculated the hash.
-            rayon::spawn(move || {
-                let mut rlp_buf = Vec::with_capacity(128);
-                for entry in chunk {
-                    rlp_buf.clear();
-                    let _ = tx.send(calculate_hash(entry, &mut rlp_buf));
+                #[inline]
+                fn calculate_hash(
+                    entry: Result<(TxNumber, TransactionSignedNoHash), DatabaseError>,
+                    rlp_buf: &mut Vec<u8>,
+                ) -> Result<(B256, TxNumber), Box<ProviderError>> {
+                    let (tx_id, tx) = entry.map_err(|e| Box::new(e.into()))?;
+                    tx.transaction.encode_with_signature(&tx.signature, rlp_buf, false);
+                    Ok((keccak256(rlp_buf), tx_id))
                 }
-            });
-        }
-        let mut tx_list = Vec::with_capacity(transaction_count);
 
-        // Iterate over channels and append the tx hashes unsorted
-        for channel in channels {
-            while let Ok(tx) = channel.recv() {
-                let (tx_hash, tx_id) = tx.map_err(|boxed| *boxed)?;
-                tx_list.push((tx_hash, tx_id));
-            }
-        }
+                for chunk in &tx_walker.chunks(chunk_size) {
+                    let (tx, rx) = mpsc::channel();
+                    channels.push(rx);
 
-        Ok(tx_list)
+                    // Note: Unfortunate side-effect of how chunk is designed in itertools (it is
+                    // not Send)
+                    let chunk: Vec<_> = chunk.collect();
+                    transaction_count += chunk.len();
+
+                    // Spawn the task onto the global rayon pool
+                    // This task will send the results through the channel after it has calculated
+                    // the hash.
+                    rayon::spawn(move || {
+                        let mut rlp_buf = Vec::with_capacity(128);
+                        for entry in chunk {
+                            rlp_buf.clear();
+                            let _ = tx.send(calculate_hash(entry, &mut rlp_buf));
+                        }
+                    });
+                }
+                let mut tx_list = Vec::with_capacity(transaction_count);
+
+                // Iterate over channels and append the tx hashes unsorted
+                for channel in channels {
+                    while let Ok(tx) = channel.recv() {
+                        let (tx_hash, tx_id) = tx.map_err(|boxed| *boxed)?;
+                        tx_list.push((tx_hash, tx_id));
+                    }
+                }
+
+                Ok(tx_list)
+            },
+            |_| true,
+        )
     }
 }
 

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -374,6 +374,13 @@ where
     fn receipts_by_block(&self, block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
         self.database.provider()?.receipts_by_block(block)
     }
+
+    fn receipts_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Receipt>> {
+        self.database.provider()?.receipts_by_tx_range(range)
+    }
 }
 impl<DB, Tree> ReceiptProviderIdExt for BlockchainProvider<DB, Tree>
 where

--- a/crates/storage/provider/src/providers/snapshot/jar.rs
+++ b/crates/storage/provider/src/providers/snapshot/jar.rs
@@ -286,4 +286,20 @@ impl<'a> ReceiptProvider for SnapshotJarProvider<'a> {
         // provider with `receipt()` instead for each
         Err(ProviderError::UnsupportedProvider)
     }
+
+    fn receipts_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Receipt>> {
+        let range = to_range(range);
+        let mut cursor = self.cursor()?;
+        let mut receipts = Vec::with_capacity((range.end - range.start) as usize);
+
+        for num in range {
+            if let Some(tx) = cursor.get_one::<ReceiptMask<Receipt>>(num.into())? {
+                receipts.push(tx)
+            }
+        }
+        Ok(receipts)
+    }
 }

--- a/crates/storage/provider/src/providers/snapshot/manager.rs
+++ b/crates/storage/provider/src/providers/snapshot/manager.rs
@@ -394,90 +394,16 @@ impl BlockHashReader for SnapshotProvider {
     }
 }
 
-impl BlockNumReader for SnapshotProvider {
-    fn chain_info(&self) -> ProviderResult<ChainInfo> {
-        todo!()
-    }
-
-    fn best_block_number(&self) -> ProviderResult<BlockNumber> {
-        todo!()
-    }
-
-    fn last_block_number(&self) -> ProviderResult<BlockNumber> {
-        todo!()
-    }
-
-    fn block_number(&self, _hash: B256) -> ProviderResult<Option<BlockNumber>> {
-        todo!()
-    }
-}
-
 impl ReceiptProvider for SnapshotProvider {
-    fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Receipt>> {
+    fn receipt(&self, _id: TxNumber) -> ProviderResult<Option<Receipt>> {
         todo!()
     }
 
-    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Receipt>> {
+    fn receipt_by_hash(&self, _hash: TxHash) -> ProviderResult<Option<Receipt>> {
         todo!()
     }
 
-    fn receipts_by_block(&self, block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
-        todo!()
-    }
-}
-
-impl BlockReader for SnapshotProvider {
-    fn find_block_by_hash(&self, hash: B256, source: BlockSource) -> ProviderResult<Option<Block>> {
-        todo!()
-    }
-
-    fn block(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Block>> {
-        todo!()
-    }
-
-    fn pending_block(&self) -> ProviderResult<Option<SealedBlock>> {
-        todo!()
-    }
-
-    fn pending_block_with_senders(&self) -> ProviderResult<Option<SealedBlockWithSenders>> {
-        todo!()
-    }
-
-    fn pending_block_and_receipts(&self) -> ProviderResult<Option<(SealedBlock, Vec<Receipt>)>> {
-        todo!()
-    }
-
-    fn ommers(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Header>>> {
-        todo!()
-    }
-
-    fn block_body_indices(&self, num: u64) -> ProviderResult<Option<StoredBlockBodyIndices>> {
-        todo!()
-    }
-
-    fn block_with_senders(
-        &self,
-        id: BlockHashOrNumber,
-        transaction_kind: TransactionVariant,
-    ) -> ProviderResult<Option<BlockWithSenders>> {
-        todo!()
-    }
-
-    fn block_range(&self, range: RangeInclusive<BlockNumber>) -> ProviderResult<Vec<Block>> {
-        todo!()
-    }
-}
-
-impl WithdrawalsProvider for SnapshotProvider {
-    fn withdrawals_by_block(
-        &self,
-        id: BlockHashOrNumber,
-        timestamp: u64,
-    ) -> ProviderResult<Option<Vec<Withdrawal>>> {
-        todo!()
-    }
-
-    fn latest_withdrawal(&self) -> ProviderResult<Option<Withdrawal>> {
+    fn receipts_by_block(&self, _block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
         todo!()
     }
 }
@@ -543,32 +469,38 @@ impl TransactionsProvider for SnapshotProvider {
         &self,
         _hash: TxHash,
     ) -> ProviderResult<Option<(TransactionSigned, TransactionMeta)>> {
-        todo!()
+        // Requires data not present in snapshots
+        Err(ProviderError::UnsupportedProvider)
     }
 
     fn transaction_block(&self, _id: TxNumber) -> ProviderResult<Option<BlockNumber>> {
-        todo!()
+        // Requires data not present in snapshots
+        Err(ProviderError::UnsupportedProvider)
     }
 
     fn transactions_by_block(
         &self,
         _block_id: BlockHashOrNumber,
     ) -> ProviderResult<Option<Vec<TransactionSigned>>> {
-        todo!()
+        // Requires data not present in snapshots
+        Err(ProviderError::UnsupportedProvider)
     }
 
     fn transactions_by_block_range(
         &self,
         _range: impl RangeBounds<BlockNumber>,
     ) -> ProviderResult<Vec<Vec<TransactionSigned>>> {
-        todo!()
+        // Requires data not present in snapshots
+        Err(ProviderError::UnsupportedProvider)
     }
 
     fn senders_by_tx_range(
         &self,
-        _range: impl RangeBounds<TxNumber>,
+        range: impl RangeBounds<TxNumber>,
     ) -> ProviderResult<Vec<Address>> {
-        todo!()
+        let txes = self.transactions_by_tx_range(range)?;
+        TransactionSignedNoHash::recover_signers(&txes, txes.len())
+            .ok_or(ProviderError::SenderRecoveryError)
     }
 
     fn transactions_by_tx_range(
@@ -587,5 +519,100 @@ impl TransactionsProvider for SnapshotProvider {
 
     fn transaction_sender(&self, id: TxNumber) -> ProviderResult<Option<Address>> {
         Ok(self.transaction_by_id_no_hash(id)?.and_then(|tx| tx.recover_signer()))
+    }
+}
+
+/* Cannot be successfully implemented but must exist for trait requirements */
+
+impl BlockNumReader for SnapshotProvider {
+    fn chain_info(&self) -> ProviderResult<ChainInfo> {
+        // Requires data not present in snapshots
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn best_block_number(&self) -> ProviderResult<BlockNumber> {
+        // Requires data not present in snapshots
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn last_block_number(&self) -> ProviderResult<BlockNumber> {
+        // Requires data not present in snapshots
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn block_number(&self, _hash: B256) -> ProviderResult<Option<BlockNumber>> {
+        // Requires data not present in snapshots
+        Err(ProviderError::UnsupportedProvider)
+    }
+}
+
+impl BlockReader for SnapshotProvider {
+    fn find_block_by_hash(
+        &self,
+        _hash: B256,
+        _source: BlockSource,
+    ) -> ProviderResult<Option<Block>> {
+        // Requires data not present in snapshots
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn block(&self, _id: BlockHashOrNumber) -> ProviderResult<Option<Block>> {
+        // Requires data not present in snapshots
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn pending_block(&self) -> ProviderResult<Option<SealedBlock>> {
+        // Requires data not present in snapshots
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn pending_block_with_senders(&self) -> ProviderResult<Option<SealedBlockWithSenders>> {
+        // Requires data not present in snapshots
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn pending_block_and_receipts(&self) -> ProviderResult<Option<(SealedBlock, Vec<Receipt>)>> {
+        // Requires data not present in snapshots
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn ommers(&self, _id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Header>>> {
+        // Requires data not present in snapshots
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn block_body_indices(&self, _num: u64) -> ProviderResult<Option<StoredBlockBodyIndices>> {
+        // Requires data not present in snapshots
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn block_with_senders(
+        &self,
+        _id: BlockHashOrNumber,
+        _transaction_kind: TransactionVariant,
+    ) -> ProviderResult<Option<BlockWithSenders>> {
+        // Requires data not present in snapshots
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn block_range(&self, _range: RangeInclusive<BlockNumber>) -> ProviderResult<Vec<Block>> {
+        // Requires data not present in snapshots
+        Err(ProviderError::UnsupportedProvider)
+    }
+}
+
+impl WithdrawalsProvider for SnapshotProvider {
+    fn withdrawals_by_block(
+        &self,
+        _id: BlockHashOrNumber,
+        _timestamp: u64,
+    ) -> ProviderResult<Option<Vec<Withdrawal>>> {
+        // Requires data not present in snapshots
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn latest_withdrawal(&self) -> ProviderResult<Option<Withdrawal>> {
+        // Requires data not present in snapshots
+        Err(ProviderError::UnsupportedProvider)
     }
 }

--- a/crates/storage/provider/src/providers/snapshot/manager.rs
+++ b/crates/storage/provider/src/providers/snapshot/manager.rs
@@ -471,12 +471,12 @@ impl TransactionsProvider for SnapshotProvider {
         &self,
         _hash: TxHash,
     ) -> ProviderResult<Option<(TransactionSigned, TransactionMeta)>> {
-        // Requires data not present in snapshots
+        // Required data not present in snapshots
         Err(ProviderError::UnsupportedProvider)
     }
 
     fn transaction_block(&self, _id: TxNumber) -> ProviderResult<Option<BlockNumber>> {
-        // Requires data not present in snapshots
+        // Required data not present in snapshots
         Err(ProviderError::UnsupportedProvider)
     }
 
@@ -484,7 +484,7 @@ impl TransactionsProvider for SnapshotProvider {
         &self,
         _block_id: BlockHashOrNumber,
     ) -> ProviderResult<Option<Vec<TransactionSigned>>> {
-        // Requires data not present in snapshots
+        // Required data not present in snapshots
         Err(ProviderError::UnsupportedProvider)
     }
 
@@ -492,7 +492,7 @@ impl TransactionsProvider for SnapshotProvider {
         &self,
         _range: impl RangeBounds<BlockNumber>,
     ) -> ProviderResult<Vec<Vec<TransactionSigned>>> {
-        // Requires data not present in snapshots
+        // Required data not present in snapshots
         Err(ProviderError::UnsupportedProvider)
     }
 
@@ -528,22 +528,22 @@ impl TransactionsProvider for SnapshotProvider {
 
 impl BlockNumReader for SnapshotProvider {
     fn chain_info(&self) -> ProviderResult<ChainInfo> {
-        // Requires data not present in snapshots
+        // Required data not present in snapshots
         Err(ProviderError::UnsupportedProvider)
     }
 
     fn best_block_number(&self) -> ProviderResult<BlockNumber> {
-        // Requires data not present in snapshots
+        // Required data not present in snapshots
         Err(ProviderError::UnsupportedProvider)
     }
 
     fn last_block_number(&self) -> ProviderResult<BlockNumber> {
-        // Requires data not present in snapshots
+        // Required data not present in snapshots
         Err(ProviderError::UnsupportedProvider)
     }
 
     fn block_number(&self, _hash: B256) -> ProviderResult<Option<BlockNumber>> {
-        // Requires data not present in snapshots
+        // Required data not present in snapshots
         Err(ProviderError::UnsupportedProvider)
     }
 }
@@ -554,37 +554,37 @@ impl BlockReader for SnapshotProvider {
         _hash: B256,
         _source: BlockSource,
     ) -> ProviderResult<Option<Block>> {
-        // Requires data not present in snapshots
+        // Required data not present in snapshots
         Err(ProviderError::UnsupportedProvider)
     }
 
     fn block(&self, _id: BlockHashOrNumber) -> ProviderResult<Option<Block>> {
-        // Requires data not present in snapshots
+        // Required data not present in snapshots
         Err(ProviderError::UnsupportedProvider)
     }
 
     fn pending_block(&self) -> ProviderResult<Option<SealedBlock>> {
-        // Requires data not present in snapshots
+        // Required data not present in snapshots
         Err(ProviderError::UnsupportedProvider)
     }
 
     fn pending_block_with_senders(&self) -> ProviderResult<Option<SealedBlockWithSenders>> {
-        // Requires data not present in snapshots
+        // Required data not present in snapshots
         Err(ProviderError::UnsupportedProvider)
     }
 
     fn pending_block_and_receipts(&self) -> ProviderResult<Option<(SealedBlock, Vec<Receipt>)>> {
-        // Requires data not present in snapshots
+        // Required data not present in snapshots
         Err(ProviderError::UnsupportedProvider)
     }
 
     fn ommers(&self, _id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Header>>> {
-        // Requires data not present in snapshots
+        // Required data not present in snapshots
         Err(ProviderError::UnsupportedProvider)
     }
 
     fn block_body_indices(&self, _num: u64) -> ProviderResult<Option<StoredBlockBodyIndices>> {
-        // Requires data not present in snapshots
+        // Required data not present in snapshots
         Err(ProviderError::UnsupportedProvider)
     }
 
@@ -593,12 +593,12 @@ impl BlockReader for SnapshotProvider {
         _id: BlockHashOrNumber,
         _transaction_kind: TransactionVariant,
     ) -> ProviderResult<Option<BlockWithSenders>> {
-        // Requires data not present in snapshots
+        // Required data not present in snapshots
         Err(ProviderError::UnsupportedProvider)
     }
 
     fn block_range(&self, _range: RangeInclusive<BlockNumber>) -> ProviderResult<Vec<Block>> {
-        // Requires data not present in snapshots
+        // Required data not present in snapshots
         Err(ProviderError::UnsupportedProvider)
     }
 }
@@ -609,12 +609,12 @@ impl WithdrawalsProvider for SnapshotProvider {
         _id: BlockHashOrNumber,
         _timestamp: u64,
     ) -> ProviderResult<Option<Vec<Withdrawal>>> {
-        // Requires data not present in snapshots
+        // Required data not present in snapshots
         Err(ProviderError::UnsupportedProvider)
     }
 
     fn latest_withdrawal(&self) -> ProviderResult<Option<Withdrawal>> {
-        // Requires data not present in snapshots
+        // Required data not present in snapshots
         Err(ProviderError::UnsupportedProvider)
     }
 }

--- a/crates/storage/provider/src/providers/snapshot/manager.rs
+++ b/crates/storage/provider/src/providers/snapshot/manager.rs
@@ -1,17 +1,23 @@
 use super::{LoadedJar, SnapshotJarProvider};
-use crate::{to_range, BlockHashReader, BlockNumReader, HeaderProvider, TransactionsProvider};
+use crate::{
+    to_range, BlockHashReader, BlockNumReader, BlockReader, BlockSource, HeaderProvider,
+    ReceiptProvider, TransactionVariant, TransactionsProvider, TransactionsProviderExt,
+    WithdrawalsProvider,
+};
 use dashmap::DashMap;
 use parking_lot::RwLock;
 use reth_db::{
     codecs::CompactU256,
+    models::StoredBlockBodyIndices,
     snapshot::{HeaderMask, SnapshotCursor, TransactionMask},
 };
 use reth_interfaces::provider::{ProviderError, ProviderResult};
 use reth_nippy_jar::NippyJar;
 use reth_primitives::{
-    snapshot::HighestSnapshots, Address, BlockHash, BlockHashOrNumber, BlockNumber, ChainInfo,
-    Header, SealedHeader, SnapshotSegment, TransactionMeta, TransactionSigned,
-    TransactionSignedNoHash, TxHash, TxNumber, B256, U256,
+    snapshot::HighestSnapshots, Address, Block, BlockHash, BlockHashOrNumber, BlockNumber,
+    BlockWithSenders, ChainInfo, Header, Receipt, SealedBlock, SealedBlockWithSenders,
+    SealedHeader, SnapshotSegment, TransactionMeta, TransactionSigned, TransactionSignedNoHash,
+    TxHash, TxNumber, Withdrawal, B256, U256,
 };
 use revm::primitives::HashMap;
 use std::{
@@ -399,6 +405,94 @@ impl BlockNumReader for SnapshotProvider {
 
     fn block_number(&self, _hash: B256) -> ProviderResult<Option<BlockNumber>> {
         todo!()
+    }
+}
+
+impl ReceiptProvider for SnapshotProvider {
+    fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Receipt>> {
+        todo!()
+    }
+
+    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Receipt>> {
+        todo!()
+    }
+
+    fn receipts_by_block(&self, block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
+        todo!()
+    }
+}
+
+impl BlockReader for SnapshotProvider {
+    fn find_block_by_hash(&self, hash: B256, source: BlockSource) -> ProviderResult<Option<Block>> {
+        todo!()
+    }
+
+    fn block(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Block>> {
+        todo!()
+    }
+
+    fn pending_block(&self) -> ProviderResult<Option<SealedBlock>> {
+        todo!()
+    }
+
+    fn pending_block_with_senders(&self) -> ProviderResult<Option<SealedBlockWithSenders>> {
+        todo!()
+    }
+
+    fn pending_block_and_receipts(&self) -> ProviderResult<Option<(SealedBlock, Vec<Receipt>)>> {
+        todo!()
+    }
+
+    fn ommers(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Header>>> {
+        todo!()
+    }
+
+    fn block_body_indices(&self, num: u64) -> ProviderResult<Option<StoredBlockBodyIndices>> {
+        todo!()
+    }
+
+    fn block_with_senders(
+        &self,
+        id: BlockHashOrNumber,
+        transaction_kind: TransactionVariant,
+    ) -> ProviderResult<Option<BlockWithSenders>> {
+        todo!()
+    }
+
+    fn block_range(&self, range: RangeInclusive<BlockNumber>) -> ProviderResult<Vec<Block>> {
+        todo!()
+    }
+}
+
+impl WithdrawalsProvider for SnapshotProvider {
+    fn withdrawals_by_block(
+        &self,
+        id: BlockHashOrNumber,
+        timestamp: u64,
+    ) -> ProviderResult<Option<Vec<Withdrawal>>> {
+        todo!()
+    }
+
+    fn latest_withdrawal(&self) -> ProviderResult<Option<Withdrawal>> {
+        todo!()
+    }
+}
+
+impl TransactionsProviderExt for SnapshotProvider {
+    fn transaction_hashes_by_range(
+        &self,
+        tx_range: Range<TxNumber>,
+    ) -> ProviderResult<Vec<(TxHash, TxNumber)>> {
+        self.fetch_range(
+            SnapshotSegment::Transactions,
+            tx_range,
+            |cursor, number| {
+                let tx =
+                    cursor.get_one::<TransactionMask<TransactionSignedNoHash>>(number.into())?;
+                Ok(tx.map(|tx| (tx.hash(), cursor.number())))
+            },
+            |_| true,
+        )
     }
 }
 

--- a/crates/storage/provider/src/providers/snapshot/mod.rs
+++ b/crates/storage/provider/src/providers/snapshot/mod.rs
@@ -131,7 +131,7 @@ mod test {
         // Use providers to query Header data and compare if it matches
         {
             let db_provider = factory.provider().unwrap();
-            let manager = SnapshotProvider::new(snap_path.path());
+            let manager = SnapshotProvider::new(snap_path.path()).unwrap();
             let jar_provider = manager
                 .get_segment_provider_from_block(SnapshotSegment::Headers, 0, Some(&snap_file))
                 .unwrap();

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -344,6 +344,13 @@ impl ReceiptProvider for MockEthProvider {
     fn receipts_by_block(&self, _block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
         Ok(None)
     }
+
+    fn receipts_by_tx_range(
+        &self,
+        _range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Receipt>> {
+        Ok(vec![])
+    }
 }
 
 impl ReceiptProviderIdExt for MockEthProvider {}

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -222,6 +222,13 @@ impl ReceiptProvider for NoopProvider {
     fn receipts_by_block(&self, _block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
         Ok(None)
     }
+
+    fn receipts_by_tx_range(
+        &self,
+        _range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Receipt>> {
+        Ok(vec![])
+    }
 }
 
 impl ReceiptProviderIdExt for NoopProvider {}

--- a/crates/storage/provider/src/traits/receipts.rs
+++ b/crates/storage/provider/src/traits/receipts.rs
@@ -1,3 +1,5 @@
+use std::ops::RangeBounds;
+
 use reth_interfaces::provider::ProviderResult;
 use reth_primitives::{BlockHashOrNumber, BlockId, BlockNumberOrTag, Receipt, TxHash, TxNumber};
 
@@ -20,6 +22,12 @@ pub trait ReceiptProvider: Send + Sync {
     ///
     /// Returns `None` if the block is not found.
     fn receipts_by_block(&self, block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>>;
+
+    /// Get receipts by tx range.
+    fn receipts_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Receipt>>;
 }
 
 /// Trait extension for `ReceiptProvider`, for types that implement `BlockId` conversion.


### PR DESCRIPTION
Adds logic to check if transaction data is in DB and snapshots, and calls it accordingly.

Also makes `get_with_snapshot` and `get_range_with_snapshot` kinda generic over tx or block number.

PR into #5593

Still going through rpc/hive tests, so won't be merged until then, but appreciate reviews.