### PR TITLE
feat: `DatabaseProvider` delegates to `SnapshotProvider` on `ReceiptsProvider` 

### DIFF
--- a/bin/reth/src/db/snapshots/headers.rs
+++ b/bin/reth/src/db/snapshots/headers.rs
@@ -50,7 +50,7 @@ impl Command {
         let path: PathBuf = SnapshotSegment::Headers
             .filename_with_configuration(filters, compression, &block_range, &tx_range)
             .into();
-        let provider = SnapshotProvider::default();
+        let provider = SnapshotProvider::new(PathBuf::default())?;
         let jar_provider = provider.get_segment_provider_from_block(
             SnapshotSegment::Headers,
             self.from,

--- a/bin/reth/src/db/snapshots/receipts.rs
+++ b/bin/reth/src/db/snapshots/receipts.rs
@@ -53,7 +53,7 @@ impl Command {
             .filename_with_configuration(filters, compression, &block_range, &tx_range)
             .into();
 
-        let provider = SnapshotProvider::default();
+        let provider = SnapshotProvider::new(PathBuf::default())?;
         let jar_provider = provider.get_segment_provider_from_block(
             SnapshotSegment::Receipts,
             self.from,

--- a/bin/reth/src/db/snapshots/transactions.rs
+++ b/bin/reth/src/db/snapshots/transactions.rs
@@ -50,7 +50,7 @@ impl Command {
         let path: PathBuf = SnapshotSegment::Transactions
             .filename_with_configuration(filters, compression, &block_range, &tx_range)
             .into();
-        let provider = SnapshotProvider::default();
+        let provider = SnapshotProvider::new(PathBuf::default())?;
         let jar_provider = provider.get_segment_provider_from_block(
             SnapshotSegment::Transactions,
             self.from,

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -263,7 +263,7 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
         )?;
 
         provider_factory = provider_factory
-            .with_snapshots(data_dir.snapshots_path(), snapshotter.highest_snapshot_receiver());
+            .with_snapshots(data_dir.snapshots_path(), snapshotter.highest_snapshot_receiver())?;
 
         self.start_metrics_endpoint(prometheus_handle, Arc::clone(&db)).await?;
 

--- a/crates/interfaces/src/provider.rs
+++ b/crates/interfaces/src/provider.rs
@@ -14,6 +14,9 @@ pub enum ProviderError {
     /// Database error.
     #[error(transparent)]
     Database(#[from] crate::db::DatabaseError),
+    /// Filesystem path error.
+    #[error("{0}")]
+    FsPathError(String),
     /// Nippy jar error.
     #[error("nippy jar error: {0}")]
     NippyJar(String),
@@ -124,6 +127,12 @@ pub enum ProviderError {
 impl From<reth_nippy_jar::NippyJarError> for ProviderError {
     fn from(err: reth_nippy_jar::NippyJarError) -> Self {
         ProviderError::NippyJar(err.to_string())
+    }
+}
+
+impl From<reth_primitives::fs::FsPathError> for ProviderError {
+    fn from(err: reth_primitives::fs::FsPathError) -> Self {
+        ProviderError::FsPathError(err.to_string())
     }
 }
 

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -86,12 +86,12 @@ impl<DB> ProviderFactory<DB> {
         mut self,
         snapshots_path: PathBuf,
         highest_snapshot_tracker: watch::Receiver<Option<HighestSnapshots>>,
-    ) -> Self {
+    ) -> ProviderResult<Self> {
         self.snapshot_provider = Some(Arc::new(
-            SnapshotProvider::new(snapshots_path)
+            SnapshotProvider::new(snapshots_path)?
                 .with_highest_tracker(Some(highest_snapshot_tracker)),
         ));
-        self
+        Ok(self)
     }
 }
 

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -398,6 +398,13 @@ impl<DB: Database> ReceiptProvider for ProviderFactory<DB> {
     fn receipts_by_block(&self, block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
         self.provider()?.receipts_by_block(block)
     }
+
+    fn receipts_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Receipt>> {
+        self.provider()?.receipts_by_tx_range(range)
+    }
 }
 
 impl<DB: Database> WithdrawalsProvider for ProviderFactory<DB> {

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1623,7 +1623,7 @@ impl<TX: DbTx> ReceiptProvider for DatabaseProvider<TX> {
                 return if tx_range.is_empty() {
                     Ok(Some(Vec::new()))
                 } else {
-                    self.receipts_by_tx_range(tx_range).map(|receipts| Some(receipts))
+                    self.receipts_by_tx_range(tx_range).map(Some)
                 }
             }
         }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1600,7 +1600,12 @@ impl<TX: DbTx> TransactionsProvider for DatabaseProvider<TX> {
 
 impl<TX: DbTx> ReceiptProvider for DatabaseProvider<TX> {
     fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Receipt>> {
-        Ok(self.tx.get::<tables::Receipts>(id)?)
+        self.get_with_snapshot(
+            SnapshotSegment::Receipts,
+            id,
+            |snapshot| snapshot.receipt(id),
+            || Ok(self.tx.get::<tables::Receipts>(id)?),
+        )
     }
 
     fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Receipt>> {

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -374,6 +374,13 @@ where
     fn receipts_by_block(&self, block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
         self.database.provider()?.receipts_by_block(block)
     }
+
+    fn receipts_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Receipt>> {
+        self.database.provider()?.receipts_by_tx_range(range)
+    }
 }
 impl<DB, Tree> ReceiptProviderIdExt for BlockchainProvider<DB, Tree>
 where

--- a/crates/storage/provider/src/providers/snapshot/jar.rs
+++ b/crates/storage/provider/src/providers/snapshot/jar.rs
@@ -286,4 +286,20 @@ impl<'a> ReceiptProvider for SnapshotJarProvider<'a> {
         // provider with `receipt()` instead for each
         Err(ProviderError::UnsupportedProvider)
     }
+
+    fn receipts_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Receipt>> {
+        let range = to_range(range);
+        let mut cursor = self.cursor()?;
+        let mut receipts = Vec::with_capacity((range.end - range.start) as usize);
+
+        for num in range {
+            if let Some(tx) = cursor.get_one::<ReceiptMask<Receipt>>(num.into())? {
+                receipts.push(tx)
+            }
+        }
+        Ok(receipts)
+    }
 }

--- a/crates/storage/provider/src/providers/snapshot/manager.rs
+++ b/crates/storage/provider/src/providers/snapshot/manager.rs
@@ -395,16 +395,20 @@ impl BlockHashReader for SnapshotProvider {
 }
 
 impl ReceiptProvider for SnapshotProvider {
-    fn receipt(&self, _id: TxNumber) -> ProviderResult<Option<Receipt>> {
-        todo!()
+    fn receipt(&self, num: TxNumber) -> ProviderResult<Option<Receipt>> {
+        self.get_segment_provider_from_transaction(SnapshotSegment::Receipts, num, None)?
+            .receipt(num)
     }
 
-    fn receipt_by_hash(&self, _hash: TxHash) -> ProviderResult<Option<Receipt>> {
-        todo!()
+    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Receipt>> {
+        if let Some(num) = self.transaction_id(hash)? {
+            return self.receipt(num)
+        }
+        Ok(None)
     }
 
     fn receipts_by_block(&self, _block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
-        todo!()
+        unreachable!()
     }
 }
 

--- a/crates/storage/provider/src/providers/snapshot/manager.rs
+++ b/crates/storage/provider/src/providers/snapshot/manager.rs
@@ -221,7 +221,7 @@ impl SnapshotProvider {
         let mut block_index = self.snapshots_block_index.write();
         let mut tx_index = self.snapshots_tx_index.write();
 
-        for (segment, block_range, tx_range) in iter_snapshots(&self.path).unwrap() {
+        for (segment, block_range, tx_range) in iter_snapshots(&self.path)? {
             let block_end = *block_range.end();
             let tx_end = *tx_range.end();
 

--- a/crates/storage/provider/src/providers/snapshot/mod.rs
+++ b/crates/storage/provider/src/providers/snapshot/mod.rs
@@ -131,7 +131,7 @@ mod test {
         // Use providers to query Header data and compare if it matches
         {
             let db_provider = factory.provider().unwrap();
-            let manager = SnapshotProvider::new(snap_path.path());
+            let manager = SnapshotProvider::new(snap_path.path()).unwrap();
             let jar_provider = manager
                 .get_segment_provider_from_block(SnapshotSegment::Headers, 0, Some(&snap_file))
                 .unwrap();

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -344,6 +344,13 @@ impl ReceiptProvider for MockEthProvider {
     fn receipts_by_block(&self, _block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
         Ok(None)
     }
+
+    fn receipts_by_tx_range(
+        &self,
+        _range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Receipt>> {
+        Ok(vec![])
+    }
 }
 
 impl ReceiptProviderIdExt for MockEthProvider {}

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -222,6 +222,13 @@ impl ReceiptProvider for NoopProvider {
     fn receipts_by_block(&self, _block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
         Ok(None)
     }
+
+    fn receipts_by_tx_range(
+        &self,
+        _range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Receipt>> {
+        Ok(vec![])
+    }
 }
 
 impl ReceiptProviderIdExt for NoopProvider {}

--- a/crates/storage/provider/src/traits/receipts.rs
+++ b/crates/storage/provider/src/traits/receipts.rs
@@ -1,3 +1,5 @@
+use std::ops::RangeBounds;
+
 use reth_interfaces::provider::ProviderResult;
 use reth_primitives::{BlockHashOrNumber, BlockId, BlockNumberOrTag, Receipt, TxHash, TxNumber};
 
@@ -20,6 +22,12 @@ pub trait ReceiptProvider: Send + Sync {
     ///
     /// Returns `None` if the block is not found.
     fn receipts_by_block(&self, block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>>;
+
+    /// Get receipts by tx range.
+    fn receipts_by_tx_range(
+        &self,
+        range: impl RangeBounds<TxNumber>,
+    ) -> ProviderResult<Vec<Receipt>>;
 }
 
 /// Trait extension for `ReceiptProvider`, for types that implement `BlockId` conversion.


### PR DESCRIPTION
Adds logic to check if receipt data is in DB and snapshots, and calls it accordingly.

Adds an additional provider method: `receipts_by_tx_range`

PR into #5654

Still going through rpc/hive tests, so won't be merged until then, but appreciate reviews.