### PR TITLE
fix: invert is error check

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/types.rs
+++ b/crates/revm/revm-inspectors/src/tracing/types.rs
@@ -61,7 +61,7 @@ impl CallTrace {
     /// Returns true if the status code is an error or revert, See [InstructionResult::Revert]
     #[inline]
     pub fn is_error(&self) -> bool {
-        self.status.is_error()
+        !self.status.is_ok()
     }
 
     /// Returns true if the status code is a revert


### PR DESCRIPTION
bug introduced in #5404

this only checked evm errors not revert variants.

fixed by treating everything that is not `ok`, which is `error || revert`