### PR TITLE
feat: add sanity tests for Args Default impls 

### DIFF
--- a/bin/reth/src/args/database_args.rs
+++ b/bin/reth/src/args/database_args.rs
@@ -11,3 +11,23 @@ pub struct DatabaseArgs {
     #[arg(long = "db.log-level", value_enum)]
     pub log_level: Option<LogLevel>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    /// A helper type to parse Args more easily
+    #[derive(Parser)]
+    struct CommandParser<T: Args> {
+        #[clap(flatten)]
+        args: T,
+    }
+
+    #[test]
+    fn test_parse_database_args() {
+        let default_args = DatabaseArgs::default();
+        let args = CommandParser::<DatabaseArgs>::parse_from(["reth"]).args;
+        assert_eq!(args, default_args);
+    }
+}

--- a/bin/reth/src/args/debug_args.rs
+++ b/bin/reth/src/args/debug_args.rs
@@ -58,3 +58,23 @@ pub struct DebugArgs {
     )]
     pub hook_all: bool,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    /// A helper type to parse Args more easily
+    #[derive(Parser)]
+    struct CommandParser<T: Args> {
+        #[clap(flatten)]
+        args: T,
+    }
+
+    #[test]
+    fn test_parse_database_args() {
+        let default_args = DebugArgs::default();
+        let args = CommandParser::<DebugArgs>::parse_from(["reth"]).args;
+        assert_eq!(args, default_args);
+    }
+}

--- a/bin/reth/src/args/dev_args.rs
+++ b/bin/reth/src/args/dev_args.rs
@@ -32,7 +32,7 @@ pub struct DevArgs {
     /// --dev.block_time 12s
     #[arg(
         long = "dev.block-time",
-        help_heading = "Dev testnet", 
+        help_heading = "Dev testnet",
         conflicts_with = "block_max_transactions",
         value_parser = parse_duration,
         verbatim_doc_comment
@@ -95,5 +95,12 @@ mod tests {
             "1s",
         ]);
         assert!(args.is_err());
+    }
+
+    #[test]
+    fn dev_args_default_sanity_check() {
+        let default_args = DevArgs::default();
+        let args = CommandParser::<DevArgs>::parse_from(["reth"]).args;
+        assert_eq!(args, default_args);
     }
 }

--- a/bin/reth/src/args/gas_price_oracle_args.rs
+++ b/bin/reth/src/args/gas_price_oracle_args.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 
 /// Parameters to configure Gas Price Oracle
-#[derive(Debug, Clone, Args, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Args, PartialEq, Eq)]
 #[clap(next_help_heading = "Gas Price Oracle")]
 pub struct GasPriceOracleArgs {
     /// Number of recent blocks to check for gas price
@@ -19,6 +19,17 @@ pub struct GasPriceOracleArgs {
     /// The percentile of gas prices to use for the estimate
     #[arg(long = "gpo.percentile", default_value = "60")]
     pub percentile: Option<u32>,
+}
+
+impl Default for GasPriceOracleArgs {
+    fn default() -> Self {
+        Self {
+            blocks: Some(20),
+            ignore_price: Some(2),
+            max_price: Some(500000000000),
+            percentile: Some(60),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -45,5 +56,12 @@ mod tests {
                 percentile: Some(60),
             }
         );
+    }
+
+    #[test]
+    fn gpo_args_default_sanity_test() {
+        let default_args = GasPriceOracleArgs::default();
+        let args = CommandParser::<GasPriceOracleArgs>::parse_from(["reth"]).args;
+        assert_eq!(args, default_args);
     }
 }

--- a/bin/reth/src/args/network_args.rs
+++ b/bin/reth/src/args/network_args.rs
@@ -11,7 +11,7 @@ use secp256k1::SecretKey;
 use std::{net::Ipv4Addr, path::PathBuf, sync::Arc};
 
 /// Parameters for configuring the network more granularity via CLI
-#[derive(Debug, Args)]
+#[derive(Debug, Args, PartialEq, Eq)]
 #[clap(next_help_heading = "Networking")]
 pub struct NetworkArgs {
     /// Disable the discovery service.
@@ -118,7 +118,7 @@ impl NetworkArgs {
     /// If `no_persist_peers` is true then this returns the path to the persistent peers file path.
     pub fn persistent_peers_file(&self, peers_file: PathBuf) -> Option<PathBuf> {
         if self.no_persist_peers {
-            return None
+            return None;
         }
 
         Some(peers_file)
@@ -146,7 +146,7 @@ impl Default for NetworkArgs {
 }
 
 /// Arguments to setup discovery
-#[derive(Debug, Args)]
+#[derive(Debug, Args, PartialEq, Eq)]
 pub struct DiscoveryArgs {
     /// Disable the discovery service.
     #[arg(short, long, default_value_if("dev", "true", "true"))]
@@ -255,5 +255,13 @@ mod tests {
             "enode://22a8232c3abc76a16ae9d6c3b164f98775fe226f0917b0ca871128a74a8e9630b458460865bab457221f1d448dd9791d24c4e5d88786180ac185df813a68d4de@3.209.45.79:30303".parse().unwrap()
             ]
         );
+    }
+
+    #[test]
+    fn network_args_default_sanity_test() {
+        let default_args = NetworkArgs::default();
+        let args = CommandParser::<NetworkArgs>::parse_from(["reth"]).args;
+
+        assert_eq!(args, default_args);
     }
 }

--- a/bin/reth/src/args/payload_builder_args.rs
+++ b/bin/reth/src/args/payload_builder_args.rs
@@ -6,7 +6,9 @@ use clap::{
     builder::{RangedU64ValueParser, TypedValueParser},
     Arg, Args, Command,
 };
-use reth_primitives::constants::MAXIMUM_EXTRA_DATA_SIZE;
+use reth_primitives::constants::{
+    ETHEREUM_BLOCK_GAS_LIMIT, MAXIMUM_EXTRA_DATA_SIZE, SLOT_DURATION,
+};
 use std::{borrow::Cow, ffi::OsStr, time::Duration};
 
 /// Parameters for configuring the Payload Builder
@@ -50,9 +52,9 @@ impl Default for PayloadBuilderArgs {
     fn default() -> Self {
         Self {
             extradata: default_extradata(),
-            max_gas_limit: 30_000_000,
+            max_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT,
             interval: Duration::from_secs(1),
-            deadline: Duration::from_secs(12),
+            deadline: SLOT_DURATION,
             max_payload_tasks: 3,
             #[cfg(feature = "optimism")]
             compute_pending_block: false,

--- a/bin/reth/src/args/payload_builder_args.rs
+++ b/bin/reth/src/args/payload_builder_args.rs
@@ -10,7 +10,7 @@ use reth_primitives::constants::MAXIMUM_EXTRA_DATA_SIZE;
 use std::{borrow::Cow, ffi::OsStr, time::Duration};
 
 /// Parameters for configuring the Payload Builder
-#[derive(Debug, Args, PartialEq, Default)]
+#[derive(Debug, Args, PartialEq)]
 #[clap(next_help_heading = "Builder")]
 pub struct PayloadBuilderArgs {
     /// Block extra data set by the payload builder.
@@ -44,6 +44,20 @@ pub struct PayloadBuilderArgs {
     #[cfg(feature = "optimism")]
     #[arg(long = "rollup.compute-pending-block")]
     pub compute_pending_block: bool,
+}
+
+impl Default for PayloadBuilderArgs {
+    fn default() -> Self {
+        Self {
+            extradata: default_extradata(),
+            max_gas_limit: 30_000_000,
+            interval: Duration::from_secs(1),
+            deadline: Duration::from_secs(12),
+            max_payload_tasks: 3,
+            #[cfg(feature = "optimism")]
+            compute_pending_block: false,
+        }
+    }
 }
 
 impl PayloadBuilderConfig for PayloadBuilderArgs {
@@ -94,7 +108,7 @@ impl TypedValueParser for ExtradataValueParser {
                 format!(
                     "Payload builder extradata size exceeds {MAXIMUM_EXTRA_DATA_SIZE}bytes limit"
                 ),
-            ))
+            ));
         }
         Ok(val.to_string())
     }
@@ -151,5 +165,12 @@ mod tests {
             extradata.as_str(),
         ]);
         assert!(args.is_err());
+    }
+
+    #[test]
+    fn payload_builder_args_default_sanity_check() {
+        let default_args = PayloadBuilderArgs::default();
+        let args = CommandParser::<PayloadBuilderArgs>::parse_from(["reth"]).args;
+        assert_eq!(args, default_args);
     }
 }

--- a/bin/reth/src/args/pruning_args.rs
+++ b/bin/reth/src/args/pruning_args.rs
@@ -47,3 +47,23 @@ impl PruningArgs {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::{Args, Parser};
+
+    /// A helper type to parse Args more easily
+    #[derive(Parser)]
+    struct CommandParser<T: Args> {
+        #[clap(flatten)]
+        args: T,
+    }
+
+    #[test]
+    fn pruning_args_sanity_check() {
+        let default_args = PruningArgs::default();
+        let args = CommandParser::<PruningArgs>::parse_from(["reth"]).args;
+        assert_eq!(args, default_args);
+    }
+}

--- a/bin/reth/src/args/rollup_args.rs
+++ b/bin/reth/src/args/rollup_args.rs
@@ -1,7 +1,7 @@
 //! clap [Args](clap::Args) for op-reth rollup configuration
 
 /// Parameters for rollup configuration
-#[derive(Debug, clap::Args)]
+#[derive(Debug, Default, PartialEq, Eq, clap::Args)]
 #[clap(next_help_heading = "Rollup")]
 pub struct RollupArgs {
     /// HTTP endpoint for the sequencer mempool
@@ -16,4 +16,24 @@ pub struct RollupArgs {
     /// prior to beginning normal syncing.
     #[arg(long = "rollup.enable-genesis-walkback")]
     pub enable_genesis_walkback: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::{Args, Parser};
+
+    /// A helper type to parse Args more easily
+    #[derive(Parser)]
+    struct CommandParser<T: Args> {
+        #[clap(flatten)]
+        args: T,
+    }
+
+    #[test]
+    fn test_parse_database_args() {
+        let default_args = RollupArgs::default();
+        let args = CommandParser::<RollupArgs>::parse_from(["reth"]).args;
+        assert_eq!(args, default_args);
+    }
 }

--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -61,7 +61,7 @@ pub(crate) const RPC_DEFAULT_MAX_RESPONSE_SIZE_MB: u32 = 150;
 pub(crate) const RPC_DEFAULT_MAX_CONNECTIONS: u32 = 500;
 
 /// Parameters for configuring the rpc more granularity via CLI
-#[derive(Debug, Clone, Args)]
+#[derive(Debug, Clone, Args, PartialEq, Eq)]
 #[clap(next_help_heading = "RPC")]
 pub struct RpcServerArgs {
     /// Enable the HTTP-RPC server
@@ -462,7 +462,7 @@ impl RethRpcConfig for RpcServerArgs {
 impl Default for RpcServerArgs {
     fn default() -> Self {
         Self {
-            http: true,
+            http: false,
             http_addr: Ipv4Addr::LOCALHOST.into(),
             http_port: constants::DEFAULT_HTTP_RPC_PORT,
             http_api: None,
@@ -708,5 +708,13 @@ mod tests {
         let config = args.eth_config().filter_config();
         assert_eq!(config.max_blocks_per_filter, Some(100));
         assert_eq!(config.max_logs_per_response, Some(200));
+    }
+
+    #[test]
+    fn rpc_server_args_default_sanity_test() {
+        let default_args = RpcServerArgs::default();
+        let args = CommandParser::<RpcServerArgs>::parse_from(["reth"]).args;
+
+        assert_eq!(args, default_args);
     }
 }

--- a/bin/reth/src/args/txpool_args.rs
+++ b/bin/reth/src/args/txpool_args.rs
@@ -8,7 +8,7 @@ use reth_transaction_pool::{
 };
 
 /// Parameters for debugging purposes
-#[derive(Debug, Args, PartialEq, Default)]
+#[derive(Debug, Args, PartialEq)]
 #[clap(next_help_heading = "TxPool")]
 pub struct TxPoolArgs {
     /// Max number of transaction in the pending sub-pool.
@@ -48,6 +48,23 @@ pub struct TxPoolArgs {
     pub no_locals: bool,
 }
 
+impl Default for TxPoolArgs {
+    fn default() -> Self {
+        Self {
+            pending_max_count: TXPOOL_SUBPOOL_MAX_TXS_DEFAULT,
+            pending_max_size: TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT,
+            basefee_max_count: TXPOOL_SUBPOOL_MAX_TXS_DEFAULT,
+            basefee_max_size: TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT,
+            queued_max_count: TXPOOL_SUBPOOL_MAX_TXS_DEFAULT,
+            queued_max_size: TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT,
+            max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
+            price_bump: DEFAULT_PRICE_BUMP,
+            blob_transaction_price_bump: REPLACE_BLOB_PRICE_BUMP,
+            no_locals: false,
+        }
+    }
+}
+
 impl TxPoolArgs {
     /// Returns transaction pool configuration.
     pub fn pool_config(&self) -> PoolConfig {
@@ -75,5 +92,25 @@ impl TxPoolArgs {
                 replace_blob_tx_price_bump: self.blob_transaction_price_bump,
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    /// A helper type to parse Args more easily
+    #[derive(Parser)]
+    struct CommandParser<T: Args> {
+        #[clap(flatten)]
+        args: T,
+    }
+
+    #[test]
+    fn txpool_args_default_sanity_test() {
+        let default_args = TxPoolArgs::default();
+        let args = CommandParser::<TxPoolArgs>::parse_from(["reth"]).args;
+        assert_eq!(args, default_args);
     }
 }

--- a/crates/rpc/rpc/src/layers/jwt_secret.rs
+++ b/crates/rpc/rpc/src/layers/jwt_secret.rs
@@ -56,7 +56,7 @@ const JWT_SIGNATURE_ALGO: Algorithm = Algorithm::HS256;
 /// for the JWT, which is included in the JWT along with its payload.
 ///
 /// See also: [Secret key - Engine API specs](https://github.com/ethereum/execution-apis/blob/main/src/engine/authentication.md#key-distribution)
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct JwtSecret([u8; 32]);
 
 impl JwtSecret {


### PR DESCRIPTION
ref https://github.com/paradigmxyz/reth/pull/5658#pullrequestreview-1760464866

added tests accordingly, this was a very good idea, since the `GasPriceOracleArgs::default` impl just set everyting to `None`