### PR TITLE
Fix eth message ID length bug

### DIFF
--- a/crates/net/eth-wire/src/protocol.rs
+++ b/crates/net/eth-wire/src/protocol.rs
@@ -1,6 +1,6 @@
 //! A Protocol defines a P2P subprotocol in a RLPx connection
 
-use crate::{capability::Capability, EthVersion};
+use crate::{capability::Capability, EthMessageID, EthVersion};
 
 /// Type that represents a [Capability] and the number of messages it uses.
 ///
@@ -14,7 +14,7 @@ pub struct Protocol {
     /// The number of messages used/reserved by this protocol
     ///
     /// This is used for message ID multiplexing
-    pub messages: u8,
+    messages: u8,
 }
 
 impl Protocol {
@@ -49,6 +49,14 @@ impl Protocol {
     #[inline]
     pub(crate) fn split(self) -> (Capability, u8) {
         (self.cap, self.messages)
+    }
+
+    /// The number of values needed to represent all message IDs of capability.
+    pub fn messages(&self) -> u8 {
+        if self.cap.is_eth() {
+            return EthMessageID::max() + 1
+        }
+        self.messages
     }
 }
 

--- a/crates/net/eth-wire/src/types/message.rs
+++ b/crates/net/eth-wire/src/types/message.rs
@@ -320,6 +320,7 @@ pub enum EthMessageID {
 }
 
 impl EthMessageID {
+    /// Returns the max value.
     pub const fn max() -> u8 {
         Self::Receipts as u8
     }

--- a/crates/net/eth-wire/src/types/message.rs
+++ b/crates/net/eth-wire/src/types/message.rs
@@ -319,6 +319,12 @@ pub enum EthMessageID {
     Receipts = 0x10,
 }
 
+impl EthMessageID {
+    pub const fn max() -> u8 {
+        Self::Receipts as u8
+    }
+}
+
 impl Encodable for EthMessageID {
     fn encode(&self, out: &mut dyn BufMut) {
         out.put_u8(*self as u8);


### PR DESCRIPTION
regardless of how many messages are used in an eth version, the message ID for receipts doesn't change. 17 values are needed to cover the eth message ID range 0x00 - 0x10. previously the number of messages used for a version has been used. this will result in bugs calculating offset when eth is preceded by another cap in the message id.

this pr is a product of https://github.com/paradigmxyz/reth/pull/5577 and is a subtask of https://github.com/paradigmxyz/reth/issues/791.