### PR TITLE
test(storage): implement `DbCursorRO::walk_back` method for `CursorMock`

### DIFF
--- a/crates/storage/db/src/abstraction/mock.rs
+++ b/crates/storage/db/src/abstraction/mock.rs
@@ -170,7 +170,7 @@ impl<T: Table> DbCursorRO<T> for CursorMock {
     ) -> Result<ReverseWalker<'_, T, Self>, DatabaseError> {
         let start: IterPairResult<T> = match start_key {
             Some(key) => <CursorMock as DbCursorRO<T>>::seek(self, key).transpose(),
-            None => <CursorMock as DbCursorRO<T>>::first(self).transpose(),
+            None => <CursorMock as DbCursorRO<T>>::last(self).transpose(),
         };
         Ok(ReverseWalker::new(self, start))
     }

--- a/crates/storage/db/src/abstraction/mock.rs
+++ b/crates/storage/db/src/abstraction/mock.rs
@@ -166,9 +166,13 @@ impl<T: Table> DbCursorRO<T> for CursorMock {
 
     fn walk_back(
         &mut self,
-        _start_key: Option<T::Key>,
+        start_key: Option<T::Key>,
     ) -> Result<ReverseWalker<'_, T, Self>, DatabaseError> {
-        todo!()
+        let start: IterPairResult<T> = match start_key {
+            Some(key) => <CursorMock as DbCursorRO<T>>::seek(self, key).transpose(),
+            None => <CursorMock as DbCursorRO<T>>::first(self).transpose(),
+        };
+        Ok(ReverseWalker::new(self, start))
     }
 }
 


### PR DESCRIPTION
Closes: #4662 

Adds implementation for the last method in DbCursorRO for CursorMock.