### PR TITLE
chore: make trace builder ctrs public

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/builder/geth.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/geth.rs
@@ -24,7 +24,7 @@ pub struct GethTraceBuilder {
 
 impl GethTraceBuilder {
     /// Returns a new instance of the builder
-    pub(crate) fn new(nodes: Vec<CallTraceNode>, _config: TracingInspectorConfig) -> Self {
+    pub fn new(nodes: Vec<CallTraceNode>, _config: TracingInspectorConfig) -> Self {
         Self { nodes, _config }
     }
 

--- a/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
@@ -32,7 +32,7 @@ pub struct ParityTraceBuilder {
 
 impl ParityTraceBuilder {
     /// Returns a new instance of the builder
-    pub(crate) fn new(
+    pub fn new(
         nodes: Vec<CallTraceNode>,
         spec_id: Option<SpecId>,
         _config: TracingInspectorConfig,


### PR DESCRIPTION
Make the `new` fns of geth/parity trace builders public outside of the crate so we can re-use the same set of trace nodes to build both geth and parity traces. this is needed for anvil (specifically `MinedTransaction`)