### PR TITLE
feat: add debug_getrawTransactions

### DIFF
--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -24,6 +24,10 @@ pub trait DebugApi {
     #[method(name = "getRawTransaction")]
     async fn raw_transaction(&self, hash: B256) -> RpcResult<Bytes>;
 
+    /// Returns an array of EIP-2718 binary-encoded transactions for the given [BlockId].
+    #[method(name = "getRawTransactions")]
+    async fn raw_transactions(&self, block_id: BlockId) -> RpcResult<Vec<Bytes>>;
+
     /// Returns an array of EIP-2718 binary-encoded receipts.
     #[method(name = "getRawReceipts")]
     async fn raw_receipts(&self, block_id: BlockId) -> RpcResult<Vec<Bytes>>;

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -21,7 +21,7 @@ use reth_primitives::{
     },
     Address, Block, BlockId, BlockNumberOrTag, Bytes, TransactionSigned, B256,
 };
-use reth_provider::{BlockReaderIdExt, HeaderProvider, StateProviderBox};
+use reth_provider::{BlockReaderIdExt, HeaderProvider, StateProviderBox, TransactionVariant};
 use reth_revm::{
     database::{StateProviderDatabase, SubState},
     tracing::{
@@ -893,6 +893,18 @@ where
             .map(TransactionSource::into_recovered)
             .map(|tx| tx.envelope_encoded())
             .unwrap_or_default())
+    }
+
+    /// Handler for `debug_getRawTransactions`
+    /// Returns the bytes of the transaction for the given hash.
+    async fn raw_transactions(&self, block_id: BlockId) -> RpcResult<Vec<Bytes>> {
+        let block = self
+            .inner
+            .provider
+            .block_with_senders_by_id(block_id, TransactionVariant::NoHash)
+            .to_rpc_result()?
+            .unwrap_or_default();
+        Ok(block.into_transactions_ecrecovered().map(|tx| tx.envelope_encoded()).collect())
     }
 
     /// Handler for `debug_getRawReceipts`

--- a/crates/storage/provider/src/traits/block.rs
+++ b/crates/storage/provider/src/traits/block.rs
@@ -187,10 +187,31 @@ pub trait BlockReaderIdExt: BlockReader + BlockIdReader + ReceiptProviderIdExt {
         self.sealed_header_by_id(BlockNumberOrTag::Finalized.into())
     }
 
-    /// Returns the block with the matching `BlockId` from the database.
+    /// Returns the block with the matching [BlockId] from the database.
     ///
     /// Returns `None` if block is not found.
     fn block_by_id(&self, id: BlockId) -> ProviderResult<Option<Block>>;
+
+    /// Returns the block with senders with matching [BlockId].
+    ///
+    /// Returns the block's transactions in the requested variant.
+    ///
+    /// Returns `None` if block is not found.
+    fn block_with_senders_by_id(
+        &self,
+        id: BlockId,
+        transaction_kind: TransactionVariant,
+    ) -> ProviderResult<Option<BlockWithSenders>> {
+        match id {
+            BlockId::Hash(hash) => {
+                self.block_with_senders(hash.block_hash.into(), transaction_kind)
+            }
+            BlockId::Number(num) => self.convert_block_number(num)?.map_or_else(
+                || Ok(None),
+                |num| self.block_with_senders(num.into(), transaction_kind),
+            ),
+        }
+    }
 
     /// Returns the header with matching tag from the database
     ///


### PR DESCRIPTION
adds new debug rpc functions to get all transactions of a block.

also adds block_with_senders_by_id provider fn