### PR TITLE
fix: use correct error if fault fn missing

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/js/mod.rs
+++ b/crates/revm/revm-inspectors/src/tracing/js/mod.rs
@@ -99,9 +99,9 @@ impl JsInspector {
             .get("fault", &mut ctx)?
             .as_object()
             .cloned()
-            .ok_or(JsInspectorError::ResultFunctionMissing)?;
+            .ok_or(JsInspectorError::FaultFunctionMissing)?;
         if !result_fn.is_callable() {
-            return Err(JsInspectorError::ResultFunctionMissing)
+            return Err(JsInspectorError::FaultFunctionMissing)
         }
 
         let enter_fn = obj.get("enter", &mut ctx)?.as_object().cloned().filter(|o| o.is_callable());


### PR DESCRIPTION
ref #5684

we already had the error variant but weren't using it