### PR TITLE
feat: add DatabaseMetrics trait for generic DB in reth node

### DIFF
--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -693,11 +693,14 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
         prometheus_exporter::install_recorder()
     }
 
-    async fn start_metrics_endpoint<DB: DatabaseMetrics + 'static>(
+    async fn start_metrics_endpoint<Metrics>(
         &self,
         prometheus_handle: PrometheusHandle,
-        db: Arc<DB>,
-    ) -> eyre::Result<()> {
+        db: Metrics,
+    ) -> eyre::Result<()>
+    where
+        Metrics: DatabaseMetrics + 'static + Send + Sync,
+    {
         if let Some(listen_addr) = self.metrics {
             info!(target: "reth::cli", addr = %listen_addr, "Starting metrics endpoint");
             prometheus_exporter::serve(

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -812,7 +812,7 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
         // try to look up the header in the database
         if let Some(header) = header {
             info!(target: "reth::cli", ?tip, "Successfully looked up tip block in the database");
-            return Ok(header.seal_slow());
+            return Ok(header.seal_slow())
         }
 
         info!(target: "reth::cli", ?tip, "Fetching tip block from the network.");
@@ -820,7 +820,7 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
             match get_single_header(&client, tip).await {
                 Ok(tip_header) => {
                     info!(target: "reth::cli", ?tip, "Successfully fetched tip");
-                    return Ok(tip_header);
+                    return Ok(tip_header)
                 }
                 Err(error) => {
                     error!(target: "reth::cli", %error, "Failed to fetch the tip. Retrying...");

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -38,7 +38,7 @@ use reth_config::{
     config::{PruneConfig, StageConfig},
     Config,
 };
-use reth_db::{database::Database, database_metrics::DatabaseMetrics, init_db, DatabaseEnv};
+use reth_db::{database::Database, database_metrics::DatabaseMetrics, init_db};
 use reth_downloaders::{
     bodies::bodies::BodiesDownloaderBuilder,
     headers::reverse_headers::ReverseHeadersDownloaderBuilder,

--- a/bin/reth/src/prometheus_exporter.rs
+++ b/bin/reth/src/prometheus_exporter.rs
@@ -74,12 +74,15 @@ async fn start_endpoint<F: Hook + 'static>(
 }
 
 /// Serves Prometheus metrics over HTTP with database and process metrics.
-pub(crate) async fn serve<DB: DatabaseMetrics + 'static>(
+pub(crate) async fn serve<Metrics>(
     listen_addr: SocketAddr,
     handle: PrometheusHandle,
-    db: Arc<DB>,
+    db: Metrics,
     process: metrics_process::Collector,
-) -> eyre::Result<()> {
+) -> eyre::Result<()>
+where
+    Metrics: DatabaseMetrics + 'static + Send + Sync,
+{
     let db_metrics_hook = move || db.report_metrics();
 
     // Clone `process` to move it into the hook and use the original `process` for describe below.

--- a/bin/reth/src/prometheus_exporter.rs
+++ b/bin/reth/src/prometheus_exporter.rs
@@ -7,7 +7,7 @@ use hyper::{
 use metrics::{describe_gauge, gauge};
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 use metrics_util::layers::{PrefixLayer, Stack};
-use reth_db::{database::Database, database_metrics::DatabaseMetrics};
+use reth_db::database_metrics::DatabaseMetrics;
 use reth_metrics::metrics::Unit;
 use std::{convert::Infallible, net::SocketAddr, sync::Arc};
 use tracing::error;
@@ -74,7 +74,7 @@ async fn start_endpoint<F: Hook + 'static>(
 }
 
 /// Serves Prometheus metrics over HTTP with database and process metrics.
-pub(crate) async fn serve<DB: Database + DatabaseMetrics + 'static>(
+pub(crate) async fn serve<DB: DatabaseMetrics + 'static>(
     listen_addr: SocketAddr,
     handle: PrometheusHandle,
     db: Arc<DB>,

--- a/bin/reth/src/prometheus_exporter.rs
+++ b/bin/reth/src/prometheus_exporter.rs
@@ -112,7 +112,7 @@ fn collect_memory_stats() {
 
     if epoch::advance().map_err(|error| error!(?error, "Failed to advance jemalloc epoch")).is_err()
     {
-        return;
+        return
     }
 
     if let Ok(value) = stats::active::read()

--- a/crates/storage/db/src/abstraction/database_metrics.rs
+++ b/crates/storage/db/src/abstraction/database_metrics.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
-/// Represents a type that has
+/// Represents a type that can report metrics, used mainly with the database. The `report_metrics`
+/// method can be used as a prometheus hook.
 pub trait DatabaseMetrics {
     /// Reports metrics for the database.
     fn report_metrics(&self);

--- a/crates/storage/db/src/abstraction/database_metrics.rs
+++ b/crates/storage/db/src/abstraction/database_metrics.rs
@@ -1,0 +1,15 @@
+use std::sync::Arc;
+
+use crate::database::Database;
+
+/// Extends [Database], adding a function that can be used as a hook for metric reporting.
+pub trait DatabaseMetrics: Database {
+    /// Reports metrics for the database.
+    fn report_metrics(&self);
+}
+
+impl<DB: DatabaseMetrics> DatabaseMetrics for Arc<DB> {
+    fn report_metrics(&self) {
+        <DB as DatabaseMetrics>::report_metrics(self)
+    }
+}

--- a/crates/storage/db/src/abstraction/database_metrics.rs
+++ b/crates/storage/db/src/abstraction/database_metrics.rs
@@ -1,9 +1,7 @@
 use std::sync::Arc;
 
-use crate::database::Database;
-
-/// Extends [Database], adding a function that can be used as a hook for metric reporting.
-pub trait DatabaseMetrics: Database {
+/// Represents a type that has
+pub trait DatabaseMetrics {
     /// Reports metrics for the database.
     fn report_metrics(&self);
 }

--- a/crates/storage/db/src/abstraction/mod.rs
+++ b/crates/storage/db/src/abstraction/mod.rs
@@ -4,6 +4,8 @@ pub mod common;
 pub mod cursor;
 /// Database traits.
 pub mod database;
+/// Database metrics trait extensions.
+pub mod database_metrics;
 /// mock
 pub mod mock;
 /// Table traits

--- a/crates/storage/db/src/lib.rs
+++ b/crates/storage/db/src/lib.rs
@@ -153,7 +153,7 @@ pub fn open_db(path: &Path, log_level: Option<LogLevel>) -> eyre::Result<Databas
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils {
     use super::*;
-    use crate::database::Database;
+    use crate::{database::Database, database_metrics::DatabaseMetrics};
     use std::{path::PathBuf, sync::Arc};
 
     /// Error during database open
@@ -207,6 +207,12 @@ pub mod test_utils {
 
         fn tx_mut(&self) -> Result<Self::TXMut, DatabaseError> {
             self.db().tx_mut()
+        }
+    }
+
+    impl<DB: DatabaseMetrics> DatabaseMetrics for TempDatabase<DB> {
+        fn report_metrics(&self) {
+            self.db().report_metrics()
         }
     }
 


### PR DESCRIPTION
This adds a trait `DatabaseMetrics` that includes a `report_metrics` method, that extends the `Database` trait. This is meant for use in `bin/reth/node`, so we can reduce usage of `DatabaseEnv`, and move towards using a generic database in the node setup. Moving towards using a generic database everywhere in the node setup methods will allow us to use `TempDatabase` as the main `DB: Database` type in tests.

The `serve` method can now be generic over `DB`.