### PR TITLE
feat(primitives/net): export `ConnectionInfo`

### DIFF
--- a/crates/net/network/src/peers/mod.rs
+++ b/crates/net/network/src/peers/mod.rs
@@ -4,7 +4,7 @@ mod manager;
 mod reputation;
 
 pub(crate) use manager::InboundConnectionError;
-pub use manager::{Peer, PeerAction, PeersConfig, PeersHandle, PeersManager};
+pub use manager::{ConnectionInfo, Peer, PeerAction, PeersConfig, PeersHandle, PeersManager};
 pub use reputation::ReputationChangeWeights;
 pub use reth_network_api::PeerKind;
 


### PR DESCRIPTION
Useful for setting `PeersConfig.connection_info`.