### PR TITLE
feat(bin): I/O metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5157,6 +5157,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
 dependencies = [
  "bitflags 2.4.1",
+ "chrono",
+ "flate2",
  "hex",
  "lazy_static",
  "procfs-core",
@@ -5170,6 +5172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
 dependencies = [
  "bitflags 2.4.1",
+ "chrono",
  "hex",
 ]
 
@@ -5550,6 +5553,7 @@ dependencies = [
  "metrics-util",
  "pin-project",
  "pretty_assertions",
+ "procfs",
  "proptest",
  "rand 0.8.5",
  "rayon",

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -109,7 +109,7 @@ rayon.workspace = true
 jemallocator = { version = "0.5.0", optional = true }
 jemalloc-ctl = { version = "0.5.0", optional = true }
 
-[target.'cfg(linux)'.dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.16.0" }
 
 [features]

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -109,6 +109,9 @@ rayon.workspace = true
 jemallocator = { version = "0.5.0", optional = true }
 jemalloc-ctl = { version = "0.5.0", optional = true }
 
+[target.'cfg(linux)'.dependencies]
+procfs = { version = "0.16.0" }
+
 [features]
 default = ["jemalloc"]
 jemalloc = ["dep:jemallocator", "dep:jemalloc-ctl"]

--- a/bin/reth/src/prometheus_exporter.rs
+++ b/bin/reth/src/prometheus_exporter.rs
@@ -228,7 +228,7 @@ fn collect_memory_stats() {}
 #[cfg(not(all(feature = "jemalloc", unix)))]
 fn describe_memory_stats() {}
 
-#[cfg(linux)]
+#[cfg(target_os = "linux")]
 fn collect_io_stats() {
     use metrics::counter;
 
@@ -253,7 +253,7 @@ fn collect_io_stats() {
     counter!("io.cancelled_write_bytes", io.cancelled_write_bytes);
 }
 
-#[cfg(linux)]
+#[cfg(target_os = "linux")]
 fn describe_io_stats() {
     use metrics::describe_counter;
 
@@ -266,8 +266,8 @@ fn describe_io_stats() {
     describe_counter!("io.cancelled_write_bytes", Unit::Bytes, "Cancelled write bytes");
 }
 
-#[cfg(not(linux))]
+#[cfg(not(target_os = "linux"))]
 fn collect_io_stats() {}
 
-#[cfg(not(linux))]
+#[cfg(not(target_os = "linux"))]
 fn describe_io_stats() {}

--- a/bin/reth/src/prometheus_exporter.rs
+++ b/bin/reth/src/prometheus_exporter.rs
@@ -230,7 +230,7 @@ fn describe_memory_stats() {}
 
 #[cfg(target_os = "linux")]
 fn collect_io_stats() {
-    use metrics::counter;
+    use metrics::absolute_counter;
 
     let Ok(process) = procfs::process::Process::myself()
         .map_err(|error| error!(?error, "Failed to get currently running process"))
@@ -244,13 +244,13 @@ fn collect_io_stats() {
         return
     };
 
-    counter!("io.rchar", io.rchar);
-    counter!("io.wchar", io.wchar);
-    counter!("io.syscr", io.syscr);
-    counter!("io.syscw", io.syscw);
-    counter!("io.read_bytes", io.read_bytes);
-    counter!("io.write_bytes", io.write_bytes);
-    counter!("io.cancelled_write_bytes", io.cancelled_write_bytes);
+    absolute_counter!("io.rchar", io.rchar);
+    absolute_counter!("io.wchar", io.wchar);
+    absolute_counter!("io.syscr", io.syscr);
+    absolute_counter!("io.syscw", io.syscw);
+    absolute_counter!("io.read_bytes", io.read_bytes);
+    absolute_counter!("io.write_bytes", io.write_bytes);
+    absolute_counter!("io.cancelled_write_bytes", io.cancelled_write_bytes);
 }
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
Database writes are reflected in `write_bytes`, so we can use these metrics to measure the I/O writes.