### PR TITLE
refactor(net): Simplified logic for determining shared capability versions

### DIFF
--- a/crates/net/eth-wire/src/capability.rs
+++ b/crates/net/eth-wire/src/capability.rs
@@ -611,25 +611,14 @@ mod tests {
 
     #[test]
     fn test_peer_capability_version_zero() {
-        let local_capabilities: Vec<Protocol> = vec![
-            Protocol::new(Capability { name: Cow::Borrowed("TestName"), version: 0 }, 0),
-            EthVersion::Eth67.into(),
-            EthVersion::Eth68.into(),
-        ];
-        let peer_capabilities: Vec<Capability> =
-            vec![Capability { name: Cow::Borrowed("TestName"), version: 0 }];
+        let cap = Capability::new_static("TestName", 0);
+        let local_capabilities: Vec<Protocol> =
+            vec![Protocol::new(cap.clone(), 0), EthVersion::Eth67.into(), EthVersion::Eth68.into()];
+        let peer_capabilities = vec![cap.clone()];
 
-        let shared_capability =
-            shared_capability_offsets(local_capabilities, peer_capabilities).unwrap()[0].clone();
-
-        assert_eq!(
-            shared_capability,
-            SharedCapability::UnknownCapability {
-                cap: Capability { name: Cow::Borrowed("TestName"), version: 0 },
-                offset: 16,
-                messages: 0
-            }
-        )
+        let shared = shared_capability_offsets(local_capabilities, peer_capabilities).unwrap();
+        assert_eq!(shared.len(), 1);
+        assert_eq!(shared[0], SharedCapability::UnknownCapability { cap, offset: 16, messages: 0 })
     }
 
     #[test]

--- a/crates/net/eth-wire/src/capability.rs
+++ b/crates/net/eth-wire/src/capability.rs
@@ -479,12 +479,8 @@ pub fn shared_capability_offsets(
         if let Some(messages) = our_capabilities.get(&peer_capability).copied() {
             // If multiple versions are shared of the same (equal name) capability, the numerically
             // highest wins, others are ignored
-
-            let version = shared_capabilities.get(&peer_capability.name).map(|v| v.version);
-
-            // TODO(mattsse): simplify
-            if version.is_none() ||
-                (version.is_some() && peer_capability.version > version.expect("is some; qed"))
+            if peer_capability.version >
+                shared_capabilities.get(&peer_capability.name).map(|v| v.version).unwrap_or(0)
             {
                 shared_capabilities.insert(
                     peer_capability.name.clone(),

--- a/crates/net/eth-wire/src/capability.rs
+++ b/crates/net/eth-wire/src/capability.rs
@@ -479,17 +479,10 @@ pub fn shared_capability_offsets(
         if let Some(messages) = our_capabilities.get(&peer_capability).copied() {
             // If multiple versions are shared of the same (equal name) capability, the numerically
             // highest wins, others are ignored
-            if let Some(existing_version) =
-                shared_capabilities.get(&peer_capability.name).map(|v| v.version)
+            if shared_capabilities
+                .get(&peer_capability.name)
+                .map_or(true, |v| peer_capability.version > v.version)
             {
-                if peer_capability.version > existing_version {
-                    shared_capabilities.insert(
-                        peer_capability.name.clone(),
-                        ProtoVersion { version: peer_capability.version, messages },
-                    );
-                    shared_capability_names.insert(peer_capability.name);
-                }
-            } else {
                 shared_capabilities.insert(
                     peer_capability.name.clone(),
                     ProtoVersion { version: peer_capability.version, messages },


### PR DESCRIPTION
## Description

Refactored the logic to determine shared capability versions, replacing complex conditionals with a more concise approach using `Option`'s `map_or` and `unwrap_or`. This enhances readability and maintainability while achieving the same functionality.






