### PR TITLE
fix: dont include empty revert reason

### DIFF
--- a/crates/revm/revm-inspectors/src/tracing/types.rs
+++ b/crates/revm/revm-inspectors/src/tracing/types.rs
@@ -347,7 +347,10 @@ impl CallTraceNode {
 
         // we need to populate error and revert reason
         if !self.trace.success {
-            call_frame.revert_reason = decode_revert_reason(self.trace.output.as_ref());
+            // decode the revert reason, but don't include it if it's empty
+            call_frame.revert_reason = decode_revert_reason(self.trace.output.as_ref())
+                .filter(|reason| !reason.is_empty());
+
             // Note: the call tracer mimics parity's trace transaction and geth maps errors to parity style error messages, <https://github.com/ethereum/go-ethereum/blob/34d507215951fb3f4a5983b65e127577989a6db8/eth/tracers/native/call_flat.go#L39-L55>
             call_frame.error = self.trace.as_error_msg(TraceStyle::Parity);
         }
@@ -674,5 +677,16 @@ impl RecordedMemory {
 impl AsRef<[u8]> for RecordedMemory {
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_empty_revert() {
+        let reason = decode_revert_reason("".as_bytes());
+        assert_eq!(reason, Some("".to_string()));
     }
 }


### PR DESCRIPTION
is omitifempty: https://github.com/ethereum/go-ethereum/blob/e206d3f8975bd98cc86d14055dca40f996bacc60/eth/tracers/native/call.go#L57-L57

<img width="906" alt="image" src="https://github.com/paradigmxyz/reth/assets/19890894/b85609ba-32c9-4810-9342-eec91564e7de">

