### PR TITLE
doc(blockchain-tree): add documentation for `MakeCanonicalAction` enum

### DIFF
--- a/crates/blockchain-tree/src/metrics.rs
+++ b/crates/blockchain-tree/src/metrics.rs
@@ -58,16 +58,26 @@ impl MakeCanonicalDurationsRecorder {
     }
 }
 
+/// Represents actions for making a canonical chain.
 #[derive(Debug, Copy, Clone)]
 pub(crate) enum MakeCanonicalAction {
+    /// Cloning old blocks for canonicalization.
     CloneOldBlocks,
+    /// Finding the canonical header.
     FindCanonicalHeader,
+    /// Splitting the chain for canonicalization.
     SplitChain,
+    /// Splitting chain forks for canonicalization.
     SplitChainForks,
+    /// Merging all chains for canonicalization.
     MergeAllChains,
+    /// Updating the canonical index during canonicalization.
     UpdateCanonicalIndex,
+    /// Committing the canonical chain to the database.
     CommitCanonicalChainToDatabase,
+    /// Reverting the canonical chain from the database.
     RevertCanonicalChainFromDatabase,
+    /// Inserting an old canonical chain.
     InsertOldCanonicalChain,
 }
 


### PR DESCRIPTION
This PR introduces documentation for the `MakeCanonicalAction` enum, providing descriptions for each variant representing actions related to creating a canonical chain within the blockchain-tree module. 

The added comments enhance code readability and understanding of the available actions for canonicalization.
