### PR TITLE
feat: add SecretKey to networkconfig

### DIFF
--- a/bin/reth/src/cli/config.rs
+++ b/bin/reth/src/cli/config.rs
@@ -124,7 +124,7 @@ pub trait RethNetworkConfig {
     fn add_rlpx_sub_protocol(&mut self, protocol: impl IntoRlpxSubProtocol);
 
     /// Returns the secret key used for authenticating sessions.
-    fn secret_key(&self) -> &secp256k1::SecretKey;
+    fn secret_key(&self) -> secp256k1::SecretKey;
 
     // TODO add more network config methods here
 }
@@ -134,7 +134,7 @@ impl<C> RethNetworkConfig for reth_network::NetworkManager<C> {
         reth_network::NetworkManager::add_rlpx_sub_protocol(self, protocol);
     }
 
-    fn secret_key(&self) -> &secp256k1::SecretKey {
+    fn secret_key(&self) -> secp256k1::SecretKey {
         self.secret_key()
     }
 }

--- a/bin/reth/src/cli/config.rs
+++ b/bin/reth/src/cli/config.rs
@@ -111,7 +111,8 @@ pub trait PayloadBuilderConfig {
     fn compute_pending_block(&self) -> bool;
 }
 
-/// A trait that can be used to apply additional configuration to the network.
+/// A trait that represents the configured network and can be used to apply additional configuration
+/// to the network.
 pub trait RethNetworkConfig {
     /// Adds a new additional protocol to the RLPx sub-protocol list.
     ///
@@ -121,11 +122,20 @@ pub trait RethNetworkConfig {
     ///
     /// See also [ProtocolHandler](reth_network::protocol::ProtocolHandler)
     fn add_rlpx_sub_protocol(&mut self, protocol: impl IntoRlpxSubProtocol);
+
+    /// Returns the secret key used for authenticating sessions.
+    fn secret_key(&self) -> &secp256k1::SecretKey;
+
+    // TODO add more network config methods here
 }
 
 impl<C> RethNetworkConfig for reth_network::NetworkManager<C> {
     fn add_rlpx_sub_protocol(&mut self, protocol: impl IntoRlpxSubProtocol) {
         reth_network::NetworkManager::add_rlpx_sub_protocol(self, protocol);
+    }
+
+    fn secret_key(&self) -> &secp256k1::SecretKey {
+        self.secret_key()
     }
 }
 

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -46,6 +46,7 @@ use reth_primitives::{ForkId, NodeRecord, PeerId, B256};
 use reth_provider::{BlockNumReader, BlockReader};
 use reth_rpc_types::{EthProtocolInfo, NetworkStatus};
 use reth_tokio_util::EventListeners;
+use secp256k1::SecretKey;
 use std::{
     net::SocketAddr,
     pin::Pin,
@@ -160,6 +161,11 @@ impl<C> NetworkManager<C> {
     pub fn bandwidth_meter(&self) -> &BandwidthMeter {
         self.handle.bandwidth_meter()
     }
+
+    /// Returns the secret key used for authenticating sessions.
+    pub fn secret_key(&self) -> &SecretKey {
+        self.swarm.sessions().secret_key()
+    }
 }
 
 impl<C> NetworkManager<C>
@@ -219,7 +225,7 @@ where
         let bandwidth_meter: BandwidthMeter = BandwidthMeter::default();
 
         let sessions = SessionManager::new(
-            secret_key,
+            secret_key.clone(),
             sessions_config,
             executor,
             status,
@@ -245,6 +251,7 @@ where
             Arc::clone(&num_active_peers),
             listener_address,
             to_manager_tx,
+            secret_key,
             local_peer_id,
             peers_handle,
             network_mode,

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -163,7 +163,7 @@ impl<C> NetworkManager<C> {
     }
 
     /// Returns the secret key used for authenticating sessions.
-    pub fn secret_key(&self) -> &SecretKey {
+    pub fn secret_key(&self) -> SecretKey {
         self.swarm.sessions().secret_key()
     }
 }
@@ -225,7 +225,7 @@ where
         let bandwidth_meter: BandwidthMeter = BandwidthMeter::default();
 
         let sessions = SessionManager::new(
-            secret_key.clone(),
+            secret_key,
             sessions_config,
             executor,
             status,

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -13,6 +13,7 @@ use reth_network_api::{
 };
 use reth_primitives::{Head, NodeRecord, PeerId, TransactionSigned, B256};
 use reth_rpc_types::NetworkStatus;
+use secp256k1::SecretKey;
 use std::{
     net::SocketAddr,
     sync::{
@@ -41,6 +42,7 @@ impl NetworkHandle {
         num_active_peers: Arc<AtomicUsize>,
         listener_address: Arc<Mutex<SocketAddr>>,
         to_manager_tx: UnboundedSender<NetworkHandleMessage>,
+        secret_key: SecretKey,
         local_peer_id: PeerId,
         peers: PeersHandle,
         network_mode: NetworkMode,
@@ -53,6 +55,7 @@ impl NetworkHandle {
             num_active_peers,
             to_manager_tx,
             listener_address,
+            secret_key,
             local_peer_id,
             peers,
             network_mode,
@@ -152,6 +155,11 @@ impl NetworkHandle {
     /// Whether tx gossip is disabled
     pub fn tx_gossip_disabled(&self) -> bool {
         self.inner.tx_gossip_disabled
+    }
+
+    /// Returns the secret key used for authenticating sessions.
+    pub fn secret_key(&self) -> &SecretKey {
+        &self.inner.secret_key
     }
 }
 
@@ -328,6 +336,8 @@ struct NetworkInner {
     to_manager_tx: UnboundedSender<NetworkHandleMessage>,
     /// The local address that accepts incoming connections.
     listener_address: Arc<Mutex<SocketAddr>>,
+    /// The secret key used for authenticating sessions.
+    secret_key: SecretKey,
     /// The identifier used by this node.
     local_peer_id: PeerId,
     /// Access to the all the nodes.

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -172,8 +172,8 @@ impl SessionManager {
     }
 
     /// Returns the secret key used for authenticating sessions.
-    pub fn secret_key(&self) -> &SecretKey {
-        &self.secret_key
+    pub fn secret_key(&self) -> SecretKey {
+        self.secret_key
     }
 
     /// Returns the session hello message.

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -171,6 +171,11 @@ impl SessionManager {
         self.status
     }
 
+    /// Returns the secret key used for authenticating sessions.
+    pub fn secret_key(&self) -> &SecretKey {
+        &self.secret_key
+    }
+
     /// Returns the session hello message.
     pub fn hello_message(&self) -> HelloMessageWithProtocols {
         self.hello_message.clone()


### PR DESCRIPTION
Make it possible to get (immutable) access to the secretkey the network uses for authentication.