### PR TITLE
fix(cli): allow no PHF or compression in snapshots

### DIFF
--- a/bin/reth/src/db/snapshots/headers.rs
+++ b/bin/reth/src/db/snapshots/headers.rs
@@ -34,7 +34,7 @@ impl Command {
         let block_range =
             self.block_ranges(tip).first().expect("has been generated before").clone();
 
-        let filters = if let (true, Some(phf)) = (self.with_filters, phf) {
+        let filters = if let Some(phf) = self.with_filters.then_some(phf).flatten() {
             Filters::WithFilters(inclusion_filter, phf)
         } else {
             Filters::WithoutFilters

--- a/bin/reth/src/db/snapshots/headers.rs
+++ b/bin/reth/src/db/snapshots/headers.rs
@@ -26,7 +26,7 @@ impl Command {
         chain: Arc<ChainSpec>,
         compression: Compression,
         inclusion_filter: InclusionFilter,
-        phf: PerfectHashingFunction,
+        phf: Option<PerfectHashingFunction>,
     ) -> eyre::Result<()> {
         let factory = ProviderFactory::new(open_db_read_only(db_path, log_level)?, chain.clone());
         let provider = factory.provider()?;
@@ -34,7 +34,7 @@ impl Command {
         let block_range =
             self.block_ranges(tip).first().expect("has been generated before").clone();
 
-        let filters = if self.with_filters {
+        let filters = if let (true, Some(phf)) = (self.with_filters, phf) {
             Filters::WithFilters(inclusion_filter, phf)
         } else {
             Filters::WithoutFilters

--- a/bin/reth/src/db/snapshots/mod.rs
+++ b/bin/reth/src/db/snapshots/mod.rs
@@ -85,12 +85,12 @@ impl Command {
             .cartesian_product(if self.compression.is_empty() {
                 vec![Compression::Uncompressed]
             } else {
-                self.compression
+                self.compression.clone()
             })
             .cartesian_product(if self.phf.is_empty() {
                 vec![None]
             } else {
-                self.phf.into_iter().map(Some).collect::<Vec<_>>()
+                self.phf.iter().copied().map(Some).collect::<Vec<_>>()
             });
 
         {
@@ -99,7 +99,7 @@ impl Command {
 
             if !self.only_bench {
                 for ((mode, compression), phf) in all_combinations.clone() {
-                    let filters = if let (true, Some(phf)) = (self.with_filters, phf) {
+                    let filters = if let Some(phf) = self.with_filters.then_some(phf).flatten() {
                         Filters::WithFilters(InclusionFilter::Cuckoo, phf)
                     } else {
                         Filters::WithoutFilters

--- a/bin/reth/src/db/snapshots/receipts.rs
+++ b/bin/reth/src/db/snapshots/receipts.rs
@@ -35,7 +35,7 @@ impl Command {
         let block_range =
             self.block_ranges(tip).first().expect("has been generated before").clone();
 
-        let filters = if let (true, Some(phf)) = (self.with_filters, phf) {
+        let filters = if let Some(phf) = self.with_filters.then_some(phf).flatten() {
             Filters::WithFilters(inclusion_filter, phf)
         } else {
             Filters::WithoutFilters

--- a/bin/reth/src/db/snapshots/receipts.rs
+++ b/bin/reth/src/db/snapshots/receipts.rs
@@ -27,7 +27,7 @@ impl Command {
         chain: Arc<ChainSpec>,
         compression: Compression,
         inclusion_filter: InclusionFilter,
-        phf: PerfectHashingFunction,
+        phf: Option<PerfectHashingFunction>,
     ) -> eyre::Result<()> {
         let factory = ProviderFactory::new(open_db_read_only(db_path, log_level)?, chain.clone());
         let provider = factory.provider()?;
@@ -35,7 +35,7 @@ impl Command {
         let block_range =
             self.block_ranges(tip).first().expect("has been generated before").clone();
 
-        let filters = if self.with_filters {
+        let filters = if let (true, Some(phf)) = (self.with_filters, phf) {
             Filters::WithFilters(inclusion_filter, phf)
         } else {
             Filters::WithoutFilters

--- a/bin/reth/src/db/snapshots/transactions.rs
+++ b/bin/reth/src/db/snapshots/transactions.rs
@@ -35,7 +35,7 @@ impl Command {
         let block_range =
             self.block_ranges(tip).first().expect("has been generated before").clone();
 
-        let filters = if let (true, Some(phf)) = (self.with_filters, phf) {
+        let filters = if let Some(phf) = self.with_filters.then_some(phf).flatten() {
             Filters::WithFilters(inclusion_filter, phf)
         } else {
             Filters::WithoutFilters

--- a/bin/reth/src/db/snapshots/transactions.rs
+++ b/bin/reth/src/db/snapshots/transactions.rs
@@ -27,7 +27,7 @@ impl Command {
         chain: Arc<ChainSpec>,
         compression: Compression,
         inclusion_filter: InclusionFilter,
-        phf: PerfectHashingFunction,
+        phf: Option<PerfectHashingFunction>,
     ) -> eyre::Result<()> {
         let factory = ProviderFactory::new(open_db_read_only(db_path, log_level)?, chain.clone());
         let provider = factory.provider()?;
@@ -35,7 +35,7 @@ impl Command {
         let block_range =
             self.block_ranges(tip).first().expect("has been generated before").clone();
 
-        let filters = if self.with_filters {
+        let filters = if let (true, Some(phf)) = (self.with_filters, phf) {
             Filters::WithFilters(inclusion_filter, phf)
         } else {
             Filters::WithoutFilters


### PR DESCRIPTION
If no `phf` was specified, the `reth db snapshot` was doing nothing as the cartesian product outputted the empty set.