### PR TITLE
chore: add note about execute fn in docs

### DIFF
--- a/crates/storage/provider/src/traits/executor.rs
+++ b/crates/storage/provider/src/traits/executor.rs
@@ -38,6 +38,8 @@ pub trait BlockExecutor {
     ) -> Result<(), BlockExecutionError>;
 
     /// Executes the block and checks receipts.
+    ///
+    /// See [execute](BlockExecutor::execute) for more details.
     fn execute_and_verify_receipt(
         &mut self,
         block: &Block,
@@ -55,6 +57,8 @@ pub trait BlockExecutor {
     /// 0, and so on).
     ///
     /// The second returned value represents the total gas used by this block of transactions.
+    ///
+    /// See [execute](BlockExecutor::execute) for more details.
     fn execute_transactions(
         &mut self,
         block: &Block,
@@ -93,9 +97,9 @@ pub struct BlockExecutorStats {
     /// Time needed to merge transitions and create reverts.
     /// It this time transitions are applies to revm bundle state.
     pub merge_transitions_duration: Duration,
-    /// Time needed to caclulate receipt roots.
+    /// Time needed to calculate receipt roots.
     pub receipt_root_duration: Duration,
-    /// Time needed to recovere senders.
+    /// Time needed to recover senders.
     pub sender_recovery_duration: Duration,
 }
 


### PR DESCRIPTION
add a note about execute fn to the other execute functions