### PR TITLE
fix: use the same ProviderFactory in reth node

### DIFF
--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -426,7 +426,7 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
                     &config.stages,
                     client.clone(),
                     Arc::clone(&consensus),
-                    provider_factory,
+                    provider_factory.clone(),
                     &ctx.task_executor,
                     sync_metrics_tx,
                     prune_config.clone(),
@@ -446,7 +446,7 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
                     &config.stages,
                     network_client.clone(),
                     Arc::clone(&consensus),
-                    provider_factory,
+                    provider_factory.clone(),
                     &ctx.task_executor,
                     sync_metrics_tx,
                     prune_config.clone(),
@@ -477,7 +477,7 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
         let pruner_events = if let Some(prune_config) = prune_config {
             let mut pruner = self.build_pruner(
                 &prune_config,
-                db.clone(),
+                provider_factory,
                 tree_config,
                 snapshotter.highest_snapshot_receiver(),
             );
@@ -979,7 +979,7 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
     fn build_pruner<DB: Database>(
         &self,
         config: &PruneConfig,
-        db: DB,
+        provider_factory: ProviderFactory<DB>,
         tree_config: BlockchainTreeConfig,
         highest_snapshots_rx: HighestSnapshotsTracker,
     ) -> Pruner<DB> {
@@ -1013,8 +1013,7 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
             );
 
         Pruner::new(
-            db,
-            self.chain.clone(),
+            provider_factory,
             segments.into_vec(),
             config.block_interval,
             self.chain.prune_delete_limit,

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -811,7 +811,7 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
         // try to look up the header in the database
         if let Some(header) = header {
             info!(target: "reth::cli", ?tip, "Successfully looked up tip block in the database");
-            return Ok(header.seal_slow());
+            return Ok(header.seal_slow())
         }
 
         info!(target: "reth::cli", ?tip, "Fetching tip block from the network.");
@@ -819,7 +819,7 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
             match get_single_header(&client, tip).await {
                 Ok(tip_header) => {
                     info!(target: "reth::cli", ?tip, "Successfully fetched tip");
-                    return Ok(tip_header);
+                    return Ok(tip_header)
                 }
                 Err(error) => {
                     error!(target: "reth::cli", %error, "Failed to fetch the tip. Retrying...");

--- a/crates/consensus/beacon/src/engine/test_utils.rs
+++ b/crates/consensus/beacon/src/engine/test_utils.rs
@@ -88,7 +88,7 @@ impl<DB> TestEnv<DB> {
         loop {
             let result = self.send_new_payload(payload.clone(), cancun_fields.clone()).await?;
             if !result.is_syncing() {
-                return Ok(result);
+                return Ok(result)
             }
         }
     }
@@ -109,7 +109,7 @@ impl<DB> TestEnv<DB> {
         loop {
             let result = self.engine_handle.fork_choice_updated(state, None).await?;
             if !result.is_syncing() {
-                return Ok(result);
+                return Ok(result)
             }
         }
     }

--- a/crates/consensus/beacon/src/engine/test_utils.rs
+++ b/crates/consensus/beacon/src/engine/test_utils.rs
@@ -88,7 +88,7 @@ impl<DB> TestEnv<DB> {
         loop {
             let result = self.send_new_payload(payload.clone(), cancun_fields.clone()).await?;
             if !result.is_syncing() {
-                return Ok(result)
+                return Ok(result);
             }
         }
     }
@@ -109,7 +109,7 @@ impl<DB> TestEnv<DB> {
         loop {
             let result = self.engine_handle.fork_choice_updated(state, None).await?;
             if !result.is_syncing() {
-                return Ok(result)
+                return Ok(result);
             }
         }
     }
@@ -525,11 +525,11 @@ where
             BlockchainTree::new(externals, config, None).expect("failed to create tree"),
         );
         let latest = self.base_config.chain_spec.genesis_header().seal_slow();
-        let blockchain_provider = BlockchainProvider::with_latest(provider_factory, tree, latest);
+        let blockchain_provider =
+            BlockchainProvider::with_latest(provider_factory.clone(), tree, latest);
 
         let pruner = Pruner::new(
-            db.clone(),
-            self.base_config.chain_spec.clone(),
+            provider_factory,
             vec![],
             5,
             self.base_config.chain_spec.prune_delete_limit,

--- a/crates/prune/src/pruner.rs
+++ b/crates/prune/src/pruner.rs
@@ -6,7 +6,7 @@ use crate::{
     Metrics, PrunerError, PrunerEvent,
 };
 use reth_db::database::Database;
-use reth_primitives::{BlockNumber, ChainSpec, PruneMode, PruneProgress, PruneSegment};
+use reth_primitives::{BlockNumber, PruneMode, PruneProgress, PruneSegment};
 use reth_provider::{ProviderFactory, PruneCheckpointReader};
 use reth_snapshot::HighestSnapshotsTracker;
 use reth_tokio_util::EventListeners;
@@ -46,8 +46,7 @@ pub struct Pruner<DB> {
 impl<DB: Database> Pruner<DB> {
     /// Creates a new [Pruner].
     pub fn new(
-        db: DB,
-        chain_spec: Arc<ChainSpec>,
+        provider_factory: ProviderFactory<DB>,
         segments: Vec<Arc<dyn Segment<DB>>>,
         min_block_interval: usize,
         delete_limit: usize,
@@ -55,7 +54,7 @@ impl<DB: Database> Pruner<DB> {
         highest_snapshots_tracker: HighestSnapshotsTracker,
     ) -> Self {
         Self {
-            provider_factory: ProviderFactory::new(db, chain_spec),
+            provider_factory,
             segments,
             min_block_interval,
             previous_tip_block_number: None,
@@ -78,7 +77,7 @@ impl<DB: Database> Pruner<DB> {
             self.previous_tip_block_number = Some(tip_block_number);
 
             trace!(target: "pruner", %tip_block_number, "Nothing to prune yet");
-            return Ok(PruneProgress::Finished)
+            return Ok(PruneProgress::Finished);
         }
 
         trace!(target: "pruner", %tip_block_number, "Pruner started");
@@ -111,7 +110,7 @@ impl<DB: Database> Pruner<DB> {
 
         for segment in &self.segments {
             if delete_limit == 0 {
-                break
+                break;
             }
 
             if let Some((to_block, prune_mode)) = segment
@@ -267,12 +266,14 @@ mod tests {
     use crate::Pruner;
     use reth_db::test_utils::create_test_rw_db;
     use reth_primitives::MAINNET;
+    use reth_provider::ProviderFactory;
     use tokio::sync::watch;
 
     #[test]
     fn is_pruning_needed() {
         let db = create_test_rw_db();
-        let mut pruner = Pruner::new(db, MAINNET.clone(), vec![], 5, 0, 5, watch::channel(None).1);
+        let provider_factory = ProviderFactory::new(db, MAINNET.clone());
+        let mut pruner = Pruner::new(provider_factory, vec![], 5, 0, 5, watch::channel(None).1);
 
         // No last pruned block number was set before
         let first_block_number = 1;

--- a/crates/prune/src/pruner.rs
+++ b/crates/prune/src/pruner.rs
@@ -77,7 +77,7 @@ impl<DB: Database> Pruner<DB> {
             self.previous_tip_block_number = Some(tip_block_number);
 
             trace!(target: "pruner", %tip_block_number, "Nothing to prune yet");
-            return Ok(PruneProgress::Finished);
+            return Ok(PruneProgress::Finished)
         }
 
         trace!(target: "pruner", %tip_block_number, "Pruner started");
@@ -110,7 +110,7 @@ impl<DB: Database> Pruner<DB> {
 
         for segment in &self.segments {
             if delete_limit == 0 {
-                break;
+                break
             }
 
             if let Some((to_block, prune_mode)) = segment


### PR DESCRIPTION
Previously we would create new `ProviderFactory`s for methods like `lookup_or_fetch_tip`, and when building the `NetworkManager` in `load_network_config`. This now uses the existing `ProviderFactory` that we've already created when `reth node` starts