### PR TITLE
feat: refactor indexing inside `SnapshotProvider`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6231,6 +6231,7 @@ dependencies = [
  "reth-primitives",
  "reth-trie",
  "revm",
+ "strum",
  "tempfile",
  "tokio",
  "tokio-stream",

--- a/crates/primitives/src/snapshot/mod.rs
+++ b/crates/primitives/src/snapshot/mod.rs
@@ -53,14 +53,13 @@ impl HighestSnapshots {
     }
 }
 
+/// Alias type for a map of [`SnapshotSegment`] and sorted lists of existing snapshot ranges.
+type SortedSnapshots =
+    HashMap<SnapshotSegment, Vec<(RangeInclusive<BlockNumber>, RangeInclusive<TxNumber>)>>;
+
 /// Given the snapshot's location, it returns a list over the existing snapshots organized by
 /// [`SnapshotSegment`]. Each segment has a sorted list of block ranges and transaction ranges.
-pub fn iter_snapshots(
-    path: impl AsRef<Path>,
-) -> Result<
-    HashMap<SnapshotSegment, Vec<(RangeInclusive<BlockNumber>, RangeInclusive<TxNumber>)>>,
-    FsPathError,
-> {
+pub fn iter_snapshots(path: impl AsRef<Path>) -> Result<SortedSnapshots, FsPathError> {
     let mut static_files: HashMap<SnapshotSegment, Vec<_>> = HashMap::default();
     let entries = crate::fs::read_dir(path.as_ref())?.filter_map(Result::ok).collect::<Vec<_>>();
 

--- a/crates/primitives/src/snapshot/mod.rs
+++ b/crates/primitives/src/snapshot/mod.rs
@@ -10,7 +10,11 @@ pub use filters::{Filters, InclusionFilter, PerfectHashingFunction};
 pub use segment::{SegmentConfig, SegmentHeader, SnapshotSegment};
 
 use crate::fs::FsPathError;
-use std::{ops::RangeInclusive, path::Path};
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    ops::RangeInclusive,
+    path::Path,
+};
 
 /// Default snapshot block count.
 pub const BLOCKS_PER_SNAPSHOT: u64 = 500_000;
@@ -49,19 +53,39 @@ impl HighestSnapshots {
     }
 }
 
-/// Given the snapshot's location, it returns an iterator over the existing snapshots in the format
-/// of a tuple composed by the segment, block range and transaction range.
+/// Given the snapshot's location, it returns a list over the existing snapshots organized by
+/// [`SnapshotSegment`]. Each segment has a sorted list of block ranges and transaction ranges.
 pub fn iter_snapshots(
     path: impl AsRef<Path>,
 ) -> Result<
-    impl Iterator<Item = (SnapshotSegment, RangeInclusive<BlockNumber>, RangeInclusive<TxNumber>)>,
+    HashMap<SnapshotSegment, Vec<(RangeInclusive<BlockNumber>, RangeInclusive<TxNumber>)>>,
     FsPathError,
 > {
-    let entries = crate::fs::read_dir(path.as_ref())?.filter_map(Result::ok);
-    Ok(entries.filter_map(|entry| {
+    let mut static_files: HashMap<SnapshotSegment, Vec<_>> = HashMap::default();
+    let entries = crate::fs::read_dir(path.as_ref())?.filter_map(Result::ok).collect::<Vec<_>>();
+
+    for entry in entries {
         if entry.metadata().map_or(false, |metadata| metadata.is_file()) {
-            return SnapshotSegment::parse_filename(&entry.file_name())
+            if let Some((segment, block_range, tx_range)) =
+                SnapshotSegment::parse_filename(&entry.file_name())
+            {
+                let ranges = (block_range, tx_range);
+                match static_files.entry(segment) {
+                    Entry::Occupied(mut entry) => {
+                        entry.get_mut().push(ranges);
+                    }
+                    Entry::Vacant(entry) => {
+                        entry.insert(vec![ranges]);
+                    }
+                }
+            }
         }
-        None
-    }))
+    }
+
+    // Sort by block end range.
+    for (_, range_list) in static_files.iter_mut() {
+        range_list.sort_by(|a, b| a.0.end().cmp(b.0.end()));
+    }
+
+    Ok(static_files)
 }

--- a/crates/primitives/src/snapshot/mod.rs
+++ b/crates/primitives/src/snapshot/mod.rs
@@ -4,11 +4,10 @@ mod compression;
 mod filters;
 mod segment;
 
-use alloy_primitives::{BlockNumber};
+use alloy_primitives::BlockNumber;
 pub use compression::Compression;
 pub use filters::{Filters, InclusionFilter, PerfectHashingFunction};
 pub use segment::{SegmentConfig, SegmentHeader, SnapshotSegment};
-
 
 /// Default snapshot block count.
 pub const BLOCKS_PER_SNAPSHOT: u64 = 500_000;

--- a/crates/primitives/src/snapshot/segment.rs
+++ b/crates/primitives/src/snapshot/segment.rs
@@ -5,7 +5,7 @@ use crate::{
 use derive_more::Display;
 use serde::{Deserialize, Serialize};
 use std::{ffi::OsStr, ops::RangeInclusive, str::FromStr};
-use strum::{AsRefStr, EnumString};
+use strum::{AsRefStr, EnumIter, EnumString};
 
 #[derive(
     Debug,
@@ -19,6 +19,7 @@ use strum::{AsRefStr, EnumString};
     Deserialize,
     Serialize,
     EnumString,
+    EnumIter,
     AsRefStr,
     Display,
 )]
@@ -151,6 +152,16 @@ impl SegmentHeader {
         segment: SnapshotSegment,
     ) -> Self {
         Self { block_range, tx_range, segment }
+    }
+
+    /// Returns the transaction range.
+    pub fn tx_range(&self) -> &RangeInclusive<TxNumber> {
+        &self.tx_range
+    }
+
+    /// Returns the block range.
+    pub fn block_range(&self) -> &RangeInclusive<BlockNumber> {
+        &self.block_range
     }
 
     /// Returns the first block number of the segment.

--- a/crates/snapshot/src/snapshotter.rs
+++ b/crates/snapshot/src/snapshotter.rs
@@ -3,11 +3,14 @@
 use crate::{segments, segments::Segment, SnapshotterError};
 use reth_db::database::Database;
 use reth_interfaces::{RethError, RethResult};
+use reth_nippy_jar::NippyJar;
 use reth_primitives::{
-    snapshot::{iter_snapshots, HighestSnapshots},
+    snapshot::{iter_snapshots, HighestSnapshots, SegmentHeader},
     BlockNumber, TxNumber,
 };
-use reth_provider::{BlockReader, DatabaseProviderRO, ProviderFactory, TransactionsProviderExt};
+use reth_provider::{
+    BlockReader, DatabaseProviderRO, ProviderError, ProviderFactory, TransactionsProviderExt,
+};
 use std::{
     collections::HashMap,
     ops::RangeInclusive,
@@ -155,10 +158,26 @@ impl<DB: Database> Snapshotter<DB> {
         // It walks over the directory and parses the snapshot filenames extracting
         // `SnapshotSegment` and their inclusive range. It then takes the maximum block
         // number for each specific segment.
-        for (segment, block_range, _) in iter_snapshots(&self.snapshots_path)? {
-            let max_segment_block = self.highest_snapshots.as_mut(segment);
-            if max_segment_block.map_or(true, |block| block < *block_range.end()) {
-                *max_segment_block = Some(*block_range.end());
+        for (segment, mut ranges) in iter_snapshots(&self.snapshots_path)? {
+            // The highest height static file filename might not be indicative of its actual
+            // block_range, so we need to read its actual configuration.
+            if let Some((block_range, tx_range)) = ranges.pop() {
+                let jar = NippyJar::<SegmentHeader>::load(
+                    &self.snapshots_path.join(segment.filename(&block_range, &tx_range)),
+                )
+                .map_err(|err| RethError::Provider(ProviderError::NippyJar(err.to_string())))?;
+
+                ranges.push((
+                    jar.user_header().block_range().clone(),
+                    jar.user_header().tx_range().clone(),
+                ))
+            }
+
+            for (block_range, _) in ranges {
+                let max_segment_block = self.highest_snapshots.as_mut(segment);
+                if max_segment_block.map_or(true, |block| block < *block_range.end()) {
+                    *max_segment_block = Some(*block_range.end());
+                }
             }
         }
 

--- a/crates/storage/db/src/snapshot/mod.rs
+++ b/crates/storage/db/src/snapshot/mod.rs
@@ -23,7 +23,7 @@ mod masks;
 type SortedSnapshots =
     HashMap<SnapshotSegment, Vec<(RangeInclusive<BlockNumber>, RangeInclusive<TxNumber>)>>;
 
-/// Given the snapshot's location, it returns a list over the existing snapshots organized by
+/// Given the snapshots directory path, it returns a list over the existing snapshots organized by
 /// [`SnapshotSegment`]. Each segment has a sorted list of block ranges and transaction ranges.
 pub fn iter_snapshots(path: impl AsRef<Path>) -> Result<SortedSnapshots, NippyJarError> {
     let mut static_files = SortedSnapshots::default();

--- a/crates/storage/db/src/snapshot/mod.rs
+++ b/crates/storage/db/src/snapshot/mod.rs
@@ -1,6 +1,12 @@
 //! reth's snapshot database table import and access
 
 mod generation;
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    ops::RangeInclusive,
+    path::Path,
+};
+
 pub use generation::*;
 
 mod cursor;
@@ -8,5 +14,63 @@ pub use cursor::SnapshotCursor;
 
 mod mask;
 pub use mask::*;
+use reth_nippy_jar::{NippyJar, NippyJarError};
+use reth_primitives::{snapshot::SegmentHeader, BlockNumber, SnapshotSegment, TxNumber};
 
 mod masks;
+
+/// Alias type for a map of [`SnapshotSegment`] and sorted lists of existing snapshot ranges.
+type SortedSnapshots =
+    HashMap<SnapshotSegment, Vec<(RangeInclusive<BlockNumber>, RangeInclusive<TxNumber>)>>;
+
+/// Given the snapshot's location, it returns a list over the existing snapshots organized by
+/// [`SnapshotSegment`]. Each segment has a sorted list of block ranges and transaction ranges.
+pub fn iter_snapshots(path: impl AsRef<Path>) -> Result<SortedSnapshots, NippyJarError> {
+    let mut static_files = SortedSnapshots::default();
+    let entries = reth_primitives::fs::read_dir(path.as_ref())
+        .map_err(|err| NippyJarError::Custom(err.to_string()))?
+        .filter_map(Result::ok)
+        .collect::<Vec<_>>();
+
+    for entry in entries {
+        if entry.metadata().map_or(false, |metadata| metadata.is_file()) {
+            if let Some((segment, block_range, tx_range)) =
+                SnapshotSegment::parse_filename(&entry.file_name())
+            {
+                let ranges = (block_range, tx_range);
+                match static_files.entry(segment) {
+                    Entry::Occupied(mut entry) => {
+                        entry.get_mut().push(ranges);
+                    }
+                    Entry::Vacant(entry) => {
+                        entry.insert(vec![ranges]);
+                    }
+                }
+            }
+        }
+    }
+
+    for (segment, range_list) in static_files.iter_mut() {
+        // Sort by block end range.
+        range_list.sort_by(|a, b| a.0.end().cmp(b.0.end()));
+
+        if let Some((block_range, tx_range)) = range_list.pop() {
+            // The highest height static file filename might not be indicative of its actual
+            // block_range, so we need to read its actual configuration.
+            let jar = NippyJar::<SegmentHeader>::load(
+                &path.as_ref().join(segment.filename(&block_range, &tx_range)),
+            )?;
+
+            if &tx_range != jar.user_header().tx_range() {
+                // TODO(joshie): rename
+            }
+
+            range_list.push((
+                jar.user_header().block_range().clone(),
+                jar.user_header().tx_range().clone(),
+            ));
+        }
+    }
+
+    Ok(static_files)
+}

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -35,6 +35,7 @@ itertools.workspace = true
 pin-project.workspace = true
 parking_lot.workspace = true
 dashmap = { version = "5.5", features = ["inline"] }
+strum.workspace = true
 
 # test-utils
 alloy-rlp = { workspace = true, optional = true }

--- a/crates/storage/provider/src/providers/snapshot/manager.rs
+++ b/crates/storage/provider/src/providers/snapshot/manager.rs
@@ -14,10 +14,10 @@ use reth_db::{
 use reth_interfaces::provider::{ProviderError, ProviderResult};
 use reth_nippy_jar::NippyJar;
 use reth_primitives::{
-    snapshot::{HighestSnapshots},
-    Address, Block, BlockHash, BlockHashOrNumber, BlockNumber, BlockWithSenders, ChainInfo, Header,
-    Receipt, SealedBlock, SealedBlockWithSenders, SealedHeader, SnapshotSegment, TransactionMeta,
-    TransactionSigned, TransactionSignedNoHash, TxHash, TxNumber, Withdrawal, B256, U256,
+    snapshot::HighestSnapshots, Address, Block, BlockHash, BlockHashOrNumber, BlockNumber,
+    BlockWithSenders, ChainInfo, Header, Receipt, SealedBlock, SealedBlockWithSenders,
+    SealedHeader, SnapshotSegment, TransactionMeta, TransactionSigned, TransactionSignedNoHash,
+    TxHash, TxNumber, Withdrawal, B256, U256,
 };
 use std::{
     collections::{hash_map::Entry, BTreeMap, HashMap},

--- a/crates/storage/provider/src/providers/snapshot/manager.rs
+++ b/crates/storage/provider/src/providers/snapshot/manager.rs
@@ -241,6 +241,11 @@ impl SnapshotProvider {
                 let jar = NippyJar::<SegmentHeader>::load(
                     &self.path.join(segment.filename(&block_range, &tx_range)),
                 )?;
+
+                if jar.user_header().tx_range() != &tx_range {
+                    // TODO(joshie): rename
+                }
+                
                 ranges.push((
                     jar.user_header().block_range().clone(),
                     jar.user_header().tx_range().clone(),


### PR DESCRIPTION
Currently indexing is being done over filenames. 

However, since we're using fixed block ranges for filenames (500k interval), it might not be the same as in `SegmentHeader` since this is only incremented as we add data. Meaning, that we have to actually read the highest height static file for the real value. 