### PR TITLE
chore: log full tx object in assert

### DIFF
--- a/crates/transaction-pool/src/pool/blob.rs
+++ b/crates/transaction-pool/src/pool/blob.rs
@@ -47,7 +47,7 @@ impl<T: PoolTransaction> BlobTransactions<T> {
     pub(crate) fn add_transaction(&mut self, tx: Arc<ValidPoolTransaction<T>>) {
         assert!(tx.is_eip4844(), "transaction is not a blob tx");
         let id = *tx.id();
-        assert!(!self.contains(&id), "transaction already included {:?}", self.contains(&id));
+        assert!(!self.contains(&id), "transaction already included {:?}", self.get(&id).unwrap());
         let submission_id = self.next_id();
 
         // keep track of size

--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -51,7 +51,7 @@ impl<T: ParkedOrd> ParkedPool<T> {
         assert!(
             !self.contains(&id),
             "transaction already included {:?}",
-            self.get(&id).unwrap().transaction.hash()
+            self.get(&id).unwrap().transaction.transaction
         );
         let submission_id = self.next_id();
 

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -289,7 +289,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
         assert!(
             !self.contains(tx.id()),
             "transaction already included {:?}",
-            self.get(tx.id()).unwrap().transaction.hash()
+            self.get(tx.id()).unwrap().transaction
         );
 
         // keep track of size
@@ -507,8 +507,9 @@ impl<T: TransactionOrdering> PendingPool<T> {
             self.highest_nonces.len() <= self.all.len(),
             "independent_descendants.len() > all.len()"
         );
-        assert!(
-            self.highest_nonces.len() == self.independent_transactions.len(),
+        assert_eq!(
+            self.highest_nonces.len(),
+            self.independent_transactions.len(),
             "independent.len() = independent_descendants.len()"
         );
     }


### PR DESCRIPTION
this is intended for debug purposes so we should just log the full object.