### PR TITLE
perf: skip initial transaction lookup during log queries

### DIFF
--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -417,7 +417,7 @@ where
         trace!(target: "rpc::eth::filter", from=from_block, to=to_block, ?filter, "finding logs in range");
 
         if to_block - from_block > self.max_blocks_per_filter {
-            return Err(FilterError::QueryExceedsMaxBlocks(self.max_blocks_per_filter));
+            return Err(FilterError::QueryExceedsMaxBlocks(self.max_blocks_per_filter))
         }
 
         let mut all_logs = Vec::new();

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -138,7 +138,7 @@ where
 
             if filter.block > best_number {
                 // no new blocks since the last poll
-                return Ok(FilterChanges::Empty);
+                return Ok(FilterChanges::Empty)
             }
 
             // update filter
@@ -208,7 +208,7 @@ where
                 *filter.clone()
             } else {
                 // Not a log filter
-                return Err(FilterError::FilterNotFound(id));
+                return Err(FilterError::FilterNotFound(id))
             }
         };
 
@@ -737,7 +737,7 @@ impl Iterator for BlockRangeInclusiveIter {
         let start = self.iter.next()?;
         let end = (start + self.step).min(self.end);
         if start > end {
-            return None;
+            return None
         }
         Some((start, end))
     }

--- a/crates/rpc/rpc/src/eth/logs_utils.rs
+++ b/crates/rpc/rpc/src/eth/logs_utils.rs
@@ -57,6 +57,8 @@ pub(crate) fn append_matching_block_logs(
     let mut log_index: u32 = 0;
 
     // Lazy loaded number of the first transaction in the block.
+    // This is useful for blocks with multiple matching logs because it prevents
+    // re-querying the block body indices.
     let mut loaded_first_tx_num = None;
 
     // Iterate over receipts and append matching logs.
@@ -76,6 +78,7 @@ pub(crate) fn append_matching_block_logs(
                     }
                 };
 
+                // This is safe because Transactions and Receipts have the same keys.
                 let transaction_id = first_tx_num + receipt_idx as u64;
                 let transaction = provider
                     .transaction_by_id(transaction_id)?

--- a/crates/rpc/rpc/src/eth/logs_utils.rs
+++ b/crates/rpc/rpc/src/eth/logs_utils.rs
@@ -1,46 +1,37 @@
-use reth_primitives::{BlockNumHash, ChainInfo, Receipt, TxHash, U256};
+use super::filter::FilterError;
+use alloy_primitives::TxHash;
+use reth_primitives::{BlockNumHash, ChainInfo, Receipt, U256};
+use reth_provider::{BlockReader, ProviderError};
 use reth_rpc_types::{FilteredParams, Log};
 use reth_rpc_types_compat::log::from_primitive_log;
 
-/// Returns all matching logs of a block's receipts grouped with the hash of their transaction.
-pub(crate) fn matching_block_logs<'a, I>(
+/// Returns all matching of a block's receipts when the transaction hashes are known.
+pub(crate) fn matching_block_logs_with_tx_hashes<'a, I>(
     filter: &FilteredParams,
-    block: BlockNumHash,
-    tx_and_receipts: I,
+    block_num_hash: BlockNumHash,
+    tx_hashes_and_receipts: I,
     removed: bool,
 ) -> Vec<Log>
 where
     I: IntoIterator<Item = (TxHash, &'a Receipt)>,
 {
     let mut all_logs = Vec::new();
-    append_matching_block_logs(&mut all_logs, filter, block, tx_and_receipts, removed);
-    all_logs
-}
-
-/// Appends all matching logs of a block's receipts grouped with the hash of their transaction
-pub(crate) fn append_matching_block_logs<'a, I>(
-    all_logs: &mut Vec<Log>,
-    filter: &FilteredParams,
-    block: BlockNumHash,
-    tx_and_receipts: I,
-    removed: bool,
-) where
-    I: IntoIterator<Item = (TxHash, &'a Receipt)>,
-{
-    let block_number_u256 = U256::from(block.number);
-    // tracks the index of a log in the entire block
+    // Tracks the index of a log in the entire block.
     let mut log_index: u32 = 0;
-    for (transaction_idx, (transaction_hash, receipt)) in tx_and_receipts.into_iter().enumerate() {
-        for log in receipt.logs.iter() {
-            if log_matches_filter(block, log, filter) {
+    // Iterate over transaction hashes and receipts and append matching logs.
+    for (receipt_idx, (tx_hash, receipt)) in tx_hashes_and_receipts.into_iter().enumerate() {
+        let logs = &receipt.logs;
+        for log in logs {
+            if log_matches_filter(block_num_hash, log, filter) {
                 let log = Log {
                     address: log.address,
                     topics: log.topics.clone(),
                     data: log.data.clone(),
-                    block_hash: Some(block.hash),
-                    block_number: Some(block_number_u256),
-                    transaction_hash: Some(transaction_hash),
-                    transaction_index: Some(U256::from(transaction_idx)),
+                    block_hash: Some(block_num_hash.hash),
+                    block_number: Some(U256::from(block_num_hash.number)),
+                    transaction_hash: Some(tx_hash),
+                    // The transaction and receipt index is always the same.
+                    transaction_index: Some(U256::from(receipt_idx)),
                     log_index: Some(U256::from(log_index)),
                     removed,
                 };
@@ -49,6 +40,65 @@ pub(crate) fn append_matching_block_logs<'a, I>(
             log_index += 1;
         }
     }
+    all_logs
+}
+
+/// Appends all matching logs of a block's receipts.
+/// If the log matches, look up the corresponding transaction hash.
+pub(crate) fn append_matching_block_logs(
+    all_logs: &mut Vec<Log>,
+    provider: impl BlockReader,
+    filter: &FilteredParams,
+    block_num_hash: BlockNumHash,
+    receipts: &[Receipt],
+    removed: bool,
+) -> Result<(), FilterError> {
+    // Tracks the index of a log in the entire block.
+    let mut log_index: u32 = 0;
+
+    // Lazy loaded number of the first transaction in the block.
+    let mut loaded_first_tx_num = None;
+
+    // Iterate over receipts and append matching logs.
+    for (receipt_idx, receipt) in receipts.iter().enumerate() {
+        let logs = &receipt.logs;
+        for log in logs {
+            if log_matches_filter(block_num_hash, log, filter) {
+                let first_tx_num = match loaded_first_tx_num {
+                    Some(num) => num,
+                    None => {
+                        let block_body_indices =
+                            provider.block_body_indices(block_num_hash.number)?.ok_or(
+                                ProviderError::BlockBodyIndicesNotFound(block_num_hash.number),
+                            )?;
+                        loaded_first_tx_num = Some(block_body_indices.first_tx_num);
+                        block_body_indices.first_tx_num
+                    }
+                };
+
+                let transaction_id = first_tx_num + receipt_idx as u64;
+                let transaction = provider
+                    .transaction_by_id(transaction_id)?
+                    .ok_or(ProviderError::TransactionNotFound(transaction_id.into()))?;
+
+                let log = Log {
+                    address: log.address,
+                    topics: log.topics.clone(),
+                    data: log.data.clone(),
+                    block_hash: Some(block_num_hash.hash),
+                    block_number: Some(U256::from(block_num_hash.number)),
+                    transaction_hash: Some(transaction.hash()),
+                    // The transaction and receipt index is always the same.
+                    transaction_index: Some(U256::from(receipt_idx)),
+                    log_index: Some(U256::from(log_index)),
+                    removed,
+                };
+                all_logs.push(log);
+            }
+            log_index += 1;
+        }
+    }
+    Ok(())
 }
 
 /// Returns true if the log matches the filter and should be included

--- a/crates/rpc/rpc/src/eth/pubsub.rs
+++ b/crates/rpc/rpc/src/eth/pubsub.rs
@@ -308,7 +308,7 @@ where
             })
             .flat_map(futures::stream::iter)
             .flat_map(move |(block_receipts, removed)| {
-                let all_logs = logs_utils::matching_block_logs(
+                let all_logs = logs_utils::matching_block_logs_with_tx_hashes(
                     &filter,
                     block_receipts.block,
                     block_receipts.tx_receipts.iter().map(|(tx, receipt)| (*tx, receipt)),


### PR DESCRIPTION
## Description

Optimize `eth_getLogs` endpoint handle by not requesting full blocks from the state cache upon a positive bloom filter match. Request only receipts instead and lookup the transaction hash from the database separately only when the log matching filter parameters match.

This approach resulted in a 300% improvement in long block ranges. 