### PR TITLE
feat: etl crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5983,6 +5983,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-etl"
+version = "0.1.0-alpha.13"
+dependencies = [
+ "reth-db",
+ "reth-primitives",
+ "tempfile",
+]
+
+[[package]]
 name = "reth-interfaces"
 version = "0.1.0-alpha.13"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/consensus/beacon/",
     "crates/consensus/common/",
     "crates/ethereum-forks/",
+    "crates/etl",
     "crates/interfaces/",
     "crates/metrics/",
     "crates/metrics/metrics-derive/",
@@ -104,6 +105,7 @@ reth-downloaders = { path = "crates/net/downloaders" }
 reth-ecies = { path = "crates/net/ecies" }
 reth-eth-wire = { path = "crates/net/eth-wire" }
 reth-ethereum-forks = { path = "crates/ethereum-forks" }
+reth-etl = { path = "crates/etl" }
 reth-interfaces = { path = "crates/interfaces" }
 reth-ipc = { path = "crates/rpc/ipc" }
 reth-libmdbx = { path = "crates/storage/libmdbx-rs" }

--- a/crates/etl/Cargo.toml
+++ b/crates/etl/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "reth-etl"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[dependencies]
+tempfile.workspace = true
+reth-db.workspace = true
+
+[dev-dependencies]
+reth-primitives.workspace = true

--- a/crates/etl/src/lib.rs
+++ b/crates/etl/src/lib.rs
@@ -1,0 +1,226 @@
+//! ETL data collector.
+//!
+//! This crate is useful for dumping unsorted data into temporary files and iterating on their
+//! sorted representation later on.
+//!
+//! This has multiple uses, such as optimizing database inserts (for Btree based databases) and
+//! memory management (as it moves the buffer to disk instead of memory).
+
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
+    html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
+    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
+)]
+#![warn(missing_debug_implementations, missing_docs, unreachable_pub, rustdoc::all)]
+#![deny(unused_must_use, rust_2018_idioms)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
+use std::{
+    cmp::Reverse,
+    collections::BinaryHeap,
+    io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write},
+    path::Path,
+};
+
+use reth_db::table::{Compress, Encode, Key, Value};
+use tempfile::{NamedTempFile, TempDir};
+
+/// An ETL data collector.
+///
+/// Data is pushed to the collector which internally flushes the data in a sorted manner to files of
+/// some specified capacity.
+///
+/// The data can later be iterated over in a sorted manner.
+#[derive(Debug)]
+pub struct Collector<'tmp, K, V>
+where
+    K: Encode + Ord,
+    V: Compress,
+    <K as Encode>::Encoded: std::fmt::Debug,
+    <V as Compress>::Compressed: std::fmt::Debug,
+{
+    dir: &'tmp TempDir,
+    buffer_size_bytes: usize,
+    files: Vec<EtlFile>,
+    buffer_capacity_bytes: usize,
+    buffer: Vec<(<K as Encode>::Encoded, <V as Compress>::Compressed)>,
+}
+
+impl<'tmp, K, V> Collector<'tmp, K, V>
+where
+    K: Key,
+    V: Value,
+    <K as Encode>::Encoded: Ord + std::fmt::Debug,
+    <V as Compress>::Compressed: Ord + std::fmt::Debug,
+{
+    /// Create a new collector in a specific temporary directory with some capacity.
+    ///
+    /// Once the capacity (in bytes) is reached, the data is sorted and flushed to disk.
+    pub fn new(dir: &'tmp TempDir, buffer_capacity_bytes: usize) -> Self {
+        Self {
+            dir,
+            buffer_size_bytes: 0,
+            files: Vec::new(),
+            buffer_capacity_bytes,
+            buffer: Vec::new(),
+        }
+    }
+
+    /// Insert an entry into the collector.
+    pub fn insert(&mut self, key: K, value: V) {
+        let key = key.encode();
+        let value = value.compress();
+        self.buffer_size_bytes += key.as_ref().len() + value.as_ref().len();
+        self.buffer.push((key, value));
+        if self.buffer_size_bytes > self.buffer_capacity_bytes {
+            self.flush();
+        }
+    }
+
+    fn flush(&mut self) {
+        self.buffer_size_bytes = 0;
+        self.buffer.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        let mut buf = Vec::with_capacity(self.buffer.len());
+        std::mem::swap(&mut buf, &mut self.buffer);
+        self.files.push(EtlFile::new(self.dir.path(), buf).expect("could not flush data to disk"))
+    }
+
+    /// Returns an iterator over the collector data.
+    ///
+    /// The items of the iterator are sorted across all underlying files.
+    ///
+    /// # Note
+    ///
+    /// The keys and values have been pre-encoded, meaning they *SHOULD NOT* be encoded or
+    /// compressed again.
+    pub fn iter(&mut self) -> std::io::Result<EtlIter<'_>> {
+        // Flush the remaining items to disk
+        if self.buffer_size_bytes > 0 {
+            self.flush();
+        }
+
+        let mut heap = BinaryHeap::new();
+        for (current_id, file) in self.files.iter_mut().enumerate() {
+            if let Some((current_key, current_value)) = file.read_next()? {
+                heap.push((Reverse((current_key, current_value)), current_id));
+            }
+        }
+
+        Ok(EtlIter { heap, files: &mut self.files })
+    }
+}
+
+/// An iterator over sorted data in a collection of ETL files.
+#[derive(Debug)]
+pub struct EtlIter<'a> {
+    heap: BinaryHeap<(Reverse<(Vec<u8>, Vec<u8>)>, usize)>,
+    files: &'a mut Vec<EtlFile>,
+}
+
+impl<'a> Iterator for EtlIter<'a> {
+    type Item = std::io::Result<(Vec<u8>, Vec<u8>)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Get the next sorted entry from the heap
+        let (Reverse(entry), id) = self.heap.pop()?;
+
+        // Populate the heap with the next entry from the same file
+        match self.files[id].read_next() {
+            Ok(Some((key, value))) => {
+                self.heap.push((Reverse((key, value)), id));
+                Some(Ok(entry))
+            }
+            Ok(None) => Some(Ok(entry)),
+            err => err.transpose(),
+        }
+    }
+}
+
+/// A temporary ETL file.
+#[derive(Debug)]
+struct EtlFile {
+    file: BufReader<NamedTempFile>,
+    len: usize,
+}
+
+impl EtlFile {
+    /// Create a new file with the given data (which should be pre-sorted) at the given path.
+    ///
+    /// The file will be a temporary file.
+    pub(crate) fn new<K, V>(dir: &Path, buffer: Vec<(K, V)>) -> std::io::Result<Self>
+    where
+        Self: Sized,
+        K: AsRef<[u8]>,
+        V: AsRef<[u8]>,
+    {
+        let file = NamedTempFile::new_in(dir)?;
+        let mut w = BufWriter::new(file);
+        for entry in &buffer {
+            let k = entry.0.as_ref();
+            let v = entry.1.as_ref();
+
+            w.write_all(&k.len().to_be_bytes())?;
+            w.write_all(&v.len().to_be_bytes())?;
+            w.write_all(k)?;
+            w.write_all(v)?;
+        }
+
+        let mut file = BufReader::new(w.into_inner()?);
+        file.seek(SeekFrom::Start(0))?;
+        let len = buffer.len();
+        Ok(Self { file, len })
+    }
+
+    /// Read the next entry in the file.
+    pub(crate) fn read_next(&mut self) -> std::io::Result<Option<(Vec<u8>, Vec<u8>)>> {
+        if self.len == 0 {
+            return Ok(None);
+        }
+
+        let mut buffer_key_length = [0; 8];
+        let mut buffer_value_length = [0; 8];
+
+        self.file.read_exact(&mut buffer_key_length)?;
+        self.file.read_exact(&mut buffer_value_length)?;
+
+        let key_length = usize::from_be_bytes(buffer_key_length);
+        let value_length = usize::from_be_bytes(buffer_value_length);
+        let mut key = vec![0; key_length];
+        let mut value = vec![0; value_length];
+
+        self.file.read_exact(&mut key)?;
+        self.file.read_exact(&mut value)?;
+
+        self.len -= 1;
+
+        Ok(Some((key, value)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use reth_primitives::{TxHash, TxNumber};
+
+    use super::*;
+
+    #[test]
+    fn etl_hashes() {
+        let mut entries: Vec<_> =
+            (0..10_000).into_iter().map(|id| (TxHash::random(), id as TxNumber)).collect();
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut collector = Collector::new(&temp_dir, 1024);
+        for (k, v) in entries.clone() {
+            collector.insert(k, v);
+        }
+        entries.sort_unstable_by_key(|entry| entry.0);
+
+        for (id, entry) in collector.iter().unwrap().enumerate() {
+            let expected = entries[id];
+            assert_eq!(
+                entry.unwrap(),
+                (expected.0.encode().to_vec(), expected.1.compress().to_vec())
+            );
+        }
+    }
+}


### PR DESCRIPTION
Adds a simple ETL collector + iterator. This does not implement any higher level abstractions for dumping data into static files or tables. 

Generally, it is worth noting that the entries in the iterator are already encoded and compressed, so inserts/appends need to happen on raw tables, and for static files, it is important that the entries are not encoded/compressed again