### PR TITLE
chore: add error struct for checking builder submissions

### DIFF
--- a/crates/rpc/rpc-types/src/relay/error.rs
+++ b/crates/rpc/rpc-types/src/relay/error.rs
@@ -1,0 +1,40 @@
+//! Error types for the relay.
+
+use alloy_primitives::B256;
+
+/// Error thrown by the `validateBuilderSubmission` endpoints if the message differs from payload.
+#[derive(Debug, thiserror::Error)]
+pub enum ValidateBuilderSubmissionEqualityError {
+    /// Thrown if parent hash mismatches
+    #[error("incorrect ParentHash {actual}, expected {expected}")]
+    IncorrectParentHash {
+        /// The expected parent hash
+        expected: B256,
+        /// The actual parent hash
+        actual: B256,
+    },
+    /// Thrown if block hash mismatches
+    #[error("incorrect BlockHash {actual}, expected {expected}")]
+    IncorrectBlockHash {
+        /// The expected block hash
+        expected: B256,
+        /// The actual block hash
+        actual: B256,
+    },
+    /// Thrown if block hash mismatches
+    #[error("incorrect GasLimit {actual}, expected {expected}")]
+    IncorrectGasLimit {
+        /// The expected gas limit
+        expected: u64,
+        /// The actual gas limit
+        actual: B256,
+    },
+    /// Thrown if block hash mismatches
+    #[error("incorrect GasUsed {actual}, expected {expected}")]
+    IncorrectGasUsed {
+        /// The expected gas used
+        expected: u64,
+        /// The actual gas used
+        actual: B256,
+    },
+}

--- a/crates/rpc/rpc-types/src/relay/mod.rs
+++ b/crates/rpc/rpc-types/src/relay/mod.rs
@@ -10,6 +10,8 @@ use alloy_primitives::{Address, B256, U256};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 
+pub mod error;
+
 /// Represents an entry of the `/relay/v1/builder/validators` endpoint
 #[serde_as]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -324,7 +326,7 @@ mod tests {
     #[test]
     fn test_can_parse_validation_request_body() {
         const VALIDATION_REQUEST_BODY: &str =
-            include_str!("../test_data/relay/single_payload.json");
+            include_str!("../../test_data/relay/single_payload.json");
 
         let _validation_request_body: BuilderBlockValidationRequest =
             serde_json::from_str(VALIDATION_REQUEST_BODY).unwrap();


### PR DESCRIPTION
helper error variant that represents various checks:

https://github.com/flashbots/builder/blob/03ee71cf0a344397204f65ff6d3a917ee8e06724/eth/block-validation/api.go#L150-L164