### PR TITLE
feat(bin): disable ETA for execution stage

### DIFF
--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -66,7 +66,7 @@ impl<DB> NodeState<DB> {
                     target,
                 };
 
-                let progress = OptionalField(
+                let stage_progress = OptionalField(
                     checkpoint.entities().and_then(|entities| entities.fmt_percentage()),
                 );
 
@@ -76,7 +76,7 @@ impl<DB> NodeState<DB> {
                         stage = %stage_id,
                         checkpoint = %checkpoint.block_number,
                         target = %OptionalField(target),
-                        %progress,
+                        %stage_progress,
                         %stage_eta,
                         "Executing stage",
                     );
@@ -86,7 +86,7 @@ impl<DB> NodeState<DB> {
                         stage = %stage_id,
                         checkpoint = %checkpoint.block_number,
                         target = %OptionalField(target),
-                        %progress,
+                        %stage_progress,
                         "Executing stage",
                     );
                 }
@@ -107,7 +107,7 @@ impl<DB> NodeState<DB> {
                     current_stage.eta.update(checkpoint);
 
                     let target = OptionalField(current_stage.target);
-                    let progress = OptionalField(
+                    let stage_progress = OptionalField(
                         checkpoint.entities().and_then(|entities| entities.fmt_percentage()),
                     );
 
@@ -120,7 +120,7 @@ impl<DB> NodeState<DB> {
                             stage = %stage_id,
                             checkpoint = %checkpoint.block_number,
                             %target,
-                            %progress,
+                            %stage_progress,
                             %stage_eta,
                             message,
                         )
@@ -130,7 +130,7 @@ impl<DB> NodeState<DB> {
                             stage = %stage_id,
                             checkpoint = %checkpoint.block_number,
                             %target,
-                            %progress,
+                            %stage_progress,
                             message,
                         )
                     }
@@ -328,7 +328,7 @@ where
             if let Some(CurrentStage { stage_id, eta, checkpoint, target }) =
                 &this.state.current_stage
             {
-                let progress = OptionalField(
+                let stage_progress = OptionalField(
                     checkpoint.entities().and_then(|entities| entities.fmt_percentage()),
                 );
 
@@ -340,7 +340,7 @@ where
                         stage = %stage_id,
                         checkpoint = checkpoint.block_number,
                         target = %OptionalField(*target),
-                        %progress,
+                        %stage_progress,
                         %stage_eta,
                         "Status"
                     );
@@ -352,7 +352,7 @@ where
                         stage = %stage_id,
                         checkpoint = checkpoint.block_number,
                         target = %OptionalField(*target),
-                        %progress,
+                        %stage_progress,
                         "Status"
                     );
                 }

--- a/bin/reth/src/node/events.rs
+++ b/bin/reth/src/node/events.rs
@@ -438,8 +438,11 @@ impl Eta {
     /// It's not the case for network-dependent ([StageId::Headers] and [StageId::Bodies]) and
     /// [StageId::Execution] stages.
     fn fmt_for_stage(&self, stage: StageId) -> Option<String> {
-        (!matches!(stage, StageId::Headers | StageId::Bodies | StageId::Execution))
-            .then_some(self.to_string())
+        if matches!(stage, StageId::Headers | StageId::Bodies | StageId::Execution) {
+            None
+        } else {
+            Some(self.to_string())
+        }
     }
 }
 


### PR DESCRIPTION
We receive a lot of reports from users who are confused about the ETA for `Execution` stage, e.g.: 
> For example, I'm on stage 5 (execution) and have seen the eta be anywhere from 6 hours to 31 days.

The problem is that our ETA works only on two points (previous and current timestamps), and the progress for `Execution` stage is measured in gas, which is likely not an ideal proxy for real CPU time. 

For the time being, I think we should disable the ETA reporting for `Execution` stage completely, and leave just the percentage progress which should be enough to get the idea of how long it takes to complete.