### PR TITLE
chore: remove `BlockBodyRoots` and reduce root calculation times

### DIFF
--- a/crates/interfaces/src/p2p/full_block.rs
+++ b/crates/interfaces/src/p2p/full_block.rs
@@ -306,17 +306,17 @@ fn ensure_valid_body_response(
     header: &SealedHeader,
     block: &BlockBody,
 ) -> Result<(), ConsensusError> {
-    let body_roots = block.calculate_roots();
-
-    if header.ommers_hash != body_roots.ommers_hash {
+    let ommers_hash = block.calculate_ommers_root();
+    if header.ommers_hash != ommers_hash {
         return Err(ConsensusError::BodyOmmersHashDiff(
-            GotExpected { got: body_roots.ommers_hash, expected: header.ommers_hash }.into(),
+            GotExpected { got: ommers_hash, expected: header.ommers_hash }.into(),
         ))
     }
 
-    if header.transactions_root != body_roots.tx_root {
+    let tx_root: revm_primitives::FixedBytes<32> = block.calculate_tx_root();
+    if header.transactions_root != tx_root {
         return Err(ConsensusError::BodyTransactionRootDiff(
-            GotExpected { got: body_roots.tx_root, expected: header.transactions_root }.into(),
+            GotExpected { got: tx_root, expected: header.transactions_root }.into(),
         ))
     }
 

--- a/crates/interfaces/src/p2p/full_block.rs
+++ b/crates/interfaces/src/p2p/full_block.rs
@@ -313,7 +313,7 @@ fn ensure_valid_body_response(
         ))
     }
 
-    let tx_root: revm_primitives::FixedBytes<32> = block.calculate_tx_root();
+    let tx_root = block.calculate_tx_root();
     if header.transactions_root != tx_root {
         return Err(ConsensusError::BodyTransactionRootDiff(
             GotExpected { got: tx_root, expected: header.transactions_root }.into(),

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -457,15 +457,6 @@ impl BlockBody {
         self.withdrawals.as_ref().map(|w| crate::proofs::calculate_withdrawals_root(w))
     }
 
-    /// Calculate all roots (transaction, ommers, withdrawals) for the block body.
-    pub fn calculate_roots(&self) -> BlockBodyRoots {
-        BlockBodyRoots {
-            tx_root: self.calculate_tx_root(),
-            ommers_hash: self.calculate_ommers_root(),
-            withdrawals_root: self.calculate_withdrawals_root(),
-        }
-    }
-
     /// Calculates a heuristic for the in-memory size of the [BlockBody].
     #[inline]
     pub fn size(&self) -> usize {
@@ -481,18 +472,6 @@ impl BlockBody {
                 })
                 .unwrap_or(std::mem::size_of::<Option<Vec<Withdrawal>>>())
     }
-}
-
-/// A struct that represents roots associated with a block body. This can be used to correlate
-/// block body responses with headers.
-#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, Hash)]
-pub struct BlockBodyRoots {
-    /// The transaction root for the block body.
-    pub tx_root: B256,
-    /// The ommers hash for the block body.
-    pub ommers_hash: B256,
-    /// The withdrawals root for the block body, if withdrawals exist.
-    pub withdrawals_root: Option<B256>,
 }
 
 #[cfg(test)]

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -2,8 +2,8 @@ use crate::{
     basefee::calculate_next_block_base_fee,
     constants::{EMPTY_OMMER_ROOT_HASH, EMPTY_ROOT_HASH},
     eip4844::{calc_blob_gasprice, calculate_excess_blob_gas},
-    keccak256, Address, BaseFeeParams, BlockBodyRoots, BlockHash, BlockNumHash, BlockNumber, Bloom,
-    Bytes, B256, B64, U256,
+    keccak256, Address, BaseFeeParams, BlockHash, BlockNumHash, BlockNumber, Bloom, Bytes, B256,
+    B64, U256,
 };
 use alloy_rlp::{length_of_length, Decodable, Encodable, EMPTY_LIST_CODE, EMPTY_STRING_CODE};
 use bytes::{Buf, BufMut, BytesMut};
@@ -145,15 +145,6 @@ impl Header {
     /// Check if the transaction root equals to empty root.
     pub fn transaction_root_is_empty(&self) -> bool {
         self.transactions_root == EMPTY_ROOT_HASH
-    }
-
-    /// Converts all roots in the header to a [BlockBodyRoots] struct.
-    pub fn body_roots(&self) -> BlockBodyRoots {
-        BlockBodyRoots {
-            tx_root: self.transactions_root,
-            ommers_hash: self.ommers_hash,
-            withdrawals_root: self.withdrawals_root,
-        }
     }
 
     /// Returns the blob fee for _this_ block according to the EIP-4844 spec.

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -48,8 +48,8 @@ mod withdrawal;
 
 pub use account::{Account, Bytecode};
 pub use block::{
-    Block, BlockBody, BlockBodyRoots, BlockHashOrNumber, BlockId, BlockNumHash, BlockNumberOrTag,
-    BlockWithSenders, ForkBlock, RpcBlockHash, SealedBlock, SealedBlockWithSenders,
+    Block, BlockBody, BlockHashOrNumber, BlockId, BlockNumHash, BlockNumberOrTag, BlockWithSenders,
+    ForkBlock, RpcBlockHash, SealedBlock, SealedBlockWithSenders,
 };
 pub use bytes::{self, Buf, BufMut, BytesMut};
 pub use chain::{


### PR DESCRIPTION
`BlockBodyRoots` is not very useful, the `pre-cal` is not cheap.