### PR TITLE
fix(consensus): correct the fork name for validating 1559 transaction

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -92,7 +92,7 @@ pub fn validate_transaction_regarding_header(
             ..
         }) => {
             // EIP-1559: Fee market change for ETH 1.0 chain https://eips.ethereum.org/EIPS/eip-1559
-            if !chain_spec.fork(Hardfork::Berlin).active_at_block(at_block_number) {
+            if !chain_spec.fork(Hardfork::London).active_at_block(at_block_number) {
                 return Err(InvalidTransactionError::Eip1559Disabled.into())
             }
 


### PR DESCRIPTION
- Considering the context, this part would be `Hardfork::London`?
- It works well for sure(no errors), as it readlly didn't enbale EIP-1559 at the Berlin hardfork.