### PR TITLE
chore(transaction): unify the chainId type in different transaction definitions

### DIFF
--- a/crates/primitives/src/transaction/eip1559.rs
+++ b/crates/primitives/src/transaction/eip1559.rs
@@ -10,7 +10,7 @@ use std::mem;
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub struct TxEip1559 {
     /// Added as EIP-pub 155: Simple replay attack protection
-    pub chain_id: u64,
+    pub chain_id: ChainId,
     /// A scalar value equal to the number of transactions sent by the sender; formally Tn.
     pub nonce: u64,
     /// A scalar value equal to the maximum

--- a/crates/primitives/src/transaction/eip4844.rs
+++ b/crates/primitives/src/transaction/eip4844.rs
@@ -24,7 +24,7 @@ use std::ops::Deref;
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub struct TxEip4844 {
     /// Added as EIP-pub 155: Simple replay attack protection
-    pub chain_id: u64,
+    pub chain_id: ChainId,
     /// A scalar value equal to the number of transactions sent by the sender; formally Tn.
     pub nonce: u64,
     /// A scalar value equal to the maximum


### PR DESCRIPTION
According to the chainId definition [here](https://github.com/paradigmxyz/reth/blob/main/crates/primitives/src/transaction/eip2930.rs#L13) (eip2930 transaction), there is a specially defined type to represent [ChainID](https://github.com/alloy-rs/core/blob/main/crates/primitives/src/aliases.rs#L78). This type is also introduced in the other two files, [here](https://github.com/paradigmxyz/reth/blob/main/crates/primitives/src/transaction/eip1559.rs#L2) and [here](https://github.com/paradigmxyz/reth/blob/main/crates/primitives/src/transaction/eip4844.rs#L3). It would be better to use it as a unified type for all chainID definitions?