### PR TITLE
fix(txpool): missing condition that tx gas limit equal to block gas l…

### DIFF
--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -132,9 +132,9 @@ impl<T: TransactionOrdering> TxPool<T> {
             (Ordering::Equal, Ordering::Equal) => {
                 // fee unchanged, nothing to update
             }
-            (Ordering::Greater, Ordering::Equal) |
-            (Ordering::Equal, Ordering::Greater) |
-            (Ordering::Greater, Ordering::Greater) => {
+            (Ordering::Greater, Ordering::Equal)
+            | (Ordering::Equal, Ordering::Greater)
+            | (Ordering::Greater, Ordering::Greater) => {
                 // increased blob fee: recheck pending pool and remove all that are no longer valid
                 let removed =
                     self.pending_pool.update_blob_fee(self.all_transactions.pending_fees.blob_fee);
@@ -1309,7 +1309,9 @@ impl<T: PoolTransaction> AllTransactions<T> {
                         cumulative_cost += tx.transaction.cost();
                         if tx.transaction.is_eip4844() && cumulative_cost > on_chain_balance {
                             // the transaction would shift
-                            return Err(InsertErr::Overdraft { transaction: Arc::new(new_blob_tx) });
+                            return Err(InsertErr::Overdraft {
+                                transaction: Arc::new(new_blob_tx),
+                            });
                         }
                     }
                 }
@@ -1333,8 +1335,8 @@ impl<T: PoolTransaction> AllTransactions<T> {
         let price_bump = price_bumps.price_bump(existing_transaction.tx_type());
         let price_bump_multiplier = (100 + price_bump) / 100;
 
-        if maybe_replacement.max_fee_per_gas() <=
-            existing_transaction.max_fee_per_gas() * price_bump_multiplier
+        if maybe_replacement.max_fee_per_gas()
+            <= existing_transaction.max_fee_per_gas() * price_bump_multiplier
         {
             return true;
         }
@@ -1344,10 +1346,10 @@ impl<T: PoolTransaction> AllTransactions<T> {
         let replacement_max_priority_fee_per_gas =
             maybe_replacement.transaction.max_priority_fee_per_gas().unwrap_or(0);
 
-        if replacement_max_priority_fee_per_gas <=
-            existing_max_priority_fee_per_gas * price_bump_multiplier &&
-            existing_max_priority_fee_per_gas != 0 &&
-            replacement_max_priority_fee_per_gas != 0
+        if replacement_max_priority_fee_per_gas
+            <= existing_max_priority_fee_per_gas * price_bump_multiplier
+            && existing_max_priority_fee_per_gas != 0
+            && replacement_max_priority_fee_per_gas != 0
         {
             return true;
         }
@@ -1359,8 +1361,8 @@ impl<T: PoolTransaction> AllTransactions<T> {
             // this enforces that blob txs can only be replaced by blob txs
             let replacement_max_blob_fee_per_gas =
                 maybe_replacement.transaction.max_fee_per_blob_gas().unwrap_or(0);
-            if replacement_max_blob_fee_per_gas <=
-                existing_max_blob_fee_per_gas * price_bump_multiplier
+            if replacement_max_blob_fee_per_gas
+                <= existing_max_blob_fee_per_gas * price_bump_multiplier
             {
                 return true;
             }
@@ -1417,7 +1419,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
 
         // Current tx does not exceed block gas limit after ensure_valid check
         state.insert(TxState::NOT_TOO_MUCH_GAS);
-        
+
         // identifier of the ancestor transaction, will be None if the transaction is the next tx of
         // the sender
         let ancestor = TransactionId::ancestor(
@@ -2498,7 +2500,8 @@ mod tests {
 
         let tx = MockTransaction::eip1559().with_gas_limit(30_000_000);
 
-        let InsertOk {state, .. } =  pool.insert_tx(f.validated(tx), on_chain_balance, on_chain_nonce).unwrap();
+        let InsertOk { state, .. } =
+            pool.insert_tx(f.validated(tx), on_chain_balance, on_chain_nonce).unwrap();
         assert!(state.contains(TxState::NOT_TOO_MUCH_GAS));
     }
 

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -132,9 +132,9 @@ impl<T: TransactionOrdering> TxPool<T> {
             (Ordering::Equal, Ordering::Equal) => {
                 // fee unchanged, nothing to update
             }
-            (Ordering::Greater, Ordering::Equal)
-            | (Ordering::Equal, Ordering::Greater)
-            | (Ordering::Greater, Ordering::Greater) => {
+            (Ordering::Greater, Ordering::Equal) |
+            (Ordering::Equal, Ordering::Greater) |
+            (Ordering::Greater, Ordering::Greater) => {
                 // increased blob fee: recheck pending pool and remove all that are no longer valid
                 let removed =
                     self.pending_pool.update_blob_fee(self.all_transactions.pending_fees.blob_fee);
@@ -1309,9 +1309,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
                         cumulative_cost += tx.transaction.cost();
                         if tx.transaction.is_eip4844() && cumulative_cost > on_chain_balance {
                             // the transaction would shift
-                            return Err(InsertErr::Overdraft {
-                                transaction: Arc::new(new_blob_tx),
-                            });
+                            return Err(InsertErr::Overdraft { transaction: Arc::new(new_blob_tx) });
                         }
                     }
                 }
@@ -1335,8 +1333,8 @@ impl<T: PoolTransaction> AllTransactions<T> {
         let price_bump = price_bumps.price_bump(existing_transaction.tx_type());
         let price_bump_multiplier = (100 + price_bump) / 100;
 
-        if maybe_replacement.max_fee_per_gas()
-            <= existing_transaction.max_fee_per_gas() * price_bump_multiplier
+        if maybe_replacement.max_fee_per_gas() <=
+            existing_transaction.max_fee_per_gas() * price_bump_multiplier
         {
             return true;
         }
@@ -1346,10 +1344,10 @@ impl<T: PoolTransaction> AllTransactions<T> {
         let replacement_max_priority_fee_per_gas =
             maybe_replacement.transaction.max_priority_fee_per_gas().unwrap_or(0);
 
-        if replacement_max_priority_fee_per_gas
-            <= existing_max_priority_fee_per_gas * price_bump_multiplier
-            && existing_max_priority_fee_per_gas != 0
-            && replacement_max_priority_fee_per_gas != 0
+        if replacement_max_priority_fee_per_gas <=
+            existing_max_priority_fee_per_gas * price_bump_multiplier &&
+            existing_max_priority_fee_per_gas != 0 &&
+            replacement_max_priority_fee_per_gas != 0
         {
             return true;
         }
@@ -1361,8 +1359,8 @@ impl<T: PoolTransaction> AllTransactions<T> {
             // this enforces that blob txs can only be replaced by blob txs
             let replacement_max_blob_fee_per_gas =
                 maybe_replacement.transaction.max_fee_per_blob_gas().unwrap_or(0);
-            if replacement_max_blob_fee_per_gas
-                <= existing_max_blob_fee_per_gas * price_bump_multiplier
+            if replacement_max_blob_fee_per_gas <=
+                existing_max_blob_fee_per_gas * price_bump_multiplier
             {
                 return true;
             }

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -1415,6 +1415,9 @@ impl<T: PoolTransaction> AllTransactions<T> {
         let mut cumulative_cost = U256::ZERO;
         let mut updates = Vec::new();
 
+        // Current tx does not exceed block gas limit after ensure_valid check
+        state.insert(TxState::NOT_TOO_MUCH_GAS);
+        
         // identifier of the ancestor transaction, will be None if the transaction is the next tx of
         // the sender
         let ancestor = TransactionId::ancestor(
@@ -1455,11 +1458,6 @@ impl<T: PoolTransaction> AllTransactions<T> {
         }
         if fee_cap >= self.pending_fees.base_fee as u128 {
             state.insert(TxState::ENOUGH_FEE_CAP_BLOCK);
-        }
-
-        // Ensure tx does not exceed block gas limit
-        if transaction.gas_limit() < self.block_gas_limit {
-            state.insert(TxState::NOT_TOO_MUCH_GAS);
         }
 
         // placeholder for the replaced transaction, if any
@@ -2489,6 +2487,19 @@ mod tests {
             pool.insert_tx(f.validated(tx), on_chain_balance, on_chain_nonce),
             Err(InsertErr::TxGasLimitMoreThanAvailableBlockGas { .. })
         ));
+    }
+
+    #[test]
+    fn test_tx_equal_gas_limit() {
+        let on_chain_balance = U256::from(1_000);
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = AllTransactions::default();
+
+        let tx = MockTransaction::eip1559().with_gas_limit(30_000_000);
+
+        let InsertOk {state, .. } =  pool.insert_tx(f.validated(tx), on_chain_balance, on_chain_nonce).unwrap();
+        assert!(state.contains(TxState::NOT_TOO_MUCH_GAS));
     }
 
     #[test]


### PR DESCRIPTION
I found the following issue when I was doing a one block one transaction test (for benchmarking).

In short, the insert transaction function does not mark a transaction as `TxState::NOT_TOO_MUCH_GAS` when its **gas limit is equal to the Block gas limit**.

- I tried on Geth to do a test and found that this kind of transaction seems to be legal since the constraint is only not to exceed the Block Gas Limit, [test here](https://github.com/ABCDELabs/go-ethereum/commit/da09b8e7f52c62bf314a941d748d82c2a322a915#diff-6083272455b210c86aaa70e7a348d038d2867870cedb4d402b4909abef8fa23bR1539-R1565)
- I found that the [`ensure_valid`](https://github.com/paradigmxyz/reth/blob/main/crates/transaction-pool/src/pool/txpool.rs#L1238-L1265) function already handles the case where the transaction's gas limit is greater than the block's gas limit. Therefore, passing through ensure_valid transactions could be all be marked as `TxState::NOT_TOO_MUCH_GAS`.
- It also make the logic for the evaluation [here](https://github.com/paradigmxyz/reth/blob/main/crates/transaction-pool/src/pool/txpool.rs#L1460-L1463) seemed a bit redundant, so I made some modifications and added a new unit test.