### PR TITLE
bin: run `reth` by default

### DIFF
--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 homepage.workspace = true
 repository.workspace = true
 description = "Reth node implementation"
+default-run = "reth"
 
 [package.metadata.cargo-udeps.ignore]
 normal = [


### PR DESCRIPTION
## Description

Add [`default-run`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-default-run-field) specification to run `reth` binary by default. 