### PR TITLE
log(downloader): log `count` instead of `distance`

### DIFF
--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -313,12 +313,12 @@ where
         }
 
         // Check if the provided range is the next expected range.
+        let count = *range.end() - *range.start() + 1; // range is inclusive
         let is_next_consecutive_range = *range.start() == *self.download_range.end() + 1;
-        let distance = *range.end() - *range.start();
         if is_next_consecutive_range {
             // New range received.
             tracing::trace!(target: "downloaders::bodies", ?range, "New download range set");
-            info!(target: "downloaders::bodies", distance, "Downloading bodies {range:?}");
+            info!(target: "downloaders::bodies", count, ?range, "Downloading bodies");
             self.download_range = range;
             return Ok(())
         }
@@ -326,7 +326,7 @@ where
         // The block range is reset. This can happen either after unwind or after the bodies were
         // written by external services (e.g. BlockchainTree).
         tracing::trace!(target: "downloaders::bodies", ?range, prev_range = ?self.download_range, "Download range reset");
-        info!(target: "downloaders::bodies", distance, "Downloading bodies {range:?}");
+        info!(target: "downloaders::bodies", count, ?range, "Downloading bodies");
         self.clear();
         self.download_range = range;
         Ok(())


### PR DESCRIPTION
## Description

Log `count` of downloaded bodies instead of `distance`.