### PR TITLE
perf(tree): cache canonical trie updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5812,6 +5812,7 @@ dependencies = [
  "reth-provider",
  "reth-revm",
  "reth-stages",
+ "reth-trie",
  "tokio",
  "tracing",
 ]

--- a/crates/blockchain-tree/Cargo.toml
+++ b/crates/blockchain-tree/Cargo.toml
@@ -23,6 +23,7 @@ reth-interfaces.workspace = true
 reth-db.workspace = true
 reth-provider.workspace = true
 reth-stages.workspace = true
+reth-trie.workspace = true
 
 # common
 parking_lot.workspace = true

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -859,12 +859,12 @@ impl<DB: Database, EF: ExecutorFactory> BlockchainTree<DB, EF> {
         &mut self,
         hashes: impl IntoIterator<Item = impl Into<BlockNumHash>>,
     ) -> RethResult<()> {
-        // check unconnected block buffer for childs of the canonical hashes
+        // check unconnected block buffer for children of the canonical hashes
         for added_block in hashes.into_iter() {
             self.try_connect_buffered_blocks(added_block.into())
         }
 
-        // check unconnected block buffer for childs of the chains
+        // check unconnected block buffer for children of the chains
         let mut all_chain_blocks = Vec::new();
         for (_, chain) in self.state.chains.iter() {
             for (&number, blocks) in chain.blocks().iter() {
@@ -969,7 +969,7 @@ impl<DB: Database, EF: ExecutorFactory> BlockchainTree<DB, EF> {
     /// # Note
     ///
     /// This unwinds the database if necessary, i.e. if parts of the canonical chain have been
-    /// re-orged.
+    /// reorged.
     ///
     /// # Returns
     ///
@@ -1160,29 +1160,41 @@ impl<DB: Database, EF: ExecutorFactory> BlockchainTree<DB, EF> {
         chain: Chain,
         recorder: &mut MakeCanonicalDurationsRecorder,
     ) -> RethResult<()> {
-        // Compute state root before opening write transaction.
-        let hashed_state = chain.state().hash_state_slow();
-        let (state_root, trie_updates) = chain
-            .state()
-            .state_root_calculator(
-                self.externals.provider_factory.provider()?.tx_ref(),
-                &hashed_state,
-            )
-            .root_with_updates()
-            .map_err(Into::<DatabaseError>::into)?;
-        let tip = chain.tip();
-        if state_root != tip.state_root {
-            return Err(RethError::Provider(ProviderError::StateRootMismatch(Box::new(
-                RootMismatch {
-                    root: GotExpected { got: state_root, expected: tip.state_root },
-                    block_number: tip.number,
-                    block_hash: tip.hash,
-                },
-            ))))
-        }
+        let (blocks, state, chain_trie_updates) = chain.into_inner();
+        let hashed_state = state.hash_state_slow();
+
+        // Compute state root or retrieve cached trie updates before opening write transaction.
+        let trie_updates = match chain_trie_updates {
+            Some(updates) => {
+                debug!(target: "blockchain_tree", ?blocks, "Using cached trie updates");
+                self.metrics.trie_updates_insert_cached.increment(1);
+                updates
+            }
+            None => {
+                debug!(target: "blockchain_tree", ?blocks, "Recomputing state root for insert");
+                let (state_root, trie_updates) = state
+                    .state_root_calculator(
+                        self.externals.provider_factory.provider()?.tx_ref(),
+                        &hashed_state,
+                    )
+                    .root_with_updates()
+                    .map_err(Into::<DatabaseError>::into)?;
+                let tip = blocks.tip();
+                if state_root != tip.state_root {
+                    return Err(RethError::Provider(ProviderError::StateRootMismatch(Box::new(
+                        RootMismatch {
+                            root: GotExpected { got: state_root, expected: tip.state_root },
+                            block_number: tip.number,
+                            block_hash: tip.hash,
+                        },
+                    ))));
+                }
+                self.metrics.trie_updates_insert_recomputed.increment(1);
+                trie_updates
+            }
+        };
         recorder.record_relative(MakeCanonicalAction::RetrieveStateTrieUpdates);
 
-        let (blocks, state) = chain.into_inner();
         let provider_rw = self.externals.provider_factory.provider_rw()?;
         provider_rw
             .append_blocks_with_state(

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1164,14 +1164,16 @@ impl<DB: Database, EF: ExecutorFactory> BlockchainTree<DB, EF> {
         let hashed_state = state.hash_state_slow();
 
         // Compute state root or retrieve cached trie updates before opening write transaction.
+        let block_hash_numbers =
+            blocks.iter().map(|(number, b)| (number, b.hash)).collect::<Vec<_>>();
         let trie_updates = match chain_trie_updates {
             Some(updates) => {
-                debug!(target: "blockchain_tree", ?blocks, "Using cached trie updates");
+                debug!(target: "blockchain_tree", blocks = ?block_hash_numbers, "Using cached trie updates");
                 self.metrics.trie_updates_insert_cached.increment(1);
                 updates
             }
             None => {
-                debug!(target: "blockchain_tree", ?blocks, "Recomputing state root for insert");
+                debug!(target: "blockchain_tree", blocks = ?block_hash_numbers, "Recomputing state root for insert");
                 let (state_root, trie_updates) = state
                     .state_root_calculator(
                         self.externals.provider_factory.provider()?.tx_ref(),

--- a/crates/blockchain-tree/src/metrics.rs
+++ b/crates/blockchain-tree/src/metrics.rs
@@ -19,6 +19,10 @@ pub struct TreeMetrics {
     pub latest_reorg_depth: Gauge,
     /// Longest sidechain height
     pub longest_sidechain_height: Gauge,
+    /// The number of times cached trie updates were used for insert.
+    pub trie_updates_insert_cached: Counter,
+    /// The number of times trie updates were recomputed for insert.
+    pub trie_updates_insert_recomputed: Counter,
 }
 
 /// Metrics for the blockchain tree block buffer

--- a/crates/consensus/auto-seal/src/task.rs
+++ b/crates/consensus/auto-seal/src/task.rs
@@ -192,8 +192,11 @@ where
 
                             debug!(target: "consensus::auto", header=?sealed_block_with_senders.hash(), "sending block notification");
 
-                            let chain =
-                                Arc::new(Chain::new(vec![sealed_block_with_senders], bundle_state));
+                            let chain = Arc::new(Chain::new(
+                                vec![sealed_block_with_senders],
+                                bundle_state,
+                                None,
+                            ));
 
                             // send block notification
                             let _ = canon_state_notification

--- a/crates/storage/provider/src/chain.rs
+++ b/crates/storage/provider/src/chain.rs
@@ -6,6 +6,7 @@ use reth_primitives::{
     Address, BlockHash, BlockNumHash, BlockNumber, ForkBlock, Receipt, SealedBlock,
     SealedBlockWithSenders, SealedHeader, TransactionSigned, TransactionSignedEcRecovered, TxHash,
 };
+use reth_trie::updates::TrieUpdates;
 use revm::db::BundleState;
 use std::{borrow::Cow, collections::BTreeMap, fmt};
 
@@ -24,6 +25,9 @@ pub struct Chain {
     ///
     /// This state also contains the individual changes that lead to the current state.
     state: BundleStateWithReceipts,
+    /// State trie updates after block is added to the chain.
+    /// NOTE: Currently, trie updates are present only if the block extends canonical chain.
+    trie_updates: Option<TrieUpdates>,
 }
 
 impl Chain {
@@ -31,13 +35,22 @@ impl Chain {
     pub fn new(
         blocks: impl IntoIterator<Item = SealedBlockWithSenders>,
         state: BundleStateWithReceipts,
+        trie_updates: Option<TrieUpdates>,
     ) -> Self {
-        Self { blocks: BTreeMap::from_iter(blocks.into_iter().map(|b| (b.number, b))), state }
+        Self {
+            blocks: BTreeMap::from_iter(blocks.into_iter().map(|b| (b.number, b))),
+            state,
+            trie_updates,
+        }
     }
 
     /// Create new Chain from a single block and its state.
-    pub fn from_block(block: SealedBlockWithSenders, state: BundleStateWithReceipts) -> Self {
-        Self::new([block], state)
+    pub fn from_block(
+        block: SealedBlockWithSenders,
+        state: BundleStateWithReceipts,
+        trie_updates: Option<TrieUpdates>,
+    ) -> Self {
+        Self::new([block], state, trie_updates)
     }
 
     /// Get the blocks in this chain.
@@ -101,8 +114,10 @@ impl Chain {
 
     /// Destructure the chain into its inner components, the blocks and the state at the tip of the
     /// chain.
-    pub fn into_inner(self) -> (ChainBlocks<'static>, BundleStateWithReceipts) {
-        (ChainBlocks { blocks: Cow::Owned(self.blocks) }, self.state)
+    pub fn into_inner(
+        self,
+    ) -> (ChainBlocks<'static>, BundleStateWithReceipts, Option<TrieUpdates>) {
+        (ChainBlocks { blocks: Cow::Owned(self.blocks) }, self.state, self.trie_updates)
     }
 
     /// Destructure the chain into its inner components, the blocks and the state at the tip of the
@@ -184,9 +199,15 @@ impl Chain {
 
     /// Append a single block with state to the chain.
     /// This method assumes that blocks attachment to the chain has already been validated.
-    pub fn append_block(&mut self, block: SealedBlockWithSenders, state: BundleStateWithReceipts) {
+    pub fn append_block(
+        &mut self,
+        block: SealedBlockWithSenders,
+        state: BundleStateWithReceipts,
+        trie_updates: Option<TrieUpdates>,
+    ) {
         self.blocks.insert(block.number, block);
         self.state.extend(state);
+        self.append_trie_updates(trie_updates);
     }
 
     /// Merge two chains by appending the given chain into the current one.
@@ -206,8 +227,21 @@ impl Chain {
         // Insert blocks from other chain
         self.blocks.extend(other.blocks);
         self.state.extend(other.state);
+        self.append_trie_updates(other.trie_updates);
 
         Ok(())
+    }
+
+    /// Append trie updates.
+    /// If existing or incoming trie updates are not set, reset as neither is valid anymore.
+    fn append_trie_updates(&mut self, other_trie_updates: Option<TrieUpdates>) {
+        if let Some((trie_updates, other)) = self.trie_updates.as_mut().zip(other_trie_updates) {
+            // Extend trie updates.
+            trie_updates.extend(other.into_iter());
+        } else {
+            // Reset trie updates as they are no longer valid.
+            self.trie_updates.take();
+        }
     }
 
     /// Split this chain at the given block.
@@ -257,12 +291,19 @@ impl Chain {
         let state = std::mem::take(&mut self.state);
         let (canonical_state, pending_state) = state.split_at(split_at);
 
+        // TODO: Currently, trie updates are reset on chain split.
+        // Add tests ensuring that it is valid to leave updates in the pending chain.
         ChainSplit::Split {
             canonical: Chain {
                 state: canonical_state.expect("split in range"),
                 blocks: self.blocks,
+                trie_updates: None,
             },
-            pending: Chain { state: pending_state, blocks: higher_number_blocks },
+            pending: Chain {
+                state: pending_state,
+                blocks: higher_number_blocks,
+                trie_updates: None,
+            },
         }
     }
 }
@@ -509,15 +550,21 @@ mod tests {
         let mut block_state_extended = block_state1.clone();
         block_state_extended.extend(block_state2.clone());
 
-        let chain = Chain::new(vec![block1.clone(), block2.clone()], block_state_extended);
+        let chain = Chain::new(vec![block1.clone(), block2.clone()], block_state_extended, None);
 
         let (split1_state, split2_state) = chain.state.clone().split_at(2);
 
-        let chain_split1 =
-            Chain { state: split1_state.unwrap(), blocks: BTreeMap::from([(1, block1.clone())]) };
+        let chain_split1 = Chain {
+            state: split1_state.unwrap(),
+            blocks: BTreeMap::from([(1, block1.clone())]),
+            trie_updates: None,
+        };
 
-        let chain_split2 =
-            Chain { state: split2_state, blocks: BTreeMap::from([(2, block2.clone())]) };
+        let chain_split2 = Chain {
+            state: split2_state,
+            blocks: BTreeMap::from([(2, block2.clone())]),
+            trie_updates: None,
+        };
 
         // return tip state
         assert_eq!(chain.state_at_block(block2.number), Some(chain.state.clone()));

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -2317,7 +2317,7 @@ impl<TX: DbTxMut + DbTx> BlockExecutionWriter for DatabaseProvider<TX> {
             }
         }
 
-        Ok(Chain::new(blocks, execution_state))
+        Ok(Chain::new(blocks, execution_state, None))
     }
 }
 

--- a/crates/trie/src/updates.rs
+++ b/crates/trie/src/updates.rs
@@ -41,7 +41,7 @@ impl TrieOp {
 }
 
 /// The aggregation of trie updates.
-#[derive(Debug, Default, Clone, Deref)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Deref)]
 pub struct TrieUpdates {
     trie_operations: HashMap<TrieKey, TrieOp>,
 }


### PR DESCRIPTION
## Description

Cache trie updates for in-memory chains that extend the canonical one and reuse them on insert. 
In essence, this PR optimistically caches trie updates that were computed upon receiving new payload, provided it extends the canonical chain, and reuses these updates during subsequent forkchoice update.

Cache invalidation is very strict:
- if chain split occurs, trie updates are discarded
- if two chains are merged and either one doesn't have trie updates, the other updates are discarded.

_Pending automated and live testing_