### PR TITLE
feat(tree): track state trie updates

### DIFF
--- a/crates/blockchain-tree/src/metrics.rs
+++ b/crates/blockchain-tree/src/metrics.rs
@@ -73,6 +73,8 @@ pub(crate) enum MakeCanonicalAction {
     MergeAllChains,
     /// Updating the canonical index during canonicalization.
     UpdateCanonicalIndex,
+    /// Retrieving (cached or recomputed) state trie updates
+    RetrieveStateTrieUpdates,
     /// Committing the canonical chain to the database.
     CommitCanonicalChainToDatabase,
     /// Reverting the canonical chain from the database.
@@ -90,6 +92,7 @@ impl MakeCanonicalAction {
             MakeCanonicalAction::SplitChainForks => "split chain forks",
             MakeCanonicalAction::MergeAllChains => "merge all chains",
             MakeCanonicalAction::UpdateCanonicalIndex => "update canonical index",
+            MakeCanonicalAction::RetrieveStateTrieUpdates => "retrieve state trie updates",
             MakeCanonicalAction::CommitCanonicalChainToDatabase => {
                 "commit canonical chain to database"
             }


### PR DESCRIPTION
## Description

Separately track the time taken to retrieve state trie updates.

Relates to #5871
