### PR TITLE
feat: add `nonce_after_all_transactions` implementation for `TxPool`

### DIFF
--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -1630,7 +1630,7 @@ impl<T: PoolTransaction> Default for AllTransactions<T> {
             by_hash: Default::default(),
             txs: Default::default(),
             tx_counter: Default::default(),
-            last_seen_block_number: 0,
+            last_seen_block_number: Default::default(),
             last_seen_block_hash: Default::default(),
             pending_fees: Default::default(),
             price_bumps: Default::default(),


### PR DESCRIPTION

### Description

This pull request introduces the implementation of the `nonce_after_all_transactions` method within the `TxPool` structure. The new method computes the next nonce for a specific sender by incorporating all transactions currently present in the transaction pool.

