### PR TITLE
chore: improve ipc error message

### DIFF
--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -122,6 +122,7 @@ where
         let connection_guard = ConnectionGuard::new(self.cfg.max_connections as usize);
 
         let mut connections = FutureDriver::default();
+        let endpoint_path = self.endpoint.path().to_string();
         let incoming = match self.endpoint.incoming() {
             Ok(connections) => {
                 #[cfg(windows)]
@@ -129,7 +130,8 @@ where
                 Incoming::new(connections)
             }
             Err(err) => {
-                on_ready.send(Err(err.to_string())).ok();
+                let msg = format!("failed to listen on ipc endpoint `{endpoint_path}`: {err}");
+                on_ready.send(Err(msg)).ok();
                 return Err(err)
             }
         };


### PR DESCRIPTION
ref #5907

adds more context to the error that we throw.