### PR TITLE
fix: also adjust ipc path

### DIFF
--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -195,6 +195,7 @@ impl RpcServerArgs {
     /// * The `auth_port` is scaled by a factor of `instance * 100`
     /// * The `http_port` is scaled by a factor of `-instance`
     /// * The `ws_port` is scaled by a factor of `instance * 2`
+    /// * The `ipcpath` is appended with the instance number: `/tmp/reth.ipc-<instance>`
     ///
     /// # Panics
     /// Warning: if `instance` is zero in debug mode, this will panic.
@@ -212,6 +213,10 @@ impl RpcServerArgs {
         self.http_port -= instance - 1;
         // ws port is scaled by a factor of instance * 2
         self.ws_port += instance * 2 - 2;
+
+        // also adjust the ipc path by appending the instance number to the path used for the
+        // endpoint
+        self.ipcpath = format!("{}-{}", self.ipcpath, instance);
     }
 
     /// Configures and launches _all_ servers.


### PR DESCRIPTION
Closes #5907

the ipc path wasn't adjusted when running multiple instances leading to race conditions in the rpc setup