### PR TITLE
chore(storage): warning log about long read db transaction

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -13,7 +13,7 @@ use crate::{
 use parking_lot::RwLock;
 use reth_interfaces::db::{DatabaseWriteError, DatabaseWriteOperation};
 use reth_libmdbx::{ffi::DBI, CommitLatency, Transaction, TransactionKind, WriteFlags, RW};
-use reth_tracing::tracing::debug;
+use reth_tracing::tracing::warn;
 use std::{
     backtrace::Backtrace,
     marker::PhantomData,
@@ -192,7 +192,7 @@ impl<K: TransactionKind> MetricsHandler<K> {
                 self.backtrace_recorded.store(true, Ordering::Relaxed);
 
                 let backtrace = Backtrace::force_capture();
-                debug!(
+                warn!(
                     target: "storage::db::mdbx",
                     ?open_duration,
                     ?backtrace,


### PR DESCRIPTION
Debug level logs are not written to stdout by default, and the file logging might be not set up properly (e.g. when running in a docker container, and losing the volume data). This long read db transaction log is written very rarely, so it's fine to make it a warning level to make it visible in the default stdout log.