### PR TITLE
Fix full mode sender_recovery distance

### DIFF
--- a/bin/reth/src/args/pruning_args.rs
+++ b/bin/reth/src/args/pruning_args.rs
@@ -24,7 +24,7 @@ impl PruningArgs {
             Some(PruneConfig {
                 block_interval: 5,
                 segments: PruneModes {
-                    sender_recovery: Some(PruneMode::Full),
+                    sender_recovery: Some(PruneMode::Distance(MINIMUM_PRUNING_DISTANCE)),
                     transaction_lookup: None,
                     receipts: chain_spec
                         .deposit_contract


### PR DESCRIPTION
According to [these docs](https://paradigmxyz.github.io/reth/run/pruning.html#full-node-1) `--full` mode flag should be equivalent to the following `reth.toml` prune config:

```
[prune]
block_interval = 5

[prune.parts]
sender_recovery = { distance = 10_064 }
# transaction_lookup is not pruned
receipts = { before = 11052984 } # Beacon Deposit Contract deployment block: https://etherscan.io/tx/0xe75fb554e433e03763a1560646ee22dcb74e5274b34c5ad644e7c0f619a7e1d0
account_history = { distance = 10_064 }
storage_history = { distance = 10_064 }

[prune.parts.receipts_log_filter]
# Prune all receipts, leaving only those which contain logs from address `0x00000000219ab540356cbb839cbe05303d7705fa`,
# starting from the block 11052984. This leaves receipts with the logs from the Beacon Deposit Contract.
"0x00000000219ab540356cbb839cbe05303d7705fa" = { before = 11052984 }
```

But when running the node with `--full` flag I'm getting the following output:

```
Pruner initialized prune_config=PruneConfig { block_interval: 5, segments: PruneModes { sender_recovery: Some(Full), transaction_lookup: None, receipts: Some(Before(11052984)), account_history: Some(Distance(10064)), storage_history: Some(Distance(10064)), receipts_log_filter: ReceiptsLogPruneConfig({0x00000000219ab540356cbb839cbe05303d7705fa: Before(11052984)}) } } — full
```

When I run the archive node with the mentioned `reth.toml` prune config I'm seeing:

```
Pruner initialized prune_config=PruneConfig { block_interval: 5, segments: PruneModes { sender_recovery: Some(Distance(10064)), transaction_lookup: None, receipts: Some(Before(11052984)), account_history: Some(Distance(10064)), storage_history: Some(Distance(10064)), receipts_log_filter: ReceiptsLogPruneConfig({0x00000000219ab540356cbb839cbe05303d7705fa: Before(11052984)}) } }
```

The difference is in `sender_recovery: Some(Full)` vs. `sender_recovery: Some(Distance(10064))`. This PR changes `sender_recovery` for `--full` node to reflect info from the docs. If this is not the intended behavior I would update the docs to avoid confusion. 
