### PR TITLE
chore: move BeaconConsensus to its own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5726,8 +5726,8 @@ dependencies = [
  "cfg-if",
  "futures",
  "metrics 0.21.1",
+ "reth-beacon-consensus-core",
  "reth-blockchain-tree",
- "reth-consensus-common",
  "reth-db",
  "reth-downloaders",
  "reth-interfaces",
@@ -5750,6 +5750,15 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+]
+
+[[package]]
+name = "reth-beacon-consensus-core"
+version = "0.1.0-alpha.13"
+dependencies = [
+ "reth-consensus-common",
+ "reth-interfaces",
+ "reth-primitives",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/config/",
     "crates/consensus/auto-seal/",
     "crates/consensus/beacon/",
+    "crates/consensus/beacon-core/",
     "crates/consensus/common/",
     "crates/ethereum-forks/",
     "crates/interfaces/",
@@ -96,6 +97,7 @@ reth = { path = "bin/reth" }
 reth-auto-seal-consensus = { path = "crates/consensus/auto-seal" }
 reth-basic-payload-builder = { path = "crates/payload/basic" }
 reth-beacon-consensus = { path = "crates/consensus/beacon" }
+reth-beacon-consensus-core = { path = "crates/consensus/beacon-core" }
 reth-blockchain-tree = { path = "crates/blockchain-tree" }
 reth-codecs = { path = "crates/storage/codecs" }
 reth-config = { path = "crates/config" }

--- a/crates/consensus/beacon-core/Cargo.toml
+++ b/crates/consensus/beacon-core/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "reth-beacon-consensus-core"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+# reth
+reth-consensus-common.workspace = true
+reth-primitives.workspace = true
+reth-interfaces.workspace = true

--- a/crates/consensus/beacon-core/src/lib.rs
+++ b/crates/consensus/beacon-core/src/lib.rs
@@ -1,3 +1,20 @@
+//! Beacon consensus implementation.
+
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
+    html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
+    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
+)]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    unused_crate_dependencies,
+    unreachable_pub,
+    rustdoc::all
+)]
+#![deny(unused_must_use, rust_2018_idioms)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
 //! Consensus for ethereum network
 
 use reth_consensus_common::validation;

--- a/crates/consensus/beacon/Cargo.toml
+++ b/crates/consensus/beacon/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 
 [dependencies]
 # reth
-reth-consensus-common.workspace = true
+reth-beacon-consensus-core.workspace = true
 reth-primitives.workspace = true
 reth-interfaces.workspace = true
 reth-stages.workspace = true
@@ -21,7 +21,6 @@ reth-payload-builder.workspace = true
 reth-payload-validator.workspace = true
 reth-prune.workspace = true
 reth-snapshot.workspace = true
-reth-rpc-types-compat.workspace = true
 reth-tokio-util.workspace = true
 
 # async
@@ -47,6 +46,7 @@ reth-stages = { workspace = true, features = ["test-utils"] }
 reth-blockchain-tree = { workspace = true, features = ["test-utils"] }
 reth-db = { workspace = true, features = ["test-utils"] }
 reth-provider = { workspace = true, features = ["test-utils"] }
+reth-rpc-types-compat.workspace = true
 reth-tracing.workspace = true
 reth-revm.workspace = true
 reth-downloaders.workspace = true
@@ -55,12 +55,10 @@ assert_matches.workspace = true
 
 [features]
 optimism = [
-  "reth-consensus-common/optimism",
   "reth-primitives/optimism",
   "reth-interfaces/optimism",
   "reth-provider/optimism",
   "reth-rpc-types/optimism",
-  "reth-rpc-types-compat/optimism",
   "reth-payload-builder/optimism",
   "reth-blockchain-tree/optimism",
 ]

--- a/crates/consensus/beacon/src/lib.rs
+++ b/crates/consensus/beacon/src/lib.rs
@@ -5,12 +5,17 @@
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
     issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
-#![warn(missing_debug_implementations, missing_docs, unreachable_pub, rustdoc::all)]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    unused_crate_dependencies,
+    unreachable_pub,
+    rustdoc::all
+)]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
-mod beacon_consensus;
-pub use beacon_consensus::BeaconConsensus;
+pub use reth_beacon_consensus_core::BeaconConsensus;
 
 mod engine;
 pub use engine::*;


### PR DESCRIPTION
the beacon consensus crate is pretty heavy because it contains the entire engine impl.

But the actual `BeaconConsensus` type (trait Conensus impl) is useful standalone, for example for payload validation.

This extracts the `BeaconConsensus` and moves it to a standalone crate so it can be reused easily.