### PR TITLE
chore: move OP payload builder error to OP crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6252,6 +6252,7 @@ dependencies = [
  "reth-revm",
  "reth-transaction-pool",
  "revm",
+ "thiserror",
  "tracing",
 ]
 

--- a/crates/payload/builder/src/error.rs
+++ b/crates/payload/builder/src/error.rs
@@ -26,36 +26,25 @@ pub enum PayloadBuilderError {
     /// Thrown if the payload requests withdrawals before Shanghai activation.
     #[error("withdrawals set before Shanghai activation")]
     WithdrawalsBeforeShanghai,
-    /// Optimism specific payload building errors.
-    #[cfg(feature = "optimism")]
+    /// Any other payload building errors.
     #[error(transparent)]
-    Optimism(#[from] OptimismPayloadBuilderError),
+    Other(Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl PayloadBuilderError {
+    /// Create a new error from a boxed error.
+    pub fn other<E>(error: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        PayloadBuilderError::Other(Box::new(error))
+    }
 }
 
 impl From<ProviderError> for PayloadBuilderError {
     fn from(error: ProviderError) -> Self {
         PayloadBuilderError::Internal(RethError::Provider(error))
     }
-}
-
-/// Optimism specific payload building errors.
-#[cfg(feature = "optimism")]
-#[derive(Debug, thiserror::Error)]
-pub enum OptimismPayloadBuilderError {
-    /// Thrown when a transaction fails to convert to a
-    /// [reth_primitives::TransactionSignedEcRecovered].
-    #[error("failed to convert deposit transaction to TransactionSignedEcRecovered")]
-    TransactionEcRecoverFailed,
-    /// Thrown when the L1 block info could not be parsed from the calldata of the
-    /// first transaction supplied in the payload attributes.
-    #[error("failed to parse L1 block info from L1 info tx calldata")]
-    L1BlockInfoParseFailed,
-    /// Thrown when a database account could not be loaded.
-    #[error("failed to load account {0:?}")]
-    AccountLoadFailed(revm_primitives::Address),
-    /// Thrown when force deploy of create2deployer code fails.
-    #[error("failed to force create2deployer account code")]
-    ForceCreate2DeployerFail,
 }
 
 impl From<oneshot::error::RecvError> for PayloadBuilderError {

--- a/crates/payload/optimism/Cargo.toml
+++ b/crates/payload/optimism/Cargo.toml
@@ -25,6 +25,8 @@ revm.workspace = true
 
 # misc
 tracing.workspace = true
+thiserror.workspace = true
+
 
 [features]
 # This is a workaround for reth-cli crate to allow this as mandatory dependency without breaking the build even if unused.

--- a/crates/payload/optimism/src/error.rs
+++ b/crates/payload/optimism/src/error.rs
@@ -1,0 +1,20 @@
+//! Error type
+
+/// Optimism specific payload building errors.
+#[derive(Debug, thiserror::Error)]
+pub enum OptimismPayloadBuilderError {
+    /// Thrown when a transaction fails to convert to a
+    /// [reth_primitives::TransactionSignedEcRecovered].
+    #[error("failed to convert deposit transaction to TransactionSignedEcRecovered")]
+    TransactionEcRecoverFailed,
+    /// Thrown when the L1 block info could not be parsed from the calldata of the
+    /// first transaction supplied in the payload attributes.
+    #[error("failed to parse L1 block info from L1 info tx calldata")]
+    L1BlockInfoParseFailed,
+    /// Thrown when a database account could not be loaded.
+    #[error("failed to load account {0:?}")]
+    AccountLoadFailed(reth_primitives::Address),
+    /// Thrown when force deploy of create2deployer code fails.
+    #[error("failed to force create2deployer account code")]
+    ForceCreate2DeployerFail,
+}

--- a/crates/payload/optimism/src/lib.rs
+++ b/crates/payload/optimism/src/lib.rs
@@ -10,13 +10,13 @@
 #[cfg(feature = "optimism")]
 pub use builder::*;
 
+pub mod error;
+
 #[cfg(feature = "optimism")]
 mod builder {
+    use crate::error::OptimismPayloadBuilderError;
     use reth_basic_payload_builder::*;
-    use reth_payload_builder::{
-        error::{OptimismPayloadBuilderError, PayloadBuilderError},
-        BuiltPayload,
-    };
+    use reth_payload_builder::{error::PayloadBuilderError, BuiltPayload};
     use reth_primitives::{
         constants::BEACON_NONCE,
         proofs,
@@ -158,7 +158,7 @@ mod builder {
             &mut db,
         )
         .map_err(|_| {
-            PayloadBuilderError::Optimism(OptimismPayloadBuilderError::ForceCreate2DeployerFail)
+            PayloadBuilderError::other(OptimismPayloadBuilderError::ForceCreate2DeployerFail)
         })?;
 
         let mut receipts = Vec::new();
@@ -173,9 +173,7 @@ mod builder {
             // Deposit transactions do not have signatures, so if the tx is a deposit, this
             // will just pull in its `from` address.
             let sequencer_tx = sequencer_tx.clone().try_into_ecrecovered().map_err(|_| {
-                PayloadBuilderError::Optimism(
-                    OptimismPayloadBuilderError::TransactionEcRecoverFailed,
-                )
+                PayloadBuilderError::other(OptimismPayloadBuilderError::TransactionEcRecoverFailed)
             })?;
 
             // Cache the depositor account prior to the state transition for the deposit nonce.
@@ -190,7 +188,7 @@ mod builder {
                 })
                 .transpose()
                 .map_err(|_| {
-                    PayloadBuilderError::Optimism(OptimismPayloadBuilderError::AccountLoadFailed(
+                    PayloadBuilderError::other(OptimismPayloadBuilderError::AccountLoadFailed(
                         sequencer_tx.signer(),
                     ))
                 })?;


### PR DESCRIPTION
move error type to op crate and add `PayloadBuilderError::other`