### PR TITLE
feat(storage): handle-slow-readers callback for MDBX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4036,6 +4036,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
+name = "libffi"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce826c243048e3d5cec441799724de52e2d42f820468431fc3fceee2341871e2"
+dependencies = [
+ "libc",
+ "libffi-sys",
+]
+
+[[package]]
+name = "libffi-sys"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36115160c57e8529781b4183c2bb51fdc1f6d6d1ed345591d84be7703befb3c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6080,6 +6099,7 @@ dependencies = [
  "derive_more",
  "indexmap 2.1.0",
  "libc",
+ "libffi",
  "parking_lot 0.12.1",
  "pprof",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5852,6 +5852,7 @@ dependencies = [
  "itertools 0.12.0",
  "metrics 0.21.1",
  "modular-bitfield",
+ "once_cell",
  "page_size",
  "parity-scale-codec",
  "parking_lot 0.12.1",

--- a/crates/storage/db/Cargo.toml
+++ b/crates/storage/db/Cargo.toml
@@ -52,6 +52,7 @@ itertools.workspace = true
 arbitrary = { workspace = true, features = ["derive"], optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
+once_cell = "1.19.0"
 
 [dev-dependencies]
 # reth libs with arbitrary

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -12,7 +12,8 @@ use metrics::{gauge, Label};
 use once_cell::sync::Lazy;
 use reth_interfaces::db::LogLevel;
 use reth_libmdbx::{
-    DatabaseFlags, Environment, EnvironmentFlags, Geometry, Mode, PageSize, SyncMode, RO, RW,
+    DatabaseFlags, Environment, EnvironmentFlags, Geometry, HandleSlowReadersReturnCode, Mode,
+    PageSize, SyncMode, RO, RW,
 };
 use reth_tracing::tracing::{error, warn};
 use std::{ops::Deref, path::Path};
@@ -178,7 +179,7 @@ impl DatabaseEnv {
         });
         let _ = *PROCESS_ID; // Initialize the process ID at the time of environment opening
         inner_env.set_handle_slow_readers(
-            |process_id: u32, thread_id: u32, read_txn_id: u64, gap: usize, space: usize, retry: isize| -> i32 {
+            |process_id: u32, thread_id: u32, read_txn_id: u64, gap: usize, space: usize, retry: isize| {
             if space > MAX_SAFE_READER_SPACE {
                 let message = if process_id == *PROCESS_ID {
                     "Current process has a long-lived database transaction that grows the database file."
@@ -197,7 +198,7 @@ impl DatabaseEnv {
                 )
             }
 
-            0
+            HandleSlowReadersReturnCode::ProceedWithoutKillingReader
         });
         inner_env.set_flags(EnvironmentFlags {
             mode,

--- a/crates/storage/libmdbx-rs/Cargo.toml
+++ b/crates/storage/libmdbx-rs/Cargo.toml
@@ -17,6 +17,7 @@ byteorder = "1"
 derive_more = "0.99"
 indexmap = "2"
 libc = "0.2"
+libffi = "3.2.0"
 parking_lot.workspace = true
 thiserror.workspace = true
 

--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -871,9 +871,13 @@ impl EnvironmentBuilder {
     }
 }
 
+/// Creates an instance of `MDBX_hsr_func`.
+///
+/// Caution: this leaks the memory for callbacks, so they're alive throughout the program. It's
+/// fine, because we also expect the database environment to be alive during this whole time.
 unsafe fn handle_slow_readers_callback(callback: HandleSlowReadersCallback) -> MDBX_hsr_func {
-    // Move the callback function to heap and intionally leak it, so it's not dropped and the MDBX
-    // env can use it throughout the whole program.
+    // Move the callback function to heap and intentionally leak it, so it's not dropped and the
+    // MDBX env can use it throughout the whole program.
     let callback = Box::leak(Box::new(callback));
 
     // Wrap the callback into an ffi binding. The callback is needed for a nicer UX with Rust types,

--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -663,11 +663,12 @@ impl EnvironmentBuilder {
                         )
                     };
                     let closure = libffi::high::Closure8::new(&hsr);
+                    let closure_ptr = *closure.code_ptr();
+                    std::mem::forget(closure);
                     mdbx_result(ffi::mdbx_env_set_hsr(
                         env,
-                        Some(std::mem::transmute(closure.code_ptr())),
+                        Some(std::mem::transmute(closure_ptr)),
                     ))?;
-                    std::mem::forget(closure);
                 }
 
                 #[cfg(unix)]

--- a/crates/storage/libmdbx-rs/src/lib.rs
+++ b/crates/storage/libmdbx-rs/src/lib.rs
@@ -14,7 +14,7 @@ pub use crate::{
     database::Database,
     environment::{
         Environment, EnvironmentBuilder, EnvironmentKind, Geometry, HandleSlowReadersCallback,
-        Info, PageSize, Stat,
+        HandleSlowReadersReturnCode, Info, PageSize, Stat,
     },
     error::{Error, Result},
     flags::*,

--- a/crates/storage/libmdbx-rs/src/lib.rs
+++ b/crates/storage/libmdbx-rs/src/lib.rs
@@ -13,7 +13,8 @@ pub use crate::{
     cursor::{Cursor, Iter, IterDup},
     database::Database,
     environment::{
-        Environment, EnvironmentBuilder, EnvironmentKind, Geometry, Info, PageSize, Stat,
+        Environment, EnvironmentBuilder, EnvironmentKind, Geometry, HandleSlowReadersCallback,
+        Info, PageSize, Stat,
     },
     error::{Error, Result},
     flags::*,


### PR DESCRIPTION
MDBX provides an ability to set the callback for handling long-lived read transactions (aka handle-slow-readers aka HSR callback) when the database file needs to grow. Using this callback, you can try to:
- Try to abort the read transaction inside your program by transaction ID (note, that you don't have the MDBX transaction object, so you need to have the bookkeeping for all open transactions in your code)
- Kill the process or the thread with this read transaction by process or thread id, respectively.
- Do nothing

Currently, I went for just "Do nothing" and emit the warning log, so either we could now that there's a read transaction leak, or the user would be aware of external process growing the database freelist.

---

Opened an infinite read transaction on database file and started syncing Sepolia. After a while, the node started reporting such logs:
```console
2024-01-05T16:27:25.879540Z  WARN storage::db::mdbx: process_id=1076048 thread_id=0 read_txn_id=11816 gap=1420 space=5899956224 retry=0 External process has a long-lived database transaction that grows the database file. Use shorter-lived read transactions or shut down the node.
2024-01-05T16:27:26.410057Z  INFO reth::commands::node::events: Executing stage pipeline_stages=5/13 stage=Execution checkpoint=3692729 target=5021184 stage_progress=18.41%
2024-01-05T16:27:31.731166Z  INFO reth::cli: Status connected_peers=46 freelist=1732899 stage=Execution checkpoint=3692729 target=5021184 stage_progress=18.41%
```