### PR TITLE
feat(cli): enable backtrace on panic by default

### DIFF
--- a/bin/reth/src/main.rs
+++ b/bin/reth/src/main.rs
@@ -9,6 +9,11 @@ compile_error!("Cannot build the `reth` binary with the `optimism` feature flag 
 
 #[cfg(not(feature = "optimism"))]
 fn main() {
+    // Enable backtraces unless a RUST_BACKTRACE value has already been explicitly provided.
+    if std::env::var("RUST_BACKTRACE").is_err() {
+        std::env::set_var("RUST_BACKTRACE", "1");
+    }
+
     if let Err(err) = reth::cli::run() {
         eprintln!("Error: {err:?}");
         std::process::exit(1);

--- a/bin/reth/src/optimism.rs
+++ b/bin/reth/src/optimism.rs
@@ -9,6 +9,11 @@ compile_error!("Cannot build the `op-reth` binary with the `optimism` feature fl
 
 #[cfg(feature = "optimism")]
 fn main() {
+    // Enable backtraces unless a RUST_BACKTRACE value has already been explicitly provided.
+    if std::env::var("RUST_BACKTRACE").is_err() {
+        std::env::set_var("RUST_BACKTRACE", "1");
+    }
+
     if let Err(err) = reth::cli::run() {
         eprintln!("Error: {err:?}");
         std::process::exit(1);


### PR DESCRIPTION
`RUST_BACKTRACE=1` only affects the backtrace reporting on panic. Unless explicitly disabled, we want to see full backtraces when an unexpected panic occurs.

Thanks https://github.com/sigp/lighthouse/commit/58012f85e18062939aa70d8df42f3d6f46c05dda