### PR TITLE
lints: use rust-2018-idioms to eliminate `#![allow(elided-lifetimes-in-paths)]`

### DIFF
--- a/crates/stages/benches/criterion.rs
+++ b/crates/stages/benches/criterion.rs
@@ -1,4 +1,4 @@
-#![allow(missing_docs, elided_lifetimes_in_paths)]
+#![allow(missing_docs)]
 use criterion::{
     async_executor::FuturesExecutor, criterion_group, criterion_main, measurement::WallTime,
     BenchmarkGroup, Criterion,
@@ -116,7 +116,7 @@ fn merkle(c: &mut Criterion) {
 
 fn measure_stage_with_path<F, S>(
     path: PathBuf,
-    group: &mut BenchmarkGroup<WallTime>,
+    group: &mut BenchmarkGroup<'_, WallTime>,
     setup: F,
     stage: S,
     stage_range: StageRange,
@@ -149,7 +149,7 @@ fn measure_stage_with_path<F, S>(
 }
 
 fn measure_stage<F, S>(
-    group: &mut BenchmarkGroup<WallTime>,
+    group: &mut BenchmarkGroup<'_, WallTime>,
     setup: F,
     stage: S,
     block_interval: std::ops::Range<u64>,

--- a/crates/storage/db/benches/criterion.rs
+++ b/crates/storage/db/benches/criterion.rs
@@ -1,4 +1,4 @@
-#![allow(missing_docs, elided_lifetimes_in_paths)]
+#![allow(missing_docs)]
 use criterion::{
     black_box, criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion,
 };
@@ -52,7 +52,7 @@ pub fn serialization(c: &mut Criterion) {
 }
 
 /// Measures `Encode`, `Decode`, `Compress` and `Decompress`.
-fn measure_table_serialization<T>(group: &mut BenchmarkGroup<WallTime>)
+fn measure_table_serialization<T>(group: &mut BenchmarkGroup<'_, WallTime>)
 where
     T: Table + Default,
     T::Key: Default + Clone + for<'de> serde::Deserialize<'de>,
@@ -117,7 +117,7 @@ where
 }
 
 /// Measures `SeqWrite`, `RandomWrite`, `SeqRead` and `RandomRead` using `cursor` and `tx.put`.
-fn measure_table_db<T>(group: &mut BenchmarkGroup<WallTime>)
+fn measure_table_db<T>(group: &mut BenchmarkGroup<'_, WallTime>)
 where
     T: Table + Default,
     T::Key: Default + Clone + for<'de> serde::Deserialize<'de>,
@@ -213,7 +213,7 @@ where
 }
 
 /// Measures `SeqWrite`, `RandomWrite` and `SeqRead`  using `cursor_dup` and `tx.put`.
-fn measure_dupsort_db<T>(group: &mut BenchmarkGroup<WallTime>)
+fn measure_dupsort_db<T>(group: &mut BenchmarkGroup<'_, WallTime>)
 where
     T: Table + Default + DupSort,
     T::Key: Default + Clone + for<'de> serde::Deserialize<'de>,

--- a/crates/storage/db/benches/hash_keys.rs
+++ b/crates/storage/db/benches/hash_keys.rs
@@ -1,4 +1,4 @@
-#![allow(missing_docs, elided_lifetimes_in_paths)]
+#![allow(missing_docs)]
 use criterion::{
     black_box, criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion,
 };
@@ -38,7 +38,7 @@ pub fn hash_keys(c: &mut Criterion) {
     }
 }
 
-fn measure_table_insertion<T>(group: &mut BenchmarkGroup<WallTime>, size: usize)
+fn measure_table_insertion<T>(group: &mut BenchmarkGroup<'_, WallTime>, size: usize)
 where
     T: Table + Default,
     T::Key: Default

--- a/crates/trie/benches/prefix_set.rs
+++ b/crates/trie/benches/prefix_set.rs
@@ -1,4 +1,4 @@
-#![allow(missing_docs, unreachable_pub, elided_lifetimes_in_paths)]
+#![allow(missing_docs, unreachable_pub)]
 use criterion::{
     black_box, criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion,
 };
@@ -58,7 +58,7 @@ pub fn prefix_set_lookups(c: &mut Criterion) {
 }
 
 fn prefix_set_bench<T: PrefixSetAbstraction>(
-    group: &mut BenchmarkGroup<WallTime>,
+    group: &mut BenchmarkGroup<'_, WallTime>,
     description: &str,
     (preload, input, expected): (Vec<Nibbles>, Vec<Nibbles>, Vec<bool>),
 ) {


### PR DESCRIPTION
## Description

This pull request addresses linting issues by adopting the `rust-2018-idioms`. It eliminates the need for `#![allow(elided-lifetimes-in-paths)]` within the codebase.

## Changes Made

- Removed `#![allow(elided-lifetimes-in-paths)]` from the project codebase.
- Updated code to adhere to Rust 2018 idioms for lifetimes in paths.


