### PR TITLE
doc: Improve documentation for `StageEnum` to remove `#[allow(missing_docs)]`

### DIFF
--- a/bin/reth/src/args/stage_args.rs
+++ b/bin/reth/src/args/stage_args.rs
@@ -1,19 +1,56 @@
 //! Shared arguments related to stages
 
-/// Represents a certain stage of the pipeline.
+/// Represents a specific stage within the data pipeline.
+///
+/// Different stages within the pipeline have dedicated functionalities and operations.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, clap::ValueEnum)]
-#[allow(missing_docs)]
 pub enum StageEnum {
+    /// The headers stage within the pipeline.
+    ///
+    /// This stage handles operations related to block headers.
     Headers,
+    /// The bodies stage within the pipeline.
+    ///
+    /// This stage deals with block bodies and their associated data.
     Bodies,
+    /// The senders stage within the pipeline.
+    ///
+    /// Responsible for sender-related processes and data recovery.
     Senders,
+    /// The execution stage within the pipeline.
+    ///
+    /// Handles the execution of transactions and contracts.
     Execution,
+    /// The account hashing stage within the pipeline.
+    ///
+    /// Manages operations related to hashing account data.
     AccountHashing,
+    /// The storage hashing stage within the pipeline.
+    ///
+    /// Manages operations related to hashing storage data.
     StorageHashing,
+    /// The hashing stage within the pipeline.
+    ///
+    /// Covers general data hashing operations.
     Hashing,
+    /// The Merkle stage within the pipeline.
+    ///
+    /// Handles Merkle tree-related computations and data processing.
     Merkle,
+    /// The transaction lookup stage within the pipeline.
+    ///
+    /// Deals with the retrieval and processing of transactions.
     TxLookup,
+    /// The account history stage within the pipeline.
+    ///
+    /// Manages historical data related to accounts.
     AccountHistory,
+    /// The storage history stage within the pipeline.
+    ///
+    /// Manages historical data related to storage.
     StorageHistory,
+    /// The total difficulty stage within the pipeline.
+    ///
+    /// Handles computations and data related to total difficulty.
     TotalDifficulty,
 }


### PR DESCRIPTION
### Description

This PR aims to enhance the documentation for the `StageEnum` enum type by providing detailed context for each stage. This improvement removes the `#[allow(missing_docs)]` directive by adding informative comments describing the role and functionality of each stage within the data pipeline.

