### PR TITLE
feat(`rpc-types`): use `alloy-trace-rpc-types` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,9 +217,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-rpc-trace-types"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy#f5174888c523b70fa1a94fad24f3214048d3d462"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types",
+ "itertools 0.12.0",
+ "jsonrpsee-types",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "alloy-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#ed5a0e820ae4ceecdaabc7ca737648c8f8072439"
+source = "git+https://github.com/alloy-rs/alloy#f5174888c523b70fa1a94fad24f3214048d3d462"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -272,21 +287,6 @@ dependencies = [
  "alloy-sol-macro",
  "const-hex",
  "serde",
-]
-
-[[package]]
-name = "alloy-trace-rpc-types"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#ed5a0e820ae4ceecdaabc7ca737648c8f8072439"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types",
- "itertools 0.12.0",
- "jsonrpsee-types",
- "serde",
- "serde_json",
- "thiserror",
 ]
 
 [[package]]
@@ -6596,8 +6596,8 @@ version = "0.1.0-alpha.13"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-rpc-trace-types",
  "alloy-rpc-types",
- "alloy-trace-rpc-types",
  "arbitrary",
  "bytes",
  "ethereum_ssz",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#e64c1c2b9e4f80fe13ac4f65504a4c30fe786454"
+source = "git+https://github.com/alloy-rs/alloy#ed5a0e820ae4ceecdaabc7ca737648c8f8072439"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -272,6 +272,21 @@ dependencies = [
  "alloy-sol-macro",
  "const-hex",
  "serde",
+]
+
+[[package]]
+name = "alloy-trace-rpc-types"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy#ed5a0e820ae4ceecdaabc7ca737648c8f8072439"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types",
+ "itertools 0.12.0",
+ "jsonrpsee-types",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -6582,6 +6597,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types",
+ "alloy-trace-rpc-types",
  "arbitrary",
  "bytes",
  "ethereum_ssz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,6 +161,7 @@ alloy-dyn-abi = "0.5"
 alloy-sol-types = "0.5"
 alloy-rlp = "0.3"
 alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", features = ["jsonrpsee-types"] }
+alloy-trace-rpc-types = { git = "https://github.com/alloy-rs/alloy", features = ["jsonrpsee-types"] }
 ethers-core = { version = "2.0", default-features = false }
 ethers-providers = { version = "2.0", default-features = false }
 ethers-signers = { version = "2.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,7 @@ alloy-dyn-abi = "0.5"
 alloy-sol-types = "0.5"
 alloy-rlp = "0.3"
 alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", features = ["jsonrpsee-types"] }
-alloy-trace-rpc-types = { git = "https://github.com/alloy-rs/alloy", features = ["jsonrpsee-types"] }
+alloy-rpc-trace-types = { git = "https://github.com/alloy-rs/alloy", features = ["jsonrpsee-types"] }
 ethers-core = { version = "2.0", default-features = false }
 ethers-providers = { version = "2.0", default-features = false }
 ethers-signers = { version = "2.0", default-features = false }

--- a/crates/rpc/rpc-types/Cargo.toml
+++ b/crates/rpc/rpc-types/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 alloy-rlp = { workspace = true, features = ["arrayvec", "derive"] }
 alloy-primitives = { workspace = true, features = ["rand", "rlp", "serde"] }
 alloy-rpc-types.workspace = true
+alloy-trace-rpc-types.workspace = true
 ethereum_ssz_derive = { version = "0.5", optional = true }
 ethereum_ssz = { version = "0.5", optional = true }
 

--- a/crates/rpc/rpc-types/Cargo.toml
+++ b/crates/rpc/rpc-types/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 alloy-rlp = { workspace = true, features = ["arrayvec", "derive"] }
 alloy-primitives = { workspace = true, features = ["rand", "rlp", "serde"] }
 alloy-rpc-types.workspace = true
-alloy-trace-rpc-types.workspace = true
+alloy-rpc-trace-types.workspace = true
 ethereum_ssz_derive = { version = "0.5", optional = true }
 ethereum_ssz = { version = "0.5", optional = true }
 

--- a/crates/rpc/rpc-types/src/lib.rs
+++ b/crates/rpc/rpc-types/src/lib.rs
@@ -24,7 +24,7 @@ pub mod serde_helpers;
 pub use alloy_rpc_types::*;
 pub mod trace {
     //! RPC types for trace endpoints and inspectors.
-    pub use alloy_trace_rpc_types::*;
+    pub use alloy_rpc_trace_types::*;
 }
 // Ethereum specific rpc types related to typed transaction requests and the engine API.
 pub use eth::{

--- a/crates/rpc/rpc-types/src/lib.rs
+++ b/crates/rpc/rpc-types/src/lib.rs
@@ -22,6 +22,10 @@ pub mod serde_helpers;
 
 // Ethereum specific rpc types coming from alloy.
 pub use alloy_rpc_types::*;
+pub mod trace {
+    //! RPC types for trace endpoints and inspectors.
+    pub use alloy_trace_rpc_types::*;
+}
 // Ethereum specific rpc types related to typed transaction requests and the engine API.
 pub use eth::{
     engine,


### PR DESCRIPTION
We've separated the tracing types into a new crate on alloy—this updates reth to use that behind a `trace` module in `reth-rpc-types`.

Unblocks using the revm reth inspectors on foundry with only alloy types instead of having to pull in reth.