### PR TITLE
chore: simplify Database impls

### DIFF
--- a/crates/revm/src/database.rs
+++ b/crates/revm/src/database.rs
@@ -47,26 +47,21 @@ impl<DB: StateProvider> Database for StateProviderDatabase<DB> {
     /// Returns `Ok` with `Some(AccountInfo)` if the account exists,
     /// `None` if it doesn't, or an error if encountered.
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
-        Ok(self.0.basic_account(address)?.map(|account| AccountInfo {
-            balance: account.balance,
-            nonce: account.nonce,
-            code_hash: account.bytecode_hash.unwrap_or(KECCAK_EMPTY),
-            code: None,
-        }))
+        DatabaseRef::basic_ref(self, address)
     }
 
     /// Retrieves the bytecode associated with a given code hash.
     ///
     /// Returns `Ok` with the bytecode if found, or the default bytecode otherwise.
     fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
-        Ok(self.0.bytecode_by_hash(code_hash)?.unwrap_or_default().0)
+        DatabaseRef::code_by_hash_ref(self, code_hash)
     }
 
     /// Retrieves the storage value at a specific index for a given address.
     ///
     /// Returns `Ok` with the storage value, or the default value if not found.
     fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
-        Ok(self.0.storage(address, B256::new(index.to_be_bytes()))?.unwrap_or_default())
+        DatabaseRef::storage_ref(self, address, index)
     }
 
     /// Retrieves the block hash for a given block number.
@@ -74,13 +69,7 @@ impl<DB: StateProvider> Database for StateProviderDatabase<DB> {
     /// Returns `Ok` with the block hash if found, or the default hash otherwise.
     /// Note: It safely casts the `number` to `u64`.
     fn block_hash(&mut self, number: U256) -> Result<B256, Self::Error> {
-        // Attempt to convert U256 to u64
-        let block_number = match number.try_into() {
-            Ok(value) => value,
-            Err(_) => return Err(Self::Error::BlockNumberOverflow(number)),
-        };
-
-        Ok(self.0.block_hash(block_number)?.unwrap_or_default())
+        DatabaseRef::block_hash_ref(self, number)
     }
 }
 


### PR DESCRIPTION
It's strange that DatabaseRef is not very useful.
Maybe the upstream revm should always impl `DatabaseRef` for type `T: Database` or offer a wrapper type directly.