### PR TITLE
feat(header): add `is_zero_difficulty` util function for POS

### DIFF
--- a/crates/consensus/beacon-core/src/lib.rs
+++ b/crates/consensus/beacon-core/src/lib.rs
@@ -55,9 +55,7 @@ impl Consensus for BeaconConsensus {
     ) -> Result<(), ConsensusError> {
         if self.chain_spec.fork(Hardfork::Paris).active_at_ttd(total_difficulty, header.difficulty)
         {
-            // EIP-3675: Upgrade consensus to Proof-of-Stake:
-            // https://eips.ethereum.org/EIPS/eip-3675#replacing-difficulty-with-0
-            if header.difficulty != U256::ZERO {
+            if !header.is_zero_difficulty() {
                 return Err(ConsensusError::TheMergeDifficultyIsNotZero)
             }
 

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1881,7 +1881,9 @@ mod tests {
     };
     use assert_matches::assert_matches;
     use reth_interfaces::test_utils::generators::{self, Rng};
-    use reth_primitives::{stage::StageCheckpoint, ChainSpec, ChainSpecBuilder, B256, MAINNET};
+    use reth_primitives::{
+        stage::StageCheckpoint, ChainSpec, ChainSpecBuilder, B256, MAINNET, U256,
+    };
     use reth_provider::{BlockWriter, ProviderFactory};
     use reth_rpc_types::engine::{ForkchoiceState, ForkchoiceUpdated, PayloadStatus};
     use reth_rpc_types_compat::engine::payload::try_block_to_payload_v1;

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -23,7 +23,7 @@ use reth_interfaces::{
 use reth_payload_builder::{PayloadBuilderAttributes, PayloadBuilderHandle};
 use reth_primitives::{
     constants::EPOCH_SLOTS, stage::StageId, BlockNumHash, BlockNumber, Head, Header, SealedBlock,
-    SealedHeader, B256, U256,
+    SealedHeader, B256,
 };
 use reth_provider::{
     BlockIdReader, BlockReader, BlockSource, CanonChainTracker, ChainSpecProvider, ProviderError,
@@ -490,7 +490,7 @@ where
 
             // we need to check if the parent block is the last POW block, if so then the payload is
             // the first POS. The engine API spec mandates a zero hash to be returned: <https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/paris.md#engine_newpayloadv1>
-            if parent_header.difficulty != U256::ZERO {
+            if !parent_header.is_zero_difficulty() {
                 return Some(B256::ZERO);
             }
 
@@ -506,7 +506,7 @@ where
         // Edge case: the `latestValid` field is the zero hash if the parent block is the terminal
         // PoW block, which we need to identify by looking at the parent's block difficulty
         if let Ok(Some(parent)) = self.blockchain.header_by_hash_or_number(parent_hash.into()) {
-            if parent.difficulty != U256::ZERO {
+            if !parent.is_zero_difficulty() {
                 parent_hash = B256::ZERO;
             }
         }

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -136,7 +136,7 @@ impl Header {
     ///
     /// Returns `true` if the block's difficulty matches the constant zero set by the EIP.
     pub fn is_zero_difficulty(&self) -> bool {
-        self.difficulty == U256::ZERO
+        self.difficulty.is_zero()
     }
 
     /// Performs a sanity check on the extradata field of the header.

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -126,6 +126,19 @@ impl Default for Header {
 }
 
 impl Header {
+    /// Checks if the block's difficulty is set to zero, indicating a Proof-of-Stake header.
+    ///
+    /// This function is linked to EIP-3675, proposing the consensus upgrade to Proof-of-Stake:
+    /// [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#replacing-difficulty-with-0)
+    ///
+    /// Verifies whether, as per the EIP, the block's difficulty is updated to zero,
+    /// signifying the transition to a Proof-of-Stake mechanism.
+    ///
+    /// Returns `true` if the block's difficulty matches the constant zero set by the EIP.
+    pub fn is_zero_difficulty(&self) -> bool {
+        self.difficulty == U256::ZERO
+    }
+
     /// Performs a sanity check on the extradata field of the header.
     ///
     /// # Errors


### PR DESCRIPTION
## Description

Adds a utility function `is_zero_difficulty` within the `Header` module to facilitate checking for zero difficulty, aligning with Proof-of-Stake (POS) headers.

## Details

- Introduces the `is_zero_difficulty` function within the `Header` module.
- Validates if the block's difficulty is set to zero, corresponding to the POS header specifications.

