### PR TITLE
feat(storage): log tx opening location

### DIFF
--- a/bin/reth/src/cli/db_type.rs
+++ b/bin/reth/src/cli/db_type.rs
@@ -54,7 +54,7 @@ impl DatabaseBuilder {
                 let db_path = data_dir.db_path();
 
                 tracing::info!(target: "reth::cli", path = ?db_path, "Opening database");
-                let db = Arc::new(init_db(db_path.clone(), log_level)?);
+                let db = Arc::new(init_db(db_path.clone(), log_level)?.with_metrics());
                 Ok(DatabaseInstance::Real { db, data_dir })
             }
         }

--- a/crates/storage/db/src/abstraction/database.rs
+++ b/crates/storage/db/src/abstraction/database.rs
@@ -54,10 +54,12 @@ impl<DB: Database> Database for Arc<DB> {
     type TX = <DB as Database>::TX;
     type TXMut = <DB as Database>::TXMut;
 
+    #[track_caller]
     fn tx(&self) -> Result<Self::TX, DatabaseError> {
         <DB as Database>::tx(self)
     }
 
+    #[track_caller]
     fn tx_mut(&self) -> Result<Self::TXMut, DatabaseError> {
         <DB as Database>::tx_mut(self)
     }
@@ -66,10 +68,13 @@ impl<DB: Database> Database for Arc<DB> {
 impl<DB: Database> Database for &DB {
     type TX = <DB as Database>::TX;
     type TXMut = <DB as Database>::TXMut;
+
+    #[track_caller]
     fn tx(&self) -> Result<Self::TX, DatabaseError> {
         <DB as Database>::tx(self)
     }
 
+    #[track_caller]
     fn tx_mut(&self) -> Result<Self::TXMut, DatabaseError> {
         <DB as Database>::tx_mut(self)
     }

--- a/crates/storage/db/src/abstraction/database.rs
+++ b/crates/storage/db/src/abstraction/database.rs
@@ -16,9 +16,11 @@ pub trait Database: Send + Sync + Sealed {
     type TXMut: DbTxMut + DbTx + TableImporter + Send + Sync + Debug + 'static;
 
     /// Create read only transaction.
+    #[track_caller]
     fn tx(&self) -> Result<Self::TX, DatabaseError>;
 
     /// Create read write transaction only possible if database is open with write access.
+    #[track_caller]
     fn tx_mut(&self) -> Result<Self::TXMut, DatabaseError>;
 
     /// Takes a function and passes a read-only transaction into it, making sure it's closed in the
@@ -54,12 +56,10 @@ impl<DB: Database> Database for Arc<DB> {
     type TX = <DB as Database>::TX;
     type TXMut = <DB as Database>::TXMut;
 
-    #[track_caller]
     fn tx(&self) -> Result<Self::TX, DatabaseError> {
         <DB as Database>::tx(self)
     }
 
-    #[track_caller]
     fn tx_mut(&self) -> Result<Self::TXMut, DatabaseError> {
         <DB as Database>::tx_mut(self)
     }
@@ -69,12 +69,10 @@ impl<DB: Database> Database for &DB {
     type TX = <DB as Database>::TX;
     type TXMut = <DB as Database>::TXMut;
 
-    #[track_caller]
     fn tx(&self) -> Result<Self::TX, DatabaseError> {
         <DB as Database>::tx(self)
     }
 
-    #[track_caller]
     fn tx_mut(&self) -> Result<Self::TXMut, DatabaseError> {
         <DB as Database>::tx_mut(self)
     }

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -48,6 +48,7 @@ impl Database for DatabaseEnv {
     type TX = tx::Tx<RO>;
     type TXMut = tx::Tx<RW>;
 
+    #[track_caller]
     fn tx(&self) -> Result<Self::TX, DatabaseError> {
         Ok(Tx::new_with_metrics(
             self.inner.begin_ro_txn().map_err(|e| DatabaseError::InitTx(e.into()))?,
@@ -55,6 +56,7 @@ impl Database for DatabaseEnv {
         ))
     }
 
+    #[track_caller]
     fn tx_mut(&self) -> Result<Self::TXMut, DatabaseError> {
         Ok(Tx::new_with_metrics(
             self.inner.begin_rw_txn().map_err(|e| DatabaseError::InitTx(e.into()))?,

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -48,7 +48,6 @@ impl Database for DatabaseEnv {
     type TX = tx::Tx<RO>;
     type TXMut = tx::Tx<RW>;
 
-    #[track_caller]
     fn tx(&self) -> Result<Self::TX, DatabaseError> {
         Ok(Tx::new_with_metrics(
             self.inner.begin_ro_txn().map_err(|e| DatabaseError::InitTx(e.into()))?,
@@ -56,7 +55,6 @@ impl Database for DatabaseEnv {
         ))
     }
 
-    #[track_caller]
     fn tx_mut(&self) -> Result<Self::TXMut, DatabaseError> {
         Ok(Tx::new_with_metrics(
             self.inner.begin_rw_txn().map_err(|e| DatabaseError::InitTx(e.into()))?,

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -57,10 +57,9 @@ impl<K: TransactionKind> Tx<K> {
             handler
         });
 
-        let caller = core::panic::Location::caller();
         debug!(
             target: "storage::db::mdbx",
-            %caller,
+            caller = %core::panic::Location::caller(),
             tx_id = inner.id(),
             read_only = K::IS_READ_ONLY,
             "Transaction opened",

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -101,6 +101,7 @@ impl<DB: Database> ProviderFactory<DB> {
     /// Returns a provider with a created `DbTx` inside, which allows fetching data from the
     /// database using different types of providers. Example: [`HeaderProvider`]
     /// [`BlockHashReader`]. This may fail if the inner read database transaction fails to open.
+    #[track_caller]
     pub fn provider(&self) -> ProviderResult<DatabaseProviderRO<DB>> {
         let mut provider = DatabaseProvider::new(self.db.tx()?, self.chain_spec.clone());
 
@@ -115,6 +116,7 @@ impl<DB: Database> ProviderFactory<DB> {
     /// data from the database using different types of providers. Example: [`HeaderProvider`]
     /// [`BlockHashReader`].  This may fail if the inner read/write database transaction fails to
     /// open.
+    #[track_caller]
     pub fn provider_rw(&self) -> ProviderResult<DatabaseProviderRW<DB>> {
         let mut provider = DatabaseProvider::new_rw(self.db.tx_mut()?, self.chain_spec.clone());
 
@@ -126,6 +128,7 @@ impl<DB: Database> ProviderFactory<DB> {
     }
 
     /// Storage provider for latest block
+    #[track_caller]
     pub fn latest(&self) -> ProviderResult<StateProviderBox> {
         trace!(target: "providers::db", "Returning latest state provider");
         Ok(Box::new(LatestStateProvider::new(self.db.tx()?)))


### PR DESCRIPTION
To be able to catch the leaked transactions, we need to know their origin. Having a caller tracked up to the provider and the transaction ID should be enough.
```console
2024-01-08T17:03:06.811863Z DEBUG storage::db::mdbx: Transaction opened caller=/Users/shekhirin/Projects/reth/crates/storage/provider/src/providers/database/mod.rs:250:14 id=305 mode=read-only
2024-01-08T17:03:06.817450Z  INFO reth::commands::node::events: Executing stage pipeline_stages=3/13 stage=Bodies checkpoint=222000 target=695895 stage_progress=31.90%
2024-01-08T17:03:06.817483Z DEBUG storage::db::mdbx: Transaction opened caller=/Users/shekhirin/Projects/reth/crates/stages/src/pipeline/mod.rs:351:53 id=306 mode=read-write
2024-01-08T17:03:07.006589Z  INFO reth::commands::node::events: pipeline_stages=3/13 stage=Bodies checkpoint=223000 target=695895 stage_progress=32.05% Stage committed progress
2024-01-08T17:03:07.020313Z DEBUG storage::db::mdbx: Transaction opened caller=/Users/shekhirin/Projects/reth/crates/storage/provider/src/providers/database/mod.rs:432:14 id=306 mode=read-only
```

---

The runtime cost of `#[track_caller]` should be negligible. No stack walk happens during the caller retrieval, and instead the caller is passed as an additional argument to the function. See https://rustc-dev-guide.rust-lang.org/backend/implicit-caller-location.html#generating-code-for-track_caller-callees for more information.