### PR TITLE
chore: update MSRV to 1.75

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.70" # MSRV
+          toolchain: "1.75" # MSRV
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ rust.rust_2018_idioms = "deny"
 [workspace.package]
 version = "0.1.0-alpha.13"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.75"
 license = "MIT OR Apache-2.0"
 homepage = "https://paradigmxyz.github.io/reth"
 repository = "https://github.com/paradigmxyz/reth"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,3 @@
-msrv = "1.70"
+msrv = "1.75"
 ignore-interior-mutability = ["bytes::Bytes", "reth_primitives::trie::nibbles::Nibbles"]
 too-large-for-stack = 128


### PR DESCRIPTION
We use features in code from 1.72, and `[lints]` is from 1.75, so we should update MSRV to 1.75

closes #5965