### PR TITLE
Use text instead of bash for CLI docs

### DIFF
--- a/book/cli/reth/config.md
+++ b/book/cli/reth/config.md
@@ -2,7 +2,7 @@
 
 Write config to stdout
 
-```bash
+```text
 $ reth config --help
 Usage: reth config [OPTIONS]
 

--- a/book/cli/reth/db.md
+++ b/book/cli/reth/db.md
@@ -2,7 +2,7 @@
 
 Database debugging utilities
 
-```bash
+```text
 $ reth db --help
 Usage: reth db [OPTIONS] <COMMAND>
 

--- a/book/cli/reth/db/clear.md
+++ b/book/cli/reth/db/clear.md
@@ -2,7 +2,7 @@
 
 Deletes all table entries
 
-```bash
+```text
 $ reth db clear --help
 Usage: reth db clear [OPTIONS] <TABLE>
 

--- a/book/cli/reth/db/diff.md
+++ b/book/cli/reth/db/diff.md
@@ -2,7 +2,7 @@
 
 Create a diff between two database tables or two entire databases
 
-```bash
+```text
 $ reth db diff --help
 Usage: reth db diff [OPTIONS] --secondary-datadir <SECONDARY_DATADIR> --output <OUTPUT>
 

--- a/book/cli/reth/db/drop.md
+++ b/book/cli/reth/db/drop.md
@@ -2,7 +2,7 @@
 
 Deletes all database entries
 
-```bash
+```text
 $ reth db drop --help
 Usage: reth db drop [OPTIONS]
 

--- a/book/cli/reth/db/get.md
+++ b/book/cli/reth/db/get.md
@@ -2,7 +2,7 @@
 
 Gets the content of a table for the given key
 
-```bash
+```text
 $ reth db get --help
 Usage: reth db get [OPTIONS] <TABLE> <KEY>
 

--- a/book/cli/reth/db/list.md
+++ b/book/cli/reth/db/list.md
@@ -2,7 +2,7 @@
 
 Lists the contents of a table
 
-```bash
+```text
 $ reth db list --help
 Usage: reth db list [OPTIONS] <TABLE>
 

--- a/book/cli/reth/db/path.md
+++ b/book/cli/reth/db/path.md
@@ -2,7 +2,7 @@
 
 Returns the full database path
 
-```bash
+```text
 $ reth db path --help
 Usage: reth db path [OPTIONS]
 

--- a/book/cli/reth/db/snapshot.md
+++ b/book/cli/reth/db/snapshot.md
@@ -2,7 +2,7 @@
 
 Snapshots tables from database
 
-```bash
+```text
 $ reth db snapshot --help
 Usage: reth db snapshot [OPTIONS] [SEGMENTS]...
 

--- a/book/cli/reth/db/stats.md
+++ b/book/cli/reth/db/stats.md
@@ -2,7 +2,7 @@
 
 Lists all the tables, their entry count and their size
 
-```bash
+```text
 $ reth db stats --help
 Usage: reth db stats [OPTIONS]
 

--- a/book/cli/reth/db/version.md
+++ b/book/cli/reth/db/version.md
@@ -2,7 +2,7 @@
 
 Lists current and local database versions
 
-```bash
+```text
 $ reth db version --help
 Usage: reth db version [OPTIONS]
 

--- a/book/cli/reth/debug.md
+++ b/book/cli/reth/debug.md
@@ -2,7 +2,7 @@
 
 Various debug routines
 
-```bash
+```text
 $ reth debug --help
 Usage: reth debug [OPTIONS] <COMMAND>
 

--- a/book/cli/reth/import.md
+++ b/book/cli/reth/import.md
@@ -2,7 +2,7 @@
 
 This syncs RLP encoded blocks from a file
 
-```bash
+```text
 $ reth import --help
 Usage: reth import [OPTIONS] <IMPORT_PATH>
 

--- a/book/cli/reth/init.md
+++ b/book/cli/reth/init.md
@@ -2,7 +2,7 @@
 
 Initialize the database from a genesis file
 
-```bash
+```text
 $ reth init --help
 Usage: reth init [OPTIONS]
 

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -2,7 +2,7 @@
 
 Start the node
 
-```bash
+```text
 $ reth node --help
 Usage: reth node [OPTIONS]
 

--- a/book/cli/reth/p2p.md
+++ b/book/cli/reth/p2p.md
@@ -2,7 +2,7 @@
 
 P2P Debugging utilities
 
-```bash
+```text
 $ reth p2p --help
 Usage: reth p2p [OPTIONS] <COMMAND>
 

--- a/book/cli/reth/p2p/body.md
+++ b/book/cli/reth/p2p/body.md
@@ -2,7 +2,7 @@
 
 Download block body
 
-```bash
+```text
 $ reth p2p body --help
 Usage: reth p2p body [OPTIONS] <ID>
 

--- a/book/cli/reth/p2p/header.md
+++ b/book/cli/reth/p2p/header.md
@@ -2,7 +2,7 @@
 
 Download block header
 
-```bash
+```text
 $ reth p2p header --help
 Usage: reth p2p header [OPTIONS] <ID>
 

--- a/book/cli/reth/recover.md
+++ b/book/cli/reth/recover.md
@@ -2,7 +2,7 @@
 
 Scripts for node recovery
 
-```bash
+```text
 $ reth recover --help
 Usage: reth recover [OPTIONS] <COMMAND>
 

--- a/book/cli/reth/recover/storage-tries.md
+++ b/book/cli/reth/recover/storage-tries.md
@@ -2,7 +2,7 @@
 
 Recover the node by deleting dangling storage tries
 
-```bash
+```text
 $ reth recover storage-tries --help
 Usage: reth recover storage-tries [OPTIONS]
 

--- a/book/cli/reth/stage.md
+++ b/book/cli/reth/stage.md
@@ -2,7 +2,7 @@
 
 Manipulate individual stages
 
-```bash
+```text
 $ reth stage --help
 Usage: reth stage [OPTIONS] <COMMAND>
 

--- a/book/cli/reth/stage/drop.md
+++ b/book/cli/reth/stage/drop.md
@@ -2,7 +2,7 @@
 
 Drop a stage's tables from the database
 
-```bash
+```text
 $ reth stage drop --help
 Usage: reth stage drop [OPTIONS] <STAGE>
 

--- a/book/cli/reth/stage/dump.md
+++ b/book/cli/reth/stage/dump.md
@@ -2,7 +2,7 @@
 
 Dumps a stage from a range into a new database
 
-```bash
+```text
 $ reth stage dump --help
 Usage: reth stage dump [OPTIONS] <COMMAND>
 

--- a/book/cli/reth/stage/dump/account-hashing.md
+++ b/book/cli/reth/stage/dump/account-hashing.md
@@ -2,7 +2,7 @@
 
 AccountHashing stage
 
-```bash
+```text
 $ reth stage dump account-hashing --help
 Usage: reth stage dump account-hashing [OPTIONS] --output-db <OUTPUT_PATH> --from <FROM> --to <TO>
 

--- a/book/cli/reth/stage/dump/execution.md
+++ b/book/cli/reth/stage/dump/execution.md
@@ -2,7 +2,7 @@
 
 Execution stage
 
-```bash
+```text
 $ reth stage dump execution --help
 Usage: reth stage dump execution [OPTIONS] --output-db <OUTPUT_PATH> --from <FROM> --to <TO>
 

--- a/book/cli/reth/stage/dump/merkle.md
+++ b/book/cli/reth/stage/dump/merkle.md
@@ -2,7 +2,7 @@
 
 Merkle stage
 
-```bash
+```text
 $ reth stage dump merkle --help
 Usage: reth stage dump merkle [OPTIONS] --output-db <OUTPUT_PATH> --from <FROM> --to <TO>
 

--- a/book/cli/reth/stage/dump/storage-hashing.md
+++ b/book/cli/reth/stage/dump/storage-hashing.md
@@ -2,7 +2,7 @@
 
 StorageHashing stage
 
-```bash
+```text
 $ reth stage dump storage-hashing --help
 Usage: reth stage dump storage-hashing [OPTIONS] --output-db <OUTPUT_PATH> --from <FROM> --to <TO>
 

--- a/book/cli/reth/stage/run.md
+++ b/book/cli/reth/stage/run.md
@@ -2,7 +2,7 @@
 
 Run a single stage.
 
-```bash
+```text
 $ reth stage run --help
 Usage: reth stage run [OPTIONS] --from <FROM> --to <TO> <STAGE>
 

--- a/book/cli/reth/stage/unwind.md
+++ b/book/cli/reth/stage/unwind.md
@@ -2,7 +2,7 @@
 
 Unwinds a certain block range, deleting it from the database
 
-```bash
+```text
 $ reth stage unwind --help
 Usage: reth stage unwind [OPTIONS] <COMMAND>
 

--- a/book/cli/reth/stage/unwind/num-blocks.md
+++ b/book/cli/reth/stage/unwind/num-blocks.md
@@ -2,7 +2,7 @@
 
 Unwinds the given number of blocks from the database
 
-```bash
+```text
 $ reth stage unwind num-blocks --help
 Usage: reth stage unwind num-blocks [OPTIONS] <AMOUNT>
 

--- a/book/cli/reth/stage/unwind/to-block.md
+++ b/book/cli/reth/stage/unwind/to-block.md
@@ -2,7 +2,7 @@
 
 Unwinds the database until the given block number (range is inclusive)
 
-```bash
+```text
 $ reth stage unwind to-block --help
 Usage: reth stage unwind to-block [OPTIONS] <TARGET>
 

--- a/book/cli/reth/test-vectors.md
+++ b/book/cli/reth/test-vectors.md
@@ -2,7 +2,7 @@
 
 Generate Test Vectors
 
-```bash
+```text
 $ reth test-vectors --help
 Usage: reth test-vectors [OPTIONS] <COMMAND>
 

--- a/book/cli/reth/test-vectors/tables.md
+++ b/book/cli/reth/test-vectors/tables.md
@@ -2,7 +2,7 @@
 
 Generates test vectors for specified tables. If no table is specified, generate for all
 
-```bash
+```text
 $ reth test-vectors tables --help
 Usage: reth test-vectors tables [OPTIONS] [NAMES]...
 


### PR DESCRIPTION
Currently CLI docs have a visual bug that affects readability. Because of bash syntax random words are highlighted and `'` character causes text to suddenly change color ([example](https://paradigmxyz.github.io/reth/cli/reth/db/drop.html)): 

<img width="745" alt="Screenshot 2024-01-08 at 21 42 20" src="https://github.com/paradigmxyz/reth/assets/1131944/0cec7e6c-a122-4575-92be-e0c7d3f1b7f1">

This PR uses `text` to disable random highlighting and improve readability. Before:

<img width="846" alt="before" src="https://github.com/paradigmxyz/reth/assets/1131944/0fb20d78-340b-4526-b675-ecc0a940741c">

after:

<img width="681" alt="after" src="https://github.com/paradigmxyz/reth/assets/1131944/2c09b2e9-284e-49ca-8736-a330df9de5b8">

