### PR TITLE
docs: update MSRV to 1.75.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ When updating this, also update:
 - .github/workflows/lint.yml
 -->
 
-The Minimum Supported Rust Version (MSRV) of this project is [1.70.0](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html).
+The Minimum Supported Rust Version (MSRV) of this project is [1.75.0](https://blog.rust-lang.org/2023/12/28/Rust-1.75.0.html).
 
 See the book for detailed instructions on how to [build from source](https://paradigmxyz.github.io/reth/installation/source.html).
 


### PR DESCRIPTION
The actual MSRV bump was in 5353ac3c05f3a09df272ea3abcef21f50cdbaaff