### PR TITLE
feat(storage): downgrade tx open log to trace

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -13,7 +13,7 @@ use crate::{
 use parking_lot::RwLock;
 use reth_interfaces::db::{DatabaseWriteError, DatabaseWriteOperation};
 use reth_libmdbx::{ffi::DBI, CommitLatency, Transaction, TransactionKind, WriteFlags, RW};
-use reth_tracing::tracing::{debug, warn};
+use reth_tracing::tracing::{trace, warn};
 use std::{
     backtrace::Backtrace,
     marker::PhantomData,
@@ -184,7 +184,7 @@ impl<K: TransactionKind> MetricsHandler<K> {
     /// Logs the caller location and ID of the transaction that was opened.
     #[track_caller]
     fn log_transaction_opened(&self) {
-        debug!(
+        trace!(
             target: "storage::db::mdbx",
             caller = %core::panic::Location::caller(),
             id = %self.txn_id,


### PR DESCRIPTION
Debug log level fills default 5 log files 200MB each too quickly:
```console
ubuntu@reth-public-1:~$ ls -lh chain/reth/logs/mainnet/
total 1.1G
-rw-r--r-- 1 root root  62M Jan  9 14:02 reth.log
-rw-r--r-- 1 root root 201M Jan  9 13:45 reth.log.1
-rw-r--r-- 1 root root 201M Jan  9 12:57 reth.log.2
-rw-r--r-- 1 root root 201M Jan  9 12:13 reth.log.3
-rw-r--r-- 1 root root 201M Jan  9 10:24 reth.log.4
-rw-r--r-- 1 root root 201M Jan  2 06:19 reth.log.5
```