### PR TITLE
test(tracing): allow tracer init to fail

### DIFF
--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -208,7 +208,9 @@ impl Tracer for RethTracer {
             None
         };
 
-        tracing_subscriber::registry().with(layers.into_inner()).init();
+        // The error is returned if the global default subscriber is already set,
+        // so it's safe to ignore it
+        let _ = tracing_subscriber::registry().with(layers.into_inner()).try_init();
         Ok(file_guard)
     }
 }


### PR DESCRIPTION
Thanks @Rjected for pointing out

```console
failures:

---- cli::tests::override_trusted_setup_file stdout ----
thread 'cli::tests::override_trusted_setup_file' panicked at /Users/shekhirin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tracing-subscriber-0.3.18/src/util.rs:91:14:
failed to set global default subscriber: SetGlobalDefaultError("a global default trace dispatcher has already been set")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```