### PR TITLE
chore: move revm inspectors to alloy rpc types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6457,10 +6457,11 @@ name = "reth-revm-inspectors"
 version = "0.1.0-alpha.14"
 dependencies = [
  "alloy-primitives",
+ "alloy-rpc-trace-types",
+ "alloy-rpc-types",
  "alloy-sol-types",
  "boa_engine",
  "boa_gc",
- "reth-rpc-types",
  "revm",
  "serde",
  "serde_json",

--- a/crates/revm/revm-inspectors/Cargo.toml
+++ b/crates/revm/revm-inspectors/Cargo.toml
@@ -12,12 +12,11 @@ description = "revm inspector implementations used by reth"
 workspace = true
 
 [dependencies]
-# reth
-reth-rpc-types.workspace = true
-
 # eth
 alloy-sol-types.workspace = true
 alloy-primitives.workspace = true
+alloy-rpc-types.workspace = true
+alloy-rpc-trace-types.workspace = true
 
 revm.workspace = true
 

--- a/crates/revm/revm-inspectors/src/access_list.rs
+++ b/crates/revm/revm-inspectors/src/access_list.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::{Address, B256};
-use reth_rpc_types::{AccessList, AccessListItem};
+use alloy_rpc_types::{AccessList, AccessListItem};
 use revm::{
     interpreter::{opcode, Interpreter},
     Database, EVMData, Inspector,

--- a/crates/revm/revm-inspectors/src/tracing/builder/geth.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/geth.rs
@@ -6,7 +6,7 @@ use crate::tracing::{
     TracingInspectorConfig,
 };
 use alloy_primitives::{Address, Bytes, B256, U256};
-use reth_rpc_types::trace::geth::{
+use alloy_rpc_trace_types::geth::{
     AccountChangeKind, AccountState, CallConfig, CallFrame, DefaultFrame, DiffMode,
     GethDefaultTracingOptions, PreStateConfig, PreStateFrame, PreStateMode, StructLog,
 };

--- a/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
+++ b/crates/revm/revm-inspectors/src/tracing/builder/parity.rs
@@ -5,7 +5,8 @@ use crate::tracing::{
     TracingInspectorConfig,
 };
 use alloy_primitives::{Address, U64};
-use reth_rpc_types::{trace::parity::*, TransactionInfo};
+use alloy_rpc_trace_types::parity::*;
+use alloy_rpc_types::TransactionInfo;
 use revm::{
     db::DatabaseRef,
     interpreter::{

--- a/crates/revm/revm-inspectors/src/tracing/config.rs
+++ b/crates/revm/revm-inspectors/src/tracing/config.rs
@@ -1,4 +1,4 @@
-use reth_rpc_types::trace::{geth::GethDefaultTracingOptions, parity::TraceType};
+use alloy_rpc_trace_types::{geth::GethDefaultTracingOptions, parity::TraceType};
 use std::collections::HashSet;
 
 /// Gives guidance to the [TracingInspector](crate::tracing::TracingInspector).

--- a/crates/revm/revm-inspectors/src/tracing/fourbyte.rs
+++ b/crates/revm/revm-inspectors/src/tracing/fourbyte.rs
@@ -22,7 +22,7 @@
 //! See also <https://geth.ethereum.org/docs/developers/evm-tracing/built-in-tracers>
 
 use alloy_primitives::{hex, Bytes, Selector};
-use reth_rpc_types::trace::geth::FourByteFrame;
+use alloy_rpc_trace_types::geth::FourByteFrame;
 use revm::{
     interpreter::{CallInputs, Gas, InstructionResult},
     Database, EVMData, Inspector,

--- a/crates/revm/revm-inspectors/src/tracing/types.rs
+++ b/crates/revm/revm-inspectors/src/tracing/types.rs
@@ -4,7 +4,7 @@ use crate::tracing::{config::TraceStyle, utils, utils::convert_memory};
 pub use alloy_primitives::Log;
 use alloy_primitives::{Address, Bytes, U256, U64};
 
-use reth_rpc_types::trace::{
+use alloy_rpc_trace_types::{
     geth::{CallFrame, CallLogFrame, GethDefaultTracingOptions, StructLog},
     parity::{
         Action, ActionType, CallAction, CallOutput, CallType, CreateAction, CreateOutput,


### PR DESCRIPTION
use alloy deps directly