### PR TITLE
add `are_configs_compatible` implementation for `ChainConfig`

### DIFF
--- a/crates/primitives/src/genesis.rs
+++ b/crates/primitives/src/genesis.rs
@@ -601,7 +601,7 @@ impl ChainConfig {
         }
 
         // Validates EIP-158 activation at the current block and different chain IDs.
-        if self.is_eip158_active_at_block(head_block) && !(self.chain_id == rhs_config.chain_id) {
+        if self.is_eip158_active_at_block(head_block) && self.chain_id != rhs_config.chain_id {
             return Err(ConfigCompatError::EIP158ChainIdError(
                 self.eip158_block,
                 rhs_config.eip158_block,
@@ -831,7 +831,7 @@ impl ChainConfig {
     ) -> bool {
         (self.is_active_at_block(lhs_config_block, block) ||
             rhs_config.is_active_at_block(rhs_config_block, block)) &&
-            !(lhs_config_block.unwrap_or_default() == rhs_config_block.unwrap_or_default())
+            lhs_config_block.unwrap_or_default() != rhs_config_block.unwrap_or_default()
     }
 
     /// Checks if two fork timestamps are incompatible based on given configurations and timestamp.
@@ -844,8 +844,7 @@ impl ChainConfig {
     ) -> bool {
         (self.is_active_at_timestamp(lhs_config_timestamp, timestamp) ||
             rhs_config.is_active_at_timestamp(rhs_config_timestamp, timestamp)) &&
-            !(lhs_config_timestamp.unwrap_or_default() ==
-                rhs_config_timestamp.unwrap_or_default())
+            lhs_config_timestamp.unwrap_or_default() != rhs_config_timestamp.unwrap_or_default()
     }
 }
 

--- a/crates/primitives/src/genesis.rs
+++ b/crates/primitives/src/genesis.rs
@@ -194,104 +194,104 @@ pub enum ConfigCompatError {
     #[error(
         "Homestead fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}"
     )]
-    HomesteadBlockError(Option<u64>, Option<u64>, u64),
+    HomesteadBlock(Option<u64>, Option<u64>, u64),
 
     /// Error for DAO fork block incompatibility with stored, new blocks, and rewind block.
     #[error("DAO fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}")]
-    DAOBlockError(Option<u64>, Option<u64>, u64),
+    DAOBlock(Option<u64>, Option<u64>, u64),
 
     /// Error for DAO fork support flag incompatibility with stored, new blocks, and rewind block.
     #[error(
         "DAO fork support flag error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}"
     )]
-    DAOSupporFlagError(Option<u64>, Option<u64>, u64),
+    DAOSupporFlag(Option<u64>, Option<u64>, u64),
 
     /// Error for EIP-150 fork block incompatibility with stored, new blocks, and rewind block.
     #[error(
         "EIP-150 fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}"
     )]
-    EIP150BlockError(Option<u64>, Option<u64>, u64),
+    EIP150Block(Option<u64>, Option<u64>, u64),
 
     /// Error for EIP-155 fork block incompatibility with stored, new blocks, and rewind block.
     #[error(
         "EIP-155 fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}"
     )]
-    EIP155BlockError(Option<u64>, Option<u64>, u64),
+    EIP155Block(Option<u64>, Option<u64>, u64),
 
     /// Error for EIP-158 fork block incompatibility with stored, new blocks, and rewind block.
     #[error(
         "EIP-158 fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}"
     )]
-    EIP158BlockError(Option<u64>, Option<u64>, u64),
+    EIP158Block(Option<u64>, Option<u64>, u64),
 
     /// Error for EIP-158 chain ID incompatibility with stored, new blocks, and rewind block.
     #[error("EIP-158 chain ID error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}")]
-    EIP158ChainIdError(Option<u64>, Option<u64>, u64),
+    EIP158ChainId(Option<u64>, Option<u64>, u64),
 
     /// Error for Byzantium fork block incompatibility with stored, new blocks, and rewind block.
     #[error(
         "Byzantium fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}"
     )]
-    ByzantiumBlockError(Option<u64>, Option<u64>, u64),
+    ByzantiumBlock(Option<u64>, Option<u64>, u64),
 
     /// Error for Constantinople fork block incompatibility with stored, new blocks, and rewind
     /// block.
     #[error("Constantinople fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}")]
-    ConstantinopleBlockError(Option<u64>, Option<u64>, u64),
+    ConstantinopleBlock(Option<u64>, Option<u64>, u64),
 
     /// Error for Petersburg fork block incompatibility with stored, new blocks, and rewind block.
     #[error(
         "Petersburg fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}"
     )]
-    PetersburgBlockError(Option<u64>, Option<u64>, u64),
+    PetersburgBlock(Option<u64>, Option<u64>, u64),
 
     /// Error for Istanbul fork block incompatibility with stored, new blocks, and rewind block.
     #[error(
         "Istanbul fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}"
     )]
-    IstanbulBlockError(Option<u64>, Option<u64>, u64),
+    IstanbulBlock(Option<u64>, Option<u64>, u64),
 
     /// Error for Muir Glacier fork block incompatibility with stored, new blocks, and rewind
     /// block.
     #[error("Muir Glacier fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}")]
-    MuirGlacierBlockError(Option<u64>, Option<u64>, u64),
+    MuirGlacierBlock(Option<u64>, Option<u64>, u64),
 
     /// Error for Berlin fork block incompatibility with stored, new blocks, and rewind block.
     #[error(
         "Berlin fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}"
     )]
-    BerlinBlockError(Option<u64>, Option<u64>, u64),
+    BerlinBlock(Option<u64>, Option<u64>, u64),
 
     /// Error for London fork block incompatibility with stored, new blocks, and rewind block.
     #[error(
         "London fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}"
     )]
-    LondonBlockError(Option<u64>, Option<u64>, u64),
+    LondonBlock(Option<u64>, Option<u64>, u64),
 
     /// Error for Arrow Glacier fork block incompatibility with stored, new blocks, and rewind
     /// block.
     #[error("Arrow Glacier fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}")]
-    ArrowGlacierBlockError(Option<u64>, Option<u64>, u64),
+    ArrowGlacierBlock(Option<u64>, Option<u64>, u64),
 
     /// Error for Gray Glacier fork block incompatibility with stored, new blocks, and rewind
     /// block.
     #[error("Gray Glacier fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}")]
-    GrayGlacierBlockError(Option<u64>, Option<u64>, u64),
+    GrayGlacierBlock(Option<u64>, Option<u64>, u64),
 
     /// Error for Merge netsplit fork block incompatibility with stored, new blocks, and rewind
     /// block.
     #[error("Merge netsplit fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}")]
-    MergeNetsplitBlockError(Option<u64>, Option<u64>, u64),
+    MergeNetsplitBlock(Option<u64>, Option<u64>, u64),
 
     /// Error for Shanghai fork timestamp incompatibility with stored, new timestamps, and rewind
     /// timestamp.
     #[error("Shanghai fork timestamp error. Stored timestamp: {0:?}, New timestamp: {1:?}, Rewind to timestamp: {2}")]
-    ShanghaiTimestampError(Option<u64>, Option<u64>, u64),
+    ShanghaiTimestamp(Option<u64>, Option<u64>, u64),
 
     /// Error for Cancun fork timestamp incompatibility with stored, new timestamps, and rewind
     /// timestamp.
     #[error("Cancun fork timestamp error. Stored timestamp: {0:?}, New timestamp: {1:?}, Rewind to timestamp: {2}")]
-    CancunTimestampError(Option<u64>, Option<u64>, u64),
+    CancunTimestamp(Option<u64>, Option<u64>, u64),
 }
 
 /// Defines core blockchain settings per block.
@@ -523,7 +523,7 @@ impl ChainConfig {
             rhs_config.homestead_block,
             head_block,
         ) {
-            return Err(ConfigCompatError::HomesteadBlockError(
+            return Err(ConfigCompatError::HomesteadBlock(
                 self.homestead_block,
                 rhs_config.homestead_block,
                 Self::block_or_timestamp_to_rewind(
@@ -540,7 +540,7 @@ impl ChainConfig {
             rhs_config.dao_fork_block,
             head_block,
         ) {
-            return Err(ConfigCompatError::DAOBlockError(
+            return Err(ConfigCompatError::DAOBlock(
                 self.dao_fork_block,
                 rhs_config.dao_fork_block,
                 Self::block_or_timestamp_to_rewind(self.dao_fork_block, rhs_config.dao_fork_block),
@@ -551,7 +551,7 @@ impl ChainConfig {
         if self.is_dao_fork_active_at_block(head_block) &&
             self.dao_fork_support != rhs_config.dao_fork_support
         {
-            return Err(ConfigCompatError::DAOSupporFlagError(
+            return Err(ConfigCompatError::DAOSupporFlag(
                 self.dao_fork_block,
                 rhs_config.dao_fork_block,
                 Self::block_or_timestamp_to_rewind(self.dao_fork_block, rhs_config.dao_fork_block),
@@ -565,7 +565,7 @@ impl ChainConfig {
             rhs_config.eip150_block,
             head_block,
         ) {
-            return Err(ConfigCompatError::EIP150BlockError(
+            return Err(ConfigCompatError::EIP150Block(
                 self.eip150_block,
                 rhs_config.eip150_block,
                 Self::block_or_timestamp_to_rewind(self.eip150_block, rhs_config.eip150_block),
@@ -579,7 +579,7 @@ impl ChainConfig {
             rhs_config.eip155_block,
             head_block,
         ) {
-            return Err(ConfigCompatError::EIP155BlockError(
+            return Err(ConfigCompatError::EIP155Block(
                 self.eip155_block,
                 rhs_config.eip155_block,
                 Self::block_or_timestamp_to_rewind(self.eip155_block, rhs_config.eip155_block),
@@ -593,7 +593,7 @@ impl ChainConfig {
             rhs_config.eip158_block,
             head_block,
         ) {
-            return Err(ConfigCompatError::EIP158BlockError(
+            return Err(ConfigCompatError::EIP158Block(
                 self.eip158_block,
                 rhs_config.eip158_block,
                 Self::block_or_timestamp_to_rewind(self.eip158_block, rhs_config.eip158_block),
@@ -602,7 +602,7 @@ impl ChainConfig {
 
         // Validates EIP-158 activation at the current block and different chain IDs.
         if self.is_eip158_active_at_block(head_block) && self.chain_id != rhs_config.chain_id {
-            return Err(ConfigCompatError::EIP158ChainIdError(
+            return Err(ConfigCompatError::EIP158ChainId(
                 self.eip158_block,
                 rhs_config.eip158_block,
                 Self::block_or_timestamp_to_rewind(self.eip158_block, rhs_config.eip158_block),
@@ -616,7 +616,7 @@ impl ChainConfig {
             rhs_config.byzantium_block,
             head_block,
         ) {
-            return Err(ConfigCompatError::ByzantiumBlockError(
+            return Err(ConfigCompatError::ByzantiumBlock(
                 self.byzantium_block,
                 rhs_config.byzantium_block,
                 Self::block_or_timestamp_to_rewind(
@@ -633,7 +633,7 @@ impl ChainConfig {
             rhs_config.constantinople_block,
             head_block,
         ) {
-            return Err(ConfigCompatError::ConstantinopleBlockError(
+            return Err(ConfigCompatError::ConstantinopleBlock(
                 self.constantinople_block,
                 rhs_config.constantinople_block,
                 Self::block_or_timestamp_to_rewind(
@@ -657,7 +657,7 @@ impl ChainConfig {
             rhs_config.petersburg_block,
             head_block,
         ) {
-            return Err(ConfigCompatError::PetersburgBlockError(
+            return Err(ConfigCompatError::PetersburgBlock(
                 self.petersburg_block,
                 rhs_config.petersburg_block,
                 Self::block_or_timestamp_to_rewind(
@@ -674,7 +674,7 @@ impl ChainConfig {
             rhs_config.istanbul_block,
             head_block,
         ) {
-            return Err(ConfigCompatError::IstanbulBlockError(
+            return Err(ConfigCompatError::IstanbulBlock(
                 self.istanbul_block,
                 rhs_config.istanbul_block,
                 Self::block_or_timestamp_to_rewind(self.istanbul_block, rhs_config.istanbul_block),
@@ -688,7 +688,7 @@ impl ChainConfig {
             rhs_config.muir_glacier_block,
             head_block,
         ) {
-            return Err(ConfigCompatError::MuirGlacierBlockError(
+            return Err(ConfigCompatError::MuirGlacierBlock(
                 self.muir_glacier_block,
                 rhs_config.muir_glacier_block,
                 Self::block_or_timestamp_to_rewind(
@@ -705,7 +705,7 @@ impl ChainConfig {
             rhs_config.berlin_block,
             head_block,
         ) {
-            return Err(ConfigCompatError::BerlinBlockError(
+            return Err(ConfigCompatError::BerlinBlock(
                 self.berlin_block,
                 rhs_config.berlin_block,
                 Self::block_or_timestamp_to_rewind(self.berlin_block, rhs_config.berlin_block),
@@ -719,7 +719,7 @@ impl ChainConfig {
             rhs_config.london_block,
             head_block,
         ) {
-            return Err(ConfigCompatError::LondonBlockError(
+            return Err(ConfigCompatError::LondonBlock(
                 self.london_block,
                 rhs_config.london_block,
                 Self::block_or_timestamp_to_rewind(self.london_block, rhs_config.london_block),
@@ -733,7 +733,7 @@ impl ChainConfig {
             rhs_config.arrow_glacier_block,
             head_block,
         ) {
-            return Err(ConfigCompatError::ArrowGlacierBlockError(
+            return Err(ConfigCompatError::ArrowGlacierBlock(
                 self.arrow_glacier_block,
                 rhs_config.arrow_glacier_block,
                 Self::block_or_timestamp_to_rewind(
@@ -750,7 +750,7 @@ impl ChainConfig {
             rhs_config.gray_glacier_block,
             head_block,
         ) {
-            return Err(ConfigCompatError::GrayGlacierBlockError(
+            return Err(ConfigCompatError::GrayGlacierBlock(
                 self.gray_glacier_block,
                 rhs_config.gray_glacier_block,
                 Self::block_or_timestamp_to_rewind(
@@ -767,7 +767,7 @@ impl ChainConfig {
             rhs_config.merge_netsplit_block,
             head_block,
         ) {
-            return Err(ConfigCompatError::MergeNetsplitBlockError(
+            return Err(ConfigCompatError::MergeNetsplitBlock(
                 self.merge_netsplit_block,
                 rhs_config.merge_netsplit_block,
                 Self::block_or_timestamp_to_rewind(
@@ -784,7 +784,7 @@ impl ChainConfig {
             rhs_config.shanghai_time,
             head_timestamp,
         ) {
-            return Err(ConfigCompatError::ShanghaiTimestampError(
+            return Err(ConfigCompatError::ShanghaiTimestamp(
                 self.shanghai_time,
                 rhs_config.shanghai_time,
                 Self::block_or_timestamp_to_rewind(self.shanghai_time, rhs_config.shanghai_time),
@@ -798,7 +798,7 @@ impl ChainConfig {
             rhs_config.cancun_time,
             head_timestamp,
         ) {
-            return Err(ConfigCompatError::CancunTimestampError(
+            return Err(ConfigCompatError::CancunTimestamp(
                 self.cancun_time,
                 rhs_config.cancun_time,
                 Self::block_or_timestamp_to_rewind(self.cancun_time, rhs_config.cancun_time),
@@ -1796,7 +1796,7 @@ mod tests {
                 100,
                 200
             ),
-            Err(ConfigCompatError::LondonBlockError(None, Some(34), 33))
+            Err(ConfigCompatError::LondonBlock(None, Some(34), 33))
         );
 
         // Test compatibility between lhs and config with Shanghai time set at 233 and different
@@ -1817,7 +1817,7 @@ mod tests {
                 100,
                 300
             ),
-            Err(ConfigCompatError::ShanghaiTimestampError(None, Some(233), 232))
+            Err(ConfigCompatError::ShanghaiTimestamp(None, Some(233), 232))
         );
     }
 }

--- a/crates/primitives/src/genesis.rs
+++ b/crates/primitives/src/genesis.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use thiserror::Error;
 
 /// The genesis block specification.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -185,6 +186,114 @@ impl From<GenesisAccount> for Account {
     }
 }
 
+/// ConfigCompatError represents errors that occur when initializing the local blockchain
+/// with a ChainConfig that would affect the historical state.
+#[derive(Clone, Debug, PartialEq, Eq, Error)]
+pub enum ConfigCompatError {
+    /// Error for Homestead fork block incompatibility with stored, new blocks, and rewind block.
+    #[error(
+        "Homestead fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}"
+    )]
+    HomesteadBlockError(Option<u64>, Option<u64>, u64),
+
+    /// Error for DAO fork block incompatibility with stored, new blocks, and rewind block.
+    #[error("DAO fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}")]
+    DAOBlockError(Option<u64>, Option<u64>, u64),
+
+    /// Error for DAO fork support flag incompatibility with stored, new blocks, and rewind block.
+    #[error(
+        "DAO fork support flag error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}"
+    )]
+    DAOSupporFlagError(Option<u64>, Option<u64>, u64),
+
+    /// Error for EIP-150 fork block incompatibility with stored, new blocks, and rewind block.
+    #[error(
+        "EIP-150 fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}"
+    )]
+    EIP150BlockError(Option<u64>, Option<u64>, u64),
+
+    /// Error for EIP-155 fork block incompatibility with stored, new blocks, and rewind block.
+    #[error(
+        "EIP-155 fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}"
+    )]
+    EIP155BlockError(Option<u64>, Option<u64>, u64),
+
+    /// Error for EIP-158 fork block incompatibility with stored, new blocks, and rewind block.
+    #[error(
+        "EIP-158 fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}"
+    )]
+    EIP158BlockError(Option<u64>, Option<u64>, u64),
+
+    /// Error for EIP-158 chain ID incompatibility with stored, new blocks, and rewind block.
+    #[error("EIP-158 chain ID error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}")]
+    EIP158ChainIdError(Option<u64>, Option<u64>, u64),
+
+    /// Error for Byzantium fork block incompatibility with stored, new blocks, and rewind block.
+    #[error(
+        "Byzantium fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}"
+    )]
+    ByzantiumBlockError(Option<u64>, Option<u64>, u64),
+
+    /// Error for Constantinople fork block incompatibility with stored, new blocks, and rewind
+    /// block.
+    #[error("Constantinople fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}")]
+    ConstantinopleBlockError(Option<u64>, Option<u64>, u64),
+
+    /// Error for Petersburg fork block incompatibility with stored, new blocks, and rewind block.
+    #[error(
+        "Petersburg fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}"
+    )]
+    PetersburgBlockError(Option<u64>, Option<u64>, u64),
+
+    /// Error for Istanbul fork block incompatibility with stored, new blocks, and rewind block.
+    #[error(
+        "Istanbul fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}"
+    )]
+    IstanbulBlockError(Option<u64>, Option<u64>, u64),
+
+    /// Error for Muir Glacier fork block incompatibility with stored, new blocks, and rewind
+    /// block.
+    #[error("Muir Glacier fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}")]
+    MuirGlacierBlockError(Option<u64>, Option<u64>, u64),
+
+    /// Error for Berlin fork block incompatibility with stored, new blocks, and rewind block.
+    #[error(
+        "Berlin fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}"
+    )]
+    BerlinBlockError(Option<u64>, Option<u64>, u64),
+
+    /// Error for London fork block incompatibility with stored, new blocks, and rewind block.
+    #[error(
+        "London fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}"
+    )]
+    LondonBlockError(Option<u64>, Option<u64>, u64),
+
+    /// Error for Arrow Glacier fork block incompatibility with stored, new blocks, and rewind
+    /// block.
+    #[error("Arrow Glacier fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}")]
+    ArrowGlacierBlockError(Option<u64>, Option<u64>, u64),
+
+    /// Error for Gray Glacier fork block incompatibility with stored, new blocks, and rewind
+    /// block.
+    #[error("Gray Glacier fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}")]
+    GrayGlacierBlockError(Option<u64>, Option<u64>, u64),
+
+    /// Error for Merge netsplit fork block incompatibility with stored, new blocks, and rewind
+    /// block.
+    #[error("Merge netsplit fork block error. Stored block: {0:?}, New block: {1:?}, Rewind to block: {2}")]
+    MergeNetsplitBlockError(Option<u64>, Option<u64>, u64),
+
+    /// Error for Shanghai fork timestamp incompatibility with stored, new timestamps, and rewind
+    /// timestamp.
+    #[error("Shanghai fork timestamp error. Stored timestamp: {0:?}, New timestamp: {1:?}, Rewind to timestamp: {2}")]
+    ShanghaiTimestampError(Option<u64>, Option<u64>, u64),
+
+    /// Error for Cancun fork timestamp incompatibility with stored, new timestamps, and rewind
+    /// timestamp.
+    #[error("Cancun fork timestamp error. Stored timestamp: {0:?}, New timestamp: {1:?}, Rewind to timestamp: {2}")]
+    CancunTimestampError(Option<u64>, Option<u64>, u64),
+}
+
 /// Defines core blockchain settings per block.
 ///
 /// Tailors unique settings for each network based on its genesis block.
@@ -304,6 +413,11 @@ impl ChainConfig {
         self.is_active_at_block(self.homestead_block, block)
     }
 
+    /// Checks if the blockchain is active at or after the DAO Fork fork block.
+    pub fn is_dao_fork_active_at_block(&self, block: u64) -> bool {
+        self.is_active_at_block(self.dao_fork_block, block)
+    }
+
     /// Checks if the blockchain is active at or after the EIP150 fork block.
     pub fn is_eip150_active_at_block(&self, block: u64) -> bool {
         self.is_active_at_block(self.eip150_block, block)
@@ -379,13 +493,359 @@ impl ChainConfig {
     }
 
     // Private function handling the comparison logic for block numbers
-    fn is_active_at_block(&self, config_block: Option<u64>, block: u64) -> bool {
-        config_block.map_or(false, |cb| cb <= block)
+    fn is_active_at_block(&self, lhs_config_block: Option<u64>, block: u64) -> bool {
+        lhs_config_block.map_or(false, |cb| cb <= block)
     }
 
     // Private function handling the comparison logic for timestamps
     fn is_active_at_timestamp(&self, config_timestamp: Option<u64>, timestamp: u64) -> bool {
         config_timestamp.map_or(false, |cb| cb <= timestamp)
+    }
+
+    /// Compares block numbers and timestamps between two chain configurations
+    /// to determine their compatibility.
+    ///
+    ///
+    /// Returns `Ok(())` for compatible configurations.
+    ///
+    /// Otherwise, specific errors indicate incompatibility due to mismatched blocks, timestamps, or
+    /// chain IDs.
+    pub fn are_configs_compatible(
+        &self,
+        rhs_config: &Self,
+        head_block: u64,
+        head_timestamp: u64,
+    ) -> Result<(), ConfigCompatError> {
+        // Checks if the Homestead block numbers between configurations are incompatible.
+        if self.are_fork_blocks_incompatible(
+            rhs_config,
+            self.homestead_block,
+            rhs_config.homestead_block,
+            head_block,
+        ) {
+            return Err(ConfigCompatError::HomesteadBlockError(
+                self.homestead_block,
+                rhs_config.homestead_block,
+                Self::block_or_timestamp_to_rewind(
+                    self.homestead_block,
+                    rhs_config.homestead_block,
+                ),
+            ));
+        }
+
+        // Checks if DAO fork block numbers are incompatible between configurations.
+        if self.are_fork_blocks_incompatible(
+            rhs_config,
+            self.dao_fork_block,
+            rhs_config.dao_fork_block,
+            head_block,
+        ) {
+            return Err(ConfigCompatError::DAOBlockError(
+                self.dao_fork_block,
+                rhs_config.dao_fork_block,
+                Self::block_or_timestamp_to_rewind(self.dao_fork_block, rhs_config.dao_fork_block),
+            ));
+        }
+
+        // Validates DAO fork activity at the current block and support status compatibility.
+        if self.is_dao_fork_active_at_block(head_block) &&
+            self.dao_fork_support != rhs_config.dao_fork_support
+        {
+            return Err(ConfigCompatError::DAOSupporFlagError(
+                self.dao_fork_block,
+                rhs_config.dao_fork_block,
+                Self::block_or_timestamp_to_rewind(self.dao_fork_block, rhs_config.dao_fork_block),
+            ));
+        }
+
+        // Checks if EIP150 block numbers are incompatible between configurations.
+        if self.are_fork_blocks_incompatible(
+            rhs_config,
+            self.eip150_block,
+            rhs_config.eip150_block,
+            head_block,
+        ) {
+            return Err(ConfigCompatError::EIP150BlockError(
+                self.eip150_block,
+                rhs_config.eip150_block,
+                Self::block_or_timestamp_to_rewind(self.eip150_block, rhs_config.eip150_block),
+            ));
+        }
+
+        // Checks if EIP-155 block numbers are incompatible between configurations.
+        if self.are_fork_blocks_incompatible(
+            rhs_config,
+            self.eip155_block,
+            rhs_config.eip155_block,
+            head_block,
+        ) {
+            return Err(ConfigCompatError::EIP155BlockError(
+                self.eip155_block,
+                rhs_config.eip155_block,
+                Self::block_or_timestamp_to_rewind(self.eip155_block, rhs_config.eip155_block),
+            ));
+        }
+
+        // Checks if EIP-158 block numbers are incompatible between configurations.
+        if self.are_fork_blocks_incompatible(
+            rhs_config,
+            self.eip158_block,
+            rhs_config.eip158_block,
+            head_block,
+        ) {
+            return Err(ConfigCompatError::EIP158BlockError(
+                self.eip158_block,
+                rhs_config.eip158_block,
+                Self::block_or_timestamp_to_rewind(self.eip158_block, rhs_config.eip158_block),
+            ));
+        }
+
+        // Validates EIP-158 activation at the current block and different chain IDs.
+        if self.is_eip158_active_at_block(head_block) && !(self.chain_id == rhs_config.chain_id) {
+            return Err(ConfigCompatError::EIP158ChainIdError(
+                self.eip158_block,
+                rhs_config.eip158_block,
+                Self::block_or_timestamp_to_rewind(self.eip158_block, rhs_config.eip158_block),
+            ));
+        }
+
+        // Checks if Byzantium block numbers are incompatible between configurations.
+        if self.are_fork_blocks_incompatible(
+            rhs_config,
+            self.byzantium_block,
+            rhs_config.byzantium_block,
+            head_block,
+        ) {
+            return Err(ConfigCompatError::ByzantiumBlockError(
+                self.byzantium_block,
+                rhs_config.byzantium_block,
+                Self::block_or_timestamp_to_rewind(
+                    self.byzantium_block,
+                    rhs_config.byzantium_block,
+                ),
+            ));
+        }
+
+        // Checks for Constantinople block number incompatibility between configurations.
+        if self.are_fork_blocks_incompatible(
+            rhs_config,
+            self.constantinople_block,
+            rhs_config.constantinople_block,
+            head_block,
+        ) {
+            return Err(ConfigCompatError::ConstantinopleBlockError(
+                self.constantinople_block,
+                rhs_config.constantinople_block,
+                Self::block_or_timestamp_to_rewind(
+                    self.constantinople_block,
+                    rhs_config.constantinople_block,
+                ),
+            ));
+        }
+
+        // Validates Petersburg block compatibility with a condition:
+        // Allows Petersburg to be set in the past only if it is equal to Constantinople
+        // This condition satisfies fork ordering requirements.
+        if self.are_fork_blocks_incompatible(
+            rhs_config,
+            self.petersburg_block,
+            rhs_config.petersburg_block,
+            head_block,
+        ) && self.are_fork_blocks_incompatible(
+            rhs_config,
+            self.constantinople_block,
+            rhs_config.petersburg_block,
+            head_block,
+        ) {
+            return Err(ConfigCompatError::PetersburgBlockError(
+                self.petersburg_block,
+                rhs_config.petersburg_block,
+                Self::block_or_timestamp_to_rewind(
+                    self.petersburg_block,
+                    rhs_config.petersburg_block,
+                ),
+            ));
+        }
+
+        // Checks for Istanbul block number incompatibility between configurations.
+        if self.are_fork_blocks_incompatible(
+            rhs_config,
+            self.istanbul_block,
+            rhs_config.istanbul_block,
+            head_block,
+        ) {
+            return Err(ConfigCompatError::IstanbulBlockError(
+                self.istanbul_block,
+                rhs_config.istanbul_block,
+                Self::block_or_timestamp_to_rewind(self.istanbul_block, rhs_config.istanbul_block),
+            ));
+        }
+
+        // Checks for Muir Glacier block number incompatibility between configurations.
+        if self.are_fork_blocks_incompatible(
+            rhs_config,
+            self.muir_glacier_block,
+            rhs_config.muir_glacier_block,
+            head_block,
+        ) {
+            return Err(ConfigCompatError::MuirGlacierBlockError(
+                self.muir_glacier_block,
+                rhs_config.muir_glacier_block,
+                Self::block_or_timestamp_to_rewind(
+                    self.muir_glacier_block,
+                    rhs_config.muir_glacier_block,
+                ),
+            ));
+        }
+
+        // Checks for Berlin block number incompatibility between configurations.
+        if self.are_fork_blocks_incompatible(
+            rhs_config,
+            self.berlin_block,
+            rhs_config.berlin_block,
+            head_block,
+        ) {
+            return Err(ConfigCompatError::BerlinBlockError(
+                self.berlin_block,
+                rhs_config.berlin_block,
+                Self::block_or_timestamp_to_rewind(self.berlin_block, rhs_config.berlin_block),
+            ));
+        }
+
+        // Checks for London block number incompatibility between configurations.
+        if self.are_fork_blocks_incompatible(
+            rhs_config,
+            self.london_block,
+            rhs_config.london_block,
+            head_block,
+        ) {
+            return Err(ConfigCompatError::LondonBlockError(
+                self.london_block,
+                rhs_config.london_block,
+                Self::block_or_timestamp_to_rewind(self.london_block, rhs_config.london_block),
+            ));
+        }
+
+        // Checks for Arrow Glacier block number incompatibility between configurations.
+        if self.are_fork_blocks_incompatible(
+            rhs_config,
+            self.arrow_glacier_block,
+            rhs_config.arrow_glacier_block,
+            head_block,
+        ) {
+            return Err(ConfigCompatError::ArrowGlacierBlockError(
+                self.arrow_glacier_block,
+                rhs_config.arrow_glacier_block,
+                Self::block_or_timestamp_to_rewind(
+                    self.arrow_glacier_block,
+                    rhs_config.arrow_glacier_block,
+                ),
+            ));
+        }
+
+        // Checks for Gray Glacier block number incompatibility between configurations.
+        if self.are_fork_blocks_incompatible(
+            rhs_config,
+            self.gray_glacier_block,
+            rhs_config.gray_glacier_block,
+            head_block,
+        ) {
+            return Err(ConfigCompatError::GrayGlacierBlockError(
+                self.gray_glacier_block,
+                rhs_config.gray_glacier_block,
+                Self::block_or_timestamp_to_rewind(
+                    self.gray_glacier_block,
+                    rhs_config.gray_glacier_block,
+                ),
+            ));
+        }
+
+        // Checks for Merge Netsplit block number incompatibility between configurations.
+        if self.are_fork_blocks_incompatible(
+            rhs_config,
+            self.merge_netsplit_block,
+            rhs_config.merge_netsplit_block,
+            head_block,
+        ) {
+            return Err(ConfigCompatError::MergeNetsplitBlockError(
+                self.merge_netsplit_block,
+                rhs_config.merge_netsplit_block,
+                Self::block_or_timestamp_to_rewind(
+                    self.merge_netsplit_block,
+                    rhs_config.merge_netsplit_block,
+                ),
+            ));
+        }
+
+        // Checks for Shanghai timestamp incompatibility between configurations.
+        if self.are_fork_timestamps_incompatible(
+            rhs_config,
+            self.shanghai_time,
+            rhs_config.shanghai_time,
+            head_timestamp,
+        ) {
+            return Err(ConfigCompatError::ShanghaiTimestampError(
+                self.shanghai_time,
+                rhs_config.shanghai_time,
+                Self::block_or_timestamp_to_rewind(self.shanghai_time, rhs_config.shanghai_time),
+            ));
+        }
+
+        // Checks for Cancun timestamp incompatibility between configurations.
+        if self.are_fork_timestamps_incompatible(
+            rhs_config,
+            self.cancun_time,
+            rhs_config.cancun_time,
+            head_timestamp,
+        ) {
+            return Err(ConfigCompatError::CancunTimestampError(
+                self.cancun_time,
+                rhs_config.cancun_time,
+                Self::block_or_timestamp_to_rewind(self.cancun_time, rhs_config.cancun_time),
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Calculates the block or timestamp to rewind based on stored and new values.
+    ///
+    /// Returns the rewind value.
+    fn block_or_timestamp_to_rewind(stored_value: Option<u64>, new_value: Option<u64>) -> u64 {
+        stored_value.map_or(new_value, |s| new_value.filter(|&n| s < n)).map_or(0, |value| {
+            if value > 0 {
+                value - 1
+            } else {
+                0
+            }
+        })
+    }
+
+    /// Checks if two fork blocks are incompatible based on given configurations and block number.
+    fn are_fork_blocks_incompatible(
+        &self,
+        rhs_config: &Self,
+        lhs_config_block: Option<u64>,
+        rhs_config_block: Option<u64>,
+        block: u64,
+    ) -> bool {
+        (self.is_active_at_block(lhs_config_block, block) ||
+            rhs_config.is_active_at_block(rhs_config_block, block)) &&
+            !(lhs_config_block.unwrap_or_default() == rhs_config_block.unwrap_or_default())
+    }
+
+    /// Checks if two fork timestamps are incompatible based on given configurations and timestamp.
+    fn are_fork_timestamps_incompatible(
+        &self,
+        rhs_config: &Self,
+        lhs_config_timestamp: Option<u64>,
+        rhs_config_timestamp: Option<u64>,
+        timestamp: u64,
+    ) -> bool {
+        (self.is_active_at_timestamp(lhs_config_timestamp, timestamp) ||
+            rhs_config.is_active_at_timestamp(rhs_config_timestamp, timestamp)) &&
+            !(lhs_config_timestamp.unwrap_or_default() ==
+                rhs_config_timestamp.unwrap_or_default())
     }
 }
 
@@ -1268,6 +1728,97 @@ mod tests {
             deserialized_genesis, expected_genesis,
             "deserialized genesis
     {deserialized_genesis:#?} does not match expected {expected_genesis:#?}"
+        );
+    }
+
+    #[test]
+    fn test_are_configs_compatible() {
+        // Create a sample chain configuration with default values.
+        let lhs_chain_config = ChainConfig {
+            ethash: Some(EthashConfig {}),
+            chain_id: 10,
+            homestead_block: Some(0),
+            eip150_block: Some(0),
+            eip155_block: Some(0),
+            eip158_block: Some(0),
+            byzantium_block: Some(0),
+            constantinople_block: Some(0),
+            petersburg_block: Some(0),
+            istanbul_block: Some(0),
+            ..Default::default()
+        };
+
+        // Create a configuration with a block (London) set at a specific height (34).
+        let rhs_chain_config_incompatible_london = ChainConfig {
+            ethash: Some(EthashConfig {}),
+            chain_id: 10,
+            homestead_block: Some(0),
+            eip150_block: Some(0),
+            eip155_block: Some(0),
+            eip158_block: Some(0),
+            byzantium_block: Some(0),
+            constantinople_block: Some(0),
+            petersburg_block: Some(0),
+            istanbul_block: Some(0),
+            london_block: Some(34),
+            ..Default::default()
+        };
+
+        // Create a configuration with a specific time (Shanghai) set at a value (233).
+        let rhs_chain_config_incompatible_shanghai = ChainConfig {
+            ethash: Some(EthashConfig {}),
+            chain_id: 10,
+            homestead_block: Some(0),
+            eip150_block: Some(0),
+            eip155_block: Some(0),
+            eip158_block: Some(0),
+            byzantium_block: Some(0),
+            constantinople_block: Some(0),
+            petersburg_block: Some(0),
+            istanbul_block: Some(0),
+            shanghai_time: Some(233),
+            ..Default::default()
+        };
+
+        // Test the compatibility between the lhs and itself, expecting Ok(()) as the result.
+        assert_eq!(lhs_chain_config.are_configs_compatible(&lhs_chain_config, 100, 100), Ok(()));
+
+        // Test compatibility between lhs and a config with London block set at 34 and different
+        // head blocks/timestamps.
+        assert_eq!(
+            lhs_chain_config.are_configs_compatible(&rhs_chain_config_incompatible_london, 22, 200),
+            Ok(())
+        );
+
+        // Test incompatibility due to different London block heights and the resulting error.
+        assert_eq!(
+            lhs_chain_config.are_configs_compatible(
+                &rhs_chain_config_incompatible_london,
+                100,
+                200
+            ),
+            Err(ConfigCompatError::LondonBlockError(None, Some(34), 33))
+        );
+
+        // Test compatibility between lhs and config with Shanghai time set at 233 and different
+        // head blocks/timestamps.
+        assert_eq!(
+            lhs_chain_config.are_configs_compatible(
+                &rhs_chain_config_incompatible_shanghai,
+                100,
+                10
+            ),
+            Ok(())
+        );
+
+        // Test incompatibility due to different Shanghai times and the resulting error.
+        assert_eq!(
+            lhs_chain_config.are_configs_compatible(
+                &rhs_chain_config_incompatible_shanghai,
+                100,
+                300
+            ),
+            Err(ConfigCompatError::ShanghaiTimestampError(None, Some(233), 232))
         );
     }
 }


### PR DESCRIPTION
### Description
This pull request implements the `are_configs_compatible` function for the `ChainConfig` struct. This function allows the comparison of two chain configurations to determine compatibility. It performs various checks related to fork blocks, support flags, chain IDs, timestamps, and more.

### Changes Made
- Implemented the `are_configs_compatible` function within the `ChainConfig` struct.
- Added comprehensive checks to verify the compatibility of two chain configurations.
- Introduced error handling to address various compatibility issues between configurations.

### Usage Example
```rust
// Example usage of are_configs_compatible function
let config1 = ChainConfig{/* configuration parameters */};
let config2 = ChainConfig{/* configuration parameters */};

match config1.are_configs_compatible(&config2, /* block_number */, /* timestamp */) {
    Ok(_) => println!("Configurations are compatible."),
    Err(e) => eprintln!("Compatibility check failed: {:?}", e),
}
```

### Potential changes
As the number of hardforks is quite high and will continue to be so, we could also make a more generic error like:

```rust
/// ConfigCompatError represents errors that occur when initializing the local blockchain
/// with a ChainConfig that would affect the historical state.
#[derive(Clone, Debug, PartialEq, Eq, Error)]
pub enum ConfigCompatError {
     /// Error related to changes in block numbers in stored and new configurations
     /// requiring a rewind to correct the issue.
     #[error("Block-based forking error: {0}")]
     BlockForkError {
         #[from]
         what: String,
         stored_block: Option<u64>,
         new_block: Option<u64>,
         rewind_to_block: u64,
     },
    
     /// Error related to changes in timestamps in stored and new configurations
     /// requiring a rewind to correct the issue.
     #[error("Time-based forking error: {0}")]
     TimeForkError {
         #[from]
         what: String,
         stored_time: Option<u64>,
         new_time: Option<u64>,
         rewind_to_time: u64,
     },
}
```

but I had the feeling that a specific error per case of incompatibility was more precise and allowed later reuse (more versatile in short).
