### PR TITLE
chore: fix clippy warnings for windows

### DIFF
--- a/bin/reth/src/main.rs
+++ b/bin/reth/src/main.rs
@@ -1,5 +1,6 @@
 // We use jemalloc for performance reasons
 #![allow(missing_docs)]
+
 #[cfg(all(feature = "jemalloc", unix))]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -464,7 +464,7 @@ impl Default for ExecutionStageThresholds {
         Self {
             max_blocks: Some(500_000),
             max_changes: Some(5_000_000),
-            // 30M block per gas on 50k blocks
+            // 30M gas per block on 50k blocks
             max_cumulative_gas: Some(30_000_000 * 50_000),
         }
     }


### PR DESCRIPTION
```console
warning: unused imports: `MDBX_env`, `MDBX_hsr_func`, `MDBX_txn`, `mdbx_pid_t`, `mdbx_tid_t`
 --> crates/storage/libmdbx-rs/src/environment.rs:9:11
  |
9 | use ffi::{mdbx_pid_t, mdbx_tid_t, MDBX_env, MDBX_hsr_func, MDBX_txn};
  |           ^^^^^^^^^^  ^^^^^^^^^^  ^^^^^^^^  ^^^^^^^^^^^^^  ^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

   Compiling boa_macros v0.17.3
warning: field `handle_slow_readers` is never read
   --> crates/storage/libmdbx-rs/src/environment.rs:598:5
    |
585 | pub struct EnvironmentBuilder {
    |            ------------------ field in this struct
...
598 |     handle_slow_readers: Option<HandleSlowReadersCallback>,
    |     ^^^^^^^^^^^^^^^^^^^
```

```console
warning: unused import: `HandleSlowReadersReturnCode`
  --> crates/storage/db/src/implementation/mdbx/mod.rs:15:61
   |
15 |     DatabaseFlags, Environment, EnvironmentFlags, Geometry, HandleSlowReadersReturnCode, Mode,
   |                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused import: `warn`
  --> crates/storage/db/src/implementation/mdbx/mod.rs:18:36
   |
18 | use reth_tracing::tracing::{error, warn};
   |                                    ^^^^

warning: constant `MAX_SAFE_READER_SPACE` is never used
  --> crates/storage/db/src/implementation/mdbx/mod.rs:33:7
   |
33 | const MAX_SAFE_READER_SPACE: usize = 10 * GIGABYTE;
   |       ^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: static `PROCESS_ID` is never used
  --> crates/storage/db/src/implementation/mdbx/mod.rs:35:8
   |
35 | static PROCESS_ID: Lazy<u32> = Lazy::new(|| {
   |        ^^^^^^^^^^
```

```console
warning: unused import: `gauge`
 --> bin/reth/src/prometheus_exporter.rs:8:31
  |
8 | use metrics::{describe_gauge, gauge};
  |                               ^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused import: `tracing::error`
  --> bin/reth/src/prometheus_exporter.rs:14:5
   |
14 | use tracing::error;
   |     ^^^^^^^^^^^^^^
```