### PR TITLE
improve usability of schnellru::LruMap and LruCache (LinkedHashSet cache) 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6219,6 +6219,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "criterion",
+ "derive_more",
  "enr",
  "ethers-core",
  "ethers-middleware",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6251,6 +6251,7 @@ dependencies = [
  "reth-tokio-util",
  "reth-tracing",
  "reth-transaction-pool",
+ "schnellru",
  "secp256k1 0.27.0",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,6 +189,7 @@ aquamarine = "0.4"
 bytes = "1.5"
 bitflags = "2.4"
 clap = "4"
+derive_more = { version = "0.99.17", default-features = false, features = ["deref", "deref_mut"] }
 eyre = "0.6"
 tracing = "0.1.0"
 tracing-appender = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ aquamarine = "0.4"
 bytes = "1.5"
 bitflags = "2.4"
 clap = "4"
-derive_more = { version = "0.99.17", default-features = false, features = ["deref", "deref_mut"] }
+derive_more = "0.99.17"
 eyre = "0.6"
 tracing = "0.1.0"
 tracing-appender = "0.2"

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -63,7 +63,8 @@ linked_hash_set = "0.1"
 linked-hash-map = "0.5.6"
 rand.workspace = true
 secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery"] }
-derive_more = { version = "0.99.17", default-features = false, features = ["deref", "deref_mut"] }
+derive_more.workspace = true
+schnellru.workspace = true
 
 enr = { workspace = true, features = ["rust-secp256k1"], optional = true }
 tempfile = { workspace = true, optional = true }

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -63,6 +63,7 @@ linked_hash_set = "0.1"
 linked-hash-map = "0.5.6"
 rand.workspace = true
 secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery"] }
+derive_more = { version = "0.99.17", default-features = false, features = ["deref", "deref_mut"] }
 
 enr = { workspace = true, features = ["rust-secp256k1"], optional = true }
 tempfile = { workspace = true, optional = true }

--- a/crates/net/network/src/cache.rs
+++ b/crates/net/network/src/cache.rs
@@ -182,4 +182,25 @@ mod test {
             assert!(cache.contains(e));
         }
     }
+
+    #[test]
+    fn test_debug_impl_lru_map() {
+        use derive_more::Display;
+
+        #[derive(Debug, Hash, PartialEq, Eq, Display)]
+        struct Key(i8);
+
+        #[derive(Debug)]
+        struct Value(i8);
+
+        let mut cache = LruMap::new(2);
+        let key_1 = Key(1);
+        let value_1 = Value(11);
+        cache.insert(key_1, value_1);
+        let key_2 = Key(2);
+        let value_2 = Value(22);
+        cache.insert(key_2, value_2);
+
+        assert_eq!("LruMap { 2: Value(22), 1: Value(11) }", format!("{cache:?}"))
+    }
 }

--- a/crates/net/network/src/cache.rs
+++ b/crates/net/network/src/cache.rs
@@ -34,14 +34,8 @@ impl<T: Hash + Eq> LruCache<T> {
     /// If the set did not have this value present, true is returned.
     /// If the set did have this value present, false is returned.
     pub fn insert(&mut self, entry: T) -> bool {
-        if self.inner.insert(entry) {
-            if self.limit.get() == self.inner.len() {
-                // remove the oldest element in the set
-                _ = self.remove_lru();
-            }
-            return true
-        }
-        false
+        let (new_entry, evicted_val) = self.insert_with_eviction_feedback(entry);
+        new_entry
     }
 
     /// Same as [`Self::insert`] but returns a tuple, where the second index is the evicted value,

--- a/crates/net/network/src/cache.rs
+++ b/crates/net/network/src/cache.rs
@@ -34,13 +34,13 @@ impl<T: Hash + Eq> LruCache<T> {
     /// If the set did not have this value present, true is returned.
     /// If the set did have this value present, false is returned.
     pub fn insert(&mut self, entry: T) -> bool {
-        let (new_entry, evicted_val) = self.insert_with_eviction_feedback(entry);
+        let (new_entry, evicted_val) = self.insert_and_get_evicted(entry);
         new_entry
     }
 
     /// Same as [`Self::insert`] but returns a tuple, where the second index is the evicted value,
     /// if one was evicted.
-    pub fn insert_with_eviction_feedback(&mut self, entry: T) -> (bool, Option<T>) {
+    pub fn insert_and_get_evicted(&mut self, entry: T) -> (bool, Option<T>) {
         if self.inner.insert(entry) {
             if self.limit.get() == self.inner.len() {
                 // remove the oldest element in the set

--- a/crates/net/network/src/cache.rs
+++ b/crates/net/network/src/cache.rs
@@ -59,8 +59,7 @@ impl<T: Hash + Eq> LruCache<T> {
 
     /// Remove the least recently used entry and return it.
     ///
-    /// If the `LruCache` is empty or if the eviction feedback is
-    /// configured, this will return None.
+    /// If the `LruCache` is empty this will return None.
     #[inline]
     fn remove_lru(&mut self) -> Option<T> {
         self.inner.pop_front()

--- a/crates/net/network/src/cache.rs
+++ b/crates/net/network/src/cache.rs
@@ -34,7 +34,7 @@ impl<T: Hash + Eq> LruCache<T> {
     /// If the set did not have this value present, true is returned.
     /// If the set did have this value present, false is returned.
     pub fn insert(&mut self, entry: T) -> bool {
-        let (new_entry, evicted_val) = self.insert_and_get_evicted(entry);
+        let (new_entry, _evicted_val) = self.insert_and_get_evicted(entry);
         new_entry
     }
 
@@ -59,6 +59,7 @@ impl<T: Hash + Eq> LruCache<T> {
         self.inner.pop_front()
     }
 
+    #[allow(dead_code)]
     /// Expels the given value. Returns true if the value existed.
     pub fn remove(&mut self, value: &T) -> bool {
         self.inner.remove(value)
@@ -80,12 +81,14 @@ impl<T: Hash + Eq> LruCache<T> {
 
     /// Returns number of elements currently in cache.
     #[cfg(test)]
+    #[allow(dead_code)]
     pub fn len(&self) -> usize {
         self.inner.len()
     }
 
     /// Returns `true` if there are currently no elements in the cache.
     #[cfg(test)]
+    #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
@@ -133,6 +136,7 @@ where
     K: Hash + PartialEq,
 {
     /// Returns a new cache with default limiter and hash builder.
+    #[allow(dead_code)]
     pub fn new(max_length: u32) -> Self {
         LruMap(schnellru::LruMap::new(ByLength::new(max_length)))
     }
@@ -143,6 +147,7 @@ where
     K: Hash + PartialEq,
 {
     /// Returns a new cache with [`Unlimited`] limiter and default hash builder.
+    #[allow(dead_code)]
     pub fn new_unlimited() -> Self {
         LruMap(schnellru::LruMap::new(Unlimited))
     }

--- a/crates/net/network/src/cache.rs
+++ b/crates/net/network/src/cache.rs
@@ -1,10 +1,10 @@
+use core::hash::BuildHasher;
 use derive_more::{Deref, DerefMut};
 use linked_hash_set::LinkedHashSet;
-use schnellru::{self, ByLength};
+use schnellru::{self, ByLength, Limiter, RandomState, Unlimited};
 use std::{
     borrow::Borrow,
     fmt::{self, Write},
-    hash,
     hash::Hash,
     num::NonZeroUsize,
 };
@@ -46,7 +46,7 @@ impl<T: Hash + Eq> LruCache<T> {
 
     /// Same as [`Self::insert`] but returns a tuple, where the second index is the evicted value,
     /// if one was evicted.
-    pub fn _insert_with_eviction_feedback(&mut self, entry: T) -> (bool, Option<T>) {
+    pub fn insert_with_eviction_feedback(&mut self, entry: T) -> (bool, Option<T>) {
         if self.inner.insert(entry) {
             if self.limit.get() == self.inner.len() {
                 // remove the oldest element in the set
@@ -66,7 +66,7 @@ impl<T: Hash + Eq> LruCache<T> {
     }
 
     /// Expels the given value. Returns true if the value existed.
-    pub fn _remove(&mut self, value: &T) -> bool {
+    pub fn remove(&mut self, value: &T) -> bool {
         self.inner.remove(value)
     }
 
@@ -83,6 +83,18 @@ impl<T: Hash + Eq> LruCache<T> {
     pub fn iter(&self) -> impl Iterator<Item = &T> + '_ {
         self.inner.iter()
     }
+
+    /// Returns number of elements currently in cache.
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Returns `true` if there are currently no elements in the cache.
+    #[cfg(test)]
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
 }
 
 impl<T> Extend<T> for LruCache<T>
@@ -98,14 +110,18 @@ where
 
 /// Wrapper of [`schnellru::LruMap`] that implements [`fmt::Debug`].
 #[derive(Deref, DerefMut)]
-pub struct LruMap<K, V>(schnellru::LruMap<K, V>)
+pub struct LruMap<K, V, L = ByLength, S = RandomState>(schnellru::LruMap<K, V, L, S>)
 where
-    K: hash::Hash + PartialEq;
+    K: Hash + PartialEq,
+    L: Limiter<K, V>,
+    S: BuildHasher;
 
-impl<K, V> fmt::Debug for LruMap<K, V>
+impl<K, V, L, S> fmt::Debug for LruMap<K, V, L, S>
 where
-    K: hash::Hash + PartialEq + fmt::Display,
+    K: Hash + PartialEq + fmt::Display,
     V: fmt::Debug,
+    L: Limiter<K, V>,
+    S: BuildHasher,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut debug_struct = f.debug_struct("LruMap");
@@ -120,19 +136,21 @@ where
 
 impl<K, V> LruMap<K, V>
 where
-    K: hash::Hash + PartialEq,
+    K: Hash + PartialEq,
 {
+    /// Returns a new cache with default limiter and hash builder.
     pub fn new(max_length: u32) -> Self {
-        Self(schnellru::LruMap::new(ByLength::new(max_length)))
+        LruMap(schnellru::LruMap::new(ByLength::new(max_length)))
     }
 }
 
-impl<K, V> From<LruMap<K, V>> for schnellru::LruMap<K, V>
+impl<K, V> LruMap<K, V, Unlimited>
 where
-    K: hash::Hash + PartialEq,
+    K: Hash + PartialEq,
 {
-    fn from(value: LruMap<K, V>) -> Self {
-        value.0
+    /// Returns a new cache with [`Unlimited`] limiter and default hash builder.
+    pub fn new_unlimited() -> Self {
+        LruMap(schnellru::LruMap::new(Unlimited))
     }
 }
 

--- a/crates/net/network/src/cache.rs
+++ b/crates/net/network/src/cache.rs
@@ -184,6 +184,7 @@ mod test {
     }
 
     #[test]
+    #[allow(dead_code)]
     fn test_debug_impl_lru_map() {
         use derive_more::Display;
 


### PR DESCRIPTION
- Wrapper of schnellru::LruMap that implements Debug to make it easier to include in structs for which Debug is derived.
- Configurable eviction feedback for LruCache (LinkedHashSet cache).