### PR TITLE
feat: add GenesisAllocator for easier genesis alloc creation

### DIFF
--- a/bin/reth/src/builder/mod.rs
+++ b/bin/reth/src/builder/mod.rs
@@ -1452,6 +1452,7 @@ mod tests {
         // spawn_test_node takes roughly 1 second per node, so this test takes ~4 seconds
         let num_nodes = 4;
 
+        // this reserves instances 3-6
         let starting_instance = 3;
         let mut handles = Vec::new();
         for i in 0..num_nodes {

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -2351,7 +2351,7 @@ mod tests {
     mod new_payload {
         use super::*;
         use reth_interfaces::test_utils::{generators, generators::random_block};
-        use reth_primitives::{AllocBuilder, Genesis, Hardfork, U256};
+        use reth_primitives::{Genesis, GenesisAllocator, Hardfork, U256};
         use reth_provider::test_utils::blocks::BlockChainTestData;
 
         #[tokio::test]
@@ -2457,13 +2457,13 @@ mod tests {
             let mut rng = generators::rng();
             // let genesis_keys = generate_keys(&mut rng, 16);
             let amount = 1000000000000000000u64;
-            let mut alloc_builder = AllocBuilder::default().with_rng(&mut rng);
+            let mut allocator = GenesisAllocator::default().with_rng(&mut rng);
             for _ in 0..16 {
                 // add 16 new accounts
-                alloc_builder.new_funded_account(U256::from(amount));
+                allocator.new_funded_account(U256::from(amount));
             }
 
-            let alloc = alloc_builder.build();
+            let alloc = allocator.build();
 
             let genesis = Genesis::default().extend_accounts(alloc);
 

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -2350,11 +2350,8 @@ mod tests {
 
     mod new_payload {
         use super::*;
-        use reth_interfaces::test_utils::{
-            generators,
-            generators::{generate_keys, random_block},
-        };
-        use reth_primitives::{public_key_to_address, Genesis, GenesisAccount, Hardfork, U256};
+        use reth_interfaces::test_utils::{generators, generators::random_block};
+        use reth_primitives::{AllocBuilder, Genesis, Hardfork, U256};
         use reth_provider::test_utils::blocks::BlockChainTestData;
 
         #[tokio::test]
@@ -2458,14 +2455,15 @@ mod tests {
         #[tokio::test]
         async fn simple_validate_block() {
             let mut rng = generators::rng();
-            let genesis_keys = generate_keys(&mut rng, 16);
+            // let genesis_keys = generate_keys(&mut rng, 16);
             let amount = 1000000000000000000u64;
-            let alloc = genesis_keys.iter().map(|pair| {
-                (
-                    public_key_to_address(pair.public_key()),
-                    GenesisAccount::default().with_balance(U256::from(amount)),
-                )
-            });
+            let mut alloc_builder = AllocBuilder::default().with_rng(&mut rng);
+            for _ in 0..16 {
+                // add 16 new accounts
+                alloc_builder.new_funded_account(U256::from(amount));
+            }
+
+            let alloc = alloc_builder.build();
 
             let genesis = Genesis::default().extend_accounts(alloc);
 

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -2455,12 +2455,11 @@ mod tests {
         #[tokio::test]
         async fn simple_validate_block() {
             let mut rng = generators::rng();
-            // let genesis_keys = generate_keys(&mut rng, 16);
-            let amount = 1000000000000000000u64;
+            let amount = U256::from(1000000000000000000u64);
             let mut allocator = GenesisAllocator::default().with_rng(&mut rng);
             for _ in 0..16 {
                 // add 16 new accounts
-                allocator.new_funded_account(U256::from(amount));
+                allocator.new_funded_account(amount);
             }
 
             let alloc = allocator.build();

--- a/crates/primitives/src/genesis.rs
+++ b/crates/primitives/src/genesis.rs
@@ -278,12 +278,78 @@ impl<'a> GenesisAllocator<'a> {
         (pair, address)
     }
 
+    /// Adds a funded account to the genesis alloc with the provided storage.
+    ///
+    /// Returns the key pair for the account and the account's address.
+    pub fn new_funded_account_with_storage(
+        &mut self,
+        balance: U256,
+        storage: HashMap<B256, B256>,
+    ) -> (KeyPair, Address) {
+        let secp = Secp256k1::new();
+        let pair = KeyPair::new(&secp, &mut self.rng);
+        let address = public_key_to_address(pair.public_key());
+
+        self.alloc.insert(
+            address,
+            GenesisAccount::default().with_balance(balance).with_storage(Some(storage)),
+        );
+
+        (pair, address)
+    }
+
+    /// Adds an account with code and storage to the genesis alloc.
+    ///
+    /// Returns the key pair for the account and the account's address.
+    pub fn new_account_with_code_and_storage(
+        &mut self,
+        code: Bytes,
+        storage: HashMap<B256, B256>,
+    ) -> (KeyPair, Address) {
+        let secp = Secp256k1::new();
+        let pair = KeyPair::new(&secp, &mut self.rng);
+        let address = public_key_to_address(pair.public_key());
+
+        self.alloc.insert(
+            address,
+            GenesisAccount::default().with_code(Some(code)).with_storage(Some(storage)),
+        );
+
+        (pair, address)
+    }
+
+    /// Adds an account with code to the genesis alloc.
+    ///
+    /// Returns the key pair for the account and the account's address.
+    pub fn new_account_with_code(&mut self, code: Bytes) -> (KeyPair, Address) {
+        let secp = Secp256k1::new();
+        let pair = KeyPair::new(&secp, &mut self.rng);
+        let address = public_key_to_address(pair.public_key());
+
+        self.alloc.insert(address, GenesisAccount::default().with_code(Some(code)));
+
+        (pair, address)
+    }
+
     /// Add a funded account to the genesis alloc with the provided address.
     ///
     /// Neither the key pair nor the account will be returned, since the address is provided by the
     /// user and the signer may be unknown.
     pub fn add_funded_account_with_address(&mut self, address: Address, balance: U256) {
         self.alloc.insert(address, GenesisAccount::default().with_balance(balance));
+    }
+
+    /// Adds the given [GenesisAccount] to the genesis alloc.
+    ///
+    /// Returns the key pair for the account and the account's address.
+    pub fn add_account(&mut self, account: GenesisAccount) -> Address {
+        let secp = Secp256k1::new();
+        let pair = KeyPair::new(&secp, &mut self.rng);
+        let address = public_key_to_address(pair.public_key());
+
+        self.alloc.insert(address, account);
+
+        address
     }
 
     /// Gets the account for the provided address.

--- a/crates/primitives/src/genesis.rs
+++ b/crates/primitives/src/genesis.rs
@@ -199,23 +199,24 @@ impl<T> RngDebugClone for T where T: RngCore + std::fmt::Debug {}
 ///
 /// # Example
 /// ```
-/// # use reth_primitives::AllocBuilder;
+/// # use reth_primitives::{AllocBuilder, Address, U256, hex, Bytes};
+/// # use std::str::FromStr;
 /// let mut builder = AllocBuilder::default();
 ///
 /// // This will add a genesis account to the alloc builder, with the provided balance. The
 /// // signer for the account will be returned.
-/// let (_signer, _addr) = builder.new_funded_account(100_000_000_000_000_000u128.into());
+/// let (_signer, _addr) = builder.new_funded_account(U256::from(100_000_000_000_000_000u128));
 ///
 /// // You can also provide code for the account.
-/// let code = hex::decode("0x1234").unwrap();
+/// let code = Bytes::from_str("0x1234").unwrap();
 /// let (_second_signer, _second_addr) =
-///     builder.new_funded_account_with_code(100_000_000_000_000_000u128.into(), code);
+///     builder.new_funded_account_with_code(U256::from(100_000_000_000_000_000u128), code);
 ///
 /// // You can also add an account with a specific address.
 /// // This will not return a signer, since the address is provided by the user and the signer
 /// // may be unknown.
 /// let addr = "0Ac1dF02185025F65202660F8167210A80dD5086".parse::<Address>().unwrap();
-/// builder.add_funded_account_with_address(addr, 100_000_000_000_000_000u128.into());
+/// builder.add_funded_account_with_address(addr, U256::from(100_000_000_000_000_000u128));
 ///
 /// // Once you're done adding accounts, you can build the alloc.
 /// let alloc = builder.build();

--- a/crates/primitives/src/genesis.rs
+++ b/crates/primitives/src/genesis.rs
@@ -199,37 +199,37 @@ impl<T> RngDebugClone for T where T: RngCore + std::fmt::Debug {}
 ///
 /// # Example
 /// ```
-/// # use reth_primitives::{AllocBuilder, Address, U256, hex, Bytes};
+/// # use reth_primitives::{GenesisAllocator, Address, U256, hex, Bytes};
 /// # use std::str::FromStr;
-/// let mut builder = AllocBuilder::default();
+/// let mut allocator = GenesisAllocator::default();
 ///
 /// // This will add a genesis account to the alloc builder, with the provided balance. The
 /// // signer for the account will be returned.
-/// let (_signer, _addr) = builder.new_funded_account(U256::from(100_000_000_000_000_000u128));
+/// let (_signer, _addr) = allocator.new_funded_account(U256::from(100_000_000_000_000_000u128));
 ///
 /// // You can also provide code for the account.
 /// let code = Bytes::from_str("0x1234").unwrap();
 /// let (_second_signer, _second_addr) =
-///     builder.new_funded_account_with_code(U256::from(100_000_000_000_000_000u128), code);
+///     allocator.new_funded_account_with_code(U256::from(100_000_000_000_000_000u128), code);
 ///
 /// // You can also add an account with a specific address.
 /// // This will not return a signer, since the address is provided by the user and the signer
 /// // may be unknown.
 /// let addr = "0Ac1dF02185025F65202660F8167210A80dD5086".parse::<Address>().unwrap();
-/// builder.add_funded_account_with_address(addr, U256::from(100_000_000_000_000_000u128));
+/// allocator.add_funded_account_with_address(addr, U256::from(100_000_000_000_000_000u128));
 ///
 /// // Once you're done adding accounts, you can build the alloc.
-/// let alloc = builder.build();
+/// let alloc = allocator.build();
 /// ```
 #[derive(Debug)]
-pub struct AllocBuilder<'a> {
+pub struct GenesisAllocator<'a> {
     /// The genesis alloc to be built.
     alloc: HashMap<Address, GenesisAccount>,
     /// The rng to use for generating key pairs.
     rng: Box<dyn RngDebugClone + 'a>,
 }
 
-impl<'a> AllocBuilder<'a> {
+impl<'a> GenesisAllocator<'a> {
     /// Initialize a new alloc builder with the provided rng.
     pub fn new_with_rng<R>(rng: &'a mut R) -> Self
     where
@@ -309,7 +309,7 @@ impl<'a> AllocBuilder<'a> {
     }
 }
 
-impl Default for AllocBuilder<'_> {
+impl Default for GenesisAllocator<'_> {
     fn default() -> Self {
         Self { alloc: HashMap::default(), rng: Box::new(thread_rng()) }
     }

--- a/crates/primitives/src/genesis.rs
+++ b/crates/primitives/src/genesis.rs
@@ -198,30 +198,27 @@ impl<T> RngDebugClone for T where T: RngCore + std::fmt::Debug {}
 /// signers to the genesis block.
 ///
 /// # Example
-/// ```no_run
-/// use reth_primitives::genesis::AllocBuilder;
+/// ```
+/// # use reth_primitives::AllocBuilder;
+/// let mut builder = AllocBuilder::default();
 ///
-/// fn custom_genesis() {
-///     let mut builder = AllocBuilder::default();
+/// // This will add a genesis account to the alloc builder, with the provided balance. The
+/// // signer for the account will be returned.
+/// let (_signer, _addr) = builder.new_funded_account(100_000_000_000_000_000u128.into());
 ///
-///     // This will add a genesis account to the alloc builder, with the provided balance. The
-///     // signer for the account will be returned.
-///     let (_signer, _addr) = builder.new_funded_account(100_000_000_000_000_000u128.into());
+/// // You can also provide code for the account.
+/// let code = hex::decode("0x1234").unwrap();
+/// let (_second_signer, _second_addr) =
+///     builder.new_funded_account_with_code(100_000_000_000_000_000u128.into(), code);
 ///
-///     // You can also provide code for the account.
-///     let code = hex::decode("0x1234").unwrap();
-///     let (_second_signer, _second_addr) =
-///         builder.new_funded_account_with_code(100_000_000_000_000_000u128.into(), code);
+/// // You can also add an account with a specific address.
+/// // This will not return a signer, since the address is provided by the user and the signer
+/// // may be unknown.
+/// let addr = "0Ac1dF02185025F65202660F8167210A80dD5086".parse::<Address>().unwrap();
+/// builder.add_funded_account_with_address(addr, 100_000_000_000_000_000u128.into());
 ///
-///     // You can also add an account with a specific address.
-///     // This will not return a signer, since the address is provided by the user and the signer
-///     // may be unknown.
-///     let addr = "0Ac1dF02185025F65202660F8167210A80dD5086".parse::<Address>().unwrap();
-///     builder.add_funded_account_with_address(addr, 100_000_000_000_000_000u128.into());
-///
-///     // Once you're done adding accounts, you can build the alloc.
-///     let alloc = builder.build();
-/// }
+/// // Once you're done adding accounts, you can build the alloc.
+/// let alloc = builder.build();
 /// ```
 #[derive(Debug)]
 pub struct AllocBuilder<'a> {
@@ -232,11 +229,18 @@ pub struct AllocBuilder<'a> {
 }
 
 impl<'a> AllocBuilder<'a> {
-    /// Use the provided rng for generating key pairs.
-    pub fn with_rng<'b, R>(mut self, rng: &'b mut R) -> Self
+    /// Initialize a new alloc builder with the provided rng.
+    pub fn new_with_rng<R>(rng: &'a mut R) -> Self
     where
         R: RngCore + std::fmt::Debug,
-        'b: 'a,
+    {
+        Self { alloc: HashMap::default(), rng: Box::new(rng) }
+    }
+
+    /// Use the provided rng for generating key pairs.
+    pub fn with_rng<R>(mut self, rng: &'a mut R) -> Self
+    where
+        R: RngCore + std::fmt::Debug,
     {
         self.rng = Box::new(rng);
         self

--- a/crates/primitives/src/genesis.rs
+++ b/crates/primitives/src/genesis.rs
@@ -191,8 +191,8 @@ impl From<GenesisAccount> for Account {
 
 /// Helper trait that encapsulates [RngCore], and [Debug](std::fmt::Debug) to get around rules for
 /// auto traits (Opt-in built-in traits).
-trait RngDebugClone: RngCore + std::fmt::Debug {}
-impl<T> RngDebugClone for T where T: RngCore + std::fmt::Debug {}
+trait RngDebug: RngCore + std::fmt::Debug {}
+impl<T> RngDebug for T where T: RngCore + std::fmt::Debug {}
 
 /// This helps create a custom genesis alloc by making it easy to add funded accounts with known
 /// signers to the genesis block.
@@ -226,7 +226,7 @@ pub struct GenesisAllocator<'a> {
     /// The genesis alloc to be built.
     alloc: HashMap<Address, GenesisAccount>,
     /// The rng to use for generating key pairs.
-    rng: Box<dyn RngDebugClone + 'a>,
+    rng: Box<dyn RngDebug + 'a>,
 }
 
 impl<'a> GenesisAllocator<'a> {

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -59,7 +59,7 @@ pub use constants::{
     KECCAK_EMPTY, MAINNET_GENESIS_HASH, SEPOLIA_GENESIS_HASH,
 };
 pub use error::{GotExpected, GotExpectedBoxed};
-pub use genesis::{AllocBuilder, ChainConfig, Genesis, GenesisAccount};
+pub use genesis::{ChainConfig, Genesis, GenesisAccount, GenesisAllocator};
 pub use header::{Header, HeadersDirection, SealedHeader};
 pub use integer_list::IntegerList;
 pub use log::{logs_bloom, Log};

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -59,7 +59,7 @@ pub use constants::{
     KECCAK_EMPTY, MAINNET_GENESIS_HASH, SEPOLIA_GENESIS_HASH,
 };
 pub use error::{GotExpected, GotExpectedBoxed};
-pub use genesis::{ChainConfig, Genesis, GenesisAccount};
+pub use genesis::{AllocBuilder, ChainConfig, Genesis, GenesisAccount};
 pub use header::{Header, HeadersDirection, SealedHeader};
 pub use integer_list::IntegerList;
 pub use log::{logs_bloom, Log};


### PR DESCRIPTION
Added `AllocBuilder` which should be useful for creating custom genesis files. New accounts in the alloc can be created, and the `KeyPair` for the account will be returned.

This would be useful in integration tests that have the following pattern:
1. Create genesis with funded accounts
2. Initialize test reth node with that genesis
3. Create valid signed transactions from those accounts
4. Send `engine_newPayload` call containing those transactions
5. Check some property, the test either succeeds or fails