### PR TITLE
fix: Add canyon to `base mainnet`

### DIFF
--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -422,6 +422,7 @@ pub static BASE_MAINNET: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
             ),
             (Hardfork::Bedrock, ForkCondition::Block(0)),
             (Hardfork::Regolith, ForkCondition::Timestamp(0)),
+            (Hardfork::Canyon, ForkCondition::Timestamp(1704992401)),
         ]),
         base_fee_params: BaseFeeParamsKind::Variable(
             vec![


### PR DESCRIPTION
## Overview

> Needs https://github.com/paradigmxyz/reth/pull/6033

Adds the `Canyon` hardfork to the base mainnet chain spec, which went live this morning at `1704992401`.