### PR TITLE
chore(db): format backtrace

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -211,9 +211,8 @@ impl<K: TransactionKind> MetricsHandler<K> {
                 warn!(
                     target: "storage::db::mdbx",
                     ?open_duration,
-                    ?backtrace,
                     %self.txn_id,
-                    "The database read transaction has been open for too long"
+                    "The database read transaction has been open for too long. Backtrace: {}", backtrace.to_string()
                 );
             }
         }


### PR DESCRIPTION
## Description

Debug implementation of `Backtrace` is impossible to read. Log formatted version instead.

Backtrace debug output:
<img width="1225" alt="Screenshot 2024-01-12 at 13 21 34" src="https://github.com/paradigmxyz/reth/assets/25429261/22eb82a2-902a-4efd-b039-2b79a3c83b6d">

Backtrace formatted:
<img width="946" alt="Screenshot 2024-01-12 at 13 21 59" src="https://github.com/paradigmxyz/reth/assets/25429261/522b8085-031d-4a69-b3cf-41f516eb7194">
