### PR TITLE
fix(cli): snapshot up to the best block number, not last

### DIFF
--- a/bin/reth/src/commands/db/snapshots/mod.rs
+++ b/bin/reth/src/commands/db/snapshots/mod.rs
@@ -174,7 +174,7 @@ impl Command {
         segment: impl Segment + Send + Sync,
     ) -> eyre::Result<()> {
         let dir = PathBuf::default();
-        let ranges = self.block_ranges(factory.last_block_number()?);
+        let ranges = self.block_ranges(factory.best_block_number()?);
 
         let mut created_snapshots = vec![];
 


### PR DESCRIPTION
Creating static files up to the `last_block_number` may be incorrect if the pipeline didn't finish running all stages and we have full headers, but partial transactions or receipts in the database.