### PR TITLE
chore: remove reth-codec dependency from ethereum-forks crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6122,7 +6122,6 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rand 0.8.5",
- "reth-codecs",
  "serde",
  "thiserror",
 ]

--- a/crates/ethereum-forks/Cargo.toml
+++ b/crates/ethereum-forks/Cargo.toml
@@ -12,9 +12,6 @@ description = "Ethereum fork types used in reth."
 workspace = true
 
 [dependencies]
-# reth
-reth-codecs.workspace = true
-
 # ethereum
 alloy-chains.workspace = true
 alloy-primitives = { workspace = true, features = ["rand", "rlp"] }
@@ -42,4 +39,4 @@ proptest-derive.workspace = true
 
 [features]
 arbitrary = ["dep:arbitrary", "dep:proptest", "dep:proptest-derive"]
-optimism = ["reth-codecs/optimism"]
+optimism = []

--- a/crates/ethereum-forks/src/forkid.rs
+++ b/crates/ethereum-forks/src/forkid.rs
@@ -6,7 +6,6 @@ use crate::Head;
 use alloy_primitives::{hex, BlockNumber, B256};
 use alloy_rlp::*;
 use crc::*;
-use reth_codecs::derive_arbitrary;
 use serde::{Deserialize, Serialize};
 use std::{
     cmp::Ordering,
@@ -15,11 +14,15 @@ use std::{
     ops::{Add, AddAssign},
 };
 use thiserror::Error;
+#[cfg(any(test, feature = "arbitrary"))]
+use arbitrary::Arbitrary;
+#[cfg(any(test, feature = "arbitrary"))]
+use proptest_derive::Arbitrary as PropTestArbitrary;
 
 const CRC_32_IEEE: Crc<u32> = Crc::<u32>::new(&CRC_32_ISO_HDLC);
 
 /// `CRC32` hash of all previous forks starting from genesis block.
-#[derive_arbitrary(rlp)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(PropTestArbitrary, Arbitrary))]
 #[derive(
     Clone,
     Copy,
@@ -108,7 +111,7 @@ impl From<ForkFilterKey> for u64 {
 
 /// A fork identifier as defined by EIP-2124.
 /// Serves as the chain compatibility identifier.
-#[derive_arbitrary(rlp)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(PropTestArbitrary, Arbitrary))]
 #[derive(
     Clone,
     Copy,

--- a/crates/ethereum-forks/src/forkid.rs
+++ b/crates/ethereum-forks/src/forkid.rs
@@ -5,7 +5,11 @@
 use crate::Head;
 use alloy_primitives::{hex, BlockNumber, B256};
 use alloy_rlp::*;
+#[cfg(any(test, feature = "arbitrary"))]
+use arbitrary::Arbitrary;
 use crc::*;
+#[cfg(any(test, feature = "arbitrary"))]
+use proptest_derive::Arbitrary as PropTestArbitrary;
 use serde::{Deserialize, Serialize};
 use std::{
     cmp::Ordering,
@@ -14,10 +18,6 @@ use std::{
     ops::{Add, AddAssign},
 };
 use thiserror::Error;
-#[cfg(any(test, feature = "arbitrary"))]
-use arbitrary::Arbitrary;
-#[cfg(any(test, feature = "arbitrary"))]
-use proptest_derive::Arbitrary as PropTestArbitrary;
 
 const CRC_32_IEEE: Crc<u32> = Crc::<u32>::new(&CRC_32_ISO_HDLC);
 


### PR DESCRIPTION
remove reth-codec dependency from ethereum-forks crate

Closes #6054 

