### PR TITLE
Remove non existing feature-flag from alloy-rpc-trace-types dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,6 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types",
  "itertools 0.12.0",
- "jsonrpsee-types",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,9 +170,7 @@ alloy-dyn-abi = "0.6"
 alloy-sol-types = "0.6"
 alloy-rlp = "0.3"
 alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", features = ["jsonrpsee-types"] }
-alloy-rpc-trace-types = { git = "https://github.com/alloy-rs/alloy", features = [
-    "jsonrpsee-types",
-] }
+alloy-rpc-trace-types = { git = "https://github.com/alloy-rs/alloy" }
 alloy-trie = "0.2"
 ethers-core = { version = "2.0", default-features = false }
 ethers-providers = { version = "2.0", default-features = false }


### PR DESCRIPTION
# Problem
Currently the workspace dependency for `alloy-rpc-trace-types` specifies the `jsonrpsee-types` feature which does not exist (anymore) on this crate.
This can lead to build errors when using reth as a library ([example](https://github.com/ultrasoundmoney/reth-payload-validator/actions/runs/7516921427/job/20462535652?pr=26))

# Solution
Remove the feature flag from the import.