### PR TITLE
fix(op): activate node-api optimism feature

### DIFF
--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -153,6 +153,7 @@ optimism = [
     "reth-payload-builder/optimism",
     "reth-optimism-payload-builder/optimism",
     "reth-ethereum-payload-builder/optimism",
+    "reth-node-api/optimism",
 ]
 
 # no-op feature flag for switching between the `optimism` and default functionality in CI matrices

--- a/crates/node-api/Cargo.toml
+++ b/crates/node-api/Cargo.toml
@@ -22,3 +22,6 @@ serde.workspace = true
 [dev-dependencies]
 # for examples
 reth-payload-builder.workspace = true
+
+[features]
+optimism = []

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -497,8 +497,6 @@ where
                 best_payload: None,
             };
 
-            println!("{:?}", args.config.attributes);
-
             // TODO: create optimism payload job, that wraps this type, that implements PayloadJob
             // with this branch. remove this branch from the non-op code. remove
             // `on_missing_payload` requirement from builder trait
@@ -509,8 +507,6 @@ where
                     KeepPayloadJobAlive::Yes,
                 )
             }
-
-            println!("returning empty payload");
 
             // if no payload has been built yet
             self.metrics.inc_requested_empty_payload();

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -497,15 +497,20 @@ where
                 best_payload: None,
             };
 
+            println!("{:?}", args.config.attributes);
+
             // TODO: create optimism payload job, that wraps this type, that implements PayloadJob
             // with this branch. remove this branch from the non-op code. remove
             // `on_missing_payload` requirement from builder trait
             if let Some(payload) = self.builder.on_missing_payload(args) {
+                debug!(target: "payload_builder", id=%self.config.payload_id(), "resolving fallback payload as best payload");
                 return (
                     ResolveBestPayload { best_payload: Some(payload), maybe_better, empty_payload },
                     KeepPayloadJobAlive::Yes,
                 )
             }
+
+            println!("returning empty payload");
 
             // if no payload has been built yet
             self.metrics.inc_requested_empty_payload();

--- a/crates/payload/builder/src/optimism.rs
+++ b/crates/payload/builder/src/optimism.rs
@@ -64,12 +64,12 @@ impl PayloadBuilderAttributes for OptimismPayloadBuilderAttributes {
         })
     }
 
-    fn parent(&self) -> B256 {
-        self.payload_attributes.parent
-    }
-
     fn payload_id(&self) -> PayloadId {
         self.payload_attributes.id
+    }
+
+    fn parent(&self) -> B256 {
+        self.payload_attributes.parent
     }
 
     fn timestamp(&self) -> u64 {

--- a/crates/payload/optimism/src/lib.rs
+++ b/crates/payload/optimism/src/lib.rs
@@ -212,7 +212,7 @@ mod builder {
                 Err(err) => {
                     match err {
                         EVMError::Transaction(err) => {
-                            trace!(target: "optimism_payload_builder", ?err, ?sequencer_tx, "Error in sequencer transaction, skipping.");
+                            trace!(target: "payload_builder", ?err, ?sequencer_tx, "Error in sequencer transaction, skipping.");
                             continue
                         }
                         err => {

--- a/crates/payload/optimism/src/lib.rs
+++ b/crates/payload/optimism/src/lib.rs
@@ -117,6 +117,11 @@ mod builder {
         Client: StateProviderFactory,
         Pool: TransactionPool,
     {
+        debug_assert!(
+            args.config.initialized_cfg.optimism,
+            "optimism payload builder called on non-optimism chain"
+        );
+
         let BuildArguments { client, pool, mut cached_reads, config, cancel, best_payload } = args;
 
         let state_provider = client.state_by_block_hash(config.parent_block.hash)?;


### PR DESCRIPTION
this missing feature resulted in misconfigured evm cfg in the default impl.

this is a hotfix. the cfg feature can be removed by not using default impls in the `cfg_and_block_env` function @Rjected 

