### PR TITLE
ci: update aarch64 linux in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,12 +31,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-20.04
-            profile: maxperf
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-20.04
             profile: maxperf
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-20.04
+            profile: maxperf-no-asm
           - target: x86_64-apple-darwin
             os: macos-latest
             profile: maxperf

--- a/Makefile
+++ b/Makefile
@@ -230,5 +230,9 @@ update-book-cli: ## Update book cli documentation.
 	@./book/cli/update.sh $(BUILD_PATH)/$(PROFILE)/reth
 
 .PHONY: maxperf
-maxperf:
+maxperf: ## Builds `reth` with the most aggressive optimisations.
 	RUSTFLAGS="-C target-cpu=native" cargo build --profile maxperf --features jemalloc,asm-keccak
+
+.PHONY: maxperf-no-asm
+maxperf-no-asm: ## Builds `reth` with the most aggressive optimisations, minus the "asm-keccak" feature.
+	RUSTFLAGS="-C target-cpu=native" cargo build --profile maxperf --features jemalloc

--- a/book/installation/source.md
+++ b/book/installation/source.md
@@ -135,6 +135,9 @@ If compilation fails with `(signal: 9, SIGKILL: kill)`, this could mean your mac
 memory during compilation. If you are on Docker, consider increasing the memory of the container, or use a [pre-built
 binary](../installation/binaries.md).
 
+If compilation fails in either the `keccak-asm` or `sha3-asm` crates, it is likely that your current
+system configuration is not supported. See the [`keccak-asm` target table](https://github.com/DaniPopes/keccak-asm?tab=readme-ov-file#support) for supported targets.
+
 If compilation fails with `error: linking with cc failed: exit code: 1`, try running `cargo clean`.
 
 _(Thanks to Sigma Prime for this section from [their Lighthouse book](https://lighthouse-book.sigmaprime.io/installation.html)!)_


### PR DESCRIPTION
Follow-up to https://github.com/paradigmxyz/reth/pull/5997.
`aarch64-unknown-linux-gnu` is not supported yet.