### PR TITLE
fix(cli): db tui serialization

### DIFF
--- a/bin/reth/src/commands/db/tui.rs
+++ b/bin/reth/src/commands/db/tui.rs
@@ -396,30 +396,20 @@ where
             .start_corner(Corner::TopLeft);
         f.render_stateful_widget(key_list, inner_chunks[0], &mut app.list_state);
 
-        let values: Vec<_> = match &app.entries {
-            Entries::RawValues(entries) => entries
-                .iter()
-                .map(|(_, v)| {
-                    serde_json::to_string_pretty(v)
-                        .unwrap_or(String::from("Error serializing value"))
-                })
-                .collect(),
-            Entries::Values(entries) => entries
-                .iter()
-                .map(|(_, v)| {
-                    serde_json::to_string_pretty(v)
-                        .unwrap_or(String::from("Error serializing value"))
-                })
-                .collect(),
-        };
-
         let value_display = Paragraph::new(
             app.list_state
                 .selected()
-                .and_then(|selected| values.get(selected))
-                .map(|entry| {
-                    serde_json::to_string_pretty(entry)
-                        .unwrap_or(String::from("Error serializing value"))
+                .and_then(|selected| {
+                    let maybe_serialized = match &app.entries {
+                        Entries::RawValues(entries) => {
+                            entries.get(selected).map(|(_, v)| serde_json::to_string(v.raw_value()))
+                        }
+                        Entries::Values(entries) => {
+                            entries.get(selected).map(|(_, v)| serde_json::to_string_pretty(v))
+                        }
+                    };
+                    maybe_serialized
+                        .map(|ser| ser.unwrap_or(String::from("Error serializing value")))
                 })
                 .unwrap_or("No value selected".to_string()),
         )

--- a/bin/reth/src/commands/db/tui.rs
+++ b/bin/reth/src/commands/db/tui.rs
@@ -408,10 +408,13 @@ where
                             entries.get(selected).map(|(_, v)| serde_json::to_string_pretty(v))
                         }
                     };
-                    maybe_serialized
-                        .map(|ser| ser.unwrap_or(String::from("Error serializing value")))
+                    maybe_serialized.map(|ser| {
+                        ser.unwrap_or_else(|error| {
+                            format!("Error serializing value: {}", error.to_string())
+                        })
+                    })
                 })
-                .unwrap_or("No value selected".to_string()),
+                .unwrap_or_else(|| "No value selected".to_string()),
         )
         .block(Block::default().borders(Borders::ALL).title("Value (JSON)"))
         .wrap(Wrap { trim: false })

--- a/bin/reth/src/commands/db/tui.rs
+++ b/bin/reth/src/commands/db/tui.rs
@@ -409,9 +409,7 @@ where
                         }
                     };
                     maybe_serialized.map(|ser| {
-                        ser.unwrap_or_else(|error| {
-                            format!("Error serializing value: {}", error.to_string())
-                        })
+                        ser.unwrap_or_else(|error| format!("Error serializing value: {error}"))
                     })
                 })
                 .unwrap_or_else(|| "No value selected".to_string()),


### PR DESCRIPTION
## Description

DB values displayed while running `reth db list <table>` are serialized twice resulting in unformatted output (see image below).
<img width="1257" alt="Screenshot 2024-01-15 at 09 24 11" src="https://github.com/paradigmxyz/reth/assets/25429261/3309e888-a8a3-4121-b938-fd56a4ab6315">

Fix serialization for regular entries and display only non-prettified raw bytes array for raw entries.