### PR TITLE
chore(db): skip serializing phantom data

### DIFF
--- a/crates/storage/db/src/tables/raw.rs
+++ b/crates/storage/db/src/tables/raw.rs
@@ -104,6 +104,7 @@ impl<K: Key> Decode for RawKey<K> {
 pub struct RawValue<V: Value> {
     /// Inner compressed value
     value: Vec<u8>,
+    #[serde(skip)]
     _phantom: std::marker::PhantomData<V>,
 }
 


### PR DESCRIPTION
## Description

Smol fix to skip serializing `PhantomData`