### PR TITLE
chore: avoid `.as_ref().to_vec()` when `Into<Vec<u8>>` is available

### DIFF
--- a/crates/net/discv4/src/config.rs
+++ b/crates/net/discv4/src/config.rs
@@ -80,22 +80,22 @@ impl Discv4Config {
     }
 
     /// Add another key value pair to include in the ENR
-    pub fn add_eip868_pair(&mut self, key: impl AsRef<[u8]>, value: impl Encodable) -> &mut Self {
+    pub fn add_eip868_pair(&mut self, key: impl Into<Vec<u8>>, value: impl Encodable) -> &mut Self {
         let mut buf = BytesMut::new();
         value.encode(&mut buf);
         self.add_eip868_rlp_pair(key, buf.freeze())
     }
 
     /// Add another key value pair to include in the ENR
-    pub fn add_eip868_rlp_pair(&mut self, key: impl AsRef<[u8]>, rlp: Bytes) -> &mut Self {
-        self.additional_eip868_rlp_pairs.insert(key.as_ref().to_vec(), rlp);
+    pub fn add_eip868_rlp_pair(&mut self, key: impl Into<Vec<u8>>, rlp: Bytes) -> &mut Self {
+        self.additional_eip868_rlp_pairs.insert(key.into(), rlp);
         self
     }
 
     /// Extend additional key value pairs to include in the ENR
     pub fn extend_eip868_rlp_pairs(
         &mut self,
-        pairs: impl IntoIterator<Item = (impl AsRef<[u8]>, Bytes)>,
+        pairs: impl IntoIterator<Item = (impl Into<Vec<u8>>, Bytes)>,
     ) -> &mut Self {
         for (k, v) in pairs.into_iter() {
             self.add_eip868_rlp_pair(k, v);
@@ -237,22 +237,22 @@ impl Discv4ConfigBuilder {
     }
 
     /// Add another key value pair to include in the ENR
-    pub fn add_eip868_pair(&mut self, key: impl AsRef<[u8]>, value: impl Encodable) -> &mut Self {
+    pub fn add_eip868_pair(&mut self, key: impl Into<Vec<u8>>, value: impl Encodable) -> &mut Self {
         let mut buf = BytesMut::new();
         value.encode(&mut buf);
         self.add_eip868_rlp_pair(key, buf.freeze())
     }
 
     /// Add another key value pair to include in the ENR
-    pub fn add_eip868_rlp_pair(&mut self, key: impl AsRef<[u8]>, rlp: Bytes) -> &mut Self {
-        self.config.additional_eip868_rlp_pairs.insert(key.as_ref().to_vec(), rlp);
+    pub fn add_eip868_rlp_pair(&mut self, key: impl Into<Vec<u8>>, rlp: Bytes) -> &mut Self {
+        self.config.additional_eip868_rlp_pairs.insert(key.into(), rlp);
         self
     }
 
     /// Extend additional key value pairs to include in the ENR
     pub fn extend_eip868_rlp_pairs(
         &mut self,
-        pairs: impl IntoIterator<Item = (impl AsRef<[u8]>, Bytes)>,
+        pairs: impl IntoIterator<Item = (impl Into<Vec<u8>>, Bytes)>,
     ) -> &mut Self {
         for (k, v) in pairs.into_iter() {
             self.add_eip868_rlp_pair(k, v);

--- a/crates/rpc/ipc/src/stream_codec.rs
+++ b/crates/rpc/ipc/src/stream_codec.rs
@@ -114,7 +114,7 @@ impl tokio_util::codec::Decoder for StreamCodec {
 
                 if depth == 0 && idx != start_idx && idx - start_idx + 1 > whitespaces {
                     let bts = buf.split_to(idx + 1);
-                    return match String::from_utf8(bts.as_ref().to_vec()) {
+                    return match String::from_utf8(bts.into()) {
                         Ok(val) => Ok(Some(val)),
                         Err(_) => Ok(None),
                     }

--- a/crates/storage/db/src/abstraction/table.rs
+++ b/crates/storage/db/src/abstraction/table.rs
@@ -13,7 +13,13 @@ use std::{
 /// Trait that will transform the data to be saved in the DB in a (ideally) compressed format
 pub trait Compress: Send + Sync + Sized + Debug {
     /// Compressed type.
-    type Compressed: bytes::BufMut + AsMut<[u8]> + Default + AsRef<[u8]> + Send + Sync;
+    type Compressed: bytes::BufMut
+        + AsRef<[u8]>
+        + AsMut<[u8]>
+        + Into<Vec<u8>>
+        + Default
+        + Send
+        + Sync;
 
     /// If the type cannot be compressed, return its inner reference as `Some(self.as_ref())`
     fn uncompressable_ref(&self) -> Option<&[u8]> {

--- a/crates/storage/db/src/tables/raw.rs
+++ b/crates/storage/db/src/tables/raw.rs
@@ -52,7 +52,7 @@ pub struct RawKey<K: Key> {
 impl<K: Key> RawKey<K> {
     /// Create new raw key.
     pub fn new(key: K) -> Self {
-        Self { key: K::encode(key).as_ref().to_vec(), _phantom: std::marker::PhantomData }
+        Self { key: K::encode(key).into(), _phantom: std::marker::PhantomData }
     }
 
     /// Returns the decoded value.
@@ -111,7 +111,7 @@ pub struct RawValue<V: Value> {
 impl<V: Value> RawValue<V> {
     /// Create new raw value.
     pub fn new(value: V) -> Self {
-        Self { value: V::compress(value).as_ref().to_vec(), _phantom: std::marker::PhantomData }
+        Self { value: V::compress(value).into(), _phantom: std::marker::PhantomData }
     }
 
     /// Returns the decompressed value.


### PR DESCRIPTION
`as_ref().to_vec()` always copies the slice while .into() may consume the underlying buffer without a copy