### PR TITLE
feat(trie): construct `HashedPostState` from revert range

### DIFF
--- a/crates/storage/provider/src/bundle_state/hashed_state_changes.rs
+++ b/crates/storage/provider/src/bundle_state/hashed_state_changes.rs
@@ -104,7 +104,7 @@ mod tests {
         }
 
         let mut hashed_state = HashedPostState::default();
-        hashed_state.insert_destroyed_account(destroyed_address_hashed);
+        hashed_state.insert_account(destroyed_address_hashed, None);
         hashed_state.insert_hashed_storage(destroyed_address_hashed, HashedStorage::new(true));
 
         let provider_rw = provider_factory.provider_rw().unwrap();

--- a/crates/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/src/hashed_cursor/post_state.rs
@@ -453,7 +453,7 @@ mod tests {
 
         let mut hashed_post_state = HashedPostState::default();
         for (hashed_address, account) in &accounts {
-            hashed_post_state.insert_account(*hashed_address, *account);
+            hashed_post_state.insert_account(*hashed_address, Some(*account));
         }
         hashed_post_state.sort();
 
@@ -499,7 +499,7 @@ mod tests {
 
         let mut hashed_post_state = HashedPostState::default();
         for (hashed_address, account) in accounts.iter().filter(|x| x.0[31] % 2 != 0) {
-            hashed_post_state.insert_account(*hashed_address, *account);
+            hashed_post_state.insert_account(*hashed_address, Some(*account));
         }
         hashed_post_state.sort();
 
@@ -526,11 +526,9 @@ mod tests {
 
         let mut hashed_post_state = HashedPostState::default();
         for (hashed_address, account) in accounts.iter().filter(|x| x.0[31] % 2 != 0) {
-            if removed_keys.contains(hashed_address) {
-                hashed_post_state.insert_destroyed_account(*hashed_address);
-            } else {
-                hashed_post_state.insert_account(*hashed_address, *account);
-            }
+            let account_info =
+                if removed_keys.contains(hashed_address) { None } else { Some(*account) };
+            hashed_post_state.insert_account(*hashed_address, account_info)
         }
         hashed_post_state.sort();
 
@@ -557,7 +555,7 @@ mod tests {
 
         let mut hashed_post_state = HashedPostState::default();
         for (hashed_address, account) in &accounts {
-            hashed_post_state.insert_account(*hashed_address, *account);
+            hashed_post_state.insert_account(*hashed_address, Some(*account));
         }
         hashed_post_state.sort();
 
@@ -579,11 +577,7 @@ mod tests {
 
                 let mut hashed_post_state = HashedPostState::default();
                 for (hashed_address, account) in &post_state_accounts {
-                    if let Some(account) = account {
-                        hashed_post_state.insert_account(*hashed_address, *account);
-                    } else {
-                        hashed_post_state.insert_destroyed_account(*hashed_address);
-                    }
+                    hashed_post_state.insert_account(*hashed_address, *account);
                 }
                 hashed_post_state.sort();
 
@@ -659,7 +653,7 @@ mod tests {
         {
             let wiped = true;
             let mut hashed_storage = HashedStorage::new(wiped);
-            hashed_storage.insert_storage(B256::random(), U256::ZERO);
+            hashed_storage.insert_slot(B256::random(), U256::ZERO);
 
             let mut hashed_post_state = HashedPostState::default();
             hashed_post_state.insert_hashed_storage(address, hashed_storage);
@@ -674,7 +668,7 @@ mod tests {
         {
             let wiped = true;
             let mut hashed_storage = HashedStorage::new(wiped);
-            hashed_storage.insert_storage(B256::random(), U256::from(1));
+            hashed_storage.insert_slot(B256::random(), U256::from(1));
 
             let mut hashed_post_state = HashedPostState::default();
             hashed_post_state.insert_hashed_storage(address, hashed_storage);
@@ -710,7 +704,7 @@ mod tests {
         let wiped = false;
         let mut hashed_storage = HashedStorage::new(wiped);
         for (slot, value) in post_state_storage.iter() {
-            hashed_storage.insert_storage(*slot, *value);
+            hashed_storage.insert_slot(*slot, *value);
         }
 
         let mut hashed_post_state = HashedPostState::default();
@@ -746,7 +740,7 @@ mod tests {
         let wiped = false;
         let mut hashed_storage = HashedStorage::new(wiped);
         for (slot, value) in post_state_storage.iter() {
-            hashed_storage.insert_storage(*slot, *value);
+            hashed_storage.insert_slot(*slot, *value);
         }
 
         let mut hashed_post_state = HashedPostState::default();
@@ -784,7 +778,7 @@ mod tests {
         let wiped = true;
         let mut hashed_storage = HashedStorage::new(wiped);
         for (slot, value) in post_state_storage.iter() {
-            hashed_storage.insert_storage(*slot, *value);
+            hashed_storage.insert_slot(*slot, *value);
         }
 
         let mut hashed_post_state = HashedPostState::default();
@@ -819,7 +813,7 @@ mod tests {
         let wiped = false;
         let mut hashed_storage = HashedStorage::new(wiped);
         for (slot, value) in storage.iter() {
-            hashed_storage.insert_storage(*slot, *value);
+            hashed_storage.insert_slot(*slot, *value);
         }
 
         let mut hashed_post_state = HashedPostState::default();
@@ -856,7 +850,7 @@ mod tests {
             for (address, (wiped, storage)) in &post_state_storages {
                 let mut hashed_storage = HashedStorage::new(*wiped);
                 for (slot, value) in storage {
-                    hashed_storage.insert_storage(*slot, *value);
+                    hashed_storage.insert_slot(*slot, *value);
                 }
                 hashed_post_state.insert_hashed_storage(*address, hashed_storage);
             }

--- a/crates/trie/src/state.rs
+++ b/crates/trie/src/state.rs
@@ -104,7 +104,7 @@ impl HashedPostState {
 
         let mut this = Self::default();
         for (address, (maybe_account_change, storage)) in state {
-            let hashed_address = keccak256(&address);
+            let hashed_address = keccak256(address);
 
             if let Some(account_change) = maybe_account_change {
                 this.insert_account(hashed_address, account_change);


### PR DESCRIPTION
## Description

Create a method for initializing `HashedPostState` from revert range. This allows constructing an "overlay" for the hashed state at `tip - n` blocks. Ref #5889