### PR TITLE
feat(stages): duration threshold for `Execution` stage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,6 @@ exclude = [".github/"]
 # Like release, but with full debug symbols. Useful for e.g. `perf`.
 [profile.debug-fast]
 inherits = "release"
-opt-level = 0
 debug = true
 
 # Meant for testing - all optimizations, but with debug assertions and overflow checks.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ exclude = [".github/"]
 # Like release, but with full debug symbols. Useful for e.g. `perf`.
 [profile.debug-fast]
 inherits = "release"
+opt-level = 0
 debug = true
 
 # Meant for testing - all optimizations, but with debug assertions and overflow checks.

--- a/bin/reth/src/builder/mod.rs
+++ b/bin/reth/src/builder/mod.rs
@@ -915,6 +915,7 @@ impl NodeConfig {
                             max_blocks: stage_config.execution.max_blocks,
                             max_changes: stage_config.execution.max_changes,
                             max_cumulative_gas: stage_config.execution.max_cumulative_gas,
+                            max_duration: stage_config.execution.max_duration,
                         },
                         stage_config
                             .merkle

--- a/bin/reth/src/commands/debug_cmd/execution.rs
+++ b/bin/reth/src/commands/debug_cmd/execution.rs
@@ -136,6 +136,7 @@ impl Command {
                         max_blocks: None,
                         max_changes: None,
                         max_cumulative_gas: None,
+                        max_duration: None,
                     },
                     stage_conf
                         .merkle

--- a/bin/reth/src/commands/debug_cmd/merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/merkle.rs
@@ -205,6 +205,7 @@ impl Command {
                 max_blocks: Some(1),
                 max_changes: None,
                 max_cumulative_gas: None,
+                max_duration: None,
             },
             MERKLE_STAGE_DEFAULT_CLEAN_THRESHOLD,
             PruneModes::all(),

--- a/bin/reth/src/commands/import.rs
+++ b/bin/reth/src/commands/import.rs
@@ -183,6 +183,7 @@ impl ImportCommand {
                         max_blocks: config.stages.execution.max_blocks,
                         max_changes: config.stages.execution.max_changes,
                         max_cumulative_gas: config.stages.execution.max_cumulative_gas,
+                        max_duration: config.stages.execution.max_duration,
                     },
                     config
                         .stages

--- a/bin/reth/src/commands/node/events.rs
+++ b/bin/reth/src/commands/node/events.rs
@@ -122,7 +122,7 @@ impl<DB> NodeState<DB> {
                             %target,
                             %stage_progress,
                             %stage_eta,
-                            message,
+                            "{message}",
                         )
                     } else {
                         info!(
@@ -131,7 +131,7 @@ impl<DB> NodeState<DB> {
                             checkpoint = %checkpoint.block_number,
                             %target,
                             %stage_progress,
-                            message,
+                            "{message}",
                         )
                     }
                 }

--- a/bin/reth/src/commands/stage/dump/merkle.rs
+++ b/bin/reth/src/commands/stage/dump/merkle.rs
@@ -73,6 +73,7 @@ async fn unwind_and_copy<DB: Database>(
             max_blocks: Some(u64::MAX),
             max_changes: None,
             max_cumulative_gas: None,
+            max_duration: None,
         },
         MERKLE_STAGE_DEFAULT_CLEAN_THRESHOLD,
         PruneModes::all(),

--- a/bin/reth/src/commands/stage/run.rs
+++ b/bin/reth/src/commands/stage/run.rs
@@ -204,6 +204,7 @@ impl Command {
                                 max_blocks: Some(batch_size),
                                 max_changes: None,
                                 max_cumulative_gas: None,
+                                max_duration: None,
                             },
                             config.stages.merkle.clean_threshold,
                             config.prune.map(|prune| prune.segments).unwrap_or_default(),

--- a/book/run/config.md
+++ b/book/run/config.md
@@ -131,22 +131,21 @@ The execution stage executes historical transactions. This stage is generally ve
 
 Each executed transaction also generates a number of changesets, and mutates the current state of accounts and storage.
 
-For this reason, there are two ways to control how much work to perform before the results are written to disk.
+For this reason, there are several ways to control how much work to perform before the results are written to disk.
 
 ```toml
 [stages.execution]
-# The maximum amount of blocks to execute before writing the results to disk.
+# The maximum number of blocks to process before the execution stage commits.
 max_blocks = 500000
-# The maximum amount of account and storage changes to collect before writing
-# the results to disk.
+# The maximum number of state changes to keep in memory before the execution stage commits.
 max_changes = 5000000
+# The maximum cumulative amount of gas to process before the execution stage commits.
+max_cumulative_gas = 1500000000000 # 30_000_000 * 50_000_000
+# The maximum spent on blocks processing before the execution stage commits.
+max_duration = '10m'
 ```
 
-Either one of `max_blocks` or `max_changes` must be specified, and both can also be specified at the same time:
-
-- If only `max_blocks` is specified, reth will execute (up to) that amount of blocks before writing to disk.
-- If only `max_changes` is specified, reth will execute as many blocks as possible until the target amount of state transitions have occurred before writing to disk.
-- If both are specified, then the first threshold to be hit will determine when the results are written to disk.
+For all thresholds specified, the first to be hit will determine when the results are written to disk.
 
 Lower values correspond to more frequent disk writes, but also lower memory consumption. A lower value also negatively impacts sync speed, since reth keeps a cache around for the entire duration of blocks executed in the same range.
 

--- a/book/run/config.md
+++ b/book/run/config.md
@@ -141,7 +141,7 @@ max_blocks = 500000
 max_changes = 5000000
 # The maximum cumulative amount of gas to process before the execution stage commits.
 max_cumulative_gas = 1500000000000 # 30_000_000 * 50_000_000
-# The maximum spent on blocks processing before the execution stage commits.
+# The maximum time spent on blocks processing before the execution stage commits.
 max_duration = '10m'
 ```
 

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -185,7 +185,7 @@ pub struct ExecutionConfig {
     pub max_changes: Option<u64>,
     /// The maximum cumulative amount of gas to process before the execution stage commits.
     pub max_cumulative_gas: Option<u64>,
-    /// The maximum spent on blocks processing before the execution stage commits.
+    /// The maximum time spent on blocks processing before the execution stage commits.
     pub max_duration: Option<Duration>,
 }
 

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -5,7 +5,7 @@ use reth_network::{NetworkConfigBuilder, PeersConfig, SessionsConfig};
 use reth_primitives::PruneModes;
 use secp256k1::SecretKey;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::{path::PathBuf, time::Duration};
 
 /// Configuration for the reth node.
 #[derive(Debug, Clone, Default, Deserialize, PartialEq, Serialize)]
@@ -181,10 +181,12 @@ impl Default for SenderRecoveryConfig {
 pub struct ExecutionConfig {
     /// The maximum number of blocks to process before the execution stage commits.
     pub max_blocks: Option<u64>,
-    /// The maximum amount of state changes to keep in memory before the execution stage commits.
+    /// The maximum number of state changes to keep in memory before the execution stage commits.
     pub max_changes: Option<u64>,
-    /// The maximum gas to process before the execution stage commits.
+    /// The maximum cumulative amount of gas to process before the execution stage commits.
     pub max_cumulative_gas: Option<u64>,
+    /// The maximum spent on blocks processing before the execution stage commits.
+    pub max_duration: Option<Duration>,
 }
 
 impl Default for ExecutionConfig {
@@ -194,6 +196,8 @@ impl Default for ExecutionConfig {
             max_changes: Some(5_000_000),
             // 50k full blocks of 30M gas
             max_cumulative_gas: Some(30_000_000 * 50_000),
+            // 10 minutes
+            max_duration: Some(Duration::from_secs(10 * 60)),
         }
     }
 }

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -137,11 +137,10 @@ impl<EF: ExecutorFactory> ExecutionStage<EF> {
         debug!(target: "sync::stages::execution", start = start_block, end = max_block, "Executing range");
 
         // Execute block range
-        let range_size = (start_block..=max_block).count();
         let mut cumulative_gas = 0;
         let start = Instant::now();
 
-        for (i, block_number) in (start_block..=max_block).enumerate() {
+        for block_number in start_block..=max_block {
             let time = Instant::now();
             let td = provider
                 .header_td_by_number(block_number)?
@@ -188,17 +187,6 @@ impl<EF: ExecutorFactory> ExecutionStage<EF> {
                 now - start,
             ) {
                 break
-            }
-
-            // Log the execution progress every 1% of block range
-            let blocks_per_percent = range_size / 100;
-            if blocks_per_percent > 0 && i % blocks_per_percent == 0 {
-                debug!(
-                    target: "sync::stages::execution",
-                    ?block_number,
-                    range = ?start_block..=max_block,
-                    "Execution progress"
-                );
             }
         }
         let time = Instant::now();

--- a/crates/stages/src/stages/mod.rs
+++ b/crates/stages/src/stages/mod.rs
@@ -135,6 +135,7 @@ mod tests {
                     max_blocks: Some(100),
                     max_changes: None,
                     max_cumulative_gas: None,
+                    max_duration: None,
                 },
                 MERKLE_STAGE_DEFAULT_CLEAN_THRESHOLD,
                 prune_modes.clone(),


### PR DESCRIPTION
Fixes https://github.com/paradigmxyz/reth/issues/6014

We lack observability in `Execution` stage when a large block range is being executed without reaching any thresholds, and the node is just silent about it.

This PR introduces a new `max_duration` threshold for `Execution` stage, which controls the maximum time spent on one batch. The default value is 10 minutes.