### PR TITLE
ci: include arbitrary and test-utils features

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - run: cargo clippy --bin "${{ matrix.binary }}" --workspace --features arbitrary,test-utils,"${{ matrix.network }}" --lib --tests --benches --examples
+      - run: cargo clippy --bin "${{ matrix.binary }}" --workspace --features "arbitrary,test-utils,${{ matrix.network }}" --lib --tests --benches --examples
         env:
           RUSTFLAGS: -D warnings
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,8 +27,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - run:
-          cargo clippy --bin "${{ matrix.binary }}" --workspace --features "${{ matrix.network }}" --lib --tests --benches --examples
+      - run: cargo clippy --bin "${{ matrix.binary }}" --workspace --features arbitrary,test-utils,"${{ matrix.network }}" --lib --tests --benches --examples
         env:
           RUSTFLAGS: -D warnings
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,8 +101,7 @@ Please also make sure that the following commands pass if you have changed the c
 cargo check --all
 cargo test --all --all-features
 cargo +nightly fmt -- --check
-cargo clippy --bin "reth" --workspace --features "arbitrary,test-utils,ethereum" --lib --tests --benches --examples -- -D warnings
-cargo clippy --bin "op-reth" --workspace --features "arbitrary,test-utils,optimism" --lib --tests --benches --examples -- -D warnings
+cargo +nightly clippy --all --all-features --lib --tests --benches --examples
 ```
 
 If you are working in VSCode, we recommend you install the [rust-analyzer](https://rust-analyzer.github.io/) extension,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,15 +111,19 @@ and use the following VSCode user settings:
 "editor.formatOnSave": true,
 "rust-analyzer.rustfmt.extraArgs": ["+nightly"],
 "rust-analyzer.check.overrideCommand": [
-"cargo",
-"+nightly",
-"clippy",
-"--all",
-"--all-features",
-"--message-format=json"
+  "cargo",
+  "+nightly",
+  "clippy",
+  "--all",
+  "--all-features",
+  "--lib",
+  "--tests",
+  "--benches",
+  "--examples",
+  "--message-format=json"
 ],
 "[rust]": {
-"editor.defaultFormatter": "rust-lang.rust-analyzer"
+  "editor.defaultFormatter": "rust-lang.rust-analyzer"
 }
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,8 +101,8 @@ Please also make sure that the following commands pass if you have changed the c
 cargo check --all
 cargo test --all --all-features
 cargo +nightly fmt -- --check
-cargo clippy --bin "reth" --workspace --features "ethereum" --lib --tests --benches --examples -- -D warnings
-cargo clippy --bin "op-reth" --workspace --features "optimism" --lib --tests --benches --examples -- -D warnings
+cargo clippy --bin "reth" --workspace --features "arbitrary,test-utils,ethereum" --lib --tests --benches --examples -- -D warnings
+cargo clippy --bin "op-reth" --workspace --features "arbitrary,test-utils,optimism" --lib --tests --benches --examples -- -D warnings
 ```
 
 If you are working in VSCode, we recommend you install the [rust-analyzer](https://rust-analyzer.github.io/) extension,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ Please also make sure that the following commands pass if you have changed the c
 cargo check --all
 cargo test --all --all-features
 cargo +nightly fmt -- --check
-cargo +nightly clippy --all --all-features --lib --tests --benches --examples
+cargo +nightly clippy --all --all-features --lib --tests --benches --examples -- -D warnings
 ```
 
 If you are working in VSCode, we recommend you install the [rust-analyzer](https://rust-analyzer.github.io/) extension,

--- a/crates/net/eth-wire/tests/fuzz_roundtrip.rs
+++ b/crates/net/eth-wire/tests/fuzz_roundtrip.rs
@@ -131,7 +131,7 @@ pub mod fuzz_rlp {
         RlpEncodableWrapper,
         RlpDecodableWrapper,
     )]
-    struct GetBlockHeadersWrapper(pub GetBlockHeaders);
+    struct GetBlockHeadersWrapper(GetBlockHeaders);
 
     impl Default for GetBlockHeadersWrapper {
         fn default() -> Self {

--- a/crates/net/eth-wire/tests/fuzz_roundtrip.rs
+++ b/crates/net/eth-wire/tests/fuzz_roundtrip.rs
@@ -37,6 +37,7 @@ where
 macro_rules! fuzz_type_and_name {
     ( $x:ty, $fuzzname:ident ) => {
         /// Fuzzes the round-trip encoding of the type.
+        #[allow(non_snake_case)]
         #[test_fuzz]
         fn $fuzzname(thing: $x) {
             crate::roundtrip_fuzz::<$x>(thing)

--- a/crates/transaction-pool/benches/priority.rs
+++ b/crates/transaction-pool/benches/priority.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use criterion::{
     black_box, criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion,
 };
@@ -21,7 +22,7 @@ fn generate_test_data_priority() -> (u128, u128, u128, u128) {
 }
 
 fn priority_bench(
-    group: &mut BenchmarkGroup<WallTime>,
+    group: &mut BenchmarkGroup<'_, WallTime>,
     description: &str,
     input_data: (u128, u128, u128, u128),
 ) {
@@ -40,7 +41,7 @@ fn priority_bench(
 }
 
 fn fee_jump_bench(
-    group: &mut BenchmarkGroup<WallTime>,
+    group: &mut BenchmarkGroup<'_, WallTime>,
     description: &str,
     input_data: (u128, u128),
 ) {
@@ -53,7 +54,7 @@ fn fee_jump_bench(
     });
 }
 
-pub fn blob_priority_calculation(c: &mut Criterion) {
+fn blob_priority_calculation(c: &mut Criterion) {
     let mut group = c.benchmark_group("Blob priority calculation");
     let fee_jump_input = generate_test_data_fee_delta();
 

--- a/crates/transaction-pool/benches/reorder.rs
+++ b/crates/transaction-pool/benches/reorder.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion,
 };
@@ -9,12 +10,12 @@ use proptest::{
 use reth_transaction_pool::test_utils::MockTransaction;
 
 /// Transaction Pool trait for benching.
-pub trait BenchTxPool: Default {
+trait BenchTxPool: Default {
     fn add_transaction(&mut self, tx: MockTransaction);
     fn reorder(&mut self, base_fee: u64);
 }
 
-pub fn txpool_reordering(c: &mut Criterion) {
+fn txpool_reordering(c: &mut Criterion) {
     let mut group = c.benchmark_group("Transaction Pool Reordering");
 
     for seed_size in [1_000, 10_000, 50_000, 100_000] {
@@ -54,7 +55,7 @@ pub fn txpool_reordering(c: &mut Criterion) {
 }
 
 fn txpool_reordering_bench<T: BenchTxPool>(
-    group: &mut BenchmarkGroup<WallTime>,
+    group: &mut BenchmarkGroup<'_, WallTime>,
     description: &str,
     seed: Vec<MockTransaction>,
     new_txs: Vec<MockTransaction>,

--- a/crates/transaction-pool/benches/reorder.rs
+++ b/crates/transaction-pool/benches/reorder.rs
@@ -171,9 +171,8 @@ mod implementations {
 
     impl PartialEq for MockTransactionWithPriority {
         // NOTE(onbjerg): False positive
-        #[allow(clippy::unconditional_recursion)]
         fn eq(&self, other: &Self) -> bool {
-            self.priority.eq(&other.priority)
+           self.priority == other.priority
         }
     }
 

--- a/crates/transaction-pool/benches/reorder.rs
+++ b/crates/transaction-pool/benches/reorder.rs
@@ -170,6 +170,8 @@ mod implementations {
     }
 
     impl PartialEq for MockTransactionWithPriority {
+        // NOTE(onbjerg): False positive
+        #[allow(clippy::unconditional_recursion)]
         fn eq(&self, other: &Self) -> bool {
             self.priority.eq(&other.priority)
         }

--- a/crates/transaction-pool/benches/truncate.rs
+++ b/crates/transaction-pool/benches/truncate.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion,
 };
@@ -124,7 +125,7 @@ fn txpool_truncate(c: &mut Criterion) {
 }
 
 fn truncate_pending(
-    group: &mut BenchmarkGroup<WallTime>,
+    group: &mut BenchmarkGroup<'_, WallTime>,
     description: &str,
     seed: Vec<MockTransaction>,
     senders: usize,
@@ -159,7 +160,7 @@ fn truncate_pending(
 }
 
 fn truncate_parked(
-    group: &mut BenchmarkGroup<WallTime>,
+    group: &mut BenchmarkGroup<'_, WallTime>,
     description: &str,
     seed: Vec<MockTransaction>,
     senders: usize,


### PR DESCRIPTION
@emhane flagged that not all code was covered using the current features we have in CI. I narrowed it down to the `arbitrary` feature which is required to compile and check some benchmarks that currently break. I've included this feature in the clippy job, as well as the `test-utils` feature since some benches require that too.

I wanted to automate this process with `cargo-hack --feature-powerset` but it generated over 1700 combinations which is impractical for us to run. Unfortunately there is no way to enable all features *except* a specific feature, so we cant do e.g. `--all-features --exclude-feature ethereum` to check that `op-reth` passes lints.

This PR also fixes the broken benches