### PR TITLE
Prioritise primary stream

### DIFF
--- a/crates/net/eth-wire/src/errors/eth.rs
+++ b/crates/net/eth-wire/src/errors/eth.rs
@@ -1,18 +1,21 @@
 //! Error handling for (`EthStream`)[crate::EthStream]
 
 use crate::{
-    errors::{MuxDemuxError, P2PStreamError},
+    errors::{MultiplexResult, MuxDemuxError, P2PStreamError},
     version::ParseVersionError,
-    DisconnectReason, EthMessageID, EthVersion,
+    DisconnectReason, EthMessage, EthMessageID, EthVersion,
 };
 use alloy_chains::Chain;
 use reth_primitives::{GotExpected, GotExpectedBoxed, ValidationError, B256};
-use std::io;
+use std::{io, sync::Arc};
 
 /// Errors when sending/receiving messages
 #[derive(thiserror::Error, Debug)]
 
 pub enum EthStreamError {
+    /// Error of the underlying satellite.
+    #[error(transparent)]
+    MultiplexError(#[from] MultiplexResult<EthMessage, Arc<EthStreamError>>),
     #[error(transparent)]
     /// Error of the underlying P2P connection.
     P2PStreamError(#[from] P2PStreamError),

--- a/crates/net/eth-wire/src/errors/mod.rs
+++ b/crates/net/eth-wire/src/errors/mod.rs
@@ -1,9 +1,11 @@
 //! Error types for stream variants
 
 mod eth;
+mod multiplex;
 mod muxdemux;
 mod p2p;
 
 pub use eth::*;
+pub use multiplex::*;
 pub use muxdemux::*;
 pub use p2p::*;

--- a/crates/net/eth-wire/src/errors/multiplex.rs
+++ b/crates/net/eth-wire/src/errors/multiplex.rs
@@ -1,0 +1,68 @@
+use std::{error, fmt};
+
+use reth_primitives::BytesMut;
+use thiserror::Error;
+use tokio::sync::mpsc;
+
+use crate::Capability;
+
+use super::P2PStreamError;
+
+#[derive(Error, Default, Debug)]
+#[error("some error was thrown in multiplexing, result primary: {primary:?}, errors subprotocols: {subprotocols:?}, errors multiplex: {multiplex:?}")]
+pub struct MultiplexResult<PrimaryOk, PrimaryErr>
+where
+    PrimaryOk: fmt::Debug,
+    PrimaryErr: error::Error,
+{
+    primary: Option<Result<PrimaryOk, PrimaryErr>>,
+    subprotocols: Vec<(Capability, SubprotocolError)>,
+    multiplex: Vec<MultiplexError>,
+}
+
+impl<PrimaryOk, PrimaryErr> MultiplexResult<PrimaryOk, PrimaryErr>
+where
+    PrimaryOk: fmt::Debug,
+    PrimaryErr: error::Error,
+{
+    pub fn new() -> Self {
+        MultiplexResult { primary: None, subprotocols: vec![], multiplex: vec![] }
+    }
+
+    pub fn is_none(&self) -> bool {
+        self.primary.is_none() && self.subprotocols.is_empty() && self.multiplex.is_empty()
+    }
+
+    pub fn set_primary_ok(mut self, ok: PrimaryOk) -> Self {
+        self.primary = Some(Ok(ok));
+        self
+    }
+
+    pub fn set_primary_error(mut self, e: PrimaryErr) -> Self {
+        self.primary = Some(Err(e));
+        self
+    }
+
+    pub fn add_subprotocol_error(&mut self, cap: Capability, e: SubprotocolError) {
+        self.subprotocols.push((cap, e))
+    }
+
+    pub fn add_multiplex_error(&mut self, e: impl Into<MultiplexError>) {
+        self.multiplex.push(e.into())
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum SubprotocolError {
+    #[error("cap handle closed")]
+    HandleClosed,
+}
+
+#[derive(Error, Debug)]
+pub enum MultiplexError {
+    /// Error of the underlying P2P connection.
+    #[error(transparent)]
+    P2PStream(#[from] P2PStreamError),
+    #[error("failed to delegate bytes from p2p, {0}")]
+    DelegateFailed(#[from] mpsc::error::SendError<BytesMut>),
+}

--- a/crates/net/eth-wire/src/multiplex.rs
+++ b/crates/net/eth-wire/src/multiplex.rs
@@ -501,6 +501,7 @@ where
                 match proto.poll_next_unpin(cx) {
                     Poll::Ready(Some(msg)) => {
                         this.inner.out_buffer.push_back(msg);
+                        this.inner.protocols.push(proto);
                     }
                     Poll::Ready(None) => {
                         debug!(

--- a/crates/net/eth-wire/src/multiplex.rs
+++ b/crates/net/eth-wire/src/multiplex.rs
@@ -478,7 +478,9 @@ where
             loop {
                 match this.primary.from_primary.poll_next_unpin(cx) {
                     Poll::Ready(Some(msg)) => {
-                        this.inner.out_buffer.push_back(msg);
+                        if let Err(err) = this.inner.conn.start_send_unpin(msg) {
+                            return Poll::Ready(Some(Err(err.into())))
+                        }
                     }
                     Poll::Ready(None) => {
                         // primary closed

--- a/crates/net/eth-wire/src/multiplex.rs
+++ b/crates/net/eth-wire/src/multiplex.rs
@@ -507,8 +507,6 @@ where
                             capability=?proto.shared_cap(),
                             "stream for capability handle has closed"
                         );
-
-                        continue
                     }
                     Poll::Pending => this.inner.protocols.push(proto),
                 }
@@ -534,6 +532,7 @@ where
                                 for proto in &this.inner.protocols {
                                     if proto.shared_cap == *cap {
                                         proto.send_raw(msg);
+                                        break
                                     }
                                 }
                             }

--- a/crates/net/eth-wire/src/multiplex.rs
+++ b/crates/net/eth-wire/src/multiplex.rs
@@ -496,10 +496,7 @@ where
                         this.inner.out_buffer.push_back(msg);
                     }
                     Poll::Ready(None) => return Poll::Ready(None),
-                    Poll::Pending => {
-                        this.inner.protocols.push(proto);
-                        break
-                    }
+                    Poll::Pending => this.inner.protocols.push(proto),
                 }
             }
 
@@ -726,6 +723,7 @@ mod tests {
             .unwrap();
 
             loop {
+                println!("stuck here");
                 let _ = st.next().await;
             }
         });


### PR DESCRIPTION
programmability spans up a new attack surface onto the node. this pr prioritises the primary stream. it is a good precaution that aims to limit the damage of user-defined vulnerabilities to the injected handles, and not let them effect the whole node.

by letting users inject cap-handles into reth, we are making the node vulnerable to all kinds of errors we cannot foresee and therefore not make any guarantees for how the node runs. a scenario that could happen before, is that some user-defined cap-handle can be dos:ed so that it sends endless messages, this means that the `RlpxSatelliteStream` stream will get stuck in a loop and no more `eth` messages would be sent or received.