### PR TITLE
fix(ci): conditional asm feature

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
             profile: maxperf
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-20.04
-            profile: maxperf-no-asm
+            profile: maxperf
           - target: x86_64-apple-darwin
             os: macos-latest
             profile: maxperf

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ BUILD_PATH = "target"
 ifeq ($(OS),Windows_NT)
     FEATURES ?=
 else
-    FEATURES ?= jemalloc
+    FEATURES ?= jemalloc,asm-keccak
 endif
 
 # Cargo profile for builds. Default is for local builds, CI uses an override.
@@ -73,6 +73,9 @@ op-build-native-%:
 
 # No jemalloc on Windows
 build-x86_64-pc-windows-gnu: FEATURES := $(filter-out jemalloc jemalloc-prof,$(FEATURES))
+
+# asm keccak optimizations not enabled
+build-aarch64-unknown-linux-gnu: FEATURES := $(filter-out asm-keccak,$(FEATURES))
 
 # Note: The additional rustc compiler flags are for intrinsics needed by MDBX.
 # See: https://github.com/cross-rs/cross/wiki/FAQ#undefined-reference-with-build-std

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ BUILD_PATH = "target"
 ifeq ($(OS),Windows_NT)
     FEATURES ?=
 else
-    FEATURES ?= jemalloc,asm-keccak
+    FEATURES ?= jemalloc asm-keccak
 endif
 
 # Cargo profile for builds. Default is for local builds, CI uses an override.


### PR DESCRIPTION
## Description

Remove non-existing profile from release workflow and disable `asm-keccak` feature on `build-aarch64-unknown-linux-gnu`.