### PR TITLE
 feat: add with_unused_ports method to rpc and network args 

### DIFF
--- a/bin/reth/src/args/network_args.rs
+++ b/bin/reth/src/args/network_args.rs
@@ -122,6 +122,19 @@ impl NetworkArgs {
 
         Some(peers_file)
     }
+
+    /// Sets the p2p port to zero, to allow the OS to assign a random unused port when
+    /// the network components bind to a socket.
+    pub fn with_unused_p2p_port(&mut self) {
+        self.port = 0;
+    }
+
+    /// Sets the p2p and discovery ports to zero, allowing the OD to assign a random unused port
+    /// when network components bind to sockets.
+    pub fn with_unused_ports(&mut self) {
+        self.with_unused_p2p_port();
+        self.discovery.with_unused_discovery_port();
+    }
 }
 
 impl Default for NetworkArgs {
@@ -182,6 +195,12 @@ impl DiscoveryArgs {
             network_config_builder = network_config_builder.disable_discv4_discovery();
         }
         network_config_builder
+    }
+
+    /// Set the discovery port to zero, to allow the OS to assign a random unused port when
+    /// discovery binds to the socket.
+    pub fn with_unused_discovery_port(&mut self) {
+        self.port = 0;
     }
 }
 

--- a/bin/reth/src/args/network_args.rs
+++ b/bin/reth/src/args/network_args.rs
@@ -125,15 +125,17 @@ impl NetworkArgs {
 
     /// Sets the p2p port to zero, to allow the OS to assign a random unused port when
     /// the network components bind to a socket.
-    pub fn with_unused_p2p_port(&mut self) {
+    pub fn with_unused_p2p_port(mut self) -> Self {
         self.port = 0;
+        self
     }
 
     /// Sets the p2p and discovery ports to zero, allowing the OD to assign a random unused port
     /// when network components bind to sockets.
-    pub fn with_unused_ports(&mut self) {
-        self.with_unused_p2p_port();
-        self.discovery.with_unused_discovery_port();
+    pub fn with_unused_ports(mut self) -> Self {
+        self = self.with_unused_p2p_port();
+        self.discovery = self.discovery.with_unused_discovery_port();
+        self
     }
 }
 
@@ -199,8 +201,9 @@ impl DiscoveryArgs {
 
     /// Set the discovery port to zero, to allow the OS to assign a random unused port when
     /// discovery binds to the socket.
-    pub fn with_unused_discovery_port(&mut self) {
+    pub fn with_unused_discovery_port(mut self) -> Self {
         self.port = 0;
+        self
     }
 }
 

--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -42,6 +42,7 @@ use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::PathBuf,
 };
+use rand::Rng;
 use tracing::{debug, info};
 
 /// Default max number of subscriptions per connection.
@@ -218,6 +219,44 @@ impl RpcServerArgs {
         // also adjust the ipc path by appending the instance number to the path used for the
         // endpoint
         self.ipcpath = format!("{}-{}", self.ipcpath, instance);
+    }
+
+    /// Set the http port to zero, to allow the OS to assign a random unused port when the rpc
+    /// server binds to a socket.
+    pub fn with_http_unused_port(&mut self) {
+        self.http_port = 0;
+    }
+
+    /// Set the ws port to zero, to allow the OS to assign a random unused port when the rpc
+    /// server binds to a socket.
+    pub fn with_ws_unused_port(&mut self) {
+        self.ws_port = 0;
+    }
+
+    /// Set the auth port to zero, to allow the OS to assign a random unused port when the rpc
+    /// server binds to a socket.
+    pub fn with_auth_unused_port(&mut self) {
+        self.auth_port = 0;
+    }
+
+    /// Append a random string to the ipc path, to prevent possible collisions when multiple nodes
+    /// are being run on the same machine.
+    pub fn with_ipc_random_path(&mut self) {
+        let random_string: String = rand::thread_rng()
+            .sample_iter(rand::distributions::Alphanumeric)
+            .take(8)
+            .map(char::from)
+            .collect();
+        self.ipcpath = format!("{}-{}", self.ipcpath, random_string);
+    }
+
+    /// Configure all ports to be set to a random unused port when bound, and set the IPC path to a
+    /// random path.
+    pub fn with_unused_ports(&mut self) {
+        self.with_http_unused_port();
+        self.with_ws_unused_port();
+        self.with_auth_unused_port();
+        self.with_ipc_random_path();
     }
 
     /// Configures and launches _all_ servers.

--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -17,6 +17,7 @@ use clap::{
     Arg, Args, Command,
 };
 use futures::TryFutureExt;
+use rand::Rng;
 use reth_network_api::{NetworkInfo, Peers};
 use reth_node_api::EngineTypes;
 use reth_provider::{
@@ -42,7 +43,6 @@ use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::PathBuf,
 };
-use rand::Rng;
 use tracing::{debug, info};
 
 /// Default max number of subscriptions per connection.

--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -223,40 +223,45 @@ impl RpcServerArgs {
 
     /// Set the http port to zero, to allow the OS to assign a random unused port when the rpc
     /// server binds to a socket.
-    pub fn with_http_unused_port(&mut self) {
+    pub fn with_http_unused_port(mut self) -> Self {
         self.http_port = 0;
+        self
     }
 
     /// Set the ws port to zero, to allow the OS to assign a random unused port when the rpc
     /// server binds to a socket.
-    pub fn with_ws_unused_port(&mut self) {
+    pub fn with_ws_unused_port(mut self) -> Self {
         self.ws_port = 0;
+        self
     }
 
     /// Set the auth port to zero, to allow the OS to assign a random unused port when the rpc
     /// server binds to a socket.
-    pub fn with_auth_unused_port(&mut self) {
+    pub fn with_auth_unused_port(mut self) -> Self {
         self.auth_port = 0;
+        self
     }
 
     /// Append a random string to the ipc path, to prevent possible collisions when multiple nodes
     /// are being run on the same machine.
-    pub fn with_ipc_random_path(&mut self) {
+    pub fn with_ipc_random_path(mut self) -> Self {
         let random_string: String = rand::thread_rng()
             .sample_iter(rand::distributions::Alphanumeric)
             .take(8)
             .map(char::from)
             .collect();
         self.ipcpath = format!("{}-{}", self.ipcpath, random_string);
+        self
     }
 
     /// Configure all ports to be set to a random unused port when bound, and set the IPC path to a
     /// random path.
-    pub fn with_unused_ports(&mut self) {
-        self.with_http_unused_port();
-        self.with_ws_unused_port();
-        self.with_auth_unused_port();
-        self.with_ipc_random_path();
+    pub fn with_unused_ports(mut self) -> Self {
+        self = self.with_http_unused_port();
+        self = self.with_ws_unused_port();
+        self = self.with_auth_unused_port();
+        self = self.with_ipc_random_path();
+        self
     }
 
     /// Configures and launches _all_ servers.

--- a/bin/reth/src/builder/mod.rs
+++ b/bin/reth/src/builder/mod.rs
@@ -354,12 +354,6 @@ impl NodeConfig {
         self
     }
 
-    /// Set the node instance number
-    pub fn with_instance_number(mut self, instance: u16) -> Self {
-        self.instance = instance;
-        self
-    }
-
     /// Set the rollup args for the node
     #[cfg(feature = "optimism")]
     pub fn with_rollup(mut self, rollup: crate::args::RollupArgs) -> Self {

--- a/bin/reth/src/builder/mod.rs
+++ b/bin/reth/src/builder/mod.rs
@@ -1417,9 +1417,6 @@ mod tests {
         // this launches a test node with http
         let rpc_args = RpcServerArgs::default().with_http();
 
-        // NOTE: tests here manually set an instance number. The alternative would be to use an
-        // atomic counter. This works for `cargo test` but if tests would be run in `nextest` then
-        // they would become flaky. So new tests should manually set a unique instance number.
         let (handle, _manager) = spawn_node(NodeConfig::test().with_rpc(rpc_args)).await.unwrap();
 
         // call a function on the node

--- a/bin/reth/src/builder/mod.rs
+++ b/bin/reth/src/builder/mod.rs
@@ -949,6 +949,13 @@ impl NodeConfig {
     fn adjust_instance_ports(&mut self) {
         self.rpc.adjust_instance_ports(self.instance);
     }
+
+    /// Sets networking and RPC ports to zero, causing the OS to choose random unused ports when
+    /// sockets are bound.
+    fn with_unused_ports(&mut self) {
+        self.rpc.with_unused_ports();
+        self.network.with_unused_ports();
+    }
 }
 
 impl Default for NodeConfig {

--- a/bin/reth/src/builder/mod.rs
+++ b/bin/reth/src/builder/mod.rs
@@ -266,7 +266,7 @@ impl NodeConfig {
         };
 
         // set all ports to zero by default for test instances
-        test.with_unused_ports();
+        test = test.with_unused_ports();
         test
     }
 
@@ -950,9 +950,10 @@ impl NodeConfig {
 
     /// Sets networking and RPC ports to zero, causing the OS to choose random unused ports when
     /// sockets are bound.
-    fn with_unused_ports(&mut self) {
-        self.rpc.with_unused_ports();
-        self.network.with_unused_ports();
+    fn with_unused_ports(mut self) -> Self {
+        self.rpc = self.rpc.with_unused_ports();
+        self.network = self.network.with_unused_ports();
+        self
     }
 }
 


### PR DESCRIPTION
ref https://github.com/paradigmxyz/reth/pull/6107#discussion_r1456435005

Adds methods on network, discovery, and rpc args for setting ports to zero. This means they will be set to an unused port when bound. This is useful in tests, when many nodes are being spun up at the same time.