### PR TITLE
Cap max graceful incoming disconnects

### DIFF
--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -53,6 +53,9 @@ pub use handle::{
 use reth_eth_wire::multiplex::RlpxProtocolMultiplexer;
 pub use reth_network_api::{Direction, PeerInfo};
 
+/// Incoming connections counter.
+#[derive(Debug)]
+pub struct Counter(pub Arc<()>);
 /// Internal identifier for active sessions.
 #[derive(Debug, Clone, Copy, PartialOrd, PartialEq, Eq, Hash)]
 pub struct SessionId(usize);
@@ -309,10 +312,12 @@ impl SessionManager {
         &mut self,
         stream: TcpStream,
         reason: DisconnectReason,
+        counter: &Counter,
     ) {
         let secret_key = self.secret_key;
 
         self.spawn(async move {
+            let counter_clone = Counter(Arc::clone(&counter.0));
             if let Ok(stream) = get_eciess_stream(stream, secret_key, Direction::Incoming).await {
                 let _ = UnauthedP2PStream::new(stream).send_disconnect(reason).await;
             }


### PR DESCRIPTION
closes #6079 
basically I used Counter(<()>) which gave me strong_count, which I used to check the reference count at different points of the counter, and if these reference count exceeded the specified MAX_GRACEFUL_DISCONNECTS(currently set to 15) I disconnected all active sessions otherwise I created the clone of the counter inside async block for spawn, which will automatically drop this clone after block execution otherwise the strong_count of counter will increase.
This is a draft solution, I am open to discuss further changes and improvements.