### PR TITLE
chore(dep): replace unmaintained dependency tui with ratatui 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1449,7 +1449,7 @@ version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c64043d6c7b7a4c58e39e7efccfdea7b93d885a795d0c054a69dbbf4dd52686"
 dependencies = [
- "crossterm 0.27.0",
+ "crossterm",
  "strum",
  "strum_macros",
  "unicode-width",
@@ -1663,22 +1663,6 @@ name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
-
-[[package]]
-name = "crossterm"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
-dependencies = [
- "bitflags 1.3.2",
- "crossterm_winapi",
- "libc",
- "mio",
- "parking_lot 0.12.1",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
 
 [[package]]
 name = "crossterm"
@@ -3697,6 +3681,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
+
+[[package]]
 name = "infer"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5518,6 +5508,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5659e52e4ba6e07b2dad9f1158f578ef84a73762625ddb51536019f34d180eb"
+dependencies = [
+ "bitflags 2.4.1",
+ "cassowary",
+ "crossterm",
+ "indoc",
+ "itertools 0.12.0",
+ "lru 0.12.1",
+ "paste",
+ "stability",
+ "strum",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "10.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5690,7 +5699,7 @@ dependencies = [
  "comfy-table",
  "confy",
  "const-str",
- "crossterm 0.27.0",
+ "crossterm",
  "dirs-next",
  "eyre",
  "fdlimit",
@@ -5712,6 +5721,7 @@ dependencies = [
  "procfs",
  "proptest",
  "rand 0.8.5",
+ "ratatui",
  "rayon",
  "reth-auto-seal-consensus",
  "reth-basic-payload-builder",
@@ -5760,7 +5770,6 @@ dependencies = [
  "tokio",
  "toml 0.8.8",
  "tracing",
- "tui",
  "vergen",
 ]
 
@@ -7805,6 +7814,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
+name = "stability"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd1b177894da2a2d9120208c3386066af06a488255caabc5de8ddca22dbc3ce"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8653,19 +8672,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "termcolor",
-]
-
-[[package]]
-name = "tui"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1"
-dependencies = [
- "bitflags 1.3.2",
- "cassowary",
- "crossterm 0.25.0",
- "unicode-segmentation",
- "unicode-width",
 ]
 
 [[package]]

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -90,7 +90,7 @@ rand.workspace = true
 # tui
 comfy-table = "7.0"
 crossterm = "0.27.0"
-tui = "0.19.0"
+ratatui = "0.25.0"
 human_bytes = "0.4.1"
 
 # async

--- a/bin/reth/src/commands/db/tui.rs
+++ b/bin/reth/src/commands/db/tui.rs
@@ -3,6 +3,13 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
+use ratatui::{
+    backend::{Backend, CrosstermBackend},
+    layout::{Alignment, Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
+    Frame, Terminal,
+};
 use reth_db::{
     table::{Table, TableRow},
     RawValue,
@@ -12,13 +19,6 @@ use std::{
     time::{Duration, Instant},
 };
 use tracing::error;
-use tui::{
-    backend::{Backend, CrosstermBackend},
-    layout::{Alignment, Constraint, Corner, Direction, Layout},
-    style::{Color, Modifier, Style},
-    widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
-    Frame, Terminal,
-};
 
 /// Available keybindings for the [DbListTUI]
 static CMDS: [(&str, &str); 6] = [
@@ -356,7 +356,7 @@ where
 }
 
 /// Render the UI
-fn ui<B: Backend, F, T: Table>(f: &mut Frame<'_, B>, app: &mut DbListTUI<F, T>)
+fn ui<F, T: Table>(f: &mut Frame<'_>, app: &mut DbListTUI<F, T>)
 where
     F: FnMut(usize, usize) -> Vec<TableRow<T>>,
 {
@@ -392,8 +392,7 @@ where
             )))
             .style(Style::default().fg(Color::White))
             .highlight_style(Style::default().fg(Color::Cyan).add_modifier(Modifier::ITALIC))
-            .highlight_symbol("➜ ")
-            .start_corner(Corner::TopLeft);
+            .highlight_symbol("➜ ");
         f.render_stateful_widget(key_list, inner_chunks[0], &mut app.list_state);
 
         let value_display = Paragraph::new(


### PR DESCRIPTION
Closes #6110

Removes deprecated `.start_corner(Corner::TopLeft);`. Unnecessary to replace it using the recommended `.direction(ListDirection::TopToBottom)` due to it being the default.

See: https://github.com/ratatui-org/ratatui/blob/68d5783a6912c644b922b7030facff4b1172a434/src/widgets/list.rs#L689-L729