### PR TITLE
Cap max graceful disconnects

### DIFF
--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -53,6 +53,9 @@ pub use handle::{
 use reth_eth_wire::multiplex::RlpxProtocolMultiplexer;
 pub use reth_network_api::{Direction, PeerInfo};
 
+/// Incoming connections counter.
+#[derive(Debug)]
+pub struct Counter(pub Arc<()>);
 /// Internal identifier for active sessions.
 #[derive(Debug, Clone, Copy, PartialOrd, PartialEq, Eq, Hash)]
 pub struct SessionId(usize);
@@ -309,10 +312,12 @@ impl SessionManager {
         &mut self,
         stream: TcpStream,
         reason: DisconnectReason,
+        counter: &Counter,
     ) {
         let secret_key = self.secret_key;
 
         self.spawn(async move {
+            let counter_clone = Counter(Arc::clone(&counter.0));
             if let Ok(stream) = get_eciess_stream(stream, secret_key, Direction::Incoming).await {
                 let _ = UnauthedP2PStream::new(stream).send_disconnect(reason).await;
             }

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -53,11 +53,9 @@ pub use handle::{
 use reth_eth_wire::multiplex::RlpxProtocolMultiplexer;
 pub use reth_network_api::{Direction, PeerInfo};
 
-/// Maximum allowed graceful disconnects.
-pub const MAX_GRACEFUL_DISCONNECTS: usize = 15;
-/// Keep track of graceful disconnects.
-#[derive(Debug, Clone)]
-pub struct GracefulDisconnects(pub Arc<()>);
+/// Maximum allowed graceful disconnects at a time.
+const MAX_GRACEFUL_DISCONNECTS: usize = 15;
+
 /// Internal identifier for active sessions.
 #[derive(Debug, Clone, Copy, PartialOrd, PartialEq, Eq, Hash)]
 pub struct SessionId(usize);
@@ -115,7 +113,7 @@ pub struct SessionManager {
     bandwidth_meter: BandwidthMeter,
     /// Metrics for the session manager.
     metrics: SessionManagerMetrics,
-    /// Tracks the number of active graceful disconnects.
+    /// Tracks the number of active graceful disconnects for incoming connections.
     graceful_disconnects_counter: GracefulDisconnects,
 }
 
@@ -158,7 +156,7 @@ impl SessionManager {
             bandwidth_meter,
             extra_protocols,
             metrics: Default::default(),
-            graceful_disconnects_counter: GracefulDisconnects(Arc::new(())),
+            graceful_disconnects_counter: Default::default(),
         }
     }
 
@@ -312,41 +310,25 @@ impl SessionManager {
         }
     }
 
-    #[allow(dead_code)]
     /// Sends a disconnect message to the peer with the given [DisconnectReason].
     pub(crate) fn disconnect_incoming_connection(
         &mut self,
         stream: TcpStream,
         reason: DisconnectReason,
     ) {
+        let counter = self.graceful_disconnects_counter.clone();
+        if counter.exceeds_limit() {
+            // simply drop the connection if there are too many active disconnects already
+            return
+        }
         let secret_key = self.secret_key;
 
         self.spawn(async move {
             if let Ok(stream) = get_eciess_stream(stream, secret_key, Direction::Incoming).await {
                 let _ = UnauthedP2PStream::new(stream).send_disconnect(reason).await;
             }
+            drop(counter)
         });
-    }
-
-    /// Handles graceful disconnects when node is at capacity
-    pub(crate) fn handle_disconnect_incoming_connection(
-        &mut self,
-        stream: TcpStream,
-        reason: DisconnectReason,
-    ) {
-        let secret_key = self.secret_key;
-        let counter_arc = Arc::clone(&self.graceful_disconnects_counter.0);
-        if Arc::strong_count(&self.graceful_disconnects_counter.0) < MAX_GRACEFUL_DISCONNECTS {
-            self.spawn(async move {
-                let _counter_clone = GracefulDisconnects(counter_arc);
-                if let Ok(stream) = get_eciess_stream(stream, secret_key, Direction::Incoming).await
-                {
-                    let _ = UnauthedP2PStream::new(stream).send_disconnect(reason).await;
-                }
-            });
-        } else {
-            self.disconnect_all(Some(reason));
-        }
     }
 
     /// Initiates a shutdown of all sessions.
@@ -651,6 +633,18 @@ impl SessionManager {
             }
         }
         infos
+    }
+}
+
+/// Keep track of graceful disconnects for incoming connections.
+#[derive(Debug, Clone, Default)]
+struct GracefulDisconnects(Arc<()>);
+
+impl GracefulDisconnects {
+    /// Returns true if the number of graceful disconnects exceeds the limit
+    /// [MAX_GRACEFUL_DISCONNECTS]
+    fn exceeds_limit(&self) -> bool {
+        Arc::strong_count(&self.0) > MAX_GRACEFUL_DISCONNECTS
     }
 }
 

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -306,7 +306,8 @@ impl SessionManager {
             session.disconnect(reason);
         }
     }
-
+    
+    #[allow(dead_code)]
     /// Sends a disconnect message to the peer with the given [DisconnectReason].
     pub(crate) fn disconnect_incoming_connection(
         &mut self,
@@ -332,7 +333,7 @@ impl SessionManager {
         let counter_arc = Arc::clone(&counter.0); // Clone the Arc
 
         self.spawn(async move {
-            let counter_clone = Counter(counter_arc); // Create the Counter inside the async block
+            let _counter_clone = Counter(counter_arc); // Create the Counter inside the async block
             if let Ok(stream) = get_eciess_stream(stream, secret_key, Direction::Incoming).await {
                 let _ = UnauthedP2PStream::new(stream).send_disconnect(reason).await;
             }

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -55,7 +55,7 @@ pub use reth_network_api::{Direction, PeerInfo};
 
 /// Maximum allowed graceful disconnects.
 pub const MAX_GRACEFUL_DISCONNECTS: usize = 15;
-/// Keep tracks of graceful disconnects.
+/// Keep track of graceful disconnects.
 #[derive(Debug, Clone)]
 pub struct GracefulDisconnects(pub Arc<()>);
 /// Internal identifier for active sessions.
@@ -328,7 +328,7 @@ impl SessionManager {
         });
     }
 
-    ///Handles graceful disconnects when node is at capacity
+    /// Handles graceful disconnects when node is at capacity
     pub(crate) fn handle_disconnect_incoming_connection(
         &mut self,
         stream: TcpStream,

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -55,7 +55,7 @@ pub use reth_network_api::{Direction, PeerInfo};
 
 /// Maximum allowed graceful disconnects.
 pub const MAX_GRACEFUL_DISCONNECTS: usize = 15;
-/// Incoming connections counter.
+/// Keep tracks of graceful disconnects.
 #[derive(Debug, Clone)]
 pub struct GracefulDisconnects(pub Arc<()>);
 /// Internal identifier for active sessions.
@@ -328,6 +328,7 @@ impl SessionManager {
         });
     }
 
+    ///Handles graceful disconnects when node is at capacity
     pub(crate) fn handle_disconnect_incoming_connection(
         &mut self,
         stream: TcpStream,

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -330,7 +330,7 @@ impl SessionManager {
     ) {
         let secret_key = self.secret_key;
         let counter_arc = Arc::clone(&counter.0); // Clone the Arc
-    
+
         self.spawn(async move {
             let counter_clone = Counter(counter_arc); // Create the Counter inside the async block
             if let Ok(stream) = get_eciess_stream(stream, secret_key, Direction::Incoming).await {

--- a/crates/net/network/src/swarm.rs
+++ b/crates/net/network/src/swarm.rs
@@ -3,9 +3,7 @@ use crate::{
     message::{PeerMessage, PeerRequestSender},
     peers::InboundConnectionError,
     protocol::IntoRlpxSubProtocol,
-    session::{
-        Counter, Direction, PendingSessionHandshakeError, SessionEvent, SessionId, SessionManager,
-    },
+    session::{Direction, PendingSessionHandshakeError, SessionEvent, SessionId, SessionManager},
     state::{NetworkState, StateAction},
 };
 use futures::Stream;
@@ -24,8 +22,6 @@ use std::{
     task::{Context, Poll},
 };
 use tracing::trace;
-
-pub const MAX_GRACEFUL_DISCONNECTS: usize = 15;
 
 #[cfg_attr(doc, aquamarine::aquamarine)]
 /// Contains the connectivity related state of the network.
@@ -188,7 +184,6 @@ where
     ///
     /// Depending on the event, this will produce a new [`SwarmEvent`].
     fn on_connection(&mut self, event: ListenerEvent) -> Option<SwarmEvent> {
-        let counter = Counter(Arc::new(()));
         match event {
             ListenerEvent::Error(err) => return Some(SwarmEvent::TcpListenerError(err)),
             ListenerEvent::ListenerClosed { local_address: address } => {
@@ -209,15 +204,10 @@ where
                         }
                         InboundConnectionError::ExceedsLimit(limit) => {
                             trace!(target: "net", %limit, ?remote_addr, "Exceeded incoming connection limit; disconnecting");
-                            if Arc::strong_count(&counter.0) < MAX_GRACEFUL_DISCONNECTS {
-                                self.sessions.handle_disconnect_incoming_connection(
-                                    stream,
-                                    DisconnectReason::TooManyPeers,
-                                    &counter,
-                                );
-                            } else {
-                                self.sessions.disconnect_all(Some(DisconnectReason::TooManyPeers));
-                            }
+                            self.sessions.handle_disconnect_incoming_connection(
+                                stream,
+                                DisconnectReason::TooManyPeers,
+                            );
                         }
                     }
                     return None

--- a/crates/net/network/src/swarm.rs
+++ b/crates/net/network/src/swarm.rs
@@ -204,7 +204,7 @@ where
                         }
                         InboundConnectionError::ExceedsLimit(limit) => {
                             trace!(target: "net", %limit, ?remote_addr, "Exceeded incoming connection limit; disconnecting");
-                            self.sessions.handle_disconnect_incoming_connection(
+                            self.sessions.disconnect_incoming_connection(
                                 stream,
                                 DisconnectReason::TooManyPeers,
                             );

--- a/crates/net/network/src/swarm.rs
+++ b/crates/net/network/src/swarm.rs
@@ -208,13 +208,13 @@ where
                         InboundConnectionError::ExceedsLimit(limit) => {
                             trace!(target: "net", %limit, ?remote_addr, "Exceeded incoming connection limit; disconnecting");
                             if Arc::strong_count(&counter.0) < MAX_GRACEFUL_DISCONNECTS {
-                                self.sessions.disconnect_incoming_connection(
+                                self.sessions.handle_disconnect_incoming_connection(
                                     stream,
                                     DisconnectReason::TooManyPeers, &counter
                                 );
                             }
                             else {
-                                self.sessions.disconnect_all(reason);
+                                self.sessions.disconnect_all(Some(DisconnectReason::TooManyPeers));
                             }
                         }
                     }

--- a/crates/net/network/src/swarm.rs
+++ b/crates/net/network/src/swarm.rs
@@ -3,7 +3,9 @@ use crate::{
     message::{PeerMessage, PeerRequestSender},
     peers::InboundConnectionError,
     protocol::IntoRlpxSubProtocol,
-    session::{Direction, PendingSessionHandshakeError, SessionEvent, SessionId, SessionManager, Counter},
+    session::{
+        Counter, Direction, PendingSessionHandshakeError, SessionEvent, SessionId, SessionManager,
+    },
     state::{NetworkState, StateAction},
 };
 use futures::Stream;
@@ -210,10 +212,10 @@ where
                             if Arc::strong_count(&counter.0) < MAX_GRACEFUL_DISCONNECTS {
                                 self.sessions.handle_disconnect_incoming_connection(
                                     stream,
-                                    DisconnectReason::TooManyPeers, &counter
+                                    DisconnectReason::TooManyPeers,
+                                    &counter,
                                 );
-                            }
-                            else {
+                            } else {
                                 self.sessions.disconnect_all(Some(DisconnectReason::TooManyPeers));
                             }
                         }


### PR DESCRIPTION
closes #6079 
basically I used Counter(<()>) which gave me strong_count, which I used to check the reference count at different points of the counter, and if these reference count exceeded the specified MAX_GRACEFUL_DISCONNECTS(currently set to 15) I disconnected all active sessions otherwise I created the clone of the counter inside async block for spawn, which will automatically drop this clone after block execution otherwise the strong_count of counter will remain increased.
This is a draft solution, I am open to discuss further changes and improvements.