### PR TITLE
feat: add `HeadersTD` static file segment

### DIFF
--- a/bin/reth/src/commands/db/snapshots/mod.rs
+++ b/bin/reth/src/commands/db/snapshots/mod.rs
@@ -113,6 +113,7 @@ impl Command {
                             factory.clone(),
                             snap_segments::Receipts::new(*compression, filters),
                         )?,
+                        SnapshotSegment::HeadersTD => todo!(),
                     }
                 }
             }
@@ -145,6 +146,7 @@ impl Command {
                         InclusionFilter::Cuckoo,
                         phf,
                     )?,
+                    SnapshotSegment::HeadersTD => todo!(),
                 }
             }
         }

--- a/crates/primitives/src/snapshot/mod.rs
+++ b/crates/primitives/src/snapshot/mod.rs
@@ -18,6 +18,9 @@ pub struct HighestSnapshots {
     /// Highest snapshotted block of headers, inclusive.
     /// If [`None`], no snapshot is available.
     pub headers: Option<BlockNumber>,
+    /// Highest snapshotted block of headers total difficulty, inclusive.
+    /// If [`None`], no snapshot is available.
+    pub headers_td: Option<BlockNumber>,
     /// Highest snapshotted block of receipts, inclusive.
     /// If [`None`], no snapshot is available.
     pub receipts: Option<BlockNumber>,
@@ -31,6 +34,7 @@ impl HighestSnapshots {
     pub fn highest(&self, segment: SnapshotSegment) -> Option<BlockNumber> {
         match segment {
             SnapshotSegment::Headers => self.headers,
+            SnapshotSegment::HeadersTD => self.headers_td,
             SnapshotSegment::Transactions => self.transactions,
             SnapshotSegment::Receipts => self.receipts,
         }
@@ -40,6 +44,7 @@ impl HighestSnapshots {
     pub fn as_mut(&mut self, segment: SnapshotSegment) -> &mut Option<BlockNumber> {
         match segment {
             SnapshotSegment::Headers => &mut self.headers,
+            SnapshotSegment::HeadersTD => &mut self.headers_td,
             SnapshotSegment::Transactions => &mut self.transactions,
             SnapshotSegment::Receipts => &mut self.receipts,
         }

--- a/crates/primitives/src/snapshot/segment.rs
+++ b/crates/primitives/src/snapshot/segment.rs
@@ -29,6 +29,9 @@ pub enum SnapshotSegment {
     #[strum(serialize = "headers")]
     /// Snapshot segment responsible for the `CanonicalHeaders`, `Headers`, `HeaderTD` tables.
     Headers,
+    #[strum(serialize = "headerstd")]
+    /// Snapshot segment responsible for the `HeaderTD` tables.
+    HeadersTD,
     #[strum(serialize = "transactions")]
     /// Snapshot segment responsible for the `Transactions` table.
     Transactions,
@@ -50,6 +53,7 @@ impl SnapshotSegment {
 
         match self {
             SnapshotSegment::Headers => default_config,
+            SnapshotSegment::HeadersTD => default_config,
             SnapshotSegment::Transactions => default_config,
             SnapshotSegment::Receipts => default_config,
         }
@@ -182,7 +186,7 @@ impl SegmentHeader {
     /// Returns the row offset which depends on whether the segment is block or transaction based.
     pub fn start(&self) -> u64 {
         match self.segment {
-            SnapshotSegment::Headers => self.block_start(),
+            SnapshotSegment::Headers | SnapshotSegment::HeadersTD => self.block_start(),
             SnapshotSegment::Transactions | SnapshotSegment::Receipts => self.tx_start(),
         }
     }

--- a/crates/primitives/src/snapshot/segment.rs
+++ b/crates/primitives/src/snapshot/segment.rs
@@ -27,7 +27,7 @@ use strum::{AsRefStr, EnumIter, EnumString};
 /// Segment of the data that can be snapshotted.
 pub enum SnapshotSegment {
     #[strum(serialize = "headers")]
-    /// Snapshot segment responsible for the `CanonicalHeaders`, `Headers`, `HeaderTD` tables.
+    /// Snapshot segment responsible for the `CanonicalHeaders`, `Headers` tables.
     Headers,
     #[strum(serialize = "headerstd")]
     /// Snapshot segment responsible for the `HeaderTD` tables.

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -274,7 +274,9 @@ impl<TX: DbTx> DatabaseProvider<TX> {
         if let Some(snapshot_provider) = &self.snapshot_provider {
             // If there is, check the maximum block or transaction number of the segment.
             if let Some(snapshot_upper_bound) = match segment {
-                SnapshotSegment::Headers => snapshot_provider.get_highest_snapshot_block(segment),
+                SnapshotSegment::Headers | SnapshotSegment::HeadersTD => {
+                    snapshot_provider.get_highest_snapshot_block(segment)
+                }
                 SnapshotSegment::Transactions | SnapshotSegment::Receipts => {
                     snapshot_provider.get_highest_snapshot_tx(segment)
                 }
@@ -321,7 +323,9 @@ impl<TX: DbTx> DatabaseProvider<TX> {
         if let Some(provider) = &self.snapshot_provider {
             // If there is, check the maximum block or transaction number of the segment.
             let snapshot_upper_bound = match segment {
-                SnapshotSegment::Headers => provider.get_highest_snapshot_block(segment),
+                SnapshotSegment::Headers | SnapshotSegment::HeadersTD => {
+                    provider.get_highest_snapshot_block(segment)
+                }
                 SnapshotSegment::Transactions | SnapshotSegment::Receipts => {
                     provider.get_highest_snapshot_tx(segment)
                 }

--- a/crates/storage/provider/src/providers/snapshot/manager.rs
+++ b/crates/storage/provider/src/providers/snapshot/manager.rs
@@ -327,7 +327,9 @@ impl SnapshotProvider {
         P: FnMut(&T) -> bool,
     {
         let get_provider = |start: u64| match segment {
-            SnapshotSegment::Headers => self.get_segment_provider_from_block(segment, start, None),
+            SnapshotSegment::Headers | SnapshotSegment::HeadersTD => {
+                self.get_segment_provider_from_block(segment, start, None)
+            }
             SnapshotSegment::Transactions | SnapshotSegment::Receipts => {
                 self.get_segment_provider_from_transaction(segment, start, None)
             }


### PR DESCRIPTION
As the title suggests.

Headers segment will be split into two: `Header + HeaderHash` and `HeaderTD`
* TD is no longer relevant in newer blocks
* TD calculation is done in a different stage from when we receive Headers


This PR just adds it to the enum. The real changes will be coming on upcoming PRs.