### PR TITLE
fix: enable tls feature correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6573,6 +6573,7 @@ dependencies = [
  "reth-consensus-common",
  "reth-interfaces",
  "reth-metrics",
+ "reth-network",
  "reth-network-api",
  "reth-primitives",
  "reth-provider",

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -20,6 +20,7 @@ reth-rpc-types.workspace = true
 reth-provider = { workspace = true, features = ["test-utils"] }
 reth-transaction-pool = { workspace = true, features = ["test-utils"] }
 reth-network-api.workspace = true
+reth-network.workspace = true
 reth-rpc-engine-api.workspace = true
 reth-revm = { workspace = true, features = ["js-tracer"] }
 reth-tasks.workspace = true
@@ -47,7 +48,7 @@ hyper = "0.14.24"
 jsonwebtoken = "8"
 
 ## required for optimism sequencer delegation
-reqwest = { version = "0.11", default-features = false, features = ["rustls"], optional = true }
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"], optional = true }
 
 # async
 async-trait.workspace = true
@@ -87,6 +88,7 @@ optimism = [
     "reth-primitives/optimism",
     "reth-rpc-types-compat/optimism",
     "reth-network-api/optimism",
+    "reth-network/optimism",
     "reth-provider/optimism",
     "reth-transaction-pool/optimism",
 ]

--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -151,7 +151,7 @@ where
             blocking_task_pool,
             fee_history_cache,
             #[cfg(feature = "optimism")]
-            http_client: reqwest::Client::new(),
+            http_client: reqwest::Client::builder().use_rustls_tls().build().unwrap(),
         };
 
         Self { inner: Arc::new(inner) }


### PR DESCRIPTION
Closes #6119

The feature wasn't enabled correctly, and the error masks a tls issue ref https://github.com/hyperium/hyper/issues/1009

This forces rustls which previously wasn't used

```
 http_client: reqwest::Client::builder().use_rustls_tls().build().unwrap(),
    |                                                     ^^^^^^^^^^^^^^ method not found in `ClientBuilder`
```

