### PR TITLE
fix: use non-None enveloped tx for trace_call

### DIFF
--- a/crates/rpc/rpc/src/eth/revm_utils.rs
+++ b/crates/rpc/rpc/src/eth/revm_utils.rs
@@ -21,6 +21,9 @@ use revm_primitives::{
 };
 use tracing::trace;
 
+#[cfg(feature = "optimism")]
+use revm::primitives::{Bytes, OptimismFields};
+
 /// Helper type that bundles various overrides for EVM Execution.
 ///
 /// By `Default`, no overrides are included.
@@ -332,7 +335,7 @@ pub(crate) fn create_txn_env(block_env: &BlockEnv, request: CallRequest) -> EthR
         blob_hashes: blob_versioned_hashes.unwrap_or_default(),
         max_fee_per_blob_gas,
         #[cfg(feature = "optimism")]
-        optimism: Default::default(),
+        optimism: OptimismFields { enveloped_tx: Some(Bytes::new()), ..Default::default() },
     };
 
     Ok(env)


### PR DESCRIPTION
Should hopefully fix https://github.com/paradigmxyz/reth/issues/6008

This just sets the `enveloped_tx` field to `Some`, without setting an actual envelope. This seems to correspond with how op-geth sets the rollup env values.