### PR TITLE
Add commands from CONTRIBUTING.md to Makefile and update ci

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,10 +8,9 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  BIN_OTHER_FEATURES: asm-keccak jemalloc jemalloc-prof min-error-logs min-warn-logs min-info-logs min-debug-logs min-trace-logs
 
 jobs:
-  clippy:
+  clippy-binaries:
     name: clippy / ${{ matrix.network }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -29,7 +28,23 @@ jobs:
         with:
           cache-on-failure: true
       - run:
-          cargo clippy --bin "${{ matrix.binary }}" --workspace --features "$BIN_OTHER_FEATURES ${{ matrix.network }} " --lib --tests --benches --examples
+          cargo clippy --bin "${{ matrix.binary }}" --workspace --features "${{ matrix.network }} $BIN_OTHER_FEATURES"
+        env:
+          RUSTFLAGS: -D warnings
+          BIN_OTHER_FEATURES: asm-keccak jemalloc jemalloc-prof min-error-logs min-warn-logs min-info-logs min-debug-logs min-trace-logs
+    
+  clippy:
+    name: clippy 
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - run:
+          cargo clippy --workspace --lib --examples --tests --benches --all-features
         env:
           RUSTFLAGS: -D warnings
 
@@ -99,7 +114,7 @@ jobs:
     name: lint success
     runs-on: ubuntu-latest
     if: always()
-    needs: [clippy, docs, fmt, grafana]
+    needs: [clippy-binaries, clippy, docs, fmt, grafana]
     timeout-minutes: 30
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  BIN_OTHER_FEATURES: asm-keccak jemalloc jemalloc-prof min-error-logs min-warn-logs min-info-logs min-debug-logs min-trace-logs
 
 jobs:
   clippy:
@@ -28,7 +29,7 @@ jobs:
         with:
           cache-on-failure: true
       - run:
-          cargo clippy --bin "${{ matrix.binary }}" --workspace --features "${{ matrix.network }}" --lib --tests --benches --examples
+          cargo clippy --bin "${{ matrix.binary }}" --workspace --features "$BIN_OTHER_FEATURES ${{ matrix.network }} " --lib --tests --benches --examples
         env:
           RUSTFLAGS: -D warnings
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,13 +28,12 @@ jobs:
         with:
           cache-on-failure: true
       - run:
-          cargo clippy --bin "${{ matrix.binary }}" --workspace --features "${{ matrix.network }} $BIN_OTHER_FEATURES"
+          cargo clippy --bin "${{ matrix.binary }}" --workspace --features "${{ matrix.network }} asm-keccak jemalloc jemalloc-prof min-error-logs min-warn-logs min-info-logs min-debug-logs min-trace-logs"
         env:
           RUSTFLAGS: -D warnings
-          BIN_OTHER_FEATURES: asm-keccak jemalloc jemalloc-prof min-error-logs min-warn-logs min-info-logs min-debug-logs min-trace-logs
-    
+
   clippy:
-    name: clippy 
+    name: clippy
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,11 +98,7 @@ likelihood of the PR getting merged.
 Please also make sure that the following commands pass if you have changed the code:
 
 ```sh
-cargo check --all
-cargo test --all --all-features
-cargo +nightly fmt -- --check
-cargo clippy --bin "reth" --workspace --features "ethereum" --lib --tests --benches --examples -- -D warnings
-cargo clippy --bin "op-reth" --workspace --features "optimism" --lib --tests --benches --examples -- -D warnings
+make pr
 ```
 
 If you are working in VSCode, we recommend you install the [rust-analyzer](https://rust-analyzer.github.io/) extension,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,14 +107,6 @@ and use the following VSCode user settings:
 ```json
 "editor.formatOnSave": true,
 "rust-analyzer.rustfmt.extraArgs": ["+nightly"],
-"rust-analyzer.check.overrideCommand": [
-"cargo",
-"+nightly",
-"clippy",
-"--all",
-"--all-features",
-"--message-format=json"
-],
 "[rust]": {
 "editor.defaultFormatter": "rust-lang.rust-analyzer"
 }

--- a/Makefile
+++ b/Makefile
@@ -256,6 +256,11 @@ lint-op-reth:
 lint-other-targets:
 	cargo +nightly clippy --workspace --lib --examples --tests --benches --all-features -- -D warnings
 
+lint:
+	make lint-reth && \
+	make lint-op-reth && \
+	make lint-other-targets
+
 docs:
 	RUSTDOCFLAGS="--cfg docsrs --show-type-layout --generate-link-to-definition --enable-index-page -Zunstable-options -D warnings" cargo +nightly docs --document-private-items
 
@@ -268,13 +273,13 @@ test-op-reth:
 test-other-targets:
 	cargo test --workspace --lib --examples --tests --benches --all-features
 
-
-pr:
-	make fmt && \
-	make lint-reth && \
-	make lint-op-reth && \
-	make lint-other-targets && \
-	make docs && \
+test:
 	make test-reth && \
 	make test-op-reth && \
 	make test-other-targets
+
+pr:
+	make fmt && \
+	make lint && \
+	make docs && \
+	make test

--- a/crates/net/eth-wire/tests/fuzz_roundtrip.rs
+++ b/crates/net/eth-wire/tests/fuzz_roundtrip.rs
@@ -130,7 +130,7 @@ pub mod fuzz_rlp {
         RlpEncodableWrapper,
         RlpDecodableWrapper,
     )]
-    struct GetBlockHeadersWrapper(pub GetBlockHeaders);
+    struct GetBlockHeadersWrapper(GetBlockHeaders);
 
     impl Default for GetBlockHeadersWrapper {
         fn default() -> Self {

--- a/crates/net/eth-wire/tests/fuzz_roundtrip.rs
+++ b/crates/net/eth-wire/tests/fuzz_roundtrip.rs
@@ -37,6 +37,7 @@ where
 macro_rules! fuzz_type_and_name {
     ( $x:ty, $fuzzname:ident ) => {
         /// Fuzzes the round-trip encoding of the type.
+        #[allow(non_snake_case)]
         #[test_fuzz]
         fn $fuzzname(thing: $x) {
             crate::roundtrip_fuzz::<$x>(thing)

--- a/crates/transaction-pool/benches/priority.rs
+++ b/crates/transaction-pool/benches/priority.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use criterion::{
     black_box, criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion,
 };
@@ -21,7 +22,7 @@ fn generate_test_data_priority() -> (u128, u128, u128, u128) {
 }
 
 fn priority_bench(
-    group: &mut BenchmarkGroup<WallTime>,
+    group: &mut BenchmarkGroup<'_, WallTime>,
     description: &str,
     input_data: (u128, u128, u128, u128),
 ) {
@@ -40,7 +41,7 @@ fn priority_bench(
 }
 
 fn fee_jump_bench(
-    group: &mut BenchmarkGroup<WallTime>,
+    group: &mut BenchmarkGroup<'_, WallTime>,
     description: &str,
     input_data: (u128, u128),
 ) {
@@ -53,7 +54,7 @@ fn fee_jump_bench(
     });
 }
 
-pub fn blob_priority_calculation(c: &mut Criterion) {
+fn blob_priority_calculation(c: &mut Criterion) {
     let mut group = c.benchmark_group("Blob priority calculation");
     let fee_jump_input = generate_test_data_fee_delta();
 

--- a/crates/transaction-pool/benches/reorder.rs
+++ b/crates/transaction-pool/benches/reorder.rs
@@ -171,7 +171,7 @@ mod implementations {
 
     impl PartialEq for MockTransactionWithPriority {
         fn eq(&self, other: &Self) -> bool {
-            self.priority == &other.priority
+            self.priority == other.priority
         }
     }
 

--- a/crates/transaction-pool/benches/reorder.rs
+++ b/crates/transaction-pool/benches/reorder.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion,
 };
@@ -9,12 +10,12 @@ use proptest::{
 use reth_transaction_pool::test_utils::MockTransaction;
 
 /// Transaction Pool trait for benching.
-pub trait BenchTxPool: Default {
+trait BenchTxPool: Default {
     fn add_transaction(&mut self, tx: MockTransaction);
     fn reorder(&mut self, base_fee: u64);
 }
 
-pub fn txpool_reordering(c: &mut Criterion) {
+fn txpool_reordering(c: &mut Criterion) {
     let mut group = c.benchmark_group("Transaction Pool Reordering");
 
     for seed_size in [1_000, 10_000, 50_000, 100_000] {
@@ -54,7 +55,7 @@ pub fn txpool_reordering(c: &mut Criterion) {
 }
 
 fn txpool_reordering_bench<T: BenchTxPool>(
-    group: &mut BenchmarkGroup<WallTime>,
+    group: &mut BenchmarkGroup<'_, WallTime>,
     description: &str,
     seed: Vec<MockTransaction>,
     new_txs: Vec<MockTransaction>,

--- a/crates/transaction-pool/benches/reorder.rs
+++ b/crates/transaction-pool/benches/reorder.rs
@@ -171,7 +171,7 @@ mod implementations {
 
     impl PartialEq for MockTransactionWithPriority {
         fn eq(&self, other: &Self) -> bool {
-            self.priority.eq(&other.priority)
+            self.priority == &other.priority
         }
     }
 

--- a/crates/transaction-pool/benches/truncate.rs
+++ b/crates/transaction-pool/benches/truncate.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion,
 };
@@ -124,7 +125,7 @@ fn txpool_truncate(c: &mut Criterion) {
 }
 
 fn truncate_pending(
-    group: &mut BenchmarkGroup<WallTime>,
+    group: &mut BenchmarkGroup<'_, WallTime>,
     description: &str,
     seed: Vec<MockTransaction>,
     senders: usize,
@@ -159,7 +160,7 @@ fn truncate_pending(
 }
 
 fn truncate_parked(
-    group: &mut BenchmarkGroup<WallTime>,
+    group: &mut BenchmarkGroup<'_, WallTime>,
     description: &str,
     seed: Vec<MockTransaction>,
     senders: usize,


### PR DESCRIPTION
- for good devx, the commands in CONTRIBUTING.md are now grouped in the Makefile: adds `cargo docs` to the list, removes duplicate `cargo check` and `cargo clippy`, formats code instead of check formatting
- ci lint is updated to run with all features available in the binaries reth and op-reth respectively
- ci runs all features available in all other targets on those
- removes recommendation to override `check` command in VSCode which seems a bit heavy when save `onFocusChange` is set