### PR TITLE
Bug fix tx fetcher RUST_LOG=trace & add state dump to `debug_assert` error

### DIFF
--- a/crates/net/eth-wire/src/types/broadcast.rs
+++ b/crates/net/eth-wire/src/types/broadcast.rs
@@ -124,6 +124,14 @@ pub enum NewPooledTransactionHashes {
 // === impl NewPooledTransactionHashes ===
 
 impl NewPooledTransactionHashes {
+    /// Returns the message [`EthVersion`].
+    pub fn version(&self) -> EthVersion {
+        match self {
+            NewPooledTransactionHashes::Eth66(_) => EthVersion::Eth66,
+            NewPooledTransactionHashes::Eth68(_) => EthVersion::Eth68,
+        }
+    }
+
     /// Returns `true` if the payload is valid for the given version
     pub fn is_valid_for_version(&self, version: EthVersion) -> bool {
         match self {

--- a/crates/net/eth-wire/src/types/version.rs
+++ b/crates/net/eth-wire/src/types/version.rs
@@ -3,6 +3,8 @@
 
 use std::str::FromStr;
 
+use derive_more::Display;
+
 /// Error thrown when failed to parse a valid [`EthVersion`].
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[error("Unknown eth protocol version: {0}")]
@@ -10,7 +12,7 @@ pub struct ParseVersionError(String);
 
 /// The `eth` protocol version.
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Display)]
 pub enum EthVersion {
     /// The `eth` protocol version 66.
     Eth66 = 66,

--- a/crates/net/network/src/cache.rs
+++ b/crates/net/network/src/cache.rs
@@ -3,12 +3,7 @@ use derive_more::{Deref, DerefMut};
 use itertools::Itertools;
 use linked_hash_set::LinkedHashSet;
 use schnellru::{self, ByLength, Limiter, RandomState, Unlimited};
-use std::{
-    borrow::Borrow,
-    fmt,
-    hash::Hash,
-    num::NonZeroUsize,
-};
+use std::{borrow::Borrow, fmt, hash::Hash, num::NonZeroUsize};
 
 /// A minimal LRU cache based on a `LinkedHashSet` with limited capacity.
 ///
@@ -124,7 +119,13 @@ where
 
         debug_struct.field("limiter", self.limiter());
 
-        debug_struct.field("inner", &format_args!("Iter: {{{}}}", self.0.iter().map(|(k, v)| format!(" {k}: {v:?}")).format(",")));
+        debug_struct.field(
+            "inner",
+            &format_args!(
+                "Iter: {{{}}}",
+                self.0.iter().map(|(k, v)| format!(" {k}: {v:?}")).format(",")
+            ),
+        );
 
         debug_struct.finish()
     }
@@ -215,6 +216,6 @@ mod test {
         let value_2 = Value(22);
         cache.insert(key_2, value_2);
 
-        assert_eq!("LruMap { 2: Value(22), 1: Value(11) }", format!("{cache:?}"))
+        assert_eq!("LruMap { limiter: ByLength { max_length: 2 }, inner: Iter: { 2: Value(22), 1: Value(11)} }", format!("{cache:?}"))
     }
 }

--- a/crates/net/network/src/cache.rs
+++ b/crates/net/network/src/cache.rs
@@ -1,10 +1,11 @@
 use core::hash::BuildHasher;
 use derive_more::{Deref, DerefMut};
+use itertools::Itertools;
 use linked_hash_set::LinkedHashSet;
 use schnellru::{self, ByLength, Limiter, RandomState, Unlimited};
 use std::{
     borrow::Borrow,
-    fmt::{self, Write},
+    fmt,
     hash::Hash,
     num::NonZeroUsize,
 };
@@ -115,16 +116,16 @@ impl<K, V, L, S> fmt::Debug for LruMap<K, V, L, S>
 where
     K: Hash + PartialEq + fmt::Display,
     V: fmt::Debug,
-    L: Limiter<K, V>,
+    L: Limiter<K, V> + fmt::Debug,
     S: BuildHasher,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut debug_struct = f.debug_struct("LruMap");
-        for (k, v) in self.0.iter() {
-            let mut key_str = String::new();
-            write!(&mut key_str, "{k}")?;
-            debug_struct.field(&key_str, &v);
-        }
+
+        debug_struct.field("limiter", self.limiter());
+
+        debug_struct.field("inner", &format_args!("Iter: {{{}}}", self.0.iter().map(|(k, v)| format!(" {k}: {v:?}")).format(",")));
+
         debug_struct.finish()
     }
 }

--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -718,7 +718,6 @@ mod test {
 
         let eth68_hashes = [
             B256::from_slice(&[1; 32]),
-            B256::from_slice(&[1; 32]),
             B256::from_slice(&[2; 32]),
             B256::from_slice(&[3; 32]),
             B256::from_slice(&[4; 32]),

--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -9,7 +9,6 @@ use reth_interfaces::p2p::error::{RequestError, RequestResult};
 use reth_primitives::{PeerId, PooledTransactionsElement, TxHash};
 use schnellru::{ByLength, Unlimited};
 use std::{
-    env,
     num::NonZeroUsize,
     pin::Pin,
     task::{Context, Poll},
@@ -264,20 +263,19 @@ impl TransactionFetcher {
                 // peer in caller's context has requested hash and is hence not eligible as
                 // fallback peer.
                 if *retries >= MAX_REQUEST_RETRIES_PER_TX_HASH {
-                    if is_log_level_debug_or_trace() {
-                        let msg_version = self
-                            .eth68_meta
-                            .get(&hash)
+                    let msg_version = || -> EthVersion {
+                        self.eth68_meta
+                            .peek(&hash)
                             .map(|_| EthVersion::Eth68)
-                            .unwrap_or(EthVersion::Eth66);
+                            .unwrap_or(EthVersion::Eth66)
+                    };
 
-                        debug!(target: "net::tx",
-                            hash=%hash,
-                            retries=retries,
-                            msg_version=%msg_version,
-                            "retry limit for `GetPooledTransactions` requests reached for hash, dropping hash"
-                        );
-                    }
+                    debug!(target: "net::tx",
+                        hash=%hash,
+                        retries=retries,
+                        msg_version=%msg_version(),
+                        "retry limit for `GetPooledTransactions` requests reached for hash, dropping hash"
+                    );
 
                     max_retried_hashes.push(hash);
                     continue;
@@ -335,13 +333,13 @@ impl TransactionFetcher {
                 return false
             }
 
-            let msg_version = is_log_level_debug_or_trace().then(|| self.eth68_meta.get(hash).map(|_| EthVersion::Eth68).unwrap_or(EthVersion::Eth66));
+            let msg_version = || -> EthVersion { self.eth68_meta.peek(hash).map(|_| EthVersion::Eth68).unwrap_or(EthVersion::Eth66) };
 
             // vacant entry
             trace!(target: "net::tx",
                 peer_id=format!("{peer_id:#}"),
                 hash=%hash,
-                msg_version=%msg_version.expect("should be set if log level trace"),
+                msg_version=%msg_version(),
                 "new hash seen in announcement by peer"
             );
 
@@ -355,7 +353,7 @@ impl TransactionFetcher {
                 debug!(target: "net::tx",
                     peer_id=format!("{peer_id:#}"),
                     hash=%hash,
-                    msg_version=%msg_version.expect("should be set if log level debug"),
+                    msg_version=%msg_version(),
                     "failed to cache new announced hash from peer in schnellru::LruMap, dropping hash"
                 );
 
@@ -380,23 +378,23 @@ impl TransactionFetcher {
     ) -> Option<Vec<TxHash>> {
         let peer_id: PeerId = peer.request_tx.peer_id;
 
-        let msg_version = is_log_level_debug_or_trace().then(|| {
+        let msg_version = || -> EthVersion {
             new_announced_hashes
                 .first()
                 .map(|hash| {
                     self.eth68_meta
-                        .get(hash)
+                        .peek(hash)
                         .map(|_| EthVersion::Eth68)
                         .unwrap_or(EthVersion::Eth66)
                 })
                 .expect("`new_announced_hashes` shouldn't be empty")
-        });
+        };
 
         if self.active_peers.len() as u32 >= MAX_CONCURRENT_TX_REQUESTS {
             debug!(target: "net::tx",
                 peer_id=format!("{peer_id:#}"),
                 new_announced_hashes=?new_announced_hashes,
-                msg_version=%msg_version.expect("should be set if log level debug"),
+                msg_version=%msg_version(),
                 limit=MAX_CONCURRENT_TX_REQUESTS,
                 "limit for concurrent `GetPooledTransactions` requests reached, dropping request for hashes to peer"
             );
@@ -407,7 +405,7 @@ impl TransactionFetcher {
             debug!(target: "net::tx",
                 peer_id=format!("{peer_id:#}"),
                 new_announced_hashes=?new_announced_hashes,
-                msg_version=%msg_version.expect("should be set if log level debug"),
+                msg_version=%msg_version(),
                 "failed to cache active peer in schnellru::LruMap, dropping request to peer"
             );
             return Some(new_announced_hashes)
@@ -417,7 +415,7 @@ impl TransactionFetcher {
             debug!(target: "net::tx",
                 peer_id=format!("{peer_id:#}"),
                 new_announced_hashes=?new_announced_hashes,
-                msg_version=%msg_version.expect("should be set if log level debug"),
+                msg_version=%msg_version(),
                 limit=MAX_CONCURRENT_TX_REQUESTS_PER_PEER,
                 "limit for concurrent `GetPooledTransactions` requests per peer reached"
             );
@@ -710,15 +708,6 @@ impl Future for GetPooledTxRequestFut {
                 Poll::Pending
             }
         }
-    }
-}
-
-fn is_log_level_debug_or_trace() -> bool {
-    if let Ok(var) = env::var("RUST_LOG") {
-        let var = var.to_lowercase();
-        var == "debug" || var == "trace"
-    } else {
-        false
     }
 }
 

--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -375,7 +375,7 @@ impl TransactionFetcher {
         metrics_increment_egress_peer_channel_full: impl FnOnce(),
     ) -> Option<Vec<TxHash>> {
         let peer_id: PeerId = peer.request_tx.peer_id;
-        let msg_version = new_announced_hashes.get(0).map(|hash| {
+        let msg_version = new_announced_hashes.first().map(|hash| {
             self.eth68_meta.get(hash).map(|_| EthVersion::Eth68).unwrap_or(EthVersion::Eth66)
         });
 

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -682,7 +682,11 @@ where
 
             debug_assert!(
                 self.peers.contains_key(&peer_id),
-                "broken invariant `peers` and `transaction-fetcher`"
+                "a dead peer has been returned as idle by `@pop_any_idle_peer`, broken invariant `@peers` and `@transaction_fetcher`,
+`%peer_id`: {:?},
+`@peers`: {:?},
+`@transaction_fetcher`: {:?}",
+                peer_id, self.peers, self.transaction_fetcher
             );
 
             // fill the request with other buffered hashes that have been announced by the peer


### PR DESCRIPTION
although https://github.com/paradigmxyz/reth/issues/6137#event-11545092572 fixes the bug, a trace message was still panicking when a buffered hash was version eth66 rather than eth68. also found a new bug, which is fixed here too: `eth68_meta` was infinitely growing since data was inserted before filtering out known and seen hashes.

- fix panicking trace message bug in `fill_request_for_peer`
- fix infinite growth of `eth68_meta` https://github.com/paradigmxyz/reth/pull/6139#issuecomment-1902262959 (thanks for the good questions @mattsse )
- print full tx hashes to log so one can copy-paste them into a block explorer search query https://github.com/paradigmxyz/reth/issues/6080#issuecomment-1901226562
- add message version to log messages
- improve `debug_assert` error messages as recommended by @shekhirin to dump current state to log