### PR TITLE
add `has_access_list` method to `TxType`

### DIFF
--- a/crates/primitives/src/transaction/tx_type.rs
+++ b/crates/primitives/src/transaction/tx_type.rs
@@ -44,6 +44,18 @@ pub enum TxType {
     DEPOSIT = 126_isize,
 }
 
+impl TxType {
+    /// Check if the transaction type has an access list.
+    pub fn has_access_list(&self) -> bool {
+        match self {
+            TxType::Legacy => false,
+            TxType::EIP2930 | TxType::EIP1559 | TxType::EIP4844 => true,
+            #[cfg(feature = "optimism")]
+            TxType::DEPOSIT => false,
+        }
+    }
+}
+
 impl From<TxType> for u8 {
     fn from(value: TxType) -> Self {
         match value {

--- a/crates/primitives/src/transaction/tx_type.rs
+++ b/crates/primitives/src/transaction/tx_type.rs
@@ -46,7 +46,7 @@ pub enum TxType {
 
 impl TxType {
     /// Check if the transaction type has an access list.
-    pub fn has_access_list(&self) -> bool {
+    pub const fn has_access_list(&self) -> bool {
         match self {
             TxType::Legacy => false,
             TxType::EIP2930 | TxType::EIP1559 | TxType::EIP4844 => true,


### PR DESCRIPTION
## Summary

This pull request adds a `has_access_list` method to the `TxType` enum, which allows checking whether a specific transaction type includes an access list. This method is useful for distinguishing between transaction types that have an access list and those that do not.

## Changes

- Added a `has_access_list` method to the `TxType` enum, returning `true` for transaction types with an access list and `false` otherwise.

## Context

The `TxType` enum represents different types of Ethereum transactions, and this addition enhances its functionality by providing a convenient way to check for the presence of an access list.

