### PR TITLE
add `is_timestamp_in_past` and `exceeds_allowed_future_timestamp` for `Header`

### DIFF
--- a/crates/consensus/beacon-core/src/lib.rs
+++ b/crates/consensus/beacon-core/src/lib.rs
@@ -12,8 +12,8 @@
 use reth_consensus_common::validation;
 use reth_interfaces::consensus::{Consensus, ConsensusError};
 use reth_primitives::{
-    constants::{ALLOWED_FUTURE_BLOCK_TIME_SECONDS, MAXIMUM_EXTRA_DATA_SIZE},
-    Chain, ChainSpec, Hardfork, Header, SealedBlock, SealedHeader, EMPTY_OMMER_ROOT_HASH, U256,
+    constants::MAXIMUM_EXTRA_DATA_SIZE, Chain, ChainSpec, Hardfork, Header, SealedBlock,
+    SealedHeader, EMPTY_OMMER_ROOT_HASH, U256,
 };
 use std::{sync::Arc, time::SystemTime};
 /// Ethereum beacon consensus
@@ -88,7 +88,7 @@ impl Consensus for BeaconConsensus {
             let present_timestamp =
                 SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs();
 
-            if header.timestamp > present_timestamp + ALLOWED_FUTURE_BLOCK_TIME_SECONDS {
+            if header.is_timestamp_in_future(present_timestamp) {
                 return Err(ConsensusError::TimestampIsInFuture {
                     timestamp: header.timestamp,
                     present_timestamp,

--- a/crates/consensus/beacon-core/src/lib.rs
+++ b/crates/consensus/beacon-core/src/lib.rs
@@ -88,7 +88,7 @@ impl Consensus for BeaconConsensus {
             let present_timestamp =
                 SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs();
 
-            if header.is_timestamp_in_future(present_timestamp) {
+            if header.exceeds_allowed_future_timestamp(present_timestamp) {
                 return Err(ConsensusError::TimestampIsInFuture {
                     timestamp: header.timestamp,
                     present_timestamp,

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -313,7 +313,7 @@ pub fn validate_header_regarding_parent(
     }
 
     // timestamp in past check
-    if child.timestamp <= parent.timestamp {
+    if child.header.is_timestamp_in_past(parent.timestamp) {
         return Err(ConsensusError::TimestampIsInPast {
             parent_timestamp: parent.timestamp,
             timestamp: child.timestamp,

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -178,6 +178,8 @@ impl Header {
     }
 
     /// Checks if the block's timestamp is in the past compared to the parent block's timestamp.
+    ///
+    /// Note: This check is relevant only pre-merge.
     pub fn is_timestamp_in_past(&self, parent_timestamp: u64) -> bool {
         self.timestamp <= parent_timestamp
     }
@@ -185,7 +187,9 @@ impl Header {
     /// Checks if the block's timestamp is in the future based on the present timestamp.
     ///
     /// Clock can drift but this can be consensus issue.
-    pub fn is_timestamp_in_future(&self, present_timestamp: u64) -> bool {
+    ///
+    /// Note: This check is relevant only pre-merge.
+    pub fn exceeds_allowed_future_timestamp(&self, present_timestamp: u64) -> bool {
         self.timestamp > present_timestamp + ALLOWED_FUTURE_BLOCK_TIME_SECONDS
     }
 

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -1,6 +1,6 @@
 use crate::{
     basefee::calculate_next_block_base_fee,
-    constants::{EMPTY_OMMER_ROOT_HASH, EMPTY_ROOT_HASH},
+    constants::{ALLOWED_FUTURE_BLOCK_TIME_SECONDS, EMPTY_OMMER_ROOT_HASH, EMPTY_ROOT_HASH},
     eip4844::{calc_blob_gasprice, calculate_excess_blob_gas},
     keccak256, Address, BaseFeeParams, BlockHash, BlockNumHash, BlockNumber, Bloom, Bytes, B256,
     B64, U256,
@@ -175,6 +175,18 @@ impl Header {
         self.ensure_difficulty_valid()?;
         self.ensure_extradata_valid()?;
         Ok(())
+    }
+
+    /// Checks if the block's timestamp is in the past compared to the parent block's timestamp.
+    pub fn is_timestamp_in_past(&self, parent_timestamp: u64) -> bool {
+        self.timestamp <= parent_timestamp
+    }
+
+    /// Checks if the block's timestamp is in the future based on the present timestamp.
+    ///
+    /// Clock can drift but this can be consensus issue.
+    pub fn is_timestamp_in_future(&self, present_timestamp: u64) -> bool {
+        self.timestamp > present_timestamp + ALLOWED_FUTURE_BLOCK_TIME_SECONDS
     }
 
     /// Returns the parent block's number and hash


### PR DESCRIPTION
## Description

This pull request introduces two new methods, `is_timestamp_in_past` and `exceeds_allowed_future_timestamp `, for the `Header` struct in order to facilitate timestamp comparison checks.

## Changes Made

- Added `is_timestamp_in_past` method to check if the block's timestamp is in the past compared to the parent block's timestamp.
- Added `exceeds_allowed_future_timestamp ` method to check if the block's timestamp is in the future based on the current system time.

## Usage

- These methods provide convenient ways to perform timestamp-related comparisons within the context of a block header.

