### PR TITLE
add `ensure_transaction_root_valid` method for `SealedBlock`

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -218,12 +218,8 @@ pub fn validate_block_standalone(
     }
 
     // Check transaction root
-    // TODO(onbjerg): This should probably be accessible directly on [Block]
-    let transaction_root = reth_primitives::proofs::calculate_transaction_root(&block.body);
-    if block.header.transactions_root != transaction_root {
-        return Err(ConsensusError::BodyTransactionRootDiff(
-            GotExpected { got: transaction_root, expected: block.header.transactions_root }.into(),
-        ))
+    if let Err(error) = block.ensure_transaction_root_valid() {
+        return Err(ConsensusError::BodyTransactionRootDiff(error.into()));
     }
 
     // EIP-4895: Beacon chain push withdrawals as operations

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Address, Header, SealedHeader, TransactionSigned, TransactionSignedEcRecovered, Withdrawal,
-    B256,
+    Address, GotExpected, Header, SealedHeader, TransactionSigned, TransactionSignedEcRecovered,
+    Withdrawal, B256,
 };
 use alloy_rlp::{RlpDecodable, RlpEncodable};
 use reth_codecs::derive_arbitrary;
@@ -322,6 +322,32 @@ impl SealedBlock {
     /// Calculates the total gas used by blob transactions in the sealed block.
     pub fn blob_gas_used(&self) -> u64 {
         self.blob_transactions().iter().filter_map(|tx| tx.blob_gas_used()).sum()
+    }
+
+    /// Ensures that the transaction root in the block header is valid.
+    ///
+    /// The transaction root is the Keccak 256-bit hash of the root node of the trie structure
+    /// populated with each transaction in the transactions list portion of the block.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` if the calculated transaction root matches the one stored in the header,
+    /// indicating that the transactions in the block are correctly represented in the trie.
+    ///
+    /// Returns `Err(error)` if the transaction root validation fails, providing a `GotExpected`
+    /// error containing the calculated and expected roots.
+    pub fn ensure_transaction_root_valid(&self) -> Result<(), GotExpected<B256>> {
+        let calculated_root = crate::proofs::calculate_transaction_root(&self.body);
+
+        if !(self.header.transactions_root == calculated_root) {
+            return Err(GotExpected {
+                got: calculated_root,
+                expected: self.header.transactions_root,
+            }
+            .into())
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -339,12 +339,11 @@ impl SealedBlock {
     pub fn ensure_transaction_root_valid(&self) -> Result<(), GotExpected<B256>> {
         let calculated_root = crate::proofs::calculate_transaction_root(&self.body);
 
-        if !(self.header.transactions_root == calculated_root) {
+        if self.header.transactions_root != calculated_root {
             return Err(GotExpected {
                 got: calculated_root,
                 expected: self.header.transactions_root,
-            }
-            .into())
+            })
         }
 
         Ok(())


### PR DESCRIPTION
### Description

This pull request introduces a new method, `ensure_transaction_root_valid`, for the `SealedBlock` type. The method checks whether the transaction root in the block header is valid. The transaction root is verified by comparing it with the calculated Keccak 256-bit hash of the root node of the trie structure populated with each transaction in the transactions list portion of the block.

### Changes Made

- Added `ensure_transaction_root_valid` method to the `SealedBlock` type.

### Usage

The new method returns a `Result<(), GotExpected<B256>>`, where success (`Ok(())`) indicates a valid transaction root, and an error (`Err`) contains details about the unexpected root.

### Example

```rust
// Assuming `block` is an instance of `SealedBlock`
match block.ensure_transaction_root_valid() {
    Ok(()) => println!("Transaction root is valid."),
    Err(error) => println!("Transaction root check failed: {:?}", error),
}
