### PR TITLE
fix(tree): reset cached trie updates on prepend

### DIFF
--- a/crates/storage/provider/src/chain.rs
+++ b/crates/storage/provider/src/chain.rs
@@ -76,6 +76,7 @@ impl Chain {
     /// Prepends the given state to the current state.
     pub fn prepend_state(&mut self, state: BundleState) {
         self.state.prepend_state(state);
+        self.trie_updates.take(); // invalidate cached trie updates
     }
 
     /// Return true if chain is empty and has no blocks.


### PR DESCRIPTION
## Description

Upon reinserting unwound block back into the blockchain tree, its state is prepended to any dependent chain.
This action should invalidate any cached trie updates in dependent chains.