### PR TITLE
fix(ci): report hive failure

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -59,6 +59,7 @@ jobs:
   test:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: false
       matrix:
         experimental: [true]
         sim: [ethereum/rpc, smoke/genesis, smoke/network, ethereum/sync]
@@ -178,7 +179,6 @@ jobs:
           - sim: pyspec
             include: [frontier/]
             experimental: true
-      fail-fast: false
     needs: prepare
     name: run
     runs-on:
@@ -221,3 +221,7 @@ jobs:
         if: ${{ failure() }}
         run: |
           cat hivetests/workspace/logs/reth/client-*.log
+
+      - name: Report job failure
+        if: ${{ failure() }}
+        run: exit 1


### PR DESCRIPTION
## Description

Currently, hive workflow succeeds even if certain jobs fail (e.g. https://github.com/paradigmxyz/reth/actions/runs/7633425296).
Report failure on failed tests instead.