### PR TITLE
add `builder_pubkey` to relay queries

### DIFF
--- a/crates/rpc/rpc-types/src/relay/mod.rs
+++ b/crates/rpc/rpc-types/src/relay/mod.rs
@@ -70,11 +70,9 @@ pub struct BidTrace {
     /// The hash of the block.
     pub block_hash: B256,
     /// The public key of the builder.
-    #[serde(rename = "builder_pubkey")]
-    pub builder_public_key: BlsPublicKey,
+    pub builder_pubkey: BlsPublicKey,
     /// The public key of the proposer.
-    #[serde(rename = "proposer_pubkey")]
-    pub proposer_pubic_key: BlsPublicKey,
+    pub proposer_pubkey: BlsPublicKey,
     /// The recipient of the proposer's fee.
     pub proposer_fee_recipient: Address,
     /// The gas limit associated with the block.

--- a/crates/rpc/rpc-types/src/relay/mod.rs
+++ b/crates/rpc/rpc-types/src/relay/mod.rs
@@ -271,8 +271,8 @@ pub enum OrderBy {
 }
 
 /// Query for the GET `/relay/v1/data/bidtraces/builder_blocks_received` endpoint.
-/// This endpoint provides BidTraces for the builder block submission for a given slot (that were
-/// verified successfully).
+/// This endpoint provides BidTraces for builder block submissions that match the query and were
+/// verified successfully.
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BuilderBlocksReceivedQuery {
     /// A specific slot
@@ -287,6 +287,9 @@ pub struct BuilderBlocksReceivedQuery {
     /// Search for a specific EL block number
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_number: Option<u64>,
+    /// Search for a specific builder public key.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub builder_pubkey: Option<BlsPublicKey>,
 }
 
 impl BuilderBlocksReceivedQuery {
@@ -311,6 +314,12 @@ impl BuilderBlocksReceivedQuery {
     /// Sets the specific EL block number
     pub fn block_number(mut self, block_number: u64) -> Self {
         self.block_number = Some(block_number);
+        self
+    }
+
+    /// Sets the specific builder public key
+    pub fn builder_pubkey(mut self, builder_pubkey: BlsPublicKey) -> Self {
+        self.builder_pubkey = Some(builder_pubkey);
         self
     }
 }

--- a/crates/rpc/rpc-types/src/relay/mod.rs
+++ b/crates/rpc/rpc-types/src/relay/mod.rs
@@ -74,7 +74,7 @@ pub struct BidTrace {
     pub builder_public_key: BlsPublicKey,
     /// The public key of the proposer.
     #[serde(rename = "proposer_pubkey")]
-    pub proposer_public_key: BlsPublicKey,
+    pub proposer_pubic_key: BlsPublicKey,
     /// The recipient of the proposer's fee.
     pub proposer_fee_recipient: Address,
     /// The gas limit associated with the block.
@@ -197,9 +197,12 @@ pub struct ProposerPayloadsDeliveredQuery {
     /// Search for a specific EL block number
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_number: Option<u64>,
-    /// filter results by a proposer public key
+    /// Filter results by a proposer public key
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub proposer_key: Option<BlsPublicKey>,
+    pub proposer_pubkey: Option<BlsPublicKey>,
+    /// Filter results by a builder public key
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub builder_pubkey: Option<BlsPublicKey>,
     /// How to order results
     #[serde(skip_serializing_if = "Option::is_none")]
     pub order_by: Option<OrderBy>,
@@ -231,8 +234,14 @@ impl ProposerPayloadsDeliveredQuery {
     }
 
     /// Sets the proposer public key
-    pub fn proposer_key(mut self, proposer_key: BlsPublicKey) -> Self {
-        self.proposer_key = Some(proposer_key);
+    pub fn proposer_pubkey(mut self, proposer_pubkey: BlsPublicKey) -> Self {
+        self.proposer_pubkey = Some(proposer_pubkey);
+        self
+    }
+
+    /// Sets the builder public key
+    pub fn builder_pubkey(mut self, builder_pubkey: BlsPublicKey) -> Self {
+        self.builder_pubkey = Some(builder_pubkey);
         self
     }
 


### PR DESCRIPTION
Adds `builder_pubkey` field to relay data queries, in accordance with the [relay api spec](https://flashbots.github.io/relay-specs/).

Also includes a minor renaming of the public key fields of the `BidTrace` struct for consistency with the spec and other types.