### PR TITLE
chore: use Display instead of Debug when printing internal errors

### DIFF
--- a/bin/reth/src/commands/stage/unwind.rs
+++ b/bin/reth/src/commands/stage/unwind.rs
@@ -73,7 +73,7 @@ impl Command {
 
         let blocks_and_execution = provider
             .take_block_and_execution_range(&self.chain, range)
-            .map_err(|err| eyre::eyre!("Transaction error on unwind: {err:?}"))?;
+            .map_err(|err| eyre::eyre!("Transaction error on unwind: {err}"))?;
 
         provider.commit()?;
 

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -643,18 +643,18 @@ impl<DB: Database, EF: ExecutorFactory> BlockchainTree<DB, EF> {
         {
             error!(
                 ?block,
-                "Failed to validate total difficulty for block {}: {e:?}", block.header.hash
+                "Failed to validate total difficulty for block {}: {e}", block.header.hash
             );
             return Err(e)
         }
 
         if let Err(e) = self.externals.consensus.validate_header(block) {
-            error!(?block, "Failed to validate header {}: {e:?}", block.header.hash);
+            error!(?block, "Failed to validate header {}: {e}", block.header.hash);
             return Err(e)
         }
 
         if let Err(e) = self.externals.consensus.validate_block(block) {
-            error!(?block, "Failed to validate block {}: {e:?}", block.header.hash);
+            error!(?block, "Failed to validate block {}: {e}", block.header.hash);
             return Err(e)
         }
 

--- a/crates/rpc/rpc-builder/tests/it/startup.rs
+++ b/crates/rpc/rpc-builder/tests/it/startup.rs
@@ -28,7 +28,7 @@ async fn test_http_addr_in_use() {
         .start_server(RpcServerConfig::http(Default::default()).with_http_address(addr))
         .await;
     let err = result.unwrap_err();
-    assert!(is_addr_in_use_kind(&err, ServerKind::Http(addr)), "{err:?}");
+    assert!(is_addr_in_use_kind(&err, ServerKind::Http(addr)), "{err}");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -40,7 +40,7 @@ async fn test_ws_addr_in_use() {
     let result =
         server.start_server(RpcServerConfig::ws(Default::default()).with_ws_address(addr)).await;
     let err = result.unwrap_err();
-    assert!(is_addr_in_use_kind(&err, ServerKind::WS(addr)), "{err:?}");
+    assert!(is_addr_in_use_kind(&err, ServerKind::WS(addr)), "{err}");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/rpc/rpc-testing-util/tests/it/trace.rs
+++ b/crates/rpc/rpc-testing-util/tests/it/trace.rs
@@ -20,7 +20,7 @@ async fn trace_many_blocks() {
     let mut stream = client.trace_block_buffered_unordered(15_000_000..=16_000_100, 20);
     let now = Instant::now();
     while let Some((err, block)) = stream.next_err().await {
-        eprintln!("Error tracing block {block:?}: {err:?}");
+        eprintln!("Error tracing block {block:?}: {err}");
     }
     println!("Traced all blocks in {:?}", now.elapsed());
 }

--- a/crates/rpc/rpc/src/layers/auth_layer.rs
+++ b/crates/rpc/rpc/src/layers/auth_layer.rs
@@ -234,7 +234,7 @@ mod tests {
         let jwt = "this jwt has serious encoding problems".to_string();
         let (status, body) = send_request(Some(jwt)).await;
         assert_eq!(status, StatusCode::UNAUTHORIZED);
-        assert_eq!(body, "JWT decoding error: Error(InvalidToken)".to_string());
+        assert_eq!(body, "JWT decoding error: InvalidToken".to_string());
     }
 
     async fn send_request(jwt: Option<String>) -> (StatusCode, String) {

--- a/crates/rpc/rpc/src/layers/jwt_secret.rs
+++ b/crates/rpc/rpc/src/layers/jwt_secret.rs
@@ -142,7 +142,7 @@ impl JwtSecret {
                 ErrorKind::InvalidSignature => Err(JwtError::InvalidSignature)?,
                 ErrorKind::InvalidAlgorithm => Err(JwtError::UnsupportedSignatureAlgorithm)?,
                 _ => {
-                    let detail = format!("{err:?}");
+                    let detail = format!("{err}");
                     Err(JwtError::JwtDecodingError(detail))?
                 }
             },

--- a/crates/rpc/rpc/src/result.rs
+++ b/crates/rpc/rpc/src/result.rs
@@ -92,7 +92,7 @@ macro_rules! impl_to_rpc_result {
                 match self {
                     Ok(t) => Ok(t),
                     Err(err) => {
-                        let msg = format!("{msg}: {err:?}");
+                        let msg = format!("{msg}: {err}");
                         Err($crate::result::internal_rpc_err(msg))
                     }
                 }


### PR DESCRIPTION
`\{e(rr)?:\?\} -> {e$1}`

Note that `eyre::Error` should still use `Debug` because of our custom handler which only implements `fn debug`.

Example error before (from https://github.com/paradigmxyz/reth/issues/6223):
```
Error: Transaction error on unwind: UnwindStateRootMismatch(RootMismatch { root: GotExpected { got: 0xce829f8b2f326a431f39da6d956a5ccbe9dc205357b6a1c8c5740f106b4299e8, expected: 0x437031ee56f4ec0930af51e2cbc756b2ca65b37623a2459a36d3a3f6d22961bb }, block_number: 18969294, block_hash: 0xfbf349e5325ff06c84250a58271fb29e02c931bc80896b7bf34fcc31c5ee153a })
```