### PR TITLE
chore: remove clippy global ignore-internal-mutability config

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,2 @@
 msrv = "1.75"
-ignore-interior-mutability = ["bytes::Bytes", "reth_primitives::trie::nibbles::Nibbles"]
 too-large-for-stack = 128


### PR DESCRIPTION
Shouldn't be ignored