### PR TITLE
refactor(trie): hashed state

### DIFF
--- a/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
@@ -25,7 +25,7 @@ use reth_provider::{
     StorageReader,
 };
 use reth_tasks::TaskExecutor;
-use reth_trie::{hashed_cursor::HashedPostStateCursorFactory, updates::TrieKey, StateRoot};
+use reth_trie::{updates::TrieKey, StateRoot};
 use std::{
     net::{SocketAddr, SocketAddrV4},
     path::PathBuf,
@@ -181,15 +181,8 @@ impl Command {
         let block_state = executor.take_output_state();
 
         // Unpacked `BundleState::state_root_slow` function
-        let hashed_post_state = block_state.hash_state_slow().sorted();
-        let (account_prefix_set, storage_prefix_set) = hashed_post_state.construct_prefix_sets();
-        let tx = provider.tx_ref();
-        let hashed_cursor_factory = HashedPostStateCursorFactory::new(tx, &hashed_post_state);
-        let (in_memory_state_root, in_memory_updates) = StateRoot::from_tx(tx)
-            .with_hashed_cursor_factory(hashed_cursor_factory)
-            .with_changed_account_prefixes(account_prefix_set)
-            .with_changed_storage_prefixes(storage_prefix_set)
-            .root_with_updates()?;
+        let (in_memory_state_root, in_memory_updates) =
+            block_state.hash_state_slow().state_root_with_updates(provider.tx_ref())?;
 
         if in_memory_state_root == block.state_root {
             info!(target: "reth::cli", state_root = ?in_memory_state_root, "Computed in-memory state root matches");

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -228,7 +228,6 @@ impl<'b, TX: DbTx> StateRootProvider for HistoricalStateProviderRef<'b, TX> {
     fn state_root(&self, state: &BundleStateWithReceipts) -> ProviderResult<B256> {
         let mut revert_state = self.revert_state()?;
         revert_state.extend(state.hash_state_slow());
-        revert_state.sort();
         revert_state.state_root(self.tx).map_err(|err| ProviderError::Database(err.into()))
     }
 
@@ -238,7 +237,6 @@ impl<'b, TX: DbTx> StateRootProvider for HistoricalStateProviderRef<'b, TX> {
     ) -> ProviderResult<(B256, TrieUpdates)> {
         let mut revert_state = self.revert_state()?;
         revert_state.extend(state.hash_state_slow());
-        revert_state.sort();
         revert_state
             .state_root_with_updates(self.tx)
             .map_err(|err| ProviderError::Database(err.into()))

--- a/crates/trie/src/lib.rs
+++ b/crates/trie/src/lib.rs
@@ -34,7 +34,7 @@ pub(crate) mod node_iter;
 
 /// In-memory hashed state.
 mod state;
-pub use state::{HashedPostState, HashedStorage};
+pub use state::*;
 
 /// Merkle proof generation.
 pub mod proof;

--- a/crates/trie/src/state.rs
+++ b/crates/trie/src/state.rs
@@ -295,7 +295,7 @@ impl HashedPostStateSorted {
         &self,
         tx: &'a TX,
     ) -> StateRoot<&'a TX, HashedPostStateCursorFactory<'_, &'a TX>> {
-        let hashed_cursor_factory = HashedPostStateCursorFactory::new(tx, &self);
+        let hashed_cursor_factory = HashedPostStateCursorFactory::new(tx, self);
         StateRoot::from_tx(tx)
             .with_hashed_cursor_factory(hashed_cursor_factory)
             .with_destroyed_accounts(self.destroyed_accounts())

--- a/crates/trie/src/state.rs
+++ b/crates/trie/src/state.rs
@@ -187,11 +187,10 @@ impl HashedPostState {
     ///
     /// // Initialize hashed post state
     /// let mut hashed_state = HashedPostState::default();
-    /// hashed_state.insert_account(
+    /// hashed_state.accounts.insert(
     ///     [0x11; 32].into(),
     ///     Some(Account { nonce: 1, balance: U256::from(10), bytecode_hash: None }),
     /// );
-    /// hashed_state.sort();
     ///
     /// // Calculate the state root
     /// let tx = db.tx().expect("failed to create transaction");


### PR DESCRIPTION
## Description

Refactor in-memory representation of hashed state. Separates primary hashed state representation and its optimized version used for in-memory state root calculation into `HashedPostState` & `HashedPostStateSorted` respectively. This enables more efficient and laconic hashed state aggregation across multiple blocks.