### PR TITLE
add `mainnet_activation_timestamp` for `Hardfork`

### DIFF
--- a/crates/ethereum-forks/src/hardfork.rs
+++ b/crates/ethereum-forks/src/hardfork.rs
@@ -88,6 +88,42 @@ impl Hardfork {
         }
     }
 
+    /// Retrieves the activation timestamp for the specified hardfork on the Ethereum mainnet.
+    pub fn mainnet_activation_timestamp(&self, chain: Chain) -> Option<u64> {
+        if chain != Chain::mainnet() {
+            return None;
+        }
+        match self {
+            Hardfork::Frontier => Some(1438226773),
+            Hardfork::Homestead => Some(1457938193),
+            Hardfork::Dao => Some(1468977640),
+            Hardfork::Tangerine => Some(1476753571),
+            Hardfork::SpuriousDragon => Some(1479788144),
+            Hardfork::Byzantium => Some(1508131331),
+            Hardfork::Constantinople => Some(1551340324),
+            Hardfork::Petersburg => Some(1551340324),
+            Hardfork::Istanbul => Some(1575807909),
+            Hardfork::MuirGlacier => Some(1577953849),
+            Hardfork::Berlin => Some(1618481223),
+            Hardfork::London => Some(1628166822),
+            Hardfork::ArrowGlacier => Some(1639036523),
+            Hardfork::GrayGlacier => Some(1656586444),
+            Hardfork::Paris => Some(1663224162),
+            Hardfork::Shanghai => Some(1681338455),
+
+            // upcoming hardforks
+            Hardfork::Cancun => None,
+
+            // optimism hardforks
+            #[cfg(feature = "optimism")]
+            Hardfork::Bedrock => None,
+            #[cfg(feature = "optimism")]
+            Hardfork::Regolith => None,
+            #[cfg(feature = "optimism")]
+            Hardfork::Canyon => None,
+        }
+    }
+
     /// Checks if the hardfork is post the Ethereum merge.
     pub fn is_post_merge(&self) -> bool {
         self >= &Hardfork::Paris


### PR DESCRIPTION
Add `mainnet_activation_timestamp` method for `Hardfork` related to the following execution layer spec: https://github.com/ethereum/execution-specs/blob/1fed0c0074f9d6aab3861057e1924411948dc50b/src/ethereum_spec_tools/forks.py#L192