### PR TITLE
add `ConsensusType` enum for `Hardfork`

### DIFF
--- a/crates/ethereum-forks/src/hardfork.rs
+++ b/crates/ethereum-forks/src/hardfork.rs
@@ -118,7 +118,7 @@ impl Hardfork {
     pub fn is_proof_of_work(&self) -> bool {
         matches!(self.consensus_type(), ConsensusType::ProofOfWork)
     }
-      
+
     /// Retrieves the activation timestamp for the specified hardfork on the given chain.
     pub fn activation_timestamp(&self, chain: Chain) -> Option<u64> {
         if chain != Chain::mainnet() {


### PR DESCRIPTION
## Add ConsensusType enum for Hardfork

As per Ethereum execution specifications ([ethereum/execution-specs#L31-L49](https://github.com/ethereum/execution-specs/blob/1fed0c0074f9d6aab3861057e1924411948dc50b/src/ethereum_spec_tools/forks.py#L31-L49)), we need to implement a `ConsensusType` enum for our existing `Hardfork` enum. This enum will be used to check the consensus type as a function of the provided hardfork.

### Changes Made
- Added a new `ConsensusType` enum.
- Implemented functions in the `Hardfork` enum to determine the consensus type.
- Remove old `is_post_merge` method which is now replaced by a proper consensus type check, which is equivalent but more explicit and precise.

### Example Usage
```rust
let hardfork = Hardfork::Paris;
let consensus_type = hardfork.consensus_type();

assert_eq!(consensus_type, ConsensusType::ProofOfStake);
