### PR TITLE
Separate `activation_timestamp` and `mainnet_activation_timestamp` methods

### DIFF
--- a/crates/ethereum-forks/src/hardfork.rs
+++ b/crates/ethereum-forks/src/hardfork.rs
@@ -88,11 +88,16 @@ impl Hardfork {
         }
     }
 
-    /// Retrieves the activation timestamp for the specified hardfork on the Ethereum mainnet.
-    pub fn mainnet_activation_timestamp(&self, chain: Chain) -> Option<u64> {
+    /// Retrieves the activation timestamp for the specified hardfork on the given chain.
+    pub fn activation_timestamp(&self, chain: Chain) -> Option<u64> {
         if chain != Chain::mainnet() {
             return None;
         }
+        self.mainnet_activation_timestamp()
+    }
+
+    /// Retrieves the activation timestamp for the specified hardfork on the Ethereum mainnet.
+    pub fn mainnet_activation_timestamp(&self) -> Option<u64> {
         match self {
             Hardfork::Frontier => Some(1438226773),
             Hardfork::Homestead => Some(1457938193),


### PR DESCRIPTION
This PR separatea `activation_timestamp` and `mainnet_activation_timestamp` methods in `Hardfork` enum.

Related https://github.com/paradigmxyz/reth/pull/6257#discussion_r1468854361