### PR TITLE
fix(evm): constantinople hardfork reward adjustment

### DIFF
--- a/crates/consensus/common/src/calc.rs
+++ b/crates/consensus/common/src/calc.rs
@@ -28,7 +28,7 @@ pub fn base_block_reward(
         chain_spec.fork(Hardfork::Paris).active_at_ttd(total_difficulty, block_difficulty)
     {
         None
-    } else if chain_spec.fork(Hardfork::Petersburg).active_at_block(block_number) {
+    } else if chain_spec.fork(Hardfork::Constantinople).active_at_block(block_number) {
         Some(ETH_TO_WEI * 2)
     } else if chain_spec.fork(Hardfork::Byzantium).active_at_block(block_number) {
         Some(ETH_TO_WEI * 3)

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -1221,9 +1221,16 @@ impl ChainSpecBuilder {
         self
     }
 
+    /// Enable Constantinople at genesis.
+    pub fn constantinople_activated(mut self) -> Self {
+        self = self.byzantium_activated();
+        self.hardforks.insert(Hardfork::Constantinople, ForkCondition::Block(0));
+        self
+    }
+
     /// Enable Petersburg at genesis.
     pub fn petersburg_activated(mut self) -> Self {
-        self = self.byzantium_activated();
+        self = self.constantinople_activated();
         self.hardforks.insert(Hardfork::Petersburg, ForkCondition::Block(0));
         self
     }


### PR DESCRIPTION
## Description

Mirror [geth's behavior](https://github.com/ethereum/go-ethereum/blob/82027945b815bee0e04558aa6e92891412dd84a1/consensus/ethash/consensus.go#L579-L581) checking for `Constantinople` for reward adjustment instead of `Petersburg`. Fixes failing p2p hive tests.

Fixes https://github.com/paradigmxyz/reth/issues/6250