### PR TITLE
add unit tests for `is_empty` method for `Account`

### DIFF
--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -43,7 +43,7 @@ pub mod transaction;
 pub mod trie;
 mod withdrawal;
 
-pub use account::{Account, Bytecode};
+pub use account::{Account, Bytecode, EMPTY_ACCOUNT};
 pub use block::{
     Block, BlockBody, BlockHashOrNumber, BlockId, BlockNumHash, BlockNumberOrTag, BlockWithSenders,
     ForkBlock, RpcBlockHash, SealedBlock, SealedBlockWithSenders,

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -43,7 +43,7 @@ pub mod transaction;
 pub mod trie;
 mod withdrawal;
 
-pub use account::{Account, Bytecode, EMPTY_ACCOUNT};
+pub use account::{Account, Bytecode};
 pub use block::{
     Block, BlockBody, BlockHashOrNumber, BlockId, BlockNumHash, BlockNumberOrTag, BlockWithSenders,
     ForkBlock, RpcBlockHash, SealedBlock, SealedBlockWithSenders,

--- a/crates/transaction-pool/src/ordering.rs
+++ b/crates/transaction-pool/src/ordering.rs
@@ -15,10 +15,7 @@ pub enum Priority<T: Ord + Clone> {
 
 impl<T: Ord + Clone> From<Option<T>> for Priority<T> {
     fn from(value: Option<T>) -> Self {
-        match value {
-            Some(val) => Priority::Value(val),
-            None => Priority::None,
-        }
+        value.map_or(Priority::None, Priority::Value)
     }
 }
 


### PR DESCRIPTION
## Description

This pull request introduces improvements inspired by the [Ethereum execution specification](https://github.com/ethereum/execution-specs/blob/1fed0c0074f9d6aab3861057e1924411948dc50b/src/ethereum/shanghai/fork_types.py#L152-L156):

- Introduces a `Lazy` pub static `EMPTY_ACCOUNT`, initialized on first access, which is now utilized in the `is_empty` method for more efficient account emptiness checks.
- Unit tests have been added to validate the correctness and functionality of the enhanced `is_empty` method.

These changes enhance the codebase by optimizing account emptiness checks and providing thorough test coverage.
