### PR TITLE
chore: new max trace response size unlocked

### DIFF
--- a/crates/node-core/src/args/rpc_server_args.rs
+++ b/crates/node-core/src/args/rpc_server_args.rs
@@ -47,12 +47,15 @@ use tracing::{debug, info};
 
 /// Default max number of subscriptions per connection.
 pub(crate) const RPC_DEFAULT_MAX_SUBS_PER_CONN: u32 = 1024;
+
 /// Default max request size in MB.
 pub(crate) const RPC_DEFAULT_MAX_REQUEST_SIZE_MB: u32 = 15;
+
 /// Default max response size in MB.
 ///
 /// This is only relevant for very large trace responses.
-pub(crate) const RPC_DEFAULT_MAX_RESPONSE_SIZE_MB: u32 = 150;
+pub(crate) const RPC_DEFAULT_MAX_RESPONSE_SIZE_MB: u32 = 160;
+
 /// Default number of incoming connections.
 pub(crate) const RPC_DEFAULT_MAX_CONNECTIONS: u32 = 500;
 


### PR DESCRIPTION
closes #6268

bump default response limit so we can server the biggest trace response