### PR TITLE
feat(nippy-jar): use `reth_primitives::fs` to preserve path in errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6366,6 +6366,7 @@ dependencies = [
  "memmap2 0.7.1",
  "ph",
  "rand 0.8.5",
+ "reth-primitives",
  "serde",
  "sucds 0.8.1",
  "tempfile",

--- a/crates/storage/nippy-jar/Cargo.toml
+++ b/crates/storage/nippy-jar/Cargo.toml
@@ -15,6 +15,8 @@ workspace = true
 name = "reth_nippy_jar"
 
 [dependencies]
+# reth
+reth-primitives.workspace = true
 
 # filter
 ph = "0.8.0"

--- a/crates/storage/nippy-jar/src/error.rs
+++ b/crates/storage/nippy-jar/src/error.rs
@@ -7,6 +7,8 @@ pub enum NippyJarError {
     Internal(#[from] Box<dyn std::error::Error + Send + Sync>),
     #[error(transparent)]
     Disconnect(#[from] std::io::Error),
+    #[error(transparent)]
+    FileSystem(#[from] reth_primitives::fs::FsPathError),
     #[error("{0}")]
     Custom(String),
     #[error(transparent)]

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -279,7 +279,7 @@ impl<H: NippyJarHeader> NippyJar<H> {
             [self.data_path().into(), self.index_path(), self.offsets_path(), self.config_path()]
         {
             if path.exists() {
-                std::fs::remove_file(path)?;
+                reth_primitives::fs::remove_file(path)?;
             }
         }
 


### PR DESCRIPTION
As per PR title