### PR TITLE
fix: only adjust ipc path if multiple instances are run

### DIFF
--- a/crates/node-core/src/args/rpc_server_args.rs
+++ b/crates/node-core/src/args/rpc_server_args.rs
@@ -219,9 +219,10 @@ impl RpcServerArgs {
         // ws port is scaled by a factor of instance * 2
         self.ws_port += instance * 2 - 2;
 
-        // also adjust the ipc path by appending the instance number to the path used for the
-        // endpoint
-        self.ipcpath = format!("{}-{}", self.ipcpath, instance);
+        // if multiple instances are being run, append the instance number to the ipc path
+        if instance > 1 {
+            self.ipcpath = format!("{}-{}", self.ipcpath, instance);
+        }
     }
 
     /// Set the http port to zero, to allow the OS to assign a random unused port when the rpc


### PR DESCRIPTION
first instance should stay on the default/configured ipc path