### PR TITLE
feat(ci): `RUST_BACKTRACE=1` for all tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,6 +21,8 @@ jobs:
     name: test / ${{ matrix.network }} (${{ matrix.partition }}/2)
     runs-on:
       group: Reth
+    env:
+      RUST_BACKTRACE: 1
     strategy:
       matrix:
         partition: [1, 2]
@@ -51,6 +53,7 @@ jobs:
       group: Reth
     env:
       RUST_LOG: info,sync=error
+      RUST_BACKTRACE: 1
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -21,6 +21,8 @@ jobs:
     name: test / ${{ matrix.network }} (${{ matrix.partition }}/2)
     runs-on:
       group: Reth
+    env:
+      RUST_BACKTRACE: 1
     strategy:
       matrix:
         partition: [1, 2]
@@ -47,6 +49,7 @@ jobs:
       group: Reth
     env:
       RUST_LOG: info,sync=error
+      RUST_BACKTRACE: 1
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -68,6 +71,8 @@ jobs:
     name: doc tests (${{ matrix.network }})
     runs-on:
       group: Reth
+    env:
+      RUST_BACKTRACE: 1
     timeout-minutes: 30
     strategy:
       matrix:


### PR DESCRIPTION
It will make flaky tests easier to debug:
```console
--- TRY 2 STDERR:        reth-node-core node_config::tests::optimism_post_canyon_withdrawals_valid ---
thread 'tokio-runtime-worker' panicked at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bytes-1.5.0/src/buf/buf_impl.rs:289:9:
assertion failed: self.remaining() >= 1
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
2024-01-30T10:58:03.134574Z ERROR reth_tasks: Critical task `consensus engine` panicked: `assertion failed: self.remaining() >= 1`
thread 'node_config::tests::optimism_post_canyon_withdrawals_valid' panicked at crates/node-core/src/node_config.rs:1786:13:
post-canyon engine call with withdrawals should succeed: Call(ErrorObject { code: InternalError, message: "Server error", data: Some(RawValue({"err":"beacon consensus engine task stopped"})) })
```