### PR TITLE
fix: pool eviction bug

### DIFF
--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -53,7 +53,7 @@ impl Default for PoolConfig {
 }
 
 /// Size limits for a sub-pool.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SubPoolLimit {
     /// Maximum amount of transaction in the pool.
     pub max_txs: usize,
@@ -62,6 +62,11 @@ pub struct SubPoolLimit {
 }
 
 impl SubPoolLimit {
+    /// Creates a new instance with the given limits.
+    pub const fn new(max_txs: usize, max_size: usize) -> Self {
+        Self { max_txs, max_size }
+    }
+
     /// Returns whether the size or amount constraint is violated.
     #[inline]
     pub fn is_exceeded(&self, txs: usize, size: usize) -> bool {


### PR DESCRIPTION
This is likely related to #6282

The previous eviction loop only removed the descendants from the entire pool but not from the total set, see docs on `remove_descendants`

This adds the missing eviction calls from the total set and adds a test.

this could use a few more tests though @Rjected 