### PR TITLE
fix: manual trigger for hive in addition to cron schedule [RET-241]

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -3,6 +3,7 @@
 name: hive
 
 on:
+  workflow_dispatch:
   schedule:
     # every day
     - cron: "0 0 * * *"


### PR DESCRIPTION
The purpose of this PR is just to add the ability for folks to manually trigger a run on the `hive.yml` workflow so that developers can verify their testing changes outside of the standard once a day schedule. 