### PR TITLE
fix: use matching image tag as upstream hive in hive action

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -28,7 +28,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          tags: paradigmxyz/reth:main
+          tags: ghcr.io/paradigmxyz/reth:latest
           build-args: BUILD_PROFILE=hivetests
           outputs: type=docker,dest=./artifacts/reth_image.tar
           cache-from: type=gha


### PR DESCRIPTION
The current upstream hive uses `ghcr.io/paradigmxyz/reth:latest`, see: https://github.com/ethereum/hive/pull/971

Instead of pushing to `paradigmxyz/reth:main`, this pushes to a tag with the same name as upstream hive.

This confirmed works and now hive runs with the proper commit, see https://github.com/paradigmxyz/reth/actions/runs/7714568023/job/21028054959

Reth emits:
```
2024-01-30T17:13:44.120311Z  INFO reth::cli: reth 0.1.0-alpha.16 (3400493) starting
```
3400493 is a commit from this branch, not the published image