### PR TITLE
feat(bin): delete snapshot jars in `db clear`

### DIFF
--- a/bin/reth/src/commands/db/clear.rs
+++ b/bin/reth/src/commands/db/clear.rs
@@ -20,7 +20,7 @@ impl Command {
     /// Execute `db clear` command
     pub fn execute<DB: Database>(self, provider_factory: ProviderFactory<DB>) -> eyre::Result<()> {
         match self.subcommand {
-            Subcommands::MDBX { table } => {
+            Subcommands::Mdbx { table } => {
                 table.view(&ClearViewer { db: provider_factory.db_ref() })?
             }
             Subcommands::Snapshot { segment } => {
@@ -44,7 +44,7 @@ impl Command {
 
 #[derive(Subcommand, Debug)]
 enum Subcommands {
-    MDBX { table: Tables },
+    Mdbx { table: Tables },
     Snapshot { segment: SnapshotSegment },
 }
 

--- a/bin/reth/src/commands/db/clear.rs
+++ b/bin/reth/src/commands/db/clear.rs
@@ -1,25 +1,51 @@
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use reth_db::{
     database::Database,
+    snapshot::iter_snapshots,
     table::Table,
     transaction::{DbTx, DbTxMut},
     TableViewer, Tables,
 };
+use reth_primitives::{snapshot::find_fixed_range, SnapshotSegment};
+use reth_provider::ProviderFactory;
 
 /// The arguments for the `reth db clear` command
 #[derive(Parser, Debug)]
 pub struct Command {
-    /// Table name
-    pub table: Tables,
+    #[clap(subcommand)]
+    subcommand: Subcommands,
 }
 
 impl Command {
     /// Execute `db clear` command
-    pub fn execute<DB: Database>(self, db: &DB) -> eyre::Result<()> {
-        self.table.view(&ClearViewer { db })?;
+    pub fn execute<DB: Database>(self, provider_factory: ProviderFactory<DB>) -> eyre::Result<()> {
+        match self.subcommand {
+            Subcommands::MDBX { table } => {
+                table.view(&ClearViewer { db: provider_factory.db_ref() })?
+            }
+            Subcommands::Snapshot { segment } => {
+                let snapshot_provider = provider_factory
+                    .snapshot_provider()
+                    .expect("snapshot provider initialized via provider factory");
+                let snapshots = iter_snapshots(snapshot_provider.directory())?;
+
+                if let Some(segment_snapshots) = snapshots.get(&segment) {
+                    for (block_range, _) in segment_snapshots {
+                        snapshot_provider
+                            .delete_jar(segment, find_fixed_range(*block_range.start()))?;
+                    }
+                }
+            }
+        }
 
         Ok(())
     }
+}
+
+#[derive(Subcommand, Debug)]
+enum Subcommands {
+    MDBX { table: Tables },
+    Snapshot { segment: SnapshotSegment },
 }
 
 struct ClearViewer<'a, DB: Database> {

--- a/bin/reth/src/commands/db/diff.rs
+++ b/bin/reth/src/commands/db/diff.rs
@@ -58,7 +58,7 @@ impl Command {
     ///
     /// The discrepancies and extra elements, along with a brief summary of the diff results are
     /// then written to a file in the output directory.
-    pub fn execute(self, tool: &DbTool<'_, DatabaseEnv>) -> eyre::Result<()> {
+    pub fn execute(self, tool: &DbTool<DatabaseEnv>) -> eyre::Result<()> {
         // open second db
         let second_db_path: PathBuf = self.secondary_datadir.join("db").into();
         let second_db = open_db_read_only(
@@ -72,7 +72,7 @@ impl Command {
         };
 
         for table in tables {
-            let primary_tx = tool.db.tx()?;
+            let primary_tx = tool.provider_factory.db_ref().tx()?;
             let secondary_tx = second_db.tx()?;
 
             let output_dir = self.output.clone();

--- a/bin/reth/src/commands/db/get.rs
+++ b/bin/reth/src/commands/db/get.rs
@@ -30,7 +30,7 @@ pub struct Command {
 
 impl Command {
     /// Execute `db get` command
-    pub fn execute<DB: Database>(self, tool: &DbTool<'_, DB>) -> eyre::Result<()> {
+    pub fn execute<DB: Database>(self, tool: &DbTool<DB>) -> eyre::Result<()> {
         self.table.view(&GetValueViewer { tool, args: &self })?;
 
         Ok(())
@@ -52,7 +52,7 @@ impl Command {
 }
 
 struct GetValueViewer<'a, DB: Database> {
-    tool: &'a DbTool<'a, DB>,
+    tool: &'a DbTool<DB>,
     args: &'a Command,
 }
 

--- a/bin/reth/src/commands/db/list.rs
+++ b/bin/reth/src/commands/db/list.rs
@@ -50,7 +50,7 @@ pub struct Command {
 
 impl Command {
     /// Execute `db list` command
-    pub fn execute(self, tool: &DbTool<'_, DatabaseEnv>) -> eyre::Result<()> {
+    pub fn execute(self, tool: &DbTool<DatabaseEnv>) -> eyre::Result<()> {
         self.table.view(&ListTableViewer { tool, args: &self })
     }
 
@@ -81,7 +81,7 @@ impl Command {
 }
 
 struct ListTableViewer<'a> {
-    tool: &'a DbTool<'a, DatabaseEnv>,
+    tool: &'a DbTool<DatabaseEnv>,
     args: &'a Command,
 }
 
@@ -89,7 +89,7 @@ impl TableViewer<()> for ListTableViewer<'_> {
     type Error = eyre::Report;
 
     fn view<T: Table>(&self) -> Result<(), Self::Error> {
-        self.tool.db.view(|tx| {
+        self.tool.provider_factory.db_ref().view(|tx| {
             let table_db = tx.inner.open_db(Some(self.args.table.name())).wrap_err("Could not open db.")?;
             let stats = tx.inner.db_stat(&table_db).wrap_err(format!("Could not find table: {}", stringify!($table)))?;
             let total_entries = stats.entries();

--- a/bin/reth/src/commands/db/mod.rs
+++ b/bin/reth/src/commands/db/mod.rs
@@ -249,7 +249,9 @@ impl Command {
             Subcommands::Clear(command) => {
                 let db =
                     open_db(&db_path, DatabaseArguments::default().log_level(self.db.log_level))?;
-                command.execute(&db)?;
+                let provider_factory = ProviderFactory::new(db, self.chain.clone())
+                    .with_snapshots(data_dir.snapshots_path())?;
+                command.execute(provider_factory)?;
             }
             Subcommands::Snapshot(command) => {
                 command.execute(&db_path, self.db.log_level, self.chain.clone())?;

--- a/bin/reth/src/commands/db/mod.rs
+++ b/bin/reth/src/commands/db/mod.rs
@@ -21,6 +21,7 @@ use reth_db::{
     Tables,
 };
 use reth_primitives::ChainSpec;
+use reth_provider::ProviderFactory;
 use std::{
     io::{self, Write},
     sync::Arc,
@@ -108,7 +109,9 @@ impl Command {
                     &db_path,
                     DatabaseArguments::default().log_level(self.db.log_level),
                 )?;
-                let tool = DbTool::new(&db, self.chain.clone())?;
+                let provider_factory = ProviderFactory::new(db, self.chain.clone())
+                    .with_snapshots(data_dir.snapshots_path())?;
+                let tool = DbTool::new(provider_factory, self.chain.clone())?;
                 let mut stats_table = ComfyTable::new();
                 stats_table.load_preset(comfy_table::presets::ASCII_MARKDOWN);
                 stats_table.set_header([
@@ -120,7 +123,7 @@ impl Command {
                     "Total Size",
                 ]);
 
-                tool.db.view(|tx| {
+                tool.provider_factory.db_ref().view(|tx| {
                     let mut tables =
                         Tables::ALL.iter().map(|table| table.name()).collect::<Vec<_>>();
                     tables.sort();
@@ -195,7 +198,9 @@ impl Command {
                     &db_path,
                     DatabaseArguments::default().log_level(self.db.log_level),
                 )?;
-                let tool = DbTool::new(&db, self.chain.clone())?;
+                let provider_factory = ProviderFactory::new(db, self.chain.clone())
+                    .with_snapshots(data_dir.snapshots_path())?;
+                let tool = DbTool::new(provider_factory, self.chain.clone())?;
                 command.execute(&tool)?;
             }
             Subcommands::Diff(command) => {
@@ -203,7 +208,9 @@ impl Command {
                     &db_path,
                     DatabaseArguments::default().log_level(self.db.log_level),
                 )?;
-                let tool = DbTool::new(&db, self.chain.clone())?;
+                let provider_factory = ProviderFactory::new(db, self.chain.clone())
+                    .with_snapshots(data_dir.snapshots_path())?;
+                let tool = DbTool::new(provider_factory, self.chain.clone())?;
                 command.execute(&tool)?;
             }
             Subcommands::Get(command) => {
@@ -211,7 +218,9 @@ impl Command {
                     &db_path,
                     DatabaseArguments::default().log_level(self.db.log_level),
                 )?;
-                let tool = DbTool::new(&db, self.chain.clone())?;
+                let provider_factory = ProviderFactory::new(db, self.chain.clone())
+                    .with_snapshots(data_dir.snapshots_path())?;
+                let tool = DbTool::new(provider_factory, self.chain.clone())?;
                 command.execute(&tool)?;
             }
             Subcommands::Drop { force } => {
@@ -232,7 +241,9 @@ impl Command {
 
                 let db =
                     open_db(&db_path, DatabaseArguments::default().log_level(self.db.log_level))?;
-                let mut tool = DbTool::new(&db, self.chain.clone())?;
+                let provider_factory = ProviderFactory::new(db, self.chain.clone())
+                    .with_snapshots(data_dir.snapshots_path())?;
+                let mut tool = DbTool::new(provider_factory, self.chain.clone())?;
                 tool.drop(db_path)?;
             }
             Subcommands::Clear(command) => {

--- a/bin/reth/src/commands/stage/drop.rs
+++ b/bin/reth/src/commands/stage/drop.rs
@@ -188,12 +188,16 @@ impl Command {
         };
 
         if let Some(snapshot_segment) = snapshot_segment {
-            let snapshot_provider = tool.provider_factory.snapshot_provider().unwrap();
+            let snapshot_provider = tool
+                .provider_factory
+                .snapshot_provider()
+                .expect("snapshot provider initialized via provider factory");
             let snapshots = iter_snapshots(data_dir.snapshots_path())?;
-            let segment_snapshots = snapshots.get(&snapshot_segment).unwrap();
-            for (block_range, _) in segment_snapshots {
-                snapshot_provider
-                    .delete_jar(snapshot_segment, find_fixed_range(*block_range.start()))?;
+            if let Some(segment_snapshots) = snapshots.get(&snapshot_segment) {
+                for (block_range, _) in segment_snapshots {
+                    snapshot_provider
+                        .delete_jar(snapshot_segment, find_fixed_range(*block_range.start()))?;
+                }
             }
         }
 

--- a/bin/reth/src/commands/stage/drop.rs
+++ b/bin/reth/src/commands/stage/drop.rs
@@ -192,7 +192,7 @@ impl Command {
                 .provider_factory
                 .snapshot_provider()
                 .expect("snapshot provider initialized via provider factory");
-            let snapshots = iter_snapshots(data_dir.snapshots_path())?;
+            let snapshots = iter_snapshots(snapshot_provider.directory())?;
             if let Some(segment_snapshots) = snapshots.get(&snapshot_segment) {
                 for (block_range, _) in segment_snapshots {
                     snapshot_provider

--- a/bin/reth/src/commands/stage/dump/hashing_storage.rs
+++ b/bin/reth/src/commands/stage/dump/hashing_storage.rs
@@ -9,7 +9,7 @@ use std::{path::PathBuf, sync::Arc};
 use tracing::info;
 
 pub(crate) async fn dump_hashing_storage_stage<DB: Database>(
-    db_tool: &DbTool<'_, DB>,
+    db_tool: &DbTool<DB>,
     from: u64,
     to: u64,
     output_db: &PathBuf,
@@ -28,12 +28,12 @@ pub(crate) async fn dump_hashing_storage_stage<DB: Database>(
 
 /// Dry-run an unwind to FROM block and copy the necessary table data to the new database.
 fn unwind_and_copy<DB: Database>(
-    db_tool: &DbTool<'_, DB>,
+    db_tool: &DbTool<DB>,
     from: u64,
     tip_block_number: u64,
     output_db: &DatabaseEnv,
 ) -> eyre::Result<()> {
-    let factory = ProviderFactory::new(db_tool.db, db_tool.chain.clone());
+    let factory = ProviderFactory::new(db_tool.provider_factory.db_ref(), db_tool.chain.clone());
     let provider = factory.provider_rw()?;
 
     let mut exec_stage = StorageHashingStage::default();

--- a/bin/reth/src/utils.rs
+++ b/bin/reth/src/utils.rs
@@ -10,6 +10,7 @@ use reth_db::{
     DatabaseError, RawTable, TableRawRow,
 };
 use reth_primitives::{fs, ChainSpec};
+use reth_provider::ProviderFactory;
 use std::{path::Path, rc::Rc, sync::Arc};
 use tracing::info;
 
@@ -24,17 +25,17 @@ pub use reth_node_core::utils::*;
 
 /// Wrapper over DB that implements many useful DB queries.
 #[derive(Debug)]
-pub struct DbTool<'a, DB: Database> {
-    /// The database that the db tool will use.
-    pub db: &'a DB,
+pub struct DbTool<DB: Database> {
+    /// The provider factory that the db tool will use.
+    pub provider_factory: ProviderFactory<DB>,
     /// The [ChainSpec] that the db tool will use.
     pub chain: Arc<ChainSpec>,
 }
 
-impl<'a, DB: Database> DbTool<'a, DB> {
+impl<DB: Database> DbTool<DB> {
     /// Takes a DB where the tables have already been created.
-    pub fn new(db: &'a DB, chain: Arc<ChainSpec>) -> eyre::Result<Self> {
-        Ok(Self { db, chain })
+    pub fn new(provider_factory: ProviderFactory<DB>, chain: Arc<ChainSpec>) -> eyre::Result<Self> {
+        Ok(Self { provider_factory, chain })
     }
 
     /// Grabs the contents of the table within a certain index range and places the
@@ -50,7 +51,7 @@ impl<'a, DB: Database> DbTool<'a, DB> {
 
         let mut hits = 0;
 
-        let data = self.db.view(|tx| {
+        let data = self.provider_factory.db_ref().view(|tx| {
             let mut cursor =
                 tx.cursor_read::<RawTable<T>>().expect("Was not able to obtain a cursor.");
 
@@ -118,12 +119,13 @@ impl<'a, DB: Database> DbTool<'a, DB> {
 
     /// Grabs the content of the table for the given key
     pub fn get<T: Table>(&self, key: T::Key) -> Result<Option<T::Value>> {
-        self.db.view(|tx| tx.get::<T>(key))?.map_err(|e| eyre::eyre!(e))
+        self.provider_factory.db_ref().view(|tx| tx.get::<T>(key))?.map_err(|e| eyre::eyre!(e))
     }
 
     /// Grabs the content of the DupSort table for the given key and subkey
     pub fn get_dup<T: DupSort>(&self, key: T::Key, subkey: T::SubKey) -> Result<Option<T::Value>> {
-        self.db
+        self.provider_factory
+            .db_ref()
             .view(|tx| tx.cursor_dup_read::<T>()?.seek_by_key_subkey(key, subkey))?
             .map_err(|e| eyre::eyre!(e))
     }
@@ -138,7 +140,7 @@ impl<'a, DB: Database> DbTool<'a, DB> {
 
     /// Drops the provided table from the database.
     pub fn drop_table<T: Table>(&mut self) -> Result<()> {
-        self.db.update(|tx| tx.clear::<T>())??;
+        self.provider_factory.db_ref().update(|tx| tx.clear::<T>())??;
         Ok(())
     }
 }


### PR DESCRIPTION
This PR makes `reth db clear` delete static files for the associated segments: https://github.com/paradigmxyz/reth/blob/d056c9fec8440858479a76853291cef6e232741a/bin/reth/src/commands/db/clear.rs#L26-L39

We now have two subcommands for `reth db clear`:
- `reth db clear mdbx <TABLE>`
- `reth db clear snapshot <SEGMENT>`.