### PR TITLE
fix(primitives): don't double-hex signature bytes in `Signature#to_hex_bytes`

### DIFF
--- a/crates/primitives/src/transaction/signature.rs
+++ b/crates/primitives/src/transaction/signature.rs
@@ -181,7 +181,7 @@ impl Signature {
 
     /// Turn this signature into its hex-encoded representation.
     pub fn to_hex_bytes(&self) -> Bytes {
-        crate::hex::encode(self.to_bytes()).into()
+        self.to_bytes().into()
     }
 
     /// Calculates a heuristic for the in-memory size of the [Signature].
@@ -194,7 +194,7 @@ impl Signature {
 #[cfg(test)]
 mod tests {
     use crate::{transaction::signature::SECP256K1N_HALF, Address, Signature, B256, U256};
-    use alloy_primitives::hex;
+    use alloy_primitives::{hex, hex::FromHex, Bytes};
     use bytes::BytesMut;
     use std::str::FromStr;
 
@@ -313,6 +313,24 @@ mod tests {
         };
 
         assert!(signature.size() >= 65);
+    }
+
+    #[test]
+    fn test_to_hex_bytes() {
+        let signature = Signature {
+            r: U256::from_str(
+                "18515461264373351373200002665853028612451056578545711640558177340181847433846",
+            )
+            .unwrap(),
+            s: U256::from_str(
+                "46948507304638947509940763649030358759909902576025900602547168820602576006531",
+            )
+            .unwrap(),
+            odd_y_parity: false,
+        };
+
+        let expected = Bytes::from_hex("0x28ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa63627667cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d831b").unwrap();
+        assert_eq!(signature.to_hex_bytes(), expected);
     }
 
     #[test]


### PR DESCRIPTION
Signature bytes were first hashed into hex bytes, and then wrapped into `Bytes`, which hex-ed the bytes again when converting to string (e.g. `Debug`/`Display`). This would probably also lead to incorrect result being returned via `eth_sign` RPC call since it would return a hex of hex bytes.