### PR TITLE
Fix bug, rebuffer hashes that were received over broadcast

### DIFF
--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -240,18 +240,18 @@ impl TransactionFetcher {
         surplus_hashes
     }
 
-    pub(super) fn buffer_hashes_for_retry(&mut self, hashes: Vec<TxHash>) {
+    pub(super) fn buffer_hashes_for_retry(&mut self, mut hashes: Vec<TxHash>) {
+        // It could be that the txns have been received over broadcast in the time being.
+        hashes.retain(|hash| self.unknown_hashes.get(hash).is_some());
+
         self.buffer_hashes(hashes, None)
     }
 
     /// Buffers hashes. Note: Only peers that haven't yet tried to request the hashes should be
     /// passed as `fallback_peer` parameter! Hashes that have been re-requested
     /// [`MAX_REQUEST_RETRIES_PER_TX_HASH`], are dropped.
-    pub(super) fn buffer_hashes(&mut self, mut hashes: Vec<TxHash>, fallback_peer: Option<PeerId>) {
+    pub(super) fn buffer_hashes(&mut self, hashes: Vec<TxHash>, fallback_peer: Option<PeerId>) {
         let mut max_retried_and_evicted_hashes = vec![];
-
-        // It could be that the txns have been received over broadcast in the time being.
-        hashes.retain(|hash| self.unknown_hashes.peek(hash).is_some());
 
         for hash in hashes {
             let Some((retries, peers)) = self.unknown_hashes.get(&hash) else { return };

--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -254,6 +254,14 @@ impl TransactionFetcher {
         let mut max_retried_and_evicted_hashes = vec![];
 
         for hash in hashes {
+            // todo: enforce by adding new types UnknownTxHash66 and UnknownTxHash68
+            debug_assert!(
+                self.unknown_hashes.peek(&hash).is_some(),
+                "`%hash` in `@buffered_hashes` that's not in `@unknown_hashes`, `@buffered_hashes` should be a subset of keys in `@unknown_hashes`, broken invariant `@buffered_hashes` and `@unknown_hashes`,
+`%hash`: {hash},
+`@self`: {self:?}",
+            );
+
             let Some((retries, peers)) = self.unknown_hashes.get(&hash) else { return };
 
             if let Some(peer_id) = fallback_peer {

--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -241,7 +241,7 @@ impl TransactionFetcher {
     }
 
     pub(super) fn buffer_hashes_for_retry(&mut self, mut hashes: Vec<TxHash>) {
-        // Igt could be that the txns have been received over broadcast in the time being.
+        // It could be that the txns have been received over broadcast in the time being.
         hashes.retain(|hash| self.unknown_hashes.peek(hash).is_some());
         self.buffer_hashes(hashes, None)
     }


### PR DESCRIPTION
closes https://github.com/paradigmxyz/reth/issues/6315 and https://github.com/paradigmxyz/reth/issues/6369 which panicked in debug mode thanks to `debug_assert`.

during the time a tx hash was in an inflight request, the tx could have been seen over gossip. this pr now accounts for the possibility of that occurring. it makes sure that hashes that weren't successfully fetched, aren't buffered for re-fetch. it also makes sure that when some txns are seen over gossip, they are also deleted from the re-fetch buffer.