### PR TITLE
fix: ensure backwards compat config

### DIFF
--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -381,7 +381,6 @@ timeout = -4096
 bad_protocol = -2147483648
 failed_to_connect = -25600
 dropped = -4096
-bad_announcement = -1204
 
 [peers.backoff_durations]
 low = '30s'

--- a/crates/net/network/src/peers/reputation.rs
+++ b/crates/net/network/src/peers/reputation.rs
@@ -46,6 +46,7 @@ pub(crate) fn is_banned_reputation(reputation: i32) -> bool {
 /// How the [`ReputationChangeKind`] are weighted.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 pub struct ReputationChangeWeights {
     /// Weight for [`ReputationChangeKind::BadMessage`]
     pub bad_message: Reputation,


### PR DESCRIPTION
overlooked updated `test_backwards_compatibility` in #6222 which defeated its purpose