### PR TITLE
fix: use ecrevored transaction for tracing

### DIFF
--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -213,7 +213,7 @@ where
         // block the transaction is included in
         let state_at: BlockId = block.parent_hash.into();
         let block_hash = block.hash;
-        let block_txs = block.body;
+        let block_txs = block.into_transactions_ecrecovered();
 
         let this = self.clone();
         self.inner


### PR DESCRIPTION
we already have the block with senders in the cache, might as well use them when replaying state.

This fixes a bug where pre EIP-2 transactions in the block failed recovery