### PR TITLE
feat: add all transaction types to MockTransactionDistribution

### DIFF
--- a/crates/transaction-pool/src/test_utils/pool.rs
+++ b/crates/transaction-pool/src/test_utils/pool.rs
@@ -214,7 +214,7 @@ fn test_on_chain_nonce_scenario() {
         num_senders: 10,
         scenarios: vec![ScenarioType::OnchainNonce],
         base_fee: 10,
-        tx_generator: MockTransactionDistribution::new(30, 10..100),
+        tx_generator: MockTransactionDistribution::new(30, 10..100, 10..100, 100..110, 1..100),
     };
     let mut simulator = MockTransactionSimulator::new(rand::thread_rng(), config);
     let mut pool = MockPool::default();

--- a/crates/transaction-pool/src/test_utils/pool.rs
+++ b/crates/transaction-pool/src/test_utils/pool.rs
@@ -208,16 +208,29 @@ pub(crate) struct ExecutedScenarios {
     scenarios: Vec<ExecutedScenario>,
 }
 
-#[test]
-fn test_on_chain_nonce_scenario() {
-    let config = MockSimulatorConfig {
-        num_senders: 10,
-        scenarios: vec![ScenarioType::OnchainNonce],
-        base_fee: 10,
-        tx_generator: MockTransactionDistribution::new(30, 10..100, 10..100, 100..110, 1..100),
-    };
-    let mut simulator = MockTransactionSimulator::new(rand::thread_rng(), config);
-    let mut pool = MockPool::default();
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::MockTransactionRatio;
 
-    simulator.next(&mut pool);
+    #[test]
+    fn test_on_chain_nonce_scenario() {
+        let transaction_ratio = MockTransactionRatio::new(30, 70, 0, 0);
+        let config = MockSimulatorConfig {
+            num_senders: 10,
+            scenarios: vec![ScenarioType::OnchainNonce],
+            base_fee: 10,
+            tx_generator: MockTransactionDistribution::new(
+                transaction_ratio,
+                10..100,
+                10..100,
+                100..110,
+                1..100,
+            ),
+        };
+        let mut simulator = MockTransactionSimulator::new(rand::thread_rng(), config);
+        let mut pool = MockPool::default();
+
+        simulator.next(&mut pool);
+    }
 }


### PR DESCRIPTION
This makes it possible to generate random mock transactions of more than just legacy and 1559 txs. `MockTransactionRatio` is added, which lets the user configure how many of each transaction type they want.