### PR TITLE
feat(db): propagate text error messages from mdbx

### DIFF
--- a/crates/interfaces/src/db.rs
+++ b/crates/interfaces/src/db.rs
@@ -56,6 +56,16 @@ pub struct DatabaseErrorInfo {
     pub code: i32,
 }
 
+impl<E> From<E> for DatabaseErrorInfo
+where
+    E: Display + Into<i32>,
+{
+    #[inline]
+    fn from(value: E) -> Self {
+        Self { message: value.to_string(), code: value.into() }
+    }
+}
+
 impl<E> From<E> for Box<DatabaseErrorInfo>
 where
     E: Display + Into<i32>,
@@ -69,12 +79,12 @@ where
 /// Database write error.
 #[derive(Clone, Debug, PartialEq, Eq, Error)]
 #[error(
-    "write operation {operation:?} failed for key \"{key}\" in table {table_name:?} ({code})",
+    "write operation {operation:?} failed for key \"{key}\" in table {table_name:?}: {info}",
     key = reth_primitives::hex::encode(key),
 )]
 pub struct DatabaseWriteError {
-    /// The error code.
-    pub code: i32,
+    /// The error code and message.
+    pub info: DatabaseErrorInfo,
     /// The write operation type.
     pub operation: DatabaseWriteOperation,
     /// The table name.

--- a/crates/interfaces/src/db.rs
+++ b/crates/interfaces/src/db.rs
@@ -6,44 +6,37 @@ use thiserror::Error;
 pub enum DatabaseError {
     /// Failed to open the database.
     #[error("failed to open the database: {0}")]
-    Open(Box<DatabaseErrorInfo>),
+    Open(DatabaseErrorInfo),
     /// Failed to create a table in the database.
     #[error("failed to create a table: {0}")]
-    CreateTable(Box<DatabaseErrorInfo>),
+    CreateTable(DatabaseErrorInfo),
     /// Failed to write a value into a table.
     #[error(transparent)]
-    Write(#[from] Box<DatabaseWriteError>),
+    Write(#[from] DatabaseWriteError),
     /// Failed to read a value from a table.
     #[error("failed to read a value from a database table: {0}")]
-    Read(Box<DatabaseErrorInfo>),
+    Read(DatabaseErrorInfo),
     /// Failed to delete a `(key, value)` pair from a table.
     #[error("database delete error code: {0}")]
-    Delete(Box<DatabaseErrorInfo>),
+    Delete(DatabaseErrorInfo),
     /// Failed to commit transaction changes into the database.
     #[error("failed to commit transaction changes: {0}")]
-    Commit(Box<DatabaseErrorInfo>),
+    Commit(DatabaseErrorInfo),
     /// Failed to initiate a transaction.
     #[error("failed to initialize a transaction: {0}")]
-    InitTx(Box<DatabaseErrorInfo>),
+    InitTx(DatabaseErrorInfo),
     /// Failed to initialize a cursor.
     #[error("failed to initialize a cursor: {0}")]
-    InitCursor(Box<DatabaseErrorInfo>),
+    InitCursor(DatabaseErrorInfo),
     /// Failed to decode a key from a table.
     #[error("failed to decode a key from a table")]
     Decode,
     /// Failed to get database stats.
     #[error("failed to get stats: {0}")]
-    Stats(Box<DatabaseErrorInfo>),
+    Stats(DatabaseErrorInfo),
     /// Failed to use the specified log level, as it's not available.
     #[error("log level {0:?} is not available")]
     LogLevelUnavailable(LogLevel),
-}
-
-impl From<DatabaseWriteError> for DatabaseError {
-    #[inline]
-    fn from(value: DatabaseWriteError) -> Self {
-        Self::Write(Box::new(value))
-    }
 }
 
 /// Common error struct to propagate implementation-specific error information.
@@ -63,16 +56,6 @@ where
     #[inline]
     fn from(value: E) -> Self {
         Self { message: value.to_string(), code: value.into() }
-    }
-}
-
-impl<E> From<E> for Box<DatabaseErrorInfo>
-where
-    E: Display + Into<i32>,
-{
-    #[inline]
-    fn from(value: E) -> Self {
-        Box::new(DatabaseErrorInfo { message: value.to_string(), code: value.into() })
     }
 }
 

--- a/crates/interfaces/src/db.rs
+++ b/crates/interfaces/src/db.rs
@@ -6,34 +6,34 @@ use thiserror::Error;
 pub enum DatabaseError {
     /// Failed to open the database.
     #[error("failed to open the database: {0}")]
-    Open(Box<DatabaseCommonError>),
+    Open(Box<DatabaseErrorInfo>),
     /// Failed to create a table in the database.
     #[error("failed to create a table: {0}")]
-    CreateTable(Box<DatabaseCommonError>),
+    CreateTable(Box<DatabaseErrorInfo>),
     /// Failed to write a value into a table.
     #[error(transparent)]
     Write(#[from] Box<DatabaseWriteError>),
     /// Failed to read a value from a table.
     #[error("failed to read a value from a database table: {0}")]
-    Read(Box<DatabaseCommonError>),
+    Read(Box<DatabaseErrorInfo>),
     /// Failed to delete a `(key, value)` pair from a table.
     #[error("database delete error code: {0}")]
-    Delete(Box<DatabaseCommonError>),
+    Delete(Box<DatabaseErrorInfo>),
     /// Failed to commit transaction changes into the database.
     #[error("failed to commit transaction changes: {0}")]
-    Commit(Box<DatabaseCommonError>),
+    Commit(Box<DatabaseErrorInfo>),
     /// Failed to initiate a transaction.
     #[error("failed to initialize a transaction: {0}")]
-    InitTx(Box<DatabaseCommonError>),
+    InitTx(Box<DatabaseErrorInfo>),
     /// Failed to initialize a cursor.
     #[error("failed to initialize a cursor: {0}")]
-    InitCursor(Box<DatabaseCommonError>),
+    InitCursor(Box<DatabaseErrorInfo>),
     /// Failed to decode a key from a table.
     #[error("failed to decode a key from a table")]
     Decode,
     /// Failed to get database stats.
     #[error("failed to get stats: {0}")]
-    Stats(Box<DatabaseCommonError>),
+    Stats(Box<DatabaseErrorInfo>),
     /// Failed to use the specified log level, as it's not available.
     #[error("log level {0:?} is not available")]
     LogLevelUnavailable(LogLevel),
@@ -49,20 +49,20 @@ impl From<DatabaseWriteError> for DatabaseError {
 /// Common error struct to propagate implementation-specific error information.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 #[error("{message} ({code})")]
-pub struct DatabaseCommonError {
+pub struct DatabaseErrorInfo {
     /// Human-readable error message.
     pub message: String,
     /// Error code.
     pub code: i32,
 }
 
-impl<E> From<E> for Box<DatabaseCommonError>
+impl<E> From<E> for Box<DatabaseErrorInfo>
 where
     E: Display + Into<i32>,
 {
     #[inline]
     fn from(value: E) -> Self {
-        Box::new(DatabaseCommonError { message: value.to_string(), code: value.into() })
+        Box::new(DatabaseErrorInfo { message: value.to_string(), code: value.into() })
     }
 }
 

--- a/crates/interfaces/src/db.rs
+++ b/crates/interfaces/src/db.rs
@@ -72,7 +72,7 @@ where
 {
     #[inline]
     fn from(value: E) -> Self {
-        Box::new(DatabaseErrorInfo::from(value))
+        Box::new(DatabaseErrorInfo { message: value.to_string(), code: value.into() })
     }
 }
 

--- a/crates/interfaces/src/db.rs
+++ b/crates/interfaces/src/db.rs
@@ -72,7 +72,7 @@ where
 {
     #[inline]
     fn from(value: E) -> Self {
-        Box::new(DatabaseErrorInfo { message: value.to_string(), code: value.into() })
+        Box::new(DatabaseErrorInfo::from(value))
     }
 }
 

--- a/crates/interfaces/src/db.rs
+++ b/crates/interfaces/src/db.rs
@@ -1,38 +1,39 @@
+use std::fmt::Display;
 use thiserror::Error;
 
 /// Database error type.
 #[derive(Clone, Debug, PartialEq, Eq, Error)]
 pub enum DatabaseError {
     /// Failed to open the database.
-    #[error("failed to open the database ({0})")]
-    Open(i32),
+    #[error("failed to open the database: {0}")]
+    Open(Box<DatabaseCommonError>),
     /// Failed to create a table in the database.
-    #[error("failed to create a table ({0})")]
-    CreateTable(i32),
+    #[error("failed to create a table: {0}")]
+    CreateTable(Box<DatabaseCommonError>),
     /// Failed to write a value into a table.
     #[error(transparent)]
     Write(#[from] Box<DatabaseWriteError>),
     /// Failed to read a value from a table.
-    #[error("failed to read a value from a database table ({0})")]
-    Read(i32),
+    #[error("failed to read a value from a database table: {0}")]
+    Read(Box<DatabaseCommonError>),
     /// Failed to delete a `(key, value)` pair from a table.
-    #[error("database delete error code ({0})")]
-    Delete(i32),
+    #[error("database delete error code: {0}")]
+    Delete(Box<DatabaseCommonError>),
     /// Failed to commit transaction changes into the database.
-    #[error("failed to commit transaction changes ({0})")]
-    Commit(i32),
+    #[error("failed to commit transaction changes: {0}")]
+    Commit(Box<DatabaseCommonError>),
     /// Failed to initiate a transaction.
-    #[error("failed to initialize a transaction ({0})")]
-    InitTx(i32),
+    #[error("failed to initialize a transaction: {0}")]
+    InitTx(Box<DatabaseCommonError>),
     /// Failed to initialize a cursor.
-    #[error("failed to initialize a cursor ({0})")]
-    InitCursor(i32),
+    #[error("failed to initialize a cursor: {0}")]
+    InitCursor(Box<DatabaseCommonError>),
     /// Failed to decode a key from a table.
     #[error("failed to decode a key from a table")]
     Decode,
     /// Failed to get database stats.
-    #[error("failed to get stats ({0})")]
-    Stats(i32),
+    #[error("failed to get stats: {0}")]
+    Stats(Box<DatabaseCommonError>),
     /// Failed to use the specified log level, as it's not available.
     #[error("log level {0:?} is not available")]
     LogLevelUnavailable(LogLevel),
@@ -42,6 +43,26 @@ impl From<DatabaseWriteError> for DatabaseError {
     #[inline]
     fn from(value: DatabaseWriteError) -> Self {
         Self::Write(Box::new(value))
+    }
+}
+
+/// Common error struct to propagate implementation-specific error information.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[error("{message} ({code})")]
+pub struct DatabaseCommonError {
+    /// Human-readable error message.
+    pub message: String,
+    /// Error code.
+    pub code: i32,
+}
+
+impl<E> From<E> for Box<DatabaseCommonError>
+where
+    E: Display + Into<i32>,
+{
+    #[inline]
+    fn from(value: E) -> Self {
+        Box::new(DatabaseCommonError { message: value.to_string(), code: value.into() })
     }
 }
 

--- a/crates/interfaces/src/db.rs
+++ b/crates/interfaces/src/db.rs
@@ -12,7 +12,7 @@ pub enum DatabaseError {
     CreateTable(DatabaseErrorInfo),
     /// Failed to write a value into a table.
     #[error(transparent)]
-    Write(#[from] DatabaseWriteError),
+    Write(#[from] Box<DatabaseWriteError>),
     /// Failed to read a value from a table.
     #[error("failed to read a value from a database table: {0}")]
     Read(DatabaseErrorInfo),
@@ -56,6 +56,13 @@ where
     #[inline]
     fn from(value: E) -> Self {
         Self { message: value.to_string(), code: value.into() }
+    }
+}
+
+impl From<DatabaseWriteError> for DatabaseError {
+    #[inline]
+    fn from(value: DatabaseWriteError) -> Self {
+        Self::Write(Box::new(value))
     }
 }
 

--- a/crates/interfaces/src/error.rs
+++ b/crates/interfaces/src/error.rs
@@ -70,11 +70,11 @@ mod size_asserts {
         };
     }
 
-    static_assert_size!(RethError, 56);
+    static_assert_size!(RethError, 88);
     static_assert_size!(BlockExecutionError, 48);
     static_assert_size!(ConsensusError, 48);
-    static_assert_size!(DatabaseError, 16);
-    static_assert_size!(ProviderError, 48);
+    static_assert_size!(DatabaseError, 80);
+    static_assert_size!(ProviderError, 80);
     static_assert_size!(NetworkError, 0);
     static_assert_size!(CanonicalError, 48);
 }

--- a/crates/interfaces/src/error.rs
+++ b/crates/interfaces/src/error.rs
@@ -70,11 +70,11 @@ mod size_asserts {
         };
     }
 
-    static_assert_size!(RethError, 88);
+    static_assert_size!(RethError, 56);
     static_assert_size!(BlockExecutionError, 48);
     static_assert_size!(ConsensusError, 48);
-    static_assert_size!(DatabaseError, 80);
-    static_assert_size!(ProviderError, 80);
+    static_assert_size!(DatabaseError, 40);
+    static_assert_size!(ProviderError, 48);
     static_assert_size!(NetworkError, 0);
     static_assert_size!(CanonicalError, 48);
 }

--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -58,7 +58,7 @@ impl<K: TransactionKind, T: Table> Cursor<K, T> {
 /// Decodes a `(key, value)` pair from the database.
 #[allow(clippy::type_complexity)]
 pub fn decode<T>(
-    res: Result<Option<(Cow<'_, [u8]>, Cow<'_, [u8]>)>, impl Into<Box<DatabaseErrorInfo>>>,
+    res: Result<Option<(Cow<'_, [u8]>, Cow<'_, [u8]>)>, impl Into<DatabaseErrorInfo>>,
 ) -> PairResult<T>
 where
     T: Table,

--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -58,7 +58,7 @@ impl<K: TransactionKind, T: Table> Cursor<K, T> {
 /// Decodes a `(key, value)` pair from the database.
 #[allow(clippy::type_complexity)]
 pub fn decode<T>(
-    res: Result<Option<(Cow<'_, [u8]>, Cow<'_, [u8]>)>, impl Into<DatabaseErrorInfo>>,
+    res: Result<Option<(Cow<'_, [u8]>, Cow<'_, [u8]>)>, impl Into<Box<DatabaseErrorInfo>>>,
 ) -> PairResult<T>
 where
     T: Table,

--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -247,7 +247,7 @@ impl<T: Table> DbCursorRW<T> for Cursor<RW, T> {
                     .put(key.as_ref(), value.unwrap_or(&this.buf), WriteFlags::UPSERT)
                     .map_err(|e| {
                         DatabaseWriteError {
-                            code: e.into(),
+                            info: e.into(),
                             operation: DatabaseWriteOperation::CursorUpsert,
                             table_name: T::NAME,
                             key: key.into(),
@@ -269,7 +269,7 @@ impl<T: Table> DbCursorRW<T> for Cursor<RW, T> {
                     .put(key.as_ref(), value.unwrap_or(&this.buf), WriteFlags::NO_OVERWRITE)
                     .map_err(|e| {
                         DatabaseWriteError {
-                            code: e.into(),
+                            info: e.into(),
                             operation: DatabaseWriteOperation::CursorInsert,
                             table_name: T::NAME,
                             key: key.into(),
@@ -293,7 +293,7 @@ impl<T: Table> DbCursorRW<T> for Cursor<RW, T> {
                     .put(key.as_ref(), value.unwrap_or(&this.buf), WriteFlags::APPEND)
                     .map_err(|e| {
                         DatabaseWriteError {
-                            code: e.into(),
+                            info: e.into(),
                             operation: DatabaseWriteOperation::CursorAppend,
                             table_name: T::NAME,
                             key: key.into(),
@@ -329,7 +329,7 @@ impl<T: DupSort> DbDupCursorRW<T> for Cursor<RW, T> {
                     .put(key.as_ref(), value.unwrap_or(&this.buf), WriteFlags::APPEND_DUP)
                     .map_err(|e| {
                         DatabaseWriteError {
-                            code: e.into(),
+                            info: e.into(),
                             operation: DatabaseWriteOperation::CursorAppendDup,
                             table_name: T::NAME,
                             key: key.into(),

--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -11,7 +11,7 @@ use crate::{
     tables::utils::*,
     DatabaseError,
 };
-use reth_interfaces::db::{DatabaseCommonError, DatabaseWriteError, DatabaseWriteOperation};
+use reth_interfaces::db::{DatabaseErrorInfo, DatabaseWriteError, DatabaseWriteOperation};
 use reth_libmdbx::{self, Error as MDBXError, TransactionKind, WriteFlags, RO, RW};
 use std::{borrow::Cow, collections::Bound, marker::PhantomData, ops::RangeBounds};
 
@@ -58,7 +58,7 @@ impl<K: TransactionKind, T: Table> Cursor<K, T> {
 /// Decodes a `(key, value)` pair from the database.
 #[allow(clippy::type_complexity)]
 pub fn decode<T>(
-    res: Result<Option<(Cow<'_, [u8]>, Cow<'_, [u8]>)>, impl Into<Box<DatabaseCommonError>>>,
+    res: Result<Option<(Cow<'_, [u8]>, Cow<'_, [u8]>)>, impl Into<Box<DatabaseErrorInfo>>>,
 ) -> PairResult<T>
 where
     T: Table,

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -363,6 +363,7 @@ mod tests {
         AccountChangeSet,
     };
     use reth_interfaces::db::{DatabaseWriteError, DatabaseWriteOperation};
+    use reth_libmdbx::Error;
     use reth_primitives::{Account, Address, Header, IntegerList, StorageEntry, B256, U256};
     use std::{path::Path, str::FromStr, sync::Arc};
     use tempfile::TempDir;
@@ -725,7 +726,7 @@ mod tests {
         assert_eq!(
             cursor.insert(key_to_insert, B256::ZERO),
             Err(DatabaseWriteError {
-                code: -30799,
+                info: Error::KeyExist.into(),
                 operation: DatabaseWriteOperation::CursorInsert,
                 table_name: CanonicalHeaders::NAME,
                 key: key_to_insert.encode().into(),
@@ -869,7 +870,7 @@ mod tests {
         assert_eq!(
             cursor.append(key_to_append, B256::ZERO),
             Err(DatabaseWriteError {
-                code: -30418,
+                info: Error::KeyMismatch.into(),
                 operation: DatabaseWriteOperation::CursorAppend,
                 table_name: CanonicalHeaders::NAME,
                 key: key_to_append.encode().into(),
@@ -951,7 +952,7 @@ mod tests {
                 AccountBeforeTx { address: Address::with_last_byte(subkey_to_append), info: None }
             ),
             Err(DatabaseWriteError {
-                code: -30418,
+                info: Error::KeyMismatch.into(),
                 operation: DatabaseWriteOperation::CursorAppendDup,
                 table_name: AccountChangeSet::NAME,
                 key: transition_id.encode().into(),
@@ -964,7 +965,7 @@ mod tests {
                 AccountBeforeTx { address: Address::with_last_byte(subkey_to_append), info: None }
             ),
             Err(DatabaseWriteError {
-                code: -30418,
+                info: Error::KeyMismatch.into(),
                 operation: DatabaseWriteOperation::CursorAppend,
                 table_name: AccountChangeSet::NAME,
                 key: (transition_id - 1).encode().into(),

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -383,7 +383,7 @@ mod tests {
 
         assert_eq!(
             tx.get::<tables::Transactions>(0).err(),
-            Some(DatabaseError::Open(reth_libmdbx::Error::NotFound.to_err_code()))
+            Some(DatabaseError::Open(reth_libmdbx::Error::NotFound.into()))
         ); // Transaction is not timeout-ed
         assert!(!tx.metrics_handler.unwrap().backtrace_recorded.load(Ordering::Relaxed)); // Backtrace is not recorded
     }
@@ -402,7 +402,7 @@ mod tests {
 
         assert_eq!(
             tx.get::<tables::Transactions>(0).err(),
-            Some(DatabaseError::Open(reth_libmdbx::Error::ReadTransactionAborted.to_err_code()))
+            Some(DatabaseError::Open(reth_libmdbx::Error::ReadTransactionAborted.into()))
         ); // Transaction is timeout-ed
         assert!(tx.metrics_handler.unwrap().backtrace_recorded.load(Ordering::Relaxed)); // Backtrace is recorded
     }

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -310,7 +310,7 @@ impl DbTxMut for Tx<RW> {
             |tx| {
                 tx.put(self.get_dbi::<T>()?, key.as_ref(), value, WriteFlags::UPSERT).map_err(|e| {
                     DatabaseWriteError {
-                        code: e.into(),
+                        info: e.into(),
                         operation: DatabaseWriteOperation::Put,
                         table_name: T::NAME,
                         key: key.into(),


### PR DESCRIPTION
This PR improves readability of errors messages returned from MDBX by changing plain `i32` error code with a struct that allows to pass down an error message. Fixes #6342.

Notes:
* I've had to do `impl<E> From<E> for DatabaseErrorInfo where E: Display + Into<i32>`, because `From<reth_libmdbx::Error>` would bind on a specific implementation.
* The error messages can still be improved. `database should be recovered, but cannot be done automatically since it's in read-only mode` doesn't provide a clear reason or action to take. `the cursor is already at the end of data` is the same. I see two future good-first-issues:
  *  Improve text in `reth_libmdbx::Error` for common errors. Should take into account past issues & Telegram messages to see what were common fundamental causes of the errors and which errors to focus on.
  * Add sanity checks on datadir (e.g. if it exists, file perms, etc.) before calling into mdbx to have own errors for them.

**Examples**

Previously (if MDBX DB is corrupted):
```
Error: Could not open database at path: ../reth-datadir-corr/db

Caused by:
    failed to open the database (-30419)

Location:
    crates/storage/db/src/lib.rs:128:14
```

Now:
```
[...]
Caused by:
    failed to open the database: database should be recovered, but cannot be done automatically since it's in read-only mode (-30419)
[...]
```

Previously (if datadir points to an empty directory):
```
Error: Could not open database at path: ../reth-empty-datadir/db

Caused by:
    failed to open the database (96)

Location:
    crates/storage/db/src/lib.rs:128:14
```

Now
```
[...]
Caused by:
    failed to open the database: the cursor is already at the end of data (96)
[...]
```

