### PR TITLE
Fix reth book optimism sequencer outdated link

### DIFF
--- a/book/run/optimism.md
+++ b/book/run/optimism.md
@@ -109,7 +109,7 @@ op-node \
 [l1-el-spec]: https://github.com/ethereum/execution-specs
 [rollup-node-spec]: https://github.com/ethereum-optimism/specs/blob/main/specs/rollup-node.md
 [op-geth-forkdiff]: https://op-geth.optimism.io
-[sequencer]: https://github.com/ethereum-optimism/optimism/blob/develop/specs/introduction.md#sequencers
+[sequencer]: https://github.com/ethereum-optimism/specs/blob/main/specs/introduction.md#sequencers
 [op-stack-spec]: https://github.com/ethereum-optimism/specs/blob/main/specs
 [l2-el-spec]: https://github.com/ethereum-optimism/specs/blob/main/specs/exec-engine.md
 [deposit-spec]: https://github.com/ethereum-optimism/specs/blob/main/specs/deposits.md


### PR DESCRIPTION
Fixes link in [book/run/optimism.md](https://github.com/paradigmxyz/reth/compare/main...MuhtasimTanmoy:reth:fix-reth-book-optimism-outdated-link?expand=1#diff-49b2afa3790c5a12712f119b47d9c10f2d14d3a055babce6c2418e2bc6038829).