### PR TITLE
fix: add test for truncating parked with large transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6973,6 +6973,7 @@ dependencies = [
  "reth-provider",
  "reth-revm",
  "reth-tasks",
+ "reth-tracing",
  "revm",
  "schnellru",
  "serde",

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -500,7 +500,7 @@ impl Transaction {
 
     /// Calculates a heuristic for the in-memory size of the [Transaction].
     #[inline]
-    fn size(&self) -> usize {
+    pub fn size(&self) -> usize {
         match self {
             Transaction::Legacy(tx) => tx.size(),
             Transaction::Eip2930(tx) => tx.size(),

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -57,6 +57,7 @@ proptest = { workspace = true, optional = true }
 [dev-dependencies]
 reth-primitives = { workspace = true, features = ["arbitrary"] }
 reth-provider = { workspace = true, features = ["test-utils"] }
+reth-tracing.workspace = true
 paste = "1.0"
 rand = "0.8"
 proptest.workspace = true

--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -614,8 +614,13 @@ mod tests {
         let a_sender = address!("000000000000000000000000000000000000000a");
 
         // 2 txs, that should put the pool over the size limit but not max txs
-        let a = MockTransactionSet::dependent(a_sender, 0, 2, TxType::EIP1559);
-        let a_txs = a.clone().into_vec();
+        let a_txs = MockTransactionSet::dependent(a_sender, 0, 2, TxType::EIP1559)
+            .into_iter()
+            .map(|mut tx| {
+                tx.set_size(default_limits.max_size / 2 + 1);
+                tx
+            })
+            .collect::<Vec<_>>();
 
         // add all the transactions to the pool
         for tx in a_txs {

--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -604,6 +604,30 @@ mod tests {
     }
 
     #[test]
+    fn test_truncate_parked_with_large_tx() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = ParkedPool::<BasefeeOrd<_>>::default();
+        let default_limits = SubPoolLimit::default();
+
+        // create a chain of transactions by sender A, B, C
+        // make sure they are all one over half the limit
+        let a_sender = address!("000000000000000000000000000000000000000a");
+
+        // 2 txs, that should put the pool over the size limit but not max txs
+        let a = MockTransactionSet::dependent(a_sender, 0, 2, TxType::EIP1559);
+        let a_txs = a.clone().into_vec();
+
+        // add all the transactions to the pool
+        for tx in a_txs {
+            pool.add_transaction(f.validated_arc(tx));
+        }
+
+        // truncate the pool
+        let removed = pool.truncate_pool(default_limits);
+        assert_eq!(removed.len(), 0);
+    }
+
+    #[test]
     fn test_senders_by_submission_id() {
         // this test ensures that we evict from the pending pool by sender
         let mut f = MockTransactionFactory::default();

--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -609,7 +609,7 @@ mod tests {
         let mut pool = ParkedPool::<BasefeeOrd<_>>::default();
         let default_limits = SubPoolLimit::default();
 
-        // create a chain of transactions by sender A, B, C
+        // create a chain of transactions by sender A
         // make sure they are all one over half the limit
         let a_sender = address!("000000000000000000000000000000000000000a");
 
@@ -627,9 +627,9 @@ mod tests {
             pool.add_transaction(f.validated_arc(tx));
         }
 
-        // truncate the pool
+        // truncate the pool, it should remove at least one transaction
         let removed = pool.truncate_pool(default_limits);
-        assert_eq!(removed.len(), 0);
+        assert_eq!(removed.len(), 1);
     }
 
     #[test]

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -32,6 +32,7 @@ use std::{
     ops::Bound::{Excluded, Unbounded},
     sync::Arc,
 };
+use tracing::trace;
 
 #[cfg_attr(doc, aquamarine::aquamarine)]
 /// A pool that manages transactions.
@@ -785,7 +786,7 @@ impl<T: TransactionOrdering> TxPool<T> {
                         .$limit
                         .is_exceeded($this.$pool.len(), $this.$pool.size())
                     {
-                        tracing::trace!(
+                        trace!(
                             "discarding transactions from {}, limit: {:?}, curr size: {}, curr len: {}",
                             stringify!($pool),
                             $this.config.$limit,
@@ -796,7 +797,7 @@ impl<T: TransactionOrdering> TxPool<T> {
                         // 1. first remove the worst transaction from the subpool
                         let removed_from_subpool = $this.$pool.truncate_pool($this.config.$limit.clone());
 
-                        tracing::trace!(
+                        trace!(
                             "removed {} transactions from {}, limit: {:?}, curr size: {}, curr len: {}",
                             removed_from_subpool.len(),
                             stringify!($pool),

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -21,7 +21,7 @@ use reth_primitives::{
     TxEip1559, TxEip2930, TxEip4844, TxHash, TxLegacy, TxType, B256, EIP1559_TX_TYPE_ID,
     EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID, LEGACY_TX_TYPE_ID, U256,
 };
-use std::{ops::Range, sync::Arc, time::Instant};
+use std::{ops::Range, sync::Arc, time::Instant, vec::IntoIter};
 
 /// A transaction pool implementation using [MockOrdering] for transaction ordering.
 ///
@@ -1393,6 +1393,25 @@ impl MockTransactionSet {
     /// Extract the inner [Vec] of [MockTransaction]s
     pub fn into_vec(self) -> Vec<MockTransaction> {
         self.transactions
+    }
+
+    /// Returns an iterator over the contained transactions in the set
+    pub fn iter(&self) -> impl Iterator<Item = &MockTransaction> {
+        self.transactions.iter()
+    }
+
+    /// Returns a mutable iterator over the contained transactions in the set.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut MockTransaction> {
+        self.transactions.iter_mut()
+    }
+}
+
+impl IntoIterator for MockTransactionSet {
+    type Item = MockTransaction;
+    type IntoIter = IntoIter<MockTransaction>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.transactions.into_iter()
     }
 }
 

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -1370,11 +1370,10 @@ impl MockTransactionSet {
     /// The number of transactions created is determined by `tx_count`.
     pub fn dependent(sender: Address, from_nonce: u64, tx_count: usize, tx_type: TxType) -> Self {
         let mut txs = Vec::with_capacity(tx_count);
-        let mut curr_tx = MockTransaction::new_from_type(tx_type).with_nonce(from_nonce);
-        for i in 0..tx_count {
-            let _nonce = from_nonce + i as u64;
-            curr_tx = curr_tx.next().with_sender(sender);
+        let mut curr_tx = MockTransaction::new_from_type(tx_type).with_nonce(from_nonce).with_sender(sender);
+        for _ in 0..tx_count {
             txs.push(curr_tx.clone());
+            curr_tx = curr_tx.next();
         }
 
         Self::new(txs)

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -1370,7 +1370,8 @@ impl MockTransactionSet {
     /// The number of transactions created is determined by `tx_count`.
     pub fn dependent(sender: Address, from_nonce: u64, tx_count: usize, tx_type: TxType) -> Self {
         let mut txs = Vec::with_capacity(tx_count);
-        let mut curr_tx = MockTransaction::new_from_type(tx_type).with_nonce(from_nonce).with_sender(sender);
+        let mut curr_tx =
+            MockTransaction::new_from_type(tx_type).with_nonce(from_nonce).with_sender(sender);
         for _ in 0..tx_count {
             txs.push(curr_tx.clone());
             curr_tx = curr_tx.next();

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -786,7 +786,14 @@ impl PoolTransaction for MockTransaction {
 
     /// Returns the size of the transaction.
     fn size(&self) -> usize {
-        0
+        match self {
+            MockTransaction::Legacy { size, .. } |
+            MockTransaction::Eip1559 { size, .. } |
+            MockTransaction::Eip4844 { size, .. } |
+            MockTransaction::Eip2930 { size, .. } => *size,
+            #[cfg(feature = "optimism")]
+            MockTransaction::Deposit(_) => 0,
+        }
     }
 
     /// Returns the transaction type as a byte identifier.


### PR DESCRIPTION
Fixes https://github.com/paradigmxyz/reth/issues/6346 and adds more tests for parked and blob pool eviction. Now both the length and the size are taken into account when the truncate method decides to remove another transaction or return.