### PR TITLE
fix: bad blob pool eviction

### DIFF
--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -69,7 +69,7 @@ impl SubPoolLimit {
 
     /// Returns whether the size or amount constraint is violated.
     #[inline]
-    pub fn is_exceeded(&self, txs: usize, size: usize) -> bool {
+    pub const fn is_exceeded(&self, txs: usize, size: usize) -> bool {
         self.max_txs < txs || self.max_size < size
     }
 }

--- a/crates/transaction-pool/src/pool/blob.rs
+++ b/crates/transaction-pool/src/pool/blob.rs
@@ -189,7 +189,7 @@ impl<T: PoolTransaction> BlobTransactions<T> {
     ) -> Vec<Arc<ValidPoolTransaction<T>>> {
         let mut removed = Vec::new();
 
-        while self.size() > limit.max_size && self.len() > limit.max_txs {
+        while limit.is_exceeded(self.len(), self.size()) {
             let tx = self.all.last().expect("pool is not empty");
             let id = *tx.transaction.id();
             removed.push(self.remove_transaction(&id).expect("transaction exists"));

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -546,6 +546,42 @@ impl MockTransaction {
         self.clone().with_gas_limit(self.get_gas_limit() + 1)
     }
 
+    /// Returns a new transaction with a higher blob fee +1
+    ///
+    /// If it's an EIP-4844 transaction.
+    pub fn inc_blob_fee(&self) -> Self {
+        self.inc_blob_fee_by(1)
+    }
+
+    /// Returns a new transaction with a higher blob fee
+    ///
+    /// If it's an EIP-4844 transaction.
+    pub fn inc_blob_fee_by(&self, value: u128) -> Self {
+        let mut this = self.clone();
+        if let MockTransaction::Eip4844 { max_fee_per_blob_gas, .. } = &mut this {
+            *max_fee_per_blob_gas = max_fee_per_blob_gas.checked_add(value).unwrap();
+        }
+        this
+    }
+
+    /// Returns a new transaction with a lower blob fee -1
+    ///
+    /// If it's an EIP-4844 transaction.
+    pub fn decr_blob_fee(&self) -> Self {
+        self.decr_price_by(1)
+    }
+
+    /// Returns a new transaction with a lower blob fee
+    ///
+    /// If it's an EIP-4844 transaction.
+    pub fn decr_blob_fee_by(&self, value: u128) -> Self {
+        let mut this = self.clone();
+        if let MockTransaction::Eip4844 { max_fee_per_blob_gas, .. } = &mut this {
+            *max_fee_per_blob_gas = max_fee_per_blob_gas.checked_sub(value).unwrap();
+        }
+        this
+    }
+
     /// Returns the transaction type identifier associated with the current [MockTransaction].
     pub fn tx_type(&self) -> u8 {
         match self {


### PR DESCRIPTION
this fixes a bad blob eviction bug that caused loop of death, because the outer discard_worst loop has a different exit condition:

https://github.com/paradigmxyz/reth/blob/5a8df5e6e8ede935e2005dfed71d88afec366f0c/crates/transaction-pool/src/config.rs#L73-L73

so the pool never actually evicted because it required `&&` but the outer loop operated on `||`


I think we can make the discard_worst loop nicer and get rid of the ugly macros if we basically do the same loop in the truncate functions anyway