### PR TITLE
chore: remove node-api optimism feature

### DIFF
--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -150,7 +150,6 @@ optimism = [
     "reth-payload-builder/optimism",
     "reth-optimism-payload-builder/optimism",
     "reth-ethereum-payload-builder/optimism",
-    "reth-node-api/optimism",
     "dep:reth-node-optimism",
     "reth-node-core/optimism",
 ]

--- a/crates/consensus/beacon/Cargo.toml
+++ b/crates/consensus/beacon/Cargo.toml
@@ -68,5 +68,4 @@ optimism = [
   "reth-rpc-types/optimism",
   "reth-payload-builder/optimism",
   "reth-blockchain-tree/optimism",
-  "reth-node-api/optimism",
 ]

--- a/crates/node-api/Cargo.toml
+++ b/crates/node-api/Cargo.toml
@@ -23,6 +23,3 @@ serde.workspace = true
 [dev-dependencies]
 # for examples
 reth-payload-builder.workspace = true
-
-[features]
-optimism = []

--- a/crates/node-api/src/engine/mod.rs
+++ b/crates/node-api/src/engine/mod.rs
@@ -215,44 +215,6 @@ pub fn validate_payload_timestamp(
     Ok(())
 }
 
-#[cfg(feature = "optimism")]
-/// Validates the presence of the `withdrawals` field according to the payload timestamp.
-///
-/// After Canyon, withdrawals field must be [Some].
-/// Before Canyon, withdrawals field must be [None];
-///
-/// Canyon activates the Shanghai EIPs, see the Canyon specs for more details:
-/// <https://github.com/ethereum-optimism/optimism/blob/ab926c5fd1e55b5c864341c44842d6d1ca679d99/specs/superchain-upgrades.md#canyon>
-pub fn optimism_validate_withdrawals_presence(
-    chain_spec: &ChainSpec,
-    version: EngineApiMessageVersion,
-    timestamp: u64,
-    has_withdrawals: bool,
-) -> Result<(), AttributesValidationError> {
-    let is_shanghai = chain_spec.fork(Hardfork::Canyon).active_at_timestamp(timestamp);
-
-    match version {
-        EngineApiMessageVersion::V1 => {
-            if has_withdrawals {
-                return Err(AttributesValidationError::WithdrawalsNotSupportedInV1)
-            }
-            if is_shanghai {
-                return Err(AttributesValidationError::NoWithdrawalsPostShanghai)
-            }
-        }
-        EngineApiMessageVersion::V2 | EngineApiMessageVersion::V3 => {
-            if is_shanghai && !has_withdrawals {
-                return Err(AttributesValidationError::NoWithdrawalsPostShanghai)
-            }
-            if !is_shanghai && has_withdrawals {
-                return Err(AttributesValidationError::HasWithdrawalsPreShanghai)
-            }
-        }
-    };
-
-    Ok(())
-}
-
 /// Validates the presence of the `withdrawals` field according to the payload timestamp.
 /// After Shanghai, withdrawals field must be [Some].
 /// Before Shanghai, withdrawals field must be [None];
@@ -340,8 +302,8 @@ pub fn validate_parent_beacon_block_root_presence(
     Ok(())
 }
 
-/// Validates the presence or exclusion of fork-specific fields based on the payload attributes
-/// and the message version.
+/// Validates the presence or exclusion of fork-specific fields based on the ethereum payload
+/// attributes and the message version.
 pub fn validate_version_specific_fields<Type>(
     chain_spec: &ChainSpec,
     version: EngineApiMessageVersion,
@@ -351,31 +313,6 @@ where
     Type: PayloadAttributes,
 {
     validate_withdrawals_presence(
-        chain_spec,
-        version,
-        payload_or_attrs.timestamp(),
-        payload_or_attrs.withdrawals().is_some(),
-    )?;
-    validate_parent_beacon_block_root_presence(
-        chain_spec,
-        version,
-        payload_or_attrs.timestamp(),
-        payload_or_attrs.parent_beacon_block_root().is_some(),
-    )
-}
-
-#[cfg(feature = "optimism")]
-/// Validates the presence or exclusion of fork-specific fields based on the payload attributes
-/// and the message version.
-pub fn optimism_validate_version_specific_fields<Type>(
-    chain_spec: &ChainSpec,
-    version: EngineApiMessageVersion,
-    payload_or_attrs: PayloadOrAttributes<'_, Type>,
-) -> Result<(), AttributesValidationError>
-where
-    Type: PayloadAttributes,
-{
-    optimism_validate_withdrawals_presence(
         chain_spec,
         version,
         payload_or_attrs.timestamp(),

--- a/crates/node-api/src/lib.rs
+++ b/crates/node-api/src/lib.rs
@@ -11,8 +11,6 @@
 ///
 /// Notably contains the [EngineTypes] trait and implementations for ethereum mainnet types.
 pub mod engine;
-#[cfg(feature = "optimism")]
-pub use engine::optimism_validate_version_specific_fields;
 pub use engine::{
     validate_payload_timestamp, validate_version_specific_fields, validate_withdrawals_presence,
     AttributesValidationError, BuiltPayload, EngineApiMessageVersion, EngineTypes,

--- a/crates/node-core/Cargo.toml
+++ b/crates/node-core/Cargo.toml
@@ -118,7 +118,6 @@ optimism = [
     "reth-blockchain-tree/optimism",
     "reth-beacon-consensus/optimism",
     "reth-optimism-payload-builder/optimism",
-    "reth-node-api/optimism",
 ]
 
 jemalloc = ["dep:jemalloc-ctl"]

--- a/crates/node-optimism/Cargo.toml
+++ b/crates/node-optimism/Cargo.toml
@@ -21,4 +21,4 @@ reth-node-api.workspace = true
 serde.workspace = true
 
 [features]
-optimism = ["reth-node-api/optimism"]
+optimism = []

--- a/crates/node-optimism/src/engine.rs
+++ b/crates/node-optimism/src/engine.rs
@@ -1,9 +1,9 @@
 use reth_node_api::{
-    optimism_validate_version_specific_fields, AttributesValidationError, EngineApiMessageVersion,
-    EngineTypes, PayloadOrAttributes,
+    engine::validate_parent_beacon_block_root_presence, AttributesValidationError,
+    EngineApiMessageVersion, EngineTypes, PayloadOrAttributes,
 };
 use reth_payload_builder::{EthBuiltPayload, OptimismPayloadBuilderAttributes};
-use reth_primitives::ChainSpec;
+use reth_primitives::{ChainSpec, Hardfork};
 use reth_rpc_types::engine::OptimismPayloadAttributes;
 
 /// The types used in the optimism beacon consensus engine.
@@ -19,8 +19,56 @@ impl EngineTypes for OptimismEngineTypes {
     fn validate_version_specific_fields(
         chain_spec: &ChainSpec,
         version: EngineApiMessageVersion,
-        payload_or_attrs: PayloadOrAttributes<'_, OptimismPayloadAttributes>,
+        payload_or_attrs: PayloadOrAttributes<'_, Self::PayloadAttributes>,
     ) -> Result<(), AttributesValidationError> {
-        optimism_validate_version_specific_fields(chain_spec, version, payload_or_attrs)
+        validate_withdrawals_presence(
+            chain_spec,
+            version,
+            payload_or_attrs.timestamp(),
+            payload_or_attrs.withdrawals().is_some(),
+        )?;
+        validate_parent_beacon_block_root_presence(
+            chain_spec,
+            version,
+            payload_or_attrs.timestamp(),
+            payload_or_attrs.parent_beacon_block_root().is_some(),
+        )
     }
+}
+
+/// Validates the presence of the `withdrawals` field according to the payload timestamp.
+///
+/// After Canyon, withdrawals field must be [Some].
+/// Before Canyon, withdrawals field must be [None];
+///
+/// Canyon activates the Shanghai EIPs, see the Canyon specs for more details:
+/// <https://github.com/ethereum-optimism/optimism/blob/ab926c5fd1e55b5c864341c44842d6d1ca679d99/specs/superchain-upgrades.md#canyon>
+pub fn validate_withdrawals_presence(
+    chain_spec: &ChainSpec,
+    version: EngineApiMessageVersion,
+    timestamp: u64,
+    has_withdrawals: bool,
+) -> Result<(), AttributesValidationError> {
+    let is_shanghai = chain_spec.fork(Hardfork::Canyon).active_at_timestamp(timestamp);
+
+    match version {
+        EngineApiMessageVersion::V1 => {
+            if has_withdrawals {
+                return Err(AttributesValidationError::WithdrawalsNotSupportedInV1)
+            }
+            if is_shanghai {
+                return Err(AttributesValidationError::NoWithdrawalsPostShanghai)
+            }
+        }
+        EngineApiMessageVersion::V2 | EngineApiMessageVersion::V3 => {
+            if is_shanghai && !has_withdrawals {
+                return Err(AttributesValidationError::NoWithdrawalsPostShanghai)
+            }
+            if !is_shanghai && has_withdrawals {
+                return Err(AttributesValidationError::HasWithdrawalsPreShanghai)
+            }
+        }
+    };
+
+    Ok(())
 }


### PR DESCRIPTION
moves op functions to op-node crate where they belong

gets rid of the node-api/optimism feature