### PR TITLE
Disable filling eth66 request from pending hashes and fix index bug

### DIFF
--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -150,10 +150,7 @@ impl TransactionFetcher {
     /// If necessary, takes hashes from buffer for which peer is listed as fallback peer.
     ///
     /// Returns left over hashes.
-    pub(super) fn pack_hashes_eth66(
-        &mut self,
-        hashes: &mut Vec<TxHash>,
-    ) -> Vec<TxHash> {
+    pub(super) fn pack_hashes_eth66(&mut self, hashes: &mut Vec<TxHash>) -> Vec<TxHash> {
         if hashes.len() <= GET_POOLED_TRANSACTION_SOFT_LIMIT_NUM_HASHES {
             return vec![]
         }

--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -143,7 +143,7 @@ impl TransactionFetcher {
         if self.eth68_meta.get(hash).is_some() {
             return self.pack_hashes_eth68(hashes, peer_id)
         }
-        self.pack_hashes_eth66(hashes, peer_id)
+        self.pack_hashes_eth66(hashes)
     }
 
     /// Packages hashes for [`GetPooledTxRequest`] up to limit as defined by protocol version 66.
@@ -153,13 +153,11 @@ impl TransactionFetcher {
     pub(super) fn pack_hashes_eth66(
         &mut self,
         hashes: &mut Vec<TxHash>,
-        peer_id: PeerId,
     ) -> Vec<TxHash> {
-        if hashes.len() < GET_POOLED_TRANSACTION_SOFT_LIMIT_NUM_HASHES {
-            self.fill_eth66_request_for_peer(hashes, peer_id);
+        if hashes.len() <= GET_POOLED_TRANSACTION_SOFT_LIMIT_NUM_HASHES {
             return vec![]
         }
-        hashes.split_off(GET_POOLED_TRANSACTION_SOFT_LIMIT_NUM_HASHES)
+        hashes.split_off(GET_POOLED_TRANSACTION_SOFT_LIMIT_NUM_HASHES - 1)
     }
 
     /// Evaluates wether or not to include a hash in a `GetPooledTransactions` version eth68


### PR DESCRIPTION
Disables filling eth66 request from pending hashes. Fixes index bug that would have been triggered if length of list of new hashes from announcement was equal to the soft limit.