### PR TITLE
feat(grafana): use reth_info to query Reth instances

### DIFF
--- a/etc/grafana/dashboards/overview.json
+++ b/etc/grafana/dashboards/overview.json
@@ -6701,14 +6701,14 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "query_result(up)",
+        "definition": "reth_info",
         "hide": 0,
         "includeAll": false,
         "multi": false,
         "name": "instance",
         "options": [],
         "query": {
-          "query": "query_result(up)",
+          "query": "reth_info",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,

--- a/etc/grafana/dashboards/overview.json
+++ b/etc/grafana/dashboards/overview.json
@@ -6701,14 +6701,14 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "reth_info",
+        "definition": "query_result(reth_info)",
         "hide": 0,
         "includeAll": false,
         "multi": false,
         "name": "instance",
         "options": [],
         "query": {
-          "query": "reth_info",
+          "query": "query_result(reth_info)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,


### PR DESCRIPTION
Currently, we are using `up` metric to filter reth instances, but it produces all the Prometheus instances, see below:

<img width="290" alt="image" src="https://github.com/paradigmxyz/reth/assets/3627395/1d3d9a98-c7d3-4466-9e96-28a08e24ec4c">



I think we can use `reth_info` instead to get accurate results.



