### PR TITLE
feature: better Address in use error message.

### DIFF
--- a/crates/net/network/src/error.rs
+++ b/crates/net/network/src/error.rs
@@ -9,12 +9,22 @@ use reth_eth_wire::{
 use std::{fmt, io, io::ErrorKind, net::SocketAddr};
 
 /// Service kind.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub enum ServiceKind {
     /// Listener service.
     Listener(SocketAddr),
     /// Discovery service.
     Discovery(SocketAddr),
+}
+
+impl ServiceKind {
+    /// Returns the appropriate flags for each variant.
+    pub fn flags(&self) -> &'static str {
+        match self {
+            ServiceKind::Listener(_) => "--port",
+            ServiceKind::Discovery(_) => "--discovery.port",
+        }
+    }
 }
 
 impl fmt::Display for ServiceKind {
@@ -33,7 +43,7 @@ pub enum NetworkError {
     #[error(transparent)]
     Io(#[from] io::Error),
     /// Error when an address is already in use.
-    #[error("address {kind} is already in use (os error 98)")]
+    #[error("address {kind} is already in use (os error 98). Choose a different port using {}", kind.flags())]
     AddressAlreadyInUse {
         /// Service kind.
         kind: ServiceKind,
@@ -269,6 +279,7 @@ impl SessionError for io::Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::{Ipv4Addr, SocketAddrV4};
 
     #[test]
     fn test_is_fatal_disconnect() {
@@ -294,5 +305,20 @@ mod tests {
             P2PHandshakeError::NoResponse,
         ));
         assert_eq!(err.should_backoff(), Some(BackoffKind::Low));
+    }
+
+    #[test]
+    fn test_address_in_use_message() {
+        let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 1234));
+        let kinds = [ServiceKind::Discovery(addr), ServiceKind::Listener(addr)];
+
+        for kind in &kinds {
+            let err = NetworkError::AddressAlreadyInUse {
+                kind: *kind,
+                error: io::Error::from(ErrorKind::AddrInUse),
+            };
+
+            assert!(err.to_string().contains(kind.flags()));
+        }
     }
 }


### PR DESCRIPTION
Resolves: #6053 

Extends the error message so that the relevant port cli options are also listed with the error message so that it can be more easily resolved. I added a function to the `ServerKind` and `ServiceKind` enums to return the relevant cli flags for each conflict and added it to the error message.

## Added Tests

Added two tests to confirm that the error message strings included the new text.
