### PR TITLE
chore: improve `Withdrawals` interface

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -781,7 +781,7 @@ mod tests {
 
         let header = Header {
             base_fee_per_gas: Some(1337u64),
-            withdrawals_root: Some(proofs::calculate_withdrawals_root(&Withdrawals::default())),
+            withdrawals_root: Some(proofs::calculate_withdrawals_root(&[])),
             ..Default::default()
         }
         .seal_slow();
@@ -798,7 +798,7 @@ mod tests {
 
         let header = Header {
             base_fee_per_gas: Some(1337u64),
-            withdrawals_root: Some(proofs::calculate_withdrawals_root(&Withdrawals::default())),
+            withdrawals_root: Some(proofs::calculate_withdrawals_root(&[])),
             blob_gas_used: Some(1),
             transactions_root: proofs::calculate_transaction_root(&[transaction.clone()]),
             ..Default::default()

--- a/crates/primitives/src/withdrawal.rs
+++ b/crates/primitives/src/withdrawal.rs
@@ -62,6 +62,11 @@ impl Withdrawals {
     pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, Withdrawal> {
         self.0.iter_mut()
     }
+
+    /// Convert [Self] into raw vec of withdrawals.
+    pub fn into_inner(self) -> Vec<Withdrawal> {
+        self.0
+    }
 }
 
 impl IntoIterator for Withdrawals {
@@ -70,6 +75,12 @@ impl IntoIterator for Withdrawals {
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
+    }
+}
+
+impl AsRef<[Withdrawal]> for Withdrawals {
+    fn as_ref(&self) -> &[Withdrawal] {
+        &self.0
     }
 }
 

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -9,7 +9,7 @@ use reth_node_api::EvmEnvConfig;
 use reth_primitives::{
     Address, Block, BlockNumber, BlockWithSenders, Bloom, ChainSpec, GotExpected, Hardfork, Header,
     PruneMode, PruneModes, PruneSegmentError, Receipt, ReceiptWithBloom, Receipts,
-    TransactionSigned, B256, MINIMUM_PRUNING_DISTANCE, U256,
+    TransactionSigned, Withdrawals, B256, MINIMUM_PRUNING_DISTANCE, U256,
 };
 use reth_provider::{
     BlockExecutor, BlockExecutorStats, ProviderError, PrunableBlockExecutor, StateProvider,
@@ -213,7 +213,7 @@ where
             block.timestamp,
             total_difficulty,
             &block.ommers,
-            block.withdrawals.as_ref(),
+            block.withdrawals.as_ref().map(Withdrawals::as_ref),
         );
 
         // Irregular state change at Ethereum DAO hardfork

--- a/crates/revm/src/state_change.rs
+++ b/crates/revm/src/state_change.rs
@@ -2,7 +2,7 @@ use reth_consensus_common::calc;
 use reth_interfaces::executor::{BlockExecutionError, BlockValidationError};
 use reth_primitives::{
     constants::SYSTEM_ADDRESS, revm::env::fill_tx_env_with_beacon_root_contract_call, Address,
-    ChainSpec, Header, Withdrawals, B256, U256,
+    ChainSpec, Header, Withdrawal, B256, U256,
 };
 use revm::{Database, DatabaseCommit, EVM};
 use std::collections::HashMap;
@@ -21,7 +21,7 @@ pub fn post_block_balance_increments(
     block_timestamp: u64,
     total_difficulty: U256,
     ommers: &[Header],
-    withdrawals: Option<&Withdrawals>,
+    withdrawals: Option<&[Withdrawal]>,
 ) -> HashMap<Address, u128> {
     let mut balance_increments = HashMap::new();
 
@@ -124,7 +124,7 @@ where
 pub fn post_block_withdrawals_balance_increments(
     chain_spec: &ChainSpec,
     block_timestamp: u64,
-    withdrawals: &Withdrawals,
+    withdrawals: &[Withdrawal],
 ) -> HashMap<Address, u128> {
     let mut balance_increments = HashMap::with_capacity(withdrawals.len());
     insert_post_block_withdrawals_balance_increments(
@@ -144,7 +144,7 @@ pub fn post_block_withdrawals_balance_increments(
 pub fn insert_post_block_withdrawals_balance_increments(
     chain_spec: &ChainSpec,
     block_timestamp: u64,
-    withdrawals: Option<&Withdrawals>,
+    withdrawals: Option<&[Withdrawal]>,
     balance_increments: &mut HashMap<Address, u128>,
 ) {
     // Process withdrawals


### PR DESCRIPTION
## Description

Improve `Withdrawals` interface and usage:
- no methods functions should accept `Withdrawals` directly, only `[Withdrawal]`
- add `Withdrawals::into_inner` to convert withdrawals back into raw vec