### PR TITLE
chore(rpc-types-compat): use SealedBlock.raw_transactions to reduce deplicate

### DIFF
--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -351,14 +351,7 @@ impl SealedBlock {
 
     /// Returns a vector of transactions RLP encoded with [TransactionSigned::encode_enveloped].
     pub fn raw_transactions(&self) -> Vec<Bytes> {
-        self.body
-            .iter()
-            .map(|tx| {
-                let mut encoded = Vec::new();
-                tx.encode_enveloped(&mut encoded);
-                encoded.into()
-            })
-            .collect()
+        self.body.iter().map(|tx| tx.envelope_encoded()).collect()
     }
 }
 

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -349,7 +349,7 @@ impl SealedBlock {
         Ok(())
     }
 
-    /// Returns a vector of raw formated transactions.
+    /// Returns a vector of transactions RLP encoded with [TransactionSigned::encode_enveloped].
     pub fn raw_transactions(&self) -> Vec<Bytes> {
         self.body
             .iter()

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Address, GotExpected, Header, SealedHeader, TransactionSigned, TransactionSignedEcRecovered,
-    Withdrawal, Withdrawals, B256,
+    Address, Bytes, GotExpected, Header, SealedHeader, TransactionSigned,
+    TransactionSignedEcRecovered, Withdrawal, Withdrawals, B256,
 };
 use alloy_rlp::{RlpDecodable, RlpEncodable};
 use reth_codecs::derive_arbitrary;
@@ -347,6 +347,18 @@ impl SealedBlock {
         }
 
         Ok(())
+    }
+
+    /// Returns a vector of raw formated transactions.
+    pub fn raw_transactions(&self) -> Vec<Bytes> {
+        self.body
+            .iter()
+            .map(|tx| {
+                let mut encoded = Vec::new();
+                tx.encode_enveloped(&mut encoded);
+                encoded.into()
+            })
+            .collect()
     }
 }
 

--- a/crates/rpc/rpc-types-compat/src/engine/payload.rs
+++ b/crates/rpc/rpc-types-compat/src/engine/payload.rs
@@ -102,15 +102,7 @@ pub fn try_block_to_payload(value: SealedBlock) -> ExecutionPayload {
 
 /// Converts [SealedBlock] to [ExecutionPayloadV1]
 pub fn try_block_to_payload_v1(value: SealedBlock) -> ExecutionPayloadV1 {
-    let transactions = value
-        .body
-        .iter()
-        .map(|tx| {
-            let mut encoded = Vec::new();
-            tx.encode_enveloped(&mut encoded);
-            encoded.into()
-        })
-        .collect();
+    let transactions = value.raw_transactions();
     ExecutionPayloadV1 {
         parent_hash: value.parent_hash,
         fee_recipient: value.beneficiary,
@@ -131,15 +123,7 @@ pub fn try_block_to_payload_v1(value: SealedBlock) -> ExecutionPayloadV1 {
 
 /// Converts [SealedBlock] to [ExecutionPayloadV2]
 pub fn try_block_to_payload_v2(value: SealedBlock) -> ExecutionPayloadV2 {
-    let transactions = value
-        .body
-        .iter()
-        .map(|tx| {
-            let mut encoded = Vec::new();
-            tx.encode_enveloped(&mut encoded);
-            encoded.into()
-        })
-        .collect();
+    let transactions = value.raw_transactions();
     let standalone_withdrawals: Vec<reth_rpc_types::withdrawal::Withdrawal> = value
         .withdrawals
         .clone()
@@ -171,15 +155,7 @@ pub fn try_block_to_payload_v2(value: SealedBlock) -> ExecutionPayloadV2 {
 
 /// Converts [SealedBlock] to [ExecutionPayloadV3]
 pub fn block_to_payload_v3(value: SealedBlock) -> ExecutionPayloadV3 {
-    let transactions = value
-        .body
-        .iter()
-        .map(|tx| {
-            let mut encoded = Vec::new();
-            tx.encode_enveloped(&mut encoded);
-            encoded.into()
-        })
-        .collect();
+    let transactions = value.raw_transactions();
 
     let withdrawals: Vec<reth_rpc_types::withdrawal::Withdrawal> = value
         .withdrawals
@@ -362,15 +338,7 @@ pub fn convert_to_payload_body_v1(value: Block) -> ExecutionPayloadBodyV1 {
 
 /// Transforms a [SealedBlock] into a [ExecutionPayloadV1]
 pub fn execution_payload_from_sealed_block(value: SealedBlock) -> ExecutionPayloadV1 {
-    let transactions = value
-        .body
-        .iter()
-        .map(|tx| {
-            let mut encoded = Vec::new();
-            tx.encode_enveloped(&mut encoded);
-            encoded.into()
-        })
-        .collect();
+    let transactions = value.raw_transactions();
     ExecutionPayloadV1 {
         parent_hash: value.parent_hash,
         fee_recipient: value.beneficiary,


### PR DESCRIPTION
Seems the `SealedBlock.body` is used in the v1,v2,v3 payload builder, use a helper function to reduce the same logic.