### PR TITLE
chore: rename EvmEnvConfig to ConfigureEvmEnv

### DIFF
--- a/crates/consensus/auto-seal/src/lib.rs
+++ b/crates/consensus/auto-seal/src/lib.rs
@@ -19,7 +19,7 @@ use reth_interfaces::{
     consensus::{Consensus, ConsensusError},
     executor::{BlockExecutionError, BlockValidationError},
 };
-use reth_node_api::{EngineTypes, ConfigureEvmEnv};
+use reth_node_api::{ConfigureEvmEnv, EngineTypes};
 use reth_primitives::{
     constants::{EMPTY_RECEIPTS, EMPTY_TRANSACTIONS, ETHEREUM_BLOCK_GAS_LIMIT},
     proofs, Block, BlockBody, BlockHash, BlockHashOrNumber, BlockNumber, BlockWithSenders, Bloom,

--- a/crates/consensus/auto-seal/src/lib.rs
+++ b/crates/consensus/auto-seal/src/lib.rs
@@ -19,7 +19,7 @@ use reth_interfaces::{
     consensus::{Consensus, ConsensusError},
     executor::{BlockExecutionError, BlockValidationError},
 };
-use reth_node_api::{EngineTypes, EvmEnvConfig};
+use reth_node_api::{EngineTypes, ConfigureEvmEnv};
 use reth_primitives::{
     constants::{EMPTY_RECEIPTS, EMPTY_TRANSACTIONS, ETHEREUM_BLOCK_GAS_LIMIT},
     proofs, Block, BlockBody, BlockHash, BlockHashOrNumber, BlockNumber, BlockWithSenders, Bloom,
@@ -318,7 +318,7 @@ impl StorageInner {
         executor: &mut EVMProcessor<'_, EvmConfig>,
     ) -> Result<(BundleStateWithReceipts, u64), BlockExecutionError>
     where
-        EvmConfig: EvmEnvConfig,
+        EvmConfig: ConfigureEvmEnv,
     {
         trace!(target: "consensus::auto", transactions=?&block.body, "executing transactions");
         // TODO: there isn't really a parent beacon block root here, so not sure whether or not to
@@ -395,7 +395,7 @@ impl StorageInner {
         evm_config: EvmConfig,
     ) -> Result<(SealedHeader, BundleStateWithReceipts), BlockExecutionError>
     where
-        EvmConfig: EvmEnvConfig,
+        EvmConfig: ConfigureEvmEnv,
     {
         let header = self.build_header_template(&transactions, chain_spec.clone());
 

--- a/crates/consensus/auto-seal/src/task.rs
+++ b/crates/consensus/auto-seal/src/task.rs
@@ -2,7 +2,7 @@ use crate::{mode::MiningMode, Storage};
 use futures_util::{future::BoxFuture, FutureExt};
 use reth_beacon_consensus::{BeaconEngineMessage, ForkchoiceStatus};
 use reth_interfaces::consensus::ForkchoiceState;
-use reth_node_api::{EngineTypes, EvmEnvConfig};
+use reth_node_api::{EngineTypes, ConfigureEvmEnv};
 use reth_primitives::{Block, ChainSpec, IntoRecoveredTransaction, SealedBlockWithSenders};
 use reth_provider::{CanonChainTracker, CanonStateNotificationSender, Chain, StateProviderFactory};
 use reth_stages::PipelineEvent;
@@ -88,7 +88,7 @@ where
     Pool: TransactionPool + Unpin + 'static,
     <Pool as TransactionPool>::Transaction: IntoRecoveredTransaction,
     Engine: EngineTypes + 'static,
-    EvmConfig: EvmEnvConfig + Clone + Unpin + Send + Sync + 'static,
+    EvmConfig: ConfigureEvmEnv + Clone + Unpin + Send + Sync + 'static,
 {
     type Output = ();
 

--- a/crates/consensus/auto-seal/src/task.rs
+++ b/crates/consensus/auto-seal/src/task.rs
@@ -2,7 +2,7 @@ use crate::{mode::MiningMode, Storage};
 use futures_util::{future::BoxFuture, FutureExt};
 use reth_beacon_consensus::{BeaconEngineMessage, ForkchoiceStatus};
 use reth_interfaces::consensus::ForkchoiceState;
-use reth_node_api::{EngineTypes, ConfigureEvmEnv};
+use reth_node_api::{ConfigureEvmEnv, EngineTypes};
 use reth_primitives::{Block, ChainSpec, IntoRecoveredTransaction, SealedBlockWithSenders};
 use reth_provider::{CanonChainTracker, CanonStateNotificationSender, Chain, StateProviderFactory};
 use reth_stages::PipelineEvent;

--- a/crates/node-api/src/evm/mod.rs
+++ b/crates/node-api/src/evm/mod.rs
@@ -2,7 +2,7 @@ use reth_primitives::{revm::env::fill_block_env, Address, ChainSpec, Header, Tra
 use revm_primitives::{BlockEnv, CfgEnv, SpecId, TxEnv};
 
 /// This represents the set of methods used to configure the EVM before execution.
-pub trait EvmEnvConfig: Send + Sync + Unpin + Clone {
+pub trait ConfigureEvmEnv: Send + Sync + Unpin + Clone {
     /// The type of the transaction metadata.
     type TxMeta;
 
@@ -19,7 +19,7 @@ pub trait EvmEnvConfig: Send + Sync + Unpin + Clone {
         total_difficulty: U256,
     );
 
-    /// Convenience function to call both [fill_cfg_env](EvmEnvConfig::fill_cfg_env) and
+    /// Convenience function to call both [fill_cfg_env](ConfigureEvmEnv::fill_cfg_env) and
     /// [fill_block_env].
     fn fill_cfg_and_block_env(
         cfg: &mut CfgEnv,

--- a/crates/node-api/src/lib.rs
+++ b/crates/node-api/src/lib.rs
@@ -19,4 +19,4 @@ pub use engine::{
 
 /// Traits and helper types used to abstract over EVM methods and types.
 pub mod evm;
-pub use evm::EvmEnvConfig;
+pub use evm::ConfigureEvmEnv;

--- a/crates/node-core/src/args/rpc_server_args.rs
+++ b/crates/node-core/src/args/rpc_server_args.rs
@@ -19,7 +19,7 @@ use clap::{
 use futures::TryFutureExt;
 use rand::Rng;
 use reth_network_api::{NetworkInfo, Peers};
-use reth_node_api::{EngineTypes, ConfigureEvmEnv};
+use reth_node_api::{ConfigureEvmEnv, EngineTypes};
 use reth_provider::{
     AccountReader, BlockReaderIdExt, CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader,
     EvmEnvProvider, HeaderProvider, StateProviderFactory,

--- a/crates/node-core/src/args/rpc_server_args.rs
+++ b/crates/node-core/src/args/rpc_server_args.rs
@@ -19,7 +19,7 @@ use clap::{
 use futures::TryFutureExt;
 use rand::Rng;
 use reth_network_api::{NetworkInfo, Peers};
-use reth_node_api::{EngineTypes, EvmEnvConfig};
+use reth_node_api::{EngineTypes, ConfigureEvmEnv};
 use reth_provider::{
     AccountReader, BlockReaderIdExt, CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader,
     EvmEnvProvider, HeaderProvider, StateProviderFactory,
@@ -368,7 +368,7 @@ impl RpcServerArgs {
         Network: NetworkInfo + Peers + Clone + 'static,
         Tasks: TaskSpawner + Clone + 'static,
         Events: CanonStateSubscriptions + Clone + 'static,
-        EvmConfig: EvmEnvConfig + 'static,
+        EvmConfig: ConfigureEvmEnv + 'static,
     {
         reth_rpc_builder::launch(
             provider,
@@ -408,7 +408,7 @@ impl RpcServerArgs {
         Network: NetworkInfo + Peers + Clone + 'static,
         Tasks: TaskSpawner + Clone + 'static,
         EngineT: EngineTypes + 'static,
-        EvmConfig: EvmEnvConfig + 'static,
+        EvmConfig: ConfigureEvmEnv + 'static,
     {
         let socket_address = SocketAddr::new(self.auth_addr, self.auth_port);
 

--- a/crates/node-core/src/cli/components.rs
+++ b/crates/node-core/src/cli/components.rs
@@ -3,7 +3,7 @@
 use reth_db::database::Database;
 use reth_network::{NetworkEvents, NetworkProtocols};
 use reth_network_api::{NetworkInfo, Peers};
-use reth_node_api::EvmEnvConfig;
+use reth_node_api::ConfigureEvmEnv;
 use reth_primitives::ChainSpec;
 use reth_provider::{
     AccountReader, BlockReaderIdExt, CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader,
@@ -61,7 +61,7 @@ pub trait RethNodeComponents: Clone + Send + Sync + 'static {
     /// The type that is used to spawn tasks.
     type Tasks: TaskSpawner + Clone + Unpin + 'static;
     /// The type that defines how to configure the EVM before execution.
-    type EvmConfig: EvmEnvConfig + 'static;
+    type EvmConfig: ConfigureEvmEnv + 'static;
 
     /// Returns the instance of the provider
     fn provider(&self) -> Self::Provider;
@@ -171,7 +171,7 @@ where
     Pool: TransactionPool + Clone + Unpin + 'static,
     Network: NetworkInfo + Peers + NetworkProtocols + NetworkEvents + Clone + 'static,
     Events: CanonStateSubscriptions + Clone + 'static,
-    EvmConfig: EvmEnvConfig + 'static,
+    EvmConfig: ConfigureEvmEnv + 'static,
 {
     type DB = DB;
     type Provider = Provider;

--- a/crates/node-core/src/node_config.rs
+++ b/crates/node-core/src/node_config.rs
@@ -36,7 +36,7 @@ use reth_interfaces::{
     RethResult,
 };
 use reth_network::{NetworkBuilder, NetworkConfig, NetworkHandle, NetworkManager};
-use reth_node_api::EvmEnvConfig;
+use reth_node_api::ConfigureEvmEnv;
 use reth_primitives::{
     constants::eip4844::{LoadKzgSettingsError, MAINNET_KZG_TRUSTED_SETUP},
     kzg::KzgSettings,
@@ -424,7 +424,7 @@ impl NodeConfig {
     ) -> eyre::Result<BlockchainTree<DB, EvmProcessorFactory<EvmConfig>>>
     where
         DB: Database + Unpin + Clone + 'static,
-        EvmConfig: EvmEnvConfig + Clone + 'static,
+        EvmConfig: ConfigureEvmEnv + Clone + 'static,
     {
         // configure blockchain tree
         let tree_externals = TreeExternals::new(
@@ -536,7 +536,7 @@ impl NodeConfig {
     where
         DB: Database + Unpin + Clone + 'static,
         Client: HeadersClient + BodiesClient + Clone + 'static,
-        EvmConfig: EvmEnvConfig + Clone + 'static,
+        EvmConfig: ConfigureEvmEnv + Clone + 'static,
     {
         // building network downloaders using the fetch client
         let header_downloader = ReverseHeadersDownloaderBuilder::new(config.headers)
@@ -774,7 +774,7 @@ impl NodeConfig {
         DB: Database + Clone + 'static,
         H: HeaderDownloader + 'static,
         B: BodyDownloader + 'static,
-        EvmConfig: EvmEnvConfig + Clone + 'static,
+        EvmConfig: ConfigureEvmEnv + Clone + 'static,
     {
         let mut builder = Pipeline::builder();
 

--- a/crates/node-ethereum/src/evm.rs
+++ b/crates/node-ethereum/src/evm.rs
@@ -1,4 +1,4 @@
-use reth_node_api::EvmEnvConfig;
+use reth_node_api::ConfigureEvmEnv;
 use reth_primitives::{
     revm::{config::revm_spec, env::fill_tx_env},
     revm_primitives::{AnalysisKind, CfgEnv, TxEnv},
@@ -10,7 +10,7 @@ use reth_primitives::{
 #[non_exhaustive]
 pub struct EthEvmConfig;
 
-impl EvmEnvConfig for EthEvmConfig {
+impl ConfigureEvmEnv for EthEvmConfig {
     type TxMeta = ();
 
     fn fill_tx_env<T>(tx_env: &mut TxEnv, transaction: T, sender: Address, _meta: ())

--- a/crates/node-ethereum/src/lib.rs
+++ b/crates/node-ethereum/src/lib.rs
@@ -12,7 +12,7 @@
 pub mod engine;
 pub use engine::EthEngineTypes;
 
-/// Exports commonly used concrete instances of the [ConfigureEvmEnv](reth_node_api::ConfigureEvmEnv)
-/// trait.
+/// Exports commonly used concrete instances of the
+/// [ConfigureEvmEnv](reth_node_api::ConfigureEvmEnv) trait.
 pub mod evm;
 pub use evm::EthEvmConfig;

--- a/crates/node-ethereum/src/lib.rs
+++ b/crates/node-ethereum/src/lib.rs
@@ -12,7 +12,7 @@
 pub mod engine;
 pub use engine::EthEngineTypes;
 
-/// Exports commonly used concrete instances of the [EvmEnvConfig](reth_node_api::EvmEnvConfig)
+/// Exports commonly used concrete instances of the [ConfigureEvmEnv](reth_node_api::ConfigureEvmEnv)
 /// trait.
 pub mod evm;
 pub use evm::EthEvmConfig;

--- a/crates/node-optimism/src/evm.rs
+++ b/crates/node-optimism/src/evm.rs
@@ -1,4 +1,4 @@
-use reth_node_api::EvmEnvConfig;
+use reth_node_api::ConfigureEvmEnv;
 use reth_primitives::{
     revm::{config::revm_spec, env::fill_op_tx_env},
     revm_primitives::{AnalysisKind, CfgEnv, TxEnv},
@@ -10,7 +10,7 @@ use reth_primitives::{
 #[non_exhaustive]
 pub struct OptimismEvmConfig;
 
-impl EvmEnvConfig for OptimismEvmConfig {
+impl ConfigureEvmEnv for OptimismEvmConfig {
     type TxMeta = Bytes;
 
     fn fill_tx_env<T>(tx_env: &mut TxEnv, transaction: T, sender: Address, meta: Bytes)

--- a/crates/node-optimism/src/lib.rs
+++ b/crates/node-optimism/src/lib.rs
@@ -14,7 +14,7 @@
 pub mod engine;
 pub use engine::OptimismEngineTypes;
 
-/// Exports optimism-specific implementations of the [EvmEnvConfig](reth_node_api::EvmEnvConfig)
+/// Exports optimism-specific implementations of the [ConfigureEvmEnv](reth_node_api::ConfigureEvmEnv)
 /// trait.
 pub mod evm;
 pub use evm::OptimismEvmConfig;

--- a/crates/node-optimism/src/lib.rs
+++ b/crates/node-optimism/src/lib.rs
@@ -14,7 +14,7 @@
 pub mod engine;
 pub use engine::OptimismEngineTypes;
 
-/// Exports optimism-specific implementations of the [ConfigureEvmEnv](reth_node_api::ConfigureEvmEnv)
-/// trait.
+/// Exports optimism-specific implementations of the
+/// [ConfigureEvmEnv](reth_node_api::ConfigureEvmEnv) trait.
 pub mod evm;
 pub use evm::OptimismEvmConfig;

--- a/crates/revm/src/factory.rs
+++ b/crates/revm/src/factory.rs
@@ -3,7 +3,7 @@ use crate::{
     processor::EVMProcessor,
     stack::{InspectorStack, InspectorStackConfig},
 };
-use reth_node_api::EvmEnvConfig;
+use reth_node_api::ConfigureEvmEnv;
 use reth_primitives::ChainSpec;
 use reth_provider::{ExecutorFactory, PrunableBlockExecutor, StateProvider};
 use std::sync::Arc;
@@ -38,7 +38,7 @@ impl<EvmConfig> EvmProcessorFactory<EvmConfig> {
 
 impl<EvmConfig> ExecutorFactory for EvmProcessorFactory<EvmConfig>
 where
-    EvmConfig: EvmEnvConfig + Send + Sync + Clone + 'static,
+    EvmConfig: ConfigureEvmEnv + Send + Sync + Clone + 'static,
 {
     fn with_state<'a, SP: StateProvider + 'a>(
         &'a self,

--- a/crates/revm/src/optimism/processor.rs
+++ b/crates/revm/src/optimism/processor.rs
@@ -2,7 +2,7 @@ use crate::processor::{verify_receipt, EVMProcessor};
 use reth_interfaces::executor::{
     BlockExecutionError, BlockValidationError, OptimismBlockExecutionError,
 };
-use reth_node_api::EvmEnvConfig;
+use reth_node_api::ConfigureEvmEnv;
 use reth_primitives::{
     revm::compat::into_reth_log, revm_primitives::ResultAndState, BlockWithSenders, Hardfork,
     Receipt, U256,
@@ -14,7 +14,7 @@ use tracing::{debug, trace};
 
 impl<'a, EvmConfig> BlockExecutor for EVMProcessor<'a, EvmConfig>
 where
-    EvmConfig: EvmEnvConfig,
+    EvmConfig: ConfigureEvmEnv,
 {
     fn execute(
         &mut self,

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -5,7 +5,7 @@ use crate::{
     state_change::{apply_beacon_root_contract_call, post_block_balance_increments},
 };
 use reth_interfaces::executor::{BlockExecutionError, BlockValidationError};
-use reth_node_api::EvmEnvConfig;
+use reth_node_api::ConfigureEvmEnv;
 use reth_primitives::{
     Address, Block, BlockNumber, BlockWithSenders, Bloom, ChainSpec, GotExpected, Hardfork, Header,
     PruneMode, PruneModes, PruneSegmentError, Receipt, ReceiptWithBloom, Receipts,
@@ -85,7 +85,7 @@ pub struct EVMProcessor<'a, EvmConfig> {
 
 impl<'a, EvmConfig> EVMProcessor<'a, EvmConfig>
 where
-    EvmConfig: EvmEnvConfig,
+    EvmConfig: ConfigureEvmEnv,
 {
     /// Return chain spec.
     pub fn chain_spec(&self) -> &Arc<ChainSpec> {
@@ -390,7 +390,7 @@ where
 #[cfg(not(feature = "optimism"))]
 impl<'a, EvmConfig> BlockExecutor for EVMProcessor<'a, EvmConfig>
 where
-    EvmConfig: EvmEnvConfig,
+    EvmConfig: ConfigureEvmEnv,
 {
     fn execute(
         &mut self,
@@ -505,7 +505,7 @@ where
 
 impl<'a, EvmConfig> PrunableBlockExecutor for EVMProcessor<'a, EvmConfig>
 where
-    EvmConfig: EvmEnvConfig,
+    EvmConfig: ConfigureEvmEnv,
 {
     fn set_tip(&mut self, tip: BlockNumber) {
         self.tip = Some(tip);

--- a/crates/rpc/rpc-builder/src/auth.rs
+++ b/crates/rpc/rpc-builder/src/auth.rs
@@ -12,7 +12,7 @@ use jsonrpsee::{
     Methods,
 };
 use reth_network_api::{NetworkInfo, Peers};
-use reth_node_api::{EngineTypes, EvmEnvConfig};
+use reth_node_api::{EngineTypes, ConfigureEvmEnv};
 use reth_provider::{
     BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, HeaderProvider, ReceiptProviderIdExt,
     StateProviderFactory,
@@ -60,7 +60,7 @@ where
     Tasks: TaskSpawner + Clone + 'static,
     EngineT: EngineTypes + 'static,
     EngineApi: EngineApiServer<EngineT>,
-    EvmConfig: EvmEnvConfig + 'static,
+    EvmConfig: ConfigureEvmEnv + 'static,
 {
     // spawn a new cache task
     let eth_cache = EthStateCache::spawn_with(
@@ -115,7 +115,7 @@ where
     Network: NetworkInfo + Peers + Clone + 'static,
     EngineT: EngineTypes + 'static,
     EngineApi: EngineApiServer<EngineT>,
-    EvmConfig: EvmEnvConfig + 'static,
+    EvmConfig: ConfigureEvmEnv + 'static,
 {
     // Configure the module and start the server.
     let mut module = RpcModule::new(());

--- a/crates/rpc/rpc-builder/src/auth.rs
+++ b/crates/rpc/rpc-builder/src/auth.rs
@@ -12,7 +12,7 @@ use jsonrpsee::{
     Methods,
 };
 use reth_network_api::{NetworkInfo, Peers};
-use reth_node_api::{EngineTypes, ConfigureEvmEnv};
+use reth_node_api::{ConfigureEvmEnv, EngineTypes};
 use reth_provider::{
     BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, HeaderProvider, ReceiptProviderIdExt,
     StateProviderFactory,

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -78,7 +78,7 @@
 //!
 //! ```
 //! use reth_network_api::{NetworkInfo, Peers};
-//! use reth_node_api::{EngineTypes, ConfigureEvmEnv};
+//! use reth_node_api::{ConfigureEvmEnv, EngineTypes};
 //! use reth_provider::{
 //!     AccountReader, BlockReaderIdExt, CanonStateSubscriptions, ChainSpecProvider,
 //!     ChangeSetReader, EvmEnvProvider, StateProviderFactory,
@@ -167,7 +167,7 @@ use jsonrpsee::{
     server::{IdProvider, Server, ServerHandle},
     Methods, RpcModule,
 };
-use reth_node_api::{EngineTypes, ConfigureEvmEnv};
+use reth_node_api::{ConfigureEvmEnv, EngineTypes};
 use serde::{Deserialize, Serialize, Serializer};
 use strum::{AsRefStr, EnumIter, IntoStaticStr, ParseError, VariantArray, VariantNames};
 use tower::layer::util::{Identity, Stack};

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! ```
 //! use reth_network_api::{NetworkInfo, Peers};
-//! use reth_node_api::EvmEnvConfig;
+//! use reth_node_api::ConfigureEvmEnv;
 //! use reth_provider::{
 //!     AccountReader, BlockReaderIdExt, CanonStateSubscriptions, ChainSpecProvider,
 //!     ChangeSetReader, EvmEnvProvider, StateProviderFactory,
@@ -47,7 +47,7 @@
 //!     Pool: TransactionPool + Clone + 'static,
 //!     Network: NetworkInfo + Peers + Clone + 'static,
 //!     Events: CanonStateSubscriptions + Clone + 'static,
-//!     EvmConfig: EvmEnvConfig + 'static,
+//!     EvmConfig: ConfigureEvmEnv + 'static,
 //! {
 //!     // configure the rpc module per transport
 //!     let transports = TransportRpcModuleConfig::default().with_http(vec![
@@ -78,7 +78,7 @@
 //!
 //! ```
 //! use reth_network_api::{NetworkInfo, Peers};
-//! use reth_node_api::{EngineTypes, EvmEnvConfig};
+//! use reth_node_api::{EngineTypes, ConfigureEvmEnv};
 //! use reth_provider::{
 //!     AccountReader, BlockReaderIdExt, CanonStateSubscriptions, ChainSpecProvider,
 //!     ChangeSetReader, EvmEnvProvider, StateProviderFactory,
@@ -114,7 +114,7 @@
 //!     Events: CanonStateSubscriptions + Clone + 'static,
 //!     EngineApi: EngineApiServer<EngineT>,
 //!     EngineT: EngineTypes + 'static,
-//!     EvmConfig: EvmEnvConfig + 'static,
+//!     EvmConfig: ConfigureEvmEnv + 'static,
 //! {
 //!     // configure the rpc module per transport
 //!     let transports = TransportRpcModuleConfig::default().with_http(vec![
@@ -167,7 +167,7 @@ use jsonrpsee::{
     server::{IdProvider, Server, ServerHandle},
     Methods, RpcModule,
 };
-use reth_node_api::{EngineTypes, EvmEnvConfig};
+use reth_node_api::{EngineTypes, ConfigureEvmEnv};
 use serde::{Deserialize, Serialize, Serializer};
 use strum::{AsRefStr, EnumIter, IntoStaticStr, ParseError, VariantArray, VariantNames};
 use tower::layer::util::{Identity, Stack};
@@ -248,7 +248,7 @@ where
     Network: NetworkInfo + Peers + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,
     Events: CanonStateSubscriptions + Clone + 'static,
-    EvmConfig: EvmEnvConfig + 'static,
+    EvmConfig: ConfigureEvmEnv + 'static,
 {
     let module_config = module_config.into();
     let server_config = server_config.into();
@@ -416,7 +416,7 @@ impl<Provider, Pool, Network, Tasks, Events, EvmConfig>
         evm_config: E,
     ) -> RpcModuleBuilder<Provider, Pool, Network, Tasks, Events, E>
     where
-        E: EvmEnvConfig + 'static,
+        E: ConfigureEvmEnv + 'static,
     {
         let Self { provider, pool, executor, network, events, .. } = self;
         RpcModuleBuilder { provider, network, pool, executor, events, evm_config }
@@ -439,7 +439,7 @@ where
     Network: NetworkInfo + Peers + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,
     Events: CanonStateSubscriptions + Clone + 'static,
-    EvmConfig: EvmEnvConfig + 'static,
+    EvmConfig: ConfigureEvmEnv + 'static,
 {
     /// Configures all [RpcModule]s specific to the given [TransportRpcModuleConfig] which can be
     /// used to start the transport server(s).
@@ -493,13 +493,13 @@ where
     ///
     /// ```no_run
     /// use reth_network_api::noop::NoopNetwork;
-    /// use reth_node_api::EvmEnvConfig;
+    /// use reth_node_api::ConfigureEvmEnv;
     /// use reth_provider::test_utils::{NoopProvider, TestCanonStateSubscriptions};
     /// use reth_rpc_builder::RpcModuleBuilder;
     /// use reth_tasks::TokioTaskExecutor;
     /// use reth_transaction_pool::noop::NoopTransactionPool;
     ///
-    /// fn init<Evm: EvmEnvConfig + 'static>(evm: Evm) {
+    /// fn init<Evm: ConfigureEvmEnv + 'static>(evm: Evm) {
     ///     let mut registry = RpcModuleBuilder::default()
     ///         .with_provider(NoopProvider::default())
     ///         .with_pool(NoopTransactionPool::default())
@@ -735,7 +735,7 @@ impl RpcModuleSelection {
         Network: NetworkInfo + Peers + Clone + 'static,
         Tasks: TaskSpawner + Clone + 'static,
         Events: CanonStateSubscriptions + Clone + 'static,
-        EvmConfig: EvmEnvConfig + 'static,
+        EvmConfig: ConfigureEvmEnv + 'static,
     {
         let mut registry =
             RethModuleRegistry::new(provider, pool, network, executor, events, config, evm_config);
@@ -1057,7 +1057,7 @@ where
     Network: NetworkInfo + Peers + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,
     Events: CanonStateSubscriptions + Clone + 'static,
-    EvmConfig: EvmEnvConfig + 'static,
+    EvmConfig: ConfigureEvmEnv + 'static,
 {
     /// Register Eth Namespace
     ///

--- a/crates/rpc/rpc/src/eth/api/block.rs
+++ b/crates/rpc/rpc/src/eth/api/block.rs
@@ -8,7 +8,7 @@ use crate::{
     EthApi,
 };
 use reth_network_api::NetworkInfo;
-use reth_node_api::EvmEnvConfig;
+use reth_node_api::ConfigureEvmEnv;
 use reth_primitives::{BlockId, TransactionMeta};
 use reth_provider::{BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, StateProviderFactory};
 use reth_rpc_types::{Index, RichBlock, TransactionReceipt};
@@ -22,7 +22,7 @@ where
         BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
     Pool: TransactionPool + Clone + 'static,
     Network: NetworkInfo + Send + Sync + 'static,
-    EvmConfig: EvmEnvConfig + 'static,
+    EvmConfig: ConfigureEvmEnv + 'static,
 {
     /// Returns the uncle headers of the given block
     ///

--- a/crates/rpc/rpc/src/eth/api/call.rs
+++ b/crates/rpc/rpc/src/eth/api/call.rs
@@ -13,7 +13,7 @@ use crate::{
     EthApi,
 };
 use reth_network_api::NetworkInfo;
-use reth_node_api::EvmEnvConfig;
+use reth_node_api::ConfigureEvmEnv;
 use reth_primitives::{revm::env::tx_env_with_recovered, BlockId, BlockNumberOrTag, Bytes, U256};
 use reth_provider::{
     BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, StateProvider, StateProviderFactory,
@@ -40,7 +40,7 @@ where
     Provider:
         BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
     Network: NetworkInfo + Send + Sync + 'static,
-    EvmConfig: EvmEnvConfig + 'static,
+    EvmConfig: ConfigureEvmEnv + 'static,
 {
     /// Estimate gas needed for execution of the `request` at the [BlockId].
     pub async fn estimate_gas_at(

--- a/crates/rpc/rpc/src/eth/api/fees.rs
+++ b/crates/rpc/rpc/src/eth/api/fees.rs
@@ -8,7 +8,7 @@ use crate::{
     EthApi,
 };
 use reth_network_api::NetworkInfo;
-use reth_node_api::EvmEnvConfig;
+use reth_node_api::ConfigureEvmEnv;
 use reth_primitives::{basefee::calculate_next_block_base_fee, BlockNumberOrTag, U256};
 use reth_provider::{BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, StateProviderFactory};
 use reth_rpc_types::FeeHistory;
@@ -21,7 +21,7 @@ where
     Provider:
         BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
     Network: NetworkInfo + Send + Sync + 'static,
-    EvmConfig: EvmEnvConfig + 'static,
+    EvmConfig: ConfigureEvmEnv + 'static,
 {
     /// Returns a suggestion for a gas price for legacy transactions.
     ///

--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -15,7 +15,7 @@ use crate::eth::{
 use async_trait::async_trait;
 use reth_interfaces::RethResult;
 use reth_network_api::NetworkInfo;
-use reth_node_api::EvmEnvConfig;
+use reth_node_api::ConfigureEvmEnv;
 use reth_primitives::{
     revm_primitives::{BlockEnv, CfgEnv},
     Address, BlockId, BlockNumberOrTag, ChainInfo, SealedBlockWithSenders, B256, U256, U64,
@@ -263,7 +263,7 @@ where
         BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
     Pool: TransactionPool + Clone + 'static,
     Network: NetworkInfo + Send + Sync + 'static,
-    EvmConfig: EvmEnvConfig + Clone + 'static,
+    EvmConfig: ConfigureEvmEnv + Clone + 'static,
 {
     /// Configures the [CfgEnv] and [BlockEnv] for the pending block
     ///
@@ -379,7 +379,7 @@ where
     Provider:
         BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
     Network: NetworkInfo + 'static,
-    EvmConfig: EvmEnvConfig + 'static,
+    EvmConfig: ConfigureEvmEnv + 'static,
 {
     /// Returns the current ethereum protocol version.
     ///

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use jsonrpsee::core::RpcResult as Result;
 use reth_network_api::NetworkInfo;
-use reth_node_api::EvmEnvConfig;
+use reth_node_api::ConfigureEvmEnv;
 use reth_primitives::{
     serde_helper::{num::U64HexOrNumber, JsonStorageKey},
     Address, BlockId, BlockNumberOrTag, Bytes, B256, B64, U256, U64,
@@ -45,7 +45,7 @@ where
         + EvmEnvProvider
         + 'static,
     Network: NetworkInfo + Send + Sync + 'static,
-    EvmConfig: EvmEnvConfig + 'static,
+    EvmConfig: ConfigureEvmEnv + 'static,
 {
     /// Handler for: `eth_protocolVersion`
     async fn protocol_version(&self) -> Result<U64> {

--- a/crates/rpc/rpc/src/eth/api/state.rs
+++ b/crates/rpc/rpc/src/eth/api/state.rs
@@ -4,7 +4,7 @@ use crate::{
     eth::error::{EthApiError, EthResult, RpcInvalidTransactionError},
     EthApi,
 };
-use reth_node_api::EvmEnvConfig;
+use reth_node_api::ConfigureEvmEnv;
 use reth_primitives::{
     serde_helper::JsonStorageKey, Address, BlockId, BlockNumberOrTag, Bytes, B256, U256,
 };
@@ -21,7 +21,7 @@ where
         BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
     Pool: TransactionPool + Clone + 'static,
     Network: Send + Sync + 'static,
-    EvmConfig: EvmEnvConfig + 'static,
+    EvmConfig: ConfigureEvmEnv + 'static,
 {
     pub(crate) fn get_code(&self, address: Address, block_id: Option<BlockId>) -> EthResult<Bytes> {
         let state = self.state_at_block_id_or_latest(block_id)?;

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use reth_network_api::NetworkInfo;
-use reth_node_api::EvmEnvConfig;
+use reth_node_api::ConfigureEvmEnv;
 use reth_primitives::{
     eip4844::calc_blob_gasprice,
     revm::env::{fill_block_env_with_coinbase, tx_env_with_recovered},
@@ -334,7 +334,7 @@ where
     Provider:
         BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
     Network: NetworkInfo + Send + Sync + 'static,
-    EvmConfig: EvmEnvConfig + 'static,
+    EvmConfig: ConfigureEvmEnv + 'static,
 {
     fn call_gas_limit(&self) -> u64 {
         self.inner.gas_cap
@@ -897,7 +897,7 @@ where
     Provider:
         BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
     Network: NetworkInfo + Send + Sync + 'static,
-    EvmConfig: EvmEnvConfig + 'static,
+    EvmConfig: ConfigureEvmEnv + 'static,
 {
     /// Spawns the given closure on a new blocking tracing task
     async fn spawn_tracing_task_with<F, T>(&self, f: F) -> EthResult<T>
@@ -1046,7 +1046,7 @@ where
     Provider:
         BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
     Network: NetworkInfo + Send + Sync + 'static,
-    EvmConfig: EvmEnvConfig + 'static,
+    EvmConfig: ConfigureEvmEnv + 'static,
 {
     pub(crate) fn sign_request(
         &self,

--- a/crates/rpc/rpc/src/eth/cache/mod.rs
+++ b/crates/rpc/rpc/src/eth/cache/mod.rs
@@ -2,7 +2,7 @@
 
 use futures::{future::Either, Stream, StreamExt};
 use reth_interfaces::provider::{ProviderError, ProviderResult};
-use reth_node_api::EvmEnvConfig;
+use reth_node_api::ConfigureEvmEnv;
 use reth_primitives::{
     Block, BlockHashOrNumber, BlockWithSenders, Receipt, SealedBlock, SealedBlockWithSenders,
     TransactionSigned, TransactionSignedEcRecovered, B256,
@@ -105,7 +105,7 @@ impl EthStateCache {
     ) -> Self
     where
         Provider: StateProviderFactory + BlockReader + EvmEnvProvider + Clone + Unpin + 'static,
-        EvmConfig: EvmEnvConfig + 'static,
+        EvmConfig: ConfigureEvmEnv + 'static,
     {
         Self::spawn_with(provider, config, TokioTaskExecutor::default(), evm_config)
     }
@@ -123,7 +123,7 @@ impl EthStateCache {
     where
         Provider: StateProviderFactory + BlockReader + EvmEnvProvider + Clone + Unpin + 'static,
         Tasks: TaskSpawner + Clone + 'static,
-        EvmConfig: EvmEnvConfig + 'static,
+        EvmConfig: ConfigureEvmEnv + 'static,
     {
         let EthStateCacheConfig { max_blocks, max_receipts, max_envs, max_concurrent_db_requests } =
             config;
@@ -311,7 +311,7 @@ impl<Provider, Tasks, EvmConfig> EthStateCacheService<Provider, Tasks, EvmConfig
 where
     Provider: StateProviderFactory + BlockReader + EvmEnvProvider + Clone + Unpin + 'static,
     Tasks: TaskSpawner + Clone + 'static,
-    EvmConfig: EvmEnvConfig + 'static,
+    EvmConfig: ConfigureEvmEnv + 'static,
 {
     fn on_new_block(&mut self, block_hash: B256, res: ProviderResult<Option<BlockWithSenders>>) {
         if let Some(queued) = self.full_block_cache.remove(&block_hash) {
@@ -366,7 +366,7 @@ impl<Provider, Tasks, EvmConfig> Future for EthStateCacheService<Provider, Tasks
 where
     Provider: StateProviderFactory + BlockReader + EvmEnvProvider + Clone + Unpin + 'static,
     Tasks: TaskSpawner + Clone + 'static,
-    EvmConfig: EvmEnvConfig + 'static,
+    EvmConfig: ConfigureEvmEnv + 'static,
 {
     type Output = ();
 

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use reth_db::{database::Database, init_db, models::StoredBlockBodyIndices, DatabaseEnv};
 use reth_interfaces::{provider::ProviderResult, RethError, RethResult};
-use reth_node_api::EvmEnvConfig;
+use reth_node_api::ConfigureEvmEnv;
 use reth_primitives::{
     snapshot::HighestSnapshots,
     stage::{StageCheckpoint, StageId},
@@ -446,7 +446,7 @@ impl<DB: Database> EvmEnvProvider for ProviderFactory<DB> {
         evm_config: EvmConfig,
     ) -> ProviderResult<()>
     where
-        EvmConfig: EvmEnvConfig,
+        EvmConfig: ConfigureEvmEnv,
     {
         self.provider()?.fill_env_at(cfg, block_env, at, evm_config)
     }
@@ -459,7 +459,7 @@ impl<DB: Database> EvmEnvProvider for ProviderFactory<DB> {
         evm_config: EvmConfig,
     ) -> ProviderResult<()>
     where
-        EvmConfig: EvmEnvConfig,
+        EvmConfig: ConfigureEvmEnv,
     {
         self.provider()?.fill_env_with_header(cfg, block_env, header, evm_config)
     }
@@ -487,7 +487,7 @@ impl<DB: Database> EvmEnvProvider for ProviderFactory<DB> {
         evm_config: EvmConfig,
     ) -> ProviderResult<()>
     where
-        EvmConfig: EvmEnvConfig,
+        EvmConfig: ConfigureEvmEnv,
     {
         self.provider()?.fill_cfg_env_at(cfg, at, evm_config)
     }
@@ -499,7 +499,7 @@ impl<DB: Database> EvmEnvProvider for ProviderFactory<DB> {
         evm_config: EvmConfig,
     ) -> ProviderResult<()>
     where
-        EvmConfig: EvmEnvConfig,
+        EvmConfig: ConfigureEvmEnv,
     {
         self.provider()?.fill_cfg_env_with_header(cfg, header, evm_config)
     }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -31,7 +31,7 @@ use reth_interfaces::{
     provider::{ProviderResult, RootMismatch},
     RethError, RethResult,
 };
-use reth_node_api::EvmEnvConfig;
+use reth_node_api::ConfigureEvmEnv;
 use reth_primitives::{
     keccak256,
     revm::{config::revm_spec, env::fill_block_env},
@@ -1735,7 +1735,7 @@ impl<TX: DbTx> EvmEnvProvider for DatabaseProvider<TX> {
         evm_config: EvmConfig,
     ) -> ProviderResult<()>
     where
-        EvmConfig: EvmEnvConfig,
+        EvmConfig: ConfigureEvmEnv,
     {
         let hash = self.convert_number(at)?.ok_or(ProviderError::HeaderNotFound(at))?;
         let header = self.header(&hash)?.ok_or(ProviderError::HeaderNotFound(at))?;
@@ -1750,7 +1750,7 @@ impl<TX: DbTx> EvmEnvProvider for DatabaseProvider<TX> {
         _evm_config: EvmConfig,
     ) -> ProviderResult<()>
     where
-        EvmConfig: EvmEnvConfig,
+        EvmConfig: ConfigureEvmEnv,
     {
         let total_difficulty = self
             .header_td_by_number(header.number)?
@@ -1807,7 +1807,7 @@ impl<TX: DbTx> EvmEnvProvider for DatabaseProvider<TX> {
         evm_config: EvmConfig,
     ) -> ProviderResult<()>
     where
-        EvmConfig: EvmEnvConfig,
+        EvmConfig: ConfigureEvmEnv,
     {
         let hash = self.convert_number(at)?.ok_or(ProviderError::HeaderNotFound(at))?;
         let header = self.header(&hash)?.ok_or(ProviderError::HeaderNotFound(at))?;
@@ -1821,7 +1821,7 @@ impl<TX: DbTx> EvmEnvProvider for DatabaseProvider<TX> {
         _evm_config: EvmConfig,
     ) -> ProviderResult<()>
     where
-        EvmConfig: EvmEnvConfig,
+        EvmConfig: ConfigureEvmEnv,
     {
         let total_difficulty = self
             .header_td_by_number(header.number)?

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -13,7 +13,7 @@ use reth_interfaces::{
     provider::ProviderResult,
     RethError, RethResult,
 };
-use reth_node_api::EvmEnvConfig;
+use reth_node_api::ConfigureEvmEnv;
 use reth_primitives::{
     stage::{StageCheckpoint, StageId},
     Account, Address, Block, BlockHash, BlockHashOrNumber, BlockId, BlockNumHash, BlockNumber,
@@ -466,7 +466,7 @@ where
         evm_config: EvmConfig,
     ) -> ProviderResult<()>
     where
-        EvmConfig: EvmEnvConfig,
+        EvmConfig: ConfigureEvmEnv,
     {
         self.database.provider()?.fill_env_at(cfg, block_env, at, evm_config)
     }
@@ -479,7 +479,7 @@ where
         evm_config: EvmConfig,
     ) -> ProviderResult<()>
     where
-        EvmConfig: EvmEnvConfig,
+        EvmConfig: ConfigureEvmEnv,
     {
         self.database.provider()?.fill_env_with_header(cfg, block_env, header, evm_config)
     }
@@ -507,7 +507,7 @@ where
         evm_config: EvmConfig,
     ) -> ProviderResult<()>
     where
-        EvmConfig: EvmEnvConfig,
+        EvmConfig: ConfigureEvmEnv,
     {
         self.database.provider()?.fill_cfg_env_at(cfg, at, evm_config)
     }
@@ -519,7 +519,7 @@ where
         evm_config: EvmConfig,
     ) -> ProviderResult<()>
     where
-        EvmConfig: EvmEnvConfig,
+        EvmConfig: ConfigureEvmEnv,
     {
         self.database.provider()?.fill_cfg_env_with_header(cfg, header, evm_config)
     }

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -9,7 +9,7 @@ use crate::{
 use parking_lot::Mutex;
 use reth_db::models::{AccountBeforeTx, StoredBlockBodyIndices};
 use reth_interfaces::provider::{ProviderError, ProviderResult};
-use reth_node_api::EvmEnvConfig;
+use reth_node_api::ConfigureEvmEnv;
 use reth_primitives::{
     keccak256, trie::AccountProof, Account, Address, Block, BlockHash, BlockHashOrNumber, BlockId,
     BlockNumber, BlockWithSenders, Bytecode, Bytes, ChainInfo, ChainSpec, Header, Receipt,
@@ -564,7 +564,7 @@ impl EvmEnvProvider for MockEthProvider {
         _evm_config: EvmConfig,
     ) -> ProviderResult<()>
     where
-        EvmConfig: EvmEnvConfig,
+        EvmConfig: ConfigureEvmEnv,
     {
         Ok(())
     }
@@ -577,7 +577,7 @@ impl EvmEnvProvider for MockEthProvider {
         _evm_config: EvmConfig,
     ) -> ProviderResult<()>
     where
-        EvmConfig: EvmEnvConfig,
+        EvmConfig: ConfigureEvmEnv,
     {
         Ok(())
     }
@@ -605,7 +605,7 @@ impl EvmEnvProvider for MockEthProvider {
         _evm_config: EvmConfig,
     ) -> ProviderResult<()>
     where
-        EvmConfig: EvmEnvConfig,
+        EvmConfig: ConfigureEvmEnv,
     {
         Ok(())
     }
@@ -617,7 +617,7 @@ impl EvmEnvProvider for MockEthProvider {
         _evm_config: EvmConfig,
     ) -> ProviderResult<()>
     where
-        EvmConfig: EvmEnvConfig,
+        EvmConfig: ConfigureEvmEnv,
     {
         Ok(())
     }

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use reth_db::models::{AccountBeforeTx, StoredBlockBodyIndices};
 use reth_interfaces::provider::ProviderResult;
-use reth_node_api::EvmEnvConfig;
+use reth_node_api::ConfigureEvmEnv;
 use reth_primitives::{
     stage::{StageCheckpoint, StageId},
     trie::AccountProof,
@@ -324,7 +324,7 @@ impl EvmEnvProvider for NoopProvider {
         _evm_config: EvmConfig,
     ) -> ProviderResult<()>
     where
-        EvmConfig: EvmEnvConfig,
+        EvmConfig: ConfigureEvmEnv,
     {
         Ok(())
     }
@@ -337,7 +337,7 @@ impl EvmEnvProvider for NoopProvider {
         _evm_config: EvmConfig,
     ) -> ProviderResult<()>
     where
-        EvmConfig: EvmEnvConfig,
+        EvmConfig: ConfigureEvmEnv,
     {
         Ok(())
     }
@@ -365,7 +365,7 @@ impl EvmEnvProvider for NoopProvider {
         _evm_config: EvmConfig,
     ) -> ProviderResult<()>
     where
-        EvmConfig: EvmEnvConfig,
+        EvmConfig: ConfigureEvmEnv,
     {
         Ok(())
     }
@@ -377,7 +377,7 @@ impl EvmEnvProvider for NoopProvider {
         _evm_config: EvmConfig,
     ) -> ProviderResult<()>
     where
-        EvmConfig: EvmEnvConfig,
+        EvmConfig: ConfigureEvmEnv,
     {
         Ok(())
     }

--- a/crates/storage/provider/src/traits/evm_env.rs
+++ b/crates/storage/provider/src/traits/evm_env.rs
@@ -1,5 +1,5 @@
 use reth_interfaces::provider::ProviderResult;
-use reth_node_api::EvmEnvConfig;
+use reth_node_api::ConfigureEvmEnv;
 use reth_primitives::{BlockHashOrNumber, Header};
 use revm::primitives::{BlockEnv, CfgEnv};
 
@@ -19,7 +19,7 @@ pub trait EvmEnvProvider: Send + Sync {
         evm_config: EvmConfig,
     ) -> ProviderResult<()>
     where
-        EvmConfig: EvmEnvConfig;
+        EvmConfig: ConfigureEvmEnv;
 
     /// Fills the default [CfgEnv] and [BlockEnv] fields with values specific to the given [Header].
     fn env_with_header<EvmConfig>(
@@ -28,7 +28,7 @@ pub trait EvmEnvProvider: Send + Sync {
         evm_config: EvmConfig,
     ) -> ProviderResult<(CfgEnv, BlockEnv)>
     where
-        EvmConfig: EvmEnvConfig,
+        EvmConfig: ConfigureEvmEnv,
     {
         let mut cfg = CfgEnv::default();
         let mut block_env = BlockEnv::default();
@@ -45,7 +45,7 @@ pub trait EvmEnvProvider: Send + Sync {
         evm_config: EvmConfig,
     ) -> ProviderResult<()>
     where
-        EvmConfig: EvmEnvConfig;
+        EvmConfig: ConfigureEvmEnv;
 
     /// Fills the [BlockEnv] fields with values specific to the given [BlockHashOrNumber].
     fn fill_block_env_at(
@@ -69,7 +69,7 @@ pub trait EvmEnvProvider: Send + Sync {
         evm_config: EvmConfig,
     ) -> ProviderResult<()>
     where
-        EvmConfig: EvmEnvConfig;
+        EvmConfig: ConfigureEvmEnv;
 
     /// Fills the [CfgEnv] fields with values specific to the given [Header].
     fn fill_cfg_env_with_header<EvmConfig>(
@@ -79,5 +79,5 @@ pub trait EvmEnvProvider: Send + Sync {
         evm_config: EvmConfig,
     ) -> ProviderResult<()>
     where
-        EvmConfig: EvmEnvConfig;
+        EvmConfig: ConfigureEvmEnv;
 }


### PR DESCRIPTION
fixes https://github.com/paradigmxyz/reth/issues/6420

This renames `EvmEnvConfig` to `ConfigureEvmEnv`, I'm not yet sure whether or not the rest of the traits should be renamed:
*  `PayloadBuilderAttributes`
* `PayloadAttributes`
* `EngineTypes`