### PR TITLE
ci: tmp pin nightly version

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -58,6 +58,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly-2024-02-03
       - name: Install mdbook
         run: |
           mkdir mdbook

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -33,7 +33,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
-
+        with:
+          toolchain: nightly-2024-02-03
       - name: cargo update
         # Remove first line that always just says "Updating crates.io index"
         run: cargo update --color never 2>&1 | sed '/crates.io index/d' | tee -a cargo_update.log

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@clippy
+        with:
+          toolchain: nightly-2024-02-03
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -39,6 +41,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@clippy
+        with:
+          toolchain: nightly-2024-02-03
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -77,6 +81,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly-2024-02-03
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -96,6 +102,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:
+          toolchain: nightly-2024-02-03
           components: rustfmt
       - run: cargo fmt --all --check
 

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly-2024-02-03
       - uses: taiki-e/install-action@cargo-udeps
       - name: Check for unused dependencies
         run: cargo udeps --lib --features "jemalloc,${{ matrix.network }}"


### PR DESCRIPTION
latest nightly broke CI

https://github.com/paradigmxyz/reth/actions/runs/7793371136/job/21253001107?pr=6433

tmp pin toolchain to latest working version
