### PR TITLE
feat: add txpool eviction property tests

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -268,6 +268,11 @@ where
     pub fn is_empty(&self) -> bool {
         self.pool.is_empty()
     }
+
+    /// Returns whether or not the pool is over its configured size and transaction count limits.
+    pub fn is_exceeded(&self) -> bool {
+        self.pool.is_exceeded()
+    }
 }
 
 impl<Client, S> EthTransactionPool<Client, S>

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -17,7 +17,7 @@ use crate::{
     TransactionValidationOutcome, TransactionValidator, ValidPoolTransaction,
 };
 use reth_eth_wire::HandleAnnouncement;
-use reth_primitives::{Address, BlobTransactionSidecar, TxHash};
+use reth_primitives::{Address, BlobTransactionSidecar, TxHash, U256};
 use std::{collections::HashSet, marker::PhantomData, sync::Arc};
 use tokio::sync::{mpsc, mpsc::Receiver};
 
@@ -263,8 +263,10 @@ impl<T: PoolTransaction> TransactionValidator for MockTransactionValidator<T> {
             )
         }
 
+        // we return `balance: U256::MAX` to simulate a valid transaction which will never go into
+        // overdraft
         TransactionValidationOutcome::Valid {
-            balance: Default::default(),
+            balance: U256::MAX,
             state_nonce: 0,
             transaction: ValidTransaction::Valid(transaction),
             propagate: match origin {

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -739,6 +739,11 @@ where
         self.get_pool_data().is_empty()
     }
 
+    /// Returns whether or not the pool is over its configured size and transaction count limits.
+    pub(crate) fn is_exceeded(&self) -> bool {
+        self.pool.read().is_exceeded()
+    }
+
     /// Enforces the size limits of pool and returns the discarded transactions if violated.
     ///
     /// If some of the transactions are blob transactions, they are also removed from the blob

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -1345,7 +1345,6 @@ impl<T: PoolTransaction> AllTransactions<T> {
                 }
             }
         } else if new_blob_tx.cost() > on_chain_balance {
-            println!("new_blob_tx: {:?} would go into overdraft, cumulative_cost: {}, bal: {on_chain_balance}", new_blob_tx, new_blob_tx.cost());
             // the transaction would go into overdraft
             return Err(InsertErr::Overdraft { transaction: Arc::new(new_blob_tx) })
         }

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -78,7 +78,7 @@ pub struct TxPool<T: TransactionOrdering> {
 
 impl<T: TransactionOrdering> TxPool<T> {
     /// Create a new graph pool instance.
-    pub(crate) fn new(ordering: T, config: PoolConfig) -> Self {
+    pub fn new(ordering: T, config: PoolConfig) -> Self {
         Self {
             sender_info: Default::default(),
             pending_pool: PendingPool::new(ordering),
@@ -116,7 +116,7 @@ impl<T: TransactionOrdering> TxPool<T> {
     }
 
     /// Returns stats about the size of pool.
-    pub(crate) fn size(&self) -> PoolSize {
+    pub fn size(&self) -> PoolSize {
         PoolSize {
             pending: self.pending_pool.len(),
             pending_size: self.pending_pool.size(),
@@ -131,7 +131,7 @@ impl<T: TransactionOrdering> TxPool<T> {
     }
 
     /// Returns the currently tracked block values
-    pub(crate) const fn block_info(&self) -> BlockInfo {
+    pub const fn block_info(&self) -> BlockInfo {
         BlockInfo {
             last_seen_block_hash: self.all_transactions.last_seen_block_hash,
             last_seen_block_number: self.all_transactions.last_seen_block_number,
@@ -271,7 +271,7 @@ impl<T: TransactionOrdering> TxPool<T> {
     /// Sets the current block info for the pool.
     ///
     /// This will also apply updates to the pool based on the new base fee
-    pub(crate) fn set_block_info(&mut self, info: BlockInfo) {
+    pub fn set_block_info(&mut self, info: BlockInfo) {
         let BlockInfo {
             last_seen_block_hash,
             last_seen_block_number,
@@ -355,6 +355,12 @@ impl<T: TransactionOrdering> TxPool<T> {
             SubPool::BaseFee => self.basefee_pool.contains(id),
             SubPool::Blob => self.blob_pool.contains(id),
         }
+    }
+
+    /// Returns `true` if the pool is over its configured limits.
+    #[inline]
+    pub(crate) fn is_exceeded(&self) -> bool {
+        self.config.is_exceeded(self.size())
     }
 
     /// Returns the transaction for the given hash.
@@ -1339,6 +1345,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
                 }
             }
         } else if new_blob_tx.cost() > on_chain_balance {
+            println!("new_blob_tx: {:?} would go into overdraft, cumulative_cost: {}, bal: {on_chain_balance}", new_blob_tx, new_blob_tx.cost());
             // the transaction would go into overdraft
             return Err(InsertErr::Overdraft { transaction: Arc::new(new_blob_tx) })
         }

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -1325,10 +1325,10 @@ impl MockFeeRange {
 }
 
 /// A configured distribution that can generate transactions
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MockTransactionDistribution {
     /// ratio of each transaction type to generate
-    transaction_ratio: WeightedIndex<u32>,
+    transaction_ratio: MockTransactionRatio,
     /// generates the gas limit
     gas_limit_range: Uniform<u64>,
     /// generates the transaction's fake size
@@ -1346,7 +1346,7 @@ impl MockTransactionDistribution {
         size_range: Range<usize>,
     ) -> Self {
         Self {
-            transaction_ratio: transaction_ratio.weighted_index(),
+            transaction_ratio,
             gas_limit_range: gas_limit_range.into(),
             fee_ranges,
             size_range: size_range.into(),
@@ -1355,7 +1355,8 @@ impl MockTransactionDistribution {
 
     /// Generates a new transaction
     pub fn tx(&self, nonce: u64, rng: &mut impl rand::Rng) -> MockTransaction {
-        let tx = match self.transaction_ratio.sample(rng) {
+        let transaction_sample = self.transaction_ratio.weighted_index().sample(rng);
+        let tx = match transaction_sample {
             0 => MockTransaction::legacy().with_gas_price(self.fee_ranges.sample_gas_price(rng)),
             1 => MockTransaction::eip2930().with_gas_price(self.fee_ranges.sample_gas_price(rng)),
             2 => MockTransaction::eip1559()
@@ -1387,6 +1388,110 @@ impl MockTransactionDistribution {
             txs.push(self.tx(nonce, rng).with_sender(sender));
         }
         MockTransactionSet::new(txs)
+    }
+
+    /// Generates a transaction set that ensures that blob txs are not mixed with other transaction
+    /// types.
+    ///
+    /// This is done by taking the existing distribution, and using the first transaction to
+    /// determine whether or not the sender should generate entirely blob transactions.
+    pub fn tx_set_non_conflicting_types(
+        &self,
+        sender: Address,
+        nonce_range: Range<u64>,
+        rng: &mut impl rand::Rng,
+    ) -> NonConflictingSetOutcome {
+        // This will create a modified distribution that will only generate blob transactions
+        // for the given sender, if the blob transaction is the first transaction in the set.
+        //
+        // Otherwise, it will modify the transaction distribution to only generate legacy, eip2930,
+        // and eip1559 transactions.
+        //
+        // The new distribution should still have the same relative amount of transaction types.
+        let mut modified_distribution = self.clone();
+        let first_tx = self.tx(nonce_range.start, rng);
+
+        // now we can check and modify the distribution, preserving potentially uneven ratios
+        // between transaction types
+        if first_tx.is_eip4844() {
+            modified_distribution.transaction_ratio = MockTransactionRatio {
+                legacy_pct: 0,
+                access_list_pct: 0,
+                dynamic_fee_pct: 0,
+                blob_pct: 100,
+            };
+
+            // finally generate the transaction set
+            NonConflictingSetOutcome::Mixed(modified_distribution.tx_set(sender, nonce_range, rng))
+        } else {
+            let MockTransactionRatio { legacy_pct, access_list_pct, dynamic_fee_pct, .. } =
+                modified_distribution.transaction_ratio;
+
+            // Calculate the total weight of non-blob transactions
+            let total_non_blob_weight: u32 = legacy_pct + access_list_pct + dynamic_fee_pct;
+
+            // Calculate new weights, preserving the ratio between non-blob transaction types
+            let new_weights: Vec<u32> = [legacy_pct, access_list_pct, dynamic_fee_pct]
+                .into_iter()
+                .map(|weight| weight * 100 / total_non_blob_weight)
+                .collect();
+
+            let new_ratio = MockTransactionRatio {
+                legacy_pct: new_weights[0],
+                access_list_pct: new_weights[1],
+                dynamic_fee_pct: new_weights[2],
+                blob_pct: 0,
+            };
+
+            // Set the new transaction ratio excluding blob transactions and preserving the relative
+            // ratios
+            modified_distribution.transaction_ratio = new_ratio;
+
+            // finally generate the transaction set
+            NonConflictingSetOutcome::BlobsOnly(modified_distribution.tx_set(
+                sender,
+                nonce_range,
+                rng,
+            ))
+        }
+    }
+}
+
+/// Indicates whether or not the non-conflicting transaction set generated includes only blobs, or
+/// a mix of transaction types.
+#[derive(Debug, Clone)]
+pub enum NonConflictingSetOutcome {
+    /// The transaction set includes only blob transactions
+    BlobsOnly(MockTransactionSet),
+    /// The transaction set includes a mix of transaction types
+    Mixed(MockTransactionSet),
+}
+
+impl NonConflictingSetOutcome {
+    /// Returns the inner [MockTransactionSet]
+    pub fn into_inner(self) -> MockTransactionSet {
+        match self {
+            NonConflictingSetOutcome::BlobsOnly(set) | NonConflictingSetOutcome::Mixed(set) => set,
+        }
+    }
+
+    /// Introduces artificial nonce gaps into the transaction set, at random, with a range of gap
+    /// sizes.
+    ///
+    /// If this is a [NonConflictingSetOutcome::BlobsOnly], then nonce gaps will not be introduced.
+    /// Otherwise, the nonce gaps will be introduced to the mixed transaction set.
+    ///
+    /// See [MockTransactionSet::with_nonce_gaps] for more information on the generation process.
+    pub fn with_nonce_gaps(
+        &mut self,
+        gap_pct: u32,
+        gap_range: Range<u64>,
+        rng: &mut impl rand::Rng,
+    ) {
+        match self {
+            NonConflictingSetOutcome::BlobsOnly(_) => {}
+            NonConflictingSetOutcome::Mixed(set) => set.with_nonce_gaps(gap_pct, gap_range, rng),
+        }
     }
 }
 
@@ -1430,6 +1535,39 @@ impl MockTransactionSet {
         tx_type: TxType,
     ) -> Self {
         Self::dependent(sender, 0, tx_count, tx_type)
+    }
+
+    /// Introduces artificial nonce gaps into the transaction set, at random, with a range of gap
+    /// sizes.
+    ///
+    /// This assumes that the `gap_pct` is between 0 and 100, and the `gap_range` has a lower bound
+    /// of at least one. This is enforced with assertions.
+    ///
+    /// The `gap_pct` is the percent chance that the next transaction in the set will introduce a
+    /// nonce gap.
+    ///
+    /// Let an example transaction set be `[(tx1, 1), (tx2, 2)]`, where the first element of the
+    /// tuple is a transaction, and the second element is the nonce. If the `gap_pct` is 50, and
+    /// the `gap_range` is `1..=1`, then the resulting transaction set could would be either
+    /// `[(tx1, 1), (tx2, 2)]` or `[(tx1, 1), (tx2, 3)]`, with a 50% chance of either.
+    pub fn with_nonce_gaps(
+        &mut self,
+        gap_pct: u32,
+        gap_range: Range<u64>,
+        rng: &mut impl rand::Rng,
+    ) {
+        assert!(gap_pct <= 100, "gap_pct must be between 0 and 100");
+        assert!(gap_range.start >= 1, "gap_range must have a lower bound of at least one");
+
+        let mut prev_nonce = 0;
+        for tx in self.transactions.iter_mut() {
+            if rng.gen_bool(gap_pct as f64 / 100.0) {
+                prev_nonce += gap_range.start;
+            } else {
+                prev_nonce += 1;
+            }
+            tx.set_nonce(prev_nonce);
+        }
     }
 
     /// Add transactions to the [MockTransactionSet]

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -1422,7 +1422,11 @@ impl MockTransactionDistribution {
             };
 
             // finally generate the transaction set
-            NonConflictingSetOutcome::Mixed(modified_distribution.tx_set(sender, nonce_range, rng))
+            NonConflictingSetOutcome::BlobsOnly(modified_distribution.tx_set(
+                sender,
+                nonce_range,
+                rng,
+            ))
         } else {
             let MockTransactionRatio { legacy_pct, access_list_pct, dynamic_fee_pct, .. } =
                 modified_distribution.transaction_ratio;
@@ -1448,11 +1452,7 @@ impl MockTransactionDistribution {
             modified_distribution.transaction_ratio = new_ratio;
 
             // finally generate the transaction set
-            NonConflictingSetOutcome::BlobsOnly(modified_distribution.tx_set(
-                sender,
-                nonce_range,
-                rng,
-            ))
+            NonConflictingSetOutcome::Mixed(modified_distribution.tx_set(sender, nonce_range, rng))
         }
     }
 }

--- a/crates/transaction-pool/tests/it/evict.rs
+++ b/crates/transaction-pool/tests/it/evict.rs
@@ -14,7 +14,6 @@ use reth_transaction_pool::{
 async fn only_blobs_eviction() {
     // This test checks that blob transactions can be inserted into the pool, and at each step the
     // blob pool can be truncated to the correct size
-    // TODO: try this with other transaction ratios
 
     // set the pool limits to something small
     let pool_config = PoolConfig {

--- a/crates/transaction-pool/tests/it/evict.rs
+++ b/crates/transaction-pool/tests/it/evict.rs
@@ -52,7 +52,6 @@ async fn only_blobs_eviction() {
     // Vary the amount of senders
     let senders = [1, 10, 100, total_txs];
     for sender_amt in &senders {
-        // TODO: set this based on something, also impl default
         let gas_limit_range = 100_000..1_000_000;
 
         // split the total txs into the amount of senders
@@ -108,23 +107,232 @@ async fn only_blobs_eviction() {
                                 // ensure that this is only returned when the sender is over the
                                 // pool limit per account
                                 if i + 1 < pool_config.max_account_slots {
-                                    // TODO: remove printlns
-                                    panic!("❌ Spammer exceeded capacity, but it shouldn't have");
+                                    panic!("Spammer exceeded capacity, but it shouldn't have. Max accounts slots: {}, current txs by sender: {}", pool_config.max_account_slots, i + 1);
                                 }
-
-                                println!("✅ Spammer exceeded capacity, like they should have");
+                                // at this point we know that the sender has been limited, so we
+                                // keep going
                             }
                             _ => {
-                                panic!(
-                                    "❌ Failed to insert tx into pool with unexpected error: {e}"
-                                );
+                                panic!("Failed to insert tx into pool with unexpected error: {e}");
                             }
                         }
                     }
                 }
             }
 
-            // after every transaction, ensure that it's under the pool limits
+            // after every insert, ensure that it's under the pool limits
+            assert!(!pool.is_exceeded());
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mixed_eviction() {
+    // This test checks that many transaction types can be inserted into the pool. The fees need
+    // to be set so that the transactions will actually pass validation. Transactions here do not
+    // have nonce gaps.
+    let pool_config = PoolConfig {
+        pending_limit: SubPoolLimit { max_txs: 20, max_size: 2000 },
+        queued_limit: SubPoolLimit { max_txs: 20, max_size: 2000 },
+        basefee_limit: SubPoolLimit { max_txs: 20, max_size: 2000 },
+        blob_limit: SubPoolLimit { max_txs: 20, max_size: 2000 },
+        ..Default::default()
+    };
+
+    let pool: TestPool = TestPoolBuilder::default().with_config(pool_config.clone()).into();
+    let block_info = BlockInfo {
+        last_seen_block_hash: B256::ZERO,
+        last_seen_block_number: 0,
+        pending_basefee: 10,
+        pending_blob_fee: Some(20),
+    };
+    pool.set_block_info(block_info);
+
+    let total_txs = 100;
+    let size_range = 10..1100;
+
+    // Adjust the ratios to include a mix of transaction types
+    let tx_ratio = MockTransactionRatio {
+        legacy_pct: 25,
+        dynamic_fee_pct: 25,
+        blob_pct: 25,
+        access_list_pct: 25,
+    };
+
+    let senders = [1, 5, 10];
+    for sender_amt in &senders {
+        let gas_limit_range = 100_000..1_000_000;
+        let txs_per_sender = total_txs / sender_amt;
+        let nonce_range = 0..txs_per_sender;
+        let pending_blob_fee = block_info.pending_blob_fee.unwrap();
+
+        // Make sure transactions are not immediately rejected
+        let min_gas_price = block_info.pending_basefee as u128 + 1;
+        let min_priority_fee = 1u128;
+        let min_max_fee = block_info.pending_basefee as u128 + 10;
+
+        let fee_range = MockFeeRange {
+            gas_price: Uniform::from(min_gas_price..(min_gas_price + 1000)),
+            priority_fee: Uniform::from(min_priority_fee..(min_priority_fee + 1000)),
+            max_fee: Uniform::from(min_max_fee..(min_max_fee + 2000)),
+            max_fee_blob: Uniform::from(pending_blob_fee..(pending_blob_fee + 1000)),
+        };
+
+        let distribution = MockTransactionDistribution::new(
+            tx_ratio.clone(),
+            fee_range,
+            gas_limit_range,
+            size_range.clone(),
+        );
+
+        for _ in 0..*sender_amt {
+            let sender = Address::random();
+            let set = distribution.tx_set_non_conflicting_types(
+                sender,
+                nonce_range.clone(),
+                &mut rand::thread_rng(),
+            );
+
+            let set = set.into_inner().into_vec();
+            assert_eq!(set[0].get_nonce(), 0);
+
+            let results = pool.add_transactions(TransactionOrigin::External, set).await;
+            for (i, result) in results.iter().enumerate() {
+                match result {
+                    Ok(_) => {
+                        // Transaction inserted successfully
+                    }
+                    Err(e) => {
+                        match e.kind {
+                            PoolErrorKind::DiscardedOnInsert => {
+                                // Transaction discarded on insert
+                                println!("✅ Discarded tx on insert, like we should have");
+                            }
+                            PoolErrorKind::SpammerExceededCapacity(addr) => {
+                                // ensure the address is the same as the sender
+                                assert_eq!(addr, sender);
+
+                                // ensure that this is only returned when the sender is over the
+                                // pool limit per account
+                                if i + 1 < pool_config.max_account_slots {
+                                    panic!("Spammer exceeded capacity, but it shouldn't have. Max accounts slots: {}, current txs by sender: {}", pool_config.max_account_slots, i + 1);
+                                }
+                            }
+                            _ => panic!("Failed to insert tx into pool with unexpected error: {e}"),
+                        }
+                    }
+                }
+            }
+
+            assert!(!pool.is_exceeded());
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn nonce_gaps_eviction() {
+    // This test checks that many transaction types can be inserted into the pool.
+    //
+    // This test also inserts nonce gaps into the non-blob transactions.
+    let pool_config = PoolConfig {
+        pending_limit: SubPoolLimit { max_txs: 20, max_size: 2000 },
+        queued_limit: SubPoolLimit { max_txs: 20, max_size: 2000 },
+        basefee_limit: SubPoolLimit { max_txs: 20, max_size: 2000 },
+        blob_limit: SubPoolLimit { max_txs: 20, max_size: 2000 },
+        ..Default::default()
+    };
+
+    let pool: TestPool = TestPoolBuilder::default().with_config(pool_config.clone()).into();
+    let block_info = BlockInfo {
+        last_seen_block_hash: B256::ZERO,
+        last_seen_block_number: 0,
+        pending_basefee: 10,
+        pending_blob_fee: Some(20),
+    };
+    pool.set_block_info(block_info);
+
+    let total_txs = 100;
+    let size_range = 10..1100;
+
+    // Adjust the ratios to include a mix of transaction types
+    let tx_ratio = MockTransactionRatio {
+        legacy_pct: 25,
+        dynamic_fee_pct: 25,
+        blob_pct: 25,
+        access_list_pct: 25,
+    };
+
+    let senders = [1, 5, 10];
+    for sender_amt in &senders {
+        let gas_limit_range = 100_000..1_000_000;
+        let txs_per_sender = total_txs / sender_amt;
+        let nonce_range = 0..txs_per_sender;
+        let pending_blob_fee = block_info.pending_blob_fee.unwrap();
+
+        // Make sure transactions are not immediately rejected
+        let min_gas_price = block_info.pending_basefee as u128 + 1;
+        let min_priority_fee = 1u128;
+        let min_max_fee = block_info.pending_basefee as u128 + 10;
+
+        let fee_range = MockFeeRange {
+            gas_price: Uniform::from(min_gas_price..(min_gas_price + 1000)),
+            priority_fee: Uniform::from(min_priority_fee..(min_priority_fee + 1000)),
+            max_fee: Uniform::from(min_max_fee..(min_max_fee + 2000)),
+            max_fee_blob: Uniform::from(pending_blob_fee..(pending_blob_fee + 1000)),
+        };
+
+        let distribution = MockTransactionDistribution::new(
+            tx_ratio.clone(),
+            fee_range,
+            gas_limit_range,
+            size_range.clone(),
+        );
+
+        // set up gap percentages and sizes, 30% chance for transactions to be followed by a gap,
+        // and the gap size is between 1 and 5
+        let gap_pct = 30;
+        let gap_range = 1u64..6;
+
+        for _ in 0..*sender_amt {
+            let sender = Address::random();
+
+            let mut set = distribution.tx_set_non_conflicting_types(
+                sender,
+                nonce_range.clone(),
+                &mut rand::thread_rng(),
+            );
+
+            set.with_nonce_gaps(gap_pct, gap_range.clone(), &mut rand::thread_rng());
+            let set = set.into_inner().into_vec();
+
+            let results = pool.add_transactions(TransactionOrigin::External, set).await;
+            for (i, result) in results.iter().enumerate() {
+                match result {
+                    Ok(_) => {
+                        // Transaction inserted successfully
+                    }
+                    Err(e) => {
+                        match e.kind {
+                            PoolErrorKind::DiscardedOnInsert => {
+                                // Transaction discarded on insert
+                                println!("✅ Discarded tx on insert, like we should have");
+                            }
+                            PoolErrorKind::SpammerExceededCapacity(addr) => {
+                                // ensure the address is the same as the sender
+                                assert_eq!(addr, sender);
+
+                                // ensure that this is only returned when the sender is over the
+                                // pool limit per account
+                                if i + 1 < pool_config.max_account_slots {
+                                    panic!("Spammer exceeded capacity, but it shouldn't have. Max accounts slots: {}, current txs by sender: {}", pool_config.max_account_slots, i + 1);
+                                }
+                            }
+                            _ => panic!("Failed to insert tx into pool with unexpected error: {e}"),
+                        }
+                    }
+                }
+            }
+
             assert!(!pool.is_exceeded());
         }
     }

--- a/crates/transaction-pool/tests/it/evict.rs
+++ b/crates/transaction-pool/tests/it/evict.rs
@@ -1,0 +1,131 @@
+//! Transaction pool eviction tests.
+
+use rand::distributions::Uniform;
+use reth_primitives::{constants::MIN_PROTOCOL_BASE_FEE, Address, B256};
+use reth_transaction_pool::{
+    error::PoolErrorKind,
+    test_utils::{
+        MockFeeRange, MockTransactionDistribution, MockTransactionRatio, TestPool, TestPoolBuilder,
+    },
+    BlockInfo, PoolConfig, SubPoolLimit, TransactionOrigin, TransactionPool, TransactionPoolExt,
+};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn only_blobs_eviction() {
+    // This test checks that blob transactions can be inserted into the pool, and at each step the
+    // blob pool can be truncated to the correct size
+    // TODO: try this with other transaction ratios
+
+    // set the pool limits to something small
+    let pool_config = PoolConfig {
+        pending_limit: SubPoolLimit { max_txs: 10, max_size: 1000 },
+        queued_limit: SubPoolLimit { max_txs: 10, max_size: 1000 },
+        basefee_limit: SubPoolLimit { max_txs: 10, max_size: 1000 },
+        blob_limit: SubPoolLimit { max_txs: 10, max_size: 1000 },
+        ..Default::default()
+    };
+
+    let pool: TestPool = TestPoolBuilder::default().with_config(pool_config.clone()).into();
+    let block_info = BlockInfo {
+        last_seen_block_hash: B256::ZERO,
+        last_seen_block_number: 0,
+        pending_basefee: 10,
+        pending_blob_fee: Some(10),
+    };
+    pool.set_block_info(block_info);
+
+    // this is how many times the test will regenerate transactions and insert them into the pool
+    let total_txs = 1000;
+
+    // If we have a wide size range we can cover cases both where we have a lot of small txs and a
+    // lot of large txs
+    let size_range = 10..1100;
+
+    // create mock tx distribution, 100% blobs
+    let tx_ratio = MockTransactionRatio {
+        legacy_pct: 0,
+        dynamic_fee_pct: 0,
+        blob_pct: 100,
+        access_list_pct: 0,
+    };
+
+    // Vary the amount of senders
+    let senders = [1, 10, 100, total_txs];
+    for sender_amt in &senders {
+        // TODO: set this based on something, also impl default
+        let gas_limit_range = 100_000..1_000_000;
+
+        // split the total txs into the amount of senders
+        let txs_per_sender = total_txs / sender_amt;
+        let nonce_range = 0..txs_per_sender;
+        let pending_blob_fee = block_info.pending_blob_fee.unwrap();
+
+        // start the fees at zero, some transactions will be underpriced
+        let fee_range = MockFeeRange {
+            gas_price: Uniform::from(0u128..(block_info.pending_basefee as u128 + 1000)),
+            priority_fee: Uniform::from(0u128..(block_info.pending_basefee as u128 + 1000)),
+            // we need to set the max fee to at least the min protocol base fee, or transactions
+            // generated could be rejected
+            max_fee: Uniform::from(
+                MIN_PROTOCOL_BASE_FEE as u128..(block_info.pending_basefee as u128 + 2000),
+            ),
+            max_fee_blob: Uniform::from(pending_blob_fee..(pending_blob_fee + 1000)),
+        };
+
+        let distribution = MockTransactionDistribution::new(
+            tx_ratio.clone(),
+            fee_range,
+            gas_limit_range,
+            size_range.clone(),
+        );
+
+        for _ in 0..*sender_amt {
+            // use a random sender, create the tx set
+            let sender = Address::random();
+            let set = distribution.tx_set(sender, nonce_range.clone(), &mut rand::thread_rng());
+
+            let set = set.into_vec();
+
+            // ensure that the first nonce is 0
+            assert_eq!(set[0].get_nonce(), 0);
+
+            // and finally insert it into the pool
+            let results = pool.add_transactions(TransactionOrigin::External, set).await;
+            for (i, result) in results.iter().enumerate() {
+                match result {
+                    Ok(hash) => {
+                        println!("✅ Inserted tx into pool with hash: {hash}");
+                    }
+                    Err(e) => {
+                        match e.kind {
+                            PoolErrorKind::DiscardedOnInsert => {
+                                println!("✅ Discarded tx on insert, like we should have");
+                            }
+                            PoolErrorKind::SpammerExceededCapacity(addr) => {
+                                // ensure the address is the same as the sender
+                                assert_eq!(addr, sender);
+
+                                // ensure that this is only returned when the sender is over the
+                                // pool limit per account
+                                if i + 1 < pool_config.max_account_slots {
+                                    // TODO: remove printlns
+                                    panic!("❌ Spammer exceeded capacity, but it shouldn't have");
+                                }
+
+                                println!("✅ Spammer exceeded capacity, like they should have");
+                            }
+                            _ => {
+                                panic!(
+                                    "❌ Failed to insert tx into pool with unexpected error: {e}"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+
+            // after every transaction, ensure that it's under the pool limits
+            assert!(!pool.is_exceeded());
+        }
+    }
+}

--- a/crates/transaction-pool/tests/it/main.rs
+++ b/crates/transaction-pool/tests/it/main.rs
@@ -3,6 +3,8 @@
 #[cfg(feature = "test-utils")]
 mod blobs;
 #[cfg(feature = "test-utils")]
+mod evict;
+#[cfg(feature = "test-utils")]
 mod listeners;
 #[cfg(feature = "test-utils")]
 mod pending;


### PR DESCRIPTION
Adds transaction pool tests which:
* generates many random transactions with:
  * uniformly random fee ranges
  * random senders, with varying numbers of transactions per sender
* inserts those transactions into the pool
* ensures that the errors are either due to transactions being evicted, or a sender reaching the configured `max_account_slots`

This uncovered a bug in the pending pool eviction method, which would loop forever if the eviction method removed _all_ of the remaining transactions from the pool.

This tests scenarios with blobs only, mixed transaction types, and mixed transaction types with nonce gaps.

ref https://github.com/paradigmxyz/reth/issues/6292