### PR TITLE
fix(consensus): skip building only for ancestor

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -474,7 +474,10 @@ where
         //    and deemed `VALID`. In the case of such an event, client software MUST return
         //    `{payloadStatus: {status: VALID, latestValidHash: forkchoiceState.headBlockHash,
         //    validationError: null}, payloadId: null}`
-        attrs.take();
+        if self.blockchain.canonical_tip() != header.num_hash() {
+            attrs.take();
+        }
+
         debug!(
             target: "consensus::engine",
             fcu_head_num=?header.number,


### PR DESCRIPTION
## Description

Another FCU might arrive with an equivalent forkchoice state, but different payload attributes. Validate the already canonical block is indeed an ancestor and not the current tip.