### PR TITLE
feat: replace `RangeInclusive` with `SegmentRangeInclusive` on `SegmentHeader`

### DIFF
--- a/bin/reth/src/commands/db/clear.rs
+++ b/bin/reth/src/commands/db/clear.rs
@@ -30,7 +30,7 @@ impl Command {
                 if let Some(segment_snapshots) = snapshots.get(&segment) {
                     for (block_range, _) in segment_snapshots {
                         snapshot_provider
-                            .delete_jar(segment, find_fixed_range(*block_range.start()))?;
+                            .delete_jar(segment, find_fixed_range(block_range.start()))?;
                     }
                 }
             }

--- a/bin/reth/src/commands/db/snapshots/headers.rs
+++ b/bin/reth/src/commands/db/snapshots/headers.rs
@@ -32,7 +32,7 @@ impl Command {
             Filters::WithoutFilters
         };
 
-        let mut row_indexes = block_range.clone().collect::<Vec<_>>();
+        let mut row_indexes = block_range.std_range().collect::<Vec<_>>();
         let mut rng = rand::thread_rng();
 
         let path: PathBuf = SnapshotSegment::Headers

--- a/bin/reth/src/commands/db/snapshots/mod.rs
+++ b/bin/reth/src/commands/db/snapshots/mod.rs
@@ -12,14 +12,14 @@ use reth_nippy_jar::{NippyJar, NippyJarCursor};
 use reth_node_core::dirs::{ChainPath, DataDirPath};
 use reth_primitives::{
     snapshot::{
-        Compression, Filters, InclusionFilter, PerfectHashingFunction, SegmentConfig, SegmentHeader,
+        Compression, Filters, InclusionFilter, PerfectHashingFunction, SegmentConfig,
+        SegmentHeader, SegmentRangeInclusive,
     },
     BlockNumber, ChainSpec, SnapshotSegment,
 };
 use reth_provider::{BlockNumReader, ProviderFactory};
 use reth_snapshot::{segments as snap_segments, segments::Segment};
 use std::{
-    ops::RangeInclusive,
     path::{Path, PathBuf},
     sync::Arc,
     time::{Duration, Instant},
@@ -164,13 +164,13 @@ impl Command {
     }
 
     /// Generates successive inclusive block ranges up to the tip starting at `self.from`.
-    fn block_ranges(&self, tip: BlockNumber) -> Vec<RangeInclusive<BlockNumber>> {
+    fn block_ranges(&self, tip: BlockNumber) -> Vec<SegmentRangeInclusive> {
         let mut from = self.from;
         let mut ranges = Vec::new();
 
         while from <= tip {
             let end_range = std::cmp::min(from + self.block_interval - 1, tip);
-            ranges.push(from..=end_range);
+            ranges.push(SegmentRangeInclusive::new(from, end_range));
             from = end_range + 1;
         }
 
@@ -202,7 +202,7 @@ impl Command {
                             &provider,
                             dir.as_path(),
                             config,
-                            block_range.clone(),
+                            block_range.std_range(),
                         )?;
                     }
 

--- a/bin/reth/src/commands/db/snapshots/mod.rs
+++ b/bin/reth/src/commands/db/snapshots/mod.rs
@@ -202,7 +202,7 @@ impl Command {
                             &provider,
                             dir.as_path(),
                             config,
-                            block_range.std_range(),
+                            block_range.into(),
                         )?;
                     }
 

--- a/bin/reth/src/commands/db/snapshots/receipts.rs
+++ b/bin/reth/src/commands/db/snapshots/receipts.rs
@@ -35,8 +35,9 @@ impl Command {
 
         let mut rng = rand::thread_rng();
 
-        let tx_range =
-            provider_factory.provider()?.transaction_range_by_block_range(block_range.clone())?;
+        let tx_range = provider_factory
+            .provider()?
+            .transaction_range_by_block_range(block_range.std_range())?;
 
         let mut row_indexes = tx_range.clone().collect::<Vec<_>>();
 

--- a/bin/reth/src/commands/db/snapshots/receipts.rs
+++ b/bin/reth/src/commands/db/snapshots/receipts.rs
@@ -24,8 +24,7 @@ impl Command {
     ) -> eyre::Result<()> {
         let provider = provider_factory.provider()?;
         let tip = provider.last_block_number()?;
-        let block_range =
-            self.block_ranges(tip).first().expect("has been generated before").clone();
+        let block_range = *self.block_ranges(tip).first().expect("has been generated before");
 
         let filters = if let Some(phf) = self.with_filters.then_some(phf).flatten() {
             Filters::WithFilters(inclusion_filter, phf)
@@ -35,9 +34,8 @@ impl Command {
 
         let mut rng = rand::thread_rng();
 
-        let tx_range = provider_factory
-            .provider()?
-            .transaction_range_by_block_range(block_range.std_range())?;
+        let tx_range =
+            provider_factory.provider()?.transaction_range_by_block_range(block_range.into())?;
 
         let mut row_indexes = tx_range.clone().collect::<Vec<_>>();
 

--- a/bin/reth/src/commands/db/snapshots/transactions.rs
+++ b/bin/reth/src/commands/db/snapshots/transactions.rs
@@ -25,8 +25,7 @@ impl Command {
     ) -> eyre::Result<()> {
         let provider = provider_factory.provider()?;
         let tip = provider.last_block_number()?;
-        let block_range =
-            self.block_ranges(tip).first().expect("has been generated before").clone();
+        let block_range = *self.block_ranges(tip).first().expect("has been generated before");
 
         let filters = if let Some(phf) = self.with_filters.then_some(phf).flatten() {
             Filters::WithFilters(inclusion_filter, phf)
@@ -36,7 +35,7 @@ impl Command {
 
         let mut rng = rand::thread_rng();
 
-        let tx_range = provider.transaction_range_by_block_range(block_range.std_range())?;
+        let tx_range = provider.transaction_range_by_block_range(block_range.into())?;
 
         let mut row_indexes = tx_range.clone().collect::<Vec<_>>();
 

--- a/bin/reth/src/commands/db/snapshots/transactions.rs
+++ b/bin/reth/src/commands/db/snapshots/transactions.rs
@@ -36,7 +36,7 @@ impl Command {
 
         let mut rng = rand::thread_rng();
 
-        let tx_range = provider.transaction_range_by_block_range(block_range.clone())?;
+        let tx_range = provider.transaction_range_by_block_range(block_range.std_range())?;
 
         let mut row_indexes = tx_range.clone().collect::<Vec<_>>();
 

--- a/bin/reth/src/commands/db/stats.rs
+++ b/bin/reth/src/commands/db/stats.rs
@@ -150,7 +150,7 @@ impl Command {
 
         for (segment, ranges) in snapshots.into_iter().sorted_by_key(|(segment, _)| *segment) {
             for (block_range, tx_range) in ranges {
-                let fixed_block_range = find_fixed_range(*block_range.start());
+                let fixed_block_range = find_fixed_range(block_range.start());
                 let jar_provider = snapshot_provider
                     .get_segment_provider(segment, || Some(fixed_block_range.clone()), None)?
                     .expect("something went wrong");

--- a/bin/reth/src/commands/db/stats.rs
+++ b/bin/reth/src/commands/db/stats.rs
@@ -152,7 +152,7 @@ impl Command {
             for (block_range, tx_range) in ranges {
                 let fixed_block_range = find_fixed_range(block_range.start());
                 let jar_provider = snapshot_provider
-                    .get_segment_provider(segment, || Some(fixed_block_range.clone()), None)?
+                    .get_segment_provider(segment, || Some(fixed_block_range), None)?
                     .expect("something went wrong");
 
                 let columns = jar_provider.columns();

--- a/bin/reth/src/commands/stage/drop.rs
+++ b/bin/reth/src/commands/stage/drop.rs
@@ -194,7 +194,7 @@ impl Command {
             if let Some(segment_snapshots) = snapshots.get(&snapshot_segment) {
                 for (block_range, _) in segment_snapshots {
                     snapshot_provider
-                        .delete_jar(snapshot_segment, find_fixed_range(*block_range.start()))?;
+                        .delete_jar(snapshot_segment, find_fixed_range(block_range.start()))?;
                 }
             }
         }

--- a/crates/node-core/src/node_config.rs
+++ b/crates/node-core/src/node_config.rs
@@ -12,12 +12,8 @@ use crate::{
 };
 use metrics_exporter_prometheus::PrometheusHandle;
 use once_cell::sync::Lazy;
-use reth_auto_seal_consensus::{AutoSealBuilder, AutoSealConsensus, MiningMode};
-use reth_beacon_consensus::{
-    hooks::{EngineHooks, PruneHook, SnapshotHook},
-    BeaconConsensus, BeaconConsensusEngine, BeaconConsensusEngineError,
-    MIN_BLOCKS_FOR_PIPELINE_RUN,
-};
+use reth_auto_seal_consensus::{AutoSealConsensus, MiningMode};
+use reth_beacon_consensus::BeaconConsensus;
 use reth_blockchain_tree::{
     config::BlockchainTreeConfig, externals::TreeExternals, BlockchainTree,
 };
@@ -53,7 +49,6 @@ use reth_provider::{
     ProviderFactory, StageCheckpointReader,
 };
 use reth_revm::EvmProcessorFactory;
-use reth_rpc_engine_api::EngineApi;
 use reth_snapshot::Snapshotter;
 use reth_stages::{
     prelude::*,

--- a/crates/primitives/src/snapshot/mod.rs
+++ b/crates/primitives/src/snapshot/mod.rs
@@ -8,7 +8,6 @@ use alloy_primitives::BlockNumber;
 pub use compression::Compression;
 pub use filters::{Filters, InclusionFilter, PerfectHashingFunction};
 pub use segment::{SegmentConfig, SegmentHeader, SegmentRangeInclusive, SnapshotSegment};
-use std::ops::RangeInclusive;
 
 /// Default snapshot block count.
 pub const BLOCKS_PER_SNAPSHOT: u64 = 500_000;

--- a/crates/primitives/src/snapshot/mod.rs
+++ b/crates/primitives/src/snapshot/mod.rs
@@ -7,7 +7,7 @@ mod segment;
 use alloy_primitives::BlockNumber;
 pub use compression::Compression;
 pub use filters::{Filters, InclusionFilter, PerfectHashingFunction};
-pub use segment::{SegmentConfig, SegmentHeader, SnapshotSegment};
+pub use segment::{SegmentConfig, SegmentHeader, SegmentRangeInclusive, SnapshotSegment};
 use std::ops::RangeInclusive;
 
 /// Default snapshot block count.
@@ -49,7 +49,7 @@ impl HighestSnapshots {
 
 /// Each snapshot has a fixed number of blocks. This gives out the range where the requested block
 /// is positioned. Used for segment filename.
-pub fn find_fixed_range(block: BlockNumber) -> RangeInclusive<BlockNumber> {
+pub fn find_fixed_range(block: BlockNumber) -> SegmentRangeInclusive {
     let start = (block / BLOCKS_PER_SNAPSHOT) * BLOCKS_PER_SNAPSHOT;
-    start..=start + BLOCKS_PER_SNAPSHOT - 1
+    SegmentRangeInclusive::new(start, start + BLOCKS_PER_SNAPSHOT - 1)
 }

--- a/crates/primitives/src/snapshot/segment.rs
+++ b/crates/primitives/src/snapshot/segment.rs
@@ -136,10 +136,14 @@ impl SnapshotSegment {
 /// A segment header that contains information common to all segments. Used for storage.
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]
 pub struct SegmentHeader {
-    /// Block range of the snapshot segment
-    block_range: RangeInclusive<BlockNumber>,
-    /// Transaction range of the snapshot segment
-    tx_range: RangeInclusive<TxNumber>,
+    /// Start block number of the snapshot segment
+    block_start: BlockNumber,
+    /// End block number of the snapshot segment
+    block_end: BlockNumber,
+    /// Start transaction number of the snapshot segment
+    tx_start: TxNumber,
+    /// End transaction number of the snapshot segment
+    tx_end: TxNumber,
     /// Segment type
     segment: SnapshotSegment,
 }
@@ -147,44 +151,51 @@ pub struct SegmentHeader {
 impl SegmentHeader {
     /// Returns [`SegmentHeader`].
     pub fn new(
-        block_range: RangeInclusive<BlockNumber>,
-        tx_range: RangeInclusive<TxNumber>,
+        block_start: BlockNumber,
+        block_end: BlockNumber,
+        tx_start: TxNumber,
+        tx_end: TxNumber,
         segment: SnapshotSegment,
     ) -> Self {
-        Self { block_range, tx_range, segment }
+        Self { block_start, block_end, tx_start, tx_end, segment }
     }
 
-    /// Returns the transaction range.
-    pub fn tx_range(&self) -> &RangeInclusive<TxNumber> {
-        &self.tx_range
-    }
-
-    /// Returns the block range.
-    pub fn block_range(&self) -> &RangeInclusive<BlockNumber> {
-        &self.block_range
-    }
-
-    /// Returns the first block number of the segment.
-    pub fn block_start(&self) -> BlockNumber {
-        *self.block_range.start()
-    }
-
-    /// Returns the last block number of the segment.
-    pub fn block_end(&self) -> BlockNumber {
-        *self.block_range.end()
-    }
-
-    /// Returns the first transaction number of the segment.
+    /// Returns the transaction start number.
     pub fn tx_start(&self) -> TxNumber {
-        *self.tx_range.start()
+        self.tx_start
     }
 
-    /// Returns the row offset which depends on whether the segment is block or transaction based.
+    /// Returns the transaction end number.
+    pub fn tx_end(&self) -> TxNumber {
+        self.tx_end
+    }
+
+    /// Returns the block start number.
+    pub fn block_start(&self) -> BlockNumber {
+        self.block_start
+    }
+
+    /// Returns the block end number.
+    pub fn block_end(&self) -> BlockNumber {
+        self.block_end
+    }
+
+    /// Returns the start number depending on whether the segment is block or transaction based.
     pub fn start(&self) -> u64 {
         match self.segment {
-            SnapshotSegment::Headers => self.block_start(),
-            SnapshotSegment::Transactions | SnapshotSegment::Receipts => self.tx_start(),
+            SnapshotSegment::Headers => self.block_start,
+            SnapshotSegment::Transactions | SnapshotSegment::Receipts => self.tx_start,
         }
+    }
+
+    /// Returns the transaction range as [`RangeInclusive`].
+    pub fn tx_range(&self) -> RangeInclusive<TxNumber> {
+        self.tx_start..=self.tx_end
+    }
+
+    /// Returns the block range as [`RangeInclusive`].
+    pub fn block_range(&self) -> RangeInclusive<BlockNumber> {
+        self.block_start..=self.block_end
     }
 }
 

--- a/crates/primitives/src/snapshot/segment.rs
+++ b/crates/primitives/src/snapshot/segment.rs
@@ -163,7 +163,7 @@ impl SegmentHeader {
 
     /// Returns the transaction range.
     pub fn tx_range(&self) -> Option<SegmentRangeInclusive> {
-        self.tx_range.clone()
+        self.tx_range
     }
 
     /// Returns the first block number of the segment.

--- a/crates/primitives/src/snapshot/segment.rs
+++ b/crates/primitives/src/snapshot/segment.rs
@@ -70,7 +70,7 @@ impl SnapshotSegment {
     }
 
     /// Returns the default file name for the provided segment and range.
-    pub fn filename(&self, block_range: &SegmentRange) -> String {
+    pub fn filename(&self, block_range: &SegmentRangeInclusive) -> String {
         // ATTENTION: if changing the name format, be sure to reflect those changes in
         // [`Self::parse_filename`].
         format!("snapshot_{}_{}_{}", self.as_ref(), block_range.start(), block_range.end())
@@ -81,7 +81,7 @@ impl SnapshotSegment {
         &self,
         filters: Filters,
         compression: Compression,
-        block_range: &SegmentRange,
+        block_range: &SegmentRangeInclusive,
     ) -> String {
         let prefix = self.filename(block_range);
 
@@ -113,7 +113,7 @@ impl SnapshotSegment {
     /// # Note
     /// This function is tightly coupled with the naming convention defined in [`Self::filename`].
     /// Any changes in the filename format in `filename` should be reflected here.
-    pub fn parse_filename(name: &str) -> Option<(Self, RangeInclusive<BlockNumber>)> {
+    pub fn parse_filename(name: &str) -> Option<(Self, SegmentRangeInclusive)> {
         let mut parts = name.split('_');
         if parts.next() != Some("snapshot") {
             return None
@@ -126,7 +126,7 @@ impl SnapshotSegment {
             return None
         }
 
-        Some((segment, block_start..=block_end))
+        Some((segment, SegmentRangeInclusive::new(block_start, block_end)))
     }
 }
 
@@ -134,9 +134,9 @@ impl SnapshotSegment {
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Hash, Clone)]
 pub struct SegmentHeader {
     /// Block range of the snapshot segment
-    block_range: SegmentRange,
+    block_range: SegmentRangeInclusive,
     /// Transaction range of the snapshot segment
-    tx_range: Option<SegmentRange>,
+    tx_range: Option<SegmentRangeInclusive>,
     /// Segment type
     segment: SnapshotSegment,
 }
@@ -144,11 +144,11 @@ pub struct SegmentHeader {
 impl SegmentHeader {
     /// Returns [`SegmentHeader`].
     pub fn new(
-        block_range: RangeInclusive<BlockNumber>,
-        tx_range: Option<RangeInclusive<TxNumber>>,
+        block_range: SegmentRangeInclusive,
+        tx_range: Option<SegmentRangeInclusive>,
         segment: SnapshotSegment,
     ) -> Self {
-        Self { block_range: block_range.into(), tx_range: tx_range.map(Into::into), segment }
+        Self { block_range, tx_range, segment }
     }
 
     /// Returns the snapshot segment kind.
@@ -157,13 +157,13 @@ impl SegmentHeader {
     }
 
     /// Returns the block range.
-    pub fn block_range(&self) -> RangeInclusive<BlockNumber> {
-        self.block_range.start()..=self.block_range.end()
+    pub fn block_range(&self) -> SegmentRangeInclusive {
+        self.block_range
     }
 
     /// Returns the transaction range.
-    pub fn tx_range(&self) -> Option<RangeInclusive<TxNumber>> {
-        self.tx_range.as_ref().map(|range| range.start()..=range.end())
+    pub fn tx_range(&self) -> Option<SegmentRangeInclusive> {
+        self.tx_range.clone()
     }
 
     /// Returns the first block number of the segment.
@@ -224,7 +224,7 @@ impl SegmentHeader {
                 if let Some(tx_range) = &mut self.tx_range {
                     tx_range.end += 1;
                 } else {
-                    self.tx_range = Some(SegmentRange::new(0, 0));
+                    self.tx_range = Some(SegmentRangeInclusive::new(0, 0));
                 }
             }
         }
@@ -234,14 +234,14 @@ impl SegmentHeader {
     pub fn prune(&mut self, num: u64) {
         match self.segment {
             SnapshotSegment::Headers => {
-                self.block_range.end.saturating_sub(num);
+                self.block_range.end = self.block_range.end.saturating_sub(num);
             }
             SnapshotSegment::Transactions | SnapshotSegment::Receipts => {
                 if let Some(range) = &mut self.tx_range {
                     if num > range.end {
                         self.tx_range = None;
                     } else {
-                        range.end.saturating_sub(num);
+                        range.end = range.end.saturating_sub(num);
                     }
                 };
             }
@@ -260,11 +260,11 @@ impl SegmentHeader {
             tx_range.start = tx_start;
             tx_range.end = tx_end;
         } else {
-            self.tx_range = Some(SegmentRange::new(tx_start, tx_end))
+            self.tx_range = Some(SegmentRangeInclusive::new(tx_start, tx_end))
         }
     }
 
-    /// Returns the start number depending on whether the segment is block or transaction based.
+    /// Returns the row offset which depends on whether the segment is block or transaction based.
     pub fn start(&self) -> u64 {
         match self.segment {
             SnapshotSegment::Headers => self.block_start(),
@@ -285,29 +285,37 @@ pub struct SegmentConfig {
 /// Helper type to handle segment transaction and block INCLUSIVE ranges.
 ///
 /// They can be modified on a hot loop, which makes the `std::ops::RangeInclusive` a poor fit.
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Hash, Clone)]
-struct SegmentRange {
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Hash, Clone, Copy)]
+pub struct SegmentRangeInclusive {
     start: u64,
     end: u64,
 }
 
-impl SegmentRange {
-    fn new(start: u64, end: u64) -> Self {
+impl SegmentRangeInclusive {
+    /// Creates a new [`SegmentRangeInclusive`]
+    pub fn new(start: u64, end: u64) -> Self {
         Self { start, end }
     }
 
-    fn start(&self) -> u64 {
+    /// Start of the inclusive range
+    pub fn start(&self) -> u64 {
         self.start
     }
 
-    fn end(&self) -> u64 {
+    /// End of the inclusive range
+    pub fn end(&self) -> u64 {
         self.end
+    }
+
+    /// Returns a [`RangeInclusive`] representation
+    pub fn std_range(&self) -> RangeInclusive<u64> {
+        self.start..=self.end
     }
 }
 
-impl From<RangeInclusive<u64>> for SegmentRange {
+impl From<RangeInclusive<u64>> for SegmentRangeInclusive {
     fn from(value: RangeInclusive<u64>) -> Self {
-        SegmentRange { start: *value.start(), end: *value.end() }
+        SegmentRangeInclusive { start: *value.start(), end: *value.end() }
     }
 }
 
@@ -365,6 +373,7 @@ mod tests {
         ];
 
         for (segment, block_range, filename, configuration) in test_vectors {
+            let block_range: SegmentRangeInclusive = block_range.into();
             if let Some((compression, filters)) = configuration {
                 assert_eq!(
                     segment.filename_with_configuration(filters, compression, &block_range,),

--- a/crates/primitives/src/snapshot/segment.rs
+++ b/crates/primitives/src/snapshot/segment.rs
@@ -306,16 +306,23 @@ impl SegmentRangeInclusive {
     pub fn end(&self) -> u64 {
         self.end
     }
-
-    /// Returns a [`RangeInclusive`] representation
-    pub fn std_range(&self) -> RangeInclusive<u64> {
-        self.start..=self.end
-    }
 }
 
 impl From<RangeInclusive<u64>> for SegmentRangeInclusive {
     fn from(value: RangeInclusive<u64>) -> Self {
         SegmentRangeInclusive { start: *value.start(), end: *value.end() }
+    }
+}
+
+impl From<&SegmentRangeInclusive> for RangeInclusive<u64> {
+    fn from(value: &SegmentRangeInclusive) -> Self {
+        value.start()..=value.end()
+    }
+}
+
+impl From<SegmentRangeInclusive> for RangeInclusive<u64> {
+    fn from(value: SegmentRangeInclusive) -> Self {
+        (&value).into()
     }
 }
 

--- a/crates/snapshot/src/segments/mod.rs
+++ b/crates/snapshot/src/segments/mod.rs
@@ -70,7 +70,13 @@ pub(crate) fn prepare_jar<DB: Database, const COLUMNS: usize>(
     let mut nippy_jar = NippyJar::new(
         COLUMNS,
         &directory.as_ref().join(segment.filename(&block_range, &tx_range).as_str()),
-        SegmentHeader::new(block_range, tx_range, segment),
+        SegmentHeader::new(
+            *block_range.start(),
+            *block_range.end(),
+            *tx_range.start(),
+            *tx_range.end(),
+            segment,
+        ),
     );
 
     nippy_jar = match segment_config.compression {

--- a/crates/snapshot/src/segments/mod.rs
+++ b/crates/snapshot/src/segments/mod.rs
@@ -65,14 +65,14 @@ pub(crate) fn prepare_jar<DB: Database, const COLUMNS: usize>(
     let tx_range = match segment {
         SnapshotSegment::Headers => None,
         SnapshotSegment::Receipts | SnapshotSegment::Transactions => {
-            Some(provider.transaction_range_by_block_range(block_range.clone())?)
+            Some(provider.transaction_range_by_block_range(block_range.clone())?.into())
         }
     };
 
     let mut nippy_jar = NippyJar::new(
         COLUMNS,
         &directory.as_ref().join(segment.filename(&find_fixed_range(*block_range.end())).as_str()),
-        SegmentHeader::new(block_range, tx_range, segment),
+        SegmentHeader::new(block_range.into(), tx_range, segment),
     );
 
     nippy_jar = match segment_config.compression {

--- a/crates/storage/db/src/snapshot/mod.rs
+++ b/crates/storage/db/src/snapshot/mod.rs
@@ -61,7 +61,7 @@ pub fn iter_snapshots(path: impl AsRef<Path>) -> Result<SortedSnapshots, NippyJa
                 &path.as_ref().join(segment.filename(&block_range, &tx_range)),
             )?;
 
-            if &tx_range != jar.user_header().tx_range() {
+            if tx_range != jar.user_header().tx_range() {
                 // TODO(joshie): rename
             }
 

--- a/crates/storage/db/src/snapshot/mod.rs
+++ b/crates/storage/db/src/snapshot/mod.rs
@@ -3,7 +3,6 @@
 mod generation;
 use std::{
     collections::{hash_map::Entry, HashMap},
-    ops::RangeInclusive,
     path::Path,
 };
 
@@ -17,7 +16,7 @@ pub use mask::*;
 use reth_nippy_jar::{NippyJar, NippyJarError};
 use reth_primitives::{
     snapshot::{SegmentHeader, SegmentRangeInclusive},
-    BlockNumber, SnapshotSegment, TxNumber,
+    SnapshotSegment,
 };
 
 mod masks;

--- a/crates/storage/db/src/snapshot/mod.rs
+++ b/crates/storage/db/src/snapshot/mod.rs
@@ -15,13 +15,16 @@ pub use cursor::SnapshotCursor;
 mod mask;
 pub use mask::*;
 use reth_nippy_jar::{NippyJar, NippyJarError};
-use reth_primitives::{snapshot::SegmentHeader, BlockNumber, SnapshotSegment, TxNumber};
+use reth_primitives::{
+    snapshot::{SegmentHeader, SegmentRangeInclusive},
+    BlockNumber, SnapshotSegment, TxNumber,
+};
 
 mod masks;
 
 /// Alias type for a map of [`SnapshotSegment`] and sorted lists of existing snapshot ranges.
 type SortedSnapshots =
-    HashMap<SnapshotSegment, Vec<(RangeInclusive<BlockNumber>, Option<RangeInclusive<TxNumber>>)>>;
+    HashMap<SnapshotSegment, Vec<(SegmentRangeInclusive, Option<SegmentRangeInclusive>)>>;
 
 /// Given the snapshots directory path, it returns a list over the existing snapshots organized by
 /// [`SnapshotSegment`]. Each segment has a sorted list of block ranges and transaction ranges as
@@ -62,7 +65,7 @@ pub fn iter_snapshots(path: impl AsRef<Path>) -> Result<SortedSnapshots, NippyJa
 
     for (_, range_list) in static_files.iter_mut() {
         // Sort by block end range.
-        range_list.sort_by(|a, b| a.0.end().cmp(b.0.end()));
+        range_list.sort_by(|a, b| a.0.end().cmp(&b.0.end()));
     }
 
     Ok(static_files)

--- a/crates/storage/provider/src/providers/snapshot/manager.rs
+++ b/crates/storage/provider/src/providers/snapshot/manager.rs
@@ -291,7 +291,7 @@ impl SnapshotProvider {
                         .and_modify(|index| {
                             index
                                 .retain(|_, block_range| block_range.start() < fixed_range.start());
-                            index.insert(tx_end, current_block_range.clone());
+                            index.insert(tx_end, current_block_range);
                         })
                         .or_insert_with(|| BTreeMap::from([(tx_end, current_block_range)]));
                 } else if let Some(1) = tx_index.get(&segment).map(|index| index.len()) {

--- a/crates/storage/provider/src/providers/snapshot/mod.rs
+++ b/crates/storage/provider/src/providers/snapshot/mod.rs
@@ -58,8 +58,13 @@ mod tests {
         // Ranges
         let row_count = 100u64;
         let range = 0..=(row_count - 1);
-        let segment_header =
-            SegmentHeader::new(range.clone(), range.clone(), SnapshotSegment::Headers);
+        let segment_header = SegmentHeader::new(
+            *range.clone().start(),
+            *range.clone().end(),
+            *range.clone().start(),
+            *range.clone().end(),
+            SnapshotSegment::Headers,
+        );
 
         // Data sources
         let factory = create_test_provider_factory();

--- a/crates/storage/provider/src/providers/snapshot/mod.rs
+++ b/crates/storage/provider/src/providers/snapshot/mod.rs
@@ -63,8 +63,11 @@ mod tests {
         // Ranges
         let row_count = 100u64;
         let range = 0..=(row_count - 1);
-        let segment_header =
-            SegmentHeader::new(range.clone(), Some(range.clone()), SnapshotSegment::Headers);
+        let segment_header = SegmentHeader::new(
+            range.clone().into(),
+            Some(range.clone().into()),
+            SnapshotSegment::Headers,
+        );
 
         // Data sources
         let factory = create_test_provider_factory();

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -8,7 +8,7 @@ use alloy_rlp::Decodable;
 use reth_db::test_utils::{create_test_rw_db, create_test_snapshots_dir};
 use reth_node_ethereum::EthEvmConfig;
 use reth_primitives::{BlockBody, SealedBlock, SnapshotSegment};
-use reth_provider::{providers::SnapshotWriter, BlockWriter, HashingWriter, ProviderFactory};
+use reth_provider::{providers::SnapshotWriter, HashingWriter, ProviderFactory};
 use reth_stages::{stages::ExecutionStage, ExecInput, Stage};
 use std::{collections::BTreeMap, fs, path::Path, sync::Arc};
 


### PR DESCRIPTION
closes #6185

Should avoid multiple `RangeInclusive` allocations when writing on `append_receipt` / `append_tx` / `increment_block`