### PR TITLE
fix: initial total_bytes value for response limit and typos

### DIFF
--- a/crates/consensus/beacon/src/engine/handle.rs
+++ b/crates/consensus/beacon/src/engine/handle.rs
@@ -89,7 +89,7 @@ where
         rx
     }
 
-    /// Sends a transition configuration exchagne message to the beacon consensus engine.
+    /// Sends a transition configuration exchange message to the beacon consensus engine.
     ///
     /// See also <https://github.com/ethereum/execution-apis/blob/3d627c95a4d3510a8187dd02e0250ecb4331d27e/src/engine/paris.md#engine_exchangetransitionconfigurationv1>
     pub async fn transition_configuration_exchanged(&self) {

--- a/crates/net/discv4/src/config.rs
+++ b/crates/net/discv4/src/config.rs
@@ -40,7 +40,7 @@ pub struct Discv4Config {
     pub request_timeout: Duration,
     /// The duration after which we consider an enr request timed out.
     pub enr_expiration: Duration,
-    /// The duration we set for neighbours responses
+    /// The duration we set for neighbours responses.
     pub neighbours_expiration: Duration,
     /// Provides a way to ban peers and ips.
     #[cfg_attr(feature = "serde", serde(skip))]
@@ -57,9 +57,9 @@ pub struct Discv4Config {
     pub enable_dht_random_walk: bool,
     /// Whether to automatically lookup peers.
     pub enable_lookup: bool,
-    /// Whether to enforce EIP-868 extension
+    /// Whether to enforce EIP-868 extension.
     pub enable_eip868: bool,
-    /// Whether to respect expiration timestamps in messages
+    /// Whether to respect expiration timestamps in messages.
     pub enforce_expiration_timestamps: bool,
     /// Additional pairs to include in The [`Enr`](enr::Enr) if EIP-868 extension is enabled <https://eips.ethereum.org/EIPS/eip-868>
     pub additional_eip868_rlp_pairs: HashMap<Vec<u8>, Bytes>,

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -639,7 +639,7 @@ impl Discv4Service {
     /// [`DiscoveryUpdate::Added`] event for the given bootnodes. So boot nodes don't appear in the
     /// update stream, which is usually desirable, since bootnodes should not be connected to.
     ///
-    /// If adding the configured boodnodes should result in a [`DiscoveryUpdate::Added`], see
+    /// If adding the configured bootnodes should result in a [`DiscoveryUpdate::Added`], see
     /// [`Self::add_all_nodes`].
     ///
     /// **Note:** This is a noop if there are no bootnodes.
@@ -1057,7 +1057,7 @@ impl Discv4Service {
         } else if needs_bond {
             self.try_ping(record, PingReason::EstablishBond);
         } else if is_proven {
-            // if node has been proven, this means we've recieved a pong and verified its endpoint
+            // if node has been proven, this means we've received a pong and verified its endpoint
             // proof. We've also sent a pong above to verify our endpoint proof, so we can now
             // send our find_nodes request if PingReason::Lookup
             if let Some((_, ctx)) = self.pending_lookup.remove(&record.id) {
@@ -1193,7 +1193,7 @@ impl Discv4Service {
     /// Handler for an incoming `FindNode` message
     fn on_find_node(&mut self, msg: FindNode, remote_addr: SocketAddr, node_id: PeerId) {
         if self.is_expired(msg.expire) {
-            // ping's expiration timestamp is in the past
+            // expiration timestamp is in the past
             return
         }
         if node_id == *self.local_peer_id() {
@@ -2018,9 +2018,9 @@ struct NodeEntry {
     last_enr_seq: Option<u64>,
     /// ForkId if retrieved via ENR requests.
     fork_id: Option<ForkId>,
-    /// Counter for failed findNode requests
+    /// Counter for failed findNode requests.
     find_node_failures: usize,
-    /// whether the endpoint of the peer is proven
+    /// Whether the endpoint of the peer is proven.
     has_endpoint_proof: bool,
 }
 
@@ -2087,7 +2087,7 @@ enum PingReason {
     /// Initial ping to a previously unknown peer that didn't fit into the table. But we still want
     /// to establish a bond.
     EstablishBond,
-    /// Re-ping a peer..
+    /// Re-ping a peer.
     RePing,
     /// Part of a lookup to ensure endpoint is proven.
     Lookup(NodeRecord, LookupContext),

--- a/crates/net/eth-wire/src/types/blocks.rs
+++ b/crates/net/eth-wire/src/types/blocks.rs
@@ -28,7 +28,7 @@ pub struct GetBlockHeaders {
     pub limit: u64,
 
     /// The number of blocks that the node should skip while traversing and returning headers.
-    /// A skip value of zero denotes that the peer should return contiguous heaaders, starting from
+    /// A skip value of zero denotes that the peer should return contiguous headers, starting from
     /// [`start_block`](#structfield.start_block) and returning at most
     /// [`limit`](#structfield.limit) headers.
     pub skip: u32,

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -79,7 +79,7 @@ pub struct NetworkConfig<C> {
     pub optimism_network_config: OptimismNetworkConfig,
 }
 
-/// Optimmism Network Config
+/// Optimism Network Config
 #[cfg(feature = "optimism")]
 #[derive(Debug, Clone, Default)]
 pub struct OptimismNetworkConfig {

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -98,7 +98,7 @@ where
         };
 
         let skip = skip as u64;
-        let mut total_bytes = APPROX_HEADER_SIZE;
+        let mut total_bytes = 0;
 
         for _ in 0..limit {
             if let Some(header) = self.client.header_by_hash_or_number(block).unwrap_or_default() {
@@ -128,13 +128,11 @@ where
                 }
 
                 headers.push(header);
-
                 if headers.len() >= MAX_HEADERS_SERVE {
                     break
                 }
 
                 total_bytes += APPROX_HEADER_SIZE;
-
                 if total_bytes > SOFT_RESPONSE_LIMIT {
                     break
                 }
@@ -166,7 +164,7 @@ where
         self.metrics.received_bodies_requests.increment(1);
         let mut bodies = Vec::new();
 
-        let mut total_bytes = APPROX_BODY_SIZE;
+        let mut total_bytes = 0;
 
         for hash in request.0 {
             if let Some(block) = self.client.block_by_hash(hash).unwrap_or_default() {
@@ -177,14 +175,12 @@ where
                 };
 
                 bodies.push(body);
-
-                total_bytes += APPROX_BODY_SIZE;
-
-                if total_bytes > SOFT_RESPONSE_LIMIT {
+                if bodies.len() >= MAX_BODIES_SERVE {
                     break
                 }
 
-                if bodies.len() >= MAX_BODIES_SERVE {
+                total_bytes += APPROX_BODY_SIZE;
+                if total_bytes > SOFT_RESPONSE_LIMIT {
                     break
                 }
             } else {
@@ -203,26 +199,24 @@ where
     ) {
         let mut receipts = Vec::new();
 
-        let mut total_bytes = APPROX_RECEIPT_SIZE;
+        let mut total_bytes = 0;
 
         for hash in request.0 {
             if let Some(receipts_by_block) =
                 self.client.receipts_by_block(BlockHashOrNumber::Hash(hash)).unwrap_or_default()
             {
-                receipts.push(
-                    receipts_by_block
-                        .into_iter()
-                        .map(|receipt| receipt.with_bloom())
-                        .collect::<Vec<_>>(),
-                );
+                let receipt = receipts_by_block
+                    .into_iter()
+                    .map(|receipt| receipt.with_bloom())
+                    .collect::<Vec<_>>();
 
-                total_bytes += APPROX_RECEIPT_SIZE;
-
-                if total_bytes > SOFT_RESPONSE_LIMIT {
+                receipts.push(receipt);
+                if receipts.len() >= MAX_RECEIPTS_SERVE {
                     break
                 }
 
-                if receipts.len() >= MAX_RECEIPTS_SERVE {
+                total_bytes += APPROX_RECEIPT_SIZE;
+                if total_bytes > SOFT_RESPONSE_LIMIT {
                     break
                 }
             } else {

--- a/crates/primitives/src/transaction/pooled.rs
+++ b/crates/primitives/src/transaction/pooled.rs
@@ -428,7 +428,7 @@ impl Decodable for PooledTransactionsElement {
             let remaining_len = buf.len();
 
             if tx_type == EIP4844_TX_TYPE_ID {
-                // Recall that the blob transaction response `TranactionPayload` is encoded like
+                // Recall that the blob transaction response `TransactionPayload` is encoded like
                 // this: `rlp([tx_payload_body, blobs, commitments, proofs])`
                 //
                 // Note that `tx_payload_body` is a list:

--- a/crates/primitives/src/transaction/sidecar.rs
+++ b/crates/primitives/src/transaction/sidecar.rs
@@ -388,9 +388,9 @@ impl Decodable for BlobTransactionSidecar {
 // Wrapper for c-kzg rlp
 #[repr(C)]
 struct BlobTransactionSidecarRlp {
-    blobs: Vec<[u8; c_kzg::BYTES_PER_BLOB]>,
-    commitments: Vec<[u8; 48]>,
-    proofs: Vec<[u8; 48]>,
+    blobs: Vec<[u8; BYTES_PER_BLOB]>,
+    commitments: Vec<[u8; BYTES_PER_COMMITMENT]>,
+    proofs: Vec<[u8; BYTES_PER_PROOF]>,
 }
 
 const _: [(); std::mem::size_of::<BlobTransactionSidecar>()] =
@@ -438,7 +438,7 @@ impl<'a> arbitrary::Arbitrary<'a> for BlobTransactionSidecar {
             .map(|_| {
                 arr = arbitrary::Arbitrary::arbitrary(u).unwrap();
 
-                // Ensure that each blob is cacnonical by ensuring each field element contained in
+                // Ensure that each blob is canonical by ensuring each field element contained in
                 // the blob is < BLS_MODULUS
                 for i in 0..(FIELD_ELEMENTS_PER_BLOB as usize) {
                     arr[i * BYTES_PER_FIELD_ELEMENT] = 0;
@@ -463,7 +463,7 @@ impl proptest::arbitrary::Arbitrary for BlobTransactionSidecar {
                     .map(|mut blob| {
                         let mut arr = [0u8; BYTES_PER_BLOB];
 
-                        // Ensure that each blob is cacnonical by ensuring each field element
+                        // Ensure that each blob is canonical by ensuring each field element
                         // contained in the blob is < BLS_MODULUS
                         for i in 0..(FIELD_ELEMENTS_PER_BLOB as usize) {
                             blob[i * BYTES_PER_FIELD_ELEMENT] = 0;

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -503,7 +503,7 @@ impl<T: PoolTransaction> Clone for NewTransactionEvent<T> {
 }
 
 /// This type represents a new blob sidecar that has been stored in the transaction pool's
-/// blobstore; it includes the TransasctionHash of the blob transaction along with the assoc.
+/// blobstore; it includes the TransactionHash of the blob transaction along with the assoc.
 /// sidecar (blobs, commitments, proofs)
 #[derive(Debug, Clone)]
 pub struct NewBlobSidecar {


### PR DESCRIPTION
This PR fixes a few of the minor things I noticed while skimming the codebase.

* Fix several minor typos I noticed while skimming the codebase.
* In `on_{headers,bodies,receipts}_request`, initialize `total_bytes` with 0 rather than `APPROX_*_SIZE`.
  * In practice, this will allow an additional item in the response. This shouldn't make a big difference.
  * Move `<vec>.len()` and `total_bytes` checks to immediately after the variable is modified.
* In `BlobTransactionSidecarRlp`, use `BYTES_PER_COMMITMENT` and `BYTES_PER_PROOF` rather than 48.