### PR TITLE
fix: sealed header should not be immutable borrowed

### DIFF
--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -259,7 +259,7 @@ impl Command {
             Arc::clone(&best_block),
             Bytes::default(),
             OptimismPayloadBuilderAttributes::try_new(
-                best_block.hash,
+                best_block.hash(),
                 OptimismPayloadAttributes {
                     payload_attributes: payload_attrs,
                     transactions: None,

--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -274,7 +274,7 @@ impl Command {
         let payload_config = PayloadConfig::new(
             Arc::clone(&best_block),
             Bytes::default(),
-            EthPayloadBuilderAttributes::try_new(best_block.hash, payload_attrs)?,
+            EthPayloadBuilderAttributes::try_new(best_block.hash(), payload_attrs)?,
             self.chain.clone(),
         );
 

--- a/bin/reth/src/commands/debug_cmd/execution.rs
+++ b/bin/reth/src/commands/debug_cmd/execution.rs
@@ -189,7 +189,7 @@ impl Command {
             match get_single_header(&client, BlockHashOrNumber::Number(block)).await {
                 Ok(tip_header) => {
                     info!(target: "reth::cli", ?block, "Successfully fetched block");
-                    return Ok(tip_header.hash)
+                    return Ok(tip_header.hash())
                 }
                 Err(error) => {
                     error!(target: "reth::cli", ?block, %error, "Failed to fetch the block. Retrying...");

--- a/bin/reth/src/commands/node/events.rs
+++ b/bin/reth/src/commands/node/events.rs
@@ -164,15 +164,15 @@ impl<DB> NodeState<DB> {
                 );
             }
             BeaconConsensusEngineEvent::CanonicalBlockAdded(block) => {
-                info!(number=block.number, hash=?block.hash, "Block added to canonical chain");
+                info!(number=block.number, hash=?block.hash(), "Block added to canonical chain");
             }
             BeaconConsensusEngineEvent::CanonicalChainCommitted(head, elapsed) => {
                 self.latest_block = Some(head.number);
 
-                info!(number=head.number, hash=?head.hash, ?elapsed, "Canonical chain committed");
+                info!(number=head.number, hash=?head.hash(), ?elapsed, "Canonical chain committed");
             }
             BeaconConsensusEngineEvent::ForkBlockAdded(block) => {
-                info!(number=block.number, hash=?block.hash, "Block added to fork chain");
+                info!(number=block.number, hash=?block.hash(), "Block added to fork chain");
             }
         }
     }

--- a/bin/reth/src/init.rs
+++ b/bin/reth/src/init.rs
@@ -210,13 +210,13 @@ pub fn insert_genesis_header<DB: Database>(
     tx: &<DB as Database>::TXMut,
     chain: Arc<ChainSpec>,
 ) -> ProviderResult<()> {
-    let header = chain.sealed_genesis_header();
+    let (header, block_hash) = chain.sealed_genesis_header().split();
 
-    tx.put::<tables::CanonicalHeaders>(0, header.hash)?;
-    tx.put::<tables::HeaderNumbers>(header.hash, 0)?;
+    tx.put::<tables::CanonicalHeaders>(0, block_hash)?;
+    tx.put::<tables::HeaderNumbers>(block_hash, 0)?;
     tx.put::<tables::BlockBodyIndices>(0, Default::default())?;
     tx.put::<tables::HeaderTD>(0, header.difficulty.into())?;
-    tx.put::<tables::Headers>(0, header.header)?;
+    tx.put::<tables::Headers>(0, header)?;
 
     Ok(())
 }

--- a/crates/blockchain-tree/src/block_buffer.rs
+++ b/crates/blockchain-tree/src/block_buffer.rs
@@ -221,16 +221,16 @@ mod tests {
 
     /// Assert that the block was removed from all buffer collections.
     fn assert_block_removal(buffer: &BlockBuffer, block: &SealedBlockWithSenders) {
-        assert!(buffer.blocks.get(&block.hash).is_none());
+        assert!(buffer.blocks.get(&block.hash()).is_none());
         assert!(buffer
             .parent_to_child
             .get(&block.parent_hash)
-            .and_then(|p| p.get(&block.hash))
+            .and_then(|p| p.get(&block.hash()))
             .is_none());
         assert!(buffer
             .earliest_blocks
             .get(&block.number)
-            .and_then(|hashes| hashes.get(&block.hash))
+            .and_then(|hashes| hashes.get(&block.hash()))
             .is_none());
     }
 
@@ -243,7 +243,7 @@ mod tests {
 
         buffer.insert_block(block1.clone());
         assert_buffer_lengths(&buffer, 1);
-        assert_eq!(buffer.block(&block1.hash), Some(&block1));
+        assert_eq!(buffer.block(&block1.hash()), Some(&block1));
     }
 
     #[test]
@@ -252,8 +252,8 @@ mod tests {
 
         let main_parent_hash = rng.gen();
         let block1 = create_block(&mut rng, 10, main_parent_hash);
-        let block2 = create_block(&mut rng, 11, block1.hash);
-        let block3 = create_block(&mut rng, 12, block2.hash);
+        let block2 = create_block(&mut rng, 11, block1.hash());
+        let block3 = create_block(&mut rng, 12, block2.hash());
         let parent4 = rng.gen();
         let block4 = create_block(&mut rng, 14, parent4);
 
@@ -265,13 +265,13 @@ mod tests {
         buffer.insert_block(block4.clone());
 
         assert_buffer_lengths(&buffer, 4);
-        assert_eq!(buffer.block(&block4.hash), Some(&block4));
-        assert_eq!(buffer.block(&block2.hash), Some(&block2));
+        assert_eq!(buffer.block(&block4.hash()), Some(&block4));
+        assert_eq!(buffer.block(&block2.hash()), Some(&block2));
         assert_eq!(buffer.block(&main_parent_hash), None);
 
-        assert_eq!(buffer.lowest_ancestor(&block4.hash), Some(&block4));
-        assert_eq!(buffer.lowest_ancestor(&block3.hash), Some(&block1));
-        assert_eq!(buffer.lowest_ancestor(&block1.hash), Some(&block1));
+        assert_eq!(buffer.lowest_ancestor(&block4.hash()), Some(&block4));
+        assert_eq!(buffer.lowest_ancestor(&block3.hash()), Some(&block1));
+        assert_eq!(buffer.lowest_ancestor(&block1.hash()), Some(&block1));
         assert_eq!(
             buffer.remove_block_with_children(&main_parent_hash),
             vec![block1, block2, block3]
@@ -285,9 +285,9 @@ mod tests {
 
         let main_parent_hash = rng.gen();
         let block1 = create_block(&mut rng, 10, main_parent_hash);
-        let block2 = create_block(&mut rng, 11, block1.hash);
-        let block3 = create_block(&mut rng, 11, block1.hash);
-        let block4 = create_block(&mut rng, 12, block2.hash);
+        let block2 = create_block(&mut rng, 11, block1.hash());
+        let block3 = create_block(&mut rng, 11, block1.hash());
+        let block4 = create_block(&mut rng, 12, block2.hash());
 
         let mut buffer = BlockBuffer::new(5);
 
@@ -301,13 +301,13 @@ mod tests {
             buffer
                 .remove_block_with_children(&main_parent_hash)
                 .into_iter()
-                .map(|b| (b.hash, b))
+                .map(|b| (b.hash(), b))
                 .collect::<HashMap<_, _>>(),
             HashMap::from([
-                (block1.hash, block1),
-                (block2.hash, block2),
-                (block3.hash, block3),
-                (block4.hash, block4)
+                (block1.hash(), block1),
+                (block2.hash(), block2),
+                (block3.hash(), block3),
+                (block4.hash(), block4)
             ])
         );
         assert_buffer_lengths(&buffer, 0);
@@ -319,9 +319,9 @@ mod tests {
 
         let main_parent = BlockNumHash::new(9, rng.gen());
         let block1 = create_block(&mut rng, 10, main_parent.hash);
-        let block2 = create_block(&mut rng, 11, block1.hash);
-        let block3 = create_block(&mut rng, 11, block1.hash);
-        let block4 = create_block(&mut rng, 12, block2.hash);
+        let block2 = create_block(&mut rng, 11, block1.hash());
+        let block3 = create_block(&mut rng, 11, block1.hash());
+        let block4 = create_block(&mut rng, 12, block2.hash());
 
         let mut buffer = BlockBuffer::new(5);
 
@@ -333,15 +333,15 @@ mod tests {
         assert_buffer_lengths(&buffer, 4);
         assert_eq!(
             buffer
-                .remove_block_with_children(&block1.hash)
+                .remove_block_with_children(&block1.hash())
                 .into_iter()
-                .map(|b| (b.hash, b))
+                .map(|b| (b.hash(), b))
                 .collect::<HashMap<_, _>>(),
             HashMap::from([
-                (block1.hash, block1),
-                (block2.hash, block2),
-                (block3.hash, block3),
-                (block4.hash, block4)
+                (block1.hash(), block1),
+                (block2.hash(), block2),
+                (block3.hash(), block3),
+                (block4.hash(), block4)
             ])
         );
         assert_buffer_lengths(&buffer, 0);
@@ -353,8 +353,8 @@ mod tests {
 
         let main_parent = BlockNumHash::new(9, rng.gen());
         let block1 = create_block(&mut rng, 10, main_parent.hash);
-        let block2 = create_block(&mut rng, 11, block1.hash);
-        let block3 = create_block(&mut rng, 12, block2.hash);
+        let block2 = create_block(&mut rng, 11, block1.hash());
+        let block3 = create_block(&mut rng, 12, block2.hash());
         let parent4 = rng.gen();
         let block4 = create_block(&mut rng, 14, parent4);
 
@@ -376,9 +376,9 @@ mod tests {
 
         let main_parent = BlockNumHash::new(9, rng.gen());
         let block1 = create_block(&mut rng, 10, main_parent.hash);
-        let block2 = create_block(&mut rng, 11, block1.hash);
-        let block3 = create_block(&mut rng, 11, block1.hash);
-        let block4 = create_block(&mut rng, 12, block2.hash);
+        let block2 = create_block(&mut rng, 11, block1.hash());
+        let block3 = create_block(&mut rng, 11, block1.hash());
+        let block4 = create_block(&mut rng, 12, block2.hash());
 
         let mut buffer = BlockBuffer::new(5);
 
@@ -399,8 +399,8 @@ mod tests {
         let main_parent = BlockNumHash::new(9, rng.gen());
         let block1 = create_block(&mut rng, 10, main_parent.hash);
         let block1a = create_block(&mut rng, 10, main_parent.hash);
-        let block2 = create_block(&mut rng, 11, block1.hash);
-        let block2a = create_block(&mut rng, 11, block1.hash);
+        let block2 = create_block(&mut rng, 11, block1.hash());
+        let block2a = create_block(&mut rng, 11, block1.hash());
         let random_parent1 = rng.gen();
         let random_block1 = create_block(&mut rng, 10, random_parent1);
         let random_parent2 = rng.gen();
@@ -419,17 +419,17 @@ mod tests {
         buffer.insert_block(random_block3.clone());
 
         // check that random blocks are their own ancestor, and that chains have proper ancestors
-        assert_eq!(buffer.lowest_ancestor(&random_block1.hash), Some(&random_block1));
-        assert_eq!(buffer.lowest_ancestor(&random_block2.hash), Some(&random_block2));
-        assert_eq!(buffer.lowest_ancestor(&random_block3.hash), Some(&random_block3));
+        assert_eq!(buffer.lowest_ancestor(&random_block1.hash()), Some(&random_block1));
+        assert_eq!(buffer.lowest_ancestor(&random_block2.hash()), Some(&random_block2));
+        assert_eq!(buffer.lowest_ancestor(&random_block3.hash()), Some(&random_block3));
 
         // descendants have ancestors
-        assert_eq!(buffer.lowest_ancestor(&block2a.hash), Some(&block1));
-        assert_eq!(buffer.lowest_ancestor(&block2.hash), Some(&block1));
+        assert_eq!(buffer.lowest_ancestor(&block2a.hash()), Some(&block1));
+        assert_eq!(buffer.lowest_ancestor(&block2.hash()), Some(&block1));
 
         // roots are themselves
-        assert_eq!(buffer.lowest_ancestor(&block1a.hash), Some(&block1a));
-        assert_eq!(buffer.lowest_ancestor(&block1.hash), Some(&block1));
+        assert_eq!(buffer.lowest_ancestor(&block1a.hash()), Some(&block1a));
+        assert_eq!(buffer.lowest_ancestor(&block1.hash()), Some(&block1));
 
         assert_buffer_lengths(&buffer, 7);
         buffer.remove_old_blocks(10);
@@ -442,8 +442,8 @@ mod tests {
 
         let main_parent = BlockNumHash::new(9, rng.gen());
         let block1 = create_block(&mut rng, 10, main_parent.hash);
-        let block2 = create_block(&mut rng, 11, block1.hash);
-        let block3 = create_block(&mut rng, 12, block2.hash);
+        let block2 = create_block(&mut rng, 11, block1.hash());
+        let block3 = create_block(&mut rng, 12, block2.hash());
         let parent4 = rng.gen();
         let block4 = create_block(&mut rng, 13, parent4);
 
@@ -454,21 +454,21 @@ mod tests {
         buffer.insert_block(block3.clone());
 
         // pre-eviction block1 is the root
-        assert_eq!(buffer.lowest_ancestor(&block3.hash), Some(&block1));
-        assert_eq!(buffer.lowest_ancestor(&block2.hash), Some(&block1));
-        assert_eq!(buffer.lowest_ancestor(&block1.hash), Some(&block1));
+        assert_eq!(buffer.lowest_ancestor(&block3.hash()), Some(&block1));
+        assert_eq!(buffer.lowest_ancestor(&block2.hash()), Some(&block1));
+        assert_eq!(buffer.lowest_ancestor(&block1.hash()), Some(&block1));
 
         buffer.insert_block(block4.clone());
 
-        assert_eq!(buffer.lowest_ancestor(&block4.hash), Some(&block4));
+        assert_eq!(buffer.lowest_ancestor(&block4.hash()), Some(&block4));
 
         // block1 gets evicted
         assert_block_removal(&buffer, &block1);
 
         // check lowest ancestor results post eviction
-        assert_eq!(buffer.lowest_ancestor(&block3.hash), Some(&block2));
-        assert_eq!(buffer.lowest_ancestor(&block2.hash), Some(&block2));
-        assert_eq!(buffer.lowest_ancestor(&block1.hash), None);
+        assert_eq!(buffer.lowest_ancestor(&block3.hash()), Some(&block2));
+        assert_eq!(buffer.lowest_ancestor(&block2.hash()), Some(&block2));
+        assert_eq!(buffer.lowest_ancestor(&block1.hash()), None);
 
         assert_buffer_lengths(&buffer, 3);
     }
@@ -479,8 +479,8 @@ mod tests {
 
         let main_parent = BlockNumHash::new(9, rng.gen());
         let block1 = create_block(&mut rng, 10, main_parent.hash);
-        let block2 = create_block(&mut rng, 11, block1.hash);
-        let block3 = create_block(&mut rng, 12, block2.hash);
+        let block2 = create_block(&mut rng, 11, block1.hash());
+        let block3 = create_block(&mut rng, 12, block2.hash());
         let parent4 = rng.gen();
         let block4 = create_block(&mut rng, 13, parent4);
 

--- a/crates/blockchain-tree/src/block_buffer.rs
+++ b/crates/blockchain-tree/src/block_buffer.rs
@@ -70,7 +70,7 @@ impl BlockBuffer {
 
     /// Insert a correct block inside the buffer.
     pub fn insert_block(&mut self, block: SealedBlockWithSenders) {
-        let hash = block.hash;
+        let hash = block.hash();
 
         self.parent_to_child.entry(block.parent_hash).or_default().insert(hash);
         self.earliest_blocks.entry(block.number).or_default().insert(hash);

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1288,8 +1288,8 @@ mod tests {
     fn setup_genesis<DB: Database>(factory: &ProviderFactory<DB>, mut genesis: SealedBlock) {
         // insert genesis to db.
 
-        genesis.header.header.number = 10;
-        genesis.header.header.state_root = EMPTY_ROOT_HASH;
+        genesis.header.set_block_number(10);
+        genesis.header.set_state_root(EMPTY_ROOT_HASH);
         let provider = factory.provider_rw().unwrap();
 
         provider
@@ -1506,14 +1506,14 @@ mod tests {
         let fork_block = mock_block(1, Some(chain_spec.genesis_hash()), Vec::from([mock_tx(0)]), 1);
 
         let canonical_block_1 =
-            mock_block(2, Some(fork_block.hash), Vec::from([mock_tx(1), mock_tx(2)]), 3);
-        let canonical_block_2 = mock_block(3, Some(canonical_block_1.hash), Vec::new(), 3);
+            mock_block(2, Some(fork_block.hash()), Vec::from([mock_tx(1), mock_tx(2)]), 3);
+        let canonical_block_2 = mock_block(3, Some(canonical_block_1.hash()), Vec::new(), 3);
         let canonical_block_3 =
-            mock_block(4, Some(canonical_block_2.hash), Vec::from([mock_tx(3)]), 4);
+            mock_block(4, Some(canonical_block_2.hash()), Vec::from([mock_tx(3)]), 4);
 
-        let sidechain_block_1 = mock_block(2, Some(fork_block.hash), Vec::from([mock_tx(1)]), 2);
+        let sidechain_block_1 = mock_block(2, Some(fork_block.hash()), Vec::from([mock_tx(1)]), 2);
         let sidechain_block_2 =
-            mock_block(3, Some(sidechain_block_1.hash), Vec::from([mock_tx(2)]), 3);
+            mock_block(3, Some(sidechain_block_1.hash()), Vec::from([mock_tx(2)]), 3);
 
         let mut tree = BlockchainTree::new(
             TreeExternals::new(provider_factory.clone(), consensus, executor_factory.clone()),
@@ -1525,7 +1525,7 @@ mod tests {
         tree.insert_block(fork_block.clone(), BlockValidationKind::Exhaustive).unwrap();
 
         assert_eq!(
-            tree.make_canonical(&fork_block.hash).unwrap(),
+            tree.make_canonical(&fork_block.hash()).unwrap(),
             CanonicalOutcome::Committed { head: fork_block.header.clone() }
         );
 
@@ -1535,7 +1535,7 @@ mod tests {
         );
 
         assert_eq!(
-            tree.make_canonical(&canonical_block_1.hash).unwrap(),
+            tree.make_canonical(&canonical_block_1.hash()).unwrap(),
             CanonicalOutcome::Committed { head: canonical_block_1.header.clone() }
         );
 
@@ -1550,12 +1550,12 @@ mod tests {
         );
 
         assert_eq!(
-            tree.make_canonical(&sidechain_block_1.hash).unwrap(),
+            tree.make_canonical(&sidechain_block_1.hash()).unwrap(),
             CanonicalOutcome::Committed { head: sidechain_block_1.header.clone() }
         );
 
         assert_eq!(
-            tree.make_canonical(&canonical_block_1.hash).unwrap(),
+            tree.make_canonical(&canonical_block_1.hash()).unwrap(),
             CanonicalOutcome::Committed { head: canonical_block_1.header.clone() }
         );
 
@@ -1565,7 +1565,7 @@ mod tests {
         );
 
         assert_eq!(
-            tree.make_canonical(&sidechain_block_2.hash).unwrap(),
+            tree.make_canonical(&sidechain_block_2.hash()).unwrap(),
             CanonicalOutcome::Committed { head: sidechain_block_2.header.clone() }
         );
 
@@ -1575,7 +1575,7 @@ mod tests {
         );
 
         assert_eq!(
-            tree.make_canonical(&canonical_block_3.hash).unwrap(),
+            tree.make_canonical(&canonical_block_3.hash()).unwrap(),
             CanonicalOutcome::Committed { head: canonical_block_3.header.clone() }
         );
     }
@@ -1609,7 +1609,7 @@ mod tests {
             tree.insert_block(block1.clone(), BlockValidationKind::Exhaustive).unwrap(),
             InsertPayloadOk::Inserted(BlockStatus::Valid(BlockAttachment::Canonical))
         );
-        let block1_chain_id = tree.state.block_indices.get_blocks_chain_id(&block1.hash).unwrap();
+        let block1_chain_id = tree.state.block_indices.get_blocks_chain_id(&block1.hash()).unwrap();
         let block1_chain = tree.state.chains.get(&block1_chain_id).unwrap();
         assert!(block1_chain.trie_updates().is_some());
 
@@ -1617,12 +1617,12 @@ mod tests {
             tree.insert_block(block2.clone(), BlockValidationKind::Exhaustive).unwrap(),
             InsertPayloadOk::Inserted(BlockStatus::Valid(BlockAttachment::Canonical))
         );
-        let block2_chain_id = tree.state.block_indices.get_blocks_chain_id(&block2.hash).unwrap();
+        let block2_chain_id = tree.state.block_indices.get_blocks_chain_id(&block2.hash()).unwrap();
         let block2_chain = tree.state.chains.get(&block2_chain_id).unwrap();
         assert!(block2_chain.trie_updates().is_some());
 
         assert_eq!(
-            tree.make_canonical(&block2.hash).unwrap(),
+            tree.make_canonical(&block2.hash()).unwrap(),
             CanonicalOutcome::Committed { head: block2.header.clone() }
         );
 
@@ -1630,12 +1630,12 @@ mod tests {
             tree.insert_block(block3.clone(), BlockValidationKind::Exhaustive).unwrap(),
             InsertPayloadOk::Inserted(BlockStatus::Valid(BlockAttachment::Canonical))
         );
-        let block3_chain_id = tree.state.block_indices.get_blocks_chain_id(&block3.hash).unwrap();
+        let block3_chain_id = tree.state.block_indices.get_blocks_chain_id(&block3.hash()).unwrap();
         let block3_chain = tree.state.chains.get(&block3_chain_id).unwrap();
         assert!(block3_chain.trie_updates().is_some());
 
         assert_eq!(
-            tree.make_canonical(&block3.hash).unwrap(),
+            tree.make_canonical(&block3.hash()).unwrap(),
             CanonicalOutcome::Committed { head: block3.header.clone() }
         );
 
@@ -1643,7 +1643,7 @@ mod tests {
             tree.insert_block(block4.clone(), BlockValidationKind::Exhaustive).unwrap(),
             InsertPayloadOk::Inserted(BlockStatus::Valid(BlockAttachment::Canonical))
         );
-        let block4_chain_id = tree.state.block_indices.get_blocks_chain_id(&block4.hash).unwrap();
+        let block4_chain_id = tree.state.block_indices.get_blocks_chain_id(&block4.hash()).unwrap();
         let block4_chain = tree.state.chains.get(&block4_chain_id).unwrap();
         assert!(block4_chain.trie_updates().is_some());
 
@@ -1652,12 +1652,12 @@ mod tests {
             InsertPayloadOk::Inserted(BlockStatus::Valid(BlockAttachment::Canonical))
         );
 
-        let block5_chain_id = tree.state.block_indices.get_blocks_chain_id(&block5.hash).unwrap();
+        let block5_chain_id = tree.state.block_indices.get_blocks_chain_id(&block5.hash()).unwrap();
         let block5_chain = tree.state.chains.get(&block5_chain_id).unwrap();
         assert!(block5_chain.trie_updates().is_some());
 
         assert_eq!(
-            tree.make_canonical(&block5.hash).unwrap(),
+            tree.make_canonical(&block5.hash()).unwrap(),
             CanonicalOutcome::Committed { head: block5.header.clone() }
         );
 
@@ -1715,13 +1715,19 @@ mod tests {
         // |
         TreeTester::default()
             .with_chain_num(1)
-            .with_block_to_chain(HashMap::from([(block1.hash, 0.into()), (block2.hash, 0.into())]))
-            .with_fork_to_child(HashMap::from([(block1.parent_hash, HashSet::from([block1.hash]))]))
+            .with_block_to_chain(HashMap::from([
+                (block1.hash(), 0.into()),
+                (block2.hash(), 0.into()),
+            ]))
+            .with_fork_to_child(HashMap::from([(
+                block1.parent_hash,
+                HashSet::from([block1.hash()]),
+            )]))
             .assert(&tree);
 
         let mut block2a = block2.clone();
         let block2a_hash = B256::new([0x34; 32]);
-        block2a.hash = block2a_hash;
+        block2a.set_hash(block2a_hash);
 
         assert_eq!(
             tree.insert_block(block2a.clone(), BlockValidationKind::Exhaustive).unwrap(),
@@ -1742,13 +1748,13 @@ mod tests {
         TreeTester::default()
             .with_chain_num(2)
             .with_block_to_chain(HashMap::from([
-                (block1.hash, 0.into()),
-                (block2.hash, 0.into()),
-                (block2a.hash, 1.into()),
+                (block1.hash(), 0.into()),
+                (block2.hash(), 0.into()),
+                (block2a.hash(), 1.into()),
             ]))
             .with_fork_to_child(HashMap::from([
-                (block1.parent_hash, HashSet::from([block1.hash])),
-                (block2a.parent_hash, HashSet::from([block2a.hash])),
+                (block1.parent_hash, HashSet::from([block1.hash()])),
+                (block2a.parent_hash, HashSet::from([block2a.hash()])),
             ]))
             .assert(&tree);
         // chain 0 has two blocks so receipts and reverts len is 2
@@ -1833,9 +1839,15 @@ mod tests {
         // |
         TreeTester::default()
             .with_chain_num(1)
-            .with_block_to_chain(HashMap::from([(block1.hash, 0.into()), (block2.hash, 0.into())]))
-            .with_fork_to_child(HashMap::from([(block1.parent_hash, HashSet::from([block1.hash]))]))
-            .with_pending_blocks((block1.number, HashSet::from([block1.hash])))
+            .with_block_to_chain(HashMap::from([
+                (block1.hash(), 0.into()),
+                (block2.hash(), 0.into()),
+            ]))
+            .with_fork_to_child(HashMap::from([(
+                block1.parent_hash,
+                HashSet::from([block1.hash()]),
+            )]))
+            .with_pending_blocks((block1.number, HashSet::from([block1.hash()])))
             .assert(&tree);
 
         // already inserted block will `InsertPayloadOk::AlreadySeen(_)`
@@ -1879,10 +1891,10 @@ mod tests {
 
         let mut block1a = block1.clone();
         let block1a_hash = B256::new([0x33; 32]);
-        block1a.hash = block1a_hash;
+        block1a.set_hash(block1a_hash);
         let mut block2a = block2.clone();
         let block2a_hash = B256::new([0x34; 32]);
-        block2a.hash = block2a_hash;
+        block2a.set_hash(block2a_hash);
 
         // reinsert two blocks that point to canonical chain
         assert_eq!(
@@ -1945,10 +1957,13 @@ mod tests {
         // |
         TreeTester::default()
             .with_chain_num(2)
-            .with_block_to_chain(HashMap::from([(block1a_hash, 1.into()), (block2.hash, 3.into())]))
+            .with_block_to_chain(HashMap::from([
+                (block1a_hash, 1.into()),
+                (block2.hash(), 3.into()),
+            ]))
             .with_fork_to_child(HashMap::from([
                 (block1.parent_hash, HashSet::from([block1a_hash])),
-                (block1.hash(), HashSet::from([block2.hash])),
+                (block1.hash(), HashSet::from([block2.hash()])),
             ]))
             .with_pending_blocks((block2.number + 1, HashSet::new()))
             .assert(&tree);
@@ -1966,13 +1981,13 @@ mod tests {
         TreeTester::default()
             .with_chain_num(2)
             .with_block_to_chain(HashMap::from([
-                (block1.hash, 4.into()),
+                (block1.hash(), 4.into()),
                 (block2a_hash, 4.into()),
-                (block2.hash, 3.into()),
+                (block2.hash(), 3.into()),
             ]))
             .with_fork_to_child(HashMap::from([
-                (block1.parent_hash, HashSet::from([block1.hash])),
-                (block1.hash(), HashSet::from([block2.hash])),
+                (block1.parent_hash, HashSet::from([block1.hash()])),
+                (block1.hash(), HashSet::from([block2.hash()])),
             ]))
             .with_pending_blocks((block1a.number + 1, HashSet::new()))
             .assert(&tree);
@@ -1984,11 +1999,11 @@ mod tests {
                 && *new.blocks() == BTreeMap::from([(block1a.number,block1a.clone())]));
 
         // check that b2 and b1 are not canonical
-        assert!(!tree.is_block_hash_canonical(&block2.hash).unwrap());
-        assert!(!tree.is_block_hash_canonical(&block1.hash).unwrap());
+        assert!(!tree.is_block_hash_canonical(&block2.hash()).unwrap());
+        assert!(!tree.is_block_hash_canonical(&block1.hash()).unwrap());
 
         // ensure that b1a is canonical
-        assert!(tree.is_block_hash_canonical(&block1a.hash).unwrap());
+        assert!(tree.is_block_hash_canonical(&block1a.hash()).unwrap());
 
         // make b2 canonical
         tree.make_canonical(&block2.hash()).unwrap();
@@ -2021,7 +2036,7 @@ mod tests {
                 && *new.blocks() == BTreeMap::from([(block1.number,block1.clone()),(block2.number,block2.clone())]));
 
         // check that b2 is now canonical
-        assert!(tree.is_block_hash_canonical(&block2.hash).unwrap());
+        assert!(tree.is_block_hash_canonical(&block2.hash()).unwrap());
 
         // finalize b1 that would make b1a removed from tree
         tree.finalize_block(11);
@@ -2054,16 +2069,19 @@ mod tests {
         // |
         TreeTester::default()
             .with_chain_num(2)
-            .with_block_to_chain(HashMap::from([(block2a_hash, 4.into()), (block2.hash, 6.into())]))
+            .with_block_to_chain(HashMap::from([
+                (block2a_hash, 4.into()),
+                (block2.hash(), 6.into()),
+            ]))
             .with_fork_to_child(HashMap::from([(
                 block1.hash(),
-                HashSet::from([block2a_hash, block2.hash]),
+                HashSet::from([block2a_hash, block2.hash()]),
             )]))
-            .with_pending_blocks((block2.number, HashSet::from([block2.hash, block2a.hash])))
+            .with_pending_blocks((block2.number, HashSet::from([block2.hash(), block2a.hash()])))
             .assert(&tree);
 
         // commit b2a
-        tree.make_canonical(&block2.hash).unwrap();
+        tree.make_canonical(&block2.hash()).unwrap();
 
         // Trie state:
         // b2   b2a (side chain)
@@ -2087,8 +2105,8 @@ mod tests {
 
         // insert unconnected block2b
         let mut block2b = block2a.clone();
-        block2b.hash = B256::new([0x99; 32]);
-        block2b.parent_hash = B256::new([0x88; 32]);
+        block2b.set_hash(B256::new([0x99; 32]));
+        block2b.set_parent_hash(B256::new([0x88; 32]));
 
         assert_eq!(
             tree.insert_block(block2b.clone(), BlockValidationKind::Exhaustive).unwrap(),

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -334,7 +334,7 @@ impl<DB: Database, EF: ExecutorFactory> BlockchainTree<DB, EF> {
             .state
             .buffered_blocks
             .lowest_ancestor(&block_hash)
-            .ok_or_else(|| BlockchainTreeError::BlockBufferingFailed { block_hash })?;
+            .ok_or(BlockchainTreeError::BlockBufferingFailed { block_hash })?;
 
         Ok(BlockStatus::Disconnected { missing_ancestor: lowest_ancestor.parent_num_hash() })
     }

--- a/crates/blockchain-tree/src/noop.rs
+++ b/crates/blockchain-tree/src/noop.rs
@@ -34,7 +34,7 @@ impl BlockchainTreeEngine for NoopBlockchainTree {
         _validation_kind: BlockValidationKind,
     ) -> Result<InsertPayloadOk, InsertBlockError> {
         Err(InsertBlockError::tree_error(
-            BlockchainTreeError::BlockHashNotFoundInChain { block_hash: block.hash },
+            BlockchainTreeError::BlockHashNotFoundInChain { block_hash: block.hash() },
             block.block,
         ))
     }

--- a/crates/blockchain-tree/src/shareable.rs
+++ b/crates/blockchain-tree/src/shareable.rs
@@ -51,7 +51,7 @@ impl<DB: Database, EF: ExecutorFactory> BlockchainTreeEngine for ShareableBlockc
         block: SealedBlockWithSenders,
         validation_kind: BlockValidationKind,
     ) -> Result<InsertPayloadOk, InsertBlockError> {
-        trace!(target: "blockchain_tree", hash=?block.hash, number=block.number, parent_hash=?block.parent_hash, "Inserting block");
+        trace!(target: "blockchain_tree", hash=?block.hash(), number=block.number, parent_hash=?block.parent_hash, "Inserting block");
         let mut tree = self.tree.write();
         let res = tree.insert_block(block, validation_kind);
         tree.update_chains_metrics();
@@ -185,7 +185,7 @@ impl<DB: Database, EF: ExecutorFactory> BlockchainTreeViewer for ShareableBlockc
         let tree = self.tree.read();
         let pending_block = tree.pending_block()?.clone();
         let receipts =
-            tree.receipts_by_block_hash(pending_block.hash)?.into_iter().cloned().collect();
+            tree.receipts_by_block_hash(pending_block.hash())?.into_iter().cloned().collect();
         Some((pending_block, receipts))
     }
 

--- a/crates/consensus/auto-seal/src/task.rs
+++ b/crates/consensus/auto-seal/src/task.rs
@@ -147,9 +147,9 @@ where
                             );
 
                             let state = ForkchoiceState {
-                                head_block_hash: new_header.hash,
-                                finalized_block_hash: new_header.hash,
-                                safe_block_hash: new_header.hash,
+                                head_block_hash: new_header.hash(),
+                                finalized_block_hash: new_header.hash(),
+                                safe_block_hash: new_header.hash(),
                             };
                             drop(storage);
 

--- a/crates/consensus/beacon/src/engine/invalid_headers.rs
+++ b/crates/consensus/beacon/src/engine/invalid_headers.rs
@@ -109,13 +109,13 @@ mod tests {
         let mut cache = InvalidHeaderCache::new(10);
         let header = Header::default().seal_slow();
         cache.insert(header.clone());
-        assert_eq!(cache.headers.get(&header.hash).unwrap().hit_count, 0);
+        assert_eq!(cache.headers.get(&header.hash()).unwrap().hit_count, 0);
 
         for hit in 1..INVALID_HEADER_HIT_EVICTION_THRESHOLD {
-            assert!(cache.get(&header.hash).is_some());
-            assert_eq!(cache.headers.get(&header.hash).unwrap().hit_count, hit);
+            assert!(cache.get(&header.hash()).is_some());
+            assert_eq!(cache.headers.get(&header.hash()).unwrap().hit_count, hit);
         }
 
-        assert!(cache.get(&header.hash).is_none());
+        assert!(cache.get(&header.hash()).is_none());
     }
 }

--- a/crates/consensus/beacon/src/engine/invalid_headers.rs
+++ b/crates/consensus/beacon/src/engine/invalid_headers.rs
@@ -66,8 +66,8 @@ impl InvalidHeaderCache {
 
     /// Inserts an invalid ancestor into the map.
     pub(crate) fn insert(&mut self, invalid_ancestor: SealedHeader) {
-        if self.get(&invalid_ancestor.hash).is_none() {
-            let hash = invalid_ancestor.hash;
+        if self.get(&invalid_ancestor.hash()).is_none() {
+            let hash = invalid_ancestor.hash();
             let header = invalid_ancestor.unseal();
             warn!(target: "consensus::engine", ?hash, ?header, "Bad block with hash");
             self.insert_entry(hash, Arc::new(header));

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -2137,7 +2137,7 @@ mod tests {
                 .build();
 
             let genesis = random_block(&mut rng, 0, None, None, Some(0));
-            let block1 = random_block(&mut rng, 1, Some(genesis.hash), None, Some(0));
+            let block1 = random_block(&mut rng, 1, Some(genesis.hash()), None, Some(0));
             insert_blocks(env.db.as_ref(), chain_spec.clone(), [&genesis, &block1].into_iter());
             env.db
                 .update(|tx| {
@@ -2152,15 +2152,15 @@ mod tests {
             let mut engine_rx = spawn_consensus_engine(consensus_engine);
 
             let forkchoice = ForkchoiceState {
-                head_block_hash: block1.hash,
-                finalized_block_hash: block1.hash,
+                head_block_hash: block1.hash(),
+                finalized_block_hash: block1.hash(),
                 ..Default::default()
             };
 
             let result = env.send_forkchoice_updated(forkchoice).await.unwrap();
             let expected_result = ForkchoiceUpdated::new(PayloadStatus::new(
                 PayloadStatusEnum::Valid,
-                Some(block1.hash),
+                Some(block1.hash()),
             ));
             assert_eq!(result, expected_result);
             assert_matches!(engine_rx.try_recv(), Err(TryRecvError::Empty));
@@ -2187,15 +2187,15 @@ mod tests {
                 .build();
 
             let genesis = random_block(&mut rng, 0, None, None, Some(0));
-            let block1 = random_block(&mut rng, 1, Some(genesis.hash), None, Some(0));
+            let block1 = random_block(&mut rng, 1, Some(genesis.hash()), None, Some(0));
             insert_blocks(env.db.as_ref(), chain_spec.clone(), [&genesis, &block1].into_iter());
 
             let mut engine_rx = spawn_consensus_engine(consensus_engine);
 
-            let next_head = random_block(&mut rng, 2, Some(block1.hash), None, Some(0));
+            let next_head = random_block(&mut rng, 2, Some(block1.hash()), None, Some(0));
             let next_forkchoice_state = ForkchoiceState {
-                head_block_hash: next_head.hash,
-                finalized_block_hash: block1.hash,
+                head_block_hash: next_head.hash(),
+                finalized_block_hash: block1.hash(),
                 ..Default::default()
             };
 
@@ -2211,7 +2211,7 @@ mod tests {
 
             let result = env.send_forkchoice_retry_on_syncing(next_forkchoice_state).await.unwrap();
             let expected_result = ForkchoiceUpdated::from_status(PayloadStatusEnum::Valid)
-                .with_latest_valid_hash(next_head.hash);
+                .with_latest_valid_hash(next_head.hash());
             assert_eq!(result, expected_result);
 
             assert_matches!(engine_rx.try_recv(), Err(TryRecvError::Empty));
@@ -2237,7 +2237,7 @@ mod tests {
                 .build();
 
             let genesis = random_block(&mut rng, 0, None, None, Some(0));
-            let block1 = random_block(&mut rng, 1, Some(genesis.hash), None, Some(0));
+            let block1 = random_block(&mut rng, 1, Some(genesis.hash()), None, Some(0));
             insert_blocks(env.db.as_ref(), chain_spec.clone(), [&genesis, &block1].into_iter());
 
             let engine = spawn_consensus_engine(consensus_engine);
@@ -2245,7 +2245,7 @@ mod tests {
             let res = env
                 .send_forkchoice_updated(ForkchoiceState {
                     head_block_hash: rng.gen(),
-                    finalized_block_hash: block1.hash,
+                    finalized_block_hash: block1.hash(),
                     ..Default::default()
                 })
                 .await;
@@ -2274,16 +2274,16 @@ mod tests {
                 .build();
 
             let genesis = random_block(&mut rng, 0, None, None, Some(0));
-            let mut block1 = random_block(&mut rng, 1, Some(genesis.hash), None, Some(0));
-            block1.header.difficulty = U256::from(1);
+            let mut block1 = random_block(&mut rng, 1, Some(genesis.hash()), None, Some(0));
+            block1.header.set_difficulty(U256::from(1));
 
             // a second pre-merge block
-            let mut block2 = random_block(&mut rng, 1, Some(genesis.hash), None, Some(0));
-            block2.header.difficulty = U256::from(1);
+            let mut block2 = random_block(&mut rng, 1, Some(genesis.hash()), None, Some(0));
+            block2.header.set_difficulty(U256::from(1));
 
             // a transition block
-            let mut block3 = random_block(&mut rng, 1, Some(genesis.hash), None, Some(0));
-            block3.header.difficulty = U256::from(1);
+            let mut block3 = random_block(&mut rng, 1, Some(genesis.hash()), None, Some(0));
+            block3.header.set_difficulty(U256::from(1));
 
             insert_blocks(
                 env.db.as_ref(),
@@ -2295,8 +2295,8 @@ mod tests {
 
             let res = env
                 .send_forkchoice_updated(ForkchoiceState {
-                    head_block_hash: block1.hash,
-                    finalized_block_hash: block1.hash,
+                    head_block_hash: block1.hash(),
+                    finalized_block_hash: block1.hash(),
                     ..Default::default()
                 })
                 .await;
@@ -2327,7 +2327,7 @@ mod tests {
                 .build();
 
             let genesis = random_block(&mut rng, 0, None, None, Some(0));
-            let block1 = random_block(&mut rng, 1, Some(genesis.hash), None, Some(0));
+            let block1 = random_block(&mut rng, 1, Some(genesis.hash()), None, Some(0));
 
             insert_blocks(env.db.as_ref(), chain_spec.clone(), [&genesis, &block1].into_iter());
 
@@ -2335,13 +2335,13 @@ mod tests {
 
             let res = env
                 .send_forkchoice_updated(ForkchoiceState {
-                    head_block_hash: block1.hash,
-                    finalized_block_hash: block1.hash,
+                    head_block_hash: block1.hash(),
+                    finalized_block_hash: block1.hash(),
                     ..Default::default()
                 })
                 .await;
             let expected_result = ForkchoiceUpdated::from_status(PayloadStatusEnum::Invalid {
-                validation_error: BlockValidationError::BlockPreMerge { hash: block1.hash }
+                validation_error: BlockValidationError::BlockPreMerge { hash: block1.hash() }
                     .to_string(),
             })
             .with_latest_valid_hash(B256::ZERO);
@@ -2422,8 +2422,8 @@ mod tests {
                 .build();
 
             let genesis = random_block(&mut rng, 0, None, None, Some(0));
-            let block1 = random_block(&mut rng, 1, Some(genesis.hash), None, Some(0));
-            let block2 = random_block(&mut rng, 2, Some(block1.hash), None, Some(0));
+            let block1 = random_block(&mut rng, 1, Some(genesis.hash()), None, Some(0));
+            let block2 = random_block(&mut rng, 2, Some(block1.hash()), None, Some(0));
             insert_blocks(
                 env.db.as_ref(),
                 chain_spec.clone(),
@@ -2435,13 +2435,13 @@ mod tests {
             // Send forkchoice
             let res = env
                 .send_forkchoice_updated(ForkchoiceState {
-                    head_block_hash: block1.hash,
-                    finalized_block_hash: block1.hash,
+                    head_block_hash: block1.hash(),
+                    finalized_block_hash: block1.hash(),
                     ..Default::default()
                 })
                 .await;
             let expected_result = PayloadStatus::from_status(PayloadStatusEnum::Valid)
-                .with_latest_valid_hash(block1.hash);
+                .with_latest_valid_hash(block1.hash());
             assert_matches!(res, Ok(ForkchoiceUpdated { payload_status, .. }) => assert_eq!(payload_status, expected_result));
 
             // Send new payload
@@ -2451,7 +2451,7 @@ mod tests {
                 .unwrap();
 
             let expected_result = PayloadStatus::from_status(PayloadStatusEnum::Valid)
-                .with_latest_valid_hash(block2.hash);
+                .with_latest_valid_hash(block2.hash());
             assert_eq!(result, expected_result);
             assert_matches!(engine_rx.try_recv(), Err(TryRecvError::Empty));
         }
@@ -2498,13 +2498,13 @@ mod tests {
             // Send forkchoice
             let res = env
                 .send_forkchoice_updated(ForkchoiceState {
-                    head_block_hash: block1.hash,
-                    finalized_block_hash: block1.hash,
+                    head_block_hash: block1.hash(),
+                    finalized_block_hash: block1.hash(),
                     ..Default::default()
                 })
                 .await;
             let expected_result = PayloadStatus::from_status(PayloadStatusEnum::Valid)
-                .with_latest_valid_hash(block1.hash);
+                .with_latest_valid_hash(block1.hash());
             assert_matches!(res, Ok(ForkchoiceUpdated { payload_status, .. }) => assert_eq!(payload_status, expected_result));
             assert_matches!(engine_rx.try_recv(), Err(TryRecvError::Empty));
         }
@@ -2536,13 +2536,13 @@ mod tests {
             // Send forkchoice
             let res = env
                 .send_forkchoice_updated(ForkchoiceState {
-                    head_block_hash: genesis.hash,
-                    finalized_block_hash: genesis.hash,
+                    head_block_hash: genesis.hash(),
+                    finalized_block_hash: genesis.hash(),
                     ..Default::default()
                 })
                 .await;
             let expected_result = PayloadStatus::from_status(PayloadStatusEnum::Valid)
-                .with_latest_valid_hash(genesis.hash);
+                .with_latest_valid_hash(genesis.hash());
             assert_matches!(res, Ok(ForkchoiceUpdated { payload_status, .. }) => assert_eq!(payload_status, expected_result));
 
             // Send new payload
@@ -2559,15 +2559,17 @@ mod tests {
         async fn payload_pre_merge() {
             let data = BlockChainTestData::default();
             let mut block1 = data.blocks[0].0.block.clone();
-            block1.header.difficulty = MAINNET.fork(Hardfork::Paris).ttd().unwrap() - U256::from(1);
+            block1
+                .header
+                .set_difficulty(MAINNET.fork(Hardfork::Paris).ttd().unwrap() - U256::from(1));
             block1 = block1.unseal().seal_slow();
             let (block2, exec_result2) = data.blocks[1].clone();
-            let mut block2 = block2.block;
+            let mut block2 = block2.unseal().block;
             block2.withdrawals = None;
-            block2.header.parent_hash = block1.hash;
+            block2.header.parent_hash = block1.hash();
             block2.header.base_fee_per_gas = Some(100);
             block2.header.difficulty = U256::ZERO;
-            block2 = block2.unseal().seal_slow();
+            let block2 = block2.clone().seal_slow();
 
             let chain_spec = Arc::new(
                 ChainSpecBuilder::default()
@@ -2596,14 +2598,14 @@ mod tests {
             // Send forkchoice
             let res = env
                 .send_forkchoice_updated(ForkchoiceState {
-                    head_block_hash: block1.hash,
-                    finalized_block_hash: block1.hash,
+                    head_block_hash: block1.hash(),
+                    finalized_block_hash: block1.hash(),
                     ..Default::default()
                 })
                 .await;
 
             let expected_result = PayloadStatus::from_status(PayloadStatusEnum::Invalid {
-                validation_error: BlockValidationError::BlockPreMerge { hash: block1.hash }
+                validation_error: BlockValidationError::BlockPreMerge { hash: block1.hash() }
                     .to_string(),
             })
             .with_latest_valid_hash(B256::ZERO);
@@ -2616,7 +2618,7 @@ mod tests {
                 .unwrap();
 
             let expected_result = PayloadStatus::from_status(PayloadStatusEnum::Invalid {
-                validation_error: BlockValidationError::BlockPreMerge { hash: block2.hash }
+                validation_error: BlockValidationError::BlockPreMerge { hash: block2.hash() }
                     .to_string(),
             })
             .with_latest_valid_hash(B256::ZERO);

--- a/crates/consensus/beacon/src/engine/sync.rs
+++ b/crates/consensus/beacon/src/engine/sync.rs
@@ -574,7 +574,7 @@ mod tests {
             header.parent_hash = hash;
             header.number += 1;
             header.timestamp += 1;
-            sealed_header = SealedHeader::new(header, hash);
+            sealed_header = header.seal_slow();
             client.insert(sealed_header.clone(), body.clone());
         }
     }

--- a/crates/consensus/beacon/src/engine/sync.rs
+++ b/crates/consensus/beacon/src/engine/sync.rs
@@ -566,7 +566,6 @@ mod tests {
         });
     }
 
-    /// Inserts headers and returns the last header and block body.
     fn insert_headers_into_client(
         client: &TestFullBlockClient,
         genesis_header: SealedHeader,

--- a/crates/consensus/beacon/src/engine/sync.rs
+++ b/crates/consensus/beacon/src/engine/sync.rs
@@ -595,7 +595,7 @@ mod tests {
         );
 
         let client = TestFullBlockClient::default();
-        let mut header = Header {
+        let header = Header {
             base_fee_per_gas: Some(7),
             gas_limit: ETHEREUM_BLOCK_GAS_LIMIT,
             ..Default::default()

--- a/crates/consensus/beacon/src/engine/sync.rs
+++ b/crates/consensus/beacon/src/engine/sync.rs
@@ -397,8 +397,7 @@ mod tests {
     use reth_db::{mdbx::DatabaseEnv, test_utils::TempDatabase};
     use reth_interfaces::{p2p::either::EitherDownloader, test_utils::TestFullBlockClient};
     use reth_primitives::{
-        stage::StageCheckpoint, BlockBody, ChainSpec,
-        ChainSpecBuilder, SealedHeader, MAINNET,
+        stage::StageCheckpoint, BlockBody, ChainSpec, ChainSpecBuilder, SealedHeader, MAINNET,
     };
     use reth_provider::{
         test_utils::{create_test_provider_factory_with_chain_spec, TestExecutorFactory},

--- a/crates/interfaces/src/blockchain_tree/error.rs
+++ b/crates/interfaces/src/blockchain_tree/error.rs
@@ -152,7 +152,10 @@ impl std::fmt::Display for InsertBlockErrorData {
         write!(
             f,
             "Failed to insert block (hash={}, number={}, parent_hash={}): {}",
-            self.block.hash, self.block.number, self.block.parent_hash, self.kind
+            self.block.hash(),
+            self.block.number,
+            self.block.parent_hash,
+            self.kind
         )
     }
 }
@@ -161,7 +164,7 @@ impl std::fmt::Debug for InsertBlockErrorData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("InsertBlockError")
             .field("error", &self.kind)
-            .field("hash", &self.block.hash)
+            .field("hash", &self.block.hash())
             .field("number", &self.block.number)
             .field("parent_hash", &self.block.parent_hash)
             .field("num_txs", &self.block.body.len())

--- a/crates/interfaces/src/p2p/full_block.rs
+++ b/crates/interfaces/src/p2p/full_block.rs
@@ -150,7 +150,7 @@ where
             BodyResponse::PendingValidation(resp) => {
                 // ensure the block is valid, else retry
                 if let Err(err) = ensure_valid_body_response(&header, resp.data()) {
-                    debug!(target: "downloaders", ?err,  hash=?header.hash, "Received wrong body");
+                    debug!(target: "downloaders", ?err,  hash=?header.hash(), "Received wrong body");
                     self.client.report_bad_message(resp.peer_id());
                     self.header = Some(header);
                     self.request.body = Some(self.client.get_block_body(self.hash));
@@ -164,7 +164,7 @@ where
     fn on_block_response(&mut self, resp: WithPeerId<BlockBody>) {
         if let Some(ref header) = self.header {
             if let Err(err) = ensure_valid_body_response(header, resp.data()) {
-                debug!(target: "downloaders", ?err,  hash=?header.hash, "Received wrong body");
+                debug!(target: "downloaders", ?err,  hash=?header.hash(), "Received wrong body");
                 self.client.report_bad_message(resp.peer_id());
                 return
             }
@@ -193,7 +193,7 @@ where
                                 maybe_header.map(|h| h.map(|h| h.seal_slow())).split();
                             if let Some(header) = maybe_header {
                                 if header.hash() != this.hash {
-                                    debug!(target: "downloaders", expected=?this.hash, received=?header.hash, "Received wrong header");
+                                    debug!(target: "downloaders", expected=?this.hash, received=?header.hash(), "Received wrong header");
                                     // received a different header than requested
                                     this.client.report_bad_message(peer)
                                 } else {
@@ -438,7 +438,7 @@ where
                     BodyResponse::PendingValidation(resp) => {
                         // ensure the block is valid, else retry
                         if let Err(err) = ensure_valid_body_response(header, resp.data()) {
-                            debug!(target: "downloaders", ?err,  hash=?header.hash, "Received wrong body in range response");
+                            debug!(target: "downloaders", ?err,  hash=?header.hash(), "Received wrong body in range response");
                             self.client.report_bad_message(resp.peer_id());
 
                             // get body that doesn't match, put back into vecdeque, and just retry

--- a/crates/interfaces/src/p2p/full_block.rs
+++ b/crates/interfaces/src/p2p/full_block.rs
@@ -777,7 +777,7 @@ mod tests {
             header.parent_hash = hash;
             header.number += 1;
 
-            sealed_header = SealedHeader::new(header, hash);
+            sealed_header = header.seal_slow();
             client.insert(sealed_header.clone(), body.clone());
         }
 

--- a/crates/interfaces/src/p2p/full_block.rs
+++ b/crates/interfaces/src/p2p/full_block.rs
@@ -438,7 +438,7 @@ where
                     BodyResponse::PendingValidation(resp) => {
                         // ensure the block is valid, else retry
                         if let Err(err) = ensure_valid_body_response(header, resp.data()) {
-                            debug!(target: "downloaders", ?err,  hash=?header.hash, "Received wrong body in range response");
+                            debug!(target: "downloaders", ?err,  hash=?header.hash(), "Received wrong body in range response");
                             self.client.report_bad_message(resp.peer_id());
 
                             // get body that doesn't match, put back into vecdeque, and just retry

--- a/crates/net/downloaders/src/headers/reverse_headers.rs
+++ b/crates/net/downloaders/src/headers/reverse_headers.rs
@@ -294,7 +294,7 @@ where
             // detached head error.
             if let Err(error) = self.consensus.validate_header_against_parent(last_header, head) {
                 // Replace the last header with a detached variant
-                error!(target: "downloaders::headers", ?error, number = last_header.number, hash = ?last_header.hash, "Header cannot be attached to known canonical chain");
+                error!(target: "downloaders::headers", ?error, number = last_header.number, hash = ?last_header.hash(), "Header cannot be attached to known canonical chain");
                 return Err(HeadersDownloaderError::DetachedHead {
                     local_head: Box::new(head.clone()),
                     header: Box::new(last_header.clone()),

--- a/crates/node-core/src/utils.rs
+++ b/crates/node-core/src/utils.rs
@@ -107,7 +107,7 @@ pub async fn get_single_body<Client>(
 where
     Client: BodiesClient,
 {
-    let (peer_id, response) = client.get_block_body(header.hash).await?.split();
+    let (peer_id, response) = client.get_block_body(header.hash()).await?.split();
 
     if response.is_none() {
         client.report_bad_message(peer_id);

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -215,7 +215,7 @@ where
                 }
             }
 
-            self.pre_cached = Some(PrecachedState { block: committed.tip().hash, cached });
+            self.pre_cached = Some(PrecachedState { block: committed.tip().hash(), cached });
         }
     }
 }

--- a/crates/payload/ethereum/src/lib.rs
+++ b/crates/payload/ethereum/src/lib.rs
@@ -73,10 +73,10 @@ mod builder {
                 ..
             } = config;
 
-            debug!(target: "payload_builder", parent_hash = ?parent_block.hash, parent_number = parent_block.number, "building empty payload");
+            debug!(target: "payload_builder", parent_hash = ?parent_block.hash(), parent_number = parent_block.number, "building empty payload");
 
-            let state = client.state_by_block_hash(parent_block.hash).map_err(|err| {
-                warn!(target: "payload_builder", parent_hash=%parent_block.hash, ?err,  "failed to get state for empty payload");
+            let state = client.state_by_block_hash(parent_block.hash()).map_err(|err| {
+                warn!(target: "payload_builder", parent_hash=%parent_block.hash(), ?err,  "failed to get state for empty payload");
                 err
             })?;
             let mut db = State::builder()
@@ -98,13 +98,13 @@ mod builder {
                 &initialized_block_env,
                 &attributes,
             ).map_err(|err| {
-                warn!(target: "payload_builder", parent_hash=%parent_block.hash, ?err,  "failed to apply beacon root contract call for empty payload");
+                warn!(target: "payload_builder", parent_hash=%parent_block.hash(), ?err,  "failed to apply beacon root contract call for empty payload");
                 err
             })?;
 
             let WithdrawalsOutcome { withdrawals_root, withdrawals } =
                 commit_withdrawals(&mut db, &chain_spec, attributes.timestamp, attributes.withdrawals.clone()).map_err(|err| {
-                    warn!(target: "payload_builder", parent_hash=%parent_block.hash, ?err,  "failed to commit withdrawals for empty payload");
+                    warn!(target: "payload_builder", parent_hash=%parent_block.hash(), ?err,  "failed to commit withdrawals for empty payload");
                     err
                 })?;
 
@@ -116,7 +116,7 @@ mod builder {
             let bundle_state =
                 BundleStateWithReceipts::new(db.take_bundle(), Receipts::new(), block_number);
             let state_root = state.state_root(&bundle_state).map_err(|err| {
-                warn!(target: "payload_builder", parent_hash=%parent_block.hash, ?err,  "failed to calculate state root for empty payload");
+                warn!(target: "payload_builder", parent_hash=%parent_block.hash(), ?err,  "failed to calculate state root for empty payload");
                 err
             })?;
 
@@ -140,7 +140,7 @@ mod builder {
             }
 
             let header = Header {
-                parent_hash: parent_block.hash,
+                parent_hash: parent_block.hash(),
                 ommers_hash: EMPTY_OMMER_ROOT_HASH,
                 beneficiary: initialized_block_env.coinbase,
                 state_root,
@@ -184,7 +184,7 @@ mod builder {
     {
         let BuildArguments { client, pool, mut cached_reads, config, cancel, best_payload } = args;
 
-        let state_provider = client.state_by_block_hash(config.parent_block.hash)?;
+        let state_provider = client.state_by_block_hash(config.parent_block.hash())?;
         let state = StateProviderDatabase::new(&state_provider);
         let mut db = State::builder()
             .with_database_ref(cached_reads.as_db(&state))
@@ -200,7 +200,7 @@ mod builder {
             ..
         } = config;
 
-        debug!(target: "payload_builder", id=%attributes.id, parent_hash = ?parent_block.hash, parent_number = parent_block.number, "building new payload");
+        debug!(target: "payload_builder", id=%attributes.id, parent_hash = ?parent_block.hash(), parent_number = parent_block.number, "building new payload");
         let mut cumulative_gas_used = 0;
         let mut sum_blob_gas_used = 0;
         let block_gas_limit: u64 = initialized_block_env.gas_limit.try_into().unwrap_or(u64::MAX);
@@ -387,7 +387,7 @@ mod builder {
         }
 
         let header = Header {
-            parent_hash: parent_block.hash,
+            parent_hash: parent_block.hash(),
             ommers_hash: EMPTY_OMMER_ROOT_HASH,
             beneficiary: initialized_block_env.coinbase,
             state_root,

--- a/crates/payload/optimism/src/lib.rs
+++ b/crates/payload/optimism/src/lib.rs
@@ -111,10 +111,10 @@ mod builder {
                 ..
             } = config;
 
-            debug!(target: "payload_builder", parent_hash = ?parent_block.hash, parent_number = parent_block.number, "building empty payload");
+            debug!(target: "payload_builder", parent_hash = ?parent_block.hash(), parent_number = parent_block.number, "building empty payload");
 
-            let state = client.state_by_block_hash(parent_block.hash).map_err(|err| {
-                warn!(target: "payload_builder", parent_hash=%parent_block.hash, ?err,  "failed to get state for empty payload");
+            let state = client.state_by_block_hash(parent_block.hash()).map_err(|err| {
+                warn!(target: "payload_builder", parent_hash=%parent_block.hash(), ?err,  "failed to get state for empty payload");
                 err
             })?;
             let mut db = State::builder()
@@ -136,13 +136,13 @@ mod builder {
                 &initialized_block_env,
                 &attributes,
             ).map_err(|err| {
-                warn!(target: "payload_builder", parent_hash=%parent_block.hash, ?err,  "failed to apply beacon root contract call for empty payload");
+                warn!(target: "payload_builder", parent_hash=%parent_block.hash(), ?err,  "failed to apply beacon root contract call for empty payload");
                 err
             })?;
 
             let WithdrawalsOutcome { withdrawals_root, withdrawals } =
                 commit_withdrawals(&mut db, &chain_spec, attributes.payload_attributes.timestamp, attributes.payload_attributes.withdrawals.clone()).map_err(|err| {
-                    warn!(target: "payload_builder", parent_hash=%parent_block.hash, ?err,  "failed to commit withdrawals for empty payload");
+                    warn!(target: "payload_builder", parent_hash=%parent_block.hash(), ?err,  "failed to commit withdrawals for empty payload");
                     err
                 })?;
 
@@ -154,12 +154,12 @@ mod builder {
             let bundle_state =
                 BundleStateWithReceipts::new(db.take_bundle(), Receipts::new(), block_number);
             let state_root = state.state_root(&bundle_state).map_err(|err| {
-                warn!(target: "payload_builder", parent_hash=%parent_block.hash, ?err,  "failed to calculate state root for empty payload");
+                warn!(target: "payload_builder", parent_hash=%parent_block.hash(), ?err,  "failed to calculate state root for empty payload");
                 err
             })?;
 
             let header = Header {
-                parent_hash: parent_block.hash,
+                parent_hash: parent_block.hash(),
                 ommers_hash: EMPTY_OMMER_ROOT_HASH,
                 beneficiary: initialized_block_env.coinbase,
                 state_root,
@@ -211,7 +211,7 @@ mod builder {
     {
         let BuildArguments { client, pool, mut cached_reads, config, cancel, best_payload } = args;
 
-        let state_provider = client.state_by_block_hash(config.parent_block.hash)?;
+        let state_provider = client.state_by_block_hash(config.parent_block.hash())?;
         let state = StateProviderDatabase::new(&state_provider);
         let mut db = State::builder()
             .with_database_ref(cached_reads.as_db(&state))
@@ -227,7 +227,7 @@ mod builder {
             ..
         } = config;
 
-        debug!(target: "payload_builder", id=%attributes.payload_attributes.payload_id(), parent_hash = ?parent_block.hash, parent_number = parent_block.number, "building new payload");
+        debug!(target: "payload_builder", id=%attributes.payload_attributes.payload_id(), parent_hash = ?parent_block.hash(), parent_number = parent_block.number, "building new payload");
         let mut cumulative_gas_used = 0;
         let block_gas_limit: u64 = attributes
             .gas_limit
@@ -480,7 +480,7 @@ mod builder {
         let blob_gas_used = None;
 
         let header = Header {
-            parent_hash: parent_block.hash,
+            parent_hash: parent_block.hash(),
             ommers_hash: EMPTY_OMMER_ROOT_HASH,
             beneficiary: initialized_block_env.coinbase,
             state_root,

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -232,7 +232,7 @@ impl SealedBlock {
 
     /// Header hash.
     #[inline]
-    pub fn hash(&self) -> B256 {
+    pub const fn hash(&self) -> B256 {
         self.header.hash()
     }
 

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -700,7 +700,7 @@ impl ChainSpec {
 
     /// Get the sealed header for the genesis block.
     pub fn sealed_genesis_header(&self) -> SealedHeader {
-        SealedHeader { header: self.genesis_header(), hash: self.genesis_hash() }
+        SealedHeader::new(self.genesis_header(), self.genesis_hash())
     }
 
     /// Get the initial base fee of the genesis block.

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -687,7 +687,7 @@ impl SealedHeader {
 
     /// Returns header/block hash.
     #[inline]
-    pub fn hash(&self) -> BlockHash {
+    pub const fn hash(&self) -> BlockHash {
         self.hash
     }
 

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -13,10 +13,7 @@ use alloy_rlp::{length_of_length, Decodable, Encodable, EMPTY_LIST_CODE, EMPTY_S
 use bytes::{Buf, BufMut, BytesMut};
 use reth_codecs::{add_arbitrary_tests, derive_arbitrary, main_codec, Compact};
 use serde::{Deserialize, Serialize};
-use std::{
-    mem,
-    ops::{Deref, DerefMut},
-};
+use std::{mem, ops::Deref};
 
 /// Errors that can occur during header sanity checks.
 #[derive(Debug, PartialEq)]
@@ -670,12 +667,30 @@ pub enum HeaderValidationError {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct SealedHeader {
     /// Locked Header fields.
-    pub header: Header,
+    header: Header,
     /// Locked Header hash.
-    pub hash: BlockHash,
+    hash: BlockHash,
 }
 
 impl SealedHeader {
+    /// Creates the sealed header with corresponding block hash.
+    #[inline]
+    pub fn new(header: Header, hash: BlockHash) -> Self {
+        Self { header, hash }
+    }
+
+    /// Returns the sealed Header fields.
+    #[inline]
+    pub fn header(&self) -> &Header {
+        &self.header
+    }
+
+    /// Return header/block hash.
+    #[inline]
+    pub fn hash(&self) -> BlockHash {
+        self.hash
+    }
+
     /// Checks the gas limit for consistency between parent and self headers.
     ///
     /// The maximum allowable difference between self and parent gas limits is determined by the
@@ -864,11 +879,6 @@ impl SealedHeader {
         (self.header, self.hash)
     }
 
-    /// Return header/block hash.
-    pub fn hash(&self) -> BlockHash {
-        self.hash
-    }
-
     /// Return the number hash tuple.
     pub fn num_hash(&self) -> BlockNumHash {
         BlockNumHash::new(self.number, self.hash)
@@ -942,12 +952,6 @@ impl Deref for SealedHeader {
 
     fn deref(&self) -> &Self::Target {
         &self.header
-    }
-}
-
-impl DerefMut for SealedHeader {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.header
     }
 }
 

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -673,9 +673,9 @@ pub struct SealedHeader {
 }
 
 impl SealedHeader {
-    /// Creates the sealed header with corresponding block hash.
+    /// Creates the sealed header with the corresponding block hash.
     #[inline]
-    pub fn new(header: Header, hash: BlockHash) -> Self {
+    pub const fn new(header: Header, hash: BlockHash) -> Self {
         Self { header, hash }
     }
 
@@ -689,6 +689,16 @@ impl SealedHeader {
     #[inline]
     pub fn hash(&self) -> BlockHash {
         self.hash
+    }
+
+    #[cfg(test)]
+    pub fn set_header(&mut self, header: Header) {
+        self.header = header
+    }
+
+    #[cfg(test)]
+    pub fn set_hash(&mut self, hash: BlockHash) {
+        self.hash = hash
     }
 
     /// Checks the gas limit for consistency between parent and self headers.

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -685,20 +685,46 @@ impl SealedHeader {
         &self.header
     }
 
-    /// Return header/block hash.
+    /// Returns header/block hash.
     #[inline]
     pub fn hash(&self) -> BlockHash {
         self.hash
     }
 
-    #[cfg(test)]
+    /// Updates the block header.
+    #[cfg(any(test, feature = "test-utils"))]
     pub fn set_header(&mut self, header: Header) {
         self.header = header
     }
 
-    #[cfg(test)]
+    /// Updates the block hash.
+    #[cfg(any(test, feature = "test-utils"))]
     pub fn set_hash(&mut self, hash: BlockHash) {
         self.hash = hash
+    }
+
+    /// Updates the parent block hash.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn set_parent_hash(&mut self, hash: BlockHash) {
+        self.header.parent_hash = hash
+    }
+
+    /// Updates the block number.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn set_block_number(&mut self, number: BlockNumber) {
+        self.header.number = number;
+    }
+
+    /// Updates the block state root.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn set_state_root(&mut self, state_root: B256) {
+        self.header.state_root = state_root;
+    }
+
+    /// Updates the block difficulty.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn set_difficulty(&mut self, difficulty: U256) {
+        self.header.difficulty = difficulty;
     }
 
     /// Checks the gas limit for consistency between parent and self headers.

--- a/crates/rpc/rpc-types-compat/src/block.rs
+++ b/crates/rpc/rpc-types-compat/src/block.rs
@@ -92,32 +92,29 @@ pub fn from_block_full(
 
 /// Converts from a [reth_primitives::SealedHeader] to a [reth_rpc_types::BlockNumberOrTag]
 pub fn from_primitive_with_hash(primitive_header: reth_primitives::SealedHeader) -> Header {
-    let reth_primitives::SealedHeader {
-        header:
-            PrimitiveHeader {
-                parent_hash,
-                ommers_hash,
-                beneficiary,
-                state_root,
-                transactions_root,
-                receipts_root,
-                logs_bloom,
-                difficulty,
-                number,
-                gas_limit,
-                gas_used,
-                timestamp,
-                mix_hash,
-                nonce,
-                base_fee_per_gas,
-                extra_data,
-                withdrawals_root,
-                blob_gas_used,
-                excess_blob_gas,
-                parent_beacon_block_root,
-            },
-        hash,
-    } = primitive_header;
+    let (header, hash) = primitive_header.split();
+    let PrimitiveHeader {
+        parent_hash,
+        ommers_hash,
+        beneficiary,
+        state_root,
+        transactions_root,
+        receipts_root,
+        logs_bloom,
+        difficulty,
+        number,
+        gas_limit,
+        gas_used,
+        timestamp,
+        mix_hash,
+        nonce,
+        base_fee_per_gas,
+        extra_data,
+        withdrawals_root,
+        blob_gas_used,
+        excess_blob_gas,
+        parent_beacon_block_root,
+    } = header;
 
     Header {
         hash: Some(hash),

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -212,12 +212,12 @@ where
             None => return Err(EthApiError::TransactionNotFound),
             Some(res) => res,
         };
-        let (cfg, block_env, _) = self.inner.eth_api.evm_env_at(block.hash.into()).await?;
+        let (cfg, block_env, _) = self.inner.eth_api.evm_env_at(block.hash().into()).await?;
 
         // we need to get the state of the parent block because we're essentially replaying the
         // block the transaction is included in
         let state_at: BlockId = block.parent_hash.into();
-        let block_hash = block.hash;
+        let block_hash = block.hash();
         let block_txs = block.into_transactions_ecrecovered();
 
         let this = self.clone();
@@ -413,7 +413,7 @@ where
         // but if all transactions are to be replayed, we can use the state at the block itself
         let num_txs = transaction_index.index().unwrap_or(block.body.len());
         if num_txs == block.body.len() {
-            at = block.hash;
+            at = block.hash();
             replay_block_txs = false;
         }
 

--- a/crates/rpc/rpc/src/eth/api/block.rs
+++ b/crates/rpc/rpc/src/eth/api/block.rs
@@ -77,7 +77,7 @@ where
         if let Some((block, receipts)) = block_and_receipts {
             let block_number = block.number;
             let base_fee = block.base_fee_per_gas;
-            let block_hash = block.hash;
+            let block_hash = block.hash();
             let excess_blob_gas = block.excess_blob_gas;
 
             #[cfg(feature = "optimism")]
@@ -193,7 +193,7 @@ where
             Some(block) => block,
             None => return Ok(None),
         };
-        let block_hash = block.hash;
+        let block_hash = block.hash();
         let total_difficulty = self
             .provider()
             .header_td_by_number(block.number)?

--- a/crates/rpc/rpc/src/eth/api/call.rs
+++ b/crates/rpc/rpc/src/eth/api/call.rs
@@ -112,7 +112,7 @@ where
         // but if all transactions are to be replayed, we can use the state at the block itself
         let num_txs = transaction_index.index().unwrap_or(block.body.len());
         if num_txs == block.body.len() {
-            at = block.hash;
+            at = block.hash();
             replay_block_txs = false;
         }
 

--- a/crates/rpc/rpc/src/eth/api/fee_history.rs
+++ b/crates/rpc/rpc/src/eth/api/fee_history.rs
@@ -343,7 +343,7 @@ impl FeeHistoryEntry {
             base_fee_per_gas: block.base_fee_per_gas.unwrap_or_default(),
             gas_used_ratio: block.gas_used as f64 / block.gas_limit as f64,
             gas_used: block.gas_used,
-            header_hash: block.hash,
+            header_hash: block.hash(),
             gas_limit: block.gas_limit,
             rewards: Vec::new(),
         }

--- a/crates/rpc/rpc/src/eth/api/fees.rs
+++ b/crates/rpc/rpc/src/eth/api/fees.rs
@@ -160,7 +160,7 @@ where
                 if let Some(percentiles) = &reward_percentiles {
                     let (transactions, receipts) = self
                         .cache()
-                        .get_transactions_and_receipts(header.hash)
+                        .get_transactions_and_receipts(header.hash())
                         .await?
                         .ok_or(EthApiError::InvalidBlockRange)?;
                     rewards.push(

--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -18,7 +18,8 @@ use reth_network_api::NetworkInfo;
 use reth_node_api::ConfigureEvmEnv;
 use reth_primitives::{
     revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg},
-    Address, BlockId, BlockNumberOrTag, ChainInfo, SealedBlockWithSenders, B256, U256, U64,
+    Address, BlockId, BlockNumberOrTag, ChainInfo, SealedBlockWithSenders, SealedHeader, B256,
+    U256, U64,
 };
 
 use reth_provider::{
@@ -270,22 +271,29 @@ where
     ///
     /// If no pending block is available, this will derive it from the `latest` block
     pub(crate) fn pending_block_env_and_cfg(&self) -> EthResult<PendingBlockEnv> {
-        let origin = if let Some(pending) = self.provider().pending_block_with_senders()? {
+        let origin: PendingBlockEnvOrigin = if let Some(pending) =
+            self.provider().pending_block_with_senders()?
+        {
             PendingBlockEnvOrigin::ActualPending(pending)
         } else {
             // no pending block from the CL yet, so we use the latest block and modify the env
             // values that we can
-            let mut latest =
+            let latest =
                 self.provider().latest_header()?.ok_or_else(|| EthApiError::UnknownBlockNumber)?;
 
+            let (mut latest_header, _block_hash) = latest.split();
             // child block
-            latest.number += 1;
+            latest_header.number += 1;
             // assumed child block is in the next slot
-            latest.timestamp += 12;
+            latest_header.timestamp += 12;
             // base fee of the child block
             let chain_spec = self.provider().chain_spec();
-            latest.base_fee_per_gas =
-                latest.next_block_base_fee(chain_spec.base_fee_params(latest.timestamp));
+
+            latest_header.base_fee_per_gas = latest_header
+                .next_block_base_fee(chain_spec.base_fee_params(latest_header.timestamp));
+
+            let block_hash = latest_header.hash_slow();
+            let latest = SealedHeader::new(latest_header, block_hash);
 
             PendingBlockEnvOrigin::DerivedFromLatest(latest)
         };
@@ -326,7 +334,7 @@ where
             if let Some(pending_block) = lock.as_ref() {
                 // this is guaranteed to be the `latest` header
                 if pending.block_env.number.to::<u64>() == pending_block.block.number &&
-                    pending.origin.header().hash == pending_block.block.parent_hash &&
+                    pending.origin.header().hash() == pending_block.block.parent_hash &&
                     now <= pending_block.expires_at
                 {
                     return Ok(Some(pending_block.block.clone()))

--- a/crates/rpc/rpc/src/eth/api/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/api/pending_block.rs
@@ -334,7 +334,7 @@ impl PendingBlockEnvOrigin {
     pub(crate) fn state_block_id(&self) -> BlockId {
         match self {
             PendingBlockEnvOrigin::ActualPending(_) => BlockNumberOrTag::Pending.into(),
-            PendingBlockEnvOrigin::DerivedFromLatest(header) => BlockId::Hash(header.hash.into()),
+            PendingBlockEnvOrigin::DerivedFromLatest(header) => BlockId::Hash(header.hash().into()),
         }
     }
 
@@ -342,7 +342,7 @@ impl PendingBlockEnvOrigin {
     fn build_target_hash(&self) -> B256 {
         match self {
             PendingBlockEnvOrigin::ActualPending(block) => block.parent_hash,
-            PendingBlockEnvOrigin::DerivedFromLatest(header) => header.hash,
+            PendingBlockEnvOrigin::DerivedFromLatest(header) => header.hash(),
         }
     }
 

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -773,7 +773,7 @@ where
         };
         let (tx, tx_info) = transaction.split();
 
-        let (cfg, block_env, _) = self.evm_env_at(block.hash.into()).await?;
+        let (cfg, block_env, _) = self.evm_env_at(block.hash().into()).await?;
 
         // we need to get the state of the parent block because we're essentially replaying the
         // block the transaction is included in
@@ -848,7 +848,7 @@ where
             // we need to get the state of the parent block because we're replaying this block on
             // top of its parent block's state
             let state_at = block.parent_hash;
-            let block_hash = block.hash;
+            let block_hash = block.hash();
 
             let block_number = block_env.number.saturating_to::<u64>();
             let base_fee = block_env.basefee.saturating_to::<u64>();
@@ -1087,7 +1087,7 @@ where
         index: Index,
     ) -> EthResult<Option<Transaction>> {
         if let Some(block) = self.block_with_senders(block_id.into()).await? {
-            let block_hash = block.hash;
+            let block_hash = block.hash();
             let block_number = block.number;
             let base_fee_per_gas = block.base_fee_per_gas;
             if let Some(tx) = block.into_transactions_ecrecovered().nth(index.into()) {

--- a/crates/rpc/rpc/src/eth/cache/mod.rs
+++ b/crates/rpc/rpc/src/eth/cache/mod.rs
@@ -530,7 +530,7 @@ where
                         }
                         CacheAction::CacheNewCanonicalChain { blocks, receipts } => {
                             for block in blocks {
-                                this.on_new_block(block.hash, Ok(Some(block.unseal())));
+                                this.on_new_block(block.hash(), Ok(Some(block.unseal())));
                             }
 
                             for block_receipts in receipts {
@@ -578,8 +578,10 @@ where
             let (blocks, receipts): (Vec<_>, Vec<_>) = committed
                 .blocks_and_receipts()
                 .map(|(block, receipts)| {
-                    let block_receipts =
-                        BlockReceipts { block_hash: block.block.hash, receipts: receipts.clone() };
+                    let block_receipts = BlockReceipts {
+                        block_hash: block.block.hash(),
+                        receipts: receipts.clone(),
+                    };
                     (block.clone(), block_receipts)
                 })
                 .unzip();

--- a/crates/rpc/rpc/src/eth/gas_oracle.rs
+++ b/crates/rpc/rpc/src/eth/gas_oracle.rs
@@ -133,7 +133,7 @@ where
         let mut inner = self.inner.lock().await;
 
         // if we have stored a last price, then we check whether or not it was for the same head
-        if inner.last_price.block_hash == header.hash {
+        if inner.last_price.block_hash == header.hash() {
             return Ok(inner.last_price.price)
         }
 
@@ -142,7 +142,7 @@ where
         //
         // we only return more than check_block blocks' worth of prices if one or more return empty
         // transactions
-        let mut current_hash = header.hash;
+        let mut current_hash = header.hash();
         let mut results = Vec::new();
         let mut populated_blocks = 0;
 
@@ -201,7 +201,7 @@ where
             }
         }
 
-        inner.last_price = GasPriceOracleResult { block_hash: header.hash, price };
+        inner.last_price = GasPriceOracleResult { block_hash: header.hash(), price };
 
         Ok(price)
     }

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -353,7 +353,7 @@ where
             maybe_traces.map(|traces| traces.into_iter().flatten().collect::<Vec<_>>());
 
         if let (Some(block), Some(traces)) = (maybe_block, maybe_traces.as_mut()) {
-            if let Some(header_td) = self.provider().header_td(&block.header.hash)? {
+            if let Some(header_td) = self.provider().header_td(&block.header.hash())? {
                 if let Some(base_block_reward) = base_block_reward(
                     self.provider().chain_spec().as_ref(),
                     block.header.number,
@@ -549,7 +549,7 @@ struct TraceApiInner<Provider, Eth> {
 /// beneficiary.
 fn reward_trace(header: &SealedHeader, reward: RewardAction) -> LocalizedTransactionTrace {
     LocalizedTransactionTrace {
-        block_hash: Some(header.hash),
+        block_hash: Some(header.hash()),
         block_number: Some(header.number),
         transaction_hash: None,
         transaction_position: None,

--- a/crates/stages/src/error.rs
+++ b/crates/stages/src/error.rs
@@ -37,9 +37,9 @@ pub enum StageError {
          downloaded header #{header_number} ({header_hash}) is detached from \
          local head #{head_number} ({head_hash}): {error}",
         header_number = header.number,
-        header_hash = header.hash,
+        header_hash = header.hash(),
         head_number = local_head.number,
-        head_hash = local_head.hash,
+        head_hash = local_head.hash(),
     )]
     DetachedHead {
         /// The local head we attempted to attach to.

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -195,7 +195,7 @@ where
             // the block number of this header as tip.
             BlockHashOrNumber::Hash(hash) => downloaded_headers
                 .first()
-                .and_then(|header| (header.hash == hash).then_some(header.number)),
+                .and_then(|header| (header.hash() == hash).then_some(header.number)),
             // If tip is number, we can just grab it and not resolve using downloaded headers.
             BlockHashOrNumber::Number(number) => Some(number),
         };

--- a/crates/stages/src/stages/mod.rs
+++ b/crates/stages/src/stages/mod.rs
@@ -82,11 +82,11 @@ mod tests {
         provider_rw.insert_block(block.clone().try_seal_with_senders().unwrap(), None).unwrap();
 
         // Fill with bogus blocks to respect PruneMode distance.
-        let mut head = block.hash;
+        let mut head = block.hash();
         let mut rng = generators::rng();
         for block_number in 2..=tip {
             let nblock = random_block(&mut rng, block_number, Some(head), Some(0), Some(0));
-            head = nblock.hash;
+            head = nblock.hash();
             provider_rw.insert_block(nblock.try_seal_with_senders().unwrap(), None).unwrap();
         }
         provider_rw.commit().unwrap();

--- a/crates/storage/provider/src/chain.rs
+++ b/crates/storage/provider/src/chain.rs
@@ -222,7 +222,7 @@ impl Chain {
     pub fn append_chain(&mut self, other: Chain) -> RethResult<()> {
         let chain_tip = self.tip();
         let other_fork_block = other.fork_block();
-        if chain_tip.hash != other_fork_block.hash {
+        if chain_tip.hash() != other_fork_block.hash {
             return Err(BlockExecutionError::AppendChainDoesntConnect {
                 chain_tip: Box::new(chain_tip.num_hash()),
                 other_chain_fork: Box::new(other_fork_block),

--- a/crates/storage/provider/src/chain.rs
+++ b/crates/storage/provider/src/chain.rs
@@ -495,9 +495,11 @@ mod tests {
         block3.block.header.set_hash(block3_hash);
         block4.block.header.set_hash(block4_hash);
 
-        let (mut header, hash) = block3.block.header.clone().split();
+        let (mut header, _hash) = block3.block.header.clone().split();
         header.parent_hash = block2_hash;
+        let new_hash = header.hash_slow();
         block3.block.header.set_header(header);
+        block3.block.header.set_hash(new_hash);
 
         let mut chain1 =
             Chain { blocks: BTreeMap::from([(1, block1), (2, block2)]), ..Default::default() };
@@ -545,13 +547,13 @@ mod tests {
 
         let mut block1 = SealedBlockWithSenders::default();
         let block1_hash = B256::new([15; 32]);
-        block1.number = 1;
+        block1.set_block_number(1);
         block1.set_hash(block1_hash);
         block1.senders.push(Address::new([4; 20]));
 
         let mut block2 = SealedBlockWithSenders::default();
         let block2_hash = B256::new([16; 32]);
-        block2.number = 2;
+        block2.set_block_number(2);
         block1.set_hash(block2_hash);
         block2.senders.push(Address::new([4; 20]));
 

--- a/crates/storage/provider/src/chain.rs
+++ b/crates/storage/provider/src/chain.rs
@@ -490,12 +490,14 @@ mod tests {
         let mut block3 = block.clone();
         let mut block4 = block;
 
-        block1.block.header.hash = block1_hash;
-        block2.block.header.hash = block2_hash;
-        block3.block.header.hash = block3_hash;
-        block4.block.header.hash = block4_hash;
+        block1.block.header.set_hash(block1_hash);
+        block2.block.header.set_hash(block2_hash);
+        block3.block.header.set_hash(block3_hash);
+        block4.block.header.set_hash(block4_hash);
 
-        block3.block.header.header.parent_hash = block2_hash;
+        let (mut header, hash) = block3.block.header.clone().split();
+        header.parent_hash = block2_hash;
+        block3.block.header.set_header(header);
 
         let mut chain1 =
             Chain { blocks: BTreeMap::from([(1, block1), (2, block2)]), ..Default::default() };
@@ -544,13 +546,13 @@ mod tests {
         let mut block1 = SealedBlockWithSenders::default();
         let block1_hash = B256::new([15; 32]);
         block1.number = 1;
-        block1.hash = block1_hash;
+        block1.set_hash(block1_hash);
         block1.senders.push(Address::new([4; 20]));
 
         let mut block2 = SealedBlockWithSenders::default();
         let block2_hash = B256::new([16; 32]);
         block2.number = 2;
-        block2.hash = block2_hash;
+        block1.set_hash(block2_hash);
         block2.senders.push(Address::new([4; 20]));
 
         let mut block_state_extended = block_state1.clone();

--- a/crates/storage/provider/src/chain.rs
+++ b/crates/storage/provider/src/chain.rs
@@ -495,11 +495,7 @@ mod tests {
         block3.block.header.set_hash(block3_hash);
         block4.block.header.set_hash(block4_hash);
 
-        let (mut header, _hash) = block3.block.header.clone().split();
-        header.parent_hash = block2_hash;
-        let new_hash = header.hash_slow();
-        block3.block.header.set_header(header);
-        block3.block.header.set_hash(new_hash);
+        block3.set_parent_hash(block2_hash);
 
         let mut chain1 =
             Chain { blocks: BTreeMap::from([(1, block1), (2, block2)]), ..Default::default() };
@@ -554,7 +550,7 @@ mod tests {
         let mut block2 = SealedBlockWithSenders::default();
         let block2_hash = B256::new([16; 32]);
         block2.set_block_number(2);
-        block1.set_hash(block2_hash);
+        block2.set_hash(block2_hash);
         block2.senders.push(Address::new([4; 20]));
 
         let mut block_state_extended = block_state1.clone();

--- a/crates/storage/provider/src/providers/snapshot/mod.rs
+++ b/crates/storage/provider/src/providers/snapshot/mod.rs
@@ -77,7 +77,7 @@ mod tests {
         let tx = provider_rw.tx_mut();
         let mut td = U256::ZERO;
         for header in headers.clone() {
-            td += header.header.difficulty;
+            td += header.header().difficulty;
             let hash = header.hash();
 
             tx.put::<CanonicalHeaders>(header.number, hash).unwrap();

--- a/crates/storage/provider/src/test_utils/blocks.rs
+++ b/crates/storage/provider/src/test_utils/blocks.rs
@@ -70,13 +70,13 @@ impl BlockChainTestData {
     pub fn default_from_number(first: BlockNumber) -> Self {
         let one = block1(first);
         let mut extended_state = one.1.clone();
-        let two = block2(first + 1, one.0.hash, &extended_state);
+        let two = block2(first + 1, one.0.hash(), &extended_state);
         extended_state.extend(two.1.clone());
-        let three = block3(first + 2, two.0.hash, &extended_state);
+        let three = block3(first + 2, two.0.hash(), &extended_state);
         extended_state.extend(three.1.clone());
-        let four = block4(first + 3, three.0.hash, &extended_state);
+        let four = block4(first + 3, three.0.hash(), &extended_state);
         extended_state.extend(four.1.clone());
-        let five = block5(first + 4, four.0.hash, &extended_state);
+        let five = block5(first + 4, four.0.hash(), &extended_state);
         Self { genesis: genesis(), blocks: vec![one, two, three, four, five] }
     }
 }
@@ -85,13 +85,13 @@ impl Default for BlockChainTestData {
     fn default() -> Self {
         let one = block1(1);
         let mut extended_state = one.1.clone();
-        let two = block2(2, one.0.hash, &extended_state);
+        let two = block2(2, one.0.hash(), &extended_state);
         extended_state.extend(two.1.clone());
-        let three = block3(3, two.0.hash, &extended_state);
+        let three = block3(3, two.0.hash(), &extended_state);
         extended_state.extend(three.1.clone());
-        let four = block4(4, three.0.hash, &extended_state);
+        let four = block4(4, three.0.hash(), &extended_state);
         extended_state.extend(four.1.clone());
-        let five = block5(5, four.0.hash, &extended_state);
+        let five = block5(5, four.0.hash(), &extended_state);
         Self { genesis: genesis(), blocks: vec![one, two, three, four, five] }
     }
 }

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -106,7 +106,7 @@ pub async fn maintain_transaction_pool<Client, P, St, Tasks>(
         let latest = latest.seal_slow();
         let chain_spec = client.chain_spec();
         let info = BlockInfo {
-            last_seen_block_hash: latest.hash,
+            last_seen_block_hash: latest.hash(),
             last_seen_block_number: latest.number,
             pending_basefee: latest
                 .next_block_base_fee(chain_spec.base_fee_params(latest.timestamp + 12))
@@ -275,7 +275,7 @@ pub async fn maintain_transaction_pool<Client, P, St, Tasks>(
 
                 // for these we need to fetch the nonce+balance from the db at the new tip
                 let mut changed_accounts =
-                    match load_accounts(client.clone(), new_tip.hash, missing_changed_acc) {
+                    match load_accounts(client.clone(), new_tip.hash(), missing_changed_acc) {
                         Ok(LoadedAccounts { accounts, failed_to_load }) => {
                             // extend accounts we failed to load from database
                             dirty_addresses.extend(failed_to_load);
@@ -288,7 +288,7 @@ pub async fn maintain_transaction_pool<Client, P, St, Tasks>(
                                 target: "txpool",
                                 ?err,
                                 "failed to load missing changed accounts at new tip: {:?}",
-                                new_tip.hash
+                                new_tip.hash()
                             );
                             dirty_addresses.extend(addresses);
                             vec![]
@@ -384,7 +384,7 @@ pub async fn maintain_transaction_pool<Client, P, St, Tasks>(
                     maintained_state = MaintainedPoolState::Drifted;
                     debug!(target: "txpool", ?depth, "skipping deep canonical update");
                     let info = BlockInfo {
-                        last_seen_block_hash: tip.hash,
+                        last_seen_block_hash: tip.hash(),
                         last_seen_block_number: tip.number,
                         pending_basefee: pending_block_base_fee,
                         pending_blob_fee: pending_block_blob_fee,

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -584,7 +584,7 @@ impl<'a> CanonicalStateUpdate<'a> {
     }
 
     /// Returns the hash of the tip block.
-    pub fn hash(&self) -> B256 {
+    pub const fn hash(&self) -> B256 {
         self.new_tip.hash()
     }
 

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -585,7 +585,7 @@ impl<'a> CanonicalStateUpdate<'a> {
 
     /// Returns the hash of the tip block.
     pub fn hash(&self) -> B256 {
-        self.new_tip.hash
+        self.new_tip.hash()
     }
 
     /// Timestamp of the latest chain update

--- a/examples/db-access.rs
+++ b/examples/db-access.rs
@@ -123,13 +123,15 @@ fn block_provider_example<T: BlockReader>(provider: T, number: u64) -> eyre::Res
     let sealed_block = block.clone().seal_slow();
 
     // Can also query the block by hash directly
-    let block_by_hash =
-        provider.block_by_hash(sealed_block.hash())?.ok_or(eyre::eyre!("block by hash not found"))?;
+    let block_by_hash = provider
+        .block_by_hash(sealed_block.hash())?
+        .ok_or(eyre::eyre!("block by hash not found"))?;
     assert_eq!(block, block_by_hash);
 
     // Or by relying in the internal conversion
-    let block_by_hash2 =
-        provider.block(sealed_block.hash().into())?.ok_or(eyre::eyre!("block by hash not found"))?;
+    let block_by_hash2 = provider
+        .block(sealed_block.hash().into())?
+        .ok_or(eyre::eyre!("block by hash not found"))?;
     assert_eq!(block, block_by_hash2);
 
     // Or you can also specify the datasource. For this provider this always return `None`, but

--- a/examples/db-access.rs
+++ b/examples/db-access.rs
@@ -60,8 +60,8 @@ fn header_provider_example<T: HeaderProvider>(provider: T, number: u64) -> eyre:
 
     // Can also query the header by hash!
     let header_by_hash =
-        provider.header(&sealed_header.hash)?.ok_or(eyre::eyre!("header by hash not found"))?;
-    assert_eq!(sealed_header.header, header_by_hash);
+        provider.header(&sealed_header.hash())?.ok_or(eyre::eyre!("header by hash not found"))?;
+    assert_eq!(sealed_header.header(), &header_by_hash);
 
     // The header's total difficulty is stored in a separate table, so we have a separate call for
     // it. This is not needed for post PoS transition chains.
@@ -124,18 +124,18 @@ fn block_provider_example<T: BlockReader>(provider: T, number: u64) -> eyre::Res
 
     // Can also query the block by hash directly
     let block_by_hash =
-        provider.block_by_hash(sealed_block.hash)?.ok_or(eyre::eyre!("block by hash not found"))?;
+        provider.block_by_hash(sealed_block.hash())?.ok_or(eyre::eyre!("block by hash not found"))?;
     assert_eq!(block, block_by_hash);
 
     // Or by relying in the internal conversion
     let block_by_hash2 =
-        provider.block(sealed_block.hash.into())?.ok_or(eyre::eyre!("block by hash not found"))?;
+        provider.block(sealed_block.hash().into())?.ok_or(eyre::eyre!("block by hash not found"))?;
     assert_eq!(block, block_by_hash2);
 
     // Or you can also specify the datasource. For this provider this always return `None`, but
     // the blockchain tree is also able to access pending state not available in the db yet.
     let block_by_hash3 = provider
-        .find_block_by_hash(sealed_block.hash, BlockSource::Any)?
+        .find_block_by_hash(sealed_block.hash(), BlockSource::Any)?
         .ok_or(eyre::eyre!("block hash not found"))?;
     assert_eq!(block, block_by_hash3);
 
@@ -144,7 +144,7 @@ fn block_provider_example<T: BlockReader>(provider: T, number: u64) -> eyre::Res
 
     // Can query the block's withdrawals (via the `WithdrawalsProvider`)
     let _withdrawals =
-        provider.withdrawals_by_block(sealed_block.hash.into(), sealed_block.timestamp)?;
+        provider.withdrawals_by_block(sealed_block.hash().into(), sealed_block.timestamp)?;
 
     Ok(())
 }

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -128,7 +128,11 @@ impl Case for BlockchainTestCase {
                     // Insert state hashes into the provider based on the expected state root.
                     let last_block = last_block.unwrap_or_default();
                     provider
-                        .insert_hashes(0..=last_block.number, last_block.hash, *expected_state_root)
+                        .insert_hashes(
+                            0..=last_block.number,
+                            last_block.hash(),
+                            *expected_state_root,
+                        )
                         .map_err(|err| Error::RethError(err.into()))?;
                 }
                 _ => return Err(Error::MissingPostState),


### PR DESCRIPTION
- Fix `pending_block_env_and_cfg` logic problem caused by the mutable ops but `sealedHeader` hash is not updated. It seems influence so many eth apis.  

The following improvements are useful to avoid the problem: 
- The `sealed` type should always means it's not easy to change its value directly. So should remove all immutable borrowed methods and replace pub fields by ref apis.
- Add some mutable api to SealedHeader but with `test-utils` feature. In non-test code path, SealedHeader should always be created by Header and then be immutable.

BTW I think other sealed types also need to be encapsulated and refactorred.
