### PR TITLE
chore(net): downgrade unseen hashes log to trace

### DIFF
--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -659,7 +659,7 @@ where
             return
         }
 
-        debug!(target: "net::tx",
+        trace!(target: "net::tx",
             peer_id=format!("{peer_id:#}"),
             hashes_len=hashes.len(),
             hashes=?*hashes,


### PR DESCRIPTION
It's filling the debug logs too fast, causing the rotation of log files.