### PR TITLE
fix(blockchain-tree): query latest canonical hashes from both db and snapshots

### DIFF
--- a/crates/blockchain-tree/src/externals.rs
+++ b/crates/blockchain-tree/src/externals.rs
@@ -76,7 +76,7 @@ impl<DB: Database, EF> TreeExternals<DB, EF> {
             )?));
         }
 
-        let hashes = hashes.into_iter().take(num_hashes).collect();
+        let hashes = hashes.into_iter().rev().take(num_hashes).collect();
         Ok(hashes)
     }
 }

--- a/crates/blockchain-tree/src/externals.rs
+++ b/crates/blockchain-tree/src/externals.rs
@@ -76,6 +76,8 @@ impl<DB: Database, EF> TreeExternals<DB, EF> {
             )?));
         }
 
+        // We may have fetched more than `num_hashes` hashes, so we need to truncate the result to
+        // the requested number.
         let hashes = hashes.into_iter().rev().take(num_hashes).collect();
         Ok(hashes)
     }

--- a/crates/blockchain-tree/src/externals.rs
+++ b/crates/blockchain-tree/src/externals.rs
@@ -76,8 +76,7 @@ impl<DB: Database, EF> TreeExternals<DB, EF> {
             )?));
         }
 
-        debug_assert!(hashes.len() <= num_hashes, "too many hashes fetched");
-
+        let hashes = hashes.into_iter().take(num_hashes).collect();
         Ok(hashes)
     }
 }


### PR DESCRIPTION
The previous implementation had an assumption that the database is always ahead of snapshots. It is not correct because we write to snapshots in pipeline sync, and the database may have a lower latest block number because we didn't prune from it yet.