### PR TITLE
feat(txpool): discard_worst compat with suffix comma

### DIFF
--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -759,7 +759,7 @@ impl<T: TransactionOrdering> TxPool<T> {
 
         // Helper macro that discards the worst transactions for the pools
         macro_rules! discard_worst {
-            ($this:ident, $removed:ident,  [$($limit:ident => $pool:ident),*]  ) => {
+            ($this:ident, $removed:ident, [$($limit:ident => $pool:ident),*]) => {
                 $ (
                 while $this
                         .config
@@ -806,9 +806,9 @@ impl<T: TransactionOrdering> TxPool<T> {
 
         discard_worst!(
             self, removed, [
-                pending_limit  => pending_pool,
-                basefee_limit  => basefee_pool,
-                blob_limit => blob_pool,
+                pending_limit => pending_pool,
+                basefee_limit => basefee_pool,
+                blob_limit    => blob_pool,
                 queued_limit  => queued_pool
             ]
         );

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -759,7 +759,7 @@ impl<T: TransactionOrdering> TxPool<T> {
 
         // Helper macro that discards the worst transactions for the pools
         macro_rules! discard_worst {
-            ($this:ident, $removed:ident, [$($limit:ident => $pool:ident),*]) => {
+            ($this:ident, $removed:ident, [$($limit:ident => $pool:ident),* $(,)*]) => {
                 $ (
                 while $this
                         .config
@@ -809,7 +809,7 @@ impl<T: TransactionOrdering> TxPool<T> {
                 pending_limit => pending_pool,
                 basefee_limit => basefee_pool,
                 blob_limit    => blob_pool,
-                queued_limit  => queued_pool
+                queued_limit  => queued_pool,
             ]
         );
 


### PR DESCRIPTION
Currently the macro `discard_worst` can't parse the list if the last one has a `,`

```diff
        discard_worst!(
            self, removed, [
                pending_limit => pending_pool,
                basefee_limit => basefee_pool,
                blob_limit    => blob_pool,
-                queued_limit  => queued_pool
+                queued_limit  => queued_pool,
            ]
        );
```

with error as below:


```bash
error: no rules expected the token `]`
   --> crates/transaction-pool/src/pool/txpool.rs:813:13
    |
761 |         macro_rules! discard_worst {
    |         -------------------------- when calling this macro
...
813 |             ]
    |             ^ no rules expected this token in macro call
    |
note: while trying to match meta-variable `$limit:ident`
   --> crates/transaction-pool/src/pool/txpool.rs:762:46
    |
762 |             ($this:ident, $removed:ident, [$($limit:ident => $pool:ident),*]  ) => {
    |                                              ^^^^^^^^^^^^

```

So let's be compatible with that case. 