### PR TITLE
feat(op): `Ecotone` reject blob txs

### DIFF
--- a/crates/interfaces/src/executor.rs
+++ b/crates/interfaces/src/executor.rs
@@ -135,6 +135,9 @@ pub enum OptimismBlockExecutionError {
     /// Thrown when force deploy of create2deployer code fails.
     #[error("failed to force create2deployer account code")]
     ForceCreate2DeployerFail,
+    /// Thrown when a blob transaction is included in a sequencer's block.
+    #[error("blob transaction included in sequencer block")]
+    BlobTransactionRejected,
 }
 
 impl BlockExecutionError {

--- a/crates/payload/optimism/src/error.rs
+++ b/crates/payload/optimism/src/error.rs
@@ -17,4 +17,7 @@ pub enum OptimismPayloadBuilderError {
     /// Thrown when force deploy of create2deployer code fails.
     #[error("failed to force create2deployer account code")]
     ForceCreate2DeployerFail,
+    /// Thrown when a blob transaction is included in a sequencer's block.
+    #[error("blob transaction included in sequencer block")]
+    BlobTransactionRejected,
 }

--- a/crates/revm/src/optimism/processor.rs
+++ b/crates/revm/src/optimism/processor.rs
@@ -97,7 +97,7 @@ where
                 .into())
             }
 
-            // An optimism block block should never contain blob transactions.
+            // An optimism block should never contain blob transactions.
             if matches!(transaction.tx_type(), TxType::EIP4844) {
                 return Err(BlockExecutionError::OptimismBlockExecution(
                     OptimismBlockExecutionError::BlobTransactionRejected,

--- a/crates/revm/src/optimism/processor.rs
+++ b/crates/revm/src/optimism/processor.rs
@@ -3,7 +3,9 @@ use reth_interfaces::executor::{
     BlockExecutionError, BlockValidationError, OptimismBlockExecutionError,
 };
 use reth_node_api::ConfigureEvmEnv;
-use reth_primitives::{revm_primitives::ResultAndState, BlockWithSenders, Hardfork, Receipt, U256};
+use reth_primitives::{
+    revm_primitives::ResultAndState, BlockWithSenders, Hardfork, Receipt, TxType, U256,
+};
 use reth_provider::{BlockExecutor, BlockExecutorStats, BundleStateWithReceipts};
 use revm::DatabaseCommit;
 use std::time::Instant;
@@ -93,6 +95,13 @@ where
                     block_available_gas,
                 }
                 .into())
+            }
+
+            // An optimism block block should never contain blob transactions.
+            if matches!(transaction.tx_type(), TxType::EIP4844) {
+                return Err(BlockExecutionError::OptimismBlockExecution(
+                    OptimismBlockExecutionError::BlobTransactionRejected,
+                ))
             }
 
             // Cache the depositor account prior to the state transition for the deposit nonce.

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -143,7 +143,7 @@ where
         mut transaction: Tx,
     ) -> TransactionValidationOutcome<Tx> {
         #[cfg(feature = "optimism")]
-        if transaction.is_deposit() {
+        if transaction.is_deposit() || transaction.is_eip4844() {
             return TransactionValidationOutcome::Invalid(
                 transaction,
                 InvalidTransactionError::TxTypeNotSupported.into(),


### PR DESCRIPTION
## Overview

> Note: This is part of a PR stack. Should be merged bottom -> up.
> ---> #6480 👈
> --> #6479
> -> #6478 
> main

Disables 4844 transactions in `op-reth` after the `Ecotone` hardfork.

specs: https://specs.optimism.io/protocol/exec-engine.html#ecotone-disable-blob-transactions
