### PR TITLE
feat(primitives): implement `Display` for `SegmentRangeInclusive`

### DIFF
--- a/bin/reth/src/commands/db/stats.rs
+++ b/bin/reth/src/commands/db/stats.rs
@@ -176,9 +176,9 @@ impl Command {
 
                 let mut row = Row::new();
                 row.add_cell(Cell::new(segment))
-                    .add_cell(Cell::new(format!("{block_range:?}")))
+                    .add_cell(Cell::new(format!("{block_range}")))
                     .add_cell(Cell::new(
-                        tx_range.map_or("N/A".to_string(), |tx_range| format!("{tx_range:?}")),
+                        tx_range.map_or("N/A".to_string(), |tx_range| format!("{tx_range}")),
                     ))
                     .add_cell(Cell::new(format!("{columns} x {rows}")));
                 if !only_total_size {

--- a/crates/primitives/src/snapshot/segment.rs
+++ b/crates/primitives/src/snapshot/segment.rs
@@ -308,6 +308,12 @@ impl SegmentRangeInclusive {
     }
 }
 
+impl std::fmt::Display for SegmentRangeInclusive {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}..={}", self.start, self.end)
+    }
+}
+
 impl From<RangeInclusive<u64>> for SegmentRangeInclusive {
     fn from(value: RangeInclusive<u64>) -> Self {
         SegmentRangeInclusive { start: *value.start(), end: *value.end() }


### PR DESCRIPTION
Before
```console
➜  reth (feat/static-files) cargo run --quiet --bin reth -- db stats --chain holesky --only-total-size
| Segment      | Block Range                                          | Transaction Range                                       | Shape        | Size       |
|--------------|------------------------------------------------------|---------------------------------------------------------|--------------|------------|
| Headers      | SegmentRangeInclusive { start: 0, end: 499999 }      | N/A                                                     | 3 x 500000   | 281.5 MiB  |
| Headers      | SegmentRangeInclusive { start: 500000, end: 834214 } | N/A                                                     | 3 x 334215   | 189.5 MiB  |
| Transactions | SegmentRangeInclusive { start: 0, end: 499999 }      | SegmentRangeInclusive { start: 0, end: 1903501 }        | 1 x 1903502  | 678.7 MiB  |
| Transactions | SegmentRangeInclusive { start: 500000, end: 850110 } | SegmentRangeInclusive { start: 1903502, end: 26189416 } | 1 x 24285915 | 5.6 GiB    |
| Receipts     | SegmentRangeInclusive { start: 0, end: 499999 }      | SegmentRangeInclusive { start: 0, end: 1903501 }        | 1 x 1903502  | 103.8 MiB  |
| Receipts     | SegmentRangeInclusive { start: 500000, end: 850110 } | SegmentRangeInclusive { start: 1903502, end: 26189416 } | 1 x 24285915 | 1009.5 MiB |
| ------------ | ---------------------------------------------------- | ------------------------------------------------------- | ------------ | ---------- |
| Total        |                                                      |                                                         |              | 7.8 GiB    |
```

After
```console
➜  reth (alexey/segment-range-inclusive-display) cargo run --quiet --bin reth -- db stats --chain holesky --only-total-size
| Segment      | Block Range     | Transaction Range  | Shape        | Size       |
|--------------|-----------------|--------------------|--------------|------------|
| Headers      | 0..=499999      | N/A                | 3 x 500000   | 281.5 MiB  |
| Headers      | 500000..=834214 | N/A                | 3 x 334215   | 189.5 MiB  |
| Transactions | 0..=499999      | 0..=1903501        | 1 x 1903502  | 678.7 MiB  |
| Transactions | 500000..=850110 | 1903502..=26189416 | 1 x 24285915 | 5.6 GiB    |
| Receipts     | 0..=499999      | 0..=1903501        | 1 x 1903502  | 103.8 MiB  |
| Receipts     | 500000..=850110 | 1903502..=26189416 | 1 x 24285915 | 1009.5 MiB |
| ------------ | --------------- | ------------------ | ------------ | ---------- |
| Total        |                 |                    |              | 7.8 GiB    |
```