### PR TITLE
feat(bin, snapshot, engine): emit and log snapshotter events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6913,9 +6913,11 @@ dependencies = [
  "reth-primitives",
  "reth-provider",
  "reth-stages",
+ "reth-tokio-util",
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tracing",
 ]
 

--- a/bin/reth/src/builder.rs
+++ b/bin/reth/src/builder.rs
@@ -263,11 +263,12 @@ impl<DB: Database + DatabaseMetrics + DatabaseMetadata + 'static> NodeBuilderWit
 
         let mut hooks = EngineHooks::new();
 
-        let snapshotter = Snapshotter::new(
+        let mut snapshotter = Snapshotter::new(
             provider_factory.clone(),
             provider_factory.snapshot_provider(),
             prune_config.clone().unwrap_or_default().segments,
         );
+        let snapshotter_events = snapshotter.events();
         hooks.add(SnapshotHook::new(snapshotter.clone(), Box::new(executor.clone())));
         info!(target: "reth::cli", "Snapshotter initialized");
 
@@ -375,7 +376,8 @@ impl<DB: Database + DatabaseMetrics + DatabaseMetadata + 'static> NodeBuilderWit
             } else {
                 Either::Right(stream::empty())
             },
-            pruner_events.map(Into::into)
+            pruner_events.map(Into::into),
+            snapshotter_events.map(Into::into),
         );
         executor.spawn_critical(
             "events task",

--- a/bin/reth/src/commands/node/events.rs
+++ b/bin/reth/src/commands/node/events.rs
@@ -12,6 +12,7 @@ use reth_primitives::{
     BlockNumber,
 };
 use reth_prune::PrunerEvent;
+use reth_snapshot::SnapshotterEvent;
 use reth_stages::{ExecOutput, PipelineEvent};
 use std::{
     fmt::{Display, Formatter},
@@ -205,6 +206,14 @@ impl<DB> NodeState<DB> {
             }
         }
     }
+
+    fn handle_snapshotter_event(&self, event: SnapshotterEvent) {
+        match event {
+            SnapshotterEvent::Finished { targets, elapsed } => {
+                info!(?targets, ?elapsed, "Snapshotter finished");
+            }
+        }
+    }
 }
 
 impl<DB: DatabaseMetadata> NodeState<DB> {
@@ -249,6 +258,8 @@ pub enum NodeEvent {
     ConsensusLayerHealth(ConsensusLayerHealthEvent),
     /// A pruner event
     Pruner(PrunerEvent),
+    /// A snapshotter event
+    Snapshotter(SnapshotterEvent),
 }
 
 impl From<NetworkEvent> for NodeEvent {
@@ -278,6 +289,12 @@ impl From<ConsensusLayerHealthEvent> for NodeEvent {
 impl From<PrunerEvent> for NodeEvent {
     fn from(event: PrunerEvent) -> Self {
         NodeEvent::Pruner(event)
+    }
+}
+
+impl From<SnapshotterEvent> for NodeEvent {
+    fn from(event: SnapshotterEvent) -> Self {
+        NodeEvent::Snapshotter(event)
     }
 }
 
@@ -390,6 +407,9 @@ where
                 }
                 NodeEvent::Pruner(event) => {
                     this.state.handle_pruner_event(event);
+                }
+                NodeEvent::Snapshotter(event) => {
+                    this.state.handle_snapshotter_event(event);
                 }
             }
         }

--- a/crates/consensus/beacon/src/engine/hooks/snapshot.rs
+++ b/crates/consensus/beacon/src/engine/hooks/snapshot.rs
@@ -75,7 +75,7 @@ impl<DB: Database + 'static> SnapshotHook<DB> {
     ) -> RethResult<Option<EngineHookEvent>> {
         Ok(match &mut self.state {
             SnapshotterState::Idle(snapshotter) => {
-                let Some(snapshotter) = snapshotter.take() else { return Ok(None) };
+                let Some(mut snapshotter) = snapshotter.take() else { return Ok(None) };
 
                 let targets = snapshotter.get_snapshot_targets(finalized_block_number)?;
 

--- a/crates/prune/src/pruner.rs
+++ b/crates/prune/src/pruner.rs
@@ -65,7 +65,7 @@ impl<DB: Database> Pruner<DB> {
         }
     }
 
-    /// Listen for events on the prune.
+    /// Listen for events on the pruner.
     pub fn events(&mut self) -> UnboundedReceiverStream<PrunerEvent> {
         self.listeners.new_listener()
     }

--- a/crates/snapshot/Cargo.toml
+++ b/crates/snapshot/Cargo.toml
@@ -18,9 +18,11 @@ reth-db.workspace = true
 reth-provider.workspace = true
 reth-interfaces.workspace = true
 reth-nippy-jar.workspace = true
+reth-tokio-util.workspace = true
 
 # async
 tokio = { workspace = true, features = ["sync"] }
+tokio-stream.workspace = true
 
 # misc
 thiserror.workspace = true

--- a/crates/snapshot/src/event.rs
+++ b/crates/snapshot/src/event.rs
@@ -1,0 +1,9 @@
+use crate::SnapshotTargets;
+use std::time::Duration;
+
+/// An event emitted by a [Pruner][crate::Pruner].
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum SnapshotterEvent {
+    /// Emitted when snapshotter finished running.
+    Finished { targets: SnapshotTargets, elapsed: Duration },
+}

--- a/crates/snapshot/src/event.rs
+++ b/crates/snapshot/src/event.rs
@@ -1,9 +1,14 @@
 use crate::SnapshotTargets;
 use std::time::Duration;
 
-/// An event emitted by a [Pruner][crate::Pruner].
+/// An event emitted by a [Snapshotter][crate::Snapshotter].
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum SnapshotterEvent {
     /// Emitted when snapshotter finished running.
-    Finished { targets: SnapshotTargets, elapsed: Duration },
+    Finished {
+        /// Targets that were snapshotted
+        targets: SnapshotTargets,
+        /// Time it took to run the snapshotter
+        elapsed: Duration,
+    },
 }

--- a/crates/snapshot/src/lib.rs
+++ b/crates/snapshot/src/lib.rs
@@ -7,7 +7,9 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
+mod event;
 pub mod segments;
 mod snapshotter;
 
+pub use event::SnapshotterEvent;
 pub use snapshotter::{SnapshotTargets, Snapshotter, SnapshotterResult, SnapshotterWithResult};


### PR DESCRIPTION
Similar to pruner events, we want to show snapshotter-related events in logs.