### PR TITLE
fix(bin): add snapshot hook to list of hooks

### DIFF
--- a/bin/reth/src/builder.rs
+++ b/bin/reth/src/builder.rs
@@ -333,7 +333,6 @@ impl<DB: Database + DatabaseMetrics + DatabaseMetadata + 'static> NodeBuilderWit
         let pipeline_events = pipeline.events();
 
         let initial_target = self.config.initial_pipeline_target(genesis_hash);
-        let mut hooks = EngineHooks::new();
 
         let prune_config = prune_config.unwrap_or_default();
         let mut pruner = PrunerBuilder::new(prune_config.clone())

--- a/crates/consensus/beacon/src/engine/hooks/controller.rs
+++ b/crates/consensus/beacon/src/engine/hooks/controller.rs
@@ -150,6 +150,8 @@ impl EngineHooksController {
             );
 
             return Poll::Ready(Ok(result))
+        } else {
+            debug!(target: "consensus::engine::hooks", hook = hook.name(), "Next hook is not ready");
         }
 
         Poll::Pending

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1501,7 +1501,9 @@ where
                     debug!(target: "consensus::engine", hash=?new_head.hash(), number=new_head.number, "Canonicalized new head");
 
                     // we can update the FCU blocks
-                    let _ = self.update_canon_chain(new_head, &target);
+                    if let Err(err) = self.update_canon_chain(new_head, &target) {
+                        debug!(target: "consensus::engine", ?err, ?target, "Failed to update the canonical chain tracker");
+                    }
 
                     // we're no longer syncing
                     self.sync_state_updater.update_sync_state(SyncState::Idle);


### PR DESCRIPTION
`bin/reth/src/builder.rs` got probably incorrectly merged during one of the conflicts, so we created `EngineHooks` twice and only the `PruneHook` was in the list.