### PR TITLE
feat(bin): do not show target on INFO level

### DIFF
--- a/crates/tracing/src/formatter.rs
+++ b/crates/tracing/src/formatter.rs
@@ -48,7 +48,14 @@ impl LogFormat {
         } else {
             false
         };
-        let target = std::env::var("RUST_LOG_TARGET").map(|val| val != "0").unwrap_or(true);
+        let target = std::env::var("RUST_LOG_TARGET")
+            // `RUST_LOG_TARGET` always overrides default behaviour
+            .map(|val| val != "0")
+            .unwrap_or(
+                // If `RUST_LOG_TARGET` is not set, show target in logs only if the max enabled
+                // level is higher than INFO (DEBUG, TRACE)
+                filter.max_level_hint().map_or(true, |max_level| max_level > tracing::Level::INFO),
+            );
 
         match self {
             LogFormat::Json => {


### PR DESCRIPTION
When running a node with default logging settings always repeating `reth::cli` and `reth::commands::node::events` just do not provide any valuable info unless higher levels like `DEBUG` or `TRACE` are enabled. This PR disables outputting targets by default for levels `<= INFO`.

```console
➜  reth (main) ./target/debug/reth init                                                                                                                                                                                  ✭
2024-02-08T22:08:35.177644Z  INFO reth init starting
2024-02-08T22:08:35.177741Z  INFO Opening database path="/Users/shekhirin/Library/Application Support/reth/mainnet/db"
2024-02-08T22:08:35.190079Z  INFO Database opened
2024-02-08T22:08:35.190118Z  INFO Writing genesis block
2024-02-08T22:08:35.206019Z  INFO Genesis block written hash=0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3

➜  reth (main) RUST_LOG=trace ./target/debug/reth init                                                                                                                                                                   ✭
2024-02-08T22:08:38.005926Z TRACE mio::poll: registering event source with poller: token=Token(1), interests=READABLE    
2024-02-08T22:08:38.006629Z  INFO reth::cli: reth init starting
2024-02-08T22:08:38.006705Z  INFO reth::cli: Opening database path="/Users/shekhirin/Library/Application Support/reth/mainnet/db"
2024-02-08T22:08:38.019269Z  INFO reth::cli: Database opened
2024-02-08T22:08:38.019305Z  INFO reth::cli: Writing genesis block
2024-02-08T22:08:38.019406Z DEBUG reth::init: Genesis already written, skipping.
2024-02-08T22:08:38.034838Z  INFO reth::cli: Genesis block written hash=0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3

➜  reth (main) RUST_LOG_TARGET=1 ./target/debug/reth init                                                                                                                                                                ✭
2024-02-08T22:08:40.790536Z  INFO reth::cli: reth init starting
2024-02-08T22:08:40.790637Z  INFO reth::cli: Opening database path="/Users/shekhirin/Library/Application Support/reth/mainnet/db"
2024-02-08T22:08:40.802667Z  INFO reth::cli: Database opened
2024-02-08T22:08:40.802714Z  INFO reth::cli: Writing genesis block
2024-02-08T22:08:40.818014Z  INFO reth::cli: Genesis block written hash=0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3
```