### PR TITLE
chore: make timestamp fork tests better

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6556,7 +6556,7 @@ dependencies = [
  "derive_more",
  "ethers-core",
  "hash-db",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "modular-bitfield",
  "num_enum 0.7.2",
  "nybbles",

--- a/crates/consensus/beacon/src/engine/handle.rs
+++ b/crates/consensus/beacon/src/engine/handle.rs
@@ -16,7 +16,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 /// A _shareable_ beacon consensus frontend type. Used to interact with the spawned beacon consensus
 /// engine task.
 ///
-/// See also [`BeaconConsensusEngine`](crate::engine::BeaconConsensusEngine).
+/// See also `BeaconConsensusEngine`
 #[derive(Debug)]
 pub struct BeaconConsensusEngineHandle<Engine>
 where

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -42,7 +42,7 @@ bytes.workspace = true
 byteorder = "1"
 clap = { workspace = true, features = ["derive"], optional = true }
 derive_more = "0.99"
-itertools = "0.11"
+itertools.workspace = true
 modular-bitfield = "0.11.2"
 num_enum = "0.7"
 once_cell.workspace = true

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -1769,25 +1769,15 @@ Post-merge hard forks (timestamp based):
     // Tests that all predefined timestamps are correctly set up in the chainspecs
     #[test]
     fn test_predefined_chain_spec_fork_timestamps() {
-        fn ensure_timestamp_fork_conditions(spec: &ChainSpec, known_timestamp_based_forks: usize) {
-            // This is a sanity test that ensures we always set all currently known fork timestamps,
-            // this will fail if a new timestamp based fork condition has added to the hardforks but
-            // no corresponding entry in the ForkTimestamp types, See also
-            // [ForkTimestamps::from_hardforks]
+        let predefined = [&MAINNET, &SEPOLIA, &HOLESKY, &GOERLI];
 
-            let num_timestamp_based_forks =
-                spec.hardforks.values().copied().filter(ForkCondition::is_timestamp).count();
-            assert_eq!(num_timestamp_based_forks, known_timestamp_based_forks);
+        for spec in predefined.iter() {
+            let expected_timestamp_forks = &spec.fork_timestamps;
+            let got_timestamp_forks = ForkTimestamps::from_hardforks(&spec.hardforks);
 
-            // ensures all timestamp forks are set
-            assert!(spec.fork_timestamps.shanghai.is_some());
+            // make sure they're the same
+            assert_eq!(expected_timestamp_forks, &got_timestamp_forks);
         }
-
-        // currently there are 2 timestamp forks known for mainnet: shanghai, cancun
-        ensure_timestamp_fork_conditions(&MAINNET, 2);
-
-        // currently there are 2 timestamp forks known for sepolia: shanghai, cancun
-        ensure_timestamp_fork_conditions(&SEPOLIA, 2);
     }
 
     // Tests that we skip any fork blocks in block #0 (the genesis ruleset)

--- a/crates/rpc/rpc-builder/src/auth.rs
+++ b/crates/rpc/rpc-builder/src/auth.rs
@@ -248,7 +248,7 @@ impl AuthServerConfigBuilder {
                     .max_connections(500)
                     // bump the default request size slightly, there aren't any methods exposed with
                     // dynamic request params that can exceed this
-                    .max_request_body_size(5 * 1024 * 1024)
+                    .max_request_body_size(128 * 1024 * 1024)
                     .set_id_provider(EthSubscriptionIdProvider::default())
             }),
         }


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/6494

This test didn't actually check fork timestamps for each predefined chainspec and was not a useful test as a result.

Instead of checking a number, we build a new `ForkTimestamps` from the hardforks and check equality.