### PR TITLE
swanny/assertoor

### DIFF
--- a/.github/workflows/assertoor.yml
+++ b/.github/workflows/assertoor.yml
@@ -1,0 +1,71 @@
+name: Run manual assertoor test
+
+on:
+  workflow_dispatch:
+    inputs:
+      overrideTests:
+        description: 'Test IDs to run (eg. test1,test2)'
+        default: ""
+        type: string
+      overrideClientPairs:
+        description: 'Override client pairs to run this test with (eg. lighthouse-get,teku-besu)'
+        default: ""
+        type: string
+
+jobs:
+  get_tests:
+    name: "Load Tests"
+    runs-on: ubuntu-latest
+    outputs:
+      test_configs: ${{ steps.tests.outputs.test_configs }}
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+    - name: "Load test configurations from tests.yaml"
+      id: tests
+      shell: bash
+      run: |
+        tests_file="etc/assertoor/tests.yaml"
+        override_tests="${{ inputs.overrideTests }}"
+        override_pairs="${{ inputs.overrideClientPairs }}"
+
+        test_configs="$(cat $tests_file | yq -o json | jq -c '.tests')"
+
+        if [ -z "$override_tests" ]; then
+          test_configs="$(echo "$test_configs" | jq -c "map(select(.schedule == true))")"
+        else
+          # filter by tests
+          filter_str=""
+
+          while read test; do
+            if ! [ -z "$filter_str" ]; then
+              filter_str="$filter_str or"
+            fi
+            filter_str="$filter_str .id == \"$test\""
+          done <<< $(echo "$override_tests" | tr "," "\n")
+
+          test_configs="$(echo "$test_configs" | jq -c "map(select($filter_str))")"
+        fi
+
+        if ! [ -z "$override_pairs" ]; then
+          test_configs="$(echo "$test_configs" | jq -c "(.[]).clientPairs |= [\"$override_pairs\"]")"
+        fi
+
+        echo "test_configs<<EOF" >> $GITHUB_OUTPUT
+        echo "$test_configs" >> $GITHUB_OUTPUT
+        echo "$(echo "$test_configs" | jq)"
+        echo "EOF" >> $GITHUB_OUTPUT
+
+  run_tests:
+    needs: get_tests
+    uses: ethpandaops/assertoor-test/.github/workflows/_shared-run.yaml@master
+    name: "${{ matrix.config.name }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        config: ${{ fromJson(needs.get_tests.outputs.test_configs) }}
+    with:
+      config: ${{ toJSON(matrix.config) }}
+    secrets:
+      RANCHER_URL: ${{ secrets.RANCHER_URL }}
+      RANCHER_TOKEN: ${{ secrets.RANCHER_TOKEN }}

--- a/etc/tests.yaml
+++ b/etc/tests.yaml
@@ -1,0 +1,97 @@
+
+tests:
+
+# Test1
+- id: "test1"
+  schedule: true
+  name: "Test latest clients"
+  clients: clients/latest.yaml
+  kurtosis: kurtosis-config/default.yaml
+  worker: ubuntu-latest
+  backend: docker
+  clientPairs:
+  # CL: [lighthouse,prysm,teku,lodestar,nimbus]
+  # EL: [geth,besu,reth,erigon,nethermind]
+  - lodestar-geth,lighthouse-geth,nimbus-erigon
+  - nimbus-besu,teku-reth,teku-besu
+  - lodestar-erigon,nimbus-reth,prysm-reth
+  - lodestar-besu,lighthouse-reth,nimbus-nethermind
+  - lighthouse-erigon,teku-erigon,prysm-nethermind
+  - lodestar-nethermind,prysm-geth,teku-geth
+  - prysm-besu,lodestar-reth,lighthouse-nethermind
+  - lighthouse-besu,teku-nethermind,prysm-erigon
+  - nimbus-geth,lighthouse-geth,prysm-reth
+  assertoorTests:
+  - assertoor-tests/stability-check.yaml
+  - assertoor-tests/block-proposal-check.yaml
+  - assertoor-tests/eoa-transactions-test.yaml
+  - assertoor-tests/all-opcodes-test.yaml
+  - assertoor-tests/validator-withdrawal-test.yaml
+  - assertoor-tests/validator-exit-test.yaml
+  - assertoor-tests/validator-slashing-test.yaml
+
+# kubetest
+- id: "kubetest"
+  schedule: false
+  name: "Kubernetes Test"
+  clients: clients/latest.yaml
+  kurtosis: kurtosis-config/default.yaml
+  worker: ubuntu-latest
+  backend: kubernetes
+  kubernetes:
+    cluster: services
+    storageClass: do-block-storage
+  clientPairs:
+  - lighthouse-geth,prysm-reth,lodestar-besu
+  assertoorTests:
+  - assertoor-tests/stability-check.yaml
+  - assertoor-tests/block-proposal-check.yaml
+  - assertoor-tests/eoa-transactions-test.yaml
+  - assertoor-tests/all-opcodes-test.yaml
+  - assertoor-tests/validator-withdrawal-test.yaml
+  - assertoor-tests/validator-exit-test.yaml
+  - assertoor-tests/validator-slashing-test.yaml
+
+
+- id: "deneb-test"
+  schedule: true
+  name: "Test dencun clients"
+  clients: clients/deneb.yaml
+  kurtosis: kurtosis-config/deneb.yaml
+  worker: ubuntu-latest
+  backend: docker
+  clientPairs:
+  - lighthouse-geth,prysm-reth,lodestar-besu
+  - lighthouse-geth,teku-erigon,nimbus-reth
+  - lighthouse-besu,prysm-reth,teku-geth
+  assertoorTests:
+  - assertoor-tests/stability-check.yaml
+  - assertoor-tests/block-proposal-check.yaml
+  - assertoor-tests/eoa-transactions-test.yaml
+  - assertoor-tests/blob-transactions-test.yaml
+  - assertoor-tests/all-opcodes-test.yaml
+  - assertoor-tests/dencun-opcodes-test.yaml
+  - assertoor-tests/validator-withdrawal-test.yaml
+  - assertoor-tests/validator-exit-test.yaml
+  - assertoor-tests/validator-slashing-test.yaml
+
+
+- id: "verkle-test"
+  schedule: true
+  name: "Test verkle clients"
+  clients: clients/verkle.yaml
+  kurtosis: kurtosis-config/verkle-gen.yaml
+  worker: ubuntu-latest
+  backend: docker
+  clientPairs:
+  - lighthouse-geth,lighthouse-geth,lodestar-geth
+  assertoorTests:
+  - assertoor-tests/stability-check.yaml
+  - assertoor-tests/block-proposal-check.yaml
+  - assertoor-tests/eoa-transactions-test.yaml
+  - assertoor-tests/all-opcodes-test.yaml
+  - assertoor-tests/validator-withdrawal-test.yaml
+  # voluntary exit test does not work because according to EIP7044 assertoor signs exits with the capella signing domain
+  #- assertoor-tests/validator-exit-test.yaml
+  - assertoor-tests/validator-slashing-test.yaml
+


### PR DESCRIPTION
- fix: pool eviction bug (#6284)
- fix: manual trigger for hive in addition to cron schedule [RET-241] (#6287)
- fix: use matching image tag as upstream hive in hive action (#6288)
- use `matches!` macro in `ForkCondition` implementation (#6297)
- Bug fix, increase tx response soft limit (#6301)
- Sanitise eth68 announcement (#6222)
- feat: separate node-builder crate (#6302)
- feat(net): batch-import received txs (#6299)
- chore: add missing is functions (#6309)
- check `suite_path` exists in ef-tests `Suite` `run` (#6303)
- opt-out of filling space in request upon announcement (#6310)
- General purpose best transaction implementation (#6203)
- feat: add with-unused-ports cli argument (#6314)
- refactor(trie): hashed state (#6244)
- fix: ensure backwards compat config (#6319)
- fix(primitives): don't double-hex signature bytes in `Signature#to_hex_bytes` (#6313)
- Example/custom payload builder (#6269)
- small refactoring (#6321)
- fix: op features for op crate (#6320)
- feat: assertoor
