### PR TITLE
chore: remove op-flagged arguments from receipt root calc

### DIFF
--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1243,10 +1243,14 @@ mod tests {
     use reth_db::{tables, test_utils::TempDatabase, transaction::DbTxMut, DatabaseEnv};
     use reth_interfaces::test_utils::TestConsensus;
     use reth_node_ethereum::EthEvmConfig;
+    #[cfg(not(feature = "optimism"))]
+    use reth_primitives::proofs::calculate_receipt_root;
+    #[cfg(feature = "optimism")]
+    use reth_primitives::proofs::calculate_receipt_root_optimism;
     use reth_primitives::{
         constants::{EIP1559_INITIAL_BASE_FEE, EMPTY_ROOT_HASH, ETHEREUM_BLOCK_GAS_LIMIT},
         keccak256,
-        proofs::{calculate_receipt_root, calculate_transaction_root, state_root_unhashed},
+        proofs::{calculate_transaction_root, state_root_unhashed},
         revm_primitives::AccountInfo,
         stage::StageCheckpoint,
         Account, Address, ChainSpecBuilder, Genesis, GenesisAccount, Header, Signature,
@@ -1466,7 +1470,7 @@ mod tests {
             let receipts_root = calculate_receipt_root(&receipts);
 
             #[cfg(feature = "optimism")]
-            let receipts_root = calculate_receipt_root(&receipts, &chain_spec, 0);
+            let receipts_root = calculate_receipt_root_optimism(&receipts, &chain_spec, 0);
 
             SealedBlockWithSenders::new(
                 SealedBlock {

--- a/crates/consensus/auto-seal/src/lib.rs
+++ b/crates/consensus/auto-seal/src/lib.rs
@@ -345,13 +345,17 @@ impl StorageInner {
 
     /// Fills in the post-execution header fields based on the given BundleState and gas used.
     /// In doing this, the state root is calculated and the final header is returned.
+    ///
+    /// This is optimism-specific and contains the `ChainSpec` so the proper state root can be
+    /// calculated.
+    #[cfg(feature = "optimism")]
     pub(crate) fn complete_header<S: StateProviderFactory>(
         &self,
         mut header: Header,
         bundle_state: &BundleStateWithReceipts,
         client: &S,
         gas_used: u64,
-        #[cfg(feature = "optimism")] chain_spec: &ChainSpec,
+        chain_spec: &ChainSpec,
     ) -> Result<Header, BlockExecutionError> {
         let receipts = bundle_state.receipts_by_block(header.number);
         header.receipts_root = if receipts.is_empty() {
@@ -363,13 +367,46 @@ impl StorageInner {
                 .collect::<Vec<ReceiptWithBloom>>();
             header.logs_bloom =
                 receipts_with_bloom.iter().fold(Bloom::ZERO, |bloom, r| bloom | r.bloom);
-            proofs::calculate_receipt_root(
+            proofs::calculate_receipt_root_optimism(
                 &receipts_with_bloom,
-                #[cfg(feature = "optimism")]
                 chain_spec,
-                #[cfg(feature = "optimism")]
                 header.timestamp,
             )
+        };
+
+        header.gas_used = gas_used;
+
+        // calculate the state root
+        let state_root = client
+            .latest()
+            .map_err(|_| BlockExecutionError::ProviderError)?
+            .state_root(bundle_state)
+            .unwrap();
+        header.state_root = state_root;
+        Ok(header)
+    }
+
+    /// Fills in the post-execution header fields based on the given BundleState and gas used.
+    /// In doing this, the state root is calculated and the final header is returned.
+    #[cfg(not(feature = "optimism"))]
+    pub(crate) fn complete_header<S: StateProviderFactory>(
+        &self,
+        mut header: Header,
+        bundle_state: &BundleStateWithReceipts,
+        client: &S,
+        gas_used: u64,
+    ) -> Result<Header, BlockExecutionError> {
+        let receipts = bundle_state.receipts_by_block(header.number);
+        header.receipts_root = if receipts.is_empty() {
+            EMPTY_RECEIPTS
+        } else {
+            let receipts_with_bloom = receipts
+                .iter()
+                .map(|r| (*r).clone().expect("receipts have not been pruned").into())
+                .collect::<Vec<ReceiptWithBloom>>();
+            header.logs_bloom =
+                receipts_with_bloom.iter().fold(Bloom::ZERO, |bloom, r| bloom | r.bloom);
+            proofs::calculate_receipt_root(&receipts_with_bloom)
         };
 
         header.gas_used = gas_used;

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -1,8 +1,10 @@
+#[cfg(not(feature = "optimism"))]
+use crate::proofs::calculate_receipt_root_ref;
+#[cfg(feature = "optimism")]
+use crate::proofs::calculate_receipt_root_ref_optimism;
 use crate::{
     compression::{RECEIPT_COMPRESSOR, RECEIPT_DECOMPRESSOR},
-    logs_bloom,
-    proofs::calculate_receipt_root_ref,
-    Bloom, Log, PruneSegmentError, TxType, B256,
+    logs_bloom, Bloom, Log, PruneSegmentError, TxType, B256,
 };
 use alloy_rlp::{length_of_length, Decodable, Encodable};
 use bytes::{Buf, BufMut, BytesMut};
@@ -110,7 +112,7 @@ impl Receipts {
         chain_spec: &crate::ChainSpec,
         timestamp: u64,
     ) -> Option<B256> {
-        Some(calculate_receipt_root_ref(
+        Some(calculate_receipt_root_ref_optimism(
             &self.receipt_vec[index].iter().map(Option::as_ref).collect::<Option<Vec<_>>>()?,
             chain_spec,
             timestamp,

--- a/crates/revm/src/optimism/processor.rs
+++ b/crates/revm/src/optimism/processor.rs
@@ -1,4 +1,4 @@
-use crate::processor::{verify_receipt, EVMProcessor};
+use crate::processor::{verify_receipt_optimism, EVMProcessor};
 use reth_interfaces::executor::{
     BlockExecutionError, BlockValidationError, OptimismBlockExecutionError,
 };
@@ -38,7 +38,7 @@ where
         // See more about EIP here: https://eips.ethereum.org/EIPS/eip-658
         if self.chain_spec.fork(Hardfork::Byzantium).active_at_block(block.header.number) {
             let time = Instant::now();
-            if let Err(error) = verify_receipt(
+            if let Err(error) = verify_receipt_optimism(
                 block.header.receipts_root,
                 block.header.logs_bloom,
                 receipts.iter(),

--- a/crates/revm/src/optimism/processor.rs
+++ b/crates/revm/src/optimism/processor.rs
@@ -11,6 +11,35 @@ use revm::DatabaseCommit;
 use std::time::Instant;
 use tracing::{debug, trace};
 
+/// Verify the calculated receipts root against the expected receipts root.
+pub fn verify_receipt_optimism<'a>(
+    expected_receipts_root: B256,
+    expected_logs_bloom: Bloom,
+    receipts: impl Iterator<Item = &'a Receipt> + Clone,
+    chain_spec: &ChainSpec,
+    timestamp: u64,
+) -> Result<(), BlockExecutionError> {
+    // Calculate receipts root.
+    let receipts_with_bloom = receipts.map(|r| r.clone().into()).collect::<Vec<ReceiptWithBloom>>();
+    let receipts_root = reth_primitives::proofs::calculate_receipt_root_optimism(
+        &receipts_with_bloom,
+        chain_spec,
+        timestamp,
+    );
+
+    // Create header log bloom.
+    let logs_bloom = receipts_with_bloom.iter().fold(Bloom::ZERO, |bloom, r| bloom | r.bloom);
+
+    compare_receipts_root_and_logs_bloom(
+        receipts_root,
+        logs_bloom,
+        expected_receipts_root,
+        expected_logs_bloom,
+    )?;
+
+    Ok(())
+}
+
 impl<'a, EvmConfig> BlockExecutor for EVMProcessor<'a, EvmConfig>
 where
     EvmConfig: ConfigureEvmEnv,

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -530,38 +530,81 @@ where
     }
 }
 
-/// Verify receipts
+/// Calculate the receipts root, and copmare it against against the expected receipts root and logs
+/// bloom.
 pub fn verify_receipt<'a>(
+    expected_receipts_root: B256,
+    expected_logs_bloom: Bloom,
+    receipts: impl Iterator<Item = &'a Receipt> + Clone,
+) -> Result<(), BlockExecutionError> {
+    // Calculate receipts root.
+    let receipts_with_bloom = receipts.map(|r| r.clone().into()).collect::<Vec<ReceiptWithBloom>>();
+    let receipts_root = reth_primitives::proofs::calculate_receipt_root(&receipts_with_bloom);
+
+    // Create header log bloom.
+    let logs_bloom = receipts_with_bloom.iter().fold(Bloom::ZERO, |bloom, r| bloom | r.bloom);
+
+    compare_receipts_root_and_logs_bloom(
+        receipts_root,
+        logs_bloom,
+        expected_receipts_root,
+        expected_logs_bloom,
+    )?;
+
+    Ok(())
+}
+
+/// Compare the calculated receipts root with the expected receipts root, also copmare
+/// the calculated logs bloom with the expected logs bloom.
+pub fn compare_receipts_root_and_logs_bloom(
+    calculated_receipts_root: B256,
+    calculated_logs_bloom: Bloom,
+    expected_receipts_root: B256,
+    expected_logs_bloom: Bloom,
+) -> Result<(), BlockExecutionError> {
+    if calculated_receipts_root != expected_receipts_root {
+        return Err(BlockValidationError::ReceiptRootDiff(
+            GotExpected { got: calculated_receipts_root, expected: expected_receipts_root }.into(),
+        )
+        .into())
+    }
+
+    if calculated_logs_bloom != expected_logs_bloom {
+        return Err(BlockValidationError::BloomLogDiff(
+            GotExpected { got: calculated_logs_bloom, expected: expected_logs_bloom }.into(),
+        )
+        .into())
+    }
+
+    Ok(())
+}
+
+/// Verify the calculated receipts root against the expected receipts root.
+#[cfg(feature = "optimism")]
+pub fn verify_receipt_optimism<'a>(
     expected_receipts_root: B256,
     expected_logs_bloom: Bloom,
     receipts: impl Iterator<Item = &'a Receipt> + Clone,
     #[cfg(feature = "optimism")] chain_spec: &ChainSpec,
     #[cfg(feature = "optimism")] timestamp: u64,
 ) -> Result<(), BlockExecutionError> {
-    // Check receipts root.
+    // Calculate receipts root.
     let receipts_with_bloom = receipts.map(|r| r.clone().into()).collect::<Vec<ReceiptWithBloom>>();
-    let receipts_root = reth_primitives::proofs::calculate_receipt_root(
+    let receipts_root = reth_primitives::proofs::calculate_receipt_root_optimism(
         &receipts_with_bloom,
-        #[cfg(feature = "optimism")]
         chain_spec,
-        #[cfg(feature = "optimism")]
         timestamp,
     );
-    if receipts_root != expected_receipts_root {
-        return Err(BlockValidationError::ReceiptRootDiff(
-            GotExpected { got: receipts_root, expected: expected_receipts_root }.into(),
-        )
-        .into())
-    }
 
     // Create header log bloom.
     let logs_bloom = receipts_with_bloom.iter().fold(Bloom::ZERO, |bloom, r| bloom | r.bloom);
-    if logs_bloom != expected_logs_bloom {
-        return Err(BlockValidationError::BloomLogDiff(
-            GotExpected { got: logs_bloom, expected: expected_logs_bloom }.into(),
-        )
-        .into())
-    }
+
+    compare_receipts_root_and_logs_bloom(
+        receipts_root,
+        logs_bloom,
+        expected_receipts_root,
+        expected_logs_bloom,
+    )?;
 
     Ok(())
 }

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -579,36 +579,6 @@ pub fn compare_receipts_root_and_logs_bloom(
     Ok(())
 }
 
-/// Verify the calculated receipts root against the expected receipts root.
-#[cfg(feature = "optimism")]
-pub fn verify_receipt_optimism<'a>(
-    expected_receipts_root: B256,
-    expected_logs_bloom: Bloom,
-    receipts: impl Iterator<Item = &'a Receipt> + Clone,
-    #[cfg(feature = "optimism")] chain_spec: &ChainSpec,
-    #[cfg(feature = "optimism")] timestamp: u64,
-) -> Result<(), BlockExecutionError> {
-    // Calculate receipts root.
-    let receipts_with_bloom = receipts.map(|r| r.clone().into()).collect::<Vec<ReceiptWithBloom>>();
-    let receipts_root = reth_primitives::proofs::calculate_receipt_root_optimism(
-        &receipts_with_bloom,
-        chain_spec,
-        timestamp,
-    );
-
-    // Create header log bloom.
-    let logs_bloom = receipts_with_bloom.iter().fold(Bloom::ZERO, |bloom, r| bloom | r.bloom);
-
-    compare_receipts_root_and_logs_bloom(
-        receipts_root,
-        logs_bloom,
-        expected_receipts_root,
-        expected_logs_bloom,
-    )?;
-
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Feature-flagged arguments are pretty cursed and differences in receipt root calculation warrants a new method entirely, so this creates new optimism-specific methods for their receipt root calculation.