### PR TITLE
best way to bring cli param to EthTransactionValidatorInner?

### DIFF
--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -182,16 +182,19 @@ impl Command {
             BlockchainProvider::new(provider_factory.clone(), blockchain_tree.clone())?;
         let blob_store = InMemoryBlobStore::default();
 
+        let pool_config = PoolConfig::default();
+
         let validator = TransactionValidationTaskExecutor::eth_builder(Arc::clone(&self.chain))
             .with_head_timestamp(best_block.timestamp)
             .kzg_settings(self.kzg_settings()?)
             .with_additional_tasks(1)
+            .with_max_tx_input_bytes(pool_config.max_tx_input_bytes)
             .build_with_tasks(blockchain_db.clone(), ctx.task_executor.clone(), blob_store.clone());
-
+        
         let transaction_pool = reth_transaction_pool::Pool::eth_pool(
             validator,
             blob_store.clone(),
-            PoolConfig::default(),
+            pool_config,
         );
         info!(target: "reth::cli", "Transaction pool initialized");
 

--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -182,13 +182,10 @@ impl Command {
             BlockchainProvider::new(provider_factory.clone(), blockchain_tree.clone())?;
         let blob_store = InMemoryBlobStore::default();
 
-        let pool_config = PoolConfig::default();
-
         let validator = TransactionValidationTaskExecutor::eth_builder(Arc::clone(&self.chain))
             .with_head_timestamp(best_block.timestamp)
             .kzg_settings(self.kzg_settings()?)
             .with_additional_tasks(1)
-            .with_max_tx_input_bytes(pool_config.max_tx_input_bytes)
             .build_with_tasks(blockchain_db.clone(), ctx.task_executor.clone(), blob_store.clone());
 
         let transaction_pool =

--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -190,12 +190,9 @@ impl Command {
             .with_additional_tasks(1)
             .with_max_tx_input_bytes(pool_config.max_tx_input_bytes)
             .build_with_tasks(blockchain_db.clone(), ctx.task_executor.clone(), blob_store.clone());
-        
-        let transaction_pool = reth_transaction_pool::Pool::eth_pool(
-            validator,
-            blob_store.clone(),
-            pool_config,
-        );
+
+        let transaction_pool =
+            reth_transaction_pool::Pool::eth_pool(validator, blob_store.clone(), pool_config);
         info!(target: "reth::cli", "Transaction pool initialized");
 
         let mut blobs_bundle = self

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -331,6 +331,11 @@ TxPool:
           
           [default: 100]
 
+      --txpool.max_tx_input_bytes <MAX_TX_INPUT_BYTES>
+        Maximum size a single transaction can have
+
+          [default: 131072]
+
       --txpool.nolocals
           Flag to disable local transaction exemptions
 

--- a/crates/node-core/src/args/txpool_args.rs
+++ b/crates/node-core/src/args/txpool_args.rs
@@ -45,7 +45,7 @@ pub struct TxPoolArgs {
     #[arg(long = "blobpool.pricebump", default_value_t = REPLACE_BLOB_PRICE_BUMP)]
     pub blob_transaction_price_bump: u128,
 
-    /// Maximum size a single transaction can have
+    /// Max size in bytes of a single transaction allowed to enter the pool
     #[arg(long = "txpool.max_tx_input_bytes", default_value_t = DEFAULT_MAX_TX_INPUT_BYTES)]
     pub max_tx_input_bytes: usize,
 

--- a/crates/node-core/src/args/txpool_args.rs
+++ b/crates/node-core/src/args/txpool_args.rs
@@ -4,8 +4,8 @@ use crate::cli::config::RethTransactionPoolConfig;
 use clap::Args;
 use reth_primitives::Address;
 use reth_transaction_pool::{
-    LocalTransactionConfig, PoolConfig, PriceBumpConfig, SubPoolLimit, DEFAULT_PRICE_BUMP,
-    REPLACE_BLOB_PRICE_BUMP, TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
+    validate::DEFAULT_MAX_TX_INPUT_BYTES, LocalTransactionConfig, PoolConfig, PriceBumpConfig,
+    SubPoolLimit, DEFAULT_PRICE_BUMP, REPLACE_BLOB_PRICE_BUMP, TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
     TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT, TXPOOL_SUBPOOL_MAX_TXS_DEFAULT,
 };
 /// Parameters for debugging purposes
@@ -44,6 +44,11 @@ pub struct TxPoolArgs {
     /// Price bump percentage to replace an already existing blob transaction
     #[arg(long = "blobpool.pricebump", default_value_t = REPLACE_BLOB_PRICE_BUMP)]
     pub blob_transaction_price_bump: u128,
+
+    /// Maximum size a single transaction can have
+    #[arg(long = "txpool.max_tx_input_bytes", default_value_t = DEFAULT_MAX_TX_INPUT_BYTES)]
+    pub max_tx_input_bytes: usize,
+
     /// Flag to disable local transaction exemptions.
     #[arg(long = "txpool.nolocals")]
     pub no_locals: bool,
@@ -67,6 +72,7 @@ impl Default for TxPoolArgs {
             max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
             price_bump: DEFAULT_PRICE_BUMP,
             blob_transaction_price_bump: REPLACE_BLOB_PRICE_BUMP,
+            max_tx_input_bytes: DEFAULT_MAX_TX_INPUT_BYTES,
             no_locals: false,
             locals: Default::default(),
             no_local_transactions_propagation: false,
@@ -104,6 +110,7 @@ impl RethTransactionPoolConfig for TxPoolArgs {
                 default_price_bump: self.price_bump,
                 replace_blob_tx_price_bump: self.blob_transaction_price_bump,
             },
+            max_tx_input_bytes: self.max_tx_input_bytes,
         }
     }
 }

--- a/crates/node-core/src/node_config.rs
+++ b/crates/node-core/src/node_config.rs
@@ -464,6 +464,8 @@ impl NodeConfig {
             .kzg_settings(self.kzg_settings()?)
             // use an additional validation task so we can validate transactions in parallel
             .with_additional_tasks(1)
+            // set the max tx size in bytes allowed to enter the pool
+            .with_max_tx_input_bytes(self.txpool.max_tx_input_bytes)
             .build_with_tasks(blockchain_db.clone(), executor.clone(), blob_store.clone());
 
         let transaction_pool =

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -1,4 +1,4 @@
-use crate::{validate::DEFAULT_MAX_TX_INPUT_BYTES, TransactionOrigin};
+use crate::TransactionOrigin;
 use reth_primitives::{Address, EIP4844_TX_TYPE_ID};
 use std::collections::HashSet;
 /// Guarantees max transactions for one sender, compatible with geth/erigon
@@ -36,8 +36,6 @@ pub struct PoolConfig {
     /// How to handle locally received transactions:
     /// [TransactionOrigin::Local](crate::TransactionOrigin).
     pub local_transactions_config: LocalTransactionConfig,
-    /// Maximum size a single transaction can have
-    pub max_tx_input_bytes: usize,
 }
 
 impl Default for PoolConfig {
@@ -50,7 +48,6 @@ impl Default for PoolConfig {
             max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
             price_bumps: Default::default(),
             local_transactions_config: Default::default(),
-            max_tx_input_bytes: DEFAULT_MAX_TX_INPUT_BYTES,
         }
     }
 }

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -1,4 +1,4 @@
-use crate::TransactionOrigin;
+use crate::{validate::DEFAULT_MAX_TX_INPUT_BYTES, TransactionOrigin};
 use reth_primitives::{Address, EIP4844_TX_TYPE_ID};
 use std::collections::HashSet;
 /// Guarantees max transactions for one sender, compatible with geth/erigon
@@ -36,6 +36,8 @@ pub struct PoolConfig {
     /// How to handle locally received transactions:
     /// [TransactionOrigin::Local](crate::TransactionOrigin).
     pub local_transactions_config: LocalTransactionConfig,
+    /// Maximum size a single transaction can have
+    pub max_tx_input_bytes: usize,
 }
 
 impl Default for PoolConfig {
@@ -48,6 +50,7 @@ impl Default for PoolConfig {
             max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
             price_bumps: Default::default(),
             local_transactions_config: Default::default(),
+            max_tx_input_bytes: DEFAULT_MAX_TX_INPUT_BYTES,
         }
     }
 }

--- a/crates/transaction-pool/src/validate/constants.rs
+++ b/crates/transaction-pool/src/validate/constants.rs
@@ -8,7 +8,7 @@ pub const TX_SLOT_BYTE_SIZE: usize = 32 * 1024;
 /// non-trivial consequences: larger transactions are significantly harder and
 /// more expensive to propagate; larger transactions also take more resources
 /// to validate whether they fit into the pool or not.
-pub const MAX_TX_INPUT_BYTES: usize = 4 * TX_SLOT_BYTE_SIZE; // 128KB
+pub const DEFAULT_MAX_TX_INPUT_BYTES: usize = 4 * TX_SLOT_BYTE_SIZE; // 128KB
 
 /// Maximum bytecode to permit for a contract.
 pub const MAX_CODE_BYTE_SIZE: usize = 24576;

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -484,6 +484,8 @@ pub struct EthTransactionValidatorBuilder {
     kzg_settings: Arc<KzgSettings>,
     /// How to handle [TransactionOrigin::Local](TransactionOrigin) transactions.
     local_transactions_config: LocalTransactionConfig,
+    /// Max size in bytes of a single transaction allowed
+    max_tx_input_bytes: usize
 }
 
 impl EthTransactionValidatorBuilder {
@@ -510,6 +512,7 @@ impl EthTransactionValidatorBuilder {
 
             // TODO: can hard enable by default once mainnet transitioned
             cancun,
+            max_tx_input_bytes: DEFAULT_MAX_TX_INPUT_BYTES,
         }
     }
 
@@ -593,6 +596,13 @@ impl EthTransactionValidatorBuilder {
         self
     }
 
+    /// Sets a max size in bytes of a single transaction allowed into the pool
+    pub const fn with_max_tx_input_bytes(mut self, max_tx_input_bytes: usize) -> Self {
+        self.max_tx_input_bytes = max_tx_input_bytes;
+        self
+    }
+
+
     /// Builds a the [EthTransactionValidator] without spawning validator tasks.
     pub fn build<Client, Tx, S>(
         self,
@@ -613,6 +623,7 @@ impl EthTransactionValidatorBuilder {
             minimum_priority_fee,
             kzg_settings,
             local_transactions_config,
+            max_tx_input_bytes,
             ..
         } = self;
 
@@ -631,8 +642,7 @@ impl EthTransactionValidatorBuilder {
             blob_store: Box::new(blob_store),
             kzg_settings,
             local_transactions_config,
-            max_tx_input_bytes: DEFAULT_MAX_TX_INPUT_BYTES, /* TODO: Best way to bring poolconfig
-                                                             * to the scope? */
+            max_tx_input_bytes,
             _marker: Default::default(),
         };
 

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -485,7 +485,7 @@ pub struct EthTransactionValidatorBuilder {
     /// How to handle [TransactionOrigin::Local](TransactionOrigin) transactions.
     local_transactions_config: LocalTransactionConfig,
     /// Max size in bytes of a single transaction allowed
-    max_tx_input_bytes: usize
+    max_tx_input_bytes: usize,
 }
 
 impl EthTransactionValidatorBuilder {
@@ -601,7 +601,6 @@ impl EthTransactionValidatorBuilder {
         self.max_tx_input_bytes = max_tx_input_bytes;
         self
     }
-
 
     /// Builds a the [EthTransactionValidator] without spawning validator tasks.
     pub fn build<Client, Tx, S>(

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -120,7 +120,7 @@ pub(crate) struct EthTransactionValidatorInner<Client, T> {
     kzg_settings: Arc<KzgSettings>,
     /// How to handle [TransactionOrigin::Local](TransactionOrigin) transactions.
     local_transactions_config: LocalTransactionConfig,
-    /// Maximum size a single transaction can have
+    /// Maximum size in bytes a single transaction can have in order to be accepted into the pool.
     max_tx_input_bytes: usize,
     /// Marker for the transaction type
     _marker: PhantomData<T>,
@@ -501,6 +501,7 @@ impl EthTransactionValidatorBuilder {
             additional_tasks: 1,
             kzg_settings: Arc::clone(&MAINNET_KZG_TRUSTED_SETUP),
             local_transactions_config: Default::default(),
+            max_tx_input_bytes: DEFAULT_MAX_TX_INPUT_BYTES,
 
             // by default all transaction types are allowed
             eip2718: true,
@@ -512,7 +513,6 @@ impl EthTransactionValidatorBuilder {
 
             // TODO: can hard enable by default once mainnet transitioned
             cancun,
-            max_tx_input_bytes: DEFAULT_MAX_TX_INPUT_BYTES,
         }
     }
 

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -23,7 +23,7 @@ pub use task::{TransactionValidationTaskExecutor, ValidationTask};
 
 /// Validation constants.
 pub use constants::{
-    MAX_CODE_BYTE_SIZE, MAX_INIT_CODE_BYTE_SIZE, MAX_TX_INPUT_BYTES, TX_SLOT_BYTE_SIZE,
+    DEFAULT_MAX_TX_INPUT_BYTES, MAX_CODE_BYTE_SIZE, MAX_INIT_CODE_BYTE_SIZE, TX_SLOT_BYTE_SIZE,
 };
 
 /// A Result type returned after checking a transaction's validity.


### PR DESCRIPTION
resolves #6411 

I add `max_tx_input_bytes` to `TxPoolArgs` to receive "soft limit" as cli args and plan to send it downstream to EthTransactionValidator but wonder what's the best practice.
i can't find an example where non-default value of TxPoolArgs is used in downstream process, e.g. `pending_limit`.
also wonder is it the right place to put `max_tx_input_bytes` in `TxPoolArgs`? a nit, what's the use of `TX_SLOT_BYTE_SIZE`, it seems only used to compute `MAX_TX_INPUT_BYTES` and not used anywhere else.

also wonder why this is done in serial, it feels like trivially parallelizable task since it's a stateless validation. https://github.com/paradigmxyz/reth/blob/cd0a2f34bcdd0e4ce86c915d3299848c3ba18ac7/crates/transaction-pool/src/validate/eth.rs#L60

