### PR TITLE
Update readme on how to run only grafana in docker

### DIFF
--- a/book/installation/docker.md
+++ b/book/installation/docker.md
@@ -126,10 +126,10 @@ docker exec -it reth bash
 
 Refer to the [CLI docs](../cli/cli.md) to interact with Reth once inside the Reth container.
 
-## Run only grafana in docker
+## Run only Grafana in Docker
 
 ```bash
 docker compose -f etc/docker-compose.yml up -d --no-deps grafana
 ```
 
-This should list Prometheus under [`grafana datasources`](http://localhost:3000/connections/datasources). Replace its `Prometheus server URL` with `http://host.docker.internal:9090`.
+After login with `admin:admin` credentials, this should list Prometheus under [`grafana datasources`](http://localhost:3000/connections/datasources). Replace its `Prometheus server URL` with `http://host.docker.internal:9090`.

--- a/book/installation/docker.md
+++ b/book/installation/docker.md
@@ -134,4 +134,4 @@ This allows importing existing Grafana dashboards, without running reth in Docke
 docker compose -f etc/docker-compose.yml up -d --no-deps grafana
 ```
 
-After login with `admin:admin` credentials, this should list Prometheus under [`grafana datasources`](http://localhost:3000/connections/datasources). Replace its `Prometheus server URL` with `http://host.docker.internal:9090`.
+After login with `admin:admin` credentials, this should list Prometheus under [`Grafana datasources`](http://localhost:3000/connections/datasources). Replace its `Prometheus server URL` with `http://host.docker.internal:9090`.

--- a/book/installation/docker.md
+++ b/book/installation/docker.md
@@ -128,6 +128,8 @@ Refer to the [CLI docs](../cli/cli.md) to interact with Reth once inside the Ret
 
 ## Run only Grafana in Docker
 
+This allows importing existing Grafana dashboards, without running reth in Docker.
+
 ```bash
 docker compose -f etc/docker-compose.yml up -d --no-deps grafana
 ```

--- a/book/installation/docker.md
+++ b/book/installation/docker.md
@@ -125,3 +125,11 @@ docker exec -it reth bash
 **If Reth is running with Docker Compose, replace `reth` with `reth-reth-1` in the above command**
 
 Refer to the [CLI docs](../cli/cli.md) to interact with Reth once inside the Reth container.
+
+## Run only grafana in docker
+
+```bash
+docker compose -f etc/docker-compose.yml up -d --no-deps grafana
+```
+
+This should list Prometheus under [`grafana datasources`](http://localhost:3000/connections/datasources). Replace its `Prometheus server URL` with `http://host.docker.internal:9090`.

--- a/book/installation/docker.md
+++ b/book/installation/docker.md
@@ -128,7 +128,7 @@ Refer to the [CLI docs](../cli/cli.md) to interact with Reth once inside the Ret
 
 ## Run only Grafana in Docker
 
-This allows importing existing Grafana dashboards, without running reth in Docker.
+This allows importing existing Grafana dashboards, without running Reth in Docker.
 
 ```bash
 docker compose -f etc/docker-compose.yml up -d --no-deps grafana

--- a/book/installation/docker.md
+++ b/book/installation/docker.md
@@ -134,4 +134,4 @@ This allows importing existing Grafana dashboards, without running reth in Docke
 docker compose -f etc/docker-compose.yml up -d --no-deps grafana
 ```
 
-After login with `admin:admin` credentials, this should list Prometheus under [`Grafana datasources`](http://localhost:3000/connections/datasources). Replace its `Prometheus server URL` with `http://host.docker.internal:9090`.
+After login with `admin:admin` credentials, Prometheus should be listed under [`Grafana datasources`](http://localhost:3000/connections/datasources). Replace its `Prometheus server URL` so it points to Docker. On Mac or Windows, use `http://host.docker.internal:9090`. On Linux, try `http://172.17.0.1:9090`.

--- a/book/installation/docker.md
+++ b/book/installation/docker.md
@@ -134,4 +134,4 @@ This allows importing existing Grafana dashboards, without running Reth in Docke
 docker compose -f etc/docker-compose.yml up -d --no-deps grafana
 ```
 
-After login with `admin:admin` credentials, Prometheus should be listed under [`Grafana datasources`](http://localhost:3000/connections/datasources). Replace its `Prometheus server URL` so it points to Docker. On Mac or Windows, use `http://host.docker.internal:9090`. On Linux, try `http://172.17.0.1:9090`.
+After login with `admin:admin` credentials, Prometheus should be listed under [`Grafana datasources`](http://localhost:3000/connections/datasources). Replace its `Prometheus server URL` so it points to locally running one. On Mac or Windows, use `http://host.docker.internal:9090`. On Linux, try `http://172.17.0.1:9090`.

--- a/etc/README.md
+++ b/etc/README.md
@@ -15,4 +15,4 @@ To run Reth, Grafana or Prometheus with Docker Compose, refer to the [docker doc
 
 ### Import Grafana dashboards
 
-Running Grafana in Docker makes it possible to import existing dashboards, refer to [docker docs on how to run only grafana in docker](/book/installation/docker.md#using-docker-compose#run-only-grafana-in-docker).
+Running Grafana in Docker makes it possible to import existing dashboards, refer to [docs on how to run only Grafana in Docker](/book/installation/docker.md#using-docker-compose#run-only-grafana-in-docker).

--- a/etc/README.md
+++ b/etc/README.md
@@ -11,4 +11,8 @@ The files in this directory may undergo a lot of changes while reth is unstable,
 
 ### Docker Compose
 
-To run Reth, Grafana or Prometheus with Docker Compose, refer to the [docker docs](/book/installation/docker.md#using-docker-compose)
+To run Reth, Grafana or Prometheus with Docker Compose, refer to the [docker docs](/book/installation/docker.md#using-docker-compose).
+
+### Import Grafana dashboards
+
+Running Grafana in Docker makes it possible to import existing dashboards, refer to [docker docs on how to run only grafana in docker](/book/installation/docker.md#using-docker-compose#run-only-grafana-in-docker).

--- a/etc/README.md
+++ b/etc/README.md
@@ -11,4 +11,4 @@ The files in this directory may undergo a lot of changes while reth is unstable,
 
 ### Docker Compose
 
-To run Reth, Grafana and Prometheus with Docker Compose, refer to the [docker docs](/book/installation/docker.md#using-docker-compose)
+To run Reth, Grafana or Prometheus with Docker Compose, refer to the [docker docs](/book/installation/docker.md#using-docker-compose)


### PR DESCRIPTION
In order to import the available `reth` and `Ethereum Metrics Exporter` Grafana dashboards, Grafana must be run in docker. 

Updates docs to explain how to do this.