### PR TITLE
chore: remove chain_spec from ExecutorFactory

### DIFF
--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1283,7 +1283,7 @@ mod tests {
         );
         let provider_factory = create_test_provider_factory_with_chain_spec(chain_spec.clone());
         let consensus = Arc::new(TestConsensus::default());
-        let executor_factory = TestExecutorFactory::new(chain_spec.clone());
+        let executor_factory = TestExecutorFactory::default();
         executor_factory.extend(exec_res);
 
         TreeExternals::new(provider_factory, consensus, executor_factory)

--- a/crates/consensus/beacon/src/engine/sync.rs
+++ b/crates/consensus/beacon/src/engine/sync.rs
@@ -452,7 +452,7 @@ mod tests {
         fn build(self, chain_spec: Arc<ChainSpec>) -> Pipeline<Arc<TempDatabase<DatabaseEnv>>> {
             reth_tracing::init_test_tracing();
 
-            let executor_factory = TestExecutorFactory::new(chain_spec.clone());
+            let executor_factory = TestExecutorFactory::default();
             executor_factory.extend(self.executor_results);
 
             // Setup pipeline

--- a/crates/consensus/beacon/src/engine/test_utils.rs
+++ b/crates/consensus/beacon/src/engine/test_utils.rs
@@ -262,13 +262,6 @@ where
     A: ExecutorFactory,
     B: ExecutorFactory,
 {
-    fn chain_spec(&self) -> &ChainSpec {
-        match self {
-            EitherExecutorFactory::Left(a) => a.chain_spec(),
-            EitherExecutorFactory::Right(b) => b.chain_spec(),
-        }
-    }
-
     fn with_state<'a, SP: reth_provider::StateProvider + 'a>(
         &'a self,
         sp: SP,
@@ -467,8 +460,7 @@ where
         // use either test executor or real executor
         let executor_factory = match self.base_config.executor_config {
             TestExecutorConfig::Test(results) => {
-                let executor_factory =
-                    TestExecutorFactory::new(self.base_config.chain_spec.clone());
+                let executor_factory = TestExecutorFactory::default();
                 executor_factory.extend(results);
                 EitherExecutorFactory::Left(executor_factory)
             }

--- a/crates/revm/src/factory.rs
+++ b/crates/revm/src/factory.rs
@@ -55,9 +55,4 @@ where
         }
         evm
     }
-
-    /// Return internal chainspec
-    fn chain_spec(&self) -> &ChainSpec {
-        self.chain_spec.as_ref()
-    }
 }

--- a/crates/storage/provider/src/test_utils/executor.rs
+++ b/crates/storage/provider/src/test_utils/executor.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use parking_lot::Mutex;
 use reth_interfaces::executor::BlockExecutionError;
-use reth_primitives::{BlockNumber, BlockWithSenders, ChainSpec, PruneModes, Receipt, U256};
+use reth_primitives::{BlockNumber, BlockWithSenders, PruneModes, Receipt, U256};
 use std::sync::Arc;
 /// Test executor with mocked result.
 #[derive(Debug)]
@@ -61,18 +61,12 @@ impl PrunableBlockExecutor for TestExecutor {
 }
 
 /// Executor factory with pre-set execution results.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct TestExecutorFactory {
     exec_results: Arc<Mutex<Vec<BundleStateWithReceipts>>>,
-    chain_spec: Arc<ChainSpec>,
 }
 
 impl TestExecutorFactory {
-    /// Create new instance of test factory.
-    pub fn new(chain_spec: Arc<ChainSpec>) -> Self {
-        Self { exec_results: Arc::new(Mutex::new(Vec::new())), chain_spec }
-    }
-
     /// Extend the mocked execution results
     pub fn extend(&self, results: Vec<BundleStateWithReceipts>) {
         self.exec_results.lock().extend(results);
@@ -86,9 +80,5 @@ impl ExecutorFactory for TestExecutorFactory {
     ) -> Box<dyn PrunableBlockExecutor + 'a> {
         let exec_res = self.exec_results.lock().pop();
         Box::new(TestExecutor(exec_res))
-    }
-
-    fn chain_spec(&self) -> &ChainSpec {
-        self.chain_spec.as_ref()
     }
 }

--- a/crates/storage/provider/src/traits/executor.rs
+++ b/crates/storage/provider/src/traits/executor.rs
@@ -2,7 +2,7 @@
 
 use crate::{bundle_state::BundleStateWithReceipts, StateProvider};
 use reth_interfaces::executor::BlockExecutionError;
-use reth_primitives::{BlockNumber, BlockWithSenders, ChainSpec, PruneModes, Receipt, U256};
+use reth_primitives::{BlockNumber, BlockWithSenders, PruneModes, Receipt, U256};
 use std::time::Duration;
 use tracing::debug;
 
@@ -15,9 +15,6 @@ pub trait ExecutorFactory: Send + Sync + 'static {
         &'a self,
         _sp: SP,
     ) -> Box<dyn PrunableBlockExecutor + 'a>;
-
-    /// Return internal chainspec
-    fn chain_spec(&self) -> &ChainSpec;
 }
 
 /// An executor capable of executing a block.


### PR DESCRIPTION
The `chain_spec` method was unused in the `ExecutorFactory` trait, so I removed it