### PR TITLE
Implement `Deref` and `DerefMut` for `StateProviderDatabase`

### DIFF
--- a/crates/rpc/rpc/src/eth/api/call.rs
+++ b/crates/rpc/rpc/src/eth/api/call.rs
@@ -215,7 +215,7 @@ where
         // if the request is a simple transfer we can optimize
         if env.tx.data.is_empty() {
             if let TransactTo::Call(to) = env.tx.transact_to {
-                if let Ok(code) = db.db.state().account_code(to) {
+                if let Ok(code) = db.db.account_code(to) {
                     let no_code_callee = code.map(|code| code.is_empty()).unwrap_or(true);
                     if no_code_callee {
                         // simple transfer, check if caller has sufficient funds
@@ -425,13 +425,8 @@ where
         let cfg_with_spec_id = CfgEnvWithHandlerCfg::new(env.cfg.clone(), env.handler_cfg.spec_id);
         // calculate the gas used using the access list
         request.access_list = Some(access_list.clone());
-        let gas_used = self.estimate_gas_with(
-            cfg_with_spec_id,
-            env.block.clone(),
-            request,
-            db.db.state(),
-            None,
-        )?;
+        let gas_used =
+            self.estimate_gas_with(cfg_with_spec_id, env.block.clone(), request, &*db.db, None)?;
 
         Ok(AccessListWithGasUsed { access_list, gas_used })
     }


### PR DESCRIPTION
## Description
This pull request implements the `Deref` and `DerefMut` traits for the `StateProviderDatabase` struct. This change allows direct access to the methods of the `StateProvider` trait from an instance of `StateProviderDatabase` through dereferencing.

## Changes Made
- Implemented the `Deref` trait for `StateProviderDatabase`, allowing it to dereference to a reference of the inner `StateProvider` instance.
- Implemented the `DerefMut` trait for `StateProviderDatabase`, allowing mutable dereferencing to modify the inner `StateProvider` instance.

@mattsse Looking at the code, I told myself that this way of doing things was more rust idiomatic than the old `state` and `state_mut` functions but maybe you wanted to keep the explicit naming of `state` and `state_mut`. If this is the case, please feel free to close this PR.
