### PR TITLE
Payload Events

### DIFF
--- a/crates/node-api/src/engine/mod.rs
+++ b/crates/node-api/src/engine/mod.rs
@@ -16,7 +16,7 @@ pub mod payload;
 pub use payload::PayloadOrAttributes;
 
 /// The types that are used by the engine.
-pub trait EngineTypes: serde::de::DeserializeOwned + Send + Sync {
+pub trait EngineTypes: serde::de::DeserializeOwned + Send + Sync + Clone {
     /// The RPC payload attributes type the CL node emits via the engine API.
     type PayloadAttributes: PayloadAttributes + Unpin;
 

--- a/crates/payload/builder/src/events.rs
+++ b/crates/payload/builder/src/events.rs
@@ -1,0 +1,39 @@
+use futures_util::Stream;
+use reth_node_api::EngineTypes;
+use tokio::sync::broadcast;
+use tokio_stream::{
+    wrappers::{errors::BroadcastStreamRecvError, BroadcastStream},
+    StreamExt,
+};
+
+/// Payload builder events.
+#[derive(Clone, Debug)]
+pub enum Events<Engine: EngineTypes> {
+    /// The payload attributes as
+    /// they are received from the CL through the engine api.
+    Attributes(Engine::PayloadBuilderAttributes),
+    /// The built payload that has been just built.
+    /// Triggered by the CL whenever it asks for an execution payload.
+    /// This event is only thrown if the CL is a validator.
+    BuiltPayload(Engine::BuiltPayload),
+}
+
+/// Represents a receiver for various payload events.
+#[derive(Debug)]
+pub struct PayloadEvents<Engine: EngineTypes> {
+    pub receiver: broadcast::Receiver<Events<Engine>>,
+}
+
+impl<Engine: EngineTypes + 'static> PayloadEvents<Engine> {
+    // Convert this receiver into a stream of PayloadEvents.
+    pub fn into_stream(
+        self,
+    ) -> impl Stream<Item = Result<Events<Engine>, BroadcastStreamRecvError>> {
+        BroadcastStream::new(self.receiver)
+    }
+    /// Asynchronously receives the next payload event.
+    pub async fn recv(self) -> Option<Result<Events<Engine>, BroadcastStreamRecvError>> {
+        let mut event_stream = self.into_stream();
+        event_stream.next().await
+    }
+}

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -102,6 +102,7 @@
 
 pub mod database;
 pub mod error;
+mod events;
 mod metrics;
 mod optimism;
 mod payload;

--- a/crates/payload/builder/src/noop.rs
+++ b/crates/payload/builder/src/noop.rs
@@ -20,7 +20,7 @@ pub struct NoopPayloadBuilderService<Engine: EngineTypes> {
 
 impl<Engine> NoopPayloadBuilderService<Engine>
 where
-    Engine: EngineTypes,
+    Engine: EngineTypes + 'static,
 {
     /// Creates a new [NoopPayloadBuilderService].
     pub fn new() -> (Self, PayloadBuilderHandle<Engine>) {

--- a/crates/payload/builder/src/noop.rs
+++ b/crates/payload/builder/src/noop.rs
@@ -52,6 +52,7 @@ where
                 PayloadServiceCommand::BestPayload(_, tx) => tx.send(None).ok(),
                 PayloadServiceCommand::PayloadAttributes(_, tx) => tx.send(None).ok(),
                 PayloadServiceCommand::Resolve(_, tx) => tx.send(None).ok(),
+                PayloadServiceCommand::Subscribe(_) => None,
             };
         }
     }

--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -318,7 +318,7 @@ where
         let fut = async move {
             let res = fut.await;
             if let Ok(ref payload) = res {
-                let _ = payload_events.send(PayloadEvents::BuiltPayload(payload.clone().into()));
+                payload_events.send(PayloadEvents::BuiltPayload(payload.clone().into())).ok();
 
                 resolved_metrics
                     .set_resolved_revenue(payload.block().number, f64::from(payload.fees()));
@@ -481,7 +481,7 @@ pub enum PayloadServiceCommand<Engine: EngineTypes> {
 }
 
 /// Payload builder events.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum PayloadEvents<Engine: EngineTypes> {
     /// The payload attributes as
     /// they are received from the CL through the engine api.
@@ -496,17 +496,6 @@ pub enum PayloadEvents<Engine: EngineTypes> {
 #[derive(Debug)]
 pub struct PayloadEventReceiver<Engine: EngineTypes> {
     pub receiver: broadcast::Receiver<PayloadEvents<Engine>>,
-}
-
-impl<Engine: EngineTypes> fmt::Debug for PayloadEvents<Engine> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            PayloadEvents::Attributes(attrs) => f.debug_tuple("Attributes").field(attrs).finish(),
-            PayloadEvents::BuiltPayload(payload) => {
-                f.debug_tuple("BuiltPayload").field(payload).finish()
-            }
-        }
-    }
 }
 
 impl<Engine> fmt::Debug for PayloadServiceCommand<Engine>

--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -496,7 +496,7 @@ pub enum PayloadEvents<Engine: EngineTypes> {
 
 /// Represents a receiver for various payload events.
 #[derive(Debug)]
-pub struct PayloadEventReceiver<Engine: EngineTypes> {
+pub struct PayloadEvents<Engine: EngineTypes> {
     pub receiver: broadcast::Receiver<PayloadEvents<Engine>>,
 }
 

--- a/crates/payload/builder/src/test_utils.rs
+++ b/crates/payload/builder/src/test_utils.rs
@@ -25,9 +25,9 @@ pub fn test_payload_service<Engine>() -> (
 )
 where
     Engine: EngineTypes<
-        PayloadBuilderAttributes = EthPayloadBuilderAttributes,
-        BuiltPayload = EthBuiltPayload,
-    >,
+            PayloadBuilderAttributes = EthPayloadBuilderAttributes,
+            BuiltPayload = EthBuiltPayload,
+        > + 'static,
 {
     PayloadBuilderService::new(Default::default(), futures_util::stream::empty())
 }

--- a/crates/payload/builder/src/traits.rs
+++ b/crates/payload/builder/src/traits.rs
@@ -25,7 +25,7 @@ pub trait PayloadJob: Future<Output = Result<(), PayloadBuilderError>> + Send + 
         + Sync
         + 'static;
     /// Represents the built payload type that is returned to the CL.
-    type BuiltPayload: BuiltPayload + std::fmt::Debug;
+    type BuiltPayload: BuiltPayload + Clone + std::fmt::Debug;
 
     /// Returns the best payload that has been built so far.
     ///


### PR DESCRIPTION
Related to: https://github.com/paradigmxyz/reth/issues/6507

Added `PayloadEvents` and sending events on payload attributes and payload resolve.

@mattsse what should be the right way to send the ResolvePayloadFuture from the broadcast::Sender?