### PR TITLE
fix: use real hash for derived from latest

### DIFF
--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -410,9 +410,12 @@ where
         let mut at = block.parent_hash;
         let mut replay_block_txs = true;
 
-        // but if all transactions are to be replayed, we can use the state at the block itself
+        // if a transaction index is provided, we need to replay the transactions until the index
         let num_txs = transaction_index.index().unwrap_or(block.body.len());
-        if num_txs == block.body.len() {
+        // but if all transactions are to be replayed, we can use the state at the block itself
+        // this works with the exception of the PENDING block, because its state might not exist if
+        // built locally
+        if !target_block.is_pending() && num_txs == block.body.len() {
             at = block.hash();
             replay_block_txs = false;
         }

--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -281,10 +281,10 @@ where
             let latest =
                 self.provider().latest_header()?.ok_or_else(|| EthApiError::UnknownBlockNumber)?;
 
-            let (mut latest_header, _block_hash) = latest.split();
+            let (mut latest_header, block_hash) = latest.split();
             // child block
             latest_header.number += 1;
-            // assumed child block is in the next slot
+            // assumed child block is in the next slot: 12s
             latest_header.timestamp += 12;
             // base fee of the child block
             let chain_spec = self.provider().chain_spec();
@@ -292,7 +292,7 @@ where
             latest_header.base_fee_per_gas = latest_header
                 .next_block_base_fee(chain_spec.base_fee_params(latest_header.timestamp));
 
-            let block_hash = latest_header.hash_slow();
+            // we're reusing the same block hash because we need this to lookup the block's state
             let latest = SealedHeader::new(latest_header, block_hash);
 
             PendingBlockEnvOrigin::DerivedFromLatest(latest)


### PR DESCRIPTION
Closes #6553

This fixes two bugs for pending block tracing

when building the pending block locally we need to keep the hash of the latest block if we derive the pending block from it, so we can't rehash it after modifying timestamp and fees

This bug was introduced in #6456


Remove optimization for debug_traceCallmany for pending block if all transactions should be replayed because we might not have the state for the block if it's being built locally or the state is no longer pending at this point.