### PR TITLE
feat: separate BlockExecutor metadata trait methods

### DIFF
--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -39,8 +39,8 @@ use reth_primitives::{
     SealedBlock, SealedBlockWithSenders, Transaction, TransactionSigned, TxEip4844, B256, U256,
 };
 use reth_provider::{
-    providers::BlockchainProvider, BlockHashReader, BlockReader, BlockWriter, ExecutorFactory,
-    ProviderFactory, StageCheckpointReader, StateProviderFactory,
+    providers::BlockchainProvider, BlockExecutor, BlockHashReader, BlockReader, BlockWriter,
+    ExecutorFactory, ProviderFactory, StageCheckpointReader, StateProviderFactory,
 };
 use reth_revm::EvmProcessorFactory;
 #[cfg(feature = "optimism")]

--- a/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
@@ -20,7 +20,7 @@ use reth_network_api::NetworkInfo;
 use reth_node_ethereum::EthEvmConfig;
 use reth_primitives::{fs, stage::StageId, BlockHashOrNumber, ChainSpec};
 use reth_provider::{
-    AccountExtReader, BlockWriter, ExecutorFactory, HashingWriter, HeaderProvider,
+    AccountExtReader, BlockExecutor, BlockWriter, ExecutorFactory, HashingWriter, HeaderProvider,
     LatestStateProviderRef, OriginalValuesKnown, ProviderFactory, StageCheckpointReader,
     StorageReader,
 };

--- a/crates/blockchain-tree/src/chain.rs
+++ b/crates/blockchain-tree/src/chain.rs
@@ -18,8 +18,8 @@ use reth_primitives::{
     BlockHash, BlockNumber, ForkBlock, GotExpected, SealedBlockWithSenders, SealedHeader, U256,
 };
 use reth_provider::{
-    providers::BundleStateProvider, BundleStateDataProvider, BundleStateWithReceipts, Chain,
-    ExecutorFactory, StateRootProvider,
+    providers::BundleStateProvider, BlockExecutor, BundleStateDataProvider,
+    BundleStateWithReceipts, Chain, ExecutorFactory, StateRootProvider,
 };
 use reth_trie::updates::TrieUpdates;
 use std::{

--- a/crates/consensus/auto-seal/src/lib.rs
+++ b/crates/consensus/auto-seal/src/lib.rs
@@ -315,7 +315,7 @@ impl StorageInner {
     pub(crate) fn execute<EvmConfig>(
         &mut self,
         block: &BlockWithSenders,
-        executor: &mut EVMProcessor<'_, EvmConfig>,
+        mut executor: EVMProcessor<'_, EvmConfig>,
     ) -> Result<(BundleStateWithReceipts, u64), BlockExecutionError>
     where
         EvmConfig: ConfigureEvmEnv,
@@ -447,9 +447,9 @@ impl StorageInner {
             .with_database_boxed(Box::new(StateProviderDatabase::new(client.latest().unwrap())))
             .with_bundle_update()
             .build();
-        let mut executor = EVMProcessor::new_with_state(chain_spec.clone(), db, evm_config);
+        let executor = EVMProcessor::new_with_state(chain_spec.clone(), db, evm_config);
 
-        let (bundle_state, gas_used) = self.execute(&block, &mut executor)?;
+        let (bundle_state, gas_used) = self.execute(&block, executor)?;
 
         let Block { header, body, .. } = block.block;
         let body = BlockBody { transactions: body, ommers: vec![], withdrawals: None };

--- a/crates/consensus/beacon/src/engine/test_utils.rs
+++ b/crates/consensus/beacon/src/engine/test_utils.rs
@@ -253,15 +253,12 @@ where
     A: ExecutorFactory,
     B: ExecutorFactory,
 {
-    type Executor<'a> = EitherExecutor<A::Executor<'a>, B::Executor<'a>>;
+    type Executor = EitherExecutor<A::Executor<'static>, B::Executor<'static>>;
 
-    fn with_state<'a, SP: reth_provider::StateProvider + 'a>(
-        &'a self,
-        sp: SP,
-    ) -> Self::Executor<'a> {
+    fn with_state<SP: reth_provider::StateProvider + 'static>(&self, sp: SP) -> Self::Executor {
         match self {
-            EitherExecutorFactory::Left(a) => EitherExecutor::Left(a.with_state::<'a, SP>(sp)),
-            EitherExecutorFactory::Right(b) => EitherExecutor::Right(b.with_state::<'a, SP>(sp)),
+            EitherExecutorFactory::Left(a) => EitherExecutor::Left(a.with_state::<SP>(sp)),
+            EitherExecutorFactory::Right(b) => EitherExecutor::Right(b.with_state::<SP>(sp)),
         }
     }
 }

--- a/crates/revm/src/factory.rs
+++ b/crates/revm/src/factory.rs
@@ -40,9 +40,9 @@ impl<EvmConfig> ExecutorFactory for EvmProcessorFactory<EvmConfig>
 where
     EvmConfig: ConfigureEvmEnv + Send + Sync + Clone + 'static,
 {
-    type Executor = for<'this> EVMProcessor<'this, EvmConfig>;
+    type Executor<'a> = EVMProcessor<'a, EvmConfig>;
 
-    fn with_state<'a, SP: StateProvider + 'a>(&'a self, sp: SP) -> EVMProcessor<'a, EvmConfig> {
+    fn with_state<'a, SP: StateProvider + 'a>(&'a self, sp: SP) -> Self::Executor<'a> {
         let database_state = StateProviderDatabase::new(sp);
         let mut evm = EVMProcessor::new_with_db(
             self.chain_spec.clone(),

--- a/crates/revm/src/factory.rs
+++ b/crates/revm/src/factory.rs
@@ -40,9 +40,9 @@ impl<EvmConfig> ExecutorFactory for EvmProcessorFactory<EvmConfig>
 where
     EvmConfig: ConfigureEvmEnv + Send + Sync + Clone + 'static,
 {
-    type Executor<'a> = EVMProcessor<'a, EvmConfig>;
+    type Executor = EVMProcessor<'static, EvmConfig>;
 
-    fn with_state<'a, SP: StateProvider + 'a>(&'a self, sp: SP) -> Self::Executor<'a> {
+    fn with_state<SP: StateProvider + 'static>(&self, sp: SP) -> Self::Executor {
         let database_state = StateProviderDatabase::new(sp);
         let mut evm = EVMProcessor::new_with_db(
             self.chain_spec.clone(),

--- a/crates/revm/src/optimism/processor.rs
+++ b/crates/revm/src/optimism/processor.rs
@@ -195,12 +195,4 @@ where
             self.first_block.unwrap_or_default(),
         )
     }
-
-    fn stats(&self) -> BlockExecutorStats {
-        self.stats.clone()
-    }
-
-    fn size_hint(&self) -> Option<usize> {
-        Some(self.evm.context.evm.db.bundle_size_hint())
-    }
 }

--- a/crates/revm/src/optimism/processor.rs
+++ b/crates/revm/src/optimism/processor.rs
@@ -7,7 +7,7 @@ use reth_primitives::{
     proofs::calculate_receipt_root_optimism, revm_primitives::ResultAndState, BlockWithSenders,
     Bloom, ChainSpec, Hardfork, Receipt, ReceiptWithBloom, TxType, B256, U256,
 };
-use reth_provider::{BlockExecutor, BlockExecutorStats, BundleStateWithReceipts};
+use reth_provider::{BlockExecutor, BundleStateWithReceipts};
 use revm::DatabaseCommit;
 use std::time::Instant;
 use tracing::{debug, trace};

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -12,8 +12,7 @@ use reth_primitives::{
     TransactionSigned, Withdrawals, B256, MINIMUM_PRUNING_DISTANCE, U256,
 };
 use reth_provider::{
-    BlockExecutor, BlockExecutorMetadata, BlockExecutorStats, ProviderError, PrunableBlockExecutor,
-    StateProvider,
+    BlockExecutor, BlockExecutorStats, ProviderError, PrunableBlockExecutor, StateProvider,
 };
 use revm::{
     db::{states::bundle_state::BundleRetention, EmptyDBTyped, StateDBBox},
@@ -500,22 +499,14 @@ where
         Ok((receipts, cumulative_gas_used))
     }
 
-    fn take_output_state(&mut self) -> BundleStateWithReceipts {
-        let receipts = std::mem::take(&mut self.receipts);
+    fn take_output_state(self) -> BundleStateWithReceipts {
+        // log the stats whenever we take the output state.
+        self.stats.log_info();
         BundleStateWithReceipts::new(
-            self.evm.context.evm.db.take_bundle(),
-            receipts,
+            self.evm.context.evm.db.bundle_state,
+            self.receipts,
             self.first_block.unwrap_or_default(),
         )
-    }
-}
-
-impl<'a, EvmConfig> BlockExecutorMetadata for EVMProcessor<'a, EvmConfig>
-where
-    EvmConfig: ConfigureEvmEnv,
-{
-    fn stats(&self) -> BlockExecutorStats {
-        self.stats.clone()
     }
 
     fn size_hint(&self) -> Option<usize> {

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -12,7 +12,8 @@ use reth_primitives::{
     TransactionSigned, Withdrawals, B256, MINIMUM_PRUNING_DISTANCE, U256,
 };
 use reth_provider::{
-    BlockExecutor, BlockExecutorStats, ProviderError, PrunableBlockExecutor, StateProvider,
+    BlockExecutor, BlockExecutorMetadata, BlockExecutorStats, ProviderError, PrunableBlockExecutor,
+    StateProvider,
 };
 use revm::{
     db::{states::bundle_state::BundleRetention, EmptyDBTyped, StateDBBox},
@@ -507,7 +508,12 @@ where
             self.first_block.unwrap_or_default(),
         )
     }
+}
 
+impl<'a, EvmConfig> BlockExecutorMetadata for EVMProcessor<'a, EvmConfig>
+where
+    EvmConfig: ConfigureEvmEnv,
+{
     fn stats(&self) -> BlockExecutorStats {
         self.stats.clone()
     }

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -18,8 +18,9 @@ use reth_primitives::{
     BlockNumber, Header, PruneModes, U256,
 };
 use reth_provider::{
-    BlockReader, DatabaseProviderRW, ExecutorFactory, HeaderProvider, LatestStateProviderRef,
-    OriginalValuesKnown, ProviderError, TransactionVariant,
+    BlockExecutor, BlockReader, DatabaseProviderRW, ExecutorFactory, HeaderProvider,
+    LatestStateProviderRef, OriginalValuesKnown, ProviderError, PrunableBlockExecutor,
+    TransactionVariant,
 };
 use std::{
     ops::RangeInclusive,
@@ -205,8 +206,6 @@ impl<EF: ExecutorFactory> ExecutionStage<EF> {
             write = ?db_write_duration,
             "Execution time"
         );
-
-        executor.stats().log_info();
 
         let done = stage_progress == max_block;
         Ok(ExecOutput {

--- a/crates/storage/provider/src/test_utils/executor.rs
+++ b/crates/storage/provider/src/test_utils/executor.rs
@@ -1,6 +1,6 @@
 use crate::{
-    bundle_state::BundleStateWithReceipts, BlockExecutor, BlockExecutorMetadata,
-    BlockExecutorStats, ExecutorFactory, PrunableBlockExecutor, StateProvider,
+    bundle_state::BundleStateWithReceipts, BlockExecutor, ExecutorFactory, PrunableBlockExecutor,
+    StateProvider,
 };
 use parking_lot::Mutex;
 use reth_interfaces::executor::BlockExecutionError;
@@ -41,14 +41,8 @@ impl BlockExecutor for TestExecutor {
         Err(BlockExecutionError::UnavailableForTest)
     }
 
-    fn take_output_state(&mut self) -> BundleStateWithReceipts {
-        self.0.clone().unwrap_or_default()
-    }
-}
-
-impl BlockExecutorMetadata for TestExecutor {
-    fn stats(&self) -> BlockExecutorStats {
-        BlockExecutorStats::default()
+    fn take_output_state(self) -> BundleStateWithReceipts {
+        self.0.unwrap_or_default()
     }
 
     fn size_hint(&self) -> Option<usize> {
@@ -76,11 +70,10 @@ impl TestExecutorFactory {
 }
 
 impl ExecutorFactory for TestExecutorFactory {
-    fn with_state<'a, SP: StateProvider + 'a>(
-        &'a self,
-        _sp: SP,
-    ) -> Box<dyn PrunableBlockExecutor + 'a> {
+    type Executor = TestExecutor;
+
+    fn with_state<'a, SP: StateProvider + 'a>(&'a self, _sp: SP) -> Self::Executor {
         let exec_res = self.exec_results.lock().pop();
-        Box::new(TestExecutor(exec_res))
+        TestExecutor(exec_res)
     }
 }

--- a/crates/storage/provider/src/test_utils/executor.rs
+++ b/crates/storage/provider/src/test_utils/executor.rs
@@ -70,9 +70,9 @@ impl TestExecutorFactory {
 }
 
 impl ExecutorFactory for TestExecutorFactory {
-    type Executor = TestExecutor;
+    type Executor<'a> = TestExecutor;
 
-    fn with_state<'a, SP: StateProvider + 'a>(&'a self, _sp: SP) -> Self::Executor {
+    fn with_state<'a, SP: StateProvider + 'a>(&'a self, _sp: SP) -> Self::Executor<'a> {
         let exec_res = self.exec_results.lock().pop();
         TestExecutor(exec_res)
     }

--- a/crates/storage/provider/src/test_utils/executor.rs
+++ b/crates/storage/provider/src/test_utils/executor.rs
@@ -1,6 +1,6 @@
 use crate::{
-    bundle_state::BundleStateWithReceipts, BlockExecutor, BlockExecutorStats, ExecutorFactory,
-    PrunableBlockExecutor, StateProvider,
+    bundle_state::BundleStateWithReceipts, BlockExecutor, BlockExecutorMetadata,
+    BlockExecutorStats, ExecutorFactory, PrunableBlockExecutor, StateProvider,
 };
 use parking_lot::Mutex;
 use reth_interfaces::executor::BlockExecutionError;
@@ -44,7 +44,9 @@ impl BlockExecutor for TestExecutor {
     fn take_output_state(&mut self) -> BundleStateWithReceipts {
         self.0.clone().unwrap_or_default()
     }
+}
 
+impl BlockExecutorMetadata for TestExecutor {
     fn stats(&self) -> BlockExecutorStats {
         BlockExecutorStats::default()
     }

--- a/crates/storage/provider/src/test_utils/executor.rs
+++ b/crates/storage/provider/src/test_utils/executor.rs
@@ -70,9 +70,9 @@ impl TestExecutorFactory {
 }
 
 impl ExecutorFactory for TestExecutorFactory {
-    type Executor<'a> = TestExecutor;
+    type Executor = TestExecutor;
 
-    fn with_state<'a, SP: StateProvider + 'a>(&'a self, _sp: SP) -> Self::Executor<'a> {
+    fn with_state<SP: StateProvider>(&self, _sp: SP) -> Self::Executor {
         let exec_res = self.exec_results.lock().pop();
         TestExecutor(exec_res)
     }

--- a/crates/storage/provider/src/traits/executor.rs
+++ b/crates/storage/provider/src/traits/executor.rs
@@ -55,7 +55,11 @@ pub trait BlockExecutor {
 
     /// Return bundle state. This is output of executed blocks.
     fn take_output_state(&mut self) -> BundleStateWithReceipts;
+}
 
+/// A [BlockExecutor] that can return metadata like current in-memory changes and internal
+/// statistics.
+pub trait BlockExecutorMetadata {
     /// Internal statistics of execution.
     fn stats(&self) -> BlockExecutorStats;
 

--- a/crates/storage/provider/src/traits/executor.rs
+++ b/crates/storage/provider/src/traits/executor.rs
@@ -68,7 +68,7 @@ pub trait BlockExecutorMetadata {
 }
 
 /// A [BlockExecutor] capable of in-memory pruning of the data that will be written to the database.
-pub trait PrunableBlockExecutor: BlockExecutor {
+pub trait PrunableBlockExecutor: BlockExecutor + BlockExecutorMetadata {
     /// Set tip - highest known block number.
     fn set_tip(&mut self, tip: BlockNumber);
 

--- a/crates/storage/provider/src/traits/executor.rs
+++ b/crates/storage/provider/src/traits/executor.rs
@@ -12,10 +12,10 @@ use tracing::debug;
 pub trait ExecutorFactory: Send + Sync + 'static {
     /// Type of block executor to return, this must be an associated type so the executor can be
     /// consumed when it's done executing.
-    type Executor<'a>: PrunableBlockExecutor;
+    type Executor: PrunableBlockExecutor;
 
     /// Executor with [`StateProvider`]
-    fn with_state<'a, SP: StateProvider + 'a>(&'a self, _sp: SP) -> Self::Executor<'a>;
+    fn with_state<SP: StateProvider + 'static>(&self, _sp: SP) -> Self::Executor;
 }
 
 /// An executor capable of executing a block.

--- a/crates/storage/provider/src/traits/executor.rs
+++ b/crates/storage/provider/src/traits/executor.rs
@@ -12,10 +12,10 @@ use tracing::debug;
 pub trait ExecutorFactory: Send + Sync + 'static {
     /// Type of block executor to return, this must be an associated type so the executor can be
     /// consumed when it's done executing.
-    type Executor: PrunableBlockExecutor;
+    type Executor<'a>: PrunableBlockExecutor;
 
     /// Executor with [`StateProvider`]
-    fn with_state<'a, SP: StateProvider + 'a>(&'a self, _sp: SP) -> Self::Executor;
+    fn with_state<'a, SP: StateProvider + 'a>(&'a self, _sp: SP) -> Self::Executor<'a>;
 }
 
 /// An executor capable of executing a block.

--- a/crates/storage/provider/src/traits/mod.rs
+++ b/crates/storage/provider/src/traits/mod.rs
@@ -46,10 +46,7 @@ mod withdrawals;
 pub use withdrawals::WithdrawalsProvider;
 
 mod executor;
-pub use executor::{
-    BlockExecutor, BlockExecutorMetadata, BlockExecutorStats, ExecutorFactory,
-    PrunableBlockExecutor,
-};
+pub use executor::{BlockExecutor, BlockExecutorStats, ExecutorFactory, PrunableBlockExecutor};
 
 mod chain;
 pub use chain::{

--- a/crates/storage/provider/src/traits/mod.rs
+++ b/crates/storage/provider/src/traits/mod.rs
@@ -46,7 +46,10 @@ mod withdrawals;
 pub use withdrawals::WithdrawalsProvider;
 
 mod executor;
-pub use executor::{BlockExecutor, BlockExecutorStats, ExecutorFactory, PrunableBlockExecutor};
+pub use executor::{
+    BlockExecutor, BlockExecutorMetadata, BlockExecutorStats, ExecutorFactory,
+    PrunableBlockExecutor,
+};
 
 mod chain;
 pub use chain::{


### PR DESCRIPTION
This adds a trait called `BlockExecutorMetadata`, which separates the metadata methods from the `BlockExecutor` trait, so the executor trait is _only_ responsible for execution specific methods.