### PR TITLE
chore: improve BundleStateWithReceipts docs

### DIFF
--- a/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
+++ b/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
@@ -285,10 +285,10 @@ impl BundleStateWithReceipts {
         std::mem::swap(&mut self.bundle, &mut other)
     }
 
-    /// Write bundle state to database.
+    /// Write the [BundleStateWithReceipts] to the database.
     ///
-    /// `omit_changed_check` should be set to true of bundle has some of it data
-    /// detached, This would make some original values not known.
+    /// `is_value_known` should be set to `Not` if the [BundleStateWithReceipts] has some of its
+    /// state detached, This would make some original values not known.
     pub fn write_to_db<TX: DbTxMut + DbTx>(
         self,
         tx: &TX,


### PR DESCRIPTION
Updates the docs for `BundleStateWithReceipts::write_to_db`, since it mentions a flag `omit_changed_check` which is not present in the codebase any more.