### PR TITLE
enhance tx gossip test coverage

### DIFF
--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -916,6 +916,11 @@ impl Peer {
         Self { kind: PeerKind::Trusted, ..Self::new(addr) }
     }
 
+    /// Returns the reputation of the peer
+    pub fn reputation(&self) -> i32 {
+        self.reputation
+    }
+
     fn with_state(addr: SocketAddr, state: PeerConnectionState) -> Self {
         Self {
             addr,

--- a/crates/net/network/src/test_utils/testnet.rs
+++ b/crates/net/network/src/test_utils/testnet.rs
@@ -4,6 +4,7 @@ use crate::{
     builder::ETH_REQUEST_CHANNEL_CAPACITY,
     error::NetworkError,
     eth_requests::EthRequestHandler,
+    peers::PeersHandle,
     protocol::IntoRlpxSubProtocol,
     transactions::{TransactionsHandle, TransactionsManager},
     NetworkConfig, NetworkConfigBuilder, NetworkEvent, NetworkEvents, NetworkHandle,
@@ -473,6 +474,10 @@ impl<Pool> PeerHandle<Pool> {
     /// Returns the [`PeerId`] used in the network.
     pub fn peer_id(&self) -> &PeerId {
         self.network.peer_id()
+    }
+
+    pub fn peer_handle(&self) -> &PeersHandle {
+        self.network.peers_handle()
     }
 
     pub fn local_addr(&self) -> SocketAddr {

--- a/crates/net/network/tests/it/txgossip.rs
+++ b/crates/net/network/tests/it/txgossip.rs
@@ -2,9 +2,10 @@
 
 use rand::thread_rng;
 use reth_network::test_utils::Testnet;
-use reth_primitives::U256;
+use reth_primitives::{TransactionSigned, U256};
 use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
 use reth_transaction_pool::{test_utils::TransactionGenerator, PoolTransaction, TransactionPool};
+use std::{sync::Arc, time::Duration};
 #[tokio::test(flavor = "multi_thread")]
 async fn test_tx_gossip() {
     reth_tracing::init_test_tracing();
@@ -41,4 +42,92 @@ async fn test_tx_gossip() {
     // ensure tx is gossiped to peer1
     let received = peer1_tx_listener.recv().await.unwrap();
     assert_eq!(received, hash);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_4844_tx_gossip_penalization() {
+    reth_tracing::init_test_tracing();
+    let provider = MockEthProvider::default();
+    let net = Testnet::create_with(2, provider.clone()).await;
+
+    // install request handlers
+    let net = net.with_eth_pool();
+
+    let handle = net.spawn();
+
+    let peer0 = &handle.peers()[0];
+    let peer1 = &handle.peers()[1];
+
+    // connect all the peers
+    handle.connect_peers().await;
+
+    // let mut peer0_tx_listener = peer0.pool().unwrap().pending_transactions_listener();
+    let mut peer1_tx_listener = peer1.pool().unwrap().pending_transactions_listener();
+
+    let mut gen = TransactionGenerator::new(thread_rng());
+    let txs = vec![gen.gen_eip4844_pooled(), gen.gen_eip1559_pooled()];
+
+    txs.iter().for_each(|tx| {
+        let sender = tx.sender();
+        provider.add_account(sender, ExtendedAccount::new(0, U256::from(100_000_000)));
+    });
+
+    let signed_txs: Vec<Arc<TransactionSigned>> =
+        txs.iter().map(|tx| Arc::new(tx.transaction().clone().into_signed())).collect();
+
+    let network_handle = peer0.network();
+
+    let peer0_reputation_before =
+        peer1.peer_handle().peer_by_id(peer0.peer_id().clone()).await.unwrap().reputation();
+
+    network_handle.send_transactions(peer1.peer_id().clone(), signed_txs);
+
+    let received = peer1_tx_listener.recv().await.unwrap();
+
+    let peer0_reputation_after =
+        peer1.peer_handle().peer_by_id(peer0.peer_id().clone()).await.unwrap().reputation();
+    assert_ne!(peer0_reputation_before, peer0_reputation_after);
+    assert_eq!(received, txs[1].transaction().hash);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sending_invalid_transactions() {
+    reth_tracing::init_test_tracing();
+    let provider = MockEthProvider::default();
+    let net = Testnet::create_with(2, provider.clone()).await;
+    // install request handlers
+    let net = net.with_eth_pool();
+
+    let handle = net.spawn();
+
+    let peer0 = &handle.peers()[0];
+    let peer1 = &handle.peers()[1];
+
+    // connect all the peers
+    handle.connect_peers().await;
+
+    // let mut peer0_tx_listener = peer0.pool().unwrap().pending_transactions_listener();
+    let mut peer1_tx_listener = peer1.pool().unwrap().pending_transactions_listener();
+
+    let invalid_txs: Vec<Arc<TransactionSigned>> = vec![Arc::new(TransactionSigned::default())];
+
+    let network_handle = peer0.network();
+
+    network_handle.send_transactions(peer1.peer_id().clone(), invalid_txs);
+
+    let received = peer1_tx_listener.recv();
+
+    let timeout_duration = Duration::from_secs(15);
+    let timeout_received_future = tokio::time::timeout(timeout_duration, received);
+
+    match timeout_received_future.await {
+        Ok(received) => {
+            let received = received.unwrap();
+            // fail the test
+            assert!(false, "peer1 received invalid transaction: {:?}", received);
+        }
+        Err(_) => {
+            assert!(true, "peer1 did not receive invalid transaction");
+        }
+    }
 }

--- a/crates/net/network/tests/it/txgossip.rs
+++ b/crates/net/network/tests/it/txgossip.rs
@@ -81,8 +81,8 @@ async fn test_4844_tx_gossip_penalization() {
     let peer0_reputation_before =
         peer1.peer_handle().peer_by_id(peer0.peer_id().clone()).await.unwrap().reputation();
 
+    // sends txs directly to peer1
     network_handle.send_transactions(peer1.peer_id().clone(), signed_txs);
-
 
     let received = peer1_tx_listener.recv().await.unwrap();
 
@@ -117,6 +117,7 @@ async fn test_sending_invalid_transactions() {
 
     let network_handle = peer0.network();
 
+    // sends txs directly to peer1
     network_handle.send_transactions(peer1.peer_id().clone(), invalid_txs);
 
     tokio::time::sleep(Duration::from_secs(1)).await;

--- a/crates/net/network/tests/it/txgossip.rs
+++ b/crates/net/network/tests/it/txgossip.rs
@@ -83,7 +83,6 @@ async fn test_4844_tx_gossip_penalization() {
 
     network_handle.send_transactions(peer1.peer_id().clone(), signed_txs);
 
-    tokio::time::sleep(Duration::from_secs(1)).await;
 
     let received = peer1_tx_listener.recv().await.unwrap();
 

--- a/crates/net/network/tests/it/txgossip.rs
+++ b/crates/net/network/tests/it/txgossip.rs
@@ -5,7 +5,7 @@ use reth_network::test_utils::Testnet;
 use reth_primitives::{TransactionSigned, U256};
 use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
 use reth_transaction_pool::{test_utils::TransactionGenerator, PoolTransaction, TransactionPool};
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 #[tokio::test(flavor = "multi_thread")]
 async fn test_tx_gossip() {
     reth_tracing::init_test_tracing();
@@ -83,6 +83,8 @@ async fn test_4844_tx_gossip_penalization() {
 
     network_handle.send_transactions(peer1.peer_id().clone(), signed_txs);
 
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
     let received = peer1_tx_listener.recv().await.unwrap();
 
     let peer0_reputation_after =
@@ -117,6 +119,8 @@ async fn test_sending_invalid_transactions() {
     let network_handle = peer0.network();
 
     network_handle.send_transactions(peer1.peer_id().clone(), invalid_txs);
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
 
     // this will return an [`Empty`] error because bad txs are disallowed to be broadcasted
     assert!(peer1_tx_listener.try_recv().is_err());

--- a/crates/transaction-pool/src/test_utils/gen.rs
+++ b/crates/transaction-pool/src/test_utils/gen.rs
@@ -173,7 +173,7 @@ impl TransactionBuilder {
             self.signer,
         )
     }
-    /// Converts the transaction builder into a transaction format using EIP-1559.
+    /// Converts the transaction builder into a transaction format using EIP-4844.
     pub fn into_eip4844(self) -> TransactionSigned {
         TransactionBuilder::signed(
             TxEip4844 {

--- a/crates/transaction-pool/src/test_utils/gen.rs
+++ b/crates/transaction-pool/src/test_utils/gen.rs
@@ -2,8 +2,8 @@ use crate::EthPooledTransaction;
 use rand::Rng;
 use reth_primitives::{
     constants::MIN_PROTOCOL_BASE_FEE, sign_message, AccessList, Address, Bytes,
-    FromRecoveredTransaction, Transaction, TransactionKind, TransactionSigned, TxEip1559, TxLegacy,
-    TxValue, B256, MAINNET,
+    FromRecoveredTransaction, Transaction, TransactionKind, TransactionSigned, TxEip1559,
+    TxEip4844, TxLegacy, TxValue, B256, MAINNET,
 };
 
 /// A generator for transactions for testing purposes.
@@ -91,10 +91,21 @@ impl<R: Rng> TransactionGenerator<R> {
         self.transaction().into_eip1559()
     }
 
+    /// Creates a new transaction with a random signer
+    pub fn gen_eip4844(&mut self) -> TransactionSigned {
+        self.transaction().into_eip4844()
+    }
+
     /// Generates and returns a pooled EIP-1559 transaction with a random signer.
     pub fn gen_eip1559_pooled(&mut self) -> EthPooledTransaction {
         EthPooledTransaction::from_recovered_transaction(
             self.gen_eip1559().into_ecrecovered().unwrap(),
+        )
+    }
+    /// Generates and returns a pooled EIP-4844 transaction with a random signer.
+    pub fn gen_eip4844_pooled(&mut self) -> EthPooledTransaction {
+        EthPooledTransaction::from_recovered_transaction(
+            self.gen_eip4844().into_ecrecovered().unwrap(),
         )
     }
 }
@@ -157,6 +168,26 @@ impl TransactionBuilder {
                 value: self.value,
                 access_list: self.access_list,
                 input: self.input,
+            }
+            .into(),
+            self.signer,
+        )
+    }
+    /// Converts the transaction builder into a transaction format using EIP-1559.
+    pub fn into_eip4844(self) -> TransactionSigned {
+        TransactionBuilder::signed(
+            TxEip4844 {
+                chain_id: self.chain_id,
+                nonce: self.nonce,
+                gas_limit: self.gas_limit,
+                max_fee_per_gas: self.max_fee_per_gas,
+                max_priority_fee_per_gas: self.max_priority_fee_per_gas,
+                to: self.to,
+                value: self.value,
+                access_list: self.access_list,
+                input: self.input,
+                blob_versioned_hashes: Default::default(),
+                max_fee_per_blob_gas: Default::default(),
             }
             .into(),
             self.signer,


### PR DESCRIPTION
Fixes #6501
- [x] Check that bad transactions are rejected
- [x] Test peer penalization when blob txs(EIP-4844 Blob tx) are gossiped
- [x] Add helper functions for TransactionGenerator.