### PR TITLE
feat(bin): support headers in `stage drop`

### DIFF
--- a/bin/reth/src/commands/stage/drop.rs
+++ b/bin/reth/src/commands/stage/drop.rs
@@ -17,7 +17,6 @@ use reth_db::{
 use reth_primitives::{fs, snapshot::find_fixed_range, stage::StageId, ChainSpec, SnapshotSegment};
 use reth_provider::ProviderFactory;
 use std::sync::Arc;
-use tracing::info;
 
 /// `reth drop-stage` command
 #[derive(Debug, Parser)]

--- a/crates/storage/provider/src/providers/snapshot/manager.rs
+++ b/crates/storage/provider/src/providers/snapshot/manager.rs
@@ -175,6 +175,7 @@ impl SnapshotProvider {
         };
 
         jar.delete()?;
+        self.update_index(segment, None)?;
 
         Ok(())
     }


### PR DESCRIPTION
Same as for other stages, we delete the associated tables and snapshots for `Headers` stage, and reset the checkpoint.