### PR TITLE
ci: auto-update homebrew formula

### DIFF
--- a/.github/workflows/release-dist.yml
+++ b/.github/workflows/release-dist.yml
@@ -1,0 +1,20 @@
+# This workflow auto-publishes Reth to external package managers such as
+# Homebrew when a release is published.
+
+name: release externally
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release-homebrew:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Homebrew formula
+        uses: dawidd6/action-homebrew-bump-formula@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          no_fork: true
+          tap: paradigmxyz/brew
+          formula: reth


### PR DESCRIPTION
Uses https://github.com/dawidd6/action-homebrew-bump-formula/ (looks up to date, skimmed `main.rb`) to automatically open a brew bump PR when a release is **published** (i.e. out of draft state).

I added a secondary workflow for this because I thought we might want to add more channels in the future (apt etc)