### PR TITLE
fix(op): set optimism flag correctly

### DIFF
--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -311,7 +311,7 @@ impl TransactionFetcher {
                     );
 
                     max_retried_and_evicted_hashes.push(hash);
-                    continue;
+                    continue
                 }
                 *retries += 1;
             }
@@ -655,7 +655,7 @@ impl TransactionFetcher {
         for hash in self.hashes_pending_fetch.iter() {
             // 1. Check if a hash pending fetch is seen by peer.
             if !seen_hashes.contains(hash) {
-                continue;
+                continue
             };
 
             // 2. Optimistically include the hash in the request.

--- a/crates/node-api/src/engine/traits.rs
+++ b/crates/node-api/src/engine/traits.rs
@@ -88,7 +88,6 @@ pub trait PayloadBuilderAttributes: Send + Sync + std::fmt::Debug {
         chain_spec: &ChainSpec,
         parent: &Header,
     ) -> (CfgEnvWithHandlerCfg, BlockEnv) {
-        // TODO: should be different once revm has configurable CfgEnvWithHandlerCfg
         // configure evm env based on parent block
         let mut cfg = CfgEnv::default();
         cfg.chain_id = chain_spec.chain().id();
@@ -130,7 +129,18 @@ pub trait PayloadBuilderAttributes: Send + Sync + std::fmt::Debug {
             blob_excess_gas_and_price,
         };
 
-        (CfgEnvWithHandlerCfg::new(cfg, spec_id), block_env)
+        #[cfg(feature = "optimism")]
+        {
+            let cfg_with_handler_cfg = CfgEnvWithHandlerCfg {
+                cfg_env: cfg,
+                handler_cfg: HandlerCfg { spec_id, is_optimism: chain_spec.is_optimism() },
+            };
+        }
+
+        #[cfg(not(feature = "optimism"))]
+        let cfg_with_handler_cfg = CfgEnvWithHandlerCfg::new(cfg, spec_id);
+
+        (cfg_with_handler_cfg, block_env)
     }
 }
 

--- a/crates/node-core/src/events/node.rs
+++ b/crates/node-core/src/events/node.rs
@@ -454,9 +454,7 @@ struct Eta {
 impl Eta {
     /// Update the ETA given the checkpoint, if possible.
     fn update(&mut self, checkpoint: StageCheckpoint) {
-        let Some(current) = checkpoint.entities() else {
-            return
-        };
+        let Some(current) = checkpoint.entities() else { return };
 
         if let Some(last_checkpoint_time) = &self.last_checkpoint_time {
             let processed_since_last = current.processed - self.last_checkpoint.processed;

--- a/crates/node-core/src/events/node.rs
+++ b/crates/node-core/src/events/node.rs
@@ -455,7 +455,7 @@ impl Eta {
     /// Update the ETA given the checkpoint, if possible.
     fn update(&mut self, checkpoint: StageCheckpoint) {
         let Some(current) = checkpoint.entities() else {
-            return;
+            return
         };
 
         if let Some(last_checkpoint_time) = &self.last_checkpoint_time {

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -753,7 +753,7 @@ impl SealedHeader {
                 return Err(HeaderValidationError::GasLimitInvalidIncrease {
                     parent_gas_limit,
                     child_gas_limit: self.gas_limit,
-                });
+                })
             }
         }
         // Check for a decrease in gas limit beyond the allowed threshold.
@@ -761,13 +761,13 @@ impl SealedHeader {
             return Err(HeaderValidationError::GasLimitInvalidDecrease {
                 parent_gas_limit,
                 child_gas_limit: self.gas_limit,
-            });
+            })
         }
         // Check if the self gas limit is below the minimum required limit.
         else if self.gas_limit < MINIMUM_GAS_LIMIT {
             return Err(HeaderValidationError::GasLimitInvalidMinimum {
                 child_gas_limit: self.gas_limit,
-            });
+            })
         }
 
         Ok(())

--- a/crates/primitives/src/proofs.rs
+++ b/crates/primitives/src/proofs.rs
@@ -99,7 +99,7 @@ pub fn calculate_receipt_root_optimism(
 
         return ordered_trie_root_with_encoder(receipts.as_slice(), |r, buf| {
             r.encode_inner(buf, false)
-        });
+        })
     }
 
     ordered_trie_root_with_encoder(receipts, |r, buf| r.encode_inner(buf, false))
@@ -142,7 +142,7 @@ pub fn calculate_receipt_root_ref_optimism(
 
         return ordered_trie_root_with_encoder(&receipts, |r, buf| {
             ReceiptWithBloomRef::from(r).encode_inner(buf, false)
-        });
+        })
     }
 
     ordered_trie_root_with_encoder(receipts, |r, buf| {
@@ -154,7 +154,7 @@ pub fn calculate_receipt_root_ref_optimism(
 pub fn calculate_ommers_root(ommers: &[Header]) -> B256 {
     // Check if `ommers` list is empty
     if ommers.is_empty() {
-        return EMPTY_OMMER_ROOT_HASH;
+        return EMPTY_OMMER_ROOT_HASH
     }
     // RLP Encode
     let mut ommers_rlp = Vec::new();

--- a/crates/primitives/src/transaction/sidecar.rs
+++ b/crates/primitives/src/transaction/sidecar.rs
@@ -561,7 +561,7 @@ mod tests {
 
             // Ensure the entry is a file and not a directory
             if !file_path.is_file() || file_path.extension().unwrap_or_default() != "json" {
-                continue;
+                continue
             }
 
             // Read the contents of the JSON file into a string.

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -286,7 +286,7 @@ where
                                 Ok(inspector)
                             })
                             .await?;
-                        return Ok(FourByteFrame::from(inspector).into());
+                        return Ok(FourByteFrame::from(inspector).into())
                     }
                     GethDebugBuiltInTracerType::CallTracer => {
                         let call_config = tracer_config
@@ -309,7 +309,7 @@ where
                                 Ok(frame.into())
                             })
                             .await?;
-                        return Ok(frame);
+                        return Ok(frame)
                     }
                     GethDebugBuiltInTracerType::PreStateTracer => {
                         let prestate_config = tracer_config
@@ -334,7 +334,7 @@ where
                                     Ok(frame)
                                 })
                                 .await?;
-                        return Ok(frame.into());
+                        return Ok(frame.into())
                     }
                     GethDebugBuiltInTracerType::NoopTracer => Ok(NoopFrame::default().into()),
                 },
@@ -356,7 +356,7 @@ where
 
                     Ok(GethTrace::JS(res))
                 }
-            };
+            }
         }
 
         // default structlog tracer
@@ -388,7 +388,7 @@ where
         opts: Option<GethDebugTracingCallOptions>,
     ) -> EthResult<Vec<Vec<GethTrace>>> {
         if bundles.is_empty() {
-            return Err(EthApiError::InvalidParams(String::from("bundles are empty.")));
+            return Err(EthApiError::InvalidParams(String::from("bundles are empty.")))
         }
 
         let StateContext { transaction_index, block_number } = state_context.unwrap_or_default();
@@ -508,7 +508,7 @@ where
                     GethDebugBuiltInTracerType::FourByteTracer => {
                         let mut inspector = FourByteInspector::default();
                         let (res, _) = inspect(db, env, &mut inspector)?;
-                        return Ok((FourByteFrame::from(inspector).into(), res.state));
+                        return Ok((FourByteFrame::from(inspector).into(), res.state))
                     }
                     GethDebugBuiltInTracerType::CallTracer => {
                         let call_config = tracer_config
@@ -526,7 +526,7 @@ where
                             .into_geth_builder()
                             .geth_call_traces(call_config, res.result.gas_used());
 
-                        return Ok((frame.into(), res.state));
+                        return Ok((frame.into(), res.state))
                     }
                     GethDebugBuiltInTracerType::PreStateTracer => {
                         let prestate_config = tracer_config
@@ -547,7 +547,7 @@ where
                             &*db,
                         )?;
 
-                        return Ok((frame.into(), res.state));
+                        return Ok((frame.into(), res.state))
                     }
                     GethDebugBuiltInTracerType::NoopTracer => {
                         Ok((NoopFrame::default().into(), Default::default()))
@@ -566,7 +566,7 @@ where
                     let result = inspector.json_result(res, &env, db)?;
                     Ok((GethTrace::JS(result), state))
                 }
-            };
+            }
         }
 
         // default structlog tracer

--- a/crates/rpc/rpc/src/eth/api/call.rs
+++ b/crates/rpc/rpc/src/eth/api/call.rs
@@ -89,7 +89,7 @@ where
     ) -> EthResult<Vec<EthCallResponse>> {
         let Bundle { transactions, block_override } = bundle;
         if transactions.is_empty() {
-            return Err(EthApiError::InvalidParams(String::from("transactions are empty.")));
+            return Err(EthApiError::InvalidParams(String::from("transactions are empty.")))
         }
 
         let StateContext { transaction_index, block_number } = state_context.unwrap_or_default();
@@ -224,9 +224,9 @@ where
                         if env.tx.value > available_funds {
                             return Err(
                                 RpcInvalidTransactionError::InsufficientFundsForTransfer.into()
-                            );
+                            )
                         }
-                        return Ok(U256::from(MIN_TRANSACTION_GAS));
+                        return Ok(U256::from(MIN_TRANSACTION_GAS))
                     }
                 }
             }
@@ -258,7 +258,7 @@ where
             // if price or limit was included in the request then we can execute the request
             // again with the block's gas limit to check if revert is gas related or not
             if request_gas.is_some() || request_gas_price.is_some() {
-                return Err(map_out_of_gas_err(env_gas_limit, env, &mut db));
+                return Err(map_out_of_gas_err(env_gas_limit, env, &mut db))
             }
         }
 
@@ -270,7 +270,7 @@ where
             ExecutionResult::Halt { reason, gas_used } => {
                 // here we don't check for invalid opcode because already executed with highest gas
                 // limit
-                return Err(RpcInvalidTransactionError::halt(reason, gas_used).into());
+                return Err(RpcInvalidTransactionError::halt(reason, gas_used).into())
             }
             ExecutionResult::Revert { output, .. } => {
                 // if price or limit was included in the request then we can execute the request
@@ -280,7 +280,7 @@ where
                 } else {
                     // the transaction did revert
                     Err(RpcInvalidTransactionError::Revert(RevertError::new(output)).into())
-                };
+                }
             }
         }
 
@@ -317,7 +317,7 @@ where
 
                 // new midpoint
                 mid_gas_limit = ((highest_gas_limit as u128 + lowest_gas_limit as u128) / 2) as u64;
-                continue;
+                continue
             }
 
             let (res, _) = ethres?;
@@ -343,7 +343,7 @@ where
                         err => {
                             // these should be unreachable because we know the transaction succeeds,
                             // but we consider these cases an error
-                            return Err(RpcInvalidTransactionError::EvmHalt(err).into());
+                            return Err(RpcInvalidTransactionError::EvmHalt(err).into())
                         }
                     }
                 }
@@ -422,7 +422,9 @@ where
 
         let access_list = inspector.into_access_list();
 
-        let cfg_with_spec_id = CfgEnvWithHandlerCfg::new(env.cfg.clone(), env.handler_cfg.spec_id);
+        let cfg_with_spec_id =
+            CfgEnvWithHandlerCfg { cfg_env: env.cfg.clone(), handler_cfg: env.handler_cfg.clone() };
+
         // calculate the gas used using the access list
         request.access_list = Some(access_list.clone());
         let gas_used = self.estimate_gas_with(

--- a/crates/rpc/rpc/src/eth/api/call.rs
+++ b/crates/rpc/rpc/src/eth/api/call.rs
@@ -423,7 +423,7 @@ where
         let access_list = inspector.into_access_list();
 
         let cfg_with_spec_id =
-            CfgEnvWithHandlerCfg { cfg_env: env.cfg.clone(), handler_cfg: env.handler_cfg.clone() };
+            CfgEnvWithHandlerCfg { cfg_env: env.cfg.clone(), handler_cfg: env.handler_cfg };
 
         // calculate the gas used using the access list
         request.access_list = Some(access_list.clone());

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -283,19 +283,19 @@ where
     /// Handler for: `eth_gasPrice`
     async fn gas_price(&self) -> Result<U256> {
         trace!(target: "rpc::eth", "Serving eth_gasPrice");
-        return Ok(EthApi::gas_price(self).await?);
+        return Ok(EthApi::gas_price(self).await?)
     }
 
     /// Handler for: `eth_blobGasPrice`
     async fn blob_gas_price(&self) -> Result<U256> {
         trace!(target: "rpc::eth", "Serving eth_blobGasPrice");
-        return Ok(EthApi::blob_gas_price(self).await?);
+        return Ok(EthApi::blob_gas_price(self).await?)
     }
 
     /// Handler for: `eth_maxPriorityFeePerGas`
     async fn max_priority_fee_per_gas(&self) -> Result<U256> {
         trace!(target: "rpc::eth", "Serving eth_maxPriorityFeePerGas");
-        return Ok(EthApi::suggested_priority_fee(self).await?);
+        return Ok(EthApi::suggested_priority_fee(self).await?)
     }
 
     // FeeHistory is calculated based on lazy evaluation of fees for historical blocks, and further
@@ -316,7 +316,7 @@ where
         trace!(target: "rpc::eth", ?block_count, ?newest_block, ?reward_percentiles, "Serving eth_feeHistory");
         return Ok(
             EthApi::fee_history(self, block_count.to(), newest_block, reward_percentiles).await?
-        );
+        )
     }
 
     /// Handler for: `eth_mining`

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -1185,7 +1185,7 @@ where
                 return match signer.sign_transaction(request, from) {
                     Ok(tx) => Ok(tx),
                     Err(e) => Err(e.into()),
-                };
+                }
             }
         }
         Err(EthApiError::InvalidTransactionSignature)
@@ -1210,7 +1210,7 @@ where
                     block_number,
                     base_fee_per_gas,
                     index.into(),
-                )));
+                )))
             }
         }
 

--- a/crates/rpc/rpc/src/eth/revm_utils.rs
+++ b/crates/rpc/rpc/src/eth/revm_utils.rs
@@ -214,7 +214,7 @@ where
     for tx in transactions.into_iter() {
         if tx.hash() == target_tx_hash {
             // reached the target transaction
-            break;
+            break
         }
 
         tx.try_fill_tx_env(evm.tx_mut())?;
@@ -319,7 +319,7 @@ pub(crate) fn create_txn_env(
 ) -> EthResult<TxEnv> {
     // Ensure that if versioned hashes are set, they're not empty
     if request.has_empty_blob_hashes() {
-        return Err(RpcInvalidTransactionError::BlobTransactionMissingBlobHashes.into());
+        return Err(RpcInvalidTransactionError::BlobTransactionMissingBlobHashes.into())
     }
 
     let TransactionRequest {
@@ -467,7 +467,7 @@ impl CallFees {
                     return Err(
                         // `max_priority_fee_per_gas` is greater than the `max_fee_per_gas`
                         RpcInvalidTransactionError::TipAboveFeeCap.into(),
-                    );
+                    )
                 }
             }
             Ok(())
@@ -504,7 +504,7 @@ impl CallFees {
                 // Ensure blob_hashes are present
                 if !has_blob_hashes {
                     // Blob transaction but no blob hashes
-                    return Err(RpcInvalidTransactionError::BlobTransactionMissingBlobHashes.into());
+                    return Err(RpcInvalidTransactionError::BlobTransactionMissingBlobHashes.into())
                 }
 
                 Ok(CallFees {

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -211,7 +211,7 @@ where
     ) -> EthResult<Option<LocalizedTransactionTrace>> {
         if indices.len() != 1 {
             // The OG impl failed if it gets more than a single index
-            return Ok(None);
+            return Ok(None)
         }
         self.trace_get_index(hash, indices[0]).await
     }
@@ -249,7 +249,7 @@ where
         if distance > 100 {
             return Err(EthApiError::InvalidParams(
                 "Block range too large; currently limited to 100 blocks".to_string(),
-            ));
+            ))
         }
 
         // fetch all blocks in that range
@@ -285,7 +285,7 @@ where
                     if let Some(idx) = tx_info.index {
                         if !indices.contains(&idx) {
                             // only record traces for relevant transactions
-                            return Ok(None);
+                            return Ok(None)
                         }
                     }
                     let traces = inspector


### PR DESCRIPTION
In two places we didn't set optimism flag

In the Node builder trait in `crates/node-api/src/engine/traits.rs`. @mattsse check if this is a bug or not, maybe it is overwritten.

And in `crates/rpc/rpc/src/eth/api/call.rs` flag would be lost.

Will add proper constructors to revm but to fix it asap this should be fine

should close https://github.com/paradigmxyz/reth/pull/6593