### PR TITLE
fix(op): add reth-node-api optimism feature + unscope cfg_with_handler_cfg

### DIFF
--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -14,8 +14,8 @@ workspace = true
 
 [package.metadata.cargo-udeps.ignore]
 normal = [
-    # Used for diagrams in docs
-    "aquamarine",
+  # Used for diagrams in docs
+  "aquamarine",
 ]
 
 [dependencies]
@@ -56,7 +56,7 @@ reth-nippy-jar.workspace = true
 reth-node-api.workspace = true
 reth-node-ethereum.workspace = true
 reth-node-optimism = { workspace = true, optional = true, features = [
-    "optimism",
+  "optimism",
 ] }
 reth-node-core.workspace = true
 
@@ -64,9 +64,9 @@ reth-node-core.workspace = true
 alloy-rlp.workspace = true
 alloy-chains.workspace = true
 secp256k1 = { workspace = true, features = [
-    "global-context",
-    "rand-std",
-    "recovery",
+  "global-context",
+  "rand-std",
+  "recovery",
 ] }
 revm-inspectors.workspace = true
 
@@ -100,10 +100,10 @@ human_bytes = "0.4.1"
 
 # async
 tokio = { workspace = true, features = [
-    "sync",
-    "macros",
-    "time",
-    "rt-multi-thread",
+  "sync",
+  "macros",
+  "time",
+  "rt-multi-thread",
 ] }
 futures.workspace = true
 pin-project.workspace = true
@@ -146,24 +146,25 @@ min-debug-logs = ["tracing/release_max_level_debug"]
 min-trace-logs = ["tracing/release_max_level_trace"]
 
 optimism = [
-    "reth-primitives/optimism",
-    "reth-revm/optimism",
-    "reth-interfaces/optimism",
-    "reth-rpc/optimism",
-    "reth-rpc-engine-api/optimism",
-    "reth-transaction-pool/optimism",
-    "reth-provider/optimism",
-    "reth-beacon-consensus/optimism",
-    "reth-auto-seal-consensus/optimism",
-    "reth-network/optimism",
-    "reth-network-api/optimism",
-    "reth-blockchain-tree/optimism",
-    "reth-payload-builder/optimism",
-    "reth-optimism-payload-builder/optimism",
-    "reth-ethereum-payload-builder/optimism",
-    "reth-node-ethereum/optimism",
-    "dep:reth-node-optimism",
-    "reth-node-core/optimism",
+  "reth-primitives/optimism",
+  "reth-revm/optimism",
+  "reth-interfaces/optimism",
+  "reth-rpc/optimism",
+  "reth-rpc-engine-api/optimism",
+  "reth-transaction-pool/optimism",
+  "reth-provider/optimism",
+  "reth-beacon-consensus/optimism",
+  "reth-auto-seal-consensus/optimism",
+  "reth-network/optimism",
+  "reth-network-api/optimism",
+  "reth-blockchain-tree/optimism",
+  "reth-payload-builder/optimism",
+  "reth-optimism-payload-builder/optimism",
+  "reth-ethereum-payload-builder/optimism",
+  "reth-node-ethereum/optimism",
+  "dep:reth-node-optimism",
+  "reth-node-core/optimism",
+  "reth-node-api/optimism",
 ]
 
 # no-op feature flag for switching between the `optimism` and default functionality in CI matrices

--- a/crates/node-api/Cargo.toml
+++ b/crates/node-api/Cargo.toml
@@ -19,3 +19,6 @@ thiserror.workspace = true
 
 # io
 serde.workspace = true
+
+[features]
+optimism = []

--- a/crates/node-api/src/engine/traits.rs
+++ b/crates/node-api/src/engine/traits.rs
@@ -1,7 +1,9 @@
 use crate::{validate_version_specific_fields, AttributesValidationError, EngineApiMessageVersion};
 use reth_primitives::{
     revm::config::revm_spec_by_timestamp_after_merge,
-    revm_primitives::{BlobExcessGasAndPrice, BlockEnv, CfgEnv, CfgEnvWithHandlerCfg, SpecId},
+    revm_primitives::{
+        BlobExcessGasAndPrice, BlockEnv, CfgEnv, CfgEnvWithHandlerCfg, HandlerCfg, SpecId,
+    },
     Address, ChainSpec, Header, SealedBlock, Withdrawals, B256, U256,
 };
 use reth_rpc_types::{
@@ -129,16 +131,20 @@ pub trait PayloadBuilderAttributes: Send + Sync + std::fmt::Debug {
             blob_excess_gas_and_price,
         };
 
-        #[cfg(feature = "optimism")]
-        {
-            let cfg_with_handler_cfg = CfgEnvWithHandlerCfg {
-                cfg_env: cfg,
-                handler_cfg: HandlerCfg { spec_id, is_optimism: chain_spec.is_optimism() },
-            };
-        }
+        let cfg_with_handler_cfg = {
+            #[cfg(feature = "optimism")]
+            {
+                CfgEnvWithHandlerCfg {
+                    cfg_env: cfg,
+                    handler_cfg: HandlerCfg { spec_id, is_optimism: chain_spec.is_optimism() },
+                }
+            }
 
-        #[cfg(not(feature = "optimism"))]
-        let cfg_with_handler_cfg = CfgEnvWithHandlerCfg::new(cfg, spec_id);
+            #[cfg(not(feature = "optimism"))]
+            {
+                CfgEnvWithHandlerCfg::new(cfg, spec_id)
+            }
+        };
 
         (cfg_with_handler_cfg, block_env)
     }

--- a/crates/node-core/Cargo.toml
+++ b/crates/node-core/Cargo.toml
@@ -82,7 +82,11 @@ tracing.workspace = true
 # crypto
 alloy-rlp.workspace = true
 alloy-chains.workspace = true
-secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery"] }
+secp256k1 = { workspace = true, features = [
+  "global-context",
+  "rand-std",
+  "recovery",
+] }
 
 # async
 futures.workspace = true
@@ -102,22 +106,23 @@ assert_matches.version = "1.5.0"
 
 [features]
 optimism = [
-    "reth-primitives/optimism",
-    "reth-interfaces/optimism",
-    "reth-rpc/optimism",
-    "reth-rpc-engine-api/optimism",
-    "reth-transaction-pool/optimism",
-    "reth-provider/optimism",
-    "reth-network/optimism",
-    "reth-network-api/optimism",
-    "reth-payload-builder/optimism",
-    "reth-rpc-types/optimism",
-    "reth-rpc-types-compat/optimism",
-    "reth-auto-seal-consensus/optimism",
-    "reth-consensus-common/optimism",
-    "reth-blockchain-tree/optimism",
-    "reth-beacon-consensus/optimism",
-    "reth-optimism-payload-builder/optimism",
+  "reth-primitives/optimism",
+  "reth-interfaces/optimism",
+  "reth-rpc/optimism",
+  "reth-rpc-engine-api/optimism",
+  "reth-transaction-pool/optimism",
+  "reth-provider/optimism",
+  "reth-network/optimism",
+  "reth-network-api/optimism",
+  "reth-payload-builder/optimism",
+  "reth-rpc-types/optimism",
+  "reth-rpc-types-compat/optimism",
+  "reth-auto-seal-consensus/optimism",
+  "reth-consensus-common/optimism",
+  "reth-blockchain-tree/optimism",
+  "reth-beacon-consensus/optimism",
+  "reth-optimism-payload-builder/optimism",
+  "reth-node-api/optimism",
 ]
 
 jemalloc = ["dep:jemalloc-ctl"]


### PR DESCRIPTION
fixes https://github.com/paradigmxyz/reth/issues/6592 and makes https://github.com/paradigmxyz/reth/pull/6593 work as intended

blocks are being built successfully again with this commit