### PR TITLE
fix: check versioned hash version for EIP-4844 transactions

### DIFF
--- a/crates/primitives/src/transaction/eip4844.rs
+++ b/crates/primitives/src/transaction/eip4844.rs
@@ -145,7 +145,7 @@ impl TxEip4844 {
             if *versioned_hash != calculated_versioned_hash {
                 return Err(BlobTransactionValidationError::WrongVersionedHash {
                     have: *versioned_hash,
-                    expected: calculated_versioned_hash
+                    expected: calculated_versioned_hash,
                 })
             }
         }

--- a/crates/primitives/src/transaction/eip4844.rs
+++ b/crates/primitives/src/transaction/eip4844.rs
@@ -139,14 +139,14 @@ impl TxEip4844 {
             // convert to KzgCommitment
             let commitment = KzgCommitment::from(*commitment.deref());
 
-            // Calculate the versioned hash
-            //
-            // TODO: should this method distinguish the type of validation failure? For example
-            // whether a certain versioned hash does not match, or whether the blob proof
-            // validation failed?
+            // calculate & verify the versioned hash
+            // https://eips.ethereum.org/EIPS/eip-4844#execution-layer-validation
             let calculated_versioned_hash = kzg_to_versioned_hash(commitment);
             if *versioned_hash != calculated_versioned_hash {
-                return Err(BlobTransactionValidationError::InvalidProof)
+                return Err(BlobTransactionValidationError::WrongVersionedHash {
+                    have: *versioned_hash,
+                    expected: calculated_versioned_hash
+                })
             }
         }
 

--- a/crates/primitives/src/transaction/sidecar.rs
+++ b/crates/primitives/src/transaction/sidecar.rs
@@ -11,7 +11,7 @@ use crate::{
     kzg::{
         self, Blob, Bytes48, KzgSettings, BYTES_PER_BLOB, BYTES_PER_COMMITMENT, BYTES_PER_PROOF,
     },
-    Signature, Transaction, TransactionSigned, TxEip4844, TxHash, EIP4844_TX_TYPE_ID, B256
+    Signature, Transaction, TransactionSigned, TxEip4844, TxHash, B256, EIP4844_TX_TYPE_ID,
 };
 use alloy_rlp::{Decodable, Encodable, Error as RlpError, Header};
 use bytes::BufMut;

--- a/crates/primitives/src/transaction/sidecar.rs
+++ b/crates/primitives/src/transaction/sidecar.rs
@@ -11,7 +11,7 @@ use crate::{
     kzg::{
         self, Blob, Bytes48, KzgSettings, BYTES_PER_BLOB, BYTES_PER_COMMITMENT, BYTES_PER_PROOF,
     },
-    Signature, Transaction, TransactionSigned, TxEip4844, TxHash, EIP4844_TX_TYPE_ID,
+    Signature, Transaction, TransactionSigned, TxEip4844, TxHash, EIP4844_TX_TYPE_ID, B256
 };
 use alloy_rlp::{Decodable, Encodable, Error as RlpError, Header};
 use bytes::BufMut;
@@ -35,6 +35,14 @@ pub enum BlobTransactionValidationError {
     /// The inner transaction is not a blob transaction.
     #[error("unable to verify proof for non blob transaction: {0}")]
     NotBlobTransaction(u8),
+    /// The versioned hash is incorrect.
+    #[error("wrong versioned hash: have {have}, expected {expected}")]
+    WrongVersionedHash {
+        /// The versioned hash we got
+        have: B256,
+        /// The versioned hash we expected
+        expected: B256,
+    },
 }
 
 /// A response to `GetPooledTransactions` that includes blob data, their commitments, and their

--- a/crates/revm/src/eth_dao_fork.rs
+++ b/crates/revm/src/eth_dao_fork.rs
@@ -1,4 +1,4 @@
-//! DAO FOrk related constants from [EIP-779](https://eips.ethereum.org/EIPS/eip-779).
+//! DAO Fork related constants from [EIP-779](https://eips.ethereum.org/EIPS/eip-779).
 //! It happened on Ethereum block 1_920_000
 
 use reth_primitives::{address, Address};

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -143,7 +143,7 @@ pub enum Eip4844PoolTransactionError {
     /// Thrown if we're unable to find the blob for a transaction that was previously extracted
     #[error("blob sidecar not found for EIP4844 transaction")]
     MissingEip4844BlobSidecar,
-    /// Thrown if an EIP-4844 without any blobs arrives
+    /// Thrown if an EIP-4844 transaction without any blobs arrives
     #[error("blobless blob transaction")]
     NoEip4844Blobs,
     /// Thrown if an EIP-4844 without any blobs arrives
@@ -153,6 +153,14 @@ pub enum Eip4844PoolTransactionError {
         have: usize,
         /// Number of maximum blobs the transaction can have
         permitted: usize,
+    },
+    /// Thrown if an EIP-4844 transaction with the wrong versioned hash version arrives
+    #[error("wrong versioned hash version: have {have}, permitted {permitted}")]
+    WrongEip4844HashVersion {
+        /// The transaction's versioned hash version
+        have: u8,
+        /// The EIP-4844 versioned hash version
+        permitted: u8,
     },
     /// Thrown if validating the blob sidecar for the transaction failed.
     #[error(transparent)]
@@ -281,6 +289,10 @@ impl InvalidPoolTransactionError {
                         true
                     }
                     Eip4844PoolTransactionError::TooManyEip4844Blobs { .. } => {
+                        // this is a malformed transaction and should not be sent over the network
+                        true
+                    }
+                    Eip4844PoolTransactionError::WrongEip4844HashVersion { .. } => {
                         // this is a malformed transaction and should not be sent over the network
                         true
                     }

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -146,7 +146,7 @@ pub enum Eip4844PoolTransactionError {
     /// Thrown if an EIP-4844 transaction without any blobs arrives
     #[error("blobless blob transaction")]
     NoEip4844Blobs,
-    /// Thrown if an EIP-4844 without any blobs arrives
+    /// Thrown if an EIP-4844 transaction without any blobs arrives
     #[error("too many blobs in transaction: have {have}, permitted {permitted}")]
     TooManyEip4844Blobs {
         /// Number of blobs the transaction has

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -154,14 +154,6 @@ pub enum Eip4844PoolTransactionError {
         /// Number of maximum blobs the transaction can have
         permitted: usize,
     },
-    /// Thrown if an EIP-4844 transaction with the wrong versioned hash version arrives
-    #[error("wrong versioned hash version: have {have}, permitted {permitted}")]
-    WrongEip4844HashVersion {
-        /// The transaction's versioned hash version
-        have: u8,
-        /// The EIP-4844 versioned hash version
-        permitted: u8,
-    },
     /// Thrown if validating the blob sidecar for the transaction failed.
     #[error(transparent)]
     InvalidEip4844Blob(BlobTransactionValidationError),
@@ -289,10 +281,6 @@ impl InvalidPoolTransactionError {
                         true
                     }
                     Eip4844PoolTransactionError::TooManyEip4844Blobs { .. } => {
-                        // this is a malformed transaction and should not be sent over the network
-                        true
-                    }
-                    Eip4844PoolTransactionError::WrongEip4844HashVersion { .. } => {
                         // this is a malformed transaction and should not be sent over the network
                         true
                     }

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -289,7 +289,7 @@ where
 
             if let Some(tx) = transaction.as_eip4844() {
                 for versioned_hash in tx.blob_versioned_hashes.iter() {
-                    let version = versioned_hash.clone()[0];
+                    let version = (*versioned_hash)[0];
                     if version != VERSIONED_HASH_VERSION_KZG {
                         // versioned hash doesn't start with VERSIONED_HASH_VERSION_KZG
                         return TransactionValidationOutcome::Invalid(

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -25,7 +25,6 @@ use std::{
     sync::{atomic::AtomicBool, Arc},
 };
 use tokio::sync::Mutex;
-use reth_primitives::constants::eip4844::VERSIONED_HASH_VERSION_KZG;
 
 #[cfg(feature = "optimism")]
 use reth_revm::optimism::RethL1BlockInfo;

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -286,24 +286,6 @@ where
                     ),
                 )
             }
-
-            if let Some(tx) = transaction.as_eip4844() {
-                for versioned_hash in tx.blob_versioned_hashes.iter() {
-                    let version = (*versioned_hash)[0];
-                    if version != VERSIONED_HASH_VERSION_KZG {
-                        // versioned hash doesn't start with VERSIONED_HASH_VERSION_KZG
-                        return TransactionValidationOutcome::Invalid(
-                            transaction,
-                            InvalidPoolTransactionError::Eip4844(
-                                Eip4844PoolTransactionError::WrongEip4844HashVersion {
-                                    have: version,
-                                    permitted: VERSIONED_HASH_VERSION_KZG,
-                                },
-                            ),
-                        );
-                    }
-                }
-            }
         }
 
         let account = match self


### PR DESCRIPTION
I didn't see where the versioned hash's version was checked for EIP-4844 transactions. This PR adds this check. I don't believe this is a big deal though because the CL should also check this.

Here's the spec for this:
* https://eips.ethereum.org/EIPS/eip-4844#execution-layer-validation

This part in particular:
```python
# all versioned blob hashes must start with VERSIONED_HASH_VERSION_KZG
for h in tx.blob_versioned_hashes:
    assert h[0] == VERSIONED_HASH_VERSION_KZG
```