### PR TITLE
feat: check snapshot range on `ProviderFactory`

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -291,55 +291,6 @@ impl<TX: DbTx> DatabaseProvider<TX> {
         self
     }
 
-    /// Gets data within a specified range, potentially spanning different snapshots and database.
-    ///
-    /// # Arguments
-    /// * `segment` - The segment of the snapshot to query.
-    /// * `block_range` - The range of data to fetch.
-    /// * `fetch_from_snapshot` - A function to fetch data from the snapshot.
-    /// * `fetch_from_database` - A function to fetch data from the database.
-    /// * `predicate` - A function used to evaluate each item in the fetched data. Fetching is
-    ///   terminated when this function returns false, thereby filtering the data based on the
-    ///   provided condition.
-    fn get_range_with_snapshot<T, P, FS, FD>(
-        &self,
-        segment: SnapshotSegment,
-        mut block_or_tx_range: Range<u64>,
-        fetch_from_snapshot: FS,
-        mut fetch_from_database: FD,
-        mut predicate: P,
-    ) -> ProviderResult<Vec<T>>
-    where
-        FS: Fn(&SnapshotProvider, Range<u64>, &mut P) -> ProviderResult<Vec<T>>,
-        FD: FnMut(Range<u64>, P) -> ProviderResult<Vec<T>>,
-        P: FnMut(&T) -> bool,
-    {
-        let mut data = Vec::new();
-
-        if let Some(snapshot_upper_bound) = match segment {
-            SnapshotSegment::Headers => self.snapshot_provider.get_highest_snapshot_block(segment),
-            SnapshotSegment::Transactions | SnapshotSegment::Receipts => {
-                self.snapshot_provider.get_highest_snapshot_tx(segment)
-            }
-        } {
-            if block_or_tx_range.start <= snapshot_upper_bound {
-                let end = block_or_tx_range.end.min(snapshot_upper_bound + 1);
-                data.extend(fetch_from_snapshot(
-                    &self.snapshot_provider,
-                    block_or_tx_range.start..end,
-                    &mut predicate,
-                )?);
-                block_or_tx_range.start = end;
-            }
-        }
-
-        if block_or_tx_range.end > block_or_tx_range.start {
-            data.extend(fetch_from_database(block_or_tx_range, predicate)?)
-        }
-
-        Ok(data)
-    }
-
     fn transactions_by_tx_range_with_cursor<C>(
         &self,
         range: impl RangeBounds<TxNumber>,

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -348,7 +348,7 @@ impl<TX: DbTx> DatabaseProvider<TX> {
     where
         C: DbCursorRO<tables::Transactions>,
     {
-        self.get_range_with_snapshot(
+        self.snapshot_provider.get_range_with_snapshot_or_database(
             SnapshotSegment::Transactions,
             to_range(range),
             |snapshot, range, _| snapshot.transactions_by_tx_range(range),
@@ -1116,7 +1116,7 @@ impl<TX: DbTx> HeaderProvider for DatabaseProvider<TX> {
     }
 
     fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> ProviderResult<Vec<Header>> {
-        self.get_range_with_snapshot(
+        self.snapshot_provider.get_range_with_snapshot_or_database(
             SnapshotSegment::Headers,
             to_range(range),
             |snapshot, range, _| snapshot.headers_range(range),
@@ -1150,7 +1150,7 @@ impl<TX: DbTx> HeaderProvider for DatabaseProvider<TX> {
         range: impl RangeBounds<BlockNumber>,
         predicate: impl FnMut(&SealedHeader) -> bool,
     ) -> ProviderResult<Vec<SealedHeader>> {
-        self.get_range_with_snapshot(
+        self.snapshot_provider.get_range_with_snapshot_or_database(
             SnapshotSegment::Headers,
             to_range(range),
             |snapshot, range, predicate| snapshot.sealed_headers_while(range, predicate),
@@ -1189,7 +1189,7 @@ impl<TX: DbTx> BlockHashReader for DatabaseProvider<TX> {
         start: BlockNumber,
         end: BlockNumber,
     ) -> ProviderResult<Vec<B256>> {
-        self.get_range_with_snapshot(
+        self.snapshot_provider.get_range_with_snapshot_or_database(
             SnapshotSegment::Headers,
             start..end,
             |snapshot, range, _| snapshot.canonical_hashes_range(range.start, range.end),
@@ -1418,7 +1418,7 @@ impl<TX: DbTx> TransactionsProviderExt for DatabaseProvider<TX> {
         &self,
         tx_range: Range<TxNumber>,
     ) -> ProviderResult<Vec<(TxHash, TxNumber)>> {
-        self.get_range_with_snapshot(
+        self.snapshot_provider.get_range_with_snapshot_or_database(
             SnapshotSegment::Transactions,
             tx_range,
             |snapshot, range, _| snapshot.transaction_hashes_by_range(range),
@@ -1629,7 +1629,7 @@ impl<TX: DbTx> TransactionsProvider for DatabaseProvider<TX> {
         &self,
         range: impl RangeBounds<TxNumber>,
     ) -> ProviderResult<Vec<RawValue<TransactionSignedNoHash>>> {
-        self.get_range_with_snapshot(
+        self.snapshot_provider.get_range_with_snapshot_or_database(
             SnapshotSegment::Transactions,
             to_range(range),
             |snapshot, range, _| snapshot.raw_transactions_by_tx_range(range),
@@ -1693,7 +1693,7 @@ impl<TX: DbTx> ReceiptProvider for DatabaseProvider<TX> {
         &self,
         range: impl RangeBounds<TxNumber>,
     ) -> ProviderResult<Vec<Receipt>> {
-        self.get_range_with_snapshot(
+        self.snapshot_provider.get_range_with_snapshot_or_database(
             SnapshotSegment::Receipts,
             to_range(range),
             |snapshot, range, _| snapshot.receipts_by_tx_range(range),

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -134,34 +134,34 @@ where
     Tree: Send + Sync,
 {
     fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Header>> {
-        self.database.provider()?.header(block_hash)
+        self.database.header(block_hash)
     }
 
     fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Header>> {
-        self.database.provider()?.header_by_number(num)
+        self.database.header_by_number(num)
     }
 
     fn header_td(&self, hash: &BlockHash) -> ProviderResult<Option<U256>> {
-        self.database.provider()?.header_td(hash)
+        self.database.header_td(hash)
     }
 
     fn header_td_by_number(&self, number: BlockNumber) -> ProviderResult<Option<U256>> {
-        self.database.provider()?.header_td_by_number(number)
+        self.database.header_td_by_number(number)
     }
 
     fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> ProviderResult<Vec<Header>> {
-        self.database.provider()?.headers_range(range)
+        self.database.headers_range(range)
     }
 
     fn sealed_header(&self, number: BlockNumber) -> ProviderResult<Option<SealedHeader>> {
-        self.database.provider()?.sealed_header(number)
+        self.database.sealed_header(number)
     }
 
     fn sealed_headers_range(
         &self,
         range: impl RangeBounds<BlockNumber>,
     ) -> ProviderResult<Vec<SealedHeader>> {
-        self.database.provider()?.sealed_headers_range(range)
+        self.database.sealed_headers_range(range)
     }
 
     fn sealed_headers_while(
@@ -169,7 +169,7 @@ where
         range: impl RangeBounds<BlockNumber>,
         predicate: impl FnMut(&SealedHeader) -> bool,
     ) -> ProviderResult<Vec<SealedHeader>> {
-        self.database.provider()?.sealed_headers_while(range, predicate)
+        self.database.sealed_headers_while(range, predicate)
     }
 }
 
@@ -179,7 +179,7 @@ where
     Tree: Send + Sync,
 {
     fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
-        self.database.provider()?.block_hash(number)
+        self.database.block_hash(number)
     }
 
     fn canonical_hashes_range(
@@ -187,7 +187,7 @@ where
         start: BlockNumber,
         end: BlockNumber,
     ) -> ProviderResult<Vec<B256>> {
-        self.database.provider()?.canonical_hashes_range(start, end)
+        self.database.canonical_hashes_range(start, end)
     }
 }
 
@@ -205,11 +205,11 @@ where
     }
 
     fn last_block_number(&self) -> ProviderResult<BlockNumber> {
-        self.database.provider()?.last_block_number()
+        self.database.last_block_number()
     }
 
     fn block_number(&self, hash: B256) -> ProviderResult<Option<BlockNumber>> {
-        self.database.provider()?.block_number(hash)
+        self.database.block_number(hash)
     }
 }
 
@@ -240,7 +240,7 @@ where
         let block = match source {
             BlockSource::Any => {
                 // check database first
-                let mut block = self.database.provider()?.block_by_hash(hash)?;
+                let mut block = self.database.block_by_hash(hash)?;
                 if block.is_none() {
                     // Note: it's fine to return the unsealed block because the caller already has
                     // the hash
@@ -249,7 +249,7 @@ where
                 block
             }
             BlockSource::Pending => self.tree.block_by_hash(hash).map(|block| block.unseal()),
-            BlockSource::Database => self.database.provider()?.block_by_hash(hash)?,
+            BlockSource::Database => self.database.block_by_hash(hash)?,
         };
 
         Ok(block)
@@ -258,7 +258,7 @@ where
     fn block(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Block>> {
         match id {
             BlockHashOrNumber::Hash(hash) => self.find_block_by_hash(hash, BlockSource::Any),
-            BlockHashOrNumber::Number(num) => self.database.provider()?.block_by_number(num),
+            BlockHashOrNumber::Number(num) => self.database.block_by_number(num),
         }
     }
 
@@ -275,14 +275,14 @@ where
     }
 
     fn ommers(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Header>>> {
-        self.database.provider()?.ommers(id)
+        self.database.ommers(id)
     }
 
     fn block_body_indices(
         &self,
         number: BlockNumber,
     ) -> ProviderResult<Option<StoredBlockBodyIndices>> {
-        self.database.provider()?.block_body_indices(number)
+        self.database.block_body_indices(number)
     }
 
     /// Returns the block with senders with matching number or hash from database.
@@ -296,11 +296,11 @@ where
         id: BlockHashOrNumber,
         transaction_kind: TransactionVariant,
     ) -> ProviderResult<Option<BlockWithSenders>> {
-        self.database.provider()?.block_with_senders(id, transaction_kind)
+        self.database.block_with_senders(id, transaction_kind)
     }
 
     fn block_range(&self, range: RangeInclusive<BlockNumber>) -> ProviderResult<Vec<Block>> {
-        self.database.provider()?.block_range(range)
+        self.database.block_range(range)
     }
 }
 
@@ -310,54 +310,54 @@ where
     Tree: BlockchainTreeViewer + Send + Sync,
 {
     fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
-        self.database.provider()?.transaction_id(tx_hash)
+        self.database.transaction_id(tx_hash)
     }
 
     fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<TransactionSigned>> {
-        self.database.provider()?.transaction_by_id(id)
+        self.database.transaction_by_id(id)
     }
 
     fn transaction_by_id_no_hash(
         &self,
         id: TxNumber,
     ) -> ProviderResult<Option<TransactionSignedNoHash>> {
-        self.database.provider()?.transaction_by_id_no_hash(id)
+        self.database.transaction_by_id_no_hash(id)
     }
 
     fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<TransactionSigned>> {
-        self.database.provider()?.transaction_by_hash(hash)
+        self.database.transaction_by_hash(hash)
     }
 
     fn transaction_by_hash_with_meta(
         &self,
         tx_hash: TxHash,
     ) -> ProviderResult<Option<(TransactionSigned, TransactionMeta)>> {
-        self.database.provider()?.transaction_by_hash_with_meta(tx_hash)
+        self.database.transaction_by_hash_with_meta(tx_hash)
     }
 
     fn transaction_block(&self, id: TxNumber) -> ProviderResult<Option<BlockNumber>> {
-        self.database.provider()?.transaction_block(id)
+        self.database.transaction_block(id)
     }
 
     fn transactions_by_block(
         &self,
         id: BlockHashOrNumber,
     ) -> ProviderResult<Option<Vec<TransactionSigned>>> {
-        self.database.provider()?.transactions_by_block(id)
+        self.database.transactions_by_block(id)
     }
 
     fn transactions_by_block_range(
         &self,
         range: impl RangeBounds<BlockNumber>,
     ) -> ProviderResult<Vec<Vec<TransactionSigned>>> {
-        self.database.provider()?.transactions_by_block_range(range)
+        self.database.transactions_by_block_range(range)
     }
 
     fn transactions_by_tx_range(
         &self,
         range: impl RangeBounds<TxNumber>,
     ) -> ProviderResult<Vec<TransactionSignedNoHash>> {
-        self.database.provider()?.transactions_by_tx_range(range)
+        self.database.transactions_by_tx_range(range)
     }
 
     fn raw_transactions_by_tx_range(
@@ -371,11 +371,11 @@ where
         &self,
         range: impl RangeBounds<TxNumber>,
     ) -> ProviderResult<Vec<Address>> {
-        self.database.provider()?.senders_by_tx_range(range)
+        self.database.senders_by_tx_range(range)
     }
 
     fn transaction_sender(&self, id: TxNumber) -> ProviderResult<Option<Address>> {
-        self.database.provider()?.transaction_sender(id)
+        self.database.transaction_sender(id)
     }
 }
 
@@ -385,22 +385,22 @@ where
     Tree: Send + Sync,
 {
     fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Receipt>> {
-        self.database.provider()?.receipt(id)
+        self.database.receipt(id)
     }
 
     fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Receipt>> {
-        self.database.provider()?.receipt_by_hash(hash)
+        self.database.receipt_by_hash(hash)
     }
 
     fn receipts_by_block(&self, block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
-        self.database.provider()?.receipts_by_block(block)
+        self.database.receipts_by_block(block)
     }
 
     fn receipts_by_tx_range(
         &self,
         range: impl RangeBounds<TxNumber>,
     ) -> ProviderResult<Vec<Receipt>> {
-        self.database.provider()?.receipts_by_tx_range(range)
+        self.database.receipts_by_tx_range(range)
     }
 }
 impl<DB, Tree> ReceiptProviderIdExt for BlockchainProvider<DB, Tree>
@@ -441,11 +441,11 @@ where
         id: BlockHashOrNumber,
         timestamp: u64,
     ) -> ProviderResult<Option<Withdrawals>> {
-        self.database.provider()?.withdrawals_by_block(id, timestamp)
+        self.database.withdrawals_by_block(id, timestamp)
     }
 
     fn latest_withdrawal(&self) -> ProviderResult<Option<Withdrawal>> {
-        self.database.provider()?.latest_withdrawal()
+        self.database.latest_withdrawal()
     }
 }
 


### PR DESCRIPTION
* Execute the snapshot check before actually creating the `DatabaseProvider`.
* `BlockchainProvider` should call `ProviderFactory` methods in instances where it can. Example: `self.database.provider()?.header_td_by_number(number)` -> `self.database.header_td_by_number(number)`.
* Removes some duplicate methods from a previous PR.

Improvements apply to methods that might skip opening a Database transaction if all the necessary data is available to query the static file data.

Holesky with `maxperf`

```
cryo blocks --blocks 0:900k --csv 
main -> 24s # 3e33ed20f5eaf18692f3e82a695a540e0ff598d7547c8135819f4be9e032c6f3
branch  -> 13s # 3e33ed20f5eaf18692f3e82a695a540e0ff598d7547c8135819f4be9e032c6f3
```

```
cryo txs --blocks 0:900k --csv
main  -> 132s # 1119bc690bdadbe65de11246eb2bfd2424d902ba9ad7ce47a027c9a696d4737e
branch  -> 120s # 1119bc690bdadbe65de11246eb2bfd2424d902ba9ad7ce47a027c9a696d4737e
```

```
cryo logs --blocks 0:900k --csv
main  -> 509s # 47079da470b7f8d6d946dbbbcd65a7d1032e7437aab094dd11d81d88971165c9
branch  -> 87s # 47079da470b7f8d6d946dbbbcd65a7d1032e7437aab094dd11d81d88971165c9
```



For equality tests, I run `b3sum` over the resulting csv and compare

I feel like `cryo`  still has some big overhead on writing/handling the incoming data, but this seems like a clear improvement.  Also, on `cryo blocks` the flamegraph hits on `rpc_block` went from 19k (feat/static-files) to 500 (this branch)
