### PR TITLE
fix: set AutoSealConsensus best_block correctly

### DIFF
--- a/crates/consensus/auto-seal/src/lib.rs
+++ b/crates/consensus/auto-seal/src/lib.rs
@@ -186,15 +186,17 @@ pub(crate) struct Storage {
 // == impl Storage ===
 
 impl Storage {
-    fn new(header: SealedHeader) -> Self {
-        let (header, best_hash) = header.split();
+    /// Initializes the [Storage] with the given best block. This should be initialized with the
+    /// highest block in the chain, if there is a chain already stored on-disk.
+    fn new(best_block: SealedHeader) -> Self {
+        let (header, best_hash) = best_block.split();
         let mut storage = StorageInner {
             best_hash,
             total_difficulty: header.difficulty,
             best_block: header.number,
             ..Default::default()
         };
-        storage.headers.insert(0, header);
+        storage.headers.insert(header.number, header);
         storage.bodies.insert(best_hash, BlockBody::default());
         Self { inner: Arc::new(RwLock::new(storage)) }
     }


### PR DESCRIPTION
Fixes https://github.com/paradigmxyz/reth/issues/6605

For the fix to apply, the dev directory should be wiped, because the db may contain stored invalid headers (i.e., post-london headers without a `baseFeePerGas` field).

This sets the best block number properly - previously, the number was set to zero, but `best_block` was set to `header.number`, causing this:
```rust
        // check previous block for base fee
        let base_fee_per_gas = self
            .headers
            .get(&self.best_block)
```

to return `None` on existing dev chains.