### PR TITLE
chore: dont set some ready when draining pending txs

### DIFF
--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1163,7 +1163,6 @@ where
             let mut new_txs = Vec::new();
             while let Poll::Ready(Some(hash)) = this.pending_transactions.poll_next_unpin(cx) {
                 new_txs.push(hash);
-                some_ready = true;
             }
             if !new_txs.is_empty() {
                 this.on_new_transactions(new_txs);


### PR DESCRIPTION
we're draining the stream, no need to flag more work here