### PR TITLE
chore: decrease network manager budget

### DIFF
--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -931,7 +931,7 @@ where
             // ensure we still have enough budget for another iteration
             budget -= 1;
             if budget == 0 {
-                trace!(target: "net", "exhausted network manager budget");
+                trace!(target: "net", budget=10, "exhausted network manager budget");
                 // make sure we're woken up again
                 cx.waker().wake_by_ref();
                 break

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -677,7 +677,9 @@ where
         // And tokio's docs on cooperative scheduling <https://docs.rs/tokio/latest/tokio/task/#cooperative-scheduling>
         //
         // Testing has shown that this loop naturally reaches the pending state within 1-5
-        // iterations in << 100µs in most cases.
+        // iterations in << 100µs in most cases. On average it requires ~50µs, which is inside
+        // the range of what's recommended as rule of thumb.
+        // <https://ryhl.io/blog/async-what-is-blocking/>
         let mut budget = 10;
 
         loop {

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -675,7 +675,10 @@ where
         // If the budget is exhausted we manually yield back control to the (coop) scheduler. This
         // manual yield point should prevent situations where polling appears to be frozen. See also <https://tokio.rs/blog/2020-04-preemption>
         // And tokio's docs on cooperative scheduling <https://docs.rs/tokio/latest/tokio/task/#cooperative-scheduling>
-        let mut budget = 1024;
+        //
+        // Testing has shown that this loop naturally reaches the pending state within 1-5
+        // iterations in << 100µs in most cases.
+        let mut budget = 10;
 
         loop {
             // advance the swarm
@@ -926,6 +929,7 @@ where
             // ensure we still have enough budget for another iteration
             budget -= 1;
             if budget == 0 {
+                trace!(target: "net", "exhausted network manager budget");
                 // make sure we're woken up again
                 cx.waker().wake_by_ref();
                 break


### PR DESCRIPTION
I monitored mainnet for a while.

The loop naturally reaches pending in ~50µs most of the time with 1-5 iterations at most (mostly 1-3), so this is an appropriate decrease imo.

though still unlikely that we reach this.

the avg ~50µs is inside the range of what's recommended as rule of thumb for

https://ryhl.io/blog/async-what-is-blocking/