### PR TITLE
implements 'ethGetHeaderByNumber' and 'ethGetHeaderByHash'

### DIFF
--- a/crates/rpc/rpc-api/src/eth.rs
+++ b/crates/rpc/rpc-api/src/eth.rs
@@ -5,8 +5,8 @@ use reth_primitives::{
 };
 use reth_rpc_types::{
     state::StateOverride, AccessListWithGasUsed, BlockOverrides, Bundle,
-    EIP1186AccountProofResponse, EthCallResponse, FeeHistory, Index, RichBlock, StateContext,
-    SyncStatus, Transaction, TransactionReceipt, TransactionRequest, Work,
+    EIP1186AccountProofResponse, EthCallResponse, FeeHistory, Header, Index, RichBlock,
+    StateContext, SyncStatus, Transaction, TransactionReceipt, TransactionRequest, Work,
 };
 
 /// Eth rpc interface: <https://ethereum.github.io/execution-apis/api-documentation/>
@@ -141,6 +141,14 @@ pub trait EthApi {
     /// Returns code at a given address at given block number.
     #[method(name = "getCode")]
     async fn get_code(&self, address: Address, block_number: Option<BlockId>) -> RpcResult<Bytes>;
+
+    /// Returns the block's header at given number.
+    #[method(name = "getHeaderByNumber")]
+    async fn header_by_number(&self, hash: BlockNumberOrTag) -> RpcResult<Option<Header>>;
+
+    /// Returns the block's header at given hash.
+    #[method(name = "getHeaderByHash")]
+    async fn header_by_hash(&self, hash: B256) -> RpcResult<Option<Header>>;
 
     /// Executes a new message call immediately without creating a transaction on the block chain.
     #[method(name = "call")]

--- a/crates/rpc/rpc/src/eth/api/block.rs
+++ b/crates/rpc/rpc/src/eth/api/block.rs
@@ -11,7 +11,7 @@ use reth_network_api::NetworkInfo;
 use reth_node_api::ConfigureEvmEnv;
 use reth_primitives::{BlockId, TransactionMeta};
 use reth_provider::{BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, StateProviderFactory};
-use reth_rpc_types::{Index, RichBlock, TransactionReceipt};
+use reth_rpc_types::{Header, Index, RichBlock, TransactionReceipt};
 use reth_rpc_types_compat::block::{from_block, uncle_block_from_header};
 use reth_transaction_pool::TransactionPool;
 use std::sync::Arc;
@@ -199,5 +199,14 @@ where
             .ok_or(EthApiError::UnknownBlockNumber)?;
         let block = from_block(block.unseal(), total_difficulty, full.into(), Some(block_hash))?;
         Ok(Some(block.into()))
+    }
+
+    /// Returns the block header for the given block id.
+    pub(crate) async fn block_header(
+        &self,
+        block_id: impl Into<BlockId>,
+    ) -> EthResult<Option<Header>> {
+        let header = self.rpc_block(block_id, false).await?.map(|block| block.inner.header);
+        Ok(header)
     }
 }

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -229,27 +229,13 @@ where
     /// Handler for: `eth_getHeaderByNumber`
     async fn header_by_number(&self, block_number: BlockNumberOrTag) -> Result<Option<Header>> {
         trace!(target: "rpc::eth", ?block_number, "Serving eth_getHeaderByNumber");
-        let block = EthApi::rpc_block(self, block_number, false).await?;
-
-        let header = match block {
-            Some(block) => block.inner.header,
-            None => return Ok(None),
-        };
-
-        Ok(Some(header))
+        Ok(EthApi::block_header(self, block_number).await?)
     }
 
     /// Handler for: `eth_getHeaderByHash`
     async fn header_by_hash(&self, hash: B256) -> Result<Option<Header>> {
         trace!(target: "rpc::eth", ?hash, "Serving eth_getHeaderByHash");
-        let block = EthApi::rpc_block(self, hash, false).await?;
-
-        let header = match block {
-            Some(block) => block.inner.header,
-            None => return Ok(None),
-        };
-
-        Ok(Some(header))
+        Ok(EthApi::block_header(self, hash).await?)
     }
 
     /// Handler for: `eth_call`

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -309,19 +309,19 @@ where
     /// Handler for: `eth_gasPrice`
     async fn gas_price(&self) -> Result<U256> {
         trace!(target: "rpc::eth", "Serving eth_gasPrice");
-        return Ok(EthApi::gas_price(self).await?);
+        return Ok(EthApi::gas_price(self).await?)
     }
 
     /// Handler for: `eth_blobGasPrice`
     async fn blob_gas_price(&self) -> Result<U256> {
         trace!(target: "rpc::eth", "Serving eth_blobGasPrice");
-        return Ok(EthApi::blob_gas_price(self).await?);
+        return Ok(EthApi::blob_gas_price(self).await?)
     }
 
     /// Handler for: `eth_maxPriorityFeePerGas`
     async fn max_priority_fee_per_gas(&self) -> Result<U256> {
         trace!(target: "rpc::eth", "Serving eth_maxPriorityFeePerGas");
-        return Ok(EthApi::suggested_priority_fee(self).await?);
+        return Ok(EthApi::suggested_priority_fee(self).await?)
     }
 
     // FeeHistory is calculated based on lazy evaluation of fees for historical blocks, and further
@@ -342,7 +342,7 @@ where
         trace!(target: "rpc::eth", ?block_count, ?newest_block, ?reward_percentiles, "Serving eth_feeHistory");
         return Ok(
             EthApi::fee_history(self, block_count.to(), newest_block, reward_percentiles).await?
-        );
+        )
     }
 
     /// Handler for: `eth_mining`


### PR DESCRIPTION
Related to [6571](https://github.com/paradigmxyz/reth/issues/6571)

Implements rpc API endpoints 'ethGetHeaderByNumber' and 'ethGetHeaderByHash'. 

It returns the entire header compatible with Geth, and if the block does not exist, returns null. 