### PR TITLE
fix(metrics): fix missing metrics by installing prometheus before creating db env

### DIFF
--- a/crates/storage/db/src/metrics.rs
+++ b/crates/storage/db/src/metrics.rs
@@ -14,6 +14,9 @@ const LARGE_VALUE_THRESHOLD_BYTES: usize = 4096;
 
 /// Caches metric handles for database environment to make sure handles are not re-created
 /// on every operation.
+///
+/// Requires a metric recorder to be registered before creating an instance of this struct.
+/// Otherwise, metric recording will no-op.
 #[derive(Debug)]
 pub struct DatabaseEnvMetrics {
     /// Caches OperationMetrics handles for each table and operation tuple.


### PR DESCRIPTION
This is a suggested alternative fix to a problem introduced in #6573. The previous fix was #6621 (registering metrics on first write vs `new`). 

Problem TLDR: `DatabaseEnvMetrics` pre-registers all metrics at `new`, but if metrics recorder isn't available at this point, all future metric writes will NOOP.

This solution here is to register a metric recorder (via dereferencing a lazy static) prior to opening a database environment. Second `self.config.install_prometheus_recorder()` still remains in the `reth` node builder to be used in `start_metrics_endpoint`.
