### PR TITLE
fix: set fees correctly on eth_sendTransaction

### DIFF
--- a/crates/rpc/rpc/src/eth/api/block.rs
+++ b/crates/rpc/rpc/src/eth/api/block.rs
@@ -202,7 +202,7 @@ where
     }
 
     /// Returns the block header for the given block id.
-    pub(crate) async fn block_header(
+    pub(crate) async fn rpc_block_header(
         &self,
         block_id: impl Into<BlockId>,
     ) -> EthResult<Option<Header>> {

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -229,13 +229,13 @@ where
     /// Handler for: `eth_getHeaderByNumber`
     async fn header_by_number(&self, block_number: BlockNumberOrTag) -> Result<Option<Header>> {
         trace!(target: "rpc::eth", ?block_number, "Serving eth_getHeaderByNumber");
-        Ok(EthApi::block_header(self, block_number).await?)
+        Ok(EthApi::rpc_block_header(self, block_number).await?)
     }
 
     /// Handler for: `eth_getHeaderByHash`
     async fn header_by_hash(&self, hash: B256) -> Result<Option<Header>> {
         trace!(target: "rpc::eth", ?hash, "Serving eth_getHeaderByHash");
-        Ok(EthApi::block_header(self, hash).await?)
+        Ok(EthApi::rpc_block_header(self, hash).await?)
     }
 
     /// Handler for: `eth_call`


### PR DESCRIPTION
Closes #6670

the request's fields for estimate gas were set incorrectly.

This now also uses suggested fees if missing from the request