### PR TITLE
Enable verbose tracing with env var

### DIFF
--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -245,7 +245,7 @@ impl<Pool: TransactionPool> TransactionsManager<Pool> {
         let network_events = network.event_listener();
         let (command_tx, command_rx) = mpsc::unbounded_channel();
 
-        let transaction_fetcher = TransactionFetcher::default().with_transaction_fetcher_config(
+        let transaction_fetcher = TransactionFetcher::new_with_transaction_fetcher_config(
             &transactions_manager_config.transaction_fetcher_config,
         );
 


### PR DESCRIPTION
Detaches the option of verbose tracing from `debug_mode`. For now this is read from an env var, not to change any code coverage in CI which runs with `--all-features` flag sometimes. Will open an issue for exposing via cli, probably nice if this done component by component since this type of logs are intended for debugging that is zoomed in on a specific component.