### PR TITLE
fix: dont include invalid responses

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1413,6 +1413,12 @@ where
             }
             Err(err) => {
                 warn!(target: "consensus::engine", ?err, "Failed to insert downloaded block");
+                if err.kind().is_invalid_block() {
+                    let (block, err) = err.split();
+                    warn!(target: "consensus::engine", invalid_number=?block.number, invalid_hash=?block.hash(), ?err, "Marking block as invalid");
+
+                    self.invalid_headers.insert(block.header);
+                }
             }
         }
     }

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1413,12 +1413,6 @@ where
             }
             Err(err) => {
                 warn!(target: "consensus::engine", ?err, "Failed to insert downloaded block");
-                if err.kind().is_invalid_block() {
-                    let (block, err) = err.split();
-                    warn!(target: "consensus::engine", invalid_number=?block.number, invalid_hash=?block.hash(), ?err, "Marking block as invalid");
-
-                    self.invalid_headers.insert(block.header);
-                }
             }
         }
     }


### PR DESCRIPTION
this fixes a bug in live sync downloading where invalid bodies where accidentally converted into validated ones.

by continuing the loop for invalid body, this is prevented.

This also removes invalid block handling in the engine for blocks downloaded from the network as a precaution.