### PR TITLE
chore: remove unused genesis_hash in NetworkState and NetworkManager

### DIFF
--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -42,7 +42,7 @@ use reth_eth_wire::{
 use reth_metrics::common::mpsc::UnboundedMeteredSender;
 use reth_net_common::bandwidth_meter::BandwidthMeter;
 use reth_network_api::ReputationChangeKind;
-use reth_primitives::{ForkId, NodeRecord, PeerId, B256};
+use reth_primitives::{ForkId, NodeRecord, PeerId};
 use reth_provider::{BlockNumReader, BlockReader};
 use reth_rpc_types::{EthProtocolInfo, NetworkStatus};
 use reth_tasks::shutdown::GracefulShutdown;
@@ -217,13 +217,8 @@ where
             bandwidth_meter.clone(),
         );
 
-        let state = NetworkState::new(
-            client,
-            discovery,
-            peers_manager,
-            chain_spec.genesis_hash(),
-            Arc::clone(&num_active_peers),
-        );
+        let state =
+            NetworkState::new(client, discovery, peers_manager, Arc::clone(&num_active_peers));
 
         let swarm = Swarm::new(incoming, sessions, state);
 
@@ -301,11 +296,6 @@ where
     /// Returns the [`SocketAddr`] that listens for incoming connections.
     pub fn local_addr(&self) -> SocketAddr {
         self.swarm.listener().local_address()
-    }
-
-    /// Returns the configured genesis hash
-    pub fn genesis_hash(&self) -> B256 {
-        self.swarm.state().genesis_hash()
     }
 
     /// How many peers we're currently connected to.

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -61,8 +61,6 @@ pub struct NetworkState<C> {
     client: C,
     /// Network discovery.
     discovery: Discovery,
-    /// The genesis hash of the network we're on
-    genesis_hash: B256,
     /// The type that handles requests.
     ///
     /// The fetcher streams RLPx related requests on a per-peer basis to this type. This type will
@@ -79,7 +77,6 @@ where
         client: C,
         discovery: Discovery,
         peers_manager: PeersManager,
-        genesis_hash: B256,
         num_active_peers: Arc<AtomicUsize>,
     ) -> Self {
         let state_fetcher = StateFetcher::new(peers_manager.handle(), num_active_peers);
@@ -89,7 +86,6 @@ where
             queued_messages: Default::default(),
             client,
             discovery,
-            genesis_hash,
             state_fetcher,
         }
     }
@@ -112,11 +108,6 @@ where
     /// Returns a new [`FetchClient`]
     pub(crate) fn fetch_client(&self) -> FetchClient {
         self.state_fetcher.client()
-    }
-
-    /// Configured genesis hash.
-    pub fn genesis_hash(&self) -> B256 {
-        self.genesis_hash
     }
 
     /// How many peers we're currently connected to.
@@ -556,7 +547,6 @@ mod tests {
             queued_messages: Default::default(),
             client: NoopProvider::default(),
             discovery: Discovery::noop(),
-            genesis_hash: Default::default(),
             state_fetcher: StateFetcher::new(handle, Default::default()),
         }
     }


### PR DESCRIPTION
The methods were unused as far as I can tell and not needed for anything internal