### PR TITLE
fix: `SnapshotProvider`  edge case scenarios on insertion and query

### DIFF
--- a/crates/storage/provider/src/providers/snapshot/manager.rs
+++ b/crates/storage/provider/src/providers/snapshot/manager.rs
@@ -225,7 +225,13 @@ impl SnapshotProvider {
                 },
             )??;
 
-            self.map.insert(key, LoadedJar::new(jar)?);
+            match self.map.entry(key) {
+                DashMapEntry::Occupied(_) => {}
+                DashMapEntry::Vacant(entry) => {
+                    entry.insert(LoadedJar::new(jar)?);
+                }
+            };
+
             Ok(self.map.get(&key).expect("qed").into())
         }
     }
@@ -333,7 +339,12 @@ impl SnapshotProvider {
                 }
 
                 // Update the cached provider.
-                self.map.insert((fixed_range.end(), segment), LoadedJar::new(jar)?);
+                match self.map.entry((fixed_range.end(), segment)) {
+                    DashMapEntry::Occupied(_) => {}
+                    DashMapEntry::Vacant(entry) => {
+                        entry.insert(LoadedJar::new(jar)?);
+                    }
+                };
 
                 // Delete any cached provider that no longer has an associated jar.
                 self.map.retain(|(end, seg), _| !(*seg == segment && *end > fixed_range.end()));

--- a/crates/storage/provider/src/providers/snapshot/manager.rs
+++ b/crates/storage/provider/src/providers/snapshot/manager.rs
@@ -470,8 +470,6 @@ impl SnapshotProvider {
             'inner: loop {
                 match get_fn(&mut cursor, number)? {
                     Some(res) => {
-                        retrying = false;
-
                         if !predicate(&res) {
                             break 'outer
                         }

--- a/crates/storage/provider/src/providers/snapshot/manager.rs
+++ b/crates/storage/provider/src/providers/snapshot/manager.rs
@@ -458,11 +458,9 @@ impl SnapshotProvider {
         let mut provider = get_provider(range.start)?;
         let mut cursor = provider.cursor()?;
 
-        // Used as a safety check to make sure we don't get stuck on a loop on an unexpected issue
-        // or corrupted file.
-        //
-        // Since we're looping through a range, we should retry at most once for a specific
-        // **number: if we're changing files (get_provider) aka checking the lower block range file.
+        // The `retrying` flag ensures a single retry attempt per `number`. If `get_fn` fails to
+        // access data in two different static files, it halts further attempts by returning
+        // an error, effectively preventing infinite retry loops.
         let mut retrying = false;
 
         // advances number in range

--- a/crates/storage/provider/src/providers/snapshot/manager.rs
+++ b/crates/storage/provider/src/providers/snapshot/manager.rs
@@ -34,6 +34,7 @@ use std::{
     path::{Path, PathBuf},
     sync::{mpsc, Arc},
 };
+use tracing::warn;
 
 /// Alias type for a map that can be queried for block ranges from a transaction
 /// segment respectively. It uses `TxNumber` to represent the transaction end of a snapshot range.
@@ -460,12 +461,11 @@ impl SnapshotProvider {
 
         // advances number in range
         'outer: for number in range {
-
             // The `retrying` flag ensures a single retry attempt per `number`. If `get_fn` fails to
             // access data in two different static files, it halts further attempts by returning
             // an error, effectively preventing infinite retry loops.
             let mut retrying = false;
-            
+
             // advances snapshot files if `get_fn` returns None
             'inner: loop {
                 match get_fn(&mut cursor, number)? {
@@ -479,6 +479,13 @@ impl SnapshotProvider {
                     }
                     None => {
                         if retrying {
+                            warn!(
+                                target: "provider::static_file",
+                                ?segment,
+                                ?number,
+                                "Could not find block or tx number on a range request"
+                            );
+
                             let err = if segment.is_headers() {
                                 ProviderError::MissingSnapshotBlock(segment, number)
                             } else {

--- a/crates/storage/provider/src/providers/snapshot/manager.rs
+++ b/crates/storage/provider/src/providers/snapshot/manager.rs
@@ -473,7 +473,6 @@ impl SnapshotProvider {
                         if !predicate(&res) {
                             break 'outer
                         }
-
                         result.push(res);
                         break 'inner
                     }

--- a/crates/storage/provider/src/providers/snapshot/manager.rs
+++ b/crates/storage/provider/src/providers/snapshot/manager.rs
@@ -458,13 +458,14 @@ impl SnapshotProvider {
         let mut provider = get_provider(range.start)?;
         let mut cursor = provider.cursor()?;
 
-        // The `retrying` flag ensures a single retry attempt per `number`. If `get_fn` fails to
-        // access data in two different static files, it halts further attempts by returning
-        // an error, effectively preventing infinite retry loops.
-        let mut retrying = false;
-
         // advances number in range
         'outer: for number in range {
+
+            // The `retrying` flag ensures a single retry attempt per `number`. If `get_fn` fails to
+            // access data in two different static files, it halts further attempts by returning
+            // an error, effectively preventing infinite retry loops.
+            let mut retrying = false;
+            
             // advances snapshot files if `get_fn` returns None
             'inner: loop {
                 match get_fn(&mut cursor, number)? {


### PR DESCRIPTION
This PR fixes two edge case scenarios.

`get_or_create_jar_provider`: change from `.insert` to `entry` api. Although not encountered, it is possible that two parallel threads reach the `self.map.insert` almost at the same time. The first one holding the lock would insert a `LoadedJar`. The second one once unblocked, would do the same thing invalidating the previous `LoadedJar` and potentially affecting the first threads task.

`fetch_range_with_predicate`: on a normal node behaviour it shouldn't happen, but when testing stuff out we have encountered this.
