### PR TITLE
refactor: rename `blob_gas_price` to `blob_base_fee`

### DIFF
--- a/crates/rpc/rpc-api/src/eth.rs
+++ b/crates/rpc/rpc-api/src/eth.rs
@@ -209,9 +209,9 @@ pub trait EthApi {
     #[method(name = "maxPriorityFeePerGas")]
     async fn max_priority_fee_per_gas(&self) -> RpcResult<U256>;
 
-    /// Introduced in EIP-4844, returns the current blob gas price in wei.
-    #[method(name = "blobGasPrice")]
-    async fn blob_gas_price(&self) -> RpcResult<U256>;
+    /// Introduced in EIP-4844, returns the current blob base fee in wei.
+    #[method(name = "blobBaseFee")]
+    async fn blob_base_fee(&self) -> RpcResult<U256>;
 
     /// Returns the Transaction fee history
     ///

--- a/crates/rpc/rpc/src/eth/api/fees.rs
+++ b/crates/rpc/rpc/src/eth/api/fees.rs
@@ -34,11 +34,11 @@ where
         Ok(suggested_tip + U256::from(base_fee))
     }
 
-    /// Returns a suggestion for a gas price for blob transactions.
-    pub(crate) async fn blob_gas_price(&self) -> EthResult<U256> {
+    /// Returns a suggestion for a base fee for blob transactions.
+    pub(crate) async fn blob_base_fee(&self) -> EthResult<U256> {
         self.block(BlockNumberOrTag::Latest)
             .await?
-            .and_then(|h| h.next_block_blob_fee())
+            .and_then(|h: reth_primitives::SealedBlock| h.next_block_blob_fee())
             .ok_or(EthApiError::ExcessBlobGasNotSet)
             .map(U256::from)
     }

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -298,10 +298,10 @@ where
         return Ok(EthApi::gas_price(self).await?)
     }
 
-    /// Handler for: `eth_blobGasPrice`
+    /// Handler for: `eth_blobBaseFee`
     async fn blob_gas_price(&self) -> Result<U256> {
-        trace!(target: "rpc::eth", "Serving eth_blobGasPrice");
-        return Ok(EthApi::blob_gas_price(self).await?)
+        trace!(target: "rpc::eth", "Serving eth_blobBaseFee");
+        return Ok(EthApi::blob_base_fee(self).await?)
     }
 
     /// Handler for: `eth_maxPriorityFeePerGas`

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -299,7 +299,7 @@ where
     }
 
     /// Handler for: `eth_blobBaseFee`
-    async fn blob_gas_price(&self) -> Result<U256> {
+    async fn blob_base_fee(&self) -> Result<U256> {
         trace!(target: "rpc::eth", "Serving eth_blobBaseFee");
         return Ok(EthApi::blob_base_fee(self).await?)
     }

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -1088,7 +1088,7 @@ where
     pub(crate) async fn eip4844_blob_fee(&self, blob_fee: Option<U256>) -> EthResult<U256> {
         match blob_fee {
             Some(blob_fee) => Ok(blob_fee),
-            None => self.blob_gas_price().await,
+            None => self.blob_base_fee().await,
         }
     }
 }

--- a/crates/rpc/rpc/src/eth/error.rs
+++ b/crates/rpc/rpc/src/eth/error.rs
@@ -342,7 +342,7 @@ pub enum RpcInvalidTransactionError {
     /// hardfork.
     #[error("blob_versioned_hashes is not supported for blocks before the Cancun hardfork")]
     BlobVersionedHashesNotSupported,
-    /// Block `blob_gas_price` is greater than tx-specified `max_fee_per_blob_gas` after Cancun.
+    /// Block `blob_base_fee` is greater than tx-specified `max_fee_per_blob_gas` after Cancun.
     #[error("max fee per blob gas less than block blob gas fee")]
     BlobFeeCapTooLow,
     /// Blob transaction has a versioned hash with an invalid blob


### PR DESCRIPTION
closes: https://github.com/paradigmxyz/reth/issues/6330
The function `calc_blob_gasprice` in 
https://github.com/paradigmxyz/reth/blob/84b13286f0046df773ace64902301ec805d55b6a/crates/primitives/src/header.rs#L239-L241
is defined in another project `revm-primitives`, so I didn't rename it. 