### PR TITLE
Fix(rpc) Effective gas_price for simulations

### DIFF
--- a/crates/rpc/rpc/src/eth/revm_utils.rs
+++ b/crates/rpc/rpc/src/eth/revm_utils.rs
@@ -739,7 +739,7 @@ mod tests {
         let call_fees = CallFees::ensure_fees(
             None,
             Some(U256::from(5 * GWEI_TO_WEI)),
-            Some(U256::from(1 * GWEI_TO_WEI)),
+            Some(U256::from(GWEI_TO_WEI)),
             U256::from(15 * GWEI_TO_WEI),
             None,
             None,


### PR DESCRIPTION
Atm there is no consideration of max_priority_fee_per_gas to compute the effective gas price of a tx in RPC simulations. I was able to find a transaction that landed on mainnet but reverts when simulated via RPC. This should fix it.

Regarding the comment "If no `gasPrice` or `maxFeePerGas` is set, then the `gas_price` in the returned `gas_price` will be `0`"; I deleted it since it wasn't true: `let max_fee = max_fee_per_gas.unwrap_or(block_base_fee);`

If that's actually the behaviour wanted lmk