### PR TITLE
chore: remove some unnecessary calls to `unwrap`/`expect`

### DIFF
--- a/crates/ethereum-forks/src/forkid.rs
+++ b/crates/ethereum-forks/src/forkid.rs
@@ -365,7 +365,7 @@ impl Cache {
 
         // Create ForkId using the last past fork's hash and the next epoch start.
         let fork_id = ForkId {
-            hash: past.last().expect("there is always at least one - genesis - fork hash; qed").1,
+            hash: past.last().expect("there is always at least one - genesis - fork hash").1,
             next: epoch_end.unwrap_or(ForkFilterKey::Block(0)).into(),
         };
 

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -545,8 +545,7 @@ impl Discv4Service {
             for (key, val) in config.additional_eip868_rlp_pairs.iter() {
                 builder.add_value_rlp(key, val.clone());
             }
-
-            builder.build(&secret_key).expect("v4 is set; qed")
+            builder.build(&secret_key).expect("v4 is set")
         };
 
         let (to_service, commands_rx) = mpsc::unbounded_channel();

--- a/crates/net/discv4/src/proto.rs
+++ b/crates/net/discv4/src/proto.rs
@@ -113,7 +113,7 @@ impl Message {
         // Sign the payload with the secret key using recoverable ECDSA
         let signature: RecoverableSignature = SECP256K1.sign_ecdsa_recoverable(
             &secp256k1::Message::from_slice(keccak256(&payload).as_ref())
-                .expect("is correct MESSAGE_SIZE; qed"),
+                .expect("B256.len() == MESSAGE_SIZE"),
             secret_key,
         );
 

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -138,7 +138,7 @@ impl StateFetcher {
 
         let Some(peer_id) = self.next_peer() else { return PollAction::NoPeersAvailable };
 
-        let request = self.queued_requests.pop_front().expect("not empty; qed");
+        let request = self.queued_requests.pop_front().expect("not empty");
         let request = self.prepare_block_request(peer_id, request);
 
         PollAction::Ready(FetchAction::BlockRequest { peer_id, request })

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -870,7 +870,7 @@ where
                 // Send a `NewPooledTransactionHashes` to the peer with up to
                 // `SOFT_LIMIT_COUNT_HASHES_IN_NEW_POOLED_TRANSACTIONS_BROADCAST_MESSAGE`
                 // transactions in the pool.
-                if !self.network.is_initially_syncing() && !self.network.tx_gossip_disabled() {
+                if self.network.is_initially_syncing() || self.network.tx_gossip_disabled() {
                     return
                 }
 

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -857,36 +857,39 @@ where
             NetworkEvent::SessionEstablished {
                 peer_id, client_version, messages, version, ..
             } => {
-                // insert a new peer into the peerset
-                self.peers.insert(peer_id, Peer::new(messages, version, client_version));
+                // Insert a new peer into the peerset.
+                let peer = Peer::new(messages, version, client_version);
+                let peer = match self.peers.entry(peer_id) {
+                    Entry::Occupied(mut entry) => {
+                        entry.insert(peer);
+                        entry.into_mut()
+                    }
+                    Entry::Vacant(entry) => entry.insert(peer),
+                };
 
                 // Send a `NewPooledTransactionHashes` to the peer with up to
-                // `NEW_POOLED_TRANSACTION_HASHES_SOFT_LIMIT` transactions in the
-                // pool
-                if !self.network.is_initially_syncing() {
-                    if self.network.tx_gossip_disabled() {
-                        return
-                    }
-                    let peer = self.peers.get_mut(&peer_id).expect("is present; qed");
-
-                    let mut msg_builder = PooledTransactionsHashesBuilder::new(version);
-
-                    let pooled_txs = self.pool.pooled_transactions_max(
-                        SOFT_LIMIT_COUNT_HASHES_IN_NEW_POOLED_TRANSACTIONS_BROADCAST_MESSAGE,
-                    );
-                    if pooled_txs.is_empty() {
-                        // do not send a message if there are no transactions in the pool
-                        return
-                    }
-
-                    for pooled_tx in pooled_txs.into_iter() {
-                        peer.seen_transactions.insert(*pooled_tx.hash());
-                        msg_builder.push_pooled(pooled_tx);
-                    }
-
-                    let msg = msg_builder.build();
-                    self.network.send_transactions_hashes(peer_id, msg);
+                // `SOFT_LIMIT_COUNT_HASHES_IN_NEW_POOLED_TRANSACTIONS_BROADCAST_MESSAGE`
+                // transactions in the pool.
+                if !self.network.is_initially_syncing() && !self.network.tx_gossip_disabled() {
+                    return
                 }
+
+                let pooled_txs = self.pool.pooled_transactions_max(
+                    SOFT_LIMIT_COUNT_HASHES_IN_NEW_POOLED_TRANSACTIONS_BROADCAST_MESSAGE,
+                );
+                if pooled_txs.is_empty() {
+                    // do not send a message if there are no transactions in the pool
+                    return
+                }
+
+                let mut msg_builder = PooledTransactionsHashesBuilder::new(version);
+                for pooled_tx in pooled_txs {
+                    peer.seen_transactions.insert(*pooled_tx.hash());
+                    msg_builder.push_pooled(pooled_tx);
+                }
+
+                let msg = msg_builder.build();
+                self.network.send_transactions_hashes(peer_id, msg);
             }
             _ => {}
         }

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -500,6 +500,8 @@ impl<'a> ReceiptWithBloomEncoder<'a> {
         }
 
         match self.receipt.tx_type {
+            TxType::Legacy => unreachable!("legacy already handled"),
+
             TxType::EIP2930 => {
                 out.put_u8(0x01);
             }
@@ -513,7 +515,6 @@ impl<'a> ReceiptWithBloomEncoder<'a> {
             TxType::DEPOSIT => {
                 out.put_u8(0x7E);
             }
-            _ => unreachable!("legacy handled; qed."),
         }
         out.put_slice(payload.as_ref());
     }

--- a/crates/primitives/src/transaction/signature.rs
+++ b/crates/primitives/src/transaction/signature.rs
@@ -42,18 +42,16 @@ impl Compact for Signature {
     where
         B: bytes::BufMut + AsMut<[u8]>,
     {
-        buf.put_slice(self.r.as_le_bytes().as_ref());
-        buf.put_slice(self.s.as_le_bytes().as_ref());
+        buf.put_slice(&self.r.as_le_bytes());
+        buf.put_slice(&self.s.as_le_bytes());
         self.odd_y_parity as usize
     }
 
     fn from_compact(mut buf: &[u8], identifier: usize) -> (Self, &[u8]) {
-        let r = U256::try_from_le_slice(&buf[..32]).expect("qed");
-        buf.advance(32);
-
-        let s = U256::try_from_le_slice(&buf[..32]).expect("qed");
-        buf.advance(32);
-
+        assert!(buf.len() >= 64);
+        let r = U256::from_le_slice(&buf[0..32]);
+        let s = U256::from_le_slice(&buf[32..64]);
+        buf.advance(64);
         (Signature { r, s, odd_y_parity: identifier != 0 }, buf)
     }
 }

--- a/crates/rpc/ipc/src/server/future.rs
+++ b/crates/rpc/ipc/src/server/future.rs
@@ -195,7 +195,7 @@ impl ConnectionGuard {
         match self.0.clone().try_acquire_owned() {
             Ok(guard) => Some(guard),
             Err(TryAcquireError::Closed) => {
-                unreachable!("Semaphore::Close is never called and can't be closed; qed")
+                unreachable!("Semaphore::Close is never called and can't be closed")
             }
             Err(TryAcquireError::NoPermits) => None,
         }

--- a/crates/rpc/rpc/src/eth/api/state.rs
+++ b/crates/rpc/rpc/src/eth/api/state.rs
@@ -48,25 +48,11 @@ where
         block_id: Option<BlockId>,
     ) -> EthResult<U256> {
         if let Some(BlockId::Number(BlockNumberOrTag::Pending)) = block_id {
-            // lookup transactions in pool
             let address_txs = self.pool().get_transactions_by_sender(address);
-
-            if !address_txs.is_empty() {
-                // get max transaction with the highest nonce
-                let highest_nonce_tx = address_txs
-                    .into_iter()
-                    .reduce(|accum, item| {
-                        if item.transaction.nonce() > accum.transaction.nonce() {
-                            item
-                        } else {
-                            accum
-                        }
-                    })
-                    .expect("Not empty; qed");
-
-                let tx_count = highest_nonce_tx
-                    .transaction
-                    .nonce()
+            if let Some(highest_nonce) =
+                address_txs.iter().map(|item| item.transaction.nonce()).max()
+            {
+                let tx_count = highest_nonce
                     .checked_add(1)
                     .ok_or(RpcInvalidTransactionError::NonceMaxValue)?;
                 return Ok(U256::from(tx_count))

--- a/crates/rpc/rpc/src/eth/gas_oracle.rs
+++ b/crates/rpc/rpc/src/eth/gas_oracle.rs
@@ -191,7 +191,7 @@ where
             results.sort_unstable();
             price = *results
                 .get((results.len() - 1) * self.oracle_config.percentile as usize / 100)
-                .expect("gas price index is a percent of nonzero array length, so a value always exists; qed");
+                .expect("gas price index is a percent of nonzero array length, so a value always exists");
         }
 
         // constrain to the max price

--- a/crates/rpc/rpc/src/eth/pubsub.rs
+++ b/crates/rpc/rpc/src/eth/pubsub.rs
@@ -305,7 +305,7 @@ where
     fn log_stream(&self, filter: FilteredParams) -> impl Stream<Item = Log> {
         BroadcastStream::new(self.chain_events.subscribe_to_canonical_state())
             .map(move |canon_state| {
-                canon_state.expect("new block subscription never ends; qed").block_receipts()
+                canon_state.expect("new block subscription never ends").block_receipts()
             })
             .flat_map(futures::stream::iter)
             .flat_map(move |(block_receipts, removed)| {

--- a/crates/storage/provider/src/providers/snapshot/manager.rs
+++ b/crates/storage/provider/src/providers/snapshot/manager.rs
@@ -159,16 +159,14 @@ impl SnapshotProvider {
         if let Some(jar) = self.map.get(&key) {
             Ok(jar.into())
         } else {
-            let jar = NippyJar::load(&self.path.join(segment.filename(block_range, tx_range)))
-                .map(|jar| {
-                if self.load_filters {
-                    return jar.load_filters()
-                }
-                Ok(jar)
-            })??;
-
-            self.map.insert(key, LoadedJar::new(jar)?);
-            Ok(self.map.get(&key).expect("qed").into())
+            let path = self.path.join(segment.filename(block_range, tx_range));
+            let mut jar = NippyJar::load(&path)?;
+            if self.load_filters {
+                jar.load_filters()?;
+            }
+            let loaded_jar = LoadedJar::new(jar)?;
+            self.map.insert(key, loaded_jar);
+            Ok(self.map.get(&key).unwrap().into())
         }
     }
 

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -350,7 +350,8 @@ where
         transaction: Self::Transaction,
     ) -> PoolResult<TxHash> {
         let (_, tx) = self.validate(origin, transaction).await;
-        self.pool.add_transactions(origin, std::iter::once(tx)).pop().expect("exists; qed")
+        let mut results = self.pool.add_transactions(origin, std::iter::once(tx));
+        results.pop().expect("result length is the same as the input")
     }
 
     async fn add_transactions(

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -476,7 +476,8 @@ where
             let mut listener = self.event_listener.write();
             listener.subscribe(tx.tx_hash())
         };
-        self.add_transactions(origin, std::iter::once(tx)).pop().expect("exists; qed")?;
+        let mut results = self.add_transactions(origin, std::iter::once(tx));
+        results.pop().expect("result length is the same as the input")?;
         Ok(listener)
     }
 

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -1581,7 +1581,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
             } else {
                 // The transaction was added above so the _inclusive_ descendants iterator
                 // returns at least 1 tx.
-                let (id, tx) = descendants.peek().expect("Includes >= 1; qed.");
+                let (id, tx) = descendants.peek().expect("includes >= 1");
                 if id.nonce < inserted_tx_id.nonce {
                     !tx.state.is_pending()
                 } else {

--- a/docs/crates/network.md
+++ b/docs/crates/network.md
@@ -440,7 +440,7 @@ fn poll_action(&mut self) -> PollAction {
         return PollAction::NoPeersAvailable
     };
 
-    let request = self.queued_requests.pop_front().expect("not empty; qed");
+    let request = self.queued_requests.pop_front().expect("not empty");
     let request = self.prepare_block_request(peer_id, request);
 
     PollAction::Ready(FetchAction::BlockRequest { peer_id, request })


### PR DESCRIPTION
Mostly using `entry` and `insert*` APIs to avoid double lookups in maps and `unwrap`/`expect` in options.

Also some cleanups along the way.