### PR TITLE
fix(op): Correct `Cancun` activation check in OP payload builder

### DIFF
--- a/crates/payload/builder/src/optimism.rs
+++ b/crates/payload/builder/src/optimism.rs
@@ -110,7 +110,7 @@ impl PayloadBuilderAttributes for OptimismPayloadBuilderAttributes {
         let blob_excess_gas_and_price = parent
             .next_block_excess_blob_gas()
             .or_else(|| {
-                if spec_id >= SpecId::CANCUN {
+                if spec_id.is_enabled_in(SpecId::CANCUN) {
                     // default excess blob gas is zero
                     Some(0)
                 } else {

--- a/crates/payload/builder/src/optimism.rs
+++ b/crates/payload/builder/src/optimism.rs
@@ -110,7 +110,7 @@ impl PayloadBuilderAttributes for OptimismPayloadBuilderAttributes {
         let blob_excess_gas_and_price = parent
             .next_block_excess_blob_gas()
             .or_else(|| {
-                if spec_id == SpecId::CANCUN {
+                if spec_id >= SpecId::CANCUN {
                     // default excess blob gas is zero
                     Some(0)
                 } else {


### PR DESCRIPTION
Ecotone is activated at the same time as Cancun, and has a higher precedence than Cancun in the `SpecId`. This change checks if the `SpecId` is >= `Cancun`, rather than `==` to `Cancun`