### PR TITLE
fix: `BlockNumberAddress` related doc and namings

### DIFF
--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -114,7 +114,7 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
         let mut ommers_cursor = tx.cursor_write::<tables::BlockOmmers>()?;
         let mut withdrawals_cursor = tx.cursor_write::<tables::BlockWithdrawals>()?;
 
-        // Get id for the next tx_num of zero if there are no transactions.
+        // Get id for the next tx_num or zero if there are no transactions.
         let mut next_tx_num = tx_cursor.last()?.map(|(id, _)| id + 1).unwrap_or_default();
 
         debug!(target: "sync::stages::bodies", stage_progress = from_block, target = to_block, start_tx_id = next_tx_num, "Commencing sync");

--- a/crates/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/src/stages/hashing_storage.rs
@@ -621,24 +621,24 @@ mod tests {
         fn insert_storage_entry<TX: DbTxMut>(
             &self,
             tx: &TX,
-            tid_address: BlockNumberAddress,
+            bn_address: BlockNumberAddress,
             entry: StorageEntry,
             hash: bool,
         ) -> Result<(), reth_db::DatabaseError> {
             let mut storage_cursor = tx.cursor_dup_write::<tables::PlainStorageState>()?;
             let prev_entry =
-                match storage_cursor.seek_by_key_subkey(tid_address.address(), entry.key)? {
+                match storage_cursor.seek_by_key_subkey(bn_address.address(), entry.key)? {
                     Some(e) if e.key == entry.key => {
-                        tx.delete::<tables::PlainStorageState>(tid_address.address(), Some(e))
+                        tx.delete::<tables::PlainStorageState>(bn_address.address(), Some(e))
                             .expect("failed to delete entry");
                         e
                     }
                     _ => StorageEntry { key: entry.key, value: U256::from(0) },
                 };
-            tx.put::<tables::PlainStorageState>(tid_address.address(), entry)?;
+            tx.put::<tables::PlainStorageState>(bn_address.address(), entry)?;
 
             if hash {
-                let hashed_address = keccak256(tid_address.address());
+                let hashed_address = keccak256(bn_address.address());
                 let hashed_entry = StorageEntry { key: keccak256(entry.key), value: entry.value };
 
                 if let Some(e) = tx
@@ -653,7 +653,7 @@ mod tests {
                 tx.put::<tables::HashedStorage>(hashed_address, hashed_entry)?;
             }
 
-            tx.put::<tables::StorageChangeSet>(tid_address, prev_entry)?;
+            tx.put::<tables::StorageChangeSet>(bn_address, prev_entry)?;
             Ok(())
         }
 

--- a/crates/stages/src/stages/merkle.rs
+++ b/crates/stages/src/stages/merkle.rs
@@ -572,14 +572,14 @@ mod tests {
 
                     let mut rev_changeset_walker =
                         storage_changesets_cursor.walk_back(None).unwrap();
-                    while let Some((tid_address, entry)) =
+                    while let Some((bn_address, entry)) =
                         rev_changeset_walker.next().transpose().unwrap()
                     {
-                        if tid_address.block_number() < target_block {
+                        if bn_address.block_number() < target_block {
                             break
                         }
 
-                        tree.entry(keccak256(tid_address.address()))
+                        tree.entry(keccak256(bn_address.address()))
                             .or_default()
                             .insert(keccak256(entry.key), entry.value);
                     }

--- a/crates/storage/db/src/tables/models/accounts.rs
+++ b/crates/storage/db/src/tables/models/accounts.rs
@@ -73,7 +73,7 @@ impl BlockNumberAddress {
         (*range.start(), Address::ZERO).into()..(*range.end() + 1, Address::ZERO).into()
     }
 
-    /// Return the transition id
+    /// Return the block number
     pub fn block_number(&self) -> BlockNumber {
         self.0 .0
     }
@@ -99,12 +99,12 @@ impl Encode for BlockNumberAddress {
     type Encoded = [u8; 28];
 
     fn encode(self) -> Self::Encoded {
-        let tx = self.0 .0;
+        let block_number = self.0 .0;
         let address = self.0 .1;
 
         let mut buf = [0u8; 28];
 
-        buf[..8].copy_from_slice(&tx.to_be_bytes());
+        buf[..8].copy_from_slice(&block_number.to_be_bytes());
         buf[8..].copy_from_slice(address.as_slice());
         buf
     }
@@ -129,7 +129,7 @@ mod tests {
     use std::str::FromStr;
 
     #[test]
-    fn test_tx_number_address() {
+    fn test_block_number_address() {
         let num = 1u64;
         let hash = Address::from_str("ba5e000000000000000000000000000000000000").unwrap();
         let key = BlockNumberAddress((num, hash));
@@ -146,7 +146,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tx_number_address_rand() {
+    fn test_block_number_address_rand() {
         let mut bytes = [0u8; 28];
         thread_rng().fill(bytes.as_mut_slice());
         let key = BlockNumberAddress::arbitrary(&mut Unstructured::new(&bytes)).unwrap();


### PR DESCRIPTION
#2275 switched from transition id to block number, but missed updating some doc and variable names accordingly