### PR TITLE
fix: `SegmentHeader` block range is now an `Option<_>`

### DIFF
--- a/crates/primitives/src/snapshot/segment.rs
+++ b/crates/primitives/src/snapshot/segment.rs
@@ -163,13 +163,13 @@ impl SegmentHeader {
     }
 
     /// Returns the block range.
-    pub fn block_range(&self) -> Option<SegmentRangeInclusive> {
-        self.block_range
+    pub fn block_range(&self) -> Option<&SegmentRangeInclusive> {
+        self.block_range.as_ref()
     }
 
     /// Returns the transaction range.
-    pub fn tx_range(&self) -> Option<SegmentRangeInclusive> {
-        self.tx_range
+    pub fn tx_range(&self) -> Option<&SegmentRangeInclusive> {
+        self.tx_range.as_ref()
     }
 
     /// The expected block start of the segment.
@@ -193,39 +193,21 @@ impl SegmentHeader {
     }
 
     /// Returns the first transaction number of the segment.  
-    ///  
-    /// ### Panics
-    ///
-    /// This method panics if `self.tx_range` is `None`.
-    #[track_caller]
-    pub fn tx_start(&self) -> TxNumber {
-        self.tx_range.as_ref().expect("should exist").start()
+    pub fn tx_start(&self) -> Option<TxNumber> {
+        self.tx_range.as_ref().map(|t| t.start())
     }
 
     /// Returns the last transaction number of the segment.   
-    ///
-    /// ### Panics
-    ///
-    /// This method panics if `self.tx_range` is `None`.
-    #[track_caller]
-    pub fn tx_end(&self) -> TxNumber {
-        self.tx_range.as_ref().expect("should exist").end()
+    pub fn tx_end(&self) -> Option<TxNumber> {
+        self.tx_range.as_ref().map(|t| t.end())
     }
 
     /// Number of transactions.  
-    ///
-    /// ### Panics
-    ///
-    /// This method panics if `self.tx_range` is `None`.
     pub fn tx_len(&self) -> Option<u64> {
         self.tx_range.as_ref().map(|r| (r.end() + 1) - r.start())
     }
 
     /// Number of blocks.
-    ///
-    /// ### Panics
-    ///
-    /// This method panics if `self.tx_range` is `None`.
     pub fn block_len(&self) -> Option<u64> {
         self.block_range.as_ref().map(|r| (r.end() + 1) - r.start())
     }
@@ -303,9 +285,9 @@ impl SegmentHeader {
     }
 
     /// Returns the row offset which depends on whether the segment is block or transaction based.
-    pub fn start(&self) -> u64 {
+    pub fn start(&self) -> Option<u64> {
         match self.segment {
-            SnapshotSegment::Headers => self.expected_block_start(),
+            SnapshotSegment::Headers => self.block_start(),
             SnapshotSegment::Transactions | SnapshotSegment::Receipts => self.tx_start(),
         }
     }

--- a/crates/primitives/src/snapshot/segment.rs
+++ b/crates/primitives/src/snapshot/segment.rs
@@ -177,6 +177,11 @@ impl SegmentHeader {
         self.expected_block_range.start()
     }
 
+    /// The expected block end of the segment.
+    pub fn expected_block_end(&self) -> BlockNumber {
+        self.expected_block_range.end()
+    }
+
     /// Returns the first block number of the segment.
     pub fn block_start(&self) -> Option<BlockNumber> {
         self.block_range.as_ref().map(|b| b.start())

--- a/crates/snapshot/src/segments/mod.rs
+++ b/crates/snapshot/src/segments/mod.rs
@@ -72,7 +72,7 @@ pub(crate) fn prepare_jar<DB: Database, const COLUMNS: usize>(
     let mut nippy_jar = NippyJar::new(
         COLUMNS,
         &directory.as_ref().join(segment.filename(&find_fixed_range(*block_range.end())).as_str()),
-        SegmentHeader::new(*block_range.start(), Some(block_range.into()), tx_range, segment),
+        SegmentHeader::new(block_range.clone().into(), Some(block_range.into()), tx_range, segment),
     );
 
     nippy_jar = match segment_config.compression {

--- a/crates/snapshot/src/segments/mod.rs
+++ b/crates/snapshot/src/segments/mod.rs
@@ -72,7 +72,7 @@ pub(crate) fn prepare_jar<DB: Database, const COLUMNS: usize>(
     let mut nippy_jar = NippyJar::new(
         COLUMNS,
         &directory.as_ref().join(segment.filename(&find_fixed_range(*block_range.end())).as_str()),
-        SegmentHeader::new(block_range.into(), tx_range, segment),
+        SegmentHeader::new(*block_range.start(), Some(block_range.into()), tx_range, segment),
     );
 
     nippy_jar = match segment_config.compression {

--- a/crates/snapshot/src/segments/receipts.rs
+++ b/crates/snapshot/src/segments/receipts.rs
@@ -32,10 +32,8 @@ impl<DB: Database> Segment<DB> for Receipts {
             snapshot_provider.get_writer(*block_range.start(), SnapshotSegment::Receipts)?;
 
         for block in block_range {
-            if block > 0 {
-                let _snapshot_block = snapshot_writer.increment_block(SnapshotSegment::Receipts)?;
-                debug_assert_eq!(_snapshot_block, block);
-            }
+            let _snapshot_block = snapshot_writer.increment_block(SnapshotSegment::Receipts)?;
+            debug_assert_eq!(_snapshot_block, block);
 
             let block_body_indices = provider
                 .block_body_indices(block)?

--- a/crates/snapshot/src/segments/transactions.rs
+++ b/crates/snapshot/src/segments/transactions.rs
@@ -34,11 +34,8 @@ impl<DB: Database> Segment<DB> for Transactions {
             snapshot_provider.get_writer(*block_range.start(), SnapshotSegment::Transactions)?;
 
         for block in block_range {
-            if block > 0 {
-                let _snapshot_block =
-                    snapshot_writer.increment_block(SnapshotSegment::Transactions)?;
-                debug_assert_eq!(_snapshot_block, block);
-            }
+            let _snapshot_block = snapshot_writer.increment_block(SnapshotSegment::Transactions)?;
+            debug_assert_eq!(_snapshot_block, block);
 
             let block_body_indices = provider
                 .block_body_indices(block)?

--- a/crates/storage/db/src/snapshot/mod.rs
+++ b/crates/storage/db/src/snapshot/mod.rs
@@ -48,14 +48,17 @@ pub fn iter_snapshots(path: impl AsRef<Path>) -> Result<SortedSnapshots, NippyJa
             {
                 let jar = NippyJar::<SegmentHeader>::load(&entry.path())?;
 
-                let ranges = (jar.user_header().block_range(), jar.user_header().tx_range());
+                let (block_range, tx_range) =
+                    (jar.user_header().block_range(), jar.user_header().tx_range());
 
-                match static_files.entry(segment) {
-                    Entry::Occupied(mut entry) => {
-                        entry.get_mut().push(ranges);
-                    }
-                    Entry::Vacant(entry) => {
-                        entry.insert(vec![ranges]);
+                if let Some(block_range) = block_range {
+                    match static_files.entry(segment) {
+                        Entry::Occupied(mut entry) => {
+                            entry.get_mut().push((block_range, tx_range));
+                        }
+                        Entry::Vacant(entry) => {
+                            entry.insert(vec![(block_range, tx_range)]);
+                        }
                     }
                 }
             }

--- a/crates/storage/db/src/snapshot/mod.rs
+++ b/crates/storage/db/src/snapshot/mod.rs
@@ -48,8 +48,10 @@ pub fn iter_snapshots(path: impl AsRef<Path>) -> Result<SortedSnapshots, NippyJa
             {
                 let jar = NippyJar::<SegmentHeader>::load(&entry.path())?;
 
-                let (block_range, tx_range) =
-                    (jar.user_header().block_range(), jar.user_header().tx_range());
+                let (block_range, tx_range) = (
+                    jar.user_header().block_range().copied(),
+                    jar.user_header().tx_range().copied(),
+                );
 
                 if let Some(block_range) = block_range {
                     match static_files.entry(segment) {

--- a/crates/storage/nippy-jar/src/writer.rs
+++ b/crates/storage/nippy-jar/src/writer.rs
@@ -119,6 +119,7 @@ impl<'a, H: NippyJarHeader> NippyJarWriter<'a, H> {
         // changes if necessary.
         if !is_created {
             writer.check_consistency_and_heal()?;
+            writer.commit()?;
         }
 
         Ok(writer)

--- a/crates/storage/provider/src/providers/snapshot/jar.rs
+++ b/crates/storage/provider/src/providers/snapshot/jar.rs
@@ -168,7 +168,7 @@ impl<'a> BlockNumReader for SnapshotJarProvider<'a> {
 
         Ok(cursor
             .get_one::<HeaderMask<BlockHash>>((&hash).into())?
-            .and_then(|res| (res == hash).then(|| cursor.number())))
+            .and_then(|res| (res == hash).then(|| cursor.number()).flatten()))
     }
 }
 
@@ -178,7 +178,7 @@ impl<'a> TransactionsProvider for SnapshotJarProvider<'a> {
 
         Ok(cursor
             .get_one::<TransactionMask<TransactionSignedNoHash>>((&hash).into())?
-            .and_then(|res| (res.hash() == hash).then(|| cursor.number())))
+            .and_then(|res| (res.hash() == hash).then(|| cursor.number()).flatten()))
     }
 
     fn transaction_by_id(&self, num: TxNumber) -> ProviderResult<Option<TransactionSigned>> {

--- a/crates/storage/provider/src/providers/snapshot/manager.rs
+++ b/crates/storage/provider/src/providers/snapshot/manager.rs
@@ -200,7 +200,12 @@ impl SnapshotProvider {
         };
 
         jar.delete()?;
-        self.update_index(segment, None)?;
+
+        let mut segment_max_block = None;
+        if !fixed_block_range.start() != 0 {
+            segment_max_block = Some(fixed_block_range.start() - 1)
+        };
+        self.update_index(segment, segment_max_block)?;
 
         Ok(())
     }

--- a/crates/storage/provider/src/providers/snapshot/manager.rs
+++ b/crates/storage/provider/src/providers/snapshot/manager.rs
@@ -314,7 +314,7 @@ impl SnapshotProvider {
 
                     // Current block range has the same block start as `fixed_range``, but block end
                     // might be different if we are still filling this static file.
-                    if let Some(current_block_range) = jar.user_header().block_range() {
+                    if let Some(current_block_range) = jar.user_header().block_range().copied() {
                         // Considering that `update_index` is called when we either append/truncate,
                         // we are sure that we are handling the latest data
                         // points.
@@ -882,7 +882,7 @@ impl TransactionsProvider for SnapshotProvider {
                 .and_then(|tx| (tx.hash() == tx_hash).then_some(tx))
                 .is_some()
             {
-                Ok(Some(cursor.number()))
+                Ok(cursor.number())
             } else {
                 Ok(None)
             }

--- a/crates/storage/provider/src/providers/snapshot/manager.rs
+++ b/crates/storage/provider/src/providers/snapshot/manager.rs
@@ -202,7 +202,7 @@ impl SnapshotProvider {
         jar.delete()?;
 
         let mut segment_max_block = None;
-        if !fixed_block_range.start() != 0 {
+        if fixed_block_range.start() > 0 {
             segment_max_block = Some(fixed_block_range.start() - 1)
         };
         self.update_index(segment, segment_max_block)?;

--- a/crates/storage/provider/src/providers/snapshot/mod.rs
+++ b/crates/storage/provider/src/providers/snapshot/mod.rs
@@ -64,7 +64,7 @@ mod tests {
         let row_count = 100u64;
         let range = 0..=(row_count - 1);
         let segment_header = SegmentHeader::new(
-            *range.start(),
+            range.clone().into(),
             Some(range.clone().into()),
             Some(range.clone().into()),
             SnapshotSegment::Headers,

--- a/crates/storage/provider/src/providers/snapshot/mod.rs
+++ b/crates/storage/provider/src/providers/snapshot/mod.rs
@@ -64,7 +64,8 @@ mod tests {
         let row_count = 100u64;
         let range = 0..=(row_count - 1);
         let segment_header = SegmentHeader::new(
-            range.clone().into(),
+            *range.start(),
+            Some(range.clone().into()),
             Some(range.clone().into()),
             SnapshotSegment::Headers,
         );

--- a/crates/storage/provider/src/providers/snapshot/writer.rs
+++ b/crates/storage/provider/src/providers/snapshot/writer.rs
@@ -5,7 +5,7 @@ use reth_db::codecs::CompactU256;
 use reth_interfaces::provider::{ProviderError, ProviderResult};
 use reth_nippy_jar::{NippyJar, NippyJarError, NippyJarWriter};
 use reth_primitives::{
-    snapshot::{find_fixed_range, SegmentHeader, SegmentRangeInclusive},
+    snapshot::{find_fixed_range, SegmentHeader},
     BlockHash, BlockNumber, Header, Receipt, SnapshotSegment, TransactionSignedNoHash, TxNumber,
     U256,
 };
@@ -51,13 +51,8 @@ impl<'a> SnapshotProviderRW<'a> {
                     (NippyJar::load(provider.data_path())?, provider.data_path().into())
                 }
                 Err(ProviderError::MissingSnapshotBlock(_, _)) => {
-                    // TODO(joshie): if its a receipt segment, we can find out the actual range.
-                    let tx_range = reader
-                        .get_highest_snapshot_tx(segment)
-                        .map(|tx| SegmentRangeInclusive::new(tx, tx));
                     let path = reader.directory().join(segment.filename(&block_range));
-
-                    (create_jar(segment, &path, block_range, tx_range), path)
+                    (create_jar(segment, &path, block_range.start()), path)
                 }
                 Err(err) => return Err(err),
             };
@@ -87,25 +82,33 @@ impl<'a> SnapshotProviderRW<'a> {
             "Commit"
         );
 
-        self.reader.update_index(self.writer.user_header().segment(), self.get_max_block())?;
+        self.update_index()?;
 
         Ok(())
     }
 
-    /// Get the maximum block of the current writer if it exists.
-    fn get_max_block(&self) -> Option<BlockNumber> {
-        let user_header = self.writer.user_header();
-        let mut max_block = Some(user_header.block_end());
-
-        if self.writer.user_header().segment().is_headers() {
-            // This can be a scenario where we pruned all blocks from the static file, including the
-            // genesis block.
-            if user_header.block_end() == 0 && self.writer.rows() == 0 {
-                max_block = None
+    /// Updates the `self.reader` internal index.
+    fn update_index(&self) -> ProviderResult<()> {
+        // We find the maximum block of the segment by checking this writer's last block.
+        //
+        // However if there's no block range (because there's no data), we try to calculate it by
+        // substracting 1 from the expected block start, resulting on the last block of the
+        // previous file.
+        //
+        // If that expected block start is 0, then it means that there's no actual block data, and
+        // there's no snapshotted block data.
+        let segment_max_block = match self.writer.user_header().block_range() {
+            Some(block_range) => Some(block_range.end()),
+            None => {
+                if self.writer.user_header().expected_block_start() > 0 {
+                    Some(self.writer.user_header().expected_block_start() - 1)
+                } else {
+                    None
+                }
             }
         };
 
-        max_block
+        self.reader.update_index(self.writer.user_header().segment(), segment_max_block)
     }
 
     /// Allows to increment the [`SegmentHeader`] end block. It will commit the current snapshot,
@@ -113,35 +116,26 @@ impl<'a> SnapshotProviderRW<'a> {
     ///
     /// Returns the current [`BlockNumber`] as seen in the static file.
     pub fn increment_block(&mut self, segment: SnapshotSegment) -> ProviderResult<BlockNumber> {
-        debug_assert!(
-            (self.writer.rows() as u64 + self.writer.user_header().block_end()) != 0
-            || !segment.is_headers(),
-            "This function should only be called by append_header when dealing with SnapshotSegment::Headers.");
+        if let Some(last_block) = self.writer.user_header().block_end() {
+            let writer_range_end = find_fixed_range(last_block).end();
 
-        let last_block = self.writer.user_header().block_end();
-        let writer_range_end = find_fixed_range(last_block).end();
+            // We have finished the previous snapshot and must freeze it
+            if last_block + 1 > writer_range_end {
+                // Commits offsets and new user_header to disk
+                self.commit()?;
 
-        // We have finished the previous snapshot and must freeze it
-        if last_block + 1 > writer_range_end {
-            // Commits offsets and new user_header to disk
-            self.commit()?;
+                // Opens the new snapshot
+                let (writer, data_path) = Self::open(segment, last_block + 1, self.reader.clone())?;
+                self.writer = writer;
+                self.data_path = data_path;
 
-            // Opens the new snapshot
-            let (writer, data_path) = Self::open(segment, last_block + 1, self.reader.clone())?;
-            self.writer = writer;
-            self.data_path = data_path;
-
-            let block_start = find_fixed_range(last_block + 1).start();
-            *self.writer.user_header_mut() = SegmentHeader::new(
-                SegmentRangeInclusive::new(block_start, block_start),
-                None,
-                segment,
-            )
-        } else {
-            self.writer.user_header_mut().increment_block()
+                let block_start = find_fixed_range(last_block + 1).start();
+                *self.writer.user_header_mut() =
+                    SegmentHeader::new(block_start, None, None, segment);
+            }
         }
 
-        Ok(self.writer.user_header().block_end())
+        Ok(self.writer.user_header_mut().increment_block())
     }
 
     /// Truncates a number of rows from disk. It deletes and loads an older snapshot file if block
@@ -159,9 +153,11 @@ impl<'a> SnapshotProviderRW<'a> {
     ) -> ProviderResult<()> {
         while num_rows > 0 {
             let len = match segment {
-                SnapshotSegment::Headers => self.writer.user_header().block_len(),
+                SnapshotSegment::Headers => {
+                    self.writer.user_header().block_len().unwrap_or_default()
+                }
                 SnapshotSegment::Transactions | SnapshotSegment::Receipts => {
-                    self.writer.user_header().tx_len()
+                    self.writer.user_header().tx_len().unwrap_or_default()
                 }
             };
 
@@ -169,12 +165,12 @@ impl<'a> SnapshotProviderRW<'a> {
                 // If there's more rows to delete than this snapshot contains, then just
                 // delete the whole file and go to the next snapshot
                 let previous_snap = self.data_path.clone();
-                let block_start = self.writer.user_header().block_start();
+                let block_start = self.writer.user_header().expected_block_start();
 
                 if block_start != 0 {
                     let (writer, data_path) = Self::open(
                         segment,
-                        self.writer.user_header().block_start() - 1,
+                        self.writer.user_header().expected_block_start() - 1,
                         self.reader.clone(),
                     )?;
                     self.writer = writer;
@@ -202,7 +198,7 @@ impl<'a> SnapshotProviderRW<'a> {
         // Only Transactions and Receipts
         if let Some(last_block) = last_block {
             let header = self.writer.user_header_mut();
-            header.set_block_range(header.block_start(), last_block);
+            header.set_block_range(header.expected_block_start(), last_block);
         }
 
         // Commits new changes to disk.
@@ -256,16 +252,13 @@ impl<'a> SnapshotProviderRW<'a> {
     ) -> ProviderResult<BlockNumber> {
         debug_assert!(self.writer.user_header().segment() == SnapshotSegment::Headers);
 
-        // Only increment the block number if this is NOT the genesis header
-        if !(self.writer.rows() == 0 && self.writer.user_header().block_end() == 0) {
-            self.increment_block(SnapshotSegment::Headers)?;
-        }
+        let block_number = self.increment_block(SnapshotSegment::Headers)?;
 
         self.append_column(header)?;
         self.append_column(CompactU256::from(terminal_difficulty))?;
         self.append_column(hash)?;
 
-        Ok(self.writer.user_header().block_end())
+        Ok(block_number)
     }
 
     /// Appends transaction to snapshot file.
@@ -354,17 +347,12 @@ impl<'a> Deref for SnapshotProviderRW<'a> {
 fn create_jar(
     segment: SnapshotSegment,
     path: &Path,
-    block_range: SegmentRangeInclusive,
-    tx_range: Option<SegmentRangeInclusive>,
+    expected_block_start: BlockNumber,
 ) -> NippyJar<SegmentHeader> {
     let mut jar = NippyJar::new(
         segment.columns(),
         path,
-        SegmentHeader::new(
-            SegmentRangeInclusive::new(block_range.start(), block_range.start()),
-            tx_range,
-            segment,
-        ),
+        SegmentHeader::new(expected_block_start, None, None, segment),
     );
 
     // Transaction and Receipt already have the compression scheme used natively in its encoding.

--- a/crates/storage/provider/src/providers/snapshot/writer.rs
+++ b/crates/storage/provider/src/providers/snapshot/writer.rs
@@ -127,12 +127,8 @@ impl<'a> SnapshotProviderRW<'a> {
                 self.writer = writer;
                 self.data_path = data_path;
 
-                *self.writer.user_header_mut() = SegmentHeader::new(
-                    find_fixed_range(last_block + 1).into(),
-                    None,
-                    None,
-                    segment,
-                );
+                *self.writer.user_header_mut() =
+                    SegmentHeader::new(find_fixed_range(last_block + 1), None, None, segment);
             }
         }
 
@@ -236,7 +232,7 @@ impl<'a> SnapshotProviderRW<'a> {
 
         self.append_column(value)?;
 
-        Ok(self.writer.user_header().tx_end())
+        Ok(self.writer.user_header().tx_end().expect("qed"))
     }
 
     /// Appends header to snapshot file.

--- a/crates/storage/provider/src/providers/snapshot/writer.rs
+++ b/crates/storage/provider/src/providers/snapshot/writer.rs
@@ -117,10 +117,8 @@ impl<'a> SnapshotProviderRW<'a> {
     /// Returns the current [`BlockNumber`] as seen in the static file.
     pub fn increment_block(&mut self, segment: SnapshotSegment) -> ProviderResult<BlockNumber> {
         if let Some(last_block) = self.writer.user_header().block_end() {
-            let writer_range_end = find_fixed_range(last_block).end();
-
             // We have finished the previous snapshot and must freeze it
-            if last_block + 1 > writer_range_end {
+            if last_block == self.writer.user_header().expected_block_end() {
                 // Commits offsets and new user_header to disk
                 self.commit()?;
 


### PR DESCRIPTION
When a `SnapshotProviderRW` creates a new file, it commits the configuration before it can be used. And `block_range` was being initialized as `block.start..=block.start`.

However, there is the case that if the node is interrupted before the first commit of a new file, then on restart, the node would return the wrong highest block of the segment. It would return `block.start`, when in fact it's just an empty file.

This would have consequences when calling `get_snapshot_target`, where it would assume that we need `block.start + 1 -> tip` data.

Changing `SegmentHeader` block_range to an option should fix this.

**This will cause existing nodes on `feat/static-files` to be incompatible with this change, since the configuration file format changed**
To make this less painful, I'll create a small cli tool that can generate configuration files (`conf`) with the same ranges, and so they can replace the existing ones. 

--

* Additional fix where we make a consistency heal but weren't committing with `fsync` to disk