### PR TITLE
chore: rm unused op dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6661,7 +6661,6 @@ dependencies = [
  "reth-interfaces",
  "reth-node-api",
  "reth-node-ethereum",
- "reth-node-optimism",
  "reth-primitives",
  "reth-provider",
  "reth-trie",

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -29,7 +29,6 @@ tracing.workspace = true
 [dev-dependencies]
 reth-trie.workspace = true
 reth-node-ethereum.workspace = true
-reth-node-optimism.workspace = true
 
 [features]
 optimism = [

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -597,9 +597,9 @@ mod tests {
         Account, Bytecode, Bytes, ChainSpecBuilder, ForkCondition, Signature, StorageKey,
         Transaction, TransactionKind, TxEip1559, MAINNET,
     };
-    #[cfg(feature = "optimism")]
-    use reth_provider::BundleStateWithReceipts;
-    use reth_provider::{AccountReader, BlockHashReader, StateRootProvider};
+    use reth_provider::{
+        AccountReader, BlockHashReader, BundleStateWithReceipts, StateRootProvider,
+    };
     use reth_trie::updates::TrieUpdates;
     use revm::{Database, TransitionState};
     use std::collections::HashMap;


### PR DESCRIPTION
this does not fix \ #6604

but unused anyway

@Rjected it's not ideal that we import the entire eth node crate here for testing
we could replicate the EthEvm type here which would solve the issue I believe

also #6611 contains some changes that get rid of these mutually exclusive functions entirely