### PR TITLE
`doc(hidden)` for `TransactionsManager` handle only used in tests

### DIFF
--- a/crates/net/network/src/test_utils/mod.rs
+++ b/crates/net/network/src/test_utils/mod.rs
@@ -7,4 +7,4 @@ pub use init::{
     enr_to_peer_id, unused_port, unused_tcp_addr, unused_tcp_and_udp_port, unused_tcp_udp,
     unused_udp_addr, unused_udp_port, GETH_TIMEOUT,
 };
-pub use testnet::{NetworkEventStream, Peer, PeerConfig, Testnet};
+pub use testnet::{NetworkEventStream, Peer, PeerConfig, PeerHandle, Testnet};

--- a/crates/net/network/src/test_utils/testnet.rs
+++ b/crates/net/network/src/test_utils/testnet.rs
@@ -491,10 +491,12 @@ impl<Pool> PeerHandle<Pool> {
         self.network.peer_id()
     }
 
+    /// Returns the [`PeersHandle`] from the network.
     pub fn peer_handle(&self) -> &PeersHandle {
         self.network.peers_handle()
     }
 
+    /// Returns the local socket as configured for the network.
     pub fn local_addr(&self) -> SocketAddr {
         self.network.local_addr()
     }

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -93,7 +93,7 @@ pub type PoolImportFuture = Pin<Box<dyn Future<Output = Vec<PoolResult<TxHash>>>
 /// This can be obtained via [TransactionsManager::handle] and can be used to manually interact with
 /// the [TransactionsManager] task once it is spawned.
 ///
-/// For example [TransactionsManager::get_peer_transaction_hashes] returns the transaction hashes
+/// For example [TransactionsHandle::get_peer_transaction_hashes] returns the transaction hashes
 /// known by a specific peer.
 #[derive(Debug, Clone)]
 pub struct TransactionsHandle {

--- a/examples/network-txpool.rs
+++ b/examples/network-txpool.rs
@@ -42,6 +42,9 @@ async fn main() -> eyre::Result<()> {
         .transactions(pool.clone(), transactions_manager_config)
         .split_with_handle();
 
+    // this can be used to interact with the `txpool` service directly
+    let _txs_handle = txpool.handle();
+
     // spawn the network task
     tokio::task::spawn(network);
     // spawn the pool task


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/6749.

Removes ambiguity around program flow in release, however by hiding docs and code comments since `TransactionCommand` channel is used in integration testing.