### PR TITLE
feat(storage): MDBX exclusive mode

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -64,7 +64,8 @@ pub struct DatabaseArguments {
     /// Maximum duration of a read transaction. If [None], the default value is used.
     max_read_transaction_duration: Option<MaxReadTransactionDuration>,
     /// Mdbx exclusive flag. If [None], the default value is used.
-    /// https://libmdbx.dqdkfa.ru/group__c__opening.html#gga9138119a904355d245777c4119534061aa516c74e6fed22c9812bb909c8c459ed
+    ///
+    /// See docs at: <https://libmdbx.dqdkfa.ru/group__c__opening.html#gga9138119a904355d245777c4119534061aa516c74e6fed22c9812bb909c8c459ed>
     exclusive: Option<bool>,
 }
 

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -64,6 +64,7 @@ pub struct DatabaseArguments {
     /// Maximum duration of a read transaction. If [None], the default value is used.
     max_read_transaction_duration: Option<MaxReadTransactionDuration>,
     /// Mdbx exclusive flag. If [None], the default value is used.
+    /// https://libmdbx.dqdkfa.ru/group__c__opening.html#gga9138119a904355d245777c4119534061aa516c74e6fed22c9812bb909c8c459ed
     exclusive: Option<bool>,
 }
 

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -274,7 +274,7 @@ impl DatabaseEnv {
             // worsens it for random access (which is our access pattern outside of sync)
             no_rdahead: true,
             coalesce: true,
-            exclusive: args.exclusive.is_some(),
+            exclusive: args.exclusive.unwrap_or_default(),
             ..Default::default()
         });
         // Configure more readers

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -266,7 +266,7 @@ impl DatabaseEnv {
             // worsens it for random access (which is our access pattern outside of sync)
             no_rdahead: true,
             coalesce: true,
-            exclusive: inner_env.is_exclusive(),
+            exclusive: args.exclusive,
             ..Default::default()
         });
         // Configure more readers

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -64,16 +64,24 @@ pub struct DatabaseArguments {
     /// Maximum duration of a read transaction. If [None], the default value is used.
     max_read_transaction_duration: Option<MaxReadTransactionDuration>,
     /// Open environment in exclusive/monopolistic mode. If [None], the default value is used.
-    /// 
-    /// This can be used as a replacement for `MDB_NOLOCK`, which don't supported by MDBX. In this way, you can get the minimal overhead, but with the correct multi-process and multi-thread locking.
-    /// 
-    /// If `true` = open environment in exclusive/monopolistic mode or return `MDBX_BUSY` if environment already used by other process. The main feature of the exclusive mode is the ability to open the environment placed on a network share.
-    /// 
-    /// If `false` = open environment in cooperative mode, i.e. for multi-process access/interaction/cooperation. The main requirements of the cooperative mode are:
+    ///
+    /// This can be used as a replacement for `MDB_NOLOCK`, which don't supported by MDBX. In this
+    /// way, you can get the minimal overhead, but with the correct multi-process and multi-thread
+    /// locking.
+    ///
+    /// If `true` = open environment in exclusive/monopolistic mode or return `MDBX_BUSY` if
+    /// environment already used by other process. The main feature of the exclusive mode is the
+    /// ability to open the environment placed on a network share.
+    ///
+    /// If `false` = open environment in cooperative mode, i.e. for multi-process
+    /// access/interaction/cooperation. The main requirements of the cooperative mode are:
     /// - Data files MUST be placed in the LOCAL file system, but NOT on a network share.
     /// - Environment MUST be opened only by LOCAL processes, but NOT over a network.
-    /// - OS kernel (i.e. file system and memory mapping implementation) and all processes that open the given environment MUST be running in the physically single RAM with cache-coherency. The only exception for cache-consistency requirement is Linux on MIPS architecture, but this case has not been tested for a long time).
-    /// 
+    /// - OS kernel (i.e. file system and memory mapping implementation) and all processes that
+    ///   open the given environment MUST be running in the physically single RAM with
+    ///   cache-coherency. The only exception for cache-consistency requirement is Linux on MIPS
+    ///   architecture, but this case has not been tested for a long time).
+    ///
     /// This flag affects only at environment opening but can't be changed after.
     exclusive: Option<bool>,
 }
@@ -266,7 +274,7 @@ impl DatabaseEnv {
             // worsens it for random access (which is our access pattern outside of sync)
             no_rdahead: true,
             coalesce: true,
-            exclusive: args.exclusive,
+            exclusive: args.exclusive.is_some(),
             ..Default::default()
         });
         // Configure more readers
@@ -326,10 +334,6 @@ impl DatabaseEnv {
 
         if let Some(max_read_transaction_duration) = args.max_read_transaction_duration {
             inner_env.set_max_read_transaction_duration(max_read_transaction_duration);
-        }
-
-        if let Some(exclusive) = args.exclusive {
-            inner_env.set_exclusive(exclusive);
         }
 
         let env = DatabaseEnv {

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -63,9 +63,18 @@ pub struct DatabaseArguments {
     log_level: Option<LogLevel>,
     /// Maximum duration of a read transaction. If [None], the default value is used.
     max_read_transaction_duration: Option<MaxReadTransactionDuration>,
-    /// Mdbx exclusive flag. If [None], the default value is used.
-    ///
-    /// See docs at: <https://libmdbx.dqdkfa.ru/group__c__opening.html#gga9138119a904355d245777c4119534061aa516c74e6fed22c9812bb909c8c459ed>
+    /// Open environment in exclusive/monopolistic mode. If [None], the default value is used.
+    /// 
+    /// This can be used as a replacement for `MDB_NOLOCK`, which don't supported by MDBX. In this way, you can get the minimal overhead, but with the correct multi-process and multi-thread locking.
+    /// 
+    /// If `true` = open environment in exclusive/monopolistic mode or return `MDBX_BUSY` if environment already used by other process. The main feature of the exclusive mode is the ability to open the environment placed on a network share.
+    /// 
+    /// If `false` = open environment in cooperative mode, i.e. for multi-process access/interaction/cooperation. The main requirements of the cooperative mode are:
+    /// - Data files MUST be placed in the LOCAL file system, but NOT on a network share.
+    /// - Environment MUST be opened only by LOCAL processes, but NOT over a network.
+    /// - OS kernel (i.e. file system and memory mapping implementation) and all processes that open the given environment MUST be running in the physically single RAM with cache-coherency. The only exception for cache-consistency requirement is Linux on MIPS architecture, but this case has not been tested for a long time).
+    /// 
+    /// This flag affects only at environment opening but can't be changed after.
     exclusive: Option<bool>,
 }
 

--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -54,7 +54,6 @@ impl Environment {
             handle_slow_readers: None,
             #[cfg(feature = "read-tx-timeouts")]
             max_read_transaction_duration: None,
-            exclusive: false,
         }
     }
 
@@ -580,8 +579,6 @@ pub struct EnvironmentBuilder {
     /// The maximum duration of a read transaction. If [None], but the `read-tx-timeout` feature is
     /// enabled, the default value of [DEFAULT_MAX_READ_TRANSACTION_DURATION] is used.
     max_read_transaction_duration: Option<read_transactions::MaxReadTransactionDuration>,
-    /// MDBX exclusive flag.
-    exclusive: bool,
 }
 
 impl EnvironmentBuilder {
@@ -725,10 +722,6 @@ impl EnvironmentBuilder {
         Ok(Environment { inner: Arc::new(env) })
     }
 
-    /// Returns true if mdbx exclusive flag is set.
-    pub fn is_exclusive(&self) -> bool {
-        self.exclusive
-    }
     /// Configures how this environment will be opened.
     pub fn set_kind(&mut self, kind: EnvironmentKind) -> &mut Self {
         self.kind = kind;
@@ -865,11 +858,6 @@ pub(crate) mod read_transactions {
             max_read_transaction_duration: MaxReadTransactionDuration,
         ) -> &mut Self {
             self.max_read_transaction_duration = Some(max_read_transaction_duration);
-            self
-        }
-        /// Set the mdbx exclusive flag.
-        pub fn set_exclusive(&mut self, exclusive: bool) -> &mut Self {
-            self.exclusive = exclusive;
             self
         }
     }

--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -725,6 +725,7 @@ impl EnvironmentBuilder {
         Ok(Environment { inner: Arc::new(env) })
     }
 
+    /// Returns true if mdbx exclusive flag is set.
     pub fn is_exclusive(&self) -> bool {
         self.exclusive
     }
@@ -866,7 +867,7 @@ pub(crate) mod read_transactions {
             self.max_read_transaction_duration = Some(max_read_transaction_duration);
             self
         }
-        /// Set the mdbx exclusive mode see https://libmdbx.dqdkfa.ru/group__c__opening.html#gga9138119a904355d245777c4119534061aa516c74e6fed22c9812bb909c8c459ed
+        /// Set the mdbx exclusive flag.
         pub fn set_exclusive(&mut self, exclusive: bool) -> &mut Self {
             self.exclusive = exclusive;
             self

--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -54,6 +54,7 @@ impl Environment {
             handle_slow_readers: None,
             #[cfg(feature = "read-tx-timeouts")]
             max_read_transaction_duration: None,
+            exclusive: false,
         }
     }
 
@@ -579,6 +580,8 @@ pub struct EnvironmentBuilder {
     /// The maximum duration of a read transaction. If [None], but the `read-tx-timeout` feature is
     /// enabled, the default value of [DEFAULT_MAX_READ_TRANSACTION_DURATION] is used.
     max_read_transaction_duration: Option<read_transactions::MaxReadTransactionDuration>,
+    /// MDBX exclusive flag.
+    exclusive: bool,
 }
 
 impl EnvironmentBuilder {
@@ -722,6 +725,9 @@ impl EnvironmentBuilder {
         Ok(Environment { inner: Arc::new(env) })
     }
 
+    pub fn is_exclusive(&self) -> bool {
+        self.exclusive
+    }
     /// Configures how this environment will be opened.
     pub fn set_kind(&mut self, kind: EnvironmentKind) -> &mut Self {
         self.kind = kind;
@@ -858,6 +864,11 @@ pub(crate) mod read_transactions {
             max_read_transaction_duration: MaxReadTransactionDuration,
         ) -> &mut Self {
             self.max_read_transaction_duration = Some(max_read_transaction_duration);
+            self
+        }
+        /// Set the mdbx exclusive mode see https://libmdbx.dqdkfa.ru/group__c__opening.html#gga9138119a904355d245777c4119534061aa516c74e6fed22c9812bb909c8c459ed
+        pub fn set_exclusive(&mut self, exclusive: bool) -> &mut Self {
+            self.exclusive = exclusive;
             self
         }
     }


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/6714

Hi @shekhirin ,

Does this mean it could be feasible to host the database file on NFS to support multiple readers alongside a single node writing to it?