### PR TITLE
Replace `#[async_trait]` with `->imp` for traits in eth_wire

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6066,7 +6066,6 @@ dependencies = [
  "alloy-rlp",
  "arbitrary",
  "async-stream",
- "async-trait",
  "bytes",
  "derive_more",
  "ethers-core",

--- a/crates/net/eth-wire/Cargo.toml
+++ b/crates/net/eth-wire/Cargo.toml
@@ -35,7 +35,6 @@ tokio-stream.workspace = true
 pin-project.workspace = true
 tracing.workspace = true
 snap = "1.0.5"
-async-trait.workspace = true
 
 # arbitrary utils
 arbitrary = { workspace = true, features = ["derive"], optional = true }

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -315,7 +315,6 @@ where
     }
 }
 
-#[async_trait::async_trait]
 impl<S> CanDisconnect<EthMessage> for EthStream<S>
 where
     S: CanDisconnect<Bytes> + Send,

--- a/crates/net/eth-wire/src/multiplex.rs
+++ b/crates/net/eth-wire/src/multiplex.rs
@@ -354,7 +354,6 @@ impl Sink<Bytes> for ProtocolProxy {
     }
 }
 
-#[async_trait::async_trait]
 impl CanDisconnect<Bytes> for ProtocolProxy {
     async fn disconnect(
         &mut self,

--- a/crates/net/eth-wire/src/muxdemux.rs
+++ b/crates/net/eth-wire/src/muxdemux.rs
@@ -280,7 +280,6 @@ where
     }
 }
 
-#[async_trait::async_trait]
 impl<S, E> CanDisconnect<Bytes> for MuxDemuxStream<S>
 where
     S: Sink<Bytes, Error = E> + CanDisconnect<Bytes> + Unpin + Send + Sync,
@@ -344,7 +343,6 @@ impl Sink<Bytes> for StreamClone {
     }
 }
 
-#[async_trait::async_trait]
 impl CanDisconnect<Bytes> for StreamClone {
     async fn disconnect(&mut self, _reason: DisconnectReason) -> Result<(), MuxDemuxError> {
         Err(CannotDisconnectP2PStream)

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -195,7 +195,6 @@ where
     }
 }
 
-#[async_trait::async_trait]
 impl<S> CanDisconnect<Bytes> for P2PStream<S>
 where
     S: Sink<Bytes, Error = io::Error> + Unpin + Send + Sync,

--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -13,7 +13,6 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
-use async_trait::async_trait;
 use reth_eth_wire::{DisconnectReason, EthVersion, Status};
 use reth_primitives::{NodeRecord, PeerId};
 use reth_rpc_types::NetworkStatus;
@@ -65,7 +64,6 @@ pub trait PeersInfo: Send + Sync {
 }
 
 /// Provides an API for managing the peers of the network.
-#[async_trait]
 pub trait Peers: PeersInfo {
     /// Adds a peer to the peer set.
     fn add_peer(&self, peer: PeerId, addr: SocketAddr) {
@@ -81,31 +79,42 @@ pub trait Peers: PeersInfo {
     fn add_peer_kind(&self, peer: PeerId, kind: PeerKind, addr: SocketAddr);
 
     /// Returns the rpc [PeerInfo] for all connected [PeerKind::Trusted] peers.
-    async fn get_trusted_peers(&self) -> Result<Vec<PeerInfo>, NetworkError> {
-        self.get_peers_by_kind(PeerKind::Trusted).await
+    fn get_trusted_peers(
+        &self,
+    ) -> impl Future<Output = Result<Vec<PeerInfo>, NetworkError>> + Send {
+        self.get_peers_by_kind(PeerKind::Trusted)
     }
 
     /// Returns the rpc [PeerInfo] for all connected [PeerKind::Basic] peers.
-    async fn get_basic_peers(&self) -> Result<Vec<PeerInfo>, NetworkError> {
-        self.get_peers_by_kind(PeerKind::Basic).await
+    fn get_basic_peers(&self) -> impl Future<Output = Result<Vec<PeerInfo>, NetworkError>> + Send {
+        self.get_peers_by_kind(PeerKind::Basic)
     }
 
     /// Returns the rpc [PeerInfo] for all connected peers with the given kind.
-    async fn get_peers_by_kind(&self, kind: PeerKind) -> Result<Vec<PeerInfo>, NetworkError>;
+    fn get_peers_by_kind(
+        &self,
+        kind: PeerKind,
+    ) -> impl Future<Output = Result<Vec<PeerInfo>, NetworkError>> + Send;
 
     /// Returns the rpc [PeerInfo] for all connected peers.
-    async fn get_all_peers(&self) -> Result<Vec<PeerInfo>, NetworkError>;
+    fn get_all_peers(&self) -> impl Future<Output = Result<Vec<PeerInfo>, NetworkError>> + Send;
 
     /// Returns the rpc [PeerInfo] for the given peer id.
     ///
     /// Returns `None` if the peer is not connected.
-    async fn get_peer_by_id(&self, peer_id: PeerId) -> Result<Option<PeerInfo>, NetworkError>;
+    fn get_peer_by_id(
+        &self,
+        peer_id: PeerId,
+    ) -> impl Future<Output = Result<Option<PeerInfo>, NetworkError>> + Send;
 
     /// Returns the rpc [PeerInfo] for the given peers if they are connected.
     ///
     /// Note: This only returns peers that are connected, unconnected peers are ignored but keeping
     /// the order in which they were requested.
-    async fn get_peers_by_id(&self, peer_ids: Vec<PeerId>) -> Result<Vec<PeerInfo>, NetworkError>;
+    fn get_peers_by_id(
+        &self,
+        peer_ids: Vec<PeerId>,
+    ) -> impl Future<Output = Result<Vec<PeerInfo>, NetworkError>> + Send;
 
     /// Removes a peer from the peer set that corresponds to given kind.
     fn remove_peer(&self, peer: PeerId, kind: PeerKind);
@@ -120,7 +129,10 @@ pub trait Peers: PeersInfo {
     fn reputation_change(&self, peer_id: PeerId, kind: ReputationChangeKind);
 
     /// Get the reputation of a peer.
-    async fn reputation_by_id(&self, peer_id: PeerId) -> Result<Option<Reputation>, NetworkError>;
+    fn reputation_by_id(
+        &self,
+        peer_id: PeerId,
+    ) -> impl Future<Output = Result<Option<Reputation>, NetworkError>> + Send;
 }
 
 /// Represents the kind of peer

--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 use reth_eth_wire::{DisconnectReason, EthVersion, Status};
 use reth_primitives::{NodeRecord, PeerId};
 use reth_rpc_types::NetworkStatus;
-use std::{net::SocketAddr, sync::Arc, time::Instant};
+use std::{future::Future, net::SocketAddr, sync::Arc, time::Instant};
 
 pub use error::NetworkError;
 pub use reputation::{Reputation, ReputationChangeKind};
@@ -32,13 +32,12 @@ pub mod reputation;
 pub mod noop;
 
 /// Provides general purpose information about the network.
-#[async_trait]
 pub trait NetworkInfo: Send + Sync {
     /// Returns the [`SocketAddr`] that listens for incoming connections.
     fn local_addr(&self) -> SocketAddr;
 
     /// Returns the current status of the network being ran by the local node.
-    async fn network_status(&self) -> Result<NetworkStatus, NetworkError>;
+    fn network_status(&self) -> impl Future<Output = Result<NetworkStatus, NetworkError>> + Send;
 
     /// Returns the chain id
     fn chain_id(&self) -> u64;

--- a/crates/net/network-api/src/noop.rs
+++ b/crates/net/network-api/src/noop.rs
@@ -22,7 +22,6 @@ use std::net::{IpAddr, SocketAddr};
 #[non_exhaustive]
 pub struct NoopNetwork;
 
-#[async_trait]
 impl NetworkInfo for NoopNetwork {
     fn local_addr(&self) -> SocketAddr {
         (IpAddr::from(std::net::Ipv4Addr::UNSPECIFIED), DEFAULT_DISCOVERY_PORT).into()

--- a/crates/net/network-api/src/noop.rs
+++ b/crates/net/network-api/src/noop.rs
@@ -8,7 +8,6 @@ use crate::{
     ReputationChangeKind,
 };
 use alloy_chains::Chain;
-use async_trait::async_trait;
 use reth_discv4::DEFAULT_DISCOVERY_PORT;
 use reth_eth_wire::{DisconnectReason, ProtocolVersion};
 use reth_primitives::{NodeRecord, PeerId};
@@ -68,7 +67,6 @@ impl PeersInfo for NoopNetwork {
     }
 }
 
-#[async_trait]
 impl Peers for NoopNetwork {
     fn add_peer_kind(&self, _peer: PeerId, _kind: PeerKind, _addr: SocketAddr) {}
 

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -288,7 +288,6 @@ impl Peers for NetworkHandle {
     }
 }
 
-#[async_trait]
 impl NetworkInfo for NetworkHandle {
     fn local_addr(&self) -> SocketAddr {
         *self.inner.listener_address.lock()

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -2,7 +2,6 @@ use crate::{
     config::NetworkMode, discovery::DiscoveryEvent, manager::NetworkEvent, message::PeerRequest,
     peers::PeersHandle, protocol::RlpxSubProtocol, swarm::NetworkConnectionState, FetchClient,
 };
-use async_trait::async_trait;
 use parking_lot::Mutex;
 use reth_eth_wire::{DisconnectReason, NewBlock, NewPooledTransactionHashes, SharedTransactions};
 use reth_interfaces::sync::{NetworkSyncUpdater, SyncState, SyncStateProvider};
@@ -226,7 +225,6 @@ impl PeersInfo for NetworkHandle {
     }
 }
 
-#[async_trait]
 impl Peers for NetworkHandle {
     /// Sends a message to the [`NetworkManager`](crate::NetworkManager) to add a peer to the known
     /// set, with the given kind.


### PR DESCRIPTION
Refer to https://github.com/paradigmxyz/reth/issues/6657
Replace `#[async_trait]` with `->imp` for traits in eth_wire: `CanDisconnect`, `NetworkInfo` and `Peer`.