### PR TITLE
Replace #[async_trait] with `->imp` for traits in `rpc_testing_util`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6733,7 +6733,6 @@ dependencies = [
 name = "reth-rpc-api-testing-util"
 version = "0.1.0-alpha.19"
 dependencies = [
- "async-trait",
  "futures",
  "jsonrpsee",
  "reth-primitives",

--- a/crates/rpc/rpc-testing-util/Cargo.toml
+++ b/crates/rpc/rpc-testing-util/Cargo.toml
@@ -18,7 +18,6 @@ reth-rpc-types.workspace = true
 reth-rpc-api = { workspace = true, features = ["client"] }
 
 # async
-async-trait.workspace = true
 futures.workspace = true
 
 # misc

--- a/crates/rpc/rpc-testing-util/src/debug.rs
+++ b/crates/rpc/rpc-testing-util/src/debug.rs
@@ -60,11 +60,11 @@ pub trait DebugApiExt {
         B: Into<BlockId> + Send;
 
     ///  method  for debug_traceCall
-    async fn debug_trace_call_json(
+    fn debug_trace_call_json(
         &self,
         request: TransactionRequest,
         opts: GethDebugTracingOptions,
-    ) -> Result<serde_json::Value, jsonrpsee::core::Error>;
+    ) -> impl Future<Output = Result<serde_json::Value, jsonrpsee::core::Error>> + Send;
 
     ///  method for debug_traceCall using raw JSON strings for the request and options.
     fn debug_trace_call_raw_json(

--- a/crates/rpc/rpc-testing-util/src/debug.rs
+++ b/crates/rpc/rpc-testing-util/src/debug.rs
@@ -15,6 +15,8 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
+use std::future::Future;
+
 const NOOP_TRACER: &str = include_str!("../assets/noop-tracer.js");
 const JS_TRACER_TEMPLATE: &str = include_str!("../assets/tracer-template.js");
 
@@ -26,24 +28,23 @@ pub type DebugTraceBlockResult =
     Result<(Vec<TraceResult<GethTrace, String>>, BlockId), (RpcError, BlockId)>;
 
 /// An extension trait for the Trace API.
-#[async_trait::async_trait]
 pub trait DebugApiExt {
     /// The provider type that is used to make the requests.
     type Provider;
 
     /// Same as [DebugApiClient::debug_trace_transaction] but returns the result as json.
-    async fn debug_trace_transaction_json(
+    fn debug_trace_transaction_json(
         &self,
         hash: B256,
         opts: GethDebugTracingOptions,
-    ) -> Result<serde_json::Value, jsonrpsee::core::Error>;
+    ) -> impl Future<Output=Result<serde_json::Value, jsonrpsee::core::Error>> + Send;
 
     /// Trace all transactions in a block individually with the given tracing opts.
-    async fn debug_trace_transactions_in_block<B>(
+    fn debug_trace_transactions_in_block<B>(
         &self,
         block: B,
         opts: GethDebugTracingOptions,
-    ) -> Result<DebugTraceTransactionsStream<'_>, jsonrpsee::core::Error>
+    ) -> impl Future<Output=Result<DebugTraceTransactionsStream<'_>, jsonrpsee::core::Error>> + Send
     where
         B: Into<BlockId> + Send;
 
@@ -66,14 +67,13 @@ pub trait DebugApiExt {
     ) -> Result<serde_json::Value, jsonrpsee::core::Error>;
 
     ///  method for debug_traceCall using raw JSON strings for the request and options.
-    async fn debug_trace_call_raw_json(
+    fn debug_trace_call_raw_json(
         &self,
         request_json: String,
         opts_json: String,
-    ) -> Result<serde_json::Value, RpcError>;
+    ) -> impl Future<Output=Result<serde_json::Value, RpcError>> + Send;
 }
 
-#[async_trait::async_trait]
 impl<T: DebugApiClient + Sync> DebugApiExt for T
 where
     T: EthApiClient,

--- a/crates/rpc/rpc-testing-util/src/debug.rs
+++ b/crates/rpc/rpc-testing-util/src/debug.rs
@@ -12,10 +12,10 @@ use reth_rpc_types::{
     TransactionRequest,
 };
 use std::{
+    future::Future,
     pin::Pin,
     task::{Context, Poll},
 };
-use std::future::Future;
 
 const NOOP_TRACER: &str = include_str!("../assets/noop-tracer.js");
 const JS_TRACER_TEMPLATE: &str = include_str!("../assets/tracer-template.js");
@@ -37,14 +37,14 @@ pub trait DebugApiExt {
         &self,
         hash: B256,
         opts: GethDebugTracingOptions,
-    ) -> impl Future<Output=Result<serde_json::Value, jsonrpsee::core::Error>> + Send;
+    ) -> impl Future<Output = Result<serde_json::Value, jsonrpsee::core::Error>> + Send;
 
     /// Trace all transactions in a block individually with the given tracing opts.
     fn debug_trace_transactions_in_block<B>(
         &self,
         block: B,
         opts: GethDebugTracingOptions,
-    ) -> impl Future<Output=Result<DebugTraceTransactionsStream<'_>, jsonrpsee::core::Error>> + Send
+    ) -> impl Future<Output = Result<DebugTraceTransactionsStream<'_>, jsonrpsee::core::Error>> + Send
     where
         B: Into<BlockId> + Send;
 
@@ -71,7 +71,7 @@ pub trait DebugApiExt {
         &self,
         request_json: String,
         opts_json: String,
-    ) -> impl Future<Output=Result<serde_json::Value, RpcError>> + Send;
+    ) -> impl Future<Output = Result<serde_json::Value, RpcError>> + Send;
 }
 
 impl<T: DebugApiClient + Sync> DebugApiExt for T

--- a/crates/rpc/rpc-testing-util/src/trace.rs
+++ b/crates/rpc/rpc-testing-util/src/trace.rs
@@ -46,7 +46,6 @@ pub type TraceFilterResult =
 pub type TraceCallResult = Result<TraceResults, (RpcError, TraceCallRequest)>;
 
 /// An extension trait for the Trace API.
-#[async_trait::async_trait]
 pub trait TraceApiExt {
     /// The provider type that is used to make the requests.
     type Provider;
@@ -236,7 +235,6 @@ impl<'a> std::fmt::Debug for ReplayTransactionStream<'a> {
     }
 }
 
-#[async_trait::async_trait]
 impl<T: TraceApiClient + Sync> TraceApiExt for T {
     type Provider = T;
 


### PR DESCRIPTION
Refer to https://github.com/paradigmxyz/reth/issues/6657
Replace `#[async_trait]` with `->imp` for traits in `rpc_testing_util`: DebugApiExt and TraceApiClient.