### PR TITLE
Disable jemalloc when cross-building aarch64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,8 +85,10 @@ op-build-native-%:
 # No jemalloc on Windows
 build-x86_64-pc-windows-gnu: FEATURES := $(filter-out jemalloc jemalloc-prof,$(FEATURES))
 
-# asm keccak optimizations not enabled
-build-aarch64-unknown-linux-gnu: FEATURES := $(filter-out asm-keccak,$(FEATURES))
+# Disable asm-keccak optimizations and jemalloc.
+# Some aarch64 systems use larger page sizes and jemalloc doesn't play well.
+# See: https://github.com/paradigmxyz/reth/issues/6742
+build-aarch64-unknown-linux-gnu: FEATURES := $(filter-out asm-keccak jemalloc jemalloc-prof,$(FEATURES))
 
 # Note: The additional rustc compiler flags are for intrinsics needed by MDBX.
 # See: https://github.com/cross-rs/cross/wiki/FAQ#undefined-reference-with-build-std


### PR DESCRIPTION
This PR will disable jemalloc when cross-building the binary for `aarch64-unknown-linux-gnu`.

This reth binary is used here:
https://github.com/paradigmxyz/reth/blob/21bc1a861b7e873ea6c9b9d014e16c3ff37efa9e/Makefile#L197-L212

And correct binary is selected here:
https://github.com/paradigmxyz/reth/blob/21bc1a861b7e873ea6c9b9d014e16c3ff37efa9e/Dockerfile.cross#L12

Fixes #6742.