### PR TITLE
Remove `async-trait` as dependency from crate `stages`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6872,7 +6872,6 @@ dependencies = [
  "alloy-rlp",
  "aquamarine",
  "assert_matches",
- "async-trait",
  "auto_impl",
  "criterion",
  "futures-util",

--- a/crates/stages/Cargo.toml
+++ b/crates/stages/Cargo.toml
@@ -33,7 +33,6 @@ revm.workspace = true
 # async
 tokio = { workspace = true, features = ["sync"] }
 tokio-stream.workspace = true
-async-trait.workspace = true
 futures-util.workspace = true
 pin-project.workspace = true
 

--- a/crates/stages/src/stage.rs
+++ b/crates/stages/src/stage.rs
@@ -7,7 +7,7 @@ use reth_primitives::{
 use reth_provider::{BlockReader, DatabaseProviderRW, ProviderError, TransactionsProvider};
 use std::{
     cmp::{max, min},
-    future::poll_fn,
+    future::{poll_fn, Future},
     ops::{Range, RangeInclusive},
     task::{Context, Poll},
 };
@@ -96,7 +96,7 @@ impl ExecInput {
 
         if all_tx_cnt == 0 {
             // if there is no more transaction return back.
-            return Ok((first_tx_num..first_tx_num, start_block..=target_block, true))
+            return Ok((first_tx_num..first_tx_num, start_block..=target_block, true));
         }
 
         // get block of this tx
@@ -247,12 +247,14 @@ pub trait Stage<DB: Database>: Send + Sync {
 }
 
 /// [Stage] trait extension.
-#[async_trait::async_trait]
 pub trait StageExt<DB: Database>: Stage<DB> {
     /// Utility extension for the `Stage` trait that invokes `Stage::poll_execute_ready`
     /// with [poll_fn] context. For more information see [Stage::poll_execute_ready].
-    async fn execute_ready(&mut self, input: ExecInput) -> Result<(), StageError> {
-        poll_fn(|cx| self.poll_execute_ready(cx, input)).await
+    fn execute_ready(
+        &mut self,
+        input: ExecInput,
+    ) -> impl Future<Output = Result<(), StageError>> + Send {
+        poll_fn(move |cx| self.poll_execute_ready(cx, input))
     }
 }
 

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -565,7 +565,6 @@ mod tests {
             }
         }
 
-        #[async_trait::async_trait]
         impl ExecuteStageTestRunner for BodyTestRunner {
             type Seed = Vec<SealedBlock>;
 

--- a/crates/stages/src/stages/hashing_account.rs
+++ b/crates/stages/src/stages/hashing_account.rs
@@ -520,7 +520,6 @@ mod tests {
             }
         }
 
-        #[async_trait::async_trait]
         impl ExecuteStageTestRunner for AccountHashingTestRunner {
             type Seed = Vec<(Address, Account)>;
 

--- a/crates/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/src/stages/hashing_storage.rs
@@ -477,7 +477,6 @@ mod tests {
         }
     }
 
-    #[async_trait::async_trait]
     impl ExecuteStageTestRunner for StorageHashingTestRunner {
         type Seed = Vec<SealedBlock>;
 

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -382,7 +382,6 @@ mod tests {
             }
         }
 
-        #[async_trait::async_trait]
         impl<D: HeaderDownloader + 'static> ExecuteStageTestRunner for HeadersTestRunner<D> {
             type Seed = Vec<SealedHeader>;
 

--- a/crates/stages/src/stages/merkle.rs
+++ b/crates/stages/src/stages/merkle.rs
@@ -460,7 +460,6 @@ mod tests {
         }
     }
 
-    #[async_trait::async_trait]
     impl ExecuteStageTestRunner for MerkleTestRunner {
         type Seed = Vec<SealedBlock>;
 

--- a/crates/stages/src/stages/total_difficulty.rs
+++ b/crates/stages/src/stages/total_difficulty.rs
@@ -224,7 +224,6 @@ mod tests {
         }
     }
 
-    #[async_trait::async_trait]
     impl ExecuteStageTestRunner for TotalDifficultyTestRunner {
         type Seed = Vec<SealedHeader>;
 


### PR DESCRIPTION
Refer to https://github.com/paradigmxyz/reth/issues/6657
Replace `#[async_trait]` with `->imp` for traits in `stages`: ExecuteStageTestRunner, UnwindStageTestRunner and StageExt.