### PR TITLE
chore: rm duplicated remove_pending_session call

### DIFF
--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -578,7 +578,6 @@ impl SessionManager {
                 Poll::Ready(SessionEvent::OutgoingConnectionError { remote_addr, peer_id, error })
             }
             PendingSessionEvent::EciesAuthError { remote_addr, session_id, error, direction } => {
-                self.remove_pending_session(&session_id);
                 trace!(
                     target: "net::session",
                     ?error,


### PR DESCRIPTION
we were calling this twice