### PR TITLE
Replace async trait with ->impl Future

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6248,7 +6248,6 @@ dependencies = [
  "alloy-node-bindings",
  "alloy-rlp",
  "aquamarine",
- "async-trait",
  "auto_impl",
  "criterion",
  "derive_more",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6948,7 +6948,6 @@ dependencies = [
  "alloy-rlp",
  "aquamarine",
  "assert_matches",
- "async-trait",
  "auto_impl",
  "bitflags 2.4.2",
  "criterion",

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -60,7 +60,6 @@ tracing.workspace = true
 fnv = "1.0"
 thiserror.workspace = true
 parking_lot.workspace = true
-async-trait.workspace = true
 linked_hash_set = "0.1"
 linked-hash-map = "0.5.6"
 rand.workspace = true

--- a/crates/net/network/tests/it/clique/clique_middleware.rs
+++ b/crates/net/network/tests/it/clique/clique_middleware.rs
@@ -1,7 +1,6 @@
 #![allow(unreachable_pub)]
 //! Helper extension traits for working with clique providers.
 
-use async_trait::async_trait;
 use enr::k256::ecdsa::SigningKey;
 use ethers_core::{
     types::{transaction::eip2718::TypedTransaction, Address, Block, BlockNumber, H256},
@@ -51,7 +50,6 @@ pub type CliqueMiddlewareError<M> = CliqueError<<M as Middleware>::Error>;
 
 /// Extension trait for [`Middleware`](ethers_providers::Middleware) to provide clique specific
 /// functionality.
-#[async_trait(?Send)]
 pub trait CliqueMiddleware: Send + Sync + Middleware {
     /// Enable mining on the clique geth instance by importing and unlocking the signer account
     /// derived from given private key and password.

--- a/crates/rpc/rpc-api/src/admin.rs
+++ b/crates/rpc/rpc-api/src/admin.rs
@@ -5,7 +5,6 @@ use reth_rpc_types::{NodeInfo, PeerInfo};
 /// Admin namespace rpc interface that gives access to several non-standard RPC methods.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "admin"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "admin"))]
-#[async_trait::async_trait]
 pub trait AdminApi {
     /// Adds the given node record to the peerset.
     #[method(name = "addPeer")]

--- a/crates/rpc/rpc-api/src/bundle.rs
+++ b/crates/rpc/rpc-api/src/bundle.rs
@@ -12,7 +12,6 @@ use reth_rpc_types::{
 /// A subset of the [EthBundleApi] API interface that only supports `eth_callBundle`.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "eth"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "eth"))]
-#[async_trait::async_trait]
 pub trait EthCallBundleApi {
     /// `eth_callBundle` can be used to simulate a bundle against a specific block number,
     /// including simulating a bundle at the top of the next block.
@@ -28,7 +27,6 @@ pub trait EthCallBundleApi {
 /// See also <https://docs.flashbots.net/flashbots-auction/searchers/advanced/rpc-endpoint>
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "eth"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "eth"))]
-#[async_trait::async_trait]
 pub trait EthBundleApi {
     /// `eth_sendBundle` can be used to send your bundles to the builder.
     #[method(name = "sendBundle")]

--- a/crates/rpc/rpc-api/src/engine.rs
+++ b/crates/rpc/rpc-api/src/engine.rs
@@ -165,7 +165,6 @@ pub trait EngineApi<Engine: EngineTypes> {
 /// Specifically for the engine auth server: <https://github.com/ethereum/execution-apis/blob/main/src/engine/common.md#underlying-protocol>
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "eth"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "eth"))]
-#[async_trait]
 pub trait EngineEthApi {
     /// Returns an object with data about the sync status or false.
     #[method(name = "syncing")]

--- a/crates/rpc/rpc-api/src/eth.rs
+++ b/crates/rpc/rpc-api/src/eth.rs
@@ -12,7 +12,6 @@ use reth_rpc_types::{
 /// Eth rpc interface: <https://ethereum.github.io/execution-apis/api-documentation/>
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "eth"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "eth"))]
-#[async_trait]
 pub trait EthApi {
     /// Returns the protocol version encoded as a string.
     #[method(name = "protocolVersion")]

--- a/crates/rpc/rpc-api/src/mev.rs
+++ b/crates/rpc/rpc-api/src/mev.rs
@@ -6,7 +6,6 @@ use reth_rpc_types::{
 /// Mev rpc interface.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "mev"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "mev"))]
-#[async_trait::async_trait]
 pub trait MevApi {
     /// Submitting bundles to the relay. It takes in a bundle and provides a bundle hash as a
     /// return value.

--- a/crates/rpc/rpc-api/src/txpool.rs
+++ b/crates/rpc/rpc-api/src/txpool.rs
@@ -5,7 +5,6 @@ use reth_rpc_types::txpool::{TxpoolContent, TxpoolContentFrom, TxpoolInspect, Tx
 /// Txpool rpc interface.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "txpool"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "txpool"))]
-#[async_trait::async_trait]
 pub trait TxPoolApi {
     /// Returns the number of transactions currently pending for inclusion in the next block(s), as
     /// well as the ones that are being scheduled for future execution only.

--- a/crates/rpc/rpc-api/src/validation.rs
+++ b/crates/rpc/rpc-api/src/validation.rs
@@ -6,7 +6,6 @@ use reth_rpc_types::relay::{BuilderBlockValidationRequest, BuilderBlockValidatio
 /// Block validation rpc interface.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "flashbots"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "flashbots"))]
-#[async_trait::async_trait]
 pub trait BlockSubmissionValidationApi {
     /// A Request to validate a block submission.
     #[method(name = "validateBuilderSubmissionV1")]

--- a/crates/rpc/rpc-api/src/web3.rs
+++ b/crates/rpc/rpc-api/src/web3.rs
@@ -4,7 +4,6 @@ use reth_primitives::{Bytes, B256};
 /// Web3 rpc interface.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "web3"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "web3"))]
-#[async_trait::async_trait]
 pub trait Web3Api {
     /// Returns current client version.
     #[method(name = "clientVersion")]

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -29,7 +29,6 @@ alloy-rlp.workspace = true
 reth-revm = { workspace = true, optional = true }
 
 # async/futures
-async-trait.workspace = true
 futures-util.workspace = true
 parking_lot.workspace = true
 tokio = { workspace = true, default-features = false, features = ["sync"] }

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -318,7 +318,6 @@ where
 }
 
 /// implements the `TransactionPool` interface for various transaction pool API consumers.
-#[async_trait::async_trait]
 impl<V, T, S> TransactionPool for Pool<V, T, S>
 where
     V: TransactionValidator,

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -29,7 +29,6 @@ use tokio::sync::{mpsc, mpsc::Receiver};
 #[non_exhaustive]
 pub struct NoopTransactionPool;
 
-#[async_trait::async_trait]
 impl TransactionPool for NoopTransactionPool {
     type Transaction = EthPooledTransaction;
 

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -247,7 +247,6 @@ pub struct MockTransactionValidator<T> {
     _marker: PhantomData<T>,
 }
 
-#[async_trait::async_trait]
 impl<T: PoolTransaction> TransactionValidator for MockTransactionValidator<T> {
     type Transaction = T;
 

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -67,7 +67,6 @@ where
     }
 }
 
-#[async_trait::async_trait]
 impl<Client, Tx> TransactionValidator for EthTransactionValidator<Client, Tx>
 where
     Client: StateProviderFactory + BlockReaderIdExt,

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -9,7 +9,7 @@ use reth_primitives::{
     Address, BlobTransactionSidecar, IntoRecoveredTransaction, SealedBlock,
     TransactionSignedEcRecovered, TxHash, B256, U256,
 };
-use std::{fmt, time::Instant};
+use std::{fmt, future::Future, time::Instant};
 
 mod constants;
 mod eth;
@@ -142,7 +142,6 @@ impl<T: PoolTransaction> ValidTransaction<T> {
 }
 
 /// Provides support for validating transaction at any given state of the chain
-#[async_trait::async_trait]
 pub trait TransactionValidator: Send + Sync {
     /// The transaction type to validate.
     type Transaction: PoolTransaction;
@@ -172,25 +171,27 @@ pub trait TransactionValidator: Send + Sync {
     /// function.
     ///
     /// See [TransactionValidationTaskExecutor] for a reference implementation.
-    async fn validate_transaction(
+    fn validate_transaction(
         &self,
         origin: TransactionOrigin,
         transaction: Self::Transaction,
-    ) -> TransactionValidationOutcome<Self::Transaction>;
+    ) -> impl Future<Output = TransactionValidationOutcome<Self::Transaction>> + Send;
 
     /// Validates a batch of transactions.
     ///
     /// Must return all outcomes for the given transactions in the same order.
     ///
     /// See also [Self::validate_transaction].
-    async fn validate_transactions(
+    fn validate_transactions(
         &self,
         transactions: Vec<(TransactionOrigin, Self::Transaction)>,
-    ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
-        futures_util::future::join_all(
-            transactions.into_iter().map(|(origin, tx)| self.validate_transaction(origin, tx)),
-        )
-        .await
+    ) -> impl Future<Output = Vec<TransactionValidationOutcome<Self::Transaction>>> + Send {
+        async {
+            futures_util::future::join_all(
+                transactions.into_iter().map(|(origin, tx)| self.validate_transaction(origin, tx)),
+            )
+            .await
+        }
     }
 
     /// Invoked when the head block changes.

--- a/crates/transaction-pool/src/validate/task.rs
+++ b/crates/transaction-pool/src/validate/task.rs
@@ -153,7 +153,6 @@ impl<V> TransactionValidationTaskExecutor<V> {
     }
 }
 
-#[async_trait::async_trait]
 impl<V> TransactionValidator for TransactionValidationTaskExecutor<V>
 where
     V: TransactionValidator + Clone + 'static,

--- a/examples/network-txpool.rs
+++ b/examples/network-txpool.rs
@@ -72,7 +72,6 @@ async fn main() -> eyre::Result<()> {
 #[non_exhaustive]
 struct OkValidator;
 
-#[async_trait::async_trait]
 impl TransactionValidator for OkValidator {
     type Transaction = EthPooledTransaction;
 


### PR DESCRIPTION
Related to https://github.com/paradigmxyz/reth/issues/6657
Remove `async-trait` as dependency from crate `transaction-pool`, `rpc-api`. 

The remaining usage towards `async-trait` are mostly related to rpc server implementation based on `jsonrpsee`, and `jsonrpsee` is working on [migrating](https://github.com/paritytech/jsonrpsee/issues/1292) to native async trait. 
