### PR TITLE
feat: Add dumpgenesis subcommand

### DIFF
--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -131,7 +131,6 @@ pub enum Commands<Ext: RethCliExt = ()> {
     #[command(name = "import")]
     Import(import::ImportCommand),
     /// Dumps genesis block JSON configuration to stdout.
-    #[command(name = "dumpgenesis")]
     DumpGenesis(dump_genesis::DumpGenesisCommand),
     /// Database debugging utilities
     #[command(name = "db")]

--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -7,7 +7,8 @@ use crate::{
     },
     cli::ext::RethCliExt,
     commands::{
-        config_cmd, db, debug_cmd, import, init_cmd, node, p2p, recover, stage, test_vectors,
+        config_cmd, db, debug_cmd, dump_genesis, import, init_cmd, node, p2p, recover, stage,
+        test_vectors,
     },
     core::cli::runner::CliRunner,
     version::{LONG_VERSION, SHORT_VERSION},
@@ -81,6 +82,7 @@ impl<Ext: RethCliExt> Cli<Ext> {
             Commands::Node(command) => runner.run_command_until_exit(|ctx| command.execute(ctx)),
             Commands::Init(command) => runner.run_blocking_until_ctrl_c(command.execute()),
             Commands::Import(command) => runner.run_blocking_until_ctrl_c(command.execute()),
+            Commands::DumpGenesis(command) => runner.run_blocking_until_ctrl_c(command.execute()),
             Commands::Db(command) => runner.run_blocking_until_ctrl_c(command.execute()),
             Commands::Stage(command) => runner.run_blocking_until_ctrl_c(command.execute()),
             Commands::P2P(command) => runner.run_until_ctrl_c(command.execute()),
@@ -128,6 +130,9 @@ pub enum Commands<Ext: RethCliExt = ()> {
     /// This syncs RLP encoded blocks from a file.
     #[command(name = "import")]
     Import(import::ImportCommand),
+    /// Dumps genesis block JSON configuration to stdout.
+    #[command(name = "dumpgenesis")]
+    DumpGenesis(dump_genesis::DumpGenesisCommand),
     /// Database debugging utilities
     #[command(name = "db")]
     Db(db::Command),

--- a/bin/reth/src/commands/dump_genesis.rs
+++ b/bin/reth/src/commands/dump_genesis.rs
@@ -1,0 +1,70 @@
+//! Command that dumps genesis block JSON configuration to stdout
+
+use crate::{
+    args::utils::{chain_help, genesis_value_parser, SUPPORTED_CHAINS},
+    dirs::{DataDirPath, MaybePlatformPath},
+};
+use clap::Parser;
+use reth_primitives::ChainSpec;
+use std::sync::Arc;
+
+/// Dumps genesis block JSON configuration to stdout, test(todo!(abner))
+#[derive(Debug, Parser)]
+pub struct DumpGenesisCommand {
+    /// The path to the data dir for all reth files and subdirectories.
+    ///
+    /// Defaults to the OS-specific data directory:
+    ///
+    /// - Linux: `$XDG_DATA_HOME/reth/` or `$HOME/.local/share/reth/`
+    /// - Windows: `{FOLDERID_RoamingAppData}/reth/`
+    /// - macOS: `$HOME/Library/Application Support/reth/`
+    #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
+    datadir: MaybePlatformPath<DataDirPath>,
+
+    /// The chain this node is running.
+    ///
+    /// Possible values are either a built-in chain or the path to a chain specification file.
+    #[arg(
+        long,
+        value_name = "CHAIN_OR_PATH",
+        long_help = chain_help(),
+        default_value = SUPPORTED_CHAINS[0],
+        value_parser = genesis_value_parser
+    )]
+    chain: Arc<ChainSpec>,
+
+    /// Görli network: pre-configured proof-of-authority test network
+    #[arg(long, verbatim_doc_comment)]
+    goerli: bool,
+
+    /// Ethereum mainnet
+    #[arg(long, verbatim_doc_comment)]
+    mainnet: bool,
+
+    /// Holesky network: pre-configured proof-of-stake test network
+    #[arg(long, verbatim_doc_comment)]
+    holesky: bool,
+
+    /// Sepolia network: pre-configured proof-of-work test network
+    #[arg(long, verbatim_doc_comment)]
+    sepolia: bool,
+}
+
+impl DumpGenesisCommand {
+    /// Execute the `dumpgenesis` command
+    pub async fn execute(self) -> eyre::Result<()> {
+        let genesis = if self.mainnet {
+            reth_primitives::MAINNET.genesis()
+        } else if self.holesky {
+            reth_primitives::HOLESKY.genesis()
+        } else if self.sepolia {
+            reth_primitives::SEPOLIA.genesis()
+        } else if self.goerli {
+            reth_primitives::GOERLI.genesis()
+        } else {
+            self.chain.genesis()
+        };
+        println!("{}", serde_json::to_string_pretty(genesis)?);
+        Ok(())
+    }
+}

--- a/bin/reth/src/commands/dump_genesis.rs
+++ b/bin/reth/src/commands/dump_genesis.rs
@@ -7,22 +7,6 @@ use std::sync::Arc;
 /// Dumps genesis block JSON configuration to stdout
 #[derive(Debug, Parser)]
 pub struct DumpGenesisCommand {
-    /// Görli network: pre-configured proof-of-authority test network
-    #[arg(long, verbatim_doc_comment)]
-    goerli: bool,
-
-    /// Ethereum mainnet
-    #[arg(long, verbatim_doc_comment)]
-    mainnet: bool,
-
-    /// Holesky network: pre-configured proof-of-stake test network
-    #[arg(long, verbatim_doc_comment)]
-    holesky: bool,
-
-    /// Sepolia network: pre-configured proof-of-work test network
-    #[arg(long, verbatim_doc_comment)]
-    sepolia: bool,
-
     /// The chain this node is running.
     ///
     /// Possible values are either a built-in chain or the path to a chain specification file.
@@ -37,20 +21,27 @@ pub struct DumpGenesisCommand {
 }
 
 impl DumpGenesisCommand {
-    /// Execute the `dumpgenesis` command
+    /// Execute the `dump-genesis` command
     pub async fn execute(self) -> eyre::Result<()> {
-        let genesis = if self.mainnet {
-            reth_primitives::MAINNET.genesis()
-        } else if self.holesky {
-            reth_primitives::HOLESKY.genesis()
-        } else if self.sepolia {
-            reth_primitives::SEPOLIA.genesis()
-        } else if self.goerli {
-            reth_primitives::GOERLI.genesis()
-        } else {
-            self.chain.genesis()
-        };
-        println!("{}", serde_json::to_string_pretty(genesis)?);
+        println!("{}", serde_json::to_string_pretty(self.chain.genesis())?);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_dump_genesis_command_chain_args() {
+        for chain in SUPPORTED_CHAINS {
+            let args: DumpGenesisCommand =
+                DumpGenesisCommand::parse_from(["reth", "--chain", chain]);
+            assert_eq!(
+                Ok(args.chain.chain),
+                chain.parse::<reth_primitives::Chain>(),
+                "failed to parse chain {chain}"
+            );
+        }
     }
 }

--- a/bin/reth/src/commands/dump_genesis.rs
+++ b/bin/reth/src/commands/dump_genesis.rs
@@ -1,9 +1,6 @@
 //! Command that dumps genesis block JSON configuration to stdout
 
-use crate::{
-    args::utils::{chain_help, genesis_value_parser, SUPPORTED_CHAINS},
-    dirs::{DataDirPath, MaybePlatformPath},
-};
+use crate::args::utils;
 use clap::Parser;
 use reth_primitives::ChainSpec;
 use std::sync::Arc;
@@ -11,28 +8,6 @@ use std::sync::Arc;
 /// Dumps genesis block JSON configuration to stdout, test(todo!(abner))
 #[derive(Debug, Parser)]
 pub struct DumpGenesisCommand {
-    /// The path to the data dir for all reth files and subdirectories.
-    ///
-    /// Defaults to the OS-specific data directory:
-    ///
-    /// - Linux: `$XDG_DATA_HOME/reth/` or `$HOME/.local/share/reth/`
-    /// - Windows: `{FOLDERID_RoamingAppData}/reth/`
-    /// - macOS: `$HOME/Library/Application Support/reth/`
-    #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
-    datadir: MaybePlatformPath<DataDirPath>,
-
-    /// The chain this node is running.
-    ///
-    /// Possible values are either a built-in chain or the path to a chain specification file.
-    #[arg(
-        long,
-        value_name = "CHAIN_OR_PATH",
-        long_help = chain_help(),
-        default_value = SUPPORTED_CHAINS[0],
-        value_parser = genesis_value_parser
-    )]
-    chain: Arc<ChainSpec>,
-
     /// Görli network: pre-configured proof-of-authority test network
     #[arg(long, verbatim_doc_comment)]
     goerli: bool,
@@ -48,6 +23,18 @@ pub struct DumpGenesisCommand {
     /// Sepolia network: pre-configured proof-of-work test network
     #[arg(long, verbatim_doc_comment)]
     sepolia: bool,
+
+    /// The chain this node is running.
+    ///
+    /// Possible values are either a built-in chain or the path to a chain specification file.
+    #[arg(
+    long,
+    value_name = "CHAIN_OR_PATH",
+    long_help = chain_help(),
+    default_value = SUPPORTED_CHAINS[0],
+    value_parser = genesis_value_parser
+    )]
+    chain: Arc<ChainSpec>,
 }
 
 impl DumpGenesisCommand {

--- a/bin/reth/src/commands/dump_genesis.rs
+++ b/bin/reth/src/commands/dump_genesis.rs
@@ -1,11 +1,10 @@
 //! Command that dumps genesis block JSON configuration to stdout
-
-use crate::args::utils;
+use crate::args::utils::{chain_help, genesis_value_parser, SUPPORTED_CHAINS};
 use clap::Parser;
 use reth_primitives::ChainSpec;
 use std::sync::Arc;
 
-/// Dumps genesis block JSON configuration to stdout, test(todo!(abner))
+/// Dumps genesis block JSON configuration to stdout
 #[derive(Debug, Parser)]
 pub struct DumpGenesisCommand {
     /// Görli network: pre-configured proof-of-authority test network
@@ -28,11 +27,11 @@ pub struct DumpGenesisCommand {
     ///
     /// Possible values are either a built-in chain or the path to a chain specification file.
     #[arg(
-    long,
-    value_name = "CHAIN_OR_PATH",
-    long_help = chain_help(),
-    default_value = SUPPORTED_CHAINS[0],
-    value_parser = genesis_value_parser
+        long,
+        value_name = "CHAIN_OR_PATH",
+        long_help = chain_help(),
+        default_value = SUPPORTED_CHAINS[0],
+        value_parser = genesis_value_parser
     )]
     chain: Arc<ChainSpec>,
 }

--- a/bin/reth/src/commands/mod.rs
+++ b/bin/reth/src/commands/mod.rs
@@ -3,8 +3,10 @@
 pub mod config_cmd;
 pub mod db;
 pub mod debug_cmd;
+pub mod dump_genesis;
 pub mod import;
 pub mod init_cmd;
+
 pub mod node;
 pub mod p2p;
 pub mod recover;

--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -31,6 +31,7 @@
     - [`reth node`](./cli/reth/node.md)
     - [`reth init`](./cli/reth/init.md)
     - [`reth import`](./cli/reth/import.md)
+    - [`reth dump-genesis`](./cli/reth/dump-genesis.md)
     - [`reth db`](./cli/reth/db.md)
       - [`reth db stats`](./cli/reth/db/stats.md)
       - [`reth db list`](./cli/reth/db/list.md)

--- a/book/cli/SUMMARY.md
+++ b/book/cli/SUMMARY.md
@@ -2,6 +2,7 @@
   - [`reth node`](./reth/node.md)
   - [`reth init`](./reth/init.md)
   - [`reth import`](./reth/import.md)
+  - [`reth dump-genesis`](./reth/dump-genesis.md)
   - [`reth db`](./reth/db.md)
     - [`reth db stats`](./reth/db/stats.md)
     - [`reth db list`](./reth/db/list.md)

--- a/book/cli/reth/dump-genesis.md
+++ b/book/cli/reth/dump-genesis.md
@@ -1,26 +1,12 @@
-# reth
+# reth dump-genesis
 
-Reth
+This dumps genesis block JSON configuration to stdout
 
 ```bash
-$ reth --help
-Reth
+$ reth dump-genesis
+Dumps genesis block JSON configuration to stdout
 
-Usage: reth [OPTIONS] <COMMAND>
-
-Commands:
-  node          Start the node
-  init          Initialize the database from a genesis file
-  import        This syncs RLP encoded blocks from a file
-  dump-genesis  Dumps genesis block JSON configuration to stdout
-  db            Database debugging utilities
-  stage         Manipulate individual stages
-  p2p           P2P Debugging utilities
-  test-vectors  Generate Test Vectors
-  config        Write config to stdout
-  debug         Various debug routines
-  recover       Scripts for node recovery
-  help          Print this message or the help of the given subcommand(s)
+Usage: reth dump-genesis [OPTIONS]
 
 Options:
       --chain <CHAIN_OR_PATH>
@@ -45,9 +31,6 @@ Options:
 
   -h, --help
           Print help (see a summary with '-h')
-
-  -V, --version
-          Print version
 
 Logging:
       --log.stdout.format <FORMAT>
@@ -83,7 +66,7 @@ Logging:
       --log.file.directory <PATH>
           The path to put log files in
           
-          [default: <CACHE_DIR>/logs]
+          [default:  <CACHE_DIR>/logs]
 
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file


### PR DESCRIPTION
Close https://github.com/paradigmxyz/reth/issues/5833

If no Dumpgenesis argument(like `--mainnet`) is provided, we simply use the chain argument.

```
./reth dumpgenesis --help
Dumps genesis block JSON configuration to stdout

Usage: reth dumpgenesis [OPTIONS]

Options:
      --goerli
          Görli network: pre-configured proof-of-authority test network

      --mainnet
          Ethereum mainnet

      --holesky
          Holesky network: pre-configured proof-of-stake test network

      --sepolia
          Sepolia network: pre-configured proof-of-work test network

      --chain <CHAIN_OR_PATH>
          The chain this node is running.
          Possible values are either a built-in chain or the path to a chain specification file.

          Built-in chains:
              mainnet, sepolia, goerli, holesky, dev

          [default: mainnet]

      --instance <INSTANCE>
          Add a new instance of a node.

          Configures the ports of the node to avoid conflicts with the defaults. This is useful for running multiple nodes on the same machine.

          Max number of instances is 200. It is chosen in a way so that it's not possible to have port numbers that conflict with each other.

          Changes to the following port numbers: - DISCOVERY_PORT: default + `instance` - 1 - AUTH_PORT: default + `instance` * 100 - 100 - HTTP_RPC_PORT: default - `instance` + 1 - WS_RPC_PORT: default + `instance` * 2 - 2

          [default: 1]

  -h, --help
          Print help (see a summary with '-h')

Logging:
      --log.stdout.format <FORMAT>
          The format to use for logs written to stdout

          [default: terminal]

          Possible values:
          - json:     Represents JSON formatting for logs. This format outputs log records as JSON objects, making it suitable for structured logging
          - log-fmt:  Represents logfmt (key=value) formatting for logs. This format is concise and human-readable, typically used in command-line applications
          - terminal: Represents terminal-friendly formatting for logs

      --log.stdout.filter <FILTER>
          The filter to use for logs written to stdout

          [default: ]

      --log.file.format <FORMAT>
          The format to use for logs written to the log file

          [default: terminal]

          Possible values:
          - json:     Represents JSON formatting for logs. This format outputs log records as JSON objects, making it suitable for structured logging
          - log-fmt:  Represents logfmt (key=value) formatting for logs. This format is concise and human-readable, typically used in command-line applications
          - terminal: Represents terminal-friendly formatting for logs

      --log.file.filter <FILTER>
          The filter to use for logs written to the log file

          [default: debug]

      --log.file.directory <PATH>
          The path to put log files in

          [default: /Users/abnerzheng/Library/Caches/reth/logs]

      --log.file.max-size <SIZE>
          The maximum size (in MB) of one log file

          [default: 200]

      --log.file.max-files <COUNT>
          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled

          [default: 5]

      --log.journald
          Write logs to journald

      --log.journald.filter <FILTER>
          The filter to use for logs written to journald

          [default: error]

      --color <COLOR>
          Sets whether or not the formatter emits ANSI terminal escape codes for colors and other text formatting

          [default: always]

          Possible values:
          - always: Colors on
          - auto:   Colors on
          - never:  Colors off

Display:
  -v, --verbosity...
          Set the minimum log level.

          -v      Errors
          -vv     Warnings
          -vvv    Info
          -vvvv   Debug
          -vvvvv  Traces (warning: very verbose!)

  -q, --quiet
          Silence all log output
```