### PR TITLE
chore: set Rust versions

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -58,6 +58,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly-2024-02-22
       - name: Install mdbook
         run: |
           mkdir mdbook
@@ -78,7 +80,7 @@ jobs:
         run: mdbook build
 
       - name: Build docs
-        run: cargo docs
+        run: cargo +nightly-2024-02-22 docs
         env:
           # Keep in sync with ./ci.yml:jobs.docs
           RUSTDOCFLAGS:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -88,10 +88,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly-2024-02-22
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - run: cargo docs --document-private-items
+      - run: cargo +nightly-2024-02-22 docs --document-private-items
         env:
           # Keep in sync with ./book.yml:jobs.build
           # This should only add `-D warnings`
@@ -108,7 +110,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
-      - run: cargo fmt --all --check
+          toolchain: nightly-2024-02-01
+      - run: cargo +nightly-2024-02-01 fmt --all --check
 
   grafana:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ FULL_DB_TOOLS_DIR := $(shell pwd)/$(DB_TOOLS_DIR)/
 
 BUILD_PATH = "target"
 
+NIGTHLY_VERSION="2024-02-01"
+
 # List of features to use when building. Can be overriden via the environment.
 # No jemalloc on Windows
 ifeq ($(OS),Windows_NT)
@@ -255,10 +257,10 @@ maxperf-no-asm: ## Builds `reth` with the most aggressive optimisations, minus t
 
 
 fmt:
-	cargo +nightly fmt
+	cargo +nightly-$(NIGTHLY_VERSION) fmt
 
 lint-reth:
-	cargo +nightly clippy \
+	cargo +nightly-$(NIGTHLY_VERSION) clippy \
 	--workspace \
 	--bin "reth" \
 	--lib \
@@ -269,7 +271,7 @@ lint-reth:
 	-- -D warnings
 
 lint-op-reth:
-	cargo +nightly clippy \
+	cargo +nightly-$(NIGTHLY_VERSION) clippy \
 	--workspace \
 	--bin "op-reth" \
 	--lib \
@@ -280,7 +282,7 @@ lint-op-reth:
 	-- -D warnings
 
 lint-other-targets:
-	cargo +nightly clippy \
+	cargo +nightly-$(NIGTHLY_VERSION) clippy \
 	--workspace \
 	--lib \
 	--examples \
@@ -301,7 +303,7 @@ rustdocs:
 	--show-type-layout \
 	--generate-link-to-definition \
 	--enable-index-page -Zunstable-options -D warnings" \
-	cargo +nightly docs \
+	cargo +nightly-$(NIGTHLY_VERSION) docs \
 	--document-private-items
 
 test-reth:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,10 @@
+[toolchain]
+channel = "1.75.0" # MSRV
+components = ["rustfmt", "clippy"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    "x86_64-pc-windows-gnu",
+]


### PR DESCRIPTION
Sets Rust versions used on all cargo commands aiming to provide reproducible builds. 

For regular cargo commands stable `1.75.0` (MSRV) is configured on a `rust-toolchain.toml` file and for CI and make targets that use nightly, `2024-02-01` is used (which is not affected by https://github.com/rust-lang/rustfmt/issues/6090)