### PR TITLE
feat(primitives): Add Base Mainnet `Ecotone` fork time

### DIFF
--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -422,7 +422,11 @@ pub static BASE_MAINNET: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
         genesis_hash: Some(b256!(
             "f712aa9241cc24369b143cf6dce85f0902a9731e70d66818a3a5845b296c73dd"
         )),
-        fork_timestamps: ForkTimestamps::default().shanghai(1704992401).canyon(1704992401),
+        fork_timestamps: ForkTimestamps::default()
+            .shanghai(1704992401)
+            .canyon(1704992401)
+            .cancun(1710374401)
+            .ecotone(1710374401),
         paris_block_and_final_difficulty: Some((0, U256::from(0))),
         hardforks: BTreeMap::from([
             (Hardfork::Frontier, ForkCondition::Block(0)),
@@ -446,6 +450,7 @@ pub static BASE_MAINNET: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
             (Hardfork::Regolith, ForkCondition::Timestamp(0)),
             (Hardfork::Shanghai, ForkCondition::Timestamp(1704992401)),
             (Hardfork::Canyon, ForkCondition::Timestamp(1704992401)),
+            (Hardfork::Ecotone, ForkCondition::Timestamp(1710374401)),
         ]),
         base_fee_params: BaseFeeParamsKind::Variable(
             vec![


### PR DESCRIPTION
## Overview

Adds the fork activation timestamp for the `Ecotone` hardfork on Base Mainnet. The fork is scheduled for `Thu Mar 14 00:00:01 UTC 2024`

ref: https://github.com/ethereum-optimism/superchain-registry/blob/main/superchain/configs/mainnet/superchain.yaml#L11C15-L11C25