### PR TITLE
Clone read transactions into TxnManager message listener

### DIFF
--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -700,12 +700,13 @@ impl EnvironmentBuilder {
             }
         }
 
+        let env_ptr = EnvPtr(env);
+
         #[cfg(not(feature = "read-tx-timeouts"))]
-        let txn_manager = TxnManager::new(EnvPtr(env));
+        let txn_manager = TxnManager::new(env_ptr);
 
         #[cfg(feature = "read-tx-timeouts")]
         let txn_manager = {
-            let env_ptr = EnvPtr(env);
             if let crate::MaxReadTransactionDuration::Set(duration) = self
                 .max_read_transaction_duration
                 .unwrap_or(read_transactions::MaxReadTransactionDuration::Set(

--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -705,16 +705,17 @@ impl EnvironmentBuilder {
 
         #[cfg(feature = "read-tx-timeouts")]
         let txn_manager = {
-            let mut txn_manager = TxnManager::new(EnvPtr(env));
+            let env_ptr = EnvPtr(env);
             if let crate::MaxReadTransactionDuration::Set(duration) = self
                 .max_read_transaction_duration
                 .unwrap_or(read_transactions::MaxReadTransactionDuration::Set(
                     DEFAULT_MAX_READ_TRANSACTION_DURATION,
                 ))
             {
-                txn_manager = txn_manager.with_max_read_transaction_duration(duration);
-            };
-            txn_manager
+                TxnManager::new_with_max_read_transaction_duration(env_ptr, duration)
+            } else {
+                TxnManager::new(env_ptr)
+            }
         };
 
         let env = EnvironmentInner { env, txn_manager, env_kind: self.kind };

--- a/crates/storage/libmdbx-rs/src/txn_manager.rs
+++ b/crates/storage/libmdbx-rs/src/txn_manager.rs
@@ -318,8 +318,7 @@ mod read_transactions {
     mod tests {
         use crate::{
             txn_manager::{
-                self, read_transactions::READ_TRANSACTIONS_CHECK_INTERVAL, TxnManagerMessage,
-                TxnPtr,
+                read_transactions::READ_TRANSACTIONS_CHECK_INTERVAL, TxnManagerMessage, TxnPtr,
             },
             Environment, Error, MaxReadTransactionDuration, TransactionKind, RO,
         };

--- a/crates/storage/libmdbx-rs/src/txn_manager.rs
+++ b/crates/storage/libmdbx-rs/src/txn_manager.rs
@@ -138,7 +138,8 @@ mod read_transactions {
     const READ_TRANSACTIONS_CHECK_INTERVAL: Duration = Duration::from_secs(5);
 
     impl TxnManager {
-        /// Sets the maximum duration that a read transaction can be open.
+        /// Returns a new instance for which the maximum duration that a read transaction can be
+        /// open is set.
         pub(crate) fn new_with_max_read_transaction_duration(
             env: EnvPtr,
             duration: Duration,


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/6807.

- Changes signature of `TxnManager::with_max_read_transaction_duration`. Alt solution was to change 

https://github.com/paradigmxyz/reth/blob/ce28fe32d94a67e8db8295c63ec95724d31ddbc2/crates/storage/libmdbx-rs/src/txn_manager.rs#L30-L31

to an `Arc<Option<_>>`, but that would result in a much larger diff and unsafe code.