### PR TITLE
fix(docs): Remove op-node Rollup Config CLI Flag

### DIFF
--- a/book/run/optimism.md
+++ b/book/run/optimism.md
@@ -83,6 +83,7 @@ op-reth node \
 Then, once `op-reth` has been started, start up the `op-node`:
 ```sh
 op-node \
+    --network="base-mainnet" \
     --l1=<your-L1-rpc> \
     --l2=http://localhost:9551 \
     --l2.jwt-secret=/path/to/jwt.hex \

--- a/book/run/optimism.md
+++ b/book/run/optimism.md
@@ -119,5 +119,3 @@ op-node \
 [op-node]: https://github.com/ethereum-optimism/optimism/tree/develop/op-node
 [magi]: https://github.com/a16z/magi
 [hildr]: https://github.com/optimism-java/hildr
-
-[base-node]: https://github.com/base-org/node/tree/main

--- a/book/run/optimism.md
+++ b/book/run/optimism.md
@@ -69,8 +69,6 @@ The `optimism` feature flag in `op-reth` adds several new CLI flags to the `reth
 1. `--rollup.disable-tx-pool-gossip` - Disables gossiping of transactions in the mempool to peers. This can be ommitted for personal nodes, though providers should always opt to enable this flag.
 1. `--rollup.enable-genesis-walkback` - Disables setting the forkchoice status to tip on startup, making the `op-node` walk back to genesis and verify the integrity of the chain before starting to sync. This can be ommitted unless a corruption of local chainstate is suspected.
 
-Base's `rollup.json` files, which contain various configuration fields for the rollup, can be found in their [node][base-node] repository, under the respective L1 settlement layer's directory (`mainnet`, `goerli`, & `sepolia`).
-
 First, ensure that your L1 archival node is running and synced to tip. Then, start `op-reth` with the `--rollup.sequencer-http` flag set to the `Base Mainnet` sequencer endpoint:
 ```sh
 op-reth node \
@@ -87,7 +85,6 @@ Then, once `op-reth` has been started, start up the `op-node`:
 op-node \
     --l1=<your-L1-rpc> \
     --l2=http://localhost:9551 \
-    --rollup.config=/path/to/rollup.json \
     --l2.jwt-secret=/path/to/jwt.hex \
     --rpc.addr=0.0.0.0 \
     --rpc.port=7000 \


### PR DESCRIPTION
**Description**

The `op-node` has been updated to dynamically load the rollup config from the superchain registry. This pr updates the OP Stack Chain docs to specify a network instead of using a static json file. This avoids the need to have a `rollup.json` config file locally so instead you can just specify the network name.

Also note, specifying both the `network` and `rollup.config` is deprecated in the `op-node`. See https://github.com/ethereum-optimism/optimism/blob/develop/op-node/service.go#L216-L228