### PR TITLE
Downgrade log level for remote client spec bug

### DIFF
--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -446,7 +446,7 @@ impl TransactionFetcher {
                     if let Some(prev_size) = previously_seen_size {
                         // check if this peer is announcing a different size than a previous peer
                         if size != prev_size {
-                            debug!(target: "net::tx",
+                            trace!(target: "net::tx",
                                 peer_id=format!("{peer_id:#}"),
                                 hash=%hash,
                                 size=size,


### PR DESCRIPTION
Downgrades log level from `debug` to `trace` for log message `"peer announced a different size for tx, this is especially worrying if one size is much bigger...`.