### PR TITLE
Fix units for tx manager poll metrics

### DIFF
--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -365,7 +365,7 @@ where
         } = poll_durations;
 
         // update metrics for whole poll function
-        metrics.duration_poll_tx_manager.set(start.elapsed());
+        metrics.duration_poll_tx_manager.set(start.elapsed().as_secs_f64());
         // update poll metrics for nested streams
         metrics.acc_duration_poll_network_events.set(acc_network_events.as_secs_f64());
         metrics.acc_duration_poll_pending_pool_imports.set(acc_pending_imports.as_secs_f64());


### PR DESCRIPTION
Fixes units for poll duration of tx manager to secs as `f64` (https://github.com/paradigmxyz/reth/pull/6688#discussion_r1500000251).