### PR TITLE
fix(downloader): remove optimization for single full block download

### DIFF
--- a/crates/interfaces/src/p2p/full_block.rs
+++ b/crates/interfaces/src/p2p/full_block.rs
@@ -81,12 +81,6 @@ where
         count: u64,
     ) -> FetchFullBlockRangeFuture<Client> {
         let client = self.client.clone();
-
-        // Optimization: if we only want one block, we don't need to wait for the headers request
-        // to complete, and can send the block bodies request right away.
-        let bodies_request =
-            if count == 1 { None } else { Some(client.get_block_bodies(vec![hash])) };
-
         FetchFullBlockRangeFuture {
             start_hash: hash,
             count,
@@ -96,7 +90,7 @@ where
                     limit: count,
                     direction: HeadersDirection::Falling,
                 })),
-                bodies: bodies_request,
+                bodies: None,
             },
             client,
             headers: None,
@@ -410,7 +404,7 @@ where
     /// Returns the remaining hashes for the bodies request, based on the headers that still exist
     /// in the `root_map`.
     fn remaining_bodies_hashes(&self) -> Vec<B256> {
-        self.pending_headers.iter().map(|h| h.hash()).collect::<Vec<_>>()
+        self.pending_headers.iter().map(|h| h.hash()).collect()
     }
 
     /// Returns the [SealedBlock]s if the request is complete and valid.


### PR DESCRIPTION
## Description

Remove optimization for a single full block download where the block body request was dispatched immediately.

1.  The check here should've been inverse
https://github.com/paradigmxyz/reth/blob/f5ce869c0ec1a6f0a9c5a5c3e702e3eb6be19aac/crates/interfaces/src/p2p/full_block.rs#L85-L88

2. If the block body response arrives before the header response, it will be discarded here
https://github.com/paradigmxyz/reth/blob/f5ce869c0ec1a6f0a9c5a5c3e702e3eb6be19aac/crates/interfaces/src/p2p/full_block.rs#L397-L401 