### PR TITLE
chore: reuse raw transaction by hash for debug_getRawTransaction

### DIFF
--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -21,8 +21,10 @@ pub trait DebugApi {
     async fn raw_block(&self, block_id: BlockId) -> RpcResult<Bytes>;
 
     /// Returns a EIP-2718 binary-encoded transaction.
+    ///
+    /// If this is a pooled EIP-4844 transaction, the blob sidecar is included.
     #[method(name = "getRawTransaction")]
-    async fn raw_transaction(&self, hash: B256) -> RpcResult<Bytes>;
+    async fn raw_transaction(&self, hash: B256) -> RpcResult<Option<Bytes>>;
 
     /// Returns an array of EIP-2718 binary-encoded transactions for the given [BlockId].
     #[method(name = "getRawTransactions")]

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -5,7 +5,7 @@ use crate::{
             inspect, inspect_and_return_db, prepare_call_env, replay_transactions_until, transact,
             EvmOverrides,
         },
-        EthTransactions, TransactionSource,
+        EthTransactions,
     },
     result::{internal_rpc_err, ToRpcResult},
     BlockingTaskGuard, EthApiSpec,
@@ -635,13 +635,12 @@ where
     }
 
     /// Handler for `debug_getRawTransaction`
+    ///
+    /// If this is a pooled EIP-4844 transaction, the blob sidecar is included.
+    ///
     /// Returns the bytes of the transaction for the given hash.
-    async fn raw_transaction(&self, hash: B256) -> RpcResult<Bytes> {
-        let tx = self.inner.eth_api.transaction_by_hash(hash).await?;
-        Ok(tx
-            .map(TransactionSource::into_recovered)
-            .map(|tx| tx.envelope_encoded())
-            .unwrap_or_default())
+    async fn raw_transaction(&self, hash: B256) -> RpcResult<Option<Bytes>> {
+        Ok(self.inner.eth_api.raw_transaction_by_hash(hash).await?)
     }
 
     /// Handler for `debug_getRawTransactions`


### PR DESCRIPTION
can reuse the new rawTransactionByHash function for the debug namespace

changed return type to option:

https://github.com/ethereum/go-ethereum/blob/b590cae89232299d54aac8aada88c66d00c5b34c/internal/ethapi/api.go#L2067-L2067