### PR TITLE
Compute min length mempool transactions message by type

### DIFF
--- a/crates/net/network/src/transactions/validation.rs
+++ b/crates/net/network/src/transactions/validation.rs
@@ -9,7 +9,7 @@ use reth_eth_wire::{
     DedupPayload, Eth68TxMetadata, HandleMempoolData, PartiallyValidData, ValidAnnouncementData,
     MAX_MESSAGE_SIZE,
 };
-use reth_primitives::{Signature, TxHash, TxType};
+use reth_primitives::{transaction::MIN_LENGTH_LEGACY_TX_ENCODED, Signature, TxHash, TxType};
 use tracing::{debug, trace};
 
 /// The size of a decoded signature in bytes.
@@ -241,8 +241,8 @@ impl ValidateTx68 for EthMessageFilter {
     }
 
     fn strict_min_encoded_tx_length(&self, _ty: TxType) -> Option<usize> {
-        // decoding a tx will exit right away if it's not at least a byte
-        Some(1)
+        // legacy is the smallest tx type
+        Some(MIN_LENGTH_LEGACY_TX_ENCODED)
     }
 }
 

--- a/crates/net/network/src/transactions/validation.rs
+++ b/crates/net/network/src/transactions/validation.rs
@@ -9,7 +9,7 @@ use reth_eth_wire::{
     DedupPayload, Eth68TxMetadata, HandleMempoolData, PartiallyValidData, ValidAnnouncementData,
     MAX_MESSAGE_SIZE,
 };
-use reth_primitives::{transaction::MIN_LENGTH_LEGACY_TX_ENCODED, Signature, TxHash, TxType};
+use reth_primitives::{Signature, TxHash, TxType};
 use tracing::{debug, trace};
 
 /// The size of a decoded signature in bytes.
@@ -241,8 +241,8 @@ impl ValidateTx68 for EthMessageFilter {
     }
 
     fn strict_min_encoded_tx_length(&self, _ty: TxType) -> Option<usize> {
-        // legacy is the smallest tx type
-        Some(MIN_LENGTH_LEGACY_TX_ENCODED)
+        // decoding a tx will exit right away if it's not at least a byte
+        Some(1)
     }
 }
 

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1276,7 +1276,7 @@ impl TransactionSigned {
             TxType::EIP1559 => Transaction::Eip1559(TxEip1559::decode_inner(data)?),
             TxType::EIP4844 => Transaction::Eip4844(TxEip4844::decode_inner(data)?),
             #[cfg(feature = "optimism")]
-            TxType::Deposit => Transaction::Deposit(TxDeposit::decode_inner(data)?),
+            TxType::DEPOSIT => Transaction::Deposit(TxDeposit::decode_inner(data)?),
             TxType::Legacy => unreachable!("path for legacy tx has diverged before this method"),
         };
 
@@ -1284,7 +1284,7 @@ impl TransactionSigned {
         let signature = Signature::decode(data)?;
 
         #[cfg(feature = "optimism")]
-        let signature = if tx_type == DEPOSIT_TX_TYPE_ID {
+        let signature = if let TxType::DEPOSIT = tx_type {
             Signature::optimism_deposit_tx_signature()
         } else {
             Signature::decode(data)?

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1961,7 +1961,7 @@ mod tests {
         let mut encoded = BytesMut::new();
         signed_tx.encode(&mut encoded);
 
-        assert_eq!(b"\xc9\x80\x80\x80\x80\x80\x80\x1b\x80\x80", &encoded[..]);
+        assert_eq!(hex!("c98080808080801b8080"), &encoded[..]);
         assert_eq!(MIN_LENGTH_LEGACY_TX_ENCODED, encoded.len());
 
         TransactionSigned::decode(&mut &encoded[..]).unwrap();
@@ -1980,7 +1980,7 @@ mod tests {
         let mut encoded = BytesMut::new();
         signed_tx.encode(&mut encoded);
 
-        assert_eq!(b"\x8d\x01\xcb\x80\x80\x80\x80\x80\x80\x80\xc0\x80\x80\x80", &encoded[..]);
+        assert_eq!(hex!("8d01cb80808080808080c0808080"), &encoded[..]);
         assert_eq!(MIN_LENGTH_EIP2930_TX_ENCODED, encoded.len());
 
         TransactionSigned::decode(&mut &encoded[..]).unwrap();
@@ -1999,7 +1999,7 @@ mod tests {
         let mut encoded = BytesMut::new();
         signed_tx.encode(&mut encoded);
 
-        assert_eq!(b"\x8e\x02\xcc\x80\x80\x80\x80\x80\x80\x80\x80\xc0\x80\x80\x80", &encoded[..]);
+        assert_eq!(hex!("8e02cc8080808080808080c0808080"), &encoded[..]);
         assert_eq!(MIN_LENGTH_EIP1559_TX_ENCODED, encoded.len());
 
         TransactionSigned::decode(&mut &encoded[..]).unwrap();
@@ -2018,10 +2018,7 @@ mod tests {
         let mut encoded = BytesMut::new();
         signed_tx.encode(&mut encoded);
 
-        assert_eq!(
-            b"\x90\x03\xce\x80\x80\x80\x80\x80\x80\x80\x80\xc0\x80\xc0\x80\x80\x80",
-            &encoded[..]
-        );
+        assert_eq!(hex!("9003ce8080808080808080c080c0808080"), &encoded[..]);
         assert_eq!(MIN_LENGTH_EIP4844_TX_ENCODED, encoded.len());
 
         TransactionSigned::decode(&mut &encoded[..]).unwrap();

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1257,7 +1257,6 @@ impl TransactionSigned {
         data.advance(1);
 
         let min_len = match tx_type {
-            0 => MIN_LENGTH_LEGACY_TX_ENCODED,
             1 => MIN_LENGTH_EIP2930_TX_ENCODED,
             2 => MIN_LENGTH_EIP1559_TX_ENCODED,
             3 => MIN_LENGTH_EIP4844_TX_ENCODED,

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1425,7 +1425,7 @@ impl Decodable for TransactionSigned {
                 TxType::EIP1559 => MIN_LENGTH_EIP1559_TX_ENCODED,
                 TxType::EIP4844 => MIN_LENGTH_EIP4844_TX_ENCODED,
                 #[cfg(feature = "optimism")]
-                TxType::Deposit => MIN_LENGTH_DEPOSIT_TX_ENCODED,
+                TxType::DEPOSIT => MIN_LENGTH_DEPOSIT_TX_ENCODED,
                 TxType::Legacy => {
                     unreachable!("path for legacy tx has diverged before this scope")
                 }


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/6852.

Calculates the minimum possible length of the rlp encoded transaction types by tests. Uses these values to opt-out early of decoding.