### PR TITLE
Revm example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,6 +1817,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "custom-inspector"
+version = "0.0.0"
+dependencies = [
+ "clap",
+ "eyre",
+ "futures-util",
+ "log",
+ "reth",
+ "reth-revm",
+ "tokio",
+]
+
+[[package]]
 name = "custom-node"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1823,10 +1823,7 @@ dependencies = [
  "clap",
  "eyre",
  "futures-util",
- "log",
  "reth",
- "reth-revm",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ members = [
     "examples/rpc-db/",
     "examples/trace-transaction-cli/",
     "examples/polygon-p2p/",
+    "examples/custom-inspector/",
     "testing/ef-tests/",
 ]
 default-members = ["bin/reth"]

--- a/examples/custom-inspector/Cargo.toml
+++ b/examples/custom-inspector/Cargo.toml
@@ -7,11 +7,6 @@ license.workspace = true
 
 [dependencies]
 reth.workspace = true
-reth-revm.workspace = true
 clap = { workspace = true, features = ["derive"] }
 futures-util.workspace = true
 eyre.workspace = true
-log = "0.4.20"
-
-[dev-dependencies]
-tokio.workspace = true

--- a/examples/custom-inspector/Cargo.toml
+++ b/examples/custom-inspector/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "custom-inspector"
+version = "0.0.0"
+publish = false
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+reth.workspace = true
+reth-revm.workspace = true
+clap = { workspace = true, features = ["derive"] }
+futures-util.workspace = true
+eyre.workspace = true
+log = "0.4.20"
+
+[dev-dependencies]
+tokio.workspace = true

--- a/examples/custom-inspector/src/main.rs
+++ b/examples/custom-inspector/src/main.rs
@@ -1,0 +1,138 @@
+//! Example of how to use a custom inspector to trace new pending transactions
+//!
+//! Run with
+//!
+//! ```not_rust
+//! cargo run --release -p custom-inspector --node --http --ws --recipients 0x....,0x....
+//! ```
+//!
+//! If no recipients are specified, all transactions will be inspected.
+
+use clap::Parser;
+use futures_util::StreamExt;
+use reth::{
+    cli::{
+        components::{RethNodeComponents, RethRpcComponents, RethRpcServerHandles},
+        config::RethRpcConfig,
+        ext::{RethCliExt, RethNodeCommandConfig},
+        Cli,
+    },
+    primitives::{Address, BlockId, IntoRecoveredTransaction},
+    revm::{
+        inspector_handle_register, interpreter::Interpreter, revm, Database, EvmContext, Inspector,
+    },
+    rpc::{
+        compat::transaction::transaction_to_call_request,
+        eth::{revm_utils::EvmOverrides, EthTransactions},
+    },
+    tasks::TaskSpawner,
+    transaction_pool::TransactionPool,
+};
+use reth_revm::interpreter::OpCode;
+use std::collections::HashSet;
+
+fn main() {
+    Cli::<MyRethCliExt>::parse().run().unwrap();
+}
+
+/// The type that tells the reth CLI what extensions to use
+struct MyRethCliExt;
+
+impl RethCliExt for MyRethCliExt {
+    /// This tells the reth CLI to trace addresses via `RethCliTxpoolExt`
+    type Node = RethCliTxpoolExt;
+}
+
+/// Our custom cli args extension that adds one flag to reth default CLI.
+#[derive(Debug, Clone, Default, clap::Args)]
+struct RethCliTxpoolExt {
+    /// recipients addresses that we want to trace
+    #[arg(long, value_delimiter = ',')]
+    pub recipients: Vec<Address>,
+}
+
+#[derive(Default, Debug, Clone)]
+struct DummyInspector {
+    ret_val: Vec<String>,
+}
+
+impl<DB> Inspector<DB> for DummyInspector
+where
+    DB: Database,
+{
+    fn step(&mut self, interp: &mut Interpreter, context: &mut EvmContext<DB>) {
+        if let Some(opcode) = OpCode::new(interp.op()) {
+            self.ret_val.push(format!("{}: {}", interp.program_counter(), opcode));
+        }
+    }
+}
+
+impl RethNodeCommandConfig for RethCliTxpoolExt {
+    fn on_rpc_server_started<Conf, Reth>(
+        &mut self,
+        _config: &Conf,
+        components: &Reth,
+        rpc_components: RethRpcComponents<'_, Reth>,
+        _handles: RethRpcServerHandles,
+    ) -> eyre::Result<()>
+    where
+        Conf: RethRpcConfig,
+        Reth: RethNodeComponents,
+    {
+        let recipients = self.recipients.iter().copied().collect::<HashSet<_>>();
+
+        // create a new subscription to pending transactions
+        let mut pending_transactions = components.pool().new_pending_pool_transactions_listener();
+
+        let eth_api = rpc_components.registry.eth_api();
+
+        println!("Spawning trace task!");
+        // Spawn an async block to listen for transactions.
+        components.task_executor().spawn(Box::pin(async move {
+            // Waiting for new transactions
+            while let Some(event) = pending_transactions.next().await {
+                let tx = event.transaction;
+                println!("Transaction received: {tx:?}");
+
+                if let Some(tx_recipient_address) = tx.to() {
+                    if recipients.is_empty() || recipients.contains(&tx_recipient_address) {
+                        // trace the transaction with `trace_call`
+                        let call_request =
+                            transaction_to_call_request(tx.to_recovered_transaction());
+
+                        let result = eth_api
+                            .spawn_with_call_at(
+                                call_request,
+                                BlockId::default(),
+                                EvmOverrides::default(),
+                                move |db, env| {
+                                    let mut dummy_inspector = DummyInspector::default();
+                                    {
+                                        let mut evm = revm::Evm::builder()
+                                            .with_db(db)
+                                            .with_external_context(&mut dummy_inspector)
+                                            .with_env_with_handler_cfg(env)
+                                            .append_handler_register(inspector_handle_register)
+                                            .build();
+                                        let _ = evm.transact()?;
+                                    }
+                                    Ok(dummy_inspector)
+                                },
+                            )
+                            .await;
+
+                        if let Ok(ret_val) = result {
+                            let hash = tx.hash();
+                            println!(
+                                "Inspector result for transaction {}: \n {}",
+                                hash,
+                                ret_val.ret_val.join("\n")
+                            );
+                        }
+                    }
+                }
+            }
+        }));
+        Ok(())
+    }
+}

--- a/examples/custom-inspector/src/main.rs
+++ b/examples/custom-inspector/src/main.rs
@@ -8,6 +8,8 @@
 //!
 //! If no recipients are specified, all transactions will be inspected.
 
+#![warn(unused_crate_dependencies)]
+
 use clap::Parser;
 use futures_util::stream::StreamExt;
 use reth::{

--- a/examples/custom-inspector/src/main.rs
+++ b/examples/custom-inspector/src/main.rs
@@ -60,8 +60,8 @@ impl<DB> Inspector<DB> for DummyInspector
 where
     DB: Database,
 {
-    fn step(&mut self, interp: &mut Interpreter, context: &mut EvmContext<DB>) {
-        if let Some(opcode) = OpCode::new(interp.op()) {
+    fn step(&mut self, interp: &mut Interpreter, _context: &mut EvmContext<DB>) {
+        if let Some(opcode) = OpCode::new(interp.current_opcode()) {
             self.ret_val.push(format!("{}: {}", interp.program_counter(), opcode));
         }
     }

--- a/examples/custom-inspector/src/main.rs
+++ b/examples/custom-inspector/src/main.rs
@@ -8,6 +8,8 @@
 //!
 //! If no recipients are specified, all transactions will be inspected.
 
+use clap::Parser;
+use futures_util::stream::StreamExt;
 use reth::{
     cli::{
         components::{RethNodeComponents, RethRpcComponents, RethRpcServerHandles},
@@ -15,7 +17,7 @@ use reth::{
         ext::{RethCliExt, RethNodeCommandConfig},
         Cli,
     },
-    primitives::{Address, BlockId},
+    primitives::{Address, BlockId, IntoRecoveredTransaction},
     revm::{
         inspector_handle_register,
         interpreter::{Interpreter, OpCode},


### PR DESCRIPTION
close https://github.com/paradigmxyz/reth/issues/6145

Add an example of how to use a custom inspector to trace new pending transactions
How to test:
```sh
> cargo run -p custom-inspector -- node --http --ws --dev`
```
and in another contracts project created by `forge`, and then run the following command to deploy a transaction:
```sh
forge create --mnemonic "test test test test test test test test test test test junk" src/Counter.sol:Counter
```


here is the running result from `node`:
```
Inspector result for transaction 0x21abbfee9d8e6af8bce70424425c8d3da92ed63d0d1de89cbd74cef108473e6a: 
 0: PUSH1
2: PUSH1
4: MSTORE
5: CALLVALUE
6: DUP1
7: ISZERO
8: PUSH2
11: JUMPI
16: JUMPDEST
17: POP
18: PUSH1
20: DUP1
21: PUSH2
24: PUSH1
26: CODECOPY
27: PUSH1
29: RETURN
```