### PR TITLE
chore: add comments clarifying evm trait

### DIFF
--- a/crates/node-api/src/evm/traits.rs
+++ b/crates/node-api/src/evm/traits.rs
@@ -1,17 +1,37 @@
 use reth_primitives::{revm::env::fill_block_env, Address, ChainSpec, Header, Transaction, U256};
-use revm::{Database, Evm, EvmBuilder};
+use revm::{Database, Evm, EvmBuilder, Handler, interpreter::Host};
 use revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg, SpecId, TxEnv};
 
 /// Trait for configuring the EVM for executing full blocks.
 pub trait ConfigureEvm: ConfigureEvmEnv {
     /// Returns new EVM with the given database
+    ///
+    /// This does not automatically configure the EVM with [ConfigureEvmEnv] methods. It is up to
+    /// the caller to call an appropriate method to fill the transaction and block environment
+    /// before executing any transactions using the provided EVM.
     fn evm<'a, DB: Database + 'a>(&self, db: DB) -> Evm<'a, (), DB> {
         EvmBuilder::default().with_db(db).build()
     }
 
-    /// Returns a new EVM with the given inspector
+    /// Returns a new EVM with the given inspector.
+    ///
+    /// This does not automatically configure the EVM with [ConfigureEvmEnv] methods. It is up to
+    /// the caller to call an appropriate method to fill the transaction and block environment
+    /// before executing any transactions using the provided EVM.
     fn evm_with_inspector<'a, DB: Database + 'a, I>(&self, db: DB, inspector: I) -> Evm<'a, I, DB> {
         EvmBuilder::default().with_db(db).with_external_context(inspector).build()
+    }
+
+    /// Returns a new EVM with the given handler, inspector, and database.
+    fn evm_with_handler_and_inspector<'a, DB: Database + 'a, I, H: Host>(
+        &self,
+        handler: Handler<'a, H, I, DB>,
+    ) -> H {
+        EvmBuilder::default()
+            .with_db(db)
+            .with_external_context(inspector)
+            .with_handler(handler)
+            .build()
     }
 }
 

--- a/crates/node-api/src/evm/traits.rs
+++ b/crates/node-api/src/evm/traits.rs
@@ -21,29 +21,6 @@ pub trait ConfigureEvm: ConfigureEvmEnv {
     fn evm_with_inspector<'a, DB: Database + 'a, I>(&self, db: DB, inspector: I) -> Evm<'a, I, DB> {
         EvmBuilder::default().with_db(db).with_external_context(inspector).build()
     }
-
-    /// Returns a new EVM with the given handler and database.
-    fn evm_with_handler<'a, DB: Database + 'a, I, H: Host>(
-        &self,
-        handler: Handler<'a, H, I, DB>,
-        db: DB,
-    ) -> H {
-        EvmBuilder::default().with_db(db).with_handler(handler).build()
-    }
-
-    /// Returns a new EVM with the given handler, inspector, and database.
-    fn evm_with_handler_and_inspector<'a, DB: Database + 'a, I, H: Host>(
-        &self,
-        handler: Handler<'a, H, I, DB>,
-        inspector: I,
-        db: DB,
-    ) -> H {
-        EvmBuilder::default()
-            .with_db(db)
-            .with_external_context(inspector)
-            .with_handler(handler)
-            .build()
-    }
 }
 
 /// This represents the set of methods used to configure the EVM's environment before block

--- a/crates/node-api/src/evm/traits.rs
+++ b/crates/node-api/src/evm/traits.rs
@@ -1,5 +1,5 @@
 use reth_primitives::{revm::env::fill_block_env, Address, ChainSpec, Header, Transaction, U256};
-use revm::{interpreter::Host, Database, Evm, EvmBuilder, Handler};
+use revm::{Database, Evm, EvmBuilder};
 use revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg, SpecId, TxEnv};
 
 /// Trait for configuring the EVM for executing full blocks.

--- a/crates/node-api/src/evm/traits.rs
+++ b/crates/node-api/src/evm/traits.rs
@@ -1,5 +1,5 @@
 use reth_primitives::{revm::env::fill_block_env, Address, ChainSpec, Header, Transaction, U256};
-use revm::{Database, Evm, EvmBuilder, Handler, interpreter::Host};
+use revm::{interpreter::Host, Database, Evm, EvmBuilder, Handler};
 use revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg, SpecId, TxEnv};
 
 /// Trait for configuring the EVM for executing full blocks.
@@ -22,10 +22,21 @@ pub trait ConfigureEvm: ConfigureEvmEnv {
         EvmBuilder::default().with_db(db).with_external_context(inspector).build()
     }
 
+    /// Returns a new EVM with the given handler and database.
+    fn evm_with_handler<'a, DB: Database + 'a, I, H: Host>(
+        &self,
+        handler: Handler<'a, H, I, DB>,
+        db: DB,
+    ) -> H {
+        EvmBuilder::default().with_db(db).with_handler(handler).build()
+    }
+
     /// Returns a new EVM with the given handler, inspector, and database.
     fn evm_with_handler_and_inspector<'a, DB: Database + 'a, I, H: Host>(
         &self,
         handler: Handler<'a, H, I, DB>,
+        inspector: I,
+        db: DB,
     ) -> H {
         EvmBuilder::default()
             .with_db(db)


### PR DESCRIPTION
Adds a comment mentioning the requirement for the user to configure the evm