### PR TITLE
chore(net): use smallvec only if debug_assertions configed

### DIFF
--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -477,7 +477,7 @@ impl TransactionFetcher {
                 }
                 // hash has been seen and is in flight. store peer as fallback peer.
                 //
-                // remove any ended sessions, so that in case of a full cache, alive peers aren't 
+                // remove any ended sessions, so that in case of a full cache, alive peers aren't
                 // removed in favour of lru dead peers
                 let mut ended_sessions = vec!();
                 for &peer_id in fallback_peers.iter() {
@@ -605,7 +605,7 @@ impl TransactionFetcher {
                 true
             }(),
             "`%new_announced_hashes` should been taken out of buffer before packing in a request, breaks invariant `@buffered_hashes` and `@inflight_requests`,
-`%new_announced_hashes`: {:?}, 
+`%new_announced_hashes`: {:?},
 `@self`: {:?}",
             new_announced_hashes, self
         );
@@ -725,7 +725,7 @@ impl TransactionFetcher {
         }
     }
 
-    /// Returns `true` if [`TransactionFetcher`] has capacity to request pending hashes. Returns  
+    /// Returns `true` if [`TransactionFetcher`] has capacity to request pending hashes. Returns
     /// `false` if [`TransactionFetcher`] is operating close to full capacity.
     pub fn has_capacity_for_fetching_pending_hashes(&self) -> bool {
         let info = &self.info;

--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -17,6 +17,7 @@ use reth_metrics::common::mpsc::{
 };
 use reth_primitives::{PeerId, PooledTransactionsElement, TxHash};
 use schnellru::{ByLength, Unlimited};
+#[cfg(debug_assertions)]
 use smallvec::{smallvec, SmallVec};
 use std::{
     collections::HashMap,
@@ -1111,7 +1112,7 @@ impl VerifyPooledTransactionsResponse for UnverifiedPooledTransactions {
     fn verify(
         self,
         requested_hashes: &[TxHash],
-        peer_id: &PeerId,
+        _peer_id: &PeerId,
     ) -> (VerificationOutcome, VerifiedPooledTransactions) {
         let mut verification_outcome = VerificationOutcome::Ok;
 
@@ -1134,7 +1135,7 @@ impl VerifyPooledTransactionsResponse for UnverifiedPooledTransactions {
 
         #[cfg(debug_assertions)]
         trace!(target: "net::tx",
-            peer_id=format!("{peer_id:#}"),
+            peer_id=format!("{_peer_id:#}"),
             tx_hashes_not_requested=?tx_hashes_not_requested,
             "transactions in `PooledTransactions` response from peer were not requested"
         );


### PR DESCRIPTION
`make build` happy without warning

```
warning: unused imports: `SmallVec`, `smallvec`
  --> crates/net/network/src/transactions/fetcher.rs:20:16
   |
20 | use smallvec::{smallvec, SmallVec};
   |                ^^^^^^^^  ^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused variable: `peer_id`
    --> crates/net/network/src/transactions/fetcher.rs:1114:9
     |
1114 |         peer_id: &PeerId,
     |         ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_peer_id`
     |
     = note: `#[warn(unused_variables)]` on by default
```