### PR TITLE
node: don't subscribe to consensus health events for dev node

### DIFF
--- a/bin/reth/src/builder.rs
+++ b/bin/reth/src/builder.rs
@@ -372,7 +372,7 @@ impl<DB: Database + DatabaseMetrics + DatabaseMetadata + 'static> NodeBuilderWit
             network.event_listener().map(Into::into),
             beacon_engine_handle.event_listener().map(Into::into),
             pipeline_events.map(Into::into),
-            if self.config.debug.tip.is_none() {
+            if self.config.debug.tip.is_none() && !self.config.dev.dev {
                 Either::Left(
                     ConsensusLayerHealthEvents::new(Box::new(blockchain_db.clone()))
                         .map(Into::into),

--- a/crates/node-builder/src/builder.rs
+++ b/crates/node-builder/src/builder.rs
@@ -541,7 +541,7 @@ where
             network.event_listener().map(Into::into),
             beacon_engine_handle.event_listener().map(Into::into),
             pipeline_events.map(Into::into),
-            if config.debug.tip.is_none() {
+            if config.debug.tip.is_none() && !config.dev.dev {
                 Either::Left(
                     ConsensusLayerHealthEvents::new(Box::new(blockchain_db.clone()))
                         .map(Into::into),


### PR DESCRIPTION
I'm running a node with `--dev` locally, but happened to see the annoying `no updates` messages, eg:

```
2024-02-29T03:03:54.059470Z  WARN Beacon client online, but no consensus updates received for a while. Please fix your beacon client to follow the chain! period=530.582623334s
2024-02-29T03:03:57.058854Z  INFO Status connected_peers=0 freelist=17 latest_block=2
2024-02-29T03:04:22.058239Z  INFO Status connected_peers=0 freelist=17 latest_block=2
2024-02-29T03:04:47.057463Z  INFO Status connected_peers=0 freelist=17 latest_block=2
2024-02-29T03:08:32.046472Z  INFO Status connected_peers=0 freelist=17 latest_block=2
...
2024-02-29T03:08:54.047061Z  WARN Beacon client online, but no consensus updates received for a while. Please fix your beacon client to follow ...
```

As the beacon client in `--dev` mode is a simulator, so we don't need to subscribe to the health events. 