### PR TITLE
feat(bin): drop static files in `db drop`

### DIFF
--- a/bin/reth/src/commands/db/mod.rs
+++ b/bin/reth/src/commands/db/mod.rs
@@ -96,6 +96,7 @@ impl Command {
         // add network name to data dir
         let data_dir = self.datadir.unwrap_or_chain_default(self.chain.chain);
         let db_path = data_dir.db_path();
+        let static_files_path = data_dir.static_files_path();
 
         match self.command {
             // TODO: We'll need to add this on the DB trait.
@@ -105,7 +106,7 @@ impl Command {
                     DatabaseArguments::default().log_level(self.db.log_level),
                 )?;
                 let provider_factory =
-                    ProviderFactory::new(db, self.chain.clone(), data_dir.static_files_path())?;
+                    ProviderFactory::new(db, self.chain.clone(), static_files_path)?;
 
                 let tool = DbTool::new(provider_factory, self.chain.clone())?;
                 command.execute(data_dir, &tool)?;
@@ -116,7 +117,7 @@ impl Command {
                     DatabaseArguments::default().log_level(self.db.log_level),
                 )?;
                 let provider_factory =
-                    ProviderFactory::new(db, self.chain.clone(), data_dir.static_files_path())?;
+                    ProviderFactory::new(db, self.chain.clone(), static_files_path)?;
 
                 let tool = DbTool::new(provider_factory, self.chain.clone())?;
                 command.execute(&tool)?;
@@ -127,7 +128,7 @@ impl Command {
                     DatabaseArguments::default().log_level(self.db.log_level),
                 )?;
                 let provider_factory =
-                    ProviderFactory::new(db, self.chain.clone(), data_dir.static_files_path())?;
+                    ProviderFactory::new(db, self.chain.clone(), static_files_path)?;
 
                 let tool = DbTool::new(provider_factory, self.chain.clone())?;
                 command.execute(&tool)?;
@@ -138,7 +139,7 @@ impl Command {
                     DatabaseArguments::default().log_level(self.db.log_level),
                 )?;
                 let provider_factory =
-                    ProviderFactory::new(db, self.chain.clone(), data_dir.static_files_path())?;
+                    ProviderFactory::new(db, self.chain.clone(), static_files_path)?;
 
                 let tool = DbTool::new(provider_factory, self.chain.clone())?;
                 command.execute(&tool)?;
@@ -146,7 +147,7 @@ impl Command {
             Subcommands::Drop { force } => {
                 if !force {
                     // Ask for confirmation
-                    print!("Are you sure you want to drop the database at {db_path:?}? This cannot be undone. (y/N): ");
+                    print!("Are you sure you want to drop the database at {data_dir}? This cannot be undone. (y/N): ");
                     // Flush the buffer to ensure the message is printed immediately
                     io::stdout().flush().unwrap();
 
@@ -162,16 +163,16 @@ impl Command {
                 let db =
                     open_db(&db_path, DatabaseArguments::default().log_level(self.db.log_level))?;
                 let provider_factory =
-                    ProviderFactory::new(db, self.chain.clone(), data_dir.static_files_path())?;
+                    ProviderFactory::new(db, self.chain.clone(), static_files_path.clone())?;
 
                 let mut tool = DbTool::new(provider_factory, self.chain.clone())?;
-                tool.drop(db_path)?;
+                tool.drop(db_path, static_files_path)?;
             }
             Subcommands::Clear(command) => {
                 let db =
                     open_db(&db_path, DatabaseArguments::default().log_level(self.db.log_level))?;
                 let provider_factory =
-                    ProviderFactory::new(db, self.chain.clone(), data_dir.static_files_path())?;
+                    ProviderFactory::new(db, self.chain.clone(), static_files_path)?;
 
                 command.execute(provider_factory)?;
             }

--- a/bin/reth/src/utils.rs
+++ b/bin/reth/src/utils.rs
@@ -130,11 +130,21 @@ impl<DB: Database> DbTool<DB> {
             .map_err(|e| eyre::eyre!(e))
     }
 
-    /// Drops the database at the given path.
-    pub fn drop(&mut self, path: impl AsRef<Path>) -> Result<()> {
-        let path = path.as_ref();
-        info!(target: "reth::cli", "Dropping database at {:?}", path);
-        fs::remove_dir_all(path)?;
+    /// Drops the database and the static files at the given path.
+    pub fn drop(
+        &mut self,
+        db_path: impl AsRef<Path>,
+        static_files_path: impl AsRef<Path>,
+    ) -> Result<()> {
+        let db_path = db_path.as_ref();
+        info!(target: "reth::cli", "Dropping database at {:?}", db_path);
+        fs::remove_dir_all(db_path)?;
+
+        let static_files_path = static_files_path.as_ref();
+        info!(target: "reth::cli", "Dropping static files at {:?}", static_files_path);
+        fs::remove_dir_all(static_files_path)?;
+        fs::create_dir_all(static_files_path)?;
+
         Ok(())
     }
 


### PR DESCRIPTION
```console
➜  reth (alexey/breaking-changes) cargo run --bin reth -- db --chain holesky drop                                                                                                                                       ✭ ✈
    Blocking waiting for file lock on build directory
   Compiling reth v0.1.0-alpha.21 (/Users/shekhirin/Projects/reth/bin/reth)
    Finished dev [unoptimized + debuginfo] target(s) in 29.22s
     Running `target/debug/reth db --chain holesky drop`
Are you sure you want to drop the database at /Users/shekhirin/Library/Application Support/reth/holesky? This cannot be undone. (y/N): y
2024-02-29T12:08:38.252312Z  INFO Dropping database at "/Users/shekhirin/Library/Application Support/reth/holesky/db"
2024-02-29T12:08:38.253621Z  INFO Dropping static files at "/Users/shekhirin/Library/Application Support/reth/holesky/static_files"
```