### PR TITLE
fix(ci): header check in integration/sync

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -71,8 +71,7 @@ jobs:
       - name: Verify the target block hash
         run: |
           cargo run --release --bin reth \
-            -- db \
-            get CanonicalHeaders 100000 \
+            -- db get static-file headers 100000 \
             | grep 0x91c90676cab257a59cd956d7cb0bceb9b1a71d79755c23c7277a0697ccfaf8c4
 
   integration-success:


### PR DESCRIPTION
We have a new syntax for `reth db get` command

```console
reth db get static-file headers 100000 | grep 0x91c90676cab257a59cd956d7cb0bceb9b1a71d79755c23c7277a0697ccfaf8c4
"0x91c90676cab257a59cd956d7cb0bceb9b1a71d79755c23c7277a0697ccfaf8c4"
```