### PR TITLE
feat(provider): consistent database view

### DIFF
--- a/crates/interfaces/src/provider.rs
+++ b/crates/interfaces/src/provider.rs
@@ -153,3 +153,20 @@ pub struct RootMismatch {
     /// The target block hash.
     pub block_hash: BlockHash,
 }
+
+/// Consistent database view error.
+#[derive(Error, Debug)]
+pub enum ConsistentViewError {
+    /// Error thrown on attempt to initialize provider while node is still syncing.
+    #[error("node is syncing. best block: {0}")]
+    Syncing(BlockNumber),
+    /// Error thrown on inconsistent database view.
+    #[error("inconsistent database state: {tip:?}")]
+    InconsistentView {
+        /// The tip diff.
+        tip: GotExpected<Option<B256>>,
+    },
+    /// Underlying provider error.
+    #[error(transparent)]
+    Provider(#[from] ProviderError),
+}

--- a/crates/storage/provider/src/providers/consistent_view.rs
+++ b/crates/storage/provider/src/providers/consistent_view.rs
@@ -1,0 +1,71 @@
+use crate::{BlockNumReader, DatabaseProviderFactory, DatabaseProviderRO, ProviderError};
+use reth_db::{cursor::DbCursorRO, database::Database, tables, transaction::DbTx};
+use reth_interfaces::provider::{ConsistentViewError, ProviderResult};
+use reth_primitives::{GotExpected, B256};
+use std::marker::PhantomData;
+
+/// A consistent view over state in the database.
+///
+/// View gets initialized with the latest or provided tip.
+/// Upon every attempt to create a database provider, the view will
+/// perform a consistency check of current tip against the initial one.
+///
+/// ## Usage
+///
+/// The view should only be used outside of staged-sync.
+/// Otherwise, any attempt to create a provider will result in [ConsistentViewError::Syncing].
+#[derive(Clone, Debug)]
+pub struct ConsistentDbView<DB, Provider> {
+    database: PhantomData<DB>,
+    provider: Provider,
+    tip: Option<B256>,
+}
+
+impl<DB, Provider> ConsistentDbView<DB, Provider>
+where
+    DB: Database,
+    Provider: DatabaseProviderFactory<DB>,
+{
+    /// Creates new consistent database view.
+    pub fn new(provider: Provider) -> Self {
+        Self { database: PhantomData, provider, tip: None }
+    }
+
+    /// Initializes the view with provided tip.
+    pub fn with_tip(mut self, tip: B256) -> Self {
+        self.tip = Some(tip);
+        self
+    }
+
+    /// Initializes the view with latest tip.
+    pub fn with_latest_tip(mut self) -> ProviderResult<Self> {
+        let provider = self.provider.database_provider_ro()?;
+        let tip = provider.tx_ref().cursor_read::<tables::CanonicalHeaders>()?.last()?;
+        self.tip = tip.map(|(_, hash)| hash);
+        Ok(self)
+    }
+
+    /// Creates new read-only provider and performs consistency checks on the current tip.
+    pub fn provider_ro(&self) -> Result<DatabaseProviderRO<DB>, ConsistentViewError> {
+        let provider_ro = self.provider.database_provider_ro()?;
+        let last_entry = provider_ro
+            .tx_ref()
+            .cursor_read::<tables::CanonicalHeaders>()
+            .and_then(|mut cursor| cursor.last())
+            .map_err(ProviderError::Database)?;
+
+        let tip = last_entry.map(|(_, hash)| hash);
+        if self.tip != tip {
+            return Err(ConsistentViewError::InconsistentView {
+                tip: GotExpected { got: tip, expected: self.tip },
+            })
+        }
+
+        let best_block_number = provider_ro.best_block_number()?;
+        if last_entry.map(|(number, _)| number).unwrap_or_default() != best_block_number {
+            return Err(ConsistentViewError::Syncing(best_block_number))
+        }
+
+        Ok(provider_ro)
+    }
+}


### PR DESCRIPTION
## Description

Extracted from https://github.com/paradigmxyz/reth/pull/6576 and modified.

This PR adds an ability to create a consistent view of the database. Each attempt to create a provider will be followed by tip consistency checks.

## Intended Usage

This view is useful when attempting to perform parallel reads of the state across multiple threads while preserving the guarantee that the state remains unchanged.