### PR TITLE
fix: don't enable jemalloc by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN cargo chef cook --profile $BUILD_PROFILE --recipe-path recipe.json
 
 # Build application
 COPY . .
-RUN cargo build --profile $BUILD_PROFILE --no-default-features --locked --bin reth
+RUN cargo build --profile $BUILD_PROFILE --locked --bin reth
 
 # ARG is not resolved in COPY so we have to hack around it by copying the
 # binary to a temporary location

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -110,8 +110,6 @@ jsonrpsee.workspace = true
 assert_matches = "1.5.0"
 
 [features]
-default = ["jemalloc"]
-
 asm-keccak = ["reth-primitives/asm-keccak"]
 
 jemalloc = ["dep:jemallocator", "reth-node-core/jemalloc"]


### PR DESCRIPTION
It's not very portable, so we shouldn't enable it by default.

We instruct users to pass the feature when building from source for better performance (<https://paradigmxyz.github.io/reth/installation/source.html>), and we pass it ourselves in Makefile FEATURES <https://github.com/paradigmxyz/reth/blob/5cb0258ce4c4a7dccd01836414560191e5416175/Makefile#L18>

Fixes https://github.com/paradigmxyz/reth/issues/6742