### PR TITLE
test(ef-tests, storage): do not `sync_all` static files in state tests

### DIFF
--- a/crates/storage/nippy-jar/Cargo.toml
+++ b/crates/storage/nippy-jar/Cargo.toml
@@ -44,3 +44,4 @@ tempfile.workspace = true
 
 [features]
 default = []
+test-utils = []

--- a/crates/storage/nippy-jar/src/writer.rs
+++ b/crates/storage/nippy-jar/src/writer.rs
@@ -394,10 +394,10 @@ impl<H: NippyJarHeader> NippyJarWriter<H> {
     }
 
     #[cfg(feature = "test-utils")]
-    pub fn commit_without_fsync(&mut self) -> Result<(), NippyJarError> {
+    pub fn commit_without_sync_all(&mut self) -> Result<(), NippyJarError> {
         self.data_file.flush()?;
 
-        self.commit_offsets_without_fsync()?;
+        self.commit_offsets_without_sync_all()?;
 
         // Flushes `max_row_size` and total `rows` to disk.
         self.jar.freeze_config()?;
@@ -414,7 +414,7 @@ impl<H: NippyJarHeader> NippyJarWriter<H> {
     }
 
     #[cfg(feature = "test-utils")]
-    fn commit_offsets_without_fsync(&mut self) -> Result<(), NippyJarError> {
+    fn commit_offsets_without_sync_all(&mut self) -> Result<(), NippyJarError> {
         self.commit_offsets_inner()
     }
 

--- a/crates/storage/nippy-jar/src/writer.rs
+++ b/crates/storage/nippy-jar/src/writer.rs
@@ -420,7 +420,7 @@ impl<H: NippyJarHeader> NippyJarWriter<H> {
 
     /// Flushes offsets to disk.
     ///
-    /// CAUTION: Does not call `fsync` on the offsets file and requires a manual call to
+    /// CAUTION: Does not call `sync_all` on the offsets file and requires a manual call to
     /// `self.offsets_file.get_ref().sync_all()`.
     fn commit_offsets_inner(&mut self) -> Result<(), NippyJarError> {
         // The last offset on disk can be the first offset of `self.offsets` given how

--- a/crates/storage/nippy-jar/src/writer.rs
+++ b/crates/storage/nippy-jar/src/writer.rs
@@ -113,7 +113,6 @@ impl<H: NippyJarHeader> NippyJarWriter<H> {
 
         // First byte of the offset file is the size of one offset in bytes
         offsets_file.write_all(&[OFFSET_SIZE_BYTES as u8])?;
-        offsets_file.sync_all()?;
         offsets_file.seek(SeekFrom::End(0))?;
 
         Ok((data_file, offsets_file, is_created))

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -61,5 +61,5 @@ assert_matches.workspace = true
 rand.workspace = true
 
 [features]
-test-utils = ["alloy-rlp", "reth-db/test-utils"]
+test-utils = ["alloy-rlp", "reth-db/test-utils", "reth-nippy-jar/test-utils"]
 optimism = ["reth-primitives/optimism", "reth-interfaces/optimism"]

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -124,11 +124,11 @@ impl StaticFileProviderRW {
     ///
     /// CAUTION: does not call `sync_all` on the files.
     #[cfg(feature = "test-utils")]
-    pub fn commit_without_fsync(&mut self) -> ProviderResult<()> {
+    pub fn commit_without_sync_all(&mut self) -> ProviderResult<()> {
         let start = Instant::now();
 
         // Commits offsets and new user_header to disk
-        self.writer.commit_without_fsync()?;
+        self.writer.commit_without_sync_all()?;
 
         if let Some(metrics) = &self.metrics {
             metrics.record_segment_operation(

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -120,6 +120,9 @@ impl StaticFileProviderRW {
         Ok(())
     }
 
+    /// Commits configuration changes to disk and updates the reader index with the new changes.
+    ///
+    /// CAUTION: does not call `sync_all` on the files.
     #[cfg(feature = "test-utils")]
     pub fn commit_without_fsync(&mut self) -> ProviderResult<()> {
         let start = Instant::now();

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -120,6 +120,34 @@ impl StaticFileProviderRW {
         Ok(())
     }
 
+    #[cfg(feature = "test-utils")]
+    pub fn commit_without_fsync(&mut self) -> ProviderResult<()> {
+        let start = Instant::now();
+
+        // Commits offsets and new user_header to disk
+        self.writer.commit_without_fsync()?;
+
+        if let Some(metrics) = &self.metrics {
+            metrics.record_segment_operation(
+                self.writer.user_header().segment(),
+                StaticFileProviderOperation::CommitWriter,
+                Some(start.elapsed()),
+            );
+        }
+
+        debug!(
+            target: "provider::static_file",
+            segment = ?self.writer.user_header().segment(),
+            path = ?self.data_path,
+            duration = ?start.elapsed(),
+            "Commit"
+        );
+
+        self.update_index()?;
+
+        Ok(())
+    }
+
     /// Updates the `self.reader` internal index.
     fn update_index(&self) -> ProviderResult<()> {
         // We find the maximum block of the segment by checking this writer's last block.

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -121,7 +121,7 @@ impl Case for BlockchainTestCase {
                     .static_file_provider()
                     .latest_writer(StaticFileSegment::Headers)
                     .unwrap()
-                    .commit()
+                    .commit_without_fsync()
                     .unwrap();
 
                 // Execute the execution stage using the EVM processor factory for the test case

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -121,7 +121,7 @@ impl Case for BlockchainTestCase {
                     .static_file_provider()
                     .latest_writer(StaticFileSegment::Headers)
                     .unwrap()
-                    .commit_without_fsync()
+                    .commit_without_sync_all()
                     .unwrap();
 
                 // Execute the execution stage using the EVM processor factory for the test case


### PR DESCRIPTION
There's no need to ensure that all in-memory buffers are flushed to disk for tests, because we don't reuse this data anymore after we finish.

> Even if the modifications have not made it to disk yet, the OS uses its buffer cache to reflect file modifications and guarantees atomicity level for reads and writes, to ALL processes. So not only your process, but any other process, would be able to see the changes.

source: https://stackoverflow.com/a/8547094

---

The removal of this `sync_all` https://github.com/paradigmxyz/reth/blob/8ea032adad8600b28dbc6041f39c3dc97952db2a/crates/storage/nippy-jar/src/writer.rs#L114-L117 is fine because we do it when actually writing the offsets.