### PR TITLE
feat(storage): log debug commit message only on commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5947,7 +5947,6 @@ dependencies = [
  "iai",
  "metrics",
  "modular-bitfield",
- "once_cell",
  "page_size",
  "parity-scale-codec",
  "paste",

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -130,12 +130,15 @@ impl<K: TransactionKind> Tx<K> {
             let (result, commit_latency) = f(tx);
             let total_duration = start.elapsed();
 
-            debug!(
-                target: "storage::db::mdbx",
-                ?total_duration,
-                ?commit_latency,
-                "Commit"
-            );
+            if outcome.is_commit() {
+                debug!(
+                    target: "storage::db::mdbx",
+                    ?total_duration,
+                    ?commit_latency,
+                    is_read_only = K::IS_READ_ONLY,
+                    "Commit"
+                );
+            }
 
             (result, commit_latency, total_duration)
         };

--- a/crates/storage/db/src/metrics.rs
+++ b/crates/storage/db/src/metrics.rs
@@ -187,6 +187,11 @@ impl TransactionOutcome {
             TransactionOutcome::Drop => "drop",
         }
     }
+
+    /// Returns `true` if the transaction outcome is a commit.
+    pub(crate) const fn is_commit(&self) -> bool {
+        matches!(self, TransactionOutcome::Commit)
+    }
 }
 
 /// Types of operations conducted on the database: get, put, delete, and various cursor operations.


### PR DESCRIPTION
`execute_with_close_transaction_metric` is also called on aborts when we just drop the read transaction