### PR TITLE
fix(tx-fetcher): only remove peer from active_peers when inflight_count <= 0

### DIFF
--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -91,7 +91,7 @@ impl TransactionFetcher {
         let remove = || -> bool {
             if let Some(inflight_count) = self.active_peers.get(peer_id) {
                 *inflight_count -= 1;
-                if *inflight_count <= 0 {
+                if *inflight_count == 0 {
                     return true
                 }
             }

--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -90,10 +90,10 @@ impl TransactionFetcher {
     fn decrement_inflight_request_count_for(&mut self, peer_id: &PeerId) {
         let remove = || -> bool {
             if let Some(inflight_count) = self.active_peers.get(peer_id) {
-                if *inflight_count <= DEFAULT_MAX_COUNT_CONCURRENT_REQUESTS_PER_PEER {
+                *inflight_count -= 1;
+                if *inflight_count <= 0 {
                     return true
                 }
-                *inflight_count -= 1;
             }
             false
         }();

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -2049,6 +2049,7 @@ mod tests {
 
         // peer_1 is idle
         assert!(tx_fetcher.is_idle(&peer_id_1));
+        assert_eq!(tx_fetcher.active_peers.len(), 0);
 
         // sends request for buffered hashes to peer_1
         tx_fetcher.on_fetch_pending_hashes(&tx_manager.peers, |_| true, || ());
@@ -2058,6 +2059,7 @@ mod tests {
         assert!(tx_fetcher.hashes_pending_fetch.is_empty());
         // as long as request is in inflight peer_1 is not idle
         assert!(!tx_fetcher.is_idle(&peer_id_1));
+        assert_eq!(tx_fetcher.active_peers.len(), 1);
 
         // mock session of peer_1 receives request
         let req = to_mock_session_rx
@@ -2079,6 +2081,7 @@ mod tests {
 
         // request has resolved, peer_1 is idle again
         assert!(tx_fetcher.is_idle(&peer_id));
+        assert_eq!(tx_fetcher.active_peers.len(), 0);
         // failing peer_1's request buffers requested hashes for retry
         assert_eq!(tx_fetcher.hashes_pending_fetch.len(), 2);
 
@@ -2091,6 +2094,9 @@ mod tests {
         tx_manager.on_new_pooled_transaction_hashes(peer_id_2, msg);
 
         let tx_fetcher = &mut tx_manager.transaction_fetcher;
+
+        // peer_2 should be in active_peers.
+        assert_eq!(tx_fetcher.active_peers.len(), 1);
 
         // since hashes are already seen, no changes to length of unknown hashes
         assert_eq!(tx_fetcher.hashes_fetch_inflight_and_pending_fetch.len(), 2);
@@ -2113,5 +2119,6 @@ mod tests {
         // `MAX_REQUEST_RETRIES_PER_TX_HASH`, 2, for hashes reached so this time won't be buffered
         // for retry
         assert!(tx_fetcher.hashes_pending_fetch.is_empty());
+        assert_eq!(tx_fetcher.active_peers.len(), 0);
     }
 }


### PR DESCRIPTION
fix logic error of `decrement_inflight_request_count_for`.