### PR TITLE
chore: Remove feature = optimism from reth-optimism-payload-builder

### DIFF
--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -133,7 +133,7 @@ optimism = [
     "reth-network-api/optimism",
     "reth-blockchain-tree/optimism",
     "reth-payload-builder/optimism",
-    "reth-optimism-payload-builder/optimism",
+    "reth-optimism-payload-builder",
     "dep:reth-node-optimism",
     "reth-node-core/optimism",
 ]

--- a/crates/node-core/Cargo.toml
+++ b/crates/node-core/Cargo.toml
@@ -125,7 +125,7 @@ optimism = [
     "reth-consensus-common/optimism",
     "reth-blockchain-tree/optimism",
     "reth-beacon-consensus/optimism",
-    "reth-optimism-payload-builder/optimism",
+    "reth-optimism-payload-builder",
 ]
 
 jemalloc = ["dep:jemalloc-ctl"]

--- a/crates/node-optimism/Cargo.toml
+++ b/crates/node-optimism/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 reth-primitives.workspace = true
 reth-payload-builder.workspace = true
 reth-basic-payload-builder.workspace = true
-reth-optimism-payload-builder.workspace = true
+reth-optimism-payload-builder = { workspace = true, optional = true }
 reth-rpc-types.workspace = true
 reth-rpc.workspace = true
 reth-rpc-types-compat.workspace = true
@@ -44,5 +44,5 @@ optimism = [
     "reth-provider/optimism",
     "reth-rpc-types-compat/optimism",
     "reth-rpc/optimism",
-    "reth-optimism-payload-builder/optimism",
+    "reth-optimism-payload-builder",
 ]

--- a/crates/payload/optimism/Cargo.toml
+++ b/crates/payload/optimism/Cargo.toml
@@ -13,11 +13,11 @@ workspace = true
 
 [dependencies]
 # reth
-reth-primitives.workspace = true
-reth-revm.workspace = true
-reth-transaction-pool.workspace = true
-reth-provider.workspace = true
-reth-payload-builder.workspace = true
+reth-primitives ={workspace = true, features = ["optimism"]}
+reth-revm = {workspace = true, features = ["optimism"]}
+reth-transaction-pool = {workspace = true, features = ["optimism"]}
+reth-provider = {workspace = true, features = ["optimism"]}
+reth-payload-builder={workspace = true, features = ["optimism"] }
 reth-basic-payload-builder.workspace = true
 
 # ethereum
@@ -26,15 +26,3 @@ revm.workspace = true
 # misc
 tracing.workspace = true
 thiserror.workspace = true
-
-
-[features]
-# This is a workaround for reth-cli crate to allow this as mandatory dependency without breaking the build even if unused.
-# This makes managing features and testing workspace easier because clippy always builds all members if --workspace is provided
-optimism = [
-    "reth-primitives/optimism",
-    "reth-revm/optimism",
-    "reth-transaction-pool/optimism",
-    "reth-provider/optimism",
-    "reth-payload-builder/optimism",
-]

--- a/crates/payload/optimism/src/lib.rs
+++ b/crates/payload/optimism/src/lib.rs
@@ -5,15 +5,12 @@
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
     issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
-#![cfg_attr(all(not(test), feature = "optimism"), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
-#[cfg(feature = "optimism")]
 pub use builder::*;
 
 pub mod error;
 
-#[cfg(feature = "optimism")]
 mod builder {
     use crate::error::OptimismPayloadBuilderError;
     use reth_basic_payload_builder::*;


### PR DESCRIPTION
close https://github.com/paradigmxyz/reth/issues/6906

The crate is only imported when building op-reth.