### PR TITLE
Fix smallvec dependency conflict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5941,6 +5941,7 @@ dependencies = [
  "iai",
  "metrics",
  "modular-bitfield",
+ "once_cell",
  "page_size",
  "parity-scale-codec",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -230,7 +230,7 @@ hex-literal = "0.4"
 once_cell = "1.17"
 syn = "2.0"
 nybbles = "0.2.1"
-smallvec = "1.13"
+smallvec = "1"
 
 # proc-macros
 proc-macro2 = "1.0"


### PR DESCRIPTION
Currently when trying to install `reth` as a library, there is an error due to conflicting nested dependencies on the `smallvec package. (See [this ci failure](https://github.com/ultrasoundmoney/reth-payload-validator/actions/runs/8139115723/job/22241544551)). 

This pr in it's current version fixes that specific conflict, which however uncovers another conflict regarding "bitflags". (see [this other ci failure](https://github.com/ultrasoundmoney/reth-payload-validator/actions/runs/8139465355/job/22242691398)).

This leads me to wonder wether I am doing something wrong when importing reth [like this](https://github.com/ultrasoundmoney/reth-payload-validator/pull/27/commits/43189a1a5c199835e575c91b950aacc0766de915), or if not wether there is something else that can be done on reth ci side to avoid such issues in the future. (i.e. adding some ci step that ensures that the current version is actually installable as cargo dependency).