### PR TITLE
chore(node-core): log errors in debug when ETA fails to calculate

### DIFF
--- a/bin/reth/src/sigsegv_handler.rs
+++ b/bin/reth/src/sigsegv_handler.rs
@@ -51,7 +51,7 @@ extern "C" fn print_stack_trace(_: libc::c_int) {
         // Collect return addresses
         let depth = libc::backtrace(STACK_TRACE.as_mut_ptr(), MAX_FRAMES as i32);
         if depth == 0 {
-            return;
+            return
         }
         &STACK_TRACE.as_slice()[0..(depth as _)]
     };

--- a/crates/ethereum-forks/src/hardfork.rs
+++ b/crates/ethereum-forks/src/hardfork.rs
@@ -91,22 +91,22 @@ impl Hardfork {
     /// Retrieves the activation block for the specified hardfork on the given chain.
     pub fn activation_block(&self, chain: Chain) -> Option<u64> {
         if chain == Chain::mainnet() {
-            return self.mainnet_activation_block();
+            return self.mainnet_activation_block()
         }
         if chain == Chain::sepolia() {
-            return self.sepolia_activation_block();
+            return self.sepolia_activation_block()
         }
         if chain == Chain::holesky() {
-            return self.holesky_activation_block();
+            return self.holesky_activation_block()
         }
 
         #[cfg(feature = "optimism")]
         {
             if chain == Chain::base_sepolia() {
-                return self.base_sepolia_activation_block();
+                return self.base_sepolia_activation_block()
             }
             if chain == Chain::base_mainnet() {
-                return self.base_mainnet_activation_block();
+                return self.base_mainnet_activation_block()
             }
         }
 
@@ -252,21 +252,21 @@ impl Hardfork {
     /// Retrieves the activation timestamp for the specified hardfork on the given chain.
     pub fn activation_timestamp(&self, chain: Chain) -> Option<u64> {
         if chain == Chain::mainnet() {
-            return self.mainnet_activation_timestamp();
+            return self.mainnet_activation_timestamp()
         }
         if chain == Chain::sepolia() {
-            return self.sepolia_activation_timestamp();
+            return self.sepolia_activation_timestamp()
         }
         if chain == Chain::holesky() {
-            return self.holesky_activation_timestamp();
+            return self.holesky_activation_timestamp()
         }
         #[cfg(feature = "optimism")]
         {
             if chain == Chain::base_sepolia() {
-                return self.base_sepolia_activation_timestamp();
+                return self.base_sepolia_activation_timestamp()
             }
             if chain == Chain::base_mainnet() {
-                return self.base_mainnet_activation_timestamp();
+                return self.base_mainnet_activation_timestamp()
             }
         }
 

--- a/crates/node-core/src/events/node.rs
+++ b/crates/node-core/src/events/node.rs
@@ -23,7 +23,7 @@ use std::{
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 use tokio::time::Interval;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 /// Interval of reporting node state.
 const INFO_MESSAGE_INTERVAL: Duration = Duration::from_secs(25);
@@ -483,14 +483,21 @@ impl Eta {
         let Some(current) = checkpoint.entities() else { return };
 
         if let Some(last_checkpoint_time) = &self.last_checkpoint_time {
-            let processed_since_last = current.processed - self.last_checkpoint.processed;
+            let Some(processed_since_last) = current.processed.checked_sub(self.last_checkpoint.processed) else {
+                self.eta = None;
+                debug!(target: "reth::cli", ?current, ?self.last_checkpoint, "Failed to calculate the ETA: processed entities is less than the last checkpoint");
+                return
+            };
             let elapsed = last_checkpoint_time.elapsed();
             let per_second = processed_since_last as f64 / elapsed.as_secs_f64();
 
-            self.eta = Duration::try_from_secs_f64(
-                ((current.total - current.processed) as f64) / per_second,
-            )
-            .ok();
+            let Some(remaining) = current.total.checked_sub(current.processed) else {
+                self.eta = None;
+                debug!(target: "reth::cli", ?current, "Failed to calculate the ETA: total entities is less than processed entities");
+                return
+            };
+
+            self.eta = Duration::try_from_secs_f64(remaining as f64 / per_second).ok();
         }
 
         self.last_checkpoint = current;

--- a/crates/node-core/src/events/node.rs
+++ b/crates/node-core/src/events/node.rs
@@ -483,7 +483,9 @@ impl Eta {
         let Some(current) = checkpoint.entities() else { return };
 
         if let Some(last_checkpoint_time) = &self.last_checkpoint_time {
-            let Some(processed_since_last) = current.processed.checked_sub(self.last_checkpoint.processed) else {
+            let Some(processed_since_last) =
+                current.processed.checked_sub(self.last_checkpoint.processed)
+            else {
                 self.eta = None;
                 debug!(target: "reth::cli", ?current, ?self.last_checkpoint, "Failed to calculate the ETA: processed entities is less than the last checkpoint");
                 return

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -642,7 +642,7 @@ impl PoolTransaction for MockTransaction {
 
         // If the maximum fee per gas is less than the base fee, return None
         if max_fee_per_gas < base_fee {
-            return None;
+            return None
         }
 
         // Calculate the fee by subtracting the base fee from the maximum fee per gas
@@ -651,7 +651,7 @@ impl PoolTransaction for MockTransaction {
         // If the maximum priority fee per gas is available, return the minimum of fee and priority
         // fee
         if let Some(priority_fee) = self.max_priority_fee_per_gas() {
-            return Some(fee.min(priority_fee));
+            return Some(fee.min(priority_fee))
         }
 
         // Otherwise, return the calculated fee

--- a/examples/custom-node/src/main.rs
+++ b/examples/custom-node/src/main.rs
@@ -99,9 +99,7 @@ impl PayloadAttributes for CustomPayloadAttributes {
 
         // custom validation logic - ensure that the custom field is not zero
         if self.custom == 0 {
-            return Err(AttributesValidationError::invalid_params(
-                CustomError::CustomFieldIsNotZero,
-            ));
+            return Err(AttributesValidationError::invalid_params(CustomError::CustomFieldIsNotZero))
         }
 
         Ok(())


### PR DESCRIPTION
I couldn't instantly identify the source of this debug mode panic
```console
2024-03-01T16:50:35.849816Z  INFO Executing stage pipeline_stages=2/12 stage=Bodies checkpoint=1046000 target=1046230
thread 'tokio-runtime-worker' panicked at crates/node-core/src/events/node.rs:491:18:
attempt to subtract with overflow
stack backtrace:
2024-03-01T16:50:36.219074Z  INFO Recovering senders tx_range=0..5000384
   0: rust_begin_unwind
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/panicking.rs:645:5
   1: core::panicking::panic_fmt
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/core/src/panicking.rs:72:14
   2: core::panicking::panic
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/core/src/panicking.rs:144:5
   3: reth_node_core::events::node::Eta::update
             at ./crates/node-core/src/events/node.rs:491:18
   4: reth_node_core::events::node::NodeState<DB>::handle_pipeline_event
             at ./crates/node-core/src/events/node.rs:120:21
   5: <reth_node_core::events::node::EventHandler<E,DB> as core::future::future::Future>::poll
             at ./crates/node-core/src/events/node.rs:445:21
   6: reth_node_core::events::node::handle_events::{{closure}}
             at ./crates/node-core/src/events/node.rs:358:13
   7: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::future::future::Future>::poll
```

So instead, on subtract with overflow, we log the error on debug level and reset the ETA instead of crashing or reporting the invalid ETA.