### PR TITLE
feat(node-core): stage progress decimal places

### DIFF
--- a/crates/primitives/src/stage/checkpoints.rs
+++ b/crates/primitives/src/stage/checkpoints.rs
@@ -148,7 +148,11 @@ impl EntitiesCheckpoint {
             return None
         }
 
-        Some(format!("{:.2}%", 100.0 * self.processed as f64 / self.total as f64))
+        // Calculate percentage with 2 decimal places.
+        let percentage = 100.0 * self.processed as f64 / self.total as f64;
+
+        // Truncate to 2 decimal places, rounding down so that 99.999% becomes 99.99% and not 100%.
+        Some(format!("{:.2}%", (percentage * 100.0).floor() / 100.0))
     }
 }
 


### PR DESCRIPTION
Blocked by https://github.com/paradigmxyz/reth/pull/6973

This formula adjustment prevents the situation when `99.9999%` rounds to `100%` and confuses the user, because the stage isn't finished yet, but reports the `100%` progress https://github.com/paradigmxyz/reth/blob/84f977c6a23ab56bf92c35b895c6a03bb2c1c89b/crates/primitives/src/stage/checkpoints.rs#L151-L155