### PR TITLE
chore: update cargo deny to handle deprecated config entries

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -72,11 +72,6 @@ expression = "LicenseRef-ring"
 license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 
 [[licenses.clarify]]
-name = "webpki"
-expression = "LicenseRef-webpki"
-license-files = [{ path = "LICENSE", hash = 0x001c7e6c }]
-
-[[licenses.clarify]]
 name = "rustls-webpki"
 expression = "LicenseRef-rustls-webpki"
 license-files = [{ path = "LICENSE", hash = 0x001c7e6c }]

--- a/deny.toml
+++ b/deny.toml
@@ -2,11 +2,8 @@
 # More documentation for the advisories section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
-vulnerability = "deny"
-unmaintained = "warn"
-unsound = "warn"
+version = 2
 yanked = "warn"
-notice = "warn"
 
 # This section is considered when running `cargo deny check bans`.
 # More documentation about the 'bans' section can be found here:
@@ -28,9 +25,8 @@ skip = []
 skip-tree = []
 
 [licenses]
-unlicensed = "deny"
+version = 2
 confidence-threshold = 0.8
-# copyleft = "deny"
 
 # List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
@@ -48,8 +44,6 @@ allow = [
     "Unicode-3.0",
     # https://github.com/briansmith/ring/issues/902
     "LicenseRef-ring",
-    # https://github.com/briansmith/webpki/issues/148
-    "LicenseRef-webpki",
     # https://github.com/rustls/webpki/blob/main/LICENSE ISC Style
     "LicenseRef-rustls-webpki",
 ]
@@ -65,6 +59,12 @@ exceptions = [
     { allow = ["CC0-1.0"], name = "tiny-keccak" },
     { allow = ["CC0-1.0"], name = "more-asserts" },
     { allow = ["CC0-1.0"], name = "aurora-engine-modexp" },
+    # TODO: decide on MPL-2.0 handling
+    # These dependencies are grandfathered in in https://github.com/paradigmxyz/reth/pull/#
+    { allow = ["MPL-2.0"], name = "attohttpc" },
+    { allow = ["MPL-2.0"], name = "option-ext" },
+    { allow = ["MPL-2.0"], name = "webpki-roots" },
+
 ]
 
 [[licenses.clarify]]

--- a/deny.toml
+++ b/deny.toml
@@ -60,7 +60,7 @@ exceptions = [
     { allow = ["CC0-1.0"], name = "more-asserts" },
     { allow = ["CC0-1.0"], name = "aurora-engine-modexp" },
     # TODO: decide on MPL-2.0 handling
-    # These dependencies are grandfathered in in https://github.com/paradigmxyz/reth/pull/#
+    # These dependencies are grandfathered in in https://github.com/paradigmxyz/reth/pull/6980
     { allow = ["MPL-2.0"], name = "attohttpc" },
     { allow = ["MPL-2.0"], name = "option-ext" },
     { allow = ["MPL-2.0"], name = "webpki-roots" },

--- a/deny.toml
+++ b/deny.toml
@@ -64,7 +64,6 @@ exceptions = [
     { allow = ["MPL-2.0"], name = "attohttpc" },
     { allow = ["MPL-2.0"], name = "option-ext" },
     { allow = ["MPL-2.0"], name = "webpki-roots" },
-
 ]
 
 [[licenses.clarify]]


### PR DESCRIPTION
A bunch of the [cargo deny config has been deprecated](https://github.com/EmbarkStudios/cargo-deny/pull/606) so this PR updates to target the new spec.

I don't know if you want to blanket accept MPL2.0 so I've just added exceptions for the current dependencies.