### PR TITLE
fix: Canyon timestamp overflow

### DIFF
--- a/crates/revm/src/optimism/mod.rs
+++ b/crates/revm/src/optimism/mod.rs
@@ -251,7 +251,7 @@ where
     // chain is an optimism chain, then we need to force-deploy the create2 deployer contract.
     if chain_spec.is_optimism() &&
         chain_spec.is_fork_active_at_timestamp(Hardfork::Canyon, timestamp) &&
-        !chain_spec.is_fork_active_at_timestamp(Hardfork::Canyon, timestamp - 2)
+        !chain_spec.is_fork_active_at_timestamp(Hardfork::Canyon, timestamp.saturating_sub(2))
     {
         trace!(target: "evm", "Forcing create2 deployer contract deployment on Canyon transition");
 


### PR DESCRIPTION
Seems now `canyon` could not be confiured at genesis, right?. And this timestamp may be overflow when timestamp is zero.