### PR TITLE
fix(staged-sync): correctly calculate total entries in bodies checkpoint

### DIFF
--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -346,8 +346,7 @@ fn stage_checkpoint<DB: Database>(
         // Count only static files entries. If we count the database entries too, we may have
         // duplicates. We're sure that the static files have all entries that database has,
         // because we run the `StaticFileProducer` before starting the pipeline.
-        total: (provider.static_file_provider().count_entries::<tables::Headers>()? as u64)
-            .saturating_sub(1),
+        total: provider.static_file_provider().count_entries::<tables::Headers>()? as u64,
     })
 }
 

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -396,7 +396,7 @@ mod tests {
                     total // seeded headers
                 }))
             }, done: false }) if block_number < 200 &&
-                processed == 1 + batch_size && total == previous_stage
+                processed == batch_size + 1 && total == previous_stage + 1
         );
         assert!(runner.validate_execution(input, output.ok()).is_ok(), "execution validation");
     }
@@ -435,7 +435,7 @@ mod tests {
                     }))
                 },
                 done: true
-            }) if processed == total && total == previous_stage
+            }) if processed + 1 == total && total == previous_stage + 1
         );
         assert!(runner.validate_execution(input, output.ok()).is_ok(), "execution validation");
     }
@@ -471,7 +471,7 @@ mod tests {
                     total
                 }))
             }, done: false }) if block_number >= 10 &&
-                processed == 1 + batch_size && total == previous_stage
+                processed - 1 == batch_size && total == previous_stage + 1
         );
         let first_run_checkpoint = first_run.unwrap().checkpoint;
 
@@ -492,7 +492,7 @@ mod tests {
                     total
                 }))
             }, done: true }) if block_number > first_run_checkpoint.block_number &&
-                processed == total && total == previous_stage
+                processed + 1 == total && total == previous_stage + 1
         );
         assert_matches!(
             runner.validate_execution(input, output.ok()),
@@ -533,7 +533,7 @@ mod tests {
                     total
                 }))
             }, done: true }) if block_number == previous_stage &&
-                processed == total && total == previous_stage
+                processed + 1 == total && total == previous_stage + 1
         );
         let checkpoint = output.unwrap().checkpoint;
         runner
@@ -559,7 +559,7 @@ mod tests {
                     processed: 1,
                     total
                 }))
-            }}) if total == previous_stage
+            }}) if total == previous_stage + 1
         );
 
         assert_matches!(runner.validate_unwind(input), Ok(_), "unwind validation");


### PR DESCRIPTION
## Description

Closes #6975.

`total` checkpoint number needs to account for genesis block since `processed` number includes it.