### PR TITLE
fix the return type for `getLogs`

### DIFF
--- a/crates/rpc/rpc-api/src/engine.rs
+++ b/crates/rpc/rpc-api/src/engine.rs
@@ -12,7 +12,7 @@ use reth_rpc_types::{
         ForkchoiceState, ForkchoiceUpdated, PayloadId, PayloadStatus, TransitionConfiguration,
     },
     state::StateOverride,
-    BlockOverrides, Filter, Log, RichBlock, SyncStatus, TransactionRequest,
+    BlockOverrides, Filter, FilterChanges, RichBlock, SyncStatus, TransactionRequest,
 };
 
 // NOTE: We can't use associated types in the `EngineApi` trait because of jsonrpsee, so we use a
@@ -209,5 +209,5 @@ pub trait EngineEthApi {
 
     /// Returns logs matching given filter object.
     #[method(name = "getLogs")]
-    async fn logs(&self, filter: Filter) -> RpcResult<Vec<Log>>;
+    async fn logs(&self, filter: Filter) -> RpcResult<FilterChanges>;
 }

--- a/crates/rpc/rpc-api/src/eth_filter.rs
+++ b/crates/rpc/rpc-api/src/eth_filter.rs
@@ -33,5 +33,5 @@ pub trait EthFilterApi {
 
     /// Returns logs matching given filter object.
     #[method(name = "getLogs")]
-    async fn logs(&self, filter: Filter) -> RpcResult<Vec<Log>>;
+    async fn logs(&self, filter: Filter) -> RpcResult<FilterChanges>;
 }

--- a/crates/rpc/rpc-api/src/eth_filter.rs
+++ b/crates/rpc/rpc-api/src/eth_filter.rs
@@ -1,5 +1,5 @@
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use reth_rpc_types::{Filter, FilterChanges, FilterId, Log, PendingTransactionFilterKind};
+use reth_rpc_types::{Filter, FilterChanges, FilterId, PendingTransactionFilterKind};
 /// Rpc Interface for poll-based ethereum filter API.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "eth"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "eth"))]

--- a/crates/rpc/rpc/src/engine.rs
+++ b/crates/rpc/rpc/src/engine.rs
@@ -4,7 +4,8 @@ use reth_rpc_api::{EngineEthApiServer, EthApiServer, EthFilterApiServer};
 /// Re-export for convenience
 pub use reth_rpc_engine_api::EngineApi;
 use reth_rpc_types::{
-    state::StateOverride, BlockOverrides, Filter, Log, RichBlock, SyncStatus, TransactionRequest,
+    state::StateOverride, BlockOverrides, Filter, FilterChanges, RichBlock, SyncStatus,
+    TransactionRequest,
 };
 use tracing_futures::Instrument;
 
@@ -95,7 +96,7 @@ where
     }
 
     /// Handler for `eth_getLogs`
-    async fn logs(&self, filter: Filter) -> Result<Vec<Log>> {
+    async fn logs(&self, filter: Filter) -> Result<FilterChanges> {
         self.eth_filter.logs(filter).instrument(engine_span!()).await
     }
 }

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -297,9 +297,10 @@ where
     /// Returns logs matching given filter object.
     ///
     /// Handler for `eth_getLogs`
-    async fn logs(&self, filter: Filter) -> RpcResult<Vec<Log>> {
+    async fn logs(&self, filter: Filter) -> RpcResult<FilterChanges> {
         trace!(target: "rpc::eth", "Serving eth_getLogs");
-        Ok(self.inner.logs_for_filter(filter).await?)
+        let logs = self.inner.logs_for_filter(filter).await?;
+        Ok(FilterChanges::Logs(logs))
     }
 }
 


### PR DESCRIPTION
The return type for `getLogs` should match the type from `getFilterChanges` and `getFilterLogs` as per https://github.com/ethereum/execution-apis/blob/main/src/eth/filter.yaml.