### PR TITLE
fix: immediately refill slots

### DIFF
--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -156,10 +156,7 @@ impl PeersManager {
             handle_rx: UnboundedReceiverStream::new(handle_rx),
             queued_actions: Default::default(),
             reputation_weights,
-            refill_slots_interval: tokio::time::interval_at(
-                now + refill_slots_interval,
-                refill_slots_interval,
-            ),
+            refill_slots_interval: tokio::time::interval(refill_slots_interval),
             release_interval: tokio::time::interval_at(now + unban_interval, unban_interval),
             connection_info,
             ban_list,
@@ -1585,7 +1582,11 @@ mod tests {
             low: Duration::from_millis(200),
             ..Default::default()
         };
-        let config = PeersConfig { backoff_durations, ..Default::default() };
+        let config = PeersConfig {
+            backoff_durations,
+            refill_slots_interval: Duration::from_millis(200),
+            ..Default::default()
+        };
         let mut peers = PeersManager::new(config);
         peers.add_peer(peer, socket_addr, None);
 

--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -1538,9 +1538,7 @@ mod tests {
         let peer = PeerId::random();
         let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 1, 2)), 8008);
 
-        let backoff_durations = PeerBackoffDurations::test();
-        let config = PeersConfig { backoff_durations, ..PeersConfig::test() };
-        let mut peers = PeersManager::new(config);
+        let mut peers = PeersManager::new(PeersConfig::test());
         peers.add_peer(peer, socket_addr, None);
 
         match event!(peers) {
@@ -1579,7 +1577,7 @@ mod tests {
         assert!(peers.backed_off_peers.contains_key(&peer));
         assert!(peers.peers.get(&peer).unwrap().is_backed_off());
 
-        tokio::time::sleep(backoff_durations.low).await;
+        tokio::time::sleep(peers.backoff_durations.low).await;
 
         match event!(peers) {
             PeerAction::Connect { peer_id, .. } => {


### PR DESCRIPTION
ref #6987

this changes the refill interval to start right away and not `now + interval`, triggering a refill immediately.

this speeds up tests and is the correct behaviour in case the node launched with existing peers