### PR TITLE
fix: setting GH_TOKEN for hive tests

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -193,6 +193,8 @@ jobs:
           hive --sim "${{ matrix.sim }}$" --sim.limit "${{matrix.limit}}/${{join(matrix.include, '|')}}" --client reth
 
       - name: Create github issue if sim failed
+        env:
+          GH_TOKEN: ${{ github.token }}
         if: ${{ failure() }}
         run: |
           echo "Simulator failed, creating issue"


### PR DESCRIPTION
This PR will fix the hive issue creation for failed tests. Token is already scoped to the right perms it just needs to be set as an env variable on the step