### PR TITLE
bugfix: hive build-args

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -29,7 +29,9 @@ jobs:
         with:
           context: .
           tags: ghcr.io/paradigmxyz/reth:latest
-          build-args: BUILD_PROFILE=hivetests,FEATURES=asm-keccak
+          build-args: |
+            BUILD_PROFILE=hivetests
+            FEATURES=asm-keccak
           outputs: type=docker,dest=./artifacts/reth_image.tar
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Discovered a bug in the newly added build arg that stemmed from how the `docker/build-push-action` parses that field. Tested the run and this will correctly set both args