### PR TITLE
chore: condition export of generate_blob_sidecar on its cfg

### DIFF
--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -23,7 +23,7 @@ pub use legacy::TxLegacy;
 pub use meta::TransactionMeta;
 #[cfg(feature = "c-kzg")]
 pub use pooled::{PooledTransactionsElement, PooledTransactionsElementEcRecovered};
-#[cfg(all(feature = "c-kzg", feature = "arbitrary"))]
+#[cfg(all(feature = "c-kzg", any(test, feature = "arbitrary")))]
 pub use sidecar::generate_blob_sidecar;
 #[cfg(feature = "c-kzg")]
 pub use sidecar::{BlobTransaction, BlobTransactionSidecar, BlobTransactionValidationError};


### PR DESCRIPTION
Fixes the following warning when running `cargo test -p reth-primitives test_blob_transaction_decode`:
```
warning: unreachable `pub` item
   --> crates/primitives/src/transaction/sidecar.rs:495:1
    |
495 | pub fn generate_blob_sidecar(blobs: Vec<Blob>) -> BlobTransactionSidecar {
    | ---^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    | |
    | help: consider restricting its visibility: `pub(crate)`
    |
    = help: or consider exporting it for use by other crates
    = note: requested on the command line with `-W unreachable-pub`

```