### PR TITLE
chore: make clippy happy

### DIFF
--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -153,12 +153,11 @@ pub mod rpc {
 #[cfg(all(unix, any(target_env = "gnu", target_os = "macos")))]
 pub mod sigsegv_handler;
 
+/// Signal handler to extract a backtrace from stack overflow.
+///
+/// This is a no-op because this platform doesn't support our signal handler's requirements.
 #[cfg(not(all(unix, any(target_env = "gnu", target_os = "macos"))))]
 pub mod sigsegv_handler {
-    //! Signal handler to extract a backtrace from stack overflow.
-    //!
-    //! This is a no-op because this platform doesn't support our signal handler's requirements.
-
     /// No-op function.
     pub fn install() {}
 }

--- a/crates/primitives/src/revm/env.rs
+++ b/crates/primitives/src/revm/env.rs
@@ -285,7 +285,7 @@ where
                     (l.address, l.storage_keys.iter().map(|k| U256::from_be_bytes(k.0)).collect())
                 })
                 .collect();
-            tx_env.blob_hashes = tx.blob_versioned_hashes.clone();
+            tx_env.blob_hashes.clone_from(&tx.blob_versioned_hashes);
             tx_env.max_fee_per_blob_gas = Some(U256::from(tx.max_fee_per_blob_gas));
         }
         #[cfg(feature = "optimism")]


### PR DESCRIPTION
```
error: assigning the result of `Clone::clone()` may be inefficient
   --> crates/primitives/src/revm/env.rs:288:13
    |
288 |             tx_env.blob_hashes = tx.blob_versioned_hashes.clone();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_from()`: `tx_env.blob_hashes.clone_from(&tx.blob_versioned_hashes)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assigning_clones
    = note: `-D clippy::assigning-clones` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::assigning_clones)]`

error: could not compile `reth-primitives` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `reth-primitives` (lib test) due to 1 previous error
Error: Process completed with exit code 101.
```