### PR TITLE
feat(rpc): add support for `muxTracer`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=975a52a#975a52a31727618a0a27f27091656c59eb9714bb"
+source = "git+https://github.com/alloy-rs/alloy?rev=64d0352#64d035273241e89a19a4fb724cf7fc88c0f36777"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -174,7 +174,7 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=975a52a#975a52a31727618a0a27f27091656c59eb9714bb"
+source = "git+https://github.com/alloy-rs/alloy?rev=64d0352#64d035273241e89a19a4fb724cf7fc88c0f36777"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -196,7 +196,7 @@ dependencies = [
 [[package]]
 name = "alloy-node-bindings"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=975a52a#975a52a31727618a0a27f27091656c59eb9714bb"
+source = "git+https://github.com/alloy-rs/alloy?rev=64d0352#64d035273241e89a19a4fb724cf7fc88c0f36777"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -257,7 +257,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-engine-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=975a52a#975a52a31727618a0a27f27091656c59eb9714bb"
+source = "git+https://github.com/alloy-rs/alloy?rev=64d0352#64d035273241e89a19a4fb724cf7fc88c0f36777"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -272,7 +272,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-trace-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=975a52a#975a52a31727618a0a27f27091656c59eb9714bb"
+source = "git+https://github.com/alloy-rs/alloy?rev=64d0352#64d035273241e89a19a4fb724cf7fc88c0f36777"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -283,7 +283,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=975a52a#975a52a31727618a0a27f27091656c59eb9714bb"
+source = "git+https://github.com/alloy-rs/alloy?rev=64d0352#64d035273241e89a19a4fb724cf7fc88c0f36777"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6858,7 +6858,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/evm-inspectors?rev=7cdbe2e#7cdbe2ec1bd34444ae828725d6cd53ceea632ccc"
+source = "git+https://github.com/paradigmxyz/evm-inspectors?rev=f0551cb#f0551cb56be80065bce7a08aa2d5178eb1b1f337"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-trace-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,7 +188,7 @@ reth-trie-parallel = { path = "crates/trie-parallel" }
 # revm
 revm = { version = "6.1.0", features = ["std", "secp256k1"], default-features = false }
 revm-primitives = { version = "2.1.0", features = ["std"], default-features = false }
-revm-inspectors = { git = "https://github.com/paradigmxyz/evm-inspectors", rev = "7cdbe2e" }
+revm-inspectors = { git = "https://github.com/paradigmxyz/evm-inspectors", rev = "f0551cb" }
 
 # eth
 alloy-chains = { version = "0.1", feature = ["serde", "rlp", "arbitrary"] }
@@ -197,12 +197,12 @@ alloy-dyn-abi = "0.6"
 alloy-sol-types = "0.6"
 alloy-rlp = "0.3"
 alloy-trie = "0.3"
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "975a52a" }
-alloy-rpc-trace-types = { git = "https://github.com/alloy-rs/alloy", rev = "975a52a" }
-alloy-rpc-engine-types = { git = "https://github.com/alloy-rs/alloy", rev = "975a52a" }
-alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "975a52a" }
-alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", rev = "975a52a" }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "975a52a" }
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "64d0352" }
+alloy-rpc-trace-types = { git = "https://github.com/alloy-rs/alloy", rev = "64d0352" }
+alloy-rpc-engine-types = { git = "https://github.com/alloy-rs/alloy", rev = "64d0352" }
+alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "64d0352" }
+alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", rev = "64d0352" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "64d0352" }
 
 # TODO: Remove
 ethers-core = { version = "2.0.14", default-features = false }

--- a/crates/rpc/rpc/src/eth/error.rs
+++ b/crates/rpc/rpc/src/eth/error.rs
@@ -8,7 +8,7 @@ use jsonrpsee::{
 };
 use reth_interfaces::RethError;
 use reth_primitives::{revm_primitives::InvalidHeader, Address, Bytes, U256};
-use reth_revm::tracing::js::JsInspectorError;
+use reth_revm::tracing::{js::JsInspectorError, MuxError};
 use reth_rpc_types::{error::EthRpcErrorCode, request::TransactionInputError, BlockError};
 use reth_transaction_pool::error::{
     Eip4844PoolTransactionError, InvalidPoolTransactionError, PoolError, PoolErrorKind,
@@ -116,6 +116,9 @@ pub enum EthApiError {
     /// Error encountered when converting a transaction type
     #[error("Transaction conversion error")]
     TransactionConversionError,
+    /// Error thrown when tracing with a muxTracer fails
+    #[error(transparent)]
+    MuxTracerError(#[from] MuxError),
 }
 
 /// Eth Optimism Api Error
@@ -183,6 +186,7 @@ impl From<EthApiError> for ErrorObject<'static> {
                 OptimismEthApiError::L1BlockFeeError |
                 OptimismEthApiError::L1BlockGasError => internal_rpc_err(err.to_string()),
             },
+            EthApiError::MuxTracerError(msg) => internal_rpc_err(msg.to_string()),
         }
     }
 }


### PR DESCRIPTION
Adds support for tracing with `muxTracer`.

Continuation of https://github.com/alloy-rs/alloy/pull/252 and https://github.com/paradigmxyz/evm-inspectors/pull/57