### PR TITLE
bug template use multi-line input for version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -55,7 +55,7 @@ body:
         - Windows (ARM)
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: client-version
     attributes:
       label: What version/commit are you on?


### PR DESCRIPTION
`--version` is 5 lines and fits better in a `textarea` input.