### PR TITLE
chore: bump max concurrent outbound dials

### DIFF
--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -4,7 +4,7 @@ use crate::{
         reputation::{
             is_banned_reputation, DEFAULT_REPUTATION, MAX_TRUSTED_PEER_REPUTATION_CHANGE,
         },
-        ReputationChangeWeights, DEFAULT_MAX_COUNT_CONCURRENT_DIALS,
+        ReputationChangeWeights, DEFAULT_MAX_COUNT_CONCURRENT_OUTBOUND_DIALS,
         DEFAULT_MAX_COUNT_PEERS_INBOUND, DEFAULT_MAX_COUNT_PEERS_OUTBOUND,
     },
     session::{Direction, PendingSessionHandshakeError},
@@ -916,7 +916,7 @@ impl Default for ConnectionInfo {
             num_inbound: 0,
             max_outbound: DEFAULT_MAX_COUNT_PEERS_OUTBOUND as usize,
             max_inbound: DEFAULT_MAX_COUNT_PEERS_INBOUND as usize,
-            max_concurrent_outbound_dials: DEFAULT_MAX_COUNT_CONCURRENT_DIALS,
+            max_concurrent_outbound_dials: DEFAULT_MAX_COUNT_CONCURRENT_OUTBOUND_DIALS,
             num_pendingout: 0,
         }
     }

--- a/crates/net/network/src/peers/mod.rs
+++ b/crates/net/network/src/peers/mod.rs
@@ -14,5 +14,7 @@ pub const DEFAULT_MAX_COUNT_PEERS_OUTBOUND: u32 = 100;
 /// Maximum number of available slots for inbound sessions.
 pub const DEFAULT_MAX_COUNT_PEERS_INBOUND: u32 = 30;
 
-/// Maximum number of available slots concurrent outgoing dials.
-pub const DEFAULT_MAX_COUNT_CONCURRENT_DIALS: usize = 10;
+/// Maximum number of available slots for concurrent outgoing dials.
+///
+/// This restricts how many outbound dials can be performed concurrently.
+pub const DEFAULT_MAX_COUNT_CONCURRENT_OUTBOUND_DIALS: usize = 15;


### PR DESCRIPTION
we only implemented proper restrictions of this property recently.
so before #6860 we allowed up until the available total slots outbound connections concurrently (up to 100)

This bumps the default to 15 which we can handle easily, this should improve peering on startup slightly