### PR TITLE
fix: use INVALID_PAYLOAD_ATTRIBUTES code for attribute validation errors

### DIFF
--- a/crates/node-api/src/engine/error.rs
+++ b/crates/node-api/src/engine/error.rs
@@ -22,7 +22,7 @@ pub enum AttributesValidationError {
     InvalidParams(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
 
-/// Thrown when validating a payload or attributes fails.
+/// Thrown when validating an execution payload OR payload attributes fails.
 #[derive(Error, Debug)]
 pub enum PayloadOrAttributesValidationError {
     /// Thrown if the pre-V3 `PayloadAttributes` or `ExecutionPayload` contains a parent beacon

--- a/crates/node-api/src/engine/error.rs
+++ b/crates/node-api/src/engine/error.rs
@@ -25,21 +25,23 @@ pub enum AttributesValidationError {
 /// Thrown when validating a payload or attributes fails.
 #[derive(Error, Debug)]
 pub enum PayloadOrAttributesValidationError {
-    /// Thrown if `PayloadAttributes` provided in engine_forkchoiceUpdated before V3 contains a
-    /// parent beacon block root
+    /// Thrown if the pre-V3 `PayloadAttributes` or `ExecutionPayload` contains a parent beacon
+    /// block root
     #[error("parent beacon block root not supported before V3")]
     ParentBeaconBlockRootNotSupportedBeforeV3,
-    /// Thrown if engine_forkchoiceUpdatedV1 contains withdrawals
+    /// Thrown if engine_forkchoiceUpdatedV1 or engine_newPayloadV1 contains withdrawals
     #[error("withdrawals not supported in V1")]
     WithdrawalsNotSupportedInV1,
-    /// Thrown if engine_forkchoiceUpdated contains no withdrawals after Shanghai
+    /// Thrown if engine_forkchoiceUpdated or engine_newPayload contains no withdrawals after
+    /// Shanghai
     #[error("no withdrawals post-Shanghai")]
     NoWithdrawalsPostShanghai,
-    /// Thrown if engine_forkchoiceUpdated contains withdrawals before Shanghai
+    /// Thrown if engine_forkchoiceUpdated or engine_newPayload contains withdrawals before
+    /// Shanghai
     #[error("withdrawals pre-Shanghai")]
     HasWithdrawalsPreShanghai,
-    /// Thrown if the `PayloadAttributes` provided in engine_forkchoiceUpdated contains no parent
-    /// beacon block root after Cancun
+    /// Thrown if the `PayloadAttributes` or `ExecutionPayload` contains no parent beacon block
+    /// root after Cancun
     #[error("no parent beacon block root post-cancun")]
     NoParentBeaconBlockRootPostCancun,
 }

--- a/crates/node-api/src/engine/error.rs
+++ b/crates/node-api/src/engine/error.rs
@@ -10,11 +10,11 @@ use thiserror::Error;
 pub enum EngineObjectValidationError {
     /// Thrown when the underlying validation error occured while validating an `ExecutionPayload`.
     #[error("Payload validation error: {0}")]
-    Payload(PayloadOrAttributesValidationError),
+    Payload(VersionSpecificValidationError),
 
     /// Thrown when the underlying validation error occured while validating a `PayloadAttributes`.
     #[error("Payload attributes validation error: {0}")]
-    PayloadAttributes(PayloadOrAttributesValidationError),
+    PayloadAttributes(VersionSpecificValidationError),
 
     /// Thrown if `PayloadAttributes` or `ExecutionPayload` were provided with a timestamp, but the
     /// version of the engine method called is meant for a fork that occurs after the provided
@@ -26,9 +26,11 @@ pub enum EngineObjectValidationError {
     InvalidParams(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
 
-/// Thrown when validating an execution payload OR payload attributes fails.
+/// Thrown when validating an execution payload OR payload attributes fails due to:
+/// * The existence of a new field that is not supported in the given engine method version, or
+/// * The absence of a field that is required in the given engine method version
 #[derive(Error, Debug)]
-pub enum PayloadOrAttributesValidationError {
+pub enum VersionSpecificValidationError {
     /// Thrown if the pre-V3 `PayloadAttributes` or `ExecutionPayload` contains a parent beacon
     /// block root
     #[error("parent beacon block root not supported before V3")]

--- a/crates/node-api/src/engine/error.rs
+++ b/crates/node-api/src/engine/error.rs
@@ -2,8 +2,12 @@
 use thiserror::Error;
 
 /// Thrown when the payload or attributes are known to be invalid before processing.
+///
+/// This is used mainly for
+/// [validate_version_specific_fields](crate::validate_version_specific_fields), which validates
+/// both execution payloads and forkchoice update attributes with respect to a method version.
 #[derive(Error, Debug)]
-pub enum AttributesValidationError {
+pub enum EngineObjectValidationError {
     /// Thrown when the underlying validation error occured while validating an `ExecutionPayload`.
     #[error("Payload validation error: {0}")]
     Payload(PayloadOrAttributesValidationError),
@@ -46,7 +50,7 @@ pub enum PayloadOrAttributesValidationError {
     NoParentBeaconBlockRootPostCancun,
 }
 
-impl AttributesValidationError {
+impl EngineObjectValidationError {
     /// Creates an instance of the `InvalidParams` variant with the given error.
     pub fn invalid_params<E>(error: E) -> Self
     where

--- a/crates/node-api/src/engine/error.rs
+++ b/crates/node-api/src/engine/error.rs
@@ -4,6 +4,27 @@ use thiserror::Error;
 /// Thrown when the payload or attributes are known to be invalid before processing.
 #[derive(Error, Debug)]
 pub enum AttributesValidationError {
+    /// Thrown when the underlying validation error occured while validating an `ExecutionPayload`.
+    #[error("Payload validation error: {0}")]
+    Payload(PayloadOrAttributesValidationError),
+
+    /// Thrown when the underlying validation error occured while validating a `PayloadAttributes`.
+    #[error("Payload attributes validation error: {0}")]
+    PayloadAttributes(PayloadOrAttributesValidationError),
+
+    /// Thrown if `PayloadAttributes` or `ExecutionPayload` were provided with a timestamp, but the
+    /// version of the engine method called is meant for a fork that occurs after the provided
+    /// timestamp.
+    #[error("Unsupported fork")]
+    UnsupportedFork,
+    /// Another type of error that is not covered by the above variants.
+    #[error("Invalid params: {0}")]
+    InvalidParams(#[from] Box<dyn std::error::Error + Send + Sync>),
+}
+
+/// Thrown when validating a payload or attributes fails.
+#[derive(Error, Debug)]
+pub enum PayloadOrAttributesValidationError {
     /// Thrown if `PayloadAttributes` provided in engine_forkchoiceUpdated before V3 contains a
     /// parent beacon block root
     #[error("parent beacon block root not supported before V3")]
@@ -21,13 +42,6 @@ pub enum AttributesValidationError {
     /// beacon block root after Cancun
     #[error("no parent beacon block root post-cancun")]
     NoParentBeaconBlockRootPostCancun,
-    /// Thrown if `PayloadAttributes` were provided with a timestamp, but the version of the engine
-    /// method called is meant for a fork that occurs after the provided timestamp.
-    #[error("Unsupported fork")]
-    UnsupportedFork,
-    /// Another type of error that is not covered by the above variants.
-    #[error("Invalid params: {0}")]
-    InvalidParams(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
 
 impl AttributesValidationError {

--- a/crates/node-api/src/engine/mod.rs
+++ b/crates/node-api/src/engine/mod.rs
@@ -162,7 +162,7 @@ pub fn validate_withdrawals_presence(
 /// will return [AttributesValidationError::UnsupportedFork].
 ///
 /// If the engine API message version is V3, but the `parentBeaconBlockRoot` is [None], then
-/// this will return [AttributesValidationError::NoParentBeaconBlockRootPostCancun].
+/// this will return [PayloadOrAttributesValidationError::NoParentBeaconBlockRootPostCancun].
 ///
 /// This implements the following Engine API spec rules:
 ///

--- a/crates/node-api/src/engine/mod.rs
+++ b/crates/node-api/src/engine/mod.rs
@@ -11,13 +11,11 @@ pub use traits::{BuiltPayload, PayloadAttributes, PayloadBuilderAttributes};
 
 /// Contains error types used in the traits defined in this crate.
 pub mod error;
-pub use error::AttributesValidationError;
+pub use error::{AttributesValidationError, PayloadOrAttributesValidationError};
 
 /// Contains types used in implementations of the [PayloadAttributes] trait.
 pub mod payload;
 pub use payload::PayloadOrAttributes;
-
-use self::error::PayloadOrAttributesValidationError;
 
 /// The types that are used by the engine API.
 pub trait EngineTypes:

--- a/crates/node-api/src/engine/mod.rs
+++ b/crates/node-api/src/engine/mod.rs
@@ -178,6 +178,17 @@ pub fn validate_withdrawals_presence(
 ///    matches the expected one and return `-32602: Invalid params` error if this check fails. Any
 ///    field having `null` value **MUST** be considered as not provided.
 ///
+/// 2. Extend point (7) of the `engine_forkchoiceUpdatedV1` specification by defining the following
+///    sequence of checks that **MUST** be run over `payloadAttributes`:
+///     1. `payloadAttributes` matches the `PayloadAttributesV3` structure, return `-38003: Invalid
+///        payload attributes` on failure.
+///     2. `payloadAttributes.timestamp` falls within the time frame of the Cancun fork, return
+///        `-38005: Unsupported fork` on failure.
+///     3. `payloadAttributes.timestamp` is greater than `timestamp` of a block referenced by
+///        `forkchoiceState.headBlockHash`, return `-38003: Invalid payload attributes` on failure.
+///     4. If any of the above checks fails, the `forkchoiceState` update **MUST NOT** be rolled
+///        back.
+///
 /// For `engine_newPayloadV3`:
 ///
 /// 2. Client software **MUST** return `-38005: Unsupported fork` error if the `timestamp` of the

--- a/crates/node-api/src/engine/payload.rs
+++ b/crates/node-api/src/engine/payload.rs
@@ -2,6 +2,8 @@ use crate::PayloadAttributes;
 use reth_primitives::B256;
 use reth_rpc_types::engine::ExecutionPayload;
 
+use super::MessageValidationKind;
+
 /// Either an [ExecutionPayload] or a types that implements the [PayloadAttributes] trait.
 #[derive(Debug)]
 pub enum PayloadOrAttributes<'a, AttributesType> {
@@ -50,6 +52,14 @@ where
         match self {
             Self::ExecutionPayload { parent_beacon_block_root, .. } => *parent_beacon_block_root,
             Self::PayloadAttributes(attributes) => attributes.parent_beacon_block_root(),
+        }
+    }
+
+    /// Return a [MessageValidationKind] for the payload or attributes.
+    pub fn message_validation_kind(&self) -> MessageValidationKind {
+        match self {
+            Self::ExecutionPayload { .. } => MessageValidationKind::Payload,
+            Self::PayloadAttributes(_) => MessageValidationKind::PayloadAttributes,
         }
     }
 }

--- a/crates/node-api/src/engine/traits.rs
+++ b/crates/node-api/src/engine/traits.rs
@@ -1,4 +1,6 @@
-use crate::{validate_version_specific_fields, AttributesValidationError, EngineApiMessageVersion};
+use crate::{
+    validate_version_specific_fields, EngineApiMessageVersion, EngineObjectValidationError,
+};
 use reth_primitives::{
     revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg},
     Address, ChainSpec, Header, SealedBlock, Withdrawals, B256, U256,
@@ -98,7 +100,7 @@ pub trait PayloadAttributes:
         &self,
         chain_spec: &ChainSpec,
         version: EngineApiMessageVersion,
-    ) -> Result<(), AttributesValidationError>;
+    ) -> Result<(), EngineObjectValidationError>;
 }
 
 impl PayloadAttributes for EthPayloadAttributes {
@@ -118,7 +120,7 @@ impl PayloadAttributes for EthPayloadAttributes {
         &self,
         chain_spec: &ChainSpec,
         version: EngineApiMessageVersion,
-    ) -> Result<(), AttributesValidationError> {
+    ) -> Result<(), EngineObjectValidationError> {
         validate_version_specific_fields(chain_spec, version, self.into())
     }
 }
@@ -140,11 +142,11 @@ impl PayloadAttributes for OptimismPayloadAttributes {
         &self,
         chain_spec: &ChainSpec,
         version: EngineApiMessageVersion,
-    ) -> Result<(), AttributesValidationError> {
+    ) -> Result<(), EngineObjectValidationError> {
         validate_version_specific_fields(chain_spec, version, self.into())?;
 
         if self.gas_limit.is_none() && chain_spec.is_optimism() {
-            return Err(AttributesValidationError::InvalidParams(
+            return Err(EngineObjectValidationError::InvalidParams(
                 "MissingGasLimitInPayloadAttributes".to_string().into(),
             ))
         }

--- a/crates/node-api/src/lib.rs
+++ b/crates/node-api/src/lib.rs
@@ -16,7 +16,7 @@ pub use engine::{
     validate_payload_timestamp, validate_version_specific_fields, validate_withdrawals_presence,
     BuiltPayload, EngineApiMessageVersion, EngineObjectValidationError, EngineTypes,
     MessageValidationKind, PayloadAttributes, PayloadBuilderAttributes, PayloadOrAttributes,
-    PayloadOrAttributesValidationError,
+    VersionSpecificValidationError,
 };
 
 /// Traits and helper types used to abstract over EVM methods and types.

--- a/crates/node-api/src/lib.rs
+++ b/crates/node-api/src/lib.rs
@@ -15,7 +15,8 @@ pub mod engine;
 pub use engine::{
     validate_payload_timestamp, validate_version_specific_fields, validate_withdrawals_presence,
     AttributesValidationError, BuiltPayload, EngineApiMessageVersion, EngineTypes,
-    PayloadAttributes, PayloadBuilderAttributes, PayloadOrAttributes,
+    MessageValidationKind, PayloadAttributes, PayloadBuilderAttributes, PayloadOrAttributes,
+    PayloadOrAttributesValidationError,
 };
 
 /// Traits and helper types used to abstract over EVM methods and types.

--- a/crates/node-api/src/lib.rs
+++ b/crates/node-api/src/lib.rs
@@ -14,7 +14,7 @@
 pub mod engine;
 pub use engine::{
     validate_payload_timestamp, validate_version_specific_fields, validate_withdrawals_presence,
-    AttributesValidationError, BuiltPayload, EngineApiMessageVersion, EngineTypes,
+    BuiltPayload, EngineApiMessageVersion, EngineObjectValidationError, EngineTypes,
     MessageValidationKind, PayloadAttributes, PayloadBuilderAttributes, PayloadOrAttributes,
     PayloadOrAttributesValidationError,
 };

--- a/crates/node-ethereum/src/engine.rs
+++ b/crates/node-ethereum/src/engine.rs
@@ -1,5 +1,5 @@
 use reth_node_api::{
-    validate_version_specific_fields, AttributesValidationError, EngineApiMessageVersion,
+    validate_version_specific_fields, EngineApiMessageVersion, EngineObjectValidationError,
     EngineTypes, PayloadOrAttributes,
 };
 use reth_payload_builder::{EthBuiltPayload, EthPayloadBuilderAttributes};
@@ -29,7 +29,7 @@ impl EngineTypes for EthEngineTypes {
         chain_spec: &ChainSpec,
         version: EngineApiMessageVersion,
         payload_or_attrs: PayloadOrAttributes<'_, EthPayloadAttributes>,
-    ) -> Result<(), AttributesValidationError> {
+    ) -> Result<(), EngineObjectValidationError> {
         validate_version_specific_fields(chain_spec, version, payload_or_attrs)
     }
 }

--- a/crates/node-optimism/src/engine.rs
+++ b/crates/node-optimism/src/engine.rs
@@ -1,6 +1,7 @@
 use reth_node_api::{
     engine::validate_parent_beacon_block_root_presence, AttributesValidationError,
-    EngineApiMessageVersion, EngineTypes, PayloadOrAttributes,
+    EngineApiMessageVersion, EngineTypes, MessageValidationKind, PayloadOrAttributes,
+    PayloadOrAttributesValidationError,
 };
 use reth_payload_builder::{OptimismBuiltPayload, OptimismPayloadBuilderAttributes};
 use reth_primitives::{ChainSpec, Hardfork};
@@ -32,12 +33,14 @@ impl EngineTypes for OptimismEngineTypes {
         validate_withdrawals_presence(
             chain_spec,
             version,
+            payload_or_attrs.message_validation_kind(),
             payload_or_attrs.timestamp(),
             payload_or_attrs.withdrawals().is_some(),
         )?;
         validate_parent_beacon_block_root_presence(
             chain_spec,
             version,
+            payload_or_attrs.message_validation_kind(),
             payload_or_attrs.timestamp(),
             payload_or_attrs.parent_beacon_block_root().is_some(),
         )
@@ -54,6 +57,7 @@ impl EngineTypes for OptimismEngineTypes {
 pub fn validate_withdrawals_presence(
     chain_spec: &ChainSpec,
     version: EngineApiMessageVersion,
+    message_validation_kind: MessageValidationKind,
     timestamp: u64,
     has_withdrawals: bool,
 ) -> Result<(), AttributesValidationError> {
@@ -62,18 +66,22 @@ pub fn validate_withdrawals_presence(
     match version {
         EngineApiMessageVersion::V1 => {
             if has_withdrawals {
-                return Err(AttributesValidationError::WithdrawalsNotSupportedInV1)
+                return Err(message_validation_kind
+                    .to_error(PayloadOrAttributesValidationError::WithdrawalsNotSupportedInV1))
             }
             if is_shanghai {
-                return Err(AttributesValidationError::NoWithdrawalsPostShanghai)
+                return Err(message_validation_kind
+                    .to_error(PayloadOrAttributesValidationError::NoWithdrawalsPostShanghai))
             }
         }
         EngineApiMessageVersion::V2 | EngineApiMessageVersion::V3 => {
             if is_shanghai && !has_withdrawals {
-                return Err(AttributesValidationError::NoWithdrawalsPostShanghai)
+                return Err(message_validation_kind
+                    .to_error(PayloadOrAttributesValidationError::NoWithdrawalsPostShanghai))
             }
             if !is_shanghai && has_withdrawals {
-                return Err(AttributesValidationError::HasWithdrawalsPreShanghai)
+                return Err(message_validation_kind
+                    .to_error(PayloadOrAttributesValidationError::HasWithdrawalsPreShanghai))
             }
         }
     };

--- a/crates/node-optimism/src/engine.rs
+++ b/crates/node-optimism/src/engine.rs
@@ -1,6 +1,6 @@
 use reth_node_api::{
-    engine::validate_parent_beacon_block_root_presence, AttributesValidationError,
-    EngineApiMessageVersion, EngineTypes, MessageValidationKind, PayloadOrAttributes,
+    engine::validate_parent_beacon_block_root_presence, EngineApiMessageVersion,
+    EngineObjectValidationError, EngineTypes, MessageValidationKind, PayloadOrAttributes,
     VersionSpecificValidationError,
 };
 use reth_payload_builder::{OptimismBuiltPayload, OptimismPayloadBuilderAttributes};
@@ -29,7 +29,7 @@ impl EngineTypes for OptimismEngineTypes {
         chain_spec: &ChainSpec,
         version: EngineApiMessageVersion,
         payload_or_attrs: PayloadOrAttributes<'_, Self::PayloadAttributes>,
-    ) -> Result<(), AttributesValidationError> {
+    ) -> Result<(), EngineObjectValidationError> {
         validate_withdrawals_presence(
             chain_spec,
             version,
@@ -60,7 +60,7 @@ pub fn validate_withdrawals_presence(
     message_validation_kind: MessageValidationKind,
     timestamp: u64,
     has_withdrawals: bool,
-) -> Result<(), AttributesValidationError> {
+) -> Result<(), EngineObjectValidationError> {
     let is_shanghai = chain_spec.fork(Hardfork::Canyon).active_at_timestamp(timestamp);
 
     match version {

--- a/crates/node-optimism/src/engine.rs
+++ b/crates/node-optimism/src/engine.rs
@@ -1,7 +1,7 @@
 use reth_node_api::{
     engine::validate_parent_beacon_block_root_presence, AttributesValidationError,
     EngineApiMessageVersion, EngineTypes, MessageValidationKind, PayloadOrAttributes,
-    PayloadOrAttributesValidationError,
+    VersionSpecificValidationError,
 };
 use reth_payload_builder::{OptimismBuiltPayload, OptimismPayloadBuilderAttributes};
 use reth_primitives::{ChainSpec, Hardfork};
@@ -67,21 +67,21 @@ pub fn validate_withdrawals_presence(
         EngineApiMessageVersion::V1 => {
             if has_withdrawals {
                 return Err(message_validation_kind
-                    .to_error(PayloadOrAttributesValidationError::WithdrawalsNotSupportedInV1))
+                    .to_error(VersionSpecificValidationError::WithdrawalsNotSupportedInV1))
             }
             if is_shanghai {
                 return Err(message_validation_kind
-                    .to_error(PayloadOrAttributesValidationError::NoWithdrawalsPostShanghai))
+                    .to_error(VersionSpecificValidationError::NoWithdrawalsPostShanghai))
             }
         }
         EngineApiMessageVersion::V2 | EngineApiMessageVersion::V3 => {
             if is_shanghai && !has_withdrawals {
                 return Err(message_validation_kind
-                    .to_error(PayloadOrAttributesValidationError::NoWithdrawalsPostShanghai))
+                    .to_error(VersionSpecificValidationError::NoWithdrawalsPostShanghai))
             }
             if !is_shanghai && has_withdrawals {
                 return Err(message_validation_kind
-                    .to_error(PayloadOrAttributesValidationError::HasWithdrawalsPreShanghai))
+                    .to_error(VersionSpecificValidationError::HasWithdrawalsPreShanghai))
             }
         }
     };

--- a/crates/rpc/rpc-engine-api/src/error.rs
+++ b/crates/rpc/rpc-engine-api/src/error.rs
@@ -85,7 +85,7 @@ pub enum EngineApiError {
     GetPayloadError(#[from] PayloadBuilderError),
     /// The payload or attributes are known to be malformed before processing.
     #[error(transparent)]
-    AttributesValidationError(#[from] EngineObjectValidationError),
+    EngineObjectValidationError(#[from] EngineObjectValidationError),
     /// If the optimism feature flag is enabled, the payload attributes must have a present
     /// gas limit for the forkchoice updated method.
     #[cfg(feature = "optimism")]
@@ -111,8 +111,10 @@ impl From<EngineApiError> for jsonrpsee_types::error::ErrorObject<'static> {
     fn from(error: EngineApiError) -> Self {
         match error {
             EngineApiError::InvalidBodiesRange { .. } |
-            EngineApiError::AttributesValidationError(EngineObjectValidationError::Payload(_)) |
-            EngineApiError::AttributesValidationError(
+            EngineApiError::EngineObjectValidationError(EngineObjectValidationError::Payload(
+                _,
+            )) |
+            EngineApiError::EngineObjectValidationError(
                 EngineObjectValidationError::InvalidParams(_),
             ) => {
                 // Note: the data field is not required by the spec, but is also included by other
@@ -123,7 +125,7 @@ impl From<EngineApiError> for jsonrpsee_types::error::ErrorObject<'static> {
                     Some(ErrorData::new(error)),
                 )
             }
-            EngineApiError::AttributesValidationError(
+            EngineApiError::EngineObjectValidationError(
                 EngineObjectValidationError::PayloadAttributes(_),
             ) => {
                 // Note: the data field is not required by the spec, but is also included by other
@@ -146,7 +148,7 @@ impl From<EngineApiError> for jsonrpsee_types::error::ErrorObject<'static> {
                     Some(ErrorData::new(error)),
                 )
             }
-            EngineApiError::AttributesValidationError(
+            EngineApiError::EngineObjectValidationError(
                 EngineObjectValidationError::UnsupportedFork,
             ) => jsonrpsee_types::error::ErrorObject::owned(
                 UNSUPPORTED_FORK_CODE,
@@ -238,7 +240,9 @@ mod tests {
         ensure_engine_rpc_error(
             UNSUPPORTED_FORK_CODE,
             "Unsupported fork",
-            EngineApiError::AttributesValidationError(EngineObjectValidationError::UnsupportedFork),
+            EngineApiError::EngineObjectValidationError(
+                EngineObjectValidationError::UnsupportedFork,
+            ),
         );
 
         ensure_engine_rpc_error(

--- a/crates/rpc/rpc-engine-api/src/error.rs
+++ b/crates/rpc/rpc-engine-api/src/error.rs
@@ -2,7 +2,7 @@ use jsonrpsee_types::error::{
     INTERNAL_ERROR_CODE, INVALID_PARAMS_CODE, INVALID_PARAMS_MSG, SERVER_ERROR_MSG,
 };
 use reth_beacon_consensus::{BeaconForkChoiceUpdateError, BeaconOnNewPayloadError};
-use reth_node_api::AttributesValidationError;
+use reth_node_api::EngineObjectValidationError;
 use reth_payload_builder::error::PayloadBuilderError;
 use reth_primitives::{B256, U256};
 use thiserror::Error;
@@ -85,7 +85,7 @@ pub enum EngineApiError {
     GetPayloadError(#[from] PayloadBuilderError),
     /// The payload or attributes are known to be malformed before processing.
     #[error(transparent)]
-    AttributesValidationError(#[from] AttributesValidationError),
+    AttributesValidationError(#[from] EngineObjectValidationError),
     /// If the optimism feature flag is enabled, the payload attributes must have a present
     /// gas limit for the forkchoice updated method.
     #[cfg(feature = "optimism")]
@@ -111,9 +111,9 @@ impl From<EngineApiError> for jsonrpsee_types::error::ErrorObject<'static> {
     fn from(error: EngineApiError) -> Self {
         match error {
             EngineApiError::InvalidBodiesRange { .. } |
-            EngineApiError::AttributesValidationError(AttributesValidationError::Payload(_)) |
+            EngineApiError::AttributesValidationError(EngineObjectValidationError::Payload(_)) |
             EngineApiError::AttributesValidationError(
-                AttributesValidationError::InvalidParams(_),
+                EngineObjectValidationError::InvalidParams(_),
             ) => {
                 // Note: the data field is not required by the spec, but is also included by other
                 // clients
@@ -124,7 +124,7 @@ impl From<EngineApiError> for jsonrpsee_types::error::ErrorObject<'static> {
                 )
             }
             EngineApiError::AttributesValidationError(
-                AttributesValidationError::PayloadAttributes(_),
+                EngineObjectValidationError::PayloadAttributes(_),
             ) => {
                 // Note: the data field is not required by the spec, but is also included by other
                 // clients
@@ -147,7 +147,7 @@ impl From<EngineApiError> for jsonrpsee_types::error::ErrorObject<'static> {
                 )
             }
             EngineApiError::AttributesValidationError(
-                AttributesValidationError::UnsupportedFork,
+                EngineObjectValidationError::UnsupportedFork,
             ) => jsonrpsee_types::error::ErrorObject::owned(
                 UNSUPPORTED_FORK_CODE,
                 error.to_string(),
@@ -238,7 +238,7 @@ mod tests {
         ensure_engine_rpc_error(
             UNSUPPORTED_FORK_CODE,
             "Unsupported fork",
-            EngineApiError::AttributesValidationError(AttributesValidationError::UnsupportedFork),
+            EngineApiError::AttributesValidationError(EngineObjectValidationError::UnsupportedFork),
         );
 
         ensure_engine_rpc_error(

--- a/examples/custom-node/src/main.rs
+++ b/examples/custom-node/src/main.rs
@@ -34,7 +34,7 @@ use reth_basic_payload_builder::{
     PayloadBuilder, PayloadConfig,
 };
 use reth_node_api::{
-    validate_version_specific_fields, AttributesValidationError, EngineApiMessageVersion,
+    validate_version_specific_fields, EngineApiMessageVersion, EngineObjectValidationError,
     EngineTypes, PayloadAttributes, PayloadBuilderAttributes, PayloadOrAttributes,
 };
 use reth_node_core::{args::RpcServerArgs, node_config::NodeConfig};
@@ -94,12 +94,14 @@ impl PayloadAttributes for CustomPayloadAttributes {
         &self,
         chain_spec: &ChainSpec,
         version: EngineApiMessageVersion,
-    ) -> Result<(), AttributesValidationError> {
+    ) -> Result<(), EngineObjectValidationError> {
         validate_version_specific_fields(chain_spec, version, self.into())?;
 
         // custom validation logic - ensure that the custom field is not zero
         if self.custom == 0 {
-            return Err(AttributesValidationError::invalid_params(CustomError::CustomFieldIsNotZero))
+            return Err(EngineObjectValidationError::invalid_params(
+                CustomError::CustomFieldIsNotZero,
+            ))
         }
 
         Ok(())
@@ -173,7 +175,7 @@ impl EngineTypes for CustomEngineTypes {
         chain_spec: &ChainSpec,
         version: EngineApiMessageVersion,
         payload_or_attrs: PayloadOrAttributes<'_, CustomPayloadAttributes>,
-    ) -> Result<(), AttributesValidationError> {
+    ) -> Result<(), EngineObjectValidationError> {
         validate_version_specific_fields(chain_spec, version, payload_or_attrs)
     }
 }


### PR DESCRIPTION
Fixes the first four tests from https://github.com/paradigmxyz/reth/issues/7026

This causes the engine to return a different error code if we are validating payload attributes specifically. `newPayload` still returns `INVALID_PARAMS`.