### PR TITLE
Dencun readiness - pin Lighthouse image tag in base Docker Compose setup

### DIFF
--- a/etc/lighthouse.yml
+++ b/etc/lighthouse.yml
@@ -4,7 +4,7 @@ name: reth
 services:
   lighthouse:
     restart: unless-stopped
-    image: sigp/lighthouse:v5.0.0-modern
+    image: sigp/lighthouse:v5.1.3-modern
     depends_on:
       - reth
     ports:

--- a/etc/lighthouse.yml
+++ b/etc/lighthouse.yml
@@ -4,7 +4,7 @@ name: reth
 services:
   lighthouse:
     restart: unless-stopped
-    image: sigp/lighthouse
+    image: sigp/lighthouse:v5.0.0-modern
     depends_on:
       - reth
     ports:


### PR DESCRIPTION
Small tweak to the Docker Compose file, pinning Lighthouse to version 5.0.0. The upstream Lighthouse Docker hub repo does not update the `latest` tag whenever new images are pushed, thus the Docker Compose yaml (implicitly pulling `latest` due to missing a pin) pulls a very old version of Lighthouse.

**All lighthouse beacon nodes need to be updated to a minimum of 5.0.0 to be compatible with the upcoming Dencun release.** 

More info here: https://github.com/sigp/lighthouse/releases/tag/v5.0.0. TL;DR:

>  All Lighthouse Beacon Nodes and Validator Clients must be upgraded to a v5.x.x release to ensure they follow the correct chain.

As it's my first PR to this repo, keeping it very light. We've modified these base Docker Compose files in other ways internally, but this seems like a critical fix that should be included as a sane default in the base files before the imminent Dencun upgrade.