### PR TITLE
fix(rpc): cache transaction hash when filtering over receipt logs

### DIFF
--- a/crates/rpc/rpc/src/eth/logs_utils.rs
+++ b/crates/rpc/rpc/src/eth/logs_utils.rs
@@ -20,8 +20,7 @@ where
     let mut log_index: u32 = 0;
     // Iterate over transaction hashes and receipts and append matching logs.
     for (receipt_idx, (tx_hash, receipt)) in tx_hashes_and_receipts.into_iter().enumerate() {
-        let logs = &receipt.logs;
-        for log in logs {
+        for log in receipt.logs.iter() {
             if log_matches_filter(block_num_hash, log, filter) {
                 let log = Log {
                     address: log.address,
@@ -63,10 +62,10 @@ pub(crate) fn append_matching_block_logs(
 
     // Iterate over receipts and append matching logs.
     for (receipt_idx, receipt) in receipts.iter().enumerate() {
-        let logs = &receipt.logs;
+        // The transaction hash of the current receipt.
         let mut transaction_hash = None;
 
-        for log in logs {
+        for log in receipt.logs.iter() {
             if log_matches_filter(block_num_hash, log, filter) {
                 let first_tx_num = match loaded_first_tx_num {
                     Some(num) => num,
@@ -80,12 +79,14 @@ pub(crate) fn append_matching_block_logs(
                     }
                 };
 
+                // if this is the first match in the receipt's logs, look up the transaction hash
                 if transaction_hash.is_none() {
                     // This is safe because Transactions and Receipts have the same keys.
                     let transaction_id = first_tx_num + receipt_idx as u64;
                     let transaction = provider
                         .transaction_by_id(transaction_id)?
                         .ok_or(ProviderError::TransactionNotFound(transaction_id.into()))?;
+
                     transaction_hash = Some(transaction.hash());
                 }
 


### PR DESCRIPTION
Makes sure to cache the transaction hash belonging to 1 receipt and N logs.