### PR TITLE
fix(bin, node-core): commit genesis header into static files after db

### DIFF
--- a/crates/node-core/src/init.rs
+++ b/crates/node-core/src/init.rs
@@ -79,7 +79,8 @@ pub fn init_genesis<DB: Database>(factory: ProviderFactory<DB>) -> Result<B256, 
 
     // Insert header
     let tx = provider_rw.into_tx();
-    insert_genesis_header::<DB>(&tx, factory.static_file_provider(), chain.clone())?;
+    let static_file_provider = factory.static_file_provider();
+    insert_genesis_header::<DB>(&tx, &static_file_provider, chain.clone())?;
 
     insert_genesis_state::<DB>(&tx, genesis)?;
 
@@ -89,6 +90,7 @@ pub fn init_genesis<DB: Database>(factory: ProviderFactory<DB>) -> Result<B256, 
     }
 
     tx.commit()?;
+    static_file_provider.commit()?;
 
     Ok(hash)
 }
@@ -209,7 +211,7 @@ pub fn insert_genesis_history<DB: Database>(
 /// Inserts header for the genesis state.
 pub fn insert_genesis_header<DB: Database>(
     tx: &<DB as Database>::TXMut,
-    static_file_provider: StaticFileProvider,
+    static_file_provider: &StaticFileProvider,
     chain: Arc<ChainSpec>,
 ) -> ProviderResult<()> {
     let (header, block_hash) = chain.sealed_genesis_header().split();
@@ -219,7 +221,6 @@ pub fn insert_genesis_header<DB: Database>(
             let (difficulty, hash) = (header.difficulty, block_hash);
             let mut writer = static_file_provider.latest_writer(StaticFileSegment::Headers)?;
             writer.append_header(header, difficulty, hash)?;
-            writer.commit()?;
         }
         Ok(Some(_)) => {}
         Err(e) => return Err(e),


### PR DESCRIPTION
It's incorrect to commit the static files before committing the database transaction when writing genesis, because we check the static files header to determine whether the genesis is written https://github.com/paradigmxyz/reth/blob/b423d8f29c3c38c0bb6bbb299041f5c2194d9908/crates/node-core/src/init.rs#L56-L71

When you shutdown the node **after** the genesis header is committed to the static files, but **before** the database transaction is committed, it creates a situation when you don't have any genesis data in the database. This is because the check above says that the genesis is already written.