### PR TITLE
fix: add timeouts to the hive CI

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   prepare:
+    timeout-minutes: 45
     runs-on:
       group: Reth
     steps:
@@ -60,6 +61,7 @@ jobs:
           path: ./artifacts
 
   test:
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The hive CI currently runs for 6 hours which is the default timeout on the CI. It seems to stall on the `ethereum/rpc` tests. The timeout can be adapted later once the full suite passes but I believe for now reducing unnecessary CI execution is better. 