### PR TITLE
reth/db: make code more readable

### DIFF
--- a/bin/reth/src/commands/db/mod.rs
+++ b/bin/reth/src/commands/db/mod.rs
@@ -96,15 +96,13 @@ impl Command {
         // add network name to data dir
         let data_dir = self.datadir.unwrap_or_chain_default(self.chain.chain);
         let db_path = data_dir.db_path();
+        let db_log_level = DatabaseArguments::default().log_level(self.db.log_level);
         let static_files_path = data_dir.static_files_path();
 
         match self.command {
             // TODO: We'll need to add this on the DB trait.
             Subcommands::Stats(command) => {
-                let db = open_db_read_only(
-                    &db_path,
-                    DatabaseArguments::default().log_level(self.db.log_level),
-                )?;
+                let db = open_db_read_only(&db_path, db_log_level)?;
                 let provider_factory =
                     ProviderFactory::new(db, self.chain.clone(), static_files_path)?;
 
@@ -112,10 +110,7 @@ impl Command {
                 command.execute(data_dir, &tool)?;
             }
             Subcommands::List(command) => {
-                let db = open_db_read_only(
-                    &db_path,
-                    DatabaseArguments::default().log_level(self.db.log_level),
-                )?;
+                let db = open_db_read_only(&db_path, db_log_level)?;
                 let provider_factory =
                     ProviderFactory::new(db, self.chain.clone(), static_files_path)?;
 
@@ -123,10 +118,7 @@ impl Command {
                 command.execute(&tool)?;
             }
             Subcommands::Diff(command) => {
-                let db = open_db_read_only(
-                    &db_path,
-                    DatabaseArguments::default().log_level(self.db.log_level),
-                )?;
+                let db = open_db_read_only(&db_path, db_log_level)?;
                 let provider_factory =
                     ProviderFactory::new(db, self.chain.clone(), static_files_path)?;
 
@@ -134,10 +126,7 @@ impl Command {
                 command.execute(&tool)?;
             }
             Subcommands::Get(command) => {
-                let db = open_db_read_only(
-                    &db_path,
-                    DatabaseArguments::default().log_level(self.db.log_level),
-                )?;
+                let db = open_db_read_only(&db_path, db_log_level)?;
                 let provider_factory =
                     ProviderFactory::new(db, self.chain.clone(), static_files_path)?;
 
@@ -160,8 +149,7 @@ impl Command {
                     }
                 }
 
-                let db =
-                    open_db(&db_path, DatabaseArguments::default().log_level(self.db.log_level))?;
+                let db = open_db(&db_path, db_log_level)?;
                 let provider_factory =
                     ProviderFactory::new(db, self.chain.clone(), static_files_path.clone())?;
 
@@ -169,8 +157,7 @@ impl Command {
                 tool.drop(db_path, static_files_path)?;
             }
             Subcommands::Clear(command) => {
-                let db =
-                    open_db(&db_path, DatabaseArguments::default().log_level(self.db.log_level))?;
+                let db = open_db(&db_path, db_log_level)?;
                 let provider_factory =
                     ProviderFactory::new(db, self.chain.clone(), static_files_path)?;
 

--- a/bin/reth/src/commands/db/stats.rs
+++ b/bin/reth/src/commands/db/stats.rs
@@ -100,8 +100,8 @@ impl Command {
             table.add_row(row);
 
             let freelist = tx.inner.env().freelist()?;
-            let freelist_size =
-                freelist * tx.inner.db_stat(&mdbx::Database::freelist_db())?.page_size() as usize;
+            let pagesize = tx.inner.db_stat(&mdbx::Database::freelist_db())?.page_size() as usize;
+            let freelist_size = freelist * pagesize;
 
             let mut row = Row::new();
             row.add_cell(Cell::new("Freelist"))

--- a/bin/reth/src/commands/db/stats.rs
+++ b/bin/reth/src/commands/db/stats.rs
@@ -169,7 +169,9 @@ impl Command {
                 let fixed_block_range = find_fixed_range(block_range.start());
                 let jar_provider = static_file_provider
                     .get_segment_provider(segment, || Some(fixed_block_range), None)?
-                    .expect("something went wrong");
+                    .ok_or_else(|| {
+                        eyre::eyre!("Failed to get segment provider for segment: {}", segment)
+                    })?;
 
                 let columns = jar_provider.columns();
                 let rows = jar_provider.rows();


### PR DESCRIPTION
make the code more readable:

1. use variable `db_log_level` to avoid duplicated;
2. make `freelist_size` calculate more understandable;
3. return error of the segment info