### PR TITLE
chore: use safe math when calculating missing senders

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -542,10 +542,11 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
         // NOTE: Transactions are always guaranteed to be in the database whereas
         // senders might be pruned.
         if senders.len() != transactions.len() {
-            senders.reserve(transactions.len() - senders.len());
+            let missing = transactions.len().saturating_sub(senders.len());
+            senders.reserve(missing);
             // Find all missing senders, their corresponding tx numbers and indexes to the original
             // `senders` vector at which the recovered senders will be inserted.
-            let mut missing_senders = Vec::with_capacity(transactions.len() - senders.len());
+            let mut missing_senders = Vec::with_capacity(missing);
             {
                 let mut senders = senders.iter().peekable();
 


### PR DESCRIPTION
this is used to allocate, so we should prevent any overflows here