### PR TITLE
feat(ci): tag docker image as latest only for beta

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,6 +23,13 @@ jobs:
       packages: write
       contents: read
     steps:
+      - name: Check latest
+        id: check-latest
+        # Return `true` only if the tag matches the beta version regex
+        run: |
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+\.beta.*$ ]]; then
+              echo "match=true" >> $GITHUB_OUTPUT
+          fi
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
@@ -36,5 +43,9 @@ jobs:
         run: |
           docker run --privileged --rm tonistiigi/binfmt --install arm64,amd64
           docker buildx create --use --name cross-builder
+      - name: Build and push image, tag as "latest"
+        if: steps.check-latest.outputs.match == 'true'
+        run: make PROFILE=maxperf docker-build-push-latest
       - name: Build and push image
-        run: make PROFILE=maxperf docker-build-latest
+        if: steps.check-latest.outputs.match != 'true'
+        run: make PROFILE=maxperf docker-build-push

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,13 +23,6 @@ jobs:
       packages: write
       contents: read
     steps:
-      - name: Check latest
-        id: check-latest
-        # Return `true` only if the tag matches the beta version regex
-        run: |
-          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+\.beta.*$ ]]; then
-              echo "match=true" >> $GITHUB_OUTPUT
-          fi
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
@@ -44,8 +37,8 @@ jobs:
           docker run --privileged --rm tonistiigi/binfmt --install arm64,amd64
           docker buildx create --use --name cross-builder
       - name: Build and push image, tag as "latest"
-        if: steps.check-latest.outputs.match == 'true'
+        if: ${{ contains(github.event.ref, 'beta') }}
         run: make PROFILE=maxperf docker-build-push-latest
       - name: Build and push image
-        if: steps.check-latest.outputs.match != 'true'
+        if: ${{ ! contains(github.event.ref, 'beta') }}
         run: make PROFILE=maxperf docker-build-push

--- a/Makefile
+++ b/Makefile
@@ -184,19 +184,27 @@ ef-tests: $(EF_TESTS_DIR) ## Runs Ethereum Foundation tests.
 # `docker run --privileged --rm tonistiigi/binfmt --install amd64,arm64`
 # `docker buildx create --use --driver docker-container --name cross-builder`
 .PHONY: docker-build-latest
-docker-build-latest: ## Build and push a cross-arch Docker image tagged with the latest git tag and `latest`.
-	$(call build_docker_image,$(GIT_TAG),latest)
+docker-build-push: ## Build and push a cross-arch Docker image tagged with the latest git tag and `latest`.
+	$(call docker_build_push,$(GIT_TAG),$(GIT_TAG))
+
+# Note: This requires a buildx builder with emulation support. For example:
+#
+# `docker run --privileged --rm tonistiigi/binfmt --install amd64,arm64`
+# `docker buildx create --use --driver docker-container --name cross-builder`
+.PHONY: docker-build-latest
+docker-build-push-latest: ## Build and push a cross-arch Docker image tagged with the latest git tag and `latest`.
+	$(call docker_build_push,$(GIT_TAG),latest)
 
 # Note: This requires a buildx builder with emulation support. For example:
 #
 # `docker run --privileged --rm tonistiigi/binfmt --install amd64,arm64`
 # `docker buildx create --use --name cross-builder`
 .PHONY: docker-build-nightly
-docker-build-nightly: ## Build and push cross-arch Docker image tagged with the latest git tag with a `-nightly` suffix, and `latest-nightly`.
-	$(call build_docker_image,$(GIT_TAG)-nightly,latest-nightly)
+docker-build-push-nightly: ## Build and push cross-arch Docker image tagged with the latest git tag with a `-nightly` suffix, and `latest-nightly`.
+	$(call docker_build_push,$(GIT_TAG)-nightly,latest-nightly)
 
 # Create a cross-arch Docker image with the given tags and push it
-define build_docker_image
+define docker_build_push
 	$(MAKE) build-x86_64-unknown-linux-gnu
 	mkdir -p $(BIN_DIR)/amd64
 	cp $(BUILD_PATH)/x86_64-unknown-linux-gnu/$(PROFILE)/reth $(BIN_DIR)/amd64/reth

--- a/Makefile
+++ b/Makefile
@@ -183,15 +183,15 @@ ef-tests: $(EF_TESTS_DIR) ## Runs Ethereum Foundation tests.
 #
 # `docker run --privileged --rm tonistiigi/binfmt --install amd64,arm64`
 # `docker buildx create --use --driver docker-container --name cross-builder`
-.PHONY: docker-build-latest
-docker-build-push: ## Build and push a cross-arch Docker image tagged with the latest git tag and `latest`.
+.PHONY: docker-build-push
+docker-build-push: ## Build and push a cross-arch Docker image tagged with the latest git tag.
 	$(call docker_build_push,$(GIT_TAG),$(GIT_TAG))
 
 # Note: This requires a buildx builder with emulation support. For example:
 #
 # `docker run --privileged --rm tonistiigi/binfmt --install amd64,arm64`
 # `docker buildx create --use --driver docker-container --name cross-builder`
-.PHONY: docker-build-latest
+.PHONY: docker-build-push-latest
 docker-build-push-latest: ## Build and push a cross-arch Docker image tagged with the latest git tag and `latest`.
 	$(call docker_build_push,$(GIT_TAG),latest)
 
@@ -199,7 +199,7 @@ docker-build-push-latest: ## Build and push a cross-arch Docker image tagged wit
 #
 # `docker run --privileged --rm tonistiigi/binfmt --install amd64,arm64`
 # `docker buildx create --use --name cross-builder`
-.PHONY: docker-build-nightly
+.PHONY: docker-build-push-nightly
 docker-build-push-nightly: ## Build and push cross-arch Docker image tagged with the latest git tag with a `-nightly` suffix, and `latest-nightly`.
 	$(call docker_build_push,$(GIT_TAG)-nightly,latest-nightly)
 


### PR DESCRIPTION
We need to tag as `latest` only Beta images, and not the Alpha images that we still release occasionally.