### PR TITLE
fix: use concat_kdf crate instead of hand rolled NIST SP 800-56A KDF

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1374,6 +1374,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concat-kdf"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d72c1252426a83be2092dd5884a5f6e3b8e7180f6891b6263d2c21b92ec8816"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5821,6 +5830,7 @@ dependencies = [
  "block-padding",
  "byteorder",
  "cipher 0.4.4",
+ "concat-kdf",
  "ctr 0.9.2",
  "digest 0.10.7",
  "educe",

--- a/crates/net/ecies/Cargo.toml
+++ b/crates/net/ecies/Cargo.toml
@@ -35,6 +35,7 @@ rand.workspace = true
 ctr = "0.9.2"
 digest = "0.10.5"
 secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery"] }
+concat-kdf = { version = "0.1.0" }
 sha2 = "0.10.6"
 sha3 = "0.10.5"
 aes = "0.8.1"


### PR DESCRIPTION
The `concat_kdf` crate implementation is simpler, easier to understand, and more efficient than the hand rolled version.

A test is added which ensures the kdf does not panic when the key len is less than the hash output len (32).

The implementation is:
```rust
pub fn derive_key_into<D>(secret: &[u8], other_info: &[u8], key: &mut [u8]) -> Result<(), Error>
where
    D: Digest + FixedOutputReset,
{
    // ... omitted useful checks for brevity

    let mut digest = D::new();
    let mut counter: u32 = 1;

    for chunk in key.chunks_mut(D::OutputSize::USIZE) {
        Update::update(&mut digest, &counter.to_be_bytes());
        Update::update(&mut digest, secret);
        Update::update(&mut digest, other_info);
        chunk.copy_from_slice(&digest.finalize_reset()[..chunk.len()]);
        counter += 1;
    }

    Ok(())
}
```