### PR TITLE
chore(primitives): remove static file stage

### DIFF
--- a/crates/primitives/src/stage/id.rs
+++ b/crates/primitives/src/stage/id.rs
@@ -97,7 +97,6 @@ mod tests {
 
     #[test]
     fn stage_id_as_string() {
-        assert_eq!(StageId::StaticFile.to_string(), "StaticFile");
         assert_eq!(StageId::Headers.to_string(), "Headers");
         assert_eq!(StageId::Bodies.to_string(), "Bodies");
         assert_eq!(StageId::SenderRecovery.to_string(), "SenderRecovery");

--- a/crates/primitives/src/stage/id.rs
+++ b/crates/primitives/src/stage/id.rs
@@ -3,6 +3,11 @@
 /// For custom stages, use [`StageId::Other`]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum StageId {
+    /// Static File stage in the process.
+    #[deprecated(
+        note = "Static Files are generated outside of the pipeline and do not require a separate stage"
+    )]
+    StaticFile,
     /// Header stage in the process.
     Headers,
     /// Bodies stage in the process.
@@ -51,6 +56,7 @@ impl StageId {
     /// Return stage id formatted as string.
     pub fn as_str(&self) -> &str {
         match self {
+            StageId::StaticFile => "StaticFile",
             StageId::Headers => "Headers",
             StageId::Bodies => "Bodies",
             StageId::SenderRecovery => "SenderRecovery",
@@ -90,6 +96,7 @@ mod tests {
 
     #[test]
     fn stage_id_as_string() {
+        assert_eq!(StageId::StaticFile.to_string(), "StaticFile");
         assert_eq!(StageId::Headers.to_string(), "Headers");
         assert_eq!(StageId::Bodies.to_string(), "Bodies");
         assert_eq!(StageId::SenderRecovery.to_string(), "SenderRecovery");

--- a/crates/primitives/src/stage/id.rs
+++ b/crates/primitives/src/stage/id.rs
@@ -3,8 +3,6 @@
 /// For custom stages, use [`StageId::Other`]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum StageId {
-    /// Static File stage in the process.
-    StaticFile,
     /// Header stage in the process.
     Headers,
     /// Bodies stage in the process.
@@ -35,8 +33,7 @@ pub enum StageId {
 
 impl StageId {
     /// All supported Stages
-    pub const ALL: [StageId; 13] = [
-        StageId::StaticFile,
+    pub const ALL: [StageId; 12] = [
         StageId::Headers,
         StageId::Bodies,
         StageId::SenderRecovery,
@@ -54,7 +51,6 @@ impl StageId {
     /// Return stage id formatted as string.
     pub fn as_str(&self) -> &str {
         match self {
-            StageId::StaticFile => "StaticFile",
             StageId::Headers => "Headers",
             StageId::Bodies => "Bodies",
             StageId::SenderRecovery => "SenderRecovery",
@@ -94,7 +90,6 @@ mod tests {
 
     #[test]
     fn stage_id_as_string() {
-        assert_eq!(StageId::StaticFile.to_string(), "StaticFile");
         assert_eq!(StageId::Headers.to_string(), "Headers");
         assert_eq!(StageId::Bodies.to_string(), "Bodies");
         assert_eq!(StageId::SenderRecovery.to_string(), "SenderRecovery");

--- a/crates/primitives/src/stage/id.rs
+++ b/crates/primitives/src/stage/id.rs
@@ -56,6 +56,7 @@ impl StageId {
     /// Return stage id formatted as string.
     pub fn as_str(&self) -> &str {
         match self {
+            #[allow(deprecated)]
             StageId::StaticFile => "StaticFile",
             StageId::Headers => "Headers",
             StageId::Bodies => "Bodies",


### PR DESCRIPTION
Cleanup after https://github.com/paradigmxyz/reth/pull/6763

This PR **does not** remove the `StageId::StaticFile` variant, as it's unclear whether it's a breaking database change.

`check_pipeline_consistency` has a strong assumption that the first stage of the pipeline is `Headers` https://github.com/paradigmxyz/reth/blob/027d50fc105fd527dca0bf56fe51b7240f119e66/crates/consensus/beacon/src/engine/mod.rs#L557-L598

But because we had `StaticFile` as the first stage without an actual stage implementation, its checkpoint was always zero, so the consistency check passed, and the node went to live sync instead of continuing the pipeline sync.