### PR TITLE
fix: check that data is large enough to fit header and mac

### DIFF
--- a/crates/net/ecies/src/algorithm.rs
+++ b/crates/net/ecies/src/algorithm.rs
@@ -637,6 +637,13 @@ impl ECIES {
     }
 
     pub fn read_header(&mut self, data: &mut [u8]) -> Result<usize, ECIESError> {
+        // If the data is not large enough to fit the header and mac bytes, return an error
+        //
+        // The header is 16 bytes, and the mac is 16 bytes, so the data must be at least 32 bytes
+        if data.len() < 32 {
+            return Err(ECIESErrorImpl::InvalidHeader.into())
+        }
+
         let (header_bytes, mac_bytes) = split_at_mut(data, 16)?;
         let header = HeaderBytes::from_mut_slice(header_bytes);
         let mac = B128::from_slice(&mac_bytes[..16]);


### PR DESCRIPTION
Ensures that the data can fit the header (16 bytes) and the mac tag (16 bytes) before attempting to read.