### PR TITLE
fix: tell jemalloc to use 64-KiB pages when cross building aarch64

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -6,6 +6,5 @@ pre-build = [
 
 [build.env]
 passthrough = [
-    "RUST_FLAGS",
     "JEMALLOC_SYS_WITH_LG_PAGE",
 ]

--- a/Cross.toml
+++ b/Cross.toml
@@ -3,3 +3,9 @@ pre-build = [
     # rust-bindgen dependencies: llvm-dev libclang-dev (>= 5.0) clang (>= 5.0)
     "apt-get update && apt-get install --assume-yes --no-install-recommends llvm-dev libclang-6.0-dev clang-6.0"
 ]
+
+[build.env]
+passthrough = [
+    "RUST_FLAGS",
+    "JEMALLOC_SYS_WITH_LG_PAGE",
+]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN cargo chef cook --profile $BUILD_PROFILE --recipe-path recipe.json
 
 # Build application
 COPY . .
-RUN cargo build --profile $BUILD_PROFILE --features "$FEATURES" --no-default-features --locked --bin reth
+RUN cargo build --profile $BUILD_PROFILE --features "$FEATURES" --locked --bin reth
 
 # ARG is not resolved in COPY so we have to hack around it by copying the
 # binary to a temporary location

--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,11 @@ op-build-native-%:
 # size, otherwise it will use the current system's page size which may not work
 # on other systems. JEMALLOC_SYS_WITH_LG_PAGE=16 tells jemalloc to use 64-KiB
 # pages. See: https://github.com/paradigmxyz/reth/issues/6742
-%build-aarch64-unknown-linux-gnu: FEATURES := $(filter-out asm-keccak,$(FEATURES))
-%build-aarch64-unknown-linux-gnu: export JEMALLOC_SYS_WITH_LG_PAGE=16
+build-aarch64-unknown-linux-gnu: FEATURES := $(filter-out asm-keccak,$(FEATURES))
+build-aarch64-unknown-linux-gnu: export JEMALLOC_SYS_WITH_LG_PAGE=16
+
+op-build-aarch64-unknown-linux-gnu: FEATURES := $(filter-out asm-keccak,$(FEATURES))
+op-build-aarch64-unknown-linux-gnu: export JEMALLOC_SYS_WITH_LG_PAGE=16
 
 # No jemalloc on Windows
 build-x86_64-pc-windows-gnu: FEATURES := $(filter-out jemalloc jemalloc-prof,$(FEATURES))

--- a/Makefile
+++ b/Makefile
@@ -100,11 +100,11 @@ build-x86_64-pc-windows-gnu: FEATURES := $(filter-out jemalloc jemalloc-prof,$(F
 # See: https://github.com/cross-rs/cross/wiki/FAQ#undefined-reference-with-build-std
 build-%:
 	RUSTFLAGS="-C link-arg=-lgcc -Clink-arg=-static-libgcc" \
-	    cross build --bin reth --target $* --features "$(FEATURES)" --profile "$(PROFILE)"
+		cross build --bin reth --target $* --features "$(FEATURES)" --profile "$(PROFILE)"
 
 op-build-%:
 	RUSTFLAGS="-C link-arg=-lgcc -Clink-arg=-static-libgcc" \
-	    cross build --bin op-reth --target $* --features "optimism,$(FEATURES)" --profile "$(PROFILE)"
+		cross build --bin op-reth --target $* --features "optimism,$(FEATURES)" --profile "$(PROFILE)"
 
 # Unfortunately we can't easily use cross to build for Darwin because of licensing issues.
 # If we wanted to, we would need to build a custom Docker image with the SDK available.

--- a/Makefile
+++ b/Makefile
@@ -82,14 +82,11 @@ op-build-native-%:
 #
 # The resulting binaries will be created in the `target/` directory.
 
-# Disable asm-keccak optimizations and set the page size for jemalloc. When
-# cross compiling for aarch64, we must compile jemalloc with a bigger page
-# size, otherwise it will use the platform's page size which may not work on
-# other systems. JEMALLOC_SYS_WITH_LG_PAGE=16 tells jemalloc to use 64-KiB
-# pages. See the following links for more information:
-#
-# (1) https://github.com/paradigmxyz/reth/issues/6742
-# (2) https://github.com/tikv/jemallocator/blob/af6e6529c087dc1d0ac159372111a859031269f6/jemalloc-sys/README.md?plain=1#L112-L117
+# For aarch64, disable asm-keccak optimizations and set the page size for
+# jemalloc. When cross compiling, we must compile jemalloc with a large page
+# size, otherwise it will use the current system's page size which may not work
+# on other systems. JEMALLOC_SYS_WITH_LG_PAGE=16 tells jemalloc to use 64-KiB
+# pages. See: https://github.com/paradigmxyz/reth/issues/6742
 build-aarch64-unknown-linux-gnu: FEATURES := $(filter-out asm-keccak,$(FEATURES))
 build-aarch64-unknown-linux-gnu: export JEMALLOC_SYS_WITH_LG_PAGE=16
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,15 @@ FULL_DB_TOOLS_DIR := $(shell pwd)/$(DB_TOOLS_DIR)/
 
 BUILD_PATH = "target"
 
+# Configure environment variable which will be used when building jemalloc.
+# This tells jemalloc to use 64-KiB pages. This is necessary when cross
+# compiling for a system that uses a different page size. See the following
+# links for more information:
+#
+# (1) https://github.com/paradigmxyz/reth/issues/6742
+# (2) https://github.com/tikv/jemallocator/blob/af6e6529c087dc1d0ac159372111a859031269f6/jemalloc-sys/README.md?plain=1#L112-L117
+export JEMALLOC_SYS_WITH_LG_PAGE=16
+
 # List of features to use when building. Can be overridden via the environment.
 # No jemalloc on Windows
 ifeq ($(OS),Windows_NT)
@@ -85,10 +94,8 @@ op-build-native-%:
 # No jemalloc on Windows
 build-x86_64-pc-windows-gnu: FEATURES := $(filter-out jemalloc jemalloc-prof,$(FEATURES))
 
-# Disable asm-keccak optimizations and jemalloc.
-# Some aarch64 systems use larger page sizes and jemalloc doesn't play well.
-# See: https://github.com/paradigmxyz/reth/issues/6742
-build-aarch64-unknown-linux-gnu: FEATURES := $(filter-out asm-keccak jemalloc jemalloc-prof,$(FEATURES))
+# Disable asm-keccak optimizations.
+build-aarch64-unknown-linux-gnu: FEATURES := $(filter-out asm-keccak,$(FEATURES))
 
 # Note: The additional rustc compiler flags are for intrinsics needed by MDBX.
 # See: https://github.com/cross-rs/cross/wiki/FAQ#undefined-reference-with-build-std

--- a/Makefile
+++ b/Makefile
@@ -101,11 +101,13 @@ build-x86_64-pc-windows-gnu: FEATURES := $(filter-out jemalloc jemalloc-prof,$(F
 
 # Note: The additional rustc compiler flags are for intrinsics needed by MDBX.
 # See: https://github.com/cross-rs/cross/wiki/FAQ#undefined-reference-with-build-std
-build-%: export RUSTFLAGS="-C link-arg=-lgcc -Clink-arg=-static-libgcc"
-	cross build --bin reth --target $* --features "$(FEATURES)" --profile "$(PROFILE)"
+build-%:
+	RUSTFLAGS="-C link-arg=-lgcc -Clink-arg=-static-libgcc" \
+	    cross build --bin reth --target $* --features "$(FEATURES)" --profile "$(PROFILE)"
 
-op-build-%: export RUSTFLAGS="-C link-arg=-lgcc -Clink-arg=-static-libgcc"
-	cross build --bin op-reth --target $* --features "optimism,$(FEATURES)" --profile "$(PROFILE)"
+op-build-%:
+	RUSTFLAGS="-C link-arg=-lgcc -Clink-arg=-static-libgcc" \
+	    cross build --bin op-reth --target $* --features "optimism,$(FEATURES)" --profile "$(PROFILE)"
 
 # Unfortunately we can't easily use cross to build for Darwin because of licensing issues.
 # If we wanted to, we would need to build a custom Docker image with the SDK available.

--- a/Makefile
+++ b/Makefile
@@ -91,25 +91,21 @@ op-build-native-%:
 # (1) https://github.com/paradigmxyz/reth/issues/6742
 # (2) https://github.com/tikv/jemallocator/blob/af6e6529c087dc1d0ac159372111a859031269f6/jemalloc-sys/README.md?plain=1#L112-L117
 build-aarch64-unknown-linux-gnu: FEATURES := $(filter-out asm-keccak,$(FEATURES))
-	RUSTFLAGS="-C link-arg=-lgcc -Clink-arg=-static-libgcc" JEMALLOC_SYS_WITH_LG_PAGE=16 \
-	    cross build --bin reth --target $* --features "$(FEATURES)" --profile "$(PROFILE)"
+build-aarch64-unknown-linux-gnu: export JEMALLOC_SYS_WITH_LG_PAGE=16
 
-op-build-aarch64-unknown-linux-gnu:
-	RUSTFLAGS="-C link-arg=-lgcc -Clink-arg=-static-libgcc" JEMALLOC_SYS_WITH_LG_PAGE=16 \
-	    cross build --bin op-reth --target $* --features "optimism,$(FEATURES)" --profile "$(PROFILE)"
+op-build-aarch64-unknown-linux-gnu: FEATURES := $(filter-out asm-keccak,$(FEATURES))
+op-build-aarch64-unknown-linux-gnu: export JEMALLOC_SYS_WITH_LG_PAGE=16
 
 # No jemalloc on Windows
 build-x86_64-pc-windows-gnu: FEATURES := $(filter-out jemalloc jemalloc-prof,$(FEATURES))
 
 # Note: The additional rustc compiler flags are for intrinsics needed by MDBX.
 # See: https://github.com/cross-rs/cross/wiki/FAQ#undefined-reference-with-build-std
-build-%:
-	RUSTFLAGS="-C link-arg=-lgcc -Clink-arg=-static-libgcc" \
- 		cross build --bin reth --target $* --features "$(FEATURES)" --profile "$(PROFILE)"
+build-%: export RUSTFLAGS="-C link-arg=-lgcc -Clink-arg=-static-libgcc"
+	cross build --bin reth --target $* --features "$(FEATURES)" --profile "$(PROFILE)"
 
-op-build-%:
-	RUSTFLAGS="-C link-arg=-lgcc -Clink-arg=-static-libgcc" \
- 		cross build --bin op-reth --target $* --features "optimism,$(FEATURES)" --profile "$(PROFILE)"
+op-build-%: export RUSTFLAGS="-C link-arg=-lgcc -Clink-arg=-static-libgcc"
+	cross build --bin op-reth --target $* --features "optimism,$(FEATURES)" --profile "$(PROFILE)"
 
 # Unfortunately we can't easily use cross to build for Darwin because of licensing issues.
 # If we wanted to, we would need to build a custom Docker image with the SDK available.

--- a/Makefile
+++ b/Makefile
@@ -10,15 +10,6 @@ FULL_DB_TOOLS_DIR := $(shell pwd)/$(DB_TOOLS_DIR)/
 
 BUILD_PATH = "target"
 
-# Configure environment variable which will be used when building jemalloc.
-# This tells jemalloc to use 64-KiB pages. This is necessary when cross
-# compiling for a system that uses a different page size. See the following
-# links for more information:
-#
-# (1) https://github.com/paradigmxyz/reth/issues/6742
-# (2) https://github.com/tikv/jemallocator/blob/af6e6529c087dc1d0ac159372111a859031269f6/jemalloc-sys/README.md?plain=1#L112-L117
-export JEMALLOC_SYS_WITH_LG_PAGE=16
-
 # List of features to use when building. Can be overridden via the environment.
 # No jemalloc on Windows
 ifeq ($(OS),Windows_NT)
@@ -91,11 +82,24 @@ op-build-native-%:
 #
 # The resulting binaries will be created in the `target/` directory.
 
+# Disable asm-keccak optimizations and set the page size for jemalloc. When
+# cross compiling for aarch64, we must compile jemalloc with a bigger page
+# size, otherwise it will use the platform's page size which may not work on
+# other systems. JEMALLOC_SYS_WITH_LG_PAGE=16 tells jemalloc to use 64-KiB
+# pages. See the following links for more information:
+#
+# (1) https://github.com/paradigmxyz/reth/issues/6742
+# (2) https://github.com/tikv/jemallocator/blob/af6e6529c087dc1d0ac159372111a859031269f6/jemalloc-sys/README.md?plain=1#L112-L117
+build-aarch64-unknown-linux-gnu: FEATURES := $(filter-out asm-keccak,$(FEATURES))
+	RUSTFLAGS="-C link-arg=-lgcc -Clink-arg=-static-libgcc" JEMALLOC_SYS_WITH_LG_PAGE=16 \
+	    cross build --bin reth --target $* --features "$(FEATURES)" --profile "$(PROFILE)"
+
+op-build-aarch64-unknown-linux-gnu:
+	RUSTFLAGS="-C link-arg=-lgcc -Clink-arg=-static-libgcc" JEMALLOC_SYS_WITH_LG_PAGE=16 \
+	    cross build --bin op-reth --target $* --features "optimism,$(FEATURES)" --profile "$(PROFILE)"
+
 # No jemalloc on Windows
 build-x86_64-pc-windows-gnu: FEATURES := $(filter-out jemalloc jemalloc-prof,$(FEATURES))
-
-# Disable asm-keccak optimizations.
-build-aarch64-unknown-linux-gnu: FEATURES := $(filter-out asm-keccak,$(FEATURES))
 
 # Note: The additional rustc compiler flags are for intrinsics needed by MDBX.
 # See: https://github.com/cross-rs/cross/wiki/FAQ#undefined-reference-with-build-std

--- a/Makefile
+++ b/Makefile
@@ -87,11 +87,8 @@ op-build-native-%:
 # size, otherwise it will use the current system's page size which may not work
 # on other systems. JEMALLOC_SYS_WITH_LG_PAGE=16 tells jemalloc to use 64-KiB
 # pages. See: https://github.com/paradigmxyz/reth/issues/6742
-build-aarch64-unknown-linux-gnu: FEATURES := $(filter-out asm-keccak,$(FEATURES))
-build-aarch64-unknown-linux-gnu: export JEMALLOC_SYS_WITH_LG_PAGE=16
-
-op-build-aarch64-unknown-linux-gnu: FEATURES := $(filter-out asm-keccak,$(FEATURES))
-op-build-aarch64-unknown-linux-gnu: export JEMALLOC_SYS_WITH_LG_PAGE=16
+%build-aarch64-unknown-linux-gnu: FEATURES := $(filter-out asm-keccak,$(FEATURES))
+%build-aarch64-unknown-linux-gnu: export JEMALLOC_SYS_WITH_LG_PAGE=16
 
 # No jemalloc on Windows
 build-x86_64-pc-windows-gnu: FEATURES := $(filter-out jemalloc jemalloc-prof,$(FEATURES))


### PR DESCRIPTION
Fixes #6742.

This PR sets `JEMALLOC_SYS_WITH_LG_PAGE` to 16 for aarch64 cross builds, which will force jemalloc to use 64 KiB pages. This should work with most of the newer arm64 systems which use larger pages. This is an alternative to:

* https://github.com/paradigmxyz/reth/pull/6913

I have tested this myself by running `make docker-build-push` on an x86_64 system. I pulled the image (which I pushed to my local docker hub account) on my M1 Mac mini running Linux and it works.

Initially, setting the environment variable didn't seem to work. I realized that environment variables weren't being passed to `cross build`, which makes sense because it's a docker container. I had to configure passthrough variables.

<img width="905" alt="image" src="https://github.com/paradigmxyz/reth/assets/95511699/1818e337-792f-48ae-9d28-c9d0805125b6">

Link: https://docs.rs/crate/cross/0.1.14

This PR also re-enables jemalloc to be a default feature.