### PR TITLE
chore(make): run doctest in `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,7 +303,8 @@ lint:
 	make lint-op-reth && \
 	make lint-other-targets
 
-rustdocs:
+.PHONY: rustdocs
+rustdocs: ## Runs `cargo docs` to generate the Rust documents in the `target/doc` directory
 	RUSTDOCFLAGS="\
 	--cfg docsrs \
 	--show-type-layout \

--- a/Makefile
+++ b/Makefile
@@ -341,9 +341,14 @@ test-other-targets:
 	--benches \
 	--all-features
 
+test-doc:
+	cargo test --doc --workspace --features "ethereum"
+	cargo test --doc --workspace --features "optimism"
+
 test:
 	make test-reth && \
 	make test-op-reth && \
+	make test-doc && \
 	make test-other-targets
 
 pr:


### PR DESCRIPTION
allow users to run doctest with makefile, so they can use `make pr` to verify if their commits are valid after changing the rustdocs, cc https://github.com/paradigmxyz/reth/pull/7120