### PR TITLE
fix: receipt for non EIP-4844 transactions

### DIFF
--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -1507,6 +1507,11 @@ pub(crate) fn build_transaction_receipt_with_block_receipts(
             .unwrap_or_default()
     };
 
+    let blob_gas_used = transaction.transaction.blob_gas_used().map(U128::from);
+    // Blob gas price should only be present if the transaction is a blob transaction
+    let blob_gas_price =
+        blob_gas_used.and_then(|_| meta.excess_blob_gas.map(calc_blob_gasprice).map(U128::from));
+
     #[allow(clippy::needless_update)]
     let mut res_receipt = TransactionReceipt {
         transaction_hash: Some(meta.tx_hash),
@@ -1526,8 +1531,8 @@ pub(crate) fn build_transaction_receipt_with_block_receipts(
         logs_bloom: receipt.bloom_slow(),
         status_code: if receipt.success { Some(U64::from(1)) } else { Some(U64::from(0)) },
         // EIP-4844 fields
-        blob_gas_price: meta.excess_blob_gas.map(calc_blob_gasprice).map(U128::from),
-        blob_gas_used: transaction.transaction.blob_gas_used().map(U128::from),
+        blob_gas_price,
+        blob_gas_used,
         ..Default::default()
     };
 


### PR DESCRIPTION
The receipt for non EIP-4844 transactions should not contain the `blob_gas_price`. The current implementation caused a blob gas price of 0x1 to be added.