### PR TITLE
fix: apply block overrides before create env

### DIFF
--- a/crates/rpc/rpc/src/eth/revm_utils.rs
+++ b/crates/rpc/rpc/src/eth/revm_utils.rs
@@ -237,7 +237,7 @@ where
 ///  - `nonce` is set to `None`
 pub(crate) fn prepare_call_env<DB>(
     mut cfg: CfgEnvWithHandlerCfg,
-    block: BlockEnv,
+    mut block: BlockEnv,
     request: TransactionRequest,
     gas_limit: u64,
     db: &mut CacheDB<DB>,
@@ -260,24 +260,25 @@ where
     // <https://github.com/ethereum/go-ethereum/blob/ee8e83fa5f6cb261dad2ed0a7bbcde4930c41e6c/internal/ethapi/api.go#L985>
     cfg.disable_base_fee = true;
 
-    let request_gas = request.gas;
-
-    let mut env = build_call_evm_env(cfg, block, request)?;
-    env.tx.nonce = None;
-
-    // apply state overrides
-    if let Some(state_overrides) = overrides.state {
-        apply_state_overrides(state_overrides, db)?;
-    }
-
-    // apply block overrides
+    // apply block overrides, we need to apply them first so that they take effect when we we create
+    // the evm env via `build_call_evm_env`, e.g. basefee
     if let Some(mut block_overrides) = overrides.block {
         if let Some(block_hashes) = block_overrides.block_hash.take() {
             // override block hashes
             db.block_hashes
                 .extend(block_hashes.into_iter().map(|(num, hash)| (U256::from(num), hash)))
         }
-        apply_block_overrides(*block_overrides, &mut env.env.block);
+        apply_block_overrides(*block_overrides, &mut block);
+    }
+
+    let request_gas = request.gas;
+    let mut env = build_call_evm_env(cfg, block, request)?;
+    // set nonce to None so that the next nonce is used when transacting the call
+    env.tx.nonce = None;
+
+    // apply state overrides
+    if let Some(state_overrides) = overrides.state {
+        apply_state_overrides(state_overrides, db)?;
     }
 
     if request_gas.is_none() {


### PR DESCRIPTION
Closes #6240

Apply block overrides before creating the call env so base fee overrides take effect when validating fees


still tbd if we should remove the max_fee < block.basefee check for calls, need to check other impls