### PR TITLE
fix: payload builder london boundary block gaslimit and basefee

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6324,6 +6324,7 @@ dependencies = [
  "reth-transaction-pool",
  "revm",
  "revm-primitives",
+ "serde_json",
  "sha2",
  "thiserror",
  "tokio",

--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -41,6 +41,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 revm.workspace = true
+serde_json.workspace = true
 
 [features]
 test-utils = []

--- a/crates/payload/builder/src/payload.rs
+++ b/crates/payload/builder/src/payload.rs
@@ -396,5 +396,8 @@ mod tests {
 
         // ensure the base fee is non zero
         assert_eq!(cfg_and_block_env.1.basefee, U256::from(EIP1559_INITIAL_BASE_FEE));
+
+        // ensure the gas limit is double the previous block's gas limit
+        assert_eq!(cfg_and_block_env.1.gas_limit, U256::from(chainspec.genesis_header().gas_limit * 2));
     }
 }

--- a/crates/payload/builder/src/payload.rs
+++ b/crates/payload/builder/src/payload.rs
@@ -3,8 +3,7 @@
 use alloy_rlp::Encodable;
 use reth_node_api::{BuiltPayload, PayloadBuilderAttributes};
 use reth_primitives::{
-    revm::config::revm_spec_by_timestamp_after_merge, Address, BlobTransactionSidecar, ChainSpec,
-    Header, SealedBlock, Withdrawals, B256, U256,
+    constants::EIP1559_INITIAL_BASE_FEE, revm::config::revm_spec_by_timestamp_after_merge, Address, BlobTransactionSidecar, ChainSpec, Hardfork, Header, SealedBlock, Withdrawals, B256, U256
 };
 use reth_rpc_types::engine::{
     ExecutionPayloadEnvelopeV2, ExecutionPayloadEnvelopeV3, ExecutionPayloadV1, PayloadAttributes,
@@ -245,6 +244,18 @@ impl PayloadBuilderAttributes for EthPayloadBuilderAttributes {
             })
             .map(BlobExcessGasAndPrice::new);
 
+        let basefee = parent
+            .next_block_base_fee(chain_spec.base_fee_params(self.timestamp()))
+            .or_else(|| {
+                if chain_spec.fork(Hardfork::London).transitions_at_block(parent.number + 1) {
+                    // default base fee is zero
+                    Some(EIP1559_INITIAL_BASE_FEE)
+                } else {
+                    None
+                }
+            })
+            .map(U256::from);
+
         let block_env = BlockEnv {
             number: U256::from(parent.number + 1),
             coinbase: self.suggested_fee_recipient(),
@@ -253,11 +264,7 @@ impl PayloadBuilderAttributes for EthPayloadBuilderAttributes {
             prevrandao: Some(self.prev_randao()),
             gas_limit: U256::from(parent.gas_limit),
             // calculate basefee based on parent block's gas usage
-            basefee: U256::from(
-                parent
-                    .next_block_base_fee(chain_spec.base_fee_params(self.timestamp()))
-                    .unwrap_or_default(),
-            ),
+            basefee: basefee.unwrap_or_default(),
             // calculate excess gas based on parent block's blob gas usage
             blob_excess_gas_and_price,
         };
@@ -288,4 +295,93 @@ pub(crate) fn payload_id(parent: &B256, attributes: &PayloadAttributes) -> Paylo
 
     let out = hasher.finalize();
     PayloadId::new(out.as_slice()[..8].try_into().expect("sufficient length"))
+}
+
+#[cfg(test)]
+mod tests {
+    use reth_primitives::Genesis;
+    use super::*;
+
+    #[test]
+    fn ensure_first_london_block_base_fee_is_set() {
+        let hive_london = r#"
+{
+  "config": {
+    "ethash": {},
+    "chainId": 7,
+    "homesteadBlock": 0,
+    "eip150Block": 0,
+    "eip155Block": 0,
+    "eip158Block": 0,
+    "byzantiumBlock": 0,
+    "constantinopleBlock": 0,
+    "petersburgBlock": 0,
+    "istanbulBlock": 0,
+    "muirGlacierBlock": 0,
+    "berlinBlock": 0,
+    "londonBlock": 1,
+    "mergeNetsplitBlock": 1,
+    "terminalTotalDifficulty": 196608,
+    "shanghaiTime": 4662,
+    "cancunTime": 4662
+  },
+  "nonce": "0x0",
+  "timestamp": "0x1234",
+  "extraData": "0x0000000000000000000000000000000000000000000000000000000000000000658bdf435d810c91414ec09147daa6db624063790000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+  "gasLimit": "0x2fefd8",
+  "difficulty": "0x30000",
+  "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "coinbase": "0x0000000000000000000000000000000000000000",
+  "alloc": {
+    "0000000000000000000000000000000000000314": {
+      "code": "0x60606040526000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063a223e05d1461006a578063abd1a0cf1461008d578063abfced1d146100d4578063e05c914a14610110578063e6768b451461014c575b610000565b346100005761007761019d565b6040518082815260200191505060405180910390f35b34610000576100be600480803573ffffffffffffffffffffffffffffffffffffffff169060200190919050506101a3565b6040518082815260200191505060405180910390f35b346100005761010e600480803573ffffffffffffffffffffffffffffffffffffffff169060200190919080359060200190919050506101ed565b005b346100005761014a600480803590602001909190803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610236565b005b346100005761017960048080359060200190919080359060200190919080359060200190919050506103c4565b60405180848152602001838152602001828152602001935050505060405180910390f35b60005481565b6000600160008373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205490505b919050565b80600160008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020819055505b5050565b7f6031a8d62d7c95988fa262657cd92107d90ed96e08d8f867d32f26edfe85502260405180905060405180910390a17f47e2689743f14e97f7dcfa5eec10ba1dff02f83b3d1d4b9c07b206cbbda66450826040518082815260200191505060405180910390a1817fa48a6b249a5084126c3da369fbc9b16827ead8cb5cdc094b717d3f1dcd995e2960405180905060405180910390a27f7890603b316f3509577afd111710f9ebeefa15e12f72347d9dffd0d65ae3bade81604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390a18073ffffffffffffffffffffffffffffffffffffffff167f7efef9ea3f60ddc038e50cccec621f86a0195894dc0520482abf8b5c6b659e4160405180905060405180910390a28181604051808381526020018273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019250505060405180910390a05b5050565b6000600060008585859250925092505b935093509390505600a165627a7a72305820aaf842d0d0c35c45622c5263cbb54813d2974d3999c8c38551d7c613ea2bc1170029",
+      "storage": {
+        "0x0000000000000000000000000000000000000000000000000000000000000000": "0x0000000000000000000000000000000000000000000000000000000000001234",
+        "0x6661e9d6d8b923d5bbaab1b96e1dd51ff6ea2a93520fdc9eb75d059238b8c5e9": "0x0000000000000000000000000000000000000000000000000000000000000001"
+      },
+      "balance": "0x0"
+    },
+    "0000000000000000000000000000000000000315": {
+      "code": "0x60606040526000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063ef2769ca1461003e575b610000565b3461000057610078600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803590602001909190505061007a565b005b8173ffffffffffffffffffffffffffffffffffffffff166108fc829081150290604051809050600060405180830381858888f1935050505015610106578173ffffffffffffffffffffffffffffffffffffffff167f30a3c50752f2552dcc2b93f5b96866280816a986c0c0408cb6778b9fa198288f826040518082815260200191505060405180910390a25b5b50505600a165627a7a72305820637991fabcc8abad4294bf2bb615db78fbec4edff1635a2647d3894e2daf6a610029",
+      "balance": "0x9999999999999999999999999999999"
+    },
+    "0000000000000000000000000000000000000316": {
+      "code": "0x444355",
+      "balance": "0x0"
+    },
+    "0000000000000000000000000000000000000317": {
+      "code": "0x600160003555",
+      "balance": "0x0"
+    },
+    "000f3df6d732807ef1319fb7b8bb8522d0beac02": {
+      "code": "0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500",
+      "balance": "0x0",
+      "nonce": "0x1"
+    }
+  },
+  "number": "0x0",
+  "gasUsed": "0x0",
+  "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "baseFeePerGas": null,
+  "excessBlobGas": null,
+  "blobGasUsed": null
+}
+            "#;
+
+        let attributes = r#"{"timestamp":"0x1235","prevRandao":"0xf343b00e02dc34ec0124241f74f32191be28fb370bb48060f5fa4df99bda774c","suggestedFeeRecipient":"0x0000000000000000000000000000000000000000","withdrawals":null,"parentBeaconBlockRoot":null}"#;
+        let attributes: PayloadAttributes = serde_json::from_str(attributes).unwrap();
+
+        // check that it deserializes properly
+        let genesis: Genesis = serde_json::from_str(hive_london).unwrap();
+        let chainspec = ChainSpec::from(genesis);
+        let payload_builder_attributes =
+            EthPayloadBuilderAttributes::new(chainspec.genesis_hash(), attributes);
+
+        // use cfg_and_block_env
+        let cfg_and_block_env =
+            payload_builder_attributes.cfg_and_block_env(&chainspec, &chainspec.genesis_header());
+
+        // ensure the base fee is non zero
+        assert_eq!(cfg_and_block_env.1.basefee, U256::from(EIP1559_INITIAL_BASE_FEE));
+    }
 }

--- a/crates/payload/builder/src/payload.rs
+++ b/crates/payload/builder/src/payload.rs
@@ -398,6 +398,9 @@ mod tests {
         assert_eq!(cfg_and_block_env.1.basefee, U256::from(EIP1559_INITIAL_BASE_FEE));
 
         // ensure the gas limit is double the previous block's gas limit
-        assert_eq!(cfg_and_block_env.1.gas_limit, U256::from(chainspec.genesis_header().gas_limit * 2));
+        assert_eq!(
+            cfg_and_block_env.1.gas_limit,
+            U256::from(chainspec.genesis_header().gas_limit * 2)
+        );
     }
 }


### PR DESCRIPTION
Previously we did not set a base fee if London was crossed, and did not set the gas limit properly on the london boundary block. In both cases, we would produce an invalid block on the boundary with payload building, which we would later reject in newPayload.

This fixes hive test `Pre-Merge Fork Number > 0 (Cancun) (reth)`