### PR TITLE
Comment pool import error is not nonce gap

### DIFF
--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1079,7 +1079,6 @@ where
                     self.on_good_import(hash);
                 }
                 Err(err) => {
-                    //
                     // If we're _currently_ syncing and the transaction is bad we
                     // ignore it, otherwise we penalize the peer that sent the bad
                     // transaction with the assumption that the peer should have

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1079,11 +1079,13 @@ where
                     self.on_good_import(hash);
                 }
                 Err(err) => {
-                    // if we're _currently_ syncing and the transaction is bad we
+                    //
+                    // If we're _currently_ syncing and the transaction is bad we
                     // ignore it, otherwise we penalize the peer that sent the bad
                     // transaction with the assumption that the peer should have
-                    // known that this transaction is bad. (e.g. consensus
-                    // rules)
+                    // known that this transaction is bad. (e.g. consensus rules).
+                    // Note: nonce gaps are not considered bad transactions.
+                    //
                     if err.is_bad_transaction() && !self.network.is_syncing() {
                         debug!(target: "net::tx", %err, "bad pool transaction import");
                         self.on_bad_import(err.hash);

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -288,4 +288,15 @@ impl InvalidPoolTransactionError {
             }
         }
     }
+
+    /// Returns `true` if an import failed due to nonce gap.
+    pub const fn is_nonce_gap(&self) -> bool {
+        matches!(
+            self,
+            InvalidPoolTransactionError::Consensus(InvalidTransactionError::NonceNotConsistent)
+        ) || matches!(
+            self,
+            InvalidPoolTransactionError::Eip4844(Eip4844PoolTransactionError::Eip4844NonceGap)
+        )
+    }
 }


### PR DESCRIPTION
This branch was supposed to disable filtering bad imports, but a tx is only added to bad imports if for specific pool import errors, which exclude 'nonce gap' error.

Adds comment to clarify this. Adds method for checking if pool import error is nonce gap error.