### PR TITLE
dep: lock enr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -269,7 +269,7 @@ secp256k1 = { version = "0.27.0", default-features = false, features = [
     "rand-std",
     "recovery",
 ] }
-enr = { version = "0.10", default-features = false, features = ["k256"] }
+enr = { version = "=0.10.0", default-features = false, features = ["k256"] }
 
 # for eip-4844
 c-kzg = "0.4.2"


### PR DESCRIPTION
## Description

Lock enr due to failing builds of projects that use `reth` as dependency. Ref https://github.com/sigp/discv5/issues/239