### PR TITLE
feat(node-core, stages): stage preparation notification

### DIFF
--- a/crates/stages/src/pipeline/event.rs
+++ b/crates/stages/src/pipeline/event.rs
@@ -14,6 +14,17 @@ use std::fmt::{Display, Formatter};
 /// - The pipeline will loop indefinitely unless a target block is set
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum PipelineEvent {
+    /// Emitted when a stage is about to be prepared for a run.
+    Prepare {
+        /// Pipeline stages progress.
+        pipeline_stages_progress: PipelineStagesProgress,
+        /// The stage that is about to be run.
+        stage_id: StageId,
+        /// The previous checkpoint of the stage.
+        checkpoint: Option<StageCheckpoint>,
+        /// The block number up to which the stage is running, if known.
+        target: Option<BlockNumber>,
+    },
     /// Emitted when a stage is about to be run.
     Run {
         /// Pipeline stages progress.

--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -371,6 +371,16 @@ where
 
             let exec_input = ExecInput { target, checkpoint: prev_checkpoint };
 
+            self.listeners.notify(PipelineEvent::Prepare {
+                pipeline_stages_progress: event::PipelineStagesProgress {
+                    current: stage_index + 1,
+                    total: total_stages,
+                },
+                stage_id,
+                checkpoint: prev_checkpoint,
+                target,
+            });
+
             if let Err(err) = stage.execute_ready(exec_input).await {
                 self.listeners.notify(PipelineEvent::Error { stage_id });
                 match on_stage_error(&self.provider_factory, stage_id, prev_checkpoint, err)? {

--- a/crates/stages/src/pipeline/mod.rs
+++ b/crates/stages/src/pipeline/mod.rs
@@ -621,6 +621,12 @@ mod tests {
         assert_eq!(
             events.collect::<Vec<PipelineEvent>>().await,
             vec![
+                PipelineEvent::Prepare {
+                    pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 2 },
+                    stage_id: StageId::Other("A"),
+                    checkpoint: None,
+                    target: Some(10),
+                },
                 PipelineEvent::Run {
                     pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 2 },
                     stage_id: StageId::Other("A"),
@@ -631,6 +637,12 @@ mod tests {
                     pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 2 },
                     stage_id: StageId::Other("A"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(20), done: true },
+                },
+                PipelineEvent::Prepare {
+                    pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 2 },
+                    stage_id: StageId::Other("B"),
+                    checkpoint: None,
+                    target: Some(10),
                 },
                 PipelineEvent::Run {
                     pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 2 },
@@ -693,6 +705,12 @@ mod tests {
             events.collect::<Vec<PipelineEvent>>().await,
             vec![
                 // Executing
+                PipelineEvent::Prepare {
+                    pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 3 },
+                    stage_id: StageId::Other("A"),
+                    checkpoint: None,
+                    target: Some(10),
+                },
                 PipelineEvent::Run {
                     pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 3 },
                     stage_id: StageId::Other("A"),
@@ -704,6 +722,12 @@ mod tests {
                     stage_id: StageId::Other("A"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(100), done: true },
                 },
+                PipelineEvent::Prepare {
+                    pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 3 },
+                    stage_id: StageId::Other("B"),
+                    checkpoint: None,
+                    target: Some(10),
+                },
                 PipelineEvent::Run {
                     pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 3 },
                     stage_id: StageId::Other("B"),
@@ -714,6 +738,12 @@ mod tests {
                     pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 3 },
                     stage_id: StageId::Other("B"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(10), done: true },
+                },
+                PipelineEvent::Prepare {
+                    pipeline_stages_progress: PipelineStagesProgress { current: 3, total: 3 },
+                    stage_id: StageId::Other("C"),
+                    checkpoint: None,
+                    target: Some(10),
                 },
                 PipelineEvent::Run {
                     pipeline_stages_progress: PipelineStagesProgress { current: 3, total: 3 },
@@ -807,6 +837,12 @@ mod tests {
             events.collect::<Vec<PipelineEvent>>().await,
             vec![
                 // Executing
+                PipelineEvent::Prepare {
+                    pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 2 },
+                    stage_id: StageId::Other("A"),
+                    checkpoint: None,
+                    target: Some(10),
+                },
                 PipelineEvent::Run {
                     pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 2 },
                     stage_id: StageId::Other("A"),
@@ -817,6 +853,12 @@ mod tests {
                     pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 2 },
                     stage_id: StageId::Other("A"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(100), done: true },
+                },
+                PipelineEvent::Prepare {
+                    pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 2 },
+                    stage_id: StageId::Other("B"),
+                    checkpoint: None,
+                    target: Some(10),
                 },
                 PipelineEvent::Run {
                     pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 2 },
@@ -906,6 +948,12 @@ mod tests {
         assert_eq!(
             events.collect::<Vec<PipelineEvent>>().await,
             vec![
+                PipelineEvent::Prepare {
+                    pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 2 },
+                    stage_id: StageId::Other("A"),
+                    checkpoint: None,
+                    target: Some(10),
+                },
                 PipelineEvent::Run {
                     pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 2 },
                     stage_id: StageId::Other("A"),
@@ -916,6 +964,12 @@ mod tests {
                     pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 2 },
                     stage_id: StageId::Other("A"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(10), done: true },
+                },
+                PipelineEvent::Prepare {
+                    pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 2 },
+                    stage_id: StageId::Other("B"),
+                    checkpoint: None,
+                    target: Some(10),
                 },
                 PipelineEvent::Run {
                     pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 2 },
@@ -936,6 +990,12 @@ mod tests {
                     stage_id: StageId::Other("A"),
                     result: UnwindOutput { checkpoint: StageCheckpoint::new(0) },
                 },
+                PipelineEvent::Prepare {
+                    pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 2 },
+                    stage_id: StageId::Other("A"),
+                    checkpoint: Some(StageCheckpoint::new(0)),
+                    target: Some(10),
+                },
                 PipelineEvent::Run {
                     pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 2 },
                     stage_id: StageId::Other("A"),
@@ -946,6 +1006,12 @@ mod tests {
                     pipeline_stages_progress: PipelineStagesProgress { current: 1, total: 2 },
                     stage_id: StageId::Other("A"),
                     result: ExecOutput { checkpoint: StageCheckpoint::new(10), done: true },
+                },
+                PipelineEvent::Prepare {
+                    pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 2 },
+                    stage_id: StageId::Other("B"),
+                    checkpoint: None,
+                    target: Some(10),
                 },
                 PipelineEvent::Run {
                     pipeline_stages_progress: PipelineStagesProgress { current: 2, total: 2 },

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -120,7 +120,7 @@ where
         for (index, header) in self.header_collector.iter()?.enumerate() {
             let (_, header_buf) = header?;
 
-            if index > 0 && index % interval == 0 {
+            if index > 0 && index % interval == 0 && total_headers > 100 {
                 info!(target: "sync::stages::headers", progress = %format!("{:.2}%", (index as f64 / total_headers as f64) * 100.0), "Writing headers");
             }
 
@@ -146,7 +146,7 @@ where
             writer.append_header(header, td, header_hash)?;
         }
 
-        info!(target: "sync::stages::headers", total = total_headers, "Writing header hash index");
+        info!(target: "sync::stages::headers", total = total_headers, "Writing headers hash index");
 
         let mut cursor_header_numbers = tx.cursor_write::<RawTable<tables::HeaderNumbers>>()?;
         let mut first_sync = false;
@@ -166,7 +166,7 @@ where
         for (index, hash_to_number) in self.hash_collector.iter()?.enumerate() {
             let (hash, number) = hash_to_number?;
 
-            if index > 0 && index % interval == 0 {
+            if index > 0 && index % interval == 0 && total_headers > 100 {
                 info!(target: "sync::stages::headers", progress = %format!("{:.2}%", (index as f64 / total_headers as f64) * 100.0), "Writing headers hash index");
             }
 


### PR DESCRIPTION
```console
2024-03-15T13:46:17.280996Z  INFO Preparing stage pipeline_stages=1/12 stage=Headers checkpoint=1145708 target=1145713
2024-03-15T13:46:17.348535Z  INFO Received headers total=5 from_block=1145713 to_block=1145709
2024-03-15T13:46:17.348778Z  INFO Executing stage pipeline_stages=1/12 stage=Headers checkpoint=1145708 target=1145713
2024-03-15T13:46:17.348790Z  INFO Writing headers total=5
2024-03-15T13:46:17.371114Z  INFO Writing header hash index total=5
2024-03-15T13:46:17.375032Z  INFO Stage finished executing pipeline_stages=1/12 stage=Headers checkpoint=1145713 target=1145713 stage_progress=100.00%
```

TODO (will create an issue): make it not emit the notification for those stages that don't require the `poll_execute_ready` call.