### PR TITLE
fix: decrease connection info based on current state

### DIFF
--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -796,7 +796,7 @@ where
                 );
 
                 if let Some(ref err) = error {
-                    self.swarm.state_mut().peers_mut().on_pending_session_dropped(
+                    self.swarm.state_mut().peers_mut().on_outgoing_pending_session_dropped(
                         &remote_addr,
                         &peer_id,
                         err,
@@ -809,7 +809,7 @@ where
                     self.swarm
                         .state_mut()
                         .peers_mut()
-                        .on_pending_session_gracefully_closed(&peer_id);
+                        .on_outgoing_pending_session_gracefully_closed(&peer_id);
                 }
                 self.metrics.closed_sessions.increment(1);
                 self.metrics


### PR DESCRIPTION
fixes a bug where we were calling `self.connection_info.decr_out();` when we should have updated the connection info based on the current state of the peer.

This is not possible to Hit under normal operations only if manually triggered via

https://github.com/paradigmxyz/reth/blob/71f85812b7cf12a89e46b17e5e742c49c7306d6f/crates/net/network/src/session/handle.rs#L27-L28

which we currently don't do.

also renames the function properly