### PR TITLE
fix: panic conditions for concat kdf in ecies

### DIFF
--- a/crates/net/ecies/src/algorithm.rs
+++ b/crates/net/ecies/src/algorithm.rs
@@ -43,7 +43,6 @@ fn ecdh_x(public_key: &PublicKey, secret_key: &SecretKey) -> B256 {
 ///
 /// # Panics
 /// * If the `dest` is empty
-/// * If `s1` is empty
 /// * If the `dest` len is greater than or equal to the hash output len * the max counter value. In
 /// this case, the hash output len is 32 bytes, and the max counter value is 2^32 - 1. So the dest
 /// cannot have a len greater than 32 * 2^32 - 1.


### PR DESCRIPTION
This was not a correct panic condition, because the inner kdf implementation allows this to be empty. We also set s1 (the `other_info`) as empty as required by devp2p.