### PR TITLE
chore: bump rust-version in Cargo.toml to 1.76

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ rust.rust_2018_idioms = "deny"
 [workspace.package]
 version = "0.2.0-beta.2"
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.76"
 license = "MIT OR Apache-2.0"
 homepage = "https://paradigmxyz.github.io/reth"
 repository = "https://github.com/paradigmxyz/reth"


### PR DESCRIPTION
Did it everywhere else but not here