### PR TITLE
chore(node-builder): display the hardfork info in new line

### DIFF
--- a/crates/node-builder/src/builder.rs
+++ b/crates/node-builder/src/builder.rs
@@ -461,7 +461,7 @@ where
 
         let genesis_hash = init_genesis(provider_factory.clone())?;
 
-        info!(target: "reth::cli", "{}",config.chain.display_hardforks());
+        info!(target: "reth::cli", "\n\n{}", config.chain.display_hardforks());
 
         let consensus = config.consensus();
 

--- a/crates/node-builder/src/builder.rs
+++ b/crates/node-builder/src/builder.rs
@@ -461,7 +461,7 @@ where
 
         let genesis_hash = init_genesis(provider_factory.clone())?;
 
-        info!(target: "reth::cli", "\n\n{}", config.chain.display_hardforks());
+        info!(target: "reth::cli", "\n{}", config.chain.display_hardforks());
 
         let consensus = config.consensus();
 

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -1524,11 +1524,11 @@ impl Display for DisplayHardforks {
             f: &mut Formatter<'_>,
         ) -> std::fmt::Result {
             writeln!(f, "{}:", header)?;
-            for (index, fork) in forks.iter().enumerate() {
-                if next_is_empty && index == forks.len() - 1 {
-                    write!(f, "- {}", fork)?;
-                } else {
-                    writeln!(f, "- {}", fork)?;
+            let mut iter = forks.iter().peekable();
+            while let Some(fork) = iter.next() {
+                write!(f, "- {}", fork)?;
+                if !next_is_empty || iter.peek().is_some() {
+                    writeln!(f)?;
                 }
             }
             Ok(())

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -1517,23 +1517,36 @@ pub struct DisplayHardforks {
 
 impl Display for DisplayHardforks {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "Pre-merge hard forks (block based):")?;
-        for fork in self.pre_merge.iter() {
-            writeln!(f, "- {fork}")?;
+        fn format(
+            header: &str,
+            forks: &Vec<DisplayFork>,
+            next_is_empty: bool,
+            f: &mut Formatter<'_>,
+        ) -> std::fmt::Result {
+            writeln!(f, "{}:", header)?;
+            for (index, fork) in forks.iter().enumerate() {
+                if next_is_empty && index == forks.len() - 1 {
+                    write!(f, "- {}", fork)?;
+                } else {
+                    writeln!(f, "- {}", fork)?;
+                }
+            }
+            Ok(())
         }
 
+        format(
+            "Pre-merge hard forks (block based)",
+            &self.pre_merge,
+            self.with_merge.is_empty(),
+            f,
+        )?;
+
         if !self.with_merge.is_empty() {
-            writeln!(f, "Merge hard forks:")?;
-            for fork in self.with_merge.iter() {
-                writeln!(f, "- {fork}")?;
-            }
+            format("Merge hard forks", &self.with_merge, self.post_merge.is_empty(), f)?;
         }
 
         if !self.post_merge.is_empty() {
-            writeln!(f, "Post-merge hard forks (timestamp based):")?;
-            for fork in self.post_merge.iter() {
-                writeln!(f, "- {fork}")?;
-            }
+            format("Post-merge hard forks (timestamp based)", &self.post_merge, true, f)?;
         }
 
         Ok(())

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -1454,7 +1454,7 @@ impl Display for DisplayFork {
                 write!(f, "{:32} @{}", name_with_eip, at)?;
             }
             ForkCondition::TTD { fork_block, total_difficulty } => {
-                writeln!(
+                write!(
                     f,
                     "{:32} @{} ({})",
                     name_with_eip,
@@ -1502,7 +1502,6 @@ impl Display for DisplayFork {
 // - GrayGlacier                      @15050000
 // Merge hard forks:
 // - Paris                            @58750000000000000000000 (network is known to be merged)
-//
 // Post-merge hard forks (timestamp based):
 // - Shanghai                         @1681338455
 /// ```
@@ -1655,7 +1654,6 @@ mod tests {
 - GrayGlacier                      @15050000
 Merge hard forks:
 - Paris                            @58750000000000000000000 (network is known to be merged)
-
 Post-merge hard forks (timestamp based):
 - Shanghai                         @1681338455
 - Cancun                           @1710338135

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -1519,7 +1519,7 @@ impl Display for DisplayHardforks {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         fn format(
             header: &str,
-            forks: &Vec<DisplayFork>,
+            forks: &[DisplayFork],
             next_is_empty: bool,
             f: &mut Formatter<'_>,
         ) -> std::fmt::Result {

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -1669,8 +1669,7 @@ Merge hard forks:
 - Paris                            @58750000000000000000000 (network is known to be merged)
 Post-merge hard forks (timestamp based):
 - Shanghai                         @1681338455
-- Cancun                           @1710338135
-"
+- Cancun                           @1710338135"
         );
     }
 
@@ -1685,8 +1684,7 @@ Post-merge hard forks (timestamp based):
         assert_eq!(
             spec.display_hardforks().to_string(),
             "Pre-merge hard forks (block based):
-- Frontier                         @0
-"
+- Frontier                         @0"
         );
     }
 


### PR DESCRIPTION
Currently the hardfork info looks like below:

<img width="622" alt="image" src="https://github.com/paradigmxyz/reth/assets/3627395/036b45f6-113e-45b8-971f-2b372a011c5d">

we can pretty print with `Pre-merge hard forks` as a newline table title:

<img width="506" alt="image" src="https://github.com/paradigmxyz/reth/assets/3627395/e8f44023-d1bf-4773-8c7e-fb7c513a73a2">
