### PR TITLE
chore(net/banlist): unify the name of peer id/ip

### DIFF
--- a/crates/net/common/src/ban_list.rs
+++ b/crates/net/common/src/ban_list.rs
@@ -27,7 +27,7 @@ pub struct BanList {
 }
 
 impl BanList {
-    /// Creates a new ban list that bans the given peers and ips indefinitely.
+    /// Creates a new ban list that bans the given peers ids and ips indefinitely.
     pub fn new(
         banned_ids: impl IntoIterator<Item = PeerId>,
         banned_ips: impl IntoIterator<Item = IpAddr>,
@@ -91,13 +91,13 @@ impl BanList {
         self.is_banned_id(id) || self.is_banned_ip(ip)
     }
 
-    /// checks the ban list to see if it contains the given ip
+    /// Checks the ban list to see if it contains the given ip.
     #[inline]
     pub fn is_banned_ip(&self, ip: &IpAddr) -> bool {
         self.banned_ips.contains_key(ip)
     }
 
-    /// checks the ban list to see if it contains the given id
+    /// Checks the ban list to see if it contains the given id.
     #[inline]
     pub fn is_banned_id(&self, id: &PeerId) -> bool {
         self.banned_ids.contains_key(id)
@@ -113,38 +113,38 @@ impl BanList {
         self.banned_ids.remove(id);
     }
 
-    /// Bans the IP until the timestamp.
+    /// Bans the peer ip until the timestamp.
     ///
-    /// This does not ban non-global IPs.
+    /// This policy only bans global IPs.
     pub fn ban_ip_until(&mut self, ip: IpAddr, until: Instant) {
         self.ban_ip_with(ip, Some(until));
     }
 
-    /// Bans the peer until the timestamp
+    /// Bans the peer id until the timestamp
     pub fn ban_id_until(&mut self, id: PeerId, until: Instant) {
         self.ban_id_with(id, Some(until));
     }
 
-    /// Bans the IP indefinitely.
+    /// Bans the peer ip indefinitely.
     ///
-    /// This does not ban non-global IPs.
+    /// This policy only bans global IPs.
     pub fn ban_ip(&mut self, ip: IpAddr) {
         self.ban_ip_with(ip, None);
     }
 
-    /// Bans the peer indefinitely,
+    /// Bans the peer id indefinitely,
     pub fn ban_id(&mut self, id: PeerId) {
         self.ban_id_with(id, None);
     }
 
-    /// Bans the peer indefinitely or until the given timeout.
+    /// Bans the peer id indefinitely or until the given timeout.
     pub fn ban_id_with(&mut self, id: PeerId, until: Option<Instant>) {
         self.banned_ids.insert(id, until);
     }
 
-    /// Bans the ip indefinitely or until the given timeout.
+    /// Bans the peer ip indefinitely or until the given timeout.
     ///
-    /// This does not ban non-global IPs.
+    /// This policy only bans global IPs.
     pub fn ban_ip_with(&mut self, ip: IpAddr, until: Option<Instant>) {
         if is_global(&ip) {
             self.banned_ips.insert(ip, until);

--- a/crates/net/common/src/ban_list.rs
+++ b/crates/net/common/src/ban_list.rs
@@ -32,18 +32,10 @@ impl BanList {
         banned_ids: impl IntoIterator<Item = PeerId>,
         banned_ips: impl IntoIterator<Item = IpAddr>,
     ) -> Self {
-        Self::new_with_timeout(
-            banned_ids.into_iter().map(|id| (id, None)).collect(),
-            banned_ips.into_iter().map(|ip| (ip, None)).collect(),
-        )
-    }
-
-    /// Creates a new ban list that bans the given peer ids and ips with an optional timeout.
-    pub fn new_with_timeout(
-        banned_ids: HashMap<PeerId, Option<Instant>>,
-        banned_ips: HashMap<IpAddr, Option<Instant>>,
-    ) -> Self {
-        Self { banned_ips, banned_ids }
+        Self {
+            banned_ids: banned_ids.into_iter().map(|id| (id, None)).collect(),
+            banned_ips: banned_ips.into_iter().map(|ip| (ip, None)).collect(),
+        }
     }
 
     /// Removes all peer ids that are no longer banned.

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -794,7 +794,7 @@ impl Discv4Service {
     /// Adds the peer to the ban list indefinitely.
     pub fn ban_node(&mut self, node_id: PeerId) {
         self.remove_node(node_id);
-        self.config.ban_list.ban_peer(node_id);
+        self.config.ban_list.ban_id(node_id);
     }
 
     /// Adds the ip to the ban list until the given timestamp.
@@ -805,7 +805,7 @@ impl Discv4Service {
     /// Adds the peer to the ban list and bans it until the given timestamp
     pub fn ban_node_until(&mut self, node_id: PeerId, until: Instant) {
         self.remove_node(node_id);
-        self.config.ban_list.ban_peer_until(node_id, until);
+        self.config.ban_list.ban_id_until(node_id, until);
     }
 
     /// Removes a `node_id` from the routing table.

--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -271,10 +271,9 @@ impl PeersManager {
     /// be scheduled.
     pub(crate) fn on_incoming_session_established(&mut self, peer_id: PeerId, addr: SocketAddr) {
         self.connection_info.decr_pending_in();
-
         // we only need to check the peer id here as the ip address will have been checked at
         // on_incoming_pending_session. We also check if the peer is in the backoff list here.
-        if self.ban_list.is_banned_peer(&peer_id) {
+        if self.ban_list.is_banned_id(&peer_id) {
             self.queued_actions.push_back(PeerAction::DisconnectBannedIncoming { peer_id });
             return
         }
@@ -341,7 +340,7 @@ impl PeersManager {
             }
         }
 
-        self.ban_list.ban_peer_until(peer_id, std::time::Instant::now() + ban_duration);
+        self.ban_list.ban_id_until(peer_id, std::time::Instant::now() + ban_duration);
         self.queued_actions.push_back(PeerAction::BanPeer { peer_id });
     }
 
@@ -362,7 +361,7 @@ impl PeersManager {
 
     /// Unbans the peer
     fn unban_peer(&mut self, peer_id: PeerId) {
-        self.ban_list.unban_peer(&peer_id);
+        self.ban_list.unban_id(&peer_id);
         self.queued_actions.push_back(PeerAction::UnBanPeer { peer_id });
     }
 


### PR DESCRIPTION
As the variable `peer` in some contexts stands for `PeerId https://github.com/paradigmxyz/reth/blob/1147f0fd79c297bf0aa46818137cc0e20f5da866/crates/rpc/rpc-types/src/peer.rs#L4

but in other contexts stands for `Peer` 
https://github.com/paradigmxyz/reth/blob/1147f0fd79c297bf0aa46818137cc0e20f5da866/crates/net/network/src/peers/manager.rs#L986-L1003

So I suggest using a unified `peer_ids` to replace all `PeerId`, and the length of this variable is exactly the same as `peer_ips`, which looks clearer :)