### PR TITLE
chore: remove txpool optimism feature

### DIFF
--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -125,7 +125,6 @@ optimism = [
     "reth-interfaces/optimism",
     "reth-rpc/optimism",
     "reth-rpc-engine-api/optimism",
-    "reth-transaction-pool/optimism",
     "reth-provider/optimism",
     "reth-beacon-consensus/optimism",
     "reth-auto-seal-consensus/optimism",

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -104,7 +104,6 @@ test-utils = [
 geth-tests = []
 optimism = [
     "reth-primitives/optimism",
-    "reth-transaction-pool/optimism",
     "reth-provider/optimism",
     "reth-network-api/optimism",
     "reth-rpc-types/optimism",

--- a/crates/net/network/src/metrics.rs
+++ b/crates/net/network/src/metrics.rs
@@ -344,8 +344,7 @@ impl TxTypesCounter {
             TxType::Eip4844 => {
                 self.eip4844 += 1;
             }
-            #[cfg(feature = "optimism")]
-            TxType::Deposit => {}
+            _ => {}
         }
     }
 }

--- a/crates/net/network/src/metrics.rs
+++ b/crates/net/network/src/metrics.rs
@@ -331,6 +331,7 @@ pub struct TxTypesCounter {
 
 impl TxTypesCounter {
     pub(crate) fn increase_by_tx_type(&mut self, tx_type: TxType) {
+        #[allow(unreachable_patterns)]
         match tx_type {
             TxType::Legacy => {
                 self.legacy += 1;

--- a/crates/node-core/Cargo.toml
+++ b/crates/node-core/Cargo.toml
@@ -106,7 +106,6 @@ optimism = [
     "reth-interfaces/optimism",
     "reth-rpc/optimism",
     "reth-rpc-engine-api/optimism",
-    "reth-transaction-pool/optimism",
     "reth-provider/optimism",
     "reth-network/optimism",
     "reth-network-api/optimism",

--- a/crates/node-optimism/Cargo.toml
+++ b/crates/node-optimism/Cargo.toml
@@ -41,7 +41,6 @@ reth-db.workspace = true
 optimism = [
     "reth-network/optimism",
     "reth-primitives/optimism",
-    "reth-transaction-pool/optimism",
     "reth-rpc-types/optimism",
     "reth-provider/optimism",
     "reth-rpc-types-compat/optimism",

--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -50,5 +50,4 @@ optimism = [
     "reth-rpc-types/optimism",
     "reth-rpc-types-compat/optimism",
     "reth-interfaces/optimism",
-    "reth-transaction-pool/optimism",
 ]

--- a/crates/payload/optimism/Cargo.toml
+++ b/crates/payload/optimism/Cargo.toml
@@ -34,7 +34,6 @@ thiserror.workspace = true
 optimism = [
     "reth-primitives/optimism",
     "reth-revm/optimism",
-    "reth-transaction-pool/optimism",
     "reth-provider/optimism",
     "reth-payload-builder/optimism",
 ]

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -99,5 +99,4 @@ optimism = [
     "reth-network-api/optimism",
     "reth-network/optimism",
     "reth-provider/optimism",
-    "reth-transaction-pool/optimism",
 ]

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -66,14 +66,6 @@ default = ["serde"]
 serde = ["dep:serde"]
 test-utils = ["rand", "paste", "serde"]
 arbitrary = ["proptest", "reth-primitives/arbitrary"]
-optimism = [
-    "dep:reth-revm",
-    "reth-revm?/optimism",
-    "reth-primitives/optimism",
-    "reth-provider/test-utils",
-    "reth-provider/optimism",
-    "revm/optimism",
-]
 
 [[bench]]
 name = "truncate"

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -664,7 +664,6 @@ pub async fn backup_local_transactions_task<P>(
     drop(graceful_guard)
 }
 
-#[cfg(not(feature = "optimism"))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1033,7 +1033,7 @@ impl PoolTransaction for EthPooledTransaction {
             Transaction::Legacy(_) | Transaction::Eip2930(_) => None,
             Transaction::Eip1559(tx) => Some(tx.max_priority_fee_per_gas),
             Transaction::Eip4844(tx) => Some(tx.max_priority_fee_per_gas),
-             _ => None,
+            _ => None,
         }
     }
 

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -914,6 +914,8 @@ impl EthPooledTransaction {
     /// [EthBlobTransactionSidecar::Missing]
     pub fn new(transaction: TransactionSignedEcRecovered, encoded_length: usize) -> Self {
         let mut blob_sidecar = EthBlobTransactionSidecar::None;
+
+        #[allow(unreachable_patterns)]
         let gas_cost = match &transaction.transaction {
             Transaction::Legacy(t) => {
                 U256::from(t.gas_price).saturating_mul(U256::from(t.gas_limit))
@@ -928,8 +930,7 @@ impl EthPooledTransaction {
                 blob_sidecar = EthBlobTransactionSidecar::Missing;
                 U256::from(t.max_fee_per_gas).saturating_mul(U256::from(t.gas_limit))
             }
-            #[cfg(feature = "optimism")]
-            Transaction::Deposit(_) => U256::ZERO,
+            _ => U256::ZERO,
         };
         let mut cost = transaction.value();
         cost = cost.saturating_add(gas_cost);
@@ -1009,13 +1010,13 @@ impl PoolTransaction for EthPooledTransaction {
     ///
     /// This is also commonly referred to as the "Gas Fee Cap" (`GasFeeCap`).
     fn max_fee_per_gas(&self) -> u128 {
+        #[allow(unreachable_patterns)]
         match &self.transaction.transaction {
             Transaction::Legacy(tx) => tx.gas_price,
             Transaction::Eip2930(tx) => tx.gas_price,
             Transaction::Eip1559(tx) => tx.max_fee_per_gas,
             Transaction::Eip4844(tx) => tx.max_fee_per_gas,
-            #[cfg(feature = "optimism")]
-            Transaction::Deposit(_) => 0,
+            _ => 0,
         }
     }
 
@@ -1027,12 +1028,12 @@ impl PoolTransaction for EthPooledTransaction {
     ///
     /// This will return `None` for non-EIP1559 transactions
     fn max_priority_fee_per_gas(&self) -> Option<u128> {
+        #[allow(unreachable_patterns)]
         match &self.transaction.transaction {
             Transaction::Legacy(_) | Transaction::Eip2930(_) => None,
             Transaction::Eip1559(tx) => Some(tx.max_priority_fee_per_gas),
             Transaction::Eip4844(tx) => Some(tx.max_priority_fee_per_gas),
-            #[cfg(feature = "optimism")]
-            Transaction::Deposit(_) => None,
+             _ => None,
         }
     }
 

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -709,7 +709,6 @@ pub fn ensure_intrinsic_gas<T: PoolTransaction>(
 #[cfg(test)]
 mod tests {
     // <https://github.com/paradigmxyz/reth/issues/5178>
-    #[cfg(not(feature = "optimism"))]
     #[tokio::test]
     async fn validate_transaction() {
         use super::*;


### PR DESCRIPTION
This is no longer required

optimism txs aren't allowed into the pool.

this however requires unreachable_patterns