### PR TITLE
Enable clippy's empty_line_after_outer_attr linter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ rust.unreachable_pub = "warn"
 rustdoc.all = "warn"
 rust.unused_must_use = "deny"
 rust.rust_2018_idioms = "deny"
+clippy.empty_line_after_outer_attr = "deny"
 
 [workspace.package]
 version = "0.2.0-beta.3"

--- a/crates/ethereum-forks/src/forkid.rs
+++ b/crates/ethereum-forks/src/forkid.rs
@@ -108,7 +108,6 @@ impl From<ForkFilterKey> for u64 {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(PropTestArbitrary, Arbitrary))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable, RlpMaxEncodedLen)]
-
 pub struct ForkId {
     /// CRC32 checksum of the all fork blocks and timestamps from genesis.
     pub hash: ForkHash,

--- a/crates/net/eth-wire/src/errors/eth.rs
+++ b/crates/net/eth-wire/src/errors/eth.rs
@@ -79,7 +79,6 @@ impl From<alloy_rlp::Error> for EthStreamError {
 
 /// Error  that can occur during the `eth` sub-protocol handshake.
 #[derive(thiserror::Error, Debug)]
-
 pub enum EthHandshakeError {
     /// Status message received or sent outside of the handshake process.
     #[error("status message can only be recv/sent in handshake")]

--- a/crates/node-core/src/args/rpc_state_cache_args.rs
+++ b/crates/node-core/src/args/rpc_state_cache_args.rs
@@ -7,7 +7,6 @@ use reth_rpc::eth::cache::{
 /// Parameters to configure RPC state cache.
 #[derive(Debug, Clone, Args, PartialEq, Eq)]
 #[command(next_help_heading = "RPC State Cache")]
-
 pub struct RpcStateCacheArgs {
     /// Max number of blocks in cache.
     #[arg(


### PR DESCRIPTION
This PR enables the [`empty_line_after_outer_attr`](https://rust-lang.github.io/rust-clippy/master/index.html#empty_line_after_outer_attr) linter and fixes its findings.