### PR TITLE
Enable clippy's trait_duplication_in_bounds linter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ rust.unreachable_pub = "warn"
 rustdoc.all = "warn"
 rust.unused_must_use = "deny"
 rust.rust_2018_idioms = "deny"
+clippy.trait_duplication_in_bounds = "deny"
 
 [workspace.package]
 version = "0.2.0-beta.3"

--- a/crates/net/eth-wire/src/muxdemux.rs
+++ b/crates/net/eth-wire/src/muxdemux.rs
@@ -433,12 +433,10 @@ mod tests {
             F: FnOnce(StreamClone) -> Pin<Box<(dyn Future<Output = BytesMut> + Send)>>
                 + Send
                 + Sync
-                + Send
                 + 'static,
             G: FnOnce(StreamClone) -> Pin<Box<(dyn Future<Output = BytesMut> + Send)>>
                 + Send
                 + Sync
-                + Send
                 + 'static,
         {
             let local_addr = self.local_addr;

--- a/crates/storage/provider/src/bundle_state/state_reverts.rs
+++ b/crates/storage/provider/src/bundle_state/state_reverts.rs
@@ -97,7 +97,7 @@ struct StorageRevertsIter<R: Iterator, W: Iterator> {
     wiped: Peekable<W>,
 }
 
-impl<R: Iterator, W: Iterator> StorageRevertsIter<R, W>
+impl<R, W> StorageRevertsIter<R, W>
 where
     R: Iterator<Item = (B256, RevertToSlot)>,
     W: Iterator<Item = (B256, U256)>,

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -523,7 +523,7 @@ where
     }
 }
 
-impl<V: TransactionValidator, T: TransactionOrdering, S> TransactionPoolExt for Pool<V, T, S>
+impl<V, T, S> TransactionPoolExt for Pool<V, T, S>
 where
     V: TransactionValidator,
     T: TransactionOrdering<Transaction = <V as TransactionValidator>::Transaction>,


### PR DESCRIPTION
This PR enables the [`trait_duplication_in_bounds`](https://rust-lang.github.io/rust-clippy/master/index.html#trait_duplication_in_bounds) linter and fixes its findings.