### PR TITLE
Enable clippy's derive_partial_eq_without_eq linter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ rust.unreachable_pub = "warn"
 rustdoc.all = "warn"
 rust.unused_must_use = "deny"
 rust.rust_2018_idioms = "deny"
+clippy.derive_partial_eq_without_eq = "deny"
 
 [workspace.package]
 version = "0.2.0-beta.3"

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 /// Configuration for the reth node.
-#[derive(Debug, Clone, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default)]
 pub struct Config {
     /// Configuration for each stage in the pipeline.
@@ -50,7 +50,7 @@ impl Config {
 }
 
 /// Configuration for each stage in the pipeline.
-#[derive(Debug, Clone, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default)]
 pub struct StageConfig {
     /// Header stage configuration.
@@ -78,7 +78,7 @@ pub struct StageConfig {
 }
 
 /// Header stage configuration.
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default)]
 pub struct HeadersConfig {
     /// The maximum number of requests to send concurrently.
@@ -111,7 +111,7 @@ impl Default for HeadersConfig {
 }
 
 /// Body stage configuration.
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default)]
 pub struct BodiesConfig {
     /// The batch size of non-empty blocks per one request
@@ -164,7 +164,7 @@ impl Default for SenderRecoveryConfig {
 }
 
 /// Execution stage configuration.
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default)]
 pub struct ExecutionConfig {
     /// The maximum number of blocks to process before the execution stage commits.
@@ -195,7 +195,7 @@ impl Default for ExecutionConfig {
 }
 
 /// Hashing stage configuration.
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default)]
 pub struct HashingConfig {
     /// The threshold (in number of blocks) for switching between
@@ -212,7 +212,7 @@ impl Default for HashingConfig {
 }
 
 /// Merkle stage configuration.
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default)]
 pub struct MerkleConfig {
     /// The threshold (in number of blocks) for switching from incremental trie building of changes
@@ -227,7 +227,7 @@ impl Default for MerkleConfig {
 }
 
 /// Transaction Lookup stage configuration.
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default)]
 pub struct TransactionLookupConfig {
     /// The maximum number of transactions to process before writing to disk.
@@ -241,7 +241,7 @@ impl Default for TransactionLookupConfig {
 }
 
 /// Common ETL related configuration.
-#[derive(Debug, Clone, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default)]
 pub struct EtlConfig {
     /// Data directory where temporary files are created.
@@ -275,7 +275,7 @@ impl EtlConfig {
 }
 
 /// History stage configuration.
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default)]
 pub struct IndexHistoryConfig {
     /// The maximum number of blocks to process before committing progress to the database.
@@ -289,7 +289,7 @@ impl Default for IndexHistoryConfig {
 }
 
 /// Pruning configuration.
-#[derive(Debug, Clone, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default)]
 pub struct PruneConfig {
     /// Minimum pruning interval measured in blocks.

--- a/crates/net/common/src/ban_list.rs
+++ b/crates/net/common/src/ban_list.rs
@@ -18,7 +18,7 @@ pub fn is_global(ip: &IpAddr) -> bool {
 
 /// Stores peers that should be taken out of circulation either indefinitely or until a certain
 /// timestamp
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct BanList {
     /// A set of IPs whose packets get dropped instantly.
     banned_ips: HashMap<IpAddr, Option<Instant>>,

--- a/crates/net/network/src/error.rs
+++ b/crates/net/network/src/error.rs
@@ -9,7 +9,7 @@ use reth_eth_wire::{
 use std::{fmt, io, io::ErrorKind, net::SocketAddr};
 
 /// Service kind.
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum ServiceKind {
     /// Listener service.
     Listener(SocketAddr),

--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -888,7 +888,7 @@ impl Default for PeersManager {
 }
 
 /// Tracks stats about connected nodes
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(default))]
 pub struct ConnectionInfo {
     /// Counter for currently occupied slots for active outbound connections.
@@ -1231,7 +1231,7 @@ pub enum PeerAction {
 }
 
 /// Config type for initiating a [`PeersManager`] instance.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(default))]
 pub struct PeersConfig {
@@ -1416,7 +1416,7 @@ impl PeersConfig {
 /// The durations to use when a backoff should be applied to a peer.
 ///
 /// See also [`BackoffKind`].
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PeerBackoffDurations {
     /// Applies to connection problems where there is a chance that they will be resolved after the

--- a/crates/net/network/src/peers/reputation.rs
+++ b/crates/net/network/src/peers/reputation.rs
@@ -51,7 +51,7 @@ pub(crate) fn is_banned_reputation(reputation: i32) -> bool {
 }
 
 /// How the [`ReputationChangeKind`] are weighted.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(default))]
 pub struct ReputationChangeWeights {

--- a/crates/node-core/src/args/database_args.rs
+++ b/crates/node-core/src/args/database_args.rs
@@ -6,7 +6,7 @@ use reth_interfaces::db::LogLevel;
 use crate::version::default_client_version;
 
 /// Parameters for database configuration
-#[derive(Debug, Args, PartialEq, Default, Clone, Copy)]
+#[derive(Debug, Args, PartialEq, Eq, Default, Clone, Copy)]
 #[command(next_help_heading = "Database")]
 pub struct DatabaseArgs {
     /// Database logging level. Levels higher than "notice" require a debug build.

--- a/crates/node-core/src/args/debug_args.rs
+++ b/crates/node-core/src/args/debug_args.rs
@@ -5,7 +5,7 @@ use reth_primitives::{TxHash, B256};
 use std::path::PathBuf;
 
 /// Parameters for debugging purposes
-#[derive(Debug, Clone, Args, PartialEq, Default)]
+#[derive(Debug, Clone, Args, PartialEq, Eq, Default)]
 #[command(next_help_heading = "Debug")]
 pub struct DebugArgs {
     /// Prompt the downloader to download blocks one at a time.

--- a/crates/node-core/src/args/dev_args.rs
+++ b/crates/node-core/src/args/dev_args.rs
@@ -6,7 +6,7 @@ use clap::Args;
 use humantime::parse_duration;
 
 /// Parameters for Dev testnet configuration
-#[derive(Debug, Args, PartialEq, Default, Clone, Copy)]
+#[derive(Debug, Args, PartialEq, Eq, Default, Clone, Copy)]
 #[command(next_help_heading = "Dev testnet")]
 pub struct DevArgs {
     /// Start the node in dev mode

--- a/crates/node-core/src/args/payload_builder_args.rs
+++ b/crates/node-core/src/args/payload_builder_args.rs
@@ -12,7 +12,7 @@ use reth_primitives::constants::{
 use std::{borrow::Cow, ffi::OsStr, time::Duration};
 
 /// Parameters for configuring the Payload Builder
-#[derive(Debug, Clone, Args, PartialEq)]
+#[derive(Debug, Clone, Args, PartialEq, Eq)]
 #[command(next_help_heading = "Builder")]
 pub struct PayloadBuilderArgs {
     /// Block extra data set by the payload builder.

--- a/crates/node-core/src/args/pruning_args.rs
+++ b/crates/node-core/src/args/pruning_args.rs
@@ -8,7 +8,7 @@ use reth_primitives::{
 use std::sync::Arc;
 
 /// Parameters for pruning and full node
-#[derive(Debug, Clone, Args, PartialEq, Default)]
+#[derive(Debug, Clone, Args, PartialEq, Eq, Default)]
 #[command(next_help_heading = "Pruning")]
 pub struct PruningArgs {
     /// Run full node. Only the most recent [`MINIMUM_PRUNING_DISTANCE`] block states are stored.

--- a/crates/node-core/src/args/txpool_args.rs
+++ b/crates/node-core/src/args/txpool_args.rs
@@ -10,7 +10,7 @@ use reth_transaction_pool::{
     TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT, TXPOOL_SUBPOOL_MAX_TXS_DEFAULT,
 };
 /// Parameters for debugging purposes
-#[derive(Debug, Clone, Args, PartialEq)]
+#[derive(Debug, Clone, Args, PartialEq, Eq)]
 #[command(next_help_heading = "TxPool")]
 pub struct TxPoolArgs {
     /// Max number of transaction in the pending sub-pool.

--- a/crates/node-core/src/dirs.rs
+++ b/crates/node-core/src/dirs.rs
@@ -102,7 +102,7 @@ pub trait XdgPath {
 ///
 /// assert_ne!(default.as_ref(), custom.as_ref());
 /// ```
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct PlatformPath<D>(PathBuf, std::marker::PhantomData<D>);
 
 impl<D> Display for PlatformPath<D> {
@@ -174,7 +174,7 @@ impl<D> PlatformPath<D> {
 /// An Optional wrapper type around [PlatformPath].
 ///
 /// This is useful for when a path is optional, such as the `--data-dir` flag.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MaybePlatformPath<D>(Option<PlatformPath<D>>);
 
 // === impl MaybePlatformPath ===
@@ -259,7 +259,7 @@ impl<D> From<PathBuf> for MaybePlatformPath<D> {
 ///  * sepolia: `<DIR>/sepolia`
 /// Otherwise, the path will be dependent on the chain ID:
 ///  * `<DIR>/<CHAIN_ID>`
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ChainPath<D>(PlatformPath<D>, Chain);
 
 impl<D> ChainPath<D> {

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 use std::{mem, ops::Deref};
 
 /// Errors that can occur during header sanity checks.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum HeaderError {
     /// Represents an error when the block difficulty is too large.
     LargeDifficulty,

--- a/crates/primitives/src/trie/subnode.rs
+++ b/crates/primitives/src/trie/subnode.rs
@@ -4,7 +4,7 @@ use reth_codecs::Compact;
 
 /// Walker sub node for storing intermediate state root calculation state in the database.
 /// See [crate::stage::MerkleCheckpoint].
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct StoredSubNode {
     /// The key of the current node.
     pub key: Vec<u8>,

--- a/crates/rpc/rpc-types/src/beacon/payload.rs
+++ b/crates/rpc/rpc-types/src/beacon/payload.rs
@@ -23,20 +23,20 @@ use std::borrow::Cow;
 /// Response object of GET `/eth/v1/builder/header/{slot}/{parent_hash}/{pubkey}`
 ///
 /// See also <https://ethereum.github.io/builder-specs/#/Builder/getHeader>
-#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GetExecutionPayloadHeaderResponse {
     pub version: String,
     pub data: ExecutionPayloadHeaderData,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExecutionPayloadHeaderData {
     pub message: ExecutionPayloadHeaderMessage,
     pub signature: String,
 }
 
 #[serde_as]
-#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExecutionPayloadHeaderMessage {
     pub header: ExecutionPayloadHeader,
     #[serde_as(as = "DisplayFromStr")]
@@ -46,7 +46,7 @@ pub struct ExecutionPayloadHeaderMessage {
 
 /// The header of the execution payload.
 #[serde_as]
-#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExecutionPayloadHeader {
     pub parent_hash: B256,
     pub fee_recipient: Address,

--- a/crates/storage/db/src/tables/mod.rs
+++ b/crates/storage/db/src/tables/mod.rs
@@ -46,7 +46,7 @@ use reth_primitives::{
 use std::fmt;
 
 /// Enum for the types of tables present in libmdbx.
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum TableType {
     /// key value table
     Table,

--- a/crates/storage/nippy-jar/src/compression/lz4.rs
+++ b/crates/storage/nippy-jar/src/compression/lz4.rs
@@ -2,7 +2,7 @@ use crate::{compression::Compression, NippyJarError};
 use serde::{Deserialize, Serialize};
 
 /// Wrapper type for `lz4_flex` that implements [`Compression`].
-#[derive(Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[non_exhaustive]
 pub struct Lz4;
 

--- a/crates/storage/nippy-jar/src/compression/zstd.rs
+++ b/crates/storage/nippy-jar/src/compression/zstd.rs
@@ -12,7 +12,7 @@ pub use zstd::{bulk::Decompressor, dict::DecoderDictionary};
 
 type RawDictionary = Vec<u8>;
 
-#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ZstdState {
     #[default]
     PendingDictionary,

--- a/crates/transaction-pool/src/blobstore/noop.rs
+++ b/crates/transaction-pool/src/blobstore/noop.rs
@@ -2,7 +2,7 @@ use crate::blobstore::{BlobStore, BlobStoreCleanupStat, BlobStoreError, BlobTran
 use reth_primitives::B256;
 
 /// A blobstore implementation that does nothing
-#[derive(Clone, Copy, Debug, PartialOrd, PartialEq, Default)]
+#[derive(Clone, Copy, Debug, PartialOrd, PartialEq, Eq, Default)]
 #[non_exhaustive]
 pub struct NoopBlobStore;
 


### PR DESCRIPTION
This PR enables the [`derive_partial_eq_without_eq`](https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq) linter and fixes its findings.