### PR TITLE
Enable clippy's uninlined_format_args linter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ rust.unreachable_pub = "warn"
 rustdoc.all = "warn"
 rust.unused_must_use = "deny"
 rust.rust_2018_idioms = "deny"
+clippy.uninlined_format_args = "warn"
 
 [workspace.package]
 version = "0.2.0-beta.3"

--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -244,7 +244,7 @@ mod tests {
             reth.logs.log_file_directory.join(reth.chain.chain.to_string());
         let log_dir = reth.logs.log_file_directory;
         let end = format!("reth/logs/{}", SUPPORTED_CHAINS[0]);
-        assert!(log_dir.as_ref().ends_with(end), "{:?}", log_dir);
+        assert!(log_dir.as_ref().ends_with(end), "{log_dir:?}");
 
         let mut iter = SUPPORTED_CHAINS.iter();
         iter.next();
@@ -253,8 +253,8 @@ mod tests {
             reth.logs.log_file_directory =
                 reth.logs.log_file_directory.join(reth.chain.chain.to_string());
             let log_dir = reth.logs.log_file_directory;
-            let end = format!("reth/logs/{}", chain);
-            assert!(log_dir.as_ref().ends_with(end), "{:?}", log_dir);
+            let end = format!("reth/logs/{chain}");
+            assert!(log_dir.as_ref().ends_with(end), "{log_dir:?}");
         }
     }
 

--- a/bin/reth/src/commands/db/get.rs
+++ b/bin/reth/src/commands/db/get.rs
@@ -85,7 +85,7 @@ impl Command {
                 match content {
                     Some(content) => {
                         if raw {
-                            println!("{:?}", content);
+                            println!("{content:?}");
                         } else {
                             match segment {
                                 StaticFileSegment::Headers => {
@@ -157,7 +157,7 @@ impl<DB: Database> TableViewer<()> for GetValueViewer<'_, DB> {
 
         match content {
             Some(content) => {
-                println!("{}", content);
+                println!("{content}");
             }
             None => {
                 error!(target: "reth::cli", "No content for the given table key.");

--- a/bin/reth/src/commands/import.rs
+++ b/bin/reth/src/commands/import.rs
@@ -221,7 +221,7 @@ impl ImportCommand {
     /// Loads the reth config
     fn load_config(&self, config_path: PathBuf) -> eyre::Result<Config> {
         confy::load_path::<Config>(config_path.clone())
-            .wrap_err_with(|| format!("Could not load config file {:?}", config_path))
+            .wrap_err_with(|| format!("Could not load config file {config_path:?}"))
     }
 }
 

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -249,7 +249,7 @@ where
                 let msg = if bytes.len() > 50 {
                     format!("{:02x?}...{:x?}", &bytes[..10], &bytes[bytes.len() - 10..])
                 } else {
-                    format!("{:02x?}", bytes)
+                    format!("{bytes:02x?}")
                 };
                 debug!(
                     version=?this.version,

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -2006,7 +2006,7 @@ mod tests {
                 assert_eq!(transactions.len(), 1);
             }
             Err(e) => {
-                panic!("error: {:?}", e);
+                panic!("error: {e:?}");
             }
         }
     }

--- a/crates/net/network/tests/it/big_pooled_txs_req.rs
+++ b/crates/net/network/tests/it/big_pooled_txs_req.rs
@@ -82,7 +82,7 @@ async fn test_large_tx_req() {
             txs.into_iter().for_each(|tx| assert!(txs_hashes.contains(tx.hash())));
         }
         Err(e) => {
-            panic!("error: {:?}", e);
+            panic!("error: {e:?}");
         }
     }
 }

--- a/crates/net/network/tests/it/startup.rs
+++ b/crates/net/network/tests/it/startup.rs
@@ -48,7 +48,7 @@ async fn test_listener_addr_in_use() {
     let addr = config.listener_addr;
     let result = NetworkManager::new(config).await;
     let err = result.err().unwrap();
-    assert!(is_addr_in_use_kind(&err, ServiceKind::Listener(addr)), "{:?}", err);
+    assert!(is_addr_in_use_kind(&err, ServiceKind::Listener(addr)), "{err:?}");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/node-builder/src/builder.rs
+++ b/crates/node-builder/src/builder.rs
@@ -154,7 +154,7 @@ impl<DB, State> NodeBuilder<DB, State> {
         let config_path = self.config.config.clone().unwrap_or_else(|| data_dir.config_path());
 
         let mut config = confy::load_path::<reth_config::Config>(&config_path)
-            .wrap_err_with(|| format!("Could not load config file {:?}", config_path))?;
+            .wrap_err_with(|| format!("Could not load config file {config_path:?}"))?;
 
         info!(target: "reth::cli", path = ?config_path, "Configuration loaded");
 

--- a/crates/node-core/src/dirs.rs
+++ b/crates/node-core/src/dirs.rs
@@ -357,28 +357,28 @@ mod tests {
     fn test_maybe_data_dir_path() {
         let path = MaybePlatformPath::<DataDirPath>::default();
         let path = path.unwrap_or_chain_default(Chain::mainnet());
-        assert!(path.as_ref().ends_with("reth/mainnet"), "{:?}", path);
+        assert!(path.as_ref().ends_with("reth/mainnet"), "{path:?}");
 
         let db_path = path.db_path();
-        assert!(db_path.ends_with("reth/mainnet/db"), "{:?}", db_path);
+        assert!(db_path.ends_with("reth/mainnet/db"), "{db_path:?}");
 
         let path = MaybePlatformPath::<DataDirPath>::from_str("my/path/to/datadir").unwrap();
         let path = path.unwrap_or_chain_default(Chain::mainnet());
-        assert!(path.as_ref().ends_with("my/path/to/datadir"), "{:?}", path);
+        assert!(path.as_ref().ends_with("my/path/to/datadir"), "{path:?}");
     }
 
     #[test]
     fn test_maybe_testnet_datadir_path() {
         let path = MaybePlatformPath::<DataDirPath>::default();
         let path = path.unwrap_or_chain_default(Chain::goerli());
-        assert!(path.as_ref().ends_with("reth/goerli"), "{:?}", path);
+        assert!(path.as_ref().ends_with("reth/goerli"), "{path:?}");
 
         let path = MaybePlatformPath::<DataDirPath>::default();
         let path = path.unwrap_or_chain_default(Chain::holesky());
-        assert!(path.as_ref().ends_with("reth/holesky"), "{:?}", path);
+        assert!(path.as_ref().ends_with("reth/holesky"), "{path:?}");
 
         let path = MaybePlatformPath::<DataDirPath>::default();
         let path = path.unwrap_or_chain_default(Chain::sepolia());
-        assert!(path.as_ref().ends_with("reth/sepolia"), "{:?}", path);
+        assert!(path.as_ref().ends_with("reth/sepolia"), "{path:?}");
     }
 }

--- a/crates/primitives/benches/integer_list.rs
+++ b/crates/primitives/benches/integer_list.rs
@@ -106,7 +106,7 @@ mod elias_fano {
     impl fmt::Debug for IntegerList {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             let vec: Vec<usize> = self.0.iter(0).collect();
-            write!(f, "IntegerList {:?}", vec)
+            write!(f, "IntegerList {vec:?}")
         }
     }
 

--- a/crates/primitives/benches/validate_blob_tx.rs
+++ b/crates/primitives/benches/validate_blob_tx.rs
@@ -73,13 +73,13 @@ fn validate_blob_tx(
         (tx, blob_sidecar)
     };
 
-    let group_id = format!("validate_blob | num blobs: {} | {}", num_blobs, description,);
+    let group_id = format!("validate_blob | num blobs: {num_blobs} | {description}");
 
     // for now we just use the default SubPoolLimit
     group.bench_function(group_id, |b| {
         b.iter_with_setup(setup, |(tx, blob_sidecar)| {
             if let Err(err) = std::hint::black_box(tx.validate_blob(&blob_sidecar, &kzg_settings)) {
-                println!("Validation failed: {:?}", err);
+                println!("Validation failed: {err:?}");
             }
         });
     });

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -1451,7 +1451,7 @@ impl Display for DisplayFork {
 
         match self.activated_at {
             ForkCondition::Block(at) | ForkCondition::Timestamp(at) => {
-                write!(f, "{:32} @{}", name_with_eip, at)?;
+                write!(f, "{name_with_eip:32} @{at}")?;
             }
             ForkCondition::TTD { fork_block, total_difficulty } => {
                 write!(
@@ -1523,10 +1523,10 @@ impl Display for DisplayHardforks {
             next_is_empty: bool,
             f: &mut Formatter<'_>,
         ) -> std::fmt::Result {
-            writeln!(f, "{}:", header)?;
+            writeln!(f, "{header}:")?;
             let mut iter = forks.iter().peekable();
             while let Some(fork) = iter.next() {
-                write!(f, "- {}", fork)?;
+                write!(f, "- {fork}")?;
                 if !next_is_empty || iter.peek().is_some() {
                     writeln!(f)?;
                 }

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -1628,15 +1628,13 @@ mod tests {
             if let Some(computed_id) = spec.hardfork_fork_id(*hardfork) {
                 assert_eq!(
                     expected_id, &computed_id,
-                    "Expected fork ID {:?}, computed fork ID {:?} for hardfork {}",
-                    expected_id, computed_id, hardfork
+                    "Expected fork ID {expected_id:?}, computed fork ID {computed_id:?} for hardfork {hardfork}"
                 );
                 if let Hardfork::Shanghai = hardfork {
                     if let Some(shangai_id) = spec.shanghai_fork_id() {
                         assert_eq!(
                             expected_id, &shangai_id,
-                            "Expected fork ID {:?}, computed fork ID {:?} for Shanghai hardfork",
-                            expected_id, computed_id
+                            "Expected fork ID {expected_id:?}, computed fork ID {computed_id:?} for Shanghai hardfork"
                         );
                     } else {
                         panic!("Expected ForkCondition to return Some for Hardfork::Shanghai");
@@ -1786,8 +1784,7 @@ Post-merge hard forks (timestamp based):
         let happy_path_expected = Head { number: 73, timestamp: 11313123, ..Default::default() };
         assert_eq!(
             happy_path_head, happy_path_expected,
-            "expected satisfy() to return {:#?}, but got {:#?} ",
-            happy_path_expected, happy_path_head
+            "expected satisfy() to return {happy_path_expected:#?}, but got {happy_path_head:#?} "
         );
         // multiple timestamp test case (i.e Shanghai -> Cancun)
         let multiple_timestamp_fork_case = ChainSpec::builder()
@@ -1804,8 +1801,7 @@ Post-merge hard forks (timestamp based):
             Head { number: 73, timestamp: 11313398, ..Default::default() };
         assert_eq!(
             multi_timestamp_head, mult_timestamp_expected,
-            "expected satisfy() to return {:#?}, but got {:#?} ",
-            mult_timestamp_expected, multi_timestamp_head
+            "expected satisfy() to return {mult_timestamp_expected:#?}, but got {multi_timestamp_head:#?} "
         );
         // no ForkCondition::Block test case
         let no_block_fork_case = ChainSpec::builder()
@@ -1817,8 +1813,7 @@ Post-merge hard forks (timestamp based):
         let no_block_fork_expected = Head { number: 0, timestamp: 11313123, ..Default::default() };
         assert_eq!(
             no_block_fork_head, no_block_fork_expected,
-            "expected satisfy() to return {:#?}, but got {:#?} ",
-            no_block_fork_expected, no_block_fork_head
+            "expected satisfy() to return {no_block_fork_expected:#?}, but got {no_block_fork_head:#?} ",
         );
         // spec w/ ForkCondition::TTD with block_num test case (Sepolia merge netsplit edge case)
         let fork_cond_ttd_blocknum_case = ChainSpec::builder()
@@ -1841,8 +1836,7 @@ Post-merge hard forks (timestamp based):
             Head { number: 101, timestamp: 11313123, ..Default::default() };
         assert_eq!(
             fork_cond_ttd_blocknum_head, fork_cond_ttd_blocknum_expected,
-            "expected satisfy() to return {:#?}, but got {:#?} ",
-            fork_cond_ttd_blocknum_expected, fork_cond_ttd_blocknum_head
+            "expected satisfy() to return {fork_cond_ttd_blocknum_expected:#?}, but got {fork_cond_ttd_blocknum_expected:#?} ",
         );
 
         // spec w/ only ForkCondition::Block - test the match arm for ForkCondition::Block to ensure
@@ -1858,8 +1852,7 @@ Post-merge hard forks (timestamp based):
         let fork_cond_block_only_expected = Head { number: 73, ..Default::default() };
         assert_eq!(
             fork_cond_block_only_head, fork_cond_block_only_expected,
-            "expected satisfy() to return {:#?}, but got {:#?} ",
-            fork_cond_block_only_expected, fork_cond_block_only_head
+            "expected satisfy() to return {fork_cond_block_only_expected:#?}, but got {fork_cond_block_only_head:#?} ",
         );
         // Fork::ConditionTTD test case without a new chain spec to demonstrate ChainSpec::satisfy
         // is independent of ChainSpec for this(these - including ForkCondition::Block) match arm(s)
@@ -1871,8 +1864,7 @@ Post-merge hard forks (timestamp based):
             Head { total_difficulty: U256::from(10_790_000), ..Default::default() };
         assert_eq!(
             fork_cond_ttd_no_new_spec, fork_cond_ttd_no_new_spec_expected,
-            "expected satisfy() to return {:#?}, but got {:#?} ",
-            fork_cond_ttd_no_new_spec_expected, fork_cond_ttd_no_new_spec
+            "expected satisfy() to return {fork_cond_ttd_blocknum_expected:#?}, but got {fork_cond_ttd_blocknum_expected:#?} ",
         );
     }
 

--- a/crates/primitives/src/compression/mod.rs
+++ b/crates/primitives/src/compression/mod.rs
@@ -55,7 +55,7 @@ impl ReusableDecompressor {
         while let Err(err) = self.decompressor.decompress_to_buffer(src, &mut self.buf) {
             let err = err.to_string();
             if !err.contains("Destination buffer is too small") {
-                panic!("Failed to decompress: {}", err);
+                panic!("Failed to decompress: {err}");
             }
             self.buf.reserve(self.buf.capacity() + 24_000);
         }

--- a/crates/primitives/src/integer_list.rs
+++ b/crates/primitives/src/integer_list.rs
@@ -23,7 +23,7 @@ impl Deref for IntegerList {
 impl fmt::Debug for IntegerList {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let vec: Vec<u64> = self.0.iter().collect();
-        write!(f, "IntegerList {:?}", vec)
+        write!(f, "IntegerList {vec:?}")
     }
 }
 

--- a/crates/primitives/src/transaction/tx_type.rs
+++ b/crates/primitives/src/transaction/tx_type.rs
@@ -142,10 +142,10 @@ impl Compact for TxType {
                         EIP4844_TX_TYPE_ID => TxType::Eip4844,
                         #[cfg(feature = "optimism")]
                         DEPOSIT_TX_TYPE_ID => TxType::Deposit,
-                        _ => panic!("Unsupported TxType identifier: {}", extended_identifier),
+                        _ => panic!("Unsupported TxType identifier: {extended_identifier}"),
                     }
                 }
-                _ => panic!("Unknown identifier for TxType: {}", identifier),
+                _ => panic!("Unknown identifier for TxType: {identifier}"),
             },
             buf,
         )

--- a/crates/primitives/src/transaction/tx_type.rs
+++ b/crates/primitives/src/transaction/tx_type.rs
@@ -172,10 +172,9 @@ mod tests {
             let identifier = tx_type.to_compact(&mut buf);
             assert_eq!(
                 identifier, expected_identifier,
-                "Unexpected identifier for TxType {:?}",
-                tx_type
+                "Unexpected identifier for TxType {tx_type:?}",
             );
-            assert_eq!(buf, expected_buf, "Unexpected buffer for TxType {:?}", tx_type);
+            assert_eq!(buf, expected_buf, "Unexpected buffer for TxType {tx_type:?}");
         }
     }
 
@@ -192,15 +191,10 @@ mod tests {
 
         for (expected_type, identifier, buf) in cases {
             let (actual_type, remaining_buf) = TxType::from_compact(&buf, identifier);
-            assert_eq!(
-                actual_type, expected_type,
-                "Unexpected TxType for identifier {}",
-                identifier
-            );
+            assert_eq!(actual_type, expected_type, "Unexpected TxType for identifier {identifier}",);
             assert!(
                 remaining_buf.is_empty(),
-                "Buffer not fully consumed for identifier {}",
-                identifier
+                "Buffer not fully consumed for identifier {identifier}",
             );
         }
     }

--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -49,7 +49,7 @@ where
         Ok(_) => {} // If the request is successful, do nothing
         Err(e) => {
             // If an error occurs, panic with the error message
-            panic!("Expected successful response, got error: {:?}", e);
+            panic!("Expected successful response, got error: {e:?}");
         }
     }
 }
@@ -61,7 +61,7 @@ where
     // Make the RPC request
     if let Ok(resp) = client.request::<R, _>(method_name, params).await {
         // Panic if an unexpected successful response is received
-        panic!("Expected error response, got successful response: {:?}", resp);
+        panic!("Expected error response, got successful response: {resp:?}");
     };
 }
 

--- a/crates/rpc/rpc-testing-util/src/debug.rs
+++ b/crates/rpc/rpc-testing-util/src/debug.rs
@@ -419,7 +419,7 @@ mod tests {
         let mut stream = client.debug_trace_transactions_in_block(block, opts).await.unwrap();
         while let Some(res) = stream.next().await {
             if let Err((err, tx)) = res {
-                println!("failed to trace {:?}  {}", tx, err);
+                println!("failed to trace {tx:?}  {err}");
             }
         }
     }

--- a/crates/rpc/rpc-testing-util/src/trace.rs
+++ b/crates/rpc/rpc-testing-util/src/trace.rs
@@ -465,10 +465,9 @@ where
                 }
                 (Err((ref err1, ref block1)), Err((ref err2, ref block2))) => {
                     assert_eq!(
-                        format!("{:?}", err1),
-                        format!("{:?}", err2),
-                        "Different errors for block: {:?}",
-                        block1
+                        format!("{err1:?}"),
+                        format!("{err2:?}"),
+                        "Different errors for block: {block1:?}"
                     );
                     assert_eq!(block1, block2, "Mismatch in block ids.");
                 }
@@ -495,17 +494,15 @@ where
                     similar_asserts::assert_eq!(
                         trace1_data,
                         trace2_data,
-                        "Mismatch in trace results for transaction: {:?}",
-                        tx_hash1
+                        "Mismatch in trace results for transaction: {tx_hash1:?}",
                     );
                     assert_eq!(tx_hash1, tx_hash2, "Mismatch in transaction hashes.");
                 }
                 (Err((ref err1, ref tx_hash1)), Err((ref err2, ref tx_hash2))) => {
                     assert_eq!(
-                        format!("{:?}", err1),
-                        format!("{:?}", err2),
-                        "Different errors for transaction: {:?}",
-                        tx_hash1
+                        format!("{err1:?}"),
+                        format!("{err2:?}"),
+                        "Different errors for transaction: {tx_hash1:?}",
                     );
                     assert_eq!(tx_hash1, tx_hash2, "Mismatch in transaction hashes.");
                 }
@@ -554,20 +551,20 @@ mod tests {
         while let Some(result) = stream.next().await {
             match result {
                 Ok((trace_result, tx_hash)) => {
-                    println!("Success for tx_hash {:?}: {:?}", tx_hash, trace_result);
+                    println!("Success for tx_hash {tx_hash:?}: {trace_result:?}");
                     successes += 1;
                     all_results.push(Ok((trace_result, tx_hash)));
                 }
                 Err((error, tx_hash)) => {
-                    println!("Error for tx_hash {:?}: {:?}", tx_hash, error);
+                    println!("Error for tx_hash {tx_hash:?}: {error:?}");
                     failures += 1;
                     all_results.push(Err((error, tx_hash)));
                 }
             }
         }
 
-        println!("Total successes: {}", successes);
-        println!("Total failures: {}", failures);
+        println!("Total successes: {successes}");
+        println!("Total failures: {failures}");
     }
 
     #[tokio::test]
@@ -587,10 +584,10 @@ mod tests {
         while let Some(result) = stream.next().await {
             match result {
                 Ok(trace_result) => {
-                    println!("Success: {:?}", trace_result);
+                    println!("Success: {trace_result:?}");
                 }
                 Err(error) => {
-                    println!("Error: {:?}", error);
+                    println!("Error: {error:?}");
                 }
             }
         }
@@ -609,10 +606,10 @@ mod tests {
         while let Some(result) = stream.next().await {
             match result {
                 Ok(trace) => {
-                    println!("Received trace: {:?}", trace);
+                    println!("Received trace: {trace:?}");
                 }
                 Err(e) => {
-                    println!("Error fetching trace: {:?}", e);
+                    println!("Error fetching trace: {e:?}");
                 }
             }
         }
@@ -639,10 +636,10 @@ mod tests {
         while let Some(result) = stream.next().await {
             match result {
                 Ok(trace) => {
-                    println!("Received trace: {:?}", trace);
+                    println!("Received trace: {trace:?}");
                 }
                 Err(e) => {
-                    println!("Error fetching trace: {:?}", e);
+                    println!("Error fetching trace: {e:?}");
                 }
             }
         }
@@ -665,19 +662,19 @@ mod tests {
         while let Some(result) = stream.next().await {
             match result {
                 Ok(trace_result) => {
-                    println!("Success: {:?}", trace_result);
+                    println!("Success: {trace_result:?}");
                     successes += 1;
                     all_results.push(Ok(trace_result));
                 }
                 Err((error, request)) => {
-                    println!("Error for request {:?}: {:?}", request, error);
+                    println!("Error for request {request:?}: {error:?}");
                     failures += 1;
                     all_results.push(Err((error, request)));
                 }
             }
         }
 
-        println!("Total successes: {}", successes);
-        println!("Total failures: {}", failures);
+        println!("Total successes: {successes}");
+        println!("Total failures: {failures}");
     }
 }

--- a/crates/rpc/rpc-testing-util/src/utils.rs
+++ b/crates/rpc/rpc-testing-util/src/utils.rs
@@ -8,6 +8,6 @@ pub fn parse_env_url(var: &str) -> Result<String, std::env::VarError> {
     if var.starts_with("http") {
         Ok(var)
     } else {
-        Ok(format!("http://{}", var))
+        Ok(format!("http://{var}"))
     }
 }

--- a/crates/rpc/rpc-testing-util/tests/it/trace.rs
+++ b/crates/rpc/rpc-testing-util/tests/it/trace.rs
@@ -44,7 +44,7 @@ async fn replay_transactions() {
     let mut stream = client.replay_transactions(tx_hashes, trace_types);
     let now = Instant::now();
     while let Some(replay_txs) = stream.next().await {
-        println!("Transaction: {:?}", replay_txs);
+        println!("Transaction: {replay_txs:?}");
         println!("Replayed transactions in {:?}", now.elapsed());
     }
 }
@@ -65,7 +65,7 @@ async fn trace_filters() {
     let mut stream = client.trace_filter_stream(filters);
     let start_time = Instant::now();
     while let Some(trace) = stream.next().await {
-        println!("Transaction Trace: {:?}", trace);
+        println!("Transaction Trace: {trace:?}");
         println!("Duration since test start: {:?}", start_time.elapsed());
     }
 }
@@ -82,10 +82,10 @@ async fn trace_call() {
     while let Some(result) = stream.next().await {
         match result {
             Ok(trace_result) => {
-                println!("Trace Result: {:?}", trace_result);
+                println!("Trace Result: {trace_result:?}");
             }
             Err((error, request)) => {
-                eprintln!("Error for request {:?}: {:?}", request, error);
+                eprintln!("Error for request {request:?}: {error:?}");
             }
         }
     }

--- a/crates/storage/db/src/lib.rs
+++ b/crates/storage/db/src/lib.rs
@@ -249,7 +249,7 @@ pub mod test_utils {
     /// Create read/write database for testing
     pub fn create_test_rw_db() -> Arc<TempDatabase<DatabaseEnv>> {
         let path = tempdir_path();
-        let emsg = format!("{}: {:?}", ERROR_DB_CREATION, path);
+        let emsg = format!("{ERROR_DB_CREATION}: {path:?}");
 
         let db = init_db(
             &path,

--- a/crates/storage/db/src/tables/mod.rs
+++ b/crates/storage/db/src/tables/mod.rs
@@ -394,7 +394,7 @@ mod tests {
     #[test]
     fn parse_table_from_str() {
         for table in Tables::ALL {
-            assert_eq!(format!("{:?}", table), table.name());
+            assert_eq!(format!("{table:?}"), table.name());
             assert_eq!(table.to_string(), table.name());
             assert_eq!(Tables::from_str(table.name()).unwrap(), *table);
         }

--- a/crates/storage/provider/src/chain.rs
+++ b/crates/storage/provider/src/chain.rs
@@ -324,9 +324,9 @@ impl<'a> fmt::Display for DisplayBlocksChain<'a> {
             write!(f, "[")?;
             let mut iter = self.0.values().map(|block| block.num_hash());
             if let Some(block_num_hash) = iter.next() {
-                write!(f, "{:?}", block_num_hash)?;
+                write!(f, "{block_num_hash:?}")?;
                 for block_num_hash_iter in iter {
-                    write!(f, ", {:?}", block_num_hash_iter)?;
+                    write!(f, ", {block_num_hash_iter:?}")?;
                 }
             }
             write!(f, "]")?;

--- a/crates/transaction-pool/benches/priority.rs
+++ b/crates/transaction-pool/benches/priority.rs
@@ -22,7 +22,7 @@ fn priority_bench(
     description: &str,
     input_data: (u128, u128, u128, u128),
 ) {
-    let group_id = format!("txpool | {}", description);
+    let group_id = format!("txpool | {description}");
 
     group.bench_function(group_id, |b| {
         b.iter(|| {
@@ -41,7 +41,7 @@ fn fee_jump_bench(
     description: &str,
     input_data: (u128, u128),
 ) {
-    let group_id = format!("txpool | {}", description);
+    let group_id = format!("txpool | {description}");
 
     group.bench_function(group_id, |b| {
         b.iter(|| {

--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -458,7 +458,7 @@ mod tests {
         }
         let all = store.get_all(all_hashes.clone()).unwrap();
         for (tx, blob) in all {
-            assert!(blobs.contains(&(tx, blob)), "missing blob {:?}", tx);
+            assert!(blobs.contains(&(tx, blob)), "missing blob {tx:?}");
         }
 
         assert!(store.contains(all_hashes[0]).unwrap());

--- a/crates/transaction-pool/src/pool/blob.rs
+++ b/crates/transaction-pool/src/pool/blob.rs
@@ -690,8 +690,7 @@ mod tests {
             let actual = fee_delta(tx_fee, base_fee);
             assert_eq!(
                 actual, expected,
-                "fee_delta({}, {}) = {}, expected: {}",
-                tx_fee, base_fee, actual, expected
+                "fee_delta({tx_fee}, {base_fee}) = {actual}, expected: {expected}"
             );
         }
     }

--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -124,8 +124,7 @@ impl<T: ParkedOrd> ParkedPool<T> {
         assert!(
             self.last_sender_submission
                 .remove(&SubmissionSenderId::new(sender_id, removed_sender.last_submission_id)),
-            "last sender transaction not found {:?}",
-            sender_id
+            "last sender transaction not found {sender_id:?}"
         );
     }
 

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -2445,7 +2445,7 @@ mod tests {
             MockTransaction::eip4844().set_sender(tx.get_sender()).inc_price_by(100).inc_limit();
         let blob = f.validated(tx);
         let err = pool.insert_tx(blob, on_chain_balance, on_chain_nonce).unwrap_err();
-        assert!(matches!(err, InsertErr::TxTypeConflict { .. }), "{:?}", err);
+        assert!(matches!(err, InsertErr::TxTypeConflict { .. }), "{err:?}");
     }
 
     #[test]
@@ -2461,7 +2461,7 @@ mod tests {
             MockTransaction::eip1559().set_sender(tx.get_sender()).inc_price_by(100).inc_limit();
         let tx = f.validated(tx);
         let err = pool.insert_tx(tx, on_chain_balance, on_chain_nonce).unwrap_err();
-        assert!(matches!(err, InsertErr::TxTypeConflict { .. }), "{:?}", err);
+        assert!(matches!(err, InsertErr::TxTypeConflict { .. }), "{err:?}");
     }
 
     // insert nonce then nonce - 1

--- a/testing/ef-tests/src/models.rs
+++ b/testing/ef-tests/src/models.rs
@@ -235,18 +235,16 @@ impl Account {
                     assert_equal(
                         *value,
                         entry.value,
-                        &format!("Storage for slot {:?} does not match", slot),
+                        &format!("Storage for slot {slot:?} does not match"),
                     )?;
                 } else {
                     return Err(Error::Assertion(format!(
-                        "Slot {:?} is missing from the database. Expected {:?}",
-                        slot, value
+                        "Slot {slot:?} is missing from the database. Expected {value:?}"
                     )))
                 }
             } else {
                 return Err(Error::Assertion(format!(
-                    "Slot {:?} is missing from the database. Expected {:?}",
-                    slot, value
+                    "Slot {slot:?} is missing from the database. Expected {value:?}"
                 )))
             }
         }

--- a/testing/ef-tests/src/suite.rs
+++ b/testing/ef-tests/src/suite.rs
@@ -33,7 +33,7 @@ pub trait Suite {
             .join(self.suite_name());
 
         // Verify that the path exists
-        assert!(suite_path.exists(), "Test suite path does not exist: {:?}", suite_path);
+        assert!(suite_path.exists(), "Test suite path does not exist: {suite_path:?}");
 
         // Find all files with the ".json" extension in the test suite directory
         let test_cases = find_all_files_with_extension(&suite_path, ".json")


### PR DESCRIPTION
This PR enables the [`uninlined_format_args`](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args) linter and fixes its findings.