### PR TITLE
`reth-primitives`: Fix warnings when default features are off.

### DIFF
--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -44,8 +44,8 @@ once_cell.workspace = true
 rayon.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-sha2 = "0.10.7"
-tempfile.workspace = true
+sha2 = { version = "0.10.7", optional = true }
+tempfile = { workspace = true, optional = true }
 thiserror.workspace = true
 zstd = { version = "0.12", features = ["experimental"] }
 roaring = "0.10.2"
@@ -101,7 +101,7 @@ arbitrary = [
     "dep:proptest",
     "dep:proptest-derive",
 ]
-c-kzg = ["dep:c-kzg", "revm/c-kzg", "revm-primitives/c-kzg"]
+c-kzg = ["dep:c-kzg", "revm/c-kzg", "revm-primitives/c-kzg", "dep:sha2", "dep:tempfile"]
 clap = ["dep:clap"]
 optimism = [
     "reth-codecs/optimism",
@@ -117,7 +117,7 @@ harness = false
 
 [[bench]]
 name = "validate_blob_tx"
-required-features = ["arbitrary"]
+required-features = ["arbitrary", "c-kzg"]
 harness = false
 
 [[bench]]


### PR DESCRIPTION
I've used [cargo-chack](https://github.com/taiki-e/cargo-hack) to verify that all set of feature do not emit any warnings or errors. Here is particular command:

```
cargo hack check -p reth-primitives --feature-powerset --exclude-features default --all-targets
```

I didn't add this check to the CI, because it is long and hungry for disk storage.