### PR TITLE
fix: enforce timeouts for pending sessions

### DIFF
--- a/crates/net/network/src/error.rs
+++ b/crates/net/network/src/error.rs
@@ -234,6 +234,7 @@ impl SessionError for PendingSessionHandshakeError {
         match self {
             PendingSessionHandshakeError::Eth(eth) => eth.merits_discovery_ban(),
             PendingSessionHandshakeError::Ecies(_) => true,
+            PendingSessionHandshakeError::Timeout => false,
         }
     }
 
@@ -241,6 +242,7 @@ impl SessionError for PendingSessionHandshakeError {
         match self {
             PendingSessionHandshakeError::Eth(eth) => eth.is_fatal_protocol_error(),
             PendingSessionHandshakeError::Ecies(_) => true,
+            PendingSessionHandshakeError::Timeout => false,
         }
     }
 
@@ -248,6 +250,7 @@ impl SessionError for PendingSessionHandshakeError {
         match self {
             PendingSessionHandshakeError::Eth(eth) => eth.should_backoff(),
             PendingSessionHandshakeError::Ecies(_) => Some(BackoffKind::Low),
+            PendingSessionHandshakeError::Timeout => Some(BackoffKind::Medium),
         }
     }
 }

--- a/crates/net/network/src/session/config.rs
+++ b/crates/net/network/src/session/config.rs
@@ -11,6 +11,9 @@ use std::time::Duration;
 /// This represents the amount of time we wait for a response until we consider it timed out.
 pub const INITIAL_REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 
+/// Default timeout after which a pending session attempt is considered failed.
+pub const PENDING_SESSION_TIMEOUT: Duration = Duration::from_secs(20);
+
 /// Default timeout after which we'll consider the peer to be in violation of the protocol.
 ///
 /// This is the time a peer has to answer a response.
@@ -48,6 +51,8 @@ pub struct SessionsConfig {
     /// `PROTOCOL_BREACH_REQUEST_TIMEOUT`) this is considered a protocol violation and results in a
     /// dropped session.
     pub protocol_breach_request_timeout: Duration,
+    /// The timeout after which a pending session attempt is considered failed.
+    pub pending_session_timeout: Duration,
 }
 
 impl Default for SessionsConfig {
@@ -66,6 +71,7 @@ impl Default for SessionsConfig {
             limits: Default::default(),
             initial_internal_request_timeout: INITIAL_REQUEST_TIMEOUT,
             protocol_breach_request_timeout: PROTOCOL_BREACH_REQUEST_TIMEOUT,
+            pending_session_timeout: PENDING_SESSION_TIMEOUT,
         }
     }
 }

--- a/crates/net/network/src/session/handle.rs
+++ b/crates/net/network/src/session/handle.rs
@@ -3,6 +3,7 @@
 use crate::{
     message::PeerMessage,
     session::{conn::EthRlpxConnection, Direction, SessionId},
+    PendingSessionHandshakeError,
 };
 use reth_ecies::ECIESError;
 use reth_eth_wire::{
@@ -188,7 +189,7 @@ pub enum PendingSessionEvent {
         /// The direction of the session, either `Inbound` or `Outgoing`
         direction: Direction,
         /// The error that caused the disconnect
-        error: Option<EthStreamError>,
+        error: Option<PendingSessionHandshakeError>,
     },
     /// Thrown when unable to establish a [`TcpStream`](tokio::net::TcpStream).
     OutgoingConnectionError {

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -37,7 +37,7 @@ use tokio::{
 };
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::PollSender;
-use tracing::{instrument, trace};
+use tracing::{debug, instrument, trace};
 
 mod active;
 mod config;
@@ -71,6 +71,8 @@ pub struct SessionManager {
     /// If an [ActiveSession] does not receive a response at all within this duration then it is
     /// considered a protocol violation and the session will initiate a drop.
     protocol_breach_request_timeout: Duration,
+    /// The timeout after which a pending session attempt is considered failed.
+    pending_session_timeout: Duration,
     /// The secret key used for authenticating sessions.
     secret_key: SecretKey,
     /// The `Status` message to send to peers.
@@ -136,6 +138,7 @@ impl SessionManager {
             counter: SessionCounter::new(config.limits),
             initial_internal_request_timeout: config.initial_internal_request_timeout,
             protocol_breach_request_timeout: config.protocol_breach_request_timeout,
+            pending_session_timeout: config.pending_session_timeout,
             secret_key,
             status,
             hello_message,
@@ -236,17 +239,24 @@ impl SessionManager {
         let status = self.status;
         let fork_filter = self.fork_filter.clone();
         let extra_handlers = self.extra_protocols.on_incoming(remote_addr);
-        self.spawn(start_pending_incoming_session(
-            disconnect_rx,
+        self.spawn(pending_session_with_timeout(
+            self.pending_session_timeout,
             session_id,
-            metered_stream,
-            pending_events,
             remote_addr,
-            secret_key,
-            hello_message,
-            status,
-            fork_filter,
-            extra_handlers,
+            Direction::Incoming,
+            pending_events.clone(),
+            start_pending_incoming_session(
+                disconnect_rx,
+                session_id,
+                metered_stream,
+                pending_events,
+                remote_addr,
+                secret_key,
+                hello_message,
+                status,
+                fork_filter,
+                extra_handlers,
+            ),
         ));
 
         let handle = PendingSessionHandle {
@@ -271,18 +281,25 @@ impl SessionManager {
             let status = self.status;
             let band_with_meter = self.bandwidth_meter.clone();
             let extra_handlers = self.extra_protocols.on_outgoing(remote_addr, remote_peer_id);
-            self.spawn(start_pending_outbound_session(
-                disconnect_rx,
-                pending_events,
+            self.spawn(pending_session_with_timeout(
+                self.pending_session_timeout,
                 session_id,
                 remote_addr,
-                remote_peer_id,
-                secret_key,
-                hello_message,
-                status,
-                fork_filter,
-                band_with_meter,
-                extra_handlers,
+                Direction::Outgoing(remote_peer_id),
+                pending_events.clone(),
+                start_pending_outbound_session(
+                    disconnect_rx,
+                    pending_events,
+                    session_id,
+                    remote_addr,
+                    remote_peer_id,
+                    secret_key,
+                    hello_message,
+                    status,
+                    fork_filter,
+                    band_with_meter,
+                    extra_handlers,
+                ),
             ));
 
             let handle = PendingSessionHandle {
@@ -521,14 +538,14 @@ impl SessionManager {
                     Direction::Incoming => {
                         Poll::Ready(SessionEvent::IncomingPendingSessionClosed {
                             remote_addr,
-                            error: error.map(PendingSessionHandshakeError::Eth),
+                            error,
                         })
                     }
                     Direction::Outgoing(peer_id) => {
                         Poll::Ready(SessionEvent::OutgoingPendingSessionClosed {
                             remote_addr,
                             peer_id,
-                            error: error.map(PendingSessionHandshakeError::Eth),
+                            error,
                         })
                     }
                 }
@@ -722,6 +739,9 @@ pub enum PendingSessionHandshakeError {
     /// The pending session failed due to an error while establishing the ECIES stream
     #[error(transparent)]
     Ecies(ECIESError),
+    /// Thrown when the authentication timed out
+    #[error("authentication timed out")]
+    Timeout,
 }
 
 impl PendingSessionHandshakeError {
@@ -739,6 +759,29 @@ impl PendingSessionHandshakeError {
 #[derive(Debug, Clone, thiserror::Error)]
 #[error("session limit reached {0}")]
 pub struct ExceedsSessionLimit(pub(crate) u32);
+
+/// Starts a pending session authentication with a timeout.
+pub(crate) async fn pending_session_with_timeout<F>(
+    timeout: Duration,
+    session_id: SessionId,
+    remote_addr: SocketAddr,
+    direction: Direction,
+    events: mpsc::Sender<PendingSessionEvent>,
+    f: F,
+) where
+    F: Future<Output = ()>,
+{
+    if tokio::time::timeout(timeout, f).await.is_err() {
+        debug!(target: "net::session", ?remote_addr, ?direction, "pending session timed out");
+        let event = PendingSessionEvent::Disconnected {
+            remote_addr,
+            session_id,
+            direction,
+            error: Some(PendingSessionHandshakeError::Timeout),
+        };
+        let _ = events.send(event).await;
+    }
+}
 
 /// Starts the authentication process for a connection initiated by a remote peer.
 ///
@@ -930,7 +973,7 @@ async fn authenticate_stream(
                 remote_addr,
                 session_id,
                 direction,
-                error: Some(err.into()),
+                error: Some(PendingSessionHandshakeError::Eth(err.into())),
             }
         }
     };
@@ -943,7 +986,7 @@ async fn authenticate_stream(
                 remote_addr,
                 session_id,
                 direction,
-                error: Some(err.into()),
+                error: Some(PendingSessionHandshakeError::Eth(err.into())),
             }
         }
     };
@@ -961,7 +1004,7 @@ async fn authenticate_stream(
                     remote_addr,
                     session_id,
                     direction,
-                    error: Some(err),
+                    error: Some(PendingSessionHandshakeError::Eth(err)),
                 }
             }
         };


### PR DESCRIPTION
closes #7216

this wraps pending session authentication into a tokio::timeout, ensuring that they will be terminated and don't occupy slots for followup requests