### PR TITLE
Enable clippy's equatable_if_let linter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ clippy.derive_partial_eq_without_eq = "deny"
 clippy.redundant_clone = "deny"
 clippy.trait_duplication_in_bounds = "deny"
 clippy.uninlined_format_args = "deny"
+clippy.equatable_if_let = "deny"
 
 [workspace.package]
 version = "0.2.0-beta.3"

--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -944,7 +944,7 @@ impl TransactionFetcher {
                 let (verification_outcome, verified_payload) =
                     payload.verify(&requested_hashes, &peer_id);
 
-                if let VerificationOutcome::ReportPeer = verification_outcome {
+                if verification_outcome == VerificationOutcome::ReportPeer {
                     // todo: report peer for sending hashes that weren't requested
                     trace!(target: "net::tx",
                         peer_id=format!("{peer_id:#}"),
@@ -971,7 +971,7 @@ impl TransactionFetcher {
                 // passing the rlp encoded length down from active session along with the decoded
                 // tx.
 
-                if let FilterOutcome::ReportPeer = validation_outcome {
+                if validation_outcome == FilterOutcome::ReportPeer {
                     trace!(target: "net::tx",
                         peer_id=format!("{peer_id:#}"),
                         unvalidated_payload_len=unvalidated_payload_len,

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -649,7 +649,7 @@ where
         let (validation_outcome, mut partially_valid_msg) =
             self.transaction_fetcher.filter_valid_message.partially_filter_valid_entries(msg);
 
-        if let FilterOutcome::ReportPeer = validation_outcome {
+        if validation_outcome == FilterOutcome::ReportPeer {
             self.report_peer(peer_id, ReputationChangeKind::BadAnnouncement);
         }
 
@@ -698,7 +698,7 @@ where
                 .filter_valid_entries_66(partially_valid_msg)
         };
 
-        if let FilterOutcome::ReportPeer = validation_outcome {
+        if validation_outcome == FilterOutcome::ReportPeer {
             self.report_peer(peer_id, ReputationChangeKind::BadAnnouncement);
         }
 

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -1626,7 +1626,7 @@ mod tests {
                     expected_id, &computed_id,
                     "Expected fork ID {expected_id:?}, computed fork ID {computed_id:?} for hardfork {hardfork}"
                 );
-                if let Hardfork::Shanghai = hardfork {
+                if matches!(hardfork, Hardfork::Shanghai) {
                     if let Some(shangai_id) = spec.shanghai_fork_id() {
                         assert_eq!(
                             expected_id, &shangai_id,

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1283,7 +1283,7 @@ impl TransactionSigned {
         let signature = Signature::decode(data)?;
 
         #[cfg(feature = "optimism")]
-        let signature = if let TxType::Deposit = tx_type {
+        let signature = if tx_type == TxType::Deposit {
             Signature::optimism_deposit_tx_signature()
         } else {
             Signature::decode(data)?

--- a/crates/rpc/rpc/src/eth/api/call.rs
+++ b/crates/rpc/rpc/src/eth/api/call.rs
@@ -256,8 +256,10 @@ where
 
         // Exceptional case: init used too much gas, we need to increase the gas limit and try
         // again
-        if let Err(EthApiError::InvalidTransaction(RpcInvalidTransactionError::GasTooHigh)) = ethres
-        {
+        if matches!(
+            ethres,
+            Err(EthApiError::InvalidTransaction(RpcInvalidTransactionError::GasTooHigh))
+        ) {
             // if price or limit was included in the request then we can execute the request
             // again with the block's gas limit to check if revert is gas related or not
             if request_gas.is_some() || request_gas_price.is_some() {
@@ -339,9 +341,10 @@ where
 
             // Exceptional case: init used too much gas, we need to increase the gas limit and try
             // again
-            if let Err(EthApiError::InvalidTransaction(RpcInvalidTransactionError::GasTooHigh)) =
-                ethres
-            {
+            if matches!(
+                ethres,
+                Err(EthApiError::InvalidTransaction(RpcInvalidTransactionError::GasTooHigh))
+            ) {
                 // increase the lowest gas limit
                 lowest_gas_limit = mid_gas_limit;
 

--- a/crates/rpc/rpc/src/eth/api/state.rs
+++ b/crates/rpc/rpc/src/eth/api/state.rs
@@ -47,7 +47,7 @@ where
         address: Address,
         block_id: Option<BlockId>,
     ) -> EthResult<U256> {
-        if let Some(BlockId::Number(BlockNumberOrTag::Pending)) = block_id {
+        if block_id == Some(BlockId::Number(BlockNumberOrTag::Pending)) {
             let address_txs = self.pool().get_transactions_by_sender(address);
             if let Some(highest_nonce) =
                 address_txs.iter().map(|item| item.transaction.nonce()).max()

--- a/crates/stages/src/stages/mod.rs
+++ b/crates/stages/src/stages/mod.rs
@@ -170,7 +170,7 @@ mod tests {
                 ..Default::default()
             };
 
-            if let Some(PruneMode::Full) = prune_modes.account_history {
+            if prune_modes.account_history == Some(PruneMode::Full) {
                 // Full is not supported
                 assert!(acc_indexing_stage.execute(&provider, input).is_err());
             } else {
@@ -186,7 +186,7 @@ mod tests {
                 ..Default::default()
             };
 
-            if let Some(PruneMode::Full) = prune_modes.storage_history {
+            if prune_modes.storage_history == Some(PruneMode::Full) {
                 // Full is not supported
                 assert!(acc_indexing_stage.execute(&provider, input).is_err());
             } else {

--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -112,7 +112,7 @@ impl Environment {
                 sender: tx,
             });
             let res = rx.recv().unwrap();
-            if let Err(Error::Busy) = &res {
+            if matches!(&res, Err(Error::Busy)) {
                 if !warned {
                     warned = true;
                     warn!(target: "libmdbx", "Process stalled, awaiting read-write transaction lock.");

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -385,7 +385,7 @@ impl StaticFileProvider {
                             })
                             .or_insert_with(|| BTreeMap::from([(tx_end, current_block_range)]));
                     }
-                } else if let Some(1) = tx_index.get(&segment).map(|index| index.len()) {
+                } else if tx_index.get(&segment).map(|index| index.len()) == Some(1) {
                     // Only happens if we unwind all the txs/receipts from the first static file.
                     // Should only happen in test scenarios.
                     if jar.user_header().expected_block_start() == 0 &&

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -349,7 +349,7 @@ where
                     // is stripped from the transaction and not included in a block.
                     // check if the blob is in the store, if it's included we previously validated
                     // it and inserted it
-                    if let Ok(true) = self.blob_store.contains(*transaction.hash()) {
+                    if matches!(self.blob_store.contains(*transaction.hash()), Ok(true)) {
                         // validated transaction is already in the store
                     } else {
                         return TransactionValidationOutcome::Invalid(


### PR DESCRIPTION
This PR enables the [`equatable_if_let`](https://rust-lang.github.io/rust-clippy/master/index.html#equatable_if_let) linter and fixes its findings.