### PR TITLE
Enable clippy's or_fun_call linter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ clippy.derive_partial_eq_without_eq = "deny"
 clippy.redundant_clone = "deny"
 clippy.trait_duplication_in_bounds = "deny"
 clippy.uninlined_format_args = "deny"
+clippy.or_fun_call = "deny"
 
 [workspace.package]
 version = "0.2.0-beta.3"

--- a/bin/reth/src/commands/import.rs
+++ b/bin/reth/src/commands/import.rs
@@ -79,7 +79,7 @@ impl ImportCommand {
 
         // add network name to data dir
         let data_dir = self.datadir.unwrap_or_chain_default(self.chain.chain);
-        let config_path = self.config.clone().unwrap_or(data_dir.config_path());
+        let config_path = self.config.clone().unwrap_or_else(|| data_dir.config_path());
 
         let config: Config = self.load_config(config_path.clone())?;
         info!(target: "reth::cli", path = ?config_path, "Configuration loaded");

--- a/bin/reth/src/commands/node/mod.rs
+++ b/bin/reth/src/commands/node/mod.rs
@@ -286,14 +286,14 @@ mod tests {
             NodeCommand::try_parse_args_from(["reth", "--config", "my/path/to/reth.toml"]).unwrap();
         // always store reth.toml in the data dir, not the chain specific data dir
         let data_dir = cmd.datadir.unwrap_or_chain_default(cmd.chain.chain);
-        let config_path = cmd.config.unwrap_or(data_dir.config_path());
+        let config_path = cmd.config.unwrap_or_else(|| data_dir.config_path());
         assert_eq!(config_path, Path::new("my/path/to/reth.toml"));
 
         let cmd = NodeCommand::try_parse_args_from(["reth"]).unwrap();
 
         // always store reth.toml in the data dir, not the chain specific data dir
         let data_dir = cmd.datadir.unwrap_or_chain_default(cmd.chain.chain);
-        let config_path = cmd.config.clone().unwrap_or(data_dir.config_path());
+        let config_path = cmd.config.clone().unwrap_or_else(|| data_dir.config_path());
         let end = format!("reth/{}/reth.toml", SUPPORTED_CHAINS[0]);
         assert!(config_path.ends_with(end), "{:?}", cmd.config);
     }

--- a/bin/reth/src/commands/p2p/mod.rs
+++ b/bin/reth/src/commands/p2p/mod.rs
@@ -104,7 +104,7 @@ impl Command {
 
         // add network name to data dir
         let data_dir = self.datadir.unwrap_or_chain_default(self.chain.chain);
-        let config_path = self.config.clone().unwrap_or(data_dir.config_path());
+        let config_path = self.config.clone().unwrap_or_else(|| data_dir.config_path());
 
         let mut config: Config = confy::load_path(&config_path).unwrap_or_default();
 

--- a/bin/reth/src/commands/stage/run.rs
+++ b/bin/reth/src/commands/stage/run.rs
@@ -126,7 +126,7 @@ impl Command {
 
         // add network name to data dir
         let data_dir = self.datadir.unwrap_or_chain_default(self.chain.chain);
-        let config_path = self.config.clone().unwrap_or(data_dir.config_path());
+        let config_path = self.config.clone().unwrap_or_else(|| data_dir.config_path());
 
         let config: Config = confy::load_path(config_path).unwrap_or_default();
         info!(target: "reth::cli", "reth {} starting stage {:?}", SHORT_VERSION, self.stage);

--- a/crates/interfaces/src/test_utils/generators.rs
+++ b/crates/interfaces/src/test_utils/generators.rs
@@ -251,7 +251,7 @@ where
                     }
                     old
                 };
-                Some(StorageEntry { value: old.unwrap_or(U256::from(0)), ..entry })
+                Some(StorageEntry { value: old.unwrap_or(U256::ZERO), ..entry })
             })
             .collect();
         old_entries.sort_by_key(|entry| entry.key);

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -503,7 +503,7 @@ impl NetworkConfigBuilder {
             peers_config: peers_config.unwrap_or_default(),
             sessions_config: sessions_config.unwrap_or_default(),
             chain_spec,
-            block_import: block_import.unwrap_or(Box::<ProofOfStakeBlockImport>::default()),
+            block_import: block_import.unwrap_or_else(|| Box::<ProofOfStakeBlockImport>::default()),
             network_mode,
             executor: executor.unwrap_or_else(|| Box::<TokioTaskExecutor>::default()),
             status,

--- a/crates/node-builder/src/builder.rs
+++ b/crates/node-builder/src/builder.rs
@@ -470,7 +470,7 @@ where
         let sync_metrics_listener = reth_stages::MetricsListener::new(sync_metrics_rx);
         executor.spawn_critical("stages metrics listener task", sync_metrics_listener);
 
-        let prune_config = config.prune_config()?.or(reth_config.prune.clone());
+        let prune_config = config.prune_config()?.or_else(|| reth_config.prune.clone());
 
         let evm_config = types.evm_config();
         let tree_config = BlockchainTreeConfig::default();

--- a/crates/payload/optimism/src/lib.rs
+++ b/crates/payload/optimism/src/lib.rs
@@ -276,7 +276,7 @@ mod builder {
         let mut cumulative_gas_used = 0;
         let block_gas_limit: u64 = attributes
             .gas_limit
-            .unwrap_or(initialized_block_env.gas_limit.try_into().unwrap_or(u64::MAX));
+            .unwrap_or_else(|| initialized_block_env.gas_limit.try_into().unwrap_or(u64::MAX));
         let base_fee = initialized_block_env.basefee.to::<u64>();
 
         let mut executed_txs = Vec::new();

--- a/crates/rpc/rpc/src/eth/revm_utils.rs
+++ b/crates/rpc/rpc/src/eth/revm_utils.rs
@@ -355,7 +355,7 @@ pub(crate) fn create_txn_env(
             block_env.get_blob_gasprice().map(U256::from),
         )?;
 
-    let gas_limit = gas.unwrap_or(block_env.gas_limit.min(U256::from(u64::MAX)));
+    let gas_limit = gas.unwrap_or_else(|| block_env.gas_limit.min(U256::from(u64::MAX)));
     let env = TxEnv {
         gas_limit: gas_limit.try_into().map_err(|_| RpcInvalidTransactionError::GasUintOverflow)?,
         nonce: nonce

--- a/crates/rpc/rpc/src/layers/auth_layer.rs
+++ b/crates/rpc/rpc/src/layers/auth_layer.rs
@@ -241,7 +241,7 @@ mod tests {
         let server = spawn_server().await;
         let client = hyper::Client::new();
 
-        let jwt = jwt.unwrap_or("".into());
+        let jwt = jwt.unwrap_or_default();
         let address = format!("http://{AUTH_ADDR}:{AUTH_PORT}");
         let bearer = format!("Bearer {jwt}");
         let body = r#"{"jsonrpc": "2.0", "method": "greet_melkor", "params": [], "id": 1}"#;

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -237,7 +237,7 @@ impl StaticFileProviderRW {
             .user_header()
             .block_end()
             .map(|b| b + 1)
-            .unwrap_or(self.writer.user_header().expected_block_start());
+            .unwrap_or_else(|| self.writer.user_header().expected_block_start());
 
         if expected_block_number != next_static_file_block {
             return Err(ProviderError::UnexpectedStaticFileBlockNumber(

--- a/crates/tracing/src/formatter.rs
+++ b/crates/tracing/src/formatter.rs
@@ -51,11 +51,10 @@ impl LogFormat {
         let target = std::env::var("RUST_LOG_TARGET")
             // `RUST_LOG_TARGET` always overrides default behaviour
             .map(|val| val != "0")
-            .unwrap_or(
+            .unwrap_or_else(|_|
                 // If `RUST_LOG_TARGET` is not set, show target in logs only if the max enabled
                 // level is higher than INFO (DEBUG, TRACE)
-                filter.max_level_hint().map_or(true, |max_level| max_level > tracing::Level::INFO),
-            );
+                filter.max_level_hint().map_or(true, |max_level| max_level > tracing::Level::INFO));
 
         match self {
             LogFormat::Json => {

--- a/crates/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/src/hashed_cursor/post_state.rs
@@ -232,9 +232,9 @@ impl<'b, C> HashedPostStateStorageCursor<'b, C> {
                 }
             }
             // Return either non-empty entry
-            _ => {
-                db_item.or(post_state_item.copied().map(|(key, value)| StorageEntry { key, value }))
-            }
+            _ => db_item.or_else(|| {
+                post_state_item.copied().map(|(key, value)| StorageEntry { key, value })
+            }),
         }
     }
 }
@@ -252,7 +252,7 @@ where
             Some(storage) => {
                 // If the storage has been wiped at any point
                 storage.wiped &&
-                    // and the current storage does not contain any non-zero values 
+                    // and the current storage does not contain any non-zero values
                     storage.non_zero_valued_slots.is_empty()
             }
             None => self.cursor.is_storage_empty(key)?,


### PR DESCRIPTION
This PR enables the [`or_fun_call`](https://rust-lang.github.io/rust-clippy/master/index.html#or_fun_call) linter and fixes its findings.

> **Why is this bad?**
>
> The function will always be called. This is only bad if it allocates or does some non-trivial amount of work.

Several of these fixes are for simple, trivial functions but fixed anyway for consistency.