### PR TITLE
Enable clippy's branches_sharing_code linter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -244,7 +244,8 @@ strum = "0.26"
 rayon = "1.7"
 itertools = "0.12"
 parking_lot = "0.12"
-metrics = "0.21.1"                                    # Needed for `metrics-macro` to resolve the crate using `::metrics` notation
+# Needed for `metrics-macro` to resolve the crate using `::metrics` notation
+metrics = "0.21.1"
 hex-literal = "0.4"
 once_cell = "1.17"
 syn = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ clippy.trait_duplication_in_bounds = "deny"
 clippy.uninlined_format_args = "deny"
 clippy.equatable_if_let = "deny"
 clippy.or_fun_call = "deny"
+clippy.branches_sharing_code = "deny"
 
 [workspace.package]
 version = "0.2.0-beta.3"
@@ -193,8 +194,13 @@ reth-trie = { path = "crates/trie" }
 reth-trie-parallel = { path = "crates/trie-parallel" }
 
 # revm
-revm = { version = "7.1.0", features = ["std", "secp256k1"], default-features = false }
-revm-primitives = { version = "3.0.0", features = ["std"], default-features = false }
+revm = { version = "7.1.0", features = [
+    "std",
+    "secp256k1",
+], default-features = false }
+revm-primitives = { version = "3.0.0", features = [
+    "std",
+], default-features = false }
 revm-inspectors = { git = "https://github.com/paradigmxyz/evm-inspectors", rev = "f96bc1f" }
 
 # eth
@@ -238,7 +244,7 @@ strum = "0.26"
 rayon = "1.7"
 itertools = "0.12"
 parking_lot = "0.12"
-metrics = "0.21.1" # Needed for `metrics-macro` to resolve the crate using `::metrics` notation
+metrics = "0.21.1"                                    # Needed for `metrics-macro` to resolve the crate using `::metrics` notation
 hex-literal = "0.4"
 once_cell = "1.17"
 syn = "2.0"

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -264,13 +264,12 @@ impl<T: TransactionOrdering> PendingPool<T> {
             // the transaction already has an ancestor, so we only need to ensure that the
             // highest nonces set actually contains the highest nonce for that sender
             self.highest_nonces.remove(ancestor);
-            self.highest_nonces.insert(tx.clone());
         } else {
             // If there's __no__ ancestor in the pool, then this transaction is independent, this is
             // guaranteed because this pool is gapless.
             self.independent_transactions.insert(tx.clone());
-            self.highest_nonces.insert(tx.clone());
         }
+        self.highest_nonces.insert(tx.clone());
     }
 
     /// Returns the ancestor the given transaction, the transaction with `nonce - 1`.


### PR DESCRIPTION
This PR enables the [`branches_sharing_code`](https://rust-lang.github.io/rust-clippy/master/index.html#branches_sharing_code) linter and fixes its findings.