### PR TITLE
feat: add metrics for pending connections

### DIFF
--- a/crates/net/network/src/metrics.rs
+++ b/crates/net/network/src/metrics.rs
@@ -34,6 +34,12 @@ pub struct NetworkMetrics {
     /// Number of active outgoing connections
     pub(crate) outgoing_connections: Gauge,
 
+    /// Number of currently pending outgoing connections
+    pub(crate) pending_outgoing_connections: Gauge,
+
+    /// Total number of pending connections, incoming and outgoing.
+    pub(crate) total_pending_connections: Gauge,
+
     /// Total Number of incoming connections handled
     pub(crate) total_incoming_connections: Counter,
 

--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -208,10 +208,16 @@ impl PeersManager {
         self.connection_info.num_inbound
     }
 
-    /// Returns the number of currently active outbound connections.
+    /// Returns the number of currently __active__ outbound connections.
     #[inline]
     pub(crate) fn num_outbound_connections(&self) -> usize {
         self.connection_info.num_outbound
+    }
+
+    /// Returns the number of currently pending outbound connections.
+    #[inline]
+    pub(crate) fn num_pending_outbound_connections(&self) -> usize {
+        self.connection_info.num_pending_out
     }
 
     /// Returns the number of currently backed off peers.

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -187,6 +187,12 @@ impl SessionManager {
         self.extra_protocols.push(protocol)
     }
 
+    /// Returns the number of currently pending connections.
+    #[inline]
+    pub(crate) fn num_pending_connections(&self) -> usize {
+        self.pending_sessions.len()
+    }
+
     /// Spawns the given future onto a new task that is tracked in the `spawned_tasks`
     /// [`JoinSet`](tokio::task::JoinSet).
     fn spawn<F>(&self, f: F)


### PR DESCRIPTION
closes #7224

this adds new metrics that explicitly track pending connections.

this also fixes issues where the connection metrics were updated in the wrong place.

needs followup to integrate in grafana