### PR TITLE
Decode with EMPTY_STRING_CODE and buf.advance()

### DIFF
--- a/crates/net/downloaders/src/bodies/request.rs
+++ b/crates/net/downloaders/src/bodies/request.rs
@@ -127,7 +127,7 @@ where
         self.metrics.total_downloaded.increment(response_len as u64);
 
         // TODO: Malicious peers often return a single block even if it does not exceed the soft
-        // response limit (2MB).  this could be penalized by checking if this block and the
+        // response limit (2MB). This could be penalized by checking if this block and the
         // next one exceed the soft response limit, if not then peer either does not have the next
         // block or deliberately sent a single block.
         if bodies.is_empty() {

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -79,7 +79,7 @@
 //!     }
 //! }
 //!
-//! /// A [PayloadJob] is a a future that's being polled by the `PayloadBuilderService`
+//! /// A [PayloadJob] is a future that's being polled by the `PayloadBuilderService`
 //! impl Future for EmptyBlockPayloadJob {
 //!  type Output = Result<(), PayloadBuilderError>;
 //!

--- a/crates/payload/builder/src/payload.rs
+++ b/crates/payload/builder/src/payload.rs
@@ -21,7 +21,7 @@ use std::convert::Infallible;
 ///
 /// According to the [engine API specification](https://github.com/ethereum/execution-apis/blob/main/src/engine/README.md) the execution layer should build the initial version of the payload with an empty transaction set and then keep update it in order to maximize the revenue.
 /// Therefore, the empty-block here is always available and full-block will be set/updated
-/// afterwards.
+/// afterward.
 #[derive(Debug, Clone)]
 pub struct EthBuiltPayload {
     /// Identifier of the payload

--- a/crates/rpc/rpc-types/src/eth/transaction/typed.rs
+++ b/crates/rpc/rpc-types/src/eth/transaction/typed.rs
@@ -3,8 +3,9 @@
 //! it can be converted into the container type [`TypedTransactionRequest`].
 
 use alloy_primitives::{Address, Bytes, B256, U256, U64};
-use alloy_rlp::{BufMut, Decodable, Encodable, Error as RlpError};
+use alloy_rlp::{BufMut, Decodable, EMPTY_STRING_CODE, Encodable, Error as RlpError};
 use alloy_rpc_types::{AccessList, BlobTransactionSidecar};
+use bytes::Buf;
 use serde::{Deserialize, Serialize};
 
 /// Container type for various Ethereum transaction requests
@@ -165,8 +166,8 @@ impl Encodable for TransactionKind {
 impl Decodable for TransactionKind {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
         if let Some(&first) = buf.first() {
-            if first == 0x80 {
-                *buf = &buf[1..];
+            if first == EMPTY_STRING_CODE {
+                buf.advance(1);
                 Ok(TransactionKind::Create)
             } else {
                 let addr = <Address as Decodable>::decode(buf)?;

--- a/crates/rpc/rpc-types/src/eth/transaction/typed.rs
+++ b/crates/rpc/rpc-types/src/eth/transaction/typed.rs
@@ -3,9 +3,8 @@
 //! it can be converted into the container type [`TypedTransactionRequest`].
 
 use alloy_primitives::{Address, Bytes, B256, U256, U64};
-use alloy_rlp::{BufMut, Decodable, EMPTY_STRING_CODE, Encodable, Error as RlpError};
+use alloy_rlp::{Buf, BufMut, Decodable, EMPTY_STRING_CODE, Encodable, Error as RlpError};
 use alloy_rpc_types::{AccessList, BlobTransactionSidecar};
-use bytes::Buf;
 use serde::{Deserialize, Serialize};
 
 /// Container type for various Ethereum transaction requests

--- a/crates/rpc/rpc-types/src/eth/transaction/typed.rs
+++ b/crates/rpc/rpc-types/src/eth/transaction/typed.rs
@@ -3,7 +3,7 @@
 //! it can be converted into the container type [`TypedTransactionRequest`].
 
 use alloy_primitives::{Address, Bytes, B256, U256, U64};
-use alloy_rlp::{Buf, BufMut, Decodable, EMPTY_STRING_CODE, Encodable, Error as RlpError};
+use alloy_rlp::{Buf, BufMut, Decodable, Encodable, Error as RlpError, EMPTY_STRING_CODE};
 use alloy_rpc_types::{AccessList, BlobTransactionSidecar};
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
This PR fixes a minor nit I had when reviewing some `decode` functions. It replaces `0x80` with `EMPTY_STRING_CODE` and uses `buf.advance()` instead of the other way, which I didn't find very readable. Also fix a few typos.