### PR TITLE
fix: enforce max inbound == 0

### DIFF
--- a/crates/net/network/src/swarm.rs
+++ b/crates/net/network/src/swarm.rs
@@ -203,6 +203,9 @@ where
                         InboundConnectionError::IpBanned => {
                             trace!(target: "net", ?remote_addr, "The incoming ip address is in the ban list");
                         }
+                        InboundConnectionError::ExceedsCapacity => {
+                            trace!(target: "net", ?remote_addr, "No capacity for incoming connection");
+                        }
                     }
                     return None
                 }

--- a/crates/net/network/tests/it/connect.rs
+++ b/crates/net/network/tests/it/connect.rs
@@ -588,61 +588,38 @@ async fn test_disconnect_incoming_when_exceeded_incoming_connections() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_always_accept_incoming_connections_from_trusted_peers() {
     reth_tracing::init_test_tracing();
-    let other_peer1 = new_random_peer(10, HashSet::new()).await;
-    let other_peer2 = new_random_peer(10, HashSet::new()).await;
-    let other_peer3 = new_random_peer(0, HashSet::new()).await;
+    let peer1 = new_random_peer(10, HashSet::new()).await;
+    let peer2 = new_random_peer(1, HashSet::new()).await;
 
     //  setup the peer with max_inbound = 1, and add other_peer_3 as trust nodes
-    let peer = new_random_peer(
-        1,
-        HashSet::from([NodeRecord::new(other_peer3.local_addr(), *other_peer3.peer_id())]),
-    )
-    .await;
+    let peer =
+        new_random_peer(0, HashSet::from([NodeRecord::new(peer2.local_addr(), *peer2.peer_id())]))
+            .await;
 
     let handle = peer.handle().clone();
-    let other_peer_handle1 = other_peer1.handle().clone();
-    let other_peer_handle2 = other_peer2.handle().clone();
-    let other_peer_handle3 = other_peer3.handle().clone();
+    let peer1_handle = peer1.handle().clone();
+    let peer2_handle = peer2.handle().clone();
 
     tokio::task::spawn(peer);
-    tokio::task::spawn(other_peer1);
-    tokio::task::spawn(other_peer2);
-    tokio::task::spawn(other_peer3);
+    tokio::task::spawn(peer1);
+    tokio::task::spawn(peer2);
 
     let mut events = NetworkEventStream::new(handle.event_listener());
-    let mut events2 = NetworkEventStream::new(other_peer_handle2.event_listener());
-
-    // though we added other_peer3 as a trust node, the incoming connection should fail because
-    // peer3 doesn't allow inbound connections
-    let (peer_id, reason) = events.next_session_closed().await.unwrap();
-    assert_eq!(peer_id, *other_peer_handle3.peer_id());
-    assert_eq!(reason, Some(DisconnectReason::TooManyPeers));
-
-    // incoming connection should succeed
-    other_peer_handle1.add_peer(*handle.peer_id(), handle.local_addr());
-    let peer_id = events.next_session_established().await.unwrap();
-    assert_eq!(peer_id, *other_peer_handle1.peer_id());
-    assert_eq!(handle.num_connected_peers(), 1);
+    let mut events2 = NetworkEventStream::new(peer1_handle.event_listener());
 
     // incoming connection should fail because exceeding max_inbound
-    other_peer_handle2.add_peer(*handle.peer_id(), handle.local_addr());
-    let (peer_id, reason) = events.next_session_closed().await.unwrap();
-    assert_eq!(peer_id, *other_peer_handle2.peer_id());
-    // fixme: this should be `Some(DisconnectReason::TooManyPeers)` but `None`
-    assert_eq!(reason, None);
+    peer1_handle.add_peer(*handle.peer_id(), handle.local_addr());
 
     let (peer_id, reason) = events2.next_session_closed().await.unwrap();
     assert_eq!(peer_id, *handle.peer_id());
     assert_eq!(reason, Some(DisconnectReason::TooManyPeers));
 
-    // outbound connection from `other_peer3` should succeed
-    other_peer_handle3.add_peer(*handle.peer_id(), handle.local_addr());
+    // outbound connection from `peer2` should succeed
+    peer2_handle.add_peer(*handle.peer_id(), handle.local_addr());
     let peer_id = events.next_session_established().await.unwrap();
-    assert_eq!(peer_id, *other_peer_handle3.peer_id());
+    assert_eq!(peer_id, *peer2_handle.peer_id());
 
-    // sleep is needed because the disconnect event happened after session_established event
-    tokio::time::sleep(Duration::from_secs(3)).await;
-    assert_eq!(handle.num_connected_peers(), 2);
+    assert_eq!(handle.num_connected_peers(), 1);
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
this makes it possible to disable incoming connections entirely.

if we don't have any slots for inc connections and no trusted nodes then we can't accept new connections