### PR TITLE
chore(stages/metrics): use Counter instead of Gauge for mgas_processed

### DIFF
--- a/crates/stages/src/metrics/listener.rs
+++ b/crates/stages/src/metrics/listener.rs
@@ -85,11 +85,9 @@ impl MetricsListener {
                     stage_metrics.entities_total.set(total as f64);
                 }
             }
-            MetricEvent::ExecutionStageGas { gas } => self
-                .sync_metrics
-                .execution_stage
-                .mgas_processed_total
-                .increment(gas as f64 / MGAS_TO_GAS as f64),
+            MetricEvent::ExecutionStageGas { gas } => {
+                self.sync_metrics.execution_stage.mgas_processed_total.increment(gas / MGAS_TO_GAS)
+            }
         }
     }
 }

--- a/crates/stages/src/metrics/sync_metrics.rs
+++ b/crates/stages/src/metrics/sync_metrics.rs
@@ -1,4 +1,7 @@
-use reth_metrics::{metrics::Gauge, Metrics};
+use reth_metrics::{
+    metrics::{Counter, Gauge},
+    Metrics,
+};
 use reth_primitives::stage::StageId;
 use std::collections::HashMap;
 
@@ -33,5 +36,5 @@ pub(crate) struct StageMetrics {
 #[metrics(scope = "sync.execution")]
 pub(crate) struct ExecutionStageMetrics {
     /// The total amount of gas processed (in millions)
-    pub(crate) mgas_processed_total: Gauge,
+    pub(crate) mgas_processed_total: Counter,
 }


### PR DESCRIPTION
From Prometheus's metric types of Gauge https://prometheus.io/docs/concepts/metric_types

> A counter is a cumulative metric that represents a single [monotonically increasing counter](https://en.wikipedia.org/wiki/Monotonic_function) whose value can only increase or be reset to zero on restart. For example, you can use a counter to represent the number of requests served, tasks completed, or errors.
> A gauge is a metric that represents a single numerical value that can arbitrarily go up and down.
> Gauges are typically used for measured values like temperatures or current memory usage, but also "counts" that can go up and down, like the number of concurrent requests.

in our usecase, `self.sync_metrics.execution_stage.mgas_processed_total` is the cumulative of mgas processed, which is increased by each block:
 https://github.com/paradigmxyz/reth/blob/b20fb3446f96e42d52ae32258f4058bf7841e366/crates/stages/src/stages/execution.rs#L187-L191


so we should prefer to use Counter instead.
