### PR TITLE
chore: make blockchain tree error results more specific

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6750,6 +6750,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "reth-db",
+ "reth-interfaces",
  "reth-metrics",
  "reth-primitives",
  "reth-provider",

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -936,11 +936,14 @@ impl<DB: Database, EVM: ExecutorFactory> BlockchainTree<DB, EVM> {
         if let Some(header) = canonical_header {
             info!(target: "blockchain_tree", ?block_hash, "Block is already canonical, ignoring.");
             // TODO: this could be fetched from the chainspec first
-            let td = self.externals.provider_factory.provider()?.header_td(block_hash)?.ok_or(
-                CanonicalError::from(BlockValidationError::MissingTotalDifficulty {
-                    hash: *block_hash,
-                }),
-            )?;
+            let td =
+                self.externals.provider_factory.provider()?.header_td(block_hash)?.ok_or_else(
+                    || {
+                        CanonicalError::from(BlockValidationError::MissingTotalDifficulty {
+                            hash: *block_hash,
+                        })
+                    },
+                )?;
             if !self
                 .externals
                 .provider_factory
@@ -950,8 +953,7 @@ impl<DB: Database, EVM: ExecutorFactory> BlockchainTree<DB, EVM> {
             {
                 return Err(CanonicalError::from(BlockValidationError::BlockPreMerge {
                     hash: *block_hash,
-                })
-                .into())
+                }))
             }
             return Ok(CanonicalOutcome::AlreadyCanonical { header })
         }
@@ -960,8 +962,7 @@ impl<DB: Database, EVM: ExecutorFactory> BlockchainTree<DB, EVM> {
             debug!(target: "blockchain_tree", ?block_hash, "Block hash not found in block indices");
             return Err(CanonicalError::from(BlockchainTreeError::BlockHashNotFoundInChain {
                 block_hash: *block_hash,
-            })
-            .into())
+            }))
         };
         let chain = self.state.chains.remove(&chain_id).expect("To be present");
 

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -6,7 +6,7 @@ use crate::{
     state::{BlockChainId, TreeState},
     AppendableChain, BlockIndices, BlockchainTreeConfig, BundleStateData, TreeExternals,
 };
-use reth_db::{database::Database, DatabaseError};
+use reth_db::database::Database;
 use reth_interfaces::{
     blockchain_tree::{
         error::{BlockchainTreeError, CanonicalError, InsertBlockError, InsertBlockErrorKind},
@@ -15,7 +15,7 @@ use reth_interfaces::{
     consensus::{Consensus, ConsensusError},
     executor::{BlockExecutionError, BlockValidationError},
     provider::RootMismatch,
-    RethError, RethResult,
+    RethResult,
 };
 use reth_primitives::{
     BlockHash, BlockNumHash, BlockNumber, ForkBlock, GotExpected, Hardfork, PruneModes, Receipt,
@@ -877,7 +877,10 @@ impl<DB: Database, EVM: ExecutorFactory> BlockchainTree<DB, EVM> {
     ///
     /// Returns `Ok(None)` if the block hash is not canonical (block hash does not exist, or is
     /// included in a sidechain).
-    pub fn find_canonical_header(&self, hash: &BlockHash) -> RethResult<Option<SealedHeader>> {
+    pub fn find_canonical_header(
+        &self,
+        hash: &BlockHash,
+    ) -> Result<Option<SealedHeader>, ProviderError> {
         // if the indices show that the block hash is not canonical, it's either in a sidechain or
         // canonical, but in the db. If it is in a sidechain, it is not canonical. If it is not in
         // the db, then it is not canonical.
@@ -901,7 +904,7 @@ impl<DB: Database, EVM: ExecutorFactory> BlockchainTree<DB, EVM> {
     }
 
     /// Determines whether or not a block is canonical, checking the db if necessary.
-    pub fn is_block_hash_canonical(&self, hash: &BlockHash) -> RethResult<bool> {
+    pub fn is_block_hash_canonical(&self, hash: &BlockHash) -> Result<bool, ProviderError> {
         self.find_canonical_header(hash).map(|header| header.is_some())
     }
 
@@ -917,7 +920,10 @@ impl<DB: Database, EVM: ExecutorFactory> BlockchainTree<DB, EVM> {
     /// Returns `Ok` if the blocks were canonicalized, or if the blocks were already canonical.
     #[track_caller]
     #[instrument(level = "trace", skip(self), target = "blockchain_tree")]
-    pub fn make_canonical(&mut self, block_hash: &BlockHash) -> RethResult<CanonicalOutcome> {
+    pub fn make_canonical(
+        &mut self,
+        block_hash: &BlockHash,
+    ) -> Result<CanonicalOutcome, CanonicalError> {
         let mut durations_recorder = MakeCanonicalDurationsRecorder::default();
 
         let old_block_indices = self.block_indices().clone();
@@ -1099,7 +1105,7 @@ impl<DB: Database, EVM: ExecutorFactory> BlockchainTree<DB, EVM> {
         &self,
         chain: Chain,
         recorder: &mut MakeCanonicalDurationsRecorder,
-    ) -> RethResult<()> {
+    ) -> Result<(), CanonicalError> {
         let (blocks, state, chain_trie_updates) = chain.into_inner();
         let hashed_state = state.hash_state_slow();
 
@@ -1123,16 +1129,15 @@ impl<DB: Database, EVM: ExecutorFactory> BlockchainTree<DB, EVM> {
                     .disable_long_read_transaction_safety();
                 let (state_root, trie_updates) = hashed_state
                     .state_root_with_updates(provider.tx_ref())
-                    .map_err(Into::<DatabaseError>::into)?;
+                    .map_err(Into::<BlockValidationError>::into)?;
                 let tip = blocks.tip();
                 if state_root != tip.state_root {
-                    return Err(RethError::Provider(ProviderError::StateRootMismatch(Box::new(
-                        RootMismatch {
-                            root: GotExpected { got: state_root, expected: tip.state_root },
-                            block_number: tip.number,
-                            block_hash: tip.hash(),
-                        },
-                    ))))
+                    return Err(ProviderError::StateRootMismatch(Box::new(RootMismatch {
+                        root: GotExpected { got: state_root, expected: tip.state_root },
+                        block_number: tip.number,
+                        block_hash: tip.hash(),
+                    }))
+                    .into())
                 }
                 self.metrics.trie_updates_insert_recomputed.increment(1);
                 trie_updates
@@ -1149,7 +1154,7 @@ impl<DB: Database, EVM: ExecutorFactory> BlockchainTree<DB, EVM> {
                 trie_updates,
                 self.prune_modes.as_ref(),
             )
-            .map_err(|e| BlockExecutionError::CanonicalCommit { inner: e.to_string() })?;
+            .map_err(|e| CanonicalError::CanonicalCommit(e.to_string()))?;
 
         provider_rw.commit()?;
         recorder.record_relative(MakeCanonicalAction::CommitCanonicalChainToDatabase);
@@ -1183,7 +1188,7 @@ impl<DB: Database, EVM: ExecutorFactory> BlockchainTree<DB, EVM> {
     fn revert_canonical_from_database(
         &mut self,
         revert_until: BlockNumber,
-    ) -> RethResult<Option<Chain>> {
+    ) -> Result<Option<Chain>, CanonicalError> {
         // read data that is needed for new sidechain
         let provider_rw = self.externals.provider_factory.provider_rw()?;
 
@@ -1196,7 +1201,7 @@ impl<DB: Database, EVM: ExecutorFactory> BlockchainTree<DB, EVM> {
                 self.externals.provider_factory.chain_spec().as_ref(),
                 revert_range,
             )
-            .map_err(|e| BlockExecutionError::CanonicalRevert { inner: e.to_string() })?;
+            .map_err(|e| CanonicalError::CanonicalRevert(e.to_string()))?;
 
         provider_rw.commit()?;
 

--- a/crates/blockchain-tree/src/noop.rs
+++ b/crates/blockchain-tree/src/noop.rs
@@ -1,9 +1,10 @@
 use reth_interfaces::{
     blockchain_tree::{
-        error::{BlockchainTreeError, InsertBlockError},
+        error::{BlockchainTreeError, CanonicalError, InsertBlockError},
         BlockValidationKind, BlockchainTreeEngine, BlockchainTreeViewer, CanonicalOutcome,
         InsertPayloadOk,
     },
+    provider::ProviderError,
     RethResult,
 };
 use reth_primitives::{
@@ -52,7 +53,7 @@ impl BlockchainTreeEngine for NoopBlockchainTree {
         Ok(())
     }
 
-    fn make_canonical(&self, block_hash: &BlockHash) -> RethResult<CanonicalOutcome> {
+    fn make_canonical(&self, block_hash: &BlockHash) -> Result<CanonicalOutcome, CanonicalError> {
         Err(BlockchainTreeError::BlockHashNotFoundInChain { block_hash: *block_hash }.into())
     }
 
@@ -94,8 +95,8 @@ impl BlockchainTreeViewer for NoopBlockchainTree {
         None
     }
 
-    fn is_canonical(&self, block_hash: BlockHash) -> RethResult<bool> {
-        Err(BlockchainTreeError::BlockHashNotFoundInChain { block_hash }.into())
+    fn is_canonical(&self, _block_hash: BlockHash) -> Result<bool, ProviderError> {
+        Ok(false)
     }
 
     fn lowest_buffered_ancestor(&self, _hash: BlockHash) -> Option<SealedBlockWithSenders> {

--- a/crates/blockchain-tree/src/shareable.rs
+++ b/crates/blockchain-tree/src/shareable.rs
@@ -5,8 +5,9 @@ use parking_lot::RwLock;
 use reth_db::database::Database;
 use reth_interfaces::{
     blockchain_tree::{
-        error::InsertBlockError, BlockValidationKind, BlockchainTreeEngine, BlockchainTreeViewer,
-        CanonicalOutcome, InsertPayloadOk,
+        error::{CanonicalError, InsertBlockError},
+        BlockValidationKind, BlockchainTreeEngine, BlockchainTreeViewer, CanonicalOutcome,
+        InsertPayloadOk,
     },
     RethResult,
 };
@@ -16,7 +17,7 @@ use reth_primitives::{
 };
 use reth_provider::{
     BlockchainTreePendingStateProvider, BundleStateDataProvider, CanonStateSubscriptions,
-    ExecutorFactory,
+    ExecutorFactory, ProviderError,
 };
 use std::{
     collections::{BTreeMap, HashSet},
@@ -85,7 +86,7 @@ impl<DB: Database, EF: ExecutorFactory> BlockchainTreeEngine for ShareableBlockc
         res
     }
 
-    fn make_canonical(&self, block_hash: &BlockHash) -> RethResult<CanonicalOutcome> {
+    fn make_canonical(&self, block_hash: &BlockHash) -> Result<CanonicalOutcome, CanonicalError> {
         trace!(target: "blockchain_tree", ?block_hash, "Making block canonical");
         let mut tree = self.tree.write();
         let res = tree.make_canonical(block_hash);
@@ -151,7 +152,7 @@ impl<DB: Database, EF: ExecutorFactory> BlockchainTreeViewer for ShareableBlockc
         None
     }
 
-    fn is_canonical(&self, hash: BlockHash) -> RethResult<bool> {
+    fn is_canonical(&self, hash: BlockHash) -> Result<bool, ProviderError> {
         trace!(target: "blockchain_tree", ?hash, "Checking if block is canonical");
         self.tree.read().is_block_hash_canonical(&hash)
     }

--- a/crates/interfaces/src/blockchain_tree/error.rs
+++ b/crates/interfaces/src/blockchain_tree/error.rs
@@ -49,9 +49,6 @@ pub enum BlockchainTreeError {
     },
 }
 
-/// Result alias for `CanonicalError`
-pub type CanonicalResult<T> = Result<T, CanonicalError>;
-
 /// Canonical Errors
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 pub enum CanonicalError {
@@ -61,6 +58,9 @@ pub enum CanonicalError {
     /// Error originating from blockchain tree operations.
     #[error(transparent)]
     BlockchainTree(#[from] BlockchainTreeError),
+    /// Error originating from a provider operation.
+    #[error(transparent)]
+    Provider(#[from] ProviderError),
     /// Error indicating a transaction reverted during execution.
     #[error("transaction error on revert: {0}")]
     CanonicalRevert(String),
@@ -280,6 +280,7 @@ impl InsertBlockErrorKind {
                 CanonicalError::CanonicalCommit(_) |
                 CanonicalError::CanonicalRevert(_) => false,
                 CanonicalError::Validation(_) => true,
+                CanonicalError::Provider(_) => false,
             },
             InsertBlockErrorKind::BlockchainTree(_) => false,
         }

--- a/crates/interfaces/src/blockchain_tree/mod.rs
+++ b/crates/interfaces/src/blockchain_tree/mod.rs
@@ -1,9 +1,11 @@
-use crate::{blockchain_tree::error::InsertBlockError, RethResult};
+use crate::{blockchain_tree::error::InsertBlockError, provider::ProviderError, RethResult};
 use reth_primitives::{
     BlockHash, BlockNumHash, BlockNumber, Receipt, SealedBlock, SealedBlockWithSenders,
     SealedHeader,
 };
 use std::collections::{BTreeMap, HashSet};
+
+use self::error::CanonicalError;
 
 pub mod error;
 
@@ -94,7 +96,7 @@ pub trait BlockchainTreeEngine: BlockchainTreeViewer + Send + Sync {
     /// # Returns
     ///
     /// Returns `Ok` if the blocks were canonicalized, or if the blocks were already canonical.
-    fn make_canonical(&self, block_hash: &BlockHash) -> RethResult<CanonicalOutcome>;
+    fn make_canonical(&self, block_hash: &BlockHash) -> Result<CanonicalOutcome, CanonicalError>;
 
     /// Unwind tables and put it inside state
     fn unwind(&self, unwind_to: BlockNumber) -> RethResult<()>;
@@ -299,7 +301,7 @@ pub trait BlockchainTreeViewer: Send + Sync {
     fn find_canonical_ancestor(&self, parent_hash: BlockHash) -> Option<BlockHash>;
 
     /// Return whether or not the block is known and in the canonical chain.
-    fn is_canonical(&self, hash: BlockHash) -> RethResult<bool>;
+    fn is_canonical(&self, hash: BlockHash) -> Result<bool, ProviderError>;
 
     /// Given the hash of a block, this checks the buffered blocks for the lowest ancestor in the
     /// buffer.

--- a/crates/interfaces/src/error.rs
+++ b/crates/interfaces/src/error.rs
@@ -76,5 +76,5 @@ mod size_asserts {
     static_assert_size!(DatabaseError, 40);
     static_assert_size!(ProviderError, 48);
     static_assert_size!(NetworkError, 0);
-    static_assert_size!(CanonicalError, 48);
+    static_assert_size!(CanonicalError, 56);
 }

--- a/crates/interfaces/src/executor.rs
+++ b/crates/interfaces/src/executor.rs
@@ -1,4 +1,4 @@
-use crate::provider::ProviderError;
+use crate::{provider::ProviderError, trie::StateRootError};
 use reth_primitives::{
     revm_primitives::EVMError, BlockNumHash, Bloom, GotExpected, GotExpectedBoxed,
     PruneSegmentError, B256,
@@ -29,6 +29,9 @@ pub enum BlockValidationError {
     /// Error when header bloom filter doesn't match expected value
     #[error("header bloom filter mismatch: {0}")]
     BloomLogDiff(GotExpectedBoxed<Bloom>),
+    /// Error when the state root does not match the expected value.
+    #[error(transparent)]
+    StateRoot(#[from] StateRootError),
     /// Error when transaction gas limit exceeds available block gas
     #[error("transaction gas limit {transaction_gas_limit} is more than blocks available gas {block_available_gas}")]
     TransactionGasLimitMoreThanAvailableBlockGas {

--- a/crates/interfaces/src/lib.rs
+++ b/crates/interfaces/src/lib.rs
@@ -28,6 +28,9 @@ pub use error::{RethError, RethResult};
 /// P2P traits.
 pub mod p2p;
 
+/// Trie error
+pub mod trie;
+
 /// Provider error
 pub mod provider;
 

--- a/crates/interfaces/src/trie/mod.rs
+++ b/crates/interfaces/src/trie/mod.rs
@@ -1,3 +1,4 @@
+use crate::db::DatabaseError;
 use thiserror::Error;
 
 /// State root error.
@@ -5,13 +6,13 @@ use thiserror::Error;
 pub enum StateRootError {
     /// Internal database error.
     #[error(transparent)]
-    DB(#[from] reth_db::DatabaseError),
+    DB(#[from] DatabaseError),
     /// Storage root error.
     #[error(transparent)]
     StorageRootError(#[from] StorageRootError),
 }
 
-impl From<StateRootError> for reth_db::DatabaseError {
+impl From<StateRootError> for DatabaseError {
     fn from(err: StateRootError) -> Self {
         match err {
             StateRootError::DB(err) => err,
@@ -25,5 +26,5 @@ impl From<StateRootError> for reth_db::DatabaseError {
 pub enum StorageRootError {
     /// Internal database error.
     #[error(transparent)]
-    DB(#[from] reth_db::DatabaseError),
+    DB(#[from] DatabaseError),
 }

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -12,12 +12,13 @@ use reth_db::{
 };
 use reth_interfaces::{
     blockchain_tree::{
-        error::InsertBlockError, BlockValidationKind, BlockchainTreeEngine, BlockchainTreeViewer,
-        CanonicalOutcome, InsertPayloadOk,
+        error::{CanonicalError, InsertBlockError},
+        BlockValidationKind, BlockchainTreeEngine, BlockchainTreeViewer, CanonicalOutcome,
+        InsertPayloadOk,
     },
     consensus::ForkchoiceState,
     provider::ProviderResult,
-    RethError, RethResult,
+    RethResult,
 };
 use reth_node_api::ConfigureEvmEnv;
 use reth_primitives::{
@@ -668,7 +669,7 @@ where
         self.tree.connect_buffered_blocks_to_canonical_hashes()
     }
 
-    fn make_canonical(&self, block_hash: &BlockHash) -> RethResult<CanonicalOutcome> {
+    fn make_canonical(&self, block_hash: &BlockHash) -> Result<CanonicalOutcome, CanonicalError> {
         self.tree.make_canonical(block_hash)
     }
 
@@ -714,7 +715,7 @@ where
         self.tree.find_canonical_ancestor(hash)
     }
 
-    fn is_canonical(&self, hash: BlockHash) -> Result<bool, RethError> {
+    fn is_canonical(&self, hash: BlockHash) -> Result<bool, ProviderError> {
         self.tree.is_canonical(hash)
     }
 

--- a/crates/trie-parallel/Cargo.toml
+++ b/crates/trie-parallel/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 reth-primitives.workspace = true
 reth-db.workspace = true
 reth-trie.workspace = true
+reth-interfaces.workspace = true
 reth-provider.workspace = true
 
 # alloy

--- a/crates/trie-parallel/src/async_root.rs
+++ b/crates/trie-parallel/src/async_root.rs
@@ -2,6 +2,7 @@ use crate::{stats::ParallelTrieTracker, storage_root_targets::StorageRootTargets
 use alloy_rlp::{BufMut, Encodable};
 use itertools::Itertools;
 use reth_db::database::Database;
+use reth_interfaces::trie::StorageRootError;
 use reth_primitives::{
     trie::{HashBuilder, Nibbles, TrieAccount},
     B256,
@@ -17,7 +18,7 @@ use reth_trie::{
     trie_cursor::TrieCursorFactory,
     updates::TrieUpdates,
     walker::TrieWalker,
-    HashedPostState, StorageRoot, StorageRootError,
+    HashedPostState, StorageRoot,
 };
 use std::{collections::HashMap, sync::Arc};
 use thiserror::Error;

--- a/crates/trie-parallel/src/parallel_root.rs
+++ b/crates/trie-parallel/src/parallel_root.rs
@@ -2,6 +2,7 @@ use crate::{stats::ParallelTrieTracker, storage_root_targets::StorageRootTargets
 use alloy_rlp::{BufMut, Encodable};
 use rayon::prelude::*;
 use reth_db::database::Database;
+use reth_interfaces::trie::StorageRootError;
 use reth_primitives::{
     trie::{HashBuilder, Nibbles, TrieAccount},
     B256,
@@ -16,7 +17,7 @@ use reth_trie::{
     trie_cursor::TrieCursorFactory,
     updates::TrieUpdates,
     walker::TrieWalker,
-    HashedPostState, StorageRoot, StorageRootError,
+    HashedPostState, StorageRoot,
 };
 use std::collections::HashMap;
 use thiserror::Error;

--- a/crates/trie/src/lib.rs
+++ b/crates/trie/src/lib.rs
@@ -26,9 +26,6 @@ pub mod hashed_cursor;
 /// The trie walker for iterating over the trie nodes.
 pub mod walker;
 
-mod errors;
-pub use errors::*;
-
 /// The iterators for traversing existing intermediate hashes and updated trie leaves.
 pub mod node_iter;
 

--- a/crates/trie/src/proof.rs
+++ b/crates/trie/src/proof.rs
@@ -4,10 +4,10 @@ use crate::{
     prefix_set::PrefixSetMut,
     trie_cursor::{DatabaseAccountTrieCursor, DatabaseStorageTrieCursor},
     walker::TrieWalker,
-    StateRootError, StorageRootError,
 };
 use alloy_rlp::{BufMut, Encodable};
 use reth_db::{tables, transaction::DbTx};
+use reth_interfaces::trie::{StateRootError, StorageRootError};
 use reth_primitives::{
     constants::EMPTY_ROOT_HASH,
     keccak256,

--- a/crates/trie/src/state.rs
+++ b/crates/trie/src/state.rs
@@ -2,7 +2,7 @@ use crate::{
     hashed_cursor::HashedPostStateCursorFactory,
     prefix_set::{PrefixSetMut, TriePrefixSets},
     updates::TrieUpdates,
-    StateRoot, StateRootError,
+    StateRoot,
 };
 use reth_db::{
     cursor::DbCursorRO,
@@ -11,6 +11,7 @@ use reth_db::{
     transaction::DbTx,
     DatabaseError,
 };
+use reth_interfaces::trie::StateRootError;
 use reth_primitives::{
     keccak256, revm::compat::into_reth_acc, trie::Nibbles, Account, Address, BlockNumber, B256,
     U256,

--- a/crates/trie/src/trie.rs
+++ b/crates/trie/src/trie.rs
@@ -7,10 +7,10 @@ use crate::{
     trie_cursor::TrieCursorFactory,
     updates::{TrieKey, TrieOp, TrieUpdates},
     walker::TrieWalker,
-    StateRootError, StorageRootError,
 };
 use alloy_rlp::{BufMut, Encodable};
 use reth_db::transaction::DbTx;
+use reth_interfaces::trie::{StateRootError, StorageRootError};
 use reth_primitives::{
     constants::EMPTY_ROOT_HASH,
     keccak256,


### PR DESCRIPTION
This makes some of the blockchain tree result types more specific, using `CanonicalError` or `ProviderError` instead of `RethError`, which is often too general. This lets us remove some trivial `RethError` wraps and `if let RethError` statements.

This also moves the trie error to `reth_interfaces`, so it can be used in `BlockValidationError`.