### PR TITLE
fix: skip block tracing if empty

### DIFF
--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -79,6 +79,11 @@ where
         block_env: BlockEnv,
         opts: GethDebugTracingOptions,
     ) -> EthResult<Vec<TraceResult>> {
+        if transactions.is_empty() {
+            // nothing to trace
+            return Ok(Vec::new());
+        }
+
         // replay all transactions of the block
         let this = self.clone();
         self.inner

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -1058,6 +1058,11 @@ where
 
         let Some(block) = block else { return Ok(None) };
 
+        if block.body.is_empty() {
+            // nothing to trace
+            return Ok(Some(Vec::new()));
+        }
+
         // replay all transactions of the block
         self.spawn_tracing_task_with(move |this| {
             // we need to get the state of the parent block because we're replaying this block on


### PR DESCRIPTION
if there are no transactions in the block, there's nothing to trace, this fixes a bug where tracing the genesis block results in an error:

cast rpc debug_traceBlockByNumber "0x0"
(code: -32001, message: unknown block number, data: None)

because we need the parent state, which does not exist