### PR TITLE
fix: do not rlp encode extradata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6116,7 +6116,6 @@ dependencies = [
 name = "reth-node-core"
 version = "0.2.0-beta.3"
 dependencies = [
- "alloy-rlp",
  "assert_matches",
  "clap",
  "const-str",

--- a/crates/node-core/Cargo.toml
+++ b/crates/node-core/Cargo.toml
@@ -75,7 +75,6 @@ hyper.workspace = true
 tracing.workspace = true
 
 # crypto
-alloy-rlp.workspace = true
 secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery"] }
 
 # async

--- a/crates/node-core/src/args/payload_builder_args.rs
+++ b/crates/node-core/src/args/payload_builder_args.rs
@@ -89,7 +89,7 @@ impl TypedValueParser for ExtradataValueParser {
             return Err(clap::Error::raw(
                 clap::error::ErrorKind::InvalidValue,
                 format!(
-                    "Payload builder extradata size exceeds {MAXIMUM_EXTRA_DATA_SIZE}bytes limit"
+                    "Payload builder extradata size exceeds {MAXIMUM_EXTRA_DATA_SIZE}-byte limit"
                 ),
             ))
         }

--- a/crates/node-core/src/cli/config.rs
+++ b/crates/node-core/src/cli/config.rs
@@ -86,9 +86,9 @@ pub trait PayloadBuilderConfig {
     /// Block extra data set by the payload builder.
     fn extradata(&self) -> Cow<'_, str>;
 
-    /// Returns the rlp-encoded extradata bytes.
-    fn extradata_rlp_bytes(&self) -> Bytes {
-        alloy_rlp::encode(self.extradata().as_bytes()).into()
+    /// Returns the extradata as bytes.
+    fn extradata_bytes(&self) -> Bytes {
+        self.extradata().as_bytes().to_owned().into()
     }
 
     /// The interval at which the job should build a new payload after the last.

--- a/crates/node-core/src/cli/config.rs
+++ b/crates/node-core/src/cli/config.rs
@@ -88,7 +88,7 @@ pub trait PayloadBuilderConfig {
 
     /// Returns the extradata as bytes.
     fn extradata_bytes(&self) -> Bytes {
-        self.extradata().as_bytes().to_owned().into()
+        self.extradata().as_bytes().to_vec().into()
     }
 
     /// The interval at which the job should build a new payload after the last.

--- a/crates/node-ethereum/src/node.rs
+++ b/crates/node-ethereum/src/node.rs
@@ -158,7 +158,7 @@ where
             .interval(conf.interval())
             .deadline(conf.deadline())
             .max_payload_tasks(conf.max_payload_tasks())
-            .extradata(conf.extradata_rlp_bytes())
+            .extradata(conf.extradata_bytes())
             .max_gas_limit(conf.max_gas_limit());
 
         let payload_generator = BasicPayloadJobGenerator::with_builder(

--- a/examples/custom-node/src/main.rs
+++ b/examples/custom-node/src/main.rs
@@ -241,7 +241,7 @@ where
             .interval(conf.interval())
             .deadline(conf.deadline())
             .max_payload_tasks(conf.max_payload_tasks())
-            .extradata(conf.extradata_rlp_bytes())
+            .extradata(conf.extradata_bytes())
             .max_gas_limit(conf.max_gas_limit());
 
         let payload_generator = BasicPayloadJobGenerator::with_builder(

--- a/examples/custom-payload-builder/src/main.rs
+++ b/examples/custom-payload-builder/src/main.rs
@@ -47,7 +47,7 @@ where
             .interval(conf.interval())
             .deadline(conf.deadline())
             .max_payload_tasks(conf.max_payload_tasks())
-            .extradata(conf.extradata_rlp_bytes())
+            .extradata(conf.extradata_bytes())
             .max_gas_limit(conf.max_gas_limit());
 
         let payload_generator = EmptyBlockPayloadJobGenerator::with_builder(


### PR DESCRIPTION
Instead of RLP encoding the extradata string, just use the string bytes.

For one, the prefix will show up as a unknown character or a space:

![telegram-cloud-photo-size-1-5177298186308529445-y](https://github.com/paradigmxyz/reth/assets/95511699/bb8dfa2a-0909-4230-9d0f-bae5569979c3)

Also, if a user set extradata (via `--builder.extradata`) as a 32-byte string, it would be accepted but when encoded it would become a 33-byte string and would no longer be valid.