### PR TITLE
fix(cmd-p2p): split off `create_db` from `init_db`

### DIFF
--- a/bin/reth/src/commands/p2p/mod.rs
+++ b/bin/reth/src/commands/p2p/mod.rs
@@ -100,7 +100,7 @@ impl Command {
     /// Execute `p2p` command
     pub async fn execute(&self) -> eyre::Result<()> {
         let tempdir = tempfile::TempDir::new()?;
-        let noop_db = Arc::new(create_db(&tempdir.into_path(), self.db.database_args())?);
+        let noop_db = Arc::new(create_db(tempdir.into_path(), self.db.database_args())?);
 
         // add network name to data dir
         let data_dir = self.datadir.unwrap_or_chain_default(self.chain.chain);

--- a/bin/reth/src/commands/p2p/mod.rs
+++ b/bin/reth/src/commands/p2p/mod.rs
@@ -12,7 +12,7 @@ use crate::{
 use backon::{ConstantBuilder, Retryable};
 use clap::{Parser, Subcommand};
 use reth_config::Config;
-use reth_db::open_db;
+use reth_db::create_db;
 use reth_discv4::NatResolver;
 use reth_interfaces::p2p::bodies::client::BodiesClient;
 use reth_primitives::{BlockHashOrNumber, ChainSpec, NodeRecord};
@@ -100,7 +100,7 @@ impl Command {
     /// Execute `p2p` command
     pub async fn execute(&self) -> eyre::Result<()> {
         let tempdir = tempfile::TempDir::new()?;
-        let noop_db = Arc::new(open_db(&tempdir.into_path(), self.db.database_args())?);
+        let noop_db = Arc::new(create_db(&tempdir.into_path(), self.db.database_args())?);
 
         // add network name to data dir
         let data_dir = self.datadir.unwrap_or_chain_default(self.chain.chain);

--- a/crates/storage/db/src/lib.rs
+++ b/crates/storage/db/src/lib.rs
@@ -92,9 +92,9 @@ use crate::mdbx::DatabaseArguments;
 use eyre::WrapErr;
 use std::path::Path;
 
-/// Opens up an existing database or creates a new one at the specified path. Creates tables if
-/// necessary. Read/Write mode.
-pub fn init_db<P: AsRef<Path>>(path: P, args: DatabaseArguments) -> eyre::Result<DatabaseEnv> {
+/// Creates a new database at the specified path if it doesn't exist. Does NOT create tables. Check
+/// [`init_db`].
+pub fn create_db<P: AsRef<Path>>(path: P, args: DatabaseArguments) -> eyre::Result<DatabaseEnv> {
     use crate::version::{check_db_version_file, create_db_version_file, DatabaseVersionError};
 
     let rpath = path.as_ref();
@@ -109,11 +109,26 @@ pub fn init_db<P: AsRef<Path>>(path: P, args: DatabaseArguments) -> eyre::Result
             Err(err) => return Err(err.into()),
         }
     }
+
     #[cfg(feature = "mdbx")]
     {
-        let db = DatabaseEnv::open(rpath, DatabaseEnvKind::RW, args.clone())?;
+        Ok(DatabaseEnv::open(rpath, DatabaseEnvKind::RW, args)?)
+    }
+    #[cfg(not(feature = "mdbx"))]
+    {
+        unimplemented!();
+    }
+}
+
+/// Opens up an existing database or creates a new one at the specified path. Creates tables if
+/// necessary. Read/Write mode.
+pub fn init_db<P: AsRef<Path>>(path: P, args: DatabaseArguments) -> eyre::Result<DatabaseEnv> {
+    #[cfg(feature = "mdbx")]
+    {
+        let client_version = args.client_version().clone();
+        let db = create_db(path, args)?;
         db.create_tables()?;
-        db.record_client_version(args.client_version().clone())?;
+        db.record_client_version(client_version)?;
         Ok(db)
     }
     #[cfg(not(feature = "mdbx"))]


### PR DESCRIPTION
With https://github.com/paradigmxyz/reth/pull/7119, `open_db` assumes that the database is initialized with tables. That is not the case with `reth p2p` command, resulting in error.

Split the `create_db` logic from `init_db` and call `create_db` on `reth p2p` command