### PR TITLE
fix: configure global rayon pool to `available_parallelism() - 2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6088,6 +6088,7 @@ dependencies = [
  "eyre",
  "fdlimit",
  "futures",
+ "rayon",
  "reth-auto-seal-consensus",
  "reth-beacon-consensus",
  "reth-blockchain-tree",

--- a/crates/node-builder/Cargo.toml
+++ b/crates/node-builder/Cargo.toml
@@ -49,3 +49,4 @@ tokio = { workspace = true, features = [
 eyre.workspace = true
 fdlimit = "0.3.0"
 confy.workspace = true
+rayon.workspace = true


### PR DESCRIPTION
Configures the global rayon pool to `available_parallelism() - 2`, making sure we don't starve other jobs when doing heavy prolongued work

ref https://github.com/paradigmxyz/reth/issues/6888