### PR TITLE
chore: remove trusted setups

### DIFF
--- a/bin/reth/src/commands/node/mod.rs
+++ b/bin/reth/src/commands/node/mod.rs
@@ -279,7 +279,7 @@ mod tests {
         let cmd =
             NodeCommand::try_parse_args_from(["reth", "--config", "my/path/to/reth.toml"]).unwrap();
         // always store reth.toml in the data dir, not the chain specific data dir
-        let data_dir = cmd.datadir.unwrap_or_ch_default(cmd.chain.chain);
+        let data_dir = cmd.datadir.unwrap_or_chain_default(cmd.chain.chain);
         let config_path = cmd.config.unwrap_or_else(|| data_dir.config_path());
         assert_eq!(config_path, Path::new("my/path/to/reth.toml"));
 

--- a/bin/reth/src/commands/node/mod.rs
+++ b/bin/reth/src/commands/node/mod.rs
@@ -76,10 +76,6 @@ pub struct NodeCommand<Ext: clap::Args + fmt::Debug = NoArgs> {
     #[arg(long, conflicts_with = "instance", global = true)]
     pub with_unused_ports: bool,
 
-    /// Overrides the KZG trusted setup by reading from the supplied file.
-    #[arg(long, value_name = "PATH")]
-    pub trusted_setup_file: Option<PathBuf>,
-
     /// All networking related arguments
     #[command(flatten)]
     pub network: NetworkArgs,
@@ -150,7 +146,6 @@ impl<Ext: clap::Args + fmt::Debug> NodeCommand<Ext> {
             config,
             chain,
             metrics,
-            trusted_setup_file,
             instance,
             with_unused_ports,
             network,
@@ -170,7 +165,6 @@ impl<Ext: clap::Args + fmt::Debug> NodeCommand<Ext> {
             chain,
             metrics,
             instance,
-            trusted_setup_file,
             network,
             rpc,
             txpool,
@@ -285,7 +279,7 @@ mod tests {
         let cmd =
             NodeCommand::try_parse_args_from(["reth", "--config", "my/path/to/reth.toml"]).unwrap();
         // always store reth.toml in the data dir, not the chain specific data dir
-        let data_dir = cmd.datadir.unwrap_or_chain_default(cmd.chain.chain);
+        let data_dir = cmd.datadir.unwrap_or_ch_default(cmd.chain.chain);
         let config_path = cmd.config.unwrap_or_else(|| data_dir.config_path());
         assert_eq!(config_path, Path::new("my/path/to/reth.toml"));
 

--- a/crates/node-builder/src/builder.rs
+++ b/crates/node-builder/src/builder.rs
@@ -40,10 +40,7 @@ use reth_node_core::{
     primitives::{kzg::KzgSettings, Head},
     utils::write_peers_to_file,
 };
-use reth_primitives::{
-    constants::eip4844::{LoadKzgSettingsError, MAINNET_KZG_TRUSTED_SETUP},
-    format_ether, ChainSpec,
-};
+use reth_primitives::{constants::eip4844::MAINNET_KZG_TRUSTED_SETUP, format_ether, ChainSpec};
 use reth_provider::{providers::BlockchainProvider, ChainSpecProvider, ProviderFactory};
 use reth_prune::PrunerBuilder;
 use reth_revm::EvmProcessorFactory;
@@ -1095,16 +1092,9 @@ impl<Node: FullNodeTypes> BuilderContext<Node> {
         self.config().txpool.pool_config()
     }
 
-    /// Loads the trusted setup params from a given file path or falls back to
-    /// `MAINNET_KZG_TRUSTED_SETUP`.
+    /// Loads `MAINNET_KZG_TRUSTED_SETUP`.
     pub fn kzg_settings(&self) -> eyre::Result<Arc<KzgSettings>> {
-        if let Some(ref trusted_setup_file) = self.config().trusted_setup_file {
-            let trusted_setup = KzgSettings::load_trusted_setup_file(trusted_setup_file)
-                .map_err(LoadKzgSettingsError::KzgError)?;
-            Ok(Arc::new(trusted_setup))
-        } else {
-            Ok(Arc::clone(&MAINNET_KZG_TRUSTED_SETUP))
-        }
+        Ok(Arc::clone(&MAINNET_KZG_TRUSTED_SETUP))
     }
 
     /// Returns the config for payload building.


### PR DESCRIPTION
This PR closes #7266 

Since managing custom trusted setups is no longer desirable the support for this has been removed