### PR TITLE
fix: mandatory `to` for EIP-4844

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -466,7 +466,7 @@ mod tests {
             max_priority_fee_per_gas: 0x28f000fff,
             max_fee_per_blob_gas: 0x7,
             gas_limit: 10,
-            to: TransactionKind::Call(Address::default()),
+            to: Address::default(),
             value: U256::from(3_u64),
             input: Bytes::from(vec![1, 2]),
             access_list: Default::default(),

--- a/crates/primitives/src/revm/env.rs
+++ b/crates/primitives/src/revm/env.rs
@@ -269,10 +269,7 @@ where
             tx_env.gas_limit = tx.gas_limit;
             tx_env.gas_price = U256::from(tx.max_fee_per_gas);
             tx_env.gas_priority_fee = Some(U256::from(tx.max_priority_fee_per_gas));
-            tx_env.transact_to = match tx.to {
-                TransactionKind::Call(to) => TransactTo::Call(to),
-                TransactionKind::Create => TransactTo::create(),
-            };
+            tx_env.transact_to = TransactTo::Call(tx.to);
             tx_env.value = tx.value;
             tx_env.data = tx.input.clone();
             tx_env.chain_id = Some(tx.chain_id);

--- a/crates/primitives/src/transaction/eip4844.rs
+++ b/crates/primitives/src/transaction/eip4844.rs
@@ -1,7 +1,7 @@
 use super::access_list::AccessList;
 use crate::{
-    constants::eip4844::DATA_GAS_PER_BLOB, keccak256, Bytes, ChainId, Signature, TransactionKind,
-    TxType, B256, U256,
+    constants::eip4844::DATA_GAS_PER_BLOB, keccak256, Address, Bytes, ChainId, Signature, TxType,
+    B256, U256,
 };
 use alloy_rlp::{length_of_length, Decodable, Encodable, Header};
 use reth_codecs::{main_codec, Compact};
@@ -52,9 +52,8 @@ pub struct TxEip4844 {
     ///
     /// This is also known as `GasTipCap`
     pub max_priority_fee_per_gas: u128,
-    /// The 160-bit address of the message call’s recipient or, for a contract creation
-    /// transaction, ∅, used here to denote the only member of B0 ; formally Tt.
-    pub to: TransactionKind,
+    /// The 160-bit address of the message call’s recipient.
+    pub to: Address,
     /// A scalar value equal to the number of Wei to
     /// be transferred to the message call’s recipient or,
     /// in the case of contract creation, as an endowment
@@ -242,7 +241,7 @@ impl TxEip4844 {
         mem::size_of::<u64>() + // gas_limit
         mem::size_of::<u128>() + // max_fee_per_gas
         mem::size_of::<u128>() + // max_priority_fee_per_gas
-        self.to.size() + // to
+        mem::size_of::<Address>() + // to
         mem::size_of::<U256>() + // value
         self.access_list.size() + // access_list
         self.input.len() +  // input

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -2009,7 +2009,10 @@ mod tests {
         );
 
         let encoded = alloy_rlp::encode(signed_tx);
-        assert_eq!(hex!("a403e280808080809400000000000000000000000000000000000000008080c080c0808080"), encoded[..]);
+        assert_eq!(
+            hex!("a403e280808080809400000000000000000000000000000000000000008080c080c0808080"),
+            encoded[..]
+        );
         assert_eq!(MIN_LENGTH_EIP4844_TX_ENCODED, encoded.len());
 
         TransactionSigned::decode(&mut &encoded[..]).unwrap();

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -76,7 +76,7 @@ pub const MIN_LENGTH_EIP2930_TX_ENCODED: usize = 14;
 /// Minimum length of a rlp-encoded eip1559 transaction.
 pub const MIN_LENGTH_EIP1559_TX_ENCODED: usize = 15;
 /// Minimum length of a rlp-encoded eip4844 transaction.
-pub const MIN_LENGTH_EIP4844_TX_ENCODED: usize = 17;
+pub const MIN_LENGTH_EIP4844_TX_ENCODED: usize = 37;
 /// Minimum length of a rlp-encoded deposit transaction.
 #[cfg(feature = "optimism")]
 pub const MIN_LENGTH_DEPOSIT_TX_ENCODED: usize = 65;
@@ -2009,7 +2009,7 @@ mod tests {
         );
 
         let encoded = alloy_rlp::encode(signed_tx);
-        assert_eq!(hex!("9003ce8080808080808080c080c0808080"), encoded[..]);
+        assert_eq!(hex!("a403e280808080809400000000000000000000000000000000000000008080c080c0808080"), encoded[..]);
         assert_eq!(MIN_LENGTH_EIP4844_TX_ENCODED, encoded.len());
 
         TransactionSigned::decode(&mut &encoded[..]).unwrap();

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -173,14 +173,14 @@ impl Transaction {
 
     /// Gets the transaction's [`TransactionKind`], which is the address of the recipient or
     /// [`TransactionKind::Create`] if the transaction is a contract creation.
-    pub fn kind(&self) -> &TransactionKind {
+    pub fn kind(&self) -> TransactionKind {
         match self {
             Transaction::Legacy(TxLegacy { to, .. }) |
             Transaction::Eip2930(TxEip2930 { to, .. }) |
-            Transaction::Eip1559(TxEip1559 { to, .. }) |
-            Transaction::Eip4844(TxEip4844 { to, .. }) => to,
+            Transaction::Eip1559(TxEip1559 { to, .. }) => *to,
+            Transaction::Eip4844(TxEip4844 { to, .. }) => TransactionKind::Call(*to),
             #[cfg(feature = "optimism")]
-            Transaction::Deposit(TxDeposit { to, .. }) => to,
+            Transaction::Deposit(TxDeposit { to, .. }) => *to,
         }
     }
 

--- a/crates/rpc/rpc-types-compat/src/transaction/mod.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction/mod.rs
@@ -49,7 +49,7 @@ fn fill(
 
     let to = match signed_tx.kind() {
         PrimitiveTransactionKind::Create => None,
-        PrimitiveTransactionKind::Call(to) => Some(*to),
+        PrimitiveTransactionKind::Call(to) => Some(to),
     };
 
     #[allow(unreachable_patterns)]

--- a/crates/rpc/rpc-types-compat/src/transaction/typed.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction/typed.rs
@@ -47,7 +47,7 @@ pub fn to_primitive_transaction(
             gas_limit: tx.gas_limit.to(),
             max_fee_per_gas: tx.max_fee_per_gas.to(),
             max_priority_fee_per_gas: tx.max_priority_fee_per_gas.to(),
-            to: to_primitive_transaction_kind(tx.kind),
+            to: tx.to,
             value: tx.value,
             access_list: tx.access_list.into(),
             blob_versioned_hashes: tx.blob_versioned_hashes,

--- a/crates/rpc/rpc-types/src/eth/transaction/typed.rs
+++ b/crates/rpc/rpc-types/src/eth/transaction/typed.rs
@@ -102,8 +102,8 @@ pub struct EIP4844TransactionRequest {
     pub max_fee_per_gas: U256,
     /// The gas limit for the transaction
     pub gas_limit: U256,
-    /// The kind of transaction (e.g., Call, Create)
-    pub kind: TransactionKind,
+    /// The 160-bit address of the message call’s recipient.
+    pub to: Address,
     /// The value of the transaction
     pub value: U256,
     /// The input data for the transaction

--- a/crates/transaction-pool/src/test_utils/gen.rs
+++ b/crates/transaction-pool/src/test_utils/gen.rs
@@ -93,7 +93,8 @@ impl<R: Rng> TransactionGenerator<R> {
 
     /// Creates a new transaction with a random signer
     pub fn gen_eip4844(&mut self) -> TransactionSigned {
-        self.transaction().into_eip4844()
+        // `to` is required for EIP-4844
+        self.transaction().to(Default::default()).into_eip4844()
     }
 
     /// Generates and returns a pooled EIP-1559 transaction with a random signer.

--- a/crates/transaction-pool/src/test_utils/gen.rs
+++ b/crates/transaction-pool/src/test_utils/gen.rs
@@ -182,7 +182,7 @@ impl TransactionBuilder {
                 gas_limit: self.gas_limit,
                 max_fee_per_gas: self.max_fee_per_gas,
                 max_priority_fee_per_gas: self.max_priority_fee_per_gas,
-                to: self.to,
+                to: self.to.to().expect("EIP4844 tx must have `to`"),
                 value: self.value,
                 access_list: self.access_list,
                 input: self.input,

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -154,7 +154,7 @@ pub enum MockTransaction {
         /// The gas limit for the transaction.
         gas_limit: u64,
         /// The transaction's destination.
-        to: TransactionKind,
+        to: Address,
         /// The value of the transaction.
         value: U256,
         /// The access list associated with the transaction.
@@ -246,7 +246,7 @@ impl MockTransaction {
             max_priority_fee_per_gas: MIN_PROTOCOL_BASE_FEE as u128,
             max_fee_per_blob_gas: DATA_GAS_PER_BLOB as u128,
             gas_limit: 0,
-            to: TransactionKind::Call(Address::random()),
+            to: Address::random(),
             value: Default::default(),
             input: Bytes::new(),
             accesslist: Default::default(),
@@ -670,12 +670,12 @@ impl PoolTransaction for MockTransaction {
     }
 
     /// Returns the transaction kind associated with the transaction.
-    fn kind(&self) -> &TransactionKind {
+    fn kind(&self) -> TransactionKind {
         match self {
             MockTransaction::Legacy { to, .. } |
             MockTransaction::Eip1559 { to, .. } |
-            MockTransaction::Eip4844 { to, .. } |
-            MockTransaction::Eip2930 { to, .. } => to,
+            MockTransaction::Eip2930 { to, .. } => *to,
+            MockTransaction::Eip4844 { to, .. } => TransactionKind::Call(*to),
         }
     }
 

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -812,12 +812,12 @@ pub trait PoolTransaction:
 
     /// Returns the transaction's [`TransactionKind`], which is the address of the recipient or
     /// [`TransactionKind::Create`] if the transaction is a contract creation.
-    fn kind(&self) -> &TransactionKind;
+    fn kind(&self) -> TransactionKind;
 
     /// Returns the recipient of the transaction if it is not a [TransactionKind::Create]
     /// transaction.
     fn to(&self) -> Option<Address> {
-        (*self.kind()).to()
+        self.kind().to()
     }
 
     /// Returns the input data of this transaction.
@@ -1057,7 +1057,7 @@ impl PoolTransaction for EthPooledTransaction {
 
     /// Returns the transaction's [`TransactionKind`], which is the address of the recipient or
     /// [`TransactionKind::Create`] if the transaction is a contract creation.
-    fn kind(&self) -> &TransactionKind {
+    fn kind(&self) -> TransactionKind {
         self.transaction.kind()
     }
 

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -695,7 +695,7 @@ pub fn ensure_intrinsic_gas<T: PoolTransaction>(
     if transaction.gas_limit() <
         calculate_intrinsic_gas_after_merge(
             transaction.input(),
-            transaction.kind(),
+            &transaction.kind(),
             &access_list,
             is_shanghai,
         )


### PR DESCRIPTION
Closes #7273

Changes `TransactionKind` to `Address`

Currently `EthApi::send_transaction` will throw `ConflictingFeeFieldsInRequest` not only in case of conflicting fee fields but also when blob transaction is missing blob fields or `to`, perhaps this error should be more specific?