### PR TITLE
fix: ignore BlockHashNotFoundInChain error for unexpected canonical error log

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1431,12 +1431,19 @@ where
                         if let Err((hash, error)) =
                             self.try_make_sync_target_canonical(downloaded_num_hash)
                         {
-                            tracing::error!(
-                                target: "consensus::engine",
-                                "Unexpected error while making sync target canonical: {:?}, {:?}",
+                            if !matches!(
                                 error,
-                                hash
-                            )
+                                CanonicalError::BlockchainTree(
+                                    BlockchainTreeError::BlockHashNotFoundInChain { .. }
+                                )
+                            ) {
+                                tracing::error!(
+                                    target: "consensus::engine",
+                                    "Unexpected error while making sync target canonical: {:?}, {:?}",
+                                    error,
+                                    hash
+                                )
+                            }
                         }
                     }
                     InsertPayloadOk::Inserted(BlockStatus::Disconnected {

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1437,12 +1437,16 @@ where
                                     BlockchainTreeError::BlockHashNotFoundInChain { .. }
                                 )
                             ) {
-                                tracing::error!(
-                                    target: "consensus::engine",
-                                    "Unexpected error while making sync target canonical: {:?}, {:?}",
-                                    error,
-                                    hash
-                                )
+                                if error.is_fatal() {
+                                    error!(target: "consensus::engine", %error, "Encountered fatal error while making sync target canonical: {:?}, {:?}", error, hash);
+                                } else {
+                                    debug!(
+                                        target: "consensus::engine",
+                                        "Unexpected error while making sync target canonical: {:?}, {:?}",
+                                        error,
+                                        hash
+                                    )
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Checking this error and logging it led to some unintended error logs:
```
2024-03-21T21:06:40.980383Z ERROR Unexpected error while making sync target canonical: BlockchainTree(BlockHashNotFoundInChain { block_hash: 0x2060ae79f50df847d62c6a7a5502ccb3bcc5090fe56f5ea6c40406b8495b4bc2 }), 0x2060ae79f50df847d62c6a7a5502ccb3bcc5090fe56f5ea6c40406b8495b4bc2
```

This now only logs when the error is __not__ `BlockHashNotFoundInChain`.

Fixes #7289 