### PR TITLE
fix: check against last block number

### DIFF
--- a/crates/storage/provider/src/providers/consistent_view.rs
+++ b/crates/storage/provider/src/providers/consistent_view.rs
@@ -65,7 +65,7 @@ where
             .into())
         }
 
-        let best_block_number = provider_ro.best_block_number()?;
+        let best_block_number = provider_ro.last_block_number()?;
         if last_entry.map(|(number, _)| number).unwrap_or_default() != best_block_number {
             return Err(ConsistentViewError::Syncing(best_block_number).into())
         }


### PR DESCRIPTION
> Failed to insert downloaded block err=Failed to insert block (hash=0x7f8427081fa75f06556c91976627869908fde6ba84a0c45fdbe6fafa7af03bb7, number=1189128, parent_hash=0x662d77b69e51b41b2bedd0b55290025439e436319e13ee9808bf77baf10fdefe): failed to initialize consistent view: node is syncing. best block: 1189127

this fixes a bug where we were unable to process blocks in live sync.

best block number uses the stage checkpoint.

this might be indicative of another issue.

The ambiguity between last and best block needs a closer look