### PR TITLE
fix: validate empty item in p2p start_send

### DIFF
--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -581,6 +581,11 @@ where
             })
         }
 
+        if item.is_empty() {
+            // empty messages are not allowed
+            return Err(P2PStreamError::EmptyProtocolMessage)
+        }
+
         // ensure we have free capacity
         if !self.has_outgoing_capacity() {
             return Err(P2PStreamError::SendBufferFull)


### PR DESCRIPTION
Fixes #7280
I'm using an existing error, but I don't know if we need a new error value for this check