### PR TITLE
fix: fix consistency check against headers table

### DIFF
--- a/crates/interfaces/src/provider.rs
+++ b/crates/interfaces/src/provider.rs
@@ -164,7 +164,7 @@ pub enum ConsistentViewError {
     #[error("inconsistent database state: {tip:?}")]
     Inconsistent {
         /// The tip diff.
-        tip: GotExpected<Option<B256>>,
+        tip: GotExpected<Option<(u64, B256)>>,
     },
 }
 


### PR DESCRIPTION
the last entry in the headers table can be None, if pruned, whereas the best block tracks the state we synced to.

so the unwrap_or_default will fail if the headers table is fully pruned.


needs more docs if that's the proper fix 