### PR TITLE
chore: make Session established log debug

### DIFF
--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -663,7 +663,7 @@ where
             } => {
                 let total_active = self.num_active_peers.fetch_add(1, Ordering::Relaxed) + 1;
                 self.metrics.connected_peers.set(total_active as f64);
-                trace!(
+                debug!(
                     target: "net",
                     ?remote_addr,
                     %client_version,


### PR DESCRIPTION
We have debug logs for session disconnects, but none for session established. This would make any session established addresses visible in debug logs.