### PR TITLE
fix: Returns an error if multiplex message is empty

### DIFF
--- a/crates/net/eth-wire/src/multiplex.rs
+++ b/crates/net/eth-wire/src/multiplex.rs
@@ -166,7 +166,10 @@ impl<St> RlpxProtocolMultiplexer<St> {
             tokio::select! {
                 Some(Ok(msg)) = self.inner.conn.next() => {
                     // Ensure the message belongs to the primary protocol
-                    let offset = msg[0];
+                    let offset = match msg.get(0) {
+                        Some(&byte) => byte,
+                        None => return Err(P2PStreamError::EmptyProtocolMessage.into())
+                    };
                     if let Some(cap) = self.shared_capabilities().find_by_relative_offset(offset).cloned() {
                             if cap == shared_cap {
                                 // delegate to primary
@@ -518,7 +521,14 @@ where
                 match this.inner.conn.poll_next_unpin(cx) {
                     Poll::Ready(Some(Ok(msg))) => {
                         delegated = true;
-                        let offset = msg[0];
+                        let offset = match msg.get(0) {
+                            Some(&byte) => byte,
+                            None => {
+                                return Poll::Ready(Some(Err(
+                                    P2PStreamError::EmptyProtocolMessage.into()
+                                )))
+                            }
+                        };
                         // delegate the multiplexed message to the correct protocol
                         if let Some(cap) =
                             this.inner.conn.shared_capabilities().find_by_relative_offset(offset)

--- a/crates/net/eth-wire/src/multiplex.rs
+++ b/crates/net/eth-wire/src/multiplex.rs
@@ -166,7 +166,7 @@ impl<St> RlpxProtocolMultiplexer<St> {
             tokio::select! {
                 Some(Ok(msg)) = self.inner.conn.next() => {
                     // Ensure the message belongs to the primary protocol
-                    let Some(&offset) = msg.first()
+                    let Some(offset) = msg.first().copied()
                     else {
                         return Err(P2PStreamError::EmptyProtocolMessage.into())
                     };
@@ -521,7 +521,7 @@ where
                 match this.inner.conn.poll_next_unpin(cx) {
                     Poll::Ready(Some(Ok(msg))) => {
                         delegated = true;
-                        let Some(&offset) = msg.first() else {
+                        let Some(offset) = msg.first().copied() else {
                             return Poll::Ready(Some(Err(
                                 P2PStreamError::EmptyProtocolMessage.into()
                             )))


### PR DESCRIPTION
Fixes #7281

Don't know if I should have defined a new error for this.