### PR TITLE
fix: race condition concurrent in and out from same peer

### DIFF
--- a/crates/net/network-api/src/reputation.rs
+++ b/crates/net/network-api/src/reputation.rs
@@ -40,8 +40,13 @@ pub enum ReputationChangeKind {
 }
 
 impl ReputationChangeKind {
-    /// Returns true if the reputation change is a reset.
+    /// Returns true if the reputation change is a [ReputationChangeKind::Reset].
     pub fn is_reset(&self) -> bool {
         matches!(self, Self::Reset)
+    }
+
+    /// Returns true if the reputation change is [ReputationChangeKind::Dropped].
+    pub fn is_dropped(&self) -> bool {
+        matches!(self, Self::Dropped)
     }
 }


### PR DESCRIPTION
this may be the root cause of https://github.com/paradigmxyz/reth/issues/7302

This fixes a problem when we dial a peer and also accept a connection from that peer at the same time.

If the outgoing connection attempt resulted in an error, we did not properly adjust the outgoing pending counter.

This fix handles the case by, adjusting pending out on incoming connection.
check on outgoing error if the peer is connected

FYI @geomad