### PR TITLE
feat(reth_db/mdbx): fix API regression in `DatabaseArguments`

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -58,7 +58,7 @@ impl DatabaseEnvKind {
 }
 
 /// Arguments for database initialization.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct DatabaseArguments {
     /// Client version that accesses the database.
     client_version: ClientVersion,

--- a/examples/db-access.rs
+++ b/examples/db-access.rs
@@ -1,4 +1,4 @@
-use reth_db::{mdbx::DatabaseArguments, models::client_version::ClientVersion, open_db_read_only};
+use reth_db::open_db_read_only;
 use reth_primitives::{Address, ChainSpecBuilder, B256};
 use reth_provider::{
     AccountReader, BlockReader, BlockSource, HeaderProvider, ProviderFactory, ReceiptProvider,
@@ -19,10 +19,7 @@ fn main() -> eyre::Result<()> {
     //  doing in 2 steps.
     let db_path = std::env::var("RETH_DB_PATH")?;
     let db_path = Path::new(&db_path);
-    let db = open_db_read_only(
-        db_path.join("db").as_path(),
-        DatabaseArguments::new(ClientVersion::default()),
-    )?;
+    let db = open_db_read_only(db_path.join("db").as_path(), Default::default())?;
 
     // Instantiate a provider factory for Ethereum mainnet using the provided DB.
     // TODO: Should the DB version include the spec so that you do not need to specify it here?


### PR DESCRIPTION
Re-added `Default` trait to `DatabaseArguments` that got lost in #7119.

This allows simpler db opening again and reverts this small and seemingly unnecessary API change:

```diff
open_db_read_only(
     ...
-    DatabaseArguments::new(ClientVersion::default()),
+    Default::default()
);
```