### PR TITLE
fix(provider): consider static files in last block num/hash lookups

### DIFF
--- a/crates/interfaces/src/provider.rs
+++ b/crates/interfaces/src/provider.rs
@@ -158,8 +158,11 @@ pub struct RootMismatch {
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 pub enum ConsistentViewError {
     /// Error thrown on attempt to initialize provider while node is still syncing.
-    #[error("node is syncing. best block: {0}")]
-    Syncing(BlockNumber),
+    #[error("node is syncing. best block: {best_block:?}")]
+    Syncing {
+        /// Best block diff.
+        best_block: GotExpected<BlockNumber>,
+    },
     /// Error thrown on inconsistent database view.
     #[error("inconsistent database state: {tip:?}")]
     Inconsistent {

--- a/crates/storage/provider/src/providers/consistent_view.rs
+++ b/crates/storage/provider/src/providers/consistent_view.rs
@@ -60,7 +60,10 @@ where
 
         let best_block_number = provider_ro.best_block_number()?;
         if last_num != best_block_number {
-            return Err(ConsistentViewError::Syncing(best_block_number).into())
+            return Err(ConsistentViewError::Syncing {
+                best_block: GotExpected { got: best_block_number, expected: last_num },
+            }
+            .into())
         }
 
         Ok(provider_ro)

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1219,13 +1219,15 @@ impl<TX: DbTx> BlockNumReader for DatabaseProvider<TX> {
     }
 
     fn last_block_number(&self) -> ProviderResult<BlockNumber> {
-        Ok(match self.tx.cursor_read::<tables::CanonicalHeaders>()?.last()? {
-            Some((num, _)) => num,
-            None => self
-                .static_file_provider
-                .get_highest_static_file_block(StaticFileSegment::Headers)
-                .unwrap_or_default(),
-        })
+        Ok(self
+            .tx
+            .cursor_read::<tables::CanonicalHeaders>()?
+            .last()?
+            .map(|(num, _)| num)
+            .max(
+                self.static_file_provider.get_highest_static_file_block(StaticFileSegment::Headers),
+            )
+            .unwrap_or_default())
     }
 
     fn block_number(&self, hash: B256) -> ProviderResult<Option<BlockNumber>> {


### PR DESCRIPTION
## Description

During the transition to live sync, it might be the case that there is no header present in the database. This behavior makes the implementation of `last_block_number` and consistency view checks broken.