### PR TITLE
perf: rm header lookup in feeHistory

### DIFF
--- a/crates/rpc/rpc/src/eth/api/fee_history.rs
+++ b/crates/rpc/rpc/src/eth/api/fee_history.rs
@@ -7,8 +7,9 @@ use futures::{
 };
 use metrics::atomics::AtomicU64;
 use reth_primitives::{
+    basefee::calculate_next_block_base_fee,
     eip4844::{calc_blob_gasprice, calculate_excess_blob_gas},
-    Receipt, SealedBlock, TransactionSigned, B256, U256,
+    ChainSpec, Receipt, SealedBlock, TransactionSigned, B256, U256,
 };
 use reth_provider::{BlockReaderIdExt, CanonStateNotification, ChainSpecProvider};
 use reth_rpc_types::TxGasAndReward;
@@ -326,7 +327,9 @@ pub struct FeeHistoryEntry {
     /// For pre EIP-4844 equals to zero.
     pub base_fee_per_blob_gas: Option<u128>,
     /// Blob gas used ratio for this block.
-    /// Calculated as the ratio pf gasUsed and gasLimit.
+    ///
+    /// Calculated as the ratio pf blob gasUsed and the available blob data gas per block.
+    /// Will be zero if no blob gas was used or pre EIP-4844.
     pub blob_gas_used_ratio: f64,
     /// The excess blob gas of the block.
     pub excess_blob_gas: Option<u64>,
@@ -341,6 +344,8 @@ pub struct FeeHistoryEntry {
     pub header_hash: B256,
     /// Approximated rewards for the configured percentiles.
     pub rewards: Vec<U256>,
+    /// The timestamp of the block.
+    pub timestamp: u64,
 }
 
 impl FeeHistoryEntry {
@@ -360,7 +365,18 @@ impl FeeHistoryEntry {
             header_hash: block.hash(),
             gas_limit: block.gas_limit,
             rewards: Vec::new(),
+            timestamp: block.timestamp,
         }
+    }
+
+    /// Returns the base fee for the next block according to the EIP-1559 spec.
+    pub fn next_block_base_fee(&self, chain_spec: &ChainSpec) -> u64 {
+        calculate_next_block_base_fee(
+            self.gas_used,
+            self.gas_limit,
+            self.base_fee_per_gas,
+            chain_spec.base_fee_params(self.timestamp),
+        )
     }
 
     /// Returns the blob fee for the next block according to the EIP-4844 spec.

--- a/crates/rpc/rpc/src/eth/api/fee_history.rs
+++ b/crates/rpc/rpc/src/eth/api/fee_history.rs
@@ -328,7 +328,7 @@ pub struct FeeHistoryEntry {
     pub base_fee_per_blob_gas: Option<u128>,
     /// Blob gas used ratio for this block.
     ///
-    /// Calculated as the ratio pf blob gasUsed and the available blob data gas per block.
+    /// Calculated as the ratio of blob gas used and the available blob data gas per block.
     /// Will be zero if no blob gas was used or pre EIP-4844.
     pub blob_gas_used_ratio: f64,
     /// The excess blob gas of the block.

--- a/crates/rpc/rpc/src/eth/api/fees.rs
+++ b/crates/rpc/rpc/src/eth/api/fees.rs
@@ -140,20 +140,10 @@ where
             }
             let last_entry = fee_entries.last().expect("is not empty");
 
-            let last_entry_timestamp = self
-                .provider()
-                .header_by_hash_or_number(last_entry.header_hash.into())?
-                .map(|h| h.timestamp)
-                .unwrap_or_default();
-
             // Also need to include the `base_fee_per_gas` and `base_fee_per_blob_gas` for the next
             // block
-            base_fee_per_gas.push(U256::from(calculate_next_block_base_fee(
-                last_entry.gas_used,
-                last_entry.gas_limit,
-                last_entry.base_fee_per_gas,
-                self.provider().chain_spec().base_fee_params(last_entry_timestamp),
-            )));
+            base_fee_per_gas
+                .push(U256::from(last_entry.next_block_base_fee(&self.provider().chain_spec())));
 
             base_fee_per_blob_gas
                 .push(U256::from(last_entry.next_block_blob_fee().unwrap_or_default()));


### PR DESCRIPTION
by caching the timestamp, we can get rid of the disk lookup, 
this increases cache size by `1024 * u64` but is preferable to having a header lookup