### PR TITLE
fix: some minor nits in txpool code

### DIFF
--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -478,7 +478,7 @@ where
                     this.pinger.on_pong()?
                 }
                 _ if id == P2PMessageID::Disconnect as u8 => {
-                    // At this point, the `decempres_buf` contains the snappy decompressed
+                    // At this point, the `decompress_buf` contains the snappy decompressed
                     // disconnect message.
                     //
                     // It's possible we already tried to RLP decode this, but it was snappy

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -165,7 +165,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
 
     /// Updates the pool with the new blob fee. Removes
     /// from the subpool all transactions and their dependents that no longer satisfy the given
-    /// base fee (`tx.max_blob_fee < blob_fee`).
+    /// blob fee (`tx.max_blob_fee < blob_fee`).
     ///
     /// Note: the transactions are not returned in a particular order.
     ///

--- a/crates/transaction-pool/src/pool/state.rs
+++ b/crates/transaction-pool/src/pool/state.rs
@@ -3,13 +3,13 @@ bitflags::bitflags! {
     ///
     /// This mirrors [erigon's ephemeral state field](https://github.com/ledgerwatch/erigon/wiki/Transaction-Pool-Design#ordering-function).
     ///
-    /// The [SubPool] the transaction belongs to is derived from it's state and determined by the following sequential checks:
+    /// The [SubPool] the transaction belongs to is derived from its state and determined by the following sequential checks:
     ///
     /// - If it satisfies the [TxState::PENDING_POOL_BITS] it belongs in the pending sub-pool: [SubPool::Pending].
     /// - If it is an EIP-4844 blob transaction it belongs in the blob sub-pool: [SubPool::Blob].
-    /// -  If it satisfies the [TxState::BASE_FEE_POOL_BITS] it belongs in the base fee sub-pool: [SubPool::BaseFee].
+    /// - If it satisfies the [TxState::BASE_FEE_POOL_BITS] it belongs in the base fee sub-pool: [SubPool::BaseFee].
     ///
-    /// Otherwise it belongs in the queued sub-pool: [SubPool::Queued].
+    /// Otherwise, it belongs in the queued sub-pool: [SubPool::Queued].
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, PartialOrd, Ord)]
     pub(crate) struct TxState: u8 {
         /// Set to `1` if all ancestor transactions are pending.
@@ -21,18 +21,17 @@ bitflags::bitflags! {
         /// Set to `1` if the sender's balance can cover the maximum cost for this transaction (`feeCap * gasLimit + value`).
         /// This includes cumulative costs of prior transactions, which ensures that the sender has enough funds for all max cost of prior transactions.
         const ENOUGH_BALANCE = 0b00100000;
-        /// Bit set to true if the transaction has a lower gas limit than the block's gas limit
+        /// Bit set to true if the transaction has a lower gas limit than the block's gas limit.
         const NOT_TOO_MUCH_GAS = 0b00010000;
         /// Covers the Dynamic fee requirement.
         ///
-        /// Set to 1 if `maxBlobFeePerGas` of the transaction meets the requirement of the pending block.
+        /// Set to 1 if `maxFeePerGas` of the transaction meets the requirement of the pending block.
         const ENOUGH_FEE_CAP_BLOCK = 0b00001000;
-        /// Covers the dynamic blob fee requirement, only relevant for EIP-4844 blob transactions
+        /// Covers the dynamic blob fee requirement, only relevant for EIP-4844 blob transactions.
         ///
-        /// Set to 1 if `maxBlobFeePer` of the transaction meets the requirement of the pending block.
+        /// Set to 1 if `maxBlobFeePerGas` of the transaction meets the requirement of the pending block.
         const ENOUGH_BLOB_FEE_CAP_BLOCK = 0b00000100;
-
-        /// Marks whether the transaction is a blob transaction
+        /// Marks whether the transaction is a blob transaction.
         ///
         /// We track this as part of the state for simplicity, since blob transactions are handled differently and are mutually exclusive with normal transactions.
         const BLOB_TRANSACTION = 0b00000010;

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -147,11 +147,11 @@ impl<T: TransactionOrdering> TxPool<T> {
         std::mem::swap(&mut self.all_transactions.pending_fees.blob_fee, &mut pending_blob_fee);
         match (self.all_transactions.pending_fees.blob_fee.cmp(&pending_blob_fee), base_fee_update)
         {
-            (Ordering::Equal, Ordering::Equal) => {
+            (Ordering::Equal, Ordering::Equal) |
+            (Ordering::Equal, Ordering::Greater) => {
                 // fee unchanged, nothing to update
             }
             (Ordering::Greater, Ordering::Equal) |
-            (Ordering::Equal, Ordering::Greater) |
             (Ordering::Greater, Ordering::Greater) => {
                 // increased blob fee: recheck pending pool and remove all that are no longer valid
                 let removed =
@@ -161,7 +161,7 @@ impl<T: TransactionOrdering> TxPool<T> {
                         let tx =
                             self.all_transactions.txs.get_mut(tx.id()).expect("tx exists in set");
 
-                        // we unset the blob fee cap block flag, if the base fee is too high now
+                        // the blob fee is too high now, unset the blob fee cap block flag
                         tx.state.remove(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK);
                         tx.subpool = tx.state.into();
                         tx.subpool
@@ -169,42 +169,8 @@ impl<T: TransactionOrdering> TxPool<T> {
                     self.add_transaction_to_subpool(to, tx);
                 }
             }
-            (Ordering::Less, Ordering::Equal) | (_, Ordering::Less) => {
-                // decreased blob fee or base fee: recheck blob pool and promote all that are now
-                // valid
-                let removed =
-                    self.blob_pool.enforce_pending_fees(&self.all_transactions.pending_fees);
-                for tx in removed {
-                    let to = {
-                        let tx =
-                            self.all_transactions.txs.get_mut(tx.id()).expect("tx exists in set");
-                        tx.state.insert(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK);
-                        tx.state.insert(TxState::ENOUGH_FEE_CAP_BLOCK);
-                        tx.subpool = tx.state.into();
-                        tx.subpool
-                    };
-                    self.add_transaction_to_subpool(to, tx);
-                }
-            }
-            (Ordering::Less, Ordering::Greater) => {
-                // increased blob fee: recheck pending pool and remove all that are no longer valid
-                let removed =
-                    self.pending_pool.update_blob_fee(self.all_transactions.pending_fees.blob_fee);
-                for tx in removed {
-                    let to = {
-                        let tx =
-                            self.all_transactions.txs.get_mut(tx.id()).expect("tx exists in set");
-
-                        // we unset the blob fee cap block flag, if the base fee is too high now
-                        tx.state.remove(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK);
-                        tx.subpool = tx.state.into();
-                        tx.subpool
-                    };
-                    self.add_transaction_to_subpool(to, tx);
-                }
-
-                // decreased blob fee or base fee: recheck blob pool and promote all that are now
-                // valid
+            (_, _) => {
+                // decreased blob/base fee: recheck blob pool and promote all that are now valid
                 let removed =
                     self.blob_pool.enforce_pending_fees(&self.all_transactions.pending_fees);
                 for tx in removed {
@@ -1480,13 +1446,13 @@ impl<T: PoolTransaction> AllTransactions<T> {
     ///
     /// The pool enforces exclusivity of eip-4844 blob vs non-blob transactions on a per sender
     /// basis:
-    ///   - If the pool already includes a blob transaction from the `transaction`'s sender, then
-    ///     the  `transaction` must also be a blob transaction
+    ///  - If the pool already includes a blob transaction from the `transaction`'s sender, then
+    ///    the `transaction` must also be a blob transaction
     ///  - If the pool already includes a non-blob transaction from the `transaction`'s sender, then
-    ///    the  `transaction` must _not_ be a blob transaction.
+    ///    the `transaction` must _not_ be a blob transaction.
     ///
     /// In other words, the presence of blob transactions exclude non-blob transactions and vice
-    /// versa:
+    /// versa.
     ///
     /// ## Replacements
     ///
@@ -1602,7 +1568,6 @@ impl<T: PoolTransaction> AllTransactions<T> {
             let mut next_nonce = on_chain_id.nonce;
 
             // We need to find out if the next transaction of the sender is considered pending
-            //
             let mut has_parked_ancestor = if ancestor.is_none() {
                 // the new transaction is the next one
                 false

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -167,7 +167,7 @@ impl<T: TransactionOrdering> TxPool<T> {
                     self.add_transaction_to_subpool(to, tx);
                 }
             }
-            (_, _) => {
+            (Ordering::Less, _) | (_, Ordering::Less) => {
                 // decreased blob/base fee: recheck blob pool and promote all that are now valid
                 let removed =
                     self.blob_pool.enforce_pending_fees(&self.all_transactions.pending_fees);

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -147,12 +147,10 @@ impl<T: TransactionOrdering> TxPool<T> {
         std::mem::swap(&mut self.all_transactions.pending_fees.blob_fee, &mut pending_blob_fee);
         match (self.all_transactions.pending_fees.blob_fee.cmp(&pending_blob_fee), base_fee_update)
         {
-            (Ordering::Equal, Ordering::Equal) |
-            (Ordering::Equal, Ordering::Greater) => {
+            (Ordering::Equal, Ordering::Equal) | (Ordering::Equal, Ordering::Greater) => {
                 // fee unchanged, nothing to update
             }
-            (Ordering::Greater, Ordering::Equal) |
-            (Ordering::Greater, Ordering::Greater) => {
+            (Ordering::Greater, Ordering::Equal) | (Ordering::Greater, Ordering::Greater) => {
                 // increased blob fee: recheck pending pool and remove all that are no longer valid
                 let removed =
                     self.pending_pool.update_blob_fee(self.all_transactions.pending_fees.blob_fee);
@@ -1446,8 +1444,8 @@ impl<T: PoolTransaction> AllTransactions<T> {
     ///
     /// The pool enforces exclusivity of eip-4844 blob vs non-blob transactions on a per sender
     /// basis:
-    ///  - If the pool already includes a blob transaction from the `transaction`'s sender, then
-    ///    the `transaction` must also be a blob transaction
+    ///  - If the pool already includes a blob transaction from the `transaction`'s sender, then the
+    ///    `transaction` must also be a blob transaction
     ///  - If the pool already includes a non-blob transaction from the `transaction`'s sender, then
     ///    the `transaction` must _not_ be a blob transaction.
     ///


### PR DESCRIPTION
* Fix some minor typos & spacing issues.
* Simplify `update_blob_fee` some.
  * In the `(Ordering::Equal, Ordering::Greater)` case, calling `update_blob_fee(blob_fee)` is unnecessary.
  * In the `(Ordering::Less, Ordering::Greater)` case, `update_blob_fee` shouldn't remove anything.
    * With that removed, we can join these two blocks of code.