### PR TITLE
fix: use root_with_progress for final merkle range

### DIFF
--- a/crates/stages/src/stages/merkle.rs
+++ b/crates/stages/src/stages/merkle.rs
@@ -225,8 +225,10 @@ impl<DB: Database> Stage<DB> for MerkleStage {
                 }
             }
         } else {
-            let mut entities_checkpoint =
-                checkpoint.as_ref().filter(|c| c.target_block == to_block).and_then(|checkpoint| {
+            let mut entities_checkpoint = checkpoint
+                .as_ref()
+                .filter(|c| c.target_block == to_block)
+                .and_then(|checkpoint| {
                     debug!(
                         target: "sync::stages::merkle::exec",
                         current = ?current_block_number,
@@ -236,13 +238,13 @@ impl<DB: Database> Stage<DB> for MerkleStage {
                     );
 
                     input.checkpoint().entities_stage_checkpoint()
-            })
-            .unwrap_or(EntitiesCheckpoint {
-                processed: 0,
-                total: (provider.count_entries::<tables::HashedAccounts>()? +
-                    provider.count_entries::<tables::HashedStorages>()?)
-                    as u64,
-            });
+                })
+                .unwrap_or(EntitiesCheckpoint {
+                    processed: 0,
+                    total: (provider.count_entries::<tables::HashedAccounts>()? +
+                        provider.count_entries::<tables::HashedStorages>()?)
+                        as u64,
+                });
 
             let progress = StateRoot::from_tx(provider.tx_ref())
                 .with_intermediate_state(checkpoint.map(IntermediateStateRootState::from))


### PR DESCRIPTION
Previously we were running the merkle stage without a _trie update threshold_ (denoted in number of updates), because the block range we're computing the root for was below the _merkle stage threshold_. This is dangerous because while the block range may be a low number of blocks, we may have many trie updates, which continue to build in memory using `incremental_root_with_updates`.

This changes the `range < threshold` case, using `root_with_progress`, so the stage yields if the number of updates is large.