### PR TITLE
feat: `--db.exclusive` flag for nfs volumes

### DIFF
--- a/book/cli/reth/db.md
+++ b/book/cli/reth/db.md
@@ -67,6 +67,11 @@ Database:
           - trace:   Enables logging for trace debug-level messages
           - extra:   Enables logging for extra debug-level messages
 
+      --db.exclusive <EXCLUSIVE>
+          Open environment in exclusive/monopolistic mode. Makes it possible to open a database on an NFS volume
+          
+          [possible values: true, false]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/book/cli/reth/db/diff.md
+++ b/book/cli/reth/db/diff.md
@@ -58,6 +58,11 @@ Database:
           - trace:   Enables logging for trace debug-level messages
           - extra:   Enables logging for extra debug-level messages
 
+      --db.exclusive <EXCLUSIVE>
+          Open environment in exclusive/monopolistic mode. Makes it possible to open a database on an NFS volume
+          
+          [possible values: true, false]
+
       --table <TABLE>
           The table name to diff. If not specified, all tables are diffed.
 

--- a/book/cli/reth/import.md
+++ b/book/cli/reth/import.md
@@ -58,6 +58,11 @@ Database:
           - trace:   Enables logging for trace debug-level messages
           - extra:   Enables logging for extra debug-level messages
 
+      --db.exclusive <EXCLUSIVE>
+          Open environment in exclusive/monopolistic mode. Makes it possible to open a database on an NFS volume
+          
+          [possible values: true, false]
+
   <IMPORT_PATH>
           The path to a block file for import.
           

--- a/book/cli/reth/init.md
+++ b/book/cli/reth/init.md
@@ -55,6 +55,11 @@ Database:
           - trace:   Enables logging for trace debug-level messages
           - extra:   Enables logging for extra debug-level messages
 
+      --db.exclusive <EXCLUSIVE>
+          Open environment in exclusive/monopolistic mode. Makes it possible to open a database on an NFS volume
+          
+          [possible values: true, false]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -434,6 +434,11 @@ Database:
           - trace:   Enables logging for trace debug-level messages
           - extra:   Enables logging for extra debug-level messages
 
+      --db.exclusive <EXCLUSIVE>
+          Exclusion mode enabled or not
+          
+          [possible values: true, false]
+
 Dev testnet:
       --dev
           Start the node in dev mode

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -46,9 +46,6 @@ Options:
           
           Mutually exclusive with `--instance`.
 
-      --trusted-setup-file <PATH>
-          Overrides the KZG trusted setup by reading from the supplied file
-
   -h, --help
           Print help (see a summary with '-h')
 
@@ -98,7 +95,7 @@ Networking:
       --identity <IDENTITY>
           Custom node identity
           
-          [default: reth/<VERSION>-<SHA>/<ARCH>]
+          [default: reth/<VERSION>-<SHA>/<ARCH>-gnu]
 
       --p2p-secret-key <PATH>
           Secret key to use for this node.
@@ -130,14 +127,14 @@ Networking:
           Maximum number of inbound requests. default: 30
 
       --pooled-tx-response-soft-limit <BYTES>
-          Soft limit for the byte size of a [`PooledTransactions`](reth_eth_wire::PooledTransactions) response on assembling a [`GetPooledTransactions`](reth_eth_wire::GetPooledTransactions) request. Spec'd at 2 MiB.
+          Soft limit for the byte size of a `PooledTransactions` response on assembling a `GetPooledTransactions` request. Spec'd at 2 MiB.
           
           <https://github.com/ethereum/devp2p/blob/master/caps/eth.md#protocol-messages>.
           
           [default: 2097152]
 
       --pooled-tx-pack-soft-limit <BYTES>
-          Default soft limit for the byte size of a [`PooledTransactions`](reth_eth_wire::PooledTransactions) response on assembling a [`GetPooledTransactions`](reth_eth_wire::PooledTransactions) request. This defaults to less than the [`SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE`], at 2 MiB, used when assembling a [`PooledTransactions`](reth_eth_wire::PooledTransactions) response. Default is 128 KiB
+          Default soft limit for the byte size of a `PooledTransactions` response on assembling a `GetPooledTransactions` request. This defaults to less than the [`SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE`], at 2 MiB, used when assembling a `PooledTransactions` response. Default is 128 KiB
           
           [default: 131072]
 
@@ -238,7 +235,7 @@ RPC:
       --rpc-max-tracing-requests <COUNT>
           Maximum number of concurrent tracing requests
           
-          [default: 10]
+          [default: 14]
 
       --rpc-max-blocks-per-filter <COUNT>
           Maximum number of blocks that could be scanned per filter request. (0 = entire chain)
@@ -435,7 +432,7 @@ Database:
           - extra:   Enables logging for extra debug-level messages
 
       --db.exclusive <EXCLUSIVE>
-          Exclusion mode enabled or not
+          Open environment in exclusive/monopolistic mode. Makes it possible to open a database on an NFS volume
           
           [possible values: true, false]
 

--- a/book/cli/reth/p2p.md
+++ b/book/cli/reth/p2p.md
@@ -101,6 +101,11 @@ Database:
           - trace:   Enables logging for trace debug-level messages
           - extra:   Enables logging for extra debug-level messages
 
+      --db.exclusive <EXCLUSIVE>
+          Open environment in exclusive/monopolistic mode. Makes it possible to open a database on an NFS volume
+          
+          [possible values: true, false]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/book/cli/reth/recover/storage-tries.md
+++ b/book/cli/reth/recover/storage-tries.md
@@ -55,6 +55,11 @@ Database:
           - trace:   Enables logging for trace debug-level messages
           - extra:   Enables logging for extra debug-level messages
 
+      --db.exclusive <EXCLUSIVE>
+          Open environment in exclusive/monopolistic mode. Makes it possible to open a database on an NFS volume
+          
+          [possible values: true, false]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/book/cli/reth/stage/drop.md
+++ b/book/cli/reth/stage/drop.md
@@ -55,6 +55,11 @@ Database:
           - trace:   Enables logging for trace debug-level messages
           - extra:   Enables logging for extra debug-level messages
 
+      --db.exclusive <EXCLUSIVE>
+          Open environment in exclusive/monopolistic mode. Makes it possible to open a database on an NFS volume
+          
+          [possible values: true, false]
+
   <STAGE>
           Possible values:
           - headers:         The headers stage within the pipeline

--- a/book/cli/reth/stage/dump.md
+++ b/book/cli/reth/stage/dump.md
@@ -62,6 +62,11 @@ Database:
           - trace:   Enables logging for trace debug-level messages
           - extra:   Enables logging for extra debug-level messages
 
+      --db.exclusive <EXCLUSIVE>
+          Open environment in exclusive/monopolistic mode. Makes it possible to open a database on an NFS volume
+          
+          [possible values: true, false]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/book/cli/reth/stage/run.md
+++ b/book/cli/reth/stage/run.md
@@ -126,7 +126,7 @@ Networking:
       --identity <IDENTITY>
           Custom node identity
           
-          [default: reth/<VERSION>-<SHA>/<ARCH>]
+          [default: reth/<VERSION>-<SHA>/<ARCH>-gnu]
 
       --p2p-secret-key <PATH>
           Secret key to use for this node.
@@ -158,14 +158,14 @@ Networking:
           Maximum number of inbound requests. default: 30
 
       --pooled-tx-response-soft-limit <BYTES>
-          Soft limit for the byte size of a [`PooledTransactions`](reth_eth_wire::PooledTransactions) response on assembling a [`GetPooledTransactions`](reth_eth_wire::GetPooledTransactions) request. Spec'd at 2 MiB.
+          Soft limit for the byte size of a `PooledTransactions` response on assembling a `GetPooledTransactions` request. Spec'd at 2 MiB.
           
           <https://github.com/ethereum/devp2p/blob/master/caps/eth.md#protocol-messages>.
           
           [default: 2097152]
 
       --pooled-tx-pack-soft-limit <BYTES>
-          Default soft limit for the byte size of a [`PooledTransactions`](reth_eth_wire::PooledTransactions) response on assembling a [`GetPooledTransactions`](reth_eth_wire::PooledTransactions) request. This defaults to less than the [`SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE`], at 2 MiB, used when assembling a [`PooledTransactions`](reth_eth_wire::PooledTransactions) response. Default is 128 KiB
+          Default soft limit for the byte size of a `PooledTransactions` response on assembling a `GetPooledTransactions` request. This defaults to less than the [`SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE`], at 2 MiB, used when assembling a `PooledTransactions` response. Default is 128 KiB
           
           [default: 131072]
 
@@ -182,6 +182,11 @@ Database:
           - debug:   Enables logging for debug-level messages
           - trace:   Enables logging for trace debug-level messages
           - extra:   Enables logging for extra debug-level messages
+
+      --db.exclusive <EXCLUSIVE>
+          Open environment in exclusive/monopolistic mode. Makes it possible to open a database on an NFS volume
+          
+          [possible values: true, false]
 
   -c, --commit
           Commits the changes in the database. WARNING: potentially destructive.

--- a/book/cli/reth/stage/unwind.md
+++ b/book/cli/reth/stage/unwind.md
@@ -60,6 +60,11 @@ Database:
           - trace:   Enables logging for trace debug-level messages
           - extra:   Enables logging for extra debug-level messages
 
+      --db.exclusive <EXCLUSIVE>
+          Open environment in exclusive/monopolistic mode. Makes it possible to open a database on an NFS volume
+          
+          [possible values: true, false]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/crates/node-core/src/args/database_args.rs
+++ b/crates/node-core/src/args/database_args.rs
@@ -12,7 +12,8 @@ pub struct DatabaseArgs {
     /// Database logging level. Levels higher than "notice" require a debug build.
     #[arg(long = "db.log-level", value_enum)]
     pub log_level: Option<LogLevel>,
-    /// Open environment in exclusive/monopolistic mode. Makes it possible to open a database on an NFS volume.
+    /// Open environment in exclusive/monopolistic mode. Makes it possible to open a database on an
+    /// NFS volume.
     #[arg(long = "db.exclusive", exclusive = false)]
     pub exclusive: Option<bool>,
 }

--- a/crates/node-core/src/args/database_args.rs
+++ b/crates/node-core/src/args/database_args.rs
@@ -14,7 +14,7 @@ pub struct DatabaseArgs {
     pub log_level: Option<LogLevel>,
     /// Open environment in exclusive/monopolistic mode. Makes it possible to open a database on an
     /// NFS volume.
-    #[arg(long = "db.exclusive", exclusive = false)]
+    #[arg(long = "db.exclusive")]
     pub exclusive: Option<bool>,
 }
 

--- a/crates/node-core/src/args/database_args.rs
+++ b/crates/node-core/src/args/database_args.rs
@@ -12,7 +12,7 @@ pub struct DatabaseArgs {
     /// Database logging level. Levels higher than "notice" require a debug build.
     #[arg(long = "db.log-level", value_enum)]
     pub log_level: Option<LogLevel>,
-    /// Open environment in exclusive/monopolistic mode. Enabling allows nfs volumes
+    /// Open environment in exclusive/monopolistic mode. Makes it possible to open a database on an NFS volume.
     #[arg(long = "db.exclusive", exclusive = false)]
     pub exclusive: Option<bool>,
 }

--- a/crates/node-core/src/args/database_args.rs
+++ b/crates/node-core/src/args/database_args.rs
@@ -14,7 +14,7 @@ pub struct DatabaseArgs {
     pub log_level: Option<LogLevel>,
     /// Open environment in exclusive/monopolistic mode. Enabling allows nfs volumes
     #[arg(long = "db.exclusive", exclusive = false)]
-    pub exclusive: Option<bool>
+    pub exclusive: Option<bool>,
 }
 
 impl DatabaseArgs {

--- a/crates/node-core/src/args/database_args.rs
+++ b/crates/node-core/src/args/database_args.rs
@@ -12,6 +12,9 @@ pub struct DatabaseArgs {
     /// Database logging level. Levels higher than "notice" require a debug build.
     #[arg(long = "db.log-level", value_enum)]
     pub log_level: Option<LogLevel>,
+    /// Open environment in exclusive/monopolistic mode. Enabling allows nfs volumes
+    #[arg(long = "db.exclusive", exclusive = false)]
+    pub exclusive: Option<bool>
 }
 
 impl DatabaseArgs {
@@ -19,6 +22,7 @@ impl DatabaseArgs {
     pub fn database_args(&self) -> reth_db::mdbx::DatabaseArguments {
         reth_db::mdbx::DatabaseArguments::new(default_client_version())
             .with_log_level(self.log_level)
+            .with_exclusive(self.exclusive)
     }
 }
 


### PR DESCRIPTION
The purpose of this PR is to further extend https://github.com/paradigmxyz/reth/pull/6755/ and allow for 
`--db.exclusive=true` to be used to support nfs volumes