### PR TITLE
fix: eth_callMany pending tag

### DIFF
--- a/crates/rpc/rpc/src/eth/api/call.rs
+++ b/crates/rpc/rpc/src/eth/api/call.rs
@@ -99,6 +99,7 @@ where
         let transaction_index = transaction_index.unwrap_or_default();
 
         let target_block = block_number.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest));
+        let is_block_target_pending = target_block.is_pending();
 
         let ((cfg, block_env, _), block) = futures::try_join!(
             self.evm_env_at(target_block),
@@ -113,9 +114,11 @@ where
         let mut at = block.parent_hash;
         let mut replay_block_txs = true;
 
-        // but if all transactions are to be replayed, we can use the state at the block itself
         let num_txs = transaction_index.index().unwrap_or(block.body.len());
-        if num_txs == block.body.len() {
+        // but if all transactions are to be replayed, we can use the state at the block itself,
+        // however only if we're not targeting the pending block, because for pending we can't rely
+        // on the block's state being available
+        if !is_block_target_pending && num_txs == block.body.len() {
             at = block.hash();
             replay_block_txs = false;
         }

--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -337,11 +337,6 @@ where
                 }
             }
 
-            // if we're currently syncing, we're unable to build a pending block
-            if this.network().is_syncing() {
-                return Ok(None)
-            }
-
             // we rebuild the block
             let pending_block = match pending.build_block(this.provider(), this.pool()) {
                 Ok(block) => block,


### PR DESCRIPTION
closes #7349

fixes two issues with pending state tag

* we should not skip building a local pending block if we're syncing, worst case this will just be an empty block on top of the latest with adjusted env
* if we're targeting pending we can't optimize state access by hash if callMany replays all txs because we might only have a locally build block without state.

This however could be optimized eventually by checking if the pending block is actually coming from the CL