### PR TITLE
crit(dep): bump zstd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,8 +647,8 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
- "zstd 0.13.0",
- "zstd-safe 7.0.0",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -6081,7 +6081,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tracing",
- "zstd 0.12.4",
+ "zstd",
 ]
 
 [[package]]
@@ -6344,7 +6344,7 @@ dependencies = [
  "thiserror",
  "toml",
  "triehash",
- "zstd 0.12.4",
+ "zstd",
 ]
 
 [[package]]
@@ -9349,30 +9349,11 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
-dependencies = [
- "zstd-safe 6.0.6",
-]
-
-[[package]]
-name = "zstd"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
 dependencies = [
- "zstd-safe 7.0.0",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "6.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
-dependencies = [
- "libc",
- "zstd-sys",
+ "zstd-safe",
 ]
 
 [[package]]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -49,7 +49,7 @@ serde_json.workspace = true
 sha2 = { version = "0.10.7", optional = true }
 tempfile = { workspace = true, optional = true }
 thiserror.workspace = true
-zstd = { version = "0.12", features = ["experimental"], optional = true }
+zstd = { version = "0.13", features = ["experimental"], optional = true }
 roaring = "0.10.2"
 cfg-if = "1.0.0"
 

--- a/crates/storage/nippy-jar/Cargo.toml
+++ b/crates/storage/nippy-jar/Cargo.toml
@@ -23,7 +23,7 @@ ph = "0.8.0"
 cuckoofilter = { version = "0.5.0", features = ["serde_support", "serde_bytes"] }
 
 # compression
-zstd = { version = "0.12", features = ["experimental", "zdict_builder"] }
+zstd = { version = "0.13", features = ["experimental", "zdict_builder"] }
 lz4_flex = { version = "0.11", default-features = false }
 
 # offsets


### PR DESCRIPTION
Bumps zstd version to 0.13, which was previously causing compilation error
```
error[E0432]: unresolved import `zstd_sys::ZSTD_cParameter::ZSTD_c_experimentalParam6`
   --> /Users/emhane/.cargo/registry/src/index.crates.io-6f17d22bba15001f/zstd-safe-6.0.6/src/lib.rs:609:13
    |
609 |             ZSTD_c_experimentalParam6 as ZSTD_c_targetCBlockSize,
    |             -------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |             |
    |             no `ZSTD_c_experimentalParam6` in `ZSTD_cParameter`
    |             help: a similar name exists in the module: `ZSTD_c_experimentalParam1`

For more information about this error, try `rustc --explain E0432`.
error: could not compile `zstd-safe` (lib) due to 1 previous error
```
