### PR TITLE
fix: reduce merkle clean_threshold to 5000

### DIFF
--- a/book/run/config.md
+++ b/book/run/config.md
@@ -179,7 +179,7 @@ The merkle stage uses the indexes built in the hashing stages (storage and accou
 # The threshold in number of blocks before the stage starts from scratch
 # and re-computes the state root, discarding the trie that has already been built,
 # as opposed to incrementally updating the trie.
-clean_threshold = 50000
+clean_threshold = 5000
 ```
 
 ### `transaction_lookup`

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -222,7 +222,7 @@ pub struct MerkleConfig {
 
 impl Default for MerkleConfig {
     fn default() -> Self {
-        Self { clean_threshold: 50_000 }
+        Self { clean_threshold: 5_000 }
     }
 }
 

--- a/crates/stages/src/stages/merkle.rs
+++ b/crates/stages/src/stages/merkle.rs
@@ -21,7 +21,7 @@ use tracing::*;
 
 /// The default threshold (in number of blocks) for switching from incremental trie building
 /// of changes to whole rebuild.
-pub const MERKLE_STAGE_DEFAULT_CLEAN_THRESHOLD: u64 = 50_000;
+pub const MERKLE_STAGE_DEFAULT_CLEAN_THRESHOLD: u64 = 5_000;
 
 /// The merkle hashing stage uses input from
 /// [`AccountHashingStage`][crate::stages::AccountHashingStage] and


### PR DESCRIPTION
This changes the merkle `clean_threshold` to 5000, because `50_000` was causing OOMs during the merkle stage. This is because the incremental calculation (only run if `range < clean_threshold`) at `50_000` was collecting over 10GB of `TrieUpdates`.

Jemalloc memory metrics for the stage:
![Screenshot 2024-04-01 at 1 57 04 PM](https://github.com/paradigmxyz/reth/assets/6798349/d65065fe-104f-473b-981a-767b0a308632)

Stage progress during the same timeframe:
![Screenshot 2024-04-01 at 1 57 29 PM](https://github.com/paradigmxyz/reth/assets/6798349/aa5750e0-1a0e-453a-bc45-a43c58d4d410)
