### PR TITLE
chore: add `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[*.rs]
+max_line_length = 100
+
+[*.md]
+# double whitespace at end of line
+# denotes a line break in Markdown
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+
+[]


### PR DESCRIPTION
Add an `.editorconfig` to hint to editors how to indent stuff, this should help avoid annoying things like: https://github.com/paradigmxyz/reth/pull/7340/commits/46d5d8dd912e024266c44cf27ba7c6bad05b7e72#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542