### PR TITLE
fix: return an error if block does nit exist

### DIFF
--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -546,7 +546,9 @@ async fn test_eth_logs_args() {
     let mut params = ArrayParams::default();
     params.insert( serde_json::json!({"blockHash":"0x58dc57ab582b282c143424bd01e8d923cddfdcda9455bad02a29522f6274a948"})).unwrap();
 
-    let _resp = client.request::<Vec<Log>, _>("eth_getLogs", params).await.unwrap();
+    let resp = client.request::<Vec<Log>, _>("eth_getLogs", params).await;
+    // block does not exist
+    assert!(resp.is_err());
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
closes #7371

previously we returned an empty list for a ethGetLogs request with a hash if we were unable to find that block.
This is incorrect behaviour because this indicates that there are no matches for the filter.

this returns an error instead