### PR TITLE
fix: handle optimism deposit transactions on `SenderRecovery` stage

### DIFF
--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -875,7 +875,7 @@ impl TransactionSignedNoHash {
     ///
     /// Returns `None` if the transaction's signature is invalid, see also
     /// [Signature::recover_signer_unchecked].
-    pub fn recover_signer_unchecked_with_buffer(&self, buffer: &mut Vec<u8>) -> Option<Address> {
+    pub fn encode_and_recover_unchecked(&self, buffer: &mut Vec<u8>) -> Option<Address> {
         // Optimism's Deposit transaction does not have a signature. Directly return the
         // `from` address.
         #[cfg(feature = "optimism")]

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -870,11 +870,12 @@ impl TransactionSignedNoHash {
     /// Recover signer from signature and hash _without ensuring that the signature has a low `s`
     /// value_.
     ///
-    /// Re-uses a given buffer to avoid numerous reallocations when recovering batches.
+    /// Re-uses a given buffer to avoid numerous reallocations when recovering batches. **Clears the
+    /// buffer before use.**
     ///
     /// Returns `None` if the transaction's signature is invalid, see also
     /// [Signature::recover_signer_unchecked].
-    pub fn recover_signer_unchecked_with_buffer(&self, rlp_buf: &mut Vec<u8>) -> Option<Address> {
+    pub fn recover_signer_unchecked_with_buffer(&self, buffer: &mut Vec<u8>) -> Option<Address> {
         // Optimism's Deposit transaction does not have a signature. Directly return the
         // `from` address.
         #[cfg(feature = "optimism")]
@@ -882,9 +883,10 @@ impl TransactionSignedNoHash {
             return Some(from)
         }
 
-        self.transaction.encode_without_signature(rlp_buf);
+        buffer.clear();
+        self.transaction.encode_without_signature(buffer);
 
-        self.signature.recover_signer_unchecked(keccak256(rlp_buf))
+        self.signature.recover_signer_unchecked(keccak256(buffer))
     }
 
     /// Converts into a transaction type with its hash: [`TransactionSigned`].

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -868,8 +868,8 @@ impl TransactionSignedNoHash {
     }
 
     /// Recover signer from signature and hash _without ensuring that the signature has a low `s`
-    /// value_. 
-    /// 
+    /// value_.
+    ///
     /// Re-uses a given buffer to avoid numerous reallocations when recovering batches.
     ///
     /// Returns `None` if the transaction's signature is invalid, see also

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -876,15 +876,15 @@ impl TransactionSignedNoHash {
     /// Returns `None` if the transaction's signature is invalid, see also
     /// [Signature::recover_signer_unchecked].
     pub fn encode_and_recover_unchecked(&self, buffer: &mut Vec<u8>) -> Option<Address> {
+        buffer.clear();
+        self.transaction.encode_without_signature(buffer);
+
         // Optimism's Deposit transaction does not have a signature. Directly return the
         // `from` address.
         #[cfg(feature = "optimism")]
         if let Transaction::Deposit(TxDeposit { from, .. }) = self.transaction {
             return Some(from)
         }
-
-        buffer.clear();
-        self.transaction.encode_without_signature(buffer);
 
         self.signature.recover_signer_unchecked(keccak256(buffer))
     }

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -234,7 +234,7 @@ fn recover_sender(
     // large `s` values, so using [Signature::recover_signer] here would not be
     // backwards-compatible.
     let sender = tx
-        .recover_signer_unchecked_with_buffer(rlp_buf)
+        .encode_and_recover_unchecked(rlp_buf)
         .ok_or(SenderRecoveryStageError::FailedRecovery(FailedSenderRecoveryError { tx: tx_id }))?;
 
     Ok((tx_id, sender))

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -11,7 +11,8 @@ use reth_interfaces::consensus;
 use reth_primitives::{
     keccak256,
     stage::{EntitiesCheckpoint, StageCheckpoint, StageId},
-    Address, PruneSegment, StaticFileSegment, TransactionSignedNoHash, TxNumber,
+    Address, PruneSegment, StaticFileSegment, Transaction, TransactionSignedNoHash, TxDeposit,
+    TxNumber,
 };
 use reth_provider::{
     BlockReader, DatabaseProviderRW, HeaderProvider, ProviderError, PruneCheckpointReader,
@@ -229,16 +230,13 @@ fn recover_sender(
     (tx_id, tx): (TxNumber, TransactionSignedNoHash),
     rlp_buf: &mut Vec<u8>,
 ) -> Result<(u64, Address), Box<SenderRecoveryStageError>> {
-    tx.transaction.encode_without_signature(rlp_buf);
-
     // We call [Signature::recover_signer_unchecked] because transactions run in the pipeline are
     // known to be valid - this means that we do not need to check whether or not the `s` value is
     // greater than `secp256k1n / 2` if past EIP-2. There are transactions pre-homestead which have
     // large `s` values, so using [Signature::recover_signer] here would not be
     // backwards-compatible.
     let sender = tx
-        .signature
-        .recover_signer_unchecked(keccak256(rlp_buf))
+        .recover_signer_unchecked_with_buffer(rlp_buf)
         .ok_or(SenderRecoveryStageError::FailedRecovery(FailedSenderRecoveryError { tx: tx_id }))?;
 
     Ok((tx_id, sender))

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -9,10 +9,8 @@ use reth_db::{
 };
 use reth_interfaces::consensus;
 use reth_primitives::{
-    keccak256,
     stage::{EntitiesCheckpoint, StageCheckpoint, StageId},
-    Address, PruneSegment, StaticFileSegment, Transaction, TransactionSignedNoHash, TxDeposit,
-    TxNumber,
+    Address, PruneSegment, StaticFileSegment, TransactionSignedNoHash, TxNumber,
 };
 use reth_provider::{
     BlockReader, DatabaseProviderRW, HeaderProvider, ProviderError, PruneCheckpointReader,


### PR DESCRIPTION
Deposit transactions do not have a signature, and we were trying to recover them during the stage.