### PR TITLE
Do no use feature `secp256k/rand-std` in project level Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -327,7 +327,6 @@ jsonrpsee-types = "0.20"
 # crypto
 secp256k1 = { version = "0.27.0", default-features = false, features = [
     "global-context",
-    "rand-std",
     "recovery",
 ] }
 enr = { version = "=0.10.0", default-features = false, features = ["k256"] }

--- a/examples/manual-p2p/Cargo.toml
+++ b/examples/manual-p2p/Cargo.toml
@@ -15,5 +15,5 @@ reth-discv4.workspace = true
 reth-eth-wire.workspace = true
 reth-ecies.workspace = true
 futures.workspace = true
-secp256k1.workspace = true
+secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery"] }
 tokio.workspace = true

--- a/examples/polygon-p2p/Cargo.toml
+++ b/examples/polygon-p2p/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-secp256k1.workspace = true
+secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery"] }
 tokio.workspace = true
 reth-network.workspace = true
 reth-primitives.workspace = true


### PR DESCRIPTION
As it affects how some crates, such as `reth-primitives` are executed in constraint environment, such as ZkVm (Risc0 or SP1)

This PR won't affect majority of the crates, as they either already have this feature explicitly specified, or it is going to be activated via feature union by cargo. 