### PR TITLE
chore: add EthApiError::Other

### DIFF
--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -51,7 +51,7 @@ use revm::{
 #[cfg(feature = "optimism")]
 use crate::eth::api::optimism::OptimismTxMeta;
 #[cfg(feature = "optimism")]
-use crate::eth::error::OptimismEthApiError;
+use crate::eth::optimism::OptimismEthApiError;
 #[cfg(feature = "optimism")]
 use reth_revm::optimism::RethL1BlockInfo;
 #[cfg(feature = "optimism")]
@@ -1286,10 +1286,10 @@ where
                     &envelope_buf,
                     tx.is_deposit(),
                 )
-                .map_err(|_| EthApiError::Optimism(OptimismEthApiError::L1BlockFeeError))?;
+                .map_err(|_| OptimismEthApiError::L1BlockFeeError)?;
             let inner_l1_data_gas = l1_block_info
                 .l1_data_gas(&self.inner.provider.chain_spec(), block_timestamp, &envelope_buf)
-                .map_err(|_| EthApiError::Optimism(OptimismEthApiError::L1BlockGasError))?;
+                .map_err(|_| OptimismEthApiError::L1BlockGasError)?;
             (Some(inner_l1_fee), Some(inner_l1_data_gas))
         } else {
             (None, None)
@@ -1316,7 +1316,7 @@ where
                     target = "rpc::eth",
                     "Failed to serialize transaction for forwarding to sequencer"
                 );
-                EthApiError::Optimism(OptimismEthApiError::InvalidSequencerTransaction)
+                OptimismEthApiError::InvalidSequencerTransaction
             })?;
 
             self.inner
@@ -1326,7 +1326,7 @@ where
                 .body(body)
                 .send()
                 .await
-                .map_err(|err| EthApiError::Optimism(OptimismEthApiError::HttpError(err)))?;
+                .map_err(OptimismEthApiError::HttpError)?;
         }
         Ok(())
     }

--- a/crates/rpc/rpc/src/eth/mod.rs
+++ b/crates/rpc/rpc/src/eth/mod.rs
@@ -13,6 +13,9 @@ pub mod revm_utils;
 mod signer;
 pub(crate) mod utils;
 
+#[cfg(feature = "optimism")]
+pub mod optimism;
+
 pub use api::{
     fee_history::{fee_history_cache_new_blocks_task, FeeHistoryCache, FeeHistoryCacheConfig},
     EthApi, EthApiSpec, EthTransactions, TransactionSource, RPC_DEFAULT_GAS_CAP,

--- a/crates/rpc/rpc/src/eth/optimism.rs
+++ b/crates/rpc/rpc/src/eth/optimism.rs
@@ -1,0 +1,46 @@
+//! Optimism specific types.
+
+use crate::{
+    eth::error::{EthApiError, ToRpcError},
+    result::internal_rpc_err,
+};
+use jsonrpsee::types::ErrorObject;
+
+/// Eth Optimism Api Error
+#[cfg(feature = "optimism")]
+#[derive(Debug, thiserror::Error)]
+pub enum OptimismEthApiError {
+    /// Wrapper around a [hyper::Error].
+    #[error(transparent)]
+    HyperError(#[from] hyper::Error),
+    /// Wrapper around an [reqwest::Error].
+    #[error(transparent)]
+    HttpError(#[from] reqwest::Error),
+    /// Thrown when serializing transaction to forward to sequencer
+    #[error("invalid sequencer transaction")]
+    InvalidSequencerTransaction,
+    /// Thrown when calculating L1 gas fee
+    #[error("failed to calculate l1 gas fee")]
+    L1BlockFeeError,
+    /// Thrown when calculating L1 gas used
+    #[error("failed to calculate l1 gas used")]
+    L1BlockGasError,
+}
+
+impl ToRpcError for OptimismEthApiError {
+    fn to_rpc_error(&self) -> ErrorObject<'static> {
+        match self {
+            OptimismEthApiError::HyperError(err) => internal_rpc_err(err.to_string()),
+            OptimismEthApiError::HttpError(err) => internal_rpc_err(err.to_string()),
+            OptimismEthApiError::InvalidSequencerTransaction |
+            OptimismEthApiError::L1BlockFeeError |
+            OptimismEthApiError::L1BlockGasError => internal_rpc_err(self.to_string()),
+        }
+    }
+}
+
+impl From<OptimismEthApiError> for EthApiError {
+    fn from(err: OptimismEthApiError) -> Self {
+        EthApiError::other(err)
+    }
+}


### PR DESCRIPTION
converts the OP specific error into a general purpose `Other` variant.

This makes the EthApiError usable for other custom errors thrown in RPC.