### PR TITLE
Add metrics for observing tx fetch outcome

### DIFF
--- a/crates/net/network/src/metrics.rs
+++ b/crates/net/network/src/metrics.rs
@@ -200,7 +200,12 @@ pub struct TransactionFetcherMetrics {
     pub(crate) egress_peer_channel_full: Counter,
     /// Total number of hashes pending fetch.
     pub(crate) hashes_pending_fetch: Gauge,
-
+    /// Total number of fetched transactions.
+    pub(crate) fetched_transactions: Counter,
+    /// Total number of transactions that were received in
+    /// [`PooledTransactions`](reth_eth_wire::PooledTransactions) responses, that weren't
+    /// requested.
+    pub(crate) unsolicited_transactions: Counter,
     /* ================ SEARCH DURATION ================ */
     /// Time spent searching for an idle peer in call to
     /// [`TransactionFetcher::find_any_idle_fallback_peer_for_any_pending_hash`](crate::transactions::TransactionFetcher::find_any_idle_fallback_peer_for_any_pending_hash).

--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -944,6 +944,10 @@ impl TransactionFetcher {
                 let (verification_outcome, verified_payload) =
                     payload.verify(&requested_hashes, &peer_id);
 
+                let unsolicited = unverified_len - verified_payload.len();
+                if unsolicited > 0 {
+                    self.metrics.unsolicited_transactions.increment(unsolicited as u64);
+                }
                 if verification_outcome == VerificationOutcome::ReportPeer {
                     // todo: report peer for sending hashes that weren't requested
                     trace!(target: "net::tx",
@@ -997,6 +1001,7 @@ impl TransactionFetcher {
                     true
                 });
                 fetched.shrink_to_fit();
+                self.metrics.fetched_transactions.increment(fetched.len() as u64);
 
                 if fetched.len() < requested_hashes_len {
                     trace!(target: "net::tx",


### PR DESCRIPTION
Adds metrics for observing tx fetch outcome:

- transactions that were requested and served
- transactions that were served, but were not requested