### PR TITLE
CI: Disable hive job on forked repositories

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   prepare:
+    if: github.repository == 'paradigmxyz/reth'
     timeout-minutes: 45
     runs-on:
       group: Reth


### PR DESCRIPTION
The action runner "Reth" is not present in a fork by default, thus the hive-job creates one failing run every day.