### PR TITLE
ci: update runners for apple builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,10 +38,10 @@ jobs:
             os: ubuntu-20.04
             profile: maxperf
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-13
             profile: maxperf
           - target: aarch64-apple-darwin
-            os: macos-latest
+            os: macos-14
             profile: maxperf
           - target: x86_64-pc-windows-gnu
             os: ubuntu-20.04


### PR DESCRIPTION
* `macos-14` runner is on M1, which means `apple-arm64` will be native, making them faster
* `macos-13` runner has an extra core, which means `apple-x86_64` builds will be slightly faster, also `macos-latest` uses an older MacOS version (12.0) for builds 