### PR TITLE
support state override for debug_traceTransaction ("offchain events")

### DIFF
--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -90,6 +90,17 @@ pub trait DebugApi {
         opts: Option<GethDebugTracingOptions>,
     ) -> RpcResult<GethTrace>;
 
+    /// The `debug_traceTransaction` debugging method will attempt to run the transaction in the
+    /// exact same manner as it was executed on the network. It will replay any transaction that
+    /// may have been executed prior to this one before it will finally attempt to execute the
+    /// transaction that corresponds to the given hash.
+    #[method(name = "traceTransactionOverrides")]
+    async fn debug_trace_transaction_overrides(
+        &self,
+        tx_hash: B256,
+        opts: Option<GethDebugTracingCallOptions>,
+    ) -> RpcResult<GethTrace>;
+
     /// The `debug_traceCall` method lets you run an `eth_call` within the context of the given
     /// block execution using the final state of parent block as the base.
     ///


### PR DESCRIPTION
the `debug_traceCall` function supports state overrides, but `debug_traceTransaction` does not - it only accepts a transaction hash.

I wrote this originally as the backbone for generating "offchain events" (as developed by shadow / ghost logs)

to prevent confusion with nodes that don't implement this feature I created a distinct function `debug_traceTransactionOverrides`.
by overriding contracts bytecode it is possible to reexecute onchain transactions in different context, specifically to emit so called "offchain events" but not limited to this.

usage:
```sh
cast rpc debug_traceTransactionOverrides $txhash '{ "stateOverrides": { "$addr": { "code": "$bytecode" } } }'
```

eg for mainnet:
```sh
cast rpc debug_traceTransactionOverrides 0xc9ab90a1796613b0fbccb33827de583901d4c0775e89c0f25d604b7c3a71771e '{ "stateOverrides": { "0x0000001D0000F38CC10d0028474a9c180058B091": { "code": "0x6000ff" } } }' | jq .
```

note:
the format may differ a bit from other nodes (eg. in geth the keys ("stateOverride", "code") are case insensitive, in reth they are case sensitive)
this is unrelated to this patch.

see equivalent implementations:

geth: https://github.com/ethereum/go-ethereum/pull/29423
erigon: https://github.com/ledgerwatch/erigon/pull/9847
