### PR TITLE
fix: check finalized sync target is not zero

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -622,7 +622,7 @@ where
     }
 
     /// Returns the finalized hash to sync to if the distance from the local tip to the block is
-    /// greater than the configured threshold and we're not synced to the finalized block yet block
+    /// greater than the configured threshold and we're not synced to the finalized block yet
     /// yet (if we've seen that block already).
     ///
     /// If this is invoked after a new block has been downloaded, the downloaded block could be the
@@ -671,9 +671,12 @@ where
                         warn!(target: "consensus::engine", %err, "Failed to get finalized block header");
                     }
                     Ok(None) => {
-                        // we don't have the block yet and the distance exceeds the allowed
-                        // threshold
-                        return Some(state.finalized_block_hash)
+                        // ensure the finalized block is known (not the zero hash)
+                        if !state.finalized_block_hash.is_zero() {
+                            // we don't have the block yet and the distance exceeds the allowed
+                            // threshold
+                            return Some(state.finalized_block_hash)
+                        }
                     }
                     Ok(Some(_)) => {
                         // we're fully synced to the finalized block
@@ -1708,6 +1711,7 @@ where
                     )
                     .is_none()
                 {
+                    // get the block number of the finalized block, if we have it
                     let newest_finalized = self
                         .forkchoice_state_tracker
                         .sync_target_state()

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -2090,6 +2090,7 @@ mod tests {
         let _ = env
             .send_forkchoice_updated(ForkchoiceState {
                 head_block_hash: rng.gen(),
+                finalized_block_hash: rng.gen(),
                 ..Default::default()
             })
             .await;

--- a/crates/consensus/beacon/src/engine/sync.rs
+++ b/crates/consensus/beacon/src/engine/sync.rs
@@ -214,7 +214,13 @@ where
     }
 
     /// Sets a new target to sync the pipeline to.
+    ///
+    /// But ensures the target is not the zero hash.
     pub(crate) fn set_pipeline_sync_target(&mut self, target: B256) {
+        if target.is_zero() {
+            // precaution to never sync to the zero hash
+            return
+        }
         self.pending_pipeline_target = Some(target);
     }
 


### PR DESCRIPTION
adds a check to ensure we don't end up with the zero hash as sync target