### PR TITLE
fix(static-file): run producer only if passed non-empty targets

### DIFF
--- a/crates/static-file/src/static_file_producer.rs
+++ b/crates/static-file/src/static_file_producer.rs
@@ -124,6 +124,11 @@ impl<DB: Database> StaticFileProducerInner<DB> {
     /// NOTE: it doesn't delete the data from database, and the actual deleting (aka pruning) logic
     /// lives in the `prune` crate.
     pub fn run(&mut self, targets: StaticFileTargets) -> StaticFileProducerResult {
+        // If there are no targets, do not produce any static files and return early
+        if !targets.any() {
+            return Ok(targets)
+        }
+
         debug_assert!(targets.is_contiguous_to_highest_static_files(
             self.static_file_provider.get_highest_static_files()
         ));


### PR DESCRIPTION
Prevents unnecessary static file producer runs, such as:
```console
2024-04-02T14:36:53.298895Z  INFO Static File Producer started targets=StaticFileTargets { headers: None, receipts: None, transactions: None }
2024-04-02T14:36:53.298963Z  INFO Static File Producer finished targets=StaticFileTargets { headers: None, receipts: None, transactions: None } elapsed=5.542µs
```