### PR TITLE
chore(node-core): unify stage progress log style

### DIFF
--- a/crates/node-core/src/events/node.rs
+++ b/crates/node-core/src/events/node.rs
@@ -167,8 +167,7 @@ impl<DB> NodeState<DB> {
                         .and_then(|entities| entities.fmt_percentage());
                     let stage_eta = current_stage.eta.fmt_for_stage(stage_id);
 
-                    let message =
-                        if done { "Stage finished executing" } else { "Stage committed progress" };
+                    let message = if done { "Finished stage" } else { "Committed stage progress" };
 
                     match (stage_progress, stage_eta) {
                         (Some(stage_progress), Some(stage_eta)) => {


### PR DESCRIPTION
Make the pipeline stage log messages consistent with each other

### Before
```console
2024-04-02T15:01:52.308117Z  INFO Preparing stage pipeline_stages=12/12 stage=Finish checkpoint=1239230 target=1266825
2024-04-02T15:01:52.308136Z  INFO Executing stage pipeline_stages=12/12 stage=Finish checkpoint=1239230 target=1266825
2024-04-02T15:01:52.308347Z  INFO Stage finished executing pipeline_stages=12/12 stage=Finish checkpoint=1266825 target=1266825
```

### After
```console
2024-04-02T15:01:52.308117Z  INFO Preparing stage pipeline_stages=12/12 stage=Finish checkpoint=1239230 target=1266825
2024-04-02T15:01:52.308136Z  INFO Executing stage pipeline_stages=12/12 stage=Finish checkpoint=1239230 target=1266825
2024-04-02T15:01:52.308347Z  INFO Finished stage pipeline_stages=12/12 stage=Finish checkpoint=1266825 target=1266825
```