### PR TITLE
perf: replace BytesMut with alloy_rlp::encode

### DIFF
--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1702,7 +1702,6 @@ mod tests {
     };
     use alloy_primitives::{address, b256, bytes};
     use alloy_rlp::{Decodable, Encodable, Error as RlpError};
-    use bytes::BytesMut;
     use reth_codecs::Compact;
     use secp256k1::{KeyPair, Secp256k1};
     use std::str::FromStr;
@@ -1963,10 +1962,8 @@ mod tests {
         let tx = TransactionSigned::decode(&mut &input[..]).unwrap();
         let recovered = tx.into_ecrecovered().unwrap();
 
-        let mut encoded = BytesMut::new();
-        recovered.encode(&mut encoded);
-
-        let decoded = TransactionSignedEcRecovered::decode(&mut &encoded[..]).unwrap();
+        let decoded =
+            TransactionSignedEcRecovered::decode(&mut &alloy_rlp::encode(&recovered)[..]).unwrap();
         assert_eq!(recovered, decoded)
     }
 

--- a/docs/crates/eth-wire.md
+++ b/docs/crates/eth-wire.md
@@ -352,10 +352,7 @@ pub struct UnauthedP2PStream<S> {
 impl<S> UnauthedP2PStream<S> {
     // ...
     pub async fn handshake(mut self, hello: HelloMessage) -> Result<(P2PStream<S>, HelloMessage), Error> {
-        let mut raw_hello_bytes = BytesMut::new();
-        P2PMessage::Hello(hello.clone()).encode(&mut raw_hello_bytes);
-
-        self.inner.send(raw_hello_bytes.into()).await?;
+        self.inner.send(alloy_rlp::encode(P2PMessage::Hello(hello.clone())).into()).await?;
         let first_message_bytes = tokio::time::timeout(HANDSHAKE_TIMEOUT, self.inner.next()).await;
 
         let their_hello = match P2PMessage::decode(&mut &first_message_bytes[..]) {


### PR DESCRIPTION
Last drop-in replacement of https://github.com/paradigmxyz/reth/issues/6986

Remaining `BytesMut::new()` is there because functions return `BytesMut`, so I can't see a trivial drop-in replacement, but I'm happy to look at it if I get some guidance on how it can be achieved.