### PR TITLE
feat: move transact and inspect calls to trait

### DIFF
--- a/crates/rpc/rpc/src/eth/revm_utils.rs
+++ b/crates/rpc/rpc/src/eth/revm_utils.rs
@@ -1,7 +1,5 @@
 //! utilities for working with revm
 
-use std::cmp::min;
-
 use crate::eth::error::{EthApiError, EthResult, RpcInvalidTransactionError};
 #[cfg(feature = "optimism")]
 use reth_primitives::revm::env::fill_op_tx_env;
@@ -19,14 +17,14 @@ use reth_rpc_types::{
 use revm::primitives::{Bytes, OptimismFields};
 use revm::{
     db::CacheDB,
-    inspector_handle_register,
     precompile::{PrecompileSpecId, Precompiles},
     primitives::{
-        db::DatabaseRef, BlockEnv, Bytecode, CfgEnvWithHandlerCfg, EnvWithHandlerCfg,
-        ResultAndState, SpecId, TransactTo, TxEnv,
+        db::DatabaseRef, BlockEnv, Bytecode, CfgEnvWithHandlerCfg, EnvWithHandlerCfg, SpecId,
+        TransactTo, TxEnv,
     },
-    Database, GetInspector,
+    Database,
 };
+use std::cmp::min;
 use tracing::trace;
 
 /// Helper type that bundles various overrides for EVM Execution.
@@ -68,7 +66,7 @@ impl From<Option<StateOverride>> for EvmOverrides {
 /// Helper type to work with different transaction types when configuring the EVM env.
 ///
 /// This makes it easier to handle errors.
-pub(crate) trait FillableTransaction {
+pub trait FillableTransaction {
     /// Returns the hash of the transaction.
     fn hash(&self) -> TxHash;
 
@@ -120,110 +118,6 @@ impl FillableTransaction for TransactionSigned {
 pub(crate) fn get_precompiles(spec_id: SpecId) -> impl IntoIterator<Item = Address> {
     let spec = PrecompileSpecId::from_spec_id(spec_id);
     Precompiles::new(spec).addresses().copied().map(Address::from)
-}
-
-/// Executes the [EnvWithHandlerCfg] against the given [Database] without committing state changes.
-pub(crate) fn transact<DB>(
-    db: DB,
-    env: EnvWithHandlerCfg,
-) -> EthResult<(ResultAndState, EnvWithHandlerCfg)>
-where
-    DB: Database,
-    <DB as Database>::Error: Into<EthApiError>,
-{
-    let mut evm = revm::Evm::builder().with_db(db).with_env_with_handler_cfg(env).build();
-    let res = evm.transact()?;
-    let (_, env) = evm.into_db_and_env_with_handler_cfg();
-    Ok((res, env))
-}
-
-/// Executes the [EnvWithHandlerCfg] against the given [Database] without committing state changes.
-pub(crate) fn inspect<DB, I>(
-    db: DB,
-    env: EnvWithHandlerCfg,
-    inspector: I,
-) -> EthResult<(ResultAndState, EnvWithHandlerCfg)>
-where
-    DB: Database,
-    <DB as Database>::Error: Into<EthApiError>,
-    I: GetInspector<DB>,
-{
-    let mut evm = revm::Evm::builder()
-        .with_db(db)
-        .with_external_context(inspector)
-        .with_env_with_handler_cfg(env)
-        .append_handler_register(inspector_handle_register)
-        .build();
-    let res = evm.transact()?;
-    let (_, env) = evm.into_db_and_env_with_handler_cfg();
-    Ok((res, env))
-}
-
-/// Same as [inspect] but also returns the database again.
-///
-/// Even though [Database] is also implemented on `&mut`
-/// this is still useful if there are certain trait bounds on the Inspector's database generic type
-pub(crate) fn inspect_and_return_db<DB, I>(
-    db: DB,
-    env: EnvWithHandlerCfg,
-    inspector: I,
-) -> EthResult<(ResultAndState, EnvWithHandlerCfg, DB)>
-where
-    DB: Database,
-    <DB as Database>::Error: Into<EthApiError>,
-    I: GetInspector<DB>,
-{
-    let mut evm = revm::Evm::builder()
-        .with_external_context(inspector)
-        .with_db(db)
-        .with_env_with_handler_cfg(env)
-        .append_handler_register(inspector_handle_register)
-        .build();
-    let res = evm.transact()?;
-    let (db, env) = evm.into_db_and_env_with_handler_cfg();
-    Ok((res, env, db))
-}
-
-/// Replays all the transactions until the target transaction is found.
-///
-/// All transactions before the target transaction are executed and their changes are written to the
-/// _runtime_ db ([CacheDB]).
-///
-/// Note: This assumes the target transaction is in the given iterator.
-/// Returns the index of the target transaction in the given iterator.
-pub(crate) fn replay_transactions_until<DB, I, Tx>(
-    db: &mut CacheDB<DB>,
-    cfg: CfgEnvWithHandlerCfg,
-    block_env: BlockEnv,
-    transactions: I,
-    target_tx_hash: B256,
-) -> Result<usize, EthApiError>
-where
-    DB: DatabaseRef,
-    EthApiError: From<<DB as DatabaseRef>::Error>,
-    I: IntoIterator<Item = Tx>,
-    Tx: FillableTransaction,
-{
-    let mut evm = revm::Evm::builder()
-        .with_db(db)
-        .with_env_with_handler_cfg(EnvWithHandlerCfg::new_with_cfg_env(
-            cfg,
-            block_env,
-            Default::default(),
-        ))
-        .build();
-    let mut index = 0;
-    for tx in transactions.into_iter() {
-        if tx.hash() == target_tx_hash {
-            // reached the target transaction
-            break
-        }
-
-        tx.try_fill_tx_env(evm.tx_mut())?;
-        evm.transact_commit()?;
-        index += 1;
-    }
-    Ok(index)
 }
 
 /// Prepares the [EnvWithHandlerCfg] for execution.


### PR DESCRIPTION
This is prep for integrating custom EVM support to RPC.

this merely moves the standalone inspect/transact functions into the `EthTransactions` trait, but does not change them yet.

In a followup the evm::Builder setup will be replaced with the EvmConfig: #7439