### PR TITLE
fix(pruner): highest pruned block metric

### DIFF
--- a/crates/prune/src/pruner.rs
+++ b/crates/prune/src/pruner.rs
@@ -202,11 +202,14 @@ impl<DB: Database> Pruner<DB> {
                     .get_prune_segment_metrics(segment.segment())
                     .duration_seconds
                     .record(segment_start.elapsed());
-
-                self.metrics
-                    .get_prune_segment_metrics(segment.segment())
-                    .highest_pruned_block
-                    .set(to_block as f64);
+                if let Some(highest_pruned_block) =
+                    output.checkpoint.and_then(|checkpoint| checkpoint.block_number)
+                {
+                    self.metrics
+                        .get_prune_segment_metrics(segment.segment())
+                        .highest_pruned_block
+                        .set(highest_pruned_block as f64);
+                }
 
                 progress = output.progress;
 

--- a/etc/grafana/dashboards/overview.json
+++ b/etc/grafana/dashboards/overview.json
@@ -7038,7 +7038,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -7213,7 +7214,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -7310,7 +7312,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -7407,7 +7410,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -7517,7 +7521,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -7614,7 +7619,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -7664,12 +7670,106 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 256
+      },
+      "id": 217,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "reth_pruner_segments_highest_pruned_block{instance=~\"$instance\"}",
+          "instant": false,
+          "legendFormat": "{{segment}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Highest pruned block, per segment",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 256
+        "y": 264
       },
       "id": 108,
       "panels": [],
@@ -7724,7 +7824,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -7766,7 +7867,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 257
+        "y": 265
       },
       "id": 109,
       "options": {
@@ -7829,7 +7930,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 257
+        "y": 265
       },
       "id": 111,
       "maxDataPoints": 25,
@@ -7941,7 +8042,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -7958,7 +8060,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 265
+        "y": 273
       },
       "id": 120,
       "options": {
@@ -8017,7 +8119,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 265
+        "y": 273
       },
       "id": 112,
       "maxDataPoints": 25,
@@ -8129,7 +8231,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -8170,7 +8273,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 273
+        "y": 281
       },
       "id": 198,
       "options": {
@@ -8302,6 +8405,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -8337,7 +8441,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -8345,7 +8450,8 @@
               }
             ]
           },
-          "unit": "reqps"
+          "unit": "reqps",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -8353,7 +8459,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 273
+        "y": 281
       },
       "id": 213,
       "options": {
@@ -8471,6 +8577,6 @@
   "timezone": "",
   "title": "reth",
   "uid": "2k8BXz24x",
-  "version": 4,
+  "version": 5,
   "weekStart": ""
 }


### PR DESCRIPTION
Before, it was reporting the target block that we're pruning towards, but not the actual highest pruned block. This PR fixes it by reporting the block number from the checkpoint.

Also, this PR adds a dashboard panel for tracking this metric:

<img width="1546" alt="image" src="https://github.com/paradigmxyz/reth/assets/5773434/c97ce5bf-cc13-4f0f-bc95-63421c95056b">
