### PR TITLE
feat(discv5): plug discv5 crate into network

### DIFF
--- a/crates/net/discv5/src/enr.rs
+++ b/crates/net/discv5/src/enr.rs
@@ -1,7 +1,8 @@
 //! Interface between node identification on protocol version 5 and 4. Specifically, between types
 //! [`discv5::enr::NodeId`] and [`PeerId`].
 
-use discv5::enr::{CombinedPublicKey, Enr, EnrPublicKey, NodeId};
+use discv5::enr::{CombinedPublicKey, EnrPublicKey, NodeId};
+use enr::Enr;
 use reth_primitives::{id2pk, pk2id, PeerId};
 use secp256k1::{PublicKey, SecretKey};
 

--- a/crates/net/discv5/src/error.rs
+++ b/crates/net/discv5/src/error.rs
@@ -7,7 +7,7 @@ use discv5::IpMode;
 pub enum Error {
     /// Failure adding node to [`discv5::Discv5`].
     #[error("failed adding node to discv5, {0}")]
-    AddNodeToDiscv5Failed(&'static str),
+    AddNodeFailed(&'static str),
     /// Node record has incompatible key type.
     #[error("incompatible key type (not secp256k1)")]
     IncompatibleKeyType,
@@ -30,9 +30,6 @@ pub enum Error {
     #[error("init failed, {0}")]
     InitFailure(&'static str),
     /// An error from underlying [`discv5::Discv5`] node.
-    #[error("{0}")]
+    #[error("sigp/discv5 error, {0}")]
     Discv5Error(discv5::Error),
-    /// An error from underlying [`discv5::Discv5`] node.
-    #[error("{0}")]
-    Discv5ErrorStr(&'static str),
 }

--- a/crates/net/discv5/src/error.rs
+++ b/crates/net/discv5/src/error.rs
@@ -12,8 +12,8 @@ pub enum Error {
     #[error("incompatible key type (not secp256k1)")]
     IncompatibleKeyType,
     /// Missing key used to identify rlpx network.
-    #[error("fork missing on enr, 'eth' key missing")]
-    ForkMissing,
+    #[error("fork missing on enr, key missing")]
+    ForkMissing(&'static [u8]),
     /// Failed to decode [`ForkId`](reth_primitives::ForkId) rlp value.
     #[error("failed to decode fork id, 'eth': {0:?}")]
     ForkIdDecodeError(#[from] alloy_rlp::Error),

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -67,9 +67,9 @@ impl Discv5 {
     ////////////////////////////////////////////////////////////////////////////////////////////////
 
     /// Adds the node to the table, if it is not already present.
-    pub fn add_node_to_routing_table(&self, node_record: Enr<SecretKey>) -> Result<(), Error> {
+    pub fn add_node(&self, node_record: Enr<SecretKey>) -> Result<(), Error> {
         let EnrCombinedKeyWrapper(enr) = node_record.into();
-        self.add_enr(enr).map_err(Error::AddNodeToDiscv5Failed)
+        self.add_enr(enr).map_err(Error::AddNodeFailed)
     }
 
     /// Sets the pair in the EIP-868 [`Enr`] of the node.
@@ -269,7 +269,7 @@ impl Discv5 {
             match node {
                 BootNode::Enr(node) => {
                     if let Err(err) = discv5.add_enr(node) {
-                        return Err(Error::Discv5ErrorStr(err))
+                        return Err(Error::AddNodeFailed(err))
                     }
                 }
                 BootNode::Enode(enode) => {
@@ -617,7 +617,7 @@ mod tests {
         // add node_2 to discovery handle of node_1 (should add node to discv5 kbuckets)
         let node_2_enr_reth_compatible_ty: Enr<SecretKey> =
             EnrCombinedKeyWrapper(node_2_enr.clone()).into();
-        node_1.add_node_to_routing_table(node_2_enr_reth_compatible_ty).unwrap();
+        node_1.add_node(node_2_enr_reth_compatible_ty).unwrap();
 
         // verify node_2 is in KBuckets of node_1:discv5
         assert!(

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -236,7 +236,7 @@ impl Discv5 {
         //
         // 4. add boot nodes
         //
-        Self::bootstrap(bootstrap_nodes, &discv5)?;
+        Self::bootstrap(bootstrap_nodes, &discv5).await?;
 
         let metrics = Discv5Metrics::default();
 
@@ -253,7 +253,7 @@ impl Discv5 {
     }
 
     /// Bootstraps underlying [`discv5::Discv5`] node with configured peers.
-    fn bootstrap(
+    async fn bootstrap(
         bootstrap_nodes: HashSet<BootNode>,
         discv5: &Arc<discv5::Discv5>,
     ) -> Result<(), Error> {
@@ -284,18 +284,8 @@ impl Discv5 {
                 }
             }
         }
-        _ = join_all(enr_requests);
 
-        debug!(target: "net::discv5",
-            nodes=format!("[{:#}]", discv5.with_kbuckets(|kbuckets| kbuckets
-                .write()
-                .iter()
-                .map(|peer| format!("enr: {:?}, status: {:?}", peer.node.value, peer.status)).collect::<Vec<_>>()
-            ).into_iter().format(", ")),
-            "added boot nodes"
-        );
-
-        Ok(())
+        Ok(_ = join_all(enr_requests).await)
     }
 
     /// Backgrounds regular look up queries, in order to keep kbuckets populated.

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -477,7 +477,8 @@ impl Discv5 {
         &self,
         enr: &discv5::enr::Enr<K>,
     ) -> Result<ForkId, Error> {
-        let mut fork_id_bytes = enr.get_raw_rlp(self.fork_id_key()).ok_or(Error::ForkMissing)?;
+        let key = self.fork_id_key;
+        let mut fork_id_bytes = enr.get_raw_rlp(key).ok_or(Error::ForkMissing(key))?;
 
         Ok(ForkId::decode(&mut fork_id_bytes)?)
     }

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -629,21 +629,21 @@ mod tests {
         // verify node_1:discv5 is connected to node_2:discv5 and vv
         let event_2_v5 = stream_2.recv().await.unwrap();
         let event_1_v5 = stream_1.recv().await.unwrap();
-        matches!(
+        assert!(matches!(
             event_1_v5,
             discv5::Event::SessionEstablished(node, socket) if node == node_2_enr && socket == node_2_enr.udp4_socket().unwrap().into()
-        );
-        matches!(
+        ));
+        assert!(matches!(
             event_2_v5,
             discv5::Event::SessionEstablished(node, socket) if node == node_1_enr && socket == node_1_enr.udp4_socket().unwrap().into()
-        );
+        ));
 
         // verify node_1 is in KBuckets of node_2:discv5
         let event_2_v5 = stream_2.recv().await.unwrap();
-        matches!(
+        assert!(matches!(
             event_2_v5,
             discv5::Event::NodeInserted { node_id, replaced } if node_id == node_1_enr.node_id() && replaced.is_none()
-        );
+        ));
     }
 
     #[test]

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -29,7 +29,7 @@ reth-rpc-types.workspace = true
 reth-tokio-util.workspace = true
 
 # ethereum
-enr = { workspace = true, features = ["rust-secp256k1"], optional = true }
+enr = { workspace = true, features = ["serde", "rust-secp256k1"] }
 alloy-rlp.workspace = true
 discv5.workspace = true
 
@@ -84,8 +84,6 @@ alloy-node-bindings.workspace = true
 ethers-core = { workspace = true, default-features = false }
 ethers-providers = { workspace = true, default-features = false, features = ["ws"] }
 
-enr = { workspace = true, features = ["serde", "rust-secp256k1"] }
-
 # misc
 serial_test.workspace = true
 tempfile.workspace = true
@@ -96,10 +94,9 @@ criterion = { workspace = true, features = ["async_tokio", "html_reports"] }
 
 [features]
 default = ["serde"]
-serde = ["dep:serde", "dep:humantime-serde", "secp256k1/serde", "enr?/serde", "dep:serde_json"]
+serde = ["dep:serde", "dep:humantime-serde", "secp256k1/serde", "enr/serde", "dep:serde_json"]
 test-utils = [
     "reth-provider/test-utils",
-    "dep:enr",
     "dep:tempfile",
     "reth-transaction-pool/test-utils",
 ]

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -155,10 +155,8 @@ impl<C> NetworkConfig<C> {
     }
 
     /// Sets the config to use for the discovery v5 protocol.
-
     pub fn set_discovery_v5(mut self, discv5_config: reth_discv5::Config) -> Self {
         self.discovery_v5_config = Some(discv5_config);
-        self.discovery_v4_addr = self.discovery_v5_config.as_ref().unwrap().discovery_socket();
         self
     }
 

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -43,12 +43,12 @@ pub struct NetworkConfig<C> {
     pub boot_nodes: HashSet<NodeRecord>,
     /// How to set up discovery over DNS.
     pub dns_discovery_config: Option<DnsDiscoveryConfig>,
+    /// Address to use for discovery v4.
+    pub discovery_v4_addr: SocketAddr,
     /// How to set up discovery.
     pub discovery_v4_config: Option<Discv4Config>,
     /// How to set up discovery version 5.
     pub discovery_v5_config: Option<reth_discv5::Config>,
-    /// Address to use for discovery
-    pub discovery_addr: SocketAddr,
     /// Address to listen for incoming connections
     pub listener_addr: SocketAddr,
     /// How to instantiate peer manager.
@@ -158,7 +158,7 @@ impl<C> NetworkConfig<C> {
 
     pub fn set_discovery_v5(mut self, discv5_config: reth_discv5::Config) -> Self {
         self.discovery_v5_config = Some(discv5_config);
-        self.discovery_addr = self.discovery_v5_config.as_ref().unwrap().discovery_socket();
+        self.discovery_v4_addr = self.discovery_v5_config.as_ref().unwrap().discovery_socket();
         self
     }
 
@@ -567,7 +567,7 @@ impl NetworkConfigBuilder {
             dns_discovery_config,
             discovery_v4_config: discovery_v4_builder.map(|builder| builder.build()),
             discovery_v5_config: None,
-            discovery_addr: discovery_addr.unwrap_or(DEFAULT_DISCOVERY_ADDRESS),
+            discovery_v4_addr: discovery_addr.unwrap_or(DEFAULT_DISCOVERY_ADDRESS),
             listener_addr,
             peers_config: peers_config.unwrap_or_default(),
             sessions_config: sessions_config.unwrap_or_default(),

--- a/crates/net/network/src/discovery.rs
+++ b/crates/net/network/src/discovery.rs
@@ -158,12 +158,18 @@ impl Discovery {
         if let Some(discv4) = &self.discv4 {
             discv4.ban_ip(ip)
         }
+        if let Some(discv5) = &self.discv5 {
+            discv5.ban_peer_by_ip(ip)
+        }
     }
 
     /// Bans the [`PeerId`] and [`IpAddr`] in the discovery service.
     pub(crate) fn ban(&self, peer_id: PeerId, ip: IpAddr) {
         if let Some(discv4) = &self.discv4 {
             discv4.ban(peer_id, ip)
+        }
+        if let Some(discv5) = &self.discv5 {
+            discv5.ban_peer_by_ip_and_node_id(peer_id, ip)
         }
     }
 

--- a/crates/net/network/src/discovery.rs
+++ b/crates/net/network/src/discovery.rs
@@ -27,8 +27,8 @@ use tracing::trace;
 
 /// Default max capacity for cache of discovered peers.
 ///
-/// Default is 1000 peers.
-pub const DEFAULT_MAX_CAPACITY_DISCOVERED_PEERS_CACHE: u32 = 1000;
+/// Default is 10 000 peers.
+pub const DEFAULT_MAX_CAPACITY_DISCOVERED_PEERS_CACHE: u32 = 10_000;
 
 /// An abstraction over the configured discovery protocol.
 ///

--- a/crates/net/network/src/discovery.rs
+++ b/crates/net/network/src/discovery.rs
@@ -40,7 +40,7 @@ pub struct Discovery {
     ///
     /// These nodes can be ephemeral and are updated via the discovery protocol.
     discovered_nodes: LruMap<PeerId, SocketAddr>,
-    /// Local ENR of the discovery v4 service.
+    /// Local ENR of the discovery v4 service (discv5 ENR has same [`PeerId`]).
     local_enr: NodeRecord,
     /// Handler to interact with the Discovery v4 service
     discv4: Option<Discv4>,

--- a/crates/net/network/src/discovery.rs
+++ b/crates/net/network/src/discovery.rs
@@ -150,6 +150,7 @@ impl Discovery {
             // use forward-compatible forkid entry
             discv4.set_eip868_rlp("eth".as_bytes().to_vec(), EnrForkIdEntry::from(fork_id))
         }
+        // todo: update discv5 enr
     }
 
     /// Bans the [`IpAddr`] in the discovery service.

--- a/crates/net/network/src/discovery.rs
+++ b/crates/net/network/src/discovery.rs
@@ -355,7 +355,7 @@ mod tests {
         .unwrap();
     }
 
-    use reth_discv4::{DiscoveryUpdate, Discv4ConfigBuilder};
+    use reth_discv4::Discv4ConfigBuilder;
     use reth_discv5::{enr::EnrCombinedKeyWrapper, enr_to_discv4_id};
     use tracing::trace;
 

--- a/crates/net/network/src/discovery.rs
+++ b/crates/net/network/src/discovery.rs
@@ -159,7 +159,7 @@ impl Discovery {
             discv4.ban_ip(ip)
         }
         if let Some(discv5) = &self.discv5 {
-            discv5.ban_peer_by_ip(ip)
+            discv5.ban_ip(ip)
         }
     }
 
@@ -169,7 +169,7 @@ impl Discovery {
             discv4.ban(peer_id, ip)
         }
         if let Some(discv5) = &self.discv5 {
-            discv5.ban_peer_by_ip_and_node_id(peer_id, ip)
+            discv5.ban(peer_id, ip)
         }
     }
 

--- a/crates/net/network/src/error.rs
+++ b/crates/net/network/src/error.rs
@@ -53,6 +53,9 @@ pub enum NetworkError {
     /// IO error when creating the discovery service
     #[error("failed to launch discovery service: {0}")]
     Discovery(io::Error),
+    /// An error occurred with discovery v5 node.
+    #[error("discv5 error, {0}")]
+    Discv5Error(#[from] reth_discv5::Error),
     /// Error when setting up the DNS resolver failed
     ///
     /// See also [DnsResolver](reth_dns_discovery::DnsResolver::from_system_conf)

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -177,8 +177,9 @@ where
         let NetworkConfig {
             client,
             secret_key,
+            discovery_v4_addr,
             mut discovery_v4_config,
-            discovery_addr,
+            discovery_v5_config,
             listener_addr,
             peers_config,
             sessions_config,
@@ -195,7 +196,7 @@ where
             tx_gossip_disabled,
             #[cfg(feature = "optimism")]
                 optimism_network_config: crate::config::OptimismNetworkConfig { sequencer_endpoint },
-            ..
+            transactions_manager_config: _,
         } = config;
 
         let peers_manager = PeersManager::new(peers_config);
@@ -213,9 +214,14 @@ where
             disc_config
         });
 
-        let discovery =
-            Discovery::new(discovery_addr, secret_key, discovery_v4_config, dns_discovery_config)
-                .await?;
+        let discovery = Discovery::new(
+            discovery_v4_addr,
+            secret_key,
+            discovery_v4_config,
+            discovery_v5_config,
+            dns_discovery_config,
+        )
+        .await?;
         // need to retrieve the addr here since provided port could be `0`
         let local_peer_id = discovery.local_id();
         let discv4 = discovery.discv4();

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -1031,7 +1031,7 @@ pub enum NetworkEvent {
     PeerRemoved(PeerId),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DiscoveredEvent {
     EventQueued { peer_id: PeerId, socket_addr: SocketAddr, fork_id: Option<ForkId> },
 }

--- a/crates/net/network/tests/it/startup.rs
+++ b/crates/net/network/tests/it/startup.rs
@@ -59,8 +59,8 @@ async fn test_discovery_addr_in_use() {
     let any_port_listener = TcpListener::bind(addr).await.unwrap();
     let port = any_port_listener.local_addr().unwrap().port();
     let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port));
-    let _discovery = Discovery::new(addr, secret_key, Some(disc_config), None).await.unwrap();
+    let _discovery = Discovery::new(addr, secret_key, Some(disc_config), None, None).await.unwrap();
     let disc_config = Discv4Config::default();
-    let result = Discovery::new(addr, secret_key, Some(disc_config), None).await;
+    let result = Discovery::new(addr, secret_key, Some(disc_config), None, None).await;
     assert!(is_addr_in_use_kind(&result.err().unwrap(), ServiceKind::Discovery(addr)));
 }


### PR DESCRIPTION
- Starts `Discv5` in `reth-network`.
- Streams discv5 events
- Adds peers discovered by dns to discv5
- Extends peer banning to discv5

Shortcoming:

Unable to update discv5 fork id out of the box. Sigp/discv5 only exposes method `enr_insert`, ~~which internally rlp encodes the given value. Conversion from `ForkId` into BE bytes must be implemented, I started this but moved it to another branch,~~ since this doesn't effect any other network than L1 atm. This is because`ForkId` update isn't configured for other keys than `'eth'`, and fixing that would be out of scope.

update: sigp/discv5 has moved to `alloy_rlp` on master
