### PR TITLE
feat(discv5): disable noisy logs

### DIFF
--- a/crates/tracing/src/layers.rs
+++ b/crates/tracing/src/layers.rs
@@ -18,9 +18,9 @@ pub(crate) type BoxedLayer<S> = Box<dyn Layer<S> + Send + Sync>;
 const RETH_LOG_FILE_NAME: &str = "reth.log";
 
 /// Default [directives](Directive) for [EnvFilter] which disables high-frequency debug logs from
-/// `hyper` and `trust-dns`
-const DEFAULT_ENV_FILTER_DIRECTIVES: [&str; 3] =
-    ["hyper::proto::h1=off", "trust_dns_proto=off", "trust_dns_resolver=off"];
+/// `hyper`, `trust-dns` and `discv5`.
+const DEFAULT_ENV_FILTER_DIRECTIVES: [&str; 4] =
+    ["hyper::proto::h1=off", "trust_dns_proto=off", "trust_dns_resolver=off", "discv5=off"];
 
 /// Manages the collection of layers for a tracing subscriber.
 ///


### PR DESCRIPTION
Disables noisy logs from sigp/discv5. The logs are disproportionately verbose compared to reth logs, drowning out reth logs if enabled.