### PR TITLE
chore(tree): accept owned block hash in `make_canonical` instead of ref

### DIFF
--- a/crates/blockchain-tree/src/noop.rs
+++ b/crates/blockchain-tree/src/noop.rs
@@ -53,8 +53,8 @@ impl BlockchainTreeEngine for NoopBlockchainTree {
         Ok(())
     }
 
-    fn make_canonical(&self, block_hash: &BlockHash) -> Result<CanonicalOutcome, CanonicalError> {
-        Err(BlockchainTreeError::BlockHashNotFoundInChain { block_hash: *block_hash }.into())
+    fn make_canonical(&self, block_hash: BlockHash) -> Result<CanonicalOutcome, CanonicalError> {
+        Err(BlockchainTreeError::BlockHashNotFoundInChain { block_hash }.into())
     }
 
     fn unwind(&self, _unwind_to: BlockNumber) -> RethResult<()> {

--- a/crates/blockchain-tree/src/shareable.rs
+++ b/crates/blockchain-tree/src/shareable.rs
@@ -60,7 +60,7 @@ where
         block: SealedBlockWithSenders,
         validation_kind: BlockValidationKind,
     ) -> Result<InsertPayloadOk, InsertBlockError> {
-        trace!(target: "blockchain_tree", hash=?block.hash(), number=block.number, parent_hash=?block.parent_hash, "Inserting block");
+        trace!(target: "blockchain_tree", hash = %block.hash(), number = block.number, parent_hash = %block.parent_hash, "Inserting block");
         let mut tree = self.tree.write();
         let res = tree.insert_block(block, validation_kind);
         tree.update_chains_metrics();
@@ -68,7 +68,7 @@ where
     }
 
     fn finalize_block(&self, finalized_block: BlockNumber) {
-        trace!(target: "blockchain_tree", ?finalized_block, "Finalizing block");
+        trace!(target: "blockchain_tree", finalized_block, "Finalizing block");
         let mut tree = self.tree.write();
         tree.finalize_block(finalized_block);
         tree.update_chains_metrics();
@@ -78,7 +78,7 @@ where
         &self,
         last_finalized_block: BlockNumber,
     ) -> RethResult<()> {
-        trace!(target: "blockchain_tree", ?last_finalized_block, "Connecting buffered blocks to canonical hashes and finalizing the tree");
+        trace!(target: "blockchain_tree", last_finalized_block, "Connecting buffered blocks to canonical hashes and finalizing the tree");
         let mut tree = self.tree.write();
         let res =
             tree.connect_buffered_blocks_to_canonical_hashes_and_finalize(last_finalized_block);
@@ -94,8 +94,8 @@ where
         res
     }
 
-    fn make_canonical(&self, block_hash: &BlockHash) -> Result<CanonicalOutcome, CanonicalError> {
-        trace!(target: "blockchain_tree", ?block_hash, "Making block canonical");
+    fn make_canonical(&self, block_hash: BlockHash) -> Result<CanonicalOutcome, CanonicalError> {
+        trace!(target: "blockchain_tree", %block_hash, "Making block canonical");
         let mut tree = self.tree.write();
         let res = tree.make_canonical(block_hash);
         tree.update_chains_metrics();
@@ -103,7 +103,7 @@ where
     }
 
     fn unwind(&self, unwind_to: BlockNumber) -> RethResult<()> {
-        trace!(target: "blockchain_tree", ?unwind_to, "Unwinding to block number");
+        trace!(target: "blockchain_tree", unwind_to, "Unwinding to block number");
         let mut tree = self.tree.write();
         let res = tree.unwind(unwind_to);
         tree.update_chains_metrics();

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -373,7 +373,7 @@ where
         }
 
         let start = Instant::now();
-        let make_canonical_result = self.blockchain.make_canonical(&state.head_block_hash);
+        let make_canonical_result = self.blockchain.make_canonical(state.head_block_hash);
         let elapsed = self.record_make_canonical_latency(start, &make_canonical_result);
 
         let status = match make_canonical_result {
@@ -1542,7 +1542,7 @@ where
             // target might have changed since the block download request was issued
             // (new FCU received)
             let start = Instant::now();
-            let make_canonical_result = self.blockchain.make_canonical(&target.head_block_hash);
+            let make_canonical_result = self.blockchain.make_canonical(target.head_block_hash);
             let elapsed = self.record_make_canonical_latency(start, &make_canonical_result);
             match make_canonical_result {
                 Ok(outcome) => {
@@ -1586,7 +1586,7 @@ where
                             .filter(|h| !h.is_head())
                         {
                             // TODO: do not ignore this
-                            let _ = self.blockchain.make_canonical(target_hash.as_ref());
+                            let _ = self.blockchain.make_canonical(*target_hash.as_ref());
                         }
                     }
 

--- a/crates/interfaces/src/blockchain_tree/mod.rs
+++ b/crates/interfaces/src/blockchain_tree/mod.rs
@@ -96,7 +96,7 @@ pub trait BlockchainTreeEngine: BlockchainTreeViewer + Send + Sync {
     /// # Returns
     ///
     /// Returns `Ok` if the blocks were canonicalized, or if the blocks were already canonical.
-    fn make_canonical(&self, block_hash: &BlockHash) -> Result<CanonicalOutcome, CanonicalError>;
+    fn make_canonical(&self, block_hash: BlockHash) -> Result<CanonicalOutcome, CanonicalError>;
 
     /// Unwind tables and put it inside state
     fn unwind(&self, unwind_to: BlockNumber) -> RethResult<()>;

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -669,7 +669,7 @@ where
         self.tree.connect_buffered_blocks_to_canonical_hashes()
     }
 
-    fn make_canonical(&self, block_hash: &BlockHash) -> Result<CanonicalOutcome, CanonicalError> {
+    fn make_canonical(&self, block_hash: BlockHash) -> Result<CanonicalOutcome, CanonicalError> {
         self.tree.make_canonical(block_hash)
     }
 


### PR DESCRIPTION
## Description

Accept owned block hash in `make_canonical`. Ref #7154 