### PR TITLE
chore: allow transmute annotations

### DIFF
--- a/bin/reth/src/commands/stage/run.rs
+++ b/bin/reth/src/commands/stage/run.rs
@@ -261,7 +261,7 @@ impl Command {
                 _ => return Ok(()),
             };
         if let Some(unwind_stage) = &unwind_stage {
-            assert_eq!(exec_stage.type_id(), unwind_stage.type_id());
+            assert_eq!((*exec_stage).type_id(), (*unwind_stage).type_id());
         }
 
         let checkpoint = provider_rw.get_stage_checkpoint(exec_stage.id())?.unwrap_or_default();

--- a/bin/reth/src/commands/stage/run.rs
+++ b/bin/reth/src/commands/stage/run.rs
@@ -261,7 +261,7 @@ impl Command {
                 _ => return Ok(()),
             };
         if let Some(unwind_stage) = &unwind_stage {
-            assert_eq!((*exec_stage).type_id(), (*unwind_stage).type_id());
+            assert_eq!((*exec_stage).type_id(), (**unwind_stage).type_id());
         }
 
         let checkpoint = provider_rw.get_stage_checkpoint(exec_stage.id())?.unwrap_or_default();

--- a/crates/net/eth-wire-types/src/lib.rs
+++ b/crates/net/eth-wire-types/src/lib.rs
@@ -6,6 +6,8 @@
     issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
+// TODO: remove when https://github.com/proptest-rs/proptest/pull/427 is merged
+#![allow(unknown_lints, non_local_definitions)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod status;

--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -911,6 +911,7 @@ unsafe fn handle_slow_readers_callback(callback: HandleSlowReadersCallback) -> f
     std::mem::forget(closure);
 
     // Cast the closure to FFI `extern fn` type.
+    #[allow(clippy::missing_transmute_annotations)]
     Some(std::mem::transmute(closure_ptr))
 }
 


### PR DESCRIPTION
can allow this because this maps to the return type