### PR TITLE
feat: exex crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6799,6 +6799,7 @@ dependencies = [
  "reth-db",
  "reth-ethereum-payload-builder",
  "reth-evm-ethereum",
+ "reth-exex",
  "reth-network",
  "reth-node-api",
  "reth-node-builder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6455,6 +6455,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-exex"
+version = "0.2.0-beta.5"
+dependencies = [
+ "reth-config",
+ "reth-node-api",
+ "reth-node-core",
+ "reth-primitives",
+ "reth-provider",
+ "reth-tasks",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "reth-interfaces"
 version = "0.2.0-beta.5"
 dependencies = [
@@ -6690,6 +6704,7 @@ dependencies = [
  "reth-blockchain-tree",
  "reth-config",
  "reth-db",
+ "reth-exex",
  "reth-interfaces",
  "reth-network",
  "reth-node-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6465,7 +6465,6 @@ dependencies = [
  "reth-provider",
  "reth-tasks",
  "tokio",
- "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/etl/",
     "crates/evm/",
     "crates/evm-ethereum/",
+    "crates/exex/",
     "crates/interfaces/",
     "crates/metrics/",
     "crates/metrics/metrics-derive/",
@@ -217,6 +218,7 @@ reth-ethereum-payload-builder = { path = "crates/payload/ethereum" }
 reth-etl = { path = "crates/etl" }
 reth-evm = { path = "crates/evm" }
 reth-evm-ethereum = { path = "crates/evm-ethereum" }
+reth-exex = { path = "crates/exex" }
 reth-optimism-payload-builder = { path = "crates/payload/optimism" }
 reth-interfaces = { path = "crates/interfaces" }
 reth-ipc = { path = "crates/rpc/ipc" }
@@ -252,8 +254,13 @@ reth-trie = { path = "crates/trie" }
 reth-trie-parallel = { path = "crates/trie-parallel" }
 
 # revm
-revm = { version = "8.0.0", features = ["std", "secp256k1"], default-features = false }
-revm-primitives = { version = "3.1.0", features = ["std"], default-features = false }
+revm = { version = "8.0.0", features = [
+    "std",
+    "secp256k1",
+], default-features = false }
+revm-primitives = { version = "3.1.0", features = [
+    "std",
+], default-features = false }
 revm-inspectors = { git = "https://github.com/paradigmxyz/evm-inspectors", rev = "5baa6b3" }
 
 # eth

--- a/crates/exex/Cargo.toml
+++ b/crates/exex/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "reth-exex"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Execution extensions for Reth"
+
+[lints]
+workspace = true
+
+[dependencies]
+reth-config.workspace = true
+reth-node-api.workspace = true
+reth-node-core.workspace = true
+reth-primitives.workspace = true
+reth-provider.workspace = true
+reth-tasks.workspace = true
+tokio.workspace = true
+tokio-util.workspace = true

--- a/crates/exex/Cargo.toml
+++ b/crates/exex/Cargo.toml
@@ -19,4 +19,3 @@ reth-primitives.workspace = true
 reth-provider.workspace = true
 reth-tasks.workspace = true
 tokio.workspace = true
-tokio-util.workspace = true

--- a/crates/exex/src/context.rs
+++ b/crates/exex/src/context.rs
@@ -29,9 +29,16 @@ pub struct ExExContext<Node: FullNodeTypes> {
     ///
     /// # Important
     ///
-    /// The node expects at least one `FinishedHeight` event in order to prune blocks.
+    /// The exex should emit a `FinishedHeight` whenever a processed block is safe to prune.
+    /// Additionally, the exex can pre-emptively emit a `FinishedHeight` event to specify what
+    /// blocks to receive notifications for.
     pub events: Sender<ExExEvent>,
     /// Channel to receive [`CanonStateNotification`]s on state transitions.
+    ///
+    /// # Important
+    ///
+    /// Once a `CanonStateNotification` is sent over the channel, it is considered delivered by the
+    /// node.
     pub notifications: Receiver<CanonStateNotification>,
     // TODO(alexey): add pool, payload builder, anything else?
 }

--- a/crates/exex/src/context.rs
+++ b/crates/exex/src/context.rs
@@ -1,0 +1,25 @@
+use reth_node_api::FullNodeTypes;
+use reth_node_core::{
+    dirs::{ChainPath, DataDirPath},
+    node_config::NodeConfig,
+};
+use reth_primitives::Head;
+use reth_tasks::TaskExecutor;
+
+/// Captures the context that an ExEx has access to.
+#[derive(Clone, Debug)]
+pub struct ExExContext<Node: FullNodeTypes> {
+    /// The current head of the blockchain at launch.
+    pub head: Head,
+    /// The configured provider to interact with the blockchain.
+    pub provider: Node::Provider,
+    /// The task executor of the node.
+    pub task_executor: TaskExecutor,
+    /// The data dir of the node.
+    pub data_dir: ChainPath<DataDirPath>,
+    /// The config of the node
+    pub config: NodeConfig,
+    /// The loaded node config
+    pub reth_config: reth_config::Config,
+    // TODO(alexey): add pool, payload builder, anything else?
+}

--- a/crates/exex/src/context.rs
+++ b/crates/exex/src/context.rs
@@ -4,10 +4,14 @@ use reth_node_core::{
     node_config::NodeConfig,
 };
 use reth_primitives::Head;
+use reth_provider::CanonStateNotification;
 use reth_tasks::TaskExecutor;
+use tokio::sync::mpsc::{Receiver, Sender};
+
+use crate::ExExEvent;
 
 /// Captures the context that an ExEx has access to.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct ExExContext<Node: FullNodeTypes> {
     /// The current head of the blockchain at launch.
     pub head: Head,
@@ -21,5 +25,13 @@ pub struct ExExContext<Node: FullNodeTypes> {
     pub config: NodeConfig,
     /// The loaded node config
     pub reth_config: reth_config::Config,
+    /// Channel used to send [`ExExEvent`]s to the rest of the node.
+    ///
+    /// # Important
+    ///
+    /// The node expects at least one `FinishedHeight` event in order to prune blocks.
+    pub events: Sender<ExExEvent>,
+    /// Channel to receive [`CanonStateNotification`]s on state transitions.
+    pub notifications: Receiver<CanonStateNotification>,
     // TODO(alexey): add pool, payload builder, anything else?
 }

--- a/crates/exex/src/event.rs
+++ b/crates/exex/src/event.rs
@@ -1,0 +1,13 @@
+use reth_primitives::BlockNumber;
+
+/// Events emitted by an ExEx.
+#[derive(Debug)]
+pub enum ExExEvent {
+    /// Highest block processed by the ExEx.
+    ///
+    /// The ExEx must guarantee that it will not require all earlier blocks in the future, meaning
+    /// that Reth is allowed to prune them.
+    ///
+    /// On reorgs, it's possible for the height to go down.
+    FinishedHeight(BlockNumber),
+}

--- a/crates/exex/src/lib.rs
+++ b/crates/exex/src/lib.rs
@@ -1,0 +1,15 @@
+//! Execution extensions.
+//!
+//! TBD
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
+    html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
+    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
+)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
+mod context;
+pub use context::*;
+
+mod event;
+pub use event::*;

--- a/crates/exex/src/lib.rs
+++ b/crates/exex/src/lib.rs
@@ -7,6 +7,7 @@
     issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 mod context;
 pub use context::*;

--- a/crates/node-builder/Cargo.toml
+++ b/crates/node-builder/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 reth-auto-seal-consensus.workspace = true
 reth-beacon-consensus.workspace = true
 reth-blockchain-tree.workspace = true
+reth-exex.workspace = true
 reth-provider.workspace = true
 reth-revm.workspace = true
 reth-db.workspace = true

--- a/crates/node-builder/src/builder.rs
+++ b/crates/node-builder/src/builder.rs
@@ -7,7 +7,7 @@ use crate::{
         ComponentsBuilder, FullNodeComponents, FullNodeComponentsAdapter, NodeComponents,
         NodeComponentsBuilder, PoolBuilder,
     },
-    exex::{BoxedLaunchExEx, ExExContext},
+    exex::BoxedLaunchExEx,
     hooks::NodeHooks,
     node::FullNode,
     rpc::{RethRpcServerHandles, RpcContext, RpcHooks},
@@ -28,6 +28,7 @@ use reth_db::{
     test_utils::{create_test_rw_db, TempDatabase},
     DatabaseEnv,
 };
+use reth_exex::ExExContext;
 use reth_interfaces::p2p::either::EitherDownloader;
 use reth_network::{NetworkBuilder, NetworkConfig, NetworkEvents, NetworkHandle};
 use reth_node_api::{FullNodeTypes, FullNodeTypesAdapter, NodeTypes};

--- a/crates/node-builder/src/exex.rs
+++ b/crates/node-builder/src/exex.rs
@@ -30,43 +30,8 @@
 
 use crate::FullNodeTypes;
 use futures::{future::BoxFuture, FutureExt};
-use reth_node_core::{
-    dirs::{ChainPath, DataDirPath},
-    node_config::NodeConfig,
-};
-use reth_primitives::{BlockNumber, Head};
-use reth_tasks::TaskExecutor;
+use reth_exex::ExExContext;
 use std::future::Future;
-
-/// Events emitted by an ExEx.
-#[derive(Debug)]
-pub enum ExExEvent {
-    /// Highest block processed by the ExEx.
-    ///
-    /// The ExEx must guarantee that it will not require all earlier blocks in the future, meaning
-    /// that Reth is allowed to prune them.
-    ///
-    /// On reorgs, it's possible for the height to go down.
-    FinishedHeight(BlockNumber),
-}
-
-/// Captures the context that an ExEx has access to.
-#[derive(Clone, Debug)]
-pub struct ExExContext<Node: FullNodeTypes> {
-    /// The current head of the blockchain at launch.
-    pub head: Head,
-    /// The configured provider to interact with the blockchain.
-    pub provider: Node::Provider,
-    /// The task executor of the node.
-    pub task_executor: TaskExecutor,
-    /// The data dir of the node.
-    pub data_dir: ChainPath<DataDirPath>,
-    /// The config of the node
-    pub config: NodeConfig,
-    /// The loaded node config
-    pub reth_config: reth_config::Config,
-    // TODO(alexey): add pool, payload builder, anything else?
-}
 
 /// A trait for launching an ExEx.
 trait LaunchExEx<Node: FullNodeTypes>: Send {

--- a/crates/node-builder/src/exex.rs
+++ b/crates/node-builder/src/exex.rs
@@ -25,7 +25,7 @@
 //! `block_number >= 0`.
 //!
 //! [`Future`]: std::future::Future
-//! [`ExExContext`]: crate::exex::ExExContext
+//! [`ExExContext`]: reth_exex::ExExContext
 //! [`CanonStateNotification`]: reth_provider::CanonStateNotification
 
 use crate::FullNodeTypes;

--- a/crates/node-ethereum/Cargo.toml
+++ b/crates/node-ethereum/Cargo.toml
@@ -31,5 +31,5 @@ serde.workspace = true
 
 [dev-dependencies]
 reth-db.workspace = true
+reth-exex.workspace = true
 futures.workspace = true
-

--- a/crates/node-ethereum/tests/it/exex.rs
+++ b/crates/node-ethereum/tests/it/exex.rs
@@ -1,6 +1,7 @@
 use futures::future;
 use reth_db::test_utils::create_test_rw_db;
-use reth_node_builder::{exex::ExExContext, FullNodeTypes, NodeBuilder, NodeConfig};
+use reth_exex::ExExContext;
+use reth_node_builder::{FullNodeTypes, NodeBuilder, NodeConfig};
 use reth_node_ethereum::EthereumNode;
 use std::{
     future::Future,


### PR DESCRIPTION
Pulls out moving things to `reth-exex` from #7340 to allow @shekhirin to work on exex examples/tests in parallel with that PR.

Also adds two new fields to `ExExContext`, one for sending events and one for receiving `CanonStateNotification`s.

#7340 will be rebased on top

I don't have pending changes to this unless a review has something, so feel free to merge this once approved