### PR TITLE
chore: rm unused execute function

### DIFF
--- a/crates/revm/src/optimism/processor.rs
+++ b/crates/revm/src/optimism/processor.rs
@@ -45,15 +45,6 @@ where
 {
     type Error = BlockExecutionError;
 
-    fn execute(
-        &mut self,
-        block: &BlockWithSenders,
-        total_difficulty: U256,
-    ) -> Result<(), BlockExecutionError> {
-        let receipts = self.execute_inner(block, total_difficulty)?;
-        self.save_receipts(receipts)
-    }
-
     fn execute_and_verify_receipt(
         &mut self,
         block: &BlockWithSenders,
@@ -216,8 +207,8 @@ mod tests {
         test_utils::{StateProviderTest, TestEvmConfig},
     };
     use reth_primitives::{
-        Account, Address, Block, ChainSpecBuilder, Header, Signature, StorageKey, StorageValue,
-        Transaction, TransactionKind, TransactionSigned, TxEip1559, BASE_MAINNET,
+        b256, Account, Address, Block, ChainSpecBuilder, Header, Signature, StorageKey,
+        StorageValue, Transaction, TransactionKind, TransactionSigned, TxEip1559, BASE_MAINNET,
     };
     use revm::L1_BLOCK_CONTRACT;
     use std::{collections::HashMap, str::FromStr, sync::Arc};
@@ -269,7 +260,10 @@ mod tests {
             number: 1,
             gas_limit: 1_000_000,
             gas_used: 42_000,
-            ..Header::default()
+            receipts_root: b256!(
+                "83465d1e7d01578c0d609be33570f91242f013e9e295b0879905346abbd63731"
+            ),
+            ..Default::default()
         };
 
         let mut db = create_op_state_provider();
@@ -306,7 +300,7 @@ mod tests {
 
         // Attempt to execute a block with one deposit and one non-deposit transaction
         executor
-            .execute(
+            .execute_and_verify_receipt(
                 &BlockWithSenders {
                     block: Block {
                         header,
@@ -340,7 +334,10 @@ mod tests {
             number: 1,
             gas_limit: 1_000_000,
             gas_used: 42_000,
-            ..Header::default()
+            receipts_root: b256!(
+                "fffc85c4004fd03c7bfbe5491fae98a7473126c099ac11e8286fd0013f15f908"
+            ),
+            ..Default::default()
         };
 
         let mut db = create_op_state_provider();
@@ -377,7 +374,7 @@ mod tests {
 
         // attempt to execute an empty block with parent beacon block root, this should not fail
         executor
-            .execute(
+            .execute_and_verify_receipt(
                 &BlockWithSenders {
                     block: Block {
                         header,

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -408,15 +408,6 @@ where
 {
     type Error = BlockExecutionError;
 
-    fn execute(
-        &mut self,
-        block: &BlockWithSenders,
-        total_difficulty: U256,
-    ) -> Result<(), BlockExecutionError> {
-        let receipts = self.execute_inner(block, total_difficulty)?;
-        self.save_receipts(receipts)
-    }
-
     fn execute_and_verify_receipt(
         &mut self,
         block: &BlockWithSenders,
@@ -660,7 +651,7 @@ mod tests {
 
         // Now execute a block with the fixed header, ensure that it does not fail
         executor
-            .execute(
+            .execute_and_verify_receipt(
                 &BlockWithSenders {
                     block: Block {
                         header: header.clone(),
@@ -854,7 +845,7 @@ mod tests {
         // now try to process the genesis block again, this time ensuring that a system contract
         // call does not occur
         executor
-            .execute(
+            .execute_and_verify_receipt(
                 &BlockWithSenders {
                     block: Block {
                         header: header.clone(),
@@ -913,7 +904,7 @@ mod tests {
 
         // Now execute a block with the fixed header, ensure that it does not fail
         executor
-            .execute(
+            .execute_and_verify_receipt(
                 &BlockWithSenders {
                     block: Block {
                         header: header.clone(),

--- a/crates/storage/provider/src/test_utils/executor.rs
+++ b/crates/storage/provider/src/test_utils/executor.rs
@@ -13,17 +13,6 @@ pub struct TestExecutor(pub Option<BundleStateWithReceipts>);
 impl BlockExecutor for TestExecutor {
     type Error = BlockExecutionError;
 
-    fn execute(
-        &mut self,
-        _block: &BlockWithSenders,
-        _total_difficulty: U256,
-    ) -> Result<(), BlockExecutionError> {
-        if self.0.is_none() {
-            return Err(BlockExecutionError::UnavailableForTest)
-        }
-        Ok(())
-    }
-
     fn execute_and_verify_receipt(
         &mut self,
         _block: &BlockWithSenders,

--- a/crates/storage/provider/src/traits/executor.rs
+++ b/crates/storage/provider/src/traits/executor.rs
@@ -18,20 +18,18 @@ pub trait ExecutorFactory: Send + Sync + 'static {
 }
 
 /// An executor capable of executing a block.
+///
+/// This type is capable of executing (multiple) blocks by applying the state changes made by each
+/// block. The final state of the executor can extracted using
+/// [take_output_state](BlockExecutor::take_output_state).
 pub trait BlockExecutor {
     /// The error type returned by the executor.
     type Error;
 
-    /// Execute a block.
-    fn execute(
-        &mut self,
-        block: &BlockWithSenders,
-        total_difficulty: U256,
-    ) -> Result<(), Self::Error>;
-
-    /// Executes the block and checks receipts.
+    /// Executes the entire block and verifies:
+    ///  - receipts (receipts root)
     ///
-    /// See [execute](BlockExecutor::execute) for more details.
+    /// This will update the state of the executor with the changes made by the block.
     fn execute_and_verify_receipt(
         &mut self,
         block: &BlockWithSenders,

--- a/crates/storage/provider/src/traits/executor.rs
+++ b/crates/storage/provider/src/traits/executor.rs
@@ -47,7 +47,8 @@ pub trait BlockExecutor {
     ///
     /// The second returned value represents the total gas used by this block of transactions.
     ///
-    /// See [execute](BlockExecutor::execute) for more details.
+    /// See [execute_and_verify_receipt](BlockExecutor::execute_and_verify_receipt) for more
+    /// details.
     fn execute_transactions(
         &mut self,
         block: &BlockWithSenders,


### PR DESCRIPTION
ref #7392

removes `BlockExecutor::execute` which isn't used.

this is an incremental step towards a simpler executor trait