### PR TITLE
chore: add `asm-keccak` to reth crate docs

### DIFF
--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -9,6 +9,9 @@
 //!   and leak detection functionality. See [jemalloc's opt.prof](https://jemalloc.net/jemalloc.3.html#opt.prof)
 //!   documentation for usage details. This is **not recommended on Windows**. See [here](https://rust-lang.github.io/rfcs/1974-global-allocators.html#jemalloc)
 //!   for more info.
+//! - `asm-keccak`: replaces the default, pure-Rust implementation of Keccak256 with one implemented
+//!   in assembly; see [the `keccak-asm` crate](https://github.com/DaniPopes/keccak-asm) for more
+//!   details and supported targets
 //! - `min-error-logs`: Disables all logs below `error` level.
 //! - `min-warn-logs`: Disables all logs below `warn` level.
 //! - `min-info-logs`: Disables all logs below `info` level. This can speed up the node, since fewer


### PR DESCRIPTION
`asm-keccak` was missing from the crate-level docs, but existed in the book, so I copied over the description from there.