### PR TITLE
chore: move request hashes failed log to trace

### DIFF
--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -488,7 +488,7 @@ impl TransactionFetcher {
         if let Some(failed_to_request_hashes) =
             self.request_transactions_from_peer(hashes_to_request, peer)
         {
-            debug!(target: "net::tx",
+            trace!(target: "net::tx",
                 peer_id=format!("{peer_id:#}"),
                 ?failed_to_request_hashes,
                 %conn_eth_version,

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -799,7 +799,7 @@ where
         {
             let conn_eth_version = peer.version;
 
-            debug!(target: "net::tx",
+            trace!(target: "net::tx",
                 peer_id=format!("{peer_id:#}"),
                 failed_to_request_hashes=?*failed_to_request_hashes,
                 %conn_eth_version,


### PR DESCRIPTION
Noticed that these logs were filling the persisted logs, and are relatively normal, especially if a single peer just became offline or is unresponsive. These also print the entire list of failed hashes, so these logs seem too verbose to be in `debug`. Moved the logs to `trace`