### PR TITLE
feat: add PeersInfo::local_enr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6629,6 +6629,7 @@ dependencies = [
 name = "reth-network-api"
 version = "0.2.0-beta.5"
 dependencies = [
+ "enr",
  "reth-discv4",
  "reth-eth-wire",
  "reth-primitives",

--- a/crates/net/network-api/Cargo.toml
+++ b/crates/net/network-api/Cargo.toml
@@ -17,11 +17,13 @@ reth-primitives.workspace = true
 reth-eth-wire.workspace = true
 reth-rpc-types.workspace = true
 reth-discv4.workspace = true
-# io
-serde = { workspace = true, features = ["derive"], optional = true }
+
+# eth
+enr = { workspace = true, default-features = false, features = ["rust-secp256k1"] }
 
 # misc
 thiserror.workspace = true
+serde = { workspace = true, features = ["derive"], optional = true }
 tokio = { workspace = true, features = ["sync"] }
 
 [features]

--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -57,6 +57,9 @@ pub trait PeersInfo: Send + Sync {
 
     /// Returns the Ethereum Node Record of the node.
     fn local_node_record(&self) -> NodeRecord;
+
+    /// Returns the local ENR of the node.
+    fn local_enr(&self) -> enr::Enr<enr::secp256k1::SecretKey>;
 }
 
 /// Provides an API for managing the peers of the network.

--- a/crates/net/network-api/src/noop.rs
+++ b/crates/net/network-api/src/noop.rs
@@ -7,6 +7,7 @@ use crate::{
     NetworkError, NetworkInfo, PeerInfo, PeerKind, Peers, PeersInfo, Reputation,
     ReputationChangeKind,
 };
+use enr::{secp256k1::SecretKey, Enr};
 use reth_discv4::DEFAULT_DISCOVERY_PORT;
 use reth_eth_wire::{DisconnectReason, ProtocolVersion};
 use reth_primitives::{Chain, NodeRecord, PeerId};
@@ -59,6 +60,11 @@ impl PeersInfo for NoopNetwork {
 
     fn local_node_record(&self) -> NodeRecord {
         NodeRecord::new(self.local_addr(), PeerId::random())
+    }
+
+    fn local_enr(&self) -> Enr<SecretKey> {
+        let sk = SecretKey::from_slice(&[0xcd; 32]).unwrap();
+        Enr::builder().build(&sk).unwrap()
     }
 }
 


### PR DESCRIPTION
this adds a new function to obtain the enr of the node.

enr mgmt can be improved but will open a separate issue for this.

this unblocks #7512