### PR TITLE
perf(pool): send blob sidecars as `Arc` to listeners

### DIFF
--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -574,6 +574,8 @@ where
 
     /// Notify all listeners about a blob sidecar for a newly inserted blob (eip4844) transaction.
     fn on_new_blob_sidecar(&self, tx_hash: &TxHash, sidecar: &BlobTransactionSidecar) {
+        let sidecar = Arc::new(sidecar.clone());
+
         let mut sidecar_listeners = self.blob_transaction_sidecar_listener.lock();
         sidecar_listeners.retain_mut(|listener| {
             let new_blob_event = NewBlobSidecar { tx_hash: *tx_hash, sidecar: sidecar.clone() };

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -530,7 +530,7 @@ pub struct NewBlobSidecar {
     /// hash of the EIP-4844 transaction.
     pub tx_hash: TxHash,
     /// the blob transaction sidecar.
-    pub sidecar: BlobTransactionSidecar,
+    pub sidecar: Arc<BlobTransactionSidecar>,
 }
 
 /// Where the transaction originates from.


### PR DESCRIPTION
`BlobTransactionSidecar` is a big type, and with many sidecar listeners, we'll do a clone on each sending. Instead, we should send `Arc`s.