### PR TITLE
ci: fix iai benches the sequel

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -34,11 +34,17 @@ jobs:
         uses: taiki-e/install-action@cargo-binstall
       - name: Install iai-callgrind-runner
         run: |
+          echo "::group::Install"
+          echo "Inside group"
           version=$(cargo metadata --format-version=1 |\
             jq '.packages[] | select(.name == "iai-callgrind").version' |\
             tr -d '"'
           )
           cargo binstall iai-callgrind-runner --version $version --no-confirm --no-symlinks
+          echo "::endgroup::"
+          echo "::group::Verification"
+          which iai-callgrind-runner
+          echo "::endgroup::"
       - name: Checkout base
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -40,7 +40,7 @@ jobs:
             jq '.packages[] | select(.name == "iai-callgrind").version' |\
             tr -d '"'
           )
-          cargo binstall iai-callgrind-runner --version $version --no-confirm --no-symlinks
+          cargo binstall iai-callgrind-runner --version $version --no-confirm --no-symlinks --force
           echo "::endgroup::"
           echo "::group::Verification"
           which iai-callgrind-runner

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -9,6 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   BASELINE: base
+  IAI_CALLGRIND_RUNNER: iai-callgrind-runner
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on:
       group: Reth
     # Only run benchmarks in merge groups
-    if: github.event_name != 'pull_request'
+    #if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - name: Install Valgrind

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on:
       group: Reth
     # Only run benchmarks in merge groups and on main
-    #if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - name: Install Valgrind
@@ -35,7 +35,6 @@ jobs:
       - name: Install iai-callgrind-runner
         run: |
           echo "::group::Install"
-          echo "Inside group"
           version=$(cargo metadata --format-version=1 |\
             jq '.packages[] | select(.name == "iai-callgrind").version' |\
             tr -d '"'

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -20,7 +20,7 @@ jobs:
   iai:
     runs-on:
       group: Reth
-    # Only run benchmarks in merge groups
+    # Only run benchmarks in merge groups and on main
     #if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The IAI workflow was failing on main because it could not find `iai-callgrind-runner`. On further investigation, it was because the cache in the workflow made `cargo binstall` think `iai-callgrind-runner` was already installed, while it was unavailable.

Quick and dirty fix: add `--force` to install `iai-callgrind-runner` every time