### PR TITLE
feat(storage): non-optional committed chain in CanonStateNotification

### DIFF
--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -194,23 +194,22 @@ where
     }
 
     fn on_new_state(&mut self, new_state: CanonStateNotification) {
-        if let Some(committed) = new_state.committed() {
-            let mut cached = CachedReads::default();
+        let mut cached = CachedReads::default();
 
-            // extract the state from the notification and put it into the cache
-            let new_state = committed.state();
-            for (addr, acc) in new_state.bundle_accounts_iter() {
-                if let Some(info) = acc.info.clone() {
-                    // we want pre cache existing accounts and their storage
-                    // this only includes changed accounts and storage but is better than nothing
-                    let storage =
-                        acc.storage.iter().map(|(key, slot)| (*key, slot.present_value)).collect();
-                    cached.insert_account(addr, info, storage);
-                }
+        // extract the state from the notification and put it into the cache
+        let committed = new_state.committed();
+        let new_state = committed.state();
+        for (addr, acc) in new_state.bundle_accounts_iter() {
+            if let Some(info) = acc.info.clone() {
+                // we want pre cache existing accounts and their storage
+                // this only includes changed accounts and storage but is better than nothing
+                let storage =
+                    acc.storage.iter().map(|(key, slot)| (*key, slot.present_value)).collect();
+                cached.insert_account(addr, info, storage);
             }
-
-            self.pre_cached = Some(PrecachedState { block: committed.tip().hash(), cached });
         }
+
+        self.pre_cached = Some(PrecachedState { block: committed.tip().hash(), cached });
     }
 }
 

--- a/crates/rpc/rpc/src/eth/api/fee_history.rs
+++ b/crates/rpc/rpc/src/eth/api/fee_history.rs
@@ -239,18 +239,17 @@ pub async fn fee_history_cache_new_blocks_task<St, Provider>(
                      // the stream ended, we are done
                     break;
                 };
-                if let Some(committed) = event.committed() {
-                    let (blocks, receipts): (Vec<_>, Vec<_>) = committed
-                        .blocks_and_receipts()
-                        .map(|(block, receipts)| {
-                            (block.block.clone(), Arc::new(receipts.iter().flatten().cloned().collect::<Vec<_>>()))
-                        })
-                        .unzip();
-                    fee_history_cache.insert_blocks(blocks.into_iter().zip(receipts)).await;
+                let (blocks, receipts): (Vec<_>, Vec<_>) = event
+                    .committed()
+                    .blocks_and_receipts()
+                    .map(|(block, receipts)| {
+                        (block.block.clone(), Arc::new(receipts.iter().flatten().cloned().collect::<Vec<_>>()))
+                    })
+                    .unzip();
+                fee_history_cache.insert_blocks(blocks.into_iter().zip(receipts)).await;
 
-                    // keep track of missing blocks
-                    missing_blocks = fee_history_cache.missing_consecutive_blocks().await;
-                }
+                // keep track of missing blocks
+                missing_blocks = fee_history_cache.missing_consecutive_blocks().await;
             }
         }
     }

--- a/crates/rpc/rpc/src/eth/cache/mod.rs
+++ b/crates/rpc/rpc/src/eth/cache/mod.rs
@@ -651,12 +651,9 @@ where
                 eth_state_cache.to_service.send(CacheAction::RemoveReorgedChain { chain_change });
         }
 
-        if let Some(committed) = event.committed() {
-            let chain_change = ChainChange::new(committed);
+        let chain_change = ChainChange::new(event.committed());
 
-            let _ = eth_state_cache
-                .to_service
-                .send(CacheAction::CacheNewCanonicalChain { chain_change });
-        }
+        let _ =
+            eth_state_cache.to_service.send(CacheAction::CacheNewCanonicalChain { chain_change });
     }
 }

--- a/crates/rpc/rpc/src/eth/pubsub.rs
+++ b/crates/rpc/rpc/src/eth/pubsub.rs
@@ -314,10 +314,7 @@ where
     /// Returns a stream that yields all new RPC blocks.
     fn new_headers_stream(&self) -> impl Stream<Item = Header> {
         self.chain_events.canonical_state_stream().flat_map(|new_chain| {
-            let headers = new_chain
-                .committed()
-                .map(|chain| chain.headers().collect::<Vec<_>>())
-                .unwrap_or_default();
+            let headers = new_chain.committed().headers().collect::<Vec<_>>();
             futures::stream::iter(
                 headers.into_iter().map(reth_rpc_types_compat::block::from_primitive_with_hash),
             )


### PR DESCRIPTION
`new` part of the `CanonStateNotification` always exists, so no need to return an `Option<Chain>` and we can return just `Chain` instead.