### PR TITLE
fix: still delete headers from db in headers unwind

### DIFF
--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -324,12 +324,12 @@ where
         // First unwind the db tables, until the unwind_to block number. use the walker to unwind
         // HeaderNumbers based on the index in CanonicalHeaders
         provider.unwind_table_by_walker::<tables::CanonicalHeaders, tables::HeaderNumbers>(
-            input.unwind_to,
+            input.unwind_to + 1,
         )?;
-        provider.unwind_table_by_num::<tables::CanonicalHeaders>(input.unwind_to)?;
-        provider.unwind_table_by_num::<tables::HeaderTerminalDifficulties>(input.unwind_to)?;
+        provider.unwind_table_by_num::<tables::CanonicalHeaders>(input.unwind_to + 1)?;
+        provider.unwind_table_by_num::<tables::HeaderTerminalDifficulties>(input.unwind_to + 1)?;
         let unfinalized_headers_unwound =
-            provider.unwind_table_by_num::<tables::Headers>(input.unwind_to)?;
+            provider.unwind_table_by_num::<tables::Headers>(input.unwind_to + 1)?;
 
         // determine how many headers to unwind from the static files based on the highest block and
         // the unwind_to block
@@ -617,8 +617,6 @@ mod tests {
         // let's insert some blocks using append_blocks_with_state
         let sealed_headers =
             random_header_range(&mut generators::rng(), tip.number..tip.number + 10, tip.hash());
-        println!("sealed_headers: {:?}", sealed_headers);
-        println!("tip num: {:?}", tip.number);
 
         // make them sealed blocks with senders by converting them to empty blocks
         let sealed_blocks = sealed_headers

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -21,8 +21,8 @@ use reth_primitives::{
     BlockHash, BlockNumber, SealedHeader, StaticFileSegment,
 };
 use reth_provider::{
-    providers::{StaticFileProvider, StaticFileWriter}, DatabaseProviderRW, HeaderProvider,
-    HeaderSyncGap, HeaderSyncGapProvider, HeaderSyncMode,
+    providers::{StaticFileProvider, StaticFileWriter},
+    DatabaseProviderRW, HeaderProvider, HeaderSyncGap, HeaderSyncGapProvider, HeaderSyncMode,
 };
 use reth_stages_api::{
     BlockErrorKind, ExecInput, ExecOutput, Stage, StageError, UnwindInput, UnwindOutput,
@@ -377,7 +377,7 @@ mod tests {
     use reth_primitives::{
         stage::StageUnitCheckpoint, BlockBody, SealedBlock, SealedBlockWithSenders, B256,
     };
-    use reth_provider::{BlockWriter, BundleStateWithReceipts, ProviderFactory};
+    use reth_provider::{BlockHashReader, BlockWriter, BundleStateWithReceipts, ProviderFactory};
     use reth_trie::{updates::TrieUpdates, HashedPostState};
     use test_runner::HeadersTestRunner;
 

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -330,7 +330,8 @@ where
             input.unwind_to + 1,
         )?;
         provider.unwind_table_by_num::<tables::CanonicalHeaders>(input.unwind_to)?;
-        let unfinalized_headers = provider.unwind_table_by_num::<tables::Headers>(input.unwind_to)?;
+        let unfinalized_headers =
+            provider.unwind_table_by_num::<tables::Headers>(input.unwind_to)?;
 
         let unwound_headers = highest_block - input.unwind_to;
 
@@ -349,7 +350,10 @@ where
             input.checkpoint.headers_stage_checkpoint().map(|stage_checkpoint| HeadersCheckpoint {
                 block_range: stage_checkpoint.block_range,
                 progress: EntitiesCheckpoint {
-                    processed: stage_checkpoint.progress.processed.saturating_sub(unwound_headers + unfinalized_headers as u64),
+                    processed: stage_checkpoint
+                        .progress
+                        .processed
+                        .saturating_sub(unwound_headers + unfinalized_headers as u64),
                     total: stage_checkpoint.progress.total,
                 },
             });

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -320,17 +320,15 @@ where
     ) -> Result<UnwindOutput, StageError> {
         self.sync_gap.take();
 
-        let unwind_target = input.unwind_to + 1;
-
         // First unwind the db tables, until the unwind_to block number. use the walker to unwind
         // HeaderNumbers based on the index in CanonicalHeaders
         provider.unwind_table_by_walker::<tables::CanonicalHeaders, tables::HeaderNumbers>(
-            unwind_target,
+            input.unwind_to,
         )?;
-        provider.unwind_table_by_num::<tables::CanonicalHeaders>(unwind_target)?;
-        provider.unwind_table_by_num::<tables::HeaderTerminalDifficulties>(unwind_target)?;
+        provider.unwind_table_by_num::<tables::CanonicalHeaders>(input.unwind_to)?;
+        provider.unwind_table_by_num::<tables::HeaderTerminalDifficulties>(input.unwind_to)?;
         let unfinalized_headers_unwound =
-            provider.unwind_table_by_num::<tables::Headers>(unwind_target)?;
+            provider.unwind_table_by_num::<tables::Headers>(input.unwind_to)?;
 
         // determine how many headers to unwind from the static files based on the highest block and
         // the unwind_to block

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -330,8 +330,9 @@ where
             input.unwind_to + 1,
         )?;
         provider.unwind_table_by_num::<tables::CanonicalHeaders>(input.unwind_to)?;
-        let _unfinalized_headers =
+        let unfinalized_headers =
             provider.unwind_table_by_num::<tables::Headers>(input.unwind_to)?;
+        provider.unwind_table_by_num::<tables::HeaderTerminalDifficulties>(input.unwind_to)?;
 
         let unwound_headers = highest_block - input.unwind_to;
 
@@ -350,7 +351,10 @@ where
             input.checkpoint.headers_stage_checkpoint().map(|stage_checkpoint| HeadersCheckpoint {
                 block_range: stage_checkpoint.block_range,
                 progress: EntitiesCheckpoint {
-                    processed: stage_checkpoint.progress.processed.saturating_sub(unwound_headers),
+                    processed: stage_checkpoint
+                        .progress
+                        .processed
+                        .saturating_sub(unwound_headers + unfinalized_headers as u64),
                     total: stage_checkpoint.progress.total,
                 },
             });

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -21,9 +21,8 @@ use reth_primitives::{
     BlockHash, BlockNumber, SealedHeader, StaticFileSegment,
 };
 use reth_provider::{
-    providers::{StaticFileProvider, StaticFileWriter},
-    BlockHashReader, DatabaseProviderRW, HeaderProvider, HeaderSyncGap, HeaderSyncGapProvider,
-    HeaderSyncMode,
+    providers::{StaticFileProvider, StaticFileWriter}, DatabaseProviderRW, HeaderProvider,
+    HeaderSyncGap, HeaderSyncGapProvider, HeaderSyncMode,
 };
 use reth_stages_api::{
     BlockErrorKind, ExecInput, ExecOutput, Stage, StageError, UnwindInput, UnwindOutput,

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -324,12 +324,12 @@ where
         // First unwind the db tables, until the unwind_to block number. use the walker to unwind
         // HeaderNumbers based on the index in CanonicalHeaders
         provider.unwind_table_by_walker::<tables::CanonicalHeaders, tables::HeaderNumbers>(
-            input.unwind_to + 1,
+            input.unwind_to,
         )?;
-        provider.unwind_table_by_num::<tables::CanonicalHeaders>(input.unwind_to + 1)?;
-        provider.unwind_table_by_num::<tables::HeaderTerminalDifficulties>(input.unwind_to + 1)?;
+        provider.unwind_table_by_num::<tables::CanonicalHeaders>(input.unwind_to)?;
+        provider.unwind_table_by_num::<tables::HeaderTerminalDifficulties>(input.unwind_to)?;
         let unfinalized_headers_unwound =
-            provider.unwind_table_by_num::<tables::Headers>(input.unwind_to + 1)?;
+            provider.unwind_table_by_num::<tables::Headers>(input.unwind_to)?;
 
         // determine how many headers to unwind from the static files based on the highest block and
         // the unwind_to block


### PR DESCRIPTION
Pipeline unwinds no longer delete headers from the DB, which is incorrect, since there may be headers in the DB that are checked in i.e. blockchain tree operations. This adds db unwind logic to the headers stage unwind.

would definitely like input on `EntitiesCheckpoint` it's not really clear what the numbers should be there. The blockchain tree definitely writes to stage progress, but I'm not sure how the entities processed is relevant during an unwind.