### PR TITLE
docs(docker): improper docker volume path causes data loss

### DIFF
--- a/book/installation/docker.md
+++ b/book/installation/docker.md
@@ -61,7 +61,7 @@ To run Reth with Docker, run:
 
 ```bash
 docker run \
-    -v rethdata:/root/.local/share/reth/mainnet/db \
+    -v rethdata:/root/.local/share/reth/mainnet \
     -d \
     -p 9001:9001 \
     -p 30303:30303 \


### PR DESCRIPTION
Resolved #7263. I encountered the same problem.

If the reth container is deleted and a new one is started (including the upgrade container), it will panic due to the loss of `static_files` and other files in the volume.

```diff
@@ -1,13 +1,5 @@
 .
-├── blobstore
-├── db
-│   ├── database.version
-│   ├── mdbx.dat
-│   └── mdbx.lck
-├── discovery-secret
-├── known-peers.json
-├── reth.toml
-└── static_files
-    ├── static_file_headers_0_499999
-    ├── static_file_headers_0_499999.conf
-    └── static_file_headers_0_499999.off
+db
+├── database.version
+├── mdbx.dat
+└── mdbx.lck
```

1. Run a reth container and then stop and delete it.

```plaintext
fedora@workstation:~$ docker run --rm -v rethdata:/root/.local/share/reth/mainnet/db -p 9001:9001 -p 30303:30303 -p 30303:30303/udp --name reth ghcr.io/paradigmxyz/reth:latest node
2024-04-12T12:33:54.083000Z  INFO Starting reth version="0.2.0-beta.5 (54f75cd)"
2024-04-12T12:33:54.083123Z  INFO Opening database path="/root/.local/share/reth/mainnet/db"
2024-04-12T12:33:54.142498Z  INFO Configuration loaded path="/root/.local/share/reth/mainnet/reth.toml"
2024-04-12T12:33:54.220281Z  INFO Database opened
2024-04-12T12:33:54.334209Z  INFO 
Pre-merge hard forks (block based):
- Frontier                         @0
- Homestead                        @1150000
- Dao                              @1920000
- Tangerine                        @2463000
- SpuriousDragon                   @2675000
- Byzantium                        @4370000
- Constantinople                   @7280000
- Petersburg                       @7280000
- Istanbul                         @9069000
- MuirGlacier                      @9200000
- Berlin                           @12244000
- London                           @12965000
- ArrowGlacier                     @13773000
- GrayGlacier                      @15050000
Merge hard forks:
- Paris                            @58750000000000000000000 (network is known to be merged)
Post-merge hard forks (timestamp based):
- Shanghai                         @1681338455
- Cancun                           @1710338135
2024-04-12T12:33:54.410351Z  INFO Transaction pool initialized
2024-04-12T12:33:54.410977Z  INFO Connecting to P2P network
2024-04-12T12:33:54.412329Z  INFO StaticFileProducer initialized
2024-04-12T12:33:54.412435Z  INFO Pruner initialized prune_config=PruneConfig { block_interval: 5, segments: PruneModes { sender_recovery: None, transaction_lookup: None, receipts: None, account_history: None, storage_history: None, receipts_log_filter: ReceiptsLogPruneConfig({}) } }
2024-04-12T12:33:54.412511Z  INFO Consensus engine initialized
2024-04-12T12:33:54.412539Z  INFO Engine API handler initialized
2024-04-12T12:33:54.412559Z  INFO Creating JWT auth secret file path="/root/.local/share/reth/mainnet/jwt.hex"
2024-04-12T12:33:54.457423Z  INFO RPC auth server started url=127.0.0.1:8551
2024-04-12T12:33:54.457769Z  INFO RPC IPC server started url=/tmp/reth.ipc
2024-04-12T12:33:54.457809Z  INFO Starting consensus engine
^C2024-04-12T12:33:55.270077Z  INFO Wrote network peers to file peers_file="/root/.local/share/reth/mainnet/known-peers.json"
```

2. Now only mdbx files are left in the volume.

```plaintext
fedora@workstation:~$ docker run --rm -it --name ubuntu -v rethdata:/mnt/reth ubuntu:latest
root@416641ff1865:/# ls /mnt/reth/
database.version  mdbx.dat  mdbx.lck
```

3. The newly started reth container will panic due to the loss of `static_files`.

```plaintext
fedora@workstation:~$ docker run --rm -v rethdata:/root/.local/share/reth/mainnet/db -p 9001:9001 -p 30303:30303 -p 30303:30303/udp --name reth ghcr.io/paradigmxyz/reth:latest node
2024-04-12T12:34:07.592663Z  INFO Starting reth version="0.2.0-beta.5 (54f75cd)"
2024-04-12T12:34:07.592776Z  INFO Opening database path="/root/.local/share/reth/mainnet/db"
2024-04-12T12:34:07.900701Z  INFO Configuration loaded path="/root/.local/share/reth/mainnet/reth.toml"
2024-04-12T12:34:07.995435Z  INFO Database opened
thread 'main' panicked at /project/crates/primitives/src/integer_list.rs:51:18:
IntegerList must be pre-sorted and non-empty: NonSortedIntegers { valid_until: 1 }
stack backtrace:
   0: rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::result::unwrap_failed
   3: reth_provider::providers::database::provider::DatabaseProvider<TX>::append_history_index
   4: reth_node_core::init::init_genesis
   5: reth_node_builder::builder::NodeBuilder<DB,reth_node_builder::builder::ComponentsState<Types,Components,reth_node_builder::components::traits::FullNodeComponentsAdapter<reth_node_api::node::FullNodeTypesAdapter<Types,DB,reth_provider::providers::BlockchainProvider<DB,reth_blockchain_tree::shareable::ShareableBlockchainTree<DB,reth_revm::factory::EvmProcessorFactory<<Types as reth_node_api::node::NodeTypes>::Evm>>>>,<Components as reth_node_builder::components::traits::NodeComponentsBuilder<reth_node_api::node::FullNodeTypesAdapter<Types,DB,reth_provider::providers::BlockchainProvider<DB,reth_blockchain_tree::shareable::ShareableBlockchainTree<DB,reth_revm::factory::EvmProcessorFactory<<Types as reth_node_api::node::NodeTypes>::Evm>>>>>>::Pool>>>::launch::{{closure}}
   6: reth_node_core::cli::runner::run_to_completion_or_panic::{{closure}}
   7: reth::cli::Cli<Ext>::run
   8: reth::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```
