### PR TITLE
chore: refactor poll_reserve logic to be a seperate function

### DIFF
--- a/crates/exex/src/manager.rs
+++ b/crates/exex/src/manager.rs
@@ -77,6 +77,13 @@ impl ExExHandle {
         )
     }
 
+    // Reserves a slot in the `PollSender` channel.
+    fn poll_reserve(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), PollSendError<ExExNotification>>> {
+        self.sender.poll_reserve(cx)
+    }
     /// Reserves a slot in the `PollSender` channel and sends the notification if the slot was
     /// successfully reserved.
     ///
@@ -102,7 +109,7 @@ impl ExExHandle {
                         );
 
                         self.next_notification_id = notification_id + 1;
-                        return Poll::Ready(Ok(()))
+                        return Poll::Ready(Ok(()));
                     }
                 }
                 // Do not handle [ExExNotification::ChainReorged] and
@@ -118,10 +125,12 @@ impl ExExHandle {
             %notification_id,
             "Reserving slot for notification"
         );
-        match self.sender.poll_reserve(cx) {
-            Poll::Ready(Ok(())) => (),
+        match self.poll_reserve(cx) {
+            Poll::Ready(Ok(())) => {}
             other => return other,
         }
+
+        // self.poll_reserve(cx);
 
         debug!(
             exex_id = %self.id,


### PR DESCRIPTION
Separating the poll_reserve logic out into a new function on the ExExHandle level that the manager can call.

Fixes: #7570