### PR TITLE
fix(op): headers above merge

### DIFF
--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -124,7 +124,6 @@ optimism = [
     "reth-rpc-engine-api/optimism",
     "reth-provider/optimism",
     "reth-beacon-consensus/optimism",
-    "reth-beacon-consensus-core/optimism",
     "reth-auto-seal-consensus/optimism",
     "reth-blockchain-tree/optimism",
     "dep:reth-node-optimism",

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -124,6 +124,7 @@ optimism = [
     "reth-rpc-engine-api/optimism",
     "reth-provider/optimism",
     "reth-beacon-consensus/optimism",
+    "reth-beacon-consensus-core/optimism",
     "reth-auto-seal-consensus/optimism",
     "reth-blockchain-tree/optimism",
     "dep:reth-node-optimism",

--- a/crates/consensus/beacon-core/Cargo.toml
+++ b/crates/consensus/beacon-core/Cargo.toml
@@ -15,3 +15,6 @@ workspace = true
 reth-consensus-common.workspace = true
 reth-primitives.workspace = true
 reth-interfaces.workspace = true
+
+[features]
+optimism = []

--- a/crates/consensus/beacon-core/Cargo.toml
+++ b/crates/consensus/beacon-core/Cargo.toml
@@ -17,4 +17,4 @@ reth-primitives.workspace = true
 reth-interfaces.workspace = true
 
 [features]
-optimism = []
+optimism = ["reth-primitives/optimism"]

--- a/crates/consensus/beacon-core/src/lib.rs
+++ b/crates/consensus/beacon-core/src/lib.rs
@@ -62,8 +62,7 @@ impl Consensus for BeaconConsensus {
         let is_post_merge = self.chain_spec.is_bedrock_active_at_fork(header.number);
 
         if is_post_merge {
-            #[cfg(not(feature = "optimism"))]
-            if !header.is_zero_difficulty() {
+            if !self.chain_spec.is_optimism() && !header.is_zero_difficulty() {
                 return Err(ConsensusError::TheMergeDifficultyIsNotZero)
             }
 

--- a/crates/consensus/beacon-core/src/lib.rs
+++ b/crates/consensus/beacon-core/src/lib.rs
@@ -59,10 +59,10 @@ impl Consensus for BeaconConsensus {
         #[cfg(feature = "optimism")]
         // If OP-Stack then bedrock activation number determines when TTD (eth Merge) has been
         // reached.
-        let is_post_merge = !self.chain_spec.is_optimism_mainnet() ||
-            self.chain_spec.is_bedrock_active_at_fork(header.number);
+        let is_post_merge = self.chain_spec.is_bedrock_active_at_fork(header.number);
 
         if is_post_merge {
+            #[cfg(not(feature = "optimism"))]
             if !header.is_zero_difficulty() {
                 return Err(ConsensusError::TheMergeDifficultyIsNotZero)
             }

--- a/crates/consensus/beacon-core/src/lib.rs
+++ b/crates/consensus/beacon-core/src/lib.rs
@@ -46,7 +46,6 @@ impl Consensus for BeaconConsensus {
         Ok(())
     }
 
-    #[allow(unused_assignments)]
     #[allow(unused_mut)]
     fn validate_header_with_total_difficulty(
         &self,

--- a/crates/consensus/beacon-core/src/lib.rs
+++ b/crates/consensus/beacon-core/src/lib.rs
@@ -47,6 +47,7 @@ impl Consensus for BeaconConsensus {
     }
 
     #[allow(unused_assignments)]
+    #[allow(unused_mut)]
     fn validate_header_with_total_difficulty(
         &self,
         header: &Header,

--- a/crates/consensus/beacon-core/src/lib.rs
+++ b/crates/consensus/beacon-core/src/lib.rs
@@ -46,7 +46,7 @@ impl Consensus for BeaconConsensus {
         Ok(())
     }
 
-    #[allow(unused_mut)]
+    #[allow(unused_assignments)]
     fn validate_header_with_total_difficulty(
         &self,
         header: &Header,

--- a/crates/consensus/beacon-core/src/lib.rs
+++ b/crates/consensus/beacon-core/src/lib.rs
@@ -52,15 +52,11 @@ impl Consensus for BeaconConsensus {
         header: &Header,
         total_difficulty: U256,
     ) -> Result<(), ConsensusError> {
-        let mut is_post_merge;
+        let mut is_post_merge = self
+            .chain_spec
+            .fork(Hardfork::Paris)
+            .active_at_ttd(total_difficulty, header.difficulty);
 
-        #[cfg(not(feature = "optimism"))]
-        {
-            is_post_merge = self
-                .chain_spec
-                .fork(Hardfork::Paris)
-                .active_at_ttd(total_difficulty, header.difficulty);
-        }
         #[cfg(feature = "optimism")]
         {
             // If OP-Stack then bedrock activation number determines when TTD (eth Merge) has been

--- a/crates/consensus/beacon-core/src/lib.rs
+++ b/crates/consensus/beacon-core/src/lib.rs
@@ -51,6 +51,13 @@ impl Consensus for BeaconConsensus {
         header: &Header,
         total_difficulty: U256,
     ) -> Result<(), ConsensusError> {
+        #[cfg(feature = "optimism")]
+        if self.chain_spec.is_optimism_mainnet() {
+            // If OP-Stack then bedrock activation number determines when TTD (eth Merge) has been
+            // reached.
+            return self.chain_spec.is_bedrock_active_at_fork(header.number)
+        }
+
         if self.chain_spec.fork(Hardfork::Paris).active_at_ttd(total_difficulty, header.difficulty)
         {
             if !header.is_zero_difficulty() {

--- a/crates/consensus/beacon-core/src/lib.rs
+++ b/crates/consensus/beacon-core/src/lib.rs
@@ -106,7 +106,7 @@ impl Consensus for BeaconConsensus {
             // Goerli exception:
             //  * If the network is goerli pre-merge, ignore the extradata check, since we do not
             //  support clique.
-            if self.chain_spec.chain != Chain::goerli() {
+            if self.chain_spec.chain != Chain::goerli() && !self.chain_spec.is_optimism() {
                 validate_header_extradata(header)?;
             }
         }

--- a/crates/consensus/beacon-core/src/lib.rs
+++ b/crates/consensus/beacon-core/src/lib.rs
@@ -46,20 +46,27 @@ impl Consensus for BeaconConsensus {
         Ok(())
     }
 
+    #[allow(unused_mut)]
     fn validate_header_with_total_difficulty(
         &self,
         header: &Header,
         total_difficulty: U256,
     ) -> Result<(), ConsensusError> {
+        let mut is_post_merge;
+
         #[cfg(not(feature = "optimism"))]
-        let is_post_merge = self
-            .chain_spec
-            .fork(Hardfork::Paris)
-            .active_at_ttd(total_difficulty, header.difficulty);
+        {
+            is_post_merge = self
+                .chain_spec
+                .fork(Hardfork::Paris)
+                .active_at_ttd(total_difficulty, header.difficulty);
+        }
         #[cfg(feature = "optimism")]
-        // If OP-Stack then bedrock activation number determines when TTD (eth Merge) has been
-        // reached.
-        let is_post_merge = self.chain_spec.is_bedrock_active_at_block(header.number);
+        {
+            // If OP-Stack then bedrock activation number determines when TTD (eth Merge) has been
+            // reached.
+            is_post_merge = self.chain_spec.is_bedrock_active_at_block(header.number);
+        }
 
         if is_post_merge {
             if !self.chain_spec.is_optimism() && !header.is_zero_difficulty() {

--- a/crates/consensus/beacon-core/src/lib.rs
+++ b/crates/consensus/beacon-core/src/lib.rs
@@ -103,9 +103,9 @@ impl Consensus for BeaconConsensus {
                 })
             }
 
-            // Goerli exception:
+            // Goerli and early OP exception:
             //  * If the network is goerli pre-merge, ignore the extradata check, since we do not
-            //  support clique.
+            //  support clique. Same goes for OP blocks below Bedrock.
             if self.chain_spec.chain != Chain::goerli() && !self.chain_spec.is_optimism() {
                 validate_header_extradata(header)?;
             }

--- a/crates/consensus/beacon-core/src/lib.rs
+++ b/crates/consensus/beacon-core/src/lib.rs
@@ -46,6 +46,7 @@ impl Consensus for BeaconConsensus {
         Ok(())
     }
 
+    #[allow(unused_assignments)]
     #[allow(unused_mut)]
     fn validate_header_with_total_difficulty(
         &self,

--- a/crates/consensus/beacon-core/src/lib.rs
+++ b/crates/consensus/beacon-core/src/lib.rs
@@ -59,7 +59,7 @@ impl Consensus for BeaconConsensus {
         #[cfg(feature = "optimism")]
         // If OP-Stack then bedrock activation number determines when TTD (eth Merge) has been
         // reached.
-        let is_post_merge = self.chain_spec.is_bedrock_active_at_fork(header.number);
+        let is_post_merge = self.chain_spec.is_bedrock_active_at_block(header.number);
 
         if is_post_merge {
             if !self.chain_spec.is_optimism() && !header.is_zero_difficulty() {

--- a/crates/consensus/beacon/Cargo.toml
+++ b/crates/consensus/beacon/Cargo.toml
@@ -65,4 +65,5 @@ optimism = [
     "reth-interfaces/optimism",
     "reth-provider/optimism",
     "reth-blockchain-tree/optimism",
+    "reth-beacon-consensus-core/optimism"
 ]

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -574,6 +574,12 @@ impl ChainSpec {
         self.chain.is_optimism()
     }
 
+    /// Returns `true` if this chain is Optimism mainnet.
+    #[inline]
+    pub fn is_optimism_mainnet(&self) -> bool {
+        self.chain == Chain::optimism_mainnet()
+    }
+
     /// Get the genesis block specification.
     ///
     /// To get the header for the genesis block, use [`Self::genesis_header`] instead.
@@ -777,6 +783,13 @@ impl ChainSpec {
     #[inline]
     pub fn is_homestead_active_at_block(&self, block_number: u64) -> bool {
         self.fork(Hardfork::Homestead).active_at_block(block_number)
+    }
+
+    /// Convenience method to check if [Hardfork::Bedrock] is active at a given block number.
+    #[cfg(feature = "optimism")]
+    #[inline]
+    pub fn is_bedrock_active_at_block(&self, block_number: u64) -> bool {
+        self.fork(Hardfork::Bedrock).active_at_block(block_number)
     }
 
     /// Creates a [`ForkFilter`] for the block described by [Head].

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -3189,4 +3189,10 @@ Post-merge hard forks (timestamp based):
             BASE_MAINNET.latest_fork_id()
         )
     }
+
+    #[cfg(feature = "optimism")]
+    #[test]
+    fn is_bedrock_active() {
+        assert!(!OP_MAINNET.is_bedrock_active_at_block(1))
+    }
 }


### PR DESCRIPTION
Fixes validation of optimism headers. Below/above merge is checked w.r.t. bedrock block number.

https://github.com/ethereum-optimism/op-geth/blob/da6ea729b858ce854ed4c3dd0979eae0855790c0/consensus/beacon/consensus.go#L485-L489