### PR TITLE
 feat: implement table range checksums for reth db checksum

### DIFF
--- a/bin/reth/src/commands/db/checksum.rs
+++ b/bin/reth/src/commands/db/checksum.rs
@@ -16,32 +16,56 @@ use tracing::{info, warn};
 pub struct Command {
     /// The table name
     table: Tables,
+    /// start of range
+    start: Option<String>,
+    /// end of range
+    end: Option<String>,
 }
 
 impl Command {
     /// Execute `db checksum` command
     pub fn execute(self, tool: &DbTool<DatabaseEnv>) -> eyre::Result<()> {
         warn!("This command should be run without the node running!");
-        self.table.view(&ChecksumViewer { tool })
+        self.table.view(&ChecksumViewer { tool, start: self.start, end: self.end })
     }
 }
 
 pub(crate) struct ChecksumViewer<'a, DB: Database> {
     tool: &'a DbTool<DB>,
+    start: Option<String>,
+    end: Option<String>,
 }
 
 impl<DB: Database> ChecksumViewer<'_, DB> {
     pub(crate) fn new(tool: &'_ DbTool<DB>) -> ChecksumViewer<'_, DB> {
-        ChecksumViewer { tool }
+        ChecksumViewer { tool, start: None, end: None }
     }
 
-    pub(crate) fn get_checksum<T: Table>(&self) -> Result<(u64, Duration), eyre::Report> {
+    pub(crate) fn get_checksum<T: Table>(&self) -> Result<(u64, Duration), eyre::Report>
+    where
+        <T as Table>::Key: std::str::FromStr,
+    {
         let provider =
             self.tool.provider_factory.provider()?.disable_long_read_transaction_safety();
         let tx = provider.tx_ref();
 
         let mut cursor = tx.cursor_read::<RawTable<T>>()?;
-        let walker = cursor.walk(None)?;
+        let walker = match (self.start.as_deref(), self.end.as_deref()) {
+            (Some(start), Some(end)) => {
+                let start_key =
+                    start.parse::<T::Key>().map_err(|_| eyre::eyre!("Invalid start key"))?;
+                let end_key = end.parse::<T::Key>().map_err(|_| eyre::eyre!("Invalid end key"))?;
+
+                RawKey::new(start_key)..=RawKey::new(end_key)
+                cursor.walk_range(start_key..=end_key)?
+            }
+            (None, Some(end)) => {
+                let end_key =
+                    end.parse::<RawKey<T::Key>>().map_err(|_| eyre::eyre!("Invalid end key"))?;
+                cursor.walk_range(..=end_key)?
+            }
+            (_, None) => cursor.walk_range(..)?,
+        };
 
         let start_time = Instant::now();
         let mut hasher = AHasher::default();
@@ -66,7 +90,10 @@ impl<DB: Database> ChecksumViewer<'_, DB> {
 impl<DB: Database> TableViewer<()> for ChecksumViewer<'_, DB> {
     type Error = eyre::Report;
 
-    fn view<T: Table>(&self) -> Result<(), Self::Error> {
+    fn view<T: Table>(&self) -> Result<(), Self::Error>
+    where
+        <T as Table>::Key: std::str::FromStr,
+    {
         let (checksum, elapsed) = self.get_checksum::<T>()?;
         info!("Checksum for table `{}`: {:#x} (elapsed: {:?})", T::NAME, checksum, elapsed);
 

--- a/bin/reth/src/commands/db/checksum.rs
+++ b/bin/reth/src/commands/db/checksum.rs
@@ -67,23 +67,26 @@ impl<DB: Database> ChecksumViewer<'_, DB> {
         let mut cursor = tx.cursor_read::<RawTable<T>>()?;
         let walker = match (self.start_key.as_deref(), self.end_key.as_deref()) {
             (Some(start), Some(end)) => {
-                info!("start={start} \n end={end}");
+                info!("Start computing checksum, range=({start}..={end}), limit={:?}", self.limit);
                 let start_key = table_key::<T>(start).map(RawKey::<T::Key>::new)?;
                 let end_key = table_key::<T>(end).map(RawKey::<T::Key>::new)?;
                 cursor.walk_range(start_key..=end_key)?
             }
             (None, Some(end)) => {
-                info!("start=.. \n end={end}");
+                info!("Start computing checksum, range=(..={end}), limit={:?}", self.limit);
                 let end_key = table_key::<T>(end).map(RawKey::<T::Key>::new)?;
 
                 cursor.walk_range(..=end_key)?
             }
             (Some(start), None) => {
-                info!("start={start} \n end= ");
+                info!("Start computing checksum, range=({start}..), limit={:?}", self.limit);
                 let start_key = table_key::<T>(start).map(RawKey::<T::Key>::new)?;
                 cursor.walk_range(start_key..)?
             }
-            (None, None) => cursor.walk_range(..)?,
+            (None, None) => {
+                info!("Start computing checksum, range=(..), limit={:?}", self.limit);
+                cursor.walk_range(..)?
+            }
         };
 
         let start_time = Instant::now();

--- a/bin/reth/src/commands/db/checksum.rs
+++ b/bin/reth/src/commands/db/checksum.rs
@@ -28,8 +28,8 @@ pub struct Command {
     #[arg(long, value_parser = maybe_json_value_parser)]
     end_key: Option<String>,
 
-    /// specify the maximum number of record that are queried and used to computing
-    /// the checksum.
+    /// The maximum number of records that are queried and used to compute the
+    /// checksum.
     #[arg(long)]
     limit: Option<usize>,
 }

--- a/bin/reth/src/commands/db/checksum.rs
+++ b/bin/reth/src/commands/db/checksum.rs
@@ -20,11 +20,11 @@ pub struct Command {
     /// The table name
     table: Tables,
 
-    /// start of range
+    /// The start of the range to checksum.
     #[arg(long, value_parser = maybe_json_value_parser)]
     start_key: Option<String>,
 
-    /// end of range
+    /// The end of the range to checksum.
     #[arg(long, value_parser = maybe_json_value_parser)]
     end_key: Option<String>,
 

--- a/bin/reth/src/commands/db/checksum.rs
+++ b/bin/reth/src/commands/db/checksum.rs
@@ -1,9 +1,12 @@
-use crate::utils::DbTool;
+use crate::{primitives::hex, utils::DbTool};
 use ahash::AHasher;
 use clap::Parser;
 use reth_db::{
-    cursor::DbCursorRO, database::Database, table::Table, transaction::DbTx, DatabaseEnv, RawKey,
-    RawTable, RawValue, TableViewer, Tables,
+    cursor::DbCursorRO,
+    database::Database,
+    table::{Decode, Table},
+    transaction::DbTx,
+    DatabaseEnv, RawKey, RawTable, RawValue, TableViewer, Tables,
 };
 use std::{
     hash::Hasher,
@@ -16,9 +19,13 @@ use tracing::{info, warn};
 pub struct Command {
     /// The table name
     table: Tables,
+
     /// start of range
+    #[arg(long, verbatim_doc_comment)]
     start: Option<String>,
+
     /// end of range
+    #[arg(long, verbatim_doc_comment)]
     end: Option<String>,
 }
 
@@ -41,10 +48,7 @@ impl<DB: Database> ChecksumViewer<'_, DB> {
         ChecksumViewer { tool, start: None, end: None }
     }
 
-    pub(crate) fn get_checksum<T: Table>(&self) -> Result<(u64, Duration), eyre::Report>
-    where
-        <T as Table>::Key: std::str::FromStr,
-    {
+    pub(crate) fn get_checksum<T: Table>(&self) -> Result<(u64, Duration), eyre::Report> {
         let provider =
             self.tool.provider_factory.provider()?.disable_long_read_transaction_safety();
         let tx = provider.tx_ref();
@@ -52,23 +56,39 @@ impl<DB: Database> ChecksumViewer<'_, DB> {
         let mut cursor = tx.cursor_read::<RawTable<T>>()?;
         let walker = match (self.start.as_deref(), self.end.as_deref()) {
             (Some(start), Some(end)) => {
-                let start_key =
-                    start.parse::<T::Key>().map_err(|_| eyre::eyre!("Invalid start key"))?;
-                let end_key = end.parse::<T::Key>().map_err(|_| eyre::eyre!("Invalid end key"))?;
+                info!("start={start} \n end={end}");
+                let start = hex::decode(start).map_err(|s| eyre::eyre!(s.to_string()))?;
+                let start_key = RawKey::<T::Key>::decode(start)
+                    .map_err(|_| eyre::eyre!("Invalid start key"))?;
 
-                RawKey::new(start_key)..=RawKey::new(end_key)
+                let end = hex::decode(end).map_err(|_| eyre::eyre!("Invalid end key"))?;
+                let end_key =
+                    RawKey::<T::Key>::decode(end).map_err(|_| eyre::eyre!("Invalid end key"))?;
+
                 cursor.walk_range(start_key..=end_key)?
             }
             (None, Some(end)) => {
+                info!("start=.. \n end={end}");
+                let end = hex::decode(end).map_err(|_| eyre::eyre!("Invalid end key"))?;
                 let end_key =
-                    end.parse::<RawKey<T::Key>>().map_err(|_| eyre::eyre!("Invalid end key"))?;
+                    RawKey::<T::Key>::decode(end).map_err(|_| eyre::eyre!("Invalid end key"))?;
+
                 cursor.walk_range(..=end_key)?
             }
-            (_, None) => cursor.walk_range(..)?,
+            (Some(start), None) => {
+                info!("start={start} \n end= ");
+                let start = hex::decode(start).map_err(|s| eyre::eyre!(s.to_string()))?;
+                let start_key =
+                    RawKey::<T::Key>::decode(start).map_err(|e| eyre::eyre!(e.to_string()))?;
+
+                cursor.walk_range(start_key..)?
+            }
+            (None, None) => cursor.walk_range(..)?,
         };
 
         let start_time = Instant::now();
         let mut hasher = AHasher::default();
+        let mut total = 0;
         for (index, entry) in walker.enumerate() {
             let (k, v): (RawKey<T::Key>, RawValue<T::Value>) = entry?;
 
@@ -78,7 +98,10 @@ impl<DB: Database> ChecksumViewer<'_, DB> {
 
             hasher.write(k.raw_key());
             hasher.write(v.raw_value());
+            total = index;
         }
+
+        info!("Hashed {total} entries.");
 
         let checksum = hasher.finish();
         let elapsed = start_time.elapsed();
@@ -90,10 +113,7 @@ impl<DB: Database> ChecksumViewer<'_, DB> {
 impl<DB: Database> TableViewer<()> for ChecksumViewer<'_, DB> {
     type Error = eyre::Report;
 
-    fn view<T: Table>(&self) -> Result<(), Self::Error>
-    where
-        <T as Table>::Key: std::str::FromStr,
-    {
+    fn view<T: Table>(&self) -> Result<(), Self::Error> {
         let (checksum, elapsed) = self.get_checksum::<T>()?;
         info!("Checksum for table `{}`: {:#x} (elapsed: {:?})", T::NAME, checksum, elapsed);
 

--- a/bin/reth/src/commands/db/checksum.rs
+++ b/bin/reth/src/commands/db/checksum.rs
@@ -2,14 +2,14 @@ use crate::{
     commands::db::get::{maybe_json_value_parser, table_key},
     utils::DbTool,
 };
-use ahash::AHasher;
+use ahash::{AHasher, RandomState};
 use clap::Parser;
 use reth_db::{
     cursor::DbCursorRO, database::Database, table::Table, transaction::DbTx, DatabaseEnv, RawKey,
     RawTable, RawValue, TableViewer, Tables,
 };
 use std::{
-    hash::Hasher,
+    hash::{BuildHasher, Hasher},
     time::{Duration, Instant},
 };
 use tracing::{info, warn};
@@ -76,7 +76,7 @@ impl<DB: Database> ChecksumViewer<'_, DB> {
         };
 
         let start_time = Instant::now();
-        let mut hasher = AHasher::default();
+        let mut hasher = RandomState::with_seeds(1, 2, 3, 4).build_hasher();
         let mut total = 0;
         for (index, entry) in walker.enumerate() {
             let (k, v): (RawKey<T::Key>, RawValue<T::Value>) = entry?;

--- a/bin/reth/src/commands/db/get.rs
+++ b/bin/reth/src/commands/db/get.rs
@@ -125,7 +125,7 @@ impl Command {
 }
 
 /// Get an instance of key for given table
-fn table_key<T: Table>(key: &str) -> Result<T::Key, eyre::Error> {
+pub(crate) fn table_key<T: Table>(key: &str) -> Result<T::Key, eyre::Error> {
     serde_json::from_str::<T::Key>(key).map_err(|e| eyre::eyre!(e))
 }
 
@@ -188,7 +188,7 @@ impl<DB: Database> TableViewer<()> for GetValueViewer<'_, DB> {
 }
 
 /// Map the user input value to json
-fn maybe_json_value_parser(value: &str) -> Result<String, eyre::Error> {
+pub(crate) fn maybe_json_value_parser(value: &str) -> Result<String, eyre::Error> {
     if serde_json::from_str::<serde::de::IgnoredAny>(value).is_ok() {
         Ok(value.to_string())
     } else {


### PR DESCRIPTION
close https://github.com/paradigmxyz/reth/issues/7561

Check whether it is in the right direction.

```sh
cargo run --bin reth db checksum HashedAccounts --datadir ~/.local/share/reth/holesky  --start 0x005e54f1867fd030f90673b8b625ac8f0656e44a88cfc0b3af3e3f3c3d486960 --end 0x03089e01be9eb2af5ff5fa1c5983c6c6fb78dd734658d1f8f11d4f8d27a23fd5
```

And here is the result:
```log
2024-04-13T17:16:42.693809Z  WARN This command should be run without the node running!
2024-04-13T17:16:42.695030Z  INFO <range>:: 0x005e54f1867fd030f90673b8b625ac8f0656e44a88cfc0b3af3e3f3c3d486960..=0x03089e01be9eb2af5ff5fa1c5983c6c6fb78dd734658d1f8f11d4f8d27a23fd5
2024-04-13T17:16:42.695765Z  INFO Hashed 0 entries.
2024-04-13T17:16:42.695850Z  INFO Hashed 4 entries.
2024-04-13T17:16:42.695895Z  INFO Checksum for table `HashedAccounts`: 0xf0b3ac90be2afa66 (elapsed: 301.167µs)

```