### PR TITLE
refactor: remove unused codecs

### DIFF
--- a/crates/storage/codecs/Cargo.toml
+++ b/crates/storage/codecs/Cargo.toml
@@ -30,10 +30,6 @@ proptest.workspace = true
 proptest-derive.workspace = true
 
 [features]
-default = ["compact", "std"]
+default = ["std"]
 std = ["alloy-primitives/std", "bytes/std"]
-compact = ["reth-codecs-derive/compact"]
-scale = ["reth-codecs-derive/scale"]
-postcard = ["reth-codecs-derive/postcard"]
-no_codec = ["reth-codecs-derive/no_codec"]
 optimism = ["reth-codecs-derive/optimism"]

--- a/crates/storage/codecs/README.md
+++ b/crates/storage/codecs/README.md
@@ -6,14 +6,3 @@ Examples:
 
 - [`Header` struct](../../primitives/src/header.rs)
 - [DB usage](../db/src/kv/codecs/scale.rs)
-
-### Features
-
-Feature defines what is the main codec used by `#[main_codec]`. However it is still possible to define them directly: `#[use_scale]`, `#[use_postcat]`, `#[no_codec]`.
-
-```rust
-default = ["scale"]
-scale = ["reth-codecs-derive/scale"]
-postcard = ["reth-codecs-derive/postcard"]
-no_codec = ["reth-codecs-derive/no_codec"]
-```

--- a/crates/storage/codecs/derive/Cargo.toml
+++ b/crates/storage/codecs/derive/Cargo.toml
@@ -25,9 +25,4 @@ similar-asserts.workspace = true
 syn = { workspace = true, features = ["full", "extra-traits"] }
 
 [features]
-default = ["compact"]
-compact = []
-scale = []
-postcard = []
-no_codec = []
 optimism = []

--- a/crates/storage/codecs/derive/src/lib.rs
+++ b/crates/storage/codecs/derive/src/lib.rs
@@ -39,64 +39,6 @@ pub fn derive_zstd(input: TokenStream) -> TokenStream {
 #[rustfmt::skip]
 #[allow(unreachable_code)]
 pub fn main_codec(args: TokenStream, input: TokenStream) -> TokenStream {
-    #[cfg(feature = "compact")]
-    return use_compact(args, input);
-
-    #[cfg(feature = "scale")]
-    return use_scale(args, input);
-
-    #[cfg(feature = "postcard")]
-    return use_postcard(args, input);
-
-    #[cfg(feature = "no_codec")]
-    return no_codec(args, input);
-
-    // no features
-    no_codec(args, input)
-}
-
-#[proc_macro_attribute]
-pub fn use_scale(_args: TokenStream, input: TokenStream) -> TokenStream {
-    let mut ast = parse_macro_input!(input as DeriveInput);
-    let compactable_types = ["u8", "u16", "u32", "i32", "i64", "u64", "f32", "f64"];
-
-    if let syn::Data::Struct(ref mut data) = &mut ast.data {
-        if let syn::Fields::Named(fields) = &mut data.fields {
-            for field in fields.named.iter_mut() {
-                if let syn::Type::Path(ref path) = field.ty {
-                    if !path.path.segments.is_empty() {
-                        let _type = format!("{}", path.path.segments[0].ident);
-                        if compactable_types.contains(&_type.as_str()) {
-                            field.attrs.push(syn::parse_quote! {
-                                #[codec(compact)]
-                            });
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    quote! {
-        #[derive(parity_scale_codec::Encode, parity_scale_codec::Decode, serde::Serialize, serde::Deserialize)]
-        #ast
-    }
-    .into()
-}
-
-#[proc_macro_attribute]
-pub fn use_postcard(_args: TokenStream, input: TokenStream) -> TokenStream {
-    let ast = parse_macro_input!(input as DeriveInput);
-
-    quote! {
-        #[derive(serde::Serialize, serde::Deserialize)]
-        #ast
-    }
-    .into()
-}
-
-#[proc_macro_attribute]
-pub fn use_compact(args: TokenStream, input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
 
     let with_zstd = args.clone().into_iter().any(|tk| tk.to_string() == "zstd");
@@ -175,10 +117,4 @@ pub fn add_arbitrary_tests(args: TokenStream, input: TokenStream) -> TokenStream
         #tests
     }
     .into()
-}
-
-#[proc_macro_attribute]
-pub fn no_codec(_args: TokenStream, input: TokenStream) -> TokenStream {
-    let ast = parse_macro_input!(input as DeriveInput);
-    quote! { #ast }.into()
 }


### PR DESCRIPTION
Originally we wanted to test with different codecs, but since we landed on just using `Compact`, I don't see a reason to support anything else in `reth-codecs-derive`.

This PR cleans up the features and removes code related to other codecs (some of which are non-functional anyway)