### PR TITLE
refactor: replace ```calculate_next_block_base_fee``` with alloy's builtin function

### DIFF
--- a/crates/primitives/src/basefee.rs
+++ b/crates/primitives/src/basefee.rs
@@ -23,16 +23,7 @@
 /// The calculated base fee for the next block as a `u64`.
 ///
 /// For more information, refer to the [EIP-1559 spec](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md).
-use alloy_eips::eip1559::calc_next_block_base_fee;
-
-pub fn calculate_next_block_base_fee(
-    gas_used: u64,
-    gas_limit: u64,
-    base_fee: u64,
-    base_fee_params: crate::BaseFeeParams,
-) -> u64 {
-    calc_next_block_base_fee(gas_used as u128, gas_limit as u128, base_fee as u128, base_fee_params) as u64
-}
+pub use alloy_eips::eip1559::calc_next_block_base_fee;
 
 #[cfg(test)]
 mod tests {
@@ -63,12 +54,12 @@ mod tests {
         for i in 0..base_fee.len() {
             assert_eq!(
                 next_base_fee[i],
-                calculate_next_block_base_fee(
-                    gas_used[i],
-                    gas_limit[i],
-                    base_fee[i],
+                calc_next_block_base_fee(
+                    gas_used[i] as u128,
+                    gas_limit[i] as u128,
+                    base_fee[i] as u128,
                     crate::BaseFeeParams::ethereum(),
-                )
+                ) as u64
             );
         }
     }
@@ -96,12 +87,12 @@ mod tests {
         for i in 0..base_fee.len() {
             assert_eq!(
                 next_base_fee[i],
-                calculate_next_block_base_fee(
-                    gas_used[i],
-                    gas_limit[i],
-                    base_fee[i],
+                calc_next_block_base_fee(
+                    gas_used[i] as u128,
+                    gas_limit[i] as u128,
+                    base_fee[i] as u128,
                     OP_BASE_FEE_PARAMS,
-                )
+                ) as u64
             );
         }
     }
@@ -129,12 +120,12 @@ mod tests {
         for i in 0..base_fee.len() {
             assert_eq!(
                 next_base_fee[i],
-                calculate_next_block_base_fee(
-                    gas_used[i],
-                    gas_limit[i],
-                    base_fee[i],
+                calc_next_block_base_fee(
+                    gas_used[i] as u128,
+                    gas_limit[i] as u128,
+                    base_fee[i] as u128,
                     OP_SEPOLIA_BASE_FEE_PARAMS,
-                )
+                ) as u64
             );
         }
     }

--- a/crates/primitives/src/basefee.rs
+++ b/crates/primitives/src/basefee.rs
@@ -1,28 +1,7 @@
 //! Helpers for working with EIP-1559 base fee
 
-/// Calculate the base fee for the next block based on the EIP-1559 specification.
-///
-/// This function calculates the base fee for the next block according to the rules defined in the
-/// EIP-1559. EIP-1559 introduces a new transaction pricing mechanism that includes a
-/// fixed-per-block network fee that is burned and dynamically adjusts block sizes to handle
-/// transient congestion.
-///
-/// For each block, the base fee per gas is determined by the gas used in the parent block and the
-/// target gas (the block gas limit divided by the elasticity multiplier). The algorithm increases
-/// the base fee when blocks are congested and decreases it when they are under the target gas
-/// usage. The base fee per gas is always burned.
-///
-/// Parameters:
-/// - `gas_used`: The gas used in the current block.
-/// - `gas_limit`: The gas limit of the current block.
-/// - `base_fee`: The current base fee per gas.
-/// - `base_fee_params`: Base fee parameters such as elasticity multiplier and max change
-///   denominator.
-///
-/// Returns:
-/// The calculated base fee for the next block as a `u64`.
-///
-/// For more information, refer to the [EIP-1559 spec](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md).
+// re-export
+#[doc(inline)]
 pub use alloy_eips::eip1559::calc_next_block_base_fee;
 
 #[cfg(test)]

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -1,7 +1,7 @@
 #[cfg(any(test, feature = "arbitrary"))]
 use crate::block::{generate_valid_header, valid_header_strategy};
 use crate::{
-    basefee::calculate_next_block_base_fee,
+    basefee::calc_next_block_base_fee,
     constants,
     constants::{
         ALLOWED_FUTURE_BLOCK_TIME_SECONDS, EMPTY_OMMER_ROOT_HASH, EMPTY_ROOT_HASH,
@@ -246,12 +246,12 @@ impl Header {
     ///
     /// Returns a `None` if no base fee is set, no EIP-1559 support
     pub fn next_block_base_fee(&self, base_fee_params: BaseFeeParams) -> Option<u64> {
-        Some(calculate_next_block_base_fee(
-            self.gas_used,
-            self.gas_limit,
-            self.base_fee_per_gas?,
+        Some(calc_next_block_base_fee(
+            self.gas_used as u128,
+            self.gas_limit as u128,
+            self.base_fee_per_gas? as u128,
             base_fee_params,
-        ))
+        ) as u64)
     }
 
     /// Calculate excess blob gas for the next block according to the EIP-4844 spec.

--- a/crates/rpc/rpc/src/eth/api/fee_history.rs
+++ b/crates/rpc/rpc/src/eth/api/fee_history.rs
@@ -7,7 +7,7 @@ use futures::{
 };
 use metrics::atomics::AtomicU64;
 use reth_primitives::{
-    basefee::calculate_next_block_base_fee,
+    basefee::calc_next_block_base_fee,
     eip4844::{calc_blob_gasprice, calculate_excess_blob_gas},
     ChainSpec, Receipt, SealedBlock, TransactionSigned, B256,
 };
@@ -370,12 +370,12 @@ impl FeeHistoryEntry {
 
     /// Returns the base fee for the next block according to the EIP-1559 spec.
     pub fn next_block_base_fee(&self, chain_spec: &ChainSpec) -> u64 {
-        calculate_next_block_base_fee(
-            self.gas_used,
-            self.gas_limit,
-            self.base_fee_per_gas,
+        calc_next_block_base_fee(
+            self.gas_used as u128,
+            self.gas_limit as u128,
+            self.base_fee_per_gas as u128,
             chain_spec.base_fee_params(self.timestamp),
-        )
+        ) as u64
     }
 
     /// Returns the blob fee for the next block according to the EIP-4844 spec.

--- a/crates/rpc/rpc/src/eth/api/fees.rs
+++ b/crates/rpc/rpc/src/eth/api/fees.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use reth_evm::ConfigureEvm;
 use reth_network_api::NetworkInfo;
-use reth_primitives::{basefee::calc_next_block_base_fee, BlockNumberOrTag, U256};
+use reth_primitives::{BlockNumberOrTag, U256};
 use reth_provider::{BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, StateProviderFactory};
 use reth_rpc_types::FeeHistory;
 use reth_transaction_pool::TransactionPool;
@@ -187,12 +187,12 @@ where
             //
             // The unwrap is safe since we checked earlier that we got at least 1 header.
             let last_header = headers.last().expect("is present");
-            base_fee_per_gas.push(calc_next_block_base_fee(
-                last_header.gas_used as u128,
-                last_header.gas_limit as u128,
-                last_header.base_fee_per_gas.unwrap_or_default() as u128,
-                self.provider().chain_spec().base_fee_params(last_header.timestamp),
-            ));
+            base_fee_per_gas.push(
+                self.provider().chain_spec().base_fee_params(last_header.timestamp).next_block_base_fee(
+                    last_header.gas_used as u128,
+                    last_header.gas_limit as u128,
+                    last_header.base_fee_per_gas.unwrap_or_default() as u128,
+                ));
 
             // Same goes for the `base_fee_per_blob_gas`:
             // > "[..] includes the next block after the newest of the returned range, because this value can be derived from the newest block.

--- a/crates/rpc/rpc/src/eth/api/fees.rs
+++ b/crates/rpc/rpc/src/eth/api/fees.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use reth_evm::ConfigureEvm;
 use reth_network_api::NetworkInfo;
-use reth_primitives::{basefee::calculate_next_block_base_fee, BlockNumberOrTag, U256};
+use reth_primitives::{basefee::calc_next_block_base_fee, BlockNumberOrTag, U256};
 use reth_provider::{BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, StateProviderFactory};
 use reth_rpc_types::FeeHistory;
 use reth_transaction_pool::TransactionPool;
@@ -187,12 +187,12 @@ where
             //
             // The unwrap is safe since we checked earlier that we got at least 1 header.
             let last_header = headers.last().expect("is present");
-            base_fee_per_gas.push(calculate_next_block_base_fee(
-                last_header.gas_used,
-                last_header.gas_limit,
-                last_header.base_fee_per_gas.unwrap_or_default(),
+            base_fee_per_gas.push(calc_next_block_base_fee(
+                last_header.gas_used as u128,
+                last_header.gas_limit as u128,
+                last_header.base_fee_per_gas.unwrap_or_default() as u128,
                 self.provider().chain_spec().base_fee_params(last_header.timestamp),
-            ) as u128);
+            ));
 
             // Same goes for the `base_fee_per_blob_gas`:
             // > "[..] includes the next block after the newest of the returned range, because this value can be derived from the newest block.

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -1,16 +1,10 @@
 //! Implementation of the [`jsonrpsee`] generated [`reth_rpc_api::EthApiServer`] trait
 //! Handles RPC requests for the `eth_` namespace.
 
-use super::EthApiSpec;
-use crate::{
-    eth::{
-        api::{EthApi, EthTransactions},
-        error::EthApiError,
-        revm_utils::EvmOverrides,
-    },
-    result::{internal_rpc_err, ToRpcResult},
-};
 use jsonrpsee::core::RpcResult as Result;
+use serde_json::Value;
+use tracing::trace;
+
 use reth_evm::ConfigureEvm;
 use reth_network_api::NetworkInfo;
 use reth_primitives::{
@@ -28,8 +22,17 @@ use reth_rpc_types::{
     StateContext, SyncStatus, TransactionRequest, Work,
 };
 use reth_transaction_pool::TransactionPool;
-use serde_json::Value;
-use tracing::trace;
+
+use crate::{
+    eth::{
+        api::{EthApi, EthTransactions},
+        error::EthApiError,
+        revm_utils::EvmOverrides,
+    },
+    result::{internal_rpc_err, ToRpcResult},
+};
+
+use super::EthApiSpec;
 
 #[async_trait::async_trait]
 impl<Provider, Pool, Network, EvmConfig> EthApiServer for EthApi<Provider, Pool, Network, EvmConfig>
@@ -435,6 +438,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use jsonrpsee::types::error::INVALID_PARAMS_CODE;
+
     use crate::{
         eth::{
             cache::EthStateCache, gas_oracle::GasPriceOracle, FeeHistoryCache,
@@ -442,13 +447,12 @@ mod tests {
         },
         EthApi,
     };
-    use jsonrpsee::types::error::INVALID_PARAMS_CODE;
     use reth_evm_ethereum::EthEvmConfig;
     use reth_interfaces::test_utils::{generators, generators::Rng};
     use reth_network_api::noop::NoopNetwork;
     use reth_primitives::{
-        basefee::calc_next_block_base_fee, constants::ETHEREUM_BLOCK_GAS_LIMIT, BaseFeeParams,
-        Block, BlockNumberOrTag, Header, TransactionSigned, B256,
+        constants::ETHEREUM_BLOCK_GAS_LIMIT, BaseFeeParams, Block, BlockNumberOrTag, Header,
+        TransactionSigned, B256,
     };
     use reth_provider::{
         test_utils::{MockEthProvider, NoopProvider},
@@ -565,11 +569,10 @@ mod tests {
 
         // Add final base fee (for the next block outside of the request)
         let last_header = last_header.unwrap();
-        base_fees_per_gas.push(calc_next_block_base_fee(
+        base_fees_per_gas.push(BaseFeeParams::ethereum().next_block_base_fee(
             last_header.gas_used as u128,
             last_header.gas_limit as u128,
             last_header.base_fee_per_gas.unwrap_or_default() as u128,
-            BaseFeeParams::ethereum(),
         ));
 
         let eth_api = build_test_eth_api(mock_provider);

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -447,7 +447,7 @@ mod tests {
     use reth_interfaces::test_utils::{generators, generators::Rng};
     use reth_network_api::noop::NoopNetwork;
     use reth_primitives::{
-        basefee::calculate_next_block_base_fee, constants::ETHEREUM_BLOCK_GAS_LIMIT, BaseFeeParams,
+        basefee::calc_next_block_base_fee, constants::ETHEREUM_BLOCK_GAS_LIMIT, BaseFeeParams,
         Block, BlockNumberOrTag, Header, TransactionSigned, B256,
     };
     use reth_provider::{
@@ -565,12 +565,12 @@ mod tests {
 
         // Add final base fee (for the next block outside of the request)
         let last_header = last_header.unwrap();
-        base_fees_per_gas.push(calculate_next_block_base_fee(
-            last_header.gas_used,
-            last_header.gas_limit,
-            last_header.base_fee_per_gas.unwrap_or_default(),
+        base_fees_per_gas.push(calc_next_block_base_fee(
+            last_header.gas_used as u128,
+            last_header.gas_limit as u128,
+            last_header.base_fee_per_gas.unwrap_or_default() as u128,
             BaseFeeParams::ethereum(),
-        ) as u128);
+        ));
 
         let eth_api = build_test_eth_api(mock_provider);
 


### PR DESCRIPTION
Fixes #7635 by replacing ```calculate_next_block_base_fee``` from https://github.com/paradigmxyz/reth/blob/d4ea41528a68c851b3d67c2a224cc2b225f65fef/crates/primitives/src/basefee.rs#L26-L26 with alloy's builtin function.