### PR TITLE
Implement `From<Block>` for `BlockBody`

### DIFF
--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -604,6 +604,12 @@ impl BlockBody {
     }
 }
 
+impl From<Block> for BlockBody {
+    fn from(block: Block) -> Self {
+        Self { transactions: block.body, ommers: block.ommers, withdrawals: block.withdrawals }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{BlockNumberOrTag::*, *};


### PR DESCRIPTION
In some circumstances, it could be useful to have a method to transform a `Block` to a `BlockBody`. As a result, `From<Block>` for `BlockBody` is implemented.