### PR TITLE
chore(tree): remove `BlockchainTreeEngine::unwind`

### DIFF
--- a/crates/blockchain-tree/src/noop.rs
+++ b/crates/blockchain-tree/src/noop.rs
@@ -56,10 +56,6 @@ impl BlockchainTreeEngine for NoopBlockchainTree {
     fn make_canonical(&self, block_hash: BlockHash) -> Result<CanonicalOutcome, CanonicalError> {
         Err(BlockchainTreeError::BlockHashNotFoundInChain { block_hash }.into())
     }
-
-    fn unwind(&self, _unwind_to: BlockNumber) -> RethResult<()> {
-        Ok(())
-    }
 }
 
 impl BlockchainTreeViewer for NoopBlockchainTree {

--- a/crates/blockchain-tree/src/shareable.rs
+++ b/crates/blockchain-tree/src/shareable.rs
@@ -101,14 +101,6 @@ where
         tree.update_chains_metrics();
         res
     }
-
-    fn unwind(&self, unwind_to: BlockNumber) -> RethResult<()> {
-        trace!(target: "blockchain_tree", unwind_to, "Unwinding to block number");
-        let mut tree = self.tree.write();
-        let res = tree.unwind(unwind_to);
-        tree.update_chains_metrics();
-        res
-    }
 }
 
 impl<DB, EF> BlockchainTreeViewer for ShareableBlockchainTree<DB, EF>

--- a/crates/interfaces/src/blockchain_tree/mod.rs
+++ b/crates/interfaces/src/blockchain_tree/mod.rs
@@ -97,9 +97,6 @@ pub trait BlockchainTreeEngine: BlockchainTreeViewer + Send + Sync {
     ///
     /// Returns `Ok` if the blocks were canonicalized, or if the blocks were already canonical.
     fn make_canonical(&self, block_hash: BlockHash) -> Result<CanonicalOutcome, CanonicalError>;
-
-    /// Unwind tables and put it inside state
-    fn unwind(&self, unwind_to: BlockNumber) -> RethResult<()>;
 }
 
 /// Represents the kind of validation that should be performed when inserting a block.

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -679,10 +679,6 @@ where
     fn make_canonical(&self, block_hash: BlockHash) -> Result<CanonicalOutcome, CanonicalError> {
         self.tree.make_canonical(block_hash)
     }
-
-    fn unwind(&self, unwind_to: BlockNumber) -> RethResult<()> {
-        self.tree.unwind(unwind_to)
-    }
 }
 
 impl<DB, Tree> BlockchainTreeViewer for BlockchainProvider<DB, Tree>


### PR DESCRIPTION
## Description

Remove unused `BlockchainTreeEngine::unwind` and corresponding implementations.