### PR TITLE
fix: check if regexp match is null in label-pr script

### DIFF
--- a/.github/scripts/label_pr.js
+++ b/.github/scripts/label_pr.js
@@ -8,7 +8,7 @@ module.exports = async ({ github, context }) => {
         const pattern = new RegExp(`(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved) ${repoUrl}/issues/(?<issue_number>\\d+)`, 'i')
 
         const re = prBody.match(pattern);
-        const issueNumber = re && re.groups?.issue_number;
+        const issueNumber = re?.groups?.issue_number;
 
         if (!issueNumber) {
             console.log("No issue reference found in PR description.");

--- a/.github/scripts/label_pr.js
+++ b/.github/scripts/label_pr.js
@@ -8,7 +8,7 @@ module.exports = async ({ github, context }) => {
         const pattern = new RegExp(`(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved) ${repoUrl}/issues/(?<issue_number>\\d+)`, 'i')
 
         const re = prBody.match(pattern);
-        const issueNumber = re.groups?.issue_number;
+        const issueNumber = re && re.groups?.issue_number;
 
         if (!issueNumber) {
             console.log("No issue reference found in PR description.");


### PR DESCRIPTION
Fix: the label-pr script should initially check if the result of the RegExp match is null.

related error message:(from https://github.com/paradigmxyz/reth/actions/runs/8689199605/job/23826416767)

```sh
Run actions/github-script@v7
Failed to label PR
TypeError: Cannot read properties of null (reading 'groups')
    at module.exports (/home/runner/work/reth/reth/.github/scripts/label_pr.js:11:32)
    at eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35424:16), <anonymous>:4:7)
    at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35425:[12](https://github.com/paradigmxyz/reth/actions/runs/8689199605/job/23826416767#step:3:13))
    at main (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35522:26)
    at /home/runner/work/_actions/actions/github-script/v7/dist/index.js:35497:1
    at /home/runner/work/_actions/actions/github-script/v7/dist/index.js:35553:3
    at Object.<anonymous> (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35556:12)
    at Module._compile (node:internal/modules/cjs/loader:1241:[14](https://github.com/paradigmxyz/reth/actions/runs/8689199605/job/23826416767#step:3:15))
    at Module._extensions..js (node:internal/modules/cjs/loader:1295:10)
    at Module.load (node:internal/modules/cjs/loader:1091:32)
```