### PR TITLE
chore(node): unify the format of command args

### DIFF
--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -4,18 +4,21 @@ Start the node
 
 ```bash
 $ reth node --help
+
+Start the node
+
 Usage: reth node [OPTIONS]
 
 Options:
       --datadir <DATA_DIR>
           The path to the data dir for all reth files and subdirectories.
-          
+
           Defaults to the OS-specific data directory:
-          
+
           - Linux: `$XDG_DATA_HOME/reth/` or `$HOME/.local/share/reth/`
           - Windows: `{FOLDERID_RoamingAppData}/reth/`
           - macOS: `$HOME/Library/Application Support/reth/`
-          
+
           [default: default]
 
       --config <FILE>
@@ -24,26 +27,26 @@ Options:
       --chain <CHAIN_OR_PATH>
           The chain this node is running.
           Possible values are either a built-in chain or the path to a chain specification file.
-          
+
           Built-in chains:
               mainnet, sepolia, goerli, holesky, dev
-          
+
           [default: mainnet]
 
       --instance <INSTANCE>
           Add a new instance of a node.
-          
+
           Configures the ports of the node to avoid conflicts with the defaults. This is useful for running multiple nodes on the same machine.
-          
+
           Max number of instances is 200. It is chosen in a way so that it's not possible to have port numbers that conflict with each other.
-          
+
           Changes to the following port numbers: - DISCOVERY_PORT: default + `instance` - 1 - AUTH_PORT: default + `instance` * 100 - 100 - HTTP_RPC_PORT: default - `instance` + 1 - WS_RPC_PORT: default + `instance` * 2 - 2
-          
+
           [default: 1]
 
       --with-unused-ports
           Sets all ports to unused, allowing the OS to choose random unused ports when sockets are bound.
-          
+
           Mutually exclusive with `--instance`.
 
   -h, --help
@@ -52,7 +55,7 @@ Options:
 Metrics:
       --metrics <SOCKET>
           Enable Prometheus metrics.
-          
+
           The metrics will be served at the given interface and port.
 
 Networking:
@@ -65,19 +68,32 @@ Networking:
       --disable-discv4-discovery
           Disable Discv4 discovery
 
+      --enable-discv5-discovery
+          Enable Discv5 discovery
+
       --discovery.addr <DISCOVERY_ADDR>
-          The UDP address to use for P2P discovery/networking
-          
+          The UDP address to use for devp2p peer discovery version 4
+
           [default: 0.0.0.0]
 
       --discovery.port <DISCOVERY_PORT>
-          The UDP port to use for P2P discovery/networking
-          
+          The UDP port to use for devp2p peer discovery version 4
+
           [default: 30303]
+
+      --discovery.v5.addr <DISCOVERY_V5_ADDR>
+          The UDP address to use for devp2p peer discovery version 5
+
+          [default: 0.0.0.0]
+
+      --discovery.v5.port <DISCOVERY_V5_PORT>
+          The UDP port to use for devp2p peer discovery version 5
+
+          [default: 9000]
 
       --trusted-peers <TRUSTED_PEERS>
           Comma separated enode URLs of trusted peers for P2P connections.
-          
+
           --trusted-peers enode://abcd@192.168.0.1:30303
 
       --trusted-only
@@ -85,7 +101,7 @@ Networking:
 
       --bootnodes <BOOTNODES>
           Comma separated enode URLs for P2P discovery bootstrap.
-          
+
           Will fall back to a network-specific default if not specified.
 
       --peers-file <FILE>
@@ -94,12 +110,12 @@ Networking:
 
       --identity <IDENTITY>
           Custom node identity
-          
-          [default: reth/<VERSION>-<SHA>/<ARCH>-gnu]
+
+          [default: reth/v0.2.0-beta.5-770785d2d/x86_64-unknown-linux-gnu]
 
       --p2p-secret-key <PATH>
           Secret key to use for this node.
-          
+
           This will also deterministically set the peer ID. If not specified, it will be set in the data dir for the chain being used.
 
       --no-persist-peers
@@ -107,17 +123,17 @@ Networking:
 
       --nat <NAT>
           NAT resolution method (any|none|upnp|publicip|extip:\<IP\>)
-          
+
           [default: any]
 
       --addr <ADDR>
           Network listening address
-          
+
           [default: 0.0.0.0]
 
       --port <PORT>
           Network listening port
-          
+
           [default: 30303]
 
       --max-outbound-peers <MAX_OUTBOUND_PEERS>
@@ -128,14 +144,14 @@ Networking:
 
       --pooled-tx-response-soft-limit <BYTES>
           Soft limit for the byte size of a `PooledTransactions` response on assembling a `GetPooledTransactions` request. Spec'd at 2 MiB.
-          
+
           <https://github.com/ethereum/devp2p/blob/master/caps/eth.md#protocol-messages>.
-          
+
           [default: 2097152]
 
       --pooled-tx-pack-soft-limit <BYTES>
           Default soft limit for the byte size of a `PooledTransactions` response on assembling a `GetPooledTransactions` request. This defaults to less than the [`SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE`], at 2 MiB, used when assembling a `PooledTransactions` response. Default is 128 KiB
-          
+
           [default: 131072]
 
 RPC:
@@ -144,17 +160,17 @@ RPC:
 
       --http.addr <HTTP_ADDR>
           Http server address to listen on
-          
+
           [default: 127.0.0.1]
 
       --http.port <HTTP_PORT>
           Http server port to listen on
-          
+
           [default: 8545]
 
       --http.api <HTTP_API>
           Rpc Modules to be configured for the HTTP server
-          
+
           [possible values: admin, debug, eth, net, trace, txpool, web3, rpc, reth, ots, eth-call-bundle]
 
       --http.corsdomain <HTTP_CORSDOMAIN>
@@ -165,12 +181,12 @@ RPC:
 
       --ws.addr <WS_ADDR>
           Ws server address to listen on
-          
+
           [default: 127.0.0.1]
 
       --ws.port <WS_PORT>
           Ws server port to listen on
-          
+
           [default: 8546]
 
       --ws.origins <ws.origins>
@@ -178,176 +194,184 @@ RPC:
 
       --ws.api <WS_API>
           Rpc Modules to be configured for the WS server
-          
+
           [possible values: admin, debug, eth, net, trace, txpool, web3, rpc, reth, ots, eth-call-bundle]
 
       --ipcdisable
-          Disable the IPC-RPC  server
+          Disable the IPC-RPC server
 
       --ipcpath <IPCPATH>
           Filename for IPC socket/pipe within the datadir
-          
-          [default: <CACHE_DIR>.ipc]
+
+          [default: /tmp/reth.ipc]
 
       --authrpc.addr <AUTH_ADDR>
           Auth server address to listen on
-          
+
           [default: 127.0.0.1]
 
       --authrpc.port <AUTH_PORT>
           Auth server port to listen on
-          
+
           [default: 8551]
 
       --authrpc.jwtsecret <PATH>
           Path to a JWT secret to use for the authenticated engine-API RPC server.
-          
+
           This will enforce JWT authentication for all requests coming from the consensus layer.
-          
+
           If no path is provided, a secret will be generated and stored in the datadir under `<DIR>/<CHAIN_ID>/jwt.hex`. For mainnet this would be `~/.reth/mainnet/jwt.hex` by default.
+
+      --auth-ipc
+          Enable auth engine api over IPC
+
+      --auth-ipc.path <AUTH_IPC_PATH>
+          Filename for auth IPC socket/pipe within the datadir
+
+          [default: /tmp/reth_engine_api.ipc]
 
       --rpc.jwtsecret <HEX>
           Hex encoded JWT secret to authenticate the regular RPC server(s), see `--http.api` and `--ws.api`.
-          
+
           This is __not__ used for the authenticated engine-API RPC server, see `--authrpc.jwtsecret`.
 
-      --rpc-max-request-size <RPC_MAX_REQUEST_SIZE>
+      --rpc.max-request-size <RPC_MAX_REQUEST_SIZE>
           Set the maximum RPC request payload size for both HTTP and WS in megabytes
-          
+
           [default: 15]
 
-      --rpc-max-response-size <RPC_MAX_RESPONSE_SIZE>
+      --rpc.max-response-size <RPC_MAX_RESPONSE_SIZE>
           Set the maximum RPC response payload size for both HTTP and WS in megabytes
-          
-          [default: 160]
-          [aliases: --rpc.returndata.limit]
 
-      --rpc-max-subscriptions-per-connection <RPC_MAX_SUBSCRIPTIONS_PER_CONNECTION>
+          [default: 160]
+          [aliases: rpc.returndata.limit]
+
+      --rpc.max-subscriptions-per-connection <RPC_MAX_SUBSCRIPTIONS_PER_CONNECTION>
           Set the maximum concurrent subscriptions per connection
-          
+
           [default: 1024]
 
-      --rpc-max-connections <COUNT>
+      --rpc.max-connections <COUNT>
           Maximum number of RPC server connections
-          
+
           [default: 500]
 
-      --rpc-max-tracing-requests <COUNT>
+      --rpc.max-tracing-requests <COUNT>
           Maximum number of concurrent tracing requests
-          
+
           [default: 14]
 
-      --rpc-max-blocks-per-filter <COUNT>
+      --rpc.max-blocks-per-filter <COUNT>
           Maximum number of blocks that could be scanned per filter request. (0 = entire chain)
-          
+
           [default: 100000]
 
-      --rpc-max-logs-per-response <COUNT>
+      --rpc.max-logs-per-response <COUNT>
           Maximum number of logs that can be returned in a single response. (0 = no limit)
-          
+
           [default: 20000]
 
-      --rpc-gas-cap <GAS_CAP>
+      --rpc.gascap <GAS_CAP>
           Maximum gas limit for `eth_call` and call tracing RPC methods
-          
+
           [default: 50000000]
 
 RPC State Cache:
       --rpc-cache.max-blocks <MAX_BLOCKS>
           Max number of blocks in cache
-          
+
           [default: 5000]
 
       --rpc-cache.max-receipts <MAX_RECEIPTS>
           Max number receipts in cache
-          
+
           [default: 2000]
 
       --rpc-cache.max-envs <MAX_ENVS>
           Max number of bytes for cached env data
-          
+
           [default: 1000]
 
       --rpc-cache.max-concurrent-db-requests <MAX_CONCURRENT_DB_REQUESTS>
           Max number of concurrent database requests
-          
+
           [default: 512]
 
 Gas Price Oracle:
       --gpo.blocks <BLOCKS>
           Number of recent blocks to check for gas price
-          
+
           [default: 20]
 
       --gpo.ignoreprice <IGNORE_PRICE>
           Gas Price below which gpo will ignore transactions
-          
+
           [default: 2]
 
       --gpo.maxprice <MAX_PRICE>
           Maximum transaction priority fee(or gasprice before London Fork) to be recommended by gpo
-          
+
           [default: 500000000000]
 
       --gpo.percentile <PERCENTILE>
           The percentile of gas prices to use for the estimate
-          
+
           [default: 60]
 
 TxPool:
-      --txpool.pending_max_count <PENDING_MAX_COUNT>
+      --txpool.pending-max-count <PENDING_MAX_COUNT>
           Max number of transaction in the pending sub-pool
-          
+
           [default: 10000]
 
-      --txpool.pending_max_size <PENDING_MAX_SIZE>
+      --txpool.pending-max-size <PENDING_MAX_SIZE>
           Max size of the pending sub-pool in megabytes
-          
+
           [default: 20]
 
-      --txpool.basefee_max_count <BASEFEE_MAX_COUNT>
+      --txpool.basefee-max-count <BASEFEE_MAX_COUNT>
           Max number of transaction in the basefee sub-pool
-          
+
           [default: 10000]
 
-      --txpool.basefee_max_size <BASEFEE_MAX_SIZE>
+      --txpool.basefee-max-size <BASEFEE_MAX_SIZE>
           Max size of the basefee sub-pool in megabytes
-          
+
           [default: 20]
 
-      --txpool.queued_max_count <QUEUED_MAX_COUNT>
+      --txpool.queued-max-count <QUEUED_MAX_COUNT>
           Max number of transaction in the queued sub-pool
-          
+
           [default: 10000]
 
-      --txpool.queued_max_size <QUEUED_MAX_SIZE>
+      --txpool.queued-max-size <QUEUED_MAX_SIZE>
           Max size of the queued sub-pool in megabytes
-          
+
           [default: 20]
 
       --txpool.max_account_slots <MAX_ACCOUNT_SLOTS>
           Max number of executable transaction slots guaranteed per account
-          
+
           [default: 16]
 
       --txpool.pricebump <PRICE_BUMP>
           Price bump (in %) for the transaction pool underpriced check
-          
+
           [default: 10]
 
       --blobpool.pricebump <BLOB_TRANSACTION_PRICE_BUMP>
           Price bump percentage to replace an already existing blob transaction
-          
+
           [default: 100]
 
-      --txpool.max_tx_input_bytes <MAX_TX_INPUT_BYTES>
+      --txpool.max-tx-input-bytes <MAX_TX_INPUT_BYTES>
           Max size in bytes of a single transaction allowed to enter the pool
-          
+
           [default: 131072]
 
-      --txpool.max_cached_entries <MAX_CACHED_ENTRIES>
+      --txpool.max-cached-entries <MAX_CACHED_ENTRIES>
           The maximum number of blobs to keep in the in memory blob cache
-          
+
           [default: 100]
 
       --txpool.nolocals
@@ -362,33 +386,33 @@ TxPool:
 Builder:
       --builder.extradata <EXTRADATA>
           Block extra data set by the payload builder
-          
-          [default: reth/<VERSION>/<OS>]
+
+          [default: reth/v0.2.0-beta.5/linux]
 
       --builder.gaslimit <GAS_LIMIT>
           Target gas ceiling for built blocks
-          
+
           [default: 30000000]
 
       --builder.interval <SECONDS>
           The interval at which the job should build a new payload after the last (in seconds)
-          
+
           [default: 1]
 
       --builder.deadline <SECONDS>
           The deadline for when the payload builder job should resolve
-          
+
           [default: 12]
 
       --builder.max-tasks <MAX_PAYLOAD_TASKS>
           Maximum number of tasks to spawn for building a payload
-          
+
           [default: 3]
 
 Debug:
       --debug.continuous
           Prompt the downloader to download blocks one at a time.
-          
+
           NOTE: This is for testing purposes only.
 
       --debug.terminate
@@ -396,7 +420,7 @@ Debug:
 
       --debug.tip <TIP>
           Set the chain tip manually for testing purposes.
-          
+
           NOTE: This is a temporary flag
 
       --debug.max-block <MAX_BLOCK>
@@ -433,13 +457,13 @@ Database:
 
       --db.exclusive <EXCLUSIVE>
           Open environment in exclusive/monopolistic mode. Makes it possible to open a database on an NFS volume
-          
+
           [possible values: true, false]
 
 Dev testnet:
       --dev
           Start the node in dev mode
-          
+
           This mode uses a local proof-of-authority consensus engine with either fixed block times
           or automatically mined blocks.
           Disables network discovery and enables local http server.
@@ -451,7 +475,7 @@ Dev testnet:
 
       --dev.block-time <BLOCK_TIME>
           Interval between blocks.
-          
+
           Parses strings using [humantime::parse_duration]
           --dev.block-time 12s
 
@@ -462,7 +486,7 @@ Pruning:
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout
-          
+
           [default: terminal]
 
           Possible values:
@@ -472,12 +496,12 @@ Logging:
 
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
-          
+
           [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file
-          
+
           [default: terminal]
 
           Possible values:
@@ -487,22 +511,22 @@ Logging:
 
       --log.file.filter <FILTER>
           The filter to use for logs written to the log file
-          
+
           [default: debug]
 
       --log.file.directory <PATH>
           The path to put log files in
-          
-          [default: <CACHE_DIR>/logs]
+
+          [default: /root/.cache/reth/logs]
 
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
-          
+
           [default: 200]
 
       --log.file.max-files <COUNT>
           The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
-          
+
           [default: 5]
 
       --log.journald
@@ -510,12 +534,12 @@ Logging:
 
       --log.journald.filter <FILTER>
           The filter to use for logs written to journald
-          
+
           [default: error]
 
       --color <COLOR>
           Sets whether or not the formatter emits ANSI terminal escape codes for colors and other text formatting
-          
+
           [default: always]
 
           Possible values:
@@ -526,7 +550,7 @@ Logging:
 Display:
   -v, --verbosity...
           Set the minimum log level.
-          
+
           -v      Errors
           -vv     Warnings
           -vvv    Info

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -111,7 +111,7 @@ Networking:
       --identity <IDENTITY>
           Custom node identity
 
-          [default: reth/v0.2.0-beta.5-770785d2d/x86_64-unknown-linux-gnu]
+          [default: reth/<VERSION>-<SHA>/<ARCH>-gnu]
 
       --p2p-secret-key <PATH>
           Secret key to use for this node.

--- a/crates/node-core/src/args/rpc_server_args.rs
+++ b/crates/node-core/src/args/rpc_server_args.rs
@@ -98,7 +98,7 @@ pub struct RpcServerArgs {
     #[arg(long = "ws.api", value_parser = RpcModuleSelectionValueParser::default())]
     pub ws_api: Option<RpcModuleSelection>,
 
-    /// Disable the IPC-RPC  server
+    /// Disable the IPC-RPC server
     #[arg(long)]
     pub ipcdisable: bool,
 
@@ -122,6 +122,14 @@ pub struct RpcServerArgs {
     /// `<DIR>/<CHAIN_ID>/jwt.hex`. For mainnet this would be `~/.reth/mainnet/jwt.hex` by default.
     #[arg(long = "authrpc.jwtsecret", value_name = "PATH", global = true, required = false)]
     pub auth_jwtsecret: Option<PathBuf>,
+
+    /// Enable auth engine api over IPC
+    #[arg(long)]
+    pub auth_ipc: bool,
+
+    /// Filename for auth IPC socket/pipe within the datadir
+    #[arg(long = "auth-ipc.path", default_value_t = constants::DEFAULT_ENGINE_API_IPC_ENDPOINT.to_string())]
+    pub auth_ipc_path: String,
 
     /// Hex encoded JWT secret to authenticate the regular RPC server(s), see `--http.api` and
     /// `--ws.api`.
@@ -176,14 +184,6 @@ pub struct RpcServerArgs {
     /// Gas price oracle configuration.
     #[command(flatten)]
     pub gas_price_oracle: GasPriceOracleArgs,
-
-    /// Enable auth engine api over IPC
-    #[arg(long)]
-    pub auth_ipc: bool,
-
-    /// Filename for auth IPC socket/pipe within the datadir
-    #[arg(long = "auth-ipc.path", default_value_t = constants::DEFAULT_ENGINE_API_IPC_ENDPOINT.to_string())]
-    pub auth_ipc_path: String,
 }
 
 impl RpcServerArgs {

--- a/crates/node-core/src/args/rpc_server_args.rs
+++ b/crates/node-core/src/args/rpc_server_args.rs
@@ -140,7 +140,7 @@ pub struct RpcServerArgs {
     pub rpc_jwtsecret: Option<JwtSecret>,
 
     /// Set the maximum RPC request payload size for both HTTP and WS in megabytes.
-    #[arg(long = "rpc.max-request-size", alias = "rpc_max_request_size", default_value_t = RPC_DEFAULT_MAX_REQUEST_SIZE_MB.into())]
+    #[arg(long = "rpc.max-request-size", alias = "rpc-max-request-size", default_value_t = RPC_DEFAULT_MAX_REQUEST_SIZE_MB.into())]
     pub rpc_max_request_size: MaxU32,
 
     /// Set the maximum RPC response payload size for both HTTP and WS in megabytes.
@@ -148,23 +148,23 @@ pub struct RpcServerArgs {
     pub rpc_max_response_size: MaxU32,
 
     /// Set the maximum concurrent subscriptions per connection.
-    #[arg(long = "rpc.max-subscriptions-per-connection", alias = "--rpc_max_subscriptions_per_connection", default_value_t = RPC_DEFAULT_MAX_SUBS_PER_CONN.into())]
+    #[arg(long = "rpc.max-subscriptions-per-connection", alias = "rpc-max-subscriptions-per-connection", default_value_t = RPC_DEFAULT_MAX_SUBS_PER_CONN.into())]
     pub rpc_max_subscriptions_per_connection: MaxU32,
 
     /// Maximum number of RPC server connections.
-    #[arg(long = "rpc.max-connections", alias = "rpc_max_connections", value_name = "COUNT", default_value_t = RPC_DEFAULT_MAX_CONNECTIONS.into())]
+    #[arg(long = "rpc.max-connections", alias = "rpc-max-connections", value_name = "COUNT", default_value_t = RPC_DEFAULT_MAX_CONNECTIONS.into())]
     pub rpc_max_connections: MaxU32,
 
     /// Maximum number of concurrent tracing requests.
-    #[arg(long = "rpc.max-tracing-requests", alias = "rpc_max_tracing_requests", value_name = "COUNT", default_value_t = constants::default_max_tracing_requests())]
+    #[arg(long = "rpc.max-tracing-requests", alias = "rpc-max-tracing-requests", value_name = "COUNT", default_value_t = constants::default_max_tracing_requests())]
     pub rpc_max_tracing_requests: usize,
 
     /// Maximum number of blocks that could be scanned per filter request. (0 = entire chain)
-    #[arg(long = "rpc.max-blocks-per-filter", alias = "rpc_max_blocks_per_filter", value_name = "COUNT", default_value_t = ZeroAsNoneU64::new(constants::DEFAULT_MAX_BLOCKS_PER_FILTER))]
+    #[arg(long = "rpc.max-blocks-per-filter", alias = "rpc-max-blocks-per-filter", value_name = "COUNT", default_value_t = ZeroAsNoneU64::new(constants::DEFAULT_MAX_BLOCKS_PER_FILTER))]
     pub rpc_max_blocks_per_filter: ZeroAsNoneU64,
 
     /// Maximum number of logs that can be returned in a single response. (0 = no limit)
-    #[arg(long = "rpc.max-logs-per-response", alias = "rpc_max_logs_per_response", value_name = "COUNT", default_value_t = ZeroAsNoneU64::new(constants::DEFAULT_MAX_LOGS_PER_RESPONSE as u64))]
+    #[arg(long = "rpc.max-logs-per-response", alias = "rpc-max-logs-per-response", value_name = "COUNT", default_value_t = ZeroAsNoneU64::new(constants::DEFAULT_MAX_LOGS_PER_RESPONSE as u64))]
     pub rpc_max_logs_per_response: ZeroAsNoneU64,
 
     /// Maximum gas limit for `eth_call` and call tracing RPC methods.

--- a/crates/node-core/src/args/rpc_server_args.rs
+++ b/crates/node-core/src/args/rpc_server_args.rs
@@ -132,37 +132,37 @@ pub struct RpcServerArgs {
     pub rpc_jwtsecret: Option<JwtSecret>,
 
     /// Set the maximum RPC request payload size for both HTTP and WS in megabytes.
-    #[arg(long, default_value_t = RPC_DEFAULT_MAX_REQUEST_SIZE_MB.into())]
+    #[arg(long = "rpc.max-request-size", alias = "rpc_max_request_size", default_value_t = RPC_DEFAULT_MAX_REQUEST_SIZE_MB.into())]
     pub rpc_max_request_size: MaxU32,
 
     /// Set the maximum RPC response payload size for both HTTP and WS in megabytes.
-    #[arg(long, visible_alias = "--rpc.returndata.limit", default_value_t = RPC_DEFAULT_MAX_RESPONSE_SIZE_MB.into())]
+    #[arg(long = "rpc.max-response-size", alias = "rpc-max-response-size", visible_alias = "rpc.returndata.limit", default_value_t = RPC_DEFAULT_MAX_RESPONSE_SIZE_MB.into())]
     pub rpc_max_response_size: MaxU32,
 
     /// Set the maximum concurrent subscriptions per connection.
-    #[arg(long, default_value_t = RPC_DEFAULT_MAX_SUBS_PER_CONN.into())]
+    #[arg(long = "rpc.max-subscriptions-per-connection", alias = "--rpc_max_subscriptions_per_connection", default_value_t = RPC_DEFAULT_MAX_SUBS_PER_CONN.into())]
     pub rpc_max_subscriptions_per_connection: MaxU32,
 
     /// Maximum number of RPC server connections.
-    #[arg(long, value_name = "COUNT", default_value_t = RPC_DEFAULT_MAX_CONNECTIONS.into())]
+    #[arg(long = "rpc.max-connections", alias = "rpc_max_connections", value_name = "COUNT", default_value_t = RPC_DEFAULT_MAX_CONNECTIONS.into())]
     pub rpc_max_connections: MaxU32,
 
     /// Maximum number of concurrent tracing requests.
-    #[arg(long, value_name = "COUNT", default_value_t = constants::default_max_tracing_requests())]
+    #[arg(long = "rpc.max-tracing-requests", alias = "rpc_max_tracing_requests", value_name = "COUNT", default_value_t = constants::default_max_tracing_requests())]
     pub rpc_max_tracing_requests: usize,
 
     /// Maximum number of blocks that could be scanned per filter request. (0 = entire chain)
-    #[arg(long, value_name = "COUNT", default_value_t = ZeroAsNoneU64::new(constants::DEFAULT_MAX_BLOCKS_PER_FILTER))]
+    #[arg(long = "rpc.max-blocks-per-filter", alias = "rpc_max_blocks_per_filter", value_name = "COUNT", default_value_t = ZeroAsNoneU64::new(constants::DEFAULT_MAX_BLOCKS_PER_FILTER))]
     pub rpc_max_blocks_per_filter: ZeroAsNoneU64,
 
     /// Maximum number of logs that can be returned in a single response. (0 = no limit)
-    #[arg(long, value_name = "COUNT", default_value_t = ZeroAsNoneU64::new(constants::DEFAULT_MAX_LOGS_PER_RESPONSE as u64))]
+    #[arg(long = "rpc.max-logs-per-response", alias = "rpc_max_logs_per_response", value_name = "COUNT", default_value_t = ZeroAsNoneU64::new(constants::DEFAULT_MAX_LOGS_PER_RESPONSE as u64))]
     pub rpc_max_logs_per_response: ZeroAsNoneU64,
 
     /// Maximum gas limit for `eth_call` and call tracing RPC methods.
     #[arg(
-        long,
-        alias = "rpc.gascap",
+        long = "rpc.gascap",
+        alias = "rpc-gascap",
         value_name = "GAS_CAP",
         value_parser = RangedU64ValueParser::<u64>::new().range(1..),
         default_value_t = RPC_DEFAULT_GAS_CAP.into()
@@ -177,7 +177,7 @@ pub struct RpcServerArgs {
     #[command(flatten)]
     pub gas_price_oracle: GasPriceOracleArgs,
 
-    /// Enable auth engine api over IPC  
+    /// Enable auth engine api over IPC
     #[arg(long)]
     pub auth_ipc: bool,
 

--- a/crates/node-core/src/args/rpc_server_args.rs
+++ b/crates/node-core/src/args/rpc_server_args.rs
@@ -123,7 +123,7 @@ pub struct RpcServerArgs {
     #[arg(long = "authrpc.jwtsecret", value_name = "PATH", global = true, required = false)]
     pub auth_jwtsecret: Option<PathBuf>,
 
-    /// Enable auth engine api over IPC
+    /// Enable auth engine API over IPC
     #[arg(long)]
     pub auth_ipc: bool,
 

--- a/crates/node-core/src/args/txpool_args.rs
+++ b/crates/node-core/src/args/txpool_args.rs
@@ -14,28 +14,28 @@ use reth_transaction_pool::{
 #[command(next_help_heading = "TxPool")]
 pub struct TxPoolArgs {
     /// Max number of transaction in the pending sub-pool.
-    #[arg(long = "txpool.pending_max_count", default_value_t = TXPOOL_SUBPOOL_MAX_TXS_DEFAULT)]
+    #[arg(long = "txpool.pending-max-count", alias = "txpool.pending_max_count", default_value_t = TXPOOL_SUBPOOL_MAX_TXS_DEFAULT)]
     pub pending_max_count: usize,
     /// Max size of the pending sub-pool in megabytes.
-    #[arg(long = "txpool.pending_max_size", default_value_t = TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT)]
+    #[arg(long = "txpool.pending-max-size", alias = "txpool.pending_max_size", default_value_t = TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT)]
     pub pending_max_size: usize,
 
     /// Max number of transaction in the basefee sub-pool
-    #[arg(long = "txpool.basefee_max_count", default_value_t = TXPOOL_SUBPOOL_MAX_TXS_DEFAULT)]
+    #[arg(long = "txpool.basefee-max-count", alias = "txpool.basefee_max_count", default_value_t = TXPOOL_SUBPOOL_MAX_TXS_DEFAULT)]
     pub basefee_max_count: usize,
     /// Max size of the basefee sub-pool in megabytes.
-    #[arg(long = "txpool.basefee_max_size", default_value_t = TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT)]
+    #[arg(long = "txpool.basefee-max-size", alias = "txpool.basefee_max_size", default_value_t = TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT)]
     pub basefee_max_size: usize,
 
     /// Max number of transaction in the queued sub-pool
-    #[arg(long = "txpool.queued_max_count", default_value_t = TXPOOL_SUBPOOL_MAX_TXS_DEFAULT)]
+    #[arg(long = "txpool.queued-max-count", alias = "txpool.queued_max_count", default_value_t = TXPOOL_SUBPOOL_MAX_TXS_DEFAULT)]
     pub queued_max_count: usize,
     /// Max size of the queued sub-pool in megabytes.
-    #[arg(long = "txpool.queued_max_size", default_value_t = TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT)]
+    #[arg(long = "txpool.queued-max-size", alias = "txpool.queued_max_size", default_value_t = TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT)]
     pub queued_max_size: usize,
 
     /// Max number of executable transaction slots guaranteed per account
-    #[arg(long = "txpool.max_account_slots", default_value_t = TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER)]
+    #[arg(long = "txpool.max-account-slots", long = "txpool.max_account_slots", default_value_t = TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER)]
     pub max_account_slots: usize,
 
     /// Price bump (in %) for the transaction pool underpriced check.
@@ -47,11 +47,11 @@ pub struct TxPoolArgs {
     pub blob_transaction_price_bump: u128,
 
     /// Max size in bytes of a single transaction allowed to enter the pool
-    #[arg(long = "txpool.max_tx_input_bytes", default_value_t = DEFAULT_MAX_TX_INPUT_BYTES)]
+    #[arg(long = "txpool.max-tx-input-bytes", alias = "txpool.max_tx_input_bytes", default_value_t = DEFAULT_MAX_TX_INPUT_BYTES)]
     pub max_tx_input_bytes: usize,
 
     /// The maximum number of blobs to keep in the in memory blob cache.
-    #[arg(long = "txpool.max_cached_entries", default_value_t = DEFAULT_MAX_CACHED_BLOBS)]
+    #[arg(long = "txpool.max-cached-entries", alias = "txpool.max_cached_entries", default_value_t = DEFAULT_MAX_CACHED_BLOBS)]
     pub max_cached_entries: u32,
 
     /// Flag to disable local transaction exemptions.


### PR DESCRIPTION
Currently, we have `xx.yy-zz` and `xx.yy_zz` command arg format, eg:

```bash
reth node --help | rg txpool

      --txpool.pending_max_count <PENDING_MAX_COUNT>
      --txpool.pending_max_size <PENDING_MAX_SIZE>
      --txpool.basefee_max_count <BASEFEE_MAX_COUNT>
      --txpool.basefee_max_size <BASEFEE_MAX_SIZE>
      --txpool.queued_max_count <QUEUED_MAX_COUNT>
      --txpool.queued_max_size <QUEUED_MAX_SIZE>
      --txpool.max_account_slots <MAX_ACCOUNT_SLOTS>
      --txpool.pricebump <PRICE_BUMP>
      --txpool.max_tx_input_bytes <MAX_TX_INPUT_BYTES>
      --txpool.max_cached_entries <MAX_CACHED_ENTRIES>
      --txpool.nolocals
      --txpool.locals <LOCALS>
      --txpool.no-local-transactions-propagation
```


This looks a bit inconsistent. I would like to change the default command-line argument format to `xx.yy-zz` and use an `alias` to keep it consistent with the old parameters.