### PR TITLE
chore: move optimism bootnodes to `reth-primitives`

### DIFF
--- a/crates/net/discv5/src/config.rs
+++ b/crates/net/discv5/src/config.rs
@@ -24,12 +24,6 @@ pub const OPSTACK: &[u8] = b"opstack";
 /// Default is 60 seconds.
 const DEFAULT_SECONDS_LOOKUP_INTERVAL: u64 = 60;
 
-/// Optimism mainnet and base mainnet boot nodes.
-const BOOT_NODES_OP_MAINNET_AND_BASE_MAINNET: &[&str] = &["enode://ca2774c3c401325850b2477fd7d0f27911efbf79b1e8b335066516e2bd8c4c9e0ba9696a94b1cb030a88eac582305ff55e905e64fb77fe0edcd70a4e5296d3ec@34.65.175.185:30305", "enode://dd751a9ef8912be1bfa7a5e34e2c3785cc5253110bd929f385e07ba7ac19929fb0e0c5d93f77827291f4da02b2232240fbc47ea7ce04c46e333e452f8656b667@34.65.107.0:30305", "enode://c5d289b56a77b6a2342ca29956dfd07aadf45364dde8ab20d1dc4efd4d1bc6b4655d902501daea308f4d8950737a4e93a4dfedd17b49cd5760ffd127837ca965@34.65.202.239:30305", "enode://87a32fd13bd596b2ffca97020e31aef4ddcc1bbd4b95bb633d16c1329f654f34049ed240a36b449fda5e5225d70fe40bc667f53c304b71f8e68fc9d448690b51@3.231.138.188:30301", "enode://ca21ea8f176adb2e229ce2d700830c844af0ea941a1d8152a9513b966fe525e809c3a6c73a2c18a12b74ed6ec4380edf91662778fe0b79f6a591236e49e176f9@184.72.129.189:30301", "enode://acf4507a211ba7c1e52cdf4eef62cdc3c32e7c9c47998954f7ba024026f9a6b2150cd3f0b734d9c78e507ab70d59ba61dfe5c45e1078c7ad0775fb251d7735a2@3.220.145.177:30301", "enode://8a5a5006159bf079d06a04e5eceab2a1ce6e0f721875b2a9c96905336219dbe14203d38f70f3754686a6324f786c2f9852d8c0dd3adac2d080f4db35efc678c5@3.231.11.52:30301", "enode://cdadbe835308ad3557f9a1de8db411da1a260a98f8421d62da90e71da66e55e98aaa8e90aa7ce01b408a54e4bd2253d701218081ded3dbe5efbbc7b41d7cef79@54.198.153.150:30301"];
-
-/// Optimism sepolia and base sepolia boot nodes.
-const BOOT_NODES_OP_SEPOLIA_AND_BASE_SEPOLIA: &[&str] = &["enode://09d1a6110757b95628cc54ab6cc50a29773075ed00e3a25bd9388807c9a6c007664e88646a6fefd82baad5d8374ba555e426e8aed93f0f0c517e2eb5d929b2a2@34.65.21.188:30304?discport=30303"];
-
 /// Builds a [`Config`].
 #[derive(Debug, Default)]
 pub struct ConfigBuilder {
@@ -121,16 +115,6 @@ impl ConfigBuilder {
         }
 
         self
-    }
-
-    /// Add optimism mainnet boot nodes.
-    pub fn add_optimism_mainnet_boot_nodes(self) -> Self {
-        self.add_serialized_unsigned_boot_nodes(BOOT_NODES_OP_MAINNET_AND_BASE_MAINNET)
-    }
-
-    /// Add optimism sepolia boot nodes.
-    pub fn add_optimism_sepolia_boot_nodes(self) -> Self {
-        self.add_serialized_unsigned_boot_nodes(BOOT_NODES_OP_SEPOLIA_AND_BASE_SEPOLIA)
     }
 
     /// Set [`ForkId`], and key used to identify it, to set in local [`Enr`](discv5::enr::Enr).
@@ -287,6 +271,7 @@ mod test {
     use super::*;
 
     const MULTI_ADDRESSES: &str = "/ip4/184.72.129.189/udp/30301/p2p/16Uiu2HAmSG2hdLwyQHQmG4bcJBgD64xnW63WMTLcrNq6KoZREfGb,/ip4/3.231.11.52/udp/30301/p2p/16Uiu2HAmMy4V8bi3XP7KDfSLQcLACSvTLroRRwEsTyFUKo8NCkkp,/ip4/54.198.153.150/udp/30301/p2p/16Uiu2HAmSVsb7MbRf1jg3Dvd6a3n5YNqKQwn1fqHCFgnbqCsFZKe,/ip4/3.220.145.177/udp/30301/p2p/16Uiu2HAm74pBDGdQ84XCZK27GRQbGFFwQ7RsSqsPwcGmCR3Cwn3B,/ip4/3.231.138.188/udp/30301/p2p/16Uiu2HAmMnTiJwgFtSVGV14ZNpwAvS1LUoF4pWWeNtURuV6C3zYB";
+    const BOOT_NODES_OP_MAINNET_AND_BASE_MAINNET: &[&str] = &["enode://ca2774c3c401325850b2477fd7d0f27911efbf79b1e8b335066516e2bd8c4c9e0ba9696a94b1cb030a88eac582305ff55e905e64fb77fe0edcd70a4e5296d3ec@34.65.175.185:30305", "enode://dd751a9ef8912be1bfa7a5e34e2c3785cc5253110bd929f385e07ba7ac19929fb0e0c5d93f77827291f4da02b2232240fbc47ea7ce04c46e333e452f8656b667@34.65.107.0:30305", "enode://c5d289b56a77b6a2342ca29956dfd07aadf45364dde8ab20d1dc4efd4d1bc6b4655d902501daea308f4d8950737a4e93a4dfedd17b49cd5760ffd127837ca965@34.65.202.239:30305", "enode://87a32fd13bd596b2ffca97020e31aef4ddcc1bbd4b95bb633d16c1329f654f34049ed240a36b449fda5e5225d70fe40bc667f53c304b71f8e68fc9d448690b51@3.231.138.188:30301", "enode://ca21ea8f176adb2e229ce2d700830c844af0ea941a1d8152a9513b966fe525e809c3a6c73a2c18a12b74ed6ec4380edf91662778fe0b79f6a591236e49e176f9@184.72.129.189:30301", "enode://acf4507a211ba7c1e52cdf4eef62cdc3c32e7c9c47998954f7ba024026f9a6b2150cd3f0b734d9c78e507ab70d59ba61dfe5c45e1078c7ad0775fb251d7735a2@3.220.145.177:30301", "enode://8a5a5006159bf079d06a04e5eceab2a1ce6e0f721875b2a9c96905336219dbe14203d38f70f3754686a6324f786c2f9852d8c0dd3adac2d080f4db35efc678c5@3.231.11.52:30301", "enode://cdadbe835308ad3557f9a1de8db411da1a260a98f8421d62da90e71da66e55e98aaa8e90aa7ce01b408a54e4bd2253d701218081ded3dbe5efbbc7b41d7cef79@54.198.153.150:30301"];
 
     #[test]
     fn parse_boot_nodes() {

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -132,14 +132,6 @@ impl<C> NetworkConfig<C> {
             builder = builder.fork(OPSTACK, fork_id)
         }
 
-        if chain == Chain::optimism_mainnet() || chain == Chain::base_mainnet() {
-            builder = builder.add_optimism_mainnet_boot_nodes()
-        } else if chain == Chain::from_named(NamedChain::OptimismSepolia) ||
-            chain == Chain::from_named(NamedChain::BaseSepolia)
-        {
-            builder = builder.add_optimism_sepolia_boot_nodes()
-        }
-
         self.set_discovery_v5(f(builder))
     }
 

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -13,8 +13,7 @@ use reth_discv5::config::OPSTACK;
 use reth_dns_discovery::DnsDiscoveryConfig;
 use reth_eth_wire::{HelloMessage, HelloMessageWithProtocols, Status};
 use reth_primitives::{
-    mainnet_nodes, pk2id, sepolia_nodes, Chain, ChainSpec, ForkFilter, Head, NamedChain,
-    NodeRecord, PeerId, MAINNET,
+    mainnet_nodes, pk2id, sepolia_nodes, ChainSpec, ForkFilter, Head, NodeRecord, PeerId, MAINNET,
 };
 use reth_provider::{BlockReader, HeaderProvider};
 use reth_tasks::{TaskSpawner, TokioTaskExecutor};
@@ -570,7 +569,7 @@ mod tests {
     use super::*;
     use rand::thread_rng;
     use reth_dns_discovery::tree::LinkEntry;
-    use reth_primitives::ForkHash;
+    use reth_primitives::{Chain, ForkHash};
     use reth_provider::test_utils::NoopProvider;
     use std::collections::BTreeMap;
 

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -1,7 +1,7 @@
 use crate::{
     constants::{EIP1559_INITIAL_BASE_FEE, EMPTY_RECEIPTS, EMPTY_TRANSACTIONS, EMPTY_WITHDRAWALS},
     holesky_nodes,
-    net::{goerli_nodes, mainnet_nodes, sepolia_nodes},
+    net::{base_nodes, base_testnet_nodes, goerli_nodes, mainnet_nodes, sepolia_nodes},
     proofs::state_root_ref_unhashed,
     revm_primitives::{address, b256},
     Address, BlockNumber, Chain, ForkFilter, ForkFilterKey, ForkHash, ForkId, Genesis, Hardfork,
@@ -917,13 +917,13 @@ impl ChainSpec {
             C::Sepolia => Some(sepolia_nodes()),
             C::Holesky => Some(holesky_nodes()),
             #[cfg(feature = "optimism")]
-            C::Base | C::Optimism => Some(op_nodes()),
+            C::Base => Some(base_nodes()),
             #[cfg(feature = "optimism")]
-            C::BaseGoerli |
-            C::BaseSepolia |
-            C::OptimismGoerli |
-            C::OptimismSepolia |
-            C::OptimismKovan => Some(op_testnet_nodes()),
+            C::Optimism => Some(op_nodes()),
+            #[cfg(feature = "optimism")]
+            C::BaseGoerli | C::BaseSepolia => Some(base_testnet_nodes()),
+            #[cfg(feature = "optimism")]
+            C::OptimismSepolia | C::OptimismGoerli | C::OptimismKovan => Some(op_testnet_nodes()),
             _ => None,
         }
     }

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -1,7 +1,7 @@
 use crate::{
     constants::{EIP1559_INITIAL_BASE_FEE, EMPTY_RECEIPTS, EMPTY_TRANSACTIONS, EMPTY_WITHDRAWALS},
     holesky_nodes,
-    net::{base_nodes, base_testnet_nodes, goerli_nodes, mainnet_nodes, sepolia_nodes},
+    net::{goerli_nodes, mainnet_nodes, sepolia_nodes},
     proofs::state_root_ref_unhashed,
     revm_primitives::{address, b256},
     Address, BlockNumber, Chain, ForkFilter, ForkFilterKey, ForkHash, ForkId, Genesis, Hardfork,
@@ -23,7 +23,7 @@ pub(crate) use crate::{
         OP_BASE_FEE_PARAMS, OP_CANYON_BASE_FEE_PARAMS, OP_SEPOLIA_BASE_FEE_PARAMS,
         OP_SEPOLIA_CANYON_BASE_FEE_PARAMS,
     },
-    net::{op_nodes, op_testnet_nodes},
+    net::{base_nodes, base_testnet_nodes, op_nodes, op_testnet_nodes},
 };
 
 /// The Ethereum mainnet spec

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -18,9 +18,12 @@ use std::{
 pub use alloy_eips::eip1559::BaseFeeParams;
 
 #[cfg(feature = "optimism")]
-pub(crate) use crate::constants::{
-    OP_BASE_FEE_PARAMS, OP_CANYON_BASE_FEE_PARAMS, OP_SEPOLIA_BASE_FEE_PARAMS,
-    OP_SEPOLIA_CANYON_BASE_FEE_PARAMS,
+pub(crate) use crate::{
+    constants::{
+        OP_BASE_FEE_PARAMS, OP_CANYON_BASE_FEE_PARAMS, OP_SEPOLIA_BASE_FEE_PARAMS,
+        OP_SEPOLIA_CANYON_BASE_FEE_PARAMS,
+    },
+    net::{op_nodes, op_testnet_nodes},
 };
 
 /// The Ethereum mainnet spec
@@ -913,6 +916,14 @@ impl ChainSpec {
             C::Goerli => Some(goerli_nodes()),
             C::Sepolia => Some(sepolia_nodes()),
             C::Holesky => Some(holesky_nodes()),
+            #[cfg(feature = "optimism")]
+            C::Base | C::Optimism => Some(op_nodes()),
+            #[cfg(feature = "optimism")]
+            C::BaseGoerli |
+            C::BaseSepolia |
+            C::OptimismGoerli |
+            C::OptimismSepolia |
+            C::OptimismKovan => Some(op_testnet_nodes()),
             _ => None,
         }
     }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -143,7 +143,10 @@ pub use c_kzg as kzg;
 mod optimism {
     pub use crate::{
         chain::{BASE_MAINNET, BASE_SEPOLIA, OP_MAINNET, OP_SEPOLIA},
-        net::{op_nodes, op_testnet_nodes, OP_BOOTNODES, OP_TESTNET_BOOTNODES},
+        net::{
+            base_nodes, base_testnet_nodes, op_nodes, op_testnet_nodes, BASE_BOOTNODES,
+            BASE_TESTNET_BOOTNODES, OP_BOOTNODES, OP_TESTNET_BOOTNODES,
+        },
         transaction::{TxDeposit, DEPOSIT_TX_TYPE_ID},
     };
 }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -143,6 +143,7 @@ pub use c_kzg as kzg;
 mod optimism {
     pub use crate::{
         chain::{BASE_MAINNET, BASE_SEPOLIA, OP_MAINNET, OP_SEPOLIA},
+        net::{op_nodes, op_testnet_nodes, OP_BOOTNODES, OP_TESTNET_BOOTNODES},
         transaction::{TxDeposit, DEPOSIT_TX_TYPE_ID},
     };
 }

--- a/crates/primitives/src/net.rs
+++ b/crates/primitives/src/net.rs
@@ -42,11 +42,24 @@ pub static HOLESKY_BOOTNODES : [&str; 2] = [
 ];
 
 #[cfg(feature = "optimism")]
-/// OP-Stack BOOTNODES
-pub static OP_BOOTNODES: [&str; 8] = [
+/// OP Mainnet BOOTNODES
+pub static OP_BOOTNODES: [&str; 3] = [
     "enode://ca2774c3c401325850b2477fd7d0f27911efbf79b1e8b335066516e2bd8c4c9e0ba9696a94b1cb030a88eac582305ff55e905e64fb77fe0edcd70a4e5296d3ec@34.65.175.185:30305", 
     "enode://dd751a9ef8912be1bfa7a5e34e2c3785cc5253110bd929f385e07ba7ac19929fb0e0c5d93f77827291f4da02b2232240fbc47ea7ce04c46e333e452f8656b667@34.65.107.0:30305", 
     "enode://c5d289b56a77b6a2342ca29956dfd07aadf45364dde8ab20d1dc4efd4d1bc6b4655d902501daea308f4d8950737a4e93a4dfedd17b49cd5760ffd127837ca965@34.65.202.239:30305", 
+];
+
+#[cfg(feature = "optimism")]
+/// OP TESTNET BOOTNODES
+pub static OP_TESTNET_BOOTNODES: [&str; 3] = [
+    "enode://2bd2e657bb3c8efffb8ff6db9071d9eb7be70d7c6d7d980ff80fc93b2629675c5f750bc0a5ef27cd788c2e491b8795a7e9a4a6e72178c14acc6753c0e5d77ae4@34.65.205.244:30305",
+	"enode://db8e1cab24624cc62fc35dbb9e481b88a9ef0116114cd6e41034c55b5b4f18755983819252333509bd8e25f6b12aadd6465710cd2e956558faf17672cce7551f@34.65.173.88:30305",
+	"enode://bfda2e0110cfd0f4c9f7aa5bf5ec66e6bd18f71a2db028d36b8bf8b0d6fdb03125c1606a6017b31311d96a36f5ef7e1ad11604d7a166745e6075a715dfa67f8a@34.65.229.245:30305",
+];
+
+#[cfg(feature = "optimism")]
+/// Base BOOTNODES
+pub static BASE_BOOTNODES: [&str; 5] = [
     "enode://87a32fd13bd596b2ffca97020e31aef4ddcc1bbd4b95bb633d16c1329f654f34049ed240a36b449fda5e5225d70fe40bc667f53c304b71f8e68fc9d448690b51@3.231.138.188:30301", 
     "enode://ca21ea8f176adb2e229ce2d700830c844af0ea941a1d8152a9513b966fe525e809c3a6c73a2c18a12b74ed6ec4380edf91662778fe0b79f6a591236e49e176f9@184.72.129.189:30301", 
     "enode://acf4507a211ba7c1e52cdf4eef62cdc3c32e7c9c47998954f7ba024026f9a6b2150cd3f0b734d9c78e507ab70d59ba61dfe5c45e1078c7ad0775fb251d7735a2@3.220.145.177:30301", 
@@ -55,10 +68,11 @@ pub static OP_BOOTNODES: [&str; 8] = [
 ];
 
 #[cfg(feature = "optimism")]
-/// OP-Stack Testnet BOOTNODES
-pub static OP_TESTNET_BOOTNODES: [&str; 1] = [
-    "enode://09d1a6110757b95628cc54ab6cc50a29773075ed00e3a25bd9388807c9a6c007664e88646a6fefd82baad5d8374ba555e426e8aed93f0f0c517e2eb5d929b2a2@34.65.21.188:30304?discport=30303"]
-;
+/// Base Testnet BOOTNODES
+pub static BASE_TESTNET_BOOTNODES: [&str; 2] = [
+    "enode://548f715f3fc388a7c917ba644a2f16270f1ede48a5d88a4d14ea287cc916068363f3092e39936f1a3e7885198bef0e5af951f1d7b1041ce8ba4010917777e71f@18.210.176.114:30301",
+	"enode://6f10052847a966a725c9f4adf6716f9141155b99a0fb487fea3f51498f4c2a2cb8d534e680ee678f9447db85b93ff7c74562762c3714783a7233ac448603b25f@107.21.251.55:30301",
+];
 
 /// Returns parsed mainnet nodes
 pub fn mainnet_nodes() -> Vec<NodeRecord> {
@@ -90,6 +104,18 @@ pub fn op_nodes() -> Vec<NodeRecord> {
 /// Returns parsed op-stack testnet nodes
 pub fn op_testnet_nodes() -> Vec<NodeRecord> {
     parse_nodes(&OP_TESTNET_BOOTNODES[..])
+}
+
+#[cfg(feature = "optimism")]
+/// Returns parsed op-stack mainnet nodes
+pub fn base_nodes() -> Vec<NodeRecord> {
+    parse_nodes(&BASE_BOOTNODES[..])
+}
+
+#[cfg(feature = "optimism")]
+/// Returns parsed op-stack testnet nodes
+pub fn base_testnet_nodes() -> Vec<NodeRecord> {
+    parse_nodes(&BASE_TESTNET_BOOTNODES[..])
 }
 
 /// Parses all the nodes

--- a/crates/primitives/src/net.rs
+++ b/crates/primitives/src/net.rs
@@ -81,13 +81,13 @@ pub fn holesky_nodes() -> Vec<NodeRecord> {
 }
 
 #[cfg(feature = "optimism")]
-/// Returns parsed mainnet nodes
+/// Returns parsed op-stack mainnet nodes
 pub fn op_nodes() -> Vec<NodeRecord> {
     parse_nodes(&OP_BOOTNODES[..])
 }
 
 #[cfg(feature = "optimism")]
-/// Returns parsed mainnet nodes
+/// Returns parsed op-stack testnet nodes
 pub fn op_testnet_nodes() -> Vec<NodeRecord> {
     parse_nodes(&OP_TESTNET_BOOTNODES[..])
 }

--- a/crates/primitives/src/net.rs
+++ b/crates/primitives/src/net.rs
@@ -41,6 +41,25 @@ pub static HOLESKY_BOOTNODES : [&str; 2] = [
     "enode://a3435a0155a3e837c02f5e7f5662a2f1fbc25b48e4dc232016e1c51b544cb5b4510ef633ea3278c0e970fa8ad8141e2d4d0f9f95456c537ff05fdf9b31c15072@178.128.136.233:30303",
 ];
 
+#[cfg(feature = "optimism")]
+/// OP-Stack BOOTNODES
+pub static OP_BOOTNODES: [&str; 8] = [
+    "enode://ca2774c3c401325850b2477fd7d0f27911efbf79b1e8b335066516e2bd8c4c9e0ba9696a94b1cb030a88eac582305ff55e905e64fb77fe0edcd70a4e5296d3ec@34.65.175.185:30305", 
+    "enode://dd751a9ef8912be1bfa7a5e34e2c3785cc5253110bd929f385e07ba7ac19929fb0e0c5d93f77827291f4da02b2232240fbc47ea7ce04c46e333e452f8656b667@34.65.107.0:30305", 
+    "enode://c5d289b56a77b6a2342ca29956dfd07aadf45364dde8ab20d1dc4efd4d1bc6b4655d902501daea308f4d8950737a4e93a4dfedd17b49cd5760ffd127837ca965@34.65.202.239:30305", 
+    "enode://87a32fd13bd596b2ffca97020e31aef4ddcc1bbd4b95bb633d16c1329f654f34049ed240a36b449fda5e5225d70fe40bc667f53c304b71f8e68fc9d448690b51@3.231.138.188:30301", 
+    "enode://ca21ea8f176adb2e229ce2d700830c844af0ea941a1d8152a9513b966fe525e809c3a6c73a2c18a12b74ed6ec4380edf91662778fe0b79f6a591236e49e176f9@184.72.129.189:30301", 
+    "enode://acf4507a211ba7c1e52cdf4eef62cdc3c32e7c9c47998954f7ba024026f9a6b2150cd3f0b734d9c78e507ab70d59ba61dfe5c45e1078c7ad0775fb251d7735a2@3.220.145.177:30301", 
+    "enode://8a5a5006159bf079d06a04e5eceab2a1ce6e0f721875b2a9c96905336219dbe14203d38f70f3754686a6324f786c2f9852d8c0dd3adac2d080f4db35efc678c5@3.231.11.52:30301", 
+    "enode://cdadbe835308ad3557f9a1de8db411da1a260a98f8421d62da90e71da66e55e98aaa8e90aa7ce01b408a54e4bd2253d701218081ded3dbe5efbbc7b41d7cef79@54.198.153.150:30301"
+];
+
+#[cfg(feature = "optimism")]
+/// OP-Stack Testnet BOOTNODES
+pub static OP_TESTNET_BOOTNODES: [&str; 1] = [
+    "enode://09d1a6110757b95628cc54ab6cc50a29773075ed00e3a25bd9388807c9a6c007664e88646a6fefd82baad5d8374ba555e426e8aed93f0f0c517e2eb5d929b2a2@34.65.21.188:30304?discport=30303"]
+;
+
 /// Returns parsed mainnet nodes
 pub fn mainnet_nodes() -> Vec<NodeRecord> {
     parse_nodes(&MAINNET_BOOTNODES[..])
@@ -59,6 +78,18 @@ pub fn sepolia_nodes() -> Vec<NodeRecord> {
 /// Returns parsed holesky nodes
 pub fn holesky_nodes() -> Vec<NodeRecord> {
     parse_nodes(&HOLESKY_BOOTNODES[..])
+}
+
+#[cfg(feature = "optimism")]
+/// Returns parsed mainnet nodes
+pub fn op_nodes() -> Vec<NodeRecord> {
+    parse_nodes(&OP_BOOTNODES[..])
+}
+
+#[cfg(feature = "optimism")]
+/// Returns parsed mainnet nodes
+pub fn op_testnet_nodes() -> Vec<NodeRecord> {
+    parse_nodes(&OP_TESTNET_BOOTNODES[..])
 }
 
 /// Parses all the nodes


### PR DESCRIPTION
As title suggests.

Additionally it fixes an issue where op stack chains were loading ethereum mainnet boot nodes (in addition to op ones) because there were no bootnodes associated with their chain specs.