### PR TITLE
fix(docker): Add support for RUSTFLAGS and feature flags in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,10 @@ COPY --from=planner /app/recipe.json recipe.json
 ARG BUILD_PROFILE=release
 ENV BUILD_PROFILE $BUILD_PROFILE
 
+# Extra Cargo flags
+ARG RUSTFLAGS=""
+ENV RUSTFLAGS "$RUSTFLAGS"
+
 # Extra Cargo features
 ARG FEATURES=""
 ENV FEATURES $FEATURES
@@ -24,7 +28,7 @@ ENV FEATURES $FEATURES
 RUN apt-get update && apt-get -y upgrade && apt-get install -y libclang-dev pkg-config
 
 # Builds dependencies
-RUN cargo chef cook --profile $BUILD_PROFILE --recipe-path recipe.json
+RUN cargo chef cook --profile $BUILD_PROFILE --features "$FEATURES" --recipe-path recipe.json
 
 # Build application
 COPY . .


### PR DESCRIPTION
Fixes #7365

- Define RUSTFLAGS as an ARG and set it as an environment variable in the builder stage
- Add --features "$FEATURES" flag to cargo chef cook command