### PR TITLE
Convert `Header` and `Block` rpc to primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,12 +146,26 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=8cb0307#8cb0307b9bdb6cef9058d2d1a2219c8d212a7421"
+source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "c-kzg",
+ "serde",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "alloy-consensus"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=8cb0307#8cb0307b9bdb6cef9058d2d1a2219c8d212a7421"
+dependencies = [
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=8cb0307)",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=8cb0307)",
  "c-kzg",
  "serde",
  "sha2 0.10.8",
@@ -178,11 +192,11 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=8cb0307#8cb0307b9bdb6cef9058d2d1a2219c8d212a7421"
+source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
  "arbitrary",
  "c-kzg",
  "ethereum_ssz",
@@ -194,12 +208,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-eips"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=8cb0307#8cb0307b9bdb6cef9058d2d1a2219c8d212a7421"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=8cb0307)",
+ "c-kzg",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
+name = "alloy-genesis"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
+dependencies = [
+ "alloy-primitives",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "serde",
+]
+
+[[package]]
 name = "alloy-genesis"
 version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=8cb0307#8cb0307b9bdb6cef9058d2d1a2219c8d212a7421"
 dependencies = [
  "alloy-primitives",
- "alloy-serde",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=8cb0307)",
  "serde",
 ]
 
@@ -218,7 +255,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=8cb0307#8cb0307b9bdb6cef9058d2d1a2219c8d212a7421"
+source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -230,13 +267,13 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=8cb0307#8cb0307b9bdb6cef9058d2d1a2219c8d212a7421"
+source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
  "alloy-json-rpc",
  "alloy-primitives",
- "alloy-rpc-types",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
  "alloy-signer",
  "async-trait",
  "futures-utils-wasm",
@@ -246,9 +283,9 @@ dependencies = [
 [[package]]
 name = "alloy-node-bindings"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=8cb0307#8cb0307b9bdb6cef9058d2d1a2219c8d212a7421"
+source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
 dependencies = [
- "alloy-genesis",
+ "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
  "alloy-primitives",
  "k256",
  "serde_json",
@@ -288,15 +325,15 @@ dependencies = [
 [[package]]
 name = "alloy-provider"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=8cb0307#8cb0307b9bdb6cef9058d2d1a2219c8d212a7421"
+source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-client",
- "alloy-rpc-types",
- "alloy-rpc-types-trace",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-rpc-types-trace 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
  "alloy-transport",
  "alloy-transport-http",
  "async-stream",
@@ -338,7 +375,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-client"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=8cb0307#8cb0307b9bdb6cef9058d2d1a2219c8d212a7421"
+source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -358,14 +395,14 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=8cb0307#8cb0307b9bdb6cef9058d2d1a2219c8d212a7421"
+source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
  "alloy-sol-types",
  "arbitrary",
  "itertools 0.12.1",
@@ -378,26 +415,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-rpc-types-anvil"
+name = "alloy-rpc-types"
 version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=8cb0307#8cb0307b9bdb6cef9058d2d1a2219c8d212a7421"
 dependencies = [
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=8cb0307)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=8cb0307)",
+ "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=8cb0307)",
  "alloy-primitives",
- "alloy-serde",
+ "alloy-rlp",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=8cb0307)",
+ "alloy-sol-types",
+ "itertools 0.12.1",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-rpc-types-anvil"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
+dependencies = [
+ "alloy-primitives",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-engine"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=8cb0307#8cb0307b9bdb6cef9058d2d1a2219c8d212a7421"
+source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types",
- "alloy-serde",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "jsonrpsee-types",
@@ -408,11 +463,33 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-trace"
 version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-rpc-types-trace"
+version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=8cb0307#8cb0307b9bdb6cef9058d2d1a2219c8d212a7421"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types",
- "alloy-serde",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=8cb0307)",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=8cb0307)",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
+dependencies = [
+ "alloy-primitives",
  "serde",
  "serde_json",
 ]
@@ -430,7 +507,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=8cb0307#8cb0307b9bdb6cef9058d2d1a2219c8d212a7421"
+source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -443,9 +520,9 @@ dependencies = [
 [[package]]
 name = "alloy-signer-wallet"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=8cb0307#8cb0307b9bdb6cef9058d2d1a2219c8d212a7421"
+source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
  "alloy-network",
  "alloy-primitives",
  "alloy-signer",
@@ -518,7 +595,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=8cb0307#8cb0307b9bdb6cef9058d2d1a2219c8d212a7421"
+source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.0",
@@ -536,7 +613,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=8cb0307#8cb0307b9bdb6cef9058d2d1a2219c8d212a7421"
+source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -4886,9 +4963,9 @@ dependencies = [
 name = "node-e2e-tests"
 version = "0.0.0"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
  "alloy-network",
- "alloy-rpc-types",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
  "alloy-signer",
  "alloy-signer-wallet",
  "eyre",
@@ -6240,7 +6317,7 @@ dependencies = [
 name = "reth-codecs"
 version = "0.2.0-beta.5"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
  "alloy-primitives",
  "arbitrary",
  "bytes",
@@ -7045,8 +7122,8 @@ name = "reth-primitives"
 version = "0.2.0-beta.5"
 dependencies = [
  "alloy-chains",
- "alloy-eips",
- "alloy-genesis",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
@@ -7308,13 +7385,13 @@ dependencies = [
 name = "reth-rpc-types"
 version = "0.2.0-beta.5"
 dependencies = [
- "alloy-genesis",
+ "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
  "alloy-rpc-types-anvil",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-trace",
+ "alloy-rpc-types-trace 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
  "arbitrary",
  "bytes",
  "enr",
@@ -7338,7 +7415,7 @@ name = "reth-rpc-types-compat"
 version = "0.2.0-beta.5"
 dependencies = [
  "alloy-rlp",
- "alloy-rpc-types",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
  "reth-primitives",
  "reth-rpc-types",
  "serde_json",
@@ -7553,8 +7630,8 @@ version = "0.1.0"
 source = "git+https://github.com/paradigmxyz/evm-inspectors?rev=f604dc4#f604dc4d4cd1f013c8bd488b2f28356a77fa2094"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types",
- "alloy-rpc-types-trace",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=8cb0307)",
+ "alloy-rpc-types-trace 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=8cb0307)",
  "alloy-sol-types",
  "anstyle",
  "boa_engine",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,26 +146,12 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
+source = "git+https://github.com/alloy-rs/alloy?rev=a32e6f7#a32e6f7f84cc1f2a1b244cc79a20057b0a3d4cba"
 dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
- "c-kzg",
- "serde",
- "sha2 0.10.8",
-]
-
-[[package]]
-name = "alloy-consensus"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=8cb0307#8cb0307b9bdb6cef9058d2d1a2219c8d212a7421"
-dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=8cb0307)",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=8cb0307)",
+ "alloy-serde",
  "c-kzg",
  "serde",
  "sha2 0.10.8",
@@ -192,11 +178,11 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
+source = "git+https://github.com/alloy-rs/alloy?rev=a32e6f7#a32e6f7f84cc1f2a1b244cc79a20057b0a3d4cba"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-serde",
  "arbitrary",
  "c-kzg",
  "ethereum_ssz",
@@ -208,35 +194,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-eips"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=8cb0307#8cb0307b9bdb6cef9058d2d1a2219c8d212a7421"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=8cb0307)",
- "c-kzg",
- "once_cell",
- "serde",
-]
-
-[[package]]
 name = "alloy-genesis"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
+source = "git+https://github.com/alloy-rs/alloy?rev=a32e6f7#a32e6f7f84cc1f2a1b244cc79a20057b0a3d4cba"
 dependencies = [
  "alloy-primitives",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
- "serde",
-]
-
-[[package]]
-name = "alloy-genesis"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=8cb0307#8cb0307b9bdb6cef9058d2d1a2219c8d212a7421"
-dependencies = [
- "alloy-primitives",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=8cb0307)",
+ "alloy-serde",
  "serde",
 ]
 
@@ -255,7 +218,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
+source = "git+https://github.com/alloy-rs/alloy?rev=a32e6f7#a32e6f7f84cc1f2a1b244cc79a20057b0a3d4cba"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -267,13 +230,13 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
+source = "git+https://github.com/alloy-rs/alloy?rev=a32e6f7#a32e6f7f84cc1f2a1b244cc79a20057b0a3d4cba"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-json-rpc",
  "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-rpc-types",
  "alloy-signer",
  "async-trait",
  "futures-utils-wasm",
@@ -283,9 +246,9 @@ dependencies = [
 [[package]]
 name = "alloy-node-bindings"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
+source = "git+https://github.com/alloy-rs/alloy?rev=a32e6f7#a32e6f7f84cc1f2a1b244cc79a20057b0a3d4cba"
 dependencies = [
- "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-genesis",
  "alloy-primitives",
  "k256",
  "serde_json",
@@ -325,15 +288,15 @@ dependencies = [
 [[package]]
 name = "alloy-provider"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
+source = "git+https://github.com/alloy-rs/alloy?rev=a32e6f7#a32e6f7f84cc1f2a1b244cc79a20057b0a3d4cba"
 dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-eips",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-client",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
- "alloy-rpc-types-trace 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-rpc-types",
+ "alloy-rpc-types-trace",
  "alloy-transport",
  "alloy-transport-http",
  "async-stream",
@@ -375,7 +338,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-client"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
+source = "git+https://github.com/alloy-rs/alloy?rev=a32e6f7#a32e6f7f84cc1f2a1b244cc79a20057b0a3d4cba"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -395,14 +358,14 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
+source = "git+https://github.com/alloy-rs/alloy?rev=a32e6f7#a32e6f7f84cc1f2a1b244cc79a20057b0a3d4cba"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
- "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-serde",
  "alloy-sol-types",
  "arbitrary",
  "itertools 0.12.1",
@@ -415,44 +378,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-rpc-types"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=8cb0307#8cb0307b9bdb6cef9058d2d1a2219c8d212a7421"
-dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=8cb0307)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=8cb0307)",
- "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=8cb0307)",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=8cb0307)",
- "alloy-sol-types",
- "itertools 0.12.1",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
 name = "alloy-rpc-types-anvil"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
+source = "git+https://github.com/alloy-rs/alloy?rev=a32e6f7#a32e6f7f84cc1f2a1b244cc79a20057b0a3d4cba"
 dependencies = [
  "alloy-primitives",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-serde",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-engine"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
+source = "git+https://github.com/alloy-rs/alloy?rev=a32e6f7#a32e6f7f84cc1f2a1b244cc79a20057b0a3d4cba"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-rpc-types",
+ "alloy-serde",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "jsonrpsee-types",
@@ -463,23 +408,11 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-trace"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
+source = "git+https://github.com/alloy-rs/alloy?rev=a32e6f7#a32e6f7f84cc1f2a1b244cc79a20057b0a3d4cba"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "alloy-rpc-types-trace"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=8cb0307#8cb0307b9bdb6cef9058d2d1a2219c8d212a7421"
-dependencies = [
- "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=8cb0307)",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=8cb0307)",
+ "alloy-rpc-types",
+ "alloy-serde",
  "serde",
  "serde_json",
 ]
@@ -487,17 +420,7 @@ dependencies = [
 [[package]]
 name = "alloy-serde"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
-dependencies = [
- "alloy-primitives",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "alloy-serde"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=8cb0307#8cb0307b9bdb6cef9058d2d1a2219c8d212a7421"
+source = "git+https://github.com/alloy-rs/alloy?rev=a32e6f7#a32e6f7f84cc1f2a1b244cc79a20057b0a3d4cba"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -507,7 +430,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
+source = "git+https://github.com/alloy-rs/alloy?rev=a32e6f7#a32e6f7f84cc1f2a1b244cc79a20057b0a3d4cba"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -520,9 +443,9 @@ dependencies = [
 [[package]]
 name = "alloy-signer-wallet"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
+source = "git+https://github.com/alloy-rs/alloy?rev=a32e6f7#a32e6f7f84cc1f2a1b244cc79a20057b0a3d4cba"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-consensus",
  "alloy-network",
  "alloy-primitives",
  "alloy-signer",
@@ -595,7 +518,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
+source = "git+https://github.com/alloy-rs/alloy?rev=a32e6f7#a32e6f7f84cc1f2a1b244cc79a20057b0a3d4cba"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.0",
@@ -613,7 +536,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=28b5750#28b57502a73070d558d4ca5ab3d277d97cf568d2"
+source = "git+https://github.com/alloy-rs/alloy?rev=a32e6f7#a32e6f7f84cc1f2a1b244cc79a20057b0a3d4cba"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -4963,9 +4886,9 @@ dependencies = [
 name = "node-e2e-tests"
 version = "0.0.0"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-consensus",
  "alloy-network",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-rpc-types",
  "alloy-signer",
  "alloy-signer-wallet",
  "eyre",
@@ -6317,7 +6240,7 @@ dependencies = [
 name = "reth-codecs"
 version = "0.2.0-beta.5"
 dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-eips",
  "alloy-primitives",
  "arbitrary",
  "bytes",
@@ -7122,8 +7045,8 @@ name = "reth-primitives"
 version = "0.2.0-beta.5"
 dependencies = [
  "alloy-chains",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
- "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-eips",
+ "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
@@ -7385,13 +7308,13 @@ dependencies = [
 name = "reth-rpc-types"
 version = "0.2.0-beta.5"
 dependencies = [
- "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-rpc-types",
  "alloy-rpc-types-anvil",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-trace 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-rpc-types-trace",
  "arbitrary",
  "bytes",
  "enr",
@@ -7415,7 +7338,7 @@ name = "reth-rpc-types-compat"
 version = "0.2.0-beta.5"
 dependencies = [
  "alloy-rlp",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=28b5750)",
+ "alloy-rpc-types",
  "reth-primitives",
  "reth-rpc-types",
  "serde_json",
@@ -7627,11 +7550,11 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/evm-inspectors?rev=f604dc4#f604dc4d4cd1f013c8bd488b2f28356a77fa2094"
+source = "git+https://github.com/paradigmxyz/evm-inspectors?rev=67f9968#67f9968fe56e5968ada322d084a98dd6a405ccdb"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=8cb0307)",
- "alloy-rpc-types-trace 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=8cb0307)",
+ "alloy-rpc-types",
+ "alloy-rpc-types-trace",
  "alloy-sol-types",
  "anstyle",
  "boa_engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -267,7 +267,7 @@ revm = { version = "8.0.0", features = [
 revm-primitives = { version = "3.1.0", features = [
     "std",
 ], default-features = false }
-revm-inspectors = { git = "https://github.com/paradigmxyz/evm-inspectors", rev = "f604dc4" }
+revm-inspectors = { git = "https://github.com/paradigmxyz/evm-inspectors", rev = "67f9968" }
 
 # eth
 alloy-chains = "0.1.15"
@@ -276,20 +276,20 @@ alloy-dyn-abi = "0.7.0"
 alloy-sol-types = "0.7.0"
 alloy-rlp = "0.3.4"
 alloy-trie = "0.3.1"
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "28b5750" }
-alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "28b5750" }
-alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "28b5750" }
-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "28b5750" }
-alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "28b5750" }
-alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", rev = "28b5750" }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "28b5750", default-features = false, features = [
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "a32e6f7" }
+alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "a32e6f7" }
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "a32e6f7" }
+alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "a32e6f7" }
+alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "a32e6f7" }
+alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", rev = "a32e6f7" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "a32e6f7", default-features = false, features = [
     "reqwest",
 ] }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "28b5750" }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "28b5750" }
-alloy-signer-wallet = { git = "https://github.com/alloy-rs/alloy", rev = "28b5750" }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "28b5750" }
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "28b5750" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "a32e6f7" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "a32e6f7" }
+alloy-signer-wallet = { git = "https://github.com/alloy-rs/alloy", rev = "a32e6f7" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "a32e6f7" }
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "a32e6f7" }
 
 # misc
 aquamarine = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,20 +276,20 @@ alloy-dyn-abi = "0.7.0"
 alloy-sol-types = "0.7.0"
 alloy-rlp = "0.3.4"
 alloy-trie = "0.3.1"
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "8cb0307" }
-alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "8cb0307" }
-alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "8cb0307" }
-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "8cb0307" }
-alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "8cb0307" }
-alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", rev = "8cb0307" }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "8cb0307", default-features = false, features = [
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "28b5750" }
+alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "28b5750" }
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "28b5750" }
+alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "28b5750" }
+alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "28b5750" }
+alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", rev = "28b5750" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "28b5750", default-features = false, features = [
     "reqwest",
 ] }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "8cb0307" }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "8cb0307" }
-alloy-signer-wallet = { git = "https://github.com/alloy-rs/alloy", rev = "8cb0307" }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "8cb0307" }
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "8cb0307" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "28b5750" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "28b5750" }
+alloy-signer-wallet = { git = "https://github.com/alloy-rs/alloy", rev = "28b5750" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "28b5750" }
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "28b5750" }
 
 # misc
 aquamarine = "0.5"

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -186,7 +186,7 @@ impl TryFrom<reth_rpc_types::Block> for Block {
             header: block.header.try_into()?,
             body,
             ommers: Default::default(),
-            withdrawals: block.withdrawals.map(Withdrawals::new),
+            withdrawals: block.withdrawals.map(Into::into),
         })
     }
 }

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -160,7 +160,7 @@ impl TryFrom<reth_rpc_types::Block> for Block {
                     .into_iter()
                     .map(|tx| {
                         let signature = tx.signature.ok_or(ConversionError::MissingSignature)?;
-                        let tx_signed = TransactionSigned::from_transaction_and_signature(
+                        Ok(TransactionSigned::from_transaction_and_signature(
                             tx.try_into()?,
                             Signature {
                                 r: signature.r,
@@ -170,8 +170,7 @@ impl TryFrom<reth_rpc_types::Block> for Block {
                                     .unwrap_or(reth_rpc_types::Parity(false))
                                     .0,
                             },
-                        );
-                        Ok(tx_signed)
+                        ))
                     })
                     .collect(),
                 reth_rpc_types::BlockTransactions::Hashes(_) |

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -1,11 +1,12 @@
 use crate::{
-    Address, Bytes, GotExpected, Header, SealedHeader, TransactionSigned,
+    Address, Bytes, GotExpected, Header, SealedHeader, Signature, TransactionSigned,
     TransactionSignedEcRecovered, Withdrawals, B256,
 };
 use alloy_rlp::{RlpDecodable, RlpEncodable};
 #[cfg(any(test, feature = "arbitrary"))]
 use proptest::prelude::{any, prop_compose};
 use reth_codecs::derive_arbitrary;
+use reth_rpc_types::ConversionError;
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
 
@@ -144,6 +145,49 @@ impl Deref for Block {
     type Target = Header;
     fn deref(&self) -> &Self::Target {
         &self.header
+    }
+}
+
+impl TryFrom<reth_rpc_types::Block> for Block {
+    type Error = ConversionError;
+
+    fn try_from(block: reth_rpc_types::Block) -> Result<Self, Self::Error> {
+        let body = {
+            let transactions: Result<Vec<TransactionSigned>, ConversionError> = match block
+                .transactions
+            {
+                reth_rpc_types::BlockTransactions::Full(transactions) => transactions
+                    .into_iter()
+                    .map(|tx| {
+                        let signature = tx.signature.ok_or(ConversionError::MissingSignature)?;
+                        let tx_signed = TransactionSigned::from_transaction_and_signature(
+                            tx.try_into()?,
+                            Signature {
+                                r: signature.r,
+                                s: signature.s,
+                                odd_y_parity: signature
+                                    .y_parity
+                                    .unwrap_or(reth_rpc_types::Parity(false))
+                                    .0,
+                            },
+                        );
+                        Ok(tx_signed)
+                    })
+                    .collect(),
+                reth_rpc_types::BlockTransactions::Hashes(_) |
+                reth_rpc_types::BlockTransactions::Uncle => {
+                    return Err(ConversionError::MissingFullTransactions);
+                }
+            };
+            transactions?
+        };
+
+        Ok(Self {
+            header: block.header.try_into()?,
+            body,
+            ommers: Default::default(),
+            withdrawals: block.withdrawals.map(Withdrawals::new),
+        })
     }
 }
 

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -494,9 +494,7 @@ impl TryFrom<reth_rpc_types::Header> for Header {
             base_fee_per_gas: header
                 .base_fee_per_gas
                 .map(|base_fee_per_gas| {
-                    base_fee_per_gas
-                        .try_into()
-                        .map_err(|e| ConversionError::BaseFeePerGasConversion(e))
+                    base_fee_per_gas.try_into().map_err(ConversionError::BaseFeePerGasConversion)
                 })
                 .transpose()?,
             beneficiary: header.miner,
@@ -510,20 +508,12 @@ impl TryFrom<reth_rpc_types::Header> for Header {
             excess_blob_gas: header
                 .excess_blob_gas
                 .map(|excess_blob_gas| {
-                    excess_blob_gas
-                        .try_into()
-                        .map_err(|e| ConversionError::ExcessBlobGasConversion(e))
+                    excess_blob_gas.try_into().map_err(ConversionError::ExcessBlobGasConversion)
                 })
                 .transpose()?,
             extra_data: header.extra_data,
-            gas_limit: header
-                .gas_limit
-                .try_into()
-                .map_err(|e| ConversionError::GasLimitConversion(e))?,
-            gas_used: header
-                .gas_used
-                .try_into()
-                .map_err(|e| ConversionError::GasUsedConversion(e))?,
+            gas_limit: header.gas_limit.try_into().map_err(ConversionError::GasLimitConversion)?,
+            gas_used: header.gas_used.try_into().map_err(ConversionError::GasUsedConversion)?,
             logs_bloom: header.logs_bloom,
             mix_hash: header.mix_hash.unwrap_or_default(),
             nonce: u64::from_be_bytes(header.nonce.unwrap_or_default().0),

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -496,38 +496,36 @@ impl TryFrom<reth_rpc_types::Header> for Header {
                 .map(|base_fee_per_gas| {
                     base_fee_per_gas
                         .try_into()
-                        .map_err(|_| ConversionError::BaseFeePerGasConversion)
+                        .map_err(|e| ConversionError::BaseFeePerGasConversion(e))
                 })
                 .transpose()?,
             beneficiary: header.miner,
-            blob_gas_used: header.blob_gas_used.map(|blob_gas_used| blob_gas_used.to::<u64>()),
+            blob_gas_used: header
+                .blob_gas_used
+                .map(|blob_gas_used| blob_gas_used.try_into().unwrap()),
             difficulty: header.difficulty,
             excess_blob_gas: header
                 .excess_blob_gas
-                .map(|excess_blob_gas| excess_blob_gas.to::<u64>()),
+                .map(|excess_blob_gas| excess_blob_gas.try_into().unwrap()),
             extra_data: header.extra_data,
             gas_limit: header
                 .gas_limit
                 .try_into()
-                .map_err(|_| ConversionError::GasLimitConversion)?,
-            gas_used: header.gas_used.try_into().map_err(|_| ConversionError::GasUsedConversion)?,
+                .map_err(|e| ConversionError::GasLimitConversion(e))?,
+            gas_used: header
+                .gas_used
+                .try_into()
+                .map_err(|e| ConversionError::GasUsedConversion(e))?,
             logs_bloom: header.logs_bloom,
             mix_hash: header.mix_hash.unwrap_or_default(),
             nonce: u64::from_be_bytes(header.nonce.unwrap_or_default().0),
-            number: header
-                .number
-                .ok_or(ConversionError::MissingBlockNumber)?
-                .try_into()
-                .map_err(|_| ConversionError::BlockNumberConversion)?,
+            number: header.number.ok_or(ConversionError::MissingBlockNumber)?,
             ommers_hash: header.uncles_hash,
             parent_beacon_block_root: header.parent_beacon_block_root,
             parent_hash: header.parent_hash,
             receipts_root: header.receipts_root,
             state_root: header.state_root,
-            timestamp: header
-                .timestamp
-                .try_into()
-                .map_err(|_| ConversionError::TimestampConversion)?,
+            timestamp: header.timestamp,
             transactions_root: header.transactions_root,
             withdrawals_root: header.withdrawals_root,
         })

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -16,6 +16,7 @@ use bytes::BufMut;
 #[cfg(any(test, feature = "arbitrary"))]
 use proptest::prelude::*;
 use reth_codecs::{add_arbitrary_tests, derive_arbitrary, main_codec, Compact};
+use reth_rpc_types::ConversionError;
 use serde::{Deserialize, Serialize};
 use std::{mem, ops::Deref};
 
@@ -482,6 +483,54 @@ impl Decodable for Header {
             })
         }
         Ok(this)
+    }
+}
+
+impl TryFrom<reth_rpc_types::Header> for Header {
+    type Error = ConversionError;
+
+    fn try_from(header: reth_rpc_types::Header) -> Result<Self, Self::Error> {
+        Ok(Self {
+            base_fee_per_gas: header
+                .base_fee_per_gas
+                .map(|base_fee_per_gas| {
+                    base_fee_per_gas
+                        .try_into()
+                        .map_err(|_| ConversionError::BaseFeePerGasConversion)
+                })
+                .transpose()?,
+            beneficiary: header.miner,
+            blob_gas_used: header.blob_gas_used.map(|blob_gas_used| blob_gas_used.to::<u64>()),
+            difficulty: header.difficulty,
+            excess_blob_gas: header
+                .excess_blob_gas
+                .map(|excess_blob_gas| excess_blob_gas.to::<u64>()),
+            extra_data: header.extra_data,
+            gas_limit: header
+                .gas_limit
+                .try_into()
+                .map_err(|_| ConversionError::GasLimitConversion)?,
+            gas_used: header.gas_used.try_into().map_err(|_| ConversionError::GasUsedConversion)?,
+            logs_bloom: header.logs_bloom,
+            mix_hash: header.mix_hash.unwrap_or_default(),
+            nonce: u64::from_be_bytes(header.nonce.unwrap_or_default().0),
+            number: header
+                .number
+                .ok_or(ConversionError::MissingBlockNumber)?
+                .try_into()
+                .map_err(|_| ConversionError::BlockNumberConversion)?,
+            ommers_hash: header.uncles_hash,
+            parent_beacon_block_root: header.parent_beacon_block_root,
+            parent_hash: header.parent_hash,
+            receipts_root: header.receipts_root,
+            state_root: header.state_root,
+            timestamp: header
+                .timestamp
+                .try_into()
+                .map_err(|_| ConversionError::TimestampConversion)?,
+            transactions_root: header.transactions_root,
+            withdrawals_root: header.withdrawals_root,
+        })
     }
 }
 

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -502,11 +502,19 @@ impl TryFrom<reth_rpc_types::Header> for Header {
             beneficiary: header.miner,
             blob_gas_used: header
                 .blob_gas_used
-                .map(|blob_gas_used| blob_gas_used.try_into().unwrap()),
+                .map(|blob_gas_used| {
+                    blob_gas_used.try_into().map_err(ConversionError::BlobGasUsedConversion)
+                })
+                .transpose()?,
             difficulty: header.difficulty,
             excess_blob_gas: header
                 .excess_blob_gas
-                .map(|excess_blob_gas| excess_blob_gas.try_into().unwrap()),
+                .map(|excess_blob_gas| {
+                    excess_blob_gas
+                        .try_into()
+                        .map_err(|e| ConversionError::ExcessBlobGasConversion(e))
+                })
+                .transpose()?,
             extra_data: header.extra_data,
             gas_limit: header
                 .gas_limit

--- a/crates/primitives/src/withdrawal.rs
+++ b/crates/primitives/src/withdrawal.rs
@@ -36,6 +36,17 @@ impl Withdrawal {
     }
 }
 
+impl From<reth_rpc_types::Withdrawal> for Withdrawal {
+    fn from(withdrawal: reth_rpc_types::Withdrawal) -> Self {
+        Self {
+            index: withdrawal.index,
+            validator_index: withdrawal.index,
+            address: withdrawal.address,
+            amount: withdrawal.amount,
+        }
+    }
+}
+
 /// Represents a collection of Withdrawals.
 #[main_codec]
 #[derive(Debug, Clone, PartialEq, Eq, Default, Hash, RlpEncodableWrapper, RlpDecodableWrapper)]
@@ -101,6 +112,12 @@ impl Deref for Withdrawals {
 impl DerefMut for Withdrawals {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
+    }
+}
+
+impl From<Vec<reth_rpc_types::Withdrawal>> for Withdrawals {
+    fn from(withdrawals: Vec<reth_rpc_types::Withdrawal>) -> Self {
+        Self(withdrawals.into_iter().map(Into::into).collect())
     }
 }
 

--- a/crates/rpc/rpc/src/txpool.rs
+++ b/crates/rpc/rpc/src/txpool.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult as Result;
-use reth_primitives::{Address, U256, U64};
+use reth_primitives::Address;
 use reth_rpc_api::TxPoolApiServer;
 use reth_rpc_types::{
     txpool::{TxpoolContent, TxpoolContentFrom, TxpoolInspect, TxpoolInspectSummary, TxpoolStatus},
@@ -69,10 +69,7 @@ where
     async fn txpool_status(&self) -> Result<TxpoolStatus> {
         trace!(target: "rpc::eth", "Serving txpool_status");
         let all = self.pool.all_transactions();
-        Ok(TxpoolStatus {
-            pending: U64::from(all.pending.len()),
-            queued: U64::from(all.queued.len()),
-        })
+        Ok(TxpoolStatus { pending: all.pending.len() as u64, queued: all.queued.len() as u64 })
     }
 
     /// Returns a summary of all the transactions currently pending for inclusion in the next
@@ -97,8 +94,8 @@ where
                 TxpoolInspectSummary {
                     to: tx.to(),
                     value: tx.value(),
-                    gas: U256::from(tx.gas_limit()),
-                    gas_price: U256::from(tx.transaction.max_fee_per_gas()),
+                    gas: tx.gas_limit() as u128,
+                    gas_price: tx.transaction.max_fee_per_gas(),
                 },
             );
         }


### PR DESCRIPTION
Add `TryFrom` implementations for:
- RPC `Header` to primitive
- RPC `Block` to primitive
- RPC `Withdrawal` to primitive
- RPC `Withdrawals` to primitives