### PR TITLE
fix: add discv5 config to p2p cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6067,6 +6067,7 @@ dependencies = [
  "comfy-table",
  "confy",
  "crossterm",
+ "discv5",
  "eyre",
  "fdlimit",
  "futures",

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -94,6 +94,9 @@ rayon.workspace = true
 boyer-moore-magiclen = "0.2.16"
 ahash = "0.8"
 
+# p2p
+discv5.workspace = true
+
 [target.'cfg(unix)'.dependencies]
 tikv-jemallocator = { version = "0.5.0", optional = true }
 libc = "0.2"

--- a/bin/reth/src/commands/p2p/mod.rs
+++ b/bin/reth/src/commands/p2p/mod.rs
@@ -11,13 +11,14 @@ use crate::{
 };
 use backon::{ConstantBuilder, Retryable};
 use clap::{Parser, Subcommand};
+use discv5::ListenConfig;
 use reth_config::Config;
 use reth_db::create_db;
 use reth_discv4::NatResolver;
 use reth_interfaces::p2p::bodies::client::BodiesClient;
 use reth_primitives::{BlockHashOrNumber, ChainSpec, NodeRecord};
 use reth_provider::ProviderFactory;
-use std::{path::PathBuf, sync::Arc};
+use std::{net::SocketAddr, path::PathBuf, sync::Arc};
 
 /// `reth p2p` command
 #[derive(Debug, Parser)]
@@ -122,8 +123,10 @@ impl Command {
         let secret_key_path = self.p2p_secret_key.clone().unwrap_or(default_secret_key_path);
         let p2p_secret_key = get_secret_key(&secret_key_path)?;
 
-        let mut network_config_builder =
-            config.network_config(self.nat, None, p2p_secret_key).chain_spec(self.chain.clone());
+        let mut network_config_builder = config
+            .network_config(self.nat, None, p2p_secret_key)
+            .chain_spec(self.chain.clone())
+            .boot_nodes(self.chain.bootnodes().unwrap_or_default());
 
         network_config_builder = self.discovery.apply_to_builder(network_config_builder);
 
@@ -133,6 +136,18 @@ impl Command {
                 self.chain.clone(),
                 data_dir.static_files_path(),
             )?))
+            .discovery_v5_with_config_builder(|builder| {
+                let DiscoveryArgs { discv5_addr, discv5_port, .. } = self.discovery;
+                builder
+                    .discv5_config(
+                        discv5::ConfigBuilder::new(ListenConfig::from(Into::<SocketAddr>::into((
+                            discv5_addr,
+                            discv5_port,
+                        ))))
+                        .build(),
+                    )
+                    .build()
+            })
             .start_network()
             .await?;
 

--- a/crates/node-core/src/args/network_args.rs
+++ b/crates/node-core/src/args/network_args.rs
@@ -252,6 +252,7 @@ impl DiscoveryArgs {
         }
 
         if !self.disable_discovery && (self.enable_discv5_discovery || cfg!(feature = "optimism")) {
+            network_config_builder = network_config_builder.disable_discv4_discovery();
             network_config_builder = network_config_builder.enable_discv5_discovery();
         }
 
@@ -271,7 +272,7 @@ impl Default for DiscoveryArgs {
         Self {
             disable_discovery: false,
             disable_dns_discovery: false,
-            disable_discv4_discovery: false,
+            disable_discv4_discovery: cfg!(feature = "optimism"),
             enable_discv5_discovery: cfg!(feature = "optimism"),
             addr: DEFAULT_DISCOVERY_ADDR,
             port: DEFAULT_DISCOVERY_PORT,


### PR DESCRIPTION
Adds missing discv5 config and bootnodes to NetworkConfig on p2p command.