### PR TITLE
chore: include block num and hash in bctree debug logs

### DIFF
--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -430,8 +430,8 @@ where
         chain_id: BlockChainId,
         block_validation_kind: BlockValidationKind,
     ) -> Result<BlockStatus, InsertBlockErrorKind> {
-        debug!(target: "blockchain_tree", "Inserting block into side chain");
         let block_num_hash = block.num_hash();
+        debug!(target: "blockchain_tree", ?block_num_hash, "Inserting block into side chain");
         // Create a new sidechain by forking the given chain, or append the block if the parent
         // block is the top of the given chain.
         let block_hashes = self.all_chain_hashes(chain_id);
@@ -458,9 +458,9 @@ where
                 BlockAttachment::HistoricalFork
             };
 
-            debug!(target: "blockchain_tree", "Appending block to side chain");
             let block_hash = block.hash();
             let block_number = block.number;
+            debug!(target: "blockchain_tree", ?block_hash, ?block_number, "Appending block to side chain");
             parent_chain.append_block(
                 block,
                 block_hashes,

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -431,7 +431,7 @@ where
         block_validation_kind: BlockValidationKind,
     ) -> Result<BlockStatus, InsertBlockErrorKind> {
         let block_num_hash = block.num_hash();
-        debug!(target: "blockchain_tree", ?block_num_hash, "Inserting block into side chain");
+        debug!(target: "blockchain_tree", ?block_num_hash, ?chain_id, "Inserting block into side chain");
         // Create a new sidechain by forking the given chain, or append the block if the parent
         // block is the top of the given chain.
         let block_hashes = self.all_chain_hashes(chain_id);


### PR DESCRIPTION
Without block num or hash, it's hard to understand what the log is actually referring to. For example, the logs look like this:
```log
2024-03-26T17:09:38.333953Z DEBUG blockchain_tree: Inserting block into side chain
2024-03-26T17:09:38.333966Z DEBUG blockchain_tree: Appending block to side chain
```