### PR TITLE
perf(discv5): boost bootstrap lookups

### DIFF
--- a/crates/net/discv5/src/config.rs
+++ b/crates/net/discv5/src/config.rs
@@ -19,7 +19,7 @@ pub const ETH2: &[u8] = b"eth2";
 /// Optimism
 pub const OPSTACK: &[u8] = b"opstack";
 
-/// Default interval in seconds at which to run a self-lookup up query.
+/// Default interval in seconds at which to run a lookup up query.
 ///
 /// Default is 60 seconds.
 const DEFAULT_SECONDS_LOOKUP_INTERVAL: u64 = 60;

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -41,6 +41,11 @@ pub use error::Error;
 pub use filter::{FilterOutcome, MustNotIncludeKeys};
 use metrics::Discv5Metrics;
 
+/// Default number of times to do pulse lookup queries, at bootstrap (5 second intervals).
+///
+/// Default is 200 seconds.
+pub const DEFAULT_COUNT_PULSE_LOOKUPS_AT_BOOTSTRAP: u64 = 200;
+
 /// The max log2 distance, is equivalent to the index of the last bit in a discv5 node id.
 const MAX_LOG2_DISTANCE: usize = 255;
 
@@ -301,7 +306,7 @@ impl Discv5 {
             let lookup_interval = Duration::from_secs(lookup_interval);
             let mut metrics = metrics.discovered_peers;
             let mut log2_distance = 0usize;
-            let mut boost_bootstrap = 100;
+            let mut boost_bootstrap = DEFAULT_COUNT_PULSE_LOOKUPS_AT_BOOTSTRAP;
             // todo: graceful shutdown
 
             async move {

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -316,7 +316,7 @@ impl Discv5 {
             async move {
                 // make many fast lookup queries at bootstrap, trying to fill kbuckets at furthest
                 // log2distance from local node
-                for i in DEFAULT_COUNT_PULSE_LOOKUPS_AT_BOOTSTRAP..0 {
+                for i in (0..DEFAULT_COUNT_PULSE_LOOKUPS_AT_BOOTSTRAP).rev() {
                     let target = discv5::enr::NodeId::random();
 
                     trace!(target: "net::discv5",

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -333,21 +333,24 @@ impl Discv5 {
                         tgt
                     };
 
+                    let sleep =
+                        if boost_bootstrap > 0 { Duration::from_secs(5) } else { lookup_interval };
+
                     trace!(target: "net::discv5",
                         target=format!("{:#?}", target),
-                        lookup_interval=format!("{:#?}", lookup_interval),
+                        lookup_interval=format!("{:#?}", sleep),
                         "starting periodic lookup query"
                     );
 
                     match discv5.find_node(target).await {
                         Err(err) => trace!(target: "net::discv5",
-                            lookup_interval=format!("{:#?}", lookup_interval),
+                            lookup_interval=format!("{:#?}", sleep),
                             %err,
                             "periodic lookup query failed"
                         ),
                         Ok(peers) => trace!(target: "net::discv5",
                             target=format!("{:#?}", target),
-                            lookup_interval=format!("{:#?}", lookup_interval),
+                            lookup_interval=format!("{:#?}", sleep),
                             peers_count=peers.len(),
                             peers=format!("[{:#}]", peers.iter()
                                 .map(|enr| enr.node_id()
@@ -363,8 +366,7 @@ impl Discv5 {
                         connected_peers=discv5.connected_peers(),
                         "connected peers in routing table"
                     );
-                    let sleep =
-                        if boost_bootstrap > 0 { Duration::from_secs(5) } else { lookup_interval };
+
                     tokio::time::sleep(sleep).await;
                 }
             }

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -320,7 +320,7 @@ impl Discv5 {
                     let target = discv5::enr::NodeId::random();
 
                     trace!(target: "net::discv5",
-                        target=format!("{:#?}", target),
+                        %target,
                         bootstrap_boost_runs_count_down=i,
                         lookup_interval=format!("{:#?}", pulse_lookup_interval),
                         "starting bootstrap boost lookup query"
@@ -338,7 +338,7 @@ impl Discv5 {
                     let target = get_lookup_target(log2_distance, local_node_id);
 
                     trace!(target: "net::discv5",
-                        target=format!("{:#?}", target),
+                        %target,
                         lookup_interval=format!("{:#?}", lookup_interval),
                         "starting periodic lookup query"
                     );

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -44,7 +44,7 @@ use metrics::Discv5Metrics;
 /// Default number of times to do pulse lookup queries, at bootstrap (5 second intervals).
 ///
 /// Default is 200 seconds.
-pub const DEFAULT_COUNT_PULSE_LOOKUPS_AT_BOOTSTRAP: u64 = 200;
+pub const DEFAULT_COUNT_PULSE_LOOKUPS_AT_BOOTSTRAP: u64 = 100;
 
 /// Default duration of look up interval, for pulse look ups at bootstrap.
 ///

--- a/crates/net/discv5/src/metrics.rs
+++ b/crates/net/discv5/src/metrics.rs
@@ -57,7 +57,7 @@ impl DiscoveredPeersMetrics {
     }
 
     /// Increments the number of kbucket insertions in [`discv5::Discv5`].
-    pub fn increment_kbucket_insertions(&mut self, num: u64) {
+    pub fn increment_kbucket_insertions(&self, num: u64) {
         self.total_inserted_kbucket_peers_raw.increment(num)
     }
 
@@ -67,19 +67,19 @@ impl DiscoveredPeersMetrics {
     }
 
     /// Increments number of sessions established by [`discv5::Discv5`].
-    pub fn increment_established_sessions_raw(&mut self, num: u64) {
+    pub fn increment_established_sessions_raw(&self, num: u64) {
         self.total_established_sessions_raw.increment(num)
     }
 
     /// Increments number of sessions established by [`discv5::Discv5`], with peers that don't have
     /// a reachable node record.
-    pub fn increment_established_sessions_unreachable_enr(&mut self, num: u64) {
+    pub fn increment_established_sessions_unreachable_enr(&self, num: u64) {
         self.total_established_sessions_unreachable_enr.increment(num)
     }
 
     /// Increments number of sessions established by [`discv5::Discv5`], that pass configured
     /// [`filter`](crate::filter) rules.
-    pub fn increment_established_sessions_filtered(&mut self, num: u64) {
+    pub fn increment_established_sessions_filtered(&self, num: u64) {
         self.total_established_sessions_custom_filtered.increment(num)
     }
 }
@@ -103,7 +103,7 @@ pub struct AdvertisedChainMetrics {
 
 impl AdvertisedChainMetrics {
     /// Counts each recognised network type that is advertised on node record, once.
-    pub fn increment_once_by_network_type(&mut self, enr: &discv5::Enr) {
+    pub fn increment_once_by_network_type(&self, enr: &discv5::Enr) {
         if enr.get_raw_rlp(OPSTACK).is_some() {
             self.opstack.increment(1u64)
         }

--- a/crates/net/discv5/src/metrics.rs
+++ b/crates/net/discv5/src/metrics.rs
@@ -52,7 +52,7 @@ pub struct DiscoveredPeersMetrics {
 
 impl DiscoveredPeersMetrics {
     /// Sets current total number of peers in [`discv5::Discv5`]'s kbuckets.
-    pub fn set_total_kbucket_peers(&mut self, num: usize) {
+    pub fn set_total_kbucket_peers(&self, num: usize) {
         self.total_kbucket_peers_raw.set(num as f64)
     }
 
@@ -62,7 +62,7 @@ impl DiscoveredPeersMetrics {
     }
 
     /// Sets current total number of peers connected to [`discv5::Discv5`].
-    pub fn set_total_sessions(&mut self, num: usize) {
+    pub fn set_total_sessions(&self, num: usize) {
         self.total_sessions_raw.set(num as f64)
     }
 


### PR DESCRIPTION
Fills the three buckets at log2distance furthest from the local node id, at 5 second intervals, at bootstrap. This gives RLPx a better chance of finding peers instantly after bootstrapping.