### PR TITLE
fix(discv5): fix panel filtered peers

### DIFF
--- a/etc/grafana/dashboards/reth-discovery.json
+++ b/etc/grafana/dashboards/reth-discovery.json
@@ -766,7 +766,7 @@
             },
             "disableTextWrap": false,
             "editorMode": "builder",
-            "expr": "rate(reth_discv5_total_established_sessions_custom_filtered{instance=\"$instance\"}[$__rate_interval])",
+            "expr": "rate(reth_discv5_total_established_sessions_raw{instance=\"$instance\"}[$__rate_interval]) - rate(reth_discv5_total_established_sessions_custom_filtered{instance=\"$instance\"}[$__rate_interval])",
             "fullMetaSearch": false,
             "hide": false,
             "includeNullMetadata": false,


### PR DESCRIPTION
Fixes calculation of peers which **pass** ENR filter, which  before was showing peers that fail the filter.