### PR TITLE
fix(docker): obsolete syntax compose file

### DIFF
--- a/etc/docker-compose.yml
+++ b/etc/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 name: 'reth'
 
 services:


### PR DESCRIPTION
Removes version from docker compose file, which is obsolete in latest version of docker compose.