### PR TITLE
fix: check for genesis block on pool validator init

### DIFF
--- a/crates/node-optimism/src/txpool.rs
+++ b/crates/node-optimism/src/txpool.rs
@@ -76,8 +76,8 @@ where
     /// Update the L1 block info.
     fn update_l1_block_info(&self, block: &Block) {
         self.block_info.timestamp.store(block.timestamp, Ordering::Relaxed);
-        if let Some(cost_addition) = reth_revm::optimism::extract_l1_info(block) {
-            *self.block_info.l1_block_info.write() = cost_addition;
+        if let Ok(cost_addition) = reth_revm::optimism::extract_l1_info(block) {
+            *self.block_info.l1_block_info.write() = Some(cost_addition);
         }
     }
 

--- a/crates/revm/src/optimism/mod.rs
+++ b/crates/revm/src/optimism/mod.rs
@@ -26,6 +26,8 @@ const L1_BLOCK_ECOTONE_SELECTOR: [u8; 4] = hex!("440a5e20");
 
 /// Extracts the [L1BlockInfo] from the L2 block. The L1 info transaction is always the first
 /// transaction in the L2 block.
+///
+/// Returns an error if the L1 info transaction is not found, if the block is empty.
 pub fn extract_l1_info(block: &Block) -> Result<L1BlockInfo, BlockExecutionError> {
     let l1_info_tx_data = block
         .body


### PR DESCRIPTION
we can only extract L1 block info if there's an info tx in the block, the genesis block is empty.
so we set the info to empty, once there's a new block this will get updated