### PR TITLE
chore(engine): inline `update_tree_on_finished_pipeline` method

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1335,25 +1335,6 @@ where
         }
     }
 
-    /// Attempt to restore the tree with the given block hash.
-    ///
-    /// This is invoked after a full pipeline to update the tree with the most recent canonical
-    /// hashes.
-    ///
-    /// If the given block is missing from the database, this will return `false`. Otherwise, `true`
-    /// is returned: the database contains the hash and the tree was updated.
-    fn update_tree_on_finished_pipeline(&mut self, block_hash: B256) -> RethResult<bool> {
-        let synced_to_finalized = match self.blockchain.block_number(block_hash)? {
-            Some(number) => {
-                // Attempt to restore the tree.
-                self.blockchain.connect_buffered_blocks_to_canonical_hashes_and_finalize(number)?;
-                true
-            }
-            None => false,
-        };
-        Ok(synced_to_finalized)
-    }
-
     /// Invoked if we successfully downloaded a new block from the network.
     ///
     /// This will attempt to insert the block into the tree.
@@ -1592,8 +1573,7 @@ where
     /// Updates the internal sync state depending on the pipeline configuration,
     /// the outcome of the pipeline run and the last observed forkchoice state.
     fn on_pipeline_outcome(&mut self, ctrl: ControlFlow) -> RethResult<()> {
-        // Pipeline unwound, memorize the invalid block and
-        // wait for CL for further sync instructions.
+        // Pipeline unwound, memorize the invalid block and wait for CL for next sync target.
         if let ControlFlow::Unwind { bad_block, .. } = ctrl {
             warn!(target: "consensus::engine", invalid_hash=?bad_block.hash(), invalid_number=?bad_block.number, "Bad block detected in unwind");
             // update the `invalid_headers` cache with the new invalid header
@@ -1678,17 +1658,18 @@ where
         if let Some(target) = pipeline_target {
             // run the pipeline to the target since the distance is sufficient
             self.sync.set_pipeline_sync_target(target);
-        } else {
-            // Update the state and hashes of the blockchain tree if possible.
-            let synced =  self.update_tree_on_finished_pipeline(sync_target_state.finalized_block_hash).inspect_err(|error| {
+        } else if let Some(number) =
+            self.blockchain.block_number(sync_target_state.finalized_block_hash)?
+        {
+            // Finalized block is in the database, attempt to restore the tree with
+            // the most recent canonical hashes.
+            self.blockchain.connect_buffered_blocks_to_canonical_hashes_and_finalize(number).inspect_err(|error| {
                 error!(target: "consensus::engine", %error, "Error restoring blockchain tree state");
             })?;
-
-            if !synced {
-                // We don't have the finalized block in the database, so
-                // we need to run another pipeline.
-                self.sync.set_pipeline_sync_target(sync_target_state.finalized_block_hash);
-            }
+        } else {
+            // We don't have the finalized block in the database, so we need to
+            // trigger another pipeline run.
+            self.sync.set_pipeline_sync_target(sync_target_state.finalized_block_hash);
         }
 
         Ok(())


### PR DESCRIPTION
## Description

Inline `update_tree_on_finished_pipeline` method. Removes most of the docs for it as they described the place where this method is invoked. This also allows simplifying conditional branches in pipeline outcome processing.