### PR TITLE
feat: `--debug.skip-fcu`

### DIFF
--- a/crates/consensus/beacon/src/engine/message.rs
+++ b/crates/consensus/beacon/src/engine/message.rs
@@ -41,7 +41,7 @@ impl OnForkChoiceUpdated {
     }
 
     /// Creates a new instance of `OnForkChoiceUpdated` for the `SYNCING` state
-    pub(crate) fn syncing() -> Self {
+    pub fn syncing() -> Self {
         let status = PayloadStatus::from_status(PayloadStatusEnum::Syncing);
         Self {
             forkchoice_status: ForkchoiceStatus::from_payload_status(&status.status),

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1,7 +1,6 @@
 use crate::{
     engine::{
         forkchoice::{ForkchoiceStateHash, ForkchoiceStateTracker},
-        message::OnForkChoiceUpdated,
         metrics::EngineMetrics,
     },
     hooks::{EngineHookContext, EngineHooksController},
@@ -51,7 +50,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::*;
 
 mod message;
-pub use message::BeaconEngineMessage;
+pub use message::{BeaconEngineMessage, OnForkChoiceUpdated};
 
 mod error;
 pub use error::{

--- a/crates/node-builder/src/builder.rs
+++ b/crates/node-builder/src/builder.rs
@@ -37,6 +37,7 @@ use reth_node_core::{
     cli::config::{PayloadBuilderConfig, RethRpcConfig, RethTransactionPoolConfig},
     dirs::{ChainPath, DataDirPath, MaybePlatformPath},
     engine_api_store::EngineApiStore,
+    engine_skip_fcu::EngineApiSkipFcu,
     events::cl::ConsensusLayerHealthEvents,
     exit::NodeExitFuture,
     init::init_genesis,
@@ -664,6 +665,17 @@ where
         // create pipeline
         let network_client = network.fetch_client().await?;
         let (consensus_engine_tx, mut consensus_engine_rx) = unbounded_channel();
+
+        if let Some(skip_fcu_threshold) = config.debug.skip_fcu {
+            debug!(target: "reth::cli", "spawning skip FCU task");
+            let (skip_fcu_tx, skip_fcu_rx) = unbounded_channel();
+            let engine_skip_fcu = EngineApiSkipFcu::new(skip_fcu_threshold);
+            executor.spawn_critical(
+                "skip FCU interceptor",
+                engine_skip_fcu.intercept(consensus_engine_rx, skip_fcu_tx),
+            );
+            consensus_engine_rx = skip_fcu_rx;
+        }
 
         if let Some(store_path) = config.debug.engine_api_store.clone() {
             debug!(target: "reth::cli", "spawning engine API store");

--- a/crates/node-core/src/args/debug_args.rs
+++ b/crates/node-core/src/args/debug_args.rs
@@ -59,6 +59,10 @@ pub struct DebugArgs {
     )]
     pub hook_all: bool,
 
+    /// If provided, the engine will skip `n` consecutive FCUs.
+    #[arg(long = "debug.skip-fcu", help_heading = "Debug")]
+    pub skip_fcu: Option<usize>,
+
     /// The path to store engine API messages at.
     /// If specified, all of the intercepted engine API messages
     /// will be written to specified location.

--- a/crates/node-core/src/engine_api_store.rs
+++ b/crates/node-core/src/engine_api_store.rs
@@ -2,7 +2,7 @@
 
 use reth_beacon_consensus::BeaconEngineMessage;
 use reth_engine_primitives::EngineTypes;
-use reth_primitives::fs::{self};
+use reth_primitives::fs;
 use reth_rpc_types::{
     engine::{CancunPayloadFields, ForkchoiceState},
     ExecutionPayload,

--- a/crates/node-core/src/engine_skip_fcu.rs
+++ b/crates/node-core/src/engine_skip_fcu.rs
@@ -1,0 +1,51 @@
+//! Stores engine API messages to disk for later inspection and replay.
+
+use reth_beacon_consensus::{BeaconEngineMessage, OnForkChoiceUpdated};
+use reth_engine_primitives::EngineTypes;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+
+/// Intercept Engine API message and skip FCUs.
+#[derive(Debug)]
+pub struct EngineApiSkipFcu {
+    /// The number of FCUs to skip.
+    threshold: usize,
+    /// Current count of skipped FCUs.
+    skipped: usize,
+}
+
+impl EngineApiSkipFcu {
+    /// Creates new [EngineApiSkipFcu] interceptor.
+    pub fn new(threshold: usize) -> Self {
+        Self { threshold, skipped: 0 }
+    }
+
+    /// Intercepts an incoming engine API message, skips FCU or forwards it
+    /// to the engine depending on current number of skipped FCUs.
+    pub async fn intercept<Engine>(
+        mut self,
+        mut rx: UnboundedReceiver<BeaconEngineMessage<Engine>>,
+        to_engine: UnboundedSender<BeaconEngineMessage<Engine>>,
+    ) where
+        Engine: EngineTypes,
+        BeaconEngineMessage<Engine>: std::fmt::Debug,
+    {
+        while let Some(msg) = rx.recv().await {
+            if let BeaconEngineMessage::ForkchoiceUpdated { state, payload_attrs, tx } = msg {
+                if self.skipped < self.threshold {
+                    self.skipped += 1;
+                    tracing::warn!(target: "engine::intercept", ?state, ?payload_attrs, threshold=self.threshold, skipped=self.skipped, "Skipping FCU");
+                    let _ = tx.send(Ok(OnForkChoiceUpdated::syncing()));
+                } else {
+                    self.skipped = 0;
+                    let _ = to_engine.send(BeaconEngineMessage::ForkchoiceUpdated {
+                        state,
+                        payload_attrs,
+                        tx,
+                    });
+                }
+            } else {
+                let _ = to_engine.send(msg);
+            }
+        }
+    }
+}

--- a/crates/node-core/src/lib.rs
+++ b/crates/node-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod args;
 pub mod cli;
 pub mod dirs;
 pub mod engine_api_store;
+pub mod engine_skip_fcu;
 pub mod events;
 pub mod exit;
 pub mod init;


### PR DESCRIPTION
## Description

Creates new `EngineApiSkipFcu` interceptor that skips `n` consecutive FCU messages if configured.