### PR TITLE
fix: don't import ipc client on windows

### DIFF
--- a/crates/rpc/rpc-builder/src/auth.rs
+++ b/crates/rpc/rpc-builder/src/auth.rs
@@ -13,7 +13,6 @@ use jsonrpsee::{
     server::{AlreadyStoppedError, RpcModule},
     Methods,
 };
-use reth_ipc::client::IpcClientBuilder;
 pub use reth_ipc::server::{Builder as IpcServerBuilder, Endpoint};
 
 use reth_engine_primitives::EngineTypes;
@@ -445,6 +444,8 @@ impl AuthServerHandle {
     /// Returns an ipc client connected to the server.
     #[cfg(unix)]
     pub async fn ipc_client(&self) -> Option<jsonrpsee::async_client::Client> {
+        use reth_ipc::client::IpcClientBuilder;
+
         if let Some(ipc_endpoint) = self.ipc_endpoint.clone() {
             return Some(
                 IpcClientBuilder::default()


### PR DESCRIPTION
We can't import the IPC client builder on Windows until https://github.com/paradigmxyz/reth/pull/7187 is merged

Closes https://github.com/paradigmxyz/reth/issues/7711