### PR TITLE
chore: rename `parent_block_hashed` to `parent_block_hashes`

### DIFF
--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -278,7 +278,11 @@ where
 
             // get canonical fork.
             let canonical_fork = self.canonical_fork(chain_id)?;
-            return Some(BundleStateData { state, parent_block_hashed, canonical_fork })
+            return Some(BundleStateData {
+                state,
+                parent_block_hashes: parent_block_hashed,
+                canonical_fork,
+            })
         }
 
         // check if there is canonical block
@@ -287,7 +291,7 @@ where
             return Some(BundleStateData {
                 canonical_fork: ForkBlock { number: canonical_number, hash: block_hash },
                 state: BundleStateWithReceipts::default(),
-                parent_block_hashed: canonical_chain.inner().clone(),
+                parent_block_hashes: canonical_chain.inner().clone(),
             })
         }
 

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -267,22 +267,18 @@ where
             let state = chain.state_at_block(block_number)?;
 
             // get parent hashes
-            let mut parent_block_hashed = self.all_chain_hashes(chain_id);
+            let mut parent_block_hashes = self.all_chain_hashes(chain_id);
             let first_pending_block_number =
-                *parent_block_hashed.first_key_value().expect("There is at least one block hash").0;
+                *parent_block_hashes.first_key_value().expect("There is at least one block hash").0;
             let canonical_chain = canonical_chain
                 .iter()
                 .filter(|&(key, _)| key < first_pending_block_number)
                 .collect::<Vec<_>>();
-            parent_block_hashed.extend(canonical_chain);
+            parent_block_hashes.extend(canonical_chain);
 
             // get canonical fork.
             let canonical_fork = self.canonical_fork(chain_id)?;
-            return Some(BundleStateData {
-                state,
-                parent_block_hashes: parent_block_hashed,
-                canonical_fork,
-            })
+            return Some(BundleStateData { state, parent_block_hashes, canonical_fork })
         }
 
         // check if there is canonical block

--- a/crates/blockchain-tree/src/bundle.rs
+++ b/crates/blockchain-tree/src/bundle.rs
@@ -44,7 +44,7 @@ pub struct BundleStateData {
     /// Parent block hashes needs for evm BLOCKHASH opcode.
     /// NOTE: it does not mean that all hashes are there but all until finalized are there.
     /// Other hashes can be obtained from provider
-    pub parent_block_hashed: BTreeMap<BlockNumber, BlockHash>,
+    pub parent_block_hashes: BTreeMap<BlockNumber, BlockHash>,
     /// Canonical block where state forked from.
     pub canonical_fork: ForkBlock,
 }
@@ -55,7 +55,7 @@ impl BundleStateDataProvider for BundleStateData {
     }
 
     fn block_hash(&self, block_number: BlockNumber) -> Option<BlockHash> {
-        self.parent_block_hashed.get(&block_number).cloned()
+        self.parent_block_hashes.get(&block_number).cloned()
     }
 
     fn canonical_fork(&self) -> ForkBlock {


### PR DESCRIPTION
## Description

See the title.