### PR TITLE
chore(engine): remove `find_canonical_ancestor`

### DIFF
--- a/crates/blockchain-tree/src/block_indices.rs
+++ b/crates/blockchain-tree/src/block_indices.rs
@@ -109,11 +109,6 @@ impl BlockIndices {
         self.canonical_chain.get_canonical_block_number(self.last_finalized_block, block_hash)
     }
 
-    /// Check if block hash belongs to canonical chain.
-    pub(crate) fn is_block_hash_canonical(&self, block_hash: &BlockHash) -> bool {
-        self.get_canonical_block_number(block_hash).is_some()
-    }
-
     /// Last finalized block
     pub fn last_finalized_block(&self) -> BlockNumber {
         self.last_finalized_block

--- a/crates/blockchain-tree/src/noop.rs
+++ b/crates/blockchain-tree/src/noop.rs
@@ -87,10 +87,6 @@ impl BlockchainTreeViewer for NoopBlockchainTree {
         Default::default()
     }
 
-    fn find_canonical_ancestor(&self, _parent_hash: BlockHash) -> Option<BlockHash> {
-        None
-    }
-
     fn is_canonical(&self, _block_hash: BlockHash) -> Result<bool, ProviderError> {
         Ok(false)
     }

--- a/crates/blockchain-tree/src/shareable.rs
+++ b/crates/blockchain-tree/src/shareable.rs
@@ -141,21 +141,6 @@ where
         self.tree.read().block_indices().canonical_chain().inner().clone()
     }
 
-    fn find_canonical_ancestor(&self, mut parent: BlockHash) -> Option<BlockHash> {
-        let tree = self.tree.read();
-
-        // walk up the tree and check if the parent is in the sidechain
-        while let Some(block) = tree.block_by_hash(parent) {
-            parent = block.parent_hash;
-        }
-
-        if tree.block_indices().is_block_hash_canonical(&parent) {
-            return Some(parent)
-        }
-
-        None
-    }
-
     fn is_canonical(&self, hash: BlockHash) -> Result<bool, ProviderError> {
         trace!(target: "blockchain_tree", ?hash, "Checking if block is canonical");
         self.tree.read().is_block_hash_canonical(&hash)

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -726,17 +726,9 @@ where
             // parent is in side-chain: validated but not canonical yet
             Some(parent_hash)
         } else {
-            let parent_hash = self.blockchain.find_canonical_ancestor(parent_hash)?;
-            let parent_header = self.blockchain.header(&parent_hash).ok().flatten()?;
-
-            // we need to check if the parent block is the last POW block, if so then the payload is
-            // the first POS. The engine API spec mandates a zero hash to be returned: <https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/paris.md#engine_newpayloadv1>
-            if !parent_header.is_zero_difficulty() {
-                return Some(B256::ZERO)
-            }
-
-            // parent is canonical POS block
-            Some(parent_hash)
+            // TODO: attempt to iterate over ancestors in the invalid cache
+            // until we encounter the first valid ancestor
+            None
         }
     }
 

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -720,10 +720,9 @@ where
             return Some(B256::ZERO)
         }
 
-        // If this is sent from new payload then the parent hash could be in a side chain, and is
-        // not necessarily canonical
-        if self.blockchain.header_by_hash(parent_hash).is_some() {
-            // parent is in side-chain: validated but not canonical yet
+        // Check if parent exists in side chain or in canonical chain.
+        if matches!(self.blockchain.find_block_by_hash(parent_hash, BlockSource::Any), Ok(Some(_)))
+        {
             Some(parent_hash)
         } else {
             // TODO: attempt to iterate over ancestors in the invalid cache

--- a/crates/interfaces/src/blockchain_tree/mod.rs
+++ b/crates/interfaces/src/blockchain_tree/mod.rs
@@ -288,15 +288,6 @@ pub trait BlockchainTreeViewer: Send + Sync {
     /// Canonical block number and hashes best known by the tree.
     fn canonical_blocks(&self) -> BTreeMap<BlockNumber, BlockHash>;
 
-    /// Given the parent hash of a block, this tries to find the last ancestor that is part of the
-    /// canonical chain.
-    ///
-    /// In other words, this will walk up the (side) chain starting with the given hash and return
-    /// the first block that's canonical.
-    ///
-    /// Note: this could be the given `parent_hash` if it's already canonical.
-    fn find_canonical_ancestor(&self, parent_hash: BlockHash) -> Option<BlockHash>;
-
     /// Return whether or not the block is known and in the canonical chain.
     fn is_canonical(&self, hash: BlockHash) -> Result<bool, ProviderError>;
 

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -714,10 +714,6 @@ where
         self.tree.canonical_blocks()
     }
 
-    fn find_canonical_ancestor(&self, hash: BlockHash) -> Option<BlockHash> {
-        self.tree.find_canonical_ancestor(hash)
-    }
-
     fn is_canonical(&self, hash: BlockHash) -> Result<bool, ProviderError> {
         self.tree.is_canonical(hash)
     }


### PR DESCRIPTION
## Description

Removes noop code for finding a canonical ancestor.

`blockchain.header_by_hash` here 
https://github.com/paradigmxyz/reth/blob/58cb524d73e1935a263ab8cd08777580cf67e15a/crates/consensus/beacon/src/engine/mod.rs#L725-L730
internally calls `tree.block_by_hash`.
https://github.com/paradigmxyz/reth/blob/58cb524d73e1935a263ab8cd08777580cf67e15a/crates/blockchain-tree/src/shareable.rs#L116-L119

if it's `None` it proceeds to perform the exact same call with same argument in `find_canonical_ancestor` which will always be `None`.
https://github.com/paradigmxyz/reth/blob/58cb524d73e1935a263ab8cd08777580cf67e15a/crates/blockchain-tree/src/shareable.rs#L144-L157

Additionally, removes `find_canonical_ancestor` from the interface.