### PR TITLE
Revert "feat(op): import bodies (#7659)"

### DIFF
--- a/bin/reth/src/commands/import.rs
+++ b/bin/reth/src/commands/import.rs
@@ -29,7 +29,7 @@ use reth_interfaces::{
 use reth_node_core::init::init_genesis;
 use reth_node_ethereum::EthEvmConfig;
 use reth_node_events::node::NodeEvent;
-use reth_primitives::{stage::StageId, ChainSpec, PruneModes, B256, OP_RETH_MAINNET_BELOW_BEDROCK};
+use reth_primitives::{stage::StageId, ChainSpec, PruneModes, B256};
 use reth_provider::{HeaderSyncMode, ProviderFactory, StageCheckpointReader};
 use reth_stages::{
     prelude::*,
@@ -75,7 +75,7 @@ pub struct ImportCommand {
 
     /// Import OP Mainnet chain below Bedrock. Caution! Flag must be set as env var, since the env
     /// var is read by another process too, in order to make below Bedrock import work.
-    #[arg(long, verbatim_doc_comment, env = OP_RETH_MAINNET_BELOW_BEDROCK)]
+    #[arg(long, verbatim_doc_comment, env = "OP_RETH_MAINNET_BELOW_BEDROCK")]
     op_mainnet_below_bedrock: bool,
 
     /// Chunk byte length.

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -100,7 +100,7 @@ pub use transaction::{
     Transaction, TransactionKind, TransactionMeta, TransactionSigned, TransactionSignedEcRecovered,
     TransactionSignedNoHash, TryFromRecoveredTransaction, TxEip1559, TxEip2930, TxEip4844,
     TxHashOrNumber, TxLegacy, TxType, EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID,
-    LEGACY_TX_TYPE_ID, OP_RETH_MAINNET_BELOW_BEDROCK,
+    LEGACY_TX_TYPE_ID,
 };
 
 pub use withdrawal::{Withdrawal, Withdrawals};

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -32,7 +32,7 @@ pub use sidecar::generate_blob_sidecar;
 #[cfg(feature = "c-kzg")]
 pub use sidecar::{BlobTransaction, BlobTransactionSidecar, BlobTransactionValidationError};
 
-pub use signature::{Signature, OP_RETH_MAINNET_BELOW_BEDROCK};
+pub use signature::Signature;
 pub use tx_type::{
     TxType, EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID, LEGACY_TX_TYPE_ID,
 };

--- a/crates/primitives/src/transaction/signature.rs
+++ b/crates/primitives/src/transaction/signature.rs
@@ -85,12 +85,6 @@ impl Signature {
             // EIP-155: v = {0, 1} + CHAIN_ID * 2 + 35
             self.odd_y_parity as u64 + chain_id * 2 + 35
         } else {
-            #[cfg(feature = "optimism")]
-            if std::env::var_os(OP_RETH_MAINNET_BELOW_BEDROCK).as_deref() == Some("true".as_ref()) &&
-                *self == Self::optimism_deposit_tx_signature()
-            {
-                return 0
-            }
             self.odd_y_parity as u64 + 27
         }
     }

--- a/crates/primitives/src/transaction/signature.rs
+++ b/crates/primitives/src/transaction/signature.rs
@@ -14,9 +14,6 @@ const SECP256K1N_HALF: U256 = U256::from_be_bytes([
     0x5D, 0x57, 0x6E, 0x73, 0x57, 0xA4, 0x50, 0x1D, 0xDF, 0xE9, 0x2F, 0x46, 0x68, 0x1B, 0x20, 0xA0,
 ]);
 
-/// Running OP Mainnet migration for chain below bedrock.]
-pub const OP_RETH_MAINNET_BELOW_BEDROCK: &str = "OP_RETH_MAINNET_BELOW_BEDROCK";
-
 /// r, s: Values corresponding to the signature of the
 /// transaction and used to determine the sender of
 /// the transaction; formally Tr and Ts. This is expanded in Appendix F of yellow paper.
@@ -101,10 +98,6 @@ impl Signature {
         if v < 35 {
             // non-EIP-155 legacy scheme, v = 27 for even y-parity, v = 28 for odd y-parity
             if v != 27 && v != 28 {
-                #[cfg(feature = "optimism")]
-                if std::env::var(OP_RETH_MAINNET_BELOW_BEDROCK) == Ok(true.to_string()) && v == 0 {
-                    return Ok((Signature { r, s, odd_y_parity: false }, None))
-                }
                 return Err(RlpError::Custom("invalid Ethereum signature (V is not 27 or 28)"))
             }
             let odd_y_parity = v == 28;


### PR DESCRIPTION
This reverts commit 855988994b809eb40672450357052633caa38da0.

this only concerns pre bedrock blocks afaik, but this fix leaks into regular recovery and is very bad because this always checks for an env var.

This entire 0 signature thing is very horrible, but for the import command this needs to be solved differently, ideally with a standalone recovery function, or at least a global oncelock that is only set in the import command that makes the env var obsolete.

reverting this for now because we need to start over

https://github.com/paradigmxyz/reth/pull/7659