### PR TITLE
feat(op): init genesis alloc

### DIFF
--- a/bin/reth/src/commands/stage/drop.rs
+++ b/bin/reth/src/commands/stage/drop.rs
@@ -133,7 +133,8 @@ impl Command {
                     StageId::Execution.to_string(),
                     Default::default(),
                 )?;
-                insert_genesis_state::<DatabaseEnv>(tx, self.chain.genesis())?;
+                let alloc = &self.chain.genesis().alloc;
+                insert_genesis_state::<DatabaseEnv>(tx, alloc.len(), alloc.iter())?;
             }
             StageEnum::AccountHashing => {
                 tx.clear::<tables::HashedAccounts>()?;
@@ -191,7 +192,7 @@ impl Command {
                     StageId::IndexStorageHistory.to_string(),
                     Default::default(),
                 )?;
-                insert_genesis_history(&provider_rw, &self.chain.genesis)?;
+                insert_genesis_history(&provider_rw, self.chain.genesis.alloc.iter())?;
             }
             StageEnum::TxLookup => {
                 tx.clear::<tables::TransactionHashNumbers>()?;

--- a/crates/primitives/src/account.rs
+++ b/crates/primitives/src/account.rs
@@ -35,13 +35,13 @@ impl Account {
             self.bytecode_hash.map_or(true, |hash| hash == KECCAK_EMPTY)
     }
 
-    /// Converts [GenesisAccount] to [Account] type
-    pub fn from_genesis_account(value: GenesisAccount) -> Self {
+    /// Makes an [Account] from [GenesisAccount] type
+    pub fn from_genesis_account(value: &GenesisAccount) -> Self {
         Account {
             // nonce must exist, so we default to zero when converting a genesis account
             nonce: value.nonce.unwrap_or_default(),
             balance: value.balance,
-            bytecode_hash: value.code.map(keccak256),
+            bytecode_hash: value.code.as_ref().map(keccak256),
         }
     }
 

--- a/crates/trie/src/proof.rs
+++ b/crates/trie/src/proof.rs
@@ -207,9 +207,8 @@ mod tests {
         let genesis = chain_spec.genesis();
         let alloc_accounts = genesis
             .alloc
-            .clone()
-            .into_iter()
-            .map(|(addr, account)| (addr, Some(Account::from_genesis_account(account))));
+            .iter()
+            .map(|(addr, account)| (*addr, Some(Account::from_genesis_account(account))));
         provider.insert_account_for_hashing(alloc_accounts).unwrap();
 
         let alloc_storage = genesis.alloc.clone().into_iter().filter_map(|(addr, account)| {


### PR DESCRIPTION
Decouples init genesis functions from the `Genesis` type. This is convenient for initialising state from dump of bedrock state. Makes it possible to read a chunk from alloc, and pass to these funcs.