### PR TITLE
fix(tree): disable cached trie updates for chains with >1 block

### DIFF
--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1715,7 +1715,7 @@ mod tests {
         );
         let block2_chain_id = tree.state.block_indices.get_blocks_chain_id(&block2.hash()).unwrap();
         let block2_chain = tree.state.chains.get(&block2_chain_id).unwrap();
-        assert!(block2_chain.trie_updates().is_some());
+        assert!(block2_chain.trie_updates().is_none());
 
         assert_eq!(
             tree.make_canonical(block2.hash()).unwrap(),
@@ -1750,7 +1750,7 @@ mod tests {
 
         let block5_chain_id = tree.state.block_indices.get_blocks_chain_id(&block5.hash()).unwrap();
         let block5_chain = tree.state.chains.get(&block5_chain_id).unwrap();
-        assert!(block5_chain.trie_updates().is_some());
+        assert!(block5_chain.trie_updates().is_none());
 
         assert_eq!(
             tree.make_canonical(block5.hash()).unwrap(),

--- a/crates/blockchain-tree/src/chain.rs
+++ b/crates/blockchain-tree/src/chain.rs
@@ -282,7 +282,7 @@ impl AppendableChain {
             canonical_fork,
         };
 
-        let (block_state, trie_updates) = Self::validate_and_execute(
+        let (block_state, _) = Self::validate_and_execute(
             block.clone(),
             parent_block,
             bundle_state_data,
@@ -291,7 +291,7 @@ impl AppendableChain {
             block_validation_kind,
         )?;
         // extend the state.
-        self.chain.append_block(block, block_state, trie_updates);
+        self.chain.append_block(block, block_state);
 
         Ok(())
     }


### PR DESCRIPTION
## Description

Closes https://github.com/paradigmxyz/reth/issues/7559.

Disabled trie updates caching for chains longer than 1 block.