### PR TITLE
ci: stop github from fighting us over labels

### DIFF
--- a/.github/scripts/label_pr.js
+++ b/.github/scripts/label_pr.js
@@ -22,7 +22,7 @@ module.exports = async ({ github, context }) => {
 
         const issueLabels = issue.data.labels.map(label => label.name);
         if (issueLabels.length > 0) {
-            await github.rest.issues.setLabels({
+            await github.rest.issues.addLabels({
                 ...repo,
                 issue_number: prNumber,
                 labels: issueLabels,

--- a/.github/scripts/label_pr.js
+++ b/.github/scripts/label_pr.js
@@ -20,7 +20,7 @@ module.exports = async ({ github, context }) => {
         const issueNumber = re?.groups?.issue_number;
 
         if (!issueNumber) {
-            console.log("No issue reference found in PR description.");
+            console.log('No issue reference found in PR description.');
             return;
         }
 
@@ -40,7 +40,7 @@ module.exports = async ({ github, context }) => {
             });
         }
     } catch (err) {
-        console.error(`Failed to label PR`);
+        console.error('Failed to label PR');
         console.error(err);
     }
 }

--- a/.github/scripts/label_pr.js
+++ b/.github/scripts/label_pr.js
@@ -1,3 +1,12 @@
+// Filter function for labels we do not want on PRs automatically.
+function shouldIncludeLabel (label) {
+    const isStatus = label.startsWith('S-');
+    const isTrackingIssue = label === 'C-tracking-issue';
+    const isPreventStale = label === 'M-prevent-stale';
+
+    return !isStatus && !isTrackingIssue && !isPreventStale;
+}
+
 module.exports = async ({ github, context }) => {
     try {
         const prNumber = context.payload.pull_request.number;
@@ -20,7 +29,9 @@ module.exports = async ({ github, context }) => {
             issue_number: issueNumber,
         });
 
-        const issueLabels = issue.data.labels.map(label => label.name);
+        const issueLabels = issue.data.labels
+            .map(label => label.name)
+            .filter(shouldIncludeLabel);
         if (issueLabels.length > 0) {
             await github.rest.issues.addLabels({
                 ...repo,

--- a/.github/scripts/label_pr.js
+++ b/.github/scripts/label_pr.js
@@ -3,8 +3,9 @@ function shouldIncludeLabel (label) {
     const isStatus = label.startsWith('S-');
     const isTrackingIssue = label === 'C-tracking-issue';
     const isPreventStale = label === 'M-prevent-stale';
+    const isDifficulty = label.startsWith('D-');
 
-    return !isStatus && !isTrackingIssue && !isPreventStale;
+    return !isStatus && !isTrackingIssue && !isPreventStale && !isDifficulty;
 }
 
 module.exports = async ({ github, context }) => {


### PR DESCRIPTION
- Uses `addLabels` instead of `setLabels` (should prevent overriding existing labels)
- Filters out labels we don't care to carry over (e.g. https://github.com/paradigmxyz/reth/labels/M-prevent-stale)
- Minor style things