### PR TITLE
fix: enable --dev for op-reth

### DIFF
--- a/crates/node-core/src/args/utils.rs
+++ b/crates/node-core/src/args/utils.rs
@@ -9,11 +9,13 @@ use std::{
     time::Duration,
 };
 
+use reth_primitives::DEV;
+
 #[cfg(feature = "optimism")]
 use reth_primitives::{BASE_MAINNET, BASE_SEPOLIA, OP_MAINNET, OP_SEPOLIA};
 
 #[cfg(not(feature = "optimism"))]
-use reth_primitives::{DEV, GOERLI, HOLESKY, MAINNET, SEPOLIA};
+use reth_primitives::{GOERLI, HOLESKY, MAINNET, SEPOLIA};
 
 #[cfg(feature = "optimism")]
 /// Chains supported by op-reth. First value should be used as the default.
@@ -77,7 +79,6 @@ pub fn genesis_value_parser(s: &str) -> eyre::Result<Arc<ChainSpec>, eyre::Error
         "sepolia" => SEPOLIA.clone(),
         #[cfg(not(feature = "optimism"))]
         "holesky" => HOLESKY.clone(),
-        #[cfg(not(feature = "optimism"))]
         "dev" => DEV.clone(),
         #[cfg(feature = "optimism")]
         "optimism" => OP_MAINNET.clone(),


### PR DESCRIPTION
if --dev is set, --chain is set to "dev" by default:

https://github.com/paradigmxyz/reth/blob/46197bd2369e183fc74fbbf5ebe65c0c300e09ed/bin/reth/src/commands/node/mod.rs#L44-L44

but we did not have a match arm for dev with optimism feature, we never really tested this

it looks like this is working though