### PR TITLE
chore(debug): allow first fcu through in `EngineApiSkipFcu` interceptor

### DIFF
--- a/crates/node-core/src/engine_skip_fcu.rs
+++ b/crates/node-core/src/engine_skip_fcu.rs
@@ -16,7 +16,11 @@ pub struct EngineApiSkipFcu {
 impl EngineApiSkipFcu {
     /// Creates new [EngineApiSkipFcu] interceptor.
     pub fn new(threshold: usize) -> Self {
-        Self { threshold, skipped: 0 }
+        Self {
+            threshold,
+            // Start with `threshold` so that the first FCU goes through.
+            skipped: threshold,
+        }
     }
 
     /// Intercepts an incoming engine API message, skips FCU or forwards it


### PR DESCRIPTION
## Description

Allow the first FCU to go through in case the node needs to be synced or caught up.