### PR TITLE
chore: bump revm to latest with placeholders for EOF

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2757,7 +2757,7 @@ dependencies = [
  "k256",
  "log",
  "rand 0.8.5",
- "secp256k1",
+ "secp256k1 0.28.2",
  "serde",
  "sha3",
  "zeroize",
@@ -2997,7 +2997,7 @@ dependencies = [
  "reth-tracing",
  "reth-trie",
  "rusqlite",
- "secp256k1",
+ "secp256k1 0.28.2",
  "serde_json",
  "tokio",
 ]
@@ -4883,7 +4883,7 @@ dependencies = [
  "reth-network",
  "reth-network-types",
  "reth-primitives",
- "secp256k1",
+ "secp256k1 0.28.2",
  "tokio",
 ]
 
@@ -5783,7 +5783,7 @@ dependencies = [
  "reth-primitives",
  "reth-provider",
  "reth-tracing",
- "secp256k1",
+ "secp256k1 0.28.2",
  "serde_json",
  "tokio",
  "tokio-stream",
@@ -6613,7 +6613,7 @@ dependencies = [
  "reth-net-nat",
  "reth-network",
  "reth-primitives",
- "secp256k1",
+ "secp256k1 0.28.2",
  "serde",
  "tempfile",
  "toml",
@@ -6692,7 +6692,7 @@ dependencies = [
  "reth-network-types",
  "reth-primitives",
  "reth-tracing",
- "secp256k1",
+ "secp256k1 0.28.2",
  "serde",
  "thiserror",
  "tokio",
@@ -6718,7 +6718,7 @@ dependencies = [
  "reth-network-types",
  "reth-primitives",
  "reth-tracing",
- "secp256k1",
+ "secp256k1 0.28.2",
  "thiserror",
  "tokio",
  "tracing",
@@ -6739,7 +6739,7 @@ dependencies = [
  "reth-primitives",
  "reth-tracing",
  "schnellru",
- "secp256k1",
+ "secp256k1 0.28.2",
  "serde",
  "serde_with",
  "thiserror",
@@ -6804,7 +6804,7 @@ dependencies = [
  "reth-rpc",
  "reth-rpc-layer",
  "reth-tracing",
- "secp256k1",
+ "secp256k1 0.28.2",
  "serde_json",
  "tokio",
  "tokio-stream",
@@ -6832,7 +6832,7 @@ dependencies = [
  "reth-net-common",
  "reth-network-types",
  "reth-primitives",
- "secp256k1",
+ "secp256k1 0.28.2",
  "sha2 0.10.8",
  "sha3",
  "thiserror",
@@ -6877,7 +6877,7 @@ dependencies = [
  "reth-network-types",
  "reth-primitives",
  "reth-tracing",
- "secp256k1",
+ "secp256k1 0.28.2",
  "serde",
  "snap",
  "test-fuzz",
@@ -6904,7 +6904,7 @@ dependencies = [
  "reth-net-common",
  "reth-primitives",
  "reth-tracing",
- "secp256k1",
+ "secp256k1 0.28.2",
  "serde",
  "test-fuzz",
  "thiserror",
@@ -7048,7 +7048,7 @@ dependencies = [
  "reth-network-api",
  "reth-network-types",
  "reth-primitives",
- "secp256k1",
+ "secp256k1 0.28.2",
  "thiserror",
  "tokio",
  "tracing",
@@ -7199,7 +7199,7 @@ dependencies = [
  "reth-tracing",
  "reth-transaction-pool",
  "schnellru",
- "secp256k1",
+ "secp256k1 0.28.2",
  "serde",
  "serde_json",
  "serial_test",
@@ -7235,7 +7235,7 @@ dependencies = [
  "alloy-rlp",
  "enr",
  "rand 0.8.5",
- "secp256k1",
+ "secp256k1 0.28.2",
  "serde_json",
  "serde_with",
  "thiserror",
@@ -7370,7 +7370,7 @@ dependencies = [
  "reth-tracing",
  "reth-transaction-pool",
  "reth-trie",
- "secp256k1",
+ "secp256k1 0.28.2",
  "serde",
  "serde_json",
  "shellexpand",
@@ -7572,7 +7572,7 @@ dependencies = [
  "revm",
  "revm-primitives",
  "roaring",
- "secp256k1",
+ "secp256k1 0.28.2",
  "serde",
  "serde_json",
  "strum",
@@ -7697,7 +7697,7 @@ dependencies = [
  "revm-inspectors",
  "revm-primitives",
  "schnellru",
- "secp256k1",
+ "secp256k1 0.28.2",
  "serde",
  "serde_json",
  "tempfile",
@@ -7963,7 +7963,7 @@ version = "0.2.0-beta.7"
 dependencies = [
  "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "reth-primitives",
- "secp256k1",
+ "secp256k1 0.28.2",
 ]
 
 [[package]]
@@ -8079,9 +8079,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a454c1c650b2b2e23f0c461af09e6c31e1d15e1cbebe905a701c46b8a50afc"
+checksum = "3a2c336f9921588e50871c00024feb51a521eca50ce6d01494bb9c50f837c8ed"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -8095,7 +8095,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/evm-inspectors?rev=a5df8a0#a5df8a041d2c82a58840776be37f935a72803917"
+source = "git+https://github.com/paradigmxyz/evm-inspectors?rev=ff0eca1#ff0eca19e0eee0b3d188d9f179eaf4fd5ace4bea"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
@@ -8112,9 +8112,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d322f2730cd300e99d271a1704a2dfb8973d832428f5aa282aaa40e2473b5eec"
+checksum = "a58182c7454179826f9dad2ca577661963092ce9d0fd0c9d682c1e9215a72e70"
 dependencies = [
  "revm-primitives",
  "serde",
@@ -8122,9 +8122,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "931f692f3f4fc72ec39d5d270f8e9d208c4a6008de7590ee96cf948e3b6d3f8d"
+checksum = "dc8af9aa737eef0509a50d9f3cc1a631557a00ef2e70a3aa8a75d9ee0ed275bb"
 dependencies = [
  "aurora-engine-modexp",
  "c-kzg",
@@ -8132,16 +8132,16 @@ dependencies = [
  "once_cell",
  "revm-primitives",
  "ripemd",
- "secp256k1",
+ "secp256k1 0.29.0",
  "sha2 0.10.8",
  "substrate-bn",
 ]
 
 [[package]]
 name = "revm-primitives"
-version = "3.1.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbbc9640790cebcb731289afb7a7d96d16ad94afeb64b5d0b66443bd151e79d6"
+checksum = "b9bf5d465e64b697da6a111cb19e798b5b2ebb18e5faf2ad48e9e8d47c64add2"
 dependencies = [
  "alloy-primitives",
  "auto_impl",
@@ -8587,8 +8587,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
 dependencies = [
  "rand 0.8.5",
- "secp256k1-sys",
+ "secp256k1-sys 0.9.2",
  "serde",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
+dependencies = [
+ "rand 0.8.5",
+ "secp256k1-sys 0.10.0",
 ]
 
 [[package]]
@@ -8596,6 +8606,15 @@ name = "secp256k1-sys"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1433bd67156263443f14d603720b082dd3121779323fce20cba2aa07b874bc1b"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -280,9 +280,9 @@ reth-node-events = { path = "crates/node/events" }
 reth-testing-utils = { path = "testing/testing-utils" }
 
 # revm
-revm = { version = "8.0.0", features = ["std", "secp256k1"], default-features = false }
-revm-primitives = { version = "3.1.0", features = ["std"], default-features = false }
-revm-inspectors = { git = "https://github.com/paradigmxyz/evm-inspectors", rev = "a5df8a0" }
+revm = { version = "9.0.0", features = ["std", "secp256k1"], default-features = false }
+revm-primitives = { version = "4.0.0", features = ["std"], default-features = false }
+revm-inspectors = { git = "https://github.com/paradigmxyz/evm-inspectors", rev = "ff0eca1" }
 
 # eth
 alloy-chains = "0.1.15"

--- a/crates/primitives/src/account.rs
+++ b/crates/primitives/src/account.rs
@@ -1,11 +1,12 @@
 use crate::{
     keccak256,
-    revm_primitives::{Bytecode as RevmBytecode, BytecodeState, Bytes, JumpMap},
+    revm_primitives::{Bytecode as RevmBytecode, Bytes},
     GenesisAccount, B256, KECCAK_EMPTY, U256,
 };
 use byteorder::{BigEndian, ReadBytesExt};
 use bytes::Buf;
 use reth_codecs::{main_codec, Compact};
+use revm_primitives::JumpTable;
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
 
@@ -80,27 +81,29 @@ impl Compact for Bytecode {
     where
         B: bytes::BufMut + AsMut<[u8]>,
     {
-        buf.put_u32(self.0.bytecode.len() as u32);
-        buf.put_slice(self.0.bytecode.as_ref());
-        let len = match self.0.state() {
-            BytecodeState::Raw => {
+        let bytecode = &self.0.bytecode()[..];
+        buf.put_u32(bytecode.len() as u32);
+        buf.put_slice(bytecode);
+        let len = match &self.0 {
+            RevmBytecode::LegacyRaw(_) => {
                 buf.put_u8(0);
                 1
             }
-            BytecodeState::Checked { len } => {
-                buf.put_u8(1);
-                buf.put_u64(*len as u64);
-                9
-            }
-            BytecodeState::Analysed { len, jump_map } => {
+            // `1` has been removed.
+            RevmBytecode::LegacyAnalyzed(analyzed) => {
                 buf.put_u8(2);
-                buf.put_u64(*len as u64);
-                let map = jump_map.as_slice();
+                buf.put_u64(analyzed.original_len() as u64);
+                let map = analyzed.jump_table().as_slice();
                 buf.put_slice(map);
-                9 + map.len()
+                1 + 8 + map.len()
+            }
+            RevmBytecode::Eof(_) => {
+                // buf.put_u8(3);
+                // TODO(EOF)
+                todo!("EOF")
             }
         };
-        len + self.0.bytecode.len() + 4
+        len + bytecode.len() + 4
     }
 
     fn from_compact(mut buf: &[u8], _: usize) -> (Self, &[u8]) {
@@ -109,17 +112,17 @@ impl Compact for Bytecode {
         let variant = buf.read_u8().expect("could not read bytecode variant");
         let decoded = match variant {
             0 => Bytecode(RevmBytecode::new_raw(bytes)),
-            1 => Bytecode(unsafe {
-                RevmBytecode::new_checked(bytes, buf.read_u64::<BigEndian>().unwrap() as usize)
+            1 => unreachable!("Junk data in database: checked Bytecode variant was removed"),
+            2 => Bytecode(unsafe {
+                RevmBytecode::new_analyzed(
+                    bytes,
+                    buf.read_u64::<BigEndian>().unwrap() as usize,
+                    JumpTable::from_slice(buf),
+                )
             }),
-            2 => Bytecode(RevmBytecode {
-                bytecode: bytes,
-                state: BytecodeState::Analysed {
-                    len: buf.read_u64::<BigEndian>().unwrap() as usize,
-                    jump_map: JumpMap::from_slice(buf),
-                },
-            }),
-            _ => unreachable!("Junk data in database: unknown BytecodeState variant"),
+            // TODO(EOF)
+            3 => todo!("EOF"),
+            _ => unreachable!("Junk data in database: unknown Bytecode variant"),
         };
         (decoded, &[])
     }
@@ -129,6 +132,7 @@ impl Compact for Bytecode {
 mod tests {
     use super::*;
     use crate::hex_literal::hex;
+    use revm_primitives::LegacyAnalyzedBytecode;
 
     #[test]
     fn test_account() {
@@ -174,17 +178,21 @@ mod tests {
     #[test]
     fn test_bytecode() {
         let mut buf = vec![];
-        let mut bytecode = Bytecode(RevmBytecode::new_raw(Bytes::default()));
-        let len = bytecode.clone().to_compact(&mut buf);
+        let bytecode = Bytecode::new_raw(Bytes::default());
+        let len = bytecode.to_compact(&mut buf);
         assert_eq!(len, 5);
 
         let mut buf = vec![];
-        bytecode.0.bytecode = Bytes::from(hex!("ffff").as_ref());
-        let len = bytecode.clone().to_compact(&mut buf);
+        let bytecode = Bytecode::new_raw(Bytes::from(&hex!("ffff")));
+        let len = bytecode.to_compact(&mut buf);
         assert_eq!(len, 7);
 
         let mut buf = vec![];
-        bytecode.0.state = BytecodeState::Analysed { len: 2, jump_map: JumpMap::from_slice(&[0]) };
+        let bytecode = Bytecode(RevmBytecode::LegacyAnalyzed(LegacyAnalyzedBytecode::new(
+            Bytes::from(&hex!("ffff")),
+            2,
+            JumpTable::from_slice(&[0]),
+        )));
         let len = bytecode.clone().to_compact(&mut buf);
         assert_eq!(len, 16);
 

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -116,7 +116,7 @@ pub use alloy_primitives::{
     StorageValue, TxHash, TxIndex, TxKind, TxNumber, B128, B256, B512, B64, U128, U256, U64, U8,
 };
 pub use reth_ethereum_forks::*;
-pub use revm_primitives::{self, JumpMap};
+pub use revm_primitives::{self, JumpTable};
 
 #[doc(hidden)]
 #[deprecated = "use B64 instead"]

--- a/crates/primitives/src/revm/compat.rs
+++ b/crates/primitives/src/revm/compat.rs
@@ -1,8 +1,5 @@
 use crate::{revm_primitives::AccountInfo, Account, Address, TxKind, KECCAK_EMPTY, U256};
-use revm::{
-    interpreter::gas::validate_initial_tx_gas,
-    primitives::{MergeSpec, ShanghaiSpec},
-};
+use revm::{interpreter::gas::validate_initial_tx_gas, primitives::SpecId};
 
 /// Converts a Revm [`AccountInfo`] into a Reth [`Account`].
 ///
@@ -38,9 +35,8 @@ pub fn calculate_intrinsic_gas_after_merge(
     access_list: &[(Address, Vec<U256>)],
     is_shanghai: bool,
 ) -> u64 {
-    if is_shanghai {
-        validate_initial_tx_gas::<ShanghaiSpec>(input, kind.is_create(), access_list)
-    } else {
-        validate_initial_tx_gas::<MergeSpec>(input, kind.is_create(), access_list)
-    }
+    let spec_id = if is_shanghai { SpecId::SHANGHAI } else { SpecId::MERGE };
+    // TODO(EOF)
+    let initcodes = &[];
+    validate_initial_tx_gas(spec_id, input, kind.is_create(), access_list, initcodes)
 }

--- a/crates/primitives/src/revm/env.rs
+++ b/crates/primitives/src/revm/env.rs
@@ -171,6 +171,9 @@ pub fn fill_tx_env_with_beacon_root_contract_call(env: &mut Env, parent_beacon_b
             // enveloped tx size.
             enveloped_tx: Some(Bytes::default()),
         },
+        // TODO(EOF)
+        eof_initcodes: vec![],
+        eof_initcodes_hashed: Default::default(),
     };
 
     // ensure the block gas limit is >= the tx

--- a/crates/revm/src/state_change.rs
+++ b/crates/revm/src/state_change.rs
@@ -87,7 +87,7 @@ where
     }
 
     // get previous env
-    let previous_env = Box::new(evm.env().clone());
+    let previous_env = Box::new(evm.context.env().clone());
 
     // modify env for pre block call
     fill_tx_env_with_beacon_root_contract_call(&mut evm.context.evm.env, parent_beacon_block_root);

--- a/crates/rpc/rpc/src/eth/api/call.rs
+++ b/crates/rpc/rpc/src/eth/api/call.rs
@@ -467,7 +467,7 @@ where
             ExecutionResult::Success { .. } => {
                 // transaction succeeded by manually increasing the gas limit to
                 // highest, which means the caller lacks funds to pay for the tx
-                RpcInvalidTransactionError::BasicOutOfGas(U256::from(req_gas_limit)).into()
+                RpcInvalidTransactionError::BasicOutOfGas(req_gas_limit).into()
             }
             ExecutionResult::Revert { output, .. } => {
                 // reverted again after bumping the limit

--- a/crates/rpc/rpc/src/eth/error.rs
+++ b/crates/rpc/rpc/src/eth/error.rs
@@ -4,7 +4,7 @@ use crate::result::{internal_rpc_err, invalid_params_rpc_err, rpc_err, rpc_error
 use alloy_sol_types::decode_revert_reason;
 use jsonrpsee::types::{error::CALL_EXECUTION_FAILED_CODE, ErrorObject};
 use reth_interfaces::RethError;
-use reth_primitives::{revm_primitives::InvalidHeader, Address, Bytes, U256};
+use reth_primitives::{revm_primitives::InvalidHeader, Address, Bytes};
 use reth_rpc_types::{
     error::EthRpcErrorCode, request::TransactionInputError, BlockError, ToRpcError,
 };
@@ -267,14 +267,14 @@ pub enum RpcInvalidTransactionError {
     /// Thrown when calculating gas usage
     #[error("gas uint64 overflow")]
     GasUintOverflow,
-    /// returned if the transaction is specified to use less gas than required to start the
+    /// Thrown if the transaction is specified to use less gas than required to start the
     /// invocation.
     #[error("intrinsic gas too low")]
     GasTooLow,
-    /// returned if the transaction gas exceeds the limit
+    /// Thrown if the transaction gas exceeds the limit
     #[error("intrinsic gas too high")]
     GasTooHigh,
-    /// thrown if a transaction is not supported in the current network configuration.
+    /// Thrown if a transaction is not supported in the current network configuration.
     #[error("transaction type not supported")]
     TxTypeNotSupported,
     /// Thrown to ensure no one is able to specify a transaction with a tip higher than the total
@@ -291,25 +291,29 @@ pub enum RpcInvalidTransactionError {
     #[error("max fee per gas less than block base fee")]
     FeeCapTooLow,
     /// Thrown if the sender of a transaction is a contract.
-    #[error("sender not an eoa")]
+    #[error("sender is not an EOA")]
     SenderNoEOA,
-    /// Thrown during estimate if caller has insufficient funds to cover the tx.
-    #[error("out of gas: gas required exceeds allowance: {0:?}")]
-    BasicOutOfGas(U256),
-    /// As BasicOutOfGas but thrown when gas exhausts during memory expansion.
-    #[error("out of gas: gas exhausts during memory expansion: {0:?}")]
-    MemoryOutOfGas(U256),
-    /// As BasicOutOfGas but thrown when gas exhausts during precompiled contract execution.
-    #[error("out of gas: gas exhausts during precompiled contract execution: {0:?}")]
-    PrecompileOutOfGas(U256),
-    /// revm's Type cast error, U256 casts down to a u64 with overflow
-    #[error("out of gas: revm's Type cast error, U256 casts down to a u64 with overflow {0:?}")]
-    InvalidOperandOutOfGas(U256),
+    /// Gas limit was exceeded during execution.
+    /// Contains the gas limit.
+    #[error("out of gas: gas required exceeds allowance: {0}")]
+    BasicOutOfGas(u64),
+    /// Gas limit was exceeded during memory expansion.
+    /// Contains the gas limit.
+    #[error("out of gas: gas exhausted during memory expansion: {0}")]
+    MemoryOutOfGas(u64),
+    /// Gas limit was exceeded during precompile execution.
+    /// Contains the gas limit.
+    #[error("out of gas: gas exhausted during precompiled contract execution: {0}")]
+    PrecompileOutOfGas(u64),
+    /// An operand to an opcode was invalid or out of range.
+    /// Contains the gas limit.
+    #[error("out of gas: invalid operand to an opcode; {0}")]
+    InvalidOperandOutOfGas(u64),
     /// Thrown if executing a transaction failed during estimate/call
-    #[error("{0}")]
+    #[error(transparent)]
     Revert(RevertError),
     /// Unspecific EVM halt error.
-    #[error("EVM error {0:?}")]
+    #[error("EVM error: {0:?}")]
     EvmHalt(HaltReason),
     /// Invalid chain id set for the transaction.
     #[error("invalid chain ID")]
@@ -337,8 +341,13 @@ pub enum RpcInvalidTransactionError {
     #[error("blob transaction missing blob hashes")]
     BlobTransactionMissingBlobHashes,
     /// Blob transaction has too many blobs
-    #[error("blob transaction exceeds max blobs per block")]
-    TooManyBlobs,
+    #[error("blob transaction exceeds max blobs per block; got {have}, max {max}")]
+    TooManyBlobs {
+        /// The maximum number of blobs allowed.
+        max: usize,
+        /// The number of blobs in the transaction.
+        have: usize,
+    },
     /// Blob transaction is a create transaction
     #[error("blob transaction is a create transaction")]
     BlobTransactionIsCreate,
@@ -385,7 +394,6 @@ impl RpcInvalidTransactionError {
 
     /// Converts the out of gas error
     pub(crate) fn out_of_gas(reason: OutOfGasError, gas_limit: u64) -> Self {
-        let gas_limit = U256::from(gas_limit);
         match reason {
             OutOfGasError::Basic => RpcInvalidTransactionError::BasicOutOfGas(gas_limit),
             OutOfGasError::Memory => RpcInvalidTransactionError::MemoryOutOfGas(gas_limit),
@@ -462,7 +470,9 @@ impl From<revm::primitives::InvalidTransaction> for RpcInvalidTransactionError {
             InvalidTransaction::BlobVersionNotSupported => {
                 RpcInvalidTransactionError::BlobHashVersionMismatch
             }
-            InvalidTransaction::TooManyBlobs => RpcInvalidTransactionError::TooManyBlobs,
+            InvalidTransaction::TooManyBlobs { max, have } => {
+                RpcInvalidTransactionError::TooManyBlobs { max, have }
+            }
             InvalidTransaction::BlobCreateTransaction => {
                 RpcInvalidTransactionError::BlobTransactionIsCreate
             }
@@ -476,6 +486,11 @@ impl From<revm::primitives::InvalidTransaction> for RpcInvalidTransactionError {
             InvalidTransaction::HaltedDepositPostRegolith => RpcInvalidTransactionError::Optimism(
                 OptimismInvalidTransactionError::HaltedDepositPostRegolith,
             ),
+            // TODO(EOF)
+            InvalidTransaction::EofInitcodesNotSupported => todo!("EOF"),
+            InvalidTransaction::EofInitcodesNumberLimit => todo!("EOF"),
+            InvalidTransaction::EofInitcodesSizeLimit => todo!("EOF"),
+            InvalidTransaction::EofCrateShouldHaveToAddress => todo!("EOF"),
         }
     }
 }

--- a/crates/rpc/rpc/src/eth/revm_utils.rs
+++ b/crates/rpc/rpc/src/eth/revm_utils.rs
@@ -272,6 +272,9 @@ pub(crate) fn create_txn_env(
         max_fee_per_blob_gas,
         #[cfg(feature = "optimism")]
         optimism: OptimismFields { enveloped_tx: Some(Bytes::new()), ..Default::default() },
+        // TODO(EOF)
+        eof_initcodes: Default::default(),
+        eof_initcodes_hashed: Default::default(),
     };
 
     Ok(env)

--- a/examples/exex/rollup/src/db.rs
+++ b/examples/exex/rollup/src/db.rs
@@ -158,7 +158,7 @@ impl Database {
         for (hash, bytecode) in changeset.contracts {
             tx.execute(
                 "INSERT INTO bytecode (hash, data) VALUES (?, ?) ON CONFLICT(hash) DO NOTHING",
-                (hash.to_string(), bytecode.bytes().to_string()),
+                (hash.to_string(), bytecode.bytecode().to_string()),
             )?;
         }
 


### PR DESCRIPTION
Blocked on new revm release

I don't think this requires a breaking db change, but I also don't really know how to convert a checked bytecode from db

cc @rakita 