### PR TITLE
fix(exex): properly check ready state in `poll_ready`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6626,7 +6626,6 @@ name = "reth-exex"
 version = "0.2.0-beta.5"
 dependencies = [
  "eyre",
- "futures",
  "metrics",
  "reth-config",
  "reth-metrics",
@@ -6637,7 +6636,6 @@ dependencies = [
  "reth-tasks",
  "reth-tracing",
  "tokio",
- "tokio-stream",
  "tokio-util",
 ]
 

--- a/crates/exex/Cargo.toml
+++ b/crates/exex/Cargo.toml
@@ -23,9 +23,7 @@ reth-tasks.workspace = true
 reth-tracing.workspace = true
 
 ## async
-futures.workspace = true
 tokio.workspace = true
-tokio-stream.workspace = true
 tokio-util.workspace = true
 
 ## misc

--- a/crates/exex/src/manager.rs
+++ b/crates/exex/src/manager.rs
@@ -424,7 +424,6 @@ impl ExExManagerHandle {
     }
 
     /// Wait until the manager is ready for new notifications.
-    #[allow(clippy::needless_pass_by_ref_mut)]
     pub fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<()> {
         let rx = ready!(self.is_ready.poll(cx));
         self.is_ready.set(make_wait_future(rx));


### PR DESCRIPTION
Ref #7760

Uses `ReusableBoxFuture` in place of `WatchStream`. The encapsulated future returns immediately if the manager is already ready. If it's not ready, we wait for the value to change to `true`. This is handled by `watch::Receiver::wait_for`.

When the future is ready, we replace the future with a fresh version in the `ReusableBoxFuture`

Closes #7761

