### PR TITLE
chore: enable optimism e2e tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -48,7 +48,6 @@ jobs:
         run: |
           cargo nextest run \
             --locked -p reth-node-optimism --features "optimism"
-            -E "kind(test)"
 
   sync:
     name: sync / 100k blocks

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -47,8 +47,7 @@ jobs:
         name: Run tests
         run: |
           cargo nextest run \
-            --locked --features "asm-keccak ${{ matrix.network }}" \
-            --workspace --exclude examples --exclude ef-tests node-ethereum \
+            --locked -p reth-node-optimism --features "optimism"
             -E "kind(test)"
 
   sync:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7009,6 +7009,7 @@ dependencies = [
 name = "reth-node-optimism"
 version = "0.2.0-beta.5"
 dependencies = [
+ "alloy-primitives",
  "async-trait",
  "clap",
  "eyre",

--- a/crates/e2e-test-utils/src/wallet.rs
+++ b/crates/e2e-test-utils/src/wallet.rs
@@ -1,29 +1,42 @@
 use alloy_network::{eip2718::Encodable2718, EthereumSigner, TransactionBuilder};
-use alloy_rpc_types::TransactionRequest;
+use alloy_rpc_types::{TransactionInput, TransactionRequest};
 use alloy_signer_wallet::{coins_bip39::English, LocalWallet, MnemonicBuilder};
 use reth_primitives::{Address, Bytes, U256};
 /// One of the accounts of the genesis allocations.
 pub struct Wallet {
     inner: LocalWallet,
     nonce: u64,
+    chain_id: u64,
 }
 
 impl Wallet {
     /// Creates a new account from one of the secret/pubkeys of the genesis allocations (test.json)
     pub(crate) fn new(phrase: &str) -> Self {
         let inner = MnemonicBuilder::<English>::default().phrase(phrase).build().unwrap();
-        Self { inner, nonce: 0 }
+        Self { inner, chain_id: 1, nonce: 0 }
+    }
+
+    /// Sets chain id
+    pub fn with_chain_id(mut self, chain_id: u64) -> Self {
+        self.chain_id = chain_id;
+        self
     }
 
     /// Creates a static transfer and signs it
     pub async fn transfer_tx(&mut self) -> Bytes {
+        self.tx(None).await
+    }
+
+    /// Creates a transaction with data and signs it
+    pub async fn tx(&mut self, data: Option<Bytes>) -> Bytes {
         let tx = TransactionRequest {
             nonce: Some(self.nonce),
             value: Some(U256::from(100)),
             to: Some(Address::random()),
             gas_price: Some(20e9 as u128),
-            gas: Some(21000),
-            chain_id: Some(1),
+            gas: Some(210000),
+            chain_id: Some(self.chain_id),
+            input: TransactionInput { input: None, data },
             ..Default::default()
         };
         self.nonce += 1;

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -57,6 +57,7 @@ reth-db.workspace = true
 reth-revm = { workspace = true, features = ["test-utils"]}
 reth-e2e-test-utils.workspace = true
 tokio.workspace = true
+alloy-primitives.workspace = true
 
 [features]
 optimism = [

--- a/crates/optimism/node/tests/assets/genesis.json
+++ b/crates/optimism/node/tests/assets/genesis.json
@@ -1,96 +1,100 @@
 {
-    "config": {
-        "chainId": 1,
-        "homesteadBlock": 0,
-        "daoForkSupport": true,
-        "eip150Block": 0,
-        "eip155Block": 0,
-        "eip158Block": 0,
-        "byzantiumBlock": 0,
-        "constantinopleBlock": 0,
-        "petersburgBlock": 0,
-        "istanbulBlock": 0,
-        "muirGlacierBlock": 0,
-        "berlinBlock": 0,
-        "londonBlock": 0,
-        "arrowGlacierBlock": 0,
-        "grayGlacierBlock": 0,
-        "shanghaiTime": 0,
-        "cancunTime": 0,
-        "terminalTotalDifficulty": "0x0",
-        "terminalTotalDifficultyPassed": true
+  "config": {
+    "chainId": 8453,
+    "homesteadBlock": 0,
+    "eip150Block": 0,
+    "eip155Block": 0,
+    "eip158Block": 0,
+    "byzantiumBlock": 0,
+    "constantinopleBlock": 0,
+    "petersburgBlock": 0,
+    "istanbulBlock": 0,
+    "muirGlacierBlock": 0,
+    "berlinBlock": 0,
+    "londonBlock": 0,
+    "arrowGlacierBlock": 0,
+    "grayGlacierBlock": 0,
+    "mergeNetsplitBlock": 0,
+    "bedrockBlock": 0,
+    "regolithTime": 0,
+    "terminalTotalDifficulty": 0,
+    "terminalTotalDifficultyPassed": true,
+    "optimism": {
+        "eip1559Elasticity": 6,
+        "eip1559Denominator": 50
+    }
+},
+"nonce": "0x0",
+"timestamp": "0x0",
+"extraData": "0x00",
+"gasLimit": "0x1c9c380",
+"difficulty": "0x0",
+"mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+"coinbase": "0x0000000000000000000000000000000000000000",
+"alloc": {
+    "0x14dc79964da2c08b23698b3d3cc7ca32193d9955": {
+      "balance": "0xd3c21bcecceda1000000"
     },
-    "nonce": "0x0",
-    "timestamp": "0x0",
-    "extraData": "0x00",
-    "gasLimit": "0x1c9c380",
-    "difficulty": "0x0",
-    "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-    "coinbase": "0x0000000000000000000000000000000000000000",
-    "alloc": {
-        "0x14dc79964da2c08b23698b3d3cc7ca32193d9955": {
-            "balance": "0xd3c21bcecceda1000000"
-        },
-        "0x15d34aaf54267db7d7c367839aaf71a00a2c6a65": {
-            "balance": "0xd3c21bcecceda1000000"
-        },
-        "0x1cbd3b2770909d4e10f157cabc84c7264073c9ec": {
-            "balance": "0xd3c21bcecceda1000000"
-        },
-        "0x23618e81e3f5cdf7f54c3d65f7fbc0abf5b21e8f": {
-            "balance": "0xd3c21bcecceda1000000"
-        },
-        "0x2546bcd3c84621e976d8185a91a922ae77ecec30": {
-            "balance": "0xd3c21bcecceda1000000"
-        },
-        "0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc": {
-            "balance": "0xd3c21bcecceda1000000"
-        },
-        "0x70997970c51812dc3a010c7d01b50e0d17dc79c8": {
-            "balance": "0xd3c21bcecceda1000000"
-        },
-        "0x71be63f3384f5fb98995898a86b02fb2426c5788": {
-            "balance": "0xd3c21bcecceda1000000"
-        },
-        "0x8626f6940e2eb28930efb4cef49b2d1f2c9c1199": {
-            "balance": "0xd3c21bcecceda1000000"
-        },
-        "0x90f79bf6eb2c4f870365e785982e1f101e93b906": {
-            "balance": "0xd3c21bcecceda1000000"
-        },
-        "0x976ea74026e726554db657fa54763abd0c3a0aa9": {
-            "balance": "0xd3c21bcecceda1000000"
-        },
-        "0x9965507d1a55bcc2695c58ba16fb37d819b0a4dc": {
-            "balance": "0xd3c21bcecceda1000000"
-        },
-        "0x9c41de96b2088cdc640c6182dfcf5491dc574a57": {
-            "balance": "0xd3c21bcecceda1000000"
-        },
-        "0xa0ee7a142d267c1f36714e4a8f75612f20a79720": {
-            "balance": "0xd3c21bcecceda1000000"
-        },
-        "0xbcd4042de499d14e55001ccbb24a551f3b954096": {
-            "balance": "0xd3c21bcecceda1000000"
-        },
-        "0xbda5747bfd65f08deb54cb465eb87d40e51b197e": {
-            "balance": "0xd3c21bcecceda1000000"
-        },
-        "0xcd3b766ccdd6ae721141f452c550ca635964ce71": {
-            "balance": "0xd3c21bcecceda1000000"
-        },
-        "0xdd2fd4581271e230360230f9337d5c0430bf44c0": {
-            "balance": "0xd3c21bcecceda1000000"
-        },
-        "0xdf3e18d64bc6a983f673ab319ccae4f1a57c7097": {
-            "balance": "0xd3c21bcecceda1000000"
-        },
-        "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266": {
-            "balance": "0xd3c21bcecceda1000000"
-        },
-        "0xfabb0ac9d68b0b445fb7357272ff202c5651694a": {
-            "balance": "0xd3c21bcecceda1000000"
-        }
+    "0x15d34aaf54267db7d7c367839aaf71a00a2c6a65": {
+      "balance": "0xd3c21bcecceda1000000"
     },
-    "number": "0x0"
+    "0x1cbd3b2770909d4e10f157cabc84c7264073c9ec": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x23618e81e3f5cdf7f54c3d65f7fbc0abf5b21e8f": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x2546bcd3c84621e976d8185a91a922ae77ecec30": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x70997970c51812dc3a010c7d01b50e0d17dc79c8": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x71be63f3384f5fb98995898a86b02fb2426c5788": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x8626f6940e2eb28930efb4cef49b2d1f2c9c1199": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x90f79bf6eb2c4f870365e785982e1f101e93b906": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x976ea74026e726554db657fa54763abd0c3a0aa9": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x9965507d1a55bcc2695c58ba16fb37d819b0a4dc": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x9c41de96b2088cdc640c6182dfcf5491dc574a57": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xa0ee7a142d267c1f36714e4a8f75612f20a79720": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xbcd4042de499d14e55001ccbb24a551f3b954096": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xbda5747bfd65f08deb54cb465eb87d40e51b197e": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xcd3b766ccdd6ae721141f452c550ca635964ce71": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xdd2fd4581271e230360230f9337d5c0430bf44c0": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xdf3e18d64bc6a983f673ab319ccae4f1a57c7097": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xfabb0ac9d68b0b445fb7357272ff202c5651694a": {
+      "balance": "0xd3c21bcecceda1000000"
+    }
+  },
+  "number": "0x0"
 }

--- a/crates/optimism/node/tests/e2e/p2p.rs
+++ b/crates/optimism/node/tests/e2e/p2p.rs
@@ -8,7 +8,7 @@ use reth::{
 };
 use reth_e2e_test_utils::{node::NodeHelper, wallet::Wallet};
 use reth_node_optimism::node::OptimismNode;
-use reth_primitives::{ChainSpecBuilder, Genesis, BASE_MAINNET, hex, Bytes};
+use reth_primitives::{hex, Bytes, ChainSpecBuilder, Genesis, BASE_MAINNET};
 
 #[tokio::test]
 async fn can_sync() -> eyre::Result<()> {

--- a/crates/optimism/node/tests/e2e/p2p.rs
+++ b/crates/optimism/node/tests/e2e/p2p.rs
@@ -8,7 +8,7 @@ use reth::{
 };
 use reth_e2e_test_utils::{node::NodeHelper, wallet::Wallet};
 use reth_node_optimism::node::OptimismNode;
-use reth_primitives::{ChainSpecBuilder, Genesis, MAINNET};
+use reth_primitives::{ChainSpecBuilder, Genesis, BASE_MAINNET, hex, Bytes};
 
 #[tokio::test]
 async fn can_sync() -> eyre::Result<()> {
@@ -20,11 +20,12 @@ async fn can_sync() -> eyre::Result<()> {
     let genesis: Genesis = serde_json::from_str(include_str!("../assets/genesis.json")).unwrap();
     let chain_spec = Arc::new(
         ChainSpecBuilder::default()
-            .chain(MAINNET.chain)
+            .chain(BASE_MAINNET.chain)
             .genesis(genesis)
-            .cancun_activated()
+            .ecotone_activated()
             .build(),
     );
+    let mut wallet = Wallet::default().with_chain_id(chain_spec.chain.into());
 
     let network_config = NetworkArgs {
         discovery: DiscoveryArgs { disable_discovery: true, ..DiscoveryArgs::default() },
@@ -53,9 +54,6 @@ async fn can_sync() -> eyre::Result<()> {
 
     let mut second_node = NodeHelper::new(node).await?;
 
-    let mut wallet = Wallet::default();
-    let raw_tx = wallet.transfer_tx().await;
-
     // Make them peer
     first_node.network.add_peer(second_node.network.record()).await;
     second_node.network.add_peer(first_node.network.record()).await;
@@ -64,7 +62,11 @@ async fn can_sync() -> eyre::Result<()> {
     first_node.network.expect_session().await;
     second_node.network.expect_session().await;
 
+    // Taken from optimism tests
+    let l1_block_info = Bytes::from_static(&hex!("7ef9015aa044bae9d41b8380d781187b426c6fe43df5fb2fb57bd4466ef6a701e1f01e015694deaddeaddeaddeaddeaddeaddeaddeaddead000194420000000000000000000000000000000000001580808408f0d18001b90104015d8eb900000000000000000000000000000000000000000000000000000000008057650000000000000000000000000000000000000000000000000000000063d96d10000000000000000000000000000000000000000000000000000000000009f35273d89754a1e0387b89520d989d3be9c37c1f32495a88faf1ea05c61121ab0d1900000000000000000000000000000000000000000000000000000000000000010000000000000000000000002d679b567db6187c0c8323fa982cfb88b74dbcc7000000000000000000000000000000000000000000000000000000000000083400000000000000000000000000000000000000000000000000000000000f4240"));
+
     // Make the first node advance
+    let raw_tx = wallet.tx(Some(l1_block_info)).await;
     let (block_hash, tx_hash) =
         first_node.advance(raw_tx.clone(), optimism_payload_attributes).await?;
 


### PR DESCRIPTION
There were some op specific details missing to have the e2e sync test to run properly:

* L1BlockInfo as first tx of the block.
* ecotone_activated
* Wallet with chain id
* github yml fix