### PR TITLE
bench: fix `reth-stages` criterion benchmarks

### DIFF
--- a/crates/stages/Cargo.toml
+++ b/crates/stages/Cargo.toml
@@ -59,7 +59,7 @@ paste.workspace = true
 tempfile.workspace = true
 
 # Stage benchmarks
-criterion = { workspace = true, features = ["async_futures"] }
+criterion = { workspace = true, features = ["async_tokio"] }
 
 # io
 serde_json.workspace = true

--- a/crates/stages/benches/criterion.rs
+++ b/crates/stages/benches/criterion.rs
@@ -70,20 +70,17 @@ fn senders(c: &mut Criterion, runtime: &Runtime) {
 
     let db = setup::txs_testdata(DEFAULT_NUM_BLOCKS);
 
-    for batch in [1000usize, 10_000, 100_000, 250_000] {
-        let stage = SenderRecoveryStage { commit_threshold: DEFAULT_NUM_BLOCKS };
-        let label = format!("SendersRecovery-batch-{batch}");
+    let stage = SenderRecoveryStage { commit_threshold: DEFAULT_NUM_BLOCKS };
 
-        measure_stage(
-            runtime,
-            &mut group,
-            &db,
-            setup::stage_unwind,
-            stage,
-            0..=DEFAULT_NUM_BLOCKS,
-            label,
-        );
-    }
+    measure_stage(
+        runtime,
+        &mut group,
+        &db,
+        setup::stage_unwind,
+        stage,
+        0..=DEFAULT_NUM_BLOCKS,
+        "SendersRecovery".to_string(),
+    );
 }
 
 fn transaction_lookup(c: &mut Criterion, runtime: &Runtime) {


### PR DESCRIPTION
These benchmarks are entirely broken:

- One stage uses `tokio::spawn` which is not possible in this benchmark (fixed in this PR)
- The testdata is always regenerated (couldn't figure out why)
- The merkle benchmark fails because there is an invalid state root (didn't figure out why)
- We re-ran sender recovery 4 times with different batch sizes, but the batch size was not used (fixed in this PR)

Ref https://github.com/paradigmxyz/reth/issues/7239#issuecomment-2068150810