### PR TITLE
feat: enable OP hardforks in DEV chainspec

### DIFF
--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -243,6 +243,12 @@ pub static DEV: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
             ),
             (Hardfork::Shanghai, ForkCondition::Timestamp(0)),
             (Hardfork::Cancun, ForkCondition::Timestamp(0)),
+            #[cfg(feature = "optimism")]
+            (Hardfork::Regolith, ForkCondition::Timestamp(0)),
+            #[cfg(feature = "optimism")]
+            (Hardfork::Bedrock, ForkCondition::Block(0)),
+            #[cfg(feature = "optimism")]
+            (Hardfork::Ecotone, ForkCondition::Timestamp(0)),
         ]),
         base_fee_params: BaseFeeParamsKind::Constant(BaseFeeParams::ethereum()),
         deposit_contract: None, // TODO: do we even have?


### PR DESCRIPTION
Followup of #7755, will prevent errors like: `TransportError(ErrorResp(ErrorPayload { code: -32603, message: "could not get L1 block info from L2 block: \"Optimism hardforks are not active\"", data: None }))`

Besides enabling the hardforks it also sets L1 block info to empty for `DEV` chain (doesn't rely on an L1), this will prevent `L1BlockInfoError`. The way this is done is by removing the Option in `OpL1BlockInfo.l1_block_info`, so that it always have a default (empty) value which is overwritten in case there's actual L1 block info. 