### PR TITLE
chore: remove consensus setup from node-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6920,7 +6920,6 @@ dependencies = [
  "procfs",
  "proptest",
  "rand 0.8.5",
- "reth-auto-seal-consensus",
  "reth-beacon-consensus",
  "reth-config",
  "reth-consensus-common",

--- a/crates/node-builder/src/builder.rs
+++ b/crates/node-builder/src/builder.rs
@@ -42,7 +42,7 @@ use reth_node_core::{
     exit::NodeExitFuture,
     init::init_genesis,
     node_config::NodeConfig,
-    primitives::{kzg::KzgSettings, Head, TxHash},
+    primitives::{kzg::KzgSettings, Head},
     utils::write_peers_to_file,
 };
 use reth_node_events::{cl::ConsensusLayerHealthEvents, node};
@@ -58,10 +58,7 @@ use reth_tasks::TaskExecutor;
 use reth_tracing::tracing::{debug, error, info};
 use reth_transaction_pool::{PoolConfig, TransactionPool};
 use std::{cmp::max, str::FromStr, sync::Arc, thread::available_parallelism};
-use tokio::sync::{
-    mpsc::{unbounded_channel, Receiver},
-    oneshot,
-};
+use tokio::sync::{mpsc::unbounded_channel, oneshot};
 
 /// The builtin provider type of the reth node.
 // Note: we need to hardcode this because custom components might depend on it in associated types.
@@ -741,8 +738,6 @@ where
                 info!(target: "reth::cli", "No mining mode specified, defaulting to ReadyTransaction");
                 MiningMode::instant(1, pending_transactions_listener)
             };
-
-            let mining_mode = config.mining_mode(transaction_pool.pending_transactions_listener());
 
             let (_, client, mut task) = reth_auto_seal_consensus::AutoSealBuilder::new(
                 Arc::clone(&config.chain),

--- a/crates/node-core/Cargo.toml
+++ b/crates/node-core/Cargo.toml
@@ -33,7 +33,6 @@ reth-evm.workspace = true
 reth-engine-primitives.workspace = true
 reth-tasks.workspace = true
 reth-consensus-common.workspace = true
-reth-auto-seal-consensus.workspace = true
 reth-beacon-consensus.workspace = true
 
 # ethereum
@@ -98,7 +97,6 @@ optimism = [
     "reth-rpc-engine-api/optimism",
     "reth-provider/optimism",
     "reth-rpc-types-compat/optimism",
-    "reth-auto-seal-consensus/optimism",
     "reth-consensus-common/optimism",
     "reth-beacon-consensus/optimism",
 ]

--- a/crates/node-core/src/init.rs
+++ b/crates/node-core/src/init.rs
@@ -235,10 +235,7 @@ pub fn insert_genesis_header<DB: Database>(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use super::*;
-
     use reth_db::{
         cursor::DbCursorRO,
         models::{storage_sharded_key::StorageShardedKey, ShardedKey},
@@ -246,8 +243,8 @@ mod tests {
         DatabaseEnv,
     };
     use reth_primitives::{
-        Address, Chain, ChainSpec, ForkTimestamps, Genesis, GenesisAccount, IntegerList, GOERLI,
-        GOERLI_GENESIS_HASH, MAINNET, MAINNET_GENESIS_HASH, SEPOLIA, SEPOLIA_GENESIS_HASH,
+        Chain, ForkTimestamps, Genesis, IntegerList, GOERLI, GOERLI_GENESIS_HASH, MAINNET,
+        MAINNET_GENESIS_HASH, SEPOLIA, SEPOLIA_GENESIS_HASH,
     };
     use reth_provider::test_utils::create_test_provider_factory_with_chain_spec;
 

--- a/crates/node-core/src/node_config.rs
+++ b/crates/node-core/src/node_config.rs
@@ -12,15 +12,13 @@ use crate::{
 use discv5::ListenConfig;
 use metrics_exporter_prometheus::PrometheusHandle;
 use once_cell::sync::Lazy;
-use reth_auto_seal_consensus::{AutoSealConsensus, MiningMode};
-use reth_beacon_consensus::BeaconConsensus;
 use reth_config::{config::PruneConfig, Config};
 use reth_db::{database::Database, database_metrics::DatabaseMetrics};
-use reth_interfaces::{consensus::Consensus, p2p::headers::client::HeadersClient, RethResult};
+use reth_interfaces::{p2p::headers::client::HeadersClient, RethResult};
 use reth_network::{NetworkBuilder, NetworkConfig, NetworkManager};
 use reth_primitives::{
     constants::eip4844::MAINNET_KZG_TRUSTED_SETUP, kzg::KzgSettings, stage::StageId,
-    BlockHashOrNumber, BlockNumber, ChainSpec, Head, SealedHeader, TxHash, B256, MAINNET,
+    BlockHashOrNumber, BlockNumber, ChainSpec, Head, SealedHeader, B256, MAINNET,
 };
 use reth_provider::{
     providers::StaticFileProvider, BlockHashReader, BlockNumReader, HeaderProvider,
@@ -29,7 +27,6 @@ use reth_provider::{
 use reth_tasks::TaskExecutor;
 use secp256k1::SecretKey;
 use std::{net::SocketAddr, path::PathBuf, sync::Arc};
-use tokio::sync::mpsc::Receiver;
 use tracing::*;
 
 /// The default prometheus recorder handle. We use a global static to ensure that it is only
@@ -291,18 +288,6 @@ impl NodeConfig {
         Ok(max_block)
     }
 
-    /// Get the [MiningMode] from the given dev args
-    pub fn mining_mode(&self, pending_transactions_listener: Receiver<TxHash>) -> MiningMode {
-        if let Some(interval) = self.dev.block_time {
-            MiningMode::interval(interval)
-        } else if let Some(max_transactions) = self.dev.block_max_transactions {
-            MiningMode::instant(max_transactions, pending_transactions_listener)
-        } else {
-            info!(target: "reth::cli", "No mining mode specified, defaulting to ReadyTransaction");
-            MiningMode::instant(1, pending_transactions_listener)
-        }
-    }
-
     /// Create the [NetworkConfig] for the node
     pub fn network_config<C>(
         &self,
@@ -335,18 +320,6 @@ impl NodeConfig {
         let network_config = self.network_config(config, client, executor, head, data_dir)?;
         let builder = NetworkManager::builder(network_config).await?;
         Ok(builder)
-    }
-
-    /// Returns the [Consensus] instance to use.
-    ///
-    /// By default this will be a [BeaconConsensus] instance, but if the `--dev` flag is set, it
-    /// will be an [AutoSealConsensus] instance.
-    pub fn consensus(&self) -> Arc<dyn Consensus> {
-        if self.dev.dev {
-            Arc::new(AutoSealConsensus::new(Arc::clone(&self.chain)))
-        } else {
-            Arc::new(BeaconConsensus::new(Arc::clone(&self.chain)))
-        }
     }
 
     /// Loads 'MAINNET_KZG_TRUSTED_SETUP'


### PR DESCRIPTION
moves the consensus setup from node-core to nodebuilder

this improves dependency graph because autoseal crate imports a lot of stuff.


this makes the node-builder launch fn slightly more verbose, but --dev mode will be separate entirely soon
