### PR TITLE
feat(stages): send `CanonStateNotification::Revert` on unwind

### DIFF
--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -436,10 +436,9 @@ impl<EF: ExecutorFactory, DB: Database> Stage<DB> for ExecutionStage<EF> {
 
             // NOTE: We can ignore the error here, since an error means that the channel is closed,
             // which means the manager has died, which then in turn means the node is shutting down.
-            let _ = self.exex_manager_handle.send(CanonStateNotification::Reorg {
-                old: Arc::new(chain),
-                new: Arc::new(Chain::default()),
-            });
+            let _ = self
+                .exex_manager_handle
+                .send(CanonStateNotification::Revert { old: Arc::new(chain) });
         }
 
         // Unwind all receipts for transactions in the block range

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -433,6 +433,9 @@ pub async fn maintain_transaction_pool<Client, P, St, Tasks>(
                 // keep track of mined blob transactions
                 blob_store_tracker.add_new_chain_blocks(&blocks);
             }
+            CanonStateNotification::Revert { .. } => {
+                // we don't need to do anything here, the pool will be updated on the next commit
+            }
         }
     }
 }

--- a/examples/exex/minimal/src/main.rs
+++ b/examples/exex/minimal/src/main.rs
@@ -22,13 +22,13 @@ async fn exex<Node: FullNodeComponents>(mut ctx: ExExContext<Node>) -> eyre::Res
     while let Some(notification) = ctx.notifications.recv().await {
         match &notification {
             CanonStateNotification::Commit { new } => {
-                println!("Received commit: {:?}", new.first().number..=new.tip().number);
+                println!("Received commit: {:?}", new.range());
             }
             CanonStateNotification::Reorg { old, new } => {
                 println!(
                     "Received reorg: {:?} -> {:?}",
-                    old.first().number..=old.tip().number,
-                    new.first().number..=new.tip().number
+                    old.range(),
+                    (!new.is_empty()).then(|| new.range())
                 );
             }
         };


### PR DESCRIPTION
Fixes the panic in ExEx during Execution stage unwind
```console
2024-04-22T13:31:33.372080Z  INFO Unwinding{stage=MerkleUnwind}: Stage unwound stage=MerkleUnwind unwind_to=1380390 progress=1380390 done=true
thread 'tokio-runtime-worker' panicked at examples/exex/minimal/src/main.rs:31:25:
Chain has at least one block for first
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
2024-04-22T13:31:33.989316Z ERROR exex{id="Minimal"}: Critical task `exex` panicked: `Chain has at least one block for first`
2024-04-22T13:31:33.989716Z ERROR shutting down due to error
```

by adding a new `CanonStateNotification::Revert` variant and handling it separately in the ExEx