### PR TITLE
chore(bin/stage): add explicit doc of the use of to-block and hashing stage

### DIFF
--- a/bin/reth/src/commands/stage/unwind.rs
+++ b/bin/reth/src/commands/stage/unwind.rs
@@ -265,6 +265,9 @@ impl Subcommands {
             },
             Subcommands::NumBlocks { amount } => last.saturating_sub(*amount),
         } + 1;
+        if target > last {
+            eyre::bail!("Target block number is higher than the latest block number")
+        }
         Ok(target..=last)
     }
 }

--- a/bin/reth/src/commands/stage/unwind.rs
+++ b/bin/reth/src/commands/stage/unwind.rs
@@ -236,10 +236,12 @@ impl Command {
 /// `reth stage unwind` subcommand
 #[derive(Subcommand, Debug, Eq, PartialEq)]
 enum Subcommands {
-    /// Unwinds the database until the given block number (range is inclusive).
+    /// Unwinds the database from the latest block, until the given block number or hash has been
+    /// reached, that block is not included.
     #[command(name = "to-block")]
     ToBlock { target: BlockHashOrNumber },
-    /// Unwinds the given number of blocks from the database.
+    /// Unwinds the database from the latest block, until the given number of blocks have been
+    /// reached.
     #[command(name = "num-blocks")]
     NumBlocks { amount: u64 },
 }

--- a/crates/node-core/src/args/stage_args.rs
+++ b/crates/node-core/src/args/stage_args.rs
@@ -30,7 +30,7 @@ pub enum StageEnum {
     ///
     /// Manages operations related to hashing storage data.
     StorageHashing,
-    /// The hashing stage within the pipeline, including `account-hashing` and `storage-hashing`.
+    /// The account and storage hashing stages within the pipeline.
     ///
     /// Covers general data hashing operations.
     Hashing,

--- a/crates/node-core/src/args/stage_args.rs
+++ b/crates/node-core/src/args/stage_args.rs
@@ -30,11 +30,11 @@ pub enum StageEnum {
     ///
     /// Manages operations related to hashing storage data.
     StorageHashing,
-    /// The hashing stage within the pipeline.
+    /// The hashing stage within the pipeline, including `account-hashing` and `storage-hashing`.
     ///
     /// Covers general data hashing operations.
     Hashing,
-    /// The Merkle stage within the pipeline.
+    /// The merkle stage within the pipeline.
     ///
     /// Handles Merkle tree-related computations and data processing.
     Merkle,


### PR DESCRIPTION
1. Add explicit doc of the usage of the `to-block/num-blocks` for `reth stage unwind` command. 
2. Check target block in unwind stage
3. Add the relationship of the xxx-hashing and hashing stage.