### PR TITLE
fix(stages): send revert chain notification instead of a reorg on unwind

### DIFF
--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -248,7 +248,7 @@ impl<EF: ExecutorFactory> ExecutionStage<EF> {
         let state = executor.take_output_state();
         let write_preparation_duration = time.elapsed();
 
-        // Check if we should send a [`CanonStateNotification`] to execution extensions.
+        // Check if we should send a [`ExExNotification`] to execution extensions.
         //
         // Note: Since we only write to `blocks` if there are any ExEx's we don't need to perform
         // the `has_exexs` check here as well
@@ -427,18 +427,17 @@ impl<EF: ExecutorFactory, DB: Database> Stage<DB> for ExecutionStage<EF> {
         // This also updates `PlainStorageState` and `PlainAccountState`.
         let bundle_state_with_receipts = provider.unwind_or_peek_state::<true>(range.clone())?;
 
-        // Construct a `CanonStateNotification` if we have ExEx's installed.
+        // Construct a `ExExNotification` if we have ExEx's installed.
         if self.exex_manager_handle.has_exexs() {
-            // Get the blocks for the unwound range. This is needed for `CanonStateNotification`.
+            // Get the blocks for the unwound range. This is needed for `ExExNotification`.
             let blocks = provider.get_take_block_range::<false>(range.clone())?;
             let chain = Chain::new(blocks, bundle_state_with_receipts, None);
 
             // NOTE: We can ignore the error here, since an error means that the channel is closed,
             // which means the manager has died, which then in turn means the node is shutting down.
-            let _ = self.exex_manager_handle.send(ExExNotification::ChainReorged {
-                old: Arc::new(chain),
-                new: Arc::new(Chain::default()),
-            });
+            let _ = self
+                .exex_manager_handle
+                .send(ExExNotification::ChainReverted { old: Arc::new(chain) });
         }
 
         // Unwind all receipts for transactions in the block range


### PR DESCRIPTION
This PR uses a new `ExExNotification::ChainReverted` variant on Execution unwind instead of the `ExExNotification::ChainReorged` variant with an empty `new` chain.