### PR TITLE
feat: support short issue links in label workflow

### DIFF
--- a/.github/scripts/label_pr.js
+++ b/.github/scripts/label_pr.js
@@ -8,6 +8,20 @@ function shouldIncludeLabel (label) {
     return !isStatus && !isTrackingIssue && !isPreventStale && !isDifficulty;
 }
 
+// Get the issue number from an issue link in the forms `<keyword> <issue url>` or `<keyword> #<issue number>`.
+function getIssueLink (repoUrl, body) {
+    const urlPattern = new RegExp(`(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved) ${repoUrl}/issues/(?<issue_number>\\d+)`, 'i')
+    const issuePattern = new RegExp(`(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved) \#(?<issue_number>\\d+)`, 'i')
+
+    const urlRe = body.match(urlPattern);
+    const issueRe = body.match(issuePattern);
+    if (urlRe?.groups?.issue_number) {
+        return urlRe.groups.issue_number
+    } else {
+        return issueRe?.groups?.issue_number
+    }
+}
+
 module.exports = async ({ github, context }) => {
     try {
         const prNumber = context.payload.pull_request.number;
@@ -15,11 +29,7 @@ module.exports = async ({ github, context }) => {
         const repo = context.repo;
 
         const repoUrl = context.payload.repository.html_url;
-        const pattern = new RegExp(`(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved) ${repoUrl}/issues/(?<issue_number>\\d+)`, 'i')
-
-        const re = prBody.match(pattern);
-        const issueNumber = re?.groups?.issue_number;
-
+        const issueNumber = getIssueLink(repoUrl, prBody);
         if (!issueNumber) {
             console.log('No issue reference found in PR description.');
             return;


### PR DESCRIPTION
The current workflow only supports `<keyword> <url>`, this PR adds support for `<keyword> #<issue number>` (e.g. `closes #12345`)