### PR TITLE
docs: add warning regarding `increment_block` necessity on `write_to_storage`

### DIFF
--- a/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
+++ b/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
@@ -316,7 +316,11 @@ impl BundleStateWithReceipts {
         let mut bodies_cursor = tx.cursor_read::<tables::BlockBodyIndices>()?;
         let mut receipts_cursor = tx.cursor_write::<tables::Receipts>()?;
 
-        for (idx, receipts) in self.receipts.into_iter().enumerate() {
+        // ATTENTION: Any potential future refactor or change to how this loop works should keep in
+        // mind that the static file producer must always call `increment_block` even if the block
+        // has no receipts.
+        let blocks = self.receipts.into_iter().enumerate();
+        for (idx, receipts) in blocks {
             let block_number = self.first_block + idx as u64;
             let first_tx_index = bodies_cursor
                 .seek_exact(block_number)?

--- a/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
+++ b/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
@@ -318,7 +318,8 @@ impl BundleStateWithReceipts {
 
         // ATTENTION: Any potential future refactor or change to how this loop works should keep in
         // mind that the static file producer must always call `increment_block` even if the block
-        // has no receipts.
+        // has no receipts. Keeping track of the exact block range of the segment is needed for
+        // consistency, querying and file range segmentation.
         let blocks = self.receipts.into_iter().enumerate();
         for (idx, receipts) in blocks {
             let block_number = self.first_block + idx as u64;


### PR DESCRIPTION
I was re-reading the code and thought that adding this warning might avoid future troubles if it were to be changed.