### PR TITLE
refactor: replace `to_primitive_transaction_kind` by `From` impl

### DIFF
--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -868,6 +868,15 @@ impl TransactionKind {
     }
 }
 
+impl From<reth_rpc_types::TransactionKind> for TransactionKind {
+    fn from(kind: reth_rpc_types::TransactionKind) -> Self {
+        match kind {
+            reth_rpc_types::TransactionKind::Call(to) => Self::Call(to),
+            reth_rpc_types::TransactionKind::Create => Self::Create,
+        }
+    }
+}
+
 impl Compact for TransactionKind {
     fn to_compact<B>(self, buf: &mut B) -> usize
     where

--- a/crates/rpc/rpc-types-compat/src/transaction/typed.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction/typed.rs
@@ -16,7 +16,7 @@ pub fn to_primitive_transaction(
             nonce: tx.nonce,
             gas_price: tx.gas_price.to(),
             gas_limit: tx.gas_limit.try_into().ok()?,
-            to: to_primitive_transaction_kind(tx.kind),
+            to: tx.kind.into(),
             value: tx.value,
             input: tx.input,
         }),
@@ -25,7 +25,7 @@ pub fn to_primitive_transaction(
             nonce: tx.nonce,
             gas_price: tx.gas_price.to(),
             gas_limit: tx.gas_limit.try_into().ok()?,
-            to: to_primitive_transaction_kind(tx.kind),
+            to: tx.kind.into(),
             value: tx.value,
             input: tx.input,
             access_list: tx.access_list,
@@ -35,7 +35,7 @@ pub fn to_primitive_transaction(
             nonce: tx.nonce,
             max_fee_per_gas: tx.max_fee_per_gas.to(),
             gas_limit: tx.gas_limit.try_into().ok()?,
-            to: to_primitive_transaction_kind(tx.kind),
+            to: tx.kind.into(),
             value: tx.value,
             input: tx.input,
             access_list: tx.access_list,
@@ -47,7 +47,7 @@ pub fn to_primitive_transaction(
             gas_limit: tx.gas_limit.to(),
             max_fee_per_gas: tx.max_fee_per_gas.to(),
             max_priority_fee_per_gas: tx.max_priority_fee_per_gas.to(),
-            to: to_primitive_transaction_kind(tx.kind),
+            to: tx.kind.into(),
             value: tx.value,
             access_list: tx.access_list,
             blob_versioned_hashes: tx.blob_versioned_hashes,
@@ -55,14 +55,4 @@ pub fn to_primitive_transaction(
             input: tx.input,
         }),
     })
-}
-
-/// Transforms a [reth_rpc_types::TransactionKind] into a [reth_primitives::TransactionKind]
-pub fn to_primitive_transaction_kind(
-    kind: reth_rpc_types::TransactionKind,
-) -> reth_primitives::TransactionKind {
-    match kind {
-        reth_rpc_types::TransactionKind::Call(to) => reth_primitives::TransactionKind::Call(to),
-        reth_rpc_types::TransactionKind::Create => reth_primitives::TransactionKind::Create,
-    }
 }


### PR DESCRIPTION
The function `to_primitive_transaction_kind` of `reth-rpc-types-compat` crate is replaced by `From<reth_rpc_types::TransactionKind>` for `TransactionKind` implementation.