### PR TITLE
refactor: remove unused map_err

### DIFF
--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -111,14 +111,7 @@ where
                                 tx_hash: Some(tx_hash),
                                 tx_index: Some(index),
                             }),
-                        )
-                        .map_err(|err| {
-                            results.push(TraceResult::Error {
-                                error: err.to_string(),
-                                tx_hash: Some(tx_hash),
-                            });
-                            err
-                        })?;
+                        )?;
 
                     results.push(TraceResult::Success { result, tx_hash: Some(tx_hash) });
                     if transactions.peek().is_some() {

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -101,17 +101,16 @@ where
                         env: Env::boxed(cfg.cfg_env.clone(), block_env.clone(), tx),
                         handler_cfg: cfg.handler_cfg,
                     };
-                    let (result, state_changes) = this
-                        .trace_transaction(
-                            opts.clone(),
-                            env,
-                            &mut db,
-                            Some(TransactionContext {
-                                block_hash,
-                                tx_hash: Some(tx_hash),
-                                tx_index: Some(index),
-                            }),
-                        )?;
+                    let (result, state_changes) = this.trace_transaction(
+                        opts.clone(),
+                        env,
+                        &mut db,
+                        Some(TransactionContext {
+                            block_hash,
+                            tx_hash: Some(tx_hash),
+                            tx_index: Some(index),
+                        }),
+                    )?;
 
                     results.push(TraceResult::Success { result, tx_hash: Some(tx_hash) });
                     if transactions.peek().is_some() {


### PR DESCRIPTION
Removes an unused `map_err` from `trace_block_with` in `DebugApi`.