### PR TITLE
chore: rename BlockChain to Blockchain

### DIFF
--- a/crates/blockchain-tree/src/block_indices.rs
+++ b/crates/blockchain-tree/src/block_indices.rs
@@ -1,6 +1,6 @@
 //! Implementation of [`BlockIndices`] related to [`super::BlockchainTree`]
 
-use super::state::BlockChainId;
+use super::state::BlockchainId;
 use crate::canonical_chain::CanonicalChain;
 use linked_hash_set::LinkedHashSet;
 use reth_primitives::{BlockHash, BlockNumHash, BlockNumber, SealedBlockWithSenders};
@@ -39,7 +39,7 @@ pub struct BlockIndices {
     /// hashes.
     block_number_to_block_hashes: BTreeMap<BlockNumber, HashSet<BlockHash>>,
     /// Block hashes and side chain they belong
-    blocks_to_chain: HashMap<BlockHash, BlockChainId>,
+    blocks_to_chain: HashMap<BlockHash, BlockchainId>,
 }
 
 impl BlockIndices {
@@ -71,7 +71,7 @@ impl BlockIndices {
     }
 
     /// Return block to chain id
-    pub fn blocks_to_chain(&self) -> &HashMap<BlockHash, BlockChainId> {
+    pub fn blocks_to_chain(&self) -> &HashMap<BlockHash, BlockchainId> {
         &self.blocks_to_chain
     }
 
@@ -119,14 +119,14 @@ impl BlockIndices {
         &mut self,
         block_number: BlockNumber,
         block_hash: BlockHash,
-        chain_id: BlockChainId,
+        chain_id: BlockchainId,
     ) {
         self.block_number_to_block_hashes.entry(block_number).or_default().insert(block_hash);
         self.blocks_to_chain.insert(block_hash, chain_id);
     }
 
     /// Insert block to chain and fork child indices of the new chain
-    pub(crate) fn insert_chain(&mut self, chain_id: BlockChainId, chain: &Chain) {
+    pub(crate) fn insert_chain(&mut self, chain_id: BlockchainId, chain: &Chain) {
         for (number, block) in chain.blocks().iter() {
             // add block -> chain_id index
             self.blocks_to_chain.insert(block.hash(), chain_id);
@@ -139,7 +139,7 @@ impl BlockIndices {
     }
 
     /// Get the chain ID the block belongs to
-    pub(crate) fn get_blocks_chain_id(&self, block: &BlockHash) -> Option<BlockChainId> {
+    pub(crate) fn get_blocks_chain_id(&self, block: &BlockHash) -> Option<BlockchainId> {
         self.blocks_to_chain.get(block).cloned()
     }
 
@@ -149,7 +149,7 @@ impl BlockIndices {
     pub(crate) fn update_block_hashes(
         &mut self,
         hashes: BTreeMap<u64, BlockHash>,
-    ) -> (BTreeSet<BlockChainId>, Vec<BlockNumHash>) {
+    ) -> (BTreeSet<BlockchainId>, Vec<BlockNumHash>) {
         // set new canonical hashes.
         self.canonical_chain.replace(hashes.clone());
 
@@ -218,7 +218,7 @@ impl BlockIndices {
 
     /// Remove chain from indices and return dependent chains that need to be removed.
     /// Does the cleaning of the tree and removing blocks from the chain.
-    pub fn remove_chain(&mut self, chain: &Chain) -> BTreeSet<BlockChainId> {
+    pub fn remove_chain(&mut self, chain: &Chain) -> BTreeSet<BlockchainId> {
         chain
             .blocks()
             .iter()
@@ -234,7 +234,7 @@ impl BlockIndices {
         &mut self,
         block_number: BlockNumber,
         block_hash: BlockHash,
-    ) -> BTreeSet<BlockChainId> {
+    ) -> BTreeSet<BlockchainId> {
         // rm number -> block
         if let btree_map::Entry::Occupied(mut entry) =
             self.block_number_to_block_hashes.entry(block_number)
@@ -327,7 +327,7 @@ impl BlockIndices {
         &mut self,
         finalized_block: BlockNumber,
         num_of_additional_canonical_hashes_to_retain: u64,
-    ) -> BTreeSet<BlockChainId> {
+    ) -> BTreeSet<BlockchainId> {
         // get finalized chains. blocks between [self.last_finalized,finalized_block).
         // Dont remove finalized_block, as sidechain can point to it.
         let finalized_blocks: Vec<BlockHash> = self

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     metrics::{MakeCanonicalAction, MakeCanonicalDurationsRecorder, TreeMetrics},
-    state::{BlockChainId, TreeState},
+    state::{BlockchainId, TreeState},
     AppendableChain, BlockIndices, BlockchainTreeConfig, BundleStateData, TreeExternals,
 };
 use reth_consensus::{Consensus, ConsensusError};
@@ -441,7 +441,7 @@ where
     fn try_insert_block_into_side_chain(
         &mut self,
         block: SealedBlockWithSenders,
-        chain_id: BlockChainId,
+        chain_id: BlockchainId,
         block_validation_kind: BlockValidationKind,
     ) -> Result<BlockStatus, InsertBlockErrorKind> {
         let block_num_hash = block.num_hash();
@@ -514,7 +514,7 @@ where
     /// # Note
     ///
     /// This is not cached in order to save memory.
-    fn all_chain_hashes(&self, chain_id: BlockChainId) -> BTreeMap<BlockNumber, BlockHash> {
+    fn all_chain_hashes(&self, chain_id: BlockchainId) -> BTreeMap<BlockNumber, BlockHash> {
         let mut chain_id = chain_id;
         let mut hashes = BTreeMap::new();
         loop {
@@ -553,7 +553,7 @@ where
     /// the block on
     ///
     /// Returns `None` if the chain is unknown.
-    fn canonical_fork(&self, chain_id: BlockChainId) -> Option<ForkBlock> {
+    fn canonical_fork(&self, chain_id: BlockchainId) -> Option<ForkBlock> {
         let mut chain_id = chain_id;
         let mut fork;
         loop {
@@ -572,13 +572,13 @@ where
     /// Insert a chain into the tree.
     ///
     /// Inserts a chain into the tree and builds the block indices.
-    fn insert_chain(&mut self, chain: AppendableChain) -> Option<BlockChainId> {
+    fn insert_chain(&mut self, chain: AppendableChain) -> Option<BlockchainId> {
         self.state.insert_chain(chain)
     }
 
     /// Iterate over all child chains that depend on this block and return
     /// their ids.
-    fn find_all_dependent_chains(&self, block: &BlockHash) -> HashSet<BlockChainId> {
+    fn find_all_dependent_chains(&self, block: &BlockHash) -> HashSet<BlockchainId> {
         // Find all forks of given block.
         let mut dependent_block =
             self.block_indices().fork_to_child().get(block).cloned().unwrap_or_default();
@@ -609,7 +609,7 @@ where
     /// This method searches for any chain that depended on this block being part of the canonical
     /// chain. Each dependent chain's state is then updated with state entries removed from the
     /// plain state during the unwind.
-    fn insert_unwound_chain(&mut self, chain: AppendableChain) -> Option<BlockChainId> {
+    fn insert_unwound_chain(&mut self, chain: AppendableChain) -> Option<BlockchainId> {
         // iterate over all blocks in chain and find any fork blocks that are in tree.
         for (number, block) in chain.blocks().iter() {
             let hash = block.hash();
@@ -893,7 +893,7 @@ where
     /// The pending part of the chain is reinserted back into the tree with the same `chain_id`.
     fn remove_and_split_chain(
         &mut self,
-        chain_id: BlockChainId,
+        chain_id: BlockchainId,
         split_at: ChainSplitTarget,
     ) -> Option<Chain> {
         let chain = self.state.chains.remove(&chain_id)?;
@@ -1278,7 +1278,7 @@ mod tests {
     };
     use reth_provider::{
         test_utils::{
-            blocks::BlockChainTestData, create_test_provider_factory_with_chain_spec,
+            blocks::BlockchainTestData, create_test_provider_factory_with_chain_spec,
             TestExecutorFactory,
         },
         ProviderFactory,
@@ -1339,7 +1339,7 @@ mod tests {
         /// Number of chains
         chain_num: Option<usize>,
         /// Check block to chain index
-        block_to_chain: Option<HashMap<BlockHash, BlockChainId>>,
+        block_to_chain: Option<HashMap<BlockHash, BlockchainId>>,
         /// Check fork to child index
         fork_to_child: Option<HashMap<BlockHash, HashSet<BlockHash>>>,
         /// Pending blocks
@@ -1354,7 +1354,7 @@ mod tests {
             self
         }
 
-        fn with_block_to_chain(mut self, block_to_chain: HashMap<BlockHash, BlockChainId>) -> Self {
+        fn with_block_to_chain(mut self, block_to_chain: HashMap<BlockHash, BlockchainId>) -> Self {
             self.block_to_chain = Some(block_to_chain);
             self
         }
@@ -1602,7 +1602,7 @@ mod tests {
 
     #[test]
     fn sidechain_block_hashes() {
-        let data = BlockChainTestData::default_from_number(11);
+        let data = BlockchainTestData::default_from_number(11);
         let (block1, exec1) = data.blocks[0].clone();
         let (block2, exec2) = data.blocks[1].clone();
         let (block3, exec3) = data.blocks[2].clone();
@@ -1678,7 +1678,7 @@ mod tests {
 
     #[test]
     fn cached_trie_updates() {
-        let data = BlockChainTestData::default_from_number(11);
+        let data = BlockchainTestData::default_from_number(11);
         let (block1, exec1) = data.blocks[0].clone();
         let (block2, exec2) = data.blocks[1].clone();
         let (block3, exec3) = data.blocks[2].clone();
@@ -1766,7 +1766,7 @@ mod tests {
 
     #[test]
     fn test_side_chain_fork() {
-        let data = BlockChainTestData::default_from_number(11);
+        let data = BlockchainTestData::default_from_number(11);
         let (block1, exec1) = data.blocks[0].clone();
         let (block2, exec2) = data.blocks[1].clone();
         let genesis = data.genesis;
@@ -1864,7 +1864,7 @@ mod tests {
 
     #[test]
     fn sanity_path() {
-        let data = BlockChainTestData::default_from_number(11);
+        let data = BlockchainTestData::default_from_number(11);
         let (block1, exec1) = data.blocks[0].clone();
         let (block2, exec2) = data.blocks[1].clone();
         let genesis = data.genesis;

--- a/crates/blockchain-tree/src/state.rs
+++ b/crates/blockchain-tree/src/state.rs
@@ -10,7 +10,7 @@ pub(crate) struct TreeState {
     /// Keeps track of new unique identifiers for chains
     block_chain_id_generator: u64,
     /// The tracked chains and their current data.
-    pub(crate) chains: HashMap<BlockChainId, AppendableChain>,
+    pub(crate) chains: HashMap<BlockchainId, AppendableChain>,
     /// Indices to block and their connection to the canonical chain.
     ///
     /// This gets modified by the tree itself and is read from engine API/RPC to access the pending
@@ -41,10 +41,10 @@ impl TreeState {
 
     /// Issues a new unique identifier for a new chain.
     #[inline]
-    fn next_id(&mut self) -> BlockChainId {
+    fn next_id(&mut self) -> BlockchainId {
         let id = self.block_chain_id_generator;
         self.block_chain_id_generator += 1;
-        BlockChainId(id)
+        BlockchainId(id)
     }
 
     /// Expose internal indices of the BlockchainTree.
@@ -85,7 +85,7 @@ impl TreeState {
     /// Insert a chain into the tree.
     ///
     /// Inserts a chain into the tree and builds the block indices.
-    pub(crate) fn insert_chain(&mut self, chain: AppendableChain) -> Option<BlockChainId> {
+    pub(crate) fn insert_chain(&mut self, chain: AppendableChain) -> Option<BlockchainId> {
         if chain.is_empty() {
             return None
         }
@@ -113,17 +113,17 @@ impl TreeState {
 
 /// The ID of a sidechain internally in a [`BlockchainTree`][super::BlockchainTree].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
-pub struct BlockChainId(u64);
+pub struct BlockchainId(u64);
 
-impl From<BlockChainId> for u64 {
-    fn from(value: BlockChainId) -> Self {
+impl From<BlockchainId> for u64 {
+    fn from(value: BlockchainId) -> Self {
         value.0
     }
 }
 
 #[cfg(test)]
-impl From<u64> for BlockChainId {
+impl From<u64> for BlockchainId {
     fn from(value: u64) -> Self {
-        BlockChainId(value)
+        BlockchainId(value)
     }
 }

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -2354,7 +2354,7 @@ mod tests {
             genesis::{Genesis, GenesisAllocator},
             Hardfork, U256,
         };
-        use reth_provider::test_utils::blocks::BlockChainTestData;
+        use reth_provider::test_utils::blocks::BlockchainTestData;
 
         #[tokio::test]
         async fn new_payload_before_forkchoice() {
@@ -2569,7 +2569,7 @@ mod tests {
 
         #[tokio::test]
         async fn payload_pre_merge() {
-            let data = BlockChainTestData::default();
+            let data = BlockchainTestData::default();
             let mut block1 = data.blocks[0].0.block.clone();
             block1
                 .header

--- a/crates/interfaces/src/blockchain_tree/error.rs
+++ b/crates/interfaces/src/blockchain_tree/error.rs
@@ -18,7 +18,7 @@ pub enum BlockchainTreeError {
         last_finalized: BlockNumber,
     },
     /// Thrown if no side chain could be found for the block.
-    #[error("blockChainId can't be found in BlockchainTree with internal index {chain_id}")]
+    #[error("chainId can't be found in BlockchainTree with internal index {chain_id}")]
     BlockSideChainIdConsistency {
         /// The internal identifier for the side chain.
         chain_id: u64,

--- a/crates/storage/provider/src/test_utils/blocks.rs
+++ b/crates/storage/provider/src/test_utils/blocks.rs
@@ -62,14 +62,14 @@ const BLOCK_RLP: [u8; 610] = hex!("f9025ff901f7a0c86e8cc0310ae7c531c758678ddbfd1
 /// Test chain with genesis, blocks, execution results
 /// that have valid changesets.
 #[derive(Debug)]
-pub struct BlockChainTestData {
+pub struct BlockchainTestData {
     /// Genesis
     pub genesis: SealedBlock,
     /// Blocks with its execution result
     pub blocks: Vec<(SealedBlockWithSenders, BundleStateWithReceipts)>,
 }
 
-impl BlockChainTestData {
+impl BlockchainTestData {
     /// Create test data with two blocks that are connected, specifying their block numbers.
     pub fn default_from_number(first: BlockNumber) -> Self {
         let one = block1(first);
@@ -85,7 +85,7 @@ impl BlockChainTestData {
     }
 }
 
-impl Default for BlockChainTestData {
+impl Default for BlockchainTestData {
     fn default() -> Self {
         let one = block1(1);
         let mut extended_state = one.1.clone();


### PR DESCRIPTION
I noticed in the code that sometimes it uses `Blockchain` and sometimes `BlockChain`. Here are the statistics I gathered:

```bash
$ rg Blockchain -c

examples/rpc-db/src/main.rs:3
testing/ef-tests/src/cases/blockchain_test.rs:11
testing/ef-tests/src/models.rs:1
testing/ef-tests/src/suite.rs:2
etc/grafana/dashboards/overview.json:2
testing/ef-tests/tests/tests.rs:2
crates/interfaces/src/blockchain_tree/mod.rs:11
crates/interfaces/src/blockchain_tree/error.rs:18
bin/reth/src/commands/debug_cmd/replay_engine.rs:5
bin/reth/src/commands/debug_cmd/build_block.rs:5
crates/primitives/src/proofs.rs:2
crates/interfaces/src/lib.rs:1
crates/primitives/src/header.rs:3
crates/interfaces/src/error.rs:4
crates/blockchain-tree/src/noop.rs:11
crates/blockchain-tree/src/block_indices.rs:1
crates/blockchain-tree/src/config.rs:4
crates/blockchain-tree/src/blockchain_tree.rs:37
crates/blockchain-tree/src/externals.rs:1
crates/blockchain-tree/src/state.rs:3
crates/blockchain-tree/src/chain.rs:3
crates/blockchain-tree/src/lib.rs:4
crates/blockchain-tree/src/shareable.rs:15
crates/consensus/beacon/src/engine/mod.rs:12
crates/consensus/beacon/src/engine/test_utils.rs:7
crates/node-builder/src/builder.rs:8
crates/net/downloaders/src/bodies/bodies.rs:1
crates/e2e-test-utils/src/lib.rs:2
crates/storage/provider/src/chain.rs:1
crates/storage/provider/src/providers/mod.rs:29
crates/storage/provider/src/traits/state.rs:3
crates/storage/provider/src/traits/tree_viewer.rs:9
crates/storage/provider/src/traits/mod.rs:1
```

```bash
$ rg BlockChain -c
crates/consensus/beacon/src/engine/mod.rs:2
crates/blockchain-tree/src/blockchain_tree.rs:15
crates/blockchain-tree/src/state.rs:9
crates/blockchain-tree/src/block_indices.rs:10
crates/storage/provider/src/test_utils/blocks.rs:3
```

And I think using `Blockchain` consistently would be more unified. That's why I submitted this PR.