### PR TITLE
refactor: replace OP error variant with general purpose error

### DIFF
--- a/crates/optimism/node/src/rpc.rs
+++ b/crates/optimism/node/src/rpc.rs
@@ -3,9 +3,10 @@
 use jsonrpsee::types::ErrorObject;
 use reqwest::Client;
 use reth_rpc::eth::{
-    error::{EthApiError, EthResult, ToRpcError},
+    error::{EthApiError, EthResult},
     traits::RawTransactionForwarder,
 };
+use reth_rpc_types::ToRpcError;
 use std::sync::{atomic::AtomicUsize, Arc};
 
 /// Error type when interacting with the Sequencer

--- a/crates/rpc/rpc-engine-api/src/error.rs
+++ b/crates/rpc/rpc-engine-api/src/error.rs
@@ -88,7 +88,7 @@ pub enum EngineApiError {
     #[error(transparent)]
     EngineObjectValidationError(#[from] EngineObjectValidationError),
     /// Any other error
-    #[error("0")]
+    #[error("{0}")]
     Other(Box<dyn ToRpcError>),
 }
 

--- a/crates/rpc/rpc-engine-api/src/error.rs
+++ b/crates/rpc/rpc-engine-api/src/error.rs
@@ -5,6 +5,7 @@ use reth_beacon_consensus::{BeaconForkChoiceUpdateError, BeaconOnNewPayloadError
 use reth_engine_primitives::EngineObjectValidationError;
 use reth_payload_builder::error::PayloadBuilderError;
 use reth_primitives::{B256, U256};
+use reth_rpc_types::ToRpcError;
 use thiserror::Error;
 
 /// The Engine API result type
@@ -88,9 +89,18 @@ pub enum EngineApiError {
     EngineObjectValidationError(#[from] EngineObjectValidationError),
     /// If the optimism feature flag is enabled, the payload attributes must have a present
     /// gas limit for the forkchoice updated method.
-    #[cfg(feature = "optimism")]
-    #[error("Missing gas limit in payload attributes")]
-    MissingGasLimitInPayloadAttributes,
+    // #[cfg(feature = "optimism")]
+    // #[error("Missing gas limit in payload attributes")]
+    // MissingGasLimitInPayloadAttributes,
+    #[error("0")]
+    Other(Box<dyn ToRpcError>),
+}
+
+impl EngineApiError {
+    /// crates a new [EngineApiError::Other] variant.
+    pub fn other<E: ToRpcError>(err: E) -> Self {
+        Self::Other(Box::new(err))
+    }
 }
 
 /// Helper type to represent the `error` field in the error response:
@@ -188,15 +198,6 @@ impl From<EngineApiError> for jsonrpsee_types::error::ErrorObject<'static> {
                     )
                 }
             },
-            // Optimism errors
-            #[cfg(feature = "optimism")]
-            EngineApiError::MissingGasLimitInPayloadAttributes => {
-                jsonrpsee_types::error::ErrorObject::owned(
-                    INVALID_PARAMS_CODE,
-                    INVALID_PARAMS_MSG,
-                    Some(ErrorData::new(error)),
-                )
-            }
             // Any other server error
             EngineApiError::TerminalTD { .. } |
             EngineApiError::TerminalBlockHash { .. } |
@@ -206,6 +207,14 @@ impl From<EngineApiError> for jsonrpsee_types::error::ErrorObject<'static> {
                 SERVER_ERROR_MSG,
                 Some(ErrorData::new(error)),
             ),
+            EngineApiError::Other(err) => {
+                err.to_rpc_error()
+                // jsonrpsee_types::error::ErrorObject::owned(
+                //     INVALID_PARAMS_CODE,
+                //     INVALID_PARAMS_MSG,
+                //     Some(ErrorData::new(error)),
+                // )
+            }
         }
     }
 }

--- a/crates/rpc/rpc-engine-api/src/error.rs
+++ b/crates/rpc/rpc-engine-api/src/error.rs
@@ -87,17 +87,13 @@ pub enum EngineApiError {
     /// The payload or attributes are known to be malformed before processing.
     #[error(transparent)]
     EngineObjectValidationError(#[from] EngineObjectValidationError),
-    /// If the optimism feature flag is enabled, the payload attributes must have a present
-    /// gas limit for the forkchoice updated method.
-    // #[cfg(feature = "optimism")]
-    // #[error("Missing gas limit in payload attributes")]
-    // MissingGasLimitInPayloadAttributes,
+    /// Any other error
     #[error("0")]
     Other(Box<dyn ToRpcError>),
 }
 
 impl EngineApiError {
-    /// crates a new [EngineApiError::Other] variant.
+    /// Crates a new [EngineApiError::Other] variant.
     pub fn other<E: ToRpcError>(err: E) -> Self {
         Self::Other(Box::new(err))
     }
@@ -207,14 +203,7 @@ impl From<EngineApiError> for jsonrpsee_types::error::ErrorObject<'static> {
                 SERVER_ERROR_MSG,
                 Some(ErrorData::new(error)),
             ),
-            EngineApiError::Other(err) => {
-                err.to_rpc_error()
-                // jsonrpsee_types::error::ErrorObject::owned(
-                //     INVALID_PARAMS_CODE,
-                //     INVALID_PARAMS_MSG,
-                //     Some(ErrorData::new(error)),
-                // )
-            }
+            EngineApiError::Other(err) => err.to_rpc_error(),
         }
     }
 }

--- a/crates/rpc/rpc-types/src/eth/error.rs
+++ b/crates/rpc/rpc-types/src/eth/error.rs
@@ -2,7 +2,7 @@
 
 use jsonrpsee_types::ErrorObject;
 
-/// A tait for custom rpc errors used by Other variants of rpc errors.
+/// A tait to convert an error to an RPC error.
 pub trait ToRpcError: std::error::Error + Send + Sync + 'static {
     /// Converts the error to a JSON-RPC error object.
     fn to_rpc_error(&self) -> ErrorObject<'static>;

--- a/crates/rpc/rpc-types/src/eth/error.rs
+++ b/crates/rpc/rpc-types/src/eth/error.rs
@@ -1,0 +1,9 @@
+//! Implementation specific Errors for the `eth_` namespace.
+
+use jsonrpsee_types::ErrorObject;
+
+/// A tait for custom rpc errors used by [EthApiError::Other].
+pub trait ToRpcError: std::error::Error + Send + Sync + 'static {
+    /// Converts the error to a JSON-RPC error object.
+    fn to_rpc_error(&self) -> ErrorObject<'static>;
+}

--- a/crates/rpc/rpc-types/src/eth/error.rs
+++ b/crates/rpc/rpc-types/src/eth/error.rs
@@ -2,7 +2,7 @@
 
 use jsonrpsee_types::ErrorObject;
 
-/// A tait for custom rpc errors used by [EthApiError::Other].
+/// A tait for custom rpc errors used by Other variants of rpc errors.
 pub trait ToRpcError: std::error::Error + Send + Sync + 'static {
     /// Converts the error to a JSON-RPC error object.
     fn to_rpc_error(&self) -> ErrorObject<'static>;

--- a/crates/rpc/rpc-types/src/eth/mod.rs
+++ b/crates/rpc/rpc-types/src/eth/mod.rs
@@ -1,5 +1,6 @@
 //! Ethereum related types
 
+pub(crate) mod error;
 pub mod transaction;
 
 // re-export

--- a/crates/rpc/rpc-types/src/lib.rs
+++ b/crates/rpc/rpc-types/src/lib.rs
@@ -37,6 +37,7 @@ pub use eth::{
     engine::{
         ExecutionPayload, ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3, PayloadError,
     },
+    error::ToRpcError,
     transaction::{self, TransactionKind, TransactionRequest, TypedTransactionRequest},
 };
 

--- a/crates/rpc/rpc-types/src/mev.rs
+++ b/crates/rpc/rpc-types/src/mev.rs
@@ -706,7 +706,7 @@ mod u256_numeric_string {
         match val {
             serde_json::Value::String(s) => {
                 if let Ok(val) = s.parse::<u128>() {
-                    return Ok(U256::from(val))
+                    return Ok(U256::from(val));
                 }
                 U256::from_str(&s).map_err(de::Error::custom)
             }

--- a/crates/rpc/rpc/src/eth/error.rs
+++ b/crates/rpc/rpc/src/eth/error.rs
@@ -6,7 +6,9 @@ use jsonrpsee::types::{error::CALL_EXECUTION_FAILED_CODE, ErrorObject};
 use reth_interfaces::RethError;
 use reth_primitives::{revm_primitives::InvalidHeader, Address, Bytes, U256};
 use reth_revm::tracing::{js::JsInspectorError, MuxError};
-use reth_rpc_types::{error::EthRpcErrorCode, request::TransactionInputError, BlockError};
+use reth_rpc_types::{
+    error::EthRpcErrorCode, request::TransactionInputError, BlockError, ToRpcError,
+};
 use reth_transaction_pool::error::{
     Eip4844PoolTransactionError, InvalidPoolTransactionError, PoolError, PoolErrorKind,
     PoolTransactionError,
@@ -16,12 +18,6 @@ use std::time::Duration;
 
 /// Result alias
 pub type EthResult<T> = Result<T, EthApiError>;
-
-/// A tait for custom rpc errors used by [EthApiError::Other].
-pub trait ToRpcError: std::error::Error + Send + Sync + 'static {
-    /// Converts the error to a JSON-RPC error object.
-    fn to_rpc_error(&self) -> ErrorObject<'static>;
-}
 
 /// Errors that can occur when interacting with the `eth_` namespace
 #[derive(Debug, thiserror::Error)]

--- a/crates/rpc/rpc/src/eth/optimism.rs
+++ b/crates/rpc/rpc/src/eth/optimism.rs
@@ -1,11 +1,9 @@
 //! Optimism specific types.
 
 use jsonrpsee::types::ErrorObject;
+use reth_rpc_types::ToRpcError;
 
-use crate::{
-    eth::error::{EthApiError, ToRpcError},
-    result::internal_rpc_err,
-};
+use crate::{eth::error::EthApiError, result::internal_rpc_err};
 
 /// Eth Optimism Api Error
 #[cfg(feature = "optimism")]


### PR DESCRIPTION
* move trait to rpc-types
* replace op error variant with Other
* the OP error variant appears to be unused so this variant was removed entirely

Closes #7825