### PR TITLE
fix(rpc): correct `Other` error msg

### DIFF
--- a/crates/rpc/rpc/src/eth/error.rs
+++ b/crates/rpc/rpc/src/eth/error.rs
@@ -119,7 +119,7 @@ pub enum EthApiError {
     #[error(transparent)]
     MuxTracerError(#[from] MuxError),
     /// Any other error
-    #[error("0")]
+    #[error("{0}")]
     Other(Box<dyn ToRpcError>),
 }
 


### PR DESCRIPTION
Currently the error message is `0` but it should be the error message of the underlying error (`{0}`)