### PR TITLE
feat(exex): do not log ID on ExEx start

### DIFF
--- a/crates/node-builder/src/builder.rs
+++ b/crates/node-builder/src/builder.rs
@@ -630,7 +630,7 @@ where
 
                 // spawn it as a crit task
                 executor.spawn_critical("exex", async move {
-                    info!(target: "reth::cli", id, "ExEx started");
+                    info!(target: "reth::cli", "ExEx started");
                     match exex.await {
                         Ok(_) => panic!("ExEx {id} finished. ExEx's should run indefinitely"),
                         Err(err) => panic!("ExEx {id} crashed: {err}"),


### PR DESCRIPTION
We already have ID as a span field
```console
2024-04-24T18:19:47.314725Z  INFO exex{id="Rollup"}: ExEx started id="Rollup"
```