### PR TITLE
chore: rename exex example crate names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2759,6 +2759,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "exex-minimal"
+version = "0.0.0"
+dependencies = [
+ "eyre",
+ "futures",
+ "reth",
+ "reth-exex",
+ "reth-node-api",
+ "reth-node-core",
+ "reth-node-ethereum",
+ "reth-primitives",
+ "reth-tracing",
+ "tokio",
+]
+
+[[package]]
+name = "exex-op-bridge"
+version = "0.0.0"
+dependencies = [
+ "alloy-sol-types",
+ "eyre",
+ "futures",
+ "itertools 0.12.1",
+ "reth",
+ "reth-exex",
+ "reth-node-api",
+ "reth-node-core",
+ "reth-node-ethereum",
+ "reth-primitives",
+ "reth-provider",
+ "reth-tracing",
+ "rusqlite",
+ "tokio",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4714,22 +4750,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal"
-version = "0.0.0"
-dependencies = [
- "eyre",
- "futures",
- "reth",
- "reth-exex",
- "reth-node-api",
- "reth-node-core",
- "reth-node-ethereum",
- "reth-primitives",
- "reth-tracing",
- "tokio",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5071,26 +5091,6 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
-
-[[package]]
-name = "op-bridge"
-version = "0.0.0"
-dependencies = [
- "alloy-sol-types",
- "eyre",
- "futures",
- "itertools 0.12.1",
- "reth",
- "reth-exex",
- "reth-node-api",
- "reth-node-core",
- "reth-node-ethereum",
- "reth-primitives",
- "reth-provider",
- "reth-tracing",
- "rusqlite",
- "tokio",
-]
 
 [[package]]
 name = "opaque-debug"

--- a/examples/exex/minimal/Cargo.toml
+++ b/examples/exex/minimal/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "minimal"
+name = "exex-minimal"
 version = "0.0.0"
 publish = false
 edition.workspace = true

--- a/examples/exex/op-bridge/Cargo.toml
+++ b/examples/exex/op-bridge/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "op-bridge"
+name = "exex-op-bridge"
 version = "0.0.0"
 publish = false
 edition.workspace = true


### PR DESCRIPTION
On our crate docs site these show up as "minimal" and "op-bridge" which is not super helpful