### PR TITLE
docs: update examples readme

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,17 +1,65 @@
-## Examples of how to use the Reth SDK
+# Examples
 
-This directory contains a number of examples showcasing various capabilities of
-the `reth-*` crates.
+These examples demonstrate the main features of some of Reth's crates and how to use them.
 
-All examples can be executed with:
-
-```
-cargo run --example $name
-```
-
-A good starting point for the examples would be [`db-access`](db-access.rs)
-and [`rpc-db`](rpc-db).
+To run an example, use the command `cargo run -p <example>`.
 
 If you've got an example you'd like to see here, please feel free to open an
 issue. Otherwise if you've got an example you'd like to add, please feel free
 to make a PR!
+
+## P2P
+
+| Example                     | Description                                                       |
+| --------------------------- | ----------------------------------------------------------------- |
+| [Manual P2P](./manual-p2p)  | Illustrates how to connect and communicate with a peer            |
+| [Polygon P2P](./manual-p2p) | Illustrates how to connect and communicate with a peer on Polygon |
+
+## Network
+
+| [Standalone network](./network.rs) | Illustrates how to use the network as a standalone component |
+
+## RPC
+
+| Example                 | Description                                                                 |
+| ----------------------- | --------------------------------------------------------------------------- |
+| [DB over RPC](./rpc-db) | Illustrates how to run a standalone RPC server over a Rethdatabase instance |
+
+## Node Builder
+
+| Example                                                       | Description                                                                                      |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| [Additional RPC namespace](./additional-rpc-namespace-in-cli) | Illustrates how to add custom CLI parameters and set up a custom RPC namespace                   |
+| [Custom event hooks](./cli-extension-event-hooks)             | Illustrates how to hook to various node lifecycle events                                         |
+| [Custom dev node](./custom-dev-node)                          | Illustrates how to run a custom dev node programmatically and submit a transaction to it via RPC |
+| [Custom EVM](./custom-evm)                                    | Illustrates how to implement a node with a custom EVM                                            |
+| [Custom inspector](./custom-inspector)                        | Illustrates how to use a custom EVM inspector to trace new transactions                          |
+| [Custom node](./custom-node)                                  | Illustrates how to create a node with custom engine types                                        |
+| [Custom node components](./custom-node-components)            | Illustrates how to configure custom node components                                              |
+| [Custom payload builder](./custom-payload-builder)            | Illustrates how to use a custom payload builder                                                  |
+
+## Mempool
+
+| Example                                               | Description                                                                                                                |
+| ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| [Trace pending transactions](./trace-transaction-cli) | Illustrates how to trace pending transactions as they arrive in the mempool                                                |
+| [Standalone txpool](./network-txpool.rs)              | Illustrates how to use the network as a standalone component together with a transaction pool with a custom pool validator |
+
+## ExEx
+
+| Example                            | Description                                                                       |
+| ---------------------------------- | --------------------------------------------------------------------------------- |
+| [Minimal ExEx](./exex/minimal)     | Illustrates how to build a simple ExEx                                            |
+| [OP Bridge ExEx](./exex/op-bridge) | Illustrates an ExEx that decodes Optimism deposit and withdrawal receipts from L1 |
+
+## Database
+
+| Example                     | Description                                                     |
+| --------------------------- | --------------------------------------------------------------- |
+| [DB access](./db-access.rs) | Illustrates how to access Reth's database in a separate process |
+
+## Misc
+
+| Example                            | Description                                                 |
+| ---------------------------------- | ----------------------------------------------------------- |
+| [Beacon API SSE](./beacon-api-sse) | Illustrates how to subscribe to beacon chain events via SSE |

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,25 +8,6 @@ If you've got an example you'd like to see here, please feel free to open an
 issue. Otherwise if you've got an example you'd like to add, please feel free
 to make a PR!
 
-## P2P
-
-| Example                     | Description                                                       |
-| --------------------------- | ----------------------------------------------------------------- |
-| [Manual P2P](./manual-p2p)  | Illustrates how to connect and communicate with a peer            |
-| [Polygon P2P](./manual-p2p) | Illustrates how to connect and communicate with a peer on Polygon |
-
-## Network
-
-| Example                            | Description                                                  |
-| ---------------------------------- | ------------------------------------------------------------ |
-| [Standalone network](./network.rs) | Illustrates how to use the network as a standalone component |
-
-## RPC
-
-| Example                 | Description                                                                 |
-| ----------------------- | --------------------------------------------------------------------------- |
-| [DB over RPC](./rpc-db) | Illustrates how to run a standalone RPC server over a Rethdatabase instance |
-
 ## Node Builder
 
 | Example                                                       | Description                                                                                      |
@@ -40,13 +21,6 @@ to make a PR!
 | [Custom node components](./custom-node-components)            | Illustrates how to configure custom node components                                              |
 | [Custom payload builder](./custom-payload-builder)            | Illustrates how to use a custom payload builder                                                  |
 
-## Mempool
-
-| Example                                               | Description                                                                                                                |
-| ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| [Trace pending transactions](./trace-transaction-cli) | Illustrates how to trace pending transactions as they arrive in the mempool                                                |
-| [Standalone txpool](./network-txpool.rs)              | Illustrates how to use the network as a standalone component together with a transaction pool with a custom pool validator |
-
 ## ExEx
 
 | Example                            | Description                                                                       |
@@ -54,11 +28,37 @@ to make a PR!
 | [Minimal ExEx](./exex/minimal)     | Illustrates how to build a simple ExEx                                            |
 | [OP Bridge ExEx](./exex/op-bridge) | Illustrates an ExEx that decodes Optimism deposit and withdrawal receipts from L1 |
 
+## RPC
+
+| Example                 | Description                                                                 |
+| ----------------------- | --------------------------------------------------------------------------- |
+| [DB over RPC](./rpc-db) | Illustrates how to run a standalone RPC server over a Rethdatabase instance |
+
 ## Database
 
 | Example                     | Description                                                     |
 | --------------------------- | --------------------------------------------------------------- |
 | [DB access](./db-access.rs) | Illustrates how to access Reth's database in a separate process |
+
+## Network
+
+| Example                            | Description                                                  |
+| ---------------------------------- | ------------------------------------------------------------ |
+| [Standalone network](./network.rs) | Illustrates how to use the network as a standalone component |
+
+## Mempool
+
+| Example                                               | Description                                                                                                                |
+| ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| [Trace pending transactions](./trace-transaction-cli) | Illustrates how to trace pending transactions as they arrive in the mempool                                                |
+| [Standalone txpool](./network-txpool.rs)              | Illustrates how to use the network as a standalone component together with a transaction pool with a custom pool validator |
+
+## P2P
+
+| Example                     | Description                                                       |
+| --------------------------- | ----------------------------------------------------------------- |
+| [Manual P2P](./manual-p2p)  | Illustrates how to connect and communicate with a peer            |
+| [Polygon P2P](./manual-p2p) | Illustrates how to connect and communicate with a peer on Polygon |
 
 ## Misc
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,6 +17,8 @@ to make a PR!
 
 ## Network
 
+| Example                            | Description                                                  |
+| ---------------------------------- | ------------------------------------------------------------ |
 | [Standalone network](./network.rs) | Illustrates how to use the network as a standalone component |
 
 ## RPC


### PR DESCRIPTION
Updates the readme in the examples directory with a listing of every example and a brief description of each. Additionally, this also shows the correct command to use to run the examples.

We cannot use `cargo run --example` due to:

1. The main `Cargo.toml` being a virtual manifest where `[[example]]` is not allowed
2. Some examples being more complicated and having their own `Cargo.toml` (unsupported by cargo)

Because of 1. I also propose that we move these examples to their own directory with their own `Cargo.toml` in a follow up:

- `db-access.rs`
- `network-txpool.rs`
- `network.rs`

Finally, a few other follow ups is probably needed to rename some examples: for example

- `custom-node` deals with only customizing the engine types. The name should reflect this
- `cli-extension-event-hooks`, `additional-rpc-namespace-in-cli` and `trace-transaction-cli` have semi misleading names; the first uses the node builder to to hook on node lifecycle events, the second adds a custom RPC namespace using the node builder, the third traces transactions as they arrive in the mempool
