### PR TITLE
fix(auto-seal): build dev blocks with withdrawals

### DIFF
--- a/crates/consensus/auto-seal/src/lib.rs
+++ b/crates/consensus/auto-seal/src/lib.rs
@@ -24,8 +24,8 @@ use reth_primitives::{
     constants::{EMPTY_RECEIPTS, EMPTY_TRANSACTIONS, ETHEREUM_BLOCK_GAS_LIMIT},
     eip4844::calculate_excess_blob_gas,
     proofs, Block, BlockBody, BlockHash, BlockHashOrNumber, BlockNumber, BlockWithSenders, Bloom,
-    ChainSpec, Header, ReceiptWithBloom, SealedBlock, SealedHeader, TransactionSigned, B256,
-    EMPTY_OMMER_ROOT_HASH, U256,
+    ChainSpec, Header, ReceiptWithBloom, SealedBlock, SealedHeader, TransactionSigned, Withdrawals,
+    B256, U256,
 };
 use reth_provider::{
     BlockExecutor, BlockReaderIdExt, BundleStateWithReceipts, CanonStateNotificationSender,
@@ -270,6 +270,8 @@ impl StorageInner {
     pub(crate) fn build_header_template(
         &self,
         transactions: &[TransactionSigned],
+        ommers: &[Header],
+        withdrawals: Option<&Withdrawals>,
         chain_spec: Arc<ChainSpec>,
     ) -> Header {
         let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
@@ -281,12 +283,12 @@ impl StorageInner {
 
         let mut header = Header {
             parent_hash: self.best_hash,
-            ommers_hash: EMPTY_OMMER_ROOT_HASH,
+            ommers_hash: proofs::calculate_ommers_root(ommers),
             beneficiary: Default::default(),
             state_root: Default::default(),
             transactions_root: Default::default(),
             receipts_root: Default::default(),
-            withdrawals_root: None,
+            withdrawals_root: withdrawals.map(|w| proofs::calculate_withdrawals_root(w)),
             logs_bloom: Default::default(),
             difficulty: U256::from(2),
             number: self.best_block + 1,
@@ -420,6 +422,8 @@ impl StorageInner {
     pub(crate) fn build_and_execute<EvmConfig>(
         &mut self,
         transactions: Vec<TransactionSigned>,
+        ommers: Vec<Header>,
+        withdrawals: Option<Withdrawals>,
         client: &impl StateProviderFactory,
         chain_spec: Arc<ChainSpec>,
         evm_config: EvmConfig,
@@ -427,11 +431,21 @@ impl StorageInner {
     where
         EvmConfig: ConfigureEvm,
     {
-        let header = self.build_header_template(&transactions, chain_spec.clone());
+        let header = self.build_header_template(
+            &transactions,
+            &ommers,
+            withdrawals.as_ref(),
+            chain_spec.clone(),
+        );
 
-        let block = Block { header, body: transactions, ommers: vec![], withdrawals: None }
-            .with_recovered_senders()
-            .ok_or(BlockExecutionError::Validation(BlockValidationError::SenderRecoveryError))?;
+        let block = Block {
+            header,
+            body: transactions,
+            ommers: ommers.clone(),
+            withdrawals: withdrawals.clone(),
+        }
+        .with_recovered_senders()
+        .ok_or(BlockExecutionError::Validation(BlockValidationError::SenderRecoveryError))?;
 
         trace!(target: "consensus::auto", transactions=?&block.body, "executing transactions");
 
@@ -447,7 +461,7 @@ impl StorageInner {
         let (bundle_state, gas_used) = self.execute(&block, &mut executor)?;
 
         let Block { header, body, .. } = block.block;
-        let body = BlockBody { transactions: body, ommers: vec![], withdrawals: None };
+        let body = BlockBody { transactions: body, ommers, withdrawals };
 
         let blob_gas_used = if chain_spec.is_cancun_active_at_timestamp(header.timestamp) {
             let mut sum_blob_gas_used = 0;

--- a/crates/consensus/auto-seal/src/task.rs
+++ b/crates/consensus/auto-seal/src/task.rs
@@ -3,7 +3,9 @@ use futures_util::{future::BoxFuture, FutureExt};
 use reth_beacon_consensus::{BeaconEngineMessage, ForkchoiceStatus};
 use reth_engine_primitives::EngineTypes;
 use reth_evm::ConfigureEvm;
-use reth_primitives::{Block, ChainSpec, IntoRecoveredTransaction, SealedBlockWithSenders};
+use reth_primitives::{
+    Block, ChainSpec, IntoRecoveredTransaction, SealedBlockWithSenders, Withdrawals,
+};
 use reth_provider::{CanonChainTracker, CanonStateNotificationSender, Chain, StateProviderFactory};
 use reth_rpc_types::engine::ForkchoiceState;
 use reth_stages_api::PipelineEvent;
@@ -134,9 +136,13 @@ where
                             (recovered.into_signed(), signer)
                         })
                         .unzip();
+                    let ommers = vec![];
+                    let withdrawals = Some(Withdrawals::default());
 
                     match storage.build_and_execute(
                         transactions.clone(),
+                        ommers.clone(),
+                        withdrawals.clone(),
                         &client,
                         chain_spec,
                         evm_config,
@@ -193,8 +199,8 @@ where
                             let block = Block {
                                 header: new_header.clone().unseal(),
                                 body: transactions,
-                                ommers: vec![],
-                                withdrawals: None,
+                                ommers,
+                                withdrawals,
                             };
                             let sealed_block = block.seal_slow();
 


### PR DESCRIPTION
Currently, dev mode is post-Shanghai but Auto Seal is still building blocks without withdrawals. This will lead to invalid block headers when, say, using `reth` to run an L1 devnet for an OP L2 devnet.

This fix unifies a few hardcoded values and ensures Auto Seal builds blocks with (empty) withdrawals for external validation. It will allow us to replace `geth` with `reth` as the L1 dev node for our L2 devnet :).