### PR TITLE
Replace TransactionKind with alloy_primitives::TxKind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99bbad0a6b588ef4aec1b5ddbbfdacd9ef04e00b979617765b03174318ee1f3a"
+checksum = "50c715249705afa1e32be79dabfd35e2ef0f1cc02ad2cf48c9d1e20026ee637b"
 dependencies = [
  "alloy-rlp",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -282,7 +282,7 @@ revm-inspectors = { git = "https://github.com/paradigmxyz/evm-inspectors", rev =
 
 # eth
 alloy-chains = "0.1.15"
-alloy-primitives = "0.7.0"
+alloy-primitives = "0.7.1"
 alloy-dyn-abi = "0.7.0"
 alloy-sol-types = "0.7.0"
 alloy-rlp = "0.3.4"

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1273,7 +1273,7 @@ mod tests {
         revm_primitives::AccountInfo,
         stage::StageCheckpoint,
         Account, Address, ChainSpecBuilder, Genesis, GenesisAccount, Header, Signature,
-        Transaction, TransactionKind, TransactionSigned, TransactionSignedEcRecovered, TxEip1559,
+        Transaction, TransactionSigned, TransactionSignedEcRecovered, TxEip1559, TxKind,
         Withdrawals, B256, MAINNET,
     };
     use reth_provider::{
@@ -1453,7 +1453,7 @@ mod tests {
                     chain_id: chain_spec.chain.id(),
                     nonce,
                     gas_limit: 21_000,
-                    to: TransactionKind::Call(Address::ZERO),
+                    to: TxKind::Call(Address::ZERO),
                     max_fee_per_gas: EIP1559_INITIAL_BASE_FEE as u128,
                     ..Default::default()
                 }),

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -331,8 +331,8 @@ mod tests {
     };
     use reth_primitives::{
         hex_literal::hex, proofs, Account, Address, BlockBody, BlockHash, BlockHashOrNumber, Bytes,
-        ChainSpecBuilder, Signature, TransactionKind, TransactionSigned, Withdrawal, Withdrawals,
-        MAINNET, U256,
+        ChainSpecBuilder, Signature, TransactionSigned, TxKind, Withdrawal, Withdrawals, MAINNET,
+        U256,
     };
     use std::ops::RangeBounds;
 
@@ -448,7 +448,7 @@ mod tests {
             nonce,
             gas_price: 0x28f000fff,
             gas_limit: 10,
-            to: TransactionKind::Call(Address::default()),
+            to: TxKind::Call(Address::default()),
             value: U256::from(3_u64),
             input: Bytes::from(vec![1, 2]),
             access_list: Default::default(),
@@ -470,7 +470,7 @@ mod tests {
             max_priority_fee_per_gas: 0x28f000fff,
             max_fee_per_blob_gas: 0x7,
             gas_limit: 10,
-            to: TransactionKind::Call(Address::default()),
+            to: TxKind::Call(Address::default()),
             value: U256::from(3_u64),
             input: Bytes::from(vec![1, 2]),
             access_list: Default::default(),

--- a/crates/interfaces/src/test_utils/generators.rs
+++ b/crates/interfaces/src/test_utils/generators.rs
@@ -4,8 +4,7 @@ use rand::{
 };
 use reth_primitives::{
     proofs, sign_message, Account, Address, BlockNumber, Bytes, Header, Log, Receipt, SealedBlock,
-    SealedHeader, StorageEntry, Transaction, TransactionKind, TransactionSigned, TxLegacy, B256,
-    U256,
+    SealedHeader, StorageEntry, Transaction, TransactionSigned, TxKind, TxLegacy, B256, U256,
 };
 use secp256k1::{KeyPair, Secp256k1};
 use std::{
@@ -79,7 +78,7 @@ pub fn random_tx<R: Rng>(rng: &mut R) -> Transaction {
         nonce: rng.gen::<u16>().into(),
         gas_price: rng.gen::<u16>().into(),
         gas_limit: rng.gen::<u16>().into(),
-        to: TransactionKind::Call(rng.gen()),
+        to: TxKind::Call(rng.gen()),
         value: U256::from(rng.gen::<u16>()),
         input: Bytes::default(),
     })
@@ -395,7 +394,7 @@ mod tests {
             chain_id: 1,
             nonce: 0x42,
             gas_limit: 44386,
-            to: TransactionKind::Call(hex!("6069a6c32cf691f5982febae4faf8a6f3ab2f0f6").into()),
+            to: TxKind::Call(hex!("6069a6c32cf691f5982febae4faf8a6f3ab2f0f6").into()),
             value: U256::from(0_u64),
             input:  hex!("a22cb4650000000000000000000000005eee75727d804a2b13038928d36f8b188945a57a0000000000000000000000000000000000000000000000000000000000000000").into(),
             max_fee_per_gas: 0x4a817c800,
@@ -427,7 +426,7 @@ mod tests {
             nonce: 9,
             gas_price: 20 * 10_u128.pow(9),
             gas_limit: 21000,
-            to: TransactionKind::Call(hex!("3535353535353535353535353535353535353535").into()),
+            to: TxKind::Call(hex!("3535353535353535353535353535353535353535").into()),
             value: U256::from(10_u128.pow(18)),
             input: Bytes::default(),
         });

--- a/crates/net/eth-wire-types/src/blocks.rs
+++ b/crates/net/eth-wire-types/src/blocks.rs
@@ -131,8 +131,8 @@ mod tests {
     use crate::{message::RequestPair, BlockBodies, BlockHeaders, GetBlockBodies, GetBlockHeaders};
     use alloy_rlp::{Decodable, Encodable};
     use reth_primitives::{
-        hex, BlockHashOrNumber, Header, HeadersDirection, Signature, Transaction, TransactionKind,
-        TransactionSigned, TxLegacy, U256,
+        hex, BlockHashOrNumber, Header, HeadersDirection, Signature, Transaction,
+        TransactionSigned, TxKind, TxLegacy, U256,
     };
     use std::str::FromStr;
 
@@ -383,7 +383,7 @@ mod tests {
                             nonce: 0x8u64,
                             gas_price: 0x4a817c808,
                             gas_limit: 0x2e248u64,
-                            to: TransactionKind::Call(hex!("3535353535353535353535353535353535353535").into()),
+                            to: TxKind::Call(hex!("3535353535353535353535353535353535353535").into()),
                             value: U256::from(0x200u64),
                             input: Default::default(),
                         }),
@@ -398,7 +398,7 @@ mod tests {
                             nonce: 0x9u64,
                             gas_price: 0x4a817c809,
                             gas_limit: 0x33450u64,
-                            to: TransactionKind::Call(hex!("3535353535353535353535353535353535353535").into()),
+                            to: TxKind::Call(hex!("3535353535353535353535353535353535353535").into()),
                             value: U256::from(0x2d9u64),
                             input: Default::default(),
                         }), Signature {
@@ -455,7 +455,7 @@ mod tests {
                                 nonce: 0x8u64,
                                 gas_price: 0x4a817c808,
                                 gas_limit: 0x2e248u64,
-                                to: TransactionKind::Call(hex!("3535353535353535353535353535353535353535").into()),
+                                to: TxKind::Call(hex!("3535353535353535353535353535353535353535").into()),
                                 value: U256::from(0x200u64),
                                 input: Default::default(),
                             }),
@@ -471,7 +471,7 @@ mod tests {
                                 nonce: 0x9u64,
                                 gas_price: 0x4a817c809,
                                 gas_limit: 0x33450u64,
-                                to: TransactionKind::Call(hex!("3535353535353535353535353535353535353535").into()),
+                                to: TxKind::Call(hex!("3535353535353535353535353535353535353535").into()),
                                 value: U256::from(0x2d9u64),
                                 input: Default::default(),
                             }),

--- a/crates/net/eth-wire-types/src/transactions.rs
+++ b/crates/net/eth-wire-types/src/transactions.rs
@@ -80,8 +80,8 @@ mod tests {
     use crate::{message::RequestPair, GetPooledTransactions, PooledTransactions};
     use alloy_rlp::{Decodable, Encodable};
     use reth_primitives::{
-        hex, PooledTransactionsElement, Signature, Transaction, TransactionKind, TransactionSigned,
-        TxEip1559, TxLegacy, U256,
+        hex, PooledTransactionsElement, Signature, Transaction, TransactionSigned, TxEip1559,
+        TxKind, TxLegacy, U256,
     };
     use std::str::FromStr;
 
@@ -130,9 +130,7 @@ mod tests {
                     nonce: 0x8u64,
                     gas_price: 0x4a817c808,
                     gas_limit: 0x2e248u64,
-                    to: TransactionKind::Call(
-                        hex!("3535353535353535353535353535353535353535").into(),
-                    ),
+                    to: TxKind::Call(hex!("3535353535353535353535353535353535353535").into()),
                     value: U256::from(0x200u64),
                     input: Default::default(),
                 }),
@@ -154,9 +152,7 @@ mod tests {
                     nonce: 0x09u64,
                     gas_price: 0x4a817c809,
                     gas_limit: 0x33450u64,
-                    to: TransactionKind::Call(
-                        hex!("3535353535353535353535353535353535353535").into(),
-                    ),
+                    to: TxKind::Call(hex!("3535353535353535353535353535353535353535").into()),
                     value: U256::from(0x2d9u64),
                     input: Default::default(),
                 }),
@@ -200,9 +196,7 @@ mod tests {
                     nonce: 0x8u64,
                     gas_price: 0x4a817c808,
                     gas_limit: 0x2e248u64,
-                    to: TransactionKind::Call(
-                        hex!("3535353535353535353535353535353535353535").into(),
-                    ),
+                    to: TxKind::Call(hex!("3535353535353535353535353535353535353535").into()),
                     value: U256::from(0x200u64),
                     input: Default::default(),
                 }),
@@ -224,9 +218,7 @@ mod tests {
                     nonce: 0x09u64,
                     gas_price: 0x4a817c809,
                     gas_limit: 0x33450u64,
-                    to: TransactionKind::Call(
-                        hex!("3535353535353535353535353535353535353535").into(),
-                    ),
+                    to: TxKind::Call(hex!("3535353535353535353535353535353535353535").into()),
                     value: U256::from(0x2d9u64),
                     input: Default::default(),
                 }),
@@ -271,9 +263,7 @@ mod tests {
                     nonce: 15u64,
                     gas_price: 2200000000,
                     gas_limit: 34811u64,
-                    to: TransactionKind::Call(
-                        hex!("cf7f9e66af820a19257a2108375b180b0ec49167").into(),
-                    ),
+                    to: TxKind::Call(hex!("cf7f9e66af820a19257a2108375b180b0ec49167").into()),
                     value: U256::from(1234u64),
                     input: Default::default(),
                 }),
@@ -296,9 +286,7 @@ mod tests {
                     max_priority_fee_per_gas: 1500000000,
                     max_fee_per_gas: 1500000013,
                     gas_limit: 21000u64,
-                    to: TransactionKind::Call(
-                        hex!("61815774383099e24810ab832a5b2a5425c154d5").into(),
-                    ),
+                    to: TxKind::Call(hex!("61815774383099e24810ab832a5b2a5425c154d5").into()),
                     value: U256::from(3000000000000000000u64),
                     input: Default::default(),
                     access_list: Default::default(),
@@ -321,9 +309,7 @@ mod tests {
                     nonce: 3u64,
                     gas_price: 2000000000,
                     gas_limit: 10000000u64,
-                    to: TransactionKind::Call(
-                        hex!("d3e8763675e4c425df46cc3b5c0f6cbdac396046").into(),
-                    ),
+                    to: TxKind::Call(hex!("d3e8763675e4c425df46cc3b5c0f6cbdac396046").into()),
                     value: U256::from(1000000000000000u64),
                     input: Default::default(),
                 }),
@@ -345,9 +331,7 @@ mod tests {
                     nonce: 1u64,
                     gas_price: 1000000000,
                     gas_limit: 100000u64,
-                    to: TransactionKind::Call(
-                        hex!("d3e8763675e4c425df46cc3b5c0f6cbdac396046").into(),
-                    ),
+                    to: TxKind::Call(hex!("d3e8763675e4c425df46cc3b5c0f6cbdac396046").into()),
                     value: U256::from(693361000000000u64),
                     input: Default::default(),
                 }),
@@ -369,9 +353,7 @@ mod tests {
                     nonce: 2u64,
                     gas_price: 1000000000,
                     gas_limit: 100000u64,
-                    to: TransactionKind::Call(
-                        hex!("d3e8763675e4c425df46cc3b5c0f6cbdac396046").into(),
-                    ),
+                    to: TxKind::Call(hex!("d3e8763675e4c425df46cc3b5c0f6cbdac396046").into()),
                     value: U256::from(1000000000000000u64),
                     input: Default::default(),
                 }),
@@ -420,9 +402,7 @@ mod tests {
                     nonce: 15u64,
                     gas_price: 2200000000,
                     gas_limit: 34811u64,
-                    to: TransactionKind::Call(
-                        hex!("cf7f9e66af820a19257a2108375b180b0ec49167").into(),
-                    ),
+                    to: TxKind::Call(hex!("cf7f9e66af820a19257a2108375b180b0ec49167").into()),
                     value: U256::from(1234u64),
                     input: Default::default(),
                 }),
@@ -445,9 +425,7 @@ mod tests {
                     max_priority_fee_per_gas: 1500000000,
                     max_fee_per_gas: 1500000013,
                     gas_limit: 21000u64,
-                    to: TransactionKind::Call(
-                        hex!("61815774383099e24810ab832a5b2a5425c154d5").into(),
-                    ),
+                    to: TxKind::Call(hex!("61815774383099e24810ab832a5b2a5425c154d5").into()),
                     value: U256::from(3000000000000000000u64),
                     input: Default::default(),
                     access_list: Default::default(),
@@ -470,9 +448,7 @@ mod tests {
                     nonce: 3u64,
                     gas_price: 2000000000,
                     gas_limit: 10000000u64,
-                    to: TransactionKind::Call(
-                        hex!("d3e8763675e4c425df46cc3b5c0f6cbdac396046").into(),
-                    ),
+                    to: TxKind::Call(hex!("d3e8763675e4c425df46cc3b5c0f6cbdac396046").into()),
                     value: U256::from(1000000000000000u64),
                     input: Default::default(),
                 }),
@@ -494,9 +470,7 @@ mod tests {
                     nonce: 1u64,
                     gas_price: 1000000000,
                     gas_limit: 100000u64,
-                    to: TransactionKind::Call(
-                        hex!("d3e8763675e4c425df46cc3b5c0f6cbdac396046").into(),
-                    ),
+                    to: TxKind::Call(hex!("d3e8763675e4c425df46cc3b5c0f6cbdac396046").into()),
                     value: U256::from(693361000000000u64),
                     input: Default::default(),
                 }),
@@ -518,9 +492,7 @@ mod tests {
                     nonce: 2u64,
                     gas_price: 1000000000,
                     gas_limit: 100000u64,
-                    to: TransactionKind::Call(
-                        hex!("d3e8763675e4c425df46cc3b5c0f6cbdac396046").into(),
-                    ),
+                    to: TxKind::Call(hex!("d3e8763675e4c425df46cc3b5c0f6cbdac396046").into()),
                     value: U256::from(1000000000000000u64),
                     input: Default::default(),
                 }),

--- a/crates/net/network/tests/it/requests.rs
+++ b/crates/net/network/tests/it/requests.rs
@@ -12,8 +12,8 @@ use reth_network::{
 };
 use reth_network_api::{NetworkInfo, Peers};
 use reth_primitives::{
-    Block, BlockBody, Bytes, Header, HeadersDirection, Signature, Transaction, TransactionKind,
-    TransactionSigned, TxEip2930, U256,
+    Block, BlockBody, Bytes, Header, HeadersDirection, Signature, Transaction, TransactionSigned,
+    TxEip2930, TxKind, U256,
 };
 use reth_provider::test_utils::MockEthProvider;
 use std::sync::Arc;
@@ -25,7 +25,7 @@ pub fn rng_transaction(rng: &mut impl rand::RngCore) -> TransactionSigned {
         nonce: rng.gen(),
         gas_price: rng.gen(),
         gas_limit: rng.gen(),
-        to: TransactionKind::Create,
+        to: TxKind::Create,
         value: U256::from(rng.gen::<u128>()),
         input: Bytes::from(vec![1, 2]),
         access_list: Default::default(),

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -539,7 +539,7 @@ mod tests {
     use super::*;
     use reth_primitives::{
         b256, Account, Address, Block, ChainSpecBuilder, Signature, StorageKey, StorageValue,
-        Transaction, TransactionKind, TransactionSigned, TxEip1559, BASE_MAINNET,
+        Transaction, TransactionSigned, TxEip1559, TxKind, BASE_MAINNET,
     };
     use reth_revm::{database::StateProviderDatabase, L1_BLOCK_CONTRACT};
     use std::{collections::HashMap, str::FromStr};
@@ -610,7 +610,7 @@ mod tests {
                 chain_id: chain_spec.chain.id(),
                 nonce: 0,
                 gas_limit: 21_000,
-                to: TransactionKind::Call(addr),
+                to: TxKind::Call(addr),
                 ..Default::default()
             }),
             Signature::default(),
@@ -619,7 +619,7 @@ mod tests {
         let tx_deposit = TransactionSigned::from_transaction_and_signature(
             Transaction::Deposit(reth_primitives::TxDeposit {
                 from: addr,
-                to: TransactionKind::Call(addr),
+                to: TxKind::Call(addr),
                 gas_limit: 21_000,
                 ..Default::default()
             }),
@@ -690,7 +690,7 @@ mod tests {
                 chain_id: chain_spec.chain.id(),
                 nonce: 0,
                 gas_limit: 21_000,
-                to: TransactionKind::Call(addr),
+                to: TxKind::Call(addr),
                 ..Default::default()
             }),
             Signature::default(),
@@ -699,7 +699,7 @@ mod tests {
         let tx_deposit = TransactionSigned::from_transaction_and_signature(
             Transaction::Deposit(reth_primitives::TxDeposit {
                 from: addr,
-                to: TransactionKind::Call(addr),
+                to: TxKind::Call(addr),
                 gas_limit: 21_000,
                 ..Default::default()
             }),

--- a/crates/optimism/node/src/txpool.rs
+++ b/crates/optimism/node/src/txpool.rs
@@ -202,8 +202,8 @@ pub struct OpL1BlockInfo {
 mod tests {
     use crate::txpool::OpTransactionValidator;
     use reth_primitives::{
-        Signature, Transaction, TransactionKind, TransactionSigned, TransactionSignedEcRecovered,
-        TxDeposit, MAINNET, U256,
+        Signature, Transaction, TransactionSigned, TransactionSignedEcRecovered, TxDeposit, TxKind,
+        MAINNET, U256,
     };
     use reth_provider::test_utils::MockEthProvider;
     use reth_transaction_pool::{
@@ -225,7 +225,7 @@ mod tests {
         let deposit_tx = Transaction::Deposit(TxDeposit {
             source_hash: Default::default(),
             from: signer,
-            to: TransactionKind::Create,
+            to: TxKind::Create,
             mint: None,
             value: U256::ZERO,
             gas_limit: 0u64,

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -97,7 +97,7 @@ pub use transaction::{
 pub use transaction::{
     util::secp256k1::{public_key_to_address, recover_signer_unchecked, sign_message},
     AccessList, AccessListItem, IntoRecoveredTransaction, InvalidTransactionError, Signature,
-    Transaction, TransactionKind, TransactionMeta, TransactionSigned, TransactionSignedEcRecovered,
+    Transaction, TransactionMeta, TransactionSigned, TransactionSignedEcRecovered,
     TransactionSignedNoHash, TryFromRecoveredTransaction, TxEip1559, TxEip2930, TxEip4844,
     TxHashOrNumber, TxLegacy, TxType, EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID,
     LEGACY_TX_TYPE_ID,
@@ -113,7 +113,7 @@ pub use alloy_primitives::{
     eip191_hash_message, hex, hex_literal, keccak256, ruint,
     utils::format_ether,
     Address, BlockHash, BlockNumber, Bloom, BloomInput, Bytes, ChainId, Selector, StorageKey,
-    StorageValue, TxHash, TxIndex, TxNumber, B128, B256, B512, B64, U128, U256, U64, U8,
+    StorageValue, TxHash, TxIndex, TxKind, TxNumber, B128, B256, B512, B64, U128, U256, U64, U8,
 };
 pub use reth_ethereum_forks::*;
 pub use revm_primitives::{self, JumpMap};

--- a/crates/primitives/src/revm/compat.rs
+++ b/crates/primitives/src/revm/compat.rs
@@ -1,4 +1,4 @@
-use crate::{revm_primitives::AccountInfo, Account, Address, TransactionKind, KECCAK_EMPTY, U256};
+use crate::{revm_primitives::AccountInfo, Account, Address, TxKind, KECCAK_EMPTY, U256};
 use revm::{
     interpreter::gas::validate_initial_tx_gas,
     primitives::{MergeSpec, ShanghaiSpec},
@@ -34,7 +34,7 @@ pub fn into_revm_acc(reth_acc: Account) -> AccountInfo {
 #[inline]
 pub fn calculate_intrinsic_gas_after_merge(
     input: &[u8],
-    kind: &TransactionKind,
+    kind: &TxKind,
     access_list: &[(Address, Vec<U256>)],
     is_shanghai: bool,
 ) -> u64 {

--- a/crates/primitives/src/revm/env.rs
+++ b/crates/primitives/src/revm/env.rs
@@ -2,8 +2,8 @@ use crate::{
     constants::{BEACON_ROOTS_ADDRESS, SYSTEM_ADDRESS},
     recover_signer_unchecked,
     revm_primitives::{BlockEnv, Env, TransactTo, TxEnv},
-    Address, Bytes, Chain, ChainSpec, Header, Transaction, TransactionKind,
-    TransactionSignedEcRecovered, B256, U256,
+    Address, Bytes, Chain, ChainSpec, Header, Transaction, TransactionSignedEcRecovered, TxKind,
+    B256, U256,
 };
 
 #[cfg(feature = "optimism")]
@@ -208,8 +208,8 @@ where
             tx_env.gas_price = U256::from(tx.gas_price);
             tx_env.gas_priority_fee = None;
             tx_env.transact_to = match tx.to {
-                TransactionKind::Call(to) => TransactTo::Call(to),
-                TransactionKind::Create => TransactTo::create(),
+                TxKind::Call(to) => TransactTo::Call(to),
+                TxKind::Create => TransactTo::create(),
             };
             tx_env.value = tx.value;
             tx_env.data = tx.input.clone();
@@ -224,8 +224,8 @@ where
             tx_env.gas_price = U256::from(tx.gas_price);
             tx_env.gas_priority_fee = None;
             tx_env.transact_to = match tx.to {
-                TransactionKind::Call(to) => TransactTo::Call(to),
-                TransactionKind::Create => TransactTo::create(),
+                TxKind::Call(to) => TransactTo::Call(to),
+                TxKind::Create => TransactTo::create(),
             };
             tx_env.value = tx.value;
             tx_env.data = tx.input.clone();
@@ -247,8 +247,8 @@ where
             tx_env.gas_price = U256::from(tx.max_fee_per_gas);
             tx_env.gas_priority_fee = Some(U256::from(tx.max_priority_fee_per_gas));
             tx_env.transact_to = match tx.to {
-                TransactionKind::Call(to) => TransactTo::Call(to),
-                TransactionKind::Create => TransactTo::create(),
+                TxKind::Call(to) => TransactTo::Call(to),
+                TxKind::Create => TransactTo::create(),
             };
             tx_env.value = tx.value;
             tx_env.data = tx.input.clone();
@@ -270,8 +270,8 @@ where
             tx_env.gas_price = U256::from(tx.max_fee_per_gas);
             tx_env.gas_priority_fee = Some(U256::from(tx.max_priority_fee_per_gas));
             tx_env.transact_to = match tx.to {
-                TransactionKind::Call(to) => TransactTo::Call(to),
-                TransactionKind::Create => TransactTo::create(),
+                TxKind::Call(to) => TransactTo::Call(to),
+                TxKind::Create => TransactTo::create(),
             };
             tx_env.value = tx.value;
             tx_env.data = tx.input.clone();
@@ -295,8 +295,8 @@ where
             tx_env.gas_price = U256::ZERO;
             tx_env.gas_priority_fee = None;
             match tx.to {
-                TransactionKind::Call(to) => tx_env.transact_to = TransactTo::Call(to),
-                TransactionKind::Create => tx_env.transact_to = TransactTo::create(),
+                TxKind::Call(to) => tx_env.transact_to = TransactTo::Call(to),
+                TxKind::Create => tx_env.transact_to = TransactTo::create(),
             }
             tx_env.value = tx.value;
             tx_env.data = tx.input.clone();

--- a/crates/primitives/src/transaction/eip1559.rs
+++ b/crates/primitives/src/transaction/eip1559.rs
@@ -1,5 +1,5 @@
 use super::access_list::AccessList;
-use crate::{keccak256, Bytes, ChainId, Signature, TransactionKind, TxType, B256, U256};
+use crate::{keccak256, Bytes, ChainId, Signature, TxKind, TxType, B256, U256};
 use alloy_rlp::{length_of_length, Decodable, Encodable, Header};
 use bytes::BytesMut;
 use reth_codecs::{main_codec, Compact};
@@ -41,7 +41,7 @@ pub struct TxEip1559 {
     pub max_priority_fee_per_gas: u128,
     /// The 160-bit address of the message call’s recipient or, for a contract creation
     /// transaction, ∅, used here to denote the only member of B0 ; formally Tt.
-    pub to: TransactionKind,
+    pub to: TxKind,
     /// A scalar value equal to the number of Wei to
     /// be transferred to the message call’s recipient or,
     /// in the case of contract creation, as an endowment
@@ -226,7 +226,7 @@ impl TxEip1559 {
 mod tests {
     use super::TxEip1559;
     use crate::{
-        transaction::{signature::Signature, TransactionKind},
+        transaction::{signature::Signature, TxKind},
         AccessList, Address, Transaction, TransactionSigned, B256, U256,
     };
     use std::str::FromStr;
@@ -243,7 +243,7 @@ mod tests {
             chain_id: 1,
             nonce: 0x42,
             gas_limit: 44386,
-            to: TransactionKind::Call( hex!("6069a6c32cf691f5982febae4faf8a6f3ab2f0f6").into()),
+            to: TxKind::Call( hex!("6069a6c32cf691f5982febae4faf8a6f3ab2f0f6").into()),
             value: U256::ZERO,
             input:  hex!("a22cb4650000000000000000000000005eee75727d804a2b13038928d36f8b188945a57a0000000000000000000000000000000000000000000000000000000000000000").into(),
             max_fee_per_gas: 0x4a817c800,

--- a/crates/primitives/src/transaction/eip2930.rs
+++ b/crates/primitives/src/transaction/eip2930.rs
@@ -1,5 +1,5 @@
 use super::access_list::AccessList;
-use crate::{keccak256, Bytes, ChainId, Signature, TransactionKind, TxType, B256, U256};
+use crate::{keccak256, Bytes, ChainId, Signature, TxKind, TxType, B256, U256};
 use alloy_rlp::{length_of_length, Decodable, Encodable, Header};
 use bytes::BytesMut;
 use reth_codecs::{main_codec, Compact};
@@ -29,7 +29,7 @@ pub struct TxEip2930 {
     pub gas_limit: u64,
     /// The 160-bit address of the message call’s recipient or, for a contract creation
     /// transaction, ∅, used here to denote the only member of B0 ; formally Tt.
-    pub to: TransactionKind,
+    pub to: TxKind,
     /// A scalar value equal to the number of Wei to
     /// be transferred to the message call’s recipient or,
     /// in the case of contract creation, as an endowment
@@ -189,7 +189,7 @@ impl TxEip2930 {
 mod tests {
     use super::TxEip2930;
     use crate::{
-        transaction::{signature::Signature, TransactionKind},
+        transaction::{signature::Signature, TxKind},
         Address, Bytes, Transaction, TransactionSigned, U256,
     };
     use alloy_rlp::{Decodable, Encodable};
@@ -202,7 +202,7 @@ mod tests {
             nonce: 0,
             gas_price: 1,
             gas_limit: 2,
-            to: TransactionKind::Create,
+            to: TxKind::Create,
             value: U256::from(3),
             input: Bytes::from(vec![1, 2]),
             access_list: Default::default(),
@@ -225,7 +225,7 @@ mod tests {
             nonce: 0,
             gas_price: 1,
             gas_limit: 2,
-            to: TransactionKind::Call(Address::default()),
+            to: TxKind::Call(Address::default()),
             value: U256::from(3),
             input: Bytes::from(vec![1, 2]),
             access_list: Default::default(),

--- a/crates/primitives/src/transaction/eip4844.rs
+++ b/crates/primitives/src/transaction/eip4844.rs
@@ -1,7 +1,7 @@
 use super::access_list::AccessList;
 use crate::{
-    constants::eip4844::DATA_GAS_PER_BLOB, keccak256, Bytes, ChainId, Signature, TransactionKind,
-    TxType, B256, U256,
+    constants::eip4844::DATA_GAS_PER_BLOB, keccak256, Bytes, ChainId, Signature, TxKind, TxType,
+    B256, U256,
 };
 use alloy_rlp::{length_of_length, Decodable, Encodable, Header};
 use reth_codecs::{main_codec, Compact};
@@ -54,7 +54,7 @@ pub struct TxEip4844 {
     pub max_priority_fee_per_gas: u128,
     /// The 160-bit address of the message call’s recipient or, for a contract creation
     /// transaction, ∅, used here to denote the only member of B0 ; formally Tt.
-    pub to: TransactionKind,
+    pub to: TxKind,
     /// A scalar value equal to the number of Wei to
     /// be transferred to the message call’s recipient or,
     /// in the case of contract creation, as an endowment

--- a/crates/primitives/src/transaction/legacy.rs
+++ b/crates/primitives/src/transaction/legacy.rs
@@ -1,4 +1,4 @@
-use crate::{keccak256, Bytes, ChainId, Signature, TransactionKind, TxType, B256, U256};
+use crate::{keccak256, Bytes, ChainId, Signature, TxKind, TxType, B256, U256};
 use alloy_rlp::{length_of_length, Encodable, Header};
 use bytes::BytesMut;
 use reth_codecs::{main_codec, Compact};
@@ -28,7 +28,7 @@ pub struct TxLegacy {
     pub gas_limit: u64,
     /// The 160-bit address of the message call’s recipient or, for a contract creation
     /// transaction, ∅, used here to denote the only member of B0 ; formally Tt.
-    pub to: TransactionKind,
+    pub to: TxKind,
     /// A scalar value equal to the number of Wei to
     /// be transferred to the message call’s recipient or,
     /// in the case of contract creation, as an endowment
@@ -173,7 +173,7 @@ impl TxLegacy {
 mod tests {
     use super::TxLegacy;
     use crate::{
-        transaction::{signature::Signature, TransactionKind},
+        transaction::{signature::Signature, TxKind},
         Address, Transaction, TransactionSigned, B256, U256,
     };
 
@@ -190,7 +190,7 @@ mod tests {
             nonce: 0x18,
             gas_price: 0xfa56ea00,
             gas_limit: 119902,
-            to: TransactionKind::Call( hex!("06012c8cf97bead5deae237070f9587f8e7a266d").into()),
+            to: TxKind::Call( hex!("06012c8cf97bead5deae237070f9587f8e7a266d").into()),
             value: U256::from(0x1c6bf526340000u64),
             input:  hex!("f7d8c88300000000000000000000000000000000000000000000000000000000000cee6100000000000000000000000000000000000000000000000000000000000ac3e1").into(),
         });

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1,6 +1,6 @@
 #[cfg(any(feature = "arbitrary", feature = "zstd-codec"))]
 use crate::compression::{TRANSACTION_COMPRESSOR, TRANSACTION_DECOMPRESSOR};
-use crate::{keccak256, Address, BlockHashOrNumber, Bytes, TxHash, B256, U256};
+use crate::{keccak256, Address, BlockHashOrNumber, Bytes, TxHash, TxKind, B256, U256};
 
 use alloy_eips::eip2718::Eip2718Error;
 use alloy_rlp::{
@@ -176,9 +176,9 @@ impl Transaction {
         }
     }
 
-    /// Gets the transaction's [`TransactionKind`], which is the address of the recipient or
-    /// [`TransactionKind::Create`] if the transaction is a contract creation.
-    pub fn kind(&self) -> &TransactionKind {
+    /// Gets the transaction's [`TxKind`], which is the address of the recipient or
+    /// [`TxKind::Create`] if the transaction is a contract creation.
+    pub fn kind(&self) -> &TxKind {
         match self {
             Transaction::Legacy(TxLegacy { to, .. }) |
             Transaction::Eip2930(TxEip2930 { to, .. }) |
@@ -194,7 +194,7 @@ impl Transaction {
     ///
     /// Returns `None` if this is a `CREATE` transaction.
     pub fn to(&self) -> Option<Address> {
-        self.kind().to()
+        self.kind().to().copied()
     }
 
     /// Get the transaction's type
@@ -641,7 +641,7 @@ impl TryFrom<reth_rpc_types::Transaction> for Transaction {
                         .gas
                         .try_into()
                         .map_err(|_| ConversionError::Eip2718Error(RlpError::Overflow.into()))?,
-                    to: tx.to.map_or(TransactionKind::Create, TransactionKind::Call),
+                    to: tx.to.map_or(TxKind::Create, TxKind::Call),
                     value: tx.value,
                     input: tx.input,
                 }))
@@ -655,7 +655,7 @@ impl TryFrom<reth_rpc_types::Transaction> for Transaction {
                         .gas
                         .try_into()
                         .map_err(|_| ConversionError::Eip2718Error(RlpError::Overflow.into()))?,
-                    to: tx.to.map_or(TransactionKind::Create, TransactionKind::Call),
+                    to: tx.to.map_or(TxKind::Create, TxKind::Call),
                     value: tx.value,
                     input: tx.input,
                     access_list: tx.access_list.ok_or(ConversionError::MissingAccessList)?,
@@ -677,7 +677,7 @@ impl TryFrom<reth_rpc_types::Transaction> for Transaction {
                         .gas
                         .try_into()
                         .map_err(|_| ConversionError::Eip2718Error(RlpError::Overflow.into()))?,
-                    to: tx.to.map_or(TransactionKind::Create, TransactionKind::Call),
+                    to: tx.to.map_or(TxKind::Create, TxKind::Call),
                     value: tx.value,
                     access_list: tx.access_list.ok_or(ConversionError::MissingAccessList)?,
                     input: tx.input,
@@ -698,7 +698,7 @@ impl TryFrom<reth_rpc_types::Transaction> for Transaction {
                         .gas
                         .try_into()
                         .map_err(|_| ConversionError::Eip2718Error(RlpError::Overflow.into()))?,
-                    to: tx.to.map_or(TransactionKind::Create, TransactionKind::Call),
+                    to: tx.to.map_or(TxKind::Create, TxKind::Call),
                     value: tx.value,
                     access_list: tx.access_list.ok_or(ConversionError::MissingAccessList)?,
                     input: tx.input,
@@ -825,118 +825,6 @@ impl Encodable for Transaction {
             Transaction::Eip4844(blob_tx) => blob_tx.payload_len_for_signature(),
             #[cfg(feature = "optimism")]
             Transaction::Deposit(deposit_tx) => deposit_tx.payload_len(),
-        }
-    }
-}
-
-/// Whether or not the transaction is a contract creation.
-#[derive_arbitrary(compact, rlp)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
-pub enum TransactionKind {
-    /// A transaction that creates a contract.
-    #[default]
-    Create,
-    /// A transaction that calls a contract or transfer.
-    Call(Address),
-}
-
-impl TransactionKind {
-    /// Returns the address of the contract that will be called or will receive the transfer.
-    pub fn to(self) -> Option<Address> {
-        match self {
-            TransactionKind::Create => None,
-            TransactionKind::Call(to) => Some(to),
-        }
-    }
-
-    /// Returns true if the transaction is a contract creation.
-    #[inline]
-    pub fn is_create(self) -> bool {
-        matches!(self, TransactionKind::Create)
-    }
-
-    /// Returns true if the transaction is a contract call.
-    #[inline]
-    pub fn is_call(self) -> bool {
-        matches!(self, TransactionKind::Call(_))
-    }
-
-    /// Calculates a heuristic for the in-memory size of the [TransactionKind].
-    #[inline]
-    fn size(self) -> usize {
-        mem::size_of::<Self>()
-    }
-}
-
-impl From<reth_rpc_types::TransactionKind> for TransactionKind {
-    fn from(kind: reth_rpc_types::TransactionKind) -> Self {
-        match kind {
-            reth_rpc_types::TransactionKind::Call(to) => Self::Call(to),
-            reth_rpc_types::TransactionKind::Create => Self::Create,
-        }
-    }
-}
-
-impl Compact for TransactionKind {
-    fn to_compact<B>(self, buf: &mut B) -> usize
-    where
-        B: bytes::BufMut + AsMut<[u8]>,
-    {
-        match self {
-            TransactionKind::Create => 0,
-            TransactionKind::Call(address) => {
-                address.to_compact(buf);
-                1
-            }
-        }
-    }
-
-    fn from_compact(buf: &[u8], identifier: usize) -> (Self, &[u8]) {
-        match identifier {
-            0 => (TransactionKind::Create, buf),
-            1 => {
-                let (addr, buf) = Address::from_compact(buf, buf.len());
-                (TransactionKind::Call(addr), buf)
-            }
-            _ => unreachable!("Junk data in database: unknown TransactionKind variant"),
-        }
-    }
-}
-
-impl Encodable for TransactionKind {
-    /// This encodes the `to` field of a transaction request.
-    /// If the [TransactionKind] is a [TransactionKind::Call] it will encode the inner address:
-    /// `rlp(address)`
-    ///
-    /// If the [TransactionKind] is a [TransactionKind::Create] it will encode an empty list:
-    /// `rlp([])`, which is also
-    fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
-        match self {
-            TransactionKind::Call(to) => to.encode(out),
-            TransactionKind::Create => out.put_u8(EMPTY_STRING_CODE),
-        }
-    }
-
-    fn length(&self) -> usize {
-        match self {
-            TransactionKind::Call(to) => to.length(),
-            TransactionKind::Create => 1, // EMPTY_STRING_CODE is a single byte
-        }
-    }
-}
-
-impl Decodable for TransactionKind {
-    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        if let Some(&first) = buf.first() {
-            if first == EMPTY_STRING_CODE {
-                buf.advance(1);
-                Ok(TransactionKind::Create)
-            } else {
-                let addr = <Address as Decodable>::decode(buf)?;
-                Ok(TransactionKind::Call(addr))
-            }
-        } else {
-            Err(RlpError::InputTooShort)
         }
     }
 }
@@ -1856,10 +1744,10 @@ mod tests {
     use crate::{
         hex, sign_message,
         transaction::{
-            from_compact_zstd_unaware, signature::Signature, to_compact_ztd_unaware,
-            TransactionKind, TxEip1559, TxLegacy, MIN_LENGTH_EIP1559_TX_ENCODED,
-            MIN_LENGTH_EIP2930_TX_ENCODED, MIN_LENGTH_EIP4844_TX_ENCODED,
-            MIN_LENGTH_LEGACY_TX_ENCODED, PARALLEL_SENDER_RECOVERY_THRESHOLD,
+            from_compact_zstd_unaware, signature::Signature, to_compact_ztd_unaware, TxEip1559,
+            TxKind, TxLegacy, MIN_LENGTH_EIP1559_TX_ENCODED, MIN_LENGTH_EIP2930_TX_ENCODED,
+            MIN_LENGTH_EIP4844_TX_ENCODED, MIN_LENGTH_LEGACY_TX_ENCODED,
+            PARALLEL_SENDER_RECOVERY_THRESHOLD,
         },
         Address, Bytes, Transaction, TransactionSigned, TransactionSignedEcRecovered,
         TransactionSignedNoHash, TxEip2930, TxEip4844, B256, U256,
@@ -1881,13 +1769,13 @@ mod tests {
     fn raw_kind_encoding_sanity() {
         // check the 0x80 encoding for Create
         let mut buf = Vec::new();
-        TransactionKind::Create.encode(&mut buf);
+        TxKind::Create.encode(&mut buf);
         assert_eq!(buf, vec![0x80]);
 
         // check decoding
         let buf = [0x80];
-        let decoded = TransactionKind::decode(&mut &buf[..]).unwrap();
-        assert_eq!(decoded, TransactionKind::Create);
+        let decoded = TxKind::decode(&mut &buf[..]).unwrap();
+        assert_eq!(decoded, TxKind::Create);
     }
 
     #[test]
@@ -1963,7 +1851,7 @@ mod tests {
             nonce: 2,
             gas_price: 1000000000,
             gas_limit: 100000,
-            to: TransactionKind::Call(
+            to: TxKind::Call(
                 Address::from_str("d3e8763675e4c425df46cc3b5c0f6cbdac396046").unwrap(),
             ),
             value: U256::from(1000000000000000u64),
@@ -1985,7 +1873,7 @@ mod tests {
             nonce: 1u64,
             gas_price: 1000000000,
             gas_limit: 100000u64,
-            to: TransactionKind::Call(Address::from_slice(
+            to: TxKind::Call(Address::from_slice(
                 &hex!("d3e8763675e4c425df46cc3b5c0f6cbdac396046")[..],
             )),
             value: U256::from(693361000000000u64),
@@ -2006,7 +1894,7 @@ mod tests {
             nonce: 3,
             gas_price: 2000000000,
             gas_limit: 10000000,
-            to: TransactionKind::Call(Address::from_slice(
+            to: TxKind::Call(Address::from_slice(
                 &hex!("d3e8763675e4c425df46cc3b5c0f6cbdac396046")[..],
             )),
             value: U256::from(1000000000000000u64),
@@ -2028,7 +1916,7 @@ mod tests {
             max_priority_fee_per_gas: 1500000000,
             max_fee_per_gas: 1500000013,
             gas_limit: 21000,
-            to: TransactionKind::Call(Address::from_slice(
+            to: TxKind::Call(Address::from_slice(
                 &hex!("61815774383099e24810ab832a5b2a5425c154d5")[..],
             )),
             value: U256::from(3000000000000000000u64),
@@ -2050,7 +1938,7 @@ mod tests {
             nonce: 15,
             gas_price: 2200000000,
             gas_limit: 34811,
-            to: TransactionKind::Call(Address::from_slice(
+            to: TxKind::Call(Address::from_slice(
                 &hex!("cf7f9e66af820a19257a2108375b180b0ec49167")[..],
             )),
             value: U256::from(1234),
@@ -2339,7 +2227,7 @@ mod tests {
                 nonce: 2,
                 gas_price: 1000000000,
                 gas_limit: 100000,
-                to: TransactionKind::Call(
+                to: TxKind::Call(
                     Address::from_str("d3e8763675e4c425df46cc3b5c0f6cbdac396046").unwrap(),
                 ),
                 value: U256::from(1000000000000000u64),
@@ -2388,7 +2276,7 @@ mod tests {
             nonce: 2,
             gas_price: 1000000000,
             gas_limit: 100000,
-            to: TransactionKind::Call(
+            to: TxKind::Call(
                 Address::from_str("d3e8763675e4c425df46cc3b5c0f6cbdac396046").unwrap(),
             ),
             value: U256::from(1000000000000000u64),

--- a/crates/primitives/src/transaction/optimism.rs
+++ b/crates/primitives/src/transaction/optimism.rs
@@ -1,4 +1,4 @@
-use crate::{Address, Bytes, TransactionKind, TxType, B256, U256};
+use crate::{Address, Bytes, TxKind, TxType, B256, U256};
 use alloy_rlp::{
     length_of_length, Decodable, Encodable, Error as DecodeError, Header, EMPTY_STRING_CODE,
 };
@@ -16,7 +16,7 @@ pub struct TxDeposit {
     pub from: Address,
     /// The address of the recipient account, or the null (zero-length) address if the deposited
     /// transaction is a contract creation.
-    pub to: TransactionKind,
+    pub to: TxKind,
     /// The ETH value to mint on L2.
     pub mint: Option<u128>,
     ///  The ETH value to send to the recipient account.
@@ -169,7 +169,7 @@ mod tests {
         let original = TxDeposit {
             source_hash: B256::default(),
             from: Address::default(),
-            to: TransactionKind::default(),
+            to: TxKind::default(),
             mint: Some(100),
             value: U256::default(),
             gas_limit: 50000,
@@ -189,7 +189,7 @@ mod tests {
         let tx_deposit = TxDeposit {
             source_hash: B256::default(),
             from: Address::default(),
-            to: TransactionKind::default(),
+            to: TxKind::default(),
             mint: Some(100),
             value: U256::default(),
             gas_limit: 50000,
@@ -211,7 +211,7 @@ mod tests {
         let tx_deposit = TxDeposit {
             source_hash: B256::default(),
             from: Address::default(),
-            to: TransactionKind::default(),
+            to: TxKind::default(),
             mint: Some(100),
             value: U256::default(),
             gas_limit: 50000,

--- a/crates/revm/src/optimism/processor.rs
+++ b/crates/revm/src/optimism/processor.rs
@@ -206,7 +206,7 @@ mod tests {
     };
     use reth_primitives::{
         b256, Account, Address, Block, ChainSpecBuilder, Header, Signature, StorageKey,
-        StorageValue, Transaction, TransactionKind, TransactionSigned, TxEip1559, BASE_MAINNET,
+        StorageValue, Transaction, TransactionSigned, TxEip1559, TxKind, BASE_MAINNET,
     };
     use revm::L1_BLOCK_CONTRACT;
     use std::{collections::HashMap, str::FromStr, sync::Arc};
@@ -278,7 +278,7 @@ mod tests {
                 chain_id: chain_spec.chain.id(),
                 nonce: 0,
                 gas_limit: 21_000,
-                to: TransactionKind::Call(addr),
+                to: TxKind::Call(addr),
                 ..Default::default()
             }),
             Signature::default(),
@@ -287,7 +287,7 @@ mod tests {
         let tx_deposit = TransactionSigned::from_transaction_and_signature(
             Transaction::Deposit(reth_primitives::TxDeposit {
                 from: addr,
-                to: TransactionKind::Call(addr),
+                to: TxKind::Call(addr),
                 gas_limit: 21_000,
                 ..Default::default()
             }),
@@ -352,7 +352,7 @@ mod tests {
                 chain_id: chain_spec.chain.id(),
                 nonce: 0,
                 gas_limit: 21_000,
-                to: TransactionKind::Call(addr),
+                to: TxKind::Call(addr),
                 ..Default::default()
             }),
             Signature::default(),
@@ -361,7 +361,7 @@ mod tests {
         let tx_deposit = TransactionSigned::from_transaction_and_signature(
             Transaction::Deposit(reth_primitives::TxDeposit {
                 from: addr,
-                to: TransactionKind::Call(addr),
+                to: TxKind::Call(addr),
                 gas_limit: 21_000,
                 ..Default::default()
             }),

--- a/crates/revm/src/processor.rs
+++ b/crates/revm/src/processor.rs
@@ -466,7 +466,7 @@ mod tests {
         bytes,
         constants::{BEACON_ROOTS_ADDRESS, EIP1559_INITIAL_BASE_FEE, SYSTEM_ADDRESS},
         keccak256, Account, Bytes, ChainSpecBuilder, ForkCondition, Signature, Transaction,
-        TransactionKind, TxEip1559, MAINNET,
+        TxEip1559, TxKind, MAINNET,
     };
     use revm::{Database, TransitionState};
     use std::collections::HashMap;
@@ -855,7 +855,7 @@ mod tests {
                 chain_id,
                 nonce: 1,
                 gas_limit: 21_000,
-                to: TransactionKind::Call(Address::ZERO),
+                to: TxKind::Call(Address::ZERO),
                 max_fee_per_gas: EIP1559_INITIAL_BASE_FEE as u128,
                 ..Default::default()
             }),

--- a/crates/rpc/rpc-types-compat/src/transaction/mod.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction/mod.rs
@@ -2,8 +2,8 @@
 use alloy_rpc_types::request::{TransactionInput, TransactionRequest};
 
 use reth_primitives::{
-    BlockNumber, Transaction as PrimitiveTransaction, TransactionKind as PrimitiveTransactionKind,
-    TransactionSignedEcRecovered, TxType, B256,
+    BlockNumber, Transaction as PrimitiveTransaction, TransactionSignedEcRecovered,
+    TxKind as PrimitiveTransactionKind, TxType, B256,
 };
 #[cfg(feature = "optimism")]
 use reth_rpc_types::optimism::OptimismTransactionFields;

--- a/crates/rpc/rpc-types-compat/src/transaction/typed.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction/typed.rs
@@ -16,7 +16,7 @@ pub fn to_primitive_transaction(
             nonce: tx.nonce,
             gas_price: tx.gas_price.to(),
             gas_limit: tx.gas_limit.try_into().ok()?,
-            to: tx.kind.into(),
+            to: to_primitive_transaction_kind(tx.kind),
             value: tx.value,
             input: tx.input,
         }),
@@ -25,7 +25,7 @@ pub fn to_primitive_transaction(
             nonce: tx.nonce,
             gas_price: tx.gas_price.to(),
             gas_limit: tx.gas_limit.try_into().ok()?,
-            to: tx.kind.into(),
+            to: to_primitive_transaction_kind(tx.kind),
             value: tx.value,
             input: tx.input,
             access_list: tx.access_list,
@@ -35,7 +35,7 @@ pub fn to_primitive_transaction(
             nonce: tx.nonce,
             max_fee_per_gas: tx.max_fee_per_gas.to(),
             gas_limit: tx.gas_limit.try_into().ok()?,
-            to: tx.kind.into(),
+            to: to_primitive_transaction_kind(tx.kind),
             value: tx.value,
             input: tx.input,
             access_list: tx.access_list,
@@ -47,7 +47,7 @@ pub fn to_primitive_transaction(
             gas_limit: tx.gas_limit.to(),
             max_fee_per_gas: tx.max_fee_per_gas.to(),
             max_priority_fee_per_gas: tx.max_priority_fee_per_gas.to(),
-            to: tx.kind.into(),
+            to: to_primitive_transaction_kind(tx.kind),
             value: tx.value,
             access_list: tx.access_list,
             blob_versioned_hashes: tx.blob_versioned_hashes,
@@ -55,4 +55,14 @@ pub fn to_primitive_transaction(
             input: tx.input,
         }),
     })
+}
+
+/// Transforms a [reth_rpc_types::TransactionKind] into a [reth_primitives::TransactionKind]
+pub fn to_primitive_transaction_kind(
+    kind: reth_rpc_types::TransactionKind,
+) -> reth_primitives::TxKind {
+    match kind {
+        reth_rpc_types::TransactionKind::Call(to) => reth_primitives::TxKind::Call(to),
+        reth_rpc_types::TransactionKind::Create => reth_primitives::TxKind::Create,
+    }
 }

--- a/crates/rpc/rpc-types-compat/src/transaction/typed.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction/typed.rs
@@ -57,7 +57,7 @@ pub fn to_primitive_transaction(
     })
 }
 
-/// Transforms a [reth_rpc_types::TransactionKind] into a [reth_primitives::TransactionKind]
+/// Transforms a [reth_rpc_types::TransactionKind] into a [reth_primitives::TxKind]
 pub fn to_primitive_transaction_kind(
     kind: reth_rpc_types::TransactionKind,
 ) -> reth_primitives::TxKind {

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -15,9 +15,10 @@ use reth_primitives::{
     eip4844::calc_blob_gasprice,
     revm::env::{fill_block_env_with_coinbase, tx_env_with_recovered},
     Address, BlockId, BlockNumberOrTag, Bytes, FromRecoveredPooledTransaction, Header,
-    IntoRecoveredTransaction, Receipt, SealedBlock, SealedBlockWithSenders,
-    TransactionKind::{Call, Create},
-    TransactionMeta, TransactionSigned, TransactionSignedEcRecovered, B256, U256,
+    IntoRecoveredTransaction, Receipt, SealedBlock, SealedBlockWithSenders, TransactionMeta,
+    TransactionSigned, TransactionSignedEcRecovered,
+    TxKind::{Call, Create},
+    B256, U256,
 };
 use reth_provider::{
     BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, StateProviderBox, StateProviderFactory,

--- a/crates/storage/codecs/derive/src/compact/generator.rs
+++ b/crates/storage/codecs/derive/src/compact/generator.rs
@@ -58,12 +58,7 @@ fn generate_from_compact(fields: &FieldList, ident: &Ident, is_zstd: bool) -> To
     // it's hard to figure out with derive_macro which types have Bytes fields.
     //
     // This removes the requirement of the field to be placed last in the struct.
-    known_types.extend_from_slice(&[
-        "TransactionKind",
-        "AccessList",
-        "Signature",
-        "CheckpointBlockRange",
-    ]);
+    known_types.extend_from_slice(&["TxKind", "AccessList", "Signature", "CheckpointBlockRange"]);
 
     // let mut handle = FieldListHandler::new(fields);
     let is_enum = fields.iter().any(|field| matches!(field, FieldTypes::EnumVariant(_)));

--- a/crates/storage/codecs/derive/src/compact/mod.rs
+++ b/crates/storage/codecs/derive/src/compact/mod.rs
@@ -161,7 +161,7 @@ fn should_use_alt_impl(ftype: &String, segment: &syn::PathSegment) -> bool {
 /// length.
 pub fn get_bit_size(ftype: &str) -> u8 {
     match ftype {
-        "TransactionKind" | "bool" | "Option" | "Signature" => 1,
+        "TransactionKind" | "TxKind" | "bool" | "Option" | "Signature" => 1,
         "TxType" => 2,
         "u64" | "BlockNumber" | "TxNumber" | "ChainId" | "NumTransactions" => 4,
         "u128" => 5,

--- a/crates/transaction-pool/src/test_utils/gen.rs
+++ b/crates/transaction-pool/src/test_utils/gen.rs
@@ -2,8 +2,8 @@ use crate::EthPooledTransaction;
 use rand::Rng;
 use reth_primitives::{
     constants::MIN_PROTOCOL_BASE_FEE, sign_message, AccessList, Address, Bytes, Transaction,
-    TransactionKind, TransactionSigned, TryFromRecoveredTransaction, TxEip1559, TxEip4844,
-    TxLegacy, B256, MAINNET, U256,
+    TransactionSigned, TryFromRecoveredTransaction, TxEip1559, TxEip4844, TxKind, TxLegacy, B256,
+    MAINNET, U256,
 };
 
 /// A generator for transactions for testing purposes.
@@ -129,7 +129,7 @@ pub struct TransactionBuilder {
     /// processing.
     pub max_priority_fee_per_gas: u128,
     /// The recipient or contract address of the transaction.
-    pub to: TransactionKind,
+    pub to: TxKind,
     /// The value to be transferred in the transaction.
     pub value: U256,
     /// The list of addresses and storage keys that the transaction can access.
@@ -246,7 +246,7 @@ impl TransactionBuilder {
 
     /// Sets the recipient or contract address for the transaction builder.
     pub const fn to(mut self, to: Address) -> Self {
-        self.to = TransactionKind::Call(to);
+        self.to = TxKind::Call(to);
         self
     }
 
@@ -306,7 +306,7 @@ impl TransactionBuilder {
 
     /// Sets the recipient or contract address for the transaction, mutable reference version.
     pub fn set_to(&mut self, to: Address) -> &mut Self {
-        self.to = TransactionKind::Call(to);
+        self.to = TxKind::Call(to);
         self
     }
 

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -16,8 +16,8 @@ use reth_primitives::{
     transaction::TryFromRecoveredTransactionError,
     AccessList, Address, BlobTransactionSidecar, Bytes, FromRecoveredPooledTransaction,
     IntoRecoveredTransaction, PooledTransactionsElementEcRecovered, Signature, Transaction,
-    TransactionKind, TransactionSigned, TransactionSignedEcRecovered, TryFromRecoveredTransaction,
-    TxEip1559, TxEip2930, TxEip4844, TxHash, TxLegacy, TxType, B256, EIP1559_TX_TYPE_ID,
+    TransactionSigned, TransactionSignedEcRecovered, TryFromRecoveredTransaction, TxEip1559,
+    TxEip2930, TxEip4844, TxHash, TxKind, TxLegacy, TxType, B256, EIP1559_TX_TYPE_ID,
     EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID, LEGACY_TX_TYPE_ID, U256,
 };
 use std::{ops::Range, sync::Arc, time::Instant, vec::IntoIter};
@@ -105,7 +105,7 @@ pub enum MockTransaction {
         /// The gas limit for the transaction.
         gas_limit: u64,
         /// The transaction's destination.
-        to: TransactionKind,
+        to: TxKind,
         /// The value of the transaction.
         value: U256,
         /// The transaction input data.
@@ -128,7 +128,7 @@ pub enum MockTransaction {
         /// The gas limit for the transaction.
         gas_limit: u64,
         /// The transaction's destination.
-        to: TransactionKind,
+        to: TxKind,
         /// The value of the transaction.
         value: U256,
         /// The access list associated with the transaction.
@@ -155,7 +155,7 @@ pub enum MockTransaction {
         /// The gas limit for the transaction.
         gas_limit: u64,
         /// The transaction's destination.
-        to: TransactionKind,
+        to: TxKind,
         /// The value of the transaction.
         value: U256,
         /// The access list associated with the transaction.
@@ -176,7 +176,7 @@ pub enum MockTransaction {
         /// The transaction nonce.
         nonce: u64,
         /// The transaction's destination.
-        to: TransactionKind,
+        to: TxKind,
         /// The gas limit for the transaction.
         gas_limit: u64,
         /// The transaction input data.
@@ -213,7 +213,7 @@ impl MockTransaction {
             nonce: 0,
             gas_price: 0,
             gas_limit: 0,
-            to: TransactionKind::Call(Address::random()),
+            to: TxKind::Call(Address::random()),
             value: Default::default(),
             input: Default::default(),
             size: Default::default(),
@@ -229,7 +229,7 @@ impl MockTransaction {
             max_fee_per_gas: MIN_PROTOCOL_BASE_FEE as u128,
             max_priority_fee_per_gas: MIN_PROTOCOL_BASE_FEE as u128,
             gas_limit: 0,
-            to: TransactionKind::Call(Address::random()),
+            to: TxKind::Call(Address::random()),
             value: Default::default(),
             input: Bytes::new(),
             accesslist: Default::default(),
@@ -247,7 +247,7 @@ impl MockTransaction {
             max_priority_fee_per_gas: MIN_PROTOCOL_BASE_FEE as u128,
             max_fee_per_blob_gas: DATA_GAS_PER_BLOB as u128,
             gas_limit: 0,
-            to: TransactionKind::Call(Address::random()),
+            to: TxKind::Call(Address::random()),
             value: Default::default(),
             input: Bytes::new(),
             accesslist: Default::default(),
@@ -272,7 +272,7 @@ impl MockTransaction {
             hash: B256::random(),
             sender: Address::random(),
             nonce: 0,
-            to: TransactionKind::Call(Address::random()),
+            to: TxKind::Call(Address::random()),
             gas_limit: 0,
             input: Bytes::new(),
             value: Default::default(),
@@ -671,7 +671,7 @@ impl PoolTransaction for MockTransaction {
     }
 
     /// Returns the transaction kind associated with the transaction.
-    fn kind(&self) -> &TransactionKind {
+    fn kind(&self) -> &TxKind {
         match self {
             MockTransaction::Legacy { to, .. } |
             MockTransaction::Eip1559 { to, .. } |

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -13,9 +13,9 @@ use reth_primitives::{
     kzg::KzgSettings, transaction::TryFromRecoveredTransactionError, AccessList, Address,
     BlobTransactionSidecar, BlobTransactionValidationError, FromRecoveredPooledTransaction,
     IntoRecoveredTransaction, PeerId, PooledTransactionsElement,
-    PooledTransactionsElementEcRecovered, SealedBlock, Transaction, TransactionKind,
-    TransactionSignedEcRecovered, TryFromRecoveredTransaction, TxEip4844, TxHash, B256,
-    EIP1559_TX_TYPE_ID, EIP4844_TX_TYPE_ID, U256,
+    PooledTransactionsElementEcRecovered, SealedBlock, Transaction, TransactionSignedEcRecovered,
+    TryFromRecoveredTransaction, TxEip4844, TxHash, TxKind, B256, EIP1559_TX_TYPE_ID,
+    EIP4844_TX_TYPE_ID, U256,
 };
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -811,14 +811,14 @@ pub trait PoolTransaction:
     /// otherwise returns the gas price.
     fn priority_fee_or_price(&self) -> u128;
 
-    /// Returns the transaction's [`TransactionKind`], which is the address of the recipient or
-    /// [`TransactionKind::Create`] if the transaction is a contract creation.
-    fn kind(&self) -> &TransactionKind;
+    /// Returns the transaction's [`TxKind`], which is the address of the recipient or
+    /// [`TxKind::Create`] if the transaction is a contract creation.
+    fn kind(&self) -> &TxKind;
 
-    /// Returns the recipient of the transaction if it is not a [TransactionKind::Create]
+    /// Returns the recipient of the transaction if it is not a [TxKind::Create]
     /// transaction.
     fn to(&self) -> Option<Address> {
-        (*self.kind()).to()
+        (*self.kind()).to().copied()
     }
 
     /// Returns the input data of this transaction.
@@ -1056,9 +1056,9 @@ impl PoolTransaction for EthPooledTransaction {
         self.transaction.priority_fee_or_price()
     }
 
-    /// Returns the transaction's [`TransactionKind`], which is the address of the recipient or
-    /// [`TransactionKind::Create`] if the transaction is a contract creation.
-    fn kind(&self) -> &TransactionKind {
+    /// Returns the transaction's [`TxKind`], which is the address of the recipient or
+    /// [`TxKind::Create`] if the transaction is a contract creation.
+    fn kind(&self) -> &TxKind {
         self.transaction.kind()
     }
 


### PR DESCRIPTION
First draft to see if it is going in the right direction.

Closes  #7690

Replaces reth primitives::TransactionKind to alloy TxKind, and updates deps.



Side note: the reth_rpc_types TransactionKind is still named 'TransactionKind', should it be renamed to TxKind to maintain parity?