### PR TITLE
chore: add `node-*` crates to `CODEOWNERS`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,6 +7,9 @@ crates/exex                 @onbjerg @shekhirin
 crates/metrics              @onbjerg
 crates/net/                 @emhane @mattsse @Rjected
 crates/net/downloaders/     @onbjerg @rkrasiuk
+crates/node-builder/        @mattsse @Rjected @onbjerg
+crates/node-core/           @mattsse @Rjected @onbjerg
+crates/node-ethereum/       @mattsse @Rjected
 crates/payload/             @mattsse @Rjected
 crates/prune                @shekhirin @joshieDo
 crates/revm/src/            @rakita


### PR DESCRIPTION
Added them based on:

1. @mattsse and @Rjected worked together on `node-builder`
2. For `node-core` there's some code in there that used to be in CLI I have a pretty good overview of
3. I am already reviewing `node-builder` PRs

Think this needs approve from @Rjected / @mattsse and if someone else wants in they should also say so

Ref https://github.com/paradigmxyz/reth/issues/7864