### PR TITLE
fix(provider): remove unnecessary parameter and check database instead

### DIFF
--- a/crates/node-core/src/init.rs
+++ b/crates/node-core/src/init.rs
@@ -123,7 +123,7 @@ pub fn insert_genesis_state<'a, 'b, DB: Database>(
     capacity: usize,
     alloc: impl Iterator<Item = (&'a Address, &'b GenesisAccount)>,
 ) -> ProviderResult<()> {
-    insert_state::<DB>(tx, capacity, alloc, 0, false)
+    insert_state::<DB>(tx, capacity, alloc, 0)
 }
 
 /// Inserts state at given block into database.
@@ -357,7 +357,6 @@ pub fn init_from_state_dump<DB: Database>(
                 accounts.len(),
                 accounts.iter().map(|(address, account)| (address, account)),
                 block,
-                false,
             )?;
 
             accounts.clear();

--- a/crates/node-core/src/init.rs
+++ b/crates/node-core/src/init.rs
@@ -131,8 +131,7 @@ pub fn insert_state<'a, 'b, DB: Database>(
     tx: &<DB as Database>::TXMut,
     capacity: usize,
     alloc: impl Iterator<Item = (&'a Address, &'b GenesisAccount)>,
-    block: u64,
-    append_only: bool,
+    block: u64
 ) -> ProviderResult<()> {
     let mut state_init: BundleStateInit = HashMap::with_capacity(capacity);
     let mut reverts_init = HashMap::with_capacity(capacity);
@@ -190,7 +189,7 @@ pub fn insert_state<'a, 'b, DB: Database>(
         block,
     );
 
-    bundle.write_to_storage_with_mode(tx, None, OriginalValuesKnown::Yes, append_only)?;
+    bundle.write_to_storage(tx, None, OriginalValuesKnown::Yes)?;
 
     trace!(target: "reth::cli", "Inserted state");
 

--- a/crates/node-core/src/init.rs
+++ b/crates/node-core/src/init.rs
@@ -131,7 +131,7 @@ pub fn insert_state<'a, 'b, DB: Database>(
     tx: &<DB as Database>::TXMut,
     capacity: usize,
     alloc: impl Iterator<Item = (&'a Address, &'b GenesisAccount)>,
-    block: u64
+    block: u64,
 ) -> ProviderResult<()> {
     let mut state_init: BundleStateInit = HashMap::with_capacity(capacity);
     let mut reverts_init = HashMap::with_capacity(capacity);

--- a/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
+++ b/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
@@ -294,47 +294,23 @@ impl BundleStateWithReceipts {
     }
 
     /// Write the [BundleStateWithReceipts] to database and receipts to either database or static
-    /// files, when [BundleStateWithReceipts] contains all values that will be written to the given
-    /// keys. See [`write_to_storage_with_mode`](Self::write_to_storage_with_mode).
-    pub fn write_to_storage<TX>(
-        self,
-        tx: &TX,
-        static_file_producer: Option<StaticFileProviderRWRefMut<'_>>,
-        is_value_known: OriginalValuesKnown,
-    ) -> ProviderResult<()>
-    where
-        TX: DbTxMut + DbTx,
-    {
-        self.write_to_storage_with_mode(tx, static_file_producer, is_value_known, true)
-    }
-
-    /// Write the [BundleStateWithReceipts] to database and receipts to either database or static
     /// files if `static_file_producer` is `Some`. It should be none if there is any kind of
     /// pruning/filtering over the receipts.
     ///
     /// `omit_changed_check` should be set to true if bundle has some of its data detached. This
     /// would make some original values not known.
-    ///
-    /// Performance gains are made if can be guaranteed that [BundleStateWithReceipts] contains all
-    /// data that will be written to the respective keys. For chunked writes to same keys, pass
-    /// `false` to 'exhaustive_data_for_keys' parameter.
-    pub fn write_to_storage_with_mode<TX>(
+    pub fn write_to_storage<TX>(
         self,
         tx: &TX,
         mut static_file_producer: Option<StaticFileProviderRWRefMut<'_>>,
         is_value_known: OriginalValuesKnown,
-        exhaustive_data_for_keys: bool,
     ) -> ProviderResult<()>
     where
         TX: DbTxMut + DbTx,
     {
         let (plain_state, reverts) = self.bundle.into_plain_state_and_reverts(is_value_known);
 
-        StateReverts(reverts).write_to_db_with_mode(
-            tx,
-            self.first_block,
-            exhaustive_data_for_keys,
-        )?;
+        StateReverts(reverts).write_to_db(tx, self.first_block)?;
 
         // write receipts
         let mut bodies_cursor = tx.cursor_read::<tables::BlockBodyIndices>()?;

--- a/crates/storage/provider/src/bundle_state/state_reverts.rs
+++ b/crates/storage/provider/src/bundle_state/state_reverts.rs
@@ -33,7 +33,9 @@ impl StateReverts {
         tracing::trace!(target: "provider::reverts", "Writing storage changes");
         let mut storages_cursor = tx.cursor_dup_write::<tables::PlainStorageState>()?;
         let mut storage_changeset_cursor = tx.cursor_dup_write::<tables::StorageChangeSets>()?;
-        let should_append_storage = storage_changeset_cursor.last()?.map_or(true, |(key, _)| key.block_number() < first_block);
+        let should_append_storage = storage_changeset_cursor
+            .last()?
+            .map_or(true, |(key, _)| key.block_number() < first_block);
         for (block_index, mut storage_changes) in self.0.storage.into_iter().enumerate() {
             let block_number = first_block + block_index as BlockNumber;
 
@@ -68,9 +70,12 @@ impl StateReverts {
                 tracing::trace!(target: "provider::reverts", %address, ?storage, "Writing storage reverts");
                 for (key, value) in StorageRevertsIter::new(storage, wiped_storage) {
                     if should_append_storage {
-                        storage_changeset_cursor.append_dup(storage_id, StorageEntry { key, value })?;
+                        storage_changeset_cursor
+                            .append_dup(storage_id, StorageEntry { key, value })?;
                     } else {
-                        if let Some(entry) = storage_changeset_cursor.seek_by_key_subkey(storage_id, key)? {
+                        if let Some(entry) =
+                            storage_changeset_cursor.seek_by_key_subkey(storage_id, key)?
+                        {
                             if entry.key == key {
                                 tracing::warn!(target: "provider::reverts", ?storage_id, ?entry, "Overwriting storage changeset entry");
                                 storage_changeset_cursor.delete_current()?;
@@ -86,7 +91,9 @@ impl StateReverts {
         // Write account changes
         tracing::trace!(target: "provider::reverts", "Writing account changes");
         let mut account_changeset_cursor = tx.cursor_dup_write::<tables::AccountChangeSets>()?;
-        let should_append_accounts = account_changeset_cursor.last()?.map_or(true, |(block_number, _)| block_number < first_block);
+        let should_append_accounts = account_changeset_cursor
+            .last()?
+            .map_or(true, |(block_number, _)| block_number < first_block);
         for (block_index, mut account_block_reverts) in self.0.accounts.into_iter().enumerate() {
             let block_number = first_block + block_index as BlockNumber;
             // Sort accounts by address.
@@ -99,7 +106,9 @@ impl StateReverts {
                         AccountBeforeTx { address, info: info.map(into_reth_acc) },
                     )?;
                 } else {
-                    if let Some(entry) = account_changeset_cursor.seek_by_key_subkey(block_number, address)? {
+                    if let Some(entry) =
+                        account_changeset_cursor.seek_by_key_subkey(block_number, address)?
+                    {
                         if entry.address == address {
                             tracing::warn!(target: "provider::reverts", block_number, ?entry, "Overwriting account changeset entry");
                             account_changeset_cursor.delete_current()?;

--- a/crates/storage/provider/src/bundle_state/state_reverts.rs
+++ b/crates/storage/provider/src/bundle_state/state_reverts.rs
@@ -21,32 +21,19 @@ impl From<PlainStateReverts> for StateReverts {
 }
 
 impl StateReverts {
-    /// Write reverts to database, when [`StateReverts`] contains all values that will be inserted
-    /// for the given keys. See [`write_to_db_with_mode`](Self::write_to_db_with_mode).
+    /// Write reverts to database.
+    ///
+    /// Note:: Reverts will delete all wiped storage from plain state.
     pub fn write_to_db<TX: DbTxMut + DbTx>(
         self,
         tx: &TX,
         first_block: BlockNumber,
     ) -> Result<(), DatabaseError> {
-        self.write_to_db_with_mode(tx, first_block, true)
-    }
-
-    /// Write reverts to database.
-    ///
-    /// Passing `true` to to 'exhaustive_data_for_keys' parameter, will bring slight performance
-    /// gain, but will panic if values are not all that will be inserted for any given key.
-    ///
-    /// Note:: Reverts will delete all wiped storage from plain state.
-    pub fn write_to_db_with_mode<TX: DbTxMut + DbTx>(
-        self,
-        tx: &TX,
-        first_block: BlockNumber,
-        exhaustive_data_for_keys: bool,
-    ) -> Result<(), DatabaseError> {
         // Write storage changes
         tracing::trace!(target: "provider::reverts", "Writing storage changes");
         let mut storages_cursor = tx.cursor_dup_write::<tables::PlainStorageState>()?;
         let mut storage_changeset_cursor = tx.cursor_dup_write::<tables::StorageChangeSets>()?;
+        let should_append_storage = storage_changeset_cursor.last()?.map_or(true, |(key, _)| key.block_number() < first_block);
         for (block_index, mut storage_changes) in self.0.storage.into_iter().enumerate() {
             let block_number = first_block + block_index as BlockNumber;
 
@@ -69,7 +56,7 @@ impl StateReverts {
                 // See [StorageWipe::Primary] for more details.
                 let mut wiped_storage = Vec::new();
                 if wiped {
-                    tracing::trace!(target: "provider::reverts", ?address, "Wiping storage");
+                    tracing::trace!(target: "provider::reverts", %address, "Wiping storage");
                     if let Some((_, entry)) = storages_cursor.seek_exact(address)? {
                         wiped_storage.push((entry.key, entry.value));
                         while let Some(entry) = storages_cursor.next_dup_val()? {
@@ -78,9 +65,23 @@ impl StateReverts {
                     }
                 }
 
-                tracing::trace!(target: "provider::reverts", ?address, ?storage, "Writing storage reverts");
+                tracing::trace!(target: "provider::reverts", %address, ?storage, "Writing storage reverts");
                 for (key, value) in StorageRevertsIter::new(storage, wiped_storage) {
-                    storage_changeset_cursor.append_dup(storage_id, StorageEntry { key, value })?;
+                    if should_append_storage {
+                        storage_changeset_cursor.append_dup(storage_id, StorageEntry { key, value })?;
+                    } else {
+                        if let Some(entry) = storage_changeset_cursor.seek_by_key_subkey(storage_id, key)? {
+                            if entry.key == key {
+                                tracing::warn!(target: "provider::reverts", ?storage_id, ?entry, "Overwriting storage changeset entry");
+                                storage_changeset_cursor.delete_current()?;
+                            }
+                        }
+
+                        // TODO: fix this comment
+                        // upsert on dupsort tables will append to subkey. see implementation of
+                        // DbCursorRW::upsert for reth_db::implementation::mdbx::cursor::Cursor<RW, _>
+                        storage_changeset_cursor.upsert(storage_id, StorageEntry { key, value })?;
+                    }
                 }
             }
         }
@@ -88,18 +89,27 @@ impl StateReverts {
         // Write account changes
         tracing::trace!(target: "provider::reverts", "Writing account changes");
         let mut account_changeset_cursor = tx.cursor_dup_write::<tables::AccountChangeSets>()?;
+        let should_append_accounts = account_changeset_cursor.last()?.map_or(true, |(block_number, _)| block_number < first_block);
         for (block_index, mut account_block_reverts) in self.0.accounts.into_iter().enumerate() {
             let block_number = first_block + block_index as BlockNumber;
             // Sort accounts by address.
             account_block_reverts.par_sort_by_key(|a| a.0);
 
             for (address, info) in account_block_reverts {
-                if exhaustive_data_for_keys {
+                if should_append_accounts {
                     account_changeset_cursor.append_dup(
                         block_number,
                         AccountBeforeTx { address, info: info.map(into_reth_acc) },
                     )?;
                 } else {
+                    if let Some(entry) = account_changeset_cursor.seek_by_key_subkey(block_number, address)? {
+                        if entry.address == address {
+                            tracing::warn!(target: "provider::reverts", block_number, ?entry, "Overwriting account changeset entry");
+                            account_changeset_cursor.delete_current()?;
+                        }
+                    }
+
+                    // TODO: fix this comment
                     // upsert on dupsort tables will append to subkey. see implementation of
                     // DbCursorRW::upsert for reth_db::implementation::mdbx::cursor::Cursor<RW, _>
                     account_changeset_cursor.upsert(

--- a/crates/storage/provider/src/bundle_state/state_reverts.rs
+++ b/crates/storage/provider/src/bundle_state/state_reverts.rs
@@ -77,9 +77,6 @@ impl StateReverts {
                             }
                         }
 
-                        // TODO: fix this comment
-                        // upsert on dupsort tables will append to subkey. see implementation of
-                        // DbCursorRW::upsert for reth_db::implementation::mdbx::cursor::Cursor<RW, _>
                         storage_changeset_cursor.upsert(storage_id, StorageEntry { key, value })?;
                     }
                 }
@@ -109,9 +106,6 @@ impl StateReverts {
                         }
                     }
 
-                    // TODO: fix this comment
-                    // upsert on dupsort tables will append to subkey. see implementation of
-                    // DbCursorRW::upsert for reth_db::implementation::mdbx::cursor::Cursor<RW, _>
                     account_changeset_cursor.upsert(
                         block_number,
                         AccountBeforeTx { address, info: info.map(into_reth_acc) },


### PR DESCRIPTION
## Description

Remove unnecessary `exhaustive_data_for_keys` parameter and `*_with_mode` variations of state and changeset write methods and check the database instead for whether we can append data.