### PR TITLE
saturating operations for `v` in `Signature`

### DIFF
--- a/crates/primitives/src/transaction/signature.rs
+++ b/crates/primitives/src/transaction/signature.rs
@@ -82,7 +82,7 @@ impl Signature {
             // EIP-155: v = {0, 1} + CHAIN_ID * 2 + 35
             (self.odd_y_parity as u64).saturating_add(chain_id.saturating_mul(2)).saturating_add(35)
         } else {
-            (self.odd_y_parity as u64).saturating_add(27)
+            self.odd_y_parity as u64 + 27
         }
     }
 

--- a/crates/primitives/src/transaction/signature.rs
+++ b/crates/primitives/src/transaction/signature.rs
@@ -80,9 +80,9 @@ impl Signature {
     pub fn v(&self, chain_id: Option<u64>) -> u64 {
         if let Some(chain_id) = chain_id {
             // EIP-155: v = {0, 1} + CHAIN_ID * 2 + 35
-            self.odd_y_parity as u64 + chain_id * 2 + 35
+            (self.odd_y_parity as u64).saturating_add(chain_id.saturating_mul(2)).saturating_add(35)
         } else {
-            self.odd_y_parity as u64 + 27
+            (self.odd_y_parity as u64).saturating_add(27)
         }
     }
 


### PR DESCRIPTION
Saturating operations for `v` in `Signature` to avoid potential overflow.