### PR TITLE
feat: support max_request_body_size

### DIFF
--- a/crates/rpc/ipc/src/server/ipc.rs
+++ b/crates/rpc/ipc/src/server/ipc.rs
@@ -149,7 +149,10 @@ where
 
     let data = request.into_bytes();
     if data.len() > max_request_body_size {
-        return Some(batch_response_error(Id::Null, reject_too_big_request(max_request_body_size as u32)));
+        return Some(batch_response_error(
+            Id::Null,
+            reject_too_big_request(max_request_body_size as u32),
+        ));
     }
 
     // Single request or notification

--- a/crates/rpc/ipc/src/server/ipc.rs
+++ b/crates/rpc/ipc/src/server/ipc.rs
@@ -149,10 +149,7 @@ where
 
     let data = request.into_bytes();
     if data.len() > max_request_body_size {
-        return Some(batch_response_error(
-            Id::Null,
-            reject_too_big_request(max_request_body_size as u32),
-        ));
+        return Some(batch_response_error(Id::Null, reject_too_big_request(max_request_body_size as u32)));
     }
 
     // Single request or notification


### PR DESCRIPTION
This PR introduces support for limiting the maximum size of the request body in the IPC server. 