### PR TITLE
fix: account for legacy tx in `try_from` tx to `TransactionSignedEcRecovered`

### DIFF
--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1734,11 +1734,17 @@ impl TryFrom<reth_rpc_types::Transaction> for TransactionSignedEcRecovered {
                 r: signature.r,
                 s: signature.s,
                 odd_y_parity: match transaction.tx_type() {
+                    // If the transaction type is Legacy, adjust the v component of the signature
+                    // according to the Ethereum specification
                     TxType::Legacy => {
+                        // Calculate the new v value based on the EIP-155 formula:
+                        // v = {0,1} + CHAIN_ID * 2 + 35
                         signature.v -
                             U256::from(if let Some(chain_id) = transaction.chain_id() {
+                                // If CHAIN_ID is available, calculate the new v value accordingly
                                 chain_id.saturating_mul(2).saturating_add(35)
                             } else {
+                                // If CHAIN_ID is not available, set v = {0,1} + 27
                                 27
                             })
                     }

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1733,7 +1733,7 @@ impl TryFrom<reth_rpc_types::Transaction> for TransactionSignedEcRecovered {
             Signature {
                 r: signature.r,
                 s: signature.s,
-                odd_y_parity: match transaction.clone().tx_type() {
+                odd_y_parity: match transaction.tx_type() {
                     TxType::Legacy => {
                         signature.v -
                             U256::from(if let Some(chain_id) = transaction.chain_id() {

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1742,7 +1742,7 @@ impl TryFrom<reth_rpc_types::Transaction> for TransactionSignedEcRecovered {
                         TxType::Legacy => {
                             // Calculate the new v value based on the EIP-155 formula:
                             // v = {0,1} + CHAIN_ID * 2 + 35
-                            (signature.v -
+                            !(signature.v -
                                 U256::from(if let Some(chain_id) = transaction.chain_id() {
                                     // If CHAIN_ID is available, calculate the new v value
                                     // accordingly
@@ -1751,12 +1751,9 @@ impl TryFrom<reth_rpc_types::Transaction> for TransactionSignedEcRecovered {
                                     // If CHAIN_ID is not available, set v = {0,1} + 27
                                     27
                                 }))
-                            .try_into()
-                            .map_err(|_| ConversionError::InvalidSignature)?
+                            .is_zero()
                         }
-                        _ => {
-                            signature.v.try_into().map_err(|_| ConversionError::InvalidSignature)?
-                        }
+                        _ => !signature.v.is_zero(),
                     }
                 },
             },


### PR DESCRIPTION
In order to take into account `TxType::Legacy`, the conversion from `reth_rpc_types::Transaction` to `TransactionSignedEcRecovered` is fixed in order to properly calculate the `odd_y_parity` considering EIP-155:

> If block.number >= FORK_BLKNUM and CHAIN_ID is available, then when computing the hash of a transaction for the purposes of signing, instead of hashing only six rlp encoded elements (nonce, gasprice, startgas, to, value, data), you SHOULD hash nine rlp encoded elements (nonce, gasprice, startgas, to, value, data, chainid, 0, 0). If you do, then the v of the signature MUST be set to {0,1} + CHAIN_ID * 2 + 35 where {0,1} is the parity of the y value of the curve point for which r is the x-value in the secp256k1 signing process. If you choose to only hash 6 values, then v continues to be set to {0,1} + 27 as previously.

Reference: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md