### PR TITLE
fix: chain spec for op mainnet

### DIFF
--- a/crates/ethereum-forks/src/hardfork.rs
+++ b/crates/ethereum-forks/src/hardfork.rs
@@ -73,6 +73,9 @@ pub enum Hardfork {
     // Upcoming
     /// Prague: <https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/prague.md>
     Prague,
+    /// Fjord: <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/superchain-upgrades.md#fjord>
+    #[cfg(feature = "optimism")]
+    Fjord,
 }
 
 impl Hardfork {

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -267,7 +267,7 @@ pub static OP_MAINNET: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
         genesis: serde_json::from_str(include_str!("../../res/genesis/optimism.json"))
             .expect("Can't deserialize Optimism Mainnet genesis json"),
         genesis_hash: Some(b256!(
-            "438335a20d98863a4c0c97999eb2481921ccd28553eac6f913af7c12aec04108"
+            "7ca38a1916c42007829c55e69d3e9a73265554b586a499015373241b8a3fa48b"
         )),
         fork_timestamps: ForkTimestamps::default()
             .shanghai(1704992401)

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -267,13 +267,13 @@ pub static OP_MAINNET: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
         genesis: serde_json::from_str(include_str!("../../res/genesis/optimism.json"))
             .expect("Can't deserialize Optimism Mainnet genesis json"),
         genesis_hash: Some(b256!(
-            "7ca38a1916c42007829c55e69d3e9a73265554b586a499015373241b8a3fa48b"
+            "438335a20d98863a4c0c97999eb2481921ccd28553eac6f913af7c12aec04108"
         )),
         fork_timestamps: ForkTimestamps::default()
-            .shanghai(1699981200)
-            .canyon(1699981200)
-            .cancun(1707238800)
-            .ecotone(1707238800),
+            .shanghai(1704992401)
+            .canyon(1704992401)
+            .cancun(1710374401)
+            .ecotone(1710374401),
         paris_block_and_final_difficulty: Some((0, U256::from(0))),
         hardforks: BTreeMap::from([
             (Hardfork::Frontier, ForkCondition::Block(0)),
@@ -286,12 +286,12 @@ pub static OP_MAINNET: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
             (Hardfork::Istanbul, ForkCondition::Block(0)),
             (Hardfork::MuirGlacier, ForkCondition::Block(0)),
             (Hardfork::Berlin, ForkCondition::Block(3950000)),
-            (Hardfork::London, ForkCondition::Block(3950000)),
-            (Hardfork::ArrowGlacier, ForkCondition::Block(3950000)),
-            (Hardfork::GrayGlacier, ForkCondition::Block(3950000)),
+            (Hardfork::London, ForkCondition::Block(105235063)),
+            (Hardfork::ArrowGlacier, ForkCondition::Block(105235063)),
+            (Hardfork::GrayGlacier, ForkCondition::Block(105235063)),
             (
                 Hardfork::Paris,
-                ForkCondition::TTD { fork_block: Some(3950000), total_difficulty: U256::from(0) },
+                ForkCondition::TTD { fork_block: Some(105235063), total_difficulty: U256::from(0) },
             ),
             (Hardfork::Bedrock, ForkCondition::Block(105235063)),
             (Hardfork::Regolith, ForkCondition::Timestamp(0)),


### PR DESCRIPTION
Fixes OP mainnet chain spec values to be accurate

pre-bedrock and genesis hash: https://github.com/ethereum-optimism/superchain-registry/commit/8164f8fabf5f86985aa5c05b231b99f3b37029d5#diff-4af356ce4f4544de484e1881acbfbc3a8c5166549246549f373d000432edccea

regolith: https://github.com/ethereum-optimism/superchain-registry/commit/8164f8fabf5f86985aa5c05b231b99f3b37029d5#diff-1878bd2f063fba4f17ec4a7babce8fda33d71925c9d4a0288021bf3ca7b1b13b

canyon and ecotone: https://github.com/ethereum-optimism/superchain-registry/blob/main/superchain/configs/mainnet/superchain.yaml

Motivation: base fee checks were active too early when copying chain spec from https://github.com/testinprod-io/op-erigon/pull/61/files#diff-25b40269eff3a4c00ef131e50f46c87f691f5fd9cf8cbce2a76fb6769204451d leading to failed import in reth since we pass blocks through the pipeline which includes validation of blocks