### PR TITLE
chore: decrease local pending block expiration time

### DIFF
--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -355,7 +355,7 @@ where
             let now = Instant::now();
             *lock = Some(PendingBlock {
                 block: pending_block.clone(),
-                expires_at: now + Duration::from_secs(3),
+                expires_at: now + Duration::from_secs(1),
             });
 
             Ok(Some(pending_block))


### PR DESCRIPTION
matches geth's new default

> The pending block can still be constructed on demand for now. Whenever an RPC method is called that is based on the pending block, Geth will generate it on the fly and cache it for 1 second for subsequent calls. The first such call will have a few hundred ms execution delay.

https://github.com/ethereum/go-ethereum/releases/tag/v1.14.0