### PR TITLE
fix: use enrforkid in dns

### DIFF
--- a/crates/ethereum-forks/src/forkid.rs
+++ b/crates/ethereum-forks/src/forkid.rs
@@ -119,7 +119,7 @@ pub struct ForkId {
 /// EIP-868. Forward compatibility is achieved by allowing trailing fields.
 ///
 /// See:
-/// <https://github.com/ethereum/go-ethereum/blob/9244d5cd61f3ea5a7645fdf2a1a96d53421e412f/eth/protocols/eth/discovery.go#L27-L38>
+/// <https://github.com/ethereum/devp2p/blob/master/enr-entries/eth.md#entry-format>
 ///
 /// for how geth implements ForkId values and forward compatibility.
 #[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]

--- a/crates/ethereum-forks/src/forkid.rs
+++ b/crates/ethereum-forks/src/forkid.rs
@@ -115,6 +115,32 @@ pub struct ForkId {
     pub next: u64,
 }
 
+/// Represents a forward-compatible ENR entry for including the forkid in a node record via
+/// EIP-868. Forward compatibility is achieved by allowing trailing fields.
+///
+/// See:
+/// <https://github.com/ethereum/go-ethereum/blob/9244d5cd61f3ea5a7645fdf2a1a96d53421e412f/eth/protocols/eth/discovery.go#L27-L38>
+///
+/// for how geth implements ForkId values and forward compatibility.
+#[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[rlp(trailing)]
+pub struct EnrForkIdEntry {
+    /// The inner forkid
+    pub fork_id: ForkId,
+}
+
+impl From<ForkId> for EnrForkIdEntry {
+    fn from(fork_id: ForkId) -> Self {
+        Self { fork_id }
+    }
+}
+
+impl From<EnrForkIdEntry> for ForkId {
+    fn from(entry: EnrForkIdEntry) -> Self {
+        entry.fork_id
+    }
+}
+
 /// Reason for rejecting provided `ForkId`.
 #[derive(Clone, Copy, Debug, Error, PartialEq, Eq, Hash)]
 pub enum ValidationError {

--- a/crates/ethereum-forks/src/lib.rs
+++ b/crates/ethereum-forks/src/lib.rs
@@ -20,7 +20,9 @@ mod forkid;
 mod hardfork;
 mod head;
 
-pub use forkid::{ForkFilter, ForkFilterKey, ForkHash, ForkId, ForkTransition, ValidationError};
+pub use forkid::{
+    EnrForkIdEntry, ForkFilter, ForkFilterKey, ForkHash, ForkId, ForkTransition, ValidationError,
+};
 pub use hardfork::Hardfork;
 pub use head::Head;
 

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -28,7 +28,6 @@ use crate::{
     error::{DecodePacketError, Discv4Error},
     proto::{FindNode, Message, Neighbours, Packet, Ping, Pong},
 };
-use alloy_rlp::{RlpDecodable, RlpEncodable};
 use discv5::{
     kbucket,
     kbucket::{
@@ -2174,33 +2173,13 @@ pub enum DiscoveryUpdate {
     Batch(Vec<DiscoveryUpdate>),
 }
 
-/// Represents a forward-compatible ENR entry for including the forkid in a node record via
-/// EIP-868. Forward compatibility is achieved by allowing trailing fields.
-///
-/// See:
-/// <https://github.com/ethereum/go-ethereum/blob/9244d5cd61f3ea5a7645fdf2a1a96d53421e412f/eth/protocols/eth/discovery.go#L27-L38>
-///
-/// for how geth implements ForkId values and forward compatibility.
-#[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
-#[rlp(trailing)]
-pub struct EnrForkIdEntry {
-    /// The inner forkid
-    pub fork_id: ForkId,
-}
-
-impl From<ForkId> for EnrForkIdEntry {
-    fn from(fork_id: ForkId) -> Self {
-        Self { fork_id }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::test_utils::{create_discv4, create_discv4_with_config, rng_endpoint, rng_record};
     use alloy_rlp::{Decodable, Encodable};
     use rand::{thread_rng, Rng};
-    use reth_primitives::{hex, mainnet_nodes, ForkHash};
+    use reth_primitives::{hex, mainnet_nodes, EnrForkIdEntry, ForkHash};
     use std::future::poll_fn;
 
     #[tokio::test]

--- a/crates/net/discv4/src/proto.rs
+++ b/crates/net/discv4/src/proto.rs
@@ -1,11 +1,11 @@
 //! Discovery v4 protocol implementation.
 
-use crate::{error::DecodePacketError, EnrForkIdEntry, PeerId, MAX_PACKET_SIZE, MIN_PACKET_SIZE};
+use crate::{error::DecodePacketError, PeerId, MAX_PACKET_SIZE, MIN_PACKET_SIZE};
 use alloy_rlp::{Decodable, Encodable, Error as RlpError, Header, RlpDecodable, RlpEncodable};
 use enr::Enr;
 use reth_primitives::{
     bytes::{Buf, BufMut, Bytes, BytesMut},
-    keccak256, pk2id, ForkId, NodeRecord, B256,
+    keccak256, pk2id, EnrForkIdEntry, ForkId, NodeRecord, B256,
 };
 use secp256k1::{
     ecdsa::{RecoverableSignature, RecoveryId},
@@ -261,7 +261,7 @@ impl EnrResponse {
     /// See also <https://github.com/ethereum/go-ethereum/blob/9244d5cd61f3ea5a7645fdf2a1a96d53421e412f/eth/protocols/eth/discovery.go#L36>
     pub fn eth_fork_id(&self) -> Option<ForkId> {
         let mut maybe_fork_id = self.enr.get_raw_rlp(b"eth")?;
-        EnrForkIdEntry::decode(&mut maybe_fork_id).ok().map(|entry| entry.fork_id)
+        EnrForkIdEntry::decode(&mut maybe_fork_id).ok().map(Into::into)
     }
 }
 

--- a/crates/net/network/src/discovery.rs
+++ b/crates/net/network/src/discovery.rs
@@ -7,12 +7,12 @@ use crate::{
 };
 use enr::Enr;
 use futures::StreamExt;
-use reth_discv4::{DiscoveryUpdate, Discv4, Discv4Config, EnrForkIdEntry};
+use reth_discv4::{DiscoveryUpdate, Discv4, Discv4Config};
 use reth_discv5::{DiscoveredPeer, Discv5};
 use reth_dns_discovery::{
     DnsDiscoveryConfig, DnsDiscoveryHandle, DnsDiscoveryService, DnsNodeRecordUpdate, DnsResolver,
 };
-use reth_primitives::{ForkId, NodeRecord, PeerId};
+use reth_primitives::{EnrForkIdEntry, ForkId, NodeRecord, PeerId};
 use secp256k1::SecretKey;
 use std::{
     collections::VecDeque,


### PR DESCRIPTION
I remember now why this did not work, because the forkid is in a list:

https://github.com/ethereum/go-ethereum/blob/ad4fb2c7291972a1940dbb276ed1b6f49906767c/eth/protocols/eth/discovery.go#L26-L32

with this fix DNS now decodes them properly:

```
[crates/net/dns/src/lib.rs:409:5] &fork_id = Some(
    ForkId {
        hash: ForkHash(
            "9b192ad0",
        ),
        next: 0,
    },
)
[crates/net/dns/src/lib.rs:409:5] &fork_id = Some(
    ForkId {
        hash: ForkHash(
            "9b192ad0",
        ),
        next: 0,
    },
)
```

@emhane the discv5 impl is likely also affected by this
