### PR TITLE
fix(discv5): fork id list in ENR

### DIFF
--- a/crates/net/discv5/src/config.rs
+++ b/crates/net/discv5/src/config.rs
@@ -9,7 +9,7 @@ use std::{
 use derive_more::Display;
 use discv5::ListenConfig;
 use multiaddr::{Multiaddr, Protocol};
-use reth_primitives::{Bytes, ForkId, NodeRecord, MAINNET};
+use reth_primitives::{Bytes, EnrForkIdEntry, ForkId, NodeRecord, MAINNET};
 
 use crate::{enr::discv4_id_to_multiaddr_id, filter::MustNotIncludeKeys, network_key};
 
@@ -50,7 +50,7 @@ impl ConfigBuilder {
         let Config {
             discv5_config,
             bootstrap_nodes,
-            fork,
+            fork: (network_key, fork_id),
             tcp_port,
             other_enr_kv_pairs,
             lookup_interval,
@@ -60,7 +60,7 @@ impl ConfigBuilder {
         Self {
             discv5_config: Some(discv5_config),
             bootstrap_nodes,
-            fork: Some(fork),
+            fork: Some((network_key, fork_id.fork_id)),
             tcp_port,
             other_enr_kv_pairs,
             lookup_interval: Some(lookup_interval),
@@ -160,7 +160,8 @@ impl ConfigBuilder {
         let discv5_config = discv5_config
             .unwrap_or_else(|| discv5::ConfigBuilder::new(ListenConfig::default()).build());
 
-        let fork = fork.unwrap_or((network_key::ETH, MAINNET.latest_fork_id()));
+        let (network_key, fork_id) = fork.unwrap_or((network_key::ETH, MAINNET.latest_fork_id()));
+        let fork = (network_key, fork_id.into());
 
         let lookup_interval = lookup_interval.unwrap_or(DEFAULT_SECONDS_LOOKUP_INTERVAL);
 
@@ -188,8 +189,8 @@ pub struct Config {
     /// Nodes to boot from.
     pub(super) bootstrap_nodes: HashSet<BootNode>,
     /// Fork kv-pair to set in local node record. Identifies which network/chain/fork the node
-    /// belongs, e.g. `(b"opstack", ChainId)` or `(b"eth", ForkId)`.
-    pub(super) fork: (&'static [u8], ForkId),
+    /// belongs, e.g. `(b"opstack", ChainId)` or `(b"eth", [ForkId])`.
+    pub(super) fork: (&'static [u8], EnrForkIdEntry),
     /// RLPx TCP port to advertise.
     pub(super) tcp_port: u16,
     /// Additional kv-pairs (besides tcp port, udp port and fork) that should be advertised to

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -17,13 +17,12 @@ use std::{
 };
 
 use ::enr::Enr;
-use alloy_rlp::Decodable;
 use discv5::ListenConfig;
 use enr::{discv4_id_to_discv5_id, EnrCombinedKeyWrapper};
 use futures::future::join_all;
 use itertools::Itertools;
 use rand::{Rng, RngCore};
-use reth_primitives::{bytes::Bytes, ForkId, NodeRecord, PeerId};
+use reth_primitives::{bytes::Bytes, EnrForkIdEntry, ForkId, NodeRecord, PeerId};
 use secp256k1::SecretKey;
 use tokio::{sync::mpsc, task};
 use tracing::{debug, error, trace};
@@ -489,9 +488,12 @@ impl Discv5 {
         enr: &discv5::enr::Enr<K>,
     ) -> Result<ForkId, Error> {
         let key = self.fork_key;
-        let mut fork_id_bytes = enr.get_raw_rlp(key).ok_or(Error::ForkMissing(key))?;
+        let fork_id = enr
+            .get_decodable::<EnrForkIdEntry>(key)
+            .ok_or(Error::ForkMissing(key))?
+            .map(Into::into)?;
 
-        Ok(ForkId::decode(&mut fork_id_bytes)?)
+        Ok(fork_id)
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -834,7 +836,7 @@ mod tests {
         let (enr, _, _, _) = Discv5::build_local_enr(&sk, &config);
 
         let decoded_fork_id =
-            ForkId::decode(&mut enr.get_raw_rlp(network_key::ETH).unwrap()).unwrap();
+            enr.get_decodable::<EnrForkIdEntry>(network_key::ETH).unwrap().map(Into::into).unwrap();
 
         assert_eq!(fork_id, decoded_fork_id);
         assert_eq!(TCP_PORT, enr.tcp4().unwrap()); // listen config is defaulting to ip mode ipv4


### PR DESCRIPTION
Advertises fork ID in ENR as single element list, as according to spec. See https://github.com/paradigmxyz/reth/pull/7900.

closes #7901