### PR TITLE
chore(sync): add block number to body validation error

### DIFF
--- a/crates/interfaces/src/p2p/error.rs
+++ b/crates/interfaces/src/p2p/error.rs
@@ -158,12 +158,12 @@ pub enum DownloadError {
 
     /* ==================== BODIES ERRORS ==================== */
     /// Block validation failed
-    #[error("failed to validate body for header {hash}: {error}")]
+    #[error("failed to validate body for header {hash}, block number {number}: {error}")]
     BodyValidation {
-        /// Hash of header failing validation
+        /// Hash of body failing validation
         hash: B256,
-        /// Number of header failing validation
-+        number: u64,
+        /// Number of body failing validation
+        number: u64,
         /// The details of validation failure
         #[source]
         error: Box<ConsensusError>,

--- a/crates/interfaces/src/p2p/error.rs
+++ b/crates/interfaces/src/p2p/error.rs
@@ -160,9 +160,9 @@ pub enum DownloadError {
     /// Block validation failed
     #[error("failed to validate body for header {hash}, block number {number}: {error}")]
     BodyValidation {
-        /// Hash of body failing validation
+        /// Hash of the block failing validation
         hash: B256,
-        /// Number of body failing validation
+        /// Number of the block failing validation
         number: u64,
         /// The details of validation failure
         #[source]

--- a/crates/interfaces/src/p2p/error.rs
+++ b/crates/interfaces/src/p2p/error.rs
@@ -162,6 +162,8 @@ pub enum DownloadError {
     BodyValidation {
         /// Hash of header failing validation
         hash: B256,
+        /// Number of header failing validation
++        number: u64,
         /// The details of validation failure
         #[source]
         error: Box<ConsensusError>,

--- a/crates/net/downloaders/src/bodies/request.rs
+++ b/crates/net/downloaders/src/bodies/request.rs
@@ -184,8 +184,13 @@ where
                 if let Err(error) = self.consensus.validate_block(&block) {
                     // Body is invalid, put the header back and return an error
                     let hash = block.hash();
+                    let number = block.number;
                     self.pending_headers.push_front(block.header);
-                    return Err(DownloadError::BodyValidation { hash, error: Box::new(error) })
+                    return Err(DownloadError::BodyValidation {
+                        hash,
+                        number,
+                        error: Box::new(error),
+                    })
                 }
 
                 self.buffer.push(BlockResponse::Full(block));


### PR DESCRIPTION
Adds block number to body validation error. This makes it easy to check out the block in block scanner.