### PR TITLE
refactor: remove futureUnordered in ipc

### DIFF
--- a/crates/rpc/ipc/src/server/connection.rs
+++ b/crates/rpc/ipc/src/server/connection.rs
@@ -23,6 +23,8 @@ where
     T: AsyncRead + AsyncWrite + Unpin,
 {
     /// Create a response for when the server is busy and can't accept more requests.
+    /// todo(abner) remove it
+    #[allow(dead_code)]
     pub(crate) async fn reject_connection(self) {
         let mut parts = self.0.into_parts();
         let _ = parts.io.write_all(b"Too many connections. Please try again later.").await;

--- a/crates/rpc/ipc/src/server/connection.rs
+++ b/crates/rpc/ipc/src/server/connection.rs
@@ -9,7 +9,7 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::codec::Framed;
 use tower::Service;
 
@@ -17,19 +17,6 @@ pub(crate) type JsonRpcStream<T> = Framed<T, StreamCodec>;
 
 #[pin_project::pin_project]
 pub(crate) struct IpcConn<T>(#[pin] pub(crate) T);
-
-impl<T> IpcConn<JsonRpcStream<T>>
-where
-    T: AsyncRead + AsyncWrite + Unpin,
-{
-    /// Create a response for when the server is busy and can't accept more requests.
-    /// todo(abner) remove it
-    #[allow(dead_code)]
-    pub(crate) async fn reject_connection(self) {
-        let mut parts = self.0.into_parts();
-        let _ = parts.io.write_all(b"Too many connections. Please try again later.").await;
-    }
-}
 
 impl<T> Stream for IpcConn<JsonRpcStream<T>>
 where

--- a/crates/rpc/ipc/src/server/ipc.rs
+++ b/crates/rpc/ipc/src/server/ipc.rs
@@ -1,7 +1,5 @@
 //! IPC request handling adapted from [`jsonrpsee`] http request handling
 
-use std::sync::Arc;
-
 use futures::{stream::FuturesOrdered, StreamExt};
 use jsonrpsee::{
     batch_response_error,
@@ -17,6 +15,7 @@ use jsonrpsee::{
     },
     BatchResponseBuilder, MethodResponse, ResponsePayload,
 };
+use std::sync::Arc;
 use tokio::sync::OwnedSemaphorePermit;
 use tokio_util::either::Either;
 use tracing::instrument;

--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -8,14 +8,13 @@ use futures::StreamExt;
 use futures_util::{future::Either, AsyncWriteExt};
 use interprocess::local_socket::tokio::{LocalSocketListener, LocalSocketStream};
 use jsonrpsee::{
-    batch_response_error,
     core::TEN_MB_SIZE_BYTES,
     server::{
         middleware::rpc::{RpcLoggerLayer, RpcServiceT},
         AlreadyStoppedError, ConnectionGuard, ConnectionPermit, IdProvider,
         RandomIntegerIdProvider,
     },
-    types::{ErrorObjectOwned, Id},
+    types::{ErrorObjectOwned},
     BoundedSubscriptions, MethodSink, Methods,
 };
 use std::{
@@ -170,7 +169,7 @@ where
                 AcceptConnection::Established { local_socket_stream, stop } => {
                     let Some(conn_permit) = connection_guard.try_acquire() else {
                         let (mut _reader, mut writer) = local_socket_stream.into_split();
-                        let _ = writer.write_all(batch_response_error(Id::Null, reject_too_many_connection()).as_ref()).await;
+                        let _ = writer.write_all(b"Too many connections. Please try again later.").await;
                         drop((_reader, writer));
                         stopped = stop;
                         continue;

--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -982,14 +982,6 @@ mod tests {
         let client = IpcClientBuilder::default().build(endpoint).await.unwrap();
         let response: String = client.request("eth_chainId", rpc_params![]).await.unwrap();
         assert_eq!(response, msg);
-        let response: String = client.request("eth_chainId", rpc_params![]).await.unwrap();
-        assert_eq!(response, msg);
-        let response: String = client.request("eth_chainId", rpc_params![]).await.unwrap();
-        assert_eq!(response, msg);
-        let response: String = client.request("eth_chainId", rpc_params![]).await.unwrap();
-        assert_eq!(response, msg);
-        let response: String = client.request("eth_chainId", rpc_params![]).await.unwrap();
-        assert_eq!(response, msg);
     }
 
     #[tokio::test]

--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -14,7 +14,6 @@ use jsonrpsee::{
         AlreadyStoppedError, ConnectionGuard, ConnectionPermit, IdProvider,
         RandomIntegerIdProvider,
     },
-    types::{ErrorObjectOwned},
     BoundedSubscriptions, MethodSink, Methods,
 };
 use std::{
@@ -47,9 +46,6 @@ mod connection;
 mod future;
 mod ipc;
 mod rpc_service;
-
-/// Connection limit was exceeded.
-pub const TOO_MANY_CONNECTION_CODE: i32 = -32011;
 
 /// Ipc Server implementation
 
@@ -417,15 +413,6 @@ where
 
         Box::pin(async move { f.await.map_err(|err| err.into()) })
     }
-}
-
-/// Helper to get a `JSON-RPC` error object when the maximum request size limit have been exceeded.
-pub fn reject_too_many_connection() -> ErrorObjectOwned {
-    ErrorObjectOwned::owned(
-        TOO_MANY_CONNECTION_CODE,
-        "Too Many Connections",
-        Some("Too many connections. Please try again later"),
-    )
 }
 
 struct ProcessConnection<'a, HttpMiddleware, RpcMiddleware> {


### PR DESCRIPTION
close https://github.com/paradigmxyz/reth/issues/7916
Furthermore, it adds a test `can_set_max_connections` for verifying `max_connection` works. 