### PR TITLE
chore: finish up flag size check test

### DIFF
--- a/crates/storage/codecs/derive/src/compact/flags.rs
+++ b/crates/storage/codecs/derive/src/compact/flags.rs
@@ -61,12 +61,7 @@ pub(crate) fn generate_flag_struct(
             pub const fn bitflag_encoded_bytes() -> usize {
                 #total_bytes as usize
             }
-
-            #[doc = #bitflag_unused_bits]
-            pub const fn bitflag_unused_bits() -> usize {
-                #unused_bits as usize
-            }
-        }
+       }
         pub use #mod_flags_ident::#flags_ident;
         #[allow(non_snake_case)]
         mod #mod_flags_ident {

--- a/crates/storage/codecs/derive/src/compact/flags.rs
+++ b/crates/storage/codecs/derive/src/compact/flags.rs
@@ -52,7 +52,6 @@ pub(crate) fn generate_flag_struct(
     let docs =
         format!("Fieldset that facilitates compacting the parent type. Used bytes: {total_bytes} | Unused bits: {unused_bits}");
     let bitflag_encoded_bytes = format!("Used bytes by [`{flags_ident}`]");
-    let bitflag_unused_bits = format!("Unused bits for new fields by [`{flags_ident}`]");
 
     // Generate the flag struct.
     quote! {

--- a/crates/storage/codecs/derive/src/compact/mod.rs
+++ b/crates/storage/codecs/derive/src/compact/mod.rs
@@ -185,18 +185,18 @@ mod tests {
     #[test]
     fn gen() {
         let f_struct = quote! {
-            #[derive(Debug, PartialEq, Clone)]
-            pub struct TestStruct {
-                f_u64: u64,
-                f_u256: U256,
-                f_bool_t: bool,
-                f_bool_f: bool,
-                f_option_none: Option<U256>,
-                f_option_some: Option<B256>,
-                f_option_some_u64: Option<u64>,
-                f_vec_empty: Vec<U256>,
-                f_vec_some: Vec<Address>,
-            }
+             #[derive(Debug, PartialEq, Clone)]
+             pub struct TestStruct {
+                 f_u64: u64,
+                 f_u256: U256,
+                 f_bool_t: bool,
+                 f_bool_f: bool,
+                 f_option_none: Option<U256>,
+                 f_option_some: Option<B256>,
+                 f_option_some_u64: Option<u64>,
+                 f_vec_empty: Vec<U256>,
+                 f_vec_some: Vec<Address>,
+             }
         };
 
         // Generate code that will impl the `Compact` trait.
@@ -208,7 +208,15 @@ mod tests {
 
         // Expected output in a TokenStream format. Commas matter!
         let should_output = quote! {
+            impl TestStruct {
+                #[doc = "Used bytes by [`TestStructFlags`]"]
+                pub const fn bitflag_encoded_bytes() -> usize {
+                    2u8 as usize
+                }
+            }
+
             pub use TestStruct_flags::TestStructFlags;
+
             #[allow(non_snake_case)]
             mod TestStruct_flags {
                 use bytes::Buf;

--- a/crates/storage/db/Cargo.toml
+++ b/crates/storage/db/Cargo.toml
@@ -16,7 +16,10 @@ workspace = true
 reth-primitives.workspace = true
 reth-interfaces.workspace = true
 reth-codecs.workspace = true
-reth-libmdbx = { workspace = true, optional = true, features = ["return-borrowed", "read-tx-timeouts"] }
+reth-libmdbx = { workspace = true, optional = true, features = [
+    "return-borrowed",
+    "read-tx-timeouts",
+] }
 reth-nippy-jar.workspace = true
 reth-tracing.workspace = true
 
@@ -58,7 +61,11 @@ serde_json.workspace = true
 tempfile.workspace = true
 test-fuzz.workspace = true
 
-pprof = { workspace = true, features = ["flamegraph", "frame-pointer", "criterion"] }
+pprof = { workspace = true, features = [
+    "flamegraph",
+    "frame-pointer",
+    "criterion",
+] }
 criterion.workspace = true
 iai-callgrind = "0.10.2"
 
@@ -81,6 +88,7 @@ arbitrary = [
     "dep:proptest",
     "dep:proptest-derive",
 ]
+optimism = []
 
 [[bench]]
 name = "hash_keys"

--- a/crates/storage/db/src/tables/codecs/compact.rs
+++ b/crates/storage/db/src/tables/codecs/compact.rs
@@ -141,65 +141,41 @@ mod tests {
         SealedHeader, TxEip1559, TxEip2930, TxEip4844, TxLegacy, Withdrawal, Withdrawals,
     };
 
+    // each value in the database has an extra field named flags that encodes metadata about other
+    // fields in the value, e.g. offset and length.
+    //
+    // this check is to ensure we do not inadvertently add too many fields to a struct which would
+    // expand the flags field and break backwards compatibility
     #[test]
     fn test_ensure_backwards_compatibility() {
         assert!(Account::bitflag_encoded_bytes() == 2);
-        assert!(Account::bitflag_unused_bits() == 5);
         assert!(AccountHashingCheckpoint::bitflag_encoded_bytes() == 1);
-        assert!(AccountHashingCheckpoint::bitflag_unused_bits() == 7);
         assert!(CheckpointBlockRange::bitflag_encoded_bytes() == 1);
-        assert!(CheckpointBlockRange::bitflag_unused_bits() == 0);
         assert!(CompactClientVersion::bitflag_encoded_bytes() == 0);
-        assert!(CompactClientVersion::bitflag_unused_bits() == 0);
         assert!(CompactU256::bitflag_encoded_bytes() == 1);
-        assert!(CompactU256::bitflag_unused_bits() == 2);
         assert!(CompactU64::bitflag_encoded_bytes() == 1);
-        assert!(CompactU64::bitflag_unused_bits() == 4);
         assert!(EntitiesCheckpoint::bitflag_encoded_bytes() == 1);
-        assert!(EntitiesCheckpoint::bitflag_unused_bits() == 0);
         assert!(ExecutionCheckpoint::bitflag_encoded_bytes() == 0);
-        assert!(ExecutionCheckpoint::bitflag_unused_bits() == 0);
         assert!(Header::bitflag_encoded_bytes() == 4);
-        assert!(Header::bitflag_unused_bits() == 1);
         assert!(HeadersCheckpoint::bitflag_encoded_bytes() == 0);
-        assert!(HeadersCheckpoint::bitflag_unused_bits() == 0);
         assert!(IndexHistoryCheckpoint::bitflag_encoded_bytes() == 0);
-        assert!(IndexHistoryCheckpoint::bitflag_unused_bits() == 0);
         assert!(PruneCheckpoint::bitflag_encoded_bytes() == 1);
-        assert!(PruneCheckpoint::bitflag_unused_bits() == 6);
         assert!(PruneMode::bitflag_encoded_bytes() == 1);
-        assert!(PruneMode::bitflag_unused_bits() == 0);
         assert!(PruneSegment::bitflag_encoded_bytes() == 1);
-        assert!(PruneSegment::bitflag_unused_bits() == 0);
         assert!(Receipt::bitflag_encoded_bytes() == 1);
-        assert!(Receipt::bitflag_unused_bits() == 0);
         assert!(ReceiptWithBloom::bitflag_encoded_bytes() == 0);
-        assert!(ReceiptWithBloom::bitflag_unused_bits() == 0);
         assert!(SealedHeader::bitflag_encoded_bytes() == 0);
-        assert!(SealedHeader::bitflag_unused_bits() == 0);
         assert!(StageCheckpoint::bitflag_encoded_bytes() == 1);
-        assert!(StageCheckpoint::bitflag_unused_bits() == 3);
         assert!(StageUnitCheckpoint::bitflag_encoded_bytes() == 1);
-        assert!(StageUnitCheckpoint::bitflag_unused_bits() == 0);
         assert!(StoredBlockBodyIndices::bitflag_encoded_bytes() == 1);
-        assert!(StoredBlockBodyIndices::bitflag_unused_bits() == 0);
         assert!(StoredBlockOmmers::bitflag_encoded_bytes() == 0);
-        assert!(StoredBlockOmmers::bitflag_unused_bits() == 0);
         assert!(StoredBlockWithdrawals::bitflag_encoded_bytes() == 0);
-        assert!(StoredBlockWithdrawals::bitflag_unused_bits() == 0);
         assert!(StorageHashingCheckpoint::bitflag_encoded_bytes() == 1);
-        assert!(StorageHashingCheckpoint::bitflag_unused_bits() == 6);
         assert!(TxEip1559::bitflag_encoded_bytes() == 4);
-        assert!(TxEip1559::bitflag_unused_bits() == 3);
         assert!(TxEip2930::bitflag_encoded_bytes() == 3);
-        assert!(TxEip2930::bitflag_unused_bits() == 0);
         assert!(TxEip4844::bitflag_encoded_bytes() == 5);
-        assert!(TxEip4844::bitflag_unused_bits() == 6);
         assert!(TxLegacy::bitflag_encoded_bytes() == 3);
-        assert!(TxLegacy::bitflag_unused_bits() == 3);
         assert!(Withdrawal::bitflag_encoded_bytes() == 2);
-        assert!(Withdrawal::bitflag_unused_bits() == 4);
         assert!(Withdrawals::bitflag_encoded_bytes() == 0);
-        assert!(Withdrawals::bitflag_unused_bits() == 0);
     }
 }

--- a/crates/storage/db/src/tables/codecs/compact.rs
+++ b/crates/storage/db/src/tables/codecs/compact.rs
@@ -148,34 +148,34 @@ mod tests {
     // expand the flags field and break backwards compatibility
     #[test]
     fn test_ensure_backwards_compatibility() {
-        assert!(Account::bitflag_encoded_bytes() == 2);
-        assert!(AccountHashingCheckpoint::bitflag_encoded_bytes() == 1);
-        assert!(CheckpointBlockRange::bitflag_encoded_bytes() == 1);
-        assert!(CompactClientVersion::bitflag_encoded_bytes() == 0);
-        assert!(CompactU256::bitflag_encoded_bytes() == 1);
-        assert!(CompactU64::bitflag_encoded_bytes() == 1);
-        assert!(EntitiesCheckpoint::bitflag_encoded_bytes() == 1);
-        assert!(ExecutionCheckpoint::bitflag_encoded_bytes() == 0);
-        assert!(Header::bitflag_encoded_bytes() == 4);
-        assert!(HeadersCheckpoint::bitflag_encoded_bytes() == 0);
-        assert!(IndexHistoryCheckpoint::bitflag_encoded_bytes() == 0);
-        assert!(PruneCheckpoint::bitflag_encoded_bytes() == 1);
-        assert!(PruneMode::bitflag_encoded_bytes() == 1);
-        assert!(PruneSegment::bitflag_encoded_bytes() == 1);
-        assert!(Receipt::bitflag_encoded_bytes() == 1);
-        assert!(ReceiptWithBloom::bitflag_encoded_bytes() == 0);
-        assert!(SealedHeader::bitflag_encoded_bytes() == 0);
-        assert!(StageCheckpoint::bitflag_encoded_bytes() == 1);
-        assert!(StageUnitCheckpoint::bitflag_encoded_bytes() == 1);
-        assert!(StoredBlockBodyIndices::bitflag_encoded_bytes() == 1);
-        assert!(StoredBlockOmmers::bitflag_encoded_bytes() == 0);
-        assert!(StoredBlockWithdrawals::bitflag_encoded_bytes() == 0);
-        assert!(StorageHashingCheckpoint::bitflag_encoded_bytes() == 1);
-        assert!(TxEip1559::bitflag_encoded_bytes() == 4);
-        assert!(TxEip2930::bitflag_encoded_bytes() == 3);
-        assert!(TxEip4844::bitflag_encoded_bytes() == 5);
-        assert!(TxLegacy::bitflag_encoded_bytes() == 3);
-        assert!(Withdrawal::bitflag_encoded_bytes() == 2);
-        assert!(Withdrawals::bitflag_encoded_bytes() == 0);
+        assert_eq!(Account::bitflag_encoded_bytes(), 2);
+        assert_eq!(AccountHashingCheckpoint::bitflag_encoded_bytes(), 1);
+        assert_eq!(CheckpointBlockRange::bitflag_encoded_bytes(), 1);
+        assert_eq!(CompactClientVersion::bitflag_encoded_bytes(), 0);
+        assert_eq!(CompactU256::bitflag_encoded_bytes(), 1);
+        assert_eq!(CompactU64::bitflag_encoded_bytes(), 1);
+        assert_eq!(EntitiesCheckpoint::bitflag_encoded_bytes(), 1);
+        assert_eq!(ExecutionCheckpoint::bitflag_encoded_bytes(), 0);
+        assert_eq!(Header::bitflag_encoded_bytes(), 4);
+        assert_eq!(HeadersCheckpoint::bitflag_encoded_bytes(), 0);
+        assert_eq!(IndexHistoryCheckpoint::bitflag_encoded_bytes(), 0);
+        assert_eq!(PruneCheckpoint::bitflag_encoded_bytes(), 1);
+        assert_eq!(PruneMode::bitflag_encoded_bytes(), 1);
+        assert_eq!(PruneSegment::bitflag_encoded_bytes(), 1);
+        assert_eq!(Receipt::bitflag_encoded_bytes(), 1);
+        assert_eq!(ReceiptWithBloom::bitflag_encoded_bytes(), 0);
+        assert_eq!(SealedHeader::bitflag_encoded_bytes(), 0);
+        assert_eq!(StageCheckpoint::bitflag_encoded_bytes(), 1);
+        assert_eq!(StageUnitCheckpoint::bitflag_encoded_bytes(), 1);
+        assert_eq!(StoredBlockBodyIndices::bitflag_encoded_bytes(), 1);
+        assert_eq!(StoredBlockOmmers::bitflag_encoded_bytes(), 0);
+        assert_eq!(StoredBlockWithdrawals::bitflag_encoded_bytes(), 0);
+        assert_eq!(StorageHashingCheckpoint::bitflag_encoded_bytes(), 1);
+        assert_eq!(TxEip1559::bitflag_encoded_bytes(), 4);
+        assert_eq!(TxEip2930::bitflag_encoded_bytes(), 3);
+        assert_eq!(TxEip4844::bitflag_encoded_bytes(), 5);
+        assert_eq!(TxLegacy::bitflag_encoded_bytes(), 3);
+        assert_eq!(Withdrawal::bitflag_encoded_bytes(), 2);
+        assert_eq!(Withdrawals::bitflag_encoded_bytes(), 0);
     }
 }

--- a/crates/storage/db/src/tables/codecs/compact.rs
+++ b/crates/storage/db/src/tables/codecs/compact.rs
@@ -197,7 +197,7 @@ mod tests {
             assert_eq!(PruneCheckpoint::bitflag_encoded_bytes(), 1);
             assert_eq!(PruneMode::bitflag_encoded_bytes(), 1);
             assert_eq!(PruneSegment::bitflag_encoded_bytes(), 1);
-            assert_eq!(Receipt::bitflag_encoded_bytes(), 1);
+            assert_eq!(Receipt::bitflag_encoded_bytes(), 2);
             assert_eq!(ReceiptWithBloom::bitflag_encoded_bytes(), 0);
             assert_eq!(SealedHeader::bitflag_encoded_bytes(), 0);
             assert_eq!(StageCheckpoint::bitflag_encoded_bytes(), 1);

--- a/crates/storage/db/src/tables/codecs/compact.rs
+++ b/crates/storage/db/src/tables/codecs/compact.rs
@@ -148,34 +148,70 @@ mod tests {
     // expand the flags field and break backwards compatibility
     #[test]
     fn test_ensure_backwards_compatibility() {
-        assert_eq!(Account::bitflag_encoded_bytes(), 2);
-        assert_eq!(AccountHashingCheckpoint::bitflag_encoded_bytes(), 1);
-        assert_eq!(CheckpointBlockRange::bitflag_encoded_bytes(), 1);
-        assert_eq!(CompactClientVersion::bitflag_encoded_bytes(), 0);
-        assert_eq!(CompactU256::bitflag_encoded_bytes(), 1);
-        assert_eq!(CompactU64::bitflag_encoded_bytes(), 1);
-        assert_eq!(EntitiesCheckpoint::bitflag_encoded_bytes(), 1);
-        assert_eq!(ExecutionCheckpoint::bitflag_encoded_bytes(), 0);
-        assert_eq!(Header::bitflag_encoded_bytes(), 4);
-        assert_eq!(HeadersCheckpoint::bitflag_encoded_bytes(), 0);
-        assert_eq!(IndexHistoryCheckpoint::bitflag_encoded_bytes(), 0);
-        assert_eq!(PruneCheckpoint::bitflag_encoded_bytes(), 1);
-        assert_eq!(PruneMode::bitflag_encoded_bytes(), 1);
-        assert_eq!(PruneSegment::bitflag_encoded_bytes(), 1);
-        assert_eq!(Receipt::bitflag_encoded_bytes(), 1);
-        assert_eq!(ReceiptWithBloom::bitflag_encoded_bytes(), 0);
-        assert_eq!(SealedHeader::bitflag_encoded_bytes(), 0);
-        assert_eq!(StageCheckpoint::bitflag_encoded_bytes(), 1);
-        assert_eq!(StageUnitCheckpoint::bitflag_encoded_bytes(), 1);
-        assert_eq!(StoredBlockBodyIndices::bitflag_encoded_bytes(), 1);
-        assert_eq!(StoredBlockOmmers::bitflag_encoded_bytes(), 0);
-        assert_eq!(StoredBlockWithdrawals::bitflag_encoded_bytes(), 0);
-        assert_eq!(StorageHashingCheckpoint::bitflag_encoded_bytes(), 1);
-        assert_eq!(TxEip1559::bitflag_encoded_bytes(), 4);
-        assert_eq!(TxEip2930::bitflag_encoded_bytes(), 3);
-        assert_eq!(TxEip4844::bitflag_encoded_bytes(), 5);
-        assert_eq!(TxLegacy::bitflag_encoded_bytes(), 3);
-        assert_eq!(Withdrawal::bitflag_encoded_bytes(), 2);
-        assert_eq!(Withdrawals::bitflag_encoded_bytes(), 0);
+        #[cfg(not(feature = "optimism"))]
+        {
+            assert_eq!(Account::bitflag_encoded_bytes(), 2);
+            assert_eq!(AccountHashingCheckpoint::bitflag_encoded_bytes(), 1);
+            assert_eq!(CheckpointBlockRange::bitflag_encoded_bytes(), 1);
+            assert_eq!(CompactClientVersion::bitflag_encoded_bytes(), 0);
+            assert_eq!(CompactU256::bitflag_encoded_bytes(), 1);
+            assert_eq!(CompactU64::bitflag_encoded_bytes(), 1);
+            assert_eq!(EntitiesCheckpoint::bitflag_encoded_bytes(), 1);
+            assert_eq!(ExecutionCheckpoint::bitflag_encoded_bytes(), 0);
+            assert_eq!(Header::bitflag_encoded_bytes(), 4);
+            assert_eq!(HeadersCheckpoint::bitflag_encoded_bytes(), 0);
+            assert_eq!(IndexHistoryCheckpoint::bitflag_encoded_bytes(), 0);
+            assert_eq!(PruneCheckpoint::bitflag_encoded_bytes(), 1);
+            assert_eq!(PruneMode::bitflag_encoded_bytes(), 1);
+            assert_eq!(PruneSegment::bitflag_encoded_bytes(), 1);
+            assert_eq!(Receipt::bitflag_encoded_bytes(), 1);
+            assert_eq!(ReceiptWithBloom::bitflag_encoded_bytes(), 0);
+            assert_eq!(SealedHeader::bitflag_encoded_bytes(), 0);
+            assert_eq!(StageCheckpoint::bitflag_encoded_bytes(), 1);
+            assert_eq!(StageUnitCheckpoint::bitflag_encoded_bytes(), 1);
+            assert_eq!(StoredBlockBodyIndices::bitflag_encoded_bytes(), 1);
+            assert_eq!(StoredBlockOmmers::bitflag_encoded_bytes(), 0);
+            assert_eq!(StoredBlockWithdrawals::bitflag_encoded_bytes(), 0);
+            assert_eq!(StorageHashingCheckpoint::bitflag_encoded_bytes(), 1);
+            assert_eq!(TxEip1559::bitflag_encoded_bytes(), 4);
+            assert_eq!(TxEip2930::bitflag_encoded_bytes(), 3);
+            assert_eq!(TxEip4844::bitflag_encoded_bytes(), 5);
+            assert_eq!(TxLegacy::bitflag_encoded_bytes(), 3);
+            assert_eq!(Withdrawal::bitflag_encoded_bytes(), 2);
+            assert_eq!(Withdrawals::bitflag_encoded_bytes(), 0);
+        }
+
+        #[cfg(feature = "optimism")]
+        {
+            assert_eq!(Account::bitflag_encoded_bytes(), 2);
+            assert_eq!(AccountHashingCheckpoint::bitflag_encoded_bytes(), 1);
+            assert_eq!(CheckpointBlockRange::bitflag_encoded_bytes(), 1);
+            assert_eq!(CompactClientVersion::bitflag_encoded_bytes(), 0);
+            assert_eq!(CompactU256::bitflag_encoded_bytes(), 1);
+            assert_eq!(CompactU64::bitflag_encoded_bytes(), 1);
+            assert_eq!(EntitiesCheckpoint::bitflag_encoded_bytes(), 1);
+            assert_eq!(ExecutionCheckpoint::bitflag_encoded_bytes(), 0);
+            assert_eq!(Header::bitflag_encoded_bytes(), 4);
+            assert_eq!(HeadersCheckpoint::bitflag_encoded_bytes(), 0);
+            assert_eq!(IndexHistoryCheckpoint::bitflag_encoded_bytes(), 0);
+            assert_eq!(PruneCheckpoint::bitflag_encoded_bytes(), 1);
+            assert_eq!(PruneMode::bitflag_encoded_bytes(), 1);
+            assert_eq!(PruneSegment::bitflag_encoded_bytes(), 1);
+            assert_eq!(Receipt::bitflag_encoded_bytes(), 2);
+            assert_eq!(ReceiptWithBloom::bitflag_encoded_bytes(), 0);
+            assert_eq!(SealedHeader::bitflag_encoded_bytes(), 0);
+            assert_eq!(StageCheckpoint::bitflag_encoded_bytes(), 1);
+            assert_eq!(StageUnitCheckpoint::bitflag_encoded_bytes(), 1);
+            assert_eq!(StoredBlockBodyIndices::bitflag_encoded_bytes(), 1);
+            assert_eq!(StoredBlockOmmers::bitflag_encoded_bytes(), 0);
+            assert_eq!(StoredBlockWithdrawals::bitflag_encoded_bytes(), 0);
+            assert_eq!(StorageHashingCheckpoint::bitflag_encoded_bytes(), 1);
+            assert_eq!(TxEip1559::bitflag_encoded_bytes(), 4);
+            assert_eq!(TxEip2930::bitflag_encoded_bytes(), 3);
+            assert_eq!(TxEip4844::bitflag_encoded_bytes(), 5);
+            assert_eq!(TxLegacy::bitflag_encoded_bytes(), 3);
+            assert_eq!(Withdrawal::bitflag_encoded_bytes(), 2);
+            assert_eq!(Withdrawals::bitflag_encoded_bytes(), 0);
+        }
     }
 }

--- a/crates/storage/db/src/tables/codecs/compact.rs
+++ b/crates/storage/db/src/tables/codecs/compact.rs
@@ -197,7 +197,7 @@ mod tests {
             assert_eq!(PruneCheckpoint::bitflag_encoded_bytes(), 1);
             assert_eq!(PruneMode::bitflag_encoded_bytes(), 1);
             assert_eq!(PruneSegment::bitflag_encoded_bytes(), 1);
-            assert_eq!(Receipt::bitflag_encoded_bytes(), 2);
+            assert_eq!(Receipt::bitflag_encoded_bytes(), 1);
             assert_eq!(ReceiptWithBloom::bitflag_encoded_bytes(), 0);
             assert_eq!(SealedHeader::bitflag_encoded_bytes(), 0);
             assert_eq!(StageCheckpoint::bitflag_encoded_bytes(), 1);


### PR DESCRIPTION
Removes `bitflag_unused_bits` since adding that to the test would break the test every time we add a field, whereas we only want the test to break if the flag field expands in size

Also adds a comment explaining why the test is there in the first place

Separate PR because I want to validate that we do *not* want to check unused bits

This is technically a semi-blocker for Prague since Prague adds a lot of new header fields