### PR TITLE
feat: use ComponentsBuilder as associated type in Node trait

### DIFF
--- a/crates/e2e-test-utils/src/lib.rs
+++ b/crates/e2e-test-utils/src/lib.rs
@@ -44,10 +44,7 @@ pub async fn setup<N>(
     is_dev: bool,
 ) -> eyre::Result<(Vec<NodeHelperType<N>>, TaskManager, Wallet)>
 where
-    N: Default + reth_node_builder::Node<TmpNodeAdapter<N>>,
-    // N::PoolBuilder: PoolBuilder<TmpNodeAdapter<N>>,
-    // N::NetworkBuilder: NetworkBuilder<TmpNodeAdapter<N>, TmpPool<N>>,
-    // N::PayloadBuilder: PayloadServiceBuilder<TmpNodeAdapter<N>, TmpPool<N>>,
+    N: Default + Node<TmpNodeAdapter<N>>,
 {
     let tasks = TaskManager::current();
     let exec = tasks.executor();
@@ -102,9 +99,6 @@ where
 // Type aliases
 
 type TmpDB = Arc<TempDatabase<DatabaseEnv>>;
-// type TmpPool<N> = <<N as reth_node_builder::Node<TmpNodeAdapter<N>>>::PoolBuilder as PoolBuilder<
-//     TmpNodeAdapter<N>,
-// >>::Pool;
 type TmpNodeAdapter<N> = FullNodeTypesAdapter<N, TmpDB, BlockchainProvider<TmpDB>>;
 
 type Adapter<N> = NodeAdapter<

--- a/crates/e2e-test-utils/src/lib.rs
+++ b/crates/e2e-test-utils/src/lib.rs
@@ -6,8 +6,7 @@ use reth::{
 };
 use reth_db::{test_utils::TempDatabase, DatabaseEnv};
 use reth_node_builder::{
-    components::{Components, NetworkBuilder, PayloadServiceBuilder, PoolBuilder},
-    FullNodeTypesAdapter, NodeAdapter,
+    components::NodeComponentsBuilder, FullNodeTypesAdapter, Node, NodeAdapter, RethFullAdapter,
 };
 use reth_primitives::ChainSpec;
 use reth_provider::providers::BlockchainProvider;
@@ -46,9 +45,9 @@ pub async fn setup<N>(
 ) -> eyre::Result<(Vec<NodeHelperType<N>>, TaskManager, Wallet)>
 where
     N: Default + reth_node_builder::Node<TmpNodeAdapter<N>>,
-    N::PoolBuilder: PoolBuilder<TmpNodeAdapter<N>>,
-    N::NetworkBuilder: NetworkBuilder<TmpNodeAdapter<N>, TmpPool<N>>,
-    N::PayloadBuilder: PayloadServiceBuilder<TmpNodeAdapter<N>, TmpPool<N>>,
+    // N::PoolBuilder: PoolBuilder<TmpNodeAdapter<N>>,
+    // N::NetworkBuilder: NetworkBuilder<TmpNodeAdapter<N>, TmpPool<N>>,
+    // N::PayloadBuilder: PayloadServiceBuilder<TmpNodeAdapter<N>, TmpPool<N>>,
 {
     let tasks = TaskManager::current();
     let exec = tasks.executor();
@@ -103,11 +102,17 @@ where
 // Type aliases
 
 type TmpDB = Arc<TempDatabase<DatabaseEnv>>;
-type TmpPool<N> = <<N as reth_node_builder::Node<TmpNodeAdapter<N>>>::PoolBuilder as PoolBuilder<
-    TmpNodeAdapter<N>,
->>::Pool;
+// type TmpPool<N> = <<N as reth_node_builder::Node<TmpNodeAdapter<N>>>::PoolBuilder as PoolBuilder<
+//     TmpNodeAdapter<N>,
+// >>::Pool;
 type TmpNodeAdapter<N> = FullNodeTypesAdapter<N, TmpDB, BlockchainProvider<TmpDB>>;
 
+type Adapter<N> = NodeAdapter<
+    RethFullAdapter<TmpDB, N>,
+    <<N as Node<TmpNodeAdapter<N>>>::ComponentsBuilder as NodeComponentsBuilder<
+        RethFullAdapter<TmpDB, N>,
+    >>::Components,
+>;
+
 /// Type alias for a type of NodeHelper
-pub type NodeHelperType<N> =
-    NodeTestContext<NodeAdapter<TmpNodeAdapter<N>, Components<TmpNodeAdapter<N>, TmpPool<N>>>>;
+pub type NodeHelperType<N> = NodeTestContext<Adapter<N>>;

--- a/crates/node-ethereum/src/node.rs
+++ b/crates/node-ethereum/src/node.rs
@@ -5,8 +5,8 @@ use reth_basic_payload_builder::{BasicPayloadJobGenerator, BasicPayloadJobGenera
 use reth_network::NetworkHandle;
 use reth_node_builder::{
     components::{ComponentsBuilder, NetworkBuilder, PayloadServiceBuilder, PoolBuilder},
-    node::{FullNodeTypes, Node, NodeTypes},
-    BuilderContext, Node2, PayloadBuilderConfig,
+    node::{FullNodeTypes, NodeTypes},
+    BuilderContext, Node, PayloadBuilderConfig,
 };
 use reth_payload_builder::{PayloadBuilderHandle, PayloadBuilderService};
 use reth_provider::CanonStateSubscriptions;
@@ -50,34 +50,11 @@ impl<N> Node<N> for EthereumNode
 where
     N: FullNodeTypes<Engine = EthEngineTypes>,
 {
-    type PoolBuilder = EthereumPoolBuilder;
-    type NetworkBuilder = EthereumNetworkBuilder;
-    type PayloadBuilder = EthereumPayloadBuilder;
-
-    fn components(
-        self,
-    ) -> ComponentsBuilder<N, Self::PoolBuilder, Self::PayloadBuilder, Self::NetworkBuilder> {
-        ComponentsBuilder::default()
-            .node_types::<N>()
-            .pool(EthereumPoolBuilder::default())
-            .payload(EthereumPayloadBuilder::default())
-            .network(EthereumNetworkBuilder::default())
-    }
-}
-
-impl<N: FullNodeTypes> Node2<N> for EthereumNode
-where
-    N: FullNodeTypes<Engine = EthEngineTypes>,
-{
     type ComponentsBuilder =
         ComponentsBuilder<N, EthereumPoolBuilder, EthereumPayloadBuilder, EthereumNetworkBuilder>;
 
-    fn components(self) -> Self::ComponentsBuilder {
-        ComponentsBuilder::default()
-            .node_types::<N>()
-            .pool(EthereumPoolBuilder::default())
-            .payload(EthereumPayloadBuilder::default())
-            .network(EthereumNetworkBuilder::default())
+    fn components_builder(self) -> Self::ComponentsBuilder {
+        Self::components()
     }
 }
 

--- a/crates/node-ethereum/src/node.rs
+++ b/crates/node-ethereum/src/node.rs
@@ -6,7 +6,7 @@ use reth_network::NetworkHandle;
 use reth_node_builder::{
     components::{ComponentsBuilder, NetworkBuilder, PayloadServiceBuilder, PoolBuilder},
     node::{FullNodeTypes, Node, NodeTypes},
-    BuilderContext, PayloadBuilderConfig,
+    BuilderContext, Node2, PayloadBuilderConfig,
 };
 use reth_payload_builder::{PayloadBuilderHandle, PayloadBuilderService};
 use reth_provider::CanonStateSubscriptions;
@@ -57,6 +57,22 @@ where
     fn components(
         self,
     ) -> ComponentsBuilder<N, Self::PoolBuilder, Self::PayloadBuilder, Self::NetworkBuilder> {
+        ComponentsBuilder::default()
+            .node_types::<N>()
+            .pool(EthereumPoolBuilder::default())
+            .payload(EthereumPayloadBuilder::default())
+            .network(EthereumNetworkBuilder::default())
+    }
+}
+
+impl<N: FullNodeTypes> Node2<N> for EthereumNode
+where
+    N: FullNodeTypes<Engine = EthEngineTypes>,
+{
+    type ComponentsBuilder =
+        ComponentsBuilder<N, EthereumPoolBuilder, EthereumPayloadBuilder, EthereumNetworkBuilder>;
+
+    fn components(self) -> Self::ComponentsBuilder {
         ComponentsBuilder::default()
             .node_types::<N>()
             .pool(EthereumPoolBuilder::default())

--- a/crates/node-ethereum/tests/it/builder.rs
+++ b/crates/node-ethereum/tests/it/builder.rs
@@ -39,5 +39,5 @@ fn test_node_setup() {
     let config = NodeConfig::test();
     let db = create_test_rw_db();
     let _builder =
-        NodeBuilder::new(config).with_database(db).node2(EthereumNode::default()).check_launch();
+        NodeBuilder::new(config).with_database(db).node(EthereumNode::default()).check_launch();
 }

--- a/crates/node-ethereum/tests/it/builder.rs
+++ b/crates/node-ethereum/tests/it/builder.rs
@@ -33,3 +33,11 @@ fn test_basic_setup() {
         })
         .check_launch();
 }
+
+#[test]
+fn test_node_setup() {
+    let config = NodeConfig::test();
+    let db = create_test_rw_db();
+    let _builder =
+        NodeBuilder::new(config).with_database(db).node2(EthereumNode::default()).check_launch();
+}

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     components::{Components, ComponentsBuilder, NodeComponentsBuilder, PoolBuilder},
     node::FullNode,
     rpc::{RethRpcServerHandles, RpcContext},
-    DefaultNodeLauncher, Node, NodeHandle,
+    DefaultNodeLauncher, Node, Node2, NodeHandle,
 };
 use futures::Future;
 use reth_db::{
@@ -227,6 +227,19 @@ where
     {
         self.with_types(node.clone()).with_components(node.components())
     }
+
+    /// Preconfigures the node with a specific node implementation.
+    ///
+    /// This is a convenience method that sets the node's types and components in one call.
+    pub fn node2<N>(
+        self,
+        node: N,
+    ) -> NodeBuilderWithComponents<RethFullAdapter<DB, N>, N::ComponentsBuilder>
+    where
+        N: Node2<RethFullAdapter<DB, N>>,
+    {
+        self.with_types(node.clone()).with_components(node.components())
+    }
 }
 
 /// A [NodeBuilder] with it's launch context already configured.
@@ -300,6 +313,19 @@ where
         self.with_types(node.clone()).with_components(node.components())
     }
 
+    /// Preconfigures the node with a specific node implementation.
+    ///
+    /// This is a convenience method that sets the node's types and components in one call.
+    pub fn node2<N>(
+        self,
+        node: N,
+    ) -> WithLaunchContext<NodeBuilderWithComponents<RethFullAdapter<DB, N>, N::ComponentsBuilder>>
+    where
+        N: Node2<RethFullAdapter<DB, N>>,
+    {
+        self.with_types(node.clone()).with_components(node.components())
+    }
+
     /// Launches a preconfigured [Node]
     ///
     /// This bootstraps the node internals, creates all the components with the given [Node]
@@ -332,6 +358,28 @@ where
         >,
     {
         self.node(node).launch().await
+    }
+
+    /// Launches a preconfigured [Node]
+    ///
+    /// This bootstraps the node internals, creates all the components with the given [Node]
+    ///
+    /// Returns a [NodeHandle] that can be used to interact with the node.
+    pub async fn launch_node2<N>(
+        self,
+        node: N,
+    ) -> eyre::Result<
+        NodeHandle<
+            NodeAdapter<
+                RethFullAdapter<DB, N>,
+                <N::ComponentsBuilder as NodeComponentsBuilder<RethFullAdapter<DB, N>>>::Components,
+            >,
+        >,
+    >
+    where
+        N: Node2<RethFullAdapter<DB, N>>,
+    {
+        self.node2(node).launch().await
     }
 }
 

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -3,10 +3,10 @@
 #![allow(clippy::type_complexity, missing_debug_implementations)]
 
 use crate::{
-    components::{Components, ComponentsBuilder, NodeComponentsBuilder, PoolBuilder},
+    components::NodeComponentsBuilder,
     node::FullNode,
     rpc::{RethRpcServerHandles, RpcContext},
-    DefaultNodeLauncher, Node, Node2, NodeHandle,
+    DefaultNodeLauncher, Node, NodeHandle,
 };
 use futures::Future;
 use reth_db::{
@@ -204,41 +204,11 @@ where
     pub fn node<N>(
         self,
         node: N,
-    ) -> NodeBuilderWithComponents<
-        RethFullAdapter<DB, N>,
-        ComponentsBuilder<
-            RethFullAdapter<DB, N>,
-            N::PoolBuilder,
-            N::PayloadBuilder,
-            N::NetworkBuilder,
-        >,
-    >
-    where
-        N: Node<RethFullAdapter<DB, N>>,
-        N::PoolBuilder: PoolBuilder<RethFullAdapter<DB, N>>,
-        N::NetworkBuilder: crate::components::NetworkBuilder<
-            RethFullAdapter<DB, N>,
-            <N::PoolBuilder as PoolBuilder<RethFullAdapter<DB, N>>>::Pool,
-        >,
-        N::PayloadBuilder: crate::components::PayloadServiceBuilder<
-            RethFullAdapter<DB, N>,
-            <N::PoolBuilder as PoolBuilder<RethFullAdapter<DB, N>>>::Pool,
-        >,
-    {
-        self.with_types(node.clone()).with_components(node.components())
-    }
-
-    /// Preconfigures the node with a specific node implementation.
-    ///
-    /// This is a convenience method that sets the node's types and components in one call.
-    pub fn node2<N>(
-        self,
-        node: N,
     ) -> NodeBuilderWithComponents<RethFullAdapter<DB, N>, N::ComponentsBuilder>
     where
-        N: Node2<RethFullAdapter<DB, N>>,
+        N: Node<RethFullAdapter<DB, N>>,
     {
-        self.with_types(node.clone()).with_components(node.components())
+        self.with_types(node.clone()).with_components(node.components_builder())
     }
 }
 
@@ -284,46 +254,16 @@ where
     }
 
     /// Preconfigures the node with a specific node implementation.
-    pub fn node<N>(
-        self,
-        node: N,
-    ) -> WithLaunchContext<
-        NodeBuilderWithComponents<
-            RethFullAdapter<DB, N>,
-            ComponentsBuilder<
-                RethFullAdapter<DB, N>,
-                N::PoolBuilder,
-                N::PayloadBuilder,
-                N::NetworkBuilder,
-            >,
-        >,
-    >
-    where
-        N: Node<RethFullAdapter<DB, N>>,
-        N::PoolBuilder: PoolBuilder<RethFullAdapter<DB, N>>,
-        N::NetworkBuilder: crate::components::NetworkBuilder<
-            RethFullAdapter<DB, N>,
-            <N::PoolBuilder as PoolBuilder<RethFullAdapter<DB, N>>>::Pool,
-        >,
-        N::PayloadBuilder: crate::components::PayloadServiceBuilder<
-            RethFullAdapter<DB, N>,
-            <N::PoolBuilder as PoolBuilder<RethFullAdapter<DB, N>>>::Pool,
-        >,
-    {
-        self.with_types(node.clone()).with_components(node.components())
-    }
-
-    /// Preconfigures the node with a specific node implementation.
     ///
     /// This is a convenience method that sets the node's types and components in one call.
-    pub fn node2<N>(
+    pub fn node<N>(
         self,
         node: N,
     ) -> WithLaunchContext<NodeBuilderWithComponents<RethFullAdapter<DB, N>, N::ComponentsBuilder>>
     where
-        N: Node2<RethFullAdapter<DB, N>>,
+        N: Node<RethFullAdapter<DB, N>>,
     {
-        self.with_types(node.clone()).with_components(node.components())
+        self.with_types(node.clone()).with_components(node.components_builder())
     }
 
     /// Launches a preconfigured [Node]
@@ -338,48 +278,14 @@ where
         NodeHandle<
             NodeAdapter<
                 RethFullAdapter<DB, N>,
-                Components<
-                    RethFullAdapter<DB, N>,
-                    <N::PoolBuilder as PoolBuilder<RethFullAdapter<DB, N>>>::Pool,
-                >,
-            >,
-        >,
-    >
-    where
-        N: Node<RethFullAdapter<DB, N>>,
-        N::PoolBuilder: PoolBuilder<RethFullAdapter<DB, N>>,
-        N::NetworkBuilder: crate::components::NetworkBuilder<
-            RethFullAdapter<DB, N>,
-            <N::PoolBuilder as PoolBuilder<RethFullAdapter<DB, N>>>::Pool,
-        >,
-        N::PayloadBuilder: crate::components::PayloadServiceBuilder<
-            RethFullAdapter<DB, N>,
-            <N::PoolBuilder as PoolBuilder<RethFullAdapter<DB, N>>>::Pool,
-        >,
-    {
-        self.node(node).launch().await
-    }
-
-    /// Launches a preconfigured [Node]
-    ///
-    /// This bootstraps the node internals, creates all the components with the given [Node]
-    ///
-    /// Returns a [NodeHandle] that can be used to interact with the node.
-    pub async fn launch_node2<N>(
-        self,
-        node: N,
-    ) -> eyre::Result<
-        NodeHandle<
-            NodeAdapter<
-                RethFullAdapter<DB, N>,
                 <N::ComponentsBuilder as NodeComponentsBuilder<RethFullAdapter<DB, N>>>::Components,
             >,
         >,
     >
     where
-        N: Node2<RethFullAdapter<DB, N>>,
+        N: Node<RethFullAdapter<DB, N>>,
     {
-        self.node2(node).launch().await
+        self.node(node).launch().await
     }
 }
 

--- a/crates/node/builder/src/node.rs
+++ b/crates/node/builder/src/node.rs
@@ -1,7 +1,4 @@
-use crate::{
-    components::ComponentsBuilder,
-    rpc::{RethRpcServerHandles, RpcRegistry},
-};
+use crate::rpc::{RethRpcServerHandles, RpcRegistry};
 use reth_network::NetworkHandle;
 use reth_node_api::FullNodeComponents;
 use reth_node_core::{
@@ -22,32 +19,15 @@ use std::sync::Arc;
 use crate::components::NodeComponentsBuilder;
 pub use reth_node_api::{FullNodeTypes, NodeTypes};
 
-/// A [Node] is a [NodeTypes] that comes with preconfigured components.
-///
-/// This can be used to configure the builder with a preset of components.
-pub trait Node<N>: NodeTypes + Clone {
-    /// The type that builds the node's pool.
-    type PoolBuilder;
-    /// The type that builds the node's network.
-    type NetworkBuilder;
-    /// The type that builds the node's payload service.
-    type PayloadBuilder;
-
-    /// Returns the [ComponentsBuilder] for the node.
-    fn components(
-        self,
-    ) -> ComponentsBuilder<N, Self::PoolBuilder, Self::PayloadBuilder, Self::NetworkBuilder>;
-}
-
 /// A [crate::Node] is a [NodeTypes] that comes with preconfigured components.
 ///
 /// This can be used to configure the builder with a preset of components.
-pub trait Node2<N: FullNodeTypes>: NodeTypes + Clone {
+pub trait Node<N: FullNodeTypes>: NodeTypes + Clone {
     /// The type that builds the node's components.
     type ComponentsBuilder: NodeComponentsBuilder<N>;
 
-    /// Returns the [ComponentsBuilder] for the node.
-    fn components(self) -> Self::ComponentsBuilder;
+    /// Returns a [NodeComponentsBuilder] for the node.
+    fn components_builder(self) -> Self::ComponentsBuilder;
 }
 
 /// The launched node with all components including RPC handlers.

--- a/crates/node/builder/src/node.rs
+++ b/crates/node/builder/src/node.rs
@@ -19,6 +19,7 @@ use reth_tasks::TaskExecutor;
 use std::sync::Arc;
 
 // re-export the node api types
+use crate::components::NodeComponentsBuilder;
 pub use reth_node_api::{FullNodeTypes, NodeTypes};
 
 /// A [Node] is a [NodeTypes] that comes with preconfigured components.
@@ -36,6 +37,17 @@ pub trait Node<N>: NodeTypes + Clone {
     fn components(
         self,
     ) -> ComponentsBuilder<N, Self::PoolBuilder, Self::PayloadBuilder, Self::NetworkBuilder>;
+}
+
+/// A [crate::Node] is a [NodeTypes] that comes with preconfigured components.
+///
+/// This can be used to configure the builder with a preset of components.
+pub trait Node2<N: FullNodeTypes>: NodeTypes + Clone {
+    /// The type that builds the node's components.
+    type ComponentsBuilder: NodeComponentsBuilder<N>;
+
+    /// Returns the [ComponentsBuilder] for the node.
+    fn components(self) -> Self::ComponentsBuilder;
 }
 
 /// The launched node with all components including RPC handlers.

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -55,13 +55,10 @@ impl<N> Node<N> for OptimismNode
 where
     N: FullNodeTypes<Engine = OptimismEngineTypes>,
 {
-    type PoolBuilder = OptimismPoolBuilder;
-    type NetworkBuilder = OptimismNetworkBuilder;
-    type PayloadBuilder = OptimismPayloadBuilder;
+    type ComponentsBuilder =
+        ComponentsBuilder<N, OptimismPoolBuilder, OptimismPayloadBuilder, OptimismNetworkBuilder>;
 
-    fn components(
-        self,
-    ) -> ComponentsBuilder<N, Self::PoolBuilder, Self::PayloadBuilder, Self::NetworkBuilder> {
+    fn components_builder(self) -> Self::ComponentsBuilder {
         let Self { args } = self;
         Self::components(args)
     }

--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -202,13 +202,14 @@ impl<N> Node<N> for MyCustomNode
 where
     N: FullNodeTypes<Engine = CustomEngineTypes>,
 {
-    type PoolBuilder = EthereumPoolBuilder;
-    type NetworkBuilder = EthereumNetworkBuilder;
-    type PayloadBuilder = CustomPayloadServiceBuilder;
+    type ComponentsBuilder = ComponentsBuilder<
+        N,
+        EthereumPoolBuilder,
+        CustomPayloadServiceBuilder,
+        EthereumNetworkBuilder,
+    >;
 
-    fn components(
-        self,
-    ) -> ComponentsBuilder<N, Self::PoolBuilder, Self::PayloadBuilder, Self::NetworkBuilder> {
+    fn components_builder(self) -> Self::ComponentsBuilder {
         ComponentsBuilder::default()
             .node_types::<N>()
             .pool(EthereumPoolBuilder::default())


### PR DESCRIPTION
closes #7956

this effectively replaces individual builder types with the `ComponentsBuilder` that encapsulates those.

this makes trait bounds a lot easier without sacrificing API