### PR TITLE
chore(storage): use `TAKE` const instead of `UNWIND`

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -387,7 +387,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
     ///     1. Take the old value from the changeset
     ///     2. Take the new value from the local state
     ///     3. Set the local state to the value in the changeset
-    pub fn unwind_or_peek_state<const UNWIND: bool>(
+    pub fn unwind_or_peek_state<const TAKE: bool>(
         &self,
         range: RangeInclusive<BlockNumber>,
     ) -> ProviderResult<BundleStateWithReceipts> {
@@ -408,8 +408,8 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
         let storage_range = BlockNumberAddress::range(range.clone());
 
         let storage_changeset =
-            self.get_or_take::<tables::StorageChangeSets, UNWIND>(storage_range)?;
-        let account_changeset = self.get_or_take::<tables::AccountChangeSets, UNWIND>(range)?;
+            self.get_or_take::<tables::StorageChangeSets, TAKE>(storage_range)?;
+        let account_changeset = self.get_or_take::<tables::AccountChangeSets, TAKE>(range)?;
 
         // iterate previous value and get plain state value to create changeset
         // Double option around Account represent if Account state is know (first option) and
@@ -478,7 +478,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
                 .push(old_storage);
         }
 
-        if UNWIND {
+        if TAKE {
             // iterate over local plain state remove all account and all storages.
             for (address, (old_account, new_account, storage)) in state.iter() {
                 // revert account if needed.
@@ -515,7 +515,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
 
         // iterate over block body and create ExecutionResult
         let mut receipt_iter = self
-            .get_or_take::<tables::Receipts, UNWIND>(from_transaction_num..=to_transaction_num)?
+            .get_or_take::<tables::Receipts, TAKE>(from_transaction_num..=to_transaction_num)?
             .into_iter();
 
         let mut receipts = Vec::new();


### PR DESCRIPTION
`const TAKE` is usually used https://github.com/paradigmxyz/reth/blob/3fc5cf646112e8d31d456f926fb07023af5829dc/crates/storage/provider/src/traits/block.rs#L284-L288