### PR TITLE
chore: add required trait bounds to DB type

### DIFF
--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -187,7 +187,7 @@ impl<DB> NodeBuilder<DB> {
 
 impl<DB> NodeBuilder<DB>
 where
-    DB: Database + Unpin + Clone + 'static,
+    DB: Database + DatabaseMetrics + DatabaseMetadata + Clone + Unpin + 'static,
 {
     /// Configures the types of the node.
     pub fn with_types<T>(self, types: T) -> NodeBuilderWithTypes<RethFullAdapter<DB, T>>


### PR DESCRIPTION
these traits are required during launch and should be part of the DB associated type