### PR TITLE
chore: less restrictive bounds

### DIFF
--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -34,12 +34,9 @@ use std::{str::FromStr, sync::Arc};
 
 mod states;
 
-/// The builtin provider type of the reth node.
+/// The adapter type for a reth node with the builtin provider type
 // Note: we need to hardcode this because custom components might depend on it in associated types.
-pub type RethFullProviderType<DB> = BlockchainProvider<DB>;
-
-/// The adapter type for a reth node with the given types
-pub type RethFullAdapter<DB, Types> = FullNodeTypesAdapter<Types, DB, RethFullProviderType<DB>>;
+pub type RethFullAdapter<DB, Types> = FullNodeTypesAdapter<Types, DB, BlockchainProvider<DB>>;
 
 #[cfg_attr(doc, aquamarine::aquamarine)]
 /// Declaratively construct a node.

--- a/crates/node/builder/src/launch/mod.rs
+++ b/crates/node/builder/src/launch/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     components::{NodeComponents, NodeComponentsBuilder},
     hooks::NodeHooks,
     node::FullNode,
-    BuilderContext, NodeBuilderWithComponents, NodeHandle, RethFullAdapter,
+    BuilderContext, NodeBuilderWithComponents, NodeHandle,
 };
 use futures::{future, future::Either, stream, stream_select, StreamExt};
 use reth_auto_seal_consensus::AutoSealConsensus;
@@ -17,14 +17,10 @@ use reth_blockchain_tree::{
     BlockchainTree, BlockchainTreeConfig, ShareableBlockchainTree, TreeExternals,
 };
 use reth_consensus::Consensus;
-use reth_db::{
-    database::Database,
-    database_metrics::{DatabaseMetadata, DatabaseMetrics},
-};
 use reth_exex::{ExExContext, ExExHandle, ExExManager, ExExManagerHandle};
 use reth_interfaces::p2p::either::EitherDownloader;
 use reth_network::NetworkEvents;
-use reth_node_api::{FullNodeComponents, NodeTypes};
+use reth_node_api::{FullNodeComponents, FullNodeTypes};
 use reth_node_core::{
     dirs::{ChainPath, DataDirPath},
     engine_api_store::EngineApiStore,
@@ -74,18 +70,16 @@ impl DefaultNodeLauncher {
     }
 }
 
-impl<T, DB, CB> LaunchNode<NodeBuilderWithComponents<RethFullAdapter<DB, T>, CB>>
-    for DefaultNodeLauncher
+impl<T, CB> LaunchNode<NodeBuilderWithComponents<T, CB>> for DefaultNodeLauncher
 where
-    DB: Database + DatabaseMetrics + DatabaseMetadata + Clone + Unpin + 'static,
-    T: NodeTypes,
-    CB: NodeComponentsBuilder<RethFullAdapter<DB, T>>,
+    T: FullNodeTypes<Provider = BlockchainProvider<<T as FullNodeTypes>::DB>>,
+    CB: NodeComponentsBuilder<T>,
 {
-    type Node = NodeHandle<NodeAdapter<RethFullAdapter<DB, T>, CB::Components>>;
+    type Node = NodeHandle<NodeAdapter<T, CB::Components>>;
 
     async fn launch_node(
         self,
-        target: NodeBuilderWithComponents<RethFullAdapter<DB, T>, CB>,
+        target: NodeBuilderWithComponents<T, CB>,
     ) -> eyre::Result<Self::Node> {
         let Self { ctx } = self;
         let NodeBuilderWithComponents {


### PR DESCRIPTION
can simplify trait bounds now.

we only mandate that the Provider type is the builtin `BlockchainProvider` type we're going to use