### PR TITLE
feat: add `Deref` impl for `PayloadTaskGuard`

### DIFF
--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -35,6 +35,7 @@ use revm::{
 };
 use std::{
     future::Future,
+    ops::Deref,
     pin::Pin,
     sync::{atomic::AtomicBool, Arc},
     task::{Context, Poll},
@@ -228,6 +229,14 @@ pub struct PrecachedState {
 #[derive(Debug, Clone)]
 pub struct PayloadTaskGuard(Arc<Semaphore>);
 
+impl Deref for PayloadTaskGuard {
+    type Target = Semaphore;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 // === impl PayloadTaskGuard ===
 
 impl PayloadTaskGuard {
@@ -385,7 +394,7 @@ where
                 let builder = this.builder.clone();
                 this.executor.spawn_blocking(Box::pin(async move {
                     // acquire the permit for executing the task
-                    let _permit = guard.0.acquire().await;
+                    let _permit = guard.acquire().await;
                     let args = BuildArguments {
                         client,
                         pool,


### PR DESCRIPTION
Follow up from #7945:

https://github.com/paradigmxyz/reth/pull/7945#issuecomment-2081519417

#7945 made the type public, but having this implementation would facilitate using it just like the `BasicPayloadJob` does.
