### PR TITLE
chore: pool type must be unpin

### DIFF
--- a/crates/node/api/src/node.rs
+++ b/crates/node/api/src/node.rs
@@ -83,7 +83,7 @@ where
 /// Encapsulates all types and components of the node.
 pub trait FullNodeComponents: FullNodeTypes + 'static {
     /// The transaction pool of the node.
-    type Pool: TransactionPool;
+    type Pool: TransactionPool + Unpin;
 
     /// Returns the transaction pool of the node.
     fn pool(&self) -> &Self::Pool;


### PR DESCRIPTION
## Description

`FullNodeComponents::Pool` must be `Unpin`.