### PR TITLE
feat: use `FnOnce` for node hooks

### DIFF
--- a/crates/node/builder/src/builder/states.rs
+++ b/crates/node/builder/src/builder/states.rs
@@ -157,7 +157,7 @@ impl<T: FullNodeTypes, CB: NodeComponentsBuilder<T>> NodeBuilderWithComponents<T
     /// Sets the hook that is run once the node's components are initialized.
     pub fn on_component_initialized<F>(mut self, hook: F) -> Self
     where
-        F: Fn(NodeAdapter<T, CB::Components>) -> eyre::Result<()> + Send + 'static,
+        F: FnOnce(NodeAdapter<T, CB::Components>) -> eyre::Result<()> + Send + 'static,
     {
         self.add_ons.hooks.set_on_component_initialized(hook);
         self
@@ -166,25 +166,16 @@ impl<T: FullNodeTypes, CB: NodeComponentsBuilder<T>> NodeBuilderWithComponents<T
     /// Sets the hook that is run once the node has started.
     pub fn on_node_started<F>(mut self, hook: F) -> Self
     where
-        F: Fn(FullNode<NodeAdapter<T, CB::Components>>) -> eyre::Result<()> + Send + 'static,
-    {
-        self.add_ons.hooks.set_on_node_started(hook);
-        self
-    }
-
-    /// Sets the hook that is run once the node has started.
-    pub fn on_node_started2<F>(mut self, hook: F) -> Self
-    where
         F: FnOnce(FullNode<NodeAdapter<T, CB::Components>>) -> eyre::Result<()> + Send + 'static,
     {
-        self.add_ons.hooks.set_on_node_started2(Box::new(hook));
+        self.add_ons.hooks.set_on_node_started(hook);
         self
     }
 
     /// Sets the hook that is run once the rpc server is started.
     pub fn on_rpc_started<F>(mut self, hook: F) -> Self
     where
-        F: Fn(
+        F: FnOnce(
                 RpcContext<'_, NodeAdapter<T, CB::Components>>,
                 RethRpcServerHandles,
             ) -> eyre::Result<()>
@@ -198,7 +189,9 @@ impl<T: FullNodeTypes, CB: NodeComponentsBuilder<T>> NodeBuilderWithComponents<T
     /// Sets the hook that is run to configure the rpc modules.
     pub fn extend_rpc_modules<F>(mut self, hook: F) -> Self
     where
-        F: Fn(RpcContext<'_, NodeAdapter<T, CB::Components>>) -> eyre::Result<()> + Send + 'static,
+        F: FnOnce(RpcContext<'_, NodeAdapter<T, CB::Components>>) -> eyre::Result<()>
+            + Send
+            + 'static,
     {
         self.add_ons.rpc.set_extend_rpc_modules(hook);
         self
@@ -211,7 +204,7 @@ impl<T: FullNodeTypes, CB: NodeComponentsBuilder<T>> NodeBuilderWithComponents<T
     /// The ExEx ID must be unique.
     pub fn install_exex<F, R, E>(mut self, exex_id: impl Into<String>, exex: F) -> Self
     where
-        F: Fn(ExExContext<NodeAdapter<T, CB::Components>>) -> R + Send + 'static,
+        F: FnOnce(ExExContext<NodeAdapter<T, CB::Components>>) -> R + Send + 'static,
         R: Future<Output = eyre::Result<E>> + Send,
         E: Future<Output = eyre::Result<()>> + Send,
     {

--- a/crates/node/builder/src/builder/states.rs
+++ b/crates/node/builder/src/builder/states.rs
@@ -172,6 +172,15 @@ impl<T: FullNodeTypes, CB: NodeComponentsBuilder<T>> NodeBuilderWithComponents<T
         self
     }
 
+    /// Sets the hook that is run once the node has started.
+    pub fn on_node_started2<F>(mut self, hook: F) -> Self
+    where
+        F: FnOnce(FullNode<NodeAdapter<T, CB::Components>>) -> eyre::Result<()> + Send + 'static,
+    {
+        self.add_ons.hooks.set_on_node_started2(Box::new(hook));
+        self
+    }
+
     /// Sets the hook that is run once the rpc server is started.
     pub fn on_rpc_started<F>(mut self, hook: F) -> Self
     where

--- a/crates/node/builder/src/launch/mod.rs
+++ b/crates/node/builder/src/launch/mod.rs
@@ -159,7 +159,7 @@ where
         debug!(target: "reth::cli", "creating components");
         let components = components_builder.build_components(&builder_ctx).await?;
 
-        let NodeHooks { on_component_initialized, on_node_started, .. } = hooks;
+        let NodeHooks { on_component_initialized, on_node_started, on_node_started2,.. } = hooks;
 
         let node_adapter = NodeAdapter {
             components,
@@ -460,7 +460,7 @@ address.to_string(), format_ether(alloc.balance));
             data_dir: ctx.data_dir().clone(),
         };
         // Notify on node started
-        on_node_started.on_event(full_node.clone())?;
+        on_node_started2.on_event(full_node.clone())?;
 
         let handle = NodeHandle {
             node_exit_future: NodeExitFuture::new(rx, full_node.config.debug.terminate),

--- a/crates/node/builder/src/launch/mod.rs
+++ b/crates/node/builder/src/launch/mod.rs
@@ -159,7 +159,7 @@ where
         debug!(target: "reth::cli", "creating components");
         let components = components_builder.build_components(&builder_ctx).await?;
 
-        let NodeHooks { on_component_initialized, on_node_started, on_node_started2,.. } = hooks;
+        let NodeHooks { on_component_initialized, on_node_started, .. } = hooks;
 
         let node_adapter = NodeAdapter {
             components,
@@ -232,8 +232,7 @@ where
                 async move {
                     while let Ok(notification) = canon_state_notifications.recv().await {
                         handle.send_async(notification.into()).await.expect(
-                            "blockchain tree notification could not be sent to exex
-manager",
+                            "blockchain tree notification could not be sent to exex manager",
                         );
                     }
                 },
@@ -460,7 +459,7 @@ address.to_string(), format_ether(alloc.balance));
             data_dir: ctx.data_dir().clone(),
         };
         // Notify on node started
-        on_node_started2.on_event(full_node.clone())?;
+        on_node_started.on_event(full_node.clone())?;
 
         let handle = NodeHandle {
             node_exit_future: NodeExitFuture::new(rx, full_node.config.debug.terminate),

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -98,7 +98,7 @@ impl<Node: FullNodeComponents> fmt::Debug for RpcHooks<Node> {
 pub trait OnRpcStarted<Node: FullNodeComponents>: Send {
     /// The hook that is called once the rpc server is started.
     fn on_rpc_started(
-        &self,
+        self: Box<Self>,
         ctx: RpcContext<'_, Node>,
         handles: RethRpcServerHandles,
     ) -> eyre::Result<()>;
@@ -106,20 +106,24 @@ pub trait OnRpcStarted<Node: FullNodeComponents>: Send {
 
 impl<Node, F> OnRpcStarted<Node> for F
 where
-    F: Fn(RpcContext<'_, Node>, RethRpcServerHandles) -> eyre::Result<()> + Send,
+    F: FnOnce(RpcContext<'_, Node>, RethRpcServerHandles) -> eyre::Result<()> + Send,
     Node: FullNodeComponents,
 {
     fn on_rpc_started(
-        &self,
+        self: Box<Self>,
         ctx: RpcContext<'_, Node>,
         handles: RethRpcServerHandles,
     ) -> eyre::Result<()> {
-        self(ctx, handles)
+        (*self)(ctx, handles)
     }
 }
 
 impl<Node: FullNodeComponents> OnRpcStarted<Node> for () {
-    fn on_rpc_started(&self, _: RpcContext<'_, Node>, _: RethRpcServerHandles) -> eyre::Result<()> {
+    fn on_rpc_started(
+        self: Box<Self>,
+        _: RpcContext<'_, Node>,
+        _: RethRpcServerHandles,
+    ) -> eyre::Result<()> {
         Ok(())
     }
 }
@@ -127,21 +131,21 @@ impl<Node: FullNodeComponents> OnRpcStarted<Node> for () {
 /// Event hook that is called when the rpc server is started.
 pub trait ExtendRpcModules<Node: FullNodeComponents>: Send {
     /// The hook that is called once the rpc server is started.
-    fn extend_rpc_modules(&self, ctx: RpcContext<'_, Node>) -> eyre::Result<()>;
+    fn extend_rpc_modules(self: Box<Self>, ctx: RpcContext<'_, Node>) -> eyre::Result<()>;
 }
 
 impl<Node, F> ExtendRpcModules<Node> for F
 where
-    F: Fn(RpcContext<'_, Node>) -> eyre::Result<()> + Send,
+    F: FnOnce(RpcContext<'_, Node>) -> eyre::Result<()> + Send,
     Node: FullNodeComponents,
 {
-    fn extend_rpc_modules(&self, ctx: RpcContext<'_, Node>) -> eyre::Result<()> {
-        self(ctx)
+    fn extend_rpc_modules(self: Box<Self>, ctx: RpcContext<'_, Node>) -> eyre::Result<()> {
+        (*self)(ctx)
     }
 }
 
 impl<Node: FullNodeComponents> ExtendRpcModules<Node> for () {
-    fn extend_rpc_modules(&self, _: RpcContext<'_, Node>) -> eyre::Result<()> {
+    fn extend_rpc_modules(self: Box<Self>, _: RpcContext<'_, Node>) -> eyre::Result<()> {
         Ok(())
     }
 }


### PR DESCRIPTION
replace Fn hooks with FnOnce,

we never expose the traits directly, they are effectively just helpers and only called once, so  we can do `self: Box<Self>`