### PR TITLE
wip: enable propagation of custom rpc builder stack layers

### DIFF
--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -361,11 +361,11 @@ Gas Price Oracle:
       --enable-auth
           Enable authentication middleware
 
-      --enable-rate-limit
-          Enable rate limiting middleware
+      --auth-username <AUTH_USERNAME>
+          Username for authentication
 
-      --enable-monitoring
-          Enable monitoring middleware
+      --auth-password <AUTH_PASSWORD>
+          Password for authentication
 
 TxPool:
       --txpool.pending-max-count <PENDING_MAX_COUNT>

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -355,6 +355,18 @@ Gas Price Oracle:
 
           [default: 60]
 
+      --enable-logging
+          Enable logging middleware
+
+      --enable-auth
+          Enable authentication middleware
+
+      --enable-rate-limit
+          Enable rate limiting middleware
+
+      --enable-monitoring
+          Enable monitoring middleware
+
 TxPool:
       --txpool.pending-max-count <PENDING_MAX_COUNT>
           Max number of transaction in the pending sub-pool

--- a/crates/node-core/src/args/rpc_server.rs
+++ b/crates/node-core/src/args/rpc_server.rs
@@ -172,13 +172,13 @@ pub struct RpcServerArgs {
     #[arg(long, default_value_t = false)]
     pub enable_auth: bool,
 
-    /// Enable rate limiting middleware
-    #[arg(long, default_value_t = false)]
-    pub enable_rate_limit: bool,
+    /// Username for authentication
+    #[arg(long, required_if_eq("enable_auth", "true"))]
+    pub auth_username: Option<String>,
 
-    /// Enable monitoring middleware
-    #[arg(long, default_value_t = false)]
-    pub enable_monitoring: bool,
+    /// Password for authentication
+    #[arg(long, required_if_eq("enable_auth", "true"))]
+    pub auth_password: Option<String>,
 }
 
 impl RpcServerArgs {
@@ -306,8 +306,8 @@ impl Default for RpcServerArgs {
             rpc_state_cache: RpcStateCacheArgs::default(),
             enable_logging: false,
             enable_auth: false,
-            enable_rate_limit: false,
-            enable_monitoring: false,
+            auth_username: None,
+            auth_password: None,
         }
     }
 }

--- a/crates/node-core/src/args/rpc_server.rs
+++ b/crates/node-core/src/args/rpc_server.rs
@@ -163,6 +163,22 @@ pub struct RpcServerArgs {
     /// Gas price oracle configuration.
     #[command(flatten)]
     pub gas_price_oracle: GasPriceOracleArgs,
+
+    /// Enable logging middleware
+    #[arg(long, default_value_t = false)]
+    pub enable_logging: bool,
+
+    /// Enable authentication middleware
+    #[arg(long, default_value_t = false)]
+    pub enable_auth: bool,
+
+    /// Enable rate limiting middleware
+    #[arg(long, default_value_t = false)]
+    pub enable_rate_limit: bool,
+
+    /// Enable monitoring middleware
+    #[arg(long, default_value_t = false)]
+    pub enable_monitoring: bool,
 }
 
 impl RpcServerArgs {
@@ -288,6 +304,10 @@ impl Default for RpcServerArgs {
             rpc_gas_cap: RPC_DEFAULT_GAS_CAP.into(),
             gas_price_oracle: GasPriceOracleArgs::default(),
             rpc_state_cache: RpcStateCacheArgs::default(),
+            enable_logging: false,
+            enable_auth: false,
+            enable_rate_limit: false,
+            enable_monitoring: false,
         }
     }
 }

--- a/crates/rpc/rpc-builder/src/config.rs
+++ b/crates/rpc/rpc-builder/src/config.rs
@@ -186,17 +186,17 @@ impl RethRpcServerConfig for RpcServerArgs {
                 config.with_ipc(self.ipc_server_builder()).with_ipc_endpoint(self.ipcpath.clone());
         }
 
-        let service_builder =
-        tower::ServiceBuilder::new()
-                .option_layer(
-                    self.enable_logging.then(tower_http::trace::TraceLayer::new_for_http),
-                )
-                .option_layer(self.enable_auth.then(|| {
-                    if let (Some(username), Some(password)) = (self.auth_username.as_deref(), self.auth_password.as_deref()) {
-                        tower_http::auth::AddAuthorizationLayer::basic(username, password)
-                    } else {
-                        panic!("Auth is enabled but username or password is missing in the config");
-                    }}));
+        let service_builder = tower::ServiceBuilder::new()
+            .option_layer(self.enable_logging.then(tower_http::trace::TraceLayer::new_for_http))
+            .option_layer(self.enable_auth.then(|| {
+                if let (Some(username), Some(password)) =
+                    (self.auth_username.as_deref(), self.auth_password.as_deref())
+                {
+                    tower_http::auth::AddAuthorizationLayer::basic(username, password)
+                } else {
+                    panic!("Auth is enabled but username or password is missing in the config");
+                }
+            }));
 
         config = config.with_additional_middleware::<tower::layer::util::Stack<
             tower::util::Either<tower_http::auth::AddAuthorizationLayer, Identity>,

--- a/crates/rpc/rpc-builder/src/config.rs
+++ b/crates/rpc/rpc-builder/src/config.rs
@@ -50,7 +50,9 @@ pub trait RethRpcServerConfig {
     fn ipc_server_builder(&self) -> IpcServerBuilder<Identity, Identity>;
 
     /// Creates the [`RpcServerConfig`] from cli args.
-    fn rpc_server_config(&self) -> RpcServerConfig<impl tower::Layer<Identity> + Send + std::marker::Sync + 'static>;
+    fn rpc_server_config(
+        &self,
+    ) -> RpcServerConfig<impl tower::Layer<Identity> + Send + std::marker::Sync + 'static>;
 
     /// Creates the [`AuthServerConfig`] from cli args.
     fn auth_server_config(&self, jwt_secret: JwtSecret) -> Result<AuthServerConfig, RpcError>;
@@ -160,7 +162,9 @@ impl RethRpcServerConfig for RpcServerArgs {
             .max_connections(self.rpc_max_connections.get())
     }
 
-    fn rpc_server_config(&self) -> RpcServerConfig<impl tower::Layer<Identity> + Send + Sync + 'static> {
+    fn rpc_server_config(
+        &self,
+    ) -> RpcServerConfig<impl tower::Layer<Identity> + Send + Sync + 'static> {
         let mut config = RpcServerConfig::new().with_jwt_secret(self.rpc_secret_key());
 
         if self.http {

--- a/crates/rpc/rpc-builder/src/config.rs
+++ b/crates/rpc/rpc-builder/src/config.rs
@@ -188,7 +188,8 @@ impl RethRpcServerConfig for RpcServerArgs {
 
         if self.enable_logging {
             let trace_layer = tower_http::trace::TraceLayer::new_for_http();
-            config = config.with_additional_middleware(trace_layer);
+            let service_builder = tower::ServiceBuilder::new().layer(trace_layer);
+            config = config.with_additional_middleware(service_builder);
         }
 
         // if self.enable_auth {

--- a/crates/rpc/rpc-builder/src/config.rs
+++ b/crates/rpc/rpc-builder/src/config.rs
@@ -192,9 +192,12 @@ impl RethRpcServerConfig for RpcServerArgs {
             config = config.with_additional_middleware(service_builder);
         }
 
-        // if self.enable_auth {
-        //     config = config.with_additional_middleware(AuthMiddleware::new());
-        // }
+        // Conditionally add authentication middleware
+        if self.enable_auth {
+            let auth_layer = tower_http::auth::AddAuthorizationLayer::basic("username", "password");
+            let service_builder = tower::ServiceBuilder::new().layer(auth_layer);
+            config = config.with_additional_middleware(service_builder);
+        }
 
         // if self.enable_rate_limit {
         //     config = config.with_additional_middleware(RateLimitMiddleware::new());

--- a/crates/rpc/rpc-builder/src/config.rs
+++ b/crates/rpc/rpc-builder/src/config.rs
@@ -186,19 +186,32 @@ impl RethRpcServerConfig for RpcServerArgs {
                 config.with_ipc(self.ipc_server_builder()).with_ipc_endpoint(self.ipcpath.clone());
         }
 
-        let service_builder = tower::ServiceBuilder::new()
-            .option_layer(self.enable_logging.then(|| tower_http::trace::TraceLayer::new_for_http()))
-            .option_layer(self.enable_auth.then(|| tower_http::auth::AddAuthorizationLayer::basic("username", "password")));
+        let service_builder =
+        tower::ServiceBuilder::new()
+                .option_layer(
+                    self.enable_logging.then(tower_http::trace::TraceLayer::new_for_http),
+                )
+                .option_layer(self.enable_auth.then(|| {
+                    if let (Some(username), Some(password)) = (self.auth_username.as_deref(), self.auth_password.as_deref()) {
+                        tower_http::auth::AddAuthorizationLayer::basic(username, password)
+                    } else {
+                        panic!("Auth is enabled but username or password is missing in the config");
+                    }}));
 
-        config = config.with_additional_middleware::<tower::layer::util::Stack<tower::util::Either<tower_http::auth::AddAuthorizationLayer, Identity>, tower::layer::util::Stack<tower::util::Either<tower_http::trace::TraceLayer<tower_http::classify::SharedClassifier<tower_http::classify::ServerErrorsAsFailures>>, Identity>, Identity>>>(service_builder);
-
-        // if self.enable_rate_limit {
-        //     config = config.with_additional_middleware(RateLimitMiddleware::new());
-        // }
-
-        // if self.enable_monitoring {
-        //     config = config.with_additional_middleware(MonitoringMiddleware::new());
-        // }
+        config = config.with_additional_middleware::<tower::layer::util::Stack<
+            tower::util::Either<tower_http::auth::AddAuthorizationLayer, Identity>,
+            tower::layer::util::Stack<
+                tower::util::Either<
+                    tower_http::trace::TraceLayer<
+                        tower_http::classify::SharedClassifier<
+                            tower_http::classify::ServerErrorsAsFailures,
+                        >,
+                    >,
+                    Identity,
+                >,
+                Identity,
+            >,
+        >>(service_builder);
 
         config
     }

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1168,6 +1168,7 @@ where
 /// Once the [`RpcModule`] is built via [`RpcModuleBuilder`] the servers can be started, See also
 /// [`ServerBuilder::build`] and [`Server::start`](jsonrpsee::server::Server::start).
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct RpcServerConfig<L = Identity>
 where
     L: tower::Layer<Identity> + Send + Sync + 'static,
@@ -1216,7 +1217,12 @@ impl<L> RpcServerConfig<L>
 where
     L: tower::Layer<Identity> + Send + Sync + 'static,
 {
-    pub fn new() -> Self {
+    /// Creates a new `RpcServerConfig` with all fields set to `None`.
+    ///
+    /// # Returns
+    ///
+    /// A new `RpcServerConfig` instance.
+    pub const fn new() -> Self {
         Self {
             http_server_config: None,
             http_cors_domains: None,
@@ -1231,11 +1237,25 @@ where
         }
     }
 
-    pub fn with_additional_middleware<M>(self, layer: L) -> RpcServerConfig<L>
+    /// Adds a middleware layer to the `RpcServerConfig`.
+    ///
+    /// # Parameters
+    ///
+    /// - `layer`: The middleware layer to add.
+    ///
+    /// # Returns
+    ///
+    /// A new `RpcServerConfig` with the added middleware layer.
+    ///
+    /// # Type Parameters
+    ///
+    /// - `M`: The type of the middleware layer, which must implement `tower::Layer<L> + Send + Sync
+    ///   + `static`.
+    pub fn with_additional_middleware<M>(self, layer: M) -> RpcServerConfig<M>
     where
         M: tower::Layer<L> + Send + Sync + 'static + tower::Layer<tower::layer::util::Identity>,
     {
-        Self {
+        RpcServerConfig {
             http_server_config: self.http_server_config,
             http_cors_domains: self.http_cors_domains,
             http_addr: self.http_addr,
@@ -1252,19 +1272,19 @@ where
     /// Creates a new config with only http set
     pub fn http(config: ServerBuilder<Identity, Identity>) -> Self {
         //Self::default().with_http(config)
-        Self { http_server_config: Some(config), ..RpcServerConfig::new() }
+        Self { http_server_config: Some(config), ..Self::new() }
     }
 
     /// Creates a new config with only ws set
     pub fn ws(config: ServerBuilder<Identity, Identity>) -> Self {
         //Self::default().with_ws(config)
-        Self { ws_server_config: Some(config), ..RpcServerConfig::new() }
+        Self { ws_server_config: Some(config), ..Self::new() }
     }
 
     /// Creates a new config with only ipc set
     pub fn ipc(config: IpcServerBuilder<Identity, Identity>) -> Self {
         //Self::default().with_ipc(config)
-        Self { ipc_server_config: Some(config), ..RpcServerConfig::new() }
+        Self { ipc_server_config: Some(config), ..Self::new() }
     }
 
     /// Configures the http server

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1245,10 +1245,41 @@ impl<L> RpcServerConfig<L> {
     /// # Type Parameters
     ///
     /// - `T`: The type of the middleware, which must implement `Send`, `Sync`, and `'static`.
+    #[allow(clippy::type_complexity)]
     pub fn with_additional_middleware<T>(
         self,
-        layer: tower::ServiceBuilder<Stack<tower::util::Either<tower_http::auth::AddAuthorizationLayer, Identity>, Stack<tower::util::Either<tower_http::trace::TraceLayer<tower_http::classify::SharedClassifier<tower_http::classify::ServerErrorsAsFailures>>, Identity>, Identity>>>,
-    ) -> RpcServerConfig<Stack<tower::util::Either<tower_http::auth::AddAuthorizationLayer, Identity>, Stack<tower::util::Either<tower_http::trace::TraceLayer<tower_http::classify::SharedClassifier<tower_http::classify::ServerErrorsAsFailures>>, Identity>, Identity>>> {
+        layer: tower::ServiceBuilder<
+            Stack<
+                tower::util::Either<tower_http::auth::AddAuthorizationLayer, Identity>,
+                Stack<
+                    tower::util::Either<
+                        tower_http::trace::TraceLayer<
+                            tower_http::classify::SharedClassifier<
+                                tower_http::classify::ServerErrorsAsFailures,
+                            >,
+                        >,
+                        Identity,
+                    >,
+                    Identity,
+                >,
+            >,
+        >,
+    ) -> RpcServerConfig<
+        Stack<
+            tower::util::Either<tower_http::auth::AddAuthorizationLayer, Identity>,
+            Stack<
+                tower::util::Either<
+                    tower_http::trace::TraceLayer<
+                        tower_http::classify::SharedClassifier<
+                            tower_http::classify::ServerErrorsAsFailures,
+                        >,
+                    >,
+                    Identity,
+                >,
+                Identity,
+            >,
+        >,
+    > {
         RpcServerConfig {
             http_server_config: self.http_server_config,
             http_cors_domains: self.http_cors_domains,

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1168,7 +1168,7 @@ where
 /// Once the [`RpcModule`] is built via [`RpcModuleBuilder`] the servers can be started, See also
 /// [`ServerBuilder::build`] and [`Server::start`](jsonrpsee::server::Server::start).
 #[derive(Debug)]
-pub struct RpcServerConfig<L = Identity> 
+pub struct RpcServerConfig<L = Identity>
 where
     L: tower::Layer<Identity> + Send + Sync + 'static,
 {
@@ -1197,7 +1197,7 @@ where
 // === impl RpcServerConfig ===
 impl Default for RpcServerConfig<Identity> {
     fn default() -> Self {
-        RpcServerConfig {
+        Self {
             http_server_config: None,
             http_cors_domains: None,
             http_addr: None,
@@ -1212,12 +1212,12 @@ impl Default for RpcServerConfig<Identity> {
     }
 }
 
-impl<L> RpcServerConfig<L> 
+impl<L> RpcServerConfig<L>
 where
     L: tower::Layer<Identity> + Send + Sync + 'static,
 {
     pub fn new() -> Self {
-        RpcServerConfig {
+        Self {
             http_server_config: None,
             http_cors_domains: None,
             http_addr: None,
@@ -1230,12 +1230,12 @@ where
             additional_middleware: None,
         }
     }
-    
-    pub fn with_additional_middleware<M>(self, layer: M) -> RpcServerConfig<M> 
+
+    pub fn with_additional_middleware<M>(self, layer: L) -> RpcServerConfig<L>
     where
         M: tower::Layer<L> + Send + Sync + 'static + tower::Layer<tower::layer::util::Identity>,
     {
-        RpcServerConfig {
+        Self {
             http_server_config: self.http_server_config,
             http_cors_domains: self.http_cors_domains,
             http_addr: self.http_addr,
@@ -1252,28 +1252,19 @@ where
     /// Creates a new config with only http set
     pub fn http(config: ServerBuilder<Identity, Identity>) -> Self {
         //Self::default().with_http(config)
-        RpcServerConfig {
-            http_server_config: Some(config),
-            ..RpcServerConfig::new()
-        }
+        Self { http_server_config: Some(config), ..RpcServerConfig::new() }
     }
 
     /// Creates a new config with only ws set
     pub fn ws(config: ServerBuilder<Identity, Identity>) -> Self {
         //Self::default().with_ws(config)
-        RpcServerConfig {
-            ws_server_config: Some(config),
-            ..RpcServerConfig::new()
-        }
+        Self { ws_server_config: Some(config), ..RpcServerConfig::new() }
     }
 
     /// Creates a new config with only ipc set
     pub fn ipc(config: IpcServerBuilder<Identity, Identity>) -> Self {
         //Self::default().with_ipc(config)
-        RpcServerConfig {
-            ipc_server_config: Some(config),
-            ..RpcServerConfig::new()
-        }
+        Self { ipc_server_config: Some(config), ..RpcServerConfig::new() }
     }
 
     /// Configures the http server
@@ -1774,8 +1765,11 @@ impl TransportRpcModules {
     }
 
     /// Convenience function for starting a server
-    pub async fn start_server<L>(self, builder: RpcServerConfig<L>) -> Result<RpcServerHandle, RpcError>
-        where
+    pub async fn start_server<L>(
+        self,
+        builder: RpcServerConfig<L>,
+    ) -> Result<RpcServerHandle, RpcError>
+    where
         L: tower::Layer<Identity> + Send + Sync + 'static,
     {
         builder.start(self).await

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1247,8 +1247,8 @@ impl<L> RpcServerConfig<L> {
     /// - `T`: The type of the middleware, which must implement `Send`, `Sync`, and `'static`.
     pub fn with_additional_middleware<T>(
         self,
-        layer: tower::ServiceBuilder<T>,
-    ) -> RpcServerConfig<T> {
+        layer: tower::ServiceBuilder<Stack<tower::util::Either<tower_http::auth::AddAuthorizationLayer, Identity>, Stack<tower::util::Either<tower_http::trace::TraceLayer<tower_http::classify::SharedClassifier<tower_http::classify::ServerErrorsAsFailures>>, Identity>, Identity>>>,
+    ) -> RpcServerConfig<Stack<tower::util::Either<tower_http::auth::AddAuthorizationLayer, Identity>, Stack<tower::util::Either<tower_http::trace::TraceLayer<tower_http::classify::SharedClassifier<tower_http::classify::ServerErrorsAsFailures>>, Identity>, Identity>>> {
         RpcServerConfig {
             http_server_config: self.http_server_config,
             http_cors_domains: self.http_cors_domains,

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1232,18 +1232,23 @@ impl<L> RpcServerConfig<L> {
     }
 
     ///
+    /// Adds a middleware layer using `tower::ServiceBuilder`.
+    ///
     /// # Parameters
     ///
-    /// - `layer`: The ServiceBuilder to add.
+    /// - `layer`: The `tower::ServiceBuilder` instance to add as middleware.
     ///
     /// # Returns
     ///
-    /// A new `RpcServerConfig` with the added ServiceBuilder.
+    /// A new `RpcServerConfig` with the added middleware.
     ///
     /// # Type Parameters
     ///
-    /// - `T`: The type of the ServiceBuilder, which must implement `tower::ServiceBuilder + Send + Sync + 'static`.
-    pub fn with_additional_middleware<T>(self, layer: tower::ServiceBuilder<T>) -> RpcServerConfig<T> {
+    /// - `T`: The type of the middleware, which must implement `Send`, `Sync`, and `'static`.
+    pub fn with_additional_middleware<T>(
+        self,
+        layer: tower::ServiceBuilder<T>,
+    ) -> RpcServerConfig<T> {
         RpcServerConfig {
             http_server_config: self.http_server_config,
             http_cors_domains: self.http_cors_domains,

--- a/crates/rpc/rpc-builder/tests/it/startup.rs
+++ b/crates/rpc/rpc-builder/tests/it/startup.rs
@@ -26,7 +26,10 @@ async fn test_http_addr_in_use() {
     let builder = test_rpc_builder();
     let server = builder.build(TransportRpcModuleConfig::set_http(vec![RethRpcModule::Admin]));
     let result = server
-        .start_server(RpcServerConfig::<reth_rpc_builder::Identity>::http(Default::default()).with_http_address(addr))
+        .start_server(
+            RpcServerConfig::<reth_rpc_builder::Identity>::http(Default::default())
+                .with_http_address(addr),
+        )
         .await;
     let err = result.unwrap_err();
     assert!(is_addr_in_use_kind(&err, ServerKind::Http(addr)), "{err}");
@@ -38,8 +41,12 @@ async fn test_ws_addr_in_use() {
     let addr = handle.ws_local_addr().unwrap();
     let builder = test_rpc_builder();
     let server = builder.build(TransportRpcModuleConfig::set_ws(vec![RethRpcModule::Admin]));
-    let result =
-        server.start_server(RpcServerConfig::<reth_rpc_builder::Identity>::ws(Default::default()).with_ws_address(addr)).await;
+    let result = server
+        .start_server(
+            RpcServerConfig::<reth_rpc_builder::Identity>::ws(Default::default())
+                .with_ws_address(addr),
+        )
+        .await;
     let err = result.unwrap_err();
     assert!(is_addr_in_use_kind(&err, ServerKind::WS(addr)), "{err}");
 }

--- a/crates/rpc/rpc-builder/tests/it/startup.rs
+++ b/crates/rpc/rpc-builder/tests/it/startup.rs
@@ -26,7 +26,7 @@ async fn test_http_addr_in_use() {
     let builder = test_rpc_builder();
     let server = builder.build(TransportRpcModuleConfig::set_http(vec![RethRpcModule::Admin]));
     let result = server
-        .start_server(RpcServerConfig::http(Default::default()).with_http_address(addr))
+        .start_server(RpcServerConfig::<reth_rpc_builder::Identity>::http(Default::default()).with_http_address(addr))
         .await;
     let err = result.unwrap_err();
     assert!(is_addr_in_use_kind(&err, ServerKind::Http(addr)), "{err}");
@@ -39,7 +39,7 @@ async fn test_ws_addr_in_use() {
     let builder = test_rpc_builder();
     let server = builder.build(TransportRpcModuleConfig::set_ws(vec![RethRpcModule::Admin]));
     let result =
-        server.start_server(RpcServerConfig::ws(Default::default()).with_ws_address(addr)).await;
+        server.start_server(RpcServerConfig::<reth_rpc_builder::Identity>::ws(Default::default()).with_ws_address(addr)).await;
     let err = result.unwrap_err();
     assert!(is_addr_in_use_kind(&err, ServerKind::WS(addr)), "{err}");
 }
@@ -62,7 +62,7 @@ async fn test_launch_same_port_different_modules() {
     let addr = test_address();
     let res = server
         .start_server(
-            RpcServerConfig::ws(Default::default())
+            RpcServerConfig::<reth_rpc_builder::Identity>::ws(Default::default())
                 .with_ws_address(addr)
                 .with_http(Default::default())
                 .with_http_address(addr),
@@ -85,7 +85,7 @@ async fn test_launch_same_port_same_cors() {
     let addr = test_address();
     let res = server
         .start_server(
-            RpcServerConfig::ws(Default::default())
+            RpcServerConfig::<reth_rpc_builder::Identity>::ws(Default::default())
                 .with_ws_address(addr)
                 .with_http(Default::default())
                 .with_cors(Some("*".to_string()))
@@ -106,7 +106,7 @@ async fn test_launch_same_port_different_cors() {
     let addr = test_address();
     let res = server
         .start_server(
-            RpcServerConfig::ws(Default::default())
+            RpcServerConfig::<reth_rpc_builder::Identity>::ws(Default::default())
                 .with_ws_address(addr)
                 .with_http(Default::default())
                 .with_cors(Some("*".to_string()))

--- a/crates/rpc/rpc-builder/tests/it/utils.rs
+++ b/crates/rpc/rpc-builder/tests/it/utils.rs
@@ -54,7 +54,7 @@ pub async fn launch_http(modules: impl Into<RpcModuleSelection>) -> RpcServerHan
     let server = builder.build(TransportRpcModuleConfig::set_http(modules));
     server
         .start_server(
-            RpcServerConfig::<L>::http(Default::default()).with_http_address(test_address()),
+            RpcServerConfig::<reth_rpc_builder::Identity>::http(Default::default()).with_http_address(test_address()),
         )
         .await
         .unwrap()
@@ -65,7 +65,7 @@ pub async fn launch_ws(modules: impl Into<RpcModuleSelection>) -> RpcServerHandl
     let builder = test_rpc_builder();
     let server = builder.build(TransportRpcModuleConfig::set_ws(modules));
     server
-        .start_server(RpcServerConfig::<L>::ws(Default::default()).with_ws_address(test_address()))
+        .start_server(RpcServerConfig::<reth_rpc_builder::Identity>::ws(Default::default()).with_ws_address(test_address()))
         .await
         .unwrap()
 }
@@ -78,7 +78,7 @@ pub async fn launch_http_ws(modules: impl Into<RpcModuleSelection>) -> RpcServer
         builder.build(TransportRpcModuleConfig::set_ws(modules.clone()).with_http(modules));
     server
         .start_server(
-            RpcServerConfig::ws(Default::default())
+            RpcServerConfig::<reth_rpc_builder::Identity>::ws(Default::default())
                 .with_ws_address(test_address())
                 .with_http(Default::default())
                 .with_http_address(test_address()),
@@ -96,7 +96,7 @@ pub async fn launch_http_ws_same_port(modules: impl Into<RpcModuleSelection>) ->
     let addr = test_address();
     server
         .start_server(
-            RpcServerConfig::ws(Default::default())
+            RpcServerConfig::<reth_rpc_builder::Identity>::ws(Default::default())
                 .with_ws_address(addr)
                 .with_http(Default::default())
                 .with_http_address(addr),

--- a/crates/rpc/rpc-builder/tests/it/utils.rs
+++ b/crates/rpc/rpc-builder/tests/it/utils.rs
@@ -53,7 +53,9 @@ pub async fn launch_http(modules: impl Into<RpcModuleSelection>) -> RpcServerHan
     let builder = test_rpc_builder();
     let server = builder.build(TransportRpcModuleConfig::set_http(modules));
     server
-        .start_server(RpcServerConfig::http(Default::default()).with_http_address(test_address()))
+        .start_server(
+            RpcServerConfig::<L>::http(Default::default()).with_http_address(test_address()),
+        )
         .await
         .unwrap()
 }
@@ -63,7 +65,7 @@ pub async fn launch_ws(modules: impl Into<RpcModuleSelection>) -> RpcServerHandl
     let builder = test_rpc_builder();
     let server = builder.build(TransportRpcModuleConfig::set_ws(modules));
     server
-        .start_server(RpcServerConfig::ws(Default::default()).with_ws_address(test_address()))
+        .start_server(RpcServerConfig::<L>::ws(Default::default()).with_ws_address(test_address()))
         .await
         .unwrap()
 }

--- a/crates/rpc/rpc-builder/tests/it/utils.rs
+++ b/crates/rpc/rpc-builder/tests/it/utils.rs
@@ -54,7 +54,8 @@ pub async fn launch_http(modules: impl Into<RpcModuleSelection>) -> RpcServerHan
     let server = builder.build(TransportRpcModuleConfig::set_http(modules));
     server
         .start_server(
-            RpcServerConfig::<reth_rpc_builder::Identity>::http(Default::default()).with_http_address(test_address()),
+            RpcServerConfig::<reth_rpc_builder::Identity>::http(Default::default())
+                .with_http_address(test_address()),
         )
         .await
         .unwrap()
@@ -65,7 +66,10 @@ pub async fn launch_ws(modules: impl Into<RpcModuleSelection>) -> RpcServerHandl
     let builder = test_rpc_builder();
     let server = builder.build(TransportRpcModuleConfig::set_ws(modules));
     server
-        .start_server(RpcServerConfig::<reth_rpc_builder::Identity>::ws(Default::default()).with_ws_address(test_address()))
+        .start_server(
+            RpcServerConfig::<reth_rpc_builder::Identity>::ws(Default::default())
+                .with_ws_address(test_address()),
+        )
         .await
         .unwrap()
 }

--- a/examples/rpc-db/src/main.rs
+++ b/examples/rpc-db/src/main.rs
@@ -17,6 +17,7 @@ use reth::{
         providers::{BlockchainProvider, StaticFileProvider},
         ProviderFactory,
     },
+    rpc::builder::Identity,
     utils::db::open_db_read_only,
 };
 use reth_chainspec::ChainSpecBuilder;
@@ -78,7 +79,7 @@ async fn main() -> eyre::Result<()> {
     server.merge_configured(custom_rpc.into_rpc())?;
 
     // Start the server & keep it alive
-    let server_args =
+    let server_args: reth::rpc::builder::RpcServerConfig<Identity> =
         RpcServerConfig::http(Default::default()).with_http_address("0.0.0.0:8545".parse()?);
     let _handle = server_args.start(server).await?;
     futures::future::pending::<()>().await;


### PR DESCRIPTION
here's all the info i've collected about this task...

if you want to continue, then we can continue with flattening it even more or support configuring additional middleware layers

---

the endgoal for this is that we can propgate custom Layers through the rpc-builder stack

if you look at how the node-builder api currently works, it would be great to plug in a layer.

[reth/examples/cli-extension-event-hooks/src/main.rs](https://github.com/paradigmxyz/reth/blob/58cb524d73e1935a263ab8cd08777580cf67e15a/examples/cli-extension-event-hooks/src/main.rs#L22-L39)


```rust
fn main() {
    Cli::parse_args()
        .run(|builder, _| async move {
            let handle = builder
                .node(EthereumNode::default())
                .on_node_started(|_ctx| {
                    println!("Node started");
                    Ok(())
                })
                .on_rpc_started(|_ctx, _handles| {
                    println!("RPC started");
                    Ok(())
                })
                .on_component_initialized(|_ctx| {
                    println!("All components initialized");
                    Ok(())
                })
                .launch()
                .await?;

            handle.wait_for_node_exit().await
        })
        .unwrap();
}
```

---
*Ok yeah, that makes sense to me. We’d parse the arguments out into an option layer.*

*Is it that there would be a set of possible layers we could intake that would be specified with different flags, or more like they would be generic and we’d figure out once they’re injested how to handle them*

---

what I'm looking for is something similar to the `tower::ServiceBuilder<T>` so we can install additional layers when we build the rpc server

for example here is where we launch the thing


[reth/crates/node-builder/src/rpc.rs](https://github.com/paradigmxyz/reth/blob/250da4e449d1872625fa6d8b0a943ceb0f6b8379/crates/node-builder/src/rpc.rs#L287-L288)

```rust
let server_config = config.rpc.rpc_server_config();
let launch_rpc = modules.clone().start_server(server_config).map_ok(|handle| {
    if let Some(url) = handle.ipc_endpoint() {
        info!(target: "reth::cli", url=%url, "RPC IPC server started");
    }
    if let Some(addr) = handle.http_local_addr() {
        info!(target: "reth::cli", url=%addr, "RPC HTTP server started");
    }
    if let Some(addr) = handle.ws_local_addr() {
        info!(target: "reth::cli", url=%addr, "RPC WS server started");
    }
    handle
});
```

so perhaps we can extend `RpcServerConfig` with `<M = Identity>` so we can configure additional middlewares?

```
#[derive(Default)]
pub struct RpcServerConfig {
    /// Configs for JSON-RPC Http.
    http_server_config: Option<ServerBuilder<Identity, Identity>>,
    /// Allowed CORS Domains for http
    http_cors_domains: Option<String>,
    /// Address where to bind the http server to
    http_addr: Option<SocketAddr>,
    /// Configs for WS server
    ws_server_config: Option<ServerBuilder<Identity, Identity>>,
    /// Allowed CORS Domains for ws.
    ws_cors_domains: Option<String>,
    /// Address where to bind the ws server to
    ws_addr: Option<SocketAddr>,
    /// Configs for JSON-RPC IPC server
    ipc_server_config: Option<IpcServerBuilder>,
    /// The Endpoint where to launch the ipc server
    ipc_endpoint: Option<Endpoint>,
    /// JWT secret for authentication
    jwt_secret: Option<JwtSecret>,
}
```

---
---

goal should be that it's possible to plug in an additional Layer here:

[reth/crates/node-builder/src/rpc.rs](https://github.com/paradigmxyz/reth/blob/688ee06e98774596d7f09283fd68f73303f2f0b6/crates/node-builder/src/rpc.rs#L287-L301)

```rust
let server_config = config.rpc.rpc_server_config();
let launch_rpc = modules.clone().start_server(server_config).map_ok(|handle| {
    if let Some(url) = handle.ipc_endpoint() {
        info!(target: "reth::cli", url=%url, "RPC IPC server started");
    }
    if let Some(addr) = handle.http_local_addr() {
        info!(target: "reth::cli", url=%addr, "RPC HTTP server started");
    }
    if let Some(addr) = handle.ws_local_addr() {
        info!(target: "reth::cli", url=%addr, "RPC WS server started");
    }
    handle
});
```

the way we currently use this, bypasses this intermediary step that uses the `RpcServer` type entirely


[reth/crates/rpc/rpc-builder/src/lib.rs](https://github.com/paradigmxyz/reth/blob/688ee06e98774596d7f09283fd68f73303f2f0b6/crates/rpc/rpc-builder/src/lib.rs#L1636-L1639)


```rust
/// Convenience function to do [RpcServerConfig::build] and [RpcServer::start] in one step
pub async fn start(self, modules: TransportRpcModules) -> Result<RpcServerHandle, RpcError> {
    self.build(&modules).await?.start(modules).await
}
```

the way the config is setup is basically with empty serverbuilders (Identity)

```rust
http_server_config: Option<ServerBuilder<Identity, Identity>>,
/// Allowed CORS Domains for http
http_cors_domains: Option<String>,
/// Address where to bind the http server to
http_addr: Option<SocketAddr>,
/// Configs for WS server
ws_server_config: Option<ServerBuilder<Identity, Identity>>,
/// Allowed CORS Domains for ws.
ws_cors_domains: Option<String>,
/// Address where to bind the ws server to
ws_addr: Option<SocketAddr>,
/// Configs for JSON-RPC IPC server
ipc_server_config: Option<IpcServerBuilder<Identity, Identity>>,
```

I think what we could do is something like
```rust
RpcServerConfig<Http =Identity, Rpc=Identity> {
   http: Http,
   rpc: Rpc
}`
```

---
---

Support the installation additional layers when building the RPC server, with the intention of enabling the propagation of custom layers thru the RPC builder stack. 

Analogous to [`tower::ServiceBuilder<T>`](https://docs.rs/tower/latest/tower/struct.ServiceBuilder.html).

Ultimately will involve an update to [`rpc_server_config`](https://github.com/paradigmxyz/reth/blob/250da4e449d1872625fa6d8b0a943ceb0f6b8379/crates/node-builder/src/rpc.rs#L287-L288) functions.

The resulting code should incorporate the [intermediary RpcServer type](https://github.com/paradigmxyz/reth/blob/688ee06e98774596d7f09283fd68f73303f2f0b6/crates/rpc/rpc-builder/src/lib.rs#L1636-L1639) for setup.

---

This code is an initial attempt at a simplification of `RpcServerConfig` with the intention of generalizing associated operations. 

