### PR TITLE
feat: add method to EthBuiltPayload to get blob sidecars

### DIFF
--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -57,6 +57,11 @@ impl EthBuiltPayload {
         self.fees
     }
 
+    /// Returns the blob sidecars.
+    pub fn sidecars(&self) -> &Vec<BlobTransactionSidecar> {
+        &self.sidecars
+    }
+
     /// Adds sidecars to the payload.
     pub fn extend_sidecars(&mut self, sidecars: Vec<BlobTransactionSidecar>) {
         self.sidecars.extend(sidecars)

--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -58,7 +58,7 @@ impl EthBuiltPayload {
     }
 
     /// Returns the blob sidecars.
-    pub fn sidecars(&self) -> &Vec<BlobTransactionSidecar> {
+    pub fn sidecars(&self) -> &[BlobTransactionSidecar] {
         &self.sidecars
     }
 


### PR DESCRIPTION
add method `EthBuiltPayload::sidecars` to retrieve (possibly empty) blob sidecars for the payload.