### PR TITLE
feat: `StaticFileProviderFactory`

### DIFF
--- a/bin/reth/src/commands/db/clear.rs
+++ b/bin/reth/src/commands/db/clear.rs
@@ -7,7 +7,7 @@ use reth_db::{
     TableViewer, Tables,
 };
 use reth_primitives::{static_file::find_fixed_range, StaticFileSegment};
-use reth_provider::ProviderFactory;
+use reth_provider::{ProviderFactory, StaticFileProviderFactory};
 
 /// The arguments for the `reth db clear` command
 #[derive(Parser, Debug)]

--- a/bin/reth/src/commands/db/get.rs
+++ b/bin/reth/src/commands/db/get.rs
@@ -7,6 +7,7 @@ use reth_db::{
     tables, RawKey, RawTable, Receipts, TableViewer, Transactions,
 };
 use reth_primitives::{BlockHash, Header, StaticFileSegment};
+use reth_provider::StaticFileProviderFactory;
 use tracing::error;
 
 /// The arguments for the `reth db get` command

--- a/bin/reth/src/commands/debug_cmd/execution.rs
+++ b/bin/reth/src/commands/debug_cmd/execution.rs
@@ -29,7 +29,10 @@ use reth_node_ethereum::EthEvmConfig;
 use reth_primitives::{
     fs, stage::StageId, BlockHashOrNumber, BlockNumber, ChainSpec, PruneModes, B256,
 };
-use reth_provider::{BlockExecutionWriter, HeaderSyncMode, ProviderFactory, StageCheckpointReader};
+use reth_provider::{
+    BlockExecutionWriter, HeaderSyncMode, ProviderFactory, StageCheckpointReader,
+    StaticFileProviderFactory,
+};
 use reth_stages::{
     sets::DefaultStages,
     stages::{ExecutionStage, ExecutionStageThresholds, SenderRecoveryStage},

--- a/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
@@ -21,7 +21,8 @@ use reth_node_ethereum::EthEvmConfig;
 use reth_primitives::{fs, stage::StageId, BlockHashOrNumber, ChainSpec};
 use reth_provider::{
     AccountExtReader, ExecutorFactory, HashingWriter, HeaderProvider, LatestStateProviderRef,
-    OriginalValuesKnown, ProviderFactory, StageCheckpointReader, StorageReader,
+    OriginalValuesKnown, ProviderFactory, StageCheckpointReader, StaticFileProviderFactory,
+    StorageReader,
 };
 use reth_tasks::TaskExecutor;
 use reth_trie::{updates::TrieKey, StateRoot};

--- a/bin/reth/src/commands/debug_cmd/replay_engine.rs
+++ b/bin/reth/src/commands/debug_cmd/replay_engine.rs
@@ -24,7 +24,10 @@ use reth_node_core::engine_api_store::{EngineApiStore, StoredEngineApiMessage};
 use reth_node_ethereum::{EthEngineTypes, EthEvmConfig};
 use reth_payload_builder::{PayloadBuilderHandle, PayloadBuilderService};
 use reth_primitives::{fs, ChainSpec, PruneModes};
-use reth_provider::{providers::BlockchainProvider, CanonStateSubscriptions, ProviderFactory};
+use reth_provider::{
+    providers::BlockchainProvider, CanonStateSubscriptions, ProviderFactory,
+    StaticFileProviderFactory,
+};
 use reth_revm::EvmProcessorFactory;
 use reth_stages::Pipeline;
 use reth_static_file::StaticFileProducer;

--- a/bin/reth/src/commands/import.rs
+++ b/bin/reth/src/commands/import.rs
@@ -31,7 +31,7 @@ use reth_node_events::node::NodeEvent;
 use reth_primitives::{stage::StageId, ChainSpec, PruneModes, B256};
 use reth_provider::{
     BlockNumReader, HeaderProvider, HeaderSyncMode, ProviderError, ProviderFactory,
-    StageCheckpointReader,
+    StageCheckpointReader, StaticFileProviderFactory,
 };
 use reth_stages::{
     prelude::*,

--- a/bin/reth/src/commands/stage/drop.rs
+++ b/bin/reth/src/commands/stage/drop.rs
@@ -15,7 +15,7 @@ use reth_node_core::init::{insert_genesis_header, insert_genesis_history, insert
 use reth_primitives::{
     fs, stage::StageId, static_file::find_fixed_range, ChainSpec, StaticFileSegment,
 };
-use reth_provider::{providers::StaticFileWriter, ProviderFactory};
+use reth_provider::{providers::StaticFileWriter, ProviderFactory, StaticFileProviderFactory};
 use std::sync::Arc;
 
 /// `reth drop-stage` command

--- a/bin/reth/src/commands/stage/run.rs
+++ b/bin/reth/src/commands/stage/run.rs
@@ -21,7 +21,9 @@ use reth_downloaders::bodies::bodies::BodiesDownloaderBuilder;
 use reth_exex::ExExManagerHandle;
 use reth_node_ethereum::EthEvmConfig;
 use reth_primitives::ChainSpec;
-use reth_provider::{ProviderFactory, StageCheckpointReader, StageCheckpointWriter};
+use reth_provider::{
+    ProviderFactory, StageCheckpointReader, StageCheckpointWriter, StaticFileProviderFactory,
+};
 use reth_stages::{
     stages::{
         AccountHashingStage, BodyStage, ExecutionStage, ExecutionStageThresholds,

--- a/bin/reth/src/commands/stage/unwind.rs
+++ b/bin/reth/src/commands/stage/unwind.rs
@@ -25,6 +25,7 @@ use reth_node_ethereum::EthEvmConfig;
 use reth_primitives::{BlockHashOrNumber, ChainSpec, PruneModes, B256};
 use reth_provider::{
     BlockExecutionWriter, BlockNumReader, ChainSpecProvider, HeaderSyncMode, ProviderFactory,
+    StaticFileProviderFactory,
 };
 use reth_prune::PrunerBuilder;
 use reth_stages::{

--- a/crates/blockchain-tree/src/externals.rs
+++ b/crates/blockchain-tree/src/externals.rs
@@ -6,7 +6,7 @@ use reth_db::{
 };
 use reth_interfaces::RethResult;
 use reth_primitives::{BlockHash, BlockNumber, StaticFileSegment};
-use reth_provider::{ProviderFactory, StatsReader};
+use reth_provider::{ProviderFactory, StaticFileProviderFactory, StatsReader};
 use std::{collections::BTreeMap, sync::Arc};
 
 /// A container for external components.

--- a/crates/consensus/beacon/src/engine/sync.rs
+++ b/crates/consensus/beacon/src/engine/sync.rs
@@ -437,7 +437,7 @@ mod tests {
     };
     use reth_provider::{
         test_utils::{create_test_provider_factory_with_chain_spec, TestExecutorFactory},
-        BundleStateWithReceipts,
+        BundleStateWithReceipts, StaticFileProviderFactory,
     };
     use reth_stages::{test_utils::TestStages, ExecOutput, StageError};
     use reth_static_file::StaticFileProducer;

--- a/crates/consensus/beacon/src/engine/test_utils.rs
+++ b/crates/consensus/beacon/src/engine/test_utils.rs
@@ -27,6 +27,7 @@ use reth_provider::{
     providers::BlockchainProvider,
     test_utils::{create_test_provider_factory_with_chain_spec, TestExecutorFactory},
     BundleStateWithReceipts, ExecutorFactory, HeaderSyncMode, PrunableBlockExecutor,
+    StaticFileProviderFactory,
 };
 use reth_prune::Pruner;
 use reth_revm::EvmProcessorFactory;

--- a/crates/node-core/src/init.rs
+++ b/crates/node-core/src/init.rs
@@ -15,7 +15,7 @@ use reth_provider::{
     providers::{StaticFileProvider, StaticFileWriter},
     BlockHashReader, BlockNumReader, BundleStateWithReceipts, ChainSpecProvider,
     DatabaseProviderRW, HashingWriter, HistoryWriter, OriginalValuesKnown, ProviderError,
-    ProviderFactory,
+    ProviderFactory, StaticFileProviderFactory,
 };
 use reth_trie::{IntermediateStateRootState, StateRoot as StateRootComputer, StateRootProgress};
 use serde::{Deserialize, Serialize};

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -17,7 +17,7 @@ use reth_node_core::{
     node_config::NodeConfig,
 };
 use reth_primitives::{BlockNumber, Chain, ChainSpec, Head, PruneModes, B256};
-use reth_provider::{providers::StaticFileProvider, ProviderFactory};
+use reth_provider::{providers::StaticFileProvider, ProviderFactory, StaticFileProviderFactory};
 use reth_prune::PrunerBuilder;
 use reth_rpc::JwtSecret;
 use reth_static_file::StaticFileProducer;

--- a/crates/prune/src/pruner.rs
+++ b/crates/prune/src/pruner.rs
@@ -10,7 +10,9 @@ use reth_primitives::{
     BlockNumber, FinishedExExHeight, PruneLimiter, PruneMode, PruneProgress, PrunePurpose,
     PruneSegment, StaticFileSegment,
 };
-use reth_provider::{DatabaseProviderRW, ProviderFactory, PruneCheckpointReader};
+use reth_provider::{
+    DatabaseProviderRW, ProviderFactory, PruneCheckpointReader, StaticFileProviderFactory,
+};
 use reth_tokio_util::EventListeners;
 use std::{
     collections::BTreeMap,

--- a/crates/stages-api/src/pipeline/mod.rs
+++ b/crates/stages-api/src/pipeline/mod.rs
@@ -13,6 +13,7 @@ use reth_primitives::{
 };
 use reth_provider::{
     providers::StaticFileWriter, ProviderFactory, StageCheckpointReader, StageCheckpointWriter,
+    StaticFileProviderFactory,
 };
 use reth_static_file::StaticFileProducer;
 use reth_tokio_util::EventListeners;

--- a/crates/stages/src/lib.rs
+++ b/crates/stages/src/lib.rs
@@ -24,6 +24,7 @@
 //! # use tokio::sync::watch;
 //! # use reth_evm_ethereum::EthEvmConfig;
 //! # use reth_provider::ProviderFactory;
+//! # use reth_provider::StaticFileProviderFactory;
 //! # use reth_provider::HeaderSyncMode;
 //! # use reth_provider::test_utils::create_test_provider_factory;
 //! # use reth_static_file::StaticFileProducer;

--- a/crates/stages/src/sets.rs
+++ b/crates/stages/src/sets.rs
@@ -15,6 +15,7 @@
 //! # use reth_revm::EvmProcessorFactory;
 //! # use reth_primitives::{PruneModes, MAINNET};
 //! # use reth_evm_ethereum::EthEvmConfig;
+//! # use reth_provider::StaticFileProviderFactory;
 //! # use reth_provider::test_utils::create_test_provider_factory;
 //! # use reth_static_file::StaticFileProducer;
 //! # use reth_config::config::EtlConfig;

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -381,6 +381,7 @@ mod tests {
     use assert_matches::assert_matches;
 
     use reth_primitives::stage::StageUnitCheckpoint;
+    use reth_provider::StaticFileProviderFactory;
     use test_utils::*;
 
     use crate::test_utils::{
@@ -632,7 +633,8 @@ mod tests {
             StaticFileSegment, TxNumber, B256,
         };
         use reth_provider::{
-            providers::StaticFileWriter, HeaderProvider, ProviderFactory, TransactionsProvider,
+            providers::StaticFileWriter, HeaderProvider, ProviderFactory,
+            StaticFileProviderFactory, TransactionsProvider,
         };
         use reth_stages_api::{ExecInput, ExecOutput, UnwindInput};
 

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -616,7 +616,10 @@ mod tests {
         Bytecode, ChainSpecBuilder, PruneMode, ReceiptsLogPruneConfig, SealedBlock, StorageEntry,
         B256, U256,
     };
-    use reth_provider::{test_utils::create_test_provider_factory, AccountReader, ReceiptProvider};
+    use reth_provider::{
+        test_utils::create_test_provider_factory, AccountReader, ReceiptProvider,
+        StaticFileProviderFactory,
+    };
     use reth_revm::EvmProcessorFactory;
     use std::collections::BTreeMap;
 

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -387,7 +387,9 @@ mod tests {
     use reth_primitives::{
         stage::StageUnitCheckpoint, BlockBody, SealedBlock, SealedBlockWithSenders, B256,
     };
-    use reth_provider::{BlockWriter, BundleStateWithReceipts, ProviderFactory};
+    use reth_provider::{
+        BlockWriter, BundleStateWithReceipts, ProviderFactory, StaticFileProviderFactory,
+    };
     use reth_trie::{updates::TrieUpdates, HashedPostState};
     use test_runner::HeadersTestRunner;
 

--- a/crates/stages/src/stages/merkle.rs
+++ b/crates/stages/src/stages/merkle.rs
@@ -377,7 +377,7 @@ mod tests {
     use reth_primitives::{
         keccak256, stage::StageUnitCheckpoint, SealedBlock, StaticFileSegment, StorageEntry, U256,
     };
-    use reth_provider::providers::StaticFileWriter;
+    use reth_provider::{providers::StaticFileWriter, StaticFileProviderFactory};
     use reth_trie::test_utils::{state_root, state_root_prehashed};
     use std::collections::BTreeMap;
 

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -292,7 +292,10 @@ mod tests {
         stage::StageUnitCheckpoint, BlockNumber, PruneCheckpoint, PruneMode, SealedBlock,
         TransactionSigned, B256,
     };
-    use reth_provider::{providers::StaticFileWriter, PruneCheckpointWriter, TransactionsProvider};
+    use reth_provider::{
+        providers::StaticFileWriter, PruneCheckpointWriter, StaticFileProviderFactory,
+        TransactionsProvider,
+    };
 
     use super::*;
     use crate::test_utils::{

--- a/crates/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/src/stages/tx_lookup.rs
@@ -248,7 +248,7 @@ mod tests {
         generators::{random_block, random_block_range},
     };
     use reth_primitives::{stage::StageUnitCheckpoint, BlockNumber, SealedBlock, B256};
-    use reth_provider::providers::StaticFileWriter;
+    use reth_provider::{providers::StaticFileWriter, StaticFileProviderFactory};
     use std::ops::Sub;
 
     // Implement stage test suite.

--- a/crates/stages/src/test_utils/macros.rs
+++ b/crates/stages/src/test_utils/macros.rs
@@ -13,7 +13,7 @@ macro_rules! stage_test_suite {
 
                 // Run stage execution
                 let result = runner.execute(input).await;
-                runner.db().factory.static_file_provider().commit().unwrap();
+                reth_provider::StaticFileProviderFactory::static_file_provider(&runner.db().factory).commit().unwrap();
 
                 // Check that the result is returned and the stage does not panic.
                 // The return result with empty db is stage-specific.
@@ -46,7 +46,7 @@ macro_rules! stage_test_suite {
 
                 // Assert the successful result
                 let result = rx.await.unwrap();
-                runner.db().factory.static_file_provider().commit().unwrap();
+                reth_provider::StaticFileProviderFactory::static_file_provider(&runner.db().factory).commit().unwrap();
 
                 assert_matches::assert_matches!(
                     result,
@@ -76,7 +76,7 @@ macro_rules! stage_test_suite {
 
                 // Run stage unwind
                 let rx = runner.unwind(input).await;
-                runner.db().factory.static_file_provider().commit().unwrap();
+                reth_provider::StaticFileProviderFactory::static_file_provider(&runner.db().factory).commit().unwrap();
 
                 assert_matches::assert_matches!(
                     rx,
@@ -110,7 +110,7 @@ macro_rules! stage_test_suite {
 
                 // Assert the successful execution result
                 let result = rx.await.unwrap();
-                runner.db().factory.static_file_provider().commit().unwrap();
+                reth_provider::StaticFileProviderFactory::static_file_provider(&runner.db().factory).commit().unwrap();
 
                 assert_matches::assert_matches!(
                     result,
@@ -179,7 +179,7 @@ macro_rules! stage_test_suite_ext {
 
                 // Assert the successful result
                 let result = rx.await.unwrap();
-                runner.db().factory.static_file_provider().commit().unwrap();
+                reth_provider::StaticFileProviderFactory::static_file_provider(&runner.db().factory).commit().unwrap();
 
                 assert_matches::assert_matches!(
                     result,

--- a/crates/stages/src/test_utils/test_db.rs
+++ b/crates/stages/src/test_utils/test_db.rs
@@ -18,7 +18,7 @@ use reth_primitives::{
 };
 use reth_provider::{
     providers::{StaticFileProviderRWRefMut, StaticFileWriter},
-    HistoryWriter, ProviderError, ProviderFactory,
+    HistoryWriter, ProviderError, ProviderFactory, StaticFileProviderFactory,
 };
 use std::{collections::BTreeMap, path::Path, sync::Arc};
 use tempfile::TempDir;

--- a/crates/static-file/src/static_file_producer.rs
+++ b/crates/static-file/src/static_file_producer.rs
@@ -255,7 +255,7 @@ mod tests {
     };
     use reth_provider::{
         providers::{StaticFileProvider, StaticFileWriter},
-        ProviderFactory,
+        ProviderFactory, StaticFileProviderFactory,
     };
     use reth_stages::test_utils::{StorageKind, TestStageDB};
     use std::{

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     BlockHashReader, BlockNumReader, BlockReader, ChainSpecProvider, DatabaseProviderFactory,
     EvmEnvProvider, HeaderProvider, HeaderSyncGap, HeaderSyncGapProvider, HeaderSyncMode,
     ProviderError, PruneCheckpointReader, StageCheckpointReader, StateProviderBox,
-    TransactionVariant, TransactionsProvider, WithdrawalsProvider,
+    StaticFileProviderFactory, TransactionVariant, TransactionsProvider, WithdrawalsProvider,
 };
 use reth_db::{database::Database, init_db, models::StoredBlockBodyIndices, DatabaseEnv};
 use reth_evm::ConfigureEvmEnv;
@@ -67,11 +67,6 @@ impl<DB> ProviderFactory<DB> {
     /// Returns reference to the underlying database.
     pub fn db_ref(&self) -> &DB {
         &self.db
-    }
-
-    /// Returns static file provider
-    pub fn static_file_provider(&self) -> StaticFileProvider {
-        self.static_file_provider.clone()
     }
 
     #[cfg(any(test, feature = "test-utils"))]
@@ -158,6 +153,13 @@ impl<DB: Database> ProviderFactory<DB> {
 impl<DB: Database> DatabaseProviderFactory<DB> for ProviderFactory<DB> {
     fn database_provider_ro(&self) -> ProviderResult<DatabaseProviderRO<DB>> {
         self.provider()
+    }
+}
+
+impl<DB> StaticFileProviderFactory for ProviderFactory<DB> {
+    /// Returns static file provider
+    fn static_file_provider(&self) -> StaticFileProvider {
+        self.static_file_provider.clone()
     }
 }
 

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -4,8 +4,8 @@ use crate::{
     CanonStateNotifications, CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader,
     DatabaseProviderFactory, EvmEnvProvider, HeaderProvider, ProviderError, PruneCheckpointReader,
     ReceiptProvider, ReceiptProviderIdExt, StageCheckpointReader, StateProviderBox,
-    StateProviderFactory, TransactionVariant, TransactionsProvider, TreeViewer,
-    WithdrawalsProvider,
+    StateProviderFactory, StaticFileProviderFactory, TransactionVariant, TransactionsProvider,
+    TreeViewer, WithdrawalsProvider,
 };
 use reth_db::{
     database::Database,
@@ -139,6 +139,12 @@ where
 {
     fn database_provider_ro(&self) -> ProviderResult<DatabaseProviderRO<DB>> {
         self.database.provider()
+    }
+}
+
+impl<DB> StaticFileProviderFactory for BlockchainProvider<DB> {
+    fn static_file_provider(&self) -> StaticFileProvider {
+        self.database.static_file_provider()
     }
 }
 

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -405,6 +405,7 @@ mod tests {
         providers::state::historical::{HistoryInfo, LowestAvailableBlocks},
         test_utils::create_test_provider_factory,
         AccountReader, HistoricalStateProvider, HistoricalStateProviderRef, StateProvider,
+        StaticFileProviderFactory,
     };
     use reth_db::{
         models::{storage_sharded_key::StorageShardedKey, AccountBeforeTx, ShardedKey},

--- a/crates/storage/provider/src/traits/full.rs
+++ b/crates/storage/provider/src/traits/full.rs
@@ -3,12 +3,14 @@
 use crate::{
     AccountReader, BlockReaderIdExt, CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader,
     DatabaseProviderFactory, EvmEnvProvider, StageCheckpointReader, StateProviderFactory,
+    StaticFileProviderFactory,
 };
 use reth_db::database::Database;
 
 /// Helper trait to unify all provider traits for simplicity.
 pub trait FullProvider<DB: Database>:
     DatabaseProviderFactory<DB>
+    + StaticFileProviderFactory
     + BlockReaderIdExt
     + AccountReader
     + StateProviderFactory
@@ -25,6 +27,7 @@ pub trait FullProvider<DB: Database>:
 
 impl<T, DB: Database> FullProvider<DB> for T where
     T: DatabaseProviderFactory<DB>
+        + StaticFileProviderFactory
         + BlockReaderIdExt
         + AccountReader
         + StateProviderFactory

--- a/crates/storage/provider/src/traits/mod.rs
+++ b/crates/storage/provider/src/traits/mod.rs
@@ -75,6 +75,9 @@ pub use prune_checkpoint::{PruneCheckpointReader, PruneCheckpointWriter};
 mod database_provider;
 pub use database_provider::DatabaseProviderFactory;
 
+mod static_file_provider;
+pub use static_file_provider::StaticFileProviderFactory;
+
 mod stats;
 pub use stats::StatsReader;
 

--- a/crates/storage/provider/src/traits/static_file_provider.rs
+++ b/crates/storage/provider/src/traits/static_file_provider.rs
@@ -1,0 +1,7 @@
+use crate::providers::StaticFileProvider;
+
+/// Static file provider factory.
+pub trait StaticFileProviderFactory {
+    /// Create new instance of static file provider.
+    fn static_file_provider(&self) -> StaticFileProvider;
+}


### PR DESCRIPTION
## Motivation

Currently, with node builder it is impossible to be able to initialize state providers directly (e.g. `LatestStateProvider::new`) because `StaticFilesProvider` is not accessible.

## Description

Expose `StaticFilesProvider` by implementing `StaticFilesProviderFactory` for `BlockchainProvider` & `ProviderFactory` and add `StaticFilesProviderFactory` trait bound to `FullProvider`.