### PR TITLE
feat: make nodetypes stateless and move evm to components

### DIFF
--- a/crates/blockchain-tree/src/noop.rs
+++ b/crates/blockchain-tree/src/noop.rs
@@ -27,6 +27,15 @@ pub struct NoopBlockchainTree {
     pub canon_state_notification_sender: Option<CanonStateNotificationSender>,
 }
 
+impl NoopBlockchainTree {
+    /// Create a new NoopBlockchainTree with a canon state notification sender.
+    pub fn with_canon_state_notifications(
+        canon_state_notification_sender: CanonStateNotificationSender,
+    ) -> Self {
+        Self { canon_state_notification_sender: Some(canon_state_notification_sender) }
+    }
+}
+
 impl BlockchainTreeEngine for NoopBlockchainTree {
     fn buffer_block(&self, _block: SealedBlockWithSenders) -> Result<(), InsertBlockError> {
         Ok(())

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -80,7 +80,7 @@ pub trait ConfigureEvm: ConfigureEvmEnv {
 
 /// This represents the set of methods used to configure the EVM's environment before block
 /// execution.
-pub trait ConfigureEvmEnv: Send + Sync + Unpin + Clone {
+pub trait ConfigureEvmEnv: Send + Sync + Unpin + Clone + 'static {
     /// The type of the transaction metadata that should be used to fill fields in the transaction
     /// environment.
     ///

--- a/crates/node-ethereum/tests/it/builder.rs
+++ b/crates/node-ethereum/tests/it/builder.rs
@@ -13,7 +13,7 @@ fn test_basic_setup() {
     let msg = "On components".to_string();
     let _builder = NodeBuilder::new(config)
         .with_database(db)
-        .with_types(EthereumNode::default())
+        .with_types::<EthereumNode>()
         .with_components(EthereumNode::components())
         .on_component_initialized(move |ctx| {
             let _provider = ctx.provider();

--- a/crates/node-ethereum/tests/it/exex.rs
+++ b/crates/node-ethereum/tests/it/exex.rs
@@ -31,7 +31,7 @@ fn basic_exex() {
     let db = create_test_rw_db();
     let _builder = NodeBuilder::new(config)
         .with_database(db)
-        .with_types(EthereumNode::default())
+        .with_types::<EthereumNode>()
         .with_components(EthereumNode::components())
         .install_exex("dummy", move |ctx| future::ok(DummyExEx { _ctx: ctx }))
         .check_launch();

--- a/crates/node/api/src/node.rs
+++ b/crates/node/api/src/node.rs
@@ -1,4 +1,4 @@
-//! Traits for configuring a node
+//! Traits for configuring a node.
 
 use crate::{primitives::NodePrimitives, ConfigureEvm, EngineTypes};
 use reth_db::{
@@ -15,7 +15,9 @@ use std::marker::PhantomData;
 /// The type that configures the essential types of an ethereum like node.
 ///
 /// This includes the primitive types of a node, the engine API types for communication with the
-/// consensus layer, and the EVM configuration type for setting up the Ethereum Virtual Machine.
+/// consensus layer.
+///
+/// This trait is intended to be stateless and only define the types of the node.
 pub trait NodeTypes: Send + Sync + 'static {
     /// The node's primitive types, defining basic operations and structures.
     type Primitives: NodePrimitives;
@@ -25,6 +27,8 @@ pub trait NodeTypes: Send + Sync + 'static {
 
 /// A helper trait that is downstream of the [NodeTypes] trait and adds stateful components to the
 /// node.
+///
+/// Its types are configured by node internally and are not intended to be user configurable.
 pub trait FullNodeTypes: NodeTypes + 'static {
     /// Underlying database type used by the node to store and retrieve data.
     type DB: Database + DatabaseMetrics + DatabaseMetadata + Clone + Unpin + 'static;

--- a/crates/node/api/src/node.rs
+++ b/crates/node/api/src/node.rs
@@ -21,11 +21,6 @@ pub trait NodeTypes: Send + Sync + 'static {
     type Primitives: NodePrimitives;
     /// The node's engine types, defining the interaction with the consensus engine.
     type Engine: EngineTypes;
-    // /// The node's EVM configuration, defining settings for the Ethereum Virtual Machine.
-    // type Evm: ConfigureEvm;
-    //
-    // /// Returns the node's evm config.
-    // fn evm_config(&self) -> Self::Evm;
 }
 
 /// A helper trait that is downstream of the [NodeTypes] trait and adds stateful components to the

--- a/crates/node/api/src/node.rs
+++ b/crates/node/api/src/node.rs
@@ -55,6 +55,12 @@ impl<Types, DB, Provider> FullNodeTypesAdapter<Types, DB, Provider> {
     }
 }
 
+impl<Types, DB, Provider> Default for FullNodeTypesAdapter<Types, DB, Provider> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<Types, DB, Provider> NodeTypes for FullNodeTypesAdapter<Types, DB, Provider>
 where
     Types: NodeTypes,

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -424,8 +424,6 @@ pub struct BuilderContext<Node: FullNodeTypes> {
     pub(crate) config: NodeConfig,
     /// loaded config
     pub(crate) reth_config: reth_config::Config,
-    // /// EVM config of the node
-    // pub(crate) evm_config: Node::Evm,
 }
 
 impl<Node: FullNodeTypes> BuilderContext<Node> {
@@ -437,7 +435,6 @@ impl<Node: FullNodeTypes> BuilderContext<Node> {
         data_dir: ChainPath<DataDirPath>,
         config: NodeConfig,
         reth_config: reth_config::Config,
-        // evm_config: Node::Evm,
     ) -> Self {
         Self { head, provider, executor, data_dir, config, reth_config }
     }
@@ -446,11 +443,6 @@ impl<Node: FullNodeTypes> BuilderContext<Node> {
     pub fn provider(&self) -> &Node::Provider {
         &self.provider
     }
-
-    // /// Returns the configured evm.
-    // pub fn evm_config(&self) -> &Node::Evm {
-    //     &self.evm_config
-    // }
 
     /// Returns the current head of the blockchain at launch.
     pub fn head(&self) -> Head {

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -187,12 +187,11 @@ where
     DB: Database + DatabaseMetrics + DatabaseMetadata + Clone + Unpin + 'static,
 {
     /// Configures the types of the node.
-    pub fn with_types<T>(self, types: T) -> NodeBuilderWithTypes<RethFullAdapter<DB, T>>
+    pub fn with_types<T>(self) -> NodeBuilderWithTypes<RethFullAdapter<DB, T>>
     where
         T: NodeTypes,
     {
-        let types = FullNodeTypesAdapter::new(types);
-        NodeBuilderWithTypes::new(self.config, types, self.database)
+        NodeBuilderWithTypes::new(self.config, self.database)
     }
 
     /// Preconfigures the node with a specific node implementation.
@@ -205,7 +204,7 @@ where
     where
         N: Node<RethFullAdapter<DB, N>>,
     {
-        self.with_types(node.clone()).with_components(node.components_builder())
+        self.with_types().with_components(node.components_builder())
     }
 }
 
@@ -236,15 +235,12 @@ where
     DB: Database + DatabaseMetrics + DatabaseMetadata + Clone + Unpin + 'static,
 {
     /// Configures the types of the node.
-    pub fn with_types<T>(
-        self,
-        types: T,
-    ) -> WithLaunchContext<NodeBuilderWithTypes<RethFullAdapter<DB, T>>>
+    pub fn with_types<T>(self) -> WithLaunchContext<NodeBuilderWithTypes<RethFullAdapter<DB, T>>>
     where
         T: NodeTypes,
     {
         WithLaunchContext {
-            builder: self.builder.with_types(types),
+            builder: self.builder.with_types(),
             task_executor: self.task_executor,
             data_dir: self.data_dir,
         }
@@ -260,7 +256,7 @@ where
     where
         N: Node<RethFullAdapter<DB, N>>,
     {
-        self.with_types(node.clone()).with_components(node.components_builder())
+        self.with_types().with_components(node.components_builder())
     }
 
     /// Launches a preconfigured [Node]
@@ -426,8 +422,8 @@ pub struct BuilderContext<Node: FullNodeTypes> {
     pub(crate) config: NodeConfig,
     /// loaded config
     pub(crate) reth_config: reth_config::Config,
-    /// EVM config of the node
-    pub(crate) evm_config: Node::Evm,
+    // /// EVM config of the node
+    // pub(crate) evm_config: Node::Evm,
 }
 
 impl<Node: FullNodeTypes> BuilderContext<Node> {
@@ -439,9 +435,9 @@ impl<Node: FullNodeTypes> BuilderContext<Node> {
         data_dir: ChainPath<DataDirPath>,
         config: NodeConfig,
         reth_config: reth_config::Config,
-        evm_config: Node::Evm,
+        // evm_config: Node::Evm,
     ) -> Self {
-        Self { head, provider, executor, data_dir, config, reth_config, evm_config }
+        Self { head, provider, executor, data_dir, config, reth_config }
     }
 
     /// Returns the configured provider to interact with the blockchain.
@@ -449,10 +445,10 @@ impl<Node: FullNodeTypes> BuilderContext<Node> {
         &self.provider
     }
 
-    /// Returns the configured evm.
-    pub fn evm_config(&self) -> &Node::Evm {
-        &self.evm_config
-    }
+    // /// Returns the configured evm.
+    // pub fn evm_config(&self) -> &Node::Evm {
+    //     &self.evm_config
+    // }
 
     /// Returns the current head of the blockchain at launch.
     pub fn head(&self) -> Head {

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -50,10 +50,10 @@ pub type RethFullAdapter<DB, Types> = FullNodeTypesAdapter<Types, DB, Blockchain
 /// example) and then proceeds to configure the core static types of the node: [NodeTypes], these
 /// include the node's primitive types and the node's engine types.
 ///
-/// Next all stateful components of the node are configured, these include the
-/// [ConfigureEvm](reth_node_api::evm::ConfigureEvm), the database [Database] and all the
+/// Next all stateful components of the node are configured, these include all the
 /// components of the node that are downstream of those types, these include:
 ///
+///  - The EVM and Executor configuration: [ExecutorBuilder](crate::components::ExecutorBuilder)
 ///  - The transaction pool: [PoolBuilder]
 ///  - The network: [NetworkBuilder](crate::components::NetworkBuilder)
 ///  - The payload builder: [PayloadBuilder](crate::components::PayloadServiceBuilder)
@@ -71,9 +71,10 @@ pub type RethFullAdapter<DB, Types> = FullNodeTypesAdapter<Types, DB, Blockchain
 /// ## Components
 ///
 /// All components are configured with a [NodeComponentsBuilder] that is responsible for actually
-/// creating the node components during the launch process. The [ComponentsBuilder] is a general
-/// purpose implementation of the [NodeComponentsBuilder] trait that can be used to configure the
-/// network, transaction pool and payload builder of the node. It enforces the correct order of
+/// creating the node components during the launch process. The
+/// [ComponentsBuilder](crate::components::ComponentsBuilder) is a general purpose implementation of
+/// the [NodeComponentsBuilder] trait that can be used to configure the executor, network,
+/// transaction pool and payload builder of the node. It enforces the correct order of
 /// configuration, for example the network and the payload builder depend on the transaction pool
 /// type that is configured first.
 ///
@@ -127,8 +128,8 @@ pub type RethFullAdapter<DB, Types> = FullNodeTypesAdapter<Types, DB, Blockchain
 /// ### Limitations
 ///
 /// Currently the launch process is limited to ethereum nodes and requires all the components
-/// specified above. It also expect beacon consensus with the ethereum engine API that is configured
-/// by the builder itself during launch. This might change in the future.
+/// specified above. It also expects beacon consensus with the ethereum engine API that is
+/// configured by the builder itself during launch. This might change in the future.
 ///
 /// [builder]: https://doc.rust-lang.org/1.0.0/style/ownership/builders.html
 pub struct NodeBuilder<DB> {

--- a/crates/node/builder/src/components/builder.rs
+++ b/crates/node/builder/src/components/builder.rs
@@ -1,8 +1,11 @@
 //! A generic [NodeComponentsBuilder]
 
 use crate::{
-    components::{Components, NetworkBuilder, NodeComponents, PayloadServiceBuilder, PoolBuilder},
-    BuilderContext, FullNodeTypes,
+    components::{
+        Components, ExecutorBuilder, NetworkBuilder, NodeComponents, PayloadServiceBuilder,
+        PoolBuilder,
+    },
+    BuilderContext, ConfigureEvm, FullNodeTypes,
 };
 use reth_transaction_pool::TransactionPool;
 use std::{future::Future, marker::PhantomData};
@@ -27,21 +30,31 @@ use std::{future::Future, marker::PhantomData};
 /// All component builders are captured in the builder state and will be consumed once the node is
 /// launched.
 #[derive(Debug)]
-pub struct ComponentsBuilder<Node, PoolB, PayloadB, NetworkB> {
+pub struct ComponentsBuilder<Node, PoolB, PayloadB, NetworkB, ExecB> {
     pool_builder: PoolB,
     payload_builder: PayloadB,
     network_builder: NetworkB,
+    executor_builder: ExecB,
     _marker: PhantomData<Node>,
 }
 
-impl<Node, PoolB, PayloadB, NetworkB> ComponentsBuilder<Node, PoolB, PayloadB, NetworkB> {
+impl<Node, PoolB, PayloadB, NetworkB, ExecB>
+    ComponentsBuilder<Node, PoolB, PayloadB, NetworkB, ExecB>
+{
     /// Configures the node types.
-    pub fn node_types<Types>(self) -> ComponentsBuilder<Types, PoolB, PayloadB, NetworkB>
+    pub fn node_types<Types>(self) -> ComponentsBuilder<Types, PoolB, PayloadB, NetworkB, ExecB>
     where
         Types: FullNodeTypes,
     {
-        let Self { pool_builder, payload_builder, network_builder, _marker } = self;
+        let Self {
+            pool_builder,
+            payload_builder,
+            network_builder,
+            executor_builder: evm_builder,
+            _marker,
+        } = self;
         ComponentsBuilder {
+            executor_builder: evm_builder,
             pool_builder,
             payload_builder,
             network_builder,
@@ -55,6 +68,7 @@ impl<Node, PoolB, PayloadB, NetworkB> ComponentsBuilder<Node, PoolB, PayloadB, N
             pool_builder: f(self.pool_builder),
             payload_builder: self.payload_builder,
             network_builder: self.network_builder,
+            executor_builder: self.executor_builder,
             _marker: self._marker,
         }
     }
@@ -65,6 +79,7 @@ impl<Node, PoolB, PayloadB, NetworkB> ComponentsBuilder<Node, PoolB, PayloadB, N
             pool_builder: self.pool_builder,
             payload_builder: f(self.payload_builder),
             network_builder: self.network_builder,
+            executor_builder: self.executor_builder,
             _marker: self._marker,
         }
     }
@@ -75,12 +90,25 @@ impl<Node, PoolB, PayloadB, NetworkB> ComponentsBuilder<Node, PoolB, PayloadB, N
             pool_builder: self.pool_builder,
             payload_builder: self.payload_builder,
             network_builder: f(self.network_builder),
+            executor_builder: self.executor_builder,
+            _marker: self._marker,
+        }
+    }
+
+    /// Apply a function to the executor builder.
+    pub fn map_executor(self, f: impl FnOnce(ExecB) -> ExecB) -> Self {
+        Self {
+            pool_builder: self.pool_builder,
+            payload_builder: self.payload_builder,
+            network_builder: self.network_builder,
+            executor_builder: f(self.executor_builder),
             _marker: self._marker,
         }
     }
 }
 
-impl<Node, PoolB, PayloadB, NetworkB> ComponentsBuilder<Node, PoolB, PayloadB, NetworkB>
+impl<Node, PoolB, PayloadB, NetworkB, ExecB>
+    ComponentsBuilder<Node, PoolB, PayloadB, NetworkB, ExecB>
 where
     Node: FullNodeTypes,
 {
@@ -88,16 +116,32 @@ where
     ///
     /// This accepts a [PoolBuilder] instance that will be used to create the node's transaction
     /// pool.
-    pub fn pool<PB>(self, pool_builder: PB) -> ComponentsBuilder<Node, PB, PayloadB, NetworkB>
+    pub fn pool<PB>(
+        self,
+        pool_builder: PB,
+    ) -> ComponentsBuilder<Node, PB, PayloadB, NetworkB, ExecB>
     where
         PB: PoolBuilder<Node>,
     {
-        let Self { pool_builder: _, payload_builder, network_builder, _marker } = self;
-        ComponentsBuilder { pool_builder, payload_builder, network_builder, _marker }
+        let Self {
+            pool_builder: _,
+            payload_builder,
+            network_builder,
+            executor_builder: evm_builder,
+            _marker,
+        } = self;
+        ComponentsBuilder {
+            pool_builder,
+            payload_builder,
+            network_builder,
+            executor_builder: evm_builder,
+            _marker,
+        }
     }
 }
 
-impl<Node, PoolB, PayloadB, NetworkB> ComponentsBuilder<Node, PoolB, PayloadB, NetworkB>
+impl<Node, PoolB, PayloadB, NetworkB, ExecB>
+    ComponentsBuilder<Node, PoolB, PayloadB, NetworkB, ExecB>
 where
     Node: FullNodeTypes,
     PoolB: PoolBuilder<Node>,
@@ -106,57 +150,118 @@ where
     ///
     /// This accepts a [NetworkBuilder] instance that will be used to create the node's network
     /// stack.
-    pub fn network<NB>(self, network_builder: NB) -> ComponentsBuilder<Node, PoolB, PayloadB, NB>
+    pub fn network<NB>(
+        self,
+        network_builder: NB,
+    ) -> ComponentsBuilder<Node, PoolB, PayloadB, NB, ExecB>
     where
         NB: NetworkBuilder<Node, PoolB::Pool>,
     {
-        let Self { pool_builder, payload_builder, network_builder: _, _marker } = self;
-        ComponentsBuilder { pool_builder, payload_builder, network_builder, _marker }
+        let Self {
+            pool_builder,
+            payload_builder,
+            network_builder: _,
+            executor_builder: evm_builder,
+            _marker,
+        } = self;
+        ComponentsBuilder {
+            pool_builder,
+            payload_builder,
+            network_builder,
+            executor_builder: evm_builder,
+            _marker,
+        }
     }
 
     /// Configures the payload builder.
     ///
     /// This accepts a [PayloadServiceBuilder] instance that will be used to create the node's
     /// payload builder service.
-    pub fn payload<PB>(self, payload_builder: PB) -> ComponentsBuilder<Node, PoolB, PB, NetworkB>
+    pub fn payload<PB>(
+        self,
+        payload_builder: PB,
+    ) -> ComponentsBuilder<Node, PoolB, PB, NetworkB, ExecB>
     where
         PB: PayloadServiceBuilder<Node, PoolB::Pool>,
     {
-        let Self { pool_builder, payload_builder: _, network_builder, _marker } = self;
-        ComponentsBuilder { pool_builder, payload_builder, network_builder, _marker }
+        let Self {
+            pool_builder,
+            payload_builder: _,
+            network_builder,
+            executor_builder: evm_builder,
+            _marker,
+        } = self;
+        ComponentsBuilder {
+            pool_builder,
+            payload_builder,
+            network_builder,
+            executor_builder: evm_builder,
+            _marker,
+        }
+    }
+
+    /// Configures the executor builder.
+    ///
+    /// This accepts a [ExecutorBuilder] instance that will be used to create the node's components
+    /// for execution.
+    pub fn executor<EB>(
+        self,
+        executor_builder: EB,
+    ) -> ComponentsBuilder<Node, PoolB, PayloadB, NetworkB, EB>
+    where
+        EB: ExecutorBuilder<Node>,
+    {
+        let Self { pool_builder, payload_builder, network_builder, executor_builder: _, _marker } =
+            self;
+        ComponentsBuilder {
+            pool_builder,
+            payload_builder,
+            network_builder,
+            executor_builder,
+            _marker,
+        }
     }
 }
 
-impl<Node, PoolB, PayloadB, NetworkB> NodeComponentsBuilder<Node>
-    for ComponentsBuilder<Node, PoolB, PayloadB, NetworkB>
+impl<Node, PoolB, PayloadB, NetworkB, ExecB> NodeComponentsBuilder<Node>
+    for ComponentsBuilder<Node, PoolB, PayloadB, NetworkB, ExecB>
 where
     Node: FullNodeTypes,
     PoolB: PoolBuilder<Node>,
     NetworkB: NetworkBuilder<Node, PoolB::Pool>,
     PayloadB: PayloadServiceBuilder<Node, PoolB::Pool>,
+    ExecB: ExecutorBuilder<Node>,
 {
-    type Components = Components<Node, PoolB::Pool>;
+    type Components = Components<Node, PoolB::Pool, ExecB::EVM>;
 
     async fn build_components(
         self,
         context: &BuilderContext<Node>,
     ) -> eyre::Result<Self::Components> {
-        let Self { pool_builder, payload_builder, network_builder, _marker } = self;
+        let Self {
+            pool_builder,
+            payload_builder,
+            network_builder,
+            executor_builder: evm_builder,
+            _marker,
+        } = self;
 
+        let evm_config = evm_builder.build_evm(context).await?;
         let pool = pool_builder.build_pool(context).await?;
         let network = network_builder.build_network(context, pool.clone()).await?;
         let payload_builder = payload_builder.spawn_payload_service(context, pool.clone()).await?;
 
-        Ok(Components { transaction_pool: pool, network, payload_builder })
+        Ok(Components { transaction_pool: pool, evm_config, network, payload_builder })
     }
 }
 
-impl Default for ComponentsBuilder<(), (), (), ()> {
+impl Default for ComponentsBuilder<(), (), (), (), ()> {
     fn default() -> Self {
         Self {
             pool_builder: (),
             payload_builder: (),
             network_builder: (),
+            executor_builder: (),
             _marker: Default::default(),
         }
     }
@@ -182,14 +287,15 @@ pub trait NodeComponentsBuilder<Node: FullNodeTypes>: Send {
     ) -> impl Future<Output = eyre::Result<Self::Components>> + Send;
 }
 
-impl<Node, F, Fut, Pool> NodeComponentsBuilder<Node> for F
+impl<Node, F, Fut, Pool, EVM> NodeComponentsBuilder<Node> for F
 where
     Node: FullNodeTypes,
     F: FnOnce(&BuilderContext<Node>) -> Fut + Send,
-    Fut: Future<Output = eyre::Result<Components<Node, Pool>>> + Send,
+    Fut: Future<Output = eyre::Result<Components<Node, Pool, EVM>>> + Send,
     Pool: TransactionPool + Unpin + 'static,
+    EVM: ConfigureEvm,
 {
-    type Components = Components<Node, Pool>;
+    type Components = Components<Node, Pool, EVM>;
 
     fn build_components(
         self,

--- a/crates/node/builder/src/components/builder.rs
+++ b/crates/node/builder/src/components/builder.rs
@@ -10,7 +10,7 @@ use crate::{
 use reth_transaction_pool::TransactionPool;
 use std::{future::Future, marker::PhantomData};
 
-/// A generic, customizable [`NodeComponentsBuilder`].
+/// A generic, general purpose and customizable [`NodeComponentsBuilder`] implementation.
 ///
 /// This type is stateful and captures the configuration of the node's components.
 ///

--- a/crates/node/builder/src/components/builder.rs
+++ b/crates/node/builder/src/components/builder.rs
@@ -272,9 +272,9 @@ impl Default for ComponentsBuilder<(), (), (), (), ()> {
 /// Implementers of this trait are responsible for building all the components of the node: See
 /// [NodeComponents].
 ///
-/// The [ComponentsBuilder] is a generic implementation of this trait that can be used to customize
-/// certain components of the node using the builder pattern and defaults, e.g. Ethereum and
-/// Optimism.
+/// The [ComponentsBuilder] is a generic, general purpose implementation of this trait that can be
+/// used to customize certain components of the node using the builder pattern and defaults, e.g.
+/// Ethereum and Optimism.
 /// A type that's responsible for building the components of the node.
 pub trait NodeComponentsBuilder<Node: FullNodeTypes>: Send {
     /// The components for the node with the given types

--- a/crates/node/builder/src/components/execute.rs
+++ b/crates/node/builder/src/components/execute.rs
@@ -1,0 +1,34 @@
+//! EVM component for the node builder.
+use crate::{BuilderContext, FullNodeTypes};
+use reth_node_api::ConfigureEvm;
+use std::future::Future;
+
+/// A type that knows how to build the executor types.
+pub trait ExecutorBuilder<Node: FullNodeTypes>: Send {
+    /// The EVM config to build.
+    type EVM: ConfigureEvm;
+    // TODO(mattsse): integrate `Executor`
+
+    /// Creates the transaction pool.
+    fn build_evm(
+        self,
+        ctx: &BuilderContext<Node>,
+    ) -> impl Future<Output = eyre::Result<Self::EVM>> + Send;
+}
+
+impl<Node, F, Fut, EVM> ExecutorBuilder<Node> for F
+where
+    Node: FullNodeTypes,
+    EVM: ConfigureEvm,
+    F: FnOnce(&BuilderContext<Node>) -> Fut + Send,
+    Fut: Future<Output = eyre::Result<EVM>> + Send,
+{
+    type EVM = EVM;
+
+    fn build_evm(
+        self,
+        ctx: &BuilderContext<Node>,
+    ) -> impl Future<Output = eyre::Result<Self::EVM>> {
+        self(ctx)
+    }
+}

--- a/crates/node/builder/src/components/mod.rs
+++ b/crates/node/builder/src/components/mod.rs
@@ -7,8 +7,9 @@
 //!
 //! Components depend on a fully type configured node: [FullNodeTypes](crate::node::FullNodeTypes).
 
-use crate::FullNodeTypes;
+use crate::{ConfigureEvm, FullNodeTypes};
 pub use builder::*;
+pub use execute::*;
 pub use network::*;
 pub use payload::*;
 pub use pool::*;
@@ -17,6 +18,7 @@ use reth_payload_builder::PayloadBuilderHandle;
 use reth_transaction_pool::TransactionPool;
 
 mod builder;
+mod execute;
 mod network;
 mod payload;
 mod pool;
@@ -29,8 +31,14 @@ pub trait NodeComponents<NodeTypes: FullNodeTypes>: Clone + Send + Sync + 'stati
     /// The transaction pool of the node.
     type Pool: TransactionPool + Unpin;
 
+    /// The node's EVM configuration, defining settings for the Ethereum Virtual Machine.
+    type Evm: ConfigureEvm;
+
     /// Returns the transaction pool of the node.
     fn pool(&self) -> &Self::Pool;
+
+    /// Returns the node's evm config.
+    fn evm_config(&self) -> &Self::Evm;
 
     /// Returns the handle to the network
     fn network(&self) -> &NetworkHandle;
@@ -43,24 +51,32 @@ pub trait NodeComponents<NodeTypes: FullNodeTypes>: Clone + Send + Sync + 'stati
 ///
 /// This provides access to all the components of the node.
 #[derive(Debug)]
-pub struct Components<Node: FullNodeTypes, Pool> {
+pub struct Components<Node: FullNodeTypes, Pool, EVM> {
     /// The transaction pool of the node.
     pub transaction_pool: Pool,
+    /// The node's EVM configuration, defining settings for the Ethereum Virtual Machine.
+    pub evm_config: EVM,
     /// The network implementation of the node.
     pub network: NetworkHandle,
     /// The handle to the payload builder service.
     pub payload_builder: PayloadBuilderHandle<Node::Engine>,
 }
 
-impl<Node, Pool> NodeComponents<Node> for Components<Node, Pool>
+impl<Node, Pool, EVM> NodeComponents<Node> for Components<Node, Pool, EVM>
 where
     Node: FullNodeTypes,
     Pool: TransactionPool + Unpin + 'static,
+    EVM: ConfigureEvm,
 {
     type Pool = Pool;
+    type Evm = EVM;
 
     fn pool(&self) -> &Self::Pool {
         &self.transaction_pool
+    }
+
+    fn evm_config(&self) -> &Self::Evm {
+        &self.evm_config
     }
 
     fn network(&self) -> &NetworkHandle {
@@ -72,14 +88,16 @@ where
     }
 }
 
-impl<Node, Pool> Clone for Components<Node, Pool>
+impl<Node, Pool, EVM> Clone for Components<Node, Pool, EVM>
 where
     Node: FullNodeTypes,
     Pool: TransactionPool,
+    EVM: ConfigureEvm,
 {
     fn clone(&self) -> Self {
         Self {
             transaction_pool: self.transaction_pool.clone(),
+            evm_config: self.evm_config.clone(),
             network: self.network.clone(),
             payload_builder: self.payload_builder.clone(),
         }

--- a/crates/node/builder/src/components/mod.rs
+++ b/crates/node/builder/src/components/mod.rs
@@ -24,6 +24,7 @@ mod payload;
 mod pool;
 
 /// An abstraction over the components of a node, consisting of:
+///  - evm and executor
 ///  - transaction pool
 ///  - network
 ///  - payload builder.

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -270,7 +270,7 @@ where
         .with_network(node.network().clone())
         .with_events(node.provider().clone())
         .with_executor(node.task_executor().clone())
-        .with_evm_config(node.evm_config())
+        .with_evm_config(node.evm_config().clone())
         .build_with_auth_server(module_config, engine_api);
 
     let mut registry = RpcRegistry { registry };

--- a/crates/optimism/node/tests/it/builder.rs
+++ b/crates/optimism/node/tests/it/builder.rs
@@ -12,7 +12,7 @@ fn test_basic_setup() {
     let db = create_test_rw_db();
     let _builder = NodeBuilder::new(config)
         .with_database(db)
-        .with_types(OptimismNode::default())
+        .with_types::<OptimismNode>()
         .with_components(OptimismNode::components(Default::default()))
         .on_component_initialized(move |ctx| {
             let _provider = ctx.provider();

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -89,6 +89,13 @@ impl<DB> BlockchainProvider<DB> {
     ) -> Self {
         Self { database, tree, chain_info: ChainInfoTracker::new(latest) }
     }
+
+    /// Sets the treeviewer for the provider.
+    #[doc(hidden)]
+    pub fn with_tree(mut self, tree: Arc<dyn TreeViewer>) -> Self {
+        self.tree = tree;
+        self
+    }
 }
 
 impl<DB> BlockchainProvider<DB>

--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -37,9 +37,8 @@ use reth_node_api::{
     EngineTypes, PayloadAttributes, PayloadBuilderAttributes, PayloadOrAttributes,
 };
 use reth_node_core::{args::RpcServerArgs, node_config::NodeConfig};
-use reth_node_ethereum::{
-    node::{EthereumNetworkBuilder, EthereumPoolBuilder},
-    EthEvmConfig,
+use reth_node_ethereum::node::{
+    EthereumExecutorBuilder, EthereumNetworkBuilder, EthereumPoolBuilder,
 };
 use reth_payload_builder::{
     error::PayloadBuilderError, EthBuiltPayload, EthPayloadBuilderAttributes, PayloadBuilderHandle,
@@ -187,12 +186,6 @@ impl NodeTypes for MyCustomNode {
     type Primitives = ();
     // use the custom engine types
     type Engine = CustomEngineTypes;
-    // use the default ethereum EVM config
-    type Evm = EthEvmConfig;
-
-    fn evm_config(&self) -> Self::Evm {
-        Self::Evm::default()
-    }
 }
 
 /// Implement the Node trait for the custom node
@@ -207,6 +200,7 @@ where
         EthereumPoolBuilder,
         CustomPayloadServiceBuilder,
         EthereumNetworkBuilder,
+        EthereumExecutorBuilder,
     >;
 
     fn components_builder(self) -> Self::ComponentsBuilder {
@@ -215,6 +209,7 @@ where
             .pool(EthereumPoolBuilder::default())
             .payload(CustomPayloadServiceBuilder::default())
             .network(EthereumNetworkBuilder::default())
+            .executor(EthereumExecutorBuilder::default())
     }
 }
 

--- a/examples/custom-evm/src/main.rs
+++ b/examples/custom-evm/src/main.rs
@@ -3,7 +3,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 use reth::{
-    builder::{node::NodeTypes, NodeBuilder},
+    builder::{components::ExecutorBuilder, BuilderContext, NodeBuilder},
     primitives::{
         address,
         revm_primitives::{CfgEnvWithHandlerCfg, Env, PrecompileResult, TxEnv},
@@ -17,9 +17,9 @@ use reth::{
     },
     tasks::TaskManager,
 };
-use reth_node_api::{ConfigureEvm, ConfigureEvmEnv};
+use reth_node_api::{ConfigureEvm, ConfigureEvmEnv, FullNodeTypes};
 use reth_node_core::{args::RpcServerArgs, node_config::NodeConfig};
-use reth_node_ethereum::{EthEngineTypes, EthEvmConfig, EthereumNode};
+use reth_node_ethereum::{EthEvmConfig, EthereumNode};
 use reth_primitives::{Chain, ChainSpec, Genesis, Header, Transaction};
 use reth_tracing::{RethTracer, Tracer};
 use std::sync::Arc;
@@ -104,18 +104,19 @@ impl ConfigureEvm for MyEvmConfig {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+/// A regular ethereum evm and executor builder.
+#[derive(Debug, Default, Clone, Copy)]
 #[non_exhaustive]
-struct MyCustomNode;
+pub struct MyExecutorBuilder;
 
-/// Configure the node types
-impl NodeTypes for MyCustomNode {
-    type Primitives = ();
-    type Engine = EthEngineTypes;
-    type Evm = MyEvmConfig;
+impl<Node> ExecutorBuilder<Node> for MyExecutorBuilder
+where
+    Node: FullNodeTypes,
+{
+    type EVM = MyEvmConfig;
 
-    fn evm_config(&self) -> Self::Evm {
-        Self::Evm::default()
+    async fn build_evm(self, _ctx: &BuilderContext<Node>) -> eyre::Result<Self::EVM> {
+        Ok(MyEvmConfig::default())
     }
 }
 
@@ -140,8 +141,8 @@ async fn main() -> eyre::Result<()> {
 
     let handle = NodeBuilder::new(node_config)
         .testing_node(tasks.executor())
-        .with_types(MyCustomNode::default())
-        .with_components(EthereumNode::components())
+        .with_types::<EthereumNode>()
+        .with_components(EthereumNode::components().executor(MyExecutorBuilder::default()))
         .launch()
         .await
         .unwrap();

--- a/examples/custom-node-components/src/main.rs
+++ b/examples/custom-node-components/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
         .run(|builder, _| async move {
             let handle = builder
                 // use the default ethereum node types
-                .with_types(EthereumNode::default())
+                .with_types::<EthereumNode>()
                 // Configure the components of the node
                 // use default ethereum components but use our custom pool
                 .with_components(EthereumNode::components().pool(CustomPoolBuilder::default()))

--- a/examples/custom-payload-builder/src/main.rs
+++ b/examples/custom-payload-builder/src/main.rs
@@ -73,7 +73,7 @@ fn main() {
     Cli::parse_args()
         .run(|builder, _| async move {
             let handle = builder
-                .with_types(EthereumNode::default())
+                .with_types::<EthereumNode>()
                 // Configure the components of the node
                 // use default ethereum components but use our custom payload builder
                 .with_components(


### PR DESCRIPTION
closes #7812

makes the `NodeTypes` trait stateless and integrate evm as a component.

there's currently an issue during launch because of cyclic deps: provider requires evm/executor for pending state etc, but provider is passed as part of the BuildContext

Hence, this contains a workaround where the components are launched without access to pending state and only to the canon state channel

this would be solved by separating the pending state info from the tree entirely: #7154 
until then we can also solve this with a workaround by using the same canon state channel wrapped in a NoopBlockchainTree. This is fine for now, with the limitation that the components don't have access to pending state, but this can also be solved in a followup that uses a mutex for the treeviewer.