### PR TITLE
fix: add checks for hardfork-specific fields to ensure_well_formed_payload

### DIFF
--- a/crates/payload/validator/src/lib.rs
+++ b/crates/payload/validator/src/lib.rs
@@ -120,9 +120,20 @@ impl ExecutionPayloadValidator {
             })
         }
 
-        let cancun_active = self.is_cancun_active_at_timestamp(sealed_block.timestamp);
-
-        if !cancun_active {
+        if self.is_cancun_active_at_timestamp(sealed_block.timestamp) {
+            if sealed_block.header.blob_gas_used.is_none() {
+                // cancun active but blob gas used not present
+                return Err(PayloadError::PostCancunBlockWithoutBlobGasUsed)
+            }
+            if sealed_block.header.excess_blob_gas.is_none() {
+                // cancun active but excess blob gas not present
+                return Err(PayloadError::PostCancunBlockWithoutExcessBlobGas)
+            }
+            if cancun_fields.clone().into_inner().is_none() {
+                // cancun active but cancun fields not present
+                return Err(PayloadError::PostCancunWithoutCancunFields)
+            }
+        } else {
             if sealed_block.has_blob_transactions() {
                 // cancun not active but blob transactions present
                 return Err(PayloadError::PreCancunBlockWithBlobTransactions)
@@ -138,19 +149,6 @@ impl ExecutionPayloadValidator {
             if cancun_fields.clone().into_inner().is_some() {
                 // cancun not active but cancun fields present
                 return Err(PayloadError::PreCancunWithCancunFields)
-            }
-        } else {
-            if sealed_block.header.blob_gas_used.is_none() {
-                // cancun active but blob gas used not present
-                return Err(PayloadError::PostCancunBlockWithoutBlobGasUsed)
-            }
-            if sealed_block.header.excess_blob_gas.is_none() {
-                // cancun active but excess blob gas not present
-                return Err(PayloadError::PostCancunBlockWithoutExcessBlobGas)
-            }
-            if cancun_fields.clone().into_inner().is_none() {
-                // cancun active but cancun fields not present
-                return Err(PayloadError::PostCancunWithoutCancunFields)
             }
         }
 

--- a/crates/payload/validator/src/lib.rs
+++ b/crates/payload/validator/src/lib.rs
@@ -155,14 +155,9 @@ impl ExecutionPayloadValidator {
         }
 
         let shanghai_active = self.is_shanghai_active_at_timestamp(sealed_block.timestamp);
-        if !shanghai_active {
-            if sealed_block.withdrawals.is_some() {
-                // shanghai not active but withdrawals present
-                return Err(PayloadError::PreShanghaiBlockWithWitdrawals);
-            }
-        } else if sealed_block.withdrawals.is_some() {
-            // shanghai active but withdrawals not present
-            return Err(PayloadError::PostShanghaiBlockWithoutWitdrawals);
+        if !shanghai_active && sealed_block.withdrawals.is_some() {
+            // shanghai not active but withdrawals present
+            return Err(PayloadError::PreShanghaiBlockWithWitdrawals);
         }
 
         // EIP-4844 checks

--- a/crates/payload/validator/src/lib.rs
+++ b/crates/payload/validator/src/lib.rs
@@ -129,7 +129,7 @@ impl ExecutionPayloadValidator {
                 // cancun active but excess blob gas not present
                 return Err(PayloadError::PostCancunBlockWithoutExcessBlobGas)
             }
-            if cancun_fields.clone().into_inner().is_none() {
+            if cancun_fields.as_ref().is_none() {
                 // cancun active but cancun fields not present
                 return Err(PayloadError::PostCancunWithoutCancunFields)
             }
@@ -146,7 +146,7 @@ impl ExecutionPayloadValidator {
                 // cancun not active but excess blob gas present
                 return Err(PayloadError::PreCancunBlockWithExcessBlobGas)
             }
-            if cancun_fields.clone().into_inner().is_some() {
+            if cancun_fields.as_ref().is_some() {
                 // cancun not active but cancun fields present
                 return Err(PayloadError::PreCancunWithCancunFields)
             }

--- a/crates/payload/validator/src/lib.rs
+++ b/crates/payload/validator/src/lib.rs
@@ -140,10 +140,6 @@ impl ExecutionPayloadValidator {
                 return Err(PayloadError::PreCancunWithCancunFields)
             }
         } else {
-            if !sealed_block.has_blob_transactions() {
-                // cancun active but blob transactions not present
-                return Err(PayloadError::PostCancunBlockWithoutBlobTransactions)
-            }
             if sealed_block.header.blob_gas_used.is_none() {
                 // cancun active but blob gas used not present
                 return Err(PayloadError::PostCancunBlockWithoutBlobGasUsed)

--- a/crates/payload/validator/src/lib.rs
+++ b/crates/payload/validator/src/lib.rs
@@ -127,15 +127,15 @@ impl ExecutionPayloadValidator {
                 // cancun not active but blob transactions present
                 return Err(PayloadError::PreCancunBlockWithBlobTransactions)
             }
-            if let Some(_) = sealed_block.header.blob_gas_used {
+            if sealed_block.header.blob_gas_used.is_some() {
                 // cancun not active but blob gas used present
                 return Err(PayloadError::PreCancunBlockWithBlobGasUsed)
             }
-            if let Some(_) = sealed_block.header.excess_blob_gas {
+            if sealed_block.header.excess_blob_gas.is_some() {
                 // cancun not active but excess blob gas present
                 return Err(PayloadError::PreCancunBlockWithExcessBlobGas)
             }
-            if let Some(_) = cancun_fields.into_inner() {
+            if cancun_fields.clone().into_inner().is_some() {
                 // cancun not active but cancun fields present
                 return Err(PayloadError::PreCancunWithCancunFields)
             }
@@ -144,15 +144,15 @@ impl ExecutionPayloadValidator {
                 // cancun active but blob transactions not present
                 return Err(PayloadError::PostCancunBlockWithoutBlobTransactions)
             }
-            if let None = sealed_block.header.blob_gas_used {
+            if sealed_block.header.blob_gas_used.is_none() {
                 // cancun active but blob gas used not present
                 return Err(PayloadError::PostCancunBlockWithoutBlobGasUsed)
             }
-            if let None = sealed_block.header.excess_blob_gas {
+            if sealed_block.header.excess_blob_gas.is_none() {
                 // cancun active but excess blob gas not present
                 return Err(PayloadError::PostCancunBlockWithoutExcessBlobGas)
             }
-            if let None = cancun_fields.into_inner() {
+            if cancun_fields.clone().into_inner().is_none() {
                 // cancun active but cancun fields not present
                 return Err(PayloadError::PostCancunWithoutCancunFields)
             }
@@ -160,13 +160,13 @@ impl ExecutionPayloadValidator {
 
         let shanghai_active = self.is_shanghai_active_at_timestamp(sealed_block.timestamp);
         if !shanghai_active {
-            if let Some(_) = sealed_block.withdrawals {
+            if sealed_block.withdrawals.is_some() {
                 // shanghai not active but withdrawals present
-                return Err(PayloadError::PreShanghaiBlockWithWithdrawals);
+                return Err(PayloadError::PreShanghaiBlockWithWitdrawals);
             }
-        } else if let None = sealed_block.withdrawals {
+        } else if sealed_block.withdrawals.is_some() {
             // shanghai active but withdrawals not present
-            return Err(PayloadError::PostShanghaiBlockWithoutWithdrawals);
+            return Err(PayloadError::PostShanghaiBlockWithoutWitdrawals);
         }
 
         // EIP-4844 checks


### PR DESCRIPTION
Adds checks to `ensure_well_formed_payload()` to ensure that the Cancun specific fields fields are `None` before Cancun and `Some()` afterwards.

Additionally, adds checks for the Shanghai fork to ensure that withdrawals are not included before this timestamp and are included afterwards.

Also ensure `cancun_fields.fields` is `None` before Cancun and `Some()` afterwards.