### PR TITLE
chore(exex): display `exex_id` log field using `Display`

### DIFF
--- a/crates/exex/src/manager.rs
+++ b/crates/exex/src/manager.rs
@@ -331,7 +331,7 @@ impl Future for ExExManager {
         // handle incoming exex events
         for exex in self.exex_handles.iter_mut() {
             while let Poll::Ready(Some(event)) = exex.receiver.poll_recv(cx) {
-                debug!(exex_id = exex.id, ?event, "Received event from exex");
+                debug!(exex_id = %exex.id, ?event, "Received event from exex");
                 exex.metrics.events_sent_total.increment(1);
                 match event {
                     ExExEvent::FinishedHeight(height) => exex.finished_height = Some(height),


### PR DESCRIPTION
```diff
2024-04-26T17:58:51.175157Z DEBUG reth_exex::manager: Sending notification exex_id=Rollup notification_id=601
-2024-04-26T17:58:51.175170Z DEBUG reth_exex::manager: Received event from exex exex_id="Rollup" event=FinishedHeight(1424695)
+2024-04-26T17:58:51.175170Z DEBUG reth_exex::manager: Received event from exex exex_id=Rollup event=FinishedHeight(1424695)
2024-04-26T17:59:01.101934Z DEBUG reth_exex::manager: Reserving slot for notification exex_id=Rollup notification_id=602
```