### PR TITLE
fix: correct expiration for discv4 lookup requests

### DIFF
--- a/crates/net/discv4/src/config.rs
+++ b/crates/net/discv4/src/config.rs
@@ -197,6 +197,12 @@ impl Discv4ConfigBuilder {
         self
     }
 
+    /// Sets the expiration duration for lookup neighbor requests
+    pub fn lookup_neighbours_expiration(&mut self, duration: Duration) -> &mut Self {
+        self.config.neighbours_expiration = duration;
+        self
+    }
+
     /// Sets the expiration duration for a bond with a peer
     pub fn bond_expiration(&mut self, duration: Duration) -> &mut Self {
         self.config.bond_expiration = duration;

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -1441,7 +1441,7 @@ impl Discv4Service {
     fn evict_failed_neighbours(&mut self, now: Instant) {
         let mut failed_neighbours = Vec::new();
         self.pending_find_nodes.retain(|node_id, find_node_request| {
-            if now.duration_since(find_node_request.sent_at) > self.config.request_timeout {
+            if now.duration_since(find_node_request.sent_at) > self.config.neighbours_expiration {
                 if !find_node_request.answered {
                     // node actually responded but with fewer entries than expected, but we don't
                     // treat this as an hard error since it responded.
@@ -2549,6 +2549,7 @@ mod tests {
         let config = Discv4Config::builder()
             .request_timeout(Duration::from_millis(200))
             .ping_expiration(Duration::from_millis(200))
+            .lookup_neighbours_expiration(Duration::from_millis(200))
             .add_eip868_pair("eth", fork_id)
             .build();
         let (_disv4, mut service) = create_discv4_with_config(config).await;

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -1421,7 +1421,7 @@ impl Discv4Service {
 
         let mut failed_lookups = Vec::new();
         self.pending_lookup.retain(|node_id, (lookup_sent_at, _)| {
-            if now.duration_since(*lookup_sent_at) > self.config.ping_expiration {
+            if now.duration_since(*lookup_sent_at) > self.config.neighbours_expiration {
                 failed_lookups.push(*node_id);
                 return false
             }

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -1421,7 +1421,7 @@ impl Discv4Service {
 
         let mut failed_lookups = Vec::new();
         self.pending_lookup.retain(|node_id, (lookup_sent_at, _)| {
-            if now.duration_since(*lookup_sent_at) > self.config.neighbours_expiration {
+            if now.duration_since(*lookup_sent_at) > self.config.request_timeout {
                 failed_lookups.push(*node_id);
                 return false
             }


### PR DESCRIPTION
Use `self.config.request_timeout` to check for expired lookup requests, and `self.config.neighbours_expiration` to check for expired neighbour lookup requests