### PR TITLE
feat: ensure offset size is at most 8 bytes

### DIFF
--- a/crates/storage/nippy-jar/src/error.rs
+++ b/crates/storage/nippy-jar/src/error.rs
@@ -37,6 +37,11 @@ pub enum NippyJarError {
     PHFMissing,
     #[error("nippy jar was built without an index")]
     UnsupportedFilterQuery,
+    #[error("the size of an offset must be at most 8 bytes, got {offset_size}")]
+    OffsetSizeTooBig {
+        /// The read offset size in number of bytes.
+        offset_size: u64,
+    },
     #[error("compression or decompression requires a bigger destination output")]
     OutputTooSmall,
     #[error("dictionary is not loaded.")]

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -485,6 +485,8 @@ impl DataReader {
         let offset_file = File::open(path.as_ref().with_extension(OFFSETS_FILE_EXTENSION))?;
         // SAFETY: File is read-only and its descriptor is kept alive as long as the mmap handle.
         let offset_mmap = unsafe { Mmap::map(&offset_file)? };
+
+        // First byte is the size of one offset in bytes
         let offset_size = offset_mmap[0] as u64;
 
         // Ensure that the size of an offset is at most 8 bytes.
@@ -492,14 +494,7 @@ impl DataReader {
             return Err(NippyJarError::OffsetSizeTooBig { offset_size })
         }
 
-        Ok(Self {
-            data_file,
-            data_mmap,
-            offset_file,
-            // First byte is the size of one offset in bytes
-            offset_size: offset_mmap[0] as u64,
-            offset_mmap,
-        })
+        Ok(Self { data_file, data_mmap, offset_file, offset_size, offset_mmap })
     }
 
     /// Returns the offset for the requested data index

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -485,6 +485,12 @@ impl DataReader {
         let offset_file = File::open(path.as_ref().with_extension(OFFSETS_FILE_EXTENSION))?;
         // SAFETY: File is read-only and its descriptor is kept alive as long as the mmap handle.
         let offset_mmap = unsafe { Mmap::map(&offset_file)? };
+        let offset_size = offset_mmap[0] as u64;
+
+        // Ensure that the size of an offset is at most 8 bytes.
+        if offset_size > 8 {
+            return Err(NippyJarError::OffsetSizeTooBig { offset_size })
+        }
 
         Ok(Self {
             data_file,


### PR DESCRIPTION
The offset size in Nippy Jar is stored in a single byte with a maximum value of 255. For context, the offset size denotes how big an offset is in number of bytes in the offset file.

Since an offset is read into an `u64`, we only support offset sizes of up to (and including) 8 bytes. This PR enforces that by checking the size of an offset on `DataReader::new`.

Note that currently all offsets are 8 bytes large, but this may change in the future: https://github.com/paradigmxyz/reth/issues/5750