### PR TITLE
fix(net, discv4): call find_node with valid endpoint

### DIFF
--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -1387,20 +1387,14 @@ impl Discv4Service {
                 BucketEntry::SelfEntry => {
                     // we received our own node entry
                 }
-                _ => {
-                    let key = kad_key(closest.id);
-                    match self.kbuckets.entry(&key) {
-                        kbucket::Entry::Present(mut entry, _) => {
-                            if entry.value_mut().has_endpoint_proof {
-                                self.find_node(&closest, ctx.clone());
-                            }
-                        }
-                        kbucket::Entry::Pending(mut entry, _) => {
-                            if entry.value().has_endpoint_proof {
-                                self.find_node(&closest, ctx.clone());
-                            }
-                        }
-                        _ => {}
+                BucketEntry::Present(mut entry, _) => {
+                    if entry.value_mut().has_endpoint_proof {
+                        self.find_node(&closest, ctx.clone());
+                    }
+                }
+                BucketEntry::Pending(mut entry, _) => {
+                    if entry.value().has_endpoint_proof {
+                        self.find_node(&closest, ctx.clone());
                     }
                 }
             }

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -1387,7 +1387,22 @@ impl Discv4Service {
                 BucketEntry::SelfEntry => {
                     // we received our own node entry
                 }
-                _ => self.find_node(&closest, ctx.clone()),
+                _ => {
+                    let key = kad_key(closest.id);
+                    match self.kbuckets.entry(&key) {
+                        kbucket::Entry::Present(mut entry, _) => {
+                            if entry.value_mut().has_endpoint_proof {
+                                self.find_node(&closest, ctx.clone());
+                            }
+                        }
+                        kbucket::Entry::Pending(mut entry, _) => {
+                            if entry.value().has_endpoint_proof {
+                                self.find_node(&closest, ctx.clone());
+                            }
+                        }
+                        _ => {}
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Prevents calling `find_node()` for a node record that does not yet have a valid endpoint.

The case can be reached if the other user has sent a Ping but not sent a Pong response. They will be added to the DHT and are considered a valid entry in `self.kbuckets.entry()`.

The function `on_neighbours()` will then iterate through all entries including those with `has_endpoint_proof = false` and if this node is the closest it will reach out to that node via `find_node`.

To fix it, in `on_neighbours()` first check that the closest entry has `has_endpoint_proof = true` before calling `find_node()` for that endpoint.