### PR TITLE
feat(rpc-builder): add tower layer for updating bearer token in auth client

### DIFF
--- a/crates/e2e-test-utils/src/engine_api.rs
+++ b/crates/e2e-test-utils/src/engine_api.rs
@@ -5,18 +5,18 @@ use reth::{
     providers::CanonStateNotificationStream,
     rpc::{
         api::EngineApiClient,
-        builder::auth::JwtSecretService,
         types::engine::{ForkchoiceState, PayloadStatusEnum},
     },
 };
 use reth_payload_builder::PayloadId;
 use reth_primitives::B256;
+use reth_rpc::AuthClientService;
 use std::marker::PhantomData;
 
 /// Helper for engine api operations
 pub struct EngineApiTestContext<E> {
     pub canonical_stream: CanonStateNotificationStream,
-    pub engine_api_client: HttpClient<JwtSecretService<HttpBackend>>,
+    pub engine_api_client: HttpClient<AuthClientService<HttpBackend>>,
     pub _marker: PhantomData<E>,
 }
 

--- a/crates/e2e-test-utils/src/engine_api.rs
+++ b/crates/e2e-test-utils/src/engine_api.rs
@@ -1,10 +1,11 @@
 use crate::traits::PayloadEnvelopeExt;
-use jsonrpsee::http_client::HttpClient;
+use jsonrpsee::http_client::{transport::HttpBackend, HttpClient};
 use reth::{
     api::{EngineTypes, PayloadBuilderAttributes},
     providers::CanonStateNotificationStream,
     rpc::{
         api::EngineApiClient,
+        builder::auth::JwtSecretService,
         types::engine::{ForkchoiceState, PayloadStatusEnum},
     },
 };
@@ -15,7 +16,7 @@ use std::marker::PhantomData;
 /// Helper for engine api operations
 pub struct EngineApiTestContext<E> {
     pub canonical_stream: CanonStateNotificationStream,
-    pub engine_api_client: HttpClient,
+    pub engine_api_client: HttpClient<JwtSecretService<HttpBackend>>,
     pub _marker: PhantomData<E>,
 }
 

--- a/crates/rpc/rpc-builder/src/auth.rs
+++ b/crates/rpc/rpc-builder/src/auth.rs
@@ -451,7 +451,7 @@ impl AuthServerHandle {
 }
 
 /// A layer that adds a new JWT token to every request using JwtSecretService.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct JwtSecretLayer {
     secret: JwtSecret,
 }
@@ -462,7 +462,7 @@ impl JwtSecretLayer {
     }
 }
 
-impl<S: Clone> Layer<S> for JwtSecretLayer {
+impl<S> Layer<S> for JwtSecretLayer {
     type Service = JwtSecretService<S>;
 
     fn layer(&self, inner: S) -> Self::Service {
@@ -472,19 +472,19 @@ impl<S: Clone> Layer<S> for JwtSecretLayer {
 
 /// Automatically authenticates every client request with the given `secret`.
 #[derive(Debug, Clone)]
-pub struct JwtSecretService<S: Clone> {
+pub struct JwtSecretService<S> {
     secret: JwtSecret,
     inner: S,
 }
 
-impl<S: Clone> JwtSecretService<S> {
+impl<S> JwtSecretService<S> {
     fn new(secret: JwtSecret, inner: S) -> Self {
         Self { secret, inner }
     }
 }
 impl<S, B> Service<hyper::Request<B>> for JwtSecretService<S>
 where
-    S: Clone + Service<hyper::Request<B>>,
+    S: Service<hyper::Request<B>>,
 {
     type Response = S::Response;
     type Error = S::Error;

--- a/crates/rpc/rpc-builder/src/auth.rs
+++ b/crates/rpc/rpc-builder/src/auth.rs
@@ -501,7 +501,7 @@ where
 }
 
 /// Helper function to convert a secret into a Bearer auth header value with claims according to
-/// https://github.com/ethereum/execution-apis/blob/main/src/engine/authentication.md#jwt-claims.
+/// <https://github.com/ethereum/execution-apis/blob/main/src/engine/authentication.md#jwt-claims>.
 /// The token is valid for 60 seconds.
 pub(crate) fn secret_to_bearer_header(secret: &JwtSecret) -> HeaderValue {
     format!(

--- a/crates/rpc/rpc/src/layers/auth_client_layer.rs
+++ b/crates/rpc/rpc/src/layers/auth_client_layer.rs
@@ -1,0 +1,78 @@
+use crate::{Claims, JwtSecret};
+use http::HeaderValue;
+use hyper::{header::AUTHORIZATION, service::Service};
+use std::{
+    task::{Context, Poll},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+use tower::Layer;
+
+/// A layer that adds a new JWT token to every request using AuthClientService.
+#[derive(Debug)]
+pub struct AuthClientLayer {
+    secret: JwtSecret,
+}
+
+impl AuthClientLayer {
+    /// Create a new AuthClientLayer with the given `secret`.
+    pub fn new(secret: JwtSecret) -> Self {
+        Self { secret }
+    }
+}
+
+impl<S> Layer<S> for AuthClientLayer {
+    type Service = AuthClientService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        AuthClientService::new(self.secret.clone(), inner)
+    }
+}
+
+/// Automatically authenticates every client request with the given `secret`.
+#[derive(Debug, Clone)]
+pub struct AuthClientService<S> {
+    secret: JwtSecret,
+    inner: S,
+}
+
+impl<S> AuthClientService<S> {
+    fn new(secret: JwtSecret, inner: S) -> Self {
+        Self { secret, inner }
+    }
+}
+impl<S, B> Service<hyper::Request<B>> for AuthClientService<S>
+where
+    S: Service<hyper::Request<B>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut request: hyper::Request<B>) -> Self::Future {
+        request.headers_mut().insert(AUTHORIZATION, secret_to_bearer_header(&self.secret));
+        self.inner.call(request)
+    }
+}
+
+/// Helper function to convert a secret into a Bearer auth header value with claims according to
+/// <https://github.com/ethereum/execution-apis/blob/main/src/engine/authentication.md#jwt-claims>.
+/// The token is valid for 60 seconds.
+pub fn secret_to_bearer_header(secret: &JwtSecret) -> HeaderValue {
+    format!(
+        "Bearer {}",
+        secret
+            .encode(&Claims {
+                iat: (SystemTime::now().duration_since(UNIX_EPOCH).unwrap() +
+                    Duration::from_secs(60))
+                .as_secs(),
+                exp: None,
+            })
+            .unwrap()
+    )
+    .parse()
+    .unwrap()
+}

--- a/crates/rpc/rpc/src/layers/auth_client_layer.rs
+++ b/crates/rpc/rpc/src/layers/auth_client_layer.rs
@@ -40,6 +40,7 @@ impl<S> AuthClientService<S> {
         Self { secret, inner }
     }
 }
+
 impl<S, B> Service<hyper::Request<B>> for AuthClientService<S>
 where
     S: Service<hyper::Request<B>>,

--- a/crates/rpc/rpc/src/layers/mod.rs
+++ b/crates/rpc/rpc/src/layers/mod.rs
@@ -1,8 +1,11 @@
 use http::{HeaderMap, Response};
 
+mod auth_client_layer;
 mod auth_layer;
 mod jwt_secret;
 mod jwt_validator;
+
+pub use auth_client_layer::{secret_to_bearer_header, AuthClientLayer, AuthClientService};
 pub use auth_layer::AuthLayer;
 pub use jwt_secret::{Claims, JwtError, JwtSecret};
 pub use jwt_validator::JwtAuthValidator;

--- a/crates/rpc/rpc/src/lib.rs
+++ b/crates/rpc/rpc/src/lib.rs
@@ -41,7 +41,10 @@ pub use admin::AdminApi;
 pub use debug::DebugApi;
 pub use engine::{EngineApi, EngineEthApi};
 pub use eth::{EthApi, EthApiSpec, EthFilter, EthPubSub, EthSubscriptionIdProvider};
-pub use layers::{AuthLayer, AuthValidator, Claims, JwtAuthValidator, JwtError, JwtSecret};
+pub use layers::{
+    secret_to_bearer_header, AuthClientLayer, AuthClientService, AuthLayer, AuthValidator, Claims,
+    JwtAuthValidator, JwtError, JwtSecret,
+};
 pub use net::NetApi;
 pub use otterscan::OtterscanApi;
 pub use reth::RethApi;


### PR DESCRIPTION
Makes progress on #6711.

Previously, the auth client only worked for 60/120 seconds. I've ran into this when running a debug consensus engine that directly used `http_client` from the handle indefinitely and didn't use JWT token directly (like regular CL) or one off script that's ran too quickly to encounter this (like `optimism.rs`).

In the future, can be optimized to re-generate JWT tokens less often, but it should be negligible now (but if you'd prefer this now, let me know). 

By the way, I've tested this by looking at logs of `cargo test -p reth-rpc-builder -- "auth::test_auth_endpoints_http"`, because `test_auth_endpoints_http` doesn't actually fail (even if auth is broken) due to unused results and only issues error logs. Is it fine? `#[allow(unused_must_use)]` hints that it was intentional.