### PR TITLE
WIP fix: check state root for buffered blocks

### DIFF
--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -887,7 +887,7 @@ where
         for block in include_blocks.into_iter() {
             // dont fail on error, just ignore the block.
             let _ = self
-                .try_insert_validated_block(block, BlockValidationKind::SkipStateRootValidation)
+                .try_insert_validated_block(block, BlockValidationKind::Exhaustive)
                 .map_err(|err| {
                     debug!(
                         target: "blockchain_tree", %err,


### PR DESCRIPTION
When connecting buffered blocks state root validation does not occur. As state root validation does not occur later except for the tip when a new canonical head is chosen.

The proposed solution is to use exhaustive validation when inserting buffered blocks in `try_insert_validated_block()`. This will increase the processing time as state roots must be checked however, it will prevent unvalidated blocks from being added to the chain.