### PR TITLE
chore: reduce number of Evm monomorphizations

### DIFF
--- a/crates/payload/builder/src/database.rs
+++ b/crates/payload/builder/src/database.rs
@@ -61,10 +61,13 @@ impl CachedReads {
     }
 }
 
+/// A [Database] that caches reads inside [CachedReads].
 #[derive(Debug)]
-struct CachedReadsDbMut<'a, DB> {
-    cached: &'a mut CachedReads,
-    db: DB,
+pub struct CachedReadsDbMut<'a, DB> {
+    /// The cache of reads.
+    pub cached: &'a mut CachedReads,
+    /// The underlying database.
+    pub db: DB,
 }
 
 impl<'a, DB: DatabaseRef> Database for CachedReadsDbMut<'a, DB> {
@@ -126,7 +129,8 @@ impl<'a, DB: DatabaseRef> Database for CachedReadsDbMut<'a, DB> {
 /// `revm::db::State` for repeated payload build jobs.
 #[derive(Debug)]
 pub struct CachedReadsDBRef<'a, DB> {
-    inner: RefCell<CachedReadsDbMut<'a, DB>>,
+    /// The inner cache reads db mut.
+    pub inner: RefCell<CachedReadsDbMut<'a, DB>>,
 }
 
 impl<'a, DB: DatabaseRef> DatabaseRef for CachedReadsDBRef<'a, DB> {

--- a/crates/payload/ethereum/src/lib.rs
+++ b/crates/payload/ethereum/src/lib.rs
@@ -73,36 +73,54 @@ where
         debug!(target: "payload_builder", parent_hash = ?parent_block.hash(), parent_number = parent_block.number, "building empty payload");
 
         let state = client.state_by_block_hash(parent_block.hash()).map_err(|err| {
-                warn!(target: "payload_builder", parent_hash=%parent_block.hash(), %err, "failed to get state for empty payload");
-                err
-            })?;
+            warn!(target: "payload_builder",
+                parent_hash=%parent_block.hash(),
+                %err,
+                "failed to get state for empty payload"
+            );
+            err
+        })?;
         let mut db = State::builder()
-            .with_database_boxed(Box::new(StateProviderDatabase::new(&state)))
+            .with_database(StateProviderDatabase::new(state))
             .with_bundle_update()
             .build();
 
         let base_fee = initialized_block_env.basefee.to::<u64>();
         let block_number = initialized_block_env.number.to::<u64>();
-        let block_gas_limit: u64 = initialized_block_env.gas_limit.try_into().unwrap_or(u64::MAX);
+        let block_gas_limit = initialized_block_env.gas_limit.try_into().unwrap_or(u64::MAX);
 
         // apply eip-4788 pre block contract call
         pre_block_beacon_root_contract_call(
-                &mut db,
-                &chain_spec,
-                block_number,
-                &initialized_cfg,
-                &initialized_block_env,
-                &attributes,
-            ).map_err(|err| {
-                warn!(target: "payload_builder", parent_hash=%parent_block.hash(), %err, "failed to apply beacon root contract call for empty payload");
-                err
-            })?;
+            &mut db,
+            &chain_spec,
+            block_number,
+            &initialized_cfg,
+            &initialized_block_env,
+            &attributes,
+        )
+        .map_err(|err| {
+            warn!(target: "payload_builder",
+                parent_hash=%parent_block.hash(),
+                %err,
+                "failed to apply beacon root contract call for empty payload"
+            );
+            err
+        })?;
 
-        let WithdrawalsOutcome { withdrawals_root, withdrawals } =
-                commit_withdrawals(&mut db, &chain_spec, attributes.timestamp, attributes.withdrawals.clone()).map_err(|err| {
-                    warn!(target: "payload_builder", parent_hash=%parent_block.hash(), %err, "failed to commit withdrawals for empty payload");
-                    err
-                })?;
+        let WithdrawalsOutcome { withdrawals_root, withdrawals } = commit_withdrawals(
+            &mut db,
+            &chain_spec,
+            attributes.timestamp,
+            attributes.withdrawals.clone(),
+        )
+        .map_err(|err| {
+            warn!(target: "payload_builder",
+                parent_hash=%parent_block.hash(),
+                %err,
+                "failed to commit withdrawals for empty payload"
+            );
+            err
+        })?;
 
         // merge all transitions into bundle state, this would apply the withdrawal balance
         // changes and 4788 contract call
@@ -110,10 +128,14 @@ where
 
         // calculate the state root
         let bundle_state = db.take_bundle();
-        let state_root = state.state_root(&bundle_state).map_err(|err| {
-                warn!(target: "payload_builder", parent_hash=%parent_block.hash(), %err, "failed to calculate state root for empty payload");
-                err
-            })?;
+        let state_root = db.database.state_root(&bundle_state).map_err(|err| {
+            warn!(target: "payload_builder",
+                parent_hash=%parent_block.hash(),
+                %err,
+                "failed to calculate state root for empty payload"
+            );
+            err
+        })?;
 
         let mut excess_blob_gas = None;
         let mut blob_gas_used = None;
@@ -178,9 +200,9 @@ where
     let BuildArguments { client, pool, mut cached_reads, config, cancel, best_payload } = args;
 
     let state_provider = client.state_by_block_hash(config.parent_block.hash())?;
-    let state = StateProviderDatabase::new(&state_provider);
+    let state = StateProviderDatabase::new(state_provider);
     let mut db =
-        State::builder().with_database_ref(cached_reads.as_db(&state)).with_bundle_update().build();
+        State::builder().with_database_ref(cached_reads.as_db(state)).with_bundle_update().build();
     let extra_data = config.extra_data();
     let PayloadConfig {
         initialized_block_env,
@@ -349,7 +371,10 @@ where
     let logs_bloom = bundle.block_logs_bloom(block_number).expect("Number is in range");
 
     // calculate the state root
-    let state_root = state_provider.state_root(bundle.state())?;
+    let state_root = {
+        let state_provider = db.database.0.inner.borrow_mut();
+        state_provider.db.state_root(bundle.state())?
+    };
 
     // create the block header
     let transactions_root = proofs::calculate_transaction_root(&executed_txs);

--- a/crates/rpc/rpc/src/eth/api/call.rs
+++ b/crates/rpc/rpc/src/eth/api/call.rs
@@ -451,14 +451,14 @@ where
         &self,
         env_gas_limit: U256,
         mut env: EnvWithHandlerCfg,
-        mut db: &mut CacheDB<StateProviderDatabase<S>>,
+        db: &mut CacheDB<StateProviderDatabase<S>>,
     ) -> EthApiError
     where
         S: StateProvider,
     {
         let req_gas_limit = env.tx.gas_limit;
         env.tx.gas_limit = env_gas_limit.try_into().unwrap_or(u64::MAX);
-        let (res, _) = match self.transact(&mut db, env) {
+        let (res, _) = match self.transact(db, env) {
             Ok(res) => res,
             Err(err) => return err,
         };

--- a/crates/rpc/rpc/src/eth/api/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/api/pending_block.rs
@@ -52,8 +52,8 @@ impl PendingBlockEnv {
 
         let parent_hash = origin.build_target_hash();
         let state_provider = client.history_by_block_hash(parent_hash)?;
-        let state = StateProviderDatabase::new(&state_provider);
-        let mut db = State::builder().with_database(Box::new(state)).with_bundle_update().build();
+        let state = StateProviderDatabase::new(state_provider);
+        let mut db = State::builder().with_database(state).with_bundle_update().build();
 
         let mut cumulative_gas_used = 0;
         let mut sum_blob_gas_used = 0;
@@ -230,6 +230,7 @@ impl PendingBlockEnv {
         let logs_bloom = bundle.block_logs_bloom(block_number).expect("Block is present");
 
         // calculate the state root
+        let state_provider = &db.database;
         let state_root = state_provider.state_root(bundle.state())?;
 
         // create the block header

--- a/crates/rpc/rpc/src/eth/revm_utils.rs
+++ b/crates/rpc/rpc/src/eth/revm_utils.rs
@@ -278,7 +278,10 @@ pub(crate) fn create_txn_env(
 }
 
 /// Caps the configured [TxEnv] `gas_limit` with the allowance of the caller.
-pub(crate) fn cap_tx_gas_limit_with_caller_allowance<DB>(db: DB, env: &mut TxEnv) -> EthResult<()>
+pub(crate) fn cap_tx_gas_limit_with_caller_allowance<DB>(
+    db: &mut DB,
+    env: &mut TxEnv,
+) -> EthResult<()>
 where
     DB: Database,
     EthApiError: From<<DB as Database>::Error>,
@@ -296,7 +299,7 @@ where
 ///
 /// Returns an error if the caller has insufficient funds.
 /// Caution: This assumes non-zero `env.gas_price`. Otherwise, zero allowance will be returned.
-pub(crate) fn caller_gas_allowance<DB>(mut db: DB, env: &TxEnv) -> EthResult<U256>
+pub(crate) fn caller_gas_allowance<DB>(db: &mut DB, env: &TxEnv) -> EthResult<U256>
 where
     DB: Database,
     EthApiError: From<<DB as Database>::Error>,

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -86,7 +86,7 @@ where
         let this = self.clone();
         self.eth_api()
             .spawn_with_call_at(trace_request.call, at, overrides, move |db, env| {
-                let (res, _, db) = this.eth_api().inspect_and_return_db(db, env, &mut inspector)?;
+                let (res, _) = this.eth_api().inspect(&mut *db, env, &mut inspector)?;
                 let trace_res = inspector.into_parity_builder().into_trace_results_with_state(
                     &res,
                     &trace_request.trace_types,


### PR DESCRIPTION
7.2m -> 6.2m llvm lines

Done by removing unnecessary borrows on db generics