### PR TITLE
feat(pool): make mock transaction validator eth-compatible

### DIFF
--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -11,10 +11,10 @@ use crate::{
         TransactionListenerKind,
     },
     validate::ValidTransaction,
-    AllPoolTransactions, AllTransactionsEvents, BestTransactions, BlockInfo, EthPooledTransaction,
-    NewTransactionEvent, PoolResult, PoolSize, PoolTransaction, PooledTransactionsElement,
-    PropagatedTransactions, TransactionEvents, TransactionOrigin, TransactionPool,
-    TransactionValidationOutcome, TransactionValidator, ValidPoolTransaction,
+    AllPoolTransactions, AllTransactionsEvents, BestTransactions, BlockInfo, EthPoolTransaction,
+    EthPooledTransaction, NewTransactionEvent, PoolResult, PoolSize, PoolTransaction,
+    PooledTransactionsElement, PropagatedTransactions, TransactionEvents, TransactionOrigin,
+    TransactionPool, TransactionValidationOutcome, TransactionValidator, ValidPoolTransaction,
 };
 use reth_eth_wire::HandleMempoolData;
 use reth_primitives::{Address, BlobTransactionSidecar, TxHash, U256};
@@ -252,20 +252,21 @@ pub struct MockTransactionValidator<T> {
     _marker: PhantomData<T>,
 }
 
-impl<T: PoolTransaction> TransactionValidator for MockTransactionValidator<T> {
+impl<T: EthPoolTransaction> TransactionValidator for MockTransactionValidator<T> {
     type Transaction = T;
 
     async fn validate_transaction(
         &self,
         origin: TransactionOrigin,
-        transaction: Self::Transaction,
+        mut transaction: Self::Transaction,
     ) -> TransactionValidationOutcome<Self::Transaction> {
+        let maybe_sidecar = transaction.take_blob().maybe_sidecar().cloned();
         // we return `balance: U256::MAX` to simulate a valid transaction which will never go into
         // overdraft
         TransactionValidationOutcome::Valid {
             balance: U256::MAX,
             state_nonce: 0,
-            transaction: ValidTransaction::Valid(transaction),
+            transaction: ValidTransaction::new(transaction, maybe_sidecar),
             propagate: match origin {
                 TransactionOrigin::External => true,
                 TransactionOrigin::Local => self.propagate_local,
@@ -285,7 +286,7 @@ impl<T> MockTransactionValidator<T> {
 
 impl<T> Default for MockTransactionValidator<T> {
     fn default() -> Self {
-        MockTransactionValidator { propagate_local: true, _marker: Default::default() }
+        Self { propagate_local: true, _marker: Default::default() }
     }
 }
 

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -361,25 +361,17 @@ where
                     }
                 }
                 EthBlobTransactionSidecar::Present(blob) => {
-                    if let Some(eip4844) = transaction.as_eip4844() {
-                        // validate the blob
-                        if let Err(err) = eip4844.validate_blob(&blob, &self.kzg_settings) {
-                            return TransactionValidationOutcome::Invalid(
-                                transaction,
-                                InvalidPoolTransactionError::Eip4844(
-                                    Eip4844PoolTransactionError::InvalidEip4844Blob(err),
-                                ),
-                            )
-                        }
-                        // store the extracted blob
-                        maybe_blob_sidecar = Some(blob);
-                    } else {
-                        // this should not happen
+                    // validate the blob
+                    if let Err(err) = transaction.validate_blob(&blob, &self.kzg_settings) {
                         return TransactionValidationOutcome::Invalid(
                             transaction,
-                            InvalidTransactionError::TxTypeNotSupported.into(),
+                            InvalidPoolTransactionError::Eip4844(
+                                Eip4844PoolTransactionError::InvalidEip4844Blob(err),
+                            ),
                         )
                     }
+                    // store the extracted blob
+                    maybe_blob_sidecar = Some(blob);
                 }
             }
         }


### PR DESCRIPTION
Previously, it was impossible to insert a blob into the mock pool, because validation always returned `Valid` and not `ValidWithSidecar` https://github.com/paradigmxyz/reth/blob/1c1cbe92317eaf89d3ff32bc6ccf896ef6e24de9/crates/transaction-pool/src/noop.rs#L255-L276

But it's important to return `ValidWithSidecar`, because otherwise the blob won't be inserted https://github.com/paradigmxyz/reth/blob/1c1cbe92317eaf89d3ff32bc6ccf896ef6e24de9/crates/transaction-pool/src/pool/mod.rs#L429-L439 https://github.com/paradigmxyz/reth/blob/1c1cbe92317eaf89d3ff32bc6ccf896ef6e24de9/crates/transaction-pool/src/pool/mod.rs#L452-L458