### PR TITLE
chore: drop ```RUST_LOG=info``` from recommended commands

### DIFF
--- a/book/jsonrpc/intro.md
+++ b/book/jsonrpc/intro.md
@@ -114,7 +114,7 @@ You can use `curl`, a programming language with a low-level library, or a tool l
 As a reminder, you need to run the command below to enable all of these APIs using an HTTP transport:
 
 ```bash
-RUST_LOG=info reth node --http --http.api "admin,debug,eth,net,trace,txpool,web3,rpc"
+reth node --http --http.api "admin,debug,eth,net,trace,txpool,web3,rpc"
 ```
 
 This allows you to then call:

--- a/book/run/mainnet.md
+++ b/book/run/mainnet.md
@@ -20,12 +20,12 @@ First, ensure that you have Reth installed by following the [installation instru
 Now, to start the archive node, run:
 
 ```bash
-RUST_LOG=info reth node
+reth node
 ```
 
 And to start the full node, run:
 ```bash
-RUST_LOG=info reth node --full
+reth node --full
 ```
 
 On differences between archive and full nodes, see [Pruning & Full Node](./pruning.md#basic-concepts) section.
@@ -39,7 +39,7 @@ You can override this path using the `--authrpc.jwtsecret` option. You MUST use 
 So one might do:
 
 ```bash
-RUST_LOG=info reth node \
+reth node \
     --authrpc.jwtsecret /path/to/secret \
     --authrpc.addr 127.0.0.1 \
     --authrpc.port 8551
@@ -54,7 +54,7 @@ First, make sure you have Lighthouse installed. Sigma Prime provides excellent [
 Assuming you have done that, run:
 
 ```bash
-RUST_LOG=info lighthouse bn \
+lighthouse bn \
     --checkpoint-sync-url https://mainnet.checkpoint.sigp.io \
     --execution-endpoint http://localhost:8551 \
     --execution-jwt /path/to/secret

--- a/book/run/observability.md
+++ b/book/run/observability.md
@@ -3,7 +3,7 @@
 Reth exposes a number of metrics, which are listed [here][metrics]. We can serve them from an HTTP endpoint by adding the `--metrics` flag:
 
 ```bash
-RUST_LOG=info reth node --metrics 127.0.0.1:9001
+reth node --metrics 127.0.0.1:9001
 ```
 
 Now, as the node is running, you can `curl` the endpoint you provided to the `--metrics` flag to get a text dump of the metrics at that time:

--- a/book/run/pruning.md
+++ b/book/run/pruning.md
@@ -39,7 +39,7 @@ To run Reth as a full node, follow the steps from the previous chapter on
 [how to run on mainnet or official testnets](./mainnet.md), and add a `--full` flag. For example:
 
 ```bash
-RUST_LOG=info reth node \
+reth node \
     --full \
     --authrpc.jwtsecret /path/to/secret \
     --authrpc.addr 127.0.0.1 \


### PR DESCRIPTION
Fixes #8049 