### PR TITLE
fix(discv5): decouple rlpx & discv5 ipmode

### DIFF
--- a/bin/reth/src/commands/p2p/mod.rs
+++ b/bin/reth/src/commands/p2p/mod.rs
@@ -147,9 +147,9 @@ impl Command {
         {
             network_config = network_config.discovery_v5_with_config_builder(|builder| {
                 let DiscoveryArgs {
-                    discv5_addr_ipv4,
+                    discv5_addr: discv5_addr_ipv4,
                     discv5_addr_ipv6,
-                    discv5_port_ipv4,
+                    discv5_port: discv5_port_ipv4,
                     discv5_port_ipv6,
                     discv5_lookup_interval,
                     discv5_bootstrap_lookup_interval,

--- a/bin/reth/src/commands/p2p/mod.rs
+++ b/bin/reth/src/commands/p2p/mod.rs
@@ -18,7 +18,11 @@ use reth_discv4::NatResolver;
 use reth_interfaces::p2p::bodies::client::BodiesClient;
 use reth_primitives::{BlockHashOrNumber, ChainSpec, NodeRecord};
 use reth_provider::ProviderFactory;
-use std::{net::SocketAddr, path::PathBuf, sync::Arc};
+use std::{
+    net::{SocketAddrV4, SocketAddrV6},
+    path::PathBuf,
+    sync::Arc,
+};
 
 /// `reth p2p` command
 #[derive(Debug, Parser)]
@@ -143,19 +147,23 @@ impl Command {
         {
             network_config = network_config.discovery_v5_with_config_builder(|builder| {
                 let DiscoveryArgs {
-                    discv5_addr,
-                    discv5_port,
+                    discv5_addr_ipv4,
+                    discv5_addr_ipv6,
+                    discv5_port_ipv4,
+                    discv5_port_ipv6,
                     discv5_lookup_interval,
                     discv5_bootstrap_lookup_interval,
                     discv5_bootstrap_lookup_countdown,
                     ..
                 } = self.discovery;
+
                 builder
                     .discv5_config(
-                        discv5::ConfigBuilder::new(ListenConfig::from(Into::<SocketAddr>::into((
-                            discv5_addr,
-                            discv5_port,
-                        ))))
+                        discv5::ConfigBuilder::new(ListenConfig::from_two_sockets(
+                            discv5_addr_ipv4.map(|addr| SocketAddrV4::new(addr, discv5_port_ipv4)),
+                            discv5_addr_ipv6
+                                .map(|addr| SocketAddrV6::new(addr, discv5_port_ipv6, 0, 0)),
+                        ))
                         .build(),
                     )
                     .lookup_interval(discv5_lookup_interval)

--- a/crates/net/discv5/src/config.rs
+++ b/crates/net/discv5/src/config.rs
@@ -260,7 +260,7 @@ pub struct Config {
     /// Fork kv-pair to set in local node record. Identifies which network/chain/fork the node
     /// belongs, e.g. `(b"opstack", ChainId)` or `(b"eth", [ForkId])`.
     pub(super) fork: Option<(&'static [u8], EnrForkIdEntry)>,
-    /// RLPx TCP port to advertise, and the tcp socket's [`IpMode`].
+    /// RLPx TCP socket to advertise.
     ///
     /// NOTE: IP address of RLPx socket overwrites IP address of same IP version in
     /// [`discv5::ListenConfig`].

--- a/crates/net/discv5/src/config.rs
+++ b/crates/net/discv5/src/config.rs
@@ -500,4 +500,34 @@ mod test {
             assert!(bootstrap_nodes.contains(&node.to_string()));
         }
     }
+
+    #[test]
+    fn overwrite_ipv4_addr() {
+        let rlpx_addr: Ipv4Addr = "192.168.0.1".parse().unwrap();
+
+        let listen_config = ListenConfig::default();
+
+        let amended_config = amend_listen_config_wrt_rlpx(rlpx_addr.into(), &listen_config);
+
+        let config_socket_ipv4 = ipv4(&amended_config).unwrap();
+
+        assert_eq!(*config_socket_ipv4.ip(), rlpx_addr);
+        assert_eq!(config_socket_ipv4.port(), DEFAULT_DISCOVERY_V5_PORT);
+        assert_eq!(ipv6(&amended_config), None);
+    }
+
+    #[test]
+    fn overwrite_ipv6_addr() {
+        let rlpx_addr: Ipv6Addr = "fe80::1".parse().unwrap();
+
+        let listen_config = ListenConfig::default();
+
+        let amended_config = amend_listen_config_wrt_rlpx(rlpx_addr.into(), &listen_config);
+
+        let config_socket_ipv6 = ipv6(&amended_config).unwrap();
+
+        assert_eq!(*config_socket_ipv6.ip(), rlpx_addr);
+        assert_eq!(config_socket_ipv6.port(), DEFAULT_DISCOVERY_V5_PORT);
+        assert_eq!(ipv4(&amended_config), None);
+    }
 }

--- a/crates/net/discv5/src/config.rs
+++ b/crates/net/discv5/src/config.rs
@@ -513,7 +513,7 @@ mod test {
 
         assert_eq!(*config_socket_ipv4.ip(), rlpx_addr);
         assert_eq!(config_socket_ipv4.port(), DEFAULT_DISCOVERY_V5_PORT);
-        assert_eq!(ipv6(&amended_config), None);
+        assert_eq!(ipv6(&amended_config), ipv6(&listen_config));
     }
 
     #[test]
@@ -528,6 +528,6 @@ mod test {
 
         assert_eq!(*config_socket_ipv6.ip(), rlpx_addr);
         assert_eq!(config_socket_ipv6.port(), DEFAULT_DISCOVERY_V5_PORT);
-        assert_eq!(ipv4(&amended_config), None);
+        assert_eq!(ipv4(&amended_config), ipv4(&listen_config));
     }
 }

--- a/crates/net/discv5/src/config.rs
+++ b/crates/net/discv5/src/config.rs
@@ -222,7 +222,7 @@ impl ConfigBuilder {
             .unwrap_or_else(|| discv5::ConfigBuilder::new(ListenConfig::default()).build());
 
         discv5_config.listen_config =
-            amend_listen_config_wrt_rlpx(tcp_socket.ip(), &discv5_config.listen_config);
+            amend_listen_config_wrt_rlpx(&discv5_config.listen_config, tcp_socket.ip());
 
         let fork = fork.map(|(key, fork_id)| (key, fork_id.into()));
 
@@ -343,8 +343,8 @@ pub fn ipv6(listen_config: &ListenConfig) -> Option<SocketAddrV6> {
 /// to one IP address per IP version (atm, may become spec'd how to advertise different addresses).
 /// The RLPx address overwrites the discv5 address w.r.t. IP version.
 pub fn amend_listen_config_wrt_rlpx(
-    rlpx_addr: IpAddr,
     listen_config: &ListenConfig,
+    rlpx_addr: IpAddr,
 ) -> ListenConfig {
     let discv5_socket_ipv4 = ipv4(listen_config);
     let discv5_socket_ipv6 = ipv6(listen_config);
@@ -507,7 +507,7 @@ mod test {
 
         let listen_config = ListenConfig::default();
 
-        let amended_config = amend_listen_config_wrt_rlpx(rlpx_addr.into(), &listen_config);
+        let amended_config = amend_listen_config_wrt_rlpx(&listen_config, rlpx_addr.into());
 
         let config_socket_ipv4 = ipv4(&amended_config).unwrap();
 
@@ -522,7 +522,7 @@ mod test {
 
         let listen_config = ListenConfig::default();
 
-        let amended_config = amend_listen_config_wrt_rlpx(rlpx_addr.into(), &listen_config);
+        let amended_config = amend_listen_config_wrt_rlpx(&listen_config, rlpx_addr.into());
 
         let config_socket_ipv6 = ipv6(&amended_config).unwrap();
 

--- a/crates/net/discv5/src/config.rs
+++ b/crates/net/discv5/src/config.rs
@@ -367,7 +367,7 @@ pub fn amend_listen_config_wrt_rlpx(
     ListenConfig::from_two_sockets(discv5_socket_ipv4, discv5_socket_ipv6)
 }
 
-/// Returns the sockets that can be used for discv5 with respect to RLPx address. ENR specs only
+/// Returns the sockets that can be used for discv5 with respect to the RLPx address. ENR specs only
 /// acknowledge one address per IP version.
 pub fn discv5_sockets_wrt_rlpx_addr(
     rlpx_addr: IpAddr,

--- a/crates/net/discv5/src/config.rs
+++ b/crates/net/discv5/src/config.rs
@@ -382,7 +382,7 @@ pub fn discv5_sockets_wrt_rlpx_addr(
                 discv5_addr_ipv6.map(|ip| SocketAddrV6::new(ip, discv5_port_ipv6, 0, 0));
 
             if let Some(discv5_addr) = discv5_addr_ipv4 {
-                warn!(target: "reth::cli",
+                warn!(target: "discv5",
                     %discv5_addr,
                     %rlpx_addr,
                     "Overwriting discv5 IPv4 address with RLPx IPv4 address, limited to one advertised IP address per IP version"
@@ -399,7 +399,7 @@ pub fn discv5_sockets_wrt_rlpx_addr(
                 discv5_addr_ipv4.map(|ip| SocketAddrV4::new(ip, discv5_port_ipv4));
 
             if let Some(discv5_addr) = discv5_addr_ipv6 {
-                warn!(target: "reth::cli",
+                warn!(target: "discv5",
                     %discv5_addr,
                     %rlpx_addr,
                     "Overwriting discv5 IPv6 address with RLPx IPv6 address, limited to one advertised IP address per IP version"

--- a/crates/net/discv5/src/config.rs
+++ b/crates/net/discv5/src/config.rs
@@ -3,20 +3,26 @@
 use std::{
     collections::HashSet,
     fmt::Debug,
-    net::{IpAddr, Ipv4Addr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
 };
 
 use derive_more::Display;
 use discv5::ListenConfig;
 use multiaddr::{Multiaddr, Protocol};
 use reth_primitives::{Bytes, EnrForkIdEntry, ForkId, NodeRecord};
+use tracing::warn;
 
 use crate::{enr::discv4_id_to_multiaddr_id, filter::MustNotIncludeKeys, NetworkStackId};
 
-/// The default address for discv5 via UDP.
+/// The default address for discv5 via UDP is IPv4.
 ///
 /// Default is 0.0.0.0, all interfaces. See [`discv5::ListenConfig`] default.
-pub const DEFAULT_DISCOVERY_V5_ADDR: IpAddr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+pub const DEFAULT_DISCOVERY_V5_ADDR: Ipv4Addr = Ipv4Addr::UNSPECIFIED;
+
+/// The default IPv6 address for discv5 via UDP.
+///
+/// Default is ::, all interfaces.
+pub const DEFAULT_DISCOVERY_V5_ADDR_IPV6: Ipv6Addr = Ipv6Addr::UNSPECIFIED;
 
 /// The default port for discv5 via UDP.
 ///
@@ -40,7 +46,7 @@ pub const DEFAULT_COUNT_BOOTSTRAP_LOOKUPS: u64 = 100;
 pub const DEFAULT_SECONDS_BOOTSTRAP_LOOKUP_INTERVAL: u64 = 5;
 
 /// Builds a [`Config`].
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct ConfigBuilder {
     /// Config used by [`discv5::Discv5`]. Contains the discovery listen socket.
     discv5_config: Option<discv5::Config>,
@@ -51,10 +57,11 @@ pub struct ConfigBuilder {
     ///
     /// Defaults to L1 mainnet if not set.
     fork: Option<(&'static [u8], ForkId)>,
-    /// RLPx TCP port to advertise. Note: so long as `reth_network` handles [`NodeRecord`]s as
-    /// opposed to [`Enr`](enr::Enr)s, TCP is limited to same IP address as UDP, since
-    /// [`NodeRecord`] doesn't supply an extra field for and alternative TCP address.
-    tcp_port: u16,
+    /// RLPx TCP socket to advertise.
+    ///
+    /// NOTE: IP address of RLPx socket overwrites IP address of same IP version in
+    /// [`discv5::ListenConfig`].
+    tcp_socket: SocketAddr,
     /// List of `(key, rlp-encoded-value)` tuples that should be advertised in local node record
     /// (in addition to tcp port, udp port and fork).
     other_enr_kv_pairs: Vec<(&'static [u8], Bytes)>,
@@ -77,7 +84,7 @@ impl ConfigBuilder {
             discv5_config,
             bootstrap_nodes,
             fork,
-            tcp_port,
+            tcp_socket,
             other_enr_kv_pairs,
             lookup_interval,
             bootstrap_lookup_interval,
@@ -89,7 +96,7 @@ impl ConfigBuilder {
             discv5_config: Some(discv5_config),
             bootstrap_nodes,
             fork: fork.map(|(key, fork_id)| (key, fork_id.fork_id)),
-            tcp_port,
+            tcp_socket,
             other_enr_kv_pairs,
             lookup_interval: Some(lookup_interval),
             bootstrap_lookup_interval: Some(bootstrap_lookup_interval),
@@ -152,9 +159,11 @@ impl ConfigBuilder {
         self
     }
 
-    /// Sets the tcp port to advertise in the local [`Enr`](discv5::enr::Enr).
-    pub fn tcp_port(mut self, port: u16) -> Self {
-        self.tcp_port = port;
+    /// Sets the tcp socket to advertise in the local [`Enr`](discv5::enr::Enr). The IP address of
+    /// this socket will overwrite the discovery address of the same IP version, if one is
+    /// configured.
+    pub fn tcp_socket(mut self, socket: SocketAddr) -> Self {
+        self.tcp_socket = socket;
         self
     }
 
@@ -201,7 +210,7 @@ impl ConfigBuilder {
             discv5_config,
             bootstrap_nodes,
             fork,
-            tcp_port,
+            tcp_socket,
             other_enr_kv_pairs,
             lookup_interval,
             bootstrap_lookup_interval,
@@ -209,8 +218,11 @@ impl ConfigBuilder {
             discovered_peer_filter,
         } = self;
 
-        let discv5_config = discv5_config
+        let mut discv5_config = discv5_config
             .unwrap_or_else(|| discv5::ConfigBuilder::new(ListenConfig::default()).build());
+
+        discv5_config.listen_config =
+            amend_listen_config_wrt_rlpx(tcp_socket.ip(), &discv5_config.listen_config);
 
         let fork = fork.map(|(key, fork_id)| (key, fork_id.into()));
 
@@ -227,7 +239,7 @@ impl ConfigBuilder {
             discv5_config,
             bootstrap_nodes,
             fork,
-            tcp_port,
+            tcp_socket,
             other_enr_kv_pairs,
             lookup_interval,
             bootstrap_lookup_interval,
@@ -248,8 +260,11 @@ pub struct Config {
     /// Fork kv-pair to set in local node record. Identifies which network/chain/fork the node
     /// belongs, e.g. `(b"opstack", ChainId)` or `(b"eth", [ForkId])`.
     pub(super) fork: Option<(&'static [u8], EnrForkIdEntry)>,
-    /// RLPx TCP port to advertise.
-    pub(super) tcp_port: u16,
+    /// RLPx TCP port to advertise, and the tcp socket's [`IpMode`].
+    ///
+    /// NOTE: IP address of RLPx socket overwrites IP address of same IP version in
+    /// [`discv5::ListenConfig`].
+    pub(super) tcp_socket: SocketAddr,
     /// Additional kv-pairs (besides tcp port, udp port and fork) that should be advertised to
     /// peers by including in local node record.
     pub(super) other_enr_kv_pairs: Vec<(&'static [u8], Bytes)>,
@@ -266,9 +281,20 @@ pub struct Config {
 }
 
 impl Config {
-    /// Returns a new [`ConfigBuilder`], with the RLPx TCP port set to the given port.
-    pub fn builder(rlpx_tcp_port: u16) -> ConfigBuilder {
-        ConfigBuilder::default().tcp_port(rlpx_tcp_port)
+    /// Returns a new [`ConfigBuilder`], with the RLPx TCP port and IP version configured w.r.t.
+    /// the given socket.
+    pub fn builder(rlpx_tcp_socket: SocketAddr) -> ConfigBuilder {
+        ConfigBuilder {
+            discv5_config: None,
+            bootstrap_nodes: HashSet::new(),
+            fork: None,
+            tcp_socket: rlpx_tcp_socket,
+            other_enr_kv_pairs: Vec::new(),
+            lookup_interval: None,
+            bootstrap_lookup_interval: None,
+            bootstrap_lookup_countdown: None,
+            discovered_peer_filter: None,
+        }
     }
 }
 
@@ -286,12 +312,104 @@ impl Config {
 
     /// Returns the RLPx (TCP) socket contained in the [`discv5::Config`]. This socket will be
     /// advertised to peers in the local [`Enr`](discv5::enr::Enr).
-    pub fn rlpx_socket(&self) -> SocketAddr {
-        let port = self.tcp_port;
-        match self.discv5_config.listen_config {
-            ListenConfig::Ipv4 { ip, .. } => (ip, port).into(),
-            ListenConfig::Ipv6 { ip, .. } => (ip, port).into(),
-            ListenConfig::DualStack { ipv4, .. } => (ipv4, port).into(),
+    pub fn rlpx_socket(&self) -> &SocketAddr {
+        &self.tcp_socket
+    }
+}
+
+/// Returns the IPv4 discovery socket if one is configured.
+pub fn ipv4(listen_config: &ListenConfig) -> Option<SocketAddrV4> {
+    match listen_config {
+        ListenConfig::Ipv4 { ip, port } |
+        ListenConfig::DualStack { ipv4: ip, ipv4_port: port, .. } => {
+            Some(SocketAddrV4::new(*ip, *port))
+        }
+        ListenConfig::Ipv6 { .. } => None,
+    }
+}
+
+/// Returns the IPv6 discovery socket if one is configured.
+pub fn ipv6(listen_config: &ListenConfig) -> Option<SocketAddrV6> {
+    match listen_config {
+        ListenConfig::Ipv4 { .. } => None,
+        ListenConfig::Ipv6 { ip, port } |
+        ListenConfig::DualStack { ipv6: ip, ipv6_port: port, .. } => {
+            Some(SocketAddrV6::new(*ip, *port, 0, 0))
+        }
+    }
+}
+
+/// Returns the amended [`discv5::ListenConfig`] based on the RLPx IP address. The ENR is limited
+/// to one IP address per IP version (atm, may become spec'd how to advertise different addresses).
+/// The RLPx address overwrites the discv5 address w.r.t. IP version.
+pub fn amend_listen_config_wrt_rlpx(
+    rlpx_addr: IpAddr,
+    listen_config: &ListenConfig,
+) -> ListenConfig {
+    let discv5_socket_ipv4 = ipv4(listen_config);
+    let discv5_socket_ipv6 = ipv6(listen_config);
+
+    let discv5_port_ipv4 =
+        discv5_socket_ipv4.map(|socket| socket.port()).unwrap_or(DEFAULT_DISCOVERY_V5_PORT);
+    let discv5_addr_ipv4 = discv5_socket_ipv4.map(|socket| *socket.ip());
+    let discv5_port_ipv6 =
+        discv5_socket_ipv6.map(|socket| socket.port()).unwrap_or(DEFAULT_DISCOVERY_V5_PORT);
+    let discv5_addr_ipv6 = discv5_socket_ipv6.map(|socket| *socket.ip());
+
+    let (discv5_socket_ipv4, discv5_socket_ipv6) = discv5_sockets_wrt_rlpx_addr(
+        rlpx_addr,
+        discv5_addr_ipv4,
+        discv5_port_ipv4,
+        discv5_addr_ipv6,
+        discv5_port_ipv6,
+    );
+
+    ListenConfig::from_two_sockets(discv5_socket_ipv4, discv5_socket_ipv6)
+}
+
+/// Returns the sockets that can be used for discv5 with respect to RLPx address. ENR specs only
+/// acknowledge one address per IP version.
+pub fn discv5_sockets_wrt_rlpx_addr(
+    rlpx_addr: IpAddr,
+    discv5_addr_ipv4: Option<Ipv4Addr>,
+    discv5_port_ipv4: u16,
+    discv5_addr_ipv6: Option<Ipv6Addr>,
+    discv5_port_ipv6: u16,
+) -> (Option<SocketAddrV4>, Option<SocketAddrV6>) {
+    match rlpx_addr {
+        IpAddr::V4(rlpx_addr) => {
+            let discv5_socket_ipv6 =
+                discv5_addr_ipv6.map(|ip| SocketAddrV6::new(ip, discv5_port_ipv6, 0, 0));
+
+            if let Some(discv5_addr) = discv5_addr_ipv4 {
+                warn!(target: "reth::cli",
+                    %discv5_addr,
+                    %rlpx_addr,
+                    "Overwriting discv5 IPv4 address with RLPx IPv4 address, limited to one advertised IP address per IP version"
+                );
+            }
+
+            // overwrite discv5 ipv4 addr with RLPx address. this is since there is no
+            // spec'd way to advertise a different address for rlpx and discovery in the
+            // ENR.
+            (Some(SocketAddrV4::new(rlpx_addr, discv5_port_ipv4)), discv5_socket_ipv6)
+        }
+        IpAddr::V6(rlpx_addr) => {
+            let discv5_socket_ipv4 =
+                discv5_addr_ipv4.map(|ip| SocketAddrV4::new(ip, discv5_port_ipv4));
+
+            if let Some(discv5_addr) = discv5_addr_ipv6 {
+                warn!(target: "reth::cli",
+                    %discv5_addr,
+                    %rlpx_addr,
+                    "Overwriting discv5 IPv6 address with RLPx IPv6 address, limited to one advertised IP address per IP version"
+                );
+            }
+
+            // overwrite discv5 ipv6 addr with RLPx address. this is since there is no
+            // spec'd way to advertise a different address for rlpx and discovery in the
+            // ENR.
+            (discv5_socket_ipv4, Some(SocketAddrV6::new(rlpx_addr, discv5_port_ipv6, 0, 0)))
         }
     }
 }
@@ -351,7 +469,7 @@ mod test {
     fn parse_boot_nodes() {
         const OP_SEPOLIA_CL_BOOTNODES: &str ="enr:-J64QBwRIWAco7lv6jImSOjPU_W266lHXzpAS5YOh7WmgTyBZkgLgOwo_mxKJq3wz2XRbsoBItbv1dCyjIoNq67mFguGAYrTxM42gmlkgnY0gmlwhBLSsHKHb3BzdGFja4S0lAUAiXNlY3AyNTZrMaEDmoWSi8hcsRpQf2eJsNUx-sqv6fH4btmo2HsAzZFAKnKDdGNwgiQGg3VkcIIkBg,enr:-J64QFa3qMsONLGphfjEkeYyF6Jkil_jCuJmm7_a42ckZeUQGLVzrzstZNb1dgBp1GGx9bzImq5VxJLP-BaptZThGiWGAYrTytOvgmlkgnY0gmlwhGsV-zeHb3BzdGFja4S0lAUAiXNlY3AyNTZrMaEDahfSECTIS_cXyZ8IyNf4leANlZnrsMEWTkEYxf4GMCmDdGNwgiQGg3VkcIIkBg";
 
-        let config = Config::builder(30303)
+        let config = Config::builder((Ipv4Addr::UNSPECIFIED, 30303).into())
             .add_cl_serialized_signed_boot_nodes(OP_SEPOLIA_CL_BOOTNODES)
             .build();
 
@@ -371,7 +489,7 @@ mod test {
 
     #[test]
     fn parse_enodes() {
-        let config = Config::builder(30303)
+        let config = Config::builder((Ipv4Addr::UNSPECIFIED, 30303).into())
             .add_serialized_unsigned_boot_nodes(BOOT_NODES_OP_MAINNET_AND_BASE_MAINNET)
             .build();
 

--- a/crates/net/discv5/src/error.rs
+++ b/crates/net/discv5/src/error.rs
@@ -35,4 +35,7 @@ pub enum Error {
     /// An error from underlying [`discv5::Discv5`] node.
     #[error("sigp/discv5 error, {0}")]
     Discv5Error(discv5::Error),
+    /// The [`ListenConfig`](discv5::ListenConfig) has been misconfigured.
+    #[error("misconfigured listen config, RLPx TCP address must also be supported by discv5")]
+    ListenConfigMisconfigured,
 }

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -336,8 +336,9 @@ impl Discv5 {
     ) -> Result<NodeRecord, Error> {
         let id = enr_to_discv4_id(enr).ok_or(Error::IncompatibleKeyType)?;
 
-        // since we, on bootstrap, set tcp4 in local ENR for `IpMode::Dual`, we prefer tcp4 here
-        // too
+        if enr.tcp4().is_none() && enr.tcp6().is_none() {
+            return Err(Error::UnreachableRlpx)
+        }
         let Some(tcp_port) = (match self.rlpx_ip_mode {
             IpMode::Ip4 => enr.tcp4(),
             IpMode::Ip6 => enr.tcp6(),

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -66,7 +66,7 @@ pub const DEFAULT_MIN_TARGET_KBUCKET_INDEX: usize = 0;
 pub struct Discv5 {
     /// sigp/discv5 node.
     discv5: Arc<discv5::Discv5>,
-    /// [`IpMode`] of the the node.
+    /// [`IpMode`] of the the RLPx network.
     rlpx_ip_mode: IpMode,
     /// Key used in kv-pair to ID chain, e.g. 'opstack' or 'eth'.
     fork_key: Option<&'static [u8]>,
@@ -328,7 +328,7 @@ impl Discv5 {
     }
 
     /// Tries to convert an [`Enr`](discv5::Enr) into the backwards compatible type [`NodeRecord`],
-    /// w.r.t. local [`IpMode`]. Uses source socket as udp socket.
+    /// w.r.t. local RLPx [`IpMode`]. Uses source socket as udp socket.
     pub fn try_into_reachable(
         &self,
         enr: &discv5::Enr,
@@ -386,7 +386,7 @@ impl Discv5 {
     // Complementary
     ////////////////////////////////////////////////////////////////////////////////////////////////
 
-    /// Returns the [`IpMode`] of the local node.
+    /// Returns the RLPx [`IpMode`] of the local node.
     pub fn ip_mode(&self) -> IpMode {
         self.rlpx_ip_mode
     }

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -676,9 +676,10 @@ mod test {
         let secret_key = SecretKey::new(&mut thread_rng());
 
         let discv5_addr: SocketAddr = format!("127.0.0.1:{udp_port_discv5}").parse().unwrap();
+        let rlpx_addr: SocketAddr = "127.0.0.1:30303".parse().unwrap();
 
         let discv5_listen_config = ListenConfig::from(discv5_addr);
-        let discv5_config = Config::builder((Ipv4Addr::UNSPECIFIED, 30303).into())
+        let discv5_config = Config::builder(rlpx_addr)
             .discv5_config(discv5::ConfigBuilder::new(discv5_listen_config).build())
             .build();
 

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -121,16 +121,15 @@ impl<C> NetworkConfig<C> {
         self,
         f: impl FnOnce(reth_discv5::ConfigBuilder) -> reth_discv5::Config,
     ) -> Self {
-        let rlpx_port = self.listener_addr.port();
         let network_stack_id = NetworkStackId::id(&self.chain_spec);
         let fork_id = self.chain_spec.latest_fork_id();
         let boot_nodes = self.boot_nodes.clone();
 
-        let mut builder =
-            reth_discv5::Config::builder(rlpx_port).add_unsigned_boot_nodes(boot_nodes.into_iter());
+        let mut builder = reth_discv5::Config::builder(self.listener_addr)
+            .add_unsigned_boot_nodes(boot_nodes.into_iter());
 
         if let Some(id) = network_stack_id {
-            builder = builder.fork(id, fork_id);
+            builder = builder.fork(id, fork_id)
         }
 
         self.set_discovery_v5(f(builder))

--- a/crates/net/network/src/discovery.rs
+++ b/crates/net/network/src/discovery.rs
@@ -369,7 +369,7 @@ mod tests {
         let discv4_config = Discv4ConfigBuilder::default().external_ip_resolver(None).build();
 
         let discv5_listen_config = discv5::ListenConfig::from(discv5_addr);
-        let discv5_config = reth_discv5::Config::builder(0)
+        let discv5_config = reth_discv5::Config::builder(discv5_addr)
             .discv5_config(discv5::ConfigBuilder::new(discv5_listen_config).build())
             .build();
 

--- a/crates/node-core/src/args/network.rs
+++ b/crates/node-core/src/args/network.rs
@@ -232,19 +232,21 @@ pub struct DiscoveryArgs {
     pub port: u16,
 
     /// The UDP IPv4 address to use for devp2p peer discovery version 5.
-    #[arg(id = "discovery.v5.addr.ipv4", long = "discovery.v5.addr.ipv4", value_name = "DISCOVERY_V5_ADDR_IPV4", default_value = None)]
-    pub discv5_addr_ipv4: Option<Ipv4Addr>,
+    #[arg(id = "discovery.v5.addr", long = "discovery.v5.addr", value_name = "DISCOVERY_V5_ADDR", default_value = None)]
+    pub discv5_addr: Option<Ipv4Addr>,
 
     /// The UDP IPv6 address to use for devp2p peer discovery version 5.
     #[arg(id = "discovery.v5.addr.ipv6", long = "discovery.v5.addr.ipv6", value_name = "DISCOVERY_V5_ADDR_IPV6", default_value = None)]
     pub discv5_addr_ipv6: Option<Ipv6Addr>,
 
-    /// The UDP IPv4 port to use for devp2p peer discovery version 5.
-    #[arg(id = "discovery.v5.port.ipv4", long = "discovery.v5.port.ipv4", value_name = "DISCOVERY_V5_PORT_IPV4",
+    /// The UDP IPv4 port to use for devp2p peer discovery version 5. Not used unless `--addr` is
+    /// IPv4, or `--discv5.addr` is set.
+    #[arg(id = "discovery.v5.port", long = "discovery.v5.port", value_name = "DISCOVERY_V5_PORT",
     default_value_t = DEFAULT_DISCOVERY_V5_PORT)]
-    pub discv5_port_ipv4: u16,
+    pub discv5_port: u16,
 
-    /// The UDP IPv6 port to use for devp2p peer discovery version 5.
+    /// The UDP IPv6 port to use for devp2p peer discovery version 5. Not used unless `--addr` is
+    /// IPv6, or `--discv5.addr.ipv6` is set.
     #[arg(id = "discovery.v5.port.ipv6", long = "discovery.v5.port.ipv6", value_name = "DISCOVERY_V5_PORT_IPV6",
     default_value = None, default_value_t = DEFAULT_DISCOVERY_V5_PORT)]
     pub discv5_port_ipv6: u16,
@@ -300,9 +302,9 @@ impl Default for DiscoveryArgs {
             enable_discv5_discovery: cfg!(feature = "optimism"),
             addr: DEFAULT_DISCOVERY_ADDR,
             port: DEFAULT_DISCOVERY_PORT,
-            discv5_addr_ipv4: None,
+            discv5_addr: None,
             discv5_addr_ipv6: None,
-            discv5_port_ipv4: DEFAULT_DISCOVERY_V5_PORT,
+            discv5_port: DEFAULT_DISCOVERY_V5_PORT,
             discv5_port_ipv6: DEFAULT_DISCOVERY_V5_PORT,
             discv5_lookup_interval: DEFAULT_SECONDS_LOOKUP_INTERVAL,
             discv5_bootstrap_lookup_interval: DEFAULT_SECONDS_BOOTSTRAP_LOOKUP_INTERVAL,

--- a/crates/node-core/src/args/network.rs
+++ b/crates/node-core/src/args/network.rs
@@ -5,7 +5,7 @@ use clap::Args;
 use reth_config::Config;
 use reth_discv4::{DEFAULT_DISCOVERY_ADDR, DEFAULT_DISCOVERY_PORT};
 use reth_discv5::{
-    DEFAULT_COUNT_BOOTSTRAP_LOOKUPS, DEFAULT_DISCOVERY_V5_ADDR, DEFAULT_DISCOVERY_V5_PORT,
+    DEFAULT_COUNT_BOOTSTRAP_LOOKUPS, DEFAULT_DISCOVERY_V5_PORT,
     DEFAULT_SECONDS_BOOTSTRAP_LOOKUP_INTERVAL, DEFAULT_SECONDS_LOOKUP_INTERVAL,
 };
 use reth_net_nat::NatResolver;
@@ -19,7 +19,11 @@ use reth_network::{
 };
 use reth_primitives::{mainnet_nodes, ChainSpec, NodeRecord};
 use secp256k1::SecretKey;
-use std::{net::IpAddr, path::PathBuf, sync::Arc};
+use std::{
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    path::PathBuf,
+    sync::Arc,
+};
 
 /// Parameters for configuring the network more granularity via CLI
 #[derive(Debug, Clone, Args, PartialEq, Eq)]
@@ -227,31 +231,38 @@ pub struct DiscoveryArgs {
     #[arg(id = "discovery.port", long = "discovery.port", value_name = "DISCOVERY_PORT", default_value_t = DEFAULT_DISCOVERY_PORT)]
     pub port: u16,
 
-    /// The UDP address to use for devp2p peer discovery version 5.
-    #[arg(id = "discovery.v5.addr", long = "discovery.v5.addr", value_name = "DISCOVERY_V5_ADDR",
-    default_value_t = DEFAULT_DISCOVERY_V5_ADDR)]
-    pub discv5_addr: IpAddr,
+    /// The UDP IPv4 address to use for devp2p peer discovery version 5.
+    #[arg(id = "discovery.v5.addr.ipv4", long = "discovery.v5.addr.ipv4", value_name = "DISCOVERY_V5_ADDR_IPV4", default_value = None)]
+    pub discv5_addr_ipv4: Option<Ipv4Addr>,
 
-    /// The UDP port to use for devp2p peer discovery version 5.
-    #[arg(id = "discovery.v5.port", long = "discovery.v5.port", value_name = "DISCOVERY_V5_PORT",
+    /// The UDP IPv6 address to use for devp2p peer discovery version 5.
+    #[arg(id = "discovery.v5.addr.ipv6", long = "discovery.v5.addr.ipv6", value_name = "DISCOVERY_V5_ADDR_IPV6", default_value = None)]
+    pub discv5_addr_ipv6: Option<Ipv6Addr>,
+
+    /// The UDP IPv4 port to use for devp2p peer discovery version 5.
+    #[arg(id = "discovery.v5.port.ipv4", long = "discovery.v5.port.ipv4", value_name = "DISCOVERY_V5_PORT_IPV4",
     default_value_t = DEFAULT_DISCOVERY_V5_PORT)]
-    pub discv5_port: u16,
+    pub discv5_port_ipv4: u16,
+
+    /// The UDP IPv6 port to use for devp2p peer discovery version 5.
+    #[arg(id = "discovery.v5.port.ipv6", long = "discovery.v5.port.ipv6", value_name = "DISCOVERY_V5_PORT_IPV6",
+    default_value = None, default_value_t = DEFAULT_DISCOVERY_V5_PORT)]
+    pub discv5_port_ipv6: u16,
 
     /// The interval in seconds at which to carry out periodic lookup queries, for the whole
     /// run of the program.
-    #[arg(id = "discovery.v5.lookup-interval", long = "discovery.v5.lookup-interval", value_name = "DISCOVERY_V5_LOOKUP_INTERVAL",
-    default_value_t = DEFAULT_SECONDS_LOOKUP_INTERVAL)]
+    #[arg(id = "discovery.v5.lookup-interval", long = "discovery.v5.lookup-interval", value_name = "DISCOVERY_V5_LOOKUP_INTERVAL", default_value_t = DEFAULT_SECONDS_LOOKUP_INTERVAL)]
     pub discv5_lookup_interval: u64,
 
     /// The interval in seconds at which to carry out boost lookup queries, for a fixed number of
     /// times, at bootstrap.
-    #[arg(id = "discovery.v5.bootstrap.lookup-interval", long = "discovery.v5.bootstrap.lookup-interval", value_name = "DISCOVERY_V5_bootstrap_lookup_interval",
+    #[arg(id = "discovery.v5.bootstrap.lookup-interval", long = "discovery.v5.bootstrap.lookup-interval", value_name = "DISCOVERY_V5_bootstrap_lookup_interval", 
         default_value_t = DEFAULT_SECONDS_BOOTSTRAP_LOOKUP_INTERVAL)]
     pub discv5_bootstrap_lookup_interval: u64,
 
     /// The number of times to carry out boost lookup queries at bootstrap.
-    #[arg(id = "discovery.v5.bootstrap.lookup-countdown", long = "discovery.v5.bootstrap.lookup-countdown", value_name = "DISCOVERY_V5_bootstrap_lookup_countdown",
-                        default_value_t = DEFAULT_COUNT_BOOTSTRAP_LOOKUPS)]
+    #[arg(id = "discovery.v5.bootstrap.lookup-countdown", long = "discovery.v5.bootstrap.lookup-countdown", value_name = "DISCOVERY_V5_bootstrap_lookup_countdown", 
+        default_value_t = DEFAULT_COUNT_BOOTSTRAP_LOOKUPS)]
     pub discv5_bootstrap_lookup_countdown: u64,
 }
 
@@ -289,8 +300,10 @@ impl Default for DiscoveryArgs {
             enable_discv5_discovery: cfg!(feature = "optimism"),
             addr: DEFAULT_DISCOVERY_ADDR,
             port: DEFAULT_DISCOVERY_PORT,
-            discv5_addr: DEFAULT_DISCOVERY_V5_ADDR,
-            discv5_port: DEFAULT_DISCOVERY_V5_PORT,
+            discv5_addr_ipv4: None,
+            discv5_addr_ipv6: None,
+            discv5_port_ipv4: DEFAULT_DISCOVERY_V5_PORT,
+            discv5_port_ipv6: DEFAULT_DISCOVERY_V5_PORT,
             discv5_lookup_interval: DEFAULT_SECONDS_LOOKUP_INTERVAL,
             discv5_bootstrap_lookup_interval: DEFAULT_SECONDS_BOOTSTRAP_LOOKUP_INTERVAL,
             discv5_bootstrap_lookup_countdown: DEFAULT_COUNT_BOOTSTRAP_LOOKUPS,

--- a/crates/node-core/src/node_config.rs
+++ b/crates/node-core/src/node_config.rs
@@ -486,9 +486,9 @@ impl NodeConfig {
         // due to unsatisfied trait bounds
         config.discovery_v5_with_config_builder(|builder| {
             let DiscoveryArgs {
-                discv5_addr_ipv4,
+                discv5_addr: discv5_addr_ipv4,
                 discv5_addr_ipv6,
-                discv5_port_ipv4,
+                discv5_port: discv5_port_ipv4,
                 discv5_port_ipv6,
                 discv5_lookup_interval,
                 discv5_bootstrap_lookup_interval,

--- a/crates/node-core/src/node_config.rs
+++ b/crates/node-core/src/node_config.rs
@@ -26,7 +26,11 @@ use reth_provider::{
 };
 use reth_tasks::TaskExecutor;
 use secp256k1::SecretKey;
-use std::{net::SocketAddr, path::PathBuf, sync::Arc};
+use std::{
+    net::{SocketAddr, SocketAddrV4, SocketAddrV6},
+    path::PathBuf,
+    sync::Arc,
+};
 use tracing::*;
 
 /// The default prometheus recorder handle. We use a global static to ensure that it is only
@@ -482,19 +486,26 @@ impl NodeConfig {
         // due to unsatisfied trait bounds
         config.discovery_v5_with_config_builder(|builder| {
             let DiscoveryArgs {
-                discv5_addr,
-                discv5_port,
+                discv5_addr_ipv4,
+                discv5_addr_ipv6,
+                discv5_port_ipv4,
+                discv5_port_ipv6,
                 discv5_lookup_interval,
                 discv5_bootstrap_lookup_interval,
                 discv5_bootstrap_lookup_countdown,
                 ..
             } = self.network.discovery;
+
+            let discv5_port_ipv4 = discv5_port_ipv4 + self.instance - 1;
+            let discv5_port_ipv6 = discv5_port_ipv6 + self.instance - 1;
+
             builder
                 .discv5_config(
-                    discv5::ConfigBuilder::new(ListenConfig::from(Into::<SocketAddr>::into((
-                        discv5_addr,
-                        discv5_port + self.instance - 1,
-                    ))))
+                    discv5::ConfigBuilder::new(ListenConfig::from_two_sockets(
+                        discv5_addr_ipv4.map(|addr| SocketAddrV4::new(addr, discv5_port_ipv4)),
+                        discv5_addr_ipv6
+                            .map(|addr| SocketAddrV6::new(addr, discv5_port_ipv6, 0, 0)),
+                    ))
                     .build(),
                 )
                 .lookup_interval(discv5_lookup_interval)


### PR DESCRIPTION
- Decouples IP version used on discv5 and rlpx networks
- Fixes network args for discv5 to allow dual-stack networking
- Handles discv5 listen sockets w.r.t. to ENR spec limitations, by overwriting IP address conflicting with RLPx IP address

@bertmiller