### PR TITLE
fix: ensures that pruning data from static files only happens on calling `commit()`

### DIFF
--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -148,7 +148,7 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
             // database expected height.
             Ordering::Greater => {
                 static_file_producer
-                    .prune_transactions(next_static_file_tx_num - next_tx_num, from_block - 1);
+                    .prune_transactions(next_static_file_tx_num - next_tx_num, from_block - 1)?;
                 // Since this is a database <-> static file inconsistency, we commit the change
                 // straight away.
                 static_file_producer.commit()?;
@@ -326,7 +326,7 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
 
         // Unwinds static file
         static_file_producer
-            .prune_transactions(static_file_tx_num.saturating_sub(db_tx_num), input.unwind_to);
+            .prune_transactions(static_file_tx_num.saturating_sub(db_tx_num), input.unwind_to)?;
 
         Ok(UnwindOutput {
             checkpoint: StageCheckpoint::new(input.unwind_to)
@@ -580,7 +580,7 @@ mod tests {
         {
             let mut static_file_producer =
                 static_file_provider.latest_writer(StaticFileSegment::Transactions).unwrap();
-            static_file_producer.prune_transactions(1, checkpoint.block_number);
+            static_file_producer.prune_transactions(1, checkpoint.block_number).unwrap();
             static_file_producer.commit().unwrap();
         }
         // Unwind all of it

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -146,8 +146,13 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
             // If static files are ahead, then we didn't reach the database commit in a previous
             // stage run. So, our only solution is to unwind the static files and proceed from the
             // database expected height.
-            Ordering::Greater => static_file_producer
-                .prune_transactions(next_static_file_tx_num - next_tx_num, from_block - 1)?,
+            Ordering::Greater => {
+                static_file_producer
+                    .prune_transactions(next_static_file_tx_num - next_tx_num, from_block - 1);
+                // Since this is a database <-> static file inconsistency, we commit the change
+                // straight away.
+                static_file_producer.commit()?;
+            }
             // If static files are behind, then there was some corruption or loss of files. This
             // error will trigger an unwind, that will bring the database to the same height as the
             // static files.
@@ -321,7 +326,7 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
 
         // Unwinds static file
         static_file_producer
-            .prune_transactions(static_file_tx_num.saturating_sub(db_tx_num), input.unwind_to)?;
+            .prune_transactions(static_file_tx_num.saturating_sub(db_tx_num), input.unwind_to);
 
         Ok(UnwindOutput {
             checkpoint: StageCheckpoint::new(input.unwind_to)
@@ -575,7 +580,8 @@ mod tests {
         {
             let mut static_file_producer =
                 static_file_provider.latest_writer(StaticFileSegment::Transactions).unwrap();
-            static_file_producer.prune_transactions(1, checkpoint.block_number).unwrap();
+            static_file_producer.prune_transactions(1, checkpoint.block_number);
+            static_file_producer.commit().unwrap();
         }
         // Unwind all of it
         let unwind_to = 1;

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -568,7 +568,7 @@ where
         Ordering::Greater => static_file_producer.prune_receipts(
             next_static_file_receipt_num - next_receipt_num,
             start_block.saturating_sub(1),
-        ),
+        )?,
         Ordering::Less => {
             let mut last_block = static_file_provider
                 .get_highest_static_file_block(StaticFileSegment::Receipts)

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -352,7 +352,7 @@ where
 
         // Now unwind the static files until the unwind_to block number
         let mut writer = static_file_provider.latest_writer(StaticFileSegment::Headers)?;
-        writer.prune_headers(static_file_headers_to_unwind)?;
+        writer.prune_headers(static_file_headers_to_unwind);
 
         // Set the stage checkpoin entities processed based on how much we unwound - we add the
         // headers unwound from static files and db

--- a/crates/stages/src/stages/headers.rs
+++ b/crates/stages/src/stages/headers.rs
@@ -352,7 +352,7 @@ where
 
         // Now unwind the static files until the unwind_to block number
         let mut writer = static_file_provider.latest_writer(StaticFileSegment::Headers)?;
-        writer.prune_headers(static_file_headers_to_unwind);
+        writer.prune_headers(static_file_headers_to_unwind)?;
 
         // Set the stage checkpoin entities processed based on how much we unwound - we add the
         // headers unwound from static files and db

--- a/crates/stages/src/stages/merkle.rs
+++ b/crates/stages/src/stages/merkle.rs
@@ -581,7 +581,7 @@ mod tests {
             last_header.state_root = root;
 
             let hash = last_header.hash_slow();
-            writer.prune_headers(1);
+            writer.prune_headers(1).unwrap();
             writer.commit().unwrap();
             writer.append_header(last_header, U256::ZERO, hash).unwrap();
             writer.commit().unwrap();

--- a/crates/stages/src/stages/merkle.rs
+++ b/crates/stages/src/stages/merkle.rs
@@ -581,7 +581,8 @@ mod tests {
             last_header.state_root = root;
 
             let hash = last_header.hash_slow();
-            writer.prune_headers(1).unwrap();
+            writer.prune_headers(1);
+            writer.commit().unwrap();
             writer.append_header(last_header, U256::ZERO, hash).unwrap();
             writer.commit().unwrap();
 

--- a/crates/static-file/src/static_file_producer.rs
+++ b/crates/static-file/src/static_file_producer.rs
@@ -276,7 +276,7 @@ mod tests {
         let mut static_file_writer = static_file_provider
             .latest_writer(StaticFileSegment::Headers)
             .expect("get static file writer for headers");
-        static_file_writer.prune_headers(blocks.len() as u64);
+        static_file_writer.prune_headers(blocks.len() as u64).unwrap();
         static_file_writer.commit().expect("prune headers");
 
         let tx = db.factory.db_ref().tx_mut().expect("init tx");

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1113,6 +1113,8 @@ impl<TX: DbTx> HeaderSyncGapProvider for DatabaseProvider<TX> {
                 let mut static_file_producer =
                     static_file_provider.latest_writer(StaticFileSegment::Headers)?;
                 static_file_producer.prune_headers(next_static_file_block_num - next_block);
+                // Since this is a database <-> static file inconsistency, we commit the change
+                // straight away.
                 static_file_producer.commit()?
             }
             Ordering::Less => {

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1112,7 +1112,7 @@ impl<TX: DbTx> HeaderSyncGapProvider for DatabaseProvider<TX> {
             Ordering::Greater => {
                 let mut static_file_producer =
                     static_file_provider.latest_writer(StaticFileSegment::Headers)?;
-                static_file_producer.prune_headers(next_static_file_block_num - next_block);
+                static_file_producer.prune_headers(next_static_file_block_num - next_block)?;
                 // Since this is a database <-> static file inconsistency, we commit the change
                 // straight away.
                 static_file_producer.commit()?

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1112,7 +1112,8 @@ impl<TX: DbTx> HeaderSyncGapProvider for DatabaseProvider<TX> {
             Ordering::Greater => {
                 let mut static_file_producer =
                     static_file_provider.latest_writer(StaticFileSegment::Headers)?;
-                static_file_producer.prune_headers(next_static_file_block_num - next_block)?
+                static_file_producer.prune_headers(next_static_file_block_num - next_block);
+                static_file_producer.commit()?
             }
             Ordering::Less => {
                 // There's either missing or corrupted files.

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -473,7 +473,7 @@ impl StaticFileProviderRW {
     }
 
     /// Adds an instruction to prune transactions during commit.
-    /// 
+    ///
     /// Note: last_block refers to the block the unwinds ends at.
     pub fn prune_transactions(
         &mut self,
@@ -485,7 +485,7 @@ impl StaticFileProviderRW {
     }
 
     /// Adds an instruction to prune receipts during commit.
-    /// 
+    ///
     /// Note: last_block refers to the block the unwinds ends at.
     pub fn prune_receipts(
         &mut self,
@@ -497,7 +497,7 @@ impl StaticFileProviderRW {
     }
 
     /// Adds an instruction to prune headers during commit.
-    /// 
+    ///
     /// Note: last_block refers to the block the unwinds ends at.
     pub fn prune_headers(&mut self, to_delete: u64) -> ProviderResult<()> {
         debug_assert_eq!(self.writer.user_header().segment(), StaticFileSegment::Headers);

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -38,7 +38,8 @@ pub struct StaticFileProviderRW {
     buf: Vec<u8>,
     /// Metrics.
     metrics: Option<Arc<StaticFileProviderMetrics>>,
-    /// On commit, does the instructed pruning: <NumberOfRows, Option<LastBlockNumber>>
+    /// On commit, does the instructed pruning: number of lines, and if it applies, the last block
+    /// it ends at.
     prune_on_commit: Option<(u64, Option<BlockNumber>)>,
 }
 


### PR DESCRIPTION
On `main`, we are truncating/unwinding the data file as soon as possible, and the `static_file_writer.commit()` function only updates the offset and configuration file.

There are some drawbacks with no real advantage:
1) A failure inbetween the data file truncation and the static file commit requires healing.
2) No way to simulate (eg. pipeline unwind) without committing.

--

**This PR queues/logs the instructed pruning, and executes it only when static provider commit is called.**

### Important to ack
* If in between a static file commit and a db commit an error or shutdown occurs, healing between both storages will still be required. 
* **This does not allow a Transaction view similar to `mdbx`. Querying before comitting will still provide the data.**

--

Apart from the already existing tests, tested it with:
* `reth stage unwind num-blocks 1` -> `reth node --debug.tip ...` ✅ 
* Added an `assert(false)` before exiting `ExecutionStage::unwind`, and no receipt data was actually pruned on the forced shutdown. Able to proceed normally after ✅
* `reth stage unwind num-blocks 1` -> `reth node --debug.tip ...` ✅  combinations with random stops with no state inconsistencies
