### PR TITLE
ci: remove check-cfg job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -127,7 +127,7 @@ jobs:
     name: lint success
     runs-on: ubuntu-latest
     if: always()
-    needs: [clippy-binaries, clippy, crate-checks, docs, fmt, codespell, grafana, check-cfg]
+    needs: [clippy-binaries, clippy, crate-checks, docs, fmt, codespell, grafana]
     timeout-minutes: 30
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,8 +27,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - run:
-          cargo clippy --bin "${{ matrix.binary }}" --workspace --features "${{ matrix.network }} asm-keccak jemalloc jemalloc-prof min-error-logs min-warn-logs min-info-logs min-debug-logs min-trace-logs"
+      - run: cargo clippy --bin "${{ matrix.binary }}" --workspace --features "${{ matrix.network }} asm-keccak jemalloc jemalloc-prof min-error-logs min-warn-logs min-info-logs min-debug-logs min-trace-logs"
         env:
           RUSTFLAGS: -D warnings
 
@@ -95,9 +94,7 @@ jobs:
         env:
           # Keep in sync with ./book.yml:jobs.build
           # This should only add `-D warnings`
-          RUSTDOCFLAGS:
-            --cfg docsrs --show-type-layout --generate-link-to-definition --enable-index-page
-            -Zunstable-options -D warnings
+          RUSTDOCFLAGS: --cfg docsrs --show-type-layout --generate-link-to-definition --enable-index-page -Zunstable-options -D warnings
 
   fmt:
     name: fmt
@@ -125,18 +122,6 @@ jobs:
         uses: sergeysova/jq-action@v2
         with:
           cmd: jq empty etc/grafana/dashboards/overview.json
-
-  check-cfg:
-    name: check-cfg
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-      - run: cargo +nightly -Zcheck-cfg c
 
   lint-success:
     name: lint success

--- a/crates/net/eth-wire/tests/fuzz_roundtrip.rs
+++ b/crates/net/eth-wire/tests/fuzz_roundtrip.rs
@@ -48,7 +48,7 @@ macro_rules! fuzz_type_and_name {
     };
 }
 
-#[cfg(any(test, feature = "bench"))]
+#[cfg(test)]
 pub mod fuzz_rlp {
     use crate::roundtrip_encoding;
     use alloy_rlp::{RlpDecodableWrapper, RlpEncodableWrapper};

--- a/crates/net/network/tests/it/main.rs
+++ b/crates/net/network/tests/it/main.rs
@@ -4,7 +4,6 @@ mod multiplex;
 mod requests;
 mod session;
 mod startup;
-#[cfg(not(feature = "optimism"))]
 mod txgossip;
 
 fn main() {}


### PR DESCRIPTION
It now triggers in the clippy job: <https://github.com/paradigmxyz/reth/actions/runs/8956523309/job/24598421659?pr=8104>

(and on by default for all cargo commands)

![image](https://github.com/paradigmxyz/reth/assets/57450786/9b884db4-0493-4290-877b-0e132ca6ba6b)
