### PR TITLE
feat: improve exex examples' validation

### DIFF
--- a/examples/exex/rollup/src/main.rs
+++ b/examples/exex/rollup/src/main.rs
@@ -243,10 +243,14 @@ fn decode_chain_into_rollup_events(
                 .zip(receipts.iter().flatten())
                 .map(move |(tx, receipt)| (block, tx, receipt))
         })
-        // Filter only transactions to the rollup contract
-        .filter(|(_, tx, _)| tx.to() == Some(ROLLUP_CONTRACT_ADDRESS))
-        // Get all logs
-        .flat_map(|(block, tx, receipt)| receipt.logs.iter().map(move |log| (block, tx, log)))
+        // Get all logs from rollup contract
+        .flat_map(|(block, tx, receipt)| {
+            receipt
+                .logs
+                .iter()
+                .filter(|log| log.address == ROLLUP_CONTRACT_ADDRESS)
+                .map(move |log| (block, tx, log))
+        })
         // Decode and filter rollup events
         .filter_map(|(block, tx, log)| {
             RollupContractEvents::decode_raw_log(log.topics(), &log.data.data, true)


### PR DESCRIPTION
The op-bridge example was processing all events and not filtering events with the same signature but unrelated address. The rollup example was not handling cases where the `to` address is not the rollup but the rollup is called in inner calls and emits events. I figure since people may copy and paste these it's best to demonstrate performing these validations

I am not too familiar with the Alloy `Filter` API but maybe it'd be possible to expose a similar, less low level API for ExEx receipts processing to make these validations pretty straightforward to get right.