### PR TITLE
chore: remote `try_` prefix from block to payload conversion methods

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1906,7 +1906,7 @@ mod tests {
     use reth_primitives::{stage::StageCheckpoint, ChainSpecBuilder, MAINNET};
     use reth_provider::{BlockWriter, ProviderFactory};
     use reth_rpc_types::engine::{ForkchoiceState, ForkchoiceUpdated, PayloadStatus};
-    use reth_rpc_types_compat::engine::payload::try_block_to_payload_v1;
+    use reth_rpc_types_compat::engine::payload::block_to_payload_v1;
     use reth_stages::{ExecOutput, PipelineError, StageError};
     use std::{collections::VecDeque, sync::Arc};
     use tokio::sync::oneshot::error::TryRecvError;
@@ -1968,7 +1968,7 @@ mod tests {
         assert_matches!(rx.try_recv(), Err(TryRecvError::Empty));
 
         // consensus engine is still idle because no FCUs were received
-        let _ = env.send_new_payload(try_block_to_payload_v1(SealedBlock::default()), None).await;
+        let _ = env.send_new_payload(block_to_payload_v1(SealedBlock::default()), None).await;
 
         assert_matches!(rx.try_recv(), Err(TryRecvError::Empty));
 
@@ -2425,7 +2425,7 @@ mod tests {
             // Send new payload
             let res = env
                 .send_new_payload(
-                    try_block_to_payload_v1(random_block(&mut rng, 0, None, None, Some(0))),
+                    block_to_payload_v1(random_block(&mut rng, 0, None, None, Some(0))),
                     None,
                 )
                 .await;
@@ -2436,7 +2436,7 @@ mod tests {
             // Send new payload
             let res = env
                 .send_new_payload(
-                    try_block_to_payload_v1(random_block(&mut rng, 1, None, None, Some(0))),
+                    block_to_payload_v1(random_block(&mut rng, 1, None, None, Some(0))),
                     None,
                 )
                 .await;
@@ -2492,7 +2492,7 @@ mod tests {
 
             // Send new payload
             let result = env
-                .send_new_payload_retry_on_syncing(try_block_to_payload_v1(block2.clone()), None)
+                .send_new_payload_retry_on_syncing(block_to_payload_v1(block2.clone()), None)
                 .await
                 .unwrap();
 
@@ -2606,7 +2606,7 @@ mod tests {
             // Send new payload
             let parent = rng.gen();
             let block = random_block(&mut rng, 2, Some(parent), None, Some(0));
-            let res = env.send_new_payload(try_block_to_payload_v1(block), None).await;
+            let res = env.send_new_payload(block_to_payload_v1(block), None).await;
             let expected_result = PayloadStatus::from_status(PayloadStatusEnum::Syncing);
             assert_matches!(res, Ok(result) => assert_eq!(result, expected_result));
 
@@ -2673,7 +2673,7 @@ mod tests {
 
             // Send new payload
             let result = env
-                .send_new_payload_retry_on_syncing(try_block_to_payload_v1(block2.clone()), None)
+                .send_new_payload_retry_on_syncing(block_to_payload_v1(block2.clone()), None)
                 .await
                 .unwrap();
 

--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -11,7 +11,7 @@ use reth_rpc_types::engine::{
     PayloadId,
 };
 use reth_rpc_types_compat::engine::payload::{
-    block_to_payload_v3, convert_block_to_payload_field_v2, try_block_to_payload_v1,
+    block_to_payload_v1, block_to_payload_v3, convert_block_to_payload_field_v2,
 };
 use revm_primitives::{BlobExcessGasAndPrice, BlockEnv, CfgEnv, CfgEnvWithHandlerCfg, SpecId};
 use std::convert::Infallible;
@@ -91,7 +91,7 @@ impl<'a> BuiltPayload for &'a EthBuiltPayload {
 // V1 engine_getPayloadV1 response
 impl From<EthBuiltPayload> for ExecutionPayloadV1 {
     fn from(value: EthBuiltPayload) -> Self {
-        try_block_to_payload_v1(value.block)
+        block_to_payload_v1(value.block)
     }
 }
 

--- a/crates/payload/optimism/src/payload.rs
+++ b/crates/payload/optimism/src/payload.rs
@@ -16,7 +16,7 @@ use reth_rpc_types::engine::{
     OptimismPayloadAttributes, PayloadId,
 };
 use reth_rpc_types_compat::engine::payload::{
-    block_to_payload_v3, convert_block_to_payload_field_v2, try_block_to_payload_v1,
+    block_to_payload_v1, block_to_payload_v3, convert_block_to_payload_field_v2,
 };
 use revm::primitives::HandlerCfg;
 use std::sync::Arc;
@@ -230,7 +230,7 @@ impl<'a> BuiltPayload for &'a OptimismBuiltPayload {
 // V1 engine_getPayloadV1 response
 impl From<OptimismBuiltPayload> for ExecutionPayloadV1 {
     fn from(value: OptimismBuiltPayload) -> Self {
-        try_block_to_payload_v1(value.block)
+        block_to_payload_v1(value.block)
     }
 }
 

--- a/crates/rpc/rpc-builder/tests/it/auth.rs
+++ b/crates/rpc/rpc-builder/tests/it/auth.rs
@@ -8,7 +8,7 @@ use reth_rpc::JwtSecret;
 use reth_rpc_api::clients::EngineApiClient;
 use reth_rpc_types::engine::{ForkchoiceState, PayloadId, TransitionConfiguration};
 use reth_rpc_types_compat::engine::payload::{
-    convert_block_to_payload_input_v2, try_block_to_payload_v1,
+    block_to_payload_v1, convert_block_to_payload_input_v2,
 };
 #[allow(unused_must_use)]
 async fn test_basic_engine_calls<C>(client: &C)
@@ -17,7 +17,7 @@ where
     C: EngineApiClient<EthEngineTypes>,
 {
     let block = Block::default().seal_slow();
-    EngineApiClient::new_payload_v1(client, try_block_to_payload_v1(block.clone())).await;
+    EngineApiClient::new_payload_v1(client, block_to_payload_v1(block.clone())).await;
     EngineApiClient::new_payload_v2(client, convert_block_to_payload_input_v2(block)).await;
     EngineApiClient::fork_choice_updated_v1(client, ForkchoiceState::default(), None).await;
     EngineApiClient::get_payload_v1(client, PayloadId::new([0, 0, 0, 0, 0, 0, 0, 0])).await;

--- a/crates/rpc/rpc-engine-api/tests/it/payload.rs
+++ b/crates/rpc/rpc-engine-api/tests/it/payload.rs
@@ -13,8 +13,8 @@ use reth_rpc_types::engine::{
     ExecutionPayload, ExecutionPayloadBodyV1, ExecutionPayloadV1, PayloadError,
 };
 use reth_rpc_types_compat::engine::payload::{
-    convert_to_payload_body_v1, try_block_to_payload, try_block_to_payload_v1,
-    try_into_sealed_block, try_payload_v1_to_block,
+    block_to_payload, block_to_payload_v1, convert_to_payload_body_v1, try_into_sealed_block,
+    try_payload_v1_to_block,
 };
 
 fn transform_block<F: FnOnce(Block) -> Block>(src: SealedBlock, f: F) -> ExecutionPayload {
@@ -23,7 +23,7 @@ fn transform_block<F: FnOnce(Block) -> Block>(src: SealedBlock, f: F) -> Executi
     // Recalculate roots
     transformed.header.transactions_root = proofs::calculate_transaction_root(&transformed.body);
     transformed.header.ommers_hash = proofs::calculate_ommers_root(&transformed.ommers);
-    try_block_to_payload(SealedBlock {
+    block_to_payload(SealedBlock {
         header: transformed.header.seal_slow(),
         body: transformed.body,
         ommers: transformed.ommers,
@@ -89,7 +89,7 @@ fn payload_validation() {
     );
 
     // Invalid encoded transactions
-    let mut payload_with_invalid_txs: ExecutionPayloadV1 = try_block_to_payload_v1(block.clone());
+    let mut payload_with_invalid_txs: ExecutionPayloadV1 = block_to_payload_v1(block.clone());
 
     payload_with_invalid_txs.transactions.iter_mut().for_each(|tx| {
         *tx = Bytes::new().into();

--- a/crates/rpc/rpc-types-compat/src/engine/mod.rs
+++ b/crates/rpc/rpc-types-compat/src/engine/mod.rs
@@ -1,3 +1,3 @@
 //! Standalone functions for engine specific rpc type conversions
 pub mod payload;
-pub use payload::{try_block_to_payload_v1, try_into_sealed_block, try_payload_v1_to_block};
+pub use payload::{block_to_payload_v1, try_into_sealed_block, try_payload_v1_to_block};

--- a/crates/rpc/rpc-types-compat/src/engine/payload.rs
+++ b/crates/rpc/rpc-types-compat/src/engine/payload.rs
@@ -84,21 +84,21 @@ pub fn try_payload_v3_to_block(payload: ExecutionPayloadV3) -> Result<Block, Pay
 }
 
 /// Converts [SealedBlock] to [ExecutionPayload]
-pub fn try_block_to_payload(value: SealedBlock) -> ExecutionPayload {
+pub fn block_to_payload(value: SealedBlock) -> ExecutionPayload {
     if value.header.parent_beacon_block_root.is_some() {
         // block with parent beacon block root: V3
         ExecutionPayload::V3(block_to_payload_v3(value))
     } else if value.withdrawals.is_some() {
         // block with withdrawals: V2
-        ExecutionPayload::V2(try_block_to_payload_v2(value))
+        ExecutionPayload::V2(block_to_payload_v2(value))
     } else {
         // otherwise V1
-        ExecutionPayload::V1(try_block_to_payload_v1(value))
+        ExecutionPayload::V1(block_to_payload_v1(value))
     }
 }
 
 /// Converts [SealedBlock] to [ExecutionPayloadV1]
-pub fn try_block_to_payload_v1(value: SealedBlock) -> ExecutionPayloadV1 {
+pub fn block_to_payload_v1(value: SealedBlock) -> ExecutionPayloadV1 {
     let transactions = value.raw_transactions();
     ExecutionPayloadV1 {
         parent_hash: value.parent_hash,
@@ -119,7 +119,7 @@ pub fn try_block_to_payload_v1(value: SealedBlock) -> ExecutionPayloadV1 {
 }
 
 /// Converts [SealedBlock] to [ExecutionPayloadV2]
-pub fn try_block_to_payload_v2(value: SealedBlock) -> ExecutionPayloadV2 {
+pub fn block_to_payload_v2(value: SealedBlock) -> ExecutionPayloadV2 {
     let transactions = value.raw_transactions();
 
     ExecutionPayloadV2 {
@@ -176,9 +176,9 @@ pub fn block_to_payload_v3(value: SealedBlock) -> ExecutionPayloadV3 {
 pub fn convert_block_to_payload_field_v2(value: SealedBlock) -> ExecutionPayloadFieldV2 {
     // if there are withdrawals, return V2
     if value.withdrawals.is_some() {
-        ExecutionPayloadFieldV2::V2(try_block_to_payload_v2(value))
+        ExecutionPayloadFieldV2::V2(block_to_payload_v2(value))
     } else {
-        ExecutionPayloadFieldV2::V1(try_block_to_payload_v1(value))
+        ExecutionPayloadFieldV2::V1(block_to_payload_v1(value))
     }
 }
 
@@ -205,7 +205,7 @@ pub fn convert_payload_input_v2_to_payload(value: ExecutionPayloadInputV2) -> Ex
 pub fn convert_block_to_payload_input_v2(value: SealedBlock) -> ExecutionPayloadInputV2 {
     ExecutionPayloadInputV2 {
         withdrawals: value.withdrawals.clone().map(Withdrawals::into_inner),
-        execution_payload: try_block_to_payload_v1(value),
+        execution_payload: block_to_payload_v1(value),
     }
 }
 


### PR DESCRIPTION
## Description

Remove `try_` prefix from payload conversion methods since they don't return a result.