### PR TITLE
fix(rpc_server): remember to set ipc config for auth server

### DIFF
--- a/crates/node-core/src/args/rpc_server.rs
+++ b/crates/node-core/src/args/rpc_server.rs
@@ -475,7 +475,9 @@ impl RethRpcConfig for RpcServerArgs {
 
         let mut builder = AuthServerConfig::builder(jwt_secret).socket_addr(address);
         if self.auth_ipc {
-            builder = builder.ipc_endpoint(self.auth_ipc_path.clone());
+            builder = builder
+                .ipc_endpoint(self.auth_ipc_path.clone())
+                .with_ipc_config(self.ipc_server_builder());
         }
         Ok(builder.build())
     }


### PR DESCRIPTION
Without setting `ipc_config`  the auth server wouldn't set `ipc_handle` to start the IPC here:
https://github.com/paradigmxyz/reth/blob/00a02f5b5c4c6d36d9d6f38fd445311a7d9da0b5/crates/rpc/rpc-builder/src/auth.rs#L201-L210