### PR TITLE
fix: ensure valid parent hash in prepare_invalid_response

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -726,11 +726,13 @@ where
 
                 // If current_header is None, then the current_hash does not have an invalid
                 // ancestor in the cache, check its presence in blockchain tree
-                if current_header.is_none() {
-                    if matches!(self.blockchain.find_block_by_hash(current_hash, BlockSource::Any), Ok(Some(_))) {
-                        return Some(current_hash)
-                    }
-                    }
+                if current_header.is_none() &&
+                    matches!(
+                        self.blockchain.find_block_by_hash(current_hash, BlockSource::Any),
+                        Ok(Some(_))
+                    )
+                {
+                    return Some(current_hash)
                 }
             }
             None

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -727,9 +727,9 @@ where
                 // If current_header is None, then the current_hash does not have an invalid
                 // ancestor in the cache, check its presence in blockchain tree
                 if current_header.is_none() {
-                    match self.blockchain.find_block_by_hash(current_hash, BlockSource::Any) {
-                        Ok(Some(_)) => return Some(current_hash),
-                        _ => return None,
+                    if matches!(self.blockchain.find_block_by_hash(current_hash, BlockSource::Any), Ok(Some(_))) {
+                        return Some(current_hash)
+                    }
                     }
                 }
             }

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -725,9 +725,12 @@ where
                 current_header = self.invalid_headers.get(&current_hash);
 
                 // If current_header is None, then the current_hash does not have an invalid
-                // ancestor in the cache
+                // ancestor in the cache, check its presence in blockchain tree
                 if current_header.is_none() {
-                    return Some(current_hash);
+                    match self.blockchain.find_block_by_hash(current_hash, BlockSource::Any) {
+                        Ok(Some(_)) => return Some(current_hash),
+                        _ => return None,
+                    }
                 }
             }
             None

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -734,10 +734,12 @@ where
             }
         }
 
+        let valid_parent_hash =
+            self.latest_valid_hash_for_invalid_payload(parent_hash, None).unwrap_or_default();
         PayloadStatus::from_status(PayloadStatusEnum::Invalid {
             validation_error: PayloadValidationError::LinksToRejectedPayload.to_string(),
         })
-        .with_latest_valid_hash(parent_hash)
+        .with_latest_valid_hash(valid_parent_hash)
     }
 
     /// Checks if the given `check` hash points to an invalid header, inserting the given `head`

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -712,6 +712,7 @@ where
         }
 
         // Check if parent exists in side chain or in canonical chain.
+        // TODO: handle find_block_by_hash errors.
         if matches!(self.blockchain.find_block_by_hash(parent_hash, BlockSource::Any), Ok(Some(_)))
         {
             Some(parent_hash)
@@ -728,6 +729,7 @@ where
                 // ancestor in the cache, check its presence in blockchain tree
                 if current_header.is_none() &&
                     matches!(
+                        // TODO: handle find_block_by_hash errors.
                         self.blockchain.find_block_by_hash(current_hash, BlockSource::Any),
                         Ok(Some(_))
                     )


### PR DESCRIPTION
The function `prepare_invalid_reponse()` does not ensure the status message contains a valid `latest_valid_hash`.

The case arises when two invalid blocks occur in a row. The invalid `header.parent_hash` is passed as a parameter to `prepare_invalid_response()` , this parent hash is unvalidated at this stage and may be invalid.

The changes in this PR use `latest_valid_hash_for_invalid_payload()` within `prepare_invalid_reposnse()` to determine the latest valid hash or set it to zero if it cannot be determined.