### PR TITLE
fix: set mainnet timestamps in op chainspecs for consensus checks

### DIFF
--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -286,7 +286,9 @@ pub static OP_MAINNET: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
             ),
             (Hardfork::Bedrock, ForkCondition::Block(105235063)),
             (Hardfork::Regolith, ForkCondition::Timestamp(0)),
+            (Hardfork::Shanghai, ForkCondition::Timestamp(1704992401)),
             (Hardfork::Canyon, ForkCondition::Timestamp(1704992401)),
+            (Hardfork::Cancun, ForkCondition::Timestamp(1710374401)),
             (Hardfork::Ecotone, ForkCondition::Timestamp(1710374401)),
         ]),
         base_fee_params: BaseFeeParamsKind::Variable(


### PR DESCRIPTION
We need these now, as they were previously set by the redundant fork timestamps field. Now this should prevent op mainnet header download failures