### PR TITLE
fix(discv5): no address cli arg

### DIFF
--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -141,10 +141,15 @@ impl<C> NetworkConfig<C> {
         self
     }
 
-    /// Sets the address for the incoming connection listener.
+    /// Sets the address for the incoming RLPx connection listener.
     pub fn set_listener_addr(mut self, listener_addr: SocketAddr) -> Self {
         self.listener_addr = listener_addr;
         self
+    }
+
+    /// Returns the address for the incoming RLPx connection listener.
+    pub fn listener_addr(&self) -> &SocketAddr {
+        &self.listener_addr
     }
 }
 

--- a/crates/node-core/src/node_config.rs
+++ b/crates/node-core/src/node_config.rs
@@ -27,7 +27,7 @@ use reth_provider::{
 use reth_tasks::TaskExecutor;
 use secp256k1::SecretKey;
 use std::{
-    net::{SocketAddr, SocketAddrV4, SocketAddrV6},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
     path::PathBuf,
     sync::Arc,
 };
@@ -482,13 +482,14 @@ impl NodeConfig {
             return config
         }
 
+        let rlpx_addr = config.listener_addr().ip();
         // work around since discv5 config builder can't be integrated into network config builder
         // due to unsatisfied trait bounds
         config.discovery_v5_with_config_builder(|builder| {
             let DiscoveryArgs {
-                discv5_addr: discv5_addr_ipv4,
+                discv5_addr,
                 discv5_addr_ipv6,
-                discv5_port: discv5_port_ipv4,
+                discv5_port,
                 discv5_port_ipv6,
                 discv5_lookup_interval,
                 discv5_bootstrap_lookup_interval,
@@ -496,7 +497,9 @@ impl NodeConfig {
                 ..
             } = self.network.discovery;
 
-            let discv5_port_ipv4 = discv5_port_ipv4 + self.instance - 1;
+            let discv5_addr_ipv4 = discv5_addr.or_else(|| ipv4(rlpx_addr));
+            let discv5_addr_ipv6 = discv5_addr_ipv6.or_else(|| ipv6(rlpx_addr));
+            let discv5_port_ipv4 = discv5_port + self.instance - 1;
             let discv5_port_ipv6 = discv5_port_ipv6 + self.instance - 1;
 
             builder
@@ -546,5 +549,21 @@ impl Default for NodeConfig {
             dev: DevArgs::default(),
             pruning: PruningArgs::default(),
         }
+    }
+}
+
+/// Returns the address if this is an [`Ipv4Addr`].
+pub fn ipv4(ip: IpAddr) -> Option<Ipv4Addr> {
+    match ip {
+        IpAddr::V4(ip) => Some(ip),
+        IpAddr::V6(_) => None,
+    }
+}
+
+/// Returns the address if this is an [`Ipv6Addr`].
+pub fn ipv6(ip: IpAddr) -> Option<Ipv6Addr> {
+    match ip {
+        IpAddr::V4(_) => None,
+        IpAddr::V6(ip) => Some(ip),
     }
 }


### PR DESCRIPTION
Bug: panics when discv5 address is not explicitly set with flags `--discovery.v5.addr` or `--discovery.v5.addr.ipv6`

Fixes missing flags to use rlpx address for discv5.

@bertmiller 