### PR TITLE
perf(net): constraint algorithm fill request with hashes

### DIFF
--- a/crates/net/network/src/transactions/constants.rs
+++ b/crates/net/network/src/transactions/constants.rs
@@ -153,19 +153,20 @@ pub mod tx_fetcher {
     /// search is budget constrained.
     ///
     /// Default is a sixth of [`DEFAULT_MAX_COUNT_PENDING_FETCH`], which defaults to 12 800 hashes
-    /// (the breadth of the search), divided by [`DEFAULT_MAX_COUNT_FALLBACK_PEERS`], which
-    /// defaults to 3 peers (the depth of the search), so the 711 lru hashes in the pending hashes
-    /// cache.
+    /// (the ideal max number of hashes pending fetch), divided by
+    /// [`DEFAULT_MAX_COUNT_FALLBACK_PEERS`], which defaults to 3 peers (the depth of the search),
+    /// so a search breadth of 711 lru hashes in the pending hashes cache.
     pub const DEFAULT_BUDGET_FIND_IDLE_FALLBACK_PEER: usize =
         DEFAULT_MAX_COUNT_PENDING_FETCH / 6 / DEFAULT_MAX_COUNT_FALLBACK_PEERS as usize;
 
     /// Default budget for finding hashes in the intersection of transactions announced by a peer
     /// and in the cache of hashes pending fetch, when said search is budget constrained.
     ///
-    /// Default is a sixth of [`DEFAULT_MAX_COUNT_PENDING_FETCH`], which defaults to 12 800 hashes
-    /// (the breadth of the search), so 2133 lru hashes in the pending hashes cache.
+    /// Default is an eight of [`DEFAULT_MAX_COUNT_PENDING_FETCH`], which defaults to 12 800 hashes
+    /// (the ideal max number of hashes pending fetch), so a search breadth of 1 600 lru hashes in
+    /// the pending hashes cache.
     pub const DEFAULT_BUDGET_FIND_INTERSECTION_ANNOUNCED_BY_PEER_AND_PENDING_FETCH: usize =
-        DEFAULT_MAX_COUNT_PENDING_FETCH / 6;
+        DEFAULT_MAX_COUNT_PENDING_FETCH / 8;
 
     /* ====== SCALARS FOR USE ON FETCH PENDING HASHES ====== */
 

--- a/crates/net/network/src/transactions/constants.rs
+++ b/crates/net/network/src/transactions/constants.rs
@@ -210,8 +210,8 @@ pub mod tx_fetcher {
     /// for the intersection of hashes announced by a peer and hashes pending fetch. The max
     /// inflight requests is configured in [`TransactionFetcherInfo`].
     ///
-    /// Default is 2 requests.
-    pub const DEFAULT_DIVISOR_MAX_COUNT_INFLIGHT_REQUESTS_ON_FIND_INTERSECTION: usize = 2;
+    /// Default is 3 requests.
+    pub const DEFAULT_DIVISOR_MAX_COUNT_INFLIGHT_REQUESTS_ON_FIND_INTERSECTION: usize = 3;
 
     // Default divisor to the max pending pool imports when calculating search breadth of the
     /// search for any idle peer to which to send a request filled with hashes pending fetch.
@@ -226,8 +226,8 @@ pub mod tx_fetcher {
     /// The max pending pool imports is configured in
     /// [`PendingPoolImportsInfo`](crate::transactions::PendingPoolImportsInfo).
     ///
-    /// Default is 3 requests.
-    pub const DEFAULT_DIVISOR_MAX_COUNT_PENDING_POOL_IMPORTS_ON_FIND_INTERSECTION: usize = 3;
+    /// Default is 4 requests.
+    pub const DEFAULT_DIVISOR_MAX_COUNT_PENDING_POOL_IMPORTS_ON_FIND_INTERSECTION: usize = 4;
 
     /* ================== ROUGH MEASURES ================== */
 


### PR DESCRIPTION
Algorithm for filling a request with hashes, from the cache of hashes pending fetch, is taking too long (see panel BUT graphs are mixed up https://github.com/paradigmxyz/reth/pull/8416)

- Decreases the search breadth budget for filling a request
- Constraints the searcher earlier, i.e. tx fetcher considered to be at capacity earlier

<img width="667" alt="Screenshot 2024-05-07 at 17 27 52" src="https://github.com/paradigmxyz/reth/assets/58548332/23cdcc73-0c74-43ed-a968-5fbfd87a2060">
