### PR TITLE
feat(pruner): timeout history pruning

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -57,7 +57,7 @@ use std::{
     sync::{mpsc, Arc},
     time::{Duration, Instant},
 };
-use tracing::{debug, error, warn};
+use tracing::{debug, error, trace, warn};
 
 /// A [`DatabaseProvider`] that holds a read-only database transaction.
 pub type DatabaseProviderRO<DB> = DatabaseProvider<<DB as Database>::TX>;


### PR DESCRIPTION
Extends pruner interruption by timeout to archive nodes. Closes https://github.com/paradigmxyz/reth/issues/7435.

- Adds pruner timeout for account and storage history pruning, from https://github.com/paradigmxyz/reth/pull/6958