### PR TITLE
feat: introduce statewriter trait

### DIFF
--- a/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
@@ -23,7 +23,7 @@ use reth_primitives::{fs, stage::StageId, BlockHashOrNumber, ChainSpec, Receipts
 use reth_provider::{
     AccountExtReader, BundleStateWithReceipts, HashingWriter, HeaderProvider,
     LatestStateProviderRef, OriginalValuesKnown, ProviderFactory, StageCheckpointReader,
-    StaticFileProviderFactory, StorageReader,
+    StateWriter, StaticFileProviderFactory, StorageReader,
 };
 use reth_revm::database::StateProviderDatabase;
 use reth_tasks::TaskExecutor;

--- a/bin/reth/src/commands/debug_cmd/merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/merkle.rs
@@ -24,7 +24,7 @@ use reth_network_api::NetworkInfo;
 use reth_primitives::{fs, stage::StageCheckpoint, BlockHashOrNumber, ChainSpec, PruneModes};
 use reth_provider::{
     BlockNumReader, BlockWriter, BundleStateWithReceipts, HeaderProvider, LatestStateProviderRef,
-    OriginalValuesKnown, ProviderError, ProviderFactory,
+    OriginalValuesKnown, ProviderError, ProviderFactory, StateWriter,
 };
 use reth_revm::database::StateProviderDatabase;
 use reth_stages::{

--- a/bin/reth/src/commands/import_receipts.rs
+++ b/bin/reth/src/commands/import_receipts.rs
@@ -17,7 +17,7 @@ use reth_node_core::version::SHORT_VERSION;
 use reth_primitives::{stage::StageId, ChainSpec, StaticFileSegment};
 use reth_provider::{
     BundleStateWithReceipts, OriginalValuesKnown, ProviderFactory, StageCheckpointReader,
-    StaticFileProviderFactory, StaticFileWriter,
+    StateWriter, StaticFileProviderFactory, StaticFileWriter,
 };
 use tracing::{debug, error, info};
 

--- a/crates/node-core/src/init.rs
+++ b/crates/node-core/src/init.rs
@@ -15,7 +15,7 @@ use reth_provider::{
     providers::{StaticFileProvider, StaticFileWriter},
     BlockHashReader, BlockNumReader, BundleStateWithReceipts, ChainSpecProvider,
     DatabaseProviderRW, HashingWriter, HistoryWriter, OriginalValuesKnown, ProviderError,
-    ProviderFactory, StageCheckpointWriter, StaticFileProviderFactory,
+    ProviderFactory, StageCheckpointWriter, StateWriter, StaticFileProviderFactory,
 };
 use reth_trie::{IntermediateStateRootState, StateRoot as StateRootComputer, StateRootProgress};
 use serde::{Deserialize, Serialize};

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -14,7 +14,8 @@ use reth_primitives::{
 use reth_provider::{
     providers::{StaticFileProvider, StaticFileProviderRWRefMut, StaticFileWriter},
     BlockReader, BundleStateWithReceipts, Chain, DatabaseProviderRW, HeaderProvider,
-    LatestStateProviderRef, OriginalValuesKnown, ProviderError, StatsReader, TransactionVariant,
+    LatestStateProviderRef, OriginalValuesKnown, ProviderError, StateWriter, StatsReader,
+    TransactionVariant,
 };
 use reth_revm::database::StateProviderDatabase;
 use reth_stages_api::{

--- a/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
+++ b/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
@@ -1,4 +1,4 @@
-use crate::{providers::StaticFileProviderRWRefMut, StateChanges, StateReverts};
+use crate::{providers::StaticFileProviderRWRefMut, StateChanges, StateReverts, StateWriter};
 use reth_db::{
     cursor::{DbCursorRO, DbCursorRW},
     tables,
@@ -309,14 +309,10 @@ impl BundleStateWithReceipts {
         // swap bundles
         std::mem::swap(&mut self.bundle, &mut other)
     }
+}
 
-    /// Write the [BundleStateWithReceipts] to database and receipts to either database or static
-    /// files if `static_file_producer` is `Some`. It should be none if there is any kind of
-    /// pruning/filtering over the receipts.
-    ///
-    /// `omit_changed_check` should be set to true if bundle has some of its data detached. This
-    /// would make some original values not known.
-    pub fn write_to_storage<TX>(
+impl StateWriter for BundleStateWithReceipts {
+    fn write_to_storage<TX>(
         self,
         tx: &TX,
         mut static_file_producer: Option<StaticFileProviderRWRefMut<'_>>,

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -9,8 +9,8 @@ use crate::{
     Chain, EvmEnvProvider, HashingWriter, HeaderProvider, HeaderSyncGap, HeaderSyncGapProvider,
     HeaderSyncMode, HistoricalStateProvider, HistoryWriter, LatestStateProvider,
     OriginalValuesKnown, ProviderError, PruneCheckpointReader, PruneCheckpointWriter,
-    StageCheckpointReader, StateProviderBox, StatsReader, StorageReader, TransactionVariant,
-    TransactionsProvider, TransactionsProviderExt, WithdrawalsProvider,
+    StageCheckpointReader, StateProviderBox, StateWriter, StatsReader, StorageReader,
+    TransactionVariant, TransactionsProvider, TransactionsProviderExt, WithdrawalsProvider,
 };
 use itertools::{izip, Itertools};
 use reth_db::{

--- a/crates/storage/provider/src/traits/mod.rs
+++ b/crates/storage/provider/src/traits/mod.rs
@@ -36,7 +36,7 @@ pub use receipts::{ReceiptProvider, ReceiptProviderIdExt};
 mod state;
 pub use state::{
     BlockchainTreePendingStateProvider, BundleStateDataProvider, StateProvider, StateProviderBox,
-    StateProviderFactory,
+    StateProviderFactory, StateWriter,
 };
 
 mod trie;

--- a/crates/storage/provider/src/traits/state.rs
+++ b/crates/storage/provider/src/traits/state.rs
@@ -232,10 +232,10 @@ pub trait BundleStateDataProvider: Send + Sync {
     fn canonical_fork(&self) -> BlockNumHash;
 }
 
-/// A helper trait for [BundleStateWithReceipts] write state data to storage.
+/// A helper trait for [BundleStateWithReceipts] to write state and receipts to storage.
 pub trait StateWriter {
-    /// Write the data to the database or static files if `static_file_producer` is `Some`. It
-    /// should be `None` if there is any kind of pruning/filtering over the receipts.
+    /// Write the data and receipts to the database or static files if `static_file_producer` is
+    /// `Some`. It should be `None` if there is any kind of pruning/filtering over the receipts.
     fn write_to_storage<TX>(
         self,
         tx: &TX,

--- a/crates/storage/provider/src/traits/state.rs
+++ b/crates/storage/provider/src/traits/state.rs
@@ -1,11 +1,16 @@
 use super::AccountReader;
-use crate::{BlockHashReader, BlockIdReader, BundleStateWithReceipts, StateRootProvider};
+use crate::{
+    providers::StaticFileProviderRWRefMut, BlockHashReader, BlockIdReader, BundleStateWithReceipts,
+    StateRootProvider,
+};
 use auto_impl::auto_impl;
+use reth_db::transaction::{DbTx, DbTxMut};
 use reth_interfaces::provider::{ProviderError, ProviderResult};
 use reth_primitives::{
     trie::AccountProof, Address, BlockHash, BlockId, BlockNumHash, BlockNumber, BlockNumberOrTag,
     Bytecode, StorageKey, StorageValue, B256, KECCAK_EMPTY, U256,
 };
+use revm::db::OriginalValuesKnown;
 
 /// Type alias of boxed [StateProvider].
 pub type StateProviderBox = Box<dyn StateProvider>;
@@ -225,4 +230,18 @@ pub trait BundleStateDataProvider: Send + Sync {
     ///
     /// Needed to create state provider.
     fn canonical_fork(&self) -> BlockNumHash;
+}
+
+/// A helper trait for [BundleStateWithReceipts] write state data to storage.
+pub trait StateWriter {
+    /// Write the data to the database or static files if `static_file_producer` is `Some`. It
+    /// should be `None` if there is any kind of pruning/filtering over the receipts.
+    fn write_to_storage<TX>(
+        self,
+        tx: &TX,
+        static_file_producer: Option<StaticFileProviderRWRefMut<'_>>,
+        is_value_known: OriginalValuesKnown,
+    ) -> ProviderResult<()>
+    where
+        TX: DbTxMut + DbTx;
 }


### PR DESCRIPTION
closes #8159

this is first step towards extracting `BundleStateWithreceipts`

trait could be improved, for example with an intermediary type that holds all inputs