### PR TITLE
chore: use `NoopBodiesDownloader` & `NoopHeaderDownloader` on `stage unwind` command

### DIFF
--- a/bin/reth/src/commands/stage/unwind.rs
+++ b/bin/reth/src/commands/stage/unwind.rs
@@ -7,7 +7,7 @@ use reth_consensus::Consensus;
 use reth_db::{database::Database, open_db};
 use reth_downloaders::{bodies::noop::NoopBodiesDownloader, headers::noop::NoopHeaderDownloader};
 use reth_exex::ExExManagerHandle;
-use reth_node_core::{args::NetworkArgs, dirs::ChainPath};
+use reth_node_core::args::NetworkArgs;
 use reth_primitives::{BlockHashOrNumber, ChainSpec, PruneModes, B256};
 use reth_provider::{
     BlockExecutionWriter, BlockNumReader, ChainSpecProvider, HeaderSyncMode, ProviderFactory,

--- a/bin/reth/src/commands/stage/unwind.rs
+++ b/bin/reth/src/commands/stage/unwind.rs
@@ -153,8 +153,8 @@ impl Command {
                     provider_factory.clone(),
                     header_mode,
                     Arc::clone(&consensus),
-                    NoopHeaderDownloader,
-                    NoopBodiesDownloader,
+                    NoopHeaderDownloader::default(),
+                    NoopBodiesDownloader::default(),
                     executor.clone(),
                     stage_conf.etl.clone(),
                 )

--- a/crates/net/downloaders/src/bodies/mod.rs
+++ b/crates/net/downloaders/src/bodies/mod.rs
@@ -2,6 +2,9 @@
 #[allow(clippy::module_inception)]
 pub mod bodies;
 
+/// A dummy body downloader. Can be useful to build unwind-only pipelines
+pub mod noop;
+
 /// A downloader implementation that spawns a downloader to a task
 pub mod task;
 

--- a/crates/net/downloaders/src/bodies/mod.rs
+++ b/crates/net/downloaders/src/bodies/mod.rs
@@ -2,7 +2,7 @@
 #[allow(clippy::module_inception)]
 pub mod bodies;
 
-/// A dummy body downloader. Can be useful to build unwind-only pipelines
+/// A body downloader that does nothing. Useful to build unwind-only pipelines.
 pub mod noop;
 
 /// A downloader implementation that spawns a downloader to a task

--- a/crates/net/downloaders/src/bodies/noop.rs
+++ b/crates/net/downloaders/src/bodies/noop.rs
@@ -4,7 +4,7 @@ use reth_interfaces::p2p::{
     error::{DownloadError, DownloadResult},
 };
 use reth_primitives::BlockNumber;
-use std::{ops::RangeInclusive, task::Poll};
+use std::ops::RangeInclusive;
 
 /// A [BodyDownloader] implementation that does nothing.
 #[derive(Debug, Default)]

--- a/crates/net/downloaders/src/bodies/noop.rs
+++ b/crates/net/downloaders/src/bodies/noop.rs
@@ -24,6 +24,6 @@ impl Stream for NoopBodiesDownloader {
         self: std::pin::Pin<&mut Self>,
         _: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
-        Poll::Pending
+        panic!("NoopBodiesDownloader shouldn't be polled.")
     }
 }

--- a/crates/net/downloaders/src/bodies/noop.rs
+++ b/crates/net/downloaders/src/bodies/noop.rs
@@ -11,7 +11,7 @@ use std::{ops::RangeInclusive, task::Poll};
 pub struct NoopBodiesDownloader;
 
 impl BodyDownloader for NoopBodiesDownloader {
-    fn set_download_range(&mut self, range: RangeInclusive<BlockNumber>) -> DownloadResult<()> {
+    fn set_download_range(&mut self, _: RangeInclusive<BlockNumber>) -> DownloadResult<()> {
         Ok(())
     }
 }
@@ -21,7 +21,7 @@ impl Stream for NoopBodiesDownloader {
 
     fn poll_next(
         self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
+        _: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
         Poll::Ready(None)
     }

--- a/crates/net/downloaders/src/bodies/noop.rs
+++ b/crates/net/downloaders/src/bodies/noop.rs
@@ -1,0 +1,28 @@
+use futures::Stream;
+use reth_interfaces::p2p::{
+    bodies::{downloader::BodyDownloader, response::BlockResponse},
+    error::{DownloadError, DownloadResult},
+};
+use reth_primitives::BlockNumber;
+use std::{ops::RangeInclusive, task::Poll};
+
+/// A [BodyDownloader] implementation that does nothing.
+#[derive(Debug, Default)]
+pub struct NoopBodiesDownloader;
+
+impl BodyDownloader for NoopBodiesDownloader {
+    fn set_download_range(&mut self, range: RangeInclusive<BlockNumber>) -> DownloadResult<()> {
+        Ok(())
+    }
+}
+
+impl Stream for NoopBodiesDownloader {
+    type Item = Result<Vec<BlockResponse>, DownloadError>;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        Poll::Ready(None)
+    }
+}

--- a/crates/net/downloaders/src/bodies/noop.rs
+++ b/crates/net/downloaders/src/bodies/noop.rs
@@ -8,6 +8,7 @@ use std::{ops::RangeInclusive, task::Poll};
 
 /// A [BodyDownloader] implementation that does nothing.
 #[derive(Debug, Default)]
+#[non_exhaustive]
 pub struct NoopBodiesDownloader;
 
 impl BodyDownloader for NoopBodiesDownloader {
@@ -23,6 +24,6 @@ impl Stream for NoopBodiesDownloader {
         self: std::pin::Pin<&mut Self>,
         _: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
-        Poll::Ready(None)
+        Poll::Pending
     }
 }

--- a/crates/net/downloaders/src/headers/mod.rs
+++ b/crates/net/downloaders/src/headers/mod.rs
@@ -1,7 +1,7 @@
 /// A Linear downloader implementation.
 pub mod reverse_headers;
 
-/// A dummy header downloader. Can be useful to build unwind-only pipelines
+/// A body header that does nothing. Useful to build unwind-only pipelines.
 pub mod noop;
 
 /// A downloader implementation that spawns a downloader to a task

--- a/crates/net/downloaders/src/headers/mod.rs
+++ b/crates/net/downloaders/src/headers/mod.rs
@@ -1,6 +1,9 @@
 /// A Linear downloader implementation.
 pub mod reverse_headers;
 
+/// A dummy header downloader. Can be useful to build unwind-only pipelines
+pub mod noop;
+
 /// A downloader implementation that spawns a downloader to a task
 pub mod task;
 

--- a/crates/net/downloaders/src/headers/mod.rs
+++ b/crates/net/downloaders/src/headers/mod.rs
@@ -1,7 +1,7 @@
 /// A Linear downloader implementation.
 pub mod reverse_headers;
 
-/// A body header that does nothing. Useful to build unwind-only pipelines.
+/// A header downloader that does nothing. Useful to build unwind-only pipelines.
 pub mod noop;
 
 /// A downloader implementation that spawns a downloader to a task

--- a/crates/net/downloaders/src/headers/noop.rs
+++ b/crates/net/downloaders/src/headers/noop.rs
@@ -4,7 +4,6 @@ use reth_interfaces::p2p::headers::{
     error::HeadersDownloaderError,
 };
 use reth_primitives::SealedHeader;
-use std::task::Poll;
 
 /// A [HeaderDownloader] implementation that does nothing.
 #[derive(Debug, Default)]

--- a/crates/net/downloaders/src/headers/noop.rs
+++ b/crates/net/downloaders/src/headers/noop.rs
@@ -1,0 +1,30 @@
+use futures::Stream;
+use reth_interfaces::p2p::headers::{
+    downloader::{HeaderDownloader, SyncTarget},
+    error::HeadersDownloaderError,
+};
+use reth_primitives::SealedHeader;
+use std::task::Poll;
+
+/// A [HeaderDownloader] implementation that does nothing.
+#[derive(Debug, Default)]
+pub struct NoopHeaderDownloader;
+
+impl HeaderDownloader for NoopHeaderDownloader {
+    fn update_local_head(&mut self, _: SealedHeader) {}
+
+    fn update_sync_target(&mut self, _: SyncTarget) {}
+
+    fn set_batch_size(&mut self, _: usize) {}
+}
+
+impl Stream for NoopHeaderDownloader {
+    type Item = Result<Vec<SealedHeader>, HeadersDownloaderError>;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        Poll::Ready(None)
+    }
+}

--- a/crates/net/downloaders/src/headers/noop.rs
+++ b/crates/net/downloaders/src/headers/noop.rs
@@ -23,7 +23,7 @@ impl Stream for NoopHeaderDownloader {
 
     fn poll_next(
         self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
+        _: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
         Poll::Ready(None)
     }

--- a/crates/net/downloaders/src/headers/noop.rs
+++ b/crates/net/downloaders/src/headers/noop.rs
@@ -26,6 +26,6 @@ impl Stream for NoopHeaderDownloader {
         self: std::pin::Pin<&mut Self>,
         _: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
-        Poll::Pending
+        panic!("NoopHeaderDownloader shouldn't be polled.")
     }
 }

--- a/crates/net/downloaders/src/headers/noop.rs
+++ b/crates/net/downloaders/src/headers/noop.rs
@@ -8,6 +8,7 @@ use std::task::Poll;
 
 /// A [HeaderDownloader] implementation that does nothing.
 #[derive(Debug, Default)]
+#[non_exhaustive]
 pub struct NoopHeaderDownloader;
 
 impl HeaderDownloader for NoopHeaderDownloader {
@@ -25,6 +26,6 @@ impl Stream for NoopHeaderDownloader {
         self: std::pin::Pin<&mut Self>,
         _: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
-        Poll::Ready(None)
+        Poll::Pending
     }
 }


### PR DESCRIPTION
Adds noop downloaders and uses them on `reth stage unwind`.

Stepping stone for a standalone unwind pipeline for [#8143](https://github.com/paradigmxyz/reth/pull/8143)

tested and unwinded with no issues