### PR TITLE
fix: use op-build instead of build-op in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
     needs: extract-version
     strategy:
       matrix:
-        build: [{command: build, binary: reth}, {command: build-op, binary: op-reth}]
+        build: [{command: build, binary: reth}, {command: op-build, binary: op-reth}]
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-20.04


### PR DESCRIPTION
We use `op-build-%` in the makefile, for this to work we have to use the same prefix