### PR TITLE
chore: refactor `DefaultStages` to take `StageConfig`

### DIFF
--- a/bin/reth/src/commands/debug_cmd/execution.rs
+++ b/bin/reth/src/commands/debug_cmd/execution.rs
@@ -35,7 +35,7 @@ use reth_provider::{
 };
 use reth_stages::{
     sets::DefaultStages,
-    stages::{ExecutionStage, ExecutionStageThresholds, SenderRecoveryStage},
+    stages::{ExecutionStage, ExecutionStageThresholds},
     Pipeline, StageSet,
 };
 use reth_static_file::StaticFileProducer;
@@ -109,6 +109,7 @@ impl Command {
             .into_task_with(task_executor);
 
         let stage_conf = &config.stages;
+        let prune_modes = config.prune.clone().map(|prune| prune.segments).unwrap_or_default();
 
         let (tip_tx, tip_rx) = watch::channel(B256::ZERO);
         let executor = block_executor!(self.chain.clone());
@@ -124,11 +125,9 @@ impl Command {
                     header_downloader,
                     body_downloader,
                     executor.clone(),
-                    stage_conf.etl.clone(),
+                    stage_conf.clone(),
+                    prune_modes.clone(),
                 )
-                .set(SenderRecoveryStage {
-                    commit_threshold: stage_conf.sender_recovery.commit_threshold,
-                })
                 .set(ExecutionStage::new(
                     executor,
                     ExecutionStageThresholds {
@@ -137,12 +136,8 @@ impl Command {
                         max_cumulative_gas: None,
                         max_duration: None,
                     },
-                    stage_conf
-                        .merkle
-                        .clean_threshold
-                        .max(stage_conf.account_hashing.clean_threshold)
-                        .max(stage_conf.storage_hashing.clean_threshold),
-                    config.prune.clone().map(|prune| prune.segments).unwrap_or_default(),
+                    stage_conf.execution_external_clean_threshold(),
+                    prune_modes,
                     ExExManagerHandle::empty(),
                 )),
             )

--- a/bin/reth/src/commands/stage/run.rs
+++ b/bin/reth/src/commands/stage/run.rs
@@ -252,7 +252,7 @@ impl Command {
                 }
                 StageEnum::TxLookup => (
                     Box::new(TransactionLookupStage::new(
-                        config.stages.transaction_lookup,
+                        batch_size,
                         etl_config,
                         prune_modes.transaction_lookup,
                     )),
@@ -260,20 +260,14 @@ impl Command {
                 ),
                 StageEnum::AccountHashing => (
                     Box::new(AccountHashingStage::new(
-                        HashingConfig {
-                            clean_threshold: 1,
-                            commit_threshold: config.stages.account_hashing.commit_threshold,
-                        },
+                        HashingConfig { clean_threshold: 1, commit_threshold: batch_size },
                         etl_config,
                     )),
                     None,
                 ),
                 StageEnum::StorageHashing => (
                     Box::new(StorageHashingStage::new(
-                        HashingConfig {
-                            clean_threshold: 1,
-                            commit_threshold: config.stages.storage_hashing.commit_threshold,
-                        },
+                        HashingConfig { clean_threshold: 1, commit_threshold: batch_size },
                         etl_config,
                     )),
                     None,

--- a/bin/reth/src/commands/stage/run.rs
+++ b/bin/reth/src/commands/stage/run.rs
@@ -17,7 +17,7 @@ use clap::Parser;
 use reth_beacon_consensus::EthBeaconConsensus;
 use reth_cli_runner::CliContext;
 use reth_config::{
-    config::{EtlConfig, HashingConfig, SenderRecoveryConfig},
+    config::{EtlConfig, HashingConfig, SenderRecoveryConfig, TransactionLookupConfig},
     Config,
 };
 use reth_db::init_db;
@@ -252,7 +252,7 @@ impl Command {
                 }
                 StageEnum::TxLookup => (
                     Box::new(TransactionLookupStage::new(
-                        batch_size,
+                        TransactionLookupConfig { chunk_size: batch_size },
                         etl_config,
                         prune_modes.transaction_lookup,
                     )),

--- a/bin/reth/src/commands/stage/unwind.rs
+++ b/bin/reth/src/commands/stage/unwind.rs
@@ -194,11 +194,8 @@ impl Command {
                     body_downloader,
                     executor.clone(),
                     stage_conf.clone(),
-                    prune_modes,
+                    prune_modes.clone(),
                 )
-                .set(SenderRecoveryStage {
-                    commit_threshold: stage_conf.sender_recovery.commit_threshold,
-                })
                 .set(ExecutionStage::new(
                     executor,
                     ExecutionStageThresholds {
@@ -207,20 +204,10 @@ impl Command {
                         max_cumulative_gas: None,
                         max_duration: None,
                     },
-                    stage_conf
-                        .merkle
-                        .clean_threshold
-                        .max(stage_conf.account_hashing.clean_threshold)
-                        .max(stage_conf.storage_hashing.clean_threshold),
-                    config.prune.clone().map(|prune| prune.segments).unwrap_or_default(),
+                    stage_conf.execution_external_clean_threshold(),
+                    prune_modes,
                     ExExManagerHandle::empty(),
-                ))
-                .set(AccountHashingStage::default())
-                .set(StorageHashingStage::default())
-                .set(MerkleStage::default_unwind())
-                .set(TransactionLookupStage::default())
-                .set(IndexAccountHistoryStage::default())
-                .set(IndexStorageHistoryStage::default()),
+                )),
             )
             .build(
                 provider_factory.clone(),

--- a/bin/reth/src/commands/stage/unwind.rs
+++ b/bin/reth/src/commands/stage/unwind.rs
@@ -22,11 +22,7 @@ use reth_provider::{
 use reth_prune::PrunerBuilder;
 use reth_stages::{
     sets::DefaultStages,
-    stages::{
-        AccountHashingStage, ExecutionStage, ExecutionStageThresholds, IndexAccountHistoryStage,
-        IndexStorageHistoryStage, MerkleStage, SenderRecoveryStage, StorageHashingStage,
-        TransactionLookupStage,
-    },
+    stages::{ExecutionStage, ExecutionStageThresholds},
     Pipeline, StageSet,
 };
 use reth_static_file::StaticFileProducer;

--- a/bin/reth/src/commands/stage/unwind.rs
+++ b/bin/reth/src/commands/stage/unwind.rs
@@ -177,6 +177,7 @@ impl Command {
             provider_factory.clone(),
         );
         let stage_conf = &config.stages;
+        let prune_modes = config.prune.clone().map(|prune| prune.segments).unwrap_or_default();
 
         let (tip_tx, tip_rx) = watch::channel(B256::ZERO);
         let executor = block_executor!(provider_factory.chain_spec());
@@ -192,7 +193,8 @@ impl Command {
                     header_downloader,
                     body_downloader,
                     executor.clone(),
-                    stage_conf.etl.clone(),
+                    stage_conf.clone(),
+                    prune_modes,
                 )
                 .set(SenderRecoveryStage {
                     commit_threshold: stage_conf.sender_recovery.commit_threshold,

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -97,10 +97,10 @@ pub struct StageConfig {
 }
 
 impl StageConfig {
-    /// The highest threshold (in number of blocks) for switching between incremental
-    /// and full calculations across [`super::MerkleStage`], [`super::AccountHashingStage`] and
-    /// [`super::StorageHashingStage`]. This is required to figure out if can prune or not
-    /// changesets on subsequent pipeline runs.
+    /// The highest threshold (in number of blocks) for switching between incremental and full
+    /// calculations across `MerkleStage`, `AccountHashingStage` and `StorageHashingStage`. This is
+    /// required to figure out if can prune or not changesets on subsequent pipeline runs during
+    /// `ExecutionStage`
     pub fn execution_external_clean_threshold(&self) -> u64 {
         self.merkle
             .clean_threshold

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -96,6 +96,19 @@ pub struct StageConfig {
     pub etl: EtlConfig,
 }
 
+impl StageConfig {
+    /// The highest threshold (in number of blocks) for switching between incremental
+    /// and full calculations across [`super::MerkleStage`], [`super::AccountHashingStage`] and
+    /// [`super::StorageHashingStage`]. This is required to figure out if can prune or not
+    /// changesets on subsequent pipeline runs.
+    pub fn execution_external_clean_threshold(&self) -> u64 {
+        self.merkle
+            .clean_threshold
+            .max(self.account_hashing.clean_threshold)
+            .max(self.storage_hashing.clean_threshold)
+    }
+}
+
 /// Header stage configuration.
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default)]

--- a/crates/consensus/beacon/src/engine/test_utils.rs
+++ b/crates/consensus/beacon/src/engine/test_utils.rs
@@ -6,7 +6,7 @@ use crate::{
 use reth_blockchain_tree::{
     config::BlockchainTreeConfig, externals::TreeExternals, BlockchainTree, ShareableBlockchainTree,
 };
-use reth_config::config::EtlConfig;
+use reth_config::config::StageConfig;
 use reth_consensus::{test_utils::TestConsensus, Consensus};
 use reth_db::{test_utils::TempDatabase, DatabaseEnv as DE};
 use reth_downloaders::{
@@ -375,7 +375,8 @@ where
                     header_downloader,
                     body_downloader,
                     executor_factory.clone(),
-                    EtlConfig::default(),
+                    StageConfig::default(),
+                    PruneModes::default(),
                 ))
             }
         };

--- a/crates/stages/benches/criterion.rs
+++ b/crates/stages/benches/criterion.rs
@@ -2,7 +2,7 @@
 use criterion::{criterion_main, measurement::WallTime, BenchmarkGroup, Criterion};
 #[cfg(not(target_os = "windows"))]
 use pprof::criterion::{Output, PProfProfiler};
-use reth_config::config::EtlConfig;
+use reth_config::config::{EtlConfig, TransactionLookupConfig};
 use reth_db::{test_utils::TempDatabase, DatabaseEnv};
 
 use reth_primitives::{stage::StageCheckpoint, BlockNumber};
@@ -87,7 +87,11 @@ fn transaction_lookup(c: &mut Criterion, runtime: &Runtime) {
     let mut group = c.benchmark_group("Stages");
     // don't need to run each stage for that many times
     group.sample_size(10);
-    let stage = TransactionLookupStage::new(DEFAULT_NUM_BLOCKS, EtlConfig::default(), None);
+    let stage = TransactionLookupStage::new(
+        TransactionLookupConfig { chunk_size: DEFAULT_NUM_BLOCKS },
+        EtlConfig::default(),
+        None,
+    );
 
     let db = setup::txs_testdata(DEFAULT_NUM_BLOCKS);
 

--- a/crates/stages/src/lib.rs
+++ b/crates/stages/src/lib.rs
@@ -28,7 +28,7 @@
 //! # use reth_provider::HeaderSyncMode;
 //! # use reth_provider::test_utils::create_test_provider_factory;
 //! # use reth_static_file::StaticFileProducer;
-//! # use reth_config::config::EtlConfig;
+//! # use reth_config::config::StageConfig;
 //! # use reth_consensus::Consensus;
 //! # use reth_consensus::test_utils::TestConsensus;
 //! #
@@ -62,7 +62,8 @@
 //!         headers_downloader,
 //!         bodies_downloader,
 //!         executor_provider,
-//!         EtlConfig::default(),
+//!         StageConfig::default(),
+//!         PruneModes::default(),
 //!     ))
 //!     .build(provider_factory, static_file_producer);
 //! ```

--- a/crates/stages/src/sets.rs
+++ b/crates/stages/src/sets.rs
@@ -17,7 +17,7 @@
 //! # use reth_provider::StaticFileProviderFactory;
 //! # use reth_provider::test_utils::create_test_provider_factory;
 //! # use reth_static_file::StaticFileProducer;
-//! # use reth_config::config::EtlConfig;
+//! # use reth_config::config::StageConfig;
 //! # use reth_evm::execute::BlockExecutorProvider;
 //!
 //! # fn create(exec: impl BlockExecutorProvider) {
@@ -30,7 +30,7 @@
 //! );
 //! // Build a pipeline with all offline stages.
 //! let pipeline = Pipeline::builder()
-//!     .add_stages(OfflineStages::new(exec, EtlConfig::default()))
+//!     .add_stages(OfflineStages::new(exec, StageConfig::default(), PruneModes::default()))
 //!     .build(provider_factory, static_file_producer);
 //!
 //! # }

--- a/crates/stages/src/sets.rs
+++ b/crates/stages/src/sets.rs
@@ -315,7 +315,7 @@ where
 {
     fn builder(self) -> StageSetBuilder<DB> {
         StageSetBuilder::default()
-            .add_stage(SenderRecoveryStage::from_config(self.stages_config.sender_recovery))
+            .add_stage(SenderRecoveryStage::new(self.stages_config.sender_recovery))
             .add_stage(ExecutionStage::from_config(
                 self.executor_factory,
                 self.stages_config.execution,
@@ -329,7 +329,7 @@ where
 #[derive(Debug, Default)]
 #[non_exhaustive]
 pub struct HashingStages {
-    /// ETL configuration
+    /// Configuration for each stage in the pipeline
     stages_config: StageConfig,
 }
 
@@ -337,11 +337,11 @@ impl<DB: Database> StageSet<DB> for HashingStages {
     fn builder(self) -> StageSetBuilder<DB> {
         StageSetBuilder::default()
             .add_stage(MerkleStage::default_unwind())
-            .add_stage(AccountHashingStage::from_config(
+            .add_stage(AccountHashingStage::new(
                 self.stages_config.account_hashing,
                 self.stages_config.etl.clone(),
             ))
-            .add_stage(StorageHashingStage::from_config(
+            .add_stage(StorageHashingStage::new(
                 self.stages_config.storage_hashing,
                 self.stages_config.etl.clone(),
             ))
@@ -353,25 +353,26 @@ impl<DB: Database> StageSet<DB> for HashingStages {
 #[derive(Debug, Default)]
 #[non_exhaustive]
 pub struct HistoryIndexingStages {
-    /// ETL configuration
+    /// Configuration for each stage in the pipeline
     stages_config: StageConfig,
+    /// Prune configuration for every segment that can be pruned
     prune_modes: PruneModes,
 }
 
 impl<DB: Database> StageSet<DB> for HistoryIndexingStages {
     fn builder(self) -> StageSetBuilder<DB> {
         StageSetBuilder::default()
-            .add_stage(TransactionLookupStage::from_config(
+            .add_stage(TransactionLookupStage::new(
                 self.stages_config.transaction_lookup,
                 self.stages_config.etl.clone(),
                 self.prune_modes.transaction_lookup,
             ))
-            .add_stage(IndexStorageHistoryStage::from_config(
+            .add_stage(IndexStorageHistoryStage::new(
                 self.stages_config.index_storage_history,
                 self.stages_config.etl.clone(),
                 self.prune_modes.account_history,
             ))
-            .add_stage(IndexAccountHistoryStage::from_config(
+            .add_stage(IndexAccountHistoryStage::new(
                 self.stages_config.index_account_history,
                 self.stages_config.etl.clone(),
                 self.prune_modes.storage_history,

--- a/crates/stages/src/sets.rs
+++ b/crates/stages/src/sets.rs
@@ -43,13 +43,14 @@ use crate::{
     },
     StageSet, StageSetBuilder,
 };
-use reth_config::config::EtlConfig;
+use reth_config::config::StageConfig;
 use reth_consensus::Consensus;
 use reth_db::database::Database;
 use reth_evm::execute::BlockExecutorProvider;
 use reth_interfaces::p2p::{
     bodies::downloader::BodyDownloader, headers::downloader::HeaderDownloader,
 };
+use reth_primitives::PruneModes;
 use reth_provider::{HeaderSyncGapProvider, HeaderSyncMode};
 use std::sync::Arc;
 
@@ -80,12 +81,15 @@ pub struct DefaultStages<Provider, H, B, EF> {
     online: OnlineStages<Provider, H, B>,
     /// Executor factory needs for execution stage
     executor_factory: EF,
-    /// ETL configuration
-    etl_config: EtlConfig,
+    /// Configuration for each stage in the pipeline
+    stages_config: StageConfig,
+    /// Prune configuration for every segment that can be pruned
+    prune_modes: PruneModes,
 }
 
 impl<Provider, H, B, E> DefaultStages<Provider, H, B, E> {
     /// Create a new set of default stages with default values.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         provider: Provider,
         header_mode: HeaderSyncMode,
@@ -93,7 +97,8 @@ impl<Provider, H, B, E> DefaultStages<Provider, H, B, E> {
         header_downloader: H,
         body_downloader: B,
         executor_factory: E,
-        etl_config: EtlConfig,
+        stages_config: StageConfig,
+        prune_modes: PruneModes,
     ) -> Self
     where
         E: BlockExecutorProvider,
@@ -105,10 +110,11 @@ impl<Provider, H, B, E> DefaultStages<Provider, H, B, E> {
                 consensus,
                 header_downloader,
                 body_downloader,
-                etl_config.clone(),
+                stages_config.clone(),
             ),
             executor_factory,
-            etl_config,
+            stages_config,
+            prune_modes,
         }
     }
 }
@@ -121,11 +127,12 @@ where
     pub fn add_offline_stages<DB: Database>(
         default_offline: StageSetBuilder<DB>,
         executor_factory: E,
-        etl_config: EtlConfig,
+        stages_config: StageConfig,
+        prune_modes: PruneModes,
     ) -> StageSetBuilder<DB> {
         StageSetBuilder::default()
             .add_set(default_offline)
-            .add_set(OfflineStages::new(executor_factory, etl_config))
+            .add_set(OfflineStages::new(executor_factory, stages_config, prune_modes))
             .add_stage(FinishStage)
     }
 }
@@ -139,7 +146,12 @@ where
     DB: Database + 'static,
 {
     fn builder(self) -> StageSetBuilder<DB> {
-        Self::add_offline_stages(self.online.builder(), self.executor_factory, self.etl_config)
+        Self::add_offline_stages(
+            self.online.builder(),
+            self.executor_factory,
+            self.stages_config.clone(),
+            self.prune_modes,
+        )
     }
 }
 
@@ -159,8 +171,8 @@ pub struct OnlineStages<Provider, H, B> {
     header_downloader: H,
     /// The block body downloader
     body_downloader: B,
-    /// ETL configuration
-    etl_config: EtlConfig,
+    /// Configuration for each stage in the pipeline
+    stages_config: StageConfig,
 }
 
 impl<Provider, H, B> OnlineStages<Provider, H, B> {
@@ -171,9 +183,9 @@ impl<Provider, H, B> OnlineStages<Provider, H, B> {
         consensus: Arc<dyn Consensus>,
         header_downloader: H,
         body_downloader: B,
-        etl_config: EtlConfig,
+        stages_config: StageConfig,
     ) -> Self {
-        Self { provider, header_mode, consensus, header_downloader, body_downloader, etl_config }
+        Self { provider, header_mode, consensus, header_downloader, body_downloader, stages_config }
     }
 }
 
@@ -198,7 +210,7 @@ where
         mode: HeaderSyncMode,
         header_downloader: H,
         consensus: Arc<dyn Consensus>,
-        etl_config: EtlConfig,
+        stages_config: StageConfig,
     ) -> StageSetBuilder<DB> {
         StageSetBuilder::default()
             .add_stage(HeaderStage::new(
@@ -206,7 +218,7 @@ where
                 header_downloader,
                 mode,
                 consensus.clone(),
-                etl_config,
+                stages_config.etl,
             ))
             .add_stage(bodies)
     }
@@ -226,7 +238,7 @@ where
                 self.header_downloader,
                 self.header_mode,
                 self.consensus.clone(),
-                self.etl_config.clone(),
+                self.stages_config.etl.clone(),
             ))
             .add_stage(BodyStage::new(self.body_downloader))
     }
@@ -244,14 +256,16 @@ where
 pub struct OfflineStages<EF> {
     /// Executor factory needs for execution stage
     pub executor_factory: EF,
-    /// ETL configuration
-    etl_config: EtlConfig,
+    /// Configuration for each stage in the pipeline
+    stages_config: StageConfig,
+    /// Prune configuration for every segment that can be pruned
+    prune_modes: PruneModes,
 }
 
 impl<EF> OfflineStages<EF> {
     /// Create a new set of offline stages with default values.
-    pub fn new(executor_factory: EF, etl_config: EtlConfig) -> Self {
-        Self { executor_factory, etl_config }
+    pub fn new(executor_factory: EF, stages_config: StageConfig, prune_modes: PruneModes) -> Self {
+        Self { executor_factory, stages_config, prune_modes }
     }
 }
 
@@ -261,10 +275,17 @@ where
     DB: Database,
 {
     fn builder(self) -> StageSetBuilder<DB> {
-        ExecutionStages::new(self.executor_factory)
-            .builder()
-            .add_set(HashingStages { etl_config: self.etl_config.clone() })
-            .add_set(HistoryIndexingStages { etl_config: self.etl_config })
+        ExecutionStages::new(
+            self.executor_factory,
+            self.stages_config.clone(),
+            self.prune_modes.clone(),
+        )
+        .builder()
+        .add_set(HashingStages { stages_config: self.stages_config.clone() })
+        .add_set(HistoryIndexingStages {
+            stages_config: self.stages_config.clone(),
+            prune_modes: self.prune_modes,
+        })
     }
 }
 
@@ -274,12 +295,16 @@ where
 pub struct ExecutionStages<E> {
     /// Executor factory that will create executors.
     executor_factory: E,
+    /// Configuration for each stage in the pipeline
+    stages_config: StageConfig,
+    /// Prune configuration for every segment that can be pruned
+    prune_modes: PruneModes,
 }
 
 impl<E> ExecutionStages<E> {
     /// Create a new set of execution stages with default values.
-    pub fn new(executor_factory: E) -> Self {
-        Self { executor_factory }
+    pub fn new(executor_factory: E, stages_config: StageConfig, prune_modes: PruneModes) -> Self {
+        Self { executor_factory, stages_config, prune_modes }
     }
 }
 
@@ -290,8 +315,13 @@ where
 {
     fn builder(self) -> StageSetBuilder<DB> {
         StageSetBuilder::default()
-            .add_stage(SenderRecoveryStage::default())
-            .add_stage(ExecutionStage::new_with_executor(self.executor_factory))
+            .add_stage(SenderRecoveryStage::from_config(self.stages_config.sender_recovery))
+            .add_stage(ExecutionStage::from_config(
+                self.executor_factory,
+                self.stages_config.execution,
+                self.stages_config.execution_external_clean_threshold(),
+                self.prune_modes,
+            ))
     }
 }
 
@@ -300,16 +330,22 @@ where
 #[non_exhaustive]
 pub struct HashingStages {
     /// ETL configuration
-    etl_config: EtlConfig,
+    stages_config: StageConfig,
 }
 
 impl<DB: Database> StageSet<DB> for HashingStages {
     fn builder(self) -> StageSetBuilder<DB> {
         StageSetBuilder::default()
             .add_stage(MerkleStage::default_unwind())
-            .add_stage(AccountHashingStage::default().with_etl_config(self.etl_config.clone()))
-            .add_stage(StorageHashingStage::default().with_etl_config(self.etl_config))
-            .add_stage(MerkleStage::default_execution())
+            .add_stage(AccountHashingStage::from_config(
+                self.stages_config.account_hashing,
+                self.stages_config.etl.clone(),
+            ))
+            .add_stage(StorageHashingStage::from_config(
+                self.stages_config.storage_hashing,
+                self.stages_config.etl.clone(),
+            ))
+            .add_stage(MerkleStage::new_execution(self.stages_config.merkle.clean_threshold))
     }
 }
 
@@ -318,14 +354,27 @@ impl<DB: Database> StageSet<DB> for HashingStages {
 #[non_exhaustive]
 pub struct HistoryIndexingStages {
     /// ETL configuration
-    etl_config: EtlConfig,
+    stages_config: StageConfig,
+    prune_modes: PruneModes,
 }
 
 impl<DB: Database> StageSet<DB> for HistoryIndexingStages {
     fn builder(self) -> StageSetBuilder<DB> {
         StageSetBuilder::default()
-            .add_stage(TransactionLookupStage::default().with_etl_config(self.etl_config.clone()))
-            .add_stage(IndexStorageHistoryStage::default().with_etl_config(self.etl_config.clone()))
-            .add_stage(IndexAccountHistoryStage::default().with_etl_config(self.etl_config))
+            .add_stage(TransactionLookupStage::from_config(
+                self.stages_config.transaction_lookup,
+                self.stages_config.etl.clone(),
+                self.prune_modes.transaction_lookup,
+            ))
+            .add_stage(IndexStorageHistoryStage::from_config(
+                self.stages_config.index_storage_history,
+                self.stages_config.etl.clone(),
+                self.prune_modes.account_history,
+            ))
+            .add_stage(IndexAccountHistoryStage::from_config(
+                self.stages_config.index_account_history,
+                self.stages_config.etl.clone(),
+                self.prune_modes.storage_history,
+            ))
     }
 }

--- a/crates/stages/src/stages/execution.rs
+++ b/crates/stages/src/stages/execution.rs
@@ -1,5 +1,6 @@
 use crate::stages::MERKLE_STAGE_DEFAULT_CLEAN_THRESHOLD;
 use num_traits::Zero;
+use reth_config::config::ExecutionConfig;
 use reth_db::{
     cursor::DbCursorRO, database::Database, static_file::HeaderMask, tables, transaction::DbTx,
 };
@@ -107,6 +108,22 @@ impl<E> ExecutionStage<E> {
             ExecutionStageThresholds::default(),
             MERKLE_STAGE_DEFAULT_CLEAN_THRESHOLD,
             PruneModes::none(),
+            ExExManagerHandle::empty(),
+        )
+    }
+
+    /// Create new instance of [ExecutionStage] from configuration.
+    pub fn from_config(
+        executor_provider: E,
+        config: ExecutionConfig,
+        external_clean_threshold: u64,
+        prune_modes: PruneModes,
+    ) -> Self {
+        Self::new(
+            executor_provider,
+            config.into(),
+            external_clean_threshold,
+            prune_modes,
             ExExManagerHandle::empty(),
         )
     }
@@ -537,6 +554,17 @@ impl ExecutionStageThresholds {
             changes_processed >= self.max_changes.unwrap_or(u64::MAX) ||
             cumulative_gas_used >= self.max_cumulative_gas.unwrap_or(u64::MAX) ||
             elapsed >= self.max_duration.unwrap_or(Duration::MAX)
+    }
+}
+
+impl From<ExecutionConfig> for ExecutionStageThresholds {
+    fn from(config: ExecutionConfig) -> Self {
+        ExecutionStageThresholds {
+            max_blocks: config.max_blocks,
+            max_changes: config.max_changes,
+            max_cumulative_gas: config.max_cumulative_gas,
+            max_duration: config.max_duration,
+        }
     }
 }
 

--- a/crates/stages/src/stages/hashing_account.rs
+++ b/crates/stages/src/stages/hashing_account.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-use reth_config::config::EtlConfig;
+use reth_config::config::{EtlConfig, HashingConfig};
 use reth_db::{
     cursor::{DbCursorRO, DbCursorRW},
     database::Database,
@@ -48,10 +48,13 @@ impl AccountHashingStage {
         Self { clean_threshold, commit_threshold, etl_config }
     }
 
-    /// Set the ETL configuration to use.
-    pub fn with_etl_config(mut self, etl_config: EtlConfig) -> Self {
-        self.etl_config = etl_config;
-        self
+    /// Create new instance of [AccountHashingStage] from configuration.
+    pub fn from_config(config: HashingConfig, etl_config: EtlConfig) -> Self {
+        Self {
+            clean_threshold: config.clean_threshold,
+            commit_threshold: config.commit_threshold,
+            etl_config,
+        }
     }
 }
 

--- a/crates/stages/src/stages/hashing_account.rs
+++ b/crates/stages/src/stages/hashing_account.rs
@@ -44,12 +44,7 @@ pub struct AccountHashingStage {
 
 impl AccountHashingStage {
     /// Create new instance of [AccountHashingStage].
-    pub fn new(clean_threshold: u64, commit_threshold: u64, etl_config: EtlConfig) -> Self {
-        Self { clean_threshold, commit_threshold, etl_config }
-    }
-
-    /// Create new instance of [AccountHashingStage] from configuration.
-    pub fn from_config(config: HashingConfig, etl_config: EtlConfig) -> Self {
+    pub fn new(config: HashingConfig, etl_config: EtlConfig) -> Self {
         Self {
             clean_threshold: config.clean_threshold,
             commit_threshold: config.commit_threshold,

--- a/crates/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/src/stages/hashing_storage.rs
@@ -45,12 +45,7 @@ pub struct StorageHashingStage {
 
 impl StorageHashingStage {
     /// Create new instance of [StorageHashingStage].
-    pub fn new(clean_threshold: u64, commit_threshold: u64, etl_config: EtlConfig) -> Self {
-        Self { clean_threshold, commit_threshold, etl_config }
-    }
-
-    /// Create new instance of [StorageHashingStage] from configuration.
-    pub fn from_config(config: HashingConfig, etl_config: EtlConfig) -> Self {
+    pub fn new(config: HashingConfig, etl_config: EtlConfig) -> Self {
         Self {
             clean_threshold: config.clean_threshold,
             commit_threshold: config.commit_threshold,

--- a/crates/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/src/stages/hashing_storage.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-use reth_config::config::EtlConfig;
+use reth_config::config::{EtlConfig, HashingConfig};
 use reth_db::{
     codecs::CompactU256,
     cursor::{DbCursorRO, DbDupCursorRW},
@@ -49,10 +49,13 @@ impl StorageHashingStage {
         Self { clean_threshold, commit_threshold, etl_config }
     }
 
-    /// Set the ETL configuration to use.
-    pub fn with_etl_config(mut self, etl_config: EtlConfig) -> Self {
-        self.etl_config = etl_config;
-        self
+    /// Create new instance of [StorageHashingStage] from configuration.
+    pub fn from_config(config: HashingConfig, etl_config: EtlConfig) -> Self {
+        Self {
+            clean_threshold: config.clean_threshold,
+            commit_threshold: config.commit_threshold,
+            etl_config,
+        }
     }
 }
 

--- a/crates/stages/src/stages/index_account_history.rs
+++ b/crates/stages/src/stages/index_account_history.rs
@@ -31,15 +31,6 @@ pub struct IndexAccountHistoryStage {
 impl IndexAccountHistoryStage {
     /// Create new instance of [IndexAccountHistoryStage].
     pub fn new(
-        commit_threshold: u64,
-        prune_mode: Option<PruneMode>,
-        etl_config: EtlConfig,
-    ) -> Self {
-        Self { commit_threshold, prune_mode, etl_config }
-    }
-
-    /// Create new instance of [IndexAccountHistoryStage] from configuration.
-    pub fn from_config(
         config: IndexHistoryConfig,
         etl_config: EtlConfig,
         prune_mode: Option<PruneMode>,

--- a/crates/stages/src/stages/index_account_history.rs
+++ b/crates/stages/src/stages/index_account_history.rs
@@ -1,5 +1,5 @@
 use super::{collect_history_indices, load_history_indices};
-use reth_config::config::EtlConfig;
+use reth_config::config::{EtlConfig, IndexHistoryConfig};
 use reth_db::{
     database::Database, models::ShardedKey, table::Decode, tables, transaction::DbTxMut,
 };
@@ -38,10 +38,13 @@ impl IndexAccountHistoryStage {
         Self { commit_threshold, prune_mode, etl_config }
     }
 
-    /// Set the ETL configuration to use.
-    pub fn with_etl_config(mut self, etl_config: EtlConfig) -> Self {
-        self.etl_config = etl_config;
-        self
+    /// Create new instance of [IndexAccountHistoryStage] from configuration.
+    pub fn from_config(
+        config: IndexHistoryConfig,
+        etl_config: EtlConfig,
+        prune_mode: Option<PruneMode>,
+    ) -> Self {
+        Self { commit_threshold: config.commit_threshold, etl_config, prune_mode }
     }
 }
 

--- a/crates/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/src/stages/index_storage_history.rs
@@ -1,5 +1,5 @@
 use super::{collect_history_indices, load_history_indices};
-use reth_config::config::EtlConfig;
+use reth_config::config::{EtlConfig, IndexHistoryConfig};
 use reth_db::{
     database::Database,
     models::{storage_sharded_key::StorageShardedKey, AddressStorageKey, BlockNumberAddress},
@@ -42,10 +42,13 @@ impl IndexStorageHistoryStage {
         Self { commit_threshold, prune_mode, etl_config }
     }
 
-    /// Set the ETL configuration to use.
-    pub fn with_etl_config(mut self, etl_config: EtlConfig) -> Self {
-        self.etl_config = etl_config;
-        self
+    /// Create new instance of [IndexStorageHistoryStage] from configuration.
+    pub fn from_config(
+        config: IndexHistoryConfig,
+        etl_config: EtlConfig,
+        prune_mode: Option<PruneMode>,
+    ) -> Self {
+        Self { commit_threshold: config.commit_threshold, prune_mode, etl_config }
     }
 }
 

--- a/crates/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/src/stages/index_storage_history.rs
@@ -35,15 +35,6 @@ pub struct IndexStorageHistoryStage {
 impl IndexStorageHistoryStage {
     /// Create new instance of [IndexStorageHistoryStage].
     pub fn new(
-        commit_threshold: u64,
-        prune_mode: Option<PruneMode>,
-        etl_config: EtlConfig,
-    ) -> Self {
-        Self { commit_threshold, prune_mode, etl_config }
-    }
-
-    /// Create new instance of [IndexStorageHistoryStage] from configuration.
-    pub fn from_config(
         config: IndexHistoryConfig,
         etl_config: EtlConfig,
         prune_mode: Option<PruneMode>,

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -43,12 +43,7 @@ pub struct SenderRecoveryStage {
 
 impl SenderRecoveryStage {
     /// Create new instance of [SenderRecoveryStage].
-    pub fn new(commit_threshold: u64) -> Self {
-        Self { commit_threshold }
-    }
-
-    /// Create new instance of [SenderRecoveryStage] from configuration.
-    pub fn from_config(config: SenderRecoveryConfig) -> Self {
+    pub fn new(config: SenderRecoveryConfig) -> Self {
         Self { commit_threshold: config.commit_threshold }
     }
 }

--- a/crates/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/src/stages/sender_recovery.rs
@@ -1,3 +1,4 @@
+use reth_config::config::SenderRecoveryConfig;
 use reth_consensus::ConsensusError;
 use reth_db::{
     cursor::DbCursorRW,
@@ -44,6 +45,11 @@ impl SenderRecoveryStage {
     /// Create new instance of [SenderRecoveryStage].
     pub fn new(commit_threshold: u64) -> Self {
         Self { commit_threshold }
+    }
+
+    /// Create new instance of [SenderRecoveryStage] from configuration.
+    pub fn from_config(config: SenderRecoveryConfig) -> Self {
+        Self { commit_threshold: config.commit_threshold }
     }
 }
 

--- a/crates/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/src/stages/tx_lookup.rs
@@ -45,12 +45,7 @@ impl Default for TransactionLookupStage {
 
 impl TransactionLookupStage {
     /// Create new instance of [TransactionLookupStage].
-    pub fn new(chunk_size: u64, etl_config: EtlConfig, prune_mode: Option<PruneMode>) -> Self {
-        Self { chunk_size, etl_config, prune_mode }
-    }
-
-    /// Create new instance of [TransactionLookupStage] from configuration.
-    pub fn from_config(
+    pub fn new(
         config: TransactionLookupConfig,
         etl_config: EtlConfig,
         prune_mode: Option<PruneMode>,

--- a/crates/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/src/stages/tx_lookup.rs
@@ -1,5 +1,5 @@
 use num_traits::Zero;
-use reth_config::config::EtlConfig;
+use reth_config::config::{EtlConfig, TransactionLookupConfig};
 use reth_db::{
     cursor::{DbCursorRO, DbCursorRW},
     database::Database,
@@ -49,10 +49,13 @@ impl TransactionLookupStage {
         Self { chunk_size, etl_config, prune_mode }
     }
 
-    /// Set the ETL configuration to use.
-    pub fn with_etl_config(mut self, etl_config: EtlConfig) -> Self {
-        self.etl_config = etl_config;
-        self
+    /// Create new instance of [TransactionLookupStage] from configuration.
+    pub fn from_config(
+        config: TransactionLookupConfig,
+        etl_config: EtlConfig,
+        prune_mode: Option<PruneMode>,
+    ) -> Self {
+        Self { chunk_size: config.chunk_size, etl_config, prune_mode }
     }
 }
 


### PR DESCRIPTION
Feel like `DefaultStages` is in a weird place and building a pipeline has a lot of inertia.

We always call it, but end up overriding the stages to pass  `StageConfig` values. In some cases, we don't pass them , even though we should.

So proposing `DefaultStages` to take these configuration values in the first place, and let the inner builders populate the initializations