### PR TITLE
fix: use configs object list in matrix to release all platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,50 +27,61 @@ jobs:
 
   build:
     name: build release
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.configs.os }}
     needs: extract-version
     strategy:
       matrix:
+        configs: [
+            {
+                target: x86_64-unknown-linux-gnu
+                os: ubuntu-20.04
+                profile: maxperf
+            },
+            {
+                target: aarch64-unknown-linux-gnu
+                os: ubuntu-20.04
+                profile: maxperf
+            },
+            {
+                target: x86_64-apple-darwin
+                os: macos-13
+                profile: maxperf
+            },
+            {
+                target: aarch64-apple-darwin
+                os: macos-14
+                profile: maxperf
+            },
+            {
+                target: x86_64-pc-windows-gnu
+                os: ubuntu-20.04
+                profile: maxperf
+            },
+        ]
         build: [{command: build, binary: reth}, {command: op-build, binary: op-reth}]
-        include:
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-20.04
-            profile: maxperf
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-20.04
-            profile: maxperf
-          - target: x86_64-apple-darwin
-            os: macos-13
-            profile: maxperf
-          - target: aarch64-apple-darwin
-            os: macos-14
-            profile: maxperf
-          - target: x86_64-pc-windows-gnu
-            os: ubuntu-20.04
-            profile: maxperf
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          target: ${{ matrix.target }}
+          target: ${{ matrix.configs.target }}
       - uses: taiki-e/install-action@cross
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
 
       - name: Apple M1 setup
-        if: matrix.target == 'aarch64-apple-darwin'
+        if: matrix.configs.target == 'aarch64-apple-darwin'
         run: |
           echo "SDKROOT=$(xcrun -sdk macosx --show-sdk-path)" >> $GITHUB_ENV
           echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-os-version)" >> $GITHUB_ENV
 
       - name: Build Reth
-        run: make PROFILE=${{ matrix.profile }} ${{ matrix.build.command }}-${{ matrix.target }}
+        run: make PROFILE=${{ matrix.configs.profile }} ${{ matrix.build.command }}-${{ matrix.configs.target }}
       - name: Move binary
         run: |
           mkdir artifacts
-          [[ "${{ matrix.target }}" == *windows* ]] && ext=".exe"
-          mv "target/${{ matrix.target }}/${{ matrix.profile }}/${{ matrix.build.binary }}${ext}" ./artifacts
+          [[ "${{ matrix.configs.target }}" == *windows* ]] && ext=".exe"
+          mv "target/${{ matrix.configs.target }}/${{ matrix.configs.profile }}/${{ matrix.build.binary }}${ext}" ./artifacts
 
       - name: Configure GPG and create artifacts
         env:
@@ -80,22 +91,22 @@ jobs:
           export GPG_TTY=$(tty)
           echo -n "$GPG_SIGNING_KEY" | base64 --decode | gpg --batch --import
           cd artifacts
-          tar -czf ${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}.tar.gz ${{ matrix.build.binary }}*
-          echo "$GPG_PASSPHRASE" | gpg --passphrase-fd 0 --pinentry-mode loopback --batch -ab ${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}.tar.gz
+          tar -czf ${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz ${{ matrix.build.binary }}*
+          echo "$GPG_PASSPHRASE" | gpg --passphrase-fd 0 --pinentry-mode loopback --batch -ab ${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz
           mv *tar.gz* ..
         shell: bash
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}.tar.gz
-          path: ${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}.tar.gz
+          name: ${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz
+          path: ${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz
 
       - name: Upload signature
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}.tar.gz.asc
-          path: ${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}.tar.gz.asc
+          name: ${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz.asc
+          path: ${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz.asc
 
   draft-release:
     name: draft release


### PR DESCRIPTION
This should now run 10 jobs, instead of 2, with each combination of config and (build cmd, binary) pair