### PR TITLE
chore(pruner): set default timeout to `None` on `PrunerBuilder`

### DIFF
--- a/crates/prune/src/builder.rs
+++ b/crates/prune/src/builder.rs
@@ -102,7 +102,7 @@ impl Default for PrunerBuilder {
             segments: PruneModes::none(),
             max_reorg_depth: 64,
             prune_delete_limit: MAINNET.prune_delete_limit,
-            timeout: Some(Self::DEFAULT_TIMEOUT),
+            timeout: None,
             finished_exex_height: watch::channel(FinishedExExHeight::NoExExs).1,
         }
     }


### PR DESCRIPTION
As discussed on: https://github.com/paradigmxyz/reth/pull/8127#discussion_r1592273027

From what I could check, node builder overrides it already anyway.

https://github.com/paradigmxyz/reth/blob/539c70256145f0a126fde406ef14d50fbd8f9589/crates/node/builder/src/launch/common.rs#L278-L282

There are scenarios such `reth stage unwind` that shouldn't have a timeout.