### PR TITLE
avoid double function call in `validate_one`

### DIFF
--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -195,11 +195,14 @@ where
         };
 
         // Reject transactions over defined size to prevent DOS attacks
-        if transaction.size() > self.max_tx_input_bytes {
-            let size = transaction.size();
+        let transaction_size = transaction.size();
+        if transaction_size > self.max_tx_input_bytes {
             return TransactionValidationOutcome::Invalid(
                 transaction,
-                InvalidPoolTransactionError::OversizedData(size, self.max_tx_input_bytes),
+                InvalidPoolTransactionError::OversizedData(
+                    transaction_size,
+                    self.max_tx_input_bytes,
+                ),
             )
         }
 
@@ -211,11 +214,14 @@ where
         }
 
         // Checks for gas limit
-        if transaction.gas_limit() > self.block_gas_limit {
-            let gas_limit = transaction.gas_limit();
+        let transaction_gas_limit = transaction.gas_limit();
+        if transaction_gas_limit > self.block_gas_limit {
             return TransactionValidationOutcome::Invalid(
                 transaction,
-                InvalidPoolTransactionError::ExceedsGasLimit(gas_limit, self.block_gas_limit),
+                InvalidPoolTransactionError::ExceedsGasLimit(
+                    transaction_gas_limit,
+                    self.block_gas_limit,
+                ),
             )
         }
 


### PR DESCRIPTION
This PR provides a small change in the transaction pool `validate_one` function in order to avoid double function calls, when possible, at two positions in the code, probably very slightly improving performance.