### PR TITLE
chore: add alloy-compat for signature and transaction

### DIFF
--- a/crates/primitives/src/alloy_compat.rs
+++ b/crates/primitives/src/alloy_compat.rs
@@ -1,8 +1,8 @@
 //! Common conversions from alloy types.
 
 use crate::{
-    Block, Header, Transaction, TransactionSigned, TxEip1559, TxEip2930, TxEip4844, TxLegacy,
-    TxType,
+    transaction::extract_chain_id, Block, Header, Signature, Transaction, TransactionSigned,
+    TransactionSignedEcRecovered, TxEip1559, TxEip2930, TxEip4844, TxLegacy, TxType,
 };
 use alloy_primitives::TxKind;
 use alloy_rlp::Error as RlpError;
@@ -115,7 +115,7 @@ impl TryFrom<alloy_rpc_types::Transaction> for Transaction {
                     return Err(ConversionError::Eip2718Error(
                         RlpError::Custom("EIP-1559 fields are present in a legacy transaction")
                             .into(),
-                    ))
+                    ));
                 }
                 Ok(Transaction::Legacy(TxLegacy {
                     chain_id: tx.chain_id,
@@ -197,5 +197,66 @@ impl TryFrom<alloy_rpc_types::Transaction> for Transaction {
             #[cfg(feature = "optimism")]
             Some(TxType::Deposit) => todo!(),
         }
+    }
+}
+
+impl TryFrom<alloy_rpc_types::Transaction> for TransactionSigned {
+    type Error = alloy_rpc_types::ConversionError;
+
+    fn try_from(tx: alloy_rpc_types::Transaction) -> Result<Self, Self::Error> {
+        use alloy_rpc_types::ConversionError;
+
+        let signature = tx.signature.ok_or(ConversionError::MissingSignature)?;
+        let transaction: Transaction = tx.try_into()?;
+
+        Ok(TransactionSigned::from_transaction_and_signature(
+            transaction.clone(),
+            Signature {
+                r: signature.r,
+                s: signature.s,
+                odd_y_parity: if let Some(y_parity) = signature.y_parity {
+                    y_parity.0
+                } else {
+                    match transaction.tx_type() {
+                        // If the transaction type is Legacy, adjust the v component of the
+                        // signature according to the Ethereum specification
+                        TxType::Legacy => {
+                            extract_chain_id(signature.v.to())
+                                .map_err(|_| ConversionError::InvalidSignature)?
+                                .0
+                        }
+                        _ => !signature.v.is_zero(),
+                    }
+                },
+            },
+        ))
+    }
+}
+
+impl TryFrom<alloy_rpc_types::Transaction> for TransactionSignedEcRecovered {
+    type Error = alloy_rpc_types::ConversionError;
+
+    fn try_from(tx: alloy_rpc_types::Transaction) -> Result<Self, Self::Error> {
+        use alloy_rpc_types::ConversionError;
+
+        let transaction: TransactionSigned = tx.try_into()?;
+
+        transaction.try_into_ecrecovered().map_err(|_| ConversionError::InvalidSignature)
+    }
+}
+
+impl TryFrom<alloy_rpc_types::Signature> for Signature {
+    type Error = alloy_rpc_types::ConversionError;
+
+    fn try_from(signature: alloy_rpc_types::Signature) -> Result<Self, Self::Error> {
+        use alloy_rpc_types::ConversionError;
+
+        let odd_y_parity = if let Some(y_parity) = signature.y_parity {
+            y_parity.0
+        } else {
+            extract_chain_id(signature.v.to()).map_err(|_| ConversionError::InvalidSignature)?.0
+        };
+
+        Ok(Self { r: signature.r, s: signature.s, odd_y_parity })
     }
 }

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1495,40 +1495,6 @@ impl<'a> arbitrary::Arbitrary<'a> for TransactionSigned {
     }
 }
 
-#[cfg(feature = "alloy-compat")]
-impl TryFrom<alloy_rpc_types::Transaction> for TransactionSigned {
-    type Error = alloy_rpc_types::ConversionError;
-
-    fn try_from(tx: alloy_rpc_types::Transaction) -> Result<Self, Self::Error> {
-        use alloy_rpc_types::ConversionError;
-
-        let signature = tx.signature.ok_or(ConversionError::MissingSignature)?;
-        let transaction: Transaction = tx.try_into()?;
-
-        Ok(TransactionSigned::from_transaction_and_signature(
-            transaction.clone(),
-            Signature {
-                r: signature.r,
-                s: signature.s,
-                odd_y_parity: if let Some(y_parity) = signature.y_parity {
-                    y_parity.0
-                } else {
-                    match transaction.tx_type() {
-                        // If the transaction type is Legacy, adjust the v component of the
-                        // signature according to the Ethereum specification
-                        TxType::Legacy => {
-                            extract_chain_id(signature.v.to())
-                                .map_err(|_| ConversionError::InvalidSignature)?
-                                .0
-                        }
-                        _ => !signature.v.is_zero(),
-                    }
-                },
-            },
-        ))
-    }
-}
-
 /// Signed transaction with recovered signer.
 #[derive(Debug, Clone, PartialEq, Hash, Eq, AsRef, Deref, Default)]
 pub struct TransactionSignedEcRecovered {
@@ -1646,19 +1612,6 @@ impl IntoRecoveredTransaction for TransactionSignedEcRecovered {
     #[inline]
     fn to_recovered_transaction(&self) -> TransactionSignedEcRecovered {
         self.clone()
-    }
-}
-
-#[cfg(feature = "alloy-compat")]
-impl TryFrom<alloy_rpc_types::Transaction> for TransactionSignedEcRecovered {
-    type Error = alloy_rpc_types::ConversionError;
-
-    fn try_from(tx: alloy_rpc_types::Transaction) -> Result<Self, Self::Error> {
-        use alloy_rpc_types::ConversionError;
-
-        let transaction: TransactionSigned = tx.try_into()?;
-
-        transaction.try_into_ecrecovered().map_err(|_| ConversionError::InvalidSignature)
     }
 }
 

--- a/crates/primitives/src/transaction/signature.rs
+++ b/crates/primitives/src/transaction/signature.rs
@@ -196,6 +196,23 @@ impl Signature {
     }
 }
 
+#[cfg(feature = "alloy-compat")]
+impl TryFrom<alloy_rpc_types::Signature> for Signature {
+    type Error = alloy_rpc_types::ConversionError;
+
+    fn try_from(signature: alloy_rpc_types::Signature) -> Result<Self, Self::Error> {
+        use alloy_rpc_types::ConversionError;
+
+        let odd_y_parity = if let Some(y_parity) = signature.y_parity {
+            y_parity.0
+        } else {
+            extract_chain_id(signature.v.to()).map_err(|_| ConversionError::InvalidSignature)?.0
+        };
+
+        Ok(Self { r: signature.r, s: signature.s, odd_y_parity })
+    }
+}
+
 /// Outputs (odd_y_parity, chain_id) from the `v` value.
 /// This doesn't check validity of the `v` value for optimism.
 #[inline]

--- a/crates/primitives/src/transaction/signature.rs
+++ b/crates/primitives/src/transaction/signature.rs
@@ -196,23 +196,6 @@ impl Signature {
     }
 }
 
-#[cfg(feature = "alloy-compat")]
-impl TryFrom<alloy_rpc_types::Signature> for Signature {
-    type Error = alloy_rpc_types::ConversionError;
-
-    fn try_from(signature: alloy_rpc_types::Signature) -> Result<Self, Self::Error> {
-        use alloy_rpc_types::ConversionError;
-
-        let odd_y_parity = if let Some(y_parity) = signature.y_parity {
-            y_parity.0
-        } else {
-            extract_chain_id(signature.v.to()).map_err(|_| ConversionError::InvalidSignature)?.0
-        };
-
-        Ok(Self { r: signature.r, s: signature.s, odd_y_parity })
-    }
-}
-
 /// Outputs (odd_y_parity, chain_id) from the `v` value.
 /// This doesn't check validity of the `v` value for optimism.
 #[inline]


### PR DESCRIPTION
Addresses #8177 

Other types already either have `alloy-compat` or are imported from `alloy`