### PR TITLE
feat(primitives): add EIP-7002 predeploy address

### DIFF
--- a/crates/primitives/src/constants/mod.rs
+++ b/crates/primitives/src/constants/mod.rs
@@ -197,11 +197,16 @@ pub const BEACON_CONSENSUS_REORG_UNWIND_DEPTH: u64 = 3;
 /// <https://github.com/ethereum/go-ethereum/blob/a196f3e8a22b6ad22ced5c2e3baf32bc3ebd4ec9/consensus/ethash/consensus.go#L227-L229>
 pub const ALLOWED_FUTURE_BLOCK_TIME_SECONDS: u64 = 15;
 
-/// The address for the beacon roots contract defined in EIP-4788.
+/// The address for the beacon roots contract defined in [EIP-4788](https://eips.ethereum.org/EIPS/eip-4788).
 pub const BEACON_ROOTS_ADDRESS: Address = address!("000F3df6D732807Ef1319fB7B8bB8522d0Beac02");
 
-/// The caller to be used when calling the EIP-4788 beacon roots contract at the beginning of the
-/// block.
+/// The address for the validator withdrawals contract defined in [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002).
+pub const WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS: Address =
+    address!("00A3ca265EBcb825B45F985A16CEFB49958cE017");
+
+/// The caller to be used when calling a system contract
+/// (such as [EIP-4788](https://eips.ethereum.org/EIPS/eip-4788) beacon roots at the beginning of the block or
+/// [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) validator withdrawals at the end of the block).
 pub const SYSTEM_ADDRESS: Address = address!("fffffffffffffffffffffffffffffffffffffffe");
 
 #[cfg(test)]


### PR DESCRIPTION
Ref https://github.com/paradigmxyz/reth/issues/7363

This PR adds the address of the [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) system contract, as well as adjusts the `SYSTEM_ADDRESS` documentation to reflect it's used in not just EIP-4788.