### PR TITLE
refactor(ethereum, primitives, evm): use Alloy EIP-4788 constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,17 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
+dependencies = [
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-primitives",
+ "alloy-rlp",
+ "c-kzg",
+]
+
+[[package]]
+name = "alloy-consensus"
+version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy#af25c53f99a4549ece47625b7d65f088c3487864"
 dependencies = [
  "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy)",
@@ -184,9 +195,26 @@ dependencies = [
  "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
  "arbitrary",
  "c-kzg",
- "derive_more",
  "ethereum_ssz",
  "ethereum_ssz_derive",
+ "once_cell",
+ "proptest",
+ "proptest-derive",
+ "serde",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "arbitrary",
+ "c-kzg",
+ "derive_more",
  "once_cell",
  "proptest",
  "proptest-derive",
@@ -481,6 +509,16 @@ dependencies = [
 name = "alloy-serde"
 version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -2977,7 +3015,7 @@ dependencies = [
 name = "exex-rollup"
 version = "0.0.0"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "alloy-rlp",
  "alloy-sol-types",
  "eyre",
@@ -6578,7 +6616,7 @@ dependencies = [
 name = "reth-codecs"
 version = "0.2.0-beta.7"
 dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
  "alloy-primitives",
  "arbitrary",
@@ -6784,7 +6822,7 @@ dependencies = [
 name = "reth-e2e-test-utils"
 version = "0.2.0-beta.7"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "alloy-network",
  "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
  "alloy-signer",
@@ -6990,6 +7028,7 @@ dependencies = [
 name = "reth-evm-ethereum"
 version = "0.2.0-beta.7"
 dependencies = [
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "reth-evm",
  "reth-interfaces",
  "reth-primitives",
@@ -7540,7 +7579,7 @@ name = "reth-primitives"
 version = "0.2.0-beta.7"
 dependencies = [
  "alloy-chains",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
  "alloy-primitives",
  "alloy-rlp",
@@ -7643,6 +7682,7 @@ dependencies = [
 name = "reth-revm"
 version = "0.2.0-beta.7"
 dependencies = [
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "reth-consensus-common",
  "reth-interfaces",
  "reth-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,12 +146,12 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
+source = "git+https://github.com/alloy-rs/alloy?rev=f1d7085#f1d708522e7fe676a3ee86dd198f87182f220927"
 dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "c-kzg",
  "serde",
 ]
@@ -204,11 +204,11 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
+source = "git+https://github.com/alloy-rs/alloy?rev=f1d7085#f1d708522e7fe676a3ee86dd198f87182f220927"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "arbitrary",
  "c-kzg",
  "derive_more",
@@ -249,10 +249,10 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
+source = "git+https://github.com/alloy-rs/alloy?rev=f1d7085#f1d708522e7fe676a3ee86dd198f87182f220927"
 dependencies = [
  "alloy-primitives",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "serde",
  "serde_json",
 ]
@@ -283,7 +283,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
+source = "git+https://github.com/alloy-rs/alloy?rev=f1d7085#f1d708522e7fe676a3ee86dd198f87182f220927"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -295,13 +295,13 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
+source = "git+https://github.com/alloy-rs/alloy?rev=f1d7085#f1d708522e7fe676a3ee86dd198f87182f220927"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "alloy-json-rpc",
  "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
@@ -312,9 +312,9 @@ dependencies = [
 [[package]]
 name = "alloy-node-bindings"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
+source = "git+https://github.com/alloy-rs/alloy?rev=f1d7085#f1d708522e7fe676a3ee86dd198f87182f220927"
 dependencies = [
- "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "alloy-primitives",
  "k256",
  "serde_json",
@@ -354,15 +354,15 @@ dependencies = [
 [[package]]
 name = "alloy-provider"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
+source = "git+https://github.com/alloy-rs/alloy?rev=f1d7085#f1d708522e7fe676a3ee86dd198f87182f220927"
 dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-client",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
- "alloy-rpc-types-trace 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
+ "alloy-rpc-types-trace 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "alloy-transport",
  "alloy-transport-http",
  "async-stream",
@@ -404,7 +404,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-client"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
+source = "git+https://github.com/alloy-rs/alloy?rev=f1d7085#f1d708522e7fe676a3ee86dd198f87182f220927"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -442,14 +442,14 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
+source = "git+https://github.com/alloy-rs/alloy?rev=f1d7085#f1d708522e7fe676a3ee86dd198f87182f220927"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
- "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
+ "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "alloy-sol-types",
  "arbitrary",
  "itertools 0.12.1",
@@ -482,19 +482,19 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-anvil"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
+source = "git+https://github.com/alloy-rs/alloy?rev=f1d7085#f1d708522e7fe676a3ee86dd198f87182f220927"
 dependencies = [
  "alloy-primitives",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-beacon"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
+source = "git+https://github.com/alloy-rs/alloy?rev=f1d7085#f1d708522e7fe676a3ee86dd198f87182f220927"
 dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "serde",
@@ -504,14 +504,14 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-engine"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
+source = "git+https://github.com/alloy-rs/alloy?rev=f1d7085#f1d708522e7fe676a3ee86dd198f87182f220927"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "jsonrpsee-types",
@@ -536,11 +536,11 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-trace"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
+source = "git+https://github.com/alloy-rs/alloy?rev=f1d7085#f1d708522e7fe676a3ee86dd198f87182f220927"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "serde",
  "serde_json",
 ]
@@ -558,7 +558,7 @@ dependencies = [
 [[package]]
 name = "alloy-serde"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
+source = "git+https://github.com/alloy-rs/alloy?rev=f1d7085#f1d708522e7fe676a3ee86dd198f87182f220927"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -578,7 +578,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
+source = "git+https://github.com/alloy-rs/alloy?rev=f1d7085#f1d708522e7fe676a3ee86dd198f87182f220927"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -591,9 +591,9 @@ dependencies = [
 [[package]]
 name = "alloy-signer-wallet"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
+source = "git+https://github.com/alloy-rs/alloy?rev=f1d7085#f1d708522e7fe676a3ee86dd198f87182f220927"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "alloy-network",
  "alloy-primitives",
  "alloy-signer",
@@ -666,7 +666,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
+source = "git+https://github.com/alloy-rs/alloy?rev=f1d7085#f1d708522e7fe676a3ee86dd198f87182f220927"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
@@ -684,7 +684,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
+source = "git+https://github.com/alloy-rs/alloy?rev=f1d7085#f1d708522e7fe676a3ee86dd198f87182f220927"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -3055,7 +3055,7 @@ dependencies = [
 name = "exex-rollup"
 version = "0.0.0"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "alloy-rlp",
  "alloy-sol-types",
  "eyre",
@@ -6656,8 +6656,8 @@ dependencies = [
 name = "reth-codecs"
 version = "0.2.0-beta.7"
 dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
- "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
+ "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "alloy-primitives",
  "arbitrary",
  "bytes",
@@ -6862,9 +6862,9 @@ dependencies = [
 name = "reth-e2e-test-utils"
 version = "0.2.0-beta.7"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "alloy-network",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "alloy-signer",
  "alloy-signer-wallet",
  "eyre",
@@ -7068,7 +7068,7 @@ dependencies = [
 name = "reth-evm-ethereum"
 version = "0.2.0-beta.7"
 dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "reth-evm",
  "reth-interfaces",
  "reth-primitives",
@@ -7619,11 +7619,11 @@ name = "reth-primitives"
 version = "0.2.0-beta.7"
 dependencies = [
  "alloy-chains",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
- "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
+ "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "alloy-trie",
  "arbitrary",
  "assert_matches",
@@ -7722,7 +7722,7 @@ dependencies = [
 name = "reth-revm"
 version = "0.2.0-beta.7"
 dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "reth-consensus-common",
  "reth-interfaces",
  "reth-primitives",
@@ -7907,11 +7907,11 @@ name = "reth-rpc-types"
 version = "0.2.0-beta.7"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "alloy-rpc-types-anvil",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-trace 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-rpc-types-trace 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "arbitrary",
  "bytes",
  "ethereum_ssz",
@@ -7932,7 +7932,7 @@ name = "reth-rpc-types-compat"
 version = "0.2.0-beta.7"
 dependencies = [
  "alloy-rlp",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "reth-primitives",
  "reth-rpc-types",
  "serde_json",
@@ -8039,7 +8039,7 @@ dependencies = [
 name = "reth-testing-utils"
 version = "0.2.0-beta.7"
 dependencies = [
- "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "reth-primitives",
  "secp256k1",
 ]
@@ -8173,7 +8173,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/evm-inspectors?rev=c1b5dd0#c1b5dd0d85dd46ef5ec5258aebd24adc041d103a"
+source = "git+https://github.com/paradigmxyz/evm-inspectors?rev=7fc34a2#7fc34a2f7fa36b869aaa304c1ff607253fa62343"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,9 @@ dependencies = [
  "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "c-kzg",
+ "serde",
 ]
 
 [[package]]
@@ -193,13 +195,8 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
- "arbitrary",
  "c-kzg",
- "ethereum_ssz",
- "ethereum_ssz_derive",
  "once_cell",
- "proptest",
- "proptest-derive",
  "serde",
  "sha2 0.10.8",
 ]
@@ -215,6 +212,8 @@ dependencies = [
  "arbitrary",
  "c-kzg",
  "derive_more",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
  "once_cell",
  "proptest",
  "proptest-derive",
@@ -250,6 +249,17 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-genesis"
+version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy#af25c53f99a4549ece47625b7d65f088c3487864"
 dependencies = [
  "alloy-primitives",
@@ -273,7 +283,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -285,13 +295,13 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "alloy-json-rpc",
  "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
@@ -302,9 +312,9 @@ dependencies = [
 [[package]]
 name = "alloy-node-bindings"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
 dependencies = [
- "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
+ "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "alloy-primitives",
  "k256",
  "serde_json",
@@ -344,15 +354,15 @@ dependencies = [
 [[package]]
 name = "alloy-provider"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
 dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-client",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
- "alloy-rpc-types-trace",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-rpc-types-trace 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "alloy-transport",
  "alloy-transport-http",
  "async-stream",
@@ -394,7 +404,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-client"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -422,6 +432,24 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
+ "alloy-sol-types",
+ "itertools 0.12.1",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
+dependencies = [
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "alloy-sol-types",
  "arbitrary",
  "itertools 0.12.1",
@@ -454,19 +482,19 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-anvil"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
 dependencies = [
  "alloy-primitives",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-beacon"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
 dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "serde",
@@ -476,14 +504,14 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-engine"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "jsonrpsee-types",
@@ -501,6 +529,18 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
  "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-rpc-types-trace"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "serde",
  "serde_json",
 ]
@@ -538,7 +578,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -551,9 +591,9 @@ dependencies = [
 [[package]]
 name = "alloy-signer-wallet"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "alloy-network",
  "alloy-primitives",
  "alloy-signer",
@@ -626,7 +666,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
@@ -644,7 +684,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
+source = "git+https://github.com/alloy-rs/alloy?rev=ba9d58d#ba9d58d9345b4b60b99bb43abf170f4fd75eb1c0"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -6617,7 +6657,7 @@ name = "reth-codecs"
 version = "0.2.0-beta.7"
 dependencies = [
  "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
- "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
+ "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "alloy-primitives",
  "arbitrary",
  "bytes",
@@ -6824,7 +6864,7 @@ version = "0.2.0-beta.7"
 dependencies = [
  "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "alloy-network",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "alloy-signer",
  "alloy-signer-wallet",
  "eyre",
@@ -7580,10 +7620,10 @@ version = "0.2.0-beta.7"
 dependencies = [
  "alloy-chains",
  "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
- "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
+ "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "alloy-trie",
  "arbitrary",
  "assert_matches",
@@ -7867,11 +7907,11 @@ name = "reth-rpc-types"
 version = "0.2.0-beta.7"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "alloy-rpc-types-anvil",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-trace",
+ "alloy-rpc-types-trace 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "arbitrary",
  "bytes",
  "ethereum_ssz",
@@ -7892,7 +7932,7 @@ name = "reth-rpc-types-compat"
 version = "0.2.0-beta.7"
 dependencies = [
  "alloy-rlp",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "reth-primitives",
  "reth-rpc-types",
  "serde_json",
@@ -7999,7 +8039,7 @@ dependencies = [
 name = "reth-testing-utils"
 version = "0.2.0-beta.7"
 dependencies = [
- "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
+ "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=ba9d58d)",
  "reth-primitives",
  "secp256k1",
 ]
@@ -8137,7 +8177,7 @@ source = "git+https://github.com/paradigmxyz/evm-inspectors?rev=c1b5dd0#c1b5dd0d
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
- "alloy-rpc-types-trace",
+ "alloy-rpc-types-trace 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
  "alloy-sol-types",
  "anstyle",
  "boa_engine",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,19 +133,6 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
-dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
- "c-kzg",
- "serde",
-]
-
-[[package]]
-name = "alloy-consensus"
-version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=f1d7085#f1d708522e7fe676a3ee86dd198f87182f220927"
 dependencies = [
  "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
@@ -190,20 +177,6 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
- "c-kzg",
- "once_cell",
- "serde",
- "sha2 0.10.8",
-]
-
-[[package]]
-name = "alloy-eips"
-version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=f1d7085#f1d708522e7fe676a3ee86dd198f87182f220927"
 dependencies = [
  "alloy-primitives",
@@ -233,17 +206,6 @@ dependencies = [
  "once_cell",
  "serde",
  "sha2 0.10.8",
-]
-
-[[package]]
-name = "alloy-genesis"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
-dependencies = [
- "alloy-primitives",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -362,7 +324,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-client",
  "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
- "alloy-rpc-types-trace 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
+ "alloy-rpc-types-trace",
  "alloy-transport",
  "alloy-transport-http",
  "async-stream",
@@ -419,24 +381,6 @@ dependencies = [
  "tower",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "alloy-rpc-types"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
-dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
- "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
- "alloy-sol-types",
- "itertools 0.12.1",
- "serde",
- "serde_json",
- "thiserror",
 ]
 
 [[package]]
@@ -524,33 +468,11 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-trace"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
-dependencies = [
- "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "alloy-rpc-types-trace"
-version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=f1d7085#f1d708522e7fe676a3ee86dd198f87182f220927"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
  "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "alloy-serde"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=899fc51#899fc51af8b5f4de6df1605ca3ffe8d8d6fa8c69"
-dependencies = [
- "alloy-primitives",
  "serde",
  "serde_json",
 ]
@@ -7911,7 +7833,7 @@ dependencies = [
  "alloy-rpc-types-anvil",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-trace 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
+ "alloy-rpc-types-trace",
  "arbitrary",
  "bytes",
  "ethereum_ssz",
@@ -8173,11 +8095,11 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/evm-inspectors?rev=7fc34a2#7fc34a2f7fa36b869aaa304c1ff607253fa62343"
+source = "git+https://github.com/paradigmxyz/evm-inspectors?rev=a5df8a0#a5df8a041d2c82a58840776be37f935a72803917"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
- "alloy-rpc-types-trace 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=899fc51)",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=f1d7085)",
+ "alloy-rpc-types-trace",
  "alloy-sol-types",
  "anstyle",
  "boa_engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -291,20 +291,20 @@ alloy-dyn-abi = "0.7.2"
 alloy-sol-types = "0.7.2"
 alloy-rlp = "0.3.4"
 alloy-trie = "0.3.1"
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51" }
-alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51" }
-alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51" }
-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51" }
-alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51" }
-alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51" }
-alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51" }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51", default-features = false, features = [
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "ba9d58d" }
+alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "ba9d58d" }
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "ba9d58d" }
+alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "ba9d58d" }
+alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", rev = "ba9d58d" }
+alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "ba9d58d" }
+alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", rev = "ba9d58d" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "ba9d58d", default-features = false, features = [
     "reqwest",
 ] }
 alloy-eips = { git = "https://github.com/alloy-rs/alloy", default-features = false, rev = "ba9d58d" }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51" }
-alloy-signer-wallet = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51" }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "ba9d58d" }
+alloy-signer-wallet = { git = "https://github.com/alloy-rs/alloy", rev = "ba9d58d" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "ba9d58d" }
 alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "ba9d58d" }
 
 # misc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -301,11 +301,11 @@ alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", rev = "899fc5
 alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51", default-features = false, features = [
     "reqwest",
 ] }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", default-features = false, rev = "899fc51" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", default-features = false, rev = "ba9d58d" }
 alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51" }
 alloy-signer-wallet = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51" }
 alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51" }
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "899fc51" }
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "ba9d58d" }
 
 # misc
 auto_impl = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -282,7 +282,7 @@ reth-testing-utils = { path = "testing/testing-utils" }
 # revm
 revm = { version = "8.0.0", features = ["std", "secp256k1"], default-features = false }
 revm-primitives = { version = "3.1.0", features = ["std"], default-features = false }
-revm-inspectors = { git = "https://github.com/paradigmxyz/evm-inspectors", rev = "c1b5dd0" }
+revm-inspectors = { git = "https://github.com/paradigmxyz/evm-inspectors", rev = "7fc34a2" }
 
 # eth
 alloy-chains = "0.1.15"
@@ -291,21 +291,21 @@ alloy-dyn-abi = "0.7.2"
 alloy-sol-types = "0.7.2"
 alloy-rlp = "0.3.4"
 alloy-trie = "0.3.1"
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "ba9d58d" }
-alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "ba9d58d" }
-alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "ba9d58d" }
-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "ba9d58d" }
-alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", rev = "ba9d58d" }
-alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "ba9d58d" }
-alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", rev = "ba9d58d" }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "ba9d58d", default-features = false, features = [
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "f1d7085" }
+alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "f1d7085" }
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "f1d7085" }
+alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "f1d7085" }
+alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", rev = "f1d7085" }
+alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "f1d7085" }
+alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", rev = "f1d7085" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "f1d7085", default-features = false, features = [
     "reqwest",
 ] }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", default-features = false, rev = "ba9d58d" }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "ba9d58d" }
-alloy-signer-wallet = { git = "https://github.com/alloy-rs/alloy", rev = "ba9d58d" }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "ba9d58d" }
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "ba9d58d" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", default-features = false, rev = "f1d7085" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "f1d7085" }
+alloy-signer-wallet = { git = "https://github.com/alloy-rs/alloy", rev = "f1d7085" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "f1d7085" }
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "f1d7085" }
 
 # misc
 auto_impl = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -282,7 +282,7 @@ reth-testing-utils = { path = "testing/testing-utils" }
 # revm
 revm = { version = "8.0.0", features = ["std", "secp256k1"], default-features = false }
 revm-primitives = { version = "3.1.0", features = ["std"], default-features = false }
-revm-inspectors = { git = "https://github.com/paradigmxyz/evm-inspectors", rev = "7fc34a2" }
+revm-inspectors = { git = "https://github.com/paradigmxyz/evm-inspectors", rev = "a5df8a0" }
 
 # eth
 alloy-chains = "0.1.15"

--- a/crates/ethereum/evm/Cargo.toml
+++ b/crates/ethereum/evm/Cargo.toml
@@ -20,11 +20,10 @@ reth-interfaces.workspace = true
 # Ethereum
 revm-primitives.workspace = true
 
-# Alloy
-alloy-eips.workspace = true
-
 # misc
 tracing.workspace = true
 
 [dev-dependencies]
 reth-revm = { workspace = true, features = ["test-utils"] }
+alloy-eips.workspace = true
+

--- a/crates/ethereum/evm/Cargo.toml
+++ b/crates/ethereum/evm/Cargo.toml
@@ -20,6 +20,9 @@ reth-interfaces.workspace = true
 # Ethereum
 revm-primitives.workspace = true
 
+# Alloy
+alloy-eips.workspace = true
+
 # misc
 tracing.workspace = true
 

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -443,31 +443,28 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_eips::eip4788::{BEACON_ROOTS_ADDRESS, BEACON_ROOTS_CODE, SYSTEM_ADDRESS};
     use reth_primitives::{
-        bytes,
-        constants::{BEACON_ROOTS_ADDRESS, SYSTEM_ADDRESS},
-        keccak256, Account, Block, Bytes, ChainSpecBuilder, ForkCondition, B256,
+        bytes, keccak256, Account, Block, Bytes, ChainSpecBuilder, ForkCondition, B256,
     };
     use reth_revm::{
         database::StateProviderDatabase, test_utils::StateProviderTest, TransitionState,
     };
     use std::collections::HashMap;
 
-    static BEACON_ROOT_CONTRACT_CODE: Bytes = bytes!("3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500");
-
     fn create_state_provider_with_beacon_root_contract() -> StateProviderTest {
         let mut db = StateProviderTest::default();
 
         let beacon_root_contract_account = Account {
             balance: U256::ZERO,
-            bytecode_hash: Some(keccak256(BEACON_ROOT_CONTRACT_CODE.clone())),
+            bytecode_hash: Some(keccak256(BEACON_ROOTS_CODE.clone())),
             nonce: 1,
         };
 
         db.insert_account(
             BEACON_ROOTS_ADDRESS,
             beacon_root_contract_account,
-            Some(BEACON_ROOT_CONTRACT_CODE.clone()),
+            Some(BEACON_ROOTS_CODE.clone()),
             HashMap::new(),
         );
 

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -444,9 +444,7 @@ where
 mod tests {
     use super::*;
     use alloy_eips::eip4788::{BEACON_ROOTS_ADDRESS, BEACON_ROOTS_CODE, SYSTEM_ADDRESS};
-    use reth_primitives::{
-        bytes, keccak256, Account, Block, Bytes, ChainSpecBuilder, ForkCondition, B256,
-    };
+    use reth_primitives::{keccak256, Account, Block, ChainSpecBuilder, ForkCondition, B256};
     use reth_revm::{
         database::StateProviderDatabase, test_utils::StateProviderTest, TransitionState,
     };

--- a/crates/primitives/src/constants/mod.rs
+++ b/crates/primitives/src/constants/mod.rs
@@ -1,9 +1,6 @@
 //! Ethereum protocol-related constants
 
-use crate::{
-    revm_primitives::{address, b256},
-    Address, B256, U256,
-};
+use crate::{revm_primitives::b256, B256, U256};
 use std::time::Duration;
 
 #[cfg(feature = "optimism")]
@@ -196,13 +193,6 @@ pub const BEACON_CONSENSUS_REORG_UNWIND_DEPTH: u64 = 3;
 /// See:
 /// <https://github.com/ethereum/go-ethereum/blob/a196f3e8a22b6ad22ced5c2e3baf32bc3ebd4ec9/consensus/ethash/consensus.go#L227-L229>
 pub const ALLOWED_FUTURE_BLOCK_TIME_SECONDS: u64 = 15;
-
-/// The address for the beacon roots contract defined in EIP-4788.
-pub const BEACON_ROOTS_ADDRESS: Address = address!("000F3df6D732807Ef1319fB7B8bB8522d0Beac02");
-
-/// The caller to be used when calling the EIP-4788 beacon roots contract at the beginning of the
-/// block.
-pub const SYSTEM_ADDRESS: Address = address!("fffffffffffffffffffffffffffffffffffffffe");
 
 #[cfg(test)]
 mod tests {

--- a/crates/primitives/src/revm/env.rs
+++ b/crates/primitives/src/revm/env.rs
@@ -5,7 +5,7 @@ use crate::{
     B256, U256,
 };
 
-use alloy_eips::eip4788::{self, BEACON_ROOTS_ADDRESS};
+use alloy_eips::eip4788::BEACON_ROOTS_ADDRESS;
 #[cfg(feature = "optimism")]
 use revm_primitives::OptimismFields;
 
@@ -143,7 +143,7 @@ pub fn tx_env_with_recovered(transaction: &TransactionSignedEcRecovered) -> TxEn
 ///  * if no code exists at `BEACON_ROOTS_ADDRESS`, the call must fail silently
 pub fn fill_tx_env_with_beacon_root_contract_call(env: &mut Env, parent_beacon_block_root: B256) {
     env.tx = TxEnv {
-        caller: eip4788::SYSTEM_ADDRESS,
+        caller: alloy_eips::eip4788::SYSTEM_ADDRESS,
         transact_to: TransactTo::Call(BEACON_ROOTS_ADDRESS),
         // Explicitly set nonce to None so revm does not do any nonce checks
         nonce: None,

--- a/crates/primitives/src/revm/env.rs
+++ b/crates/primitives/src/revm/env.rs
@@ -1,11 +1,11 @@
 use crate::{
-    constants::{BEACON_ROOTS_ADDRESS, SYSTEM_ADDRESS},
     recover_signer_unchecked,
     revm_primitives::{BlockEnv, Env, TransactTo, TxEnv},
     Address, Bytes, Chain, ChainSpec, Header, Transaction, TransactionSignedEcRecovered, TxKind,
     B256, U256,
 };
 
+use alloy_eips::eip4788::{self, BEACON_ROOTS_ADDRESS};
 #[cfg(feature = "optimism")]
 use revm_primitives::OptimismFields;
 
@@ -143,7 +143,7 @@ pub fn tx_env_with_recovered(transaction: &TransactionSignedEcRecovered) -> TxEn
 ///  * if no code exists at `BEACON_ROOTS_ADDRESS`, the call must fail silently
 pub fn fill_tx_env_with_beacon_root_contract_call(env: &mut Env, parent_beacon_block_root: B256) {
     env.tx = TxEnv {
-        caller: SYSTEM_ADDRESS,
+        caller: eip4788::SYSTEM_ADDRESS,
         transact_to: TransactTo::Call(BEACON_ROOTS_ADDRESS),
         // Explicitly set nonce to None so revm does not do any nonce checks
         nonce: None,

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -22,6 +22,9 @@ reth-trie = { workspace = true, optional = true }
 # revm
 revm.workspace = true
 
+# alloy
+alloy-eips.workspace = true
+
 # common
 tracing.workspace = true
 

--- a/crates/revm/src/state_change.rs
+++ b/crates/revm/src/state_change.rs
@@ -1,8 +1,9 @@
+use alloy_eips::eip4788;
 use reth_consensus_common::calc;
 use reth_interfaces::executor::{BlockExecutionError, BlockValidationError};
 use reth_primitives::{
-    constants::SYSTEM_ADDRESS, revm::env::fill_tx_env_with_beacon_root_contract_call, Address,
-    ChainSpec, Header, Withdrawal, B256, U256,
+    revm::env::fill_tx_env_with_beacon_root_contract_call, Address, ChainSpec, Header, Withdrawal,
+    B256, U256,
 };
 use revm::{interpreter::Host, Database, DatabaseCommit, Evm};
 use std::collections::HashMap;
@@ -104,7 +105,7 @@ where
         }
     };
 
-    state.remove(&SYSTEM_ADDRESS);
+    state.remove(&eip4788::SYSTEM_ADDRESS);
     state.remove(&evm.block().coinbase);
 
     evm.context.evm.db.commit(state);

--- a/crates/revm/src/state_change.rs
+++ b/crates/revm/src/state_change.rs
@@ -1,4 +1,3 @@
-use alloy_eips::eip4788;
 use reth_consensus_common::calc;
 use reth_interfaces::executor::{BlockExecutionError, BlockValidationError};
 use reth_primitives::{
@@ -105,7 +104,7 @@ where
         }
     };
 
-    state.remove(&eip4788::SYSTEM_ADDRESS);
+    state.remove(&alloy_eips::eip4788::SYSTEM_ADDRESS);
     state.remove(&evm.block().coinbase);
 
     evm.context.evm.db.commit(state);


### PR DESCRIPTION
Use the EIP-4788 constants from the [alloy-eips](https://github.com/alloy-rs/alloy/tree/main/crates/eips) introduced by https://github.com/alloy-rs/alloy/pull/727.