### PR TITLE
chore: remove validate_block_regarding_chain

### DIFF
--- a/crates/consensus/common/Cargo.toml
+++ b/crates/consensus/common/Cargo.toml
@@ -13,8 +13,6 @@ workspace = true
 [dependencies]
 # reth
 reth-primitives.workspace = true
-reth-interfaces.workspace = true
-reth-provider.workspace = true
 reth-consensus.workspace=true
 
 [dev-dependencies]

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -1,7 +1,6 @@
 //! Collection of methods for block validation.
 
 use reth_consensus::ConsensusError;
-use reth_interfaces::RethResult;
 use reth_primitives::{
     constants::{
         eip4844::{DATA_GAS_PER_BLOB, MAX_DATA_GAS_PER_BLOCK},
@@ -9,7 +8,6 @@ use reth_primitives::{
     },
     ChainSpec, GotExpected, Hardfork, Header, SealedBlock, SealedHeader,
 };
-use reth_provider::{HeaderProvider, WithdrawalsProvider};
 
 /// Validate header standalone
 pub fn validate_header_standalone(

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -175,7 +175,7 @@ mod tests {
         BlockNumber, Bytes, ChainSpecBuilder, Signature, Transaction, TransactionSigned, TxEip4844,
         Withdrawal, Withdrawals, U256,
     };
-    use reth_provider::AccountReader;
+    use reth_provider::{AccountReader, HeaderProvider, WithdrawalsProvider};
     use std::ops::RangeBounds;
 
     mock! {


### PR DESCRIPTION
This function was only used in tests, so this is removed now