### PR TITLE
feat(e2e): add helpers to TransactionTestContext

### DIFF
--- a/crates/ethereum/node/tests/e2e/blobs.rs
+++ b/crates/ethereum/node/tests/e2e/blobs.rs
@@ -46,7 +46,7 @@ async fn can_handle_blobs() -> eyre::Result<()> {
     let second_wallet = wallets.last().unwrap();
 
     // inject normal tx
-    let raw_tx = TransactionTestContext::transfer_tx(1, second_wallet.clone()).await;
+    let raw_tx = TransactionTestContext::transfer_tx_bytes(1, second_wallet.clone()).await;
     let tx_hash = node.rpc.inject_tx(raw_tx).await?;
     // build payload with normal tx
     let (payload, attributes) = node.new_payload(eth_payload_attributes).await?;
@@ -55,7 +55,7 @@ async fn can_handle_blobs() -> eyre::Result<()> {
     node.inner.pool.remove_transactions(vec![tx_hash]);
 
     // build blob tx
-    let blob_tx = TransactionTestContext::tx_with_blobs(1, blob_wallet.clone()).await?;
+    let blob_tx = TransactionTestContext::tx_with_blobs_bytes(1, blob_wallet.clone()).await?;
 
     // inject blob tx to the pool
     let blob_tx_hash = node.rpc.inject_tx(blob_tx).await?;

--- a/crates/ethereum/node/tests/e2e/eth.rs
+++ b/crates/ethereum/node/tests/e2e/eth.rs
@@ -30,7 +30,7 @@ async fn can_run_eth_node() -> eyre::Result<()> {
 
     let mut node = nodes.pop().unwrap();
     let wallet = Wallet::default();
-    let raw_tx = TransactionTestContext::transfer_tx(1, wallet.inner).await;
+    let raw_tx = TransactionTestContext::transfer_tx_bytes(1, wallet.inner).await;
 
     // make the node advance
     let tx_hash = node.rpc.inject_tx(raw_tx).await?;
@@ -78,7 +78,7 @@ async fn can_run_eth_node_with_auth_engine_api_over_ipc() -> eyre::Result<()> {
 
     // Configure wallet from test mnemonic and create dummy transfer tx
     let wallet = Wallet::default();
-    let raw_tx = TransactionTestContext::transfer_tx(1, wallet.inner).await;
+    let raw_tx = TransactionTestContext::transfer_tx_bytes(1, wallet.inner).await;
 
     // make the node advance
     let tx_hash = node.rpc.inject_tx(raw_tx).await?;

--- a/crates/ethereum/node/tests/e2e/p2p.rs
+++ b/crates/ethereum/node/tests/e2e/p2p.rs
@@ -21,7 +21,7 @@ async fn can_sync() -> eyre::Result<()> {
     )
     .await?;
 
-    let raw_tx = TransactionTestContext::transfer_tx(1, wallet.inner).await;
+    let raw_tx = TransactionTestContext::transfer_tx_bytes(1, wallet.inner).await;
     let mut second_node = nodes.pop().unwrap();
     let mut first_node = nodes.pop().unwrap();
 


### PR DESCRIPTION
Adds non-bytes-output helpers to `TransactionTestContext`