### PR TITLE
feat: deposit contract address conversion for genesis

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -299,21 +299,21 @@ alloy-dyn-abi = "0.7.2"
 alloy-sol-types = "0.7.2"
 alloy-rlp = "0.3.4"
 alloy-trie = "0.3.1"
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "dd25769" }
-alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "dd25769" }
-alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "dd25769" }
-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "dd25769" }
-alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", rev = "dd25769" }
-alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "dd25769" }
-alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", rev = "dd25769" }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "dd25769", default-features = false, features = [
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "9d3fa45" }
+alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "9d3fa45" }
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "9d3fa45" }
+alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "9d3fa45" }
+alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", rev = "9d3fa45" }
+alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "9d3fa45" }
+alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", rev = "9d3fa45" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "9d3fa45", default-features = false, features = [
     "reqwest",
 ] }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", default-features = false, rev = "dd25769" }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "dd25769" }
-alloy-signer-wallet = { git = "https://github.com/alloy-rs/alloy", rev = "dd25769" }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "dd25769" }
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "dd25769" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", default-features = false, rev = "9d3fa45" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "9d3fa45" }
+alloy-signer-wallet = { git = "https://github.com/alloy-rs/alloy", rev = "9d3fa45" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "9d3fa45" }
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "9d3fa45" }
 
 # misc
 auto_impl = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -299,21 +299,21 @@ alloy-dyn-abi = "0.7.2"
 alloy-sol-types = "0.7.2"
 alloy-rlp = "0.3.4"
 alloy-trie = "0.3.1"
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "9d3fa45" }
-alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "9d3fa45" }
-alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "9d3fa45" }
-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "9d3fa45" }
-alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", rev = "9d3fa45" }
-alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "9d3fa45" }
-alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", rev = "9d3fa45" }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "9d3fa45", default-features = false, features = [
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "dd25769" }
+alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "dd25769" }
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "dd25769" }
+alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "dd25769" }
+alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", rev = "dd25769" }
+alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "dd25769" }
+alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", rev = "dd25769" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "dd25769", default-features = false, features = [
     "reqwest",
 ] }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", default-features = false, rev = "9d3fa45" }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "9d3fa45" }
-alloy-signer-wallet = { git = "https://github.com/alloy-rs/alloy", rev = "9d3fa45" }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "9d3fa45" }
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "9d3fa45" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", default-features = false, rev = "dd25769" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "dd25769" }
+alloy-signer-wallet = { git = "https://github.com/alloy-rs/alloy", rev = "dd25769" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "dd25769" }
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "dd25769" }
 
 # misc
 auto_impl = "1"

--- a/crates/primitives/src/chain/mod.rs
+++ b/crates/primitives/src/chain/mod.rs
@@ -2,7 +2,8 @@ pub use alloy_chains::{Chain, ChainKind, NamedChain};
 pub use info::ChainInfo;
 pub use spec::{
     AllGenesisFormats, BaseFeeParams, BaseFeeParamsKind, ChainSpec, ChainSpecBuilder,
-    DisplayHardforks, ForkBaseFeeParams, ForkCondition, DEV, GOERLI, HOLESKY, MAINNET, SEPOLIA,
+    DepositContract, DisplayHardforks, ForkBaseFeeParams, ForkCondition, DEV, GOERLI, HOLESKY,
+    MAINNET, SEPOLIA,
 };
 #[cfg(feature = "optimism")]
 pub use spec::{BASE_MAINNET, BASE_SEPOLIA, OP_MAINNET, OP_SEPOLIA};

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -1611,6 +1611,7 @@ pub struct DepositContract {
 }
 
 impl DepositContract {
+    /// Creates a new deposit contract with the given address, block, and topic.
     pub const fn new(address: Address, block: BlockNumber, topic: B256) -> Self {
         DepositContract { address, block, topic }
     }

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -1059,7 +1059,7 @@ impl From<Genesis> for ChainSpec {
             genesis_hash: None,
             hardforks,
             paris_block_and_final_difficulty,
-            deposit_contract: None,
+            deposit_contract: genesis.deposit_contract_address,
             ..Default::default()
         }
     }

--- a/crates/primitives/src/constants/mod.rs
+++ b/crates/primitives/src/constants/mod.rs
@@ -1,6 +1,10 @@
 //! Ethereum protocol-related constants
 
-use crate::{revm_primitives::b256, B256, U256};
+use crate::{
+    chain::DepositContract,
+    revm_primitives::{address, b256},
+    B256, U256,
+};
 use std::time::Duration;
 
 #[cfg(feature = "optimism")]
@@ -63,6 +67,13 @@ pub const EIP1559_DEFAULT_ELASTICITY_MULTIPLIER: u64 = 2;
 
 /// Minimum gas limit allowed for transactions.
 pub const MINIMUM_GAS_LIMIT: u64 = 5000;
+
+/// Deposit contract address
+pub const MAINNET_DEPOSIT_CONTRACT: DepositContract = DepositContract::new(
+    address!("00000000219ab540356cbb839cbe05303d7705fa"),
+    11052984,
+    b256!("649bbc62d0e31342afea4e5cd82d4049e7e1ee912fc0889aa790803be39038c5"),
+);
 
 /// Base fee max change denominator for Optimism Mainnet as defined in the Optimism
 /// [transaction costs](https://community.optimism.io/docs/developers/build/differences/#transaction-costs) doc.

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -57,14 +57,14 @@ pub use block::{
 };
 pub use chain::{
     AllGenesisFormats, BaseFeeParams, BaseFeeParamsKind, Chain, ChainInfo, ChainKind, ChainSpec,
-    ChainSpecBuilder, DisplayHardforks, ForkBaseFeeParams, ForkCondition, NamedChain, DEV, GOERLI,
-    HOLESKY, MAINNET, SEPOLIA,
+    ChainSpecBuilder, DepositContract, DisplayHardforks, ForkBaseFeeParams, ForkCondition,
+    NamedChain, DEV, GOERLI, HOLESKY, MAINNET, SEPOLIA,
 };
 #[cfg(feature = "zstd-codec")]
 pub use compression::*;
 pub use constants::{
     DEV_GENESIS_HASH, EMPTY_OMMER_ROOT_HASH, GOERLI_GENESIS_HASH, HOLESKY_GENESIS_HASH,
-    KECCAK_EMPTY, MAINNET_GENESIS_HASH, SEPOLIA_GENESIS_HASH,
+    KECCAK_EMPTY, MAINNET_DEPOSIT_CONTRACT, MAINNET_GENESIS_HASH, SEPOLIA_GENESIS_HASH,
 };
 pub use error::{GotExpected, GotExpectedBoxed};
 pub use exex::FinishedExExHeight;


### PR DESCRIPTION
Now that the deposit contract address is configurable in the genesis, this maps it to the `DepositContract` struct in our `Genesis -> ChainSpec` conversion