### PR TITLE
docs(network): update command instruction for the --trusted-only

### DIFF
--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -1276,7 +1276,7 @@ pub struct PeersConfig {
     /// How often to recheck free slots for outbound connections.
     #[cfg_attr(feature = "serde", serde(with = "humantime_serde"))]
     pub refill_slots_interval: Duration,
-    /// Trusted nodes to connect to.
+    /// Trusted nodes to connect to or accept from
     pub trusted_nodes: HashSet<NodeRecord>,
     /// Connect to or accept from trusted nodes only?
     #[cfg_attr(feature = "serde", serde(alias = "connect_trusted_nodes_only"))]

--- a/crates/node-core/src/args/network.rs
+++ b/crates/node-core/src/args/network.rs
@@ -21,6 +21,7 @@ use reth_primitives::{mainnet_nodes, ChainSpec, NodeRecord};
 use secp256k1::SecretKey;
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    ops::Not,
     path::PathBuf,
     sync::Arc,
 };
@@ -158,7 +159,7 @@ impl NetworkArgs {
 
     /// If `no_persist_peers` is false then this returns the path to the persistent peers file path.
     pub fn persistent_peers_file(&self, peers_file: PathBuf) -> Option<PathBuf> {
-        (!self.no_persist_peers).then_some(peers_file)
+        self.no_persist_peers.not().then_some(peers_file)
     }
 
     /// Sets the p2p port to zero, to allow the OS to assign a random unused port when

--- a/crates/node-core/src/args/network.rs
+++ b/crates/node-core/src/args/network.rs
@@ -40,7 +40,7 @@ pub struct NetworkArgs {
     #[arg(long, value_delimiter = ',')]
     pub trusted_peers: Vec<NodeRecord>,
 
-    /// Connect to or accept from trusted peers only?
+    /// Connect to or accept from trusted peers only
     #[arg(long)]
     pub trusted_only: bool,
 

--- a/crates/node-core/src/args/network.rs
+++ b/crates/node-core/src/args/network.rs
@@ -39,7 +39,7 @@ pub struct NetworkArgs {
     #[arg(long, value_delimiter = ',')]
     pub trusted_peers: Vec<NodeRecord>,
 
-    /// Connect only to trusted peers
+    /// Connect to or accept from trusted peers only?
     #[arg(long)]
     pub trusted_only: bool,
 
@@ -258,12 +258,12 @@ pub struct DiscoveryArgs {
 
     /// The interval in seconds at which to carry out boost lookup queries, for a fixed number of
     /// times, at bootstrap.
-    #[arg(id = "discovery.v5.bootstrap.lookup-interval", long = "discovery.v5.bootstrap.lookup-interval", value_name = "DISCOVERY_V5_bootstrap_lookup_interval", 
+    #[arg(id = "discovery.v5.bootstrap.lookup-interval", long = "discovery.v5.bootstrap.lookup-interval", value_name = "DISCOVERY_V5_bootstrap_lookup_interval",
         default_value_t = DEFAULT_SECONDS_BOOTSTRAP_LOOKUP_INTERVAL)]
     pub discv5_bootstrap_lookup_interval: u64,
 
     /// The number of times to carry out boost lookup queries at bootstrap.
-    #[arg(id = "discovery.v5.bootstrap.lookup-countdown", long = "discovery.v5.bootstrap.lookup-countdown", value_name = "DISCOVERY_V5_bootstrap_lookup_countdown", 
+    #[arg(id = "discovery.v5.bootstrap.lookup-countdown", long = "discovery.v5.bootstrap.lookup-countdown", value_name = "DISCOVERY_V5_bootstrap_lookup_countdown",
         default_value_t = DEFAULT_COUNT_BOOTSTRAP_LOOKUPS)]
     pub discv5_bootstrap_lookup_countdown: u64,
 }

--- a/crates/node-core/src/args/network.rs
+++ b/crates/node-core/src/args/network.rs
@@ -156,13 +156,9 @@ impl NetworkArgs {
         self.discovery.apply_to_builder(network_config_builder)
     }
 
-    /// If `no_persist_peers` is true then this returns the path to the persistent peers file path.
+    /// If `no_persist_peers` is false then this returns the path to the persistent peers file path.
     pub fn persistent_peers_file(&self, peers_file: PathBuf) -> Option<PathBuf> {
-        if self.no_persist_peers {
-            return None
-        }
-
-        Some(peers_file)
+        (!self.no_persist_peers).then_some(peers_file)
     }
 
     /// Sets the p2p port to zero, to allow the OS to assign a random unused port when


### PR DESCRIPTION
1. update the instructions for `--trusted-only` 
2. use `bool.then_some` to simply the single bool branch
3. fix the opposite comment of `no_persist_peers`