### PR TITLE
fix: use calc_authcall_gas that uses 6700

### DIFF
--- a/crates/ethereum/evm/src/instructions/eip3074.rs
+++ b/crates/ethereum/evm/src/instructions/eip3074.rs
@@ -33,7 +33,7 @@ const FIXED_FEE_GAS: u64 = 3100;
 const AUTHORIZED_VAR_NAME: &str = "authorized";
 /// The gas that should be consumed for authcall transactions.
 ///
-/// From the spec: `NB: Not 9000, like in `CALL`
+/// From the spec: `NB: Not 9000, like in CALL`
 const AUTH_CALL_GAS: u64 = 6700;
 
 /// Generates an iterator over EIP3074 boxed instructions. Defining the

--- a/crates/ethereum/evm/src/instructions/eip3074.rs
+++ b/crates/ethereum/evm/src/instructions/eip3074.rs
@@ -632,7 +632,7 @@ mod tests {
         assert_eq!(interpreter.instruction_result, InstructionResult::CallOrCreate);
 
         // check gas
-        let expected_gas = 66612;
+        let expected_gas = 64312;
         assert_eq!(expected_gas, interpreter.gas.spent());
 
         // check next action

--- a/crates/ethereum/evm/src/instructions/eip3074.rs
+++ b/crates/ethereum/evm/src/instructions/eip3074.rs
@@ -1,12 +1,11 @@
 use crate::instructions::{context::InstructionsContext, BoxedInstructionWithOpCode};
 use reth_revm::{Context, Database};
 use revm_interpreter::{
-    Host,
     gas,
     gas::{warm_cold_cost, NEWACCOUNT},
     instructions::contract::get_memory_input_and_out_ranges,
-    pop, pop_address, push, resize_memory, CallInputs, CallScheme, CallValue, InstructionResult,
-    Interpreter, InterpreterAction, LoadAccountResult,
+    pop, pop_address, push, resize_memory, CallInputs, CallScheme, CallValue, Host,
+    InstructionResult, Interpreter, InterpreterAction, LoadAccountResult,
 };
 use revm_precompile::secp256k1::ecrecover;
 use revm_primitives::{
@@ -278,9 +277,9 @@ fn authcall_instruction<EXT, DB: Database>(
         evm.evm.spec_id(),
         calc_authcall_gas::<SPEC>(
             interp,
-            is_cold,                // is_cold
+            is_cold,             // is_cold
             value != U256::ZERO, // has_transfer
-            is_empty,                // new_account_accounting
+            is_empty,            // new_account_accounting
             local_gas_limit,
         )
     ) else {


### PR DESCRIPTION
Adds new methods `calc_authcall_gas` and `authcall_cost` which are used instead of `calc_call_gas` due to this in the 3074 spec:
```python
if value > 0:
    dynamic_gas += 6700         # NB: Not 9000, like in `CALL`
    if is_empty(addr):
        dynamic_gas += 25000
```