### PR TITLE
fix: allow to call V1 methods post-Shanghai

### DIFF
--- a/crates/engine-primitives/src/lib.rs
+++ b/crates/engine-primitives/src/lib.rs
@@ -159,10 +159,6 @@ pub fn validate_withdrawals_presence(
                 return Err(message_validation_kind
                     .to_error(VersionSpecificValidationError::WithdrawalsNotSupportedInV1))
             }
-            if is_shanghai_active {
-                return Err(message_validation_kind
-                    .to_error(VersionSpecificValidationError::NoWithdrawalsPostShanghai))
-            }
         }
         EngineApiMessageVersion::V2 | EngineApiMessageVersion::V3 | EngineApiMessageVersion::V4 => {
             if is_shanghai_active && !has_withdrawals {


### PR DESCRIPTION
The execution specs only states that V1 versions of `engine_newPayloadV1` and `engine_forkChoiceUpdateV1` should be validated by the consensus client not the execution client. 

With these changes reth will stop returning an error in this case, same as geth does.