### PR TITLE
fix(revm): increment nonce of EIP-2935 account

### DIFF
--- a/crates/revm/src/state_change.rs
+++ b/crates/revm/src/state_change.rs
@@ -104,9 +104,9 @@ where
     let mut account = Account::from(AccountInfo::default());
 
     // HACK(onbjerg): This is a temporary workaround to make sure the account does not get cleared
-    // by state clearing later. This balance will likely be present in the devnet 0 genesis file
+    // by state clearing later. This nonce will likely be present in the devnet 0 genesis file
     // until the EIP itself is fixed.
-    account.info.balance = U256::from(1);
+    account.info.nonce = 1;
 
     // We load the `HISTORY_STORAGE_ADDRESS` account because REVM expects this to be loaded in order
     // to access any storage, which we will do below.
@@ -311,7 +311,7 @@ where
     // get previous env
     let previous_env = Box::new(evm.context.env().clone());
 
-    // modify env for pre block call
+    // modify env for post block call
     fill_tx_env_with_withdrawal_requests_contract_call(&mut evm.context.evm.env);
 
     let ResultAndState { result, mut state } = match evm.transact() {


### PR DESCRIPTION
devnet-0 genesis file has a nonce of `1` for this account, and not a balance of `1`