### PR TITLE
fix: state root order empty block

### DIFF
--- a/crates/payload/ethereum/src/lib.rs
+++ b/crates/payload/ethereum/src/lib.rs
@@ -153,6 +153,26 @@ where
             err
         })?;
 
+        // Calculate the requests and the requests root.
+        let (requests, requests_root) =
+            if chain_spec.is_prague_active_at_timestamp(attributes.timestamp) {
+                // We do not calculate the EIP-6110 deposit requests because there are no
+                // transactions in an empty payload.
+                let withdrawal_requests = post_block_withdrawal_requests_contract_call(
+                    &mut db,
+                    &chain_spec,
+                    &initialized_cfg,
+                    &initialized_block_env,
+                    &attributes,
+                )?;
+
+                let requests = withdrawal_requests;
+                let requests_root = calculate_requests_root(&requests);
+                (Some(requests.into()), Some(requests_root))
+            } else {
+                (None, None)
+            };
+
         // merge all transitions into bundle state, this would apply the withdrawal balance
         // changes and 4788 contract call
         db.merge_transitions(BundleRetention::PlainState);
@@ -184,26 +204,6 @@ where
 
             blob_gas_used = Some(0);
         }
-
-        // Calculate the requests and the requests root.
-        let (requests, requests_root) =
-            if chain_spec.is_prague_active_at_timestamp(attributes.timestamp) {
-                // We do not calculate the EIP-6110 deposit requests because there are no
-                // transactions in an empty payload.
-                let withdrawal_requests = post_block_withdrawal_requests_contract_call(
-                    &mut db,
-                    &chain_spec,
-                    &initialized_cfg,
-                    &initialized_block_env,
-                    &attributes,
-                )?;
-
-                let requests = withdrawal_requests;
-                let requests_root = calculate_requests_root(&requests);
-                (Some(requests.into()), Some(requests_root))
-            } else {
-                (None, None)
-            };
 
         let header = Header {
             parent_hash: parent_block.hash(),


### PR DESCRIPTION
7002 syscall must happen before we calc the state root on empty block