### PR TITLE
fix(make): use the default rust dir for build/build-op

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,11 +59,11 @@ install-op: ## Build and install the op-reth binary under `~/.cargo/bin`.
 
 .PHONY: build
 build: ## Build the reth binary into `target` directory.
-	$(MAKE) build-native-$(shell rustc -Vv | grep host | cut -d ' ' -f2)
+	cargo build --bin reth --features "$(FEATURES)" --profile "$(PROFILE)"
 
 .PHONY: build-op
 build-op: ## Build the op-reth binary into `target` directory.
-	$(MAKE) op-build-native-$(shell rustc -Vv | grep host | cut -d ' ' -f2)
+	cargo build --bin op-reth --features "optimism,$(FEATURES)" --profile "$(PROFILE)"
 
 # Builds the reth binary natively.
 build-native-%:

--- a/Makefile
+++ b/Makefile
@@ -303,8 +303,7 @@ db-tools: ## Compile MDBX debugging tools.
 	@echo "Run \"$(DB_TOOLS_DIR)/mdbx_chk\" for the MDBX db file integrity check."
 
 .PHONY: update-book-cli
-update-book-cli: ## Update book cli documentation.
-	cargo build --bin reth --features "$(FEATURES)" --profile "$(PROFILE)"
+update-book-cli: build ## Update book cli documentation.
 	@echo "Updating book cli doc..."
 	@./book/cli/update.sh $(BUILD_PATH)/$(PROFILE)/reth
 


### PR DESCRIPTION
Currently, we use `cargo build --target $(shell rustc -Vv | grep host | cut -d ' ' -f2)` to run the `make build` process, this will put the result into the directory as below:

```
target/aarch64-apple-darwin/release/reth # for macOS
target/x86_64-unknown-linux-gnu/release/reth # for Linux
```

This is inconvenience to run reth command(eg: `./target/aarch64-apple-darwin/release/reth node --dev`), so propose to use the default rust target directory(target/{release,debug}) for the build process.