### PR TITLE
chore: install apt-get deps before cargo deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ WORKDIR /app
 LABEL org.opencontainers.image.source=https://github.com/paradigmxyz/reth
 LABEL org.opencontainers.image.licenses="MIT OR Apache-2.0"
 
+# Install system dependencies
+RUN apt-get update && apt-get -y upgrade && apt-get install -y libclang-dev pkg-config
+
 # Builds a cargo-chef plan
 FROM chef AS planner
 COPY . .
@@ -23,9 +26,6 @@ ENV RUSTFLAGS "$RUSTFLAGS"
 # Extra Cargo features
 ARG FEATURES=""
 ENV FEATURES $FEATURES
-
-# Install system dependencies
-RUN apt-get update && apt-get -y upgrade && apt-get install -y libclang-dev pkg-config
 
 # Builds dependencies
 RUN cargo chef cook --profile $BUILD_PROFILE --features "$FEATURES" --recipe-path recipe.json


### PR DESCRIPTION
Let's cache system dependencies before copying the changed sources