### PR TITLE
fix: make payload to block fns sound

### DIFF
--- a/crates/rpc/rpc-types-compat/src/engine/payload.rs
+++ b/crates/rpc/rpc-types-compat/src/engine/payload.rs
@@ -425,8 +425,7 @@ mod tests {
         let parent_beacon_block_root =
             b256!("531cd53b8e68deef0ea65edfa3cda927a846c307b0907657af34bc3f313b5871");
 
-        let mut block =
-            try_payload_v3_to_block(new_payload.clone(), parent_beacon_block_root).unwrap();
+        let block = try_payload_v3_to_block(new_payload.clone(), parent_beacon_block_root).unwrap();
 
         let converted_payload = block_to_payload_v3(block.seal_slow());
 

--- a/crates/rpc/rpc-types-compat/src/engine/payload.rs
+++ b/crates/rpc/rpc-types-compat/src/engine/payload.rs
@@ -80,21 +80,32 @@ pub fn try_payload_v2_to_block(payload: ExecutionPayloadV2) -> Result<Block, Pay
 }
 
 /// Converts [ExecutionPayloadV3] to [Block]
-pub fn try_payload_v3_to_block(payload: ExecutionPayloadV3) -> Result<Block, PayloadError> {
+///
+/// This requires the [EIP-4788](https://eips.ethereum.org/EIPS/eip-4788) parent beacon block root
+pub fn try_payload_v3_to_block(
+    payload: ExecutionPayloadV3,
+    parent_beacon_block_root: B256,
+) -> Result<Block, PayloadError> {
     // this performs the same conversion as the underlying V2 payload, but inserts the blob gas
     // used and excess blob gas
     let mut base_block = try_payload_v2_to_block(payload.payload_inner)?;
 
     base_block.header.blob_gas_used = Some(payload.blob_gas_used);
     base_block.header.excess_blob_gas = Some(payload.excess_blob_gas);
+    base_block.header.parent_beacon_block_root = Some(parent_beacon_block_root);
 
     Ok(base_block)
 }
 
 /// Converts [ExecutionPayloadV4] to [Block]
-pub fn try_payload_v4_to_block(payload: ExecutionPayloadV4) -> Result<Block, PayloadError> {
+///
+/// This requires the [EIP-4788](https://eips.ethereum.org/EIPS/eip-4788) parent beacon block root
+pub fn try_payload_v4_to_block(
+    payload: ExecutionPayloadV4,
+    parent_beacon_block_root: B256,
+) -> Result<Block, PayloadError> {
     let ExecutionPayloadV4 { payload_inner, deposit_requests, withdrawal_requests } = payload;
-    let mut block = try_payload_v3_to_block(payload_inner)?;
+    let mut block = try_payload_v3_to_block(payload_inner, parent_beacon_block_root)?;
 
     // attach requests with asc type identifiers
     let requests = deposit_requests
@@ -276,14 +287,18 @@ pub fn try_into_block(
     value: ExecutionPayload,
     parent_beacon_block_root: Option<B256>,
 ) -> Result<Block, PayloadError> {
-    let mut base_payload = match value {
+    let base_payload = match value {
         ExecutionPayload::V1(payload) => try_payload_v1_to_block(payload)?,
         ExecutionPayload::V2(payload) => try_payload_v2_to_block(payload)?,
-        ExecutionPayload::V3(payload) => try_payload_v3_to_block(payload)?,
-        ExecutionPayload::V4(payload) => try_payload_v4_to_block(payload)?,
+        ExecutionPayload::V3(payload) => try_payload_v3_to_block(
+            payload,
+            parent_beacon_block_root.ok_or_else(|| PayloadError::PostCancunWithoutCancunFields)?,
+        )?,
+        ExecutionPayload::V4(payload) => try_payload_v4_to_block(
+            payload,
+            parent_beacon_block_root.ok_or_else(|| PayloadError::PostCancunWithoutCancunFields)?,
+        )?,
     };
-
-    base_payload.header.parent_beacon_block_root = parent_beacon_block_root;
 
     Ok(base_payload)
 }
@@ -367,11 +382,12 @@ pub fn execution_payload_from_sealed_block(value: SealedBlock) -> ExecutionPaylo
 #[cfg(test)]
 mod tests {
     use super::{
-        block_to_payload_v3, try_into_block, try_payload_v3_to_block, validate_block_hash,
+        block_to_payload_v3, try_into_block, try_payload_v3_to_block, try_payload_v4_to_block,
+        validate_block_hash,
     };
-    use reth_primitives::{b256, hex, Bytes, U256};
+    use reth_primitives::{b256, hex, Bytes, B256, U256};
     use reth_rpc_types::{
-        engine::{CancunPayloadFields, ExecutionPayloadV3},
+        engine::{CancunPayloadFields, ExecutionPayloadV3, ExecutionPayloadV4},
         ExecutionPayload, ExecutionPayloadV1, ExecutionPayloadV2,
     };
 
@@ -404,13 +420,13 @@ mod tests {
             excess_blob_gas: 0x580000,
         };
 
-        let mut block = try_payload_v3_to_block(new_payload.clone()).unwrap();
-
         // this newPayload came with a parent beacon block root, we need to manually insert it
         // before hashing
         let parent_beacon_block_root =
-            hex!("531cd53b8e68deef0ea65edfa3cda927a846c307b0907657af34bc3f313b5871");
-        block.header.parent_beacon_block_root = Some(parent_beacon_block_root.into());
+            b256!("531cd53b8e68deef0ea65edfa3cda927a846c307b0907657af34bc3f313b5871");
+
+        let mut block =
+            try_payload_v3_to_block(new_payload.clone(), parent_beacon_block_root).unwrap();
 
         let converted_payload = block_to_payload_v3(block.seal_slow());
 
@@ -447,7 +463,7 @@ mod tests {
             excess_blob_gas: 0x580000,
         };
 
-        let _block = try_payload_v3_to_block(new_payload)
+        let _block = try_payload_v3_to_block(new_payload, B256::random())
             .expect_err("execution payload conversion requires typed txs without a rlp header");
     }
 
@@ -594,5 +610,55 @@ mod tests {
 
         // Ensure the actual hash is calculated if we set the fields to what they should be
         validate_block_hash(block_hash_with_blob_fee_fields, block).unwrap();
+    }
+
+    #[test]
+    fn parse_payload_v4() {
+        let s = r#"{
+      "baseFeePerGas": "0x2ada43",
+      "blobGasUsed": "0x0",
+      "blockHash": "0xedfe4ef7d8a7c116f68f7e72bdb75be157bedf03ac8b63fa8d5762495b0473d3",
+      "blockNumber": "0x2c",
+      "depositRequests": [
+        {
+          "amount": "0xe8d4a51000",
+          "index": "0x0",
+          "pubkey": "0xaab5f2b3aad5c2075faf0c1d8937c7de51a53b765a21b4173eb2975878cea05d9ed3428b77f16a981716aa32af74c464",
+          "signature": "0xa889cd238be2dae44f2a3c24c04d686c548f6f82eb44d4604e1bc455b6960efb72b117e878068a8f2cfb91ad84b7ebce05b9254207aa51a1e8a3383d75b5a5bd2439f707636ea5b17b2b594b989c93b000b33e5dff6e4bed9d53a6d2d6889b0c",
+          "withdrawalCredentials": "0x00ab9364f8bf7561862ea0fc3b69c424c94ace406c4dc36ddfbf8a9d72051c80"
+        },
+        {
+          "amount": "0xe8d4a51000",
+          "index": "0x1",
+          "pubkey": "0xb0b1b3b51cf688ead965a954c5cc206ba4e76f3f8efac60656ae708a9aad63487a2ca1fb30ccaf2ebe1028a2b2886b1b",
+          "signature": "0xb9759766e9bb191b1c457ae1da6cdf71a23fb9d8bc9f845eaa49ee4af280b3b9720ac4d81e64b1b50a65db7b8b4e76f1176a12e19d293d75574600e99fbdfecc1ab48edaeeffb3226cd47691d24473821dad0c6ff3973f03e4aa89f418933a56",
+          "withdrawalCredentials": "0x002d2b75f4a27f78e585a4735a40ab2437eceb12ec39938a94dc785a54d62513"
+        }
+      ],
+      "excessBlobGas": "0x0",
+      "extraData": "0x726574682f76302e322e302d626574612e372f6c696e7578",
+      "feeRecipient": "0x8943545177806ed17b9f23f0a21ee5948ecaa776",
+      "gasLimit": "0x1855e85",
+      "gasUsed": "0x25f98",
+      "logsBloom": "0x10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000",
+      "parentHash": "0xd753194ef19b5c566b7eca6e9ebcca03895b548e1e93a20a23d922ba0bc210d4",
+      "prevRandao": "0x8c52256fd491776dc32f531ad4c0dc1444684741bca15f54c9cd40c60142df90",
+      "receiptsRoot": "0x510e7fb94279897e5dcd6c1795f6137d8fe02e49e871bfea7999fd21a89f66aa",
+      "stateRoot": "0x59ae0706a2b47162666fc7af3e30ff7aa34154954b68cc6aed58c3af3d58c9c2",
+      "timestamp": "0x6643c5a9",
+      "transactions": [
+        "0x02f9021e8330182480843b9aca0085174876e80083030d40944242424242424242424242424242424242424242893635c9adc5dea00000b901a422895118000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000000012049f42823819771c6bbbd9cb6649850083fd3b6e5d0beb1069342c32d65a3b0990000000000000000000000000000000000000000000000000000000000000030aab5f2b3aad5c2075faf0c1d8937c7de51a53b765a21b4173eb2975878cea05d9ed3428b77f16a981716aa32af74c46400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000ab9364f8bf7561862ea0fc3b69c424c94ace406c4dc36ddfbf8a9d72051c800000000000000000000000000000000000000000000000000000000000000060a889cd238be2dae44f2a3c24c04d686c548f6f82eb44d4604e1bc455b6960efb72b117e878068a8f2cfb91ad84b7ebce05b9254207aa51a1e8a3383d75b5a5bd2439f707636ea5b17b2b594b989c93b000b33e5dff6e4bed9d53a6d2d6889b0cc080a0db786f0d89923949e533680524f003cebd66f32fbd30429a6b6bfbd3258dcf60a05241c54e05574765f7ddc1a742ae06b044edfe02bffb202bf172be97397eeca9",
+        "0x02f9021e8330182401843b9aca0085174876e80083030d40944242424242424242424242424242424242424242893635c9adc5dea00000b901a422895118000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000000000000000000000000000000000000000120d694d6a0b0103651aafd87db6c88297175d7317c6e6da53ccf706c3c991c91fd0000000000000000000000000000000000000000000000000000000000000030b0b1b3b51cf688ead965a954c5cc206ba4e76f3f8efac60656ae708a9aad63487a2ca1fb30ccaf2ebe1028a2b2886b1b000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020002d2b75f4a27f78e585a4735a40ab2437eceb12ec39938a94dc785a54d625130000000000000000000000000000000000000000000000000000000000000060b9759766e9bb191b1c457ae1da6cdf71a23fb9d8bc9f845eaa49ee4af280b3b9720ac4d81e64b1b50a65db7b8b4e76f1176a12e19d293d75574600e99fbdfecc1ab48edaeeffb3226cd47691d24473821dad0c6ff3973f03e4aa89f418933a56c080a099dc5b94a51e9b91a6425b1fed9792863006496ab71a4178524819d7db0c5e88a0119748e62700234079d91ae80f4676f9e0f71b260e9b46ef9b4aff331d3c2318"
+      ],
+      "withdrawalRequests": [],
+      "withdrawals": []
+    }"#;
+
+        let parent_beacon_block =
+            b256!("d9851db05fa63593f75e2b12c4bba9f47740613ca57da3b523a381b8c27f3297");
+
+        let payload = serde_json::from_str::<ExecutionPayloadV4>(s).unwrap();
+        let block = try_payload_v4_to_block(payload, parent_beacon_block).unwrap().seal_slow();
+        let _hash = block.hash();
     }
 }


### PR DESCRIPTION
the payload to block conversion fn for v3 and v4 were unsound, this moves the parent beacon block update from try_from_payload to the versioned functions