### PR TITLE
fix: Make L1 tx data fee calculation aware of Ecotone hardfork

### DIFF
--- a/crates/optimism/evm/src/l1.rs
+++ b/crates/optimism/evm/src/l1.rs
@@ -190,7 +190,9 @@ impl RethL1BlockInfo for L1BlockInfo {
             return Ok(U256::ZERO)
         }
 
-        let spec_id = if chain_spec.is_fork_active_at_timestamp(Hardfork::Regolith, timestamp) {
+        let spec_id = if chain_spec.is_fork_active_at_timestamp(Hardfork::Ecotone, timestamp) {
+            SpecId::ECOTONE
+        } else if chain_spec.is_fork_active_at_timestamp(Hardfork::Regolith, timestamp) {
             SpecId::REGOLITH
         } else if chain_spec.is_fork_active_at_timestamp(Hardfork::Bedrock, timestamp) {
             SpecId::BEDROCK


### PR DESCRIPTION
Ensure that the Ecotone spec is passed into revm L1 cost calculations when this active, as this hardfork introduced a [new cost function](https://github.com/bluealloy/revm/blob/84d1372e072564ae4f3334a60e9074d2790f6293/crates/revm/src/optimism/l1block.rs#L148-L149).