### PR TITLE
feat: Enable Fjord L1 data cost function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5462,6 +5462,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.8",
+]
+
+[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5868,6 +5880,15 @@ checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
  "syn 2.0.66",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -8196,8 +8217,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a2c336f9921588e50871c00024feb51a521eca50ce6d01494bb9c50f837c8ed"
+source = "git+https://github.com/bluealloy/revm?rev=a28a543#a28a5439b9cfb7494cbd670da10cbedcfe6c5854"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -8211,7 +8231,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/evm-inspectors?rev=5a4fd5e#5a4fd5e394d8bdf1337ac076d0b5fde4f2dd617c"
+source = "git+https://github.com/BrianBland/revm-inspectors?rev=9a32b2b#9a32b2bf63136447c66d5b06d3be1f1443d32737"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=64feb9b)",
@@ -8229,8 +8249,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a58182c7454179826f9dad2ca577661963092ce9d0fd0c9d682c1e9215a72e70"
+source = "git+https://github.com/bluealloy/revm?rev=a28a543#a28a5439b9cfb7494cbd670da10cbedcfe6c5854"
 dependencies = [
  "revm-primitives",
  "serde",
@@ -8239,13 +8258,13 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc8af9aa737eef0509a50d9f3cc1a631557a00ef2e70a3aa8a75d9ee0ed275bb"
+source = "git+https://github.com/bluealloy/revm?rev=a28a543#a28a5439b9cfb7494cbd670da10cbedcfe6c5854"
 dependencies = [
  "aurora-engine-modexp",
  "c-kzg",
  "k256",
  "once_cell",
+ "p256",
  "revm-primitives",
  "ripemd",
  "secp256k1 0.29.0",
@@ -8256,8 +8275,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9bf5d465e64b697da6a111cb19e798b5b2ebb18e5faf2ad48e9e8d47c64add2"
+source = "git+https://github.com/bluealloy/revm?rev=a28a543#a28a5439b9cfb7494cbd670da10cbedcfe6c5854"
 dependencies = [
  "alloy-primitives",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -300,14 +300,14 @@ reth-trie = { path = "crates/trie" }
 reth-trie-parallel = { path = "crates/trie-parallel" }
 
 # revm
-revm = { version = "9.0.0", features = [
+revm = { git = "https://github.com/bluealloy/revm", rev = "a28a543", features = [
     "std",
     "secp256k1",
 ], default-features = false }
-revm-primitives = { version = "4.0.0", features = [
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "a28a543", features = [
     "std",
 ], default-features = false }
-revm-inspectors = { git = "https://github.com/paradigmxyz/evm-inspectors", rev = "5a4fd5e" }
+revm-inspectors = { git = "https://github.com/BrianBland/revm-inspectors", rev = "9a32b2b" }
 
 # eth
 alloy-chains = "0.1.15"

--- a/crates/optimism/evm/src/l1.rs
+++ b/crates/optimism/evm/src/l1.rs
@@ -190,7 +190,9 @@ impl RethL1BlockInfo for L1BlockInfo {
             return Ok(U256::ZERO)
         }
 
-        let spec_id = if chain_spec.is_fork_active_at_timestamp(Hardfork::Ecotone, timestamp) {
+        let spec_id = if chain_spec.is_fork_active_at_timestamp(Hardfork::Fjord, timestamp) {
+            SpecId::FJORD
+        } else if chain_spec.is_fork_active_at_timestamp(Hardfork::Ecotone, timestamp) {
             SpecId::ECOTONE
         } else if chain_spec.is_fork_active_at_timestamp(Hardfork::Regolith, timestamp) {
             SpecId::REGOLITH
@@ -211,7 +213,9 @@ impl RethL1BlockInfo for L1BlockInfo {
         timestamp: u64,
         input: &[u8],
     ) -> Result<U256, BlockExecutionError> {
-        let spec_id = if chain_spec.is_fork_active_at_timestamp(Hardfork::Regolith, timestamp) {
+        let spec_id = if chain_spec.is_fork_active_at_timestamp(Hardfork::Fjord, timestamp) {
+            SpecId::FJORD
+        } else if chain_spec.is_fork_active_at_timestamp(Hardfork::Regolith, timestamp) {
             SpecId::REGOLITH
         } else if chain_spec.is_fork_active_at_timestamp(Hardfork::Bedrock, timestamp) {
             SpecId::BEDROCK

--- a/crates/primitives/src/revm/compat.rs
+++ b/crates/primitives/src/revm/compat.rs
@@ -36,7 +36,5 @@ pub fn calculate_intrinsic_gas_after_merge(
     is_shanghai: bool,
 ) -> u64 {
     let spec_id = if is_shanghai { SpecId::SHANGHAI } else { SpecId::MERGE };
-    // TODO(EOF)
-    let initcodes = &[];
-    validate_initial_tx_gas(spec_id, input, kind.is_create(), access_list, initcodes)
+    validate_initial_tx_gas(spec_id, input, kind.is_create(), access_list)
 }

--- a/crates/primitives/src/revm/env.rs
+++ b/crates/primitives/src/revm/env.rs
@@ -171,9 +171,6 @@ pub fn fill_tx_env_with_beacon_root_contract_call(env: &mut Env, parent_beacon_b
             // enveloped tx size.
             enveloped_tx: Some(Bytes::default()),
         },
-        // TODO(EOF)
-        eof_initcodes: vec![],
-        eof_initcodes_hashed: Default::default(),
     };
 
     // ensure the block gas limit is >= the tx


### PR DESCRIPTION
Follow-up to #8268, adding support for the Fjord hardfork to both the `l1_tx_data_fee` and `l1_data_gas` methods on `RethL1BlockInfo`.

Note: this currently depends on an unmerged `revm` commit, but will be cleaned up prior to merging. The associated `revm` changes can be tracked at https://github.com/bluealloy/revm/pull/1420 for now