### PR TITLE
fix: request encoding for requests

### DIFF
--- a/crates/primitives/src/proofs.rs
+++ b/crates/primitives/src/proofs.rs
@@ -77,8 +77,6 @@ pub fn calculate_receipt_root(receipts: &[ReceiptWithBloom]) -> B256 {
 /// Calculate [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) requests root.
 ///
 /// NOTE: The requests are encoded as `id + request`
-///
-/// See also [Encodable7685] and <https://github.com/ethereum/go-ethereum/blob/main/core/types/request.go#L108-L112>
 pub fn calculate_requests_root(requests: &[Request]) -> B256 {
     ordered_trie_root_with_encoder(requests, |item, buf| item.encode_7685(buf))
 }

--- a/crates/primitives/src/proofs.rs
+++ b/crates/primitives/src/proofs.rs
@@ -8,6 +8,7 @@ use crate::{
     B256, U256,
 };
 use alloy_consensus::Request;
+use alloy_eips::eip7685::Encodable7685;
 use alloy_rlp::Encodable;
 use bytes::BufMut;
 use itertools::Itertools;
@@ -73,9 +74,13 @@ pub fn calculate_receipt_root(receipts: &[ReceiptWithBloom]) -> B256 {
     ordered_trie_root_with_encoder(receipts, |r, buf| r.encode_inner(buf, false))
 }
 
-/// Calculate EIP-7685 requests root.
+/// Calculate [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) requests root.
+///
+/// NOTE: The requests are encoded as `id + request`
+///
+/// See also [Encodable7685] and <https://github.com/ethereum/go-ethereum/blob/main/core/types/request.go#L108-L112>
 pub fn calculate_requests_root(requests: &[Request]) -> B256 {
-    ordered_trie_root(requests)
+    ordered_trie_root_with_encoder(requests, |item, buf| item.encode_7685(buf))
 }
 
 /// Calculates the receipt root for a header.

--- a/crates/rpc/rpc-types-compat/src/engine/payload.rs
+++ b/crates/rpc/rpc-types-compat/src/engine/payload.rs
@@ -616,7 +616,7 @@ mod tests {
         let s = r#"{
       "baseFeePerGas": "0x2ada43",
       "blobGasUsed": "0x0",
-      "blockHash": "0xedfe4ef7d8a7c116f68f7e72bdb75be157bedf03ac8b63fa8d5762495b0473d3",
+      "blockHash": "0x86eeb2a4b656499f313b601e1dcaedfeacccab27131b6d4ea99bc69a57607f7d",
       "blockNumber": "0x2c",
       "depositRequests": [
         {
@@ -658,6 +658,7 @@ mod tests {
 
         let payload = serde_json::from_str::<ExecutionPayloadV4>(s).unwrap();
         let block = try_payload_v4_to_block(payload, parent_beacon_block).unwrap().seal_slow();
-        let _hash = block.hash();
+        let hash = block.hash();
+        assert_eq!(hash, b256!("86eeb2a4b656499f313b601e1dcaedfeacccab27131b6d4ea99bc69a57607f7d"))
     }
 }


### PR DESCRIPTION
for the request trie we need to encode using the 7685 trait

see also https://github.com/lightclient/go-ethereum/blob/bad02c134ffa8acb1e26dc63cbeae9c92067abcf/core/types/request.go#L108-L111