### PR TITLE
fix: enc/dec rlp for `Requests`

### DIFF
--- a/crates/primitives/src/request.rs
+++ b/crates/primitives/src/request.rs
@@ -1,12 +1,14 @@
 //! EIP-7685 requests.
 
 use alloy_consensus::Request;
-use alloy_rlp::{RlpDecodableWrapper, RlpEncodableWrapper};
+use alloy_eips::eip7685::{Decodable7685, Encodable7685};
+use alloy_rlp::{Decodable, Encodable};
 use reth_codecs::{main_codec, Compact};
+use revm_primitives::Bytes;
 
 /// A list of EIP-7685 requests.
 #[main_codec]
-#[derive(Debug, Clone, PartialEq, Eq, Default, Hash, RlpEncodableWrapper, RlpDecodableWrapper)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Hash)]
 pub struct Requests(pub Vec<Request>);
 
 impl From<Vec<Request>> for Requests {
@@ -21,5 +23,27 @@ impl IntoIterator for Requests {
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
+    }
+}
+
+impl Encodable for Requests {
+    fn encode(&self, out: &mut dyn bytes::BufMut) {
+        self.0
+            .iter()
+            .map(Encodable7685::encoded_7685)
+            .map(Bytes::from)
+            .collect::<Vec<_>>()
+            .encode(out)
+    }
+}
+
+impl Decodable for Requests {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        Ok(Self(
+            <Vec<Bytes> as Decodable>::decode(buf)?
+                .into_iter()
+                .map(|bytes| Request::decode_7685(&mut bytes.as_ref()))
+                .collect::<Result<Vec<_>, alloy_eips::eip7685::Eip7685Error>>()?,
+        ))
     }
 }

--- a/crates/primitives/src/request.rs
+++ b/crates/primitives/src/request.rs
@@ -2,8 +2,7 @@
 
 use alloy_consensus::Request;
 use alloy_eips::eip7685::{Decodable7685, Encodable7685};
-use alloy_rlp::{encode_iter, encode_list, Decodable, Encodable};
-use bytes::BufMut;
+use alloy_rlp::{Decodable, Encodable};
 use reth_codecs::{main_codec, Compact};
 use revm_primitives::Bytes;
 

--- a/crates/primitives/src/request.rs
+++ b/crates/primitives/src/request.rs
@@ -39,11 +39,10 @@ impl Encodable for Requests {
 
 impl Decodable for Requests {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        Ok(Self(
-            <Vec<Bytes> as Decodable>::decode(buf)?
-                .into_iter()
-                .map(|bytes| Request::decode_7685(&mut bytes.as_ref()))
-                .collect::<Result<Vec<_>, alloy_eips::eip7685::Eip7685Error>>()?,
-        ))
+        <Vec<Bytes> as Decodable>::decode(buf)?
+            .into_iter()
+            .map(|bytes| Request::decode_7685(&mut bytes.as_ref()))
+            .collect::<Result<Vec<_>, alloy_eips::eip7685::Eip7685Error>>()
+            .map(Self)
     }
 }


### PR DESCRIPTION
this is cursed

we need to encode `Requests` as `rlp([req_bytes_1, req_bytes_2, ..])`, but previously we were encoding it as `rlp([rlp(req_bytes_1), ..])`