### PR TITLE
fix: Chain::split returns NoSplitPending for block number > tip

### DIFF
--- a/crates/storage/provider/src/chain.rs
+++ b/crates/storage/provider/src/chain.rs
@@ -591,7 +591,7 @@ mod tests {
         // split at higher number
         assert_eq!(
             chain.clone().split(ChainSplitTarget::Number(10)),
-            ChainSplit::NoSplitCanonical(chain.clone())
+            ChainSplit::NoSplitPending(chain.clone())
         );
 
         // split at lower number

--- a/crates/storage/provider/src/chain.rs
+++ b/crates/storage/provider/src/chain.rs
@@ -289,7 +289,10 @@ impl Chain {
                 block_number
             }
             ChainSplitTarget::Number(block_number) => {
-                if block_number >= chain_tip {
+                if block_number > chain_tip {
+                    return ChainSplit::NoSplitPending(self)
+                }
+                if block_number == chain_tip {
                     return ChainSplit::NoSplitCanonical(self)
                 }
                 if block_number < *self.blocks.first_entry().expect("chain is never empty").key() {


### PR DESCRIPTION
If the function `split()` is called with a block number greater than the tip it will consider this split valid and treat it the same as splitting the canonical head. 

If the block_number > chain_tip then it implies the block is not in this chain and the chain cannot be split, with these changes a `ChainSplit::NoSplitPending` is returned (same as with missing hash).