### PR TITLE
fix(cli): tx fetcher args help

### DIFF
--- a/crates/node-core/src/args/network.rs
+++ b/crates/node-core/src/args/network.rs
@@ -90,19 +90,24 @@ pub struct NetworkArgs {
     #[arg(long)]
     pub max_inbound_peers: Option<usize>,
 
-    /// Soft limit for the byte size of a `PooledTransactions` response on assembling a
-    /// `GetPooledTransactions` request. Spec'd at 2 MiB.
-    ///
-    /// <https://github.com/ethereum/devp2p/blob/master/caps/eth.md#protocol-messages>.
-    #[arg(long = "pooled-tx-response-soft-limit", value_name = "BYTES", default_value_t = SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE, help = "Sets the soft limit for the byte size of pooled transactions response. Specified at 2 MiB by default. This is a spec'd value that should only be set for experimental purposes on a testnet.",long_help = None)]
+    /// Experimental, for usage in research. Sets the max accumulated byte size of a transactions
+    /// to pack in one responses.
+    /// Spec'd at 2MiB.
+    #[arg(long = "pooled-tx-response-soft-limit", value_name = "BYTES", default_value_t = SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE, verbatim_doc_comment)]
     pub soft_limit_byte_size_pooled_transactions_response: usize,
 
-    /// Default soft limit for the byte size of a `PooledTransactions` response on assembling a
-    /// `GetPooledTransactions` request. This defaults to less
-    /// than the [`SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE`], at 2 MiB, used when
-    /// assembling a `PooledTransactions` response. Default
-    /// is 128 KiB.
-    #[arg(long = "pooled-tx-pack-soft-limit", value_name = "BYTES", default_value_t = DEFAULT_SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESP_ON_PACK_GET_POOLED_TRANSACTIONS_REQ,help = "Sets the soft limit for the byte size of a single pooled transactions response when packing multiple responses into a single packet for a `GetPooledTransactions` request. Specified at 128 Kib by default.",long_help = None)]
+    /// Experimental, for usage in research. Sets the max accumulated byte size of transactions to
+    /// request in one request.
+    ///
+    /// Since RLPx protocol version 68, the byte size of a transaction is shared as metadata in a
+    /// transaction announcement (see RLPx specs). This allows a node to request a specific size
+    /// response.
+    ///
+    /// By default, nodes request only 128 KiB worth of transactions, but should a peer request
+    /// more, up to 2 MiB, a node will answer with more than 128 KiB.
+    ///
+    /// Default is 128 KiB.
+    #[arg(long = "pooled-tx-pack-soft-limit", value_name = "BYTES", default_value_t = DEFAULT_SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESP_ON_PACK_GET_POOLED_TRANSACTIONS_REQ, verbatim_doc_comment)]
     pub soft_limit_byte_size_pooled_transactions_response_on_pack_request: usize,
 }
 

--- a/crates/node-core/src/args/network.rs
+++ b/crates/node-core/src/args/network.rs
@@ -90,8 +90,8 @@ pub struct NetworkArgs {
     #[arg(long)]
     pub max_inbound_peers: Option<usize>,
 
-    /// Experimental, for usage in research. Sets the max accumulated byte size of a transactions
-    /// to pack in one responses.
+    /// Experimental, for usage in research. Sets the max accumulated byte size of transactions
+    /// to pack in one response.
     /// Spec'd at 2MiB.
     #[arg(long = "pooled-tx-response-soft-limit", value_name = "BYTES", default_value_t = SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE, verbatim_doc_comment)]
     pub soft_limit_byte_size_pooled_transactions_response: usize,


### PR DESCRIPTION
- Fixes help for cli args for tx fetcher.
- Makes help less implementation specific. 