### PR TITLE
fix: calculate parity of legacy EIP155 txs correctly in alloy compat

### DIFF
--- a/crates/primitives/src/alloy_compat.rs
+++ b/crates/primitives/src/alloy_compat.rs
@@ -28,7 +28,7 @@ impl TryFrom<alloy_rpc_types::Block> for Block {
                                 s: signature.s,
                                 odd_y_parity: signature
                                     .y_parity
-                                    .unwrap_or(alloy_rpc_types::Parity(!signature.v.bit(0)))
+                                    .unwrap_or_else(|| reth_rpc_types::Parity(!signature.v.bit(0)))
                                     .0,
                             },
                         ))

--- a/crates/primitives/src/alloy_compat.rs
+++ b/crates/primitives/src/alloy_compat.rs
@@ -28,7 +28,7 @@ impl TryFrom<alloy_rpc_types::Block> for Block {
                                 s: signature.s,
                                 odd_y_parity: signature
                                     .y_parity
-                                    .unwrap_or_else(|| reth_rpc_types::Parity(!signature.v.bit(0)))
+                                    .unwrap_or_else(|| alloy_rpc_types::Parity(!signature.v.bit(0)))
                                     .0,
                             },
                         ))

--- a/crates/primitives/src/alloy_compat.rs
+++ b/crates/primitives/src/alloy_compat.rs
@@ -28,7 +28,7 @@ impl TryFrom<alloy_rpc_types::Block> for Block {
                                 s: signature.s,
                                 odd_y_parity: signature
                                     .y_parity
-                                    .unwrap_or(alloy_rpc_types::Parity(false))
+                                    .unwrap_or(alloy_rpc_types::Parity(!signature.v.bit(0)))
                                     .0,
                             },
                         ))


### PR DESCRIPTION
EIP155 transactions have their `y_parity` set to None, which makes the code always return false as the `odd_y_parity`, but this does not result in the correct recovery of the senders. Checking if `v` is odd/even works as far as I can tell, but I'm not sure if this is the best way to fix this.