### PR TITLE
fix(pruner): increase default pruner block interval

### DIFF
--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -333,7 +333,7 @@ pub struct PruneConfig {
 
 impl Default for PruneConfig {
     fn default() -> Self {
-        Self { block_interval: 5, segments: PruneModes::none() }
+        Self { block_interval: 100_000, segments: PruneModes::none() }
     }
 }
 

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -13,6 +13,11 @@ use std::{
 
 const EXTENSION: &str = "toml";
 
+/// Default number of blocks after which a periodic prune job is triggered.
+///
+/// Default is 500k blocks (equivalent to the number of blocks that map to one static file).
+pub const DEFAULT_COUNT_BLOCKS_PRUNER_INTERVAL: usize = 500_000;
+
 /// Configuration for the reth node.
 #[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default)]
@@ -333,7 +338,7 @@ pub struct PruneConfig {
 
 impl Default for PruneConfig {
     fn default() -> Self {
-        Self { block_interval: 100_000, segments: PruneModes::none() }
+        Self { block_interval: DEFAULT_COUNT_BLOCKS_PRUNER_INTERVAL, segments: PruneModes::none() }
     }
 }
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -8,4 +8,4 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 pub mod config;
-pub use config::{BodiesConfig, Config, PruneConfig};
+pub use config::{BodiesConfig, Config, PruneConfig, DEFAULT_COUNT_BLOCKS_PRUNER_INTERVAL};

--- a/crates/node-core/src/args/pruning.rs
+++ b/crates/node-core/src/args/pruning.rs
@@ -1,7 +1,7 @@
 //! Pruning and full node arguments
 
 use clap::Args;
-use reth_config::config::PruneConfig;
+use reth_config::{PruneConfig, DEFAULT_COUNT_BLOCKS_PRUNER_INTERVAL};
 use reth_primitives::{
     ChainSpec, PruneMode, PruneModes, ReceiptsLogPruneConfig, MINIMUM_PRUNING_DISTANCE,
 };
@@ -23,7 +23,7 @@ impl PruningArgs {
             return None;
         }
         Some(PruneConfig {
-            block_interval: 5,
+            block_interval: DEFAULT_COUNT_BLOCKS_PRUNER_INTERVAL,
             segments: PruneModes {
                 sender_recovery: Some(PruneMode::Full),
                 transaction_lookup: None,

--- a/crates/prune/src/builder.rs
+++ b/crates/prune/src/builder.rs
@@ -1,5 +1,5 @@
 use crate::{segments::SegmentSet, Pruner};
-use reth_config::PruneConfig;
+use reth_config::{PruneConfig, DEFAULT_COUNT_BLOCKS_PRUNER_INTERVAL};
 use reth_db::database::Database;
 use reth_primitives::{FinishedExExHeight, PruneModes, MAINNET};
 use reth_provider::ProviderFactory;
@@ -97,7 +97,7 @@ impl PrunerBuilder {
 impl Default for PrunerBuilder {
     fn default() -> Self {
         Self {
-            block_interval: 5,
+            block_interval: DEFAULT_COUNT_BLOCKS_PRUNER_INTERVAL,
             segments: PruneModes::none(),
             max_reorg_depth: 64,
             prune_delete_limit: MAINNET.prune_delete_limit,


### PR DESCRIPTION
Ref https://github.com/paradigmxyz/reth/issues/7500.

Increase default pruner block interval from 5 to 500k blocks (= one static file worth of blocks/transactions/receipts).