### PR TITLE
feat: add additional message type metrics to EthRequestHandlerMetrics

### DIFF
--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -144,7 +144,7 @@ where
         request: GetBlockHeaders,
         response: oneshot::Sender<RequestResult<BlockHeaders>>,
     ) {
-        self.metrics.received_headers_requests.increment(1);
+        self.metrics.eth_requests_get_block_headers_received_total.increment(1);
         let headers = self.get_headers_response(request);
         let _ = response.send(Ok(BlockHeaders(headers)));
     }
@@ -155,7 +155,7 @@ where
         request: GetBlockBodies,
         response: oneshot::Sender<RequestResult<BlockBodies>>,
     ) {
-        self.metrics.received_bodies_requests.increment(1);
+        self.metrics.eth_requests_get_block_bodies_received_total.increment(1);
         let mut bodies = Vec::new();
 
         let mut total_bytes = 0;
@@ -192,7 +192,7 @@ where
         request: GetReceipts,
         response: oneshot::Sender<RequestResult<Receipts>>,
     ) {
-        self.metrics.received_receipts_requests.increment(1);
+        self.metrics.eth_requests_get_receipts_received_total.increment(1);
 
         let mut receipts = Vec::new();
 
@@ -252,7 +252,7 @@ where
                         this.on_bodies_request(peer_id, request, response)
                     }
                     IncomingEthRequest::GetNodeData { .. } => {
-                        this.metrics.received_node_data_requests.increment(1);
+                        this.metrics.eth_requests_get_node_data_received_total.increment(1);
                     }
                     IncomingEthRequest::GetReceipts { peer_id, request, response } => {
                         this.on_receipts_request(peer_id, request, response)

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -144,7 +144,7 @@ where
         request: GetBlockHeaders,
         response: oneshot::Sender<RequestResult<BlockHeaders>>,
     ) {
-        self.metrics.eth_requests_get_block_headers_received_total.increment(1);
+        self.metrics.eth_headers_requests_received_total.increment(1);
         let headers = self.get_headers_response(request);
         let _ = response.send(Ok(BlockHeaders(headers)));
     }
@@ -155,7 +155,7 @@ where
         request: GetBlockBodies,
         response: oneshot::Sender<RequestResult<BlockBodies>>,
     ) {
-        self.metrics.eth_requests_get_block_bodies_received_total.increment(1);
+        self.metrics.eth_bodies_requests_received_total.increment(1);
         let mut bodies = Vec::new();
 
         let mut total_bytes = 0;
@@ -192,7 +192,7 @@ where
         request: GetReceipts,
         response: oneshot::Sender<RequestResult<Receipts>>,
     ) {
-        self.metrics.eth_requests_get_receipts_received_total.increment(1);
+        self.metrics.eth_receipts_requests_received_total.increment(1);
 
         let mut receipts = Vec::new();
 
@@ -252,7 +252,7 @@ where
                         this.on_bodies_request(peer_id, request, response)
                     }
                     IncomingEthRequest::GetNodeData { .. } => {
-                        this.metrics.eth_requests_get_node_data_received_total.increment(1);
+                        this.metrics.eth_node_data_requests_received_total.increment(1);
                     }
                     IncomingEthRequest::GetReceipts { peer_id, request, response } => {
                         this.on_receipts_request(peer_id, request, response)

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -192,6 +192,8 @@ where
         request: GetReceipts,
         response: oneshot::Sender<RequestResult<Receipts>>,
     ) {
+        self.metrics.received_receipts_requests.increment(1);
+
         let mut receipts = Vec::new();
 
         let mut total_bytes = 0;
@@ -249,7 +251,9 @@ where
                     IncomingEthRequest::GetBlockBodies { peer_id, request, response } => {
                         this.on_bodies_request(peer_id, request, response)
                     }
-                    IncomingEthRequest::GetNodeData { .. } => {}
+                    IncomingEthRequest::GetNodeData { .. } => {
+                        this.metrics.received_node_data_requests.increment(1);
+                    }
                     IncomingEthRequest::GetReceipts { peer_id, request, response } => {
                         this.on_receipts_request(peer_id, request, response)
                     }

--- a/crates/net/network/src/metrics.rs
+++ b/crates/net/network/src/metrics.rs
@@ -311,16 +311,16 @@ impl DisconnectMetrics {
 #[metrics(scope = "network")]
 pub struct EthRequestHandlerMetrics {
     /// Number of GetBlockHeaders requests received
-    pub(crate) eth_requests_get_block_headers_received_total: Counter,
+    pub(crate) eth_headers_requests_received_total: Counter,
 
     /// Number of GetReceipts requests received
-    pub(crate) eth_requests_get_receipts_received_total: Counter,
+    pub(crate) eth_receipts_requests_received_total: Counter,
 
     /// Number of GetBlockBodies requests received
-    pub(crate) eth_requests_get_block_bodies_received_total: Counter,
+    pub(crate) eth_bodies_requests_received_total: Counter,
 
     /// Number of GetNodeData requests received
-    pub(crate) eth_requests_get_node_data_received_total: Counter,
+    pub(crate) eth_node_data_requests_received_total: Counter,
 }
 
 /// Eth67 announcement metrics, track entries by TxType

--- a/crates/net/network/src/metrics.rs
+++ b/crates/net/network/src/metrics.rs
@@ -310,17 +310,17 @@ impl DisconnectMetrics {
 #[derive(Metrics)]
 #[metrics(scope = "network")]
 pub struct EthRequestHandlerMetrics {
-    /// Number of received headers requests
-    pub(crate) received_headers_requests: Counter,
+    /// Number of GetBlockHeaders requests received
+    pub(crate) eth_requests_get_block_headers_received_total: Counter,
 
-    /// Number of received bodies requests
-    pub(crate) received_bodies_requests: Counter,
+    /// Number of GetReceipts requests received
+    pub(crate) eth_requests_get_receipts_received_total: Counter,
 
-    /// Number of received receipts requests
-    pub(crate) received_receipts_requests: Counter,
+    /// Number of GetBlockBodies requests received
+    pub(crate) eth_requests_get_block_bodies_received_total: Counter,
 
-    /// Number of received node data requests
-    pub(crate) received_node_data_requests: Counter,
+    /// Number of GetNodeData requests received
+    pub(crate) eth_requests_get_node_data_received_total: Counter,
 }
 
 /// Eth67 announcement metrics, track entries by TxType

--- a/crates/net/network/src/metrics.rs
+++ b/crates/net/network/src/metrics.rs
@@ -315,6 +315,12 @@ pub struct EthRequestHandlerMetrics {
 
     /// Number of received bodies requests
     pub(crate) received_bodies_requests: Counter,
+
+    /// Number of received receipts requests
+    pub(crate) received_receipts_requests: Counter,
+
+    /// Number of received node data requests
+    pub(crate) received_node_data_requests: Counter,
 }
 
 /// Eth67 announcement metrics, track entries by TxType


### PR DESCRIPTION
Resolves #8245 

Adds additional metrics for when `GetNodeData` and `GetReceipts` eth requests are received. Also normalizes the `Counter` metric names to better follow convention as mentioned in #8150. Let me know if these metric names make sense or if there are any further suggestions.

I tried to look for ways to test this, but I didn't see any tests for metrics handling in this file. Would love to add some if it is helpful and if they are tested some other way in the codebase that I can use for guidance.