### PR TITLE
fix: disambiguate use of next when validating ForkId

### DIFF
--- a/crates/ethereum-forks/src/forkid.rs
+++ b/crates/ethereum-forks/src/forkid.rs
@@ -21,6 +21,7 @@ use std::{
 use thiserror::Error;
 
 const CRC_32_IEEE: Crc<u32> = Crc::<u32>::new(&CRC_32_ISO_HDLC);
+const TIMESTAMP_BEFORE_ETHEREUM_MAINNET: u64 = 1_300_000_000;
 
 /// `CRC32` hash of all previous forks starting from genesis block.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -313,16 +314,27 @@ impl ForkFilter {
                 return Ok(())
             }
 
-            // We check if this fork is time-based or block number-based
-            // NOTE: This is a bit hacky but I'm unsure how else we can figure out when to use
-            // timestamp vs when to use block number..
-            let head_block_or_time = match self.cache.epoch_start {
-                ForkFilterKey::Block(_) => self.head.number,
-                ForkFilterKey::Time(_) => self.head.timestamp,
+            let is_incompatible = if self.head.number < TIMESTAMP_BEFORE_ETHEREUM_MAINNET {
+                println!("self.head.number < TIMESTAMP_BEFORE_ETHEREUM_MAINNET");
+                // When the block number is less than an old timestamp before Ethereum mainnet,
+                // we check if this fork is time-based or block number-based by estimating that,
+                // if fork_id.next is bigger than the old timestamp, we are dealing with a
+                // timestamp, otherwise with a block.
+                (fork_id.next > TIMESTAMP_BEFORE_ETHEREUM_MAINNET &&
+                    self.head.timestamp >= fork_id.next) ||
+                    (fork_id.next <= TIMESTAMP_BEFORE_ETHEREUM_MAINNET &&
+                        self.head.number >= fork_id.next)
+            } else {
+                println!("self.head.number >= TIMESTAMP_BEFORE_ETHEREUM_MAINNET");
+                // Extra safety check to future-proof for when Ethereum has over a billion blocks.
+                let head_block_or_time = match self.cache.epoch_start {
+                    ForkFilterKey::Block(_) => self.head.number,
+                    ForkFilterKey::Time(_) => self.head.timestamp,
+                };
+                head_block_or_time >= fork_id.next
             };
 
-            //... compare local head to FORK_NEXT.
-            return if head_block_or_time >= fork_id.next {
+            return if is_incompatible {
                 // 1a) A remotely announced but remotely not passed block is already passed locally,
                 // disconnect, since the chains are incompatible.
                 Err(ValidationError::LocalIncompatibleOrStale {
@@ -588,6 +600,27 @@ mod tests {
             filter.validate(remote),
             Err(ValidationError::LocalIncompatibleOrStale { local: filter.current(), remote })
         );
+
+        // Block far in the future (bigger than TIMESTAMP_BEFORE_ETHEREUM_MAINNET), not compatible.
+        filter
+            .set_head(Head { number: TIMESTAMP_BEFORE_ETHEREUM_MAINNET + 1, ..Default::default() });
+        let remote = ForkId {
+            hash: ForkHash(hex!("668db0af")),
+            next: TIMESTAMP_BEFORE_ETHEREUM_MAINNET + 1,
+        };
+        assert_eq!(
+            filter.validate(remote),
+            Err(ValidationError::LocalIncompatibleOrStale { local: filter.current(), remote })
+        );
+
+        // Block far in the future (bigger than TIMESTAMP_BEFORE_ETHEREUM_MAINNET), compatible.
+        filter
+            .set_head(Head { number: TIMESTAMP_BEFORE_ETHEREUM_MAINNET + 1, ..Default::default() });
+        let remote = ForkId {
+            hash: ForkHash(hex!("668db0af")),
+            next: TIMESTAMP_BEFORE_ETHEREUM_MAINNET + 2,
+        };
+        assert_eq!(filter.validate(remote), Ok(()));
     }
 
     #[test]

--- a/crates/ethereum-forks/src/forkid.rs
+++ b/crates/ethereum-forks/src/forkid.rs
@@ -315,7 +315,6 @@ impl ForkFilter {
             }
 
             let is_incompatible = if self.head.number < TIMESTAMP_BEFORE_ETHEREUM_MAINNET {
-                println!("self.head.number < TIMESTAMP_BEFORE_ETHEREUM_MAINNET");
                 // When the block number is less than an old timestamp before Ethereum mainnet,
                 // we check if this fork is time-based or block number-based by estimating that,
                 // if fork_id.next is bigger than the old timestamp, we are dealing with a
@@ -325,7 +324,6 @@ impl ForkFilter {
                     (fork_id.next <= TIMESTAMP_BEFORE_ETHEREUM_MAINNET &&
                         self.head.number >= fork_id.next)
             } else {
-                println!("self.head.number >= TIMESTAMP_BEFORE_ETHEREUM_MAINNET");
                 // Extra safety check to future-proof for when Ethereum has over a billion blocks.
                 let head_block_or_time = match self.cache.epoch_start {
                     ForkFilterKey::Block(_) => self.head.number,


### PR DESCRIPTION
When validating if a given `ForkId` is compatible with a `ForkFilter`, the field `next` can represent a timestamp or a block, and there isn't enough distinction about which one it might refer to.

The `next` field is used to determine whether a connection should be established with the peer and the issue can occur if `self.cache.epoch_start` is measured in block numbers and `fork_id.next` is measured in timestamps.

Since block numbers are significantly less than timestamps, if the timestamp is somewhat recent it will always be larger.
The current mainnet block height of Ethereum is about 19 million whereas the current timestamp for Unix is almost 2
billion.

To prevent the issue, the changes in PR check if `fork_id.next` is greater than an old timestamp (taken a timestamp close to 2011 before Ethereum mainnet, 1.3 billion) and estimates if `fork_id.next` > old_timestampo then it is expected to be a timestamp and if it is less, then the units are in block numbers.

It also adds an extra safety check so that the estimation does not occur if `self.head.number` > old_timestamp to
future-proof for when Ethereum has over 1.3 billion blocks (far in the future), defaulting in that case to the current logic.