### PR TITLE
fix: disable db shrinking

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -272,7 +272,7 @@ impl DatabaseEnv {
             // We grow the database in increments of 4 gigabytes
             growth_step: Some(4 * GIGABYTE as isize),
             // The database never shrinks
-            shrink_threshold: None,
+            shrink_threshold: Some(0),
             page_size: Some(PageSize::Set(default_page_size())),
         });
         #[cfg(not(windows))]


### PR DESCRIPTION
When configuring `libdbmx` on `DatabaseEnv::open`, the `shrink_threshold` field is set to `None`, which  actually results in the default of −1 being passed through to the underlying implementation at https://github.com/paradigmxyz/reth/blob/main/crates/storage/libmdbx-rs/src/environment.rs#L643

According to the [libmdbx API documentation](https://libmdbx.dqdkfa.ru/group__c__settings.html#ga79065e4f3c5fb2ad37a52b59224d583e) `shrink_threshold` is:
```
The shrink threshold in bytes, must be greater than zero to allow the database to shrink and
greater than growth_step to avoid shrinking right after grow. Negative value means "keep  current 
or use default". Default is 2*growth_step.
```
So, with the current setting, the resulting value for shrink_threshold is actually 8 GiB (given 4GiB of `growth_step`).

The fix in this PR consists of setting `shrink_threshold` in `DatabaseEnv::open` to `Some(0)`, so that the value passed is 0 and db shrinking is disabled.