### PR TITLE
fix: open db in non-exclusive mode by default

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -317,7 +317,7 @@ impl DatabaseEnv {
             // worsens it for random access (which is our access pattern outside of sync)
             no_rdahead: true,
             coalesce: true,
-            exclusive: args.exclusive.unwrap_or_default(),
+            exclusive: args.exclusive.unwrap_or(true),
             ..Default::default()
         });
         // Configure more readers


### PR DESCRIPTION
We are configuring the exclusive mode of `libmdbx` with `exclusive: args.exclusive.unwrap_or_default()`. `args.exlusive` is `Option<bool>`, so, if it is not set by an argument from the command line, `unwrap_or_default()` will set it to false (`bool::default()`), leaving the db in non-exclusive mode.
