### PR TITLE
fix(op): fix logs

### DIFF
--- a/bin/reth/src/commands/import_op.rs
+++ b/bin/reth/src/commands/import_op.rs
@@ -121,7 +121,7 @@ impl ImportOpCommand {
             info!(target: "reth::cli", "Chain file chunk read");
 
             total_decoded_blocks += file_client.headers_len();
-            total_decoded_txns += file_client.bodies_len();
+            total_decoded_txns += file_client.total_transactions();
 
             for (block_number, body) in file_client.bodies_iter_mut() {
                 body.transactions.retain(|tx| {
@@ -172,16 +172,17 @@ impl ImportOpCommand {
 
         let provider = provider_factory.provider()?;
 
-        let total_imported_blocks = provider.tx_ref().entries::<tables::Headers>()?;
+        let total_imported_blocks = provider.tx_ref().entries::<tables::HeaderNumbers>()?;
         let total_imported_txns = provider.tx_ref().entries::<tables::TransactionHashNumbers>()?;
 
         if total_decoded_blocks != total_imported_blocks ||
-            total_decoded_txns != total_imported_txns
+            total_decoded_txns != total_imported_txns + total_filtered_out_dup_txns
         {
             error!(target: "reth::cli",
                 total_decoded_blocks,
                 total_imported_blocks,
                 total_decoded_txns,
+                total_filtered_out_dup_txns,
                 total_imported_txns,
                 "Chain was partially imported"
             );

--- a/bin/reth/src/commands/import_receipts.rs
+++ b/bin/reth/src/commands/import_receipts.rs
@@ -19,7 +19,7 @@ use reth_provider::{
     BundleStateWithReceipts, OriginalValuesKnown, ProviderFactory, StageCheckpointReader,
     StateWriter, StaticFileProviderFactory, StaticFileWriter,
 };
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, trace};
 
 use std::{path::PathBuf, sync::Arc};
 
@@ -89,7 +89,7 @@ impl ImportReceiptsCommand {
 
         for stage in StageId::ALL {
             let checkpoint = provider.get_stage_checkpoint(stage)?;
-            debug!(target: "reth::cli",
+            trace!(target: "reth::cli",
                 ?stage,
                 ?checkpoint,
                 "Read stage checkpoints from db"

--- a/crates/net/downloaders/src/file_client.rs
+++ b/crates/net/downloaders/src/file_client.rs
@@ -172,7 +172,7 @@ impl FileClient {
 
     /// Returns the current number of transactions in the client.
     pub fn total_transactions(&self) -> usize {
-        self.bodies.iter().flat_map(|(_, body)| &body.transactions).count()
+        self.bodies.iter().fold(0, |acc, (_, body)| acc + body.transactions.len())
     }
 }
 

--- a/crates/net/downloaders/src/receipt_file_client.rs
+++ b/crates/net/downloaders/src/receipt_file_client.rs
@@ -43,7 +43,7 @@ impl FromReader for ReceiptFileClient {
         trace!(target: "downloaders::file",
             target_num_bytes=num_bytes,
             capacity=stream.read_buffer().capacity(),
-            coded=?HackReceiptFileCodec,
+            codec=?HackReceiptFileCodec,
             "init decode stream"
         );
 


### PR DESCRIPTION
Fixes logs for importing op blocks and receipts (this was fixed at some point, smthg smthg merge conflicts)