### PR TITLE
Fix enode URL parse failure due to enode prefix

### DIFF
--- a/crates/net/discv5/src/config.rs
+++ b/crates/net/discv5/src/config.rs
@@ -129,7 +129,7 @@ impl ConfigBuilder {
         self
     }
 
-    /// Adds boot nodes in the form a list of [`NodeRecord`]s, parsed enodes.
+    /// Adds boot nodes in the form a list of [`DNSNodeRecord`]s, parsed enodes.
     pub fn add_unsigned_boot_nodes<T: Into<DNSNodeRecord>>(
         mut self,
         enodes: impl Iterator<Item = T>,

--- a/crates/net/types/src/dns_node_record.rs
+++ b/crates/net/types/src/dns_node_record.rs
@@ -78,7 +78,11 @@ impl FromStr for DNSNodeRecord {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use url::Url;
 
-        let url = Url::parse(s).map_err(|e| NodeRecordParseError::InvalidUrl(e.to_string()))?;
+        // Parse the URL with enode prefix replaced with http.
+        // The enode prefix causes the parser to use parse_opaque() on
+        // the host str which only handles domains and ipv6, not ipv4.
+        let url = Url::parse(s.replace("enode://", "http://").as_str())
+            .map_err(|e| NodeRecordParseError::InvalidUrl(e.to_string()))?;
 
         let host = url
             .host()


### PR DESCRIPTION
Relates to PR #8188

Hack to fix parsing of enode strings with the URL crate.

The enode prefix causes the parser to go down this host parsing logic which does not handle ipv4:
```rust
    pub fn parse_opaque(input: &str) -> Result<Self, ParseError> {
// ...snip...
        if input.find(is_invalid_host_char).is_some() {
            Err(ParseError::InvalidDomainCharacter)
        } else {
            Ok(Host::Domain(
                utf8_percent_encode(input, CONTROLS).to_string(),
            ))
        }
    }
```