### PR TITLE
chore(trie): `PrefixSet::iter`

### DIFF
--- a/crates/trie/src/prefix_set/mod.rs
+++ b/crates/trie/src/prefix_set/mod.rs
@@ -163,7 +163,7 @@ impl PrefixSet {
 
     /// Returns an iterator over reference to _all_ nibbles regardless of cursor position.
     pub fn iter(&self) -> core::slice::Iter<'_, Nibbles> {
-        self.keys.as_ref().iter()
+        self.keys.iter()
     }
 
     /// Returns the number of elements in the set.

--- a/crates/trie/src/prefix_set/mod.rs
+++ b/crates/trie/src/prefix_set/mod.rs
@@ -161,6 +161,11 @@ impl PrefixSet {
         false
     }
 
+    /// Returns an iterator over reference to _all_ nibbles regardless of cursor position.
+    pub fn iter(&self) -> core::slice::Iter<'_, Nibbles> {
+        self.keys.as_ref().iter()
+    }
+
     /// Returns the number of elements in the set.
     pub fn len(&self) -> usize {
         self.keys.len()


### PR DESCRIPTION
## Description

Expose iterator over underlying keys.