### PR TITLE
docs: add panic comments in from_compact()

### DIFF
--- a/crates/primitives/src/account.rs
+++ b/crates/primitives/src/account.rs
@@ -106,6 +106,10 @@ impl Compact for Bytecode {
         len + bytecode.len() + 4
     }
 
+    // # Panics
+    //
+    // A panic will be triggered if a bytecode variant of 1 or greater than 2 is passed from the
+    // database.
     fn from_compact(mut buf: &[u8], _: usize) -> (Self, &[u8]) {
         let len = buf.read_u32::<BigEndian>().expect("could not read bytecode length");
         let bytes = Bytes::from(buf.copy_to_bytes(len as usize));

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -644,6 +644,11 @@ impl Compact for Transaction {
     // For backwards compatibility purposes, only 2 bits of the type are encoded in the identifier
     // parameter. In the case of a 3, the full transaction type is read from the buffer as a
     // single byte.
+    //
+    // # Panics
+    //
+    // A panic will be triggered if an identifier larger than 3 is passed from the database. For
+    // optimism a identifier with value 126 is allowed.
     fn from_compact(mut buf: &[u8], identifier: usize) -> (Self, &[u8]) {
         match identifier {
             0 => {

--- a/crates/primitives/src/trie/hash_builder/value.rs
+++ b/crates/primitives/src/trie/hash_builder/value.rs
@@ -23,6 +23,10 @@ impl Compact for StoredHashBuilderValue {
         }
     }
 
+    // # Panics
+    //
+    // A panic will be triggered if a HashBuilderValue variant greater than 1 is passed from the
+    // database.
     fn from_compact(mut buf: &[u8], _len: usize) -> (Self, &[u8]) {
         match buf.get_u8() {
             0 => {


### PR DESCRIPTION
These panics are not reachable unless there is an invalid database entry, this is not likely to occur. The doc comments state how and why these panics could occur.