### PR TITLE
feat: return parent beacon block root in payload conversion

### DIFF
--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -112,7 +112,7 @@ impl From<EthBuiltPayload> for ExecutionPayloadEnvelopeV3 {
         let EthBuiltPayload { block, fees, sidecars, .. } = value;
 
         ExecutionPayloadEnvelopeV3 {
-            execution_payload: block_to_payload_v3(block),
+            execution_payload: block_to_payload_v3(block).0,
             block_value: fees,
             // From the engine API spec:
             //

--- a/crates/optimism/payload/src/payload.rs
+++ b/crates/optimism/payload/src/payload.rs
@@ -256,7 +256,7 @@ impl From<OptimismBuiltPayload> for OptimismExecutionPayloadEnvelopeV3 {
                 B256::ZERO
             };
         OptimismExecutionPayloadEnvelopeV3 {
-            execution_payload: block_to_payload_v3(block),
+            execution_payload: block_to_payload_v3(block).0,
             block_value: fees,
             // From the engine API spec:
             //

--- a/crates/rpc/rpc-engine-api/tests/it/payload.rs
+++ b/crates/rpc/rpc-engine-api/tests/it/payload.rs
@@ -29,6 +29,7 @@ fn transform_block<F: FnOnce(Block) -> Block>(src: SealedBlock, f: F) -> Executi
         ommers: transformed.ommers,
         withdrawals: transformed.withdrawals,
     })
+    .0
 }
 
 #[test]

--- a/crates/rpc/rpc-types-compat/src/engine/payload.rs
+++ b/crates/rpc/rpc-types-compat/src/engine/payload.rs
@@ -379,7 +379,7 @@ mod tests {
         let converted_payload = block_to_payload_v3(block.seal_slow());
 
         // ensure the payloads are the same
-        assert_eq!(new_payload, converted_payload.0);
+        assert_eq!((new_payload, Some(parent_beacon_block_root.into())), converted_payload);
     }
 
     #[test]

--- a/crates/rpc/rpc-types-compat/src/engine/payload.rs
+++ b/crates/rpc/rpc-types-compat/src/engine/payload.rs
@@ -97,18 +97,20 @@ pub fn try_payload_v4_to_block(payload: ExecutionPayloadV4) -> Result<Block, Pay
     try_payload_v3_to_block(payload.payload_inner)
 }
 
-/// Converts [SealedBlock] to [ExecutionPayload]
-pub fn block_to_payload(value: SealedBlock) -> ExecutionPayload {
+/// Converts [SealedBlock] to [ExecutionPayload], returning additional data (the parent beacon block
+/// root) if the block is a V3 payload
+pub fn block_to_payload(value: SealedBlock) -> (ExecutionPayload, Option<B256>) {
     // todo(onbjerg): check for requests_root here and return payload v4
     if value.header.parent_beacon_block_root.is_some() {
         // block with parent beacon block root: V3
-        ExecutionPayload::V3(block_to_payload_v3(value))
+        let (payload, beacon_block_root) = block_to_payload_v3(value);
+        (ExecutionPayload::V3(payload), beacon_block_root)
     } else if value.withdrawals.is_some() {
         // block with withdrawals: V2
-        ExecutionPayload::V2(block_to_payload_v2(value))
+        (ExecutionPayload::V2(block_to_payload_v2(value)), None)
     } else {
         // otherwise V1
-        ExecutionPayload::V1(block_to_payload_v1(value))
+        (ExecutionPayload::V1(block_to_payload_v1(value)), None)
     }
 }
 
@@ -158,11 +160,12 @@ pub fn block_to_payload_v2(value: SealedBlock) -> ExecutionPayloadV2 {
     }
 }
 
-/// Converts [SealedBlock] to [ExecutionPayloadV3]
-pub fn block_to_payload_v3(value: SealedBlock) -> ExecutionPayloadV3 {
+/// Converts [SealedBlock] to [ExecutionPayloadV3], and returns the parent beacon block root.
+pub fn block_to_payload_v3(value: SealedBlock) -> (ExecutionPayloadV3, Option<B256>) {
     let transactions = value.raw_transactions();
 
-    ExecutionPayloadV3 {
+    let parent_beacon_block_root = value.header.parent_beacon_block_root;
+    let payload = ExecutionPayloadV3 {
         blob_gas_used: value.blob_gas_used.unwrap_or_default(),
         excess_blob_gas: value.excess_blob_gas.unwrap_or_default(),
         payload_inner: ExecutionPayloadV2 {
@@ -184,7 +187,9 @@ pub fn block_to_payload_v3(value: SealedBlock) -> ExecutionPayloadV3 {
             },
             withdrawals: value.withdrawals.unwrap_or_default().into_inner(),
         },
-    }
+    };
+
+    (payload, parent_beacon_block_root)
 }
 
 /// Converts [SealedBlock] to [ExecutionPayloadFieldV2]
@@ -374,7 +379,7 @@ mod tests {
         let converted_payload = block_to_payload_v3(block.seal_slow());
 
         // ensure the payloads are the same
-        assert_eq!(new_payload, converted_payload);
+        assert_eq!(new_payload, converted_payload.0);
     }
 
     #[test]


### PR DESCRIPTION
This allows for block -> payload conversion to be more lossless, returning the parent beacon block root if it exists.