### PR TITLE
perf(primitives): avoid cloning receipts when calculating the root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d58d9f5da7b40e9bfff0b7e7816700be4019db97d4b6359fe7f94a9e22e42ac"
+checksum = "b155716bab55763c95ba212806cf43d05bcc70e5f35b02bad20cf5ec7fe11fed"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -353,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a047897373be4bbb0224c1afdabca92648dc57a9c9ef6e7b0be3aff7a859c83"
+checksum = "8037e03c7f462a063f28daec9fda285a9a89da003c552f8637a80b9c8fd96241"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/primitives/src/log.rs
+++ b/crates/primitives/src/log.rs
@@ -1,13 +1,9 @@
 use crate::Bloom;
 
-/// Re-export `Log` from `alloy_primitives`.
 pub use alloy_primitives::Log;
 
 /// Calculate receipt logs bloom.
-pub fn logs_bloom<'a, It>(logs: It) -> Bloom
-where
-    It: IntoIterator<Item = &'a Log>,
-{
+pub fn logs_bloom<'a>(logs: impl IntoIterator<Item = &'a Log>) -> Bloom {
     let mut bloom = Bloom::ZERO;
     for log in logs {
         bloom.m3_2048(log.address.as_slice());

--- a/crates/primitives/src/proofs.rs
+++ b/crates/primitives/src/proofs.rs
@@ -8,7 +8,6 @@ use crate::{
     B256, U256,
 };
 use alloy_rlp::Encodable;
-use bytes::BufMut;
 use itertools::Itertools;
 
 /// Adjust the index of an item for rlp encoding.
@@ -30,9 +29,8 @@ pub fn ordered_trie_root<T: Encodable>(items: &[T]) -> B256 {
 /// Compute a trie root of the collection of items with a custom encoder.
 pub fn ordered_trie_root_with_encoder<T, F>(items: &[T], mut encode: F) -> B256
 where
-    F: FnMut(&T, &mut dyn BufMut),
+    F: FnMut(&T, &mut Vec<u8>),
 {
-    let mut index_buffer = Vec::new();
     let mut value_buffer = Vec::new();
 
     let mut hb = HashBuilder::default();
@@ -40,8 +38,7 @@ where
     for i in 0..items_len {
         let index = adjust_index_for_rlp(i, items_len);
 
-        index_buffer.clear();
-        index.encode(&mut index_buffer);
+        let index_buffer = alloy_rlp::encode_fixed_size(&index);
 
         value_buffer.clear();
         encode(&items[index], &mut value_buffer);
@@ -104,10 +101,15 @@ pub fn calculate_receipt_root_optimism(
     ordered_trie_root_with_encoder(receipts, |r, buf| r.encode_inner(buf, false))
 }
 
+/// Calculates the receipt root for a header.
+pub fn calculate_receipt_root_ref(receipts: &[ReceiptWithBloomRef<'_>]) -> B256 {
+    ordered_trie_root_with_encoder(receipts, |r, buf| r.encode_inner(buf, false))
+}
+
 /// Calculates the receipt root for a header for the reference type of [Receipt].
 ///
-/// NOTE: Prefer [calculate_receipt_root] if you have log blooms memoized.
-pub fn calculate_receipt_root_ref(receipts: &[&Receipt]) -> B256 {
+/// NOTE: Prefer [`calculate_receipt_root`] if you have log blooms memoized.
+pub fn calculate_receipt_root_no_memo(receipts: &[&Receipt]) -> B256 {
     ordered_trie_root_with_encoder(receipts, |r, buf| {
         ReceiptWithBloomRef::from(*r).encode_inner(buf, false)
     })
@@ -115,9 +117,9 @@ pub fn calculate_receipt_root_ref(receipts: &[&Receipt]) -> B256 {
 
 /// Calculates the receipt root for a header for the reference type of [Receipt].
 ///
-/// NOTE: Prefer [calculate_receipt_root] if you have log blooms memoized.
+/// NOTE: Prefer [`calculate_receipt_root_optimism`] if you have log blooms memoized.
 #[cfg(feature = "optimism")]
-pub fn calculate_receipt_root_ref_optimism(
+pub fn calculate_receipt_root_no_memo_optimism(
     receipts: &[&Receipt],
     chain_spec: &crate::ChainSpec,
     timestamp: u64,

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -56,6 +56,12 @@ impl Receipt {
     pub fn with_bloom(self) -> ReceiptWithBloom {
         self.into()
     }
+
+    /// Calculates the bloom filter for the receipt and returns the [ReceiptWithBloomRef] container
+    /// type.
+    pub fn with_bloom_ref(&self) -> ReceiptWithBloomRef<'_> {
+        self.into()
+    }
 }
 
 /// A collection of receipts organized as a two-dimensional vector.
@@ -98,7 +104,7 @@ impl Receipts {
 
     /// Retrieves the receipt root for all recorded receipts from index.
     pub fn root_slow(&self, index: usize) -> Option<B256> {
-        Some(crate::proofs::calculate_receipt_root_ref(
+        Some(crate::proofs::calculate_receipt_root_no_memo(
             &self.receipt_vec[index].iter().map(Option::as_ref).collect::<Option<Vec<_>>>()?,
         ))
     }
@@ -111,7 +117,7 @@ impl Receipts {
         chain_spec: &crate::ChainSpec,
         timestamp: u64,
     ) -> Option<B256> {
-        Some(crate::proofs::calculate_receipt_root_ref_optimism(
+        Some(crate::proofs::calculate_receipt_root_no_memo_optimism(
             &self.receipt_vec[index].iter().map(Option::as_ref).collect::<Option<Vec<_>>>()?,
             chain_spec,
             timestamp,

--- a/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
+++ b/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
@@ -182,12 +182,11 @@ impl BundleStateWithReceipts {
     /// Returns the receipt root for all recorded receipts.
     /// Note: this function calculated Bloom filters for every receipt and created merkle trees
     /// of receipt. This is a expensive operation.
-    #[allow(unused_variables)]
-    pub fn receipts_root_slow(&self, block_number: BlockNumber) -> Option<B256> {
+    pub fn receipts_root_slow(&self, _block_number: BlockNumber) -> Option<B256> {
         #[cfg(feature = "optimism")]
         panic!("This should not be called in optimism mode. Use `optimism_receipts_root_slow` instead.");
         #[cfg(not(feature = "optimism"))]
-        self.receipts.root_slow(self.block_number_to_index(block_number)?)
+        self.receipts.root_slow(self.block_number_to_index(_block_number)?)
     }
 
     /// Returns the receipt root for all recorded receipts.


### PR DESCRIPTION
We can re-use the ref-type `ReceiptWithBloomRef` instead of cloning into `ReceiptWithBloom` to calculate the logs blooms and receipt root.

Drive-by: use `encode_fixed_size` to RLP encode the receipt index on the stack.

Closes https://github.com/paradigmxyz/reth/issues/8340