### PR TITLE
fix: check for files in is_database_empty

### DIFF
--- a/crates/storage/db/src/utils.rs
+++ b/crates/storage/db/src/utils.rs
@@ -23,9 +23,25 @@ pub fn is_database_empty<P: AsRef<Path>>(path: P) -> bool {
 
     if !path.exists() {
         true
+    } else if path.is_file() {
+        false
     } else if let Ok(dir) = path.read_dir() {
         dir.count() == 0
     } else {
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_database_empty_false_if_db_path_is_a_file() {
+        let db_file = tempfile::NamedTempFile::new().unwrap();
+
+        let result = is_database_empty(&db_file);
+
+        assert!(!result);
     }
 }


### PR DESCRIPTION
Fix for the case in which `is_database_empty()` returns true for paths that exist but are not directories.