### PR TITLE
chore: make unknown block error lowercase

### DIFF
--- a/crates/rpc/rpc/src/eth/error.rs
+++ b/crates/rpc/rpc/src/eth/error.rs
@@ -40,11 +40,11 @@ pub enum EthApiError {
     /// Thrown when querying for `finalized` or `safe` block before the merge transition is
     /// finalized, <https://github.com/ethereum/execution-apis/blob/6d17705a875e52c26826124c2a8a15ed542aeca2/src/schemas/block.yaml#L109>
     ///
-    /// op-node uses case sensitive string comparison to parse this error:
-    /// <https://github.com/ethereum-optimism/optimism/blob/0913776869f6cb2c1218497463d7377cf4de16de/op-service/sources/l2_client.go#L105>
+    /// op-node now checks for either `Unknown block` OR `unknown block`:
+    /// <https://github.com/ethereum-optimism/optimism/blob/3b374c292e2b05cc51b52212ba68dd88ffce2a3b/op-service/sources/l2_client.go#L105>
     ///
     /// TODO(#8045): Temporary, until a version of <https://github.com/ethereum-optimism/optimism/pull/10071> is pushed through that doesn't require this to figure out the EL sync status.
-    #[error("Unknown block")]
+    #[error("unknown block")]
     UnknownSafeOrFinalizedBlock,
     /// Thrown when an unknown block or transaction index is encountered
     #[error("unknown block or tx index")]


### PR DESCRIPTION
Fixes https://github.com/paradigmxyz/reth/issues/8045

The condition in op-node has now changed to allow for a lowercase error:
https://github.com/ethereum-optimism/optimism/blob/3b374c292e2b05cc51b52212ba68dd88ffce2a3b/op-service/sources/l2_client.go#L105

this was done here:
https://github.com/ethereum-optimism/optimism/pull/10127

and should be in releases `1.7.4` onwards:
https://github.com/ethereum-optimism/optimism/compare/v1.7.3...op-node/v1.7.4