### PR TITLE
fix: disable timeout on DbTool level

### DIFF
--- a/bin/reth/src/commands/db/list.rs
+++ b/bin/reth/src/commands/db/list.rs
@@ -90,8 +90,6 @@ impl TableViewer<()> for ListTableViewer<'_> {
 
     fn view<T: Table>(&self) -> Result<(), Self::Error> {
         self.tool.provider_factory.db_ref().view(|tx| {
-            // Disable timeout because we are entering a TUI which might read for a long time
-            tx.inner.disable_timeout();
             let table_db = tx.inner.open_db(Some(self.args.table.name())).wrap_err("Could not open db.")?;
             let stats = tx.inner.db_stat(&table_db).wrap_err(format!("Could not find table: {}", stringify!($table)))?;
             let total_entries = stats.entries();

--- a/bin/reth/src/utils.rs
+++ b/bin/reth/src/utils.rs
@@ -36,6 +36,9 @@ pub struct DbTool<DB: Database> {
 impl<DB: Database> DbTool<DB> {
     /// Takes a DB where the tables have already been created.
     pub fn new(provider_factory: ProviderFactory<DB>, chain: Arc<ChainSpec>) -> eyre::Result<Self> {
+        // Disable timeout because we are entering a TUI which might read for a long time. We
+        // disable on the [`DbTool`] level since it's only used in the CLI.
+        provider_factory.provider()?.disable_long_read_transaction_safety();
         Ok(Self { provider_factory, chain })
     }
 


### PR DESCRIPTION
Resolves #7707 .

### Overview

This PR disables timeout on the DbTool level, as it's only used by the CLI. 

### Test Plan

- Ran the unit tests
