### PR TITLE
chore: remove network setup from config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6591,11 +6591,8 @@ version = "0.2.0-beta.7"
 dependencies = [
  "confy",
  "humantime-serde",
- "reth-discv4",
- "reth-net-nat",
  "reth-network",
  "reth-primitives",
- "secp256k1 0.28.2",
  "serde",
  "tempfile",
  "toml",

--- a/bin/reth/src/commands/p2p/mod.rs
+++ b/bin/reth/src/commands/p2p/mod.rs
@@ -15,6 +15,7 @@ use discv5::ListenConfig;
 use reth_config::Config;
 use reth_db::create_db;
 use reth_interfaces::p2p::bodies::client::BodiesClient;
+use reth_network::NetworkConfigBuilder;
 use reth_primitives::{BlockHashOrNumber, ChainSpec};
 use reth_provider::ProviderFactory;
 use std::{
@@ -112,8 +113,9 @@ impl Command {
         let rlpx_socket = (self.network.addr, self.network.port).into();
         let boot_nodes = self.chain.bootnodes().unwrap_or_default();
 
-        let mut network_config_builder = config
-            .network_config(self.network.nat, None, p2p_secret_key)
+        let mut network_config_builder = NetworkConfigBuilder::new(p2p_secret_key)
+            .peer_config(config.peers_config_with_basic_nodes_from_file(None))
+            .external_ip_resolver(self.network.nat)
             .chain_spec(self.chain.clone())
             .disable_discv4_discovery_if(self.chain.chain.is_optimism())
             .boot_nodes(boot_nodes.clone());

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -13,16 +13,11 @@ workspace = true
 [dependencies]
 # reth
 reth-network.workspace = true
-reth-net-nat.workspace = true
-reth-discv4.workspace = true
 reth-primitives.workspace = true
 
 # serde
 serde.workspace = true
 humantime-serde.workspace = true
-
-# crypto
-secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery"] }
 
 # toml
 confy.workspace = true

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -1,9 +1,7 @@
 //! Configuration files.
 
-use reth_discv4::Discv4Config;
-use reth_network::{NetworkConfigBuilder, PeersConfig, SessionsConfig};
+use reth_network::{PeersConfig, SessionsConfig};
 use reth_primitives::PruneModes;
-use secp256k1::SecretKey;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::{
     ffi::OsStr,
@@ -30,25 +28,17 @@ pub struct Config {
 }
 
 impl Config {
-    /// Initializes network config from read data
-    pub fn network_config(
+    /// Returns the [PeersConfig] for the node.
+    ///
+    /// If a peers file is provided, the basic nodes from the file are added to the configuration.
+    pub fn peers_config_with_basic_nodes_from_file(
         &self,
-        nat_resolution_method: reth_net_nat::NatResolver,
-        peers_file: Option<PathBuf>,
-        secret_key: SecretKey,
-    ) -> NetworkConfigBuilder {
-        let peer_config = self
-            .peers
+        peers_file: Option<&Path>,
+    ) -> PeersConfig {
+        self.peers
             .clone()
             .with_basic_nodes_from_file(peers_file)
-            .unwrap_or_else(|_| self.peers.clone());
-
-        let discv4 =
-            Discv4Config::builder().external_ip_resolver(Some(nat_resolution_method)).clone();
-        NetworkConfigBuilder::new(secret_key)
-            .sessions_config(self.sessions.clone())
-            .peer_config(peer_config)
-            .discovery(discv4)
+            .unwrap_or_else(|_| self.peers.clone())
     }
 
     /// Save the configuration to toml file.
@@ -357,8 +347,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{Config, EXTENSION};
     use std::time::Duration;
+
+    use super::{Config, EXTENSION};
 
     fn with_tempdir(filename: &str, proc: fn(&std::path::Path)) {
         let temp_dir = tempfile::tempdir().unwrap();

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -347,9 +347,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
     use super::{Config, EXTENSION};
+    use std::time::Duration;
 
     fn with_tempdir(filename: &str, proc: fn(&std::path::Path)) {
         let temp_dir = tempfile::tempdir().unwrap();

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -5,6 +5,7 @@
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
     issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 pub mod config;

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -8,7 +8,7 @@ use crate::{
     transactions::TransactionsManagerConfig,
     NetworkHandle, NetworkManager,
 };
-use reth_discv4::{Discv4Config, Discv4ConfigBuilder, DEFAULT_DISCOVERY_ADDRESS};
+use reth_discv4::{Discv4Config, Discv4ConfigBuilder, NatResolver, DEFAULT_DISCOVERY_ADDRESS};
 use reth_discv5::NetworkStackId;
 use reth_dns_discovery::DnsDiscoveryConfig;
 use reth_eth_wire::{HelloMessage, HelloMessageWithProtocols, Status};
@@ -311,6 +311,19 @@ impl NetworkConfigBuilder {
     /// By default, this is [DEFAULT_DISCOVERY_PORT](reth_discv4::DEFAULT_DISCOVERY_PORT)
     pub fn discovery_port(mut self, port: u16) -> Self {
         self.discovery_addr.get_or_insert(DEFAULT_DISCOVERY_ADDRESS).set_port(port);
+        self
+    }
+
+    /// Sets the external ip resolver to use for discovery v4.
+    ///
+    /// If no [Discv4ConfigBuilder] is set via [Self::discovery], this will create a new one.
+    ///
+    /// This is a convenience function for setting the external ip resolver on the default
+    /// [Discv4Config] config.
+    pub fn external_ip_resolver(mut self, resolver: NatResolver) -> Self {
+        self.discovery_v4_builder
+            .get_or_insert_with(Discv4Config::builder)
+            .external_ip_resolver(Some(resolver));
         self
     }
 

--- a/crates/node-core/src/args/network.rs
+++ b/crates/node-core/src/args/network.rs
@@ -145,8 +145,11 @@ impl NetworkArgs {
             ),
         };
         // Configure basic network stack
-        let mut network_config_builder = config
-            .network_config(self.nat, self.persistent_peers_file(peers_file), secret_key)
+        let mut network_config_builder = NetworkConfigBuilder::new(secret_key)
+            .peer_config(config.peers_config_with_basic_nodes_from_file(
+                self.persistent_peers_file(peers_file).as_deref(),
+            ))
+            .external_ip_resolver(self.nat)
             .sessions_config(
                 SessionsConfig::default().with_upscaled_event_buffer(peers_config.max_peers()),
             )


### PR DESCRIPTION
removes the networkbuilder helper from the config type and instead use the builder API

this removes a few deps from config crate.

needs followup to extract the peersconfig as well.