### PR TITLE
chore: remove peer types dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7128,8 +7128,8 @@ dependencies = [
 name = "reth-net-common"
 version = "0.2.0-beta.7"
 dependencies = [
+ "alloy-primitives",
  "pin-project",
- "reth-network-types",
  "tokio",
 ]
 

--- a/crates/net/common/Cargo.toml
+++ b/crates/net/common/Cargo.toml
@@ -12,8 +12,8 @@ description = "Types shared across network code"
 workspace = true
 
 [dependencies]
-# reth
-reth-network-types.workspace = true
+# ethereum
+alloy-primitives.workspace = true
 
 # async
 pin-project.workspace = true

--- a/crates/net/common/src/ban_list.rs
+++ b/crates/net/common/src/ban_list.rs
@@ -1,6 +1,7 @@
 //! Support for banning peers.
 
-use reth_network_types::PeerId;
+type PeerId = alloy_primitives::B512;
+
 use std::{collections::HashMap, net::IpAddr, time::Instant};
 
 /// Determines whether or not the IP is globally routable.


### PR DESCRIPTION
dep not required for type alias