### PR TITLE
feat: reset trie updates on make_canonical

### DIFF
--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1211,7 +1211,7 @@ where
                 chain.clear_trie_updates();
             }
         }
-        durations_recorder.record_relative(MakeCanonicalAction::ResetTrieUpdatesForOtherChilds);
+        durations_recorder.record_relative(MakeCanonicalAction::ClearTrieUpdatesForOtherChilds);
 
         // Send notification about new canonical chain and return outcome of canonicalization.
         let outcome = CanonicalOutcome::Committed { head: chain_notification.tip().header.clone() };

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1195,7 +1195,7 @@ where
             "Canonicalization finished"
         );
 
-        // reset trie updates for other childs
+        // clear trie updates for other childs
         let chain_ids: Vec<_> = self
             .block_indices()
             .fork_to_child()
@@ -1203,13 +1203,12 @@ where
             .cloned()
             .unwrap_or_default()
             .into_iter()
-            .filter(|child| child != &block_hash)
             .filter_map(|child| self.block_indices().get_blocks_chain_id(&child))
             .collect();
 
         for chain_id in chain_ids {
             if let Some(chain) = self.state.chains.get_mut(&chain_id) {
-                chain.reset_trie_updates();
+                chain.clear_trie_updates();
             }
         }
         durations_recorder.record_relative(MakeCanonicalAction::ResetTrieUpdatesForOtherChilds);

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1196,7 +1196,7 @@ where
         );
 
         // reset trie updates for other childs
-        let children_chain_id: Vec<_> = self
+        let chain_ids: Vec<_> = self
             .block_indices()
             .fork_to_child()
             .get(&old_tip.hash)
@@ -1204,15 +1204,11 @@ where
             .unwrap_or_default()
             .into_iter()
             .filter(|child| child != &block_hash)
-            .filter_map(|child| {
-                self.block_indices().get_blocks_chain_id(&child).map(|chain_id| (child, chain_id))
-            })
+            .filter_map(|child| self.block_indices().get_blocks_chain_id(&child))
             .collect();
 
-        for (child, chain_id) in children_chain_id {
-            if let Some(mut chain) =
-                self.remove_and_split_chain(chain_id, ChainSplitTarget::Hash(child))
-            {
+        for chain_id in chain_ids {
+            if let Some(chain) = self.state.chains.get_mut(&chain_id) {
                 chain.reset_trie_updates();
             }
         }

--- a/crates/blockchain-tree/src/metrics.rs
+++ b/crates/blockchain-tree/src/metrics.rs
@@ -85,6 +85,8 @@ pub(crate) enum MakeCanonicalAction {
     RevertCanonicalChainFromDatabase,
     /// Inserting an old canonical chain.
     InsertOldCanonicalChain,
+    /// Resetting trie updates of other childs chains after fork choice update.
+    ResetTrieUpdatesForOtherChilds,
 }
 
 impl MakeCanonicalAction {
@@ -104,6 +106,9 @@ impl MakeCanonicalAction {
                 "revert canonical chain from database"
             }
             MakeCanonicalAction::InsertOldCanonicalChain => "insert old canonical chain",
+            MakeCanonicalAction::ResetTrieUpdatesForOtherChilds => {
+                "reset trie updates of other childs chains after fork choice update"
+            }
         }
     }
 }

--- a/crates/blockchain-tree/src/metrics.rs
+++ b/crates/blockchain-tree/src/metrics.rs
@@ -85,8 +85,8 @@ pub(crate) enum MakeCanonicalAction {
     RevertCanonicalChainFromDatabase,
     /// Inserting an old canonical chain.
     InsertOldCanonicalChain,
-    /// Resetting trie updates of other childs chains after fork choice update.
-    ResetTrieUpdatesForOtherChilds,
+    /// Clearing trie updates of other childs chains after fork choice update.
+    ClearTrieUpdatesForOtherChilds,
 }
 
 impl MakeCanonicalAction {
@@ -106,8 +106,8 @@ impl MakeCanonicalAction {
                 "revert canonical chain from database"
             }
             MakeCanonicalAction::InsertOldCanonicalChain => "insert old canonical chain",
-            MakeCanonicalAction::ResetTrieUpdatesForOtherChilds => {
-                "reset trie updates of other childs chains after fork choice update"
+            MakeCanonicalAction::ClearTrieUpdatesForOtherChilds => {
+                "clear trie updates of other childs chains after fork choice update"
             }
         }
     }

--- a/crates/storage/provider/src/chain.rs
+++ b/crates/storage/provider/src/chain.rs
@@ -81,8 +81,8 @@ impl Chain {
         self.trie_updates.as_ref()
     }
 
-    /// Reset cached trie updates for this chain.
-    pub fn reset_trie_updates(&mut self) {
+    /// Remove cached trie updates for this chain.
+    pub fn clear_trie_updates(&mut self) {
         self.trie_updates.take();
     }
 

--- a/crates/storage/provider/src/chain.rs
+++ b/crates/storage/provider/src/chain.rs
@@ -81,6 +81,11 @@ impl Chain {
         self.trie_updates.as_ref()
     }
 
+    /// Reset cached trie updates for this chain.
+    pub fn reset_trie_updates(&mut self) {
+        self.trie_updates.take();
+    }
+
     /// Get post state of this chain
     pub fn state(&self) -> &BundleStateWithReceipts {
         &self.state


### PR DESCRIPTION
Reset trie updates for the rest of the children forking from the canonical tip after a fork choice update. 