### PR TITLE
chore(trie): account specific hashed storage cursor

### DIFF
--- a/crates/trie/src/hashed_cursor/default.rs
+++ b/crates/trie/src/hashed_cursor/default.rs
@@ -8,14 +8,21 @@ use reth_primitives::{Account, StorageEntry, B256};
 
 impl<'a, TX: DbTx> HashedCursorFactory for &'a TX {
     type AccountCursor = <TX as DbTx>::Cursor<tables::HashedAccounts>;
-    type StorageCursor = <TX as DbTx>::DupCursor<tables::HashedStorages>;
+    type StorageCursor =
+        DatabaseHashedStorageCursor<<TX as DbTx>::DupCursor<tables::HashedStorages>>;
 
     fn hashed_account_cursor(&self) -> Result<Self::AccountCursor, reth_db::DatabaseError> {
         self.cursor_read::<tables::HashedAccounts>()
     }
 
-    fn hashed_storage_cursor(&self) -> Result<Self::StorageCursor, reth_db::DatabaseError> {
-        self.cursor_dup_read::<tables::HashedStorages>()
+    fn hashed_storage_cursor(
+        &self,
+        hashed_address: B256,
+    ) -> Result<Self::StorageCursor, reth_db::DatabaseError> {
+        Ok(DatabaseHashedStorageCursor::new(
+            self.cursor_dup_read::<tables::HashedStorages>()?,
+            hashed_address,
+        ))
     }
 }
 
@@ -32,23 +39,35 @@ where
     }
 }
 
-impl<C> HashedStorageCursor for C
+/// The structure wrapping a database cursor for hashed storage and
+/// a target hashed address. Implements [HashedStorageCursor] for iterating
+/// hashed state
+#[derive(Debug)]
+pub struct DatabaseHashedStorageCursor<C> {
+    cursor: C,
+    hashed_address: B256,
+}
+
+impl<C> DatabaseHashedStorageCursor<C> {
+    /// Create new [DatabaseHashedStorageCursor].
+    pub fn new(cursor: C, hashed_address: B256) -> Self {
+        Self { cursor, hashed_address }
+    }
+}
+
+impl<C> HashedStorageCursor for DatabaseHashedStorageCursor<C>
 where
     C: DbCursorRO<tables::HashedStorages> + DbDupCursorRO<tables::HashedStorages>,
 {
-    fn is_storage_empty(&mut self, key: B256) -> Result<bool, reth_db::DatabaseError> {
-        Ok(self.seek_exact(key)?.is_none())
+    fn is_storage_empty(&mut self) -> Result<bool, reth_db::DatabaseError> {
+        Ok(self.cursor.seek_exact(self.hashed_address)?.is_none())
     }
 
-    fn seek(
-        &mut self,
-        key: B256,
-        subkey: B256,
-    ) -> Result<Option<StorageEntry>, reth_db::DatabaseError> {
-        self.seek_by_key_subkey(key, subkey)
+    fn seek(&mut self, subkey: B256) -> Result<Option<StorageEntry>, reth_db::DatabaseError> {
+        self.cursor.seek_by_key_subkey(self.hashed_address, subkey)
     }
 
     fn next(&mut self) -> Result<Option<StorageEntry>, reth_db::DatabaseError> {
-        self.next_dup_val()
+        self.cursor.next_dup_val()
     }
 }

--- a/crates/trie/src/hashed_cursor/mod.rs
+++ b/crates/trie/src/hashed_cursor/mod.rs
@@ -2,6 +2,7 @@ use reth_primitives::{Account, StorageEntry, B256};
 
 /// Default implementation of the hashed state cursor traits.
 mod default;
+pub use default::DatabaseHashedStorageCursor;
 
 /// Implementation of hashed state cursor traits for the post state.
 mod post_state;
@@ -18,7 +19,10 @@ pub trait HashedCursorFactory {
     fn hashed_account_cursor(&self) -> Result<Self::AccountCursor, reth_db::DatabaseError>;
 
     /// Returns a cursor for iterating over all hashed storage entries in the state.
-    fn hashed_storage_cursor(&self) -> Result<Self::StorageCursor, reth_db::DatabaseError>;
+    fn hashed_storage_cursor(
+        &self,
+        hashed_address: B256,
+    ) -> Result<Self::StorageCursor, reth_db::DatabaseError>;
 }
 
 /// The cursor for iterating over hashed accounts.
@@ -33,14 +37,10 @@ pub trait HashedAccountCursor {
 /// The cursor for iterating over hashed storage entries.
 pub trait HashedStorageCursor {
     /// Returns `true` if there are no entries for a given key.
-    fn is_storage_empty(&mut self, key: B256) -> Result<bool, reth_db::DatabaseError>;
+    fn is_storage_empty(&mut self) -> Result<bool, reth_db::DatabaseError>;
 
     /// Seek an entry greater or equal to the given key/subkey and position the cursor there.
-    fn seek(
-        &mut self,
-        key: B256,
-        subkey: B256,
-    ) -> Result<Option<StorageEntry>, reth_db::DatabaseError>;
+    fn seek(&mut self, subkey: B256) -> Result<Option<StorageEntry>, reth_db::DatabaseError>;
 
     /// Move the cursor to the next entry and return it.
     fn next(&mut self) -> Result<Option<StorageEntry>, reth_db::DatabaseError>;

--- a/crates/trie/src/node_iter.rs
+++ b/crates/trie/src/node_iter.rs
@@ -166,8 +166,6 @@ pub struct StorageNodeIter<C, H> {
     pub walker: TrieWalker<C>,
     /// The cursor for the hashed storage entries.
     pub hashed_storage_cursor: H,
-    /// The hashed address this storage trie belongs to.
-    hashed_address: B256,
 
     /// Current hashed storage entry.
     current_hashed_entry: Option<StorageEntry>,
@@ -177,11 +175,10 @@ pub struct StorageNodeIter<C, H> {
 
 impl<C, H> StorageNodeIter<C, H> {
     /// Creates a new instance of StorageNodeIter.
-    pub fn new(walker: TrieWalker<C>, hashed_storage_cursor: H, hashed_address: B256) -> Self {
+    pub fn new(walker: TrieWalker<C>, hashed_storage_cursor: H) -> Self {
         Self {
             walker,
             hashed_storage_cursor,
-            hashed_address,
             current_walker_key_checked: false,
             current_hashed_entry: None,
         }
@@ -238,8 +235,7 @@ where
             // Attempt to get the next unprocessed key from the walker.
             if let Some(seek_key) = self.walker.next_unprocessed_key() {
                 // Seek and update the current hashed entry based on the new seek key.
-                self.current_hashed_entry =
-                    self.hashed_storage_cursor.seek(self.hashed_address, seek_key)?;
+                self.current_hashed_entry = self.hashed_storage_cursor.seek(seek_key)?;
                 self.walker.advance()?;
             } else {
                 // No more keys to process, break the loop.

--- a/crates/trie/src/proof.rs
+++ b/crates/trie/src/proof.rs
@@ -109,12 +109,13 @@ where
         hashed_address: B256,
         slots: &[B256],
     ) -> Result<(B256, Vec<StorageProof>), StorageRootError> {
-        let mut hashed_storage_cursor = self.hashed_cursor_factory.hashed_storage_cursor()?;
+        let mut hashed_storage_cursor =
+            self.hashed_cursor_factory.hashed_storage_cursor(hashed_address)?;
 
         let mut proofs = slots.iter().copied().map(StorageProof::new).collect::<Vec<_>>();
 
         // short circuit on empty storage
-        if hashed_storage_cursor.is_storage_empty(hashed_address)? {
+        if hashed_storage_cursor.is_storage_empty()? {
             return Ok((EMPTY_ROOT_HASH, proofs))
         }
 
@@ -128,8 +129,7 @@ where
 
         let retainer = ProofRetainer::from_iter(target_nibbles);
         let mut hash_builder = HashBuilder::default().with_proof_retainer(retainer);
-        let mut storage_node_iter =
-            StorageNodeIter::new(walker, hashed_storage_cursor, hashed_address);
+        let mut storage_node_iter = StorageNodeIter::new(walker, hashed_storage_cursor);
         while let Some(node) = storage_node_iter.try_next()? {
             match node {
                 StorageNode::Branch(node) => {

--- a/crates/trie/src/trie.rs
+++ b/crates/trie/src/trie.rs
@@ -483,10 +483,11 @@ where
     ) -> Result<(B256, usize, TrieUpdates), StorageRootError> {
         trace!(target: "trie::storage_root", hashed_address = ?self.hashed_address, "calculating storage root");
 
-        let mut hashed_storage_cursor = self.hashed_cursor_factory.hashed_storage_cursor()?;
+        let mut hashed_storage_cursor =
+            self.hashed_cursor_factory.hashed_storage_cursor(self.hashed_address)?;
 
         // short circuit on empty storage
-        if hashed_storage_cursor.is_storage_empty(self.hashed_address)? {
+        if hashed_storage_cursor.is_storage_empty()? {
             return Ok((
                 EMPTY_ROOT_HASH,
                 0,
@@ -500,8 +501,7 @@ where
 
         let mut hash_builder = HashBuilder::default().with_updates(retain_updates);
 
-        let mut storage_node_iter =
-            StorageNodeIter::new(walker, hashed_storage_cursor, self.hashed_address);
+        let mut storage_node_iter = StorageNodeIter::new(walker, hashed_storage_cursor);
         while let Some(node) = storage_node_iter.try_next()? {
             match node {
                 StorageNode::Branch(node) => {


### PR DESCRIPTION
## Description

Refactor hashed storage cursors to be account specific since they are instantiated per account anyway.

P.S. Please, do not merge. I'll do it myself.