### PR TITLE
chore(trie): simplify hashed cursor abstraction

### DIFF
--- a/crates/trie/src/hashed_cursor/default.rs
+++ b/crates/trie/src/hashed_cursor/default.rs
@@ -46,7 +46,9 @@ where
 /// for iterating over hashed storage.
 #[derive(Debug)]
 pub struct DatabaseHashedStorageCursor<C> {
+    /// Database hashed storage cursor.
     cursor: C,
+    /// Target hashed address of the account that the storage belongs to.
     hashed_address: B256,
 }
 

--- a/crates/trie/src/hashed_cursor/default.rs
+++ b/crates/trie/src/hashed_cursor/default.rs
@@ -42,8 +42,8 @@ where
 }
 
 /// The structure wrapping a database cursor for hashed storage and
-/// a target hashed address. Implements [HashedStorageCursor] for iterating
-/// hashed state
+/// a target hashed address. Implements [HashedCursor] and [HashedStorageCursor]
+/// for iterating over hashed storage.
 #[derive(Debug)]
 pub struct DatabaseHashedStorageCursor<C> {
     cursor: C,

--- a/crates/trie/src/hashed_cursor/mod.rs
+++ b/crates/trie/src/hashed_cursor/mod.rs
@@ -1,4 +1,4 @@
-use reth_primitives::{Account, StorageEntry, B256};
+use reth_primitives::{Account, B256, U256};
 
 /// Default implementation of the hashed state cursor traits.
 mod default;
@@ -11,9 +11,9 @@ pub use post_state::*;
 /// The factory trait for creating cursors over the hashed state.
 pub trait HashedCursorFactory {
     /// The hashed account cursor type.
-    type AccountCursor: HashedAccountCursor;
+    type AccountCursor: HashedCursor<Value = Account>;
     /// The hashed storage cursor type.
-    type StorageCursor: HashedStorageCursor;
+    type StorageCursor: HashedStorageCursor<Value = U256>;
 
     /// Returns a cursor for iterating over all hashed accounts in the state.
     fn hashed_account_cursor(&self) -> Result<Self::AccountCursor, reth_db::DatabaseError>;
@@ -25,23 +25,20 @@ pub trait HashedCursorFactory {
     ) -> Result<Self::StorageCursor, reth_db::DatabaseError>;
 }
 
-/// The cursor for iterating over hashed accounts.
-pub trait HashedAccountCursor {
+/// The cursor for iterating over hashed entries.
+pub trait HashedCursor {
+    /// Value returned by the cursor.
+    type Value;
+
     /// Seek an entry greater or equal to the given key and position the cursor there.
-    fn seek(&mut self, key: B256) -> Result<Option<(B256, Account)>, reth_db::DatabaseError>;
+    fn seek(&mut self, key: B256) -> Result<Option<(B256, Self::Value)>, reth_db::DatabaseError>;
 
     /// Move the cursor to the next entry and return it.
-    fn next(&mut self) -> Result<Option<(B256, Account)>, reth_db::DatabaseError>;
+    fn next(&mut self) -> Result<Option<(B256, Self::Value)>, reth_db::DatabaseError>;
 }
 
 /// The cursor for iterating over hashed storage entries.
-pub trait HashedStorageCursor {
+pub trait HashedStorageCursor: HashedCursor {
     /// Returns `true` if there are no entries for a given key.
     fn is_storage_empty(&mut self) -> Result<bool, reth_db::DatabaseError>;
-
-    /// Seek an entry greater or equal to the given key/subkey and position the cursor there.
-    fn seek(&mut self, subkey: B256) -> Result<Option<StorageEntry>, reth_db::DatabaseError>;
-
-    /// Move the cursor to the next entry and return it.
-    fn next(&mut self) -> Result<Option<StorageEntry>, reth_db::DatabaseError>;
 }

--- a/crates/trie/src/hashed_cursor/mod.rs
+++ b/crates/trie/src/hashed_cursor/mod.rs
@@ -31,6 +31,7 @@ pub trait HashedCursor {
     type Value;
 
     /// Seek an entry greater or equal to the given key and position the cursor there.
+    /// Returns the first entry with the key greater or equal to the sought key.
     fn seek(&mut self, key: B256) -> Result<Option<(B256, Self::Value)>, reth_db::DatabaseError>;
 
     /// Move the cursor to the next entry and return it.

--- a/crates/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/src/hashed_cursor/post_state.rs
@@ -194,7 +194,7 @@ pub struct HashedPostStateStorageCursor<'b, C> {
 }
 
 impl<'b, C> HashedPostStateStorageCursor<'b, C> {
-    /// Create new instance of [HashedPostStateStorageCursor].
+    /// Create new instance of [HashedPostStateStorageCursor] for the given hashed address.
     pub fn new(cursor: C, post_state: &'b HashedPostStateSorted, hashed_address: B256) -> Self {
         Self { cursor, post_state, hashed_address, last_slot: None, post_state_storage_index: 0 }
     }

--- a/crates/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/src/hashed_cursor/post_state.rs
@@ -101,7 +101,7 @@ where
     /// database and the post state. The two entries are compared and the lowest is returned.
     ///
     /// The returned account key is memoized and the cursor remains positioned at that key until
-    /// [HashedAccountCursor::seek] or [HashedAccountCursor::next] are called.
+    /// [HashedCursor::seek] or [HashedCursor::next] are called.
     fn seek(&mut self, key: B256) -> Result<Option<(B256, Self::Value)>, reth_db::DatabaseError> {
         self.last_account = None;
 
@@ -144,7 +144,7 @@ where
     /// If the cursor is positioned at the entry, return the entry with next greater key.
     /// Returns [None] if the previous memoized or the next greater entries are missing.
     ///
-    /// NOTE: This function will not return any entry unless [HashedAccountCursor::seek] has been
+    /// NOTE: This function will not return any entry unless [HashedCursor::seek] has been
     /// called.
     fn next(&mut self) -> Result<Option<(B256, Self::Value)>, reth_db::DatabaseError> {
         let last_account = match self.last_account.as_ref() {
@@ -300,7 +300,7 @@ where
     ///
     /// # Panics
     ///
-    /// If the account key is not set. [HashedStorageCursor::seek] must be called first in order to
+    /// If the account key is not set. [HashedCursor::seek] must be called first in order to
     /// position the cursor.
     fn next(&mut self) -> Result<Option<(B256, Self::Value)>, reth_db::DatabaseError> {
         let last_slot = match self.last_slot.as_ref() {
@@ -349,8 +349,8 @@ where
 {
     /// Returns `true` if the account has no storage entries.
     ///
-    /// This function should be called before attempting to call [HashedStorageCursor::seek] or
-    /// [HashedStorageCursor::next].
+    /// This function should be called before attempting to call [HashedCursor::seek] or
+    /// [HashedCursor::next].
     fn is_storage_empty(&mut self) -> Result<bool, reth_db::DatabaseError> {
         let is_empty = match self.post_state.storages.get(&self.hashed_address) {
             Some(storage) => {


### PR DESCRIPTION
## Description

Builds on top of #8377.

Refactor hashed cursors abstractions. Unify common methods to a single `HashedCursor`. Make `HashedStorageCursor` trait extend the `HashedCursor` trait.