### PR TITLE
chore: replace interfaces dep with storage-errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6646,6 +6646,7 @@ dependencies = [
  "reth-metrics",
  "reth-nippy-jar",
  "reth-primitives",
+ "reth-storage-errors",
  "reth-tracing",
  "rustc-hash",
  "serde",

--- a/crates/storage/db/Cargo.toml
+++ b/crates/storage/db/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 # reth
 reth-primitives.workspace = true
 reth-fs-util.workspace = true
-reth-interfaces.workspace = true
+reth-storage-errors.workspace = true
 reth-codecs.workspace = true
 reth-libmdbx = { workspace = true, optional = true, features = [
     "return-borrowed",

--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -11,8 +11,8 @@ use crate::{
     tables::utils::*,
     DatabaseError,
 };
-use reth_interfaces::db::{DatabaseErrorInfo, DatabaseWriteError, DatabaseWriteOperation};
 use reth_libmdbx::{Error as MDBXError, TransactionKind, WriteFlags, RO, RW};
+use reth_storage_errors::db::{DatabaseErrorInfo, DatabaseWriteError, DatabaseWriteOperation};
 use std::{borrow::Cow, collections::Bound, marker::PhantomData, ops::RangeBounds, sync::Arc};
 
 /// Read only Cursor.

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -13,11 +13,11 @@ use crate::{
 };
 use eyre::Context;
 use metrics::{gauge, Label};
-use reth_interfaces::db::LogLevel;
 use reth_libmdbx::{
     DatabaseFlags, Environment, EnvironmentFlags, Geometry, MaxReadTransactionDuration, Mode,
     PageSize, SyncMode, RO, RW,
 };
+use reth_storage_errors::db::LogLevel;
 use reth_tracing::tracing::error;
 use std::{
     ops::Deref,
@@ -455,9 +455,9 @@ mod tests {
         test_utils::*,
         AccountChangeSets,
     };
-    use reth_interfaces::db::{DatabaseWriteError, DatabaseWriteOperation};
     use reth_libmdbx::Error;
     use reth_primitives::{Account, Address, Header, IntegerList, StorageEntry, B256, U256};
+    use reth_storage_errors::db::{DatabaseWriteError, DatabaseWriteOperation};
     use std::str::FromStr;
     use tempfile::TempDir;
 

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -9,8 +9,8 @@ use crate::{
     DatabaseError,
 };
 use once_cell::sync::OnceCell;
-use reth_interfaces::db::{DatabaseWriteError, DatabaseWriteOperation};
 use reth_libmdbx::{ffi::DBI, CommitLatency, Transaction, TransactionKind, WriteFlags, RW};
+use reth_storage_errors::db::{DatabaseWriteError, DatabaseWriteOperation};
 use reth_tracing::tracing::{debug, trace, warn};
 use std::{
     backtrace::Backtrace,
@@ -395,8 +395,8 @@ mod tests {
         database::Database, mdbx::DatabaseArguments, models::client_version::ClientVersion, tables,
         transaction::DbTx, DatabaseEnv, DatabaseEnvKind,
     };
-    use reth_interfaces::db::DatabaseError;
     use reth_libmdbx::MaxReadTransactionDuration;
+    use reth_storage_errors::db::DatabaseError;
     use std::{sync::atomic::Ordering, thread::sleep, time::Duration};
     use tempfile::tempdir;
 

--- a/crates/storage/db/src/lib.rs
+++ b/crates/storage/db/src/lib.rs
@@ -81,7 +81,7 @@ pub mod mdbx {
 }
 
 pub use abstraction::*;
-pub use reth_interfaces::db::{DatabaseError, DatabaseWriteOperation};
+pub use reth_storage_errors::db::{DatabaseError, DatabaseWriteOperation};
 pub use tables::*;
 pub use utils::is_database_empty;
 

--- a/crates/storage/db/src/static_file/cursor.rs
+++ b/crates/storage/db/src/static_file/cursor.rs
@@ -1,9 +1,9 @@
 use super::mask::{ColumnSelectorOne, ColumnSelectorThree, ColumnSelectorTwo};
 use crate::table::Decompress;
 use derive_more::{Deref, DerefMut};
-use reth_interfaces::provider::{ProviderError, ProviderResult};
 use reth_nippy_jar::{DataReader, NippyJar, NippyJarCursor};
 use reth_primitives::{static_file::SegmentHeader, B256};
+use reth_storage_errors::provider::{ProviderError, ProviderResult};
 use std::sync::Arc;
 
 /// Cursor of a static file segment.

--- a/crates/storage/db/src/static_file/generation.rs
+++ b/crates/storage/db/src/static_file/generation.rs
@@ -5,8 +5,8 @@ use crate::{
     RawKey, RawTable,
 };
 
-use reth_interfaces::provider::{ProviderError, ProviderResult};
 use reth_nippy_jar::{ColumnResult, NippyJar, NippyJarHeader, PHFKey};
+use reth_storage_errors::provider::{ProviderError, ProviderResult};
 use reth_tracing::tracing::*;
 use std::{error::Error as StdError, ops::RangeInclusive};
 


### PR DESCRIPTION
storage errors have been moved, can now be imported with less bloat