### PR TITLE
chore: add 0BSD to deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -38,6 +38,7 @@ allow = [
     "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "0BSD",
     "ISC",
     "Unicode-DFS-2016",
     "Unlicense",


### PR DESCRIPTION
This license is permissive, see https://spdx.org/licenses/ for more info