### PR TITLE
chore(docs): clarify tree canonical chain docs

### DIFF
--- a/crates/blockchain-tree/src/block_indices.rs
+++ b/crates/blockchain-tree/src/block_indices.rs
@@ -17,9 +17,9 @@ use std::collections::{btree_map, hash_map, BTreeMap, BTreeSet, HashMap, HashSet
 pub struct BlockIndices {
     /// Last finalized block.
     last_finalized_block: BlockNumber,
-    /// Canonical chain. Contains N number (depends on `finalization_depth`) of blocks.
-    /// These blocks are found in fork_to_child but not inside `blocks_to_chain` or
-    /// `number_to_block` as those are chain specific indices.
+    /// Non-finalized canonical chain. Contains N number (depends on `finalization_depth`) of
+    /// blocks. These blocks are found in fork_to_child but not inside `blocks_to_chain` or
+    /// `number_to_block` as those are sidechain specific indices.
     canonical_chain: CanonicalChain,
     /// Index needed when discarding the chain, so we can remove connected chains from tree.
     ///
@@ -101,14 +101,6 @@ impl BlockIndices {
         (canonical_tip.number + 1, pending_blocks)
     }
 
-    /// Returns the block number of the canonical block with the given hash.
-    ///
-    /// Returns `None` if no block could be found in the canonical chain.
-    #[inline]
-    pub(crate) fn get_canonical_block_number(&self, block_hash: &BlockHash) -> Option<BlockNumber> {
-        self.canonical_chain.get_canonical_block_number(self.last_finalized_block, block_hash)
-    }
-
     /// Last finalized block
     pub fn last_finalized_block(&self) -> BlockNumber {
         self.last_finalized_block
@@ -138,8 +130,8 @@ impl BlockIndices {
         self.fork_to_child.entry(first.parent_hash).or_default().insert_if_absent(first.hash());
     }
 
-    /// Get the chain ID the block belongs to
-    pub(crate) fn get_blocks_chain_id(&self, block: &BlockHash) -> Option<BlockchainId> {
+    /// Get the [BlockchainId] the given block belongs to if it exists.
+    pub(crate) fn get_block_chain_id(&self, block: &BlockHash) -> Option<BlockchainId> {
         self.blocks_to_chain.get(block).cloned()
     }
 
@@ -370,7 +362,7 @@ impl BlockIndices {
 
     /// Returns the block number of the canonical block with the given hash.
     #[inline]
-    pub fn canonical_number(&self, block_hash: BlockHash) -> Option<BlockNumber> {
+    pub fn canonical_number(&self, block_hash: &BlockHash) -> Option<BlockNumber> {
         self.canonical_chain.canonical_number(block_hash)
     }
 

--- a/crates/blockchain-tree/src/canonical_chain.rs
+++ b/crates/blockchain-tree/src/canonical_chain.rs
@@ -1,13 +1,13 @@
 use reth_primitives::{BlockHash, BlockNumHash, BlockNumber};
 use std::collections::BTreeMap;
 
-/// This keeps track of all blocks of the canonical chain.
+/// This keeps track of (non-finalized) blocks of the canonical chain.
 ///
 /// This is a wrapper type around an ordered set of block numbers and hashes that belong to the
-/// canonical chain.
+/// canonical chain that is not yet finalized.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct CanonicalChain {
-    /// All blocks of the canonical chain in order.
+    /// All blocks of the canonical chain in order of their block number.
     chain: BTreeMap<BlockNumber, BlockHash>,
 }
 
@@ -22,38 +22,24 @@ impl CanonicalChain {
         self.chain = chain;
     }
 
-    /// Returns the block hash of the canonical block with the given number.
+    /// Returns the block hash of the (non-finalized) canonical block with the given number.
     #[inline]
     pub(crate) fn canonical_hash(&self, number: &BlockNumber) -> Option<BlockHash> {
         self.chain.get(number).cloned()
     }
 
-    /// Returns the block number of the canonical block with the given hash.
+    /// Returns the block number of the (non-finalized) canonical block with the given hash.
     #[inline]
-    pub(crate) fn canonical_number(&self, block_hash: BlockHash) -> Option<BlockNumber> {
+    pub(crate) fn canonical_number(&self, block_hash: &BlockHash) -> Option<BlockNumber> {
         self.chain.iter().find_map(
             |(number, hash)| {
-                if *hash == block_hash {
+                if hash == block_hash {
                     Some(*number)
                 } else {
                     None
                 }
             },
         )
-    }
-
-    /// Returns the block number of the canonical block with the given hash.
-    ///
-    /// Returns `None` if no block could be found in the canonical chain.
-    #[inline]
-    pub(crate) fn get_canonical_block_number(
-        &self,
-        last_finalized_block: BlockNumber,
-        block_hash: &BlockHash,
-    ) -> Option<BlockNumber> {
-        self.chain
-            .range(last_finalized_block..)
-            .find_map(|(num, &h)| (h == *block_hash).then_some(*num))
     }
 
     /// Extends all items from the given iterator to the chain.

--- a/crates/blockchain-tree/src/state.rs
+++ b/crates/blockchain-tree/src/state.rs
@@ -68,7 +68,7 @@ impl TreeState {
         &self,
         block_hash: BlockHash,
     ) -> Option<&SealedBlockWithSenders> {
-        let id = self.block_indices.get_blocks_chain_id(&block_hash)?;
+        let id = self.block_indices.get_block_chain_id(&block_hash)?;
         let chain = self.chains.get(&id)?;
         chain.block_with_senders(block_hash)
     }
@@ -77,7 +77,7 @@ impl TreeState {
     ///
     /// Caution: This will not return blocks from the canonical chain.
     pub(crate) fn receipts_by_block_hash(&self, block_hash: BlockHash) -> Option<Vec<&Receipt>> {
-        let id = self.block_indices.get_blocks_chain_id(&block_hash)?;
+        let id = self.block_indices.get_block_chain_id(&block_hash)?;
         let chain = self.chains.get(&id)?;
         chain.receipts_by_block_hash(block_hash)
     }


### PR DESCRIPTION
clarifies some comments wrt. sidechain/non-finalized canonical etc.

also removes useless get_canonical_block_number function which was ambiguous and didn't do anything really because the `CanonicalChain` already only tracks non finalized blocks