### PR TITLE
chore: rm NetworkError variant from RethError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7073,7 +7073,6 @@ dependencies = [
  "reth-consensus",
  "reth-execution-errors",
  "reth-fs-util",
- "reth-network-api",
  "reth-network-p2p",
  "reth-storage-errors",
  "thiserror",

--- a/crates/consensus/beacon/src/engine/hooks/controller.rs
+++ b/crates/consensus/beacon/src/engine/hooks/controller.rs
@@ -330,7 +330,7 @@ mod tests {
         let hook_ro_name = "read-only";
         let mut hook_ro = TestHook::new_ro(hook_ro_name);
         hook_ro.add_result(Ok(EngineHookEvent::Started));
-        hook_ro.add_result(Err(RethError::Custom("something went wrong".to_string())));
+        hook_ro.add_result(Err(RethError::msg("something went wrong")));
 
         let mut hooks = EngineHooks::new();
         hooks.add(hook_rw_1);

--- a/crates/interfaces/Cargo.toml
+++ b/crates/interfaces/Cargo.toml
@@ -15,7 +15,6 @@ reth-blockchain-tree-api.workspace = true
 reth-consensus.workspace = true
 reth-execution-errors.workspace = true
 reth-fs-util.workspace = true
-reth-network-api.workspace = true
 reth-network-p2p.workspace = true
 reth-storage-errors.workspace = true
 

--- a/crates/interfaces/src/error.rs
+++ b/crates/interfaces/src/error.rs
@@ -83,6 +83,5 @@ mod size_asserts {
     static_assert_size!(ConsensusError, 48);
     static_assert_size!(DatabaseError, 40);
     static_assert_size!(ProviderError, 48);
-    static_assert_size!(NetworkError, 0);
     static_assert_size!(CanonicalError, 56);
 }

--- a/crates/interfaces/src/error.rs
+++ b/crates/interfaces/src/error.rs
@@ -2,8 +2,8 @@ use crate::blockchain_tree::error::{BlockchainTreeError, CanonicalError};
 use reth_consensus::ConsensusError;
 use reth_execution_errors::BlockExecutionError;
 use reth_fs_util::FsPathError;
-use reth_network_api::NetworkError;
 use reth_storage_errors::{db::DatabaseError, provider::ProviderError};
+use std::fmt::Display;
 
 /// Result alias for [`RethError`].
 pub type RethResult<T> = Result<T, RethError>;
@@ -31,17 +31,28 @@ pub enum RethError {
     #[error(transparent)]
     Provider(#[from] ProviderError),
 
-    /// Errors related to networking.
-    #[error(transparent)]
-    Network(#[from] NetworkError),
-
     /// Canonical errors encountered.
     #[error(transparent)]
     Canonical(#[from] CanonicalError),
 
-    /// Custom error message.
-    #[error("{0}")]
-    Custom(String),
+    /// Any other error.
+    #[error(transparent)]
+    Other(Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl RethError {
+    /// Create a new `RethError` from a given error.
+    pub fn other<E>(error: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        RethError::Other(Box::new(error))
+    }
+
+    /// Create a new `RethError` from a given message.
+    pub fn msg(msg: impl Display) -> Self {
+        RethError::Other(msg.to_string().into())
+    }
 }
 
 impl From<BlockchainTreeError> for RethError {
@@ -52,7 +63,7 @@ impl From<BlockchainTreeError> for RethError {
 
 impl From<FsPathError> for RethError {
     fn from(err: FsPathError) -> Self {
-        RethError::Custom(err.to_string())
+        RethError::other(err)
     }
 }
 

--- a/crates/prune/src/error.rs
+++ b/crates/prune/src/error.rs
@@ -26,7 +26,7 @@ impl From<PrunerError> for RethError {
     fn from(err: PrunerError) -> Self {
         match err {
             PrunerError::PruneSegment(_) | PrunerError::InconsistentData(_) => {
-                RethError::Custom(err.to_string())
+                RethError::other(err)
             }
             PrunerError::Interface(err) => err,
             PrunerError::Database(err) => RethError::Database(err),

--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -14,7 +14,7 @@ use crate::eth::{
 
 use async_trait::async_trait;
 use reth_evm::ConfigureEvm;
-use reth_interfaces::RethResult;
+use reth_interfaces::{RethError, RethResult};
 use reth_network_api::NetworkInfo;
 use reth_primitives::{
     revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg},
@@ -391,7 +391,7 @@ where
     ///
     /// Note: This returns an `U64`, since this should return as hex string.
     async fn protocol_version(&self) -> RethResult<U64> {
-        let status = self.network().network_status().await?;
+        let status = self.network().network_status().await.map_err(RethError::other)?;
         Ok(U64::from(status.protocol_version))
     }
 

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -87,7 +87,7 @@ impl ProviderFactory<DatabaseEnv> {
         static_files_path: PathBuf,
     ) -> RethResult<Self> {
         Ok(ProviderFactory::<DatabaseEnv> {
-            db: Arc::new(init_db(path, args).map_err(|e| RethError::Custom(e.to_string()))?),
+            db: Arc::new(init_db(path, args).map_err(|e| RethError::msg(e))?),
             chain_spec,
             static_file_provider: StaticFileProvider::new(static_files_path)?,
         })

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -7,7 +7,10 @@ use crate::{
     ProviderError, PruneCheckpointReader, StageCheckpointReader, StateProviderBox,
     StaticFileProviderFactory, TransactionVariant, TransactionsProvider, WithdrawalsProvider,
 };
-use reth_db::{database::Database, init_db, models::StoredBlockBodyIndices, DatabaseEnv};
+use reth_db::{
+    database::Database, init_db, mdbx::DatabaseArguments, models::StoredBlockBodyIndices,
+    DatabaseEnv,
+};
 use reth_evm::ConfigureEvmEnv;
 use reth_interfaces::{RethError, RethResult};
 use reth_primitives::{
@@ -17,6 +20,7 @@ use reth_primitives::{
     SealedHeader, StaticFileSegment, TransactionMeta, TransactionSigned, TransactionSignedNoHash,
     TxHash, TxNumber, Withdrawal, Withdrawals, B256, U256,
 };
+use reth_storage_errors::provider::ProviderResult;
 use revm::primitives::{BlockEnv, CfgEnvWithHandlerCfg};
 use std::{
     ops::{RangeBounds, RangeInclusive},
@@ -29,8 +33,6 @@ mod metrics;
 mod provider;
 
 pub use provider::{DatabaseProvider, DatabaseProviderRO, DatabaseProviderRW};
-use reth_db::mdbx::DatabaseArguments;
-use reth_storage_errors::provider::ProviderResult;
 
 /// A common provider that fetches data from a database or static file.
 ///
@@ -87,7 +89,7 @@ impl ProviderFactory<DatabaseEnv> {
         static_files_path: PathBuf,
     ) -> RethResult<Self> {
         Ok(ProviderFactory::<DatabaseEnv> {
-            db: Arc::new(init_db(path, args).map_err(|e| RethError::msg(e))?),
+            db: Arc::new(init_db(path, args).map_err(RethError::msg)?),
             chain_spec,
             static_file_provider: StaticFileProvider::new(static_files_path)?,
         })


### PR DESCRIPTION
this variant was only used for a single rpc ethapi call

replace `custom(String)` with `Other(dyn Error)` and use that instead