### PR TITLE
chore: move EvmEnvProvider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6989,6 +6989,7 @@ dependencies = [
 name = "reth-evm"
 version = "0.2.0-beta.7"
 dependencies = [
+ "auto_impl",
  "futures-util",
  "parking_lot 0.12.3",
  "reth-execution-errors",

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -19,6 +19,7 @@ reth-storage-errors.workspace = true
 
 revm.workspace = true
 
+auto_impl.workspace = true
 futures-util.workspace = true
 parking_lot = { workspace = true, optional = true }
 

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -16,6 +16,7 @@ use revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg, EnvWithHandlerCfg, SpecId,
 
 pub mod either;
 pub mod execute;
+pub mod provider;
 
 #[cfg(any(test, feature = "test-utils"))]
 /// test helpers for mocking executor

--- a/crates/evm/src/provider.rs
+++ b/crates/evm/src/provider.rs
@@ -1,12 +1,15 @@
-use reth_evm::ConfigureEvmEnv;
+//! Provider trait for populating the EVM environment.
+
+use crate::ConfigureEvmEnv;
 use reth_primitives::{BlockHashOrNumber, Header};
 use reth_storage_errors::provider::ProviderResult;
 use revm::primitives::{BlockEnv, CfgEnv, CfgEnvWithHandlerCfg, SpecId};
 
-/// A provider type that knows chain specific information required to configure an
+/// A provider type that knows chain specific information required to configure a
 /// [CfgEnvWithHandlerCfg].
 ///
-/// This type is mainly used to provide required data to configure the EVM environment.
+/// This type is mainly used to provide required data to configure the EVM environment that is
+/// usually stored on disk.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait EvmEnvProvider: Send + Sync {
     /// Fills the [CfgEnvWithHandlerCfg] and [BlockEnv] fields with values specific to the given

--- a/crates/storage/provider/src/traits/mod.rs
+++ b/crates/storage/provider/src/traits/mod.rs
@@ -18,8 +18,8 @@ pub use block_hash::BlockHashReader;
 mod block_id;
 pub use block_id::{BlockIdReader, BlockNumReader};
 
-mod evm_env;
-pub use evm_env::EvmEnvProvider;
+// Re-export for convenience
+pub use reth_evm::provider::EvmEnvProvider;
 
 mod chain_info;
 pub use chain_info::CanonChainTracker;


### PR DESCRIPTION
more progress on #8342 

moves the trait def to the evm crate and for now re-export in reth-provider