### PR TITLE
chore(tree): remove unused `BlockchainTreeViewer` methods

### DIFF
--- a/crates/blockchain-tree-api/src/lib.rs
+++ b/crates/blockchain-tree-api/src/lib.rs
@@ -266,11 +266,6 @@ pub enum InsertPayloadOk {
 /// * Pending blocks that extend the canonical chain but are not yet included.
 /// * Future pending blocks that extend the pending blocks.
 pub trait BlockchainTreeViewer: Send + Sync {
-    /// Returns both pending and side-chain block numbers and their hashes.
-    ///
-    /// Caution: This will not return blocks from the canonical chain.
-    fn blocks(&self) -> BTreeMap<BlockNumber, HashSet<BlockHash>>;
-
     /// Returns the header with matching hash from the tree, if it exists.
     ///
     /// Caution: This will not return headers from the canonical chain.
@@ -288,13 +283,6 @@ pub trait BlockchainTreeViewer: Send + Sync {
     /// disconnected from the canonical chain.
     fn block_with_senders_by_hash(&self, hash: BlockHash) -> Option<SealedBlockWithSenders>;
 
-    /// Returns the _buffered_ (disconnected) block with matching hash from the internal buffer if
-    /// it exists.
-    ///
-    /// Caution: Unlike [Self::block_by_hash] this will only return blocks that are currently
-    /// disconnected from the canonical chain.
-    fn buffered_block_by_hash(&self, block_hash: BlockHash) -> Option<SealedBlock>;
-
     /// Returns the _buffered_ (disconnected) header with matching hash from the internal buffer if
     /// it exists.
     ///
@@ -307,9 +295,6 @@ pub trait BlockchainTreeViewer: Send + Sync {
         self.block_by_hash(hash).is_some()
     }
 
-    /// Canonical block number and hashes best known by the tree.
-    fn canonical_blocks(&self) -> BTreeMap<BlockNumber, BlockHash>;
-
     /// Return whether or not the block is known and in the canonical chain.
     fn is_canonical(&self, hash: BlockHash) -> Result<bool, ProviderError>;
 
@@ -321,11 +306,6 @@ pub trait BlockchainTreeViewer: Send + Sync {
 
     /// Return BlockchainTree best known canonical chain tip (BlockHash, BlockNumber)
     fn canonical_tip(&self) -> BlockNumHash;
-
-    /// Return block hashes that extends the canonical chain tip by one.
-    /// This is used to fetch what is considered the pending blocks, blocks that
-    /// has best chance to become canonical.
-    fn pending_blocks(&self) -> (BlockNumber, Vec<BlockHash>);
 
     /// Return block number and hash that extends the canonical chain tip by one.
     ///

--- a/crates/blockchain-tree-api/src/lib.rs
+++ b/crates/blockchain-tree-api/src/lib.rs
@@ -14,7 +14,7 @@ use reth_primitives::{
     SealedHeader,
 };
 use reth_storage_errors::provider::ProviderError;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 
 pub mod error;
 

--- a/crates/blockchain-tree/src/block_indices.rs
+++ b/crates/blockchain-tree/src/block_indices.rs
@@ -57,14 +57,6 @@ impl BlockIndices {
         }
     }
 
-    /// Return internal index that maps all pending block number to their hashes.
-    ///
-    /// This essentially contains all possible branches. Given a parent block, then the child block
-    /// number as the key has all possible block hashes as the value.
-    pub fn block_number_to_block_hashes(&self) -> &BTreeMap<BlockNumber, HashSet<BlockHash>> {
-        &self.block_number_to_block_hashes
-    }
-
     /// Return fork to child indices
     pub fn fork_to_child(&self) -> &HashMap<BlockHash, LinkedHashSet<BlockHash>> {
         &self.fork_to_child

--- a/crates/blockchain-tree/src/noop.rs
+++ b/crates/blockchain-tree/src/noop.rs
@@ -12,7 +12,7 @@ use reth_provider::{
     BlockchainTreePendingStateProvider, CanonStateNotificationSender, CanonStateNotifications,
     CanonStateSubscriptions, FullBundleStateDataProvider,
 };
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 
 /// A BlockchainTree that does nothing.
 ///
@@ -74,10 +74,6 @@ impl BlockchainTreeEngine for NoopBlockchainTree {
 }
 
 impl BlockchainTreeViewer for NoopBlockchainTree {
-    fn blocks(&self) -> BTreeMap<BlockNumber, HashSet<BlockHash>> {
-        Default::default()
-    }
-
     fn header_by_hash(&self, _hash: BlockHash) -> Option<SealedHeader> {
         None
     }
@@ -90,16 +86,8 @@ impl BlockchainTreeViewer for NoopBlockchainTree {
         None
     }
 
-    fn buffered_block_by_hash(&self, _block_hash: BlockHash) -> Option<SealedBlock> {
-        None
-    }
-
     fn buffered_header_by_hash(&self, _block_hash: BlockHash) -> Option<SealedHeader> {
         None
-    }
-
-    fn canonical_blocks(&self) -> BTreeMap<BlockNumber, BlockHash> {
-        Default::default()
     }
 
     fn is_canonical(&self, _block_hash: BlockHash) -> Result<bool, ProviderError> {
@@ -112,10 +100,6 @@ impl BlockchainTreeViewer for NoopBlockchainTree {
 
     fn canonical_tip(&self) -> BlockNumHash {
         Default::default()
-    }
-
-    fn pending_blocks(&self) -> (BlockNumber, Vec<BlockHash>) {
-        (0, vec![])
     }
 
     fn pending_block_num_hash(&self) -> Option<BlockNumHash> {

--- a/crates/blockchain-tree/src/shareable.rs
+++ b/crates/blockchain-tree/src/shareable.rs
@@ -17,10 +17,7 @@ use reth_provider::{
     BlockchainTreePendingStateProvider, CanonStateSubscriptions, FullBundleStateDataProvider,
     ProviderError,
 };
-use std::{
-    collections::{BTreeMap, HashSet},
-    sync::Arc,
-};
+use std::{collections::BTreeMap, sync::Arc};
 use tracing::trace;
 
 /// Shareable blockchain tree that is behind a RwLock
@@ -111,11 +108,6 @@ where
     DB: Database + Clone,
     E: BlockExecutorProvider,
 {
-    fn blocks(&self) -> BTreeMap<BlockNumber, HashSet<BlockHash>> {
-        trace!(target: "blockchain_tree", "Returning all blocks in blockchain tree");
-        self.tree.read().block_indices().block_number_to_block_hashes().clone()
-    }
-
     fn header_by_hash(&self, hash: BlockHash) -> Option<SealedHeader> {
         trace!(target: "blockchain_tree", ?hash, "Returning header by hash");
         self.tree.read().block_by_hash(hash).map(|b| b.header.clone())
@@ -131,17 +123,8 @@ where
         self.tree.read().block_with_senders_by_hash(block_hash).cloned()
     }
 
-    fn buffered_block_by_hash(&self, block_hash: BlockHash) -> Option<SealedBlock> {
-        self.tree.read().get_buffered_block(&block_hash).map(|b| b.block.clone())
-    }
-
     fn buffered_header_by_hash(&self, block_hash: BlockHash) -> Option<SealedHeader> {
         self.tree.read().get_buffered_block(&block_hash).map(|b| b.header.clone())
-    }
-
-    fn canonical_blocks(&self) -> BTreeMap<BlockNumber, BlockHash> {
-        trace!(target: "blockchain_tree", "Returning canonical blocks in tree");
-        self.tree.read().block_indices().canonical_chain().inner().clone()
     }
 
     fn is_canonical(&self, hash: BlockHash) -> Result<bool, ProviderError> {
@@ -157,11 +140,6 @@ where
     fn canonical_tip(&self) -> BlockNumHash {
         trace!(target: "blockchain_tree", "Returning canonical tip");
         self.tree.read().block_indices().canonical_tip()
-    }
-
-    fn pending_blocks(&self) -> (BlockNumber, Vec<BlockHash>) {
-        trace!(target: "blockchain_tree", "Returning all pending blocks");
-        self.tree.read().block_indices().pending_blocks()
     }
 
     fn pending_block_num_hash(&self) -> Option<BlockNumHash> {

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -28,7 +28,7 @@ use reth_primitives::{
 use reth_storage_errors::provider::ProviderResult;
 use revm::primitives::{BlockEnv, CfgEnvWithHandlerCfg};
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::BTreeMap,
     ops::{RangeBounds, RangeInclusive},
     sync::Arc,
     time::Instant,
@@ -692,10 +692,6 @@ impl<DB> BlockchainTreeViewer for BlockchainProvider<DB>
 where
     DB: Send + Sync,
 {
-    fn blocks(&self) -> BTreeMap<BlockNumber, HashSet<BlockHash>> {
-        self.tree.blocks()
-    }
-
     fn header_by_hash(&self, hash: BlockHash) -> Option<SealedHeader> {
         self.tree.header_by_hash(hash)
     }
@@ -708,16 +704,8 @@ where
         self.tree.block_with_senders_by_hash(block_hash)
     }
 
-    fn buffered_block_by_hash(&self, block_hash: BlockHash) -> Option<SealedBlock> {
-        self.tree.buffered_block_by_hash(block_hash)
-    }
-
     fn buffered_header_by_hash(&self, block_hash: BlockHash) -> Option<SealedHeader> {
         self.tree.buffered_header_by_hash(block_hash)
-    }
-
-    fn canonical_blocks(&self) -> BTreeMap<BlockNumber, BlockHash> {
-        self.tree.canonical_blocks()
     }
 
     fn is_canonical(&self, hash: BlockHash) -> Result<bool, ProviderError> {
@@ -730,10 +718,6 @@ where
 
     fn canonical_tip(&self) -> BlockNumHash {
         self.tree.canonical_tip()
-    }
-
-    fn pending_blocks(&self) -> (BlockNumber, Vec<BlockHash>) {
-        self.tree.pending_blocks()
     }
 
     fn pending_block_num_hash(&self) -> Option<BlockNumHash> {


### PR DESCRIPTION
## Description

Remove unused `BlockchainTreeViewer` methods.