### PR TITLE
chore: move Chain type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7066,6 +7066,7 @@ name = "reth-execution-types"
 version = "0.2.0-beta.7"
 dependencies = [
  "reth-evm",
+ "reth-execution-errors",
  "reth-primitives",
  "reth-trie",
  "revm",
@@ -7678,7 +7679,6 @@ dependencies = [
  "reth-codecs",
  "reth-db",
  "reth-evm",
- "reth-execution-errors",
  "reth-execution-types",
  "reth-fs-util",
  "reth-interfaces",

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -18,11 +18,10 @@ use reth_primitives::{
     SealedBlock, SealedBlockWithSenders, SealedHeader, StaticFileSegment, B256, U256,
 };
 use reth_provider::{
-    chain::{ChainSplit, ChainSplitTarget},
     BlockExecutionWriter, BlockNumReader, BlockWriter, BundleStateWithReceipts,
     CanonStateNotification, CanonStateNotificationSender, CanonStateNotifications, Chain,
-    ChainSpecProvider, DisplayBlocksChain, HeaderProvider, ProviderError,
-    StaticFileProviderFactory,
+    ChainSpecProvider, ChainSplit, ChainSplitTarget, DisplayBlocksChain, HeaderProvider,
+    ProviderError, StaticFileProviderFactory,
 };
 use reth_stages_api::{MetricEvent, MetricEventsSender};
 use reth_storage_errors::provider::{ProviderResult, RootMismatch};

--- a/crates/evm/execution-types/Cargo.toml
+++ b/crates/evm/execution-types/Cargo.toml
@@ -12,10 +12,14 @@ workspace = true
 
 [dependencies]
 reth-primitives.workspace = true
+reth-execution-errors.workspace = true
 reth-trie.workspace = true
 reth-evm.workspace = true
 
 revm.workspace = true
+
+[dev-dependencies]
+reth-primitives = { workspace = true, features = ["test-utils"] }
 
 [features]
 optimism = []

--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -1,6 +1,6 @@
 //! Contains [Chain], a chain of blocks and their final state.
 
-use crate::bundle_state::BundleStateWithReceipts;
+use crate::BundleStateWithReceipts;
 use reth_execution_errors::BlockExecutionError;
 use reth_primitives::{
     Address, BlockHash, BlockNumHash, BlockNumber, ForkBlock, Receipt, SealedBlock,

--- a/crates/evm/execution-types/src/lib.rs
+++ b/crates/evm/execution-types/src/lib.rs
@@ -10,3 +10,6 @@
 
 mod bundle;
 pub use bundle::*;
+
+mod chain;
+pub use chain::*;

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 [dependencies]
 # reth
 reth-blockchain-tree-api.workspace = true
-reth-execution-errors.workspace = true
 reth-execution-types.workspace = true
 reth-primitives.workspace = true
 reth-fs-util.workspace = true

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -31,11 +31,10 @@ pub mod test_utils;
 /// Re-export provider error.
 pub use reth_storage_errors::provider::ProviderError;
 
-pub mod chain;
-pub use chain::{Chain, DisplayBlocksChain};
+pub use reth_execution_types::*;
 
 pub mod bundle_state;
-pub use bundle_state::{BundleStateWithReceipts, OriginalValuesKnown, StateChanges, StateReverts};
+pub use bundle_state::{OriginalValuesKnown, StateChanges, StateReverts};
 
 pub(crate) fn to_range<R: std::ops::RangeBounds<u64>>(bounds: R) -> std::ops::Range<u64> {
     let start = match bounds.start_bound() {

--- a/crates/storage/provider/src/traits/chain.rs
+++ b/crates/storage/provider/src/traits/chain.rs
@@ -1,6 +1,6 @@
 //! Canonical chain state notification trait and types.
 
-use crate::{chain::BlockReceipts, Chain};
+use crate::{BlockReceipts, Chain};
 use auto_impl::auto_impl;
 use reth_primitives::SealedBlockWithSenders;
 use std::{

--- a/crates/transaction-pool/src/blobstore/tracker.rs
+++ b/crates/transaction-pool/src/blobstore/tracker.rs
@@ -1,7 +1,7 @@
 //! Support for maintaining the blob pool.
 
 use reth_primitives::{BlockNumber, B256};
-use reth_provider::chain::ChainBlocks;
+use reth_provider::ChainBlocks;
 use std::collections::BTreeMap;
 
 /// The type that is used to track canonical blob transactions.


### PR DESCRIPTION
move `Chain` types to execution-types