### PR TITLE
chore: use noop consensus for op import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6643,7 +6643,6 @@ dependencies = [
  "mockall",
  "reth-consensus",
  "reth-interfaces",
- "reth-optimism-primitives",
  "reth-primitives",
  "reth-provider",
 ]

--- a/bin/reth/src/commands/import_op.rs
+++ b/bin/reth/src/commands/import_op.rs
@@ -11,8 +11,8 @@ use crate::{
     version::SHORT_VERSION,
 };
 use clap::Parser;
-use reth_beacon_consensus::EthBeaconConsensus;
 use reth_config::{config::EtlConfig, Config};
+use reth_consensus::noop::NoopConsensus;
 use reth_db::{init_db, tables, transaction::DbTx};
 use reth_db_common::init::init_genesis;
 use reth_downloaders::file_client::{
@@ -98,8 +98,8 @@ impl ImportOpCommand {
 
         init_genesis(provider_factory.clone())?;
 
-        let consensus = Arc::new(EthBeaconConsensus::new(chain_spec.clone()));
-        info!(target: "reth::cli", "Consensus engine initialized");
+        // we use noop here because we expect the inputs to be valid
+        let consensus = Arc::new(NoopConsensus::default());
 
         // open file
         let mut reader = ChunkedFileReader::new(&self.path, self.chunk_len).await?;

--- a/crates/consensus/common/Cargo.toml
+++ b/crates/consensus/common/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 [dependencies]
 # reth
 reth-primitives.workspace = true
-reth-optimism-primitives.workspace = true
 reth-consensus.workspace=true
 
 [dev-dependencies]

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -1,7 +1,6 @@
 //! Collection of methods for block validation.
 
 use reth_consensus::ConsensusError;
-use reth_optimism_primitives::bedrock_import::is_dup_tx;
 use reth_primitives::{
     constants::{
         eip4844::{DATA_GAS_PER_BLOB, MAX_DATA_GAS_PER_BLOCK},
@@ -82,10 +81,8 @@ pub fn validate_block_pre_execution(
     }
 
     // Check transaction root
-    if !chain_spec.is_optimism_mainnet() || !is_dup_tx(block.number) {
-        if let Err(error) = block.ensure_transaction_root_valid() {
-            return Err(ConsensusError::BodyTransactionRootDiff(error.into()))
-        }
+    if let Err(error) = block.ensure_transaction_root_valid() {
+        return Err(ConsensusError::BodyTransactionRootDiff(error.into()))
     }
 
     // EIP-4895: Beacon chain push withdrawals as operations

--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -15,6 +15,9 @@ use reth_primitives::{
 };
 use std::fmt::Debug;
 
+/// A consensus implementation that does nothing.
+pub mod noop;
+
 #[cfg(any(test, feature = "test-utils"))]
 /// test helpers for mocking consensus
 pub mod test_utils;

--- a/crates/consensus/consensus/src/noop.rs
+++ b/crates/consensus/consensus/src/noop.rs
@@ -1,0 +1,41 @@
+use crate::{Consensus, ConsensusError, PostExecutionInput};
+use reth_primitives::{BlockWithSenders, Header, SealedBlock, SealedHeader, U256};
+
+/// A Consensus implementation that does nothing.
+#[derive(Debug, Copy, Clone, Default)]
+#[non_exhaustive]
+pub struct NoopConsensus;
+
+impl Consensus for NoopConsensus {
+    fn validate_header(&self, _header: &SealedHeader) -> Result<(), ConsensusError> {
+        Ok(())
+    }
+
+    fn validate_header_against_parent(
+        &self,
+        _header: &SealedHeader,
+        _parent: &SealedHeader,
+    ) -> Result<(), ConsensusError> {
+        Ok(())
+    }
+
+    fn validate_header_with_total_difficulty(
+        &self,
+        _header: &Header,
+        _total_difficulty: U256,
+    ) -> Result<(), ConsensusError> {
+        Ok(())
+    }
+
+    fn validate_block_pre_execution(&self, _block: &SealedBlock) -> Result<(), ConsensusError> {
+        Ok(())
+    }
+
+    fn validate_block_post_execution(
+        &self,
+        _block: &BlockWithSenders,
+        _input: PostExecutionInput<'_>,
+    ) -> Result<(), ConsensusError> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
this removes hardcoded op bedrock checks from the regular consensus functions and uses a new NoopConsensus import for the OP import.

This is reasonable because we assume the data is valid.