### PR TITLE
fix: save last finalized block

### DIFF
--- a/bin/reth/src/commands/stage/unwind.rs
+++ b/bin/reth/src/commands/stage/unwind.rs
@@ -8,11 +8,10 @@ use reth_db_api::database::Database;
 use reth_downloaders::{bodies::noop::NoopBodiesDownloader, headers::noop::NoopHeaderDownloader};
 use reth_exex::ExExManagerHandle;
 use reth_node_core::args::NetworkArgs;
-use reth_primitives::{BlockHashOrNumber, BlockNumber, ChainSpec, PruneModes, B256};
+use reth_primitives::{BlockHashOrNumber, BlockNumber, PruneModes, B256};
 use reth_provider::{
-    providers::StaticFileProvider, BlockExecutionWriter, BlockNumReader, ChainSpecProvider,
-    FinalizedBlockReader, FinalizedBlockWriter, HeaderSyncMode, ProviderFactory,
-    StaticFileProviderFactory,
+    BlockExecutionWriter, BlockNumReader, ChainSpecProvider, FinalizedBlockReader,
+    FinalizedBlockWriter, HeaderSyncMode, ProviderFactory, StaticFileProviderFactory,
 };
 use reth_stages::{
     sets::DefaultStages,

--- a/bin/reth/src/commands/stage/unwind.rs
+++ b/bin/reth/src/commands/stage/unwind.rs
@@ -76,8 +76,7 @@ impl Command {
                 .map_err(|err| eyre::eyre!("Transaction error on unwind: {err}"))?;
 
             // update finalized block if needed
-            let last_saved_finalized_block_number =
-                provider.fetch_latest_finalized_block_number()?;
+            let last_saved_finalized_block_number = provider.last_finalized_block_number()?;
             let range_min =
                 range.clone().min().ok_or(eyre::eyre!("Could not fetch lower range end"))?;
             if range_min < last_saved_finalized_block_number {

--- a/crates/blockchain-tree-api/src/lib.rs
+++ b/crates/blockchain-tree-api/src/lib.rs
@@ -13,7 +13,7 @@ use reth_primitives::{
     BlockHash, BlockNumHash, BlockNumber, Receipt, SealedBlock, SealedBlockWithSenders,
     SealedHeader,
 };
-use reth_storage_errors::provider::ProviderError;
+use reth_storage_errors::provider::{ProviderError, ProviderResult};
 use std::collections::BTreeMap;
 
 pub mod error;
@@ -69,7 +69,7 @@ pub trait BlockchainTreeEngine: BlockchainTreeViewer + Send + Sync {
     ) -> Result<InsertPayloadOk, InsertBlockError>;
 
     /// Finalize blocks up until and including `finalized_block`, and remove them from the tree.
-    fn finalize_block(&self, finalized_block: BlockNumber);
+    fn finalize_block(&self, finalized_block: BlockNumber) -> ProviderResult<()>;
 
     /// Reads the last `N` canonical hashes from the database and updates the block indices of the
     /// tree by attempting to connect the buffered blocks to canonical hashes.

--- a/crates/blockchain-tree/Cargo.toml
+++ b/crates/blockchain-tree/Cargo.toml
@@ -45,6 +45,7 @@ reth-db = { workspace = true, features = ["test-utils"] }
 reth-primitives = { workspace = true, features = ["test-utils"] }
 reth-provider = { workspace = true, features = ["test-utils"] }
 reth-evm = { workspace = true, features = ["test-utils"] }
+reth-consensus = { workspace = true, features = ["test-utils"] }
 reth-testing-utils.workspace = true
 reth-revm.workspace = true
 reth-evm-ethereum.workspace = true

--- a/crates/blockchain-tree/src/block_indices.rs
+++ b/crates/blockchain-tree/src/block_indices.rs
@@ -342,6 +342,7 @@ impl BlockIndices {
 
         // set last finalized block.
         self.last_finalized_block = finalized_block;
+
         lose_chains
     }
 

--- a/crates/blockchain-tree/src/block_indices.rs
+++ b/crates/blockchain-tree/src/block_indices.rs
@@ -320,14 +320,6 @@ impl BlockIndices {
             .filter(|(number, _)| *number >= self.last_finalized_block && *number < finalized_block)
             .map(|(_, hash)| hash)
             .collect();
-        println!(
-            "in BlockIndices::finalize_canonical_blocks, self.last_finalized_block: {} before",
-            self.last_finalized_block
-        );
-        println!(
-            "in BlockIndices::finalize_canonical_blocks finalized_blocks.len(): {}",
-            finalized_blocks.len()
-        );
 
         // remove unneeded canonical hashes.
         let remove_until =
@@ -350,10 +342,6 @@ impl BlockIndices {
 
         // set last finalized block.
         self.last_finalized_block = finalized_block;
-        println!(
-            "in BlockIndices::finalize_canonical_blocks, self.last_finalized_block: {} after",
-            self.last_finalized_block
-        );
         lose_chains
     }
 

--- a/crates/blockchain-tree/src/block_indices.rs
+++ b/crates/blockchain-tree/src/block_indices.rs
@@ -320,8 +320,14 @@ impl BlockIndices {
             .filter(|(number, _)| *number >= self.last_finalized_block && *number < finalized_block)
             .map(|(_, hash)| hash)
             .collect();
-        println!("self.last_finalized_block: {}", self.last_finalized_block);
-        println!("finalized_blocks.len(): {}", finalized_blocks.len());
+        println!(
+            "in BlockIndices::finalize_canonical_blocks, self.last_finalized_block: {} before",
+            self.last_finalized_block
+        );
+        println!(
+            "in BlockIndices::finalize_canonical_blocks finalized_blocks.len(): {}",
+            finalized_blocks.len()
+        );
 
         // remove unneeded canonical hashes.
         let remove_until =
@@ -344,7 +350,10 @@ impl BlockIndices {
 
         // set last finalized block.
         self.last_finalized_block = finalized_block;
-
+        println!(
+            "in BlockIndices::finalize_canonical_blocks, self.last_finalized_block: {} after",
+            self.last_finalized_block
+        );
         lose_chains
     }
 

--- a/crates/blockchain-tree/src/block_indices.rs
+++ b/crates/blockchain-tree/src/block_indices.rs
@@ -320,6 +320,8 @@ impl BlockIndices {
             .filter(|(number, _)| *number >= self.last_finalized_block && *number < finalized_block)
             .map(|(_, hash)| hash)
             .collect();
+        println!("self.last_finalized_block: {}", self.last_finalized_block);
+        println!("finalized_blocks.len(): {}", finalized_blocks.len());
 
         // remove unneeded canonical hashes.
         let remove_until =

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -20,8 +20,8 @@ use reth_primitives::{
 use reth_provider::{
     BlockExecutionWriter, BlockNumReader, BlockWriter, BundleStateWithReceipts,
     CanonStateNotification, CanonStateNotificationSender, CanonStateNotifications, Chain,
-    ChainSpecProvider, ChainSplit, ChainSplitTarget, DisplayBlocksChain, FinalizedBlockProvider,
-    HeaderProvider, ProviderError, StaticFileProviderFactory,
+    ChainSpecProvider, ChainSplit, ChainSplitTarget, DisplayBlocksChain, HeaderProvider,
+    ProviderError, StaticFileProviderFactory,
 };
 use reth_stages_api::{MetricEvent, MetricEventsSender};
 use reth_storage_errors::provider::{ProviderResult, RootMismatch};

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -20,8 +20,8 @@ use reth_primitives::{
 use reth_provider::{
     BlockExecutionWriter, BlockNumReader, BlockWriter, BundleStateWithReceipts,
     CanonStateNotification, CanonStateNotificationSender, CanonStateNotifications, Chain,
-    ChainSpecProvider, ChainSplit, ChainSplitTarget, DisplayBlocksChain, HeaderProvider,
-    ProviderError, StaticFileProviderFactory,
+    ChainSpecProvider, ChainSplit, ChainSplitTarget, DisplayBlocksChain, FinalizedBlockProvider,
+    HeaderProvider, ProviderError, StaticFileProviderFactory,
 };
 use reth_stages_api::{MetricEvent, MetricEventsSender};
 use reth_storage_errors::provider::{ProviderResult, RootMismatch};

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -2421,6 +2421,6 @@ mod tests {
         let tree =
             BlockchainTree::new(cloned_externals_2, config, None).expect("failed to create tree");
 
-        assert_eq!(tree.block_indices().last_finalized_block(), 11);
+        assert_eq!(tree.block_indices().last_finalized_block(), block1a.number);
     }
 }

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -2367,14 +2367,8 @@ mod tests {
         let genesis = data.genesis;
 
         // test pops execution results from vector, so order is from last to first.
-        let externals = setup_externals(vec![
-            exec3.clone(),
-            exec2.clone(),
-            exec1.clone(),
-            exec3.clone(),
-            exec2.clone(),
-            exec1.clone(),
-        ]);
+        let externals =
+            setup_externals(vec![exec3.clone(), exec2.clone(), exec1.clone(), exec3, exec2, exec1]);
         let cloned_externals = TreeExternals {
             provider_factory: externals.provider_factory.clone(),
             executor_factory: externals.executor_factory.clone(),
@@ -2399,7 +2393,7 @@ mod tests {
         );
 
         assert_eq!(
-            tree.insert_block(block3.clone(), BlockValidationKind::Exhaustive).unwrap(),
+            tree.insert_block(block3, BlockValidationKind::Exhaustive).unwrap(),
             InsertPayloadOk::Inserted(BlockStatus::Valid(BlockAttachment::Canonical))
         );
 
@@ -2410,7 +2404,7 @@ mod tests {
         let mut tree =
             BlockchainTree::new(cloned_externals, config, None).expect("failed to create tree");
 
-        let mut block1a = block1.clone();
+        let mut block1a = block1;
         let block1a_hash = B256::new([0x33; 32]);
         block1a.set_hash(block1a_hash);
 

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -119,6 +119,7 @@ where
         prune_modes: Option<PruneModes>,
     ) -> ProviderResult<Self> {
         let max_reorg_depth = config.max_reorg_depth() as usize;
+        println!("in BlochainTree::new, max_reorg_depth: {max_reorg_depth}");
         // The size of the broadcast is twice the maximum reorg depth, because at maximum reorg
         // depth at least N blocks must be sent at once.
         let (canon_state_notification_sender, _receiver) =
@@ -126,6 +127,14 @@ where
 
         let last_canonical_hashes =
             externals.fetch_latest_canonical_hashes(config.num_of_canonical_hashes() as usize)?;
+        println!(
+            "in BlochainTree::new, num_of_canonical_hashes: {}",
+            config.num_of_canonical_hashes()
+        );
+        println!(
+            "in BlochainTree::new, last_canonical_hashes.keys(): {:?}",
+            last_canonical_hashes.keys()
+        );
 
         // TODO(rakita) save last finalized block inside database but for now just take
         // `tip - max_reorg_depth`
@@ -139,11 +148,6 @@ where
         }
         .copied()
         .unwrap_or_default();
-        println!(
-            "in BlochainTree::new, last_canonical_hashes.len(): {}",
-            last_canonical_hashes.len()
-        );
-        println!("in BlochainTree::new, max_reorg_depth: {max_reorg_depth}");
         println!(
             "in BlochainTree::new, last_finalized_block_number: {last_finalized_block_number}"
         );

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -2399,7 +2399,6 @@ mod tests {
         tree.make_canonical(block2.hash()).unwrap();
 
         // restart
-        drop(tree);
         let mut tree =
             BlockchainTree::new(cloned_externals_1, config, None).expect("failed to create tree");
         assert_eq!(tree.block_indices().last_finalized_block(), 0);
@@ -2417,7 +2416,6 @@ mod tests {
         tree.finalize_block(block1a.number).unwrap();
 
         // restart
-        drop(tree);
         let tree =
             BlockchainTree::new(cloned_externals_2, config, None).expect("failed to create tree");
 

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -127,18 +127,7 @@ where
         let last_canonical_hashes =
             externals.fetch_latest_canonical_hashes(config.num_of_canonical_hashes() as usize)?;
 
-        // TODO(rakita) save last finalized block inside database but for now just take
-        // `tip - max_reorg_depth`
-        // https://github.com/paradigmxyz/reth/issues/1712
-        let last_finalized_block_number = if last_canonical_hashes.len() > max_reorg_depth {
-            // we pick `Highest - max_reorg_depth` block as last finalized block.
-            last_canonical_hashes.keys().nth_back(max_reorg_depth)
-        } else {
-            // we pick the lowest block as last finalized block.
-            last_canonical_hashes.keys().next()
-        }
-        .copied()
-        .unwrap_or_default();
+        let last_finalized_block_number = externals.fetch_latest_finalized_block_number()?;
 
         Ok(Self {
             externals,
@@ -803,7 +792,7 @@ where
     }
 
     /// Finalize blocks up until and including `finalized_block`, and remove them from the tree.
-    pub fn finalize_block(&mut self, finalized_block: BlockNumber) {
+    pub fn finalize_block(&mut self, finalized_block: BlockNumber) -> ProviderResult<()> {
         // remove blocks
         let mut remove_chains = self.state.block_indices.finalize_canonical_blocks(
             finalized_block,
@@ -817,6 +806,11 @@ where
         }
         // clean block buffer.
         self.remove_old_blocks(finalized_block);
+
+        // save finalized block in db.
+        self.externals.save_finalized_block_number(finalized_block)?;
+
+        Ok(())
     }
 
     /// Reads the last `N` canonical hashes from the database and updates the block indices of the
@@ -834,7 +828,7 @@ where
         &mut self,
         last_finalized_block: BlockNumber,
     ) -> ProviderResult<()> {
-        self.finalize_block(last_finalized_block);
+        self.finalize_block(last_finalized_block)?;
 
         let last_canonical_hashes = self.update_block_hashes()?;
 
@@ -1738,7 +1732,7 @@ mod tests {
         tree.make_canonical(B256::ZERO).unwrap();
 
         // make genesis block 10 as finalized
-        tree.finalize_block(10);
+        tree.finalize_block(10).unwrap();
 
         assert_eq!(
             tree.insert_block(block1.clone(), BlockValidationKind::Exhaustive).unwrap(),
@@ -1814,7 +1808,7 @@ mod tests {
         tree.make_canonical(B256::ZERO).unwrap();
 
         // make genesis block 10 as finalized
-        tree.finalize_block(10);
+        tree.finalize_block(10).unwrap();
 
         assert_eq!(
             tree.insert_block(block1.clone(), BlockValidationKind::Exhaustive).unwrap(),
@@ -1899,7 +1893,7 @@ mod tests {
         tree.make_canonical(B256::ZERO).unwrap();
 
         // make genesis block 10 as finalized
-        tree.finalize_block(10);
+        tree.finalize_block(10).unwrap();
 
         assert_eq!(
             tree.insert_block(block1.clone(), BlockValidationKind::Exhaustive).unwrap(),
@@ -2003,7 +1997,7 @@ mod tests {
         tree.is_block_hash_canonical(&B256::ZERO).unwrap();
 
         // make genesis block 10 as finalized
-        tree.finalize_block(head.number);
+        tree.finalize_block(head.number).unwrap();
 
         // block 2 parent is not known, block2 is buffered.
         assert_eq!(
@@ -2253,7 +2247,7 @@ mod tests {
         assert!(tree.is_block_hash_canonical(&block2.hash()).unwrap());
 
         // finalize b1 that would make b1a removed from tree
-        tree.finalize_block(11);
+        tree.finalize_block(11).unwrap();
         // Trie state:
         // b2   b2a (side chain)
         // |   /
@@ -2369,7 +2363,12 @@ mod tests {
         // test pops execution results from vector, so order is from last to first.
         let externals =
             setup_externals(vec![exec3.clone(), exec2.clone(), exec1.clone(), exec3, exec2, exec1]);
-        let cloned_externals = TreeExternals {
+        let cloned_externals_1 = TreeExternals {
+            provider_factory: externals.provider_factory.clone(),
+            executor_factory: externals.executor_factory.clone(),
+            consensus: externals.consensus.clone(),
+        };
+        let cloned_externals_2 = TreeExternals {
             provider_factory: externals.provider_factory.clone(),
             executor_factory: externals.executor_factory.clone(),
             consensus: externals.consensus.clone(),
@@ -2402,7 +2401,8 @@ mod tests {
         // restart
         drop(tree);
         let mut tree =
-            BlockchainTree::new(cloned_externals, config, None).expect("failed to create tree");
+            BlockchainTree::new(cloned_externals_1, config, None).expect("failed to create tree");
+        assert_eq!(tree.block_indices().last_finalized_block(), 0);
 
         let mut block1a = block1;
         let block1a_hash = B256::new([0x33; 32]);
@@ -2414,6 +2414,13 @@ mod tests {
         );
 
         tree.make_canonical(block1a.hash()).unwrap();
-        tree.finalize_block(block1a.number);
+        tree.finalize_block(block1a.number).unwrap();
+
+        // restart
+        drop(tree);
+        let tree =
+            BlockchainTree::new(cloned_externals_2, config, None).expect("failed to create tree");
+
+        assert_eq!(tree.block_indices().last_finalized_block(), 11);
     }
 }

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -119,7 +119,6 @@ where
         prune_modes: Option<PruneModes>,
     ) -> ProviderResult<Self> {
         let max_reorg_depth = config.max_reorg_depth() as usize;
-        println!("in BlochainTree::new, max_reorg_depth: {max_reorg_depth}");
         // The size of the broadcast is twice the maximum reorg depth, because at maximum reorg
         // depth at least N blocks must be sent at once.
         let (canon_state_notification_sender, _receiver) =
@@ -127,14 +126,6 @@ where
 
         let last_canonical_hashes =
             externals.fetch_latest_canonical_hashes(config.num_of_canonical_hashes() as usize)?;
-        println!(
-            "in BlochainTree::new, num_of_canonical_hashes: {}",
-            config.num_of_canonical_hashes()
-        );
-        println!(
-            "in BlochainTree::new, last_canonical_hashes.keys(): {:?}",
-            last_canonical_hashes.keys()
-        );
 
         // TODO(rakita) save last finalized block inside database but for now just take
         // `tip - max_reorg_depth`
@@ -148,9 +139,6 @@ where
         }
         .copied()
         .unwrap_or_default();
-        println!(
-            "in BlochainTree::new, last_finalized_block_number: {last_finalized_block_number}"
-        );
 
         Ok(Self {
             externals,
@@ -2378,7 +2366,6 @@ mod tests {
         let (block3, exec3) = data.blocks[2].clone();
         let genesis = data.genesis;
 
-        println!("block1 number: {}", block1.number);
         // test pops execution results from vector, so order is from last to first.
         let externals = setup_externals(vec![
             exec3.clone(),

--- a/crates/blockchain-tree/src/externals.rs
+++ b/crates/blockchain-tree/src/externals.rs
@@ -1,12 +1,21 @@
 //! Blockchain tree externals.
 
 use reth_consensus::Consensus;
-use reth_db::{static_file::HeaderMask, tables};
+use reth_db::{
+    cursor::DbCursorRO,
+    database::Database,
+    static_file::HeaderMask,
+    tables,
+    transaction::{DbTx, DbTxMut},
+};
 use reth_db_api::{cursor::DbCursorRO, database::Database, transaction::DbTx};
 use reth_primitives::{BlockHash, BlockNumber, StaticFileSegment};
 use reth_provider::{ProviderFactory, StaticFileProviderFactory, StatsReader};
 use reth_storage_errors::provider::ProviderResult;
 use std::{collections::BTreeMap, sync::Arc};
+
+/// Table key used to read and write the last finalized block.
+const FINALIZED_BLOCKS_KEY: u64 = 0;
 
 /// A container for external components.
 ///
@@ -80,5 +89,32 @@ impl<DB: Database, E> TreeExternals<DB, E> {
         // the requested number.
         let hashes = hashes.into_iter().rev().take(num_hashes).collect();
         Ok(hashes)
+    }
+
+    /// Fetches and returns the latest finalized block number.
+    pub(crate) fn fetch_latest_finalized_block_number(&self) -> ProviderResult<BlockNumber> {
+        let mut finalized_blocks = self
+            .provider_factory
+            .provider()?
+            .tx_ref()
+            .cursor_read::<tables::FinalizedBlocks>()?
+            .walk(Some(FINALIZED_BLOCKS_KEY))?
+            .take(1)
+            .collect::<Result<BTreeMap<BlockNumber, BlockNumber>, _>>()?;
+
+        let last_finalized_block_number = finalized_blocks.pop_first().unwrap_or_default();
+        Ok(last_finalized_block_number.1)
+    }
+
+    /// Saves finalized block.
+    pub(crate) fn save_finalized_block_number(
+        &self,
+        block_number: BlockNumber,
+    ) -> ProviderResult<()> {
+        let provider = self.provider_factory.provider_rw()?;
+        provider.tx_ref().put::<tables::FinalizedBlocks>(FINALIZED_BLOCKS_KEY, block_number)?;
+        provider.commit()?;
+
+        Ok(())
     }
 }

--- a/crates/blockchain-tree/src/externals.rs
+++ b/crates/blockchain-tree/src/externals.rs
@@ -15,7 +15,7 @@ use reth_storage_errors::provider::ProviderResult;
 use std::{collections::BTreeMap, sync::Arc};
 
 /// Table key used to read and write the last finalized block.
-const FINALIZED_BLOCKS_KEY: u64 = 0;
+const FINALIZED_BLOCKS_KEY: u8 = 0;
 
 /// A container for external components.
 ///
@@ -100,7 +100,7 @@ impl<DB: Database, E> TreeExternals<DB, E> {
             .cursor_read::<tables::FinalizedBlocks>()?
             .walk(Some(FINALIZED_BLOCKS_KEY))?
             .take(1)
-            .collect::<Result<BTreeMap<BlockNumber, BlockNumber>, _>>()?;
+            .collect::<Result<BTreeMap<u8, BlockNumber>, _>>()?;
 
         let last_finalized_block_number = finalized_blocks.pop_first().unwrap_or_default();
         Ok(last_finalized_block_number.1)

--- a/crates/blockchain-tree/src/externals.rs
+++ b/crates/blockchain-tree/src/externals.rs
@@ -86,7 +86,7 @@ impl<DB: Database, E> TreeExternals<DB, E> {
     }
 
     pub(crate) fn fetch_latest_finalized_block_number(&self) -> ProviderResult<BlockNumber> {
-        self.provider_factory.provider()?.fetch_latest_finalized_block_number()
+        self.provider_factory.provider()?.last_finalized_block_number()
     }
 
     pub(crate) fn save_finalized_block_number(

--- a/crates/blockchain-tree/src/externals.rs
+++ b/crates/blockchain-tree/src/externals.rs
@@ -1,9 +1,7 @@
 //! Blockchain tree externals.
 
 use reth_consensus::Consensus;
-use reth_db::{
-    cursor::DbCursorRO, database::Database, static_file::HeaderMask, tables, transaction::DbTx,
-};
+use reth_db::{static_file::HeaderMask, tables};
 use reth_db_api::{cursor::DbCursorRO, database::Database, transaction::DbTx};
 use reth_primitives::{BlockHash, BlockNumber, StaticFileSegment};
 use reth_provider::{

--- a/crates/blockchain-tree/src/noop.rs
+++ b/crates/blockchain-tree/src/noop.rs
@@ -12,7 +12,8 @@ use reth_provider::{
     BlockchainTreePendingStateProvider, CanonStateNotificationSender, CanonStateNotifications,
     CanonStateSubscriptions, FullBundleStateDataProvider,
 };
-use std::collections::BTreeMap;
+use reth_storage_errors::provider::ProviderResult;
+use std::collections::{BTreeMap, HashSet};
 
 /// A `BlockchainTree` that does nothing.
 ///
@@ -49,7 +50,9 @@ impl BlockchainTreeEngine for NoopBlockchainTree {
         ))
     }
 
-    fn finalize_block(&self, _finalized_block: BlockNumber) {}
+    fn finalize_block(&self, _finalized_block: BlockNumber) -> ProviderResult<()> {
+        Ok(())
+    }
 
     fn connect_buffered_blocks_to_canonical_hashes_and_finalize(
         &self,

--- a/crates/blockchain-tree/src/noop.rs
+++ b/crates/blockchain-tree/src/noop.rs
@@ -13,7 +13,7 @@ use reth_provider::{
     CanonStateSubscriptions, FullBundleStateDataProvider,
 };
 use reth_storage_errors::provider::ProviderResult;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 
 /// A `BlockchainTree` that does nothing.
 ///

--- a/crates/blockchain-tree/src/shareable.rs
+++ b/crates/blockchain-tree/src/shareable.rs
@@ -17,7 +17,11 @@ use reth_provider::{
     BlockchainTreePendingStateProvider, CanonStateSubscriptions, FullBundleStateDataProvider,
     ProviderError,
 };
-use std::{collections::BTreeMap, sync::Arc};
+use reth_storage_errors::provider::ProviderResult;
+use std::{
+    collections::{BTreeMap, HashSet},
+    sync::Arc,
+};
 use tracing::trace;
 
 /// Shareable blockchain tree that is behind a `RwLock`
@@ -58,11 +62,13 @@ where
         res
     }
 
-    fn finalize_block(&self, finalized_block: BlockNumber) {
+    fn finalize_block(&self, finalized_block: BlockNumber) -> ProviderResult<()> {
         trace!(target: "blockchain_tree", finalized_block, "Finalizing block");
         let mut tree = self.tree.write();
-        tree.finalize_block(finalized_block);
+        tree.finalize_block(finalized_block)?;
         tree.update_chains_metrics();
+
+        Ok(())
     }
 
     fn connect_buffered_blocks_to_canonical_hashes_and_finalize(

--- a/crates/blockchain-tree/src/shareable.rs
+++ b/crates/blockchain-tree/src/shareable.rs
@@ -18,10 +18,7 @@ use reth_provider::{
     ProviderError,
 };
 use reth_storage_errors::provider::ProviderResult;
-use std::{
-    collections::{BTreeMap, HashSet},
-    sync::Arc,
-};
+use std::{collections::BTreeMap, sync::Arc};
 use tracing::trace;
 
 /// Shareable blockchain tree that is behind a `RwLock`

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -960,7 +960,7 @@ where
                 .blockchain
                 .find_block_by_hash(finalized_block_hash, BlockSource::Any)?
                 .ok_or_else(|| ProviderError::UnknownBlockHash(finalized_block_hash))?;
-            self.blockchain.finalize_block(finalized.number);
+            self.blockchain.finalize_block(finalized.number)?;
             self.blockchain.set_finalized(finalized.header.seal(finalized_block_hash));
         }
         Ok(())

--- a/crates/stages/api/src/pipeline/mod.rs
+++ b/crates/stages/api/src/pipeline/mod.rs
@@ -355,7 +355,7 @@ where
 
                         // update finalized block if needed
                         let last_saved_finalized_block_number =
-                            provider_rw.fetch_latest_finalized_block_number()?;
+                            provider_rw.last_finalized_block_number()?;
                         if checkpoint.block_number < last_saved_finalized_block_number {
                             provider_rw.save_finalized_block_number(BlockNumber::from(
                                 checkpoint.block_number,

--- a/crates/storage/db/src/tables/mod.rs
+++ b/crates/storage/db/src/tables/mod.rs
@@ -408,7 +408,7 @@ tables! {
     table BlockRequests<Key = BlockNumber, Value = Requests>;
 
     /// Stores the last finalized block.
-    table FinalizedBlocks<Key = BlockNumber, Value = BlockNumber>;
+    table FinalizedBlocks<Key = u8, Value = BlockNumber>;
 }
 
 // Alias types.

--- a/crates/storage/db/src/tables/mod.rs
+++ b/crates/storage/db/src/tables/mod.rs
@@ -406,6 +406,9 @@ tables! {
 
     /// Stores EIP-7685 EL -> CL requests, indexed by block number.
     table BlockRequests<Key = BlockNumber, Value = Requests>;
+
+    /// Stores the last finalized block.
+    table FinalizedBlocks<Key = BlockNumber, Value = BlockNumber>;
 }
 
 // Alias types.

--- a/crates/storage/db/src/tables/mod.rs
+++ b/crates/storage/db/src/tables/mod.rs
@@ -407,8 +407,8 @@ tables! {
     /// Stores EIP-7685 EL -> CL requests, indexed by block number.
     table BlockRequests<Key = BlockNumber, Value = Requests>;
 
-    /// Stores the last finalized block.
-    table FinalizedBlocks<Key = u8, Value = BlockNumber>;
+    /// Stores generic chain state info, like the last finalized block.
+    table ChainState<Key = u8, Value = BlockNumber>;
 }
 
 // Alias types.

--- a/crates/storage/db/src/tables/mod.rs
+++ b/crates/storage/db/src/tables/mod.rs
@@ -4,8 +4,7 @@
 //!
 //! This module defines the tables in reth, as well as some table-related abstractions:
 //!
-//! - [`codecs`] integrates different codecs into [`Encode`](reth_db_api::table::Encode) and
-//!   [`Decode`](reth_db_api::table::Decode)
+//! - [`codecs`] integrates different codecs into [`Encode`] and [`Decode`]
 //! - [`models`](reth_db_api::models) defines the values written to tables
 //!
 //! # Database Tour

--- a/crates/storage/db/src/tables/mod.rs
+++ b/crates/storage/db/src/tables/mod.rs
@@ -412,10 +412,9 @@ tables! {
 }
 
 /// Keys for the `ChainState` table.
-#[derive(Ord, Clone, Eq, PartialOrd, PartialEq, Debug, Deserialize, Serialize, Default, Hash)]
+#[derive(Ord, Clone, Eq, PartialOrd, PartialEq, Debug, Deserialize, Serialize, Hash)]
 pub enum ChainStateKey {
     /// Last finalized block key
-    #[default]
     LastFinalizedBlock,
 }
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -2757,7 +2757,7 @@ impl<TX: DbTx> StatsReader for DatabaseProvider<TX> {
 const FINALIZED_BLOCKS_KEY: u8 = 0;
 
 impl<TX: DbTx> FinalizedBlockReader for DatabaseProvider<TX> {
-    fn fetch_latest_finalized_block_number(&self) -> ProviderResult<BlockNumber> {
+    fn last_finalized_block_number(&self) -> ProviderResult<BlockNumber> {
         let mut finalized_blocks = self
             .tx
             .cursor_read::<tables::FinalizedBlocks>()?

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -2760,7 +2760,7 @@ impl<TX: DbTx> FinalizedBlockReader for DatabaseProvider<TX> {
     fn last_finalized_block_number(&self) -> ProviderResult<BlockNumber> {
         let mut finalized_blocks = self
             .tx
-            .cursor_read::<tables::FinalizedBlocks>()?
+            .cursor_read::<tables::ChainState>()?
             .walk(Some(FINALIZED_BLOCKS_KEY))?
             .take(1)
             .collect::<Result<BTreeMap<u8, BlockNumber>, _>>()?;
@@ -2772,7 +2772,7 @@ impl<TX: DbTx> FinalizedBlockReader for DatabaseProvider<TX> {
 
 impl<TX: DbTxMut> FinalizedBlockWriter for DatabaseProvider<TX> {
     fn save_finalized_block_number(&self, block_number: BlockNumber) -> ProviderResult<()> {
-        Ok(self.tx.put::<tables::FinalizedBlocks>(FINALIZED_BLOCKS_KEY, block_number)?)
+        Ok(self.tx.put::<tables::ChainState>(FINALIZED_BLOCKS_KEY, block_number)?)
     }
 }
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -2762,7 +2762,9 @@ impl<TX: DbTx> FinalizedBlockReader for DatabaseProvider<TX> {
             .take(1)
             .collect::<Result<BTreeMap<tables::ChainStateKey, BlockNumber>, _>>()?;
 
-        let last_finalized_block_number = finalized_blocks.pop_first().unwrap_or_default();
+        let last_finalized_block_number = finalized_blocks
+            .pop_first()
+            .unwrap_or((tables::ChainStateKey::LastFinalizedBlock, 0_u64));
         Ok(last_finalized_block_number.1)
     }
 }

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -684,7 +684,7 @@ where
         self.tree.insert_block(block, validation_kind)
     }
 
-    fn finalize_block(&self, finalized_block: BlockNumber) {
+    fn finalize_block(&self, finalized_block: BlockNumber) -> ProviderResult<()> {
         self.tree.finalize_block(finalized_block)
     }
 

--- a/crates/storage/provider/src/traits/finalized_block.rs
+++ b/crates/storage/provider/src/traits/finalized_block.rs
@@ -1,48 +1,14 @@
-use crate::ProviderFactory;
-use reth_db::{
-    cursor::DbCursorRO,
-    database::Database,
-    tables,
-    transaction::{DbTx, DbTxMut},
-};
 use reth_errors::ProviderResult;
 use reth_primitives::BlockNumber;
-use std::collections::BTreeMap;
 
-/// Table key used to read and write the last finalized block.
-const FINALIZED_BLOCKS_KEY: u8 = 0;
-
-/// Methods to read/write the last known finalized block from the database.
-/// The default implementation already has all the required functionality,
-/// only the `provider_factory` method needs to be implemented to wire the
-/// functionality with the consumer's provider.
-pub trait FinalizedBlockProvider<DB>
-where
-    DB: Database,
-{
+/// Functionality to read the last known finalized block from the database.
+pub trait FinalizedBlockReader: Send + Sync {
     /// Fetches and returns the latest finalized block number.
-    fn fetch_latest_finalized_block_number(&self) -> ProviderResult<BlockNumber> {
-        let mut finalized_blocks = self
-            .provider_factory()
-            .provider()?
-            .tx_ref()
-            .cursor_read::<tables::FinalizedBlocks>()?
-            .walk(Some(FINALIZED_BLOCKS_KEY))?
-            .take(1)
-            .collect::<Result<BTreeMap<u8, BlockNumber>, _>>()?;
+    fn fetch_latest_finalized_block_number(&self) -> ProviderResult<BlockNumber>;
+}
 
-        let last_finalized_block_number = finalized_blocks.pop_first().unwrap_or_default();
-        Ok(last_finalized_block_number.1)
-    }
-
-    /// Saves finalized block.
-    fn save_finalized_block_number(&self, block_number: BlockNumber) -> ProviderResult<()> {
-        let provider = self.provider_factory().provider_rw()?;
-        provider.tx_ref().put::<tables::FinalizedBlocks>(FINALIZED_BLOCKS_KEY, block_number)?;
-        provider.commit()?;
-        Ok(())
-    }
-
-    /// Provider factory getter.
-    fn provider_factory(&self) -> &ProviderFactory<DB>;
+/// Functionality to write the last known finalized block to the database.
+pub trait FinalizedBlockWriter: Send + Sync {
+    /// Saves the given finalized block number in the DB.
+    fn save_finalized_block_number(&self, block_number: BlockNumber) -> ProviderResult<()>;
 }

--- a/crates/storage/provider/src/traits/finalized_block.rs
+++ b/crates/storage/provider/src/traits/finalized_block.rs
@@ -1,0 +1,48 @@
+use crate::ProviderFactory;
+use reth_db::{
+    cursor::DbCursorRO,
+    database::Database,
+    tables,
+    transaction::{DbTx, DbTxMut},
+};
+use reth_errors::ProviderResult;
+use reth_primitives::BlockNumber;
+use std::collections::BTreeMap;
+
+/// Table key used to read and write the last finalized block.
+const FINALIZED_BLOCKS_KEY: u8 = 0;
+
+/// Methods to read/write the last known finalized block from the database.
+/// The default implementation already has all the required functionality,
+/// only the `provider_factory` method needs to be implemented to wire the
+/// functionality with the consumer's provider.
+pub trait FinalizedBlockProvider<DB>
+where
+    DB: Database,
+{
+    /// Fetches and returns the latest finalized block number.
+    fn fetch_latest_finalized_block_number(&self) -> ProviderResult<BlockNumber> {
+        let mut finalized_blocks = self
+            .provider_factory()
+            .provider()?
+            .tx_ref()
+            .cursor_read::<tables::FinalizedBlocks>()?
+            .walk(Some(FINALIZED_BLOCKS_KEY))?
+            .take(1)
+            .collect::<Result<BTreeMap<u8, BlockNumber>, _>>()?;
+
+        let last_finalized_block_number = finalized_blocks.pop_first().unwrap_or_default();
+        Ok(last_finalized_block_number.1)
+    }
+
+    /// Saves finalized block.
+    fn save_finalized_block_number(&self, block_number: BlockNumber) -> ProviderResult<()> {
+        let provider = self.provider_factory().provider_rw()?;
+        provider.tx_ref().put::<tables::FinalizedBlocks>(FINALIZED_BLOCKS_KEY, block_number)?;
+        provider.commit()?;
+        Ok(())
+    }
+
+    /// Provider factory getter.
+    fn provider_factory(&self) -> &ProviderFactory<DB>;
+}

--- a/crates/storage/provider/src/traits/finalized_block.rs
+++ b/crates/storage/provider/src/traits/finalized_block.rs
@@ -3,8 +3,8 @@ use reth_primitives::BlockNumber;
 
 /// Functionality to read the last known finalized block from the database.
 pub trait FinalizedBlockReader: Send + Sync {
-    /// Fetches and returns the latest finalized block number.
-    fn fetch_latest_finalized_block_number(&self) -> ProviderResult<BlockNumber>;
+    /// Returns the last finalized block number.
+    fn last_finalized_block_number(&self) -> ProviderResult<BlockNumber>;
 }
 
 /// Functionality to write the last known finalized block to the database.

--- a/crates/storage/provider/src/traits/mod.rs
+++ b/crates/storage/provider/src/traits/mod.rs
@@ -49,4 +49,4 @@ mod tree_viewer;
 pub use tree_viewer::TreeViewer;
 
 mod finalized_block;
-pub use finalized_block::FinalizedBlockProvider;
+pub use finalized_block::{FinalizedBlockReader, FinalizedBlockWriter};

--- a/crates/storage/provider/src/traits/mod.rs
+++ b/crates/storage/provider/src/traits/mod.rs
@@ -47,3 +47,6 @@ pub use full::FullProvider;
 
 mod tree_viewer;
 pub use tree_viewer::TreeViewer;
+
+mod finalized_block;
+pub use finalized_block::FinalizedBlockProvider;


### PR DESCRIPTION
Closes #1712

Prevents potential issues with fixed finality depth on adverse conditions, there are no fixed bounds to finality depth and the actual finalized block can be earlier than a  `last_finalized_block_number` initialized to a fixed value.