### PR TITLE
Fix: manually impl Clone for BlockchainProvider

### DIFF
--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -65,7 +65,6 @@ pub use consistent_view::{ConsistentDbView, ConsistentViewError};
 /// This type serves as the main entry point for interacting with the blockchain and provides data
 /// from database storage and from the blockchain tree (pending state etc.) It is a simple wrapper
 /// type that holds an instance of the database and the blockchain tree.
-#[derive(Clone)]
 #[allow(missing_debug_implementations)]
 pub struct BlockchainProvider<DB> {
     /// Provider type used to access the database.
@@ -74,6 +73,16 @@ pub struct BlockchainProvider<DB> {
     tree: Arc<dyn TreeViewer>,
     /// Tracks the chain info wrt forkchoice updates
     chain_info: ChainInfoTracker,
+}
+
+impl<DB> Clone for BlockchainProvider<DB> {
+    fn clone(&self) -> Self {
+        Self {
+            database: self.database.clone(),
+            tree: self.tree.clone(),
+            chain_info: self.chain_info.clone(),
+        }
+    }
 }
 
 impl<DB> BlockchainProvider<DB> {


### PR DESCRIPTION
Derived `Clone` is incorrect as it inserts an unnecessary `where Db: Clone` bound. Manual clone can remove that bound, and rely on the Arc inside `ProviderFactory`

```
error[E0277]: the trait bound `Db: std::clone::Clone` is not satisfied
   --> src/rpc/mod.rs:60:6
    |
60  |     .await
    |      ^^^^^ the trait `std::clone::Clone` is not implemented for `Db`, which is required by `reth::providers::providers::BlockchainProvider<Db>: std::clone::Clone`
```