### PR TITLE
feat: create_transport_rpc_modules

### DIFF
--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1168,7 +1168,7 @@ where
         config.map(|config| self.module_for(config))
     }
 
-    /// Configure a [`TransportRpcModule`] using the current registry. This
+    /// Configure a [`TransportRpcModules`] using the current registry. This
     /// creates [`RpcModule`] instances for the modules selected by the
     /// `config`.
     pub fn create_transport_rpc_modules(

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -469,11 +469,9 @@ where
         EngineT: EngineTypes + 'static,
         EngineApi: EngineApiServer<EngineT>,
     {
-        let mut modules = TransportRpcModules::default();
-
         let Self { provider, pool, network, executor, events, evm_config } = self;
 
-        let TransportRpcModuleConfig { http, ws, ipc, config } = module_config.clone();
+        let TransportRpcModuleConfig { config, .. } = module_config.clone();
 
         let mut registry = RethModuleRegistry::new(
             provider,
@@ -485,10 +483,7 @@ where
             evm_config,
         );
 
-        modules.config = module_config;
-        modules.http = registry.maybe_module(http.as_ref());
-        modules.ws = registry.maybe_module(ws.as_ref());
-        modules.ipc = registry.maybe_module(ipc.as_ref());
+        let modules = registry.create_transport_rpc_modules(module_config);
 
         let auth_module = registry.create_auth_module(engine);
 
@@ -1175,11 +1170,28 @@ where
         self
     }
 
-    /// Helper function to create a [RpcModule] if it's not `None`
+    /// Helper function to create a [`RpcModule`] if it's not `None`
     fn maybe_module(&mut self, config: Option<&RpcModuleSelection>) -> Option<RpcModule<()>> {
-        let config = config?;
-        let module = self.module_for(config);
-        Some(module)
+        config.map(|config| self.module_for(config))
+    }
+
+    /// Configure a [`TransportRpcModule`] using the current registry. This
+    /// creates [`RpcModule`] instances for the modules selected by the
+    /// `config`.
+    pub fn create_transport_rpc_modules(
+        &mut self,
+        config: TransportRpcModuleConfig,
+    ) -> TransportRpcModules<()> {
+        let mut modules = TransportRpcModules::default();
+        let http = self.maybe_module(config.http.as_ref());
+        let ws = self.maybe_module(config.ws.as_ref());
+        let ipc = self.maybe_module(config.ipc.as_ref());
+
+        modules.config = config;
+        modules.http = http;
+        modules.ws = ws;
+        modules.ipc = ipc;
+        modules
     }
 
     /// Populates a new [RpcModule] based on the selected [RethRpcModule]s in the given

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -471,17 +471,10 @@ where
     {
         let Self { provider, pool, network, executor, events, evm_config } = self;
 
-        let TransportRpcModuleConfig { config, .. } = module_config.clone();
+        let config = module_config.config.clone().unwrap_or_default();
 
-        let mut registry = RethModuleRegistry::new(
-            provider,
-            pool,
-            network,
-            executor,
-            events,
-            config.unwrap_or_default(),
-            evm_config,
-        );
+        let mut registry =
+            RethModuleRegistry::new(provider, pool, network, executor, events, config, evm_config);
 
         let modules = registry.create_transport_rpc_modules(module_config);
 


### PR DESCRIPTION
Adds a method to [RethModuleRegisty](https://reth.rs/docs/reth/core/rpc/builder/struct.RethModuleRegistry.html) that allows creating an [TransportRpcModules](https://reth.rs/docs/reth/core/rpc/builder/struct.TransportRpcModules.html) configured by the registry

Refactors `build_with_auth_server` to use that method