### PR TITLE
Refactor: Clean up `RpcModuleSelection` API

### DIFF
--- a/crates/node-core/src/args/rpc_server.rs
+++ b/crates/node-core/src/args/rpc_server.rs
@@ -532,7 +532,7 @@ mod tests {
     fn test_rpc_server_args_parser_none() {
         let args = CommandParser::<RpcServerArgs>::parse_from(["reth", "--http.api", "none"]).args;
         let apis = args.http_api.unwrap();
-        let expected = Selection(vec![]);
+        let expected = Selection(Default::default());
         assert_eq!(apis, expected);
     }
 
@@ -547,10 +547,10 @@ mod tests {
         ])
         .args;
         let config = args.transport_rpc_module_config();
-        let expected = vec![RethRpcModule::Eth, RethRpcModule::Admin, RethRpcModule::Debug];
-        assert_eq!(config.http().cloned().unwrap().into_selection_set(), expected);
+        let expected = [RethRpcModule::Eth, RethRpcModule::Admin, RethRpcModule::Debug];
+        assert_eq!(config.http().cloned().unwrap().into_selection(), expected.into());
         assert_eq!(
-            config.ws().cloned().unwrap().into_selection_set(),
+            &config.ws().cloned().unwrap().into_selection(),
             RpcModuleSelection::standard_modules()
         );
     }
@@ -566,10 +566,10 @@ mod tests {
         ])
         .args;
         let config = args.transport_rpc_module_config();
-        let expected = vec![RethRpcModule::Eth, RethRpcModule::Admin, RethRpcModule::Debug];
-        assert_eq!(config.http().cloned().unwrap().into_selection_set(), expected);
+        let expected = [RethRpcModule::Eth, RethRpcModule::Admin, RethRpcModule::Debug];
+        assert_eq!(config.http().cloned().unwrap().into_selection(), expected.into());
         assert_eq!(
-            config.ws().cloned().unwrap().into_selection_set(),
+            &config.ws().cloned().unwrap().into_selection(),
             RpcModuleSelection::standard_modules()
         );
     }
@@ -585,10 +585,10 @@ mod tests {
         ])
         .args;
         let config = args.transport_rpc_module_config();
-        let expected = vec![RethRpcModule::Eth, RethRpcModule::Admin, RethRpcModule::Debug];
-        assert_eq!(config.http().cloned().unwrap().into_selection_set(), expected);
+        let expected = [RethRpcModule::Eth, RethRpcModule::Admin, RethRpcModule::Debug];
+        assert_eq!(config.http().cloned().unwrap().into_selection(), expected.into());
         assert_eq!(
-            config.ws().cloned().unwrap().into_selection_set(),
+            &config.ws().cloned().unwrap().into_selection(),
             RpcModuleSelection::standard_modules()
         );
     }

--- a/crates/node-core/src/args/rpc_server.rs
+++ b/crates/node-core/src/args/rpc_server.rs
@@ -329,7 +329,7 @@ impl RethRpcConfig for RpcServerArgs {
         }
 
         if self.is_ipc_enabled() {
-            config = config.with_ipc(RpcModuleSelection::default_ipc_modules());
+            config = config.with_ipc(RpcModuleSelection::default_ipc_modules().clone());
         }
 
         config
@@ -548,9 +548,9 @@ mod tests {
         .args;
         let config = args.transport_rpc_module_config();
         let expected = vec![RethRpcModule::Eth, RethRpcModule::Admin, RethRpcModule::Debug];
-        assert_eq!(config.http().cloned().unwrap().into_selection(), expected);
+        assert_eq!(config.http().cloned().unwrap().into_selection_set(), expected);
         assert_eq!(
-            config.ws().cloned().unwrap().into_selection(),
+            config.ws().cloned().unwrap().into_selection_set(),
             RpcModuleSelection::standard_modules()
         );
     }
@@ -567,9 +567,9 @@ mod tests {
         .args;
         let config = args.transport_rpc_module_config();
         let expected = vec![RethRpcModule::Eth, RethRpcModule::Admin, RethRpcModule::Debug];
-        assert_eq!(config.http().cloned().unwrap().into_selection(), expected);
+        assert_eq!(config.http().cloned().unwrap().into_selection_set(), expected);
         assert_eq!(
-            config.ws().cloned().unwrap().into_selection(),
+            config.ws().cloned().unwrap().into_selection_set(),
             RpcModuleSelection::standard_modules()
         );
     }
@@ -586,9 +586,9 @@ mod tests {
         .args;
         let config = args.transport_rpc_module_config();
         let expected = vec![RethRpcModule::Eth, RethRpcModule::Admin, RethRpcModule::Debug];
-        assert_eq!(config.http().cloned().unwrap().into_selection(), expected);
+        assert_eq!(config.http().cloned().unwrap().into_selection_set(), expected);
         assert_eq!(
-            config.ws().cloned().unwrap().into_selection(),
+            config.ws().cloned().unwrap().into_selection_set(),
             RpcModuleSelection::standard_modules()
         );
     }

--- a/crates/node-core/src/args/rpc_server.rs
+++ b/crates/node-core/src/args/rpc_server.rs
@@ -329,7 +329,7 @@ impl RethRpcConfig for RpcServerArgs {
         }
 
         if self.is_ipc_enabled() {
-            config = config.with_ipc(RpcModuleSelection::default_ipc_modules().clone());
+            config = config.with_ipc(RpcModuleSelection::default_ipc_modules());
         }
 
         config
@@ -550,7 +550,7 @@ mod tests {
         let expected = [RethRpcModule::Eth, RethRpcModule::Admin, RethRpcModule::Debug];
         assert_eq!(config.http().cloned().unwrap().into_selection(), expected.into());
         assert_eq!(
-            &config.ws().cloned().unwrap().into_selection(),
+            config.ws().cloned().unwrap().into_selection(),
             RpcModuleSelection::standard_modules()
         );
     }
@@ -569,7 +569,7 @@ mod tests {
         let expected = [RethRpcModule::Eth, RethRpcModule::Admin, RethRpcModule::Debug];
         assert_eq!(config.http().cloned().unwrap().into_selection(), expected.into());
         assert_eq!(
-            &config.ws().cloned().unwrap().into_selection(),
+            config.ws().cloned().unwrap().into_selection(),
             RpcModuleSelection::standard_modules()
         );
     }
@@ -588,7 +588,7 @@ mod tests {
         let expected = [RethRpcModule::Eth, RethRpcModule::Admin, RethRpcModule::Debug];
         assert_eq!(config.http().cloned().unwrap().into_selection(), expected.into());
         assert_eq!(
-            &config.ws().cloned().unwrap().into_selection(),
+            config.ws().cloned().unwrap().into_selection(),
             RpcModuleSelection::standard_modules()
         );
     }

--- a/crates/rpc/rpc-builder/src/error.rs
+++ b/crates/rpc/rpc-builder/src/error.rs
@@ -1,6 +1,10 @@
 use crate::{cors::CorsDomainError, RethRpcModule};
 use reth_ipc::server::IpcServerStartError;
-use std::{io, io::ErrorKind, net::SocketAddr};
+use std::{
+    collections::HashSet,
+    io::{self, ErrorKind},
+    net::SocketAddr,
+};
 
 /// Rpc server kind.
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
@@ -98,13 +102,19 @@ pub enum WsHttpSamePortError {
     /// Ws and http server configured on same port but with different modules.
     #[error(
         "different API modules for HTTP and WS on the same port is currently not supported: \
-         HTTP: {http_modules:?}, WS: {ws_modules:?}"
+         HTTP: {http_modules:?}, WS: {ws_modules:?} \
+         HTTP modules not present in WS: {http_not_ws:?} \
+         WS modules not present in HTTP: {ws_not_http:?}"
     )]
     ConflictingModules {
         /// Http modules.
-        http_modules: Vec<RethRpcModule>,
+        http_modules: HashSet<RethRpcModule>,
         /// Ws modules.
-        ws_modules: Vec<RethRpcModule>,
+        ws_modules: HashSet<RethRpcModule>,
+        /// Modules present in http but not in ws.
+        http_not_ws: HashSet<RethRpcModule>,
+        /// Modules present in ws but not in http.
+        ws_not_http: HashSet<RethRpcModule>,
     },
 }
 

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1888,22 +1888,22 @@ impl TransportRpcModuleConfig {
     }
 
     /// Returns the [RpcModuleSelection] for the http transport
-    pub fn http(&self) -> Option<&RpcModuleSelection> {
+    pub const fn http(&self) -> Option<&RpcModuleSelection> {
         self.http.as_ref()
     }
 
     /// Returns the [RpcModuleSelection] for the ws transport
-    pub fn ws(&self) -> Option<&RpcModuleSelection> {
+    pub const fn ws(&self) -> Option<&RpcModuleSelection> {
         self.ws.as_ref()
     }
 
     /// Returns the [RpcModuleSelection] for the ipc transport
-    pub fn ipc(&self) -> Option<&RpcModuleSelection> {
+    pub const fn ipc(&self) -> Option<&RpcModuleSelection> {
         self.ipc.as_ref()
     }
 
     /// Returns the [RpcModuleConfig] for the configured modules
-    pub fn config(&self) -> Option<&RpcModuleConfig> {
+    pub const fn config(&self) -> Option<&RpcModuleConfig> {
         self.config.as_ref()
     }
 

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -2344,8 +2344,8 @@ mod tests {
             Some(&RpcModuleSelection::Standard),
         ));
         assert!(RpcModuleSelection::are_identical(
-            dbg!(Some(&RpcModuleSelection::Selection(RpcModuleSelection::Standard.to_selection()))),
-            dbg!(Some(&RpcModuleSelection::Standard)),
+            Some(&RpcModuleSelection::Selection(RpcModuleSelection::Standard.to_selection())),
+            Some(&RpcModuleSelection::Standard),
         ));
         assert!(RpcModuleSelection::are_identical(
             Some(&RpcModuleSelection::Selection([RethRpcModule::Eth].into())),


### PR DESCRIPTION
- Use `HashSet` instead of vec internally
- Create statics for `All` and `Standard` hashsets
- Refactor to use `&'static HashSet` where appropriate
- use standard pattern for `as_selection` `to_selection` and `into_selection`
- extend `ConflictingModules` with conflict information
- add `len()`
- condense `are_identical` logic where available
- modify `From` impls on `RpcModuleSelection`


drive-by
- add functions to modify `TransportRpcModuleConfig` when mutable by taking the values
- add accessor for inner config on `TransportRpcModuleConfig`