### PR TITLE
chore(net): `get` and `peek` for `LruCache`

### DIFF
--- a/crates/net/network/src/cache.rs
+++ b/crates/net/network/src/cache.rs
@@ -117,7 +117,7 @@ where
         debug_struct.field("limit", &self.limit);
 
         debug_struct.field(
-            "res_fn_iter",
+            "ret %iter",
             &format_args!("Iter: {{{} }}", self.iter().map(|k| format!(" {k:?}")).format(",")),
         );
 
@@ -146,7 +146,7 @@ where
         debug_struct.field("limiter", self.limiter());
 
         debug_struct.field(
-            "res_fn_iter",
+            "ret %iter",
             &format_args!(
                 "Iter: {{{} }}",
                 self.iter().map(|(k, v)| format!(" {k}: {v:?}")).format(",")
@@ -240,7 +240,7 @@ mod test {
         let value_2 = Value(22);
         cache.insert(key_2, value_2);
 
-        assert_eq!("LruMap { limiter: ByLength { max_length: 2 }, res_fn_iter: Iter: { 2: Value(22), 1: Value(11) } }", format!("{cache:?}"))
+        assert_eq!("LruMap { limiter: ByLength { max_length: 2 }, ret %iter: Iter: { 2: Value(22), 1: Value(11) } }", format!("{cache:?}"))
     }
 
     #[test]
@@ -253,7 +253,7 @@ mod test {
         cache.insert(key_2);
 
         assert_eq!(
-            "LruCache { limit: 2, res_fn_iter: Iter: { Key(2), Key(1) } }",
+            "LruCache { limit: 2, ret %iter: Iter: { Key(2), Key(1) } }",
             format!("{cache:?}")
         )
     }
@@ -270,7 +270,7 @@ mod test {
         _ = cache.get(&key_1);
 
         assert_eq!(
-            "LruCache { limit: 2, res_fn_iter: Iter: { Key(1), Key(2) } }",
+            "LruCache { limit: 2, ret %iter: Iter: { Key(1), Key(2) } }",
             format!("{cache:?}")
         )
     }
@@ -319,7 +319,7 @@ mod test {
         _ = cache.peek(&key_1);
 
         assert_eq!(
-            "LruCache { limit: 2, res_fn_iter: Iter: { Key(2), Key(1) } }",
+            "LruCache { limit: 2, ret %iter: Iter: { Key(2), Key(1) } }",
             format!("{cache:?}")
         )
     }

--- a/crates/net/network/src/cache.rs
+++ b/crates/net/network/src/cache.rs
@@ -48,6 +48,17 @@ impl<T: Hash + Eq + fmt::Debug> LruCache<T> {
         (new, evicted)
     }
 
+    /// Gets the given element, if exists, and promotes to lru.
+    pub fn get(&mut self, entry: &T) -> Option<&T> {
+        let _ = self.inner.get(entry)?;
+        self.inner.iter().next().map(|(key, ())| key)
+    }
+
+    /// Gets the given element, if exists, without promoting to lru.
+    pub fn peek(&self, entry: &T) -> Option<&T> {
+        self.inner.iter().find_map(|(key, ())| (key == entry).then_some(key))
+    }
+
     /// Remove the least recently used entry and return it.
     ///
     /// If the `LruCache` is empty or if the eviction feedback is

--- a/crates/net/network/src/cache.rs
+++ b/crates/net/network/src/cache.rs
@@ -180,9 +180,7 @@ where
 #[cfg(test)]
 mod test {
     use std::hash::Hasher;
-
     use derive_more::{Constructor, Display};
-
     use super::*;
 
     #[derive(Debug, Hash, PartialEq, Eq, Display, Clone, Copy)]

--- a/crates/net/network/src/cache.rs
+++ b/crates/net/network/src/cache.rs
@@ -65,7 +65,7 @@ impl<T: Hash + Eq + fmt::Debug> LruCache<T> {
     /// configured, this will return None.
     #[inline]
     fn remove_lru(&mut self) -> Option<T> {
-        self.inner.pop_oldest().map(|(k, _v)| k)
+        self.inner.pop_oldest().map(|(k, ())| k)
     }
 
     /// Expels the given value. Returns true if the value existed.
@@ -80,7 +80,7 @@ impl<T: Hash + Eq + fmt::Debug> LruCache<T> {
 
     /// Returns an iterator over all cached entries in lru order
     pub fn iter(&self) -> impl Iterator<Item = &T> + '_ {
-        self.inner.iter().map(|(k, _v)| k)
+        self.inner.iter().map(|(k, ())| k)
     }
 
     /// Returns number of elements currently in cache.

--- a/crates/net/network/src/cache.rs
+++ b/crates/net/network/src/cache.rs
@@ -188,6 +188,25 @@ mod test {
     #[derive(Debug, Hash, PartialEq, Eq, Display, Clone, Copy)]
     struct Key(i8);
 
+    #[derive(Debug, Eq, Constructor, Clone, Copy)]
+    struct CompoundKey {
+        // type unique for id
+        id: i8,
+        other: i8,
+    }
+
+    impl PartialEq for CompoundKey {
+        fn eq(&self, other: &Self) -> bool {
+            self.id == other.id
+        }
+    }
+
+    impl Hash for CompoundKey {
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            self.id.hash(state)
+        }
+    }
+
     #[test]
     fn test_cache_should_insert_into_empty_set() {
         let mut cache = LruCache::new(5);
@@ -277,25 +296,6 @@ mod test {
 
     #[test]
     fn get_ty_custom_eq_impl() {
-        #[derive(Debug, Eq, Constructor, Clone, Copy)]
-        struct CompoundKey {
-            // type unique for id
-            id: i8,
-            other: i8,
-        }
-
-        impl PartialEq for CompoundKey {
-            fn eq(&self, other: &Self) -> bool {
-                self.id == other.id
-            }
-        }
-
-        impl Hash for CompoundKey {
-            fn hash<H: Hasher>(&self, state: &mut H) {
-                self.id.hash(state)
-            }
-        }
-
         let mut cache = LruCache::new(2);
         let key_1 = CompoundKey::new(1, 11);
         cache.insert(key_1);
@@ -326,25 +326,6 @@ mod test {
 
     #[test]
     fn peek_ty_custom_eq_impl() {
-        #[derive(Debug, Eq, Constructor, Clone, Copy)]
-        struct CompoundKey {
-            // type unique for id
-            id: i8,
-            other: i8,
-        }
-
-        impl PartialEq for CompoundKey {
-            fn eq(&self, other: &Self) -> bool {
-                self.id == other.id
-            }
-        }
-
-        impl Hash for CompoundKey {
-            fn hash<H: Hasher>(&self, state: &mut H) {
-                self.id.hash(state)
-            }
-        }
-
         let mut cache = LruCache::new(2);
         let key_1 = CompoundKey::new(1, 11);
         cache.insert(key_1);


### PR DESCRIPTION
Adds methods `get` and `peek` to LruCache, which are needed for https://github.com/paradigmxyz/reth/pull/6559