### PR TITLE
fix: make reth-db compile without default features

### DIFF
--- a/crates/storage/db/src/abstraction/common.rs
+++ b/crates/storage/db/src/abstraction/common.rs
@@ -20,7 +20,7 @@ pub type ValueOnlyResult<T> = Result<Option<<T as Table>::Value>, DatabaseError>
 
 // Sealed trait helper to prevent misuse of the Database API.
 mod sealed {
-    use crate::{database::Database, mock::DatabaseMock, DatabaseEnv};
+    use crate::{database::Database, mock::DatabaseMock};
     use std::sync::Arc;
 
     /// Sealed trait to limit the implementers of the Database trait.
@@ -28,7 +28,9 @@ mod sealed {
 
     impl<DB: Database> Sealed for &DB {}
     impl<DB: Database> Sealed for Arc<DB> {}
-    impl Sealed for DatabaseEnv {}
+
+    #[cfg(feature = "mdbx")]
+    impl Sealed for crate::DatabaseEnv {}
     impl Sealed for DatabaseMock {}
 
     #[cfg(any(test, feature = "test-utils"))]

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -52,7 +52,7 @@ impl<K: TransactionKind> Tx<K> {
     /// Creates new `Tx` object with a `RO` or `RW` transaction and optionally enables metrics.
     #[inline]
     #[track_caller]
-    pub fn new_with_metrics(
+    pub(crate) fn new_with_metrics(
         inner: Transaction<K>,
         env_metrics: Option<Arc<DatabaseEnvMetrics>>,
     ) -> reth_libmdbx::Result<Self> {

--- a/crates/storage/db/src/lib.rs
+++ b/crates/storage/db/src/lib.rs
@@ -73,12 +73,9 @@ pub mod tables;
 mod utils;
 pub mod version;
 
-#[cfg(feature = "mdbx")]
 /// Bindings for [MDBX](https://libmdbx.dqdkfa.ru/).
-pub mod mdbx {
-    pub use crate::implementation::mdbx::*;
-    pub use reth_libmdbx::*;
-}
+#[cfg(feature = "mdbx")]
+pub mod mdbx;
 
 pub use abstraction::*;
 pub use reth_storage_errors::db::{DatabaseError, DatabaseWriteOperation};
@@ -86,85 +83,7 @@ pub use tables::*;
 pub use utils::is_database_empty;
 
 #[cfg(feature = "mdbx")]
-pub use mdbx::{DatabaseEnv, DatabaseEnvKind};
-
-use crate::mdbx::DatabaseArguments;
-use eyre::WrapErr;
-use std::path::Path;
-
-/// Creates a new database at the specified path if it doesn't exist. Does NOT create tables. Check
-/// [`init_db`].
-pub fn create_db<P: AsRef<Path>>(path: P, args: DatabaseArguments) -> eyre::Result<DatabaseEnv> {
-    use crate::version::{check_db_version_file, create_db_version_file, DatabaseVersionError};
-
-    let rpath = path.as_ref();
-    if is_database_empty(rpath) {
-        reth_fs_util::create_dir_all(rpath)
-            .wrap_err_with(|| format!("Could not create database directory {}", rpath.display()))?;
-        create_db_version_file(rpath)?;
-    } else {
-        match check_db_version_file(rpath) {
-            Ok(_) => (),
-            Err(DatabaseVersionError::MissingFile) => create_db_version_file(rpath)?,
-            Err(err) => return Err(err.into()),
-        }
-    }
-
-    #[cfg(feature = "mdbx")]
-    {
-        Ok(DatabaseEnv::open(rpath, DatabaseEnvKind::RW, args)?)
-    }
-    #[cfg(not(feature = "mdbx"))]
-    {
-        unimplemented!();
-    }
-}
-
-/// Opens up an existing database or creates a new one at the specified path. Creates tables if
-/// necessary. Read/Write mode.
-pub fn init_db<P: AsRef<Path>>(path: P, args: DatabaseArguments) -> eyre::Result<DatabaseEnv> {
-    #[cfg(feature = "mdbx")]
-    {
-        let client_version = args.client_version().clone();
-        let db = create_db(path, args)?;
-        db.create_tables()?;
-        db.record_client_version(client_version)?;
-        Ok(db)
-    }
-    #[cfg(not(feature = "mdbx"))]
-    {
-        unimplemented!();
-    }
-}
-
-/// Opens up an existing database. Read only mode. It doesn't create it or create tables if missing.
-pub fn open_db_read_only(path: &Path, args: DatabaseArguments) -> eyre::Result<DatabaseEnv> {
-    #[cfg(feature = "mdbx")]
-    {
-        DatabaseEnv::open(path, DatabaseEnvKind::RO, args)
-            .with_context(|| format!("Could not open database at path: {}", path.display()))
-    }
-    #[cfg(not(feature = "mdbx"))]
-    {
-        unimplemented!();
-    }
-}
-
-/// Opens up an existing database. Read/Write mode with WriteMap enabled. It doesn't create it or
-/// create tables if missing.
-pub fn open_db(path: &Path, args: DatabaseArguments) -> eyre::Result<DatabaseEnv> {
-    #[cfg(feature = "mdbx")]
-    {
-        let db = DatabaseEnv::open(path, DatabaseEnvKind::RW, args.clone())
-            .with_context(|| format!("Could not open database at path: {}", path.display()))?;
-        db.record_client_version(args.client_version().clone())?;
-        Ok(db)
-    }
-    #[cfg(not(feature = "mdbx"))]
-    {
-        unimplemented!();
-    }
-}
+pub use mdbx::{create_db, init_db, open_db, open_db_read_only, DatabaseEnv, DatabaseEnvKind};
 
 /// Collection of database test utilities
 #[cfg(any(test, feature = "test-utils"))]
@@ -173,11 +92,15 @@ pub mod test_utils {
     use crate::{
         database::Database,
         database_metrics::{DatabaseMetadata, DatabaseMetadataValue, DatabaseMetrics},
+        mdbx::DatabaseArguments,
         models::client_version::ClientVersion,
     };
     use reth_fs_util;
     use reth_libmdbx::MaxReadTransactionDuration;
-    use std::{path::PathBuf, sync::Arc};
+    use std::{
+        path::{Path, PathBuf},
+        sync::Arc,
+    };
     use tempfile::TempDir;
 
     /// Error during database open

--- a/crates/storage/db/src/lib.rs
+++ b/crates/storage/db/src/lib.rs
@@ -73,7 +73,6 @@ pub mod tables;
 mod utils;
 pub mod version;
 
-/// Bindings for [MDBX](https://libmdbx.dqdkfa.ru/).
 #[cfg(feature = "mdbx")]
 pub mod mdbx;
 

--- a/crates/storage/db/src/mdbx.rs
+++ b/crates/storage/db/src/mdbx.rs
@@ -1,0 +1,58 @@
+//! MDBX helpers
+
+pub use crate::implementation::mdbx::*;
+pub use reth_libmdbx::*;
+
+use crate::is_database_empty;
+use eyre::Context;
+use std::path::Path;
+
+/// Creates a new database at the specified path if it doesn't exist. Does NOT create tables. Check
+/// [`init_db`].
+pub fn create_db<P: AsRef<Path>>(path: P, args: DatabaseArguments) -> eyre::Result<DatabaseEnv> {
+    use crate::version::{check_db_version_file, create_db_version_file, DatabaseVersionError};
+
+    let rpath = path.as_ref();
+    if is_database_empty(rpath) {
+        reth_fs_util::create_dir_all(rpath)
+            .wrap_err_with(|| format!("Could not create database directory {}", rpath.display()))?;
+        create_db_version_file(rpath)?;
+    } else {
+        match check_db_version_file(rpath) {
+            Ok(_) => (),
+            Err(DatabaseVersionError::MissingFile) => create_db_version_file(rpath)?,
+            Err(err) => return Err(err.into()),
+        }
+    }
+
+    Ok(DatabaseEnv::open(rpath, DatabaseEnvKind::RW, args)?)
+}
+
+/// Opens up an existing database or creates a new one at the specified path. Creates tables if
+/// necessary. Read/Write mode.
+pub fn init_db<P: AsRef<Path>>(path: P, args: DatabaseArguments) -> eyre::Result<DatabaseEnv> {
+    {
+        let client_version = args.client_version().clone();
+        let db = create_db(path, args)?;
+        db.create_tables()?;
+        db.record_client_version(client_version)?;
+        Ok(db)
+    }
+}
+
+/// Opens up an existing database. Read only mode. It doesn't create it or create tables if missing.
+pub fn open_db_read_only(path: &Path, args: DatabaseArguments) -> eyre::Result<DatabaseEnv> {
+    {
+        DatabaseEnv::open(path, DatabaseEnvKind::RO, args)
+            .with_context(|| format!("Could not open database at path: {}", path.display()))
+    }
+}
+
+/// Opens up an existing database. Read/Write mode with WriteMap enabled. It doesn't create it or
+/// create tables if missing.
+pub fn open_db(path: &Path, args: DatabaseArguments) -> eyre::Result<DatabaseEnv> {
+    let db = DatabaseEnv::open(path, DatabaseEnvKind::RW, args.clone())
+        .with_context(|| format!("Could not open database at path: {}", path.display()))?;
+    db.record_client_version(args.client_version().clone())?;
+    Ok(db)
+}

--- a/crates/storage/db/src/mdbx.rs
+++ b/crates/storage/db/src/mdbx.rs
@@ -1,4 +1,4 @@
-//! MDBX helpers
+//! Bindings for [MDBX](https://libmdbx.dqdkfa.ru/).
 
 pub use crate::implementation::mdbx::*;
 pub use reth_libmdbx::*;


### PR DESCRIPTION
closes #8477

This crate is a little bit busted because it mixes the db abstraction with a feature gated implementation.

imo this should be split into `reth-mdbx`