### PR TITLE
chore(deps): bump metrics to 0.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,15 +79,6 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
@@ -3346,9 +3337,6 @@ name = "hashbrown"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -3739,7 +3727,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -4766,49 +4754,33 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.21.1"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde3af1a009ed76a778cb84fdef9e7dbbdf5775ae3e4cc1f434a6a307f6f76c5"
+checksum = "2be3cbd384d4e955b231c895ce10685e3d8260c5ccffae898c96c723b0772835"
 dependencies = [
  "ahash",
- "metrics-macros",
  "portable-atomic",
 ]
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.12.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d4fa7ce7c4862db464a37b0b31d89bca874562f034bd7993895572783d02950"
+checksum = "5d58e362dc7206e9456ddbcdbd53c71ba441020e62104703075a69151e38d85f"
 dependencies = [
- "base64 0.21.7",
- "hyper 0.14.28",
- "indexmap 1.9.3",
- "ipnet",
+ "base64 0.22.1",
+ "indexmap 2.2.6",
  "metrics",
  "metrics-util",
  "quanta",
  "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "metrics-macros"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b4faf00617defe497754acde3024865bc143d44a86799b24e191ecff91354f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
 ]
 
 [[package]]
 name = "metrics-process"
-version = "1.0.14"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aa2a67e2580fbeba4d5a96e659945981e700a383b4cea1432e0cfc18f58c5da"
+checksum = "e7d8f5027620bf43b86e2c8144beea1e4323aec39241f5eae59dee54f79c6a29"
 dependencies = [
  "libproc",
  "mach2",
@@ -4821,15 +4793,15 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.15.0"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111cb375987443c3de8d503580b536f77dc8416d32db62d9456db5d93bd7ac47"
+checksum = "8b07a5eb561b8cbc16be2d216faf7757f9baf3bfb94dbb0fae3df8387a5bb47f"
 dependencies = [
- "aho-corasick 0.7.20",
+ "aho-corasick",
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown 0.13.2",
- "indexmap 1.9.3",
+ "hashbrown 0.14.5",
+ "indexmap 2.2.6",
  "metrics",
  "num_cpus",
  "ordered-float",
@@ -5277,9 +5249,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
-version = "3.9.2"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
+checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
 dependencies = [
  "num-traits",
 ]
@@ -5834,13 +5806,12 @@ dependencies = [
 
 [[package]]
 name = "quanta"
-version = "0.11.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17e662a7a8291a865152364c20c7abc5e60486ab2001e8ec10b24862de0b9ab"
+checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
 dependencies = [
  "crossbeam-utils",
  "libc",
- "mach2",
  "once_cell",
  "raw-cpuid",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -5999,11 +5970,11 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "10.7.0"
+version = "11.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+checksum = "e29830cbb1290e404f24c73af91c5d8d631ce7e128691e9477556b540cd01ecd"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -6061,7 +6032,7 @@ version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
- "aho-corasick 1.1.3",
+ "aho-corasick",
  "memchr",
  "regex-automata 0.4.6",
  "regex-syntax 0.8.3",
@@ -6082,7 +6053,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
- "aho-corasick 1.1.3",
+ "aho-corasick",
  "memchr",
  "regex-syntax 0.8.3",
 ]
@@ -6735,7 +6706,6 @@ dependencies = [
  "bytes",
  "derive_more",
  "futures",
- "metrics",
  "pin-project",
  "proptest",
  "proptest-derive",
@@ -10219,11 +10189,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.52.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
 dependencies = [
- "windows-core",
+ "windows-core 0.56.0",
  "windows-targets 0.52.5",
 ]
 
@@ -10232,6 +10202,49 @@ name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "749f0da9cc72d82e600d8d2e44cadd0b9eedb9038f71a1c58556ac1c5791813b"
 dependencies = [
  "windows-targets 0.52.5",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -361,8 +361,6 @@ strum = "0.26"
 rayon = "1.7"
 itertools = "0.12"
 parking_lot = "0.12"
-# Needed for `metrics-macro` to resolve the crate using `::metrics` notation
-metrics = "0.21.1"
 modular-bitfield = "0.11.2"
 once_cell = "1.17"
 syn = "2.0"
@@ -372,6 +370,12 @@ dyn-clone = "1.0.17"
 sha2 = { version = "0.10", default-features = false }
 paste = "1.0"
 url = "2.3"
+
+# metrics
+metrics = "0.22.0"
+metrics-exporter-prometheus = { version = "0.14.0", default-features = false }
+metrics-util = "0.16.0"
+metrics-process = "2.0.0"
 
 # proc-macros
 proc-macro2 = "1.0"

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -75,7 +75,7 @@ confy.workspace = true
 toml = { workspace = true, features = ["display"] }
 
 # metrics
-metrics-process = "=1.0.14"
+metrics-process.workspace = true
 
 # test vectors generation
 proptest.workspace = true

--- a/crates/metrics/metrics-derive/src/lib.rs
+++ b/crates/metrics/metrics-derive/src/lib.rs
@@ -58,10 +58,10 @@ mod with_attrs;
 /// impl Default for CustomMetrics {
 ///     fn default() -> Self {
 ///         Self {
-///             gauge: metrics::register_gauge!("metrics_custom_gauge"),
-///             gauge2: metrics::register_gauge!("metrics_custom_second_gauge"),
-///             counter: metrics::register_counter!("metrics_custom_counter"),
-///             histo: metrics::register_histogram!("metrics_custom_histogram"),
+///             gauge: metrics::gauge!("metrics_custom_gauge"),
+///             gauge2: metrics::gauge!("metrics_custom_second_gauge"),
+///             counter: metrics::counter!("metrics_custom_counter"),
+///             histo: metrics::histogram!("metrics_custom_histogram"),
 ///         }
 ///     }
 /// }
@@ -115,7 +115,7 @@ mod with_attrs;
 ///
 /// impl DynamicScopeMetrics {
 ///     pub fn new(scope: &str) -> Self {
-///         Self { gauge: metrics::register_gauge!(format!("{}{}{}", scope, "_", "gauge")) }
+///         Self { gauge: metrics::gauge!(format!("{}{}{}", scope, "_", "gauge")) }
 ///     }
 ///
 ///     pub fn describe(scope: &str) {

--- a/crates/metrics/metrics-derive/src/metric.rs
+++ b/crates/metrics/metrics-derive/src/metric.rs
@@ -27,9 +27,9 @@ impl<'a> Metric<'a> {
         if let Type::Path(ref path_ty) = self.field.ty {
             if let Some(last) = path_ty.path.segments.last() {
                 let registrar = match last.ident.to_string().as_str() {
-                    COUNTER_TY => quote! { metrics::register_counter! },
-                    HISTOGRAM_TY => quote! { metrics::register_histogram! },
-                    GAUGE_TY => quote! { metrics::register_gauge! },
+                    COUNTER_TY => quote! { metrics::counter! },
+                    HISTOGRAM_TY => quote! { metrics::histogram! },
+                    GAUGE_TY => quote! { metrics::gauge! },
                     _ => return Err(Error::new_spanned(path_ty, "Unsupported metric type")),
                 };
 

--- a/crates/net/eth-wire/Cargo.toml
+++ b/crates/net/eth-wire/Cargo.toml
@@ -23,7 +23,6 @@ reth-network-types.workspace = true
 
 # metrics
 reth-metrics.workspace = true
-metrics.workspace = true
 
 bytes.workspace = true
 derive_more.workspace = true

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -128,7 +128,7 @@ where
                 } else {
                     debug!(%reason, "Disconnected by peer during handshake");
                 };
-                counter!("p2pstream.disconnected_errors", 1);
+                counter!("p2pstream.disconnected_errors").increment(1);
                 Err(P2PStreamError::HandshakeError(P2PHandshakeError::Disconnected(reason)))
             }
             Err(err) => {

--- a/crates/node-core/Cargo.toml
+++ b/crates/node-core/Cargo.toml
@@ -47,12 +47,11 @@ tokio-util.workspace = true
 pin-project.workspace = true
 
 # metrics
-metrics-exporter-prometheus = "0.12.1"
-once_cell.workspace = true
-metrics-util = "0.15.0"
-metrics-process = "=1.0.14"
-metrics.workspace = true
 reth-metrics.workspace = true
+metrics.workspace = true
+metrics-exporter-prometheus.workspace = true
+metrics-process.workspace = true
+metrics-util.workspace = true
 
 # misc
 eyre.workspace = true
@@ -62,6 +61,7 @@ thiserror.workspace = true
 const-str = "0.5.6"
 rand.workspace = true
 derive_more.workspace = true
+once_cell.workspace = true
 
 # io
 dirs-next = "2.0.0"

--- a/crates/node-core/src/metrics/prometheus_exporter.rs
+++ b/crates/node-core/src/metrics/prometheus_exporter.rs
@@ -164,37 +164,37 @@ fn collect_memory_stats() {
     if let Ok(value) = stats::active::read()
         .map_err(|error| error!(%error, "Failed to read jemalloc.stats.active"))
     {
-        gauge!("jemalloc.active", value as f64);
+        gauge!("jemalloc.active").set(value as f64);
     }
 
     if let Ok(value) = stats::allocated::read()
         .map_err(|error| error!(%error, "Failed to read jemalloc.stats.allocated"))
     {
-        gauge!("jemalloc.allocated", value as f64);
+        gauge!("jemalloc.allocated").set(value as f64);
     }
 
     if let Ok(value) = stats::mapped::read()
         .map_err(|error| error!(%error, "Failed to read jemalloc.stats.mapped"))
     {
-        gauge!("jemalloc.mapped", value as f64);
+        gauge!("jemalloc.mapped").set(value as f64);
     }
 
     if let Ok(value) = stats::metadata::read()
         .map_err(|error| error!(%error, "Failed to read jemalloc.stats.metadata"))
     {
-        gauge!("jemalloc.metadata", value as f64);
+        gauge!("jemalloc.metadata").set(value as f64);
     }
 
     if let Ok(value) = stats::resident::read()
         .map_err(|error| error!(%error, "Failed to read jemalloc.stats.resident"))
     {
-        gauge!("jemalloc.resident", value as f64);
+        gauge!("jemalloc.resident").set(value as f64);
     }
 
     if let Ok(value) = stats::retained::read()
         .map_err(|error| error!(%error, "Failed to read jemalloc.stats.retained"))
     {
-        gauge!("jemalloc.retained", value as f64);
+        gauge!("jemalloc.retained").set(value as f64);
     }
 }
 
@@ -241,7 +241,7 @@ fn describe_memory_stats() {}
 
 #[cfg(target_os = "linux")]
 fn collect_io_stats() {
-    use metrics::absolute_counter;
+    use metrics::counter;
     use tracing::error;
 
     let Ok(process) = procfs::process::Process::myself()
@@ -256,13 +256,13 @@ fn collect_io_stats() {
         return
     };
 
-    absolute_counter!("io.rchar", io.rchar);
-    absolute_counter!("io.wchar", io.wchar);
-    absolute_counter!("io.syscr", io.syscr);
-    absolute_counter!("io.syscw", io.syscw);
-    absolute_counter!("io.read_bytes", io.read_bytes);
-    absolute_counter!("io.write_bytes", io.write_bytes);
-    absolute_counter!("io.cancelled_write_bytes", io.cancelled_write_bytes);
+    counter!("io.rchar").absolute(io.rchar);
+    counter!("io.wchar").absolute(io.wchar);
+    counter!("io.syscr").absolute(io.syscr);
+    counter!("io.syscw").absolute(io.syscw);
+    counter!("io.read_bytes").absolute(io.read_bytes);
+    counter!("io.write_bytes").absolute(io.write_bytes);
+    counter!("io.cancelled_write_bytes").absolute(io.cancelled_write_bytes);
 }
 
 #[cfg(target_os = "linux")]
@@ -287,7 +287,6 @@ const fn describe_io_stats() {}
 #[cfg(test)]
 mod tests {
     use crate::node_config::PROMETHEUS_RECORDER_HANDLE;
-    use std::ops::Deref;
 
     // Dependencies using different version of the `metrics` crate (to be exact, 0.21 vs 0.22)
     // may not be able to communicate with each other through the global recorder.
@@ -297,13 +296,13 @@ mod tests {
     #[test]
     fn process_metrics() {
         // initialize the lazy handle
-        let _ = PROMETHEUS_RECORDER_HANDLE.deref();
+        let _ = &*PROMETHEUS_RECORDER_HANDLE;
 
         let process = metrics_process::Collector::default();
         process.describe();
         process.collect();
 
         let metrics = PROMETHEUS_RECORDER_HANDLE.render();
-        assert!(metrics.contains("process_cpu_seconds_total"));
+        assert!(metrics.contains("process_cpu_seconds_total"), "{metrics:?}");
     }
 }

--- a/crates/node-core/src/metrics/version_metrics.rs
+++ b/crates/node-core/src/metrics/version_metrics.rs
@@ -1,7 +1,7 @@
 //! This exposes reth's version information over prometheus.
 
 use crate::version::build_profile_name;
-use metrics::register_gauge;
+use metrics::gauge;
 
 const LABELS: [(&str, &str); 6] = [
     ("version", env!("CARGO_PKG_VERSION")),
@@ -14,5 +14,5 @@ const LABELS: [(&str, &str); 6] = [
 
 /// This exposes reth's version information over prometheus.
 pub fn register_version_metrics() {
-    register_gauge!("info", &LABELS);
+    let _gauge = gauge!("reth_version_info", &LABELS);
 }

--- a/crates/storage/db/src/abstraction/database_metrics.rs
+++ b/crates/storage/db/src/abstraction/database_metrics.rs
@@ -7,15 +7,15 @@ pub trait DatabaseMetrics {
     /// Reports metrics for the database.
     fn report_metrics(&self) {
         for (name, value, labels) in self.gauge_metrics() {
-            gauge!(name, value, labels);
+            gauge!(name, labels).set(value);
         }
 
         for (name, value, labels) in self.counter_metrics() {
-            counter!(name, value, labels);
+            counter!(name, labels).increment(value);
         }
 
         for (name, value, labels) in self.histogram_metrics() {
-            histogram!(name, value, labels);
+            histogram!(name, labels).record(value);
         }
     }
 

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -160,7 +160,7 @@ impl Database for DatabaseEnv {
 impl DatabaseMetrics for DatabaseEnv {
     fn report_metrics(&self) {
         for (name, value, labels) in self.gauge_metrics() {
-            gauge!(name, value, labels);
+            gauge!(name, labels).set(value);
         }
     }
 


### PR DESCRIPTION
Last hyper dupe in https://github.com/paradigmxyz/reth/pull/7018

There's 0.23, but it's blocked by `metrics-process` not yet being up to date. Should be a trivial follow-up once they update it.