### PR TITLE
feat: accessor for ethconfig

### DIFF
--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -570,9 +570,15 @@ impl RpcModuleConfig {
     pub fn builder() -> RpcModuleConfigBuilder {
         RpcModuleConfigBuilder::default()
     }
+
     /// Returns a new RPC module config given the eth namespace config
     pub const fn new(eth: EthConfig) -> Self {
         Self { eth }
+    }
+
+    /// Get a mutable reference to the eth namespace config
+    pub fn eth_mut(&mut self) -> &mut EthConfig {
+        &mut self.eth
     }
 }
 
@@ -595,6 +601,11 @@ impl RpcModuleConfigBuilder {
     pub fn build(self) -> RpcModuleConfig {
         let Self { eth } = self;
         RpcModuleConfig { eth: eth.unwrap_or_default() }
+    }
+
+    /// Get a mutable reference to the eth namespace config.
+    pub fn eth_mut(&mut self) -> &mut Option<EthConfig> {
+        &mut self.eth
     }
 }
 

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -576,6 +576,11 @@ impl RpcModuleConfig {
         Self { eth }
     }
 
+    /// Get a reference to the eth namespace config
+    pub fn eth(&self) -> &EthConfig {
+        &self.eth
+    }
+
     /// Get a mutable reference to the eth namespace config
     pub fn eth_mut(&mut self) -> &mut EthConfig {
         &mut self.eth
@@ -603,9 +608,19 @@ impl RpcModuleConfigBuilder {
         RpcModuleConfig { eth: eth.unwrap_or_default() }
     }
 
-    /// Get a mutable reference to the eth namespace config.
+    /// Get a reference to the eth namespace config, if any
+    pub fn get_eth(&self) -> &Option<EthConfig> {
+        &self.eth
+    }
+
+    /// Get a mutable reference to the eth namespace config, if any
     pub fn eth_mut(&mut self) -> &mut Option<EthConfig> {
         &mut self.eth
+    }
+
+    /// Get the eth namespace config, creating a default if none is set
+    pub fn eth_mut_or_default(&mut self) -> &mut EthConfig {
+        self.eth.get_or_insert_with(EthConfig::default)
     }
 }
 

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -577,7 +577,7 @@ impl RpcModuleConfig {
     }
 
     /// Get a reference to the eth namespace config
-    pub fn eth(&self) -> &EthConfig {
+    pub const fn eth(&self) -> &EthConfig {
         &self.eth
     }
 
@@ -609,7 +609,7 @@ impl RpcModuleConfigBuilder {
     }
 
     /// Get a reference to the eth namespace config, if any
-    pub fn get_eth(&self) -> &Option<EthConfig> {
+    pub const fn get_eth(&self) -> &Option<EthConfig> {
         &self.eth
     }
 


### PR DESCRIPTION
Followup to #8504.

## Motivation
`RpcModuleConfig` is completely opaque outside of the crate

## Solution
- Adds mutable accessors for eth rpc config
- Adds immutable accessor to the builder
- Adds mutable _or_default