### PR TITLE
chore: OptimismPayloadAttributes Re-export

### DIFF
--- a/crates/optimism/payload/src/lib.rs
+++ b/crates/optimism/payload/src/lib.rs
@@ -18,3 +18,6 @@ pub mod payload;
 pub use payload::{
     OptimismBuiltPayload, OptimismPayloadAttributes, OptimismPayloadBuilderAttributes,
 };
+
+/// Re-export for use in downstream arguments.
+pub use reth_rpc_types::engine::OptimismPayloadAttributes;

--- a/crates/optimism/payload/src/lib.rs
+++ b/crates/optimism/payload/src/lib.rs
@@ -15,4 +15,4 @@ pub mod builder;
 pub use builder::OptimismPayloadBuilder;
 pub mod error;
 pub mod payload;
-pub use payload::{OptimismBuiltPayload, OptimismPayloadBuilderAttributes};
+pub use payload::{OptimismBuiltPayload, OptimismPayloadAttributes, OptimismPayloadBuilderAttributes};

--- a/crates/optimism/payload/src/lib.rs
+++ b/crates/optimism/payload/src/lib.rs
@@ -15,4 +15,6 @@ pub mod builder;
 pub use builder::OptimismPayloadBuilder;
 pub mod error;
 pub mod payload;
-pub use payload::{OptimismBuiltPayload, OptimismPayloadAttributes, OptimismPayloadBuilderAttributes};
+pub use payload::{
+    OptimismBuiltPayload, OptimismPayloadAttributes, OptimismPayloadBuilderAttributes,
+};

--- a/crates/optimism/payload/src/payload.rs
+++ b/crates/optimism/payload/src/payload.rs
@@ -22,7 +22,7 @@ use reth_rpc_types_compat::engine::payload::{
 use revm::primitives::HandlerCfg;
 use std::sync::Arc;
 
-/// Re-export [OptimsimPayloadAttributes] for argument use.
+/// Re-export for use in downstream arguments.
 pub use reth_rpc_types::engine::OptimismPayloadAttributes;
 
 /// Optimism Payload Builder Attributes

--- a/crates/optimism/payload/src/payload.rs
+++ b/crates/optimism/payload/src/payload.rs
@@ -13,7 +13,7 @@ use reth_primitives::{
 };
 use reth_rpc_types::engine::{
     ExecutionPayloadEnvelopeV2, ExecutionPayloadV1, OptimismExecutionPayloadEnvelopeV3,
-    OptimismExecutionPayloadEnvelopeV4, PayloadId,
+    OptimismExecutionPayloadEnvelopeV4, OptimismPayloadAttributes, PayloadId,
 };
 use reth_rpc_types_compat::engine::payload::{
     block_to_payload_v1, block_to_payload_v3, block_to_payload_v4,
@@ -21,9 +21,6 @@ use reth_rpc_types_compat::engine::payload::{
 };
 use revm::primitives::HandlerCfg;
 use std::sync::Arc;
-
-/// Re-export for use in downstream arguments.
-pub use reth_rpc_types::engine::OptimismPayloadAttributes;
 
 /// Optimism Payload Builder Attributes
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/optimism/payload/src/payload.rs
+++ b/crates/optimism/payload/src/payload.rs
@@ -13,7 +13,7 @@ use reth_primitives::{
 };
 use reth_rpc_types::engine::{
     ExecutionPayloadEnvelopeV2, ExecutionPayloadV1, OptimismExecutionPayloadEnvelopeV3,
-    OptimismExecutionPayloadEnvelopeV4, OptimismPayloadAttributes, PayloadId,
+    OptimismExecutionPayloadEnvelopeV4, PayloadId,
 };
 use reth_rpc_types_compat::engine::payload::{
     block_to_payload_v1, block_to_payload_v3, block_to_payload_v4,
@@ -21,6 +21,9 @@ use reth_rpc_types_compat::engine::payload::{
 };
 use revm::primitives::HandlerCfg;
 use std::sync::Arc;
+
+/// Re-export [OptimsimPayloadAttributes] for argument use.
+pub use reth_rpc_types::engine::OptimismPayloadAttributes;
 
 /// Optimism Payload Builder Attributes
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
**Description**

Re-exports the `reth_rpc_types::engine::OptimismPayloadAttributes` from the Optimism payload modules for downstream use since `OptimismPayloadAttributes` is used as an argument type. This saves downstream users from importing the `reth_rpc_types` crate just to pull in the `OptimismPayloadAttributes` type.