### PR TITLE
[RFC] feat: Kona ExEx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,48 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#4ecb7d86882ece8a9a7a5a892b71a3c198030731"
+source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
+dependencies = [
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "c-kzg",
+ "serde",
+]
+
+[[package]]
+name = "alloy-consensus"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=cb95183#cb95183d477024b57b27336035d10403e8ba55b8"
+dependencies = [
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
+ "serde",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "alloy-consensus"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=e3f2f07#e3f2f075a9e7ad9753a255dbe71dbad6a91ba96d"
+dependencies = [
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "c-kzg",
+ "serde",
+ "sha2 0.10.8",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-consensus"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy#dc56a76dda6c10d9eea267e775c36130128f9e5b"
 dependencies = [
  "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy)",
  "alloy-primitives",
@@ -189,7 +230,47 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#4ecb7d86882ece8a9a7a5a892b71a3c198030731"
+source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "c-kzg",
+ "once_cell",
+ "serde",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=cb95183#cb95183d477024b57b27336035d10403e8ba55b8"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
+ "c-kzg",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=e3f2f07#e3f2f075a9e7ad9753a255dbe71dbad6a91ba96d"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "c-kzg",
+ "derive_more",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy#dc56a76dda6c10d9eea267e775c36130128f9e5b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -214,7 +295,28 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#4ecb7d86882ece8a9a7a5a892b71a3c198030731"
+source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
+dependencies = [
+ "alloy-primitives",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-genesis"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=e3f2f07#e3f2f075a9e7ad9753a255dbe71dbad6a91ba96d"
+dependencies = [
+ "alloy-primitives",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "serde",
+]
+
+[[package]]
+name = "alloy-genesis"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy#dc56a76dda6c10d9eea267e775c36130128f9e5b"
 dependencies = [
  "alloy-primitives",
  "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy)",
@@ -247,19 +349,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-json-rpc"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-json-rpc"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=e3f2f07#e3f2f075a9e7ad9753a255dbe71dbad6a91ba96d"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "alloy-network"
 version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=61140ec#61140ec42988abed6db3d2d38044b2918e08d2a9"
 dependencies = [
  "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
  "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
- "alloy-json-rpc",
+ "alloy-json-rpc 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
  "alloy-primitives",
  "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
- "alloy-signer",
+ "alloy-signer 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
+ "futures-utils-wasm",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-network"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
+dependencies = [
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-json-rpc 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-primitives",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-signer 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-sol-types",
+ "async-trait",
+ "auto_impl",
+ "futures-utils-wasm",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-network"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=e3f2f07#e3f2f075a9e7ad9753a255dbe71dbad6a91ba96d"
+dependencies = [
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "alloy-json-rpc 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "alloy-primitives",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "alloy-signer 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "async-trait",
  "futures-utils-wasm",
  "thiserror",
 ]
@@ -314,14 +473,14 @@ dependencies = [
  "alloy-chains",
  "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
  "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
- "alloy-json-rpc",
- "alloy-network",
+ "alloy-json-rpc 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
+ "alloy-network 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
  "alloy-primitives",
- "alloy-rpc-client",
+ "alloy-rpc-client 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
  "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
- "alloy-rpc-types-trace",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-rpc-types-trace 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
+ "alloy-transport 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
+ "alloy-transport-http 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
  "async-stream",
  "async-trait",
  "auto_impl",
@@ -332,6 +491,64 @@ dependencies = [
  "pin-project",
  "reqwest 0.12.4",
  "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "alloy-provider"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-json-rpc 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-network 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-primitives",
+ "alloy-rpc-client 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-rpc-types-trace 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-transport 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-transport-http 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "async-stream",
+ "async-trait",
+ "auto_impl",
+ "dashmap",
+ "futures",
+ "futures-utils-wasm",
+ "lru",
+ "pin-project",
+ "reqwest 0.12.4",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "alloy-provider"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=e3f2f07#e3f2f075a9e7ad9753a255dbe71dbad6a91ba96d"
+dependencies = [
+ "alloy-json-rpc 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "alloy-network 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "alloy-primitives",
+ "alloy-rpc-client 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "alloy-rpc-types-trace 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "alloy-transport 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "alloy-transport-http 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "async-stream",
+ "async-trait",
+ "auto_impl",
+ "dashmap",
+ "futures",
+ "lru",
+ "reqwest 0.12.4",
  "serde_json",
  "tokio",
  "tracing",
@@ -365,9 +582,49 @@ name = "alloy-rpc-client"
 version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=61140ec#61140ec42988abed6db3d2d38044b2918e08d2a9"
 dependencies = [
- "alloy-json-rpc",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-json-rpc 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
+ "alloy-transport 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
+ "alloy-transport-http 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
+ "futures",
+ "pin-project",
+ "reqwest 0.12.4",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "alloy-rpc-client"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
+dependencies = [
+ "alloy-json-rpc 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-transport 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-transport-http 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "futures",
+ "pin-project",
+ "reqwest 0.12.4",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "alloy-rpc-client"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=e3f2f07#e3f2f075a9e7ad9753a255dbe71dbad6a91ba96d"
+dependencies = [
+ "alloy-json-rpc 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "alloy-transport 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "alloy-transport-http 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
  "futures",
  "pin-project",
  "reqwest 0.12.4",
@@ -405,7 +662,43 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#4ecb7d86882ece8a9a7a5a892b71a3c198030731"
+source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
+dependencies = [
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-sol-types",
+ "itertools 0.12.1",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=e3f2f07#e3f2f075a9e7ad9753a255dbe71dbad6a91ba96d"
+dependencies = [
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "alloy-sol-types",
+ "itertools 0.12.1",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy#dc56a76dda6c10d9eea267e775c36130128f9e5b"
 dependencies = [
  "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy)",
  "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy)",
@@ -474,6 +767,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-rpc-types-trace"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-rpc-types-trace"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=e3f2f07#e3f2f075a9e7ad9753a255dbe71dbad6a91ba96d"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "alloy-serde"
 version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=61140ec#61140ec42988abed6db3d2d38044b2918e08d2a9"
@@ -486,7 +803,37 @@ dependencies = [
 [[package]]
 name = "alloy-serde"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#4ecb7d86882ece8a9a7a5a892b71a3c198030731"
+source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=cb95183#cb95183d477024b57b27336035d10403e8ba55b8"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=e3f2f07#e3f2f075a9e7ad9753a255dbe71dbad6a91ba96d"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy#dc56a76dda6c10d9eea267e775c36130128f9e5b"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -507,14 +854,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-signer"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
+dependencies = [
+ "alloy-primitives",
+ "async-trait",
+ "auto_impl",
+ "elliptic-curve",
+ "k256",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-signer"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=e3f2f07#e3f2f075a9e7ad9753a255dbe71dbad6a91ba96d"
+dependencies = [
+ "alloy-primitives",
+ "async-trait",
+ "auto_impl",
+ "elliptic-curve",
+ "k256",
+ "thiserror",
+]
+
+[[package]]
 name = "alloy-signer-wallet"
 version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=61140ec#61140ec42988abed6db3d2d38044b2918e08d2a9"
 dependencies = [
  "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
- "alloy-network",
+ "alloy-network 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
  "alloy-primitives",
- "alloy-signer",
+ "alloy-signer 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
  "async-trait",
  "coins-bip32",
  "coins-bip39",
@@ -600,7 +973,43 @@ name = "alloy-transport"
 version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=61140ec#61140ec42988abed6db3d2d38044b2918e08d2a9"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
+ "base64 0.22.1",
+ "futures-util",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tower",
+ "url",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "alloy-transport"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
+dependencies = [
+ "alloy-json-rpc 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "base64 0.22.1",
+ "futures-util",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tower",
+ "url",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "alloy-transport"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=e3f2f07#e3f2f075a9e7ad9753a255dbe71dbad6a91ba96d"
+dependencies = [
+ "alloy-json-rpc 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
  "base64 0.22.1",
  "futures-util",
  "futures-utils-wasm",
@@ -618,12 +1027,39 @@ name = "alloy-transport-http"
 version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=61140ec#61140ec42988abed6db3d2d38044b2918e08d2a9"
 dependencies = [
- "alloy-json-rpc",
- "alloy-transport",
+ "alloy-json-rpc 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
+ "alloy-transport 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
  "reqwest 0.12.4",
  "serde_json",
  "tower",
  "tracing",
+ "url",
+]
+
+[[package]]
+name = "alloy-transport-http"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
+dependencies = [
+ "alloy-json-rpc 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-transport 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "reqwest 0.12.4",
+ "serde_json",
+ "tower",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "alloy-transport-http"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=e3f2f07#e3f2f075a9e7ad9753a255dbe71dbad6a91ba96d"
+dependencies = [
+ "alloy-json-rpc 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "alloy-transport 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "reqwest 0.12.4",
+ "serde_json",
+ "tower",
  "url",
 ]
 
@@ -2977,6 +3413,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3624,6 +4075,22 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -4325,6 +4792,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "kona-derive"
+version = "0.0.1"
+source = "git+https://github.com/ethereum-optimism/kona?branch=main#044570b3581c3392224c21183bff99b215b9d364"
+dependencies = [
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "alloy-primitives",
+ "alloy-provider 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "alloy-rlp",
+ "alloy-sol-types",
+ "alloy-transport-http 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "anyhow",
+ "async-trait",
+ "c-kzg",
+ "hashbrown 0.14.5",
+ "kona-primitives",
+ "lru",
+ "miniz_oxide",
+ "op-alloy-consensus",
+ "reqwest 0.12.4",
+ "revm-primitives 3.1.1",
+ "serde",
+ "sha2 0.10.8",
+ "spin 0.9.8",
+ "tracing",
+ "unsigned-varint 0.8.0",
+]
+
+[[package]]
+name = "kona-exex"
+version = "0.0.0"
+dependencies = [
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "alloy-provider 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-rlp",
+ "alloy-rpc-client 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-transport-http 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "anyhow",
+ "async-trait",
+ "eyre",
+ "kona-derive",
+ "kona-primitives",
+ "reqwest 0.12.4",
+ "reth",
+ "reth-basic-payload-builder",
+ "reth-evm",
+ "reth-execution-errors",
+ "reth-exex",
+ "reth-node-api",
+ "reth-node-ethereum",
+ "reth-node-optimism",
+ "reth-payload-builder",
+ "reth-primitives",
+ "reth-provider",
+ "reth-revm",
+ "reth-rpc-types",
+ "reth-testing-utils",
+ "reth-tracing",
+ "reth-transaction-pool",
+ "secp256k1 0.28.2",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "kona-primitives"
+version = "0.0.1"
+source = "git+https://github.com/ethereum-optimism/kona?branch=main#044570b3581c3392224c21183bff99b215b9d364"
+dependencies = [
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-sol-types",
+ "anyhow",
+ "op-alloy-consensus",
+ "serde",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4948,6 +5497,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "network"
 version = "0.0.0"
 dependencies = [
@@ -5205,16 +5771,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
+name = "op-alloy-consensus"
+version = "0.1.0"
+source = "git+https://github.com/clabby/op-alloy?branch=refcell/consensus-port#74ed6337b600a7f77fa10568be0f054042f70400"
+dependencies = [
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
+ "serde",
+]
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl"
+version = "0.10.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+dependencies = [
+ "bitflags 2.5.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -5715,9 +6332,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.84"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
@@ -6108,11 +6725,13 @@ dependencies = [
  "http-body-util",
  "hyper 1.3.1",
  "hyper-rustls 0.26.0",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -6125,6 +6744,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.25.0",
  "tower-service",
  "url",
@@ -6596,9 +7216,9 @@ name = "reth-e2e-test-utils"
 version = "0.2.0-beta.7"
 dependencies = [
  "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
- "alloy-network",
+ "alloy-network 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
  "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
- "alloy-signer",
+ "alloy-signer 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
  "alloy-signer-wallet",
  "eyre",
  "futures-util",
@@ -6747,7 +7367,7 @@ dependencies = [
  "reth-primitives",
  "reth-rpc-types",
  "reth-rpc-types-compat",
- "revm-primitives",
+ "revm-primitives 4.0.0",
  "serde",
  "serde_json",
  "sha2 0.10.8",
@@ -6806,7 +7426,7 @@ dependencies = [
  "reth-primitives",
  "reth-storage-errors",
  "revm",
- "revm-primitives",
+ "revm-primitives 4.0.0",
 ]
 
 [[package]]
@@ -6820,7 +7440,7 @@ dependencies = [
  "reth-primitives",
  "reth-revm",
  "reth-testing-utils",
- "revm-primitives",
+ "revm-primitives 4.0.0",
  "secp256k1 0.28.2",
  "serde_json",
 ]
@@ -6837,7 +7457,7 @@ dependencies = [
  "reth-provider",
  "reth-revm",
  "revm",
- "revm-primitives",
+ "revm-primitives 4.0.0",
  "thiserror",
  "tracing",
 ]
@@ -6995,7 +7615,7 @@ name = "reth-network"
 version = "0.2.0-beta.7"
 dependencies = [
  "alloy-node-bindings",
- "alloy-provider",
+ "alloy-provider 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
@@ -7309,7 +7929,7 @@ dependencies = [
  "reth-rpc-types-compat",
  "reth-tracing",
  "reth-transaction-pool",
- "revm-primitives",
+ "revm-primitives 4.0.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -7418,7 +8038,7 @@ dependencies = [
  "reth-network-types",
  "reth-static-file-types",
  "revm",
- "revm-primitives",
+ "revm-primitives 4.0.0",
  "roaring",
  "secp256k1 0.28.2",
  "serde",
@@ -7551,7 +8171,7 @@ dependencies = [
  "reth-transaction-pool",
  "revm",
  "revm-inspectors",
- "revm-primitives",
+ "revm-primitives 4.0.0",
  "schnellru",
  "secp256k1 0.28.2",
  "serde",
@@ -7688,7 +8308,7 @@ dependencies = [
  "alloy-rpc-types-anvil",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-trace",
+ "alloy-rpc-types-trace 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
  "arbitrary",
  "bytes",
  "jsonrpsee-types",
@@ -7988,7 +8608,7 @@ source = "git+https://github.com/paradigmxyz/evm-inspectors?rev=2b6fff1#2b6fff14
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
- "alloy-rpc-types-trace",
+ "alloy-rpc-types-trace 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=61140ec)",
  "alloy-sol-types",
  "anstyle",
  "boa_engine",
@@ -8004,7 +8624,7 @@ name = "revm-interpreter"
 version = "5.0.0"
 source = "git+https://github.com/bluealloy/revm?rev=a28a543#a28a5439b9cfb7494cbd670da10cbedcfe6c5854"
 dependencies = [
- "revm-primitives",
+ "revm-primitives 4.0.0",
  "serde",
 ]
 
@@ -8019,11 +8639,32 @@ dependencies = [
  "k256",
  "once_cell",
  "p256",
- "revm-primitives",
+ "revm-primitives 4.0.0",
  "ripemd",
  "secp256k1 0.29.0",
  "sha2 0.10.8",
  "substrate-bn",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbbc9640790cebcb731289afb7a7d96d16ad94afeb64b5d0b66443bd151e79d6"
+dependencies = [
+ "alloy-primitives",
+ "auto_impl",
+ "bitflags 2.5.0",
+ "bitvec",
+ "c-kzg",
+ "cfg-if",
+ "derive_more",
+ "dyn-clone",
+ "enumn",
+ "hashbrown 0.14.5",
+ "hex",
+ "once_cell",
+ "serde",
 ]
 
 [[package]]
@@ -8938,6 +9579,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spinning"
@@ -9431,6 +10075,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.66",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/examples/exex/kona/Cargo.toml
+++ b/examples/exex/kona/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "kona-exex"
+version = "0.0.0"
+publish = false
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+# reth
+reth.workspace = true
+reth-exex.workspace = true
+reth-node-api.workspace = true
+reth-node-ethereum.workspace = true
+reth-primitives.workspace = true
+reth-execution-errors.workspace = true
+reth-provider.workspace = true
+reth-revm.workspace = true
+reth-tracing.workspace = true
+reth-transaction-pool.workspace = true
+reth-basic-payload-builder.workspace = true
+reth-evm.workspace = true
+reth-payload-builder.workspace = true
+reth-rpc-types.workspace = true
+reth-node-optimism = { workspace = true, features = [ "optimism" ] }
+
+# workspace deps
+tracing.workspace = true
+async-trait.workspace = true
+url.workspace = true
+reqwest.workspace = true
+eyre.workspace = true
+tokio.workspace = true
+serde_json.workspace = true
+
+# kona
+anyhow = { version = "1.0.79", default-features = false }
+kona-derive = { git = "https://github.com/ethereum-optimism/kona", branch = "main", features = ["online", "serde", "k256"] }
+kona-primitives = { git = "https://github.com/ethereum-optimism/kona", branch = "main" }
+
+# alloy
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "bd39117" }
+alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "bd39117" }
+alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "bd39117" }
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "e3f2f07", default-features = false, features = ["kzg"] }
+# alloy-consensus = { workspace = true, features = ["kzg"] }
+alloy-rlp.workspace = true
+
+[dev-dependencies]
+reth-testing-utils.workspace = true
+secp256k1.workspace = true

--- a/examples/exex/kona/src/blobs.rs
+++ b/examples/exex/kona/src/blobs.rs
@@ -1,0 +1,66 @@
+//! Blob Provider
+
+use anyhow::Result;
+use std::boxed::Box;
+use std::sync::{Arc, Mutex};
+use std::collections::HashMap;
+use reth_primitives::alloy_primitives::{FixedBytes, B256};
+use kona_derive::types::{BlockInfo, Blob, BlobProviderError, IndexedBlobHash};
+use async_trait::async_trait;
+use kona_derive::traits::BlobProvider;
+
+/// A blob provider that hold blobs in memory.
+#[derive(Default, Debug, Clone)]
+pub struct InMemoryBlobProvider {
+    /// Maps block hashes to blobs.
+    blocks_to_blob: HashMap<B256, Vec<Blob>>,
+}
+
+impl InMemoryBlobProvider {
+    /// Creates a new [InMemoryBlobProvider].
+    pub fn new() -> Self {
+        Self { blocks_to_blob: HashMap::new() }
+    }
+
+    /// Inserts multiple blobs into the provider.
+    pub fn insert_blobs(&mut self, block_hash: B256, blobs: Vec<Blob>) {
+        self.blocks_to_blob.entry(block_hash).or_default().extend(blobs);
+    }
+}
+
+/// [BlobProvider] for the [kona_derive::DerivationPipeline].
+#[derive(Debug, Clone)]
+pub struct ExExBlobProvider(Arc<Mutex<InMemoryBlobProvider>>);
+
+impl ExExBlobProvider {
+    /// Creates a new [ExExBlobProvider].
+    pub fn new(inner: Arc<Mutex<InMemoryBlobProvider>>) -> Self {
+        Self(inner)
+    }
+}
+
+#[async_trait]
+impl BlobProvider for ExExBlobProvider {
+    /// Fetches blobs for a given block ref and the blob hashes.
+    async fn get_blobs(
+        &mut self,
+        block_ref: &BlockInfo,
+        blob_hashes: &[IndexedBlobHash],
+    ) -> Result<Vec<Blob>, BlobProviderError> {
+        let err = |block_ref: &BlockInfo| BlobProviderError::Custom(anyhow::anyhow!("Blob not found for block ref: {:?}", block_ref));
+        let locked = self.0.lock().map_err(|_| err(block_ref))?;
+        let blobs_for_block = locked.blocks_to_blob.get(&block_ref.hash).ok_or_else(|| err(block_ref))?;
+        let mut blobs = Vec::new();
+        for _blob_hash in blob_hashes {
+            for blob in blobs_for_block {
+                // TODO: update kona-derive to use the alloy_eips Blob type
+                // if blob_hash.hash == blob.hash {
+                //     blobs.push(*blob.clone());
+                //     break;
+                // }
+                blobs.push(FixedBytes(**blob));
+            }
+        }
+        Ok(blobs)
+    }
+}

--- a/examples/exex/kona/src/execution.rs
+++ b/examples/exex/kona/src/execution.rs
@@ -1,0 +1,97 @@
+//! Module for executing [kona_derive::types::L2ExecutionPayload]s against [reth_revm::Evm].
+
+use std::sync::Arc;
+use reth_evm::ConfigureEvm;
+use reth_payload_builder::database::CachedReads;
+use reth_basic_payload_builder::*;
+use reth_node_optimism::{OptimismPayloadBuilderAttributes, OptimismPayloadBuilder};
+use reth_revm::InMemoryDB;
+use reth_primitives::{Bytes, SealedBlockWithSenders, ChainSpec, B256};
+use reth_transaction_pool::TransactionPool;
+use tracing::debug;
+use kona_derive::types::L2AttributesWithParent;
+
+/// Executes an [L2ExecutionPayload] against the EVM.
+pub async fn exec_payload(
+    db: &mut InMemoryDB,
+    attributes: L2AttributesWithParent,
+    pool: impl TransactionPool,
+    evm_config: impl ConfigureEvm,
+    chain_spec: Arc<ChainSpec>,
+) -> eyre::Result<B256> {
+    let builder = OptimismPayloadBuilder::new(chain_spec, evm_config);
+    let blockchain_db = db;
+    let payload_config = PayloadConfig::new(
+        /* Best Payload */,
+        Bytes::default(),
+        OptimismPayloadBuilderAttributes::try_new(
+            /* Best Payload .hash() */,
+            reth_rpc_types::engine::OptimismPayloadAttributes::try_new(
+                payload_attributes: attributes,
+                transactions: None,
+                no_tx_pool: None,
+                gas_limit: None,
+            ),
+        )?,
+        chain
+    );
+    let args = BuildArguments::new(
+        blockchain_db,
+        pool,
+        CachedReads::default(),
+        payload_config,
+        Cancelled::default(),
+        None,
+    );
+    let hash: B256 = match builder.try_build(args)? {
+        BuildOutcome::Better { payload, .. } => {
+            let block = payload.block();
+            debug!(target: "exex::kona", ?block, "Built new payload");
+
+            let senders = block.senders().expect("sender recovery failed");
+            let block_with_senders =
+                SealedBlockWithSenders::new(block.clone(), senders).unwrap();
+
+            block_with_senders.hash_slow()
+        },
+        _ => unreachable!("other outcomes are unreachable"),
+    };
+    Ok(hash)
+}
+
+// Execute a rollup block and return (block with recovered senders)[BlockWithSenders], (bundle
+// state)[BundleState] and list of (receipts)[Receipt].
+// pub async fn exec_block<Pool: TransactionPool>(
+//     db: &mut Database,
+//     pool: &Pool,
+//     tx: &TransactionSigned,
+//     header: &RollupContract::BlockHeader,
+//     block_data: Bytes,
+//     block_data_hash: B256,
+// ) -> eyre::Result<(BlockWithSenders, BundleState, Vec<Receipt>, Vec<ExecutionResult>)> {
+//     if header.rollupChainId != U256::from(CHAIN_ID) {
+//         eyre::bail!("Invalid rollup chain ID")
+//     }
+//
+//     // Construct header
+//     let header = construct_header(db, header)?;
+//
+//     // Decode transactions
+//     let transactions = decode_transactions(pool, tx, block_data, block_data_hash).await?;
+//
+//     // Configure EVM
+//     let evm_config = EthEvmConfig::default();
+//     let mut evm = configure_evm(&evm_config, db, &header);
+//
+//     // Execute transactions
+//     let (executed_txs, receipts, results) = execute_transactions(&mut evm, &header, transactions)?;
+//
+//     // Construct block and recover senders
+//     let block = Block { header, body: executed_txs, ..Default::default() }
+//         .with_recovered_senders()
+//         .ok_or_eyre("failed to recover senders")?;
+//
+//     let bundle = evm.db_mut().take_bundle();
+//
+//     Ok((block, bundle, receipts, results))
+// }

--- a/examples/exex/kona/src/main.rs
+++ b/examples/exex/kona/src/main.rs
@@ -1,0 +1,270 @@
+//! A minimal consensus client that derives L2 blocks using [kona-derive][1].
+//!
+//! [1]: https://gituhb.com/ethereum-optimism/kona
+
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use reth_transaction_pool::TransactionPool;
+use reth_provider::Chain;
+use reth_node_ethereum::EthereumNode;
+use reth_node_api::FullNodeComponents;
+use reth_revm::InMemoryDB;
+use reth_exex::{ExExContext, ExExEvent};
+use reth_tracing::tracing::{error, info};
+use reth_primitives::{Receipt, TxHash, B256, BlobTransactionSidecar, SealedBlockWithSenders};
+
+use kona_derive::types::Blob;
+use kona_derive::DerivationPipeline;
+use kona_derive::sources::EthereumDataSource;
+use kona_derive::stages::{L1Traversal, StatefulAttributesBuilder, L1Retrieval, FrameQueue, ChannelBank, ChannelReader, BatchQueue, AttributesQueue};
+use kona_primitives::{BlockInfo, L2BlockInfo, RollupConfig, SystemConfig};
+
+mod execution;
+
+mod blobs;
+use blobs::{ExExBlobProvider, InMemoryBlobProvider};
+
+mod reset;
+use reset::{TipState, ExExResetProvider};
+
+mod providers;
+use providers::{InMemoryChainProvider, InMemoryL2ChainProvider, ExExChainProvider, ExExL2ChainProvider};
+
+/* Custom ExEx Kona Derivation Types */
+type ExExDerivationPipeline = DerivationPipeline<ExExAttributesQueue, ExExResetProvider>;
+type ExExAttributesBuilder = StatefulAttributesBuilder<ExExChainProvider, ExExL2ChainProvider>;
+type ExExAttributesQueue = AttributesQueue<ExExBatchQueue, ExExAttributesBuilder>;
+type ExExBatchQueue = BatchQueue<ExExChannelReader, ExExL2ChainProvider>;
+type ExExChannelReader = ChannelReader<ExExChannelBank>;
+type ExExChannelBank = ChannelBank<ExExFrameQueue>;
+type ExExFrameQueue = FrameQueue<ExExL1Retrieval>;
+type ExExL1Retrieval = L1Retrieval<EthereumDataSource<ExExChainProvider, ExExBlobProvider>, ExExL1Traversal>;
+type ExExL1Traversal = L1Traversal<ExExChainProvider>;
+
+const DEFAULT_ATTRIBUTE_CHANNEL_SIZE: usize = 100;
+
+fn main() -> eyre::Result<()> {
+    reth::cli::Cli::parse_args().run(|builder, _| async move {
+        let handle = builder
+            .node(EthereumNode::default())
+            .install_exex("Kona", move |ctx| async {
+                Ok(Deriver::new(ctx).start())
+            })
+            .launch()
+            .await?;
+        handle.wait_for_node_exit().await
+    })
+}
+
+struct Deriver<Node: FullNodeComponents> {
+    ctx: ExExContext<Node>,
+    db: InMemoryDB,
+    chain_provider: Arc<Mutex<InMemoryChainProvider>>,
+    tip_state: Arc<Mutex<TipState>>,
+    l2_chain_provider: Arc<Mutex<InMemoryL2ChainProvider>>,
+    blob_provider: Arc<Mutex<InMemoryBlobProvider>>,
+}
+
+impl<Node: FullNodeComponents> Deriver<Node> {
+    fn new(ctx: ExExContext<Node>) -> Self {
+        Self {
+            ctx,
+            db: InMemoryDB::new(reth_revm::db::EmptyDB::default()),
+            chain_provider: Arc::new(Mutex::new(InMemoryChainProvider::new())),
+            tip_state: Arc::new(Mutex::new(TipState::new(BlockInfo::default(), SystemConfig::default()))),
+            l2_chain_provider: Arc::new(Mutex::new(InMemoryL2ChainProvider::new())),
+            blob_provider: Arc::new(Mutex::new(InMemoryBlobProvider::new())),
+        }
+    }
+
+    async fn start(mut self) -> eyre::Result<()> {
+        // Build the kona derivation pipeline
+        info!("Kona ExEx Deriver starting");
+
+        // Create a channel for the derivation pipeline to send back prepared
+        // L2AttributesWithParent.
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(DEFAULT_ATTRIBUTE_CHANNEL_SIZE);
+
+        // Create a channel for the deriver to reset the pipeline.
+        let (reset_sender, mut reset_receiver) = tokio::sync::mpsc::channel(1);
+
+        // Continuously attempt to step on the derivation pipeline.
+        let mut pipeline = self.new_pipeline();
+        tokio::spawn(async move {
+            loop {
+                // Reset the pipeline if needed
+                if (reset_receiver.recv().await).is_some() {
+                    pipeline.reset();
+                }
+                // Step the pipeline.
+                if let Err(e) = pipeline.step().await {
+                    error!("Error stepping derivation pipeline: {:?}", e);
+                }
+                // Try to pop an item off the prepared attributes.
+                if let Some(attributes) = pipeline.prepared.pop_front() {
+                    if let Err(e) = sender.send(attributes).await {
+                        error!("Error sending prepared attributes: {:?}", e);
+                    }
+                }
+            }
+        });
+
+        // TODO: get rollup config from superchain-registry + configured chain id
+        //       get genesis from rollup config
+        //       derive ChainSpec from genesis
+        let chain_spec = Arc::new(reth_primitives::ChainSpec::default());
+
+        // Process all new chain state notifications
+        loop {
+            tokio::select! {
+                Some(attributes) = receiver.recv() => {
+                    let block_hash = execution::exec_payload(
+                        &mut self.db,
+                        attributes,
+                        self.ctx.pool().clone(),
+                        self.ctx.evm_config().clone(),
+                        Arc::clone(&chain_spec),
+                    ).await?;
+                    info!("Executed block with hash: {}", block_hash);
+                    // TODO: fetch block from sequencer and verify block hash matches
+                }
+                Some(notification) = self.ctx.notifications.recv() => {
+                    if let Some(reverted_chain) = notification.reverted_chain() {
+                        reset_sender.send(()).await?;
+                        self.revert(&reverted_chain)?;
+                    }
+
+                    if let Some(committed_chain) = notification.committed_chain() {
+                        self.commit(&committed_chain).await?;
+                        self.ctx.events.send(ExExEvent::FinishedHeight(committed_chain.tip().number))?;
+                    }
+                }
+            }
+            if receiver.is_closed() { break; }
+        }
+
+        Ok(())
+    }
+
+    /// Creates a new derivation pipeline.
+    fn new_pipeline(&self) -> ExExDerivationPipeline {
+        // Place the cursor at the origin.
+        let cursor = L2BlockInfo::default();
+
+        // Create the base rollup config.
+        // TODO: get this from superchain-registry?
+        let rollup_config = Arc::new(RollupConfig::default());
+
+        // Create a stateful attributes provider.
+        let builder = StatefulAttributesBuilder::new(
+            Arc::clone(&rollup_config),
+            ExExL2ChainProvider::new(Arc::clone(&self.l2_chain_provider)),
+            ExExChainProvider::new(Arc::clone(&self.chain_provider)),
+        );
+
+        // Other Providers
+        let reset = ExExResetProvider::new(Arc::clone(&self.tip_state));
+        let l2_chain_provider = ExExL2ChainProvider::new(Arc::clone(&self.l2_chain_provider));
+
+        // Build the ethereum data source
+        let chain_provider = ExExChainProvider::new(Arc::clone(&self.chain_provider));
+        let blob_provider = ExExBlobProvider::new(Arc::clone(&self.blob_provider));
+        let dap_source = EthereumDataSource::new(chain_provider, blob_provider, &rollup_config);
+
+        // Instantiates and link all the stages.
+        let chain_provider = ExExChainProvider::new(Arc::clone(&self.chain_provider));
+        let l1_traversal = L1Traversal::new(chain_provider, Arc::clone(&rollup_config));
+        let l1_retrieval = L1Retrieval::new(l1_traversal, dap_source);
+        let frame_queue = FrameQueue::new(l1_retrieval);
+        let channel_bank = ChannelBank::new(Arc::clone(&rollup_config), frame_queue);
+        let channel_reader = ChannelReader::new(channel_bank, Arc::clone(&rollup_config));
+        let batch_queue = BatchQueue::new(rollup_config.clone(), channel_reader, l2_chain_provider);
+        let queue = AttributesQueue::new(*rollup_config, batch_queue, builder);
+
+        // Assemble and return the pipeline.
+        DerivationPipeline::new(queue, reset, cursor)
+    }
+
+    /// Process a new chain commit.
+    ///
+    /// This function decodes all transactions to the rollup contract into events, executes the
+    /// corresponding actions and inserts the results into the database.
+    async fn commit(&mut self, chain: &Chain) -> eyre::Result<()> {
+        // Insert blocks and receipts into the provider for the derivation pipeline.
+        let mut blocks = chain.blocks_iter().cloned().collect::<Vec<SealedBlockWithSenders>>();
+        blocks.sort_by(|a, b| b.number.cmp(&a.number));
+        let highest_block = blocks.first().cloned();
+        let block_with_receipts: Vec<(&SealedBlockWithSenders, &Vec<Option<Receipt>>)> = chain.blocks_and_receipts().collect();
+        let receipts: Vec<(B256, Vec<Option<alloy_consensus::Receipt>>)> = block_with_receipts.into_iter().map(|(block, receipts)| (block.hash(), receipts.clone().into_iter().map(to_consensus).collect())).collect();
+        {
+            let mut locked_chain_provider = self.chain_provider.lock().map_err(|_| eyre::eyre!("Failed to lock chain provider"))?;
+            locked_chain_provider.insert_blocks(blocks);
+            locked_chain_provider.insert_receipts(receipts);
+        }
+
+        // Fetch all blobs for all transactions.
+        let blocks = chain.blocks_iter().collect::<Vec<&SealedBlockWithSenders>>();
+        for block in blocks {
+            let tx_hashes = block.transactions().map(|tx| tx.hash).collect::<Vec<TxHash>>();
+            let blobs = self.ctx.pool().get_all_blobs(tx_hashes)?;
+            let blobs = blobs.into_iter().map(|b| b.1).collect::<Vec<BlobTransactionSidecar>>();
+            let mut locked_blob_provider = self.blob_provider.lock().map_err(|_| eyre::eyre!("Failed to lock blob provider"))?;
+            // Flatten blob sidecar blobs.
+            let blobs = blobs.into_iter().flat_map(|b| b.blobs).collect::<Vec<Blob>>();
+            locked_blob_provider.insert_blobs(block.hash(), blobs);
+        }
+
+        // Update the reset provider with the latest origin.
+        self.update_tip_state(highest_block)?;
+
+        Ok(())
+    }
+
+    /// Process a chain revert.
+    fn revert(&mut self, chain: &Chain) -> eyre::Result<()> {
+        // Get the highest block after the chain revert.
+        let mut blocks = chain.blocks_iter().collect::<Vec<&SealedBlockWithSenders>>();
+        blocks.sort_by(|a, b| b.number.cmp(&a.number));
+        let highest_block = blocks.first().cloned().cloned();
+        let highest_block_number = highest_block.as_ref().map(|b| b.number).unwrap_or(0);
+
+        // Prune the Chain Provider.
+        self.chain_provider.lock().map_err(|_| eyre::eyre!("Failed to lock chain provider"))?.prune(
+            highest_block_number
+        );
+
+        // Prune the L2 Chain Provider.
+        self.l2_chain_provider.lock().map_err(|_| eyre::eyre!("Failed to lock L2 chain provider"))?.prune(
+            highest_block_number
+        );
+
+        // Update the tip state.
+        self.update_tip_state(highest_block)?;
+
+        Ok(())
+    }
+
+    fn update_tip_state(&mut self, highest_block: Option<SealedBlockWithSenders>) -> eyre::Result<()> {
+        if let Some(origin) = highest_block.map(|b| BlockInfo {
+            hash: b.hash(),
+            number: b.number,
+            parent_hash: b.parent_hash,
+            timestamp: b.timestamp
+        }) {
+            let mut locked = self.tip_state.lock().map_err(|_| eyre::eyre!("Failed to lock tip state"))?;
+            locked.set_origin(origin);
+        }
+        Ok(())
+    }
+}
+
+fn to_consensus(receipt: Option<Receipt>) -> Option<alloy_consensus::Receipt> {
+    let receipt = receipt?;
+    Some(alloy_consensus::Receipt {
+        status: receipt.success,
+        cumulative_gas_used: receipt.cumulative_gas_used,
+        logs: receipt.logs,
+    })
+}
+

--- a/examples/exex/kona/src/providers.rs
+++ b/examples/exex/kona/src/providers.rs
@@ -1,0 +1,195 @@
+//! Provider adapters for kona.
+
+use anyhow::Result;
+use std::boxed::Box;
+use std::sync::{Arc, Mutex};
+use async_trait::async_trait;
+use std::collections::HashMap;
+use kona_derive::types::BlockInfo;
+use kona_derive::traits::ChainProvider;
+use kona_derive::traits::L2ChainProvider;
+use reth::primitives::SealedBlockWithSenders;
+use reth_primitives::alloy_primitives::B256;
+use alloy_consensus::{Receipt, TxEnvelope, Header};
+use kona_primitives::{SystemConfig, L2BlockInfo, RollupConfig, L2ExecutionPayloadEnvelope};
+
+/// Stores and serves locally-derived L2 Chain data in memory.
+#[derive(Debug, Clone)]
+pub struct InMemoryL2ChainProvider {
+    /// L2 Safe Blocks.
+    blocks_by_number: HashMap<u64, L2BlockInfo>,
+    /// Payload Attributes by number.
+    payloads_by_number: HashMap<u64, L2ExecutionPayloadEnvelope>,
+    /// Maps block numbers to a [SystemConfig] at that point in time.
+    configs_by_number: HashMap<u64, SystemConfig>,
+}
+
+impl InMemoryL2ChainProvider {
+    /// Instantiates a new [InMemoryL2ChainProvider].
+    pub fn new() -> Self {
+        Self {
+            blocks_by_number: HashMap::new(),
+            payloads_by_number: HashMap::new(),
+            configs_by_number: HashMap::new(),
+        }
+    }
+
+    /// Prunes all [L2BlockInfo] and [L2ExecutionPayloadEnvelope]s that
+    /// have L1 Origins greater than the given number.
+    /// Also prunes [SystemConfig]s that were set after the given number.
+    pub fn prune(&mut self, number: u64) {
+        // Get all l2 block numbers that have an l1 origin greater than the given number.
+        let block_numbers_to_prune: Vec<u64> = self.blocks_by_number.iter()
+            .filter(|(_, v)| v.l1_origin.number > number)
+            .map(|(k, _)| *k)
+            .collect();
+        // Prune all l2 blocks with numbers in the block_numbers_to_prune list.
+        for number in block_numbers_to_prune {
+            self.blocks_by_number.remove(&number);
+            self.payloads_by_number.remove(&number);
+            self.configs_by_number.remove(&number);
+        }
+    }
+}
+
+/// [L2ChainProvider] for the execution extension.
+#[derive(Debug, Clone)]
+pub struct ExExL2ChainProvider(Arc<Mutex<InMemoryL2ChainProvider>>);
+
+impl ExExL2ChainProvider {
+    /// Creates a new [ExExL2ChainProvider].
+    pub fn new(inner: Arc<Mutex<InMemoryL2ChainProvider>>) -> Self {
+        Self(inner)
+    }
+}
+
+#[async_trait]
+impl L2ChainProvider for ExExL2ChainProvider {
+    /// Returns the L2 block info given a block number.
+    /// Errors if the block does not exist.
+    async fn l2_block_info_by_number(&mut self, number: u64) -> Result<L2BlockInfo> {
+        let err = |number: u64| anyhow::anyhow!("Failed to find L2 block info for block number {}", number);
+        let locked = self.0.lock().map_err(|_| err(number))?;
+        locked.blocks_by_number.get(&number).ok_or_else(|| err(number)).cloned()
+    }
+
+    /// Returns an execution payload for a given number.
+    /// Errors if the execution payload does not exist.
+    async fn payload_by_number(&mut self, number: u64) -> Result<L2ExecutionPayloadEnvelope> {
+        let err = |number: u64| anyhow::anyhow!("Failed to find payload for block number {}", number);
+        let locked = self.0.lock().map_err(|_| err(number))?;
+        locked.payloads_by_number.get(&number).ok_or_else(|| err(number)).cloned()
+    }
+
+    /// Returns the [SystemConfig] by L2 number.
+    async fn system_config_by_number(&mut self,number: u64, _: Arc<RollupConfig>) -> Result<SystemConfig> {
+        let err = |number: u64| anyhow::anyhow!("Failed to find system config for block number {}", number);
+        let locked = self.0.lock().map_err(|_| err(number))?;
+        locked.configs_by_number.get(&number).ok_or_else(|| err(number)).cloned()
+    }
+}
+
+/// InMemoryChainProvider
+///
+/// Implements the [ChainProvider] trait with in memory maps.
+#[derive(Debug, Clone, PartialEq)]
+pub struct InMemoryChainProvider {
+    /// Maps block numbers to their respective [SealedBlockWithSenders].
+    pub blocks: HashMap<u64, SealedBlockWithSenders>,
+    /// Maps block hashes to their respective [Vec<Receipt>].
+    pub receipts: HashMap<B256, Vec<Option<Receipt>>>,
+}
+
+impl InMemoryChainProvider {
+    /// Creates a new [InMemoryChainProvider] with empty maps.
+    pub fn new() -> Self {
+        Self {
+            blocks: HashMap::new(),
+            receipts: HashMap::new(),
+        }
+    }
+
+    /// Removes all blocks and receipts from the provider after the given block number.
+    pub fn prune(&mut self, number: u64) {
+        self.blocks.retain(|k, b| {
+            if *k <= number { return true; }
+            self.receipts.remove(&b.hash());
+            false
+        });
+    }
+
+    /// Inserts a list of blocks into the provider.
+    pub fn insert_blocks(&mut self, blocks: Vec<SealedBlockWithSenders>) {
+        for block in blocks {
+            self.blocks.insert(block.number, block);
+        }
+    }
+
+    /// Inserts a list of receipts into the provider.
+    pub fn insert_receipts(&mut self, receipts: Vec<(B256, Vec<Option<Receipt>>)>) {
+        for (hash, receipt) in receipts {
+            if self.receipts.contains_key(&hash) {
+                self.receipts.get_mut(&hash).expect(
+                    "Receipts not found"
+                ).extend(receipt.clone());
+                continue;
+            }
+            self.receipts.insert(hash, receipt.clone());
+        }
+    }
+}
+
+fn simplify_block(block: &SealedBlockWithSenders) -> BlockInfo {
+    BlockInfo {
+        hash: block.hash(),
+        number: block.number,
+        parent_hash: block.parent_hash,
+        timestamp: block.timestamp,
+    }
+}
+
+/// [ChainProvider] for the execution extension.
+#[derive(Debug, Clone)]
+pub struct ExExChainProvider(Arc<Mutex<InMemoryChainProvider>>);
+
+impl ExExChainProvider {
+    /// Creates a new [ExExL2ChainProvider].
+    pub fn new(inner: Arc<Mutex<InMemoryChainProvider>>) -> Self {
+        Self(inner)
+    }
+}
+
+#[async_trait]
+impl ChainProvider for ExExChainProvider {
+    async fn block_info_by_number(&mut self, number: u64) -> Result<BlockInfo> {
+        let err = |number: u64| anyhow::anyhow!("Failed to find block info for block number {}", number);
+        let locked = self.0.lock().map_err(|_| err(number))?;
+        locked.blocks.get(&number).map(simplify_block).ok_or_else(|| err(number))
+    }
+
+    async fn receipts_by_hash(&mut self, hash: B256) -> Result<Vec<Receipt>> {
+        let err = |hash: B256| anyhow::anyhow!("Failed to find receipts for block {}", hash);
+        let locked = self.0.lock().map_err(|_| err(hash))?;
+        let receipts = locked.receipts.get(&hash).ok_or_else(|| err(hash))?;
+        Ok(receipts.iter().flatten().cloned().collect::<Vec<Receipt>>())
+    }
+
+    /// `header_by_hash` is not used by the [L1Traversal][1] stage of the
+    /// derivation pipeline.
+    ///
+    /// [1]: kona_derive::stages::L1Traversal
+    async fn header_by_hash(&mut self, _: B256) -> Result<Header> {
+        unimplemented!()
+    }
+
+    /// `block_info_and_transactions_by_hash` is unused for the [L1Traversal][1]
+    /// stage of the derivation pipeline.
+    ///
+    /// [1]: kona_derive::stages::L1Traversal
+    async fn block_info_and_transactions_by_hash(
+        &mut self,
+        _: B256,
+    ) -> Result<(BlockInfo, Vec<TxEnvelope>)> {
+        unimplemented!()
+    }
+}

--- a/examples/exex/kona/src/reset.rs
+++ b/examples/exex/kona/src/reset.rs
@@ -1,0 +1,70 @@
+//! Reset Provider for Kona's Derivation Pipeline
+
+use std::sync::Mutex;
+use std::sync::Arc;
+use async_trait::async_trait;
+use kona_derive::builder::ResetProvider;
+use kona_primitives::{BlockInfo, SystemConfig};
+
+/// TipState stores the tip information for the derivation pipeline.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TipState {
+    /// The origin [BlockInfo].
+    /// This is used downstream by [kona_derive] to reset the origin
+    /// of the [kona_derive::stages::BatchQueue] and l1 block list.
+    origin: BlockInfo,
+    /// The [SystemConfig] is used in two places.
+    ///
+    system_config: SystemConfig,
+}
+
+impl TipState {
+    /// Creates a new [TipState].
+    pub fn new(origin: BlockInfo, system_config: SystemConfig) -> Self {
+        Self { origin, system_config }
+    }
+
+    /// Retrieves a copy of the [BlockInfo].
+    pub fn origin(&self) -> BlockInfo {
+        self.origin
+    }
+
+    /// Retrieves a copy of the [SystemConfig].
+    pub fn system_config(&self) -> SystemConfig {
+        self.system_config
+    }
+
+    /// Sets the block info.
+    pub fn set_origin(&mut self, new_bi: BlockInfo) {
+        self.origin = new_bi;
+    }
+
+    // /// Sets the system config.
+    // pub fn set_system_config(&mut self, new_config: SystemConfig) {
+    //     self.system_config = new_config;
+    // }
+}
+
+/// The ExExResetProvider implements the [ResetProvider] trait.
+#[derive(Debug, Clone)]
+pub struct ExExResetProvider(Arc<Mutex<TipState>>);
+
+impl ExExResetProvider {
+    /// Creates a new [ExExResetProvider].
+    pub fn new(ts: Arc<Mutex<TipState>>) -> Self {
+        Self(ts)
+    }
+}
+
+#[async_trait]
+impl ResetProvider for ExExResetProvider {
+    /// Returns the current [BlockInfo] for the pipeline to reset.
+    async fn block_info(&self) -> BlockInfo {
+        self.0.lock().map(|ts| ts.origin()).unwrap_or_default()
+    }
+
+    /// Returns the current [SystemConfig] for the pipeline to reset.
+    async fn system_config(&self) -> SystemConfig {
+        self.0.lock().map(|ts| ts.system_config()).unwrap_or_default()
+    }
+}


### PR DESCRIPTION
**Description**

Introduces a [kona](1) backed execution extension example.

The newly added ExEx pulls in the [`kona-derive`](2) crate from [kona](1) and runs the derivation pipeline over newly committed L1 blocks. It then takes the generated payload attributes from the derivation pipeline and constructs a block using the Optimism Payload Builder. With this block, the execution extension can fetch the reference block hash from the trusted sequencer to determine if the derived block is valid, effectively "following" the safe head.

**Terminology**

Unsafe Head: Accepted by sequencer
Safe Head: Batch-submitted "safely" to L1
Finalized Head: Batch-submitted data on L1 is finalized

[1]: https://github.com/ethereum-optimism/kona
[2]: https://github.com/ethereum-optimism/kona/tree/main/crates/derive