### PR TITLE
fix(rpc): add invalid block range error

### DIFF
--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -711,10 +711,10 @@ impl From<FilterError> for jsonrpsee::types::error::ErrorObject<'static> {
                 rpc_error_with_code(jsonrpsee::types::error::INTERNAL_ERROR_CODE, err.to_string())
             }
             FilterError::EthAPIError(err) => err.into(),
-            err @ FilterError::QueryExceedsMaxBlocks(_) => {
+            err @ FilterError::InvalidBlockRangeParams => {
                 rpc_error_with_code(jsonrpsee::types::error::INVALID_PARAMS_CODE, err.to_string())
             }
-            err @ FilterError::InvalidBlockRangeParams => {
+            err @ FilterError::QueryExceedsMaxBlocks(_) => {
                 rpc_error_with_code(jsonrpsee::types::error::INVALID_PARAMS_CODE, err.to_string())
             }
             err @ FilterError::QueryExceedsMaxResults(_) => {


### PR DESCRIPTION
When I request the `getLogs` with below query:

```json
{
  "jsonrpc": "2.0",
  "method": "eth_getLogs",
  "id": 74,
  "params": [
    {
      "toBlock": "0x100",
      "fromBlock": "0x101",
      "topics": [        
      ]
    }
  ]
}
```

Reth returns with:

```json
{
  "jsonrpc": "2.0",
  "error": {
    "code": -32602,
    "message": "query exceeds max block range 5000"
  },
  "id": 74
}
```

The error msg is misleading, changed to geth's error msg. 