### PR TITLE
docs: mention beacon node API endpoint for ecotone

### DIFF
--- a/book/run/optimism.md
+++ b/book/run/optimism.md
@@ -69,7 +69,7 @@ The `optimism` feature flag in `op-reth` adds several new CLI flags to the `reth
 1. `--rollup.disable-tx-pool-gossip` - Disables gossiping of transactions in the mempool to peers. This can be omitted for personal nodes, though providers should always opt to enable this flag.
 1. `--rollup.enable-genesis-walkback` - Disables setting the forkchoice status to tip on startup, making the `op-node` walk back to genesis and verify the integrity of the chain before starting to sync. This can be omitted unless a corruption of local chainstate is suspected.
 
-First, ensure that your L1 archival node is running and synced to tip. Then, start `op-reth` with the `--rollup.sequencer-http` flag set to the `Base Mainnet` sequencer endpoint:
+First, ensure that your L1 archival node is running and synced to tip. Also make sure that the beacon node / consensus layer client is running and has http APIs enabled. Then, start `op-reth` with the `--rollup.sequencer-http` flag set to the `Base Mainnet` sequencer endpoint:
 ```sh
 op-reth node \
     --chain base \
@@ -89,7 +89,8 @@ op-node \
     --l2.jwt-secret=/path/to/jwt.hex \
     --rpc.addr=0.0.0.0 \
     --rpc.port=7000 \
-    --l1.trustrpc
+    --l1.trustrpc \
+    --l1.beacon=<your-beacon-node-http-endpoint>
 ```
 
 If you opted to build the `op-node` with the `rethdb` build tag, this feature can be enabled by appending one extra flag to the `op-node` invocation:


### PR DESCRIPTION
Since ecotone, running op-node now requires running a beacon node / consensus client. Instructions mentioning running a consensus client are added, along with instructions on how to hook up op-node with the CL.

Ecotone changes:
https://docs.optimism.io/builders/notices/ecotone-changes

Example in Op docs:
https://docs.optimism.io/builders/node-operators/configuration/base-config