### PR TITLE
chore: downgrade error message

### DIFF
--- a/crates/tokio-util/src/event_sender.rs
+++ b/crates/tokio-util/src/event_sender.rs
@@ -1,6 +1,6 @@
 use crate::EventStream;
 use tokio::sync::broadcast::{self, Sender};
-use tracing::error;
+use tracing::trace;
 
 const DEFAULT_SIZE_BROADCAST_CHANNEL: usize = 2000;
 
@@ -30,7 +30,7 @@ impl<T: Clone + Send + Sync + 'static> EventSender<T> {
     /// Broadcasts an event to all listeners.
     pub fn notify(&self, event: T) {
         if self.sender.send(event).is_err() {
-            error!("channel closed");
+            trace!("no receivers for broadcast events");
         }
     }
 


### PR DESCRIPTION
this logged an error if there are no receivers.

downgrades to trace instead