### PR TITLE
chore: remove `chain` field from `DbTool`

### DIFF
--- a/bin/reth/src/commands/db/mod.rs
+++ b/bin/reth/src/commands/db/mod.rs
@@ -96,7 +96,7 @@ macro_rules! db_ro_exec {
         let provider_factory =
             ProviderFactory::new(db, $chain.clone(), StaticFileProvider::read_only($sfp)?);
 
-        let $tool = DbTool::new(provider_factory, $chain.clone())?;
+        let $tool = DbTool::new(provider_factory)?;
         $command;
     };
 }
@@ -160,7 +160,7 @@ impl Command {
                     StaticFileProvider::read_write(&static_files_path)?,
                 );
 
-                let tool = DbTool::new(provider_factory, self.chain.clone())?;
+                let tool = DbTool::new(provider_factory)?;
                 tool.drop(db_path, static_files_path)?;
             }
             Subcommands::Clear(command) => {

--- a/bin/reth/src/commands/stage/drop.rs
+++ b/bin/reth/src/commands/stage/drop.rs
@@ -69,7 +69,7 @@ impl Command {
         );
         let static_file_provider = provider_factory.static_file_provider();
 
-        let tool = DbTool::new(provider_factory, self.chain.clone())?;
+        let tool = DbTool::new(provider_factory)?;
 
         let static_file_segment = match self.stage {
             StageEnum::Headers => Some(StaticFileSegment::Headers),

--- a/bin/reth/src/commands/stage/dump/execution.rs
+++ b/bin/reth/src/commands/stage/dump/execution.rs
@@ -27,7 +27,7 @@ pub(crate) async fn dump_execution_stage<DB: Database>(
         dry_run(
             ProviderFactory::new(
                 output_db,
-                db_tool.chain.clone(),
+                db_tool.chain(),
                 StaticFileProvider::read_write(output_datadir.static_files())?,
             ),
             to,
@@ -128,7 +128,7 @@ async fn unwind_and_copy<DB: Database>(
 ) -> eyre::Result<()> {
     let provider = db_tool.provider_factory.provider_rw()?;
 
-    let executor = block_executor!(db_tool.chain.clone());
+    let executor = block_executor!(db_tool.chain());
     let mut exec_stage = ExecutionStage::new_with_executor(executor);
 
     exec_stage.unwind(

--- a/bin/reth/src/commands/stage/dump/hashing_account.rs
+++ b/bin/reth/src/commands/stage/dump/hashing_account.rs
@@ -32,7 +32,7 @@ pub(crate) async fn dump_hashing_account_stage<DB: Database>(
         dry_run(
             ProviderFactory::new(
                 output_db,
-                db_tool.chain.clone(),
+                db_tool.chain(),
                 StaticFileProvider::read_write(output_datadir.static_files())?,
             ),
             to,

--- a/bin/reth/src/commands/stage/dump/hashing_storage.rs
+++ b/bin/reth/src/commands/stage/dump/hashing_storage.rs
@@ -23,7 +23,7 @@ pub(crate) async fn dump_hashing_storage_stage<DB: Database>(
         dry_run(
             ProviderFactory::new(
                 output_db,
-                db_tool.chain.clone(),
+                db_tool.chain(),
                 StaticFileProvider::read_write(output_datadir.static_files())?,
             ),
             to,

--- a/bin/reth/src/commands/stage/dump/merkle.rs
+++ b/bin/reth/src/commands/stage/dump/merkle.rs
@@ -47,7 +47,7 @@ pub(crate) async fn dump_merkle_stage<DB: Database>(
         dry_run(
             ProviderFactory::new(
                 output_db,
-                db_tool.chain.clone(),
+                db_tool.chain(),
                 StaticFileProvider::read_write(output_datadir.static_files())?,
             ),
             to,
@@ -84,7 +84,7 @@ async fn unwind_and_copy<DB: Database>(
 
     MerkleStage::default_unwind().unwind(&provider, unwind)?;
 
-    let executor = block_executor!(db_tool.chain.clone());
+    let executor = block_executor!(db_tool.chain());
 
     // Bring Plainstate to TO (hashing stage execution requires it)
     let mut exec_stage = ExecutionStage::new(

--- a/bin/reth/src/commands/stage/dump/mod.rs
+++ b/bin/reth/src/commands/stage/dump/mod.rs
@@ -113,7 +113,7 @@ impl Command {
 
         info!(target: "reth::cli", "Database opened");
 
-        let tool = DbTool::new(provider_factory, self.chain.clone())?;
+        let tool = DbTool::new(provider_factory)?;
 
         match &self.command {
             Stages::Execution(StageCommand { output_datadir, from, to, dry_run, .. }) => {

--- a/bin/reth/src/utils.rs
+++ b/bin/reth/src/utils.rs
@@ -11,7 +11,7 @@ use reth_db::{
 };
 use reth_fs_util as fs;
 use reth_primitives::ChainSpec;
-use reth_provider::ProviderFactory;
+use reth_provider::{ChainSpecProvider, ProviderFactory};
 use std::{path::Path, rc::Rc, sync::Arc};
 use tracing::info;
 
@@ -29,17 +29,20 @@ pub use reth_node_core::utils::*;
 pub struct DbTool<DB: Database> {
     /// The provider factory that the db tool will use.
     pub provider_factory: ProviderFactory<DB>,
-    /// The [`ChainSpec`] that the db tool will use.
-    pub chain: Arc<ChainSpec>,
 }
 
 impl<DB: Database> DbTool<DB> {
     /// Takes a DB where the tables have already been created.
-    pub fn new(provider_factory: ProviderFactory<DB>, chain: Arc<ChainSpec>) -> eyre::Result<Self> {
+    pub fn new(provider_factory: ProviderFactory<DB>) -> eyre::Result<Self> {
         // Disable timeout because we are entering a TUI which might read for a long time. We
         // disable on the [`DbTool`] level since it's only used in the CLI.
         provider_factory.provider()?.disable_long_read_transaction_safety();
-        Ok(Self { provider_factory, chain })
+        Ok(Self { provider_factory })
+    }
+
+    /// Get an [Arc] to the [ChainSpec].
+    pub fn chain(&self) -> Arc<ChainSpec> {
+        self.provider_factory.chain_spec().clone()
     }
 
     /// Grabs the contents of the table within a certain index range and places the

--- a/bin/reth/src/utils.rs
+++ b/bin/reth/src/utils.rs
@@ -42,7 +42,7 @@ impl<DB: Database> DbTool<DB> {
 
     /// Get an [Arc] to the [ChainSpec].
     pub fn chain(&self) -> Arc<ChainSpec> {
-        self.provider_factory.chain_spec().clone()
+        self.provider_factory.chain_spec()
     }
 
     /// Grabs the contents of the table within a certain index range and places the

--- a/bin/reth/src/utils.rs
+++ b/bin/reth/src/utils.rs
@@ -40,7 +40,7 @@ impl<DB: Database> DbTool<DB> {
         Ok(Self { provider_factory })
     }
 
-    /// Get an [Arc] to the [ChainSpec].
+    /// Get an [`Arc`] to the [`ChainSpec`].
     pub fn chain(&self) -> Arc<ChainSpec> {
         self.provider_factory.chain_spec()
     }


### PR DESCRIPTION
Removes the `chain` field from `DbTool` and retrieve it from `ProviderFactory`.