### PR TITLE
chore: log endpoint as path

### DIFF
--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -291,8 +291,8 @@ where
 
     let server_config = config.rpc.rpc_server_config();
     let launch_rpc = modules.clone().start_server(server_config).map_ok(|handle| {
-        if let Some(url) = handle.ipc_endpoint() {
-            info!(target: "reth::cli", url=%url, "RPC IPC server started");
+        if let Some(path) = handle.ipc_endpoint() {
+            info!(target: "reth::cli", %path, "RPC IPC server started");
         }
         if let Some(addr) = handle.http_local_addr() {
             info!(target: "reth::cli", url=%addr, "RPC HTTP server started");


### PR DESCRIPTION
while url is technically correct as well, for IPC it's always a file path, so we should name it path

but maybe, for consistency, we should keep it as URL?