### PR TITLE
fix: allow the same PID to acquire `StorageLock`

### DIFF
--- a/crates/storage/db/src/lockfile.rs
+++ b/crates/storage/db/src/lockfile.rs
@@ -108,4 +108,16 @@ mod tests {
         reth_fs_util::write(&lock_file, "1").unwrap();
         assert_eq!(Err(StorageLockError::Taken(1)), StorageLock::try_acquire(temp_dir.path()));
     }
+
+    #[test]
+    fn test_drop_lock() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let lock_file = temp_dir.path().join(LOCKFILE_NAME);
+
+        let lock = StorageLock::try_acquire(temp_dir.path()).unwrap();
+
+        drop(lock);
+
+        assert!(!lock_file.exists());
+    }
 }

--- a/crates/storage/errors/src/lockfile.rs
+++ b/crates/storage/errors/src/lockfile.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 /// Storage lock error.
 pub enum StorageLockError {
     /// Write lock taken
-    #[error("storage directory is currently in use as read-write by another process: {0}")]
+    #[error("storage directory is currently in use as read-write by another process: PID {0}")]
     Taken(usize),
     /// Indicates other unspecified errors.
     #[error("{0}")]


### PR DESCRIPTION
closes #8575 

The goal of `StorageLock` is to make a best effort to ensure write permission exclusivity **between different processes**. If a process with the same PID tries to acquire the lock, let it.

This is especially relevant for container setups, where the node process will always have PID 1. On a non graceful shutdown it won't remove the lock file, leading to failure to restart.