### PR TITLE
fix `EthTransactionValidationBuilder::set_eip4844` and `no_eip4844`

### DIFF
--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -528,12 +528,12 @@ impl EthTransactionValidatorBuilder {
 
     /// Disables the support for EIP-4844 transactions.
     pub const fn no_eip4844(self) -> Self {
-        self.set_eip1559(false)
+        self.set_eip4844(false)
     }
 
     /// Set the support for EIP-4844 transactions.
-    pub const fn set_eip4844(mut self, eip1559: bool) -> Self {
-        self.eip1559 = eip1559;
+    pub const fn set_eip4844(mut self, eip4844: bool) -> Self {
+        self.eip4844 = eip4844;
         self
     }
 


### PR DESCRIPTION
I didn't create an issue for this since it's a simple fix, sorry about that.

`set_eip4844` and `no_eip4844` functions of `EthTransactionValidationBuilder` were modifying  `self.eip1559` variables instead of `self.eip4844`. They now modify `self.eip4844`.  