### PR TITLE
fix: check for empty tx root in BlockTransactions::Uncle match

### DIFF
--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -95,7 +95,7 @@ pprof = { workspace = true, features = [
 secp256k1.workspace = true
 
 [features]
-default = ["c-kzg", "zstd-codec"]
+default = ["c-kzg", "zstd-codec", "alloy-compat"]
 asm-keccak = ["alloy-primitives/asm-keccak"]
 arbitrary = [
     "revm-primitives/arbitrary",

--- a/crates/primitives/src/alloy_compat.rs
+++ b/crates/primitives/src/alloy_compat.rs
@@ -1,8 +1,9 @@
 //! Common conversions from alloy types.
 
 use crate::{
-    transaction::extract_chain_id, Block, Header, Signature, Transaction, TransactionSigned,
-    TransactionSignedEcRecovered, TxEip1559, TxEip2930, TxEip4844, TxLegacy, TxType,
+    constants::EMPTY_TRANSACTIONS, transaction::extract_chain_id, Block, Header, Signature,
+    Transaction, TransactionSigned, TransactionSignedEcRecovered, TxEip1559, TxEip2930, TxEip4844,
+    TxLegacy, TxType,
 };
 use alloy_primitives::TxKind;
 use alloy_rlp::Error as RlpError;
@@ -36,7 +37,13 @@ impl TryFrom<alloy_rpc_types::Block> for Block {
                     .collect(),
                 alloy_rpc_types::BlockTransactions::Hashes(_) |
                 alloy_rpc_types::BlockTransactions::Uncle => {
-                    return Err(ConversionError::MissingFullTransactions)
+                    // alloy deserializes empty blocks into `BlockTransactions::Hashes`, if the tx
+                    // root is the empty root then we can just return an empty vec.
+                    if block.header.transactions_root == EMPTY_TRANSACTIONS {
+                        Ok(vec![])
+                    } else {
+                        Err(ConversionError::MissingFullTransactions)
+                    }
                 }
             };
             transactions?
@@ -123,7 +130,17 @@ impl TryFrom<alloy_rpc_types::Transaction> for Transaction {
                     ))
                 }
                 Ok(Self::Legacy(TxLegacy {
-                    chain_id: tx.chain_id,
+                    chain_id: tx.chain_id.or_else(|| {
+                        tx.signature.and_then(|signature| {
+                            // TODO: make this error conversion better. This is needed because
+                            // sometimes rpc providers return legacy transactions without a chain id
+                            // explicitly in the response, however those transactions may also have
+                            // a chain id in the signature from eip155
+                            extract_chain_id(signature.v.to())
+                                .map_err(|err| ConversionError::Eip2718Error(err.into()))?
+                                .1
+                        })
+                    }),
                     nonce: tx.nonce,
                     gas_price: tx.gas_price.ok_or(ConversionError::MissingGasPrice)?,
                     gas_limit: tx


### PR DESCRIPTION
This fixes two things in alloy conversions:
* Preventing errors when empty blocks are returned by getBlockByNumber RPC calls.
* Extracting the chain id from the signature in nonstandard rpc responses that do not directly populate the chain id.