### PR TITLE
feat(node-builder): expose block executor

### DIFF
--- a/crates/node/builder/src/launch/mod.rs
+++ b/crates/node/builder/src/launch/mod.rs
@@ -449,6 +449,7 @@ where
 
         let full_node = FullNode {
             evm_config: node_adapter.components.evm_config().clone(),
+            block_executor: node_adapter.components.block_executor().clone(),
             pool: node_adapter.components.pool().clone(),
             network: node_adapter.components.network().clone(),
             provider: node_adapter.provider.clone(),

--- a/crates/node/builder/src/node.rs
+++ b/crates/node/builder/src/node.rs
@@ -37,6 +37,8 @@ pub trait Node<N: FullNodeTypes>: NodeTypes + Clone {
 pub struct FullNode<Node: FullNodeComponents> {
     /// The evm configuration.
     pub evm_config: Node::Evm,
+    /// The executor of the node.
+    pub block_executor: Node::Executor,
     /// The node's transaction pool.
     pub pool: Node::Pool,
     /// Handle to the node's network.
@@ -100,6 +102,7 @@ impl<Node: FullNodeComponents> Clone for FullNode<Node> {
     fn clone(&self) -> Self {
         Self {
             evm_config: self.evm_config.clone(),
+            block_executor: self.block_executor.clone(),
             pool: self.pool.clone(),
             network: self.network.clone(),
             provider: self.provider.clone(),


### PR DESCRIPTION
Makes block executor from the components accessible via `FullNode`