### PR TITLE
fix(op): fix import blocks benchmark

### DIFF
--- a/book/run/sync-op-mainnet.md
+++ b/book/run/sync-op-mainnet.md
@@ -22,7 +22,7 @@ Output from running the command to export state, can also be downloaded from <ht
 
 Imports a `.rlp` file of blocks.
 
-Import of >100 million OVM blocks, from genesis to Bedrock, completes in 6 hours.
+Import of >100 million OVM blocks, from genesis to Bedrock, completes in 45 minutes.
 
 ```bash
 ./op-reth import-op <exported-blocks>


### PR DESCRIPTION
Fixes block import benchmark to reflect maxperf benchmark

<img width="1155" alt="Screenshot 2024-06-05 at 21 09 23" src="https://github.com/paradigmxyz/reth/assets/58548332/8b9faf53-a335-4af3-9153-ae0e8c68c589">