### PR TITLE
Fix code spell lint in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -130,7 +130,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - uses: actions/checkout@v4
       - uses: codespell-project/actions-codespell@v2
+        with:
+          skip: "*.json"
 
   grafana:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -356,7 +356,7 @@ lint-other-targets:
 	-- -D warnings
 
 lint-codespell: ensure-codespell
-	codespell
+	codespell --skip "*.json"
 
 ensure-codespell:
 	@if ! command -v codespell &> /dev/null; then \

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1190,7 +1190,7 @@ where
             "Canonicalization finished"
         );
 
-        // clear trie updates for other childs
+        // clear trie updates for other children
         self.block_indices()
             .fork_to_child()
             .get(&old_tip.hash)

--- a/crates/blockchain-tree/src/metrics.rs
+++ b/crates/blockchain-tree/src/metrics.rs
@@ -88,7 +88,7 @@ pub(crate) enum MakeCanonicalAction {
     RevertCanonicalChainFromDatabase,
     /// Inserting an old canonical chain.
     InsertOldCanonicalChain,
-    /// Clearing trie updates of other childs chains after fork choice update.
+    /// Clearing trie updates of other children chains after fork choice update.
     ClearTrieUpdatesForOtherChilds,
 }
 
@@ -116,7 +116,7 @@ struct MakeCanonicalMetrics {
     revert_canonical_chain_from_database: Histogram,
     /// Duration of the insert old canonical chain action.
     insert_old_canonical_chain: Histogram,
-    /// Duration of the clear trie updates of other childs chains after fork choice update action.
+    /// Duration of the clear trie updates of other children chains after fork choice update action.
     clear_trie_updates_for_other_childs: Histogram,
 }
 

--- a/crates/blockchain-tree/src/metrics.rs
+++ b/crates/blockchain-tree/src/metrics.rs
@@ -116,7 +116,8 @@ struct MakeCanonicalMetrics {
     revert_canonical_chain_from_database: Histogram,
     /// Duration of the insert old canonical chain action.
     insert_old_canonical_chain: Histogram,
-    /// Duration of the clear trie updates of other children chains after fork choice update action.
+    /// Duration of the clear trie updates of other children chains after fork choice update
+    /// action.
     clear_trie_updates_for_other_childs: Histogram,
 }
 

--- a/crates/node/builder/src/components/builder.rs
+++ b/crates/node/builder/src/components/builder.rs
@@ -281,7 +281,7 @@ pub trait NodeComponentsBuilder<Node: FullNodeTypes>: Send {
     /// The components for the node with the given types
     type Components: NodeComponents<Node>;
 
-    /// Consumes the type and returns the crated components.
+    /// Consumes the type and returns the created components.
     fn build_components(
         self,
         ctx: &BuilderContext<Node>,

--- a/crates/rpc/rpc-types-compat/src/engine/payload.rs
+++ b/crates/rpc/rpc-types-compat/src/engine/payload.rs
@@ -43,7 +43,7 @@ pub fn try_payload_v1_to_block(payload: ExecutionPayloadV1) -> Result<Block, Pay
         timestamp: payload.timestamp,
         mix_hash: payload.prev_randao,
         // WARNING: It’s allowed for a base fee in EIP1559 to increase unbounded. We assume that
-        // it will fit in an u64. This is not always necessarily true, although it is extremelly
+        // it will fit in an u64. This is not always necessarily true, although it is extremely
         // unlikely not to be the case, a u64 maximum would have 2^64 which equates to 18 ETH per
         // gas.
         base_fee_per_gas: Some(

--- a/crates/stages/stages/src/stages/headers.rs
+++ b/crates/stages/stages/src/stages/headers.rs
@@ -351,7 +351,7 @@ where
         let mut writer = static_file_provider.latest_writer(StaticFileSegment::Headers)?;
         writer.prune_headers(static_file_headers_to_unwind)?;
 
-        // Set the stage checkpoin entities processed based on how much we unwound - we add the
+        // Set the stage checkpoint entities processed based on how much we unwound - we add the
         // headers unwound from static files and db
         let stage_checkpoint =
             input.checkpoint.headers_stage_checkpoint().map(|stage_checkpoint| HeadersCheckpoint {

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -593,7 +593,7 @@ impl StaticFileProviderRW {
     fn ensure_no_queued_prune(&self) -> ProviderResult<()> {
         if self.prune_on_commit.is_some() {
             return Err(ProviderError::NippyJar(
-                "Pruning should be comitted before appending or pruning more data".to_string(),
+                "Pruning should be committed before appending or pruning more data".to_string(),
             ))
         }
         Ok(())


### PR DESCRIPTION
Fix #8587.

Fix the code spell check in CI. Fix existing typo.