### PR TITLE
fix: remove support for empty OP payloads

### DIFF
--- a/crates/optimism/payload/src/error.rs
+++ b/crates/optimism/payload/src/error.rs
@@ -20,4 +20,10 @@ pub enum OptimismPayloadBuilderError {
     /// Thrown when a blob transaction is included in a sequencer's block.
     #[error("blob transaction included in sequencer block")]
     BlobTransactionRejected,
+    /// OP requires system tx to be included in the block.
+    ///
+    /// Without at least the system tx in the block, no valid block can be produced, because the
+    /// first tx in the block contains the L1 block info.
+    #[error("empty payload building is unsupported")]
+    EmptyPayloadUnsupported,
 }


### PR DESCRIPTION
empty OP payloads are useless and potentially dangerous

this codepath isn't reachable because for this reason we never invoked this instead force built the requested block.

we should instead return an error here