### PR TITLE
fix: ensure tx forwarder is set

### DIFF
--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1016,6 +1016,10 @@ impl<Provider, Pool, Network, Tasks, Events, EvmConfig>
         &mut self,
         forwarder: Arc<dyn RawTransactionForwarder>,
     ) {
+        if let Some(eth) = self.eth.as_ref() {
+            // in case the eth api has been created before the forwarder was set: <https://github.com/paradigmxyz/reth/issues/8661>
+            eth.api.set_eth_raw_transaction_forwarder(forwarder.clone());
+        }
         self.eth_raw_transaction_forwarder = Some(forwarder);
     }
 

--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -88,6 +88,15 @@ pub struct EthApi<Provider, Pool, Network, EvmConfig> {
     inner: Arc<EthApiInner<Provider, Pool, Network, EvmConfig>>,
 }
 
+impl<Provider, Pool, Network, EvmConfig> EthApi<Provider, Pool, Network, EvmConfig> {
+    /// Sets a forwarder for `eth_sendRawTransaction`
+    ///
+    /// Note: this might be removed in the future in favor of a more generic approach.
+    pub fn set_eth_raw_transaction_forwarder(&self, forwarder: Arc<dyn RawTransactionForwarder>) {
+        self.inner.raw_transaction_forwarder.write().replace(forwarder);
+    }
+}
+
 impl<Provider, Pool, Network, EvmConfig> EthApi<Provider, Pool, Network, EvmConfig>
 where
     Provider: BlockReaderIdExt + ChainSpecProvider,
@@ -158,7 +167,7 @@ where
             blocking_task_pool,
             fee_history_cache,
             evm_config,
-            raw_transaction_forwarder,
+            raw_transaction_forwarder: parking_lot::RwLock::new(raw_transaction_forwarder),
         };
 
         Self { inner: Arc::new(inner) }
@@ -490,5 +499,5 @@ struct EthApiInner<Provider, Pool, Network, EvmConfig> {
     /// The type that defines how to configure the EVM
     evm_config: EvmConfig,
     /// Allows forwarding received raw transactions
-    raw_transaction_forwarder: Option<Arc<dyn RawTransactionForwarder>>,
+    raw_transaction_forwarder: parking_lot::RwLock<Option<Arc<dyn RawTransactionForwarder>>>,
 }

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -849,7 +849,8 @@ where
     async fn send_raw_transaction(&self, tx: Bytes) -> EthResult<B256> {
         // On optimism, transactions are forwarded directly to the sequencer to be included in
         // blocks that it builds.
-        if let Some(client) = self.inner.raw_transaction_forwarder.as_ref() {
+        let maybe_forwarder = self.inner.raw_transaction_forwarder.read().clone();
+        if let Some(client) = maybe_forwarder {
             tracing::debug!( target: "rpc::eth",  "forwarding raw transaction to");
             client.forward_raw_transaction(&tx).await?;
         }


### PR DESCRIPTION
closes #8661

there is something like a race condition when the ethapi is created and modified with the tx forwarder we use for OP.

By the time the forwarded is set via the extend_rpc function the EthApi instance is already created for the engine_ endpoint, so the forwarder is never used...

This includes a hotfix and wraps the forwarder in an rwlock so that we can always set it.

this is not great, but this feature will soon be replaced with rpc middleware.
the overhead to acquire the read lock barely exists.