### PR TITLE
chore: add link to new_payload_v4 docs

### DIFF
--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -602,6 +602,8 @@ where
         Ok(res?)
     }
 
+    /// Handler for `engine_newPayloadV4`
+    /// See also <https://github.com/ethereum/execution-apis/blob/03911ffc053b8b806123f1fc237184b0092a485a/src/engine/prague.md#engine_newpayloadv4>
     async fn new_payload_v4(
         &self,
         payload: ExecutionPayloadV4,


### PR DESCRIPTION
Just adds the spec to the docs above the EngineApi impl like we do for the other methods