### PR TITLE
fix: ensure jsonrpsee logs are off by default

### DIFF
--- a/crates/tracing/src/layers.rs
+++ b/crates/tracing/src/layers.rs
@@ -18,9 +18,14 @@ pub(crate) type BoxedLayer<S> = Box<dyn Layer<S> + Send + Sync>;
 const RETH_LOG_FILE_NAME: &str = "reth.log";
 
 /// Default [directives](Directive) for [`EnvFilter`] which disables high-frequency debug logs from
-/// `hyper`, `trust-dns` and `discv5`.
-const DEFAULT_ENV_FILTER_DIRECTIVES: [&str; 4] =
-    ["hyper::proto::h1=off", "trust_dns_proto=off", "trust_dns_resolver=off", "discv5=off"];
+/// `hyper`, `trust-dns`, `jsonrpsee-server`, and `discv5`.
+const DEFAULT_ENV_FILTER_DIRECTIVES: [&str; 5] = [
+    "hyper::proto::h1=off",
+    "trust_dns_proto=off",
+    "trust_dns_resolver=off",
+    "discv5=off",
+    "jsonrpsee-server=off",
+];
 
 /// Manages the collection of layers for a tracing subscriber.
 ///


### PR DESCRIPTION
Running with `debug` on this we would print out
```
reth 2024-06-07T21:52:48.899854Z DEBUG jsonrpsee-server: Accepting new connection 1/500
reth 2024-06-07T21:52:48.900714Z DEBUG jsonrpsee-server: Accepting new connection 1/500
```
On every rpc call. Now this is silent.