### PR TITLE
fix(example/op-bridge): ethereum Receipt needless update

### DIFF
--- a/examples/exex/op-bridge/src/main.rs
+++ b/examples/exex/op-bridge/src/main.rs
@@ -283,6 +283,7 @@ mod tests {
             event.encode_data().into(),
         )
         .ok_or_else(|| eyre::eyre!("failed to encode event"))?;
+        #[allow(clippy::needless_update)] // side-effect of optimism fields
         let receipt = Receipt {
             tx_type: TxType::Legacy,
             success: true,


### PR DESCRIPTION
run `make lint-reth` error:

```
cargo +nightly clippy \
        --workspace \
        --bin "reth" \
        --lib \
        --examples \
        --tests \
        --benches \
        --features "ethereum asm-keccak jemalloc jemalloc-prof min-error-logs min-warn-logs min-info-logs min-debug-logs min-trace-logs" \
        -- -D warnings
    Checking exex-op-bridge v0.0.0 ...
error: struct update has no effect, all the fields in the struct have already been specified
   --> examples/exex/op-bridge/src/main.rs:291:15
    |
291 |             ..Default::default()
    |               ^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_update
    = note: `-D clippy::needless-update` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::needless_update)]`
```