### PR TITLE
feat: support `no_std` for `reth-storage-errors`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7904,7 +7904,6 @@ version = "0.2.0-beta.9"
 dependencies = [
  "reth-fs-util",
  "reth-primitives",
- "thiserror",
 ]
 
 [[package]]

--- a/crates/storage/errors/Cargo.toml
+++ b/crates/storage/errors/Cargo.toml
@@ -14,8 +14,6 @@ workspace = true
 reth-primitives.workspace = true
 reth-fs-util.workspace = true
 
-thiserror.workspace = true
-
 [features]
 default = ["std"]
 std = []

--- a/crates/storage/errors/Cargo.toml
+++ b/crates/storage/errors/Cargo.toml
@@ -16,4 +16,6 @@ reth-fs-util.workspace = true
 
 thiserror.workspace = true
 
-    
+[features]
+default = ["std"]
+std = []

--- a/crates/storage/errors/src/db.rs
+++ b/crates/storage/errors/src/db.rs
@@ -96,10 +96,9 @@ impl std::error::Error for DatabaseErrorInfo {}
 
 impl Display for DatabaseErrorInfo {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        f.write_fmt(format_args!("{0} ({1})", self.message, self.code))
+        write!(f, "{} ({})", self.message, self.code)
     }
 }
-
 /// Database write error.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DatabaseWriteError {
@@ -133,13 +132,14 @@ impl std::error::Error for DatabaseWriteError {}
 
 impl Display for DatabaseWriteError {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        f.write_fmt(format_args!(
-            "write operation {0:?} failed for key \"{1}\" in table {2:?}: {3}",
+        write!(
+            f,
+            "write operation {:?} failed for key \"{}\" in table {:?}: {}",
             self.operation,
             reth_primitives::hex::encode(&self.key),
             self.table_name,
-            self.info,
-        ))
+            self.info
+        )
     }
 }
 

--- a/crates/storage/errors/src/db.rs
+++ b/crates/storage/errors/src/db.rs
@@ -1,13 +1,10 @@
 use core::{
-    fmt::{Display, Result},
+    fmt::{Display, Formatter, Result},
     str::FromStr,
 };
 
 extern crate alloc;
 use alloc::boxed::Box;
-
-#[cfg(feature = "std")]
-use std::{error::Error, fmt};
 
 /// Database error type.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -39,8 +36,8 @@ pub enum DatabaseError {
 }
 
 #[cfg(feature = "std")]
-impl Error for DatabaseError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
+impl std::error::Error for DatabaseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Write(err) => Some(&**err),
             _ => None,
@@ -49,35 +46,20 @@ impl Error for DatabaseError {
 }
 
 impl Display for DatabaseError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
-            Self::Open(info) => f.write_fmt(format_args!("failed to open the database: {0}", info)),
-            Self::CreateTable(info) => {
-                f.write_fmt(format_args!("failed to create a table: {0}", info))
-            }
-            Self::Write(err) => f.write_fmt(format_args!("{0}", err)),
-            Self::Read(info) => f
-                .write_fmt(
-                    format_args!("failed to read a value from a database table: {0}", info,),
-                ),
-            Self::Delete(info) => {
-                f.write_fmt(format_args!("database delete error code: {0}", info))
-            }
-            Self::Commit(info) => {
-                f.write_fmt(format_args!("failed to commit transaction changes: {0}", info))
-            }
-            Self::InitTx(info) => {
-                f.write_fmt(format_args!("failed to initialize a transaction: {0}", info))
-            }
-            Self::InitCursor(info) => {
-                f.write_fmt(format_args!("failed to initialize a cursor: {0}", info))
-            }
-            Self::Decode => f.write_fmt(format_args!("failed to decode a key from a table")),
-            Self::Stats(info) => f.write_fmt(format_args!("failed to get stats: {0}", info)),
-            Self::LogLevelUnavailable(level) => {
-                f.write_fmt(format_args!("log level {0:?} is not available", level))
-            }
-            Self::Other(msg) => f.write_fmt(format_args!("{0}", msg)),
+            Self::Open(info) => write!(f, "failed to open the database: {}", info),
+            Self::CreateTable(info) => write!(f, "failed to create a table: {}", info),
+            Self::Write(err) => write!(f, "{}", err),
+            Self::Read(info) => write!(f, "failed to read a value from a database table: {}", info),
+            Self::Delete(info) => write!(f, "database delete error code: {}", info),
+            Self::Commit(info) => write!(f, "failed to commit transaction changes: {}", info),
+            Self::InitTx(info) => write!(f, "failed to initialize a transaction: {}", info),
+            Self::InitCursor(info) => write!(f, "failed to initialize a cursor: {}", info),
+            Self::Decode => write!(f, "failed to decode a key from a table"),
+            Self::Stats(info) => write!(f, "failed to get stats: {}", info),
+            Self::LogLevelUnavailable(level) => write!(f, "log level {:?} is not available", level),
+            Self::Other(msg) => write!(f, "{}", msg),
         }
     }
 }
@@ -110,10 +92,10 @@ impl From<DatabaseWriteError> for DatabaseError {
 }
 
 #[cfg(feature = "std")]
-impl Error for DatabaseErrorInfo {}
+impl std::error::Error for DatabaseErrorInfo {}
 
 impl Display for DatabaseErrorInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         f.write_fmt(format_args!("{0} ({1})", self.message, self.code))
     }
 }
@@ -147,10 +129,10 @@ pub enum DatabaseWriteOperation {
 }
 
 #[cfg(feature = "std")]
-impl Error for DatabaseWriteError {}
+impl std::error::Error for DatabaseWriteError {}
 
 impl Display for DatabaseWriteError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.write_fmt(format_args!(
             "write operation {0:?} failed for key \"{1}\" in table {2:?}: {3}",
             self.operation,

--- a/crates/storage/errors/src/db.rs
+++ b/crates/storage/errors/src/db.rs
@@ -1,10 +1,8 @@
+use alloc::boxed::Box;
 use core::{
     fmt::{Display, Formatter, Result},
     str::FromStr,
 };
-
-extern crate alloc;
-use alloc::boxed::Box;
 
 /// Database error type.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -211,7 +209,7 @@ impl LogLevel {
 impl FromStr for LogLevel {
     type Err = String;
 
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "fatal" => Ok(Self::Fatal),
             "error" => Ok(Self::Error),

--- a/crates/storage/errors/src/db.rs
+++ b/crates/storage/errors/src/db.rs
@@ -1,4 +1,4 @@
-use alloc::boxed::Box;
+use alloc::{boxed::Box, format, string::String, vec::Vec};
 use core::{
     fmt::{Display, Formatter, Result},
     str::FromStr,

--- a/crates/storage/errors/src/lib.rs
+++ b/crates/storage/errors/src/lib.rs
@@ -9,6 +9,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate alloc;
+
 /// Database error
 pub mod db;
 

--- a/crates/storage/errors/src/lib.rs
+++ b/crates/storage/errors/src/lib.rs
@@ -7,6 +7,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 /// Database error
 pub mod db;

--- a/crates/storage/errors/src/lockfile.rs
+++ b/crates/storage/errors/src/lockfile.rs
@@ -23,11 +23,12 @@ impl std::error::Error for StorageLockError {}
 impl Display for StorageLockError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
-            Self::Taken(write_lock) => f.write_fmt(format_args!(
-                "storage directory is currently in use as read-write by another process: PID {0}",
-                write_lock,
-            )),
-            Self::Other(unspecified) => f.write_fmt(format_args!("{0}", unspecified,)),
+            Self::Taken(write_lock) => write!(
+                f,
+                "storage directory is currently in use as read-write by another process: PID {}",
+                write_lock
+            ),
+            Self::Other(unspecified) => write!(f, "{}", unspecified),
         }
     }
 }

--- a/crates/storage/errors/src/lockfile.rs
+++ b/crates/storage/errors/src/lockfile.rs
@@ -1,14 +1,15 @@
+use core::fmt::{Display, Formatter, Result};
 use reth_fs_util::FsPathError;
-use thiserror::Error;
 
-#[derive(Error, Debug, Clone, PartialEq, Eq)]
+#[cfg(feature = "std")]
+use std::error::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 /// Storage lock error.
 pub enum StorageLockError {
     /// Write lock taken
-    #[error("storage directory is currently in use as read-write by another process: PID {0}")]
     Taken(usize),
     /// Indicates other unspecified errors.
-    #[error("{0}")]
     Other(String),
 }
 
@@ -16,5 +17,23 @@ pub enum StorageLockError {
 impl From<FsPathError> for StorageLockError {
     fn from(source: FsPathError) -> Self {
         Self::Other(source.to_string())
+    }
+}
+
+#[cfg(feature = "std")]
+impl Error for StorageLockError {}
+
+impl Display for StorageLockError {
+    fn fmt(&self, __formatter: &mut Formatter<'_>) -> Result {
+        use thiserror::__private::AsDisplay as _;
+        match self {
+            Self::Taken(write_lock) => __formatter.write_fmt(format_args!(
+                "storage directory is currently in use as read-write by another process: PID {0}",
+                write_lock.as_display(),
+            )),
+            Self::Other(unspecified) => {
+                __formatter.write_fmt(format_args!("{0}", unspecified.as_display()))
+            }
+        }
     }
 }

--- a/crates/storage/errors/src/lockfile.rs
+++ b/crates/storage/errors/src/lockfile.rs
@@ -1,9 +1,6 @@
 use core::fmt::{Display, Formatter, Result};
 use reth_fs_util::FsPathError;
 
-#[cfg(feature = "std")]
-use std::error::Error;
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Storage lock error.
 pub enum StorageLockError {
@@ -21,7 +18,7 @@ impl From<FsPathError> for StorageLockError {
 }
 
 #[cfg(feature = "std")]
-impl Error for StorageLockError {}
+impl std::error::Error for StorageLockError {}
 
 impl Display for StorageLockError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {

--- a/crates/storage/errors/src/lockfile.rs
+++ b/crates/storage/errors/src/lockfile.rs
@@ -1,3 +1,4 @@
+use alloc::string::{String, ToString};
 use core::fmt::{Display, Formatter, Result};
 use reth_fs_util::FsPathError;
 

--- a/crates/storage/errors/src/lockfile.rs
+++ b/crates/storage/errors/src/lockfile.rs
@@ -24,16 +24,13 @@ impl From<FsPathError> for StorageLockError {
 impl Error for StorageLockError {}
 
 impl Display for StorageLockError {
-    fn fmt(&self, __formatter: &mut Formatter<'_>) -> Result {
-        use thiserror::__private::AsDisplay as _;
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
-            Self::Taken(write_lock) => __formatter.write_fmt(format_args!(
+            Self::Taken(write_lock) => f.write_fmt(format_args!(
                 "storage directory is currently in use as read-write by another process: PID {0}",
-                write_lock.as_display(),
+                write_lock,
             )),
-            Self::Other(unspecified) => {
-                __formatter.write_fmt(format_args!("{0}", unspecified.as_display()))
-            }
+            Self::Other(unspecified) => f.write_fmt(format_args!("{0}", unspecified,)),
         }
     }
 }

--- a/crates/storage/errors/src/provider.rs
+++ b/crates/storage/errors/src/provider.rs
@@ -1,37 +1,33 @@
+use core::fmt::{Display, Formatter, Result};
 use reth_primitives::{
     Address, BlockHash, BlockHashOrNumber, BlockNumber, GotExpected, StaticFileSegment,
     TxHashOrNumber, TxNumber, B256, U256,
 };
 use std::path::PathBuf;
-use thiserror::Error;
+
+#[cfg(feature = "std")]
+use std::error::Error;
 
 /// Provider result type.
-pub type ProviderResult<Ok> = Result<Ok, ProviderError>;
+pub type ProviderResult<Ok> = std::result::Result<Ok, ProviderError>;
 
 /// Bundled errors variants thrown by various providers.
-#[derive(Clone, Debug, Error, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ProviderError {
     /// Database error.
-    #[error(transparent)]
-    Database(#[from] crate::db::DatabaseError),
+    Database(crate::db::DatabaseError),
     /// Filesystem path error.
-    #[error("{0}")]
     FsPathError(String),
     /// Nippy jar error.
-    #[error("nippy jar error: {0}")]
     NippyJar(String),
     /// Error when recovering the sender for a transaction
-    #[error("failed to recover sender for transaction")]
     SenderRecoveryError,
     /// The header number was not found for the given block hash.
-    #[error("block hash {0} does not exist in Headers table")]
     BlockHashNotFound(BlockHash),
     /// A block body is missing.
-    #[error("block meta not found for block #{0}")]
     BlockBodyIndicesNotFound(BlockNumber),
     /// The transition ID was found for the given address and storage key, but the changeset was
     /// not found.
-    #[error("storage change set for address {address} and key {storage_key} at block #{block_number} does not exist")]
     StorageChangesetNotFound {
         /// The block number found for the address and storage key.
         block_number: BlockNumber,
@@ -43,7 +39,6 @@ pub enum ProviderError {
         storage_key: Box<B256>,
     },
     /// The block number was found for the given address, but the changeset was not found.
-    #[error("account change set for address {address} at block #{block_number} does not exist")]
     AccountChangesetNotFound {
         /// Block number found for the address.
         block_number: BlockNumber,
@@ -51,89 +46,246 @@ pub enum ProviderError {
         address: Address,
     },
     /// The total difficulty for a block is missing.
-    #[error("total difficulty not found for block #{0}")]
     TotalDifficultyNotFound(BlockNumber),
     /// when required header related data was not found but was required.
-    #[error("no header found for {0:?}")]
     HeaderNotFound(BlockHashOrNumber),
     /// The specific transaction is missing.
-    #[error("no transaction found for {0:?}")]
     TransactionNotFound(TxHashOrNumber),
     /// The specific receipt is missing
-    #[error("no receipt found for {0:?}")]
     ReceiptNotFound(TxHashOrNumber),
     /// Unable to find the best block.
-    #[error("best block does not exist")]
     BestBlockNotFound,
     /// Unable to find the finalized block.
-    #[error("finalized block does not exist")]
     FinalizedBlockNotFound,
     /// Unable to find the safe block.
-    #[error("safe block does not exist")]
     SafeBlockNotFound,
     /// Mismatch of sender and transaction.
-    #[error("mismatch of sender and transaction id {tx_id}")]
     MismatchOfTransactionAndSenderId {
         /// The transaction ID.
         tx_id: TxNumber,
     },
     /// Block body wrong transaction count.
-    #[error("stored block indices does not match transaction count")]
     BlockBodyTransactionCount,
     /// Thrown when the cache service task dropped.
-    #[error("cache service task stopped")]
     CacheServiceUnavailable,
     /// Thrown when we failed to lookup a block for the pending state.
-    #[error("unknown block {0}")]
     UnknownBlockHash(B256),
     /// Thrown when we were unable to find a state for a block hash.
-    #[error("no state found for block {0}")]
     StateForHashNotFound(B256),
     /// Unable to compute state root on top of historical block.
-    #[error("unable to compute state root on top of historical block")]
     StateRootNotAvailableForHistoricalBlock,
     /// Unable to find the block number for a given transaction index.
-    #[error("unable to find the block number for a given transaction index")]
     BlockNumberForTransactionIndexNotFound,
     /// Root mismatch.
-    #[error("merkle trie {0}")]
     StateRootMismatch(Box<RootMismatch>),
     /// Root mismatch during unwind
-    #[error("unwind merkle trie {0}")]
     UnwindStateRootMismatch(Box<RootMismatch>),
     /// State is not available for the given block number because it is pruned.
-    #[error("state at block #{0} is pruned")]
     StateAtBlockPruned(BlockNumber),
     /// Provider does not support this particular request.
-    #[error("this provider does not support this request")]
     UnsupportedProvider,
     /// Static File is not found at specified path.
-    #[error("not able to find {0} static file at {1}")]
     MissingStaticFilePath(StaticFileSegment, PathBuf),
     /// Static File is not found for requested block.
-    #[error("not able to find {0} static file for block number {1}")]
     MissingStaticFileBlock(StaticFileSegment, BlockNumber),
     /// Static File is not found for requested transaction.
-    #[error("unable to find {0} static file for transaction id {1}")]
     MissingStaticFileTx(StaticFileSegment, TxNumber),
     /// Static File is finalized and cannot be written to.
-    #[error("unable to write block #{1} to finalized static file {0}")]
     FinalizedStaticFile(StaticFileSegment, BlockNumber),
     /// Trying to insert data from an unexpected block number.
-    #[error("trying to append data to {0} as block #{1} but expected block #{2}")]
     UnexpectedStaticFileBlockNumber(StaticFileSegment, BlockNumber, BlockNumber),
     /// Static File Provider was initialized as read-only.
-    #[error("cannot get a writer on a read-only environment.")]
     ReadOnlyStaticFileAccess,
     /// Error encountered when the block number conversion from U256 to u64 causes an overflow.
-    #[error("failed to convert block number U256 to u64: {0}")]
     BlockNumberOverflow(U256),
     /// Consistent view error.
-    #[error("failed to initialize consistent view: {0}")]
     ConsistentView(Box<ConsistentViewError>),
     /// Storage lock error.
-    #[error(transparent)]
-    StorageLockError(#[from] crate::lockfile::StorageLockError),
+    StorageLockError(crate::lockfile::StorageLockError),
+}
+
+impl Error for ProviderError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        use thiserror::__private::AsDynError as _;
+        #[allow(deprecated)]
+        match self {
+            ProviderError::Database { 0: transparent } => {
+                std::error::Error::source(transparent.as_dyn_error())
+            }
+            ProviderError::FsPathError { .. } => ::core::option::Option::None,
+            ProviderError::NippyJar { .. } => ::core::option::Option::None,
+            ProviderError::SenderRecoveryError { .. } => ::core::option::Option::None,
+            ProviderError::BlockHashNotFound { .. } => ::core::option::Option::None,
+            ProviderError::BlockBodyIndicesNotFound { .. } => ::core::option::Option::None,
+            ProviderError::StorageChangesetNotFound { .. } => ::core::option::Option::None,
+            ProviderError::AccountChangesetNotFound { .. } => ::core::option::Option::None,
+            ProviderError::TotalDifficultyNotFound { .. } => ::core::option::Option::None,
+            ProviderError::HeaderNotFound { .. } => ::core::option::Option::None,
+            ProviderError::TransactionNotFound { .. } => ::core::option::Option::None,
+            ProviderError::ReceiptNotFound { .. } => ::core::option::Option::None,
+            ProviderError::BestBlockNotFound { .. } => ::core::option::Option::None,
+            ProviderError::FinalizedBlockNotFound { .. } => ::core::option::Option::None,
+            ProviderError::SafeBlockNotFound { .. } => ::core::option::Option::None,
+            ProviderError::MismatchOfTransactionAndSenderId { .. } => ::core::option::Option::None,
+            ProviderError::BlockBodyTransactionCount { .. } => ::core::option::Option::None,
+            ProviderError::CacheServiceUnavailable { .. } => ::core::option::Option::None,
+            ProviderError::UnknownBlockHash { .. } => ::core::option::Option::None,
+            ProviderError::StateForHashNotFound { .. } => ::core::option::Option::None,
+            ProviderError::StateRootNotAvailableForHistoricalBlock { .. } => {
+                ::core::option::Option::None
+            }
+            ProviderError::BlockNumberForTransactionIndexNotFound { .. } => {
+                ::core::option::Option::None
+            }
+            ProviderError::StateRootMismatch { .. } => ::core::option::Option::None,
+            ProviderError::UnwindStateRootMismatch { .. } => ::core::option::Option::None,
+            ProviderError::StateAtBlockPruned { .. } => ::core::option::Option::None,
+            ProviderError::UnsupportedProvider { .. } => ::core::option::Option::None,
+            ProviderError::MissingStaticFilePath { .. } => ::core::option::Option::None,
+            ProviderError::MissingStaticFileBlock { .. } => ::core::option::Option::None,
+            ProviderError::MissingStaticFileTx { .. } => ::core::option::Option::None,
+            ProviderError::FinalizedStaticFile { .. } => ::core::option::Option::None,
+            ProviderError::UnexpectedStaticFileBlockNumber { .. } => ::core::option::Option::None,
+            ProviderError::ReadOnlyStaticFileAccess { .. } => ::core::option::Option::None,
+            ProviderError::BlockNumberOverflow { .. } => ::core::option::Option::None,
+            ProviderError::ConsistentView { .. } => ::core::option::Option::None,
+            ProviderError::StorageLockError { 0: transparent } => {
+                std::error::Error::source(transparent.as_dyn_error())
+            }
+        }
+    }
+}
+
+impl Display for ProviderError {
+    fn fmt(&self, __formatter: &mut Formatter<'_>) -> Result {
+        use thiserror::__private::AsDisplay as _;
+        #[allow(unused_variables, deprecated, clippy::used_underscore_binding)]
+        match self {
+            ProviderError::Database(_0) => Display::fmt(_0, __formatter),
+            ProviderError::FsPathError(_0) => {
+                __formatter.write_fmt(format_args!("{0}", _0.as_display()))
+            }
+            ProviderError::NippyJar(_0) => {
+                __formatter.write_fmt(format_args!("nippy jar error: {0}", _0.as_display()))
+            }
+            ProviderError::SenderRecoveryError {} => {
+                __formatter.write_str("failed to recover sender for transaction")
+            }
+            ProviderError::BlockHashNotFound(_0) => __formatter.write_fmt(format_args!(
+                "block hash {0} does not exist in Headers table",
+                _0.as_display(),
+            )),
+            ProviderError::BlockBodyIndicesNotFound(_0) => __formatter
+                .write_fmt(format_args!("block meta not found for block #{0}", _0.as_display(),)),
+            ProviderError::StorageChangesetNotFound { block_number, address, storage_key } => {
+                __formatter.write_fmt(format_args!(
+                    "storage change set for address {0} and key {1} at block #{2} does not exist",
+                    address.as_display(),
+                    storage_key.as_display(),
+                    block_number.as_display(),
+                ))
+            }
+            ProviderError::AccountChangesetNotFound { block_number, address } => __formatter
+                .write_fmt(format_args!(
+                    "account change set for address {0} at block #{1} does not exist",
+                    address.as_display(),
+                    block_number.as_display(),
+                )),
+            ProviderError::TotalDifficultyNotFound(_0) => __formatter.write_fmt(format_args!(
+                "total difficulty not found for block #{0}",
+                _0.as_display(),
+            )),
+            ProviderError::HeaderNotFound(_0) => {
+                __formatter.write_fmt(format_args!("no header found for {0:?}", _0))
+            }
+            ProviderError::TransactionNotFound(_0) => {
+                __formatter.write_fmt(format_args!("no transaction found for {0:?}", _0))
+            }
+            ProviderError::ReceiptNotFound(_0) => {
+                __formatter.write_fmt(format_args!("no receipt found for {0:?}", _0))
+            }
+            ProviderError::BestBlockNotFound {} => {
+                __formatter.write_str("best block does not exist")
+            }
+            ProviderError::FinalizedBlockNotFound {} => {
+                __formatter.write_str("finalized block does not exist")
+            }
+            ProviderError::SafeBlockNotFound {} => {
+                __formatter.write_str("safe block does not exist")
+            }
+            ProviderError::MismatchOfTransactionAndSenderId { tx_id } => __formatter.write_fmt(
+                format_args!("mismatch of sender and transaction id {0}", tx_id.as_display(),),
+            ),
+            ProviderError::BlockBodyTransactionCount {} => {
+                __formatter.write_str("stored block indices does not match transaction count")
+            }
+            ProviderError::CacheServiceUnavailable {} => {
+                __formatter.write_str("cache service task stopped")
+            }
+            ProviderError::UnknownBlockHash(_0) => {
+                __formatter.write_fmt(format_args!("unknown block {0}", _0.as_display()))
+            }
+            ProviderError::StateForHashNotFound(_0) => {
+                __formatter.write_fmt(format_args!("no state found for block {0}", _0.as_display()))
+            }
+            ProviderError::StateRootNotAvailableForHistoricalBlock {} => {
+                __formatter.write_str("unable to compute state root on top of historical block")
+            }
+            ProviderError::BlockNumberForTransactionIndexNotFound {} => __formatter
+                .write_str("unable to find the block number for a given transaction index"),
+            ProviderError::StateRootMismatch(_0) => {
+                __formatter.write_fmt(format_args!("merkle trie {0}", _0.as_display()))
+            }
+            ProviderError::UnwindStateRootMismatch(_0) => {
+                __formatter.write_fmt(format_args!("unwind merkle trie {0}", _0.as_display()))
+            }
+            ProviderError::StateAtBlockPruned(_0) => __formatter
+                .write_fmt(format_args!("state at block #{0} is pruned", _0.as_display(),)),
+            ProviderError::UnsupportedProvider {} => {
+                __formatter.write_str("this provider does not support this request")
+            }
+            ProviderError::MissingStaticFilePath(_0, _1) => __formatter.write_fmt(format_args!(
+                "not able to find {0} static file at {1}",
+                _0.as_display(),
+                _1.as_display(),
+            )),
+            ProviderError::MissingStaticFileBlock(_0, _1) => __formatter.write_fmt(format_args!(
+                "not able to find {0} static file for block number {1}",
+                _0.as_display(),
+                _1.as_display(),
+            )),
+            ProviderError::MissingStaticFileTx(_0, _1) => __formatter.write_fmt(format_args!(
+                "unable to find {0} static file for transaction id {1}",
+                _0.as_display(),
+                _1.as_display(),
+            )),
+            ProviderError::FinalizedStaticFile(_0, _1) => __formatter.write_fmt(format_args!(
+                "unable to write block #{0} to finalized static file {1}",
+                _1.as_display(),
+                _0.as_display(),
+            )),
+            ProviderError::UnexpectedStaticFileBlockNumber(_0, _1, _2) => {
+                __formatter.write_fmt(format_args!(
+                    "trying to append data to {0} as block #{1} but expected block #{2}",
+                    _0.as_display(),
+                    _1.as_display(),
+                    _2.as_display(),
+                ))
+            }
+            ProviderError::ReadOnlyStaticFileAccess {} => {
+                __formatter.write_str("cannot get a writer on a read-only environment.")
+            }
+            ProviderError::BlockNumberOverflow(_0) => __formatter.write_fmt(format_args!(
+                "failed to convert block number U256 to u64: {0}",
+                _0.as_display(),
+            )),
+            ProviderError::ConsistentView(_0) => __formatter.write_fmt(format_args!(
+                "failed to initialize consistent view: {0}",
+                _0.as_display(),
+            )),
+            ProviderError::StorageLockError(_0) => ::core::fmt::Display::fmt(_0, __formatter),
+        }
+    }
 }
 
 impl From<reth_fs_util::FsPathError> for ProviderError {
@@ -143,8 +295,7 @@ impl From<reth_fs_util::FsPathError> for ProviderError {
 }
 
 /// A root mismatch error at a given block height.
-#[derive(Clone, Debug, Error, PartialEq, Eq)]
-#[error("root mismatch at #{block_number} ({block_hash}): {root}")]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RootMismatch {
     /// The target block root diff.
     pub root: GotExpected<B256>,
@@ -154,17 +305,33 @@ pub struct RootMismatch {
     pub block_hash: BlockHash,
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for RootMismatch {}
+
+impl Display for RootMismatch {
+    #[allow(clippy::used_underscore_binding)]
+    fn fmt(&self, __formatter: &mut Formatter<'_>) -> Result {
+        use thiserror::__private::AsDisplay as _;
+        #[allow(unused_variables, deprecated)]
+        let Self { root, block_number, block_hash } = self;
+        __formatter.write_fmt(format_args!(
+            "root mismatch at #{0} ({1}): {2}",
+            block_number.as_display(),
+            block_hash.as_display(),
+            root.as_display(),
+        ))
+    }
+}
+
 /// Consistent database view error.
-#[derive(Clone, Debug, Error, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ConsistentViewError {
     /// Error thrown on attempt to initialize provider while node is still syncing.
-    #[error("node is syncing. best block: {best_block:?}")]
     Syncing {
         /// Best block diff.
         best_block: GotExpected<BlockNumber>,
     },
     /// Error thrown on inconsistent database view.
-    #[error("inconsistent database state: {tip:?}")]
     Inconsistent {
         /// The tip diff.
         tip: GotExpected<Option<B256>>,
@@ -174,5 +341,20 @@ pub enum ConsistentViewError {
 impl From<ConsistentViewError> for ProviderError {
     fn from(value: ConsistentViewError) -> Self {
         Self::ConsistentView(Box::new(value))
+    }
+}
+
+#[cfg(feature = "std")]
+impl Error for ConsistentViewError {}
+
+impl Display for ConsistentViewError {
+    fn fmt(&self, __formatter: &mut Formatter<'_>) -> Result {
+        match self {
+            ConsistentViewError::Syncing { best_block } => __formatter
+                .write_fmt(format_args!("node is syncing. best block: {0:?}", best_block,)),
+            ConsistentViewError::Inconsistent { tip } => {
+                __formatter.write_fmt(format_args!("inconsistent database state: {0:?}", tip))
+            }
+        }
     }
 }

--- a/crates/storage/errors/src/provider.rs
+++ b/crates/storage/errors/src/provider.rs
@@ -7,9 +7,6 @@ use reth_primitives::{
 };
 use std::path::PathBuf;
 
-#[cfg(feature = "std")]
-use std::error::Error;
-
 /// Provider result type.
 pub type ProviderResult<Ok> = std::result::Result<Ok, ProviderError>;
 
@@ -107,8 +104,8 @@ pub enum ProviderError {
 }
 
 #[cfg(feature = "std")]
-impl Error for ProviderError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
+impl std::error::Error for ProviderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Database(ref e) => Some(e),
             Self::StorageLockError(ref e) => Some(e),
@@ -271,7 +268,7 @@ impl From<ConsistentViewError> for ProviderError {
 }
 
 #[cfg(feature = "std")]
-impl Error for ConsistentViewError {}
+impl std::error::Error for ConsistentViewError {}
 
 impl Display for ConsistentViewError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {


### PR DESCRIPTION
Description

have a subset of crates with no_std supports (evm specifically)
we need to do some prep for this first by making some crates no_std first

Motivation
closes #8459 