### PR TITLE
refactor: replace `BatchBlockExecutionOutput` by `BundleStateWithReceipts`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6848,6 +6848,7 @@ dependencies = [
  "futures-util",
  "parking_lot 0.12.3",
  "reth-execution-errors",
+ "reth-execution-types",
  "reth-primitives",
  "reth-prune-types",
  "reth-storage-errors",
@@ -6863,6 +6864,7 @@ dependencies = [
  "alloy-sol-types",
  "reth-ethereum-consensus",
  "reth-evm",
+ "reth-execution-types",
  "reth-primitives",
  "reth-prune-types",
  "reth-revm",
@@ -6905,7 +6907,6 @@ dependencies = [
 name = "reth-execution-types"
 version = "0.2.0-beta.9"
 dependencies = [
- "reth-evm",
  "reth-execution-errors",
  "reth-primitives",
  "reth-trie",

--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -271,12 +271,13 @@ impl Command {
                 let db = StateProviderDatabase::new(blockchain_db.latest()?);
                 let executor = block_executor!(provider_factory.chain_spec()).executor(db);
 
-                let BlockExecutionOutput { state, receipts, .. } =
+                let BlockExecutionOutput { state, receipts, requests, .. } =
                     executor.execute((&block_with_senders.clone().unseal(), U256::MAX).into())?;
                 let state = BundleStateWithReceipts::new(
                     state,
                     Receipts::from_block_receipt(receipts),
                     block.number,
+                    vec![requests.into()],
                 );
                 debug!(target: "reth::cli", ?state, "Executed block");
 

--- a/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
@@ -135,7 +135,7 @@ impl Command {
 
         let merkle_block_td =
             provider.header_td_by_number(merkle_block_number)?.unwrap_or_default();
-        let BlockExecutionOutput { state, receipts, .. } = executor.execute(
+        let BlockExecutionOutput { state, receipts, requests, .. } = executor.execute(
             (
                 &block
                     .clone()
@@ -150,6 +150,7 @@ impl Command {
             state,
             Receipts::from_block_receipt(receipts),
             block.number,
+            vec![requests.into()],
         );
 
         // Unpacked `BundleState::state_root_slow` function

--- a/bin/reth/src/commands/debug_cmd/merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/merkle.rs
@@ -14,14 +14,14 @@ use reth_config::Config;
 use reth_consensus::Consensus;
 use reth_db::{tables, DatabaseEnv};
 use reth_db_api::{cursor::DbCursorRO, transaction::DbTx};
-use reth_evm::execute::{BatchBlockExecutionOutput, BatchExecutor, BlockExecutorProvider};
+use reth_evm::execute::{BatchExecutor, BlockExecutorProvider};
 use reth_network::NetworkHandle;
 use reth_network_api::NetworkInfo;
 use reth_network_p2p::full_block::FullBlockClient;
 use reth_primitives::{stage::StageCheckpoint, BlockHashOrNumber};
 use reth_provider::{
-    BlockNumReader, BlockWriter, BundleStateWithReceipts, ChainSpecProvider, HeaderProvider,
-    LatestStateProviderRef, OriginalValuesKnown, ProviderError, ProviderFactory, StateWriter,
+    BlockNumReader, BlockWriter, ChainSpecProvider, HeaderProvider, LatestStateProviderRef,
+    OriginalValuesKnown, ProviderError, ProviderFactory, StateWriter,
 };
 use reth_prune_types::PruneModes;
 use reth_revm::database::StateProviderDatabase;
@@ -161,9 +161,7 @@ impl Command {
                 PruneModes::none(),
             );
             executor.execute_and_verify_one((&sealed_block.clone().unseal(), td).into())?;
-            let BatchBlockExecutionOutput { bundle, receipts, requests: _, first_block } =
-                executor.finalize();
-            BundleStateWithReceipts::new(bundle, receipts, first_block).write_to_storage(
+            executor.finalize().write_to_storage(
                 provider_rw.tx_ref(),
                 None,
                 OriginalValuesKnown::Yes,

--- a/bin/reth/src/commands/import_receipts_op.rs
+++ b/bin/reth/src/commands/import_receipts_op.rs
@@ -132,7 +132,12 @@ where
         // We're reusing receipt writing code internal to
         // `BundleStateWithReceipts::write_to_storage`, so we just use a default empty
         // `BundleState`.
-        let bundled_state = BundleStateWithReceipts::new(Default::default(), receipts, first_block);
+        let bundled_state = BundleStateWithReceipts::new(
+            Default::default(),
+            receipts,
+            first_block,
+            Default::default(),
+        );
 
         let static_file_producer =
             static_file_provider.get_writer(first_block, StaticFileSegment::Receipts)?;

--- a/crates/blockchain-tree/src/chain.rs
+++ b/crates/blockchain-tree/src/chain.rs
@@ -219,6 +219,7 @@ impl AppendableChain {
             state,
             Receipts::from_block_receipt(receipts),
             block.number,
+            vec![requests.into()],
         );
 
         // check state root if the block extends the canonical chain __and__ if state root

--- a/crates/consensus/auto-seal/src/lib.rs
+++ b/crates/consensus/auto-seal/src/lib.rs
@@ -389,12 +389,13 @@ impl StorageInner {
         );
 
         // execute the block
-        let BlockExecutionOutput { state, receipts, .. } =
+        let BlockExecutionOutput { state, receipts, requests: block_execution_requests, .. } =
             executor.executor(&mut db).execute((&block, U256::ZERO).into())?;
         let bundle_state = BundleStateWithReceipts::new(
             state,
             Receipts::from_block_receipt(receipts),
             block.number,
+            vec![block_execution_requests.into()],
         );
 
         // todo(onbjerg): we should not pass requests around as this is building a block, which

--- a/crates/ethereum/evm/Cargo.toml
+++ b/crates/ethereum/evm/Cargo.toml
@@ -17,6 +17,7 @@ reth-primitives.workspace = true
 reth-revm.workspace = true
 reth-ethereum-consensus.workspace = true
 reth-prune-types.workspace = true
+reth-execution-types.workspace = true
 
 # Ethereum
 revm-primitives.workspace = true

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -7,11 +7,12 @@ use crate::{
 use reth_ethereum_consensus::validate_block_post_execution;
 use reth_evm::{
     execute::{
-        BatchBlockExecutionOutput, BatchExecutor, BlockExecutionError, BlockExecutionInput,
-        BlockExecutionOutput, BlockExecutorProvider, BlockValidationError, Executor, ProviderError,
+        BatchExecutor, BlockExecutionError, BlockExecutionInput, BlockExecutionOutput,
+        BlockExecutorProvider, BlockValidationError, Executor, ProviderError,
     },
     ConfigureEvm,
 };
+use reth_execution_types::BundleStateWithReceipts;
 use reth_primitives::{
     BlockNumber, BlockWithSenders, ChainSpec, Hardfork, Header, Receipt, Request, Withdrawals,
     MAINNET, U256,
@@ -405,7 +406,7 @@ where
     DB: Database<Error = ProviderError>,
 {
     type Input<'a> = BlockExecutionInput<'a, BlockWithSenders>;
-    type Output = BatchBlockExecutionOutput;
+    type Output = BundleStateWithReceipts;
     type Error = BlockExecutionError;
 
     fn execute_and_verify_one(&mut self, input: Self::Input<'_>) -> Result<(), Self::Error> {
@@ -435,11 +436,11 @@ where
     fn finalize(mut self) -> Self::Output {
         self.stats.log_debug();
 
-        BatchBlockExecutionOutput::new(
+        BundleStateWithReceipts::new(
             self.executor.state.take_bundle(),
             self.batch_record.take_receipts(),
-            self.batch_record.take_requests(),
             self.batch_record.first_block().unwrap_or_default(),
+            self.batch_record.take_requests(),
         )
     }
 

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -448,6 +448,7 @@ where
         db.take_bundle(),
         Receipts::from_vec(vec![receipts]),
         block_number,
+        vec![requests.clone().unwrap_or_default()],
     );
     let receipts_root = bundle.receipts_root_slow(block_number).expect("Number is in range");
     let logs_bloom = bundle.block_logs_bloom(block_number).expect("Number is in range");

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -17,6 +17,7 @@ reth-primitives.workspace = true
 revm-primitives.workspace = true
 reth-prune-types.workspace = true
 reth-storage-errors.workspace = true
+reth-execution-types.workspace = true
 
 revm.workspace = true
 

--- a/crates/evm/execution-types/Cargo.toml
+++ b/crates/evm/execution-types/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 reth-primitives.workspace = true
 reth-execution-errors.workspace = true
 reth-trie.workspace = true
-reth-evm.workspace = true
 
 revm.workspace = true
 

--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -526,6 +526,7 @@ mod tests {
             ),
             Receipts::from_vec(vec![vec![]]),
             1,
+            vec![],
         );
 
         let block_state2 = BundleStateWithReceipts::new(
@@ -541,6 +542,7 @@ mod tests {
             ),
             Receipts::from_vec(vec![vec![]]),
             2,
+            vec![],
         );
 
         let mut block1 = SealedBlockWithSenders::default();

--- a/crates/evm/src/either.rs
+++ b/crates/evm/src/either.rs
@@ -1,10 +1,10 @@
 //! Helper type that represents one of two possible executor types
 
 use crate::execute::{
-    BatchBlockExecutionOutput, BatchExecutor, BlockExecutionInput, BlockExecutionOutput,
-    BlockExecutorProvider, Executor,
+    BatchExecutor, BlockExecutionInput, BlockExecutionOutput, BlockExecutorProvider, Executor,
 };
 use reth_execution_errors::BlockExecutionError;
+use reth_execution_types::BundleStateWithReceipts;
 use reth_primitives::{BlockNumber, BlockWithSenders, Receipt};
 use reth_prune_types::PruneModes;
 use reth_storage_errors::provider::ProviderError;
@@ -76,19 +76,19 @@ where
     A: for<'a> BatchExecutor<
         DB,
         Input<'a> = BlockExecutionInput<'a, BlockWithSenders>,
-        Output = BatchBlockExecutionOutput,
+        Output = BundleStateWithReceipts,
         Error = BlockExecutionError,
     >,
     B: for<'a> BatchExecutor<
         DB,
         Input<'a> = BlockExecutionInput<'a, BlockWithSenders>,
-        Output = BatchBlockExecutionOutput,
+        Output = BundleStateWithReceipts,
         Error = BlockExecutionError,
     >,
     DB: Database<Error = ProviderError>,
 {
     type Input<'a> = BlockExecutionInput<'a, BlockWithSenders>;
-    type Output = BatchBlockExecutionOutput;
+    type Output = BundleStateWithReceipts;
     type Error = BlockExecutionError;
 
     fn execute_and_verify_one(&mut self, input: Self::Input<'_>) -> Result<(), Self::Error> {

--- a/crates/evm/src/noop.rs
+++ b/crates/evm/src/noop.rs
@@ -1,14 +1,14 @@
 //! A no operation block executor implementation.
 
 use reth_execution_errors::BlockExecutionError;
+use reth_execution_types::BundleStateWithReceipts;
 use reth_primitives::{BlockNumber, BlockWithSenders, Receipt};
 use reth_prune_types::PruneModes;
 use reth_storage_errors::provider::ProviderError;
 use revm_primitives::db::Database;
 
 use crate::execute::{
-    BatchBlockExecutionOutput, BatchExecutor, BlockExecutionInput, BlockExecutionOutput,
-    BlockExecutorProvider, Executor,
+    BatchExecutor, BlockExecutionInput, BlockExecutionOutput, BlockExecutorProvider, Executor,
 };
 
 const UNAVAILABLE_FOR_NOOP: &str = "execution unavailable for noop";
@@ -50,7 +50,7 @@ impl<DB> Executor<DB> for NoopBlockExecutorProvider {
 
 impl<DB> BatchExecutor<DB> for NoopBlockExecutorProvider {
     type Input<'a> = BlockExecutionInput<'a, BlockWithSenders>;
-    type Output = BatchBlockExecutionOutput;
+    type Output = BundleStateWithReceipts;
     type Error = BlockExecutionError;
 
     fn execute_and_verify_one(&mut self, _: Self::Input<'_>) -> Result<(), Self::Error> {

--- a/crates/evm/src/test_utils.rs
+++ b/crates/evm/src/test_utils.rs
@@ -1,8 +1,7 @@
 //! Helpers for testing.
 
 use crate::execute::{
-    BatchBlockExecutionOutput, BatchExecutor, BlockExecutionInput, BlockExecutionOutput,
-    BlockExecutorProvider, Executor,
+    BatchExecutor, BlockExecutionInput, BlockExecutionOutput, BlockExecutorProvider, Executor,
 };
 use parking_lot::Mutex;
 use reth_execution_errors::BlockExecutionError;
@@ -15,12 +14,12 @@ use std::sync::Arc;
 /// A [`BlockExecutorProvider`] that returns mocked execution results.
 #[derive(Clone, Debug, Default)]
 pub struct MockExecutorProvider {
-    exec_results: Arc<Mutex<Vec<BatchBlockExecutionOutput>>>,
+    exec_results: Arc<Mutex<Vec<BundleStateWithReceipts>>>,
 }
 
 impl MockExecutorProvider {
     /// Extend the mocked execution results
-    pub fn extend(&self, results: impl IntoIterator<Item = impl Into<BatchBlockExecutionOutput>>) {
+    pub fn extend(&self, results: impl IntoIterator<Item = impl Into<BundleStateWithReceipts>>) {
         self.exec_results.lock().extend(results.into_iter().map(Into::into));
     }
 }
@@ -51,7 +50,7 @@ impl<DB> Executor<DB> for MockExecutorProvider {
     type Error = BlockExecutionError;
 
     fn execute(self, _: Self::Input<'_>) -> Result<Self::Output, Self::Error> {
-        let BatchBlockExecutionOutput { bundle, receipts, requests, first_block: _ } =
+        let BundleStateWithReceipts { bundle, receipts, requests, first_block: _ } =
             self.exec_results.lock().pop().unwrap();
         Ok(BlockExecutionOutput {
             state: bundle,
@@ -64,7 +63,7 @@ impl<DB> Executor<DB> for MockExecutorProvider {
 
 impl<DB> BatchExecutor<DB> for MockExecutorProvider {
     type Input<'a> = BlockExecutionInput<'a, BlockWithSenders>;
-    type Output = BatchBlockExecutionOutput;
+    type Output = BundleStateWithReceipts;
     type Error = BlockExecutionError;
 
     fn execute_and_verify_one(&mut self, _: Self::Input<'_>) -> Result<(), Self::Error> {

--- a/crates/evm/src/test_utils.rs
+++ b/crates/evm/src/test_utils.rs
@@ -5,6 +5,7 @@ use crate::execute::{
 };
 use parking_lot::Mutex;
 use reth_execution_errors::BlockExecutionError;
+use reth_execution_types::BundleStateWithReceipts;
 use reth_primitives::{BlockNumber, BlockWithSenders, Receipt};
 use reth_prune_types::PruneModes;
 use reth_storage_errors::provider::ProviderError;

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -3,8 +3,8 @@
 use crate::{l1::ensure_create2_deployer, OptimismBlockExecutionError, OptimismEvmConfig};
 use reth_evm::{
     execute::{
-        BatchBlockExecutionOutput, BatchExecutor, BlockExecutionError, BlockExecutionInput,
-        BlockExecutionOutput, BlockExecutorProvider, BlockValidationError, Executor, ProviderError,
+        BatchExecutor, BlockExecutionError, BlockExecutionInput, BlockExecutionOutput,
+        BlockExecutorProvider, BlockValidationError, Executor, ProviderError,
     },
     ConfigureEvm,
 };
@@ -396,7 +396,7 @@ where
     DB: Database<Error = ProviderError>,
 {
     type Input<'a> = BlockExecutionInput<'a, BlockWithSenders>;
-    type Output = BatchBlockExecutionOutput;
+    type Output = BundleStateWithReceipts;
     type Error = BlockExecutionError;
 
     fn execute_and_verify_one(&mut self, input: Self::Input<'_>) -> Result<(), Self::Error> {
@@ -423,7 +423,7 @@ where
     fn finalize(mut self) -> Self::Output {
         self.stats.log_debug();
 
-        BatchBlockExecutionOutput::new(
+        BundleStateWithReceipts::new(
             self.executor.state.take_bundle(),
             self.batch_record.take_receipts(),
             self.batch_record.take_requests(),

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -13,6 +13,7 @@ use reth_primitives::{
     BlockNumber, BlockWithSenders, ChainSpec, Hardfork, Header, Receipt, Receipts, TxType,
     Withdrawals, U256,
 };
+use reth_provider::BundleStateWithReceipts;
 use reth_prune_types::PruneModes;
 use reth_revm::{
     batch::{BlockBatchRecord, BlockExecutorStats},
@@ -426,8 +427,8 @@ where
         BundleStateWithReceipts::new(
             self.executor.state.take_bundle(),
             self.batch_record.take_receipts(),
-            self.batch_record.take_requests(),
             self.batch_record.first_block().unwrap_or_default(),
+            self.batch_record.take_requests(),
         )
     }
 

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -510,6 +510,7 @@ where
         db.take_bundle(),
         Receipts::from_vec(vec![receipts]),
         block_number,
+        Vec::new(),
     );
     let receipts_root = bundle
         .optimism_receipts_root_slow(

--- a/crates/rpc/rpc/src/eth/api/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/api/pending_block.rs
@@ -225,6 +225,7 @@ impl PendingBlockEnv {
             db.take_bundle(),
             Receipts::from_vec(vec![receipts]),
             block_number,
+            Vec::new(),
         );
 
         #[cfg(feature = "optimism")]

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -3,7 +3,7 @@ use num_traits::Zero;
 use reth_config::config::ExecutionConfig;
 use reth_db::{static_file::HeaderMask, tables};
 use reth_db_api::{cursor::DbCursorRO, database::Database, transaction::DbTx};
-use reth_evm::execute::{BatchBlockExecutionOutput, BatchExecutor, BlockExecutorProvider};
+use reth_evm::execute::{BatchExecutor, BlockExecutorProvider};
 use reth_exex::{ExExManagerHandle, ExExNotification};
 use reth_primitives::{
     stage::{
@@ -273,9 +273,9 @@ where
             }
         }
         let time = Instant::now();
-        let BatchBlockExecutionOutput { bundle, receipts, requests: _, first_block } =
+        let BundleStateWithReceipts { bundle, receipts, requests, first_block } =
             executor.finalize();
-        let state = BundleStateWithReceipts::new(bundle, receipts, first_block);
+        let state = BundleStateWithReceipts::new(bundle, receipts, first_block, requests);
         let write_preparation_duration = time.elapsed();
 
         // Check if we should send a [`ExExNotification`] to execution extensions.

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -199,6 +199,7 @@ pub fn insert_state<'a, 'b, DB: Database>(
         contracts.into_iter().collect(),
         Receipts::new(),
         block,
+        Vec::new(),
     );
 
     bundle.write_to_storage(tx, None, OriginalValuesKnown::Yes)?;

--- a/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
+++ b/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
@@ -288,7 +288,7 @@ mod tests {
 
         state.merge_transitions(BundleRetention::Reverts);
 
-        BundleStateWithReceipts::new(state.take_bundle(), Receipts::new(), 1)
+        BundleStateWithReceipts::new(state.take_bundle(), Receipts::new(), 1, Vec::new())
             .write_to_storage(provider.tx_ref(), None, OriginalValuesKnown::Yes)
             .expect("Could not write bundle state to DB");
 
@@ -386,7 +386,7 @@ mod tests {
         )]));
 
         state.merge_transitions(BundleRetention::Reverts);
-        BundleStateWithReceipts::new(state.take_bundle(), Receipts::new(), 2)
+        BundleStateWithReceipts::new(state.take_bundle(), Receipts::new(), 2, Vec::new())
             .write_to_storage(provider.tx_ref(), None, OriginalValuesKnown::Yes)
             .expect("Could not write bundle state to DB");
 
@@ -450,7 +450,7 @@ mod tests {
             },
         )]));
         init_state.merge_transitions(BundleRetention::Reverts);
-        BundleStateWithReceipts::new(init_state.take_bundle(), Receipts::new(), 0)
+        BundleStateWithReceipts::new(init_state.take_bundle(), Receipts::new(), 0, Vec::new())
             .write_to_storage(provider.tx_ref(), None, OriginalValuesKnown::Yes)
             .expect("Could not write init bundle state to DB");
 
@@ -592,7 +592,7 @@ mod tests {
 
         let bundle = state.take_bundle();
 
-        BundleStateWithReceipts::new(bundle, Receipts::new(), 1)
+        BundleStateWithReceipts::new(bundle, Receipts::new(), 1, Vec::new())
             .write_to_storage(provider.tx_ref(), None, OriginalValuesKnown::Yes)
             .expect("Could not write bundle state to DB");
 
@@ -755,7 +755,7 @@ mod tests {
             },
         )]));
         init_state.merge_transitions(BundleRetention::Reverts);
-        BundleStateWithReceipts::new(init_state.take_bundle(), Receipts::new(), 0)
+        BundleStateWithReceipts::new(init_state.take_bundle(), Receipts::new(), 0, Vector::new())
             .write_to_storage(provider.tx_ref(), None, OriginalValuesKnown::Yes)
             .expect("Could not write init bundle state to DB");
 
@@ -800,7 +800,7 @@ mod tests {
 
         // Commit block #1 changes to the database.
         state.merge_transitions(BundleRetention::Reverts);
-        BundleStateWithReceipts::new(state.take_bundle(), Receipts::new(), 1)
+        BundleStateWithReceipts::new(state.take_bundle(), Receipts::new(), 1, Vec::new())
             .write_to_storage(provider.tx_ref(), None, OriginalValuesKnown::Yes)
             .expect("Could not write bundle state to DB");
 
@@ -834,6 +834,7 @@ mod tests {
             bundle: BundleState::default(),
             receipts: Receipts::from_vec(vec![vec![Some(Receipt::default()); 2]; 7]),
             first_block: 10,
+            requests: Vec::new(),
         };
 
         let mut this = base.clone();
@@ -895,10 +896,15 @@ mod tests {
 
         let assert_state_root = |state: &State<EmptyDB>, expected: &PreState, msg| {
             assert_eq!(
-                BundleStateWithReceipts::new(state.bundle_state.clone(), Receipts::default(), 0)
-                    .hash_state_slow()
-                    .state_root(&tx)
-                    .unwrap(),
+                BundleStateWithReceipts::new(
+                    state.bundle_state.clone(),
+                    Receipts::default(),
+                    0,
+                    Vec::new()
+                )
+                .hash_state_slow()
+                .state_root(&tx)
+                .unwrap(),
                 state_root(expected.clone().into_iter().map(|(address, (account, storage))| (
                     address,
                     (account, storage.into_iter())
@@ -1045,6 +1051,7 @@ mod tests {
             bundle: present_state,
             receipts: Receipts::from_vec(vec![vec![Some(Receipt::default()); 2]; 1]),
             first_block: 2,
+            requests: Vec::new(),
         };
 
         test.prepend_state(previous_state);

--- a/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
+++ b/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
@@ -755,7 +755,7 @@ mod tests {
             },
         )]));
         init_state.merge_transitions(BundleRetention::Reverts);
-        BundleStateWithReceipts::new(init_state.take_bundle(), Receipts::new(), 0, Vector::new())
+        BundleStateWithReceipts::new(init_state.take_bundle(), Receipts::new(), 0, Vec::new())
             .write_to_storage(provider.tx_ref(), None, OriginalValuesKnown::Yes)
             .expect("Could not write init bundle state to DB");
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -540,6 +540,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
             Vec::new(),
             reth_primitives::Receipts::from_vec(receipts),
             start_block_number,
+            Vec::new(),
         ))
     }
 

--- a/crates/storage/provider/src/test_utils/blocks.rs
+++ b/crates/storage/provider/src/test_utils/blocks.rs
@@ -166,6 +166,7 @@ fn block1(number: BlockNumber) -> (SealedBlockWithSenders, BundleStateWithReceip
             deposit_receipt_version: None,
         })]]),
         number,
+        Vec::new(),
     );
 
     let state_root = bundle_state_root(&bundle);
@@ -224,6 +225,7 @@ fn block2(
             deposit_receipt_version: None,
         })]]),
         number,
+        Vec::new(),
     );
 
     let mut extended = prev_state.clone();
@@ -292,6 +294,7 @@ fn block3(
             deposit_receipt_version: None,
         })]]),
         number,
+        Vec::new(),
     );
 
     let mut extended = prev_state.clone();
@@ -381,6 +384,7 @@ fn block4(
             deposit_receipt_version: None,
         })]]),
         number,
+        Vec::new(),
     );
 
     let mut extended = prev_state.clone();
@@ -465,6 +469,7 @@ fn block5(
             deposit_receipt_version: None,
         })]]),
         number,
+        Vec::new(),
     );
 
     let mut extended = prev_state.clone();

--- a/examples/exex/op-bridge/src/main.rs
+++ b/examples/exex/op-bridge/src/main.rs
@@ -345,6 +345,7 @@ mod tests {
                 BundleState::default(),
                 Receipts::from_block_receipt(vec![deposit_tx_receipt, withdrawal_tx_receipt]),
                 block.number,
+                vec![block.requests.unwrap_or_default()],
             ),
             None,
         );

--- a/examples/exex/op-bridge/src/main.rs
+++ b/examples/exex/op-bridge/src/main.rs
@@ -345,7 +345,7 @@ mod tests {
                 BundleState::default(),
                 Receipts::from_block_receipt(vec![deposit_tx_receipt, withdrawal_tx_receipt]),
                 block.number,
-                vec![block.requests.unwrap_or_default()],
+                vec![block.requests.clone().unwrap_or_default()],
             ),
             None,
         );


### PR DESCRIPTION
## Summary

This pull request replaces the `BatchBlockExecutionOutput` structure with the new `BundleStateWithReceipts` structure. The change is aimed at simplifying the representation of execution outputs by combining related state and receipt data into a unified structure.

## Details

### Changes Made
 **Structure Replacement**:
   - The `BatchBlockExecutionOutput` structure has been removed.
   - `BundleStateWithReceipts` replaces it with the introduction of `requests` field inside it.

