### PR TITLE
refactor: simplify `Receipts` implementation

### DIFF
--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -26,7 +26,7 @@ use reth_primitives::{
     constants::eip4844::{LoadKzgSettingsError, MAINNET_KZG_TRUSTED_SETUP},
     revm_primitives::KzgSettings,
     stage::StageId,
-    Address, BlobTransaction, BlobTransactionSidecar, Bytes, PooledTransactionsElement, Receipts,
+    Address, BlobTransaction, BlobTransactionSidecar, Bytes, PooledTransactionsElement,
     SealedBlock, SealedBlockWithSenders, Transaction, TransactionSigned, TxEip4844, B256, U256,
 };
 use reth_provider::{
@@ -273,11 +273,7 @@ impl Command {
 
                 let BlockExecutionOutput { state, receipts, .. } =
                     executor.execute((&block_with_senders.clone().unseal(), U256::MAX).into())?;
-                let state = BundleStateWithReceipts::new(
-                    state,
-                    Receipts::from_block_receipt(receipts),
-                    block.number,
-                );
+                let state = BundleStateWithReceipts::new(state, receipts.into(), block.number);
                 debug!(target: "reth::cli", ?state, "Executed block");
 
                 let hashed_state = state.hash_state_slow();

--- a/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
@@ -15,7 +15,7 @@ use reth_errors::BlockValidationError;
 use reth_evm::execute::{BlockExecutionOutput, BlockExecutorProvider, Executor};
 use reth_network::NetworkHandle;
 use reth_network_api::NetworkInfo;
-use reth_primitives::{stage::StageId, BlockHashOrNumber, Receipts};
+use reth_primitives::{stage::StageId, BlockHashOrNumber};
 use reth_provider::{
     AccountExtReader, BundleStateWithReceipts, ChainSpecProvider, HashingWriter, HeaderProvider,
     LatestStateProviderRef, OriginalValuesKnown, ProviderFactory, StageCheckpointReader,
@@ -146,11 +146,7 @@ impl Command {
             )
                 .into(),
         )?;
-        let block_state = BundleStateWithReceipts::new(
-            state,
-            Receipts::from_block_receipt(receipts),
-            block.number,
-        );
+        let block_state = BundleStateWithReceipts::new(state, receipts.into(), block.number);
 
         // Unpacked `BundleState::state_root_slow` function
         let (in_memory_state_root, in_memory_updates) =

--- a/crates/blockchain-tree/src/chain.rs
+++ b/crates/blockchain-tree/src/chain.rs
@@ -14,8 +14,7 @@ use reth_db_api::database::Database;
 use reth_evm::execute::{BlockExecutionOutput, BlockExecutorProvider, Executor};
 use reth_execution_errors::BlockExecutionError;
 use reth_primitives::{
-    BlockHash, BlockNumber, ForkBlock, GotExpected, Receipts, SealedBlockWithSenders, SealedHeader,
-    U256,
+    BlockHash, BlockNumber, ForkBlock, GotExpected, SealedBlockWithSenders, SealedHeader, U256,
 };
 use reth_provider::{
     providers::{BundleStateProvider, ConsistentDbView},
@@ -215,11 +214,7 @@ impl AppendableChain {
             .consensus
             .validate_block_post_execution(&block, PostExecutionInput::new(&receipts, &requests))?;
 
-        let bundle_state = BundleStateWithReceipts::new(
-            state,
-            Receipts::from_block_receipt(receipts),
-            block.number,
-        );
+        let bundle_state = BundleStateWithReceipts::new(state, receipts.into(), block.number);
 
         // check state root if the block extends the canonical chain __and__ if state root
         // validation was requested.

--- a/crates/consensus/auto-seal/src/lib.rs
+++ b/crates/consensus/auto-seal/src/lib.rs
@@ -23,8 +23,8 @@ use reth_primitives::{
     constants::{EMPTY_TRANSACTIONS, ETHEREUM_BLOCK_GAS_LIMIT},
     eip4844::calculate_excess_blob_gas,
     proofs, Block, BlockBody, BlockHash, BlockHashOrNumber, BlockNumber, BlockWithSenders,
-    ChainSpec, Header, Receipts, Requests, SealedBlock, SealedHeader, TransactionSigned,
-    Withdrawals, B256, U256,
+    ChainSpec, Header, Requests, SealedBlock, SealedHeader, TransactionSigned, Withdrawals, B256,
+    U256,
 };
 use reth_provider::{
     BlockReaderIdExt, BundleStateWithReceipts, StateProviderFactory, StateRootProvider,
@@ -391,11 +391,7 @@ impl StorageInner {
         // execute the block
         let BlockExecutionOutput { state, receipts, .. } =
             executor.executor(&mut db).execute((&block, U256::ZERO).into())?;
-        let bundle_state = BundleStateWithReceipts::new(
-            state,
-            Receipts::from_block_receipt(receipts),
-            block.number,
-        );
+        let bundle_state = BundleStateWithReceipts::new(state, receipts.into(), block.number);
 
         // todo(onbjerg): we should not pass requests around as this is building a block, which
         // means we need to extract the requests from the execution output and compute the requests

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -27,7 +27,7 @@ use reth_primitives::{
     eip4844::calculate_excess_blob_gas,
     proofs::{self, calculate_requests_root},
     revm::env::tx_env_with_recovered,
-    Block, Header, IntoRecoveredTransaction, Receipt, Receipts, EMPTY_OMMER_ROOT_HASH, U256,
+    Block, Header, IntoRecoveredTransaction, Receipt, EMPTY_OMMER_ROOT_HASH, U256,
 };
 use reth_provider::{BundleStateWithReceipts, StateProviderFactory};
 use reth_revm::{database::StateProviderDatabase, state_change::apply_blockhashes_update};
@@ -444,11 +444,8 @@ where
     // and 4788 contract call
     db.merge_transitions(BundleRetention::PlainState);
 
-    let bundle = BundleStateWithReceipts::new(
-        db.take_bundle(),
-        Receipts::from_vec(vec![receipts]),
-        block_number,
-    );
+    let bundle =
+        BundleStateWithReceipts::new(db.take_bundle(), vec![receipts].into(), block_number);
     let receipts_root = bundle.receipts_root_slow(block_number).expect("Number is in range");
     let logs_bloom = bundle.block_logs_bloom(block_number).expect("Number is in range");
 

--- a/crates/evm/execution-types/src/bundle.rs
+++ b/crates/evm/execution-types/src/bundle.rs
@@ -271,7 +271,7 @@ impl BundleStateWithReceipts {
 
         // Truncate higher state to [at..].
         let at_idx = higher_state.block_number_to_index(at).unwrap();
-        higher_state.receipts = Receipts::from_vec(higher_state.receipts.split_off(at_idx));
+        higher_state.receipts = higher_state.receipts.split_off(at_idx).into();
         higher_state.bundle.take_n_reverts(at_idx);
         higher_state.first_block = at;
 

--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -476,7 +476,7 @@ pub enum ChainSplit {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use reth_primitives::{Receipts, B256};
+    use reth_primitives::B256;
     use revm::primitives::{AccountInfo, HashMap};
 
     #[test]

--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -524,7 +524,7 @@ mod tests {
                 vec![vec![(Address::new([2; 20]), None, vec![])]],
                 vec![],
             ),
-            Receipts::from_vec(vec![vec![]]),
+            vec![vec![]].into(),
             1,
         );
 
@@ -539,7 +539,7 @@ mod tests {
                 vec![vec![(Address::new([3; 20]), None, vec![])]],
                 vec![],
             ),
-            Receipts::from_vec(vec![vec![]]),
+            vec![vec![]].into(),
             2,
         );
 

--- a/crates/net/downloaders/src/receipt_file_client.rs
+++ b/crates/net/downloaders/src/receipt_file_client.rs
@@ -34,7 +34,7 @@ impl FromReader for ReceiptFileClient {
     where
         B: AsyncReadExt + Unpin,
     {
-        let mut receipts = Receipts::new();
+        let mut receipts = Receipts::default();
 
         // use with_capacity to make sure the internal buffer contains the entire chunk
         let mut stream =

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -506,11 +506,8 @@ where
     // and 4788 contract call
     db.merge_transitions(BundleRetention::PlainState);
 
-    let bundle = BundleStateWithReceipts::new(
-        db.take_bundle(),
-        Receipts::from_vec(vec![receipts]),
-        block_number,
-    );
+    let bundle =
+        BundleStateWithReceipts::new(db.take_bundle(), vec![receipts].into(), block_number);
     let receipts_root = bundle
         .optimism_receipts_root_slow(
             block_number,

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -12,7 +12,7 @@ use reth_primitives::{
     eip4844::calculate_excess_blob_gas,
     proofs,
     revm::env::tx_env_with_recovered,
-    Block, ChainSpec, Hardfork, Header, IntoRecoveredTransaction, Receipt, Receipts, TxType,
+    Block, ChainSpec, Hardfork, Header, IntoRecoveredTransaction, Receipt, TxType,
     EMPTY_OMMER_ROOT_HASH, U256,
 };
 use reth_provider::{BundleStateWithReceipts, StateProviderFactory};

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -72,21 +72,6 @@ pub struct Receipts {
 }
 
 impl Receipts {
-    /// Create a new `Receipts` instance with an empty vector.
-    pub const fn new() -> Self {
-        Self { receipt_vec: vec![] }
-    }
-
-    /// Create a new `Receipts` instance from an existing vector.
-    pub fn from_vec(vec: Vec<Vec<Option<Receipt>>>) -> Self {
-        Self { receipt_vec: vec }
-    }
-
-    /// Create a new `Receipts` instance from a single block receipt.
-    pub fn from_block_receipt(block_receipts: Vec<Receipt>) -> Self {
-        Self { receipt_vec: vec![block_receipts.into_iter().map(Option::Some).collect()] }
-    }
-
     /// Returns the length of the `Receipts` vector.
     pub fn len(&self) -> usize {
         self.receipt_vec.len()
@@ -125,6 +110,18 @@ impl Receipts {
     }
 }
 
+impl From<Vec<Vec<Option<Receipt>>>> for Receipts {
+    fn from(receipt_vec: Vec<Vec<Option<Receipt>>>) -> Self {
+        Self { receipt_vec }
+    }
+}
+
+impl From<Vec<Receipt>> for Receipts {
+    fn from(block_receipts: Vec<Receipt>) -> Self {
+        Self { receipt_vec: vec![block_receipts.into_iter().map(Option::Some).collect()] }
+    }
+}
+
 impl Deref for Receipts {
     type Target = Vec<Vec<Option<Receipt>>>;
 
@@ -150,7 +147,7 @@ impl IntoIterator for Receipts {
 
 impl FromIterator<Vec<Option<Receipt>>> for Receipts {
     fn from_iter<I: IntoIterator<Item = Vec<Option<Receipt>>>>(iter: I) -> Self {
-        Self::from_vec(iter.into_iter().collect())
+        iter.into_iter().collect::<Vec<_>>().into()
     }
 }
 

--- a/crates/rpc/rpc/src/eth/api/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/api/pending_block.rs
@@ -11,7 +11,7 @@ use reth_primitives::{
     },
     trie::EMPTY_ROOT_HASH,
     Block, BlockId, BlockNumberOrTag, ChainSpec, Header, IntoRecoveredTransaction, Receipt,
-    Receipts, Requests, SealedBlockWithSenders, SealedHeader, B256, EMPTY_OMMER_ROOT_HASH, U256,
+    Requests, SealedBlockWithSenders, SealedHeader, B256, EMPTY_OMMER_ROOT_HASH, U256,
 };
 use reth_provider::{BundleStateWithReceipts, ChainSpecProvider, StateProviderFactory};
 use reth_revm::{
@@ -221,11 +221,8 @@ impl PendingBlockEnv {
         // merge all transitions into bundle state.
         db.merge_transitions(BundleRetention::PlainState);
 
-        let bundle = BundleStateWithReceipts::new(
-            db.take_bundle(),
-            Receipts::from_vec(vec![receipts]),
-            block_number,
-        );
+        let bundle =
+            BundleStateWithReceipts::new(db.take_bundle(), vec![receipts].into(), block_number);
 
         #[cfg(feature = "optimism")]
         let receipts_root = bundle

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -197,7 +197,7 @@ pub fn insert_state<'a, 'b, DB: Database>(
         state_init,
         all_reverts_init,
         contracts.into_iter().collect(),
-        Receipts::new(),
+        Receipts::default(),
         block,
     );
 

--- a/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
+++ b/crates/storage/provider/src/bundle_state/bundle_state_with_receipts.rs
@@ -288,7 +288,7 @@ mod tests {
 
         state.merge_transitions(BundleRetention::Reverts);
 
-        BundleStateWithReceipts::new(state.take_bundle(), Receipts::new(), 1)
+        BundleStateWithReceipts::new(state.take_bundle(), Receipts::default(), 1)
             .write_to_storage(provider.tx_ref(), None, OriginalValuesKnown::Yes)
             .expect("Could not write bundle state to DB");
 
@@ -386,7 +386,7 @@ mod tests {
         )]));
 
         state.merge_transitions(BundleRetention::Reverts);
-        BundleStateWithReceipts::new(state.take_bundle(), Receipts::new(), 2)
+        BundleStateWithReceipts::new(state.take_bundle(), Receipts::default(), 2)
             .write_to_storage(provider.tx_ref(), None, OriginalValuesKnown::Yes)
             .expect("Could not write bundle state to DB");
 
@@ -450,7 +450,7 @@ mod tests {
             },
         )]));
         init_state.merge_transitions(BundleRetention::Reverts);
-        BundleStateWithReceipts::new(init_state.take_bundle(), Receipts::new(), 0)
+        BundleStateWithReceipts::new(init_state.take_bundle(), Receipts::default(), 0)
             .write_to_storage(provider.tx_ref(), None, OriginalValuesKnown::Yes)
             .expect("Could not write init bundle state to DB");
 
@@ -592,7 +592,7 @@ mod tests {
 
         let bundle = state.take_bundle();
 
-        BundleStateWithReceipts::new(bundle, Receipts::new(), 1)
+        BundleStateWithReceipts::new(bundle, Receipts::default(), 1)
             .write_to_storage(provider.tx_ref(), None, OriginalValuesKnown::Yes)
             .expect("Could not write bundle state to DB");
 
@@ -755,7 +755,7 @@ mod tests {
             },
         )]));
         init_state.merge_transitions(BundleRetention::Reverts);
-        BundleStateWithReceipts::new(init_state.take_bundle(), Receipts::new(), 0)
+        BundleStateWithReceipts::new(init_state.take_bundle(), Receipts::default(), 0)
             .write_to_storage(provider.tx_ref(), None, OriginalValuesKnown::Yes)
             .expect("Could not write init bundle state to DB");
 
@@ -800,7 +800,7 @@ mod tests {
 
         // Commit block #1 changes to the database.
         state.merge_transitions(BundleRetention::Reverts);
-        BundleStateWithReceipts::new(state.take_bundle(), Receipts::new(), 1)
+        BundleStateWithReceipts::new(state.take_bundle(), Receipts::default(), 1)
             .write_to_storage(provider.tx_ref(), None, OriginalValuesKnown::Yes)
             .expect("Could not write bundle state to DB");
 
@@ -832,7 +832,7 @@ mod tests {
     fn revert_to_indices() {
         let base = BundleStateWithReceipts {
             bundle: BundleState::default(),
-            receipts: Receipts::from_vec(vec![vec![Some(Receipt::default()); 2]; 7]),
+            receipts: vec![vec![Some(Receipt::default()); 2]; 7].into(),
             first_block: 10,
         };
 
@@ -1043,7 +1043,7 @@ mod tests {
 
         let mut test = BundleStateWithReceipts {
             bundle: present_state,
-            receipts: Receipts::from_vec(vec![vec![Some(Receipt::default()); 2]; 1]),
+            receipts: vec![vec![Some(Receipt::default()); 2]; 1].into(),
             first_block: 2,
         };
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -538,7 +538,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
             state,
             reverts,
             Vec::new(),
-            reth_primitives::Receipts::from_vec(receipts),
+            receipts.into(),
             start_block_number,
         ))
     }

--- a/crates/storage/provider/src/test_utils/blocks.rs
+++ b/crates/storage/provider/src/test_utils/blocks.rs
@@ -4,14 +4,13 @@ use alloy_primitives::Log;
 use alloy_rlp::Decodable;
 use reth_db::tables;
 use reth_db_api::{database::Database, models::StoredBlockBodyIndices};
-
 use reth_primitives::{
     alloy_primitives, b256,
     hex_literal::hex,
     proofs::{state_root_unhashed, storage_root_unhashed},
     revm::compat::into_reth_acc,
-    Address, BlockNumber, Bytes, Header, Receipt, Receipts, Requests, SealedBlock,
-    SealedBlockWithSenders, TxType, Withdrawal, Withdrawals, B256, U256,
+    Address, BlockNumber, Bytes, Header, Receipt, Requests, SealedBlock, SealedBlockWithSenders,
+    TxType, Withdrawal, Withdrawals, B256, U256,
 };
 use revm::{
     db::BundleState,
@@ -151,7 +150,7 @@ fn block1(number: BlockNumber) -> (SealedBlockWithSenders, BundleStateWithReceip
             .revert_account_info(number, account2, Some(None))
             .state_storage(account1, HashMap::from([(slot, (U256::ZERO, U256::from(10)))]))
             .build(),
-        Receipts::from_vec(vec![vec![Some(Receipt {
+        vec![vec![Some(Receipt {
             tx_type: TxType::Eip2930,
             success: true,
             cumulative_gas_used: 300,
@@ -164,7 +163,8 @@ fn block1(number: BlockNumber) -> (SealedBlockWithSenders, BundleStateWithReceip
             deposit_nonce: None,
             #[cfg(feature = "optimism")]
             deposit_receipt_version: None,
-        })]]),
+        })]]
+        .into(),
         number,
     );
 
@@ -209,7 +209,7 @@ fn block2(
             )
             .revert_storage(number, account, Vec::from([(slot, U256::from(10))]))
             .build(),
-        Receipts::from_vec(vec![vec![Some(Receipt {
+        vec![vec![Some(Receipt {
             tx_type: TxType::Eip1559,
             success: false,
             cumulative_gas_used: 400,
@@ -222,7 +222,8 @@ fn block2(
             deposit_nonce: None,
             #[cfg(feature = "optimism")]
             deposit_receipt_version: None,
-        })]]),
+        })]]
+        .into(),
         number,
     );
 
@@ -277,7 +278,7 @@ fn block3(
     }
     let bundle = BundleStateWithReceipts::new(
         bundle_state_builder.build(),
-        Receipts::from_vec(vec![vec![Some(Receipt {
+        vec![vec![Some(Receipt {
             tx_type: TxType::Eip1559,
             success: true,
             cumulative_gas_used: 400,
@@ -290,7 +291,8 @@ fn block3(
             deposit_nonce: None,
             #[cfg(feature = "optimism")]
             deposit_receipt_version: None,
-        })]]),
+        })]]
+        .into(),
         number,
     );
 
@@ -366,7 +368,7 @@ fn block4(
     }
     let bundle = BundleStateWithReceipts::new(
         bundle_state_builder.build(),
-        Receipts::from_vec(vec![vec![Some(Receipt {
+        vec![vec![Some(Receipt {
             tx_type: TxType::Eip1559,
             success: true,
             cumulative_gas_used: 400,
@@ -379,7 +381,8 @@ fn block4(
             deposit_nonce: None,
             #[cfg(feature = "optimism")]
             deposit_receipt_version: None,
-        })]]),
+        })]]
+        .into(),
         number,
     );
 
@@ -450,7 +453,7 @@ fn block5(
     }
     let bundle = BundleStateWithReceipts::new(
         bundle_state_builder.build(),
-        Receipts::from_vec(vec![vec![Some(Receipt {
+        vec![vec![Some(Receipt {
             tx_type: TxType::Eip1559,
             success: true,
             cumulative_gas_used: 400,
@@ -463,7 +466,8 @@ fn block5(
             deposit_nonce: None,
             #[cfg(feature = "optimism")]
             deposit_receipt_version: None,
-        })]]),
+        })]]
+        .into(),
         number,
     );
 

--- a/examples/exex/op-bridge/src/main.rs
+++ b/examples/exex/op-bridge/src/main.rs
@@ -343,7 +343,7 @@ mod tests {
             vec![block.clone()],
             BundleStateWithReceipts::new(
                 BundleState::default(),
-                Receipts::from_block_receipt(vec![deposit_tx_receipt, withdrawal_tx_receipt]),
+                vec![deposit_tx_receipt, withdrawal_tx_receipt].into(),
                 block.number,
             ),
             None,

--- a/examples/exex/op-bridge/src/main.rs
+++ b/examples/exex/op-bridge/src/main.rs
@@ -261,8 +261,8 @@ mod tests {
     use reth::revm::db::BundleState;
     use reth_exex_test_utils::{test_exex_context, PollOnce};
     use reth_primitives::{
-        Address, Block, Header, Log, Receipt, Receipts, Transaction, TransactionSigned, TxKind,
-        TxLegacy, TxType, U256,
+        Address, Block, Header, Log, Receipt, Transaction, TransactionSigned, TxKind, TxLegacy,
+        TxType, U256,
     };
     use reth_provider::{BundleStateWithReceipts, Chain};
     use reth_testing_utils::generators::sign_tx_with_random_key_pair;


### PR DESCRIPTION
- `new` function is removed as it does exactly the same as `default` which is already derived.
- `from_vec` and `from_block_receipt` are replaced by `From` implementations for a less verbose and more concise usage.