### PR TITLE
feat: add secp256k1 feature in reth-network-peers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -281,7 +281,7 @@ reth-net-common = { path = "crates/net/common" }
 reth-net-nat = { path = "crates/net/nat" }
 reth-network = { path = "crates/net/network" }
 reth-network-api = { path = "crates/net/network-api" }
-reth-network-peers = { path = "crates/net/peers" }
+reth-network-peers = { path = "crates/net/peers", default-features = false }
 reth-network-p2p = { path = "crates/net/p2p" }
 reth-nippy-jar = { path = "crates/storage/nippy-jar" }
 reth-node-api = { path = "crates/node/api" }

--- a/crates/net/discv4/Cargo.toml
+++ b/crates/net/discv4/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 reth-primitives.workspace = true
 reth-net-common.workspace = true
 reth-net-nat.workspace = true
-reth-network-peers.workspace = true
+reth-network-peers = { workspace = true, features = ["secp256k1"] }
 
 # ethereum
 alloy-rlp = { workspace = true, features = ["derive"] }

--- a/crates/net/discv5/Cargo.toml
+++ b/crates/net/discv5/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 # reth
 reth-primitives.workspace = true
 reth-metrics.workspace = true
-reth-network-peers.workspace = true
+reth-network-peers = { workspace = true, features = ["secp256k1"] }
 
 # ethereum
 alloy-rlp.workspace = true

--- a/crates/net/dns/Cargo.toml
+++ b/crates/net/dns/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 # reth
 reth-primitives.workspace = true
 reth-net-common.workspace = true
-reth-network-peers.workspace = true
+reth-network-peers = { workspace = true, features = ["secp256k1"] }
 
 # ethereum
 secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery", "serde"] }

--- a/crates/net/ecies/Cargo.toml
+++ b/crates/net/ecies/Cargo.toml
@@ -35,11 +35,7 @@ byteorder = "1.4.3"
 rand.workspace = true
 ctr = "0.9.2"
 digest = "0.10.5"
-secp256k1 = { workspace = true, features = [
-    "global-context",
-    "rand-std",
-    "recovery",
-] }
+secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery"] }
 concat-kdf = "0.1.0"
 sha2 = "0.10.6"
 sha3 = "0.10.5"

--- a/crates/net/ecies/Cargo.toml
+++ b/crates/net/ecies/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 reth-primitives.workspace = true
 reth-net-common.workspace = true
-reth-network-peers.workspace = true
+reth-network-peers = { workspace = true, features = ["secp256k1"] }
 
 alloy-rlp = { workspace = true, features = ["derive"] }
 futures.workspace = true
@@ -35,7 +35,11 @@ byteorder = "1.4.3"
 rand.workspace = true
 ctr = "0.9.2"
 digest = "0.10.5"
-secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery"] }
+secp256k1 = { workspace = true, features = [
+    "global-context",
+    "rand-std",
+    "recovery",
+] }
 concat-kdf = "0.1.0"
 sha2 = "0.10.6"
 sha3 = "0.10.5"

--- a/crates/net/peers/Cargo.toml
+++ b/crates/net/peers/Cargo.toml
@@ -19,8 +19,8 @@ alloy-rlp = { workspace = true, features = ["derive"] }
 enr.workspace = true
 
 # crypto
-secp256k1.workspace = true
 
+secp256k1 = { workspace = true, optional = true }
 # misc
 serde_with.workspace = true
 thiserror.workspace = true
@@ -32,3 +32,7 @@ alloy-primitives = { workspace = true, features = ["rand"] }
 rand.workspace = true
 secp256k1 = { workspace = true, features = ["rand"] }
 serde_json.workspace = true
+
+[features]
+default = []
+secp256k1 = ["dep:secp256k1"]

--- a/crates/net/peers/Cargo.toml
+++ b/crates/net/peers/Cargo.toml
@@ -34,5 +34,4 @@ secp256k1 = { workspace = true, features = ["rand"] }
 serde_json.workspace = true
 
 [features]
-default = []
 secp256k1 = ["dep:secp256k1"]

--- a/crates/net/peers/src/node_record.rs
+++ b/crates/net/peers/src/node_record.rs
@@ -8,10 +8,14 @@ use std::{
     str::FromStr,
 };
 
-use crate::{pk2id, PeerId};
+use crate::PeerId;
 use alloy_rlp::{RlpDecodable, RlpEncodable};
-use enr::Enr;
 use serde_with::{DeserializeFromStr, SerializeDisplay};
+
+#[cfg(feature = "secp256k1")]
+use crate::pk2id;
+#[cfg(feature = "secp256k1")]
+use enr::Enr;
 
 /// Represents a ENR in discovery.
 ///
@@ -40,6 +44,7 @@ pub struct NodeRecord {
 }
 
 impl NodeRecord {
+    #[cfg(feature = "secp256k1")]
     /// Derive the [`NodeRecord`] from the secret key and addr
     pub fn from_secret_key(addr: SocketAddr, sk: &secp256k1::SecretKey) -> Self {
         let pk = secp256k1::PublicKey::from_secret_key(secp256k1::SECP256K1, sk);
@@ -169,6 +174,7 @@ impl FromStr for NodeRecord {
     }
 }
 
+#[cfg(feature = "secp256k1")]
 impl TryFrom<&Enr<secp256k1::SecretKey>> for NodeRecord {
     type Error = NodeRecordParseError;
 

--- a/crates/net/peers/src/node_record.rs
+++ b/crates/net/peers/src/node_record.rs
@@ -13,8 +13,6 @@ use alloy_rlp::{RlpDecodable, RlpEncodable};
 use serde_with::{DeserializeFromStr, SerializeDisplay};
 
 #[cfg(feature = "secp256k1")]
-use crate::pk2id;
-#[cfg(feature = "secp256k1")]
 use enr::Enr;
 
 /// Represents a ENR in discovery.
@@ -192,7 +190,7 @@ impl TryFrom<&Enr<secp256k1::SecretKey>> for NodeRecord {
             return Err(NodeRecordParseError::InvalidUrl("tcp port missing".to_string()))
         };
 
-        let id = pk2id(&enr.public_key());
+        let id = crate::pk2id(&enr.public_key());
 
         Ok(Self { address, tcp_port, udp_port, id }.into_ipv4_mapped())
     }

--- a/crates/net/peers/src/trusted_peer.rs
+++ b/crates/net/peers/src/trusted_peer.rs
@@ -32,8 +32,8 @@ pub struct TrustedPeer {
 }
 
 impl TrustedPeer {
-    #[cfg(feature = "secp256k1")]
     /// Derive the [`NodeRecord`] from the secret key and addr
+    #[cfg(feature = "secp256k1")]
     pub fn from_secret_key(host: Host, port: u16, sk: &secp256k1::SecretKey) -> Self {
         let pk = secp256k1::PublicKey::from_secret_key(secp256k1::SECP256K1, sk);
         let id = PeerId::from_slice(&pk.serialize_uncompressed()[1..]);

--- a/crates/net/peers/src/trusted_peer.rs
+++ b/crates/net/peers/src/trusted_peer.rs
@@ -32,6 +32,7 @@ pub struct TrustedPeer {
 }
 
 impl TrustedPeer {
+    #[cfg(feature = "secp256k1")]
     /// Derive the [`NodeRecord`] from the secret key and addr
     pub fn from_secret_key(host: Host, port: u16, sk: &secp256k1::SecretKey) -> Self {
         let pk = secp256k1::PublicKey::from_secret_key(secp256k1::SECP256K1, sk);


### PR DESCRIPTION
- Adds secp256k1 feature to reth-network-peers crate
- Disables default features in workspace for reth-network-peers
- Enables secp256k1 for reth-network-peers crate in reth-ecies, reth-discv4,reth-discv5, reth-dns-discovery crates

Closes #8700 