### PR TITLE
feat(stages): send a notification to ExExes only when Execution stage commits

### DIFF
--- a/crates/node/builder/src/launch/exex.rs
+++ b/crates/node/builder/src/launch/exex.rs
@@ -71,7 +71,7 @@ impl<Node: FullNodeComponents + Clone> ExExLauncher<Node> {
                 executor.spawn_critical("exex", async move {
                     info!(target: "reth::cli", "ExEx started");
                     match exex.await {
-                        Ok(_) => panic!("ExEx {id} finished. ExEx's should run indefinitely"),
+                        Ok(_) => panic!("ExEx {id} finished. ExExes should run indefinitely"),
                         Err(err) => panic!("ExEx {id} crashed: {err}"),
                     }
                 });

--- a/crates/stages/api/src/pipeline/mod.rs
+++ b/crates/stages/api/src/pipeline/mod.rs
@@ -369,6 +369,8 @@ where
                         provider_rw.commit()?;
                         self.provider_factory.static_file_provider().commit()?;
 
+                        stage.post_unwind_commit()?;
+
                         provider_rw = self.provider_factory.provider_rw()?;
                     }
                     Err(err) => {
@@ -478,6 +480,8 @@ where
                     // start-up.
                     self.provider_factory.static_file_provider().commit()?;
                     provider_rw.commit()?;
+
+                    stage.post_execute_commit()?;
 
                     if done {
                         let block_number = checkpoint.block_number;

--- a/crates/stages/api/src/stage.rs
+++ b/crates/stages/api/src/stage.rs
@@ -253,6 +253,15 @@ pub trait Stage<DB: Database>: Send + Sync {
         provider: &DatabaseProviderRW<DB>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError>;
+
+    /// Post unwind commit hook.
+    ///
+    /// This is called after the stage has been unwound and the database transaction has been
+    /// committed. The stage may want to pass some data from [`Self::unwind`] via the internal
+    /// field of struct.
+    fn post_unwind_commit(&mut self) -> Result<(), StageError> {
+        Ok(())
+    }
 }
 
 /// [Stage] trait extension.

--- a/crates/stages/api/src/stage.rs
+++ b/crates/stages/api/src/stage.rs
@@ -240,8 +240,9 @@ pub trait Stage<DB: Database>: Send + Sync {
 
     /// Post execution commit hook.
     ///
-    /// This is called after the stage has been executed and the provider has been committed.
-    /// The stage may want to pass some data from [`Self::execute`] via the internal field.
+    /// This is called after the stage has been executed and the data has been committed by the
+    /// provider. The stage may want to pass some data from [`Self::execute`] via the internal
+    /// field.
     fn post_execute_commit(&mut self) -> Result<(), StageError> {
         Ok(())
     }
@@ -255,8 +256,9 @@ pub trait Stage<DB: Database>: Send + Sync {
 
     /// Post unwind commit hook.
     ///
-    /// This is called after the stage has been unwound and the provider has been committed.
-    /// The stage may want to pass some data from [`Self::unwind`] via the internal field.
+    /// This is called after the stage has been unwound and the data has been committed by the
+    /// provider. The stage may want to pass some data from [`Self::unwind`] via the internal
+    /// field.
     fn post_unwind_commit(&mut self) -> Result<(), StageError> {
         Ok(())
     }

--- a/crates/stages/api/src/stage.rs
+++ b/crates/stages/api/src/stage.rs
@@ -238,6 +238,15 @@ pub trait Stage<DB: Database>: Send + Sync {
         input: ExecInput,
     ) -> Result<ExecOutput, StageError>;
 
+    /// Post execution commit hook.
+    ///
+    /// This is called after the stage has been executed and the database transaction has been
+    /// committed. The stage may want to pass some data from [`Self::execute`] via the internal
+    /// field of struct.
+    fn post_execute_commit(&mut self) -> Result<(), StageError> {
+        Ok(())
+    }
+
     /// Unwind the stage.
     fn unwind(
         &mut self,

--- a/crates/stages/api/src/stage.rs
+++ b/crates/stages/api/src/stage.rs
@@ -240,9 +240,8 @@ pub trait Stage<DB: Database>: Send + Sync {
 
     /// Post execution commit hook.
     ///
-    /// This is called after the stage has been executed and the database transaction has been
-    /// committed. The stage may want to pass some data from [`Self::execute`] via the internal
-    /// field of struct.
+    /// This is called after the stage has been executed and the provider has been committed.
+    /// The stage may want to pass some data from [`Self::execute`] via the internal field.
     fn post_execute_commit(&mut self) -> Result<(), StageError> {
         Ok(())
     }
@@ -256,9 +255,8 @@ pub trait Stage<DB: Database>: Send + Sync {
 
     /// Post unwind commit hook.
     ///
-    /// This is called after the stage has been unwound and the database transaction has been
-    /// committed. The stage may want to pass some data from [`Self::unwind`] via the internal
-    /// field of struct.
+    /// This is called after the stage has been unwound and the provider has been committed.
+    /// The stage may want to pass some data from [`Self::unwind`] via the internal field.
     fn post_unwind_commit(&mut self) -> Result<(), StageError> {
         Ok(())
     }

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -309,6 +309,10 @@ where
             });
             let previous_input =
                 self.post_execute_commit_input.replace(Chain::new(blocks, state.clone(), None));
+            debug_assert!(
+                previous_input.is_none(),
+                "Previous post execute commit input wasn't processed"
+            );
             if let Some(previous_input) = previous_input {
                 tracing::debug!(target: "sync::stages::execution", ?previous_input, "Previous post execute commit input wasn't processed");
             }
@@ -379,6 +383,10 @@ where
                 bundle_state_with_receipts,
                 None,
             ));
+            debug_assert!(
+                previous_input.is_none(),
+                "Previous post unwind commit input wasn't processed"
+            );
             if let Some(previous_input) = previous_input {
                 tracing::debug!(target: "sync::stages::execution", ?previous_input, "Previous post unwind commit input wasn't processed");
             }

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -75,7 +75,13 @@ pub struct ExecutionStage<E> {
     external_clean_threshold: u64,
     /// Pruning configuration.
     prune_modes: PruneModes,
+    /// Input for the post execute commit hook.
+    /// Set after every [`ExecutionStage::execute`] and cleared after
+    /// [`ExecutionStage::post_execute_commit`].
     post_execute_commit_input: Option<Chain>,
+    /// Input for the post unwind commit hook.
+    /// Set after every [`ExecutionStage::unwind`] and cleared after
+    /// [`ExecutionStage::post_unwind_commit`].
     post_unwind_commit_input: Option<Chain>,
     /// Handle to communicate with `ExEx` manager.
     exex_manager_handle: ExExManagerHandle,


### PR DESCRIPTION
Fixes https://github.com/paradigmxyz/reth/issues/8696 by separating the `ExExNotification` sending from the `execute` and `unwind` methods. It ensures that the stage provider commits before sending a notification, making the data available for querying on the receiver end of an ExEx.