### PR TITLE
feat: support `no_std` for `reth-execution-errors`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6898,7 +6898,7 @@ dependencies = [
  "reth-primitives",
  "reth-prune-types",
  "reth-storage-errors",
- "thiserror",
+ "thiserror-no-std",
 ]
 
 [[package]]
@@ -9419,6 +9419,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.66",
+]
+
+[[package]]
+name = "thiserror-impl-no-std"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58e6318948b519ba6dc2b442a6d0b904ebfb8d411a3ad3e07843615a72249758"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "thiserror-no-std"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ad459d94dd517257cc96add8a43190ee620011bb6e6cdc82dafd97dfafafea"
+dependencies = [
+ "thiserror-impl-no-std",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -366,7 +366,7 @@ generic-array = "0.14"
 tracing = "0.1.0"
 tracing-appender = "0.2"
 thiserror = "1.0"
-thiserror-no-std = "2.0.2"
+thiserror-no-std = { version = "2.0.2", default-features = false }
 serde_json = "1.0.94"
 serde = { version = "1.0", default-features = false }
 serde_with = "3.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -366,6 +366,7 @@ generic-array = "0.14"
 tracing = "0.1.0"
 tracing-appender = "0.2"
 thiserror = "1.0"
+thiserror-no-std = "=2.0.2"
 serde_json = "1.0.94"
 serde = { version = "1.0", default-features = false }
 serde_with = "3.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -366,7 +366,7 @@ generic-array = "0.14"
 tracing = "0.1.0"
 tracing-appender = "0.2"
 thiserror = "1.0"
-thiserror-no-std = "=2.0.2"
+thiserror-no-std = "2.0.2"
 serde_json = "1.0.94"
 serde = { version = "1.0", default-features = false }
 serde_with = "3.3.0"

--- a/crates/evm/execution-errors/Cargo.toml
+++ b/crates/evm/execution-errors/Cargo.toml
@@ -16,8 +16,8 @@ reth-consensus.workspace = true
 reth-primitives.workspace = true
 reth-storage-errors.workspace = true
 reth-prune-types.workspace = true
-thiserror-no-std.workspace = true
+thiserror-no-std = { workspace = true, default-features = false }
 
 [features]
 default = ["std"]
-std = []
+std = ["thiserror-no-std/std"]

--- a/crates/evm/execution-errors/Cargo.toml
+++ b/crates/evm/execution-errors/Cargo.toml
@@ -16,7 +16,8 @@ reth-consensus.workspace = true
 reth-primitives.workspace = true
 reth-storage-errors.workspace = true
 reth-prune-types.workspace = true
-thiserror-no-std.workspace = true
+thiserror-no-std = { workspace = true, default-features = false }
+
 
 [features]
 default = ["std"]

--- a/crates/evm/execution-errors/Cargo.toml
+++ b/crates/evm/execution-errors/Cargo.toml
@@ -16,4 +16,8 @@ reth-consensus.workspace = true
 reth-primitives.workspace = true
 reth-storage-errors.workspace = true
 reth-prune-types.workspace = true
-thiserror.workspace = true
+thiserror-no-std.workspace = true
+
+[features]
+default = ["std"]
+std = []

--- a/crates/evm/execution-errors/Cargo.toml
+++ b/crates/evm/execution-errors/Cargo.toml
@@ -16,7 +16,7 @@ reth-consensus.workspace = true
 reth-primitives.workspace = true
 reth-storage-errors.workspace = true
 reth-prune-types.workspace = true
-thiserror-no-std = { workspace = true, default-features = false }
+thiserror-no-std.workspace = true
 
 [features]
 default = ["std"]

--- a/crates/evm/execution-errors/src/lib.rs
+++ b/crates/evm/execution-errors/src/lib.rs
@@ -98,7 +98,6 @@ pub enum BlockValidationError {
     DepositRequestDecode(String),
 }
 
-// Explicitly implement the std::error::Error trait if needed
 #[cfg(feature = "std")]
 impl std::error::Error for BlockValidationError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {

--- a/crates/evm/execution-errors/src/lib.rs
+++ b/crates/evm/execution-errors/src/lib.rs
@@ -7,6 +7,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 use reth_consensus::ConsensusError;
 use reth_primitives::{revm_primitives::EVMError, BlockNumHash, B256};

--- a/crates/evm/execution-errors/src/lib.rs
+++ b/crates/evm/execution-errors/src/lib.rs
@@ -148,7 +148,6 @@ pub enum BlockExecutionError {
     #[error(transparent)]
     LatestBlock(#[from] ProviderError),
     /// Arbitrary Block Executor Errors
-    #[cfg(feature = "std")]
     #[error(transparent)]
     Other(Box<dyn std::error::Error + Send + Sync>),
 }
@@ -169,7 +168,6 @@ impl std::error::Error for BlockExecutionError {
 
 impl BlockExecutionError {
     /// Create a new `BlockExecutionError::Other` variant.
-    #[cfg(feature = "std")]
     pub fn other<E>(error: E) -> Self
     where
         E: std::error::Error + Send + Sync + 'static,
@@ -178,7 +176,6 @@ impl BlockExecutionError {
     }
 
     /// Create a new [`BlockExecutionError::Other`] from a given message.
-    #[cfg(feature = "std")]
     pub fn msg(msg: impl Display) -> Self {
         Self::Other(msg.to_string().into())
     }

--- a/crates/evm/execution-errors/src/lib.rs
+++ b/crates/evm/execution-errors/src/lib.rs
@@ -98,18 +98,6 @@ pub enum BlockValidationError {
     DepositRequestDecode(String),
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for BlockValidationError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::EVM { error, .. } => Some(&**error),
-            Self::StateRoot(err) => Some(err),
-            Self::BlockHashAccountLoadingFailed(err) => Some(err),
-            _ => None,
-        }
-    }
-}
-
 /// `BlockExecutor` Errors
 #[derive(Error, Debug)]
 pub enum BlockExecutionError {
@@ -150,20 +138,6 @@ pub enum BlockExecutionError {
     /// Arbitrary Block Executor Errors
     #[error(transparent)]
     Other(Box<dyn std::error::Error + Send + Sync>),
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for BlockExecutionError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::Validation(err) => Some(err),
-            Self::Pruning(err) => Some(err),
-            Self::Consensus(err) => Some(err),
-            Self::LatestBlock(err) => Some(err),
-            Self::Other(err) => Some(&**err),
-            _ => None,
-        }
-    }
 }
 
 impl BlockExecutionError {

--- a/crates/evm/execution-errors/src/lib.rs
+++ b/crates/evm/execution-errors/src/lib.rs
@@ -16,19 +16,15 @@ use reth_consensus::ConsensusError;
 use reth_primitives::{revm_primitives::EVMError, BlockNumHash, B256};
 use reth_prune_types::PruneSegmentError;
 use reth_storage_errors::provider::ProviderError;
-use thiserror_no_std::Error;
 
 #[cfg(not(feature = "std"))]
 use alloc::{boxed::Box, string::String};
-
-#[cfg(feature = "std")]
-use std::boxed::Box;
 
 pub mod trie;
 pub use trie::{StateRootError, StorageRootError};
 
 /// Transaction validation errors
-#[derive(Error, Debug, Clone, PartialEq, Eq)]
+#[derive(thiserror_no_std::Error, Debug, Clone, PartialEq, Eq)]
 pub enum BlockValidationError {
     /// EVM error with transaction hash and message
     #[error("EVM reported invalid transaction ({hash}): {error}")]
@@ -108,7 +104,7 @@ pub enum BlockValidationError {
 }
 
 /// `BlockExecutor` Errors
-#[derive(Error, Debug)]
+#[derive(thiserror_no_std::Error, Debug)]
 pub enum BlockExecutionError {
     /// Validation error, transparently wrapping `BlockValidationError`
     #[error(transparent)]
@@ -160,8 +156,8 @@ impl BlockExecutionError {
         Self::Other(Box::new(error))
     }
 
-    #[cfg(feature = "std")]
     /// Create a new [`BlockExecutionError::Other`] from a given message.
+    #[cfg(feature = "std")]
     pub fn msg(msg: impl std::fmt::Display) -> Self {
         Self::Other(msg.to_string().into())
     }

--- a/crates/evm/execution-errors/src/trie.rs
+++ b/crates/evm/execution-errors/src/trie.rs
@@ -23,29 +23,10 @@ impl From<StateRootError> for DatabaseError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for StateRootError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::DB(err) => Some(err),
-            Self::StorageRootError(err) => Some(err),
-        }
-    }
-}
-
 /// Storage root error.
 #[derive(Error, PartialEq, Eq, Clone, Debug)]
 pub enum StorageRootError {
     /// Internal database error.
     #[error(transparent)]
     DB(#[from] DatabaseError),
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for StorageRootError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::DB(err) => Some(err),
-        }
-    }
 }

--- a/crates/evm/execution-errors/src/trie.rs
+++ b/crates/evm/execution-errors/src/trie.rs
@@ -1,7 +1,6 @@
 //! Errors when computing the state root.
-
 use reth_storage_errors::db::DatabaseError;
-use thiserror::Error;
+use thiserror_no_std::Error;
 
 /// State root errors.
 #[derive(Error, Debug, PartialEq, Eq, Clone)]
@@ -23,10 +22,31 @@ impl From<StateRootError> for DatabaseError {
     }
 }
 
+// Implement std::error::Error for StateRootError
+#[cfg(feature = "std")]
+impl std::error::Error for StateRootError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::DB(err) => Some(err),
+            Self::StorageRootError(err) => Some(err),
+        }
+    }
+}
+
 /// Storage root error.
 #[derive(Error, PartialEq, Eq, Clone, Debug)]
 pub enum StorageRootError {
     /// Internal database error.
     #[error(transparent)]
     DB(#[from] DatabaseError),
+}
+
+// Implement std::error::Error for StorageRootError
+#[cfg(feature = "std")]
+impl std::error::Error for StorageRootError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::DB(err) => Some(err),
+        }
+    }
 }

--- a/crates/evm/execution-errors/src/trie.rs
+++ b/crates/evm/execution-errors/src/trie.rs
@@ -1,4 +1,5 @@
 //! Errors when computing the state root.
+
 use reth_storage_errors::db::DatabaseError;
 use thiserror_no_std::Error;
 
@@ -22,7 +23,6 @@ impl From<StateRootError> for DatabaseError {
     }
 }
 
-// Implement std::error::Error for StateRootError
 #[cfg(feature = "std")]
 impl std::error::Error for StateRootError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
@@ -41,7 +41,6 @@ pub enum StorageRootError {
     DB(#[from] DatabaseError),
 }
 
-// Implement std::error::Error for StorageRootError
 #[cfg(feature = "std")]
 impl std::error::Error for StorageRootError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {


### PR DESCRIPTION
Description

I have created a seperate implementation that uses `thiserror_no_std` instead of manually implementing said traits as `no-std` will be stabilized in core in the not to distant future.

Motivation
closes #8706 
 