### PR TITLE
fix(db): format tracing log fields with Debug

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -321,12 +321,12 @@ impl DatabaseEnv {
                 };
                 reth_tracing::tracing::warn!(
                     target: "storage::db::mdbx",
-                    process_id,
-                    thread_id,
-                    read_txn_id,
-                    gap,
-                    space,
-                    retry,
+                    ?process_id,
+                    ?thread_id,
+                    ?read_txn_id,
+                    ?gap,
+                    ?space,
+                    ?retry,
                     "{message}"
                 )
             }


### PR DESCRIPTION
```console
error[E0277]: the trait bound `*mut _opaque_pthread_t: reth_tracing::tracing::Value` is not satisfied
   --> crates/storage/db/src/implementation/mdbx/mod.rs:322:17
    |
322 | /                 reth_tracing::tracing::warn!(
323 | |                     target: "storage::db::mdbx",
324 | |                     process_id,
325 | |                     thread_id,
...   |
330 | |                     "{message}"
331 | |                 )
    | |_________________^ the trait `reth_tracing::tracing::Value` is not implemented for `*mut _opaque_pthread_t`
    |
    = help: the following other types implement trait `reth_tracing::tracing::Value`:
              bool
              isize
              i8
              i16
              i32
              i64
              i128
              usize
            and 34 others
    = note: required for the cast from `&*mut _opaque_pthread_t` to `&dyn reth_tracing::tracing::Value`
    = note: this error originates in the macro `$crate::valueset` which comes from the expansion of the macro `reth_tracing::tracing::warn` (in Nightly builds, run with -Z macro-backtrace for more info)
```