### PR TITLE
fix: add `start_time` to `ProcessUID` on `StorageLock`

### DIFF
--- a/crates/storage/db/Cargo.toml
+++ b/crates/storage/db/Cargo.toml
@@ -78,7 +78,6 @@ mdbx = ["reth-libmdbx"]
 bench = []
 arbitrary = ["reth-primitives/arbitrary", "reth-db-api/arbitrary"]
 optimism = []
-disable_lock = []
 
 [[bench]]
 name = "hash_keys"

--- a/crates/storage/db/Cargo.toml
+++ b/crates/storage/db/Cargo.toml
@@ -78,6 +78,7 @@ mdbx = ["reth-libmdbx"]
 bench = []
 arbitrary = ["reth-primitives/arbitrary", "reth-db-api/arbitrary"]
 optimism = []
+disable_lock = []
 
 [[bench]]
 name = "hash_keys"

--- a/crates/storage/db/Cargo.toml
+++ b/crates/storage/db/Cargo.toml
@@ -78,7 +78,7 @@ mdbx = ["reth-libmdbx"]
 bench = []
 arbitrary = ["reth-primitives/arbitrary", "reth-db-api/arbitrary"]
 optimism = []
-disable_lock = []
+disable-lock = []
 
 [[bench]]
 name = "hash_keys"

--- a/crates/storage/db/src/lockfile.rs
+++ b/crates/storage/db/src/lockfile.rs
@@ -9,7 +9,7 @@ use std::{
     process,
     sync::Arc,
 };
-use sysinfo::System;
+use sysinfo::{ProcessRefreshKind, RefreshKind, System};
 
 /// File lock name.
 const LOCKFILE_NAME: &str = "lock";
@@ -95,7 +95,7 @@ struct ProcessUID {
 impl ProcessUID {
     /// Creates [`Self`] for the provided PID.
     fn new(pid: usize) -> Option<Self> {
-        System::new_all()
+        System::new_with_specifics(RefreshKind::new().with_processes(ProcessRefreshKind::new()))
             .process(pid.into())
             .map(|process| Self { pid, start_time: process.start_time() })
     }
@@ -123,7 +123,7 @@ impl ProcessUID {
 
     /// Whether a process with this `pid` and `start_time` exists.
     fn is_active(&self) -> bool {
-        System::new_all()
+        System::new_with_specifics(RefreshKind::new().with_processes(ProcessRefreshKind::new()))
             .process(self.pid.into())
             .is_some_and(|p| p.start_time() == self.start_time)
     }

--- a/crates/storage/db/src/lockfile.rs
+++ b/crates/storage/db/src/lockfile.rs
@@ -1,5 +1,7 @@
 //! Storage lock utils.
 
+#![cfg_attr(feature = "disable_lock", allow(dead_code))]
+
 use reth_storage_errors::lockfile::StorageLockError;
 use reth_tracing::tracing::error;
 use std::{
@@ -29,13 +31,23 @@ impl StorageLock {
     /// with the same PID), it will succeed.
     pub fn try_acquire(path: &Path) -> Result<Self, StorageLockError> {
         let file_path = path.join(LOCKFILE_NAME);
-        if let Some(process_lock) = ProcessUID::parse(&file_path)? {
-            if process_lock.pid != (process::id() as usize) && process_lock.is_active() {
-                return Err(StorageLockError::Taken(process_lock.pid))
-            }
+
+        #[cfg(feature = "disable_lock")]
+        {
+            // Too expensive for ef-tests to write/read lock to/from disk.
+            Ok(Self(Arc::new(StorageLockInner { file_path })))
         }
 
-        Ok(Self(Arc::new(StorageLockInner::new(file_path)?)))
+        #[cfg(not(feature = "disable_lock"))]
+        {
+            if let Some(process_lock) = ProcessUID::parse(&file_path)? {
+                if process_lock.pid != (process::id() as usize) && process_lock.is_active() {
+                    return Err(StorageLockError::Taken(process_lock.pid))
+                }
+            }
+
+            Ok(Self(Arc::new(StorageLockInner::new(file_path)?)))
+        }
     }
 }
 

--- a/crates/storage/db/src/lockfile.rs
+++ b/crates/storage/db/src/lockfile.rs
@@ -88,7 +88,7 @@ impl ProcessUID {
             .process(pid.into())
             .map(|process| Self { pid, start_time: process.start_time() })
     }
-            
+
     /// Creates [`Self`] from own process.
     fn own() -> Self {
         Self::new(process::id() as usize).expect("own process")

--- a/crates/storage/db/src/lockfile.rs
+++ b/crates/storage/db/src/lockfile.rs
@@ -30,6 +30,7 @@ impl StorageLock {
     pub fn try_acquire(path: &Path) -> Result<Self, StorageLockError> {
         let path = path.join(LOCKFILE_NAME);
 
+        #[cfg(not(feature = "disable_lock"))]
         if let Some(process_lock) = ProcessUID::parse(&path)? {
             if process_lock.pid != (process::id() as usize) && process_lock.is_active() {
                 return Err(StorageLockError::Taken(process_lock.pid))

--- a/crates/storage/db/src/lockfile.rs
+++ b/crates/storage/db/src/lockfile.rs
@@ -42,6 +42,13 @@ impl StorageLock {
         {
             if let Some(process_lock) = ProcessUID::parse(&file_path)? {
                 if process_lock.pid != (process::id() as usize) && process_lock.is_active() {
+                    error!(
+                        target: "reth::db::lockfile",
+                        path = ?file_path,
+                        pid = process_lock.pid,
+                        start_time = process_lock.start_time,
+                        "Storage lock already taken."
+                    );
                     return Err(StorageLockError::Taken(process_lock.pid))
                 }
             }

--- a/crates/storage/db/src/lockfile.rs
+++ b/crates/storage/db/src/lockfile.rs
@@ -1,7 +1,5 @@
 //! Storage lock utils.
 
-#![cfg_attr(feature = "disable_lock", allow(dead_code))]
-
 use reth_storage_errors::lockfile::StorageLockError;
 use reth_tracing::tracing::error;
 use std::{
@@ -31,23 +29,13 @@ impl StorageLock {
     /// with the same PID), it will succeed.
     pub fn try_acquire(path: &Path) -> Result<Self, StorageLockError> {
         let file_path = path.join(LOCKFILE_NAME);
-
-        #[cfg(feature = "disable_lock")]
-        {
-            // Too expensive for ef-tests to write/read lock to/from disk.
-            Ok(Self(Arc::new(StorageLockInner { file_path })))
-        }
-
-        #[cfg(not(feature = "disable_lock"))]
-        {
-            if let Some(process_lock) = ProcessUID::parse(&file_path)? {
-                if process_lock.pid != (process::id() as usize) && process_lock.is_active() {
-                    return Err(StorageLockError::Taken(process_lock.pid))
-                }
+        if let Some(process_lock) = ProcessUID::parse(&file_path)? {
+            if process_lock.pid != (process::id() as usize) && process_lock.is_active() {
+                return Err(StorageLockError::Taken(process_lock.pid))
             }
-
-            Ok(Self(Arc::new(StorageLockInner::new(file_path)?)))
         }
+
+        Ok(Self(Arc::new(StorageLockInner::new(file_path)?)))
     }
 }
 

--- a/crates/storage/db/src/lockfile.rs
+++ b/crates/storage/db/src/lockfile.rs
@@ -1,6 +1,6 @@
 //! Storage lock utils.
 
-#![cfg_attr(feature = "disable_lock", allow(dead_code))]
+#![cfg_attr(feature = "disable-lock", allow(dead_code))]
 
 use reth_storage_errors::lockfile::StorageLockError;
 use reth_tracing::tracing::error;
@@ -32,13 +32,13 @@ impl StorageLock {
     pub fn try_acquire(path: &Path) -> Result<Self, StorageLockError> {
         let file_path = path.join(LOCKFILE_NAME);
 
-        #[cfg(feature = "disable_lock")]
+        #[cfg(feature = "disable-lock")]
         {
             // Too expensive for ef-tests to write/read lock to/from disk.
             Ok(Self(Arc::new(StorageLockInner { file_path })))
         }
 
-        #[cfg(not(feature = "disable_lock"))]
+        #[cfg(not(feature = "disable-lock"))]
         {
             if let Some(process_lock) = ProcessUID::parse(&file_path)? {
                 if process_lock.pid != (process::id() as usize) && process_lock.is_active() {

--- a/testing/ef-tests/Cargo.toml
+++ b/testing/ef-tests/Cargo.toml
@@ -17,7 +17,7 @@ asm-keccak = ["reth-primitives/asm-keccak"]
 
 [dependencies]
 reth-primitives.workspace = true
-reth-db = { workspace = true, features = ["mdbx", "test-utils", "disable_lock"] }
+reth-db = { workspace = true, features = ["mdbx", "test-utils", "disable-lock"] }
 reth-db-api.workspace = true
 reth-provider = { workspace = true, features = ["test-utils"] }
 reth-stages.workspace = true

--- a/testing/ef-tests/Cargo.toml
+++ b/testing/ef-tests/Cargo.toml
@@ -17,7 +17,7 @@ asm-keccak = ["reth-primitives/asm-keccak"]
 
 [dependencies]
 reth-primitives.workspace = true
-reth-db = { workspace = true, features = ["mdbx", "test-utils"] }
+reth-db = { workspace = true, features = ["mdbx", "test-utils", "disable_lock"] }
 reth-db-api.workspace = true
 reth-provider = { workspace = true, features = ["test-utils"] }
 reth-stages.workspace = true

--- a/testing/ef-tests/Cargo.toml
+++ b/testing/ef-tests/Cargo.toml
@@ -17,7 +17,7 @@ asm-keccak = ["reth-primitives/asm-keccak"]
 
 [dependencies]
 reth-primitives.workspace = true
-reth-db = { workspace = true, features = ["mdbx", "test-utils", "disable_lock"] }
+reth-db = { workspace = true, features = ["mdbx", "test-utils"] }
 reth-db-api.workspace = true
 reth-provider = { workspace = true, features = ["test-utils"] }
 reth-stages.workspace = true


### PR DESCRIPTION
Makes the identifier more unique by adding `start_time`. 

Fixes the following kind of issue:

1. `reth node` with PID 9 locks storage.
2. `reth node` stops non-gracefully leaving the lockfiles behind.
3. `firefox` starts with PID 9.
4. `reth node` attempts to start but realizes that PID 9 is executing, and thus, does not acquire the lock.
