### PR TITLE
fix(rpc/trace): trace_filter check block range

### DIFF
--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -249,8 +249,7 @@ where
 
         if start > end {
             return Err(EthApiError::InvalidParams(
-                "invalid parameters: fromBlock cannot be greater than toBlock"
-                    .to_string(),
+                "invalid parameters: fromBlock cannot be greater than toBlock".to_string(),
             ))
         }
 

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -247,7 +247,7 @@ where
             self.provider().best_block_number()?
         };
 
-        if end > start {
+        if start > end {
             return Err(EthApiError::InvalidParams(
                 "Invalid block range; `from_block` must be less than or equal to `to_block`"
                     .to_string(),

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -249,7 +249,7 @@ where
 
         if start > end {
             return Err(EthApiError::InvalidParams(
-                "Invalid block range; `from_block` must be less than or equal to `to_block`"
+                "invalid parameters: fromBlock cannot be greater than toBlock"
                     .to_string(),
             ))
         }

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -239,13 +239,20 @@ where
         filter: TraceFilter,
     ) -> EthResult<Vec<LocalizedTransactionTrace>> {
         let matcher = filter.matcher();
-        let TraceFilter { from_block, to_block, after: _after, count: _count, .. } = filter;
+        let TraceFilter { from_block, to_block, .. } = filter;
         let start = from_block.unwrap_or(0);
         let end = if let Some(to_block) = to_block {
             to_block
         } else {
             self.provider().best_block_number()?
         };
+
+        if end > start {
+            return Err(EthApiError::InvalidParams(
+                "Invalid block range; `from_block` must be less than or equal to `to_block`"
+                    .to_string(),
+            ))
+        }
 
         // ensure that the range is not too large, since we need to fetch all blocks in the range
         let distance = end.saturating_sub(start);


### PR DESCRIPTION
should return error if `from_block < to_block`

cc https://github.com/ledgerwatch/erigon/blob/b4c9f22923cd7156cd26be91a8a83b131eb3cc73/turbo/jsonrpc/trace_filtering.go#L311-L313