### PR TITLE
fix(rpc/trace): wrong calculate of block ommer rewards

### DIFF
--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -373,7 +373,7 @@ where
                         },
                     ));
 
-                    for uncle in &block.ommers.iter() {
+                    for uncle in &block.ommers {
                         let uncle_reward =
                             ommer_reward(base_block_reward, block.header.number, uncle.number);
                         traces.push(reward_trace(

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -373,7 +373,7 @@ where
                         },
                     ));
 
-                    for uncle in block.ommers.iter() {
+                    for uncle in &block.ommers.iter() {
                         let uncle_reward =
                             ommer_reward(base_block_reward, block.header.number, uncle.number);
                         traces.push(reward_trace(

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -6,7 +6,7 @@ use crate::eth::{
 };
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult as Result;
-use reth_consensus_common::calc::{base_block_reward, block_reward};
+use reth_consensus_common::calc::{base_block_reward, block_reward, ommer_reward};
 use reth_primitives::{revm::env::tx_env_with_recovered, BlockId, Bytes, SealedHeader, B256, U256};
 use reth_provider::{BlockReader, ChainSpecProvider, EvmEnvProvider, StateProviderFactory};
 use reth_revm::database::StateProviderDatabase;
@@ -363,25 +363,25 @@ where
                     block.header.difficulty,
                     header_td,
                 ) {
+                    let block_reward = block_reward(base_block_reward, block.ommers.len());
                     traces.push(reward_trace(
                         &block.header,
                         RewardAction {
                             author: block.header.beneficiary,
                             reward_type: RewardType::Block,
-                            value: U256::from(base_block_reward),
+                            value: U256::from(block_reward),
                         },
                     ));
 
-                    if !block.ommers.is_empty() {
+                    for uncle in block.ommers.iter() {
+                        let uncle_reward =
+                            ommer_reward(base_block_reward, block.header.number, uncle.number);
                         traces.push(reward_trace(
                             &block.header,
                             RewardAction {
-                                author: block.header.beneficiary,
+                                author: uncle.beneficiary,
                                 reward_type: RewardType::Uncle,
-                                value: U256::from(
-                                    block_reward(base_block_reward, block.ommers.len()) -
-                                        base_block_reward,
-                                ),
+                                value: U256::from(uncle_reward),
                             },
                         ));
                     }


### PR DESCRIPTION
In the current implementation of `trace_block` rpc, we return block base reward as `block` reward, and the uncle inclusion rewards as `uncle` reward. 

But in OpenEthereum/Erigon's implementation, they return `block base + uncle inclusion` as `block` reward, and each uncle reward as `uncle` reward, so the actual uncle rewards were missed. 

IMHO, we should keep the same as oe/erigon, because the results will be more inaccurate, similar to etherscan's. 

Eg the reward of https://etherscan.io/block/1378035

<img width="788" alt="image" src="https://github.com/paradigmxyz/reth/assets/3627395/81de3b33-aaca-4769-8eae-39e703e23c9e">

Reth's response:

```json
{
    "jsonrpc": "2.0",
    "result": [
        {
            "action": {
                "author": "0xea674fdde714fd979de3edf0f56aa9716b898ec8",
                "rewardType": "block",
                "value": "0x4563918244f40000" // 5ETH
            },
            "blockHash": "0xd6940190d24aa1c2e8aa70fb2847aba6c4461679753a7546daf79e6295a9e1e2",
            "blockNumber": 1378035,
            "subtraces": 0,
            "traceAddress": [],
            "type": "reward"
        },
        {
            "action": {
                "author": "0xea674fdde714fd979de3edf0f56aa9716b898ec8",
                "rewardType": "uncle",
                "value": "0x22b1c8c1227a000" // 0.15625ETH
            },
            "blockHash": "0xd6940190d24aa1c2e8aa70fb2847aba6c4461679753a7546daf79e6295a9e1e2",
            "blockNumber": 1378035,
            "subtraces": 0,
            "traceAddress": [],
            "type": "reward"
        }
    ],
    "id": "reth"
}
```


Erigon's response 

```json
{
    "jsonrpc": "2.0",
    "id": "erigon",
    "result": [
        {
            "action": {
                "author": "0xea674fdde714fd979de3edf0f56aa9716b898ec8",
                "rewardType": "block",
                "value": "0x478eae0e571ba000" // 5.15625ETH
            },
            "blockHash": "0xd6940190d24aa1c2e8aa70fb2847aba6c4461679753a7546daf79e6295a9e1e2",
            "blockNumber": 1378035,
            "result": null,
            "subtraces": 0,
            "traceAddress": [],
            "type": "reward"
        },
        {
            "action": {
                "author": "0xea674fdde714fd979de3edf0f56aa9716b898ec8",
                "rewardType": "uncle",
                "value": "0x3cb71f51fc558000" // 4.375ETH
            },
            "blockHash": "0xd6940190d24aa1c2e8aa70fb2847aba6c4461679753a7546daf79e6295a9e1e2",
            "blockNumber": 1378035,
            "result": null,
            "subtraces": 0,
            "traceAddress": [],
            "type": "reward"
        }
    ]
}
```

Ref https://github.com/ledgerwatch/erigon/blob/b4c9f22923cd7156cd26be91a8a83b131eb3cc73/consensus/ethash/consensus.go#L624-L668