### PR TITLE
feat: abstract execution layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2319,11 +2319,13 @@ version = "0.0.0"
 dependencies = [
  "eyre",
  "reth",
+ "reth-evm",
  "reth-node-api",
  "reth-node-core",
  "reth-node-ethereum",
  "reth-primitives",
  "reth-tracing",
+ "revm-primitives",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2319,13 +2319,11 @@ version = "0.0.0"
 dependencies = [
  "eyre",
  "reth",
- "reth-evm",
  "reth-node-api",
  "reth-node-core",
  "reth-node-ethereum",
  "reth-primitives",
  "reth-tracing",
- "revm-primitives",
  "tokio",
 ]
 

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -10,7 +10,7 @@ use reth_evm::{
         BatchExecutor, BlockExecutionError, BlockExecutionInput, BlockExecutionOutput,
         BlockExecutorProvider, BlockValidationError, Executor, ProviderError,
     },
-    ConfigureEvm,
+    ConfigureEvmGeneric,
 };
 use reth_execution_types::ExecutionOutcome;
 use reth_primitives::{
@@ -61,7 +61,7 @@ impl<EvmConfig> EthExecutorProvider<EvmConfig> {
 
 impl<EvmConfig> EthExecutorProvider<EvmConfig>
 where
-    EvmConfig: ConfigureEvm,
+    EvmConfig: ConfigureEvmGeneric,
 {
     fn eth_executor<DB>(&self, db: DB) -> EthBlockExecutor<EvmConfig, DB>
     where
@@ -77,7 +77,7 @@ where
 
 impl<EvmConfig> BlockExecutorProvider for EthExecutorProvider<EvmConfig>
 where
-    EvmConfig: ConfigureEvm,
+    EvmConfig: ConfigureEvmGeneric,
 {
     type Executor<DB: Database<Error = ProviderError>> = EthBlockExecutor<EvmConfig, DB>;
 
@@ -122,7 +122,7 @@ struct EthEvmExecutor<EvmConfig> {
 
 impl<EvmConfig> EthEvmExecutor<EvmConfig>
 where
-    EvmConfig: ConfigureEvm,
+    EvmConfig: ConfigureEvmGeneric,
 {
     /// Executes the transactions in the block and returns the receipts of the transactions in the
     /// block, the total gas used and the list of EIP-7685 [requests](Request).
@@ -254,7 +254,7 @@ impl<EvmConfig, DB> EthBlockExecutor<EvmConfig, DB> {
 
 impl<EvmConfig, DB> EthBlockExecutor<EvmConfig, DB>
 where
-    EvmConfig: ConfigureEvm,
+    EvmConfig: ConfigureEvmGeneric,
     DB: Database<Error = ProviderError>,
 {
     /// Configures a new evm configuration and block environment for the given block.
@@ -352,7 +352,7 @@ where
 
 impl<EvmConfig, DB> Executor<DB> for EthBlockExecutor<EvmConfig, DB>
 where
-    EvmConfig: ConfigureEvm,
+    EvmConfig: ConfigureEvmGeneric,
     DB: Database<Error = ProviderError>,
 {
     type Input<'a> = BlockExecutionInput<'a, BlockWithSenders>;
@@ -402,7 +402,7 @@ impl<EvmConfig, DB> EthBatchExecutor<EvmConfig, DB> {
 
 impl<EvmConfig, DB> BatchExecutor<DB> for EthBatchExecutor<EvmConfig, DB>
 where
-    EvmConfig: ConfigureEvm,
+    EvmConfig: ConfigureEvmGeneric,
     DB: Database<Error = ProviderError>,
 {
     type Input<'a> = BlockExecutionInput<'a, BlockWithSenders>;

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -8,10 +8,10 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
-use reth_evm::{execute::EvmTransact, ConfigureEvm, ConfigureEvmEnv, ConfigureEvmGeneric};
+use reth_evm::{ConfigureEvm, ConfigureEvmEnv, ConfigureEvmGeneric};
 use reth_primitives::{
     revm::{config::revm_spec, env::fill_tx_env},
-    revm_primitives::{AnalysisKind, CfgEnvWithHandlerCfg, EnvWithHandlerCfg, TxEnv},
+    revm_primitives::{AnalysisKind, CfgEnvWithHandlerCfg, TxEnv},
     Address, ChainSpec, Head, Header, TransactionSigned, U256,
 };
 use reth_revm::{Database, EvmBuilder};
@@ -58,21 +58,7 @@ impl ConfigureEvmEnv for EthEvmConfig {
     }
 }
 
-impl ConfigureEvmGeneric for EthEvmConfig {
-    fn evm_with_env_ext<'a, DB>(
-        &'a self,
-        db: DB,
-        env: EnvWithHandlerCfg,
-    ) -> Box<dyn EvmTransact<DB = DB> + 'a>
-    where
-        DB: Database + 'a,
-    {
-        let mut evm = self.evm(db);
-        evm.modify_spec_id(env.spec_id());
-        evm.context.evm.env = env.env;
-        Box::new(evm)
-    }
-}
+impl ConfigureEvmGeneric for EthEvmConfig {}
 
 impl ConfigureEvm for EthEvmConfig {
     type DefaultExternalContext<'a> = ();

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -8,10 +8,10 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
-use reth_evm::{ConfigureEvm, ConfigureEvmEnv};
+use reth_evm::{execute::EvmTransact, ConfigureEvm, ConfigureEvmEnv, ConfigureEvmGeneric};
 use reth_primitives::{
     revm::{config::revm_spec, env::fill_tx_env},
-    revm_primitives::{AnalysisKind, CfgEnvWithHandlerCfg, TxEnv},
+    revm_primitives::{AnalysisKind, CfgEnvWithHandlerCfg, EnvWithHandlerCfg, TxEnv},
     Address, ChainSpec, Head, Header, TransactionSigned, U256,
 };
 use reth_revm::{Database, EvmBuilder};
@@ -55,6 +55,22 @@ impl ConfigureEvmEnv for EthEvmConfig {
         cfg_env.perf_analyse_created_bytecodes = AnalysisKind::Analyse;
 
         cfg_env.handler_cfg.spec_id = spec_id;
+    }
+}
+
+impl ConfigureEvmGeneric for EthEvmConfig {
+    fn evm_with_env_ext<'a, DB>(
+        &'a self,
+        db: DB,
+        env: EnvWithHandlerCfg,
+    ) -> Box<dyn EvmTransact<DB = DB> + 'a>
+    where
+        DB: Database + 'a,
+    {
+        let mut evm = self.evm(db);
+        evm.modify_spec_id(env.spec_id());
+        evm.context.evm.env = env.env;
+        Box::new(evm)
     }
 }
 

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -15,7 +15,7 @@ use reth_basic_payload_builder::{
     PayloadConfig, WithdrawalsOutcome,
 };
 use reth_errors::RethError;
-use reth_evm::ConfigureEvm;
+use reth_evm::ConfigureEvmGeneric;
 use reth_evm_ethereum::{eip6110::parse_deposits_from_receipts, EthEvmConfig};
 use reth_payload_builder::{
     error::PayloadBuilderError, EthBuiltPayload, EthPayloadBuilderAttributes,
@@ -62,7 +62,7 @@ impl Default for EthereumPayloadBuilder {
 // Default implementation of [PayloadBuilder] for unit type
 impl<EvmConfig, Pool, Client> PayloadBuilder<Pool, Client> for EthereumPayloadBuilder<EvmConfig>
 where
-    EvmConfig: ConfigureEvm,
+    EvmConfig: ConfigureEvmGeneric,
     Client: StateProviderFactory,
     Pool: TransactionPool,
 {
@@ -247,7 +247,7 @@ pub fn default_ethereum_payload_builder<EvmConfig, Pool, Client>(
     args: BuildArguments<Pool, Client, EthPayloadBuilderAttributes, EthBuiltPayload>,
 ) -> Result<BuildOutcome<EthBuiltPayload>, PayloadBuilderError>
 where
-    EvmConfig: ConfigureEvm,
+    EvmConfig: ConfigureEvmGeneric,
     Client: StateProviderFactory,
     Pool: TransactionPool,
 {

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -6,8 +6,7 @@ use reth_primitives::{Address, BlockNumber, BlockWithSenders, Receipt, Request, 
 use reth_prune_types::PruneModes;
 use revm::{db::BundleState, DatabaseCommit};
 use revm_primitives::{
-    db::Database, Account, BlockEnv, EVMError, EVMResult, Env, EvmState, ExecutionResult,
-    ResultAndState, TxEnv,
+    db::Database, Account, EVMError, EVMResult, Env, EvmState, ExecutionResult, ResultAndState,
 };
 use std::collections::HashMap;
 
@@ -34,21 +33,6 @@ pub trait EvmTransact {
 
     /// Returns the current env with handler cfg.
     fn env_with_handler_cfg(&self) -> EnvWithHandlerCfg;
-
-    /// Returns a reference to the current database.
-    fn db(&self) -> &Self::DB;
-
-    /// Returns a mutable reference to the current database.
-    fn db_mut(&mut self) -> &mut Self::DB;
-
-    /// Returns the reference of transaction.
-    fn tx(&self) -> &TxEnv;
-
-    /// Returns the mutable reference of transaction.
-    fn tx_mut(&mut self) -> &mut TxEnv;
-
-    /// Returns the reference of block.
-    fn block(&self) -> &BlockEnv;
 }
 
 /// Trait that represents the output of a transaction and provides access to the state.
@@ -99,26 +83,6 @@ where
 
     fn env_with_handler_cfg(&self) -> EnvWithHandlerCfg {
         EnvWithHandlerCfg { env: Box::new(self.env().clone()), handler_cfg: self.handler.cfg() }
-    }
-
-    fn db(&self) -> &Self::DB {
-        self.db()
-    }
-
-    fn db_mut(&mut self) -> &mut Self::DB {
-        self.db_mut()
-    }
-
-    fn tx(&self) -> &TxEnv {
-        self.tx()
-    }
-
-    fn tx_mut(&mut self) -> &mut TxEnv {
-        self.tx_mut()
-    }
-
-    fn block(&self) -> &BlockEnv {
-        self.block()
     }
 }
 

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -12,7 +12,7 @@ pub use reth_storage_errors::provider::ProviderError;
 /// Trait that transacts an input (e.g. transaction and height) and produces an output
 /// (e.g. state changes).
 ///
-/// The trait cannot commit the state changes to the database directly, see [`EvmCommitter`].
+/// The trait cannot commit the state changes to the database directly, see [`EvmCommit`].
 pub trait EvmTransact {
     /// The environment for the evm.
     type Env;

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -37,18 +37,16 @@ pub trait EvmTransact {
 /// commit state changes to the database.
 pub trait EvmCommit: EvmTransact {
     /// The output produced by the evm.
-    type TransactCommitOutput;
+    type EvmOutput;
     /// The error produced by the evm.
-    type TransactCommitError;
+    type EvmError;
 
     /// Commit state changes to the database.
     fn commit(&mut self, output: HashMap<Address, Account>);
 
     /// Transact using [`EvmTransact::Env`], commit the state changes and
     /// return them.
-    fn transact_and_commit(
-        &mut self,
-    ) -> Result<Self::TransactCommitOutput, Self::TransactCommitError>;
+    fn transact_and_commit(&mut self) -> Result<Self::EvmOutput, Self::EvmError>;
 }
 
 impl<'a, C, DB> EvmTransact for Evm<'a, C, DB>
@@ -78,16 +76,14 @@ impl<'a, C, DB> EvmCommit for Evm<'a, C, DB>
 where
     DB: Database + DatabaseCommit + 'a,
 {
-    type TransactCommitOutput = ExecutionResult;
-    type TransactCommitError = EVMError<DB::Error>;
+    type EvmOutput = ExecutionResult;
+    type EvmError = EVMError<DB::Error>;
 
     fn commit(&mut self, output: HashMap<Address, Account>) {
         self.context.evm.db.commit(output)
     }
 
-    fn transact_and_commit(
-        &mut self,
-    ) -> Result<Self::TransactCommitOutput, Self::TransactCommitError> {
+    fn transact_and_commit(&mut self) -> Result<Self::EvmOutput, Self::EvmError> {
         self.transact_commit()
     }
 }

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -2,11 +2,10 @@
 
 use crate::{EnvWithHandlerCfg, Evm};
 use reth_execution_types::ExecutionOutcome;
-use reth_primitives::{Address, BlockNumber, BlockWithSenders, Receipt, Request, U256};
+use reth_primitives::{BlockNumber, BlockWithSenders, Receipt, Request, U256};
 use reth_prune_types::PruneModes;
 use revm::{db::BundleState, DatabaseCommit};
-use revm_primitives::{db::Database, Account, EVMError, EVMResult, Env, ExecutionResult};
-use std::collections::HashMap;
+use revm_primitives::{db::Database, EVMError, EVMResult, Env, ExecutionResult, ResultAndState};
 
 pub use reth_execution_errors::{BlockExecutionError, BlockValidationError};
 pub use reth_storage_errors::provider::ProviderError;
@@ -42,7 +41,7 @@ pub trait EvmCommit: EvmTransact {
     type EvmError;
 
     /// Commit state changes to the database.
-    fn commit(&mut self, output: HashMap<Address, Account>);
+    fn commit(&mut self, output: ResultAndState);
 
     /// Transact using [`EvmTransact::Env`], commit the state changes and
     /// return them.
@@ -79,8 +78,8 @@ where
     type EvmOutput = ExecutionResult;
     type EvmError = EVMError<DB::Error>;
 
-    fn commit(&mut self, output: HashMap<Address, Account>) {
-        self.context.evm.db.commit(output)
+    fn commit(&mut self, output: ResultAndState) {
+        self.context.evm.db.commit(output.state)
     }
 
     fn transact_and_commit(&mut self) -> Result<Self::EvmOutput, Self::EvmError> {

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -21,9 +21,6 @@ pub trait EvmExecutor<DB> {
     /// The output produced by the executor.
     type Output;
 
-    /// Updates the state of the executor.
-    fn with_state(self, db: DB) -> Self;
-
     /// Executes the input and returns the output without committing the state.
     fn execute(&mut self, input: Self::Input) -> Self::Output;
 

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -9,6 +9,37 @@ use revm_primitives::db::Database;
 pub use reth_execution_errors::{BlockExecutionError, BlockValidationError};
 pub use reth_storage_errors::provider::ProviderError;
 
+/// An EVM executor trait that executes an input (e.g. transaction and height) and produces an output
+/// (e.g. state changes).
+///
+/// The executor can also commit the state changes to the database.
+pub trait EvmExecutor<DB> {
+    /// The input type for the executor.
+    type Input;
+    /// The configuration for the evm executor.
+    type Config;
+    /// The output produced by the executor.
+    type Output;
+
+    /// Updates the state of the executor.
+    fn with_state(self, db: DB) -> Self;
+
+    /// Executes the input and returns the output without committing the state.
+    fn execute(&mut self, input: Self::Input) -> Self::Output;
+
+    /// Commit the state changes to the database.
+    fn commit(&mut self, output: Self::Output);
+
+    /// Execute the input and commit the state changes to the database.
+    fn execute_and_commit(&mut self, input: Self::Input) {
+        let output = self.execute(input);
+        self.commit(output);
+    }
+
+    /// Returns the current config of the executor.
+    fn config(&self) -> Self::Config;
+}
+
 /// A general purpose executor trait that executes an input (e.g. block) and produces an output
 /// (e.g. state changes and receipts).
 ///

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -5,9 +5,7 @@ use reth_execution_types::ExecutionOutcome;
 use reth_primitives::{Address, BlockNumber, BlockWithSenders, Receipt, Request, U256};
 use reth_prune_types::PruneModes;
 use revm::{db::BundleState, DatabaseCommit};
-use revm_primitives::{
-    db::Database, Account, EVMError, EVMResult, Env, EvmState, ExecutionResult, ResultAndState,
-};
+use revm_primitives::{db::Database, Account, EVMError, EVMResult, Env, ExecutionResult};
 use std::collections::HashMap;
 
 pub use reth_execution_errors::{BlockExecutionError, BlockValidationError};
@@ -35,12 +33,6 @@ pub trait EvmTransact {
     fn env_with_handler_cfg(&self) -> EnvWithHandlerCfg;
 }
 
-/// Trait that represents the output of a transaction and provides access to the state.
-pub trait EvmTransactOutput {
-    /// Returns the state produced by the transaction.
-    fn state(&self) -> EvmState;
-}
-
 /// Trait that can transact an [`EvmTransact::Env`] and
 /// commit state changes to the database.
 pub trait EvmCommit: EvmTransact {
@@ -55,12 +47,6 @@ pub trait EvmCommit: EvmTransact {
     /// Transact using [`EvmTransact::Env`], commit the state changes and
     /// return them.
     fn transact_and_commit(&mut self) -> Result<Self::CommitOutput, Self::CommitError>;
-}
-
-impl EvmTransactOutput for ResultAndState {
-    fn state(&self) -> EvmState {
-        self.state.clone()
-    }
 }
 
 impl<'a, C, DB> EvmTransact for Evm<'a, C, DB>

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -12,8 +12,8 @@ pub use reth_storage_errors::provider::ProviderError;
 /// An EVM executor trait that executes an input (e.g. transaction and height) and produces an output
 /// (e.g. state changes).
 ///
-/// The executor can also commit the state changes to the database.
-pub trait EvmExecutor<DB> {
+/// The executor cannot commit the state changes to the database directly, see [`EvmCommitter`].
+pub trait EvmExecutor {
     /// The environment for the executor.
     type Env;
     /// The output produced by the executor.
@@ -28,7 +28,8 @@ pub trait EvmExecutor<DB> {
     fn env(&self) -> &Self::Env;
 }
 
-pub trait EvmCommitter<DB>: EvmExecutor<DB> {
+/// An EVM executor trait that can commit the state changes to the database.
+pub trait EvmCommitter: EvmExecutor {
     /// Commit the state changes to the database.
     fn commit(&mut self, output: Self::Output);
 
@@ -37,7 +38,7 @@ pub trait EvmCommitter<DB>: EvmExecutor<DB> {
 }
 
 /// An EVM executor that uses the [`Evm`] struct to execute the current Env.
-impl<'a, DB, I> EvmExecutor<DB> for Evm<'a, I, DB>
+impl<'a, DB, I> EvmExecutor for Evm<'a, I, DB>
 where
     DB: Database,
 {
@@ -54,7 +55,7 @@ where
     }
 }
 
-impl<'a, DB, I> EvmCommitter<DB> for Evm<'a, I, DB>
+impl<'a, DB, I> EvmCommitter for Evm<'a, I, DB>
 where
     DB: Database + DatabaseCommit,
 {

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -37,16 +37,18 @@ pub trait EvmTransact {
 /// commit state changes to the database.
 pub trait EvmCommit: EvmTransact {
     /// The output produced by the evm.
-    type CommitOutput;
+    type TransactCommitOutput;
     /// The error produced by the evm.
-    type CommitError;
+    type TransactCommitError;
 
     /// Commit state changes to the database.
     fn commit(&mut self, output: HashMap<Address, Account>);
 
     /// Transact using [`EvmTransact::Env`], commit the state changes and
     /// return them.
-    fn transact_and_commit(&mut self) -> Result<Self::CommitOutput, Self::CommitError>;
+    fn transact_and_commit(
+        &mut self,
+    ) -> Result<Self::TransactCommitOutput, Self::TransactCommitError>;
 }
 
 impl<'a, C, DB> EvmTransact for Evm<'a, C, DB>
@@ -76,14 +78,16 @@ impl<'a, C, DB> EvmCommit for Evm<'a, C, DB>
 where
     DB: Database + DatabaseCommit + 'a,
 {
-    type CommitOutput = ExecutionResult;
-    type CommitError = EVMError<DB::Error>;
+    type TransactCommitOutput = ExecutionResult;
+    type TransactCommitError = EVMError<DB::Error>;
 
     fn commit(&mut self, output: HashMap<Address, Account>) {
         self.context.evm.db.commit(output)
     }
 
-    fn transact_and_commit(&mut self) -> Result<Self::CommitOutput, Self::CommitError> {
+    fn transact_and_commit(
+        &mut self,
+    ) -> Result<Self::TransactCommitOutput, Self::TransactCommitError> {
         self.transact_commit()
     }
 }

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -14,11 +14,11 @@ pub use reth_storage_errors::provider::ProviderError;
 ///
 /// The trait cannot commit the state changes to the database directly, see [`EvmCommitter`].
 pub trait EvmTransact {
-    /// The environment for the executor.
+    /// The environment for the evm.
     type Env;
-    /// The output produced by the executor.
+    /// The output produced by the evm.
     type Output;
-    /// The error produced by the executor.
+    /// The error produced by the evm.
     type Error;
 
     /// Transacts with the current env to produce an output without
@@ -42,6 +42,7 @@ pub trait EvmCommit: EvmTransact {
     /// return them.
     fn transact_and_commit(&mut self) -> Result<Self::Output, Self::Error>;
 }
+
 /// A general purpose executor trait that executes an input (e.g. block) and produces an output
 /// (e.g. state changes and receipts).
 ///

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -129,7 +129,7 @@ pub trait ConfigureEvmEnv: Send + Sync + Unpin + Clone + 'static {
 /// Allows to build an EVM Executor with the given context.
 pub trait EvmContext<'a, EXT, DB: Database> {
     /// The executor produced with the context set.
-    type Executor: EvmExecutor<DB>;
+    type Executor: EvmExecutor;
 
     /// Sets the EVM database.
     #[must_use]

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -33,7 +33,13 @@ pub trait ConfigureEvmGeneric: ConfigureEvm + ConfigureEvmEnv {
         env: EnvWithHandlerCfg,
     ) -> Box<dyn EvmTransact<DB = DB> + 'a>
     where
-        DB: Database + 'a;
+        DB: Database + 'a,
+    {
+        let mut evm = self.evm(db);
+        evm.modify_spec_id(env.spec_id());
+        evm.context.evm.env = env.env;
+        Box::new(evm)
+    }
 }
 
 /// Trait for configuring the EVM for executing full blocks.

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -12,7 +12,7 @@ use execute::EvmExecutor;
 use reth_primitives::{
     revm::env::fill_block_env, Address, ChainSpec, Header, TransactionSigned, U256,
 };
-use revm::{inspector_handle_register, Database, Evm, EvmBuilder, GetInspector};
+use revm::{inspector_handle_register, Database, DatabaseCommit, Evm, EvmBuilder, GetInspector};
 use revm_primitives::{
     BlockEnv, CfgEnv, CfgEnvWithHandlerCfg, Env, EnvWithHandlerCfg, SpecId, TxEnv,
 };
@@ -126,7 +126,7 @@ pub trait ConfigureEvmEnv: Send + Sync + Unpin + Clone + 'static {
 }
 
 /// Trait for managing the EVM context.
-pub trait EvmContext<DB: Database> {
+pub trait EvmContext<EXT, DB: Database> {
     /// The executor produced with the context set.
     type Executor: EvmExecutor<DB>;
 
@@ -156,10 +156,51 @@ pub trait EvmContext<DB: Database> {
 
     /// Sets the inspector for the EVM instance.
     #[must_use]
-    fn with_inspector<I>(self, inspector: I) -> Self
-    where
-        I: GetInspector<DB>;
+    fn with_inspector(self, inspector: EXT) -> Self;
 
     /// Returns the EVM executor.
     fn executor(self) -> Self::Executor;
+}
+
+/// A context for configuring a Revm EVM instance.
+#[allow(missing_debug_implementations)]
+pub struct RevmContext<'a, Stage, EXT, DB: Database>(EvmBuilder<'a, Stage, EXT, DB>);
+
+impl<'a, Stage, EXT, DB> EvmContext<EXT, DB> for RevmContext<'a, Stage, EXT, DB>
+where
+    DB: Database + DatabaseCommit + 'a,
+{
+    type Executor = Evm<'a, EXT, DB>;
+
+    fn with_db(self, db: DB) -> Self {
+        Self(self.0.modify_db(|old| *old = db))
+    }
+
+    fn with_env(self, env: Env) -> Self {
+        Self(self.0.modify_env(|old| *old = env.into()))
+    }
+
+    fn with_cfg_env(self, cfg: CfgEnv) -> Self {
+        Self(self.0.modify_cfg_env(|old| *old = cfg))
+    }
+
+    fn with_block_env(self, block: BlockEnv) -> Self {
+        Self(self.0.modify_block_env(|old| *old = block))
+    }
+
+    fn with_tx_env(self, tx: TxEnv) -> Self {
+        Self(self.0.modify_tx_env(|old| *old = tx))
+    }
+
+    fn with_spec_id(self, spec_id: SpecId) -> Self {
+        Self(self.0.with_spec_id(spec_id))
+    }
+
+    fn with_inspector(self, inspector: EXT) -> Self {
+        Self(self.0.modify_external_context(|old| *old = inspector))
+    }
+
+    fn executor(self) -> Self::Executor {
+        self.0.build()
+    }
 }

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -27,7 +27,7 @@ pub mod test_utils;
 /// Trait for configuring the EVM in a generic way
 pub trait ConfigureEvmGeneric: ConfigureEvm + ConfigureEvmEnv {
     /// Returns a new EVM with the given database configured with the given environment settings.
-    fn evm_with_env_ext<'a, DB>(
+    fn evm_with_env_generic<'a, DB>(
         &'a self,
         db: DB,
         env: EnvWithHandlerCfg,

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -8,6 +8,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
+use crate::execute::EvmTransact;
 use reth_primitives::{
     revm::env::fill_block_env, Address, ChainSpec, Header, TransactionSigned, U256,
 };
@@ -22,6 +23,18 @@ pub mod provider;
 #[cfg(any(test, feature = "test-utils"))]
 /// test helpers for mocking executor
 pub mod test_utils;
+
+/// Trait for configuring the EVM in a generic way
+pub trait ConfigureEvmGeneric: ConfigureEvm + ConfigureEvmEnv {
+    /// Returns a new EVM with the given database configured with the given environment settings.
+    fn evm_with_env_ext<'a, DB>(
+        &'a self,
+        db: DB,
+        env: EnvWithHandlerCfg,
+    ) -> Box<dyn EvmTransact<DB = DB> + 'a>
+    where
+        DB: Database + 'a;
+}
 
 /// Trait for configuring the EVM for executing full blocks.
 pub trait ConfigureEvm: ConfigureEvmEnv {

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -130,6 +130,10 @@ pub trait EvmContext<DB: Database> {
     /// The executor produced with the context set.
     type Executor: EvmExecutor<DB>;
 
+    /// Sets the EVM database.
+    #[must_use]
+    fn with_db(self, db: DB) -> Self;
+
     /// Sets the EVM environment.
     #[must_use]
     fn with_env(self, env: Env) -> Self;

--- a/crates/node/api/src/lib.rs
+++ b/crates/node/api/src/lib.rs
@@ -17,7 +17,7 @@ pub use reth_payload_primitives as payload;
 pub use reth_payload_primitives::*;
 
 /// Traits and helper types used to abstract over EVM methods and types.
-pub use reth_evm::{ConfigureEvm, ConfigureEvmEnv};
+pub use reth_evm::{ConfigureEvm, ConfigureEvmEnv, ConfigureEvmGeneric};
 
 pub mod primitives;
 

--- a/crates/node/api/src/node.rs
+++ b/crates/node/api/src/node.rs
@@ -1,11 +1,11 @@
 //! Traits for configuring a node.
 
-use crate::{primitives::NodePrimitives, ConfigureEvm, EngineTypes};
+use crate::{primitives::NodePrimitives, EngineTypes};
 use reth_db_api::{
     database::Database,
     database_metrics::{DatabaseMetadata, DatabaseMetrics},
 };
-use reth_evm::execute::BlockExecutorProvider;
+use reth_evm::{execute::BlockExecutorProvider, ConfigureEvmGeneric};
 use reth_network::NetworkHandle;
 use reth_payload_builder::PayloadBuilderHandle;
 use reth_provider::FullProvider;
@@ -93,7 +93,7 @@ pub trait FullNodeComponents: FullNodeTypes + 'static {
     type Pool: TransactionPool + Unpin;
 
     /// The node's EVM configuration, defining settings for the Ethereum Virtual Machine.
-    type Evm: ConfigureEvm;
+    type Evm: ConfigureEvmGeneric;
 
     /// The type that knows how to execute blocks.
     type Executor: BlockExecutorProvider;

--- a/crates/node/builder/src/components/builder.rs
+++ b/crates/node/builder/src/components/builder.rs
@@ -5,7 +5,7 @@ use crate::{
         Components, ConsensusBuilder, ExecutorBuilder, NetworkBuilder, NodeComponents,
         PayloadServiceBuilder, PoolBuilder,
     },
-    BuilderContext, ConfigureEvm, FullNodeTypes,
+    BuilderContext, ConfigureEvmGeneric, FullNodeTypes,
 };
 use reth_consensus::Consensus;
 use reth_evm::execute::BlockExecutorProvider;
@@ -369,7 +369,7 @@ where
     F: FnOnce(&BuilderContext<Node>) -> Fut + Send,
     Fut: Future<Output = eyre::Result<Components<Node, Pool, EVM, Executor, Cons>>> + Send,
     Pool: TransactionPool + Unpin + 'static,
-    EVM: ConfigureEvm,
+    EVM: ConfigureEvmGeneric,
     Executor: BlockExecutorProvider,
     Cons: Consensus + Clone + Unpin + 'static,
 {

--- a/crates/node/builder/src/components/execute.rs
+++ b/crates/node/builder/src/components/execute.rs
@@ -1,7 +1,7 @@
 //! EVM component for the node builder.
 use crate::{BuilderContext, FullNodeTypes};
 use reth_evm::execute::BlockExecutorProvider;
-use reth_node_api::ConfigureEvm;
+use reth_node_api::ConfigureEvmGeneric;
 use std::future::Future;
 
 /// A type that knows how to build the executor types.
@@ -9,7 +9,7 @@ pub trait ExecutorBuilder<Node: FullNodeTypes>: Send {
     /// The EVM config to use.
     ///
     /// This provides the node with the necessary configuration to configure an EVM.
-    type EVM: ConfigureEvm;
+    type EVM: ConfigureEvmGeneric;
 
     /// The type that knows how to execute blocks.
     type Executor: BlockExecutorProvider;
@@ -24,7 +24,7 @@ pub trait ExecutorBuilder<Node: FullNodeTypes>: Send {
 impl<Node, F, Fut, EVM, Executor> ExecutorBuilder<Node> for F
 where
     Node: FullNodeTypes,
-    EVM: ConfigureEvm,
+    EVM: ConfigureEvmGeneric,
     Executor: BlockExecutorProvider,
     F: FnOnce(&BuilderContext<Node>) -> Fut + Send,
     Fut: Future<Output = eyre::Result<(EVM, Executor)>> + Send,

--- a/crates/node/builder/src/components/mod.rs
+++ b/crates/node/builder/src/components/mod.rs
@@ -7,7 +7,7 @@
 //!
 //! Components depend on a fully type configured node: [FullNodeTypes](crate::node::FullNodeTypes).
 
-use crate::{ConfigureEvm, FullNodeTypes};
+use crate::FullNodeTypes;
 pub use builder::*;
 pub use consensus::*;
 pub use execute::*;
@@ -15,7 +15,7 @@ pub use network::*;
 pub use payload::*;
 pub use pool::*;
 use reth_consensus::Consensus;
-use reth_evm::execute::BlockExecutorProvider;
+use reth_evm::{execute::BlockExecutorProvider, ConfigureEvmGeneric};
 use reth_network::NetworkHandle;
 use reth_payload_builder::PayloadBuilderHandle;
 use reth_transaction_pool::TransactionPool;
@@ -37,7 +37,7 @@ pub trait NodeComponents<NodeTypes: FullNodeTypes>: Clone + Unpin + Send + Sync 
     type Pool: TransactionPool + Unpin;
 
     /// The node's EVM configuration, defining settings for the Ethereum Virtual Machine.
-    type Evm: ConfigureEvm;
+    type Evm: ConfigureEvmGeneric;
 
     /// The type that knows how to execute blocks.
     type Executor: BlockExecutorProvider;
@@ -88,7 +88,7 @@ impl<Node, Pool, EVM, Executor, Cons> NodeComponents<Node>
 where
     Node: FullNodeTypes,
     Pool: TransactionPool + Unpin + 'static,
-    EVM: ConfigureEvm,
+    EVM: ConfigureEvmGeneric,
     Executor: BlockExecutorProvider,
     Cons: Consensus + Clone + Unpin + 'static,
 {
@@ -126,7 +126,7 @@ impl<Node, Pool, EVM, Executor, Cons> Clone for Components<Node, Pool, EVM, Exec
 where
     Node: FullNodeTypes,
     Pool: TransactionPool,
-    EVM: ConfigureEvm,
+    EVM: ConfigureEvmGeneric,
     Executor: BlockExecutorProvider,
     Cons: Consensus + Clone,
 {

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -6,7 +6,7 @@ use reth_evm::{
         BatchExecutor, BlockExecutionError, BlockExecutionInput, BlockExecutionOutput,
         BlockExecutorProvider, BlockValidationError, Executor, ProviderError,
     },
-    ConfigureEvm,
+    ConfigureEvmGeneric,
 };
 use reth_optimism_consensus::validate_block_post_execution;
 use reth_primitives::{
@@ -51,7 +51,7 @@ impl<EvmConfig> OpExecutorProvider<EvmConfig> {
 
 impl<EvmConfig> OpExecutorProvider<EvmConfig>
 where
-    EvmConfig: ConfigureEvm,
+    EvmConfig: ConfigureEvmGeneric,
 {
     fn op_executor<DB>(&self, db: DB) -> OpBlockExecutor<EvmConfig, DB>
     where
@@ -67,7 +67,7 @@ where
 
 impl<EvmConfig> BlockExecutorProvider for OpExecutorProvider<EvmConfig>
 where
-    EvmConfig: ConfigureEvm,
+    EvmConfig: ConfigureEvmGeneric,
 {
     type Executor<DB: Database<Error = ProviderError>> = OpBlockExecutor<EvmConfig, DB>;
 
@@ -103,7 +103,7 @@ struct OpEvmExecutor<EvmConfig> {
 
 impl<EvmConfig> OpEvmExecutor<EvmConfig>
 where
-    EvmConfig: ConfigureEvm,
+    EvmConfig: ConfigureEvmGeneric,
 {
     /// Executes the transactions in the block and returns the receipts.
     ///
@@ -254,7 +254,7 @@ impl<EvmConfig, DB> OpBlockExecutor<EvmConfig, DB> {
 
 impl<EvmConfig, DB> OpBlockExecutor<EvmConfig, DB>
 where
-    EvmConfig: ConfigureEvm,
+    EvmConfig: ConfigureEvmGeneric,
     DB: Database<Error = ProviderError>,
 {
     /// Configures a new evm configuration and block environment for the given block.
@@ -336,7 +336,7 @@ where
 
 impl<EvmConfig, DB> Executor<DB> for OpBlockExecutor<EvmConfig, DB>
 where
-    EvmConfig: ConfigureEvm,
+    EvmConfig: ConfigureEvmGeneric,
     DB: Database<Error = ProviderError>,
 {
     type Input<'a> = BlockExecutionInput<'a, BlockWithSenders>;
@@ -393,7 +393,7 @@ impl<EvmConfig, DB> OpBatchExecutor<EvmConfig, DB> {
 
 impl<EvmConfig, DB> BatchExecutor<DB> for OpBatchExecutor<EvmConfig, DB>
 where
-    EvmConfig: ConfigureEvm,
+    EvmConfig: ConfigureEvmGeneric,
     DB: Database<Error = ProviderError>,
 {
     type Input<'a> = BlockExecutionInput<'a, BlockWithSenders>;

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -9,13 +9,14 @@
 // The `optimism` feature must be enabled to use this crate.
 #![cfg(feature = "optimism")]
 
-use reth_evm::{ConfigureEvm, ConfigureEvmEnv};
+use reth_evm::{execute::EvmTransact, ConfigureEvm, ConfigureEvmEnv, ConfigureEvmGeneric};
 use reth_primitives::{
     revm::{config::revm_spec, env::fill_op_tx_env},
     revm_primitives::{AnalysisKind, CfgEnvWithHandlerCfg, TxEnv},
     Address, ChainSpec, Head, Header, TransactionSigned, U256,
 };
 use reth_revm::{inspector_handle_register, Database, Evm, EvmBuilder, GetInspector};
+use revm_primitives::EnvWithHandlerCfg;
 
 mod execute;
 pub use execute::*;
@@ -80,6 +81,22 @@ impl ConfigureEvm for OptimismEvmConfig {
             .optimism()
             .append_handler_register(inspector_handle_register)
             .build()
+    }
+}
+
+impl ConfigureEvmGeneric for OptimismEvmConfig {
+    fn evm_with_env_ext<'a, DB>(
+        &'a self,
+        db: DB,
+        env: EnvWithHandlerCfg,
+    ) -> Box<dyn EvmTransact<DB = DB> + 'a>
+    where
+        DB: Database + 'a,
+    {
+        let mut evm = self.evm(db);
+        evm.modify_spec_id(env.spec_id());
+        evm.context.evm.env = env.env;
+        Box::new(evm)
     }
 }
 

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -9,14 +9,13 @@
 // The `optimism` feature must be enabled to use this crate.
 #![cfg(feature = "optimism")]
 
-use reth_evm::{execute::EvmTransact, ConfigureEvm, ConfigureEvmEnv, ConfigureEvmGeneric};
+use reth_evm::{ConfigureEvm, ConfigureEvmEnv, ConfigureEvmGeneric};
 use reth_primitives::{
     revm::{config::revm_spec, env::fill_op_tx_env},
     revm_primitives::{AnalysisKind, CfgEnvWithHandlerCfg, TxEnv},
     Address, ChainSpec, Head, Header, TransactionSigned, U256,
 };
 use reth_revm::{inspector_handle_register, Database, Evm, EvmBuilder, GetInspector};
-use revm_primitives::EnvWithHandlerCfg;
 
 mod execute;
 pub use execute::*;
@@ -84,21 +83,7 @@ impl ConfigureEvm for OptimismEvmConfig {
     }
 }
 
-impl ConfigureEvmGeneric for OptimismEvmConfig {
-    fn evm_with_env_ext<'a, DB>(
-        &'a self,
-        db: DB,
-        env: EnvWithHandlerCfg,
-    ) -> Box<dyn EvmTransact<DB = DB> + 'a>
-    where
-        DB: Database + 'a,
-    {
-        let mut evm = self.evm(db);
-        evm.modify_spec_id(env.spec_id());
-        evm.context.evm.env = env.env;
-        Box::new(evm)
-    }
-}
+impl ConfigureEvmGeneric for OptimismEvmConfig {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -6,7 +6,7 @@ use crate::{
     OptimismEngineTypes,
 };
 use reth_basic_payload_builder::{BasicPayloadJobGenerator, BasicPayloadJobGeneratorConfig};
-use reth_evm::ConfigureEvm;
+use reth_evm::ConfigureEvmGeneric;
 use reth_evm_optimism::{OpExecutorProvider, OptimismEvmConfig};
 use reth_network::{NetworkHandle, NetworkManager};
 use reth_node_builder::{

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -218,7 +218,7 @@ impl<Node, EVM, Pool> PayloadServiceBuilder<Node, Pool> for OptimismPayloadBuild
 where
     Node: FullNodeTypes<Engine = OptimismEngineTypes>,
     Pool: TransactionPool + Unpin + 'static,
-    EVM: ConfigureEvm,
+    EVM: ConfigureEvmGeneric,
 {
     async fn spawn_payload_service(
         self,

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -5,7 +5,7 @@ use crate::{
     payload::{OptimismBuiltPayload, OptimismPayloadBuilderAttributes},
 };
 use reth_basic_payload_builder::*;
-use reth_evm::ConfigureEvm;
+use reth_evm::ConfigureEvmGeneric;
 use reth_payload_builder::error::PayloadBuilderError;
 use reth_primitives::{
     constants::{BEACON_NONCE, EMPTY_RECEIPTS, EMPTY_TRANSACTIONS},

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -72,7 +72,7 @@ impl<Pool, Client, EvmConfig> PayloadBuilder<Pool, Client> for OptimismPayloadBu
 where
     Client: StateProviderFactory,
     Pool: TransactionPool,
-    EvmConfig: ConfigureEvm,
+    EvmConfig: ConfigureEvmGeneric,
 {
     type Attributes = OptimismPayloadBuilderAttributes;
     type BuiltPayload = OptimismBuiltPayload;
@@ -240,7 +240,7 @@ pub(crate) fn optimism_payload_builder<EvmConfig, Pool, Client>(
     _compute_pending_block: bool,
 ) -> Result<BuildOutcome<OptimismBuiltPayload>, PayloadBuilderError>
 where
-    EvmConfig: ConfigureEvm,
+    EvmConfig: ConfigureEvmGeneric,
     Client: StateProviderFactory,
     Pool: TransactionPool,
 {

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -47,7 +47,7 @@
 //!     Pool: TransactionPool + Clone + 'static,
 //!     Network: NetworkInfo + Peers + Clone + 'static,
 //!     Events: CanonStateSubscriptions + Clone + 'static,
-//!     EvmConfig: ConfigureEvm + 'static,
+//!     EvmConfig: ConfigureEvmGeneric + 'static,
 //! {
 //!     // configure the rpc module per transport
 //!     let transports = TransportRpcModuleConfig::default().with_http(vec![
@@ -115,7 +115,7 @@
 //!     Events: CanonStateSubscriptions + Clone + 'static,
 //!     EngineApi: EngineApiServer<EngineT>,
 //!     EngineT: EngineTypes + 'static,
-//!     EvmConfig: ConfigureEvm + 'static,
+//!     EvmConfig: ConfigureEvmGeneric + 'static,
 //! {
 //!     // configure the rpc module per transport
 //!     let transports = TransportRpcModuleConfig::default().with_http(vec![
@@ -167,7 +167,7 @@ use jsonrpsee::{
     Methods, RpcModule,
 };
 use reth_engine_primitives::EngineTypes;
-use reth_evm::ConfigureEvm;
+use reth_evm::ConfigureEvmGeneric;
 use reth_ipc::server::IpcServer;
 use reth_network_api::{noop::NoopNetwork, NetworkInfo, Peers};
 use reth_provider::{
@@ -256,7 +256,7 @@ where
     Network: NetworkInfo + Peers + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,
     Events: CanonStateSubscriptions + Clone + 'static,
-    EvmConfig: ConfigureEvm + 'static,
+    EvmConfig: ConfigureEvmGeneric + 'static,
 {
     let module_config = module_config.into();
     let server_config = server_config.into();
@@ -424,7 +424,7 @@ impl<Provider, Pool, Network, Tasks, Events, EvmConfig>
         evm_config: E,
     ) -> RpcModuleBuilder<Provider, Pool, Network, Tasks, Events, E>
     where
-        E: ConfigureEvm + 'static,
+        E: ConfigureEvmGeneric + 'static,
     {
         let Self { provider, pool, executor, network, events, .. } = self;
         RpcModuleBuilder { provider, network, pool, executor, events, evm_config }
@@ -447,7 +447,7 @@ where
     Network: NetworkInfo + Peers + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,
     Events: CanonStateSubscriptions + Clone + 'static,
-    EvmConfig: ConfigureEvm + 'static,
+    EvmConfig: ConfigureEvmGeneric + 'static,
 {
     /// Configures all [`RpcModule`]s specific to the given [`TransportRpcModuleConfig`] which can
     /// be used to start the transport server(s).
@@ -497,7 +497,7 @@ where
     /// use reth_tasks::TokioTaskExecutor;
     /// use reth_transaction_pool::noop::NoopTransactionPool;
     ///
-    /// fn init<Evm: ConfigureEvm + 'static>(evm: Evm) {
+    /// fn init<Evm: ConfigureEvmGeneric + 'static>(evm: Evm) {
     ///     let mut registry = RpcModuleBuilder::default()
     ///         .with_provider(NoopProvider::default())
     ///         .with_pool(NoopTransactionPool::default())
@@ -772,7 +772,7 @@ where
     Network: NetworkInfo + Peers + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,
     Events: CanonStateSubscriptions + Clone + 'static,
-    EvmConfig: ConfigureEvm + 'static,
+    EvmConfig: ConfigureEvmGeneric + 'static,
 {
     /// Register Eth Namespace
     ///

--- a/crates/rpc/rpc/src/eth/api/block.rs
+++ b/crates/rpc/rpc/src/eth/api/block.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     EthApi,
 };
-use reth_evm::ConfigureEvm;
+use reth_evm::ConfigureEvmGeneric;
 use reth_network_api::NetworkInfo;
 use reth_primitives::{BlockId, TransactionMeta};
 use reth_provider::{BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, StateProviderFactory};
@@ -22,7 +22,7 @@ where
         BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
     Pool: TransactionPool + Clone + 'static,
     Network: NetworkInfo + Send + Sync + 'static,
-    EvmConfig: ConfigureEvm + 'static,
+    EvmConfig: ConfigureEvmGeneric + 'static,
 {
     /// Returns the uncle headers of the given block
     ///

--- a/crates/rpc/rpc/src/eth/api/call.rs
+++ b/crates/rpc/rpc/src/eth/api/call.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     EthApi,
 };
-use reth_evm::ConfigureEvm;
+use reth_evm::ConfigureEvmGeneric;
 use reth_network_api::NetworkInfo;
 use reth_primitives::{revm::env::tx_env_with_recovered, BlockId, Bytes, TxKind, U256};
 use reth_provider::{
@@ -47,7 +47,7 @@ where
     Provider:
         BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
     Network: NetworkInfo + Send + Sync + 'static,
-    EvmConfig: ConfigureEvm + 'static,
+    EvmConfig: ConfigureEvmGeneric + 'static,
 {
     /// Estimate gas needed for execution of the `request` at the [`BlockId`].
     pub async fn estimate_gas_at(

--- a/crates/rpc/rpc/src/eth/api/fees.rs
+++ b/crates/rpc/rpc/src/eth/api/fees.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     EthApi,
 };
-use reth_evm::ConfigureEvm;
+use reth_evm::ConfigureEvmGeneric;
 use reth_network_api::NetworkInfo;
 use reth_primitives::{BlockNumberOrTag, U256};
 use reth_provider::{BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, StateProviderFactory};
@@ -21,7 +21,7 @@ where
     Provider:
         BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
     Network: NetworkInfo + Send + Sync + 'static,
-    EvmConfig: ConfigureEvm + 'static,
+    EvmConfig: ConfigureEvmGeneric + 'static,
 {
     /// Returns a suggestion for a gas price for legacy transactions.
     ///

--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -14,7 +14,7 @@ use crate::eth::{
 };
 use async_trait::async_trait;
 use reth_errors::{RethError, RethResult};
-use reth_evm::ConfigureEvm;
+use reth_evm::ConfigureEvmGeneric;
 use reth_network_api::NetworkInfo;
 use reth_primitives::{
     revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg},
@@ -276,7 +276,7 @@ where
         BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
     Pool: TransactionPool + Clone + 'static,
     Network: NetworkInfo + Send + Sync + 'static,
-    EvmConfig: ConfigureEvm + Clone + 'static,
+    EvmConfig: ConfigureEvmGeneric + Clone + 'static,
 {
     /// Configures the [`CfgEnvWithHandlerCfg`] and [`BlockEnv`] for the pending block
     ///
@@ -393,7 +393,7 @@ where
     Provider:
         BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
     Network: NetworkInfo + 'static,
-    EvmConfig: ConfigureEvm + 'static,
+    EvmConfig: ConfigureEvmGeneric + 'static,
 {
     /// Returns the current ethereum protocol version.
     ///

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -2,7 +2,7 @@
 //! Handles RPC requests for the `eth_` namespace.
 
 use jsonrpsee::core::RpcResult as Result;
-use reth_evm::ConfigureEvm;
+use reth_evm::ConfigureEvmGeneric;
 use reth_network_api::NetworkInfo;
 use reth_primitives::{Address, BlockId, BlockNumberOrTag, Bytes, B256, B64, U256, U64};
 use reth_provider::{
@@ -44,7 +44,7 @@ where
         + EvmEnvProvider
         + 'static,
     Network: NetworkInfo + Send + Sync + 'static,
-    EvmConfig: ConfigureEvm + 'static,
+    EvmConfig: ConfigureEvmGeneric + 'static,
 {
     /// Handler for: `eth_protocolVersion`
     async fn protocol_version(&self) -> Result<U64> {

--- a/crates/rpc/rpc/src/eth/api/state.rs
+++ b/crates/rpc/rpc/src/eth/api/state.rs
@@ -4,7 +4,7 @@ use crate::{
     eth::error::{EthApiError, EthResult, RpcInvalidTransactionError},
     EthApi,
 };
-use reth_evm::ConfigureEvm;
+use reth_evm::ConfigureEvmGeneric;
 use reth_primitives::{Address, BlockId, BlockNumberOrTag, Bytes, B256, U256};
 use reth_provider::{
     BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, StateProvider, StateProviderFactory,
@@ -19,7 +19,7 @@ where
         BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
     Pool: TransactionPool + Clone + 'static,
     Network: Send + Sync + 'static,
-    EvmConfig: ConfigureEvm + 'static,
+    EvmConfig: ConfigureEvmGeneric + 'static,
 {
     pub(crate) fn get_code(&self, address: Address, block_id: Option<BlockId>) -> EthResult<Bytes> {
         Ok(self

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use alloy_primitives::TxKind as RpcTransactionKind;
 use async_trait::async_trait;
-use reth_evm::ConfigureEvm;
+use reth_evm::ConfigureEvmGeneric;
 use reth_network_api::NetworkInfo;
 use reth_primitives::{
     eip4844::calc_blob_gasprice,
@@ -547,7 +547,7 @@ where
     Provider:
         BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
     Network: NetworkInfo + Send + Sync + 'static,
-    EvmConfig: ConfigureEvm + 'static,
+    EvmConfig: ConfigureEvmGeneric + 'static,
 {
     fn transact<DB>(
         &self,
@@ -556,11 +556,11 @@ where
     ) -> EthResult<(ResultAndState, EnvWithHandlerCfg)>
     where
         DB: Database,
-        <DB as Database>::Error: Into<EthApiError>,
+        DB::Error: Into<EthApiError>,
     {
-        let mut evm = self.inner.evm_config.evm_with_env(db, env);
+        let mut evm = self.inner.evm_config.evm_with_env_ext(db, env);
         let res = evm.transact()?;
-        let (_, env) = evm.into_db_and_env_with_handler_cfg();
+        let env = evm.env_with_handler_cfg();
         Ok((res, env))
     }
 
@@ -1386,7 +1386,7 @@ where
     Provider:
         BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
     Network: NetworkInfo + 'static,
-    EvmConfig: ConfigureEvm,
+    EvmConfig: ConfigureEvmGeneric,
 {
     /// Returns the gas price if it is set, otherwise fetches a suggested gas price for legacy
     /// transactions.

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -558,7 +558,7 @@ where
         DB: Database,
         DB::Error: Into<EthApiError>,
     {
-        let mut evm = self.inner.evm_config.evm_with_env_ext(db, env);
+        let mut evm = self.inner.evm_config.evm_with_env_generic(db, env);
         let res = evm.transact()?;
         let env = evm.env_with_handler_cfg();
         Ok((res, env))

--- a/crates/rpc/rpc/src/eth/cache/mod.rs
+++ b/crates/rpc/rpc/src/eth/cache/mod.rs
@@ -2,7 +2,7 @@
 
 use futures::{future::Either, Stream, StreamExt};
 use reth_errors::{ProviderError, ProviderResult};
-use reth_evm::ConfigureEvm;
+use reth_evm::ConfigureEvmGeneric;
 use reth_primitives::{
     Block, BlockHashOrNumber, BlockWithSenders, Receipt, SealedBlock, SealedBlockWithSenders,
     TransactionSigned, TransactionSignedEcRecovered, B256,
@@ -107,7 +107,7 @@ impl EthStateCache {
     ) -> Self
     where
         Provider: StateProviderFactory + BlockReader + EvmEnvProvider + Clone + Unpin + 'static,
-        EvmConfig: ConfigureEvm + 'static,
+        EvmConfig: ConfigureEvmGeneric + 'static,
     {
         Self::spawn_with(provider, config, TokioTaskExecutor::default(), evm_config)
     }
@@ -125,7 +125,7 @@ impl EthStateCache {
     where
         Provider: StateProviderFactory + BlockReader + EvmEnvProvider + Clone + Unpin + 'static,
         Tasks: TaskSpawner + Clone + 'static,
-        EvmConfig: ConfigureEvm + 'static,
+        EvmConfig: ConfigureEvmGeneric + 'static,
     {
         let EthStateCacheConfig { max_blocks, max_receipts, max_envs, max_concurrent_db_requests } =
             config;
@@ -316,7 +316,7 @@ impl<Provider, Tasks, EvmConfig> EthStateCacheService<Provider, Tasks, EvmConfig
 where
     Provider: StateProviderFactory + BlockReader + EvmEnvProvider + Clone + Unpin + 'static,
     Tasks: TaskSpawner + Clone + 'static,
-    EvmConfig: ConfigureEvm + 'static,
+    EvmConfig: ConfigureEvmGeneric + 'static,
 {
     fn on_new_block(&mut self, block_hash: B256, res: ProviderResult<Option<BlockWithSenders>>) {
         if let Some(queued) = self.full_block_cache.remove(&block_hash) {
@@ -403,7 +403,7 @@ impl<Provider, Tasks, EvmConfig> Future for EthStateCacheService<Provider, Tasks
 where
     Provider: StateProviderFactory + BlockReader + EvmEnvProvider + Clone + Unpin + 'static,
     Tasks: TaskSpawner + Clone + 'static,
-    EvmConfig: ConfigureEvm + 'static,
+    EvmConfig: ConfigureEvmGeneric + 'static,
 {
     type Output = ();
 

--- a/examples/custom-evm/Cargo.toml
+++ b/examples/custom-evm/Cargo.toml
@@ -12,8 +12,6 @@ reth-node-core.workspace = true
 reth-primitives.workspace = true
 reth-node-ethereum.workspace = true
 reth-tracing.workspace = true
-revm-primitives.workspace = true
-reth-evm.workspace = true
 
 eyre.workspace = true
 tokio.workspace = true

--- a/examples/custom-evm/Cargo.toml
+++ b/examples/custom-evm/Cargo.toml
@@ -12,6 +12,8 @@ reth-node-core.workspace = true
 reth-primitives.workspace = true
 reth-node-ethereum.workspace = true
 reth-tracing.workspace = true
+revm-primitives.workspace = true
+reth-evm.workspace = true
 
 eyre.workspace = true
 tokio.workspace = true

--- a/examples/custom-evm/src/main.rs
+++ b/examples/custom-evm/src/main.rs
@@ -17,13 +17,11 @@ use reth::{
     },
     tasks::TaskManager,
 };
-use reth_evm::execute::EvmTransact;
 use reth_node_api::{ConfigureEvm, ConfigureEvmEnv, ConfigureEvmGeneric, FullNodeTypes};
 use reth_node_core::{args::RpcServerArgs, node_config::NodeConfig};
 use reth_node_ethereum::{EthEvmConfig, EthExecutorProvider, EthereumNode};
 use reth_primitives::{Chain, ChainSpec, Genesis, Header, TransactionSigned};
 use reth_tracing::{RethTracer, Tracer};
-use revm_primitives::EnvWithHandlerCfg;
 use std::sync::Arc;
 
 /// Custom EVM configuration
@@ -103,21 +101,7 @@ impl ConfigureEvm for MyEvmConfig {
     }
 }
 
-impl ConfigureEvmGeneric for MyEvmConfig {
-    fn evm_with_env_ext<'a, DB>(
-        &'a self,
-        db: DB,
-        env: EnvWithHandlerCfg,
-    ) -> Box<dyn EvmTransact<DB = DB> + 'a>
-    where
-        DB: Database + 'a,
-    {
-        let mut evm = self.evm(db);
-        evm.modify_spec_id(env.spec_id());
-        evm.context.evm.env = env.env;
-        Box::new(evm)
-    }
-}
+impl ConfigureEvmGeneric for MyEvmConfig {}
 
 /// Builds a regular ethereum block executor that uses the custom EVM.
 #[derive(Debug, Default, Clone, Copy)]


### PR DESCRIPTION
WIP on #8672. I am currently not happy at all on the `EvmContext` trait, but can't figure out how to set up the trait correctly in order to incorporate the builder pattern in it. 

The main issue comes when I want to implement it for `revm::Evm`. The way the `EvmBuilder` uses the `Stage` marker type and the lifetime bound on `revm::Evm` makes it really hard to implement a builder pattern for it. I don't know if you have suggestions @mattsse about changes.