### PR TITLE
fix: add a 5 second timeout for `tokio_runtime` shutdown

### DIFF
--- a/crates/cli/runner/src/lib.rs
+++ b/crates/cli/runner/src/lib.rs
@@ -68,9 +68,7 @@ impl CliRunner {
             })
             .unwrap();
 
-        if rx.recv_timeout(Duration::from_secs(5)).is_err() {
-            error!(target: "reth::cli", "could not shutdown runtime gracefully");
-        }
+        let _ = rx.recv_timeout(Duration::from_secs(5));
 
         command_res
     }

--- a/crates/cli/runner/src/lib.rs
+++ b/crates/cli/runner/src/lib.rs
@@ -68,8 +68,8 @@ impl CliRunner {
             })
             .unwrap();
 
-        let _ = rx.recv_timeout(Duration::from_secs(5)).inspect_err(|| {
-            debug!(target: "reth::cli", "tokio runtime shutdown timed out");
+        let _ = rx.recv_timeout(Duration::from_secs(5)).inspect_err(|err| {
+            debug!(target: "reth::cli", %err, "tokio runtime shutdown timed out");
         });
 
         command_res

--- a/crates/cli/runner/src/lib.rs
+++ b/crates/cli/runner/src/lib.rs
@@ -68,7 +68,9 @@ impl CliRunner {
             })
             .unwrap();
 
-        let _ = rx.recv_timeout(Duration::from_secs(5));
+        let _ = rx.recv_timeout(Duration::from_secs(5)).inspect_err(|| {
+            debug!(target: "reth::cli", "tokio runtime shutdown timed out");
+        });
 
         command_res
     }

--- a/crates/cli/runner/src/lib.rs
+++ b/crates/cli/runner/src/lib.rs
@@ -52,7 +52,7 @@ impl CliRunner {
             // after the command has finished or exit signal was received we shutdown the task
             // manager which fires the shutdown signal to all tasks spawned via the task
             // executor and awaiting on tasks spawned with graceful shutdown
-            task_manager.graceful_shutdown_with_timeout(std::time::Duration::from_secs(10));
+            task_manager.graceful_shutdown_with_timeout(Duration::from_secs(5));
         }
 
         // `drop(tokio_runtime)` would block the current thread until its pools


### PR DESCRIPTION
Waits 5 seconds for `tokio_runtime` to shutdown. Making a best effort to allow components to have a chance to drop cleanly should be preferred. Examples: allows for `StorageLock` file to be cleared (not a must) or errors to be properly printed (eg. https://github.com/paradigmxyz/reth/issues/8772).

Acknowledging that for long blocking tasks, this will timeout anyway. (eg. sender recovery stage)

Also, reduces `task_manager` shutdown timeout to 5 seconds as to not increase the worst case waiting time.