### PR TITLE
feat(static-file): replace string metric name with enum

### DIFF
--- a/crates/storage/provider/src/providers/static_file/metrics.rs
+++ b/crates/storage/provider/src/providers/static_file/metrics.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, time::Duration};
+use std::time::Duration;
 
 use itertools::Itertools;
 use metrics::{Counter, Gauge, Histogram};
@@ -7,41 +7,38 @@ use reth_primitives::StaticFileSegment;
 use strum::{EnumIter, IntoEnumIterator};
 
 /// Metrics for the static file provider.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct StaticFileProviderMetrics {
-    segments: HashMap<StaticFileSegment, StaticFileSegmentMetrics>,
-    segment_operations: HashMap<
-        (StaticFileSegment, StaticFileProviderOperation),
-        StaticFileProviderOperationMetrics,
-    >,
+    segments: StaticFileSegmentMetrics,
+    segment_operations: StaticFileProviderOperationMetrics,
 }
 
-impl Default for StaticFileProviderMetrics {
-    fn default() -> Self {
-        Self {
-            segments: StaticFileSegment::iter()
-                .map(|segment| {
-                    (
-                        segment,
-                        StaticFileSegmentMetrics::new_with_labels(&[("segment", segment.as_str())]),
-                    )
-                })
-                .collect(),
-            segment_operations: StaticFileSegment::iter()
-                .cartesian_product(StaticFileProviderOperation::iter())
-                .map(|(segment, operation)| {
-                    (
-                        (segment, operation),
-                        StaticFileProviderOperationMetrics::new_with_labels(&[
-                            ("segment", segment.as_str()),
-                            ("operation", operation.as_str()),
-                        ]),
-                    )
-                })
-                .collect(),
-        }
-    }
-}
+// impl Default for StaticFileProviderMetrics {
+//     fn default() -> Self {
+//         Self {
+//             segments: StaticFileSegment::iter()
+//                 .map(|segment| {
+//                     (
+//                         segment,
+//                         StaticFileSegmentMetrics::new_with_labels(&[("segment",
+// segment.as_str())]),                     )
+//                 })
+//                 .collect(),
+//             segment_operations: StaticFileSegment::iter()
+//                 .cartesian_product(StaticFileProviderOperation::iter())
+//                 .map(|(segment, operation)| {
+//                     (
+//                         (segment, operation),
+//                         StaticFileProviderOperationMetrics::new_with_labels(&[
+//                             ("segment", segment.as_str()),
+//                             ("operation", operation.as_str()),
+//                         ]),
+//                     )
+//                 })
+//                 .collect(),
+//         }
+//     }
+// }
 
 impl StaticFileProviderMetrics {
     pub(crate) fn record_segment(
@@ -51,13 +48,23 @@ impl StaticFileProviderMetrics {
         files: usize,
         entries: usize,
     ) {
-        self.segments.get(&segment).expect("segment metrics should exist").size.set(size as f64);
-        self.segments.get(&segment).expect("segment metrics should exist").files.set(files as f64);
-        self.segments
-            .get(&segment)
-            .expect("segment metrics should exist")
-            .entries
-            .set(entries as f64);
+        match segment {
+            StaticFileSegment::Headers => {
+                self.segments.headers_size.set(size as f64);
+                self.segments.headers_files.set(files as f64);
+                self.segments.headers_entries.set(entries as f64);
+            }
+            StaticFileSegment::Transactions => {
+                self.segments.transactions_size.set(size as f64);
+                self.segments.transactions_files.set(files as f64);
+                self.segments.transactions_entries.set(entries as f64);
+            }
+            StaticFileSegment::Receipts => {
+                self.segments.receipts_size.set(size as f64);
+                self.segments.receipts_files.set(files as f64);
+                self.segments.receipts_entries.set(entries as f64);
+            }
+        }
     }
 
     pub(crate) fn record_segment_operation(
@@ -66,18 +73,151 @@ impl StaticFileProviderMetrics {
         operation: StaticFileProviderOperation,
         duration: Option<Duration>,
     ) {
-        self.segment_operations
-            .get(&(segment, operation))
-            .expect("segment operation metrics should exist")
-            .calls_total
-            .increment(1);
-
-        if let Some(duration) = duration {
-            self.segment_operations
-                .get(&(segment, operation))
-                .expect("segment operation metrics should exist")
-                .write_duration_seconds
-                .record(duration.as_secs_f64());
+        match (segment, operation) {
+            (StaticFileSegment::Headers, StaticFileProviderOperation::InitCursor) => {
+                self.segment_operations.headers_init_cursor_calls_total.increment(1);
+                if let Some(duration) = duration {
+                    self.segment_operations
+                        .headers_init_cursor_write_duration_seconds
+                        .record(duration.as_secs_f64());
+                }
+            }
+            (StaticFileSegment::Headers, StaticFileProviderOperation::OpenWriter) => {
+                self.segment_operations.headers_open_writer_calls_total.increment(1);
+                if let Some(duration) = duration {
+                    self.segment_operations
+                        .headers_open_writer_write_duration_seconds
+                        .record(duration.as_secs_f64());
+                }
+            }
+            (StaticFileSegment::Headers, StaticFileProviderOperation::Append) => {
+                self.segment_operations.headers_append_calls_total.increment(1);
+                if let Some(duration) = duration {
+                    self.segment_operations
+                        .headers_append_write_duration_seconds
+                        .record(duration.as_secs_f64());
+                }
+            }
+            (StaticFileSegment::Headers, StaticFileProviderOperation::Prune) => {
+                self.segment_operations.headers_prune_calls_total.increment(1);
+                if let Some(duration) = duration {
+                    self.segment_operations
+                        .headers_prune_write_duration_seconds
+                        .record(duration.as_secs_f64());
+                }
+            }
+            (StaticFileSegment::Headers, StaticFileProviderOperation::IncrementBlock) => {
+                self.segment_operations.headers_increment_block_calls_total.increment(1);
+                if let Some(duration) = duration {
+                    self.segment_operations
+                        .headers_increment_block_write_duration_seconds
+                        .record(duration.as_secs_f64());
+                }
+            }
+            (StaticFileSegment::Headers, StaticFileProviderOperation::CommitWriter) => {
+                self.segment_operations.headers_commit_writer_calls_total.increment(1);
+                if let Some(duration) = duration {
+                    self.segment_operations
+                        .headers_commit_writer_write_duration_seconds
+                        .record(duration.as_secs_f64());
+                }
+            }
+            (StaticFileSegment::Transactions, StaticFileProviderOperation::InitCursor) => {
+                self.segment_operations.transactions_init_cursor_calls_total.increment(1);
+                if let Some(duration) = duration {
+                    self.segment_operations
+                        .transactions_init_cursor_write_duration_seconds
+                        .record(duration.as_secs_f64());
+                }
+            }
+            (StaticFileSegment::Transactions, StaticFileProviderOperation::OpenWriter) => {
+                self.segment_operations.transactions_open_writer_calls_total.increment(1);
+                if let Some(duration) = duration {
+                    self.segment_operations
+                        .transactions_open_writer_write_duration_seconds
+                        .record(duration.as_secs_f64());
+                }
+            }
+            (StaticFileSegment::Transactions, StaticFileProviderOperation::Append) => {
+                self.segment_operations.transactions_append_calls_total.increment(1);
+                if let Some(duration) = duration {
+                    self.segment_operations
+                        .transactions_append_write_duration_seconds
+                        .record(duration.as_secs_f64());
+                }
+            }
+            (StaticFileSegment::Transactions, StaticFileProviderOperation::Prune) => {
+                self.segment_operations.transactions_prune_calls_total.increment(1);
+                if let Some(duration) = duration {
+                    self.segment_operations
+                        .transactions_prune_write_duration_seconds
+                        .record(duration.as_secs_f64());
+                }
+            }
+            (StaticFileSegment::Transactions, StaticFileProviderOperation::IncrementBlock) => {
+                self.segment_operations.transactions_increment_block_calls_total.increment(1);
+                if let Some(duration) = duration {
+                    self.segment_operations
+                        .transactions_increment_block_write_duration_seconds
+                        .record(duration.as_secs_f64());
+                }
+            }
+            (StaticFileSegment::Transactions, StaticFileProviderOperation::CommitWriter) => {
+                self.segment_operations.transactions_commit_writer_calls_total.increment(1);
+                if let Some(duration) = duration {
+                    self.segment_operations
+                        .transactions_commit_writer_write_duration_seconds
+                        .record(duration.as_secs_f64());
+                }
+            }
+            (StaticFileSegment::Receipts, StaticFileProviderOperation::InitCursor) => {
+                self.segment_operations.receipts_init_cursor_calls_total.increment(1);
+                if let Some(duration) = duration {
+                    self.segment_operations
+                        .receipts_init_cursor_write_duration_seconds
+                        .record(duration.as_secs_f64());
+                }
+            }
+            (StaticFileSegment::Receipts, StaticFileProviderOperation::OpenWriter) => {
+                self.segment_operations.receipts_open_writer_calls_total.increment(1);
+                if let Some(duration) = duration {
+                    self.segment_operations
+                        .receipts_open_writer_write_duration_seconds
+                        .record(duration.as_secs_f64());
+                }
+            }
+            (StaticFileSegment::Receipts, StaticFileProviderOperation::Append) => {
+                self.segment_operations.receipts_append_calls_total.increment(1);
+                if let Some(duration) = duration {
+                    self.segment_operations
+                        .receipts_append_write_duration_seconds
+                        .record(duration.as_secs_f64());
+                }
+            }
+            (StaticFileSegment::Receipts, StaticFileProviderOperation::Prune) => {
+                self.segment_operations.receipts_prune_calls_total.increment(1);
+                if let Some(duration) = duration {
+                    self.segment_operations
+                        .receipts_prune_write_duration_seconds
+                        .record(duration.as_secs_f64());
+                }
+            }
+            (StaticFileSegment::Receipts, StaticFileProviderOperation::IncrementBlock) => {
+                self.segment_operations.receipts_increment_block_calls_total.increment(1);
+                if let Some(duration) = duration {
+                    self.segment_operations
+                        .receipts_increment_block_write_duration_seconds
+                        .record(duration.as_secs_f64());
+                }
+            }
+            (StaticFileSegment::Receipts, StaticFileProviderOperation::CommitWriter) => {
+                self.segment_operations.receipts_commit_writer_calls_total.increment(1);
+                if let Some(duration) = duration {
+                    self.segment_operations
+                        .receipts_commit_writer_write_duration_seconds
+                        .record(duration.as_secs_f64());
+                }
+            }
         }
     }
 }
@@ -109,19 +249,117 @@ impl StaticFileProviderOperation {
 #[derive(Metrics)]
 #[metrics(scope = "static_files.segment")]
 pub(crate) struct StaticFileSegmentMetrics {
-    /// The size of a static file segment
-    size: Gauge,
-    /// The number of files for a static file segment
-    files: Gauge,
-    /// The number of entries for a static file segment
-    entries: Gauge,
+    /// The size of a header static file segment.
+    headers_size: Gauge,
+    /// The size of a transaction static file segment.
+    transactions_size: Gauge,
+    /// The size of a receipt static file segment.
+    receipts_size: Gauge,
+    /// The number of files for a header static file segment.
+    headers_files: Gauge,
+    /// The number of files for a transaction static file segment.
+    transactions_files: Gauge,
+    /// The number of files for a receipt static file segment.
+    receipts_files: Gauge,
+    /// The number of entries for a receipt static file segment.
+    headers_entries: Gauge,
+    /// The number of entries for a transaction static file segment.
+    transactions_entries: Gauge,
+    /// The number of entries for a header static file segment.
+    receipts_entries: Gauge,
 }
 
 #[derive(Metrics)]
 #[metrics(scope = "static_files.jar_provider")]
 pub(crate) struct StaticFileProviderOperationMetrics {
-    /// Total number of static file jar provider operations made.
-    calls_total: Counter,
-    /// The time it took to execute the static file jar provider operation that writes data.
-    write_duration_seconds: Histogram,
+    /// Total number of calls to the init cursor operation on headers static file segment.
+    headers_init_cursor_calls_total: Counter,
+    /// Total number of calls to the open writer operation on headers static file segment.
+    headers_open_writer_calls_total: Counter,
+    /// Total number of calls to the append operation on headers static file segment.
+    headers_append_calls_total: Counter,
+    /// Total number of calls to the prune operation on headers static file segment.
+    headers_prune_calls_total: Counter,
+    /// Total number of calls to the increment block operation on headers static file segment.
+    headers_increment_block_calls_total: Counter,
+    /// Total number of calls to the commit writer operation on headers static file segment.
+    headers_commit_writer_calls_total: Counter,
+    /// Total number of calls to the init cursor operation on transactions static file segment.
+    transactions_init_cursor_calls_total: Counter,
+    /// Total number of calls to the open writer operation on transactions static file segment.
+    transactions_open_writer_calls_total: Counter,
+    /// Total number of calls to the append operation on transactions static file segment.
+    transactions_append_calls_total: Counter,
+    /// Total number of calls to the prune operation on transactions static file segment.
+    transactions_prune_calls_total: Counter,
+    /// Total number of calls to the increment block operation on transactions static file segment.
+    transactions_increment_block_calls_total: Counter,
+    /// Total number of calls to the commit writer operation on transactions static file segment.
+    transactions_commit_writer_calls_total: Counter,
+    /// Total number of calls to the init cursor operation on receipts static file segment.
+    receipts_init_cursor_calls_total: Counter,
+    /// Total number of calls to the open writer operation on receipts static file segment.
+    receipts_open_writer_calls_total: Counter,
+    /// Total number of calls to the append operation on receipts static file segment.
+    receipts_append_calls_total: Counter,
+    /// Total number of calls to the prune operation on receipts static file segment.
+    receipts_prune_calls_total: Counter,
+    /// Total number of calls to the increment block operation on receipts static file segment.
+    receipts_increment_block_calls_total: Counter,
+    /// Total number of calls to the commit writer operation on receipts static file segment.
+    receipts_commit_writer_calls_total: Counter,
+    /// The time it took to execute the headers static file jar provider operation that initializes
+    /// a cursor.
+    headers_init_cursor_write_duration_seconds: Histogram,
+    /// The time it took to execute the headers static file jar provider operation that opens a
+    /// writer.
+    headers_open_writer_write_duration_seconds: Histogram,
+    /// The time it took to execute the headers static file jar provider operation that appends
+    /// data.
+    headers_append_write_duration_seconds: Histogram,
+    /// The time it took to execute the headers static file jar provider operation that prunes
+    /// data.
+    headers_prune_write_duration_seconds: Histogram,
+    /// The time it took to execute the headers static file jar provider operation that increments
+    /// the block.
+    headers_increment_block_write_duration_seconds: Histogram,
+    /// The time it took to execute the headers static file jar provider operation that commits
+    /// the writer.
+    headers_commit_writer_write_duration_seconds: Histogram,
+    /// The time it took to execute the transactions static file jar provider operation that
+    /// initializes a cursor.
+    transactions_init_cursor_write_duration_seconds: Histogram,
+    /// The time it took to execute the transactions static file jar provider operation that opens
+    /// a writer.
+    transactions_open_writer_write_duration_seconds: Histogram,
+    /// The time it took to execute the transactions static file jar provider operation that
+    /// appends data.
+    transactions_append_write_duration_seconds: Histogram,
+    /// The time it took to execute the transactions static file jar provider operation that prunes
+    /// data.
+    transactions_prune_write_duration_seconds: Histogram,
+    /// The time it took to execute the transactions static file jar provider operation that
+    /// increments the block.
+    transactions_increment_block_write_duration_seconds: Histogram,
+    /// The time it took to execute the transactions static file jar provider operation that
+    /// commits the writer.
+    transactions_commit_writer_write_duration_seconds: Histogram,
+    /// The time it took to execute the receipts static file jar provider operation that
+    /// initializes a cursor.
+    receipts_init_cursor_write_duration_seconds: Histogram,
+    /// The time it took to execute the receipts static file jar provider operation that opens a
+    /// writer.
+    receipts_open_writer_write_duration_seconds: Histogram,
+    /// The time it took to execute the receipts static file jar provider operation that appends
+    /// data.
+    receipts_append_write_duration_seconds: Histogram,
+    /// The time it took to execute the receipts static file jar provider operation that prunes
+    /// data.
+    receipts_prune_write_duration_seconds: Histogram,
+    /// The time it took to execute the receipts static file jar provider operation that increments
+    /// the block.
+    receipts_increment_block_write_duration_seconds: Histogram,
+    /// The time it took to execute the receipts static file jar provider operation that commits
+    /// the writer.
+    receipts_commit_writer_write_duration_seconds: Histogram,
 }

--- a/crates/storage/provider/src/providers/static_file/metrics.rs
+++ b/crates/storage/provider/src/providers/static_file/metrics.rs
@@ -1,10 +1,9 @@
 use std::time::Duration;
 
-use itertools::Itertools;
 use metrics::{Counter, Gauge, Histogram};
 use reth_metrics::Metrics;
 use reth_primitives::StaticFileSegment;
-use strum::{EnumIter, IntoEnumIterator};
+use strum::EnumIter;
 
 /// Metrics for the static file provider.
 #[derive(Debug, Default)]
@@ -12,33 +11,6 @@ pub struct StaticFileProviderMetrics {
     segments: StaticFileSegmentMetrics,
     segment_operations: StaticFileProviderOperationMetrics,
 }
-
-// impl Default for StaticFileProviderMetrics {
-//     fn default() -> Self {
-//         Self {
-//             segments: StaticFileSegment::iter()
-//                 .map(|segment| {
-//                     (
-//                         segment,
-//                         StaticFileSegmentMetrics::new_with_labels(&[("segment",
-// segment.as_str())]),                     )
-//                 })
-//                 .collect(),
-//             segment_operations: StaticFileSegment::iter()
-//                 .cartesian_product(StaticFileProviderOperation::iter())
-//                 .map(|(segment, operation)| {
-//                     (
-//                         (segment, operation),
-//                         StaticFileProviderOperationMetrics::new_with_labels(&[
-//                             ("segment", segment.as_str()),
-//                             ("operation", operation.as_str()),
-//                         ]),
-//                     )
-//                 })
-//                 .collect(),
-//         }
-//     }
-// }
 
 impl StaticFileProviderMetrics {
     pub(crate) fn record_segment(
@@ -230,19 +202,6 @@ pub(crate) enum StaticFileProviderOperation {
     Prune,
     IncrementBlock,
     CommitWriter,
-}
-
-impl StaticFileProviderOperation {
-    const fn as_str(&self) -> &'static str {
-        match self {
-            Self::InitCursor => "init-cursor",
-            Self::OpenWriter => "open-writer",
-            Self::Append => "append",
-            Self::Prune => "prune",
-            Self::IncrementBlock => "increment-block",
-            Self::CommitWriter => "commit-writer",
-        }
-    }
 }
 
 /// Metrics for a specific static file segment.

--- a/crates/storage/provider/src/providers/static_file/metrics.rs
+++ b/crates/storage/provider/src/providers/static_file/metrics.rs
@@ -45,150 +45,159 @@ impl StaticFileProviderMetrics {
         operation: StaticFileProviderOperation,
         duration: Option<Duration>,
     ) {
+        macro_rules! record_operation {
+            ($self:ident, $counter:ident, $histogram:ident, $duration:expr) => {
+                $self.segment_operations.$counter.increment(1);
+                if let Some(duration) = $duration {
+                    $self.segment_operations.$histogram.record(duration.as_secs_f64());
+                }
+            };
+        }
+
         match (segment, operation) {
             (StaticFileSegment::Headers, StaticFileProviderOperation::InitCursor) => {
-                self.segment_operations.headers_init_cursor_calls_total.increment(1);
-                if let Some(duration) = duration {
-                    self.segment_operations
-                        .headers_init_cursor_write_duration_seconds
-                        .record(duration.as_secs_f64());
-                }
+                record_operation!(
+                    self,
+                    headers_init_cursor_calls_total,
+                    headers_init_cursor_duration_seconds,
+                    duration
+                );
             }
             (StaticFileSegment::Headers, StaticFileProviderOperation::OpenWriter) => {
-                self.segment_operations.headers_open_writer_calls_total.increment(1);
-                if let Some(duration) = duration {
-                    self.segment_operations
-                        .headers_open_writer_write_duration_seconds
-                        .record(duration.as_secs_f64());
-                }
+                record_operation!(
+                    self,
+                    headers_open_writer_calls_total,
+                    headers_open_writer_duration_seconds,
+                    duration
+                );
             }
             (StaticFileSegment::Headers, StaticFileProviderOperation::Append) => {
-                self.segment_operations.headers_append_calls_total.increment(1);
-                if let Some(duration) = duration {
-                    self.segment_operations
-                        .headers_append_write_duration_seconds
-                        .record(duration.as_secs_f64());
-                }
+                record_operation!(
+                    self,
+                    headers_append_calls_total,
+                    headers_append_duration_seconds,
+                    duration
+                );
             }
             (StaticFileSegment::Headers, StaticFileProviderOperation::Prune) => {
-                self.segment_operations.headers_prune_calls_total.increment(1);
-                if let Some(duration) = duration {
-                    self.segment_operations
-                        .headers_prune_write_duration_seconds
-                        .record(duration.as_secs_f64());
-                }
+                record_operation!(
+                    self,
+                    headers_prune_calls_total,
+                    headers_prune_duration_seconds,
+                    duration
+                );
             }
             (StaticFileSegment::Headers, StaticFileProviderOperation::IncrementBlock) => {
-                self.segment_operations.headers_increment_block_calls_total.increment(1);
-                if let Some(duration) = duration {
-                    self.segment_operations
-                        .headers_increment_block_write_duration_seconds
-                        .record(duration.as_secs_f64());
-                }
+                record_operation!(
+                    self,
+                    headers_increment_block_calls_total,
+                    headers_increment_block_duration_seconds,
+                    duration
+                );
             }
             (StaticFileSegment::Headers, StaticFileProviderOperation::CommitWriter) => {
-                self.segment_operations.headers_commit_writer_calls_total.increment(1);
-                if let Some(duration) = duration {
-                    self.segment_operations
-                        .headers_commit_writer_write_duration_seconds
-                        .record(duration.as_secs_f64());
-                }
+                record_operation!(
+                    self,
+                    headers_commit_writer_calls_total,
+                    headers_commit_writer_duration_seconds,
+                    duration
+                );
             }
             (StaticFileSegment::Transactions, StaticFileProviderOperation::InitCursor) => {
-                self.segment_operations.transactions_init_cursor_calls_total.increment(1);
-                if let Some(duration) = duration {
-                    self.segment_operations
-                        .transactions_init_cursor_write_duration_seconds
-                        .record(duration.as_secs_f64());
-                }
+                record_operation!(
+                    self,
+                    transactions_init_cursor_calls_total,
+                    transactions_init_cursor_duration_seconds,
+                    duration
+                );
             }
             (StaticFileSegment::Transactions, StaticFileProviderOperation::OpenWriter) => {
-                self.segment_operations.transactions_open_writer_calls_total.increment(1);
-                if let Some(duration) = duration {
-                    self.segment_operations
-                        .transactions_open_writer_write_duration_seconds
-                        .record(duration.as_secs_f64());
-                }
+                record_operation!(
+                    self,
+                    transactions_open_writer_calls_total,
+                    transactions_open_writer_duration_seconds,
+                    duration
+                );
             }
             (StaticFileSegment::Transactions, StaticFileProviderOperation::Append) => {
-                self.segment_operations.transactions_append_calls_total.increment(1);
-                if let Some(duration) = duration {
-                    self.segment_operations
-                        .transactions_append_write_duration_seconds
-                        .record(duration.as_secs_f64());
-                }
+                record_operation!(
+                    self,
+                    transactions_append_calls_total,
+                    transactions_append_duration_seconds,
+                    duration
+                );
             }
             (StaticFileSegment::Transactions, StaticFileProviderOperation::Prune) => {
-                self.segment_operations.transactions_prune_calls_total.increment(1);
-                if let Some(duration) = duration {
-                    self.segment_operations
-                        .transactions_prune_write_duration_seconds
-                        .record(duration.as_secs_f64());
-                }
+                record_operation!(
+                    self,
+                    transactions_prune_calls_total,
+                    transactions_prune_duration_seconds,
+                    duration
+                );
             }
             (StaticFileSegment::Transactions, StaticFileProviderOperation::IncrementBlock) => {
-                self.segment_operations.transactions_increment_block_calls_total.increment(1);
-                if let Some(duration) = duration {
-                    self.segment_operations
-                        .transactions_increment_block_write_duration_seconds
-                        .record(duration.as_secs_f64());
-                }
+                record_operation!(
+                    self,
+                    transactions_increment_block_calls_total,
+                    transactions_increment_block_duration_seconds,
+                    duration
+                );
             }
             (StaticFileSegment::Transactions, StaticFileProviderOperation::CommitWriter) => {
-                self.segment_operations.transactions_commit_writer_calls_total.increment(1);
-                if let Some(duration) = duration {
-                    self.segment_operations
-                        .transactions_commit_writer_write_duration_seconds
-                        .record(duration.as_secs_f64());
-                }
+                record_operation!(
+                    self,
+                    transactions_commit_writer_calls_total,
+                    transactions_commit_writer_duration_seconds,
+                    duration
+                );
             }
             (StaticFileSegment::Receipts, StaticFileProviderOperation::InitCursor) => {
-                self.segment_operations.receipts_init_cursor_calls_total.increment(1);
-                if let Some(duration) = duration {
-                    self.segment_operations
-                        .receipts_init_cursor_write_duration_seconds
-                        .record(duration.as_secs_f64());
-                }
+                record_operation!(
+                    self,
+                    receipts_init_cursor_calls_total,
+                    receipts_init_cursor_duration_seconds,
+                    duration
+                );
             }
             (StaticFileSegment::Receipts, StaticFileProviderOperation::OpenWriter) => {
-                self.segment_operations.receipts_open_writer_calls_total.increment(1);
-                if let Some(duration) = duration {
-                    self.segment_operations
-                        .receipts_open_writer_write_duration_seconds
-                        .record(duration.as_secs_f64());
-                }
+                record_operation!(
+                    self,
+                    receipts_open_writer_calls_total,
+                    receipts_open_writer_duration_seconds,
+                    duration
+                );
             }
             (StaticFileSegment::Receipts, StaticFileProviderOperation::Append) => {
-                self.segment_operations.receipts_append_calls_total.increment(1);
-                if let Some(duration) = duration {
-                    self.segment_operations
-                        .receipts_append_write_duration_seconds
-                        .record(duration.as_secs_f64());
-                }
+                record_operation!(
+                    self,
+                    receipts_append_calls_total,
+                    receipts_append_duration_seconds,
+                    duration
+                );
             }
             (StaticFileSegment::Receipts, StaticFileProviderOperation::Prune) => {
-                self.segment_operations.receipts_prune_calls_total.increment(1);
-                if let Some(duration) = duration {
-                    self.segment_operations
-                        .receipts_prune_write_duration_seconds
-                        .record(duration.as_secs_f64());
-                }
+                record_operation!(
+                    self,
+                    receipts_prune_calls_total,
+                    receipts_prune_duration_seconds,
+                    duration
+                );
             }
             (StaticFileSegment::Receipts, StaticFileProviderOperation::IncrementBlock) => {
-                self.segment_operations.receipts_increment_block_calls_total.increment(1);
-                if let Some(duration) = duration {
-                    self.segment_operations
-                        .receipts_increment_block_write_duration_seconds
-                        .record(duration.as_secs_f64());
-                }
+                record_operation!(
+                    self,
+                    receipts_increment_block_calls_total,
+                    receipts_increment_block_duration_seconds,
+                    duration
+                );
             }
             (StaticFileSegment::Receipts, StaticFileProviderOperation::CommitWriter) => {
-                self.segment_operations.receipts_commit_writer_calls_total.increment(1);
-                if let Some(duration) = duration {
-                    self.segment_operations
-                        .receipts_commit_writer_write_duration_seconds
-                        .record(duration.as_secs_f64());
-                }
+                record_operation!(
+                    self,
+                    receipts_commit_writer_calls_total,
+                    receipts_commit_writer_duration_seconds,
+                    duration
+                );
             }
         }
     }
@@ -269,56 +278,56 @@ pub(crate) struct StaticFileProviderOperationMetrics {
     receipts_commit_writer_calls_total: Counter,
     /// The time it took to execute the headers static file jar provider operation that initializes
     /// a cursor.
-    headers_init_cursor_write_duration_seconds: Histogram,
+    headers_init_cursor_duration_seconds: Histogram,
     /// The time it took to execute the headers static file jar provider operation that opens a
     /// writer.
-    headers_open_writer_write_duration_seconds: Histogram,
+    headers_open_writer_duration_seconds: Histogram,
     /// The time it took to execute the headers static file jar provider operation that appends
     /// data.
-    headers_append_write_duration_seconds: Histogram,
+    headers_append_duration_seconds: Histogram,
     /// The time it took to execute the headers static file jar provider operation that prunes
     /// data.
-    headers_prune_write_duration_seconds: Histogram,
+    headers_prune_duration_seconds: Histogram,
     /// The time it took to execute the headers static file jar provider operation that increments
     /// the block.
-    headers_increment_block_write_duration_seconds: Histogram,
+    headers_increment_block_duration_seconds: Histogram,
     /// The time it took to execute the headers static file jar provider operation that commits
     /// the writer.
-    headers_commit_writer_write_duration_seconds: Histogram,
+    headers_commit_writer_duration_seconds: Histogram,
     /// The time it took to execute the transactions static file jar provider operation that
     /// initializes a cursor.
-    transactions_init_cursor_write_duration_seconds: Histogram,
+    transactions_init_cursor_duration_seconds: Histogram,
     /// The time it took to execute the transactions static file jar provider operation that opens
     /// a writer.
-    transactions_open_writer_write_duration_seconds: Histogram,
+    transactions_open_writer_duration_seconds: Histogram,
     /// The time it took to execute the transactions static file jar provider operation that
     /// appends data.
-    transactions_append_write_duration_seconds: Histogram,
+    transactions_append_duration_seconds: Histogram,
     /// The time it took to execute the transactions static file jar provider operation that prunes
     /// data.
-    transactions_prune_write_duration_seconds: Histogram,
+    transactions_prune_duration_seconds: Histogram,
     /// The time it took to execute the transactions static file jar provider operation that
     /// increments the block.
-    transactions_increment_block_write_duration_seconds: Histogram,
+    transactions_increment_block_duration_seconds: Histogram,
     /// The time it took to execute the transactions static file jar provider operation that
     /// commits the writer.
-    transactions_commit_writer_write_duration_seconds: Histogram,
+    transactions_commit_writer_duration_seconds: Histogram,
     /// The time it took to execute the receipts static file jar provider operation that
     /// initializes a cursor.
-    receipts_init_cursor_write_duration_seconds: Histogram,
+    receipts_init_cursor_duration_seconds: Histogram,
     /// The time it took to execute the receipts static file jar provider operation that opens a
     /// writer.
-    receipts_open_writer_write_duration_seconds: Histogram,
+    receipts_open_writer_duration_seconds: Histogram,
     /// The time it took to execute the receipts static file jar provider operation that appends
     /// data.
-    receipts_append_write_duration_seconds: Histogram,
+    receipts_append_duration_seconds: Histogram,
     /// The time it took to execute the receipts static file jar provider operation that prunes
     /// data.
-    receipts_prune_write_duration_seconds: Histogram,
+    receipts_prune_duration_seconds: Histogram,
     /// The time it took to execute the receipts static file jar provider operation that increments
     /// the block.
-    receipts_increment_block_write_duration_seconds: Histogram,
+    receipts_increment_block_duration_seconds: Histogram,
     /// The time it took to execute the receipts static file jar provider operation that commits
     /// the writer.
-    receipts_commit_writer_write_duration_seconds: Histogram,
+    receipts_commit_writer_duration_seconds: Histogram,
 }


### PR DESCRIPTION
close https://github.com/paradigmxyz/reth/issues/8758

FYI, this PR also changed the `reth_static_files_xxx` metric names(from label to name):

```diff
-reth_static_files_jar_provider_calls_total{segment="headers",operation="prune"}  0
+reth_static_files_jar_provider_headers_prune_total 0
```

BTW, I'm not quite satisfied with the 18 match arms(`match (segment, operation)`), don't know if there are any other solutions.