### PR TITLE
fix: disable sysinfo multithreading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9540,7 +9540,6 @@ dependencies = [
  "libc",
  "ntapi",
  "once_cell",
- "rayon",
  "windows 0.52.0",
 ]
 

--- a/crates/storage/db/Cargo.toml
+++ b/crates/storage/db/Cargo.toml
@@ -43,7 +43,7 @@ derive_more.workspace = true
 eyre.workspace = true
 paste.workspace = true
 rustc-hash.workspace = true
-sysinfo = "0.30"
+sysinfo = { version = "0.30", default-features = false }
 
 # arbitrary utils
 strum = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
sysinfo has a multithread feature which races with our global rayon pool initialization.


this disables the multithreaded feature