### PR TITLE
feat: log debug log directory on startup

### DIFF
--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -19,6 +19,7 @@ use reth_node_builder::{NodeBuilder, WithLaunchContext};
 use reth_primitives::ChainSpec;
 use reth_tracing::FileWorkerGuard;
 use std::{ffi::OsString, fmt, future::Future, sync::Arc};
+use tracing::info;
 
 /// Re-export of the `reth_node_core` types specifically in the `cli` module.
 ///
@@ -139,6 +140,7 @@ impl<Ext: clap::Args + fmt::Debug> Cli<Ext> {
             self.logs.log_file_directory.join(self.chain.chain.to_string());
 
         let _guard = self.init_tracing()?;
+        info!(target: "reth::cli", "Initialized tracing, debug log directory: {}", self.logs.log_file_directory);
 
         let runner = CliRunner::default();
         match self.command {

--- a/crates/node-core/src/args/log.rs
+++ b/crates/node-core/src/args/log.rs
@@ -92,6 +92,8 @@ impl LogArgs {
     }
 
     /// Initializes tracing with the configured options from cli args.
+    ///
+    /// Returns the file worker guard, and the file name, if a file worker was configured.
     pub fn init_tracing(&self) -> eyre::Result<Option<FileWorkerGuard>> {
         let mut tracer = RethTracer::new();
 


### PR DESCRIPTION
Startup logs now look like:
```
2024-06-12T20:36:58.908349Z  INFO Initialized tracing, debug log directory: /Users/dan/Library/Caches/reth/logs/holesky
2024-06-12T20:36:58.915608Z  INFO Starting reth version="0.2.0-beta.9-dev (a5d825edb)"
```