### PR TITLE
fix: separate Base Sepolia and OP Sepolia BASE_FEE_PARAMS

### DIFF
--- a/crates/primitives/src/basefee.rs
+++ b/crates/primitives/src/basefee.rs
@@ -9,7 +9,9 @@ mod tests {
     use super::*;
 
     #[cfg(feature = "optimism")]
-    use crate::chain::{OP_BASE_FEE_PARAMS, OP_SEPOLIA_BASE_FEE_PARAMS, BASE_SEPOLIA_BASE_FEE_PARAMS};
+    use crate::chain::{
+        BASE_SEPOLIA_BASE_FEE_PARAMS, OP_BASE_FEE_PARAMS, OP_SEPOLIA_BASE_FEE_PARAMS,
+    };
 
     #[test]
     fn calculate_base_fee_success() {

--- a/crates/primitives/src/basefee.rs
+++ b/crates/primitives/src/basefee.rs
@@ -9,7 +9,7 @@ mod tests {
     use super::*;
 
     #[cfg(feature = "optimism")]
-    use crate::chain::{OP_BASE_FEE_PARAMS, OP_SEPOLIA_BASE_FEE_PARAMS};
+    use crate::chain::{OP_BASE_FEE_PARAMS, OP_SEPOLIA_BASE_FEE_PARAMS, BASE_SEPOLIA_BASE_FEE_PARAMS};
 
     #[test]
     fn calculate_base_fee_success() {
@@ -92,7 +92,7 @@ mod tests {
             18000000, 18000000,
         ];
         let next_base_fee = [
-            1180000000, 1146666666, 1122857142, 1244299375, 1189416692, 1028254188, 1144836295, 1,
+            1100000048, 1080000000, 1065714297, 1167067046, 1128881311, 1028254188, 1098203452, 1,
             2, 3,
         ];
 
@@ -104,6 +104,39 @@ mod tests {
                     gas_limit[i] as u128,
                     base_fee[i] as u128,
                     OP_SEPOLIA_BASE_FEE_PARAMS,
+                ) as u64
+            );
+        }
+    }
+
+    #[cfg(feature = "optimism")]
+    #[test]
+    fn calculate_base_sepolia_base_fee_success() {
+        let base_fee = [
+            1000000000, 1000000000, 1000000000, 1072671875, 1059263476, 1049238967, 1049238967, 0,
+            1, 2,
+        ];
+        let gas_used = [
+            10000000, 10000000, 10000000, 9000000, 10001000, 0, 10000000, 10000000, 10000000,
+            10000000,
+        ];
+        let gas_limit = [
+            10000000, 12000000, 14000000, 10000000, 14000000, 2000000, 18000000, 18000000,
+            18000000, 18000000,
+        ];
+        let next_base_fee = [
+            1180000000, 1146666666, 1122857142, 1244299375, 1189416692, 1028254188, 1144836295, 1,
+            2, 3,
+        ];
+
+        for i in 0..base_fee.len() {
+            assert_eq!(
+                next_base_fee[i],
+                calc_next_block_base_fee(
+                    gas_used[i] as u128,
+                    gas_limit[i] as u128,
+                    base_fee[i] as u128,
+                    BASE_SEPOLIA_BASE_FEE_PARAMS,
                 ) as u64
             );
         }

--- a/crates/primitives/src/chain/mod.rs
+++ b/crates/primitives/src/chain/mod.rs
@@ -10,7 +10,9 @@ pub use spec::{BASE_MAINNET, BASE_SEPOLIA, OP_MAINNET, OP_SEPOLIA};
 
 #[cfg(feature = "optimism")]
 #[cfg(test)]
-pub(crate) use spec::{OP_BASE_FEE_PARAMS, OP_SEPOLIA_BASE_FEE_PARAMS, BASE_SEPOLIA_BASE_FEE_PARAMS};
+pub(crate) use spec::{
+    BASE_SEPOLIA_BASE_FEE_PARAMS, OP_BASE_FEE_PARAMS, OP_SEPOLIA_BASE_FEE_PARAMS,
+};
 
 // The chain spec module.
 mod spec;

--- a/crates/primitives/src/chain/mod.rs
+++ b/crates/primitives/src/chain/mod.rs
@@ -10,7 +10,7 @@ pub use spec::{BASE_MAINNET, BASE_SEPOLIA, OP_MAINNET, OP_SEPOLIA};
 
 #[cfg(feature = "optimism")]
 #[cfg(test)]
-pub(crate) use spec::{OP_BASE_FEE_PARAMS, OP_SEPOLIA_BASE_FEE_PARAMS};
+pub(crate) use spec::{OP_BASE_FEE_PARAMS, OP_SEPOLIA_BASE_FEE_PARAMS, BASE_SEPOLIA_BASE_FEE_PARAMS};
 
 // The chain spec module.
 mod spec;

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -24,9 +24,8 @@ pub use alloy_eips::eip1559::BaseFeeParams;
 #[cfg(feature = "optimism")]
 pub(crate) use crate::{
     constants::{
-        OP_BASE_FEE_PARAMS, OP_CANYON_BASE_FEE_PARAMS, OP_SEPOLIA_BASE_FEE_PARAMS,
-        OP_SEPOLIA_CANYON_BASE_FEE_PARAMS,
-        BASE_SEPOLIA_BASE_FEE_PARAMS, BASE_SEPOLIA_CANYON_BASE_FEE_PARAMS,
+        BASE_SEPOLIA_BASE_FEE_PARAMS, BASE_SEPOLIA_CANYON_BASE_FEE_PARAMS, OP_BASE_FEE_PARAMS,
+        OP_CANYON_BASE_FEE_PARAMS, OP_SEPOLIA_BASE_FEE_PARAMS, OP_SEPOLIA_CANYON_BASE_FEE_PARAMS,
     },
     net::{base_nodes, base_testnet_nodes, op_nodes, op_testnet_nodes},
 };

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -26,6 +26,7 @@ pub(crate) use crate::{
     constants::{
         OP_BASE_FEE_PARAMS, OP_CANYON_BASE_FEE_PARAMS, OP_SEPOLIA_BASE_FEE_PARAMS,
         OP_SEPOLIA_CANYON_BASE_FEE_PARAMS,
+        BASE_SEPOLIA_BASE_FEE_PARAMS, BASE_SEPOLIA_CANYON_BASE_FEE_PARAMS,
     },
     net::{base_nodes, base_testnet_nodes, op_nodes, op_testnet_nodes},
 };
@@ -397,8 +398,8 @@ pub static BASE_SEPOLIA: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
         ]),
         base_fee_params: BaseFeeParamsKind::Variable(
             vec![
-                (Hardfork::London, OP_SEPOLIA_BASE_FEE_PARAMS),
-                (Hardfork::Canyon, OP_SEPOLIA_CANYON_BASE_FEE_PARAMS),
+                (Hardfork::London, BASE_SEPOLIA_BASE_FEE_PARAMS),
+                (Hardfork::Canyon, BASE_SEPOLIA_CANYON_BASE_FEE_PARAMS),
             ]
             .into(),
         ),

--- a/crates/primitives/src/constants/mod.rs
+++ b/crates/primitives/src/constants/mod.rs
@@ -105,6 +105,25 @@ pub const OP_SEPOLIA_EIP1559_BASE_FEE_MAX_CHANGE_DENOMINATOR_CANYON: u128 = 250;
 #[cfg(feature = "optimism")]
 pub const OP_SEPOLIA_EIP1559_DEFAULT_ELASTICITY_MULTIPLIER: u128 = 6;
 
+/// Base fee max change denominator for Base Sepolia as defined in the Optimism
+/// [transaction costs](https://community.optimism.io/docs/developers/build/differences/#transaction-costs) doc.
+#[cfg(feature = "optimism")]
+pub const BASE_SEPOLIA_EIP1559_DEFAULT_ELASTICITY_MULTIPLIER: u128 = 10;
+
+/// Get the base fee parameters for Base Sepolia.
+#[cfg(feature = "optimism")]
+pub const BASE_SEPOLIA_BASE_FEE_PARAMS: BaseFeeParams = BaseFeeParams {
+    max_change_denominator: OP_SEPOLIA_EIP1559_DEFAULT_BASE_FEE_MAX_CHANGE_DENOMINATOR,
+    elasticity_multiplier: BASE_SEPOLIA_EIP1559_DEFAULT_ELASTICITY_MULTIPLIER,
+};
+
+/// Get the base fee parameters for Base Sepolia (post Canyon).
+#[cfg(feature = "optimism")]
+pub const BASE_SEPOLIA_CANYON_BASE_FEE_PARAMS: BaseFeeParams = BaseFeeParams {
+    max_change_denominator: OP_SEPOLIA_EIP1559_BASE_FEE_MAX_CHANGE_DENOMINATOR_CANYON,
+    elasticity_multiplier: BASE_SEPOLIA_EIP1559_DEFAULT_ELASTICITY_MULTIPLIER,
+};
+
 /// Get the base fee parameters for Optimism Sepolia.
 #[cfg(feature = "optimism")]
 pub const OP_SEPOLIA_BASE_FEE_PARAMS: BaseFeeParams = BaseFeeParams {

--- a/crates/primitives/src/constants/mod.rs
+++ b/crates/primitives/src/constants/mod.rs
@@ -103,7 +103,7 @@ pub const OP_SEPOLIA_EIP1559_BASE_FEE_MAX_CHANGE_DENOMINATOR_CANYON: u128 = 250;
 /// Base fee max change denominator for Optimism Sepolia as defined in the Optimism
 /// [transaction costs](https://community.optimism.io/docs/developers/build/differences/#transaction-costs) doc.
 #[cfg(feature = "optimism")]
-pub const OP_SEPOLIA_EIP1559_DEFAULT_ELASTICITY_MULTIPLIER: u128 = 10;
+pub const OP_SEPOLIA_EIP1559_DEFAULT_ELASTICITY_MULTIPLIER: u128 = 6;
 
 /// Get the base fee parameters for Optimism Sepolia.
 #[cfg(feature = "optimism")]


### PR DESCRIPTION
Op-reth was not syncing for OP Sepolia and finally tracked down the issue to a bad setting when trying to calculate the next expected base fee. This PR is my attempt to fix it, but happy to implement another way!

From op-geth:
- Settings for Base Sepolia: https://github.com/ethereum-optimism/op-geth/blob/optimism/params/superchain.go#L104
- Default settings (for OP Sepolia): https://github.com/ethereum-optimism/op-geth/blob/optimism/params/superchain.go#L77