### PR TITLE
feat: support `no_std` for `reth-storage-errors`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8218,7 +8218,7 @@ version = "1.0.0-rc.1"
 dependencies = [
  "reth-fs-util",
  "reth-primitives",
- "thiserror",
+ "thiserror-no-std",
 ]
 
 [[package]]

--- a/crates/storage/errors/Cargo.toml
+++ b/crates/storage/errors/Cargo.toml
@@ -14,6 +14,8 @@ workspace = true
 reth-primitives.workspace = true
 reth-fs-util.workspace = true
 
-thiserror.workspace = true
+thiserror-no-std = { workspace = true, default-features = false }
 
-    
+[features]
+default = ["std"]
+std = ["thiserror-no-std/std"]

--- a/crates/storage/errors/src/db.rs
+++ b/crates/storage/errors/src/db.rs
@@ -54,7 +54,7 @@ pub enum DatabaseError {
 }
 
 /// Common error struct to propagate implementation-specific error information.
-#[derive(Debug, thiserror_no_std::Error, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror_no_std::Error)]
 #[error("{message} ({code})")]
 pub struct DatabaseErrorInfo {
     /// Human-readable error message.
@@ -180,7 +180,7 @@ impl LogLevel {
 impl FromStr for LogLevel {
     type Err = String;
 
-    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "fatal" => Ok(Self::Fatal),
             "error" => Ok(Self::Error),
@@ -190,7 +190,7 @@ impl FromStr for LogLevel {
             "debug" => Ok(Self::Debug),
             "trace" => Ok(Self::Trace),
             "extra" => Ok(Self::Extra),
-            _ => Err(format!("Invalid log level: {}", s)),
+            _ => Err(format!("Invalid log level: {s}")),
         }
     }
 }

--- a/crates/storage/errors/src/db.rs
+++ b/crates/storage/errors/src/db.rs
@@ -1,8 +1,17 @@
+#[cfg(feature = "std")]
 use std::{fmt::Display, str::FromStr};
-use thiserror::Error;
+
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, format, string::String, vec::Vec};
+
+#[cfg(not(feature = "std"))]
+use core::{
+    fmt::{Display, Formatter, Result},
+    str::FromStr,
+};
 
 /// Database error type.
-#[derive(Clone, Debug, PartialEq, Eq, Error)]
+#[derive(Clone, Debug, PartialEq, Eq, thiserror_no_std::Error)]
 pub enum DatabaseError {
     /// Failed to open the database.
     #[error("failed to open the database: {0}")]
@@ -43,7 +52,7 @@ pub enum DatabaseError {
 }
 
 /// Common error struct to propagate implementation-specific error information.
-#[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[derive(Debug, thiserror_no_std::Error, Clone, PartialEq, Eq)]
 #[error("{message} ({code})")]
 pub struct DatabaseErrorInfo {
     /// Human-readable error message.
@@ -70,7 +79,7 @@ impl From<DatabaseWriteError> for DatabaseError {
 }
 
 /// Database write error.
-#[derive(Clone, Debug, PartialEq, Eq, Error)]
+#[derive(Clone, Debug, PartialEq, Eq, thiserror_no_std::Error)]
 #[error(
     "write operation {operation:?} failed for key \"{key}\" in table {table_name:?}: {info}",
     key = reth_primitives::hex::encode(key),

--- a/crates/storage/errors/src/db.rs
+++ b/crates/storage/errors/src/db.rs
@@ -1,14 +1,16 @@
 #[cfg(feature = "std")]
-use std::{fmt::Display, str::FromStr};
+use std::{fmt::Display, str::FromStr, string::String};
 
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, format, string::String, vec::Vec};
-
-#[cfg(not(feature = "std"))]
-use core::{
-    fmt::{Display, Formatter, Result},
-    str::FromStr,
+use alloc::{
+    boxed::Box,
+    format,
+    string::{String, ToString},
+    vec::Vec,
 };
+
+#[cfg(not(feature = "std"))]
+use core::{fmt::Display, str::FromStr};
 
 /// Database error type.
 #[derive(Clone, Debug, PartialEq, Eq, thiserror_no_std::Error)]
@@ -178,7 +180,7 @@ impl LogLevel {
 impl FromStr for LogLevel {
     type Err = String;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "fatal" => Ok(Self::Fatal),
             "error" => Ok(Self::Error),

--- a/crates/storage/errors/src/lib.rs
+++ b/crates/storage/errors/src/lib.rs
@@ -7,6 +7,10 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
 
 /// Database error
 pub mod db;

--- a/crates/storage/errors/src/lockfile.rs
+++ b/crates/storage/errors/src/lockfile.rs
@@ -1,7 +1,7 @@
 use reth_fs_util::FsPathError;
 
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String};
+use alloc::string::{String, ToString};
 
 #[derive(thiserror_no_std::Error, Debug, Clone, PartialEq, Eq)]
 /// Storage lock error.

--- a/crates/storage/errors/src/lockfile.rs
+++ b/crates/storage/errors/src/lockfile.rs
@@ -1,7 +1,9 @@
 use reth_fs_util::FsPathError;
-use thiserror::Error;
 
-#[derive(Error, Debug, Clone, PartialEq, Eq)]
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String};
+
+#[derive(thiserror_no_std::Error, Debug, Clone, PartialEq, Eq)]
 /// Storage lock error.
 pub enum StorageLockError {
     /// Write lock taken

--- a/crates/storage/errors/src/lockfile.rs
+++ b/crates/storage/errors/src/lockfile.rs
@@ -3,8 +3,8 @@ use reth_fs_util::FsPathError;
 #[cfg(not(feature = "std"))]
 use alloc::string::{String, ToString};
 
-#[derive(thiserror_no_std::Error, Debug, Clone, PartialEq, Eq)]
 /// Storage lock error.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror_no_std::Error)]
 pub enum StorageLockError {
     /// Write lock taken
     #[error("storage directory is currently in use as read-write by another process: PID {0}")]

--- a/crates/storage/errors/src/provider.rs
+++ b/crates/storage/errors/src/provider.rs
@@ -2,14 +2,17 @@ use reth_primitives::{
     Address, BlockHash, BlockHashOrNumber, BlockNumber, GotExpected, StaticFileSegment,
     TxHashOrNumber, TxNumber, B256, U256,
 };
+#[cfg(feature = "std")]
 use std::path::PathBuf;
-use thiserror::Error;
+
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String};
 
 /// Provider result type.
 pub type ProviderResult<Ok> = Result<Ok, ProviderError>;
 
 /// Bundled errors variants thrown by various providers.
-#[derive(Clone, Debug, Error, PartialEq, Eq)]
+#[derive(Clone, Debug, thiserror_no_std::Error, PartialEq, Eq)]
 pub enum ProviderError {
     /// Database error.
     #[error(transparent)]
@@ -143,7 +146,7 @@ impl From<reth_fs_util::FsPathError> for ProviderError {
 }
 
 /// A root mismatch error at a given block height.
-#[derive(Clone, Debug, Error, PartialEq, Eq)]
+#[derive(Clone, Debug, thiserror_no_std::Error, PartialEq, Eq)]
 #[error("root mismatch at #{block_number} ({block_hash}): {root}")]
 pub struct RootMismatch {
     /// The target block root diff.
@@ -155,7 +158,7 @@ pub struct RootMismatch {
 }
 
 /// Consistent database view error.
-#[derive(Clone, Debug, Error, PartialEq, Eq)]
+#[derive(Clone, Debug, thiserror_no_std::Error, PartialEq, Eq)]
 pub enum ConsistentViewError {
     /// Error thrown on attempt to initialize provider while node is still syncing.
     #[error("node is syncing. best block: {best_block:?}")]

--- a/crates/storage/errors/src/provider.rs
+++ b/crates/storage/errors/src/provider.rs
@@ -151,7 +151,7 @@ impl From<reth_fs_util::FsPathError> for ProviderError {
 }
 
 /// A root mismatch error at a given block height.
-#[derive(Clone, Debug, thiserror_no_std::Error, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, thiserror_no_std::Error)]
 #[error("root mismatch at #{block_number} ({block_hash}): {root}")]
 pub struct RootMismatch {
     /// The target block root diff.
@@ -163,7 +163,7 @@ pub struct RootMismatch {
 }
 
 /// Consistent database view error.
-#[derive(Clone, Debug, thiserror_no_std::Error, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, thiserror_no_std::Error)]
 pub enum ConsistentViewError {
     /// Error thrown on attempt to initialize provider while node is still syncing.
     #[error("node is syncing. best block: {best_block:?}")]

--- a/crates/storage/errors/src/provider.rs
+++ b/crates/storage/errors/src/provider.rs
@@ -2,11 +2,15 @@ use reth_primitives::{
     Address, BlockHash, BlockHashOrNumber, BlockNumber, GotExpected, StaticFileSegment,
     TxHashOrNumber, TxNumber, B256, U256,
 };
+
 #[cfg(feature = "std")]
 use std::path::PathBuf;
 
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String};
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+};
 
 /// Provider result type.
 pub type ProviderResult<Ok> = Result<Ok, ProviderError>;
@@ -111,6 +115,7 @@ pub enum ProviderError {
     #[error("this provider does not support this request")]
     UnsupportedProvider,
     /// Static File is not found at specified path.
+    #[cfg(feature = "std")]
     #[error("not able to find {0} static file at {1}")]
     MissingStaticFilePath(StaticFileSegment, PathBuf),
     /// Static File is not found for requested block.


### PR DESCRIPTION
Description
Enable no-std support using thiserror_no_std until supported directly.

Motivation
closes #8459 

Superceeds #8702 