### PR TITLE
feat: main control loop for chain orchestrator

### DIFF
--- a/crates/engine/tree/src/chain.rs
+++ b/crates/engine/tree/src/chain.rs
@@ -80,7 +80,7 @@ where
                     PipelineEvent::Finished(res) => {
                         return match res {
                             Ok(event) => {
-                                tracing::error!(?event, "pipeline finished");
+                                tracing::debug!(?event, "pipeline finished");
                                 // notify handler that pipeline finished
                                 this.handler.on_event(FromOrchestrator::PipelineFinished);
                                 Poll::Ready(ChainEvent::PipelineFinished)

--- a/crates/engine/tree/src/chain.rs
+++ b/crates/engine/tree/src/chain.rs
@@ -73,7 +73,7 @@ where
                 Poll::Ready(pipeline_event) => match pipeline_event {
                     PipelineEvent::Idle => {}
                     PipelineEvent::Started(_) => {
-                        // notify handler that pipeline finished
+                        // notify handler that pipeline started
                         this.handler.on_event(FromOrchestrator::PipelineStarted);
                         return Poll::Ready(ChainEvent::PipelineStarted);
                     }

--- a/crates/engine/tree/src/engine.rs
+++ b/crates/engine/tree/src/engine.rs
@@ -53,7 +53,7 @@ where
         todo!()
     }
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<HandlerEvent> {
+    fn poll(&mut self, cx: &mut Context<'_>) -> Poll<HandlerEvent> {
         todo!()
     }
 }

--- a/crates/engine/tree/src/lib.rs
+++ b/crates/engine/tree/src/lib.rs
@@ -16,5 +16,7 @@ pub use reth_blockchain_tree_api::*;
 pub mod chain;
 /// Engine Api chain handler support.
 pub mod engine;
+/// Support for managing the pipeline.
+pub mod pipeline;
 /// Support for interacting with the blockchain tree.
 pub mod tree;

--- a/crates/engine/tree/src/pipeline.rs
+++ b/crates/engine/tree/src/pipeline.rs
@@ -1,0 +1,40 @@
+//! It is expected that the node has two sync modes:
+//!
+//!  - Pipeline sync: Sync to a certain block height in stages, e.g. download data from p2p then
+//!    execute that range.
+//!  - Live sync: In this mode the nodes is keeping up with the latest tip and listens for new
+//!    requests from the consensus client.
+//!
+//! These modes are mutually exclusive and the node can only be in one mode at a time.
+
+use reth_primitives::stage::PipelineTarget;
+use reth_stages_api::{ControlFlow, PipelineError};
+use std::task::{Context, Poll};
+
+/// A handler for the pipeline.
+pub trait PipelineHandler: Send + Sync {
+    /// Performs an action on the pipeline.
+    fn on_action(&mut self, event: PipelineAction);
+
+    /// Polls the pipeline for completion.
+    fn poll(&mut self, cx: &mut Context<'_>) -> Poll<PipelineEvent>;
+}
+
+/// The actions that can be performed on the pipeline.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PipelineAction {
+    /// Start the pipeline with the given target.
+    Start(PipelineTarget),
+}
+
+/// The events that can be emitted by the pipeline.
+#[derive(Debug)]
+pub enum PipelineEvent {
+    Idle,
+    /// Pipeline started syncing
+    Started(PipelineTarget),
+    /// Pipeline finished
+    ///
+    /// If this is returned, the pipeline is idle.
+    Finished(Result<ControlFlow, PipelineError>),
+}

--- a/crates/engine/tree/src/tree.rs
+++ b/crates/engine/tree/src/tree.rs
@@ -1,4 +1,4 @@
-use crate::{chain::PipelineAction, engine::DownloadRequest};
+use crate::{engine::DownloadRequest, pipeline::PipelineAction};
 use parking_lot::Mutex;
 use reth_beacon_consensus::{ForkchoiceStateTracker, InvalidHeaderCache, OnForkChoiceUpdated};
 use reth_blockchain_tree_api::{error::InsertBlockError, InsertPayloadOk};


### PR DESCRIPTION
abstracts away the pipeline handler.

controlled via events, and chain handler is responsible for requesting a pipeline run (e.g. based on received FCU).


naming all tbd, perhaps we rename this to `BackfillSync` to be more general