### PR TITLE
chore: remove educe dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2713,18 +2713,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "educe"
-version = "0.4.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0042ff8246a363dbe77d2ceedb073339e85a804b9a47636c6e016a9a32c05f"
-dependencies = [
- "enum-ordinalize",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "ef-tests"
 version = "1.0.0-rc.1"
 dependencies = [
@@ -2806,19 +2794,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "enum-ordinalize"
-version = "3.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf1fa3f06bbff1ea5b1a9c7b14aa992a39657db60a2759457328d7e058f49ee"
-dependencies = [
- "num-bigint",
- "num-traits",
  "proc-macro2",
  "quote",
  "syn 2.0.66",
@@ -6864,7 +6839,6 @@ dependencies = [
  "concat-kdf",
  "ctr 0.9.2",
  "digest 0.10.7",
- "educe",
  "futures",
  "generic-array",
  "hmac 0.12.1",

--- a/crates/net/ecies/Cargo.toml
+++ b/crates/net/ecies/Cargo.toml
@@ -23,7 +23,6 @@ tokio-stream.workspace = true
 tokio-util = { workspace = true, features = ["codec"] }
 pin-project.workspace = true
 
-educe = "0.4.19"
 tracing.workspace = true
 
 # HeaderBytes

--- a/crates/net/ecies/src/algorithm.rs
+++ b/crates/net/ecies/src/algorithm.rs
@@ -11,7 +11,6 @@ use alloy_rlp::{Encodable, Rlp, RlpEncodable, RlpMaxEncodedLen};
 use byteorder::{BigEndian, ByteOrder, ReadBytesExt};
 use ctr::Ctr64BE;
 use digest::{crypto_common::KeyIvInit, Digest};
-use educe::Educe;
 use rand::{thread_rng, Rng};
 use reth_network_peers::{id2pk, pk2id};
 use reth_primitives::{
@@ -51,17 +50,13 @@ fn kdf(secret: B256, s1: &[u8], dest: &mut [u8]) {
     concat_kdf::derive_key_into::<Sha256>(secret.as_slice(), s1, dest).unwrap();
 }
 
-#[derive(Educe)]
-#[educe(Debug)]
 pub struct ECIES {
-    #[educe(Debug(ignore))]
     secret_key: SecretKey,
     public_key: PublicKey,
     remote_public_key: Option<PublicKey>,
 
     pub(crate) remote_id: Option<PeerId>,
 
-    #[educe(Debug(ignore))]
     ephemeral_secret_key: SecretKey,
     ephemeral_public_key: PublicKey,
     ephemeral_shared_secret: Option<B256>,
@@ -70,9 +65,7 @@ pub struct ECIES {
     nonce: B256,
     remote_nonce: Option<B256>,
 
-    #[educe(Debug(ignore))]
     ingress_aes: Option<Ctr64BE<Aes256>>,
-    #[educe(Debug(ignore))]
     egress_aes: Option<Ctr64BE<Aes256>>,
     ingress_mac: Option<MAC>,
     egress_mac: Option<MAC>,
@@ -81,6 +74,27 @@ pub struct ECIES {
     remote_init_msg: Option<Bytes>,
 
     body_size: Option<usize>,
+}
+
+impl core::fmt::Debug for ECIES {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ECIES")
+            .field("public_key", &self.public_key)
+            .field("remote_public_key", &self.remote_public_key)
+            .field("remote_id", &self.remote_id)
+            .field("ephemeral_public_key", &self.ephemeral_public_key)
+            .field("ephemeral_shared_secret", &self.ephemeral_shared_secret)
+            .field("remote_ephemeral_public_key", &self.remote_ephemeral_public_key)
+            .field("nonce", &self.nonce)
+            .field("remote_nonce", &self.remote_nonce)
+            .field("ingress_mac", &self.ingress_mac)
+            .field("egress_mac", &self.egress_mac)
+            .field("init_msg", &self.init_msg)
+            .field("remote_init_msg", &self.remote_init_msg)
+            .field("body_size", &self.body_size)
+            .finish()
+    }
 }
 
 fn split_at_mut<T>(arr: &mut [T], idx: usize) -> Result<(&mut [T], &mut [T]), ECIESError> {


### PR DESCRIPTION
this was only used to skip a few fields when deriving debug

replace derive with expanded impl and remove dependency