### PR TITLE
chore: fix references

### DIFF
--- a/book/run/optimism.md
+++ b/book/run/optimism.md
@@ -101,7 +101,7 @@ op-node \
 [l1-el-spec]: https://github.com/ethereum/execution-specs
 [rollup-node-spec]: https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/rollup-node.md
 [op-geth-forkdiff]: https://op-geth.optimism.io
-[sequencer]: https://github.com/ethereum-optimism/specs/blob/main/specs/introduction.md#sequencers
+[sequencer]: https://github.com/ethereum-optimism/specs/blob/main/specs/background.md#sequencers
 [op-stack-spec]: https://github.com/ethereum-optimism/specs/blob/main/specs
 [l2-el-spec]: https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/exec-engine.md
 [deposit-spec]: https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/deposits.md

--- a/crates/blockchain-tree/src/canonical_chain.rs
+++ b/crates/blockchain-tree/src/canonical_chain.rs
@@ -12,7 +12,7 @@ pub(crate) struct CanonicalChain {
 }
 
 impl CanonicalChain {
-    pub(crate) fn new(chain: BTreeMap<BlockNumber, BlockHash>) -> Self {
+    pub(crate) const fn new(chain: BTreeMap<BlockNumber, BlockHash>) -> Self {
         Self { chain }
     }
 

--- a/crates/blockchain-tree/src/noop.rs
+++ b/crates/blockchain-tree/src/noop.rs
@@ -27,7 +27,7 @@ pub struct NoopBlockchainTree {
 
 impl NoopBlockchainTree {
     /// Create a new `NoopBlockchainTree` with a canon state notification sender.
-    pub fn with_canon_state_notifications(
+    pub const fn with_canon_state_notifications(
         canon_state_notification_sender: CanonStateNotificationSender,
     ) -> Self {
         Self { canon_state_notification_sender: Some(canon_state_notification_sender) }

--- a/crates/consensus/auto-seal/src/lib.rs
+++ b/crates/consensus/auto-seal/src/lib.rs
@@ -56,7 +56,7 @@ pub struct AutoSealConsensus {
 
 impl AutoSealConsensus {
     /// Create a new instance of [`AutoSealConsensus`]
-    pub fn new(chain_spec: Arc<ChainSpec>) -> Self {
+    pub const fn new(chain_spec: Arc<ChainSpec>) -> Self {
         Self { chain_spec }
     }
 }

--- a/crates/consensus/beacon/src/engine/message.rs
+++ b/crates/consensus/beacon/src/engine/message.rs
@@ -86,7 +86,7 @@ impl OnForkChoiceUpdated {
     }
 
     /// If the forkchoice update was successful and no payload attributes were provided, this method
-    pub(crate) fn updated_with_pending_payload_id(
+    pub(crate) const fn updated_with_pending_payload_id(
         payload_status: PayloadStatus,
         pending_payload_id: oneshot::Receiver<Result<PayloadId, PayloadBuilderError>>,
     ) -> Self {

--- a/crates/consensus/beacon/src/engine/sync.rs
+++ b/crates/consensus/beacon/src/engine/sync.rs
@@ -438,7 +438,7 @@ mod tests {
 
     impl TestPipelineBuilder {
         /// Create a new [`TestPipelineBuilder`].
-        fn new() -> Self {
+        const fn new() -> Self {
             Self {
                 pipeline_exec_outputs: VecDeque::new(),
                 executor_results: Vec::new(),

--- a/crates/consensus/beacon/src/engine/test_utils.rs
+++ b/crates/consensus/beacon/src/engine/test_utils.rs
@@ -57,7 +57,7 @@ pub struct TestEnv<DB> {
 }
 
 impl<DB> TestEnv<DB> {
-    fn new(
+    const fn new(
         db: DB,
         tip_rx: watch::Receiver<B256>,
         engine_handle: BeaconConsensusEngineHandle<EthEngineTypes>,

--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -32,7 +32,7 @@ pub struct EthBeaconConsensus {
 
 impl EthBeaconConsensus {
     /// Create a new instance of [`EthBeaconConsensus`]
-    pub fn new(chain_spec: Arc<ChainSpec>) -> Self {
+    pub const fn new(chain_spec: Arc<ChainSpec>) -> Self {
         Self { chain_spec }
     }
 }

--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -39,7 +39,7 @@ pub struct EthBuiltPayload {
 
 impl EthBuiltPayload {
     /// Initializes the payload with the given initial block.
-    pub fn new(id: PayloadId, block: SealedBlock, fees: U256) -> Self {
+    pub const fn new(id: PayloadId, block: SealedBlock, fees: U256) -> Self {
         Self { id, block, fees, sidecars: Vec::new() }
     }
 

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -54,7 +54,7 @@ impl EthExecutorProvider {
 
 impl<EvmConfig> EthExecutorProvider<EvmConfig> {
     /// Creates a new executor provider.
-    pub fn new(chain_spec: Arc<ChainSpec>, evm_config: EvmConfig) -> Self {
+    pub const fn new(chain_spec: Arc<ChainSpec>, evm_config: EvmConfig) -> Self {
         Self { chain_spec, evm_config }
     }
 }
@@ -236,7 +236,7 @@ pub struct EthBlockExecutor<EvmConfig, DB> {
 
 impl<EvmConfig, DB> EthBlockExecutor<EvmConfig, DB> {
     /// Creates a new Ethereum block executor.
-    pub fn new(chain_spec: Arc<ChainSpec>, evm_config: EvmConfig, state: State<DB>) -> Self {
+    pub const fn new(chain_spec: Arc<ChainSpec>, evm_config: EvmConfig, state: State<DB>) -> Self {
         Self { executor: EthEvmExecutor { chain_spec, evm_config }, state }
     }
 

--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -1152,7 +1152,7 @@ pub struct GetPooledTxRequestFut {
 
 impl GetPooledTxRequestFut {
     #[inline]
-    fn new(
+    const fn new(
         peer_id: PeerId,
         requested_hashes: RequestTxHashes,
         response: oneshot::Receiver<RequestResult<PooledTransactions>>,

--- a/crates/net/p2p/src/test_utils/headers.rs
+++ b/crates/net/p2p/src/test_utils/headers.rs
@@ -38,7 +38,7 @@ pub struct TestHeaderDownloader {
 
 impl TestHeaderDownloader {
     /// Instantiates the downloader with the mock responses
-    pub fn new(
+    pub const fn new(
         client: TestHeadersClient,
         consensus: Arc<TestConsensus>,
         limit: u64,

--- a/crates/node-core/src/args/network.rs
+++ b/crates/node-core/src/args/network.rs
@@ -205,7 +205,7 @@ impl NetworkArgs {
 
     /// Sets the p2p and discovery ports to zero, allowing the OD to assign a random unused port
     /// when network components bind to sockets.
-    pub fn with_unused_ports(mut self) -> Self {
+    pub const fn with_unused_ports(mut self) -> Self {
         self = self.with_unused_p2p_port();
         self.discovery = self.discovery.with_unused_discovery_port();
         self

--- a/crates/node-core/src/engine/engine_store.rs
+++ b/crates/node-core/src/engine/engine_store.rs
@@ -129,7 +129,7 @@ pub struct EngineStoreStream<S> {
 
 impl<S> EngineStoreStream<S> {
     /// Create new engine store stream wrapper.
-    pub fn new(stream: S, path: PathBuf) -> Self {
+    pub const fn new(stream: S, path: PathBuf) -> Self {
         Self { stream, store: EngineMessageStore::new(path) }
     }
 }

--- a/crates/node-core/src/exit.rs
+++ b/crates/node-core/src/exit.rs
@@ -22,7 +22,7 @@ pub struct NodeExitFuture {
 
 impl NodeExitFuture {
     /// Create a new `NodeExitFuture`.
-    pub fn new(
+    pub const fn new(
         consensus_engine_rx: oneshot::Receiver<Result<(), BeaconConsensusEngineError>>,
         terminate: bool,
     ) -> Self {

--- a/crates/node/builder/src/builder/states.rs
+++ b/crates/node/builder/src/builder/states.rs
@@ -31,7 +31,7 @@ pub struct NodeBuilderWithTypes<T: FullNodeTypes> {
 
 impl<T: FullNodeTypes> NodeBuilderWithTypes<T> {
     /// Creates a new instance of the node builder with the given configuration and types.
-    pub fn new(config: NodeConfig, database: T::DB) -> Self {
+    pub const fn new(config: NodeConfig, database: T::DB) -> Self {
         Self { config, adapter: NodeTypesAdapter::new(database) }
     }
 

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -44,7 +44,7 @@ impl OpExecutorProvider {
 
 impl<EvmConfig> OpExecutorProvider<EvmConfig> {
     /// Creates a new executor provider.
-    pub fn new(chain_spec: Arc<ChainSpec>, evm_config: EvmConfig) -> Self {
+    pub const fn new(chain_spec: Arc<ChainSpec>, evm_config: EvmConfig) -> Self {
         Self { chain_spec, evm_config }
     }
 }
@@ -236,7 +236,7 @@ pub struct OpBlockExecutor<EvmConfig, DB> {
 
 impl<EvmConfig, DB> OpBlockExecutor<EvmConfig, DB> {
     /// Creates a new Ethereum block executor.
-    pub fn new(chain_spec: Arc<ChainSpec>, evm_config: EvmConfig, state: State<DB>) -> Self {
+    pub const fn new(chain_spec: Arc<ChainSpec>, evm_config: EvmConfig, state: State<DB>) -> Self {
         Self { executor: OpEvmExecutor { chain_spec, evm_config }, state }
     }
 

--- a/crates/optimism/payload/src/payload.rs
+++ b/crates/optimism/payload/src/payload.rs
@@ -179,7 +179,7 @@ pub struct OptimismBuiltPayload {
 
 impl OptimismBuiltPayload {
     /// Initializes the payload with the given initial block.
-    pub fn new(
+    pub const fn new(
         id: PayloadId,
         block: SealedBlock,
         fees: U256,

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -636,7 +636,7 @@ pub struct PendingPayload<P> {
 
 impl<P> PendingPayload<P> {
     /// Constructs a `PendingPayload` future.
-    pub fn new(
+    pub const fn new(
         cancel: Cancelled,
         payload: oneshot::Receiver<Result<BuildOutcome<P>, PayloadBuilderError>>,
     ) -> Self {
@@ -773,7 +773,7 @@ pub struct BuildArguments<Pool, Client, Attributes, Payload> {
 
 impl<Pool, Client, Attributes, Payload> BuildArguments<Pool, Client, Attributes, Payload> {
     /// Create new build arguments.
-    pub fn new(
+    pub const fn new(
         client: Client,
         pool: Pool,
         cached_reads: CachedReads,

--- a/crates/payload/validator/src/lib.rs
+++ b/crates/payload/validator/src/lib.rs
@@ -22,7 +22,7 @@ pub struct ExecutionPayloadValidator {
 
 impl ExecutionPayloadValidator {
     /// Create a new validator.
-    pub fn new(chain_spec: Arc<ChainSpec>) -> Self {
+    pub const fn new(chain_spec: Arc<ChainSpec>) -> Self {
         Self { chain_spec }
     }
 

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -633,7 +633,7 @@ impl From<Block> for BlockBody {
 /// This __does not, and should not guarantee__ that the header is valid with respect to __anything
 /// else__.
 #[cfg(any(test, feature = "arbitrary"))]
-pub fn generate_valid_header(
+pub const fn generate_valid_header(
     mut header: Header,
     eip_4844_active: bool,
     blob_gas_used: u64,

--- a/crates/primitives/src/withdrawal.rs
+++ b/crates/primitives/src/withdrawal.rs
@@ -15,7 +15,7 @@ pub struct Withdrawals(Vec<Withdrawal>);
 
 impl Withdrawals {
     /// Create a new Withdrawals instance.
-    pub fn new(withdrawals: Vec<Withdrawal>) -> Self {
+    pub const fn new(withdrawals: Vec<Withdrawal>) -> Self {
         Self(withdrawals)
     }
 

--- a/crates/rpc/ipc/src/server/future.rs
+++ b/crates/rpc/ipc/src/server/future.rs
@@ -33,7 +33,7 @@ use tokio::sync::watch;
 pub(crate) struct StopHandle(watch::Receiver<()>);
 
 impl StopHandle {
-    pub(crate) fn new(rx: watch::Receiver<()>) -> Self {
+    pub(crate) const fn new(rx: watch::Receiver<()>) -> Self {
         Self(rx)
     }
 

--- a/crates/rpc/rpc-types/src/mev.rs
+++ b/crates/rpc/rpc-types/src/mev.rs
@@ -400,7 +400,7 @@ pub struct SimBundleLogs {
 
 impl SendBundleRequest {
     /// Create a new bundle request.
-    pub fn new(
+    pub const fn new(
         block_num: u64,
         max_block: Option<u64>,
         protocol_version: ProtocolVersion,

--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -24,7 +24,7 @@ pub struct AdminApi<N> {
 
 impl<N> AdminApi<N> {
     /// Creates a new instance of `AdminApi`.
-    pub fn new(network: N, chain_spec: Arc<ChainSpec>) -> Self {
+    pub const fn new(network: N, chain_spec: Arc<ChainSpec>) -> Self {
         Self { network, chain_spec }
     }
 }

--- a/crates/stages/api/src/test_utils.rs
+++ b/crates/stages/api/src/test_utils.rs
@@ -16,7 +16,7 @@ pub struct TestStage {
 }
 
 impl TestStage {
-    pub fn new(id: StageId) -> Self {
+    pub const fn new(id: StageId) -> Self {
         Self { id, exec_outputs: VecDeque::new(), unwind_outputs: VecDeque::new() }
     }
 

--- a/crates/stages/stages/src/test_utils/set.rs
+++ b/crates/stages/stages/src/test_utils/set.rs
@@ -11,7 +11,7 @@ pub struct TestStages {
 }
 
 impl TestStages {
-    pub fn new(
+    pub const fn new(
         exec_outputs: VecDeque<Result<ExecOutput, StageError>>,
         unwind_outputs: VecDeque<Result<UnwindOutput, StageError>>,
     ) -> Self {

--- a/crates/stages/types/src/checkpoints.rs
+++ b/crates/stages/types/src/checkpoints.rs
@@ -21,7 +21,7 @@ pub struct MerkleCheckpoint {
 
 impl MerkleCheckpoint {
     /// Creates a new Merkle checkpoint.
-    pub fn new(
+    pub const fn new(
         target_block: BlockNumber,
         last_account_key: B256,
         walker_stack: Vec<StoredSubNode>,

--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -36,7 +36,7 @@ pub struct Cursor<K: TransactionKind, T: Table> {
 }
 
 impl<K: TransactionKind, T: Table> Cursor<K, T> {
-    pub(crate) fn new_with_metrics(
+    pub(crate) const fn new_with_metrics(
         inner: reth_libmdbx::Cursor<K>,
         metrics: Option<Arc<DatabaseEnvMetrics>>,
     ) -> Self {

--- a/crates/storage/db/src/tables/raw.rs
+++ b/crates/storage/db/src/tables/raw.rs
@@ -53,7 +53,7 @@ impl<K: Key> RawKey<K> {
 
     /// Creates a raw key from an existing `Vec`. Useful when we already have the encoded
     /// key.
-    pub fn from_vec(vec: Vec<u8>) -> Self {
+    pub const fn from_vec(vec: Vec<u8>) -> Self {
         Self { key: vec, _phantom: std::marker::PhantomData }
     }
 
@@ -118,7 +118,7 @@ impl<V: Value> RawValue<V> {
 
     /// Creates a raw value from an existing `Vec`. Useful when we already have the encoded
     /// value.
-    pub fn from_vec(vec: Vec<u8>) -> Self {
+    pub const fn from_vec(vec: Vec<u8>) -> Self {
         Self { value: vec, _phantom: std::marker::PhantomData }
     }
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -115,7 +115,7 @@ impl<TX> DatabaseProvider<TX> {
 
 impl<TX: DbTxMut> DatabaseProvider<TX> {
     /// Creates a provider with an inner read-write transaction.
-    pub fn new_rw(
+    pub const fn new_rw(
         tx: TX,
         chain_spec: Arc<ChainSpec>,
         static_file_provider: StaticFileProvider,
@@ -252,7 +252,7 @@ where
 
 impl<TX: DbTx> DatabaseProvider<TX> {
     /// Creates a provider with an inner read-only transaction.
-    pub fn new(
+    pub const fn new(
         tx: TX,
         chain_spec: Arc<ChainSpec>,
         static_file_provider: StaticFileProvider,

--- a/crates/tasks/src/shutdown.rs
+++ b/crates/tasks/src/shutdown.rs
@@ -20,7 +20,7 @@ pub struct GracefulShutdown {
 }
 
 impl GracefulShutdown {
-    pub(crate) fn new(shutdown: Shutdown, guard: GracefulShutdownGuard) -> Self {
+    pub(crate) const fn new(shutdown: Shutdown, guard: GracefulShutdownGuard) -> Self {
         Self { shutdown, guard: Some(guard) }
     }
 

--- a/crates/transaction-pool/src/test_utils/gen.rs
+++ b/crates/transaction-pool/src/test_utils/gen.rs
@@ -225,13 +225,13 @@ impl TransactionBuilder {
     }
 
     /// Increments the nonce value of the transaction builder by 1.
-    pub fn inc_nonce(mut self) -> Self {
+    pub const fn inc_nonce(mut self) -> Self {
         self.nonce += 1;
         self
     }
 
     /// Decrements the nonce value of the transaction builder by 1, avoiding underflow.
-    pub fn decr_nonce(mut self) -> Self {
+    pub const fn decr_nonce(mut self) -> Self {
         self.nonce = self.nonce.saturating_sub(1);
         self
     }

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -1447,7 +1447,7 @@ pub struct MockTransactionSet {
 
 impl MockTransactionSet {
     /// Create a new [`MockTransactionSet`] from a list of transactions
-    fn new(transactions: Vec<MockTransaction>) -> Self {
+    const fn new(transactions: Vec<MockTransaction>) -> Self {
         Self { transactions }
     }
 

--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -27,7 +27,7 @@ pub struct AccountProof {
 
 impl AccountProof {
     /// Create new account proof entity.
-    pub fn new(address: Address) -> Self {
+    pub const fn new(address: Address) -> Self {
         Self {
             address,
             info: None,

--- a/docs/repo/layout.md
+++ b/docs/repo/layout.md
@@ -137,11 +137,9 @@ Crates related to building and validating payloads (blocks).
 
 ### Primitives
 
-These crates define primitive types or algorithms such as RLP.
+These crates define primitive types or algorithms.
 
 - [`primitives`](../../crates/primitives): Commonly used types in Reth.
-- [`rlp`](../../crates/rlp): An implementation of RLP, forked from an earlier Apache-licensed version of [`fastrlp`][fastrlp]
-- [`rlp/rlp-derive`](../../crates/rlp/rlp-derive): Forked from an earlier Apache licenced version of the [`fastrlp-derive`][fastrlp-derive] crate, before it changed licence to GPL.
 - [`trie`](../../crates/trie): An implementation of a Merkle Patricia Trie used for various roots (e.g. the state root) in Ethereum.
 
 ### Misc
@@ -154,8 +152,6 @@ Small utility crates.
 - [`metrics/metrics-derive`](../../crates/metrics/metrics-derive): A derive-style API for creating metrics
 - [`tracing`](../../crates/tracing): A small utility crate to install a uniform [`tracing`][tracing] subscriber
 
-[fastrlp]: https://crates.io/crates/fastrlp
-[fastrlp-derive]: https://crates.io/crates/fastrlp-derive
 [libmdbx-rs]: https://crates.io/crates/libmdbx
 [discv4]: https://github.com/ethereum/devp2p/blob/master/discv4.md
 [jsonrpsee]: https://github.com/paritytech/jsonrpsee/


### PR DESCRIPTION
fixed a broken op link & removed references to rlp and rlp-derive as they were migrated to Alloy in #4737 