### PR TITLE
fix: split requests in `split_at` execution outcome

### DIFF
--- a/crates/evm/execution-types/src/bundle.rs
+++ b/crates/evm/execution-types/src/bundle.rs
@@ -276,6 +276,7 @@ impl ExecutionOutcome {
         // Truncate higher state to [at..].
         let at_idx = higher_state.block_number_to_index(at).unwrap();
         higher_state.receipts = higher_state.receipts.split_off(at_idx).into();
+        higher_state.requests = higher_state.requests.split_off(at_idx).into();
         higher_state.bundle.take_n_reverts(at_idx);
         higher_state.first_block = at;
 
@@ -703,5 +704,75 @@ mod tests {
                 first_block: 123,
             }
         );
+    }
+
+    #[test]
+    fn test_split_at_execution_outcome() {
+        // Create a random receipt object
+        let receipt = Receipt {
+            tx_type: TxType::Legacy,
+            cumulative_gas_used: 46913,
+            logs: vec![],
+            success: true,
+            #[cfg(feature = "optimism")]
+            deposit_nonce: Some(18),
+            #[cfg(feature = "optimism")]
+            deposit_receipt_version: Some(34),
+        };
+
+        // Create a Receipts object with a vector of receipt vectors
+        let receipts = Receipts {
+            receipt_vec: vec![
+                vec![Some(receipt.clone())],
+                vec![Some(receipt.clone())],
+                vec![Some(receipt.clone())],
+            ],
+        };
+
+        // Define the first block number
+        let first_block = 123;
+
+        // Create a DepositRequest object with specific attributes.
+        let request = Request::DepositRequest(DepositRequest {
+            pubkey: FixedBytes::<48>::from([1; 48]),
+            withdrawal_credentials: B256::from([0; 32]),
+            amount: 1111,
+            signature: FixedBytes::<96>::from([2; 96]),
+            index: 222,
+        });
+
+        // Create a vector of Requests containing the request.
+        let requests =
+            vec![Requests(vec![request]), Requests(vec![request]), Requests(vec![request])];
+
+        // Create a ExecutionOutcome object with the created bundle, receipts, requests, and
+        // first_block
+        let exec_res =
+            ExecutionOutcome { bundle: Default::default(), receipts, requests, first_block };
+
+        // Split the ExecutionOutcome at block number 124
+        let result = exec_res.split_at(124);
+
+        // Define the expected lower ExecutionOutcome after splitting
+        let lower_execution_outcome = ExecutionOutcome {
+            bundle: Default::default(),
+            receipts: Receipts { receipt_vec: vec![vec![Some(receipt.clone())]] },
+            requests: vec![Requests(vec![request])],
+            first_block,
+        };
+
+        // Define the expected higher ExecutionOutcome after splitting
+        let higher_execution_outcome = ExecutionOutcome {
+            bundle: Default::default(),
+            receipts: Receipts {
+                receipt_vec: vec![vec![Some(receipt.clone())], vec![Some(receipt.clone())]],
+            },
+            requests: vec![Requests(vec![request]), Requests(vec![request])],
+            first_block: 124,
+        };
+
+        // Assert that the split result matches the expected lower and higher outcomes
+        assert_eq!(result.0, Some(lower_execution_outcome));
+        assert_eq!(result.1, higher_execution_outcome);
     }
 }

--- a/crates/evm/execution-types/src/bundle.rs
+++ b/crates/evm/execution-types/src/bundle.rs
@@ -279,7 +279,7 @@ impl ExecutionOutcome {
         // Ensure that there are enough requests to truncate.
         // Sometimes we just have receipts and no requests.
         if at_idx < higher_state.requests.len() {
-            higher_state.requests.truncate(at_idx);
+            higher_state.requests = higher_state.requests.split_off(at_idx);
         }
         higher_state.bundle.take_n_reverts(at_idx);
         higher_state.first_block = at;

--- a/crates/evm/execution-types/src/bundle.rs
+++ b/crates/evm/execution-types/src/bundle.rs
@@ -276,7 +276,7 @@ impl ExecutionOutcome {
         // Truncate higher state to [at..].
         let at_idx = higher_state.block_number_to_index(at).unwrap();
         higher_state.receipts = higher_state.receipts.split_off(at_idx).into();
-        higher_state.requests = higher_state.requests.split_off(at_idx).into();
+        higher_state.requests = higher_state.requests.split_off(at_idx);
         higher_state.bundle.take_n_reverts(at_idx);
         higher_state.first_block = at;
 
@@ -751,7 +751,7 @@ mod tests {
             ExecutionOutcome { bundle: Default::default(), receipts, requests, first_block };
 
         // Split the ExecutionOutcome at block number 124
-        let result = exec_res.split_at(124);
+        let result = exec_res.clone().split_at(124);
 
         // Define the expected lower ExecutionOutcome after splitting
         let lower_execution_outcome = ExecutionOutcome {
@@ -765,7 +765,7 @@ mod tests {
         let higher_execution_outcome = ExecutionOutcome {
             bundle: Default::default(),
             receipts: Receipts {
-                receipt_vec: vec![vec![Some(receipt.clone())], vec![Some(receipt.clone())]],
+                receipt_vec: vec![vec![Some(receipt.clone())], vec![Some(receipt)]],
             },
             requests: vec![Requests(vec![request]), Requests(vec![request])],
             first_block: 124,
@@ -774,5 +774,8 @@ mod tests {
         // Assert that the split result matches the expected lower and higher outcomes
         assert_eq!(result.0, Some(lower_execution_outcome));
         assert_eq!(result.1, higher_execution_outcome);
+
+        // Assert that splitting at the first block number returns None for the lower outcome
+        assert_eq!(exec_res.clone().split_at(123), (None, exec_res));
     }
 }

--- a/crates/evm/execution-types/src/bundle.rs
+++ b/crates/evm/execution-types/src/bundle.rs
@@ -276,7 +276,11 @@ impl ExecutionOutcome {
         // Truncate higher state to [at..].
         let at_idx = higher_state.block_number_to_index(at).unwrap();
         higher_state.receipts = higher_state.receipts.split_off(at_idx).into();
-        higher_state.requests = higher_state.requests.split_off(at_idx);
+        // Ensure that there are enough requests to truncate.
+        // Sometimes we just have receipts and no requests.
+        if at_idx < higher_state.requests.len() {
+            higher_state.requests.truncate(at_idx);
+        }
         higher_state.bundle.take_n_reverts(at_idx);
         higher_state.first_block = at;
 


### PR DESCRIPTION
In `ExecutionOutcome`, when we split at a specific block number, receipts are splitted but requests should also be splitted:
- `split_at` is fixed
- a unit test is added to catch this behavior