### PR TITLE
chore: remove blob gas related code from op crate

### DIFF
--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -9,7 +9,6 @@ use reth_evm::ConfigureEvm;
 use reth_payload_builder::error::PayloadBuilderError;
 use reth_primitives::{
     constants::{BEACON_NONCE, EMPTY_RECEIPTS, EMPTY_TRANSACTIONS},
-    eip4844::calculate_excess_blob_gas,
     proofs,
     revm::env::tx_env_with_recovered,
     Block, ChainSpec, Hardfork, Header, IntoRecoveredTransaction, Receipt, TxType,
@@ -171,23 +170,6 @@ where
             err
         })?;
 
-        let mut excess_blob_gas = None;
-        let mut blob_gas_used = None;
-
-        if chain_spec.is_cancun_active_at_timestamp(attributes.payload_attributes.timestamp) {
-            excess_blob_gas = if chain_spec.is_cancun_active_at_timestamp(parent_block.timestamp) {
-                let parent_excess_blob_gas = parent_block.excess_blob_gas.unwrap_or_default();
-                let parent_blob_gas_used = parent_block.blob_gas_used.unwrap_or_default();
-                Some(calculate_excess_blob_gas(parent_excess_blob_gas, parent_blob_gas_used))
-            } else {
-                // for the first post-fork block, both parent.blob_gas_used and
-                // parent.excess_blob_gas are evaluated as 0
-                Some(calculate_excess_blob_gas(0, 0))
-            };
-
-            blob_gas_used = Some(0);
-        }
-
         let header = Header {
             parent_hash: parent_block.hash(),
             ommers_hash: EMPTY_OMMER_ROOT_HASH,
@@ -206,8 +188,8 @@ where
             difficulty: U256::ZERO,
             gas_used: 0,
             extra_data,
-            blob_gas_used,
-            excess_blob_gas,
+            blob_gas_used: None,
+            excess_blob_gas: None,
             parent_beacon_block_root: attributes.payload_attributes.parent_beacon_block_root,
             requests_root: None,
         };
@@ -526,26 +508,6 @@ where
     // create the block header
     let transactions_root = proofs::calculate_transaction_root(&executed_txs);
 
-    // initialize empty blob sidecars. There are no blob transactions on L2.
-    let blob_sidecars = Vec::new();
-    let mut excess_blob_gas = None;
-    let mut blob_gas_used = None;
-
-    // only determine cancun fields when active
-    if chain_spec.is_cancun_active_at_timestamp(attributes.payload_attributes.timestamp) {
-        excess_blob_gas = if chain_spec.is_cancun_active_at_timestamp(parent_block.timestamp) {
-            let parent_excess_blob_gas = parent_block.excess_blob_gas.unwrap_or_default();
-            let parent_blob_gas_used = parent_block.blob_gas_used.unwrap_or_default();
-            Some(calculate_excess_blob_gas(parent_excess_blob_gas, parent_blob_gas_used))
-        } else {
-            // for the first post-fork block, both parent.blob_gas_used and
-            // parent.excess_blob_gas are evaluated as 0
-            Some(calculate_excess_blob_gas(0, 0))
-        };
-
-        blob_gas_used = Some(0);
-    }
-
     let header = Header {
         parent_hash: parent_block.hash(),
         ommers_hash: EMPTY_OMMER_ROOT_HASH,
@@ -565,8 +527,8 @@ where
         gas_used: cumulative_gas_used,
         extra_data,
         parent_beacon_block_root: attributes.payload_attributes.parent_beacon_block_root,
-        blob_gas_used,
-        excess_blob_gas,
+        blob_gas_used: None,
+        excess_blob_gas: None,
         requests_root: None,
     };
 
@@ -576,16 +538,13 @@ where
     let sealed_block = block.seal_slow();
     debug!(target: "payload_builder", ?sealed_block, "sealed built block");
 
-    let mut payload = OptimismBuiltPayload::new(
+    let payload = OptimismBuiltPayload::new(
         attributes.payload_attributes.id,
         sealed_block,
         total_fees,
         chain_spec,
         attributes,
     );
-
-    // extend the payload with the blob sidecars from the executed txs
-    payload.extend_sidecars(blob_sidecars);
 
     Ok(BuildOutcome::Better { payload, cached_reads })
 }


### PR DESCRIPTION
No blob transactions on optimism

https://specs.optimism.io/protocol/exec-engine.html#ecotone-disable-blob-transactions

Need to create a PR to remove `blobs_bundle` from the payload type before moving on further