### PR TITLE
chore: add address constants with 0x prefix

### DIFF
--- a/crates/primitives/src/constants/mod.rs
+++ b/crates/primitives/src/constants/mod.rs
@@ -68,7 +68,7 @@ pub const EIP1559_DEFAULT_ELASTICITY_MULTIPLIER: u64 = 2;
 /// Minimum gas limit allowed for transactions.
 pub const MINIMUM_GAS_LIMIT: u64 = 5000;
 
-/// Deposit contract address
+/// Deposit contract address: `0x00000000219ab540356cbb839cbe05303d7705fa`
 pub const MAINNET_DEPOSIT_CONTRACT: DepositContract = DepositContract::new(
     address!("00000000219ab540356cbb839cbe05303d7705fa"),
     11052984,
@@ -164,35 +164,36 @@ pub const ETH_TO_WEI: u128 = FINNEY_TO_WEI * 1000;
 /// Multiplier for converting mgas to gas.
 pub const MGAS_TO_GAS: u64 = 1_000_000u64;
 
-/// The Ethereum mainnet genesis hash.
+/// The Ethereum mainnet genesis hash:
+/// `0x0d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3`
 pub const MAINNET_GENESIS_HASH: B256 =
     b256!("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3");
 
-/// Goerli genesis hash.
+/// Goerli genesis hash: `0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a`
 pub const GOERLI_GENESIS_HASH: B256 =
     b256!("bf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a");
 
-/// Sepolia genesis hash.
+/// Sepolia genesis hash: `0x25a5cc106eea7138acab33231d7160d69cb777ee0c2c553fcddf5138993e6dd9`
 pub const SEPOLIA_GENESIS_HASH: B256 =
     b256!("25a5cc106eea7138acab33231d7160d69cb777ee0c2c553fcddf5138993e6dd9");
 
-/// Holesky genesis hash.
+/// Holesky genesis hash: `0xff9006519a8ce843ac9c28549d24211420b546e12ce2d170c77a8cca7964f23d`
 pub const HOLESKY_GENESIS_HASH: B256 =
     b256!("ff9006519a8ce843ac9c28549d24211420b546e12ce2d170c77a8cca7964f23d");
 
-/// Testnet genesis hash.
+/// Testnet genesis hash: `0x2f980576711e3617a5e4d83dd539548ec0f7792007d505a3d2e9674833af2d7c`
 pub const DEV_GENESIS_HASH: B256 =
     b256!("2f980576711e3617a5e4d83dd539548ec0f7792007d505a3d2e9674833af2d7c");
 
-/// Keccak256 over empty array.
+/// Keccak256 over empty array: `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`
 pub const KECCAK_EMPTY: B256 =
     b256!("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470");
 
-/// Ommer root of empty list.
+/// Ommer root of empty list: `0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347`
 pub const EMPTY_OMMER_ROOT_HASH: B256 =
     b256!("1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347");
 
-/// Root hash of an empty trie.
+/// Root hash of an empty trie: `0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421`
 pub const EMPTY_ROOT_HASH: B256 =
     b256!("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
 


### PR DESCRIPTION
I often search for certain hashes in the codebase, usually with the 0x prefix after copying from somewhere else.

this makes it easier to find them hehe