### PR TITLE
chore(primitives): use `derive_more` where possible

### DIFF
--- a/crates/primitives/benches/integer_list.rs
+++ b/crates/primitives/benches/integer_list.rs
@@ -89,19 +89,12 @@ criterion_main!(benches);
 /// adapted to work with `sucds = "0.8.1"`
 #[allow(unused, unreachable_pub)]
 mod elias_fano {
+    use derive_more::Deref;
     use std::{fmt, ops::Deref};
     use sucds::{mii_sequences::EliasFano, Serializable};
 
-    #[derive(Clone, PartialEq, Eq, Default)]
+    #[derive(Clone, PartialEq, Eq, Default, Deref)]
     pub struct IntegerList(pub EliasFano);
-
-    impl Deref for IntegerList {
-        type Target = EliasFano;
-
-        fn deref(&self) -> &Self::Target {
-            &self.0
-        }
-    }
 
     impl fmt::Debug for IntegerList {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/primitives/src/account.rs
+++ b/crates/primitives/src/account.rs
@@ -1,17 +1,17 @@
 use crate::revm_primitives::{Bytecode as RevmBytecode, Bytes};
 use byteorder::{BigEndian, ReadBytesExt};
 use bytes::Buf;
+use derive_more::Deref;
 use reth_codecs::Compact;
 use revm_primitives::JumpTable;
 use serde::{Deserialize, Serialize};
-use std::ops::Deref;
 
 pub use reth_primitives_traits::Account;
 
 /// Bytecode for an account.
 ///
 /// A wrapper around [`revm::primitives::Bytecode`][RevmBytecode] with encoding/decoding support.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, Deref)]
 pub struct Bytecode(pub RevmBytecode);
 
 impl Bytecode {
@@ -20,14 +20,6 @@ impl Bytecode {
     /// No analysis will be performed.
     pub fn new_raw(bytes: Bytes) -> Self {
         Self(RevmBytecode::new_raw(bytes))
-    }
-}
-
-impl Deref for Bytecode {
-    type Target = RevmBytecode;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
     }
 }
 

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -10,6 +10,7 @@ use crate::{
     Hardfork, Head, Header, NamedChain, NodeRecord, SealedHeader, B256, EMPTY_OMMER_ROOT_HASH,
     MAINNET_DEPOSIT_CONTRACT, U256,
 };
+use derive_more::From;
 use once_cell::sync::Lazy;
 use reth_trie_common::root::state_root_ref_unhashed;
 use serde::{Deserialize, Serialize};
@@ -484,14 +485,8 @@ impl From<ForkBaseFeeParams> for BaseFeeParamsKind {
 
 /// A type alias to a vector of tuples of [Hardfork] and [`BaseFeeParams`], sorted by [Hardfork]
 /// activation order. This is used to specify dynamic EIP-1559 parameters for chains like Optimism.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, From)]
 pub struct ForkBaseFeeParams(Vec<(Hardfork, BaseFeeParams)>);
-
-impl From<Vec<(Hardfork, BaseFeeParams)>> for ForkBaseFeeParams {
-    fn from(params: Vec<(Hardfork, BaseFeeParams)>) -> Self {
-        Self(params)
-    }
-}
 
 /// An Ethereum chain specification.
 ///

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -9,11 +9,12 @@ use crate::{
 };
 use alloy_rlp::{length_of_length, Decodable, Encodable};
 use bytes::BufMut;
+use derive_more::{AsRef, Deref};
 #[cfg(any(test, feature = "arbitrary"))]
 use proptest::prelude::*;
 use reth_codecs::{add_arbitrary_tests, derive_arbitrary, main_codec, Compact};
 use serde::{Deserialize, Serialize};
-use std::{mem, ops::Deref};
+use std::mem;
 
 /// Errors that can occur during header sanity checks.
 #[derive(Debug, PartialEq, Eq)]
@@ -517,11 +518,13 @@ impl Decodable for Header {
 /// to modify header.
 #[main_codec(no_arbitrary)]
 #[add_arbitrary_tests(rlp, compact)]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, AsRef, Deref)]
 pub struct SealedHeader {
     /// Locked Header hash.
     hash: BlockHash,
     /// Locked Header fields.
+    #[as_ref]
+    #[deref]
     header: Header,
 }
 
@@ -655,20 +658,6 @@ impl Decodable for SealedHeader {
         *buf = *b;
 
         Ok(Self { header, hash })
-    }
-}
-
-impl AsRef<Header> for SealedHeader {
-    fn as_ref(&self) -> &Header {
-        &self.header
-    }
-}
-
-impl Deref for SealedHeader {
-    type Target = Header;
-
-    fn deref(&self) -> &Self::Target {
-        &self.header
     }
 }
 

--- a/crates/primitives/src/integer_list.rs
+++ b/crates/primitives/src/integer_list.rs
@@ -1,24 +1,17 @@
 use bytes::BufMut;
+use derive_more::Deref;
 use roaring::RoaringTreemap;
 use serde::{
     de::{SeqAccess, Unexpected, Visitor},
     ser::SerializeSeq,
     Deserialize, Deserializer, Serialize, Serializer,
 };
-use std::{fmt, ops::Deref};
+use std::fmt;
 
 /// Uses Roaring Bitmaps to hold a list of integers. It provides really good compression with the
 /// capability to access its elements without decoding it.
-#[derive(Clone, PartialEq, Default)]
+#[derive(Clone, PartialEq, Default, Deref)]
 pub struct IntegerList(pub RoaringTreemap);
-
-impl Deref for IntegerList {
-    type Target = RoaringTreemap;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
 
 impl fmt::Debug for IntegerList {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -4,15 +4,13 @@ use crate::{logs_bloom, Bloom, Bytes, TxType, B256};
 use alloy_primitives::Log;
 use alloy_rlp::{length_of_length, Decodable, Encodable, RlpDecodable, RlpEncodable};
 use bytes::{Buf, BufMut};
+use derive_more::{Deref, DerefMut, From, IntoIterator};
 #[cfg(any(test, feature = "arbitrary"))]
 use proptest::strategy::Strategy;
 #[cfg(feature = "zstd-codec")]
 use reth_codecs::CompactZstd;
 use reth_codecs::{add_arbitrary_tests, main_codec, Compact};
-use std::{
-    cmp::Ordering,
-    ops::{Deref, DerefMut},
-};
+use std::{cmp::Ordering, ops::Deref};
 
 /// Receipt containing result of transaction execution.
 #[cfg_attr(feature = "zstd-codec", main_codec(no_arbitrary, zstd))]
@@ -65,7 +63,7 @@ impl Receipt {
 }
 
 /// A collection of receipts organized as a two-dimensional vector.
-#[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, From, Deref, DerefMut, IntoIterator)]
 pub struct Receipts {
     /// A two-dimensional vector of optional `Receipt` instances.
     pub receipt_vec: Vec<Vec<Option<Receipt>>>,
@@ -110,38 +108,9 @@ impl Receipts {
     }
 }
 
-impl From<Vec<Vec<Option<Receipt>>>> for Receipts {
-    fn from(receipt_vec: Vec<Vec<Option<Receipt>>>) -> Self {
-        Self { receipt_vec }
-    }
-}
-
 impl From<Vec<Receipt>> for Receipts {
     fn from(block_receipts: Vec<Receipt>) -> Self {
         Self { receipt_vec: vec![block_receipts.into_iter().map(Option::Some).collect()] }
-    }
-}
-
-impl Deref for Receipts {
-    type Target = Vec<Vec<Option<Receipt>>>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.receipt_vec
-    }
-}
-
-impl DerefMut for Receipts {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.receipt_vec
-    }
-}
-
-impl IntoIterator for Receipts {
-    type Item = Vec<Option<Receipt>>;
-    type IntoIter = std::vec::IntoIter<Self::Item>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.receipt_vec.into_iter()
     }
 }
 

--- a/crates/primitives/src/request.rs
+++ b/crates/primitives/src/request.rs
@@ -3,29 +3,14 @@
 use crate::Request;
 use alloy_eips::eip7685::{Decodable7685, Encodable7685};
 use alloy_rlp::{Decodable, Encodable};
+use derive_more::{Deref, DerefMut, From, IntoIterator};
 use reth_codecs::{main_codec, Compact};
 use revm_primitives::Bytes;
-use std::ops::{Deref, DerefMut};
 
 /// A list of EIP-7685 requests.
 #[main_codec]
-#[derive(Debug, Clone, PartialEq, Eq, Default, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Hash, Deref, DerefMut, From, IntoIterator)]
 pub struct Requests(pub Vec<Request>);
-
-impl From<Vec<Request>> for Requests {
-    fn from(requests: Vec<Request>) -> Self {
-        Self(requests)
-    }
-}
-
-impl IntoIterator for Requests {
-    type Item = Request;
-    type IntoIter = std::vec::IntoIter<Request>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
-}
 
 impl Encodable for Requests {
     fn encode(&self, out: &mut dyn bytes::BufMut) {
@@ -52,19 +37,5 @@ impl Decodable for Requests {
             .map(|bytes| Request::decode_7685(&mut bytes.as_ref()))
             .collect::<Result<Vec<_>, alloy_eips::eip7685::Eip7685Error>>()
             .map(Self)?)
-    }
-}
-
-impl Deref for Requests {
-    type Target = Vec<Request>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for Requests {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
     }
 }

--- a/crates/primitives/src/withdrawal.rs
+++ b/crates/primitives/src/withdrawal.rs
@@ -1,8 +1,8 @@
 //! [EIP-4895](https://eips.ethereum.org/EIPS/eip-4895) Withdrawal types.
 
 use alloy_rlp::{RlpDecodableWrapper, RlpEncodableWrapper};
+use derive_more::{AsRef, Deref, DerefMut, From, IntoIterator};
 use reth_codecs::{main_codec, Compact};
-use std::ops::{Deref, DerefMut};
 
 /// Re-export from `alloy_eips`.
 #[doc(inline)]
@@ -10,7 +10,22 @@ pub use alloy_eips::eip4895::Withdrawal;
 
 /// Represents a collection of Withdrawals.
 #[main_codec]
-#[derive(Debug, Clone, PartialEq, Eq, Default, Hash, RlpEncodableWrapper, RlpDecodableWrapper)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Default,
+    Hash,
+    From,
+    AsRef,
+    Deref,
+    DerefMut,
+    IntoIterator,
+    RlpEncodableWrapper,
+    RlpDecodableWrapper,
+)]
+#[as_ref(forward)]
 pub struct Withdrawals(Vec<Withdrawal>);
 
 impl Withdrawals {
@@ -44,41 +59,6 @@ impl Withdrawals {
     /// Convert [Self] into raw vec of withdrawals.
     pub fn into_inner(self) -> Vec<Withdrawal> {
         self.0
-    }
-}
-
-impl IntoIterator for Withdrawals {
-    type Item = Withdrawal;
-    type IntoIter = std::vec::IntoIter<Withdrawal>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
-}
-
-impl AsRef<[Withdrawal]> for Withdrawals {
-    fn as_ref(&self) -> &[Withdrawal] {
-        &self.0
-    }
-}
-
-impl Deref for Withdrawals {
-    type Target = Vec<Withdrawal>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for Withdrawals {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl From<Vec<Withdrawal>> for Withdrawals {
-    fn from(withdrawals: Vec<Withdrawal>) -> Self {
-        Self(withdrawals)
     }
 }
 


### PR DESCRIPTION
We already had `derive_more` as a dependency in `reth-primitives`, let's use it where possible.