### PR TITLE
feat(primitives): gas limit setter

### DIFF
--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -479,7 +479,6 @@ impl Transaction {
     }
 
     /// This sets the transaction's gas limit.
-    #[allow(dead_code)]
     pub fn set_gas_limit(&mut self, gas_limit: u64) {
         match self {
             Self::Legacy(tx) => tx.gas_limit = gas_limit,

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -478,6 +478,19 @@ impl Transaction {
         }
     }
 
+    /// This sets the transaction's gas limit.
+    #[allow(dead_code)]
+    pub fn set_gas_limit(&mut self, gas_limit: u64) {
+        match self {
+            Self::Legacy(tx) => tx.gas_limit = gas_limit,
+            Self::Eip2930(tx) => tx.gas_limit = gas_limit,
+            Self::Eip1559(tx) => tx.gas_limit = gas_limit,
+            Self::Eip4844(tx) => tx.gas_limit = gas_limit,
+            #[cfg(feature = "optimism")]
+            Self::Deposit(tx) => tx.gas_limit = gas_limit,
+        }
+    }
+
     /// This sets the transaction's nonce.
     pub fn set_nonce(&mut self, nonce: u64) {
         match self {


### PR DESCRIPTION
Found myself needing to change a `Transaction`'s gas_limit so including it as part of the library might be useful for others.