### PR TITLE
fix(net): use real tcp port for local node record

### DIFF
--- a/crates/net/network/src/discovery.rs
+++ b/crates/net/network/src/discovery.rs
@@ -71,14 +71,17 @@ impl Discovery {
     /// This will spawn the [`reth_discv4::Discv4Service`] onto a new task and establish a listener
     /// channel to receive all discovered nodes.
     pub async fn new(
+        tcp_addr: SocketAddr,
         discovery_v4_addr: SocketAddr,
         sk: SecretKey,
         discv4_config: Option<Discv4Config>,
         discv5_config: Option<reth_discv5::Config>, // contains discv5 listen address
         dns_discovery_config: Option<DnsDiscoveryConfig>,
     ) -> Result<Self, NetworkError> {
-        // setup discv4
-        let local_enr = NodeRecord::from_secret_key(discovery_v4_addr, &sk);
+        // setup discv4 with the discovery address and tcp port
+        let local_enr =
+            NodeRecord::from_secret_key(discovery_v4_addr, &sk).with_tcp_port(tcp_addr.port());
+
         let discv4_future = async {
             let Some(disc_config) = discv4_config else { return Ok((None, None, None)) };
             let (discv4, mut discv4_service) =
@@ -343,6 +346,7 @@ mod tests {
         let discovery_addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0));
         let _discovery = Discovery::new(
             discovery_addr,
+            discovery_addr,
             secret_key,
             Default::default(),
             None,
@@ -370,9 +374,16 @@ mod tests {
             .discv5_config(discv5::ConfigBuilder::new(discv5_listen_config).build())
             .build();
 
-        Discovery::new(discv4_addr, secret_key, Some(discv4_config), Some(discv5_config), None)
-            .await
-            .expect("should build discv5 with discv4 downgrade")
+        Discovery::new(
+            discv4_addr,
+            discv4_addr,
+            secret_key,
+            Some(discv4_config),
+            Some(discv5_config),
+            None,
+        )
+        .await
+        .expect("should build discv5 with discv4 downgrade")
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/net/network/src/listener.rs
+++ b/crates/net/network/src/listener.rs
@@ -1,7 +1,6 @@
 //! Contains connection-oriented interfaces.
 
 use futures::{ready, Stream};
-
 use std::{
     io,
     net::SocketAddr,

--- a/crates/net/peers/src/node_record.rs
+++ b/crates/net/peers/src/node_record.rs
@@ -42,8 +42,10 @@ pub struct NodeRecord {
 }
 
 impl NodeRecord {
+    /// Derive the [`NodeRecord`] from the secret key and addr.
+    ///
+    /// Note: this will set both the TCP and UDP ports to the port of the addr.
     #[cfg(feature = "secp256k1")]
-    /// Derive the [`NodeRecord`] from the secret key and addr
     pub fn from_secret_key(addr: SocketAddr, sk: &secp256k1::SecretKey) -> Self {
         let pk = secp256k1::PublicKey::from_secret_key(secp256k1::SECP256K1, sk);
         let id = PeerId::from_slice(&pk.serialize_uncompressed()[1..]);
@@ -73,8 +75,19 @@ impl NodeRecord {
         self
     }
 
+    /// Sets the tcp port
+    pub const fn with_tcp_port(mut self, port: u16) -> Self {
+        self.tcp_port = port;
+        self
+    }
+
+    /// Sets the udp port
+    pub const fn with_udp_port(mut self, port: u16) -> Self {
+        self.udp_port = port;
+        self
+    }
+
     /// Creates a new record from a socket addr and peer id.
-    #[allow(dead_code)]
     pub const fn new(addr: SocketAddr, id: PeerId) -> Self {
         Self { address: addr.ip(), tcp_port: addr.port(), udp_port: addr.port(), id }
     }


### PR DESCRIPTION
closes #8851

we didn't configure the tcp port correctly when setting up discv4.

resulting in misreporting of the listener ports via `admin_nodeInfo`