### PR TITLE
chore: remove reth-rpc-types dep in node-events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7507,6 +7507,7 @@ dependencies = [
 name = "reth-node-events"
 version = "1.0.0-rc.1"
 dependencies = [
+ "alloy-rpc-types-engine",
  "futures",
  "humantime",
  "pin-project",
@@ -7517,7 +7518,6 @@ dependencies = [
  "reth-primitives",
  "reth-provider",
  "reth-prune",
- "reth-rpc-types",
  "reth-stages",
  "reth-static-file",
  "tokio",

--- a/crates/node/events/Cargo.toml
+++ b/crates/node/events/Cargo.toml
@@ -20,7 +20,9 @@ reth-prune.workspace = true
 reth-static-file.workspace = true
 reth-db-api.workspace = true
 reth-primitives.workspace = true
-reth-rpc-types.workspace = true
+
+# alloy
+alloy-rpc-types-engine.workspace = true
 
 # async
 tokio.workspace = true

--- a/crates/node/events/src/node.rs
+++ b/crates/node/events/src/node.rs
@@ -1,6 +1,7 @@
 //! Support for handling events emitted by node components.
 
 use crate::cl::ConsensusLayerHealthEvent;
+use alloy_rpc_types_engine::ForkchoiceState;
 use futures::Stream;
 use reth_beacon_consensus::{
     BeaconConsensusEngineEvent, ConsensusEngineLiveSyncProgress, ForkchoiceStatus,
@@ -10,7 +11,6 @@ use reth_network::{NetworkEvent, NetworkHandle};
 use reth_network_api::PeersInfo;
 use reth_primitives::{constants, BlockNumber, B256};
 use reth_prune::PrunerEvent;
-use reth_rpc_types::engine::ForkchoiceState;
 use reth_stages::{EntitiesCheckpoint, ExecOutput, PipelineEvent, StageCheckpoint, StageId};
 use reth_static_file::StaticFileProducerEvent;
 use std::{


### PR DESCRIPTION
just switches to the alloy dep