### PR TITLE
feat: move builtpayload to payload types

### DIFF
--- a/crates/e2e-test-utils/src/node.rs
+++ b/crates/e2e-test-utils/src/node.rs
@@ -70,13 +70,13 @@ where
             + Copy,
     ) -> eyre::Result<
         Vec<(
-            <Node::Engine as EngineTypes>::BuiltPayload,
+            <Node::Engine as PayloadTypes>::BuiltPayload,
             <Node::Engine as PayloadTypes>::PayloadBuilderAttributes,
         )>,
     >
     where
         <Node::Engine as EngineTypes>::ExecutionPayloadV3:
-            From<<Node::Engine as EngineTypes>::BuiltPayload> + PayloadEnvelopeExt,
+            From<<Node::Engine as PayloadTypes>::BuiltPayload> + PayloadEnvelopeExt,
     {
         let mut chain = Vec::with_capacity(length as usize);
         for i in 0..length {
@@ -99,12 +99,12 @@ where
         &mut self,
         attributes_generator: impl Fn(u64) -> <Node::Engine as PayloadTypes>::PayloadBuilderAttributes,
     ) -> eyre::Result<(
-        <<Node as NodeTypes>::Engine as EngineTypes>::BuiltPayload,
+        <<Node as NodeTypes>::Engine as PayloadTypes>::BuiltPayload,
         <<Node as NodeTypes>::Engine as PayloadTypes>::PayloadBuilderAttributes,
     )>
     where
         <Node::Engine as EngineTypes>::ExecutionPayloadV3:
-            From<<Node::Engine as EngineTypes>::BuiltPayload> + PayloadEnvelopeExt,
+            From<<Node::Engine as PayloadTypes>::BuiltPayload> + PayloadEnvelopeExt,
     {
         // trigger new payload building draining the pool
         let eth_attr = self.payload.new_payload(attributes_generator).await.unwrap();
@@ -124,12 +124,12 @@ where
         versioned_hashes: Vec<B256>,
         attributes_generator: impl Fn(u64) -> <Node::Engine as PayloadTypes>::PayloadBuilderAttributes,
     ) -> eyre::Result<(
-        <Node::Engine as EngineTypes>::BuiltPayload,
+        <Node::Engine as PayloadTypes>::BuiltPayload,
         <<Node as NodeTypes>::Engine as PayloadTypes>::PayloadBuilderAttributes,
     )>
     where
         <Node::Engine as EngineTypes>::ExecutionPayloadV3:
-            From<<Node::Engine as EngineTypes>::BuiltPayload> + PayloadEnvelopeExt,
+            From<<Node::Engine as PayloadTypes>::BuiltPayload> + PayloadEnvelopeExt,
     {
         let (payload, eth_attr) = self.new_payload(attributes_generator).await?;
 

--- a/crates/engine-primitives/src/lib.rs
+++ b/crates/engine-primitives/src/lib.rs
@@ -8,7 +8,6 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
-use core::fmt;
 pub use reth_payload_primitives::{
     BuiltPayload, EngineApiMessageVersion, EngineObjectValidationError, PayloadOrAttributes,
     PayloadTypes,
@@ -21,17 +20,14 @@ use serde::{de::DeserializeOwned, ser::Serialize};
 /// This includes the execution payload types and payload attributes that are used to trigger a
 /// payload job. Hence this trait is also [`PayloadTypes`].
 pub trait EngineTypes:
-    PayloadTypes + DeserializeOwned + Serialize + fmt::Debug + Unpin + Send + Sync + Clone
+    PayloadTypes<
+        BuiltPayload: TryInto<Self::ExecutionPayloadV1>
+                          + TryInto<Self::ExecutionPayloadV2>
+                          + TryInto<Self::ExecutionPayloadV3>
+                          + TryInto<Self::ExecutionPayloadV4>,
+    > + DeserializeOwned
+    + Serialize
 {
-    /// The built payload type.
-    type BuiltPayload: BuiltPayload
-        + Clone
-        + Unpin
-        + TryInto<Self::ExecutionPayloadV1>
-        + TryInto<Self::ExecutionPayloadV2>
-        + TryInto<Self::ExecutionPayloadV3>
-        + TryInto<Self::ExecutionPayloadV4>;
-
     /// Execution Payload V1 type.
     type ExecutionPayloadV1: DeserializeOwned + Serialize + Clone + Unpin + Send + Sync + 'static;
     /// Execution Payload V2 type.

--- a/crates/ethereum/engine-primitives/src/lib.rs
+++ b/crates/ethereum/engine-primitives/src/lib.rs
@@ -31,12 +31,12 @@ use reth_rpc_types::{
 pub struct EthEngineTypes;
 
 impl PayloadTypes for EthEngineTypes {
+    type BuiltPayload = EthBuiltPayload;
     type PayloadAttributes = EthPayloadAttributes;
     type PayloadBuilderAttributes = EthPayloadBuilderAttributes;
 }
 
 impl EngineTypes for EthEngineTypes {
-    type BuiltPayload = EthBuiltPayload;
     type ExecutionPayloadV1 = ExecutionPayloadV1;
     type ExecutionPayloadV2 = ExecutionPayloadEnvelopeV2;
     type ExecutionPayloadV3 = ExecutionPayloadEnvelopeV3;

--- a/crates/optimism/node/src/engine.rs
+++ b/crates/optimism/node/src/engine.rs
@@ -22,12 +22,12 @@ use reth_rpc_types::{
 pub struct OptimismEngineTypes;
 
 impl PayloadTypes for OptimismEngineTypes {
+    type BuiltPayload = OptimismBuiltPayload;
     type PayloadAttributes = OptimismPayloadAttributes;
     type PayloadBuilderAttributes = OptimismPayloadBuilderAttributes;
 }
 
 impl EngineTypes for OptimismEngineTypes {
-    type BuiltPayload = OptimismBuiltPayload;
     type ExecutionPayloadV1 = ExecutionPayloadV1;
     type ExecutionPayloadV2 = ExecutionPayloadEnvelopeV2;
     type ExecutionPayloadV3 = OptimismExecutionPayloadEnvelopeV3;

--- a/crates/payload/primitives/src/lib.rs
+++ b/crates/payload/primitives/src/lib.rs
@@ -9,6 +9,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod error;
+
 pub use error::{EngineObjectValidationError, PayloadBuilderError, VersionSpecificValidationError};
 
 /// Contains traits to abstract over payload attributes types and default implementations of the
@@ -20,10 +21,12 @@ mod payload;
 pub use payload::PayloadOrAttributes;
 
 use reth_primitives::ChainSpec;
-use std::fmt::Debug;
 
 /// The types that are used by the engine API.
-pub trait PayloadTypes: Send + Sync + Unpin {
+pub trait PayloadTypes: Send + Sync + Unpin + core::fmt::Debug + Clone {
+    /// The built payload type.
+    type BuiltPayload: BuiltPayload + Clone + Unpin;
+
     /// The RPC payload attributes type the CL node emits via the engine API.
     type PayloadAttributes: PayloadAttributes + Unpin;
 

--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -164,12 +164,12 @@ impl PayloadBuilderAttributes for CustomPayloadBuilderAttributes {
 pub struct CustomEngineTypes;
 
 impl PayloadTypes for CustomEngineTypes {
+    type BuiltPayload = EthBuiltPayload;
     type PayloadAttributes = CustomPayloadAttributes;
     type PayloadBuilderAttributes = CustomPayloadBuilderAttributes;
 }
 
 impl EngineTypes for CustomEngineTypes {
-    type BuiltPayload = EthBuiltPayload;
     type ExecutionPayloadV1 = ExecutionPayloadV1;
     type ExecutionPayloadV2 = ExecutionPayloadEnvelopeV2;
     type ExecutionPayloadV3 = ExecutionPayloadEnvelopeV3;


### PR DESCRIPTION
prep for https://github.com/paradigmxyz/reth/issues/8330 

this moves the associated types to PayloadTypes and enforces the conversions in enginetypes.

this decouples raw payload types from engine types