### PR TITLE
feat(rpc/block): simplify the block_receipts rpc

### DIFF
--- a/crates/rpc/rpc/src/eth/api/block.rs
+++ b/crates/rpc/rpc/src/eth/api/block.rs
@@ -63,65 +63,69 @@ where
         &self,
         block_id: BlockId,
     ) -> EthResult<Option<Vec<AnyTransactionReceipt>>> {
-        let mut block_and_receipts = None;
-
-        if block_id.is_pending() {
-            block_and_receipts = self
-                .provider()
+        // Fetch block and receipts based on block_id
+        let block_and_receipts = if block_id.is_pending() {
+            self.provider()
                 .pending_block_and_receipts()?
-                .map(|(sb, receipts)| (sb, Arc::new(receipts)));
+                .map(|(sb, receipts)| (sb, Arc::new(receipts)))
         } else if let Some(block_hash) = self.provider().block_hash_for_id(block_id)? {
-            block_and_receipts = self.cache().get_block_and_receipts(block_hash).await?;
-        }
+            self.cache().get_block_and_receipts(block_hash).await?
+        } else {
+            None
+        };
 
-        if let Some((block, receipts)) = block_and_receipts {
-            let block_number = block.number;
-            let base_fee = block.base_fee_per_gas;
-            let block_hash = block.hash();
-            let excess_blob_gas = block.excess_blob_gas;
-            let timestamp = block.timestamp;
-            let block = block.unseal();
+        // If no block and receipts found, return None
+        let (block, receipts) = match block_and_receipts {
+            Some(data) => data,
+            None => return Ok(None),
+        };
 
-            #[cfg(feature = "optimism")]
-            let (block_timestamp, l1_block_info) = {
-                let body = reth_evm_optimism::extract_l1_info(&block);
-                (block.timestamp, body.ok())
-            };
+        // Extract block details
+        let block_number = block.number;
+        let base_fee = block.base_fee_per_gas;
+        let block_hash = block.hash();
+        let excess_blob_gas = block.excess_blob_gas;
+        let timestamp = block.timestamp;
+        let block = block.unseal();
 
-            let receipts = block
-                .body
-                .into_iter()
-                .zip(receipts.iter())
-                .enumerate()
-                .map(|(idx, (tx, receipt))| {
-                    let meta = TransactionMeta {
-                        tx_hash: tx.hash,
-                        index: idx as u64,
-                        block_hash,
-                        block_number,
-                        base_fee,
-                        excess_blob_gas,
-                        timestamp,
-                    };
+        #[cfg(feature = "optimism")]
+        let (block_timestamp, l1_block_info) = {
+            let body = reth_evm_optimism::extract_l1_info(&block);
+            (block.timestamp, body.ok())
+        };
 
+        // Build transaction receipts
+        block
+            .body
+            .into_iter()
+            .zip(receipts.iter())
+            .enumerate()
+            .map(|(idx, (tx, receipt))| {
+                let meta = TransactionMeta {
+                    tx_hash: tx.hash,
+                    index: idx as u64,
+                    block_hash,
+                    block_number,
+                    base_fee,
+                    excess_blob_gas,
+                    timestamp,
+                };
+
+                #[cfg(feature = "optimism")]
+                let op_tx_meta =
+                    self.build_op_tx_meta(&tx, l1_block_info.clone(), block_timestamp)?;
+
+                build_transaction_receipt_with_block_receipts(
+                    tx,
+                    meta,
+                    receipt.clone(),
+                    &receipts,
                     #[cfg(feature = "optimism")]
-                    let op_tx_meta =
-                        self.build_op_tx_meta(&tx, l1_block_info.clone(), block_timestamp)?;
-
-                    build_transaction_receipt_with_block_receipts(
-                        tx,
-                        meta,
-                        receipt.clone(),
-                        &receipts,
-                        #[cfg(feature = "optimism")]
-                        op_tx_meta,
-                    )
-                })
-                .collect::<EthResult<Vec<_>>>();
-            return receipts.map(Some)
-        }
-
-        Ok(None)
+                    op_tx_meta,
+                )
+            })
+            .collect::<EthResult<Vec<_>>>()
+            .map(Some)
     }
 
     /// Returns the number transactions in the given block.

--- a/crates/rpc/rpc/src/eth/api/block.rs
+++ b/crates/rpc/rpc/src/eth/api/block.rs
@@ -75,9 +75,8 @@ where
         };
 
         // If no block and receipts found, return None
-        let (block, receipts) = match block_and_receipts {
-            Some(data) => data,
-            None => return Ok(None),
+        let Some((block, receipts)) = block_and_receipts else {
+            return Ok(None);
         };
 
         // Extract block details


### PR DESCRIPTION
Seems like we don't need to declare `block_and_receipts` as mutable, can make the main code flow more simple to read.